### PR TITLE
feat/screening-transunion-polish

### DIFF
--- a/rentchain-frontend/src/api/rentalApplicationsApi.ts
+++ b/rentchain-frontend/src/api/rentalApplicationsApi.ts
@@ -51,6 +51,18 @@ export type ScreeningResult = {
   reportText?: string | null;
 };
 
+export type ScreeningReceipt = {
+  status: "paid" | "completed" | "pending" | "failed";
+  provider?: string | null;
+  inquiryType?: string | null;
+  referenceId?: string | null;
+  consentVersion?: string | null;
+  consentTimestamp?: number | string | null;
+  generatedAt?: number | string | null;
+  reportUrl?: string | null;
+  pdfUrl?: string | null;
+};
+
 export type ScreeningOrder = {
   id: string;
   landlordId?: string | null;
@@ -385,6 +397,13 @@ export async function fetchScreeningResult(
 ): Promise<{ ok: boolean; result?: ScreeningResult; error?: string }> {
   const res: any = await apiFetch(`/rental-applications/${encodeURIComponent(id)}/screening/result`);
   return res as { ok: boolean; result?: ScreeningResult; error?: string };
+}
+
+export async function fetchScreeningReceipt(
+  id: string
+): Promise<{ ok: boolean; receipt?: ScreeningReceipt; error?: string }> {
+  const res: any = await apiFetch(`/rental-applications/${encodeURIComponent(id)}/screening/receipt`);
+  return res as { ok: boolean; receipt?: ScreeningReceipt; error?: string };
 }
 
 export async function fetchScreeningOrder(

--- a/rentchain-frontend/src/components/screening/SendScreeningInviteModal.tsx
+++ b/rentchain-frontend/src/components/screening/SendScreeningInviteModal.tsx
@@ -202,6 +202,27 @@ export function SendScreeningInviteModal({
             ×
           </button>
         </div>
+        <div
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 8,
+            padding: "4px 10px",
+            borderRadius: 999,
+            background: "rgba(15, 118, 110, 0.08)",
+            color: "#0f766e",
+            fontSize: 12,
+            fontWeight: 600,
+            width: "fit-content",
+          }}
+        >
+          Powered by TransUnion
+          <span style={{ fontWeight: 400, color: text.subtle }}>Soft inquiry (no score impact)</span>
+        </div>
+        <div style={{ fontSize: 12, color: text.subtle }}>
+          Tenant authorizes screening and receives the consent flow. You receive a verified screening report and
+          audit-ready record.
+        </div>
 
         <label style={{ display: "grid", gap: 6, fontSize: 13, color: text.muted }}>
           Tenant email


### PR DESCRIPTION
Added receipt fetching + UI wiring in Applications screening panel. Added TransUnion trust badge + microcopy in both Applications screening panel and Send Screening Invite modal. Added receipt panel with status/provider/inquiry/consent/timestamps + View/Download/Copy actions. Added “Calculating total…” and “Opening secure checkout…” states. Added error mapping for consent_required and stripe_not_configured. Backend already has the new receipt endpoint and referenceId/inquiryType fields.