### PR TITLE
feat(admin): add KPI metrics endpoint and dashboard widgets

### DIFF
--- a/rentchain-frontend/src/api/adminDashboardApi.ts
+++ b/rentchain-frontend/src/api/adminDashboardApi.ts
@@ -23,6 +23,24 @@ export type AdminSummary = {
   };
 };
 
+export type AdminMetrics = {
+  activeSubscribers: number;
+  mrrCents: number;
+  arrCents: number;
+  subscriptionsByTier: { starter: number; pro: number; business: number; elite: number };
+  screeningsPaidThisMonth: number;
+  screeningsPaidYtd: number;
+  screeningRevenueCentsThisMonth: number;
+  screeningRevenueCentsYtd: number;
+  upgradesStartedThisMonth?: number;
+  upgradesCompletedThisMonth?: number;
+};
+
+export type StripeHealth = {
+  ok: boolean;
+  stripeConfigured?: boolean;
+};
+
 export type AdminExpense = {
   id: string;
   date: string;
@@ -41,6 +59,20 @@ export async function fetchAdminSummary() {
     marketing: data.marketing,
     expenses: data.expenses,
   } as AdminSummary;
+}
+
+export async function fetchAdminMetrics() {
+  const data = await apiFetch<{ ok: boolean; metrics: AdminMetrics }>("/admin/metrics");
+  return data.metrics;
+}
+
+export async function fetchStripeHealth() {
+  try {
+    const data = await apiFetch<StripeHealth>("/health/stripe");
+    return data;
+  } catch {
+    return null;
+  }
 }
 
 export async function listAdminExpenses(params?: { from?: string; to?: string }) {


### PR DESCRIPTION
Backend admin metrics endpoint: GET /api/admin/metrics in adminRoutes.ts
activeSubscribers, mrrCents, arrCents
subscriptionsByTier (starter/pro/business/elite)
screeningsPaidThisMonth, screeningsPaidYtd
screeningRevenueCentsThisMonth, screeningRevenueCentsYtd
upgradesStartedThisMonth, upgradesCompletedThisMonth
Admin-only via requireAdmin
Stripe-based computation when configured, Firestore fallback otherwise
Frontend API wiring in adminDashboardApi.ts
fetchAdminMetrics()
fetchStripeHealth()
Admin dashboard widgets in AdminDashboardPage.tsx
KPI cards (active subs, MRR, ARR, screenings sold, screening revenue)
subscriptions-by-tier breakdown panel
health panel for Stripe configured status