### PR TITLE
feat: refine tenant document upload and review ux

### DIFF
--- a/docs/tenant-document-upload-review-ux-refinement.md
+++ b/docs/tenant-document-upload-review-ux-refinement.md
@@ -1,0 +1,57 @@
+## Tenant Document Upload / Review UX Refinement
+
+This mission refines the existing tenant document surface at `/tenant/attachments` so it works as a clearer destination from tenant profile and application completion.
+
+### What was improved
+
+- The tenant attachments route now returns tenant-safe document status metadata in addition to the underlying attachment list.
+- The attachments page now shows a completion-aware summary instead of a raw list of files.
+- Document items now use clearer tenant-safe statuses and next-step guidance.
+- Profile and application-completion document links now direct tenants into `/tenant/attachments`.
+
+### Document states tenants now see
+
+The refined UX uses tenant-safe status labels:
+
+- `missing`
+- `uploaded`
+- `pending_review`
+- `verified`
+- `needs_attention`
+- `reupload_requested`
+
+These states are derived from existing checklist and attachment records. They are intended for tenant guidance only and do not expose landlord/admin-only reasoning.
+
+### What remains deferred
+
+This mission does not:
+
+- redesign the upload backend
+- add a new storage subsystem
+- create a separate tenant document model
+- expose internal review notes or screening reasoning
+- silently mutate application state
+
+Direct tenant upload/re-upload from this page is still deferred because there is not yet a dedicated tenant-safe upload flow on this surface.
+
+### How this connects to application completion
+
+The attachments page now acts as the clearer document destination for:
+
+- tenant profile document checklist prompts
+- application completion document-related steps
+
+This makes the completion engine more actionable by giving tenants a better answer to:
+
+- what is missing
+- what is pending review
+- what needs attention
+- what they should do next
+
+### Existing document architecture preserved
+
+This mission keeps the current document/storage architecture intact:
+
+- canonical attachment records remain the source of truth
+- tenant-safe checklist data is used for status translation
+- no duplicate document system was introduced

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -179,6 +179,17 @@ describe("tenantPortalRoutes foundation", () => {
       created_at: Date.now(),
       expires_at: Date.now() + 10_000,
     });
+    ensureCollection("ledgerAttachments").set("attachment-1", {
+      tenantId: "tenant-1",
+      ledgerItemId: "ledger-1",
+      title: "Government ID",
+      fileName: "id-card.pdf",
+      purpose: "identity",
+      purposeLabel: "Upload Id",
+      url: "https://example.com/id-card.pdf",
+      createdAt: 500,
+      internalNotes: "private",
+    });
   });
 
   it("rejects unauthorized tenant workspace access", async () => {
@@ -289,6 +300,44 @@ describe("tenantPortalRoutes foundation", () => {
     expect(Array.isArray(res.body?.data?.sections)).toBe(true);
     const readinessSection = res.body?.data?.sections?.find((section: any) => section.key === "readiness");
     expect(readinessSection).toBeTruthy();
+  });
+
+  it("returns tenant-safe document states and completion guidance", async () => {
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/attachments",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body?.data)).toBe(true);
+    expect(res.body?.summary?.total).toBeGreaterThan(0);
+    expect(res.body?.summary?.pendingReview).toBeTypeOf("number");
+    expect(res.body?.guidance?.headline).toBeTypeOf("string");
+    expect(res.body?.data?.[0]?.internalNotes).toBeUndefined();
+    expect(
+      res.body?.data?.some((item: any) =>
+        ["uploaded", "missing", "pending_review", "verified", "needs_attention", "reupload_requested"].includes(item.status)
+      )
+    ).toBe(true);
+  });
+
+  it("rejects unauthorized tenant attachments access", async () => {
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/attachments",
+    });
+
+    expect(res.status).toBe(401);
   });
 
   it("returns tenant-safe profile data with edit and document entry actions", async () => {

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -118,6 +118,33 @@ type TenantCompletionSection = {
   items: TenantCompletionItem[];
 };
 
+type TenantDocumentStatus =
+  | "missing"
+  | "uploaded"
+  | "pending_review"
+  | "verified"
+  | "needs_attention"
+  | "reupload_requested";
+
+type TenantDocumentItem = {
+  id: string;
+  label: string;
+  category: string;
+  status: TenantDocumentStatus;
+  fileName: string | null;
+  title: string | null;
+  purpose: string | null;
+  purposeLabel: string | null;
+  url: string | null;
+  uploadedAt: number | null;
+  nextAction: string | null;
+  actionAvailable: boolean;
+  actionLabel: string | null;
+  actionPath: string | null;
+  helpLabel: string | null;
+  helpPath: string | null;
+};
+
 const SCREENING_REQUEST_STATUSES = [
   "requested",
   "consent_pending",
@@ -1887,6 +1914,214 @@ function shapeTenantProfileResponse(profile: Awaited<ReturnType<typeof loadTenan
   return {
     ...profile,
     actions: buildTenantProfileActions(profile),
+  };
+}
+
+function normalizeDocumentKey(value: unknown): string {
+  return String(value || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function documentCategoryForLabel(value: string): string {
+  const normalized = normalizeDocumentKey(value);
+  if (normalized.includes("income") || normalized.includes("paystub") || normalized.includes("employment")) return "Income";
+  if (normalized.includes("identity") || normalized.includes("id") || normalized.includes("passport") || normalized.includes("license")) {
+    return "Identity";
+  }
+  if (normalized.includes("lease")) return "Lease";
+  if (normalized.includes("invite")) return "Invite";
+  return "Documents";
+}
+
+function labelForAttachmentRecord(item: any): string {
+  const purpose = String(item?.purpose || "").trim();
+  const custom = String(item?.purposeLabel || "").trim();
+  if (purpose && custom) return `${purpose} — ${custom}`;
+  if (custom) return custom;
+  if (purpose) return purpose;
+  return String(item?.title || item?.fileName || "Document").trim() || "Document";
+}
+
+function toTenantDocumentStatus(params: {
+  checklistStatus: string | null;
+  hasAttachment: boolean;
+  nextAction: string | null;
+}): TenantDocumentStatus {
+  const normalized = String(params.checklistStatus || "").trim().toLowerCase();
+  const nextAction = String(params.nextAction || "").trim().toLowerCase();
+
+  if (normalized === "verified" || normalized === "completed") return "verified";
+  if (normalized === "pending") return "pending_review";
+  if (normalized === "needs_review") {
+    if (nextAction.includes("reupload") || nextAction.includes("re-upload") || nextAction.includes("replace")) {
+      return "reupload_requested";
+    }
+    return "needs_attention";
+  }
+  if (params.hasAttachment) return "uploaded";
+  return "missing";
+}
+
+function documentNextActionCopy(status: TenantDocumentStatus, nextAction: string | null, hasAttachmentUrl: boolean): string | null {
+  const explicit = String(nextAction || "").trim();
+  if (explicit) return explicit;
+  switch (status) {
+    case "verified":
+      return "This document has been reviewed and accepted.";
+    case "pending_review":
+      return "Your document has been added and is waiting for review.";
+    case "uploaded":
+      return "Your document has been added and is waiting to be reviewed in context.";
+    case "needs_attention":
+      return "This document needs attention before your application is fully complete.";
+    case "reupload_requested":
+      return "A clearer or updated version is needed before review can continue.";
+    default:
+      return hasAttachmentUrl ? "Review the latest file you added here." : "This document is still needed for completion.";
+  }
+}
+
+function buildTenantDocumentWorkspace(params: {
+  attachments: Array<any>;
+  profile: Awaited<ReturnType<typeof loadTenantProfileProjection>>;
+}) {
+  const checklist = Array.isArray(params.profile?.identity?.documentChecklist) ? params.profile.identity.documentChecklist : [];
+  const attachments = Array.isArray(params.attachments) ? params.attachments : [];
+
+  const normalizedAttachmentMap = new Map<string, any[]>();
+  attachments.forEach((item) => {
+    const labels = [item?.purpose, item?.purposeLabel, item?.title, item?.fileName]
+      .map((value) => normalizeDocumentKey(value))
+      .filter(Boolean);
+    labels.forEach((label) => {
+      const current = normalizedAttachmentMap.get(label) || [];
+      current.push(item);
+      normalizedAttachmentMap.set(label, current);
+    });
+  });
+
+  const usedAttachmentIds = new Set<string>();
+  const items: TenantDocumentItem[] = checklist.map((entry: any, index: number) => {
+    const label = String(entry?.label || "").trim() || prettyChecklistLabel(String(entry?.code || "document"));
+    const normalizedTargets = [
+      normalizeDocumentKey(entry?.code),
+      normalizeDocumentKey(label),
+      normalizeDocumentKey(entry?.nextStep),
+    ].filter(Boolean);
+
+    const matchedAttachment =
+      normalizedTargets
+        .flatMap((target) => normalizedAttachmentMap.get(target) || [])
+        .find((item) => item && !usedAttachmentIds.has(String(item.id || ""))) || null;
+
+    if (matchedAttachment?.id) {
+      usedAttachmentIds.add(String(matchedAttachment.id));
+    }
+
+    const status = toTenantDocumentStatus({
+      checklistStatus: String(entry?.status || ""),
+      hasAttachment: Boolean(matchedAttachment),
+      nextAction: String(entry?.nextStep || ""),
+    });
+
+    return {
+      id: String(entry?.code || matchedAttachment?.id || `document_${index + 1}`),
+      label,
+      category: documentCategoryForLabel(String(entry?.code || label)),
+      status,
+      fileName: matchedAttachment?.fileName ? String(matchedAttachment.fileName) : null,
+      title: matchedAttachment?.title ? String(matchedAttachment.title) : null,
+      purpose: matchedAttachment?.purpose ? String(matchedAttachment.purpose) : null,
+      purposeLabel: matchedAttachment?.purposeLabel ? String(matchedAttachment.purposeLabel) : null,
+      url: matchedAttachment?.url ? String(matchedAttachment.url) : null,
+      uploadedAt: Number(matchedAttachment?.createdAt || 0) || null,
+      nextAction: documentNextActionCopy(status, String(entry?.nextStep || ""), Boolean(matchedAttachment?.url)),
+      actionAvailable: false,
+      actionLabel: null,
+      actionPath: null,
+      helpLabel: status === "missing" || status === "needs_attention" || status === "reupload_requested" ? "Open messages" : null,
+      helpPath: status === "missing" || status === "needs_attention" || status === "reupload_requested" ? "/tenant/messages" : null,
+    };
+  });
+
+  attachments.forEach((item, index) => {
+    if (usedAttachmentIds.has(String(item?.id || ""))) return;
+    const label = labelForAttachmentRecord(item);
+    items.push({
+      id: String(item?.id || `uploaded_document_${index + 1}`),
+      label,
+      category: documentCategoryForLabel(label),
+      status: "uploaded",
+      fileName: item?.fileName ? String(item.fileName) : null,
+      title: item?.title ? String(item.title) : null,
+      purpose: item?.purpose ? String(item.purpose) : null,
+      purposeLabel: item?.purposeLabel ? String(item.purposeLabel) : null,
+      url: item?.url ? String(item.url) : null,
+      uploadedAt: Number(item?.createdAt || 0) || null,
+      nextAction: "This file has been added to your record.",
+      actionAvailable: false,
+      actionLabel: null,
+      actionPath: null,
+      helpLabel: null,
+      helpPath: null,
+    });
+  });
+
+  const order: Record<TenantDocumentStatus, number> = {
+    reupload_requested: 0,
+    needs_attention: 1,
+    missing: 2,
+    pending_review: 3,
+    uploaded: 4,
+    verified: 5,
+  };
+  items.sort((a, b) => {
+    const priority = order[a.status] - order[b.status];
+    if (priority !== 0) return priority;
+    return (b.uploadedAt || 0) - (a.uploadedAt || 0);
+  });
+
+  const summary = {
+    total: items.length,
+    missing: items.filter((item) => item.status === "missing").length,
+    uploaded: items.filter((item) => item.status === "uploaded").length,
+    pendingReview: items.filter((item) => item.status === "pending_review").length,
+    verified: items.filter((item) => item.status === "verified").length,
+    needsAttention: items.filter((item) => item.status === "needs_attention" || item.status === "reupload_requested").length,
+  };
+
+  const nextSteps = items
+    .filter((item) => item.status === "missing" || item.status === "needs_attention" || item.status === "reupload_requested")
+    .slice(0, 4)
+    .map((item) => item.nextAction)
+    .filter((value: string | null): value is string => Boolean(value));
+
+  return {
+    summary,
+    guidance: {
+      headline:
+        summary.needsAttention > 0
+          ? "Some documents need attention before your application can move forward smoothly."
+          : summary.missing > 0
+          ? "A few documents are still missing from your completion checklist."
+          : summary.pendingReview > 0
+          ? "Your latest documents are in and waiting for review."
+          : items.length
+          ? "Your current tenant-safe document record is up to date."
+          : "You have not added any tenant-visible documents yet.",
+      nextSteps,
+      uploadEntryAvailable: false,
+      uploadEntryLabel: null,
+      uploadEntryPath: null,
+      supportPath: "/tenant/messages",
+      supportLabel: "Message your landlord",
+    },
+    updatedAt: items.find((item) => item.uploadedAt)?.uploadedAt || null,
+    items,
   };
 }
 
@@ -3841,20 +4076,38 @@ router.get("/ledger", requireTenant, async (req: any, res) => {
   }
 });
 
-router.get("/attachments", requireTenant, async (req: any, res) => {
+router.get("/attachments", requireTenantWorkspaceIdentity, async (req: any, res) => {
+  const context = await resolveWorkspaceContextOrRespond(req, res);
+  if (!context) return;
+
   try {
     const tenantId = req.user?.tenantId;
     if (!tenantId) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
 
-    const snap = await db
-      .collection("ledgerAttachments")
-      .where("tenantId", "==", tenantId)
-      .limit(50)
-      .get();
+    const [snap, profile] = await Promise.all([
+      db.collection("ledgerAttachments").where("tenantId", "==", tenantId).limit(50).get(),
+      loadTenantProfileProjection({
+        context,
+        userId: String(req.user?.id || "").trim(),
+        userEmail: String(req.user?.email || "").trim() || null,
+      }),
+    ]);
 
-    const data = snap.docs.map((d) => ({ id: d.id, ...(d.data() as any) }));
-    data.sort((a, b) => (Number(b.createdAt || 0) || 0) - (Number(a.createdAt || 0) || 0));
-    return res.json({ ok: true, data });
+    const rawAttachments = snap.docs.map((d) => ({ id: d.id, ...(d.data() as any) }));
+    rawAttachments.sort((a, b) => (Number(b.createdAt || 0) || 0) - (Number(a.createdAt || 0) || 0));
+
+    const workspace = buildTenantDocumentWorkspace({
+      attachments: rawAttachments,
+      profile,
+    });
+
+    return res.json({
+      ok: true,
+      data: workspace.items,
+      summary: workspace.summary,
+      guidance: workspace.guidance,
+      updatedAt: workspace.updatedAt,
+    });
   } catch (err) {
     console.error("[tenant/attachments] failed", {
       tenantId: req.user?.tenantId,

--- a/rentchain-frontend/src/api/tenantAttachmentsApi.ts
+++ b/rentchain-frontend/src/api/tenantAttachmentsApi.ts
@@ -2,16 +2,57 @@ import { tenantApiFetch } from "./tenantApiFetch";
 
 export type TenantAttachment = {
   id: string;
-  tenantId: string;
-  ledgerItemId: string;
+  tenantId?: string | null;
+  ledgerItemId?: string | null;
   title?: string | null;
-  url: string;
+  url?: string | null;
   purpose?: string | null;
   purposeLabel?: string | null;
   fileName?: string | null;
   createdAt?: number | null;
+  label?: string | null;
+  category?: string | null;
+  status?: "missing" | "uploaded" | "pending_review" | "verified" | "needs_attention" | "reupload_requested";
+  uploadedAt?: number | null;
+  nextAction?: string | null;
+  actionAvailable?: boolean;
+  actionLabel?: string | null;
+  actionPath?: string | null;
+  helpLabel?: string | null;
+  helpPath?: string | null;
 };
 
-export async function getTenantAttachments(): Promise<{ ok: boolean; data: TenantAttachment[] }> {
-  return tenantApiFetch<{ ok: boolean; data: TenantAttachment[] }>("/tenant/attachments");
+export type TenantAttachmentSummary = {
+  total: number;
+  missing: number;
+  uploaded: number;
+  pendingReview: number;
+  verified: number;
+  needsAttention: number;
+};
+
+export type TenantAttachmentGuidance = {
+  headline: string;
+  nextSteps: string[];
+  uploadEntryAvailable: boolean;
+  uploadEntryLabel: string | null;
+  uploadEntryPath: string | null;
+  supportPath: string | null;
+  supportLabel: string | null;
+};
+
+export async function getTenantAttachments(): Promise<{
+  ok: boolean;
+  data: TenantAttachment[];
+  summary?: TenantAttachmentSummary;
+  guidance?: TenantAttachmentGuidance;
+  updatedAt?: number | null;
+}> {
+  return tenantApiFetch<{
+    ok: boolean;
+    data: TenantAttachment[];
+    summary?: TenantAttachmentSummary;
+    guidance?: TenantAttachmentGuidance;
+    updatedAt?: number | null;
+  }>("/tenant/attachments");
 }

--- a/rentchain-frontend/src/pages/tenant/TenantAttachmentsPage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantAttachmentsPage.test.tsx
@@ -1,0 +1,128 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import TenantAttachmentsPage from "./TenantAttachmentsPage";
+
+const tenantAttachmentsApi = vi.hoisted(() => ({
+  getTenantAttachments: vi.fn(),
+}));
+
+vi.mock("../../api/tenantAttachmentsApi", () => tenantAttachmentsApi);
+
+describe("tenant attachments page", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("renders empty state correctly", async () => {
+    tenantAttachmentsApi.getTenantAttachments.mockResolvedValue({
+      ok: true,
+      data: [],
+      summary: {
+        total: 0,
+        missing: 0,
+        uploaded: 0,
+        pendingReview: 0,
+        verified: 0,
+        needsAttention: 0,
+      },
+      guidance: {
+        headline: "You have not added any tenant-visible documents yet.",
+        nextSteps: [],
+        uploadEntryAvailable: false,
+        uploadEntryLabel: null,
+        uploadEntryPath: null,
+        supportPath: "/tenant/messages",
+        supportLabel: "Message your landlord",
+      },
+      updatedAt: null,
+    });
+
+    render(
+      <MemoryRouter>
+        <TenantAttachmentsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/No documents visible yet/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Open completion checklist/i })).toBeInTheDocument();
+  });
+
+  it("renders grouped status-aware document items and guidance", async () => {
+    tenantAttachmentsApi.getTenantAttachments.mockResolvedValue({
+      ok: true,
+      data: [
+        {
+          id: "doc-1",
+          label: "Income documents",
+          category: "Income",
+          status: "reupload_requested",
+          fileName: "paystub.pdf",
+          url: "https://example.com/paystub.pdf",
+          uploadedAt: 1710000000000,
+          nextAction: "Please upload a clearer income document.",
+          helpLabel: "Open messages",
+          helpPath: "/tenant/messages",
+        },
+        {
+          id: "doc-2",
+          label: "Government ID",
+          category: "Identity",
+          status: "pending_review",
+          fileName: "id-card.pdf",
+          url: "https://example.com/id-card.pdf",
+          uploadedAt: 1710001000000,
+          nextAction: "Your document has been added and is waiting for review.",
+          helpLabel: null,
+          helpPath: null,
+        },
+      ],
+      summary: {
+        total: 2,
+        missing: 0,
+        uploaded: 0,
+        pendingReview: 1,
+        verified: 0,
+        needsAttention: 1,
+      },
+      guidance: {
+        headline: "Some documents need attention before your application can move forward smoothly.",
+        nextSteps: ["Please upload a clearer income document."],
+        uploadEntryAvailable: false,
+        uploadEntryLabel: null,
+        uploadEntryPath: null,
+        supportPath: "/tenant/messages",
+        supportLabel: "Message your landlord",
+      },
+      updatedAt: 1710001000000,
+    });
+
+    render(
+      <MemoryRouter>
+        <TenantAttachmentsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Document Summary/i)).toBeInTheDocument();
+    expect(screen.getByText(/Some documents need attention/i)).toBeInTheDocument();
+    expect(screen.getByText(/Re-upload requested/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Pending review/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("link", { name: /Open file/i }).length).toBeGreaterThan(0);
+    expect(screen.getByRole("link", { name: /Message your landlord/i })).toBeInTheDocument();
+    expect(screen.getByText(/Direct upload is not available from this page yet/i)).toBeInTheDocument();
+  });
+
+  it("renders unauthorized state safely", async () => {
+    tenantAttachmentsApi.getTenantAttachments.mockRejectedValue({ message: "FORBIDDEN" });
+
+    render(
+      <MemoryRouter>
+        <TenantAttachmentsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Access unavailable/i)).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/tenant/TenantAttachmentsPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantAttachmentsPage.tsx
@@ -1,26 +1,71 @@
 import React, { useEffect, useState } from "react";
-import { getTenantAttachments, TenantAttachment } from "../../api/tenantAttachmentsApi";
-import { Card } from "../../components/ui/Ui";
-import { colors, spacing, text as textTokens } from "../../styles/tokens";
+import { Link } from "react-router-dom";
+import {
+  getTenantAttachments,
+  type TenantAttachment,
+  type TenantAttachmentGuidance,
+  type TenantAttachmentSummary,
+} from "../../api/tenantAttachmentsApi";
+import {
+  TenantEmptyState,
+  TenantErrorState,
+  TenantInfoCard,
+  TenantLoadingState,
+  TenantSurfaceShell,
+  TenantUnauthorizedState,
+  formatDate,
+} from "./TenantWorkspaceShared";
+import { spacing, text as textTokens } from "../../styles/tokens";
 
-function fmtDate(ts?: number | null): string {
-  if (!ts) return "—";
-  const d = new Date(ts);
-  if (Number.isNaN(d.getTime())) return "—";
-  return d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+function statusTone(status?: TenantAttachment["status"]) {
+  switch (status) {
+    case "verified":
+      return { label: "Verified", color: "#166534", background: "#dcfce7" };
+    case "pending_review":
+      return { label: "Pending review", color: "#1d4ed8", background: "#dbeafe" };
+    case "needs_attention":
+      return { label: "Needs attention", color: "#9a3412", background: "#ffedd5" };
+    case "reupload_requested":
+      return { label: "Re-upload requested", color: "#991b1b", background: "#fee2e2" };
+    case "missing":
+      return { label: "Missing", color: "#991b1b", background: "#fee2e2" };
+    default:
+      return { label: "Uploaded", color: "#0f766e", background: "#ccfbf1" };
+  }
 }
 
-function labelForAttachment(item: TenantAttachment): string {
-  const purpose = String(item.purpose || "").trim();
-  const custom = String(item.purposeLabel || "").trim();
-  if (purpose && custom) return `${purpose} — ${custom}`;
-  if (custom) return custom;
-  if (purpose) return purpose;
-  return "Document";
+function summaryTiles(summary?: TenantAttachmentSummary) {
+  if (!summary) return [];
+  return [
+    { label: "Missing", value: summary.missing, accent: "#991b1b" },
+    { label: "Pending review", value: summary.pendingReview, accent: "#1d4ed8" },
+    { label: "Needs attention", value: summary.needsAttention, accent: "#9a3412" },
+    { label: "Verified", value: summary.verified, accent: "#166534" },
+  ];
+}
+
+function sortUrgent(items: TenantAttachment[]) {
+  const order: Record<string, number> = {
+    reupload_requested: 0,
+    needs_attention: 1,
+    missing: 2,
+    pending_review: 3,
+    uploaded: 4,
+    verified: 5,
+  };
+  return [...items].sort((a, b) => {
+    const left = order[String(a.status || "uploaded")] ?? 99;
+    const right = order[String(b.status || "uploaded")] ?? 99;
+    if (left !== right) return left - right;
+    return Number(b.uploadedAt || b.createdAt || 0) - Number(a.uploadedAt || a.createdAt || 0);
+  });
 }
 
 export default function TenantAttachmentsPage() {
   const [items, setItems] = useState<TenantAttachment[]>([]);
+  const [summary, setSummary] = useState<TenantAttachmentSummary | undefined>(undefined);
+  const [guidance, setGuidance] = useState<TenantAttachmentGuidance | undefined>(undefined);
+  const [updatedAt, setUpdatedAt] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -31,9 +76,14 @@ export default function TenantAttachmentsPage() {
       setError(null);
       try {
         const res = await getTenantAttachments();
-        if (!cancelled) setItems(Array.isArray(res?.data) ? res.data : []);
+        if (!cancelled) {
+          setItems(Array.isArray(res?.data) ? sortUrgent(res.data) : []);
+          setSummary(res?.summary);
+          setGuidance(res?.guidance);
+          setUpdatedAt(typeof res?.updatedAt === "number" ? res.updatedAt : null);
+        }
       } catch (err: any) {
-        if (!cancelled) setError(err?.message || "Unable to load documents.");
+        if (!cancelled) setError(err?.message || err?.payload?.error || "Unable to load documents.");
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -44,55 +94,199 @@ export default function TenantAttachmentsPage() {
     };
   }, []);
 
-  return (
-    <Card elevated style={{ padding: spacing.lg }}>
-      <div style={{ marginBottom: spacing.md }}>
-        <h1 style={{ margin: 0, color: textTokens.primary, fontSize: "1.4rem" }}>Documents</h1>
-        <div style={{ marginTop: 6, color: textTokens.muted }}>
-          Files and receipts shared with your tenancy record.
-        </div>
-      </div>
+  if (loading) {
+    return (
+      <TenantSurfaceShell
+        title="Documents"
+        subtitle="Track what you’ve added, what is still missing, and what may need attention for application completion."
+      >
+        <TenantLoadingState label="Loading your document checklist..." />
+      </TenantSurfaceShell>
+    );
+  }
 
-      {error ? (
-        <div style={{ color: colors.danger }}>{error}</div>
-      ) : loading ? (
-        <div style={{ color: textTokens.muted }}>Loading documents…</div>
-      ) : items.length === 0 ? (
-        <div style={{ color: textTokens.muted }}>No documents available yet.</div>
-      ) : (
+  if (error) {
+    const unauthorized = /unauthorized|forbidden|ambiguous/i.test(error);
+    return (
+      <TenantSurfaceShell
+        title="Documents"
+        subtitle="This tenant-safe document workspace only shows records linked to your current application or tenancy context."
+      >
+        {unauthorized ? <TenantUnauthorizedState /> : <TenantErrorState message={error} />}
+      </TenantSurfaceShell>
+    );
+  }
+
+  const tiles = summaryTiles(summary);
+
+  return (
+    <TenantSurfaceShell
+      title="Documents"
+      subtitle="Use this page to understand which documents are in, which ones are still missing, and what needs attention before your application is fully complete."
+      action={
+        <Link
+          to="/tenant/application"
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            padding: "9px 12px",
+            borderRadius: 10,
+            textDecoration: "none",
+            fontWeight: 700,
+            border: "1px solid rgba(15,23,42,0.08)",
+          }}
+        >
+          Back to completion
+        </Link>
+      }
+    >
+      <TenantInfoCard heading="Document Summary" accent="#1d4ed8">
         <div style={{ display: "grid", gap: spacing.sm }}>
-          {items.map((item) => (
+          <div style={{ color: textTokens.secondary }}>
+            {guidance?.headline || "Your tenant-safe document record appears here as documents are requested and shared."}
+          </div>
+          {tiles.length ? (
             <div
-              key={item.id}
               style={{
-                border: `1px solid ${colors.border}`,
-                borderRadius: 12,
-                background: colors.card,
-                padding: spacing.sm,
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "space-between",
+                display: "grid",
+                gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))",
                 gap: spacing.sm,
               }}
             >
-              <div style={{ display: "grid", gap: 2 }}>
-                <div style={{ fontWeight: 700, color: textTokens.primary }}>{labelForAttachment(item)}</div>
-                <div style={{ fontSize: "0.9rem", color: textTokens.muted }}>
-                  {item.fileName || item.title || "Attachment"} • {fmtDate(item.createdAt)}
+              {tiles.map((tile) => (
+                <div
+                  key={tile.label}
+                  style={{
+                    border: "1px solid rgba(15,23,42,0.08)",
+                    borderRadius: 12,
+                    padding: "12px 14px",
+                    display: "grid",
+                    gap: 4,
+                  }}
+                >
+                  <div style={{ color: tile.accent, fontSize: "1.8rem", fontWeight: 900, lineHeight: 1 }}>{tile.value}</div>
+                  <div style={{ color: textTokens.secondary, fontWeight: 700 }}>{tile.label}</div>
                 </div>
-              </div>
-              <a
-                href={item.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                style={{ color: colors.accent, textDecoration: "none", fontWeight: 700 }}
-              >
-                Open
-              </a>
+              ))}
             </div>
-          ))}
+          ) : null}
+          <div style={{ color: textTokens.muted }}>
+            Last updated: <strong>{formatDate(updatedAt)}</strong>
+          </div>
+        </div>
+      </TenantInfoCard>
+
+      <TenantInfoCard heading="What To Do Next" accent="#0891b2">
+        {guidance?.nextSteps?.length ? (
+          <div style={{ display: "grid", gap: 8 }}>
+            {guidance.nextSteps.map((step) => (
+              <div key={step} style={{ color: textTokens.secondary }}>
+                {step}
+              </div>
+            ))}
+            <div style={{ display: "flex", gap: 10, flexWrap: "wrap", marginTop: 4 }}>
+              {guidance?.supportPath && guidance?.supportLabel ? (
+                <Link to={guidance.supportPath} style={{ fontWeight: 700 }}>
+                  {guidance.supportLabel}
+                </Link>
+              ) : null}
+              <Link to="/tenant/profile" style={{ fontWeight: 700 }}>
+                Review profile
+              </Link>
+            </div>
+          </div>
+        ) : (
+          <div style={{ display: "grid", gap: 8 }}>
+            <div style={{ color: textTokens.secondary }}>
+              Nothing urgent is blocking you here right now. Keep an eye on this page if new document requests appear.
+            </div>
+            {guidance?.supportPath && guidance?.supportLabel ? (
+              <Link to={guidance.supportPath} style={{ fontWeight: 700 }}>
+                {guidance.supportLabel}
+              </Link>
+            ) : null}
+          </div>
+        )}
+      </TenantInfoCard>
+
+      {items.length === 0 ? (
+        <TenantEmptyState
+          title="No documents visible yet"
+          body="When your application or tenancy asks for documents, they’ll show up here with clear tenant-safe statuses and next steps."
+          action={
+            <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+              <Link to="/tenant/application" style={{ fontWeight: 700 }}>
+                Open completion checklist
+              </Link>
+              <Link to="/tenant/messages" style={{ fontWeight: 700 }}>
+                Message your landlord
+              </Link>
+            </div>
+          }
+        />
+      ) : (
+        <div style={{ display: "grid", gap: spacing.sm }}>
+          {items.map((item) => {
+            const tone = statusTone(item.status);
+            return (
+              <TenantInfoCard key={item.id} heading={item.label || "Document"} accent={tone.color}>
+                <div style={{ display: "grid", gap: 10 }}>
+                  <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, flexWrap: "wrap" }}>
+                    <div style={{ color: textTokens.secondary }}>
+                      {item.category || "Documents"}
+                      {item.fileName ? ` • ${item.fileName}` : item.title ? ` • ${item.title}` : ""}
+                    </div>
+                    <div
+                      style={{
+                        padding: "4px 8px",
+                        borderRadius: 999,
+                        fontSize: 12,
+                        fontWeight: 700,
+                        color: tone.color,
+                        background: tone.background,
+                      }}
+                    >
+                      {tone.label}
+                    </div>
+                  </div>
+
+                  <div style={{ color: textTokens.secondary }}>
+                    {item.nextAction || "No additional action is required right now."}
+                  </div>
+
+                  <div style={{ color: textTokens.muted }}>
+                    Updated: <strong>{formatDate(item.uploadedAt || item.createdAt)}</strong>
+                  </div>
+
+                  <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+                    {item.url ? (
+                      <a
+                        href={item.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        style={{ fontWeight: 700, textDecoration: "none" }}
+                      >
+                        Open file
+                      </a>
+                    ) : null}
+                    {item.helpPath && item.helpLabel ? (
+                      <Link to={item.helpPath} style={{ fontWeight: 700 }}>
+                        {item.helpLabel}
+                      </Link>
+                    ) : null}
+                    {item.status === "missing" || item.status === "reupload_requested" ? (
+                      <span style={{ color: textTokens.muted, fontWeight: 700 }}>
+                        Direct upload is not available from this page yet
+                      </span>
+                    ) : null}
+                  </div>
+                </div>
+              </TenantInfoCard>
+            );
+          })}
         </div>
       )}
-    </Card>
+    </TenantSurfaceShell>
   );
 }

--- a/rentchain-frontend/src/pages/tenant/TenantProfileCommunicationsPages.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantProfileCommunicationsPages.test.tsx
@@ -120,6 +120,7 @@ describe("tenant profile and communications pages", () => {
     expect(screen.getAllByText(/Upload government id/i).length).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: /Save profile changes/i })).toBeInTheDocument();
     expect(screen.getAllByRole("link", { name: /Review requested documents/i }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("link", { name: /Open documents|Review documents/i }).length).toBeGreaterThan(0);
   });
 
   it("tenant profile page saves bounded profile edits safely", async () => {

--- a/rentchain-frontend/src/pages/tenant/TenantProfilePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantProfilePage.tsx
@@ -346,11 +346,9 @@ export default function TenantProfilePage() {
                 {step}
               </div>
             ))}
-            {documentEntry?.available && documentEntry?.path ? (
-              <Link to={documentEntry.path} style={{ fontWeight: 700 }}>
-                {documentEntry.label}
-              </Link>
-            ) : null}
+            <Link to="/tenant/attachments" style={{ fontWeight: 700 }}>
+              Review documents
+            </Link>
           </div>
         ) : (
           <div style={{ color: textTokens.muted }}>No pending next steps right now.</div>


### PR DESCRIPTION
## Summary
- Recreate the lost tenant document UX refinement on top of current `main`.
- Turn `/tenant/attachments` into a completion-aware tenant document workspace.
- Add clearer tenant-safe document states, urgency-first guidance, and better routing from profile/completion entry points without changing the underlying document architecture.

## Changes
- Extended tenant-safe document projection in:
  - `rentchain-api/src/routes/tenantPortalRoutes.ts`
- Added / updated tests in:
  - `rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts`
- Added / updated frontend document API and page behavior in:
  - `rentchain-frontend/src/api/tenantAttachmentsApi.ts`
  - `rentchain-frontend/src/pages/tenant/TenantAttachmentsPage.tsx`
  - `rentchain-frontend/src/pages/tenant/TenantProfilePage.tsx`
- Added / updated frontend tests in:
  - `rentchain-frontend/src/pages/tenant/TenantAttachmentsPage.test.tsx`
  - `rentchain-frontend/src/pages/tenant/TenantProfileCommunicationsPages.test.tsx`
- Added documentation:
  - `docs/tenant-document-upload-review-ux-refinement.md`

## Document Status UX
Tenant-safe document states now shown clearly in `/tenant/attachments`:
- `missing`
- `uploaded`
- `pending_review`
- `verified`
- `needs_attention`
- `reupload_requested`

Each item renders with:
- safe label
- timestamp when available
- next-step copy

## Completion Guidance
Added:
- summary counts for missing / pending review / needs attention / verified
- urgency-first ordering
- “What To Do Next” guidance
- improved empty state when no tenant-visible documents exist yet

## Action Prompts
Where supported:
- `Open file`
- `Open messages`
- `Message your landlord`

Where direct upload is not yet supported:
- `Direct upload is not available from this page yet`

## Validation
- [x] Backend targeted tests passed
- [x] Backend build passed
- [x] Frontend targeted tests passed
- [x] Frontend build passed

## Notes / Limitations
- No new tenant upload or re-upload backend added
- Direct upload from `/tenant/attachments` remains deferred
- Document states are derived from existing checklist and attachment records
- No landlord/admin-only notes, review reasoning, or internal scoring context are exposed

## ⚠ Hook Dependency Guardrail (TDZ Safety)
- [x] No TDZ-sensitive hook-heavy modules outside scoped tenant pages were modified
- [x] Frontend tests passed
- [x] Frontend build passed