### PR TITLE
feat(landlord): add decision outcome tracking v1

### DIFF
--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
@@ -141,6 +141,11 @@ describe("ApplicationReviewSummaryPage", () => {
     expect(await screen.findByText("What is still missing")).toBeInTheDocument();
     expect(await screen.findByText(/This application is not ready for a landlord next-step decision yet/i)).toBeInTheDocument();
     expect(screen.getAllByText("Needs follow-up").length).toBeGreaterThan(0);
+    expect(await screen.findByText("Decision outcome")).toBeInTheDocument();
+    expect(await screen.findByText("Hold for later")).toBeInTheDocument();
+    expect(await screen.findByText("Outcome blockers")).toBeInTheDocument();
+    expect(await screen.findByText("Outcome next steps")).toBeInTheDocument();
+    expect(await screen.findByText(/Derived from current review state/i)).toBeInTheDocument();
     expect(await screen.findByText("Recent updates")).toBeInTheDocument();
     expect(await screen.findByText(/Tenant updated follow-up items/i)).toBeInTheDocument();
     expect(await screen.findByText(/Follow-up stays organized by aligned package categories/i)).toBeInTheDocument();
@@ -221,6 +226,7 @@ describe("ApplicationReviewSummaryPage", () => {
 
     expect((await screen.findAllByText("Decision workspace")).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("Ready for decision")).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText("Ready for next step")).length).toBeGreaterThan(0);
     expect(await screen.findByText(/No decision blockers are currently surfaced/i)).toBeInTheDocument();
   });
 
@@ -295,6 +301,8 @@ describe("ApplicationReviewSummaryPage", () => {
 
     expect((await screen.findAllByText("Decision workspace")).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("Hold for later")).length).toBeGreaterThan(0);
-    expect(await screen.findByText(/Screening is still recommended before moving this file/i)).toBeInTheDocument();
+    expect(
+      (await screen.findAllByText(/Screening is still recommended before moving this file/i)).length
+    ).toBeGreaterThan(0);
   });
 });

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
@@ -23,6 +23,7 @@ import { buildTenantLandlordInteractionLoop } from "./tenantLandlordInteractionL
 import { buildLandlordStructuredActivityTimeline } from "./structuredActivityTimeline";
 import { buildFollowUpResolutionState } from "./followUpResolutionState";
 import { buildLandlordDecisionWorkspace } from "./landlordDecisionWorkspace";
+import { buildLandlordDecisionOutcome } from "./landlordDecisionOutcome";
 import StructuredNotificationList from "./StructuredNotificationList";
 import { buildLandlordStructuredNotificationTriggers } from "./structuredNotificationTriggers";
 
@@ -85,6 +86,16 @@ function decisionTone(state: "needs_follow_up" | "hold_for_later" | "ready_for_d
     return { color: "#1d4ed8", background: "#dbeafe", label: "Hold for later" };
   }
   return { color: "#9a3412", background: "#ffedd5", label: "Needs follow-up" };
+}
+
+function decisionOutcomeTone(state: "ready_for_next_step" | "hold_for_later" | "not_proceeding") {
+  if (state === "ready_for_next_step") {
+    return { color: "#166534", background: "#dcfce7", label: "Ready for next step" };
+  }
+  if (state === "not_proceeding") {
+    return { color: "#7f1d1d", background: "#fee2e2", label: "Not proceeding" };
+  }
+  return { color: "#1d4ed8", background: "#dbeafe", label: "Hold for later" };
 }
 
 type SummaryLoadError = {
@@ -283,6 +294,18 @@ function ApplicationReviewSummaryPageBody() {
           })
         : null,
     [summary, intakeView]
+  );
+  const decisionOutcome = useMemo(
+    () =>
+      decisionWorkspace && resolutionView
+        ? buildLandlordDecisionOutcome({
+            decisionStatus: summary?.decisionSummary?.status || null,
+            decisionWorkspace,
+            followUpOverallState: resolutionView.overallState,
+            remainingCategories: resolutionView.remainingCategoriesNeedingAttention,
+          })
+        : null,
+    [decisionWorkspace, resolutionView, summary]
   );
 
   const recentActivity = useMemo(
@@ -697,6 +720,84 @@ function ApplicationReviewSummaryPageBody() {
               <div style={{ fontSize: 12, color: text.subtle }}>
                 This workspace helps organize the next landlord step after review. It does not automate approval, decline, or lease actions.
               </div>
+
+              {decisionOutcome ? (
+                <div
+                  style={{
+                    border: `1px solid ${colors.border}`,
+                    borderRadius: 10,
+                    padding: 10,
+                    display: "grid",
+                    gap: 10,
+                  }}
+                >
+                  <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+                    <div>
+                      <div style={{ fontWeight: 700, color: text.main }}>Decision outcome</div>
+                      <div style={{ fontSize: 13, color: text.subtle, marginTop: 4 }}>
+                        {decisionOutcome.description}
+                      </div>
+                    </div>
+                    <div
+                      style={{
+                        padding: "6px 10px",
+                        borderRadius: 999,
+                        fontWeight: 700,
+                        color: decisionOutcomeTone(decisionOutcome.outcomeState).color,
+                        background: decisionOutcomeTone(decisionOutcome.outcomeState).background,
+                      }}
+                    >
+                      {decisionOutcomeTone(decisionOutcome.outcomeState).label}
+                    </div>
+                  </div>
+
+                  <div style={{ fontSize: 12, color: text.subtle }}>
+                    {decisionOutcome.sourceLabel}
+                  </div>
+
+                  <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))", gap: 8 }}>
+                    <div
+                      style={{
+                        border: `1px solid ${colors.border}`,
+                        borderRadius: 10,
+                        padding: 10,
+                        display: "grid",
+                        gap: 6,
+                      }}
+                    >
+                      <div style={{ fontWeight: 700, color: text.main }}>Outcome blockers</div>
+                      {decisionOutcome.blockers.length ? (
+                        decisionOutcome.blockers.map((item) => (
+                          <div key={item} style={{ fontSize: 13, color: text.subtle }}>
+                            {item}
+                          </div>
+                        ))
+                      ) : (
+                        <div style={{ fontSize: 13, color: text.subtle }}>
+                          No current blockers are surfaced for this structured outcome view.
+                        </div>
+                      )}
+                    </div>
+
+                    <div
+                      style={{
+                        border: `1px solid ${colors.border}`,
+                        borderRadius: 10,
+                        padding: 10,
+                        display: "grid",
+                        gap: 6,
+                      }}
+                    >
+                      <div style={{ fontWeight: 700, color: text.main }}>Outcome next steps</div>
+                      {decisionOutcome.landlordNextSteps.map((step) => (
+                        <div key={step} style={{ fontSize: 13, color: text.subtle }}>
+                          {step}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              ) : null}
             </Card>
           ) : null}
 

--- a/rentchain-frontend/src/pages/landlordDecisionOutcome.test.ts
+++ b/rentchain-frontend/src/pages/landlordDecisionOutcome.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { buildLandlordDecisionOutcome } from "./landlordDecisionOutcome";
+
+describe("buildLandlordDecisionOutcome", () => {
+  it("maps an explicit ready outcome record when present", () => {
+    const result = buildLandlordDecisionOutcome({
+      decisionStatus: "approved",
+    });
+
+    expect(result.outcomeState).toBe("ready_for_next_step");
+    expect(result.source).toBe("explicit");
+    expect(result.timelineEvent.title).toBe("Application marked Ready for next step");
+  });
+
+  it("maps an explicit not proceeding outcome record when present", () => {
+    const result = buildLandlordDecisionOutcome({
+      decisionStatus: "not_proceeding",
+    });
+
+    expect(result.outcomeState).toBe("not_proceeding");
+    expect(result.source).toBe("explicit");
+    expect(result.tenantDescription).toMatch(/not proceeding/i);
+  });
+
+  it("derives ready for next step from a ready-for-decision workspace", () => {
+    const result = buildLandlordDecisionOutcome({
+      decisionWorkspace: {
+        decisionState: "ready_for_decision",
+        statusLabel: "Ready for decision",
+        summary: "Decision workspace",
+        explanation: "Ready.",
+        blockers: [],
+        nextSteps: ["Move forward."],
+        missingCategories: [],
+      },
+      followUpOverallState: "ready_for_rereview",
+      remainingCategories: [],
+    });
+
+    expect(result.outcomeState).toBe("ready_for_next_step");
+    expect(result.source).toBe("derived");
+    expect(result.timelineEvent.title).toBe("Application aligned as Ready for next step");
+  });
+
+  it("derives hold for later when follow-up still remains open", () => {
+    const result = buildLandlordDecisionOutcome({
+      followUpOverallState: "follow_up_needed",
+      remainingCategories: ["Documents & records"],
+    });
+
+    expect(result.outcomeState).toBe("hold_for_later");
+    expect(result.source).toBe("derived");
+    expect(result.blockers[0]).toMatch(/Documents & records/i);
+    expect(result.timelineEvent.actionRequired).toBe(true);
+  });
+});

--- a/rentchain-frontend/src/pages/landlordDecisionOutcome.ts
+++ b/rentchain-frontend/src/pages/landlordDecisionOutcome.ts
@@ -1,0 +1,245 @@
+import type { LandlordDecisionWorkspaceView } from "./landlordDecisionWorkspace";
+import type { FollowUpResolutionOverallState, FollowUpResolutionCategoryView } from "./followUpResolutionState";
+
+export type LandlordDecisionOutcomeState =
+  | "ready_for_next_step"
+  | "hold_for_later"
+  | "not_proceeding";
+
+export type LandlordDecisionOutcomeView = {
+  outcomeState: LandlordDecisionOutcomeState;
+  label: string;
+  source: "explicit" | "derived";
+  sourceLabel: string;
+  description: string;
+  tenantDescription: string;
+  blockers: string[];
+  landlordNextSteps: string[];
+  tenantNextSteps: string[];
+  timelineEvent: {
+    title: string;
+    description: string;
+    actionRequired: boolean;
+  };
+};
+
+function normalizeExplicitOutcomeState(
+  raw: string | null | undefined
+): LandlordDecisionOutcomeState | null {
+  const value = String(raw || "").trim().toLowerCase();
+  if (!value) return null;
+
+  if (
+    [
+      "ready_for_next_step",
+      "ready for next step",
+      "ready_for_decision",
+      "approved",
+      "approve",
+      "proceed",
+      "proceeding",
+    ].includes(value)
+  ) {
+    return "ready_for_next_step";
+  }
+
+  if (
+    [
+      "hold_for_later",
+      "hold for later",
+      "hold",
+      "on_hold",
+      "on hold",
+      "request_info",
+      "request info",
+      "in_review",
+      "decision_in_progress",
+    ].includes(value)
+  ) {
+    return "hold_for_later";
+  }
+
+  if (
+    [
+      "not_proceeding",
+      "not proceeding",
+      "declined",
+      "decline",
+      "rejected",
+      "reject",
+      "closed_not_proceeding",
+    ].includes(value)
+  ) {
+    return "not_proceeding";
+  }
+
+  return null;
+}
+
+function outcomeLabel(state: LandlordDecisionOutcomeState): string {
+  if (state === "ready_for_next_step") return "Ready for next step";
+  if (state === "not_proceeding") return "Not proceeding";
+  return "Hold for later";
+}
+
+function withFallbackSteps(steps: string[], fallback: string[]): string[] {
+  return steps.length ? steps : fallback;
+}
+
+export function buildLandlordDecisionOutcome(input: {
+  decisionStatus?: string | null;
+  decisionWorkspace?: LandlordDecisionWorkspaceView | null;
+  followUpOverallState?: FollowUpResolutionOverallState | null;
+  remainingCategories?: FollowUpResolutionCategoryView[] | string[];
+}): LandlordDecisionOutcomeView {
+  const explicitState = normalizeExplicitOutcomeState(input.decisionStatus);
+  const unresolvedCategoryLabels = (input.remainingCategories || []).map((item) =>
+    typeof item === "string" ? item : item.label
+  );
+  const decisionWorkspace = input.decisionWorkspace || null;
+  const followUpOverallState = input.followUpOverallState || null;
+
+  if (explicitState === "ready_for_next_step") {
+    return {
+      outcomeState: explicitState,
+      label: outcomeLabel(explicitState),
+      source: "explicit",
+      sourceLabel: "Current outcome record",
+      description:
+        "A landlord decision outcome is currently recorded as ready for next step in the authorized review context.",
+      tenantDescription:
+        "Your application is currently marked ready for the next step.",
+      blockers: [],
+      landlordNextSteps: [
+        "Continue the next landlord step using your existing operating process outside this read-first review summary.",
+        "Keep any final operational notes separate from this structured outcome view.",
+      ],
+      tenantNextSteps: [
+        "Watch for the landlord’s next-step instructions or follow-on workflow.",
+        "Keep your profile and documents current in case anything needs to be confirmed again.",
+      ],
+      timelineEvent: {
+        title: "Application marked Ready for next step",
+        description:
+          "The current decision outcome is recorded as ready for the next landlord step.",
+        actionRequired: false,
+      },
+    };
+  }
+
+  if (explicitState === "hold_for_later") {
+    return {
+      outcomeState: explicitState,
+      label: outcomeLabel(explicitState),
+      source: "explicit",
+      sourceLabel: "Current outcome record",
+      description:
+        "A landlord decision outcome is currently recorded as hold for later while this file remains in review.",
+      tenantDescription:
+        "Your application is currently on hold while the landlord completes the next review step.",
+      blockers: decisionWorkspace?.blockers || unresolvedCategoryLabels,
+      landlordNextSteps: withFallbackSteps(decisionWorkspace?.nextSteps || [], [
+        "Keep the file on hold until the remaining review context is clear enough for a next-step decision.",
+      ]),
+      tenantNextSteps: [
+        "Keep an eye on any follow-up or review updates that appear in your tenant workspace.",
+      ],
+      timelineEvent: {
+        title: "Application placed on hold",
+        description: "The current decision outcome is recorded as hold for later.",
+        actionRequired: false,
+      },
+    };
+  }
+
+  if (explicitState === "not_proceeding") {
+    return {
+      outcomeState: explicitState,
+      label: outcomeLabel(explicitState),
+      source: "explicit",
+      sourceLabel: "Current outcome record",
+      description:
+        "A landlord decision outcome is currently recorded as not proceeding in the authorized review context.",
+      tenantDescription:
+        "Your application is currently marked as not proceeding.",
+      blockers: [],
+      landlordNextSteps: [
+        "Keep any final compliance or communication actions in the appropriate workflow outside this review summary.",
+      ],
+      tenantNextSteps: [
+        "Review the latest application updates in your tenant workspace for any next instructions that are already visible to you.",
+      ],
+      timelineEvent: {
+        title: "Application not proceeding",
+        description: "The current decision outcome is recorded as not proceeding.",
+        actionRequired: false,
+      },
+    };
+  }
+
+  if (decisionWorkspace?.decisionState === "ready_for_decision") {
+    return {
+      outcomeState: "ready_for_next_step",
+      label: outcomeLabel("ready_for_next_step"),
+      source: "derived",
+      sourceLabel: "Derived from current review state",
+      description:
+        "The current review, follow-up, and re-review signals now appear organized enough for the next landlord step.",
+      tenantDescription:
+        "Your application currently appears ready for the next step after re-review.",
+      blockers: [],
+      landlordNextSteps: [
+        "Use the review summary and structured outcome view to guide your next landlord step.",
+        "Capture any final recorded outcome separately if a dedicated persistence path is added later.",
+      ],
+      tenantNextSteps: [
+        "Your file currently looks ready for the next landlord step.",
+        "Keep your profile and supporting documents available in case anything needs to be reconfirmed.",
+      ],
+      timelineEvent: {
+        title: "Application aligned as Ready for next step",
+        description:
+          "The current authorized review state now appears ready for the next landlord step.",
+        actionRequired: false,
+      },
+    };
+  }
+
+  const followUpStillOpen =
+    followUpOverallState === "follow_up_needed" || followUpOverallState === "partly_addressed";
+  const blockers = decisionWorkspace?.blockers?.length
+    ? decisionWorkspace.blockers
+    : unresolvedCategoryLabels.map((label) =>
+        `${label} still needs follow-up before this file can move forward.`
+      );
+
+  return {
+    outcomeState: "hold_for_later",
+    label: outcomeLabel("hold_for_later"),
+    source: "derived",
+    sourceLabel: "Derived from current review state",
+    description: followUpStillOpen
+      ? "Follow-up or re-review is still active, so this application remains on hold for now."
+      : "This application should stay on hold until the remaining review context is clearer.",
+    tenantDescription: followUpStillOpen
+      ? "Your application still has open follow-up or re-review work before it can move forward."
+      : "Your application is still on hold while the landlord finishes reviewing the current file.",
+    blockers,
+    landlordNextSteps: withFallbackSteps(decisionWorkspace?.nextSteps || [], [
+      "Keep this file in review until the remaining follow-up and readiness signals are clearer.",
+    ]),
+    tenantNextSteps: followUpStillOpen
+      ? [
+          "Finish any remaining follow-up areas that still need attention in your tenant workspace.",
+          "Review the package again after the visible follow-up items are addressed.",
+        ]
+      : ["Keep an eye on your tenant workspace for any follow-up or next-step updates."],
+    timelineEvent: {
+      title: followUpStillOpen ? "Application placed on hold" : "Application currently held for later",
+      description: followUpStillOpen
+        ? "The current review state still has follow-up or re-review work before a next-step outcome."
+        : "The current review state is still on hold while the remaining context is clarified.",
+      actionRequired: followUpStillOpen,
+    },
+  };
+}

--- a/rentchain-frontend/src/pages/structuredActivityTimeline.test.ts
+++ b/rentchain-frontend/src/pages/structuredActivityTimeline.test.ts
@@ -89,6 +89,9 @@ describe("structuredActivityTimeline", () => {
       title: "Review state updated",
       actionRequired: false,
     });
+    expect(
+      result.some((item) => item.title === "Application placed on hold" && item.actionRequired)
+    ).toBe(true);
     expect(result.some((item) => item.title === "Review follow-up remains active" && item.actionRequired)).toBe(true);
     expect(result.some((item) => item.title === "Follow-up requested")).toBe(true);
     expect(result.some((item) => item.title === "Consent / identity status pending")).toBe(true);

--- a/rentchain-frontend/src/pages/structuredActivityTimeline.ts
+++ b/rentchain-frontend/src/pages/structuredActivityTimeline.ts
@@ -1,5 +1,8 @@
 import type { ApplicationReviewSummary } from "../api/reviewSummaryApi";
 import type { TenantNotificationItem } from "../api/tenantNotifications";
+import { buildLandlordIntakeAlignmentView } from "./applicationReviewIntakeAlignment";
+import { buildLandlordDecisionWorkspace } from "./landlordDecisionWorkspace";
+import { buildLandlordDecisionOutcome } from "./landlordDecisionOutcome";
 
 export type StructuredActivityTimelineItem = {
   id: string;
@@ -95,6 +98,22 @@ export function buildLandlordStructuredActivityTimeline(
   const items: StructuredActivityTimelineItem[] = [];
   const missingCategories = summary.derived.flags.length;
   const completeness = Math.round(summary.derived.completeness.score * 100);
+  const intakeView = buildLandlordIntakeAlignmentView(summary);
+  const decisionWorkspace = buildLandlordDecisionWorkspace({
+    summary,
+    packageCategories: intakeView.packageCategories,
+  });
+  const decisionOutcome = buildLandlordDecisionOutcome({
+    decisionStatus: summary.decisionSummary?.status || null,
+    decisionWorkspace,
+    followUpOverallState:
+      decisionWorkspace.decisionState === "ready_for_decision"
+        ? "ready_for_rereview"
+        : decisionWorkspace.decisionState === "needs_follow_up"
+        ? "follow_up_needed"
+        : "partly_addressed",
+    remainingCategories: intakeView.packageCategories.filter((item) => item.status === "missing"),
+  });
 
   pushTimelineItem(items, {
     id: `review-summary-${summary.applicationId}`,
@@ -166,6 +185,19 @@ export function buildLandlordStructuredActivityTimeline(
       relatedPath: null,
     });
   }
+
+  pushTimelineItem(items, {
+    id: `decision-outcome-${summary.applicationId}`,
+    type: decisionOutcome.outcomeState === "ready_for_next_step" ? "ready_for_rereview" : "review_updated",
+    title: decisionOutcome.timelineEvent.title,
+    description: decisionOutcome.timelineEvent.description,
+    occurredAt:
+      summary.decisionSummary?.riskSnapshot?.updatedAt ||
+      summary.generatedAt,
+    actorLabel: decisionOutcome.source === "explicit" ? "Decision workspace" : "Derived review state",
+    actionRequired: decisionOutcome.timelineEvent.actionRequired,
+    relatedPath: null,
+  });
 
   return items.sort((left, right) => right.occurredAt - left.occurredAt);
 }

--- a/rentchain-frontend/src/pages/tenant/TenantApplicationCompletionPage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantApplicationCompletionPage.test.tsx
@@ -203,6 +203,10 @@ describe("tenant application completion page", () => {
     expect(screen.getByText(/Still needs attention/i)).toBeInTheDocument();
     expect(screen.getByText(/^Addressed$/i)).toBeInTheDocument();
     expect(screen.getByText(/Application ready for re-review/i)).toBeInTheDocument();
+    expect(screen.getByText(/Decision outcome/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Hold for later/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/What this means/i)).toBeInTheDocument();
+    expect(screen.getByText(/derived from your current follow-up and re-review state/i)).toBeInTheDocument();
     expect(screen.getByText(/Go next/i)).toBeInTheDocument();
     expect(screen.getAllByText(/Review Before Sharing/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Identity verification/i).length).toBeGreaterThan(0);

--- a/rentchain-frontend/src/pages/tenant/TenantApplicationStatusPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantApplicationStatusPage.tsx
@@ -24,6 +24,7 @@ import { buildTenantApplicationReuseView } from "./tenantApplicationReuse";
 import { buildTenantApplicationFlow } from "./tenantApplicationFlow";
 import { buildTenantLandlordInteractionLoop } from "../tenantLandlordInteractionLoop";
 import { buildFollowUpResolutionState } from "../followUpResolutionState";
+import { buildLandlordDecisionOutcome } from "../landlordDecisionOutcome";
 import StructuredNotificationList from "../StructuredNotificationList";
 import { buildTenantStructuredNotificationTriggers } from "../structuredNotificationTriggers";
 import { filterStructuredNotificationsByPreferences } from "../notificationChannelRouting";
@@ -266,6 +267,16 @@ export default function TenantApplicationStatusPage() {
       : interactionLoop.state === "partly_addressed"
       ? { color: "#1d4ed8", background: "#dbeafe", label: "Partly addressed" }
       : { color: "#9a3412", background: "#ffedd5", label: "Follow-up needed" };
+  const decisionOutcome = buildLandlordDecisionOutcome({
+    followUpOverallState: resolutionView.overallState,
+    remainingCategories: resolutionView.remainingCategoriesNeedingAttention,
+  });
+  const decisionOutcomeTone =
+    decisionOutcome.outcomeState === "ready_for_next_step"
+      ? { color: "#166534", background: "#dcfce7", label: "Ready for next step" }
+      : decisionOutcome.outcomeState === "not_proceeding"
+      ? { color: "#7f1d1d", background: "#fee2e2", label: "Not proceeding" }
+      : { color: "#1d4ed8", background: "#dbeafe", label: "Hold for later" };
 
   return (
     <TenantSurfaceShell
@@ -453,6 +464,71 @@ export default function TenantApplicationStatusPage() {
           emptyLabel="Recent workflow-triggered notifications will appear here once this application starts moving through review and follow-up."
           items={notificationItems}
         />
+      </TenantInfoCard>
+
+      <TenantInfoCard heading="Decision outcome" accent="#0f766e">
+        <div style={{ display: "grid", gap: spacing.sm }}>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+            <div>
+              <div style={{ fontWeight: 800, color: textTokens.primary }}>{decisionOutcome.label}</div>
+              <div style={{ color: textTokens.secondary }}>{decisionOutcome.tenantDescription}</div>
+            </div>
+            <div
+              style={{
+                padding: "6px 10px",
+                borderRadius: 999,
+                fontWeight: 700,
+                color: decisionOutcomeTone.color,
+                background: decisionOutcomeTone.background,
+              }}
+            >
+              {decisionOutcomeTone.label}
+            </div>
+          </div>
+
+          <div
+            style={{
+              border: "1px solid rgba(15,23,42,0.08)",
+              borderRadius: 12,
+              padding: "12px 14px",
+              display: "grid",
+              gap: 8,
+            }}
+          >
+            <div style={{ fontWeight: 700, color: textTokens.primary }}>What this means</div>
+            <div style={{ color: textTokens.secondary }}>
+              {decisionOutcome.source === "explicit"
+                ? "This high-level outcome comes from the current authorized application outcome record."
+                : "This high-level outcome is derived from your current follow-up and re-review state."}
+            </div>
+            {decisionOutcome.blockers.length ? (
+              <div style={{ display: "grid", gap: 6 }}>
+                {decisionOutcome.blockers.map((item) => (
+                  <div key={item} style={{ color: textTokens.secondary }}>
+                    {item}
+                  </div>
+                ))}
+              </div>
+            ) : null}
+          </div>
+
+          <div
+            style={{
+              border: "1px solid rgba(15,23,42,0.08)",
+              borderRadius: 12,
+              padding: "12px 14px",
+              display: "grid",
+              gap: 8,
+            }}
+          >
+            <div style={{ fontWeight: 700, color: textTokens.primary }}>Next steps</div>
+            {decisionOutcome.tenantNextSteps.map((step) => (
+              <div key={step} style={{ color: textTokens.secondary }}>
+                {step}
+              </div>
+            ))}
+          </div>
+        </div>
       </TenantInfoCard>
 
       <div


### PR DESCRIPTION
## Summary
Adds a structured landlord decision outcome layer to the existing review workflow.

This PR introduces a shared pure helper that derives a high-level decision outcome from the current review and follow-up state, then surfaces that outcome in:
- the landlord review-summary decision workspace
- the tenant application readiness page
- the landlord structured activity timeline

## Scope
- shared landlord decision outcome helper
- landlord review-summary outcome UI
- tenant read-only outcome visibility
- landlord timeline outcome events
- focused frontend tests

## Outcome logic
Supported outcome states:
- ready for next step
- hold for later
- not proceeding

Behavior:
- use an already-visible explicit status when one exists
- otherwise derive the outcome from the current decision workspace and follow-up / re-review state

## Implementation notes
- Read-first v1
- No backend or API changes
- No schema changes
- No auth or permission changes
- No fake persistence or automation
- Tenant visibility stays high-level and neutral

## Validation
- Targeted frontend tests passed
- Frontend build passed

## Limitations
- No persisted neutral landlord outcome record yet
- No landlord outcome-selection action flow in this PR
- Timeline events are derived from current authorized state, not a new stored event ledger