### PR TITLE
fix(marketing+app): static pdf sample, contrast, auth-aware CTAs, mob…

### DIFF
--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -283,11 +283,7 @@ function App() {
         />
         <Route
           path="/pdf/sample"
-          element={
-            <LandlordNav>
-              <PdfSamplePage />
-            </LandlordNav>
-          }
+          element={<Navigate to="/sample/screening_report_sample.pdf" replace />}
         />
         {import.meta.env.DEV ? (
           <Route

--- a/rentchain-frontend/src/components/billing/SamplePdfModal.tsx
+++ b/rentchain-frontend/src/components/billing/SamplePdfModal.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useRef, useState } from "react";
-import { useNavigate } from "react-router-dom";
 
 type Props = {
   open: boolean;
@@ -10,7 +9,6 @@ export function SamplePdfModal({ open, onClose }: Props) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [loadError, setLoadError] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
-  const navigate = useNavigate();
   const pdfUrl = "/sample/screening_report_sample.pdf?v=1";
 
   useEffect(() => {
@@ -126,7 +124,11 @@ export function SamplePdfModal({ open, onClose }: Props) {
           <div style={{ display: "flex", gap: 8 }}>
             <button
               type="button"
-              onClick={() => navigate("/pdf/sample")}
+              onClick={() => {
+                if (typeof window !== "undefined") {
+                  window.location.assign(pdfUrl);
+                }
+              }}
               style={{
                 fontSize: 13,
                 color: "#0f172a",

--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
@@ -599,10 +599,10 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
             border: "1px solid rgba(148,163,184,0.15)",
           }}
         >
-          <div className="rc-kpi-label" style={{ color: "#94a3b8", fontSize: "0.8rem" }}>
+          <div className="rc-kpi-label" style={{ color: "#111827", fontSize: "0.8rem" }}>
             Total units
           </div>
-          <div className="rc-kpi-value" style={{ color: "#e5e7eb", fontWeight: 700, fontSize: "1.1rem" }}>
+          <div className="rc-kpi-value" style={{ color: "#0b1220", fontWeight: 700, fontSize: "1.1rem" }}>
             {unitCount}
           </div>
         </div>
@@ -615,10 +615,10 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
             border: "1px solid rgba(148,163,184,0.15)",
           }}
         >
-          <div className="rc-kpi-label" style={{ color: "#94a3b8", fontSize: "0.8rem" }}>
+          <div className="rc-kpi-label" style={{ color: "#111827", fontSize: "0.8rem" }}>
             Leased units
           </div>
-          <div className="rc-kpi-value" style={{ color: "#e5e7eb", fontWeight: 700, fontSize: "1.1rem" }}>
+          <div className="rc-kpi-value" style={{ color: "#0b1220", fontWeight: 700, fontSize: "1.1rem" }}>
             {leasedUnits}
           </div>
         </div>
@@ -631,10 +631,10 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
             border: "1px solid rgba(148,163,184,0.15)",
           }}
         >
-          <div className="rc-kpi-label" style={{ color: "#94a3b8", fontSize: "0.8rem" }}>
+          <div className="rc-kpi-label" style={{ color: "#111827", fontSize: "0.8rem" }}>
             Occupancy
           </div>
-          <div className="rc-kpi-value" style={{ color: "#e5e7eb", fontWeight: 700, fontSize: "1.05rem" }}>
+          <div className="rc-kpi-value" style={{ color: "#0b1220", fontWeight: 700, fontSize: "1.05rem" }}>
             {unitCount === 0 ? "--" : `${occupancy.toFixed(0)}%`}
           </div>
         </div>
@@ -647,13 +647,13 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
             border: "1px solid rgba(148,163,184,0.15)",
           }}
         >
-          <div className="rc-kpi-label" style={{ color: "#94a3b8", fontSize: "0.8rem" }}>
+          <div className="rc-kpi-label" style={{ color: "#111827", fontSize: "0.8rem" }}>
             Lease rent roll
           </div>
-          <div className="rc-kpi-value" style={{ color: "#e5e7eb", fontWeight: 700, fontSize: "1.05rem" }}>
+          <div className="rc-kpi-value" style={{ color: "#0b1220", fontWeight: 700, fontSize: "1.05rem" }}>
             {formatCurrency(leaseRentRoll)}
           </div>
-          <div className="rc-kpi-subtext" style={{ color: "#6b7280", fontSize: "0.75rem", marginTop: 2 }}>
+          <div className="rc-kpi-subtext" style={{ color: "#4b5563", fontSize: "0.75rem", marginTop: 2 }}>
             Configured rent roll: {formatCurrency(totalRentConfigured)}
           </div>
         </div>
@@ -667,10 +667,10 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
             border: "1px solid rgba(148,163,184,0.15)",
           }}
         >
-          <div className="rc-kpi-label" style={{ color: "#94a3b8", fontSize: "0.8rem" }}>
+          <div className="rc-kpi-label" style={{ color: "#111827", fontSize: "0.8rem" }}>
             Collected this month
           </div>
-          <div className="rc-kpi-value" style={{ color: "#e5e7eb", fontWeight: 700, fontSize: "1.05rem" }}>
+          <div className="rc-kpi-value" style={{ color: "#0b1220", fontWeight: 700, fontSize: "1.05rem" }}>
             {formatCurrency(totalCollectedThisMonth)}
           </div>
         </div>
@@ -684,10 +684,10 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
             border: "1px solid rgba(148,163,184,0.15)",
           }}
         >
-          <div className="rc-kpi-label" style={{ color: "#94a3b8", fontSize: "0.8rem" }}>
+          <div className="rc-kpi-label" style={{ color: "#111827", fontSize: "0.8rem" }}>
             Collection
           </div>
-          <div className="rc-kpi-value" style={{ color: "#e5e7eb", fontWeight: 700, fontSize: "1.05rem" }}>
+          <div className="rc-kpi-value" style={{ color: "#0b1220", fontWeight: 700, fontSize: "1.05rem" }}>
             {leaseRentRoll === 0 ? "--" : `${(collectionRate * 100).toFixed(0)}%`}
           </div>
         </div>

--- a/rentchain-frontend/src/lib/onboardingSteps.ts
+++ b/rentchain-frontend/src/lib/onboardingSteps.ts
@@ -96,7 +96,12 @@ export function buildOnboardingSteps({
       actionLabel: "Preview export",
       onAction: () => {
         track("onboarding_step_clicked", { stepKey: "exportPreviewed" });
-        navigate("/pdf/sample");
+        const url = "/sample/screening_report_sample.pdf";
+        if (typeof window !== "undefined") {
+          window.location.assign(url);
+          return;
+        }
+        navigate(url);
       },
     },
   ];

--- a/rentchain-frontend/src/pages/help/TemplatesPage.tsx
+++ b/rentchain-frontend/src/pages/help/TemplatesPage.tsx
@@ -116,6 +116,8 @@ const TemplatesPage: React.FC = () => {
             key={f.file}
             href={templateUrl(f.file)}
             download
+            target="_blank"
+            rel="noopener noreferrer"
             style={{
               border: "1px solid rgba(15,23,42,0.12)",
               borderRadius: 999,

--- a/rentchain-frontend/src/pages/marketing/LandingPage.tsx
+++ b/rentchain-frontend/src/pages/marketing/LandingPage.tsx
@@ -3,11 +3,13 @@ import { useNavigate } from "react-router-dom";
 import { Button, Card } from "../../components/ui/Ui";
 import { spacing, text } from "../../styles/tokens";
 import { MarketingLayout } from "./MarketingLayout";
+import { useAuth } from "../../context/useAuth";
 import { RequestAccessModal } from "../../components/marketing/RequestAccessModal";
 
 const LandingPage: React.FC = () => {
   const navigate = useNavigate();
   const [requestOpen, setRequestOpen] = useState(false);
+  const { user } = useAuth();
 
   useEffect(() => {
     document.title = "RentChain — Verified screening. Clear records.";
@@ -26,12 +28,17 @@ const LandingPage: React.FC = () => {
             between landlords and tenants — through verified information and structured records.
           </p>
           <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap", marginTop: spacing.sm }}>
-            <Button type="button" onClick={() => setRequestOpen(true)}>
-              Request access
+            <Button
+              type="button"
+              onClick={() => (user?.id ? navigate("/dashboard") : setRequestOpen(true))}
+            >
+              {user?.id ? "Go to dashboard" : "Request access"}
             </Button>
-            <Button type="button" variant="secondary" onClick={() => navigate("/login")}>
-              Sign in
-            </Button>
+            {!user?.id ? (
+              <Button type="button" variant="secondary" onClick={() => navigate("/login")}>
+                Sign in
+              </Button>
+            ) : null}
             <Button type="button" variant="ghost" onClick={() => navigate("/site/pricing")}>
               See pricing
             </Button>

--- a/rentchain-frontend/src/pages/marketing/LegalHelpPage.tsx
+++ b/rentchain-frontend/src/pages/marketing/LegalHelpPage.tsx
@@ -98,38 +98,38 @@ const LegalHelpPage: React.FC = () => {
                 <li style={{ display: "flex", justifyContent: "space-between", gap: spacing.sm }}>
                   <span>Late Rent Notice</span>
                   <span style={{ display: "flex", gap: spacing.xs }}>
-                    <a href={templateUrl("/templates/Late_Rent_Notice_Template.pdf")} download>PDF</a>
-                    <a href={templateUrl("/templates/Late_Rent_Notice_Template.docx")} download>DOCX</a>
+                    <a href={templateUrl("/templates/Late_Rent_Notice_Template.pdf")} download target="_blank" rel="noopener noreferrer">PDF</a>
+                    <a href={templateUrl("/templates/Late_Rent_Notice_Template.docx")} download target="_blank" rel="noopener noreferrer">DOCX</a>
                   </span>
                 </li>
                 <li style={{ display: "flex", justifyContent: "space-between", gap: spacing.sm }}>
                   <span>Notice of Entry</span>
                   <span style={{ display: "flex", gap: spacing.xs }}>
-                    <a href={templateUrl("/templates/Notice_of_Entry_Template.pdf")} download>PDF</a>
-                    <a href={templateUrl("/templates/Notice_of_Entry_Template.docx")} download>DOCX</a>
+                    <a href={templateUrl("/templates/Notice_of_Entry_Template.pdf")} download target="_blank" rel="noopener noreferrer">PDF</a>
+                    <a href={templateUrl("/templates/Notice_of_Entry_Template.docx")} download target="_blank" rel="noopener noreferrer">DOCX</a>
                   </span>
                 </li>
                 <li style={{ display: "flex", justifyContent: "space-between", gap: spacing.sm }}>
                   <span>Lease Event Log</span>
                   <span style={{ display: "flex", gap: spacing.xs }}>
-                    <a href={templateUrl("/templates/Lease_Event_Log_Template.pdf")} download>PDF</a>
-                    <a href={templateUrl("/templates/Lease_Event_Log_Template.docx")} download>DOCX</a>
-                    <a href={templateUrl("/templates/Lease_Event_Log_Template.csv")} download>CSV</a>
+                    <a href={templateUrl("/templates/Lease_Event_Log_Template.pdf")} download target="_blank" rel="noopener noreferrer">PDF</a>
+                    <a href={templateUrl("/templates/Lease_Event_Log_Template.docx")} download target="_blank" rel="noopener noreferrer">DOCX</a>
+                    <a href={templateUrl("/templates/Lease_Event_Log_Template.csv")} download target="_blank" rel="noopener noreferrer">CSV</a>
                   </span>
                 </li>
                 <li style={{ display: "flex", justifyContent: "space-between", gap: spacing.sm }}>
                   <span>Move-In / Move-Out Inspection Checklist</span>
                   <span style={{ display: "flex", gap: spacing.xs }}>
-                    <a href={templateUrl("/templates/Move_In_Out_Inspection_Checklist_Template.pdf")} download>PDF</a>
-                    <a href={templateUrl("/templates/Move_In_Out_Inspection_Checklist_Template.docx")} download>DOCX</a>
+                    <a href={templateUrl("/templates/Move_In_Out_Inspection_Checklist_Template.pdf")} download target="_blank" rel="noopener noreferrer">PDF</a>
+                    <a href={templateUrl("/templates/Move_In_Out_Inspection_Checklist_Template.docx")} download target="_blank" rel="noopener noreferrer">DOCX</a>
                   </span>
                 </li>
                 <li style={{ display: "flex", justifyContent: "space-between", gap: spacing.sm }}>
                   <span>Rent Ledger Summary Sheet</span>
                   <span style={{ display: "flex", gap: spacing.xs }}>
-                    <a href={templateUrl("/templates/Rent_Ledger_Summary_Template.pdf")} download>PDF</a>
-                    <a href={templateUrl("/templates/Rent_Ledger_Summary_Template.docx")} download>DOCX</a>
-                    <a href={templateUrl("/templates/Rent_Ledger_Summary_Template.csv")} download>CSV</a>
+                    <a href={templateUrl("/templates/Rent_Ledger_Summary_Template.pdf")} download target="_blank" rel="noopener noreferrer">PDF</a>
+                    <a href={templateUrl("/templates/Rent_Ledger_Summary_Template.docx")} download target="_blank" rel="noopener noreferrer">DOCX</a>
+                    <a href={templateUrl("/templates/Rent_Ledger_Summary_Template.csv")} download target="_blank" rel="noopener noreferrer">CSV</a>
                   </span>
                 </li>
               </ul>
@@ -144,15 +144,15 @@ const LegalHelpPage: React.FC = () => {
                 <li style={{ display: "flex", justifyContent: "space-between", gap: spacing.sm }}>
                   <span>Rental Application Checklist (Tenant)</span>
                   <span style={{ display: "flex", gap: spacing.xs }}>
-                    <a href={templateUrl("/templates/Rental_Application_Checklist_Tenant.pdf")} download>PDF</a>
-                    <a href={templateUrl("/templates/Rental_Application_Checklist_Tenant.docx")} download>DOCX</a>
+                    <a href={templateUrl("/templates/Rental_Application_Checklist_Tenant.pdf")} download target="_blank" rel="noopener noreferrer">PDF</a>
+                    <a href={templateUrl("/templates/Rental_Application_Checklist_Tenant.docx")} download target="_blank" rel="noopener noreferrer">DOCX</a>
                   </span>
                 </li>
                 <li style={{ display: "flex", justifyContent: "space-between", gap: spacing.sm }}>
                   <span>Dispute Documentation Guide</span>
                   <span style={{ display: "flex", gap: spacing.xs }}>
-                    <a href={templateUrl("/templates/Dispute_Documentation_Guide_Template.pdf")} download>PDF</a>
-                    <a href={templateUrl("/templates/Dispute_Documentation_Guide_Template.docx")} download>DOCX</a>
+                    <a href={templateUrl("/templates/Dispute_Documentation_Guide_Template.pdf")} download target="_blank" rel="noopener noreferrer">PDF</a>
+                    <a href={templateUrl("/templates/Dispute_Documentation_Guide_Template.docx")} download target="_blank" rel="noopener noreferrer">DOCX</a>
                   </span>
                 </li>
               </ul>

--- a/rentchain-frontend/src/pages/marketing/MarketingLayout.tsx
+++ b/rentchain-frontend/src/pages/marketing/MarketingLayout.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { colors, layout, radius, shadows, spacing, text, typography } from "../../styles/tokens";
+import { useAuth } from "../../context/useAuth";
 
 interface MarketingLayoutProps {
   children: React.ReactNode;
@@ -13,6 +14,8 @@ export const MarketingLayout: React.FC<MarketingLayoutProps> = ({ children }) =>
   const prevMenuOpen = useRef(false);
   const prevBodyOverflow = useRef<string | null>(null);
   const location = useLocation();
+  const { user } = useAuth();
+  const isAuthed = Boolean(user?.id);
 
   const onHover = (event: React.MouseEvent<HTMLElement>, active: boolean) => {
     event.currentTarget.style.color = active ? text.primary : text.muted;
@@ -220,16 +223,18 @@ export const MarketingLayout: React.FC<MarketingLayoutProps> = ({ children }) =>
                 FR
               </button>
             </div>
+            {!isAuthed ? (
+              <Link
+                to="/login"
+                style={{ color: text.muted, textDecoration: "none" }}
+                onMouseEnter={(e) => onHover(e, true)}
+                onMouseLeave={(e) => onHover(e, false)}
+              >
+                Log in
+              </Link>
+            ) : null}
             <Link
-              to="/login"
-              style={{ color: text.muted, textDecoration: "none" }}
-              onMouseEnter={(e) => onHover(e, true)}
-              onMouseLeave={(e) => onHover(e, false)}
-            >
-              Log in
-            </Link>
-            <Link
-              to="/site/pricing"
+              to={isAuthed ? "/dashboard" : "/site/pricing"}
               style={{
                 color: "#fff",
                 background: colors.accent,
@@ -240,7 +245,7 @@ export const MarketingLayout: React.FC<MarketingLayoutProps> = ({ children }) =>
                 boxShadow: shadows.sm,
               }}
             >
-              Request access
+              {isAuthed ? "Dashboard" : "Request access"}
             </Link>
           </div>
           {isMobile ? (
@@ -257,7 +262,7 @@ export const MarketingLayout: React.FC<MarketingLayoutProps> = ({ children }) =>
               }}
             >
               <Link
-                to="/site/pricing"
+                to={isAuthed ? "/dashboard" : "/site/pricing"}
                 style={{
                   color: "#fff",
                   background: colors.accent,
@@ -269,7 +274,7 @@ export const MarketingLayout: React.FC<MarketingLayoutProps> = ({ children }) =>
                   whiteSpace: "nowrap",
                 }}
               >
-                Request access
+                {isAuthed ? "Dashboard" : "Request access"}
               </Link>
               <button
                 type="button"
@@ -422,17 +427,19 @@ export const MarketingLayout: React.FC<MarketingLayoutProps> = ({ children }) =>
               </div>
             </div>
             <div style={{ display: "flex", flexWrap: "wrap", gap: spacing.sm, alignItems: "center" }}>
+              {!isAuthed ? (
+                <Link
+                  to="/login"
+                  style={{ color: text.muted, textDecoration: "none" }}
+                  onMouseEnter={(e) => onHover(e, true)}
+                  onMouseLeave={(e) => onHover(e, false)}
+                  onClick={() => setMenuOpen(false)}
+                >
+                  Log in
+                </Link>
+              ) : null}
               <Link
-                to="/login"
-                style={{ color: text.muted, textDecoration: "none" }}
-                onMouseEnter={(e) => onHover(e, true)}
-                onMouseLeave={(e) => onHover(e, false)}
-                onClick={() => setMenuOpen(false)}
-              >
-                Log in
-              </Link>
-              <Link
-                to="/site/pricing"
+                to={isAuthed ? "/dashboard" : "/site/pricing"}
                 style={{
                   color: "#fff",
                   background: colors.accent,
@@ -444,7 +451,7 @@ export const MarketingLayout: React.FC<MarketingLayoutProps> = ({ children }) =>
                 }}
                 onClick={() => setMenuOpen(false)}
               >
-                Request access
+                {isAuthed ? "Dashboard" : "Request access"}
               </Link>
             </div>
           </div>

--- a/rentchain-frontend/src/pages/marketing/PricingPage.tsx
+++ b/rentchain-frontend/src/pages/marketing/PricingPage.tsx
@@ -95,12 +95,20 @@ const PricingPage: React.FC = () => {
             There are no long-term contracts, and you can change plans as your needs evolve.
           </p>
           <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap", marginTop: spacing.sm }}>
-            <Button type="button" variant="secondary" onClick={() => setRequestOpen(true)}>
-              Request access
-            </Button>
-            <Button type="button" variant="ghost" onClick={() => (window.location.href = "/login")}>
-              Sign in
-            </Button>
+            {isAuthed ? (
+              <Button type="button" onClick={() => (window.location.href = "/dashboard")}>
+                Go to dashboard
+              </Button>
+            ) : (
+              <>
+                <Button type="button" variant="secondary" onClick={() => setRequestOpen(true)}>
+                  Request access
+                </Button>
+                <Button type="button" variant="ghost" onClick={() => (window.location.href = "/login")}>
+                  Sign in
+                </Button>
+              </>
+            )}
           </div>
         </div>
 

--- a/rentchain-frontend/vite.config.ts
+++ b/rentchain-frontend/vite.config.ts
@@ -24,11 +24,17 @@ export default defineConfig({
         ],
       },
       workbox: {
+        navigateFallbackDenylist: [/^\/templates\//, /^\/sample\//],
         runtimeCaching: [
           {
             urlPattern: /\/templates\/.*\.(pdf|docx|csv)(\?.*)?$/,
             handler: "NetworkOnly",
             options: { cacheName: "templates" },
+          },
+          {
+            urlPattern: /\/sample\/.*\.pdf(\?.*)?$/,
+            handler: "NetworkOnly",
+            options: { cacheName: "samples" },
           },
         ],
       },


### PR DESCRIPTION
What changed (mapped to requirements):

PDF sample static URL
Onboarding step now navigates directly to [screening_report_sample.pdf](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/P2/.vscode/extensions/openai.chatgpt-0.4.69-win32-x64/webview/#)
/pdf/sample route now redirects to the static PDF
SamplePdfModal “View full page” now opens the static PDF
Static asset safety
Workbox navigateFallbackDenylist for /templates/ and /sample/
Added runtime caching rule for [*.pdf](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/P2/.vscode/extensions/openai.chatgpt-0.4.69-win32-x64/webview/#) as NetworkOnly
Template downloads (mobile)
Templates page and marketing Legal Help downloads now use direct <a> links with download + target="_blank" rel="noopener noreferrer"
Properties summary contrast
KPI label/value colors updated to dark, high-contrast values
Auth-aware marketing CTAs
Marketing header + mobile menu show “Dashboard” when logged in, “Request access” + “Log in” when logged out
Landing hero now shows “Go to dashboard” for authed users, “Request access” + “Sign in” otherwise
Marketing pricing page hides Request access when authed and shows “Go to dashboard”