### PR TITLE
feat(shared): add tenant-landlord interaction loop v1

### DIFF
--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
@@ -130,7 +130,13 @@ describe("ApplicationReviewSummaryPage", () => {
     expect(screen.getAllByText("Application readiness").length).toBeGreaterThan(0);
     expect(await screen.findByText("Ready for review")).toBeInTheDocument();
     expect(await screen.findByText("Next steps")).toBeInTheDocument();
+    expect(await screen.findByText("Structured follow-up loop")).toBeInTheDocument();
     expect(screen.getAllByText(/Review the categories already available now/i).length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText((_, element) => element?.textContent?.includes("Follow-up categories:") ?? false).length
+    ).toBeGreaterThan(0);
+    expect(screen.getAllByText("Rental history").length).toBeGreaterThan(0);
+    expect(await screen.findByText(/Follow up is organized by aligned package categories/i)).toBeInTheDocument();
     expect(await screen.findByText("Shared with tenant permission and current server-authorized review access.")).toBeInTheDocument();
     expect(await screen.findByText("Jane Applicant")).toBeInTheDocument();
     expect(await screen.findByText("Landlord Decision Panel")).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
@@ -19,6 +19,7 @@ import {
 import { useToast } from "../components/ui/ToastProvider";
 import { buildLandlordIntakeAlignmentView } from "./applicationReviewIntakeAlignment";
 import { buildLandlordReviewGuidance } from "./landlordReviewGuidance";
+import { buildTenantLandlordInteractionLoop } from "./tenantLandlordInteractionLoop";
 
 function money(cents: number | null): string {
   if (cents == null || !Number.isFinite(cents)) return "Not provided";
@@ -230,6 +231,16 @@ function ApplicationReviewSummaryPageBody() {
     () => (intakeView ? buildLandlordReviewGuidance(intakeView) : null),
     [intakeView]
   );
+  const interactionLoop = useMemo(
+    () =>
+      intakeView
+        ? buildTenantLandlordInteractionLoop({
+            audience: "landlord",
+            packageCategories: intakeView.packageCategories,
+          })
+        : null,
+    [intakeView]
+  );
 
   return (
     <div style={{ padding: 16, display: "grid", gap: 12 }}>
@@ -407,7 +418,7 @@ function ApplicationReviewSummaryPageBody() {
             </Card>
           ) : null}
 
-          {guidanceView ? (
+          {guidanceView && interactionLoop ? (
             <Card style={{ display: "grid", gap: 10 }}>
               <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
                 <div>
@@ -439,20 +450,35 @@ function ApplicationReviewSummaryPageBody() {
                 </div>
               </div>
 
-              {guidanceView.missingCategories.length ? (
+              {interactionLoop.followUpCategories.length ? (
                 <div style={{ fontSize: 13, color: text.subtle }}>
-                  <strong style={{ color: text.main }}>Missing information:</strong>{" "}
-                  {guidanceView.missingCategories.join(", ")}
+                  <strong style={{ color: text.main }}>Follow-up categories:</strong>{" "}
+                  {interactionLoop.followUpCategories.join(", ")}
                 </div>
               ) : (
                 <div style={{ fontSize: 13, color: text.subtle }}>
-                  <strong style={{ color: text.main }}>Available now:</strong> The aligned package categories are ready for review.
+                  <strong style={{ color: text.main }}>Available now:</strong>{" "}
+                  {interactionLoop.readyCategories.join(", ")}
                 </div>
               )}
 
               <div style={{ display: "grid", gap: 8 }}>
+                <div style={{ fontWeight: 700 }}>Structured follow-up loop</div>
+                <div style={{ fontSize: 13, color: text.subtle }}>{interactionLoop.detail}</div>
+                {interactionLoop.followUpCategories.length ? (
+                  <div style={{ fontSize: 13, color: text.subtle }}>
+                    Follow up is organized by aligned package categories so the tenant can work back through the same areas in their readiness flow.
+                  </div>
+                ) : (
+                  <div style={{ fontSize: 13, color: text.subtle }}>
+                    No follow-up categories are surfaced right now, so this package is ready for landlord review as-is.
+                  </div>
+                )}
+              </div>
+
+              <div style={{ display: "grid", gap: 8 }}>
                 <div style={{ fontWeight: 700 }}>Next steps</div>
-                {guidanceView.nextSteps.map((step) => (
+                {interactionLoop.nextSteps.map((step) => (
                   <div
                     key={step}
                     style={{

--- a/rentchain-frontend/src/pages/landlordReviewGuidance.test.ts
+++ b/rentchain-frontend/src/pages/landlordReviewGuidance.test.ts
@@ -32,22 +32,28 @@ describe("buildLandlordReviewGuidance", () => {
     expect(result.nextSteps[0]).toMatch(/Review the categories already available now/i);
   });
 
-  it("returns partly available when some categories are missing but some are still available", () => {
+  it("returns partly available when the package only has partial categories left", () => {
     const result = buildLandlordReviewGuidance(
       buildIntake({
         packageCategories: [
           { key: "profile_details", label: "Profile details", status: "ready", detail: "Available" },
-          { key: "rental_history", label: "Rental history", status: "missing", detail: "Missing" },
+          { key: "rental_history", label: "Rental history", status: "partial", detail: "Partial" },
           { key: "documents_records", label: "Documents & records", status: "partial", detail: "Partial" },
-          { key: "consent_identity_status", label: "Consent / identity status", status: "missing", detail: "Missing" },
+          { key: "consent_identity_status", label: "Consent / identity status", status: "partial", detail: "Partial" },
           { key: "application_readiness", label: "Application readiness", status: "partial", detail: "Partial" },
         ],
       })
     );
 
     expect(result.state).toBe("partly_available");
-    expect(result.missingCategories).toEqual(["Rental history", "Consent / identity status"]);
-    expect(result.nextSteps.some((step) => /Follow up on missing information/i.test(step))).toBe(true);
+    expect(result.summary).toBe("Ready for re-review");
+    expect(result.missingCategories).toEqual([
+      "Rental history",
+      "Documents & records",
+      "Consent / identity status",
+      "Application readiness",
+    ]);
+    expect(result.nextSteps.some((step) => /Re-review the package/i.test(step))).toBe(true);
   });
 
   it("returns needs follow-up when nothing is available to review", () => {
@@ -64,7 +70,7 @@ describe("buildLandlordReviewGuidance", () => {
     );
 
     expect(result.state).toBe("needs_follow_up");
-    expect(result.summary).toBe("Needs follow-up");
-    expect(result.nextSteps[0]).toMatch(/Follow up on missing information/i);
+    expect(result.summary).toBe("Follow-up needed");
+    expect(result.nextSteps.some((step) => /Request follow-up/i.test(step))).toBe(true);
   });
 });

--- a/rentchain-frontend/src/pages/landlordReviewGuidance.ts
+++ b/rentchain-frontend/src/pages/landlordReviewGuidance.ts
@@ -1,4 +1,5 @@
 import type { LandlordIntakeAlignmentView } from "./applicationReviewIntakeAlignment";
+import { buildTenantLandlordInteractionLoop } from "./tenantLandlordInteractionLoop";
 
 export type LandlordReviewGuidanceState =
   | "ready_to_review"
@@ -16,63 +17,22 @@ export type LandlordReviewGuidanceView = {
 export function buildLandlordReviewGuidance(
   intake: LandlordIntakeAlignmentView
 ): LandlordReviewGuidanceView {
-  const readyCount = intake.packageCategories.filter((item) => item.status === "ready").length;
-  const partialCount = intake.packageCategories.filter((item) => item.status === "partial").length;
-  const missingCategories = intake.packageCategories
-    .filter((item) => item.status === "missing")
-    .map((item) => item.label);
-
-  let state: LandlordReviewGuidanceState = "ready_to_review";
-  if (missingCategories.length > 0) {
-    state = readyCount > 0 || partialCount > 0 ? "partly_available" : "needs_follow_up";
-  } else if (partialCount > 0) {
-    state = "partly_available";
-  }
-
-  const nextSteps: string[] = [];
-  if (readyCount > 0) {
-    nextSteps.push("Review the categories already available now before following up on anything else.");
-  }
-  if (missingCategories.length > 0) {
-    nextSteps.push(
-      `Follow up on missing information in ${missingCategories.join(", ")} before final review.`
-    );
-  }
-  if (partialCount > 0) {
-    nextSteps.push("Confirm the partly available sections so the review record stays complete and consistent.");
-  }
-  if (nextSteps.length === 0) {
-    nextSteps.push("Review the available package sections and document your final decision in the summary.");
-  }
-
-  if (state === "ready_to_review") {
-    return {
-      state,
-      summary: "Ready to review",
-      explanation:
-        "The current package is organized enough to review now, and no major category gaps are surfaced from the authorized summary.",
-      nextSteps,
-      missingCategories,
-    };
-  }
-
-  if (state === "partly_available") {
-    return {
-      state,
-      summary: "Partly available",
-      explanation:
-        "Some sections are available to review now, but a few package categories still need follow-up before the file feels complete.",
-      nextSteps,
-      missingCategories,
-    };
-  }
+  const loop = buildTenantLandlordInteractionLoop({
+    audience: "landlord",
+    packageCategories: intake.packageCategories,
+  });
+  const state: LandlordReviewGuidanceState =
+    loop.state === "ready_for_review"
+      ? "ready_to_review"
+      : loop.state === "ready_for_rereview"
+      ? "partly_available"
+      : "needs_follow_up";
 
   return {
     state,
-    summary: "Needs follow-up",
-    explanation:
-      "The current package is still missing too many categories for a confident review, so follow-up is the next step.",
-    nextSteps,
-    missingCategories,
+    summary: loop.headline,
+    explanation: loop.detail,
+    nextSteps: loop.nextSteps,
+    missingCategories: loop.followUpCategories,
   };
 }

--- a/rentchain-frontend/src/pages/tenant/TenantApplicationCompletionPage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantApplicationCompletionPage.test.tsx
@@ -182,13 +182,16 @@ describe("tenant application completion page", () => {
     expect(screen.getAllByText(/Documents & records/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Consent \/ identity status/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Application readiness/i).length).toBeGreaterThan(0);
-    expect(screen.getByText(/Review Package Guidance/i)).toBeInTheDocument();
+    expect(screen.getByText(/Structured Follow-up/i)).toBeInTheDocument();
+    expect(screen.getByText(/Needs attention:/i)).toBeInTheDocument();
+    expect(screen.getByText(/Go next/i)).toBeInTheDocument();
     expect(screen.getAllByText(/Review Before Sharing/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Identity verification/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Upload income documents/i).length).toBeGreaterThan(0);
     expect(screen.getAllByRole("link", { name: /Review your profile/i }).length).toBeGreaterThan(0);
     expect(screen.getAllByRole("link", { name: /Open documents/i }).length).toBeGreaterThan(0);
     expect(screen.getAllByRole("link", { name: /Review access/i }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("link", { name: /Review your application/i }).length).toBeGreaterThan(0);
   });
 
   it("renders empty state safely", async () => {

--- a/rentchain-frontend/src/pages/tenant/TenantApplicationStatusPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantApplicationStatusPage.tsx
@@ -21,6 +21,7 @@ import {
 import { spacing, text as textTokens } from "../../styles/tokens";
 import { buildTenantApplicationReuseView } from "./tenantApplicationReuse";
 import { buildTenantApplicationFlow } from "./tenantApplicationFlow";
+import { buildTenantLandlordInteractionLoop } from "../tenantLandlordInteractionLoop";
 
 function statusTone(status: TenantApplicationCompletionStatus) {
   switch (status) {
@@ -226,6 +227,10 @@ export default function TenantApplicationStatusPage() {
     completion: data,
     reuse,
   });
+  const interactionLoop = buildTenantLandlordInteractionLoop({
+    audience: "tenant",
+    packageCategories: reuse.packageCategories,
+  });
   const flowTone =
     flow.state === "ready_to_proceed"
       ? { color: "#166534", background: "#dcfce7", label: "Ready to proceed" }
@@ -235,6 +240,12 @@ export default function TenantApplicationStatusPage() {
       ? { color: "#9a3412", background: "#ffedd5", label: "Needs attention" }
       : { color: "#0f766e", background: "#ccfbf1", label: "Readiness" };
   const entryLabel = flow.entry === "invite" ? "Invite entry" : flow.entry === "application" ? "Application link" : "Direct tenant navigation";
+  const interactionTone =
+    interactionLoop.state === "ready_for_review"
+      ? { color: "#166534", background: "#dcfce7", label: "Ready to continue" }
+      : interactionLoop.state === "ready_for_rereview"
+      ? { color: "#1d4ed8", background: "#dbeafe", label: "Ready for re-review" }
+      : { color: "#9a3412", background: "#ffedd5", label: "Follow-up requested" };
 
   return (
     <TenantSurfaceShell
@@ -465,18 +476,71 @@ export default function TenantApplicationStatusPage() {
           </div>
         </TenantInfoCard>
 
-        <TenantInfoCard heading="Review Package Guidance" accent="#166534">
+        <TenantInfoCard heading="Structured Follow-up" accent="#166534">
           <div style={{ display: "grid", gap: spacing.sm }}>
-            {[...reuse.reusableProfileItems, ...reuse.documentItems].map((item) => {
-              const tone =
-                item.status === "ready"
-                  ? { color: "#166534", background: "#dcfce7", label: "Ready" }
-                  : item.status === "info"
-                  ? { color: "#1d4ed8", background: "#dbeafe", label: "In review" }
-                  : { color: "#9a3412", background: "#ffedd5", label: "Needs attention" };
-              return (
+            <div
+              style={{
+                border: "1px solid rgba(15,23,42,0.08)",
+                borderRadius: 12,
+                padding: "12px 14px",
+                display: "grid",
+                gap: 8,
+              }}
+            >
+              <div style={{ display: "flex", justifyContent: "space-between", gap: 8, flexWrap: "wrap" }}>
+                <div>
+                  <div style={{ fontWeight: 700, color: textTokens.primary }}>{interactionLoop.headline}</div>
+                  <div style={{ color: textTokens.secondary }}>{interactionLoop.detail}</div>
+                </div>
                 <div
-                  key={item.label}
+                  style={{
+                    padding: "4px 8px",
+                    borderRadius: 999,
+                    fontSize: 12,
+                    fontWeight: 700,
+                    color: interactionTone.color,
+                    background: interactionTone.background,
+                  }}
+                >
+                  {interactionTone.label}
+                </div>
+              </div>
+
+              {interactionLoop.followUpCategories.length ? (
+                <div style={{ color: textTokens.secondary }}>
+                  <strong style={{ color: textTokens.primary }}>Needs attention:</strong>{" "}
+                  {interactionLoop.followUpCategories.join(", ")}
+                </div>
+              ) : (
+                <div style={{ color: textTokens.secondary }}>
+                  <strong style={{ color: textTokens.primary }}>Ready now:</strong>{" "}
+                  {interactionLoop.readyCategories.join(", ")}
+                </div>
+              )}
+            </div>
+
+            <div style={{ display: "grid", gap: 8 }}>
+              <div style={{ fontWeight: 700, color: textTokens.primary }}>Next steps</div>
+              {interactionLoop.nextSteps.map((step) => (
+                <div
+                  key={step}
+                  style={{
+                    border: "1px solid rgba(15,23,42,0.08)",
+                    borderRadius: 12,
+                    padding: "12px 14px",
+                    color: textTokens.secondary,
+                  }}
+                >
+                  {step}
+                </div>
+              ))}
+            </div>
+
+            <div style={{ display: "grid", gap: 8 }}>
+              <div style={{ fontWeight: 700, color: textTokens.primary }}>Go next</div>
+              {interactionLoop.actions.map((action) => (
+                <div
+                  key={action.path}
                   style={{
                     border: "1px solid rgba(15,23,42,0.08)",
                     borderRadius: 12,
@@ -485,30 +549,17 @@ export default function TenantApplicationStatusPage() {
                     gap: 8,
                   }}
                 >
-                  <div style={{ display: "flex", justifyContent: "space-between", gap: 8, flexWrap: "wrap" }}>
-                    <div style={{ fontWeight: 700, color: textTokens.primary }}>{item.label}</div>
-                    <div
-                      style={{
-                        padding: "4px 8px",
-                        borderRadius: 999,
-                        fontSize: 12,
-                        fontWeight: 700,
-                        color: tone.color,
-                        background: tone.background,
-                      }}
-                    >
-                      {tone.label}
-                    </div>
+                  <div style={{ fontWeight: 700, color: textTokens.primary }}>{action.label}</div>
+                  <div style={{ color: textTokens.secondary }}>{action.detail}</div>
+                  <div style={{ color: textTokens.secondary, fontSize: 12 }}>
+                    Covers: {action.categories.join(", ")}
                   </div>
-                  <div style={{ color: textTokens.secondary }}>{item.detail}</div>
-                  {item.actionPath ? (
-                    <Link to={item.actionPath} style={{ fontWeight: 700 }}>
-                      {item.actionLabel || "Open documents"}
-                    </Link>
-                  ) : null}
+                  <Link to={action.path} style={{ fontWeight: 700 }}>
+                    {action.label}
+                  </Link>
                 </div>
-              );
-            })}
+              ))}
+            </div>
           </div>
         </TenantInfoCard>
       </div>

--- a/rentchain-frontend/src/pages/tenantLandlordInteractionLoop.test.ts
+++ b/rentchain-frontend/src/pages/tenantLandlordInteractionLoop.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { buildTenantLandlordInteractionLoop } from "./tenantLandlordInteractionLoop";
+import type { SharePackageCategoryView } from "./sharePackageAlignment";
+
+function categories(
+  statuses: Array<SharePackageCategoryView["status"]>
+): SharePackageCategoryView[] {
+  return [
+    {
+      key: "profile_details",
+      label: "Profile details",
+      status: statuses[0],
+      detail: "Profile details",
+    },
+    {
+      key: "rental_history",
+      label: "Rental history",
+      status: statuses[1],
+      detail: "Rental history",
+    },
+    {
+      key: "documents_records",
+      label: "Documents & records",
+      status: statuses[2],
+      detail: "Documents & records",
+    },
+    {
+      key: "consent_identity_status",
+      label: "Consent / identity status",
+      status: statuses[3],
+      detail: "Consent / identity status",
+    },
+    {
+      key: "application_readiness",
+      label: "Application readiness",
+      status: statuses[4],
+      detail: "Application readiness",
+    },
+  ];
+}
+
+describe("buildTenantLandlordInteractionLoop", () => {
+  it("returns ready for review when every category is ready", () => {
+    const result = buildTenantLandlordInteractionLoop({
+      audience: "landlord",
+      packageCategories: categories(["ready", "ready", "ready", "ready", "ready"]),
+    });
+
+    expect(result.state).toBe("ready_for_review");
+    expect(result.followUpCategories).toEqual([]);
+    expect(result.readyCategories).toHaveLength(5);
+    expect(result.nextSteps[0]).toMatch(/Review the categories already available now/i);
+  });
+
+  it("returns ready for rereview when the package only has partial categories left", () => {
+    const result = buildTenantLandlordInteractionLoop({
+      audience: "tenant",
+      packageCategories: categories(["ready", "partial", "ready", "partial", "partial"]),
+    });
+
+    expect(result.state).toBe("ready_for_rereview");
+    expect(result.followUpCategories).toEqual([
+      "Rental history",
+      "Consent / identity status",
+      "Application readiness",
+    ]);
+    expect(result.actions.map((item) => item.path)).toEqual([
+      "/tenant/profile",
+      "/tenant/access",
+      "/tenant/application",
+    ]);
+  });
+
+  it("returns follow up needed when any categories are missing", () => {
+    const result = buildTenantLandlordInteractionLoop({
+      audience: "tenant",
+      packageCategories: categories(["missing", "ready", "missing", "partial", "partial"]),
+    });
+
+    expect(result.state).toBe("follow_up_needed");
+    expect(result.followUpCategories).toEqual([
+      "Profile details",
+      "Documents & records",
+      "Consent / identity status",
+      "Application readiness",
+    ]);
+    expect(result.nextSteps[0]).toMatch(/Work through/i);
+  });
+});

--- a/rentchain-frontend/src/pages/tenantLandlordInteractionLoop.ts
+++ b/rentchain-frontend/src/pages/tenantLandlordInteractionLoop.ts
@@ -1,0 +1,172 @@
+import type { SharePackageCategoryKey, SharePackageCategoryView } from "./sharePackageAlignment";
+
+export type TenantLandlordInteractionLoopState =
+  | "ready_for_review"
+  | "follow_up_needed"
+  | "ready_for_rereview";
+
+export type TenantLandlordInteractionLoopAudience = "tenant" | "landlord";
+
+export type TenantLandlordInteractionLoopAction = {
+  label: string;
+  path: string;
+  detail: string;
+  categories: string[];
+};
+
+export type TenantLandlordInteractionLoopView = {
+  state: TenantLandlordInteractionLoopState;
+  headline: string;
+  detail: string;
+  followUpCategories: string[];
+  readyCategories: string[];
+  nextSteps: string[];
+  actions: TenantLandlordInteractionLoopAction[];
+};
+
+const CATEGORY_ACTIONS: Record<
+  SharePackageCategoryKey,
+  { label: string; path: string; detail: string }
+> = {
+  profile_details: {
+    label: "Update your profile",
+    path: "/tenant/profile",
+    detail: "Review your saved profile details and fill in anything still missing.",
+  },
+  rental_history: {
+    label: "Update your profile",
+    path: "/tenant/profile",
+    detail: "Review your rental history details so the shared package stays consistent.",
+  },
+  documents_records: {
+    label: "Add missing documents",
+    path: "/tenant/attachments",
+    detail: "Add or organize the documents and records that still need attention.",
+  },
+  consent_identity_status: {
+    label: "Review access",
+    path: "/tenant/access",
+    detail: "Check your access and identity-related status before the next review.",
+  },
+  application_readiness: {
+    label: "Review your application",
+    path: "/tenant/application",
+    detail: "Return to your application readiness view and confirm the package is ready to continue.",
+  },
+};
+
+function buildHeadline(
+  audience: TenantLandlordInteractionLoopAudience,
+  state: TenantLandlordInteractionLoopState
+): string {
+  if (audience === "landlord") {
+    if (state === "ready_for_review") return "Ready to review";
+    if (state === "ready_for_rereview") return "Ready for re-review";
+    return "Follow-up needed";
+  }
+
+  if (state === "ready_for_review") return "Ready to continue";
+  if (state === "ready_for_rereview") return "Ready for re-review";
+  return "Follow-up requested";
+}
+
+function buildDetail(
+  audience: TenantLandlordInteractionLoopAudience,
+  state: TenantLandlordInteractionLoopState,
+  followUpCategories: string[]
+): string {
+  if (audience === "landlord") {
+    if (state === "ready_for_review") {
+      return "The aligned package categories are organized enough to review now using the information currently available.";
+    }
+    if (state === "ready_for_rereview") {
+      return "Most package categories are in place, with only a few partly available sections left to confirm before final review.";
+    }
+    return `Follow-up is still needed in ${followUpCategories.join(", ")} before this package feels complete.`;
+  }
+
+  if (state === "ready_for_review") {
+    return "Your current package categories look organized enough to continue with review from your saved profile.";
+  }
+  if (state === "ready_for_rereview") {
+    return "You have enough in place to return for re-review, with only a few sections still needing a final pass.";
+  }
+  return `A few package categories still need attention before this application feels ready to share again: ${followUpCategories.join(", ")}.`;
+}
+
+export function buildTenantLandlordInteractionLoop(params: {
+  audience: TenantLandlordInteractionLoopAudience;
+  packageCategories: SharePackageCategoryView[];
+}): TenantLandlordInteractionLoopView {
+  const followUpItems = params.packageCategories.filter((item) => item.status !== "ready");
+  const missingItems = followUpItems.filter((item) => item.status === "missing");
+  const readyCategories = params.packageCategories
+    .filter((item) => item.status === "ready")
+    .map((item) => item.label);
+  const followUpCategories = followUpItems.map((item) => item.label);
+
+  let state: TenantLandlordInteractionLoopState = "ready_for_review";
+  if (followUpItems.length > 0) {
+    state = missingItems.length > 0 ? "follow_up_needed" : "ready_for_rereview";
+  }
+
+  const nextSteps: string[] = [];
+  if (params.audience === "landlord") {
+    if (readyCategories.length > 0) {
+      nextSteps.push("Review the categories already available now so the current package can move forward without guesswork.");
+    }
+    if (followUpCategories.length > 0) {
+      nextSteps.push(`Request follow-up in ${followUpCategories.join(", ")} using the aligned package categories.`);
+      nextSteps.push("Re-review the package after those categories are updated in the tenant workflow.");
+    }
+    if (nextSteps.length === 0) {
+      nextSteps.push("Review the available package and capture your decision in the summary when you are ready.");
+    }
+  } else {
+    if (followUpCategories.length > 0) {
+      nextSteps.push(`Work through ${followUpCategories.join(", ")} next so your package is easier to re-review.`);
+    }
+    if (readyCategories.length > 0) {
+      nextSteps.push("Keep the categories that are already ready as they are while you update the remaining sections.");
+    }
+    if (nextSteps.length === 0) {
+      nextSteps.push("Continue with your application and review what is already ready to share.");
+    }
+  }
+
+  const actionsMap = new Map<string, TenantLandlordInteractionLoopAction>();
+  if (params.audience === "tenant") {
+    followUpItems.forEach((item) => {
+      const config = CATEGORY_ACTIONS[item.key];
+      const existing = actionsMap.get(config.path);
+      if (existing) {
+        existing.categories.push(item.label);
+        return;
+      }
+      actionsMap.set(config.path, {
+        label: config.label,
+        path: config.path,
+        detail: config.detail,
+        categories: [item.label],
+      });
+    });
+    if (!actionsMap.has("/tenant/application")) {
+      actionsMap.set("/tenant/application", {
+        label: "Review your application",
+        path: "/tenant/application",
+        detail: "Return to your application readiness view before continuing.",
+        categories: ["Application readiness"],
+      });
+    }
+  }
+
+  return {
+    state,
+    headline: buildHeadline(params.audience, state),
+    detail: buildDetail(params.audience, state, followUpCategories),
+    followUpCategories,
+    readyCategories,
+    nextSteps,
+    actions: Array.from(actionsMap.values()),
+  };
+}


### PR DESCRIPTION
## Summary
Adds a structured, read-first tenant ↔ landlord follow-up loop using the existing aligned share-package categories.

## What changed
- added a shared interaction-loop helper to classify package state as `ready_for_review`, `follow_up_needed`, or `ready_for_rereview`
- refined the landlord review-summary page with clearer structured follow-up guidance and next steps
- refined the tenant application readiness page with matching follow-up visibility and direct remediation links to profile, documents, access, and application
- added targeted tests for the shared helper and both touched page surfaces

## Scope / safety
- frontend-only
- no backend or schema changes
- no permission expansion
- no notifications, messaging overhaul, or scoring logic

## Verification
- targeted Vitest suite for the new helper plus landlord and tenant pages
- frontend production build passed