### PR TITLE
feat(admin): access request approval workflow

### DIFF
--- a/rentchain-frontend/src/api/adminLeadsApi.ts
+++ b/rentchain-frontend/src/api/adminLeadsApi.ts
@@ -8,14 +8,14 @@ export type LandlordLead = {
   note?: string | null;
   status?: string | null;
   createdAt?: number | null;
-  invitedAt?: number | null;
-  invitedBy?: string | null;
+  approvedAt?: number | null;
+  approvedBy?: string | null;
   rejectedAt?: number | null;
   rejectedBy?: string | null;
 };
 
 export async function fetchLandlordLeads(
-  status?: "new" | "invited" | "rejected",
+  status?: "pending" | "approved" | "rejected",
   limit: number = 100
 ): Promise<LandlordLead[]> {
   const qs = new URLSearchParams();

--- a/rentchain-frontend/src/components/auth/RequireAuth.tsx
+++ b/rentchain-frontend/src/components/auth/RequireAuth.tsx
@@ -85,5 +85,57 @@ export const RequireAuth: React.FC<RequireAuthProps> = ({ children }) => {
     return <Navigate to={`/login?${params.toString()}`} replace />;
   }
 
+  if (String(user.role || "").toLowerCase() === "landlord" && user.approved === false) {
+    return (
+      <div
+        style={{
+          minHeight: "100vh",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          fontFamily:
+            "system-ui, -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'SF Pro Display', sans-serif",
+          fontSize: "0.95rem",
+          color: "#0f172a",
+          background:
+            "radial-gradient(circle at top left, rgba(37,99,235,0.08) 0, rgba(14,165,233,0.06) 45%, rgba(255,255,255,0.9) 100%)",
+          padding: "24px",
+        }}
+      >
+        <div
+          style={{
+            width: "min(420px, 90vw)",
+            background: "rgba(255,255,255,0.9)",
+            border: "1px solid rgba(15,23,42,0.08)",
+            borderRadius: 16,
+            padding: "20px 22px",
+            boxShadow: "0 12px 30px rgba(15,23,42,0.12)",
+          }}
+        >
+          <div style={{ fontWeight: 700, marginBottom: 8 }}>
+            Your RentChain landlord access is pending approval.
+          </div>
+          <div style={{ color: "#475569", marginBottom: 16 }}>
+            We’ll notify you once your request is approved.
+          </div>
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            style={{
+              borderRadius: 10,
+              border: "1px solid rgba(15,23,42,0.12)",
+              padding: "10px 14px",
+              fontWeight: 600,
+              cursor: "pointer",
+              background: "#fff",
+            }}
+          >
+            Refresh
+          </button>
+        </div>
+      </div>
+    );
+  }
+
   return <>{children}</>;
 };

--- a/rentchain-frontend/src/context/AuthContext.tsx
+++ b/rentchain-frontend/src/context/AuthContext.tsx
@@ -37,6 +37,7 @@ export interface AuthUser {
   plan?: string;
   actorRole?: string | null;
   actorLandlordId?: string | null;
+  approved?: boolean;
 }
 
 export interface AuthContextValue {

--- a/rentchain-frontend/src/pages/admin/AdminLeadsPage.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminLeadsPage.tsx
@@ -24,10 +24,10 @@ const maskEmail = (email?: string | null) => {
 };
 
 const statusLabel = (status?: string | null) => {
-  const s = String(status || "new").toLowerCase();
-  if (s === "invited") return "Invited";
+  const s = String(status || "pending").toLowerCase();
+  if (s === "approved" || s === "invited") return "Approved";
   if (s === "rejected") return "Rejected";
-  return "New";
+  return "Pending";
 };
 
 const AdminLeadsPage: React.FC = () => {
@@ -37,7 +37,7 @@ const AdminLeadsPage: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [busyId, setBusyId] = useState<string | null>(null);
   const { showToast } = useToast();
-  const [statusFilter, setStatusFilter] = useState<"new" | "invited" | "rejected">("new");
+  const [statusFilter, setStatusFilter] = useState<"pending" | "approved" | "rejected">("pending");
   const [sortOrder, setSortOrder] = useState<"newest" | "oldest">("newest");
 
   const isAdmin = String(user?.role || "").toLowerCase() === "admin";
@@ -141,14 +141,14 @@ const AdminLeadsPage: React.FC = () => {
 
       <Card style={{ padding: spacing.md }}>
         <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap", marginBottom: spacing.sm }}>
-          {(["new", "invited", "rejected"] as const).map((status) => (
+          {(["pending", "approved", "rejected"] as const).map((status) => (
             <Button
               key={status}
               type="button"
               variant={statusFilter === status ? "primary" : "ghost"}
               onClick={() => setStatusFilter(status)}
             >
-              {status === "new" ? "New" : status === "invited" ? "Invited" : "Rejected"}
+              {status === "pending" ? "Pending" : status === "approved" ? "Approved" : "Rejected"}
             </Button>
           ))}
         </div>
@@ -156,19 +156,19 @@ const AdminLeadsPage: React.FC = () => {
           <div style={{ color: text.muted }}>Loading…</div>
         ) : sorted.length === 0 ? (
           <div style={{ color: text.muted }}>
-            {statusFilter === "new" ? "No access requests yet." : `No ${statusFilter} requests.`}
+            {statusFilter === "pending" ? "No access requests yet." : `No ${statusFilter} requests.`}
           </div>
         ) : (
           <div style={{ display: "grid", gap: spacing.sm }}>
             {sorted.map((lead) => {
               const id = lead.id;
-              const status = String(lead.status || "new").toLowerCase();
+              const status = String(lead.status || "pending").toLowerCase();
               const isBusy = busyId === id;
               const isBlocked = busyId !== null;
-              const isNew = status === "new";
+              const isNew = status === "pending" || status === "new";
               const highlight = new URLSearchParams(location.search).get("leadId") === id;
               const badgeStyle: React.CSSProperties =
-                status === "invited"
+                status === "approved" || status === "invited"
                   ? { background: "#dcfce7", color: "#166534" }
                   : status === "rejected"
                   ? { background: "#f1f5f9", color: "#475569" }


### PR DESCRIPTION
Use landlordLeads as the single source of truth for Request Access with pending/approved/rejected status
Admin approve sets lead → approved, writes approvedAt/approvedBy, sends approval email (invite link if user doesn’t exist yet)
Auth now resolves approval from users + landlordLeads and exposes user.approved
Frontend blocks landlord dashboard routes when approval is pending and shows a friendly “pending approval” screen with Refresh
