### PR TITLE
feat: add application completion engine v1

### DIFF
--- a/docs/application-completion-engine-v1.md
+++ b/docs/application-completion-engine-v1.md
@@ -1,0 +1,71 @@
+# Application Completion Engine v1
+
+## What It Does
+
+Application Completion Engine v1 gives tenants a guided view of what is complete, missing, pending, or needs review in their application journey.
+
+It turns the existing tenant-safe workspace data into:
+
+- a progress indicator
+- grouped completion checklist sections
+- clear item statuses
+- next-step guidance
+- direct links to existing tenant flows when those flows already exist
+
+## What Data It Uses
+
+The completion engine is a projection layer only. It does not create a new application model.
+
+It aggregates existing tenant-safe data from:
+
+- application status projection
+- identity verification status
+- document checklist visibility
+- profile completeness signals
+- lease and readiness context where safely available
+
+## Status Meanings
+
+The completion engine uses tenant-safe status translations such as:
+
+- `completed`
+- `verified`
+- `pending`
+- `missing`
+- `needs_review`
+- `not_started`
+- `in_progress`
+
+These are friendly, tenant-safe translations of the current platform state. Internal-only landlord, compliance, or risk reasoning is not exposed here.
+
+## Supported Tenant Actions
+
+When a step can be completed through an existing tenant flow, the completion engine links tenants into it directly, including:
+
+- tenant profile
+- invite redemption
+- tenant messages
+- lease or feed views where relevant
+
+It does not add fake actions for unsupported flows.
+
+## What Is Intentionally Deferred
+
+This version does not:
+
+- auto-submit applications
+- auto-approve or auto-deny anything
+- expose landlord/admin-only reasoning
+- redesign the broader tenant portal
+- re-architect upload or verification systems
+
+## How It Improves Downstream Review
+
+By making missing and pending steps clearer for tenants, the completion engine helps improve:
+
+- application completeness
+- profile quality
+- document readiness
+- identity readiness
+- downstream landlord review clarity
+- downstream Risk Agent input quality

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -214,6 +214,73 @@ describe("tenantPortalRoutes foundation", () => {
     expect(eventDocs.some((event) => event.event_type === "tenant_workspace_viewed")).toBe(true);
   });
 
+  it("returns a grouped tenant-safe application completion checklist", async () => {
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/application-completion",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.progressPercent).toBeTypeOf("number");
+    expect(Array.isArray(res.body?.data?.sections)).toBe(true);
+    expect(res.body?.data?.sections?.map((section: any) => section.key)).toEqual(
+      expect.arrayContaining(["identity", "documents", "profile", "readiness"])
+    );
+    expect(res.body?.data?.sections?.some((section: any) => Array.isArray(section.items) && section.items.length > 0)).toBe(true);
+    expect(res.body?.data?.sections?.flatMap((section: any) => section.items || [])).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ internalSecret: expect.anything() })])
+    );
+    expect(res.body?.data?.sections?.flatMap((section: any) => section.items || [])).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ sin: expect.anything() })])
+    );
+
+    const eventDocs = Array.from(ensureCollection("event_log").values());
+    expect(eventDocs.some((event) => event.event_type === "tenant_application_completion_viewed")).toBe(true);
+  });
+
+  it("rejects unauthorized application completion access", async () => {
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/application-completion",
+    });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("handles missing application context safely in the completion engine", async () => {
+    ensureCollection("applications").clear();
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/application-completion",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.status).toMatch(/not_started|in_progress|pending|needs_review/);
+    expect(Array.isArray(res.body?.data?.sections)).toBe(true);
+    const readinessSection = res.body?.data?.sections?.find((section: any) => section.key === "readiness");
+    expect(readinessSection).toBeTruthy();
+  });
+
   it("submits maintenance only for active tenant context", async () => {
     const router = (await import("../tenantPortalRoutes")).default;
     const res = await invokeRouter(router, {

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -93,6 +93,30 @@ type TenantCommunicationItem = {
   relatedEntityId: string | null;
 };
 
+type CompletionStatus =
+  | "completed"
+  | "verified"
+  | "pending"
+  | "missing"
+  | "needs_review"
+  | "not_started"
+  | "in_progress";
+
+type TenantCompletionItem = {
+  key: string;
+  label: string;
+  status: CompletionStatus;
+  nextAction: string | null;
+  actionPath: string | null;
+};
+
+type TenantCompletionSection = {
+  key: string;
+  label: string;
+  status: CompletionStatus;
+  items: TenantCompletionItem[];
+};
+
 const SCREENING_REQUEST_STATUSES = [
   "requested",
   "consent_pending",
@@ -1725,6 +1749,259 @@ async function loadTenantWorkspaceData(context: Awaited<ReturnType<typeof resolv
   };
 }
 
+function completionWeight(status: CompletionStatus): number {
+  switch (status) {
+    case "completed":
+    case "verified":
+      return 1;
+    case "pending":
+    case "in_progress":
+      return 0.55;
+    case "needs_review":
+      return 0.35;
+    default:
+      return 0;
+  }
+}
+
+function aggregateCompletionStatus(statuses: CompletionStatus[]): CompletionStatus {
+  if (!statuses.length) return "not_started";
+  if (statuses.every((status) => status === "completed" || status === "verified")) return "completed";
+  if (statuses.some((status) => status === "needs_review")) return "needs_review";
+  if (statuses.every((status) => status === "missing" || status === "not_started")) return "not_started";
+  if (statuses.some((status) => status === "pending")) return "pending";
+  return "in_progress";
+}
+
+function mapIdentityStatus(status: string | null | undefined): CompletionStatus {
+  switch (String(status || "").trim().toLowerCase()) {
+    case "verified":
+      return "verified";
+    case "pending":
+      return "pending";
+    case "needs_review":
+      return "needs_review";
+    case "missing":
+      return "missing";
+    default:
+      return "not_started";
+  }
+}
+
+function prettyChecklistLabel(value: string): string {
+  return String(value || "")
+    .trim()
+    .replace(/[_-]+/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function inferActionPath(params: { key: string; nextAction: string | null; authority: string | null }): string | null {
+  const key = String(params.key || "").toLowerCase();
+  const nextAction = String(params.nextAction || "").toLowerCase();
+  if (key.includes("identity") || key.includes("document") || key.includes("income") || key.includes("profile") || key.includes("employer")) {
+    return "/tenant/profile";
+  }
+  if (key.includes("invite") || params.authority === "invite") {
+    return "/tenant/invite/redeem";
+  }
+  if (key.includes("message") || key.includes("communication") || nextAction.includes("message") || nextAction.includes("contact")) {
+    return "/tenant/messages";
+  }
+  return null;
+}
+
+function buildCompletionSections(params: {
+  context: Awaited<ReturnType<typeof resolveTenancyContext>>;
+  workspace: Awaited<ReturnType<typeof loadTenantWorkspaceData>>;
+  profile: Awaited<ReturnType<typeof loadTenantProfileProjection>>;
+}) {
+  const { context, workspace, profile } = params;
+  const application = workspace.application;
+  const profileSummary = profile.profile;
+  const identity = profile.identity;
+
+  const identityItems: TenantCompletionItem[] = [
+    {
+      key: "identity_verification",
+      label: "Identity verification",
+      status: mapIdentityStatus(identity?.identityVerification?.status),
+      nextAction:
+        identity?.identityVerification?.status === "verified"
+          ? null
+          : identity?.identityVerification?.note || "Complete identity verification",
+      actionPath: identity?.identityVerification?.status === "verified" ? null : "/tenant/profile",
+    },
+  ];
+
+  const documentItems: TenantCompletionItem[] =
+    identity?.documentChecklist?.length
+      ? identity.documentChecklist.map((item: any) => ({
+          key: String(item.code || "").trim(),
+          label: String(item.label || "").trim() || prettyChecklistLabel(String(item.code || "")),
+          status: mapIdentityStatus(item.status),
+          nextAction: String(item.nextStep || "").trim() || null,
+          actionPath: inferActionPath({
+            key: String(item.code || ""),
+            nextAction: String(item.nextStep || ""),
+            authority: context.authority,
+          }),
+        }))
+      : [
+          {
+            key: "documents_not_started",
+            label: "Documents",
+            status: "not_started",
+            nextAction: "Add any requested identity or income documents",
+            actionPath: "/tenant/profile",
+          },
+        ];
+
+  const missingStepItems: TenantCompletionItem[] = Array.isArray(application?.missingSteps)
+    ? application.missingSteps.map((step: string) => ({
+        key: String(step || "").trim().toLowerCase(),
+        label: prettyChecklistLabel(step),
+        status: "missing" as CompletionStatus,
+        nextAction:
+          (application?.nextActions || []).find((action: string) =>
+            String(action || "").toLowerCase().includes(String(step || "").toLowerCase())
+          ) || `Complete ${prettyChecklistLabel(step)}`,
+        actionPath: inferActionPath({
+          key: String(step || ""),
+          nextAction:
+            (application?.nextActions || []).find((action: string) =>
+              String(action || "").toLowerCase().includes(String(step || "").toLowerCase())
+            ) || "",
+          authority: context.authority,
+        }),
+      }))
+    : [];
+
+  const profileItems: TenantCompletionItem[] = [
+    {
+      key: "profile_basics",
+      label: "Profile basics",
+      status:
+        profileSummary?.displayName && profileSummary?.email
+          ? "completed"
+          : profileSummary?.email
+          ? "pending"
+          : "missing",
+      nextAction:
+        profileSummary?.displayName && profileSummary?.email ? null : "Complete your profile details",
+      actionPath:
+        profileSummary?.displayName && profileSummary?.email ? null : "/tenant/profile",
+    },
+    ...(missingStepItems.length
+      ? missingStepItems
+      : [
+          {
+            key: "application_details",
+            label: "Application details",
+            status: application ? "completed" : "not_started",
+            nextAction: application ? null : "Start your application details",
+            actionPath: application ? null : context.authority === "invite" ? "/tenant/invite/redeem" : "/tenant/profile",
+          } as TenantCompletionItem,
+        ]),
+  ];
+
+  const readinessItems: TenantCompletionItem[] = [
+    {
+      key: "application_submission",
+      label: "Application submission",
+      status:
+        !application
+          ? "not_started"
+          : ["approved", "submitted", "in_review", "conditional_cosigner", "conditional_deposit"].includes(
+              String(application.status || "").toLowerCase()
+            )
+          ? "completed"
+          : String(application.status || "").toLowerCase() === "draft"
+          ? "in_progress"
+          : "pending",
+      nextAction:
+        !application
+          ? "Begin your application"
+          : String(application.status || "").toLowerCase() === "draft"
+          ? "Finish the remaining application steps"
+          : null,
+      actionPath:
+        !application || String(application?.status || "").toLowerCase() === "draft"
+          ? context.authority === "invite"
+            ? "/tenant/invite/redeem"
+            : "/tenant/application"
+          : null,
+    },
+    {
+      key: "lease_readiness",
+      label: "Lease readiness",
+      status:
+        workspace.lease?.status
+          ? ["active", "signed"].includes(String(workspace.lease.status || "").toLowerCase())
+            ? "completed"
+            : "pending"
+          : "pending",
+      nextAction: workspace.lease ? null : "Watch for lease updates after your application review",
+      actionPath: workspace.lease ? "/tenant/lease" : "/tenant/activity",
+    },
+  ];
+
+  const sections: TenantCompletionSection[] = [
+    {
+      key: "identity",
+      label: "Identity",
+      status: aggregateCompletionStatus(identityItems.map((item) => item.status)),
+      items: identityItems,
+    },
+    {
+      key: "documents",
+      label: "Documents",
+      status: aggregateCompletionStatus(documentItems.map((item) => item.status)),
+      items: documentItems,
+    },
+    {
+      key: "profile",
+      label: "Profile & Application Info",
+      status: aggregateCompletionStatus(profileItems.map((item) => item.status)),
+      items: profileItems,
+    },
+    {
+      key: "readiness",
+      label: "Application Readiness",
+      status: aggregateCompletionStatus(readinessItems.map((item) => item.status)),
+      items: readinessItems,
+    },
+  ];
+
+  const actionableItems = sections
+    .flatMap((section) => section.items)
+    .filter((item) => !["completed", "verified"].includes(item.status) && item.nextAction);
+  const nextSteps = Array.from(new Set(actionableItems.map((item) => String(item.nextAction || "").trim()).filter(Boolean)));
+
+  const allStatuses = sections.flatMap((section) => section.items.map((item) => item.status));
+  const weightedTotal = allStatuses.reduce((sum, status) => sum + completionWeight(status), 0);
+  const progressPercent = allStatuses.length ? Math.round((weightedTotal / allStatuses.length) * 100) : 0;
+  const status =
+    progressPercent >= 100 && !sections.some((section) => section.status === "needs_review")
+      ? "completed"
+      : sections.some((section) => section.status === "needs_review")
+      ? "needs_review"
+      : progressPercent === 0
+      ? "not_started"
+      : "in_progress";
+
+  return {
+    status,
+    progressPercent,
+    sections,
+    nextSteps,
+    updatedAt:
+      profile?.identity?.identityVerification?.updatedAt ||
+      profileSummary?.application?.updatedAt ||
+      profileSummary?.lease?.startDate ||
+      null,
+  };
+}
+
 async function handleTenantWorkspaceSummary(req: any, res: any) {
   const context = await resolveWorkspaceContextOrRespond(req, res);
   if (!context) return;
@@ -1917,6 +2194,51 @@ router.get("/application-status", requireTenantWorkspaceIdentity, async (req: an
   if (!context) return;
   const workspace = await loadTenantWorkspaceData(context);
   return res.json({ ok: true, data: workspace.application });
+});
+
+router.get("/application-completion", requireTenantWorkspaceIdentity, async (req: any, res) => {
+  const context = await resolveWorkspaceContextOrRespond(req, res);
+  if (!context) return;
+
+  try {
+    const [workspace, profile] = await Promise.all([
+      loadTenantWorkspaceData(context),
+      loadTenantProfileProjection({
+        context,
+        userId: String(req.user?.id || "").trim(),
+        userEmail: String(req.user?.email || "").trim() || null,
+      }),
+    ]);
+
+    const summary = buildCompletionSections({ context, workspace, profile });
+
+    await recordTenantEvent({
+      eventType: "tenant_application_completion_viewed",
+      entityType: "tenant_application_completion",
+      entityId: String(context.applicationId || context.tenantId || context.propertyId || req.user?.id || "tenant_application_completion"),
+      createdBy: String(req.user?.id || "").trim(),
+      context: {
+        authority: context.authority,
+        propertyId: context.propertyId,
+        rc_prop_id: context.rc_prop_id,
+        applicationId: context.applicationId,
+        leaseId: context.leaseId,
+      },
+      payload: {
+        progressPercent: summary.progressPercent,
+        status: summary.status,
+        nextStepCount: summary.nextSteps.length,
+      },
+    });
+
+    return res.json({ ok: true, data: summary });
+  } catch (err: any) {
+    console.error("[tenant/application-completion] failed", {
+      userId: req.user?.id,
+      message: err?.message || "failed",
+    });
+    return res.status(500).json({ ok: false, error: "TENANT_APPLICATION_COMPLETION_FAILED" });
+  }
 });
 
 router.get("/lease", requireTenantWorkspaceIdentity, async (req: any, res) => {

--- a/rentchain-frontend/src/api/tenantApplicationCompletion.ts
+++ b/rentchain-frontend/src/api/tenantApplicationCompletion.ts
@@ -1,0 +1,40 @@
+import { tenantApiFetch } from "./tenantApiFetch";
+
+export type TenantApplicationCompletionStatus =
+  | "completed"
+  | "verified"
+  | "pending"
+  | "missing"
+  | "needs_review"
+  | "not_started"
+  | "in_progress";
+
+export type TenantApplicationCompletionItem = {
+  key: string;
+  label: string;
+  status: TenantApplicationCompletionStatus;
+  nextAction: string | null;
+  actionPath: string | null;
+};
+
+export type TenantApplicationCompletionSection = {
+  key: string;
+  label: string;
+  status: TenantApplicationCompletionStatus;
+  items: TenantApplicationCompletionItem[];
+};
+
+export type TenantApplicationCompletionSummary = {
+  status: TenantApplicationCompletionStatus;
+  progressPercent: number;
+  sections: TenantApplicationCompletionSection[];
+  nextSteps: string[];
+  updatedAt: string | null;
+};
+
+export async function getTenantApplicationCompletion(): Promise<TenantApplicationCompletionSummary | null> {
+  const res = await tenantApiFetch<{ ok: boolean; data: TenantApplicationCompletionSummary | null }>(
+    "/tenant/application-completion"
+  );
+  return res?.data ?? null;
+}

--- a/rentchain-frontend/src/pages/tenant/TenantApplicationCompletionPage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantApplicationCompletionPage.test.tsx
@@ -1,0 +1,94 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import TenantApplicationStatusPage from "./TenantApplicationStatusPage";
+
+const tenantApplicationCompletionApi = vi.hoisted(() => ({
+  getTenantApplicationCompletion: vi.fn(),
+}));
+
+vi.mock("../../api/tenantApplicationCompletion", () => tenantApplicationCompletionApi);
+
+describe("tenant application completion page", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("renders progress and grouped checklist safely", async () => {
+    tenantApplicationCompletionApi.getTenantApplicationCompletion.mockResolvedValue({
+      status: "in_progress",
+      progressPercent: 62,
+      sections: [
+        {
+          key: "identity",
+          label: "Identity",
+          status: "verified",
+          items: [
+            {
+              key: "identity_verification",
+              label: "Identity verification",
+              status: "verified",
+              nextAction: null,
+              actionPath: null,
+            },
+          ],
+        },
+        {
+          key: "documents",
+          label: "Documents",
+          status: "missing",
+          items: [
+            {
+              key: "income_documents",
+              label: "Income documents",
+              status: "missing",
+              nextAction: "Upload income documents",
+              actionPath: "/tenant/profile",
+            },
+          ],
+        },
+      ],
+      nextSteps: ["Upload income documents"],
+      updatedAt: "2026-01-02T00:00:00.000Z",
+    });
+
+    render(
+      <MemoryRouter>
+        <TenantApplicationStatusPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Application Completion/i)).toBeInTheDocument();
+    expect(screen.getByText(/62%/i)).toBeInTheDocument();
+    expect(screen.getByText(/Identity verification/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Upload income documents/i).length).toBeGreaterThan(0);
+    expect(screen.getByRole("link", { name: /Continue this step/i })).toBeInTheDocument();
+  });
+
+  it("renders empty state safely", async () => {
+    tenantApplicationCompletionApi.getTenantApplicationCompletion.mockResolvedValue(null);
+
+    render(
+      <MemoryRouter>
+        <TenantApplicationStatusPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/No application checklist yet/i)).toBeInTheDocument();
+  });
+
+  it("renders error state safely", async () => {
+    tenantApplicationCompletionApi.getTenantApplicationCompletion.mockRejectedValue(new Error("Unable to load application completion."));
+
+    render(
+      <MemoryRouter>
+        <TenantApplicationStatusPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/We couldn't load this view/i)).toBeInTheDocument();
+    expect(screen.getByText(/Unable to load application completion/i)).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/tenant/TenantApplicationStatusPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantApplicationStatusPage.tsx
@@ -1,19 +1,139 @@
 import React from "react";
-import { getTenantApplicationStatus } from "../../api/tenantPortal";
+import { Link } from "react-router-dom";
+import {
+  getTenantApplicationCompletion,
+  type TenantApplicationCompletionItem,
+  type TenantApplicationCompletionStatus,
+} from "../../api/tenantApplicationCompletion";
 import {
   TenantEmptyState,
   TenantErrorState,
   TenantInfoCard,
-  TenantKeyValueGrid,
   TenantLoadingState,
   TenantSurfaceShell,
+  TenantUnauthorizedState,
   formatDate,
   prettyStatus,
 } from "./TenantWorkspaceShared";
 import { spacing, text as textTokens } from "../../styles/tokens";
 
+function statusTone(status: TenantApplicationCompletionStatus) {
+  switch (status) {
+    case "completed":
+    case "verified":
+      return { label: status === "verified" ? "Verified" : "Completed", color: "#166534", background: "#dcfce7" };
+    case "pending":
+      return { label: "Pending", color: "#1d4ed8", background: "#dbeafe" };
+    case "needs_review":
+      return { label: "Needs review", color: "#9a3412", background: "#ffedd5" };
+    case "missing":
+      return { label: "Missing", color: "#991b1b", background: "#fee2e2" };
+    case "not_started":
+      return { label: "Not started", color: "#475569", background: "#e2e8f0" };
+    default:
+      return { label: "In progress", color: "#0f766e", background: "#ccfbf1" };
+  }
+}
+
+function sectionSummary(status: TenantApplicationCompletionStatus) {
+  if (status === "completed" || status === "verified") return "All key items in this section are complete.";
+  if (status === "needs_review") return "At least one item needs attention before your file is fully ready.";
+  if (status === "pending") return "This section is moving forward, but some steps are still being processed.";
+  if (status === "missing" || status === "not_started") return "You still have steps to finish in this section.";
+  return "You’ve started this section, but it still needs a few more updates.";
+}
+
+const CompletionProgressCard: React.FC<{ progressPercent: number; status: TenantApplicationCompletionStatus }> = ({
+  progressPercent,
+  status,
+}) => {
+  const tone = statusTone(status);
+  return (
+    <TenantInfoCard heading="Completion Progress" accent="#1d4ed8">
+      <div style={{ display: "grid", gap: spacing.sm }}>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+          <div>
+            <div style={{ fontSize: "2.4rem", fontWeight: 900, color: textTokens.primary, lineHeight: 1 }}>
+              {progressPercent}%
+            </div>
+            <div style={{ color: textTokens.secondary }}>Complete based on your tenant-safe application checklist.</div>
+          </div>
+          <div
+            style={{
+              padding: "6px 10px",
+              borderRadius: 999,
+              fontWeight: 700,
+              color: tone.color,
+              background: tone.background,
+            }}
+          >
+            {tone.label}
+          </div>
+        </div>
+        <div
+          style={{
+            width: "100%",
+            height: 12,
+            borderRadius: 999,
+            background: "rgba(15,23,42,0.08)",
+            overflow: "hidden",
+          }}
+        >
+          <div
+            style={{
+              width: `${Math.max(0, Math.min(progressPercent, 100))}%`,
+              height: "100%",
+              borderRadius: 999,
+              background: "linear-gradient(90deg, #1d4ed8, #0f766e)",
+            }}
+          />
+        </div>
+      </div>
+    </TenantInfoCard>
+  );
+};
+
+const CompletionItemRow: React.FC<{ item: TenantApplicationCompletionItem }> = ({ item }) => {
+  const tone = statusTone(item.status);
+  return (
+    <div
+      style={{
+        display: "grid",
+        gap: 8,
+        border: "1px solid rgba(15,23,42,0.08)",
+        borderRadius: 12,
+        padding: "12px 14px",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, flexWrap: "wrap" }}>
+        <div style={{ fontWeight: 700, color: textTokens.primary }}>{item.label}</div>
+        <div
+          style={{
+            padding: "4px 8px",
+            borderRadius: 999,
+            fontSize: 12,
+            fontWeight: 700,
+            color: tone.color,
+            background: tone.background,
+          }}
+        >
+          {tone.label}
+        </div>
+      </div>
+      {item.nextAction ? <div style={{ color: textTokens.secondary }}>{item.nextAction}</div> : null}
+      {item.actionPath ? (
+        <div>
+          <Link to={item.actionPath} style={{ fontWeight: 700 }}>
+            Continue this step
+          </Link>
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
 export default function TenantApplicationStatusPage() {
-  const [data, setData] = React.useState<Awaited<ReturnType<typeof getTenantApplicationStatus>>>(null);
+  const [data, setData] = React.useState<Awaited<ReturnType<typeof getTenantApplicationCompletion>>>(null);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
 
@@ -21,10 +141,10 @@ export default function TenantApplicationStatusPage() {
     setLoading(true);
     setError(null);
     try {
-      setData(await getTenantApplicationStatus());
+      setData(await getTenantApplicationCompletion());
     } catch (err: any) {
       setData(null);
-      setError(err?.payload?.error || err?.message || "Unable to load application status.");
+      setError(err?.payload?.error || err?.message || "Unable to load application completion.");
     } finally {
       setLoading(false);
     }
@@ -34,68 +154,131 @@ export default function TenantApplicationStatusPage() {
     void load();
   }, [load]);
 
+  if (loading) {
+    return (
+      <TenantSurfaceShell
+        title="Application Completion"
+        subtitle="Follow the guided completion engine to see what’s done, what’s missing, and what needs review."
+      >
+        <TenantLoadingState label="Loading your application completion checklist..." />
+      </TenantSurfaceShell>
+    );
+  }
+
+  if (error) {
+    const unauthorized = /unauthorized|forbidden|ambiguous/i.test(error);
+    return (
+      <TenantSurfaceShell
+        title="Application Completion"
+        subtitle="This view only uses tenant-safe application completion signals from your current tenancy or application context."
+      >
+        {unauthorized ? <TenantUnauthorizedState /> : <TenantErrorState message={error} retry={load} />}
+      </TenantSurfaceShell>
+    );
+  }
+
+  if (!data) {
+    return (
+      <TenantSurfaceShell
+        title="Application Completion"
+        subtitle="Follow the guided completion engine to see what’s done, what’s missing, and what needs review."
+      >
+        <TenantEmptyState
+          title="No application checklist yet"
+          body="We couldn’t find an active tenant-safe application completion view for this workspace yet."
+        />
+      </TenantSurfaceShell>
+    );
+  }
+
   return (
     <TenantSurfaceShell
-      title="Application Status"
-      subtitle="This page only renders the tenant-safe application projection from the tenant foundation backend."
+      title="Application Completion"
+      subtitle="Use this checklist to finish the right steps in the right order so your application moves forward with fewer delays."
+      action={
+        <Link
+          to="/tenant/profile"
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            padding: "9px 12px",
+            borderRadius: 10,
+            textDecoration: "none",
+            fontWeight: 700,
+            border: "1px solid rgba(15,23,42,0.08)",
+          }}
+        >
+          Open profile
+        </Link>
+      }
     >
-      {loading ? <TenantLoadingState label="Loading application status..." /> : null}
-      {!loading && error ? <TenantErrorState message={error} retry={load} /> : null}
-      {!loading && !error && !data ? (
-        <TenantEmptyState
-          title="No application status yet"
-          body="This workspace does not currently expose an application status projection."
-        />
-      ) : null}
-      {!loading && !error && data ? (
-        <>
-          <TenantInfoCard heading="Application Summary" accent="#1d4ed8">
-            <TenantKeyValueGrid
-              rows={[
-                { label: "Status", value: prettyStatus(data.status) },
-                { label: "Created", value: formatDate(data.createdAt) },
-                { label: "Updated", value: formatDate(data.updatedAt) },
-              ]}
-            />
-          </TenantInfoCard>
+      <CompletionProgressCard progressPercent={data.progressPercent} status={data.status} />
 
-          <div
-            style={{
-              display: "grid",
-              gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
-              gap: spacing.md,
-            }}
-          >
-            <TenantInfoCard heading="Missing Steps" accent="#b45309">
-              {data.missingSteps.length ? (
-                <div style={{ display: "grid", gap: 8 }}>
-                  {data.missingSteps.map((item) => (
-                    <div key={item} style={{ color: textTokens.secondary }}>
-                      {item}
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <div style={{ color: textTokens.muted }}>No missing steps are currently listed.</div>
-              )}
-            </TenantInfoCard>
-
-            <TenantInfoCard heading="Next Actions" accent="#0f766e">
-              {data.nextActions.length ? (
-                <div style={{ display: "grid", gap: 8 }}>
-                  {data.nextActions.map((item) => (
-                    <div key={item} style={{ color: textTokens.secondary }}>
-                      {item}
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <div style={{ color: textTokens.muted }}>No next actions are currently listed.</div>
-              )}
-            </TenantInfoCard>
+      {data.nextSteps.length ? (
+        <TenantInfoCard heading="Next Steps" accent="#0891b2">
+          <div style={{ display: "grid", gap: 8 }}>
+            {data.nextSteps.map((step) => (
+              <div key={step} style={{ color: textTokens.secondary }}>
+                {step}
+              </div>
+            ))}
           </div>
-        </>
-      ) : null}
+        </TenantInfoCard>
+      ) : (
+        <TenantInfoCard heading="Next Steps" accent="#0891b2">
+          <div style={{ color: textTokens.muted }}>
+            No extra actions are required right now. Keep an eye on your feed for updates.
+          </div>
+        </TenantInfoCard>
+      )}
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
+          gap: spacing.md,
+        }}
+      >
+        {data.sections.map((section) => {
+          const tone = statusTone(section.status);
+          return (
+            <TenantInfoCard key={section.key} heading={section.label} accent={tone.color}>
+              <div style={{ display: "grid", gap: spacing.sm }}>
+                <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, flexWrap: "wrap" }}>
+                  <div style={{ color: textTokens.secondary }}>{sectionSummary(section.status)}</div>
+                  <div
+                    style={{
+                      padding: "4px 8px",
+                      borderRadius: 999,
+                      fontSize: 12,
+                      fontWeight: 700,
+                      color: tone.color,
+                      background: tone.background,
+                    }}
+                  >
+                    {tone.label}
+                  </div>
+                </div>
+                <div style={{ display: "grid", gap: 10 }}>
+                  {section.items.map((item) => (
+                    <CompletionItemRow key={`${section.key}:${item.key}`} item={item} />
+                  ))}
+                </div>
+              </div>
+            </TenantInfoCard>
+          );
+        })}
+      </div>
+
+      <TenantInfoCard heading="Checklist Updated" accent="#7c3aed">
+        <div style={{ color: textTokens.secondary }}>
+          Last updated: <strong>{formatDate(data.updatedAt)}</strong>
+        </div>
+        <div style={{ color: textTokens.muted }}>
+          Status: <strong>{prettyStatus(data.status)}</strong>
+        </div>
+      </TenantInfoCard>
     </TenantSurfaceShell>
   );
 }

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -11,10 +11,13 @@ import { TenantNav } from "../../components/layout/TenantNav";
 
 const tenantPortalApi = vi.hoisted(() => ({
   getTenantWorkspace: vi.fn(),
-  getTenantApplicationStatus: vi.fn(),
   getTenantLeaseWorkspace: vi.fn(),
   listTenantWorkspaceMaintenance: vi.fn(),
   redeemTenantWorkspaceInvite: vi.fn(),
+}));
+
+const tenantApplicationCompletionApi = vi.hoisted(() => ({
+  getTenantApplicationCompletion: vi.fn(),
 }));
 
 const maintenanceWorkflowApi = vi.hoisted(() => ({
@@ -26,6 +29,7 @@ const tenantCommunicationsApi = vi.hoisted(() => ({
 }));
 
 vi.mock("../../api/tenantPortal", () => tenantPortalApi);
+vi.mock("../../api/tenantApplicationCompletion", () => tenantApplicationCompletionApi);
 vi.mock("../../api/tenantCommunicationsApi", () => tenantCommunicationsApi);
 vi.mock("../../api/maintenanceWorkflowApi", async () => {
   const actual = await vi.importActual<any>("../../api/maintenanceWorkflowApi");
@@ -142,13 +146,27 @@ describe("tenant workspace frontend shell", () => {
     expect(screen.getByText(/finish_profile/i)).toBeInTheDocument();
   });
 
-  it("renders application status page with safe projected fields", async () => {
-    tenantPortalApi.getTenantApplicationStatus.mockResolvedValue({
-      applicationId: "app-1",
-      status: "submitted",
-      missingSteps: ["upload_id"],
-      nextActions: ["finish_profile"],
-      createdAt: "2026-01-01T00:00:00.000Z",
+  it("renders application completion page with safe grouped checklist fields", async () => {
+    tenantApplicationCompletionApi.getTenantApplicationCompletion.mockResolvedValue({
+      status: "in_progress",
+      progressPercent: 62,
+      sections: [
+        {
+          key: "documents",
+          label: "Documents",
+          status: "missing",
+          items: [
+            {
+              key: "upload_id",
+              label: "Upload Id",
+              status: "missing",
+              nextAction: "Upload government id",
+              actionPath: "/tenant/profile",
+            },
+          ],
+        },
+      ],
+      nextSteps: ["Upload government id"],
       updatedAt: "2026-01-02T00:00:00.000Z",
     });
 
@@ -158,9 +176,9 @@ describe("tenant workspace frontend shell", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText(/Application Status/i)).toBeInTheDocument();
-    expect(screen.getByText(/Submitted/i)).toBeInTheDocument();
-    expect(screen.getByText(/upload_id/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Application Completion/i)).toBeInTheDocument();
+    expect(screen.getByText(/62%/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Upload government id/i).length).toBeGreaterThan(0);
   });
 
   it("renders lease page with safe projected fields", async () => {
@@ -268,7 +286,7 @@ describe("tenant workspace frontend shell", () => {
   });
 
   it("empty state renders safely for application and maintenance", async () => {
-    tenantPortalApi.getTenantApplicationStatus.mockResolvedValue(null);
+    tenantApplicationCompletionApi.getTenantApplicationCompletion.mockResolvedValue(null);
     maintenanceWorkflowApi.listTenantMaintenance.mockResolvedValue({ items: [] });
 
     const applicationRender = render(
@@ -276,7 +294,7 @@ describe("tenant workspace frontend shell", () => {
         <TenantApplicationStatusPage />
       </MemoryRouter>
     );
-    expect(await screen.findByText(/No application status yet/i)).toBeInTheDocument();
+    expect(await screen.findByText(/No application checklist yet/i)).toBeInTheDocument();
     applicationRender.unmount();
 
     render(

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
@@ -111,7 +111,7 @@ export default function TenantWorkspacePage() {
             <div style={{ display: "grid", gap: spacing.sm }}>
               <div style={{ color: textTokens.secondary }}>Current status: <strong>{prettyStatus(data.application.status)}</strong></div>
               <div style={{ color: textTokens.secondary }}>Updated: {formatDate(data.application.updatedAt || data.application.createdAt)}</div>
-              <Link to="/tenant/application">Open application status</Link>
+              <Link to="/tenant/application">Open completion checklist</Link>
             </div>
           ) : (
             <TenantEmptyState title="No application projection yet" body="We couldn't find a tenant-safe application view for this workspace yet." />


### PR DESCRIPTION
Summary
Add Application Completion Engine v1 to the tenant portal
Turn the existing /tenant/application surface into a guided completion experience
Show grouped completion status, progress, next steps, and safe action links without introducing a new tenant/application source-of-truth model
Changes
Added tenant-safe backend completion surface:
GET /api/tenant/application-completion
Extended existing tenant portal route layer to return:
overall completion status
progress percent
grouped sections
per-item statuses
next steps
updated time
Upgraded /tenant/application into a completion experience with:
progress summary
grouped checklist
status badges
next-step guidance
safe action links into existing tenant flows
Updated workspace entry copy so the application card points tenants into the completion checklist
Added documentation:
docs/application-completion-engine-v1.md
Completion Model

Sections:

identity
documents
profile
readiness

Statuses:

completed
verified
pending
missing
needs_review
not_started
in_progress
Validation
 Backend targeted tests passed
 Backend build passed
 Frontend targeted tests passed
 Frontend build passed
 Lint not required for this scoped mission