### PR TITLE
feat(growth): landlord referral loop with tracked invites and priority approval

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -27,6 +27,7 @@ import tenantHistoryShareRoutes, {
 import propertiesRoutes from "./routes/propertiesRoutes";
 import accountRoutes from "./routes/accountRoutes";
 import onboardingRoutes from "./routes/onboardingRoutes";
+import referralsRoutes from "./routes/referralsRoutes";
 import billingRoutes from "./routes/billingRoutes";
 import tenantSignalsRoutes from "./routes/tenantSignalsRoutes";
 import reportingRoutes from "./routes/reportingRoutes";
@@ -183,6 +184,7 @@ app.use("/api", routeSource("unitsRoutes.ts"), unitsRoutes);
 app.use("/api/ledger", ledgerRoutes);
 app.use("/api/dashboard", routeSource("dashboardRoutes.ts"), dashboardRoutes);
 app.use("/api/application-links", routeSource("landlordApplicationLinksRoutes.ts"), landlordApplicationLinksRoutes);
+app.use("/api", routeSource("referralsRoutes.ts"), referralsRoutes);
 app.use(
   "/api/landlord/application-links",
   routeSource("landlordApplicationLinksRoutes.ts"),

--- a/rentchain-api/src/app.ts
+++ b/rentchain-api/src/app.ts
@@ -74,6 +74,7 @@ import adminRoutes from "./routes/adminRoutes";
 import adminScreeningResultsRoutes from "./routes/adminScreeningResultsRoutes";
 import screeningReportRoutes from "./routes/screeningReportRoutes";
 import onboardingRoutes from "./routes/onboardingRoutes";
+import referralsRoutes from "./routes/referralsRoutes";
 
 const app: Application = express();
 
@@ -180,6 +181,7 @@ app.use("/api", compatRoutes);
 app.use("/api/ledger", ledgerRoutes);
 app.use("/api/dashboard", routeSource("dashboardRoutes.ts"), dashboardRoutes);
 app.use("/api/application-links", routeSource("landlordApplicationLinksRoutes.ts"), landlordApplicationLinksRoutes);
+app.use("/api", routeSource("referralsRoutes.ts"), referralsRoutes);
 app.use(
   "/api/landlord/application-links",
   routeSource("landlordApplicationLinksRoutes.ts"),

--- a/rentchain-api/src/middleware/rateLimit.ts
+++ b/rentchain-api/src/middleware/rateLimit.ts
@@ -89,3 +89,9 @@ export const rateLimitTenantInvitesUser = createLimiter({
   max: 30,
   keyGenerator: keyByUser,
 });
+
+export const rateLimitReferralsUser = createLimiter({
+  windowMs: 24 * 60 * 60 * 1000,
+  max: 10,
+  keyGenerator: keyByUser,
+});

--- a/rentchain-api/src/routes/referralsRoutes.ts
+++ b/rentchain-api/src/routes/referralsRoutes.ts
@@ -1,0 +1,172 @@
+import { Router } from "express";
+import crypto from "crypto";
+import sgMail from "@sendgrid/mail";
+import { db } from "../config/firebase";
+import { requireAuth } from "../middleware/requireAuth";
+import { rateLimitReferralsUser } from "../middleware/rateLimit";
+
+const router = Router();
+
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const ACTIVE_REFERRAL_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+function normEmail(email: string) {
+  return String(email || "").trim().toLowerCase();
+}
+
+function resolveFrontendBase(): string {
+  const fallback =
+    process.env.NODE_ENV === "production"
+      ? "https://www.rentchain.ai"
+      : "http://localhost:5173";
+  return String(process.env.FRONTEND_URL || fallback).trim().replace(/\/$/, "");
+}
+
+function getSendgridConfig() {
+  const apiKey = process.env.SENDGRID_API_KEY;
+  const from =
+    process.env.SENDGRID_FROM_EMAIL || process.env.SENDGRID_FROM || process.env.FROM_EMAIL;
+  return { apiKey, from };
+}
+
+async function sendEmail(message: sgMail.MailDataRequired) {
+  const { apiKey } = getSendgridConfig();
+  if (!apiKey) throw new Error("SENDGRID_API_KEY missing");
+  sgMail.setApiKey(apiKey as string);
+  await sgMail.send({
+    ...message,
+    trackingSettings: {
+      clickTracking: { enable: false, enableText: false },
+      openTracking: { enable: false },
+    },
+  });
+}
+
+async function createReferralCode() {
+  for (let i = 0; i < 5; i += 1) {
+    const code = `RCREF-${crypto.randomBytes(4).toString("hex").toUpperCase()}`;
+    const snap = await db
+      .collection("referrals")
+      .where("referralCode", "==", code)
+      .limit(1)
+      .get();
+    if (snap.empty) return code;
+  }
+  throw new Error("referral_code_generation_failed");
+}
+
+router.get("/referrals", requireAuth, async (req: any, res) => {
+  res.setHeader("x-route-source", "referralsRoutes.ts");
+  const landlordId = String(req.user?.landlordId || req.user?.id || "");
+  if (!landlordId) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+
+  const snap = await db
+    .collection("referrals")
+    .where("referrerLandlordId", "==", landlordId)
+    .orderBy("createdAt", "desc")
+    .limit(200)
+    .get();
+
+  const referrals = snap.docs.map((doc) => ({ id: doc.id, ...(doc.data() as any) }));
+  return res.json({ ok: true, referrals });
+});
+
+router.post("/referrals", requireAuth, rateLimitReferralsUser, async (req: any, res) => {
+  res.setHeader("x-route-source", "referralsRoutes.ts");
+
+  const role = String(req.user?.role || "").toLowerCase();
+  const approved = req.user?.approved !== false;
+  if (role !== "landlord" || !approved) {
+    return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+  }
+
+  const refereeEmail = normEmail(req.body?.refereeEmail || "");
+  const refereeName = String(req.body?.refereeName || "").trim().slice(0, 120) || null;
+  const note = String(req.body?.note || "").trim().slice(0, 500) || null;
+  if (!refereeEmail || !emailRegex.test(refereeEmail)) {
+    return res.status(400).json({ ok: false, error: "invalid_email" });
+  }
+
+  const landlordId = String(req.user?.landlordId || req.user?.id || "");
+  const now = Date.now();
+  const existingSnap = await db
+    .collection("referrals")
+    .where("refereeEmail", "==", refereeEmail)
+    .where("createdAt", ">=", now - ACTIVE_REFERRAL_WINDOW_MS)
+    .limit(1)
+    .get();
+  if (!existingSnap.empty) {
+    const existingDoc = existingSnap.docs[0];
+    const data = existingDoc.data() as any;
+    if (String(data.status || "").toLowerCase() !== "expired") {
+      return res.json({
+        ok: true,
+        referral: {
+          id: existingDoc.id,
+          referralCode: data.referralCode,
+          status: data.status,
+        },
+        deduped: true,
+        emailed: false,
+      });
+    }
+  }
+
+  const referralCode = await createReferralCode();
+  const referrerEmail = normEmail(req.user?.email || "");
+  const referrerName = String(req.user?.name || req.user?.displayName || "").trim() || null;
+
+  const referralRef = db.collection("referrals").doc();
+  await referralRef.set({
+    referrerLandlordId: landlordId,
+    referrerEmail: referrerEmail || null,
+    referrerName,
+    refereeEmail,
+    refereeName,
+    note,
+    status: "sent",
+    referralCode,
+    createdAt: now,
+    updatedAt: now,
+    acceptedAt: null,
+    approvedAt: null,
+    lastEmailSentAt: null,
+    metadata: {
+      userAgent: req.get("user-agent") || null,
+    },
+  });
+
+  const link = `${resolveFrontendBase()}/site/request-access?ref=${encodeURIComponent(referralCode)}`;
+  const { apiKey, from } = getSendgridConfig();
+  let emailed = false;
+  if (apiKey && from) {
+    try {
+      await sendEmail({
+        to: refereeEmail,
+        from: from as string,
+        subject: "You've been invited to RentChain",
+        text:
+          `${referrerName || "A RentChain landlord"} invited you to RentChain.\n\n` +
+          `Request access here:\n${link}\n\n` +
+          "Verified screening, clear records, trusted rental relationships.",
+      });
+      emailed = true;
+      await referralRef.set({ lastEmailSentAt: Date.now() }, { merge: true });
+    } catch (err: any) {
+      console.error("[referrals] invite email failed", err?.message || err);
+    }
+  }
+
+  return res.json({
+    ok: true,
+    referral: {
+      id: referralRef.id,
+      referralCode,
+      status: "sent",
+      link,
+    },
+    emailed,
+  });
+});
+
+export default router;

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -16,6 +16,7 @@ import TenantLoginPageV2 from "./pages/tenant/TenantLoginPage.v2";
 import LandingPage from "./pages/marketing/LandingPage";
 import AboutPage from "./pages/marketing/AboutPage";
 import MarketingPricingPage from "./pages/marketing/PricingPage";
+import RequestAccessPage from "./pages/marketing/RequestAccessPage";
 import InvitePage from "./pages/InvitePage";
 import LegalHelpPage from "./pages/marketing/LegalHelpPage";
 import HelpIndexPage from "./pages/help/HelpIndexPage";
@@ -64,6 +65,7 @@ import MaintenanceRequestsPage from "./pages/MaintenanceRequestsPage";
 import PdfSamplePage from "./pages/PdfSamplePage";
 import LeaseLedgerPage from "./pages/LeaseLedgerPage";
 import ApplicationReviewSummaryPage from "./pages/ApplicationReviewSummaryPage";
+import ReferralsPage from "./pages/ReferralsPage";
 
 const TENANT_PORTAL_ENABLED = import.meta.env.VITE_TENANT_PORTAL_ENABLED === "true";
 
@@ -198,6 +200,7 @@ function App() {
         <Route path="/2fa" element={<TwoFactorPage />} />
         <Route path="/pricing" element={<PricingGate />} />
         <Route path="/site/pricing" element={<MarketingPricingPage />} />
+        <Route path="/site/request-access" element={<RequestAccessPage />} />
         <Route path="/about" element={<AboutPage />} />
         <Route path="/site/about" element={<AboutPage />} />
         <Route path="/legal" element={<LegalHelpPage />} />
@@ -297,6 +300,16 @@ function App() {
             <RequireAuth>
               <LandlordNav>
                 <ApplicationReviewSummaryPage />
+              </LandlordNav>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/referrals"
+          element={
+            <RequireAuth>
+              <LandlordNav>
+                <ReferralsPage />
               </LandlordNav>
             </RequireAuth>
           }

--- a/rentchain-frontend/src/api/adminLeadsApi.ts
+++ b/rentchain-frontend/src/api/adminLeadsApi.ts
@@ -12,6 +12,10 @@ export type LandlordLead = {
   approvedBy?: string | null;
   rejectedAt?: number | null;
   rejectedBy?: string | null;
+  referralCode?: string | null;
+  referrerLandlordId?: string | null;
+  referralStatus?: string | null;
+  priority?: boolean;
 };
 
 export async function fetchLandlordLeads(

--- a/rentchain-frontend/src/api/public.ts
+++ b/rentchain-frontend/src/api/public.ts
@@ -17,6 +17,7 @@ export async function requestLandlordInquiry(payload: {
   firstName: string;
   portfolioSize: string;
   note?: string;
+  referralCode?: string;
 }) {
   const url = `${window.location.origin}/api/public/landlord-inquiry`;
   const res = await fetch(url, {

--- a/rentchain-frontend/src/api/referralsApi.ts
+++ b/rentchain-frontend/src/api/referralsApi.ts
@@ -1,0 +1,29 @@
+import { apiFetch } from "../lib/apiClient";
+
+export type ReferralRecord = {
+  id: string;
+  refereeEmail: string;
+  refereeName?: string | null;
+  status: "sent" | "accepted" | "approved" | "expired";
+  referralCode: string;
+  createdAt: number;
+  acceptedAt?: number | null;
+  approvedAt?: number | null;
+};
+
+export async function listReferrals(): Promise<ReferralRecord[]> {
+  const res = await apiFetch("/referrals", { method: "GET" });
+  return Array.isArray((res as any)?.referrals) ? (res as any).referrals : [];
+}
+
+export async function createReferral(payload: {
+  refereeEmail: string;
+  refereeName?: string;
+  note?: string;
+}): Promise<{ ok: true; referral: ReferralRecord & { link?: string }; emailed?: boolean; deduped?: boolean }> {
+  return apiFetch("/referrals", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  }) as any;
+}

--- a/rentchain-frontend/src/components/layout/navConfig.ts
+++ b/rentchain-frontend/src/components/layout/navConfig.ts
@@ -76,6 +76,12 @@ export const NAV_ITEMS: NavItem[] = [
     showInDrawer: true,
   },
   {
+    id: "referrals",
+    label: "Referrals",
+    to: "/referrals",
+    showInDrawer: true,
+  },
+  {
     id: "maintenance",
     label: "Maintenance",
     to: "/maintenance",

--- a/rentchain-frontend/src/components/marketing/RequestAccessModal.tsx
+++ b/rentchain-frontend/src/components/marketing/RequestAccessModal.tsx
@@ -6,9 +6,10 @@ import { requestLandlordInquiry } from "../../api/public";
 type Props = {
   open: boolean;
   onClose: () => void;
+  referralCode?: string | null;
 };
 
-export const RequestAccessModal: React.FC<Props> = ({ open, onClose }) => {
+export const RequestAccessModal: React.FC<Props> = ({ open, onClose, referralCode }) => {
   const [email, setEmail] = useState("");
   const [firstName, setFirstName] = useState("");
   const [portfolioSize, setPortfolioSize] = useState("");
@@ -31,7 +32,7 @@ export const RequestAccessModal: React.FC<Props> = ({ open, onClose }) => {
     setError(null);
     setLoading(true);
     try {
-      await requestLandlordInquiry({ email, firstName, portfolioSize, note });
+      await requestLandlordInquiry({ email, firstName, portfolioSize, note, referralCode: referralCode || undefined });
       setSent(true);
     } catch (err: any) {
       setError(err?.message || "Request failed");
@@ -93,6 +94,19 @@ export const RequestAccessModal: React.FC<Props> = ({ open, onClose }) => {
           </div>
         ) : (
           <form onSubmit={handleSubmit} style={{ display: "grid", gap: spacing.md }}>
+            {referralCode ? (
+              <div
+                style={{
+                  padding: "10px 12px",
+                  border: `1px solid ${colors.border}`,
+                  borderRadius: radius.md,
+                  background: "#f8fafc",
+                  color: text.muted,
+                }}
+              >
+                You were invited by a RentChain landlord.
+              </div>
+            ) : null}
             <div style={{ display: "grid", gap: 6 }}>
               <label style={{ fontWeight: 600 }}>Email</label>
               <Input

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -24,6 +24,7 @@ import { buildCreatePropertyUrl, buildReturnTo } from "../lib/propertyGate";
 import { SendScreeningInviteModal } from "../components/screening/SendScreeningInviteModal";
 import { SendApplicationModal } from "../components/properties/SendApplicationModal";
 import { useUnitsForProperty } from "../hooks/useUnitsForProperty";
+import { listReferrals } from "../api/referralsApi";
 
 const StarterOnboardingPanel = React.lazy(
   () => import("../components/dashboard/StarterOnboardingPanel")
@@ -114,6 +115,7 @@ const DashboardPage: React.FC = () => {
   const [modalPropertyId, setModalPropertyId] = React.useState<string | null>(null);
   const [modalUnitId, setModalUnitId] = React.useState<string | null>(null);
   const [onboardingChunkError, setOnboardingChunkError] = React.useState(false);
+  const [referralsCount, setReferralsCount] = React.useState(0);
   const onboarding = useOnboardingState();
   const prevDerivedRef = React.useRef({
     propertyAdded: false,
@@ -168,6 +170,23 @@ const DashboardPage: React.FC = () => {
       alive = false;
     };
   }, []);
+
+  React.useEffect(() => {
+    let active = true;
+    const loadReferrals = async () => {
+      if (!meLoaded) return;
+      try {
+        const rows = await listReferrals();
+        if (active) setReferralsCount(rows.length);
+      } catch {
+        if (active) setReferralsCount(0);
+      }
+    };
+    void loadReferrals();
+    return () => {
+      active = false;
+    };
+  }, [meLoaded]);
 
   React.useEffect(() => {
     let alive = true;
@@ -551,6 +570,16 @@ const DashboardPage: React.FC = () => {
             <Button onClick={handleCreateApplicationClick}>
               Send application link
             </Button>
+          </Card>
+        ) : null}
+
+        {dataReady ? (
+          <Card style={{ padding: spacing.md, border: `1px solid ${colors.border}` }}>
+            <div style={{ fontWeight: 700, marginBottom: 6 }}>Invite another landlord</div>
+            <div style={{ color: text.muted, marginBottom: 12 }}>
+              Referrals sent: {referralsCount}
+            </div>
+            <Button onClick={() => navigate("/referrals")}>Refer a landlord</Button>
           </Card>
         ) : null}
 

--- a/rentchain-frontend/src/pages/ReferralsPage.tsx
+++ b/rentchain-frontend/src/pages/ReferralsPage.tsx
@@ -1,0 +1,157 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Card, Section, Button, Input } from "../components/ui/Ui";
+import { spacing, text, colors } from "../styles/tokens";
+import { createReferral, listReferrals, type ReferralRecord } from "../api/referralsApi";
+import { useToast } from "../components/ui/ToastProvider";
+
+const statusLabel: Record<string, string> = {
+  sent: "Invite sent",
+  accepted: "Request received",
+  approved: "Approved",
+  expired: "Expired",
+};
+
+const fmt = (value?: number | null) => (value ? new Date(value).toLocaleString() : "—");
+
+const ReferralsPage: React.FC = () => {
+  const [referrals, setReferrals] = useState<ReferralRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [sending, setSending] = useState(false);
+  const [email, setEmail] = useState("");
+  const [name, setName] = useState("");
+  const [note, setNote] = useState("");
+  const [copiedLink, setCopiedLink] = useState<string | null>(null);
+  const { showToast } = useToast();
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const rows = await listReferrals();
+      setReferrals(rows);
+    } catch (err: any) {
+      showToast({ message: "Failed to load referrals", description: err?.message || "", variant: "error" });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  const referralCount = useMemo(
+    () => referrals.filter((row) => row.status === "approved" || row.status === "accepted").length,
+    [referrals]
+  );
+
+  const handleSend = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (sending) return;
+    setSending(true);
+    try {
+      const res = await createReferral({ refereeEmail: email, refereeName: name, note });
+      showToast({
+        message: res.deduped ? "Referral already active" : "Referral sent",
+        description: res.emailed === false ? "Saved but email was not sent." : undefined,
+        variant: "success",
+      });
+      setCopiedLink(res.referral?.link || null);
+      setEmail("");
+      setName("");
+      setNote("");
+      await load();
+    } catch (err: any) {
+      showToast({ message: "Could not send referral", description: err?.message || "", variant: "error" });
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <Section style={{ display: "grid", gap: spacing.md }}>
+      <Card style={{ padding: spacing.md, display: "grid", gap: spacing.sm }}>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.md, flexWrap: "wrap" }}>
+          <div>
+            <h1 style={{ margin: 0, fontSize: "1.25rem" }}>Refer a landlord</h1>
+            <div style={{ color: text.muted }}>Invite trusted landlords and track each referral status.</div>
+          </div>
+          <div style={{ color: text.muted }}>Referrals progressed: {referralCount}</div>
+        </div>
+        <form onSubmit={handleSend} style={{ display: "grid", gap: spacing.sm }}>
+          <Input
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            type="email"
+            placeholder="landlord@example.com"
+            required
+          />
+          <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Name (optional)" />
+          <textarea
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            rows={2}
+            placeholder="Optional note"
+            style={{
+              border: `1px solid ${colors.border}`,
+              borderRadius: 10,
+              padding: "10px 12px",
+              background: colors.card,
+              color: text.primary,
+              resize: "vertical",
+            }}
+          />
+          <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
+            <Button type="submit" disabled={sending}>
+              {sending ? "Sending..." : "Send referral"}
+            </Button>
+            <Button type="button" variant="ghost" onClick={load} disabled={loading}>
+              Refresh
+            </Button>
+          </div>
+        </form>
+        {copiedLink ? (
+          <div style={{ color: text.muted }}>
+            Referral link:{" "}
+            <a href={copiedLink} target="_blank" rel="noreferrer">
+              {copiedLink}
+            </a>
+          </div>
+        ) : null}
+      </Card>
+
+      <Card style={{ padding: spacing.md }}>
+        {loading ? (
+          <div style={{ color: text.muted }}>Loading referrals...</div>
+        ) : referrals.length === 0 ? (
+          <div style={{ color: text.muted }}>No referrals yet.</div>
+        ) : (
+          <div style={{ display: "grid", gap: spacing.sm }}>
+            {referrals.map((row) => (
+              <div
+                key={row.id}
+                style={{
+                  border: `1px solid ${colors.border}`,
+                  borderRadius: 10,
+                  padding: spacing.sm,
+                  display: "grid",
+                  gap: 4,
+                }}
+              >
+                <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.sm, flexWrap: "wrap" }}>
+                  <div style={{ fontWeight: 700 }}>{row.refereeEmail}</div>
+                  <div style={{ color: text.muted }}>{statusLabel[row.status] || row.status}</div>
+                </div>
+                <div style={{ color: text.muted }}>
+                  {row.refereeName || "—"} · Sent {fmt(row.createdAt)} · Accepted {fmt(row.acceptedAt)} · Approved{" "}
+                  {fmt(row.approvedAt)}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </Card>
+    </Section>
+  );
+};
+
+export default ReferralsPage;

--- a/rentchain-frontend/src/pages/admin/AdminLeadsPage.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminLeadsPage.tsx
@@ -210,6 +210,12 @@ const AdminLeadsPage: React.FC = () => {
                     </span>
                   </div>
                   {lead.note ? <div style={{ color: text.muted }}>Note: {lead.note}</div> : null}
+                  {lead.referrerLandlordId ? (
+                    <div style={{ color: text.muted }}>
+                      Referred by landlord {lead.referrerLandlordId}
+                      {lead.referralCode ? ` (${lead.referralCode})` : ""}
+                    </div>
+                  ) : null}
                   <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
                     <Button
                       type="button"

--- a/rentchain-frontend/src/pages/marketing/RequestAccessPage.tsx
+++ b/rentchain-frontend/src/pages/marketing/RequestAccessPage.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { MarketingLayout } from "./MarketingLayout";
+import { RequestAccessModal } from "../../components/marketing/RequestAccessModal";
+
+const RequestAccessPage: React.FC = () => {
+  const navigate = useNavigate();
+  const [params] = useSearchParams();
+  const referralCode = params.get("ref");
+
+  return (
+    <MarketingLayout>
+      <RequestAccessModal
+        open
+        referralCode={referralCode}
+        onClose={() => navigate("/site/pricing")}
+      />
+    </MarketingLayout>
+  );
+};
+
+export default RequestAccessPage;


### PR DESCRIPTION
Backend referrals API
POST /api/referrals (approved landlord only, dedupe + rate limit + email)
GET /api/referrals (current landlord list)
File: [referralsRoutes.ts](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/P2/.vscode/extensions/openai.chatgpt-0.4.71-win32-x64/webview/#)
Backend wiring
Mounted in both [app.ts](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/P2/.vscode/extensions/openai.chatgpt-0.4.71-win32-x64/webview/#) and [app.build.ts](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/P2/.vscode/extensions/openai.chatgpt-0.4.71-win32-x64/webview/#)
Added rateLimitReferralsUser (10/day/user) in [rateLimit.ts](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/P2/.vscode/extensions/openai.chatgpt-0.4.71-win32-x64/webview/#)
Lead/referral linkage
Public inquiry now accepts referralCode
Marks referral accepted on valid inquiry submission
Flags lead with referral metadata/priority
On lead approval, matching referral is marked approved
File: [landlordInquiryRoutes.ts](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/P2/.vscode/extensions/openai.chatgpt-0.4.71-win32-x64/webview/#)
Frontend landlord flow
New referrals page: /referrals
New API client: [referralsApi.ts](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/P2/.vscode/extensions/openai.chatgpt-0.4.71-win32-x64/webview/#)
Dashboard CTA card: “Invite another landlord” + count
Nav item: “Referrals”
Frontend referral landing flow
New route: /site/request-access
New page: [RequestAccessPage.tsx](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/P2/.vscode/extensions/openai.chatgpt-0.4.71-win32-x64/webview/#)
Request access modal supports referralCode and shows referral context
requestLandlordInquiry now supports referralCode
Admin visibility enhancement
Admin leads list now shows referral source info when present