### PR TITLE
fix(frontend): enforce /api/me session hydration and stabilize nav lo…

### DIFF
--- a/rentchain-frontend/src/components/layout/TopNav.tsx
+++ b/rentchain-frontend/src/components/layout/TopNav.tsx
@@ -17,12 +17,13 @@ function roleLabel(raw: string): string {
 
 const TopNav: React.FC = () => {
   const navigate = useNavigate();
-  const { user, logout, ready } = useAuth();
+  const { user, logout, ready, isLoading, authStatus } = useAuth();
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const effectiveRole = ready ? String(user?.actorRole || user?.role || "landlord") : "landlord";
+  const authResolved = ready && !isLoading && authStatus !== "restoring" && !!user;
+  const effectiveRole = authResolved ? String(user?.actorRole || user?.role || "landlord") : "";
   const billingStatus = useBillingStatus();
   const planLabel = billingTierLabel(billingStatus.tier);
-  const roleBadge = roleLabel(effectiveRole);
+  const roleBadge = authResolved ? roleLabel(effectiveRole) : "Loading...";
 
   return (
     <>
@@ -118,7 +119,7 @@ const TopNav: React.FC = () => {
         open={drawerOpen}
         onClose={() => setDrawerOpen(false)}
         userEmail={user?.email || ""}
-        userRole={effectiveRole}
+        userRole={authResolved ? effectiveRole : null}
         onSignOut={() => {
           logout();
           navigate("/login");

--- a/rentchain-frontend/src/components/layout/WorkspaceDrawer.tsx
+++ b/rentchain-frontend/src/components/layout/WorkspaceDrawer.tsx
@@ -15,8 +15,9 @@ type WorkspaceDrawerProps = {
 export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({ open, onClose, userEmail, userRole, onSignOut }) => {
   const navigate = useNavigate();
   const location = useLocation();
-  const { features } = useCapabilities();
-  const visibleItems = getVisibleNavItems(userRole, features);
+  const { features, loading: capsLoading } = useCapabilities();
+  const navLoading = !userRole || capsLoading;
+  const visibleItems = navLoading ? [] : getVisibleNavItems(userRole, features);
   const drawerItems = visibleItems.filter((item) => item.showInDrawer !== false);
   const primaryDrawerItems = drawerItems.filter((item) => !item.requiresAdmin);
   const adminDrawerItems = drawerItems.filter((item) => item.requiresAdmin);
@@ -103,6 +104,21 @@ export const WorkspaceDrawer: React.FC<WorkspaceDrawerProps> = ({ open, onClose,
 
         <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: "0.02em", color: text.muted }}>Pages</div>
         <div style={{ display: "grid", gap: 8 }}>
+          {navLoading ? (
+            <div
+              style={{
+                textAlign: "left",
+                padding: "10px 12px",
+                borderRadius: radius.md,
+                border: `1px solid ${colors.border}`,
+                background: colors.card,
+                color: text.muted,
+                fontWeight: 600,
+              }}
+            >
+              Loading menu...
+            </div>
+          ) : null}
           {primaryDrawerItems.map((link) => {
             const active = location.pathname.startsWith(link.to);
             return (


### PR DESCRIPTION
What changed:

Auth session hardening in AuthContext.tsx
Clears existing auth storage/state before starting a new login/signup/demo/2FA session.
Persists user state from /api/me (apiRestoreSession) only.
Verifies identity after login/session hydration:
compares expected email/id vs /api/me user
on mismatch: clears session and throws Session mismatch, please log in again.
Nav flicker stabilization