### PR TITLE
fix(ux): pdf viewer stability + interval + chunk recovery + app modal…

### DIFF
--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -58,6 +58,7 @@ import MessagesPage from "./pages/MessagesPage";
 import TenantMessagesPage from "./pages/tenant/TenantMessagesPage";
 import TenantNoticeDetailPage from "./pages/tenant/TenantNoticeDetailPage";
 import MaintenanceRequestsPage from "./pages/MaintenanceRequestsPage";
+import PdfSamplePage from "./pages/PdfSamplePage";
 
 const TENANT_PORTAL_ENABLED = import.meta.env.VITE_TENANT_PORTAL_ENABLED === "true";
 
@@ -185,6 +186,14 @@ function App() {
                 <ApplicationsPage />
               </LandlordNav>
             </RequireAuth>
+          }
+        />
+        <Route
+          path="/pdf/sample"
+          element={
+            <LandlordNav>
+              <PdfSamplePage />
+            </LandlordNav>
           }
         />
         {import.meta.env.DEV ? (

--- a/rentchain-frontend/src/components/billing/SamplePdfModal.tsx
+++ b/rentchain-frontend/src/components/billing/SamplePdfModal.tsx
@@ -9,6 +9,7 @@ export function SamplePdfModal({ open, onClose }: Props) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [loadError, setLoadError] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
+  const pdfUrl = "/sample/screening_report_sample.pdf?v=1";
 
   useEffect(() => {
     if (!open) return;
@@ -122,7 +123,21 @@ export function SamplePdfModal({ open, onClose }: Props) {
           <div style={{ fontWeight: 700 }}>Sample screening report</div>
           <div style={{ display: "flex", gap: 8 }}>
             <a
-              href="/sample/screening_report_sample.pdf"
+              href="/pdf/sample"
+              style={{
+                fontSize: 13,
+                color: "#0f172a",
+                textDecoration: "none",
+                padding: "6px 10px",
+                borderRadius: 10,
+                border: "1px solid #e2e8f0",
+                background: "#fff",
+              }}
+            >
+              View full page
+            </a>
+            <a
+              href={pdfUrl}
               target="_blank"
               rel="noreferrer"
               style={{
@@ -158,7 +173,7 @@ export function SamplePdfModal({ open, onClose }: Props) {
             <div style={{ padding: 16, fontSize: 14, color: "#b91c1c" }}>
               Unable to load the sample report.
               <div style={{ marginTop: 8 }}>
-                <a href="/sample/screening_report_sample.pdf" target="_blank" rel="noreferrer">
+                <a href={pdfUrl} target="_blank" rel="noreferrer">
                   Open in new tab
                 </a>
               </div>
@@ -166,7 +181,7 @@ export function SamplePdfModal({ open, onClose }: Props) {
           ) : (
             <iframe
               title="Sample screening report PDF"
-              src="/sample/screening_report_sample.pdf#view=FitH"
+              src={`${pdfUrl}#view=FitH`}
               className="w-full h-full rounded-xl"
               style={{
                 width: "100%",

--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
@@ -1082,6 +1082,13 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
               ]
             : []
         }
+        units={(units || [])
+          .map((u: any) => ({
+            id: String(u?.id || u?.unitId || u?.uid || ""),
+            name: u?.unitNumber || u?.label || u?.name || u?.unit || "Unit",
+          }))
+          .filter((u: any) => u.id)}
+        initialUnitId={(sendAppUnit as any)?.id ? String((sendAppUnit as any).id) : null}
         unit={sendAppUnit}
         onClose={() => setSendAppUnit(null)}
       />

--- a/rentchain-frontend/src/components/properties/SendApplicationModal.tsx
+++ b/rentchain-frontend/src/components/properties/SendApplicationModal.tsx
@@ -10,6 +10,9 @@ type Props = {
   propertyName?: string | null;
   properties?: Array<{ id: string; name: string }>;
   onPropertyChange?: (nextId: string) => void;
+  units?: Array<{ id: string; name: string }>;
+  initialUnitId?: string | null;
+  onUnitChange?: (nextId: string | null) => void;
   unit?: any | null;
   onClose: () => void;
 };
@@ -20,6 +23,9 @@ export function SendApplicationModal({
   propertyName,
   properties,
   onPropertyChange,
+  units,
+  initialUnitId,
+  onUnitChange,
   unit,
   onClose,
 }: Props) {
@@ -39,6 +45,9 @@ export function SendApplicationModal({
     return [];
   }, [properties, propertyId, propertyName]);
   const [selectedPropertyId, setSelectedPropertyId] = React.useState<string>(propertyId || "");
+  const [selectedUnitId, setSelectedUnitId] = React.useState<string>(
+    initialUnitId || ((unit as any)?.id ? String((unit as any).id) : "")
+  );
 
   React.useEffect(() => {
     if (!open) {
@@ -63,6 +72,17 @@ export function SendApplicationModal({
     }
   }, [open, propertyId]);
 
+  React.useEffect(() => {
+    if (!open) return;
+    if (initialUnitId) {
+      setSelectedUnitId(String(initialUnitId));
+    } else if ((unit as any)?.id) {
+      setSelectedUnitId(String((unit as any).id));
+    } else {
+      setSelectedUnitId("");
+    }
+  }, [open, initialUnitId, unit]);
+
   if (!open) return null;
 
   const handleGenerate = async () => {
@@ -77,7 +97,7 @@ export function SendApplicationModal({
     try {
       const res = await createApplicationLink({
         propertyId: String(selectedPropertyId),
-        unitId: (unit as any)?.id ? String((unit as any).id) : null,
+        unitId: selectedUnitId ? String(selectedUnitId) : null,
         applicantEmail: applicantEmail.trim() || null,
       });
       if ((res as any)?.ok === false) {
@@ -189,6 +209,10 @@ export function SendApplicationModal({
                   const nextId = e.target.value;
                   setSelectedPropertyId(nextId);
                   onPropertyChange?.(nextId);
+                  if (nextId !== selectedPropertyId) {
+                    setSelectedUnitId("");
+                    onUnitChange?.(null);
+                  }
                 }}
                 style={{
                   width: "100%",
@@ -210,6 +234,34 @@ export function SendApplicationModal({
                 This link will be for the selected property.
               </span>
             </label>
+            {units && units.length ? (
+              <label style={{ display: "grid", gap: 6, fontSize: "0.9rem", color: "#111827" }}>
+                Unit (optional)
+                <select
+                  value={selectedUnitId}
+                  onChange={(e) => {
+                    const nextId = e.target.value;
+                    setSelectedUnitId(nextId);
+                    onUnitChange?.(nextId ? nextId : null);
+                  }}
+                  style={{
+                    width: "100%",
+                    padding: "8px 10px",
+                    borderRadius: 8,
+                    border: "1px solid #e5e7eb",
+                    fontSize: "0.9rem",
+                    background: "#fff",
+                  }}
+                >
+                  <option value="">No unit selected</option>
+                  {units.map((option) => (
+                    <option key={option.id} value={option.id}>
+                      {option.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            ) : null}
             {!unit ? (
               <div style={{ fontSize: "0.85rem", color: "#6b7280" }}>
                 Unit and rent details can be entered manually by the applicant.

--- a/rentchain-frontend/src/components/system/ErrorBoundary.tsx
+++ b/rentchain-frontend/src/components/system/ErrorBoundary.tsx
@@ -62,6 +62,22 @@ export class ErrorBoundary extends React.Component<
             >
               {this.state.error?.message}
             </pre>
+            <button
+              type="button"
+              onClick={() => window.location.reload()}
+              style={{
+                marginTop: "1rem",
+                padding: "8px 12px",
+                borderRadius: "999px",
+                border: "1px solid rgba(148,163,184,0.4)",
+                background: "rgba(148,163,184,0.15)",
+                color: "#e2e8f0",
+                cursor: "pointer",
+                fontWeight: 600,
+              }}
+            >
+              Reload
+            </button>
           </div>
         </div>
       );

--- a/rentchain-frontend/src/main.tsx
+++ b/rentchain-frontend/src/main.tsx
@@ -22,6 +22,41 @@ if (typeof window !== "undefined" && window.location.hostname === "rentchain.ai"
   window.location.replace(target.toString());
 }
 
+function showReloadBanner(message: string) {
+  if (typeof document === "undefined") return;
+  const existing = document.getElementById("rc-reload-banner");
+  if (existing) return;
+  const banner = document.createElement("div");
+  banner.id = "rc-reload-banner";
+  banner.textContent = message;
+  banner.style.position = "fixed";
+  banner.style.top = "16px";
+  banner.style.left = "50%";
+  banner.style.transform = "translateX(-50%)";
+  banner.style.background = "rgba(15,23,42,0.95)";
+  banner.style.color = "#f8fafc";
+  banner.style.padding = "10px 14px";
+  banner.style.borderRadius = "999px";
+  banner.style.fontSize = "13px";
+  banner.style.fontWeight = "600";
+  banner.style.zIndex = "9999";
+  banner.style.boxShadow = "0 10px 30px rgba(15,23,42,0.4)";
+  document.body.appendChild(banner);
+}
+
+if (typeof window !== "undefined") {
+  window.addEventListener("unhandledrejection", (event) => {
+    const msg = String((event as any)?.reason?.message || (event as any)?.reason || "");
+    if (
+      msg.includes("Failed to fetch dynamically imported module") ||
+      msg.includes("Importing a module script failed")
+    ) {
+      showReloadBanner("Update available — reloading…");
+      window.setTimeout(() => window.location.reload(), 1200);
+    }
+  });
+}
+
 const originalFetch = window.fetch.bind(window);
 // Legacy global (DO NOT REMOVE until all fetch() calls are migrated)
 (window as any).API_BASE_URL = API_BASE_URL;

--- a/rentchain-frontend/src/pages/PdfSamplePage.tsx
+++ b/rentchain-frontend/src/pages/PdfSamplePage.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import { Card } from "../components/ui/Ui";
+import { spacing } from "../styles/tokens";
+
+const pdfUrl = "/sample/screening_report_sample.pdf?v=1";
+
+const PdfSamplePage: React.FC = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div style={{ display: "grid", gap: spacing.md }}>
+      <Card>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: spacing.sm,
+            flexWrap: "wrap",
+          }}
+        >
+          <div style={{ fontWeight: 700, fontSize: "1.1rem" }}>
+            Sample screening report
+          </div>
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+            <button
+              type="button"
+              onClick={() => navigate(-1)}
+              style={{
+                padding: "8px 12px",
+                borderRadius: 10,
+                border: "1px solid #e2e8f0",
+                background: "#fff",
+                cursor: "pointer",
+                fontWeight: 600,
+              }}
+            >
+              Back
+            </button>
+            <a
+              href={pdfUrl}
+              target="_blank"
+              rel="noreferrer"
+              style={{
+                padding: "8px 12px",
+                borderRadius: 10,
+                border: "1px solid #e2e8f0",
+                background: "#fff",
+                textDecoration: "none",
+                color: "#0f172a",
+                fontWeight: 600,
+              }}
+            >
+              Open in new tab
+            </a>
+          </div>
+        </div>
+      </Card>
+      <Card style={{ padding: 0, overflow: "hidden" }}>
+        <iframe
+          title="Sample screening report"
+          src={`${pdfUrl}#view=FitH`}
+          style={{
+            width: "100%",
+            height: "90vh",
+            border: "none",
+          }}
+        />
+      </Card>
+    </div>
+  );
+};
+
+export default PdfSamplePage;


### PR DESCRIPTION
What’s included

Sample PDF viewer:
SamplePdfModal now uses [screening_report_sample.pdf?v=1"](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/P2/.vscode/extensions/openai.chatgpt-0.4.69-win32-x64/webview/#) and embeds iframe (no Router nav).
Added “View full page” link to /pdf/sample and “Open in new tab” anchor.
Inline error state keeps anchor.
New full‑page viewer route /pdf/sample (app shell):
[PdfSamplePage.tsx](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/P2/.vscode/extensions/openai.chatgpt-0.4.69-win32-x64/webview/#)
Header + Back + Open in new tab; iframe 90vh.
Chunk load recovery:
[main.tsx](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/P2/.vscode/extensions/openai.chatgpt-0.4.69-win32-x64/webview/#) adds unhandledrejection handler that shows a reload banner and reloads on dynamic import failure.
ErrorBoundary now includes a Reload button.
Application modal decoupling + unit selector:
SendApplicationModal now supports unit selector; uses local modal state.
ApplicationsPage no longer mutates filter when modal property changes.