### PR TITLE
fix(authz): allow landlord access to rental applications for QA-creat…

### DIFF
--- a/rentchain-api/src/routes/__tests__/adminCreateLandlord.test.ts
+++ b/rentchain-api/src/routes/__tests__/adminCreateLandlord.test.ts
@@ -3,6 +3,7 @@ import request from "supertest";
 import { describe, it, expect, vi } from "vitest";
 
 const createUserMock = vi.fn(async () => ({ uid: "user-123" }));
+const usersSetMock = vi.fn(async () => ({}));
 const accountsSetMock = vi.fn(async () => ({}));
 const landlordsSetMock = vi.fn(async () => ({}));
 const onboardingSetMock = vi.fn(async () => ({}));
@@ -19,6 +20,9 @@ vi.mock("firebase-admin", () => ({
 vi.mock("../../config/firebase", () => ({
   db: {
     collection: (name: string) => {
+      if (name === "users") {
+        return { doc: () => ({ set: usersSetMock }) };
+      }
       if (name === "accounts") {
         return { doc: () => ({ set: accountsSetMock }) };
       }
@@ -56,6 +60,7 @@ describe("admin create landlord", () => {
     expect(res.body.ok).toBe(true);
     expect(res.body.uid).toBe("user-123");
     expect(createUserMock).toHaveBeenCalled();
+    expect(usersSetMock).toHaveBeenCalled();
     expect(accountsSetMock).toHaveBeenCalled();
     expect(landlordsSetMock).toHaveBeenCalled();
     expect(onboardingSetMock).toHaveBeenCalled();

--- a/rentchain-api/src/routes/adminRoutes.ts
+++ b/rentchain-api/src/routes/adminRoutes.ts
@@ -30,6 +30,15 @@ router.post("/users/create-landlord", requireAdmin, async (req, res) => {
     const uid = user.uid;
     const createdAt = admin.firestore.FieldValue.serverTimestamp();
 
+    await db.collection("users").doc(uid).set({
+      id: uid,
+      email,
+      role: "landlord",
+      landlordId: uid,
+      status: "active",
+      createdAt,
+    });
+
     await db.collection("accounts").doc(uid).set({
       id: uid,
       email,


### PR DESCRIPTION
Admin bootstrap now writes users/{uid} doc on QA landlord creation (role/landlordId/plan) to match auth middleware expectations
- Test updated to assert users doc is written