### PR TITLE
Clean up marketing nav: Help Center and Legal groups

### DIFF
--- a/rentchain-frontend/src/pages/marketing/MarketingLayout.tsx
+++ b/rentchain-frontend/src/pages/marketing/MarketingLayout.tsx
@@ -163,7 +163,7 @@ export const MarketingLayout: React.FC<MarketingLayoutProps> = ({ children }) =>
               onMouseEnter={(e) => onHover(e, true)}
               onMouseLeave={(e) => onHover(e, false)}
             >
-              Legal &amp; Help
+              Legal
             </Link>
           </nav>
           <div
@@ -223,12 +223,12 @@ export const MarketingLayout: React.FC<MarketingLayoutProps> = ({ children }) =>
               </button>
             </div>
             <Link
-              to="/legal"
+              to="/help"
               style={{ color: text.muted, textDecoration: "none" }}
               onMouseEnter={(e) => onHover(e, true)}
               onMouseLeave={(e) => onHover(e, false)}
             >
-              Support
+              Help Center
             </Link>
             <Link
               to="/login"
@@ -367,15 +367,6 @@ export const MarketingLayout: React.FC<MarketingLayoutProps> = ({ children }) =>
               >
                 Pricing
               </Link>
-              <Link
-                to="/legal"
-                style={{ color: text.muted, textDecoration: "none" }}
-                onMouseEnter={(e) => onHover(e, true)}
-                onMouseLeave={(e) => onHover(e, false)}
-                onClick={() => setMenuOpen(false)}
-              >
-                Legal &amp; Help
-              </Link>
             </div>
             <div style={{ display: "flex", flexWrap: "wrap", gap: spacing.sm, alignItems: "center" }}>
               <div
@@ -424,15 +415,126 @@ export const MarketingLayout: React.FC<MarketingLayoutProps> = ({ children }) =>
                   FR
                 </button>
               </div>
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: spacing.xs }}>
+              <div style={{ fontSize: "0.8rem", color: text.subtle, textTransform: "uppercase", letterSpacing: "0.08em" }}>
+                Help Center
+              </div>
               <Link
-                to="/legal"
+                to="/help"
                 style={{ color: text.muted, textDecoration: "none" }}
                 onMouseEnter={(e) => onHover(e, true)}
                 onMouseLeave={(e) => onHover(e, false)}
                 onClick={() => setMenuOpen(false)}
               >
-                Support
+                Help Center
               </Link>
+              <Link
+                to="/help/landlords"
+                style={{ color: text.muted, textDecoration: "none" }}
+                onMouseEnter={(e) => onHover(e, true)}
+                onMouseLeave={(e) => onHover(e, false)}
+                onClick={() => setMenuOpen(false)}
+              >
+                Landlords
+              </Link>
+              <Link
+                to="/help/tenants"
+                style={{ color: text.muted, textDecoration: "none" }}
+                onMouseEnter={(e) => onHover(e, true)}
+                onMouseLeave={(e) => onHover(e, false)}
+                onClick={() => setMenuOpen(false)}
+              >
+                Tenants
+              </Link>
+              <Link
+                to="/contact"
+                style={{ color: text.muted, textDecoration: "none" }}
+                onMouseEnter={(e) => onHover(e, true)}
+                onMouseLeave={(e) => onHover(e, false)}
+                onClick={() => setMenuOpen(false)}
+              >
+                Contact
+              </Link>
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: spacing.xs }}>
+              <div style={{ fontSize: "0.8rem", color: text.subtle, textTransform: "uppercase", letterSpacing: "0.08em" }}>
+                Legal
+              </div>
+              <Link
+                to="/privacy"
+                style={{ color: text.muted, textDecoration: "none" }}
+                onMouseEnter={(e) => onHover(e, true)}
+                onMouseLeave={(e) => onHover(e, false)}
+                onClick={() => setMenuOpen(false)}
+              >
+                Privacy
+              </Link>
+              <Link
+                to="/terms"
+                style={{ color: text.muted, textDecoration: "none" }}
+                onMouseEnter={(e) => onHover(e, true)}
+                onMouseLeave={(e) => onHover(e, false)}
+                onClick={() => setMenuOpen(false)}
+              >
+                Terms
+              </Link>
+              <Link
+                to="/acceptable-use"
+                style={{ color: text.muted, textDecoration: "none" }}
+                onMouseEnter={(e) => onHover(e, true)}
+                onMouseLeave={(e) => onHover(e, false)}
+                onClick={() => setMenuOpen(false)}
+              >
+                Acceptable Use
+              </Link>
+              <Link
+                to="/subprocessors"
+                style={{ color: text.muted, textDecoration: "none" }}
+                onMouseEnter={(e) => onHover(e, true)}
+                onMouseLeave={(e) => onHover(e, false)}
+                onClick={() => setMenuOpen(false)}
+              >
+                Subprocessors
+              </Link>
+              <Link
+                to="/trust"
+                style={{ color: text.muted, textDecoration: "none" }}
+                onMouseEnter={(e) => onHover(e, true)}
+                onMouseLeave={(e) => onHover(e, false)}
+                onClick={() => setMenuOpen(false)}
+              >
+                Trust
+              </Link>
+              <Link
+                to="/security"
+                style={{ color: text.muted, textDecoration: "none" }}
+                onMouseEnter={(e) => onHover(e, true)}
+                onMouseLeave={(e) => onHover(e, false)}
+                onClick={() => setMenuOpen(false)}
+              >
+                Security
+              </Link>
+              <Link
+                to="/accessibility"
+                style={{ color: text.muted, textDecoration: "none" }}
+                onMouseEnter={(e) => onHover(e, true)}
+                onMouseLeave={(e) => onHover(e, false)}
+                onClick={() => setMenuOpen(false)}
+              >
+                Accessibility
+              </Link>
+              <Link
+                to="/status"
+                style={{ color: text.muted, textDecoration: "none" }}
+                onMouseEnter={(e) => onHover(e, true)}
+                onMouseLeave={(e) => onHover(e, false)}
+                onClick={() => setMenuOpen(false)}
+              >
+                Status
+              </Link>
+            </div>
+            <div style={{ display: "flex", flexWrap: "wrap", gap: spacing.sm, alignItems: "center" }}>
               <Link
                 to="/login"
                 style={{ color: text.muted, textDecoration: "none" }}


### PR DESCRIPTION
Desktop nav now shows “Legal” and “Help Center”. Mobile menu groups Help Center and Legal with the requested links; no duplicates. Menu close behavior, overlay, ESC, focus return, and scroll lock are preserved. QA not run here.