### PR TITLE
feat(maintenance): add resolution approval and tenant signoff v1

### DIFF
--- a/rentchain-api/src/routes/__tests__/maintenanceRequestsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/maintenanceRequestsRoutes.test.ts
@@ -322,12 +322,16 @@ describe("maintenanceRequestsRoutes scheduling access", () => {
     const savedMaintenance = ensureCollection("maintenanceRequests").get("maint-1");
     expect(savedMaintenance?.status).toBe("completed");
     expect(savedMaintenance?.completionSummary).toMatch(/Replaced the thermostat/i);
+    expect(savedMaintenance?.resolutionStatus).toBe("completed_pending_review");
+    expect(savedMaintenance?.followUpRequired).toBe(false);
 
     const savedWorkOrder = ensureCollection("workOrders").get("maintenance_maint-1");
     expect(savedWorkOrder?.serviceCompletedAt).toBeDefined();
     expect(savedWorkOrder?.completionSummary).toMatch(/Replaced the thermostat/i);
     expect(savedWorkOrder?.completedByActorRole).toBe("contractor");
     expect(savedWorkOrder?.completedByActorId).toBe("contractor-1");
+    expect(savedWorkOrder?.resolutionStatus).toBe("completed_pending_review");
+    expect(savedWorkOrder?.finalResolvedAt).toBeNull();
   });
 
   it("allows an assigned contractor to upload evidence for their job", async () => {

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -434,6 +434,93 @@ describe("tenantPortalRoutes foundation", () => {
     expect(JSON.stringify(res.body?.data?.evidence || [])).not.toMatch(/internal review/i);
   });
 
+  it("lets the tenant sign off a completed maintenance request as resolved", async () => {
+    const router = (await import("../tenantPortalRoutes")).default;
+    ensureCollection("maintenanceRequests").set("maint-2", {
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      status: "completed",
+      priority: "NORMAL",
+      category: "GENERAL",
+      title: "Window repair",
+      description: "The latch is broken.",
+      statusHistory: [],
+      createdAt: 100,
+      updatedAt: 200,
+    });
+    ensureCollection("workOrders").set("maintenance_maint-2", {
+      maintenanceRequestId: "maint-2",
+      tenantId: "tenant-1",
+      status: "completed",
+      resolutionStatus: "tenant_pending_signoff",
+    });
+
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/maintenance/maint-2/signoff",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+      body: {
+        decision: "resolved",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.resolutionStatus).toBe("resolved");
+    expect(typeof res.body?.data?.finalResolvedAt).toBe("number");
+
+    const savedWorkOrder = ensureCollection("workOrders").get("maintenance_maint-2");
+    expect(savedWorkOrder?.tenantSignoffStatus).toBe("accepted");
+    expect(savedWorkOrder?.finalResolvedAt).toBeDefined();
+  });
+
+  it("requires a reason when the tenant reports the issue is not resolved", async () => {
+    const router = (await import("../tenantPortalRoutes")).default;
+    ensureCollection("maintenanceRequests").set("maint-2", {
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      status: "completed",
+      priority: "NORMAL",
+      category: "GENERAL",
+      title: "Window repair",
+      description: "The latch is broken.",
+      statusHistory: [],
+      createdAt: 100,
+      updatedAt: 200,
+    });
+    ensureCollection("workOrders").set("maintenance_maint-2", {
+      maintenanceRequestId: "maint-2",
+      tenantId: "tenant-1",
+      status: "completed",
+      resolutionStatus: "tenant_pending_signoff",
+    });
+
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/maintenance/maint-2/signoff",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+      body: {
+        decision: "not_resolved",
+      },
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body?.error).toBe("TENANT_DECLINE_REASON_REQUIRED");
+  });
+
   it("rejects unauthorized application completion access", async () => {
     const router = (await import("../tenantPortalRoutes")).default;
     const res = await invokeRouter(router, {

--- a/rentchain-api/src/routes/__tests__/workOrdersRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/workOrdersRoutes.test.ts
@@ -214,6 +214,8 @@ describe("workOrdersRoutes execution completion", () => {
 
     const savedWorkOrder = ensureCollection("workOrders").get("wo-1");
     expect(savedWorkOrder?.completionConfirmedByLandlordBy).toBe("landlord-1");
+    expect(savedWorkOrder?.landlordApprovedBy).toBe("landlord-1");
+    expect(savedWorkOrder?.resolutionStatus).toBe("landlord_approved");
   });
 
   it("rejects completion confirmation when the work order is not completed", async () => {
@@ -232,6 +234,68 @@ describe("workOrdersRoutes execution completion", () => {
 
     expect(res.status).toBe(400);
     expect(res.body?.error).toBe("WORK_ORDER_NOT_COMPLETED");
+  });
+
+  it("approves completed work and advances to tenant signoff when a tenant is attached", async () => {
+    const router = (await import("../workOrdersRoutes")).default;
+    ensureCollection("workOrders").set("wo-1", {
+      ...ensureCollection("workOrders").get("wo-1"),
+      tenantId: "tenant-1",
+      status: "completed",
+      completionSummary: "Completed service visit.",
+      serviceCompletedAt: 500,
+    });
+
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/landlord/work-orders/wo-1/approve-resolution",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "landlord-1",
+          role: "landlord",
+          landlordId: "landlord-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.item?.resolutionStatus).toBe("tenant_pending_signoff");
+
+    const savedWorkOrder = ensureCollection("workOrders").get("wo-1");
+    expect(savedWorkOrder?.tenantSignoffStatus).toBe("pending");
+    expect(savedWorkOrder?.landlordApprovedBy).toBe("landlord-1");
+  });
+
+  it("marks follow-up required for completed work with a reason", async () => {
+    const router = (await import("../workOrdersRoutes")).default;
+    ensureCollection("workOrders").set("wo-1", {
+      ...ensureCollection("workOrders").get("wo-1"),
+      status: "completed",
+      completionSummary: "Completed service visit.",
+      serviceCompletedAt: 500,
+    });
+
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/landlord/work-orders/wo-1/mark-follow-up-required",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "landlord-1",
+          role: "landlord",
+          landlordId: "landlord-1",
+        }),
+      },
+      body: {
+        reason: "Tenant reported the heat is still inconsistent.",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.item?.resolutionStatus).toBe("follow_up_required");
+
+    const savedWorkOrder = ensureCollection("workOrders").get("wo-1");
+    expect(savedWorkOrder?.followUpRequired).toBe(true);
+    expect(savedWorkOrder?.followUpReason).toMatch(/still inconsistent/i);
   });
 
   it("reopens a completed work order with a required reason", async () => {
@@ -265,6 +329,7 @@ describe("workOrdersRoutes execution completion", () => {
     const savedWorkOrder = ensureCollection("workOrders").get("wo-1");
     expect(savedWorkOrder?.reopenReason).toMatch(/Heating issue still present/i);
     expect(savedWorkOrder?.executionBlockedReason).toMatch(/Heating issue still present/i);
+    expect(savedWorkOrder?.resolutionStatus).toBe("follow_up_required");
   });
 
   it("allows a landlord to upload evidence and update its visibility", async () => {

--- a/rentchain-api/src/routes/maintenanceRequestsRoutes.ts
+++ b/rentchain-api/src/routes/maintenanceRequestsRoutes.ts
@@ -453,6 +453,28 @@ function normalizeCompletionOutcome(value: any): WorkOrderCompletionOutcome | nu
   return null;
 }
 
+function normalizeResolutionStatus(
+  value: any
+): "completed_pending_review" | "landlord_approved" | "tenant_pending_signoff" | "resolved" | "follow_up_required" | null {
+  const next = String(value || "").trim().toLowerCase();
+  if (
+    next === "completed_pending_review" ||
+    next === "landlord_approved" ||
+    next === "tenant_pending_signoff" ||
+    next === "resolved" ||
+    next === "follow_up_required"
+  ) {
+    return next;
+  }
+  return null;
+}
+
+function normalizeTenantSignoffStatus(value: any): "pending" | "accepted" | "declined" | null {
+  const next = String(value || "").trim().toLowerCase();
+  if (next === "pending" || next === "accepted" || next === "declined") return next;
+  return null;
+}
+
 async function appendWorkOrderUpdate(
   workOrderId: string,
   payload: {
@@ -607,6 +629,16 @@ async function upsertMaintenanceWorkOrder(input: {
   completedByActorId?: string | null;
   completionConfirmedByLandlordAt?: number | null;
   completionConfirmedByLandlordBy?: string | null;
+  resolutionStatus?: "completed_pending_review" | "landlord_approved" | "tenant_pending_signoff" | "resolved" | "follow_up_required" | null;
+  landlordApprovedAt?: number | null;
+  landlordApprovedBy?: string | null;
+  tenantSignoffStatus?: "pending" | "accepted" | "declined" | null;
+  tenantSignedOffAt?: number | null;
+  tenantDeclinedAt?: number | null;
+  tenantDeclineReason?: string | null;
+  followUpRequired?: boolean | null;
+  followUpReason?: string | null;
+  finalResolvedAt?: number | null;
   reopenedAt?: number | null;
   reopenedByActorId?: string | null;
   reopenedByActorRole?: "landlord" | "admin" | null;
@@ -706,6 +738,56 @@ async function upsertMaintenanceWorkOrder(input: {
       input.completionConfirmedByLandlordBy !== undefined
         ? String(input.completionConfirmedByLandlordBy || "").trim() || null
         : String(existingData.completionConfirmedByLandlordBy || "").trim() || null,
+    resolutionStatus:
+      input.resolutionStatus !== undefined ? input.resolutionStatus || null : normalizeResolutionStatus(existingData.resolutionStatus),
+    landlordApprovedAt:
+      input.landlordApprovedAt !== undefined
+        ? typeof input.landlordApprovedAt === "number"
+          ? input.landlordApprovedAt
+          : null
+        : toMillis(existingData.landlordApprovedAt),
+    landlordApprovedBy:
+      input.landlordApprovedBy !== undefined
+        ? String(input.landlordApprovedBy || "").trim() || null
+        : String(existingData.landlordApprovedBy || "").trim() || null,
+    tenantSignoffStatus:
+      input.tenantSignoffStatus !== undefined
+        ? input.tenantSignoffStatus || null
+        : normalizeTenantSignoffStatus(existingData.tenantSignoffStatus),
+    tenantSignedOffAt:
+      input.tenantSignedOffAt !== undefined
+        ? typeof input.tenantSignedOffAt === "number"
+          ? input.tenantSignedOffAt
+          : null
+        : toMillis(existingData.tenantSignedOffAt),
+    tenantDeclinedAt:
+      input.tenantDeclinedAt !== undefined
+        ? typeof input.tenantDeclinedAt === "number"
+          ? input.tenantDeclinedAt
+          : null
+        : toMillis(existingData.tenantDeclinedAt),
+    tenantDeclineReason:
+      input.tenantDeclineReason !== undefined
+        ? String(input.tenantDeclineReason || "").trim() || null
+        : String(existingData.tenantDeclineReason || "").trim() || null,
+    followUpRequired:
+      input.followUpRequired !== undefined
+        ? typeof input.followUpRequired === "boolean"
+          ? input.followUpRequired
+          : null
+        : typeof existingData.followUpRequired === "boolean"
+        ? existingData.followUpRequired
+        : null,
+    followUpReason:
+      input.followUpReason !== undefined
+        ? String(input.followUpReason || "").trim() || null
+        : String(existingData.followUpReason || "").trim() || null,
+    finalResolvedAt:
+      input.finalResolvedAt !== undefined
+        ? typeof input.finalResolvedAt === "number"
+          ? input.finalResolvedAt
+          : null
+        : toMillis(existingData.finalResolvedAt),
     reopenedAt:
       input.reopenedAt !== undefined
         ? typeof input.reopenedAt === "number"
@@ -1835,6 +1917,16 @@ router.patch("/contractor/jobs/:id/status", async (req: any, res) => {
       completedByActorId: nextStatus === "completed" ? actorId : undefined,
       completionConfirmedByLandlordAt: nextStatus === "completed" ? null : undefined,
       completionConfirmedByLandlordBy: nextStatus === "completed" ? null : undefined,
+      resolutionStatus: nextStatus === "completed" ? "completed_pending_review" : undefined,
+      landlordApprovedAt: nextStatus === "completed" ? null : undefined,
+      landlordApprovedBy: nextStatus === "completed" ? null : undefined,
+      tenantSignoffStatus: nextStatus === "completed" ? null : undefined,
+      tenantSignedOffAt: nextStatus === "completed" ? null : undefined,
+      tenantDeclinedAt: nextStatus === "completed" ? null : undefined,
+      tenantDeclineReason: nextStatus === "completed" ? null : undefined,
+      followUpRequired: nextStatus === "completed" ? false : undefined,
+      followUpReason: nextStatus === "completed" ? null : undefined,
+      finalResolvedAt: nextStatus === "completed" ? null : undefined,
       reopenedAt: nextStatus === "completed" ? null : undefined,
       reopenedByActorId: nextStatus === "completed" ? null : undefined,
       reopenedByActorRole: nextStatus === "completed" ? null : undefined,
@@ -1853,6 +1945,16 @@ router.patch("/contractor/jobs/:id/status", async (req: any, res) => {
     if (nextStatus === "completed") {
       maintenancePatch.completionSummary = completionSummary;
       maintenancePatch.completionOutcome = completionOutcome;
+      maintenancePatch.resolutionStatus = "completed_pending_review";
+      maintenancePatch.landlordApprovedAt = null;
+      maintenancePatch.landlordApprovedBy = null;
+      maintenancePatch.tenantSignoffStatus = null;
+      maintenancePatch.tenantSignedOffAt = null;
+      maintenancePatch.tenantDeclinedAt = null;
+      maintenancePatch.tenantDeclineReason = null;
+      maintenancePatch.followUpRequired = false;
+      maintenancePatch.followUpReason = null;
+      maintenancePatch.finalResolvedAt = null;
     } else if (nextStatus === "blocked") {
       maintenancePatch.completionSummary = null;
       maintenancePatch.completionOutcome = null;

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -4983,8 +4983,9 @@ router.get("/maintenance-requests/:id", requireTenant, async (req: any, res) => 
       return res.status(403).json({ ok: false, error: "FORBIDDEN" });
     }
     const workOrderSnap = await db.collection("workOrders").doc(`maintenance_${doc.id}`).get();
+    const workOrderData = workOrderSnap.exists ? ((workOrderSnap.data() as any) || {}) : {};
     const tenantSafeEvidence = workOrderSnap.exists
-      ? await serializeEvidenceForAudience((workOrderSnap.data() as any)?.evidence, "tenant")
+      ? await serializeEvidenceForAudience(workOrderData?.evidence, "tenant")
       : [];
     const payload = {
       id: doc.id,
@@ -5009,6 +5010,42 @@ router.get("/maintenance-requests/:id", requireTenant, async (req: any, res) => 
           : null,
       tenantConfirmationUpdatedAt: toMillis(data.tenantConfirmationUpdatedAt),
       accessAcknowledgedAt: toMillis(data.accessAcknowledgedAt),
+      resolutionStatus:
+        workOrderData?.resolutionStatus === "completed_pending_review" ||
+        workOrderData?.resolutionStatus === "landlord_approved" ||
+        workOrderData?.resolutionStatus === "tenant_pending_signoff" ||
+        workOrderData?.resolutionStatus === "resolved" ||
+        workOrderData?.resolutionStatus === "follow_up_required"
+          ? workOrderData.resolutionStatus
+          : data?.resolutionStatus === "completed_pending_review" ||
+            data?.resolutionStatus === "landlord_approved" ||
+            data?.resolutionStatus === "tenant_pending_signoff" ||
+            data?.resolutionStatus === "resolved" ||
+            data?.resolutionStatus === "follow_up_required"
+          ? data.resolutionStatus
+          : null,
+      landlordApprovedAt: toMillis(workOrderData?.landlordApprovedAt ?? data?.landlordApprovedAt),
+      tenantSignoffStatus:
+        workOrderData?.tenantSignoffStatus === "pending" ||
+        workOrderData?.tenantSignoffStatus === "accepted" ||
+        workOrderData?.tenantSignoffStatus === "declined"
+          ? workOrderData.tenantSignoffStatus
+          : data?.tenantSignoffStatus === "pending" ||
+            data?.tenantSignoffStatus === "accepted" ||
+            data?.tenantSignoffStatus === "declined"
+          ? data.tenantSignoffStatus
+          : null,
+      tenantSignedOffAt: toMillis(workOrderData?.tenantSignedOffAt ?? data?.tenantSignedOffAt),
+      tenantDeclinedAt: toMillis(workOrderData?.tenantDeclinedAt ?? data?.tenantDeclinedAt),
+      tenantDeclineReason: String(workOrderData?.tenantDeclineReason || data?.tenantDeclineReason || "").trim() || null,
+      followUpRequired:
+        typeof workOrderData?.followUpRequired === "boolean"
+          ? workOrderData.followUpRequired
+          : typeof data?.followUpRequired === "boolean"
+          ? data.followUpRequired
+          : null,
+      followUpReason: String(workOrderData?.followUpReason || data?.followUpReason || "").trim() || null,
+      finalResolvedAt: toMillis(workOrderData?.finalResolvedAt ?? data?.finalResolvedAt),
       evidence: tenantSafeEvidence,
       tenantContact: data.tenantContact ?? null,
       createdAt: toMillis(data.createdAt),
@@ -5032,6 +5069,172 @@ router.get("/maintenance-requests/:id", requireTenant, async (req: any, res) => 
       err,
     });
     return res.status(500).json({ ok: false, error: "TENANT_MAINT_REQUEST_READ_FAILED" });
+  }
+});
+
+router.post("/maintenance/:id/signoff", requireTenant, async (req: any, res) => {
+  try {
+    const tenantId = String(req.user?.tenantId || "").trim();
+    const id = String(req.params?.id || "").trim();
+    if (!tenantId) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    if (!id) return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+
+    const docRef = db.collection("maintenanceRequests").doc(id);
+    const snap = await docRef.get();
+    if (!snap.exists) return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+
+    const data = (snap.data() as any) || {};
+    if (String(data.tenantId || "").trim() !== tenantId) {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+
+    const workOrderRef = db.collection("workOrders").doc(`maintenance_${id}`);
+    const workOrderSnap = await workOrderRef.get();
+    if (!workOrderSnap.exists) {
+      return res.status(404).json({ ok: false, error: "WORK_ORDER_NOT_FOUND" });
+    }
+
+    const workOrder = (workOrderSnap.data() as any) || {};
+    if (String(workOrder.status || "").trim().toLowerCase() !== "completed") {
+      return res.status(400).json({ ok: false, error: "WORK_ORDER_NOT_COMPLETED" });
+    }
+    if (String(workOrder.resolutionStatus || "").trim().toLowerCase() !== "tenant_pending_signoff") {
+      return res.status(400).json({ ok: false, error: "TENANT_SIGNOFF_NOT_AVAILABLE" });
+    }
+
+    const decision = req.body?.decision === "resolved" || req.body?.decision === "not_resolved" ? req.body.decision : null;
+    if (!decision) {
+      return res.status(400).json({ ok: false, error: "INVALID_SIGNOFF_DECISION" });
+    }
+    const reason = String(req.body?.reason || "").trim().slice(0, 2000);
+    if (decision === "not_resolved" && !reason) {
+      return res.status(400).json({ ok: false, error: "TENANT_DECLINE_REASON_REQUIRED" });
+    }
+
+    const now = Date.now();
+    const workOrderUpdate: Record<string, unknown> = {
+      updatedAtMs: now,
+      lastExecutionUpdateAt: now,
+    };
+    const maintenanceUpdate: Record<string, unknown> = {
+      updatedAt: now,
+      lastUpdatedBy: "TENANT",
+    };
+    let historyMessage = "";
+    let contractorLastUpdate = "";
+
+    if (decision === "resolved") {
+      Object.assign(workOrderUpdate, {
+        tenantSignoffStatus: "accepted",
+        tenantSignedOffAt: now,
+        tenantDeclinedAt: null,
+        tenantDeclineReason: null,
+        resolutionStatus: "resolved",
+        followUpRequired: false,
+        followUpReason: null,
+        finalResolvedAt: now,
+      });
+      Object.assign(maintenanceUpdate, {
+        tenantSignoffStatus: "accepted",
+        tenantSignedOffAt: now,
+        tenantDeclinedAt: null,
+        tenantDeclineReason: null,
+        resolutionStatus: "resolved",
+        followUpRequired: false,
+        followUpReason: null,
+        finalResolvedAt: now,
+      });
+      historyMessage = "Tenant confirmed that the maintenance issue is resolved.";
+      contractorLastUpdate = "Tenant confirmed that the maintenance issue is resolved.";
+    } else {
+      Object.assign(workOrderUpdate, {
+        tenantSignoffStatus: "declined",
+        tenantSignedOffAt: null,
+        tenantDeclinedAt: now,
+        tenantDeclineReason: reason,
+        resolutionStatus: "follow_up_required",
+        followUpRequired: true,
+        followUpReason: reason,
+        finalResolvedAt: null,
+      });
+      Object.assign(maintenanceUpdate, {
+        tenantSignoffStatus: "declined",
+        tenantSignedOffAt: null,
+        tenantDeclinedAt: now,
+        tenantDeclineReason: reason,
+        resolutionStatus: "follow_up_required",
+        followUpRequired: true,
+        followUpReason: reason,
+        finalResolvedAt: null,
+      });
+      historyMessage = `Tenant reported the issue is not resolved: ${reason}`;
+      contractorLastUpdate = `Tenant requested follow-up: ${reason}`;
+    }
+
+    await Promise.all([
+      workOrderRef.set(workOrderUpdate, { merge: true }),
+      docRef.set(
+        {
+          ...maintenanceUpdate,
+          contractorLastUpdate,
+          statusHistory: FieldValue.arrayUnion({
+            status: String(data.status || "completed"),
+            actorRole: "tenant",
+            actorId: tenantId,
+            message: historyMessage,
+            createdAt: now,
+          }),
+        },
+        { merge: true }
+      ),
+      db.collection("workOrderUpdates").doc().set({
+        workOrderId: workOrderRef.id,
+        actorRole: "tenant",
+        actorId: tenantId,
+        updateType: "confirmed",
+        message: historyMessage,
+        createdAtMs: now,
+      }),
+    ]);
+
+    const [refreshed, refreshedWorkOrder] = await Promise.all([docRef.get(), workOrderRef.get()]);
+    const refreshedWorkOrderData = refreshedWorkOrder.exists ? ((refreshedWorkOrder.data() as any) || {}) : {};
+    return res.json({
+      ok: true,
+      data: {
+        ...projectTenantMaintenance(refreshed.id, refreshed.data() || {}),
+        evidence: refreshedWorkOrder.exists ? await serializeEvidenceForAudience(refreshedWorkOrderData?.evidence, "tenant") : [],
+        resolutionStatus:
+          refreshedWorkOrderData?.resolutionStatus === "completed_pending_review" ||
+          refreshedWorkOrderData?.resolutionStatus === "landlord_approved" ||
+          refreshedWorkOrderData?.resolutionStatus === "tenant_pending_signoff" ||
+          refreshedWorkOrderData?.resolutionStatus === "resolved" ||
+          refreshedWorkOrderData?.resolutionStatus === "follow_up_required"
+            ? refreshedWorkOrderData.resolutionStatus
+            : null,
+        landlordApprovedAt: toMillis(refreshedWorkOrderData?.landlordApprovedAt),
+        tenantSignoffStatus:
+          refreshedWorkOrderData?.tenantSignoffStatus === "pending" ||
+          refreshedWorkOrderData?.tenantSignoffStatus === "accepted" ||
+          refreshedWorkOrderData?.tenantSignoffStatus === "declined"
+            ? refreshedWorkOrderData.tenantSignoffStatus
+            : null,
+        tenantSignedOffAt: toMillis(refreshedWorkOrderData?.tenantSignedOffAt),
+        tenantDeclinedAt: toMillis(refreshedWorkOrderData?.tenantDeclinedAt),
+        tenantDeclineReason: String(refreshedWorkOrderData?.tenantDeclineReason || "").trim() || null,
+        followUpRequired:
+          typeof refreshedWorkOrderData?.followUpRequired === "boolean" ? refreshedWorkOrderData.followUpRequired : null,
+        followUpReason: String(refreshedWorkOrderData?.followUpReason || "").trim() || null,
+        finalResolvedAt: toMillis(refreshedWorkOrderData?.finalResolvedAt),
+      },
+    });
+  } catch (err) {
+    console.error("[tenant/maintenance/:id/signoff] update failed", {
+      tenantId: req.user?.tenantId,
+      id: req.params?.id,
+      err,
+    });
+    return res.status(500).json({ ok: false, error: "TENANT_MAINT_REQUEST_SIGNOFF_FAILED" });
   }
 });
 

--- a/rentchain-api/src/routes/workOrdersRoutes.ts
+++ b/rentchain-api/src/routes/workOrdersRoutes.ts
@@ -102,6 +102,34 @@ function normalizeCompletionOutcome(value: unknown): "completed" | "partially_co
   return null;
 }
 
+function normalizeResolutionStatus(
+  value: unknown
+):
+  | "completed_pending_review"
+  | "landlord_approved"
+  | "tenant_pending_signoff"
+  | "resolved"
+  | "follow_up_required"
+  | null {
+  const next = asString(value, 80).toLowerCase();
+  if (
+    next === "completed_pending_review" ||
+    next === "landlord_approved" ||
+    next === "tenant_pending_signoff" ||
+    next === "resolved" ||
+    next === "follow_up_required"
+  ) {
+    return next;
+  }
+  return null;
+}
+
+function normalizeTenantSignoffStatus(value: unknown): "pending" | "accepted" | "declined" | null {
+  const next = asString(value, 40).toLowerCase();
+  if (next === "pending" || next === "accepted" || next === "declined") return next;
+  return null;
+}
+
 function normalizeRole(req: any): string {
   const actorRole = asString(req.user?.actorRole, 40).toLowerCase();
   const role = asString(req.user?.role, 40).toLowerCase();
@@ -398,6 +426,16 @@ async function syncMaintenanceFromWorkOrder(workOrderId: string, patch: Record<s
       scheduledFor: toMillis(workOrder.scheduledFor),
       serviceCompletedAt: toMillis(workOrder.serviceCompletedAt),
       completionSummary: asOptionalString(workOrder.completionSummary, 2000),
+      resolutionStatus: normalizeResolutionStatus(workOrder.resolutionStatus),
+      landlordApprovedAt: toMillis(workOrder.landlordApprovedAt),
+      landlordApprovedBy: asOptionalString(workOrder.landlordApprovedBy, 120),
+      tenantSignoffStatus: normalizeTenantSignoffStatus(workOrder.tenantSignoffStatus),
+      tenantSignedOffAt: toMillis(workOrder.tenantSignedOffAt),
+      tenantDeclinedAt: toMillis(workOrder.tenantDeclinedAt),
+      tenantDeclineReason: asOptionalString(workOrder.tenantDeclineReason, 2000),
+      followUpRequired: typeof workOrder.followUpRequired === "boolean" ? workOrder.followUpRequired : null,
+      followUpReason: asOptionalString(workOrder.followUpReason, 2000),
+      finalResolvedAt: toMillis(workOrder.finalResolvedAt),
       contractorLastUpdate: asOptionalString(patch.contractorLastUpdate, 500) || asOptionalString(workOrder.completionSummary, 500),
       updatedAt: nowMs(),
       ...patch,
@@ -1161,18 +1199,29 @@ router.patch("/work-orders/:id", requireAuth, async (req: any, res) => {
         if (nextStatus === "completed") {
           const completionSummary = asString(req.body?.completionSummary, 2000);
           const completionOutcome = normalizeCompletionOutcome(req.body?.completionOutcome) || "completed";
+          const completedAt = nowMs();
           if (!completionSummary) {
             return res.status(400).json({ ok: false, error: "COMPLETION_SUMMARY_REQUIRED" });
           }
-          patch.completedAtMs = nowMs();
-          patch.serviceCompletedAt = nowMs();
-          patch.lastExecutionUpdateAt = nowMs();
+          patch.completedAtMs = completedAt;
+          patch.serviceCompletedAt = completedAt;
+          patch.lastExecutionUpdateAt = completedAt;
           patch.completionSummary = completionSummary;
           patch.completionOutcome = completionOutcome;
           patch.completedByActorRole = access.role === "admin" ? "admin" : "landlord";
           patch.completedByActorId = access.userId;
           patch.completionConfirmedByLandlordAt = null;
           patch.completionConfirmedByLandlordBy = null;
+          patch.resolutionStatus = "completed_pending_review";
+          patch.landlordApprovedAt = null;
+          patch.landlordApprovedBy = null;
+          patch.tenantSignoffStatus = null;
+          patch.tenantSignedOffAt = null;
+          patch.tenantDeclinedAt = null;
+          patch.tenantDeclineReason = null;
+          patch.followUpRequired = false;
+          patch.followUpReason = null;
+          patch.finalResolvedAt = null;
           updateMessage = "Work order marked completed in-house";
           maintenanceHistoryMessage = `Service completed in-house: ${completionSummary}`;
         }
@@ -1426,6 +1475,18 @@ router.post("/work-orders/:id/complete", requireAuth, async (req: any, res) => {
         status: "completed",
         assignedContractorId: userId,
         completedAtMs: now,
+        serviceCompletedAt: now,
+        lastExecutionUpdateAt: now,
+        resolutionStatus: "completed_pending_review",
+        landlordApprovedAt: null,
+        landlordApprovedBy: null,
+        tenantSignoffStatus: null,
+        tenantSignedOffAt: null,
+        tenantDeclinedAt: null,
+        tenantDeclineReason: null,
+        followUpRequired: false,
+        followUpReason: null,
+        finalResolvedAt: null,
         updatedAtMs: now,
       },
       { merge: true }
@@ -1475,10 +1536,21 @@ router.post("/landlord/work-orders/:id/confirm-completion", requireAuth, async (
     }
 
     const now = nowMs();
+    const tenantId = asOptionalString((access.item as any)?.tenantId, 120);
     await db.collection("workOrders").doc(workOrderId).set(
       {
         completionConfirmedByLandlordAt: now,
         completionConfirmedByLandlordBy: access.userId,
+        resolutionStatus: tenantId ? "tenant_pending_signoff" : "landlord_approved",
+        landlordApprovedAt: now,
+        landlordApprovedBy: access.userId,
+        tenantSignoffStatus: tenantId ? "pending" : null,
+        tenantSignedOffAt: null,
+        tenantDeclinedAt: null,
+        tenantDeclineReason: null,
+        followUpRequired: false,
+        followUpReason: null,
+        finalResolvedAt: null,
         updatedAtMs: now,
         lastExecutionUpdateAt: now,
       },
@@ -1490,18 +1562,24 @@ router.post("/landlord/work-orders/:id/confirm-completion", requireAuth, async (
       actorRole: isAdmin(req) ? "admin" : "landlord",
       actorId: access.userId,
       updateType: "confirmed",
-      message: "Landlord confirmed work order completion",
+      message: tenantId
+        ? "Landlord approved the completed work and is waiting for tenant signoff"
+        : "Landlord approved the completed work",
     });
 
     await syncMaintenanceFromWorkOrder(workOrderId, {
-      contractorLastUpdate: "Landlord confirmed completion.",
+      contractorLastUpdate: tenantId
+        ? "Landlord approved the completed work and is waiting for tenant signoff."
+        : "Landlord approved the completed work.",
     });
     await appendMaintenanceStatusHistory({
       maintenanceRequestId: asOptionalString((access.item as any)?.maintenanceRequestId, 120),
       status: "completed",
       actorRole: isAdmin(req) ? "admin" : "landlord",
       actorId: access.userId,
-      message: "Landlord confirmed completion.",
+      message: tenantId
+        ? "Landlord approved the completed work and is waiting for tenant signoff."
+        : "Landlord approved the completed work.",
     });
 
     const refreshed = await db.collection("workOrders").doc(workOrderId).get();
@@ -1509,6 +1587,146 @@ router.post("/landlord/work-orders/:id/confirm-completion", requireAuth, async (
   } catch (err) {
     console.error("[work-orders] confirm completion failed", err);
     return res.status(500).json({ ok: false, error: "WORK_ORDER_CONFIRM_COMPLETION_FAILED" });
+  }
+});
+
+router.post("/landlord/work-orders/:id/approve-resolution", requireAuth, async (req: any, res) => {
+  try {
+    if (!isLandlord(req)) return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+
+    const workOrderId = asString(req.params?.id, 120);
+    const access = await getWorkOrderAuthorized(req, workOrderId);
+    if (!access.ok) {
+      if (access.code === "NOT_FOUND") return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+
+    const currentStatus = asString((access.item as any)?.status, 40).toLowerCase();
+    if (currentStatus !== "completed") {
+      return res.status(400).json({ ok: false, error: "WORK_ORDER_NOT_COMPLETED" });
+    }
+
+    const now = nowMs();
+    const tenantId = asOptionalString((access.item as any)?.tenantId, 120);
+    await db.collection("workOrders").doc(workOrderId).set(
+      {
+        resolutionStatus: tenantId ? "tenant_pending_signoff" : "landlord_approved",
+        landlordApprovedAt: now,
+        landlordApprovedBy: access.userId,
+        completionConfirmedByLandlordAt: now,
+        completionConfirmedByLandlordBy: access.userId,
+        tenantSignoffStatus: tenantId ? "pending" : null,
+        tenantSignedOffAt: null,
+        tenantDeclinedAt: null,
+        tenantDeclineReason: null,
+        followUpRequired: false,
+        followUpReason: null,
+        finalResolvedAt: null,
+        updatedAtMs: now,
+        lastExecutionUpdateAt: now,
+      },
+      { merge: true }
+    );
+
+    await writeWorkOrderUpdate({
+      workOrderId,
+      actorRole: isAdmin(req) ? "admin" : "landlord",
+      actorId: access.userId,
+      updateType: "confirmed",
+      message: tenantId
+        ? "Landlord approved the completed work and is waiting for tenant signoff"
+        : "Landlord approved the completed work",
+    });
+
+    await syncMaintenanceFromWorkOrder(workOrderId, {
+      contractorLastUpdate: tenantId
+        ? "Landlord approved the completed work and is waiting for tenant signoff."
+        : "Landlord approved the completed work.",
+    });
+    await appendMaintenanceStatusHistory({
+      maintenanceRequestId: asOptionalString((access.item as any)?.maintenanceRequestId, 120),
+      status: "completed",
+      actorRole: isAdmin(req) ? "admin" : "landlord",
+      actorId: access.userId,
+      message: tenantId
+        ? "Landlord approved the completed work and is waiting for tenant signoff."
+        : "Landlord approved the completed work.",
+    });
+
+    const refreshed = await db.collection("workOrders").doc(workOrderId).get();
+    return res.json({ ok: true, item: await toWorkOrderResponseForAudience(refreshed.id, refreshed.data(), "landlord") });
+  } catch (err) {
+    console.error("[work-orders] approve resolution failed", err);
+    return res.status(500).json({ ok: false, error: "WORK_ORDER_APPROVE_RESOLUTION_FAILED" });
+  }
+});
+
+router.post("/landlord/work-orders/:id/mark-follow-up-required", requireAuth, async (req: any, res) => {
+  try {
+    if (!isLandlord(req)) return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+
+    const workOrderId = asString(req.params?.id, 120);
+    const access = await getWorkOrderAuthorized(req, workOrderId);
+    if (!access.ok) {
+      if (access.code === "NOT_FOUND") return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+
+    const currentStatus = asString((access.item as any)?.status, 40).toLowerCase();
+    if (currentStatus !== "completed") {
+      return res.status(400).json({ ok: false, error: "WORK_ORDER_NOT_COMPLETED" });
+    }
+
+    const reason = asString(req.body?.reason, 2000);
+    if (!reason) {
+      return res.status(400).json({ ok: false, error: "FOLLOW_UP_REASON_REQUIRED" });
+    }
+
+    const now = nowMs();
+    await db.collection("workOrders").doc(workOrderId).set(
+      {
+        resolutionStatus: "follow_up_required",
+        landlordApprovedAt: null,
+        landlordApprovedBy: null,
+        completionConfirmedByLandlordAt: null,
+        completionConfirmedByLandlordBy: null,
+        followUpRequired: true,
+        followUpReason: reason,
+        tenantSignoffStatus: null,
+        tenantSignedOffAt: null,
+        tenantDeclinedAt: null,
+        tenantDeclineReason: null,
+        finalResolvedAt: null,
+        updatedAtMs: now,
+        lastExecutionUpdateAt: now,
+      },
+      { merge: true }
+    );
+
+    await writeWorkOrderUpdate({
+      workOrderId,
+      actorRole: isAdmin(req) ? "admin" : "landlord",
+      actorId: access.userId,
+      updateType: "status_changed",
+      message: `Follow-up required: ${reason}`,
+    });
+
+    await syncMaintenanceFromWorkOrder(workOrderId, {
+      contractorLastUpdate: `Follow-up required: ${reason}`,
+    });
+    await appendMaintenanceStatusHistory({
+      maintenanceRequestId: asOptionalString((access.item as any)?.maintenanceRequestId, 120),
+      status: "completed",
+      actorRole: isAdmin(req) ? "admin" : "landlord",
+      actorId: access.userId,
+      message: `Follow-up required: ${reason}`,
+    });
+
+    const refreshed = await db.collection("workOrders").doc(workOrderId).get();
+    return res.json({ ok: true, item: await toWorkOrderResponseForAudience(refreshed.id, refreshed.data(), "landlord") });
+  } catch (err) {
+    console.error("[work-orders] mark follow-up required failed", err);
+    return res.status(500).json({ ok: false, error: "WORK_ORDER_MARK_FOLLOW_UP_FAILED" });
   }
 });
 
@@ -1541,6 +1759,16 @@ router.post("/landlord/work-orders/:id/reopen", requireAuth, async (req: any, re
         reopenedByActorId: access.userId,
         reopenedByActorRole: isAdmin(req) ? "admin" : "landlord",
         reopenReason: reason,
+        resolutionStatus: "follow_up_required",
+        landlordApprovedAt: null,
+        landlordApprovedBy: null,
+        tenantSignoffStatus: null,
+        tenantSignedOffAt: null,
+        tenantDeclinedAt: null,
+        tenantDeclineReason: null,
+        followUpRequired: true,
+        followUpReason: reason,
+        finalResolvedAt: null,
         completionConfirmedByLandlordAt: null,
         completionConfirmedByLandlordBy: null,
         updatedAtMs: now,

--- a/rentchain-api/src/services/tenantPortal/tenantProjectionService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantProjectionService.ts
@@ -42,6 +42,21 @@ type TenantMaintenanceProjection = {
   tenantConfirmationStatus: "confirmed" | "needs_schedule_change" | null;
   tenantConfirmationUpdatedAt: number | null;
   accessAcknowledgedAt: number | null;
+  resolutionStatus:
+    | "completed_pending_review"
+    | "landlord_approved"
+    | "tenant_pending_signoff"
+    | "resolved"
+    | "follow_up_required"
+    | null;
+  landlordApprovedAt: number | null;
+  tenantSignoffStatus: "pending" | "accepted" | "declined" | null;
+  tenantSignedOffAt: number | null;
+  tenantDeclinedAt: number | null;
+  tenantDeclineReason: string | null;
+  followUpRequired: boolean | null;
+  followUpReason: string | null;
+  finalResolvedAt: number | null;
   evidence: Array<{
     id: string;
     url: string | null;
@@ -176,6 +191,27 @@ export function projectTenantMaintenance(recordId: string, data: any): TenantMai
         : null,
     tenantConfirmationUpdatedAt: toMillis(data?.tenantConfirmationUpdatedAt),
     accessAcknowledgedAt: toMillis(data?.accessAcknowledgedAt),
+    resolutionStatus:
+      data?.resolutionStatus === "completed_pending_review" ||
+      data?.resolutionStatus === "landlord_approved" ||
+      data?.resolutionStatus === "tenant_pending_signoff" ||
+      data?.resolutionStatus === "resolved" ||
+      data?.resolutionStatus === "follow_up_required"
+        ? data.resolutionStatus
+        : null,
+    landlordApprovedAt: toMillis(data?.landlordApprovedAt),
+    tenantSignoffStatus:
+      data?.tenantSignoffStatus === "pending" ||
+      data?.tenantSignoffStatus === "accepted" ||
+      data?.tenantSignoffStatus === "declined"
+        ? data.tenantSignoffStatus
+        : null,
+    tenantSignedOffAt: toMillis(data?.tenantSignedOffAt),
+    tenantDeclinedAt: toMillis(data?.tenantDeclinedAt),
+    tenantDeclineReason: asString(data?.tenantDeclineReason),
+    followUpRequired: typeof data?.followUpRequired === "boolean" ? data.followUpRequired : null,
+    followUpReason: asString(data?.followUpReason),
+    finalResolvedAt: toMillis(data?.finalResolvedAt),
     evidence: Array.isArray(data?.evidence)
       ? data.evidence
           .map((entry: any) => ({

--- a/rentchain-frontend/src/api/maintenanceWorkflowApi.ts
+++ b/rentchain-frontend/src/api/maintenanceWorkflowApi.ts
@@ -4,6 +4,7 @@ import {
   getTenantWorkspaceMaintenance,
   listTenantWorkspaceMaintenance,
   updateTenantWorkspaceMaintenanceConfirmation,
+  updateTenantWorkspaceMaintenanceSignoff,
 } from "./tenantPortal";
 
 export type MaintenanceWorkflowStatus =
@@ -57,6 +58,15 @@ export type MaintenanceWorkflowItem = {
   tenantConfirmationStatus?: "confirmed" | "needs_schedule_change" | null;
   tenantConfirmationUpdatedAt?: number | null;
   accessAcknowledgedAt?: number | null;
+  resolutionStatus?: "completed_pending_review" | "landlord_approved" | "tenant_pending_signoff" | "resolved" | "follow_up_required" | null;
+  landlordApprovedAt?: number | null;
+  tenantSignoffStatus?: "pending" | "accepted" | "declined" | null;
+  tenantSignedOffAt?: number | null;
+  tenantDeclinedAt?: number | null;
+  tenantDeclineReason?: string | null;
+  followUpRequired?: boolean | null;
+  followUpReason?: string | null;
+  finalResolvedAt?: number | null;
   landlordNote?: string | null;
   createdAt: number;
   updatedAt: number;
@@ -266,6 +276,27 @@ export async function getTenantMaintenance(id: string) {
     tenantConfirmationUpdatedAt:
       typeof item?.tenantConfirmationUpdatedAt === "number" ? item.tenantConfirmationUpdatedAt : null,
     accessAcknowledgedAt: typeof item?.accessAcknowledgedAt === "number" ? item.accessAcknowledgedAt : null,
+    resolutionStatus:
+      item?.resolutionStatus === "completed_pending_review" ||
+      item?.resolutionStatus === "landlord_approved" ||
+      item?.resolutionStatus === "tenant_pending_signoff" ||
+      item?.resolutionStatus === "resolved" ||
+      item?.resolutionStatus === "follow_up_required"
+        ? item.resolutionStatus
+        : null,
+    landlordApprovedAt: typeof item?.landlordApprovedAt === "number" ? item.landlordApprovedAt : null,
+    tenantSignoffStatus:
+      item?.tenantSignoffStatus === "pending" ||
+      item?.tenantSignoffStatus === "accepted" ||
+      item?.tenantSignoffStatus === "declined"
+        ? item.tenantSignoffStatus
+        : null,
+    tenantSignedOffAt: typeof item?.tenantSignedOffAt === "number" ? item.tenantSignedOffAt : null,
+    tenantDeclinedAt: typeof item?.tenantDeclinedAt === "number" ? item.tenantDeclinedAt : null,
+    tenantDeclineReason: item?.tenantDeclineReason ? String(item.tenantDeclineReason) : null,
+    followUpRequired: typeof item?.followUpRequired === "boolean" ? item.followUpRequired : null,
+    followUpReason: item?.followUpReason ? String(item.followUpReason) : null,
+    finalResolvedAt: typeof item?.finalResolvedAt === "number" ? item.finalResolvedAt : null,
     createdAt: item?.createdAt || Date.now(),
     updatedAt: item?.updatedAt || item?.createdAt || Date.now(),
     statusHistory: Array.isArray(item?.statusHistory)
@@ -312,6 +343,95 @@ export async function updateTenantMaintenanceConfirmation(
     tenantConfirmationUpdatedAt:
       typeof item?.tenantConfirmationUpdatedAt === "number" ? item.tenantConfirmationUpdatedAt : null,
     accessAcknowledgedAt: typeof item?.accessAcknowledgedAt === "number" ? item.accessAcknowledgedAt : null,
+    resolutionStatus:
+      item?.resolutionStatus === "completed_pending_review" ||
+      item?.resolutionStatus === "landlord_approved" ||
+      item?.resolutionStatus === "tenant_pending_signoff" ||
+      item?.resolutionStatus === "resolved" ||
+      item?.resolutionStatus === "follow_up_required"
+        ? item.resolutionStatus
+        : null,
+    landlordApprovedAt: typeof item?.landlordApprovedAt === "number" ? item.landlordApprovedAt : null,
+    tenantSignoffStatus:
+      item?.tenantSignoffStatus === "pending" ||
+      item?.tenantSignoffStatus === "accepted" ||
+      item?.tenantSignoffStatus === "declined"
+        ? item.tenantSignoffStatus
+        : null,
+    tenantSignedOffAt: typeof item?.tenantSignedOffAt === "number" ? item.tenantSignedOffAt : null,
+    tenantDeclinedAt: typeof item?.tenantDeclinedAt === "number" ? item.tenantDeclinedAt : null,
+    tenantDeclineReason: item?.tenantDeclineReason ? String(item.tenantDeclineReason) : null,
+    followUpRequired: typeof item?.followUpRequired === "boolean" ? item.followUpRequired : null,
+    followUpReason: item?.followUpReason ? String(item.followUpReason) : null,
+    finalResolvedAt: typeof item?.finalResolvedAt === "number" ? item.finalResolvedAt : null,
+    evidence: Array.isArray((item as any)?.evidence) ? (item as any).evidence : [],
+    createdAt: item?.createdAt || Date.now(),
+    updatedAt: item?.updatedAt || item?.createdAt || Date.now(),
+    statusHistory: Array.isArray(item?.statusHistory)
+      ? item.statusHistory.map((entry) => ({
+          status: String(entry?.status || ""),
+          actorRole: String(entry?.actorRole || ""),
+          actorId: entry?.actorId ? String(entry.actorId) : null,
+          message: entry?.message ? String(entry.message) : null,
+          createdAt: typeof entry?.createdAt === "number" ? entry.createdAt : undefined,
+        }))
+      : [],
+  };
+  return { ok: true, item: mapped, data: mapped };
+}
+
+export async function updateTenantMaintenanceSignoff(
+  id: string,
+  payload: {
+    decision: "resolved" | "not_resolved";
+    reason?: string;
+  }
+) {
+  const item = await updateTenantWorkspaceMaintenanceSignoff(id, payload);
+  const mapped: MaintenanceWorkflowItem = {
+    id: item?.requestId || id,
+    tenantId: "",
+    landlordId: "",
+    propertyId: null,
+    unitId: null,
+    title: item?.title || "Maintenance request",
+    description: item?.summary || "",
+    category: String(item?.category || "GENERAL"),
+    priority: String(item?.priority || "normal").toLowerCase() as "low" | "normal" | "urgent",
+    status: String(item?.status || "submitted").toLowerCase() as MaintenanceWorkflowStatus,
+    assignedContractorName: item?.assignedContractorName || null,
+    contractorStatus: item?.contractorStatus || null,
+    serviceWindowStartAt: typeof item?.serviceWindowStartAt === "number" ? item.serviceWindowStartAt : null,
+    serviceWindowEndAt: typeof item?.serviceWindowEndAt === "number" ? item.serviceWindowEndAt : null,
+    accessRequired: typeof item?.accessRequired === "boolean" ? item.accessRequired : null,
+    tenantConfirmationStatus:
+      item?.tenantConfirmationStatus === "confirmed" || item?.tenantConfirmationStatus === "needs_schedule_change"
+        ? item.tenantConfirmationStatus
+        : null,
+    tenantConfirmationUpdatedAt:
+      typeof item?.tenantConfirmationUpdatedAt === "number" ? item.tenantConfirmationUpdatedAt : null,
+    accessAcknowledgedAt: typeof item?.accessAcknowledgedAt === "number" ? item.accessAcknowledgedAt : null,
+    resolutionStatus:
+      item?.resolutionStatus === "completed_pending_review" ||
+      item?.resolutionStatus === "landlord_approved" ||
+      item?.resolutionStatus === "tenant_pending_signoff" ||
+      item?.resolutionStatus === "resolved" ||
+      item?.resolutionStatus === "follow_up_required"
+        ? item.resolutionStatus
+        : null,
+    landlordApprovedAt: typeof item?.landlordApprovedAt === "number" ? item.landlordApprovedAt : null,
+    tenantSignoffStatus:
+      item?.tenantSignoffStatus === "pending" ||
+      item?.tenantSignoffStatus === "accepted" ||
+      item?.tenantSignoffStatus === "declined"
+        ? item.tenantSignoffStatus
+        : null,
+    tenantSignedOffAt: typeof item?.tenantSignedOffAt === "number" ? item.tenantSignedOffAt : null,
+    tenantDeclinedAt: typeof item?.tenantDeclinedAt === "number" ? item.tenantDeclinedAt : null,
+    tenantDeclineReason: item?.tenantDeclineReason ? String(item.tenantDeclineReason) : null,
+    followUpRequired: typeof item?.followUpRequired === "boolean" ? item.followUpRequired : null,
+    followUpReason: item?.followUpReason ? String(item.followUpReason) : null,
+    finalResolvedAt: typeof item?.finalResolvedAt === "number" ? item.finalResolvedAt : null,
     createdAt: item?.createdAt || Date.now(),
     updatedAt: item?.updatedAt || item?.createdAt || Date.now(),
     statusHistory: Array.isArray(item?.statusHistory)

--- a/rentchain-frontend/src/api/tenantPortal.ts
+++ b/rentchain-frontend/src/api/tenantPortal.ts
@@ -65,6 +65,26 @@ export type TenantWorkspaceMaintenance = {
   tenantConfirmationStatus?: "confirmed" | "needs_schedule_change" | null;
   tenantConfirmationUpdatedAt?: number | null;
   accessAcknowledgedAt?: number | null;
+  resolutionStatus?: "completed_pending_review" | "landlord_approved" | "tenant_pending_signoff" | "resolved" | "follow_up_required" | null;
+  landlordApprovedAt?: number | null;
+  tenantSignoffStatus?: "pending" | "accepted" | "declined" | null;
+  tenantSignedOffAt?: number | null;
+  tenantDeclinedAt?: number | null;
+  tenantDeclineReason?: string | null;
+  followUpRequired?: boolean | null;
+  followUpReason?: string | null;
+  finalResolvedAt?: number | null;
+  evidence?: Array<{
+    id: string;
+    url: string | null;
+    filename?: string | null;
+    contentType?: string | null;
+    uploadedAt?: number | null;
+    uploadedByActorRole?: string | null;
+    evidenceType?: string | null;
+    caption?: string | null;
+    visibility?: "tenant_safe";
+  }>;
   createdAt: number | null;
   updatedAt: number | null;
   statusHistory?: Array<{
@@ -136,6 +156,23 @@ export async function updateTenantWorkspaceMaintenanceConfirmation(
 ) {
   const res = await tenantApiFetch<{ ok: boolean; data: TenantWorkspaceMaintenance }>(
     `/tenant/maintenance-requests/${encodeURIComponent(id)}/confirmation`,
+    {
+      method: "POST",
+      body: payload,
+    }
+  );
+  return res?.data;
+}
+
+export async function updateTenantWorkspaceMaintenanceSignoff(
+  id: string,
+  payload: {
+    decision: "resolved" | "not_resolved";
+    reason?: string;
+  }
+) {
+  const res = await tenantApiFetch<{ ok: boolean; data: TenantWorkspaceMaintenance }>(
+    `/tenant/maintenance/${encodeURIComponent(id)}/signoff`,
     {
       method: "POST",
       body: payload,

--- a/rentchain-frontend/src/api/workOrdersApi.ts
+++ b/rentchain-frontend/src/api/workOrdersApi.ts
@@ -41,6 +41,16 @@ export type WorkOrderRecord = {
   completedByActorId?: string | null;
   completionConfirmedByLandlordAt?: number | null;
   completionConfirmedByLandlordBy?: string | null;
+  resolutionStatus?: "completed_pending_review" | "landlord_approved" | "tenant_pending_signoff" | "resolved" | "follow_up_required" | null;
+  landlordApprovedAt?: number | null;
+  landlordApprovedBy?: string | null;
+  tenantSignoffStatus?: "pending" | "accepted" | "declined" | null;
+  tenantSignedOffAt?: number | null;
+  tenantDeclinedAt?: number | null;
+  tenantDeclineReason?: string | null;
+  followUpRequired?: boolean | null;
+  followUpReason?: string | null;
+  finalResolvedAt?: number | null;
   reopenedAt?: number | null;
   reopenedByActorId?: string | null;
   reopenedByActorRole?: "landlord" | "admin" | null;
@@ -194,6 +204,27 @@ export async function confirmWorkOrderCompletion(workOrderId: string): Promise<W
     { method: "POST" }
   );
   if (!res?.ok || !res.item) throw new Error("Failed to confirm work order completion");
+  return res.item;
+}
+
+export async function approveWorkOrderResolution(workOrderId: string): Promise<WorkOrderRecord> {
+  const res = await apiFetch<{ ok: boolean; item: WorkOrderRecord }>(
+    `/landlord/work-orders/${encodeURIComponent(workOrderId)}/approve-resolution`,
+    { method: "POST" }
+  );
+  if (!res?.ok || !res.item) throw new Error("Failed to approve work order resolution");
+  return res.item;
+}
+
+export async function markWorkOrderFollowUpRequired(
+  workOrderId: string,
+  payload: { reason: string }
+): Promise<WorkOrderRecord> {
+  const res = await apiFetch<{ ok: boolean; item: WorkOrderRecord }>(
+    `/landlord/work-orders/${encodeURIComponent(workOrderId)}/mark-follow-up-required`,
+    { method: "POST", body: payload }
+  );
+  if (!res?.ok || !res.item) throw new Error("Failed to mark work order follow-up required");
   return res.item;
 }
 

--- a/rentchain-frontend/src/pages/landlord/WorkOrdersPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/WorkOrdersPage.test.tsx
@@ -9,7 +9,9 @@ const mocks = vi.hoisted(() => ({
   listWorkOrderUpdates: vi.fn(),
   getWorkOrder: vi.fn(),
   patchWorkOrder: vi.fn(),
+  approveWorkOrderResolution: vi.fn(),
   confirmWorkOrderCompletion: vi.fn(),
+  markWorkOrderFollowUpRequired: vi.fn(),
   reopenWorkOrder: vi.fn(),
   uploadWorkOrderEvidence: vi.fn(),
   updateWorkOrderEvidence: vi.fn(),
@@ -26,12 +28,14 @@ vi.mock("@/hooks/useEntitlements", () => ({
 
 vi.mock("../../api/workOrdersApi", () => ({
   addWorkOrderUpdate: mocks.addWorkOrderUpdate,
+  approveWorkOrderResolution: mocks.approveWorkOrderResolution,
   completeWorkOrder: vi.fn(),
   confirmWorkOrderCompletion: mocks.confirmWorkOrderCompletion,
   getContractorProfileById: mocks.getContractorProfileById,
   getWorkOrder: mocks.getWorkOrder,
   listWorkOrderUpdates: mocks.listWorkOrderUpdates,
   listWorkOrders: mocks.listWorkOrders,
+  markWorkOrderFollowUpRequired: mocks.markWorkOrderFollowUpRequired,
   patchWorkOrder: mocks.patchWorkOrder,
   reopenWorkOrder: mocks.reopenWorkOrder,
   updateWorkOrderEvidence: mocks.updateWorkOrderEvidence,
@@ -73,7 +77,9 @@ describe("WorkOrdersPage", () => {
     mocks.listWorkOrderUpdates.mockReset();
     mocks.getWorkOrder.mockReset();
     mocks.patchWorkOrder.mockReset();
+    mocks.approveWorkOrderResolution.mockReset();
     mocks.confirmWorkOrderCompletion.mockReset();
+    mocks.markWorkOrderFollowUpRequired.mockReset();
     mocks.reopenWorkOrder.mockReset();
     mocks.uploadWorkOrderEvidence.mockReset();
     mocks.updateWorkOrderEvidence.mockReset();
@@ -175,6 +181,12 @@ describe("WorkOrdersPage", () => {
       completedByActorRole: "contractor",
       completionConfirmedByLandlordAt: 40,
       completionConfirmedByLandlordBy: "landlord-1",
+      resolutionStatus: "completed_pending_review",
+      landlordApprovedAt: null,
+      tenantSignoffStatus: null,
+      followUpRequired: false,
+      followUpReason: null,
+      finalResolvedAt: null,
       reopenedAt: null,
       reopenedByActorId: null,
       reopenedByActorRole: null,
@@ -185,7 +197,9 @@ describe("WorkOrdersPage", () => {
       createdAtMs: 1,
       updatedAtMs: 40,
     });
+    mocks.approveWorkOrderResolution.mockResolvedValue({ ok: true });
     mocks.confirmWorkOrderCompletion.mockResolvedValue({ ok: true });
+    mocks.markWorkOrderFollowUpRequired.mockResolvedValue({ ok: true });
     mocks.reopenWorkOrder.mockResolvedValue({ ok: true });
 
     render(
@@ -199,11 +213,29 @@ describe("WorkOrdersPage", () => {
     expect(await screen.findByText(/Execution and completion/i)).toBeInTheDocument();
     expect(screen.getByText(/Replaced igniter and restored heat/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /confirm completion/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /approve resolution/i })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /confirm completion/i }));
 
     await waitFor(() => {
       expect(mocks.confirmWorkOrderCompletion).toHaveBeenCalledWith("wo-1");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /approve resolution/i }));
+
+    await waitFor(() => {
+      expect(mocks.approveWorkOrderResolution).toHaveBeenCalledWith("wo-1");
+    });
+
+    fireEvent.change(screen.getByPlaceholderText(/Explain why this work still needs follow-up/i), {
+      target: { value: "Heat is still uneven near the bedroom wall." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /mark follow-up required/i }));
+
+    await waitFor(() => {
+      expect(mocks.markWorkOrderFollowUpRequired).toHaveBeenCalledWith("wo-1", {
+        reason: "Heat is still uneven near the bedroom wall.",
+      });
     });
 
     fireEvent.change(screen.getByPlaceholderText(/Explain why this work order needs follow-up/i), {

--- a/rentchain-frontend/src/pages/landlord/WorkOrdersPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/WorkOrdersPage.tsx
@@ -7,11 +7,13 @@ import { LockedFeature } from "@/components/billing/LockedFeature";
 import { fetchProperties } from "../../api/propertiesApi";
 import {
   addWorkOrderUpdate,
+  approveWorkOrderResolution,
   confirmWorkOrderCompletion,
   getWorkOrder,
   getContractorProfileById,
   listWorkOrderUpdates,
   listWorkOrders,
+  markWorkOrderFollowUpRequired,
   patchWorkOrder,
   reopenWorkOrder,
   updateWorkOrderEvidence,
@@ -36,8 +38,29 @@ function canConfirmCompletion(item: WorkOrderRecord) {
   return item.status === "completed" && !item.completionConfirmedByLandlordAt;
 }
 
+function canApproveResolution(item: WorkOrderRecord) {
+  return item.status === "completed" && item.resolutionStatus !== "tenant_pending_signoff" && item.resolutionStatus !== "resolved";
+}
+
 function canReopenWorkOrder(item: WorkOrderRecord) {
   return item.status === "completed";
+}
+
+function resolutionStatusLabel(value?: WorkOrderRecord["resolutionStatus"]) {
+  switch (value) {
+    case "completed_pending_review":
+      return "Completed, pending review";
+    case "landlord_approved":
+      return "Landlord approved";
+    case "tenant_pending_signoff":
+      return "Awaiting tenant signoff";
+    case "resolved":
+      return "Resolved";
+    case "follow_up_required":
+      return "Follow-up required";
+    default:
+      return "Not set";
+  }
 }
 
 function completionOutcomeLabel(value?: WorkOrderRecord["completionOutcome"]) {
@@ -96,6 +119,7 @@ export default function WorkOrdersPage() {
     "completed"
   );
   const [reopenReason, setReopenReason] = React.useState("");
+  const [followUpReason, setFollowUpReason] = React.useState("");
   const [savingNote, setSavingNote] = React.useState(false);
   const [savingAction, setSavingAction] = React.useState(false);
   const [savingEvidence, setSavingEvidence] = React.useState(false);
@@ -203,6 +227,46 @@ export default function WorkOrdersPage() {
     [load, refreshSelected]
   );
 
+  const handleApproveResolution = React.useCallback(
+    async (item: WorkOrderRecord) => {
+      if (!canApproveResolution(item)) return;
+      setSavingAction(true);
+      setError(null);
+      try {
+        await approveWorkOrderResolution(item.id);
+        await load();
+        await refreshSelected(item.id);
+      } catch (err: any) {
+        setError(String(err?.message || "Failed to approve resolution"));
+      } finally {
+        setSavingAction(false);
+      }
+    },
+    [load, refreshSelected]
+  );
+
+  const handleMarkFollowUpRequired = React.useCallback(
+    async (item: WorkOrderRecord) => {
+      if (!item || item.status !== "completed") return;
+      if (!followUpReason.trim()) {
+        setError("Add a follow-up reason before marking the work order for follow-up.");
+        return;
+      }
+      setSavingAction(true);
+      setError(null);
+      try {
+        await markWorkOrderFollowUpRequired(item.id, { reason: followUpReason.trim() });
+        await load();
+        await refreshSelected(item.id);
+      } catch (err: any) {
+        setError(String(err?.message || "Failed to mark follow-up required"));
+      } finally {
+        setSavingAction(false);
+      }
+    },
+    [followUpReason, load, refreshSelected]
+  );
+
   const handleReopen = React.useCallback(
     async (item: WorkOrderRecord, status: "in_progress" | "blocked") => {
       if (!canReopenWorkOrder(item)) return;
@@ -275,6 +339,7 @@ export default function WorkOrdersPage() {
       setCompletionSummary("");
       setCompletionOutcome("completed");
       setReopenReason("");
+      setFollowUpReason("");
       setEvidenceFile(null);
       setEvidenceCaption("");
       setEvidenceType("inspection");
@@ -288,6 +353,7 @@ export default function WorkOrdersPage() {
         : "completed"
     );
     setReopenReason(String(selected.reopenReason || ""));
+    setFollowUpReason(String(selected.followUpReason || ""));
   }, [selected]);
 
   React.useEffect(() => {
@@ -587,6 +653,10 @@ export default function WorkOrdersPage() {
                       : "Awaiting review"}
                   </div>
                 </div>
+                <div>
+                  <div style={{ fontSize: 12, color: "#64748b" }}>Resolution state</div>
+                  <div style={{ marginTop: 4, fontWeight: 600 }}>{resolutionStatusLabel(selected.resolutionStatus)}</div>
+                </div>
               </div>
               {selected.executionBlockedReason ? (
                 <div>
@@ -604,6 +674,12 @@ export default function WorkOrdersPage() {
                 <div>
                   <div style={{ fontSize: 12, color: "#64748b" }}>Last reopen reason</div>
                   <div style={{ marginTop: 4 }}>{selected.reopenReason}</div>
+                </div>
+              ) : null}
+              {selected.followUpReason ? (
+                <div>
+                  <div style={{ fontSize: 12, color: "#64748b" }}>Follow-up reason</div>
+                  <div style={{ marginTop: 4 }}>{selected.followUpReason}</div>
                 </div>
               ) : null}
             </div>
@@ -764,6 +840,25 @@ export default function WorkOrdersPage() {
                 <Button disabled={savingAction} onClick={() => void handleConfirmCompletion(selected)}>
                   {savingAction ? "Saving..." : "Confirm completion"}
                 </Button>
+              ) : null}
+              {canApproveResolution(selected) ? (
+                <Button disabled={savingAction} onClick={() => void handleApproveResolution(selected)}>
+                  {savingAction ? "Saving..." : "Approve resolution"}
+                </Button>
+              ) : null}
+              {selected.status === "completed" ? (
+                <>
+                  <textarea
+                    value={followUpReason}
+                    onChange={(e) => setFollowUpReason(e.target.value)}
+                    placeholder="Explain why this work still needs follow-up"
+                    rows={3}
+                    style={{ width: "100%", borderRadius: 8, border: "1px solid #cbd5e1", padding: 8, resize: "vertical" }}
+                  />
+                  <Button variant="secondary" disabled={savingAction} onClick={() => void handleMarkFollowUpRequired(selected)}>
+                    {savingAction ? "Saving..." : "Mark follow-up required"}
+                  </Button>
+                </>
               ) : null}
               {canReopenWorkOrder(selected) ? (
                 <>

--- a/rentchain-frontend/src/pages/tenant/TenantMaintenancePages.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantMaintenancePages.test.tsx
@@ -11,6 +11,7 @@ const maintenanceWorkflowApi = vi.hoisted(() => ({
   getTenantMaintenance: vi.fn(),
   createTenantMaintenance: vi.fn(),
   updateTenantMaintenanceConfirmation: vi.fn(),
+  updateTenantMaintenanceSignoff: vi.fn(),
 }));
 
 const tenantAuth = vi.hoisted(() => ({
@@ -28,6 +29,7 @@ vi.mock("../../api/maintenanceWorkflowApi", async () => {
     getTenantMaintenance: maintenanceWorkflowApi.getTenantMaintenance,
     createTenantMaintenance: maintenanceWorkflowApi.createTenantMaintenance,
     updateTenantMaintenanceConfirmation: maintenanceWorkflowApi.updateTenantMaintenanceConfirmation,
+    updateTenantMaintenanceSignoff: maintenanceWorkflowApi.updateTenantMaintenanceSignoff,
   };
 });
 
@@ -202,6 +204,63 @@ describe("tenant maintenance pages", () => {
       });
     });
     expect(await screen.findByText(/The tenant has confirmed the service window and acknowledged the access requirement/i)).toBeInTheDocument();
+  });
+
+  it("submits tenant resolution signoff from the detail page", async () => {
+    maintenanceWorkflowApi.getTenantMaintenance.mockResolvedValue({
+      item: {
+        id: "maint-1",
+        title: "Broken heater",
+        description: "The heat is not turning on.",
+        status: "completed",
+        priority: "urgent",
+        category: "HVAC",
+        assignedContractorName: "North Shore HVAC",
+        contractorStatus: "completed",
+        resolutionStatus: "tenant_pending_signoff",
+        landlordApprovedAt: 350,
+        createdAt: 100,
+        updatedAt: 400,
+        statusHistory: [],
+      },
+    });
+    maintenanceWorkflowApi.updateTenantMaintenanceSignoff.mockResolvedValue({
+      item: {
+        id: "maint-1",
+        title: "Broken heater",
+        description: "The heat is not turning on.",
+        status: "completed",
+        priority: "urgent",
+        category: "HVAC",
+        assignedContractorName: "North Shore HVAC",
+        contractorStatus: "completed",
+        resolutionStatus: "resolved",
+        tenantSignoffStatus: "accepted",
+        tenantSignedOffAt: 500,
+        finalResolvedAt: 500,
+        createdAt: 100,
+        updatedAt: 500,
+        statusHistory: [],
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/tenant/maintenance/maint-1"]}>
+        <Routes>
+          <Route path="/tenant/maintenance/:id" element={<TenantMaintenanceRequestDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /Mark resolved/i }));
+
+    await waitFor(() => {
+      expect(maintenanceWorkflowApi.updateTenantMaintenanceSignoff).toHaveBeenCalledWith("maint-1", {
+        decision: "resolved",
+        reason: undefined,
+      });
+    });
+    expect(await screen.findByText(/This request has been marked resolved/i)).toBeInTheDocument();
   });
 
   it("submits the tenant maintenance request form", async () => {

--- a/rentchain-frontend/src/pages/tenant/TenantMaintenanceRequestDetailPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantMaintenanceRequestDetailPage.tsx
@@ -3,6 +3,7 @@ import { useParams } from "react-router-dom";
 import {
   getTenantMaintenance,
   updateTenantMaintenanceConfirmation,
+  updateTenantMaintenanceSignoff,
   type MaintenanceWorkflowItem,
 } from "../../api/maintenanceWorkflowApi";
 import { Button, Card, Section } from "../../components/ui/Ui";
@@ -21,12 +22,30 @@ function fmtDate(ts?: number | null) {
   return new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric", year: "numeric" }).format(d);
 }
 
+function resolutionStatusLabel(value?: MaintenanceWorkflowItem["resolutionStatus"]) {
+  switch (value) {
+    case "completed_pending_review":
+      return "Completed and waiting for landlord review.";
+    case "landlord_approved":
+      return "Landlord approved the completed work.";
+    case "tenant_pending_signoff":
+      return "Your review is needed before this request is fully resolved.";
+    case "resolved":
+      return "This request has been marked resolved.";
+    case "follow_up_required":
+      return "This request needs follow-up before it can be fully resolved.";
+    default:
+      return "No resolution decision has been recorded yet.";
+  }
+}
+
 export default function TenantMaintenanceRequestDetailPage() {
   const { id } = useParams();
   const [data, setData] = useState<MaintenanceWorkflowItem | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [savingAction, setSavingAction] = useState(false);
+  const [signoffReason, setSignoffReason] = useState("");
   const [sessionExpired, setSessionExpired] = useState(false);
   const [hasToken, setHasToken] = useState<boolean>(() =>
     typeof window === "undefined" ? true : !!getTenantToken()
@@ -123,6 +142,31 @@ export default function TenantMaintenanceRequestDetailPage() {
       setData((res as any)?.item || (res as any)?.data || null);
     } catch (err: any) {
       const msg = err?.payload?.error || err?.message || "Unable to update the maintenance confirmation.";
+      setError(String(msg));
+    } finally {
+      setSavingAction(false);
+    }
+  };
+
+  const applyResolutionSignoff = async (decision: "resolved" | "not_resolved") => {
+    if (!id) return;
+    if (decision === "not_resolved" && !signoffReason.trim()) {
+      setError("Add a reason before requesting follow-up.");
+      return;
+    }
+    setSavingAction(true);
+    setError(null);
+    try {
+      const res = await updateTenantMaintenanceSignoff(id, {
+        decision,
+        reason: decision === "not_resolved" ? signoffReason.trim() : undefined,
+      });
+      setData((res as any)?.item || (res as any)?.data || null);
+      if (decision === "resolved") {
+        setSignoffReason("");
+      }
+    } catch (err: any) {
+      const msg = err?.payload?.error || err?.message || "Unable to update the maintenance resolution.";
       setError(String(msg));
     } finally {
       setSavingAction(false);
@@ -342,6 +386,66 @@ export default function TenantMaintenanceRequestDetailPage() {
                   ) : null}
                 </div>
               ) : null}
+              <div
+                style={{
+                  border: `1px solid ${colors.border}`,
+                  borderRadius: radius.md,
+                  padding: "12px 14px",
+                  background: colors.panel,
+                  display: "grid",
+                  gap: 8,
+                }}
+              >
+                <div style={{ fontWeight: 800, color: textTokens.primary }}>Resolution approval</div>
+                <div style={{ color: textTokens.secondary }}>{resolutionStatusLabel(data.resolutionStatus)}</div>
+                {data.landlordApprovedAt ? (
+                  <div style={{ color: textTokens.secondary }}>Landlord approved the completed work on {fmtDate(data.landlordApprovedAt)}.</div>
+                ) : null}
+                {data.finalResolvedAt ? (
+                  <div style={{ color: textTokens.secondary }}>Final resolution recorded on {fmtDate(data.finalResolvedAt)}.</div>
+                ) : null}
+                {data.followUpReason ? (
+                  <>
+                    <div style={{ color: textTokens.primary, fontWeight: 700 }}>Follow-up reason</div>
+                    <div style={{ color: textTokens.secondary }}>{data.followUpReason}</div>
+                  </>
+                ) : null}
+                {data.tenantDeclineReason ? (
+                  <>
+                    <div style={{ color: textTokens.primary, fontWeight: 700 }}>Your latest note</div>
+                    <div style={{ color: textTokens.secondary }}>{data.tenantDeclineReason}</div>
+                  </>
+                ) : null}
+                {data.status === "completed" && data.resolutionStatus === "tenant_pending_signoff" ? (
+                  <>
+                    <div style={{ color: textTokens.primary, fontWeight: 700 }}>Next step</div>
+                    <div style={{ color: textTokens.secondary }}>
+                      Review the completed work and let your landlord know whether the issue is fully resolved.
+                    </div>
+                    <textarea
+                      value={signoffReason}
+                      onChange={(e) => setSignoffReason(e.target.value)}
+                      placeholder="If follow-up is still needed, explain what is incomplete or still not working"
+                      rows={3}
+                      style={{
+                        width: "100%",
+                        borderRadius: 8,
+                        border: `1px solid ${colors.border}`,
+                        padding: 10,
+                        resize: "vertical",
+                      }}
+                    />
+                    <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                      <Button variant="secondary" disabled={savingAction} onClick={() => void applyResolutionSignoff("resolved")}>
+                        {savingAction ? "Saving..." : "Mark resolved"}
+                      </Button>
+                      <Button variant="ghost" disabled={savingAction} onClick={() => void applyResolutionSignoff("not_resolved")}>
+                        {savingAction ? "Saving..." : "Request follow-up"}
+                      </Button>
+                    </div>
+                  </>
+                ) : null}
+              </div>
               {Array.isArray(data.evidence) && data.evidence.length ? (
                 <div
                   style={{


### PR DESCRIPTION
## Summary
Adds a structured maintenance resolution approval and tenant signoff layer after work completion.

This PR distinguishes completed work from approved work, tenant-confirmed resolution, and follow-up-required outcomes by extending the existing maintenance/work-order workflow with explicit resolution states and signoff actions.

## Scope
- structured resolution/signoff metadata on work orders
- landlord resolution approval and follow-up-required actions
- tenant maintenance signoff flow
- tenant-safe projection of resolution state
- focused backend and frontend tests

## Resolution states
The workflow now supports clearer post-completion states:
- completed pending review
- landlord approved
- tenant pending signoff
- resolved
- follow-up required

Additional tracked fields include:
- landlord approval timestamp/user
- tenant signoff status
- tenant signoff / decline timestamps
- tenant decline reason
- follow-up-required flag/reason
- final resolved timestamp

## Implementation notes
- `workOrders` remain the canonical source of truth
- contractor and in-house completion now initialize `completed_pending_review`
- landlord actions add:
  - `POST /landlord/work-orders/:id/approve-resolution`
  - `POST /landlord/work-orders/:id/mark-follow-up-required`
- tenant action adds:
  - `POST /tenant/maintenance/:id/signoff`
- tenant responses expose only safe resolution/signoff fields
- existing reopen flow is preserved rather than replaced

## Validation
- Focused backend tests passed
- Focused frontend tests passed
- Backend build passed
- Frontend build passed

## Limitations
- No auto-reopen behavior when tenant requests follow-up
- No new notification orchestration beyond existing timeline/history patterns
- Tenant signoff is available from maintenance detail, not a separate task center