### PR TITLE
feat(landlord): add lease preparation workspace v1

### DIFF
--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
@@ -149,6 +149,11 @@ describe("ApplicationReviewSummaryPage", () => {
     expect(await screen.findByText("Lease step")).toBeInTheDocument();
     expect(await screen.findByText("Not ready for lease step")).toBeInTheDocument();
     expect(await screen.findByText("Lease blockers")).toBeInTheDocument();
+    expect(await screen.findByText("Lease preparation")).toBeInTheDocument();
+    expect(await screen.findByText("Not started")).toBeInTheDocument();
+    expect(await screen.findByText("Completed items")).toBeInTheDocument();
+    expect(await screen.findByText("Outstanding items")).toBeInTheDocument();
+    expect(await screen.findByText("Preparation blockers")).toBeInTheDocument();
     expect(await screen.findByText("Recent updates")).toBeInTheDocument();
     expect(await screen.findByText(/Tenant updated follow-up items/i)).toBeInTheDocument();
     expect(await screen.findByText(/Follow-up stays organized by aligned package categories/i)).toBeInTheDocument();
@@ -231,6 +236,8 @@ describe("ApplicationReviewSummaryPage", () => {
     expect((await screen.findAllByText("Ready for decision")).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("Ready for next step")).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("Ready for lease step")).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText("Awaiting next action")).length).toBeGreaterThan(0);
+    expect(await screen.findByText(/A lease-preparation record is not visible from the current review-summary surface yet/i)).toBeInTheDocument();
     expect(await screen.findByText(/Move this file into the lease flow/i)).toBeInTheDocument();
     expect(await screen.findByText(/No decision blockers are currently surfaced/i)).toBeInTheDocument();
   });
@@ -307,6 +314,7 @@ describe("ApplicationReviewSummaryPage", () => {
     expect((await screen.findAllByText("Decision workspace")).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("Hold for later")).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("Not ready for lease step")).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText("Not started")).length).toBeGreaterThan(0);
     expect(
       (await screen.findAllByText(/Screening is still recommended before moving this file/i)).length
     ).toBeGreaterThan(0);

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
@@ -25,6 +25,7 @@ import { buildFollowUpResolutionState } from "./followUpResolutionState";
 import { buildLandlordDecisionWorkspace } from "./landlordDecisionWorkspace";
 import { buildLandlordDecisionOutcome } from "./landlordDecisionOutcome";
 import { buildLeaseFlowTransitionState } from "./leaseFlowTransitionState";
+import { buildLeasePreparationWorkspaceState } from "./leasePreparationWorkspaceState";
 import StructuredNotificationList from "./StructuredNotificationList";
 import { buildLandlordStructuredNotificationTriggers } from "./structuredNotificationTriggers";
 
@@ -112,6 +113,24 @@ function leaseTransitionTone(
     return { color: "#1d4ed8", background: "#dbeafe", label: "Awaiting next action" };
   }
   return { color: "#9a3412", background: "#ffedd5", label: "Not ready for lease step" };
+}
+
+function leasePreparationTone(
+  state: "not_started" | "preparing_lease" | "needs_attention" | "ready_for_execution" | "awaiting_next_action"
+) {
+  if (state === "ready_for_execution") {
+    return { color: "#166534", background: "#dcfce7", label: "Ready for execution" };
+  }
+  if (state === "preparing_lease") {
+    return { color: "#0f766e", background: "#ccfbf1", label: "Preparing lease" };
+  }
+  if (state === "awaiting_next_action") {
+    return { color: "#1d4ed8", background: "#dbeafe", label: "Awaiting next action" };
+  }
+  if (state === "needs_attention") {
+    return { color: "#9a3412", background: "#ffedd5", label: "Needs attention" };
+  }
+  return { color: "#64748b", background: "#e2e8f0", label: "Not started" };
 }
 
 type SummaryLoadError = {
@@ -332,6 +351,18 @@ function ApplicationReviewSummaryPageBody() {
           })
         : null,
     [decisionOutcome]
+  );
+  const leasePreparation = useMemo(
+    () =>
+      decisionOutcome && leaseTransition && intakeView
+        ? buildLeasePreparationWorkspaceState({
+            audience: "landlord",
+            decisionOutcome,
+            leaseTransition,
+            packageCategories: intakeView.packageCategories,
+          })
+        : null,
+    [decisionOutcome, intakeView, leaseTransition]
   );
 
   const recentActivity = useMemo(
@@ -890,6 +921,128 @@ function ApplicationReviewSummaryPageBody() {
                     >
                       <div style={{ fontWeight: 700, color: text.main }}>Next action</div>
                       {leaseTransition.nextActions.map((step) => (
+                        <div key={step} style={{ fontSize: 13, color: text.subtle }}>
+                          {step}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              ) : null}
+
+              {leasePreparation ? (
+                <div
+                  style={{
+                    border: `1px solid ${colors.border}`,
+                    borderRadius: 10,
+                    padding: 10,
+                    display: "grid",
+                    gap: 10,
+                  }}
+                >
+                  <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+                    <div>
+                      <div style={{ fontWeight: 700, color: text.main }}>Lease preparation</div>
+                      <div style={{ fontSize: 13, color: text.subtle, marginTop: 4 }}>
+                        {leasePreparation.explanation}
+                      </div>
+                    </div>
+                    <div
+                      style={{
+                        padding: "6px 10px",
+                        borderRadius: 999,
+                        fontWeight: 700,
+                        color: leasePreparationTone(leasePreparation.preparationState).color,
+                        background: leasePreparationTone(leasePreparation.preparationState).background,
+                      }}
+                    >
+                      {leasePreparationTone(leasePreparation.preparationState).label}
+                    </div>
+                  </div>
+
+                  <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 8 }}>
+                    <div
+                      style={{
+                        border: `1px solid ${colors.border}`,
+                        borderRadius: 10,
+                        padding: 10,
+                        display: "grid",
+                        gap: 6,
+                      }}
+                    >
+                      <div style={{ fontWeight: 700, color: text.main }}>Completed items</div>
+                      {leasePreparation.completedItems.length ? (
+                        leasePreparation.completedItems.map((item) => (
+                          <div key={item.key} style={{ fontSize: 13, color: text.subtle }}>
+                            <strong style={{ color: text.main }}>{item.label}:</strong> {item.detail}
+                          </div>
+                        ))
+                      ) : (
+                        <div style={{ fontSize: 13, color: text.subtle }}>
+                          No completed lease-preparation items are surfaced from this review-summary view yet.
+                        </div>
+                      )}
+                    </div>
+
+                    <div
+                      style={{
+                        border: `1px solid ${colors.border}`,
+                        borderRadius: 10,
+                        padding: 10,
+                        display: "grid",
+                        gap: 6,
+                      }}
+                    >
+                      <div style={{ fontWeight: 700, color: text.main }}>Outstanding items</div>
+                      {leasePreparation.outstandingItems.length ? (
+                        leasePreparation.outstandingItems.map((item) => (
+                          <div key={item.key} style={{ fontSize: 13, color: text.subtle }}>
+                            <strong style={{ color: text.main }}>{item.label}:</strong> {item.detail}
+                          </div>
+                        ))
+                      ) : (
+                        <div style={{ fontSize: 13, color: text.subtle }}>
+                          No outstanding lease-preparation items are currently surfaced from the visible review state.
+                        </div>
+                      )}
+                    </div>
+                  </div>
+
+                  <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 8 }}>
+                    <div
+                      style={{
+                        border: `1px solid ${colors.border}`,
+                        borderRadius: 10,
+                        padding: 10,
+                        display: "grid",
+                        gap: 6,
+                      }}
+                    >
+                      <div style={{ fontWeight: 700, color: text.main }}>Preparation blockers</div>
+                      {leasePreparation.blockers.length ? (
+                        leasePreparation.blockers.map((item) => (
+                          <div key={item} style={{ fontSize: 13, color: text.subtle }}>
+                            {item}
+                          </div>
+                        ))
+                      ) : (
+                        <div style={{ fontSize: 13, color: text.subtle }}>
+                          No current blockers are surfaced in this read-first preparation workspace.
+                        </div>
+                      )}
+                    </div>
+
+                    <div
+                      style={{
+                        border: `1px solid ${colors.border}`,
+                        borderRadius: 10,
+                        padding: 10,
+                        display: "grid",
+                        gap: 6,
+                      }}
+                    >
+                      <div style={{ fontWeight: 700, color: text.main }}>Next steps</div>
+                      {leasePreparation.nextActions.map((step) => (
                         <div key={step} style={{ fontSize: 13, color: text.subtle }}>
                           {step}
                         </div>

--- a/rentchain-frontend/src/pages/leasePreparationWorkspaceState.test.ts
+++ b/rentchain-frontend/src/pages/leasePreparationWorkspaceState.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import { buildLeasePreparationWorkspaceState } from "./leasePreparationWorkspaceState";
+
+const readyPackageCategories = [
+  { key: "profile_details", label: "Profile details", status: "ready", detail: "Ready." },
+  { key: "rental_history", label: "Rental history", status: "ready", detail: "Ready." },
+  { key: "documents_records", label: "Documents & records", status: "ready", detail: "Ready." },
+  { key: "consent_identity_status", label: "Consent / identity status", status: "ready", detail: "Ready." },
+  { key: "application_readiness", label: "Application readiness", status: "ready", detail: "Ready." },
+] as const;
+
+describe("leasePreparationWorkspaceState", () => {
+  it("stays not started when the lease step is not ready", () => {
+    const result = buildLeasePreparationWorkspaceState({
+      audience: "landlord",
+      decisionOutcome: {
+        outcomeState: "hold_for_later",
+        label: "Hold for later",
+        source: "derived",
+        sourceLabel: "Derived",
+        description: "Still on hold.",
+        tenantDescription: "Still on hold.",
+        blockers: ["Follow-up is still open."],
+        landlordNextSteps: ["Wait."],
+        tenantNextSteps: ["Wait."],
+        timelineEvent: { title: "Hold", description: "Hold", actionRequired: true },
+      },
+      leaseTransition: {
+        transitionState: "not_ready_for_lease",
+        label: "Not ready for lease step",
+        summary: "Lease transition",
+        explanation: "Not ready yet.",
+        blockers: ["Follow-up is still open."],
+        nextActions: ["Finish follow-up."],
+        timelineEvent: null,
+      },
+      packageCategories: readyPackageCategories as any,
+    });
+
+    expect(result.preparationState).toBe("not_started");
+    expect(result.timelineEvent).toBeNull();
+  });
+
+  it("shows awaiting next action when the file is ready but no lease record is visible", () => {
+    const result = buildLeasePreparationWorkspaceState({
+      audience: "landlord",
+      decisionOutcome: {
+        outcomeState: "ready_for_next_step",
+        label: "Ready for next step",
+        source: "derived",
+        sourceLabel: "Derived",
+        description: "Ready.",
+        tenantDescription: "Ready.",
+        blockers: [],
+        landlordNextSteps: ["Proceed."],
+        tenantNextSteps: ["Wait."],
+        timelineEvent: { title: "Ready", description: "Ready", actionRequired: false },
+      },
+      leaseTransition: {
+        transitionState: "ready_for_lease_step",
+        label: "Ready for lease step",
+        summary: "Lease transition",
+        explanation: "Ready for lease step.",
+        blockers: [],
+        nextActions: ["Start lease step."],
+        timelineEvent: { title: "Lease ready", description: "Lease ready", actionRequired: false },
+      },
+      packageCategories: readyPackageCategories as any,
+    });
+
+    expect(result.preparationState).toBe("awaiting_next_action");
+    expect(result.timelineEvent?.title).toBe("Lease preparation awaiting next action");
+  });
+
+  it("shows preparing lease when a lease record is visible but no document is available yet", () => {
+    const result = buildLeasePreparationWorkspaceState({
+      audience: "tenant",
+      decisionOutcome: {
+        outcomeState: "ready_for_next_step",
+        label: "Ready for next step",
+        source: "derived",
+        sourceLabel: "Derived",
+        description: "Ready.",
+        tenantDescription: "Ready.",
+        blockers: [],
+        landlordNextSteps: ["Proceed."],
+        tenantNextSteps: ["Wait."],
+        timelineEvent: { title: "Ready", description: "Ready", actionRequired: false },
+      },
+      leaseTransition: {
+        transitionState: "lease_step_started",
+        label: "Lease step started",
+        summary: "Lease transition",
+        explanation: "Started.",
+        blockers: [],
+        nextActions: ["Review lease step."],
+        timelineEvent: { title: "Lease started", description: "Started", actionRequired: false },
+      },
+      packageCategories: readyPackageCategories as any,
+      lease: {
+        leaseId: "lease-1",
+        startDate: "2026-05-01",
+        endDate: "2027-04-30",
+        monthlyRent: 180000,
+        status: "draft",
+        documentUrl: null,
+      },
+    });
+
+    expect(result.preparationState).toBe("preparing_lease");
+    expect(result.outstandingItems.some((item) => item.label === "Lease document availability")).toBe(true);
+  });
+
+  it("shows ready for execution when the visible preparation record includes a document", () => {
+    const result = buildLeasePreparationWorkspaceState({
+      audience: "tenant",
+      decisionOutcome: {
+        outcomeState: "ready_for_next_step",
+        label: "Ready for next step",
+        source: "derived",
+        sourceLabel: "Derived",
+        description: "Ready.",
+        tenantDescription: "Ready.",
+        blockers: [],
+        landlordNextSteps: ["Proceed."],
+        tenantNextSteps: ["Wait."],
+        timelineEvent: { title: "Ready", description: "Ready", actionRequired: false },
+      },
+      leaseTransition: {
+        transitionState: "lease_step_started",
+        label: "Lease step started",
+        summary: "Lease transition",
+        explanation: "Started.",
+        blockers: [],
+        nextActions: ["Review lease step."],
+        timelineEvent: { title: "Lease started", description: "Started", actionRequired: false },
+      },
+      packageCategories: readyPackageCategories as any,
+      lease: {
+        leaseId: "lease-1",
+        startDate: "2026-05-01",
+        endDate: "2027-04-30",
+        monthlyRent: 180000,
+        status: "draft",
+        documentUrl: "https://example.com/lease.pdf",
+      },
+    });
+
+    expect(result.preparationState).toBe("ready_for_execution");
+    expect(result.timelineEvent?.title).toBe("Lease preparation ready for execution");
+  });
+});

--- a/rentchain-frontend/src/pages/leasePreparationWorkspaceState.ts
+++ b/rentchain-frontend/src/pages/leasePreparationWorkspaceState.ts
@@ -1,0 +1,319 @@
+import type { SharePackageCategoryView } from "./sharePackageAlignment";
+import type { LeaseFlowTransitionView } from "./leaseFlowTransitionState";
+import type { LandlordDecisionOutcomeView } from "./landlordDecisionOutcome";
+import type { TenantWorkspaceLease } from "../api/tenantPortal";
+
+export type LeasePreparationWorkspaceState =
+  | "not_started"
+  | "preparing_lease"
+  | "needs_attention"
+  | "ready_for_execution"
+  | "awaiting_next_action";
+
+export type LeasePreparationWorkspaceItem = {
+  key: string;
+  label: string;
+  detail: string;
+};
+
+export type LeasePreparationWorkspaceView = {
+  preparationState: LeasePreparationWorkspaceState;
+  label: string;
+  summary: string;
+  explanation: string;
+  completedItems: LeasePreparationWorkspaceItem[];
+  outstandingItems: LeasePreparationWorkspaceItem[];
+  blockers: string[];
+  nextActions: string[];
+  timelineEvent: {
+    title: string;
+    description: string;
+    actionRequired: boolean;
+  } | null;
+};
+
+function hasLeaseProjection(lease: TenantWorkspaceLease | null | undefined): boolean {
+  if (!lease) return false;
+  return Boolean(String(lease.leaseId || "").trim() || String(lease.status || "").trim());
+}
+
+function hasLeaseDocument(lease: TenantWorkspaceLease | null | undefined): boolean {
+  return Boolean(String(lease?.documentUrl || "").trim());
+}
+
+function stateLabel(state: LeasePreparationWorkspaceState): string {
+  if (state === "ready_for_execution") return "Ready for execution";
+  if (state === "preparing_lease") return "Preparing lease";
+  if (state === "needs_attention") return "Needs attention";
+  if (state === "awaiting_next_action") return "Awaiting next action";
+  return "Not started";
+}
+
+function completedCategoryItems(
+  packageCategories: SharePackageCategoryView[]
+): LeasePreparationWorkspaceItem[] {
+  return packageCategories
+    .filter((item) => item.status !== "missing")
+    .map((item) => ({
+      key: item.key,
+      label: item.label,
+      detail:
+        item.status === "ready"
+          ? `${item.label} is visible and ready in the current workflow state.`
+          : `${item.label} is partly visible and can still support lease preparation review.`,
+    }));
+}
+
+function outstandingCategoryItems(
+  packageCategories: SharePackageCategoryView[]
+): LeasePreparationWorkspaceItem[] {
+  return packageCategories
+    .filter((item) => item.status === "missing")
+    .map((item) => ({
+      key: item.key,
+      label: item.label,
+      detail: item.detail,
+    }));
+}
+
+function timelineForState(
+  state: LeasePreparationWorkspaceState
+): LeasePreparationWorkspaceView["timelineEvent"] {
+  if (state === "preparing_lease") {
+    return {
+      title: "Lease preparation started",
+      description:
+        "The lease step is visible and the current preparation checklist is now in progress.",
+      actionRequired: false,
+    };
+  }
+  if (state === "needs_attention") {
+    return {
+      title: "Lease preparation updated",
+      description:
+        "Visible preparation items still need attention before the lease can move forward.",
+      actionRequired: true,
+    };
+  }
+  if (state === "ready_for_execution") {
+    return {
+      title: "Lease preparation ready for execution",
+      description:
+        "The currently visible preparation items appear organized enough for the next lease execution step.",
+      actionRequired: false,
+    };
+  }
+  if (state === "awaiting_next_action") {
+    return {
+      title: "Lease preparation awaiting next action",
+      description:
+        "The file looks ready to begin lease preparation, and the next supported action is still pending.",
+      actionRequired: false,
+    };
+  }
+  return null;
+}
+
+export function buildLeasePreparationWorkspaceState(input: {
+  audience: "landlord" | "tenant";
+  decisionOutcome: LandlordDecisionOutcomeView;
+  leaseTransition: LeaseFlowTransitionView;
+  packageCategories: SharePackageCategoryView[];
+  lease?: TenantWorkspaceLease | null;
+}): LeasePreparationWorkspaceView {
+  const lease = input.lease || null;
+  const outstandingItems = outstandingCategoryItems(input.packageCategories);
+  const completedItems = completedCategoryItems(input.packageCategories);
+  const leaseVisible = hasLeaseProjection(lease);
+  const leaseDocumentVisible = hasLeaseDocument(lease);
+  const leaseReady = input.decisionOutcome.outcomeState === "ready_for_next_step";
+  const baseCompleted: LeasePreparationWorkspaceItem[] = leaseReady
+    ? [
+        ...completedItems,
+        {
+          key: "decision_outcome",
+          label: "Application outcome",
+          detail: "The current decision outcome appears ready for the next supported step.",
+        },
+      ]
+    : completedItems;
+
+  if (input.leaseTransition.transitionState === "not_ready_for_lease") {
+    return {
+      preparationState: "not_started",
+      label: stateLabel("not_started"),
+      summary: "Lease preparation",
+      explanation:
+        "Lease preparation has not started because the application is not yet ready to move beyond the current decision and follow-up workflow.",
+      completedItems: completedItems,
+      outstandingItems: [
+        ...outstandingItems,
+        {
+          key: "lease_step",
+          label: "Lease step readiness",
+          detail: "The lease step has not started because the current application outcome is not ready yet.",
+        },
+      ],
+      blockers: input.leaseTransition.blockers,
+      nextActions:
+        input.audience === "landlord"
+          ? [
+              "Finish the remaining review and follow-up work before starting lease preparation.",
+              "Return to this workspace after the application is ready for the next step.",
+            ]
+          : [
+              "Finish the remaining application updates that are still visible in your tenant workspace.",
+              "Check back once the landlord has moved the file into the next supported step.",
+            ],
+      timelineEvent: null,
+    };
+  }
+
+  if (outstandingItems.length > 0) {
+    return {
+      preparationState: "needs_attention",
+      label: stateLabel("needs_attention"),
+      summary: "Lease preparation",
+      explanation:
+        "Lease preparation can move forward only after the remaining visible package gaps are addressed.",
+      completedItems: baseCompleted,
+      outstandingItems: [
+        ...outstandingItems,
+        {
+          key: "lease_transition",
+          label: "Lease step readiness",
+          detail:
+            input.leaseTransition.transitionState === "lease_step_started"
+              ? "A lease-related record is visible, but the remaining preparation items still need attention."
+              : "The file is approaching lease preparation, but the remaining visible items still need attention first.",
+        },
+      ],
+      blockers: outstandingItems.map((item) => `${item.label} still needs attention before lease preparation can settle.`),
+      nextActions:
+        input.audience === "landlord"
+          ? [
+              "Review the outstanding package categories and keep lease preparation read-first until those items are clearer.",
+              "Use the existing lease workflow only after the missing visible items are stronger.",
+            ]
+          : [
+              "Address the remaining package items that still show as missing before the lease can move forward.",
+              "Keep your documents, access, and profile current while the next lease step is being prepared.",
+            ],
+      timelineEvent: timelineForState("needs_attention"),
+    };
+  }
+
+  if (!leaseVisible) {
+    return {
+      preparationState: "awaiting_next_action",
+      label: stateLabel("awaiting_next_action"),
+      summary: "Lease preparation",
+      explanation:
+        "The visible package appears ready for lease preparation, but no lease-preparation record is surfaced in the current workspace yet.",
+      completedItems: [
+        ...baseCompleted,
+        {
+          key: "lease_transition",
+          label: "Lease step readiness",
+          detail: "The file now appears ready to move into lease preparation.",
+        },
+      ],
+      outstandingItems: [
+        {
+          key: "lease_record",
+          label: "Lease preparation record",
+          detail:
+            input.audience === "landlord"
+              ? "A lease-preparation record is not visible from the current review-summary surface yet."
+              : "A lease-preparation record is not visible in your tenant workspace yet.",
+        },
+      ],
+      blockers: [],
+      nextActions:
+        input.audience === "landlord"
+          ? [
+              "Start the next supported lease-preparation action from the existing lease workflow when you are ready.",
+              "Use this checklist to confirm the file stays organized while the lease step begins.",
+            ]
+          : [
+              "Watch for the next lease-preparation update in your tenant workspace.",
+              "Keep your current profile and supporting records available in case anything else needs confirmation.",
+            ],
+      timelineEvent: timelineForState("awaiting_next_action"),
+    };
+  }
+
+  if (!leaseDocumentVisible) {
+    return {
+      preparationState: "preparing_lease",
+      label: stateLabel("preparing_lease"),
+      summary: "Lease preparation",
+      explanation:
+        "Lease preparation is in progress because a lease-related record is visible, but the visible preparation checklist is not fully assembled yet.",
+      completedItems: [
+        ...baseCompleted,
+        {
+          key: "lease_record",
+          label: "Lease preparation record",
+          detail: "A lease-related record is visible in the current authorized workspace.",
+        },
+      ],
+      outstandingItems: [
+        {
+          key: "lease_document",
+          label: "Lease document availability",
+          detail:
+            input.audience === "landlord"
+              ? "The review-summary workspace does not show a completed lease document yet."
+              : "A lease document is not visible in your tenant workspace yet.",
+        },
+      ],
+      blockers: [],
+      nextActions:
+        input.audience === "landlord"
+          ? [
+              "Continue the supported lease-preparation work in the existing lease workflow.",
+              "Return here to confirm when the visible preparation items are ready for the next step.",
+            ]
+          : [
+              "Watch for the lease document or next preparation update in your tenant workspace.",
+              "Review any newly visible lease details once they appear.",
+            ],
+      timelineEvent: timelineForState("preparing_lease"),
+    };
+  }
+
+  return {
+    preparationState: "ready_for_execution",
+    label: stateLabel("ready_for_execution"),
+    summary: "Lease preparation",
+    explanation:
+      "The currently visible preparation items appear organized enough for the next supported lease execution step.",
+    completedItems: [
+      ...baseCompleted,
+      {
+        key: "lease_record",
+        label: "Lease preparation record",
+        detail: "A lease-related record is visible in the current authorized workspace.",
+      },
+      {
+        key: "lease_document",
+        label: "Lease document availability",
+        detail: "A lease document is already visible in the current workspace.",
+      },
+    ],
+    outstandingItems: [],
+    blockers: [],
+    nextActions:
+      input.audience === "landlord"
+        ? [
+            "Continue to the next supported execution step in the existing lease workflow.",
+            "Keep any final execution or signing actions inside the current lease tools rather than this read-first workspace.",
+          ]
+        : [
+            "Review the visible lease details and watch for the next supported execution instruction.",
+            "Use your lease workspace if you need to revisit the currently visible lease information.",
+          ],
+    timelineEvent: timelineForState("ready_for_execution"),
+  };
+}

--- a/rentchain-frontend/src/pages/structuredActivityTimeline.test.ts
+++ b/rentchain-frontend/src/pages/structuredActivityTimeline.test.ts
@@ -95,6 +95,9 @@ describe("structuredActivityTimeline", () => {
     expect(
       result.some((item) => item.title === "Application marked ready for lease step")
     ).toBe(false);
+    expect(
+      result.some((item) => item.title === "Lease preparation awaiting next action")
+    ).toBe(false);
     expect(result.some((item) => item.title === "Review follow-up remains active" && item.actionRequired)).toBe(true);
     expect(result.some((item) => item.title === "Follow-up requested")).toBe(true);
     expect(result.some((item) => item.title === "Consent / identity status pending")).toBe(true);
@@ -166,6 +169,14 @@ describe("structuredActivityTimeline", () => {
         (item) =>
           item.title === "Application marked ready for lease step" &&
           item.actorLabel === "Decision workspace" &&
+          item.actionRequired === false
+      )
+    ).toBe(true);
+    expect(
+      result.some(
+        (item) =>
+          item.title === "Lease preparation awaiting next action" &&
+          item.actorLabel === "Lease preparation" &&
           item.actionRequired === false
       )
     ).toBe(true);

--- a/rentchain-frontend/src/pages/structuredActivityTimeline.ts
+++ b/rentchain-frontend/src/pages/structuredActivityTimeline.ts
@@ -4,6 +4,7 @@ import { buildLandlordIntakeAlignmentView } from "./applicationReviewIntakeAlign
 import { buildLandlordDecisionWorkspace } from "./landlordDecisionWorkspace";
 import { buildLandlordDecisionOutcome } from "./landlordDecisionOutcome";
 import { buildLeaseFlowTransitionState } from "./leaseFlowTransitionState";
+import { buildLeasePreparationWorkspaceState } from "./leasePreparationWorkspaceState";
 
 export type StructuredActivityTimelineItem = {
   id: string;
@@ -119,6 +120,12 @@ export function buildLandlordStructuredActivityTimeline(
     audience: "landlord",
     decisionOutcome,
   });
+  const leasePreparation = buildLeasePreparationWorkspaceState({
+    audience: "landlord",
+    decisionOutcome,
+    leaseTransition,
+    packageCategories: intakeView.packageCategories,
+  });
 
   pushTimelineItem(items, {
     id: `review-summary-${summary.applicationId}`,
@@ -215,6 +222,24 @@ export function buildLandlordStructuredActivityTimeline(
         summary.generatedAt,
       actorLabel: "Decision workspace",
       actionRequired: leaseTransition.timelineEvent.actionRequired,
+      relatedPath: null,
+    });
+  }
+
+  if (leasePreparation.timelineEvent) {
+    pushTimelineItem(items, {
+      id: `lease-preparation-${summary.applicationId}`,
+      type:
+        leasePreparation.preparationState === "ready_for_execution"
+          ? "ready_for_rereview"
+          : "review_updated",
+      title: leasePreparation.timelineEvent.title,
+      description: leasePreparation.timelineEvent.description,
+      occurredAt:
+        summary.decisionSummary?.riskSnapshot?.updatedAt ||
+        summary.generatedAt,
+      actorLabel: "Lease preparation",
+      actionRequired: leasePreparation.timelineEvent.actionRequired,
       relatedPath: null,
     });
   }

--- a/rentchain-frontend/src/pages/tenant/TenantApplicationCompletionPage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantApplicationCompletionPage.test.tsx
@@ -213,6 +213,10 @@ describe("tenant application completion page", () => {
     expect(screen.getAllByText(/Hold for later/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/^Lease step$/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Not ready for lease step/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Lease preparation/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Not started/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Completed items/i)).toBeInTheDocument();
+    expect(screen.getByText(/Outstanding items/i)).toBeInTheDocument();
     expect(screen.getByText(/What this means/i)).toBeInTheDocument();
     expect(screen.getByText(/derived from your current follow-up and re-review state/i)).toBeInTheDocument();
     expect(screen.getByText(/Go next/i)).toBeInTheDocument();
@@ -250,7 +254,37 @@ describe("tenant application completion page", () => {
 
     expect((await screen.findAllByText(/Lease step/i)).length).toBeGreaterThan(0);
     expect((await screen.findAllByText(/Lease step started/i)).length).toBeGreaterThan(0);
-    expect(screen.getByRole("link", { name: /Open lease details/i })).toBeInTheDocument();
+    expect((await screen.findAllByText(/Lease preparation/i)).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText(/Preparing lease/i)).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("link", { name: /Open lease details/i }).length).toBeGreaterThan(0);
+  });
+
+  it("shows ready-for-execution preparation when the lease document is already visible", async () => {
+    tenantPortalApi.getTenantLeaseWorkspace.mockResolvedValue({
+      leaseId: "lease-1",
+      startDate: "2026-05-01",
+      endDate: "2027-04-30",
+      monthlyRent: 180000,
+      status: "draft",
+      documentUrl: "https://example.com/lease.pdf",
+    });
+    tenantApplicationCompletionApi.getTenantApplicationCompletion.mockResolvedValue({
+      status: "completed",
+      progressPercent: 100,
+      sections: [],
+      nextSteps: [],
+      updatedAt: "2026-01-02T00:00:00.000Z",
+    });
+
+    render(
+      <MemoryRouter>
+        <TenantApplicationStatusPage />
+      </MemoryRouter>
+    );
+
+    expect((await screen.findAllByText(/Lease preparation/i)).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText(/Ready for execution/i)).length).toBeGreaterThan(0);
+    expect(screen.getByText(/A lease document is already visible in the current workspace/i)).toBeInTheDocument();
   });
 
   it("renders empty state safely", async () => {

--- a/rentchain-frontend/src/pages/tenant/TenantApplicationStatusPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantApplicationStatusPage.tsx
@@ -27,6 +27,7 @@ import { buildTenantLandlordInteractionLoop } from "../tenantLandlordInteraction
 import { buildFollowUpResolutionState } from "../followUpResolutionState";
 import { buildLandlordDecisionOutcome } from "../landlordDecisionOutcome";
 import { buildLeaseFlowTransitionState } from "../leaseFlowTransitionState";
+import { buildLeasePreparationWorkspaceState } from "../leasePreparationWorkspaceState";
 import StructuredNotificationList from "../StructuredNotificationList";
 import { buildTenantStructuredNotificationTriggers } from "../structuredNotificationTriggers";
 import { filterStructuredNotificationsByPreferences } from "../notificationChannelRouting";
@@ -282,6 +283,13 @@ export default function TenantApplicationStatusPage() {
     decisionOutcome,
     lease,
   });
+  const leasePreparation = buildLeasePreparationWorkspaceState({
+    audience: "tenant",
+    decisionOutcome,
+    leaseTransition,
+    packageCategories: reuse.packageCategories,
+    lease,
+  });
   const decisionOutcomeTone =
     decisionOutcome.outcomeState === "ready_for_next_step"
       ? { color: "#166534", background: "#dcfce7", label: "Ready for next step" }
@@ -296,6 +304,16 @@ export default function TenantApplicationStatusPage() {
       : leaseTransition.transitionState === "awaiting_next_action"
       ? { color: "#1d4ed8", background: "#dbeafe", label: "Awaiting next action" }
       : { color: "#9a3412", background: "#ffedd5", label: "Not ready for lease step" };
+  const leasePreparationTone =
+    leasePreparation.preparationState === "ready_for_execution"
+      ? { color: "#166534", background: "#dcfce7", label: "Ready for execution" }
+      : leasePreparation.preparationState === "preparing_lease"
+      ? { color: "#0f766e", background: "#ccfbf1", label: "Preparing lease" }
+      : leasePreparation.preparationState === "awaiting_next_action"
+      ? { color: "#1d4ed8", background: "#dbeafe", label: "Awaiting next action" }
+      : leasePreparation.preparationState === "needs_attention"
+      ? { color: "#9a3412", background: "#ffedd5", label: "Needs attention" }
+      : { color: "#64748b", background: "#e2e8f0", label: "Not started" };
 
   return (
     <TenantSurfaceShell
@@ -600,6 +618,115 @@ export default function TenantApplicationStatusPage() {
           >
             <div style={{ fontWeight: 700, color: textTokens.primary }}>Next step</div>
             {leaseTransition.nextActions.map((step) => (
+              <div key={step} style={{ color: textTokens.secondary }}>
+                {step}
+              </div>
+            ))}
+            {leaseTransition.transitionState === "lease_step_started" ? (
+              <Link to="/tenant/lease" style={{ fontWeight: 700 }}>
+                Open lease details
+              </Link>
+            ) : null}
+          </div>
+        </div>
+      </TenantInfoCard>
+
+      <TenantInfoCard heading="Lease preparation" accent="#6d28d9">
+        <div style={{ display: "grid", gap: spacing.sm }}>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+            <div>
+              <div style={{ fontWeight: 800, color: textTokens.primary }}>{leasePreparation.label}</div>
+              <div style={{ color: textTokens.secondary }}>{leasePreparation.explanation}</div>
+            </div>
+            <div
+              style={{
+                padding: "6px 10px",
+                borderRadius: 999,
+                fontWeight: 700,
+                color: leasePreparationTone.color,
+                background: leasePreparationTone.background,
+              }}
+            >
+              {leasePreparationTone.label}
+            </div>
+          </div>
+
+          <div
+            style={{
+              border: "1px solid rgba(15,23,42,0.08)",
+              borderRadius: 12,
+              padding: "12px 14px",
+              display: "grid",
+              gap: 8,
+            }}
+          >
+            <div style={{ fontWeight: 700, color: textTokens.primary }}>Completed items</div>
+            {leasePreparation.completedItems.length ? (
+              leasePreparation.completedItems.map((item) => (
+                <div key={item.key} style={{ color: textTokens.secondary }}>
+                  <strong style={{ color: textTokens.primary }}>{item.label}:</strong> {item.detail}
+                </div>
+              ))
+            ) : (
+              <div style={{ color: textTokens.secondary }}>
+                No completed lease-preparation items are visible in your tenant workspace yet.
+              </div>
+            )}
+          </div>
+
+          <div
+            style={{
+              border: "1px solid rgba(15,23,42,0.08)",
+              borderRadius: 12,
+              padding: "12px 14px",
+              display: "grid",
+              gap: 8,
+            }}
+          >
+            <div style={{ fontWeight: 700, color: textTokens.primary }}>Outstanding items</div>
+            {leasePreparation.outstandingItems.length ? (
+              leasePreparation.outstandingItems.map((item) => (
+                <div key={item.key} style={{ color: textTokens.secondary }}>
+                  <strong style={{ color: textTokens.primary }}>{item.label}:</strong> {item.detail}
+                </div>
+              ))
+            ) : (
+              <div style={{ color: textTokens.secondary }}>
+                No outstanding preparation items are currently visible in your tenant workspace.
+              </div>
+            )}
+          </div>
+
+          {leasePreparation.blockers.length ? (
+            <div
+              style={{
+                border: "1px solid rgba(15,23,42,0.08)",
+                borderRadius: 12,
+                padding: "12px 14px",
+                display: "grid",
+                gap: 8,
+              }}
+            >
+              <div style={{ fontWeight: 700, color: textTokens.primary }}>Needs attention</div>
+              {leasePreparation.blockers.map((item) => (
+                <div key={item} style={{ color: textTokens.secondary }}>
+                  {item}
+                </div>
+              ))}
+            </div>
+          ) : null}
+
+          <div
+            style={{
+              border: "1px solid rgba(15,23,42,0.08)",
+              borderRadius: 12,
+              padding: "12px 14px",
+              display: "grid",
+              gap: 8,
+            }}
+          >
+            <div style={{ fontWeight: 700, color: textTokens.primary }}>Next steps</div>
+            {leasePreparation.nextActions.map((step) => (
               <div key={step} style={{ color: textTokens.secondary }}>
                 {step}
               </div>


### PR DESCRIPTION
## Summary
Adds a read-first lease preparation workspace between lease-step transition and actual lease execution.

This PR introduces a shared pure helper that derives pre-lease preparation status from the current decision outcome, lease-step state, aligned package categories, and visible tenant-safe lease data, then surfaces that status in:
- the landlord review-summary workspace
- the tenant application readiness page
- the landlord structured activity timeline

## Scope
- shared lease preparation helper
- landlord lease preparation workspace UI
- tenant pre-lease preparation visibility
- landlord timeline preparation events
- focused frontend tests

## Preparation states
The helper derives a small, explainable set of states:
- not started
- preparing lease
- needs attention
- ready for execution
- awaiting next action

The state is based only on currently supported visible signals:
- decision outcome
- lease-step transition state
- aligned package categories
- tenant-safe lease projection and document visibility

## Implementation notes
- Read-first v1
- No backend or API changes
- No schema changes
- No auth or permission changes
- No fake persistence or lease automation
- Tenant copy stays neutral and does not imply signing or completion

## Validation
- Targeted frontend tests passed
- Frontend build passed

## Limitations
- No persisted lease-preparation action flow in this PR
- No drafting, signing, deposit, or execution workflow changes
- Timeline events are derived from current authorized state, not a stored preparation ledger