### PR TITLE
fix(mobile): restore scrolling; tighten properties table; unify application link modals (f95040d)

### DIFF
--- a/rentchain-frontend/src/components/layout/LandlordNav.css
+++ b/rentchain-frontend/src/components/layout/LandlordNav.css
@@ -97,6 +97,7 @@
   overflow-y: auto;
   display: grid;
   gap: 12px;
+  -webkit-overflow-scrolling: touch;
 }
 
 .rc-landlord-drawer-links {

--- a/rentchain-frontend/src/components/layout/WorkspaceDrawer.tsx
+++ b/rentchain-frontend/src/components/layout/WorkspaceDrawer.tsx
@@ -70,6 +70,7 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({ open, onClose,
           gap: spacing.md,
           zIndex: 3001,
           overflowY: "auto",
+          WebkitOverflowScrolling: "touch",
         }}
       >
         <div

--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
@@ -761,7 +761,7 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
                 className="rc-units-table"
                 style={{
                   width: "100%",
-                  minWidth: 720,
+                  minWidth: 560,
                   borderCollapse: "collapse",
                   fontSize: "0.9rem",
                   color: "#0f172a",
@@ -769,13 +769,13 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
               >
             <thead>
               <tr style={{ background: "rgba(255,255,255,0.03)", color: "#9ca3af" }}>
-                <th style={{ textAlign: "left", padding: "10px 12px", whiteSpace: "nowrap" }}>Unit #</th>
-                <th style={{ textAlign: "right", padding: "10px 12px", whiteSpace: "nowrap" }}>Rent</th>
-                <th style={{ textAlign: "center", padding: "10px 12px", whiteSpace: "nowrap" }}>Beds</th>
-                <th style={{ textAlign: "center", padding: "10px 12px", whiteSpace: "nowrap" }}>Baths</th>
-                <th style={{ textAlign: "center", padding: "10px 12px", whiteSpace: "nowrap" }}>Sqft</th>
-                <th style={{ textAlign: "left", padding: "10px 12px", whiteSpace: "nowrap" }}>Status</th>
-                <th style={{ textAlign: "left", padding: "10px 12px" }}>Actions</th>
+                <th className="rc-units-col-unit" style={{ textAlign: "left", padding: "10px 12px", whiteSpace: "nowrap" }}>Unit</th>
+                <th className="rc-units-col-rent" style={{ textAlign: "right", padding: "10px 12px", whiteSpace: "nowrap" }}>Rent</th>
+                <th className="rc-units-col-beds" style={{ textAlign: "center", padding: "10px 12px", whiteSpace: "nowrap" }}>Beds</th>
+                <th className="rc-units-col-baths" style={{ textAlign: "center", padding: "10px 12px", whiteSpace: "nowrap" }}>Baths</th>
+                <th className="rc-units-col-sqft" style={{ textAlign: "center", padding: "10px 12px", whiteSpace: "nowrap" }}>Sqft</th>
+                <th className="rc-units-col-status" style={{ textAlign: "left", padding: "10px 12px", whiteSpace: "nowrap" }}>Status</th>
+                <th className="rc-units-col-actions" style={{ textAlign: "left", padding: "10px 12px" }}>Actions</th>
               </tr>
             </thead>
             <tbody>
@@ -853,28 +853,28 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
                         color: "#0f172a",
                       }}
                     >
-                      <td style={{ padding: "10px 12px", whiteSpace: "nowrap" }}>{unitNum}</td>
-                      <td style={{ padding: "10px 12px", textAlign: "right", whiteSpace: "nowrap" }}>
+                      <td className="rc-units-col-unit" style={{ padding: "10px 12px", whiteSpace: "nowrap" }}>{unitNum}</td>
+                      <td className="rc-units-col-rent" style={{ padding: "10px 12px", textAlign: "right", whiteSpace: "nowrap" }}>
                         <span className={rentVal !== null && rentVal !== undefined ? "" : "rc-unit-placeholder"}>
                           {rentDisplay}
                         </span>
                       </td>
-                      <td style={{ padding: "10px 12px", textAlign: "center", whiteSpace: "nowrap" }}>
+                      <td className="rc-units-col-beds" style={{ padding: "10px 12px", textAlign: "center", whiteSpace: "nowrap" }}>
                         <span className={bedsVal !== null && bedsVal !== undefined ? "" : "rc-unit-placeholder"}>
                           {bedsDisplay}
                         </span>
                       </td>
-                      <td style={{ padding: "10px 12px", textAlign: "center", whiteSpace: "nowrap" }}>
+                      <td className="rc-units-col-baths" style={{ padding: "10px 12px", textAlign: "center", whiteSpace: "nowrap" }}>
                         <span className={bathsVal !== null && bathsVal !== undefined ? "" : "rc-unit-placeholder"}>
                           {bathsDisplay}
                         </span>
                       </td>
-                      <td style={{ padding: "10px 12px", textAlign: "center", whiteSpace: "nowrap" }}>
+                      <td className="rc-units-col-sqft" style={{ padding: "10px 12px", textAlign: "center", whiteSpace: "nowrap" }}>
                         <span className={sqftVal !== null && sqftVal !== undefined ? "" : "rc-unit-placeholder"}>
                           {sqftDisplay}
                         </span>
                       </td>
-                      <td style={{ padding: "10px 12px" }}>
+                      <td className="rc-units-col-status" style={{ padding: "10px 12px" }}>
                         <span
                           style={{
                             display: "inline-flex",
@@ -901,7 +901,7 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
                           {isLeased ? "Occupied" : "Vacant"}
                         </span>
                       </td>
-                      <td style={{ padding: "10px 12px" }}>
+                      <td className="rc-units-col-actions" style={{ padding: "10px 12px" }}>
                         <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
                           <button
                             type="button"

--- a/rentchain-frontend/src/components/properties/SendApplicationModal.tsx
+++ b/rentchain-frontend/src/components/properties/SendApplicationModal.tsx
@@ -11,6 +11,9 @@ type Props = {
   properties?: Array<{ id: string; name: string }>;
   onPropertyChange?: (nextId: string) => void;
   units?: Array<{ id: string; name: string }>;
+  unitsLoading?: boolean;
+  unitsError?: string | null;
+  onUnitsRetry?: () => void;
   initialUnitId?: string | null;
   onUnitChange?: (nextId: string | null) => void;
   unit?: any | null;
@@ -24,6 +27,9 @@ export function SendApplicationModal({
   properties,
   onPropertyChange,
   units,
+  unitsLoading,
+  unitsError,
+  onUnitsRetry,
   initialUnitId,
   onUnitChange,
   unit,
@@ -253,14 +259,34 @@ export function SendApplicationModal({
                     background: "#fff",
                   }}
                 >
-                  <option value="">Whole property / unspecified</option>
+                  <option value="">{unitsLoading ? "Loading units..." : "Whole property / unspecified"}</option>
                   {(units || []).map((option) => (
                     <option key={option.id} value={option.id}>
                       {option.name}
                     </option>
                   ))}
                 </select>
-                {!units || units.length === 0 ? (
+                {unitsError ? (
+                  <span style={{ fontSize: "0.8rem", color: "#b91c1c", display: "flex", gap: 8, alignItems: "center" }}>
+                    {unitsError}
+                    {onUnitsRetry ? (
+                      <button
+                        type="button"
+                        onClick={onUnitsRetry}
+                        style={{
+                          border: "none",
+                          background: "transparent",
+                          color: "#2563eb",
+                          fontWeight: 600,
+                          cursor: "pointer",
+                          padding: 0,
+                        }}
+                      >
+                        Retry
+                      </button>
+                    ) : null}
+                  </span>
+                ) : !unitsLoading && (!units || units.length === 0) ? (
                   <span style={{ fontSize: "0.8rem", color: "#6b7280" }}>
                     No units found for this property.
                   </span>

--- a/rentchain-frontend/src/hooks/useUnitsForProperty.ts
+++ b/rentchain-frontend/src/hooks/useUnitsForProperty.ts
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useState } from "react";
+import { fetchUnitsForProperty } from "../api/unitsApi";
+
+export type UnitOption = { id: string; name: string };
+
+export function useUnitsForProperty(propertyId?: string | null, enabled = true) {
+  const [units, setUnits] = useState<UnitOption[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!propertyId || !enabled) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetchUnitsForProperty(propertyId);
+      const mapped = (res || [])
+        .map((u: any) => ({
+          id: String(u.id || u.unitId || u.uid || ""),
+          name: String(u.unitNumber || u.label || u.name || u.unit || "Unit"),
+        }))
+        .filter((u: UnitOption) => Boolean(u.id));
+      setUnits(mapped);
+    } catch (err: any) {
+      setUnits([]);
+      setError("Unable to load units.");
+    } finally {
+      setLoading(false);
+    }
+  }, [enabled, propertyId]);
+
+  useEffect(() => {
+    if (!enabled || !propertyId) {
+      setUnits([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+    void load();
+  }, [enabled, load, propertyId]);
+
+  return { units, loading, error, refetch: load };
+}

--- a/rentchain-frontend/src/pages/ApplicationsPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.tsx
@@ -31,6 +31,7 @@ import { track } from "@/lib/analytics";
 import { useAuth } from "../context/useAuth";
 import { ResponsiveMasterDetail } from "@/components/layout/ResponsiveMasterDetail";
 import { useOnboardingState } from "../hooks/useOnboardingState";
+import { useUnitsForProperty } from "../hooks/useUnitsForProperty";
 import { SendApplicationModal } from "../components/properties/SendApplicationModal";
 import { unitsForProperty } from "../lib/propertyCounts";
 import { getApplicationPrereqState } from "../lib/applicationPrereqs";
@@ -182,29 +183,12 @@ const ApplicationsPage: React.FC = () => {
   const propertiesCount = propertyRecords.length;
   const unitsCount = propertyRecords.reduce((sum, p) => sum + unitsForProperty(p), 0);
 
-  const modalUnits = useMemo(() => {
-    if (!modalPropertyId) return [];
-    const property = propertyRecords.find(
-      (p) => String(p.id || p.propertyId || p.uid || "") === modalPropertyId
-    );
-    const unitsRaw =
-      (property as any)?.units ||
-      (property as any)?.unitList ||
-      (property as any)?.unitDetails ||
-      [];
-    if (!Array.isArray(unitsRaw)) return [];
-    return unitsRaw
-      .map((unit: any) => ({
-        id: String(unit?.id || unit?.unitId || unit?.uid || ""),
-        name:
-          unit?.unitNumber ||
-          unit?.label ||
-          unit?.name ||
-          unit?.unit ||
-          "Unit",
-      }))
-      .filter((u) => u.id);
-  }, [modalPropertyId, propertyRecords]);
+  const {
+    units: modalUnits,
+    loading: modalUnitsLoading,
+    error: modalUnitsError,
+    refetch: refetchModalUnits,
+  } = useUnitsForProperty(modalPropertyId, sendAppOpen);
 
   const screeningOptions = [
     { value: "basic", label: "Basic", priceLabel: "$19.99" },
@@ -1631,6 +1615,9 @@ const ApplicationsPage: React.FC = () => {
         propertyName={modalPropertyName}
         properties={properties}
         units={modalUnits}
+        unitsLoading={modalUnitsLoading}
+        unitsError={modalUnitsError}
+        onUnitsRetry={refetchModalUnits}
         initialUnitId={modalUnitId}
         onPropertyChange={(nextId) => {
           setModalPropertyId(nextId);

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -23,6 +23,7 @@ import { CreatePropertyFirstModal } from "../components/properties/CreatePropert
 import { buildCreatePropertyUrl, buildReturnTo } from "../lib/propertyGate";
 import { SendScreeningInviteModal } from "../components/screening/SendScreeningInviteModal";
 import { SendApplicationModal } from "../components/properties/SendApplicationModal";
+import { useUnitsForProperty } from "../hooks/useUnitsForProperty";
 
 const StarterOnboardingPanel = React.lazy(
   () => import("../components/dashboard/StarterOnboardingPanel")
@@ -332,29 +333,12 @@ const DashboardPage: React.FC = () => {
     [properties]
   );
 
-  const modalUnits = React.useMemo(() => {
-    if (!modalPropertyId) return [];
-    const property = properties.find(
-      (p) => String(p?.id || p?.propertyId || p?.uid || "") === modalPropertyId
-    );
-    const unitsRaw =
-      (property as any)?.units ||
-      (property as any)?.unitList ||
-      (property as any)?.unitDetails ||
-      [];
-    if (!Array.isArray(unitsRaw)) return [];
-    return unitsRaw
-      .map((unit: any) => ({
-        id: String(unit?.id || unit?.unitId || unit?.uid || ""),
-        name:
-          unit?.unitNumber ||
-          unit?.label ||
-          unit?.name ||
-          unit?.unit ||
-          "Unit",
-      }))
-      .filter((u) => u.id);
-  }, [modalPropertyId, properties]);
+  const {
+    units: modalUnits,
+    loading: modalUnitsLoading,
+    error: modalUnitsError,
+    refetch: refetchModalUnits,
+  } = useUnitsForProperty(modalPropertyId, sendApplicationOpen);
 
   return (
     <MacShell title="RentChain · Dashboard" showTopNav={false}>
@@ -644,6 +628,9 @@ const DashboardPage: React.FC = () => {
         properties={propertyOptions}
         propertyId={modalPropertyId}
         units={modalUnits}
+        unitsLoading={modalUnitsLoading}
+        unitsError={modalUnitsError}
+        onUnitsRetry={refetchModalUnits}
         initialUnitId={modalUnitId}
         onPropertyChange={(nextId) => {
           setModalPropertyId(nextId);

--- a/rentchain-frontend/src/styles/propertiesMobile.css
+++ b/rentchain-frontend/src/styles/propertiesMobile.css
@@ -225,6 +225,11 @@
     color: #0f172a;
   }
 
+  .rc-units-col-sqft,
+  .rc-units-col-actions {
+    display: none;
+  }
+
   .rc-unit-placeholder {
     color: #94a3b8;
   }


### PR DESCRIPTION
Shared unit loader: added useUnitsForProperty hook (uses /api/units like SendScreeningInviteModal).
Dashboard + Applications: both SendApplicationModal instances now use the hook, pass unitsLoading/unitsError/onUnitsRetry, so “No units found” won’t show while loading or when units exist.
SendApplicationModal: handles loading/error states and retry for units.
Mobile drawer scroll: added -webkit-overflow-scrolling: touch for both WorkspaceDrawer and LandlordNav drawer scroll.
Properties units table: reduced min width and added column class names; hid Sqft + Actions columns on tablet widths via [propertiesMobile.css](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/P2/.vscode/extensions/openai.chatgpt-0.4.69-win32-x64/webview/#) to reduce horizontal scroll.