### PR TITLE
feat(landlord): add lease flow integration v1

### DIFF
--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
@@ -146,6 +146,9 @@ describe("ApplicationReviewSummaryPage", () => {
     expect(await screen.findByText("Outcome blockers")).toBeInTheDocument();
     expect(await screen.findByText("Outcome next steps")).toBeInTheDocument();
     expect(await screen.findByText(/Derived from current review state/i)).toBeInTheDocument();
+    expect(await screen.findByText("Lease step")).toBeInTheDocument();
+    expect(await screen.findByText("Not ready for lease step")).toBeInTheDocument();
+    expect(await screen.findByText("Lease blockers")).toBeInTheDocument();
     expect(await screen.findByText("Recent updates")).toBeInTheDocument();
     expect(await screen.findByText(/Tenant updated follow-up items/i)).toBeInTheDocument();
     expect(await screen.findByText(/Follow-up stays organized by aligned package categories/i)).toBeInTheDocument();
@@ -227,6 +230,8 @@ describe("ApplicationReviewSummaryPage", () => {
     expect((await screen.findAllByText("Decision workspace")).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("Ready for decision")).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("Ready for next step")).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText("Ready for lease step")).length).toBeGreaterThan(0);
+    expect(await screen.findByText(/Move this file into the lease flow/i)).toBeInTheDocument();
     expect(await screen.findByText(/No decision blockers are currently surfaced/i)).toBeInTheDocument();
   });
 
@@ -301,6 +306,7 @@ describe("ApplicationReviewSummaryPage", () => {
 
     expect((await screen.findAllByText("Decision workspace")).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("Hold for later")).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText("Not ready for lease step")).length).toBeGreaterThan(0);
     expect(
       (await screen.findAllByText(/Screening is still recommended before moving this file/i)).length
     ).toBeGreaterThan(0);

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
@@ -24,6 +24,7 @@ import { buildLandlordStructuredActivityTimeline } from "./structuredActivityTim
 import { buildFollowUpResolutionState } from "./followUpResolutionState";
 import { buildLandlordDecisionWorkspace } from "./landlordDecisionWorkspace";
 import { buildLandlordDecisionOutcome } from "./landlordDecisionOutcome";
+import { buildLeaseFlowTransitionState } from "./leaseFlowTransitionState";
 import StructuredNotificationList from "./StructuredNotificationList";
 import { buildLandlordStructuredNotificationTriggers } from "./structuredNotificationTriggers";
 
@@ -96,6 +97,21 @@ function decisionOutcomeTone(state: "ready_for_next_step" | "hold_for_later" | "
     return { color: "#7f1d1d", background: "#fee2e2", label: "Not proceeding" };
   }
   return { color: "#1d4ed8", background: "#dbeafe", label: "Hold for later" };
+}
+
+function leaseTransitionTone(
+  state: "not_ready_for_lease" | "ready_for_lease_step" | "lease_step_started" | "awaiting_next_action"
+) {
+  if (state === "lease_step_started") {
+    return { color: "#0f766e", background: "#ccfbf1", label: "Lease step started" };
+  }
+  if (state === "ready_for_lease_step") {
+    return { color: "#166534", background: "#dcfce7", label: "Ready for lease step" };
+  }
+  if (state === "awaiting_next_action") {
+    return { color: "#1d4ed8", background: "#dbeafe", label: "Awaiting next action" };
+  }
+  return { color: "#9a3412", background: "#ffedd5", label: "Not ready for lease step" };
 }
 
 type SummaryLoadError = {
@@ -306,6 +322,16 @@ function ApplicationReviewSummaryPageBody() {
           })
         : null,
     [decisionWorkspace, resolutionView, summary]
+  );
+  const leaseTransition = useMemo(
+    () =>
+      decisionOutcome
+        ? buildLeaseFlowTransitionState({
+            audience: "landlord",
+            decisionOutcome,
+          })
+        : null,
+    [decisionOutcome]
   );
 
   const recentActivity = useMemo(
@@ -790,6 +816,80 @@ function ApplicationReviewSummaryPageBody() {
                     >
                       <div style={{ fontWeight: 700, color: text.main }}>Outcome next steps</div>
                       {decisionOutcome.landlordNextSteps.map((step) => (
+                        <div key={step} style={{ fontSize: 13, color: text.subtle }}>
+                          {step}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              ) : null}
+
+              {leaseTransition ? (
+                <div
+                  style={{
+                    border: `1px solid ${colors.border}`,
+                    borderRadius: 10,
+                    padding: 10,
+                    display: "grid",
+                    gap: 10,
+                  }}
+                >
+                  <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+                    <div>
+                      <div style={{ fontWeight: 700, color: text.main }}>Lease step</div>
+                      <div style={{ fontSize: 13, color: text.subtle, marginTop: 4 }}>
+                        {leaseTransition.explanation}
+                      </div>
+                    </div>
+                    <div
+                      style={{
+                        padding: "6px 10px",
+                        borderRadius: 999,
+                        fontWeight: 700,
+                        color: leaseTransitionTone(leaseTransition.transitionState).color,
+                        background: leaseTransitionTone(leaseTransition.transitionState).background,
+                      }}
+                    >
+                      {leaseTransitionTone(leaseTransition.transitionState).label}
+                    </div>
+                  </div>
+
+                  <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))", gap: 8 }}>
+                    <div
+                      style={{
+                        border: `1px solid ${colors.border}`,
+                        borderRadius: 10,
+                        padding: 10,
+                        display: "grid",
+                        gap: 6,
+                      }}
+                    >
+                      <div style={{ fontWeight: 700, color: text.main }}>Lease blockers</div>
+                      {leaseTransition.blockers.length ? (
+                        leaseTransition.blockers.map((item) => (
+                          <div key={item} style={{ fontSize: 13, color: text.subtle }}>
+                            {item}
+                          </div>
+                        ))
+                      ) : (
+                        <div style={{ fontSize: 13, color: text.subtle }}>
+                          No lease-step blockers are currently surfaced in this read-first transition view.
+                        </div>
+                      )}
+                    </div>
+
+                    <div
+                      style={{
+                        border: `1px solid ${colors.border}`,
+                        borderRadius: 10,
+                        padding: 10,
+                        display: "grid",
+                        gap: 6,
+                      }}
+                    >
+                      <div style={{ fontWeight: 700, color: text.main }}>Next action</div>
+                      {leaseTransition.nextActions.map((step) => (
                         <div key={step} style={{ fontSize: 13, color: text.subtle }}>
                           {step}
                         </div>

--- a/rentchain-frontend/src/pages/leaseFlowTransitionState.test.ts
+++ b/rentchain-frontend/src/pages/leaseFlowTransitionState.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import { buildLeaseFlowTransitionState } from "./leaseFlowTransitionState";
+
+describe("leaseFlowTransitionState", () => {
+  it("keeps the lease step blocked when the decision outcome is not ready", () => {
+    const result = buildLeaseFlowTransitionState({
+      audience: "landlord",
+      decisionOutcome: {
+        outcomeState: "hold_for_later",
+        label: "Hold for later",
+        source: "derived",
+        sourceLabel: "Derived from current review state",
+        description: "Still in review.",
+        tenantDescription: "Still in review.",
+        blockers: ["Documents still need follow-up."],
+        landlordNextSteps: ["Finish follow-up."],
+        tenantNextSteps: ["Wait for updates."],
+        timelineEvent: {
+          title: "Application placed on hold",
+          description: "Still in review.",
+          actionRequired: true,
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      transitionState: "not_ready_for_lease",
+      label: "Not ready for lease step",
+      blockers: ["Documents still need follow-up."],
+      timelineEvent: null,
+    });
+  });
+
+  it("marks the file ready for the lease step for landlords when the outcome is ready", () => {
+    const result = buildLeaseFlowTransitionState({
+      audience: "landlord",
+      decisionOutcome: {
+        outcomeState: "ready_for_next_step",
+        label: "Ready for next step",
+        source: "derived",
+        sourceLabel: "Derived from current review state",
+        description: "Ready to move forward.",
+        tenantDescription: "Ready to move forward.",
+        blockers: [],
+        landlordNextSteps: ["Proceed."],
+        tenantNextSteps: ["Watch for updates."],
+        timelineEvent: {
+          title: "Application marked Ready for next step",
+          description: "Ready.",
+          actionRequired: false,
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      transitionState: "ready_for_lease_step",
+      label: "Ready for lease step",
+    });
+    expect(result.timelineEvent?.title).toBe("Application marked ready for lease step");
+  });
+
+  it("shows awaiting-next-action for tenants until a lease record is visible", () => {
+    const result = buildLeaseFlowTransitionState({
+      audience: "tenant",
+      decisionOutcome: {
+        outcomeState: "ready_for_next_step",
+        label: "Ready for next step",
+        source: "derived",
+        sourceLabel: "Derived from current review state",
+        description: "Ready to move forward.",
+        tenantDescription: "Ready to move forward.",
+        blockers: [],
+        landlordNextSteps: ["Proceed."],
+        tenantNextSteps: ["Watch for updates."],
+        timelineEvent: {
+          title: "Application marked Ready for next step",
+          description: "Ready.",
+          actionRequired: false,
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      transitionState: "awaiting_next_action",
+      label: "Awaiting next lease action",
+    });
+  });
+
+  it("shows lease-step-started when a lease workspace record is already visible", () => {
+    const result = buildLeaseFlowTransitionState({
+      audience: "tenant",
+      decisionOutcome: {
+        outcomeState: "ready_for_next_step",
+        label: "Ready for next step",
+        source: "derived",
+        sourceLabel: "Derived from current review state",
+        description: "Ready to move forward.",
+        tenantDescription: "Ready to move forward.",
+        blockers: [],
+        landlordNextSteps: ["Proceed."],
+        tenantNextSteps: ["Watch for updates."],
+        timelineEvent: {
+          title: "Application marked Ready for next step",
+          description: "Ready.",
+          actionRequired: false,
+        },
+      },
+      lease: {
+        leaseId: "lease-1",
+        startDate: "2026-05-01",
+        endDate: "2027-04-30",
+        monthlyRent: 180000,
+        status: "draft",
+        documentUrl: null,
+      },
+    });
+
+    expect(result).toMatchObject({
+      transitionState: "lease_step_started",
+      label: "Lease step started",
+    });
+    expect(result.timelineEvent?.title).toBe("Lease step started");
+  });
+});

--- a/rentchain-frontend/src/pages/leaseFlowTransitionState.ts
+++ b/rentchain-frontend/src/pages/leaseFlowTransitionState.ts
@@ -1,0 +1,126 @@
+import type { TenantWorkspaceLease } from "../api/tenantPortal";
+import type { LandlordDecisionOutcomeView } from "./landlordDecisionOutcome";
+
+export type LeaseFlowTransitionState =
+  | "not_ready_for_lease"
+  | "ready_for_lease_step"
+  | "lease_step_started"
+  | "awaiting_next_action";
+
+export type LeaseFlowTransitionView = {
+  transitionState: LeaseFlowTransitionState;
+  label: string;
+  summary: string;
+  explanation: string;
+  blockers: string[];
+  nextActions: string[];
+  timelineEvent: {
+    title: string;
+    description: string;
+    actionRequired: boolean;
+  } | null;
+};
+
+function hasLeaseProjection(lease: TenantWorkspaceLease | null | undefined): boolean {
+  if (!lease) return false;
+  return Boolean(String(lease.leaseId || "").trim() || String(lease.status || "").trim());
+}
+
+function isTenantAudience(audience: "landlord" | "tenant") {
+  return audience === "tenant";
+}
+
+export function buildLeaseFlowTransitionState(input: {
+  audience: "landlord" | "tenant";
+  decisionOutcome: LandlordDecisionOutcomeView;
+  lease?: TenantWorkspaceLease | null;
+}): LeaseFlowTransitionView {
+  const lease = input.lease || null;
+  const leaseVisible = hasLeaseProjection(lease);
+
+  if (leaseVisible) {
+    return {
+      transitionState: "lease_step_started",
+      label: "Lease step started",
+      summary: "Lease transition",
+      explanation:
+        "A lease-related record is already visible in the current authorized workspace, so the post-decision transition has started.",
+      blockers: [],
+      nextActions: isTenantAudience(input.audience)
+        ? [
+            "Open your lease workspace to review the current lease-step information that is already available to you.",
+            "Wait for any additional lease-preparation instructions that appear in your tenant workspace.",
+          ]
+        : [
+            "Continue the lease preparation work using the current lease tools already available in the product.",
+            "Keep lease drafting or follow-on lease actions in the appropriate lease workflow rather than this review summary.",
+          ],
+      timelineEvent: {
+        title: "Lease step started",
+        description:
+          "A lease-related record is now visible in the current authorized workspace.",
+        actionRequired: false,
+      },
+    };
+  }
+
+  if (input.decisionOutcome.outcomeState !== "ready_for_next_step") {
+    return {
+      transitionState: "not_ready_for_lease",
+      label: "Not ready for lease step",
+      summary: "Lease transition",
+      explanation:
+        "This application is not ready to move into the lease step yet because the current decision outcome has not reached the next-step stage.",
+      blockers: input.decisionOutcome.blockers,
+      nextActions: input.decisionOutcome.outcomeState === "not_proceeding"
+        ? [
+            "No lease-step transition is shown because the current outcome is not proceeding.",
+          ]
+        : [
+            "Complete the remaining review and decision work before moving this file into the lease step.",
+            "Return to the lease transition view after the application outcome is ready for the next step.",
+          ],
+      timelineEvent: null,
+    };
+  }
+
+  if (isTenantAudience(input.audience)) {
+    return {
+      transitionState: "awaiting_next_action",
+      label: "Awaiting next lease action",
+      summary: "Lease transition",
+      explanation:
+        "The application outcome is ready for the next step, but no lease-step record is visible in your tenant workspace yet.",
+      blockers: [],
+      nextActions: [
+        "Watch for the next lease-preparation update in your tenant workspace.",
+        "Keep your profile and documents current in case the next step needs anything else from you.",
+      ],
+      timelineEvent: {
+        title: "Awaiting next lease action",
+        description:
+          "The application outcome is ready, and the next lease-related action has not appeared in the tenant workspace yet.",
+        actionRequired: false,
+      },
+    };
+  }
+
+  return {
+    transitionState: "ready_for_lease_step",
+    label: "Ready for lease step",
+    summary: "Lease transition",
+    explanation:
+      "The current application outcome is ready for the next step, and this file now appears ready to move into the lease flow.",
+    blockers: [],
+    nextActions: [
+      "Move this file into the lease flow using the current lease tools already supported in the product.",
+      "Keep lease drafting or activation actions in the existing lease workflow rather than this review summary.",
+    ],
+    timelineEvent: {
+      title: "Application marked ready for lease step",
+      description:
+        "The current application outcome now appears ready to move into the lease step.",
+      actionRequired: false,
+    },
+  };
+}

--- a/rentchain-frontend/src/pages/structuredActivityTimeline.test.ts
+++ b/rentchain-frontend/src/pages/structuredActivityTimeline.test.ts
@@ -92,8 +92,82 @@ describe("structuredActivityTimeline", () => {
     expect(
       result.some((item) => item.title === "Application placed on hold" && item.actionRequired)
     ).toBe(true);
+    expect(
+      result.some((item) => item.title === "Application marked ready for lease step")
+    ).toBe(false);
     expect(result.some((item) => item.title === "Review follow-up remains active" && item.actionRequired)).toBe(true);
     expect(result.some((item) => item.title === "Follow-up requested")).toBe(true);
     expect(result.some((item) => item.title === "Consent / identity status pending")).toBe(true);
+  });
+
+  it("includes a lease-step readiness event when the application is ready for the next step", () => {
+    const result = buildLandlordStructuredActivityTimeline({
+      applicationId: "app-2",
+      generatedAt: "2026-04-03T00:00:00.000Z",
+      applicant: {
+        name: "Jordan Applicant",
+        email: "jordan@example.com",
+        currentAddressLine: "12 Main St",
+        city: "Halifax",
+        provinceState: "NS",
+        postalCode: "B3H1A1",
+        country: "CA",
+        timeAtCurrentAddressMonths: 24,
+        currentRentAmountCents: 180000,
+      },
+      employment: {
+        employerName: "Acme",
+        jobTitle: "Manager",
+        incomeAmountCents: 7200000,
+        incomeFrequency: "annual",
+        incomeMonthlyCents: 600000,
+        monthsAtJob: 36,
+      },
+      reference: { name: "Sam Ref", phone: "555-0100" },
+      compliance: {
+        applicationConsentAcceptedAt: "2026-03-29T00:00:00.000Z",
+        applicationConsentVersion: "v1",
+        signatureType: "electronic",
+        signedAt: "2026-03-29T00:00:00.000Z",
+      },
+      screening: { status: "complete", provider: "transunion", referenceId: "TU-2" },
+      derived: { incomeToRentRatio: 3.2, completeness: { score: 0.92, label: "High" }, flags: [] },
+      insights: [],
+      decisionSummary: {
+        applicationId: "app-2",
+        screeningRecommendation: {
+          recommended: false,
+          reason: "Already complete.",
+          priority: "low",
+        },
+        screeningSummary: {
+          available: true,
+          provider: "transunion",
+          completedAt: "2026-04-01T00:00:00.000Z",
+          highlights: [],
+        },
+        riskSnapshot: {
+          version: "risk-v1",
+          status: "completed",
+          score: 78,
+          grade: "B",
+          confidence: 0.88,
+          factors: [],
+          flags: [],
+          recommendations: [],
+          updatedAt: "2026-04-04T00:00:00.000Z",
+        },
+      },
+      risk: null,
+    } as any);
+
+    expect(
+      result.some(
+        (item) =>
+          item.title === "Application marked ready for lease step" &&
+          item.actorLabel === "Decision workspace" &&
+          item.actionRequired === false
+      )
+    ).toBe(true);
   });
 });

--- a/rentchain-frontend/src/pages/structuredActivityTimeline.ts
+++ b/rentchain-frontend/src/pages/structuredActivityTimeline.ts
@@ -3,6 +3,7 @@ import type { TenantNotificationItem } from "../api/tenantNotifications";
 import { buildLandlordIntakeAlignmentView } from "./applicationReviewIntakeAlignment";
 import { buildLandlordDecisionWorkspace } from "./landlordDecisionWorkspace";
 import { buildLandlordDecisionOutcome } from "./landlordDecisionOutcome";
+import { buildLeaseFlowTransitionState } from "./leaseFlowTransitionState";
 
 export type StructuredActivityTimelineItem = {
   id: string;
@@ -114,6 +115,10 @@ export function buildLandlordStructuredActivityTimeline(
         : "partly_addressed",
     remainingCategories: intakeView.packageCategories.filter((item) => item.status === "missing"),
   });
+  const leaseTransition = buildLeaseFlowTransitionState({
+    audience: "landlord",
+    decisionOutcome,
+  });
 
   pushTimelineItem(items, {
     id: `review-summary-${summary.applicationId}`,
@@ -198,6 +203,21 @@ export function buildLandlordStructuredActivityTimeline(
     actionRequired: decisionOutcome.timelineEvent.actionRequired,
     relatedPath: null,
   });
+
+  if (leaseTransition.timelineEvent) {
+    pushTimelineItem(items, {
+      id: `lease-transition-${summary.applicationId}`,
+      type: leaseTransition.transitionState === "ready_for_lease_step" ? "ready_for_rereview" : "review_updated",
+      title: leaseTransition.timelineEvent.title,
+      description: leaseTransition.timelineEvent.description,
+      occurredAt:
+        summary.decisionSummary?.riskSnapshot?.updatedAt ||
+        summary.generatedAt,
+      actorLabel: "Decision workspace",
+      actionRequired: leaseTransition.timelineEvent.actionRequired,
+      relatedPath: null,
+    });
+  }
 
   return items.sort((left, right) => right.occurredAt - left.occurredAt);
 }

--- a/rentchain-frontend/src/pages/tenant/TenantApplicationCompletionPage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantApplicationCompletionPage.test.tsx
@@ -24,11 +24,16 @@ const tenantNotificationPreferencesApi = vi.hoisted(() => ({
   getTenantNotificationPreferences: vi.fn(),
 }));
 
+const tenantPortalApi = vi.hoisted(() => ({
+  getTenantLeaseWorkspace: vi.fn(),
+}));
+
 vi.mock("../../api/tenantApplicationCompletion", () => tenantApplicationCompletionApi);
 vi.mock("../../api/tenantProfile", () => tenantProfileApi);
 vi.mock("../../api/tenantAttachmentsApi", () => tenantAttachmentsApi);
 vi.mock("../../api/tenantAccess", () => tenantAccessApi);
 vi.mock("../../api/tenantNotificationPreferences", () => tenantNotificationPreferencesApi);
+vi.mock("../../api/tenantPortal", () => tenantPortalApi);
 
 describe("tenant application completion page", () => {
   beforeEach(() => {
@@ -136,6 +141,7 @@ describe("tenant application completion page", () => {
       },
       updatedAt: 1710000000000,
     });
+    tenantPortalApi.getTenantLeaseWorkspace.mockResolvedValue(null);
   });
 
   it("renders progress and grouped checklist safely", async () => {
@@ -189,7 +195,7 @@ describe("tenant application completion page", () => {
     expect(screen.getByText(/Flow Status/i)).toBeInTheDocument();
     expect(screen.getByText(/Needs attention before review/i)).toBeInTheDocument();
     expect(screen.getByText(/Invite entry/i)).toBeInTheDocument();
-    expect(screen.getByText(/^Next step$/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/^Next step$/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Application Readiness Summary/i)).toBeInTheDocument();
     expect(screen.getByText(/Recent activity \/ notifications/i)).toBeInTheDocument();
     expect(screen.getByText(/Recent workflow updates/i)).toBeInTheDocument();
@@ -203,8 +209,10 @@ describe("tenant application completion page", () => {
     expect(screen.getByText(/Still needs attention/i)).toBeInTheDocument();
     expect(screen.getByText(/^Addressed$/i)).toBeInTheDocument();
     expect(screen.getByText(/Application ready for re-review/i)).toBeInTheDocument();
-    expect(screen.getByText(/Decision outcome/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Decision outcome/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Hold for later/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/^Lease step$/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Not ready for lease step/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/What this means/i)).toBeInTheDocument();
     expect(screen.getByText(/derived from your current follow-up and re-review state/i)).toBeInTheDocument();
     expect(screen.getByText(/Go next/i)).toBeInTheDocument();
@@ -215,6 +223,34 @@ describe("tenant application completion page", () => {
     expect(screen.getAllByRole("link", { name: /Open documents/i }).length).toBeGreaterThan(0);
     expect(screen.getAllByRole("link", { name: /Review access/i }).length).toBeGreaterThan(0);
     expect(screen.getAllByRole("link", { name: /Review again/i }).length).toBeGreaterThan(0);
+  });
+
+  it("shows lease-step-started state when a lease workspace record is visible", async () => {
+    tenantPortalApi.getTenantLeaseWorkspace.mockResolvedValue({
+      leaseId: "lease-1",
+      startDate: "2026-05-01",
+      endDate: "2027-04-30",
+      monthlyRent: 180000,
+      status: "draft",
+      documentUrl: null,
+    });
+    tenantApplicationCompletionApi.getTenantApplicationCompletion.mockResolvedValue({
+      status: "completed",
+      progressPercent: 100,
+      sections: [],
+      nextSteps: [],
+      updatedAt: "2026-01-02T00:00:00.000Z",
+    });
+
+    render(
+      <MemoryRouter>
+        <TenantApplicationStatusPage />
+      </MemoryRouter>
+    );
+
+    expect((await screen.findAllByText(/Lease step/i)).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText(/Lease step started/i)).length).toBeGreaterThan(0);
+    expect(screen.getByRole("link", { name: /Open lease details/i })).toBeInTheDocument();
   });
 
   it("renders empty state safely", async () => {

--- a/rentchain-frontend/src/pages/tenant/TenantApplicationStatusPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantApplicationStatusPage.tsx
@@ -9,6 +9,7 @@ import { getTenantNotificationPreferences } from "../../api/tenantNotificationPr
 import { getTenantAccess } from "../../api/tenantAccess";
 import { getTenantAttachments } from "../../api/tenantAttachmentsApi";
 import { getTenantProfile } from "../../api/tenantProfile";
+import { getTenantLeaseWorkspace } from "../../api/tenantPortal";
 import {
   TenantEmptyState,
   TenantErrorState,
@@ -25,6 +26,7 @@ import { buildTenantApplicationFlow } from "./tenantApplicationFlow";
 import { buildTenantLandlordInteractionLoop } from "../tenantLandlordInteractionLoop";
 import { buildFollowUpResolutionState } from "../followUpResolutionState";
 import { buildLandlordDecisionOutcome } from "../landlordDecisionOutcome";
+import { buildLeaseFlowTransitionState } from "../leaseFlowTransitionState";
 import StructuredNotificationList from "../StructuredNotificationList";
 import { buildTenantStructuredNotificationTriggers } from "../structuredNotificationTriggers";
 import { filterStructuredNotificationsByPreferences } from "../notificationChannelRouting";
@@ -150,6 +152,7 @@ export default function TenantApplicationStatusPage() {
   const [profile, setProfile] = React.useState<Awaited<ReturnType<typeof getTenantProfile>> | null>(null);
   const [attachments, setAttachments] = React.useState<Awaited<ReturnType<typeof getTenantAttachments>> | null>(null);
   const [access, setAccess] = React.useState<Awaited<ReturnType<typeof getTenantAccess>> | null>(null);
+  const [lease, setLease] = React.useState<Awaited<ReturnType<typeof getTenantLeaseWorkspace>> | null>(null);
   const [notificationPreferences, setNotificationPreferences] = React.useState<Awaited<ReturnType<typeof getTenantNotificationPreferences>> | null>(null);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
@@ -158,11 +161,12 @@ export default function TenantApplicationStatusPage() {
     setLoading(true);
     setError(null);
     try {
-      const [completionResult, profileResult, attachmentsResult, accessResult, preferencesResult] = await Promise.allSettled([
+      const [completionResult, profileResult, attachmentsResult, accessResult, leaseResult, preferencesResult] = await Promise.allSettled([
         getTenantApplicationCompletion(),
         getTenantProfile(),
         getTenantAttachments(),
         getTenantAccess(),
+        getTenantLeaseWorkspace(),
         getTenantNotificationPreferences(),
       ]);
       if (completionResult.status !== "fulfilled") {
@@ -172,12 +176,14 @@ export default function TenantApplicationStatusPage() {
       setProfile(profileResult.status === "fulfilled" ? profileResult.value : null);
       setAttachments(attachmentsResult.status === "fulfilled" ? attachmentsResult.value : null);
       setAccess(accessResult.status === "fulfilled" ? accessResult.value : null);
+      setLease(leaseResult.status === "fulfilled" ? leaseResult.value : null);
       setNotificationPreferences(preferencesResult.status === "fulfilled" ? preferencesResult.value : null);
     } catch (err: any) {
       setData(null);
       setProfile(null);
       setAttachments(null);
       setAccess(null);
+      setLease(null);
       setNotificationPreferences(null);
       setError(err?.payload?.error || err?.message || "Unable to load application completion.");
     } finally {
@@ -271,12 +277,25 @@ export default function TenantApplicationStatusPage() {
     followUpOverallState: resolutionView.overallState,
     remainingCategories: resolutionView.remainingCategoriesNeedingAttention,
   });
+  const leaseTransition = buildLeaseFlowTransitionState({
+    audience: "tenant",
+    decisionOutcome,
+    lease,
+  });
   const decisionOutcomeTone =
     decisionOutcome.outcomeState === "ready_for_next_step"
       ? { color: "#166534", background: "#dcfce7", label: "Ready for next step" }
       : decisionOutcome.outcomeState === "not_proceeding"
       ? { color: "#7f1d1d", background: "#fee2e2", label: "Not proceeding" }
       : { color: "#1d4ed8", background: "#dbeafe", label: "Hold for later" };
+  const leaseTransitionTone =
+    leaseTransition.transitionState === "lease_step_started"
+      ? { color: "#0f766e", background: "#ccfbf1", label: "Lease step started" }
+      : leaseTransition.transitionState === "ready_for_lease_step"
+      ? { color: "#166534", background: "#dcfce7", label: "Ready for lease step" }
+      : leaseTransition.transitionState === "awaiting_next_action"
+      ? { color: "#1d4ed8", background: "#dbeafe", label: "Awaiting next action" }
+      : { color: "#9a3412", background: "#ffedd5", label: "Not ready for lease step" };
 
   return (
     <TenantSurfaceShell
@@ -527,6 +546,69 @@ export default function TenantApplicationStatusPage() {
                 {step}
               </div>
             ))}
+          </div>
+        </div>
+      </TenantInfoCard>
+
+      <TenantInfoCard heading="Lease step" accent="#7c3aed">
+        <div style={{ display: "grid", gap: spacing.sm }}>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+            <div>
+              <div style={{ fontWeight: 800, color: textTokens.primary }}>{leaseTransition.label}</div>
+              <div style={{ color: textTokens.secondary }}>{leaseTransition.explanation}</div>
+            </div>
+            <div
+              style={{
+                padding: "6px 10px",
+                borderRadius: 999,
+                fontWeight: 700,
+                color: leaseTransitionTone.color,
+                background: leaseTransitionTone.background,
+              }}
+            >
+              {leaseTransitionTone.label}
+            </div>
+          </div>
+
+          {leaseTransition.blockers.length ? (
+            <div
+              style={{
+                border: "1px solid rgba(15,23,42,0.08)",
+                borderRadius: 12,
+                padding: "12px 14px",
+                display: "grid",
+                gap: 8,
+              }}
+            >
+              <div style={{ fontWeight: 700, color: textTokens.primary }}>What is still blocking this step</div>
+              {leaseTransition.blockers.map((item) => (
+                <div key={item} style={{ color: textTokens.secondary }}>
+                  {item}
+                </div>
+              ))}
+            </div>
+          ) : null}
+
+          <div
+            style={{
+              border: "1px solid rgba(15,23,42,0.08)",
+              borderRadius: 12,
+              padding: "12px 14px",
+              display: "grid",
+              gap: 8,
+            }}
+          >
+            <div style={{ fontWeight: 700, color: textTokens.primary }}>Next step</div>
+            {leaseTransition.nextActions.map((step) => (
+              <div key={step} style={{ color: textTokens.secondary }}>
+                {step}
+              </div>
+            ))}
+            {leaseTransition.transitionState === "lease_step_started" ? (
+              <Link to="/tenant/lease" style={{ fontWeight: 700 }}>
+                Open lease details
+              </Link>
+            ) : null}
           </div>
         </div>
       </TenantInfoCard>


### PR DESCRIPTION
## Summary
Adds a read-first lease-flow transition layer after landlord decision outcome.

This PR introduces a shared pure helper that derives lease-step readiness from the current decision outcome and visible lease state, then surfaces that status in:
- the landlord review-summary decision workspace
- the tenant application readiness page
- the landlord structured activity timeline

## Scope
- shared lease transition helper
- landlord lease-step workspace UI
- tenant post-decision lease-step visibility
- landlord timeline lease-step event
- focused frontend tests

## Transition states
The helper derives a small, explainable set of states:
- not ready for lease step
- ready for lease step
- lease step started
- awaiting next action

The state is based only on:
- current landlord decision outcome
- currently visible authorized lease workspace state

## Implementation notes
- Read-first v1
- No backend or API changes
- No schema changes
- No auth or permission changes
- No fake persistence or lease automation
- Tenant messaging stays neutral and avoids implying lease completion or signing

## Validation
- Targeted frontend tests passed
- Frontend build passed

## Limitations
- No persisted “move to lease flow” action in this PR
- No lease drafting/signing workflow changes
- Timeline events are derived from current authorized state, not a stored transition history