### PR TITLE
feat(tenant): add tenant-first portal foundation (/tenant)

### DIFF
--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -1,7 +1,11 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+beforeEach(() => {
+  cleanup();
+});
 
 vi.stubEnv("VITE_TENANT_PORTAL_ENABLED", "true");
 
@@ -40,12 +44,42 @@ vi.mock("./features/automation/timeline/AutomationTimelinePage", () => ({
 }));
 
 vi.mock("./pages/tenant/TenantWorkspacePage", () => ({
-  default: () => <h1>Tenant Workspace</h1>,
+  default: () => <h1>Tenant Dashboard</h1>,
 }));
 
 vi.mock("./pages/tenant/TenantApplicationStatusPage", () => ({
   default: () => <h1>Tenant Application Status</h1>,
 }));
+
+describe("Routes: /tenant", () => {
+  it("renders the tenant-first landing page without landlord pricing content", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/tenant"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(
+      await screen.findByText(/Your rental profile\. Secure, organized, and in your control\./i)
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Create free account/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Routes: /tenant/dashboard", () => {
+  it("renders the tenant dashboard route without falling into landlord surfaces", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/tenant/dashboard"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Tenant Dashboard/i)).toBeInTheDocument();
+    expect(screen.queryByText(/DashboardPage/i)).not.toBeInTheDocument();
+  });
+});
 
 describe("Routes: /automation/timeline", () => {
   it("renders the Automation Timeline shell and does not fall through to NotFound", async () => {

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -57,6 +57,8 @@ import MicroLiveInvitePage from "./pages/MicroLiveInvitePage";
 import TenantInviteRedeem from "./tenant/TenantInviteRedeem";
 import { LandlordNav } from "./components/layout/LandlordNav";
 import TenantPortalComingSoon from "./pages/tenant/TenantPortalComingSoon";
+import TenantLandingPage from "./pages/tenant/TenantLandingPage";
+import TenantLayout from "./pages/tenant/TenantLayout";
 import TenantWorkspacePage from "./pages/tenant/TenantWorkspacePage";
 import TenantApplicationStatusPage from "./pages/tenant/TenantApplicationStatusPage";
 import TenantLeasePage from "./pages/tenant/TenantLeasePage";
@@ -95,7 +97,6 @@ import ContractorDashboardPage from "./pages/contractor/ContractorDashboardPage"
 import ContractorJobsPage from "./pages/contractor/ContractorJobsPage";
 import ContractorProfilePage from "./pages/contractor/ContractorProfilePage";
 import { ContractorNav } from "./components/layout/ContractorNav";
-import { TenantNav } from "./components/layout/TenantNav";
 import { getRoleDefaultDestination } from "./lib/authDestination";
 
 const TENANT_PORTAL_ENABLED = import.meta.env.VITE_TENANT_PORTAL_ENABLED === "true";
@@ -262,7 +263,7 @@ function App() {
   const renderTenantShell = (page: React.ReactNode) =>
     TENANT_PORTAL_ENABLED ? (
       <RequireTenant>
-        <TenantNav>{page}</TenantNav>
+        <TenantLayout>{page}</TenantLayout>
       </RequireTenant>
     ) : (
       <TenantPortalComingSoon />
@@ -913,6 +914,10 @@ function App() {
         <Route path="/apply" element={<ApplicantApplyPage />} />
         <Route
           path="/tenant"
+          element={TENANT_PORTAL_ENABLED ? <TenantLandingPage /> : <TenantPortalComingSoon />}
+        />
+        <Route
+          path="/tenant/dashboard"
           element={renderTenantShell(<TenantWorkspacePage />)}
         />
         <Route

--- a/rentchain-frontend/src/components/layout/TenantNav.tsx
+++ b/rentchain-frontend/src/components/layout/TenantNav.tsx
@@ -9,13 +9,14 @@ type Props = {
 };
 
 const navItems = [
-  { label: "Workspace", to: "/tenant" },
+  { label: "Dashboard", to: "/tenant/dashboard" },
   { label: "Profile", to: "/tenant/profile" },
   { label: "Application", to: "/tenant/application" },
+  { label: "Documents", to: "/tenant/attachments" },
+  { label: "History", to: "/tenant/activity" },
   { label: "Lease", to: "/tenant/lease" },
   { label: "Maintenance", to: "/tenant/maintenance" },
   { label: "Messages", to: "/tenant/messages" },
-  { label: "Feed", to: "/tenant/activity" },
 ];
 
 export const TenantNav: React.FC<Props> = ({ children }) => {
@@ -131,9 +132,9 @@ export const TenantNav: React.FC<Props> = ({ children }) => {
           }}
         >
           <div style={{ display: "grid", gap: 2 }}>
-            <div style={{ fontWeight: 700 }}>RentChain Tenant Portal</div>
+            <div style={{ fontWeight: 700 }}>RentChain Tenant Space</div>
             <div style={{ fontSize: 12, color: "#64748b" }}>
-              {identityLoading ? "Loading workspace..." : tenantName || "Tenant workspace"}
+              {identityLoading ? "Loading your space..." : tenantName || "Your tenant space"}
             </div>
             <div style={{ fontSize: 12, color: "#94a3b8", minHeight: 16 }}>
               {identityLoading
@@ -154,7 +155,7 @@ export const TenantNav: React.FC<Props> = ({ children }) => {
             }}
           >
             {navItems.map((item) => (
-              <NavLink key={item.to} to={item.to} style={linkStyle} end={item.to === "/tenant"}>
+              <NavLink key={item.to} to={item.to} style={linkStyle} end={item.to === "/tenant/dashboard"}>
                 <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
                   <span>{item.label}</span>
                   {item.to === "/tenant/messages" && unreadMessages > 0 ? (

--- a/rentchain-frontend/src/pages/LoginPage.tsx
+++ b/rentchain-frontend/src/pages/LoginPage.tsx
@@ -357,6 +357,9 @@ export const LoginPage: React.FC = () => {
           <Link to="/signup" style={{ color: colors.accent, textDecoration: "none", fontWeight: 600 }}>
             Create free account
           </Link>
+          <Link to="/tenant" style={{ color: colors.accent, textDecoration: "none", fontWeight: 600 }}>
+            Are you a tenant? Access your profile
+          </Link>
           <Link to="/request-access" style={{ color: text.muted, textDecoration: "none" }}>
             Request access
           </Link>

--- a/rentchain-frontend/src/pages/tenant/TenantLandingPage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantLandingPage.test.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import TenantLandingPage from "./TenantLandingPage";
+
+describe("TenantLandingPage", () => {
+  it("renders tenant-first copy and avoids landlord pricing language", () => {
+    render(
+      <MemoryRouter>
+        <TenantLandingPage />
+      </MemoryRouter>
+    );
+
+    expect(
+      screen.getByText(/Your rental profile\. Secure, organized, and in your control\./i)
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole("link", { name: /Log in \/ Continue/i }).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/Create free account/i)).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/tenant/TenantLandingPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantLandingPage.tsx
@@ -1,0 +1,179 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+const primaryLinkStyle: React.CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  minHeight: 46,
+  padding: "0 18px",
+  borderRadius: 999,
+  textDecoration: "none",
+  fontWeight: 700,
+  background: "#0f172a",
+  color: "#f8fafc",
+  boxShadow: "0 16px 28px rgba(15, 23, 42, 0.16)",
+};
+
+const secondaryLinkStyle: React.CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  minHeight: 46,
+  padding: "0 18px",
+  borderRadius: 999,
+  textDecoration: "none",
+  fontWeight: 700,
+  border: "1px solid rgba(15, 23, 42, 0.12)",
+  color: "#0f172a",
+  background: "rgba(255,255,255,0.84)",
+};
+
+const infoCardStyle: React.CSSProperties = {
+  borderRadius: 20,
+  border: "1px solid rgba(148, 163, 184, 0.24)",
+  background: "rgba(255,255,255,0.84)",
+  boxShadow: "0 20px 48px rgba(148, 163, 184, 0.12)",
+  padding: "20px 22px",
+  display: "grid",
+  gap: 10,
+};
+
+export default function TenantLandingPage() {
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        background:
+          "radial-gradient(circle at top left, rgba(14, 165, 233, 0.14) 0, rgba(255,255,255,0.96) 46%, rgba(240,249,255,0.92) 100%)",
+        color: "#0f172a",
+      }}
+    >
+      <div
+        style={{
+          maxWidth: 1120,
+          margin: "0 auto",
+          padding: "clamp(24px, 5vw, 48px) clamp(16px, 4vw, 32px) 56px",
+          display: "grid",
+          gap: 32,
+        }}
+      >
+        <header
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: 16,
+            flexWrap: "wrap",
+          }}
+        >
+          <Link
+            to="/"
+            style={{
+              color: "#0f172a",
+              textDecoration: "none",
+              fontWeight: 800,
+              letterSpacing: "-0.02em",
+              fontSize: "1.05rem",
+            }}
+          >
+            RentChain
+          </Link>
+          <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+            <Link to="/tenant/login" style={secondaryLinkStyle}>
+              Log in / Continue
+            </Link>
+            <Link to="/signup" style={secondaryLinkStyle}>
+              Create profile
+            </Link>
+          </div>
+        </header>
+
+        <section
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
+            gap: 24,
+            alignItems: "start",
+          }}
+        >
+          <div style={{ display: "grid", gap: 18 }}>
+            <div
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                width: "fit-content",
+                borderRadius: 999,
+                background: "rgba(255,255,255,0.72)",
+                border: "1px solid rgba(148, 163, 184, 0.28)",
+                color: "#0369a1",
+                padding: "8px 12px",
+                fontSize: "0.88rem",
+                fontWeight: 700,
+              }}
+            >
+              Tenant portal
+            </div>
+            <div style={{ display: "grid", gap: 14 }}>
+              <h1
+                style={{
+                  margin: 0,
+                  fontSize: "clamp(2.2rem, 5vw, 4rem)",
+                  lineHeight: 1.04,
+                  letterSpacing: "-0.04em",
+                  maxWidth: 640,
+                }}
+              >
+                Your rental profile. Secure, organized, and in your control.
+              </h1>
+              <p
+                style={{
+                  margin: 0,
+                  maxWidth: 620,
+                  fontSize: "1.05rem",
+                  lineHeight: 1.7,
+                  color: "#334155",
+                }}
+              >
+                Access your rental history, documents, and profile details in one place. Share
+                information when needed.
+              </p>
+            </div>
+            <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+              <Link to="/tenant/login" style={primaryLinkStyle}>
+                Log in / Continue
+              </Link>
+              <Link to="/tenant/dashboard" style={secondaryLinkStyle}>
+                Preview dashboard
+              </Link>
+            </div>
+          </div>
+
+          <div style={{ display: "grid", gap: 14 }}>
+            <div style={infoCardStyle}>
+              <div style={{ fontWeight: 800, fontSize: "1.05rem" }}>What you can manage here</div>
+              <div style={{ color: "#475569", lineHeight: 1.6 }}>
+                Keep your profile current, keep documents organized, and return to your rental
+                history whenever a landlord asks you to share information.
+              </div>
+            </div>
+            <div style={infoCardStyle}>
+              <div style={{ fontWeight: 800, fontSize: "1.05rem" }}>Designed for tenants first</div>
+              <div style={{ color: "#475569", lineHeight: 1.6 }}>
+                No sales prompts, no landlord setup language, and no pressure to navigate a
+                property-management workflow just to manage your rental identity.
+              </div>
+            </div>
+            <div style={infoCardStyle}>
+              <div style={{ fontWeight: 800, fontSize: "1.05rem" }}>When you are ready</div>
+              <div style={{ color: "#475569", lineHeight: 1.6 }}>
+                Continue into your dashboard to review profile details, application progress,
+                documents, messages, and account history.
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/rentchain-frontend/src/pages/tenant/TenantLayout.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantLayout.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { TenantNav } from "../../components/layout/TenantNav";
+
+type TenantLayoutProps = {
+  children: React.ReactNode;
+};
+
+export default function TenantLayout({ children }: TenantLayoutProps) {
+  return <TenantNav>{children}</TenantNav>;
+}

--- a/rentchain-frontend/src/pages/tenant/TenantProfileCommunicationsPages.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantProfileCommunicationsPages.test.tsx
@@ -115,8 +115,8 @@ describe("tenant profile and communications pages", () => {
     );
 
     expect(await screen.findByText(/Tenant Profile/i)).toBeInTheDocument();
-    expect(screen.getByText(/Taylor Tenant/i)).toBeInTheDocument();
-    expect(screen.getByText(/Verification is still in progress/i)).toBeInTheDocument();
+    expect(await screen.findByDisplayValue(/Taylor Tenant/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Verification is still in progress/i)).toBeInTheDocument();
     expect(screen.getAllByText(/Upload government id/i).length).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: /Save profile changes/i })).toBeInTheDocument();
     expect(screen.getAllByRole("link", { name: /Review requested documents/i }).length).toBeGreaterThan(0);

--- a/rentchain-frontend/src/pages/tenant/TenantProfileCommunicationsPages.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantProfileCommunicationsPages.test.tsx
@@ -64,9 +64,9 @@ describe("tenant profile and communications pages", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText(/RentChain Tenant Portal/i)).toBeInTheDocument();
+    expect(await screen.findByText(/RentChain Tenant Space/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Profile/i })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /Feed/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /History/i })).toBeInTheDocument();
   });
 
   it("tenant profile page renders safe projected profile data and identity states", async () => {

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -75,8 +75,10 @@ describe("tenant workspace frontend shell", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText(/RentChain Tenant Portal/i)).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /Workspace/i })).toBeInTheDocument();
+    expect(await screen.findByText(/RentChain Tenant Space/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Dashboard/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Documents/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /History/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Application/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Lease/i })).toBeInTheDocument();
   });
@@ -139,7 +141,7 @@ describe("tenant workspace frontend shell", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText(/^Tenant Workspace$/i)).toBeInTheDocument();
+    expect(await screen.findByText(/^Tenant Dashboard$/i)).toBeInTheDocument();
     expect(screen.queryByText(/^Applicant$/i)).not.toBeInTheDocument();
     expect(screen.getByText(/Active tenancy/i)).toBeInTheDocument();
     expect(screen.getByText(/123 Main St, Unit 4, Halifax, NS/i)).toBeInTheDocument();
@@ -282,7 +284,7 @@ describe("tenant workspace frontend shell", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText(/cannot open this workspace/i)).toBeInTheDocument();
+    expect(await screen.findByText(/cannot open this dashboard/i)).toBeInTheDocument();
   });
 
   it("empty state renders safely for application and maintenance", async () => {

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
@@ -40,7 +40,7 @@ export default function TenantWorkspacePage() {
 
   if (loading) {
     return (
-      <TenantSurfaceShell title="Tenant Workspace" subtitle="Loading your property, application, lease, and maintenance summary.">
+      <TenantSurfaceShell title="Tenant Dashboard" subtitle="Loading your rental profile, application progress, lease, and maintenance summary.">
         <TenantLoadingState />
       </TenantSurfaceShell>
     );
@@ -49,9 +49,9 @@ export default function TenantWorkspacePage() {
   if (error) {
     const unauthorized = /unauthorized|forbidden|ambiguous/i.test(error);
     return (
-      <TenantSurfaceShell title="Tenant Workspace" subtitle="Your summary is generated from the tenant-safe workspace contract only.">
+      <TenantSurfaceShell title="Tenant Dashboard" subtitle="Your dashboard only shows tenant-safe information tied to your current rental context.">
         {unauthorized ? (
-          <TenantErrorState message="Your current session cannot open this workspace yet. Sign in again or contact support if this looks wrong." retry={load} />
+          <TenantErrorState message="Your current session cannot open this dashboard yet. Sign in again or contact support if this looks wrong." retry={load} />
         ) : (
           <TenantErrorState message={error} retry={load} />
         )}
@@ -67,8 +67,8 @@ export default function TenantWorkspacePage() {
 
   return (
     <TenantSurfaceShell
-      title="Tenant Workspace"
-      subtitle="Your RentChain tenant workspace is powered by the landlord-side canonical records that are safe for tenant access."
+      title="Tenant Dashboard"
+      subtitle="Keep your rental profile, documents, application progress, and ongoing tenancy details organized in one place."
       action={
         <Link
           to="/tenant/invite/redeem"
@@ -87,7 +87,7 @@ export default function TenantWorkspacePage() {
         </Link>
       }
     >
-      <TenantInfoCard heading="Workspace Summary" accent="#0f766e">
+      <TenantInfoCard heading="Dashboard Summary" accent="#0f766e">
         <TenantKeyValueGrid
           rows={[
             { label: "Access", value: prettyAuthority(data?.context?.authority) },
@@ -111,10 +111,10 @@ export default function TenantWorkspacePage() {
             <div style={{ display: "grid", gap: spacing.sm }}>
               <div style={{ color: textTokens.secondary }}>Current status: <strong>{prettyStatus(data.application.status)}</strong></div>
               <div style={{ color: textTokens.secondary }}>Updated: {formatDate(data.application.updatedAt || data.application.createdAt)}</div>
-              <Link to="/tenant/application">Open completion checklist</Link>
+              <Link to="/tenant/application">Open application checklist</Link>
             </div>
           ) : (
-            <TenantEmptyState title="No application projection yet" body="We couldn't find a tenant-safe application view for this workspace yet." />
+            <TenantEmptyState title="No application view yet" body="We couldn't find a tenant-safe application summary for this dashboard yet." />
           )}
         </TenantInfoCard>
 


### PR DESCRIPTION
## Summary

This PR introduces a tenant-first foundation inside the existing RentChain app without changing backend behavior or landlord workflows.

The main change is a new dedicated `/tenant` entry experience that gives tenants a calmer, more respectful way into the platform. The existing tenant workspace is preserved and now lives at `/tenant/dashboard`, with updated tenant-facing navigation and copy so the experience feels more like a tenant product and less like a landlord-side workflow.

## What changed

- Added a dedicated tenant-first landing page at `/tenant`
- Moved the existing tenant workspace entry to `/tenant/dashboard`
- Added a lightweight tenant layout wrapper for a cleaner tenant shell
- Updated tenant navigation labels to be more personal and practical:
  - `Workspace` → `Dashboard`
  - `Feed` → `History`
  - surfaced `Documents` directly in nav
- Updated tenant-facing dashboard copy to focus on:
  - rental profile
  - documents
  - history
  - progress
- Added a minimal login-page link:
  - `Are you a tenant? Access your profile`

## Scope

This PR is intentionally frontend-only.

No backend behavior was changed.
No schema changes were made.
No landlord billing, pricing, screening, or auth-core logic was changed.

## Files changed

- `rentchain-frontend/src/App.tsx`
- `rentchain-frontend/src/App.routes.test.tsx`
- `rentchain-frontend/src/components/layout/TenantNav.tsx`
- `rentchain-frontend/src/pages/LoginPage.tsx`
- `rentchain-frontend/src/pages/tenant/TenantLandingPage.tsx`
- `rentchain-frontend/src/pages/tenant/TenantLandingPage.test.tsx`
- `rentchain-frontend/src/pages/tenant/TenantLayout.tsx`
- `rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx`
- `rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx`

## Key UX decisions

- Created `/tenant` as a dedicated tenant-first entry page instead of dropping tenants directly into the authenticated workspace
- Preserved existing tenant functionality by moving the workspace entry to `/tenant/dashboard`
- Kept the implementation lightweight by wrapping the current tenant shell rather than replacing architecture
- Shifted tenant language toward profile, documents, and history instead of landlord-side record framing
- Avoided any homepage hard split or landlord marketing redesign in this PR

## Validation

Ran targeted frontend validation for the touched area:

```bash
npm run test -- src/App.routes.test.tsx src/pages/tenant/TenantLandingPage.test.tsx src/pages/tenant/TenantWorkspacePage.test.tsx
PATH="$HOME/.nvm/versions/node/v20.20.2/bin:$PATH" npm run build