### PR TITLE
Phase 4A.2: onboarding API mount + dashboard/CTA hotfix

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -226,7 +226,7 @@ app.get("/api/__probe/version", (_req, res) =>
 );
 app.use("/api/tenants", routeSource("tenantsRoutes.ts"), tenantsRoutes);
 app.use("/api/account", accountRoutes);
-app.use("/api/onboarding", onboardingRoutes);
+app.use("/api/onboarding", routeSource("onboardingRoutes.ts"), onboardingRoutes);
 app.use("/api", routeSource("messagesRoutes.ts"), messagesRoutes);
 console.log(
   "[routes] /api/properties, /api/properties/:propertyId/units, /api/action-requests, /api/applications"

--- a/rentchain-api/src/app.ts
+++ b/rentchain-api/src/app.ts
@@ -67,6 +67,7 @@ import screeningJobsAdminRoutes from "./routes/screeningJobsAdminRoutes";
 import adminRoutes from "./routes/adminRoutes";
 import adminScreeningResultsRoutes from "./routes/adminScreeningResultsRoutes";
 import screeningReportRoutes from "./routes/screeningReportRoutes";
+import onboardingRoutes from "./routes/onboardingRoutes";
 
 const app: Application = express();
 app.set("etag", false);
@@ -272,6 +273,7 @@ app.get("/api/__probe/version", (_req, res) =>
 );
 app.use("/api/tenants", routeSource("tenantsRoutes.ts"), tenantsRoutes);
 app.use("/api/account", accountRoutes);
+app.use("/api/onboarding", routeSource("onboardingRoutes.ts"), onboardingRoutes);
 app.use("/api", routeSource("messagesRoutes.ts"), messagesRoutes);
 
 process.on("unhandledRejection", (reason) => {

--- a/rentchain-api/src/routes/__tests__/onboardingRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/onboardingRoutes.test.ts
@@ -1,0 +1,32 @@
+import express from "express";
+import request from "supertest";
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../../middleware/authMiddleware", () => ({
+  authenticateJwt: (req: any, _res: any, next: any) => {
+    req.user = { landlordId: "landlord-1", id: "user-1" };
+    next();
+  },
+}));
+
+vi.mock("../../db/onboardingRepo", () => ({
+  updateOnboarding: vi.fn(async () => ({
+    landlordId: "landlord-1",
+    dismissed: false,
+    steps: { propertyAdded: false },
+    lastSeenAt: null,
+  })),
+  getOrCreateDefault: vi.fn(),
+  markStep: vi.fn(),
+}));
+
+describe("GET /api/onboarding", () => {
+  it("returns 200 when authed", async () => {
+    const router = (await import("../onboardingRoutes")).default;
+    const app = express();
+    app.use("/api/onboarding", router);
+    const res = await request(app).get("/api/onboarding");
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+});

--- a/rentchain-frontend/src/api/onboardingApi.ts
+++ b/rentchain-frontend/src/api/onboardingApi.ts
@@ -3,6 +3,7 @@ import { apiFetch } from "./apiFetch";
 export async function fetchOnboarding() {
   return apiFetch("/onboarding", {
     method: "GET",
+    allow404: true,
   });
 }
 

--- a/rentchain-frontend/src/hooks/useOnboardingState.ts
+++ b/rentchain-frontend/src/hooks/useOnboardingState.ts
@@ -28,6 +28,12 @@ export function useOnboardingState() {
     try {
       setLoading(true);
       const res: any = await fetchOnboarding();
+      if (!res) {
+        if (import.meta.env.DEV) {
+          console.warn("[onboarding] /api/onboarding returned 404 or empty response");
+        }
+        return;
+      }
       setDismissed(Boolean(res?.dismissed));
       setSteps({ ...defaultSteps, ...(res?.steps || {}) });
       setLastSeenAt(res?.lastSeenAt || null);

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -379,7 +379,7 @@ const DashboardPage: React.FC = () => {
             <div style={{ color: text.muted, marginBottom: 12 }}>
               Next up: create your first application.
             </div>
-            <Button onClick={() => navigate("/applications")}>Create application</Button>
+            <Button onClick={() => navigate("/properties?openSendApplication=1")}>Create application</Button>
           </Card>
         ) : null}
 
@@ -389,7 +389,7 @@ const DashboardPage: React.FC = () => {
             <div style={{ color: text.muted, marginBottom: 12 }}>
               Invite a tenant or start an application to begin screening.
             </div>
-            <Button onClick={() => navigate("/applications")}>Go to applications</Button>
+            <Button onClick={() => navigate("/properties?openSendApplication=1")}>Create application</Button>
           </Card>
         ) : null}
 


### PR DESCRIPTION
Mount /api/onboarding routes with routeSource in app.ts + app.build.ts
Add onboarding route test (authed GET returns 200)
Handle onboarding 404 in hook (dev warning) and ensure dashboard card renders without refresh
Route Step 4 CTA to open SendApplicationModal via /properties?openSendApplication=1
