### PR TITLE
fix(frontend): replace invite raw error codes with friendly UX messaging

### DIFF
--- a/rentchain-frontend/src/api/tenantInvites.ts
+++ b/rentchain-frontend/src/api/tenantInvites.ts
@@ -27,14 +27,18 @@ export async function createTenantInvite(payload: {
 }) {
   return apiFetch<{
     ok: boolean;
-    token: string;
+    token?: string;
     inviteUrl?: string;
     invite?: TenantInvite;
     expiresAt?: number;
     emailed?: boolean;
+    error?: string;
+    capability?: string;
+    plan?: string;
   }>("/tenant-invites", {
     method: "POST",
     body: payload,
+    allowStatuses: [400, 403],
   });
 }
 


### PR DESCRIPTION
Friendly error mapping in invite modal:
InviteTenantModal.tsx
upgrade_required + tenant_invites => upgrade nudge + warning toast
unit_required => inline friendly message: “Please select a property and unit before sending an invite.”
raw codes only logged via console.debug
Same friendly mapping on invites page:
InvitesPage.tsx
Invite API now returns structured 400/403 payloads to UI (instead of throwing generic message):
tenantInvites.ts