### PR TITLE
feat(shared): add structured notifications timeline v1

### DIFF
--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
@@ -122,12 +122,14 @@ describe("ApplicationReviewSummaryPage", () => {
     expect(await screen.findByText("Application Review Summary")).toBeInTheDocument();
     expect(await screen.findByText("Intake Summary")).toBeInTheDocument();
     expect(await screen.findByText("Shared package categories")).toBeInTheDocument();
+    expect(await screen.findByText("Recent activity")).toBeInTheDocument();
     expect(screen.getAllByText("Profile details").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Rental history").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Documents & records").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Consent / identity status").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Application readiness").length).toBeGreaterThan(0);
-    expect(await screen.findByText("Ready for review")).toBeInTheDocument();
+    expect((await screen.findAllByText("Ready for review")).length).toBeGreaterThan(0);
+    expect(await screen.findByText("Application readiness updated")).toBeInTheDocument();
     expect(await screen.findByText("Shared with tenant permission and current server-authorized review access.")).toBeInTheDocument();
     expect(await screen.findByText("Jane Applicant")).toBeInTheDocument();
     expect(await screen.findByText("Landlord Decision Panel")).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
@@ -18,6 +18,7 @@ import {
 } from "../api/reviewSummaryApi";
 import { useToast } from "../components/ui/ToastProvider";
 import { buildLandlordIntakeAlignmentView } from "./applicationReviewIntakeAlignment";
+import { buildLandlordStructuredActivityTimeline } from "./structuredActivityTimeline";
 
 function money(cents: number | null): string {
   if (cents == null || !Number.isFinite(cents)) return "Not provided";
@@ -225,6 +226,10 @@ function ApplicationReviewSummaryPageBody() {
     () => (summary ? buildLandlordIntakeAlignmentView(summary) : null),
     [summary]
   );
+  const recentActivity = useMemo(
+    () => (summary ? buildLandlordStructuredActivityTimeline(summary).slice(0, 4) : []),
+    [summary]
+  );
 
   return (
     <div style={{ padding: 16, display: "grid", gap: 12 }}>
@@ -398,6 +403,51 @@ function ApplicationReviewSummaryPageBody() {
                 <div style={{ fontSize: 12, color: text.subtle }}>
                   Shared with tenant permission and current server-authorized review access.
                 </div>
+              </Card>
+
+              <Card style={{ display: "grid", gap: 8 }}>
+                <div style={{ fontWeight: 700 }}>Recent activity</div>
+                <div style={{ fontSize: 12, color: text.subtle }}>
+                  Recent review-state updates are shown here using the same authorized summary and current package state.
+                </div>
+                {recentActivity.length ? (
+                  recentActivity.map((item) => (
+                    <div
+                      key={item.id}
+                      style={{
+                        border: `1px solid ${colors.border}`,
+                        borderRadius: 10,
+                        padding: 10,
+                        display: "grid",
+                        gap: 6,
+                      }}
+                    >
+                      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, flexWrap: "wrap" }}>
+                        <div style={{ fontWeight: 600, color: text.main }}>{item.title}</div>
+                        <div
+                          style={{
+                            padding: "4px 8px",
+                            borderRadius: 999,
+                            fontSize: 12,
+                            fontWeight: 700,
+                            color: item.actionRequired ? "#9a3412" : "#1d4ed8",
+                            background: item.actionRequired ? "#ffedd5" : "#dbeafe",
+                          }}
+                        >
+                          {item.actionRequired ? "Needs attention" : "Updated"}
+                        </div>
+                      </div>
+                      <div style={{ fontSize: 13, color: text.subtle }}>{item.description}</div>
+                      <div style={{ fontSize: 12, color: text.subtle }}>
+                        {(item.actorLabel ? `${item.actorLabel} • ` : "") + dateOr(item.occurredAt)}
+                      </div>
+                    </div>
+                  ))
+                ) : (
+                  <div style={{ fontSize: 13, color: text.subtle }}>
+                    No recent review activity is available from the current summary yet.
+                  </div>
+                )}
               </Card>
             </Card>
           ) : null}

--- a/rentchain-frontend/src/pages/structuredActivityTimeline.test.ts
+++ b/rentchain-frontend/src/pages/structuredActivityTimeline.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildLandlordStructuredActivityTimeline,
+  buildTenantStructuredActivityTimeline,
+} from "./structuredActivityTimeline";
+
+describe("structuredActivityTimeline", () => {
+  it("normalizes tenant notifications into ordered timeline items", () => {
+    const result = buildTenantStructuredActivityTimeline([
+      {
+        id: "application-1",
+        type: "application",
+        title: "Application status updated",
+        summary: "Current application status: submitted.",
+        createdAt: "2026-04-01T00:00:00.000Z",
+        status: "info",
+        relatedPath: "/tenant/application",
+      },
+      {
+        id: "identity-1",
+        type: "identity",
+        title: "Identity verification needs attention",
+        summary: "Verification is still in progress.",
+        createdAt: "2026-04-02T00:00:00.000Z",
+        status: "warning",
+        relatedPath: "/tenant/profile",
+      },
+    ]);
+
+    expect(result.map((item) => item.id)).toEqual(["identity-1", "application-1"]);
+    expect(result[0]).toMatchObject({
+      type: "identity_updated",
+      actionRequired: true,
+      actorLabel: "Tenant workspace",
+    });
+  });
+
+  it("builds a landlord timeline from current authorized review-summary state", () => {
+    const result = buildLandlordStructuredActivityTimeline({
+      applicationId: "app-1",
+      generatedAt: "2026-04-03T00:00:00.000Z",
+      applicant: {
+        name: "Jane Applicant",
+        email: "jane@example.com",
+        currentAddressLine: null,
+        city: null,
+        provinceState: null,
+        postalCode: null,
+        country: null,
+        timeAtCurrentAddressMonths: null,
+        currentRentAmountCents: null,
+      },
+      employment: {
+        employerName: null,
+        jobTitle: null,
+        incomeAmountCents: null,
+        incomeFrequency: null,
+        incomeMonthlyCents: null,
+        monthsAtJob: null,
+      },
+      reference: { name: null, phone: null },
+      compliance: {
+        applicationConsentAcceptedAt: null,
+        applicationConsentVersion: null,
+        signatureType: null,
+        signedAt: null,
+      },
+      screening: { status: "complete", provider: "transunion", referenceId: "TU-1" },
+      derived: { incomeToRentRatio: null, completeness: { score: 0.8, label: "High" }, flags: ["MISSING_CURRENT_RENT"] },
+      insights: [],
+      decisionSummary: {
+        applicationId: "app-1",
+        riskSnapshot: {
+          version: "risk-v1",
+          status: "completed",
+          score: 72,
+          grade: "B",
+          confidence: 0.84,
+          factors: [],
+          flags: [],
+          recommendations: [],
+          updatedAt: "2026-04-04T00:00:00.000Z",
+        },
+      },
+      risk: null,
+    } as any);
+
+    expect(result[0]).toMatchObject({
+      title: "Review state updated",
+      actionRequired: false,
+    });
+    expect(result.some((item) => item.title === "Review follow-up remains active" && item.actionRequired)).toBe(true);
+    expect(result.some((item) => item.title === "Follow-up requested")).toBe(true);
+    expect(result.some((item) => item.title === "Consent / identity status pending")).toBe(true);
+  });
+});

--- a/rentchain-frontend/src/pages/structuredActivityTimeline.ts
+++ b/rentchain-frontend/src/pages/structuredActivityTimeline.ts
@@ -1,0 +1,171 @@
+import type { ApplicationReviewSummary } from "../api/reviewSummaryApi";
+import type { TenantNotificationItem } from "../api/tenantNotifications";
+
+export type StructuredActivityTimelineItem = {
+  id: string;
+  type:
+    | "profile_updated"
+    | "documents_updated"
+    | "access_updated"
+    | "follow_up_requested"
+    | "ready_for_review"
+    | "ready_for_rereview"
+    | "application_updated"
+    | "review_updated"
+    | "message"
+    | "maintenance"
+    | "invite"
+    | "identity_updated"
+    | "system";
+  title: string;
+  description: string;
+  occurredAt: number;
+  actorLabel: string | null;
+  actionRequired: boolean;
+  relatedPath: string | null;
+};
+
+function toMillis(value: string | number | null | undefined): number | null {
+  if (value == null) return null;
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  const parsed = Date.parse(String(value));
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function normalizeTenantType(
+  item: TenantNotificationItem
+): StructuredActivityTimelineItem["type"] {
+  switch (item.type) {
+    case "application":
+      return "application_updated";
+    case "identity":
+      return "identity_updated";
+    case "document":
+      return "documents_updated";
+    case "lease":
+      return "review_updated";
+    case "maintenance":
+      return "maintenance";
+    case "message":
+      return "message";
+    case "invite":
+      return "invite";
+    default:
+      return "system";
+  }
+}
+
+export function buildTenantStructuredActivityTimeline(
+  items: TenantNotificationItem[]
+): StructuredActivityTimelineItem[] {
+  return [...items]
+    .map((item) => ({
+      id: item.id,
+      type: normalizeTenantType(item),
+      title: item.title,
+      description: item.summary,
+      occurredAt: toMillis(item.createdAt) || 0,
+      actorLabel:
+        item.type === "message"
+          ? "Landlord"
+          : item.type === "system"
+          ? "System"
+          : "Tenant workspace",
+      actionRequired: item.status === "warning",
+      relatedPath: item.relatedPath,
+    }))
+    .sort((left, right) => right.occurredAt - left.occurredAt);
+}
+
+function pushTimelineItem(
+  items: StructuredActivityTimelineItem[],
+  next: Omit<StructuredActivityTimelineItem, "occurredAt"> & { occurredAt: string | number | null | undefined }
+) {
+  const occurredAt = toMillis(next.occurredAt);
+  if (!occurredAt) return;
+  items.push({
+    ...next,
+    occurredAt,
+  });
+}
+
+export function buildLandlordStructuredActivityTimeline(
+  summary: ApplicationReviewSummary
+): StructuredActivityTimelineItem[] {
+  const items: StructuredActivityTimelineItem[] = [];
+  const missingCategories = summary.derived.flags.length;
+  const completeness = Math.round(summary.derived.completeness.score * 100);
+
+  pushTimelineItem(items, {
+    id: `review-summary-${summary.applicationId}`,
+    type: missingCategories > 0 ? "follow_up_requested" : "ready_for_review",
+    title: missingCategories > 0 ? "Follow-up requested" : "Ready for review",
+    description:
+      missingCategories > 0
+        ? `${missingCategories} category gap${missingCategories === 1 ? "" : "s"} still need attention in the current review summary.`
+        : `The current review summary is organized and ready to review at ${completeness}% completeness.`,
+    occurredAt: summary.generatedAt,
+    actorLabel: "Review summary",
+    actionRequired: missingCategories > 0,
+    relatedPath: null,
+  });
+
+  pushTimelineItem(items, {
+    id: `application-readiness-${summary.applicationId}`,
+    type: missingCategories > 0 ? "ready_for_rereview" : "application_updated",
+    title: "Application readiness updated",
+    description:
+      missingCategories > 0
+        ? `Application readiness is ${completeness}% complete and is waiting on follow-up before re-review.`
+        : `Application readiness is ${completeness}% complete with no current category gaps surfaced.`,
+    occurredAt: summary.generatedAt,
+    actorLabel: "Tenant package",
+    actionRequired: missingCategories > 0,
+    relatedPath: null,
+  });
+
+  pushTimelineItem(items, {
+    id: `consent-${summary.applicationId}`,
+    type: "review_updated",
+    title: summary.compliance.signedAt ? "Consent / identity status updated" : "Consent / identity status pending",
+    description: summary.compliance.signedAt
+      ? "Consent and signature records are available in the current review package."
+      : "Consent or signature records are still limited in the current review package.",
+    occurredAt: summary.compliance.signedAt || summary.generatedAt,
+    actorLabel: "Tenant package",
+    actionRequired: !summary.compliance.signedAt,
+    relatedPath: null,
+  });
+
+  if (summary.screening.status && summary.screening.status !== "not_run") {
+    pushTimelineItem(items, {
+      id: `screening-${summary.applicationId}`,
+      type: "review_updated",
+      title: "Review state updated",
+      description: summary.screening.provider
+        ? `Screening status is ${summary.screening.status} through ${summary.screening.provider}.`
+        : `Screening status is ${summary.screening.status}.`,
+      occurredAt: summary.decisionSummary?.riskSnapshot?.updatedAt || summary.generatedAt,
+      actorLabel: "Review summary",
+      actionRequired: false,
+      relatedPath: null,
+    });
+  }
+
+  if (summary.decisionSummary?.riskSnapshot?.updatedAt) {
+    pushTimelineItem(items, {
+      id: `risk-${summary.applicationId}`,
+      type: missingCategories > 0 ? "follow_up_requested" : "review_updated",
+      title: missingCategories > 0 ? "Review follow-up remains active" : "Review summary refreshed",
+      description: missingCategories > 0
+        ? "The latest review snapshot still shows categories that need follow-up."
+        : "The latest review snapshot reflects the current application package.",
+      occurredAt: summary.decisionSummary.riskSnapshot.updatedAt,
+      actorLabel: "Review summary",
+      actionRequired: missingCategories > 0,
+      relatedPath: null,
+    });
+  }
+
+  return items.sort((left, right) => right.occurredAt - left.occurredAt);
+}

--- a/rentchain-frontend/src/pages/tenant/TenantActivityPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantActivityPage.tsx
@@ -11,6 +11,7 @@ import {
   prettyStatus,
 } from "./TenantWorkspaceShared";
 import { spacing, text as textTokens } from "../../styles/tokens";
+import { buildTenantStructuredActivityTimeline } from "../structuredActivityTimeline";
 
 export default function TenantActivityPage() {
   const [items, setItems] = useState<TenantNotificationItem[]>([]);
@@ -60,19 +61,37 @@ export default function TenantActivityPage() {
     );
   }
 
+  const timeline = buildTenantStructuredActivityTimeline(items);
+
   return (
     <TenantSurfaceShell
-      title="Notifications & Feed"
-      subtitle="Track the tenant-safe updates that matter most: application progress, identity steps, communications, lease changes, and maintenance."
+      title="Recent Activity"
+      subtitle="Follow the recent timeline of tenant-safe workflow updates across your application, profile, documents, access, communications, and tenancy."
     >
-      {items.length === 0 ? (
+      {timeline.length === 0 ? (
         <TenantEmptyState
-          title="No notifications yet"
-          body="Recent updates will appear here once your application, tenancy, or communications begin generating tenant-visible events."
+          title="No recent activity yet"
+          body="Timeline updates will appear here once your application, profile, or communications begin generating tenant-visible events."
         />
       ) : (
-        <div style={{ display: "grid", gap: spacing.sm }}>
-          {items.map((item) => (
+        <div style={{ display: "grid", gap: spacing.md }}>
+          <div
+            style={{
+              border: "1px solid rgba(15,23,42,0.08)",
+              borderRadius: 12,
+              padding: spacing.sm,
+              display: "grid",
+              gap: 8,
+            }}
+          >
+            <div style={{ fontWeight: 700, color: textTokens.primary }}>Timeline summary</div>
+            <div style={{ color: textTokens.secondary }}>
+              {timeline.filter((item) => item.actionRequired).length > 0
+                ? `${timeline.filter((item) => item.actionRequired).length} recent update${timeline.filter((item) => item.actionRequired).length === 1 ? "" : "s"} may need your attention.`
+                : "Your recent workflow updates are organized here so you can see what changed without guessing."}
+            </div>
+          </div>
+          {timeline.map((item) => (
             <div
               key={item.id}
               style={{
@@ -80,30 +99,38 @@ export default function TenantActivityPage() {
                 borderRadius: 12,
                 padding: spacing.sm,
                 display: "grid",
-                gap: 8,
+                gap: 10,
               }}
             >
               <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, flexWrap: "wrap" }}>
-                <div style={{ fontWeight: 700, color: textTokens.primary }}>{item.title}</div>
+                <div style={{ display: "grid", gap: 4 }}>
+                  <div style={{ fontWeight: 700, color: textTokens.primary }}>{item.title}</div>
+                  <div style={{ color: textTokens.muted, fontSize: "0.9rem" }}>
+                    {item.actorLabel ? `${item.actorLabel} • ` : ""}
+                    {formatDate(item.occurredAt)}
+                  </div>
+                </div>
                 <div
                   style={{
                     padding: "4px 8px",
                     borderRadius: 999,
                     fontSize: 12,
                     fontWeight: 700,
-                    color: item.status === "success" ? "#166534" : item.status === "warning" ? "#9a3412" : "#1d4ed8",
-                    background: item.status === "success" ? "#dcfce7" : item.status === "warning" ? "#ffedd5" : "#dbeafe",
+                    color: item.actionRequired ? "#9a3412" : "#1d4ed8",
+                    background: item.actionRequired ? "#ffedd5" : "#dbeafe",
                   }}
                 >
-                  {prettyStatus(item.type)}
+                  {item.actionRequired ? "Needs attention" : prettyStatus(item.type)}
                 </div>
               </div>
-              <div style={{ color: textTokens.secondary }}>{item.summary}</div>
+              <div style={{ color: textTokens.secondary }}>{item.description}</div>
               <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, flexWrap: "wrap" }}>
-                <div style={{ color: textTokens.muted, fontSize: "0.9rem" }}>{formatDate(item.createdAt)}</div>
+                <div style={{ color: textTokens.muted, fontSize: "0.9rem" }}>
+                  {item.actionRequired ? "Action may be helpful" : "No immediate action required"}
+                </div>
                 {item.relatedPath ? (
                   <Link to={item.relatedPath} style={{ fontWeight: 700 }}>
-                    Open
+                    {item.actionRequired ? "Review update" : "Open"}
                   </Link>
                 ) : null}
               </div>

--- a/rentchain-frontend/src/pages/tenant/TenantProfileCommunicationsPages.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantProfileCommunicationsPages.test.tsx
@@ -390,7 +390,8 @@ describe("tenant profile and communications pages", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText(/Notifications & Feed/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Recent Activity/i)).toBeInTheDocument();
+    expect(screen.getByText(/Timeline summary/i)).toBeInTheDocument();
     expect(screen.getByText(/Application status updated/i)).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary
Adds a structured, in-app recent-activity timeline for tenant workflow visibility, with a small aligned recent-activity section on the landlord review-summary page.

## What changed
- added a shared `structuredActivityTimeline` helper to normalize existing tenant and landlord-safe activity signals
- refined `/tenant/activity` into a calmer recent-activity timeline with clearer action-needed cues
- added a lightweight landlord-side recent-activity block to the application review summary
- updated targeted tests for timeline normalization and rendering

## Scope / safety
- frontend-only
- no backend or schema changes
- no delivery system changes for email, SMS, or push
- no permission expansion or new notification semantics

## Verification
- targeted Vitest coverage for the shared timeline helper, tenant activity page, and landlord review-summary page
- frontend production build passed