### PR TITLE
feat(shared): add structured notification triggers v1

### DIFF
--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
@@ -136,6 +136,8 @@ describe("ApplicationReviewSummaryPage", () => {
     expect(screen.getAllByText(/Review the addressed categories now visible/i).length).toBeGreaterThan(0);
     expect(await screen.findByText("Still needs follow-up")).toBeInTheDocument();
     expect(await screen.findByText("Now appears addressed")).toBeInTheDocument();
+    expect(await screen.findByText("Recent updates")).toBeInTheDocument();
+    expect(await screen.findByText(/Tenant updated follow-up items/i)).toBeInTheDocument();
     expect(await screen.findByText(/Follow-up stays organized by aligned package categories/i)).toBeInTheDocument();
     expect(await screen.findByText("Shared with tenant permission and current server-authorized review access.")).toBeInTheDocument();
     expect(await screen.findByText("Jane Applicant")).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
@@ -22,6 +22,8 @@ import { buildLandlordReviewGuidance } from "./landlordReviewGuidance";
 import { buildTenantLandlordInteractionLoop } from "./tenantLandlordInteractionLoop";
 import { buildLandlordStructuredActivityTimeline } from "./structuredActivityTimeline";
 import { buildFollowUpResolutionState } from "./followUpResolutionState";
+import StructuredNotificationList from "./StructuredNotificationList";
+import { buildLandlordStructuredNotificationTriggers } from "./structuredNotificationTriggers";
 
 function money(cents: number | null): string {
   if (cents == null || !Number.isFinite(cents)) return "Not provided";
@@ -253,6 +255,13 @@ function ApplicationReviewSummaryPageBody() {
   const resolutionView = useMemo(
     () => (intakeView ? buildFollowUpResolutionState(intakeView.packageCategories) : null),
     [intakeView]
+  );
+  const structuredNotifications = useMemo(
+    () =>
+      summary && intakeView
+        ? buildLandlordStructuredNotificationTriggers(summary, intakeView.packageCategories)
+        : [],
+    [summary, intakeView]
   );
 
   const recentActivity = useMemo(
@@ -582,6 +591,16 @@ function ApplicationReviewSummaryPageBody() {
                   </div>
                 ))}
               </div>
+            </Card>
+          ) : null}
+
+          {structuredNotifications.length ? (
+            <Card style={{ display: "grid", gap: 8 }}>
+              <StructuredNotificationList
+                heading="Recent updates"
+                emptyLabel="Recent workflow-triggered review updates will appear here as the package changes."
+                items={structuredNotifications}
+              />
             </Card>
           ) : null}
 

--- a/rentchain-frontend/src/pages/StructuredNotificationList.tsx
+++ b/rentchain-frontend/src/pages/StructuredNotificationList.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { text } from "../styles/tokens";
+import type { StructuredNotificationItem } from "./structuredNotificationTriggers";
+
+export default function StructuredNotificationList(props: {
+  heading: string;
+  emptyLabel: string;
+  items: StructuredNotificationItem[];
+  linkLabel?: string;
+}) {
+  return (
+    <div style={{ display: "grid", gap: 8 }}>
+      <div style={{ fontWeight: 700, color: text.main }}>{props.heading}</div>
+      {props.items.length ? (
+        props.items.map((item) => (
+          <div
+            key={item.id}
+            style={{
+              border: "1px solid rgba(15,23,42,0.08)",
+              borderRadius: 12,
+              padding: "12px 14px",
+              display: "grid",
+              gap: 8,
+            }}
+          >
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, flexWrap: "wrap" }}>
+              <div style={{ fontWeight: 700, color: text.main }}>{item.title}</div>
+              <div
+                style={{
+                  padding: "4px 8px",
+                  borderRadius: 999,
+                  fontSize: 12,
+                  fontWeight: 700,
+                  color: item.actionRequired ? "#9a3412" : "#1d4ed8",
+                  background: item.actionRequired ? "#ffedd5" : "#dbeafe",
+                }}
+              >
+                {item.actionRequired ? "Action required" : "Updated"}
+              </div>
+            </div>
+            <div style={{ color: text.subtle }}>{item.description}</div>
+            {item.targetLink ? (
+              <div>
+                <Link to={item.targetLink} style={{ fontWeight: 700 }}>
+                  {props.linkLabel || (item.actionRequired ? "Review update" : "Open")}
+                </Link>
+              </div>
+            ) : null}
+          </div>
+        ))
+      ) : (
+        <div style={{ color: text.subtle }}>{props.emptyLabel}</div>
+      )}
+    </div>
+  );
+}

--- a/rentchain-frontend/src/pages/structuredNotificationTriggers.test.ts
+++ b/rentchain-frontend/src/pages/structuredNotificationTriggers.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import { buildLandlordStructuredNotificationTriggers, buildTenantStructuredNotificationTriggers } from "./structuredNotificationTriggers";
+import type { SharePackageCategoryView } from "./sharePackageAlignment";
+
+function categories(
+  statuses: Array<SharePackageCategoryView["status"]>
+): SharePackageCategoryView[] {
+  return [
+    {
+      key: "profile_details",
+      label: "Profile details",
+      status: statuses[0],
+      detail: "Profile details are available.",
+    },
+    {
+      key: "rental_history",
+      label: "Rental history",
+      status: statuses[1],
+      detail: "Rental history is available.",
+    },
+    {
+      key: "documents_records",
+      label: "Documents & records",
+      status: statuses[2],
+      detail: "Documents are available.",
+    },
+    {
+      key: "consent_identity_status",
+      label: "Consent / identity status",
+      status: statuses[3],
+      detail: "Consent is available.",
+    },
+    {
+      key: "application_readiness",
+      label: "Application readiness",
+      status: statuses[4],
+      detail: "Readiness is available.",
+    },
+  ];
+}
+
+describe("structuredNotificationTriggers", () => {
+  it("builds tenant notifications with action-required items first", () => {
+    const result = buildTenantStructuredNotificationTriggers({
+      packageCategories: categories(["missing", "ready", "ready", "partial", "partial"]),
+      completion: {
+        status: "in_progress",
+        progressPercent: 62,
+        sections: [],
+        nextSteps: [],
+        updatedAt: "2026-04-05T00:00:00.000Z",
+      },
+      profile: {
+        context: {
+          authority: "applicant",
+          propertyId: "prop-1",
+          rc_prop_id: "rc-prop-1",
+          applicationId: "app-1",
+          leaseId: null,
+          tenantId: "tenant-1",
+          unitId: "unit-1",
+          invitedEmail: "tenant@example.com",
+        },
+        profile: {
+          displayName: "Taylor Tenant",
+          email: "tenant@example.com",
+          phone: "902-555-0100",
+          authorityLabel: "Applicant",
+          property: null,
+          application: {
+            applicationId: "app-1",
+            status: "submitted",
+            missingSteps: [],
+            nextActions: [],
+            createdAt: "2026-04-01T00:00:00.000Z",
+            updatedAt: "2026-04-05T00:00:00.000Z",
+          },
+          lease: null,
+        },
+        identity: {
+          overallStatus: "pending",
+          identityVerification: {
+            status: "pending",
+            label: "Pending",
+            note: "Still in progress.",
+            updatedAt: "2026-04-04T00:00:00.000Z",
+          },
+          documentChecklist: [],
+          nextSteps: [],
+        },
+        actions: {
+          editableFields: [],
+          documentEntry: {
+            available: true,
+            path: "/tenant/attachments",
+            label: "Open documents",
+            note: null,
+          },
+        },
+      },
+      attachments: {
+        data: [{ id: "doc-1", status: "uploaded" }],
+        updatedAt: 1712361600000,
+      } as any,
+      access: {
+        summary: {
+          activeGrants: 1,
+          pendingRequests: 0,
+          latestActivityAt: 1712275200000,
+        },
+        pendingRequests: [],
+        activeAccess: [],
+        recentActivity: [],
+        guidance: {
+          headline: "Shared",
+          body: "Visible",
+        },
+      },
+    });
+
+    expect(result[0]).toMatchObject({
+      type: "follow_up_requested",
+      actionRequired: true,
+      targetLink: "/tenant/profile",
+    });
+    expect(result.some((item) => item.type === "documents_updated")).toBe(true);
+    expect(result.some((item) => item.type === "access_changed")).toBe(true);
+  });
+
+  it("builds landlord notifications for follow-up and rereview state", () => {
+    const result = buildLandlordStructuredNotificationTriggers(
+      {
+        applicationId: "app-1",
+        generatedAt: "2026-04-06T00:00:00.000Z",
+        applicant: {} as any,
+        employment: {} as any,
+        reference: {} as any,
+        compliance: {} as any,
+        screening: { status: "complete", provider: "transunion", referenceId: "TU-1" },
+        derived: { incomeToRentRatio: null, completeness: { score: 0.9, label: "High" }, flags: [] },
+        insights: [],
+        decisionSummary: {
+          applicationId: "app-1",
+          riskSnapshot: {
+            version: "risk-v1",
+            status: "completed",
+            score: 72,
+            grade: "B",
+            confidence: 0.84,
+            factors: [],
+            flags: [],
+            recommendations: [],
+            updatedAt: "2026-04-07T00:00:00.000Z",
+          },
+        },
+        risk: null,
+      } as any,
+      categories(["ready", "partial", "ready", "partial", "ready"])
+    );
+
+    expect(result[0]).toMatchObject({
+      type: "ready_for_rereview",
+      title: "Application ready for re-review",
+      actionRequired: false,
+    });
+    expect(result.some((item) => item.type === "follow_up_addressed")).toBe(true);
+  });
+});

--- a/rentchain-frontend/src/pages/structuredNotificationTriggers.ts
+++ b/rentchain-frontend/src/pages/structuredNotificationTriggers.ts
@@ -1,0 +1,242 @@
+import type { ApplicationReviewSummary } from "../api/reviewSummaryApi";
+import type { TenantAccessWorkspace } from "../api/tenantAccess";
+import type { TenantAttachment } from "../api/tenantAttachmentsApi";
+import type { TenantProfileData } from "../api/tenantProfile";
+import type { TenantApplicationCompletionSummary } from "../api/tenantApplicationCompletion";
+import type { SharePackageCategoryKey, SharePackageCategoryView } from "./sharePackageAlignment";
+import { buildFollowUpResolutionState } from "./followUpResolutionState";
+
+export type StructuredNotificationTriggerType =
+  | "follow_up_requested"
+  | "follow_up_addressed"
+  | "ready_for_rereview"
+  | "readiness_improved"
+  | "access_changed"
+  | "documents_updated";
+
+export type StructuredNotificationItem = {
+  id: string;
+  type: StructuredNotificationTriggerType;
+  title: string;
+  description: string;
+  timestamp: number;
+  actionRequired: boolean;
+  targetLink: string | null;
+};
+
+const CATEGORY_TARGETS: Record<SharePackageCategoryKey, string> = {
+  profile_details: "/tenant/profile",
+  rental_history: "/tenant/profile",
+  documents_records: "/tenant/attachments",
+  consent_identity_status: "/tenant/access",
+  application_readiness: "/tenant/application",
+};
+
+function toMillis(value: string | number | null | undefined): number | null {
+  if (value == null) return null;
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  const parsed = Date.parse(String(value));
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function latestMillis(...values: Array<string | number | null | undefined>): number | null {
+  return values.reduce<number | null>((current, value) => {
+    const next = toMillis(value);
+    if (next == null) return current;
+    return current == null ? next : Math.max(current, next);
+  }, null);
+}
+
+function formatCategorySummary(categories: SharePackageCategoryView[]): string {
+  return categories.map((item) => item.label).join(", ");
+}
+
+function pushItem(
+  items: StructuredNotificationItem[],
+  item: Omit<StructuredNotificationItem, "timestamp"> & { timestamp: string | number | null | undefined }
+) {
+  const timestamp = toMillis(item.timestamp);
+  if (timestamp == null) return;
+  items.push({
+    ...item,
+    timestamp,
+  });
+}
+
+function compareNotifications(left: StructuredNotificationItem, right: StructuredNotificationItem): number {
+  if (left.actionRequired !== right.actionRequired) {
+    return left.actionRequired ? -1 : 1;
+  }
+  return right.timestamp - left.timestamp;
+}
+
+function firstOpenCategoryLink(categories: SharePackageCategoryView[]): string | null {
+  const first = categories[0];
+  return first ? CATEGORY_TARGETS[first.key] : null;
+}
+
+function primaryAddressedCategoryLabel(categories: SharePackageCategoryView[]): string {
+  if (categories.some((item) => item.key === "profile_details")) return "Profile updated";
+  if (categories.some((item) => item.key === "documents_records")) return "Documents updated";
+  if (categories.some((item) => item.key === "consent_identity_status")) return "Access updated";
+  if (categories.some((item) => item.key === "application_readiness")) return "Application updated";
+  return "Follow-up items updated";
+}
+
+export function buildTenantStructuredNotificationTriggers(params: {
+  packageCategories: SharePackageCategoryView[];
+  completion: TenantApplicationCompletionSummary | null;
+  profile: TenantProfileData | null;
+  attachments?: { data: TenantAttachment[]; updatedAt?: number | null } | null;
+  access?: TenantAccessWorkspace | null;
+}): StructuredNotificationItem[] {
+  const items: StructuredNotificationItem[] = [];
+  const resolution = buildFollowUpResolutionState(params.packageCategories);
+  const followUpTimestamp = latestMillis(
+    params.completion?.updatedAt,
+    params.profile?.profile.application?.updatedAt,
+    params.attachments?.updatedAt,
+    params.access?.summary.latestActivityAt
+  );
+
+  if (resolution.openFollowUpCategories.length > 0) {
+    pushItem(items, {
+      id: "tenant-follow-up-requested",
+      type: "follow_up_requested",
+      title: `Follow-up requested for ${resolution.openFollowUpCategories[0].label}${resolution.openFollowUpCategories.length > 1 ? ` and ${resolution.openFollowUpCategories.length - 1} more` : ""}`,
+      description: `${formatCategorySummary(
+        resolution.openFollowUpCategories
+      )} still need attention before your package is ready for re-review.`,
+      timestamp: followUpTimestamp,
+      actionRequired: true,
+      targetLink: firstOpenCategoryLink(resolution.openFollowUpCategories),
+    });
+  }
+
+  if (resolution.addressedCategories.length > 0) {
+    pushItem(items, {
+      id: "tenant-follow-up-addressed",
+      type: "follow_up_addressed",
+      title:
+        resolution.overallState === "ready_for_rereview"
+          ? `${primaryAddressedCategoryLabel(resolution.addressedCategories)} — ready for re-review`
+          : `${primaryAddressedCategoryLabel(resolution.addressedCategories)} — update saved`,
+      description: `${formatCategorySummary(
+        resolution.addressedCategories
+      )} now appear addressed from the latest tenant-safe workspace data.`,
+      timestamp: followUpTimestamp,
+      actionRequired: false,
+      targetLink: "/tenant/application",
+    });
+  }
+
+  if (resolution.overallState === "ready_for_rereview") {
+    pushItem(items, {
+      id: "tenant-ready-for-rereview",
+      type: "ready_for_rereview",
+      title: "Application ready for re-review",
+      description: "The requested follow-up categories now appear addressed and are ready to review again.",
+      timestamp: followUpTimestamp,
+      actionRequired: false,
+      targetLink: "/tenant/application",
+    });
+  }
+
+  if ((params.completion?.progressPercent || 0) > 0) {
+    pushItem(items, {
+      id: "tenant-readiness-improved",
+      type: "readiness_improved",
+      title:
+        (params.completion?.progressPercent || 0) >= 80
+          ? "Application now ready for review"
+          : "Application readiness improved",
+      description: `Your application readiness is ${params.completion?.progressPercent || 0}% complete in the current tenant-safe checklist.`,
+      timestamp: params.completion?.updatedAt,
+      actionRequired: false,
+      targetLink: "/tenant/application",
+    });
+  }
+
+  if (params.attachments?.updatedAt && params.attachments.data.length > 0) {
+    pushItem(items, {
+      id: "tenant-documents-updated",
+      type: "documents_updated",
+      title: "Documents updated",
+      description: `${params.attachments.data.length} document${params.attachments.data.length === 1 ? "" : "s"} are currently in your tenant document workspace.`,
+      timestamp: params.attachments.updatedAt,
+      actionRequired: false,
+      targetLink: "/tenant/attachments",
+    });
+  }
+
+  if (params.access?.summary.latestActivityAt) {
+    pushItem(items, {
+      id: "tenant-access-changed",
+      type: "access_changed",
+      title: "Access changed",
+      description:
+        params.access.summary.activeGrants > 0
+          ? `${params.access.summary.activeGrants} active access grant${params.access.summary.activeGrants === 1 ? "" : "s"} are available in your access workspace.`
+          : "Your access workspace shows recent sharing activity.",
+      timestamp: params.access.summary.latestActivityAt,
+      actionRequired: false,
+      targetLink: "/tenant/access",
+    });
+  }
+
+  return items.sort(compareNotifications).slice(0, 6);
+}
+
+export function buildLandlordStructuredNotificationTriggers(
+  summary: ApplicationReviewSummary,
+  packageCategories: SharePackageCategoryView[]
+): StructuredNotificationItem[] {
+  const items: StructuredNotificationItem[] = [];
+  const resolution = buildFollowUpResolutionState(packageCategories);
+  const reviewTimestamp = latestMillis(
+    summary.decisionSummary?.riskSnapshot?.updatedAt,
+    summary.generatedAt
+  );
+
+  if (resolution.openFollowUpCategories.length > 0) {
+    pushItem(items, {
+      id: `landlord-follow-up-requested-${summary.applicationId}`,
+      type: "follow_up_requested",
+      title: `Follow-up requested for ${resolution.openFollowUpCategories[0].label}${resolution.openFollowUpCategories.length > 1 ? ` and ${resolution.openFollowUpCategories.length - 1} more` : ""}`,
+      description: `${formatCategorySummary(
+        resolution.openFollowUpCategories
+      )} still need follow-up in the current authorized review package.`,
+      timestamp: reviewTimestamp,
+      actionRequired: true,
+      targetLink: null,
+    });
+  }
+
+  if (resolution.addressedCategories.length > 0) {
+    pushItem(items, {
+      id: `landlord-follow-up-addressed-${summary.applicationId}`,
+      type: "follow_up_addressed",
+      title: "Tenant updated follow-up items",
+      description: `${formatCategorySummary(
+        resolution.addressedCategories
+      )} now appear addressed from the latest authorized review summary.`,
+      timestamp: summary.generatedAt,
+      actionRequired: false,
+      targetLink: null,
+    });
+  }
+
+  if (resolution.overallState === "ready_for_rereview") {
+    pushItem(items, {
+      id: `landlord-ready-for-rereview-${summary.applicationId}`,
+      type: "ready_for_rereview",
+      title: "Application ready for re-review",
+      description: "The visible follow-up categories now appear addressed and are ready to review again.",
+      timestamp: reviewTimestamp,
+      actionRequired: false,
+      targetLink: null,
+    });
+  }
+
+  return items.sort(compareNotifications).slice(0, 4);
+}

--- a/rentchain-frontend/src/pages/tenant/TenantApplicationCompletionPage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantApplicationCompletionPage.test.tsx
@@ -176,6 +176,8 @@ describe("tenant application completion page", () => {
     expect(screen.getByText(/Invite entry/i)).toBeInTheDocument();
     expect(screen.getByText(/^Next step$/i)).toBeInTheDocument();
     expect(screen.getByText(/Application Readiness Summary/i)).toBeInTheDocument();
+    expect(screen.getByText(/Recent activity \/ notifications/i)).toBeInTheDocument();
+    expect(screen.getByText(/Recent workflow updates/i)).toBeInTheDocument();
     expect(screen.getByText(/Share Package/i)).toBeInTheDocument();
     expect(screen.getAllByText(/Profile details/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Rental history/i).length).toBeGreaterThan(0);
@@ -185,6 +187,7 @@ describe("tenant application completion page", () => {
     expect(screen.getByText(/Structured Follow-up/i)).toBeInTheDocument();
     expect(screen.getByText(/Still needs attention/i)).toBeInTheDocument();
     expect(screen.getByText(/^Addressed$/i)).toBeInTheDocument();
+    expect(screen.getByText(/Application ready for re-review/i)).toBeInTheDocument();
     expect(screen.getByText(/Go next/i)).toBeInTheDocument();
     expect(screen.getAllByText(/Review Before Sharing/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Identity verification/i).length).toBeGreaterThan(0);

--- a/rentchain-frontend/src/pages/tenant/TenantApplicationStatusPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantApplicationStatusPage.tsx
@@ -23,6 +23,8 @@ import { buildTenantApplicationReuseView } from "./tenantApplicationReuse";
 import { buildTenantApplicationFlow } from "./tenantApplicationFlow";
 import { buildTenantLandlordInteractionLoop } from "../tenantLandlordInteractionLoop";
 import { buildFollowUpResolutionState } from "../followUpResolutionState";
+import StructuredNotificationList from "../StructuredNotificationList";
+import { buildTenantStructuredNotificationTriggers } from "../structuredNotificationTriggers";
 
 function statusTone(status: TenantApplicationCompletionStatus) {
   switch (status) {
@@ -233,6 +235,13 @@ export default function TenantApplicationStatusPage() {
     packageCategories: reuse.packageCategories,
   });
   const resolutionView = buildFollowUpResolutionState(reuse.packageCategories);
+  const notificationItems = buildTenantStructuredNotificationTriggers({
+    packageCategories: reuse.packageCategories,
+    completion: data,
+    profile,
+    attachments,
+    access,
+  });
   const flowTone =
     flow.state === "ready_to_proceed"
       ? { color: "#166534", background: "#dcfce7", label: "Ready to proceed" }
@@ -427,6 +436,14 @@ export default function TenantApplicationStatusPage() {
             </div>
           ))}
         </div>
+      </TenantInfoCard>
+
+      <TenantInfoCard heading="Recent activity / notifications" accent="#0891b2">
+        <StructuredNotificationList
+          heading="Recent workflow updates"
+          emptyLabel="Recent workflow-triggered notifications will appear here once this application starts moving through review and follow-up."
+          items={notificationItems}
+        />
       </TenantInfoCard>
 
       <div

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -63,6 +63,13 @@ describe("tenant workspace frontend shell", () => {
       unreadNotices: 2,
       unreadScreeningUpdates: 0,
     });
+    tenantApplicationCompletionApi.getTenantApplicationCompletion.mockResolvedValue({
+      status: "in_progress",
+      progressPercent: 62,
+      sections: [],
+      nextSteps: ["Upload government id"],
+      updatedAt: "2026-01-02T00:00:00.000Z",
+    });
     tenantAccessApi.getTenantAccess.mockResolvedValue({
       summary: {
         activeGrants: 1,
@@ -274,6 +281,8 @@ describe("tenant workspace frontend shell", () => {
     );
 
     expect(await screen.findByText(/^Tenant Dashboard$/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Recent activity \/ notifications/i)).toBeInTheDocument();
+    expect(screen.getByText(/Recent workflow updates/i)).toBeInTheDocument();
     expect(await screen.findByText(/Profile completion/i)).toBeInTheDocument();
     expect(screen.getByText(/Add missing details to keep your rental profile organized/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /View your profile/i })).toBeInTheDocument();
@@ -281,8 +290,9 @@ describe("tenant workspace frontend shell", () => {
     expect(screen.getByText(/Active tenancy/i)).toBeInTheDocument();
     expect(screen.getByText(/123 Main St, Unit 4, Halifax, NS/i)).toBeInTheDocument();
     expect(screen.getByText(/finish_profile/i)).toBeInTheDocument();
-    expect(screen.getByText(/1 active access grant/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/1 active access grant/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/1 document in your vault, 1 ready to share, and 0 still needing attention/i)).toBeInTheDocument();
+    expect(screen.getByText(/Documents updated/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Open document vault/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Open access/i })).toBeInTheDocument();
   });

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
@@ -4,6 +4,7 @@ import { getTenantWorkspace } from "../../api/tenantPortal";
 import { getTenantAccess, type TenantAccessWorkspace } from "../../api/tenantAccess";
 import { getTenantAttachments } from "../../api/tenantAttachmentsApi";
 import { getTenantProfile } from "../../api/tenantProfile";
+import { getTenantApplicationCompletion } from "../../api/tenantApplicationCompletion";
 import {
   TenantEmptyState,
   TenantErrorState,
@@ -20,12 +21,16 @@ import { spacing, text as textTokens } from "../../styles/tokens";
 import TenantProfileCompletionCard from "./TenantProfileCompletionCard";
 import { buildTenantProfileCompletion } from "./tenantProfileCompletion";
 import { buildTenantDocumentVaultView } from "./tenantDocumentVault";
+import { buildTenantApplicationReuseView } from "./tenantApplicationReuse";
+import StructuredNotificationList from "../StructuredNotificationList";
+import { buildTenantStructuredNotificationTriggers } from "../structuredNotificationTriggers";
 
 export default function TenantWorkspacePage() {
   const [data, setData] = React.useState<Awaited<ReturnType<typeof getTenantWorkspace>> | null>(null);
   const [access, setAccess] = React.useState<TenantAccessWorkspace | null>(null);
   const [attachments, setAttachments] = React.useState<Awaited<ReturnType<typeof getTenantAttachments>> | null>(null);
   const [profileData, setProfileData] = React.useState<Awaited<ReturnType<typeof getTenantProfile>> | null>(null);
+  const [completion, setCompletion] = React.useState<Awaited<ReturnType<typeof getTenantApplicationCompletion>> | null>(null);
   const [profileLoading, setProfileLoading] = React.useState(true);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
@@ -34,10 +39,11 @@ export default function TenantWorkspacePage() {
     setLoading(true);
     setError(null);
     try {
-      const [workspaceResult, accessResult, attachmentsResult] = await Promise.allSettled([
+      const [workspaceResult, accessResult, attachmentsResult, completionResult] = await Promise.allSettled([
         getTenantWorkspace(),
         getTenantAccess(),
         getTenantAttachments(),
+        getTenantApplicationCompletion(),
       ]);
 
       if (workspaceResult.status === "rejected") {
@@ -47,10 +53,12 @@ export default function TenantWorkspacePage() {
       setData(workspaceResult.value);
       setAccess(accessResult.status === "fulfilled" ? accessResult.value : null);
       setAttachments(attachmentsResult.status === "fulfilled" ? attachmentsResult.value : null);
+      setCompletion(completionResult.status === "fulfilled" ? completionResult.value : null);
     } catch (err: any) {
       setData(null);
       setAccess(null);
       setAttachments(null);
+      setCompletion(null);
       setError(err?.payload?.error || err?.message || "Unable to load your tenant workspace.");
     } finally {
       setLoading(false);
@@ -120,6 +128,19 @@ export default function TenantWorkspacePage() {
     updatedAt: attachments?.updatedAt,
     access,
   });
+  const reuse = buildTenantApplicationReuseView({
+    completion,
+    profile: profileData,
+    attachments,
+    access,
+  });
+  const notificationItems = buildTenantStructuredNotificationTriggers({
+    packageCategories: reuse.packageCategories,
+    completion,
+    profile: profileData,
+    attachments,
+    access,
+  });
 
   return (
     <TenantSurfaceShell
@@ -152,6 +173,14 @@ export default function TenantWorkspacePage() {
             { label: "Lease", value: prettyStatus(data?.lease?.status) },
             { label: "Maintenance", value: `${maintenanceCount} request${maintenanceCount === 1 ? "" : "s"}` },
           ]}
+        />
+      </TenantInfoCard>
+
+      <TenantInfoCard heading="Recent activity / notifications" accent="#0891b2">
+        <StructuredNotificationList
+          heading="Recent workflow updates"
+          emptyLabel="Workflow-triggered notifications will appear here as your application, documents, access, and follow-up state change."
+          items={notificationItems}
         />
       </TenantInfoCard>
 


### PR DESCRIPTION
## Summary
Adds v1 structured in-app notification triggers for tenant and landlord workflow updates.

This PR introduces a shared deterministic helper that maps existing workflow state into lightweight notification items, then surfaces those updates in:
- the tenant dashboard
- the tenant application readiness page
- the landlord review summary page

## Scope
- shared notification trigger helper
- small reusable notification list UI
- tenant-side recent activity / notifications blocks
- landlord-side recent updates block
- focused frontend tests

## Trigger decisions
Notifications are derived from real existing state, including:
- follow-up requested
- follow-up addressed
- ready for re-review
- readiness improved
- access changed
- documents updated

Ordering is:
- action-required first
- newest first

## Implementation notes
- Frontend-only v1
- No schema changes
- No auth changes
- No email, SMS, push, or preferences system
- No backend event bus redesign
- No fabricated events; notifications are derived from existing authorized data

## Validation
- `npm run test -- src`
- `npm run build`

Both passed.

## Limitations
- This is a derived notification layer, not a persisted event history system
- No unread-count platform work in this PR
- Landlord notifications remain intentionally lightweight and review-summary scoped