### PR TITLE
feat(shared): add follow-up resolution and re-review state v1

### DIFF
--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
@@ -119,29 +119,27 @@ describe("ApplicationReviewSummaryPage", () => {
 
     renderPage();
 
-   expect(await screen.findByText("Application Review Summary")).toBeInTheDocument();
-expect(await screen.findByText("Intake Summary")).toBeInTheDocument();
-expect(await screen.findByText("Review workflow guidance")).toBeInTheDocument();
-expect(await screen.findByText("Shared package categories")).toBeInTheDocument();
-expect(await screen.findByText("Recent activity")).toBeInTheDocument();
-expect(screen.getAllByText("Profile details").length).toBeGreaterThan(0);
-expect(screen.getAllByText("Rental history").length).toBeGreaterThan(0);
-expect(screen.getAllByText("Documents & records").length).toBeGreaterThan(0);
-expect(screen.getAllByText("Consent / identity status").length).toBeGreaterThan(0);
-expect(screen.getAllByText("Application readiness").length).toBeGreaterThan(0);
-expect((await screen.findAllByText("Ready for review")).length).toBeGreaterThan(0);
-expect(await screen.findByText("Application readiness updated")).toBeInTheDocument();
-expect(await screen.findByText("Next steps")).toBeInTheDocument();
-expect(await screen.findByText("Structured follow-up loop")).toBeInTheDocument();
-expect(screen.getAllByText(/Review the categories already available now/i).length).toBeGreaterThan(0);
-expect(
-  screen.getAllByText((_, element) => element?.textContent?.includes("Follow-up categories:") ?? false).length
-).toBeGreaterThan(0);
-expect(screen.getAllByText("Rental history").length).toBeGreaterThan(0);
-expect(await screen.findByText(/Follow up is organized by aligned package categories/i)).toBeInTheDocument();
-expect(await screen.findByText("Shared with tenant permission and current server-authorized review access.")).toBeInTheDocument();
-expect(await screen.findByText("Jane Applicant")).toBeInTheDocument();
-expect(await screen.findByText("Landlord Decision Panel")).toBeInTheDocument();
-expect(await screen.findByText("Identity verification completed")).toBeInTheDocument();
+    expect(await screen.findByText("Application Review Summary")).toBeInTheDocument();
+    expect(await screen.findByText("Intake Summary")).toBeInTheDocument();
+    expect(await screen.findByText("Follow-up resolution")).toBeInTheDocument();
+    expect(await screen.findByText("Shared package categories")).toBeInTheDocument();
+    expect(await screen.findByText("Recent activity")).toBeInTheDocument();
+    expect(screen.getAllByText("Profile details").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Rental history").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Documents & records").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Consent / identity status").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Application readiness").length).toBeGreaterThan(0);
+    expect((await screen.findAllByText("Partly addressed")).length).toBeGreaterThan(0);
+    expect(await screen.findByText("Application readiness updated")).toBeInTheDocument();
+    expect(await screen.findByText("Next steps")).toBeInTheDocument();
+    expect(await screen.findByText("Structured follow-up loop")).toBeInTheDocument();
+    expect(screen.getAllByText(/Review the addressed categories now visible/i).length).toBeGreaterThan(0);
+    expect(await screen.findByText("Still needs follow-up")).toBeInTheDocument();
+    expect(await screen.findByText("Now appears addressed")).toBeInTheDocument();
+    expect(await screen.findByText(/Follow-up stays organized by aligned package categories/i)).toBeInTheDocument();
+    expect(await screen.findByText("Shared with tenant permission and current server-authorized review access.")).toBeInTheDocument();
+    expect(await screen.findByText("Jane Applicant")).toBeInTheDocument();
+    expect(await screen.findByText("Landlord Decision Panel")).toBeInTheDocument();
+    expect(await screen.findByText("Identity verification completed")).toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
@@ -21,6 +21,7 @@ import { buildLandlordIntakeAlignmentView } from "./applicationReviewIntakeAlign
 import { buildLandlordReviewGuidance } from "./landlordReviewGuidance";
 import { buildTenantLandlordInteractionLoop } from "./tenantLandlordInteractionLoop";
 import { buildLandlordStructuredActivityTimeline } from "./structuredActivityTimeline";
+import { buildFollowUpResolutionState } from "./followUpResolutionState";
 
 function money(cents: number | null): string {
   if (cents == null || !Number.isFinite(cents)) return "Not provided";
@@ -61,6 +62,16 @@ function intakeTone(state: "ready_for_review" | "needs_follow_up") {
   return state === "ready_for_review"
     ? { color: "#166534", background: "#dcfce7", label: "Ready for review" }
     : { color: "#9a3412", background: "#ffedd5", label: "Needs follow-up" };
+}
+
+function followUpTone(state: "follow_up_needed" | "partly_addressed" | "ready_for_rereview") {
+  if (state === "ready_for_rereview") {
+    return { color: "#166534", background: "#dcfce7", label: "Ready for re-review" };
+  }
+  if (state === "partly_addressed") {
+    return { color: "#1d4ed8", background: "#dbeafe", label: "Partly addressed" };
+  }
+  return { color: "#9a3412", background: "#ffedd5", label: "Follow-up needed" };
 }
 
 type SummaryLoadError = {
@@ -224,31 +235,30 @@ function ApplicationReviewSummaryPageBody() {
     }
   };
 
-  const intakeView = useMemo(
-  () => (summary ? buildLandlordIntakeAlignmentView(summary) : null),
-  [summary]
-);
+  const intakeView = useMemo(() => (summary ? buildLandlordIntakeAlignmentView(summary) : null), [summary]);
 
-const guidanceView = useMemo(
-  () => (intakeView ? buildLandlordReviewGuidance(intakeView) : null),
-  [intakeView]
-);
+  const guidanceView = useMemo(() => (intakeView ? buildLandlordReviewGuidance(intakeView) : null), [intakeView]);
 
-const interactionLoop = useMemo(
-  () =>
-    intakeView
-      ? buildTenantLandlordInteractionLoop({
-          audience: "landlord",
-          packageCategories: intakeView.packageCategories,
-        })
-      : null,
-  [intakeView]
-);
+  const interactionLoop = useMemo(
+    () =>
+      intakeView
+        ? buildTenantLandlordInteractionLoop({
+            audience: "landlord",
+            packageCategories: intakeView.packageCategories,
+          })
+        : null,
+    [intakeView]
+  );
 
-const recentActivity = useMemo(
-  () => (summary ? buildLandlordStructuredActivityTimeline(summary).slice(0, 4) : []),
-  [summary]
-);
+  const resolutionView = useMemo(
+    () => (intakeView ? buildFollowUpResolutionState(intakeView.packageCategories) : null),
+    [intakeView]
+  );
+
+  const recentActivity = useMemo(
+    () => (summary ? buildLandlordStructuredActivityTimeline(summary).slice(0, 4) : []),
+    [summary]
+  );
 
   return (
     <div style={{ padding: 16, display: "grid", gap: 12 }}>
@@ -471,11 +481,11 @@ const recentActivity = useMemo(
             </Card>
           ) : null}
 
-          {guidanceView && interactionLoop ? (
+          {guidanceView && interactionLoop && resolutionView ? (
             <Card style={{ display: "grid", gap: 10 }}>
               <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
                 <div>
-                  <div style={{ fontWeight: 700 }}>Review workflow guidance</div>
+                  <div style={{ fontWeight: 700 }}>Follow-up resolution</div>
                   <div style={{ fontSize: 13, color: text.subtle, marginTop: 4 }}>
                     {guidanceView.explanation}
                   </div>
@@ -485,46 +495,72 @@ const recentActivity = useMemo(
                     padding: "6px 10px",
                     borderRadius: 999,
                     fontWeight: 700,
-                    color:
-                      guidanceView.state === "ready_to_review"
-                        ? "#166534"
-                        : guidanceView.state === "partly_available"
-                        ? "#1d4ed8"
-                        : "#9a3412",
-                    background:
-                      guidanceView.state === "ready_to_review"
-                        ? "#dcfce7"
-                        : guidanceView.state === "partly_available"
-                        ? "#dbeafe"
-                        : "#ffedd5",
+                    color: followUpTone(guidanceView.state).color,
+                    background: followUpTone(guidanceView.state).background,
                   }}
                 >
-                  {guidanceView.summary}
+                  {followUpTone(guidanceView.state).label}
                 </div>
               </div>
 
-              {interactionLoop.followUpCategories.length ? (
-                <div style={{ fontSize: 13, color: text.subtle }}>
-                  <strong style={{ color: text.main }}>Follow-up categories:</strong>{" "}
-                  {interactionLoop.followUpCategories.join(", ")}
+              <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))", gap: 8 }}>
+                <div
+                  style={{
+                    border: `1px solid ${colors.border}`,
+                    borderRadius: 10,
+                    padding: 10,
+                    display: "grid",
+                    gap: 6,
+                  }}
+                >
+                  <div style={{ fontWeight: 700, color: text.main }}>Still needs follow-up</div>
+                  {resolutionView.openFollowUpCategories.length ? (
+                    resolutionView.openFollowUpCategories.map((item) => (
+                      <div key={item.key} style={{ fontSize: 13, color: text.subtle }}>
+                        <strong style={{ color: text.main }}>{item.label}:</strong> {item.detail}
+                      </div>
+                    ))
+                  ) : (
+                    <div style={{ fontSize: 13, color: text.subtle }}>
+                      No categories still need follow-up from the current authorized package.
+                    </div>
+                  )}
                 </div>
-              ) : (
-                <div style={{ fontSize: 13, color: text.subtle }}>
-                  <strong style={{ color: text.main }}>Available now:</strong>{" "}
-                  {interactionLoop.readyCategories.join(", ")}
+
+                <div
+                  style={{
+                    border: `1px solid ${colors.border}`,
+                    borderRadius: 10,
+                    padding: 10,
+                    display: "grid",
+                    gap: 6,
+                  }}
+                >
+                  <div style={{ fontWeight: 700, color: text.main }}>Now appears addressed</div>
+                  {resolutionView.addressedCategories.length ? (
+                    resolutionView.addressedCategories.map((item) => (
+                      <div key={item.key} style={{ fontSize: 13, color: text.subtle }}>
+                        <strong style={{ color: text.main }}>{item.label}:</strong> {item.detail}
+                      </div>
+                    ))
+                  ) : (
+                    <div style={{ fontSize: 13, color: text.subtle }}>
+                      No addressed categories are visible yet from the current authorized package.
+                    </div>
+                  )}
                 </div>
-              )}
+              </div>
 
               <div style={{ display: "grid", gap: 8 }}>
                 <div style={{ fontWeight: 700 }}>Structured follow-up loop</div>
                 <div style={{ fontSize: 13, color: text.subtle }}>{interactionLoop.detail}</div>
-                {interactionLoop.followUpCategories.length ? (
+                {resolutionView.openFollowUpCategories.length ? (
                   <div style={{ fontSize: 13, color: text.subtle }}>
-                    Follow up is organized by aligned package categories so the tenant can work back through the same areas in their readiness flow.
+                    Follow-up stays organized by aligned package categories so the tenant and landlord are looking at the same high-level areas.
                   </div>
                 ) : (
                   <div style={{ fontSize: 13, color: text.subtle }}>
-                    No follow-up categories are surfaced right now, so this package is ready for landlord review as-is.
+                    The currently visible follow-up categories now appear addressed, so this package is ready for re-review.
                   </div>
                 )}
               </div>

--- a/rentchain-frontend/src/pages/followUpResolutionState.test.ts
+++ b/rentchain-frontend/src/pages/followUpResolutionState.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { buildFollowUpResolutionState } from "./followUpResolutionState";
+import type { SharePackageCategoryView } from "./sharePackageAlignment";
+
+function categories(
+  statuses: Array<SharePackageCategoryView["status"]>
+): SharePackageCategoryView[] {
+  return [
+    {
+      key: "profile_details",
+      label: "Profile details",
+      status: statuses[0],
+      detail: "Profile details",
+    },
+    {
+      key: "rental_history",
+      label: "Rental history",
+      status: statuses[1],
+      detail: "Rental history",
+    },
+    {
+      key: "documents_records",
+      label: "Documents & records",
+      status: statuses[2],
+      detail: "Documents & records",
+    },
+    {
+      key: "consent_identity_status",
+      label: "Consent / identity status",
+      status: statuses[3],
+      detail: "Consent / identity status",
+    },
+    {
+      key: "application_readiness",
+      label: "Application readiness",
+      status: statuses[4],
+      detail: "Application readiness",
+    },
+  ];
+}
+
+describe("buildFollowUpResolutionState", () => {
+  it("returns follow-up needed when every category is still missing", () => {
+    const result = buildFollowUpResolutionState(
+      categories(["missing", "missing", "missing", "missing", "missing"])
+    );
+
+    expect(result.overallState).toBe("follow_up_needed");
+    expect(result.openFollowUpCategories).toHaveLength(5);
+    expect(result.addressedCategories).toEqual([]);
+  });
+
+  it("returns partly addressed when some categories are updated but open items remain", () => {
+    const result = buildFollowUpResolutionState(
+      categories(["ready", "missing", "partial", "missing", "partial"])
+    );
+
+    expect(result.overallState).toBe("partly_addressed");
+    expect(result.remainingCategoriesNeedingAttention).toEqual([
+      "Rental history",
+      "Consent / identity status",
+    ]);
+    expect(result.addressedCategories.map((item) => item.label)).toEqual([
+      "Profile details",
+      "Documents & records",
+      "Application readiness",
+    ]);
+  });
+
+  it("returns ready for rereview when no categories are still missing", () => {
+    const result = buildFollowUpResolutionState(
+      categories(["ready", "partial", "ready", "partial", "ready"])
+    );
+
+    expect(result.overallState).toBe("ready_for_rereview");
+    expect(result.openFollowUpCategories).toEqual([]);
+    expect(result.addressedCategories).toHaveLength(5);
+  });
+});

--- a/rentchain-frontend/src/pages/followUpResolutionState.ts
+++ b/rentchain-frontend/src/pages/followUpResolutionState.ts
@@ -1,0 +1,54 @@
+import type { SharePackageCategoryView } from "./sharePackageAlignment";
+
+export type FollowUpResolutionOverallState =
+  | "follow_up_needed"
+  | "partly_addressed"
+  | "ready_for_rereview";
+
+export type FollowUpResolutionCategoryState = "still_needed" | "addressed";
+
+export type FollowUpResolutionCategory = SharePackageCategoryView & {
+  resolutionState: FollowUpResolutionCategoryState;
+};
+
+export type FollowUpResolutionView = {
+  overallState: FollowUpResolutionOverallState;
+  openFollowUpCategories: FollowUpResolutionCategory[];
+  addressedCategories: FollowUpResolutionCategory[];
+  remainingCategoriesNeedingAttention: string[];
+};
+
+function withResolutionState(
+  category: SharePackageCategoryView,
+  resolutionState: FollowUpResolutionCategoryState
+): FollowUpResolutionCategory {
+  return {
+    ...category,
+    resolutionState,
+  };
+}
+
+export function buildFollowUpResolutionState(
+  packageCategories: SharePackageCategoryView[]
+): FollowUpResolutionView {
+  const openFollowUpCategories = packageCategories
+    .filter((category) => category.status === "missing")
+    .map((category) => withResolutionState(category, "still_needed"));
+  const addressedCategories = packageCategories
+    .filter((category) => category.status !== "missing")
+    .map((category) => withResolutionState(category, "addressed"));
+
+  const overallState: FollowUpResolutionOverallState =
+    openFollowUpCategories.length === 0
+      ? "ready_for_rereview"
+      : addressedCategories.length > 0
+      ? "partly_addressed"
+      : "follow_up_needed";
+
+  return {
+    overallState,
+    openFollowUpCategories,
+    addressedCategories,
+    remainingCategoriesNeedingAttention: openFollowUpCategories.map((category) => category.label),
+  };
+}

--- a/rentchain-frontend/src/pages/landlordReviewGuidance.test.ts
+++ b/rentchain-frontend/src/pages/landlordReviewGuidance.test.ts
@@ -23,16 +23,16 @@ function buildIntake(
 }
 
 describe("buildLandlordReviewGuidance", () => {
-  it("returns ready to review when no package categories are missing", () => {
+  it("returns ready for rereview when no package categories are missing", () => {
     const result = buildLandlordReviewGuidance(buildIntake());
 
-    expect(result.state).toBe("ready_to_review");
-    expect(result.summary).toBe("Ready to review");
+    expect(result.state).toBe("ready_for_rereview");
+    expect(result.summary).toBe("Ready for re-review");
     expect(result.missingCategories).toEqual([]);
-    expect(result.nextSteps[0]).toMatch(/Review the categories already available now/i);
+    expect(result.nextSteps[0]).toMatch(/Review again/i);
   });
 
-  it("returns partly available when the package only has partial categories left", () => {
+  it("returns ready for rereview when the package only has partial categories left", () => {
     const result = buildLandlordReviewGuidance(
       buildIntake({
         packageCategories: [
@@ -45,15 +45,32 @@ describe("buildLandlordReviewGuidance", () => {
       })
     );
 
-    expect(result.state).toBe("partly_available");
+    expect(result.state).toBe("ready_for_rereview");
     expect(result.summary).toBe("Ready for re-review");
+    expect(result.missingCategories).toEqual([]);
+    expect(result.nextSteps.some((step) => /Review again/i.test(step))).toBe(true);
+  });
+
+  it("returns partly addressed when some categories are addressed and some still need follow-up", () => {
+    const result = buildLandlordReviewGuidance(
+      buildIntake({
+        packageCategories: [
+          { key: "profile_details", label: "Profile details", status: "ready", detail: "Available" },
+          { key: "rental_history", label: "Rental history", status: "missing", detail: "Missing" },
+          { key: "documents_records", label: "Documents & records", status: "ready", detail: "Available" },
+          { key: "consent_identity_status", label: "Consent / identity status", status: "missing", detail: "Missing" },
+          { key: "application_readiness", label: "Application readiness", status: "partial", detail: "Partial" },
+        ],
+      })
+    );
+
+    expect(result.state).toBe("partly_addressed");
+    expect(result.summary).toBe("Partly addressed");
     expect(result.missingCategories).toEqual([
       "Rental history",
-      "Documents & records",
       "Consent / identity status",
-      "Application readiness",
     ]);
-    expect(result.nextSteps.some((step) => /Re-review the package/i.test(step))).toBe(true);
+    expect(result.nextSteps.some((step) => /Keep follow-up active/i.test(step))).toBe(true);
   });
 
   it("returns needs follow-up when nothing is available to review", () => {
@@ -69,7 +86,7 @@ describe("buildLandlordReviewGuidance", () => {
       })
     );
 
-    expect(result.state).toBe("needs_follow_up");
+    expect(result.state).toBe("follow_up_needed");
     expect(result.summary).toBe("Follow-up needed");
     expect(result.nextSteps.some((step) => /Request follow-up/i.test(step))).toBe(true);
   });

--- a/rentchain-frontend/src/pages/landlordReviewGuidance.ts
+++ b/rentchain-frontend/src/pages/landlordReviewGuidance.ts
@@ -2,9 +2,9 @@ import type { LandlordIntakeAlignmentView } from "./applicationReviewIntakeAlign
 import { buildTenantLandlordInteractionLoop } from "./tenantLandlordInteractionLoop";
 
 export type LandlordReviewGuidanceState =
-  | "ready_to_review"
-  | "partly_available"
-  | "needs_follow_up";
+  | "follow_up_needed"
+  | "partly_addressed"
+  | "ready_for_rereview";
 
 export type LandlordReviewGuidanceView = {
   state: LandlordReviewGuidanceState;
@@ -21,12 +21,7 @@ export function buildLandlordReviewGuidance(
     audience: "landlord",
     packageCategories: intake.packageCategories,
   });
-  const state: LandlordReviewGuidanceState =
-    loop.state === "ready_for_review"
-      ? "ready_to_review"
-      : loop.state === "ready_for_rereview"
-      ? "partly_available"
-      : "needs_follow_up";
+  const state: LandlordReviewGuidanceState = loop.state;
 
   return {
     state,

--- a/rentchain-frontend/src/pages/tenant/TenantApplicationCompletionPage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantApplicationCompletionPage.test.tsx
@@ -183,7 +183,8 @@ describe("tenant application completion page", () => {
     expect(screen.getAllByText(/Consent \/ identity status/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Application readiness/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Structured Follow-up/i)).toBeInTheDocument();
-    expect(screen.getByText(/Needs attention:/i)).toBeInTheDocument();
+    expect(screen.getByText(/Still needs attention/i)).toBeInTheDocument();
+    expect(screen.getByText(/^Addressed$/i)).toBeInTheDocument();
     expect(screen.getByText(/Go next/i)).toBeInTheDocument();
     expect(screen.getAllByText(/Review Before Sharing/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Identity verification/i).length).toBeGreaterThan(0);
@@ -191,7 +192,7 @@ describe("tenant application completion page", () => {
     expect(screen.getAllByRole("link", { name: /Review your profile/i }).length).toBeGreaterThan(0);
     expect(screen.getAllByRole("link", { name: /Open documents/i }).length).toBeGreaterThan(0);
     expect(screen.getAllByRole("link", { name: /Review access/i }).length).toBeGreaterThan(0);
-    expect(screen.getAllByRole("link", { name: /Review your application/i }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("link", { name: /Review again/i }).length).toBeGreaterThan(0);
   });
 
   it("renders empty state safely", async () => {

--- a/rentchain-frontend/src/pages/tenant/TenantApplicationStatusPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantApplicationStatusPage.tsx
@@ -22,6 +22,7 @@ import { spacing, text as textTokens } from "../../styles/tokens";
 import { buildTenantApplicationReuseView } from "./tenantApplicationReuse";
 import { buildTenantApplicationFlow } from "./tenantApplicationFlow";
 import { buildTenantLandlordInteractionLoop } from "../tenantLandlordInteractionLoop";
+import { buildFollowUpResolutionState } from "../followUpResolutionState";
 
 function statusTone(status: TenantApplicationCompletionStatus) {
   switch (status) {
@@ -231,6 +232,7 @@ export default function TenantApplicationStatusPage() {
     audience: "tenant",
     packageCategories: reuse.packageCategories,
   });
+  const resolutionView = buildFollowUpResolutionState(reuse.packageCategories);
   const flowTone =
     flow.state === "ready_to_proceed"
       ? { color: "#166534", background: "#dcfce7", label: "Ready to proceed" }
@@ -241,11 +243,11 @@ export default function TenantApplicationStatusPage() {
       : { color: "#0f766e", background: "#ccfbf1", label: "Readiness" };
   const entryLabel = flow.entry === "invite" ? "Invite entry" : flow.entry === "application" ? "Application link" : "Direct tenant navigation";
   const interactionTone =
-    interactionLoop.state === "ready_for_review"
-      ? { color: "#166534", background: "#dcfce7", label: "Ready to continue" }
-      : interactionLoop.state === "ready_for_rereview"
-      ? { color: "#1d4ed8", background: "#dbeafe", label: "Ready for re-review" }
-      : { color: "#9a3412", background: "#ffedd5", label: "Follow-up requested" };
+    interactionLoop.state === "ready_for_rereview"
+      ? { color: "#166534", background: "#dcfce7", label: "Ready for re-review" }
+      : interactionLoop.state === "partly_addressed"
+      ? { color: "#1d4ed8", background: "#dbeafe", label: "Partly addressed" }
+      : { color: "#9a3412", background: "#ffedd5", label: "Follow-up needed" };
 
   return (
     <TenantSurfaceShell
@@ -506,17 +508,53 @@ export default function TenantApplicationStatusPage() {
                 </div>
               </div>
 
-              {interactionLoop.followUpCategories.length ? (
-                <div style={{ color: textTokens.secondary }}>
-                  <strong style={{ color: textTokens.primary }}>Needs attention:</strong>{" "}
-                  {interactionLoop.followUpCategories.join(", ")}
+              <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 8 }}>
+                <div
+                  style={{
+                    border: "1px solid rgba(15,23,42,0.08)",
+                    borderRadius: 12,
+                    padding: "12px 14px",
+                    display: "grid",
+                    gap: 8,
+                  }}
+                >
+                  <div style={{ fontWeight: 700, color: textTokens.primary }}>Still needs attention</div>
+                  {resolutionView.openFollowUpCategories.length ? (
+                    resolutionView.openFollowUpCategories.map((item) => (
+                      <div key={item.key} style={{ color: textTokens.secondary }}>
+                        <strong style={{ color: textTokens.primary }}>{item.label}:</strong> {item.detail}
+                      </div>
+                    ))
+                  ) : (
+                    <div style={{ color: textTokens.secondary }}>
+                      No categories still need attention from the current tenant-safe package.
+                    </div>
+                  )}
                 </div>
-              ) : (
-                <div style={{ color: textTokens.secondary }}>
-                  <strong style={{ color: textTokens.primary }}>Ready now:</strong>{" "}
-                  {interactionLoop.readyCategories.join(", ")}
+
+                <div
+                  style={{
+                    border: "1px solid rgba(15,23,42,0.08)",
+                    borderRadius: 12,
+                    padding: "12px 14px",
+                    display: "grid",
+                    gap: 8,
+                  }}
+                >
+                  <div style={{ fontWeight: 700, color: textTokens.primary }}>Addressed</div>
+                  {resolutionView.addressedCategories.length ? (
+                    resolutionView.addressedCategories.map((item) => (
+                      <div key={item.key} style={{ color: textTokens.secondary }}>
+                        <strong style={{ color: textTokens.primary }}>{item.label}:</strong> {item.detail}
+                      </div>
+                    ))
+                  ) : (
+                    <div style={{ color: textTokens.secondary }}>
+                      Addressed categories will appear here as your package becomes more complete.
+                    </div>
+                  )}
                 </div>
-              )}
+              </div>
             </div>
 
             <div style={{ display: "grid", gap: 8 }}>

--- a/rentchain-frontend/src/pages/tenantLandlordInteractionLoop.test.ts
+++ b/rentchain-frontend/src/pages/tenantLandlordInteractionLoop.test.ts
@@ -40,16 +40,16 @@ function categories(
 }
 
 describe("buildTenantLandlordInteractionLoop", () => {
-  it("returns ready for review when every category is ready", () => {
+  it("returns ready for rereview when every category is addressed", () => {
     const result = buildTenantLandlordInteractionLoop({
       audience: "landlord",
       packageCategories: categories(["ready", "ready", "ready", "ready", "ready"]),
     });
 
-    expect(result.state).toBe("ready_for_review");
+    expect(result.state).toBe("ready_for_rereview");
     expect(result.followUpCategories).toEqual([]);
     expect(result.readyCategories).toHaveLength(5);
-    expect(result.nextSteps[0]).toMatch(/Review the categories already available now/i);
+    expect(result.nextSteps[0]).toMatch(/Review again/i);
   });
 
   it("returns ready for rereview when the package only has partial categories left", () => {
@@ -59,31 +59,48 @@ describe("buildTenantLandlordInteractionLoop", () => {
     });
 
     expect(result.state).toBe("ready_for_rereview");
-    expect(result.followUpCategories).toEqual([
+    expect(result.followUpCategories).toEqual([]);
+    expect(result.readyCategories).toEqual([
+      "Profile details",
       "Rental history",
+      "Documents & records",
       "Consent / identity status",
       "Application readiness",
     ]);
     expect(result.actions.map((item) => item.path)).toEqual([
-      "/tenant/profile",
-      "/tenant/access",
       "/tenant/application",
     ]);
+    expect(result.headline).toBe("Ready for re-review");
   });
 
-  it("returns follow up needed when any categories are missing", () => {
+  it("returns partly addressed when open and addressed categories are mixed", () => {
     const result = buildTenantLandlordInteractionLoop({
       audience: "tenant",
       packageCategories: categories(["missing", "ready", "missing", "partial", "partial"]),
     });
 
-    expect(result.state).toBe("follow_up_needed");
+    expect(result.state).toBe("partly_addressed");
     expect(result.followUpCategories).toEqual([
       "Profile details",
       "Documents & records",
+    ]);
+    expect(result.readyCategories).toEqual([
+      "Rental history",
       "Consent / identity status",
       "Application readiness",
     ]);
+    expect(result.nextSteps[0]).toMatch(/Keep Rental history/i);
+  });
+
+  it("returns follow up needed when every category is still open", () => {
+    const result = buildTenantLandlordInteractionLoop({
+      audience: "tenant",
+      packageCategories: categories(["missing", "missing", "missing", "missing", "missing"]),
+    });
+
+    expect(result.state).toBe("follow_up_needed");
+    expect(result.followUpCategories).toHaveLength(5);
+    expect(result.readyCategories).toEqual([]);
     expect(result.nextSteps[0]).toMatch(/Work through/i);
   });
 });

--- a/rentchain-frontend/src/pages/tenantLandlordInteractionLoop.ts
+++ b/rentchain-frontend/src/pages/tenantLandlordInteractionLoop.ts
@@ -1,9 +1,7 @@
 import type { SharePackageCategoryKey, SharePackageCategoryView } from "./sharePackageAlignment";
+import { buildFollowUpResolutionState, type FollowUpResolutionOverallState } from "./followUpResolutionState";
 
-export type TenantLandlordInteractionLoopState =
-  | "ready_for_review"
-  | "follow_up_needed"
-  | "ready_for_rereview";
+export type TenantLandlordInteractionLoopState = FollowUpResolutionOverallState;
 
 export type TenantLandlordInteractionLoopAudience = "tenant" | "landlord";
 
@@ -60,79 +58,136 @@ function buildHeadline(
   state: TenantLandlordInteractionLoopState
 ): string {
   if (audience === "landlord") {
-    if (state === "ready_for_review") return "Ready to review";
     if (state === "ready_for_rereview") return "Ready for re-review";
+    if (state === "partly_addressed") return "Partly addressed";
     return "Follow-up needed";
   }
 
-  if (state === "ready_for_review") return "Ready to continue";
   if (state === "ready_for_rereview") return "Ready for re-review";
-  return "Follow-up requested";
+  if (state === "partly_addressed") return "Partly addressed";
+  return "Follow-up needed";
+}
+
+function describeCategoryList(categories: string[]): string {
+  return categories.join(", ");
+}
+
+function buildLandlordDetail(
+  state: TenantLandlordInteractionLoopState,
+  followUpCategories: string[],
+  addressedCategories: string[]
+): string {
+  if (state === "ready_for_rereview") {
+    return "The follow-up categories surfaced in this authorized package now appear addressed and are ready for re-review.";
+  }
+  if (state === "partly_addressed") {
+    return `Some follow-up appears addressed already (${describeCategoryList(
+      addressedCategories
+    )}), while ${describeCategoryList(followUpCategories)} still need follow-up.`;
+  }
+  return `Follow-up is still needed in ${describeCategoryList(
+    followUpCategories
+  )} before this package is ready for re-review.`;
+}
+
+function buildTenantDetail(
+  state: TenantLandlordInteractionLoopState,
+  followUpCategories: string[],
+  addressedCategories: string[]
+): string {
+  if (state === "ready_for_rereview") {
+    return "Your package now appears ready for re-review based on the categories currently available in your tenant-safe workspace.";
+  }
+  if (state === "partly_addressed") {
+    return `You have already addressed ${describeCategoryList(
+      addressedCategories
+    )}. ${describeCategoryList(followUpCategories)} still need attention before re-review.`;
+  }
+  return `A few package categories still need attention before this application looks ready for re-review: ${describeCategoryList(
+    followUpCategories
+  )}.`;
 }
 
 function buildDetail(
   audience: TenantLandlordInteractionLoopAudience,
   state: TenantLandlordInteractionLoopState,
-  followUpCategories: string[]
+  followUpCategories: string[],
+  addressedCategories: string[]
 ): string {
   if (audience === "landlord") {
-    if (state === "ready_for_review") {
-      return "The aligned package categories are organized enough to review now using the information currently available.";
-    }
-    if (state === "ready_for_rereview") {
-      return "Most package categories are in place, with only a few partly available sections left to confirm before final review.";
-    }
-    return `Follow-up is still needed in ${followUpCategories.join(", ")} before this package feels complete.`;
+    return buildLandlordDetail(state, followUpCategories, addressedCategories);
   }
 
-  if (state === "ready_for_review") {
-    return "Your current package categories look organized enough to continue with review from your saved profile.";
-  }
+  return buildTenantDetail(state, followUpCategories, addressedCategories);
+}
+
+function buildLandlordNextSteps(
+  state: TenantLandlordInteractionLoopState,
+  followUpCategories: string[],
+  addressedCategories: string[]
+): string[] {
   if (state === "ready_for_rereview") {
-    return "You have enough in place to return for re-review, with only a few sections still needing a final pass.";
+    return [
+      "Review again using the categories that now appear addressed in the current authorized package.",
+      "Capture any final review decision separately from this follow-up summary.",
+    ];
   }
-  return `A few package categories still need attention before this application feels ready to share again: ${followUpCategories.join(", ")}.`;
+
+  if (state === "partly_addressed") {
+    return [
+      `Review the addressed categories now visible in ${describeCategoryList(addressedCategories)}.`,
+      `Keep follow-up active for ${describeCategoryList(followUpCategories)} until those categories are updated.`,
+    ];
+  }
+
+  return [
+    `Request follow-up in ${describeCategoryList(followUpCategories)} using the aligned package categories.`,
+    "Review the package again after those categories are updated in the tenant workflow.",
+  ];
+}
+
+function buildTenantNextSteps(
+  state: TenantLandlordInteractionLoopState,
+  followUpCategories: string[],
+  addressedCategories: string[]
+): string[] {
+  if (state === "ready_for_rereview") {
+    return [
+      "Review again from your application readiness page when you are ready.",
+      "Keep the addressed categories as they are unless something changes.",
+    ];
+  }
+
+  if (state === "partly_addressed") {
+    return [
+      `Keep ${describeCategoryList(addressedCategories)} as they are while you finish ${describeCategoryList(
+        followUpCategories
+      )}.`,
+      `Finish the categories that still need attention so your package can be ready for re-review.`,
+    ];
+  }
+
+  return [
+    `Work through ${describeCategoryList(followUpCategories)} next so your package is easier to review again.`,
+    "The categories already addressed can stay as they are while you update the remaining sections.",
+  ];
 }
 
 export function buildTenantLandlordInteractionLoop(params: {
   audience: TenantLandlordInteractionLoopAudience;
   packageCategories: SharePackageCategoryView[];
 }): TenantLandlordInteractionLoopView {
-  const followUpItems = params.packageCategories.filter((item) => item.status !== "ready");
-  const missingItems = followUpItems.filter((item) => item.status === "missing");
-  const readyCategories = params.packageCategories
-    .filter((item) => item.status === "ready")
-    .map((item) => item.label);
-  const followUpCategories = followUpItems.map((item) => item.label);
+  const resolution = buildFollowUpResolutionState(params.packageCategories);
+  const followUpItems = resolution.openFollowUpCategories;
+  const addressedItems = resolution.addressedCategories;
+  const readyCategories = addressedItems.map((item) => item.label);
+  const followUpCategories = resolution.remainingCategoriesNeedingAttention;
+  const state: TenantLandlordInteractionLoopState = resolution.overallState;
 
-  let state: TenantLandlordInteractionLoopState = "ready_for_review";
-  if (followUpItems.length > 0) {
-    state = missingItems.length > 0 ? "follow_up_needed" : "ready_for_rereview";
-  }
-
-  const nextSteps: string[] = [];
-  if (params.audience === "landlord") {
-    if (readyCategories.length > 0) {
-      nextSteps.push("Review the categories already available now so the current package can move forward without guesswork.");
-    }
-    if (followUpCategories.length > 0) {
-      nextSteps.push(`Request follow-up in ${followUpCategories.join(", ")} using the aligned package categories.`);
-      nextSteps.push("Re-review the package after those categories are updated in the tenant workflow.");
-    }
-    if (nextSteps.length === 0) {
-      nextSteps.push("Review the available package and capture your decision in the summary when you are ready.");
-    }
-  } else {
-    if (followUpCategories.length > 0) {
-      nextSteps.push(`Work through ${followUpCategories.join(", ")} next so your package is easier to re-review.`);
-    }
-    if (readyCategories.length > 0) {
-      nextSteps.push("Keep the categories that are already ready as they are while you update the remaining sections.");
-    }
-    if (nextSteps.length === 0) {
-      nextSteps.push("Continue with your application and review what is already ready to share.");
-    }
-  }
+  const nextSteps =
+    params.audience === "landlord"
+      ? buildLandlordNextSteps(state, followUpCategories, readyCategories)
+      : buildTenantNextSteps(state, followUpCategories, readyCategories);
 
   const actionsMap = new Map<string, TenantLandlordInteractionLoopAction>();
   if (params.audience === "tenant") {
@@ -150,20 +205,22 @@ export function buildTenantLandlordInteractionLoop(params: {
         categories: [item.label],
       });
     });
-    if (!actionsMap.has("/tenant/application")) {
-      actionsMap.set("/tenant/application", {
-        label: "Review your application",
-        path: "/tenant/application",
-        detail: "Return to your application readiness view before continuing.",
-        categories: ["Application readiness"],
-      });
-    }
+    actionsMap.set("/tenant/application", {
+      label: state === "ready_for_rereview" ? "Review again" : "Review your application",
+      path: "/tenant/application",
+      detail:
+        state === "ready_for_rereview"
+          ? "Return to your application readiness view and confirm the package is ready for re-review."
+          : "Return to your application readiness view and confirm the package is ready to continue.",
+      categories:
+        state === "ready_for_rereview" ? ["Ready for re-review"] : ["Application readiness"],
+    });
   }
 
   return {
     state,
     headline: buildHeadline(params.audience, state),
-    detail: buildDetail(params.audience, state, followUpCategories),
+    detail: buildDetail(params.audience, state, followUpCategories, readyCategories),
     followUpCategories,
     readyCategories,
     nextSteps,


### PR DESCRIPTION
## Summary
Adds the v1 follow-up closure foundation for landlord review and tenant re-review readiness.

This PR introduces a shared deterministic follow-up resolution helper based on the existing aligned package categories, then uses it on both surfaces to clearly show:
- what still needs follow-up / attention
- what now appears addressed
- whether the package is `follow_up_needed`, `partly_addressed`, or `ready_for_rereview`

## Scope
- landlord review-summary follow-up resolution UI
- tenant application readiness re-review UI
- shared category-level resolution model
- focused frontend tests

## Implementation notes
- Kept this as a read-first frontend-only V1
- No backend/API changes
- No schema changes
- No auth, billing, Firestore rules, or infra changes
- `partial` and `ready` categories are treated as addressed in this version; `missing` remains open

## Validation
- Targeted Vitest coverage added/updated for helper logic and both surfaces
- Frontend build passes

## Limitations
- No persisted landlord-authored follow-up state yet
- No notifications, messaging, per-document controls, or workflow automation in this PR