### PR TITLE
feat(ui): use shared RentChainLogo in all headers (desktop + mobile)

### DIFF
--- a/rentchain-frontend/src/index.css
+++ b/rentchain-frontend/src/index.css
@@ -73,10 +73,10 @@ canvas {
 }
 
 .rc-logo-link {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   justify-content: center;
-  min-height: 32px;
+  height: 100%;
   line-height: 0;
 }
 
@@ -87,24 +87,24 @@ canvas {
 }
 
 .rc-logo-sm {
-  --rc-logo-h: 36px;
+  --rc-logo-h: 28px;
 }
 
 .rc-logo-md {
-  --rc-logo-h: 100px;
+  --rc-logo-h: 42px;
 }
 
 .rc-logo-dark {
   filter: brightness(0) invert(1);
 }
 
-@media (max-width: 640px) {
+@media (max-width: 768px) {
   .rc-logo-md {
-    --rc-logo-h: 100px;
+    --rc-logo-h: 32px;
   }
 
   .rc-logo-sm {
-    --rc-logo-h: 36px;
+    --rc-logo-h: 28px;
   }
 }
 


### PR DESCRIPTION
Added reusable brand component: RentChainLogo.tsx
Marketing shared header now uses logo link to /: MarketingLayout.tsx
App shared header now uses logo link to /dashboard: TopNav.tsx
Standardized shared logo sizing/alignment styles: index.css
.rc-logo-md = 42px desktop, 32px <= 768px
.rc-logo-sm = 28px
.rc-logo-link uses flex + centered + full-height