### PR TITLE
chore(probe): expose revision + commit in public probe routes

### DIFF
--- a/rentchain-api/src/routes/publicRoutes.ts
+++ b/rentchain-api/src/routes/publicRoutes.ts
@@ -90,7 +90,23 @@ router.get("/health/stripe", async (_req, res) => {
 
 router.get("/__probe/version", (_req, res) => {
   res.setHeader("x-route-source", "publicRoutes.ts");
-  res.json({ ok: true, marker: "probe-v1", ts: Date.now() });
+  res.json({
+    ok: true,
+    marker: "probe-v1",
+    commit: process.env.COMMIT_SHA || null,
+    ts: Date.now(),
+  });
+});
+
+router.get("/__probe/revision", (_req, res) => {
+  res.setHeader("x-route-source", "publicRoutes.ts");
+  res.json({
+    ok: true,
+    service: "rentchain-landlord-api",
+    revision: process.env.K_REVISION || null,
+    commit: process.env.COMMIT_SHA || null,
+    ts: Date.now(),
+  });
 });
 
 router.post("/notify-plan-interest", async (req: any, res) => {


### PR DESCRIPTION
Add /api/__probe/revision in publicRoutes to return { service, revision, commit, ts }
Include commit in /api/__probe/version for quick deploy verification
QA:
After deploy: curl /api/__probe/version shows commit
curl /api/__probe/revision returns 200 with revision + commit