### PR TITLE
fix(dashboard): remove TDZ crash (culprit isAdmin)

### DIFF
--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -167,12 +167,12 @@ const DashboardPage: React.FC = () => {
     !loading && !propsLoading && !applicationsLoading && !tenantsLoading && !invitesLoading && !error;
   const hasNoProperties = dataReady && (kpis?.propertiesCount ?? 0) === 0;
   const hasNoApplications = dataReady && applicationsCount === 0;
+  const isAdmin = String(user?.role || "").toLowerCase() === "admin";
   const showEmptyCTA = hasNoProperties;
   const progressLoading = !dataReady || onboarding.loading;
   const showOnboardingSkeleton = onboarding.loading && !isAdmin;
   const showStarterOnboarding = !onboarding.loading && !onboarding.dismissed && !onboarding.allComplete;
   const showAdvancedCollapsed = showStarterOnboarding;
-  const isAdmin = String(user?.role || "").toLowerCase() === "admin";
 
   const derivedSteps = {
     propertyAdded: derivedPropertiesCount > 0,


### PR DESCRIPTION
Culprit: isAdmin referenced before initialization in [DashboardPage.tsx](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/P2/.vscode/extensions/openai.chatgpt-0.4.68-win32-x64/webview/#) (TDZ in prod minified bundle).
Fix: move const isAdmin = … above showOnboardingSkeleton/showStarterOnboarding to remove TDZ.
Verified: npm run build passes.