### PR TITLE
feat: add tenant profile edit and document entry points

### DIFF
--- a/docs/tenant-profile-edit-and-document-entry-points.md
+++ b/docs/tenant-profile-edit-and-document-entry-points.md
@@ -1,0 +1,51 @@
+## Tenant Profile Edit and Document Entry Points
+
+This mission makes the tenant workspace more actionable without introducing a new tenant-owned data model.
+
+### What is editable
+
+The tenant profile now supports a bounded edit surface for:
+
+- `displayName`
+- `phone`
+
+These values update existing canonical tenant and application records when that tenant authority context allows it. The route does not allow edits to landlord-only notes, admin-only notes, verification state, approval state, or risk-related fields.
+
+### What document entry actions exist
+
+Document-related next steps now point tenants into the existing tenant attachments/documents surface at `/tenant/attachments`.
+
+This mission reuses the existing document visibility flow instead of introducing a separate upload subsystem. The goal is to give tenants a direct, safe place to review document-related completion needs from:
+
+- the tenant profile page
+- the application completion checklist
+
+### What remains deferred
+
+This mission does not:
+
+- redesign document uploads
+- add a new document-management system
+- add hidden automation
+- expose landlord/admin-only internal reasoning
+- change Risk Agent scoring logic
+
+If a richer upload or document-resolution workflow is needed later, it should build on the existing canonical records and tenant authority rules rather than introducing a second source of truth.
+
+### How this improves completion flow
+
+The tenant can now:
+
+- correct a small set of profile gaps directly
+- follow document-related checklist actions into a real tenant page
+- move from “what is missing” to “what do I do next” with fewer dead ends
+
+That should improve application completeness and data quality while preserving the existing projection-based tenant architecture.
+
+### Projection architecture preserved
+
+This mission continues to treat the tenant portal as a projection layer over canonical records:
+
+- profile updates write through controlled backend routes into existing tenant/application records
+- document entry points reuse existing tenant-safe document surfaces
+- no separate tenant profile or document source-of-truth model was created

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -150,6 +150,12 @@ describe("tenantPortalRoutes foundation", () => {
       documentUrl: "https://example.com/lease.pdf",
       confidentialNotes: "private",
     });
+    ensureCollection("tenants").set("tenant-1", {
+      email: "tenant@example.com",
+      fullName: "Taylor Tenant",
+      phone: "902-555-0100",
+      internalNotes: "do-not-expose",
+    });
     ensureCollection("maintenanceRequests").set("maint-1", {
       tenantId: "tenant-1",
       propertyId: "prop-1",
@@ -242,6 +248,10 @@ describe("tenantPortalRoutes foundation", () => {
     expect(res.body?.data?.sections?.flatMap((section: any) => section.items || [])).not.toEqual(
       expect.arrayContaining([expect.objectContaining({ sin: expect.anything() })])
     );
+    const documentItem = res.body?.data?.sections
+      ?.flatMap((section: any) => section.items || [])
+      ?.find((item: any) => item.key === "upload_id");
+    expect(documentItem?.actionPath).toBe("/tenant/attachments");
 
     const eventDocs = Array.from(ensureCollection("event_log").values());
     expect(eventDocs.some((event) => event.event_type === "tenant_application_completion_viewed")).toBe(true);
@@ -279,6 +289,75 @@ describe("tenantPortalRoutes foundation", () => {
     expect(Array.isArray(res.body?.data?.sections)).toBe(true);
     const readinessSection = res.body?.data?.sections?.find((section: any) => section.key === "readiness");
     expect(readinessSection).toBeTruthy();
+  });
+
+  it("returns tenant-safe profile data with edit and document entry actions", async () => {
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/profile",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.profile?.displayName).toBe("Taylor Tenant");
+    expect(res.body?.data?.profile?.phone).toBe("902-555-0100");
+    expect(res.body?.data?.profile?.internalNotes).toBeUndefined();
+    expect(res.body?.data?.actions?.editableFields).toEqual(["displayName", "phone"]);
+    expect(res.body?.data?.actions?.documentEntry?.path).toBe("/tenant/attachments");
+  });
+
+  it("updates only allowed tenant profile fields", async () => {
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "PATCH",
+      url: "/profile",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+      body: {
+        displayName: "Taylor Updated",
+        phone: "902-555-0111",
+        internalNotes: "should-not-stick",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.profile?.displayName).toBe("Taylor Updated");
+    expect(res.body?.data?.profile?.phone).toBe("902-555-0111");
+    expect(ensureCollection("tenants").get("tenant-1")?.fullName).toBe("Taylor Updated");
+    expect(ensureCollection("tenants").get("tenant-1")?.phone).toBe("902-555-0111");
+    expect(ensureCollection("tenants").get("tenant-1")?.internalNotes).toBe("do-not-expose");
+    expect(ensureCollection("applications").get("app-1")?.applicantName).toBe("Taylor Updated");
+    expect(ensureCollection("applications").get("app-1")?.phone).toBe("902-555-0111");
+
+    const eventDocs = Array.from(ensureCollection("event_log").values());
+    expect(eventDocs.some((event) => event.event_type === "tenant_profile_updated")).toBe(true);
+  });
+
+  it("rejects unauthorized tenant profile edits", async () => {
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "PATCH",
+      url: "/profile",
+      body: {
+        displayName: "Taylor Updated",
+      },
+    });
+
+    expect(res.status).toBe(401);
   });
 
   it("submits maintenance only for active tenant context", async () => {

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -108,6 +108,7 @@ type TenantCompletionItem = {
   status: CompletionStatus;
   nextAction: string | null;
   actionPath: string | null;
+  actionLabel: string | null;
 };
 
 type TenantCompletionSection = {
@@ -1798,7 +1799,16 @@ function prettyChecklistLabel(value: string): string {
 function inferActionPath(params: { key: string; nextAction: string | null; authority: string | null }): string | null {
   const key = String(params.key || "").toLowerCase();
   const nextAction = String(params.nextAction || "").toLowerCase();
-  if (key.includes("identity") || key.includes("document") || key.includes("income") || key.includes("profile") || key.includes("employer")) {
+  if (
+    key.includes("document") ||
+    key.includes("income") ||
+    key.includes("upload") ||
+    nextAction.includes("document") ||
+    nextAction.includes("upload")
+  ) {
+    return "/tenant/attachments";
+  }
+  if (key.includes("identity") || key.includes("profile") || key.includes("employer")) {
     return "/tenant/profile";
   }
   if (key.includes("invite") || params.authority === "invite") {
@@ -1808,6 +1818,76 @@ function inferActionPath(params: { key: string; nextAction: string | null; autho
     return "/tenant/messages";
   }
   return null;
+}
+
+function inferActionLabel(actionPath: string | null): string | null {
+  switch (actionPath) {
+    case "/tenant/attachments":
+      return "Open documents";
+    case "/tenant/profile":
+      return "Update profile";
+    case "/tenant/invite/redeem":
+      return "Redeem invite";
+    case "/tenant/messages":
+      return "Open messages";
+    case "/tenant/lease":
+      return "Open lease";
+    case "/tenant/activity":
+      return "Open feed";
+    case "/tenant/application":
+      return "Open application";
+    default:
+      return null;
+  }
+}
+
+function cleanProfileField(value: unknown, max = 120): string | null {
+  const next = String(value || "")
+    .trim()
+    .replace(/\s+/g, " ")
+    .slice(0, max);
+  return next || null;
+}
+
+async function queryFirstDocument(collectionName: string, field: string, value: string | null) {
+  const normalized = cleanProfileField(value, 160);
+  if (!normalized) return null;
+  try {
+    const snap = await db.collection(collectionName).where(field, "==", normalized).limit(1).get();
+    const doc = snap.docs?.[0];
+    if (!doc) return null;
+    return { id: doc.id, data: (doc.data() as any) || {} };
+  } catch {
+    return null;
+  }
+}
+
+function buildTenantProfileActions(profile: Awaited<ReturnType<typeof loadTenantProfileProjection>>) {
+  const checklist = Array.isArray(profile?.identity?.documentChecklist) ? profile.identity.documentChecklist : [];
+  const pendingDocuments = checklist.filter((item: any) => {
+    const status = String(item?.status || "").trim().toLowerCase();
+    return status === "missing" || status === "pending" || status === "needs_review";
+  }).length;
+
+  return {
+    editableFields: ["displayName", "phone"],
+    documentEntry: {
+      available: true,
+      path: "/tenant/attachments",
+      label: pendingDocuments > 0 ? "Review requested documents" : "Open documents",
+      note:
+        pendingDocuments > 0
+          ? `${pendingDocuments} document-related step${pendingDocuments === 1 ? "" : "s"} still need attention.`
+          : "Open your tenant documents area to review what has already been shared with your record.",
+    },
+  };
+}
+
+function shapeTenantProfileResponse(profile: Awaited<ReturnType<typeof loadTenantProfileProjection>>) {
+  return {
+    ...profile,
+    actions: buildTenantProfileActions(profile),
+  };
 }
 
 function buildCompletionSections(params: {
@@ -1830,6 +1910,7 @@ function buildCompletionSections(params: {
           ? null
           : identity?.identityVerification?.note || "Complete identity verification",
       actionPath: identity?.identityVerification?.status === "verified" ? null : "/tenant/profile",
+      actionLabel: identity?.identityVerification?.status === "verified" ? null : "Update profile",
     },
   ];
 
@@ -1845,6 +1926,13 @@ function buildCompletionSections(params: {
             nextAction: String(item.nextStep || ""),
             authority: context.authority,
           }),
+          actionLabel: inferActionLabel(
+            inferActionPath({
+              key: String(item.code || ""),
+              nextAction: String(item.nextStep || ""),
+              authority: context.authority,
+            })
+          ),
         }))
       : [
           {
@@ -1852,7 +1940,8 @@ function buildCompletionSections(params: {
             label: "Documents",
             status: "not_started",
             nextAction: "Add any requested identity or income documents",
-            actionPath: "/tenant/profile",
+            actionPath: "/tenant/attachments",
+            actionLabel: "Open documents",
           },
         ];
 
@@ -1873,6 +1962,16 @@ function buildCompletionSections(params: {
             ) || "",
           authority: context.authority,
         }),
+        actionLabel: inferActionLabel(
+          inferActionPath({
+            key: String(step || ""),
+            nextAction:
+              (application?.nextActions || []).find((action: string) =>
+                String(action || "").toLowerCase().includes(String(step || "").toLowerCase())
+              ) || "",
+            authority: context.authority,
+          })
+        ),
       }))
     : [];
 
@@ -1890,6 +1989,7 @@ function buildCompletionSections(params: {
         profileSummary?.displayName && profileSummary?.email ? null : "Complete your profile details",
       actionPath:
         profileSummary?.displayName && profileSummary?.email ? null : "/tenant/profile",
+      actionLabel: profileSummary?.displayName && profileSummary?.email ? null : "Update profile",
     },
     ...(missingStepItems.length
       ? missingStepItems
@@ -1900,6 +2000,7 @@ function buildCompletionSections(params: {
             status: application ? "completed" : "not_started",
             nextAction: application ? null : "Start your application details",
             actionPath: application ? null : context.authority === "invite" ? "/tenant/invite/redeem" : "/tenant/profile",
+            actionLabel: application ? null : context.authority === "invite" ? "Redeem invite" : "Update profile",
           } as TenantCompletionItem,
         ]),
   ];
@@ -1930,6 +2031,12 @@ function buildCompletionSections(params: {
             ? "/tenant/invite/redeem"
             : "/tenant/application"
           : null,
+      actionLabel:
+        !application || String(application?.status || "").toLowerCase() === "draft"
+          ? context.authority === "invite"
+            ? "Redeem invite"
+            : "Open application"
+          : null,
     },
     {
       key: "lease_readiness",
@@ -1942,6 +2049,7 @@ function buildCompletionSections(params: {
           : "pending",
       nextAction: workspace.lease ? null : "Watch for lease updates after your application review",
       actionPath: workspace.lease ? "/tenant/lease" : "/tenant/activity",
+      actionLabel: workspace.lease ? "Open lease" : "Open feed",
     },
   ];
 
@@ -2067,13 +2175,101 @@ router.get("/profile", requireTenantWorkspaceIdentity, async (req: any, res) => 
       },
     });
 
-    return res.json({ ok: true, data: profile });
+    return res.json({ ok: true, data: shapeTenantProfileResponse(profile) });
   } catch (err: any) {
     console.error("[tenant/profile] failed", {
       userId: req.user?.id,
       message: err?.message || "failed",
     });
     return res.status(500).json({ ok: false, error: "TENANT_PROFILE_FAILED" });
+  }
+});
+
+router.patch("/profile", requireTenantWorkspaceIdentity, async (req: any, res) => {
+  const context = await resolveWorkspaceContextOrRespond(req, res);
+  if (!context) return;
+
+  const displayName = cleanProfileField(req.body?.displayName, 120);
+  const phone = cleanProfileField(req.body?.phone, 40);
+  const requestedFields = Object.keys(req.body || {}).filter((field) => ["displayName", "phone"].includes(field));
+  if (!requestedFields.length) {
+    return res.status(400).json({ ok: false, error: "TENANT_PROFILE_FIELDS_REQUIRED" });
+  }
+
+  try {
+    const userId = String(req.user?.id || "").trim();
+    const userEmail = cleanProfileField(String(req.user?.email || "").trim().toLowerCase(), 160);
+
+    const tenantDocId = cleanProfileField(context.tenantId, 120);
+    const applicationDocId =
+      cleanProfileField(context.applicationId, 120) ||
+      (await queryFirstDocument("applications", "applicantEmail", userEmail))?.id ||
+      (await queryFirstDocument("applications", "email", userEmail))?.id ||
+      null;
+
+    if (!tenantDocId && !applicationDocId) {
+      return res.status(403).json({ ok: false, error: "TENANT_PROFILE_EDIT_UNAVAILABLE" });
+    }
+
+    const now = Date.now();
+
+    if (tenantDocId) {
+      const tenantUpdates: Record<string, any> = {
+        updatedAt: now,
+        updatedAtServer: FieldValue.serverTimestamp(),
+      };
+      if (requestedFields.includes("displayName")) {
+        tenantUpdates.fullName = displayName;
+      }
+      if (requestedFields.includes("phone")) {
+        tenantUpdates.phone = phone;
+      }
+      await db.collection("tenants").doc(tenantDocId).set(tenantUpdates, { merge: true });
+    }
+
+    if (applicationDocId) {
+      const applicationUpdates: Record<string, any> = {
+        updatedAt: now,
+      };
+      if (requestedFields.includes("displayName")) {
+        applicationUpdates.applicantName = displayName;
+      }
+      if (requestedFields.includes("phone")) {
+        applicationUpdates.phone = phone;
+      }
+      await db.collection("applications").doc(applicationDocId).set(applicationUpdates, { merge: true });
+    }
+
+    const profile = await loadTenantProfileProjection({
+      context,
+      userId,
+      userEmail,
+    });
+
+    await recordTenantEvent({
+      eventType: "tenant_profile_updated",
+      entityType: "tenant_profile",
+      entityId: String(context.tenantId || context.applicationId || context.propertyId || userId || "tenant_profile"),
+      createdBy: userId,
+      context: {
+        authority: context.authority,
+        propertyId: context.propertyId,
+        rc_prop_id: context.rc_prop_id,
+        applicationId: context.applicationId,
+        leaseId: context.leaseId,
+      },
+      payload: {
+        updatedFields: requestedFields,
+      },
+    });
+
+    return res.json({ ok: true, data: shapeTenantProfileResponse(profile) });
+  } catch (err: any) {
+    console.error("[tenant/profile:patch] failed", {
+      userId: req.user?.id,
+      message: err?.message || "failed",
+    });
+    return res.status(500).json({ ok: false, error: "TENANT_PROFILE_UPDATE_FAILED" });
   }
 });
 

--- a/rentchain-frontend/src/api/tenantApplicationCompletion.ts
+++ b/rentchain-frontend/src/api/tenantApplicationCompletion.ts
@@ -15,6 +15,7 @@ export type TenantApplicationCompletionItem = {
   status: TenantApplicationCompletionStatus;
   nextAction: string | null;
   actionPath: string | null;
+  actionLabel: string | null;
 };
 
 export type TenantApplicationCompletionSection = {

--- a/rentchain-frontend/src/api/tenantProfile.ts
+++ b/rentchain-frontend/src/api/tenantProfile.ts
@@ -61,9 +61,29 @@ export type TenantProfileData = {
     }>;
     nextSteps: string[];
   };
+  actions: {
+    editableFields: string[];
+    documentEntry: {
+      available: boolean;
+      path: string | null;
+      label: string;
+      note: string | null;
+    };
+  };
 };
 
 export async function getTenantProfile(): Promise<TenantProfileData> {
   const res = await tenantApiFetch<{ ok: boolean; data: TenantProfileData }>("/tenant/profile");
+  return res.data;
+}
+
+export async function updateTenantProfile(input: {
+  displayName?: string | null;
+  phone?: string | null;
+}): Promise<TenantProfileData> {
+  const res = await tenantApiFetch<{ ok: boolean; data: TenantProfileData }>("/tenant/profile", {
+    method: "PATCH",
+    body: JSON.stringify(input),
+  });
   return res.data;
 }

--- a/rentchain-frontend/src/pages/tenant/TenantApplicationCompletionPage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantApplicationCompletionPage.test.tsx
@@ -32,6 +32,7 @@ describe("tenant application completion page", () => {
               status: "verified",
               nextAction: null,
               actionPath: null,
+              actionLabel: null,
             },
           ],
         },
@@ -45,7 +46,8 @@ describe("tenant application completion page", () => {
               label: "Income documents",
               status: "missing",
               nextAction: "Upload income documents",
-              actionPath: "/tenant/profile",
+              actionPath: "/tenant/attachments",
+              actionLabel: "Open documents",
             },
           ],
         },
@@ -64,7 +66,7 @@ describe("tenant application completion page", () => {
     expect(screen.getByText(/62%/i)).toBeInTheDocument();
     expect(screen.getByText(/Identity verification/i)).toBeInTheDocument();
     expect(screen.getAllByText(/Upload income documents/i).length).toBeGreaterThan(0);
-    expect(screen.getByRole("link", { name: /Continue this step/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Open documents/i })).toBeInTheDocument();
   });
 
   it("renders empty state safely", async () => {

--- a/rentchain-frontend/src/pages/tenant/TenantApplicationStatusPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantApplicationStatusPage.tsx
@@ -124,7 +124,7 @@ const CompletionItemRow: React.FC<{ item: TenantApplicationCompletionItem }> = (
       {item.actionPath ? (
         <div>
           <Link to={item.actionPath} style={{ fontWeight: 700 }}>
-            Continue this step
+            {item.actionLabel || "Continue this step"}
           </Link>
         </div>
       ) : null}

--- a/rentchain-frontend/src/pages/tenant/TenantProfileCommunicationsPages.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantProfileCommunicationsPages.test.tsx
@@ -9,6 +9,7 @@ import { TenantNav } from "../../components/layout/TenantNav";
 
 const tenantProfileApi = vi.hoisted(() => ({
   getTenantProfile: vi.fn(),
+  updateTenantProfile: vi.fn(),
 }));
 
 const tenantCommunicationsApi = vi.hoisted(() => ({
@@ -96,6 +97,15 @@ describe("tenant profile and communications pages", () => {
         documentChecklist: [{ code: "upload_id", label: "Upload Id", status: "missing", nextStep: "Upload government id" }],
         nextSteps: ["Upload government id"],
       },
+      actions: {
+        editableFields: ["displayName", "phone"],
+        documentEntry: {
+          available: true,
+          path: "/tenant/attachments",
+          label: "Review requested documents",
+          note: "1 document-related step still needs attention.",
+        },
+      },
     });
 
     render(
@@ -108,6 +118,143 @@ describe("tenant profile and communications pages", () => {
     expect(screen.getByText(/Taylor Tenant/i)).toBeInTheDocument();
     expect(screen.getByText(/Verification is still in progress/i)).toBeInTheDocument();
     expect(screen.getAllByText(/Upload government id/i).length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: /Save profile changes/i })).toBeInTheDocument();
+    expect(screen.getAllByRole("link", { name: /Review requested documents/i }).length).toBeGreaterThan(0);
+  });
+
+  it("tenant profile page saves bounded profile edits safely", async () => {
+    tenantProfileApi.getTenantProfile.mockResolvedValue({
+      context: { authority: "active_tenant" },
+      profile: {
+        displayName: "Taylor Tenant",
+        email: "tenant@example.com",
+        phone: "902-555-0100",
+        authorityLabel: "Active tenant",
+        property: null,
+        application: null,
+        lease: null,
+      },
+      identity: {
+        overallStatus: "verified",
+        identityVerification: {
+          status: "verified",
+          label: "Verified",
+          note: "All set.",
+          updatedAt: "2026-01-05T00:00:00.000Z",
+        },
+        documentChecklist: [],
+        nextSteps: [],
+      },
+      actions: {
+        editableFields: ["displayName", "phone"],
+        documentEntry: {
+          available: true,
+          path: "/tenant/attachments",
+          label: "Open documents",
+          note: "Open your tenant documents area.",
+        },
+      },
+    });
+    tenantProfileApi.updateTenantProfile.mockResolvedValue({
+      context: { authority: "active_tenant" },
+      profile: {
+        displayName: "Taylor Updated",
+        email: "tenant@example.com",
+        phone: "902-555-0111",
+        authorityLabel: "Active tenant",
+        property: null,
+        application: null,
+        lease: null,
+      },
+      identity: {
+        overallStatus: "verified",
+        identityVerification: {
+          status: "verified",
+          label: "Verified",
+          note: "All set.",
+          updatedAt: "2026-01-05T00:00:00.000Z",
+        },
+        documentChecklist: [],
+        nextSteps: [],
+      },
+      actions: {
+        editableFields: ["displayName", "phone"],
+        documentEntry: {
+          available: true,
+          path: "/tenant/attachments",
+          label: "Open documents",
+          note: "Open your tenant documents area.",
+        },
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <TenantProfilePage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByDisplayValue("Taylor Tenant")).toBeInTheDocument();
+    fireEvent.change(screen.getByRole("textbox", { name: /Display name/i }), {
+      target: { value: "Taylor Updated" },
+    });
+    fireEvent.change(screen.getByRole("textbox", { name: /Phone/i }), {
+      target: { value: "902-555-0111" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Save profile changes/i }));
+
+    expect(tenantProfileApi.updateTenantProfile).toHaveBeenCalledWith({
+      displayName: "Taylor Updated",
+      phone: "902-555-0111",
+    });
+    expect(await screen.findByText(/Profile details updated/i)).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Taylor Updated")).toBeInTheDocument();
+  });
+
+  it("tenant profile page handles validation failure safely", async () => {
+    tenantProfileApi.getTenantProfile.mockResolvedValue({
+      context: { authority: "active_tenant" },
+      profile: {
+        displayName: "Taylor Tenant",
+        email: "tenant@example.com",
+        phone: "902-555-0100",
+        authorityLabel: "Active tenant",
+        property: null,
+        application: null,
+        lease: null,
+      },
+      identity: {
+        overallStatus: "pending",
+        identityVerification: {
+          status: "pending",
+          label: "Pending",
+          note: "Verification is still in progress.",
+          updatedAt: "2026-01-05T00:00:00.000Z",
+        },
+        documentChecklist: [],
+        nextSteps: [],
+      },
+      actions: {
+        editableFields: ["displayName", "phone"],
+        documentEntry: {
+          available: false,
+          path: null,
+          label: "Open documents",
+          note: null,
+        },
+      },
+    });
+    tenantProfileApi.updateTenantProfile.mockRejectedValue(new Error("TENANT_PROFILE_UPDATE_FAILED"));
+
+    render(
+      <MemoryRouter>
+        <TenantProfilePage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByDisplayValue("Taylor Tenant")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Save profile changes/i }));
+    expect(await screen.findByText(/TENANT_PROFILE_UPDATE_FAILED/i)).toBeInTheDocument();
   });
 
   it("communications page handles empty state and compose/send success", async () => {

--- a/rentchain-frontend/src/pages/tenant/TenantProfilePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantProfilePage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
-import { getTenantProfile, type TenantProfileStatus } from "../../api/tenantProfile";
+import { Link } from "react-router-dom";
+import { getTenantProfile, updateTenantProfile, type TenantProfileStatus } from "../../api/tenantProfile";
 import {
   TenantEmptyState,
   TenantErrorState,
@@ -31,6 +32,10 @@ export default function TenantProfilePage() {
   const [data, setData] = useState<Awaited<ReturnType<typeof getTenantProfile>> | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [formValues, setFormValues] = useState({ displayName: "", phone: "" });
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -39,7 +44,13 @@ export default function TenantProfilePage() {
       setError(null);
       try {
         const res = await getTenantProfile();
-        if (!cancelled) setData(res);
+        if (!cancelled) {
+          setData(res);
+          setFormValues({
+            displayName: res?.profile?.displayName || "",
+            phone: res?.profile?.phone || "",
+          });
+        }
       } catch (err: any) {
         if (!cancelled) setError(err?.message || "Unable to load profile information.");
       } finally {
@@ -51,6 +62,36 @@ export default function TenantProfilePage() {
       cancelled = true;
     };
   }, []);
+
+  const handleChange =
+    (field: "displayName" | "phone") => (event: React.ChangeEvent<HTMLInputElement>) => {
+      setSaveError(null);
+      setSaveMessage(null);
+      setFormValues((current) => ({ ...current, [field]: event.target.value }));
+    };
+
+  const handleSave = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSaving(true);
+    setSaveError(null);
+    setSaveMessage(null);
+    try {
+      const next = await updateTenantProfile({
+        displayName: formValues.displayName,
+        phone: formValues.phone,
+      });
+      setData(next);
+      setFormValues({
+        displayName: next?.profile?.displayName || "",
+        phone: next?.profile?.phone || "",
+      });
+      setSaveMessage("Profile details updated.");
+    } catch (err: any) {
+      setSaveError(err?.payload?.error || err?.message || "Unable to save profile changes.");
+    } finally {
+      setSaving(false);
+    }
+  };
 
   if (loading) {
     return (
@@ -77,6 +118,7 @@ export default function TenantProfilePage() {
 
   const identityTone = statusTone(data?.identity?.overallStatus || "missing");
   const verificationTone = statusTone(data?.identity?.identityVerification?.status || "missing");
+  const documentEntry = data?.actions?.documentEntry;
   const propertyAddress = [
     data?.profile?.property?.street1,
     data?.profile?.property?.street2,
@@ -102,6 +144,93 @@ export default function TenantProfilePage() {
             { label: "Lease status", value: prettyStatus(data?.profile?.lease?.status) },
           ]}
         />
+      </TenantInfoCard>
+
+      <TenantInfoCard heading="Edit profile details" accent="#0f766e">
+        <form onSubmit={handleSave} style={{ display: "grid", gap: spacing.sm }}>
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+              gap: spacing.sm,
+            }}
+          >
+            <label style={{ display: "grid", gap: 6, color: textTokens.secondary }}>
+              <span style={{ fontWeight: 700, color: textTokens.primary }}>Display name</span>
+              <input
+                name="displayName"
+                value={formValues.displayName}
+                onChange={handleChange("displayName")}
+                maxLength={120}
+                style={{
+                  border: "1px solid rgba(15,23,42,0.12)",
+                  borderRadius: 10,
+                  padding: "10px 12px",
+                  font: "inherit",
+                }}
+              />
+            </label>
+
+            <label style={{ display: "grid", gap: 6, color: textTokens.secondary }}>
+              <span style={{ fontWeight: 700, color: textTokens.primary }}>Phone</span>
+              <input
+                name="phone"
+                value={formValues.phone}
+                onChange={handleChange("phone")}
+                maxLength={40}
+                style={{
+                  border: "1px solid rgba(15,23,42,0.12)",
+                  borderRadius: 10,
+                  padding: "10px 12px",
+                  font: "inherit",
+                }}
+              />
+            </label>
+          </div>
+
+          <div style={{ color: textTokens.muted }}>
+            You can update a small tenant-safe set of profile fields here without changing lease, approval, or verification records.
+          </div>
+
+          {saveError ? <div style={{ color: "#b91c1c", fontWeight: 600 }}>{saveError}</div> : null}
+          {saveMessage ? <div style={{ color: "#166534", fontWeight: 600 }}>{saveMessage}</div> : null}
+
+          <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+            <button
+              type="submit"
+              disabled={saving}
+              style={{
+                padding: "10px 14px",
+                borderRadius: 10,
+                border: "1px solid rgba(15,23,42,0.12)",
+                background: "#0f766e",
+                color: "#fff",
+                fontWeight: 700,
+                cursor: saving ? "wait" : "pointer",
+              }}
+            >
+              {saving ? "Saving..." : "Save profile changes"}
+            </button>
+            {documentEntry?.available && documentEntry?.path ? (
+              <Link
+                to={documentEntry.path}
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  padding: "10px 14px",
+                  borderRadius: 10,
+                  textDecoration: "none",
+                  fontWeight: 700,
+                  border: "1px solid rgba(15,23,42,0.12)",
+                  color: textTokens.primary,
+                }}
+              >
+                {documentEntry.label}
+              </Link>
+            ) : null}
+          </div>
+        </form>
       </TenantInfoCard>
 
       <div
@@ -158,6 +287,7 @@ export default function TenantProfilePage() {
       </div>
 
       <TenantInfoCard heading="Document checklist" accent="#b45309">
+        {documentEntry?.note ? <div style={{ color: textTokens.secondary }}>{documentEntry.note}</div> : null}
         {data?.identity?.documentChecklist?.length ? (
           <div style={{ display: "grid", gap: spacing.sm }}>
             {data.identity.documentChecklist.map((item) => {
@@ -189,6 +319,13 @@ export default function TenantProfilePage() {
                     </div>
                   </div>
                   {item.nextStep ? <div style={{ color: textTokens.secondary }}>{item.nextStep}</div> : null}
+                  {documentEntry?.available && documentEntry?.path ? (
+                    <div>
+                      <Link to={documentEntry.path} style={{ fontWeight: 700 }}>
+                        {documentEntry.label}
+                      </Link>
+                    </div>
+                  ) : null}
                 </div>
               );
             })}
@@ -209,6 +346,11 @@ export default function TenantProfilePage() {
                 {step}
               </div>
             ))}
+            {documentEntry?.available && documentEntry?.path ? (
+              <Link to={documentEntry.path} style={{ fontWeight: 700 }}>
+                {documentEntry.label}
+              </Link>
+            ) : null}
           </div>
         ) : (
           <div style={{ color: textTokens.muted }}>No pending next steps right now.</div>


### PR DESCRIPTION
Summary

Add a bounded tenant profile edit flow plus real document entry links from tenant profile and application completion surfaces.
Keep the implementation inside existing tenant routes/pages and preserve the projection-based architecture.
Update only safe canonical fields and make the completion engine more actionable without redesigning uploads or introducing a new tenant-owned data model.

Changes

Added tenant-safe profile update route:
PATCH /api/tenant/profile
Allowed editable fields are explicitly limited to:
displayName
phone
Reused existing tenant authority resolution and canonical record update paths
Added compact tenant profile update event logging
Updated tenant profile UI with:
inline edit form
loading state
save state
success state
error handling
Reused existing tenant attachments/documents surface as the document entry point:
/tenant/attachments
Added document-entry metadata to the tenant profile response
Updated application completion flow so next-step actions route into:
Open documents
Update profile

Validation

Backend targeted tests passed
Backend build passed
Frontend targeted tests passed
Frontend build passed
Final git status clean

Notes / Limitations

Editable profile scope is intentionally narrow: displayName and phone only
Reuses existing tenant attachments/documents surface; no new upload subsystem added
Improves routing and discoverability only; no hidden automation or submission behavior
No landlord/admin fields, verification-state edits, risk fields, or approval-state edits were exposed