### PR TITLE
feat: add risk agent v1

### DIFF
--- a/docs/risk-agent-v1.md
+++ b/docs/risk-agent-v1.md
@@ -1,0 +1,165 @@
+# Risk Agent v1
+
+## Purpose
+
+Risk Agent v1 is RentChain's first deterministic application and tenancy risk evaluation layer. It converts existing canonical platform signals into a structured, explainable risk result for landlord and admin review workflows.
+
+This version is intentionally:
+
+- deterministic
+- auditable
+- machine-readable
+- non-mutating
+
+It does not auto-approve, auto-decline, or change tenant, application, or lease state.
+
+## What It Uses
+
+Risk Agent v1 evaluates only signals already available in canonical backend data. The current application-focused input set includes:
+
+- monthly rent
+- monthly income
+- income-to-rent ratio
+- identity verification status
+- document completeness status
+- employment duration
+- co-tenant count
+- application completeness
+- payment history proxy when linked tenant/payment data exists
+- lease/application consistency when a linked lease exists
+
+Missing signals do not trigger hidden inference. They reduce confidence and may move the result to `insufficient_data`.
+
+## Score Model
+
+Risk Agent v1 uses:
+
+- score range `0-100`
+- higher score = lower risk / stronger file
+- grade bands:
+  - `A` = 85-100
+  - `B` = 70-84
+  - `C` = 55-69
+  - `D` = 40-54
+  - `E` = 0-39
+
+The engine starts from a neutral baseline and applies explicit positive or negative factors.
+
+Examples:
+
+- strong income-to-rent coverage improves the score
+- verified identity improves the score
+- missing documents lower the score
+- incomplete application lowers the score
+- short employment history lowers the score
+- lease/application conflicts trigger manual review behavior
+
+## Status Model
+
+Risk Agent v1 returns one of:
+
+- `completed`
+- `insufficient_data`
+- `manual_review_required`
+
+Rules:
+
+- `completed` when the engine has enough core signals and no deterministic blocker
+- `insufficient_data` when too many core inputs are missing
+- `manual_review_required` when deterministic conflict or review-only conditions are present, such as lease/application inconsistency or identity/document review states
+
+## Confidence Model
+
+Confidence is deterministic and documentation-based. It increases when more core signals are present and consistent. It decreases when:
+
+- monthly income or rent is missing
+- identity or document status is unknown
+- employment history is missing
+- application completeness cannot be determined
+- linked lease/application context conflicts
+
+Confidence is not an ML probability. It is a coverage and consistency indicator.
+
+## Output Contract
+
+Each evaluation returns structured fields including:
+
+- `version`
+- `score`
+- `grade`
+- `confidence`
+- `confidenceBand`
+- `status`
+- `factors`
+- `flags`
+- `recommendations`
+- `inputs`
+- `createdAt`
+
+## Persistence
+
+Risk Agent v1 writes to dedicated collections:
+
+- `risk_agent_runs`
+  - append-only evaluation runs
+- `risk_agent_latest`
+  - latest snapshot per evaluated entity
+
+Current entity support:
+
+- `application`
+
+Each stored run includes:
+
+- application id
+- landlord id
+- property id
+- tenant id when available
+- lease id when available
+- review summary snapshot
+- structured factors, flags, recommendations
+- version and timestamp
+
+## Access Surface
+
+Risk Agent v1 is exposed only to landlord/admin-safe backend routes:
+
+- `POST /api/risk-agent/applications/:id/evaluate`
+- `GET /api/risk-agent/applications/:id/latest`
+
+Access rules:
+
+- landlord can only access their own application
+- admin can access any application
+- no tenant-facing route exposes internal risk reasoning in v1
+
+## What It Does Not Do
+
+Risk Agent v1 does not:
+
+- use LLM reasoning
+- use opaque ML scoring
+- auto-approve or auto-decline applications
+- mutate tenant/application/lease state
+- expose risk reasoning to tenant routes
+- store raw sensitive document payloads
+
+## How To Interpret It
+
+Landlords and admins should treat Risk Agent v1 as a structured decision-support layer, not a final decision maker.
+
+Use it to answer:
+
+- what factors are currently increasing or lowering confidence in this file
+- what should be reviewed next
+- whether the current application looks complete enough for manual decisioning
+
+## Future V2 Ideas
+
+Possible future extensions:
+
+- richer screening-result normalization
+- stronger payment history signals
+- lease-review summary integration
+- policy-specific overlays for different landlord operating models
+- explicit comparison of multiple applicants or co-applicant bundles

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -100,6 +100,7 @@ import transunionRoutes from "./services/integrations/transunion/transunionRoute
 import viewingRoutes from "./routes/viewingRoutes";
 import screeningOpsRoutes from "./routes/screeningOpsRoutes";
 import leaseOverlapCleanupRoutes from "./routes/leaseOverlapCleanupRoutes";
+import riskAgentRoutes from "./routes/riskAgentRoutes";
 
 process.on("unhandledRejection", (reason) => {
   console.error("[FATAL] unhandledRejection", reason);
@@ -258,6 +259,7 @@ app.use("/api", routeSource("usageBreakdownRoutes.ts"), usageBreakdownRoutes);
 app.use("/api/properties", propertiesRoutes);
 app.use("/api/integrations", routeSource("transunionRoutes.ts"), transunionRoutes);
 app.use("/api", routeSource("screeningOpsRoutes.ts"), screeningOpsRoutes);
+app.use("/api", routeSource("riskAgentRoutes.ts"), riskAgentRoutes);
 app.use("/api", routeSource("leaseOverlapCleanupRoutes.ts"), leaseOverlapCleanupRoutes);
 app.use("/api", routeSource("rentalApplicationsRoutes.ts"), rentalApplicationsRoutes);
 if (process.env.NODE_ENV !== "production") {

--- a/rentchain-api/src/routes/__tests__/riskAgentRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/riskAgentRoutes.test.ts
@@ -1,0 +1,273 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type StoredDoc = { id: string; data: any };
+
+const state = vi.hoisted(() => ({
+  collections: new Map<string, Map<string, StoredDoc>>(),
+}));
+
+function resetDb() {
+  state.collections = new Map();
+}
+
+function ensureCollection(name: string) {
+  if (!state.collections.has(name)) state.collections.set(name, new Map());
+  return state.collections.get(name)!;
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function seedDoc(name: string, id: string, data: any) {
+  ensureCollection(name).set(id, { id, data: clone(data) });
+}
+
+vi.mock("../../config/firebase", () => ({
+  db: {
+    collection(name: string) {
+      return {
+        doc(id?: string) {
+          const docId = id || `auto-${ensureCollection(name).size + 1}`;
+          return {
+            id: docId,
+            async get() {
+              const stored = ensureCollection(name).get(docId);
+              return {
+                id: docId,
+                exists: Boolean(stored),
+                data: () => (stored ? clone(stored.data) : undefined),
+              };
+            },
+            async set(payload: any, options?: { merge?: boolean }) {
+              const existing = ensureCollection(name).get(docId);
+              const next =
+                options?.merge && existing
+                  ? { ...clone(existing.data), ...clone(payload) }
+                  : clone(payload);
+              ensureCollection(name).set(docId, { id: docId, data: next });
+            },
+          };
+        },
+        where(field: string, op: string, value: any) {
+          return {
+            limit(count: number) {
+              return {
+                async get() {
+                  const docs = Array.from(ensureCollection(name).values())
+                    .filter((entry) => {
+                      const current = entry.data?.[field];
+                      if (op === "==") return current === value;
+                      if (op === "array-contains") return Array.isArray(current) && current.includes(value);
+                      return false;
+                    })
+                    .slice(0, count)
+                    .map((entry) => ({
+                      id: entry.id,
+                      exists: true,
+                      data: () => clone(entry.data),
+                    }));
+                  return { docs, empty: docs.length === 0 };
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+  },
+}));
+
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: any, res: any, next: any) => {
+    const header = String(req.headers["x-test-user"] || "").trim();
+    if (!header) {
+      return res.status(401).json({ ok: false, error: "Unauthorized" });
+    }
+    req.user = JSON.parse(header);
+    next();
+  },
+}));
+
+vi.mock("../../services/ledgerEventsFirestoreService", () => ({
+  listLedgerEventsV2: vi.fn(async () => ({
+    items: [{ id: "evt-1", tenantId: "tenant-1", type: "late_payment" }],
+  })),
+}));
+
+vi.mock("../../services/tenantSignalsService", () => ({
+  computeTenantSignals: vi.fn(() => ({
+    latePaymentsCount: 1,
+  })),
+}));
+
+describe("riskAgentRoutes", () => {
+  beforeEach(() => {
+    resetDb();
+
+    seedDoc("rentalApplications", "app-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      requestedRent: 1800,
+      monthlyIncome: 5200,
+      status: "IN_REVIEW",
+      applicant: {
+        firstName: "Jordan",
+        lastName: "Lee",
+        email: "jordan@example.com",
+      },
+      applicantProfile: {
+        currentAddress: {
+          line1: "123 Main St",
+          city: "Halifax",
+          provinceState: "NS",
+          postalCode: "B3H1A1",
+          country: "CA",
+        },
+        timeAtCurrentAddressMonths: 18,
+        currentRentAmountCents: 170000,
+        employment: {
+          employerName: "Harbour Labs",
+          jobTitle: "Designer",
+          incomeAmountCents: 520000,
+          incomeFrequency: "monthly",
+          monthsAtJob: 14,
+        },
+        workReference: {
+          name: "Taylor Grant",
+          phone: "555-555-0100",
+        },
+        signature: {
+          type: "typed",
+          signedAt: "2026-03-18T10:00:00.000Z",
+        },
+      },
+      applicationConsent: {
+        acceptedAt: "2026-03-18T10:00:00.000Z",
+        version: "v1.0",
+      },
+      screeningStatus: "complete",
+      screeningProvider: "TransUnion",
+      screeningResultId: "screening-result-1",
+      screeningResultSummary: {
+        overall: "pass",
+        scoreBand: "B",
+      },
+    });
+
+    seedDoc("screeningResults", "screening-result-1", {
+      status: "completed",
+      identityVerified: true,
+    });
+
+    seedDoc("leases", "lease-1", {
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      status: "draft",
+    });
+
+    seedDoc("payments", "payment-1", {
+      tenantId: "tenant-1",
+      amount: 1800,
+    });
+  });
+
+  async function invokeRouter(options: {
+    method: string;
+    url: string;
+    headers?: Record<string, string>;
+    body?: any;
+  }) {
+    const router = (await import("../riskAgentRoutes")).default;
+    return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+      const req: any = {
+        method: options.method,
+        url: options.url,
+        originalUrl: options.url,
+        path: options.url,
+        headers: options.headers || {},
+        body: options.body || {},
+      };
+      const res: any = {
+        statusCode: 200,
+        status(code: number) {
+          this.statusCode = code;
+          return this;
+        },
+        json(payload: any) {
+          resolve({ status: this.statusCode, body: payload });
+          return this;
+        },
+        send(payload: any) {
+          resolve({ status: this.statusCode, body: payload });
+          return this;
+        },
+      };
+
+      router.handle(req, res, (err: any) => {
+        if (err) reject(err);
+      });
+    });
+  }
+
+  it("rejects unauthorized access", async () => {
+    const res = await invokeRouter({
+      method: "POST",
+      url: "/risk-agent/applications/app-1/evaluate",
+      body: {},
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns a structured landlord-safe risk result and persists it", async () => {
+    const res = await invokeRouter({
+      method: "POST",
+      url: "/risk-agent/applications/app-1/evaluate",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "landlord-1",
+          landlordId: "landlord-1",
+          role: "landlord",
+        }),
+      },
+      body: {},
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.run?.version).toBe("risk-v1");
+    expect(typeof res.body?.run?.score).toBe("number");
+    expect(Array.isArray(res.body?.run?.factors)).toBe(true);
+
+    const latestRes = await invokeRouter({
+      method: "GET",
+      url: "/risk-agent/applications/app-1/latest",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "landlord-1",
+          landlordId: "landlord-1",
+          role: "landlord",
+        }),
+      },
+    });
+
+    expect(latestRes.status).toBe(200);
+    expect(latestRes.body?.latest?.latestRunId).toBe(res.body?.run?.id);
+  });
+
+  it("rejects landlord access to another landlord's application", async () => {
+    const res = await invokeRouter({
+      method: "GET",
+      url: "/risk-agent/applications/app-1/latest",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "landlord-2",
+          landlordId: "landlord-2",
+          role: "landlord",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/rentchain-api/src/routes/riskAgentRoutes.ts
+++ b/rentchain-api/src/routes/riskAgentRoutes.ts
@@ -1,0 +1,70 @@
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { requireLandlord } from "../middleware/requireLandlord";
+import { evaluateApplicationRisk, getLatestApplicationRisk } from "../services/riskAgent/riskAgentService";
+
+const router = Router();
+
+router.use(requireLandlord);
+
+async function assertApplicationAccess(req: any, applicationId: string) {
+  if (!applicationId) {
+    const error = new Error("NOT_FOUND") as Error & { statusCode?: number };
+    error.statusCode = 404;
+    throw error;
+  }
+
+  const snap = await db.collection("rentalApplications").doc(applicationId).get();
+  if (!snap.exists) {
+    const error = new Error("NOT_FOUND") as Error & { statusCode?: number };
+    error.statusCode = 404;
+    throw error;
+  }
+
+  const application = snap.data() as any;
+  const role = String(req.user?.role || "").toLowerCase();
+  const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
+  if (role !== "admin" && application?.landlordId && application.landlordId !== landlordId) {
+    const error = new Error("FORBIDDEN") as Error & { statusCode?: number };
+    error.statusCode = 403;
+    throw error;
+  }
+}
+
+router.post("/risk-agent/applications/:id/evaluate", async (req: any, res) => {
+  try {
+    const applicationId = String(req.params?.id || "").trim();
+    await assertApplicationAccess(req, applicationId);
+    const result = await evaluateApplicationRisk({ applicationId });
+    return res.json({ ok: true, ...result });
+  } catch (err: any) {
+    const statusCode = typeof err?.statusCode === "number" ? err.statusCode : 500;
+    if (statusCode >= 500) {
+      console.error("[risk-agent] evaluate failed", err?.message || err);
+    }
+    return res.status(statusCode).json({
+      ok: false,
+      error: statusCode >= 500 ? "risk_agent_evaluation_failed" : String(err?.message || "bad_request"),
+    });
+  }
+});
+
+router.get("/risk-agent/applications/:id/latest", async (req: any, res) => {
+  try {
+    const applicationId = String(req.params?.id || "").trim();
+    await assertApplicationAccess(req, applicationId);
+    const latest = await getLatestApplicationRisk({ applicationId });
+    return res.json({ ok: true, latest });
+  } catch (err: any) {
+    const statusCode = typeof err?.statusCode === "number" ? err.statusCode : 500;
+    if (statusCode >= 500) {
+      console.error("[risk-agent] latest failed", err?.message || err);
+    }
+    return res.status(statusCode).json({
+      ok: false,
+      error: statusCode >= 500 ? "risk_agent_latest_failed" : String(err?.message || "bad_request"),
+    });
+  }
+});
+
+export default router;

--- a/rentchain-api/src/services/__tests__/riskAgentService.test.ts
+++ b/rentchain-api/src/services/__tests__/riskAgentService.test.ts
@@ -1,0 +1,196 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type StoredDoc = { id: string; data: any };
+
+const state = vi.hoisted(() => ({
+  collections: new Map<string, Map<string, StoredDoc>>(),
+}));
+
+function resetDb() {
+  state.collections = new Map();
+}
+
+function ensureCollection(name: string) {
+  if (!state.collections.has(name)) state.collections.set(name, new Map());
+  return state.collections.get(name)!;
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function seedDoc(name: string, id: string, data: any) {
+  ensureCollection(name).set(id, { id, data: clone(data) });
+}
+
+vi.mock("../../config/firebase", () => ({
+  db: {
+    collection(name: string) {
+      return {
+        doc(id?: string) {
+          const docId = id || `auto-${ensureCollection(name).size + 1}`;
+          return {
+            id: docId,
+            async get() {
+              const stored = ensureCollection(name).get(docId);
+              return {
+                id: docId,
+                exists: Boolean(stored),
+                data: () => (stored ? clone(stored.data) : undefined),
+              };
+            },
+            async set(payload: any, options?: { merge?: boolean }) {
+              const existing = ensureCollection(name).get(docId);
+              const next =
+                options?.merge && existing
+                  ? { ...clone(existing.data), ...clone(payload) }
+                  : clone(payload);
+              ensureCollection(name).set(docId, { id: docId, data: next });
+            },
+          };
+        },
+        where(field: string, op: string, value: any) {
+          return {
+            limit(count: number) {
+              return {
+                async get() {
+                  const docs = Array.from(ensureCollection(name).values())
+                    .filter((entry) => {
+                      const current = entry.data?.[field];
+                      if (op === "==") return current === value;
+                      if (op === "array-contains") return Array.isArray(current) && current.includes(value);
+                      return false;
+                    })
+                    .slice(0, count)
+                    .map((entry) => ({
+                      id: entry.id,
+                      exists: true,
+                      data: () => clone(entry.data),
+                    }));
+                  return { docs, empty: docs.length === 0 };
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+  },
+}));
+
+vi.mock("../ledgerEventsFirestoreService", () => ({
+  listLedgerEventsV2: vi.fn(async () => ({
+    items: [{ id: "evt-1", tenantId: "tenant-1", type: "late_payment" }],
+  })),
+}));
+
+vi.mock("../tenantSignalsService", () => ({
+  computeTenantSignals: vi.fn(() => ({
+    latePaymentsCount: 1,
+  })),
+}));
+
+describe("riskAgentService", () => {
+  beforeEach(() => {
+    resetDb();
+
+    seedDoc("rentalApplications", "app-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      requestedRent: 1800,
+      monthlyIncome: 5200,
+      status: "IN_REVIEW",
+      applicant: {
+        firstName: "Jordan",
+        lastName: "Lee",
+        email: "jordan@example.com",
+      },
+      applicantProfile: {
+        currentAddress: {
+          line1: "123 Main St",
+          city: "Halifax",
+          provinceState: "NS",
+          postalCode: "B3H1A1",
+          country: "CA",
+        },
+        timeAtCurrentAddressMonths: 18,
+        currentRentAmountCents: 170000,
+        employment: {
+          employerName: "Harbour Labs",
+          jobTitle: "Designer",
+          incomeAmountCents: 520000,
+          incomeFrequency: "monthly",
+          monthsAtJob: 14,
+        },
+        workReference: {
+          name: "Taylor Grant",
+          phone: "555-555-0100",
+        },
+        signature: {
+          type: "typed",
+          signedAt: "2026-03-18T10:00:00.000Z",
+        },
+      },
+      applicationConsent: {
+        acceptedAt: "2026-03-18T10:00:00.000Z",
+        version: "v1.0",
+      },
+      screeningStatus: "complete",
+      screeningProvider: "TransUnion",
+      screeningResultId: "screening-result-1",
+      screeningResultSummary: {
+        overall: "pass",
+        scoreBand: "B",
+      },
+    });
+
+    seedDoc("screeningResults", "screening-result-1", {
+      status: "completed",
+      identityVerified: true,
+    });
+
+    seedDoc("leases", "lease-1", {
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      status: "draft",
+    });
+
+    seedDoc("payments", "payment-1", {
+      tenantId: "tenant-1",
+      amount: 1800,
+    });
+  });
+
+  it("persists a structured run and latest snapshot", async () => {
+    const { evaluateApplicationRisk, getLatestApplicationRisk } = await import("../riskAgent/riskAgentService");
+
+    const result = await evaluateApplicationRisk({ applicationId: "app-1" });
+
+    expect(result.run.version).toBe("risk-v1");
+    expect(typeof result.run.score).toBe("number");
+    expect(Array.isArray(result.run.factors)).toBe(true);
+    expect(Array.isArray(result.run.flags)).toBe(true);
+    expect(Array.isArray(result.run.recommendations)).toBe(true);
+
+    const latest = await getLatestApplicationRisk({ applicationId: "app-1" });
+    expect(latest?.latestRunId).toBe(result.run.id);
+    expect(latest?.applicationId).toBe("app-1");
+  });
+
+  it("includes version, score, factors, flags, and recommendations in the stored output", async () => {
+    const { evaluateApplicationRisk } = await import("../riskAgent/riskAgentService");
+
+    const result = await evaluateApplicationRisk({ applicationId: "app-1" });
+
+    expect(result.latest).toEqual(
+      expect.objectContaining({
+        version: "risk-v1",
+        score: expect.any(Number),
+        factors: expect.any(Array),
+        flags: expect.any(Array),
+        recommendations: expect.any(Array),
+      })
+    );
+  });
+});

--- a/rentchain-api/src/services/__tests__/riskRulesEngine.test.ts
+++ b/rentchain-api/src/services/__tests__/riskRulesEngine.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { evaluateRiskAgentContext } from "../riskAgent/riskRulesEngine";
+import type { RiskAgentApplicationContext } from "../riskAgent/riskTypes";
+
+function buildContext(overrides: Partial<RiskAgentApplicationContext> = {}): RiskAgentApplicationContext {
+  return {
+    applicationId: "app-1",
+    application: {},
+    landlordId: "landlord-1",
+    propertyId: "prop-1",
+    tenantId: "tenant-1",
+    leaseId: null,
+    identityStatus: "pending",
+    documentStatus: "pending",
+    monthlyIncome: 5400,
+    monthlyRent: 1800,
+    employmentMonths: 14,
+    coTenantCount: 1,
+    applicationCompleteness: 0.86,
+    paymentHistoryRatio: null,
+    latePayments: null,
+    leaseApplicationConsistency: "unknown",
+    reviewSummarySnapshot: {
+      screeningStatus: "processing",
+      screeningProvider: "TransUnion",
+      screeningScoreBand: null,
+      applicationStatus: "IN_REVIEW",
+    },
+    ...overrides,
+  };
+}
+
+describe("riskRulesEngine", () => {
+  it("low income-to-rent ratio lowers the score", () => {
+    const strong = evaluateRiskAgentContext(buildContext({ monthlyIncome: 7200, monthlyRent: 1800 }));
+    const weak = evaluateRiskAgentContext(buildContext({ monthlyIncome: 3000, monthlyRent: 1800 }));
+
+    expect(weak.score).toBeLessThan(strong.score);
+    expect(weak.factors.some((factor) => factor.code === "income_to_rent_low")).toBe(true);
+  });
+
+  it("verified identity improves score", () => {
+    const pending = evaluateRiskAgentContext(buildContext({ identityStatus: "pending" }));
+    const verified = evaluateRiskAgentContext(buildContext({ identityStatus: "verified" }));
+
+    expect(verified.score).toBeGreaterThan(pending.score);
+    expect(verified.factors.some((factor) => factor.code === "identity_verified")).toBe(true);
+  });
+
+  it("missing critical documents produces flags and recommendations", () => {
+    const result = evaluateRiskAgentContext(buildContext({ documentStatus: "missing" }));
+
+    expect(result.flags).toContain("Missing required documents");
+    expect(result.recommendations.some((item) => item.toLowerCase().includes("missing application documents"))).toBe(true);
+  });
+
+  it("incomplete application lowers confidence", () => {
+    const complete = evaluateRiskAgentContext(buildContext({ applicationCompleteness: 0.94 }));
+    const incomplete = evaluateRiskAgentContext(buildContext({ applicationCompleteness: 0.32 }));
+
+    expect(incomplete.confidence).toBeLessThan(complete.confidence);
+  });
+
+  it("stable employment improves score", () => {
+    const stable = evaluateRiskAgentContext(buildContext({ employmentMonths: 36 }));
+    const short = evaluateRiskAgentContext(buildContext({ employmentMonths: 3 }));
+
+    expect(stable.score).toBeGreaterThan(short.score);
+  });
+
+  it("missing data produces insufficient_data safely", () => {
+    const result = evaluateRiskAgentContext(
+      buildContext({
+        monthlyIncome: null,
+        monthlyRent: null,
+        employmentMonths: null,
+        applicationCompleteness: null,
+        identityStatus: "unknown",
+        documentStatus: "unknown",
+      })
+    );
+
+    expect(result.status).toBe("insufficient_data");
+    expect(result.confidence).toBeLessThan(0.6);
+  });
+
+  it("recommendations correspond to triggered rules", () => {
+    const result = evaluateRiskAgentContext(
+      buildContext({
+        monthlyIncome: 3100,
+        monthlyRent: 1900,
+        identityStatus: "needs_review",
+      })
+    );
+
+    expect(result.recommendations.some((item) => item.toLowerCase().includes("identity verification"))).toBe(true);
+    expect(result.status).toBe("manual_review_required");
+  });
+
+  it("maps score bands to grades deterministically", () => {
+    expect(evaluateRiskAgentContext(buildContext({ monthlyIncome: 9000, monthlyRent: 1800, identityStatus: "verified", documentStatus: "verified", employmentMonths: 48, applicationCompleteness: 0.98 })).grade).toBe("A");
+    expect(evaluateRiskAgentContext(buildContext({ monthlyIncome: 2500, monthlyRent: 1800, identityStatus: "missing", documentStatus: "missing", employmentMonths: 2, applicationCompleteness: 0.4 })).grade).toBe("E");
+  });
+});

--- a/rentchain-api/src/services/riskAgent/riskAgentService.ts
+++ b/rentchain-api/src/services/riskAgent/riskAgentService.ts
@@ -1,0 +1,259 @@
+import { db } from "../../config/firebase";
+import { listLedgerEventsV2 } from "../ledgerEventsFirestoreService";
+import { buildReviewSummary } from "../../lib/reviewSummary";
+import { computeTenantSignals } from "../tenantSignalsService";
+import { loadLatestRiskAgentResult, persistRiskAgentRun } from "./riskPersistenceService";
+import { evaluateRiskAgentContext } from "./riskRulesEngine";
+import type {
+  RiskAgentApplicationContext,
+  RiskAgentConsistencyStatus,
+  RiskAgentDocumentStatus,
+  RiskAgentEvaluation,
+  RiskAgentIdentityStatus,
+  RiskAgentLatestRecord,
+  RiskAgentRunRecord,
+} from "./riskTypes";
+
+function asString(value: unknown): string | null {
+  const next = String(value || "").trim();
+  return next || null;
+}
+
+function numberOrNull(value: unknown): number | null {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+function toMonthlyIncome(application: any): number | null {
+  const direct = numberOrNull(application?.monthlyIncome);
+  const coApplicantIncome = numberOrNull(application?.coApplicant?.monthlyIncome) || 0;
+  if (direct != null && direct > 0) return direct + coApplicantIncome;
+
+  const employment = application?.applicantProfile?.employment || {};
+  const incomeAmountCents = numberOrNull(employment?.incomeAmountCents);
+  const frequency = String(employment?.incomeFrequency || "monthly").trim().toLowerCase();
+  if (incomeAmountCents == null || incomeAmountCents <= 0) return coApplicantIncome || null;
+
+  const primary =
+    frequency === "annual"
+      ? Math.round((incomeAmountCents / 100) / 12)
+      : Math.round(incomeAmountCents / 100);
+  return primary + coApplicantIncome;
+}
+
+function toEmploymentMonths(application: any): number | null {
+  return (
+    numberOrNull(application?.applicantProfile?.employment?.monthsAtJob) ??
+    numberOrNull(application?.employment?.monthsAtJob) ??
+    numberOrNull(application?.employmentMonths)
+  );
+}
+
+function toCoTenantCount(application: any): number {
+  const explicit = numberOrNull(application?.coTenantCount);
+  if (explicit != null && explicit > 0) return explicit;
+  return application?.coApplicant ? 2 : 1;
+}
+
+function deriveIdentityStatus(application: any, screeningResult: any): RiskAgentIdentityStatus {
+  if (screeningResult?.identityVerified === true) return "verified";
+
+  const summaryFlags = Array.isArray(application?.screeningResultSummary?.flags)
+    ? application.screeningResultSummary.flags.map((value: unknown) => String(value || "").toLowerCase())
+    : [];
+  if (summaryFlags.some((flag: string) => flag.includes("identity") && flag.includes("recheck"))) {
+    return "needs_review";
+  }
+
+  const screeningStatus = String(application?.screeningStatus || screeningResult?.status || "").trim().toLowerCase();
+  if (["complete", "completed"].includes(screeningStatus)) return "pending";
+  if (["processing", "paid", "external_pending", "requested", "in_progress"].includes(screeningStatus)) return "pending";
+  if (["failed", "manual_review_required", "inconclusive"].includes(screeningStatus)) return "needs_review";
+  if (screeningStatus) return "missing";
+  return "unknown";
+}
+
+function deriveDocumentStatus(application: any, reviewSummary: ReturnType<typeof buildReviewSummary>): RiskAgentDocumentStatus {
+  const checklist = Array.isArray(application?.documentChecklist) ? application.documentChecklist : [];
+  if (checklist.length) {
+    const statuses = checklist.map((entry: any) => String(entry?.status || "").trim().toLowerCase());
+    if (statuses.some((status: string) => status === "needs_review" || status === "manual_review_required")) return "needs_review";
+    if (statuses.some((status: string) => status === "missing")) return "missing";
+    if (statuses.some((status: string) => status === "pending" || status === "uploaded" || status === "submitted")) return "pending";
+    return "verified";
+  }
+
+  const missingSteps = Array.isArray(application?.missingSteps) ? application.missingSteps.filter(Boolean) : [];
+  if (missingSteps.length) return "missing";
+
+  const reviewFlags = Array.isArray(reviewSummary?.derived?.flags) ? reviewSummary.derived.flags : [];
+  const criticalFlags = reviewFlags.filter((flag: string) =>
+    ["MISSING_SIGNATURE", "MISSING_APPLICATION_CONSENT", "MISSING_INCOME", "MISSING_WORK_REFERENCE_PHONE"].includes(flag)
+  );
+
+  const uploadedDocsCount = Array.isArray(application?.documents)
+    ? application.documents.length
+    : Array.isArray(application?.documentRefs)
+    ? application.documentRefs.length
+    : 0;
+
+  if (criticalFlags.length) return uploadedDocsCount > 0 ? "pending" : "missing";
+  if (uploadedDocsCount > 0) return "pending";
+  if ((reviewSummary?.derived?.completeness?.score || 0) >= 0.9) return "verified";
+  return "unknown";
+}
+
+function deriveLeaseApplicationConsistency(application: any, lease: any): RiskAgentConsistencyStatus {
+  if (!lease) return "unknown";
+  const applicationPropertyId = asString(application?.propertyId);
+  const leasePropertyId = asString(lease?.propertyId);
+  if (applicationPropertyId && leasePropertyId && applicationPropertyId !== leasePropertyId) return "conflict";
+
+  const applicationTenantId = asString(application?.tenantId || application?.convertedTenantId);
+  const leaseTenantIds = [
+    asString(lease?.tenantId),
+    ...(Array.isArray(lease?.tenantIds) ? lease.tenantIds.map((value: unknown) => asString(value)) : []),
+  ].filter(Boolean);
+  if (applicationTenantId && leaseTenantIds.length && !leaseTenantIds.includes(applicationTenantId)) return "conflict";
+  return "aligned";
+}
+
+async function loadDoc(collectionName: string, id: string | null) {
+  const docId = asString(id);
+  if (!docId) return null;
+  const snap = await db.collection(collectionName).doc(docId).get();
+  if (!snap.exists) return null;
+  return { id: snap.id, ...(snap.data() as any) };
+}
+
+async function loadScreeningResult(application: any) {
+  const byId = await loadDoc("screeningResults", asString(application?.screeningResultId));
+  if (byId) return byId;
+  return null;
+}
+
+async function loadLease(application: any) {
+  const direct = await loadDoc("leases", asString(application?.leaseId));
+  if (direct) return direct;
+
+  const tenantId = asString(application?.tenantId || application?.convertedTenantId);
+  if (!tenantId) return null;
+
+  const candidates = await Promise.all([
+    db.collection("leases").where("tenantId", "==", tenantId).limit(10).get().catch(() => ({ docs: [] } as any)),
+    db.collection("leases").where("tenantIds", "array-contains", tenantId).limit(10).get().catch(() => ({ docs: [] } as any)),
+  ]);
+
+  for (const result of candidates) {
+    const first = result.docs?.[0];
+    if (first) return { id: first.id, ...(first.data() as any) };
+  }
+
+  return null;
+}
+
+async function buildPaymentHistory(landlordId: string | null, tenantId: string | null) {
+  if (!landlordId || !tenantId) {
+    return { paymentHistoryRatio: null, latePayments: null };
+  }
+
+  let paymentCount = 0;
+  try {
+    const paymentSnap = await db.collection("payments").where("tenantId", "==", tenantId).limit(24).get();
+    paymentCount = paymentSnap.docs?.length || 0;
+  } catch {
+    paymentCount = 0;
+  }
+
+  try {
+    const ledger = await listLedgerEventsV2({ landlordId, tenantId, limit: 50 });
+    const signals = computeTenantSignals(ledger.items || [], tenantId, landlordId);
+    const latePayments = numberOrNull(signals?.latePaymentsCount) || 0;
+    const paymentHistoryRatio =
+      paymentCount + latePayments > 0 ? Number((paymentCount / (paymentCount + latePayments)).toFixed(2)) : null;
+    return {
+      paymentHistoryRatio,
+      latePayments: latePayments > 0 ? latePayments : null,
+    };
+  } catch {
+    return { paymentHistoryRatio: null, latePayments: null };
+  }
+}
+
+async function buildApplicationRiskContext(applicationId: string): Promise<RiskAgentApplicationContext> {
+  const snap = await db.collection("rentalApplications").doc(applicationId).get();
+  if (!snap.exists) {
+    const error = new Error("NOT_FOUND") as Error & { statusCode?: number };
+    error.statusCode = 404;
+    throw error;
+  }
+
+  const application = { id: snap.id, ...(snap.data() as any) };
+  const landlordId = asString(application?.landlordId);
+  const propertyId = asString(application?.propertyId);
+  const tenantId = asString(application?.tenantId || application?.convertedTenantId);
+  const leaseId = asString(application?.leaseId);
+  const reviewSummary = buildReviewSummary(applicationId, application);
+  const [screeningResult, lease] = await Promise.all([loadScreeningResult(application), loadLease(application)]);
+  const paymentHistory = await buildPaymentHistory(landlordId, tenantId);
+
+  return {
+    applicationId,
+    application,
+    landlordId,
+    propertyId,
+    tenantId,
+    leaseId: asString(lease?.id || leaseId),
+    identityStatus: deriveIdentityStatus(application, screeningResult),
+    documentStatus: deriveDocumentStatus(application, reviewSummary),
+    monthlyIncome: toMonthlyIncome(application),
+    monthlyRent:
+      numberOrNull(application?.requestedRent) ??
+      numberOrNull(application?.monthlyRent) ??
+      (numberOrNull(application?.applicantProfile?.currentRentAmountCents) != null
+        ? Math.round(Number(application.applicantProfile.currentRentAmountCents) / 100)
+        : null),
+    employmentMonths: toEmploymentMonths(application),
+    coTenantCount: toCoTenantCount(application),
+    applicationCompleteness: numberOrNull(reviewSummary?.derived?.completeness?.score),
+    paymentHistoryRatio: paymentHistory.paymentHistoryRatio,
+    latePayments: paymentHistory.latePayments,
+    leaseApplicationConsistency: deriveLeaseApplicationConsistency(application, lease),
+    reviewSummarySnapshot: {
+      screeningStatus: asString(application?.screeningStatus),
+      screeningProvider: asString(application?.screeningProvider),
+      screeningScoreBand: asString(application?.screeningResultSummary?.scoreBand),
+      applicationStatus: asString(application?.status),
+    },
+  };
+}
+
+export async function evaluateApplicationRisk(params: { applicationId: string }): Promise<{
+  run: RiskAgentRunRecord;
+  latest: RiskAgentLatestRecord;
+  evaluation: RiskAgentEvaluation;
+}> {
+  const context = await buildApplicationRiskContext(params.applicationId);
+  const evaluation = evaluateRiskAgentContext(context);
+  const persisted = await persistRiskAgentRun({
+    entityType: "application",
+    entityId: params.applicationId,
+    applicationId: params.applicationId,
+    landlordId: context.landlordId,
+    propertyId: context.propertyId,
+    tenantId: context.tenantId,
+    leaseId: context.leaseId,
+    reviewSummarySnapshot: context.reviewSummarySnapshot,
+    evaluation,
+  });
+
+  return {
+    run: persisted.run,
+    latest: persisted.latest,
+    evaluation,
+  };
+}
+
+export async function getLatestApplicationRisk(params: { applicationId: string }): Promise<RiskAgentLatestRecord | null> {
+  return loadLatestRiskAgentResult("application", params.applicationId);
+}

--- a/rentchain-api/src/services/riskAgent/riskPersistenceService.ts
+++ b/rentchain-api/src/services/riskAgent/riskPersistenceService.ts
@@ -1,0 +1,58 @@
+import { db } from "../../config/firebase";
+import type { RiskAgentEvaluation, RiskAgentLatestRecord, RiskAgentRunRecord } from "./riskTypes";
+
+function latestDocId(entityType: string, entityId: string): string {
+  return `${entityType}:${entityId}`;
+}
+
+export async function persistRiskAgentRun(params: {
+  entityType: "application";
+  entityId: string;
+  applicationId: string;
+  landlordId: string | null;
+  propertyId: string | null;
+  tenantId: string | null;
+  leaseId: string | null;
+  reviewSummarySnapshot: RiskAgentRunRecord["reviewSummarySnapshot"];
+  evaluation: RiskAgentEvaluation;
+}): Promise<{ run: RiskAgentRunRecord; latest: RiskAgentLatestRecord }> {
+  const runRef = db.collection("risk_agent_runs").doc();
+  const run: RiskAgentRunRecord = {
+    id: runRef.id,
+    entityType: params.entityType,
+    entityId: params.entityId,
+    applicationId: params.applicationId,
+    landlordId: params.landlordId,
+    propertyId: params.propertyId,
+    tenantId: params.tenantId,
+    leaseId: params.leaseId,
+    reviewSummarySnapshot: params.reviewSummarySnapshot,
+    ...params.evaluation,
+  };
+
+  await runRef.set(run);
+
+  const latest: RiskAgentLatestRecord = {
+    id: latestDocId(params.entityType, params.entityId),
+    latestRunId: run.id,
+    entityType: params.entityType,
+    entityId: params.entityId,
+    applicationId: params.applicationId,
+    landlordId: params.landlordId,
+    propertyId: params.propertyId,
+    tenantId: params.tenantId,
+    leaseId: params.leaseId,
+    updatedAt: run.createdAt,
+    ...params.evaluation,
+  };
+
+  await db.collection("risk_agent_latest").doc(latest.id).set(latest);
+
+  return { run, latest };
+}
+
+export async function loadLatestRiskAgentResult(entityType: "application", entityId: string): Promise<RiskAgentLatestRecord | null> {
+  const snap = await db.collection("risk_agent_latest").doc(latestDocId(entityType, entityId)).get();
+  if (!snap.exists) return null;
+  return { id: snap.id, ...(snap.data() as any) } as RiskAgentLatestRecord;
+}

--- a/rentchain-api/src/services/riskAgent/riskRulesEngine.ts
+++ b/rentchain-api/src/services/riskAgent/riskRulesEngine.ts
@@ -1,0 +1,493 @@
+import { clamp, confidenceBandForValue, gradeForScore, roundTo } from "./riskScoring";
+import type {
+  RiskAgentApplicationContext,
+  RiskAgentEvaluation,
+  RiskAgentFactorImpact,
+  RiskAgentInputs,
+  RiskAgentStatus,
+} from "./riskTypes";
+
+type WorkingState = {
+  score: number;
+  factors: RiskAgentEvaluation["factors"];
+  flags: string[];
+  recommendations: string[];
+  manualReview: boolean;
+};
+
+function unique(items: string[]): string[] {
+  return Array.from(new Set(items.filter(Boolean)));
+}
+
+function pushFactor(
+  state: WorkingState,
+  params: {
+    code: string;
+    label: string;
+    impact: RiskAgentFactorImpact;
+    weight: number;
+    flag?: string | null;
+    recommendation?: string | null;
+  }
+) {
+  state.factors.push({
+    code: params.code,
+    label: params.label,
+    impact: params.impact,
+    weight: params.weight,
+  });
+
+  if (params.impact === "positive") {
+    state.score += params.weight;
+  } else if (params.impact === "negative") {
+    state.score -= params.weight;
+  }
+
+  if (params.flag) state.flags.push(params.flag);
+  if (params.recommendation) state.recommendations.push(params.recommendation);
+}
+
+function buildInputs(context: RiskAgentApplicationContext): RiskAgentInputs {
+  const incomeToRentRatio =
+    typeof context.monthlyIncome === "number" &&
+    Number.isFinite(context.monthlyIncome) &&
+    context.monthlyIncome > 0 &&
+    typeof context.monthlyRent === "number" &&
+    Number.isFinite(context.monthlyRent) &&
+    context.monthlyRent > 0
+      ? roundTo(context.monthlyIncome / context.monthlyRent, 2)
+      : null;
+
+  return {
+    monthlyIncome: context.monthlyIncome,
+    monthlyRent: context.monthlyRent,
+    incomeToRentRatio,
+    identityStatus: context.identityStatus,
+    documentStatus: context.documentStatus,
+    employmentMonths: context.employmentMonths,
+    coTenantCount: context.coTenantCount,
+    applicationCompleteness: context.applicationCompleteness,
+    paymentHistoryRatio: context.paymentHistoryRatio,
+    latePayments: context.latePayments,
+    leaseApplicationConsistency: context.leaseApplicationConsistency,
+  };
+}
+
+function evaluateIncome(state: WorkingState, inputs: RiskAgentInputs) {
+  if (inputs.incomeToRentRatio == null) {
+    pushFactor(state, {
+      code: "income_data_incomplete",
+      label: "Income or rent data incomplete",
+      impact: "negative",
+      weight: 10,
+      flag: "Income verification incomplete",
+      recommendation: "Request additional income documentation before relying on this assessment.",
+    });
+    return;
+  }
+
+  if (inputs.incomeToRentRatio >= 3) {
+    pushFactor(state, {
+      code: "income_to_rent_strong",
+      label: "Income comfortably covers rent",
+      impact: "positive",
+      weight: 18,
+    });
+    return;
+  }
+
+  if (inputs.incomeToRentRatio >= 2.3) {
+    pushFactor(state, {
+      code: "income_to_rent_acceptable",
+      label: "Income covers rent within preferred range",
+      impact: "positive",
+      weight: 10,
+    });
+    return;
+  }
+
+  if (inputs.incomeToRentRatio >= 1.8) {
+    pushFactor(state, {
+      code: "income_to_rent_tight",
+      label: "Income-to-rent coverage is tighter than preferred",
+      impact: "negative",
+      weight: 8,
+      flag: "Income-to-rent coverage is tight",
+      recommendation: "Review income stability and ask for any missing income verification.",
+    });
+    return;
+  }
+
+  pushFactor(state, {
+    code: "income_to_rent_low",
+    label: "Income is below preferred rent coverage threshold",
+    impact: "negative",
+    weight: 18,
+    flag: "Income below preferred threshold",
+    recommendation: "Request additional income documentation or guarantor support.",
+  });
+}
+
+function evaluateIdentity(state: WorkingState, inputs: RiskAgentInputs) {
+  if (inputs.identityStatus === "verified") {
+    pushFactor(state, {
+      code: "identity_verified",
+      label: "Identity verification completed",
+      impact: "positive",
+      weight: 8,
+    });
+    return;
+  }
+
+  if (inputs.identityStatus === "pending") {
+    pushFactor(state, {
+      code: "identity_pending",
+      label: "Identity verification is still pending",
+      impact: "negative",
+      weight: 4,
+      flag: "Identity verification pending",
+      recommendation: "Wait for identity verification to complete before making a final decision.",
+    });
+    return;
+  }
+
+  if (inputs.identityStatus === "needs_review") {
+    state.manualReview = true;
+    pushFactor(state, {
+      code: "identity_review_needed",
+      label: "Identity verification needs manual review",
+      impact: "negative",
+      weight: 14,
+      flag: "Identity verification needs manual review",
+      recommendation: "Review identity verification exceptions before proceeding.",
+    });
+    return;
+  }
+
+  pushFactor(state, {
+    code: "identity_unverified",
+    label: "Identity verification is not available",
+    impact: "negative",
+    weight: 10,
+    flag: "Identity verification incomplete",
+    recommendation: "Verify identity details before relying on this assessment.",
+  });
+}
+
+function evaluateDocuments(state: WorkingState, inputs: RiskAgentInputs) {
+  if (inputs.documentStatus === "verified") {
+    pushFactor(state, {
+      code: "documents_complete",
+      label: "Required application documents appear complete",
+      impact: "positive",
+      weight: 6,
+    });
+    return;
+  }
+
+  if (inputs.documentStatus === "pending") {
+    pushFactor(state, {
+      code: "documents_pending",
+      label: "Documents have been submitted but not fully cleared",
+      impact: "negative",
+      weight: 4,
+      flag: "Supporting documents are still pending review",
+      recommendation: "Confirm document review has completed before final approval.",
+    });
+    return;
+  }
+
+  if (inputs.documentStatus === "needs_review") {
+    state.manualReview = true;
+    pushFactor(state, {
+      code: "documents_need_review",
+      label: "Application documents need review",
+      impact: "negative",
+      weight: 10,
+      flag: "Documents need manual review",
+      recommendation: "Review uploaded documents and resolve any checklist issues.",
+    });
+    return;
+  }
+
+  pushFactor(state, {
+    code: "documents_missing",
+    label: "Critical application documents are missing",
+    impact: "negative",
+    weight: 12,
+    flag: "Missing required documents",
+    recommendation: "Request the missing application documents before making a final decision.",
+  });
+}
+
+function evaluateEmployment(state: WorkingState, inputs: RiskAgentInputs) {
+  if (inputs.employmentMonths == null) {
+    pushFactor(state, {
+      code: "employment_history_unknown",
+      label: "Employment history is incomplete",
+      impact: "negative",
+      weight: 6,
+      flag: "Employment history incomplete",
+      recommendation: "Confirm employment duration with the applicant or employer reference.",
+    });
+    return;
+  }
+
+  if (inputs.employmentMonths >= 24) {
+    pushFactor(state, {
+      code: "employment_stable",
+      label: "Employment history shows stability",
+      impact: "positive",
+      weight: 8,
+    });
+    return;
+  }
+
+  if (inputs.employmentMonths >= 12) {
+    pushFactor(state, {
+      code: "employment_established",
+      label: "Employment history is established",
+      impact: "positive",
+      weight: 4,
+    });
+    return;
+  }
+
+  if (inputs.employmentMonths >= 6) {
+    return;
+  }
+
+  pushFactor(state, {
+    code: "employment_short",
+    label: "Employment history is shorter than preferred",
+    impact: "negative",
+    weight: 8,
+    flag: "Short employment history",
+    recommendation: "Confirm employment stability with an employer reference.",
+  });
+}
+
+function evaluateCompleteness(state: WorkingState, inputs: RiskAgentInputs) {
+  if (inputs.applicationCompleteness == null) {
+    pushFactor(state, {
+      code: "application_completeness_unknown",
+      label: "Application completeness could not be determined",
+      impact: "negative",
+      weight: 6,
+      flag: "Application completeness is unclear",
+      recommendation: "Review the application for missing information before deciding.",
+    });
+    return;
+  }
+
+  if (inputs.applicationCompleteness >= 0.9) {
+    pushFactor(state, {
+      code: "application_complete",
+      label: "Application is materially complete",
+      impact: "positive",
+      weight: 10,
+    });
+    return;
+  }
+
+  if (inputs.applicationCompleteness >= 0.75) {
+    pushFactor(state, {
+      code: "application_mostly_complete",
+      label: "Application is mostly complete",
+      impact: "positive",
+      weight: 4,
+    });
+    return;
+  }
+
+  if (inputs.applicationCompleteness >= 0.55) {
+    pushFactor(state, {
+      code: "application_partially_complete",
+      label: "Application is only partially complete",
+      impact: "negative",
+      weight: 4,
+      flag: "Application has missing information",
+      recommendation: "Fill in the remaining application details before making a final decision.",
+    });
+    return;
+  }
+
+  pushFactor(state, {
+    code: "application_incomplete",
+    label: "Application is incomplete",
+    impact: "negative",
+    weight: 12,
+    flag: "Application is missing required information",
+    recommendation: "Complete the application before relying on a risk decision.",
+  });
+}
+
+function evaluatePaymentHistory(state: WorkingState, inputs: RiskAgentInputs) {
+  if (inputs.paymentHistoryRatio == null && inputs.latePayments == null) {
+    return;
+  }
+
+  if ((inputs.latePayments || 0) >= 2) {
+    pushFactor(state, {
+      code: "late_payment_history",
+      label: "Past payment behavior shows repeated late payments",
+      impact: "negative",
+      weight: 10,
+      flag: "Repeated late payment history",
+      recommendation: "Review available payment history before approving this file.",
+    });
+    return;
+  }
+
+  if (inputs.paymentHistoryRatio != null && inputs.paymentHistoryRatio >= 0.97) {
+    pushFactor(state, {
+      code: "payment_history_strong",
+      label: "Payment history proxy is strong",
+      impact: "positive",
+      weight: 8,
+    });
+    return;
+  }
+
+  if (inputs.paymentHistoryRatio != null && inputs.paymentHistoryRatio >= 0.9) {
+    pushFactor(state, {
+      code: "payment_history_acceptable",
+      label: "Payment history proxy is acceptable",
+      impact: "positive",
+      weight: 4,
+    });
+    return;
+  }
+
+  if (inputs.paymentHistoryRatio != null && inputs.paymentHistoryRatio < 0.8) {
+    pushFactor(state, {
+      code: "payment_history_concerning",
+      label: "Payment history proxy is below preferred range",
+      impact: "negative",
+      weight: 8,
+      flag: "Payment history needs closer review",
+      recommendation: "Review payment history and ask follow-up questions before finalizing.",
+    });
+  }
+}
+
+function evaluateCoTenants(state: WorkingState, inputs: RiskAgentInputs) {
+  if (inputs.coTenantCount == null || inputs.coTenantCount <= 1) return;
+
+  if (inputs.coTenantCount >= 3) {
+    pushFactor(state, {
+      code: "multiple_cotenants",
+      label: "Multiple co-tenants increase file complexity",
+      impact: "negative",
+      weight: 6,
+      flag: "Multiple co-tenants require coordinated review",
+      recommendation: "Confirm all co-tenant identities and supporting documents are complete.",
+    });
+    return;
+  }
+
+  pushFactor(state, {
+    code: "co_tenant_present",
+    label: "Co-tenant information needs to be reviewed together",
+    impact: "negative",
+    weight: 3,
+    flag: "Co-tenant information should be reviewed together",
+    recommendation: "Check that co-tenant income and document coverage are complete.",
+  });
+}
+
+function evaluateConsistency(state: WorkingState, inputs: RiskAgentInputs) {
+  if (inputs.leaseApplicationConsistency === "aligned") {
+    pushFactor(state, {
+      code: "application_lease_aligned",
+      label: "Application and linked lease context are aligned",
+      impact: "positive",
+      weight: 4,
+    });
+    return;
+  }
+
+  if (inputs.leaseApplicationConsistency === "conflict") {
+    state.manualReview = true;
+    pushFactor(state, {
+      code: "application_lease_conflict",
+      label: "Application and linked lease context conflict",
+      impact: "negative",
+      weight: 12,
+      flag: "Lease and application context conflict",
+      recommendation: "Review lease and application linkage before making a final decision.",
+    });
+  }
+}
+
+function resolveStatus(inputs: RiskAgentInputs, state: WorkingState): RiskAgentStatus {
+  const coreSignals = [
+    inputs.monthlyIncome != null && inputs.monthlyRent != null,
+    inputs.identityStatus !== "unknown",
+    inputs.documentStatus !== "unknown",
+    inputs.applicationCompleteness != null,
+    inputs.employmentMonths != null,
+  ].filter(Boolean).length;
+
+  if (coreSignals < 3) return "insufficient_data";
+  if (state.manualReview) return "manual_review_required";
+  return "completed";
+}
+
+function deriveConfidence(inputs: RiskAgentInputs, status: RiskAgentStatus): number {
+  const coreSignals = [
+    inputs.monthlyIncome != null && inputs.monthlyRent != null,
+    inputs.identityStatus !== "unknown",
+    inputs.documentStatus !== "unknown",
+    inputs.applicationCompleteness != null,
+    inputs.employmentMonths != null,
+  ].filter(Boolean).length;
+
+  const supportSignals = [inputs.paymentHistoryRatio != null || inputs.latePayments != null, inputs.coTenantCount != null].filter(Boolean).length;
+
+  let confidence = 0.42 + coreSignals * 0.08 + supportSignals * 0.03;
+  if (inputs.applicationCompleteness != null && inputs.applicationCompleteness < 0.75) confidence -= 0.05;
+  if (inputs.applicationCompleteness != null && inputs.applicationCompleteness < 0.55) confidence -= 0.05;
+  if (inputs.leaseApplicationConsistency === "conflict") confidence -= 0.08;
+  if (status === "manual_review_required") confidence -= 0.05;
+  if (status === "insufficient_data") confidence = Math.min(confidence - 0.1, 0.58);
+  return roundTo(clamp(confidence, 0.35, 0.95), 2);
+}
+
+export function evaluateRiskAgentContext(context: RiskAgentApplicationContext): RiskAgentEvaluation {
+  const inputs = buildInputs(context);
+  const state: WorkingState = {
+    score: 60,
+    factors: [],
+    flags: [],
+    recommendations: [],
+    manualReview: false,
+  };
+
+  evaluateIncome(state, inputs);
+  evaluateIdentity(state, inputs);
+  evaluateDocuments(state, inputs);
+  evaluateEmployment(state, inputs);
+  evaluateCompleteness(state, inputs);
+  evaluatePaymentHistory(state, inputs);
+  evaluateCoTenants(state, inputs);
+  evaluateConsistency(state, inputs);
+
+  const status = resolveStatus(inputs, state);
+  const score = Math.round(clamp(state.score, 0, 100));
+  const confidence = deriveConfidence(inputs, status);
+
+  return {
+    version: "risk-v1",
+    score,
+    grade: gradeForScore(score),
+    confidence,
+    confidenceBand: confidenceBandForValue(confidence),
+    status,
+    factors: state.factors,
+    flags: unique(state.flags),
+    recommendations: unique(state.recommendations).slice(0, 6),
+    inputs,
+    createdAt: new Date().toISOString(),
+  };
+}

--- a/rentchain-api/src/services/riskAgent/riskScoring.ts
+++ b/rentchain-api/src/services/riskAgent/riskScoring.ts
@@ -1,0 +1,24 @@
+import type { RiskAgentConfidenceBand, RiskAgentGrade } from "./riskTypes";
+
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+export function roundTo(value: number, places: number): number {
+  const factor = 10 ** places;
+  return Math.round(value * factor) / factor;
+}
+
+export function gradeForScore(score: number): RiskAgentGrade {
+  if (score >= 85) return "A";
+  if (score >= 70) return "B";
+  if (score >= 55) return "C";
+  if (score >= 40) return "D";
+  return "E";
+}
+
+export function confidenceBandForValue(confidence: number): RiskAgentConfidenceBand {
+  if (confidence >= 0.8) return "high";
+  if (confidence >= 0.6) return "medium";
+  return "low";
+}

--- a/rentchain-api/src/services/riskAgent/riskTypes.ts
+++ b/rentchain-api/src/services/riskAgent/riskTypes.ts
@@ -1,0 +1,105 @@
+export type RiskAgentVersion = "risk-v1";
+
+export type RiskAgentGrade = "A" | "B" | "C" | "D" | "E";
+
+export type RiskAgentStatus = "completed" | "insufficient_data" | "manual_review_required";
+
+export type RiskAgentConfidenceBand = "low" | "medium" | "high";
+
+export type RiskAgentFactorImpact = "positive" | "negative" | "neutral";
+
+export type RiskAgentIdentityStatus = "verified" | "pending" | "missing" | "needs_review" | "unknown";
+
+export type RiskAgentDocumentStatus = "verified" | "pending" | "missing" | "needs_review" | "unknown";
+
+export type RiskAgentConsistencyStatus = "aligned" | "conflict" | "unknown";
+
+export interface RiskAgentFactor {
+  code: string;
+  label: string;
+  impact: RiskAgentFactorImpact;
+  weight: number;
+}
+
+export interface RiskAgentInputs {
+  monthlyIncome: number | null;
+  monthlyRent: number | null;
+  incomeToRentRatio: number | null;
+  identityStatus: RiskAgentIdentityStatus;
+  documentStatus: RiskAgentDocumentStatus;
+  employmentMonths: number | null;
+  coTenantCount: number | null;
+  applicationCompleteness: number | null;
+  paymentHistoryRatio: number | null;
+  latePayments: number | null;
+  leaseApplicationConsistency: RiskAgentConsistencyStatus;
+}
+
+export interface RiskAgentEvaluation {
+  version: RiskAgentVersion;
+  score: number;
+  grade: RiskAgentGrade;
+  confidence: number;
+  confidenceBand: RiskAgentConfidenceBand;
+  status: RiskAgentStatus;
+  factors: RiskAgentFactor[];
+  flags: string[];
+  recommendations: string[];
+  inputs: RiskAgentInputs;
+  createdAt: string;
+}
+
+export interface RiskAgentRunRecord extends RiskAgentEvaluation {
+  id: string;
+  entityType: "application";
+  entityId: string;
+  applicationId: string;
+  landlordId: string | null;
+  propertyId: string | null;
+  tenantId: string | null;
+  leaseId: string | null;
+  reviewSummarySnapshot: {
+    screeningStatus: string | null;
+    screeningProvider: string | null;
+    screeningScoreBand: string | null;
+    applicationStatus: string | null;
+  };
+}
+
+export interface RiskAgentLatestRecord extends RiskAgentEvaluation {
+  id: string;
+  latestRunId: string;
+  entityType: "application";
+  entityId: string;
+  applicationId: string;
+  landlordId: string | null;
+  propertyId: string | null;
+  tenantId: string | null;
+  leaseId: string | null;
+  updatedAt: string;
+}
+
+export interface RiskAgentApplicationContext {
+  applicationId: string;
+  application: any;
+  landlordId: string | null;
+  propertyId: string | null;
+  tenantId: string | null;
+  leaseId: string | null;
+  identityStatus: RiskAgentIdentityStatus;
+  documentStatus: RiskAgentDocumentStatus;
+  monthlyIncome: number | null;
+  monthlyRent: number | null;
+  employmentMonths: number | null;
+  coTenantCount: number | null;
+  applicationCompleteness: number | null;
+  paymentHistoryRatio: number | null;
+  latePayments: number | null;
+  leaseApplicationConsistency: RiskAgentConsistencyStatus;
+  reviewSummarySnapshot: {
+    screeningStatus: string | null;
+    screeningProvider: string | null;
+    screeningScoreBand: string | null;
+    applicationStatus: string | null;
+  };
+}


### PR DESCRIPTION
Summary
Add Risk Agent v1 as the first deterministic landlord/admin decision-support layer
Evaluate application risk using explicit rules over canonical platform data
Persist structured risk results and expose landlord/admin-safe retrieval without automatic decisioning
Changes
Added deterministic risk engine and supporting services:
riskAgentService.ts
riskRulesEngine.ts
riskScoring.ts
riskTypes.ts
riskPersistenceService.ts
Added landlord/admin-safe routes:
POST /api/risk-agent/applications/:id/evaluate
GET /api/risk-agent/applications/:id/latest
Added persistence model:
append-only runs in risk_agent_runs
latest snapshot in risk_agent_latest
Added documentation:
docs/risk-agent-v1.md
Added tests for:
scoring rules
service behavior
route access and retrieval
Risk Inputs Used
monthly rent
monthly income
income-to-rent ratio
identity verification status
document completeness
application completeness
employment months
co-tenant count
payment history proxy when available
lease/application consistency when linked context exists
Score / Grade Model
version: risk-v1
score range: 0–100
higher score = lower risk / stronger file
grades:
A = 85–100
B = 70–84
C = 55–69
D = 40–54
E = 0–39
statuses:
completed
insufficient_data
manual_review_required
Validation
 Targeted backend tests passed
 Backend build passed
 Frontend changes not part of this mission
 Lint not required for this scoped mission

Commands run:

cd rentchain-api
PATH="$HOME/.nvm/versions/node/v20.20.2/bin:$PATH" npm run test -- src/services/__tests__/riskAgentService.test.ts src/services/__tests__/riskRulesEngine.test.ts src/routes/__tests__/riskAgentRoutes.test.ts
PATH="$HOME/.nvm/versions/node/v20.20.2/bin:$PATH" npm run build
git status --short
Notes / Limitations
V1 is application-focused, not yet a broader multi-entity risk platform
Risk results are available through dedicated backend routes, not yet embedded everywhere in landlord/admin review surfaces
Payment history is only used when linked canonical data already exists
No tenant-facing explanation UI exists
No automatic approval, denial, or status mutation is performed