### PR TITLE
feat(shared): add move-in readiness workspace v1

### DIFF
--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
@@ -150,10 +150,12 @@ describe("ApplicationReviewSummaryPage", () => {
     expect(await screen.findByText("Not ready for lease step")).toBeInTheDocument();
     expect(await screen.findByText("Lease blockers")).toBeInTheDocument();
     expect(await screen.findByText("Lease preparation")).toBeInTheDocument();
-    expect(await screen.findByText("Not started")).toBeInTheDocument();
-    expect(await screen.findByText("Completed items")).toBeInTheDocument();
-    expect(await screen.findByText("Outstanding items")).toBeInTheDocument();
+    expect((await screen.findAllByText("Not started")).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText("Completed items")).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText("Outstanding items")).length).toBeGreaterThan(0);
     expect(await screen.findByText("Preparation blockers")).toBeInTheDocument();
+    expect(await screen.findByText("Move-in readiness")).toBeInTheDocument();
+    expect(await screen.findByText("Readiness blockers")).toBeInTheDocument();
     expect(await screen.findByText("Recent updates")).toBeInTheDocument();
     expect(await screen.findByText(/Tenant updated follow-up items/i)).toBeInTheDocument();
     expect(await screen.findByText(/Follow-up stays organized by aligned package categories/i)).toBeInTheDocument();
@@ -237,6 +239,8 @@ describe("ApplicationReviewSummaryPage", () => {
     expect((await screen.findAllByText("Ready for next step")).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("Ready for lease step")).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("Awaiting next action")).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText("Move-in readiness")).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText("Awaiting next action")).length).toBeGreaterThan(1);
     expect(await screen.findByText(/A lease-preparation record is not visible from the current review-summary surface yet/i)).toBeInTheDocument();
     expect(await screen.findByText(/Move this file into the lease flow/i)).toBeInTheDocument();
     expect(await screen.findByText(/No decision blockers are currently surfaced/i)).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
@@ -26,6 +26,7 @@ import { buildLandlordDecisionWorkspace } from "./landlordDecisionWorkspace";
 import { buildLandlordDecisionOutcome } from "./landlordDecisionOutcome";
 import { buildLeaseFlowTransitionState } from "./leaseFlowTransitionState";
 import { buildLeasePreparationWorkspaceState } from "./leasePreparationWorkspaceState";
+import { buildMoveInReadinessWorkspaceState } from "./moveInReadinessWorkspaceState";
 import StructuredNotificationList from "./StructuredNotificationList";
 import { buildLandlordStructuredNotificationTriggers } from "./structuredNotificationTriggers";
 
@@ -129,6 +130,29 @@ function leasePreparationTone(
   }
   if (state === "needs_attention") {
     return { color: "#9a3412", background: "#ffedd5", label: "Needs attention" };
+  }
+  return { color: "#64748b", background: "#e2e8f0", label: "Not started" };
+}
+
+function moveInReadinessTone(
+  state:
+    | "not_started"
+    | "in_progress"
+    | "needs_attention"
+    | "ready_for_move_in"
+    | "awaiting_next_action"
+) {
+  if (state === "ready_for_move_in") {
+    return { color: "#166534", background: "#dcfce7", label: "Ready for move-in" };
+  }
+  if (state === "in_progress") {
+    return { color: "#0f766e", background: "#ccfbf1", label: "Preparing for move-in" };
+  }
+  if (state === "needs_attention") {
+    return { color: "#9a3412", background: "#ffedd5", label: "Needs attention" };
+  }
+  if (state === "awaiting_next_action") {
+    return { color: "#1d4ed8", background: "#dbeafe", label: "Awaiting next action" };
   }
   return { color: "#64748b", background: "#e2e8f0", label: "Not started" };
 }
@@ -363,6 +387,19 @@ function ApplicationReviewSummaryPageBody() {
           })
         : null,
     [decisionOutcome, intakeView, leaseTransition]
+  );
+  const moveInReadiness = useMemo(
+    () =>
+      decisionOutcome && leaseTransition && leasePreparation && intakeView
+        ? buildMoveInReadinessWorkspaceState({
+            audience: "landlord",
+            decisionOutcome,
+            leaseTransition,
+            leasePreparation,
+            packageCategories: intakeView.packageCategories,
+          })
+        : null,
+    [decisionOutcome, intakeView, leasePreparation, leaseTransition]
   );
 
   const recentActivity = useMemo(
@@ -744,8 +781,8 @@ function ApplicationReviewSummaryPageBody() {
                 >
                   <div style={{ fontWeight: 700, color: text.main }}>What is still missing</div>
                   {decisionWorkspace.blockers.length ? (
-                    decisionWorkspace.blockers.map((item) => (
-                      <div key={item} style={{ fontSize: 13, color: text.subtle }}>
+                    decisionWorkspace.blockers.map((item, index) => (
+                      <div key={`${item}-${index}`} style={{ fontSize: 13, color: text.subtle }}>
                         {item}
                       </div>
                     ))
@@ -766,8 +803,8 @@ function ApplicationReviewSummaryPageBody() {
                   }}
                 >
                   <div style={{ fontWeight: 700, color: text.main }}>Next steps</div>
-                  {decisionWorkspace.nextSteps.map((step) => (
-                    <div key={step} style={{ fontSize: 13, color: text.subtle }}>
+                  {decisionWorkspace.nextSteps.map((step, index) => (
+                    <div key={`${step}-${index}`} style={{ fontSize: 13, color: text.subtle }}>
                       {step}
                     </div>
                   ))}
@@ -824,8 +861,8 @@ function ApplicationReviewSummaryPageBody() {
                     >
                       <div style={{ fontWeight: 700, color: text.main }}>Outcome blockers</div>
                       {decisionOutcome.blockers.length ? (
-                        decisionOutcome.blockers.map((item) => (
-                          <div key={item} style={{ fontSize: 13, color: text.subtle }}>
+                        decisionOutcome.blockers.map((item, index) => (
+                          <div key={`${item}-${index}`} style={{ fontSize: 13, color: text.subtle }}>
                             {item}
                           </div>
                         ))
@@ -846,8 +883,8 @@ function ApplicationReviewSummaryPageBody() {
                       }}
                     >
                       <div style={{ fontWeight: 700, color: text.main }}>Outcome next steps</div>
-                      {decisionOutcome.landlordNextSteps.map((step) => (
-                        <div key={step} style={{ fontSize: 13, color: text.subtle }}>
+                      {decisionOutcome.landlordNextSteps.map((step, index) => (
+                        <div key={`${step}-${index}`} style={{ fontSize: 13, color: text.subtle }}>
                           {step}
                         </div>
                       ))}
@@ -898,8 +935,8 @@ function ApplicationReviewSummaryPageBody() {
                     >
                       <div style={{ fontWeight: 700, color: text.main }}>Lease blockers</div>
                       {leaseTransition.blockers.length ? (
-                        leaseTransition.blockers.map((item) => (
-                          <div key={item} style={{ fontSize: 13, color: text.subtle }}>
+                        leaseTransition.blockers.map((item, index) => (
+                          <div key={`${item}-${index}`} style={{ fontSize: 13, color: text.subtle }}>
                             {item}
                           </div>
                         ))
@@ -920,8 +957,8 @@ function ApplicationReviewSummaryPageBody() {
                       }}
                     >
                       <div style={{ fontWeight: 700, color: text.main }}>Next action</div>
-                      {leaseTransition.nextActions.map((step) => (
-                        <div key={step} style={{ fontSize: 13, color: text.subtle }}>
+                      {leaseTransition.nextActions.map((step, index) => (
+                        <div key={`${step}-${index}`} style={{ fontSize: 13, color: text.subtle }}>
                           {step}
                         </div>
                       ))}
@@ -1020,8 +1057,8 @@ function ApplicationReviewSummaryPageBody() {
                     >
                       <div style={{ fontWeight: 700, color: text.main }}>Preparation blockers</div>
                       {leasePreparation.blockers.length ? (
-                        leasePreparation.blockers.map((item) => (
-                          <div key={item} style={{ fontSize: 13, color: text.subtle }}>
+                        leasePreparation.blockers.map((item, index) => (
+                          <div key={`${item}-${index}`} style={{ fontSize: 13, color: text.subtle }}>
                             {item}
                           </div>
                         ))
@@ -1042,8 +1079,130 @@ function ApplicationReviewSummaryPageBody() {
                       }}
                     >
                       <div style={{ fontWeight: 700, color: text.main }}>Next steps</div>
-                      {leasePreparation.nextActions.map((step) => (
-                        <div key={step} style={{ fontSize: 13, color: text.subtle }}>
+                      {leasePreparation.nextActions.map((step, index) => (
+                        <div key={`${step}-${index}`} style={{ fontSize: 13, color: text.subtle }}>
+                          {step}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              ) : null}
+
+              {moveInReadiness ? (
+                <div
+                  style={{
+                    border: `1px solid ${colors.border}`,
+                    borderRadius: 10,
+                    padding: 10,
+                    display: "grid",
+                    gap: 10,
+                  }}
+                >
+                  <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+                    <div>
+                      <div style={{ fontWeight: 700, color: text.main }}>Move-in readiness</div>
+                      <div style={{ fontSize: 13, color: text.subtle, marginTop: 4 }}>
+                        {moveInReadiness.explanation}
+                      </div>
+                    </div>
+                    <div
+                      style={{
+                        padding: "6px 10px",
+                        borderRadius: 999,
+                        fontWeight: 700,
+                        color: moveInReadinessTone(moveInReadiness.readinessState).color,
+                        background: moveInReadinessTone(moveInReadiness.readinessState).background,
+                      }}
+                    >
+                      {moveInReadinessTone(moveInReadiness.readinessState).label}
+                    </div>
+                  </div>
+
+                  <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 8 }}>
+                    <div
+                      style={{
+                        border: `1px solid ${colors.border}`,
+                        borderRadius: 10,
+                        padding: 10,
+                        display: "grid",
+                        gap: 6,
+                      }}
+                    >
+                      <div style={{ fontWeight: 700, color: text.main }}>Completed items</div>
+                      {moveInReadiness.completedItems.length ? (
+                        moveInReadiness.completedItems.map((item) => (
+                          <div key={item.key} style={{ fontSize: 13, color: text.subtle }}>
+                            <strong style={{ color: text.main }}>{item.label}:</strong> {item.detail}
+                          </div>
+                        ))
+                      ) : (
+                        <div style={{ fontSize: 13, color: text.subtle }}>
+                          No completed move-in readiness items are surfaced from this review-summary view yet.
+                        </div>
+                      )}
+                    </div>
+
+                    <div
+                      style={{
+                        border: `1px solid ${colors.border}`,
+                        borderRadius: 10,
+                        padding: 10,
+                        display: "grid",
+                        gap: 6,
+                      }}
+                    >
+                      <div style={{ fontWeight: 700, color: text.main }}>Outstanding items</div>
+                      {moveInReadiness.outstandingItems.length ? (
+                        moveInReadiness.outstandingItems.map((item) => (
+                          <div key={item.key} style={{ fontSize: 13, color: text.subtle }}>
+                            <strong style={{ color: text.main }}>{item.label}:</strong> {item.detail}
+                          </div>
+                        ))
+                      ) : (
+                        <div style={{ fontSize: 13, color: text.subtle }}>
+                          No outstanding move-in readiness items are currently surfaced from the visible review state.
+                        </div>
+                      )}
+                    </div>
+                  </div>
+
+                  <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 8 }}>
+                    <div
+                      style={{
+                        border: `1px solid ${colors.border}`,
+                        borderRadius: 10,
+                        padding: 10,
+                        display: "grid",
+                        gap: 6,
+                      }}
+                    >
+                      <div style={{ fontWeight: 700, color: text.main }}>Readiness blockers</div>
+                      {moveInReadiness.blockers.length ? (
+                        moveInReadiness.blockers.map((item, index) => (
+                          <div key={`${item}-${index}`} style={{ fontSize: 13, color: text.subtle }}>
+                            {item}
+                          </div>
+                        ))
+                      ) : (
+                        <div style={{ fontSize: 13, color: text.subtle }}>
+                          No current blockers are surfaced in this read-first move-in readiness workspace.
+                        </div>
+                      )}
+                    </div>
+
+                    <div
+                      style={{
+                        border: `1px solid ${colors.border}`,
+                        borderRadius: 10,
+                        padding: 10,
+                        display: "grid",
+                        gap: 6,
+                      }}
+                    >
+                      <div style={{ fontWeight: 700, color: text.main }}>Next steps</div>
+                      {moveInReadiness.nextActions.map((step, index) => (
+                        <div key={`${step}-${index}`} style={{ fontSize: 13, color: text.subtle }}>
                           {step}
                         </div>
                       ))}

--- a/rentchain-frontend/src/pages/moveInReadinessWorkspaceState.test.ts
+++ b/rentchain-frontend/src/pages/moveInReadinessWorkspaceState.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "vitest";
+import { buildMoveInReadinessWorkspaceState } from "./moveInReadinessWorkspaceState";
+
+const readyPackageCategories = [
+  { key: "profile_details", label: "Profile details", status: "ready", detail: "Ready." },
+  { key: "rental_history", label: "Rental history", status: "ready", detail: "Ready." },
+  { key: "documents_records", label: "Documents & records", status: "ready", detail: "Ready." },
+  { key: "consent_identity_status", label: "Consent / identity status", status: "ready", detail: "Ready." },
+  { key: "application_readiness", label: "Application readiness", status: "ready", detail: "Ready." },
+] as const;
+
+describe("moveInReadinessWorkspaceState", () => {
+  it("stays not started when lease and preparation flow have not advanced enough", () => {
+    const result = buildMoveInReadinessWorkspaceState({
+      audience: "landlord",
+      decisionOutcome: {
+        outcomeState: "hold_for_later",
+        label: "Hold for later",
+        source: "derived",
+        sourceLabel: "Derived",
+        description: "Still on hold.",
+        tenantDescription: "Still on hold.",
+        blockers: ["Follow-up is still open."],
+        landlordNextSteps: ["Wait."],
+        tenantNextSteps: ["Wait."],
+        timelineEvent: { title: "Hold", description: "Hold", actionRequired: true },
+      },
+      leaseTransition: {
+        transitionState: "not_ready_for_lease",
+        label: "Not ready for lease step",
+        summary: "Lease transition",
+        explanation: "Not ready yet.",
+        blockers: ["Follow-up is still open."],
+        nextActions: ["Finish follow-up."],
+        timelineEvent: null,
+      },
+      leasePreparation: {
+        preparationState: "not_started",
+        label: "Not started",
+        summary: "Lease preparation",
+        explanation: "Not started.",
+        completedItems: [],
+        outstandingItems: [],
+        blockers: ["Lease prep has not started."],
+        nextActions: ["Wait."],
+        timelineEvent: null,
+      },
+      packageCategories: readyPackageCategories as any,
+    });
+
+    expect(result.readinessState).toBe("not_started");
+    expect(result.timelineEvent).toBeNull();
+  });
+
+  it("shows awaiting next action when lease preparation is organized but no move-in step is visible", () => {
+    const result = buildMoveInReadinessWorkspaceState({
+      audience: "landlord",
+      decisionOutcome: {
+        outcomeState: "ready_for_next_step",
+        label: "Ready for next step",
+        source: "derived",
+        sourceLabel: "Derived",
+        description: "Ready.",
+        tenantDescription: "Ready.",
+        blockers: [],
+        landlordNextSteps: ["Proceed."],
+        tenantNextSteps: ["Wait."],
+        timelineEvent: { title: "Ready", description: "Ready", actionRequired: false },
+      },
+      leaseTransition: {
+        transitionState: "ready_for_lease_step",
+        label: "Ready for lease step",
+        summary: "Lease transition",
+        explanation: "Ready.",
+        blockers: [],
+        nextActions: ["Start lease step."],
+        timelineEvent: { title: "Lease ready", description: "Lease ready", actionRequired: false },
+      },
+      leasePreparation: {
+        preparationState: "awaiting_next_action",
+        label: "Awaiting next action",
+        summary: "Lease preparation",
+        explanation: "Awaiting next action.",
+        completedItems: [],
+        outstandingItems: [],
+        blockers: [],
+        nextActions: ["Start prep."],
+        timelineEvent: { title: "Lease prep", description: "Awaiting", actionRequired: false },
+      },
+      packageCategories: readyPackageCategories as any,
+    });
+
+    expect(result.readinessState).toBe("awaiting_next_action");
+    expect(result.timelineEvent?.title).toBe("Move-in readiness updated");
+  });
+
+  it("shows in progress when a lease record is visible but the move-in checklist is still forming", () => {
+    const result = buildMoveInReadinessWorkspaceState({
+      audience: "tenant",
+      decisionOutcome: {
+        outcomeState: "ready_for_next_step",
+        label: "Ready for next step",
+        source: "derived",
+        sourceLabel: "Derived",
+        description: "Ready.",
+        tenantDescription: "Ready.",
+        blockers: [],
+        landlordNextSteps: ["Proceed."],
+        tenantNextSteps: ["Wait."],
+        timelineEvent: { title: "Ready", description: "Ready", actionRequired: false },
+      },
+      leaseTransition: {
+        transitionState: "lease_step_started",
+        label: "Lease step started",
+        summary: "Lease transition",
+        explanation: "Started.",
+        blockers: [],
+        nextActions: ["Review lease step."],
+        timelineEvent: { title: "Lease started", description: "Started", actionRequired: false },
+      },
+      leasePreparation: {
+        preparationState: "preparing_lease",
+        label: "Preparing lease",
+        summary: "Lease preparation",
+        explanation: "Preparing lease.",
+        completedItems: [],
+        outstandingItems: [],
+        blockers: [],
+        nextActions: ["Review lease."],
+        timelineEvent: { title: "Prep", description: "Prep", actionRequired: false },
+      },
+      packageCategories: readyPackageCategories as any,
+      lease: {
+        leaseId: "lease-1",
+        startDate: "2026-05-01",
+        endDate: "2027-04-30",
+        monthlyRent: 180000,
+        status: "draft",
+        documentUrl: null,
+      },
+    });
+
+    expect(result.readinessState).toBe("in_progress");
+    expect(result.outstandingItems.some((item) => item.label === "Lease document visibility")).toBe(true);
+    expect(result.timelineEvent?.title).toBe("Move-in readiness started");
+  });
+
+  it("shows ready for move-in when the visible lease and preparation details are fully organized", () => {
+    const result = buildMoveInReadinessWorkspaceState({
+      audience: "tenant",
+      decisionOutcome: {
+        outcomeState: "ready_for_next_step",
+        label: "Ready for next step",
+        source: "derived",
+        sourceLabel: "Derived",
+        description: "Ready.",
+        tenantDescription: "Ready.",
+        blockers: [],
+        landlordNextSteps: ["Proceed."],
+        tenantNextSteps: ["Wait."],
+        timelineEvent: { title: "Ready", description: "Ready", actionRequired: false },
+      },
+      leaseTransition: {
+        transitionState: "lease_step_started",
+        label: "Lease step started",
+        summary: "Lease transition",
+        explanation: "Started.",
+        blockers: [],
+        nextActions: ["Review lease step."],
+        timelineEvent: { title: "Lease started", description: "Started", actionRequired: false },
+      },
+      leasePreparation: {
+        preparationState: "ready_for_execution",
+        label: "Ready for execution",
+        summary: "Lease preparation",
+        explanation: "Ready for execution.",
+        completedItems: [],
+        outstandingItems: [],
+        blockers: [],
+        nextActions: ["Review lease."],
+        timelineEvent: { title: "Prep", description: "Prep", actionRequired: false },
+      },
+      packageCategories: readyPackageCategories as any,
+      lease: {
+        leaseId: "lease-1",
+        startDate: "2026-05-01",
+        endDate: "2027-04-30",
+        monthlyRent: 180000,
+        status: "draft",
+        documentUrl: "https://example.com/lease.pdf",
+      },
+    });
+
+    expect(result.readinessState).toBe("ready_for_move_in");
+    expect(result.timelineEvent?.title).toBe("Ready for move-in");
+  });
+});

--- a/rentchain-frontend/src/pages/moveInReadinessWorkspaceState.ts
+++ b/rentchain-frontend/src/pages/moveInReadinessWorkspaceState.ts
@@ -1,0 +1,331 @@
+import type { SharePackageCategoryView } from "./sharePackageAlignment";
+import type { LeasePreparationWorkspaceView } from "./leasePreparationWorkspaceState";
+import type { LeaseFlowTransitionView } from "./leaseFlowTransitionState";
+import type { LandlordDecisionOutcomeView } from "./landlordDecisionOutcome";
+import type { TenantWorkspaceLease } from "../api/tenantPortal";
+
+export type MoveInReadinessWorkspaceState =
+  | "not_started"
+  | "in_progress"
+  | "needs_attention"
+  | "ready_for_move_in"
+  | "awaiting_next_action";
+
+export type MoveInReadinessWorkspaceItem = {
+  key: string;
+  label: string;
+  detail: string;
+};
+
+export type MoveInReadinessWorkspaceView = {
+  readinessState: MoveInReadinessWorkspaceState;
+  label: string;
+  summary: string;
+  explanation: string;
+  completedItems: MoveInReadinessWorkspaceItem[];
+  outstandingItems: MoveInReadinessWorkspaceItem[];
+  blockers: string[];
+  nextActions: string[];
+  timelineEvent: {
+    title: string;
+    description: string;
+    actionRequired: boolean;
+  } | null;
+};
+
+function stateLabel(state: MoveInReadinessWorkspaceState): string {
+  if (state === "ready_for_move_in") return "Ready for move-in";
+  if (state === "in_progress") return "Preparing for move-in";
+  if (state === "needs_attention") return "Needs attention";
+  if (state === "awaiting_next_action") return "Awaiting next action";
+  return "Not started";
+}
+
+function timelineForState(
+  state: MoveInReadinessWorkspaceState
+): MoveInReadinessWorkspaceView["timelineEvent"] {
+  if (state === "in_progress") {
+    return {
+      title: "Move-in readiness started",
+      description:
+        "The visible lease and preparation details now support a structured move-in readiness view.",
+      actionRequired: false,
+    };
+  }
+  if (state === "needs_attention") {
+    return {
+      title: "Move-in readiness updated",
+      description:
+        "Visible move-in requirements still need attention before the file appears ready for move-in.",
+      actionRequired: true,
+    };
+  }
+  if (state === "awaiting_next_action") {
+    return {
+      title: "Move-in readiness updated",
+      description:
+        "The file is approaching move-in readiness, and the next visible move-in step is still pending.",
+      actionRequired: false,
+    };
+  }
+  if (state === "ready_for_move_in") {
+    return {
+      title: "Ready for move-in",
+      description:
+        "The currently visible move-in requirements appear organized enough for the next move-in step.",
+      actionRequired: false,
+    };
+  }
+  return null;
+}
+
+function visibleLeaseDetailsItem(
+  lease: TenantWorkspaceLease | null | undefined
+): MoveInReadinessWorkspaceItem | null {
+  if (!lease) return null;
+  const details = [
+    lease.startDate ? `Start ${lease.startDate}` : null,
+    lease.endDate ? `End ${lease.endDate}` : null,
+    typeof lease.monthlyRent === "number" ? `Rent ${lease.monthlyRent}` : null,
+  ].filter(Boolean);
+  if (!details.length) return null;
+  return {
+    key: "lease_details",
+    label: "Lease details",
+    detail: `Current lease details are visible in the workspace (${details.join(" • ")}).`,
+  };
+}
+
+function completedCategoryItems(
+  packageCategories: SharePackageCategoryView[]
+): MoveInReadinessWorkspaceItem[] {
+  return packageCategories
+    .filter((item) => item.status !== "missing")
+    .map((item) => ({
+      key: item.key,
+      label: item.label,
+      detail:
+        item.status === "ready"
+          ? `${item.label} is visible and organized for move-in readiness review.`
+          : `${item.label} is partly visible and can still support move-in readiness review.`,
+    }));
+}
+
+function outstandingCategoryItems(
+  packageCategories: SharePackageCategoryView[]
+): MoveInReadinessWorkspaceItem[] {
+  return packageCategories
+    .filter((item) => item.status === "missing")
+    .map((item) => ({
+      key: item.key,
+      label: item.label,
+      detail: item.detail,
+    }));
+}
+
+export function buildMoveInReadinessWorkspaceState(input: {
+  audience: "landlord" | "tenant";
+  decisionOutcome: LandlordDecisionOutcomeView;
+  leaseTransition: LeaseFlowTransitionView;
+  leasePreparation: LeasePreparationWorkspaceView;
+  packageCategories: SharePackageCategoryView[];
+  lease?: TenantWorkspaceLease | null;
+}): MoveInReadinessWorkspaceView {
+  const lease = input.lease || null;
+  const categoryCompleted = completedCategoryItems(input.packageCategories);
+  const categoryOutstanding = outstandingCategoryItems(input.packageCategories);
+  const leaseDetails = visibleLeaseDetailsItem(lease);
+  const leaseVisible = Boolean(String(lease?.leaseId || "").trim() || String(lease?.status || "").trim());
+  const leaseDocumentVisible = Boolean(String(lease?.documentUrl || "").trim());
+
+  const completedItems: MoveInReadinessWorkspaceItem[] = [
+    ...categoryCompleted,
+    {
+      key: "decision_outcome",
+      label: "Application outcome",
+      detail:
+        input.decisionOutcome.outcomeState === "ready_for_next_step"
+          ? "The current application outcome is ready for the next supported step."
+          : "The current application outcome is still earlier in the workflow.",
+    },
+  ];
+
+  if (input.leaseTransition.transitionState === "lease_step_started") {
+    completedItems.push({
+      key: "lease_step_started",
+      label: "Lease step",
+      detail: "The lease step has started in the current visible workflow.",
+    });
+  }
+
+  if (leaseDetails) {
+    completedItems.push(leaseDetails);
+  }
+
+  if (leaseDocumentVisible) {
+    completedItems.push({
+      key: "lease_document",
+      label: "Lease document visibility",
+      detail: "A lease document is already visible in the current workspace.",
+    });
+  }
+
+  if (
+    input.leaseTransition.transitionState === "not_ready_for_lease" ||
+    input.leasePreparation.preparationState === "not_started"
+  ) {
+    return {
+      readinessState: "not_started",
+      label: stateLabel("not_started"),
+      summary: "Move-in readiness",
+      explanation:
+        "Move-in readiness has not started because the file has not reached a stable lease or preparation stage yet.",
+      completedItems: categoryCompleted,
+      outstandingItems: [
+        ...categoryOutstanding,
+        {
+          key: "lease_stage",
+          label: "Lease and preparation stage",
+          detail:
+            "The lease step and preparation workflow need to progress further before move-in readiness can be organized.",
+        },
+      ],
+      blockers: [
+        ...input.leaseTransition.blockers,
+        ...input.leasePreparation.blockers,
+      ],
+      nextActions:
+        input.audience === "landlord"
+          ? [
+              "Keep the current review, follow-up, and lease-preparation steps organized before starting move-in readiness.",
+              "Return to this workspace once the lease step is visibly underway.",
+            ]
+          : [
+              "Finish the current application and lease-preparation items that are still visible in your tenant workspace.",
+              "Check back once the next lease step is available.",
+            ],
+      timelineEvent: null,
+    };
+  }
+
+  if (
+    input.leasePreparation.preparationState === "needs_attention" ||
+    categoryOutstanding.length > 0
+  ) {
+    return {
+      readinessState: "needs_attention",
+      label: stateLabel("needs_attention"),
+      summary: "Move-in readiness",
+      explanation:
+        "Some visible move-in requirements still need attention before this file appears ready for move-in.",
+      completedItems,
+      outstandingItems: [
+        ...categoryOutstanding,
+        ...input.leasePreparation.outstandingItems,
+      ],
+      blockers: [
+        ...input.leasePreparation.blockers,
+        ...categoryOutstanding.map((item) => `${item.label} still needs attention before move-in readiness settles.`),
+      ],
+      nextActions:
+        input.audience === "landlord"
+          ? [
+              "Review the remaining lease-preparation and package items before treating this tenancy as ready for move-in.",
+              "Use the checklist below to keep the next landlord step structured and visible.",
+            ]
+          : [
+              "Address the remaining visible items before move-in readiness can look complete.",
+              "Use your profile, documents, access, and lease views to keep the file current.",
+            ],
+      timelineEvent: timelineForState("needs_attention"),
+    };
+  }
+
+  if (input.leasePreparation.preparationState === "awaiting_next_action" || !leaseVisible) {
+    return {
+      readinessState: "awaiting_next_action",
+      label: stateLabel("awaiting_next_action"),
+      summary: "Move-in readiness",
+      explanation:
+        "The file appears organized enough to begin move-in readiness, but the next visible move-in step has not surfaced yet.",
+      completedItems,
+      outstandingItems: [
+        {
+          key: "move_in_record",
+          label: "Move-in readiness step",
+          detail:
+            input.audience === "landlord"
+              ? "A distinct move-in readiness record is not visible from the current review-summary surface yet."
+              : "A distinct move-in readiness step is not visible in your tenant workspace yet.",
+        },
+      ],
+      blockers: [],
+      nextActions:
+        input.audience === "landlord"
+          ? [
+              "Use the current lease and preparation views to keep the file organized while the move-in step is still pending.",
+              "Return here when more move-in-ready details are visible.",
+            ]
+          : [
+              "Watch for the next move-in update in your tenant workspace.",
+              "Keep your current lease and supporting records available in case anything else needs confirmation.",
+            ],
+      timelineEvent: timelineForState("awaiting_next_action"),
+    };
+  }
+
+  if (!leaseDocumentVisible) {
+    return {
+      readinessState: "in_progress",
+      label: stateLabel("in_progress"),
+      summary: "Move-in readiness",
+      explanation:
+        "Move-in readiness is in progress because the lease and preparation workflow are visible, but the visible move-in checklist is still forming.",
+      completedItems,
+      outstandingItems: [
+        {
+          key: "lease_document_visibility",
+          label: "Lease document visibility",
+          detail:
+            input.audience === "landlord"
+              ? "A visible lease document is not yet surfaced from the current review-summary context."
+              : "A visible lease document is not yet available in your tenant workspace.",
+        },
+      ],
+      blockers: [],
+      nextActions:
+        input.audience === "landlord"
+          ? [
+              "Continue preparing the current lease details and keep move-in requirements organized in this shared checklist.",
+              "Use the visible lease tools to confirm the remaining move-in information as it becomes available.",
+            ]
+          : [
+              "Continue reviewing the current lease details and watch for the next move-in update.",
+              "Keep your profile, documents, and access details current while move-in preparation continues.",
+            ],
+      timelineEvent: timelineForState("in_progress"),
+    };
+  }
+
+  return {
+    readinessState: "ready_for_move_in",
+    label: stateLabel("ready_for_move_in"),
+    summary: "Move-in readiness",
+    explanation:
+      "The visible move-in requirements now appear organized enough for the next move-in step.",
+    completedItems,
+    outstandingItems: [],
+    blockers: [],
+    nextActions:
+      input.audience === "landlord"
+        ? [
+            "Use the current lease and tenant operations tools to manage the next move-in step.",
+            "Keep this checklist as the shared view for any remaining operational confirmations.",
+          ]
+        : [
+            "Review the visible lease details and keep an eye on your tenant workspace for the next move-in update.",
+            "Use your current tenant tools if anything needs another look before move-in.",
+          ],
+    timelineEvent: timelineForState("ready_for_move_in"),
+  };
+}

--- a/rentchain-frontend/src/pages/structuredActivityTimeline.test.ts
+++ b/rentchain-frontend/src/pages/structuredActivityTimeline.test.ts
@@ -180,5 +180,13 @@ describe("structuredActivityTimeline", () => {
           item.actionRequired === false
       )
     ).toBe(true);
+    expect(
+      result.some(
+        (item) =>
+          item.title === "Move-in readiness updated" &&
+          item.actorLabel === "Move-in readiness" &&
+          item.actionRequired === false
+      )
+    ).toBe(true);
   });
 });

--- a/rentchain-frontend/src/pages/structuredActivityTimeline.ts
+++ b/rentchain-frontend/src/pages/structuredActivityTimeline.ts
@@ -5,6 +5,7 @@ import { buildLandlordDecisionWorkspace } from "./landlordDecisionWorkspace";
 import { buildLandlordDecisionOutcome } from "./landlordDecisionOutcome";
 import { buildLeaseFlowTransitionState } from "./leaseFlowTransitionState";
 import { buildLeasePreparationWorkspaceState } from "./leasePreparationWorkspaceState";
+import { buildMoveInReadinessWorkspaceState } from "./moveInReadinessWorkspaceState";
 
 export type StructuredActivityTimelineItem = {
   id: string;
@@ -126,6 +127,13 @@ export function buildLandlordStructuredActivityTimeline(
     leaseTransition,
     packageCategories: intakeView.packageCategories,
   });
+  const moveInReadiness = buildMoveInReadinessWorkspaceState({
+    audience: "landlord",
+    decisionOutcome,
+    leaseTransition,
+    leasePreparation,
+    packageCategories: intakeView.packageCategories,
+  });
 
   pushTimelineItem(items, {
     id: `review-summary-${summary.applicationId}`,
@@ -240,6 +248,24 @@ export function buildLandlordStructuredActivityTimeline(
         summary.generatedAt,
       actorLabel: "Lease preparation",
       actionRequired: leasePreparation.timelineEvent.actionRequired,
+      relatedPath: null,
+    });
+  }
+
+  if (moveInReadiness.timelineEvent) {
+    pushTimelineItem(items, {
+      id: `move-in-readiness-${summary.applicationId}`,
+      type:
+        moveInReadiness.readinessState === "ready_for_move_in"
+          ? "ready_for_rereview"
+          : "review_updated",
+      title: moveInReadiness.timelineEvent.title,
+      description: moveInReadiness.timelineEvent.description,
+      occurredAt:
+        summary.decisionSummary?.riskSnapshot?.updatedAt ||
+        summary.generatedAt,
+      actorLabel: "Move-in readiness",
+      actionRequired: moveInReadiness.timelineEvent.actionRequired,
       relatedPath: null,
     });
   }

--- a/rentchain-frontend/src/pages/tenant/TenantApplicationCompletionPage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantApplicationCompletionPage.test.tsx
@@ -217,8 +217,9 @@ describe("tenant application completion page", () => {
     expect(screen.getAllByText(/Not ready for lease step/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Lease preparation/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Not started/i).length).toBeGreaterThan(0);
-    expect(screen.getByText(/Completed items/i)).toBeInTheDocument();
-    expect(screen.getByText(/Outstanding items/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Move-in readiness/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Completed items/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Outstanding items/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/What this means/i)).toBeInTheDocument();
     expect(screen.getByText(/derived from your current follow-up and re-review state/i)).toBeInTheDocument();
     expect(screen.getByText(/Go next/i)).toBeInTheDocument();
@@ -286,7 +287,9 @@ describe("tenant application completion page", () => {
 
     expect((await screen.findAllByText(/Lease preparation/i)).length).toBeGreaterThan(0);
     expect((await screen.findAllByText(/Ready for execution/i)).length).toBeGreaterThan(0);
-    expect(screen.getByText(/A lease document is already visible in the current workspace/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/A lease document is already visible in the current workspace/i).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText(/Move-in readiness/i)).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText(/Ready for move-in/i)).length).toBeGreaterThan(0);
   });
 
   it("renders empty state safely", async () => {

--- a/rentchain-frontend/src/pages/tenant/TenantApplicationStatusPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantApplicationStatusPage.tsx
@@ -28,6 +28,7 @@ import { buildFollowUpResolutionState } from "../followUpResolutionState";
 import { buildLandlordDecisionOutcome } from "../landlordDecisionOutcome";
 import { buildLeaseFlowTransitionState } from "../leaseFlowTransitionState";
 import { buildLeasePreparationWorkspaceState } from "../leasePreparationWorkspaceState";
+import { buildMoveInReadinessWorkspaceState } from "../moveInReadinessWorkspaceState";
 import StructuredNotificationList from "../StructuredNotificationList";
 import { buildTenantStructuredNotificationTriggers } from "../structuredNotificationTriggers";
 import { filterStructuredNotificationsByPreferences } from "../notificationChannelRouting";
@@ -315,6 +316,24 @@ export default function TenantApplicationStatusPage() {
       : leasePreparation.preparationState === "awaiting_next_action"
       ? { color: "#1d4ed8", background: "#dbeafe", label: "Awaiting next action" }
       : leasePreparation.preparationState === "needs_attention"
+      ? { color: "#9a3412", background: "#ffedd5", label: "Needs attention" }
+      : { color: "#64748b", background: "#e2e8f0", label: "Not started" };
+  const moveInReadiness = buildMoveInReadinessWorkspaceState({
+    audience: "tenant",
+    decisionOutcome,
+    leaseTransition,
+    leasePreparation,
+    packageCategories: reuse.packageCategories,
+    lease,
+  });
+  const moveInReadinessTone =
+    moveInReadiness.readinessState === "ready_for_move_in"
+      ? { color: "#166534", background: "#dcfce7", label: "Ready for move-in" }
+      : moveInReadiness.readinessState === "in_progress"
+      ? { color: "#0f766e", background: "#ccfbf1", label: "Preparing for move-in" }
+      : moveInReadiness.readinessState === "awaiting_next_action"
+      ? { color: "#1d4ed8", background: "#dbeafe", label: "Awaiting next action" }
+      : moveInReadiness.readinessState === "needs_attention"
       ? { color: "#9a3412", background: "#ffedd5", label: "Needs attention" }
       : { color: "#64748b", background: "#e2e8f0", label: "Not started" };
 
@@ -713,8 +732,8 @@ export default function TenantApplicationStatusPage() {
               }}
             >
               <div style={{ fontWeight: 700, color: textTokens.primary }}>Needs attention</div>
-              {leasePreparation.blockers.map((item) => (
-                <div key={item} style={{ color: textTokens.secondary }}>
+              {leasePreparation.blockers.map((item, index) => (
+                <div key={`${item}-${index}`} style={{ color: textTokens.secondary }}>
                   {item}
                 </div>
               ))}
@@ -731,8 +750,8 @@ export default function TenantApplicationStatusPage() {
             }}
           >
             <div style={{ fontWeight: 700, color: textTokens.primary }}>Next steps</div>
-            {leasePreparation.nextActions.map((step) => (
-              <div key={step} style={{ color: textTokens.secondary }}>
+            {leasePreparation.nextActions.map((step, index) => (
+              <div key={`${step}-${index}`} style={{ color: textTokens.secondary }}>
                 {step}
               </div>
             ))}
@@ -741,6 +760,124 @@ export default function TenantApplicationStatusPage() {
                 Open lease details
               </Link>
             ) : null}
+          </div>
+        </div>
+      </TenantInfoCard>
+
+      <TenantInfoCard heading="Move-in readiness" accent="#0f766e">
+        <div style={{ display: "grid", gap: spacing.sm }}>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+            <div>
+              <div style={{ fontWeight: 800, color: textTokens.primary }}>{moveInReadiness.label}</div>
+              <div style={{ color: textTokens.secondary }}>{moveInReadiness.explanation}</div>
+            </div>
+            <div
+              style={{
+                padding: "6px 10px",
+                borderRadius: 999,
+                fontWeight: 700,
+                color: moveInReadinessTone.color,
+                background: moveInReadinessTone.background,
+              }}
+            >
+              {moveInReadinessTone.label}
+            </div>
+          </div>
+
+          <div
+            style={{
+              border: "1px solid rgba(15,23,42,0.08)",
+              borderRadius: 12,
+              padding: "12px 14px",
+              display: "grid",
+              gap: 8,
+            }}
+          >
+            <div style={{ fontWeight: 700, color: textTokens.primary }}>Completed items</div>
+            {moveInReadiness.completedItems.length ? (
+              moveInReadiness.completedItems.map((item) => (
+                <div key={item.key} style={{ color: textTokens.secondary }}>
+                  <strong style={{ color: textTokens.primary }}>{item.label}:</strong> {item.detail}
+                </div>
+              ))
+            ) : (
+              <div style={{ color: textTokens.secondary }}>
+                No completed move-in readiness items are visible in your tenant workspace yet.
+              </div>
+            )}
+          </div>
+
+          <div
+            style={{
+              border: "1px solid rgba(15,23,42,0.08)",
+              borderRadius: 12,
+              padding: "12px 14px",
+              display: "grid",
+              gap: 8,
+            }}
+          >
+            <div style={{ fontWeight: 700, color: textTokens.primary }}>Outstanding items</div>
+            {moveInReadiness.outstandingItems.length ? (
+              moveInReadiness.outstandingItems.map((item) => (
+                <div key={item.key} style={{ color: textTokens.secondary }}>
+                  <strong style={{ color: textTokens.primary }}>{item.label}:</strong> {item.detail}
+                </div>
+              ))
+            ) : (
+              <div style={{ color: textTokens.secondary }}>
+                No outstanding move-in readiness items are currently visible in your tenant workspace.
+              </div>
+            )}
+          </div>
+
+          {moveInReadiness.blockers.length ? (
+            <div
+              style={{
+                border: "1px solid rgba(15,23,42,0.08)",
+                borderRadius: 12,
+                padding: "12px 14px",
+                display: "grid",
+                gap: 8,
+              }}
+            >
+              <div style={{ fontWeight: 700, color: textTokens.primary }}>Needs attention</div>
+              {moveInReadiness.blockers.map((item, index) => (
+                <div key={`${item}-${index}`} style={{ color: textTokens.secondary }}>
+                  {item}
+                </div>
+              ))}
+            </div>
+          ) : null}
+
+          <div
+            style={{
+              border: "1px solid rgba(15,23,42,0.08)",
+              borderRadius: 12,
+              padding: "12px 14px",
+              display: "grid",
+              gap: 8,
+            }}
+          >
+            <div style={{ fontWeight: 700, color: textTokens.primary }}>Next steps</div>
+            {moveInReadiness.nextActions.map((step, index) => (
+              <div key={`${step}-${index}`} style={{ color: textTokens.secondary }}>
+                {step}
+              </div>
+            ))}
+            <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+              <Link to="/tenant/profile" style={{ fontWeight: 700 }}>
+                Review your profile
+              </Link>
+              <Link to="/tenant/attachments" style={{ fontWeight: 700 }}>
+                Open documents
+              </Link>
+              <Link to="/tenant/access" style={{ fontWeight: 700 }}>
+                Review access
+              </Link>
+              <Link to="/tenant/lease" style={{ fontWeight: 700 }}>
+                Open lease details
+              </Link>
+            </div>
           </div>
         </div>
       </TenantInfoCard>


### PR DESCRIPTION
## Summary

This PR adds a read-first move-in readiness workspace so landlords and tenants can see a shared pre-move-in checklist view based on current authorized workflow state.

The landlord review summary, tenant application status, and structured activity timeline now reflect whether the file is:
- `not_started`
- `awaiting_next_action`
- `in_progress`
- `needs_attention`
- `ready_for_move_in`

## What changed

- Added a shared pure helper:
  - `buildMoveInReadinessWorkspaceState`
- Added a landlord-side `Move-in readiness` section showing:
  - status
  - completed items
  - outstanding items
  - blockers
  - next steps
- Added a tenant-facing `Move-in readiness` card with calm next-step guidance
- Added derived move-in readiness timeline events:
  - `Move-in readiness started`
  - `Move-in readiness updated`
  - `Ready for move-in`

## Scope

- Frontend only
- No backend changes
- No schema changes
- No payment, signing, inspection, or move-in coordination workflows

## Validation

```bash
cd rentchain-frontend
PATH="$HOME/.nvm/versions/node/v20.20.2/bin:$PATH" npm run test -- src/pages/moveInReadinessWorkspaceState.test.ts src/pages/ApplicationReviewSummaryPage.test.tsx src/pages/tenant/TenantApplicationCompletionPage.test.tsx src/pages/structuredActivityTimeline.test.ts
PATH="$HOME/.nvm/versions/node/v20.20.2/bin:$PATH" npm run build