### PR TITLE
feat(maintenance): add evidence and photo attachments v1

### DIFF
--- a/rentchain-api/src/lib/workOrderEvidence.ts
+++ b/rentchain-api/src/lib/workOrderEvidence.ts
@@ -1,0 +1,141 @@
+import crypto from "crypto";
+import path from "path";
+import { getSignedDownloadUrl } from "./gcsSignedUrl";
+
+export const WORK_ORDER_EVIDENCE_TYPES = [
+  "before",
+  "during",
+  "after",
+  "completion",
+  "inspection",
+  "damage",
+  "other",
+] as const;
+
+export const WORK_ORDER_EVIDENCE_VISIBILITIES = ["internal", "landlord_contractor", "tenant_safe"] as const;
+
+export type WorkOrderEvidenceType = (typeof WORK_ORDER_EVIDENCE_TYPES)[number];
+export type WorkOrderEvidenceVisibility = (typeof WORK_ORDER_EVIDENCE_VISIBILITIES)[number];
+export type WorkOrderEvidenceAudience = "landlord" | "contractor" | "tenant";
+
+export type WorkOrderEvidenceItem = {
+  id: string;
+  storagePath?: string | null;
+  url?: string | null;
+  filename?: string | null;
+  contentType?: string | null;
+  uploadedAt: number;
+  uploadedByActorRole: "contractor" | "landlord" | "admin";
+  uploadedByActorId: string;
+  evidenceType: WorkOrderEvidenceType;
+  caption?: string | null;
+  visibility: WorkOrderEvidenceVisibility;
+};
+
+function asString(value: unknown, max = 2000): string {
+  return String(value || "").trim().slice(0, max);
+}
+
+export function normalizeEvidenceType(value: unknown): WorkOrderEvidenceType | null {
+  const next = asString(value, 60).toLowerCase();
+  return (WORK_ORDER_EVIDENCE_TYPES as readonly string[]).includes(next) ? (next as WorkOrderEvidenceType) : null;
+}
+
+export function normalizeEvidenceVisibility(value: unknown): WorkOrderEvidenceVisibility | null {
+  const next = asString(value, 60).toLowerCase();
+  return (WORK_ORDER_EVIDENCE_VISIBILITIES as readonly string[]).includes(next)
+    ? (next as WorkOrderEvidenceVisibility)
+    : null;
+}
+
+export function sanitizeFilename(filename: unknown) {
+  const raw = asString(filename, 180);
+  const base = raw || "evidence-upload";
+  return base.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "") || "evidence-upload";
+}
+
+export function makeEvidenceId() {
+  return crypto.randomUUID();
+}
+
+export function buildEvidenceStoragePath(params: { workOrderId: string; evidenceId: string; filename: string }) {
+  const safeName = sanitizeFilename(params.filename);
+  const ext = path.extname(safeName);
+  const basename = safeName.slice(0, safeName.length - ext.length) || "evidence";
+  return `work-orders/evidence/${params.workOrderId}/${params.evidenceId}_${basename}${ext}`;
+}
+
+export function filterEvidenceForAudience(
+  items: unknown,
+  audience: WorkOrderEvidenceAudience
+): WorkOrderEvidenceItem[] {
+  const list = Array.isArray(items) ? items : [];
+  return list
+    .map((entry) => {
+      const evidenceType = normalizeEvidenceType((entry as any)?.evidenceType);
+      const visibility = normalizeEvidenceVisibility((entry as any)?.visibility);
+      const uploadedByActorRole = asString((entry as any)?.uploadedByActorRole, 40).toLowerCase();
+      const uploadedAt = Number((entry as any)?.uploadedAt || 0);
+      const uploadedByActorId = asString((entry as any)?.uploadedByActorId, 120);
+      if (
+        !evidenceType ||
+        !visibility ||
+        !uploadedAt ||
+        !uploadedByActorId ||
+        (uploadedByActorRole !== "contractor" && uploadedByActorRole !== "landlord" && uploadedByActorRole !== "admin")
+      ) {
+        return null;
+      }
+      return {
+        id: asString((entry as any)?.id, 120) || makeEvidenceId(),
+        storagePath: asString((entry as any)?.storagePath, 500) || null,
+        filename: asString((entry as any)?.filename, 180) || null,
+        contentType: asString((entry as any)?.contentType, 120) || null,
+        uploadedAt,
+        uploadedByActorRole,
+        uploadedByActorId,
+        evidenceType,
+        caption: asString((entry as any)?.caption, 500) || null,
+        visibility,
+      } as WorkOrderEvidenceItem;
+    })
+    .filter((entry): entry is WorkOrderEvidenceItem => Boolean(entry))
+    .filter((entry) => {
+      if (audience === "landlord") return true;
+      if (audience === "contractor") return entry.visibility !== "internal";
+      return entry.visibility === "tenant_safe";
+    })
+    .sort((a, b) => Number(b.uploadedAt || 0) - Number(a.uploadedAt || 0));
+}
+
+export async function serializeEvidenceForAudience(
+  items: unknown,
+  audience: WorkOrderEvidenceAudience
+): Promise<Array<Omit<WorkOrderEvidenceItem, "storagePath">>> {
+  const bucket = asString(process.env.GCS_UPLOAD_BUCKET, 200);
+  const filtered = filterEvidenceForAudience(items, audience);
+  return await Promise.all(
+    filtered.map(async (entry) => {
+      let url: string | null = null;
+      if (bucket && entry.storagePath) {
+        try {
+          url = await getSignedDownloadUrl({ bucket, path: entry.storagePath, expiresMinutes: 30 });
+        } catch {
+          url = null;
+        }
+      }
+      return {
+        id: entry.id,
+        url,
+        filename: entry.filename || null,
+        contentType: entry.contentType || null,
+        uploadedAt: entry.uploadedAt,
+        uploadedByActorRole: entry.uploadedByActorRole,
+        uploadedByActorId: entry.uploadedByActorId,
+        evidenceType: entry.evidenceType,
+        caption: entry.caption || null,
+        visibility: entry.visibility,
+      };
+    })
+  );
+}

--- a/rentchain-api/src/routes/__tests__/maintenanceRequestsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/maintenanceRequestsRoutes.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const uploadBufferToGcsMock = vi.fn();
+const getSignedDownloadUrlMock = vi.fn();
+
 const collections = new Map<string, Map<string, any>>();
 
 function ensureCollection(name: string) {
@@ -73,11 +76,32 @@ vi.mock("../../services/emailService", () => ({
   sendEmail: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("multer", () => {
+  const factory = Object.assign(
+    () => ({
+      single: () => (req: any, _res: any, next: any) => next(),
+    }),
+    {
+      memoryStorage: () => ({}),
+    }
+  );
+  return { default: factory };
+});
+
+vi.mock("../../lib/gcs", () => ({
+  uploadBufferToGcs: uploadBufferToGcsMock,
+}));
+
+vi.mock("../../lib/gcsSignedUrl", () => ({
+  getSignedDownloadUrl: getSignedDownloadUrlMock,
+}));
+
 describe("maintenanceRequestsRoutes scheduling access", () => {
   async function invokeRouter(router: any, options: {
     method: string;
     url: string;
     body?: any;
+    file?: any;
     headers?: Record<string, string>;
   }) {
     return await new Promise<{ status: number; body: any }>((resolve, reject) => {
@@ -87,6 +111,7 @@ describe("maintenanceRequestsRoutes scheduling access", () => {
         originalUrl: options.url,
         path: options.url,
         body: options.body ?? {},
+        file: options.file,
         headers: options.headers ?? {},
       };
       const res: any = {
@@ -113,6 +138,9 @@ describe("maintenanceRequestsRoutes scheduling access", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     collections.clear();
+    process.env.GCS_UPLOAD_BUCKET = "test-bucket";
+    uploadBufferToGcsMock.mockResolvedValue(undefined);
+    getSignedDownloadUrlMock.mockImplementation(async ({ path }: { path: string }) => `https://signed.example/${path}`);
     ensureCollection("maintenanceRequests").set("maint-1", {
       id: "maint-1",
       landlordId: "landlord-1",
@@ -300,5 +328,91 @@ describe("maintenanceRequestsRoutes scheduling access", () => {
     expect(savedWorkOrder?.completionSummary).toMatch(/Replaced the thermostat/i);
     expect(savedWorkOrder?.completedByActorRole).toBe("contractor");
     expect(savedWorkOrder?.completedByActorId).toBe("contractor-1");
+  });
+
+  it("allows an assigned contractor to upload evidence for their job", async () => {
+    const router = (await import("../maintenanceRequestsRoutes")).default;
+
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/contractor/jobs/maint-1/evidence",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "contractor-1",
+          role: "contractor",
+        }),
+      },
+      body: {
+        evidenceType: "during",
+        caption: "Valve replacement in progress",
+      },
+      file: {
+        originalname: "during.jpg",
+        mimetype: "image/jpeg",
+        buffer: Buffer.from("photo"),
+      },
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body?.item?.evidence?.[0]?.caption).toBe("Valve replacement in progress");
+
+    const savedWorkOrder = ensureCollection("workOrders").get("maintenance_maint-1");
+    expect(savedWorkOrder?.evidence?.[0]?.visibility).toBe("landlord_contractor");
+  });
+
+  it("rejects contractor evidence uploads for unassigned jobs", async () => {
+    const router = (await import("../maintenanceRequestsRoutes")).default;
+    ensureCollection("maintenanceRequests").set("maint-1", {
+      ...ensureCollection("maintenanceRequests").get("maint-1"),
+      assignedContractorId: "contractor-2",
+    });
+
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/contractor/jobs/maint-1/evidence",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "contractor-1",
+          role: "contractor",
+        }),
+      },
+      body: {
+        evidenceType: "during",
+      },
+      file: {
+        originalname: "during.jpg",
+        mimetype: "image/jpeg",
+        buffer: Buffer.from("photo"),
+      },
+    });
+
+    expect(res.status).toBe(403);
+    expect(res.body?.error).toBe("FORBIDDEN");
+  });
+
+  it("rejects unsupported contractor evidence file types", async () => {
+    const router = (await import("../maintenanceRequestsRoutes")).default;
+
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/contractor/jobs/maint-1/evidence",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "contractor-1",
+          role: "contractor",
+        }),
+      },
+      body: {
+        evidenceType: "during",
+      },
+      file: {
+        originalname: "during.txt",
+        mimetype: "text/plain",
+        buffer: Buffer.from("photo"),
+      },
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body?.error).toBe("UNSUPPORTED_FILE_TYPE");
   });
 });

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const getSignedDownloadUrlMock = vi.fn();
+
 const collections = new Map<string, Map<string, any>>();
 
 function ensureCollection(name: string) {
@@ -90,6 +92,10 @@ vi.mock("../../middleware/authMiddleware", () => ({
   },
 }));
 
+vi.mock("../../lib/gcsSignedUrl", () => ({
+  getSignedDownloadUrl: getSignedDownloadUrlMock,
+}));
+
 describe("tenantPortalRoutes foundation", () => {
   async function invokeRouter(router: any, options: {
     method: string;
@@ -133,6 +139,9 @@ describe("tenantPortalRoutes foundation", () => {
 
   beforeEach(() => {
     collections.clear();
+    process.env.GCS_UPLOAD_BUCKET = "test-bucket";
+    getSignedDownloadUrlMock.mockReset();
+    getSignedDownloadUrlMock.mockImplementation(async ({ path }: { path: string }) => `https://signed.example/${path}`);
     ensureCollection("properties").set("prop-1", {
       rc_prop_id: "rc-prop-1",
       street1: "123 Main St",
@@ -197,6 +206,35 @@ describe("tenantPortalRoutes foundation", () => {
       createdAt: 100,
       updatedAt: 200,
       internalCost: 999,
+    });
+    ensureCollection("workOrders").set("maintenance_maint-1", {
+      maintenanceRequestId: "maint-1",
+      evidence: [
+        {
+          id: "evidence-tenant",
+          storagePath: "work-orders/evidence/maintenance_maint-1/tenant.jpg",
+          filename: "tenant.jpg",
+          contentType: "image/jpeg",
+          uploadedAt: 250,
+          uploadedByActorRole: "landlord",
+          uploadedByActorId: "landlord-1",
+          evidenceType: "completion",
+          caption: "Tenant-safe completion photo",
+          visibility: "tenant_safe",
+        },
+        {
+          id: "evidence-internal",
+          storagePath: "work-orders/evidence/maintenance_maint-1/internal.jpg",
+          filename: "internal.jpg",
+          contentType: "image/jpeg",
+          uploadedAt: 260,
+          uploadedByActorRole: "landlord",
+          uploadedByActorId: "landlord-1",
+          evidenceType: "damage",
+          caption: "Internal review photo",
+          visibility: "internal",
+        },
+      ],
     });
     ensureCollection("tenancy_invites").set("invite-1", {
       token_hash: "invite-1",
@@ -368,6 +406,32 @@ describe("tenantPortalRoutes foundation", () => {
         expect.objectContaining({ message: "Tenant acknowledged the access requirement." }),
       ])
     );
+  });
+
+  it("returns only tenant-safe maintenance evidence in the detail payload", async () => {
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/maintenance-requests/maint-1",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.evidence).toEqual([
+      expect.objectContaining({
+        id: "evidence-tenant",
+        caption: "Tenant-safe completion photo",
+        visibility: "tenant_safe",
+      }),
+    ]);
+    expect(JSON.stringify(res.body?.data?.evidence || [])).not.toMatch(/internal review/i);
   });
 
   it("rejects unauthorized application completion access", async () => {

--- a/rentchain-api/src/routes/__tests__/workOrdersRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/workOrdersRoutes.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const uploadBufferToGcsMock = vi.fn();
+const getSignedDownloadUrlMock = vi.fn();
+
 const collections = new Map<string, Map<string, any>>();
 
 function ensureCollection(name: string) {
@@ -69,6 +72,26 @@ vi.mock("../../services/emailService", () => ({
   sendEmail: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("multer", () => {
+  const factory = Object.assign(
+    () => ({
+      single: () => (req: any, _res: any, next: any) => next(),
+    }),
+    {
+      memoryStorage: () => ({}),
+    }
+  );
+  return { default: factory };
+});
+
+vi.mock("../../lib/gcs", () => ({
+  uploadBufferToGcs: uploadBufferToGcsMock,
+}));
+
+vi.mock("../../lib/gcsSignedUrl", () => ({
+  getSignedDownloadUrl: getSignedDownloadUrlMock,
+}));
+
 describe("workOrdersRoutes execution completion", () => {
   async function invokeRouter(
     router: any,
@@ -76,6 +99,7 @@ describe("workOrdersRoutes execution completion", () => {
       method: string;
       url: string;
       body?: any;
+      file?: any;
       headers?: Record<string, string>;
     }
   ) {
@@ -86,6 +110,7 @@ describe("workOrdersRoutes execution completion", () => {
         originalUrl: options.url,
         path: options.url,
         body: options.body ?? {},
+        file: options.file,
         headers: options.headers ?? {},
       };
       const res: any = {
@@ -112,6 +137,9 @@ describe("workOrdersRoutes execution completion", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     collections.clear();
+    process.env.GCS_UPLOAD_BUCKET = "test-bucket";
+    uploadBufferToGcsMock.mockResolvedValue(undefined);
+    getSignedDownloadUrlMock.mockImplementation(async ({ path }: { path: string }) => `https://signed.example/${path}`);
     ensureCollection("maintenanceRequests").set("maint-1", {
       id: "maint-1",
       landlordId: "landlord-1",
@@ -237,5 +265,89 @@ describe("workOrdersRoutes execution completion", () => {
     const savedWorkOrder = ensureCollection("workOrders").get("wo-1");
     expect(savedWorkOrder?.reopenReason).toMatch(/Heating issue still present/i);
     expect(savedWorkOrder?.executionBlockedReason).toMatch(/Heating issue still present/i);
+  });
+
+  it("allows a landlord to upload evidence and update its visibility", async () => {
+    const router = (await import("../workOrdersRoutes")).default;
+
+    const uploadRes = await invokeRouter(router, {
+      method: "POST",
+      url: "/landlord/work-orders/wo-1/evidence",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "landlord-1",
+          role: "landlord",
+          landlordId: "landlord-1",
+        }),
+      },
+      body: {
+        evidenceType: "inspection",
+        caption: "Inspection proof",
+        visibility: "internal",
+      },
+      file: {
+        originalname: "inspection.jpg",
+        mimetype: "image/jpeg",
+        buffer: Buffer.from("photo"),
+      },
+    });
+
+    expect(uploadRes.status).toBe(201);
+    expect(uploadRes.body?.item?.evidence?.[0]?.caption).toBe("Inspection proof");
+    expect(uploadBufferToGcsMock).toHaveBeenCalled();
+
+    const savedWorkOrder = ensureCollection("workOrders").get("wo-1");
+    const savedEvidenceId = savedWorkOrder?.evidence?.[0]?.id;
+    expect(savedEvidenceId).toBeTruthy();
+    expect(Array.from(ensureCollection("workOrderUpdates").values())).toEqual(
+      expect.arrayContaining([expect.objectContaining({ updateType: "photo" })])
+    );
+
+    const patchRes = await invokeRouter(router, {
+      method: "PATCH",
+      url: `/landlord/work-orders/wo-1/evidence/${savedEvidenceId}`,
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "landlord-1",
+          role: "landlord",
+          landlordId: "landlord-1",
+        }),
+      },
+      body: {
+        visibility: "tenant_safe",
+        caption: "Tenant-safe proof",
+      },
+    });
+
+    expect(patchRes.status).toBe(200);
+    expect(patchRes.body?.item?.evidence?.[0]?.visibility).toBe("tenant_safe");
+  });
+
+  it("rejects unsupported evidence file types", async () => {
+    const router = (await import("../workOrdersRoutes")).default;
+
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/landlord/work-orders/wo-1/evidence",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "landlord-1",
+          role: "landlord",
+          landlordId: "landlord-1",
+        }),
+      },
+      body: {
+        evidenceType: "inspection",
+        visibility: "internal",
+      },
+      file: {
+        originalname: "notes.txt",
+        mimetype: "text/plain",
+        buffer: Buffer.from("hello"),
+      },
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body?.error).toBe("UNSUPPORTED_FILE_TYPE");
   });
 });

--- a/rentchain-api/src/routes/maintenanceRequestsRoutes.ts
+++ b/rentchain-api/src/routes/maintenanceRequestsRoutes.ts
@@ -1,9 +1,18 @@
 import { Router } from "express";
+import multer from "multer";
 import { db, FieldValue } from "../config/firebase";
 import { authenticateJwt } from "../middleware/authMiddleware";
 import { verifyAuthToken } from "../auth/jwt";
 import { buildEmailHtml, buildEmailText } from "../email/templates/baseEmailTemplate";
 import { sendEmail } from "../services/emailService";
+import { uploadBufferToGcs } from "../lib/gcs";
+import {
+  buildEvidenceStoragePath,
+  makeEvidenceId,
+  normalizeEvidenceType,
+  serializeEvidenceForAudience,
+  type WorkOrderEvidenceItem,
+} from "../lib/workOrderEvidence";
 
 const router = Router();
 
@@ -74,6 +83,12 @@ const LEGACY_TO_WORKFLOW_STATUS: Record<string, (typeof WORKFLOW_STATUSES)[numbe
   RESOLVED: "completed",
   CLOSED: "completed",
 };
+const MAX_EVIDENCE_BYTES = 10 * 1024 * 1024;
+const evidenceUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: MAX_EVIDENCE_BYTES },
+});
+const ALLOWED_EVIDENCE_MIME_TYPES = new Set(["image/jpeg", "image/png", "image/webp"]);
 
 router.use(authenticateJwt);
 
@@ -258,6 +273,11 @@ function cleanString(value: any, max = 200): string | null {
   return text.slice(0, max);
 }
 
+function isAllowedEvidenceFile(file: Express.Multer.File | undefined) {
+  if (!file?.buffer || !file.originalname) return false;
+  return ALLOWED_EVIDENCE_MIME_TYPES.has(String(file.mimetype || "").toLowerCase());
+}
+
 function normalizeOptionalBoolean(value: any): boolean | null | undefined {
   if (value === undefined) return undefined;
   if (value === null || value === "") return null;
@@ -418,6 +438,7 @@ type WorkOrderExecutionUpdateType =
   | "scheduled"
   | "started"
   | "blocked"
+  | "photo"
   | "completed"
   | "confirmed"
   | "reopened";
@@ -720,7 +741,7 @@ async function upsertMaintenanceWorkOrder(input: {
   return { workOrderId, payload };
 }
 
-function shapeContractorJobFromSources(workOrder: any, maintenance: any) {
+async function shapeContractorJobFromSources(workOrder: any, maintenance: any) {
   const maintenanceId =
     String(workOrder?.maintenanceRequestId || maintenance?.id || "").trim() || String(workOrder?.id || "").trim();
   const status = normalizeWorkflowStatus(workOrder?.status || maintenance?.status) || "assigned";
@@ -782,6 +803,7 @@ function shapeContractorJobFromSources(workOrder: any, maintenance: any) {
     updatedAt:
       Number(maintenance?.updatedAt || workOrder?.updatedAt || workOrder?.updatedAtMs || Date.now()) || Date.now(),
     statusHistory: Array.isArray(maintenance?.statusHistory) ? maintenance.statusHistory : [],
+    evidence: await serializeEvidenceForAudience(workOrder?.evidence, "contractor"),
   };
 }
 
@@ -1658,9 +1680,13 @@ router.get("/contractor/jobs", async (req: any, res) => {
       maintenanceDocs.filter((item): item is any => Boolean(item)).map((item) => [String(item.id), item])
     );
 
-    let items = workOrders
-      .map((workOrder) => shapeContractorJobFromSources(workOrder, maintenanceMap.get(String(workOrder.maintenanceRequestId || "").trim()) || null))
-      .filter((item) => Boolean(item?.id) && Boolean(item?.title) && Boolean(item?.description));
+    let items = (
+      await Promise.all(
+        workOrders.map((workOrder) =>
+          shapeContractorJobFromSources(workOrder, maintenanceMap.get(String(workOrder.maintenanceRequestId || "").trim()) || null)
+        )
+      )
+    ).filter((item) => Boolean(item?.id) && Boolean(item?.title) && Boolean(item?.description));
     if (statusFilter) {
       items = items.filter((item) => normalizeWorkflowStatus(item.status) === statusFilter);
     }
@@ -1902,6 +1928,134 @@ router.patch("/contractor/jobs/:id/status", async (req: any, res) => {
     });
     return res.status(500).json({ ok: false, error: "CONTRACTOR_MAINTENANCE_PATCH_FAILED" });
   }
+});
+
+router.post("/contractor/jobs/:id/evidence", async (req: any, res) => {
+  evidenceUpload.single("file")(req, res, async (uploadErr: any) => {
+    try {
+      if (uploadErr) {
+        const message = String(uploadErr?.message || "");
+        if (String(uploadErr?.code || "") === "LIMIT_FILE_SIZE") {
+          return res.status(400).json({ ok: false, error: "FILE_TOO_LARGE", maxBytes: MAX_EVIDENCE_BYTES });
+        }
+        return res.status(400).json({ ok: false, error: "UPLOAD_FAILED", detail: message || "upload_failed" });
+      }
+
+      const access = await resolveContractorAccess(req);
+      if (access.role !== "contractor" && access.role !== "admin") {
+        return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+      }
+      const contractorId = access.contractorId;
+      const id = String(req.params?.id || "").trim();
+      if (!contractorId) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+      const actorId = String(req.user?.id || "").trim() || contractorId;
+      if (!id) return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+
+      const maintenanceRef = db.collection("maintenanceRequests").doc(id);
+      const maintenanceSnap = await maintenanceRef.get();
+      if (!maintenanceSnap.exists) return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+      const maintenance = { id: maintenanceSnap.id, ...(maintenanceSnap.data() as any) };
+      if (String(maintenance.assignedContractorId || "") !== contractorId) {
+        return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+      }
+
+      const file = req.file as Express.Multer.File | undefined;
+      if (!file?.buffer || !file.originalname) {
+        return res.status(400).json({ ok: false, error: "FILE_REQUIRED" });
+      }
+      if (!isAllowedEvidenceFile(file)) {
+        return res.status(400).json({ ok: false, error: "UNSUPPORTED_FILE_TYPE" });
+      }
+
+      const evidenceType = normalizeEvidenceType(req.body?.evidenceType);
+      if (!evidenceType || !["before", "during", "after", "completion", "other"].includes(evidenceType)) {
+        return res.status(400).json({ ok: false, error: "INVALID_EVIDENCE_TYPE" });
+      }
+
+      const now = Date.now();
+      const workOrder = await upsertMaintenanceWorkOrder({
+        maintenanceRequestId: id,
+        landlordId: String(maintenance.landlordId || "").trim() || null,
+        propertyId: String(maintenance.propertyId || "").trim() || null,
+        unitId: String(maintenance.unitId || "").trim() || null,
+        tenantId: String(maintenance.tenantId || "").trim() || null,
+        assignedContractorId: contractorId,
+        assignedContractorName: String(maintenance.assignedContractorName || "").trim() || null,
+        title: String(maintenance.title || "").trim() || null,
+        description: String(maintenance.description || "").trim() || null,
+        category: String(maintenance.category || "").trim() || null,
+        priority: String(maintenance.priority || "").trim() || null,
+        status: normalizeWorkflowStatus(maintenance.status) || "assigned",
+        serviceWindowStartAt: toMillis(maintenance.serviceWindowStartAt),
+        serviceWindowEndAt: toMillis(maintenance.serviceWindowEndAt),
+        accessRequired: typeof maintenance.accessRequired === "boolean" ? maintenance.accessRequired : null,
+      });
+
+      const evidenceId = makeEvidenceId();
+      const storagePath = buildEvidenceStoragePath({
+        workOrderId: workOrder.workOrderId,
+        evidenceId,
+        filename: file.originalname,
+      });
+      await uploadBufferToGcs({
+        path: storagePath,
+        contentType: String(file.mimetype || "application/octet-stream"),
+        buffer: file.buffer,
+        metadata: {
+          workOrderId: workOrder.workOrderId,
+          maintenanceRequestId: id,
+          evidenceType,
+          visibility: "landlord_contractor",
+          uploadedAtMs: String(now),
+          actorRole: access.role === "admin" ? "admin" : "contractor",
+          actorId,
+        },
+      });
+
+      const workOrderRef = db.collection("workOrders").doc(workOrder.workOrderId);
+      const currentWorkOrderSnap = await workOrderRef.get();
+      const currentWorkOrder = currentWorkOrderSnap.exists ? ((currentWorkOrderSnap.data() as any) || {}) : {};
+      const evidenceItem: WorkOrderEvidenceItem = {
+        id: evidenceId,
+        storagePath,
+        filename: String(file.originalname || "").trim() || null,
+        contentType: String(file.mimetype || "").trim() || null,
+        uploadedAt: now,
+        uploadedByActorRole: access.role === "admin" ? "admin" : "contractor",
+        uploadedByActorId: actorId,
+        evidenceType,
+        caption: String(req.body?.caption || "").trim().slice(0, 500) || null,
+        visibility: "landlord_contractor",
+      };
+      await workOrderRef.set(
+        {
+          evidence: [...(Array.isArray(currentWorkOrder.evidence) ? currentWorkOrder.evidence : []), evidenceItem],
+          updatedAtMs: now,
+          lastExecutionUpdateAt: now,
+        },
+        { merge: true }
+      );
+
+      await appendWorkOrderUpdate(workOrder.workOrderId, {
+        actorRole: access.role === "admin" ? "admin" : "contractor",
+        actorId,
+        updateType: "photo",
+        message: `Uploaded ${evidenceType} evidence photo${evidenceItem.caption ? `: ${evidenceItem.caption}` : ""}`,
+      });
+
+      const refreshedWorkOrderSnap = await workOrderRef.get();
+      const refreshedJob = await shapeContractorJobFromSources(
+        { id: refreshedWorkOrderSnap.id, ...(refreshedWorkOrderSnap.data() || {}) },
+        maintenance
+      );
+      return res.status(201).json({ ok: true, item: refreshedJob, data: refreshedJob, workOrderId: workOrder.workOrderId });
+    } catch (err: any) {
+      console.error("[maintenance-v2] contractor evidence upload failed", {
+        message: err?.message || "failed",
+      });
+      return res.status(500).json({ ok: false, error: "CONTRACTOR_EVIDENCE_UPLOAD_FAILED" });
+    }
+  });
 });
 
 router.post("/rental-applications/:id/screening/request", async (req: any, res) => {

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -22,6 +22,7 @@ import {
   sendTenantCommunicationMessage,
 } from "../services/tenantPortal/tenantCommunicationsService";
 import { listTenantNotificationFeed } from "../services/tenantPortal/tenantNotificationsService";
+import { serializeEvidenceForAudience } from "../lib/workOrderEvidence";
 
 const router = Router();
 router.use(authenticateJwt);
@@ -4981,6 +4982,10 @@ router.get("/maintenance-requests/:id", requireTenant, async (req: any, res) => 
     if (data.tenantId && data.tenantId !== tenantId) {
       return res.status(403).json({ ok: false, error: "FORBIDDEN" });
     }
+    const workOrderSnap = await db.collection("workOrders").doc(`maintenance_${doc.id}`).get();
+    const tenantSafeEvidence = workOrderSnap.exists
+      ? await serializeEvidenceForAudience((workOrderSnap.data() as any)?.evidence, "tenant")
+      : [];
     const payload = {
       id: doc.id,
       requestId: doc.id,
@@ -5004,6 +5009,7 @@ router.get("/maintenance-requests/:id", requireTenant, async (req: any, res) => 
           : null,
       tenantConfirmationUpdatedAt: toMillis(data.tenantConfirmationUpdatedAt),
       accessAcknowledgedAt: toMillis(data.accessAcknowledgedAt),
+      evidence: tenantSafeEvidence,
       tenantContact: data.tenantContact ?? null,
       createdAt: toMillis(data.createdAt),
       updatedAt: toMillis(data.updatedAt),

--- a/rentchain-api/src/routes/workOrdersRoutes.ts
+++ b/rentchain-api/src/routes/workOrdersRoutes.ts
@@ -1,9 +1,19 @@
 import { Router } from "express";
 import crypto from "crypto";
+import multer from "multer";
 import { db, FieldValue } from "../config/firebase";
 import { requireAuth } from "../middleware/requireAuth";
 import { sendEmail } from "../services/emailService";
 import { buildEmailHtml, buildEmailText } from "../email/templates/baseEmailTemplate";
+import { uploadBufferToGcs } from "../lib/gcs";
+import {
+  buildEvidenceStoragePath,
+  makeEvidenceId,
+  normalizeEvidenceType,
+  normalizeEvidenceVisibility,
+  serializeEvidenceForAudience,
+  type WorkOrderEvidenceItem,
+} from "../lib/workOrderEvidence";
 
 const router = Router();
 
@@ -34,6 +44,12 @@ const CONTRACTOR_INVITE_TTL_MS = Math.max(
   60_000,
   Number(process.env.CONTRACTOR_INVITE_TTL_MS || 7 * 24 * 60 * 60 * 1000)
 );
+const MAX_EVIDENCE_BYTES = 10 * 1024 * 1024;
+const evidenceUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: MAX_EVIDENCE_BYTES },
+});
+const ALLOWED_EVIDENCE_MIME_TYPES = new Set(["image/jpeg", "image/png", "image/webp"]);
 
 function nowMs() {
   return Date.now();
@@ -129,6 +145,19 @@ function isContractor(req: any): boolean {
 
 function toWorkOrderResponse(id: string, data: any) {
   return { id, ...(data || {}) };
+}
+
+async function toWorkOrderResponseForAudience(id: string, data: any, audience: "landlord" | "contractor") {
+  const item = toWorkOrderResponse(id, data);
+  return {
+    ...item,
+    evidence: await serializeEvidenceForAudience(item.evidence, audience),
+  };
+}
+
+function isAllowedEvidenceFile(file: Express.Multer.File | undefined) {
+  if (!file?.buffer || !file.originalname) return false;
+  return ALLOWED_EVIDENCE_MIME_TYPES.has(String(file.mimetype || "").toLowerCase());
 }
 
 function inviteIsExpired(invite: any, atMs = nowMs()) {
@@ -409,6 +438,28 @@ async function getWorkOrderAuthorized(req: any, workOrderId: string) {
   }
 
   return { ok: false as const, code: "FORBIDDEN" as const };
+}
+
+function buildEvidenceUploadMessage(item: WorkOrderEvidenceItem) {
+  const label = item.evidenceType.replace(/_/g, " ");
+  const caption = asString(item.caption, 180);
+  return caption ? `Uploaded ${label} evidence photo: ${caption}` : `Uploaded ${label} evidence photo`;
+}
+
+function replaceEvidenceItem(
+  current: unknown,
+  evidenceId: string,
+  updater: (item: WorkOrderEvidenceItem) => WorkOrderEvidenceItem
+) {
+  const list = Array.isArray(current) ? current : [];
+  return list.map((entry) => {
+    const normalized = {
+      ...(entry as any),
+      id: asString((entry as any)?.id, 120),
+    } as WorkOrderEvidenceItem;
+    if (normalized.id !== evidenceId) return entry;
+    return updater(normalized);
+  });
 }
 router.post("/contractor/profile", requireAuth, async (req: any, res) => {
   try {
@@ -1002,7 +1053,7 @@ router.get("/work-orders", requireAuth, async (req: any, res) => {
         .where("landlordId", "==", landlordId)
         .limit(500)
         .get();
-      let items = snap.docs.map((d) => toWorkOrderResponse(d.id, d.data()));
+      let items = await Promise.all(snap.docs.map((d) => toWorkOrderResponseForAudience(d.id, d.data(), "landlord")));
       if (statusFilter) items = items.filter((item) => String(item.status || "").toLowerCase() === statusFilter);
       items.sort((a, b) => Number(b.updatedAtMs || 0) - Number(a.updatedAtMs || 0));
       return res.json({ ok: true, items });
@@ -1016,7 +1067,7 @@ router.get("/work-orders", requireAuth, async (req: any, res) => {
 
       const map = new Map<string, any>();
       for (const doc of [...assignedSnap.docs, ...invitedSnap.docs]) {
-        const item = toWorkOrderResponse(doc.id, doc.data());
+        const item = await toWorkOrderResponseForAudience(doc.id, doc.data(), "contractor");
         const assigned = asString(item.assignedContractorId, 120);
         const invited = uniqueStrings(item.invitedContractorIds, 200);
         if (assigned === userId || invited.includes(userId)) {
@@ -1048,7 +1099,7 @@ router.get("/work-orders/:id", requireAuth, async (req: any, res) => {
       return res.status(403).json({ ok: false, error: "FORBIDDEN" });
     }
 
-    return res.json({ ok: true, item: access.item });
+    return res.json({ ok: true, item: await toWorkOrderResponseForAudience(access.item.id, access.item, access.role === "contractor" ? "contractor" : "landlord") });
   } catch (err) {
     console.error("[work-orders] get failed", err);
     return res.status(500).json({ ok: false, error: "WORK_ORDER_GET_FAILED" });
@@ -1190,7 +1241,7 @@ router.patch("/work-orders/:id", requireAuth, async (req: any, res) => {
         message: maintenanceHistoryMessage,
       });
     }
-    return res.json({ ok: true, item: toWorkOrderResponse(refreshed.id, refreshed.data()) });
+    return res.json({ ok: true, item: await toWorkOrderResponseForAudience(refreshed.id, refreshed.data(), "landlord") });
   } catch (err) {
     console.error("[work-orders] patch failed", err);
     return res.status(500).json({ ok: false, error: "WORK_ORDER_PATCH_FAILED" });
@@ -1244,7 +1295,7 @@ router.post("/work-orders/:id/accept", requireAuth, async (req: any, res) => {
     }
 
     const refreshed = await db.collection("workOrders").doc(workOrderId).get();
-    return res.json({ ok: true, item: toWorkOrderResponse(refreshed.id, refreshed.data()) });
+    return res.json({ ok: true, item: await toWorkOrderResponseForAudience(refreshed.id, refreshed.data(), access.role === "contractor" ? "contractor" : "landlord") });
   } catch (err) {
     console.error("[work-orders] accept failed", err);
     return res.status(500).json({ ok: false, error: "WORK_ORDER_ACCEPT_FAILED" });
@@ -1303,7 +1354,7 @@ router.post("/work-orders/:id/decline", requireAuth, async (req: any, res) => {
     }
 
     const refreshed = await db.collection("workOrders").doc(workOrderId).get();
-    return res.json({ ok: true, item: toWorkOrderResponse(refreshed.id, refreshed.data()) });
+    return res.json({ ok: true, item: await toWorkOrderResponseForAudience(refreshed.id, refreshed.data(), access.role === "contractor" ? "contractor" : "landlord") });
   } catch (err) {
     console.error("[work-orders] decline failed", err);
     return res.status(500).json({ ok: false, error: "WORK_ORDER_DECLINE_FAILED" });
@@ -1346,7 +1397,7 @@ router.post("/work-orders/:id/start", requireAuth, async (req: any, res) => {
     });
 
     const refreshed = await db.collection("workOrders").doc(workOrderId).get();
-    return res.json({ ok: true, item: toWorkOrderResponse(refreshed.id, refreshed.data()) });
+    return res.json({ ok: true, item: await toWorkOrderResponseForAudience(refreshed.id, refreshed.data(), access.role === "contractor" ? "contractor" : "landlord") });
   } catch (err) {
     console.error("[work-orders] start failed", err);
     return res.status(500).json({ ok: false, error: "WORK_ORDER_START_FAILED" });
@@ -1400,7 +1451,7 @@ router.post("/work-orders/:id/complete", requireAuth, async (req: any, res) => {
     }
 
     const refreshed = await db.collection("workOrders").doc(workOrderId).get();
-    return res.json({ ok: true, item: toWorkOrderResponse(refreshed.id, refreshed.data()) });
+    return res.json({ ok: true, item: await toWorkOrderResponseForAudience(refreshed.id, refreshed.data(), access.role === "contractor" ? "contractor" : "landlord") });
   } catch (err) {
     console.error("[work-orders] complete failed", err);
     return res.status(500).json({ ok: false, error: "WORK_ORDER_COMPLETE_FAILED" });
@@ -1454,7 +1505,7 @@ router.post("/landlord/work-orders/:id/confirm-completion", requireAuth, async (
     });
 
     const refreshed = await db.collection("workOrders").doc(workOrderId).get();
-    return res.json({ ok: true, item: toWorkOrderResponse(refreshed.id, refreshed.data()) });
+    return res.json({ ok: true, item: await toWorkOrderResponseForAudience(refreshed.id, refreshed.data(), "landlord") });
   } catch (err) {
     console.error("[work-orders] confirm completion failed", err);
     return res.status(500).json({ ok: false, error: "WORK_ORDER_CONFIRM_COMPLETION_FAILED" });
@@ -1519,10 +1570,164 @@ router.post("/landlord/work-orders/:id/reopen", requireAuth, async (req: any, re
     });
 
     const refreshed = await db.collection("workOrders").doc(workOrderId).get();
-    return res.json({ ok: true, item: toWorkOrderResponse(refreshed.id, refreshed.data()) });
+    return res.json({ ok: true, item: await toWorkOrderResponseForAudience(refreshed.id, refreshed.data(), "landlord") });
   } catch (err) {
     console.error("[work-orders] reopen failed", err);
     return res.status(500).json({ ok: false, error: "WORK_ORDER_REOPEN_FAILED" });
+  }
+});
+
+router.post("/landlord/work-orders/:id/evidence", requireAuth, async (req: any, res) => {
+  evidenceUpload.single("file")(req, res, async (uploadErr: any) => {
+    try {
+      if (uploadErr) {
+        const message = String(uploadErr?.message || "");
+        if (String(uploadErr?.code || "") === "LIMIT_FILE_SIZE") {
+          return res.status(400).json({ ok: false, error: "FILE_TOO_LARGE", maxBytes: MAX_EVIDENCE_BYTES });
+        }
+        return res.status(400).json({ ok: false, error: "UPLOAD_FAILED", detail: message || "upload_failed" });
+      }
+
+      if (!isLandlord(req)) return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+
+      const workOrderId = asString(req.params?.id, 120);
+      const access = await getWorkOrderAuthorized(req, workOrderId);
+      if (!access.ok) {
+        if (access.code === "NOT_FOUND") return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+        return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+      }
+
+      const file = req.file as Express.Multer.File | undefined;
+      if (!file?.buffer || !file.originalname) {
+        return res.status(400).json({ ok: false, error: "FILE_REQUIRED" });
+      }
+      if (!isAllowedEvidenceFile(file)) {
+        return res.status(400).json({ ok: false, error: "UNSUPPORTED_FILE_TYPE" });
+      }
+
+      const evidenceType = normalizeEvidenceType(req.body?.evidenceType);
+      const visibility = normalizeEvidenceVisibility(req.body?.visibility);
+      if (!evidenceType) return res.status(400).json({ ok: false, error: "INVALID_EVIDENCE_TYPE" });
+      if (!visibility) return res.status(400).json({ ok: false, error: "INVALID_VISIBILITY" });
+
+      const now = nowMs();
+      const evidenceId = makeEvidenceId();
+      const storagePath = buildEvidenceStoragePath({
+        workOrderId,
+        evidenceId,
+        filename: file.originalname,
+      });
+      await uploadBufferToGcs({
+        path: storagePath,
+        contentType: String(file.mimetype || "application/octet-stream"),
+        buffer: file.buffer,
+        metadata: {
+          workOrderId,
+          evidenceType,
+          visibility,
+          uploadedAtMs: String(now),
+          actorRole: isAdmin(req) ? "admin" : "landlord",
+          actorId: access.userId,
+        },
+      });
+
+      const evidenceItem: WorkOrderEvidenceItem = {
+        id: evidenceId,
+        storagePath,
+        filename: asString(file.originalname, 180),
+        contentType: asString(file.mimetype, 120),
+        uploadedAt: now,
+        uploadedByActorRole: isAdmin(req) ? "admin" : "landlord",
+        uploadedByActorId: access.userId,
+        evidenceType,
+        caption: asOptionalString(req.body?.caption, 500),
+        visibility,
+      };
+
+      const nextEvidence = [...(Array.isArray((access.item as any)?.evidence) ? (access.item as any).evidence : []), evidenceItem];
+      await db.collection("workOrders").doc(workOrderId).set(
+        {
+          evidence: nextEvidence,
+          updatedAtMs: now,
+          lastExecutionUpdateAt: now,
+        },
+        { merge: true }
+      );
+
+      await writeWorkOrderUpdate({
+        workOrderId,
+        actorRole: isAdmin(req) ? "admin" : "landlord",
+        actorId: access.userId,
+        updateType: "photo",
+        message: buildEvidenceUploadMessage(evidenceItem),
+      });
+
+      const refreshed = await db.collection("workOrders").doc(workOrderId).get();
+      return res.status(201).json({ ok: true, item: await toWorkOrderResponseForAudience(refreshed.id, refreshed.data(), "landlord") });
+    } catch (err) {
+      console.error("[work-orders] landlord evidence upload failed", err);
+      return res.status(500).json({ ok: false, error: "WORK_ORDER_EVIDENCE_UPLOAD_FAILED" });
+    }
+  });
+});
+
+router.patch("/landlord/work-orders/:id/evidence/:evidenceId", requireAuth, async (req: any, res) => {
+  try {
+    if (!isLandlord(req)) return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+
+    const workOrderId = asString(req.params?.id, 120);
+    const evidenceId = asString(req.params?.evidenceId, 120);
+    const access = await getWorkOrderAuthorized(req, workOrderId);
+    if (!access.ok) {
+      if (access.code === "NOT_FOUND") return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+    if (!evidenceId) return res.status(404).json({ ok: false, error: "EVIDENCE_NOT_FOUND" });
+
+    const nextVisibility =
+      req.body?.visibility === undefined ? undefined : normalizeEvidenceVisibility(req.body?.visibility);
+    const nextEvidenceType =
+      req.body?.evidenceType === undefined ? undefined : normalizeEvidenceType(req.body?.evidenceType);
+    if (req.body?.visibility !== undefined && !nextVisibility) {
+      return res.status(400).json({ ok: false, error: "INVALID_VISIBILITY" });
+    }
+    if (req.body?.evidenceType !== undefined && !nextEvidenceType) {
+      return res.status(400).json({ ok: false, error: "INVALID_EVIDENCE_TYPE" });
+    }
+
+    const currentEvidence = Array.isArray((access.item as any)?.evidence) ? ((access.item as any).evidence as any[]) : [];
+    if (!currentEvidence.some((entry) => asString(entry?.id, 120) === evidenceId)) {
+      return res.status(404).json({ ok: false, error: "EVIDENCE_NOT_FOUND" });
+    }
+
+    const nextEvidence = replaceEvidenceItem(currentEvidence, evidenceId, (entry) => ({
+      ...entry,
+      caption: req.body?.caption !== undefined ? asOptionalString(req.body?.caption, 500) : entry.caption || null,
+      visibility: nextVisibility || entry.visibility,
+      evidenceType: nextEvidenceType || entry.evidenceType,
+    }));
+
+    await db.collection("workOrders").doc(workOrderId).set(
+      {
+        evidence: nextEvidence,
+        updatedAtMs: nowMs(),
+      },
+      { merge: true }
+    );
+
+    await writeWorkOrderUpdate({
+      workOrderId,
+      actorRole: isAdmin(req) ? "admin" : "landlord",
+      actorId: access.userId,
+      updateType: "photo",
+      message: "Evidence metadata updated",
+    });
+
+    const refreshed = await db.collection("workOrders").doc(workOrderId).get();
+    return res.json({ ok: true, item: await toWorkOrderResponseForAudience(refreshed.id, refreshed.data(), "landlord") });
+  } catch (err) {
+    console.error("[work-orders] evidence update failed", err);
+    return res.status(500).json({ ok: false, error: "WORK_ORDER_EVIDENCE_UPDATE_FAILED" });
   }
 });
 

--- a/rentchain-api/src/services/tenantPortal/tenantProjectionService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantProjectionService.ts
@@ -42,6 +42,17 @@ type TenantMaintenanceProjection = {
   tenantConfirmationStatus: "confirmed" | "needs_schedule_change" | null;
   tenantConfirmationUpdatedAt: number | null;
   accessAcknowledgedAt: number | null;
+  evidence: Array<{
+    id: string;
+    url: string | null;
+    filename: string | null;
+    contentType: string | null;
+    uploadedAt: number | null;
+    uploadedByActorRole: string | null;
+    evidenceType: string | null;
+    caption: string | null;
+    visibility: "tenant_safe";
+  }>;
   createdAt: number | null;
   updatedAt: number | null;
   statusHistory: Array<{
@@ -165,6 +176,21 @@ export function projectTenantMaintenance(recordId: string, data: any): TenantMai
         : null,
     tenantConfirmationUpdatedAt: toMillis(data?.tenantConfirmationUpdatedAt),
     accessAcknowledgedAt: toMillis(data?.accessAcknowledgedAt),
+    evidence: Array.isArray(data?.evidence)
+      ? data.evidence
+          .map((entry: any) => ({
+            id: asString(entry?.id),
+            url: asString(entry?.url),
+            filename: asString(entry?.filename),
+            contentType: asString(entry?.contentType),
+            uploadedAt: toMillis(entry?.uploadedAt),
+            uploadedByActorRole: asString(entry?.uploadedByActorRole),
+            evidenceType: asString(entry?.evidenceType),
+            caption: asString(entry?.caption),
+            visibility: entry?.visibility === "tenant_safe" ? "tenant_safe" : null,
+          }))
+          .filter((entry: any) => entry.id && entry.visibility === "tenant_safe")
+      : [],
     createdAt: toMillis(data?.createdAt),
     updatedAt: toMillis(data?.updatedAt),
     statusHistory,

--- a/rentchain-frontend/src/api/maintenanceWorkflowApi.ts
+++ b/rentchain-frontend/src/api/maintenanceWorkflowApi.ts
@@ -50,6 +50,7 @@ export type MaintenanceWorkflowItem = {
   reopenedByActorId?: string | null;
   reopenedByActorRole?: "landlord" | "admin" | null;
   reopenReason?: string | null;
+  evidence?: WorkOrderEvidenceItem[];
   serviceWindowStartAt?: number | null;
   serviceWindowEndAt?: number | null;
   accessRequired?: boolean | null;
@@ -66,6 +67,21 @@ export type MaintenanceWorkflowItem = {
     message?: string | null;
     createdAt?: number;
   }>;
+};
+
+export type WorkOrderEvidenceType = "before" | "during" | "after" | "completion" | "inspection" | "damage" | "other";
+export type WorkOrderEvidenceVisibility = "internal" | "landlord_contractor" | "tenant_safe";
+export type WorkOrderEvidenceItem = {
+  id: string;
+  url?: string | null;
+  filename?: string | null;
+  contentType?: string | null;
+  uploadedAt: number;
+  uploadedByActorRole: "contractor" | "landlord" | "admin";
+  uploadedByActorId: string;
+  evidenceType: WorkOrderEvidenceType;
+  caption?: string | null;
+  visibility: WorkOrderEvidenceVisibility;
 };
 
 export type LandlordMaintenanceContractor = {
@@ -162,6 +178,7 @@ export async function listTenantMaintenance() {
         ? (item as any).reopenedByActorRole
         : null,
     reopenReason: typeof (item as any).reopenReason === "string" ? (item as any).reopenReason : null,
+    evidence: Array.isArray((item as any).evidence) ? (item as any).evidence : [],
     accessRequired: typeof item.accessRequired === "boolean" ? item.accessRequired : null,
     tenantConfirmationStatus:
       item.tenantConfirmationStatus === "confirmed" || item.tenantConfirmationStatus === "needs_schedule_change"
@@ -240,6 +257,7 @@ export async function getTenantMaintenance(id: string) {
         ? (item as any).reopenedByActorRole
         : null,
     reopenReason: typeof (item as any)?.reopenReason === "string" ? (item as any).reopenReason : null,
+    evidence: Array.isArray((item as any)?.evidence) ? (item as any).evidence : [],
     accessRequired: typeof item?.accessRequired === "boolean" ? item.accessRequired : null,
     tenantConfirmationStatus:
       item?.tenantConfirmationStatus === "confirmed" || item?.tenantConfirmationStatus === "needs_schedule_change"
@@ -378,4 +396,27 @@ export async function patchContractorMaintenanceJobStatus(
       body: payload,
     }
   );
+}
+
+export async function uploadContractorMaintenanceEvidence(
+  maintenanceRequestId: string,
+  payload: {
+    file: File;
+    evidenceType: Extract<WorkOrderEvidenceType, "before" | "during" | "after" | "completion" | "other">;
+    caption?: string;
+  }
+) {
+  const form = new FormData();
+  form.append("file", payload.file);
+  form.append("evidenceType", payload.evidenceType);
+  if (payload.caption) form.append("caption", payload.caption);
+  const res = await apiFetch<{ ok: boolean; item: MaintenanceWorkflowItem }>(
+    `/contractor/jobs/${encodeURIComponent(maintenanceRequestId)}/evidence`,
+    {
+      method: "POST",
+      body: form,
+    }
+  );
+  if (!res?.ok || !res.item) throw new Error("Failed to upload maintenance evidence");
+  return res.item;
 }

--- a/rentchain-frontend/src/api/workOrdersApi.ts
+++ b/rentchain-frontend/src/api/workOrdersApi.ts
@@ -45,10 +45,27 @@ export type WorkOrderRecord = {
   reopenedByActorId?: string | null;
   reopenedByActorRole?: "landlord" | "admin" | null;
   reopenReason?: string | null;
+  evidence?: WorkOrderEvidenceItem[];
   notesInternal: string;
   linkedExpenseId: string | null;
   createdAtMs: number;
   updatedAtMs: number;
+};
+
+export type WorkOrderEvidenceType = "before" | "during" | "after" | "completion" | "inspection" | "damage" | "other";
+export type WorkOrderEvidenceVisibility = "internal" | "landlord_contractor" | "tenant_safe";
+
+export type WorkOrderEvidenceItem = {
+  id: string;
+  url?: string | null;
+  filename?: string | null;
+  contentType?: string | null;
+  uploadedAt: number;
+  uploadedByActorRole: "contractor" | "landlord" | "admin";
+  uploadedByActorId: string;
+  evidenceType: WorkOrderEvidenceType;
+  caption?: string | null;
+  visibility: WorkOrderEvidenceVisibility;
 };
 
 export type WorkOrderUpdateRecord = {
@@ -189,6 +206,45 @@ export async function reopenWorkOrder(
     { method: "POST", body: payload }
   );
   if (!res?.ok || !res.item) throw new Error("Failed to reopen work order");
+  return res.item;
+}
+
+export async function uploadWorkOrderEvidence(
+  workOrderId: string,
+  payload: {
+    file: File;
+    evidenceType: WorkOrderEvidenceType;
+    caption?: string;
+    visibility: WorkOrderEvidenceVisibility;
+  }
+): Promise<WorkOrderRecord> {
+  const form = new FormData();
+  form.append("file", payload.file);
+  form.append("evidenceType", payload.evidenceType);
+  form.append("visibility", payload.visibility);
+  if (payload.caption) form.append("caption", payload.caption);
+  const res = await apiFetch<{ ok: boolean; item: WorkOrderRecord }>(
+    `/landlord/work-orders/${encodeURIComponent(workOrderId)}/evidence`,
+    { method: "POST", body: form }
+  );
+  if (!res?.ok || !res.item) throw new Error("Failed to upload work order evidence");
+  return res.item;
+}
+
+export async function updateWorkOrderEvidence(
+  workOrderId: string,
+  evidenceId: string,
+  payload: {
+    caption?: string;
+    visibility?: WorkOrderEvidenceVisibility;
+    evidenceType?: WorkOrderEvidenceType;
+  }
+): Promise<WorkOrderRecord> {
+  const res = await apiFetch<{ ok: boolean; item: WorkOrderRecord }>(
+    `/landlord/work-orders/${encodeURIComponent(workOrderId)}/evidence/${encodeURIComponent(evidenceId)}`,
+    { method: "PATCH", body: payload }
+  );
+  if (!res?.ok || !res.item) throw new Error("Failed to update work order evidence");
   return res.item;
 }
 

--- a/rentchain-frontend/src/pages/contractor/ContractorJobsPage.test.tsx
+++ b/rentchain-frontend/src/pages/contractor/ContractorJobsPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import ContractorJobsPage from "./ContractorJobsPage";
@@ -6,6 +6,7 @@ import ContractorJobsPage from "./ContractorJobsPage";
 const apiMocks = vi.hoisted(() => ({
   listContractorMaintenanceJobs: vi.fn(),
   patchContractorMaintenanceJobStatus: vi.fn(),
+  uploadContractorMaintenanceEvidence: vi.fn(),
 }));
 
 vi.mock("../../api/maintenanceWorkflowApi", async () => {
@@ -14,11 +15,13 @@ vi.mock("../../api/maintenanceWorkflowApi", async () => {
     ...actual,
     listContractorMaintenanceJobs: apiMocks.listContractorMaintenanceJobs,
     patchContractorMaintenanceJobStatus: apiMocks.patchContractorMaintenanceJobStatus,
+    uploadContractorMaintenanceEvidence: apiMocks.uploadContractorMaintenanceEvidence,
   };
 });
 
 describe("ContractorJobsPage", () => {
   beforeEach(() => {
+    cleanup();
     Object.defineProperty(window, "matchMedia", {
       writable: true,
       value: vi.fn().mockImplementation(() => ({
@@ -31,6 +34,7 @@ describe("ContractorJobsPage", () => {
     });
     apiMocks.listContractorMaintenanceJobs.mockReset();
     apiMocks.patchContractorMaintenanceJobStatus.mockReset();
+    apiMocks.uploadContractorMaintenanceEvidence.mockReset();
   });
 
   it("requires a blocked reason before marking a job blocked", async () => {
@@ -99,5 +103,69 @@ describe("ContractorJobsPage", () => {
 
     expect(await screen.findByText(/Add a completion summary before finishing the job/i)).toBeInTheDocument();
     expect(apiMocks.patchContractorMaintenanceJobStatus).not.toHaveBeenCalled();
+  });
+
+  it("uploads contractor evidence from the selected job", async () => {
+    apiMocks.listContractorMaintenanceJobs.mockResolvedValue({
+      items: [
+        {
+          id: "maint-1",
+          title: "Broken heater",
+          description: "No heat in the bedroom.",
+          status: "in_progress",
+          priority: "urgent",
+          tenantId: "tenant-1",
+          landlordId: "landlord-1",
+          propertyLabel: "Harbour View",
+          unitLabel: "Unit 2",
+          createdAt: 100,
+          updatedAt: 200,
+          statusHistory: [],
+          evidence: [],
+        },
+      ],
+    });
+    apiMocks.uploadContractorMaintenanceEvidence.mockResolvedValue({
+      id: "maint-1",
+      evidence: [
+        {
+          id: "evidence-1",
+          url: "https://example.com/proof.jpg",
+          uploadedAt: 300,
+          uploadedByActorRole: "contractor",
+          uploadedByActorId: "contractor-1",
+          evidenceType: "during",
+          caption: "Valve replacement underway",
+          visibility: "landlord_contractor",
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/contractor/jobs/maint-1"]}>
+        <Routes>
+          <Route path="/contractor/jobs/:id" element={<ContractorJobsPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.change((await screen.findAllByLabelText(/Evidence file/i))[0], {
+      target: { files: [new File(["photo"], "during.jpg", { type: "image/jpeg" })] },
+    });
+    fireEvent.change(screen.getAllByLabelText(/^Evidence type$/i)[0], { target: { value: "during" } });
+    fireEvent.change(screen.getAllByLabelText(/Evidence caption/i)[0], {
+      target: { value: "Valve replacement underway" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Upload evidence/i }));
+
+    await waitFor(() => {
+      expect(apiMocks.uploadContractorMaintenanceEvidence).toHaveBeenCalledWith(
+        "maint-1",
+        expect.objectContaining({
+          evidenceType: "during",
+          caption: "Valve replacement underway",
+        })
+      );
+    });
   });
 });

--- a/rentchain-frontend/src/pages/contractor/ContractorJobsPage.tsx
+++ b/rentchain-frontend/src/pages/contractor/ContractorJobsPage.tsx
@@ -5,8 +5,10 @@ import { ResponsiveMasterDetail } from "../../components/layout/ResponsiveMaster
 import {
   listContractorMaintenanceJobs,
   patchContractorMaintenanceJobStatus,
+  uploadContractorMaintenanceEvidence,
   type MaintenanceWorkflowItem,
   type MaintenanceWorkflowStatus,
+  type WorkOrderEvidenceType,
 } from "../../api/maintenanceWorkflowApi";
 import { colors, radius, spacing, text } from "../../styles/tokens";
 
@@ -28,6 +30,21 @@ function fromLocalInputValue(value: string) {
   if (!value) return null;
   const parsed = new Date(value);
   return Number.isNaN(parsed.getTime()) ? null : parsed.getTime();
+}
+
+function evidenceTypeLabel(value?: WorkOrderEvidenceType | null) {
+  switch (value) {
+    case "before":
+      return "Before";
+    case "during":
+      return "During";
+    case "after":
+      return "After";
+    case "completion":
+      return "Completion";
+    default:
+      return "Other";
+  }
 }
 
 function findScheduledDate(item: MaintenanceWorkflowItem) {
@@ -62,7 +79,8 @@ function normalizeJob(item: any): MaintenanceWorkflowItem | null {
   const title = String(item?.title || "").trim();
   const description = String(item?.description || "").trim();
   if (!id || !title || !description) return null;
-  const status = statusLabel(item?.status) as MaintenanceWorkflowStatus;
+  const rawStatus = String(item?.status || "").trim().toLowerCase();
+  const status = (rawStatus === "in progress" ? "in_progress" : rawStatus || "assigned") as MaintenanceWorkflowStatus;
   return {
     ...item,
     id,
@@ -111,6 +129,11 @@ export default function ContractorJobsPage() {
   const [completionSummary, setCompletionSummary] = React.useState("");
   const [completionOutcome, setCompletionOutcome] = React.useState<"completed" | "partially_completed" | "follow_up_required">("completed");
   const [saving, setSaving] = React.useState(false);
+  const [evidenceFile, setEvidenceFile] = React.useState<File | null>(null);
+  const [evidenceType, setEvidenceType] =
+    React.useState<Extract<WorkOrderEvidenceType, "before" | "during" | "after" | "completion" | "other">>("during");
+  const [evidenceCaption, setEvidenceCaption] = React.useState("");
+  const [uploadingEvidence, setUploadingEvidence] = React.useState(false);
 
   const load = React.useCallback(async () => {
     setLoading(true);
@@ -168,6 +191,9 @@ export default function ContractorJobsPage() {
       setCompletionSummary("");
       setCompletionOutcome("completed");
       setNote("");
+      setEvidenceFile(null);
+      setEvidenceCaption("");
+      setEvidenceType("during");
       return;
     }
     setScheduledForInput(toLocalInputValue(selected.scheduledFor || findScheduledDate(selected)));
@@ -232,6 +258,31 @@ export default function ContractorJobsPage() {
     },
     [completionOutcome, completionSummary, load, note, scheduledForInput, selected]
   );
+
+  const uploadEvidence = React.useCallback(async () => {
+    if (!selected) return;
+    if (!evidenceFile) {
+      setError("Choose an image before uploading evidence.");
+      return;
+    }
+    setUploadingEvidence(true);
+    setError(null);
+    try {
+      await uploadContractorMaintenanceEvidence(selected.id, {
+        file: evidenceFile,
+        evidenceType,
+        caption: evidenceCaption.trim() || undefined,
+      });
+      setEvidenceFile(null);
+      setEvidenceCaption("");
+      setEvidenceType("during");
+      await load();
+    } catch (err: any) {
+      setError(String(err?.message || "Failed to upload evidence"));
+    } finally {
+      setUploadingEvidence(false);
+    }
+  }, [evidenceCaption, evidenceFile, evidenceType, load, selected]);
 
   const actions = React.useMemo(() => {
     if (!selected) return [] as Array<{ label: string; onClick: () => Promise<void> }>;
@@ -509,6 +560,105 @@ export default function ContractorJobsPage() {
                         {saving ? "Saving..." : action.label}
                       </Button>
                     ))}
+                  </div>
+
+                  <div
+                    style={{
+                      border: `1px solid ${colors.border}`,
+                      borderRadius: radius.md,
+                      padding: "12px 14px",
+                      background: colors.panel,
+                      display: "grid",
+                      gap: 8,
+                    }}
+                  >
+                    <div style={{ fontWeight: 700, color: text.primary }}>Evidence photos</div>
+                    <div style={{ color: text.secondary }}>
+                      Add before, during, after, or completion photos so the landlord can review visual proof with the job.
+                    </div>
+                    <input
+                      aria-label="Evidence file"
+                      type="file"
+                      accept="image/png,image/jpeg,image/webp"
+                      onChange={(e) => setEvidenceFile(e.target.files?.[0] || null)}
+                    />
+                    <div style={{ display: "grid", gap: 8, gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))" }}>
+                      <select
+                        aria-label="Evidence type"
+                        value={evidenceType}
+                        onChange={(e) =>
+                          setEvidenceType(
+                            e.target.value as Extract<WorkOrderEvidenceType, "before" | "during" | "after" | "completion" | "other">
+                          )
+                        }
+                        style={{
+                          padding: "9px 10px",
+                          borderRadius: radius.md,
+                          border: `1px solid ${colors.border}`,
+                          background: colors.panel,
+                          color: text.primary,
+                        }}
+                      >
+                        <option value="before">Before</option>
+                        <option value="during">During</option>
+                        <option value="after">After</option>
+                        <option value="completion">Completion</option>
+                        <option value="other">Other</option>
+                      </select>
+                    </div>
+                    <textarea
+                      aria-label="Evidence caption"
+                      rows={2}
+                      value={evidenceCaption}
+                      onChange={(e) => setEvidenceCaption(e.target.value)}
+                      placeholder="Add a short caption for this photo"
+                      style={{
+                        width: "100%",
+                        padding: "10px",
+                        borderRadius: radius.md,
+                        border: `1px solid ${colors.border}`,
+                        background: colors.panel,
+                        color: text.primary,
+                        resize: "vertical",
+                      }}
+                    />
+                    <div>
+                      <Button disabled={uploadingEvidence} onClick={() => void uploadEvidence()}>
+                        {uploadingEvidence ? "Uploading..." : "Upload evidence"}
+                      </Button>
+                    </div>
+                    {selected.evidence?.length ? (
+                      <div style={{ display: "grid", gap: 8 }}>
+                        {selected.evidence.map((item) => (
+                          <div
+                            key={item.id}
+                            style={{
+                              border: `1px solid ${colors.border}`,
+                              borderRadius: radius.md,
+                              padding: "8px 10px",
+                              background: colors.card,
+                              display: "grid",
+                              gap: 6,
+                            }}
+                          >
+                            {item.url ? (
+                              <img
+                                src={item.url}
+                                alt={item.caption || `${evidenceTypeLabel(item.evidenceType)} evidence`}
+                                style={{ width: "100%", maxHeight: 220, objectFit: "cover", borderRadius: radius.md }}
+                              />
+                            ) : null}
+                            <div style={{ color: text.primary, fontWeight: 700 }}>{evidenceTypeLabel(item.evidenceType)}</div>
+                            <div style={{ color: text.muted, fontSize: 12 }}>
+                              {item.visibility === "tenant_safe" ? "Tenant-safe" : "Landlord + contractor"} • {fmtDate(item.uploadedAt)}
+                            </div>
+                            {item.caption ? <div style={{ color: text.secondary }}>{item.caption}</div> : null}
+                          </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <div style={{ color: text.muted }}>No evidence photos uploaded yet.</div>
+                    )}
                   </div>
 
                   <div style={{ display: "grid", gap: 8 }}>

--- a/rentchain-frontend/src/pages/landlord/WorkOrdersPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/WorkOrdersPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import WorkOrdersPage from "./WorkOrdersPage";
@@ -11,6 +11,8 @@ const mocks = vi.hoisted(() => ({
   patchWorkOrder: vi.fn(),
   confirmWorkOrderCompletion: vi.fn(),
   reopenWorkOrder: vi.fn(),
+  uploadWorkOrderEvidence: vi.fn(),
+  updateWorkOrderEvidence: vi.fn(),
   addWorkOrderUpdate: vi.fn(),
   getContractorProfileById: vi.fn(),
   fetchProperties: vi.fn(),
@@ -32,6 +34,8 @@ vi.mock("../../api/workOrdersApi", () => ({
   listWorkOrders: mocks.listWorkOrders,
   patchWorkOrder: mocks.patchWorkOrder,
   reopenWorkOrder: mocks.reopenWorkOrder,
+  updateWorkOrderEvidence: mocks.updateWorkOrderEvidence,
+  uploadWorkOrderEvidence: mocks.uploadWorkOrderEvidence,
 }));
 
 vi.mock("../../api/propertiesApi", () => ({
@@ -53,6 +57,7 @@ vi.mock("@/components/billing/LockedFeature", () => ({
 
 describe("WorkOrdersPage", () => {
   beforeEach(() => {
+    cleanup();
     Object.defineProperty(window, "matchMedia", {
       writable: true,
       value: vi.fn().mockImplementation(() => ({
@@ -70,6 +75,8 @@ describe("WorkOrdersPage", () => {
     mocks.patchWorkOrder.mockReset();
     mocks.confirmWorkOrderCompletion.mockReset();
     mocks.reopenWorkOrder.mockReset();
+    mocks.uploadWorkOrderEvidence.mockReset();
+    mocks.updateWorkOrderEvidence.mockReset();
     mocks.addWorkOrderUpdate.mockReset();
     mocks.getContractorProfileById.mockReset();
     mocks.fetchProperties.mockReset();
@@ -208,6 +215,126 @@ describe("WorkOrdersPage", () => {
       expect(mocks.reopenWorkOrder).toHaveBeenCalledWith("wo-1", {
         reason: "Heat output is still inconsistent.",
         status: "blocked",
+      });
+    });
+  });
+
+  it("uploads evidence and lets the landlord mark it tenant-safe", async () => {
+    mocks.canUseWorkOrders = true;
+    const baseItem = {
+      id: "wo-2",
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      title: "Hallway repaint",
+      description: "Repaint the hallway after drywall patching.",
+      category: "Painting",
+      priority: "medium",
+      status: "in_progress",
+      visibility: "private",
+      budgetMinCents: null,
+      budgetMaxCents: null,
+      assignedContractorId: "contractor-1",
+      invitedContractorIds: [],
+      acceptedAtMs: 10,
+      startedAtMs: 20,
+      completedAtMs: null,
+      scheduledFor: 15,
+      serviceStartedAt: 20,
+      serviceCompletedAt: null,
+      completionSummary: null,
+      completionOutcome: null,
+      completedByActorRole: null,
+      completionConfirmedByLandlordAt: null,
+      completionConfirmedByLandlordBy: null,
+      reopenedAt: null,
+      reopenedByActorId: null,
+      reopenedByActorRole: null,
+      reopenReason: null,
+      executionBlockedReason: null,
+      evidence: [
+        {
+          id: "evidence-1",
+          url: "https://example.com/evidence-1.jpg",
+          filename: "before.jpg",
+          contentType: "image/jpeg",
+          uploadedAt: 35,
+          uploadedByActorRole: "contractor",
+          uploadedByActorId: "contractor-1",
+          evidenceType: "before",
+          caption: "Before repainting",
+          visibility: "landlord_contractor",
+        },
+      ],
+      notesInternal: "",
+      linkedExpenseId: null,
+      createdAtMs: 1,
+      updatedAtMs: 35,
+    };
+    mocks.listWorkOrders.mockResolvedValue([baseItem]);
+    mocks.listWorkOrderUpdates.mockResolvedValue([]);
+    mocks.uploadWorkOrderEvidence.mockResolvedValue({
+      ...baseItem,
+      evidence: [
+        ...baseItem.evidence,
+        {
+          id: "evidence-2",
+          url: "https://example.com/evidence-2.jpg",
+          filename: "after.jpg",
+          contentType: "image/jpeg",
+          uploadedAt: 40,
+          uploadedByActorRole: "landlord",
+          uploadedByActorId: "landlord-1",
+          evidenceType: "completion",
+          caption: "Final walkthrough",
+          visibility: "internal",
+        },
+      ],
+    });
+    mocks.updateWorkOrderEvidence.mockResolvedValue({
+      ...baseItem,
+      evidence: [
+        {
+          ...baseItem.evidence[0],
+          visibility: "tenant_safe",
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter>
+        <WorkOrdersPage />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /timeline/i }));
+
+    fireEvent.change(screen.getByLabelText(/Evidence file/i), {
+      target: {
+        files: [new File(["photo"], "after.jpg", { type: "image/jpeg" })],
+      },
+    });
+    fireEvent.change(screen.getByLabelText(/^Evidence type$/i), { target: { value: "completion" } });
+    fireEvent.change(screen.getByLabelText(/Evidence visibility/i), { target: { value: "internal" } });
+    fireEvent.change(screen.getByLabelText(/Evidence caption/i), { target: { value: "Final walkthrough" } });
+    fireEvent.click(screen.getByRole("button", { name: /Upload evidence/i }));
+
+    await waitFor(() => {
+      expect(mocks.uploadWorkOrderEvidence).toHaveBeenCalledWith(
+        "wo-2",
+        expect.objectContaining({
+          evidenceType: "completion",
+          caption: "Final walkthrough",
+          visibility: "internal",
+        })
+      );
+    });
+
+    fireEvent.click(screen.getAllByRole("button", { name: /Mark tenant-safe/i })[0]);
+
+    await waitFor(() => {
+      expect(mocks.updateWorkOrderEvidence).toHaveBeenCalledWith("wo-2", "evidence-1", {
+        visibility: "tenant_safe",
       });
     });
   });

--- a/rentchain-frontend/src/pages/landlord/WorkOrdersPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/WorkOrdersPage.tsx
@@ -14,6 +14,10 @@ import {
   listWorkOrders,
   patchWorkOrder,
   reopenWorkOrder,
+  updateWorkOrderEvidence,
+  uploadWorkOrderEvidence,
+  type WorkOrderEvidenceType,
+  type WorkOrderEvidenceVisibility,
   type WorkOrderRecord,
   type WorkOrderUpdateRecord,
 } from "../../api/workOrdersApi";
@@ -49,6 +53,36 @@ function completionOutcomeLabel(value?: WorkOrderRecord["completionOutcome"]) {
   }
 }
 
+function evidenceTypeLabel(value?: WorkOrderEvidenceType | null) {
+  switch (value) {
+    case "before":
+      return "Before";
+    case "during":
+      return "During";
+    case "after":
+      return "After";
+    case "completion":
+      return "Completion";
+    case "inspection":
+      return "Inspection";
+    case "damage":
+      return "Damage";
+    default:
+      return "Other";
+  }
+}
+
+function evidenceVisibilityLabel(value?: WorkOrderEvidenceVisibility | null) {
+  switch (value) {
+    case "internal":
+      return "Internal only";
+    case "tenant_safe":
+      return "Tenant-safe";
+    default:
+      return "Landlord + contractor";
+  }
+}
+
 export default function WorkOrdersPage() {
   const entitlements = useEntitlements();
   const [items, setItems] = React.useState<WorkOrderRecord[]>([]);
@@ -64,10 +98,15 @@ export default function WorkOrdersPage() {
   const [reopenReason, setReopenReason] = React.useState("");
   const [savingNote, setSavingNote] = React.useState(false);
   const [savingAction, setSavingAction] = React.useState(false);
+  const [savingEvidence, setSavingEvidence] = React.useState(false);
   const [properties, setProperties] = React.useState<Array<{ id: string; name: string }>>([]);
   const [convertTarget, setConvertTarget] = React.useState<WorkOrderRecord | null>(null);
   const [convertVendor, setConvertVendor] = React.useState("");
   const [isMobile, setIsMobile] = React.useState(false);
+  const [evidenceFile, setEvidenceFile] = React.useState<File | null>(null);
+  const [evidenceType, setEvidenceType] = React.useState<WorkOrderEvidenceType>("inspection");
+  const [evidenceCaption, setEvidenceCaption] = React.useState("");
+  const [evidenceVisibility, setEvidenceVisibility] = React.useState<WorkOrderEvidenceVisibility>("internal");
   const canUseWorkOrders = entitlements.canUseWorkOrders;
 
   const normalizeCategory = React.useCallback((input: string): ExpenseCategory => {
@@ -114,6 +153,11 @@ export default function WorkOrdersPage() {
     },
     [loadUpdates]
   );
+
+  const syncSelectedItem = React.useCallback((next: WorkOrderRecord) => {
+    setSelected(next);
+    setItems((current) => current.map((item) => (item.id === next.id ? next : item)));
+  }, []);
 
   const markCompleted = React.useCallback(
     async (item: WorkOrderRecord) => {
@@ -181,11 +225,60 @@ export default function WorkOrdersPage() {
     [load, refreshSelected, reopenReason]
   );
 
+  const handleEvidenceUpload = React.useCallback(async () => {
+    if (!selected) return;
+    if (!evidenceFile) {
+      setError("Choose an image before uploading evidence.");
+      return;
+    }
+    setSavingEvidence(true);
+    setError(null);
+    try {
+      const refreshed = await uploadWorkOrderEvidence(selected.id, {
+        file: evidenceFile,
+        evidenceType,
+        caption: evidenceCaption.trim() || undefined,
+        visibility: evidenceVisibility,
+      });
+      syncSelectedItem(refreshed);
+      await loadUpdates(selected.id);
+      setEvidenceFile(null);
+      setEvidenceCaption("");
+      setEvidenceType("inspection");
+      setEvidenceVisibility("internal");
+    } catch (err: any) {
+      setError(String(err?.message || "Failed to upload work order evidence"));
+    } finally {
+      setSavingEvidence(false);
+    }
+  }, [evidenceCaption, evidenceFile, evidenceType, evidenceVisibility, loadUpdates, selected, syncSelectedItem]);
+
+  const markEvidenceTenantSafe = React.useCallback(
+    async (evidenceId: string) => {
+      if (!selected) return;
+      setSavingEvidence(true);
+      setError(null);
+      try {
+        const refreshed = await updateWorkOrderEvidence(selected.id, evidenceId, { visibility: "tenant_safe" });
+        syncSelectedItem(refreshed);
+      } catch (err: any) {
+        setError(String(err?.message || "Failed to update evidence visibility"));
+      } finally {
+        setSavingEvidence(false);
+      }
+    },
+    [selected, syncSelectedItem]
+  );
+
   React.useEffect(() => {
     if (!selected) {
       setCompletionSummary("");
       setCompletionOutcome("completed");
       setReopenReason("");
+      setEvidenceFile(null);
+      setEvidenceCaption("");
+      setEvidenceType("inspection");
+      setEvidenceVisibility("internal");
       return;
     }
     setCompletionSummary(String(selected.completionSummary || ""));
@@ -513,6 +606,108 @@ export default function WorkOrdersPage() {
                   <div style={{ marginTop: 4 }}>{selected.reopenReason}</div>
                 </div>
               ) : null}
+            </div>
+            <div
+              style={{
+                display: "grid",
+                gap: 10,
+                marginBottom: 12,
+                padding: 12,
+                border: "1px solid #e2e8f0",
+                borderRadius: 12,
+                background: "#f8fafc",
+              }}
+            >
+              <div style={{ fontWeight: 700 }}>Evidence photos</div>
+              <div style={{ color: "#64748b", fontSize: 13 }}>
+                Keep before, during, completion, and review photos with the work order so service proof stays attached to the job.
+              </div>
+              <input
+                aria-label="Evidence file"
+                type="file"
+                accept="image/png,image/jpeg,image/webp"
+                onChange={(e) => setEvidenceFile(e.target.files?.[0] || null)}
+              />
+              <div style={{ display: "grid", gap: 8, gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))" }}>
+                <select
+                  aria-label="Evidence type"
+                  value={evidenceType}
+                  onChange={(e) => setEvidenceType(e.target.value as WorkOrderEvidenceType)}
+                  style={{ width: "100%", borderRadius: 8, border: "1px solid #cbd5e1", padding: 8 }}
+                >
+                  <option value="before">Before</option>
+                  <option value="during">During</option>
+                  <option value="after">After</option>
+                  <option value="completion">Completion</option>
+                  <option value="inspection">Inspection</option>
+                  <option value="damage">Damage</option>
+                  <option value="other">Other</option>
+                </select>
+                <select
+                  aria-label="Evidence visibility"
+                  value={evidenceVisibility}
+                  onChange={(e) => setEvidenceVisibility(e.target.value as WorkOrderEvidenceVisibility)}
+                  style={{ width: "100%", borderRadius: 8, border: "1px solid #cbd5e1", padding: 8 }}
+                >
+                  <option value="internal">Internal only</option>
+                  <option value="landlord_contractor">Landlord + contractor</option>
+                  <option value="tenant_safe">Tenant-safe</option>
+                </select>
+              </div>
+              <textarea
+                aria-label="Evidence caption"
+                value={evidenceCaption}
+                onChange={(e) => setEvidenceCaption(e.target.value)}
+                placeholder="Add a short caption for this photo"
+                rows={2}
+                style={{ width: "100%", borderRadius: 8, border: "1px solid #cbd5e1", padding: 8, resize: "vertical" }}
+              />
+              <div>
+                <Button disabled={savingEvidence} onClick={() => void handleEvidenceUpload()}>
+                  {savingEvidence ? "Uploading..." : "Upload evidence"}
+                </Button>
+              </div>
+              {selected.evidence?.length ? (
+                <div style={{ display: "grid", gap: 10 }}>
+                  {selected.evidence.map((item) => (
+                    <div
+                      key={item.id}
+                      style={{
+                        border: "1px solid #e2e8f0",
+                        borderRadius: 12,
+                        padding: 10,
+                        background: "#fff",
+                        display: "grid",
+                        gap: 8,
+                      }}
+                    >
+                      {item.url ? (
+                        <img
+                          src={item.url}
+                          alt={item.caption || `${evidenceTypeLabel(item.evidenceType)} evidence`}
+                          style={{ width: "100%", maxHeight: 220, objectFit: "cover", borderRadius: 10, background: "#e2e8f0" }}
+                        />
+                      ) : null}
+                      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", fontSize: 12, color: "#64748b" }}>
+                        <span>{evidenceTypeLabel(item.evidenceType)}</span>
+                        <span>{evidenceVisibilityLabel(item.visibility)}</span>
+                        <span>Uploaded by {item.uploadedByActorRole}</span>
+                        <span>{formatDate(item.uploadedAt)}</span>
+                      </div>
+                      {item.caption ? <div style={{ whiteSpace: "pre-wrap" }}>{item.caption}</div> : null}
+                      {item.visibility !== "tenant_safe" ? (
+                        <div>
+                          <Button variant="secondary" disabled={savingEvidence} onClick={() => void markEvidenceTenantSafe(item.id)}>
+                            {savingEvidence ? "Saving..." : "Mark tenant-safe"}
+                          </Button>
+                        </div>
+                      ) : null}
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div style={{ color: "#64748b" }}>No evidence photos uploaded yet.</div>
+              )}
             </div>
             <div style={{ display: "grid", gap: 8, maxHeight: 320, overflow: "auto", paddingRight: 4 }}>
               {updates.length === 0 ? (

--- a/rentchain-frontend/src/pages/tenant/TenantMaintenancePages.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantMaintenancePages.test.tsx
@@ -97,6 +97,18 @@ describe("tenant maintenance pages", () => {
         serviceWindowStartAt: Date.UTC(2026, 3, 15, 13, 0),
         serviceWindowEndAt: Date.UTC(2026, 3, 15, 15, 0),
         accessRequired: true,
+        evidence: [
+          {
+            id: "evidence-1",
+            url: "https://example.com/completion.jpg",
+            uploadedAt: 250,
+            uploadedByActorRole: "landlord",
+            uploadedByActorId: "landlord-1",
+            evidenceType: "completion",
+            caption: "Heat restored",
+            visibility: "tenant_safe",
+          },
+        ],
         createdAt: 100,
         updatedAt: 200,
         statusHistory: [
@@ -127,6 +139,8 @@ describe("tenant maintenance pages", () => {
     expect(screen.getByRole("button", { name: /Confirm service window/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Request schedule change/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Acknowledge access/i })).toBeInTheDocument();
+    expect(screen.getByText(/Completion photos/i)).toBeInTheDocument();
+    expect(screen.getByText(/Heat restored/i)).toBeInTheDocument();
     expect(screen.getByText(/Status timeline/i)).toBeInTheDocument();
     expect(screen.getByText(/Technician is on site/i)).toBeInTheDocument();
   });

--- a/rentchain-frontend/src/pages/tenant/TenantMaintenanceRequestDetailPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantMaintenanceRequestDetailPage.tsx
@@ -342,6 +342,53 @@ export default function TenantMaintenanceRequestDetailPage() {
                   ) : null}
                 </div>
               ) : null}
+              {Array.isArray(data.evidence) && data.evidence.length ? (
+                <div
+                  style={{
+                    border: `1px solid ${colors.border}`,
+                    borderRadius: radius.md,
+                    padding: "12px 14px",
+                    background: colors.panel,
+                    display: "grid",
+                    gap: 8,
+                  }}
+                >
+                  <div style={{ fontWeight: 800, color: textTokens.primary }}>Completion photos</div>
+                  <div style={{ color: textTokens.secondary }}>
+                    These are the tenant-safe photos shared with this maintenance update.
+                  </div>
+                  <div style={{ display: "grid", gap: 10 }}>
+                    {data.evidence.map((item) => (
+                      <div
+                        key={item.id}
+                        style={{
+                          border: `1px solid ${colors.border}`,
+                          borderRadius: radius.md,
+                          padding: "10px",
+                          background: "#fff",
+                          display: "grid",
+                          gap: 8,
+                        }}
+                      >
+                        {item.url ? (
+                          <img
+                            src={item.url}
+                            alt={item.caption || "Maintenance evidence photo"}
+                            style={{ width: "100%", maxHeight: 240, objectFit: "cover", borderRadius: radius.md }}
+                          />
+                        ) : null}
+                        <div style={{ color: textTokens.primary, fontWeight: 700 }}>
+                          {String(item.evidenceType || "completion").replace(/_/g, " ")}
+                        </div>
+                        <div style={{ color: textTokens.muted, fontSize: "0.85rem" }}>
+                          Shared {fmtDate(item.uploadedAt)}
+                        </div>
+                        {item.caption ? <div style={{ color: textTokens.secondary }}>{item.caption}</div> : null}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
               <div style={{ display: "grid", gap: 8, marginTop: spacing.xs }}>
                 <div style={{ fontWeight: 700, color: textTokens.primary }}>Status timeline</div>
                 {Array.isArray(data.statusHistory) && data.statusHistory.length > 0 ? (


### PR DESCRIPTION
## Summary
Adds structured evidence/photo attachments to maintenance work orders.

This PR introduces a visual proof layer on top of the existing maintenance execution and completion workflow so landlords and contractors can upload before/during/after/completion photos with visibility controls, and tenants can see only explicitly tenant-safe evidence.

## Scope
- structured work-order evidence model
- landlord evidence upload + review UI
- contractor evidence upload UI
- tenant-safe evidence rendering in maintenance detail
- narrow backend upload/update routes
- focused backend and frontend tests

## Evidence model
Evidence now lives on `workOrders` as the operational source of truth and includes:
- evidence type
- caption
- uploader role/id
- upload timestamp
- filename/content type
- storage metadata
- visibility

Supported evidence types:
- before
- during
- after
- completion
- inspection
- damage
- other

Visibility levels:
- internal
- landlord_contractor
- tenant_safe

## Implementation notes
- Reuses the existing private storage upload pattern and signed URL approach
- Adds:
  - `POST /landlord/work-orders/:id/evidence`
  - `PATCH /landlord/work-orders/:id/evidence/:evidenceId`
  - `POST /contractor/jobs/:id/evidence`
- Limits uploads to image files for v1
- Keeps contractor uploads defaulted to `landlord_contractor`
- Enforces tenant-safe filtering in tenant maintenance responses
- Does not duplicate the full evidence set onto maintenance requests

## Validation
- Focused frontend tests passed
- Focused backend tests passed
- Frontend build passed
- Backend build passed

## Limitations
- Image uploads only
- No video/PDF/general attachments
- No evidence deletion workflow
- No storage-provider redesign
- Tenant evidence is limited to explicitly `tenant_safe` items