### PR TITLE
feat(billing): gate pro features with upgrade modal

### DIFF
--- a/rentchain-frontend/src/billing/requireTier.ts
+++ b/rentchain-frontend/src/billing/requireTier.ts
@@ -1,0 +1,25 @@
+export type TierKey = "starter" | "pro" | "business" | "elite";
+
+const TIER_ORDER: Record<TierKey, number> = {
+  starter: 0,
+  pro: 1,
+  business: 2,
+  elite: 3,
+};
+
+export function normalizeTier(input?: string | null): TierKey {
+  const value = String(input || "").trim().toLowerCase();
+  if (value === "pro" || value === "professional") return "pro";
+  if (value === "business" || value === "enterprise") return "business";
+  if (value === "elite") return "elite";
+  return "starter";
+}
+
+export function hasTier(userTier?: string | null, requiredTier: TierKey = "pro"): boolean {
+  const current = normalizeTier(userTier);
+  return TIER_ORDER[current] >= TIER_ORDER[requiredTier];
+}
+
+export function assertTier(userTier?: string | null, requiredTier: TierKey = "pro"): boolean {
+  return hasTier(userTier, requiredTier);
+}


### PR DESCRIPTION
Adds tier-based gating for Pro-only actions and routes blocked users into the existing upgrade flow.

Changes
Added tier utility:
[requireTier.ts](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/P2/.vscode/extensions/openai.chatgpt-0.4.71-win32-x64/webview/#)
hasTier, assertTier, normalizeTier
Reused existing UpgradeModal via useUpgrade() and added analytics:
upgrade_modal_opened
upgrade_modal_upgrade_clicked
Added action-level gating (no nav blocking):
Dashboard: “Send screening invite” action
Applications: “Send screening invite” action
Applications: run screening / checkout action
Applications: export action
SendScreeningInviteModal submit safety guard
Added analytics for blocked actions:
gating_blocked with { featureName, requiredTier, userTier }