### PR TITLE
chore(probe): expose deployed commit sha

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,7 +7,8 @@ steps:
         '--source', './rentchain-api',
         '--region', 'us-central1',
         '--platform', 'managed',
-        '--allow-unauthenticated'
+        '--allow-unauthenticated',
+        '--set-env-vars', 'COMMIT_SHA=$COMMIT_SHA'
       ]
 
 options:

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -224,6 +224,16 @@ app.get("/api/__probe/tenants-mount", (_req, res) =>
 app.get("/api/__probe/version", (_req, res) =>
   res.json({ ok: true, ts: Date.now(), marker: "probe-v1" })
 );
+app.get("/api/__probe/revision", (_req, res) => {
+  res.setHeader("x-route-source", "app.build.ts:/api/__probe/revision");
+  return res.json({
+    ok: true,
+    service: "rentchain-landlord-api",
+    revision: process.env.K_REVISION || null,
+    commit: process.env.GIT_SHA || process.env.COMMIT_SHA || null,
+    ts: Date.now(),
+  });
+});
 app.use("/api/tenants", routeSource("tenantsRoutes.ts"), tenantsRoutes);
 app.use("/api/account", accountRoutes);
 app.use("/api/onboarding", routeSource("onboardingRoutes.ts"), onboardingRoutes);

--- a/rentchain-api/src/app.ts
+++ b/rentchain-api/src/app.ts
@@ -255,6 +255,16 @@ app.get("/api/__debug/ping-application-links", (_req, res) => {
   res.setHeader("x-route-source", "debugPingApplicationLinks");
   return res.json({ ok: true });
 });
+app.get("/api/__probe/revision", (_req, res) => {
+  res.setHeader("x-route-source", "app.ts:/api/__probe/revision");
+  return res.json({
+    ok: true,
+    service: "rentchain-landlord-api",
+    revision: process.env.K_REVISION || null,
+    commit: process.env.GIT_SHA || process.env.COMMIT_SHA || null,
+    ts: Date.now(),
+  });
+});
 
 app.use("/api/leases", leaseRoutes);
 app.use("/api", tenantOnboardRoutes);


### PR DESCRIPTION
Add /api/__probe/revision to return { service, revision, commit, ts } with x-route-source
Pass COMMIT_SHA into Cloud Run env via Cloud Build --set-env-vars
QA:
After deploy: curl /api/__probe/revision returns 200 and commit matches merge SHA