### PR TITLE
feat(maintenance): add service execution and completion tracking v1

### DIFF
--- a/rentchain-api/src/routes/__tests__/maintenanceRequestsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/maintenanceRequestsRoutes.test.ts
@@ -180,4 +180,125 @@ describe("maintenanceRequestsRoutes scheduling access", () => {
     expect(savedWorkOrder?.serviceWindowStartAt).toBe(500);
     expect(savedWorkOrder?.accessRequired).toBe(true);
   });
+
+  it("allows a contractor to schedule service with structured execution metadata", async () => {
+    const router = (await import("../maintenanceRequestsRoutes")).default;
+
+    const res = await invokeRouter(router, {
+      method: "PATCH",
+      url: "/contractor/jobs/maint-1/status",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "contractor-1",
+          role: "contractor",
+        }),
+      },
+      body: {
+        status: "scheduled",
+        scheduledFor: 700,
+        message: "Scheduled for tomorrow morning.",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.item?.status).toBe("scheduled");
+    expect(res.body?.item?.scheduledFor).toBe(700);
+
+    const savedMaintenance = ensureCollection("maintenanceRequests").get("maint-1");
+    expect(savedMaintenance?.status).toBe("scheduled");
+    expect(savedMaintenance?.scheduledFor).toBe(700);
+
+    const savedWorkOrder = ensureCollection("workOrders").get("maintenance_maint-1");
+    expect(savedWorkOrder?.status).toBe("scheduled");
+    expect(savedWorkOrder?.scheduledFor).toBe(700);
+    expect(savedWorkOrder?.lastExecutionUpdateAt).toBeDefined();
+  });
+
+  it("rejects blocked contractor updates without a reason", async () => {
+    const router = (await import("../maintenanceRequestsRoutes")).default;
+    ensureCollection("maintenanceRequests").set("maint-1", {
+      ...ensureCollection("maintenanceRequests").get("maint-1"),
+      status: "scheduled",
+    });
+
+    const res = await invokeRouter(router, {
+      method: "PATCH",
+      url: "/contractor/jobs/maint-1/status",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "contractor-1",
+          role: "contractor",
+        }),
+      },
+      body: {
+        status: "blocked",
+      },
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body?.error).toBe("BLOCKED_REASON_REQUIRED");
+  });
+
+  it("rejects completed contractor updates without a completion summary", async () => {
+    const router = (await import("../maintenanceRequestsRoutes")).default;
+    ensureCollection("maintenanceRequests").set("maint-1", {
+      ...ensureCollection("maintenanceRequests").get("maint-1"),
+      status: "in_progress",
+    });
+
+    const res = await invokeRouter(router, {
+      method: "PATCH",
+      url: "/contractor/jobs/maint-1/status",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "contractor-1",
+          role: "contractor",
+        }),
+      },
+      body: {
+        status: "completed",
+      },
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body?.error).toBe("COMPLETION_SUMMARY_REQUIRED");
+  });
+
+  it("persists completion metadata when a contractor completes the job", async () => {
+    const router = (await import("../maintenanceRequestsRoutes")).default;
+    ensureCollection("maintenanceRequests").set("maint-1", {
+      ...ensureCollection("maintenanceRequests").get("maint-1"),
+      status: "in_progress",
+    });
+
+    const res = await invokeRouter(router, {
+      method: "PATCH",
+      url: "/contractor/jobs/maint-1/status",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "contractor-1",
+          role: "contractor",
+        }),
+      },
+      body: {
+        status: "completed",
+        completionSummary: "Replaced the thermostat and verified heat output.",
+        completionOutcome: "completed",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.item?.status).toBe("completed");
+    expect(res.body?.item?.completionSummary).toMatch(/Replaced the thermostat/i);
+
+    const savedMaintenance = ensureCollection("maintenanceRequests").get("maint-1");
+    expect(savedMaintenance?.status).toBe("completed");
+    expect(savedMaintenance?.completionSummary).toMatch(/Replaced the thermostat/i);
+
+    const savedWorkOrder = ensureCollection("workOrders").get("maintenance_maint-1");
+    expect(savedWorkOrder?.serviceCompletedAt).toBeDefined();
+    expect(savedWorkOrder?.completionSummary).toMatch(/Replaced the thermostat/i);
+    expect(savedWorkOrder?.completedByActorRole).toBe("contractor");
+    expect(savedWorkOrder?.completedByActorId).toBe("contractor-1");
+  });
 });

--- a/rentchain-api/src/routes/__tests__/workOrdersRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/workOrdersRoutes.test.ts
@@ -1,0 +1,241 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const collections = new Map<string, Map<string, any>>();
+
+function ensureCollection(name: string) {
+  if (!collections.has(name)) {
+    collections.set(name, new Map<string, any>());
+  }
+  return collections.get(name)!;
+}
+
+function clone<T>(value: T): T {
+  return value === undefined ? value : JSON.parse(JSON.stringify(value));
+}
+
+function applyMerge(current: any, incoming: any) {
+  const next = { ...(current || {}) };
+  Object.entries(incoming || {}).forEach(([key, value]) => {
+    if (value && typeof value === "object" && (value as any).__op === "arrayUnion") {
+      const existing = Array.isArray(next[key]) ? next[key] : [];
+      next[key] = [...existing, ...(value as any).values.map((entry: any) => clone(entry))];
+      return;
+    }
+    next[key] = clone(value);
+  });
+  return next;
+}
+
+const dbMock = {
+  collection: (name: string) => ({
+    doc: (id: string) => ({
+      id,
+      get: async () => ({
+        id,
+        exists: ensureCollection(name).has(id),
+        data: () => clone(ensureCollection(name).get(id)),
+      }),
+      set: async (value: any, opts?: { merge?: boolean }) => {
+        const current = ensureCollection(name).get(id);
+        ensureCollection(name).set(id, opts?.merge ? applyMerge(current, value) : clone(value));
+      },
+      update: async (value: any) => {
+        const current = ensureCollection(name).get(id) || {};
+        ensureCollection(name).set(id, applyMerge(current, value));
+      },
+    }),
+  }),
+};
+
+vi.mock("../../config/firebase", () => ({
+  db: dbMock,
+  FieldValue: {
+    serverTimestamp: () => "__server_timestamp__",
+    arrayUnion: (...values: any[]) => ({ __op: "arrayUnion", values }),
+  },
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, _res: any, next: any) => {
+    const header = String(req.headers["x-test-user"] || "").trim();
+    if (header) {
+      req.user = JSON.parse(header);
+    }
+    next();
+  },
+}));
+
+vi.mock("../../services/emailService", () => ({
+  sendEmail: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe("workOrdersRoutes execution completion", () => {
+  async function invokeRouter(
+    router: any,
+    options: {
+      method: string;
+      url: string;
+      body?: any;
+      headers?: Record<string, string>;
+    }
+  ) {
+    return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+      const req: any = {
+        method: options.method,
+        url: options.url,
+        originalUrl: options.url,
+        path: options.url,
+        body: options.body ?? {},
+        headers: options.headers ?? {},
+      };
+      const res: any = {
+        statusCode: 200,
+        status(code: number) {
+          this.statusCode = code;
+          return this;
+        },
+        json(payload: any) {
+          resolve({ status: this.statusCode, body: payload });
+          return this;
+        },
+        send(payload: any) {
+          resolve({ status: this.statusCode, body: payload });
+          return this;
+        },
+      };
+      router.handle(req, res, (error: any) => {
+        if (error) reject(error);
+      });
+    });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    collections.clear();
+    ensureCollection("maintenanceRequests").set("maint-1", {
+      id: "maint-1",
+      landlordId: "landlord-1",
+      status: "assigned",
+      statusHistory: [],
+      updatedAt: 100,
+    });
+    ensureCollection("workOrders").set("wo-1", {
+      id: "wo-1",
+      landlordId: "landlord-1",
+      maintenanceRequestId: "maint-1",
+      status: "assigned",
+      title: "Broken heater",
+      assignedContractorId: null,
+      createdAtMs: 100,
+      updatedAtMs: 100,
+    });
+  });
+
+  it("writes structured metadata when a landlord completes an in-house work order", async () => {
+    const router = (await import("../workOrdersRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "PATCH",
+      url: "/work-orders/wo-1",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "landlord-1",
+          role: "landlord",
+          landlordId: "landlord-1",
+        }),
+      },
+      body: {
+        status: "completed",
+        completionSummary: "Replaced the thermostat and tested the system.",
+        completionOutcome: "completed",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.item?.status).toBe("completed");
+
+    const savedWorkOrder = ensureCollection("workOrders").get("wo-1");
+    expect(savedWorkOrder?.serviceCompletedAt).toBeDefined();
+    expect(savedWorkOrder?.completionSummary).toMatch(/Replaced the thermostat/i);
+    expect(savedWorkOrder?.completedByActorRole).toBe("landlord");
+    expect(savedWorkOrder?.completedByActorId).toBe("landlord-1");
+  });
+
+  it("confirms completion only for completed work orders", async () => {
+    const router = (await import("../workOrdersRoutes")).default;
+    ensureCollection("workOrders").set("wo-1", {
+      ...ensureCollection("workOrders").get("wo-1"),
+      status: "completed",
+      completionSummary: "Completed service visit.",
+      serviceCompletedAt: 500,
+    });
+
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/landlord/work-orders/wo-1/confirm-completion",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "landlord-1",
+          role: "landlord",
+          landlordId: "landlord-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.item?.completionConfirmedByLandlordAt).toBeDefined();
+
+    const savedWorkOrder = ensureCollection("workOrders").get("wo-1");
+    expect(savedWorkOrder?.completionConfirmedByLandlordBy).toBe("landlord-1");
+  });
+
+  it("rejects completion confirmation when the work order is not completed", async () => {
+    const router = (await import("../workOrdersRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/landlord/work-orders/wo-1/confirm-completion",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "landlord-1",
+          role: "landlord",
+          landlordId: "landlord-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body?.error).toBe("WORK_ORDER_NOT_COMPLETED");
+  });
+
+  it("reopens a completed work order with a required reason", async () => {
+    const router = (await import("../workOrdersRoutes")).default;
+    ensureCollection("workOrders").set("wo-1", {
+      ...ensureCollection("workOrders").get("wo-1"),
+      status: "completed",
+      completionSummary: "Completed service visit.",
+      serviceCompletedAt: 500,
+    });
+
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/landlord/work-orders/wo-1/reopen",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "landlord-1",
+          role: "landlord",
+          landlordId: "landlord-1",
+        }),
+      },
+      body: {
+        reason: "Heating issue still present after the visit.",
+        status: "blocked",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.item?.status).toBe("blocked");
+
+    const savedWorkOrder = ensureCollection("workOrders").get("wo-1");
+    expect(savedWorkOrder?.reopenReason).toMatch(/Heating issue still present/i);
+    expect(savedWorkOrder?.executionBlockedReason).toMatch(/Heating issue still present/i);
+  });
+});

--- a/rentchain-api/src/routes/maintenanceRequestsRoutes.ts
+++ b/rentchain-api/src/routes/maintenanceRequestsRoutes.ts
@@ -30,6 +30,7 @@ const WORKFLOW_STATUSES = [
   "reviewed",
   "assigned",
   "scheduled",
+  "blocked",
   "in_progress",
   "completed",
   "cancelled",
@@ -59,8 +60,9 @@ const WORKFLOW_TRANSITIONS: Record<(typeof WORKFLOW_STATUSES)[number], Array<(ty
   submitted: ["reviewed", "assigned", "cancelled"],
   reviewed: ["assigned", "completed", "cancelled"],
   assigned: ["scheduled", "completed", "cancelled"],
-  scheduled: ["in_progress", "completed", "cancelled"],
-  in_progress: ["completed", "cancelled"],
+  scheduled: ["in_progress", "blocked", "completed", "cancelled"],
+  blocked: ["scheduled", "in_progress", "completed", "cancelled"],
+  in_progress: ["blocked", "completed", "cancelled"],
   completed: [],
   cancelled: [],
 };
@@ -411,6 +413,49 @@ async function appendStatusHistory(
     );
 }
 
+type WorkOrderExecutionUpdateType =
+  | "status_changed"
+  | "scheduled"
+  | "started"
+  | "blocked"
+  | "completed"
+  | "confirmed"
+  | "reopened";
+
+type WorkOrderCompletionOutcome = "completed" | "partially_completed" | "follow_up_required";
+
+function normalizeCompletionOutcome(value: any): WorkOrderCompletionOutcome | null {
+  const next = String(value || "").trim().toLowerCase();
+  if (next === "completed" || next === "partially_completed" || next === "follow_up_required") {
+    return next;
+  }
+  return null;
+}
+
+async function appendWorkOrderUpdate(
+  workOrderId: string,
+  payload: {
+    actorRole: "tenant" | "landlord" | "contractor" | "admin";
+    actorId: string | null;
+    updateType: WorkOrderExecutionUpdateType;
+    message?: string | null;
+  }
+) {
+  if (!workOrderId) return;
+  const ref = db.collection("workOrderUpdates").doc();
+  const createdAtMs = Date.now();
+  await ref.set({
+    id: ref.id,
+    workOrderId,
+    actorRole: payload.actorRole,
+    actorId: payload.actorId || null,
+    updateType: payload.updateType,
+    message: String(payload.message || "").trim().slice(0, 5000),
+    attachmentUrl: null,
+    createdAtMs,
+  });
+}
+
 async function lookupEmailFromDoc(docPath: [string, string][]): Promise<string | null> {
   for (const [collection, id] of docPath) {
     if (!id) continue;
@@ -530,6 +575,21 @@ async function upsertMaintenanceWorkOrder(input: {
   serviceWindowStartAt?: number | null;
   serviceWindowEndAt?: number | null;
   accessRequired?: boolean | null;
+  scheduledFor?: number | null;
+  serviceStartedAt?: number | null;
+  serviceCompletedAt?: number | null;
+  lastExecutionUpdateAt?: number | null;
+  executionBlockedReason?: string | null;
+  completionSummary?: string | null;
+  completionOutcome?: WorkOrderCompletionOutcome | null;
+  completedByActorRole?: "contractor" | "landlord" | "admin" | null;
+  completedByActorId?: string | null;
+  completionConfirmedByLandlordAt?: number | null;
+  completionConfirmedByLandlordBy?: string | null;
+  reopenedAt?: number | null;
+  reopenedByActorId?: string | null;
+  reopenedByActorRole?: "landlord" | "admin" | null;
+  reopenReason?: string | null;
 }) {
   const workOrderId = `maintenance_${input.maintenanceRequestId}`;
   const ref = db.collection("workOrders").doc(workOrderId);
@@ -551,9 +611,98 @@ async function upsertMaintenanceWorkOrder(input: {
     category: String(input.category || "").trim() || "GENERAL",
     priority: String(input.priority || "").trim() || "normal",
     status: String(input.status || "assigned").trim() || "assigned",
-    serviceWindowStartAt: typeof input.serviceWindowStartAt === "number" ? input.serviceWindowStartAt : null,
-    serviceWindowEndAt: typeof input.serviceWindowEndAt === "number" ? input.serviceWindowEndAt : null,
-    accessRequired: typeof input.accessRequired === "boolean" ? input.accessRequired : null,
+    serviceWindowStartAt:
+      input.serviceWindowStartAt !== undefined
+        ? typeof input.serviceWindowStartAt === "number"
+          ? input.serviceWindowStartAt
+          : null
+        : toMillis(existingData.serviceWindowStartAt),
+    serviceWindowEndAt:
+      input.serviceWindowEndAt !== undefined
+        ? typeof input.serviceWindowEndAt === "number"
+          ? input.serviceWindowEndAt
+          : null
+        : toMillis(existingData.serviceWindowEndAt),
+    accessRequired:
+      input.accessRequired !== undefined
+        ? typeof input.accessRequired === "boolean"
+          ? input.accessRequired
+          : null
+        : typeof existingData.accessRequired === "boolean"
+        ? existingData.accessRequired
+        : null,
+    scheduledFor:
+      input.scheduledFor !== undefined
+        ? typeof input.scheduledFor === "number"
+          ? input.scheduledFor
+          : null
+        : toMillis(existingData.scheduledFor),
+    serviceStartedAt:
+      input.serviceStartedAt !== undefined
+        ? typeof input.serviceStartedAt === "number"
+          ? input.serviceStartedAt
+          : null
+        : toMillis(existingData.serviceStartedAt),
+    serviceCompletedAt:
+      input.serviceCompletedAt !== undefined
+        ? typeof input.serviceCompletedAt === "number"
+          ? input.serviceCompletedAt
+          : null
+        : toMillis(existingData.serviceCompletedAt),
+    lastExecutionUpdateAt:
+      input.lastExecutionUpdateAt !== undefined
+        ? typeof input.lastExecutionUpdateAt === "number"
+          ? input.lastExecutionUpdateAt
+          : null
+        : toMillis(existingData.lastExecutionUpdateAt),
+    executionBlockedReason:
+      input.executionBlockedReason !== undefined
+        ? String(input.executionBlockedReason || "").trim() || null
+        : String(existingData.executionBlockedReason || "").trim() || null,
+    completionSummary:
+      input.completionSummary !== undefined
+        ? String(input.completionSummary || "").trim() || null
+        : String(existingData.completionSummary || "").trim() || null,
+    completionOutcome:
+      input.completionOutcome !== undefined
+        ? input.completionOutcome || null
+        : normalizeCompletionOutcome(existingData.completionOutcome),
+    completedByActorRole:
+      input.completedByActorRole !== undefined
+        ? input.completedByActorRole || null
+        : String(existingData.completedByActorRole || "").trim() || null,
+    completedByActorId:
+      input.completedByActorId !== undefined
+        ? String(input.completedByActorId || "").trim() || null
+        : String(existingData.completedByActorId || "").trim() || null,
+    completionConfirmedByLandlordAt:
+      input.completionConfirmedByLandlordAt !== undefined
+        ? typeof input.completionConfirmedByLandlordAt === "number"
+          ? input.completionConfirmedByLandlordAt
+          : null
+        : toMillis(existingData.completionConfirmedByLandlordAt),
+    completionConfirmedByLandlordBy:
+      input.completionConfirmedByLandlordBy !== undefined
+        ? String(input.completionConfirmedByLandlordBy || "").trim() || null
+        : String(existingData.completionConfirmedByLandlordBy || "").trim() || null,
+    reopenedAt:
+      input.reopenedAt !== undefined
+        ? typeof input.reopenedAt === "number"
+          ? input.reopenedAt
+          : null
+        : toMillis(existingData.reopenedAt),
+    reopenedByActorId:
+      input.reopenedByActorId !== undefined
+        ? String(input.reopenedByActorId || "").trim() || null
+        : String(existingData.reopenedByActorId || "").trim() || null,
+    reopenedByActorRole:
+      input.reopenedByActorRole !== undefined
+        ? input.reopenedByActorRole || null
+        : String(existingData.reopenedByActorRole || "").trim() || null,
+    reopenReason:
+      input.reopenReason !== undefined
+        ? String(input.reopenReason || "").trim() || null
+        : String(existingData.reopenReason || "").trim() || null,
     visibility: "private",
     createdAt: createdAtMs,
     updatedAt: now,
@@ -598,6 +747,21 @@ function shapeContractorJobFromSources(workOrder: any, maintenance: any) {
       String(maintenance?.contractorStatus || workOrder?.contractorStatus || status).trim() || status,
     contractorLastUpdate:
       String(maintenance?.contractorLastUpdate || workOrder?.contractorLastUpdate || "").trim() || null,
+    scheduledFor: toMillis(workOrder?.scheduledFor) ?? null,
+    serviceStartedAt: toMillis(workOrder?.serviceStartedAt) ?? null,
+    serviceCompletedAt: toMillis(workOrder?.serviceCompletedAt) ?? null,
+    lastExecutionUpdateAt: toMillis(workOrder?.lastExecutionUpdateAt) ?? null,
+    executionBlockedReason: String(workOrder?.executionBlockedReason || "").trim() || null,
+    completionSummary: String(workOrder?.completionSummary || "").trim() || null,
+    completionOutcome: normalizeCompletionOutcome(workOrder?.completionOutcome),
+    completionConfirmedByLandlordAt: toMillis(workOrder?.completionConfirmedByLandlordAt) ?? null,
+    completionConfirmedByLandlordBy: String(workOrder?.completionConfirmedByLandlordBy || "").trim() || null,
+    completedByActorRole: String(workOrder?.completedByActorRole || "").trim() || null,
+    completedByActorId: String(workOrder?.completedByActorId || "").trim() || null,
+    reopenedAt: toMillis(workOrder?.reopenedAt) ?? null,
+    reopenedByActorId: String(workOrder?.reopenedByActorId || "").trim() || null,
+    reopenedByActorRole: String(workOrder?.reopenedByActorRole || "").trim() || null,
+    reopenReason: String(workOrder?.reopenReason || "").trim() || null,
     serviceWindowStartAt:
       toMillis(maintenance?.serviceWindowStartAt) ?? toMillis(workOrder?.serviceWindowStartAt) ?? null,
     serviceWindowEndAt:
@@ -1099,6 +1263,12 @@ router.patch("/landlord/maintenance/:id", async (req: any, res) => {
         serviceWindowStartAt: toMillis(refreshed.serviceWindowStartAt),
         serviceWindowEndAt: toMillis(refreshed.serviceWindowEndAt),
         accessRequired: typeof refreshed.accessRequired === "boolean" ? refreshed.accessRequired : null,
+        scheduledFor: toMillis(refreshed.serviceWindowStartAt) ?? toMillis(refreshed.scheduledFor),
+        serviceCompletedAt: toMillis(refreshed.serviceCompletedAt),
+        completionSummary: String(refreshed.completionSummary || "").trim() || null,
+        completionOutcome: normalizeCompletionOutcome(refreshed.completionOutcome),
+        completionConfirmedByLandlordAt: toMillis(refreshed.completionConfirmedByLandlordAt),
+        completionConfirmedByLandlordBy: String(refreshed.completionConfirmedByLandlordBy || "").trim() || null,
       });
       workOrderId = workOrder.workOrderId;
     }
@@ -1352,6 +1522,21 @@ router.post("/landlord/maintenance/:id/assign", async (req: any, res) => {
         serviceWindowStartAt: toMillis(current.serviceWindowStartAt),
         serviceWindowEndAt: toMillis(current.serviceWindowEndAt),
         accessRequired: typeof current.accessRequired === "boolean" ? current.accessRequired : null,
+        scheduledFor: toMillis(current.serviceWindowStartAt),
+        serviceStartedAt: null,
+        serviceCompletedAt: null,
+        lastExecutionUpdateAt: null,
+        executionBlockedReason: null,
+        completionSummary: null,
+        completionOutcome: null,
+        completedByActorRole: null,
+        completedByActorId: null,
+        completionConfirmedByLandlordAt: null,
+        completionConfirmedByLandlordBy: null,
+        reopenedAt: null,
+        reopenedByActorId: null,
+        reopenedByActorRole: null,
+        reopenReason: null,
         visibility: "private",
         createdAt: Number(current.createdAt || now) || now,
         updatedAt: now,
@@ -1512,7 +1697,7 @@ router.patch("/contractor/jobs/:id/status", async (req: any, res) => {
     if (!id) return res.status(404).json({ ok: false, error: "NOT_FOUND" });
 
     const nextStatus = normalizeWorkflowStatus(req.body?.status);
-    if (!nextStatus || !["assigned", "scheduled", "in_progress", "completed"].includes(nextStatus)) {
+    if (!nextStatus || !["assigned", "scheduled", "blocked", "in_progress", "completed"].includes(nextStatus)) {
       return res.status(400).json({ ok: false, error: "INVALID_STATUS" });
     }
 
@@ -1536,25 +1721,67 @@ router.patch("/contractor/jobs/:id/status", async (req: any, res) => {
       });
     }
 
-    const note = String(req.body?.message || "").trim().slice(0, 500);
-    await ref.set(
-      {
-        status: nextStatus,
-        contractorStatus: nextStatus,
-        contractorLastUpdate: note || null,
-        updatedAt: Date.now(),
-        lastUpdatedBy: "CONTRACTOR",
-      },
-      { merge: true }
-    );
-    await appendStatusHistory(id, {
-      status: nextStatus,
-      actorRole: access.role === "admin" ? "admin" : "contractor",
-      actorId,
-      message:
-        note ||
-        (isAcknowledgement ? "Contractor accepted the assigned job" : `Contractor updated status to ${nextStatus}`),
-    });
+    const now = Date.now();
+    const note = String(req.body?.message || req.body?.note || "").trim().slice(0, 500);
+    const blockedReason = String(req.body?.blockedReason || req.body?.executionBlockedReason || note || "")
+      .trim()
+      .slice(0, 500);
+    const completionSummary = String(req.body?.completionSummary || "").trim().slice(0, 2000);
+    const completionOutcome = normalizeCompletionOutcome(req.body?.completionOutcome) || "completed";
+    const requestedScheduledFor =
+      req.body?.scheduledFor === undefined ? undefined : toMillis(req.body?.scheduledFor);
+
+    if (req.body?.scheduledFor !== undefined && requestedScheduledFor === null && req.body?.scheduledFor !== null) {
+      return res.status(400).json({ ok: false, error: "INVALID_SCHEDULED_FOR" });
+    }
+    if (nextStatus === "blocked" && !blockedReason) {
+      return res.status(400).json({ ok: false, error: "BLOCKED_REASON_REQUIRED" });
+    }
+    if (nextStatus === "completed" && !completionSummary) {
+      return res.status(400).json({ ok: false, error: "COMPLETION_SUMMARY_REQUIRED" });
+    }
+
+    const existingWorkOrderRef = db.collection("workOrders").doc(`maintenance_${id}`);
+    const existingWorkOrderSnap = await existingWorkOrderRef.get();
+    const existingWorkOrder = existingWorkOrderSnap.exists ? ((existingWorkOrderSnap.data() as any) || {}) : {};
+
+    const scheduledFor =
+      nextStatus === "scheduled"
+        ? requestedScheduledFor === undefined
+          ? toMillis(existingWorkOrder.scheduledFor) ??
+            toMillis(item.scheduledFor) ??
+            toMillis(item.serviceWindowStartAt) ??
+            now
+          : requestedScheduledFor
+        : undefined;
+    const serviceStartedAt =
+      nextStatus === "in_progress"
+        ? toMillis(existingWorkOrder.serviceStartedAt) ?? toMillis(item.serviceStartedAt) ?? now
+        : undefined;
+    const serviceCompletedAt = nextStatus === "completed" ? now : undefined;
+    const contractorMessage =
+      nextStatus === "scheduled"
+        ? note || "Contractor scheduled the service visit."
+        : nextStatus === "in_progress"
+        ? note || "Contractor started the work."
+        : nextStatus === "blocked"
+        ? blockedReason
+        : nextStatus === "completed"
+        ? completionSummary
+        : note || (isAcknowledgement ? "Contractor accepted the assigned job." : `Contractor updated status to ${nextStatus}.`);
+    const historyMessage =
+      nextStatus === "scheduled"
+        ? scheduledFor
+          ? `Contractor scheduled service for ${new Date(scheduledFor).toLocaleString()}.`
+          : contractorMessage
+        : nextStatus === "in_progress"
+        ? contractorMessage
+        : nextStatus === "blocked"
+        ? `Service is blocked: ${blockedReason}`
+        : nextStatus === "completed"
+        ? `Service completed: ${completionSummary}`
+        : contractorMessage;
+
     const workOrder = await upsertMaintenanceWorkOrder({
       maintenanceRequestId: id,
       landlordId: String(item.landlordId || "").trim() || null,
@@ -1571,6 +1798,61 @@ router.patch("/contractor/jobs/:id/status", async (req: any, res) => {
       serviceWindowStartAt: toMillis(item.serviceWindowStartAt),
       serviceWindowEndAt: toMillis(item.serviceWindowEndAt),
       accessRequired: typeof item.accessRequired === "boolean" ? item.accessRequired : null,
+      scheduledFor,
+      serviceStartedAt,
+      serviceCompletedAt,
+      lastExecutionUpdateAt: now,
+      executionBlockedReason: nextStatus === "blocked" ? blockedReason : null,
+      completionSummary: nextStatus === "completed" ? completionSummary : undefined,
+      completionOutcome: nextStatus === "completed" ? completionOutcome : undefined,
+      completedByActorRole: nextStatus === "completed" ? (access.role === "admin" ? "admin" : "contractor") : undefined,
+      completedByActorId: nextStatus === "completed" ? actorId : undefined,
+      completionConfirmedByLandlordAt: nextStatus === "completed" ? null : undefined,
+      completionConfirmedByLandlordBy: nextStatus === "completed" ? null : undefined,
+      reopenedAt: nextStatus === "completed" ? null : undefined,
+      reopenedByActorId: nextStatus === "completed" ? null : undefined,
+      reopenedByActorRole: nextStatus === "completed" ? null : undefined,
+      reopenReason: nextStatus === "completed" ? null : undefined,
+    });
+
+    const maintenancePatch: Record<string, unknown> = {
+      status: nextStatus,
+      contractorStatus: nextStatus,
+      contractorLastUpdate: contractorMessage || null,
+      updatedAt: now,
+      lastUpdatedBy: "CONTRACTOR",
+      scheduledFor: workOrder.payload.scheduledFor ?? null,
+      serviceCompletedAt: workOrder.payload.serviceCompletedAt ?? null,
+    };
+    if (nextStatus === "completed") {
+      maintenancePatch.completionSummary = completionSummary;
+      maintenancePatch.completionOutcome = completionOutcome;
+    } else if (nextStatus === "blocked") {
+      maintenancePatch.completionSummary = null;
+      maintenancePatch.completionOutcome = null;
+    }
+    await ref.set(maintenancePatch, { merge: true });
+
+    await appendStatusHistory(id, {
+      status: nextStatus,
+      actorRole: access.role === "admin" ? "admin" : "contractor",
+      actorId,
+      message: historyMessage,
+    });
+    await appendWorkOrderUpdate(workOrder.workOrderId, {
+      actorRole: access.role === "admin" ? "admin" : "contractor",
+      actorId,
+      updateType:
+        nextStatus === "scheduled"
+          ? "scheduled"
+          : nextStatus === "in_progress"
+          ? "started"
+          : nextStatus === "blocked"
+          ? "blocked"
+          : nextStatus === "completed"
+          ? "completed"
+          : "status_changed",
+      message: historyMessage,
     });
 
     const refreshedSnap = await ref.get();

--- a/rentchain-api/src/routes/workOrdersRoutes.ts
+++ b/rentchain-api/src/routes/workOrdersRoutes.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import crypto from "crypto";
-import { db } from "../config/firebase";
+import { db, FieldValue } from "../config/firebase";
 import { requireAuth } from "../middleware/requireAuth";
 import { sendEmail } from "../services/emailService";
 import { buildEmailHtml, buildEmailText } from "../email/templates/baseEmailTemplate";
@@ -13,13 +13,23 @@ const WORK_ORDER_STATUSES = new Set([
   "invited",
   "assigned",
   "accepted",
+  "scheduled",
+  "blocked",
   "in_progress",
   "completed",
   "cancelled",
 ]);
 
-const CONTRACTOR_VISIBLE_STATUSES = new Set(["accepted", "in_progress", "completed"]);
-const ACTIVE_INCIDENT_WORK_ORDER_STATUSES = new Set(["open", "invited", "assigned", "accepted", "in_progress"]);
+const CONTRACTOR_VISIBLE_STATUSES = new Set(["accepted", "scheduled", "blocked", "in_progress", "completed"]);
+const ACTIVE_INCIDENT_WORK_ORDER_STATUSES = new Set([
+  "open",
+  "invited",
+  "assigned",
+  "accepted",
+  "scheduled",
+  "blocked",
+  "in_progress",
+]);
 const CONTRACTOR_INVITE_TTL_MS = Math.max(
   60_000,
   Number(process.env.CONTRACTOR_INVITE_TTL_MS || 7 * 24 * 60 * 60 * 1000)
@@ -54,6 +64,26 @@ function parseMoneyToCents(value: unknown): number | null {
   const numeric = typeof value === "number" ? value : Number(value);
   if (!Number.isFinite(numeric) || numeric < 0) return null;
   return Math.round(numeric);
+}
+
+function toMillis(value: unknown): number | null {
+  if (value == null || value === "") return null;
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+  if (typeof (value as any)?.toMillis === "function") return (value as any).toMillis();
+  if (typeof (value as any)?.seconds === "number") return (value as any).seconds * 1000;
+  return null;
+}
+
+function normalizeCompletionOutcome(value: unknown): "completed" | "partially_completed" | "follow_up_required" | null {
+  const next = asString(value, 60).toLowerCase();
+  if (next === "completed" || next === "partially_completed" || next === "follow_up_required") {
+    return next;
+  }
+  return null;
 }
 
 function normalizeRole(req: any): string {
@@ -119,16 +149,29 @@ function canTransitionWorkOrder(params: {
 
   if (actor === "contractor") {
     if ((from === "open" || from === "invited" || from === "assigned") && to === "accepted") return true;
-    if (from === "accepted" && to === "in_progress") return true;
+    if ((from === "accepted" || from === "assigned" || from === "scheduled" || from === "blocked") && to === "in_progress") {
+      return true;
+    }
+    if ((from === "accepted" || from === "assigned") && to === "scheduled") return true;
+    if ((from === "scheduled" || from === "in_progress") && to === "blocked") return true;
+    if ((from === "scheduled" || from === "blocked" || from === "in_progress") && to === "completed") return true;
     if (from === "in_progress" && to === "completed") return true;
     return false;
   }
 
   if (actor === "landlord" || actor === "admin") {
     if (to === "cancelled" && ACTIVE_INCIDENT_WORK_ORDER_STATUSES.has(from)) return true;
+    if ((from === "completed" || from === "blocked") && to === "in_progress") return true;
+    if (from === "completed" && to === "blocked") return true;
     if (
       to === "completed" &&
-      (from === "open" || from === "invited" || from === "assigned" || from === "accepted" || from === "in_progress")
+      (from === "open" ||
+        from === "invited" ||
+        from === "assigned" ||
+        from === "accepted" ||
+        from === "scheduled" ||
+        from === "blocked" ||
+        from === "in_progress")
     ) {
       return true;
     }
@@ -264,10 +307,15 @@ async function writeWorkOrderUpdate(input: {
     | "accepted"
     | "declined"
     | "status_changed"
+    | "scheduled"
+    | "started"
+    | "blocked"
     | "note"
     | "photo"
     | "invoice"
-    | "completed";
+    | "completed"
+    | "confirmed"
+    | "reopened";
   message?: string;
   attachmentUrl?: string | null;
 }) {
@@ -283,6 +331,50 @@ async function writeWorkOrderUpdate(input: {
     attachmentUrl: asOptionalString(input.attachmentUrl, 2000),
     createdAtMs,
   });
+}
+
+async function appendMaintenanceStatusHistory(input: {
+  maintenanceRequestId: string | null;
+  status: string;
+  actorRole: "landlord" | "contractor" | "admin";
+  actorId: string;
+  message: string;
+}) {
+  const maintenanceRequestId = asString(input.maintenanceRequestId, 120);
+  if (!maintenanceRequestId) return;
+  await db.collection("maintenanceRequests").doc(maintenanceRequestId).set(
+    {
+      statusHistory: FieldValue.arrayUnion({
+        status: input.status,
+        actorRole: input.actorRole,
+        actorId: input.actorId,
+        message: input.message,
+        createdAt: nowMs(),
+      }),
+    },
+    { merge: true }
+  );
+}
+
+async function syncMaintenanceFromWorkOrder(workOrderId: string, patch: Record<string, unknown>) {
+  const snap = await db.collection("workOrders").doc(workOrderId).get();
+  if (!snap.exists) return;
+  const workOrder = (snap.data() as any) || {};
+  const maintenanceRequestId = asString(workOrder.maintenanceRequestId, 120);
+  if (!maintenanceRequestId) return;
+  await db.collection("maintenanceRequests").doc(maintenanceRequestId).set(
+    {
+      status: asString(workOrder.status, 40).toLowerCase() || null,
+      contractorStatus: asString(workOrder.status, 40).toLowerCase() || null,
+      scheduledFor: toMillis(workOrder.scheduledFor),
+      serviceCompletedAt: toMillis(workOrder.serviceCompletedAt),
+      completionSummary: asOptionalString(workOrder.completionSummary, 2000),
+      contractorLastUpdate: asOptionalString(patch.contractorLastUpdate, 500) || asOptionalString(workOrder.completionSummary, 500),
+      updatedAt: nowMs(),
+      ...patch,
+    },
+    { merge: true }
+  );
 }
 
 async function getWorkOrderAuthorized(req: any, workOrderId: string) {
@@ -975,6 +1067,7 @@ router.patch("/work-orders/:id", requireAuth, async (req: any, res) => {
 
     const patch: Record<string, any> = { updatedAtMs: nowMs() };
     let updateMessage = "Work order updated";
+    let maintenanceHistoryMessage: string | null = null;
 
     if (access.role === "landlord" || access.role === "admin") {
       if (req.body?.title !== undefined) patch.title = asString(req.body.title, 180);
@@ -1000,6 +1093,13 @@ router.patch("/work-orders/:id", requireAuth, async (req: any, res) => {
       if (req.body?.finalCostCents !== undefined) {
         patch.finalCostCents = parseMoneyToCents(req.body.finalCostCents);
       }
+      if (req.body?.scheduledFor !== undefined) {
+        const scheduledFor = toMillis(req.body.scheduledFor);
+        if (scheduledFor === null && req.body.scheduledFor !== null) {
+          return res.status(400).json({ ok: false, error: "INVALID_SCHEDULED_FOR" });
+        }
+        patch.scheduledFor = scheduledFor;
+      }
       if (req.body?.status !== undefined) {
         const nextStatus = asString(req.body.status, 40).toLowerCase();
         const currentStatus = asString((access.item as any)?.status, 40).toLowerCase();
@@ -1007,13 +1107,48 @@ router.patch("/work-orders/:id", requireAuth, async (req: any, res) => {
           return res.status(400).json({ ok: false, error: "INVALID_STATUS_TRANSITION" });
         }
         patch.status = nextStatus;
-        if (nextStatus === "completed") patch.completedAtMs = nowMs();
-        if (nextStatus === "in_progress") patch.startedAtMs = nowMs();
+        if (nextStatus === "completed") {
+          const completionSummary = asString(req.body?.completionSummary, 2000);
+          const completionOutcome = normalizeCompletionOutcome(req.body?.completionOutcome) || "completed";
+          if (!completionSummary) {
+            return res.status(400).json({ ok: false, error: "COMPLETION_SUMMARY_REQUIRED" });
+          }
+          patch.completedAtMs = nowMs();
+          patch.serviceCompletedAt = nowMs();
+          patch.lastExecutionUpdateAt = nowMs();
+          patch.completionSummary = completionSummary;
+          patch.completionOutcome = completionOutcome;
+          patch.completedByActorRole = access.role === "admin" ? "admin" : "landlord";
+          patch.completedByActorId = access.userId;
+          patch.completionConfirmedByLandlordAt = null;
+          patch.completionConfirmedByLandlordBy = null;
+          updateMessage = "Work order marked completed in-house";
+          maintenanceHistoryMessage = `Service completed in-house: ${completionSummary}`;
+        }
+        if (nextStatus === "in_progress") {
+          patch.startedAtMs = Number((access.item as any)?.startedAtMs || 0) || nowMs();
+          patch.serviceStartedAt = Number((access.item as any)?.serviceStartedAt || 0) || nowMs();
+          patch.lastExecutionUpdateAt = nowMs();
+          updateMessage = "Work order moved back into service";
+          maintenanceHistoryMessage = "Service is in progress.";
+        }
+        if (nextStatus === "blocked") {
+          const blockedReason = asString(req.body?.blockedReason || req.body?.reopenReason, 500);
+          if (!blockedReason) {
+            return res.status(400).json({ ok: false, error: "BLOCKED_REASON_REQUIRED" });
+          }
+          patch.executionBlockedReason = blockedReason;
+          patch.lastExecutionUpdateAt = nowMs();
+          updateMessage = "Work order marked blocked";
+          maintenanceHistoryMessage = `Service is blocked: ${blockedReason}`;
+        }
         const hasAssignedContractor = Boolean(asString((access.item as any)?.assignedContractorId, 120));
-        updateMessage =
-          nextStatus === "completed" && !hasAssignedContractor
-            ? "Work order marked completed in-house"
-            : `Status changed to ${nextStatus}`;
+        if (!(nextStatus === "completed" || nextStatus === "in_progress" || nextStatus === "blocked")) {
+          updateMessage =
+            nextStatus === "completed" && !hasAssignedContractor
+              ? "Work order marked completed in-house"
+              : `Status changed to ${nextStatus}`;
+        }
       }
     } else if (access.role === "contractor") {
       if (req.body?.status !== undefined) {
@@ -1040,6 +1175,21 @@ router.patch("/work-orders/:id", requireAuth, async (req: any, res) => {
     });
 
     const refreshed = await db.collection("workOrders").doc(id).get();
+    await syncMaintenanceFromWorkOrder(id, {
+      contractorLastUpdate:
+        patch.completionSummary ||
+        patch.executionBlockedReason ||
+        (typeof req.body?.message === "string" ? req.body.message : null),
+    });
+    if (maintenanceHistoryMessage) {
+      await appendMaintenanceStatusHistory({
+        maintenanceRequestId: asOptionalString((refreshed.data() as any)?.maintenanceRequestId, 120),
+        status: asString((refreshed.data() as any)?.status, 40).toLowerCase(),
+        actorRole: access.role === "admin" ? "admin" : "landlord",
+        actorId: access.userId,
+        message: maintenanceHistoryMessage,
+      });
+    }
     return res.json({ ok: true, item: toWorkOrderResponse(refreshed.id, refreshed.data()) });
   } catch (err) {
     console.error("[work-orders] patch failed", err);
@@ -1254,6 +1404,125 @@ router.post("/work-orders/:id/complete", requireAuth, async (req: any, res) => {
   } catch (err) {
     console.error("[work-orders] complete failed", err);
     return res.status(500).json({ ok: false, error: "WORK_ORDER_COMPLETE_FAILED" });
+  }
+});
+
+router.post("/landlord/work-orders/:id/confirm-completion", requireAuth, async (req: any, res) => {
+  try {
+    if (!isLandlord(req)) return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+
+    const workOrderId = asString(req.params?.id, 120);
+    const access = await getWorkOrderAuthorized(req, workOrderId);
+    if (!access.ok) {
+      if (access.code === "NOT_FOUND") return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+
+    const currentStatus = asString((access.item as any)?.status, 40).toLowerCase();
+    if (currentStatus !== "completed") {
+      return res.status(400).json({ ok: false, error: "WORK_ORDER_NOT_COMPLETED" });
+    }
+
+    const now = nowMs();
+    await db.collection("workOrders").doc(workOrderId).set(
+      {
+        completionConfirmedByLandlordAt: now,
+        completionConfirmedByLandlordBy: access.userId,
+        updatedAtMs: now,
+        lastExecutionUpdateAt: now,
+      },
+      { merge: true }
+    );
+
+    await writeWorkOrderUpdate({
+      workOrderId,
+      actorRole: isAdmin(req) ? "admin" : "landlord",
+      actorId: access.userId,
+      updateType: "confirmed",
+      message: "Landlord confirmed work order completion",
+    });
+
+    await syncMaintenanceFromWorkOrder(workOrderId, {
+      contractorLastUpdate: "Landlord confirmed completion.",
+    });
+    await appendMaintenanceStatusHistory({
+      maintenanceRequestId: asOptionalString((access.item as any)?.maintenanceRequestId, 120),
+      status: "completed",
+      actorRole: isAdmin(req) ? "admin" : "landlord",
+      actorId: access.userId,
+      message: "Landlord confirmed completion.",
+    });
+
+    const refreshed = await db.collection("workOrders").doc(workOrderId).get();
+    return res.json({ ok: true, item: toWorkOrderResponse(refreshed.id, refreshed.data()) });
+  } catch (err) {
+    console.error("[work-orders] confirm completion failed", err);
+    return res.status(500).json({ ok: false, error: "WORK_ORDER_CONFIRM_COMPLETION_FAILED" });
+  }
+});
+
+router.post("/landlord/work-orders/:id/reopen", requireAuth, async (req: any, res) => {
+  try {
+    if (!isLandlord(req)) return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+
+    const workOrderId = asString(req.params?.id, 120);
+    const access = await getWorkOrderAuthorized(req, workOrderId);
+    if (!access.ok) {
+      if (access.code === "NOT_FOUND") return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+
+    const reason = asString(req.body?.reason, 500);
+    if (!reason) return res.status(400).json({ ok: false, error: "REOPEN_REASON_REQUIRED" });
+
+    const currentStatus = asString((access.item as any)?.status, 40).toLowerCase();
+    if (currentStatus !== "completed") {
+      return res.status(400).json({ ok: false, error: "WORK_ORDER_NOT_COMPLETED" });
+    }
+
+    const requestedStatus = asString(req.body?.status, 40).toLowerCase();
+    const nextStatus = requestedStatus === "blocked" ? "blocked" : "in_progress";
+    const now = nowMs();
+    await db.collection("workOrders").doc(workOrderId).set(
+      {
+        status: nextStatus,
+        reopenedAt: now,
+        reopenedByActorId: access.userId,
+        reopenedByActorRole: isAdmin(req) ? "admin" : "landlord",
+        reopenReason: reason,
+        completionConfirmedByLandlordAt: null,
+        completionConfirmedByLandlordBy: null,
+        updatedAtMs: now,
+        lastExecutionUpdateAt: now,
+        executionBlockedReason: nextStatus === "blocked" ? reason : null,
+      },
+      { merge: true }
+    );
+
+    await writeWorkOrderUpdate({
+      workOrderId,
+      actorRole: isAdmin(req) ? "admin" : "landlord",
+      actorId: access.userId,
+      updateType: "reopened",
+      message: `Work order reopened: ${reason}`,
+    });
+
+    await syncMaintenanceFromWorkOrder(workOrderId, {
+      contractorLastUpdate: reason,
+    });
+    await appendMaintenanceStatusHistory({
+      maintenanceRequestId: asOptionalString((access.item as any)?.maintenanceRequestId, 120),
+      status: nextStatus,
+      actorRole: isAdmin(req) ? "admin" : "landlord",
+      actorId: access.userId,
+      message: `Work order reopened: ${reason}`,
+    });
+
+    const refreshed = await db.collection("workOrders").doc(workOrderId).get();
+    return res.json({ ok: true, item: toWorkOrderResponse(refreshed.id, refreshed.data()) });
+  } catch (err) {
+    console.error("[work-orders] reopen failed", err);
+    return res.status(500).json({ ok: false, error: "WORK_ORDER_REOPEN_FAILED" });
   }
 });
 

--- a/rentchain-frontend/src/api/maintenanceWorkflowApi.ts
+++ b/rentchain-frontend/src/api/maintenanceWorkflowApi.ts
@@ -11,6 +11,7 @@ export type MaintenanceWorkflowStatus =
   | "reviewed"
   | "assigned"
   | "scheduled"
+  | "blocked"
   | "in_progress"
   | "completed"
   | "cancelled";
@@ -34,6 +35,21 @@ export type MaintenanceWorkflowItem = {
   assignedContractorName?: string | null;
   contractorStatus?: string | null;
   contractorLastUpdate?: string | null;
+  scheduledFor?: number | null;
+  serviceStartedAt?: number | null;
+  serviceCompletedAt?: number | null;
+  lastExecutionUpdateAt?: number | null;
+  executionBlockedReason?: string | null;
+  completionSummary?: string | null;
+  completionOutcome?: "completed" | "partially_completed" | "follow_up_required" | null;
+  completionConfirmedByLandlordAt?: number | null;
+  completionConfirmedByLandlordBy?: string | null;
+  completedByActorRole?: "contractor" | "landlord" | "admin" | null;
+  completedByActorId?: string | null;
+  reopenedAt?: number | null;
+  reopenedByActorId?: string | null;
+  reopenedByActorRole?: "landlord" | "admin" | null;
+  reopenReason?: string | null;
   serviceWindowStartAt?: number | null;
   serviceWindowEndAt?: number | null;
   accessRequired?: boolean | null;
@@ -111,6 +127,41 @@ export async function listTenantMaintenance() {
     contractorStatus: item.contractorStatus || null,
     serviceWindowStartAt: typeof item.serviceWindowStartAt === "number" ? item.serviceWindowStartAt : null,
     serviceWindowEndAt: typeof item.serviceWindowEndAt === "number" ? item.serviceWindowEndAt : null,
+    scheduledFor: typeof (item as any).scheduledFor === "number" ? (item as any).scheduledFor : null,
+    serviceStartedAt: typeof (item as any).serviceStartedAt === "number" ? (item as any).serviceStartedAt : null,
+    serviceCompletedAt: typeof (item as any).serviceCompletedAt === "number" ? (item as any).serviceCompletedAt : null,
+    lastExecutionUpdateAt:
+      typeof (item as any).lastExecutionUpdateAt === "number" ? (item as any).lastExecutionUpdateAt : null,
+    executionBlockedReason: typeof (item as any).executionBlockedReason === "string" ? (item as any).executionBlockedReason : null,
+    completionSummary: typeof (item as any).completionSummary === "string" ? (item as any).completionSummary : null,
+    completionOutcome:
+      (item as any).completionOutcome === "completed" ||
+      (item as any).completionOutcome === "partially_completed" ||
+      (item as any).completionOutcome === "follow_up_required"
+        ? (item as any).completionOutcome
+        : null,
+    completionConfirmedByLandlordAt:
+      typeof (item as any).completionConfirmedByLandlordAt === "number"
+        ? (item as any).completionConfirmedByLandlordAt
+        : null,
+    completionConfirmedByLandlordBy:
+      typeof (item as any).completionConfirmedByLandlordBy === "string"
+        ? (item as any).completionConfirmedByLandlordBy
+        : null,
+    completedByActorRole:
+      (item as any).completedByActorRole === "contractor" ||
+      (item as any).completedByActorRole === "landlord" ||
+      (item as any).completedByActorRole === "admin"
+        ? (item as any).completedByActorRole
+        : null,
+    completedByActorId: typeof (item as any).completedByActorId === "string" ? (item as any).completedByActorId : null,
+    reopenedAt: typeof (item as any).reopenedAt === "number" ? (item as any).reopenedAt : null,
+    reopenedByActorId: typeof (item as any).reopenedByActorId === "string" ? (item as any).reopenedByActorId : null,
+    reopenedByActorRole:
+      (item as any).reopenedByActorRole === "landlord" || (item as any).reopenedByActorRole === "admin"
+        ? (item as any).reopenedByActorRole
+        : null,
+    reopenReason: typeof (item as any).reopenReason === "string" ? (item as any).reopenReason : null,
     accessRequired: typeof item.accessRequired === "boolean" ? item.accessRequired : null,
     tenantConfirmationStatus:
       item.tenantConfirmationStatus === "confirmed" || item.tenantConfirmationStatus === "needs_schedule_change"
@@ -151,6 +202,44 @@ export async function getTenantMaintenance(id: string) {
     contractorStatus: item?.contractorStatus || null,
     serviceWindowStartAt: typeof item?.serviceWindowStartAt === "number" ? item.serviceWindowStartAt : null,
     serviceWindowEndAt: typeof item?.serviceWindowEndAt === "number" ? item.serviceWindowEndAt : null,
+    scheduledFor: typeof (item as any)?.scheduledFor === "number" ? (item as any).scheduledFor : null,
+    serviceStartedAt: typeof (item as any)?.serviceStartedAt === "number" ? (item as any).serviceStartedAt : null,
+    serviceCompletedAt: typeof (item as any)?.serviceCompletedAt === "number" ? (item as any).serviceCompletedAt : null,
+    lastExecutionUpdateAt:
+      typeof (item as any)?.lastExecutionUpdateAt === "number" ? (item as any).lastExecutionUpdateAt : null,
+    executionBlockedReason:
+      typeof (item as any)?.executionBlockedReason === "string" ? (item as any).executionBlockedReason : null,
+    completionSummary: typeof (item as any)?.completionSummary === "string" ? (item as any).completionSummary : null,
+    completionOutcome:
+      (item as any)?.completionOutcome === "completed" ||
+      (item as any)?.completionOutcome === "partially_completed" ||
+      (item as any)?.completionOutcome === "follow_up_required"
+        ? (item as any).completionOutcome
+        : null,
+    completionConfirmedByLandlordAt:
+      typeof (item as any)?.completionConfirmedByLandlordAt === "number"
+        ? (item as any).completionConfirmedByLandlordAt
+        : null,
+    completionConfirmedByLandlordBy:
+      typeof (item as any)?.completionConfirmedByLandlordBy === "string"
+        ? (item as any).completionConfirmedByLandlordBy
+        : null,
+    completedByActorRole:
+      (item as any)?.completedByActorRole === "contractor" ||
+      (item as any)?.completedByActorRole === "landlord" ||
+      (item as any)?.completedByActorRole === "admin"
+        ? (item as any).completedByActorRole
+        : null,
+    completedByActorId:
+      typeof (item as any)?.completedByActorId === "string" ? (item as any).completedByActorId : null,
+    reopenedAt: typeof (item as any)?.reopenedAt === "number" ? (item as any).reopenedAt : null,
+    reopenedByActorId:
+      typeof (item as any)?.reopenedByActorId === "string" ? (item as any).reopenedByActorId : null,
+    reopenedByActorRole:
+      (item as any)?.reopenedByActorRole === "landlord" || (item as any)?.reopenedByActorRole === "admin"
+        ? (item as any).reopenedByActorRole
+        : null,
+    reopenReason: typeof (item as any)?.reopenReason === "string" ? (item as any).reopenReason : null,
     accessRequired: typeof item?.accessRequired === "boolean" ? item.accessRequired : null,
     tenantConfirmationStatus:
       item?.tenantConfirmationStatus === "confirmed" || item?.tenantConfirmationStatus === "needs_schedule_change"
@@ -273,7 +362,14 @@ export async function listContractorMaintenanceJobs(status?: string) {
 
 export async function patchContractorMaintenanceJobStatus(
   id: string,
-  payload: { status: "assigned" | "scheduled" | "in_progress" | "completed"; message?: string }
+  payload: {
+    status: "assigned" | "scheduled" | "blocked" | "in_progress" | "completed";
+    message?: string;
+    scheduledFor?: number | null;
+    blockedReason?: string;
+    completionSummary?: string;
+    completionOutcome?: "completed" | "partially_completed" | "follow_up_required";
+  }
 ) {
   return apiFetch<{ ok: boolean; item: MaintenanceWorkflowItem; data?: MaintenanceWorkflowItem }>(
     `/contractor/jobs/${encodeURIComponent(id)}/status`,

--- a/rentchain-frontend/src/api/workOrdersApi.ts
+++ b/rentchain-frontend/src/api/workOrdersApi.ts
@@ -6,6 +6,8 @@ export type WorkOrderStatus =
   | "invited"
   | "assigned"
   | "accepted"
+  | "scheduled"
+  | "blocked"
   | "in_progress"
   | "completed"
   | "cancelled";
@@ -28,6 +30,21 @@ export type WorkOrderRecord = {
   acceptedAtMs: number | null;
   startedAtMs: number | null;
   completedAtMs: number | null;
+  scheduledFor?: number | null;
+  serviceStartedAt?: number | null;
+  serviceCompletedAt?: number | null;
+  lastExecutionUpdateAt?: number | null;
+  executionBlockedReason?: string | null;
+  completionSummary?: string | null;
+  completionOutcome?: "completed" | "partially_completed" | "follow_up_required" | null;
+  completedByActorRole?: "contractor" | "landlord" | "admin" | null;
+  completedByActorId?: string | null;
+  completionConfirmedByLandlordAt?: number | null;
+  completionConfirmedByLandlordBy?: string | null;
+  reopenedAt?: number | null;
+  reopenedByActorId?: string | null;
+  reopenedByActorRole?: "landlord" | "admin" | null;
+  reopenReason?: string | null;
   notesInternal: string;
   linkedExpenseId: string | null;
   createdAtMs: number;
@@ -45,10 +62,15 @@ export type WorkOrderUpdateRecord = {
     | "accepted"
     | "declined"
     | "status_changed"
+    | "scheduled"
+    | "started"
+    | "blocked"
     | "note"
     | "photo"
     | "invoice"
-    | "completed";
+    | "completed"
+    | "confirmed"
+    | "reopened";
   message: string;
   attachmentUrl: string | null;
   createdAtMs: number;
@@ -96,7 +118,14 @@ export async function getWorkOrder(workOrderId: string): Promise<WorkOrderRecord
 
 export async function patchWorkOrder(
   workOrderId: string,
-  patch: Partial<CreateWorkOrderInput> & { status?: WorkOrderStatus; linkedExpenseId?: string | null }
+  patch: Partial<CreateWorkOrderInput> & {
+    status?: WorkOrderStatus;
+    linkedExpenseId?: string | null;
+    scheduledFor?: number | null;
+    blockedReason?: string;
+    completionSummary?: string;
+    completionOutcome?: "completed" | "partially_completed" | "follow_up_required";
+  }
 ): Promise<WorkOrderRecord> {
   const res = await apiFetch<{ ok: boolean; item: WorkOrderRecord }>(
     `/work-orders/${encodeURIComponent(workOrderId)}`,
@@ -139,6 +168,27 @@ export async function completeWorkOrder(workOrderId: string): Promise<WorkOrderR
     { method: "POST" }
   );
   if (!res?.ok || !res.item) throw new Error("Failed to complete work order");
+  return res.item;
+}
+
+export async function confirmWorkOrderCompletion(workOrderId: string): Promise<WorkOrderRecord> {
+  const res = await apiFetch<{ ok: boolean; item: WorkOrderRecord }>(
+    `/landlord/work-orders/${encodeURIComponent(workOrderId)}/confirm-completion`,
+    { method: "POST" }
+  );
+  if (!res?.ok || !res.item) throw new Error("Failed to confirm work order completion");
+  return res.item;
+}
+
+export async function reopenWorkOrder(
+  workOrderId: string,
+  payload: { reason: string; status?: "in_progress" | "blocked" }
+): Promise<WorkOrderRecord> {
+  const res = await apiFetch<{ ok: boolean; item: WorkOrderRecord }>(
+    `/landlord/work-orders/${encodeURIComponent(workOrderId)}/reopen`,
+    { method: "POST", body: payload }
+  );
+  if (!res?.ok || !res.item) throw new Error("Failed to reopen work order");
   return res.item;
 }
 

--- a/rentchain-frontend/src/pages/contractor/ContractorJobsPage.test.tsx
+++ b/rentchain-frontend/src/pages/contractor/ContractorJobsPage.test.tsx
@@ -1,0 +1,103 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import ContractorJobsPage from "./ContractorJobsPage";
+
+const apiMocks = vi.hoisted(() => ({
+  listContractorMaintenanceJobs: vi.fn(),
+  patchContractorMaintenanceJobStatus: vi.fn(),
+}));
+
+vi.mock("../../api/maintenanceWorkflowApi", async () => {
+  const actual = await vi.importActual<any>("../../api/maintenanceWorkflowApi");
+  return {
+    ...actual,
+    listContractorMaintenanceJobs: apiMocks.listContractorMaintenanceJobs,
+    patchContractorMaintenanceJobStatus: apiMocks.patchContractorMaintenanceJobStatus,
+  };
+});
+
+describe("ContractorJobsPage", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation(() => ({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+      })),
+    });
+    apiMocks.listContractorMaintenanceJobs.mockReset();
+    apiMocks.patchContractorMaintenanceJobStatus.mockReset();
+  });
+
+  it("requires a blocked reason before marking a job blocked", async () => {
+    apiMocks.listContractorMaintenanceJobs.mockResolvedValue({
+      items: [
+        {
+          id: "maint-1",
+          title: "Leaking sink",
+          description: "Water is pooling under the sink.",
+          status: "scheduled",
+          priority: "normal",
+          tenantId: "tenant-1",
+          landlordId: "landlord-1",
+          propertyLabel: "Harbour View",
+          unitLabel: "Unit 2",
+          createdAt: 100,
+          updatedAt: 200,
+          statusHistory: [],
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/contractor/jobs/maint-1"]}>
+        <Routes>
+          <Route path="/contractor/jobs/:id" element={<ContractorJobsPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /mark blocked/i }));
+
+    expect(await screen.findByText(/A blocked job needs a reason/i)).toBeInTheDocument();
+    expect(apiMocks.patchContractorMaintenanceJobStatus).not.toHaveBeenCalled();
+  });
+
+  it("requires a completion summary before marking a job completed", async () => {
+    apiMocks.listContractorMaintenanceJobs.mockResolvedValue({
+      items: [
+        {
+          id: "maint-1",
+          title: "Broken heater",
+          description: "No heat in the bedroom.",
+          status: "in_progress",
+          priority: "urgent",
+          tenantId: "tenant-1",
+          landlordId: "landlord-1",
+          propertyLabel: "Harbour View",
+          unitLabel: "Unit 2",
+          createdAt: 100,
+          updatedAt: 200,
+          statusHistory: [],
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/contractor/jobs/maint-1"]}>
+        <Routes>
+          <Route path="/contractor/jobs/:id" element={<ContractorJobsPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /mark completed/i }));
+
+    expect(await screen.findByText(/Add a completion summary before finishing the job/i)).toBeInTheDocument();
+    expect(apiMocks.patchContractorMaintenanceJobStatus).not.toHaveBeenCalled();
+  });
+});

--- a/rentchain-frontend/src/pages/contractor/ContractorJobsPage.tsx
+++ b/rentchain-frontend/src/pages/contractor/ContractorJobsPage.tsx
@@ -15,18 +15,36 @@ function fmtDate(ts?: number | null) {
   return new Date(ts).toLocaleString();
 }
 
+function toLocalInputValue(ts?: number | null) {
+  if (!ts) return "";
+  const date = new Date(ts);
+  const pad = (value: number) => String(value).padStart(2, "0");
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(
+    date.getMinutes()
+  )}`;
+}
+
+function fromLocalInputValue(value: string) {
+  if (!value) return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.getTime();
+}
+
 function findScheduledDate(item: MaintenanceWorkflowItem) {
+  if (typeof item.scheduledFor === "number") return item.scheduledFor;
   const history = Array.isArray(item.statusHistory) ? item.statusHistory : [];
   const scheduledEntry = [...history]
     .filter((entry) => entry.status === "scheduled")
     .sort((a, b) => Number(b.createdAt || 0) - Number(a.createdAt || 0))[0];
-  return scheduledEntry?.createdAt || null;
+  return scheduledEntry?.createdAt || item.serviceWindowStartAt || null;
 }
 
 function statusLabel(status?: MaintenanceWorkflowStatus | string | null) {
   switch (status) {
     case "in_progress":
       return "in progress";
+    case "blocked":
+      return "blocked";
     case "submitted":
     case "reviewed":
     case "assigned":
@@ -63,6 +81,17 @@ function normalizeJob(item: any): MaintenanceWorkflowItem | null {
     landlordNote: item?.landlordNote ? String(item.landlordNote) : null,
     contractorStatus: item?.contractorStatus ? String(item.contractorStatus) : null,
     contractorLastUpdate: item?.contractorLastUpdate ? String(item.contractorLastUpdate) : null,
+    scheduledFor: typeof item?.scheduledFor === "number" ? item.scheduledFor : null,
+    serviceStartedAt: typeof item?.serviceStartedAt === "number" ? item.serviceStartedAt : null,
+    serviceCompletedAt: typeof item?.serviceCompletedAt === "number" ? item.serviceCompletedAt : null,
+    executionBlockedReason: item?.executionBlockedReason ? String(item.executionBlockedReason) : null,
+    completionSummary: item?.completionSummary ? String(item.completionSummary) : null,
+    completionOutcome:
+      item?.completionOutcome === "completed" ||
+      item?.completionOutcome === "partially_completed" ||
+      item?.completionOutcome === "follow_up_required"
+        ? item.completionOutcome
+        : null,
     createdAt: Number(item?.createdAt || 0),
     updatedAt: Number(item?.updatedAt || 0),
     statusHistory: Array.isArray(item?.statusHistory) ? item.statusHistory : [],
@@ -78,6 +107,9 @@ export default function ContractorJobsPage() {
   const [selectedId, setSelectedId] = React.useState(routeId || "");
   const [search, setSearch] = React.useState("");
   const [note, setNote] = React.useState("");
+  const [scheduledForInput, setScheduledForInput] = React.useState("");
+  const [completionSummary, setCompletionSummary] = React.useState("");
+  const [completionOutcome, setCompletionOutcome] = React.useState<"completed" | "partially_completed" | "follow_up_required">("completed");
   const [saving, setSaving] = React.useState(false);
 
   const load = React.useCallback(async () => {
@@ -130,6 +162,24 @@ export default function ContractorJobsPage() {
     }
   }, [filtered, routeId, selected]);
 
+  React.useEffect(() => {
+    if (!selected) {
+      setScheduledForInput("");
+      setCompletionSummary("");
+      setCompletionOutcome("completed");
+      setNote("");
+      return;
+    }
+    setScheduledForInput(toLocalInputValue(selected.scheduledFor || findScheduledDate(selected)));
+    setCompletionSummary(String(selected.completionSummary || ""));
+    setCompletionOutcome(
+      selected.completionOutcome === "partially_completed" || selected.completionOutcome === "follow_up_required"
+        ? selected.completionOutcome
+        : "completed"
+    );
+    setNote(String(selected.executionBlockedReason || selected.contractorLastUpdate || ""));
+  }, [selected]);
+
   const selectJob = (item: MaintenanceWorkflowItem | null) => {
     if (!item) {
       setSelectedId("");
@@ -141,16 +191,38 @@ export default function ContractorJobsPage() {
   };
 
   const updateStatus = React.useCallback(
-    async (status: "assigned" | "scheduled" | "in_progress" | "completed", fallbackMessage: string) => {
+    async (
+      status: "assigned" | "scheduled" | "blocked" | "in_progress" | "completed",
+      fallbackMessage: string
+    ) => {
       if (!selected) return;
+      const scheduledFor = fromLocalInputValue(scheduledForInput);
+      if (status === "scheduled" && scheduledForInput && !scheduledFor) {
+        setError("Enter a valid scheduled service time.");
+        return;
+      }
+      if (status === "blocked" && !note.trim()) {
+        setError("A blocked job needs a reason.");
+        return;
+      }
+      if (status === "completed" && !completionSummary.trim()) {
+        setError("Add a completion summary before finishing the job.");
+        return;
+      }
       setSaving(true);
       setError(null);
       try {
         await patchContractorMaintenanceJobStatus(selected.id, {
           status,
           message: note.trim() || fallbackMessage,
+          scheduledFor: status === "scheduled" ? scheduledFor : undefined,
+          blockedReason: status === "blocked" ? note.trim() : undefined,
+          completionSummary: status === "completed" ? completionSummary.trim() : undefined,
+          completionOutcome: status === "completed" ? completionOutcome : undefined,
         });
-        setNote("");
+        if (status === "completed") {
+          setCompletionSummary("");
+        }
         await load();
       } catch (err: any) {
         setError(String(err?.message || "Failed to update job"));
@@ -158,7 +230,7 @@ export default function ContractorJobsPage() {
         setSaving(false);
       }
     },
-    [load, note, selected]
+    [completionOutcome, completionSummary, load, note, scheduledForInput, selected]
   );
 
   const actions = React.useMemo(() => {
@@ -172,17 +244,23 @@ export default function ContractorJobsPage() {
     }
     if (selected.status === "assigned") {
       next.push({
-        label: "Mark scheduled",
+        label: "Schedule service",
         onClick: () => updateStatus("scheduled", "Contractor scheduled the visit."),
       });
     }
-    if (selected.status === "scheduled") {
+    if (["assigned", "scheduled", "blocked"].includes(selected.status)) {
       next.push({
-        label: "Mark in progress",
+        label: "Start work",
         onClick: () => updateStatus("in_progress", "Contractor started the work."),
       });
     }
-    if (selected.status === "in_progress") {
+    if (["scheduled", "in_progress"].includes(selected.status)) {
+      next.push({
+        label: "Mark blocked",
+        onClick: () => updateStatus("blocked", "Contractor reported a blocked visit."),
+      });
+    }
+    if (["scheduled", "blocked", "in_progress"].includes(selected.status)) {
       next.push({
         label: "Mark completed",
         onClick: () => updateStatus("completed", "Contractor completed the work."),
@@ -301,12 +379,22 @@ export default function ContractorJobsPage() {
                       <div style={{ color: text.primary, fontWeight: 700, marginTop: 6 }}>{selected.priority}</div>
                     </div>
                     <div>
-                      <div style={{ color: text.muted, fontSize: 12 }}>Scheduled date</div>
+                      <div style={{ color: text.muted, fontSize: 12 }}>Scheduled service</div>
                       <div style={{ color: text.primary, fontWeight: 700, marginTop: 6 }}>{fmtDate(findScheduledDate(selected))}</div>
                     </div>
                     <div>
                       <div style={{ color: text.muted, fontSize: 12 }}>Last update</div>
                       <div style={{ color: text.primary, fontWeight: 700, marginTop: 6 }}>{fmtDate(selected.updatedAt)}</div>
+                    </div>
+                    <div>
+                      <div style={{ color: text.muted, fontSize: 12 }}>Started</div>
+                      <div style={{ color: text.primary, fontWeight: 700, marginTop: 6 }}>{fmtDate(selected.serviceStartedAt)}</div>
+                    </div>
+                    <div>
+                      <div style={{ color: text.muted, fontSize: 12 }}>Completed</div>
+                      <div style={{ color: text.primary, fontWeight: 700, marginTop: 6 }}>
+                        {fmtDate(selected.serviceCompletedAt)}
+                      </div>
                     </div>
                   </div>
 
@@ -322,24 +410,98 @@ export default function ContractorJobsPage() {
                     </div>
                   ) : null}
 
-                  <label style={{ display: "grid", gap: 6 }}>
-                    <span style={{ color: text.muted, fontSize: 12 }}>Update note</span>
-                    <textarea
-                      rows={3}
-                      value={note}
-                      onChange={(e) => setNote(e.target.value)}
-                      placeholder="Add schedule details or a progress note"
-                      style={{
-                        width: "100%",
-                        padding: "10px",
-                        borderRadius: radius.md,
-                        border: `1px solid ${colors.border}`,
-                        background: colors.panel,
-                        color: text.primary,
-                        resize: "vertical",
-                      }}
-                    />
-                  </label>
+                  <div
+                    style={{
+                      border: `1px solid ${colors.border}`,
+                      borderRadius: radius.md,
+                      padding: "12px 14px",
+                      background: colors.panel,
+                      display: "grid",
+                      gap: 8,
+                    }}
+                  >
+                    <div style={{ fontWeight: 700, color: text.primary }}>Execution details</div>
+                    <div style={{ color: text.secondary }}>
+                      {selected.executionBlockedReason
+                        ? `Blocked reason: ${selected.executionBlockedReason}`
+                        : selected.completionSummary
+                        ? `Completion summary: ${selected.completionSummary}`
+                        : selected.contractorLastUpdate || "Use the actions below to keep service progress current."}
+                    </div>
+                    <label style={{ display: "grid", gap: 4 }}>
+                      <span style={{ color: text.muted, fontSize: 12 }}>Scheduled service time</span>
+                      <input
+                        type="datetime-local"
+                        value={scheduledForInput}
+                        onChange={(e) => setScheduledForInput(e.target.value)}
+                        style={{
+                          padding: "9px 10px",
+                          borderRadius: radius.md,
+                          border: `1px solid ${colors.border}`,
+                          background: colors.panel,
+                          color: text.primary,
+                        }}
+                      />
+                    </label>
+                    <label style={{ display: "grid", gap: 6 }}>
+                      <span style={{ color: text.muted, fontSize: 12 }}>
+                        {selected.status === "completed" ? "Completion update" : "Execution note / blocked reason"}
+                      </span>
+                      <textarea
+                        rows={3}
+                        value={note}
+                        onChange={(e) => setNote(e.target.value)}
+                        placeholder="Add schedule details, a blocked reason, or a progress note"
+                        style={{
+                          width: "100%",
+                          padding: "10px",
+                          borderRadius: radius.md,
+                          border: `1px solid ${colors.border}`,
+                          background: colors.panel,
+                          color: text.primary,
+                          resize: "vertical",
+                        }}
+                      />
+                    </label>
+                    <label style={{ display: "grid", gap: 6 }}>
+                      <span style={{ color: text.muted, fontSize: 12 }}>Completion summary</span>
+                      <textarea
+                        rows={3}
+                        value={completionSummary}
+                        onChange={(e) => setCompletionSummary(e.target.value)}
+                        placeholder="Summarize what work was completed"
+                        style={{
+                          width: "100%",
+                          padding: "10px",
+                          borderRadius: radius.md,
+                          border: `1px solid ${colors.border}`,
+                          background: colors.panel,
+                          color: text.primary,
+                          resize: "vertical",
+                        }}
+                      />
+                    </label>
+                    <label style={{ display: "grid", gap: 4 }}>
+                      <span style={{ color: text.muted, fontSize: 12 }}>Completion outcome</span>
+                      <select
+                        value={completionOutcome}
+                        onChange={(e) =>
+                          setCompletionOutcome(e.target.value as "completed" | "partially_completed" | "follow_up_required")
+                        }
+                        style={{
+                          padding: "9px 10px",
+                          borderRadius: radius.md,
+                          border: `1px solid ${colors.border}`,
+                          background: colors.panel,
+                          color: text.primary,
+                        }}
+                      >
+                        <option value="completed">Completed</option>
+                        <option value="partially_completed">Partially completed</option>
+                        <option value="follow_up_required">Follow-up required</option>
+                      </select>
+                    </label>
+                  </div>
 
                   <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
                     {actions.map((action) => (

--- a/rentchain-frontend/src/pages/landlord/WorkOrdersPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/WorkOrdersPage.test.tsx
@@ -1,26 +1,37 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import WorkOrdersPage from "./WorkOrdersPage";
 
 const mocks = vi.hoisted(() => ({
+  canUseWorkOrders: false,
   listWorkOrders: vi.fn(),
+  listWorkOrderUpdates: vi.fn(),
+  getWorkOrder: vi.fn(),
+  patchWorkOrder: vi.fn(),
+  confirmWorkOrderCompletion: vi.fn(),
+  reopenWorkOrder: vi.fn(),
+  addWorkOrderUpdate: vi.fn(),
+  getContractorProfileById: vi.fn(),
   fetchProperties: vi.fn(),
 }));
 
 vi.mock("@/hooks/useEntitlements", () => ({
   useEntitlements: () => ({
-    canUseWorkOrders: false,
+    canUseWorkOrders: mocks.canUseWorkOrders,
   }),
 }));
 
 vi.mock("../../api/workOrdersApi", () => ({
-  addWorkOrderUpdate: vi.fn(),
+  addWorkOrderUpdate: mocks.addWorkOrderUpdate,
   completeWorkOrder: vi.fn(),
-  getContractorProfileById: vi.fn(),
-  listWorkOrderUpdates: vi.fn(),
+  confirmWorkOrderCompletion: mocks.confirmWorkOrderCompletion,
+  getContractorProfileById: mocks.getContractorProfileById,
+  getWorkOrder: mocks.getWorkOrder,
+  listWorkOrderUpdates: mocks.listWorkOrderUpdates,
   listWorkOrders: mocks.listWorkOrders,
-  patchWorkOrder: vi.fn(),
+  patchWorkOrder: mocks.patchWorkOrder,
+  reopenWorkOrder: mocks.reopenWorkOrder,
 }));
 
 vi.mock("../../api/propertiesApi", () => ({
@@ -52,8 +63,17 @@ describe("WorkOrdersPage", () => {
         removeListener: vi.fn(),
       })),
     });
+    mocks.canUseWorkOrders = false;
     mocks.listWorkOrders.mockReset();
+    mocks.listWorkOrderUpdates.mockReset();
+    mocks.getWorkOrder.mockReset();
+    mocks.patchWorkOrder.mockReset();
+    mocks.confirmWorkOrderCompletion.mockReset();
+    mocks.reopenWorkOrder.mockReset();
+    mocks.addWorkOrderUpdate.mockReset();
+    mocks.getContractorProfileById.mockReset();
     mocks.fetchProperties.mockReset();
+    mocks.fetchProperties.mockResolvedValue({ items: [] });
   });
 
   it("renders the locked free-tier state without crashing", async () => {
@@ -68,5 +88,127 @@ describe("WorkOrdersPage", () => {
     });
 
     expect(mocks.listWorkOrders).not.toHaveBeenCalled();
+  });
+
+  it("shows execution details and lets the landlord confirm and reopen completion", async () => {
+    mocks.canUseWorkOrders = true;
+    mocks.listWorkOrders.mockResolvedValue([
+      {
+        id: "wo-1",
+        landlordId: "landlord-1",
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        title: "Broken heater",
+        description: "Restore heat in unit 3A",
+        category: "HVAC",
+        priority: "urgent",
+        status: "completed",
+        visibility: "private",
+        budgetMinCents: null,
+        budgetMaxCents: null,
+        assignedContractorId: "contractor-1",
+        invitedContractorIds: [],
+        acceptedAtMs: 10,
+        startedAtMs: 20,
+        completedAtMs: 30,
+        scheduledFor: 15,
+        serviceStartedAt: 20,
+        serviceCompletedAt: 30,
+        completionSummary: "Replaced igniter and restored heat.",
+        completionOutcome: "completed",
+        completedByActorRole: "contractor",
+        completionConfirmedByLandlordAt: null,
+        completionConfirmedByLandlordBy: null,
+        reopenedAt: null,
+        reopenedByActorId: null,
+        reopenedByActorRole: null,
+        reopenReason: null,
+        executionBlockedReason: null,
+        notesInternal: "",
+        linkedExpenseId: null,
+        createdAtMs: 1,
+        updatedAtMs: 35,
+      },
+    ]);
+    mocks.listWorkOrderUpdates.mockResolvedValue([
+      {
+        id: "upd-1",
+        workOrderId: "wo-1",
+        actorRole: "contractor",
+        actorId: "contractor-1",
+        updateType: "completed",
+        message: "Work order marked completed",
+        attachmentUrl: null,
+        createdAtMs: 30,
+      },
+    ]);
+    mocks.getWorkOrder.mockResolvedValue({
+      id: "wo-1",
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      title: "Broken heater",
+      description: "Restore heat in unit 3A",
+      category: "HVAC",
+      priority: "urgent",
+      status: "completed",
+      visibility: "private",
+      budgetMinCents: null,
+      budgetMaxCents: null,
+      assignedContractorId: "contractor-1",
+      invitedContractorIds: [],
+      acceptedAtMs: 10,
+      startedAtMs: 20,
+      completedAtMs: 30,
+      scheduledFor: 15,
+      serviceStartedAt: 20,
+      serviceCompletedAt: 30,
+      completionSummary: "Replaced igniter and restored heat.",
+      completionOutcome: "completed",
+      completedByActorRole: "contractor",
+      completionConfirmedByLandlordAt: 40,
+      completionConfirmedByLandlordBy: "landlord-1",
+      reopenedAt: null,
+      reopenedByActorId: null,
+      reopenedByActorRole: null,
+      reopenReason: null,
+      executionBlockedReason: null,
+      notesInternal: "",
+      linkedExpenseId: null,
+      createdAtMs: 1,
+      updatedAtMs: 40,
+    });
+    mocks.confirmWorkOrderCompletion.mockResolvedValue({ ok: true });
+    mocks.reopenWorkOrder.mockResolvedValue({ ok: true });
+
+    render(
+      <MemoryRouter>
+        <WorkOrdersPage />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /timeline/i }));
+
+    expect(await screen.findByText(/Execution and completion/i)).toBeInTheDocument();
+    expect(screen.getByText(/Replaced igniter and restored heat/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /confirm completion/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /confirm completion/i }));
+
+    await waitFor(() => {
+      expect(mocks.confirmWorkOrderCompletion).toHaveBeenCalledWith("wo-1");
+    });
+
+    fireEvent.change(screen.getByPlaceholderText(/Explain why this work order needs follow-up/i), {
+      target: { value: "Heat output is still inconsistent." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /reopen blocked/i }));
+
+    await waitFor(() => {
+      expect(mocks.reopenWorkOrder).toHaveBeenCalledWith("wo-1", {
+        reason: "Heat output is still inconsistent.",
+        status: "blocked",
+      });
+    });
   });
 });

--- a/rentchain-frontend/src/pages/landlord/WorkOrdersPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/WorkOrdersPage.tsx
@@ -7,11 +7,13 @@ import { LockedFeature } from "@/components/billing/LockedFeature";
 import { fetchProperties } from "../../api/propertiesApi";
 import {
   addWorkOrderUpdate,
-  completeWorkOrder,
+  confirmWorkOrderCompletion,
+  getWorkOrder,
   getContractorProfileById,
   listWorkOrderUpdates,
   listWorkOrders,
   patchWorkOrder,
+  reopenWorkOrder,
   type WorkOrderRecord,
   type WorkOrderUpdateRecord,
 } from "../../api/workOrdersApi";
@@ -26,6 +28,27 @@ function canCompleteWorkOrder(item: WorkOrderRecord) {
   return item.status !== "completed" && item.status !== "cancelled";
 }
 
+function canConfirmCompletion(item: WorkOrderRecord) {
+  return item.status === "completed" && !item.completionConfirmedByLandlordAt;
+}
+
+function canReopenWorkOrder(item: WorkOrderRecord) {
+  return item.status === "completed";
+}
+
+function completionOutcomeLabel(value?: WorkOrderRecord["completionOutcome"]) {
+  switch (value) {
+    case "partially_completed":
+      return "Partially completed";
+    case "follow_up_required":
+      return "Follow-up required";
+    case "completed":
+      return "Completed";
+    default:
+      return "-";
+  }
+}
+
 export default function WorkOrdersPage() {
   const entitlements = useEntitlements();
   const [items, setItems] = React.useState<WorkOrderRecord[]>([]);
@@ -34,7 +57,13 @@ export default function WorkOrdersPage() {
   const [selected, setSelected] = React.useState<WorkOrderRecord | null>(null);
   const [updates, setUpdates] = React.useState<WorkOrderUpdateRecord[]>([]);
   const [newNote, setNewNote] = React.useState("");
+  const [completionSummary, setCompletionSummary] = React.useState("");
+  const [completionOutcome, setCompletionOutcome] = React.useState<"completed" | "partially_completed" | "follow_up_required">(
+    "completed"
+  );
+  const [reopenReason, setReopenReason] = React.useState("");
   const [savingNote, setSavingNote] = React.useState(false);
+  const [savingAction, setSavingAction] = React.useState(false);
   const [properties, setProperties] = React.useState<Array<{ id: string; name: string }>>([]);
   const [convertTarget, setConvertTarget] = React.useState<WorkOrderRecord | null>(null);
   const [convertVendor, setConvertVendor] = React.useState("");
@@ -57,7 +86,9 @@ export default function WorkOrdersPage() {
     setLoading(true);
     setError(null);
     try {
-      setItems(await listWorkOrders());
+      const nextItems = await listWorkOrders();
+      setItems(nextItems);
+      setSelected((current) => (current ? nextItems.find((item) => item.id === current.id) || current : null));
     } catch (err: any) {
       setError(String(err?.message || "Failed to load work orders"));
     } finally {
@@ -73,23 +104,98 @@ export default function WorkOrdersPage() {
     }
   }, []);
 
+  const refreshSelected = React.useCallback(
+    async (workOrderId: string) => {
+      const refreshed = await getWorkOrder(workOrderId).catch(() => null);
+      if (refreshed) {
+        setSelected(refreshed);
+      }
+      await loadUpdates(workOrderId);
+    },
+    [loadUpdates]
+  );
+
   const markCompleted = React.useCallback(
     async (item: WorkOrderRecord) => {
-      if (!canCompleteWorkOrder(item)) return;
-      const shouldUseContractorCompletion = Boolean(item.assignedContractorId) && item.status === "in_progress";
-      if (shouldUseContractorCompletion) {
-        await completeWorkOrder(item.id);
-      } else {
-        await patchWorkOrder(item.id, { status: "completed" });
+      if (!canCompleteWorkOrder(item) || item.assignedContractorId) return;
+      if (!completionSummary.trim()) {
+        setError("Add a completion summary before marking the work order completed.");
+        return;
       }
-      await load();
-      if (selected?.id === item.id) {
-        setSelected((prev) => (prev ? { ...prev, status: "completed" } : prev));
-        await loadUpdates(item.id);
+      setSavingAction(true);
+      setError(null);
+      try {
+        await patchWorkOrder(item.id, {
+          status: "completed",
+          completionSummary: completionSummary.trim(),
+          completionOutcome,
+        });
+        await load();
+        await refreshSelected(item.id);
+      } catch (err: any) {
+        setError(String(err?.message || "Failed to complete work order"));
+      } finally {
+        setSavingAction(false);
       }
     },
-    [load, loadUpdates, selected?.id]
+    [completionOutcome, completionSummary, load, refreshSelected]
   );
+
+  const handleConfirmCompletion = React.useCallback(
+    async (item: WorkOrderRecord) => {
+      if (!canConfirmCompletion(item)) return;
+      setSavingAction(true);
+      setError(null);
+      try {
+        await confirmWorkOrderCompletion(item.id);
+        await load();
+        await refreshSelected(item.id);
+      } catch (err: any) {
+        setError(String(err?.message || "Failed to confirm completion"));
+      } finally {
+        setSavingAction(false);
+      }
+    },
+    [load, refreshSelected]
+  );
+
+  const handleReopen = React.useCallback(
+    async (item: WorkOrderRecord, status: "in_progress" | "blocked") => {
+      if (!canReopenWorkOrder(item)) return;
+      if (!reopenReason.trim()) {
+        setError("Add a reason before reopening the work order.");
+        return;
+      }
+      setSavingAction(true);
+      setError(null);
+      try {
+        await reopenWorkOrder(item.id, { reason: reopenReason.trim(), status });
+        await load();
+        await refreshSelected(item.id);
+      } catch (err: any) {
+        setError(String(err?.message || "Failed to reopen work order"));
+      } finally {
+        setSavingAction(false);
+      }
+    },
+    [load, refreshSelected, reopenReason]
+  );
+
+  React.useEffect(() => {
+    if (!selected) {
+      setCompletionSummary("");
+      setCompletionOutcome("completed");
+      setReopenReason("");
+      return;
+    }
+    setCompletionSummary(String(selected.completionSummary || ""));
+    setCompletionOutcome(
+      selected.completionOutcome === "partially_completed" || selected.completionOutcome === "follow_up_required"
+        ? selected.completionOutcome
+        : "completed"
+    );
+    setReopenReason(String(selected.reopenReason || ""));
+  }, [selected]);
 
   React.useEffect(() => {
     if (!canUseWorkOrders) {
@@ -220,12 +326,12 @@ export default function WorkOrdersPage() {
                     >
                       Timeline
                     </Button>
-                    {canCompleteWorkOrder(item) ? (
+                    {!item.assignedContractorId && canCompleteWorkOrder(item) ? (
                       <Button
                         variant="ghost"
                         onClick={() => void markCompleted(item)}
                       >
-                        {item.assignedContractorId ? "Mark Completed" : "Mark Completed In-house"}
+                        Mark Completed In-house
                       </Button>
                     ) : null}
                     {item.status === "completed" && !item.linkedExpenseId ? (
@@ -294,12 +400,12 @@ export default function WorkOrdersPage() {
                         >
                           Timeline
                         </Button>
-                        {canCompleteWorkOrder(item) ? (
+                        {!item.assignedContractorId && canCompleteWorkOrder(item) ? (
                           <Button
                             variant="ghost"
                             onClick={() => void markCompleted(item)}
                           >
-                            {item.assignedContractorId ? "Mark Completed" : "Mark Completed In-house"}
+                            Mark Completed In-house
                           </Button>
                         ) : null}
                         {item.status === "completed" && !item.linkedExpenseId ? (
@@ -343,6 +449,71 @@ export default function WorkOrdersPage() {
         {selected ? (
           <Card>
             <div style={{ fontWeight: 700, marginBottom: 8 }}>Timeline: {selected.title}</div>
+            <div
+              style={{
+                display: "grid",
+                gap: 10,
+                marginBottom: 12,
+                padding: 12,
+                border: "1px solid #e2e8f0",
+                borderRadius: 12,
+                background: "#f8fafc",
+              }}
+            >
+              <div style={{ fontWeight: 700 }}>Execution and completion</div>
+              <div style={{ display: "grid", gap: 8, gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))" }}>
+                <div>
+                  <div style={{ fontSize: 12, color: "#64748b" }}>Scheduled time</div>
+                  <div style={{ marginTop: 4, fontWeight: 600 }}>{formatDate(selected.scheduledFor)}</div>
+                </div>
+                <div>
+                  <div style={{ fontSize: 12, color: "#64748b" }}>Service started</div>
+                  <div style={{ marginTop: 4, fontWeight: 600 }}>
+                    {formatDate(selected.serviceStartedAt || selected.startedAtMs)}
+                  </div>
+                </div>
+                <div>
+                  <div style={{ fontSize: 12, color: "#64748b" }}>Service completed</div>
+                  <div style={{ marginTop: 4, fontWeight: 600 }}>
+                    {formatDate(selected.serviceCompletedAt || selected.completedAtMs)}
+                  </div>
+                </div>
+                <div>
+                  <div style={{ fontSize: 12, color: "#64748b" }}>Completion outcome</div>
+                  <div style={{ marginTop: 4, fontWeight: 600 }}>{completionOutcomeLabel(selected.completionOutcome)}</div>
+                </div>
+                <div>
+                  <div style={{ fontSize: 12, color: "#64748b" }}>Completed by</div>
+                  <div style={{ marginTop: 4, fontWeight: 600 }}>{selected.completedByActorRole || "-"}</div>
+                </div>
+                <div>
+                  <div style={{ fontSize: 12, color: "#64748b" }}>Landlord confirmation</div>
+                  <div style={{ marginTop: 4, fontWeight: 600 }}>
+                    {selected.completionConfirmedByLandlordAt
+                      ? `Confirmed ${formatDate(selected.completionConfirmedByLandlordAt)}`
+                      : "Awaiting review"}
+                  </div>
+                </div>
+              </div>
+              {selected.executionBlockedReason ? (
+                <div>
+                  <div style={{ fontSize: 12, color: "#64748b" }}>Blocked reason</div>
+                  <div style={{ marginTop: 4 }}>{selected.executionBlockedReason}</div>
+                </div>
+              ) : null}
+              {selected.completionSummary ? (
+                <div>
+                  <div style={{ fontSize: 12, color: "#64748b" }}>Completion summary</div>
+                  <div style={{ marginTop: 4, whiteSpace: "pre-wrap" }}>{selected.completionSummary}</div>
+                </div>
+              ) : null}
+              {selected.reopenReason ? (
+                <div>
+                  <div style={{ fontSize: 12, color: "#64748b" }}>Last reopen reason</div>
+                  <div style={{ marginTop: 4 }}>{selected.reopenReason}</div>
+                </div>
+              ) : null}
+            </div>
             <div style={{ display: "grid", gap: 8, maxHeight: 320, overflow: "auto", paddingRight: 4 }}>
               {updates.length === 0 ? (
                 <div style={{ color: "#64748b" }}>No updates yet.</div>
@@ -356,6 +527,73 @@ export default function WorkOrdersPage() {
                   </div>
                 ))
               )}
+            </div>
+            <div
+              style={{
+                display: "grid",
+                gap: 8,
+                marginTop: 10,
+                padding: 12,
+                border: "1px solid #e2e8f0",
+                borderRadius: 12,
+                background: "#f8fafc",
+              }}
+            >
+              <div style={{ fontWeight: 700 }}>Completion review</div>
+              {!selected.assignedContractorId && canCompleteWorkOrder(selected) ? (
+                <>
+                  <textarea
+                    value={completionSummary}
+                    onChange={(e) => setCompletionSummary(e.target.value)}
+                    placeholder="Summarize what was completed for this in-house job"
+                    rows={3}
+                    style={{ width: "100%", borderRadius: 8, border: "1px solid #cbd5e1", padding: 8, resize: "vertical" }}
+                  />
+                  <select
+                    value={completionOutcome}
+                    onChange={(e) =>
+                      setCompletionOutcome(e.target.value as "completed" | "partially_completed" | "follow_up_required")
+                    }
+                    style={{ width: "100%", borderRadius: 8, border: "1px solid #cbd5e1", padding: 8 }}
+                  >
+                    <option value="completed">Completed</option>
+                    <option value="partially_completed">Partially completed</option>
+                    <option value="follow_up_required">Follow-up required</option>
+                  </select>
+                  <Button disabled={savingAction} onClick={() => void markCompleted(selected)}>
+                    {savingAction ? "Saving..." : "Complete In-house"}
+                  </Button>
+                </>
+              ) : null}
+              {canConfirmCompletion(selected) ? (
+                <Button disabled={savingAction} onClick={() => void handleConfirmCompletion(selected)}>
+                  {savingAction ? "Saving..." : "Confirm completion"}
+                </Button>
+              ) : null}
+              {canReopenWorkOrder(selected) ? (
+                <>
+                  <textarea
+                    value={reopenReason}
+                    onChange={(e) => setReopenReason(e.target.value)}
+                    placeholder="Explain why this work order needs follow-up"
+                    rows={3}
+                    style={{ width: "100%", borderRadius: 8, border: "1px solid #cbd5e1", padding: 8, resize: "vertical" }}
+                  />
+                  <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                    <Button variant="secondary" disabled={savingAction} onClick={() => void handleReopen(selected, "in_progress")}>
+                      {savingAction ? "Saving..." : "Reopen in progress"}
+                    </Button>
+                    <Button variant="ghost" disabled={savingAction} onClick={() => void handleReopen(selected, "blocked")}>
+                      {savingAction ? "Saving..." : "Reopen blocked"}
+                    </Button>
+                  </div>
+                </>
+              ) : null}
+              {!selected.assignedContractorId && canCompleteWorkOrder(selected) ? null : !canConfirmCompletion(selected) && !canReopenWorkOrder(selected) ? (
+                <div style={{ color: "#64748b" }}>
+                  Execution details are up to date. Review the timeline for the latest operational context.
+                </div>
+              ) : null}
             </div>
             <div style={{ display: "grid", gap: 8, marginTop: 10 }}>
               <textarea


### PR DESCRIPTION
## Summary
Adds structured maintenance service execution and completion tracking on top of the existing work-order workflow.

This PR makes maintenance jobs operationally meaningful beyond status flips by adding structured execution metadata to `workOrders`, extending contractor execution updates, and giving landlords a clear completion review flow.

## Scope
- structured execution/completion metadata on work orders
- contractor schedule / start / block / complete updates
- landlord completion review, confirm-completion, and reopen flow
- richer landlord execution/completion detail UI
- richer contractor job action UI
- focused backend and frontend tests

## Execution lifecycle
The workflow now supports clearer operational states:
- assigned
- scheduled
- in progress
- blocked
- completed
- cancelled

Structured execution fields include:
- scheduled time
- service started/completed timestamps
- blocked reason
- completion summary
- completion outcome
- completed-by actor metadata
- landlord completion confirmation
- reopen metadata

## Implementation notes
- `workOrders` remain the canonical operational source of truth
- contractor execution updates extend the existing `PATCH /contractor/jobs/:id/status` flow
- landlord review adds:
  - `POST /landlord/work-orders/:id/confirm-completion`
  - `POST /landlord/work-orders/:id/reopen`
- in-house landlord completion now writes structured completion metadata instead of only flipping status
- maintenance requests only mirror a safe subset of execution/completion state for compatibility

## Validation
- focused frontend tests passed
- focused backend tests passed
- frontend build passed
- backend build passed

## Limitations
- no calendar/dispatch redesign
- no photo uploads
- no messaging overhaul
- no billing or contractor payment workflow changes
- tenant-facing exposure remains whitelist-safe and minimal