### PR TITLE
feat(landlord): align intake with tenant shared data v1

### DIFF
--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
@@ -120,6 +120,11 @@ describe("ApplicationReviewSummaryPage", () => {
     renderPage();
 
     expect(await screen.findByText("Application Review Summary")).toBeInTheDocument();
+    expect(await screen.findByText("Intake Summary")).toBeInTheDocument();
+    expect(screen.getAllByText("Shared profile details").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Shared documents & records").length).toBeGreaterThan(0);
+    expect(await screen.findByText("Ready for review")).toBeInTheDocument();
+    expect(await screen.findByText("Shared with tenant permission and current server-authorized review access.")).toBeInTheDocument();
     expect(await screen.findByText("Jane Applicant")).toBeInTheDocument();
     expect(await screen.findByText("Landlord Decision Panel")).toBeInTheDocument();
     expect(await screen.findByText("Identity verification completed")).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
@@ -17,6 +17,7 @@ import {
   ReviewSummaryApiError,
 } from "../api/reviewSummaryApi";
 import { useToast } from "../components/ui/ToastProvider";
+import { buildLandlordIntakeAlignmentView } from "./applicationReviewIntakeAlignment";
 
 function money(cents: number | null): string {
   if (cents == null || !Number.isFinite(cents)) return "Not provided";
@@ -51,6 +52,18 @@ function kv(label: string, value: string) {
       <div style={{ fontWeight: 600, color: text.main }}>{value || "Not provided"}</div>
     </div>
   );
+}
+
+function intakeTone(state: "ready_for_review" | "needs_follow_up") {
+  return state === "ready_for_review"
+    ? { color: "#166534", background: "#dcfce7", label: "Ready for review" }
+    : { color: "#9a3412", background: "#ffedd5", label: "Needs follow-up" };
+}
+
+function itemTone(status: "available" | "missing") {
+  return status === "available"
+    ? { color: "#166534", background: "#dcfce7", label: "Available" }
+    : { color: "#9a3412", background: "#ffedd5", label: "Missing" };
 }
 
 type SummaryLoadError = {
@@ -214,6 +227,11 @@ function ApplicationReviewSummaryPageBody() {
     }
   };
 
+  const intakeView = useMemo(
+    () => (summary ? buildLandlordIntakeAlignmentView(summary) : null),
+    [summary]
+  );
+
   return (
     <div style={{ padding: 16, display: "grid", gap: 12 }}>
       {!entitlements.canViewReviewSummary ? (
@@ -271,6 +289,161 @@ function ApplicationReviewSummaryPageBody() {
 
       {!loading && !error && summary ? (
         <>
+          {intakeView ? (
+            <Card style={{ display: "grid", gap: 12 }}>
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+                <div>
+                  <div style={{ fontWeight: 700 }}>Intake Summary</div>
+                  <div style={{ fontSize: 13, color: text.subtle, marginTop: 4 }}>
+                    {intakeView.detail}
+                  </div>
+                </div>
+                <div
+                  style={{
+                    padding: "6px 10px",
+                    borderRadius: 999,
+                    fontWeight: 700,
+                    color: intakeTone(intakeView.state).color,
+                    background: intakeTone(intakeView.state).background,
+                  }}
+                >
+                  {intakeTone(intakeView.state).label}
+                </div>
+              </div>
+
+              <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 8 }}>
+                {intakeView.metrics.map((metric) => (
+                  <div
+                    key={metric.label}
+                    style={{
+                      border: `1px solid ${colors.border}`,
+                      borderRadius: 10,
+                      background: "#fff",
+                      padding: 12,
+                      display: "grid",
+                      gap: 4,
+                    }}
+                  >
+                    <div style={{ fontSize: 24, fontWeight: 800, color: metric.accent }}>{metric.value}</div>
+                    <div style={{ fontWeight: 600, color: text.main }}>{metric.label}</div>
+                    <div style={{ fontSize: 12, color: text.subtle }}>{metric.hint}</div>
+                  </div>
+                ))}
+              </div>
+
+              <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))", gap: 12 }}>
+                <Card style={{ display: "grid", gap: 8 }}>
+                  <div style={{ fontWeight: 700 }}>Shared profile details</div>
+                  <div style={{ fontSize: 12, color: text.subtle }}>
+                    Only categories visible in the current authorized review summary appear here.
+                  </div>
+                  {intakeView.profileItems.map((item) => {
+                    const tone = itemTone(item.status);
+                    return (
+                      <div
+                        key={item.label}
+                        style={{
+                          border: `1px solid ${colors.border}`,
+                          borderRadius: 10,
+                          padding: 10,
+                          display: "grid",
+                          gap: 6,
+                        }}
+                      >
+                        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, flexWrap: "wrap" }}>
+                          <div style={{ fontWeight: 600, color: text.main }}>{item.label}</div>
+                          <div
+                            style={{
+                              padding: "4px 8px",
+                              borderRadius: 999,
+                              fontSize: 12,
+                              fontWeight: 700,
+                              color: tone.color,
+                              background: tone.background,
+                            }}
+                          >
+                            {tone.label}
+                          </div>
+                        </div>
+                        <div style={{ fontSize: 13, color: text.subtle }}>{item.detail}</div>
+                      </div>
+                    );
+                  })}
+                </Card>
+
+                <Card style={{ display: "grid", gap: 8 }}>
+                  <div style={{ fontWeight: 700 }}>Shared documents & records</div>
+                  <div style={{ fontSize: 12, color: text.subtle }}>
+                    This stays high-level and only reflects records already available to review.
+                  </div>
+                  {intakeView.recordItems.map((item) => {
+                    const tone = itemTone(item.status);
+                    return (
+                      <div
+                        key={item.label}
+                        style={{
+                          border: `1px solid ${colors.border}`,
+                          borderRadius: 10,
+                          padding: 10,
+                          display: "grid",
+                          gap: 6,
+                        }}
+                      >
+                        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, flexWrap: "wrap" }}>
+                          <div style={{ fontWeight: 600, color: text.main }}>{item.label}</div>
+                          <div
+                            style={{
+                              padding: "4px 8px",
+                              borderRadius: 999,
+                              fontSize: 12,
+                              fontWeight: 700,
+                              color: tone.color,
+                              background: tone.background,
+                            }}
+                          >
+                            {tone.label}
+                          </div>
+                        </div>
+                        <div style={{ fontSize: 13, color: text.subtle }}>{item.detail}</div>
+                      </div>
+                    );
+                  })}
+                </Card>
+              </div>
+
+              <Card style={{ display: "grid", gap: 8 }}>
+                <div style={{ fontWeight: 700 }}>Missing items</div>
+                <div style={{ fontSize: 12, color: text.subtle }}>
+                  Missing categories stay high-level so this view does not imply access to anything the tenant has not shared.
+                </div>
+                {intakeView.missingItems.length ? (
+                  intakeView.missingItems.map((item) => (
+                    <div
+                      key={item.label}
+                      style={{
+                        border: `1px solid ${colors.border}`,
+                        borderRadius: 10,
+                        padding: 10,
+                        display: "grid",
+                        gap: 6,
+                      }}
+                    >
+                      <div style={{ fontWeight: 600, color: text.main }}>{item.label}</div>
+                      <div style={{ fontSize: 13, color: text.subtle }}>{item.detail}</div>
+                    </div>
+                  ))
+                ) : (
+                  <div style={{ fontSize: 13, color: text.subtle }}>
+                    No major intake gaps are surfaced in the current review summary.
+                  </div>
+                )}
+                <div style={{ fontSize: 12, color: text.subtle }}>
+                  Shared with tenant permission and current server-authorized review access.
+                </div>
+              </Card>
+            </Card>
+          ) : null}
+
           <Card style={{ display: "grid", gap: 8 }}>
             <div style={{ fontWeight: 700 }}>Applicant Overview</div>
             <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 8 }}>

--- a/rentchain-frontend/src/pages/applicationReviewIntakeAlignment.test.ts
+++ b/rentchain-frontend/src/pages/applicationReviewIntakeAlignment.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import { buildLandlordIntakeAlignmentView } from "./applicationReviewIntakeAlignment";
+import type { ApplicationReviewSummary } from "../api/reviewSummaryApi";
+
+function buildSummary(overrides?: Partial<ApplicationReviewSummary>): ApplicationReviewSummary {
+  return {
+    applicationId: "app-1",
+    generatedAt: "2026-04-01T00:00:00.000Z",
+    applicant: {
+      name: "Jane Applicant",
+      email: "jane@example.com",
+      currentAddressLine: "123 Main St",
+      city: "Halifax",
+      provinceState: "NS",
+      postalCode: "B3H1A1",
+      country: "CA",
+      timeAtCurrentAddressMonths: 24,
+      currentRentAmountCents: 180000,
+    },
+    employment: {
+      employerName: "Harbor Co",
+      jobTitle: "Manager",
+      incomeAmountCents: 720000,
+      incomeFrequency: "monthly",
+      incomeMonthlyCents: 720000,
+      monthsAtJob: 18,
+    },
+    reference: {
+      name: "Jordan Ref",
+      phone: "902-555-0100",
+    },
+    compliance: {
+      applicationConsentAcceptedAt: "2026-04-01T00:00:00.000Z",
+      applicationConsentVersion: "v1",
+      signatureType: "typed",
+      signedAt: "2026-04-01T00:00:00.000Z",
+    },
+    screening: {
+      status: "complete",
+      provider: "transunion",
+      referenceId: "TU-1",
+    },
+    derived: {
+      incomeToRentRatio: 4,
+      completeness: { score: 1, label: "High" },
+      flags: [],
+    },
+    insights: [],
+    decisionSummary: null,
+    risk: null,
+    ...overrides,
+  };
+}
+
+describe("buildLandlordIntakeAlignmentView", () => {
+  it("marks a complete authorized review payload as ready for review", () => {
+    const view = buildLandlordIntakeAlignmentView(buildSummary());
+
+    expect(view.state).toBe("ready_for_review");
+    expect(view.metrics[0]?.value).toBe("4/4");
+    expect(view.metrics[1]?.value).toBe("3");
+    expect(view.missingItems).toHaveLength(0);
+  });
+
+  it("groups missing review-summary flags into high-level follow-up categories", () => {
+    const view = buildLandlordIntakeAlignmentView(
+      buildSummary({
+        applicant: {
+          name: "Jane Applicant",
+          email: "jane@example.com",
+          currentAddressLine: null,
+          city: null,
+          provinceState: null,
+          postalCode: null,
+          country: "CA",
+          timeAtCurrentAddressMonths: null,
+          currentRentAmountCents: null,
+        },
+        employment: {
+          employerName: null,
+          jobTitle: null,
+          incomeAmountCents: null,
+          incomeFrequency: null,
+          incomeMonthlyCents: null,
+          monthsAtJob: null,
+        },
+        reference: {
+          name: null,
+          phone: null,
+        },
+        compliance: {
+          applicationConsentAcceptedAt: null,
+          applicationConsentVersion: null,
+          signatureType: null,
+          signedAt: null,
+        },
+        screening: {
+          status: "not_run",
+          provider: null,
+          referenceId: null,
+        },
+        derived: {
+          incomeToRentRatio: null,
+          completeness: { score: 0.42, label: "Low" },
+          flags: [
+            "MISSING_CURRENT_ADDRESS_LINE1",
+            "MISSING_CURRENT_ADDRESS_CITY",
+            "MISSING_EMPLOYER_NAME",
+            "MISSING_INCOME",
+            "MISSING_WORK_REFERENCE_NAME",
+            "MISSING_SIGNATURE",
+            "MISSING_APPLICATION_CONSENT",
+          ],
+        },
+      })
+    );
+
+    expect(view.state).toBe("needs_follow_up");
+    expect(view.missingItems.map((item) => item.label)).toEqual(
+      expect.arrayContaining([
+        "Current address",
+        "Employment & income",
+        "Work reference",
+        "Signature record",
+        "Consent record",
+      ])
+    );
+  });
+});

--- a/rentchain-frontend/src/pages/applicationReviewIntakeAlignment.ts
+++ b/rentchain-frontend/src/pages/applicationReviewIntakeAlignment.ts
@@ -1,0 +1,221 @@
+import type { ApplicationReviewSummary } from "../api/reviewSummaryApi";
+
+type IntakeMetric = {
+  label: string;
+  value: string;
+  hint: string;
+  accent: string;
+};
+
+type IntakeItem = {
+  label: string;
+  status: "available" | "missing";
+  detail: string;
+};
+
+export type LandlordIntakeAlignmentView = {
+  state: "ready_for_review" | "needs_follow_up";
+  headline: string;
+  detail: string;
+  metrics: IntakeMetric[];
+  profileItems: IntakeItem[];
+  recordItems: IntakeItem[];
+  missingItems: IntakeItem[];
+};
+
+function hasText(value: string | null | undefined): boolean {
+  return Boolean(String(value || "").trim());
+}
+
+function moneyProvided(value: number | null | undefined): boolean {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function statusLabel(available: boolean): IntakeItem["status"] {
+  return available ? "available" : "missing";
+}
+
+function missingFlagDetails(flags: string[]): IntakeItem[] {
+  const groups = new Map<string, string>();
+  flags.forEach((flag) => {
+    if (flag.startsWith("MISSING_CURRENT_ADDRESS_")) {
+      groups.set(
+        "Current address",
+        "Current address details are still incomplete in the information available to review."
+      );
+      return;
+    }
+    if (flag === "MISSING_TIME_AT_ADDRESS" || flag === "MISSING_CURRENT_RENT") {
+      groups.set(
+        "Current housing details",
+        "Housing history details are still limited in the current intake view."
+      );
+      return;
+    }
+    if (
+      flag === "MISSING_EMPLOYER_NAME" ||
+      flag === "MISSING_JOB_TITLE" ||
+      flag === "MISSING_INCOME" ||
+      flag === "MISSING_MONTHS_AT_JOB"
+    ) {
+      groups.set(
+        "Employment & income",
+        "Employment or income details are not fully available to review yet."
+      );
+      return;
+    }
+    if (flag === "MISSING_WORK_REFERENCE_NAME" || flag === "MISSING_WORK_REFERENCE_PHONE") {
+      groups.set(
+        "Work reference",
+        "A full work reference is not yet available in the shared intake data."
+      );
+      return;
+    }
+    if (flag === "MISSING_SIGNATURE") {
+      groups.set(
+        "Signature record",
+        "A signed application record is not available in this review summary yet."
+      );
+      return;
+    }
+    if (flag === "MISSING_APPLICATION_CONSENT") {
+      groups.set(
+        "Consent record",
+        "An application consent record is not available in this review summary yet."
+      );
+    }
+  });
+
+  return Array.from(groups.entries()).map(([label, detail]) => ({
+    label,
+    status: "missing",
+    detail,
+  }));
+}
+
+export function buildLandlordIntakeAlignmentView(
+  summary: ApplicationReviewSummary
+): LandlordIntakeAlignmentView {
+  const profileItems: IntakeItem[] = [
+    {
+      label: "Shared profile details",
+      status: statusLabel(hasText(summary.applicant.name) || hasText(summary.applicant.email)),
+      detail:
+        hasText(summary.applicant.name) || hasText(summary.applicant.email)
+          ? "Core applicant identity and contact details are available to review."
+          : "Core applicant identity details are still limited in this intake view.",
+    },
+    {
+      label: "Address history",
+      status: statusLabel(
+        hasText(summary.applicant.currentAddressLine) &&
+          hasText(summary.applicant.city) &&
+          hasText(summary.applicant.provinceState)
+      ),
+      detail:
+        hasText(summary.applicant.currentAddressLine) &&
+        hasText(summary.applicant.city) &&
+        hasText(summary.applicant.provinceState)
+          ? "Current address details are available to review."
+          : "Address history details are still incomplete in the shared intake data.",
+    },
+    {
+      label: "Employment & income",
+      status: statusLabel(
+        hasText(summary.employment.employerName) &&
+          hasText(summary.employment.jobTitle) &&
+          moneyProvided(summary.employment.incomeAmountCents) &&
+          hasText(summary.employment.incomeFrequency)
+      ),
+      detail:
+        hasText(summary.employment.employerName) &&
+        hasText(summary.employment.jobTitle) &&
+        moneyProvided(summary.employment.incomeAmountCents) &&
+        hasText(summary.employment.incomeFrequency)
+          ? "Employment and income details are available to review."
+          : "Employment or income details still need follow-up.",
+    },
+    {
+      label: "Work reference",
+      status: statusLabel(hasText(summary.reference.name) && hasText(summary.reference.phone)),
+      detail:
+        hasText(summary.reference.name) && hasText(summary.reference.phone)
+          ? "A work reference is available to review."
+          : "A full work reference is not yet available in this intake view.",
+    },
+  ];
+
+  const recordItems: IntakeItem[] = [
+    {
+      label: "Consent record",
+      status: statusLabel(
+        hasText(summary.compliance.applicationConsentVersion) ||
+          hasText(summary.compliance.applicationConsentAcceptedAt)
+      ),
+      detail:
+        hasText(summary.compliance.applicationConsentVersion) ||
+        hasText(summary.compliance.applicationConsentAcceptedAt)
+          ? "An application consent record is available to review."
+          : "No application consent record is visible in this summary yet.",
+    },
+    {
+      label: "Signature record",
+      status: statusLabel(hasText(summary.compliance.signatureType) || hasText(summary.compliance.signedAt)),
+      detail:
+        hasText(summary.compliance.signatureType) || hasText(summary.compliance.signedAt)
+          ? "A signed application record is available to review."
+          : "A signed application record is not visible in this summary yet.",
+    },
+    {
+      label: "Screening reference",
+      status: statusLabel(hasText(summary.screening.referenceId) || hasText(summary.screening.provider)),
+      detail:
+        hasText(summary.screening.referenceId) || hasText(summary.screening.provider)
+          ? "A screening or verification record is available in the current intake view."
+          : "No screening or verification record is visible yet.",
+    },
+  ];
+
+  const missingItems = missingFlagDetails(summary.derived.flags);
+  const profileAvailable = profileItems.filter((item) => item.status === "available").length;
+  const recordsAvailable = recordItems.filter((item) => item.status === "available").length;
+  const state = missingItems.length === 0 ? "ready_for_review" : "needs_follow_up";
+
+  return {
+    state,
+    headline: state === "ready_for_review" ? "Ready for review" : "Needs follow-up",
+    detail:
+      state === "ready_for_review"
+        ? "This intake view only reflects information that is currently available in the authorized review summary."
+        : "Some categories are still missing or incomplete in the information currently available to review.",
+    metrics: [
+      {
+        label: "Shared profile details",
+        value: `${profileAvailable}/${profileItems.length}`,
+        hint: "High-level profile categories available to review.",
+        accent: "#1d4ed8",
+      },
+      {
+        label: "Shared documents & records",
+        value: String(recordsAvailable),
+        hint: "Visible consent, signature, or screening records.",
+        accent: "#166534",
+      },
+      {
+        label: "Missing items",
+        value: String(missingItems.length),
+        hint: "High-level categories that still need follow-up.",
+        accent: "#b45309",
+      },
+      {
+        label: "Completeness",
+        value: `${Math.round(summary.derived.completeness.score * 100)}%`,
+        hint: "Current review-summary completeness signal.",
+        accent: "#7c3aed",
+      },
+    ],
+    profileItems,
+    recordItems,
+    missingItems,
+  };
+}


### PR DESCRIPTION
## Summary

This PR refines the existing landlord review-summary page so it more clearly reflects what tenant-shared information is available, what records are visible, and what categories are still missing, without implying broader access than the current authorized payload supports.

## What changed

- refined the existing landlord review-summary page instead of adding a new intake screen
- added a deterministic intake-alignment helper for:
  - shared profile categories
  - shared documents & records
  - missing categories
  - ready-for-review vs needs-follow-up state
- kept document language honest and high-level
- limited intake visibility to data already present in the authorized review-summary payload

## Scope

- frontend only
- no backend changes
- no schema changes
- no auth-core changes
- no permission expansion

## Files changed

- `rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx`
- `rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx`
- `rentchain-frontend/src/pages/applicationReviewIntakeAlignment.ts`
- `rentchain-frontend/src/pages/applicationReviewIntakeAlignment.test.ts`

## Validation

```bash
cd rentchain-frontend && PATH="$HOME/.nvm/versions/node/v20.20.2/bin:$PATH" npm run test -- src/pages/ApplicationReviewSummaryPage.test.tsx src/pages/applicationReviewIntakeAlignment.test.ts
cd rentchain-frontend && PATH="$HOME/.nvm/versions/node/v20.20.2/bin:$PATH" npm run build