### PR TITLE
ci: add guarded merge gate workflow

### DIFF
--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -55,6 +55,7 @@ jobs:
               core.setOutput("ready", "true");
               core.setOutput("summary", summary);
               core.setOutput("commentable", "false");
+              core.setOutput("comment_skip_reason", "Merge queue context does not post PR comments.");
               core.setOutput("pr_number", "");
               core.setOutput("unmet", "");
               return;
@@ -69,6 +70,7 @@ jobs:
               core.setOutput("ready", "false");
               core.setOutput("summary", "Unable to determine pull request context for merge-gate evaluation.");
               core.setOutput("commentable", "false");
+              core.setOutput("comment_skip_reason", "Pull request context could not be determined for comment posting.");
               core.setOutput("pr_number", "");
               core.setOutput("unmet", "Unable to determine pull request context.");
               return;
@@ -254,7 +256,13 @@ jobs:
 
             core.setOutput("ready", ready ? "true" : "false");
             core.setOutput("summary", summaryLines.join("\n"));
-            core.setOutput("commentable", "true");
+            core.setOutput("commentable", isInRepo ? "true" : "false");
+            core.setOutput(
+              "comment_skip_reason",
+              isInRepo
+                ? ""
+                : "Skipping PR comment because the head branch is not in the same repository and token write access may be restricted."
+            );
             core.setOutput("pr_number", String(prNumber));
             core.setOutput("unmet", unmet.join("\n"));
 
@@ -267,6 +275,7 @@ jobs:
 
       - name: Update merge-gate PR comment
         if: steps.evaluate.outputs.commentable == 'true'
+        continue-on-error: true
         uses: actions/github-script@v7
         env:
           PR_NUMBER: ${{ steps.evaluate.outputs.pr_number }}
@@ -275,36 +284,54 @@ jobs:
         with:
           github-token: ${{ github.token }}
           script: |
-            const issue_number = Number(process.env.PR_NUMBER);
-            const marker = "<!-- rentchain-merge-gate -->";
-            const heading = process.env.MERGE_GATE_READY === "true" ? "Merge-ready" : "Not merge-ready";
-            const body = `${marker}\n## Merge Gate\n\n**${heading}**\n\n${process.env.MERGE_GATE_SUMMARY}`;
+            try {
+              const issue_number = Number(process.env.PR_NUMBER);
+              const marker = "<!-- rentchain-merge-gate -->";
+              const heading = process.env.MERGE_GATE_READY === "true" ? "Merge-ready" : "Not merge-ready";
+              const body = `${marker}\n## Merge Gate\n\n**${heading}**\n\n${process.env.MERGE_GATE_SUMMARY}`;
 
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number,
-              per_page: 100,
-            });
-            const existing = comments.find((comment) =>
-              comment.user?.type === "Bot" && comment.body?.includes(marker)
-            );
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
+              const { data: comments } = await github.rest.issues.listComments({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number,
-                body,
+                per_page: 100,
               });
+              const existing = comments.find((comment) =>
+                comment.user?.type === "Bot" && comment.body?.includes(marker)
+              );
+
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number,
+                  body,
+                });
+              }
+            } catch (error) {
+              const status = error?.status || error?.response?.status || "unknown";
+              const message = error?.message || "Unknown comment-posting failure";
+              if (String(status) === "403") {
+                core.warning(`Merge-gate PR comment skipped because comment writes are not permitted in this context (${status}: ${message}).`);
+              } else {
+                core.warning(`Merge-gate PR comment failed but will not block the workflow (${status}: ${message}).`);
+              }
             }
+
+      - name: Log skipped PR comment context
+        if: steps.evaluate.outputs.commentable != 'true' && steps.evaluate.outputs.comment_skip_reason != ''
+        run: |
+          {
+            echo "## Merge Gate Comment"
+            echo "${{ steps.evaluate.outputs.comment_skip_reason }}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Enforce merge gate
         if: steps.evaluate.outputs.ready != 'true'

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -1,0 +1,313 @@
+name: merge-gate
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - labeled
+      - unlabeled
+      - review_requested
+      - edited
+  pull_request_review:
+    types:
+      - submitted
+      - dismissed
+  merge_group:
+
+permissions:
+  contents: read
+  pull-requests: read
+  checks: read
+  statuses: read
+  issues: write
+
+concurrency:
+  group: merge-gate-${{ github.event.pull_request.number || github.event.merge_group.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  merge-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate merge readiness
+        id: evaluate
+        uses: actions/github-script@v7
+        env:
+          REQUIRED_APPROVAL_LABEL: maintainer-approved
+          BLOCKING_LABELS: do-not-merge,manual-review-required
+          FALLBACK_REQUIRED_CHECKS: backend,frontend
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const eventName = context.eventName;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            if (eventName === "merge_group") {
+              const summary = [
+                "merge_group compatibility run.",
+                "This job exists so the merge-gate required check can run in GitHub merge queue context.",
+                "PR-level labels and approval rules are evaluated on pull request events before a PR enters the queue.",
+              ].join("\n");
+              core.setOutput("ready", "true");
+              core.setOutput("summary", summary);
+              core.setOutput("commentable", "false");
+              core.setOutput("pr_number", "");
+              core.setOutput("unmet", "");
+              return;
+            }
+
+            const prNumber =
+              context.payload.pull_request?.number ||
+              context.payload.review?.pull_request_url?.split("/").pop() ||
+              null;
+
+            if (!prNumber) {
+              core.setOutput("ready", "false");
+              core.setOutput("summary", "Unable to determine pull request context for merge-gate evaluation.");
+              core.setOutput("commentable", "false");
+              core.setOutput("pr_number", "");
+              core.setOutput("unmet", "Unable to determine pull request context.");
+              return;
+            }
+
+            const requiredApprovalLabel = String(process.env.REQUIRED_APPROVAL_LABEL || "maintainer-approved").trim();
+            const blockingLabels = String(process.env.BLOCKING_LABELS || "")
+              .split(",")
+              .map((item) => item.trim())
+              .filter(Boolean);
+            const fallbackRequiredChecks = String(process.env.FALLBACK_REQUIRED_CHECKS || "")
+              .split(",")
+              .map((item) => item.trim())
+              .filter(Boolean);
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: Number(prNumber),
+            });
+
+            const reviewQuery = await github.graphql(
+              `
+                query MergeGatePullRequest($owner: String!, $repo: String!, $number: Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    pullRequest(number: $number) {
+                      isDraft
+                      reviewDecision
+                      baseRefName
+                      headRefName
+                      headRefOid
+                      headRepository {
+                        nameWithOwner
+                      }
+                      labels(first: 100) {
+                        nodes {
+                          name
+                        }
+                      }
+                    }
+                  }
+                }
+              `,
+              { owner, repo, number: Number(prNumber) }
+            );
+
+            const pull = reviewQuery.repository.pullRequest;
+            const labels = new Set((pull.labels.nodes || []).map((node) => node.name));
+            const requestedReviewerCount =
+              (pr.requested_reviewers || []).length + (pr.requested_teams || []).length;
+            const isInRepo = pull.headRepository?.nameWithOwner === `${owner}/${repo}`;
+            const reviewDecision = String(pull.reviewDecision || "");
+
+            let requiredChecks = [];
+            let usedBranchProtection = false;
+            try {
+              const protection = await github.request(
+                "GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks",
+                {
+                  owner,
+                  repo,
+                  branch: pull.baseRefName,
+                }
+              );
+              const contexts = Array.isArray(protection.data.contexts) ? protection.data.contexts : [];
+              const checks = Array.isArray(protection.data.checks)
+                ? protection.data.checks
+                    .map((entry) => entry?.context)
+                    .filter(Boolean)
+                : [];
+              requiredChecks = [...new Set([...contexts, ...checks])];
+              usedBranchProtection = requiredChecks.length > 0;
+            } catch (error) {
+              requiredChecks = fallbackRequiredChecks;
+            }
+
+            requiredChecks = requiredChecks.filter((check) => check && check !== "merge-gate");
+
+            const { data: checkRunsData } = await github.rest.checks.listForRef({
+              owner,
+              repo,
+              ref: pull.headRefOid,
+              per_page: 100,
+            });
+            const { data: combinedStatus } = await github.rest.repos.getCombinedStatusForRef({
+              owner,
+              repo,
+              ref: pull.headRefOid,
+            });
+
+            const successfulConclusions = new Set(["success", "neutral", "skipped"]);
+            const completedStatuses = new Set(["completed"]);
+
+            function checkState(name) {
+              const checkRun = (checkRunsData.check_runs || []).find((run) => run.name === name);
+              if (checkRun) {
+                return {
+                  source: "check_run",
+                  status: checkRun.status || "",
+                  conclusion: checkRun.conclusion || "",
+                  passing:
+                    completedStatuses.has(String(checkRun.status || "")) &&
+                    successfulConclusions.has(String(checkRun.conclusion || "")),
+                };
+              }
+
+              const statusContext = (combinedStatus.statuses || []).find((status) => status.context === name);
+              if (statusContext) {
+                return {
+                  source: "status",
+                  status: statusContext.state || "",
+                  conclusion: statusContext.state || "",
+                  passing: statusContext.state === "success",
+                };
+              }
+
+              return {
+                source: "missing",
+                status: "missing",
+                conclusion: "missing",
+                passing: false,
+              };
+            }
+
+            const unmet = [];
+            if (pull.isDraft) unmet.push("PR is still draft.");
+            if (!isInRepo) unmet.push("PR head branch is not in the same repository.");
+
+            const presentBlockingLabels = blockingLabels.filter((label) => labels.has(label));
+            if (presentBlockingLabels.length) {
+              unmet.push(`Blocking label present: ${presentBlockingLabels.join(", ")}.`);
+            }
+
+            if (!labels.has(requiredApprovalLabel)) {
+              unmet.push(`Missing required maintainer label: ${requiredApprovalLabel}.`);
+            }
+
+            if (requestedReviewerCount > 0) {
+              unmet.push("Outstanding review requests are still open.");
+            }
+
+            if (reviewDecision === "CHANGES_REQUESTED") {
+              unmet.push("A blocking changes-requested review is still active.");
+            } else if (reviewDecision !== "APPROVED") {
+              unmet.push("Pull request does not currently have an approved review decision.");
+            }
+
+            const requiredCheckResults = requiredChecks.map((checkName) => ({
+              name: checkName,
+              ...checkState(checkName),
+            }));
+
+            for (const result of requiredCheckResults) {
+              if (!result.passing) {
+                unmet.push(
+                  `Required check \`${result.name}\` is not passing (source: ${result.source}, state: ${result.status || "unknown"}, conclusion: ${result.conclusion || "unknown"}).`
+                );
+              }
+            }
+
+            if (!requiredChecks.length) {
+              unmet.push("No required checks were discoverable for merge evaluation.");
+            }
+
+            const ready = unmet.length === 0;
+            const summaryLines = [
+              ready ? "Merge gate passed. PR is merge-ready under the guarded policy." : "Merge gate failed. PR is not merge-ready yet.",
+              `PR #${prNumber}`,
+              `Branch protection required checks source: ${usedBranchProtection ? "GitHub branch protection" : "workflow fallback list"}`,
+            ];
+
+            if (requiredChecks.length) {
+              summaryLines.push(`Required checks evaluated: ${requiredChecks.join(", ")}`);
+            } else {
+              summaryLines.push("No required checks were discoverable, so merge-gate could not confirm CI readiness.");
+            }
+
+            if (unmet.length) {
+              summaryLines.push("");
+              summaryLines.push("Unmet conditions:");
+              for (const item of unmet) summaryLines.push(`- ${item}`);
+            }
+
+            core.setOutput("ready", ready ? "true" : "false");
+            core.setOutput("summary", summaryLines.join("\n"));
+            core.setOutput("commentable", "true");
+            core.setOutput("pr_number", String(prNumber));
+            core.setOutput("unmet", unmet.join("\n"));
+
+      - name: Publish merge-gate summary
+        run: |
+          {
+            echo "## Merge Gate"
+            echo "${{ steps.evaluate.outputs.summary }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Update merge-gate PR comment
+        if: steps.evaluate.outputs.commentable == 'true'
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.evaluate.outputs.pr_number }}
+          MERGE_GATE_SUMMARY: ${{ steps.evaluate.outputs.summary }}
+          MERGE_GATE_READY: ${{ steps.evaluate.outputs.ready }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const issue_number = Number(process.env.PR_NUMBER);
+            const marker = "<!-- rentchain-merge-gate -->";
+            const heading = process.env.MERGE_GATE_READY === "true" ? "Merge-ready" : "Not merge-ready";
+            const body = `${marker}\n## Merge Gate\n\n**${heading}**\n\n${process.env.MERGE_GATE_SUMMARY}`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) =>
+              comment.user?.type === "Bot" && comment.body?.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                body,
+              });
+            }
+
+      - name: Enforce merge gate
+        if: steps.evaluate.outputs.ready != 'true'
+        run: |
+          echo "Merge gate is not satisfied."
+          exit 1

--- a/docs/github-actions-codex-phase-1.md
+++ b/docs/github-actions-codex-phase-1.md
@@ -25,6 +25,8 @@ Existing legacy workflows remain in place in this phase. The new `ci.yml` is the
 
 Phase 2 builds on this baseline with a separate bounded autofix workflow documented in `docs/github-actions-codex-phase-2-autofix.md`.
 
+Phase 3 adds a guarded merge gate documented in `docs/github-actions-codex-phase-3-merge-gate.md`.
+
 ## Workflows Added
 
 ### `codex-mission-runner.yml`

--- a/docs/github-actions-codex-phase-2-autofix.md
+++ b/docs/github-actions-codex-phase-2-autofix.md
@@ -137,3 +137,4 @@ Potential later work could include:
 - explicit merge-gate integration
 - selective retry policies
 
+Phase 3 now adds a separate guarded merge gate so autofix remains distinct from merge readiness decisions.

--- a/docs/github-actions-codex-phase-3-merge-gate.md
+++ b/docs/github-actions-codex-phase-3-merge-gate.md
@@ -7,7 +7,7 @@ Phase 3 adds a guarded merge-gate workflow that evaluates whether a pull request
 It provides:
 
 - an explicit `merge-gate` check in GitHub
-- a concise PR comment that explains missing requirements
+- a concise PR comment that explains missing requirements when comment writes are permitted
 - a policy layer that works alongside GitHub branch protection instead of replacing it
 - optional merge queue compatibility through the `merge_group` event
 
@@ -70,6 +70,19 @@ The merge gate adds:
 - a consistent signal that maintainers can use before merging
 
 If branch protection and merge-gate disagree, branch protection still controls whether GitHub allows the merge.
+
+## Comment Posting Behavior
+
+Merge-gate comments are best-effort only.
+
+Behavior:
+
+- the merge-readiness evaluation remains the source of truth
+- the workflow check still passes or fails based on merge policy
+- PR comment posting is attempted only in safe commentable contexts
+- if GitHub denies comment writes, such as a `403 Resource not accessible by integration`, the workflow logs the condition and continues
+
+This prevents comment-permission limits from turning a valid merge-gate result into a failed workflow.
 
 ## Merge Queue Notes
 

--- a/docs/github-actions-codex-phase-3-merge-gate.md
+++ b/docs/github-actions-codex-phase-3-merge-gate.md
@@ -1,0 +1,117 @@
+# GitHub Actions Codex Phase 3 Merge Gate
+
+## What Phase 3 Adds
+
+Phase 3 adds a guarded merge-gate workflow that evaluates whether a pull request is merge-ready under RentChain policy.
+
+It provides:
+
+- an explicit `merge-gate` check in GitHub
+- a concise PR comment that explains missing requirements
+- a policy layer that works alongside GitHub branch protection instead of replacing it
+- optional merge queue compatibility through the `merge_group` event
+
+## What Merge Gate Checks
+
+The merge gate treats a PR as merge-ready only when all of the following are true:
+
+1. the PR is not draft
+2. the PR head branch is in the same repository
+3. required CI checks are passing
+4. there is no active blocking review state
+5. there are no outstanding review requests
+6. the maintainer approval label is present
+7. no explicit blocking label is present
+
+Current label policy:
+
+- required approval label:
+  - `maintainer-approved`
+- blocking labels:
+  - `do-not-merge`
+  - `manual-review-required`
+
+## How It Determines Required Checks
+
+The workflow uses GitHub state as the source of truth where possible.
+
+Primary behavior:
+
+- it attempts to read required status check configuration from branch protection for the PR base branch
+
+Fallback behavior:
+
+- if that branch-protection metadata is not accessible with the workflow token, it falls back to the repo's current guarded CI check names:
+  - `backend`
+  - `frontend`
+
+This keeps the gate usable without requiring elevated secret access while still aligning with the repo's current CI structure.
+
+## What Phase 3 Intentionally Does Not Do
+
+Phase 3 does not:
+
+- auto-merge pull requests
+- perform merges directly
+- change branch protection rules
+- override required reviews or required checks
+- replace GitHub's protection model
+
+The merge gate is an explicit readiness signal, not a merge executor.
+
+## Relationship To Branch Protection
+
+GitHub branch protection remains the primary enforcement mechanism.
+
+The merge gate adds:
+
+- a human-readable readiness check
+- explicit policy around labels and blocking conditions
+- a consistent signal that maintainers can use before merging
+
+If branch protection and merge-gate disagree, branch protection still controls whether GitHub allows the merge.
+
+## Merge Queue Notes
+
+The workflow includes the `merge_group` event for merge queue compatibility.
+
+Why:
+
+- GitHub merge queues require required checks to run in merge queue context when those checks are part of the protected branch policy
+
+Behavior in merge queue context:
+
+- the workflow runs a compatibility path
+- PR-level labels and review requirements are expected to have been satisfied before the PR entered the queue
+- the workflow does not attempt to reconstruct full PR policy from merge queue context
+
+## Maintainer Signals
+
+Current maintainer-controlled approval signal:
+
+- `maintainer-approved`
+
+Current explicit block signals:
+
+- `do-not-merge`
+- `manual-review-required`
+
+Maintainers should remove block labels and add the approval label only after reviewing the PR normally.
+
+## Why Auto-Merge Is Not Included
+
+Auto-merge is intentionally excluded in Phase 3 because this mission is about readiness signaling, not merge execution.
+
+That keeps the system safer while the automation stack is still maturing:
+
+- CI remains the check path
+- autofix remains bounded
+- maintainers still decide when to merge
+
+## Future Phase 4 Possibilities
+
+Potential future work could include:
+
+- optional maintainer-triggered auto-merge after merge-gate passes
+- tighter merge queue policy integration
+- workflow consolidation once the phase stack is stable


### PR DESCRIPTION
Summary
Add Phase 3 guarded merge-gate for the Codex/GitHub Actions workflow
Introduce a merge-gate workflow that evaluates whether a PR is merge-ready using live GitHub PR, check, label, and review state
Keep merge approval human-controlled and do not enable auto-merge
Changes
Added .github/workflows/merge-gate.yml
evaluates merge readiness on PR activity
supports:
pull_request
pull_request_review
merge_group
never merges the PR directly
Added merge readiness policy requiring:
PR is not draft
same-repo branch context
required CI checks passing
no blocking review state
no outstanding review requests
maintainer-approved label present
no blocking labels:
do-not-merge
manual-review-required
Added fallback required-check behavior:
attempts to read branch protection required checks
falls back to current repo CI checks:
backend
frontend
Added/updated docs:
docs/github-actions-codex-phase-1.md
docs/github-actions-codex-phase-2-autofix.md
docs/github-actions-codex-phase-3-merge-gate.md
Trigger Logic
pull_request
opened
synchronize
reopened
ready_for_review
labeled
unlabeled
review_requested
edited
pull_request_review
submitted
dismissed
merge_group
included for merge queue compatibility
Validation
 npm run lint (not applicable to this workflow/docs mission)
 npm run test (workflow/docs mission only; no app code changed)
 npm run build (workflow/docs mission only; no app code changed)

Manual validation performed:

reviewed existing Phase 1/2 workflows and docs
validated trigger/event alignment
parsed workflow YAML locally
confirmed clean git scope
documented limitations and merge-queue behavior
Notes / Limitations
merge-gate does not perform merges or auto-merge
branch-protection required-check discovery may fall back to backend / frontend when branch protection metadata is not accessible with workflow token permissions
merge_group support is compatibility-oriented and does not fully recreate PR label/review policy inside merge-queue context
this is a merge-readiness signal layered on top of GitHub branch protection, not a replacement for it