### PR TITLE
fix(pricing): render plan amounts from pricing API

### DIFF
--- a/rentchain-frontend/src/api/billingApi.ts
+++ b/rentchain-frontend/src/api/billingApi.ts
@@ -113,9 +113,9 @@ export type BillingPricingResponse = {
 
 export async function fetchBillingPricing(): Promise<BillingPricingResponse | null> {
   try {
-    const res = await apiGetJson<any>("/billing/pricing", { allowStatuses: [404, 501] });
-    if (!res.ok) return null;
-    return res.data as BillingPricingResponse;
+    const res = await apiFetch<any>("/billing/pricing", { method: "GET" });
+    if (!res?.ok) return null;
+    return res as BillingPricingResponse;
   } catch {
     return null;
   }

--- a/rentchain-frontend/src/pages/PricingPage.tsx
+++ b/rentchain-frontend/src/pages/PricingPage.tsx
@@ -16,6 +16,7 @@ const PricingPage: React.FC = () => {
   const [notifyPlan, setNotifyPlan] = useState<"core" | "pro" | "elite">("core");
   const [pricing, setPricing] = useState<any | null>(null);
   const [loading, setLoading] = useState(true);
+  const [pricingError, setPricingError] = useState(false);
   const [pricingHealth, setPricingHealth] = useState<any | null>(null);
   const [healthLoading, setHealthLoading] = useState(true);
 
@@ -24,7 +25,17 @@ const PricingPage: React.FC = () => {
     fetchBillingPricing()
       .then((res) => {
         if (!active) return;
+        if (!res) {
+          setPricingError(true);
+          return;
+        }
         setPricing(res);
+      })
+      .catch((err) => {
+        if (import.meta.env.DEV) {
+          console.warn("[pricing] fetch failed", { message: err?.message || err });
+        }
+        setPricingError(true);
       })
       .finally(() => {
         if (active) setLoading(false);
@@ -50,7 +61,8 @@ const PricingPage: React.FC = () => {
   }, []);
 
   const pricingUnavailable =
-    !healthLoading && pricingHealth && pricingHealth.ok === false;
+    (!healthLoading && pricingHealth && pricingHealth.ok === false) ||
+    (!loading && pricingError);
 
   const planMap = useMemo(() => {
     const map = new Map<string, any>();
@@ -108,7 +120,7 @@ const PricingPage: React.FC = () => {
                   fontWeight: 600,
                 }}
               >
-                Billing temporarily unavailable. Please try again later.
+                Pricing unavailable. Please try again later.
               </div>
             ) : null}
           </div>
@@ -131,7 +143,7 @@ const PricingPage: React.FC = () => {
               >
                 <div style={{ fontWeight: 700 }}>Starter</div>
                 <div style={{ color: text.muted, fontSize: 13 }}>
-                  {loading ? "Loading..." : renderPrice("starter")}
+                  {loading ? "—" : renderPrice("starter")}
                 </div>
                 <Button
                   type="button"
@@ -154,7 +166,7 @@ const PricingPage: React.FC = () => {
               >
                 <div style={{ fontWeight: 700 }}>Pro</div>
                 <div style={{ color: text.muted, fontSize: 13 }}>
-                  {loading ? "Loading..." : renderPrice("pro")}
+                  {loading ? "—" : renderPrice("pro")}
                 </div>
                 <Button
                   type="button"
@@ -177,7 +189,7 @@ const PricingPage: React.FC = () => {
               >
                 <div style={{ fontWeight: 700 }}>Business</div>
                 <div style={{ color: text.muted, fontSize: 13 }}>
-                  {loading ? "Loading..." : renderPrice("business")}
+                  {loading ? "—" : renderPrice("business")}
                 </div>
                 <Button type="button" onClick={() => navigate(user ? "/billing" : "/login")}>
                   Contact sales

--- a/rentchain-frontend/src/pages/marketing/PricingPage.tsx
+++ b/rentchain-frontend/src/pages/marketing/PricingPage.tsx
@@ -1,16 +1,66 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { Card, Button } from "../../components/ui/Ui";
 import { spacing, text } from "../../styles/tokens";
 import { MarketingLayout } from "./MarketingLayout";
 import { useAuth } from "../../context/useAuth";
+import { fetchBillingPricing } from "../../api/billingApi";
 
 const PricingPage: React.FC = () => {
   const { user } = useAuth();
   const isAuthed = Boolean(user?.id);
+  const [pricing, setPricing] = useState<any | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [pricingError, setPricingError] = useState(false);
 
   useEffect(() => {
     document.title = "Pricing — RentChain";
   }, []);
+
+  useEffect(() => {
+    let active = true;
+    fetchBillingPricing()
+      .then((res) => {
+        if (!active) return;
+        if (!res) {
+          setPricingError(true);
+          return;
+        }
+        setPricing(res);
+      })
+      .catch((err) => {
+        if (import.meta.env.DEV) {
+          console.warn("[marketing/pricing] fetch failed", { message: err?.message || err });
+        }
+        setPricingError(true);
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const planMap = useMemo(() => {
+    const map = new Map<string, any>();
+    if (pricing?.plans) {
+      pricing.plans.forEach((plan: any) => map.set(plan.key, plan));
+    }
+    return map;
+  }, [pricing]);
+
+  const renderPrice = (planKey: "starter" | "pro") => {
+    const plan = planMap.get(planKey);
+    if (!plan) return "—";
+    if (plan.monthlyAmountCents === 0) return "Free";
+    const monthly = `$${Math.round(plan.monthlyAmountCents / 100)} / month`;
+    const yearly = plan.yearlyAmountCents
+      ? `$${Math.round(plan.yearlyAmountCents / 100)} / year`
+      : "";
+    return yearly ? `${monthly} • ${yearly}` : monthly;
+  };
+
+  const pricingUnavailable = !loading && pricingError;
 
   return (
     <MarketingLayout>
@@ -34,6 +84,14 @@ const PricingPage: React.FC = () => {
             alignItems: "stretch",
           }}
         >
+          {pricingUnavailable ? (
+            <Card>
+              <div style={{ fontWeight: 700, fontSize: "1.05rem" }}>Pricing unavailable</div>
+              <div style={{ color: text.muted, marginTop: spacing.xs }}>
+                Please try again shortly.
+              </div>
+            </Card>
+          ) : null}
           <Card>
             <h2 style={{ marginTop: 0 }}>Starter</h2>
             <p style={{ color: text.muted, marginTop: 0 }}>For individual landlords and small portfolios.</p>
@@ -44,9 +102,15 @@ const PricingPage: React.FC = () => {
               <li>Lease and tenant lifecycle tracking</li>
               <li>Core rental event records</li>
             </ul>
-            <div style={{ fontWeight: 700, fontSize: "1.1rem" }}>$XX / month</div>
+            <div style={{ fontWeight: 700, fontSize: "1.1rem" }}>
+              {loading ? "—" : renderPrice("starter")}
+            </div>
             <div className="rc-wrap-row" style={{ marginTop: spacing.sm }}>
-              <Button type="button" onClick={() => (window.location.href = isAuthed ? "/billing" : "/login")}>
+              <Button
+                type="button"
+                onClick={() => (window.location.href = isAuthed ? "/billing" : "/login")}
+                disabled={pricingUnavailable}
+              >
                 {isAuthed ? "Choose plan" : "Get started"}
               </Button>
             </div>
@@ -62,10 +126,16 @@ const PricingPage: React.FC = () => {
               <li>Exports for reporting and audits</li>
               <li>Compliance-ready notices and timelines</li>
             </ul>
-            <div style={{ fontWeight: 700, fontSize: "1.1rem" }}>$XX / month</div>
+            <div style={{ fontWeight: 700, fontSize: "1.1rem" }}>
+              {loading ? "—" : renderPrice("pro")}
+            </div>
             <div style={{ color: text.subtle, marginTop: spacing.xs }}>Screening: Pay-per-applicant</div>
             <div className="rc-wrap-row" style={{ marginTop: spacing.sm }}>
-              <Button type="button" onClick={() => (window.location.href = isAuthed ? "/billing" : "/login")}>
+              <Button
+                type="button"
+                onClick={() => (window.location.href = isAuthed ? "/billing" : "/login")}
+                disabled={pricingUnavailable}
+              >
                 {isAuthed ? "Upgrade to Pro" : "Get started"}
               </Button>
             </div>


### PR DESCRIPTION
/pricing (app) and /site/pricing now render amounts from GET /api/billing/pricing
Loading state shows “—” (no placeholders)
Error state shows “Pricing unavailable” + disables buttons
Dev‑only console warning on fetch failures
fetchBillingPricing now uses apiFetch for consistent base URL/auth headers