### PR TITLE
feat(landlord): add decision workspace v1

### DIFF
--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
@@ -122,6 +122,7 @@ describe("ApplicationReviewSummaryPage", () => {
     expect(await screen.findByText("Application Review Summary")).toBeInTheDocument();
     expect(await screen.findByText("Intake Summary")).toBeInTheDocument();
     expect(await screen.findByText("Follow-up resolution")).toBeInTheDocument();
+    expect((await screen.findAllByText("Decision workspace")).length).toBeGreaterThan(0);
     expect(await screen.findByText("Shared package categories")).toBeInTheDocument();
     expect(await screen.findByText("Recent activity")).toBeInTheDocument();
     expect(screen.getAllByText("Profile details").length).toBeGreaterThan(0);
@@ -131,11 +132,15 @@ describe("ApplicationReviewSummaryPage", () => {
     expect(screen.getAllByText("Application readiness").length).toBeGreaterThan(0);
     expect((await screen.findAllByText("Partly addressed")).length).toBeGreaterThan(0);
     expect(await screen.findByText("Application readiness updated")).toBeInTheDocument();
-    expect(await screen.findByText("Next steps")).toBeInTheDocument();
+    expect((await screen.findAllByText("Next steps")).length).toBeGreaterThan(0);
     expect(await screen.findByText("Structured follow-up loop")).toBeInTheDocument();
     expect(screen.getAllByText(/Review the addressed categories now visible/i).length).toBeGreaterThan(0);
     expect(await screen.findByText("Still needs follow-up")).toBeInTheDocument();
     expect(await screen.findByText("Now appears addressed")).toBeInTheDocument();
+    expect(await screen.findByText("Decision status")).toBeInTheDocument();
+    expect(await screen.findByText("What is still missing")).toBeInTheDocument();
+    expect(await screen.findByText(/This application is not ready for a landlord next-step decision yet/i)).toBeInTheDocument();
+    expect(screen.getAllByText("Needs follow-up").length).toBeGreaterThan(0);
     expect(await screen.findByText("Recent updates")).toBeInTheDocument();
     expect(await screen.findByText(/Tenant updated follow-up items/i)).toBeInTheDocument();
     expect(await screen.findByText(/Follow-up stays organized by aligned package categories/i)).toBeInTheDocument();
@@ -143,5 +148,153 @@ describe("ApplicationReviewSummaryPage", () => {
     expect(await screen.findByText("Jane Applicant")).toBeInTheDocument();
     expect(await screen.findByText("Landlord Decision Panel")).toBeInTheDocument();
     expect(await screen.findByText("Identity verification completed")).toBeInTheDocument();
+  });
+
+  it("shows ready for decision when follow-up is resolved and review signals are organized", async () => {
+    const { useEntitlements } = await import("@/hooks/useEntitlements");
+    const { fetchReviewSummary } = await import("../api/reviewSummaryApi");
+
+    vi.mocked(useEntitlements).mockReturnValue({
+      canViewReviewSummary: true,
+      canExportPdf: true,
+    } as any);
+    vi.mocked(fetchReviewSummary).mockResolvedValue({
+      applicationId: "app-1",
+      generatedAt: "2026-04-01T00:00:00.000Z",
+      applicant: {
+        name: "Jordan Applicant",
+        email: "jordan@example.com",
+        currentAddressLine: "12 Main St",
+        city: "Halifax",
+        provinceState: "NS",
+        postalCode: "B3H1A1",
+        country: "CA",
+        timeAtCurrentAddressMonths: 24,
+        currentRentAmountCents: 180000,
+      },
+      employment: {
+        employerName: "Acme",
+        jobTitle: "Manager",
+        incomeAmountCents: 7200000,
+        incomeFrequency: "annual",
+        incomeMonthlyCents: 600000,
+        monthsAtJob: 36,
+      },
+      reference: { name: "Sam Ref", phone: "555-0100" },
+      compliance: {
+        applicationConsentAcceptedAt: "2026-03-29T00:00:00.000Z",
+        applicationConsentVersion: "v1",
+        signatureType: "electronic",
+        signedAt: "2026-03-29T00:00:00.000Z",
+      },
+      screening: { status: "complete", provider: "transunion", referenceId: "TU-2" },
+      derived: { incomeToRentRatio: 3.2, completeness: { score: 0.92, label: "High" }, flags: [] },
+      insights: [],
+      decisionSummary: {
+        applicationId: "app-1",
+        screeningRecommendation: {
+          recommended: false,
+          reason: "Already complete.",
+          priority: "low",
+        },
+        screeningSummary: {
+          available: true,
+          provider: "transunion",
+          completedAt: "2026-04-01T00:00:00.000Z",
+          highlights: [],
+        },
+        riskSnapshot: {
+          version: "risk-v1",
+          status: "completed",
+          score: 78,
+          grade: "B",
+          confidence: 0.88,
+          factors: [],
+          flags: [],
+          recommendations: [],
+          updatedAt: "2026-04-01T00:00:00.000Z",
+        },
+      },
+    } as any);
+
+    renderPage();
+
+    expect((await screen.findAllByText("Decision workspace")).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText("Ready for decision")).length).toBeGreaterThan(0);
+    expect(await screen.findByText(/No decision blockers are currently surfaced/i)).toBeInTheDocument();
+  });
+
+  it("shows hold for later when follow-up is resolved but review signals still need work", async () => {
+    const { useEntitlements } = await import("@/hooks/useEntitlements");
+    const { fetchReviewSummary } = await import("../api/reviewSummaryApi");
+
+    vi.mocked(useEntitlements).mockReturnValue({
+      canViewReviewSummary: true,
+      canExportPdf: true,
+    } as any);
+    vi.mocked(fetchReviewSummary).mockResolvedValue({
+      applicationId: "app-1",
+      generatedAt: "2026-04-01T00:00:00.000Z",
+      applicant: {
+        name: "Morgan Applicant",
+        email: "morgan@example.com",
+        currentAddressLine: "45 Harbour St",
+        city: "Halifax",
+        provinceState: "NS",
+        postalCode: "B3H2B2",
+        country: "CA",
+        timeAtCurrentAddressMonths: 18,
+        currentRentAmountCents: 160000,
+      },
+      employment: {
+        employerName: "Acme",
+        jobTitle: "Coordinator",
+        incomeAmountCents: 5400000,
+        incomeFrequency: "annual",
+        incomeMonthlyCents: 450000,
+        monthsAtJob: 8,
+      },
+      reference: { name: "Pat Ref", phone: "555-0101" },
+      compliance: {
+        applicationConsentAcceptedAt: "2026-03-29T00:00:00.000Z",
+        applicationConsentVersion: "v1",
+        signatureType: "electronic",
+        signedAt: "2026-03-29T00:00:00.000Z",
+      },
+      screening: { status: "not_run", provider: null, referenceId: null },
+      derived: { incomeToRentRatio: 2.1, completeness: { score: 0.68, label: "Medium" }, flags: ["MISSING_EMPLOYER_NAME"] },
+      insights: [],
+      decisionSummary: {
+        applicationId: "app-1",
+        screeningRecommendation: {
+          recommended: true,
+          reason: "Still recommended.",
+          priority: "high",
+        },
+        screeningSummary: {
+          available: false,
+          provider: null,
+          completedAt: null,
+          highlights: [],
+        },
+        riskSnapshot: {
+          version: "risk-v1",
+          status: "completed",
+          score: 61,
+          grade: "C",
+          confidence: 0.71,
+          factors: [],
+          flags: [],
+          recommendations: [],
+          updatedAt: "2026-04-01T00:00:00.000Z",
+        },
+      },
+    } as any);
+
+    renderPage();
+
+    expect((await screen.findAllByText("Decision workspace")).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText("Hold for later")).length).toBeGreaterThan(0);
+    expect(await screen.findByText(/Screening is still recommended before moving this file/i)).toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
@@ -22,6 +22,7 @@ import { buildLandlordReviewGuidance } from "./landlordReviewGuidance";
 import { buildTenantLandlordInteractionLoop } from "./tenantLandlordInteractionLoop";
 import { buildLandlordStructuredActivityTimeline } from "./structuredActivityTimeline";
 import { buildFollowUpResolutionState } from "./followUpResolutionState";
+import { buildLandlordDecisionWorkspace } from "./landlordDecisionWorkspace";
 import StructuredNotificationList from "./StructuredNotificationList";
 import { buildLandlordStructuredNotificationTriggers } from "./structuredNotificationTriggers";
 
@@ -74,6 +75,16 @@ function followUpTone(state: "follow_up_needed" | "partly_addressed" | "ready_fo
     return { color: "#1d4ed8", background: "#dbeafe", label: "Partly addressed" };
   }
   return { color: "#9a3412", background: "#ffedd5", label: "Follow-up needed" };
+}
+
+function decisionTone(state: "needs_follow_up" | "hold_for_later" | "ready_for_decision") {
+  if (state === "ready_for_decision") {
+    return { color: "#166534", background: "#dcfce7", label: "Ready for decision" };
+  }
+  if (state === "hold_for_later") {
+    return { color: "#1d4ed8", background: "#dbeafe", label: "Hold for later" };
+  }
+  return { color: "#9a3412", background: "#ffedd5", label: "Needs follow-up" };
 }
 
 type SummaryLoadError = {
@@ -261,6 +272,16 @@ function ApplicationReviewSummaryPageBody() {
       summary && intakeView
         ? buildLandlordStructuredNotificationTriggers(summary, intakeView.packageCategories)
         : [],
+    [summary, intakeView]
+  );
+  const decisionWorkspace = useMemo(
+    () =>
+      summary && intakeView
+        ? buildLandlordDecisionWorkspace({
+            summary,
+            packageCategories: intakeView.packageCategories,
+          })
+        : null,
     [summary, intakeView]
   );
 
@@ -590,6 +611,91 @@ function ApplicationReviewSummaryPageBody() {
                     {step}
                   </div>
                 ))}
+              </div>
+            </Card>
+          ) : null}
+
+          {decisionWorkspace ? (
+            <Card style={{ display: "grid", gap: 10 }}>
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+                <div>
+                  <div style={{ fontWeight: 700 }}>Decision workspace</div>
+                  <div style={{ fontSize: 13, color: text.subtle, marginTop: 4 }}>
+                    {decisionWorkspace.explanation}
+                  </div>
+                </div>
+                <div
+                  style={{
+                    padding: "6px 10px",
+                    borderRadius: 999,
+                    fontWeight: 700,
+                    color: decisionTone(decisionWorkspace.decisionState).color,
+                    background: decisionTone(decisionWorkspace.decisionState).background,
+                  }}
+                >
+                  {decisionTone(decisionWorkspace.decisionState).label}
+                </div>
+              </div>
+
+              <div
+                style={{
+                  border: `1px solid ${colors.border}`,
+                  borderRadius: 10,
+                  padding: 10,
+                  display: "grid",
+                  gap: 6,
+                }}
+              >
+                <div style={{ fontWeight: 700, color: text.main }}>Decision status</div>
+                <div style={{ fontSize: 13, color: text.subtle }}>
+                  {decisionWorkspace.statusLabel}
+                </div>
+              </div>
+
+              <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))", gap: 8 }}>
+                <div
+                  style={{
+                    border: `1px solid ${colors.border}`,
+                    borderRadius: 10,
+                    padding: 10,
+                    display: "grid",
+                    gap: 6,
+                  }}
+                >
+                  <div style={{ fontWeight: 700, color: text.main }}>What is still missing</div>
+                  {decisionWorkspace.blockers.length ? (
+                    decisionWorkspace.blockers.map((item) => (
+                      <div key={item} style={{ fontSize: 13, color: text.subtle }}>
+                        {item}
+                      </div>
+                    ))
+                  ) : (
+                    <div style={{ fontSize: 13, color: text.subtle }}>
+                      No decision blockers are currently surfaced in this read-first workspace.
+                    </div>
+                  )}
+                </div>
+
+                <div
+                  style={{
+                    border: `1px solid ${colors.border}`,
+                    borderRadius: 10,
+                    padding: 10,
+                    display: "grid",
+                    gap: 6,
+                  }}
+                >
+                  <div style={{ fontWeight: 700, color: text.main }}>Next steps</div>
+                  {decisionWorkspace.nextSteps.map((step) => (
+                    <div key={step} style={{ fontSize: 13, color: text.subtle }}>
+                      {step}
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div style={{ fontSize: 12, color: text.subtle }}>
+                This workspace helps organize the next landlord step after review. It does not automate approval, decline, or lease actions.
               </div>
             </Card>
           ) : null}

--- a/rentchain-frontend/src/pages/landlordDecisionWorkspace.test.ts
+++ b/rentchain-frontend/src/pages/landlordDecisionWorkspace.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import { buildLandlordDecisionWorkspace } from "./landlordDecisionWorkspace";
+import type { SharePackageCategoryView } from "./sharePackageAlignment";
+
+function categories(
+  statuses: Array<SharePackageCategoryView["status"]>
+): SharePackageCategoryView[] {
+  return [
+    { key: "profile_details", label: "Profile details", status: statuses[0], detail: "Profile details." },
+    { key: "rental_history", label: "Rental history", status: statuses[1], detail: "Rental history." },
+    { key: "documents_records", label: "Documents & records", status: statuses[2], detail: "Documents." },
+    { key: "consent_identity_status", label: "Consent / identity status", status: statuses[3], detail: "Consent." },
+    { key: "application_readiness", label: "Application readiness", status: statuses[4], detail: "Readiness." },
+  ];
+}
+
+function summary(overrides?: Record<string, any>): any {
+  return {
+    applicationId: "app-1",
+    generatedAt: "2026-04-10T00:00:00.000Z",
+    applicant: {},
+    employment: {},
+    reference: {},
+    compliance: {},
+    screening: {
+      status: "complete",
+      provider: "transunion",
+      referenceId: "TU-1",
+    },
+    derived: {
+      incomeToRentRatio: 2.8,
+      completeness: {
+        score: 0.85,
+        label: "High",
+      },
+      flags: [],
+    },
+    insights: [],
+    decisionSummary: {
+      applicationId: "app-1",
+      screeningRecommendation: {
+        recommended: false,
+        reason: "Optional for now.",
+        priority: "low",
+      },
+      screeningSummary: {
+        available: true,
+        provider: "transunion",
+        completedAt: "2026-04-10T00:00:00.000Z",
+        highlights: [],
+      },
+      riskSnapshot: {
+        version: "risk-v1",
+        status: "completed",
+        score: 72,
+        grade: "B",
+        confidence: 0.84,
+        factors: [],
+        flags: [],
+        recommendations: [],
+        updatedAt: "2026-04-10T00:00:00.000Z",
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe("buildLandlordDecisionWorkspace", () => {
+  it("returns needs follow-up when category follow-up is still open", () => {
+    const result = buildLandlordDecisionWorkspace({
+      summary: summary(),
+      packageCategories: categories(["ready", "missing", "ready", "partial", "ready"]),
+    });
+
+    expect(result.decisionState).toBe("needs_follow_up");
+    expect(result.statusLabel).toBe("Needs follow-up");
+    expect(result.blockers.some((item) => /Rental history/i.test(item))).toBe(true);
+  });
+
+  it("returns hold for later when follow-up is complete but review signals remain limited", () => {
+    const result = buildLandlordDecisionWorkspace({
+      summary: summary({
+        screening: {
+          status: "not_run",
+          provider: null,
+          referenceId: null,
+        },
+        derived: {
+          incomeToRentRatio: 1.9,
+          completeness: {
+            score: 0.62,
+            label: "Medium",
+          },
+          flags: ["MISSING_EMPLOYER_NAME"],
+        },
+        decisionSummary: {
+          applicationId: "app-1",
+          screeningRecommendation: {
+            recommended: true,
+            reason: "Still recommended.",
+            priority: "high",
+          },
+          screeningSummary: {
+            available: false,
+            provider: null,
+            completedAt: null,
+            highlights: [],
+          },
+        },
+      }),
+      packageCategories: categories(["ready", "partial", "ready", "partial", "ready"]),
+    });
+
+    expect(result.decisionState).toBe("hold_for_later");
+    expect(result.statusLabel).toBe("Hold for later");
+    expect(result.blockers.some((item) => /Screening is still recommended/i.test(item))).toBe(true);
+    expect(result.nextSteps[0]).toMatch(/Keep this file in review/i);
+  });
+
+  it("returns ready for decision when follow-up is resolved and review signals are organized", () => {
+    const result = buildLandlordDecisionWorkspace({
+      summary: summary(),
+      packageCategories: categories(["ready", "ready", "ready", "partial", "ready"]),
+    });
+
+    expect(result.decisionState).toBe("ready_for_decision");
+    expect(result.statusLabel).toBe("Ready for decision");
+    expect(result.blockers).toEqual([]);
+    expect(result.nextSteps[0]).toMatch(/guide your next landlord decision step/i);
+  });
+});

--- a/rentchain-frontend/src/pages/landlordDecisionWorkspace.ts
+++ b/rentchain-frontend/src/pages/landlordDecisionWorkspace.ts
@@ -1,0 +1,103 @@
+import type { ApplicationReviewSummary } from "../api/reviewSummaryApi";
+import type { SharePackageCategoryView } from "./sharePackageAlignment";
+import { buildFollowUpResolutionState } from "./followUpResolutionState";
+
+export type LandlordDecisionWorkspaceState =
+  | "needs_follow_up"
+  | "hold_for_later"
+  | "ready_for_decision";
+
+export type LandlordDecisionWorkspaceView = {
+  decisionState: LandlordDecisionWorkspaceState;
+  statusLabel: string;
+  summary: string;
+  explanation: string;
+  blockers: string[];
+  nextSteps: string[];
+  missingCategories: string[];
+};
+
+function screeningComplete(status: string | null | undefined): boolean {
+  const normalized = String(status || "").trim().toLowerCase();
+  return normalized === "complete" || normalized === "completed";
+}
+
+function buildHoldBlockers(summary: ApplicationReviewSummary): string[] {
+  const blockers: string[] = [];
+  const completeness = Math.round(summary.derived.completeness.score * 100);
+
+  if (summary.derived.flags.length > 0) {
+    blockers.push(
+      `${summary.derived.flags.length} high-level intake gap${summary.derived.flags.length === 1 ? "" : "s"} still appear in the current review summary.`
+    );
+  }
+
+  if (completeness < 80) {
+    blockers.push(`Application readiness is ${completeness}% complete in the current review summary.`);
+  }
+
+  if (summary.decisionSummary?.screeningRecommendation?.recommended) {
+    blockers.push("Screening is still recommended before moving this file to a final landlord next step.");
+  } else if (!screeningComplete(summary.screening.status) && !summary.decisionSummary?.screeningSummary?.available) {
+    blockers.push("Screening is not yet complete, so this file may still need more review context.");
+  }
+
+  return blockers;
+}
+
+export function buildLandlordDecisionWorkspace(params: {
+  summary: ApplicationReviewSummary;
+  packageCategories: SharePackageCategoryView[];
+}): LandlordDecisionWorkspaceView {
+  const resolution = buildFollowUpResolutionState(params.packageCategories);
+  const missingCategories = resolution.remainingCategoriesNeedingAttention;
+
+  if (resolution.overallState !== "ready_for_rereview") {
+    return {
+      decisionState: "needs_follow_up",
+      statusLabel: "Needs follow-up",
+      summary: "Decision workspace",
+      explanation:
+        "This application is not ready for a landlord next-step decision yet because follow-up is still open in the current authorized package.",
+      blockers: missingCategories.map(
+        (category) => `${category} still needs follow-up before this file can move forward.`
+      ),
+      nextSteps: [
+        "Keep follow-up active in the aligned package categories until the missing areas are updated.",
+        "Review the package again after the visible follow-up categories have been addressed.",
+      ],
+      missingCategories,
+    };
+  }
+
+  const holdBlockers = buildHoldBlockers(params.summary);
+  if (holdBlockers.length > 0) {
+    return {
+      decisionState: "hold_for_later",
+      statusLabel: "Hold for later",
+      summary: "Decision workspace",
+      explanation:
+        "Follow-up appears complete enough for re-review, but this file should stay in review until the remaining summary signals are clearer.",
+      blockers: holdBlockers,
+      nextSteps: [
+        "Keep this file in review while the remaining readiness and screening signals are clarified.",
+        "Return to the review summary after the outstanding review items are stronger or more complete.",
+      ],
+      missingCategories: [],
+    };
+  }
+
+  return {
+    decisionState: "ready_for_decision",
+    statusLabel: "Ready for decision",
+    summary: "Decision workspace",
+    explanation:
+      "The current authorized package no longer shows open follow-up, and the available review signals are organized enough for a landlord next-step decision.",
+    blockers: [],
+    nextSteps: [
+      "Use this review summary to guide your next landlord decision step without relying on automation.",
+      "Capture any internal decision note or operational next step separately from this read-first workspace.",
+    ],
+    missingCategories: [],
+  };
+}


### PR DESCRIPTION
## Summary
Adds a structured landlord decision workspace to the review-summary experience.

This PR introduces a shared pure helper that derives a landlord-facing decision state from the current review summary and follow-up status, then surfaces that state directly on the existing review-summary page with clear blockers and next steps.

## Scope
- shared landlord decision workspace helper
- landlord review-summary decision workspace UI
- focused landlord-side tests

## Decision states
The workspace derives a small, explainable set of states:
- needs follow-up
- hold for later
- ready for decision

The state is based on:
- current aligned package / follow-up status
- visible review-summary completeness
- high-level intake gaps
- current screening recommendation / availability

## Implementation notes
- Read-first v1
- No backend or API changes
- No schema changes
- No auth or permission changes
- No fake persistence or automation
- Existing risk-oriented decision support remains intact and separate from this new workspace

## Validation
- Targeted frontend tests passed
- Frontend build passed

## Limitations
- No persisted landlord decision state yet
- No hold / in-progress write actions
- No approval, decline, or lease automation in this PR