### PR TITLE
Phase 4A hotfix: onboarding render + create-application CTA + applications layout

### DIFF
--- a/rentchain-frontend/src/pages/ApplicationsPage.css
+++ b/rentchain-frontend/src/pages/ApplicationsPage.css
@@ -32,6 +32,12 @@
 
 .rc-applications-list-item {
   min-height: 44px;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .rc-applications-search {

--- a/rentchain-frontend/src/pages/ApplicationsPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.tsx
@@ -686,13 +686,19 @@ const ApplicationsPage: React.FC = () => {
                         borderRadius: radius.md,
                         padding: "12px 12px",
                         cursor: "pointer",
-                        display: "grid",
+                        display: "flex",
+                        flexDirection: "column",
                         gap: 4,
+                        minWidth: 0,
                       }}
                     >
-                      <div style={{ fontWeight: 700, color: text.primary, fontSize: 15 }}>{app.applicantName || "Applicant"}</div>
-                      <div style={{ color: text.muted, fontSize: 12 }}>{app.email || "No email"}</div>
-                      <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+                      <div style={{ fontWeight: 700, color: text.primary, fontSize: 15, overflowWrap: "anywhere" }}>
+                        {app.applicantName || "Applicant"}
+                      </div>
+                      <div style={{ color: text.muted, fontSize: 12, overflowWrap: "anywhere" }}>
+                        {app.email || "No email"}
+                      </div>
+                      <div style={{ display: "flex", gap: 6, alignItems: "center", flexWrap: "wrap" }}>
                         <Pill>{app.status}</Pill>
                       </div>
                     </button>

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -278,7 +278,7 @@ const DashboardPage: React.FC = () => {
                   actionLabel: "Create application",
                   onAction: () => {
                     track("onboarding_step_clicked", { stepKey: "applicationCreated" });
-                    navigate("/applications");
+                    navigate("/properties?openSendApplication=1");
                   },
                   isPrimary: true,
                 },
@@ -309,7 +309,7 @@ const DashboardPage: React.FC = () => {
                 </Button>
                 <Button
                   variant="secondary"
-                  onClick={() => navigate("/applications")}
+                  onClick={() => navigate("/properties?openSendApplication=1")}
                   aria-label="Create application"
                   disabled={progressLoading}
                 >

--- a/rentchain-frontend/src/pages/PropertiesPage.tsx
+++ b/rentchain-frontend/src/pages/PropertiesPage.tsx
@@ -89,17 +89,19 @@ const PropertiesPage: React.FC = () => {
   const openAddUnit = params.get("openAddUnit") === "1";
   const openEditUnits = params.get("openEditUnits") === "1";
   const openEditProperty = params.get("openEditProperty") === "1";
+  const openSendApplication = params.get("openSendApplication") === "1";
   const deepLinkId = params.get("actionRequestId") || undefined;
   const panel = params.get("panel") || "";
 
   useEffect(() => {
-    if (!(openAddLease || openAddUnit || openEditUnits || openEditProperty)) return;
+    if (!(openAddLease || openAddUnit || openEditUnits || openEditProperty || openSendApplication)) return;
 
     const next = new URLSearchParams(location.search);
     next.delete("openAddLease");
     next.delete("openAddUnit");
     next.delete("openEditUnits");
     next.delete("openEditProperty");
+    next.delete("openSendApplication");
 
     navigate(
       { pathname: location.pathname, search: next.toString() },
@@ -110,6 +112,7 @@ const PropertiesPage: React.FC = () => {
     openAddUnit,
     openEditUnits,
     openEditProperty,
+    openSendApplication,
     location.pathname,
     location.search,
     navigate,
@@ -712,7 +715,16 @@ const PropertiesPage: React.FC = () => {
                 </div>
               ) : null}
 
-              <PropertyDetailPanel property={selectedProperty} onRefresh={loadProperties} />
+              <PropertyDetailPanel
+                property={selectedProperty}
+                onRefresh={loadProperties}
+                openSendApplication={openSendApplication}
+                onSendApplicationOpened={() => {
+                  const next = new URLSearchParams(location.search);
+                  next.delete("openSendApplication");
+                  navigate({ pathname: location.pathname, search: next.toString() }, { replace: true });
+                }}
+              />
             </div>
 
           <div


### PR DESCRIPTION
Ensure onboarding card renders as onboarding data loads (no manual refresh)
Route “Create application” CTA to open SendApplicationModal via /properties?openSendApplication=1
Fix Applications list item wrapping to prevent mobile overflow