### PR TITLE
feat(shared): align tenant-landlord share package v1

### DIFF
--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
@@ -121,8 +121,12 @@ describe("ApplicationReviewSummaryPage", () => {
 
     expect(await screen.findByText("Application Review Summary")).toBeInTheDocument();
     expect(await screen.findByText("Intake Summary")).toBeInTheDocument();
-    expect(screen.getAllByText("Shared profile details").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Shared documents & records").length).toBeGreaterThan(0);
+    expect(await screen.findByText("Shared package categories")).toBeInTheDocument();
+    expect(screen.getAllByText("Profile details").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Rental history").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Documents & records").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Consent / identity status").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Application readiness").length).toBeGreaterThan(0);
     expect(await screen.findByText("Ready for review")).toBeInTheDocument();
     expect(await screen.findByText("Shared with tenant permission and current server-authorized review access.")).toBeInTheDocument();
     expect(await screen.findByText("Jane Applicant")).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
@@ -60,12 +60,6 @@ function intakeTone(state: "ready_for_review" | "needs_follow_up") {
     : { color: "#9a3412", background: "#ffedd5", label: "Needs follow-up" };
 }
 
-function itemTone(status: "available" | "missing") {
-  return status === "available"
-    ? { color: "#166534", background: "#dcfce7", label: "Available" }
-    : { color: "#9a3412", background: "#ffedd5", label: "Missing" };
-}
-
 type SummaryLoadError = {
   message: string;
   status?: number;
@@ -331,85 +325,49 @@ function ApplicationReviewSummaryPageBody() {
                 ))}
               </div>
 
-              <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))", gap: 12 }}>
-                <Card style={{ display: "grid", gap: 8 }}>
-                  <div style={{ fontWeight: 700 }}>Shared profile details</div>
-                  <div style={{ fontSize: 12, color: text.subtle }}>
-                    Only categories visible in the current authorized review summary appear here.
-                  </div>
-                  {intakeView.profileItems.map((item) => {
-                    const tone = itemTone(item.status);
-                    return (
-                      <div
-                        key={item.label}
-                        style={{
-                          border: `1px solid ${colors.border}`,
-                          borderRadius: 10,
-                          padding: 10,
-                          display: "grid",
-                          gap: 6,
-                        }}
-                      >
-                        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, flexWrap: "wrap" }}>
-                          <div style={{ fontWeight: 600, color: text.main }}>{item.label}</div>
-                          <div
-                            style={{
-                              padding: "4px 8px",
-                              borderRadius: 999,
-                              fontSize: 12,
-                              fontWeight: 700,
-                              color: tone.color,
-                              background: tone.background,
-                            }}
-                          >
-                            {tone.label}
-                          </div>
+              <Card style={{ display: "grid", gap: 8 }}>
+                <div style={{ fontWeight: 700 }}>Shared package categories</div>
+                <div style={{ fontSize: 12, color: text.subtle }}>
+                  These categories match the tenant-facing package language and only reflect records available in the current authorized review summary.
+                </div>
+                {intakeView.packageCategories.map((item) => {
+                  const tone =
+                    item.status === "ready"
+                      ? { color: "#166534", background: "#dcfce7", label: "Available to review" }
+                      : item.status === "partial"
+                      ? { color: "#1d4ed8", background: "#dbeafe", label: "Partly available" }
+                      : { color: "#9a3412", background: "#ffedd5", label: "Missing" };
+                  return (
+                    <div
+                      key={item.key}
+                      style={{
+                        border: `1px solid ${colors.border}`,
+                        borderRadius: 10,
+                        padding: 10,
+                        display: "grid",
+                        gap: 6,
+                      }}
+                    >
+                      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, flexWrap: "wrap" }}>
+                        <div style={{ fontWeight: 600, color: text.main }}>{item.label}</div>
+                        <div
+                          style={{
+                            padding: "4px 8px",
+                            borderRadius: 999,
+                            fontSize: 12,
+                            fontWeight: 700,
+                            color: tone.color,
+                            background: tone.background,
+                          }}
+                        >
+                          {tone.label}
                         </div>
-                        <div style={{ fontSize: 13, color: text.subtle }}>{item.detail}</div>
                       </div>
-                    );
-                  })}
-                </Card>
-
-                <Card style={{ display: "grid", gap: 8 }}>
-                  <div style={{ fontWeight: 700 }}>Shared documents & records</div>
-                  <div style={{ fontSize: 12, color: text.subtle }}>
-                    This stays high-level and only reflects records already available to review.
-                  </div>
-                  {intakeView.recordItems.map((item) => {
-                    const tone = itemTone(item.status);
-                    return (
-                      <div
-                        key={item.label}
-                        style={{
-                          border: `1px solid ${colors.border}`,
-                          borderRadius: 10,
-                          padding: 10,
-                          display: "grid",
-                          gap: 6,
-                        }}
-                      >
-                        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, flexWrap: "wrap" }}>
-                          <div style={{ fontWeight: 600, color: text.main }}>{item.label}</div>
-                          <div
-                            style={{
-                              padding: "4px 8px",
-                              borderRadius: 999,
-                              fontSize: 12,
-                              fontWeight: 700,
-                              color: tone.color,
-                              background: tone.background,
-                            }}
-                          >
-                            {tone.label}
-                          </div>
-                        </div>
-                        <div style={{ fontSize: 13, color: text.subtle }}>{item.detail}</div>
-                      </div>
-                    );
-                  })}
-                </Card>
-              </div>
+                      <div style={{ fontSize: 13, color: text.subtle }}>{item.detail}</div>
+                    </div>
+                  );
+                })}
+              </Card>
 
               <Card style={{ display: "grid", gap: 8 }}>
                 <div style={{ fontWeight: 700 }}>Missing items</div>

--- a/rentchain-frontend/src/pages/applicationReviewIntakeAlignment.test.ts
+++ b/rentchain-frontend/src/pages/applicationReviewIntakeAlignment.test.ts
@@ -57,8 +57,15 @@ describe("buildLandlordIntakeAlignmentView", () => {
     const view = buildLandlordIntakeAlignmentView(buildSummary());
 
     expect(view.state).toBe("ready_for_review");
-    expect(view.metrics[0]?.value).toBe("4/4");
-    expect(view.metrics[1]?.value).toBe("3");
+    expect(view.metrics[0]?.value).toBe("2/2");
+    expect(view.metrics[1]?.value).toBe("2");
+    expect(view.packageCategories.map((item) => item.label)).toEqual([
+      "Profile details",
+      "Rental history",
+      "Documents & records",
+      "Consent / identity status",
+      "Application readiness",
+    ]);
     expect(view.missingItems).toHaveLength(0);
   });
 
@@ -118,11 +125,9 @@ describe("buildLandlordIntakeAlignmentView", () => {
     expect(view.state).toBe("needs_follow_up");
     expect(view.missingItems.map((item) => item.label)).toEqual(
       expect.arrayContaining([
-        "Current address",
-        "Employment & income",
-        "Work reference",
-        "Signature record",
-        "Consent record",
+        "Rental history",
+        "Profile details",
+        "Consent / identity status",
       ])
     );
   });

--- a/rentchain-frontend/src/pages/applicationReviewIntakeAlignment.ts
+++ b/rentchain-frontend/src/pages/applicationReviewIntakeAlignment.ts
@@ -1,4 +1,8 @@
 import type { ApplicationReviewSummary } from "../api/reviewSummaryApi";
+import {
+  buildLandlordSharePackageCategories,
+  type SharePackageCategoryView,
+} from "./sharePackageAlignment";
 
 type IntakeMetric = {
   label: string;
@@ -18,37 +22,24 @@ export type LandlordIntakeAlignmentView = {
   headline: string;
   detail: string;
   metrics: IntakeMetric[];
-  profileItems: IntakeItem[];
-  recordItems: IntakeItem[];
+  packageCategories: SharePackageCategoryView[];
   missingItems: IntakeItem[];
 };
-
-function hasText(value: string | null | undefined): boolean {
-  return Boolean(String(value || "").trim());
-}
-
-function moneyProvided(value: number | null | undefined): boolean {
-  return typeof value === "number" && Number.isFinite(value);
-}
-
-function statusLabel(available: boolean): IntakeItem["status"] {
-  return available ? "available" : "missing";
-}
 
 function missingFlagDetails(flags: string[]): IntakeItem[] {
   const groups = new Map<string, string>();
   flags.forEach((flag) => {
     if (flag.startsWith("MISSING_CURRENT_ADDRESS_")) {
       groups.set(
-        "Current address",
-        "Current address details are still incomplete in the information available to review."
+        "Rental history",
+        "Rental history details are still incomplete in the information available to review."
       );
       return;
     }
     if (flag === "MISSING_TIME_AT_ADDRESS" || flag === "MISSING_CURRENT_RENT") {
       groups.set(
-        "Current housing details",
-        "Housing history details are still limited in the current intake view."
+        "Rental history",
+        "Rental history details are still limited in the current intake view."
       );
       return;
     }
@@ -59,29 +50,22 @@ function missingFlagDetails(flags: string[]): IntakeItem[] {
       flag === "MISSING_MONTHS_AT_JOB"
     ) {
       groups.set(
-        "Employment & income",
-        "Employment or income details are not fully available to review yet."
+        "Profile details",
+        "Profile details are not fully available to review yet."
       );
       return;
     }
     if (flag === "MISSING_WORK_REFERENCE_NAME" || flag === "MISSING_WORK_REFERENCE_PHONE") {
       groups.set(
-        "Work reference",
-        "A full work reference is not yet available in the shared intake data."
+        "Profile details",
+        "Supporting profile details are still incomplete in the shared intake data."
       );
       return;
     }
-    if (flag === "MISSING_SIGNATURE") {
+    if (flag === "MISSING_SIGNATURE" || flag === "MISSING_APPLICATION_CONSENT") {
       groups.set(
-        "Signature record",
-        "A signed application record is not available in this review summary yet."
-      );
-      return;
-    }
-    if (flag === "MISSING_APPLICATION_CONSENT") {
-      groups.set(
-        "Consent record",
-        "An application consent record is not available in this review summary yet."
+        "Consent / identity status",
+        "Consent or identity status is not fully available in this review package yet."
       );
     }
   });
@@ -96,89 +80,18 @@ function missingFlagDetails(flags: string[]): IntakeItem[] {
 export function buildLandlordIntakeAlignmentView(
   summary: ApplicationReviewSummary
 ): LandlordIntakeAlignmentView {
-  const profileItems: IntakeItem[] = [
-    {
-      label: "Shared profile details",
-      status: statusLabel(hasText(summary.applicant.name) || hasText(summary.applicant.email)),
-      detail:
-        hasText(summary.applicant.name) || hasText(summary.applicant.email)
-          ? "Core applicant identity and contact details are available to review."
-          : "Core applicant identity details are still limited in this intake view.",
-    },
-    {
-      label: "Address history",
-      status: statusLabel(
-        hasText(summary.applicant.currentAddressLine) &&
-          hasText(summary.applicant.city) &&
-          hasText(summary.applicant.provinceState)
-      ),
-      detail:
-        hasText(summary.applicant.currentAddressLine) &&
-        hasText(summary.applicant.city) &&
-        hasText(summary.applicant.provinceState)
-          ? "Current address details are available to review."
-          : "Address history details are still incomplete in the shared intake data.",
-    },
-    {
-      label: "Employment & income",
-      status: statusLabel(
-        hasText(summary.employment.employerName) &&
-          hasText(summary.employment.jobTitle) &&
-          moneyProvided(summary.employment.incomeAmountCents) &&
-          hasText(summary.employment.incomeFrequency)
-      ),
-      detail:
-        hasText(summary.employment.employerName) &&
-        hasText(summary.employment.jobTitle) &&
-        moneyProvided(summary.employment.incomeAmountCents) &&
-        hasText(summary.employment.incomeFrequency)
-          ? "Employment and income details are available to review."
-          : "Employment or income details still need follow-up.",
-    },
-    {
-      label: "Work reference",
-      status: statusLabel(hasText(summary.reference.name) && hasText(summary.reference.phone)),
-      detail:
-        hasText(summary.reference.name) && hasText(summary.reference.phone)
-          ? "A work reference is available to review."
-          : "A full work reference is not yet available in this intake view.",
-    },
-  ];
-
-  const recordItems: IntakeItem[] = [
-    {
-      label: "Consent record",
-      status: statusLabel(
-        hasText(summary.compliance.applicationConsentVersion) ||
-          hasText(summary.compliance.applicationConsentAcceptedAt)
-      ),
-      detail:
-        hasText(summary.compliance.applicationConsentVersion) ||
-        hasText(summary.compliance.applicationConsentAcceptedAt)
-          ? "An application consent record is available to review."
-          : "No application consent record is visible in this summary yet.",
-    },
-    {
-      label: "Signature record",
-      status: statusLabel(hasText(summary.compliance.signatureType) || hasText(summary.compliance.signedAt)),
-      detail:
-        hasText(summary.compliance.signatureType) || hasText(summary.compliance.signedAt)
-          ? "A signed application record is available to review."
-          : "A signed application record is not visible in this summary yet.",
-    },
-    {
-      label: "Screening reference",
-      status: statusLabel(hasText(summary.screening.referenceId) || hasText(summary.screening.provider)),
-      detail:
-        hasText(summary.screening.referenceId) || hasText(summary.screening.provider)
-          ? "A screening or verification record is available in the current intake view."
-          : "No screening or verification record is visible yet.",
-    },
-  ];
-
+  const packageCategories = buildLandlordSharePackageCategories(summary);
   const missingItems = missingFlagDetails(summary.derived.flags);
-  const profileAvailable = profileItems.filter((item) => item.status === "available").length;
-  const recordsAvailable = recordItems.filter((item) => item.status === "available").length;
+  const profileAvailable = packageCategories.filter(
+    (item) =>
+      (item.key === "profile_details" || item.key === "rental_history") &&
+      item.status !== "missing"
+  ).length;
+  const recordsAvailable = packageCategories.filter(
+    (item) =>
+      (item.key === "documents_records" || item.key === "consent_identity_status") &&
+      item.status !== "missing"
+  ).length;
   const state = missingItems.length === 0 ? "ready_for_review" : "needs_follow_up";
 
   return {
@@ -187,18 +100,18 @@ export function buildLandlordIntakeAlignmentView(
     detail:
       state === "ready_for_review"
         ? "This intake view only reflects information that is currently available in the authorized review summary."
-        : "Some categories are still missing or incomplete in the information currently available to review.",
+        : "Some package categories are still missing or incomplete in the information currently available to review.",
     metrics: [
       {
-        label: "Shared profile details",
-        value: `${profileAvailable}/${profileItems.length}`,
-        hint: "High-level profile categories available to review.",
+        label: "Profile details",
+        value: `${profileAvailable}/2`,
+        hint: "Aligned package categories available to review.",
         accent: "#1d4ed8",
       },
       {
-        label: "Shared documents & records",
+        label: "Documents & records",
         value: String(recordsAvailable),
-        hint: "Visible consent, signature, or screening records.",
+        hint: "High-level package records currently visible to review.",
         accent: "#166534",
       },
       {
@@ -208,14 +121,13 @@ export function buildLandlordIntakeAlignmentView(
         accent: "#b45309",
       },
       {
-        label: "Completeness",
+        label: "Application readiness",
         value: `${Math.round(summary.derived.completeness.score * 100)}%`,
         hint: "Current review-summary completeness signal.",
         accent: "#7c3aed",
       },
     ],
-    profileItems,
-    recordItems,
+    packageCategories,
     missingItems,
   };
 }

--- a/rentchain-frontend/src/pages/sharePackageAlignment.test.ts
+++ b/rentchain-frontend/src/pages/sharePackageAlignment.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import {
+  SHARE_PACKAGE_CATEGORY_LABELS,
+  buildLandlordSharePackageCategories,
+  buildTenantSharePackageCategories,
+} from "./sharePackageAlignment";
+
+describe("share package alignment helper", () => {
+  it("uses the same package category labels across tenant and landlord surfaces", () => {
+    expect(Object.values(SHARE_PACKAGE_CATEGORY_LABELS)).toEqual([
+      "Profile details",
+      "Rental history",
+      "Documents & records",
+      "Consent / identity status",
+      "Application readiness",
+    ]);
+  });
+
+  it("builds aligned tenant package categories", () => {
+    const result = buildTenantSharePackageCategories({
+      hasProfileBasics: true,
+      rentalHistoryDetail: "123 Main St, Halifax, NS",
+      hasRentalHistory: true,
+      readyDocumentCount: 2,
+      missingDocumentCount: 1,
+      identityStatusLabel: "Identity is pending review.",
+      identityVerified: false,
+      activeGrantCount: 1,
+      progressPercent: 62,
+      missingCount: 2,
+    });
+
+    expect(result.map((item) => item.label)).toEqual(Object.values(SHARE_PACKAGE_CATEGORY_LABELS));
+    expect(result[2]).toMatchObject({ label: "Documents & records", status: "partial" });
+    expect(result[4]).toMatchObject({ label: "Application readiness", status: "partial" });
+  });
+
+  it("builds aligned landlord package categories", () => {
+    const result = buildLandlordSharePackageCategories({
+      applicationId: "app-1",
+      generatedAt: "2026-04-01T00:00:00.000Z",
+      applicant: {
+        name: "Jane Applicant",
+        email: "jane@example.com",
+        currentAddressLine: "123 Main St",
+        city: "Halifax",
+        provinceState: "NS",
+        postalCode: "B3H1A1",
+        country: "CA",
+        timeAtCurrentAddressMonths: 24,
+        currentRentAmountCents: 180000,
+      },
+      employment: {
+        employerName: "Harbor Co",
+        jobTitle: "Manager",
+        incomeAmountCents: 720000,
+        incomeFrequency: "monthly",
+        incomeMonthlyCents: 720000,
+        monthsAtJob: 18,
+      },
+      reference: { name: "Jordan Ref", phone: "902-555-0100" },
+      compliance: {
+        applicationConsentAcceptedAt: "2026-04-01T00:00:00.000Z",
+        applicationConsentVersion: "v1",
+        signatureType: "typed",
+        signedAt: "2026-04-01T00:00:00.000Z",
+      },
+      screening: { status: "complete", provider: "transunion", referenceId: "TU-1" },
+      derived: { incomeToRentRatio: 4, completeness: { score: 0.94, label: "High" }, flags: [] },
+      insights: [],
+      decisionSummary: null,
+      risk: null,
+    });
+
+    expect(result.map((item) => item.label)).toEqual(Object.values(SHARE_PACKAGE_CATEGORY_LABELS));
+    expect(result.every((item) => item.status === "ready")).toBe(true);
+  });
+});

--- a/rentchain-frontend/src/pages/sharePackageAlignment.ts
+++ b/rentchain-frontend/src/pages/sharePackageAlignment.ts
@@ -1,0 +1,212 @@
+import type { ApplicationReviewSummary } from "../api/reviewSummaryApi";
+
+export type SharePackageCategoryKey =
+  | "profile_details"
+  | "rental_history"
+  | "documents_records"
+  | "consent_identity_status"
+  | "application_readiness";
+
+export type SharePackageCategoryStatus = "ready" | "partial" | "missing";
+
+export type SharePackageCategoryView = {
+  key: SharePackageCategoryKey;
+  label: string;
+  status: SharePackageCategoryStatus;
+  detail: string;
+};
+
+export const SHARE_PACKAGE_CATEGORY_LABELS: Record<SharePackageCategoryKey, string> = {
+  profile_details: "Profile details",
+  rental_history: "Rental history",
+  documents_records: "Documents & records",
+  consent_identity_status: "Consent / identity status",
+  application_readiness: "Application readiness",
+};
+
+function hasText(value: string | null | undefined): boolean {
+  return Boolean(String(value || "").trim());
+}
+
+function hasNumber(value: number | null | undefined): boolean {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function category(
+  key: SharePackageCategoryKey,
+  status: SharePackageCategoryStatus,
+  detail: string
+): SharePackageCategoryView {
+  return {
+    key,
+    label: SHARE_PACKAGE_CATEGORY_LABELS[key],
+    status,
+    detail,
+  };
+}
+
+export function buildTenantSharePackageCategories(input: {
+  hasProfileBasics: boolean;
+  rentalHistoryDetail: string;
+  hasRentalHistory: boolean;
+  readyDocumentCount: number;
+  missingDocumentCount: number;
+  identityStatusLabel: string;
+  identityVerified: boolean;
+  activeGrantCount: number;
+  progressPercent: number;
+  missingCount: number;
+}): SharePackageCategoryView[] {
+  const documentStatus: SharePackageCategoryStatus =
+    input.readyDocumentCount > 0
+      ? input.missingDocumentCount > 0
+        ? "partial"
+        : "ready"
+      : input.missingDocumentCount > 0
+      ? "missing"
+      : "partial";
+
+  const consentStatus: SharePackageCategoryStatus =
+    input.identityVerified && input.activeGrantCount > 0
+      ? "ready"
+      : input.identityVerified || input.activeGrantCount > 0
+      ? "partial"
+      : "missing";
+
+  const readinessStatus: SharePackageCategoryStatus =
+    input.missingCount === 0 && input.progressPercent >= 80
+      ? "ready"
+      : input.progressPercent > 0
+      ? "partial"
+      : "missing";
+
+  return [
+    category(
+      "profile_details",
+      input.hasProfileBasics ? "ready" : "missing",
+      input.hasProfileBasics
+        ? "Your core profile details are organized in this package."
+        : "Add the missing basics in your profile before sharing this package."
+    ),
+    category(
+      "rental_history",
+      input.hasRentalHistory ? "ready" : "missing",
+      input.hasRentalHistory
+        ? input.rentalHistoryDetail
+        : "Rental history details will appear here when they are connected to your profile."
+    ),
+    category(
+      "documents_records",
+      documentStatus,
+      input.readyDocumentCount > 0
+        ? `${input.readyDocumentCount} document${input.readyDocumentCount === 1 ? "" : "s"} are part of your package${input.missingDocumentCount > 0 ? `, with ${input.missingDocumentCount} still needing attention.` : "."}`
+        : input.missingDocumentCount > 0
+        ? `${input.missingDocumentCount} document item${input.missingDocumentCount === 1 ? "" : "s"} still need attention before this package feels complete.`
+        : "Documents and records will appear here when they are available in your profile.",
+    ),
+    category(
+      "consent_identity_status",
+      consentStatus,
+      input.identityVerified && input.activeGrantCount > 0
+        ? `Identity is verified and ${input.activeGrantCount} supported share record${input.activeGrantCount === 1 ? "" : "s"} are active.`
+        : input.identityVerified
+        ? "Your identity status is ready, and you can review sharing from your access workspace."
+        : input.activeGrantCount > 0
+        ? `${input.activeGrantCount} supported share record${input.activeGrantCount === 1 ? "" : "s"} are active. ${input.identityStatusLabel}`
+        : input.identityStatusLabel,
+    ),
+    category(
+      "application_readiness",
+      readinessStatus,
+      input.missingCount === 0
+        ? `Your package is ${input.progressPercent}% ready based on the current application checklist.`
+        : `${input.progressPercent}% ready with ${input.missingCount} item${input.missingCount === 1 ? "" : "s"} still needing attention.`,
+    ),
+  ];
+}
+
+export function buildLandlordSharePackageCategories(
+  summary: ApplicationReviewSummary
+): SharePackageCategoryView[] {
+  const profileSignals = [
+    hasText(summary.applicant.name),
+    hasText(summary.applicant.email),
+    hasText(summary.employment.employerName),
+    hasText(summary.employment.jobTitle),
+  ].filter(Boolean).length;
+
+  const rentalSignals = [
+    hasText(summary.applicant.currentAddressLine),
+    hasText(summary.applicant.city),
+    hasText(summary.applicant.provinceState),
+    hasNumber(summary.applicant.timeAtCurrentAddressMonths),
+    hasNumber(summary.applicant.currentRentAmountCents),
+  ].filter(Boolean).length;
+
+  const recordSignals = [
+    hasText(summary.compliance.applicationConsentVersion) || hasText(summary.compliance.applicationConsentAcceptedAt),
+    hasText(summary.compliance.signatureType) || hasText(summary.compliance.signedAt),
+    hasText(summary.screening.referenceId) || hasText(summary.screening.provider),
+  ].filter(Boolean).length;
+
+  const consentSignals = [
+    hasText(summary.compliance.applicationConsentVersion) || hasText(summary.compliance.applicationConsentAcceptedAt),
+    hasText(summary.compliance.signatureType) || hasText(summary.compliance.signedAt),
+    summary.screening.status !== "not_run",
+  ].filter(Boolean).length;
+
+  const readinessStatus: SharePackageCategoryStatus =
+    summary.derived.flags.length === 0 && summary.derived.completeness.score >= 0.8
+      ? "ready"
+      : summary.derived.completeness.score > 0
+      ? "partial"
+      : "missing";
+
+  return [
+    category(
+      "profile_details",
+      profileSignals >= 3 ? "ready" : profileSignals > 0 ? "partial" : "missing",
+      profileSignals >= 3
+        ? "Profile details are available to review in this package."
+        : profileSignals > 0
+        ? "Some profile details are available, but the package is still incomplete."
+        : "Profile details are still limited in the current authorized review summary.",
+    ),
+    category(
+      "rental_history",
+      rentalSignals >= 3 ? "ready" : rentalSignals > 0 ? "partial" : "missing",
+      rentalSignals >= 3
+        ? "Rental history details are available to review."
+        : rentalSignals > 0
+        ? "Some rental history details are visible, but this category is still incomplete."
+        : "Rental history details are not yet available in this review package.",
+    ),
+    category(
+      "documents_records",
+      recordSignals >= 2 ? "ready" : recordSignals > 0 ? "partial" : "missing",
+      recordSignals >= 2
+        ? "Documents and records are available to review at a high level."
+        : recordSignals > 0
+        ? "Some package records are available to review, with more still missing."
+        : "Documents and records are not yet available in this review package.",
+    ),
+    category(
+      "consent_identity_status",
+      consentSignals >= 2 ? "ready" : consentSignals > 0 ? "partial" : "missing",
+      consentSignals >= 2
+        ? "Consent and identity-related status records are available to review."
+        : consentSignals > 0
+        ? "Some consent or identity status is available, but it is not yet complete."
+        : "Consent or identity status is not yet visible in this review package.",
+    ),
+    category(
+      "application_readiness",
+      readinessStatus,
+      readinessStatus === "ready"
+        ? `This package is ready for review at ${Math.round(summary.derived.completeness.score * 100)}% completeness.`
+        : readinessStatus === "partial"
+        ? `${Math.round(summary.derived.completeness.score * 100)}% completeness with ${summary.derived.flags.length} category gap${summary.derived.flags.length === 1 ? "" : "s"} still surfaced.`
+        : "Application readiness is not yet available from the current review summary.",
+    ),
+  ];
+}

--- a/rentchain-frontend/src/pages/tenant/TenantApplicationCompletionPage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantApplicationCompletionPage.test.tsx
@@ -176,8 +176,13 @@ describe("tenant application completion page", () => {
     expect(screen.getByText(/Invite entry/i)).toBeInTheDocument();
     expect(screen.getByText(/^Next step$/i)).toBeInTheDocument();
     expect(screen.getByText(/Application Readiness Summary/i)).toBeInTheDocument();
-    expect(screen.getAllByText(/Use Your Saved Profile/i).length).toBeGreaterThan(0);
-    expect(screen.getByText(/Document Readiness/i)).toBeInTheDocument();
+    expect(screen.getByText(/Share Package/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Profile details/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Rental history/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Documents & records/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Consent \/ identity status/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Application readiness/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Review Package Guidance/i)).toBeInTheDocument();
     expect(screen.getAllByText(/Review Before Sharing/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Identity verification/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Upload income documents/i).length).toBeGreaterThan(0);

--- a/rentchain-frontend/src/pages/tenant/TenantApplicationStatusPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantApplicationStatusPage.tsx
@@ -423,14 +423,14 @@ export default function TenantApplicationStatusPage() {
           gap: spacing.md,
         }}
       >
-        <TenantInfoCard heading="Use Your Saved Profile" accent="#1d4ed8">
+        <TenantInfoCard heading="Share Package" accent="#1d4ed8">
           <div style={{ display: "grid", gap: spacing.sm }}>
-            {reuse.reusableProfileItems.map((item) => {
+            {reuse.packageCategories.map((item) => {
               const tone =
                 item.status === "ready"
                   ? { color: "#166534", background: "#dcfce7", label: "Ready" }
-                  : item.status === "info"
-                  ? { color: "#1d4ed8", background: "#dbeafe", label: "In review" }
+                  : item.status === "partial"
+                  ? { color: "#1d4ed8", background: "#dbeafe", label: "Partly ready" }
                   : { color: "#9a3412", background: "#ffedd5", label: "Needs attention" };
               return (
                 <div
@@ -459,23 +459,20 @@ export default function TenantApplicationStatusPage() {
                     </div>
                   </div>
                   <div style={{ color: textTokens.secondary }}>{item.detail}</div>
-                  {item.actionPath ? (
-                    <Link to={item.actionPath} style={{ fontWeight: 700 }}>
-                      {item.actionLabel || "Review"}
-                    </Link>
-                  ) : null}
                 </div>
               );
             })}
           </div>
         </TenantInfoCard>
 
-        <TenantInfoCard heading="Document Readiness" accent="#166534">
+        <TenantInfoCard heading="Review Package Guidance" accent="#166534">
           <div style={{ display: "grid", gap: spacing.sm }}>
-            {reuse.documentItems.map((item) => {
+            {[...reuse.reusableProfileItems, ...reuse.documentItems].map((item) => {
               const tone =
                 item.status === "ready"
                   ? { color: "#166534", background: "#dcfce7", label: "Ready" }
+                  : item.status === "info"
+                  ? { color: "#1d4ed8", background: "#dbeafe", label: "In review" }
                   : { color: "#9a3412", background: "#ffedd5", label: "Needs attention" };
               return (
                 <div
@@ -554,6 +551,9 @@ export default function TenantApplicationStatusPage() {
               <strong style={{ color: textTokens.primary }}>{item.label}:</strong> {item.detail}
             </div>
           ))}
+          <div style={{ color: textTokens.secondary }}>
+            <strong style={{ color: textTokens.primary }}>Shared package:</strong> Profile details, rental history, documents & records, consent / identity status, and application readiness stay aligned with what a landlord can review today.
+          </div>
           <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
             <Link to="/tenant/profile" style={{ fontWeight: 700 }}>
               Review your profile

--- a/rentchain-frontend/src/pages/tenant/tenantApplicationReuse.test.ts
+++ b/rentchain-frontend/src/pages/tenant/tenantApplicationReuse.test.ts
@@ -141,6 +141,17 @@ describe("buildTenantApplicationReuseView", () => {
     });
 
     expect(result.metrics.map((item) => item.value)).toEqual(["62%", "1/3", "1", expect.any(String)]);
+    expect(result.packageCategories.map((item) => item.label)).toEqual([
+      "Profile details",
+      "Rental history",
+      "Documents & records",
+      "Consent / identity status",
+      "Application readiness",
+    ]);
+    expect(result.packageCategories[2]).toMatchObject({
+      label: "Documents & records",
+      status: "ready",
+    });
     expect(result.reusableProfileItems[0]).toMatchObject({
       label: "Profile basics",
       status: "needs_attention",

--- a/rentchain-frontend/src/pages/tenant/tenantApplicationReuse.ts
+++ b/rentchain-frontend/src/pages/tenant/tenantApplicationReuse.ts
@@ -5,6 +5,7 @@ import type { TenantProfileData } from "../../api/tenantProfile";
 import { buildTenantDocumentVaultView } from "./tenantDocumentVault";
 import { buildTenantProfileCompletion } from "./tenantProfileCompletion";
 import { prettyStatus } from "./TenantWorkspaceShared";
+import { buildTenantSharePackageCategories, type SharePackageCategoryView } from "../sharePackageAlignment";
 
 type ApplicationReuseMetric = {
   label: string;
@@ -28,6 +29,7 @@ type ApplicationShareInsight = {
 
 export type TenantApplicationReuseView = {
   metrics: ApplicationReuseMetric[];
+  packageCategories: SharePackageCategoryView[];
   reusableProfileItems: ApplicationReuseItem[];
   documentItems: ApplicationReuseItem[];
   missingItems: ApplicationReuseItem[];
@@ -191,8 +193,30 @@ export function buildTenantApplicationReuseView(params: {
     },
   ];
 
+  const packageCategories = buildTenantSharePackageCategories({
+    hasProfileBasics: Boolean(
+      params.profile?.profile.displayName && params.profile?.profile.email && params.profile?.profile.phone
+    ),
+    rentalHistoryDetail: params.profile
+      ? propertySummary(params.profile.profile)
+      : "Property details will appear here when they are linked to this application.",
+    hasRentalHistory: Boolean(
+      params.profile?.profile.property || params.profile?.profile.application || params.profile?.profile.lease
+    ),
+    readyDocumentCount: documentVault.readyItems.length,
+    missingDocumentCount: documentVault.missingItems.length,
+    identityStatusLabel:
+      params.profile?.identity?.identityVerification?.note ||
+      "Identity and consent status will appear here when they are available in your profile.",
+    identityVerified: params.profile?.identity?.identityVerification?.status === "verified",
+    activeGrantCount: params.access?.summary?.activeGrants || 0,
+    progressPercent: params.completion?.progressPercent ?? 0,
+    missingCount: missingItems.filter((item) => item.status !== "info").length,
+  });
+
   return {
     metrics,
+    packageCategories,
     reusableProfileItems,
     documentItems,
     missingItems,


### PR DESCRIPTION
## Summary

This PR aligns the tenant and landlord views around a single, shared package model.

Both `/tenant/application` and the landlord review-summary page now describe the same high-level package using consistent categories:
- Profile details
- Rental history
- Documents & records
- Consent / identity status
- Application readiness

## What changed

- Introduced a shared, pure helper to derive package categories and states
- Standardized category labels across tenant and landlord surfaces
- Aligned state language:
  - Tenant: Ready / Partly ready / Needs attention
  - Landlord: Available to review / Partly available / Missing
- Refined tenant application and landlord review-summary pages to use the shared model
- Kept document visibility intentionally high-level and permission-respecting

## Scope

- Frontend only
- No backend changes
- No schema changes
- No auth or permission expansion

## Files changed

- `rentchain-frontend/src/pages/sharePackageAlignment.ts`
- `rentchain-frontend/src/pages/sharePackageAlignment.test.ts`
- `rentchain-frontend/src/pages/tenant/tenantApplicationReuse.ts`
- `rentchain-frontend/src/pages/tenant/tenantApplicationReuse.test.ts`
- `rentchain-frontend/src/pages/tenant/TenantApplicationStatusPage.tsx`
- `rentchain-frontend/src/pages/tenant/TenantApplicationCompletionPage.test.tsx`
- `rentchain-frontend/src/pages/applicationReviewIntakeAlignment.ts`
- `rentchain-frontend/src/pages/applicationReviewIntakeAlignment.test.ts`
- `rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx`
- `rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx`

## Validation

```bash
cd rentchain-frontend
PATH="$HOME/.nvm/versions/node/v20.20.2/bin:$PATH" npm run test -- src/pages/sharePackageAlignment.test.ts src/pages/tenant/tenantApplicationReuse.test.ts src/pages/tenant/TenantApplicationCompletionPage.test.tsx src/pages/applicationReviewIntakeAlignment.test.ts src/pages/ApplicationReviewSummaryPage.test.tsx
PATH="$HOME/.nvm/versions/node/v20.20.2/bin:$PATH" npm run build