### PR TITLE
feat(landlord): add review workflow guidance v1

### DIFF
--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
@@ -121,6 +121,7 @@ describe("ApplicationReviewSummaryPage", () => {
 
     expect(await screen.findByText("Application Review Summary")).toBeInTheDocument();
     expect(await screen.findByText("Intake Summary")).toBeInTheDocument();
+    expect(await screen.findByText("Review workflow guidance")).toBeInTheDocument();
     expect(await screen.findByText("Shared package categories")).toBeInTheDocument();
     expect(screen.getAllByText("Profile details").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Rental history").length).toBeGreaterThan(0);
@@ -128,6 +129,8 @@ describe("ApplicationReviewSummaryPage", () => {
     expect(screen.getAllByText("Consent / identity status").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Application readiness").length).toBeGreaterThan(0);
     expect(await screen.findByText("Ready for review")).toBeInTheDocument();
+    expect(await screen.findByText("Next steps")).toBeInTheDocument();
+    expect(screen.getAllByText(/Review the categories already available now/i).length).toBeGreaterThan(0);
     expect(await screen.findByText("Shared with tenant permission and current server-authorized review access.")).toBeInTheDocument();
     expect(await screen.findByText("Jane Applicant")).toBeInTheDocument();
     expect(await screen.findByText("Landlord Decision Panel")).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
@@ -18,6 +18,7 @@ import {
 } from "../api/reviewSummaryApi";
 import { useToast } from "../components/ui/ToastProvider";
 import { buildLandlordIntakeAlignmentView } from "./applicationReviewIntakeAlignment";
+import { buildLandlordReviewGuidance } from "./landlordReviewGuidance";
 
 function money(cents: number | null): string {
   if (cents == null || !Number.isFinite(cents)) return "Not provided";
@@ -225,6 +226,10 @@ function ApplicationReviewSummaryPageBody() {
     () => (summary ? buildLandlordIntakeAlignmentView(summary) : null),
     [summary]
   );
+  const guidanceView = useMemo(
+    () => (intakeView ? buildLandlordReviewGuidance(intakeView) : null),
+    [intakeView]
+  );
 
   return (
     <div style={{ padding: 16, display: "grid", gap: 12 }}>
@@ -399,6 +404,69 @@ function ApplicationReviewSummaryPageBody() {
                   Shared with tenant permission and current server-authorized review access.
                 </div>
               </Card>
+            </Card>
+          ) : null}
+
+          {guidanceView ? (
+            <Card style={{ display: "grid", gap: 10 }}>
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+                <div>
+                  <div style={{ fontWeight: 700 }}>Review workflow guidance</div>
+                  <div style={{ fontSize: 13, color: text.subtle, marginTop: 4 }}>
+                    {guidanceView.explanation}
+                  </div>
+                </div>
+                <div
+                  style={{
+                    padding: "6px 10px",
+                    borderRadius: 999,
+                    fontWeight: 700,
+                    color:
+                      guidanceView.state === "ready_to_review"
+                        ? "#166534"
+                        : guidanceView.state === "partly_available"
+                        ? "#1d4ed8"
+                        : "#9a3412",
+                    background:
+                      guidanceView.state === "ready_to_review"
+                        ? "#dcfce7"
+                        : guidanceView.state === "partly_available"
+                        ? "#dbeafe"
+                        : "#ffedd5",
+                  }}
+                >
+                  {guidanceView.summary}
+                </div>
+              </div>
+
+              {guidanceView.missingCategories.length ? (
+                <div style={{ fontSize: 13, color: text.subtle }}>
+                  <strong style={{ color: text.main }}>Missing information:</strong>{" "}
+                  {guidanceView.missingCategories.join(", ")}
+                </div>
+              ) : (
+                <div style={{ fontSize: 13, color: text.subtle }}>
+                  <strong style={{ color: text.main }}>Available now:</strong> The aligned package categories are ready for review.
+                </div>
+              )}
+
+              <div style={{ display: "grid", gap: 8 }}>
+                <div style={{ fontWeight: 700 }}>Next steps</div>
+                {guidanceView.nextSteps.map((step) => (
+                  <div
+                    key={step}
+                    style={{
+                      border: `1px solid ${colors.border}`,
+                      borderRadius: 10,
+                      padding: 10,
+                      fontSize: 13,
+                      color: text.subtle,
+                    }}
+                  >
+                    {step}
+                  </div>
+                ))}
+              </div>
             </Card>
           ) : null}
 

--- a/rentchain-frontend/src/pages/landlordReviewGuidance.test.ts
+++ b/rentchain-frontend/src/pages/landlordReviewGuidance.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { buildLandlordReviewGuidance } from "./landlordReviewGuidance";
+import type { LandlordIntakeAlignmentView } from "./applicationReviewIntakeAlignment";
+
+function buildIntake(
+  overrides?: Partial<LandlordIntakeAlignmentView>
+): LandlordIntakeAlignmentView {
+  return {
+    state: "ready_for_review",
+    headline: "Ready for review",
+    detail: "Summary",
+    metrics: [],
+    packageCategories: [
+      { key: "profile_details", label: "Profile details", status: "ready", detail: "Available" },
+      { key: "rental_history", label: "Rental history", status: "ready", detail: "Available" },
+      { key: "documents_records", label: "Documents & records", status: "ready", detail: "Available" },
+      { key: "consent_identity_status", label: "Consent / identity status", status: "ready", detail: "Available" },
+      { key: "application_readiness", label: "Application readiness", status: "ready", detail: "Available" },
+    ],
+    missingItems: [],
+    ...overrides,
+  };
+}
+
+describe("buildLandlordReviewGuidance", () => {
+  it("returns ready to review when no package categories are missing", () => {
+    const result = buildLandlordReviewGuidance(buildIntake());
+
+    expect(result.state).toBe("ready_to_review");
+    expect(result.summary).toBe("Ready to review");
+    expect(result.missingCategories).toEqual([]);
+    expect(result.nextSteps[0]).toMatch(/Review the categories already available now/i);
+  });
+
+  it("returns partly available when some categories are missing but some are still available", () => {
+    const result = buildLandlordReviewGuidance(
+      buildIntake({
+        packageCategories: [
+          { key: "profile_details", label: "Profile details", status: "ready", detail: "Available" },
+          { key: "rental_history", label: "Rental history", status: "missing", detail: "Missing" },
+          { key: "documents_records", label: "Documents & records", status: "partial", detail: "Partial" },
+          { key: "consent_identity_status", label: "Consent / identity status", status: "missing", detail: "Missing" },
+          { key: "application_readiness", label: "Application readiness", status: "partial", detail: "Partial" },
+        ],
+      })
+    );
+
+    expect(result.state).toBe("partly_available");
+    expect(result.missingCategories).toEqual(["Rental history", "Consent / identity status"]);
+    expect(result.nextSteps.some((step) => /Follow up on missing information/i.test(step))).toBe(true);
+  });
+
+  it("returns needs follow-up when nothing is available to review", () => {
+    const result = buildLandlordReviewGuidance(
+      buildIntake({
+        packageCategories: [
+          { key: "profile_details", label: "Profile details", status: "missing", detail: "Missing" },
+          { key: "rental_history", label: "Rental history", status: "missing", detail: "Missing" },
+          { key: "documents_records", label: "Documents & records", status: "missing", detail: "Missing" },
+          { key: "consent_identity_status", label: "Consent / identity status", status: "missing", detail: "Missing" },
+          { key: "application_readiness", label: "Application readiness", status: "missing", detail: "Missing" },
+        ],
+      })
+    );
+
+    expect(result.state).toBe("needs_follow_up");
+    expect(result.summary).toBe("Needs follow-up");
+    expect(result.nextSteps[0]).toMatch(/Follow up on missing information/i);
+  });
+});

--- a/rentchain-frontend/src/pages/landlordReviewGuidance.ts
+++ b/rentchain-frontend/src/pages/landlordReviewGuidance.ts
@@ -1,0 +1,78 @@
+import type { LandlordIntakeAlignmentView } from "./applicationReviewIntakeAlignment";
+
+export type LandlordReviewGuidanceState =
+  | "ready_to_review"
+  | "partly_available"
+  | "needs_follow_up";
+
+export type LandlordReviewGuidanceView = {
+  state: LandlordReviewGuidanceState;
+  summary: string;
+  explanation: string;
+  nextSteps: string[];
+  missingCategories: string[];
+};
+
+export function buildLandlordReviewGuidance(
+  intake: LandlordIntakeAlignmentView
+): LandlordReviewGuidanceView {
+  const readyCount = intake.packageCategories.filter((item) => item.status === "ready").length;
+  const partialCount = intake.packageCategories.filter((item) => item.status === "partial").length;
+  const missingCategories = intake.packageCategories
+    .filter((item) => item.status === "missing")
+    .map((item) => item.label);
+
+  let state: LandlordReviewGuidanceState = "ready_to_review";
+  if (missingCategories.length > 0) {
+    state = readyCount > 0 || partialCount > 0 ? "partly_available" : "needs_follow_up";
+  } else if (partialCount > 0) {
+    state = "partly_available";
+  }
+
+  const nextSteps: string[] = [];
+  if (readyCount > 0) {
+    nextSteps.push("Review the categories already available now before following up on anything else.");
+  }
+  if (missingCategories.length > 0) {
+    nextSteps.push(
+      `Follow up on missing information in ${missingCategories.join(", ")} before final review.`
+    );
+  }
+  if (partialCount > 0) {
+    nextSteps.push("Confirm the partly available sections so the review record stays complete and consistent.");
+  }
+  if (nextSteps.length === 0) {
+    nextSteps.push("Review the available package sections and document your final decision in the summary.");
+  }
+
+  if (state === "ready_to_review") {
+    return {
+      state,
+      summary: "Ready to review",
+      explanation:
+        "The current package is organized enough to review now, and no major category gaps are surfaced from the authorized summary.",
+      nextSteps,
+      missingCategories,
+    };
+  }
+
+  if (state === "partly_available") {
+    return {
+      state,
+      summary: "Partly available",
+      explanation:
+        "Some sections are available to review now, but a few package categories still need follow-up before the file feels complete.",
+      nextSteps,
+      missingCategories,
+    };
+  }
+
+  return {
+    state,
+    summary: "Needs follow-up",
+    explanation:
+      "The current package is still missing too many categories for a confident review, so follow-up is the next step.",
+    nextSteps,
+    missingCategories,
+  };
+}


### PR DESCRIPTION
## Summary

This PR adds a landlord-side review workflow guidance layer to the existing application review-summary page.

The page now classifies the current tenant package into:
- Ready to review
- Partly available
- Needs follow-up

and provides clear, non-judgmental next steps based only on currently visible, tenant-shared data.

## What changed

- Added a deterministic guidance helper:
  - `landlordReviewGuidance.ts`
- Introduced a guidance card on the review-summary page showing:
  - current review state
  - explanation of that state
  - next-step recommendations
  - missing categories
- Kept guidance grounded in existing aligned package categories
- Avoided scoring, automation, or unsupported workflow behavior

## Scope

- Frontend only
- No backend changes
- No schema changes
- No auth or permission expansion

## Files changed

- `rentchain-frontend/src/pages/landlordReviewGuidance.ts`
- `rentchain-frontend/src/pages/landlordReviewGuidance.test.ts`
- `rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx`
- `rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx`

## Validation

```bash
cd rentchain-frontend
PATH="$HOME/.nvm/versions/node/v20.20.2/bin:$PATH" npm run test -- src/pages/landlordReviewGuidance.test.ts src/pages/ApplicationReviewSummaryPage.test.tsx
PATH="$HOME/.nvm/versions/node/v20.20.2/bin:$PATH" npm run build