### PR TITLE
feat: add tenant profile and communications

### DIFF
--- a/docs/tenant-profile-and-communications.md
+++ b/docs/tenant-profile-and-communications.md
@@ -1,0 +1,89 @@
+# Tenant Profile And Communications
+
+## What This Mission Adds
+
+This mission extends the merged tenant portal foundation and frontend shell with the next bounded tenant-facing layer:
+
+- a tenant-safe profile surface
+- identity and document status visibility
+- a landlord-to-tenant communications surface
+- a tenant-safe notifications and feed view
+
+The portal remains a projection over canonical backend records. No separate tenant source-of-truth model was introduced.
+
+## Backend Surfaces
+
+The tenant portal backend now exposes:
+
+- `/api/tenant/profile`
+- `/api/tenant/communications`
+- `/api/tenant/communications/messages`
+- `/api/tenant/communications/read`
+- `/api/tenant/notifications`
+
+The existing `/api/tenant/activity` path now uses the same tenant-safe notification feed logic for route compatibility.
+
+## Profile And Identity Model
+
+The tenant profile surface includes:
+
+- display name
+- email
+- phone when already available safely
+- authority context label
+- linked property summary
+- linked application summary
+- linked lease summary
+
+Identity and document visibility stays high-level:
+
+- overall status
+- identity verification status
+- document checklist items
+- tenant-safe next steps
+
+It does not expose:
+
+- raw screening payloads
+- internal risk reasoning
+- landlord-only notes
+- admin-only notes
+
+## Communications Model
+
+The communications surface is intentionally bounded:
+
+- one tenant-scoped conversation channel per tenancy or application context
+- safe participant labels only
+- message list
+- tenant compose/send action when authority context allows it
+
+This mission does not add:
+
+- real-time chat infrastructure
+- push delivery
+- moderation or AI messaging features
+
+## Notifications Feed
+
+The feed is a tenant-safe projection across:
+
+- application status
+- identity and document next steps
+- lease visibility
+- maintenance updates
+- landlord message notices
+- invite linkage outcomes
+
+It is curated rather than dumping raw backend events into the UI.
+
+## Intentionally Deferred
+
+This mission does not include:
+
+- broader tenant automation
+- CRM-style communications tooling
+- landlord portal redesign
+- external notification delivery changes
+- document upload re-architecture
+- risk-agent or compliance-agent integrations

--- a/rentchain-api/src/routes/__tests__/tenantCommunicationsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantCommunicationsRoutes.test.ts
@@ -1,0 +1,231 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const collections = new Map<string, Map<string, any>>();
+
+function ensureCollection(name: string) {
+  if (!collections.has(name)) collections.set(name, new Map<string, any>());
+  return collections.get(name)!;
+}
+
+function clone<T>(value: T): T {
+  return value === undefined ? value : JSON.parse(JSON.stringify(value));
+}
+
+function applyFilters(rows: Array<[string, any]>, filters: Array<{ field: string; op: string; value: any }>) {
+  return rows.filter(([, data]) =>
+    filters.every((filter) => {
+      const current = data?.[filter.field];
+      if (filter.op === "==") return current === filter.value;
+      if (filter.op === "array-contains") return Array.isArray(current) && current.includes(filter.value);
+      return false;
+    })
+  );
+}
+
+function createQuery(name: string, filters: Array<{ field: string; op: string; value: any }> = []) {
+  const api: any = {
+    where(field: string, op: string, value: any) {
+      return createQuery(name, [...filters, { field, op, value }]);
+    },
+    orderBy() {
+      return api;
+    },
+    limit(count: number) {
+      return {
+        get: async () => {
+          const docs = applyFilters(Array.from(ensureCollection(name).entries()), filters)
+            .slice(0, count)
+            .map(([id, data]) => ({ id, exists: true, data: () => clone(data) }));
+          return { docs, empty: docs.length === 0 };
+        },
+      };
+    },
+    async get() {
+      const docs = applyFilters(Array.from(ensureCollection(name).entries()), filters).map(([id, data]) => ({
+        id,
+        exists: true,
+        data: () => clone(data),
+      }));
+      return { docs, empty: docs.length === 0 };
+    },
+  };
+  return api;
+}
+
+const dbMock = {
+  collection: (name: string) => ({
+    doc: (id?: string) => {
+      const docId = id || `doc_${ensureCollection(name).size + 1}`;
+      return {
+        id: docId,
+        get: async () => ({
+          id: docId,
+          exists: ensureCollection(name).has(docId),
+          data: () => clone(ensureCollection(name).get(docId)),
+        }),
+        set: async (value: any, opts?: { merge?: boolean }) => {
+          const current = ensureCollection(name).get(docId) || {};
+          ensureCollection(name).set(docId, opts?.merge ? { ...current, ...clone(value) } : clone(value));
+        },
+      };
+    },
+    where: (field: string, op: string, value: any) => createQuery(name, [{ field, op, value }]),
+  }),
+};
+
+vi.mock("../../config/firebase", () => ({
+  db: dbMock,
+  FieldValue: {
+    serverTimestamp: () => "__server_timestamp__",
+  },
+}));
+
+vi.mock("../../middleware/authMiddleware", () => ({
+  authenticateJwt: (req: any, _res: any, next: any) => {
+    const header = String(req.headers["x-test-user"] || "").trim();
+    if (header) req.user = JSON.parse(header);
+    next();
+  },
+}));
+
+async function invokeRouter(router: any, options: {
+  method: string;
+  url: string;
+  body?: any;
+  headers?: Record<string, string>;
+}) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path: options.url,
+      body: options.body ?? {},
+      headers: options.headers ?? {},
+      query: {},
+      params: {},
+    };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("tenant communications routes", () => {
+  beforeEach(() => {
+    collections.clear();
+    ensureCollection("properties").set("prop-1", {
+      rc_prop_id: "rc-prop-1",
+      landlordId: "landlord-1",
+      street1: "123 Main St",
+    });
+    ensureCollection("applications").set("app-1", {
+      applicantEmail: "tenant@example.com",
+      propertyId: "prop-1",
+      status: "submitted",
+    });
+    ensureCollection("leases").set("lease-1", {
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      status: "active",
+    });
+    ensureCollection("conversations").set("landlord-1__tenant-1__na", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      lastMessageAt: "2026-01-03T00:00:00.000Z",
+      lastReadAtTenant: "2026-01-01T00:00:00.000Z",
+    });
+    ensureCollection("messages").set("msg-1", {
+      conversationId: "landlord-1__tenant-1__na",
+      senderRole: "landlord",
+      body: "Please confirm your move-in timing.",
+      createdAtMs: Date.parse("2026-01-02T00:00:00.000Z"),
+    });
+    ensureCollection("messages").set("msg-2", {
+      conversationId: "landlord-1__tenant-1__na",
+      senderRole: "tenant",
+      body: "I can confirm by Friday.",
+      createdAtMs: Date.parse("2026-01-03T00:00:00.000Z"),
+    });
+    ensureCollection("event_log").clear();
+  });
+
+  it("rejects unauthorized communications access", async () => {
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, { method: "GET", url: "/communications" });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns only tenant-scoped thread messages", async () => {
+    ensureCollection("messages").set("msg-3", {
+      conversationId: "landlord-1__other-tenant__na",
+      senderRole: "landlord",
+      body: "Should not leak",
+      createdAtMs: Date.parse("2026-01-04T00:00:00.000Z"),
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/communications",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+          leaseId: "lease-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.thread?.messages).toHaveLength(2);
+    expect(JSON.stringify(res.body)).not.toContain("Should not leak");
+    expect(res.body?.data?.thread?.unreadCount).toBe(1);
+  });
+
+  it("send path respects authority context and records a scoped message", async () => {
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/communications/messages",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+          leaseId: "lease-1",
+        }),
+      },
+      body: {
+        body: "Can we schedule key pickup tomorrow?",
+      },
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body?.data?.body).toContain("key pickup");
+    const writtenMessages = Array.from(ensureCollection("messages").values()).filter(
+      (entry) => entry?.body === "Can we schedule key pickup tomorrow?"
+    );
+    expect(writtenMessages).toHaveLength(1);
+    expect(Array.from(ensureCollection("event_log").values()).some((event) => event.event_type === "tenant_message_sent")).toBe(true);
+  });
+});

--- a/rentchain-api/src/routes/__tests__/tenantNotificationsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantNotificationsRoutes.test.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const collections = new Map<string, Map<string, any>>();
+
+function ensureCollection(name: string) {
+  if (!collections.has(name)) collections.set(name, new Map<string, any>());
+  return collections.get(name)!;
+}
+
+function clone<T>(value: T): T {
+  return value === undefined ? value : JSON.parse(JSON.stringify(value));
+}
+
+function applyFilters(rows: Array<[string, any]>, filters: Array<{ field: string; op: string; value: any }>) {
+  return rows.filter(([, data]) =>
+    filters.every((filter) => {
+      const current = data?.[filter.field];
+      if (filter.op === "==") return current === filter.value;
+      if (filter.op === "array-contains") return Array.isArray(current) && current.includes(filter.value);
+      return false;
+    })
+  );
+}
+
+function createQuery(name: string, filters: Array<{ field: string; op: string; value: any }> = []) {
+  const api: any = {
+    where(field: string, op: string, value: any) {
+      return createQuery(name, [...filters, { field, op, value }]);
+    },
+    orderBy() {
+      return api;
+    },
+    limit(count: number) {
+      return {
+        get: async () => {
+          const docs = applyFilters(Array.from(ensureCollection(name).entries()), filters)
+            .slice(0, count)
+            .map(([id, data]) => ({ id, exists: true, data: () => clone(data) }));
+          return { docs, empty: docs.length === 0 };
+        },
+      };
+    },
+    async get() {
+      const docs = applyFilters(Array.from(ensureCollection(name).entries()), filters).map(([id, data]) => ({
+        id,
+        exists: true,
+        data: () => clone(data),
+      }));
+      return { docs, empty: docs.length === 0 };
+    },
+  };
+  return api;
+}
+
+const dbMock = {
+  collection: (name: string) => ({
+    doc: (id?: string) => {
+      const docId = id || `doc_${ensureCollection(name).size + 1}`;
+      return {
+        id: docId,
+        get: async () => ({
+          id: docId,
+          exists: ensureCollection(name).has(docId),
+          data: () => clone(ensureCollection(name).get(docId)),
+        }),
+        set: async (value: any, opts?: { merge?: boolean }) => {
+          const current = ensureCollection(name).get(docId) || {};
+          ensureCollection(name).set(docId, opts?.merge ? { ...current, ...clone(value) } : clone(value));
+        },
+      };
+    },
+    where: (field: string, op: string, value: any) => createQuery(name, [{ field, op, value }]),
+  }),
+};
+
+vi.mock("../../config/firebase", () => ({
+  db: dbMock,
+  FieldValue: {
+    serverTimestamp: () => "__server_timestamp__",
+  },
+}));
+
+vi.mock("../../middleware/authMiddleware", () => ({
+  authenticateJwt: (req: any, _res: any, next: any) => {
+    const header = String(req.headers["x-test-user"] || "").trim();
+    if (header) req.user = JSON.parse(header);
+    next();
+  },
+}));
+
+async function invokeRouter(router: any, options: {
+  method: string;
+  url: string;
+  body?: any;
+  headers?: Record<string, string>;
+}) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path: options.url,
+      body: options.body ?? {},
+      headers: options.headers ?? {},
+      query: {},
+      params: {},
+    };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("tenant notifications route", () => {
+  beforeEach(() => {
+    collections.clear();
+    ensureCollection("properties").set("prop-1", {
+      rc_prop_id: "rc-prop-1",
+      landlordId: "landlord-1",
+      street1: "123 Main St",
+      city: "Halifax",
+      province: "NS",
+    });
+    ensureCollection("applications").set("app-1", {
+      applicantEmail: "tenant@example.com",
+      propertyId: "prop-1",
+      status: "submitted",
+      missingSteps: ["upload_id"],
+      nextActions: ["upload government id"],
+      updatedAt: "2026-01-03T00:00:00.000Z",
+      rawDecisionNotes: "private",
+    });
+    ensureCollection("leases").set("lease-1", {
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      status: "active",
+      startDate: "2026-02-01",
+    });
+    ensureCollection("tenants").set("tenant-1", {
+      email: "tenant@example.com",
+    });
+    ensureCollection("maintenanceRequests").set("maint-1", {
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      title: "Leaky faucet",
+      status: "submitted",
+      updatedAt: "2026-01-04T00:00:00.000Z",
+    });
+    ensureCollection("tenancy_invites").set("invite-1", {
+      redeemed_by_uid: "user-1",
+      created_at: "2026-01-02T00:00:00.000Z",
+      token_hash: "secret-token-hash",
+    });
+    ensureCollection("messages").set("msg-1", {
+      conversationId: "landlord-1__tenant-1__na",
+      senderRole: "landlord",
+      body: "Welcome to your new place.",
+      createdAtMs: 1500,
+    });
+  });
+
+  it("returns tenant-safe feed items only", async () => {
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/notifications",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+          leaseId: "lease-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body?.data)).toBe(true);
+    expect(res.body?.data.some((item: any) => item.type === "application")).toBe(true);
+    expect(res.body?.data.some((item: any) => item.type === "maintenance")).toBe(true);
+    expect(res.body?.data.some((item: any) => item.type === "message")).toBe(true);
+    expect(JSON.stringify(res.body)).not.toContain("secret-token-hash");
+    expect(JSON.stringify(res.body)).not.toContain("rawDecisionNotes");
+  });
+});

--- a/rentchain-api/src/routes/__tests__/tenantProfileRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantProfileRoutes.test.ts
@@ -1,0 +1,217 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const collections = new Map<string, Map<string, any>>();
+
+function ensureCollection(name: string) {
+  if (!collections.has(name)) collections.set(name, new Map<string, any>());
+  return collections.get(name)!;
+}
+
+function clone<T>(value: T): T {
+  return value === undefined ? value : JSON.parse(JSON.stringify(value));
+}
+
+function applyFilters(rows: Array<[string, any]>, filters: Array<{ field: string; op: string; value: any }>) {
+  return rows.filter(([, data]) =>
+    filters.every((filter) => {
+      const current = data?.[filter.field];
+      if (filter.op === "==") return current === filter.value;
+      if (filter.op === "array-contains") return Array.isArray(current) && current.includes(filter.value);
+      return false;
+    })
+  );
+}
+
+function createQuery(name: string, filters: Array<{ field: string; op: string; value: any }> = []) {
+  const api: any = {
+    where(field: string, op: string, value: any) {
+      return createQuery(name, [...filters, { field, op, value }]);
+    },
+    orderBy() {
+      return api;
+    },
+    limit(count: number) {
+      return {
+        get: async () => {
+          const docs = applyFilters(Array.from(ensureCollection(name).entries()), filters)
+            .slice(0, count)
+            .map(([id, data]) => ({ id, exists: true, data: () => clone(data) }));
+          return { docs, empty: docs.length === 0 };
+        },
+      };
+    },
+    async get() {
+      const docs = applyFilters(Array.from(ensureCollection(name).entries()), filters).map(([id, data]) => ({
+        id,
+        exists: true,
+        data: () => clone(data),
+      }));
+      return { docs, empty: docs.length === 0 };
+    },
+  };
+  return api;
+}
+
+const dbMock = {
+  collection: (name: string) => ({
+    doc: (id?: string) => {
+      const docId = id || `doc_${ensureCollection(name).size + 1}`;
+      return {
+        id: docId,
+        get: async () => ({
+          id: docId,
+          exists: ensureCollection(name).has(docId),
+          data: () => clone(ensureCollection(name).get(docId)),
+        }),
+        set: async (value: any, opts?: { merge?: boolean }) => {
+          const current = ensureCollection(name).get(docId) || {};
+          ensureCollection(name).set(docId, opts?.merge ? { ...current, ...clone(value) } : clone(value));
+        },
+      };
+    },
+    where: (field: string, op: string, value: any) => createQuery(name, [{ field, op, value }]),
+  }),
+};
+
+vi.mock("../../config/firebase", () => ({
+  db: dbMock,
+  FieldValue: {
+    serverTimestamp: () => "__server_timestamp__",
+  },
+}));
+
+vi.mock("../../middleware/authMiddleware", () => ({
+  authenticateJwt: (req: any, _res: any, next: any) => {
+    const header = String(req.headers["x-test-user"] || "").trim();
+    if (header) req.user = JSON.parse(header);
+    next();
+  },
+}));
+
+async function invokeRouter(router: any, options: {
+  method: string;
+  url: string;
+  body?: any;
+  headers?: Record<string, string>;
+}) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path: options.url,
+      body: options.body ?? {},
+      headers: options.headers ?? {},
+      query: {},
+      params: {},
+    };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("tenant profile route", () => {
+  beforeEach(() => {
+    collections.clear();
+    ensureCollection("properties").set("prop-1", {
+      rc_prop_id: "rc-prop-1",
+      landlordId: "landlord-1",
+      street1: "123 Main St",
+      city: "Halifax",
+      province: "NS",
+      postalCode: "B3H1A1",
+      internalSecret: "private",
+    });
+    ensureCollection("applications").set("app-1", {
+      applicantEmail: "tenant@example.com",
+      applicantName: "Taylor Tenant",
+      propertyId: "prop-1",
+      status: "submitted",
+      missingSteps: ["upload_id"],
+      nextActions: ["upload government id"],
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-03T00:00:00.000Z",
+      sin: "123-45-6789",
+      documentRefs: ["doc-1"],
+    });
+    ensureCollection("leases").set("lease-1", {
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      status: "active",
+      startDate: "2026-02-01",
+      endDate: "2027-01-31",
+      monthlyRent: 1800,
+      confidentialNotes: "private",
+    });
+    ensureCollection("tenants").set("tenant-1", {
+      fullName: "Taylor Tenant",
+      email: "tenant@example.com",
+      phone: "902-555-0100",
+      internalRiskScore: 900,
+    });
+    ensureCollection("screening_requests").set("screen-1", {
+      applicantTenantId: "tenant-1",
+      latestResultId: "result-1",
+      status: "completed",
+      updatedAt: "2026-01-04T00:00:00.000Z",
+    });
+    ensureCollection("screening_results").set("result-1", {
+      status: "completed",
+      identityVerified: true,
+      rawPayloadRef: "secret/path",
+      updatedAt: "2026-01-05T00:00:00.000Z",
+    });
+  });
+
+  it("rejects unauthorized tenant profile access", async () => {
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, { method: "GET", url: "/profile" });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns only safe projected tenant profile fields", async () => {
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/profile",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+          leaseId: "lease-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.profile?.displayName).toBe("Taylor Tenant");
+    expect(res.body?.data?.profile?.email).toBe("tenant@example.com");
+    expect(res.body?.data?.profile?.phone).toBe("902-555-0100");
+    expect(res.body?.data?.profile?.property?.street1).toBe("123 Main St");
+    expect(res.body?.data?.profile?.property?.internalSecret).toBeUndefined();
+    expect(res.body?.data?.profile?.application?.sin).toBeUndefined();
+    expect(res.body?.data?.profile?.lease?.confidentialNotes).toBeUndefined();
+    expect(res.body?.data?.identity?.identityVerification?.status).toBe("verified");
+    expect(res.body?.data?.identity?.documentChecklist?.[0]?.code).toBe("upload_id");
+    expect(JSON.stringify(res.body)).not.toContain("rawPayloadRef");
+    expect(JSON.stringify(res.body)).not.toContain("internalRiskScore");
+  });
+});

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -15,6 +15,13 @@ import {
 } from "../services/tenantPortal/tenantProjectionService";
 import { recordTenantEvent } from "../services/tenantPortal/tenantEventLogService";
 import { redeemTenancyInvite } from "../services/tenantPortal/tenantInviteService";
+import { loadTenantProfileProjection } from "../services/tenantPortal/tenantProfileService";
+import {
+  loadTenantCommunicationsWorkspace,
+  markTenantCommunicationsRead,
+  sendTenantCommunicationMessage,
+} from "../services/tenantPortal/tenantCommunicationsService";
+import { listTenantNotificationFeed } from "../services/tenantPortal/tenantNotificationsService";
 
 const router = Router();
 router.use(authenticateJwt);
@@ -1755,6 +1762,156 @@ async function handleTenantWorkspaceSummary(req: any, res: any) {
 router.get("/workspace", requireTenantWorkspaceIdentity, handleTenantWorkspaceSummary);
 router.get("/me", requireTenantWorkspaceIdentity, handleTenantWorkspaceSummary);
 
+router.get("/profile", requireTenantWorkspaceIdentity, async (req: any, res) => {
+  const context = await resolveWorkspaceContextOrRespond(req, res);
+  if (!context) return;
+
+  try {
+    const profile = await loadTenantProfileProjection({
+      context,
+      userId: String(req.user?.id || "").trim(),
+      userEmail: String(req.user?.email || "").trim() || null,
+    });
+
+    await recordTenantEvent({
+      eventType: "tenant_profile_viewed",
+      entityType: "tenant_profile",
+      entityId: String(context.tenantId || context.applicationId || context.propertyId || req.user?.id || "tenant_profile"),
+      createdBy: String(req.user?.id || "").trim(),
+      context: {
+        authority: context.authority,
+        propertyId: context.propertyId,
+        rc_prop_id: context.rc_prop_id,
+        applicationId: context.applicationId,
+        leaseId: context.leaseId,
+      },
+      payload: {
+        overallStatus: profile.identity.overallStatus,
+      },
+    });
+
+    return res.json({ ok: true, data: profile });
+  } catch (err: any) {
+    console.error("[tenant/profile] failed", {
+      userId: req.user?.id,
+      message: err?.message || "failed",
+    });
+    return res.status(500).json({ ok: false, error: "TENANT_PROFILE_FAILED" });
+  }
+});
+
+router.get("/communications", requireTenantWorkspaceIdentity, async (req: any, res) => {
+  const context = await resolveWorkspaceContextOrRespond(req, res);
+  if (!context) return;
+
+  try {
+    const workspace = await loadTenantCommunicationsWorkspace({
+      context,
+      userId: String(req.user?.id || "").trim(),
+    });
+    return res.json({ ok: true, data: workspace });
+  } catch (err: any) {
+    console.error("[tenant/communications] failed", {
+      userId: req.user?.id,
+      message: err?.message || "failed",
+    });
+    return res.status(500).json({ ok: false, error: "TENANT_COMMUNICATIONS_FAILED" });
+  }
+});
+
+router.post("/communications/messages", requireTenantWorkspaceIdentity, async (req: any, res) => {
+  const context = await resolveWorkspaceContextOrRespond(req, res);
+  if (!context) return;
+
+  try {
+    const result = await sendTenantCommunicationMessage({
+      context,
+      userId: String(req.user?.id || "").trim(),
+      body: req.body?.body,
+    });
+
+    if (!result.ok) {
+      const status =
+        result.error === "TENANCY_CONTEXT_REQUIRED" || result.error === "LANDLORD_CONTEXT_MISSING"
+          ? 403
+          : result.error === "MESSAGE_BODY_REQUIRED" || result.error === "MESSAGE_BODY_TOO_LONG"
+          ? 400
+          : 500;
+      return res.status(status).json({ ok: false, error: result.error });
+    }
+
+    return res.status(201).json({ ok: true, data: result.message });
+  } catch (err: any) {
+    console.error("[tenant/communications/messages] failed", {
+      userId: req.user?.id,
+      message: err?.message || "failed",
+    });
+    return res.status(500).json({ ok: false, error: "TENANT_COMMUNICATION_SEND_FAILED" });
+  }
+});
+
+router.post("/communications/read", requireTenantWorkspaceIdentity, async (req: any, res) => {
+  const context = await resolveWorkspaceContextOrRespond(req, res);
+  if (!context) return;
+
+  try {
+    const result = await markTenantCommunicationsRead({
+      context,
+      userId: String(req.user?.id || "").trim(),
+    });
+    if (!result.ok) {
+      return res.status(403).json({ ok: false, error: result.error });
+    }
+    return res.json({ ok: true });
+  } catch (err: any) {
+    console.error("[tenant/communications/read] failed", {
+      userId: req.user?.id,
+      message: err?.message || "failed",
+    });
+    return res.status(500).json({ ok: false, error: "TENANT_COMMUNICATION_READ_FAILED" });
+  }
+});
+
+async function handleTenantNotifications(req: any, res: any) {
+  const context = await resolveWorkspaceContextOrRespond(req, res);
+  if (!context) return;
+
+  try {
+    const items = await listTenantNotificationFeed({
+      context,
+      userId: String(req.user?.id || "").trim(),
+      userEmail: String(req.user?.email || "").trim() || null,
+    });
+
+    await recordTenantEvent({
+      eventType: "tenant_notifications_viewed",
+      entityType: "tenant_notifications",
+      entityId: String(context.tenantId || context.applicationId || context.propertyId || req.user?.id || "tenant_notifications"),
+      createdBy: String(req.user?.id || "").trim(),
+      context: {
+        authority: context.authority,
+        propertyId: context.propertyId,
+        rc_prop_id: context.rc_prop_id,
+        applicationId: context.applicationId,
+        leaseId: context.leaseId,
+      },
+      payload: {
+        itemCount: items.length,
+      },
+    });
+
+    return res.json({ ok: true, data: items });
+  } catch (err: any) {
+    console.error("[tenant/notifications] failed", {
+      userId: req.user?.id,
+      message: err?.message || "failed",
+    });
+    return res.status(500).json({ ok: false, error: "TENANT_NOTIFICATIONS_FAILED" });
+  }
+}
+
+router.get("/notifications", requireTenantWorkspaceIdentity, handleTenantNotifications);
+
 router.get("/application-status", requireTenantWorkspaceIdentity, async (req: any, res) => {
   const context = await resolveWorkspaceContextOrRespond(req, res);
   if (!context) return;
@@ -2045,121 +2202,7 @@ router.get("/me", requireTenant, async (req: any, res) => {
   }
 });
 
-router.get("/activity", requireTenant, async (req: any, res) => {
-  try {
-    const tenantId = req.user?.tenantId;
-    if (!tenantId) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
-
-    const items: Array<{
-      id: string;
-      type: "invite" | "lease" | "rent" | "notice" | "system";
-      title: string;
-      description?: string;
-      occurredAt: number;
-    }> = [];
-
-    let tenantData: any = {};
-    try {
-      const tenantSnap = await db.collection("tenants").doc(tenantId).get();
-      tenantData = tenantSnap.exists ? (tenantSnap.data() as any) : {};
-    } catch {
-      tenantData = {};
-    }
-    const tenantEmail = tenantData?.email ?? req.user?.email ?? null;
-
-    // Invite redemption
-    try {
-      const inviteSnap = await db
-        .collection("tenantInvites")
-        .where("tenantId", "==", tenantId)
-        .limit(1)
-        .get();
-      const doc = inviteSnap.docs[0];
-      if (doc?.exists) {
-        const inv = doc.data() as any;
-        const occurredAt = toMillis(inv.redeemedAt ?? inv.createdAt ?? null);
-        if (occurredAt) {
-          items.push({
-            id: `invite-${doc.id}`,
-            type: "invite",
-            title: "Invite accepted",
-            description: tenantEmail ? `Joined as ${tenantEmail}` : "Invite accepted",
-            occurredAt,
-          });
-        }
-      }
-    } catch {
-      // ignore invite errors
-    }
-
-    // Lease start
-    try {
-      const data = tenantData || {};
-      const propertyId = data?.propertyId ?? null;
-      const unitId = data?.unitId ?? data?.unit ?? null;
-      const leaseStart = toMillis(
-        data?.leaseStart ?? data?.lease_begin ?? data?.leaseStartDate ?? null
-      );
-      if (propertyId && unitId && leaseStart) {
-        let propertyName: string | null = data?.propertyName ?? data?.property ?? null;
-        try {
-          const propSnap = await db.collection("properties").doc(propertyId).get();
-          if (propSnap.exists) {
-            const prop = propSnap.data() as any;
-            propertyName = prop?.name ?? prop?.addressLine1 ?? propertyName ?? null;
-          }
-        } catch {
-          // ignore
-        }
-        items.push({
-          id: `lease-${tenantId}-${leaseStart}`,
-          type: "lease",
-          title: "Lease started",
-          description: propertyName ?? undefined,
-          occurredAt: leaseStart,
-        });
-      }
-    } catch {
-      // ignore lease errors
-    }
-
-    // Ledger / rent events
-    try {
-      const { listEventsForTenant } = await import("../services/ledgerEventsService");
-      const ledgerEvents = listEventsForTenant(tenantId).slice(0, 10);
-      ledgerEvents.forEach((ev) => {
-        const occurredAt = toMillis(ev.occurredAt);
-        if (!occurredAt) return;
-        const type: "rent" | "system" =
-          ev.type.includes("charge") || ev.type.includes("payment") ? "rent" : "system";
-        const title =
-          ev.type === "charge_created" || ev.type === "charge_issued"
-            ? "Rent charge issued"
-            : ev.type === "payment_recorded" || ev.type === "payment_created"
-            ? "Payment recorded"
-            : "Account update";
-        const description = ev.notes ?? ev.reference?.kind ?? undefined;
-        items.push({
-          id: `ledger-${ev.id}`,
-          type,
-          title,
-          description,
-          occurredAt,
-        });
-      });
-    } catch {
-      // ignore ledger errors
-    }
-
-    items.sort((a, b) => b.occurredAt - a.occurredAt);
-    const limited = items.slice(0, 25);
-
-    return res.json({ ok: true, data: limited });
-  } catch (err) {
-    console.error("[tenantPortalRoutes] /tenant/activity error", err);
-    return res.status(500).json({ ok: false, error: "TENANT_ACTIVITY_FAILED" });
-  }
-});
+router.get("/activity", requireTenantWorkspaceIdentity, handleTenantNotifications);
 
 router.get("/messages", requireTenant, async (req: any, res) => {
   try {

--- a/rentchain-api/src/services/tenantPortal/tenantCommunicationsService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantCommunicationsService.ts
@@ -1,0 +1,252 @@
+import { db, FieldValue } from "../../config/firebase";
+import type { TenancyContext } from "./tenancyContextService";
+import { recordTenantEvent } from "./tenantEventLogService";
+
+export type TenantCommunicationsWorkspace = {
+  canSend: boolean;
+  canSendReason: string | null;
+  thread: {
+    id: string;
+    landlordLabel: string;
+    propertyId: string | null;
+    unitId: string | null;
+    unreadCount: number;
+    lastMessageAt: string | null;
+    messages: TenantThreadMessage[];
+  } | null;
+};
+
+export type TenantThreadMessage = {
+  id: string;
+  senderRole: "tenant" | "landlord";
+  body: string;
+  createdAt: string | null;
+  createdAtMs: number | null;
+};
+
+function asString(value: unknown): string | null {
+  const next = String(value || "").trim();
+  return next || null;
+}
+
+function toMillis(value: any): number | null {
+  if (!value) return null;
+  if (typeof value === "number") return value;
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+  if (typeof value?.toMillis === "function") return value.toMillis();
+  if (typeof value?.seconds === "number") return value.seconds * 1000;
+  return null;
+}
+
+function toIso(value: any): string | null {
+  const millis = toMillis(value);
+  return millis ? new Date(millis).toISOString() : null;
+}
+
+async function loadPropertyLandlord(propertyId: string | null) {
+  const id = asString(propertyId);
+  if (!id) return null;
+  try {
+    const snap = await db.collection("properties").doc(id).get();
+    if (!snap.exists) return null;
+    const data = (snap.data() as any) || {};
+    return {
+      landlordId: asString(data?.landlordId),
+      landlordLabel: asString(data?.landlordName) || "Landlord",
+    };
+  } catch {
+    return null;
+  }
+}
+
+function buildConversationId(params: {
+  landlordId: string;
+  context: TenancyContext;
+  userId: string;
+}) {
+  const scopeId = asString(params.context.tenantId) || asString(params.context.applicationId) || params.userId;
+  return `${params.landlordId}__${scopeId}__${asString(params.context.unitId) || "na"}`;
+}
+
+export async function loadTenantCommunicationsWorkspace(params: {
+  context: TenancyContext;
+  userId: string;
+}) : Promise<TenantCommunicationsWorkspace> {
+  const propertyLandlord = await loadPropertyLandlord(params.context.propertyId);
+  const landlordId = propertyLandlord?.landlordId;
+  const canSend =
+    Boolean(landlordId) &&
+    (params.context.authority === "applicant" || params.context.authority === "active_tenant");
+
+  if (!landlordId) {
+    return {
+      canSend: false,
+      canSendReason: "No landlord communication context is linked to this workspace yet.",
+      thread: null,
+    };
+  }
+
+  const conversationId = buildConversationId({
+    landlordId,
+    context: params.context,
+    userId: params.userId,
+  });
+
+  let conversationData: any = null;
+  try {
+    const conversationSnap = await db.collection("conversations").doc(conversationId).get();
+    if (conversationSnap.exists) {
+      conversationData = (conversationSnap.data() as any) || {};
+    }
+  } catch {
+    conversationData = null;
+  }
+
+  let messages: TenantThreadMessage[] = [];
+  try {
+    const snap = await db
+      .collection("messages")
+      .where("conversationId", "==", conversationId)
+      .orderBy("createdAt", "desc")
+      .limit(100)
+      .get();
+    messages = snap.docs
+      .map((doc) => {
+        const data = (doc.data() as any) || {};
+        return {
+          id: doc.id,
+          senderRole: String(data?.senderRole || "").trim().toLowerCase() === "landlord" ? "landlord" : "tenant",
+          body: String(data?.body || "").trim(),
+          createdAt: toIso(data?.createdAt) || toIso(data?.createdAtMs),
+          createdAtMs: toMillis(data?.createdAt) || toMillis(data?.createdAtMs),
+        } satisfies TenantThreadMessage;
+      })
+      .sort((left, right) => Number(left.createdAtMs || 0) - Number(right.createdAtMs || 0));
+  } catch {
+    messages = [];
+  }
+
+  const lastReadAtTenant = toMillis(conversationData?.lastReadAtTenant);
+  const unreadCount = messages.filter((message) => {
+    if (message.senderRole !== "landlord") return false;
+    if (!message.createdAtMs) return false;
+    return !lastReadAtTenant || message.createdAtMs > lastReadAtTenant;
+  }).length;
+
+  return {
+    canSend,
+    canSendReason: canSend ? null : "Messaging becomes available once your tenancy or application context is fully linked.",
+    thread: {
+      id: conversationId,
+      landlordLabel: propertyLandlord?.landlordLabel || "Landlord",
+      propertyId: params.context.propertyId,
+      unitId: params.context.unitId,
+      unreadCount,
+      lastMessageAt: toIso(conversationData?.lastMessageAt) || messages[messages.length - 1]?.createdAt || null,
+      messages,
+    },
+  };
+}
+
+export async function sendTenantCommunicationMessage(params: {
+  context: TenancyContext;
+  userId: string;
+  body: string;
+}) {
+  const propertyLandlord = await loadPropertyLandlord(params.context.propertyId);
+  const landlordId = propertyLandlord?.landlordId;
+  if (!landlordId) {
+    return { ok: false as const, error: "LANDLORD_CONTEXT_MISSING" };
+  }
+  if (!(params.context.authority === "applicant" || params.context.authority === "active_tenant")) {
+    return { ok: false as const, error: "TENANCY_CONTEXT_REQUIRED" };
+  }
+
+  const body = String(params.body || "").trim();
+  if (!body) return { ok: false as const, error: "MESSAGE_BODY_REQUIRED" };
+  if (body.length > 4000) return { ok: false as const, error: "MESSAGE_BODY_TOO_LONG" };
+
+  const conversationId = buildConversationId({
+    landlordId,
+    context: params.context,
+    userId: params.userId,
+  });
+  const now = Date.now();
+
+  await db.collection("conversations").doc(conversationId).set(
+    {
+      landlordId,
+      tenantId: asString(params.context.tenantId),
+      propertyId: asString(params.context.propertyId),
+      unitId: asString(params.context.unitId),
+      applicationId: asString(params.context.applicationId),
+      leaseId: asString(params.context.leaseId),
+      createdAt: FieldValue.serverTimestamp(),
+      lastMessageAt: FieldValue.serverTimestamp(),
+      lastReadAtTenant: FieldValue.serverTimestamp(),
+    },
+    { merge: true }
+  );
+
+  const messageRef = db.collection("messages").doc();
+  await messageRef.set({
+    conversationId,
+    senderRole: "tenant",
+    body,
+    createdAt: FieldValue.serverTimestamp(),
+    createdAtMs: now,
+  });
+
+  await recordTenantEvent({
+    eventType: "tenant_message_sent",
+    entityType: "conversation",
+    entityId: conversationId,
+    createdBy: params.userId,
+    context: {
+      propertyId: params.context.propertyId,
+      rc_prop_id: params.context.rc_prop_id,
+      applicationId: params.context.applicationId,
+      leaseId: params.context.leaseId,
+      tenantId: params.context.tenantId,
+    },
+    payload: {
+      length: body.length,
+    },
+  });
+
+  return {
+    ok: true as const,
+    message: {
+      id: messageRef.id,
+      senderRole: "tenant" as const,
+      body,
+      createdAt: new Date(now).toISOString(),
+      createdAtMs: now,
+    },
+  };
+}
+
+export async function markTenantCommunicationsRead(params: {
+  context: TenancyContext;
+  userId: string;
+}) {
+  const propertyLandlord = await loadPropertyLandlord(params.context.propertyId);
+  const landlordId = propertyLandlord?.landlordId;
+  if (!landlordId) return { ok: false as const, error: "LANDLORD_CONTEXT_MISSING" };
+
+  const conversationId = buildConversationId({
+    landlordId,
+    context: params.context,
+    userId: params.userId,
+  });
+  await db.collection("conversations").doc(conversationId).set(
+    {
+      lastReadAtTenant: FieldValue.serverTimestamp(),
+    },
+    { merge: true }
+  );
+  return { ok: true as const };
+}

--- a/rentchain-api/src/services/tenantPortal/tenantNotificationsService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantNotificationsService.ts
@@ -1,0 +1,186 @@
+import { db } from "../../config/firebase";
+import type { TenancyContext } from "./tenancyContextService";
+import { loadTenantProfileProjection } from "./tenantProfileService";
+
+export type TenantNotificationItem = {
+  id: string;
+  type: "application" | "identity" | "document" | "lease" | "maintenance" | "message" | "invite" | "system";
+  title: string;
+  summary: string;
+  createdAt: string;
+  status: "info" | "success" | "warning";
+  relatedPath: string | null;
+};
+
+function asString(value: unknown): string | null {
+  const next = String(value || "").trim();
+  return next || null;
+}
+
+function toMillis(value: any): number | null {
+  if (!value) return null;
+  if (typeof value === "number") return value;
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+  if (typeof value?.toMillis === "function") return value.toMillis();
+  if (typeof value?.seconds === "number") return value.seconds * 1000;
+  return null;
+}
+
+function toIso(value: any): string {
+  const millis = toMillis(value) || Date.now();
+  return new Date(millis).toISOString();
+}
+
+async function queryDocs(collectionName: string, field: string, value: string | null, limit = 25) {
+  const normalized = asString(value);
+  if (!normalized) return [];
+  try {
+    const snap = await db.collection(collectionName).where(field, "==", normalized).limit(limit).get();
+    return snap.docs || [];
+  } catch {
+    return [];
+  }
+}
+
+export async function listTenantNotificationFeed(params: {
+  context: TenancyContext;
+  userId: string;
+  userEmail?: string | null;
+}) : Promise<TenantNotificationItem[]> {
+  const profile = await loadTenantProfileProjection({
+    context: params.context,
+    userId: params.userId,
+    userEmail: params.userEmail,
+  });
+
+  const items: TenantNotificationItem[] = [];
+  const application = profile.profile.application;
+  const lease = profile.profile.lease;
+  const identity = profile.identity;
+
+  if (application) {
+    items.push({
+      id: `application-${application.applicationId}`,
+      type: "application",
+      title: "Application status updated",
+      summary: application.status ? `Current application status: ${application.status}.` : "Your application is active in the tenant workspace.",
+      createdAt: application.updatedAt || application.createdAt || new Date().toISOString(),
+      status: application.status && /approved|completed/i.test(application.status) ? "success" : "info",
+      relatedPath: "/tenant/application",
+    });
+  }
+
+  if (identity.identityVerification.status !== "verified") {
+    items.push({
+      id: `identity-${params.context.propertyId || params.userId}`,
+      type: "identity",
+      title: "Identity verification needs attention",
+      summary:
+        identity.identityVerification.note ||
+        (identity.identityVerification.status === "pending"
+          ? "Your identity verification is still being processed."
+          : identity.identityVerification.status === "missing"
+          ? "Identity verification has not started yet."
+          : "Identity verification needs a manual review step."),
+      createdAt: identity.identityVerification.updatedAt || new Date().toISOString(),
+      status: identity.identityVerification.status === "needs_review" ? "warning" : "info",
+      relatedPath: "/tenant/profile",
+    });
+  }
+
+  identity.documentChecklist
+    .filter((entry) => entry.status !== "verified")
+    .slice(0, 4)
+    .forEach((entry, index) => {
+      items.push({
+        id: `document-${entry.code}-${index}`,
+        type: "document",
+        title: `${entry.label} is ${entry.status.replace(/_/g, " ")}`,
+        summary: entry.nextStep || "Open your profile to see the current checklist and next steps.",
+        createdAt: new Date().toISOString(),
+        status: entry.status === "needs_review" || entry.status === "missing" ? "warning" : "info",
+        relatedPath: "/tenant/profile",
+      });
+    });
+
+  if (lease) {
+    items.push({
+      id: `lease-${lease.leaseId}`,
+      type: "lease",
+      title: "Lease summary available",
+      summary: lease.status ? `Your lease is currently ${lease.status}.` : "Your lease summary is available in the tenant workspace.",
+      createdAt: lease.startDate || new Date().toISOString(),
+      status: lease.status && /active|current/i.test(lease.status) ? "success" : "info",
+      relatedPath: "/tenant/lease",
+    });
+  }
+
+  if (params.context.tenantId) {
+    const maintenanceDocs = await queryDocs("maintenanceRequests", "tenantId", params.context.tenantId, 10);
+    maintenanceDocs.forEach((doc) => {
+      const data = (doc.data() as any) || {};
+      items.push({
+        id: `maintenance-${doc.id}`,
+        type: "maintenance",
+        title: String(data?.title || "Maintenance request").trim() || "Maintenance request",
+        summary: `Status: ${String(data?.status || "submitted").trim() || "submitted"}`,
+        createdAt: toIso(data?.updatedAt || data?.createdAt),
+        status: /blocked|cancelled|urgent/i.test(String(data?.status || "")) ? "warning" : "info",
+        relatedPath: `/tenant/maintenance/${doc.id}`,
+      });
+    });
+
+    const inviteDocs = await queryDocs("tenancy_invites", "redeemed_by_uid", params.userId, 5);
+    inviteDocs.forEach((doc) => {
+      const data = (doc.data() as any) || {};
+      items.push({
+        id: `invite-${doc.id}`,
+        type: "invite",
+        title: "Invite linked to your workspace",
+        summary: "A tenancy invite was redeemed and linked to your tenant workspace.",
+        createdAt: toIso(data?.redeemed_at || data?.created_at),
+        status: "success",
+        relatedPath: "/tenant/invite/redeem",
+      });
+    });
+  }
+
+  if (params.context.propertyId) {
+    try {
+      const propertySnap = await db.collection("properties").doc(params.context.propertyId).get();
+      const property = propertySnap.exists ? ((propertySnap.data() as any) || {}) : {};
+      const landlordId = asString(property?.landlordId);
+      const conversationId =
+        landlordId && (params.context.tenantId || params.context.applicationId || params.userId)
+          ? `${landlordId}__${params.context.tenantId || params.context.applicationId || params.userId}__${asString(params.context.unitId) || "na"}`
+          : null;
+      if (conversationId) {
+        const messageDocs = await queryDocs("messages", "conversationId", conversationId, 10);
+        messageDocs
+          .map((doc) => ({ id: doc.id, data: (doc.data() as any) || {} }))
+          .filter((entry) => String(entry.data?.senderRole || "").trim().toLowerCase() === "landlord")
+          .slice(0, 4)
+          .forEach((entry) => {
+            items.push({
+              id: `message-${entry.id}`,
+              type: "message",
+              title: "New landlord message",
+              summary: String(entry.data?.body || "").trim().slice(0, 180) || "You have a new message from your landlord.",
+              createdAt: toIso(entry.data?.createdAt || entry.data?.createdAtMs),
+              status: "info",
+              relatedPath: "/tenant/messages",
+            });
+          });
+      }
+    } catch {
+      // Fail closed to the feed items already assembled.
+    }
+  }
+
+  return items
+    .sort((left, right) => Date.parse(right.createdAt) - Date.parse(left.createdAt))
+    .slice(0, 30);
+}

--- a/rentchain-api/src/services/tenantPortal/tenantProfileService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantProfileService.ts
@@ -1,0 +1,350 @@
+import { db } from "../../config/firebase";
+import type { TenancyContext } from "./tenancyContextService";
+import {
+  projectTenantApplication,
+  projectTenantLease,
+  projectTenantProperty,
+} from "./tenantProjectionService";
+
+export type TenantVisibleStatus = "verified" | "pending" | "missing" | "needs_review";
+
+export type TenantProfileProjection = {
+  context: Pick<
+    TenancyContext,
+    "authority" | "propertyId" | "rc_prop_id" | "applicationId" | "leaseId" | "tenantId" | "unitId" | "invitedEmail"
+  >;
+  profile: {
+    displayName: string | null;
+    email: string | null;
+    phone: string | null;
+    authorityLabel: string;
+    property: ReturnType<typeof projectTenantProperty> | null;
+    application: ReturnType<typeof projectTenantApplication> | null;
+    lease: ReturnType<typeof projectTenantLease> | null;
+  };
+  identity: {
+    overallStatus: TenantVisibleStatus;
+    identityVerification: {
+      status: TenantVisibleStatus;
+      label: string;
+      note: string | null;
+      updatedAt: string | null;
+    };
+    documentChecklist: Array<{
+      code: string;
+      label: string;
+      status: TenantVisibleStatus;
+      nextStep: string | null;
+    }>;
+    nextSteps: string[];
+  };
+};
+
+function asString(value: unknown): string | null {
+  const next = String(value || "").trim();
+  return next || null;
+}
+
+function normalizeEmail(value: unknown): string | null {
+  const next = String(value || "").trim().toLowerCase();
+  return next || null;
+}
+
+function toMillis(value: any): number | null {
+  if (!value) return null;
+  if (typeof value === "number") return value;
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+  if (typeof value?.toMillis === "function") return value.toMillis();
+  if (typeof value?.seconds === "number") return value.seconds * 1000;
+  return null;
+}
+
+function toIso(value: any): string | null {
+  const millis = toMillis(value);
+  return millis ? new Date(millis).toISOString() : null;
+}
+
+async function loadDocument(collectionName: string, docId: string | null) {
+  const id = asString(docId);
+  if (!id) return null;
+  try {
+    const snap = await db.collection(collectionName).doc(id).get();
+    if (!snap.exists) return null;
+    return { id: snap.id, data: (snap.data() as any) || {} };
+  } catch {
+    return null;
+  }
+}
+
+async function queryFirst(
+  collectionName: string,
+  field: string,
+  value: string | null,
+  operator: "==" | "array-contains" = "=="
+) {
+  const normalized = asString(value);
+  if (!normalized) return null;
+  try {
+    const snap = await db.collection(collectionName).where(field, operator, normalized).limit(5).get();
+    const doc = snap.docs?.[0];
+    if (!doc) return null;
+    return { id: doc.id, data: (doc.data() as any) || {} };
+  } catch {
+    return null;
+  }
+}
+
+async function loadWorkspaceDocuments(context: TenancyContext) {
+  const property = await loadDocument("properties", context.propertyId);
+
+  let application = await loadDocument("applications", context.applicationId);
+  if (!application && context.tenantId) {
+    application = await queryFirst("applications", "tenantId", context.tenantId);
+  }
+  if (!application && context.invitedEmail) {
+    const match = await queryFirst("applications", "applicantEmail", context.invitedEmail);
+    if (match && String(match.data?.propertyId || "") === String(context.propertyId || "")) {
+      application = match;
+    }
+  }
+  if (!application && context.invitedEmail) {
+    const match = await queryFirst("applications", "email", context.invitedEmail);
+    if (match && String(match.data?.propertyId || "") === String(context.propertyId || "")) {
+      application = match;
+    }
+  }
+
+  let lease = await loadDocument("leases", context.leaseId);
+  if (!lease && context.tenantId) {
+    const match = await queryFirst("leases", "tenantId", context.tenantId);
+    if (match && String(match.data?.propertyId || "") === String(context.propertyId || "")) {
+      lease = match;
+    }
+  }
+
+  let tenant = await loadDocument("tenants", context.tenantId);
+  if (!tenant && context.invitedEmail) {
+    tenant = await queryFirst("tenants", "email", context.invitedEmail);
+  }
+
+  return { property, application, lease, tenant };
+}
+
+function normalizeAuthorityLabel(authority: TenancyContext["authority"]): string {
+  switch (authority) {
+    case "applicant":
+      return "Applicant";
+    case "active_tenant":
+      return "Active tenant";
+    case "invite":
+      return "Invite-linked tenant";
+    default:
+      return "Tenant";
+  }
+}
+
+function titleCaseWords(value: string): string {
+  return value
+    .replace(/[_-]+/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function normalizeChecklist(input: any, nextActions: string[]): TenantProfileProjection["identity"]["documentChecklist"] {
+  const explicitChecklist = Array.isArray(input?.documentChecklist) ? input.documentChecklist : [];
+  if (explicitChecklist.length) {
+    return explicitChecklist
+      .map((entry: any) => {
+        const code = asString(entry?.code) || asString(entry?.id);
+        if (!code) return null;
+        const rawStatus = String(entry?.status || "").trim().toLowerCase();
+        const status: TenantVisibleStatus =
+          rawStatus === "verified" || rawStatus === "complete" || rawStatus === "completed"
+            ? "verified"
+            : rawStatus === "needs_review" || rawStatus === "manual_review_required"
+            ? "needs_review"
+            : rawStatus === "pending" || rawStatus === "uploaded" || rawStatus === "submitted"
+            ? "pending"
+            : "missing";
+        return {
+          code,
+          label: asString(entry?.label) || titleCaseWords(code),
+          status,
+          nextStep: asString(entry?.nextStep),
+        };
+      })
+      .filter((entry: {
+        code: string;
+        label: string;
+        status: TenantVisibleStatus;
+        nextStep: string | null;
+      } | null): entry is {
+        code: string;
+        label: string;
+        status: TenantVisibleStatus;
+        nextStep: string | null;
+      } => Boolean(entry));
+  }
+
+  const missingSteps = Array.isArray(input?.missingSteps)
+    ? input.missingSteps
+        .map((entry: unknown) => asString(entry))
+        .filter((entry: string | null): entry is string => Boolean(entry))
+    : [];
+  const checklist = missingSteps.map((code: string) => ({
+    code,
+    label: titleCaseWords(code),
+    status: "missing" as TenantVisibleStatus,
+    nextStep: nextActions.find((step) => step.toLowerCase().includes(code.toLowerCase())) || null,
+  }));
+
+  const documentRefs = Array.isArray(input?.documentRefs)
+    ? input.documentRefs.length
+    : Array.isArray(input?.documents)
+    ? input.documents.length
+    : 0;
+  if (!checklist.length && documentRefs > 0) {
+    checklist.push({
+      code: "uploaded_documents",
+      label: "Uploaded documents",
+      status: "pending",
+      nextStep: null,
+    });
+  }
+
+  return checklist;
+}
+
+function deriveIdentityStatuses(params: {
+  application: any;
+  screeningRequest: any;
+  screeningResult: any;
+}) {
+  const nextActions = Array.isArray(params.application?.nextActions)
+    ? params.application.nextActions
+        .map((entry: unknown) => asString(entry))
+        .filter((entry: string | null): entry is string => Boolean(entry))
+    : [];
+  const checklist = normalizeChecklist(params.application, nextActions);
+
+  const requestStatus = String(params.screeningRequest?.status || "").trim().toLowerCase();
+  const resultStatus = String(params.screeningResult?.status || "").trim().toLowerCase();
+  const identityVerified = params.screeningResult?.identityVerified === true;
+
+  let verificationStatus: TenantVisibleStatus = "missing";
+  let verificationLabel = "Not started";
+  let verificationNote: string | null = null;
+
+  if (identityVerified || resultStatus === "completed") {
+    verificationStatus = identityVerified ? "verified" : "pending";
+    verificationLabel = identityVerified ? "Verified" : "Completed";
+    verificationNote = identityVerified
+      ? "Your identity verification is complete."
+      : "Verification has completed, but some records may still be updating.";
+  } else if (["manual_review_required", "inconclusive", "failed"].includes(resultStatus) || ["manual_review_required", "failed"].includes(requestStatus)) {
+    verificationStatus = "needs_review";
+    verificationLabel = "Needs attention";
+    verificationNote = "A team member may need to review your verification details.";
+  } else if (
+    ["requested", "consent_pending", "consented", "in_progress", "pending_review"].includes(requestStatus) ||
+    ["pending", "in_progress"].includes(resultStatus)
+  ) {
+    verificationStatus = "pending";
+    verificationLabel = "Pending";
+    verificationNote = "Verification is still in progress.";
+  }
+
+  let documentsStatus: TenantVisibleStatus = "verified";
+  if (checklist.some((entry) => entry.status === "needs_review")) {
+    documentsStatus = "needs_review";
+  } else if (checklist.some((entry) => entry.status === "missing")) {
+    documentsStatus = "missing";
+  } else if (checklist.some((entry) => entry.status === "pending")) {
+    documentsStatus = "pending";
+  }
+
+  const order: Record<TenantVisibleStatus, number> = {
+    verified: 0,
+    pending: 1,
+    missing: 2,
+    needs_review: 3,
+  };
+  const overallStatus = order[verificationStatus] >= order[documentsStatus] ? verificationStatus : documentsStatus;
+
+  return {
+    overallStatus,
+    verificationStatus,
+    verificationLabel,
+    verificationNote,
+    checklist,
+    nextActions,
+  };
+}
+
+export async function loadTenantProfileProjection(params: {
+  context: TenancyContext;
+  userId: string;
+  userEmail?: string | null;
+}) : Promise<TenantProfileProjection> {
+  const { context, userEmail } = params;
+  const { property, application, lease, tenant } = await loadWorkspaceDocuments(context);
+
+  const screeningRequest =
+    (context.tenantId ? await queryFirst("screening_requests", "applicantTenantId", context.tenantId) : null) ||
+    (context.applicationId ? await queryFirst("screening_requests", "rentalApplicationId", context.applicationId) : null);
+
+  let screeningResult: { id: string; data: any } | null = null;
+  const latestResultId = asString(screeningRequest?.data?.latestResultId);
+  if (latestResultId) {
+    screeningResult = await loadDocument("screening_results", latestResultId);
+  }
+
+  const identity = deriveIdentityStatuses({
+    application: application?.data || {},
+    screeningRequest: screeningRequest?.data || {},
+    screeningResult: screeningResult?.data || {},
+  });
+
+  return {
+    context: {
+      authority: context.authority,
+      propertyId: context.propertyId,
+      rc_prop_id: context.rc_prop_id,
+      applicationId: context.applicationId,
+      leaseId: context.leaseId,
+      tenantId: context.tenantId,
+      unitId: context.unitId,
+      invitedEmail: context.invitedEmail,
+    },
+    profile: {
+      displayName:
+        asString(tenant?.data?.fullName) ||
+        asString(tenant?.data?.name) ||
+        asString(application?.data?.applicantName) ||
+        (normalizeEmail(userEmail) ? normalizeEmail(userEmail)!.split("@")[0] : null),
+      email:
+        normalizeEmail(tenant?.data?.email) ||
+        normalizeEmail(application?.data?.applicantEmail) ||
+        normalizeEmail(userEmail) ||
+        context.invitedEmail,
+      phone: asString(tenant?.data?.phone) || asString(application?.data?.phone),
+      authorityLabel: normalizeAuthorityLabel(context.authority),
+      property: property ? projectTenantProperty(property.id, property.data) : null,
+      application: application ? projectTenantApplication(application.id, application.data) : null,
+      lease: lease ? projectTenantLease(lease.id, lease.data) : null,
+    },
+    identity: {
+      overallStatus: identity.overallStatus,
+      identityVerification: {
+        status: identity.verificationStatus,
+        label: identity.verificationLabel,
+        note: identity.verificationNote,
+        updatedAt: toIso(screeningResult?.data?.updatedAt) || toIso(screeningRequest?.data?.updatedAt),
+      },
+      documentChecklist: identity.checklist,
+      nextSteps: identity.nextActions.slice(0, 6),
+    },
+  };
+}

--- a/rentchain-frontend/src/api/tenantCommunicationsApi.ts
+++ b/rentchain-frontend/src/api/tenantCommunicationsApi.ts
@@ -25,6 +25,28 @@ export type TenantCommunicationSummary = {
   unreadTotal: number;
 };
 
+export type TenantThreadMessage = {
+  id: string;
+  senderRole: "tenant" | "landlord";
+  body: string;
+  createdAt: string | null;
+  createdAtMs: number | null;
+};
+
+export type TenantCommunicationsWorkspace = {
+  canSend: boolean;
+  canSendReason: string | null;
+  thread: {
+    id: string;
+    landlordLabel: string;
+    propertyId: string | null;
+    unitId: string | null;
+    unreadCount: number;
+    lastMessageAt: string | null;
+    messages: TenantThreadMessage[];
+  } | null;
+};
+
 export async function getTenantMessages() {
   return tenantApiFetch<{ ok: boolean; items: TenantCommunicationItem[]; unreadCount: number }>(
     "/tenant/messages"
@@ -69,5 +91,24 @@ export async function markTenantScreeningUpdateRead(requestId: string) {
 
 export async function getTenantCommunicationSummary() {
   return tenantApiFetch<TenantCommunicationSummary>("/tenant/communication/summary");
+}
+
+export async function getTenantCommunicationsWorkspace(): Promise<TenantCommunicationsWorkspace> {
+  const res = await tenantApiFetch<{ ok: boolean; data: TenantCommunicationsWorkspace }>("/tenant/communications");
+  return res.data;
+}
+
+export async function sendTenantCommunicationMessage(body: string): Promise<TenantThreadMessage> {
+  const res = await tenantApiFetch<{ ok: boolean; data: TenantThreadMessage }>("/tenant/communications/messages", {
+    method: "POST",
+    body: { body },
+  });
+  return res.data;
+}
+
+export async function markTenantCommunicationsRead(): Promise<void> {
+  await tenantApiFetch<{ ok: boolean }>("/tenant/communications/read", {
+    method: "POST",
+  });
 }
 

--- a/rentchain-frontend/src/api/tenantNotifications.ts
+++ b/rentchain-frontend/src/api/tenantNotifications.ts
@@ -1,0 +1,16 @@
+import { tenantApiFetch } from "./tenantApiFetch";
+
+export type TenantNotificationItem = {
+  id: string;
+  type: "application" | "identity" | "document" | "lease" | "maintenance" | "message" | "invite" | "system";
+  title: string;
+  summary: string;
+  createdAt: string;
+  status: "info" | "success" | "warning";
+  relatedPath: string | null;
+};
+
+export async function getTenantNotifications(): Promise<TenantNotificationItem[]> {
+  const res = await tenantApiFetch<{ ok: boolean; data: TenantNotificationItem[] }>("/tenant/notifications");
+  return Array.isArray(res?.data) ? res.data : [];
+}

--- a/rentchain-frontend/src/api/tenantProfile.ts
+++ b/rentchain-frontend/src/api/tenantProfile.ts
@@ -1,0 +1,69 @@
+import { tenantApiFetch } from "./tenantApiFetch";
+
+export type TenantProfileStatus = "verified" | "pending" | "missing" | "needs_review";
+
+export type TenantProfileData = {
+  context: {
+    authority: "applicant" | "active_tenant" | "invite" | null;
+    propertyId: string | null;
+    rc_prop_id: string | null;
+    applicationId: string | null;
+    leaseId: string | null;
+    tenantId: string | null;
+    unitId: string | null;
+    invitedEmail: string | null;
+  };
+  profile: {
+    displayName: string | null;
+    email: string | null;
+    phone: string | null;
+    authorityLabel: string;
+    property: {
+      propertyId: string;
+      rc_prop_id: string | null;
+      street1: string | null;
+      street2: string | null;
+      city: string | null;
+      province: string | null;
+      postalCode: string | null;
+      features: string[];
+    } | null;
+    application: {
+      applicationId: string;
+      status: string | null;
+      missingSteps: string[];
+      nextActions: string[];
+      createdAt: string | null;
+      updatedAt: string | null;
+    } | null;
+    lease: {
+      leaseId: string;
+      startDate: string | null;
+      endDate: string | null;
+      monthlyRent: number | null;
+      status: string | null;
+      documentUrl: string | null;
+    } | null;
+  };
+  identity: {
+    overallStatus: TenantProfileStatus;
+    identityVerification: {
+      status: TenantProfileStatus;
+      label: string;
+      note: string | null;
+      updatedAt: string | null;
+    };
+    documentChecklist: Array<{
+      code: string;
+      label: string;
+      status: TenantProfileStatus;
+      nextStep: string | null;
+    }>;
+    nextSteps: string[];
+  };
+};
+
+export async function getTenantProfile(): Promise<TenantProfileData> {
+  const res = await tenantApiFetch<{ ok: boolean; data: TenantProfileData }>("/tenant/profile");
+  return res.data;
+}

--- a/rentchain-frontend/src/components/layout/TenantNav.tsx
+++ b/rentchain-frontend/src/components/layout/TenantNav.tsx
@@ -10,12 +10,12 @@ type Props = {
 
 const navItems = [
   { label: "Workspace", to: "/tenant" },
+  { label: "Profile", to: "/tenant/profile" },
   { label: "Application", to: "/tenant/application" },
   { label: "Lease", to: "/tenant/lease" },
   { label: "Maintenance", to: "/tenant/maintenance" },
   { label: "Messages", to: "/tenant/messages" },
-  { label: "Notices", to: "/tenant/notices" },
-  { label: "Account", to: "/tenant/account" },
+  { label: "Feed", to: "/tenant/activity" },
 ];
 
 export const TenantNav: React.FC<Props> = ({ children }) => {

--- a/rentchain-frontend/src/pages/tenant/TenantActivityPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantActivityPage.tsx
@@ -1,25 +1,19 @@
 import React, { useEffect, useState } from "react";
-import { tenantApiFetch } from "../../api/tenantApiFetch";
-import { Card } from "../../components/ui/Ui";
-import { colors, spacing, text as textTokens } from "../../styles/tokens";
-
-type ActivityItem = {
-  id: string;
-  type: "invite" | "lease" | "rent" | "notice" | "system";
-  title: string;
-  description?: string | null;
-  occurredAt: number;
-};
-
-function fmtDate(ts: number | null | undefined): string {
-  if (!ts) return "—";
-  const d = new Date(ts);
-  if (Number.isNaN(d.getTime())) return "—";
-  return d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
-}
+import { Link } from "react-router-dom";
+import { getTenantNotifications, type TenantNotificationItem } from "../../api/tenantNotifications";
+import {
+  TenantEmptyState,
+  TenantErrorState,
+  TenantLoadingState,
+  TenantSurfaceShell,
+  TenantUnauthorizedState,
+  formatDate,
+  prettyStatus,
+} from "./TenantWorkspaceShared";
+import { spacing, text as textTokens } from "../../styles/tokens";
 
 export default function TenantActivityPage() {
-  const [items, setItems] = useState<ActivityItem[]>([]);
+  const [items, setItems] = useState<TenantNotificationItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -29,8 +23,8 @@ export default function TenantActivityPage() {
       setLoading(true);
       setError(null);
       try {
-        const res = await tenantApiFetch<{ ok: boolean; data: ActivityItem[] }>("/tenant/activity");
-        if (!cancelled) setItems(Array.isArray(res?.data) ? res.data : []);
+        const res = await getTenantNotifications();
+        if (!cancelled) setItems(Array.isArray(res) ? res : []);
       } catch (err: any) {
         if (!cancelled) setError(err?.message || "Unable to load activity.");
       } finally {
@@ -43,44 +37,80 @@ export default function TenantActivityPage() {
     };
   }, []);
 
-  return (
-    <Card elevated style={{ padding: spacing.lg }}>
-      <div style={{ marginBottom: spacing.md }}>
-        <h1 style={{ margin: 0, color: textTokens.primary, fontSize: "1.4rem" }}>Activity</h1>
-        <div style={{ marginTop: 6, color: textTokens.muted }}>
-          Recent events for your tenant account.
-        </div>
-      </div>
+  if (loading) {
+    return (
+      <TenantSurfaceShell
+        title="Notifications & Feed"
+        subtitle="Recent tenant-safe updates across your application, profile, communications, and tenancy."
+      >
+        <TenantLoadingState label="Loading your recent feed..." />
+      </TenantSurfaceShell>
+    );
+  }
 
-      {error ? (
-        <div style={{ color: colors.danger }}>{error}</div>
-      ) : loading ? (
-        <div style={{ color: textTokens.muted }}>Loading activity…</div>
-      ) : items.length === 0 ? (
-        <div style={{ color: textTokens.muted }}>No activity available yet.</div>
+  if (error) {
+    const unauthorized = /unauthorized|forbidden|ambiguous/i.test(error);
+    return (
+      <TenantSurfaceShell
+        title="Notifications & Feed"
+        subtitle="Only tenant-safe updates and system-visible events appear here."
+      >
+        {unauthorized ? <TenantUnauthorizedState /> : <TenantErrorState message={error} />}
+      </TenantSurfaceShell>
+    );
+  }
+
+  return (
+    <TenantSurfaceShell
+      title="Notifications & Feed"
+      subtitle="Track the tenant-safe updates that matter most: application progress, identity steps, communications, lease changes, and maintenance."
+    >
+      {items.length === 0 ? (
+        <TenantEmptyState
+          title="No notifications yet"
+          body="Recent updates will appear here once your application, tenancy, or communications begin generating tenant-visible events."
+        />
       ) : (
         <div style={{ display: "grid", gap: spacing.sm }}>
           {items.map((item) => (
             <div
               key={item.id}
               style={{
-                border: `1px solid ${colors.border}`,
+                border: "1px solid rgba(15,23,42,0.08)",
                 borderRadius: 12,
-                background: colors.card,
                 padding: spacing.sm,
+                display: "grid",
+                gap: 8,
               }}
             >
-              <div style={{ fontWeight: 700, color: textTokens.primary }}>{item.title}</div>
-              <div style={{ color: textTokens.muted, fontSize: "0.9rem" }}>
-                {item.type} • {fmtDate(item.occurredAt)}
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, flexWrap: "wrap" }}>
+                <div style={{ fontWeight: 700, color: textTokens.primary }}>{item.title}</div>
+                <div
+                  style={{
+                    padding: "4px 8px",
+                    borderRadius: 999,
+                    fontSize: 12,
+                    fontWeight: 700,
+                    color: item.status === "success" ? "#166534" : item.status === "warning" ? "#9a3412" : "#1d4ed8",
+                    background: item.status === "success" ? "#dcfce7" : item.status === "warning" ? "#ffedd5" : "#dbeafe",
+                  }}
+                >
+                  {prettyStatus(item.type)}
+                </div>
               </div>
-              {item.description ? (
-                <div style={{ marginTop: 6, color: textTokens.secondary }}>{item.description}</div>
-              ) : null}
+              <div style={{ color: textTokens.secondary }}>{item.summary}</div>
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, flexWrap: "wrap" }}>
+                <div style={{ color: textTokens.muted, fontSize: "0.9rem" }}>{formatDate(item.createdAt)}</div>
+                {item.relatedPath ? (
+                  <Link to={item.relatedPath} style={{ fontWeight: 700 }}>
+                    Open
+                  </Link>
+                ) : null}
+              </div>
             </div>
           ))}
         </div>
       )}
-    </Card>
+    </TenantSurfaceShell>
   );
 }

--- a/rentchain-frontend/src/pages/tenant/TenantMessagesCenterPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantMessagesCenterPage.tsx
@@ -1,110 +1,36 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { Link } from "react-router-dom";
-import { Card } from "../../components/ui/Ui";
 import {
-  TenantCommunicationItem,
-  getTenantMessages,
-  markTenantMaintenanceUpdateRead,
-  markTenantMessageRead,
-  markTenantMessagesReadAll,
-  markTenantScreeningUpdateRead,
+  getTenantCommunicationsWorkspace,
+  markTenantCommunicationsRead,
+  sendTenantCommunicationMessage,
 } from "../../api/tenantCommunicationsApi";
 import {
-  TenantScreeningRequest,
-  acceptTenantScreeningConsent,
-  getTenantScreeningStatus,
-  markTenantScreeningViewed,
-  retryTenantScreening,
-  startTenantScreening,
-} from "../../api/tenantScreeningApi";
-import { colors, spacing, text as textTokens } from "../../styles/tokens";
-import { track } from "../../lib/analytics";
-
-type FilterKey = "all" | "unread" | "message" | "maintenance_update" | "screening_update";
-
-const filters: Array<{ key: FilterKey; label: string }> = [
-  { key: "all", label: "All" },
-  { key: "unread", label: "Unread" },
-  { key: "message", label: "Messages" },
-  { key: "maintenance_update", label: "Maintenance" },
-  { key: "screening_update", label: "Screening" },
-];
-
-function fmtDate(value: string): string {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return "—";
-  return date.toLocaleString(undefined, { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" });
-}
-
-function bodyPreview(value: string): string {
-  const clean = String(value || "").trim();
-  if (!clean) return "No additional details.";
-  return clean.length > 180 ? `${clean.slice(0, 179)}…` : clean;
-}
-
-function priorityTone(priority: TenantCommunicationItem["priority"]): string {
-  if (priority === "high") return "#b91c1c";
-  if (priority === "low") return "#1e40af";
-  return "#334155";
-}
-
-function relatedLink(item: TenantCommunicationItem): string | null {
-  if (item.relatedEntityType === "maintenance" && item.relatedEntityId) {
-    return `/tenant/maintenance/${item.relatedEntityId}`;
-  }
-  return null;
-}
-
-function screeningTone(status?: string | null) {
-  switch (status) {
-    case "completed":
-      return { bg: "#dcfce7", color: "#166534", label: "Completed" };
-    case "manual_review_required":
-      return { bg: "#fef3c7", color: "#92400e", label: "Manual review" };
-    case "failed":
-      return { bg: "#fee2e2", color: "#991b1b", label: "Failed" };
-    case "in_progress":
-      return { bg: "#dbeafe", color: "#1d4ed8", label: "In progress" };
-    case "consented":
-      return { bg: "#e0f2fe", color: "#0369a1", label: "Ready to start" };
-    case "consent_pending":
-      return { bg: "#ede9fe", color: "#6d28d9", label: "Consent needed" };
-    default:
-      return { bg: "#e2e8f0", color: "#475569", label: "Requested" };
-  }
-}
-
-function screeningProviderDisclosure(screening?: TenantScreeningRequest | null) {
-  if (screening?.provider && screening.provider !== "manual") {
-    return `RentChain may route this screening through ${screening.provider.replace(/_/g, " ")} once you continue.`;
-  }
-  return "RentChain may route this screening through a secure provider selected at runtime, or move it to manual review if no live provider is active.";
-}
+  TenantEmptyState,
+  TenantErrorState,
+  TenantInfoCard,
+  TenantLoadingState,
+  TenantSurfaceShell,
+  TenantUnauthorizedState,
+} from "./TenantWorkspaceShared";
+import { spacing, text as textTokens } from "../../styles/tokens";
 
 export default function TenantMessagesCenterPage() {
-  const [items, setItems] = useState<TenantCommunicationItem[]>([]);
-  const [screeningById, setScreeningById] = useState<Record<string, TenantScreeningRequest>>({});
-  const [filter, setFilter] = useState<FilterKey>("all");
+  const [workspace, setWorkspace] = useState<Awaited<ReturnType<typeof getTenantCommunicationsWorkspace>> | null>(null);
+  const [composer, setComposer] = useState("");
   const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
-  const [screeningSaving, setScreeningSaving] = useState(false);
+  const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [selectedId, setSelectedId] = useState<string | null>(null);
 
   const load = React.useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      const res = await getTenantMessages();
-      const nextItems = Array.isArray(res?.items) ? res.items : [];
-      setItems(nextItems);
-      setSelectedId((prev) => (prev && nextItems.some((item) => item.id === prev) ? prev : nextItems[0]?.id || null));
-      track("tenant.messages.opened", {
-        count: Array.isArray(res?.items) ? res.items.length : 0,
-        unreadCount: Number(res?.unreadCount || 0),
-      });
+      const res = await getTenantCommunicationsWorkspace();
+      setWorkspace(res);
+      await markTenantCommunicationsRead().catch(() => undefined);
     } catch (err: any) {
       setError(err?.message || "Unable to load messages.");
+      setWorkspace(null);
     } finally {
       setLoading(false);
     }
@@ -114,433 +40,160 @@ export default function TenantMessagesCenterPage() {
     void load();
   }, [load]);
 
-  const unreadCount = useMemo(() => items.filter((item) => !item.read).length, [items]);
+  const thread = workspace?.thread;
+  const messages = useMemo(() => thread?.messages || [], [thread]);
 
-  const filtered = useMemo(() => {
-    if (filter === "all") return items;
-    if (filter === "unread") return items.filter((item) => !item.read);
-    return items.filter((item) => item.type === filter);
-  }, [filter, items]);
-
-  const selected = useMemo(
-    () => filtered.find((item) => item.id === selectedId) || filtered[0] || null,
-    [filtered, selectedId]
-  );
-  const selectedScreening =
-    selected?.relatedEntityType === "screening" && selected.relatedEntityId
-      ? screeningById[selected.relatedEntityId] || null
-      : null;
-
-  useEffect(() => {
-    if (!filtered.length) {
-      if (selectedId !== null) setSelectedId(null);
-      return;
-    }
-    if (!selectedId || !filtered.some((item) => item.id === selectedId)) {
-      setSelectedId(filtered[0].id);
-    }
-  }, [filtered, selectedId]);
-
-  const markOneRead = async (item: TenantCommunicationItem) => {
-    if (item.read) return;
-    try {
-      if (item.type === "message") {
-        await markTenantMessageRead(item.id);
-      } else if (item.type === "maintenance_update") {
-        const requestId = item.relatedEntityId;
-        if (!requestId) return;
-        await markTenantMaintenanceUpdateRead(requestId);
-      } else if (item.type === "screening_update") {
-        const requestId = item.relatedEntityId;
-        if (!requestId) return;
-        await markTenantScreeningUpdateRead(requestId);
-      } else {
-        return;
-      }
-      setItems((prev) => prev.map((x) => (x.id === item.id ? { ...x, read: true } : x)));
-      track("tenant.message.read", { id: item.id, type: item.type });
-    } catch {
-      // Keep UX non-blocking; data refresh can reconcile later.
-    }
-  };
-
-  const loadScreening = React.useCallback(async (requestId: string) => {
-    const res = await getTenantScreeningStatus(requestId);
-    if (res?.screeningRequest) {
-      setScreeningById((prev) => ({ ...prev, [requestId]: res.screeningRequest }));
-      return res.screeningRequest;
-    }
-    return null;
-  }, []);
-
-  const onSelect = (item: TenantCommunicationItem) => {
-    setSelectedId(item.id);
-    void markOneRead(item);
-    if (item.relatedEntityType === "screening" && item.relatedEntityId) {
-      void loadScreening(item.relatedEntityId).then((screening) => {
-        if (!screening?.consent?.viewedAt && screening.status === "consent_pending") {
-          void markTenantScreeningViewed(item.relatedEntityId as string, {
-            providerDisclosure: screeningProviderDisclosure(screening),
-            disclosureVersion: "screening-consent-v1",
-          })
-            .then((res) => {
-              if (res?.screeningRequest) {
-                setScreeningById((prev) => ({ ...prev, [item.relatedEntityId as string]: res.screeningRequest }));
-              }
-            })
-            .catch(() => {
-              // keep panel usable even if view logging fails
-            });
-        }
-      });
-    }
-  };
-
-  const runScreeningAction = async (action: "consent" | "start" | "retry") => {
-    if (!selected?.relatedEntityId) return;
-    setScreeningSaving(true);
+  const handleSend = async () => {
+    const body = composer.trim();
+    if (!body || !workspace?.canSend) return;
+    setSending(true);
     setError(null);
     try {
-      const requestId = selected.relatedEntityId;
-      const response =
-        action === "consent"
-          ? await acceptTenantScreeningConsent(requestId, {
-              providerDisclosure: screeningProviderDisclosure(selectedScreening),
-              disclosureVersion: "screening-consent-v1",
-            })
-          : action === "start"
-          ? await startTenantScreening(requestId)
-          : await retryTenantScreening(requestId);
-      if (response?.screeningRequest) {
-        setScreeningById((prev) => ({ ...prev, [requestId]: response.screeningRequest }));
-      } else {
-        await loadScreening(requestId);
-      }
+      await sendTenantCommunicationMessage(body);
+      setComposer("");
       await load();
     } catch (err: any) {
-      setError(err?.message || "Unable to update screening.");
+      setError(err?.message || "Unable to send your message.");
     } finally {
-      setScreeningSaving(false);
+      setSending(false);
     }
   };
 
-  const markAll = async () => {
-    if (!unreadCount || saving) return;
-    setSaving(true);
-    try {
-      await markTenantMessagesReadAll();
-      setItems((prev) => prev.map((item) => ({ ...item, read: true })));
-      track("tenant.messages.read_all", { count: unreadCount });
-    } catch (err: any) {
-      setError(err?.message || "Unable to mark messages as read.");
-    } finally {
-      setSaving(false);
-    }
-  };
+  if (loading) {
+    return (
+      <TenantSurfaceShell
+        title="Communications"
+        subtitle="Message your landlord through the tenant-safe communications channel linked to your tenancy or application."
+      >
+        <TenantLoadingState label="Loading your communications workspace..." />
+      </TenantSurfaceShell>
+    );
+  }
+
+  if (error && !workspace) {
+    const unauthorized = /unauthorized|forbidden|ambiguous/i.test(error);
+    return (
+      <TenantSurfaceShell
+        title="Communications"
+        subtitle="This view stays scoped to your tenant authority context and never falls back to landlord surfaces."
+      >
+        {unauthorized ? <TenantUnauthorizedState /> : <TenantErrorState message={error} retry={load} />}
+      </TenantSurfaceShell>
+    );
+  }
 
   return (
-    <Card elevated style={{ padding: spacing.lg }}>
-      <div
-        style={{
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "center",
-          gap: spacing.sm,
-          flexWrap: "wrap",
-          marginBottom: spacing.md,
-        }}
-      >
-        <div>
-          <h1 style={{ margin: 0, color: textTokens.primary, fontSize: "1.4rem" }}>
-            Messages, Maintenance & Screening
-          </h1>
-          <div style={{ marginTop: 6, color: textTokens.muted }}>
-            Unread: <strong>{unreadCount}</strong>
+    <TenantSurfaceShell
+      title="Communications"
+      subtitle="Use this bounded thread to communicate with the property side safely. Sending stays disabled when your tenancy context is incomplete."
+    >
+      <TenantInfoCard heading="Thread summary" accent="#1d4ed8">
+        <div style={{ display: "grid", gap: spacing.sm }}>
+          <div style={{ color: textTokens.secondary }}>
+            Contact: <strong>{thread?.landlordLabel || "Landlord"}</strong>
+          </div>
+          <div style={{ color: textTokens.secondary }}>
+            Unread messages: <strong>{thread?.unreadCount || 0}</strong>
+          </div>
+          <div style={{ color: textTokens.secondary }}>
+            Last activity: <strong>{thread?.lastMessageAt ? new Date(thread.lastMessageAt).toLocaleString() : "No messages yet"}</strong>
           </div>
         </div>
-        <button
-          type="button"
-          onClick={() => void markAll()}
-          disabled={!unreadCount || saving}
-          style={{
-            border: `1px solid ${colors.border}`,
-            borderRadius: 10,
-            background: colors.panel,
-            color: textTokens.primary,
-            padding: "8px 12px",
-            cursor: !unreadCount || saving ? "not-allowed" : "pointer",
-            fontWeight: 600,
-          }}
-        >
-          {saving ? "Updating..." : "Mark all as read"}
-        </button>
-      </div>
+      </TenantInfoCard>
 
-      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: spacing.md }}>
-        {filters.map((option) => (
-          <button
-            key={option.key}
-            type="button"
-            onClick={() => setFilter(option.key)}
-            style={{
-              border: `1px solid ${filter === option.key ? "#bfdbfe" : colors.border}`,
-              borderRadius: 999,
-              padding: "6px 12px",
-              background: filter === option.key ? "#dbeafe" : colors.card,
-              color: filter === option.key ? "#1d4ed8" : textTokens.secondary,
-              fontWeight: 600,
-              cursor: "pointer",
-            }}
-          >
-            {option.label}
-          </button>
-        ))}
-      </div>
-
-      {error ? <div style={{ color: colors.danger, marginBottom: spacing.sm }}>{error}</div> : null}
-      {loading ? (
-        <div style={{ color: textTokens.muted }}>Loading messages…</div>
-      ) : filtered.length === 0 ? (
-        <div style={{ color: textTokens.muted }}>No messages, maintenance updates, or screening actions for this filter.</div>
-      ) : (
-        <div
-          style={{
-            display: "grid",
-            gridTemplateColumns: "minmax(280px, 380px) minmax(0, 1fr)",
-            gap: spacing.md,
-          }}
-        >
-          <div style={{ display: "grid", gap: 8 }}>
-            {filtered.map((item) => (
-              <button
-                key={item.id}
-                type="button"
-                onClick={() => void onSelect(item)}
-                style={{
-                  textAlign: "left",
-                  border: `1px solid ${selected?.id === item.id ? "#bfdbfe" : colors.border}`,
-                  borderRadius: 12,
-                  background: selected?.id === item.id ? "#eff6ff" : colors.card,
-                  padding: spacing.sm,
-                  cursor: "pointer",
-                }}
-              >
-                <div style={{ display: "flex", justifyContent: "space-between", gap: 8, marginBottom: 4 }}>
-                  <div style={{ fontWeight: 700, color: textTokens.primary }}>{item.title}</div>
-                  {!item.read ? (
-                    <span style={{ fontSize: 11, color: "#1d4ed8", fontWeight: 700 }}>Unread</span>
-                  ) : (
-                    <span style={{ fontSize: 11, color: textTokens.muted }}>Read</span>
-                  )}
-                </div>
-                <div style={{ color: textTokens.muted, fontSize: "0.9rem", marginBottom: 6 }}>
-                  {item.fromLabel} • {fmtDate(item.createdAt)}
-                </div>
-                <div style={{ color: textTokens.secondary, fontSize: "0.92rem" }}>{bodyPreview(item.body)}</div>
-              </button>
-            ))}
+      {!workspace?.canSend ? (
+        <TenantInfoCard heading="Messaging availability" accent="#b45309">
+          <div style={{ color: textTokens.secondary }}>
+            {workspace?.canSendReason || "Messaging is not available for this workspace yet."}
           </div>
+        </TenantInfoCard>
+      ) : null}
 
-          <div
-            style={{
-              border: `1px solid ${colors.border}`,
-              borderRadius: 12,
-              background: colors.card,
-              padding: spacing.md,
-              minHeight: 280,
-            }}
-          >
-            {selected ? (
-              <div style={{ display: "grid", gap: spacing.sm }}>
-                <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.sm }}>
-                  <div>
-                    <div style={{ fontWeight: 800, fontSize: "1.1rem", color: textTokens.primary }}>
-                      {selected.title}
-                    </div>
-                    <div style={{ color: textTokens.muted, marginTop: 4 }}>
-                      {selected.fromLabel} • {fmtDate(selected.createdAt)}
-                    </div>
-                  </div>
-                  <span
+      {error ? (
+        <TenantErrorState message={error} retry={load} />
+      ) : (
+        <div style={{ display: "grid", gap: spacing.md }}>
+          <TenantInfoCard heading="Conversation" accent="#0f766e">
+            {messages.length ? (
+              <div style={{ display: "grid", gap: 10 }}>
+                {messages.map((message) => (
+                  <div
+                    key={message.id}
                     style={{
-                      alignSelf: "start",
-                      border: `1px solid ${colors.border}`,
-                      borderRadius: 999,
-                      padding: "4px 8px",
-                      fontWeight: 700,
-                      fontSize: 12,
-                      color: priorityTone(selected.priority),
-                      background: colors.panel,
+                      alignSelf: message.senderRole === "tenant" ? "end" : "start",
+                      justifySelf: message.senderRole === "tenant" ? "end" : "start",
+                      maxWidth: "78%",
+                      border: "1px solid rgba(15,23,42,0.08)",
+                      borderRadius: 12,
+                      padding: "10px 12px",
+                      background: message.senderRole === "tenant" ? "#eff6ff" : "#f8fafc",
+                      display: "grid",
+                      gap: 4,
                     }}
                   >
-                    {selected.priority}
-                  </span>
-                </div>
-                <div style={{ color: textTokens.secondary, whiteSpace: "pre-wrap", lineHeight: 1.5 }}>
-                  {selected.body || "No additional details."}
-                </div>
-                {selected.type === "screening_update" && selected.relatedEntityId ? (
-                  selectedScreening ? (
-                    <div
-                      style={{
-                        border: `1px solid ${colors.border}`,
-                        borderRadius: 12,
-                        background: colors.panel,
-                        padding: spacing.sm,
-                        display: "grid",
-                        gap: 10,
-                      }}
-                    >
-                      <div style={{ display: "flex", justifyContent: "space-between", gap: 8, flexWrap: "wrap" }}>
-                        <div style={{ display: "grid", gap: 4 }}>
-                          <div style={{ fontWeight: 700, color: textTokens.primary }}>Screening summary</div>
-                          <div style={{ color: textTokens.muted, fontSize: "0.9rem" }}>
-                            {selectedScreening.applicantName || "Applicant"}
-                            {selectedScreening.propertyLabel ? ` • ${selectedScreening.propertyLabel}` : ""}
-                            {selectedScreening.unitLabel ? ` • Unit ${selectedScreening.unitLabel}` : ""}
-                          </div>
-                        </div>
-                        <span
-                          style={{
-                            alignSelf: "start",
-                            borderRadius: 999,
-                            padding: "4px 8px",
-                            fontWeight: 700,
-                            fontSize: 12,
-                            background: screeningTone(selectedScreening.status).bg,
-                            color: screeningTone(selectedScreening.status).color,
-                          }}
-                        >
-                          {screeningTone(selectedScreening.status).label}
-                        </span>
-                      </div>
-                      <div style={{ display: "grid", gap: 6, color: textTokens.secondary, fontSize: "0.92rem" }}>
-                        <div>Package: {selectedScreening.packageType || "standard"}</div>
-                        <div>Provider: {selectedScreening.provider ? selectedScreening.provider.replace(/_/g, " ") : "runtime selected"}</div>
-                        <div>Requested: {selectedScreening.requestedAt ? fmtDate(new Date(selectedScreening.requestedAt).toISOString()) : "—"}</div>
-                        <div>{selectedScreening.summary.summaryResult}</div>
-                      </div>
-                      <div
-                        style={{
-                          border: `1px solid ${colors.border}`,
-                          borderRadius: 10,
-                          background: colors.card,
-                          padding: "10px 12px",
-                          color: textTokens.secondary,
-                          lineHeight: 1.5,
-                        }}
-                      >
-                        <div style={{ fontWeight: 700, color: textTokens.primary, marginBottom: 6 }}>Consent disclosure</div>
-                        <div>
-                          RentChain will not start screening until you accept consent. {screeningProviderDisclosure(selectedScreening)}
-                        </div>
-                      </div>
-                      <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
-                        {selectedScreening.status === "consent_pending" ? (
-                          <button
-                            type="button"
-                            onClick={() => void runScreeningAction("consent")}
-                            disabled={screeningSaving}
-                            style={{
-                              border: `1px solid ${colors.border}`,
-                              borderRadius: 10,
-                              background: "#dbeafe",
-                              color: "#1d4ed8",
-                              padding: "8px 12px",
-                              cursor: screeningSaving ? "not-allowed" : "pointer",
-                              fontWeight: 700,
-                            }}
-                          >
-                            {screeningSaving ? "Saving..." : "Accept consent"}
-                          </button>
-                        ) : null}
-                        {(selectedScreening.status === "consented" || selectedScreening.status === "requested") && !selectedScreening.session ? (
-                          <button
-                            type="button"
-                            onClick={() => void runScreeningAction("start")}
-                            disabled={screeningSaving}
-                            style={{
-                              border: `1px solid ${colors.border}`,
-                              borderRadius: 10,
-                              background: "#dcfce7",
-                              color: "#166534",
-                              padding: "8px 12px",
-                              cursor: screeningSaving ? "not-allowed" : "pointer",
-                              fontWeight: 700,
-                            }}
-                          >
-                            {screeningSaving ? "Starting..." : "Start screening"}
-                          </button>
-                        ) : null}
-                        {(selectedScreening.status === "failed" || selectedScreening.status === "manual_review_required") ? (
-                          <button
-                            type="button"
-                            onClick={() => void runScreeningAction("retry")}
-                            disabled={screeningSaving}
-                            style={{
-                              border: `1px solid ${colors.border}`,
-                              borderRadius: 10,
-                              background: colors.card,
-                              color: textTokens.primary,
-                              padding: "8px 12px",
-                              cursor: screeningSaving ? "not-allowed" : "pointer",
-                              fontWeight: 700,
-                            }}
-                          >
-                            {screeningSaving ? "Retrying..." : "Retry screening"}
-                          </button>
-                        ) : null}
-                      </div>
+                    <div style={{ fontSize: 12, color: textTokens.muted }}>
+                      {message.senderRole === "tenant" ? "You" : thread?.landlordLabel || "Landlord"} •{" "}
+                      {message.createdAt ? new Date(message.createdAt).toLocaleString() : "—"}
                     </div>
-                  ) : (
-                    <div style={{ color: textTokens.muted }}>Loading screening details…</div>
-                  )
-                ) : null}
-                <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
-                  {!selected.read ? (
-                    <button
-                      type="button"
-                      onClick={() => void markOneRead(selected)}
-                      style={{
-                        border: `1px solid ${colors.border}`,
-                        borderRadius: 10,
-                        background: colors.panel,
-                        color: textTokens.primary,
-                        padding: "7px 11px",
-                        cursor: "pointer",
-                        fontWeight: 600,
-                      }}
-                    >
-                      Mark as read
-                    </button>
-                  ) : null}
-                  {relatedLink(selected) ? (
-                    <Link
-                      to={relatedLink(selected) || "#"}
-                      style={{
-                        border: `1px solid ${colors.border}`,
-                        borderRadius: 10,
-                        background: colors.card,
-                        color: textTokens.primary,
-                        padding: "7px 11px",
-                        textDecoration: "none",
-                        fontWeight: 600,
-                      }}
-                    >
-                      Open related item
-                    </Link>
-                  ) : null}
-                </div>
+                    <div style={{ color: textTokens.primary, whiteSpace: "pre-wrap", lineHeight: 1.6 }}>
+                      {message.body}
+                    </div>
+                  </div>
+                ))}
               </div>
             ) : (
-              <div style={{ color: textTokens.muted }}>Select an item to view full details.</div>
+              <TenantEmptyState
+                title="No messages yet"
+                body="Once you or your landlord start a conversation, the thread will appear here."
+              />
             )}
-          </div>
+          </TenantInfoCard>
+
+          <TenantInfoCard heading="Send a message" accent="#7c3aed">
+            <div style={{ display: "grid", gap: spacing.sm }}>
+              <textarea
+                aria-label="Compose message"
+                value={composer}
+                onChange={(event) => setComposer(event.target.value)}
+                disabled={!workspace?.canSend || sending}
+                placeholder={
+                  workspace?.canSend
+                    ? "Write a message for your landlord"
+                    : "Messaging is disabled until your authority context is active."
+                }
+                style={{
+                  minHeight: 110,
+                  resize: "vertical",
+                  borderRadius: 12,
+                  border: "1px solid rgba(15,23,42,0.12)",
+                  padding: "12px 14px",
+                }}
+              />
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
+                <div style={{ color: textTokens.muted, fontSize: "0.9rem" }}>
+                  Messages are limited to your current tenancy or application context.
+                </div>
+                <button
+                  type="button"
+                  onClick={() => void handleSend()}
+                  disabled={!composer.trim() || !workspace?.canSend || sending}
+                  style={{
+                    padding: "10px 14px",
+                    borderRadius: 10,
+                    border: "1px solid rgba(15,23,42,0.08)",
+                    background: !composer.trim() || !workspace?.canSend || sending ? "#e2e8f0" : "#0f766e",
+                    color: !composer.trim() || !workspace?.canSend || sending ? "#64748b" : "#fff",
+                    fontWeight: 700,
+                    cursor: !composer.trim() || !workspace?.canSend || sending ? "not-allowed" : "pointer",
+                  }}
+                >
+                  {sending ? "Sending..." : "Send message"}
+                </button>
+              </div>
+            </div>
+          </TenantInfoCard>
         </div>
       )}
-    </Card>
+    </TenantSurfaceShell>
   );
 }
-
-
-

--- a/rentchain-frontend/src/pages/tenant/TenantProfileCommunicationsPages.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantProfileCommunicationsPages.test.tsx
@@ -1,0 +1,214 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import TenantProfilePage from "./TenantProfilePage";
+import TenantMessagesCenterPage from "./TenantMessagesCenterPage";
+import TenantActivityPage from "./TenantActivityPage";
+import { TenantNav } from "../../components/layout/TenantNav";
+
+const tenantProfileApi = vi.hoisted(() => ({
+  getTenantProfile: vi.fn(),
+}));
+
+const tenantCommunicationsApi = vi.hoisted(() => ({
+  getTenantCommunicationSummary: vi.fn(),
+  getTenantCommunicationsWorkspace: vi.fn(),
+  sendTenantCommunicationMessage: vi.fn(),
+  markTenantCommunicationsRead: vi.fn(),
+}));
+
+const tenantNotificationsApi = vi.hoisted(() => ({
+  getTenantNotifications: vi.fn(),
+}));
+
+const tenantPortalApi = vi.hoisted(() => ({
+  getTenantWorkspace: vi.fn(),
+}));
+
+vi.mock("../../api/tenantProfile", () => tenantProfileApi);
+vi.mock("../../api/tenantCommunicationsApi", () => tenantCommunicationsApi);
+vi.mock("../../api/tenantNotifications", () => tenantNotificationsApi);
+vi.mock("../../api/tenantPortal", () => tenantPortalApi);
+
+describe("tenant profile and communications pages", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    tenantPortalApi.getTenantWorkspace.mockResolvedValue({
+      context: {
+        authority: "active_tenant",
+        propertyId: "prop-1",
+        rc_prop_id: "rc-prop-1",
+        applicationId: "app-1",
+        leaseId: "lease-1",
+        tenantId: "tenant-1",
+        unitId: "unit-2",
+        invitedEmail: "tenant@example.com",
+      },
+    });
+    tenantCommunicationsApi.getTenantCommunicationSummary.mockResolvedValue({
+      unreadMessages: 1,
+      unreadNotices: 0,
+      unreadScreeningUpdates: 0,
+    });
+  });
+
+  it("tenant nav integrates profile and feed links coherently", async () => {
+    render(
+      <MemoryRouter>
+        <TenantNav>
+          <div>Tenant content</div>
+        </TenantNav>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/RentChain Tenant Portal/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Profile/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Feed/i })).toBeInTheDocument();
+  });
+
+  it("tenant profile page renders safe projected profile data and identity states", async () => {
+    tenantProfileApi.getTenantProfile.mockResolvedValue({
+      context: { authority: "active_tenant" },
+      profile: {
+        displayName: "Taylor Tenant",
+        email: "tenant@example.com",
+        phone: "902-555-0100",
+        authorityLabel: "Active tenant",
+        property: {
+          street1: "123 Main St",
+          street2: "Unit 4",
+          city: "Halifax",
+          province: "NS",
+        },
+        application: { status: "submitted" },
+        lease: { status: "active", monthlyRent: 1800, startDate: "2026-02-01", endDate: "2027-01-31", documentUrl: null },
+      },
+      identity: {
+        overallStatus: "pending",
+        identityVerification: {
+          status: "pending",
+          label: "Pending",
+          note: "Verification is still in progress.",
+          updatedAt: "2026-01-05T00:00:00.000Z",
+        },
+        documentChecklist: [{ code: "upload_id", label: "Upload Id", status: "missing", nextStep: "Upload government id" }],
+        nextSteps: ["Upload government id"],
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <TenantProfilePage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Tenant Profile/i)).toBeInTheDocument();
+    expect(screen.getByText(/Taylor Tenant/i)).toBeInTheDocument();
+    expect(screen.getByText(/Verification is still in progress/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Upload government id/i).length).toBeGreaterThan(0);
+  });
+
+  it("communications page handles empty state and compose/send success", async () => {
+    tenantCommunicationsApi.getTenantCommunicationsWorkspace.mockResolvedValue({
+      canSend: true,
+      canSendReason: null,
+      thread: {
+        id: "thread-1",
+        landlordLabel: "Landlord",
+        unreadCount: 0,
+        lastMessageAt: null,
+        propertyId: "prop-1",
+        unitId: "unit-2",
+        messages: [],
+      },
+    });
+    tenantCommunicationsApi.markTenantCommunicationsRead.mockResolvedValue(undefined);
+    tenantCommunicationsApi.sendTenantCommunicationMessage.mockResolvedValue({
+      id: "msg-1",
+      senderRole: "tenant",
+      body: "Hello there",
+      createdAt: "2026-01-06T00:00:00.000Z",
+      createdAtMs: 1234,
+    });
+
+    render(
+      <MemoryRouter>
+        <TenantMessagesCenterPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Once you or your landlord start a conversation/i)).toBeInTheDocument();
+    fireEvent.change(screen.getByRole("textbox", { name: /Compose message/i }), {
+      target: { value: "Hello there" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Send message/i }));
+    expect(tenantCommunicationsApi.sendTenantCommunicationMessage).toHaveBeenCalledWith("Hello there");
+  });
+
+  it("communications page handles send failure safely", async () => {
+    tenantCommunicationsApi.getTenantCommunicationsWorkspace.mockResolvedValue({
+      canSend: true,
+      canSendReason: null,
+      thread: {
+        id: "thread-1",
+        landlordLabel: "Landlord",
+        unreadCount: 0,
+        lastMessageAt: null,
+        propertyId: "prop-1",
+        unitId: "unit-2",
+        messages: [],
+      },
+    });
+    tenantCommunicationsApi.markTenantCommunicationsRead.mockResolvedValue(undefined);
+    tenantCommunicationsApi.sendTenantCommunicationMessage.mockRejectedValue(new Error("Send failed"));
+
+    render(
+      <MemoryRouter>
+        <TenantMessagesCenterPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Once you or your landlord start a conversation/i)).toBeInTheDocument();
+    fireEvent.change(screen.getByRole("textbox", { name: /Compose message/i }), {
+      target: { value: "Hello there" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Send message/i }));
+    expect(await screen.findByText(/Send failed/i)).toBeInTheDocument();
+  });
+
+  it("notifications page renders safe feed items", async () => {
+    tenantNotificationsApi.getTenantNotifications.mockResolvedValue([
+      {
+        id: "feed-1",
+        type: "application",
+        title: "Application status updated",
+        summary: "Current application status: submitted.",
+        createdAt: "2026-01-05T00:00:00.000Z",
+        status: "info",
+        relatedPath: "/tenant/application",
+      },
+    ]);
+
+    render(
+      <MemoryRouter>
+        <TenantActivityPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Notifications & Feed/i)).toBeInTheDocument();
+    expect(screen.getByText(/Application status updated/i)).toBeInTheDocument();
+  });
+
+  it("unauthorized profile state renders safely", async () => {
+    tenantProfileApi.getTenantProfile.mockRejectedValue({ message: "FORBIDDEN" });
+    render(
+      <MemoryRouter>
+        <TenantProfilePage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Access unavailable/i)).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/tenant/TenantProfilePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantProfilePage.tsx
@@ -1,44 +1,34 @@
 import React, { useEffect, useState } from "react";
-import { tenantApiFetch } from "../../api/tenantApiFetch";
-import { Card } from "../../components/ui/Ui";
-import { colors, spacing, text as textTokens } from "../../styles/tokens";
+import { getTenantProfile, type TenantProfileStatus } from "../../api/tenantProfile";
+import {
+  TenantEmptyState,
+  TenantErrorState,
+  TenantInfoCard,
+  TenantKeyValueGrid,
+  TenantLoadingState,
+  TenantSurfaceShell,
+  TenantUnauthorizedState,
+  formatDate,
+  formatMoney,
+  prettyStatus,
+} from "./TenantWorkspaceShared";
+import { spacing, text as textTokens } from "../../styles/tokens";
 
-type TenantMeResponse = {
-  ok: boolean;
-  data?: {
-    tenant?: {
-      name?: string | null;
-      email?: string | null;
-      shortId?: string | null;
-    };
-    property?: { name?: string | null };
-    unit?: { label?: string | null };
-    lease?: { startDate?: number | null; endDate?: number | null };
-  };
-};
-
-function fmtDate(ts?: number | null): string {
-  if (!ts) return "—";
-  const d = new Date(ts);
-  if (Number.isNaN(d.getTime())) return "—";
-  return d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+function statusTone(status: TenantProfileStatus): { label: string; color: string; background: string } {
+  switch (status) {
+    case "verified":
+      return { label: "Verified", color: "#166534", background: "#dcfce7" };
+    case "pending":
+      return { label: "Pending", color: "#1d4ed8", background: "#dbeafe" };
+    case "needs_review":
+      return { label: "Needs review", color: "#9a3412", background: "#ffedd5" };
+    default:
+      return { label: "Missing", color: "#991b1b", background: "#fee2e2" };
+  }
 }
-
-function valueOrDash(value?: string | null): string {
-  const trimmed = String(value || "").trim();
-  return trimmed || "—";
-}
-
-const rowStyle: React.CSSProperties = {
-  display: "grid",
-  gridTemplateColumns: "200px 1fr",
-  gap: spacing.sm,
-  padding: `${spacing.xs} 0`,
-  borderBottom: `1px solid ${colors.border}`,
-};
 
 export default function TenantProfilePage() {
-  const [data, setData] = useState<TenantMeResponse["data"] | null>(null);
+  const [data, setData] = useState<Awaited<ReturnType<typeof getTenantProfile>> | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -48,8 +38,8 @@ export default function TenantProfilePage() {
       setLoading(true);
       setError(null);
       try {
-        const res = await tenantApiFetch<TenantMeResponse>("/tenant/me");
-        if (!cancelled) setData(res?.data || null);
+        const res = await getTenantProfile();
+        if (!cancelled) setData(res);
       } catch (err: any) {
         if (!cancelled) setError(err?.message || "Unable to load profile information.");
       } finally {
@@ -62,65 +52,168 @@ export default function TenantProfilePage() {
     };
   }, []);
 
+  if (loading) {
+    return (
+      <TenantSurfaceShell
+        title="Tenant Profile"
+        subtitle="Your profile and identity checklist are shown from tenant-safe projections only."
+      >
+        <TenantLoadingState label="Loading your profile and identity status..." />
+      </TenantSurfaceShell>
+    );
+  }
+
+  if (error) {
+    const unauthorized = /unauthorized|forbidden|ambiguous/i.test(error);
+    return (
+      <TenantSurfaceShell
+        title="Tenant Profile"
+        subtitle="This page reflects your tenancy context, profile basics, and document visibility."
+      >
+        {unauthorized ? <TenantUnauthorizedState /> : <TenantErrorState message={error} />}
+      </TenantSurfaceShell>
+    );
+  }
+
+  const identityTone = statusTone(data?.identity?.overallStatus || "missing");
+  const verificationTone = statusTone(data?.identity?.identityVerification?.status || "missing");
+  const propertyAddress = [
+    data?.profile?.property?.street1,
+    data?.profile?.property?.street2,
+    data?.profile?.property?.city,
+    data?.profile?.property?.province,
+  ]
+    .filter(Boolean)
+    .join(", ");
+
   return (
-    <Card elevated style={{ padding: spacing.lg }}>
-      <div style={{ marginBottom: spacing.md }}>
-        <h1 style={{ margin: 0, color: textTokens.primary, fontSize: "1.4rem" }}>Profile Information</h1>
-        <div style={{ marginTop: 6, color: textTokens.muted }}>
-          Account and lease details for your tenant profile.
-        </div>
+    <TenantSurfaceShell
+      title="Tenant Profile"
+      subtitle="Review your tenant-safe profile details, identity progress, and the next steps still linked to your tenancy or application."
+    >
+      <TenantInfoCard heading="Profile Summary" accent="#0f766e">
+        <TenantKeyValueGrid
+          rows={[
+            { label: "Name", value: data?.profile?.displayName || "—" },
+            { label: "Email", value: data?.profile?.email || "—" },
+            { label: "Phone", value: data?.profile?.phone || "—" },
+            { label: "Access", value: data?.profile?.authorityLabel || "Tenant" },
+            { label: "Property", value: propertyAddress || "No property linked yet" },
+            { label: "Lease status", value: prettyStatus(data?.profile?.lease?.status) },
+          ]}
+        />
+      </TenantInfoCard>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
+          gap: spacing.md,
+        }}
+      >
+        <TenantInfoCard heading="Identity status" accent="#1d4ed8">
+          <div style={{ display: "grid", gap: spacing.sm }}>
+            <div
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                width: "fit-content",
+                padding: "6px 10px",
+                borderRadius: 999,
+                fontWeight: 700,
+                color: identityTone.color,
+                background: identityTone.background,
+              }}
+            >
+              {identityTone.label}
+            </div>
+            <div style={{ color: textTokens.secondary }}>
+              Verification: <strong>{verificationTone.label}</strong>
+            </div>
+            <div style={{ color: textTokens.secondary }}>
+              {data?.identity?.identityVerification?.note || "Open next steps below if anything is still pending."}
+            </div>
+            <div style={{ color: textTokens.muted }}>
+              Updated: {formatDate(data?.identity?.identityVerification?.updatedAt)}
+            </div>
+          </div>
+        </TenantInfoCard>
+
+        <TenantInfoCard heading="Lease & application" accent="#7c3aed">
+          <TenantKeyValueGrid
+            rows={[
+              { label: "Application", value: prettyStatus(data?.profile?.application?.status) },
+              { label: "Lease", value: prettyStatus(data?.profile?.lease?.status) },
+              { label: "Rent", value: formatMoney(data?.profile?.lease?.monthlyRent) },
+              { label: "Lease start", value: formatDate(data?.profile?.lease?.startDate) },
+              { label: "Lease end", value: formatDate(data?.profile?.lease?.endDate) },
+              {
+                label: "Lease document",
+                value: data?.profile?.lease?.documentUrl ? "Available" : "Not shared yet",
+              },
+            ]}
+          />
+        </TenantInfoCard>
       </div>
 
-      {error ? (
-        <div style={{ color: colors.danger }}>{error}</div>
-      ) : loading ? (
-        <div style={{ color: textTokens.muted }}>Loading profile…</div>
-      ) : (
-        <div style={{ display: "grid", gap: 0 }}>
-          <div style={rowStyle}>
-            <div style={{ color: textTokens.muted }}>Full Name</div>
-            <div style={{ color: textTokens.primary, fontWeight: 600 }}>{valueOrDash(data?.tenant?.name)}</div>
+      <TenantInfoCard heading="Document checklist" accent="#b45309">
+        {data?.identity?.documentChecklist?.length ? (
+          <div style={{ display: "grid", gap: spacing.sm }}>
+            {data.identity.documentChecklist.map((item) => {
+              const tone = statusTone(item.status);
+              return (
+                <div
+                  key={item.code}
+                  style={{
+                    display: "grid",
+                    gap: 6,
+                    border: "1px solid rgba(15,23,42,0.08)",
+                    borderRadius: 12,
+                    padding: "12px 14px",
+                  }}
+                >
+                  <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, flexWrap: "wrap" }}>
+                    <div style={{ fontWeight: 700, color: textTokens.primary }}>{item.label}</div>
+                    <div
+                      style={{
+                        padding: "4px 8px",
+                        borderRadius: 999,
+                        fontSize: 12,
+                        fontWeight: 700,
+                        color: tone.color,
+                        background: tone.background,
+                      }}
+                    >
+                      {tone.label}
+                    </div>
+                  </div>
+                  {item.nextStep ? <div style={{ color: textTokens.secondary }}>{item.nextStep}</div> : null}
+                </div>
+              );
+            })}
           </div>
-          <div style={rowStyle}>
-            <div style={{ color: textTokens.muted }}>Email</div>
-            <div style={{ color: textTokens.primary, fontWeight: 600 }}>{valueOrDash(data?.tenant?.email)}</div>
-          </div>
-          <div style={rowStyle}>
-            <div style={{ color: textTokens.muted }}>Lease Property</div>
-            <div style={{ color: textTokens.primary, fontWeight: 600 }}>{valueOrDash(data?.property?.name)}</div>
-          </div>
-          <div style={rowStyle}>
-            <div style={{ color: textTokens.muted }}>Unit</div>
-            <div style={{ color: textTokens.primary, fontWeight: 600 }}>{valueOrDash(data?.unit?.label)}</div>
-          </div>
-          <div style={rowStyle}>
-            <div style={{ color: textTokens.muted }}>Lease Start</div>
-            <div style={{ color: textTokens.primary, fontWeight: 600 }}>{fmtDate(data?.lease?.startDate)}</div>
-          </div>
-          <div style={{ ...rowStyle, borderBottom: "none" }}>
-            <div style={{ color: textTokens.muted }}>Lease End</div>
-            <div style={{ color: textTokens.primary, fontWeight: 600 }}>{fmtDate(data?.lease?.endDate)}</div>
-          </div>
-        </div>
-      )}
+        ) : (
+          <TenantEmptyState
+            title="No document checklist yet"
+            body="When documents or identity steps are linked to your application or lease, they will appear here in a tenant-safe format."
+          />
+        )}
+      </TenantInfoCard>
 
-      <div style={{ marginTop: spacing.md }}>
-        <button
-          type="button"
-          disabled
-          style={{
-            border: `1px solid ${colors.border}`,
-            borderRadius: 10,
-            background: colors.panel,
-            color: textTokens.muted,
-            padding: "8px 12px",
-            cursor: "not-allowed",
-            fontWeight: 600,
-          }}
-        >
-          Edit Profile (Coming soon)
-        </button>
-      </div>
-    </Card>
+      <TenantInfoCard heading="Next steps" accent="#0891b2">
+        {data?.identity?.nextSteps?.length ? (
+          <div style={{ display: "grid", gap: 8 }}>
+            {data.identity.nextSteps.map((step) => (
+              <div key={step} style={{ color: textTokens.secondary }}>
+                {step}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div style={{ color: textTokens.muted }}>No pending next steps right now.</div>
+        )}
+      </TenantInfoCard>
+    </TenantSurfaceShell>
   );
 }


### PR DESCRIPTION
Summary
Extend Tenant Portal with profile, identity status, communications, and notifications/feed surfaces
Build the first tenant-facing interaction layer on top of the existing tenant foundation and workspace shell
Maintain strict tenant-safe projection model without introducing a separate tenant source-of-truth
Changes
Backend
Added tenant profile projection service and route:
/api/tenant/profile
Added tenant-safe communications endpoints:
/api/tenant/communications
/api/tenant/communications/messages
/api/tenant/communications/read
Added tenant-safe notifications/feed:
/api/tenant/notifications
/api/tenant/activity (compatibility)
Added tenant-safe identity/document aggregation:
high-level statuses (verified, pending, missing, needs_review)
document checklist + next steps
Frontend
Added tenant profile page:
/tenant/profile
Added communications center:
/tenant/messages
Added notifications/feed surface:
/tenant/activity
Updated tenant navigation:
profile and feed prioritized
older routes preserved but deprioritized
Added API bindings:
tenantProfile.ts
tenantCommunicationsApi.ts
tenantNotifications.ts
UX Improvements
tenant workspace now answers:
who am I?
what’s verified?
what’s missing?
what changed?
how do I communicate?
Validation
 Backend targeted tests passed
 Backend build passed
 Frontend targeted tests passed
 Frontend build passed