### PR TITLE
Show admin dashboard link in workspace drawer for admin users

### DIFF
--- a/rentchain-frontend/src/components/layout/LandlordNav.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.tsx
@@ -3,7 +3,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import TopNav from "./TopNav";
 import { useAuth } from "../../context/useAuth";
 import { fetchLandlordConversations } from "../../api/messagesApi";
-import { NAV_ITEMS } from "./navConfig";
+import { getVisibleNavItems } from "./navConfig";
 import "./LandlordNav.css";
 
 type Props = {
@@ -19,13 +19,10 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
   const unreadFlag = typeof unreadMessages === "boolean" ? unreadMessages : hasUnread;
   const [drawerOpen, setDrawerOpen] = useState(false);
   const lastFocusedRef = useRef<HTMLElement | null>(null);
-  const isAdmin = String(user?.role || "").toLowerCase() === "admin";
-
-  const visibleItems = NAV_ITEMS.filter((item) => {
-    if (item.requiresAdmin && !isAdmin) return false;
-    return true;
-  });
+  const visibleItems = getVisibleNavItems(user?.role);
   const drawerItems = visibleItems.filter((item) => item.showInDrawer !== false);
+  const primaryDrawerItems = drawerItems.filter((item) => !item.requiresAdmin);
+  const adminDrawerItems = drawerItems.filter((item) => item.requiresAdmin);
   const tabItems = visibleItems.filter((item) => item.showInTabs);
 
   useEffect(() => {
@@ -122,7 +119,20 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
         </div>
         <div className="rc-landlord-drawer-scroll">
           <div className="rc-landlord-drawer-links">
-            {drawerItems.map(({ to, label }) => (
+            {primaryDrawerItems.map(({ to, label }) => (
+              <button
+                key={to}
+                type="button"
+                onClick={() => nav(to)}
+                className={loc.pathname.startsWith(to) ? "active" : ""}
+              >
+                {label}
+              </button>
+            ))}
+            {adminDrawerItems.length ? (
+              <div className="rc-landlord-drawer-divider" />
+            ) : null}
+            {adminDrawerItems.map(({ to, label }) => (
               <button
                 key={to}
                 type="button"

--- a/rentchain-frontend/src/components/layout/WorkspaceDrawer.tsx
+++ b/rentchain-frontend/src/components/layout/WorkspaceDrawer.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { colors, radius, spacing, text, shadows } from "../../styles/tokens";
-import { NAV_ITEMS } from "./navConfig";
+import { getVisibleNavItems } from "./navConfig";
 
 type WorkspaceDrawerProps = {
   open: boolean;
@@ -14,12 +14,10 @@ type WorkspaceDrawerProps = {
 export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({ open, onClose, userEmail, userRole, onSignOut }) => {
   const navigate = useNavigate();
   const location = useLocation();
-  const isAdmin = String(userRole || "").toLowerCase() === "admin";
-  const visibleItems = NAV_ITEMS.filter((item) => {
-    if (item.requiresAdmin && !isAdmin) return false;
-    return true;
-  });
+  const visibleItems = getVisibleNavItems(userRole);
   const drawerItems = visibleItems.filter((item) => item.showInDrawer !== false);
+  const primaryDrawerItems = drawerItems.filter((item) => !item.requiresAdmin);
+  const adminDrawerItems = drawerItems.filter((item) => item.requiresAdmin);
 
   useEffect(() => {
     if (!open) return;
@@ -102,7 +100,32 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({ open, onClose,
 
         <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: "0.02em", color: text.muted }}>Pages</div>
         <div style={{ display: "grid", gap: 8 }}>
-          {drawerItems.map((link) => {
+          {primaryDrawerItems.map((link) => {
+            const active = location.pathname.startsWith(link.to);
+            return (
+              <button
+                key={link.to}
+                type="button"
+                onClick={() => handleNav(link.to)}
+                style={{
+                  textAlign: "left",
+                  padding: "10px 12px",
+                  borderRadius: radius.md,
+                  border: `1px solid ${active ? colors.accent : colors.border}`,
+                  background: active ? "rgba(37,99,235,0.08)" : colors.card,
+                  color: text.primary,
+                  fontWeight: active ? 700 : 600,
+                  cursor: "pointer",
+                }}
+              >
+                {link.label}
+              </button>
+            );
+          })}
+          {adminDrawerItems.length ? (
+            <div style={{ height: 1, background: colors.border, margin: `${spacing.xs} 0` }} />
+          ) : null}
+          {adminDrawerItems.map((link) => {
             const active = location.pathname.startsWith(link.to);
             return (
               <button

--- a/rentchain-frontend/src/components/layout/navConfig.ts
+++ b/rentchain-frontend/src/components/layout/navConfig.ts
@@ -12,6 +12,11 @@ export type NavItem = {
   requiresFeature?: string;
 };
 
+export const getVisibleNavItems = (role?: string | null) => {
+  const isAdmin = String(role || "").toLowerCase() === "admin";
+  return NAV_ITEMS.filter((item) => !(item.requiresAdmin && !isAdmin));
+};
+
 export const NAV_ITEMS: NavItem[] = [
   {
     id: "dashboard",


### PR DESCRIPTION
Adds role-based nav filtering via getVisibleNavItems(role) for consistent gating

Adds “Admin Dashboard” link (/admin) for admin users in both desktop and mobile drawers

Admin items appear below a divider

Admin links are not shown in bottom tabs

No backend changes