### PR TITLE
fix(tenant): correct auth entry and redirect flow

### DIFF
--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 beforeEach(() => {
   cleanup();
+  mockTenantToken = null;
 });
 
 vi.stubEnv("VITE_TENANT_PORTAL_ENABLED", "true");
@@ -29,6 +30,8 @@ vi.mock("./components/layout/TenantNav", () => ({
   TenantNav: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+let mockTenantToken: string | null = null;
+
 vi.mock("./context/useAuth", () => ({
   useAuth: () => ({
     user: { id: "landlord_1", role: "landlord", landlordId: "landlord_1" },
@@ -37,6 +40,10 @@ vi.mock("./context/useAuth", () => ({
     ready: true,
     authStatus: "authed",
   }),
+}));
+
+vi.mock("./lib/tenantAuth", () => ({
+  getTenantToken: () => mockTenantToken,
 }));
 
 vi.mock("./features/automation/timeline/AutomationTimelinePage", () => ({
@@ -67,6 +74,32 @@ describe("Routes: /tenant", () => {
       await screen.findByText(/Your rental profile\. Secure, organized, and in your control\./i)
     ).toBeInTheDocument();
     expect(screen.queryByText(/Create free account/i)).not.toBeInTheDocument();
+  });
+
+  it("redirects authenticated tenants from the public tenant entry page to the tenant dashboard", async () => {
+    mockTenantToken = "header.payload.signature";
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/tenant"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Tenant Dashboard/i)).toBeInTheDocument();
+  });
+
+  it("restores a safe preserved tenant route when an authenticated tenant lands on /tenant", async () => {
+    mockTenantToken = "header.payload.signature";
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/tenant?next=%2Ftenant%2Fapplication"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(
+      await screen.findByText(/Tenant Application Status \/tenant\/application/i)
+    ).toBeInTheDocument();
   });
 });
 

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -99,7 +99,12 @@ import ContractorDashboardPage from "./pages/contractor/ContractorDashboardPage"
 import ContractorJobsPage from "./pages/contractor/ContractorJobsPage";
 import ContractorProfilePage from "./pages/contractor/ContractorProfilePage";
 import { ContractorNav } from "./components/layout/ContractorNav";
-import { getRoleDefaultDestination } from "./lib/authDestination";
+import {
+  getRoleDefaultDestination,
+  resolveTenantPostAuthDestination,
+  TENANT_DEFAULT_DESTINATION,
+} from "./lib/authDestination";
+import { getTenantToken } from "./lib/tenantAuth";
 
 const TENANT_PORTAL_ENABLED = import.meta.env.VITE_TENANT_PORTAL_ENABLED === "true";
 
@@ -267,6 +272,18 @@ const AccountRouteGate: React.FC<{ children: React.ReactNode }> = ({ children })
   if (isAllowed) return <>{children}</>;
   if (role === "contractor") return <Navigate to="/contractor/profile" replace />;
   return <Navigate to={getRoleDefaultDestination(role as any)} replace />;
+};
+
+const TenantEntryRouteGate: React.FC = () => {
+  const location = useLocation();
+  const tenantToken = typeof window === "undefined" ? null : getTenantToken();
+  if (!tenantToken) return <TenantLandingPage />;
+
+  const destination = resolveTenantPostAuthDestination({
+    search: location.search,
+    fallback: TENANT_DEFAULT_DESTINATION,
+  }).destination;
+  return <Navigate to={destination} replace />;
 };
 
 function App() {
@@ -941,7 +958,7 @@ function App() {
         <Route path="/apply" element={<ApplicantApplyPage />} />
         <Route
           path="/tenant"
-          element={TENANT_PORTAL_ENABLED ? <TenantLandingPage /> : <TenantPortalComingSoon />}
+          element={TENANT_PORTAL_ENABLED ? <TenantEntryRouteGate /> : <TenantPortalComingSoon />}
         />
         <Route
           path="/tenant/dashboard"

--- a/rentchain-frontend/src/lib/authDestination.test.ts
+++ b/rentchain-frontend/src/lib/authDestination.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+  getRoleDefaultDestination,
+  getSafeTenantRedirect,
+  resolveTenantPostAuthDestination,
+  TENANT_DEFAULT_DESTINATION,
+} from "./authDestination";
+
+describe("authDestination tenant routing", () => {
+  it("uses the tenant workspace as the tenant role default", () => {
+    expect(getRoleDefaultDestination("tenant")).toBe(TENANT_DEFAULT_DESTINATION);
+  });
+
+  it("rejects public tenant entry routes as post-auth destinations", () => {
+    expect(getSafeTenantRedirect("/tenant")).toBeNull();
+    expect(getSafeTenantRedirect("/tenant/login?next=%2Ftenant%2Fprofile")).toBeNull();
+    expect(getSafeTenantRedirect("/auth/magic?token=abc")).toBeNull();
+  });
+
+  it("allows safe tenant workspace routes and onboarding continuations", () => {
+    expect(getSafeTenantRedirect("/tenant/profile")).toBe("/tenant/profile");
+    expect(getSafeTenantRedirect("/tenant/application?step=documents")).toBe(
+      "/tenant/application?step=documents"
+    );
+    expect(getSafeTenantRedirect("/auth/onboard?token=invite-123")).toBe(
+      "/auth/onboard?token=invite-123"
+    );
+  });
+
+  it("falls back to the tenant dashboard when no safe destination is preserved", () => {
+    expect(resolveTenantPostAuthDestination({ search: "" })).toEqual({
+      destination: TENANT_DEFAULT_DESTINATION,
+      usedFallback: true,
+      source: "fallback",
+    });
+  });
+
+  it("preserves a safe tenant destination from query params", () => {
+    expect(
+      resolveTenantPostAuthDestination({
+        search: "?next=%2Ftenant%2Fattachments",
+      })
+    ).toEqual({
+      destination: "/tenant/attachments",
+      usedFallback: false,
+      source: "query",
+    });
+  });
+
+  it("ignores a backend redirect to the public tenant entry page", () => {
+    expect(
+      resolveTenantPostAuthDestination({
+        explicitDestination: "/tenant",
+        backendRedirect: "/tenant",
+        search: "",
+      })
+    ).toEqual({
+      destination: TENANT_DEFAULT_DESTINATION,
+      usedFallback: true,
+      source: "fallback",
+    });
+  });
+});

--- a/rentchain-frontend/src/lib/authDestination.ts
+++ b/rentchain-frontend/src/lib/authDestination.ts
@@ -1,5 +1,7 @@
 export type AuthRole = "landlord" | "tenant" | "contractor" | "admin" | null | undefined;
 
+export const TENANT_DEFAULT_DESTINATION = "/tenant/dashboard";
+
 export function getSafeInternalRedirect(raw: string | null | undefined): string | null {
   const value = String(raw || "").trim();
   if (!value) return null;
@@ -15,10 +17,31 @@ export function getSafeInternalRedirect(raw: string | null | undefined): string 
 
 export function getRoleDefaultDestination(role: AuthRole): string {
   const value = String(role || "").trim().toLowerCase();
-  if (value === "tenant") return "/tenant";
+  if (value === "tenant") return TENANT_DEFAULT_DESTINATION;
   if (value === "contractor") return "/contractor";
   if (value === "admin") return "/admin";
   return "/dashboard";
+}
+
+export function getSafeTenantRedirect(raw: string | null | undefined): string | null {
+  const value = getSafeInternalRedirect(raw);
+  if (!value) return null;
+  if (value === "/tenant") return null;
+  if (value === "/tenant/login" || value.startsWith("/tenant/login?")) return null;
+  if (value === "/tenant/magic" || value.startsWith("/tenant/magic?")) return null;
+  if (value === "/auth/magic" || value.startsWith("/auth/magic?")) return null;
+  if (value === "/auth/onboard" || value.startsWith("/auth/onboard?")) return value;
+  if (value === TENANT_DEFAULT_DESTINATION || value.startsWith("/tenant/")) return value;
+  return null;
+}
+
+export function readTenantDestinationFromSearch(search: string): string | null {
+  const params = new URLSearchParams(search || "");
+  return (
+    getSafeTenantRedirect(params.get("redirect")) ||
+    getSafeTenantRedirect(params.get("next")) ||
+    getSafeTenantRedirect(params.get("continueUrl"))
+  );
 }
 
 export function readDestinationFromSearch(search: string): string | null {
@@ -58,6 +81,29 @@ export function resolvePostAuthDestination(input: {
   return { destination: fallback, usedFallback: true, source: "fallback" };
 }
 
+export function resolveTenantPostAuthDestination(input: {
+  search?: string;
+  explicitDestination?: string | null;
+  backendRedirect?: string | null;
+  fallback?: string | null;
+}): { destination: string; usedFallback: boolean; source: string } {
+  const explicit = getSafeTenantRedirect(input.explicitDestination || null);
+  if (explicit) return { destination: explicit, usedFallback: false, source: "explicit" };
+
+  const backend = getSafeTenantRedirect(input.backendRedirect || null);
+  if (backend) return { destination: backend, usedFallback: false, source: "backend" };
+
+  const fromSearch = readTenantDestinationFromSearch(input.search || "");
+  if (fromSearch) return { destination: fromSearch, usedFallback: false, source: "query" };
+
+  const fallback = getSafeTenantRedirect(input.fallback || TENANT_DEFAULT_DESTINATION);
+  if (fallback) {
+    return { destination: fallback, usedFallback: true, source: "fallback" };
+  }
+
+  return { destination: TENANT_DEFAULT_DESTINATION, usedFallback: true, source: "tenant-default" };
+}
+
 export function buildOnboardContinuationPath(token: string, source?: string): string {
   const params = new URLSearchParams();
   if (token) params.set("token", token);
@@ -65,4 +111,3 @@ export function buildOnboardContinuationPath(token: string, source?: string): st
   const query = params.toString();
   return query ? `/auth/onboard?${query}` : "/auth/onboard";
 }
-

--- a/rentchain-frontend/src/pages/tenant/TenantLandingPage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantLandingPage.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it } from "vitest";
 import TenantLandingPage from "./TenantLandingPage";
+import { TENANT_DEFAULT_DESTINATION } from "../../lib/authDestination";
 
 describe("TenantLandingPage", () => {
   it("renders tenant-first copy and avoids landlord pricing language", () => {
@@ -17,5 +18,29 @@ describe("TenantLandingPage", () => {
     ).toBeInTheDocument();
     expect(screen.getAllByRole("link", { name: /Log in \/ Continue/i }).length).toBeGreaterThan(0);
     expect(screen.queryByText(/Create free account/i)).not.toBeInTheDocument();
+  });
+
+  it("keeps tenant CTAs inside the tenant auth flow", () => {
+    render(
+      <MemoryRouter>
+        <TenantLandingPage />
+      </MemoryRouter>
+    );
+
+    const loginLinks = screen.getAllByRole("link", { name: /Log in \/ Continue/i });
+    for (const link of loginLinks) {
+      expect(link).toHaveAttribute(
+        "href",
+        `/tenant/login?next=${encodeURIComponent(TENANT_DEFAULT_DESTINATION)}`
+      );
+    }
+
+    const getStartedLinks = screen.getAllByRole("link", { name: /Get started/i });
+    for (const link of getStartedLinks) {
+      expect(link).toHaveAttribute(
+        "href",
+        `/tenant/login?next=${encodeURIComponent(TENANT_DEFAULT_DESTINATION)}&intent=create-profile`
+      );
+    }
   });
 });

--- a/rentchain-frontend/src/pages/tenant/TenantLandingPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantLandingPage.tsx
@@ -1,5 +1,8 @@
 import React from "react";
 import { Link } from "react-router-dom";
+import { TENANT_DEFAULT_DESTINATION } from "../../lib/authDestination";
+
+const tenantLoginPath = `/tenant/login?next=${encodeURIComponent(TENANT_DEFAULT_DESTINATION)}`;
 
 const primaryLinkStyle: React.CSSProperties = {
   display: "inline-flex",
@@ -80,11 +83,11 @@ export default function TenantLandingPage() {
             RentChain
           </Link>
           <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
-            <Link to="/tenant/login" style={secondaryLinkStyle}>
+            <Link to={tenantLoginPath} style={secondaryLinkStyle}>
               Log in / Continue
             </Link>
-            <Link to="/signup" style={secondaryLinkStyle}>
-              Create profile
+            <Link to={`${tenantLoginPath}&intent=create-profile`} style={secondaryLinkStyle}>
+              Get started
             </Link>
           </div>
         </header>
@@ -140,7 +143,7 @@ export default function TenantLandingPage() {
               </p>
             </div>
             <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
-              <Link to="/tenant/login" style={primaryLinkStyle}>
+              <Link to={tenantLoginPath} style={primaryLinkStyle}>
                 Log in / Continue
               </Link>
               <Link to="/tenant/dashboard" style={secondaryLinkStyle}>

--- a/rentchain-frontend/src/pages/tenant/TenantLoginPage.v2.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantLoginPage.v2.tsx
@@ -1,7 +1,10 @@
 import React, { useMemo, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { apiFetch } from "../../api/apiFetch";
-import { resolvePostAuthDestination } from "../../lib/authDestination";
+import {
+  resolveTenantPostAuthDestination,
+  TENANT_DEFAULT_DESTINATION,
+} from "../../lib/authDestination";
 import { trackAuthEvent } from "../../lib/authAnalytics";
 
 function Card({ children }: { children: React.ReactNode }) {
@@ -27,10 +30,9 @@ const TenantLoginPageV2: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const location = useLocation();
   const next = useMemo(() => {
-    const resolved = resolvePostAuthDestination({
+    const resolved = resolveTenantPostAuthDestination({
       search: location.search,
-      role: "tenant",
-      fallback: "/tenant",
+      fallback: TENANT_DEFAULT_DESTINATION,
     });
     return resolved.destination;
   }, [location.search]);

--- a/rentchain-frontend/src/pages/tenant/TenantMagicRedeemPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantMagicRedeemPage.tsx
@@ -3,7 +3,10 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { apiFetch } from "../../api/apiFetch";
 import { setTenantToken } from "../../lib/tenantAuth";
 import { clearAuthToken } from "../../lib/authToken";
-import { resolvePostAuthDestination } from "../../lib/authDestination";
+import {
+  resolveTenantPostAuthDestination,
+  TENANT_DEFAULT_DESTINATION,
+} from "../../lib/authDestination";
 import { fingerprintToken, trackAuthEvent } from "../../lib/authAnalytics";
 
 export default function TenantMagicRedeemPage() {
@@ -15,10 +18,9 @@ export default function TenantMagicRedeemPage() {
   const token = useMemo(() => new URLSearchParams(location.search).get("token") || "", [location.search]);
   const next = useMemo(
     () =>
-      resolvePostAuthDestination({
+      resolveTenantPostAuthDestination({
         search: location.search,
-        role: "tenant",
-        fallback: "/tenant",
+        fallback: TENANT_DEFAULT_DESTINATION,
       }).destination,
     [location.search]
   );
@@ -48,11 +50,10 @@ export default function TenantMagicRedeemPage() {
         }
         if (!mounted) return;
         setStatus("ok");
-        const destination = resolvePostAuthDestination({
+        const destination = resolveTenantPostAuthDestination({
           explicitDestination: res?.next || null,
           search: location.search,
-          role: "tenant",
-          fallback: "/tenant",
+          fallback: TENANT_DEFAULT_DESTINATION,
         }).destination;
         trackAuthEvent("auth.onboard.magic_link_completed", {
           tokenFingerprint: fingerprintToken(token),


### PR DESCRIPTION
## Summary
Fixes the tenant auth entry path so `/tenant` stays tenant-first from the public entry page through authenticated landing.

This PR corrects tenant CTA routing, adds safe tenant-specific post-auth destination handling, and ensures authenticated tenants are redirected into the tenant workspace instead of landing back on the public `/tenant` page.

## Scope
- tenant entry CTA routing
- tenant-safe redirect resolution
- authenticated `/tenant` entry guard
- focused frontend tests

## Implementation notes
- `/tenant` CTAs now stay inside the tenant auth flow
- Tenant post-auth fallback is now `/tenant/dashboard`
- Safe tenant routes are preserved across auth when present
- Public/auth routes like `/tenant`, `/tenant/login`, and `/auth/magic` are rejected as post-auth destinations to avoid circular redirects
- Frontend-only fix using existing auth and routing patterns
- No backend, schema, or auth-provider changes

## Validation
- Targeted frontend tests passed
- Frontend build passed

## Limitations
- No new tenant-specific signup system was added
- This PR focuses only on path integrity and redirect behavior, not broader onboarding changes