### PR TITLE
feat(tenant): refine documents vault and sharing visibility v1

### DIFF
--- a/rentchain-frontend/src/pages/tenant/TenantAttachmentsPage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantAttachmentsPage.test.tsx
@@ -8,12 +8,43 @@ const tenantAttachmentsApi = vi.hoisted(() => ({
   getTenantAttachments: vi.fn(),
 }));
 
+const tenantAccessApi = vi.hoisted(() => ({
+  getTenantAccess: vi.fn(),
+}));
+
 vi.mock("../../api/tenantAttachmentsApi", () => tenantAttachmentsApi);
+vi.mock("../../api/tenantAccess", () => tenantAccessApi);
 
 describe("tenant attachments page", () => {
   beforeEach(() => {
     cleanup();
     vi.clearAllMocks();
+    tenantAccessApi.getTenantAccess.mockResolvedValue({
+      summary: {
+        activeGrants: 1,
+        pendingRequests: 0,
+        latestActivityAt: 1710001000000,
+      },
+      pendingRequests: [],
+      activeAccess: [
+        {
+          id: "share-1",
+          grantedToLabel: "Shared with your landlord for 123 Main St",
+          categories: ["Rental history"],
+          status: "active",
+          grantedAt: 1710000000000,
+          expiresAt: 1711000000000,
+          lastActivityAt: 1710001000000,
+          canRevoke: true,
+          accessLabel: "View-only access",
+        },
+      ],
+      recentActivity: [],
+      guidance: {
+        headline: "You can review and manage the access you’ve already shared.",
+        body: "This view shows tenant-safe sharing records only.",
+      },
+    });
   });
 
   it("renders empty state correctly", async () => {
@@ -46,8 +77,8 @@ describe("tenant attachments page", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText(/No documents visible yet/i)).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /Open completion checklist/i })).toBeInTheDocument();
+    expect(await screen.findByText(/No documents in your vault yet/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Add documents to your profile/i })).toBeInTheDocument();
   });
 
   it("renders grouped status-aware document items and guidance", async () => {
@@ -105,12 +136,15 @@ describe("tenant attachments page", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText(/Document Summary/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Document Vault Summary/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Ready to share/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Sharing Visibility/i)).toBeInTheDocument();
     expect(screen.getByText(/Some documents need attention/i)).toBeInTheDocument();
     expect(screen.getByText(/Re-upload requested/i)).toBeInTheDocument();
     expect(screen.getAllByText(/Pending review/i).length).toBeGreaterThan(0);
     expect(screen.getAllByRole("link", { name: /Open file/i }).length).toBeGreaterThan(0);
     expect(screen.getByRole("link", { name: /Message your landlord/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Review sharing/i })).toBeInTheDocument();
     expect(screen.getByText(/Direct upload is not available from this page yet/i)).toBeInTheDocument();
   });
 

--- a/rentchain-frontend/src/pages/tenant/TenantAttachmentsPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantAttachmentsPage.tsx
@@ -3,9 +3,8 @@ import { Link } from "react-router-dom";
 import {
   getTenantAttachments,
   type TenantAttachment,
-  type TenantAttachmentGuidance,
-  type TenantAttachmentSummary,
 } from "../../api/tenantAttachmentsApi";
+import { getTenantAccess, type TenantAccessWorkspace } from "../../api/tenantAccess";
 import {
   TenantEmptyState,
   TenantErrorState,
@@ -16,6 +15,7 @@ import {
   formatDate,
 } from "./TenantWorkspaceShared";
 import { spacing, text as textTokens } from "../../styles/tokens";
+import { buildTenantDocumentVaultView } from "./tenantDocumentVault";
 
 function statusTone(status?: TenantAttachment["status"]) {
   switch (status) {
@@ -32,16 +32,6 @@ function statusTone(status?: TenantAttachment["status"]) {
     default:
       return { label: "Uploaded", color: "#0f766e", background: "#ccfbf1" };
   }
-}
-
-function summaryTiles(summary?: TenantAttachmentSummary) {
-  if (!summary) return [];
-  return [
-    { label: "Missing", value: summary.missing, accent: "#991b1b" },
-    { label: "Pending review", value: summary.pendingReview, accent: "#1d4ed8" },
-    { label: "Needs attention", value: summary.needsAttention, accent: "#9a3412" },
-    { label: "Verified", value: summary.verified, accent: "#166534" },
-  ];
 }
 
 function sortUrgent(items: TenantAttachment[]) {
@@ -63,9 +53,10 @@ function sortUrgent(items: TenantAttachment[]) {
 
 export default function TenantAttachmentsPage() {
   const [items, setItems] = useState<TenantAttachment[]>([]);
-  const [summary, setSummary] = useState<TenantAttachmentSummary | undefined>(undefined);
-  const [guidance, setGuidance] = useState<TenantAttachmentGuidance | undefined>(undefined);
+  const [summary, setSummary] = useState<Awaited<ReturnType<typeof getTenantAttachments>>["summary"]>(undefined);
+  const [guidance, setGuidance] = useState<Awaited<ReturnType<typeof getTenantAttachments>>["guidance"]>(undefined);
   const [updatedAt, setUpdatedAt] = useState<number | null>(null);
+  const [access, setAccess] = useState<TenantAccessWorkspace | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -75,12 +66,20 @@ export default function TenantAttachmentsPage() {
       setLoading(true);
       setError(null);
       try {
-        const res = await getTenantAttachments();
+        const [attachmentsResult, accessResult] = await Promise.allSettled([
+          getTenantAttachments(),
+          getTenantAccess(),
+        ]);
+        if (attachmentsResult.status !== "fulfilled") {
+          throw attachmentsResult.reason;
+        }
+        const res = attachmentsResult.value;
         if (!cancelled) {
           setItems(Array.isArray(res?.data) ? sortUrgent(res.data) : []);
           setSummary(res?.summary);
           setGuidance(res?.guidance);
           setUpdatedAt(typeof res?.updatedAt === "number" ? res.updatedAt : null);
+          setAccess(accessResult.status === "fulfilled" ? accessResult.value : null);
         }
       } catch (err: any) {
         if (!cancelled) setError(err?.message || err?.payload?.error || "Unable to load documents.");
@@ -117,15 +116,21 @@ export default function TenantAttachmentsPage() {
     );
   }
 
-  const tiles = summaryTiles(summary);
+  const vault = buildTenantDocumentVaultView({
+    items,
+    summary,
+    guidance,
+    updatedAt,
+    access,
+  });
 
   return (
     <TenantSurfaceShell
       title="Documents"
-      subtitle="Use this page to understand which documents are in, which ones are still missing, and what needs attention before your application is fully complete."
+      subtitle="Keep your documents organized and ready to share. Review what is in your profile, what still needs attention, and what is shared with your permission."
       action={
         <Link
-          to="/tenant/application"
+          to="/tenant/profile"
           style={{
             display: "inline-flex",
             alignItems: "center",
@@ -137,16 +142,16 @@ export default function TenantAttachmentsPage() {
             border: "1px solid rgba(15,23,42,0.08)",
           }}
         >
-          Back to completion
+          Open profile
         </Link>
       }
     >
-      <TenantInfoCard heading="Document Summary" accent="#1d4ed8">
+      <TenantInfoCard heading="Document Vault Summary" accent="#1d4ed8">
         <div style={{ display: "grid", gap: spacing.sm }}>
           <div style={{ color: textTokens.secondary }}>
-            {guidance?.headline || "Your tenant-safe document record appears here as documents are requested and shared."}
+            {guidance?.headline || "Add documents to your profile and keep them organized for supported sharing later."}
           </div>
-          {tiles.length ? (
+          {vault.metrics.length ? (
             <div
               style={{
                 display: "grid",
@@ -154,7 +159,7 @@ export default function TenantAttachmentsPage() {
                 gap: spacing.sm,
               }}
             >
-              {tiles.map((tile) => (
+              {vault.metrics.map((tile) => (
                 <div
                   key={tile.label}
                   style={{
@@ -162,62 +167,137 @@ export default function TenantAttachmentsPage() {
                     borderRadius: 12,
                     padding: "12px 14px",
                     display: "grid",
-                    gap: 4,
+                    gap: 6,
                   }}
                 >
                   <div style={{ color: tile.accent, fontSize: "1.8rem", fontWeight: 900, lineHeight: 1 }}>{tile.value}</div>
                   <div style={{ color: textTokens.secondary, fontWeight: 700 }}>{tile.label}</div>
+                  <div style={{ color: textTokens.muted, fontSize: 12 }}>{tile.hint}</div>
                 </div>
               ))}
             </div>
           ) : null}
           <div style={{ color: textTokens.muted }}>
-            Last updated: <strong>{formatDate(updatedAt)}</strong>
+            Last updated: <strong>{formatDate(vault.updatedAt)}</strong>
           </div>
         </div>
       </TenantInfoCard>
 
-      <TenantInfoCard heading="What To Do Next" accent="#0891b2">
-        {guidance?.nextSteps?.length ? (
+      <TenantInfoCard heading="Ready To Share" accent="#166534">
+        {vault.readyItems.length ? (
           <div style={{ display: "grid", gap: 8 }}>
-            {guidance.nextSteps.map((step) => (
-              <div key={step} style={{ color: textTokens.secondary }}>
-                {step}
+            <div style={{ color: textTokens.secondary }}>
+              {vault.readyItems.length} document{vault.readyItems.length === 1 ? "" : "s"} already live in your profile and available when a supported sharing flow uses them.
+            </div>
+            {vault.readyItems.slice(0, 3).map((item) => (
+              <div key={item.id} style={{ color: textTokens.muted }}>
+                <strong>{item.label}</strong>
+                {item.fileName ? ` • ${item.fileName}` : ""}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div style={{ display: "grid", gap: 8 }}>
+            <div style={{ color: textTokens.secondary }}>
+              No documents are marked ready to share yet. Add documents to your profile or finish any follow-up steps below.
+            </div>
+            <div style={{ color: textTokens.muted }}>
+              This vault stays honest about readiness and will only show supported sharing states.
+            </div>
+          </div>
+        )}
+      </TenantInfoCard>
+
+      <TenantInfoCard heading="Missing Or Recommended" accent="#b45309">
+        {vault.missingItems.length ? (
+          <div style={{ display: "grid", gap: 8 }}>
+            {vault.missingItems.slice(0, 4).map((item) => (
+              <div key={item.id} style={{ color: textTokens.secondary }}>
+                <strong>{item.label}</strong>
+                {item.nextAction ? ` — ${item.nextAction}` : ""}
               </div>
             ))}
             <div style={{ display: "flex", gap: 10, flexWrap: "wrap", marginTop: 4 }}>
+              <Link to="/tenant/application" style={{ fontWeight: 700 }}>
+                Open completion checklist
+              </Link>
               {guidance?.supportPath && guidance?.supportLabel ? (
                 <Link to={guidance.supportPath} style={{ fontWeight: 700 }}>
                   {guidance.supportLabel}
                 </Link>
               ) : null}
-              <Link to="/tenant/profile" style={{ fontWeight: 700 }}>
-                Review profile
-              </Link>
             </div>
           </div>
         ) : (
           <div style={{ display: "grid", gap: 8 }}>
             <div style={{ color: textTokens.secondary }}>
-              Nothing urgent is blocking you here right now. Keep an eye on this page if new document requests appear.
+              Nothing urgent is missing right now. Keep your profile organized and check back if new document prompts appear.
             </div>
-            {guidance?.supportPath && guidance?.supportLabel ? (
-              <Link to={guidance.supportPath} style={{ fontWeight: 700 }}>
-                {guidance.supportLabel}
-              </Link>
-            ) : null}
+            <div style={{ color: textTokens.muted }}>
+              We only surface missing or follow-up items when they are linked to your current tenant-safe workspace.
+            </div>
           </div>
         )}
       </TenantInfoCard>
 
+      <TenantInfoCard heading="Sharing Visibility" accent="#0891b2">
+        <div style={{ display: "grid", gap: spacing.sm }}>
+          {vault.shareInsights.map((item) => {
+            const tone =
+              item.status === "shared"
+                ? { color: "#166534", background: "#dcfce7", label: "Shared" }
+                : item.status === "limited"
+                ? { color: "#9a3412", background: "#ffedd5", label: "Read-first" }
+                : { color: "#475569", background: "#e2e8f0", label: "Unshared" };
+            return (
+              <div
+                key={item.id}
+                style={{
+                  border: "1px solid rgba(15,23,42,0.08)",
+                  borderRadius: 12,
+                  padding: "12px 14px",
+                  display: "grid",
+                  gap: 6,
+                }}
+              >
+                <div style={{ display: "flex", justifyContent: "space-between", gap: 8, flexWrap: "wrap" }}>
+                  <div style={{ fontWeight: 800, color: textTokens.primary }}>{item.label}</div>
+                  <div
+                    style={{
+                      padding: "4px 8px",
+                      borderRadius: 999,
+                      fontSize: 12,
+                      fontWeight: 700,
+                      color: tone.color,
+                      background: tone.background,
+                    }}
+                  >
+                    {tone.label}
+                  </div>
+                </div>
+                <div style={{ color: textTokens.secondary }}>{item.detail}</div>
+              </div>
+            );
+          })}
+          <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+            <Link to="/tenant/access" style={{ fontWeight: 700 }}>
+              Review sharing
+            </Link>
+            <div style={{ color: textTokens.muted }}>
+              Document-specific share and revoke controls are not supported from this vault yet.
+            </div>
+          </div>
+        </div>
+      </TenantInfoCard>
+
       {items.length === 0 ? (
         <TenantEmptyState
-          title="No documents visible yet"
-          body="When your application or tenancy asks for documents, they’ll show up here with clear tenant-safe statuses and next steps."
+          title="No documents in your vault yet"
+          body="When documents are linked to your tenant profile, they will show up here with clear readiness and sharing visibility."
           action={
             <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
               <Link to="/tenant/application" style={{ fontWeight: 700 }}>
-                Open completion checklist
+                Add documents to your profile
               </Link>
               <Link to="/tenant/messages" style={{ fontWeight: 700 }}>
                 Message your landlord
@@ -227,64 +307,89 @@ export default function TenantAttachmentsPage() {
         />
       ) : (
         <div style={{ display: "grid", gap: spacing.sm }}>
-          {items.map((item) => {
-            const tone = statusTone(item.status);
-            return (
-              <TenantInfoCard key={item.id} heading={item.label || "Document"} accent={tone.color}>
-                <div style={{ display: "grid", gap: 10 }}>
-                  <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, flexWrap: "wrap" }}>
-                    <div style={{ color: textTokens.secondary }}>
-                      {item.category || "Documents"}
-                      {item.fileName ? ` • ${item.fileName}` : item.title ? ` • ${item.title}` : ""}
-                    </div>
+          {vault.recentItems.length ? (
+            <TenantInfoCard heading="Recently Updated" accent="#7c3aed">
+              <div style={{ display: "grid", gap: 8 }}>
+                {vault.recentItems.map((item) => (
+                  <div key={item.id} style={{ color: textTokens.secondary }}>
+                    <strong>{item.label}</strong> updated {formatDate(item.uploadedAt || item.createdAt)}
+                  </div>
+                ))}
+              </div>
+            </TenantInfoCard>
+          ) : null}
+
+          {vault.groupedItems.map((group) => (
+            <TenantInfoCard key={group.category} heading={group.category} accent="#0f766e">
+              <div style={{ display: "grid", gap: spacing.sm }}>
+                {group.items.map((item) => {
+                  const tone = statusTone(item.status);
+                  return (
                     <div
+                      key={item.id}
                       style={{
-                        padding: "4px 8px",
-                        borderRadius: 999,
-                        fontSize: 12,
-                        fontWeight: 700,
-                        color: tone.color,
-                        background: tone.background,
+                        border: "1px solid rgba(15,23,42,0.08)",
+                        borderRadius: 12,
+                        padding: "12px 14px",
+                        display: "grid",
+                        gap: 10,
                       }}
                     >
-                      {tone.label}
+                      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, flexWrap: "wrap" }}>
+                        <div style={{ color: textTokens.secondary }}>
+                          <strong style={{ color: textTokens.primary }}>{item.label || "Document"}</strong>
+                          {item.fileName ? ` • ${item.fileName}` : item.title ? ` • ${item.title}` : ""}
+                        </div>
+                        <div
+                          style={{
+                            padding: "4px 8px",
+                            borderRadius: 999,
+                            fontSize: 12,
+                            fontWeight: 700,
+                            color: tone.color,
+                            background: tone.background,
+                          }}
+                        >
+                          {tone.label}
+                        </div>
+                      </div>
+
+                      <div style={{ color: textTokens.secondary }}>
+                        {item.nextAction || "No additional action is required right now."}
+                      </div>
+
+                      <div style={{ color: textTokens.muted }}>
+                        Updated: <strong>{formatDate(item.uploadedAt || item.createdAt)}</strong>
+                      </div>
+
+                      <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+                        {item.url ? (
+                          <a
+                            href={item.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            style={{ fontWeight: 700, textDecoration: "none" }}
+                          >
+                            Open file
+                          </a>
+                        ) : null}
+                        {item.helpPath && item.helpLabel ? (
+                          <Link to={item.helpPath} style={{ fontWeight: 700 }}>
+                            {item.helpLabel}
+                          </Link>
+                        ) : null}
+                        {item.status === "missing" || item.status === "reupload_requested" ? (
+                          <span style={{ color: textTokens.muted, fontWeight: 700 }}>
+                            Direct upload is not available from this page yet
+                          </span>
+                        ) : null}
+                      </div>
                     </div>
-                  </div>
-
-                  <div style={{ color: textTokens.secondary }}>
-                    {item.nextAction || "No additional action is required right now."}
-                  </div>
-
-                  <div style={{ color: textTokens.muted }}>
-                    Updated: <strong>{formatDate(item.uploadedAt || item.createdAt)}</strong>
-                  </div>
-
-                  <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
-                    {item.url ? (
-                      <a
-                        href={item.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        style={{ fontWeight: 700, textDecoration: "none" }}
-                      >
-                        Open file
-                      </a>
-                    ) : null}
-                    {item.helpPath && item.helpLabel ? (
-                      <Link to={item.helpPath} style={{ fontWeight: 700 }}>
-                        {item.helpLabel}
-                      </Link>
-                    ) : null}
-                    {item.status === "missing" || item.status === "reupload_requested" ? (
-                      <span style={{ color: textTokens.muted, fontWeight: 700 }}>
-                        Direct upload is not available from this page yet
-                      </span>
-                    ) : null}
-                  </div>
-                </div>
-              </TenantInfoCard>
-            );
-          })}
+                  );
+                })}
+              </div>
+            </TenantInfoCard>
+          ))}
         </div>
       )}
     </TenantSurfaceShell>

--- a/rentchain-frontend/src/pages/tenant/TenantProfileCommunicationsPages.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantProfileCommunicationsPages.test.tsx
@@ -12,6 +12,10 @@ const tenantProfileApi = vi.hoisted(() => ({
   updateTenantProfile: vi.fn(),
 }));
 
+const tenantAttachmentsApi = vi.hoisted(() => ({
+  getTenantAttachments: vi.fn(),
+}));
+
 const tenantCommunicationsApi = vi.hoisted(() => ({
   getTenantCommunicationSummary: vi.fn(),
   getTenantCommunicationsWorkspace: vi.fn(),
@@ -28,6 +32,7 @@ const tenantPortalApi = vi.hoisted(() => ({
 }));
 
 vi.mock("../../api/tenantProfile", () => tenantProfileApi);
+vi.mock("../../api/tenantAttachmentsApi", () => tenantAttachmentsApi);
 vi.mock("../../api/tenantCommunicationsApi", () => tenantCommunicationsApi);
 vi.mock("../../api/tenantNotifications", () => tenantNotificationsApi);
 vi.mock("../../api/tenantPortal", () => tenantPortalApi);
@@ -47,6 +52,37 @@ describe("tenant profile and communications pages", () => {
         unitId: "unit-2",
         invitedEmail: "tenant@example.com",
       },
+    });
+    tenantAttachmentsApi.getTenantAttachments.mockResolvedValue({
+      ok: true,
+      data: [
+        {
+          id: "doc-1",
+          label: "Upload Id",
+          category: "Identity",
+          status: "uploaded",
+          fileName: "id-card.pdf",
+          uploadedAt: 1710000000000,
+        },
+      ],
+      summary: {
+        total: 1,
+        missing: 0,
+        uploaded: 1,
+        pendingReview: 0,
+        verified: 0,
+        needsAttention: 0,
+      },
+      guidance: {
+        headline: "Your current tenant-safe document record is up to date.",
+        nextSteps: [],
+        uploadEntryAvailable: false,
+        uploadEntryLabel: null,
+        uploadEntryPath: null,
+        supportPath: "/tenant/messages",
+        supportLabel: "Message your landlord",
+      },
+      updatedAt: 1710000000000,
     });
     tenantCommunicationsApi.getTenantCommunicationSummary.mockResolvedValue({
       unreadMessages: 1,
@@ -126,6 +162,8 @@ describe("tenant profile and communications pages", () => {
     expect(screen.getAllByText(/Employment and income/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Upload government id/i).length).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: /Save profile changes/i })).toBeInTheDocument();
+    expect(screen.getAllByText(/Document Vault/i).length).toBeGreaterThan(0);
+    expect(screen.getByRole("link", { name: /Open document vault/i })).toBeInTheDocument();
     expect(screen.getAllByRole("link", { name: /Review requested documents/i }).length).toBeGreaterThan(0);
     expect(screen.getAllByRole("link", { name: /Open documents|Review documents/i }).length).toBeGreaterThan(0);
   });

--- a/rentchain-frontend/src/pages/tenant/TenantProfilePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantProfilePage.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { getTenantProfile, updateTenantProfile, type TenantProfileStatus } from "../../api/tenantProfile";
+import { getTenantAttachments } from "../../api/tenantAttachmentsApi";
 import {
   TenantEmptyState,
   TenantErrorState,
@@ -16,6 +17,7 @@ import {
 import { spacing, text as textTokens } from "../../styles/tokens";
 import TenantProfileCompletionCard from "./TenantProfileCompletionCard";
 import { buildTenantProfileCompletion } from "./tenantProfileCompletion";
+import { buildTenantDocumentVaultView } from "./tenantDocumentVault";
 
 function statusTone(status: TenantProfileStatus): { label: string; color: string; background: string } {
   switch (status) {
@@ -38,6 +40,7 @@ export default function TenantProfilePage() {
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saveMessage, setSaveMessage] = useState<string | null>(null);
+  const [attachments, setAttachments] = useState<Awaited<ReturnType<typeof getTenantAttachments>> | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -60,6 +63,22 @@ export default function TenantProfilePage() {
       }
     };
     void load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const loadAttachments = async () => {
+      try {
+        const next = await getTenantAttachments();
+        if (!cancelled) setAttachments(next);
+      } catch {
+        if (!cancelled) setAttachments(null);
+      }
+    };
+    void loadAttachments();
     return () => {
       cancelled = true;
     };
@@ -138,6 +157,13 @@ export default function TenantProfilePage() {
     .toLowerCase();
   const hasEmploymentSignal =
     /employment|employer|income|paystub|salary|proof of income/.test(applicationSignals);
+  const documentVault = buildTenantDocumentVaultView({
+    items: attachments?.data || [],
+    summary: attachments?.summary,
+    guidance: attachments?.guidance,
+    updatedAt: attachments?.updatedAt,
+    access: null,
+  });
 
   return (
     <TenantSurfaceShell
@@ -328,6 +354,43 @@ export default function TenantProfilePage() {
           </div>
         </TenantInfoCard>
       </div>
+
+      <TenantInfoCard heading="Document Vault" accent="#b45309">
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))",
+            gap: spacing.sm,
+          }}
+        >
+          {documentVault.metrics.slice(0, 3).map((metric) => (
+            <div
+              key={metric.label}
+              style={{
+                border: "1px solid rgba(15,23,42,0.08)",
+                borderRadius: 12,
+                padding: "12px 14px",
+                display: "grid",
+                gap: 4,
+              }}
+            >
+              <div style={{ fontSize: "1.4rem", fontWeight: 900, color: metric.accent }}>{metric.value}</div>
+              <div style={{ color: textTokens.secondary, fontWeight: 700 }}>{metric.label}</div>
+            </div>
+          ))}
+        </div>
+        <div style={{ color: textTokens.secondary }}>
+          {attachments?.guidance?.headline || "Add documents to your profile and keep them organized here."}
+        </div>
+        <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+          <Link to="/tenant/attachments" style={{ fontWeight: 700 }}>
+            Open document vault
+          </Link>
+          <Link to="/tenant/access" style={{ fontWeight: 700 }}>
+            Review sharing
+          </Link>
+        </div>
+      </TenantInfoCard>
 
       <TenantInfoCard heading="Document checklist" accent="#b45309">
         {documentEntry?.note ? <div style={{ color: textTokens.secondary }}>{documentEntry.note}</div> : null}

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -24,6 +24,10 @@ const tenantAccessApi = vi.hoisted(() => ({
   getTenantAccess: vi.fn(),
 }));
 
+const tenantAttachmentsApi = vi.hoisted(() => ({
+  getTenantAttachments: vi.fn(),
+}));
+
 const tenantProfileApi = vi.hoisted(() => ({
   getTenantProfile: vi.fn(),
 }));
@@ -39,6 +43,7 @@ const tenantCommunicationsApi = vi.hoisted(() => ({
 vi.mock("../../api/tenantPortal", () => tenantPortalApi);
 vi.mock("../../api/tenantApplicationCompletion", () => tenantApplicationCompletionApi);
 vi.mock("../../api/tenantAccess", () => tenantAccessApi);
+vi.mock("../../api/tenantAttachmentsApi", () => tenantAttachmentsApi);
 vi.mock("../../api/tenantProfile", () => tenantProfileApi);
 vi.mock("../../api/tenantCommunicationsApi", () => tenantCommunicationsApi);
 vi.mock("../../api/maintenanceWorkflowApi", async () => {
@@ -87,6 +92,37 @@ describe("tenant workspace frontend shell", () => {
       application: null,
       lease: null,
       maintenance: [],
+    });
+    tenantAttachmentsApi.getTenantAttachments.mockResolvedValue({
+      ok: true,
+      data: [
+        {
+          id: "doc-1",
+          label: "Government ID",
+          category: "Identity",
+          status: "uploaded",
+          fileName: "id-card.pdf",
+          uploadedAt: 1710000000000,
+        },
+      ],
+      summary: {
+        total: 1,
+        missing: 0,
+        uploaded: 1,
+        pendingReview: 0,
+        verified: 0,
+        needsAttention: 0,
+      },
+      guidance: {
+        headline: "Your current tenant-safe document record is up to date.",
+        nextSteps: [],
+        uploadEntryAvailable: false,
+        uploadEntryLabel: null,
+        uploadEntryPath: null,
+        supportPath: "/tenant/messages",
+        supportLabel: "Message your landlord",
+      },
+      updatedAt: 1710000000000,
     });
     tenantProfileApi.getTenantProfile.mockResolvedValue({
       context: {
@@ -246,6 +282,8 @@ describe("tenant workspace frontend shell", () => {
     expect(screen.getByText(/123 Main St, Unit 4, Halifax, NS/i)).toBeInTheDocument();
     expect(screen.getByText(/finish_profile/i)).toBeInTheDocument();
     expect(screen.getByText(/1 active access grant/i)).toBeInTheDocument();
+    expect(screen.getByText(/1 document in your vault, 1 ready to share, and 0 still needing attention/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Open document vault/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Open access/i })).toBeInTheDocument();
   });
 

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Link } from "react-router-dom";
 import { getTenantWorkspace } from "../../api/tenantPortal";
 import { getTenantAccess, type TenantAccessWorkspace } from "../../api/tenantAccess";
+import { getTenantAttachments } from "../../api/tenantAttachmentsApi";
 import { getTenantProfile } from "../../api/tenantProfile";
 import {
   TenantEmptyState,
@@ -18,10 +19,12 @@ import {
 import { spacing, text as textTokens } from "../../styles/tokens";
 import TenantProfileCompletionCard from "./TenantProfileCompletionCard";
 import { buildTenantProfileCompletion } from "./tenantProfileCompletion";
+import { buildTenantDocumentVaultView } from "./tenantDocumentVault";
 
 export default function TenantWorkspacePage() {
   const [data, setData] = React.useState<Awaited<ReturnType<typeof getTenantWorkspace>> | null>(null);
   const [access, setAccess] = React.useState<TenantAccessWorkspace | null>(null);
+  const [attachments, setAttachments] = React.useState<Awaited<ReturnType<typeof getTenantAttachments>> | null>(null);
   const [profileData, setProfileData] = React.useState<Awaited<ReturnType<typeof getTenantProfile>> | null>(null);
   const [profileLoading, setProfileLoading] = React.useState(true);
   const [loading, setLoading] = React.useState(true);
@@ -31,9 +34,10 @@ export default function TenantWorkspacePage() {
     setLoading(true);
     setError(null);
     try {
-      const [workspaceResult, accessResult] = await Promise.allSettled([
+      const [workspaceResult, accessResult, attachmentsResult] = await Promise.allSettled([
         getTenantWorkspace(),
         getTenantAccess(),
+        getTenantAttachments(),
       ]);
 
       if (workspaceResult.status === "rejected") {
@@ -42,9 +46,11 @@ export default function TenantWorkspacePage() {
 
       setData(workspaceResult.value);
       setAccess(accessResult.status === "fulfilled" ? accessResult.value : null);
+      setAttachments(attachmentsResult.status === "fulfilled" ? attachmentsResult.value : null);
     } catch (err: any) {
       setData(null);
       setAccess(null);
+      setAttachments(null);
       setError(err?.payload?.error || err?.message || "Unable to load your tenant workspace.");
     } finally {
       setLoading(false);
@@ -107,6 +113,13 @@ export default function TenantWorkspacePage() {
   const maintenanceCount = Array.isArray(data?.maintenance) ? data.maintenance.length : 0;
   const nextActions = data?.application?.nextActions || [];
   const profileCompletion = profileData ? buildTenantProfileCompletion(profileData) : null;
+  const documentVault = buildTenantDocumentVaultView({
+    items: attachments?.data || [],
+    summary: attachments?.summary,
+    guidance: attachments?.guidance,
+    updatedAt: attachments?.updatedAt,
+    access,
+  });
 
   return (
     <TenantSurfaceShell
@@ -215,6 +228,20 @@ export default function TenantWorkspacePage() {
                 : "Review what you’ve shared and who can currently view supported profile information."}
             </div>
             <Link to="/tenant/access">Open access</Link>
+          </div>
+        </TenantInfoCard>
+
+        <TenantInfoCard heading="Documents" accent="#166534">
+          <div style={{ display: "grid", gap: spacing.sm }}>
+            <div style={{ color: textTokens.secondary }}>
+              {attachments
+                ? `${documentVault.metrics[0]?.value || 0} document${documentVault.metrics[0]?.value === 1 ? "" : "s"} in your vault, ${documentVault.metrics[1]?.value || 0} ready to share, and ${documentVault.metrics[2]?.value || 0} still needing attention.`
+                : "Open your document vault to review readiness and sharing visibility."}
+            </div>
+            <div style={{ color: textTokens.muted }}>
+              {attachments?.guidance?.headline || "Keep your profile organized by keeping documents ready in one place."}
+            </div>
+            <Link to="/tenant/attachments">Open document vault</Link>
           </div>
         </TenantInfoCard>
       </div>

--- a/rentchain-frontend/src/pages/tenant/tenantDocumentVault.test.ts
+++ b/rentchain-frontend/src/pages/tenant/tenantDocumentVault.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { buildTenantDocumentVaultView } from "./tenantDocumentVault";
+
+describe("buildTenantDocumentVaultView", () => {
+  it("builds readiness and sharing metrics deterministically", () => {
+    const result = buildTenantDocumentVaultView({
+      items: [
+        {
+          id: "doc-1",
+          label: "Government ID",
+          category: "Identity",
+          status: "uploaded",
+          uploadedAt: 30,
+        },
+        {
+          id: "doc-2",
+          label: "Income documents",
+          category: "Income",
+          status: "missing",
+          uploadedAt: 10,
+        },
+        {
+          id: "doc-3",
+          label: "Lease addendum",
+          category: "Lease",
+          status: "verified",
+          uploadedAt: 20,
+        },
+      ],
+      summary: {
+        total: 3,
+        missing: 1,
+        uploaded: 1,
+        pendingReview: 0,
+        verified: 1,
+        needsAttention: 0,
+      },
+      access: {
+        summary: {
+          activeGrants: 1,
+          pendingRequests: 0,
+          latestActivityAt: 50,
+        },
+        pendingRequests: [],
+        activeAccess: [
+          {
+            id: "share-1",
+            grantedToLabel: "Shared with your landlord",
+            categories: ["Rental history"],
+            status: "active",
+            grantedAt: 40,
+            expiresAt: 100,
+            lastActivityAt: 50,
+            canRevoke: true,
+            accessLabel: "View-only access",
+          },
+        ],
+        recentActivity: [],
+        guidance: {
+          headline: "Shared",
+          body: "Visible",
+        },
+      },
+    });
+
+    expect(result.metrics.map((item) => item.value)).toEqual([3, 2, 1, 1]);
+    expect(result.readyItems.map((item) => item.id)).toEqual(["doc-1", "doc-3"]);
+    expect(result.missingItems.map((item) => item.id)).toEqual(["doc-2"]);
+    expect(result.groupedItems.map((group) => group.category)).toEqual(["Identity", "Income", "Lease"]);
+    expect(result.shareInsights[0]).toMatchObject({
+      label: "Rental history",
+      status: "shared",
+    });
+  });
+
+  it("falls back to read-first sharing guidance when no access grants exist", () => {
+    const result = buildTenantDocumentVaultView({
+      items: [],
+    });
+
+    expect(result.shareInsights).toEqual([
+      expect.objectContaining({
+        label: "Documents in your vault",
+        status: "unshared",
+      }),
+      expect.objectContaining({
+        label: "Selective sharing",
+        status: "limited",
+      }),
+    ]);
+  });
+});

--- a/rentchain-frontend/src/pages/tenant/tenantDocumentVault.ts
+++ b/rentchain-frontend/src/pages/tenant/tenantDocumentVault.ts
@@ -1,0 +1,178 @@
+import type { TenantAccessWorkspace } from "../../api/tenantAccess";
+import type { TenantAttachment, TenantAttachmentGuidance, TenantAttachmentSummary } from "../../api/tenantAttachmentsApi";
+
+type VaultMetric = {
+  label: string;
+  value: number;
+  accent: string;
+  hint: string;
+};
+
+type VaultDocumentGroup = {
+  category: string;
+  items: TenantAttachment[];
+};
+
+type VaultShareInsight = {
+  id: string;
+  label: string;
+  detail: string;
+  status: "shared" | "unshared" | "limited";
+};
+
+export type TenantDocumentVaultView = {
+  metrics: VaultMetric[];
+  readyItems: TenantAttachment[];
+  missingItems: TenantAttachment[];
+  recentItems: TenantAttachment[];
+  groupedItems: VaultDocumentGroup[];
+  shareInsights: VaultShareInsight[];
+  updatedAt: number | null;
+  guidance: TenantAttachmentGuidance | undefined;
+};
+
+function isReadyToShare(item: TenantAttachment): boolean {
+  return item.status === "uploaded" || item.status === "verified";
+}
+
+function needsAttention(item: TenantAttachment): boolean {
+  return item.status === "missing" || item.status === "needs_attention" || item.status === "reupload_requested";
+}
+
+function statusRank(status?: TenantAttachment["status"]): number {
+  switch (status) {
+    case "reupload_requested":
+      return 0;
+    case "needs_attention":
+      return 1;
+    case "missing":
+      return 2;
+    case "pending_review":
+      return 3;
+    case "uploaded":
+      return 4;
+    case "verified":
+      return 5;
+    default:
+      return 6;
+  }
+}
+
+function categoryRank(category: string): number {
+  switch (category) {
+    case "Identity":
+      return 0;
+    case "Income":
+      return 1;
+    case "Lease":
+      return 2;
+    case "Invite":
+      return 3;
+    default:
+      return 4;
+  }
+}
+
+function buildShareInsights(access?: TenantAccessWorkspace | null): VaultShareInsight[] {
+  const activeAccess = access?.activeAccess || [];
+  if (activeAccess.length) {
+    return activeAccess.map((grant) => ({
+      id: grant.id,
+      label: grant.categories.join(", ") || "Shared access",
+      detail: `${grant.grantedToLabel}. ${grant.accessLabel}.`,
+      status: "shared" as const,
+    }));
+  }
+
+  return [
+    {
+      id: "documents-not-separately-shared",
+      label: "Documents in your vault",
+      detail: "Saved to your profile and not separately shared from this vault in v1.",
+      status: "unshared",
+    },
+    {
+      id: "sharing-controls",
+      label: "Selective sharing",
+      detail: "Document-specific sharing controls are not available yet, so this vault stays read-first.",
+      status: "limited",
+    },
+  ];
+}
+
+export function buildTenantDocumentVaultView(params: {
+  items: TenantAttachment[];
+  summary?: TenantAttachmentSummary;
+  guidance?: TenantAttachmentGuidance;
+  updatedAt?: number | null;
+  access?: TenantAccessWorkspace | null;
+}): TenantDocumentVaultView {
+  const items = Array.isArray(params.items) ? [...params.items] : [];
+  const summary = params.summary;
+  const readyItems = items.filter(isReadyToShare);
+  const missingItems = items.filter(needsAttention);
+  const recentItems = [...items]
+    .sort((a, b) => Number(b.uploadedAt || b.createdAt || 0) - Number(a.uploadedAt || a.createdAt || 0))
+    .slice(0, 3);
+
+  const groupedItems = Array.from(
+    items.reduce((map, item) => {
+      const category = item.category || "Documents";
+      const current = map.get(category) || [];
+      current.push(item);
+      map.set(category, current);
+      return map;
+    }, new Map<string, TenantAttachment[]>())
+  )
+    .map(([category, grouped]) => ({
+      category,
+      items: [...grouped].sort((a, b) => {
+        const priority = statusRank(a.status) - statusRank(b.status);
+        if (priority !== 0) return priority;
+        return Number(b.uploadedAt || b.createdAt || 0) - Number(a.uploadedAt || a.createdAt || 0);
+      }),
+    }))
+    .sort((a, b) => {
+      const priority = categoryRank(a.category) - categoryRank(b.category);
+      if (priority !== 0) return priority;
+      return a.category.localeCompare(b.category);
+    });
+
+  const metrics: VaultMetric[] = [
+    {
+      label: "In your vault",
+      value: summary?.total ?? items.length,
+      accent: "#0f766e",
+      hint: "Documents already connected to your tenant profile.",
+    },
+    {
+      label: "Ready to share",
+      value: readyItems.length,
+      accent: "#166534",
+      hint: "Saved files that are already available in your profile.",
+    },
+    {
+      label: "Missing or needs attention",
+      value: missingItems.length,
+      accent: "#9a3412",
+      hint: "Items still missing or needing follow-up before they are fully ready.",
+    },
+    {
+      label: "Shared with permission",
+      value: params.access?.summary?.activeGrants ?? 0,
+      accent: "#1d4ed8",
+      hint: "Current supported profile shares you have already granted.",
+    },
+  ];
+
+  return {
+    metrics,
+    readyItems,
+    missingItems,
+    recentItems,
+    groupedItems,
+    shareInsights: buildShareInsights(params.access),
+    updatedAt: typeof params.updatedAt === "number" ? params.updatedAt : null,
+    guidance: params.guidance,
+  };
+}


### PR DESCRIPTION
## Summary

This PR implements a frontend-only v1 refinement of the tenant documents experience, turning `/tenant/attachments` into a clearer document vault with readiness, organization, recent updates, and honest sharing visibility tied to the existing tenant access model.

The tenant documents experience now feels more like a reusable profile asset and less like a simple upload list. Document readiness summaries were also surfaced in the tenant dashboard and profile to reinforce document organization as part of the broader tenant identity workflow.

## What changed

### Document vault refinement
- Refined `/tenant/attachments` into a more tenant-first document vault experience
- Added clearer vault framing and copy:
  - `Keep your documents organized and ready to share`
- Added grouped document organization by supported category
- Surfaced:
  - `ready`
  - `missing or needs attention`
  - `recently updated`

### Shared vault presentation model
- Added a deterministic document-vault helper so vault, dashboard, and profile all use the same readiness logic
- Ensured readiness and summary language stay consistent across tenant surfaces

### Dashboard and profile integration
- Added lightweight document-readiness summaries to:
  - `/tenant/dashboard`
  - `/tenant/profile`
- Reinforced documents as part of the tenant profile system, not a separate isolated page

### Sharing visibility
- Kept document sharing read-first and honest
- Surfaced current sharing visibility based on the existing access model
- Linked sharing review to `/tenant/access`
- Did **not** invent unsupported per-document share/revoke controls

## Scope

This PR is intentionally frontend-only.

- No backend changes
- No schema changes
- No auth changes
- No billing or screening changes
- No landlord workflow changes

## Files changed

- `rentchain-frontend/src/pages/tenant/TenantAttachmentsPage.tsx`
- `rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx`
- `rentchain-frontend/src/pages/tenant/TenantProfilePage.tsx`
- `rentchain-frontend/src/pages/tenant/tenantDocumentVault.ts`
- `rentchain-frontend/src/pages/tenant/TenantAttachmentsPage.test.tsx`
- `rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx`
- `rentchain-frontend/src/pages/tenant/TenantProfileCommunicationsPages.test.tsx`
- `rentchain-frontend/src/pages/tenant/tenantDocumentVault.test.ts`

## Key UX decisions

- Kept the vault tenant-first and profile-oriented
- Used a shared deterministic helper so readiness stays consistent across vault, dashboard, and profile
- Grouped documents by supported category rather than leaving them as a flat upload list
- Kept sharing read-first because current backend support does not safely provide per-document share mutations
- Directed tenants to `/tenant/access` for sharing review rather than inventing unsupported controls

## Validation

Ran targeted frontend validation plus build:

```bash
npm run test -- src/pages/tenant/TenantAttachmentsPage.test.tsx src/pages/tenant/TenantWorkspacePage.test.tsx src/pages/tenant/TenantProfileCommunicationsPages.test.tsx src/pages/tenant/tenantDocumentVault.test.ts
PATH="$HOME/.nvm/versions/node/v20.20.2/bin:$PATH" npm run test -- src/pages/tenant
PATH="$HOME/.nvm/versions/node/v20.20.2/bin:$PATH" npm run build