### PR TITLE
feat(tenant): add application reuse and share profile flow v1

### DIFF
--- a/rentchain-frontend/src/pages/tenant/TenantApplicationCompletionPage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantApplicationCompletionPage.test.tsx
@@ -8,12 +8,119 @@ const tenantApplicationCompletionApi = vi.hoisted(() => ({
   getTenantApplicationCompletion: vi.fn(),
 }));
 
+const tenantProfileApi = vi.hoisted(() => ({
+  getTenantProfile: vi.fn(),
+}));
+
+const tenantAttachmentsApi = vi.hoisted(() => ({
+  getTenantAttachments: vi.fn(),
+}));
+
+const tenantAccessApi = vi.hoisted(() => ({
+  getTenantAccess: vi.fn(),
+}));
+
 vi.mock("../../api/tenantApplicationCompletion", () => tenantApplicationCompletionApi);
+vi.mock("../../api/tenantProfile", () => tenantProfileApi);
+vi.mock("../../api/tenantAttachmentsApi", () => tenantAttachmentsApi);
+vi.mock("../../api/tenantAccess", () => tenantAccessApi);
 
 describe("tenant application completion page", () => {
   beforeEach(() => {
     cleanup();
     vi.clearAllMocks();
+    tenantProfileApi.getTenantProfile.mockResolvedValue({
+      context: { authority: "applicant" },
+      profile: {
+        displayName: "Taylor Tenant",
+        email: "tenant@example.com",
+        phone: "902-555-0100",
+        authorityLabel: "Applicant",
+        property: {
+          street1: "123 Main St",
+          street2: "Unit 4",
+          city: "Halifax",
+          province: "NS",
+        },
+        application: { status: "submitted", missingSteps: [], nextActions: [] },
+        lease: null,
+      },
+      identity: {
+        overallStatus: "pending",
+        identityVerification: {
+          status: "pending",
+          label: "Pending",
+          note: "Verification is still in progress.",
+          updatedAt: "2026-01-05T00:00:00.000Z",
+        },
+        documentChecklist: [],
+        nextSteps: [],
+      },
+      actions: {
+        editableFields: ["displayName", "phone"],
+        documentEntry: {
+          available: true,
+          path: "/tenant/attachments",
+          label: "Open documents",
+          note: "Open your tenant documents area.",
+        },
+      },
+    });
+    tenantAttachmentsApi.getTenantAttachments.mockResolvedValue({
+      ok: true,
+      data: [
+        {
+          id: "doc-1",
+          label: "Government ID",
+          category: "Identity",
+          status: "uploaded",
+        },
+      ],
+      summary: {
+        total: 1,
+        missing: 0,
+        uploaded: 1,
+        pendingReview: 0,
+        verified: 0,
+        needsAttention: 0,
+      },
+      guidance: {
+        headline: "Your current tenant-safe document record is up to date.",
+        nextSteps: [],
+        uploadEntryAvailable: false,
+        uploadEntryLabel: null,
+        uploadEntryPath: null,
+        supportPath: "/tenant/messages",
+        supportLabel: "Message your landlord",
+      },
+      updatedAt: 1710000000000,
+    });
+    tenantAccessApi.getTenantAccess.mockResolvedValue({
+      summary: {
+        activeGrants: 1,
+        pendingRequests: 0,
+        latestActivityAt: 1710000000000,
+      },
+      pendingRequests: [],
+      activeAccess: [
+        {
+          id: "share-1",
+          grantedToLabel: "Shared with your landlord",
+          categories: ["Rental history"],
+          status: "active",
+          grantedAt: 1710000000000,
+          expiresAt: 1711000000000,
+          lastActivityAt: 1710000000000,
+          canRevoke: true,
+          accessLabel: "View-only access",
+        },
+      ],
+      recentActivity: [],
+      guidance: {
+        headline: "You can review and manage the access you’ve already shared.",
+        body: "This view shows tenant-safe sharing records only.",
+      },
+    });
   });
 
   it("renders progress and grouped checklist safely", async () => {
@@ -62,11 +169,17 @@ describe("tenant application completion page", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText(/Application Completion/i)).toBeInTheDocument();
-    expect(screen.getByText(/62%/i)).toBeInTheDocument();
-    expect(screen.getByText(/Identity verification/i)).toBeInTheDocument();
+    expect(await screen.findAllByText(/Application Readiness/i)).not.toHaveLength(0);
+    expect(screen.getAllByText(/62%/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Application Readiness Summary/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Use Your Saved Profile/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Document Readiness/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Review Before Sharing/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Identity verification/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Upload income documents/i).length).toBeGreaterThan(0);
-    expect(screen.getByRole("link", { name: /Open documents/i })).toBeInTheDocument();
+    expect(screen.getAllByRole("link", { name: /Review your profile/i }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("link", { name: /Open documents/i }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("link", { name: /Review access/i }).length).toBeGreaterThan(0);
   });
 
   it("renders empty state safely", async () => {

--- a/rentchain-frontend/src/pages/tenant/TenantApplicationStatusPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantApplicationStatusPage.tsx
@@ -5,6 +5,9 @@ import {
   type TenantApplicationCompletionItem,
   type TenantApplicationCompletionStatus,
 } from "../../api/tenantApplicationCompletion";
+import { getTenantAccess } from "../../api/tenantAccess";
+import { getTenantAttachments } from "../../api/tenantAttachmentsApi";
+import { getTenantProfile } from "../../api/tenantProfile";
 import {
   TenantEmptyState,
   TenantErrorState,
@@ -16,6 +19,7 @@ import {
   prettyStatus,
 } from "./TenantWorkspaceShared";
 import { spacing, text as textTokens } from "../../styles/tokens";
+import { buildTenantApplicationReuseView } from "./tenantApplicationReuse";
 
 function statusTone(status: TenantApplicationCompletionStatus) {
   switch (status) {
@@ -134,6 +138,9 @@ const CompletionItemRow: React.FC<{ item: TenantApplicationCompletionItem }> = (
 
 export default function TenantApplicationStatusPage() {
   const [data, setData] = React.useState<Awaited<ReturnType<typeof getTenantApplicationCompletion>>>(null);
+  const [profile, setProfile] = React.useState<Awaited<ReturnType<typeof getTenantProfile>> | null>(null);
+  const [attachments, setAttachments] = React.useState<Awaited<ReturnType<typeof getTenantAttachments>> | null>(null);
+  const [access, setAccess] = React.useState<Awaited<ReturnType<typeof getTenantAccess>> | null>(null);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
 
@@ -141,9 +148,24 @@ export default function TenantApplicationStatusPage() {
     setLoading(true);
     setError(null);
     try {
-      setData(await getTenantApplicationCompletion());
+      const [completionResult, profileResult, attachmentsResult, accessResult] = await Promise.allSettled([
+        getTenantApplicationCompletion(),
+        getTenantProfile(),
+        getTenantAttachments(),
+        getTenantAccess(),
+      ]);
+      if (completionResult.status !== "fulfilled") {
+        throw completionResult.reason;
+      }
+      setData(completionResult.value);
+      setProfile(profileResult.status === "fulfilled" ? profileResult.value : null);
+      setAttachments(attachmentsResult.status === "fulfilled" ? attachmentsResult.value : null);
+      setAccess(accessResult.status === "fulfilled" ? accessResult.value : null);
     } catch (err: any) {
       setData(null);
+      setProfile(null);
+      setAttachments(null);
+      setAccess(null);
       setError(err?.payload?.error || err?.message || "Unable to load application completion.");
     } finally {
       setLoading(false);
@@ -191,10 +213,17 @@ export default function TenantApplicationStatusPage() {
     );
   }
 
+  const reuse = buildTenantApplicationReuseView({
+    completion: data,
+    profile,
+    attachments,
+    access,
+  });
+
   return (
     <TenantSurfaceShell
-      title="Application Completion"
-      subtitle="Use this checklist to finish the right steps in the right order so your application moves forward with fewer delays."
+      title="Application Readiness"
+      subtitle="Use your saved profile to prepare this application. Review what’s ready to share and add any missing details before you continue."
       action={
         <Link
           to="/tenant/profile"
@@ -209,11 +238,193 @@ export default function TenantApplicationStatusPage() {
             border: "1px solid rgba(15,23,42,0.08)",
           }}
         >
-          Open profile
+          Review your profile
         </Link>
       }
     >
       <CompletionProgressCard progressPercent={data.progressPercent} status={data.status} />
+
+      <TenantInfoCard heading="Application Readiness Summary" accent="#0f766e">
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))",
+            gap: spacing.sm,
+          }}
+        >
+          {reuse.metrics.map((metric) => (
+            <div
+              key={metric.label}
+              style={{
+                border: "1px solid rgba(15,23,42,0.08)",
+                borderRadius: 12,
+                padding: "12px 14px",
+                display: "grid",
+                gap: 4,
+              }}
+            >
+              <div style={{ fontSize: "1.6rem", fontWeight: 900, color: metric.accent }}>{metric.value}</div>
+              <div style={{ color: textTokens.secondary, fontWeight: 700 }}>{metric.label}</div>
+              <div style={{ color: textTokens.muted, fontSize: 12 }}>{metric.hint}</div>
+            </div>
+          ))}
+        </div>
+      </TenantInfoCard>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
+          gap: spacing.md,
+        }}
+      >
+        <TenantInfoCard heading="Use Your Saved Profile" accent="#1d4ed8">
+          <div style={{ display: "grid", gap: spacing.sm }}>
+            {reuse.reusableProfileItems.map((item) => {
+              const tone =
+                item.status === "ready"
+                  ? { color: "#166534", background: "#dcfce7", label: "Ready" }
+                  : item.status === "info"
+                  ? { color: "#1d4ed8", background: "#dbeafe", label: "In review" }
+                  : { color: "#9a3412", background: "#ffedd5", label: "Needs attention" };
+              return (
+                <div
+                  key={item.label}
+                  style={{
+                    border: "1px solid rgba(15,23,42,0.08)",
+                    borderRadius: 12,
+                    padding: "12px 14px",
+                    display: "grid",
+                    gap: 8,
+                  }}
+                >
+                  <div style={{ display: "flex", justifyContent: "space-between", gap: 8, flexWrap: "wrap" }}>
+                    <div style={{ fontWeight: 700, color: textTokens.primary }}>{item.label}</div>
+                    <div
+                      style={{
+                        padding: "4px 8px",
+                        borderRadius: 999,
+                        fontSize: 12,
+                        fontWeight: 700,
+                        color: tone.color,
+                        background: tone.background,
+                      }}
+                    >
+                      {tone.label}
+                    </div>
+                  </div>
+                  <div style={{ color: textTokens.secondary }}>{item.detail}</div>
+                  {item.actionPath ? (
+                    <Link to={item.actionPath} style={{ fontWeight: 700 }}>
+                      {item.actionLabel || "Review"}
+                    </Link>
+                  ) : null}
+                </div>
+              );
+            })}
+          </div>
+        </TenantInfoCard>
+
+        <TenantInfoCard heading="Document Readiness" accent="#166534">
+          <div style={{ display: "grid", gap: spacing.sm }}>
+            {reuse.documentItems.map((item) => {
+              const tone =
+                item.status === "ready"
+                  ? { color: "#166534", background: "#dcfce7", label: "Ready" }
+                  : { color: "#9a3412", background: "#ffedd5", label: "Needs attention" };
+              return (
+                <div
+                  key={item.label}
+                  style={{
+                    border: "1px solid rgba(15,23,42,0.08)",
+                    borderRadius: 12,
+                    padding: "12px 14px",
+                    display: "grid",
+                    gap: 8,
+                  }}
+                >
+                  <div style={{ display: "flex", justifyContent: "space-between", gap: 8, flexWrap: "wrap" }}>
+                    <div style={{ fontWeight: 700, color: textTokens.primary }}>{item.label}</div>
+                    <div
+                      style={{
+                        padding: "4px 8px",
+                        borderRadius: 999,
+                        fontSize: 12,
+                        fontWeight: 700,
+                        color: tone.color,
+                        background: tone.background,
+                      }}
+                    >
+                      {tone.label}
+                    </div>
+                  </div>
+                  <div style={{ color: textTokens.secondary }}>{item.detail}</div>
+                  {item.actionPath ? (
+                    <Link to={item.actionPath} style={{ fontWeight: 700 }}>
+                      {item.actionLabel || "Open documents"}
+                    </Link>
+                  ) : null}
+                </div>
+              );
+            })}
+          </div>
+        </TenantInfoCard>
+      </div>
+
+      <TenantInfoCard heading="Missing Details" accent="#b45309">
+        {reuse.missingItems.length ? (
+          <div style={{ display: "grid", gap: spacing.sm }}>
+            {reuse.missingItems.slice(0, 8).map((item, index) => (
+              <div
+                key={`${item.label}-${index}`}
+                style={{
+                  border: "1px solid rgba(15,23,42,0.08)",
+                  borderRadius: 12,
+                  padding: "12px 14px",
+                  display: "grid",
+                  gap: 8,
+                }}
+              >
+                <div style={{ fontWeight: 700, color: textTokens.primary }}>{item.label}</div>
+                <div style={{ color: textTokens.secondary }}>{item.detail}</div>
+                {item.actionPath ? (
+                  <Link to={item.actionPath} style={{ fontWeight: 700 }}>
+                    {item.actionLabel || "Review this step"}
+                  </Link>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div style={{ color: textTokens.secondary }}>
+            No major missing details are surfaced right now. Review the sections below before you continue.
+          </div>
+        )}
+      </TenantInfoCard>
+
+      <TenantInfoCard heading="Review Before Sharing" accent="#0891b2">
+        <div style={{ display: "grid", gap: spacing.sm }}>
+          {reuse.shareInsights.map((item) => (
+            <div key={item.label} style={{ color: textTokens.secondary }}>
+              <strong style={{ color: textTokens.primary }}>{item.label}:</strong> {item.detail}
+            </div>
+          ))}
+          <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+            <Link to="/tenant/profile" style={{ fontWeight: 700 }}>
+              Review your profile
+            </Link>
+            <Link to="/tenant/attachments" style={{ fontWeight: 700 }}>
+              Open documents
+            </Link>
+            <Link to="/tenant/access" style={{ fontWeight: 700 }}>
+              Review access
+            </Link>
+          </div>
+          <div style={{ color: textTokens.muted }}>
+            This v1 view does not invent autofill or document-level sharing controls that are not already supported elsewhere in the tenant workspace.
+          </div>
+        </div>
+      </TenantInfoCard>
 
       {data.nextSteps.length ? (
         <TenantInfoCard heading="Next Steps" accent="#0891b2">
@@ -277,6 +488,9 @@ export default function TenantApplicationStatusPage() {
         </div>
         <div style={{ color: textTokens.muted }}>
           Status: <strong>{prettyStatus(data.status)}</strong>
+        </div>
+        <div style={{ color: textTokens.muted }}>
+          Review what’s ready before continuing so this application feels like a guided reuse flow, not a blank restart.
         </div>
       </TenantInfoCard>
     </TenantSurfaceShell>

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -317,8 +317,8 @@ describe("tenant workspace frontend shell", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText(/Application Completion/i)).toBeInTheDocument();
-    expect(screen.getByText(/62%/i)).toBeInTheDocument();
+    expect(await screen.findAllByText(/Application Readiness/i)).not.toHaveLength(0);
+    expect(screen.getAllByText(/62%/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Upload government id/i).length).toBeGreaterThan(0);
   });
 

--- a/rentchain-frontend/src/pages/tenant/tenantApplicationReuse.test.ts
+++ b/rentchain-frontend/src/pages/tenant/tenantApplicationReuse.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+import { buildTenantApplicationReuseView } from "./tenantApplicationReuse";
+
+describe("buildTenantApplicationReuseView", () => {
+  it("builds reuse metrics and remediation links from supported tenant-safe data", () => {
+    const result = buildTenantApplicationReuseView({
+      completion: {
+        status: "in_progress",
+        progressPercent: 62,
+        sections: [
+          {
+            key: "documents",
+            label: "Documents",
+            status: "missing",
+            items: [
+              {
+                key: "income_documents",
+                label: "Income documents",
+                status: "missing",
+                nextAction: "Upload income documents",
+                actionPath: "/tenant/attachments",
+                actionLabel: "Open documents",
+              },
+            ],
+          },
+        ],
+        nextSteps: ["Upload income documents"],
+        updatedAt: "2026-01-02T00:00:00.000Z",
+      },
+      profile: {
+        context: {
+          authority: "applicant",
+          propertyId: "prop-1",
+          rc_prop_id: "rc-prop-1",
+          applicationId: "app-1",
+          leaseId: null,
+          tenantId: "tenant-1",
+          unitId: "unit-1",
+          invitedEmail: "tenant@example.com",
+        },
+        profile: {
+          displayName: "Taylor Tenant",
+          email: "tenant@example.com",
+          phone: null,
+          authorityLabel: "Applicant",
+          property: {
+            propertyId: "prop-1",
+            rc_prop_id: "rc-prop-1",
+            street1: "123 Main St",
+            street2: "Unit 4",
+            city: "Halifax",
+            province: "NS",
+            postalCode: "B3H1A1",
+            features: [],
+          },
+          application: {
+            applicationId: "app-1",
+            status: "submitted",
+            missingSteps: ["income_documents"],
+            nextActions: ["Upload income documents"],
+            createdAt: null,
+            updatedAt: null,
+          },
+          lease: null,
+        },
+        identity: {
+          overallStatus: "pending",
+          identityVerification: {
+            status: "pending",
+            label: "Pending",
+            note: "Verification is still in progress.",
+            updatedAt: null,
+          },
+          documentChecklist: [
+            {
+              code: "income_documents",
+              label: "Income documents",
+              status: "missing",
+              nextStep: "Upload income documents",
+            },
+          ],
+          nextSteps: ["Upload income documents"],
+        },
+        actions: {
+          editableFields: ["displayName", "phone"],
+          documentEntry: {
+            available: true,
+            path: "/tenant/attachments",
+            label: "Open documents",
+            note: "1 document-related step still needs attention.",
+          },
+        },
+      },
+      attachments: {
+        ok: true,
+        data: [
+          {
+            id: "doc-1",
+            label: "Government ID",
+            category: "Identity",
+            status: "uploaded",
+          },
+        ],
+        summary: {
+          total: 1,
+          missing: 0,
+          uploaded: 1,
+          pendingReview: 0,
+          verified: 0,
+          needsAttention: 0,
+        },
+        guidance: undefined,
+        updatedAt: null,
+      },
+      access: {
+        summary: {
+          activeGrants: 1,
+          pendingRequests: 0,
+          latestActivityAt: 1,
+        },
+        pendingRequests: [],
+        activeAccess: [
+          {
+            id: "share-1",
+            grantedToLabel: "Shared with your landlord",
+            categories: ["Rental history"],
+            status: "active",
+            grantedAt: 1,
+            expiresAt: 2,
+            lastActivityAt: 3,
+            canRevoke: true,
+            accessLabel: "View-only access",
+          },
+        ],
+        recentActivity: [],
+        guidance: {
+          headline: "Shared",
+          body: "Visible",
+        },
+      },
+    });
+
+    expect(result.metrics.map((item) => item.value)).toEqual(["62%", "1/3", "1", expect.any(String)]);
+    expect(result.reusableProfileItems[0]).toMatchObject({
+      label: "Profile basics",
+      status: "needs_attention",
+    });
+    expect(result.documentItems[0]).toMatchObject({
+      label: "Ready to share",
+      status: "ready",
+    });
+    expect(result.shareInsights.some((item) => item.detail.includes("1 supported share record"))).toBe(true);
+    expect(result.missingItems.some((item) => item.actionPath === "/tenant/attachments")).toBe(true);
+  });
+});

--- a/rentchain-frontend/src/pages/tenant/tenantApplicationReuse.ts
+++ b/rentchain-frontend/src/pages/tenant/tenantApplicationReuse.ts
@@ -1,0 +1,201 @@
+import type { TenantAccessWorkspace } from "../../api/tenantAccess";
+import type { TenantApplicationCompletionSummary } from "../../api/tenantApplicationCompletion";
+import type { TenantAttachment } from "../../api/tenantAttachmentsApi";
+import type { TenantProfileData } from "../../api/tenantProfile";
+import { buildTenantDocumentVaultView } from "./tenantDocumentVault";
+import { buildTenantProfileCompletion } from "./tenantProfileCompletion";
+import { prettyStatus } from "./TenantWorkspaceShared";
+
+type ApplicationReuseMetric = {
+  label: string;
+  value: string;
+  accent: string;
+  hint: string;
+};
+
+type ApplicationReuseItem = {
+  label: string;
+  status: "ready" | "needs_attention" | "info";
+  detail: string;
+  actionPath: string | null;
+  actionLabel: string | null;
+};
+
+type ApplicationShareInsight = {
+  label: string;
+  detail: string;
+};
+
+export type TenantApplicationReuseView = {
+  metrics: ApplicationReuseMetric[];
+  reusableProfileItems: ApplicationReuseItem[];
+  documentItems: ApplicationReuseItem[];
+  missingItems: ApplicationReuseItem[];
+  shareInsights: ApplicationShareInsight[];
+};
+
+function statusLabel(ready: boolean): ApplicationReuseItem["status"] {
+  return ready ? "ready" : "needs_attention";
+}
+
+function propertySummary(profile: TenantProfileData["profile"]): string {
+  const property = profile.property;
+  if (!property) return "Property details will appear here when they are linked to this application.";
+  return [property.street1, property.street2, property.city, property.province].filter(Boolean).join(", ");
+}
+
+export function buildTenantApplicationReuseView(params: {
+  completion: TenantApplicationCompletionSummary | null;
+  profile: TenantProfileData | null;
+  attachments?: { data: TenantAttachment[]; summary?: any; guidance?: any; updatedAt?: number | null } | null;
+  access?: TenantAccessWorkspace | null;
+}): TenantApplicationReuseView {
+  const profileCompletion = params.profile ? buildTenantProfileCompletion(params.profile) : null;
+  const documentVault = buildTenantDocumentVaultView({
+    items: params.attachments?.data || [],
+    summary: params.attachments?.summary,
+    guidance: params.attachments?.guidance,
+    updatedAt: params.attachments?.updatedAt,
+    access: params.access,
+  });
+
+  const reusableProfileItems: ApplicationReuseItem[] = params.profile
+    ? [
+        {
+          label: "Profile basics",
+          status: statusLabel(Boolean(params.profile.profile.displayName && params.profile.profile.email && params.profile.profile.phone)),
+          detail:
+            params.profile.profile.displayName && params.profile.profile.email && params.profile.profile.phone
+              ? "Your saved profile basics are ready to review for this application."
+              : "Add your missing profile basics before continuing.",
+          actionPath: "/tenant/profile",
+          actionLabel: "Review your profile",
+        },
+        {
+          label: "Rental context",
+          status: statusLabel(Boolean(params.profile.profile.property || params.profile.profile.application || params.profile.profile.lease)),
+          detail: propertySummary(params.profile.profile),
+          actionPath: "/tenant/profile",
+          actionLabel: "Open profile",
+        },
+        {
+          label: "Identity status",
+          status: statusLabel(params.profile.identity.identityVerification.status === "verified"),
+          detail: params.profile.identity.identityVerification.note || "Identity progress is tracked from your tenant-safe profile.",
+          actionPath: "/tenant/profile",
+          actionLabel: "Review identity",
+        },
+      ]
+    : [
+        {
+          label: "Profile details",
+          status: "needs_attention",
+          detail: "Your saved profile summary is not available yet for this application view.",
+          actionPath: "/tenant/profile",
+          actionLabel: "Open profile",
+        },
+      ];
+
+  const documentItems: ApplicationReuseItem[] = [
+    {
+      label: "Ready to share",
+      status: documentVault.readyItems.length > 0 ? "ready" : "needs_attention",
+      detail:
+        documentVault.readyItems.length > 0
+          ? `${documentVault.readyItems.length} document${documentVault.readyItems.length === 1 ? "" : "s"} already sit in your profile for supported reuse.`
+          : "No documents are marked ready to share yet.",
+      actionPath: "/tenant/attachments",
+      actionLabel: "Open documents",
+    },
+    {
+      label: "Missing details",
+      status: documentVault.missingItems.length === 0 ? "ready" : "needs_attention",
+      detail:
+        documentVault.missingItems.length === 0
+          ? "Your document checklist does not show any missing items right now."
+          : `${documentVault.missingItems.length} document item${documentVault.missingItems.length === 1 ? "" : "s"} still need attention before this application feels fully ready.`,
+      actionPath: "/tenant/attachments",
+      actionLabel: "Add missing details",
+    },
+  ];
+
+  const missingItems = [
+    ...(params.completion?.sections || []).flatMap((section) =>
+      section.items
+        .filter((item) => ["missing", "needs_review", "not_started", "pending", "in_progress"].includes(item.status))
+        .map((item) => ({
+          label: item.label,
+          status: item.status === "pending" || item.status === "in_progress" ? "info" : "needs_attention",
+          detail: item.nextAction || "Review this step before continuing.",
+          actionPath: item.actionPath,
+          actionLabel: item.actionLabel,
+        }))
+    ),
+    ...(profileCompletion?.sections || []).flatMap((section) =>
+      section.items
+        .filter((item) => item.status !== "complete")
+        .map((item) => ({
+          label: item.label,
+          status: item.status === "pending" ? "info" : "needs_attention",
+          detail: item.detail,
+          actionPath: item.actionPath,
+          actionLabel: item.actionLabel,
+        }))
+    ),
+  ].filter((item, index, array) => array.findIndex((candidate) => candidate.label === item.label && candidate.detail === item.detail) === index);
+
+  const shareInsights: ApplicationShareInsight[] = [
+    {
+      label: "Review before sharing",
+      detail: "This application view shows what is already in your profile and what still needs work before you continue.",
+    },
+    {
+      label: "Shared with your permission",
+      detail:
+        params.access?.summary?.activeGrants
+          ? `${params.access.summary.activeGrants} supported share record${params.access.summary.activeGrants === 1 ? "" : "s"} are already active in your access workspace.`
+          : "No supported profile shares are active right now.",
+    },
+    {
+      label: "Current application status",
+      detail: params.profile?.profile?.application?.status
+        ? `Your current application is ${prettyStatus(params.profile.profile.application.status)}.`
+        : "Your current application status will appear here once this workspace has an active application context.",
+    },
+  ];
+
+  const metrics: ApplicationReuseMetric[] = [
+    {
+      label: "Application readiness",
+      value: `${params.completion?.progressPercent ?? 0}%`,
+      accent: "#1d4ed8",
+      hint: "Overall tenant-safe completion progress for this application.",
+    },
+    {
+      label: "Profile reuse",
+      value: `${reusableProfileItems.filter((item) => item.status === "ready").length}/${reusableProfileItems.length}`,
+      accent: "#0f766e",
+      hint: "Saved profile sections already ready for review.",
+    },
+    {
+      label: "Documents ready",
+      value: String(documentVault.readyItems.length),
+      accent: "#166534",
+      hint: "Saved document items already available in your profile.",
+    },
+    {
+      label: "Missing details",
+      value: String(missingItems.filter((item) => item.status !== "info").length),
+      accent: "#b45309",
+      hint: "Items still needing your attention before you continue.",
+    },
+  ];
+
+  return {
+    metrics,
+    reusableProfileItems,
+    documentItems,
+    missingItems,
+    shareInsights,
+  };
+}


### PR DESCRIPTION
## Summary

This PR refines `/tenant/application` into an application-readiness and profile-reuse flow.

Instead of treating the application experience like a blank form, the page now pulls together existing tenant-safe application, profile, document, and access data so tenants can review what is already reusable, see what is missing, and understand supported sharing paths without implying unsupported autofill or document-level submission behavior.

## What changed

### Application readiness experience
- Refined the tenant application experience into a review-first readiness flow
- Added tenant-first framing such as:
  - `Use your saved profile to prepare this application`
- Surfaced what is already reusable from:
  - tenant profile
  - tenant documents
  - tenant access/share visibility
  - existing application completion state

### Reuse summary model
- Added a deterministic helper to derive:
  - reuse metrics
  - reusable profile items
  - document readiness
  - missing details
  - review/share guidance
- Kept logic centralized and testable instead of embedding it directly in the page

### Review-first behavior
- Kept the flow honest and grounded in current support
- Did **not** add fake autofill
- Did **not** add fake document-level share controls
- Did **not** add fake submit promises
- Added clear remediation links back to:
  - `/tenant/profile`
  - `/tenant/attachments`
  - `/tenant/access`

## Scope

This PR is intentionally frontend-only.

- No backend changes
- No schema changes
- No auth changes
- No billing or screening changes
- No landlord workflow changes

## Files changed

- `rentchain-frontend/src/pages/tenant/TenantApplicationStatusPage.tsx`
- `rentchain-frontend/src/pages/tenant/tenantApplicationReuse.ts`
- `rentchain-frontend/src/pages/tenant/TenantApplicationCompletionPage.test.tsx`
- `rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx`
- `rentchain-frontend/src/pages/tenant/tenantApplicationReuse.test.ts`

## Key UX decisions

- Kept the experience review-first rather than form-first
- Built reuse/readiness entirely from existing tenant-safe endpoints
- Added deterministic helper logic for consistency and maintainability
- Preserved honesty in the UI by excluding unsupported autofill/submission behavior
- Added clear remediation paths into profile, documents, and access instead of trapping the tenant in one page

## Validation

Ran targeted validation for the touched area:

```bash
npm run test -- src/pages/tenant/TenantApplicationCompletionPage.test.tsx src/pages/tenant/tenantApplicationReuse.test.ts
PATH="$HOME/.nvm/versions/node/v20.20.2/bin:$PATH" npm run test -- src/pages/tenant/TenantApplicationCompletionPage.test.tsx src/pages/tenant/TenantWorkspacePage.test.tsx src/pages/tenant/tenantApplicationReuse.test.ts
PATH="$HOME/.nvm/versions/node/v20.20.2/bin:$PATH" npm run build