### PR TITLE
fix(ui): pdf link open new tab + navy upgrade + mobile header/landing…

### DIFF
--- a/rentchain-frontend/src/components/layout/TopNav.tsx
+++ b/rentchain-frontend/src/components/layout/TopNav.tsx
@@ -22,6 +22,7 @@ const TopNav: React.FC = () => {
           borderBottom: `1px solid ${colors.border}`,
           boxShadow: shadows.sm,
           backdropFilter: blur.sm,
+          paddingTop: "env(safe-area-inset-top)",
         }}
       >
         <div

--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
@@ -21,6 +21,7 @@ import { setOnboardingStep } from "../../api/onboardingApi";
 import "../../styles/propertiesMobile.css";
 import { useCapabilities } from "@/hooks/useCapabilities";
 import { useUpgrade } from "@/context/UpgradeContext";
+import { upgradeStarterButtonStyle } from "../../lib/upgradeButtonStyles";
 import { dispatchUpgradePrompt } from "@/lib/upgradePrompt";
 
 interface PropertyDetailPanelProps {
@@ -741,15 +742,7 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
                 ctaLabel: "Upgrade to Starter",
               })
             }
-            style={{
-              padding: "8px 12px",
-              borderRadius: 10,
-              border: "1px solid rgba(59,130,246,0.45)",
-              background: "rgba(59,130,246,0.12)",
-              color: "#2563eb",
-              cursor: "pointer",
-              fontWeight: 700,
-            }}
+            style={upgradeStarterButtonStyle}
           >
             Upgrade to Starter
           </button>

--- a/rentchain-frontend/src/components/tenants/TenantDetailPanel.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantDetailPanel.tsx
@@ -13,6 +13,7 @@ import { useToast } from "../ui/ToastProvider";
 import { colors, radius, spacing, text, shadows } from "../../styles/tokens";
 import { useCapabilities } from "@/hooks/useCapabilities";
 import { useUpgrade } from "@/context/UpgradeContext";
+import { upgradeStarterButtonStyle } from "../../lib/upgradeButtonStyles";
 
 interface TenantDetailPanelProps {
   tenantId: string | null;
@@ -389,15 +390,7 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId }) => {
                 ctaLabel: "Upgrade to Starter",
               })
             }
-            style={{
-              padding: "8px 12px",
-              borderRadius: 10,
-              border: "1px solid rgba(59,130,246,0.45)",
-              background: "rgba(59,130,246,0.12)",
-              color: "#2563eb",
-              cursor: "pointer",
-              fontWeight: 700,
-            }}
+            style={upgradeStarterButtonStyle}
           >
             Upgrade to Starter
           </button>

--- a/rentchain-frontend/src/components/tenants/TenantLeasePanel.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantLeasePanel.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { endLease, getLeasesForTenant, Lease } from "../../api/leasesApi";
 import { useCapabilities } from "@/hooks/useCapabilities";
 import { useUpgrade } from "@/context/UpgradeContext";
+import { upgradeStarterButtonStyle } from "@/lib/upgradeButtonStyles";
 
 function isNotFound(err: any): boolean {
   return (
@@ -147,15 +148,7 @@ export const TenantLeasePanel: React.FC<TenantLeasePanelProps> = ({ tenantId }) 
               ctaLabel: "Upgrade to Starter",
             })
           }
-          style={{
-            padding: "8px 12px",
-            borderRadius: 10,
-            border: "1px solid rgba(59,130,246,0.45)",
-            background: "rgba(59,130,246,0.12)",
-            color: "#2563eb",
-            cursor: "pointer",
-            fontWeight: 700,
-          }}
+          style={upgradeStarterButtonStyle}
         >
           Upgrade to Starter
         </button>

--- a/rentchain-frontend/src/components/ui/Ui.tsx
+++ b/rentchain-frontend/src/components/ui/Ui.tsx
@@ -47,7 +47,7 @@ export const Section: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({
 };
 
 type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
-  variant?: "primary" | "secondary" | "ghost";
+  variant?: "primary" | "secondary" | "ghost" | "navy";
 };
 
 export const Button: React.FC<ButtonProps> = ({
@@ -69,6 +69,11 @@ export const Button: React.FC<ButtonProps> = ({
   const variants: Record<string, React.CSSProperties> = {
     primary: {
       background: colors.accent,
+      color: "#fff",
+      boxShadow: shadows.sm,
+    },
+    navy: {
+      background: colors.navy,
       color: "#fff",
       boxShadow: shadows.sm,
     },

--- a/rentchain-frontend/src/lib/upgradeButtonStyles.ts
+++ b/rentchain-frontend/src/lib/upgradeButtonStyles.ts
@@ -1,0 +1,13 @@
+import type React from "react";
+import { colors, shadows } from "../styles/tokens";
+
+export const upgradeStarterButtonStyle: React.CSSProperties = {
+  padding: "8px 12px",
+  borderRadius: 10,
+  border: `1px solid ${colors.navy}`,
+  background: colors.navy,
+  color: "#fff",
+  cursor: "pointer",
+  fontWeight: 700,
+  boxShadow: shadows.sm,
+};

--- a/rentchain-frontend/src/pages/LedgerPage.tsx
+++ b/rentchain-frontend/src/pages/LedgerPage.tsx
@@ -6,6 +6,7 @@ import { useToast } from "../components/ui/ToastProvider";
 import { useCapabilities } from "@/hooks/useCapabilities";
 import { useUpgrade } from "@/context/UpgradeContext";
 import { colors, spacing } from "@/styles/tokens";
+import { upgradeStarterButtonStyle } from "@/lib/upgradeButtonStyles";
 
 function getEventDate(e: LedgerEventStored): Date {
   if (typeof e.ts === "number") return new Date(e.ts);
@@ -197,15 +198,7 @@ const LedgerPage: React.FC = () => {
                     ctaLabel: "Upgrade to Starter",
                   })
                 }
-                style={{
-                  padding: "10px 14px",
-                  borderRadius: 12,
-                  border: "1px solid rgba(148,163,184,0.35)",
-                  background: "rgba(59,130,246,0.12)",
-                  color: colors.accent,
-                  fontWeight: 700,
-                  cursor: "pointer",
-                }}
+                style={upgradeStarterButtonStyle}
               >
                 Upgrade to Starter
               </button>

--- a/rentchain-frontend/src/pages/LedgerV2Page.tsx
+++ b/rentchain-frontend/src/pages/LedgerV2Page.tsx
@@ -3,6 +3,7 @@ import { createLedgerNoteV2, getLedgerEventV2, listLedgerV2, LedgerEventV2 } fro
 import { useCapabilities } from "@/hooks/useCapabilities";
 import { useUpgrade } from "@/context/UpgradeContext";
 import { colors, spacing } from "@/styles/tokens";
+import { upgradeStarterButtonStyle } from "@/lib/upgradeButtonStyles";
 
 type Filters = {
   eventType: string;
@@ -134,15 +135,7 @@ export default function LedgerV2Page() {
                 ctaLabel: "Upgrade to Starter",
               })
             }
-            style={{
-              padding: "10px 14px",
-              borderRadius: 12,
-              border: "1px solid rgba(59,130,246,0.45)",
-              background: "rgba(59,130,246,0.12)",
-              color: colors.accent,
-              fontWeight: 700,
-              cursor: "pointer",
-            }}
+            style={upgradeStarterButtonStyle}
           >
             Upgrade to Starter
           </button>

--- a/rentchain-frontend/src/pages/MaintenanceRequestsPage.tsx
+++ b/rentchain-frontend/src/pages/MaintenanceRequestsPage.tsx
@@ -128,7 +128,7 @@ const MaintenanceRequestsPage: React.FC = () => {
             RentChain Screening is free. Rental management starts on Starter.
           </div>
           <Button
-            variant="secondary"
+            variant="navy"
             onClick={() =>
               openUpgrade({
                 reason: "screening",

--- a/rentchain-frontend/src/pages/MessagesPage.tsx
+++ b/rentchain-frontend/src/pages/MessagesPage.tsx
@@ -12,6 +12,7 @@ import { spacing, colors, text, radius } from "@/styles/tokens";
 import { ResponsiveMasterDetail } from "@/components/layout/ResponsiveMasterDetail";
 import { useCapabilities } from "@/hooks/useCapabilities";
 import { useUpgrade } from "@/context/UpgradeContext";
+import { upgradeStarterButtonStyle } from "@/lib/upgradeButtonStyles";
 import "./MessagesPage.css";
 
 const POLL_CONVERSATIONS_MS = 15000;
@@ -132,15 +133,7 @@ export default function MessagesPage() {
                 ctaLabel: "Upgrade to Starter",
               })
             }
-            style={{
-              padding: "10px 14px",
-              borderRadius: 12,
-              border: `1px solid ${colors.border}`,
-              background: "rgba(59,130,246,0.12)",
-              color: colors.accent,
-              fontWeight: 700,
-              cursor: "pointer",
-            }}
+            style={upgradeStarterButtonStyle}
           >
             Upgrade to Starter
           </button>

--- a/rentchain-frontend/src/pages/marketing/MarketingLayout.tsx
+++ b/rentchain-frontend/src/pages/marketing/MarketingLayout.tsx
@@ -102,6 +102,7 @@ export const MarketingLayout: React.FC<MarketingLayoutProps> = ({ children }) =>
           backdropFilter: "blur(12px)",
           background: "rgba(247,249,252,0.9)",
           borderBottom: `1px solid ${colors.border}`,
+          paddingTop: "env(safe-area-inset-top)",
         }}
       >
         <div
@@ -445,10 +446,11 @@ export const MarketingLayout: React.FC<MarketingLayoutProps> = ({ children }) =>
 
         <main
           style={{
-            maxWidth: layout.maxWidth,
+            maxWidth: "100vw",
             width: "100%",
             margin: "0 auto",
-            padding: `${spacing.xl} ${layout.pagePadding}`,
+            padding: `clamp(16px, 4vw, 40px) ${layout.pagePadding}`,
+            boxSizing: "border-box",
           }}
         >
         <div
@@ -457,7 +459,9 @@ export const MarketingLayout: React.FC<MarketingLayoutProps> = ({ children }) =>
             borderRadius: radius.xl,
             boxShadow: shadows.md,
             border: `1px solid ${colors.border}`,
-            padding: spacing.xxl,
+            padding: "clamp(20px, 6vw, 48px)",
+            maxWidth: "100%",
+            boxSizing: "border-box",
           }}
         >
           {children}

--- a/rentchain-frontend/src/styles/tokens.ts
+++ b/rentchain-frontend/src/styles/tokens.ts
@@ -41,6 +41,8 @@ export const colors = {
   borderStrong: "rgba(15,23,42,0.16)",
   accent: "#2563eb",
   accentSoft: "rgba(37,99,235,0.12)",
+  navy: "#0f1f3d",
+  navySoft: "rgba(15,31,61,0.12)",
   danger: "#ef4444",
 };
 


### PR DESCRIPTION
Added navy button token + shared style helper, applied to all “Upgrade to Starter” buttons.
Added safe‑area top padding to dashboard TopNav header.
Marketing layout now clamps padding and ensures max‑width/box‑sizing to prevent mobile overflow/cut‑off.
Sample PDF link already opens in new tab with window.open(..., "_blank", "noopener,noreferrer") (confirmed in ApplicationsPage).