### PR TITLE
feat(maintenance): add confirmation and tenant access workflow v1

### DIFF
--- a/rentchain-api/src/routes/__tests__/maintenanceRequestsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/maintenanceRequestsRoutes.test.ts
@@ -126,6 +126,9 @@ describe("maintenanceRequestsRoutes scheduling access", () => {
       status: "assigned",
       assignedContractorId: "contractor-1",
       assignedContractorName: "North Shore HVAC",
+      tenantConfirmationStatus: "confirmed",
+      tenantConfirmationUpdatedAt: 150,
+      accessAcknowledgedAt: 160,
       createdAt: 100,
       updatedAt: 200,
       statusHistory: [],
@@ -162,11 +165,14 @@ describe("maintenanceRequestsRoutes scheduling access", () => {
 
     const savedMaintenance = ensureCollection("maintenanceRequests").get("maint-1");
     expect(savedMaintenance?.status).toBe("scheduled");
+    expect(savedMaintenance?.tenantConfirmationStatus).toBeNull();
+    expect(savedMaintenance?.accessAcknowledgedAt).toBeNull();
     expect(savedMaintenance?.statusHistory).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ status: "scheduled" }),
         expect.objectContaining({ message: "Service window updated." }),
         expect.objectContaining({ message: "Access coordination marked as required." }),
+        expect.objectContaining({ message: "Tenant confirmation was reset because the service window changed." }),
       ])
     );
 

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -14,6 +14,19 @@ function clone(value: any) {
   return JSON.parse(JSON.stringify(value));
 }
 
+function applyMerge(current: any, incoming: any) {
+  const next = { ...(current || {}) };
+  Object.entries(incoming || {}).forEach(([key, value]) => {
+    if (value && typeof value === "object" && (value as any).__op === "arrayUnion") {
+      const existing = Array.isArray(next[key]) ? next[key] : [];
+      next[key] = [...existing, ...(value as any).values.map((entry: any) => clone(entry))];
+      return;
+    }
+    next[key] = clone(value);
+  });
+  return next;
+}
+
 function queryCollection(name: string, filters: Array<{ field: string; op: string; value: any }>, limitCount?: number) {
   let docs = Array.from(ensureCollection(name).entries())
     .filter(([, data]) =>
@@ -46,7 +59,7 @@ const dbMock = {
         }),
         set: async (value: any, opts?: { merge?: boolean }) => {
           const current = ensureCollection(name).get(docId) || {};
-          ensureCollection(name).set(docId, opts?.merge ? { ...current, ...clone(value) } : clone(value));
+          ensureCollection(name).set(docId, opts?.merge ? applyMerge(current, value) : clone(value));
         },
       };
     },
@@ -63,6 +76,7 @@ vi.mock("../../config/firebase", () => ({
   db: dbMock,
   FieldValue: {
     serverTimestamp: () => "__server_timestamp__",
+    arrayUnion: (...values: any[]) => ({ __op: "arrayUnion", values }),
   },
 }));
 
@@ -169,6 +183,9 @@ describe("tenantPortalRoutes foundation", () => {
       serviceWindowStartAt: 300,
       serviceWindowEndAt: 600,
       accessRequired: true,
+      tenantConfirmationStatus: null,
+      tenantConfirmationUpdatedAt: null,
+      accessAcknowledgedAt: null,
       statusHistory: [
         {
           status: "submitted",
@@ -258,6 +275,7 @@ describe("tenantPortalRoutes foundation", () => {
     expect(res.body?.data?.maintenance?.[0]?.contractorStatus).toBe("assigned");
     expect(res.body?.data?.maintenance?.[0]?.serviceWindowStartAt).toBe(300);
     expect(res.body?.data?.maintenance?.[0]?.accessRequired).toBe(true);
+    expect(res.body?.data?.maintenance?.[0]?.tenantConfirmationStatus).toBeNull();
     expect(res.body?.data?.maintenance?.[0]?.statusHistory?.[0]?.message).toBe("Submitted from tenant workspace.");
     expect(res.body?.data?.maintenance?.[0]?.internalCost).toBeUndefined();
 
@@ -300,6 +318,56 @@ describe("tenantPortalRoutes foundation", () => {
 
     const eventDocs = Array.from(ensureCollection("event_log").values());
     expect(eventDocs.some((event) => event.event_type === "tenant_application_completion_viewed")).toBe(true);
+  });
+
+  it("lets the tenant confirm the service window and acknowledge access", async () => {
+    const router = (await import("../tenantPortalRoutes")).default;
+    ensureCollection("maintenanceRequests").set("maint-2", {
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      status: "scheduled",
+      priority: "NORMAL",
+      category: "GENERAL",
+      title: "Window repair",
+      description: "The latch is broken.",
+      serviceWindowStartAt: 1_000,
+      serviceWindowEndAt: 1_600,
+      accessRequired: true,
+      statusHistory: [],
+      createdAt: 100,
+      updatedAt: 200,
+    });
+
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/maintenance-requests/maint-2/confirmation",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+      body: {
+        confirmationStatus: "confirmed",
+        acknowledgeAccess: true,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.tenantConfirmationStatus).toBe("confirmed");
+    expect(typeof res.body?.data?.tenantConfirmationUpdatedAt).toBe("number");
+    expect(typeof res.body?.data?.accessAcknowledgedAt).toBe("number");
+
+    const saved = ensureCollection("maintenanceRequests").get("maint-2");
+    expect(saved?.tenantConfirmationStatus).toBe("confirmed");
+    expect(saved?.statusHistory).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ message: "Tenant confirmed the scheduled service window." }),
+        expect.objectContaining({ message: "Tenant acknowledged the access requirement." }),
+      ])
+    );
   });
 
   it("rejects unauthorized application completion access", async () => {

--- a/rentchain-api/src/routes/maintenanceRequestsRoutes.ts
+++ b/rentchain-api/src/routes/maintenanceRequestsRoutes.ts
@@ -1021,6 +1021,13 @@ router.patch("/landlord/maintenance/:id", async (req: any, res) => {
     if (requestedAccessRequired !== undefined) {
       update.accessRequired = requestedAccessRequired;
     }
+    if (req.body?.serviceWindowStartAt !== undefined || req.body?.serviceWindowEndAt !== undefined) {
+      update.tenantConfirmationStatus = null;
+      update.tenantConfirmationUpdatedAt = null;
+      update.accessAcknowledgedAt = null;
+    } else if (requestedAccessRequired !== undefined) {
+      update.accessAcknowledgedAt = null;
+    }
     await ref.set(update, { merge: true });
     if (effectiveNextStatus && effectiveNextStatus !== currentStatus) {
       await appendStatusHistory(id, {
@@ -1054,6 +1061,21 @@ router.patch("/landlord/maintenance/:id", async (req: any, res) => {
             : requestedAccessRequired === false
             ? "Access coordination marked as not required."
             : "Access coordination requirement cleared.",
+      });
+    }
+    if (req.body?.serviceWindowStartAt !== undefined || req.body?.serviceWindowEndAt !== undefined) {
+      await appendStatusHistory(id, {
+        status: effectiveNextStatus || currentStatus,
+        actorRole: role === "admin" ? "admin" : "landlord",
+        actorId,
+        message: "Tenant confirmation was reset because the service window changed.",
+      });
+    } else if (requestedAccessRequired !== undefined) {
+      await appendStatusHistory(id, {
+        status: effectiveNextStatus || currentStatus,
+        actorRole: role === "admin" ? "admin" : "landlord",
+        actorId,
+        message: "Tenant access acknowledgement was reset because the access requirement changed.",
       });
     }
 

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -4931,13 +4931,7 @@ router.get("/maintenance-requests", requireTenant, async (req: any, res) => {
     const items = snap.docs.map((d) => {
       const data = (d.data() as any) || {};
       return {
-        id: d.id,
-        status: data.status ?? "NEW",
-        priority: data.priority ?? "NORMAL",
-        category: data.category ?? "GENERAL",
-        title: data.title ?? "",
-        createdAt: toMillis(data.createdAt),
-        updatedAt: toMillis(data.updatedAt),
+        ...projectTenantMaintenance(d.id, data),
       };
     });
     items.sort((a, b) => (Number(b.updatedAt || 0) || 0) - (Number(a.updatedAt || 0) || 0));
@@ -4959,13 +4953,7 @@ router.get("/maintenance", requireTenant, async (req: any, res) => {
     const items = snap.docs.map((d) => {
       const data = (d.data() as any) || {};
       return {
-        id: d.id,
-        status: data.status ?? "NEW",
-        priority: data.priority ?? "NORMAL",
-        category: data.category ?? "GENERAL",
-        title: data.title ?? "",
-        createdAt: toMillis(data.createdAt),
-        updatedAt: toMillis(data.updatedAt),
+        ...projectTenantMaintenance(d.id, data),
       };
     });
     items.sort((a, b) => (Number(b.updatedAt || 0) || 0) - (Number(a.updatedAt || 0) || 0));
@@ -4995,6 +4983,7 @@ router.get("/maintenance-requests/:id", requireTenant, async (req: any, res) => 
     }
     const payload = {
       id: doc.id,
+      requestId: doc.id,
       landlordId: data.landlordId ?? null,
       tenantId: data.tenantId ?? null,
       propertyId: data.propertyId ?? null,
@@ -5009,6 +4998,12 @@ router.get("/maintenance-requests/:id", requireTenant, async (req: any, res) => 
       serviceWindowStartAt: toMillis(data.serviceWindowStartAt),
       serviceWindowEndAt: toMillis(data.serviceWindowEndAt),
       accessRequired: typeof data.accessRequired === "boolean" ? data.accessRequired : null,
+      tenantConfirmationStatus:
+        data.tenantConfirmationStatus === "confirmed" || data.tenantConfirmationStatus === "needs_schedule_change"
+          ? data.tenantConfirmationStatus
+          : null,
+      tenantConfirmationUpdatedAt: toMillis(data.tenantConfirmationUpdatedAt),
+      accessAcknowledgedAt: toMillis(data.accessAcknowledgedAt),
       tenantContact: data.tenantContact ?? null,
       createdAt: toMillis(data.createdAt),
       updatedAt: toMillis(data.updatedAt),
@@ -5031,6 +5026,108 @@ router.get("/maintenance-requests/:id", requireTenant, async (req: any, res) => 
       err,
     });
     return res.status(500).json({ ok: false, error: "TENANT_MAINT_REQUEST_READ_FAILED" });
+  }
+});
+
+router.post("/maintenance-requests/:id/confirmation", requireTenant, async (req: any, res) => {
+  try {
+    const tenantId = String(req.user?.tenantId || "").trim();
+    const id = String(req.params?.id || "").trim();
+    if (!tenantId) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    if (!id) return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+
+    const docRef = db.collection("maintenanceRequests").doc(id);
+    const snap = await docRef.get();
+    if (!snap.exists) return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+
+    const data = (snap.data() as any) || {};
+    if (String(data.tenantId || "").trim() !== tenantId) {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+
+    const confirmationStatus =
+      req.body?.confirmationStatus === undefined
+        ? undefined
+        : req.body?.confirmationStatus === "confirmed" || req.body?.confirmationStatus === "needs_schedule_change"
+        ? req.body.confirmationStatus
+        : null;
+    if (req.body?.confirmationStatus !== undefined && confirmationStatus === null) {
+      return res.status(400).json({ ok: false, error: "INVALID_CONFIRMATION_STATUS" });
+    }
+
+    const acknowledgeAccess = req.body?.acknowledgeAccess === true;
+    const serviceWindowStartAt = toMillis(data.serviceWindowStartAt);
+    const accessRequired = data.accessRequired === true;
+    if (confirmationStatus && !serviceWindowStartAt) {
+      return res.status(400).json({ ok: false, error: "SERVICE_WINDOW_REQUIRED" });
+    }
+    if (acknowledgeAccess && !accessRequired) {
+      return res.status(400).json({ ok: false, error: "ACCESS_ACKNOWLEDGEMENT_NOT_REQUIRED" });
+    }
+    if (confirmationStatus === undefined && !acknowledgeAccess) {
+      return res.status(400).json({ ok: false, error: "NO_CONFIRMATION_UPDATE" });
+    }
+
+    const now = Date.now();
+    const update: Record<string, unknown> = {
+      updatedAt: now,
+      lastUpdatedBy: "TENANT",
+    };
+    if (confirmationStatus !== undefined) {
+      update.tenantConfirmationStatus = confirmationStatus;
+      update.tenantConfirmationUpdatedAt = now;
+    }
+    if (acknowledgeAccess) {
+      update.accessAcknowledgedAt = now;
+    }
+
+    await docRef.set(update, { merge: true });
+
+    const historyEntries: Array<{ status: string; actorRole: string; actorId: string; message: string; createdAt: number }> = [];
+    if (confirmationStatus === "confirmed") {
+      historyEntries.push({
+        status: String(data.status || "scheduled"),
+        actorRole: "tenant",
+        actorId: tenantId,
+        message: "Tenant confirmed the scheduled service window.",
+        createdAt: now,
+      });
+    } else if (confirmationStatus === "needs_schedule_change") {
+      historyEntries.push({
+        status: String(data.status || "scheduled"),
+        actorRole: "tenant",
+        actorId: tenantId,
+        message: "Tenant requested a schedule change.",
+        createdAt: now,
+      });
+    }
+    if (acknowledgeAccess) {
+      historyEntries.push({
+        status: String(data.status || "scheduled"),
+        actorRole: "tenant",
+        actorId: tenantId,
+        message: "Tenant acknowledged the access requirement.",
+        createdAt: now,
+      });
+    }
+    if (historyEntries.length) {
+      await docRef.set({ statusHistory: FieldValue.arrayUnion(...historyEntries) }, { merge: true });
+    }
+
+    const refreshed = await docRef.get();
+    return res.json({
+      ok: true,
+      data: {
+        ...projectTenantMaintenance(refreshed.id, refreshed.data() || {}),
+      },
+    });
+  } catch (err) {
+    console.error("[tenant/maintenance-requests/:id/confirmation] update failed", {
+      tenantId: req.user?.tenantId,
+      id: req.params?.id,
+      err,
+    });
+    return res.status(500).json({ ok: false, error: "TENANT_MAINT_REQUEST_CONFIRMATION_FAILED" });
   }
 });
 

--- a/rentchain-api/src/services/tenantPortal/tenantProjectionService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantProjectionService.ts
@@ -39,6 +39,9 @@ type TenantMaintenanceProjection = {
   serviceWindowStartAt: number | null;
   serviceWindowEndAt: number | null;
   accessRequired: boolean | null;
+  tenantConfirmationStatus: "confirmed" | "needs_schedule_change" | null;
+  tenantConfirmationUpdatedAt: number | null;
+  accessAcknowledgedAt: number | null;
   createdAt: number | null;
   updatedAt: number | null;
   statusHistory: Array<{
@@ -156,6 +159,12 @@ export function projectTenantMaintenance(recordId: string, data: any): TenantMai
     serviceWindowStartAt: toMillis(data?.serviceWindowStartAt),
     serviceWindowEndAt: toMillis(data?.serviceWindowEndAt),
     accessRequired: typeof data?.accessRequired === "boolean" ? data.accessRequired : null,
+    tenantConfirmationStatus:
+      data?.tenantConfirmationStatus === "confirmed" || data?.tenantConfirmationStatus === "needs_schedule_change"
+        ? data.tenantConfirmationStatus
+        : null,
+    tenantConfirmationUpdatedAt: toMillis(data?.tenantConfirmationUpdatedAt),
+    accessAcknowledgedAt: toMillis(data?.accessAcknowledgedAt),
     createdAt: toMillis(data?.createdAt),
     updatedAt: toMillis(data?.updatedAt),
     statusHistory,

--- a/rentchain-frontend/src/api/maintenanceWorkflowApi.ts
+++ b/rentchain-frontend/src/api/maintenanceWorkflowApi.ts
@@ -3,6 +3,7 @@ import {
   createTenantWorkspaceMaintenance,
   getTenantWorkspaceMaintenance,
   listTenantWorkspaceMaintenance,
+  updateTenantWorkspaceMaintenanceConfirmation,
 } from "./tenantPortal";
 
 export type MaintenanceWorkflowStatus =
@@ -36,6 +37,9 @@ export type MaintenanceWorkflowItem = {
   serviceWindowStartAt?: number | null;
   serviceWindowEndAt?: number | null;
   accessRequired?: boolean | null;
+  tenantConfirmationStatus?: "confirmed" | "needs_schedule_change" | null;
+  tenantConfirmationUpdatedAt?: number | null;
+  accessAcknowledgedAt?: number | null;
   landlordNote?: string | null;
   createdAt: number;
   updatedAt: number;
@@ -108,6 +112,13 @@ export async function listTenantMaintenance() {
     serviceWindowStartAt: typeof item.serviceWindowStartAt === "number" ? item.serviceWindowStartAt : null,
     serviceWindowEndAt: typeof item.serviceWindowEndAt === "number" ? item.serviceWindowEndAt : null,
     accessRequired: typeof item.accessRequired === "boolean" ? item.accessRequired : null,
+    tenantConfirmationStatus:
+      item.tenantConfirmationStatus === "confirmed" || item.tenantConfirmationStatus === "needs_schedule_change"
+        ? item.tenantConfirmationStatus
+        : null,
+    tenantConfirmationUpdatedAt:
+      typeof item.tenantConfirmationUpdatedAt === "number" ? item.tenantConfirmationUpdatedAt : null,
+    accessAcknowledgedAt: typeof item.accessAcknowledgedAt === "number" ? item.accessAcknowledgedAt : null,
     createdAt: item.createdAt || Date.now(),
     updatedAt: item.updatedAt || item.createdAt || Date.now(),
     statusHistory: Array.isArray(item.statusHistory)
@@ -141,6 +152,59 @@ export async function getTenantMaintenance(id: string) {
     serviceWindowStartAt: typeof item?.serviceWindowStartAt === "number" ? item.serviceWindowStartAt : null,
     serviceWindowEndAt: typeof item?.serviceWindowEndAt === "number" ? item.serviceWindowEndAt : null,
     accessRequired: typeof item?.accessRequired === "boolean" ? item.accessRequired : null,
+    tenantConfirmationStatus:
+      item?.tenantConfirmationStatus === "confirmed" || item?.tenantConfirmationStatus === "needs_schedule_change"
+        ? item.tenantConfirmationStatus
+        : null,
+    tenantConfirmationUpdatedAt:
+      typeof item?.tenantConfirmationUpdatedAt === "number" ? item.tenantConfirmationUpdatedAt : null,
+    accessAcknowledgedAt: typeof item?.accessAcknowledgedAt === "number" ? item.accessAcknowledgedAt : null,
+    createdAt: item?.createdAt || Date.now(),
+    updatedAt: item?.updatedAt || item?.createdAt || Date.now(),
+    statusHistory: Array.isArray(item?.statusHistory)
+      ? item.statusHistory.map((entry) => ({
+          status: String(entry?.status || ""),
+          actorRole: String(entry?.actorRole || ""),
+          actorId: entry?.actorId ? String(entry.actorId) : null,
+          message: entry?.message ? String(entry.message) : null,
+          createdAt: typeof entry?.createdAt === "number" ? entry.createdAt : undefined,
+        }))
+      : [],
+  };
+  return { ok: true, item: mapped, data: mapped };
+}
+
+export async function updateTenantMaintenanceConfirmation(
+  id: string,
+  payload: {
+    confirmationStatus?: "confirmed" | "needs_schedule_change";
+    acknowledgeAccess?: boolean;
+  }
+) {
+  const item = await updateTenantWorkspaceMaintenanceConfirmation(id, payload);
+  const mapped: MaintenanceWorkflowItem = {
+    id: item?.requestId || id,
+    tenantId: "",
+    landlordId: "",
+    propertyId: null,
+    unitId: null,
+    title: item?.title || "Maintenance request",
+    description: item?.summary || "",
+    category: String(item?.category || "GENERAL"),
+    priority: String(item?.priority || "normal").toLowerCase() as "low" | "normal" | "urgent",
+    status: String(item?.status || "submitted").toLowerCase() as MaintenanceWorkflowStatus,
+    assignedContractorName: item?.assignedContractorName || null,
+    contractorStatus: item?.contractorStatus || null,
+    serviceWindowStartAt: typeof item?.serviceWindowStartAt === "number" ? item.serviceWindowStartAt : null,
+    serviceWindowEndAt: typeof item?.serviceWindowEndAt === "number" ? item.serviceWindowEndAt : null,
+    accessRequired: typeof item?.accessRequired === "boolean" ? item.accessRequired : null,
+    tenantConfirmationStatus:
+      item?.tenantConfirmationStatus === "confirmed" || item?.tenantConfirmationStatus === "needs_schedule_change"
+        ? item.tenantConfirmationStatus
+        : null,
+    tenantConfirmationUpdatedAt:
+      typeof item?.tenantConfirmationUpdatedAt === "number" ? item.tenantConfirmationUpdatedAt : null,
+    accessAcknowledgedAt: typeof item?.accessAcknowledgedAt === "number" ? item.accessAcknowledgedAt : null,
     createdAt: item?.createdAt || Date.now(),
     updatedAt: item?.updatedAt || item?.createdAt || Date.now(),
     statusHistory: Array.isArray(item?.statusHistory)

--- a/rentchain-frontend/src/api/tenantPortal.ts
+++ b/rentchain-frontend/src/api/tenantPortal.ts
@@ -62,6 +62,9 @@ export type TenantWorkspaceMaintenance = {
   serviceWindowStartAt?: number | null;
   serviceWindowEndAt?: number | null;
   accessRequired?: boolean | null;
+  tenantConfirmationStatus?: "confirmed" | "needs_schedule_change" | null;
+  tenantConfirmationUpdatedAt?: number | null;
+  accessAcknowledgedAt?: number | null;
   createdAt: number | null;
   updatedAt: number | null;
   statusHistory?: Array<{
@@ -116,6 +119,23 @@ export async function createTenantWorkspaceMaintenance(payload: {
 }) {
   const res = await tenantApiFetch<{ ok: boolean; data: TenantWorkspaceMaintenance }>(
     "/tenant/maintenance-requests",
+    {
+      method: "POST",
+      body: payload,
+    }
+  );
+  return res?.data;
+}
+
+export async function updateTenantWorkspaceMaintenanceConfirmation(
+  id: string,
+  payload: {
+    confirmationStatus?: "confirmed" | "needs_schedule_change";
+    acknowledgeAccess?: boolean;
+  }
+) {
+  const res = await tenantApiFetch<{ ok: boolean; data: TenantWorkspaceMaintenance }>(
+    `/tenant/maintenance-requests/${encodeURIComponent(id)}/confirmation`,
     {
       method: "POST",
       body: payload,

--- a/rentchain-frontend/src/pages/MaintenanceRequestsPage.test.tsx
+++ b/rentchain-frontend/src/pages/MaintenanceRequestsPage.test.tsx
@@ -102,6 +102,8 @@ describe("landlord maintenance workspace", () => {
     expect(screen.getAllByText(/No handler has been assigned to this request yet/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Scheduling \/ access/i)).toBeInTheDocument();
     expect(screen.getByText(/Awaiting schedule/i)).toBeInTheDocument();
+    expect(screen.getByText(/Confirmation \/ access/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Not ready for service/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Review the request details/i)).toBeInTheDocument();
     expect(screen.getByText(/Mark reviewed/i)).toBeInTheDocument();
   });
@@ -146,6 +148,8 @@ describe("landlord maintenance workspace", () => {
           serviceWindowStartAt: Date.UTC(2026, 3, 15, 13, 0),
           serviceWindowEndAt: Date.UTC(2026, 3, 15, 15, 0),
           accessRequired: false,
+          tenantConfirmationStatus: "confirmed",
+          tenantConfirmationUpdatedAt: Date.UTC(2026, 3, 14, 10, 0),
           createdAt: 100,
           updatedAt: 200,
           statusHistory: [],
@@ -165,6 +169,6 @@ describe("landlord maintenance workspace", () => {
     fireEvent.click(screen.getAllByRole("button", { name: /Leaky pipe/i })[0]);
 
     expect(await screen.findAllByText(/Leaky pipe/i)).not.toHaveLength(0);
-    expect(screen.getByText(/Ready for service/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Ready for service/i).length).toBeGreaterThan(0);
   });
 });

--- a/rentchain-frontend/src/pages/MaintenanceRequestsPage.tsx
+++ b/rentchain-frontend/src/pages/MaintenanceRequestsPage.tsx
@@ -15,6 +15,7 @@ import { getContractorProfileById, listContractorInvites } from "../api/workOrde
 import { colors, radius, spacing, text } from "../styles/tokens";
 import { buildMaintenanceLifecycleView, buildMaintenanceWorkspaceState } from "./maintenanceWorkspaceState";
 import { buildMaintenanceAssignmentRoutingView } from "./maintenanceAssignmentRoutingState";
+import { buildMaintenanceConfirmationAccessView } from "./maintenanceConfirmationAccessState";
 import {
   buildMaintenanceSchedulingAccessView,
   buildMaintenanceSchedulingCalendarEvents,
@@ -381,6 +382,10 @@ export default function MaintenanceRequestsPage() {
   );
   const selectedScheduling = React.useMemo(
     () => (selected ? buildMaintenanceSchedulingAccessView(selected, "landlord") : null),
+    [selected]
+  );
+  const selectedConfirmation = React.useMemo(
+    () => (selected ? buildMaintenanceConfirmationAccessView(selected, "landlord") : null),
     [selected]
   );
   const calendarEvents = React.useMemo(() => buildMaintenanceSchedulingCalendarEvents(items), [items]);
@@ -906,6 +911,60 @@ export default function MaintenanceRequestsPage() {
                         <Button variant="secondary" onClick={() => void saveScheduleAccess()} disabled={saving}>
                           {saving ? "Saving..." : "Save scheduling"}
                         </Button>
+                      </div>
+                    </div>
+                  ) : null}
+
+                  {selectedConfirmation ? (
+                    <div
+                      style={{
+                        border: `1px solid ${colors.border}`,
+                        borderRadius: radius.md,
+                        padding: "12px 14px",
+                        background: colors.panel,
+                        display: "grid",
+                        gap: 10,
+                      }}
+                    >
+                      <div style={{ fontWeight: 700, color: text.primary }}>Confirmation / access</div>
+                      <div style={{ color: text.secondary }}>{selectedConfirmation.summary}</div>
+                      <div style={{ display: "grid", gap: spacing.sm, gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))" }}>
+                        <div>
+                          <div style={{ color: text.muted, fontSize: 12 }}>Confirmation status</div>
+                          <div style={{ color: text.primary, fontWeight: 700, marginTop: 6 }}>
+                            {selectedConfirmation.confirmationLabel}
+                          </div>
+                        </div>
+                        <div>
+                          <div style={{ color: text.muted, fontSize: 12 }}>Access</div>
+                          <div style={{ color: text.primary, fontWeight: 700, marginTop: 6 }}>
+                            {selectedConfirmation.accessLabel}
+                          </div>
+                        </div>
+                        <div>
+                          <div style={{ color: text.muted, fontSize: 12 }}>Service readiness</div>
+                          <div style={{ color: text.primary, fontWeight: 700, marginTop: 6 }}>
+                            {selectedConfirmation.readinessLabel}
+                          </div>
+                        </div>
+                      </div>
+                      {selectedConfirmation.blockers.length ? (
+                        <div style={{ display: "grid", gap: 4 }}>
+                          <div style={{ fontWeight: 700, color: text.primary }}>Needs attention</div>
+                          {selectedConfirmation.blockers.map((item) => (
+                            <div key={item} style={{ color: text.secondary }}>
+                              {item}
+                            </div>
+                          ))}
+                        </div>
+                      ) : null}
+                      <div style={{ display: "grid", gap: 4 }}>
+                        <div style={{ fontWeight: 700, color: text.primary }}>Next steps</div>
+                        {selectedConfirmation.nextActions.map((item) => (
+                          <div key={item} style={{ color: text.secondary }}>
+                            {item}
+                          </div>
+                        ))}
                       </div>
                     </div>
                   ) : null}

--- a/rentchain-frontend/src/pages/maintenanceConfirmationAccessState.test.ts
+++ b/rentchain-frontend/src/pages/maintenanceConfirmationAccessState.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { buildMaintenanceConfirmationAccessView } from "./maintenanceConfirmationAccessState";
+import type { MaintenanceWorkflowItem } from "../api/maintenanceWorkflowApi";
+
+function makeItem(overrides: Partial<MaintenanceWorkflowItem> = {}): MaintenanceWorkflowItem {
+  return {
+    id: "maint-1",
+    tenantId: "tenant-1",
+    landlordId: "landlord-1",
+    propertyId: "prop-1",
+    unitId: "unit-1",
+    title: "Broken heater",
+    description: "Heat is not turning on.",
+    category: "HVAC",
+    priority: "urgent",
+    status: "scheduled",
+    createdAt: 100,
+    updatedAt: 200,
+    ...overrides,
+  };
+}
+
+describe("buildMaintenanceConfirmationAccessView", () => {
+  it("marks a scheduled request as awaiting confirmation by default", () => {
+    const view = buildMaintenanceConfirmationAccessView(
+      makeItem({
+        serviceWindowStartAt: Date.UTC(2026, 3, 15, 13, 0),
+        serviceWindowEndAt: Date.UTC(2026, 3, 15, 15, 0),
+        accessRequired: true,
+      }),
+      "tenant"
+    );
+
+    expect(view.confirmationState).toBe("awaiting_confirmation");
+    expect(view.readinessState).toBe("not_ready");
+    expect(view.accessState).toBe("access_required");
+  });
+
+  it("marks a request ready for service when the window is confirmed and access is acknowledged", () => {
+    const view = buildMaintenanceConfirmationAccessView(
+      makeItem({
+        serviceWindowStartAt: Date.UTC(2026, 3, 15, 13, 0),
+        serviceWindowEndAt: Date.UTC(2026, 3, 15, 15, 0),
+        accessRequired: true,
+        tenantConfirmationStatus: "confirmed",
+        tenantConfirmationUpdatedAt: 500,
+        accessAcknowledgedAt: 600,
+      }),
+      "landlord"
+    );
+
+    expect(view.confirmationState).toBe("confirmed");
+    expect(view.readinessState).toBe("ready_for_service");
+    expect(view.accessState).toBe("access_acknowledged");
+  });
+
+  it("surfaces a schedule-change request as needing attention", () => {
+    const view = buildMaintenanceConfirmationAccessView(
+      makeItem({
+        serviceWindowStartAt: Date.UTC(2026, 3, 15, 13, 0),
+        tenantConfirmationStatus: "needs_schedule_change",
+        tenantConfirmationUpdatedAt: 500,
+      }),
+      "landlord"
+    );
+
+    expect(view.confirmationState).toBe("needs_schedule_change");
+    expect(view.readinessState).toBe("needs_attention");
+    expect(view.blockers.join(" ")).toMatch(/service window/i);
+  });
+});

--- a/rentchain-frontend/src/pages/maintenanceConfirmationAccessState.ts
+++ b/rentchain-frontend/src/pages/maintenanceConfirmationAccessState.ts
@@ -1,0 +1,252 @@
+import type { MaintenanceWorkflowItem } from "../api/maintenanceWorkflowApi";
+
+export type MaintenanceConfirmationState =
+  | "awaiting_confirmation"
+  | "confirmed"
+  | "needs_schedule_change"
+  | "in_progress"
+  | "completed"
+  | "needs_attention";
+
+export type MaintenanceConfirmationAccessState =
+  | "access_not_needed"
+  | "access_required"
+  | "access_acknowledged"
+  | "access_not_set";
+
+export type MaintenanceServiceReadinessState =
+  | "not_ready"
+  | "ready_for_service"
+  | "in_progress"
+  | "completed"
+  | "needs_attention";
+
+export type MaintenanceConfirmationAudience = "landlord" | "tenant";
+
+export type MaintenanceConfirmationAccessView = {
+  confirmationState: MaintenanceConfirmationState;
+  confirmationLabel: string;
+  accessState: MaintenanceConfirmationAccessState;
+  accessLabel: string;
+  readinessState: MaintenanceServiceReadinessState;
+  readinessLabel: string;
+  tenantVisibleState: string;
+  summary: string;
+  blockers: string[];
+  nextActions: string[];
+};
+
+function hasScheduledWindow(item: MaintenanceWorkflowItem) {
+  return typeof item.serviceWindowStartAt === "number";
+}
+
+function hasAccessAcknowledged(item: MaintenanceWorkflowItem) {
+  return typeof item.accessAcknowledgedAt === "number";
+}
+
+function isConfirmationStatus(value: string | null | undefined): value is "confirmed" | "needs_schedule_change" {
+  return value === "confirmed" || value === "needs_schedule_change";
+}
+
+function pretty(value: string) {
+  return value
+    .split("_")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export function buildMaintenanceConfirmationAccessView(
+  item: MaintenanceWorkflowItem,
+  audience: MaintenanceConfirmationAudience
+): MaintenanceConfirmationAccessView {
+  const status = String(item.status || "").toLowerCase();
+  const confirmationStatus = isConfirmationStatus(item.tenantConfirmationStatus)
+    ? item.tenantConfirmationStatus
+    : null;
+  const accessRequired = item.accessRequired === true;
+  const accessAcknowledged = hasAccessAcknowledged(item);
+  const hasWindow = hasScheduledWindow(item);
+  const blockers: string[] = [];
+  const nextActions: string[] = [];
+
+  let confirmationState: MaintenanceConfirmationState = "awaiting_confirmation";
+  let confirmationLabel = "Awaiting confirmation";
+  let accessState: MaintenanceConfirmationAccessState = accessRequired
+    ? accessAcknowledged
+      ? "access_acknowledged"
+      : "access_required"
+    : item.accessRequired === false
+    ? "access_not_needed"
+    : "access_not_set";
+  let accessLabel =
+    accessState === "access_acknowledged"
+      ? "Access acknowledged"
+      : accessState === "access_required"
+      ? "Access required"
+      : accessState === "access_not_needed"
+      ? "Access not needed"
+      : "Access requirement not set";
+  let readinessState: MaintenanceServiceReadinessState = "not_ready";
+  let readinessLabel = "Not ready for service";
+  let tenantVisibleState = "Awaiting confirmation";
+  let summary = "A scheduled service window still needs tenant confirmation before it is clearly ready to proceed.";
+
+  if (status === "completed") {
+    confirmationState = "completed";
+    confirmationLabel = "Completed";
+    readinessState = "completed";
+    readinessLabel = "Completed";
+    tenantVisibleState = "Completed";
+    summary = "This request is marked complete.";
+  } else if (status === "in_progress") {
+    confirmationState = "in_progress";
+    confirmationLabel = "In progress";
+    readinessState = "in_progress";
+    readinessLabel = "In progress";
+    tenantVisibleState = "Service in progress";
+    summary = "Service is already underway for this request.";
+  } else if (status === "cancelled") {
+    confirmationState = "needs_attention";
+    confirmationLabel = "Needs attention";
+    readinessState = "needs_attention";
+    readinessLabel = "Needs attention";
+    tenantVisibleState = "Needs attention";
+    summary = "This request is not currently in a normal confirmation workflow.";
+    blockers.push("The request is cancelled and will need manual review before service can proceed.");
+  } else if (!hasWindow || !["assigned", "scheduled"].includes(status)) {
+    confirmationState = "needs_attention";
+    confirmationLabel = "Needs attention";
+    readinessState = "not_ready";
+    readinessLabel = "Not ready for service";
+    tenantVisibleState = "Not ready";
+    summary =
+      audience === "landlord"
+        ? "A confirmed service window is required before tenant confirmation can be resolved."
+        : "Your landlord needs to confirm the service window before this request can move into confirmation.";
+    blockers.push(
+      audience === "landlord"
+        ? "Set or update the service window before using the confirmation workflow."
+        : "Wait for a confirmed service window before taking the next step."
+    );
+  } else if (confirmationStatus === "needs_schedule_change") {
+    confirmationState = "needs_schedule_change";
+    confirmationLabel = "Needs schedule change";
+    readinessState = "needs_attention";
+    readinessLabel = "Needs attention";
+    tenantVisibleState = "Needs schedule change";
+    summary =
+      audience === "landlord"
+        ? "The tenant flagged this service window as needing a change before the visit should proceed."
+        : "You flagged this service window as needing a change.";
+    blockers.push(
+      audience === "landlord"
+        ? "Update the service window or follow up with the tenant before treating this request as ready."
+        : "Wait for an updated service window from your landlord."
+    );
+  } else if (confirmationStatus === "confirmed" && (!accessRequired || accessAcknowledged)) {
+    confirmationState = "confirmed";
+    confirmationLabel = "Confirmed";
+    readinessState = "ready_for_service";
+    readinessLabel = "Ready for service";
+    tenantVisibleState = "Ready for service";
+    summary =
+      accessRequired && accessAcknowledged
+        ? "The tenant has confirmed the service window and acknowledged the access requirement."
+        : "The tenant has confirmed the current service window.";
+  } else if (confirmationStatus === "confirmed") {
+    confirmationState = "confirmed";
+    confirmationLabel = "Confirmed";
+    readinessState = "not_ready";
+    readinessLabel = "Awaiting access acknowledgement";
+    tenantVisibleState = "Confirmed";
+    summary = "The service window is confirmed, but access still needs to be acknowledged before the request is ready.";
+    blockers.push(
+      audience === "landlord"
+        ? "Access is required but has not been acknowledged by the tenant yet."
+        : "Access is required before this service visit can be treated as ready."
+    );
+  } else {
+    confirmationState = "awaiting_confirmation";
+    confirmationLabel = "Awaiting confirmation";
+    readinessState = "not_ready";
+    readinessLabel = "Awaiting tenant confirmation";
+    tenantVisibleState = "Awaiting your confirmation";
+    summary =
+      audience === "landlord"
+        ? "The scheduled service window is waiting on tenant confirmation."
+        : "Please review the scheduled service window and confirm whether it works for you.";
+    blockers.push(
+      audience === "landlord"
+        ? "Tenant confirmation is still pending for this service window."
+        : "This service window has not been confirmed yet."
+    );
+  }
+
+  if (confirmationState === "awaiting_confirmation") {
+    nextActions.push(
+      audience === "landlord"
+        ? "Wait for the tenant to confirm or request a schedule change."
+        : "Confirm the service window or flag that you need a schedule change."
+    );
+  }
+
+  if (confirmationState === "needs_schedule_change") {
+    nextActions.push(
+      audience === "landlord"
+        ? "Adjust the service window and ask the tenant to re-confirm it."
+        : "Watch for an updated service window from your landlord."
+    );
+  }
+
+  if (confirmationState === "confirmed" && accessRequired && !accessAcknowledged) {
+    nextActions.push(
+      audience === "landlord"
+        ? "Wait for access acknowledgement before treating the visit as fully ready."
+        : "Acknowledge the access requirement if you are comfortable with the current plan."
+    );
+  }
+
+  if (readinessState === "ready_for_service") {
+    nextActions.push(
+      audience === "landlord"
+        ? "Keep the request detail updated if the visit timing changes."
+        : "Watch this request for any last-minute service window updates."
+    );
+  }
+
+  if (confirmationState === "needs_attention" && nextActions.length === 0) {
+    nextActions.push(
+      audience === "landlord"
+        ? "Review the request detail and scheduling history before making the next update."
+        : "Review the request detail for the latest service update."
+    );
+  }
+
+  if (nextActions.length === 0) {
+    nextActions.push(
+      audience === "landlord"
+        ? "Review the request detail for the next operational step."
+        : "Use this request detail for the latest confirmation and access updates."
+    );
+  }
+
+  return {
+    confirmationState,
+    confirmationLabel,
+    accessState,
+    accessLabel,
+    readinessState,
+    readinessLabel,
+    tenantVisibleState,
+    summary,
+    blockers,
+    nextActions,
+  };
+}
+
+export function getMaintenanceConfirmationBadgeLabel(item: MaintenanceWorkflowItem) {
+  return pretty(
+    isConfirmationStatus(item.tenantConfirmationStatus) ? item.tenantConfirmationStatus : "awaiting_confirmation"
+  );
+}

--- a/rentchain-frontend/src/pages/tenant/TenantMaintenancePages.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantMaintenancePages.test.tsx
@@ -10,6 +10,7 @@ const maintenanceWorkflowApi = vi.hoisted(() => ({
   listTenantMaintenance: vi.fn(),
   getTenantMaintenance: vi.fn(),
   createTenantMaintenance: vi.fn(),
+  updateTenantMaintenanceConfirmation: vi.fn(),
 }));
 
 const tenantAuth = vi.hoisted(() => ({
@@ -26,6 +27,7 @@ vi.mock("../../api/maintenanceWorkflowApi", async () => {
     listTenantMaintenance: maintenanceWorkflowApi.listTenantMaintenance,
     getTenantMaintenance: maintenanceWorkflowApi.getTenantMaintenance,
     createTenantMaintenance: maintenanceWorkflowApi.createTenantMaintenance,
+    updateTenantMaintenanceConfirmation: maintenanceWorkflowApi.updateTenantMaintenanceConfirmation,
   };
 });
 
@@ -77,19 +79,21 @@ describe("tenant maintenance pages", () => {
     expect(screen.getByText(/Handling: Awaiting Assignment/i)).toBeInTheDocument();
     expect(screen.getAllByText(/Scheduling \/ access/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Upcoming service window: No service window has been confirmed yet/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Confirmation \/ access/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/landlord needs to confirm the service window/i)).toBeInTheDocument();
   });
 
-  it("renders the tenant maintenance detail with next steps and timeline", async () => {
+  it("renders the tenant maintenance detail with confirmation actions and timeline", async () => {
     maintenanceWorkflowApi.getTenantMaintenance.mockResolvedValue({
       item: {
         id: "maint-1",
         title: "Broken heater",
         description: "The heat is not turning on.",
-        status: "in_progress",
+        status: "scheduled",
         priority: "urgent",
         category: "HVAC",
         assignedContractorName: "North Shore HVAC",
-        contractorStatus: "in_progress",
+        contractorStatus: "assigned",
         serviceWindowStartAt: Date.UTC(2026, 3, 15, 13, 0),
         serviceWindowEndAt: Date.UTC(2026, 3, 15, 15, 0),
         accessRequired: true,
@@ -116,13 +120,74 @@ describe("tenant maintenance pages", () => {
 
     expect(await screen.findByText(/Broken heater/i)).toBeInTheDocument();
     expect(screen.getByText(/What this status means/i)).toBeInTheDocument();
-    expect(screen.getByText(/Work is actively underway/i)).toBeInTheDocument();
     expect(screen.getByText(/Handling status/i)).toBeInTheDocument();
-    expect(screen.getByText(/Your request is actively being handled/i)).toBeInTheDocument();
     expect(screen.getAllByText(/Scheduling \/ access/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Access needed/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Confirmation \/ access/i).length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: /Confirm service window/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Request schedule change/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Acknowledge access/i })).toBeInTheDocument();
     expect(screen.getByText(/Status timeline/i)).toBeInTheDocument();
     expect(screen.getByText(/Technician is on site/i)).toBeInTheDocument();
+  });
+
+  it("submits tenant confirmation updates from the detail page", async () => {
+    maintenanceWorkflowApi.getTenantMaintenance.mockResolvedValue({
+      item: {
+        id: "maint-1",
+        title: "Broken heater",
+        description: "The heat is not turning on.",
+        status: "scheduled",
+        priority: "urgent",
+        category: "HVAC",
+        assignedContractorName: "North Shore HVAC",
+        contractorStatus: "assigned",
+        serviceWindowStartAt: Date.UTC(2026, 3, 15, 13, 0),
+        serviceWindowEndAt: Date.UTC(2026, 3, 15, 15, 0),
+        accessRequired: true,
+        createdAt: 100,
+        updatedAt: 200,
+        statusHistory: [],
+      },
+    });
+    maintenanceWorkflowApi.updateTenantMaintenanceConfirmation.mockResolvedValue({
+      item: {
+        id: "maint-1",
+        title: "Broken heater",
+        description: "The heat is not turning on.",
+        status: "scheduled",
+        priority: "urgent",
+        category: "HVAC",
+        assignedContractorName: "North Shore HVAC",
+        contractorStatus: "assigned",
+        serviceWindowStartAt: Date.UTC(2026, 3, 15, 13, 0),
+        serviceWindowEndAt: Date.UTC(2026, 3, 15, 15, 0),
+        accessRequired: true,
+        tenantConfirmationStatus: "confirmed",
+        tenantConfirmationUpdatedAt: 300,
+        accessAcknowledgedAt: 301,
+        createdAt: 100,
+        updatedAt: 400,
+        statusHistory: [],
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/tenant/maintenance/maint-1"]}>
+        <Routes>
+          <Route path="/tenant/maintenance/:id" element={<TenantMaintenanceRequestDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /Confirm service window/i }));
+
+    await waitFor(() => {
+      expect(maintenanceWorkflowApi.updateTenantMaintenanceConfirmation).toHaveBeenCalledWith("maint-1", {
+        confirmationStatus: "confirmed",
+      });
+    });
+    expect(await screen.findByText(/The tenant has confirmed the service window and acknowledged the access requirement/i)).toBeInTheDocument();
   });
 
   it("submits the tenant maintenance request form", async () => {

--- a/rentchain-frontend/src/pages/tenant/TenantMaintenanceRequestDetailPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantMaintenanceRequestDetailPage.tsx
@@ -1,12 +1,17 @@
 import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
-import { getTenantMaintenance, type MaintenanceWorkflowItem } from "../../api/maintenanceWorkflowApi";
-import { Card, Section } from "../../components/ui/Ui";
+import {
+  getTenantMaintenance,
+  updateTenantMaintenanceConfirmation,
+  type MaintenanceWorkflowItem,
+} from "../../api/maintenanceWorkflowApi";
+import { Button, Card, Section } from "../../components/ui/Ui";
 import { clearTenantToken, getTenantToken } from "../../lib/tenantAuth";
 import { colors, radius, spacing, text as textTokens } from "../../styles/tokens";
 import { TenantSurfaceShell, prettyStatus } from "./TenantWorkspaceShared";
 import { buildMaintenanceLifecycleView } from "../maintenanceWorkspaceState";
 import { buildMaintenanceAssignmentRoutingView } from "../maintenanceAssignmentRoutingState";
+import { buildMaintenanceConfirmationAccessView } from "../maintenanceConfirmationAccessState";
 import { buildMaintenanceSchedulingAccessView } from "../maintenanceSchedulingAccessState";
 
 function fmtDate(ts?: number | null) {
@@ -21,6 +26,7 @@ export default function TenantMaintenanceRequestDetailPage() {
   const [data, setData] = useState<MaintenanceWorkflowItem | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [savingAction, setSavingAction] = useState(false);
   const [sessionExpired, setSessionExpired] = useState(false);
   const [hasToken, setHasToken] = useState<boolean>(() =>
     typeof window === "undefined" ? true : !!getTenantToken()
@@ -28,6 +34,7 @@ export default function TenantMaintenanceRequestDetailPage() {
   const lifecycleView = data ? buildMaintenanceLifecycleView(data, "tenant") : null;
   const assignmentView = data ? buildMaintenanceAssignmentRoutingView(data, "tenant") : null;
   const schedulingView = data ? buildMaintenanceSchedulingAccessView(data, "tenant") : null;
+  const confirmationView = data ? buildMaintenanceConfirmationAccessView(data, "tenant") : null;
 
   useEffect(() => {
     const token = getTenantToken();
@@ -103,6 +110,24 @@ export default function TenantMaintenanceRequestDetailPage() {
       </div>
     );
   }
+
+  const applyConfirmationUpdate = async (payload: {
+    confirmationStatus?: "confirmed" | "needs_schedule_change";
+    acknowledgeAccess?: boolean;
+  }) => {
+    if (!id) return;
+    setSavingAction(true);
+    setError(null);
+    try {
+      const res = await updateTenantMaintenanceConfirmation(id, payload);
+      setData((res as any)?.item || (res as any)?.data || null);
+    } catch (err: any) {
+      const msg = err?.payload?.error || err?.message || "Unable to update the maintenance confirmation.";
+      setError(String(msg));
+    } finally {
+      setSavingAction(false);
+    }
+  };
 
   return (
     <TenantSurfaceShell
@@ -253,6 +278,68 @@ export default function TenantMaintenanceRequestDetailPage() {
                       {step}
                     </div>
                   ))}
+                </div>
+              ) : null}
+              {confirmationView ? (
+                <div
+                  style={{
+                    border: `1px solid ${colors.border}`,
+                    borderRadius: radius.md,
+                    padding: "12px 14px",
+                    background: colors.panel,
+                    display: "grid",
+                    gap: 8,
+                  }}
+                >
+                  <div style={{ fontWeight: 800, color: textTokens.primary }}>Confirmation / access</div>
+                  <div style={{ color: textTokens.secondary }}>{confirmationView.summary}</div>
+                  <div style={{ color: textTokens.primary, fontWeight: 700 }}>Service readiness</div>
+                  <div style={{ color: textTokens.secondary }}>{confirmationView.readinessLabel}</div>
+                  <div style={{ color: textTokens.primary, fontWeight: 700 }}>Access</div>
+                  <div style={{ color: textTokens.secondary }}>{confirmationView.accessLabel}</div>
+                  {confirmationView.blockers.length ? (
+                    <>
+                      <div style={{ color: textTokens.primary, fontWeight: 700 }}>Needs attention</div>
+                      {confirmationView.blockers.map((item) => (
+                        <div key={item} style={{ color: textTokens.secondary }}>
+                          {item}
+                        </div>
+                      ))}
+                    </>
+                  ) : null}
+                  <div style={{ color: textTokens.primary, fontWeight: 700 }}>Next step</div>
+                  {confirmationView.nextActions.map((step) => (
+                    <div key={step} style={{ color: textTokens.secondary }}>
+                      {step}
+                    </div>
+                  ))}
+                  {data?.status === "scheduled" && schedulingView?.serviceWindowSummary !== "No service window has been confirmed yet." ? (
+                    <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginTop: 4 }}>
+                      <Button
+                        variant="secondary"
+                        onClick={() => void applyConfirmationUpdate({ confirmationStatus: "confirmed" })}
+                        disabled={savingAction || confirmationView.confirmationState === "confirmed"}
+                      >
+                        {savingAction ? "Saving..." : "Confirm service window"}
+                      </Button>
+                      <Button
+                        variant="secondary"
+                        onClick={() => void applyConfirmationUpdate({ confirmationStatus: "needs_schedule_change" })}
+                        disabled={savingAction || confirmationView.confirmationState === "needs_schedule_change"}
+                      >
+                        {savingAction ? "Saving..." : "Request schedule change"}
+                      </Button>
+                      {data.accessRequired === true ? (
+                        <Button
+                          variant="secondary"
+                          onClick={() => void applyConfirmationUpdate({ acknowledgeAccess: true })}
+                          disabled={savingAction || confirmationView.accessState === "access_acknowledged"}
+                        >
+                          {savingAction ? "Saving..." : "Acknowledge access"}
+                        </Button>
+                      ) : null}
+                    </div>
+                  ) : null}
                 </div>
               ) : null}
               <div style={{ display: "grid", gap: 8, marginTop: spacing.xs }}>

--- a/rentchain-frontend/src/pages/tenant/TenantMaintenanceRequestsPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantMaintenanceRequestsPage.tsx
@@ -5,6 +5,7 @@ import { listTenantMaintenance, type MaintenanceWorkflowItem } from "../../api/m
 import { colors, spacing, text as textTokens } from "../../styles/tokens";
 import { buildMaintenanceWorkspaceState } from "../maintenanceWorkspaceState";
 import { buildMaintenanceAssignmentRoutingView } from "../maintenanceAssignmentRoutingState";
+import { buildMaintenanceConfirmationAccessView } from "../maintenanceConfirmationAccessState";
 import { buildMaintenanceSchedulingAccessView } from "../maintenanceSchedulingAccessState";
 import {
   TenantEmptyState,
@@ -134,6 +135,7 @@ export default function TenantMaintenanceRequestsPage() {
               const requestView = workspaceView.requestViews.find((entry) => entry.id === item.id);
               const assignmentView = buildMaintenanceAssignmentRoutingView(item, "tenant");
               const schedulingView = buildMaintenanceSchedulingAccessView(item, "tenant");
+              const confirmationView = buildMaintenanceConfirmationAccessView(item, "tenant");
               return (
                 <TenantInfoCard
                   key={item.id}
@@ -168,6 +170,21 @@ export default function TenantMaintenanceRequestsPage() {
                     </div>
                     <div style={{ color: textTokens.secondary }}>
                       Upcoming service window: {schedulingView.serviceWindowSummary}
+                    </div>
+                  </div>
+                  <div
+                    style={{
+                      border: "1px solid rgba(15,23,42,0.08)",
+                      borderRadius: 12,
+                      padding: "12px 14px",
+                      display: "grid",
+                      gap: 8,
+                    }}
+                  >
+                    <div style={{ color: textTokens.primary, fontWeight: 700 }}>Confirmation / access</div>
+                    <div style={{ color: textTokens.secondary }}>{confirmationView.summary}</div>
+                    <div style={{ color: textTokens.secondary }}>
+                      {`${confirmationView.tenantVisibleState} • ${confirmationView.accessLabel}`}
                     </div>
                   </div>
                   {requestView?.nextSteps.length ? (


### PR DESCRIPTION
## Summary

This PR adds a structured maintenance confirmation and tenant access workflow layer, making scheduled service meaningfully different from service that is ready to proceed.

Tenants can now confirm a service window, request a schedule change, and acknowledge access requirements, while landlords gain a clear confirmation/access readiness view within the maintenance workspace.

## What changed

- Added a shared helper:
  - `buildMaintenanceConfirmationAccessView`
- Introduced confirmation/access states:
  - `awaiting_confirmation`
  - `confirmed`
  - `needs_schedule_change`
  - `ready_for_service`
  - `needs_attention`
- Added tenant-side actions:
  - confirm service window
  - request schedule change
  - acknowledge access requirement
- Added landlord-side confirmation/access workspace section:
  - confirmation status
  - access status
  - service readiness
  - blockers and next steps
- Reset confirmation/access state when landlord updates scheduling or access requirements
- Extended tenant-safe maintenance projection with:
  - `tenantConfirmationStatus`
  - `tenantConfirmationUpdatedAt`
  - `accessAcknowledgedAt`

## Scope

- Narrow backend/API extension
- Frontend workspace refinement
- No schema redesign
- No dispatch, messaging, or legal-entry workflow expansion

## Validation

```bash
cd rentchain-frontend
PATH="$HOME/.nvm/versions/node/v20.20.2/bin:$PATH" npm run test -- src/pages/maintenanceConfirmationAccessState.test.ts src/pages/MaintenanceRequestsPage.test.tsx src/pages/tenant/TenantMaintenancePages.test.tsx
PATH="$HOME/.nvm/versions/node/v20.20.2/bin:$PATH" npm run build

cd rentchain-api
PATH="$HOME/.nvm/versions/node/v20.20.2/bin:$PATH" npm run test -- src/routes/__tests__/tenantPortalRoutes.test.ts src/routes/__tests__/maintenanceRequestsRoutes.test.ts
PATH="$HOME/.nvm/versions/node/v20.20.2/bin:$PATH" npm run build