### PR TITLE
fix(pdf): use signed URLs for review summary downloads

### DIFF
--- a/rentchain-frontend/src/api/reviewSummaryApi.ts
+++ b/rentchain-frontend/src/api/reviewSummaryApi.ts
@@ -1,5 +1,4 @@
 import { apiFetch } from "./apiFetch";
-import { API_BASE_URL } from "./config";
 
 export type ApplicationReviewSummary = {
   applicationId: string;
@@ -75,7 +74,22 @@ export async function fetchReviewSummary(applicationId: string): Promise<Applica
   return res.summary as ApplicationReviewSummary;
 }
 
-export function reviewSummaryPdfUrl(applicationId: string): string {
-  const base = API_BASE_URL.replace(/\/$/, "").replace(/\/api$/i, "");
-  return `${base}/api/rental-applications/${encodeURIComponent(applicationId)}/review-summary.pdf`;
+export async function fetchReviewSummaryPdfSignedUrl(applicationId: string): Promise<string> {
+  const res: any = await apiFetch(
+    `/rental-applications/${encodeURIComponent(applicationId)}/review-summary.pdf`,
+    {
+      method: "GET",
+      allowStatuses: [400, 401, 403, 404, 500],
+    }
+  );
+  if (!res?.ok || typeof res?.url !== "string" || !res.url) {
+    const err = new ReviewSummaryApiError(
+      res?.detail || res?.error || "Failed to fetch review summary PDF URL"
+    );
+    err.status = Number.isFinite(Number(res?.status)) ? Number(res.status) : undefined;
+    err.backendError = typeof res?.error === "string" ? res.error : undefined;
+    err.detail = typeof res?.detail === "string" ? res.detail : undefined;
+    throw err;
+  }
+  return res.url;
 }

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
@@ -4,7 +4,7 @@ import { Card, Button } from "../components/ui/Ui";
 import { colors, text } from "../styles/tokens";
 import {
   fetchReviewSummary,
-  reviewSummaryPdfUrl,
+  fetchReviewSummaryPdfSignedUrl,
   type ApplicationReviewSummary,
   ReviewSummaryApiError,
 } from "../api/reviewSummaryApi";
@@ -124,9 +124,17 @@ function ApplicationReviewSummaryPageBody() {
     return `${window.location.origin}/applications/${id}/review-summary`;
   }, [id]);
 
-  const downloadPdf = () => {
-    const url = reviewSummaryPdfUrl(id);
-    window.open(url, "_blank", "noopener,noreferrer");
+  const downloadPdf = async () => {
+    try {
+      const url = await fetchReviewSummaryPdfSignedUrl(id);
+      window.open(url, "_blank", "noopener,noreferrer");
+    } catch (err: any) {
+      showToast({
+        message: "Unable to open PDF",
+        description: err?.message || "Failed to load review summary PDF.",
+        variant: "error",
+      });
+    }
   };
 
   const copyText = async (value: string, successMessage: string) => {
@@ -147,7 +155,7 @@ function ApplicationReviewSummaryPageBody() {
         </div>
         <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
           <Button variant="ghost" onClick={() => navigate(-1)}>Back</Button>
-          <Button variant="secondary" onClick={downloadPdf}>Download PDF</Button>
+          <Button variant="secondary" onClick={() => void downloadPdf()}>Download PDF</Button>
           <Button variant="secondary" onClick={() => void copyText(shareUrl, "Share link copied")}>Copy link</Button>
           {summary?.screening?.referenceId ? (
             <Button


### PR DESCRIPTION
Backend (rentalApplicationsRoutes.ts)

review-summary.pdf now:
keeps existing authz check via loadAuthorizedApplication
builds the PDF buffer
uploads it to GCS (putPdfObject)
returns a signed URL (createSignedUrl, 10-minute expiry)
responds with JSON: { ok: true, url }
Unauthorized access still returns 403 through existing access checks.