### PR TITLE
feat(billing): show plan badge in header and polish billing page UX

### DIFF
--- a/rentchain-frontend/src/components/billing/BillingPlansPanel.tsx
+++ b/rentchain-frontend/src/components/billing/BillingPlansPanel.tsx
@@ -15,6 +15,7 @@ type Props = {
   mode: "billing" | "pricing";
   planActionLoading?: string | null;
   onSelectPlan: (planKey: "starter" | "pro" | "business") => void;
+  onContactSales?: () => void;
 };
 
 const normalizePlan = (input?: string | null): PlanKey => {
@@ -37,6 +38,7 @@ export function BillingPlansPanel({
   mode,
   planActionLoading,
   onSelectPlan,
+  onContactSales,
 }: Props) {
   const visiblePlans = React.useMemo<PlanKey[]>(
     () => getVisiblePlans(role),
@@ -86,12 +88,8 @@ export function BillingPlansPanel({
     if (isCurrent) return "Current plan";
     if (planId === "elite") return "Contact sales";
     if (planActionLoading === planId) return "Starting...";
-    if (mode === "pricing") {
-      if (planId === "pro") return "Upgrade to Pro";
-      if (planId === "business") return "Choose plan";
-      return "Get started";
-    }
-    return "Choose plan";
+    if (mode === "pricing" && planId === "starter") return "Get started";
+    return "Upgrade";
   };
 
   return (
@@ -132,7 +130,10 @@ export function BillingPlansPanel({
                 type="button"
                 variant={highlight ? "secondary" : "primary"}
                 onClick={() => {
-                  if (planId === "elite") return;
+                  if (planId === "elite") {
+                    onContactSales?.();
+                    return;
+                  }
                   if (planId === "starter" || planId === "pro" || planId === "business") {
                     onSelectPlan(planId);
                   }
@@ -140,8 +141,7 @@ export function BillingPlansPanel({
                 disabled={
                   pricingUnavailable ||
                   highlight ||
-                  planActionLoading === planId ||
-                  planId === "elite"
+                  planActionLoading === planId
                 }
               >
                 {ctaLabel(planId, highlight)}

--- a/rentchain-frontend/src/components/layout/LandlordNav.css
+++ b/rentchain-frontend/src/components/layout/LandlordNav.css
@@ -27,6 +27,22 @@
   z-index: 30;
 }
 
+.rc-landlord-plan-badge {
+  display: none;
+  position: fixed;
+  top: 12px;
+  left: 12px;
+  height: 36px;
+  padding: 0 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  background: #ffffff;
+  color: #111827;
+  font-size: 12px;
+  font-weight: 700;
+  z-index: 30;
+}
+
 .rc-landlord-hamburger span {
   display: block;
   width: 18px;
@@ -182,6 +198,11 @@
 @media (max-width: 768px) {
   .rc-landlord-topnav {
     display: none;
+  }
+
+  .rc-landlord-plan-badge {
+    display: inline-flex;
+    align-items: center;
   }
 
   .rc-landlord-hamburger {

--- a/rentchain-frontend/src/components/layout/LandlordNav.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.tsx
@@ -5,6 +5,7 @@ import { useAuth } from "../../context/useAuth";
 import { fetchLandlordConversations } from "../../api/messagesApi";
 import { getVisibleNavItems } from "./navConfig";
 import { useCapabilities } from "@/hooks/useCapabilities";
+import { billingTierLabel, useBillingStatus } from "@/hooks/useBillingStatus";
 import "./LandlordNav.css";
 
 type Props = {
@@ -17,6 +18,8 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
   const loc = useLocation();
   const { logout, user, ready } = useAuth();
   const { features } = useCapabilities();
+  const billingStatus = useBillingStatus();
+  const planLabel = billingTierLabel(billingStatus.tier);
   const [hasUnread, setHasUnread] = useState<boolean>(false);
   const unreadFlag = typeof unreadMessages === "boolean" ? unreadMessages : hasUnread;
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -97,6 +100,15 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
       <div className="rc-landlord-topnav">
         <TopNav />
       </div>
+
+      <button
+        type="button"
+        className="rc-landlord-plan-badge"
+        onClick={() => nav("/billing")}
+        aria-label={`Current plan ${planLabel}. Open billing`}
+      >
+        {billingStatus.isLoading ? "Plan..." : planLabel}
+      </button>
 
       <button
         type="button"

--- a/rentchain-frontend/src/components/layout/TopNav.tsx
+++ b/rentchain-frontend/src/components/layout/TopNav.tsx
@@ -6,12 +6,15 @@ import { WorkspaceDrawer } from "./WorkspaceDrawer";
 import { Button } from "../ui/Ui";
 import { colors, radius, shadows, spacing, text, layout, blur } from "../../styles/tokens";
 import { RentChainLogo } from "../brand/RentChainLogo";
+import { billingTierLabel, useBillingStatus } from "@/hooks/useBillingStatus";
 
 const TopNav: React.FC = () => {
   const navigate = useNavigate();
   const { user, logout, ready } = useAuth();
   const [drawerOpen, setDrawerOpen] = useState(false);
   const effectiveRole = ready ? String(user?.actorRole || user?.role || "landlord") : "landlord";
+  const billingStatus = useBillingStatus();
+  const planLabel = billingTierLabel(billingStatus.tier);
 
   return (
     <>
@@ -39,6 +42,25 @@ const TopNav: React.FC = () => {
           <RentChainLogo href="/dashboard" size="sm" />
 
           <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: spacing.sm }}>
+            <button
+              type="button"
+              onClick={() => navigate("/billing")}
+              style={{
+                borderRadius: radius.pill,
+                border: `1px solid ${colors.border}`,
+                background: colors.card,
+                color: text.primary,
+                boxShadow: shadows.sm,
+                fontWeight: 700,
+                fontSize: "0.8rem",
+                padding: "8px 10px",
+                whiteSpace: "nowrap",
+                cursor: "pointer",
+              }}
+              aria-label={`Current plan ${planLabel}. Open billing`}
+            >
+              {billingStatus.isLoading ? "Plan..." : planLabel}
+            </button>
             <Button
               variant="ghost"
               onClick={() => navigate("/site")}

--- a/rentchain-frontend/src/config/support.ts
+++ b/rentchain-frontend/src/config/support.ts
@@ -1,1 +1,1 @@
-export const SUPPORT_EMAIL = "support@rentchain.ca";
+export const SUPPORT_EMAIL = "support@rentchain.ai";

--- a/rentchain-frontend/src/hooks/useBillingStatus.ts
+++ b/rentchain-frontend/src/hooks/useBillingStatus.ts
@@ -1,0 +1,108 @@
+import { useEffect, useMemo, useState } from "react";
+import { fetchSubscriptionStatus } from "@/api/billingApi";
+import { useCapabilities } from "@/hooks/useCapabilities";
+import { useAuth } from "@/context/useAuth";
+
+type PlanTier = "starter" | "pro" | "business" | "elite";
+type BillingInterval = "month" | "year" | null;
+
+type BillingStatus = {
+  tier: PlanTier;
+  interval: BillingInterval;
+  renewalDate: string | null;
+  isLoading: boolean;
+};
+
+type SubscriptionDetail = {
+  interval: BillingInterval;
+  renewalDate: string | null;
+};
+
+const DEFAULT_STATUS: BillingStatus = {
+  tier: "starter",
+  interval: null,
+  renewalDate: null,
+  isLoading: true,
+};
+
+const planFromString = (raw?: string | null): PlanTier | null => {
+  const value = String(raw || "").trim().toLowerCase();
+  if (!value) return null;
+  if (value === "pro" || value === "professional") return "pro";
+  if (value === "business" || value === "enterprise") return "business";
+  if (value === "elite") return "elite";
+  if (value === "starter" || value === "screening" || value === "free") return "starter";
+  return null;
+};
+
+const intervalFromString = (raw?: string | null): BillingInterval => {
+  const value = String(raw || "").trim().toLowerCase();
+  if (value === "month" || value === "monthly") return "month";
+  if (value === "year" || value === "yearly" || value === "annual") return "year";
+  return null;
+};
+
+const parseDate = (value: unknown): string | null => {
+  if (!value) return null;
+  const parsed = new Date(String(value));
+  return Number.isFinite(parsed.getTime()) ? parsed.toISOString() : null;
+};
+
+export function useBillingStatus(): BillingStatus {
+  const { caps, loading: capsLoading } = useCapabilities();
+  const { user } = useAuth();
+  const [subscription, setSubscription] = useState<SubscriptionDetail>({
+    interval: null,
+    renewalDate: null,
+  });
+  const [subscriptionLoading, setSubscriptionLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+    fetchSubscriptionStatus()
+      .then((raw: any) => {
+        if (!active) return;
+        const interval = intervalFromString(
+          raw?.interval || raw?.billingInterval || raw?.period || null
+        );
+        const renewalDate = parseDate(
+          raw?.renewalDate || raw?.currentPeriodEnd || raw?.nextBillingAt || null
+        );
+        setSubscription({ interval, renewalDate });
+      })
+      .catch(() => {
+        if (!active) return;
+        setSubscription({ interval: null, renewalDate: null });
+      })
+      .finally(() => {
+        if (active) setSubscriptionLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return useMemo(() => {
+    const tier =
+      planFromString(caps?.plan) ||
+      planFromString(user?.plan) ||
+      planFromString((user as any)?.subscriptionPlan) ||
+      "starter";
+
+    return {
+      tier,
+      interval: subscription.interval,
+      renewalDate: subscription.renewalDate,
+      isLoading: capsLoading || subscriptionLoading,
+    };
+  }, [caps?.plan, capsLoading, subscription.interval, subscription.renewalDate, subscriptionLoading, user?.plan]);
+}
+
+export function billingTierLabel(tier?: string | null): string {
+  const normalized = planFromString(tier) || "starter";
+  if (normalized === "starter") return "Starter";
+  if (normalized === "pro") return "Pro";
+  if (normalized === "business") return "Business";
+  return "Elite";
+}


### PR DESCRIPTION
Added shared billing status hook used by both header and billing page: useBillingStatus.ts
Added plan badge in app header (desktop) linking to /billing: TopNav.tsx
Added compact mobile plan badge linking to /billing: LandlordNav.tsx, LandlordNav.css
Polished /billing:
new “Current plan” summary card (tier, interval, renewal date)
starter upgrade callout + “Upgrade to Pro”
tracked events:
billing_page_opened
billing_manage_subscription_clicked
billing_upgrade_clicked
billing_contact_sales_clicked
updated plans panel wiring for contact sales
file: BillingPage.tsx
Updated plan-card CTA behavior and contact sales callback support: BillingPlansPanel.tsx
Updated support email to .ai: support.ts
