### PR TITLE
feat(tenant): add invite/apply flow orchestration v1

### DIFF
--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { cleanup, render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, useLocation } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 beforeEach(() => {
@@ -48,7 +48,10 @@ vi.mock("./pages/tenant/TenantWorkspacePage", () => ({
 }));
 
 vi.mock("./pages/tenant/TenantApplicationStatusPage", () => ({
-  default: () => <h1>Tenant Application Status</h1>,
+  default: () => {
+    const location = useLocation();
+    return <h1>{`Tenant Application Status ${location.pathname}${location.search}`}</h1>;
+  },
 }));
 
 describe("Routes: /tenant", () => {
@@ -106,5 +109,31 @@ describe("Routes: /tenant/application", () => {
 
     expect(await screen.findByText(/Tenant Application Status/i)).toBeInTheDocument();
     expect(screen.queryByText(/Dashboard/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Routes: tenant application aliases", () => {
+  it("normalizes tenant apply links into the tenant application flow", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/tenant/apply/app-123"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(
+      await screen.findByText(/Tenant Application Status \/tenant\/application\?entry=application&applicationToken=app-123/i)
+    ).toBeInTheDocument();
+  });
+
+  it("normalizes tenant invite redeem aliases into a tokenized redeem route", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/tenant/invite/redeem/invite-123"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole("textbox", { name: /Invite token/i })).toHaveValue("invite-123");
   });
 });

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -74,6 +74,7 @@ import TenantInviteRedeemPage from "./pages/tenant/TenantInviteRedeemPage";
 import TenantMaintenanceRequestDetailPage from "./pages/tenant/TenantMaintenanceRequestDetailPage";
 import TenantMaintenanceRequestsPage from "./pages/tenant/TenantMaintenanceRequestsPage";
 import TenantMaintenanceRequestNewPage from "./pages/tenant/TenantMaintenanceRequestNewPage";
+import { buildTenantApplicationEntryPath } from "./pages/tenant/tenantApplicationFlow";
 import MonthlyOpsReportPageWithNudge from "./pages/reports/MonthlyOpsReportPageWithNudge";
 import InvitesPage from "./pages/landlord/InvitesPage";
 import PublicApplyPage from "./pages/PublicApplyPage";
@@ -246,6 +247,19 @@ const LegacyTenantMagicRedirect: React.FC = () => {
   return <Navigate to={`/auth/magic${query}`} replace />;
 };
 
+const TenantApplicationEntryRedirect: React.FC<{ entry: "invite" | "application" }> = ({ entry }) => {
+  const { token } = useParams();
+  return <Navigate to={buildTenantApplicationEntryPath({ entry, token })} replace />;
+};
+
+const TenantInviteRedeemRedirect: React.FC = () => {
+  const { token } = useParams();
+  const params = new URLSearchParams();
+  if (token) params.set("token", token);
+  const query = params.toString();
+  return <Navigate to={query ? `/tenant/invite/redeem?${query}` : "/tenant/invite/redeem"} replace />;
+};
+
 const AccountRouteGate: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { user } = useAuth();
   const role = String(user?.actorRole || user?.role || "").trim().toLowerCase();
@@ -325,6 +339,18 @@ function App() {
           element={
             TENANT_PORTAL_ENABLED ? <LegacyTokenInviteRedirect source="tenant" /> : <TenantInviteRedeem />
           }
+        />
+        <Route
+          path="/tenant/apply"
+          element={TENANT_PORTAL_ENABLED ? <TenantApplicationEntryRedirect entry="application" /> : <TenantPortalComingSoon />}
+        />
+        <Route
+          path="/tenant/apply/:token"
+          element={TENANT_PORTAL_ENABLED ? <TenantApplicationEntryRedirect entry="application" /> : <TenantPortalComingSoon />}
+        />
+        <Route
+          path="/tenant/invite/redeem/:token"
+          element={TENANT_PORTAL_ENABLED ? <TenantInviteRedeemRedirect /> : <TenantPortalComingSoon />}
         />
 
         <Route

--- a/rentchain-frontend/src/pages/tenant/TenantApplicationCompletionPage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantApplicationCompletionPage.test.tsx
@@ -164,13 +164,17 @@ describe("tenant application completion page", () => {
     });
 
     render(
-      <MemoryRouter>
+      <MemoryRouter initialEntries={["/tenant/application?entry=invite&inviteToken=invite-1"]}>
         <TenantApplicationStatusPage />
       </MemoryRouter>
     );
 
     expect(await screen.findAllByText(/Application Readiness/i)).not.toHaveLength(0);
     expect(screen.getAllByText(/62%/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Flow Status/i)).toBeInTheDocument();
+    expect(screen.getByText(/Needs attention before review/i)).toBeInTheDocument();
+    expect(screen.getByText(/Invite entry/i)).toBeInTheDocument();
+    expect(screen.getByText(/^Next step$/i)).toBeInTheDocument();
     expect(screen.getByText(/Application Readiness Summary/i)).toBeInTheDocument();
     expect(screen.getAllByText(/Use Your Saved Profile/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Document Readiness/i)).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/tenant/TenantApplicationStatusPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantApplicationStatusPage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import {
   getTenantApplicationCompletion,
   type TenantApplicationCompletionItem,
@@ -20,6 +20,7 @@ import {
 } from "./TenantWorkspaceShared";
 import { spacing, text as textTokens } from "../../styles/tokens";
 import { buildTenantApplicationReuseView } from "./tenantApplicationReuse";
+import { buildTenantApplicationFlow } from "./tenantApplicationFlow";
 
 function statusTone(status: TenantApplicationCompletionStatus) {
   switch (status) {
@@ -137,6 +138,7 @@ const CompletionItemRow: React.FC<{ item: TenantApplicationCompletionItem }> = (
 };
 
 export default function TenantApplicationStatusPage() {
+  const location = useLocation();
   const [data, setData] = React.useState<Awaited<ReturnType<typeof getTenantApplicationCompletion>>>(null);
   const [profile, setProfile] = React.useState<Awaited<ReturnType<typeof getTenantProfile>> | null>(null);
   const [attachments, setAttachments] = React.useState<Awaited<ReturnType<typeof getTenantAttachments>> | null>(null);
@@ -219,6 +221,20 @@ export default function TenantApplicationStatusPage() {
     attachments,
     access,
   });
+  const flow = buildTenantApplicationFlow({
+    search: location.search,
+    completion: data,
+    reuse,
+  });
+  const flowTone =
+    flow.state === "ready_to_proceed"
+      ? { color: "#166534", background: "#dcfce7", label: "Ready to proceed" }
+      : flow.state === "ready_to_review"
+      ? { color: "#1d4ed8", background: "#dbeafe", label: "Ready to review" }
+      : flow.state === "needs_attention"
+      ? { color: "#9a3412", background: "#ffedd5", label: "Needs attention" }
+      : { color: "#0f766e", background: "#ccfbf1", label: "Readiness" };
+  const entryLabel = flow.entry === "invite" ? "Invite entry" : flow.entry === "application" ? "Application link" : "Direct tenant navigation";
 
   return (
     <TenantSurfaceShell
@@ -243,6 +259,135 @@ export default function TenantApplicationStatusPage() {
       }
     >
       <CompletionProgressCard progressPercent={data.progressPercent} status={data.status} />
+
+      <TenantInfoCard heading="Flow Status" accent="#0891b2">
+        <div style={{ display: "grid", gap: spacing.sm }}>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+            <div>
+              <div style={{ fontWeight: 800, color: textTokens.primary }}>{flow.title}</div>
+              <div style={{ color: textTokens.secondary }}>{flow.detail}</div>
+            </div>
+            <div
+              style={{
+                padding: "6px 10px",
+                borderRadius: 999,
+                fontWeight: 700,
+                color: flowTone.color,
+                background: flowTone.background,
+              }}
+            >
+              {flowTone.label}
+            </div>
+          </div>
+
+          <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
+            <div
+              style={{
+                padding: "6px 10px",
+                borderRadius: 999,
+                background: "rgba(15,23,42,0.06)",
+                color: textTokens.secondary,
+                fontWeight: 700,
+              }}
+            >
+              {entryLabel}
+            </div>
+            <div
+              style={{
+                padding: "6px 10px",
+                borderRadius: 999,
+                background: "rgba(15,23,42,0.06)",
+                color: textTokens.secondary,
+                fontWeight: 700,
+              }}
+            >
+              {flow.readyCount} readiness signal{flow.readyCount === 1 ? "" : "s"} ready
+            </div>
+            <div
+              style={{
+                padding: "6px 10px",
+                borderRadius: 999,
+                background: "rgba(15,23,42,0.06)",
+                color: textTokens.secondary,
+                fontWeight: 700,
+              }}
+            >
+              {flow.missingCount} missing item{flow.missingCount === 1 ? "" : "s"}
+            </div>
+          </div>
+
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))",
+              gap: spacing.sm,
+            }}
+          >
+            {flow.steps.map((step) => {
+              const tone =
+                step.status === "complete"
+                  ? { color: "#166534", background: "#dcfce7", label: "Complete" }
+                  : step.status === "current"
+                  ? { color: "#1d4ed8", background: "#dbeafe", label: "Current" }
+                  : { color: "#64748b", background: "#e2e8f0", label: "Up next" };
+              return (
+                <div
+                  key={step.key}
+                  style={{
+                    border: "1px solid rgba(15,23,42,0.08)",
+                    borderRadius: 12,
+                    padding: "12px 14px",
+                    display: "grid",
+                    gap: 6,
+                  }}
+                >
+                  <div style={{ fontWeight: 700, color: textTokens.primary }}>{step.label}</div>
+                  <div
+                    style={{
+                      width: "fit-content",
+                      padding: "4px 8px",
+                      borderRadius: 999,
+                      fontSize: 12,
+                      fontWeight: 700,
+                      color: tone.color,
+                      background: tone.background,
+                    }}
+                  >
+                    {tone.label}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          <div
+            style={{
+              border: "1px solid rgba(15,23,42,0.08)",
+              borderRadius: 12,
+              padding: "12px 14px",
+              display: "grid",
+              gap: 8,
+            }}
+          >
+            <div style={{ fontWeight: 700, color: textTokens.primary }}>Next step</div>
+            <div style={{ color: textTokens.secondary }}>{flow.nextStepDetail}</div>
+            <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+              <Link to={flow.nextStepPath} style={{ fontWeight: 700 }}>
+                {flow.nextStepLabel}
+              </Link>
+              <Link to="/tenant/profile" style={{ fontWeight: 700 }}>
+                Profile
+              </Link>
+              <Link to="/tenant/attachments" style={{ fontWeight: 700 }}>
+                Documents
+              </Link>
+              <Link to="/tenant/access" style={{ fontWeight: 700 }}>
+                Access
+              </Link>
+            </div>
+          </div>
+        </div>
+      </TenantInfoCard>
 
       <TenantInfoCard heading="Application Readiness Summary" accent="#0f766e">
         <div

--- a/rentchain-frontend/src/pages/tenant/TenantInviteRedeemPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantInviteRedeemPage.tsx
@@ -1,8 +1,9 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { redeemTenantWorkspaceInvite } from "../../api/tenantPortal";
 import { TenantInfoCard, TenantSurfaceShell } from "./TenantWorkspaceShared";
 import { colors, radius, spacing, text as textTokens } from "../../styles/tokens";
+import { buildTenantApplicationEntryPath } from "./tenantApplicationFlow";
 
 function mapInviteError(input: string | null) {
   const normalized = String(input || "").trim().toLowerCase();
@@ -16,7 +17,12 @@ function mapInviteError(input: string | null) {
 }
 
 export default function TenantInviteRedeemPage() {
-  const [token, setToken] = React.useState("");
+  const location = useLocation();
+  const prefilledToken = React.useMemo(
+    () => String(new URLSearchParams(location.search).get("token") || "").trim(),
+    [location.search]
+  );
+  const [token, setToken] = React.useState(prefilledToken);
   const [submitting, setSubmitting] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
   const [success, setSuccess] = React.useState<{
@@ -47,6 +53,14 @@ export default function TenantInviteRedeemPage() {
       setSubmitting(false);
     }
   };
+
+  React.useEffect(() => {
+    setToken(prefilledToken);
+  }, [prefilledToken]);
+
+  const nextApplicationPath = success
+    ? buildTenantApplicationEntryPath({ entry: "invite", token: success.applicationId || success.inviteId || prefilledToken })
+    : buildTenantApplicationEntryPath({ entry: "invite", token: prefilledToken });
 
   return (
     <TenantSurfaceShell
@@ -101,7 +115,8 @@ export default function TenantInviteRedeemPage() {
               <div>Status: {success.status || "redeemed"}</div>
               {success.propertyId ? <div>Property: {success.propertyId}</div> : null}
               {success.applicationId ? <div>Application: {success.applicationId}</div> : null}
-              <div>
+              <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
+                <Link to={nextApplicationPath}>Continue to application readiness</Link>
                 <Link to="/tenant">Return to workspace</Link>
               </div>
             </div>

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -389,6 +389,10 @@ describe("tenant workspace frontend shell", () => {
     fireEvent.click(screen.getByRole("button", { name: /Redeem invite/i }));
 
     expect(await screen.findByText(/Invite redeemed/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Continue to application readiness/i })).toHaveAttribute(
+      "href",
+      "/tenant/application?entry=invite&inviteToken=app-1"
+    );
   });
 
   it("invite redemption page handles expired or reused states", async () => {
@@ -409,6 +413,16 @@ describe("tenant workspace frontend shell", () => {
     fireEvent.click(screen.getByRole("button", { name: /Redeem invite/i }));
 
     expect(await screen.findByText(/This invite has expired/i)).toBeInTheDocument();
+  });
+
+  it("invite redemption page prefills token from the route query", async () => {
+    render(
+      <MemoryRouter initialEntries={["/tenant/invite/redeem?token=token-123"]}>
+        <TenantInviteRedeemPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("textbox", { name: /Invite token/i })).toHaveValue("token-123");
   });
 
   it("unauthorized workspace response renders safe denial state", async () => {

--- a/rentchain-frontend/src/pages/tenant/tenantApplicationFlow.test.ts
+++ b/rentchain-frontend/src/pages/tenant/tenantApplicationFlow.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildTenantApplicationEntryPath,
+  buildTenantApplicationFlow,
+} from "./tenantApplicationFlow";
+import type { TenantApplicationReuseView } from "./tenantApplicationReuse";
+
+function makeReuse(overrides?: Partial<TenantApplicationReuseView>): TenantApplicationReuseView {
+  return {
+    metrics: [],
+    reusableProfileItems: [
+      {
+        label: "Profile basics",
+        status: "ready",
+        detail: "Ready",
+        actionPath: "/tenant/profile",
+        actionLabel: "Review your profile",
+      },
+    ],
+    documentItems: [
+      {
+        label: "Ready to share",
+        status: "ready",
+        detail: "Ready",
+        actionPath: "/tenant/attachments",
+        actionLabel: "Open documents",
+      },
+    ],
+    missingItems: [],
+    shareInsights: [],
+    ...overrides,
+  };
+}
+
+describe("tenant application flow helper", () => {
+  it("builds normalized tenant application entry paths", () => {
+    expect(buildTenantApplicationEntryPath()).toBe("/tenant/application");
+    expect(buildTenantApplicationEntryPath({ entry: "application", token: "app-123" })).toBe(
+      "/tenant/application?entry=application&applicationToken=app-123"
+    );
+    expect(buildTenantApplicationEntryPath({ entry: "invite", token: "invite-123" })).toBe(
+      "/tenant/application?entry=invite&inviteToken=invite-123"
+    );
+  });
+
+  it("returns needs attention when required items are missing", () => {
+    const view = buildTenantApplicationFlow({
+      search: "?entry=invite&inviteToken=invite-123",
+      completion: {
+        status: "in_progress",
+        progressPercent: 42,
+        sections: [],
+        nextSteps: ["Upload ID"],
+        updatedAt: "2026-01-02T00:00:00.000Z",
+      },
+      reuse: makeReuse({
+        missingItems: [
+          {
+            label: "Government ID",
+            status: "needs_attention",
+            detail: "Upload your ID",
+            actionPath: "/tenant/attachments",
+            actionLabel: "Open documents",
+          },
+        ],
+      }),
+    });
+
+    expect(view.entry).toBe("invite");
+    expect(view.state).toBe("needs_attention");
+    expect(view.nextStepPath).toBe("/tenant/attachments");
+    expect(view.steps[1]?.status).toBe("current");
+  });
+
+  it("returns ready to review for in-progress reusable application links", () => {
+    const view = buildTenantApplicationFlow({
+      search: "?entry=application&applicationToken=app-123",
+      completion: {
+        status: "in_progress",
+        progressPercent: 74,
+        sections: [],
+        nextSteps: [],
+        updatedAt: "2026-01-02T00:00:00.000Z",
+      },
+      reuse: makeReuse(),
+    });
+
+    expect(view.entry).toBe("application");
+    expect(view.state).toBe("ready_to_review");
+    expect(view.nextStepPath).toBe("/tenant/application");
+  });
+
+  it("returns ready to proceed for complete direct navigation", () => {
+    const view = buildTenantApplicationFlow({
+      search: "",
+      completion: {
+        status: "completed",
+        progressPercent: 100,
+        sections: [],
+        nextSteps: [],
+        updatedAt: "2026-01-02T00:00:00.000Z",
+      },
+      reuse: makeReuse(),
+    });
+
+    expect(view.entry).toBe("direct");
+    expect(view.state).toBe("ready_to_proceed");
+    expect(view.nextStepPath).toBe("/tenant/access");
+    expect(view.steps[3]?.status).toBe("current");
+  });
+});

--- a/rentchain-frontend/src/pages/tenant/tenantApplicationFlow.ts
+++ b/rentchain-frontend/src/pages/tenant/tenantApplicationFlow.ts
@@ -1,0 +1,176 @@
+import type { TenantApplicationCompletionSummary } from "../../api/tenantApplicationCompletion";
+import type { TenantApplicationReuseView } from "./tenantApplicationReuse";
+
+export type TenantApplicationFlowEntry = "direct" | "invite" | "application";
+export type TenantApplicationFlowState =
+  | "readiness"
+  | "needs_attention"
+  | "ready_to_review"
+  | "ready_to_proceed";
+
+type TenantApplicationFlowStepStatus = "complete" | "current" | "upcoming";
+
+export type TenantApplicationFlowStep = {
+  key: "readiness" | "fix" | "review" | "continue";
+  label: string;
+  status: TenantApplicationFlowStepStatus;
+};
+
+export type TenantApplicationFlowView = {
+  entry: TenantApplicationFlowEntry;
+  state: TenantApplicationFlowState;
+  title: string;
+  detail: string;
+  nextStepLabel: string;
+  nextStepPath: string;
+  nextStepDetail: string;
+  missingCount: number;
+  readyCount: number;
+  steps: TenantApplicationFlowStep[];
+};
+
+function normalizeEntry(value: string | null | undefined): TenantApplicationFlowEntry {
+  const normalized = String(value || "").trim().toLowerCase();
+  if (normalized === "invite") return "invite";
+  if (normalized === "application" || normalized === "apply") return "application";
+  return "direct";
+}
+
+function firstActionPath(reuse: TenantApplicationReuseView): string {
+  return (
+    reuse.missingItems.find((item) => item.actionPath)?.actionPath ||
+    reuse.documentItems.find((item) => item.status === "needs_attention")?.actionPath ||
+    reuse.reusableProfileItems.find((item) => item.status === "needs_attention")?.actionPath ||
+    "/tenant/profile"
+  );
+}
+
+function firstActionLabel(reuse: TenantApplicationReuseView): string {
+  return (
+    reuse.missingItems.find((item) => item.actionLabel)?.actionLabel ||
+    reuse.documentItems.find((item) => item.status === "needs_attention")?.actionLabel ||
+    reuse.reusableProfileItems.find((item) => item.status === "needs_attention")?.actionLabel ||
+    "Add missing details"
+  );
+}
+
+function entryDescription(entry: TenantApplicationFlowEntry): string {
+  if (entry === "invite") {
+    return "You came in from a tenant invite. Review what is already ready before you continue.";
+  }
+  if (entry === "application") {
+    return "You came in from an application link. Use your saved profile so this does not feel like a blank restart.";
+  }
+  return "You opened the application flow directly from your tenant workspace.";
+}
+
+function buildSteps(state: TenantApplicationFlowState): TenantApplicationFlowStep[] {
+  const currentIndex = state === "needs_attention" ? 1 : state === "ready_to_review" ? 2 : state === "ready_to_proceed" ? 3 : 0;
+  return [
+    { key: "readiness", label: "Readiness", status: currentIndex > 0 ? "complete" : "current" },
+    { key: "fix", label: "Fix details", status: currentIndex > 1 ? "complete" : currentIndex === 1 ? "current" : "upcoming" },
+    { key: "review", label: "Review", status: currentIndex > 2 ? "complete" : currentIndex === 2 ? "current" : "upcoming" },
+    { key: "continue", label: "Continue", status: currentIndex === 3 ? "current" : "upcoming" },
+  ];
+}
+
+export function buildTenantApplicationEntryPath(input?: {
+  entry?: TenantApplicationFlowEntry | null;
+  token?: string | null;
+}): string {
+  const entry = normalizeEntry(input?.entry);
+  const params = new URLSearchParams();
+  if (entry !== "direct") {
+    params.set("entry", entry);
+  }
+  const token = String(input?.token || "").trim();
+  if (token) {
+    params.set(entry === "invite" ? "inviteToken" : "applicationToken", token);
+  }
+  const query = params.toString();
+  return query ? `/tenant/application?${query}` : "/tenant/application";
+}
+
+export function buildTenantApplicationFlow(input: {
+  search?: string;
+  completion: TenantApplicationCompletionSummary | null;
+  reuse: TenantApplicationReuseView;
+}): TenantApplicationFlowView {
+  const entry = normalizeEntry(new URLSearchParams(input.search || "").get("entry"));
+  const missingCount = input.reuse.missingItems.filter((item) => item.status !== "info").length;
+  const readyCount =
+    input.reuse.reusableProfileItems.filter((item) => item.status === "ready").length +
+    input.reuse.documentItems.filter((item) => item.status === "ready").length;
+  const pendingSignals =
+    input.reuse.missingItems.filter((item) => item.status === "info").length +
+    (input.completion?.sections || []).flatMap((section) => section.items).filter((item) => item.status === "pending" || item.status === "in_progress").length;
+  const progressPercent = input.completion?.progressPercent ?? 0;
+  const completionStatus = String(input.completion?.status || "").trim().toLowerCase();
+
+  let state: TenantApplicationFlowState = "readiness";
+  if (missingCount > 0) {
+    state = "needs_attention";
+  } else if (progressPercent >= 100 || completionStatus === "completed" || completionStatus === "verified") {
+    state = entry === "direct" ? "ready_to_proceed" : "ready_to_review";
+  } else if (readyCount > 0 || pendingSignals > 0 || progressPercent >= 50) {
+    state = "ready_to_review";
+  }
+
+  if (state === "needs_attention") {
+    return {
+      entry,
+      state,
+      title: "Needs attention before review",
+      detail: `${entryDescription(entry)} Add the missing details below so the application can move forward with clarity.`,
+      nextStepLabel: firstActionLabel(input.reuse),
+      nextStepPath: firstActionPath(input.reuse),
+      nextStepDetail: `${missingCount} item${missingCount === 1 ? "" : "s"} still need your attention.`,
+      missingCount,
+      readyCount,
+      steps: buildSteps(state),
+    };
+  }
+
+  if (state === "ready_to_proceed") {
+    return {
+      entry,
+      state,
+      title: "Ready to proceed",
+      detail: `${entryDescription(entry)} Your saved profile and document signals are in a good place for the supported next step.`,
+      nextStepLabel: "Review access before continuing",
+      nextStepPath: "/tenant/access",
+      nextStepDetail: "Confirm what is shared with your permission before you continue.",
+      missingCount,
+      readyCount,
+      steps: buildSteps(state),
+    };
+  }
+
+  if (state === "ready_to_review") {
+    return {
+      entry,
+      state,
+      title: "Ready to review",
+      detail: `${entryDescription(entry)} Review what is ready so this flow stays organized and tenant-controlled.`,
+      nextStepLabel: "Review your application readiness",
+      nextStepPath: "/tenant/application",
+      nextStepDetail: "Check the sections below and confirm what is already reusable.",
+      missingCount,
+      readyCount,
+      steps: buildSteps(state),
+    };
+  }
+
+  return {
+    entry,
+    state,
+    title: "Start with readiness",
+    detail: `${entryDescription(entry)} Start by filling in your profile and documents so the rest of the flow has something to reuse.`,
+    nextStepLabel: "Review your profile",
+    nextStepPath: "/tenant/profile",
+    nextStepDetail: "Profile details are the foundation for the rest of this application flow.",
+    missingCount,
+    readyCount,
+    steps: buildSteps(state),
+  };
+}


### PR DESCRIPTION
## Summary

This PR adds a frontend-only orchestration layer for tenant invite/apply flows.

Tenant entry now normalizes more cleanly into `/tenant/application`, the application page includes an explicit flow-status / next-step card, and invite redemption can hand tenants directly into application readiness without inventing unsupported backend submission behavior.

## What changed

- normalized tenant-safe aliases for:
  - `/tenant/apply`
  - `/tenant/apply/:token`
  - `/tenant/invite/redeem/:token`
- added deterministic flow-state helper for:
  - `readiness`
  - `needs_attention`
  - `ready_to_review`
  - `ready_to_proceed`
- updated the application experience to guide tenants back to:
  - `/tenant/profile`
  - `/tenant/attachments`
  - `/tenant/access`

## Scope

- frontend only
- no backend changes
- no schema changes
- no auth-core changes
- no landlord workflow changes

## Validation

```bash
cd rentchain-frontend && PATH="$HOME/.nvm/versions/node/v20.20.2/bin:$PATH" npm run test -- src/App.routes.test.tsx src/pages/tenant/TenantApplicationCompletionPage.test.tsx src/pages/tenant/TenantWorkspacePage.test.tsx src/pages/tenant/tenantApplicationFlow.test.ts
cd rentchain-frontend && PATH="$HOME/.nvm/versions/node/v20.20.2/bin:$PATH" npm run build