### PR TITLE
feat(shared): add notification preferences and channel routing v1

### DIFF
--- a/rentchain-api/src/routes/__tests__/tenantNotificationPreferencesRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantNotificationPreferencesRoutes.test.ts
@@ -1,0 +1,195 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const collections = new Map<string, Map<string, any>>();
+
+function ensureCollection(name: string) {
+  if (!collections.has(name)) collections.set(name, new Map<string, any>());
+  return collections.get(name)!;
+}
+
+function clone<T>(value: T): T {
+  return value === undefined ? value : JSON.parse(JSON.stringify(value));
+}
+
+function applyFilters(rows: Array<[string, any]>, filters: Array<{ field: string; op: string; value: any }>) {
+  return rows.filter(([, data]) =>
+    filters.every((filter) => {
+      const current = data?.[filter.field];
+      if (filter.op === "==") return current === filter.value;
+      if (filter.op === "array-contains") return Array.isArray(current) && current.includes(filter.value);
+      return false;
+    })
+  );
+}
+
+function createQuery(name: string, filters: Array<{ field: string; op: string; value: any }> = []) {
+  const api: any = {
+    where(field: string, op: string, value: any) {
+      return createQuery(name, [...filters, { field, op, value }]);
+    },
+    orderBy() {
+      return api;
+    },
+    limit(count: number) {
+      return {
+        get: async () => {
+          const docs = applyFilters(Array.from(ensureCollection(name).entries()), filters)
+            .slice(0, count)
+            .map(([id, data]) => ({ id, exists: true, data: () => clone(data) }));
+          return { docs, empty: docs.length === 0 };
+        },
+      };
+    },
+    async get() {
+      const docs = applyFilters(Array.from(ensureCollection(name).entries()), filters).map(([id, data]) => ({
+        id,
+        exists: true,
+        data: () => clone(data),
+      }));
+      return { docs, empty: docs.length === 0 };
+    },
+  };
+  return api;
+}
+
+const dbMock = {
+  collection: (name: string) => ({
+    doc: (id?: string) => {
+      const docId = id || `doc_${ensureCollection(name).size + 1}`;
+      return {
+        id: docId,
+        get: async () => ({
+          id: docId,
+          exists: ensureCollection(name).has(docId),
+          data: () => clone(ensureCollection(name).get(docId)),
+        }),
+        set: async (value: any, opts?: { merge?: boolean }) => {
+          const current = ensureCollection(name).get(docId) || {};
+          ensureCollection(name).set(docId, opts?.merge ? { ...current, ...clone(value) } : clone(value));
+        },
+      };
+    },
+    where: (field: string, op: string, value: any) => createQuery(name, [{ field, op, value }]),
+  }),
+};
+
+vi.mock("../../config/firebase", () => ({
+  db: dbMock,
+  FieldValue: {
+    serverTimestamp: () => "__server_timestamp__",
+  },
+}));
+
+vi.mock("../../middleware/authMiddleware", () => ({
+  authenticateJwt: (req: any, _res: any, next: any) => {
+    const header = String(req.headers["x-test-user"] || "").trim();
+    if (header) req.user = JSON.parse(header);
+    next();
+  },
+}));
+
+async function invokeRouter(router: any, options: {
+  method: string;
+  url: string;
+  body?: any;
+  headers?: Record<string, string>;
+}) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path: options.url,
+      body: options.body ?? {},
+      headers: options.headers ?? {},
+      query: {},
+      params: {},
+    };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("tenant notification preferences route", () => {
+  beforeEach(() => {
+    collections.clear();
+    ensureCollection("users").set("user-1", {
+      email: "tenant@example.com",
+      tenantNotificationPreferences: {
+        inApp: {
+          follow_up_requested: true,
+          ready_for_rereview: true,
+          application_updated: true,
+          access_changed: true,
+          documents_updated: true,
+        },
+        updatedAt: 1710000000000,
+      },
+    });
+  });
+
+  it("returns default-safe preferences for the authenticated tenant", async () => {
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/notification-preferences",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.inApp?.follow_up_requested).toBe(true);
+    expect(res.body?.data?.inApp?.documents_updated).toBe(true);
+  });
+
+  it("patches only supported boolean in-app preference fields", async () => {
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "PATCH",
+      url: "/notification-preferences",
+      body: {
+        inApp: {
+          documents_updated: false,
+          access_changed: false,
+          fake_channel: true,
+        },
+      },
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.inApp?.documents_updated).toBe(false);
+    expect(res.body?.data?.inApp?.access_changed).toBe(false);
+    expect(res.body?.data?.inApp?.follow_up_requested).toBe(true);
+    expect(ensureCollection("users").get("user-1")?.tenantNotificationPreferences?.inApp?.fake_channel).toBeUndefined();
+  });
+});

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -1846,6 +1846,55 @@ function requireTenantWorkspaceIdentity(req: any, res: any, next: any) {
   return next();
 }
 
+const TENANT_NOTIFICATION_PREFERENCE_KEYS = [
+  "follow_up_requested",
+  "ready_for_rereview",
+  "application_updated",
+  "access_changed",
+  "documents_updated",
+] as const;
+
+type TenantNotificationPreferenceKey = (typeof TENANT_NOTIFICATION_PREFERENCE_KEYS)[number];
+
+type TenantNotificationPreferences = {
+  inApp: Record<TenantNotificationPreferenceKey, boolean>;
+  updatedAt: number | null;
+};
+
+function defaultTenantNotificationPreferences(): TenantNotificationPreferences {
+  return {
+    inApp: {
+      follow_up_requested: true,
+      ready_for_rereview: true,
+      application_updated: true,
+      access_changed: true,
+      documents_updated: true,
+    },
+    updatedAt: null,
+  };
+}
+
+function normalizeTenantNotificationPreferences(input: any): TenantNotificationPreferences {
+  const defaults = defaultTenantNotificationPreferences();
+  const source = input?.inApp && typeof input.inApp === "object" ? input.inApp : {};
+  const inApp = { ...defaults.inApp };
+  for (const key of TENANT_NOTIFICATION_PREFERENCE_KEYS) {
+    if (typeof source[key] === "boolean") {
+      inApp[key] = source[key];
+    }
+  }
+  return {
+    inApp,
+    updatedAt: typeof input?.updatedAt === "number" && Number.isFinite(input.updatedAt) ? input.updatedAt : null,
+  };
+}
+
+async function loadTenantNotificationPreferences(userId: string): Promise<TenantNotificationPreferences> {
+  const userSnap = await db.collection("users").doc(userId).get();
+  const data = userSnap.exists ? userSnap.data() : null;
+  return normalizeTenantNotificationPreferences(data?.tenantNotificationPreferences);
+}
+
 async function resolveWorkspaceContextOrRespond(req: any, res: any) {
   const context = await resolveTenancyContext({
     uid: String(req.user?.id || "").trim(),
@@ -2535,6 +2584,73 @@ async function handleTenantWorkspaceSummary(req: any, res: any) {
 
 router.get("/workspace", requireTenantWorkspaceIdentity, handleTenantWorkspaceSummary);
 router.get("/me", requireTenantWorkspaceIdentity, handleTenantWorkspaceSummary);
+
+router.get("/notification-preferences", requireTenantWorkspaceIdentity, async (req: any, res) => {
+  const userId = String(req.user?.id || "").trim();
+  if (!userId) {
+    return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+  }
+
+  try {
+    const preferences = await loadTenantNotificationPreferences(userId);
+    return res.json({ ok: true, data: preferences });
+  } catch (err: any) {
+    console.error("[tenant/notification-preferences] failed", {
+      userId: req.user?.id,
+      message: err?.message || "failed",
+    });
+    return res.status(500).json({ ok: false, error: "TENANT_NOTIFICATION_PREFERENCES_FAILED" });
+  }
+});
+
+router.patch("/notification-preferences", requireTenantWorkspaceIdentity, async (req: any, res) => {
+  const userId = String(req.user?.id || "").trim();
+  if (!userId) {
+    return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+  }
+
+  const requested = req.body?.inApp;
+  if (!requested || typeof requested !== "object") {
+    return res.status(400).json({ ok: false, error: "TENANT_NOTIFICATION_PREFERENCES_INVALID" });
+  }
+
+  const hasRequestedField = TENANT_NOTIFICATION_PREFERENCE_KEYS.some((key) => typeof requested[key] === "boolean");
+  if (!hasRequestedField) {
+    return res.status(400).json({ ok: false, error: "TENANT_NOTIFICATION_PREFERENCES_INVALID" });
+  }
+
+  try {
+    const current = await loadTenantNotificationPreferences(userId);
+    const next: TenantNotificationPreferences = {
+      inApp: { ...current.inApp },
+      updatedAt: Date.now(),
+    };
+
+    for (const key of TENANT_NOTIFICATION_PREFERENCE_KEYS) {
+      if (typeof requested[key] === "boolean") {
+        next.inApp[key] = requested[key];
+      }
+    }
+
+    await db.collection("users").doc(userId).set(
+      {
+        tenantNotificationPreferences: {
+          inApp: next.inApp,
+          updatedAt: next.updatedAt,
+        },
+      },
+      { merge: true }
+    );
+
+    return res.json({ ok: true, data: next });
+  } catch (err: any) {
+    console.error("[tenant/notification-preferences:patch] failed", {
+      userId: req.user?.id,
+      message: err?.message || "failed",
+    });
+    return res.status(500).json({ ok: false, error: "TENANT_NOTIFICATION_PREFERENCES_UPDATE_FAILED" });
+  }
+});
 
 router.get("/profile", requireTenantWorkspaceIdentity, async (req: any, res) => {
   const context = await resolveWorkspaceContextOrRespond(req, res);

--- a/rentchain-frontend/src/api/tenantNotificationPreferences.ts
+++ b/rentchain-frontend/src/api/tenantNotificationPreferences.ts
@@ -1,0 +1,21 @@
+import { tenantApiFetch } from "./tenantApiFetch";
+import type { NotificationChannelPreferences } from "../pages/notificationChannelRouting";
+
+export type TenantNotificationPreferences = NotificationChannelPreferences & {
+  updatedAt: number | null;
+};
+
+export async function getTenantNotificationPreferences(): Promise<TenantNotificationPreferences> {
+  const res = await tenantApiFetch<{ ok: boolean; data: TenantNotificationPreferences }>("/tenant/notification-preferences");
+  return res.data;
+}
+
+export async function updateTenantNotificationPreferences(input: {
+  inApp: Partial<NotificationChannelPreferences["inApp"]>;
+}): Promise<TenantNotificationPreferences> {
+  const res = await tenantApiFetch<{ ok: boolean; data: TenantNotificationPreferences }>("/tenant/notification-preferences", {
+    method: "PATCH",
+    body: JSON.stringify(input),
+  });
+  return res.data;
+}

--- a/rentchain-frontend/src/pages/notificationChannelRouting.test.ts
+++ b/rentchain-frontend/src/pages/notificationChannelRouting.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_NOTIFICATION_CHANNEL_PREFERENCES,
+  filterStructuredNotificationsByPreferences,
+  resolveNotificationChannels,
+} from "./notificationChannelRouting";
+import type { StructuredNotificationItem } from "./structuredNotificationTriggers";
+
+describe("notificationChannelRouting", () => {
+  it("routes follow-up requested notifications to in-app by default", () => {
+    expect(resolveNotificationChannels({ type: "follow_up_requested" })).toMatchObject({
+      category: "follow_up_requested",
+      eligibleChannels: ["in_app"],
+      effectiveChannels: ["in_app"],
+      blockedChannels: [],
+    });
+  });
+
+  it("blocks in-app delivery when a category is muted", () => {
+    expect(
+      resolveNotificationChannels({
+        type: "documents_updated",
+        preferences: {
+          inApp: {
+            ...DEFAULT_NOTIFICATION_CHANNEL_PREFERENCES.inApp,
+            documents_updated: false,
+          },
+        },
+      })
+    ).toMatchObject({
+      category: "documents_updated",
+      effectiveChannels: [],
+      blockedChannels: ["in_app"],
+    });
+  });
+
+  it("filters structured items to the effective in-app set", () => {
+    const items: StructuredNotificationItem[] = [
+      {
+        id: "1",
+        type: "follow_up_requested",
+        title: "Follow-up requested",
+        description: "Needs attention.",
+        timestamp: 100,
+        actionRequired: true,
+        targetLink: "/tenant/application",
+      },
+      {
+        id: "2",
+        type: "documents_updated",
+        title: "Documents updated",
+        description: "Saved.",
+        timestamp: 90,
+        actionRequired: false,
+        targetLink: "/tenant/attachments",
+      },
+    ];
+
+    const result = filterStructuredNotificationsByPreferences(items, {
+      inApp: {
+        ...DEFAULT_NOTIFICATION_CHANNEL_PREFERENCES.inApp,
+        documents_updated: false,
+      },
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe("1");
+  });
+});

--- a/rentchain-frontend/src/pages/notificationChannelRouting.ts
+++ b/rentchain-frontend/src/pages/notificationChannelRouting.ts
@@ -1,0 +1,131 @@
+import type { StructuredNotificationItem, StructuredNotificationTriggerType } from "./structuredNotificationTriggers";
+
+export type NotificationPreferenceCategory =
+  | "follow_up_requested"
+  | "ready_for_rereview"
+  | "application_updated"
+  | "access_changed"
+  | "documents_updated";
+
+export type NotificationChannel = "in_app";
+
+export type NotificationChannelPreferences = {
+  inApp: Record<NotificationPreferenceCategory, boolean>;
+};
+
+export type NotificationRoutingDecision = {
+  category: NotificationPreferenceCategory;
+  eligibleChannels: NotificationChannel[];
+  effectiveChannels: NotificationChannel[];
+  blockedChannels: NotificationChannel[];
+};
+
+export const NOTIFICATION_PREFERENCE_CATEGORIES: Array<{
+  key: NotificationPreferenceCategory;
+  label: string;
+  description: string;
+}> = [
+  {
+    key: "follow_up_requested",
+    label: "Follow-up requested",
+    description: "Important updates when your application still needs attention.",
+  },
+  {
+    key: "ready_for_rereview",
+    label: "Ready for re-review",
+    description: "Updates when requested follow-up now appears ready to review again.",
+  },
+  {
+    key: "application_updated",
+    label: "Application updated",
+    description: "Progress updates for readiness and other application changes.",
+  },
+  {
+    key: "access_changed",
+    label: "Access updated",
+    description: "Changes to supported access and sharing activity.",
+  },
+  {
+    key: "documents_updated",
+    label: "Documents updated",
+    description: "Changes in your tenant document workspace.",
+  },
+];
+
+export const DEFAULT_NOTIFICATION_CHANNEL_PREFERENCES: NotificationChannelPreferences = {
+  inApp: {
+    follow_up_requested: true,
+    ready_for_rereview: true,
+    application_updated: true,
+    access_changed: true,
+    documents_updated: true,
+  },
+};
+
+export function getNotificationPreferenceCategory(
+  type: StructuredNotificationTriggerType
+): NotificationPreferenceCategory {
+  switch (type) {
+    case "follow_up_requested":
+      return "follow_up_requested";
+    case "ready_for_rereview":
+      return "ready_for_rereview";
+    case "access_changed":
+      return "access_changed";
+    case "documents_updated":
+      return "documents_updated";
+    case "follow_up_addressed":
+    case "readiness_improved":
+    default:
+      return "application_updated";
+  }
+}
+
+export function normalizeNotificationChannelPreferences(
+  input: Partial<NotificationChannelPreferences> | null | undefined
+): NotificationChannelPreferences {
+  const next: NotificationChannelPreferences = {
+    inApp: { ...DEFAULT_NOTIFICATION_CHANNEL_PREFERENCES.inApp },
+  };
+
+  if (!input?.inApp) {
+    return next;
+  }
+
+  for (const category of NOTIFICATION_PREFERENCE_CATEGORIES) {
+    if (typeof input.inApp[category.key] === "boolean") {
+      next.inApp[category.key] = input.inApp[category.key];
+    }
+  }
+
+  return next;
+}
+
+export function resolveNotificationChannels(params: {
+  type: StructuredNotificationTriggerType;
+  preferences?: Partial<NotificationChannelPreferences> | null;
+  supportedChannels?: NotificationChannel[];
+}): NotificationRoutingDecision {
+  const category = getNotificationPreferenceCategory(params.type);
+  const supportedChannels = params.supportedChannels?.length ? params.supportedChannels : ["in_app"];
+  const normalized = normalizeNotificationChannelPreferences(params.preferences);
+  const eligibleChannels = supportedChannels.filter((channel): channel is NotificationChannel => channel === "in_app");
+  const effectiveChannels = eligibleChannels.filter((channel) => {
+    if (channel === "in_app") return normalized.inApp[category];
+    return false;
+  });
+
+  return {
+    category,
+    eligibleChannels,
+    effectiveChannels,
+    blockedChannels: eligibleChannels.filter((channel) => !effectiveChannels.includes(channel)),
+  };
+}
+
+export function filterStructuredNotificationsByPreferences(
+  items: StructuredNotificationItem[],
+  preferences?: Partial<NotificationChannelPreferences> | null
+): StructuredNotificationItem[] {
+  return items.filter((item) => resolveNotificationChannels({ type: item.type, preferences }).effectiveChannels.includes("in_app"));
+}

--- a/rentchain-frontend/src/pages/tenant/TenantAccountPage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantAccountPage.test.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import TenantAccountPage from "./TenantAccountPage";
+
+const tenantApiFetchApi = vi.hoisted(() => ({
+  tenantApiFetch: vi.fn(),
+}));
+
+const tenantNotificationPreferencesApi = vi.hoisted(() => ({
+  getTenantNotificationPreferences: vi.fn(),
+  updateTenantNotificationPreferences: vi.fn(),
+}));
+
+vi.mock("../../api/tenantApiFetch", () => tenantApiFetchApi);
+vi.mock("../../api/tenantNotificationPreferences", () => tenantNotificationPreferencesApi);
+vi.mock("../../lib/logoutTenant", () => ({
+  logoutTenant: vi.fn(),
+}));
+
+describe("TenantAccountPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tenantApiFetchApi.tenantApiFetch.mockResolvedValue({
+      ok: true,
+      data: {
+        tenant: {
+          shortId: "tenant-1",
+          email: "tenant@example.com",
+        },
+      },
+    });
+    tenantNotificationPreferencesApi.getTenantNotificationPreferences.mockResolvedValue({
+      inApp: {
+        follow_up_requested: true,
+        ready_for_rereview: true,
+        application_updated: true,
+        access_changed: true,
+        documents_updated: true,
+      },
+      updatedAt: 1710000000000,
+    });
+    tenantNotificationPreferencesApi.updateTenantNotificationPreferences.mockResolvedValue({
+      inApp: {
+        follow_up_requested: true,
+        ready_for_rereview: true,
+        application_updated: true,
+        access_changed: true,
+        documents_updated: false,
+      },
+      updatedAt: 1711000000000,
+    });
+  });
+
+  it("renders notification preferences with supported channels only", async () => {
+    render(
+      <MemoryRouter>
+        <TenantAccountPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Notification preferences/i)).toBeInTheDocument();
+    expect(screen.getByText(/Supported channels:/i)).toBeInTheDocument();
+    expect(screen.getByText(/In-app notifications/i)).toBeInTheDocument();
+    expect(screen.getByText(/Email updates are not enabled/i)).toBeInTheDocument();
+  });
+
+  it("saves updated in-app preferences", async () => {
+    render(
+      <MemoryRouter>
+        <TenantAccountPage />
+      </MemoryRouter>
+    );
+
+    const documentsToggle = await screen.findByRole("checkbox", { name: /Documents updated/i });
+    fireEvent.click(documentsToggle);
+    fireEvent.click(screen.getAllByRole("button", { name: /Save preferences/i })[0]);
+
+    await waitFor(() => {
+      expect(tenantNotificationPreferencesApi.updateTenantNotificationPreferences).toHaveBeenCalledWith({
+        inApp: expect.objectContaining({
+          documents_updated: false,
+        }),
+      });
+    });
+    expect(await screen.findByText(/Preferences saved\./i)).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/tenant/TenantAccountPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantAccountPage.tsx
@@ -1,9 +1,19 @@
 import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { tenantApiFetch } from "../../api/tenantApiFetch";
+import {
+  getTenantNotificationPreferences,
+  updateTenantNotificationPreferences,
+  type TenantNotificationPreferences,
+} from "../../api/tenantNotificationPreferences";
 import { Card } from "../../components/ui/Ui";
 import { logoutTenant } from "../../lib/logoutTenant";
 import { colors, spacing, text as textTokens } from "../../styles/tokens";
+import {
+  DEFAULT_NOTIFICATION_CHANNEL_PREFERENCES,
+  NOTIFICATION_PREFERENCE_CATEGORIES,
+  normalizeNotificationChannelPreferences,
+} from "../notificationChannelRouting";
 
 type TenantMeResponse = {
   ok: boolean;
@@ -29,8 +39,13 @@ const sectionTitleStyle: React.CSSProperties = {
 
 export default function TenantAccountPage() {
   const [data, setData] = useState<TenantMeResponse["data"] | null>(null);
+  const [preferences, setPreferences] = useState<TenantNotificationPreferences | null>(null);
+  const [draftPreferences, setDraftPreferences] = useState(DEFAULT_NOTIFICATION_CHANNEL_PREFERENCES);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [preferencesLoading, setPreferencesLoading] = useState(true);
+  const [preferencesError, setPreferencesError] = useState<string | null>(null);
+  const [saveState, setSaveState] = useState<"idle" | "saving" | "saved" | "error">("idle");
 
   useEffect(() => {
     let cancelled = false;
@@ -51,6 +66,51 @@ export default function TenantAccountPage() {
       cancelled = true;
     };
   }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const loadPreferences = async () => {
+      setPreferencesLoading(true);
+      setPreferencesError(null);
+      try {
+        const next = await getTenantNotificationPreferences();
+        if (!cancelled) {
+          setPreferences(next);
+          setDraftPreferences(normalizeNotificationChannelPreferences(next));
+        }
+      } catch (err: any) {
+        if (!cancelled) {
+          setPreferences(null);
+          setDraftPreferences(normalizeNotificationChannelPreferences(null));
+          setPreferencesError(err?.message || "Unable to load notification preferences.");
+        }
+      } finally {
+        if (!cancelled) {
+          setPreferencesLoading(false);
+        }
+      }
+    };
+    void loadPreferences();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const hasPreferenceChanges = JSON.stringify(draftPreferences) !== JSON.stringify(normalizeNotificationChannelPreferences(preferences));
+
+  async function savePreferences() {
+    setSaveState("saving");
+    setPreferencesError(null);
+    try {
+      const next = await updateTenantNotificationPreferences({ inApp: draftPreferences.inApp });
+      setPreferences(next);
+      setDraftPreferences(normalizeNotificationChannelPreferences(next));
+      setSaveState("saved");
+    } catch (err: any) {
+      setSaveState("error");
+      setPreferencesError(err?.message || "Unable to save notification preferences.");
+    }
+  }
 
   return (
     <Card elevated style={{ padding: spacing.lg, display: "grid", gap: spacing.md }}>
@@ -119,9 +179,86 @@ export default function TenantAccountPage() {
           </section>
 
           <section>
-            <div style={sectionTitleStyle}>Coming soon</div>
-            <div style={{ color: textTokens.muted }}>
-              Notification preferences and contact preferences will appear here.
+            <div style={sectionTitleStyle}>Notification preferences</div>
+            <div style={{ color: textTokens.muted, marginBottom: spacing.sm }}>
+              Choose which important workflow updates should appear in your in-app notification views.
+            </div>
+            <div
+              style={{
+                border: `1px solid ${colors.border}`,
+                borderRadius: 12,
+                padding: spacing.md,
+                display: "grid",
+                gap: spacing.sm,
+                background: colors.panel,
+              }}
+            >
+              <div style={{ color: textTokens.muted }}>
+                Supported channels: <strong style={{ color: textTokens.primary }}>In-app notifications</strong>
+              </div>
+              <div style={{ color: textTokens.muted }}>
+                Email updates are not enabled in this workspace yet, so this version only shows channels that currently exist.
+              </div>
+              {preferencesError ? <div style={{ color: colors.danger }}>{preferencesError}</div> : null}
+              {preferencesLoading ? (
+                <div style={{ color: textTokens.muted }}>Loading notification preferences…</div>
+              ) : (
+                <>
+                  {NOTIFICATION_PREFERENCE_CATEGORIES.map((item) => (
+                    <label
+                      key={item.key}
+                      style={{
+                        display: "grid",
+                        gap: 4,
+                        border: `1px solid ${colors.border}`,
+                        borderRadius: 12,
+                        padding: spacing.sm,
+                        background: colors.card,
+                        cursor: "pointer",
+                      }}
+                    >
+                      <span style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                        <input
+                          type="checkbox"
+                          checked={draftPreferences.inApp[item.key]}
+                          onChange={(event) => {
+                            setDraftPreferences((current) => ({
+                              inApp: {
+                                ...current.inApp,
+                                [item.key]: event.target.checked,
+                              },
+                            }));
+                            setSaveState("idle");
+                          }}
+                        />
+                        <span style={{ fontWeight: 700, color: textTokens.primary }}>{item.label}</span>
+                      </span>
+                      <span style={{ color: textTokens.muted, paddingLeft: 30 }}>{item.description}</span>
+                    </label>
+                  ))}
+                  <div style={{ display: "flex", alignItems: "center", gap: spacing.sm, flexWrap: "wrap" }}>
+                    <button
+                      type="button"
+                      onClick={() => void savePreferences()}
+                      disabled={!hasPreferenceChanges || saveState === "saving"}
+                      style={{
+                        border: `1px solid ${colors.border}`,
+                        borderRadius: 10,
+                        background: hasPreferenceChanges ? colors.card : colors.panel,
+                        color: textTokens.primary,
+                        padding: "8px 12px",
+                        cursor: hasPreferenceChanges && saveState !== "saving" ? "pointer" : "default",
+                        fontWeight: 600,
+                      }}
+                    >
+                      {saveState === "saving" ? "Saving…" : "Save preferences"}
+                    </button>
+                    {saveState === "saved" ? (
+                      <div style={{ color: "#166534", fontWeight: 600 }}>Preferences saved.</div>
+                    ) : null}
+                  </div>
+                </>
+              )}
             </div>
           </section>
         </>

--- a/rentchain-frontend/src/pages/tenant/TenantApplicationCompletionPage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantApplicationCompletionPage.test.tsx
@@ -20,10 +20,15 @@ const tenantAccessApi = vi.hoisted(() => ({
   getTenantAccess: vi.fn(),
 }));
 
+const tenantNotificationPreferencesApi = vi.hoisted(() => ({
+  getTenantNotificationPreferences: vi.fn(),
+}));
+
 vi.mock("../../api/tenantApplicationCompletion", () => tenantApplicationCompletionApi);
 vi.mock("../../api/tenantProfile", () => tenantProfileApi);
 vi.mock("../../api/tenantAttachmentsApi", () => tenantAttachmentsApi);
 vi.mock("../../api/tenantAccess", () => tenantAccessApi);
+vi.mock("../../api/tenantNotificationPreferences", () => tenantNotificationPreferencesApi);
 
 describe("tenant application completion page", () => {
   beforeEach(() => {
@@ -120,6 +125,16 @@ describe("tenant application completion page", () => {
         headline: "You can review and manage the access you’ve already shared.",
         body: "This view shows tenant-safe sharing records only.",
       },
+    });
+    tenantNotificationPreferencesApi.getTenantNotificationPreferences.mockResolvedValue({
+      inApp: {
+        follow_up_requested: true,
+        ready_for_rereview: true,
+        application_updated: true,
+        access_changed: true,
+        documents_updated: true,
+      },
+      updatedAt: 1710000000000,
     });
   });
 
@@ -221,5 +236,35 @@ describe("tenant application completion page", () => {
 
     expect(await screen.findByText(/We couldn't load this view/i)).toBeInTheDocument();
     expect(screen.getByText(/Unable to load application completion/i)).toBeInTheDocument();
+  });
+
+  it("respects muted document update notifications", async () => {
+    tenantNotificationPreferencesApi.getTenantNotificationPreferences.mockResolvedValue({
+      inApp: {
+        follow_up_requested: true,
+        ready_for_rereview: true,
+        application_updated: true,
+        access_changed: true,
+        documents_updated: false,
+      },
+      updatedAt: 1710000000000,
+    });
+    tenantApplicationCompletionApi.getTenantApplicationCompletion.mockResolvedValue({
+      status: "in_progress",
+      progressPercent: 40,
+      sections: [],
+      nextSteps: [],
+      updatedAt: "2026-01-02T00:00:00.000Z",
+    });
+
+    render(
+      <MemoryRouter>
+        <TenantApplicationStatusPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Recent workflow updates/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^Documents updated$/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/^Access changed$/i)).toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/pages/tenant/TenantApplicationStatusPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantApplicationStatusPage.tsx
@@ -5,6 +5,7 @@ import {
   type TenantApplicationCompletionItem,
   type TenantApplicationCompletionStatus,
 } from "../../api/tenantApplicationCompletion";
+import { getTenantNotificationPreferences } from "../../api/tenantNotificationPreferences";
 import { getTenantAccess } from "../../api/tenantAccess";
 import { getTenantAttachments } from "../../api/tenantAttachmentsApi";
 import { getTenantProfile } from "../../api/tenantProfile";
@@ -25,6 +26,7 @@ import { buildTenantLandlordInteractionLoop } from "../tenantLandlordInteraction
 import { buildFollowUpResolutionState } from "../followUpResolutionState";
 import StructuredNotificationList from "../StructuredNotificationList";
 import { buildTenantStructuredNotificationTriggers } from "../structuredNotificationTriggers";
+import { filterStructuredNotificationsByPreferences } from "../notificationChannelRouting";
 
 function statusTone(status: TenantApplicationCompletionStatus) {
   switch (status) {
@@ -147,6 +149,7 @@ export default function TenantApplicationStatusPage() {
   const [profile, setProfile] = React.useState<Awaited<ReturnType<typeof getTenantProfile>> | null>(null);
   const [attachments, setAttachments] = React.useState<Awaited<ReturnType<typeof getTenantAttachments>> | null>(null);
   const [access, setAccess] = React.useState<Awaited<ReturnType<typeof getTenantAccess>> | null>(null);
+  const [notificationPreferences, setNotificationPreferences] = React.useState<Awaited<ReturnType<typeof getTenantNotificationPreferences>> | null>(null);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
 
@@ -154,11 +157,12 @@ export default function TenantApplicationStatusPage() {
     setLoading(true);
     setError(null);
     try {
-      const [completionResult, profileResult, attachmentsResult, accessResult] = await Promise.allSettled([
+      const [completionResult, profileResult, attachmentsResult, accessResult, preferencesResult] = await Promise.allSettled([
         getTenantApplicationCompletion(),
         getTenantProfile(),
         getTenantAttachments(),
         getTenantAccess(),
+        getTenantNotificationPreferences(),
       ]);
       if (completionResult.status !== "fulfilled") {
         throw completionResult.reason;
@@ -167,11 +171,13 @@ export default function TenantApplicationStatusPage() {
       setProfile(profileResult.status === "fulfilled" ? profileResult.value : null);
       setAttachments(attachmentsResult.status === "fulfilled" ? attachmentsResult.value : null);
       setAccess(accessResult.status === "fulfilled" ? accessResult.value : null);
+      setNotificationPreferences(preferencesResult.status === "fulfilled" ? preferencesResult.value : null);
     } catch (err: any) {
       setData(null);
       setProfile(null);
       setAttachments(null);
       setAccess(null);
+      setNotificationPreferences(null);
       setError(err?.payload?.error || err?.message || "Unable to load application completion.");
     } finally {
       setLoading(false);
@@ -235,13 +241,16 @@ export default function TenantApplicationStatusPage() {
     packageCategories: reuse.packageCategories,
   });
   const resolutionView = buildFollowUpResolutionState(reuse.packageCategories);
-  const notificationItems = buildTenantStructuredNotificationTriggers({
-    packageCategories: reuse.packageCategories,
-    completion: data,
-    profile,
-    attachments,
-    access,
-  });
+  const notificationItems = filterStructuredNotificationsByPreferences(
+    buildTenantStructuredNotificationTriggers({
+      packageCategories: reuse.packageCategories,
+      completion: data,
+      profile,
+      attachments,
+      access,
+    }),
+    notificationPreferences
+  );
   const flowTone =
     flow.state === "ready_to_proceed"
       ? { color: "#166534", background: "#dcfce7", label: "Ready to proceed" }

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -32,6 +32,10 @@ const tenantProfileApi = vi.hoisted(() => ({
   getTenantProfile: vi.fn(),
 }));
 
+const tenantNotificationPreferencesApi = vi.hoisted(() => ({
+  getTenantNotificationPreferences: vi.fn(),
+}));
+
 const maintenanceWorkflowApi = vi.hoisted(() => ({
   listTenantMaintenance: vi.fn(),
 }));
@@ -45,6 +49,7 @@ vi.mock("../../api/tenantApplicationCompletion", () => tenantApplicationCompleti
 vi.mock("../../api/tenantAccess", () => tenantAccessApi);
 vi.mock("../../api/tenantAttachmentsApi", () => tenantAttachmentsApi);
 vi.mock("../../api/tenantProfile", () => tenantProfileApi);
+vi.mock("../../api/tenantNotificationPreferences", () => tenantNotificationPreferencesApi);
 vi.mock("../../api/tenantCommunicationsApi", () => tenantCommunicationsApi);
 vi.mock("../../api/maintenanceWorkflowApi", async () => {
   const actual = await vi.importActual<any>("../../api/maintenanceWorkflowApi");
@@ -202,6 +207,16 @@ describe("tenant workspace frontend shell", () => {
         },
       },
     });
+    tenantNotificationPreferencesApi.getTenantNotificationPreferences.mockResolvedValue({
+      inApp: {
+        follow_up_requested: true,
+        ready_for_rereview: true,
+        application_updated: true,
+        access_changed: true,
+        documents_updated: true,
+      },
+      updatedAt: 1710000000000,
+    });
   });
 
   it("tenant shell renders expected navigation safely", async () => {
@@ -295,6 +310,29 @@ describe("tenant workspace frontend shell", () => {
     expect(screen.getByText(/Documents updated/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Open document vault/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Open access/i })).toBeInTheDocument();
+  });
+
+  it("filters muted in-app document notifications from tenant views", async () => {
+    tenantNotificationPreferencesApi.getTenantNotificationPreferences.mockResolvedValue({
+      inApp: {
+        follow_up_requested: true,
+        ready_for_rereview: true,
+        application_updated: true,
+        access_changed: true,
+        documents_updated: false,
+      },
+      updatedAt: 1710000000000,
+    });
+
+    render(
+      <MemoryRouter>
+        <TenantWorkspacePage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Recent workflow updates/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^Documents updated$/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/^Access changed$/i)).toBeInTheDocument();
   });
 
   it("renders application completion page with safe grouped checklist fields", async () => {

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
@@ -5,6 +5,7 @@ import { getTenantAccess, type TenantAccessWorkspace } from "../../api/tenantAcc
 import { getTenantAttachments } from "../../api/tenantAttachmentsApi";
 import { getTenantProfile } from "../../api/tenantProfile";
 import { getTenantApplicationCompletion } from "../../api/tenantApplicationCompletion";
+import { getTenantNotificationPreferences } from "../../api/tenantNotificationPreferences";
 import {
   TenantEmptyState,
   TenantErrorState,
@@ -24,6 +25,7 @@ import { buildTenantDocumentVaultView } from "./tenantDocumentVault";
 import { buildTenantApplicationReuseView } from "./tenantApplicationReuse";
 import StructuredNotificationList from "../StructuredNotificationList";
 import { buildTenantStructuredNotificationTriggers } from "../structuredNotificationTriggers";
+import { filterStructuredNotificationsByPreferences } from "../notificationChannelRouting";
 
 export default function TenantWorkspacePage() {
   const [data, setData] = React.useState<Awaited<ReturnType<typeof getTenantWorkspace>> | null>(null);
@@ -31,6 +33,7 @@ export default function TenantWorkspacePage() {
   const [attachments, setAttachments] = React.useState<Awaited<ReturnType<typeof getTenantAttachments>> | null>(null);
   const [profileData, setProfileData] = React.useState<Awaited<ReturnType<typeof getTenantProfile>> | null>(null);
   const [completion, setCompletion] = React.useState<Awaited<ReturnType<typeof getTenantApplicationCompletion>> | null>(null);
+  const [notificationPreferences, setNotificationPreferences] = React.useState<Awaited<ReturnType<typeof getTenantNotificationPreferences>> | null>(null);
   const [profileLoading, setProfileLoading] = React.useState(true);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
@@ -39,11 +42,12 @@ export default function TenantWorkspacePage() {
     setLoading(true);
     setError(null);
     try {
-      const [workspaceResult, accessResult, attachmentsResult, completionResult] = await Promise.allSettled([
+      const [workspaceResult, accessResult, attachmentsResult, completionResult, preferencesResult] = await Promise.allSettled([
         getTenantWorkspace(),
         getTenantAccess(),
         getTenantAttachments(),
         getTenantApplicationCompletion(),
+        getTenantNotificationPreferences(),
       ]);
 
       if (workspaceResult.status === "rejected") {
@@ -54,11 +58,13 @@ export default function TenantWorkspacePage() {
       setAccess(accessResult.status === "fulfilled" ? accessResult.value : null);
       setAttachments(attachmentsResult.status === "fulfilled" ? attachmentsResult.value : null);
       setCompletion(completionResult.status === "fulfilled" ? completionResult.value : null);
+      setNotificationPreferences(preferencesResult.status === "fulfilled" ? preferencesResult.value : null);
     } catch (err: any) {
       setData(null);
       setAccess(null);
       setAttachments(null);
       setCompletion(null);
+      setNotificationPreferences(null);
       setError(err?.payload?.error || err?.message || "Unable to load your tenant workspace.");
     } finally {
       setLoading(false);
@@ -134,13 +140,16 @@ export default function TenantWorkspacePage() {
     attachments,
     access,
   });
-  const notificationItems = buildTenantStructuredNotificationTriggers({
-    packageCategories: reuse.packageCategories,
-    completion,
-    profile: profileData,
-    attachments,
-    access,
-  });
+  const notificationItems = filterStructuredNotificationsByPreferences(
+    buildTenantStructuredNotificationTriggers({
+      packageCategories: reuse.packageCategories,
+      completion,
+      profile: profileData,
+      attachments,
+      access,
+    }),
+    notificationPreferences
+  );
 
   return (
     <TenantSurfaceShell


### PR DESCRIPTION
## Summary
Adds v1 notification preferences and channel routing for structured workflow notifications.

This PR introduces a small tenant-facing preferences model for supported workflow updates, a shared deterministic routing helper, and wiring so tenant in-app notification surfaces respect saved preferences.

## Scope
- tenant notification preferences UI
- shared channel-routing helper
- tenant portal preference read/write API
- preference-aware filtering on tenant notification surfaces
- focused frontend and backend tests

## Implementation notes
- V1 is intentionally in-app only
- No email option is exposed because there is no narrow existing workflow email delivery path that fits safely within scope
- Preferences are stored server-side on the authenticated user record
- Supported categories:
  - follow-up requested
  - ready for re-review
  - application updated
  - access changed
  - documents updated

## Validation
- Targeted frontend tests passed
- Targeted backend tests passed
- Frontend build passed
- Backend build passed

## Limitations
- Tenant-only preferences surface in this PR
- No email, push, or SMS delivery
- No unread-count overhaul or broader notification platform changes