### PR TITLE
feat(maintenance): add rework resolution review and second-pass closu…

### DIFF
--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -480,7 +480,7 @@ describe("tenantPortalRoutes foundation", () => {
     expect(savedWorkOrder?.finalResolvedAt).toBeDefined();
   });
 
-  it("returns tenant-safe rework state and allows signoff again after rework completion", async () => {
+  it("returns tenant-safe rework state and allows rework signoff again after rework completion", async () => {
     const router = (await import("../tenantPortalRoutes")).default;
     ensureCollection("maintenanceRequests").set("maint-3", {
       tenantId: "tenant-1",
@@ -517,6 +517,18 @@ describe("tenantPortalRoutes foundation", () => {
           notes: "Second pass complete.",
         },
       ],
+      reworkReview: {
+        status: "tenant_pending_signoff",
+        reviewedAt: 370,
+        reviewedBy: "landlord-1",
+        landlordReviewNote: "Please confirm whether the return visit resolved the issue.",
+        tenantSignoffStatus: "pending",
+        tenantSignedOffAt: null,
+        tenantDeclinedAt: null,
+        tenantDeclineReason: null,
+        closureOutcome: null,
+        closedAt: null,
+      },
     });
 
     const detailRes = await invokeRouter(router, {
@@ -540,10 +552,16 @@ describe("tenantPortalRoutes foundation", () => {
         completionSummary: expect.stringMatching(/Balanced vents/i),
       })
     );
+    expect(detailRes.body?.data?.reworkReview).toEqual(
+      expect.objectContaining({
+        status: "tenant_pending_signoff",
+        tenantSignoffStatus: "pending",
+      })
+    );
 
     const signoffRes = await invokeRouter(router, {
       method: "POST",
-      url: "/maintenance/maint-3/signoff",
+      url: "/maintenance/maint-3/rework-signoff",
       headers: {
         "x-test-user": JSON.stringify({
           id: "user-1",
@@ -559,9 +577,73 @@ describe("tenantPortalRoutes foundation", () => {
 
     expect(signoffRes.status).toBe(200);
     expect(signoffRes.body?.data?.resolutionStatus).toBe("resolved");
-    expect(signoffRes.body?.data?.reworkHistory).toEqual(
-      expect.arrayContaining([expect.objectContaining({ cycleNumber: 1, outcome: "resolved" })])
+    expect(signoffRes.body?.data?.reworkReview).toEqual(
+      expect.objectContaining({
+        status: "closed",
+        tenantSignoffStatus: "accepted",
+        closureOutcome: "resolved",
+      })
     );
+  });
+
+  it("requires the dedicated rework signoff route when a second-pass review is pending", async () => {
+    const router = (await import("../tenantPortalRoutes")).default;
+    ensureCollection("maintenanceRequests").set("maint-3b", {
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      status: "completed",
+      priority: "NORMAL",
+      category: "GENERAL",
+      title: "Heater follow-up",
+      description: "Bedroom still cool.",
+      statusHistory: [],
+      createdAt: 100,
+      updatedAt: 200,
+    });
+    ensureCollection("workOrders").set("maintenance_maint-3b", {
+      maintenanceRequestId: "maint-3b",
+      tenantId: "tenant-1",
+      status: "completed",
+      resolutionStatus: "tenant_pending_signoff",
+      reworkCycle: {
+        cycleNumber: 1,
+        status: "completed",
+        createdAt: 300,
+        createdBy: "landlord-1",
+        completedAt: 360,
+      },
+      reworkReview: {
+        status: "tenant_pending_signoff",
+        reviewedAt: 370,
+        reviewedBy: "landlord-1",
+        landlordReviewNote: null,
+        tenantSignoffStatus: "pending",
+        tenantSignedOffAt: null,
+        tenantDeclinedAt: null,
+        tenantDeclineReason: null,
+        closureOutcome: null,
+        closedAt: null,
+      },
+    });
+
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/maintenance/maint-3b/signoff",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+      body: {
+        decision: "resolved",
+      },
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body?.error).toBe("REWORK_SIGNOFF_REQUIRED");
   });
 
   it("requires a reason when the tenant reports the issue is not resolved", async () => {

--- a/rentchain-api/src/routes/__tests__/workOrdersRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/workOrdersRoutes.test.ts
@@ -521,6 +521,114 @@ describe("workOrdersRoutes execution completion", () => {
     );
   });
 
+  it("reviews a completed rework cycle and advances it to tenant signoff when a tenant is attached", async () => {
+    const router = (await import("../workOrdersRoutes")).default;
+    ensureCollection("workOrders").set("wo-1", {
+      ...ensureCollection("workOrders").get("wo-1"),
+      status: "completed",
+      tenantId: "tenant-1",
+      resolutionStatus: "completed_pending_review",
+      reworkCycle: {
+        cycleNumber: 2,
+        status: "completed",
+        createdAt: 1000,
+        createdBy: "landlord-1",
+        startedAt: 1100,
+        completedAt: 1200,
+        completionSummary: "Balanced the vents and sealed the remaining draft.",
+      },
+      reworkReview: {
+        status: "pending_review",
+        reviewedAt: null,
+        reviewedBy: null,
+        landlordReviewNote: null,
+        tenantSignoffStatus: null,
+        tenantSignedOffAt: null,
+        tenantDeclinedAt: null,
+        tenantDeclineReason: null,
+        closureOutcome: null,
+        closedAt: null,
+      },
+    });
+
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/landlord/work-orders/wo-1/review-rework-resolution",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "landlord-1",
+          role: "landlord",
+          landlordId: "landlord-1",
+        }),
+      },
+      body: {
+        decision: "approve",
+        note: "Second pass looks good. Sending to the tenant for final confirmation.",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.item?.resolutionStatus).toBe("tenant_pending_signoff");
+    expect(res.body?.item?.reworkReview?.status).toBe("tenant_pending_signoff");
+
+    const savedWorkOrder = ensureCollection("workOrders").get("wo-1");
+    expect(savedWorkOrder?.reworkReview?.tenantSignoffStatus).toBe("pending");
+    expect(savedWorkOrder?.reworkReview?.landlordReviewNote).toMatch(/final confirmation/i);
+  });
+
+  it("closes a completed rework cycle directly when tenant signoff is not required", async () => {
+    const router = (await import("../workOrdersRoutes")).default;
+    ensureCollection("workOrders").set("wo-1", {
+      ...ensureCollection("workOrders").get("wo-1"),
+      status: "completed",
+      resolutionStatus: "completed_pending_review",
+      reworkCycle: {
+        cycleNumber: 1,
+        status: "completed",
+        createdAt: 1000,
+        createdBy: "landlord-1",
+        startedAt: 1100,
+        completedAt: 1200,
+        completionSummary: "In-house follow-up completed.",
+      },
+      reworkReview: {
+        status: "pending_review",
+        reviewedAt: null,
+        reviewedBy: null,
+        landlordReviewNote: null,
+        tenantSignoffStatus: null,
+        tenantSignedOffAt: null,
+        tenantDeclinedAt: null,
+        tenantDeclineReason: null,
+        closureOutcome: null,
+        closedAt: null,
+      },
+    });
+
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/landlord/work-orders/wo-1/close-rework-directly",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "landlord-1",
+          role: "landlord",
+          landlordId: "landlord-1",
+        }),
+      },
+      body: {
+        note: "Closed after in-house follow-up.",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.item?.resolutionStatus).toBe("resolved");
+    expect(res.body?.item?.reworkReview?.status).toBe("closed");
+
+    const savedWorkOrder = ensureCollection("workOrders").get("wo-1");
+    expect(savedWorkOrder?.reworkReview?.closureOutcome).toBe("resolved");
+    expect(savedWorkOrder?.finalResolvedAt).toBeDefined();
+  });
+
   it("schedules and reschedules an active rework cycle", async () => {
     const router = (await import("../workOrdersRoutes")).default;
     ensureCollection("workOrders").set("wo-1", {

--- a/rentchain-api/src/routes/maintenanceRequestsRoutes.ts
+++ b/rentchain-api/src/routes/maintenanceRequestsRoutes.ts
@@ -2308,11 +2308,53 @@ router.patch("/contractor/jobs/:id/rework-status", async (req: any, res) => {
           : null,
     };
 
+    const nextReworkHistory =
+      nextStatus === "completed"
+        ? [
+            ...(Array.isArray(workOrder?.reworkHistory)
+              ? workOrder.reworkHistory.filter(
+                  (entry: any) => Number(entry?.cycleNumber || 0) !== Number(reworkCycle?.cycleNumber || 1)
+                )
+              : []),
+            {
+              cycleNumber: Number(reworkCycle?.cycleNumber || 1),
+              startedAt:
+                typeof updatedReworkCycle?.startedAt === "number"
+                  ? updatedReworkCycle.startedAt
+                  : typeof reworkCycle?.startedAt === "number"
+                  ? reworkCycle.startedAt
+                  : null,
+              completedAt: now,
+              outcome: "resolved",
+              notes: completionSummary || null,
+            },
+          ]
+        : workOrder?.reworkHistory || [];
+
     await workOrderRef.set(
       {
         status: nextStatus === "completed" ? "completed" : "in_progress",
         assignedContractorId: contractorId,
         reworkCycle: updatedReworkCycle,
+        reworkHistory: nextReworkHistory,
+        reworkReview:
+          nextStatus === "completed"
+            ? {
+                status: "pending_review",
+                reviewedAt: null,
+                reviewedBy: null,
+                landlordReviewNote: null,
+                tenantSignoffStatus: null,
+                tenantSignedOffAt: null,
+                tenantDeclinedAt: null,
+                tenantDeclineReason: null,
+                closureOutcome: null,
+                closedAt: null,
+              }
+            : workOrder?.reworkReview || null,
+        resolutionStatus: nextStatus === "completed" ? "completed_pending_review" : workOrder?.resolutionStatus || "completed_pending_review",
+        followUpRequired: nextStatus === "completed" ? false : workOrder?.followUpRequired ?? false,
+        followUpReason: nextStatus === "completed" ? null : workOrder?.followUpReason || null,
         updatedAtMs: now,
         lastExecutionUpdateAt: now,
       },

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -4967,6 +4967,131 @@ router.get("/maintenance", requireTenant, async (req: any, res) => {
   }
 });
 
+function projectTenantSafeReworkReview(value: any) {
+  if (!value || typeof value !== "object") return null;
+  return {
+    status:
+      value.status === "pending_review" ||
+      value.status === "landlord_approved" ||
+      value.status === "tenant_pending_signoff" ||
+      value.status === "closed" ||
+      value.status === "follow_up_required"
+        ? value.status
+        : null,
+    reviewedAt: toMillis(value.reviewedAt),
+    tenantSignoffStatus:
+      value.tenantSignoffStatus === "pending" ||
+      value.tenantSignoffStatus === "accepted" ||
+      value.tenantSignoffStatus === "declined"
+        ? value.tenantSignoffStatus
+        : null,
+    tenantSignedOffAt: toMillis(value.tenantSignedOffAt),
+    tenantDeclinedAt: toMillis(value.tenantDeclinedAt),
+    tenantDeclineReason: String(value.tenantDeclineReason || "").trim() || null,
+    closureOutcome:
+      value.closureOutcome === "resolved" ||
+      value.closureOutcome === "partial" ||
+      value.closureOutcome === "needs_more_followup"
+        ? value.closureOutcome
+        : null,
+    closedAt: toMillis(value.closedAt),
+  };
+}
+
+function projectTenantSafeReworkCycle(value: any) {
+  if (!value || typeof value !== "object") return null;
+  return {
+    cycleNumber: Number(value.cycleNumber || 1),
+    status:
+      value.status === "not_started" ||
+      value.status === "assigned" ||
+      value.status === "in_progress" ||
+      value.status === "completed" ||
+      value.status === "cancelled"
+        ? value.status
+        : "not_started",
+    createdAt: toMillis(value.createdAt),
+    assignedAt: toMillis(value.assignedAt),
+    startedAt: toMillis(value.startedAt),
+    completedAt: toMillis(value.completedAt),
+    completionSummary: String(value.completionSummary || "").trim() || null,
+    schedule:
+      value.schedule && typeof value.schedule === "object"
+        ? {
+            scheduledFor: toMillis(value.schedule.scheduledFor),
+            timeWindowStart: toMillis(value.schedule.timeWindowStart),
+            timeWindowEnd: toMillis(value.schedule.timeWindowEnd),
+            status:
+              value.schedule.status === "not_scheduled" ||
+              value.schedule.status === "scheduled" ||
+              value.schedule.status === "contractor_confirmed" ||
+              value.schedule.status === "tenant_pending" ||
+              value.schedule.status === "confirmed" ||
+              value.schedule.status === "reschedule_requested" ||
+              value.schedule.status === "cancelled"
+                ? value.schedule.status
+                : null,
+            requiresTenantAccess:
+              typeof value.schedule.requiresTenantAccess === "boolean" ? value.schedule.requiresTenantAccess : null,
+            tenantAccessStatus:
+              value.schedule.tenantAccessStatus === "pending" ||
+              value.schedule.tenantAccessStatus === "confirmed" ||
+              value.schedule.tenantAccessStatus === "denied" ||
+              value.schedule.tenantAccessStatus === "not_required"
+                ? value.schedule.tenantAccessStatus
+                : null,
+            tenantAccessNote: String(value.schedule.tenantAccessNote || "").trim() || null,
+          }
+        : null,
+  };
+}
+
+function projectTenantSafeReworkHistory(value: any) {
+  return Array.isArray(value)
+    ? value.map((entry: any) => ({
+        cycleNumber: Number(entry?.cycleNumber || 1),
+        startedAt: toMillis(entry?.startedAt),
+        completedAt: toMillis(entry?.completedAt),
+        outcome:
+          entry?.outcome === "resolved" || entry?.outcome === "failed" || entry?.outcome === "partial"
+            ? entry.outcome
+            : null,
+        notes: String(entry?.notes || "").trim() || null,
+      }))
+    : [];
+}
+
+async function buildTenantMaintenanceDetailResponse(docId: string, maintenanceData: any, workOrderData: any, workOrderExists: boolean) {
+  return {
+    ...projectTenantMaintenance(docId, maintenanceData || {}),
+    evidence: workOrderExists ? await serializeEvidenceForAudience(workOrderData?.evidence, "tenant") : [],
+    resolutionStatus:
+      workOrderData?.resolutionStatus === "completed_pending_review" ||
+      workOrderData?.resolutionStatus === "landlord_approved" ||
+      workOrderData?.resolutionStatus === "tenant_pending_signoff" ||
+      workOrderData?.resolutionStatus === "resolved" ||
+      workOrderData?.resolutionStatus === "follow_up_required"
+        ? workOrderData.resolutionStatus
+        : null,
+    landlordApprovedAt: toMillis(workOrderData?.landlordApprovedAt),
+    tenantSignoffStatus:
+      workOrderData?.tenantSignoffStatus === "pending" ||
+      workOrderData?.tenantSignoffStatus === "accepted" ||
+      workOrderData?.tenantSignoffStatus === "declined"
+        ? workOrderData.tenantSignoffStatus
+        : null,
+    tenantSignedOffAt: toMillis(workOrderData?.tenantSignedOffAt),
+    tenantDeclinedAt: toMillis(workOrderData?.tenantDeclinedAt),
+    tenantDeclineReason: String(workOrderData?.tenantDeclineReason || "").trim() || null,
+    followUpRequired: typeof workOrderData?.followUpRequired === "boolean" ? workOrderData.followUpRequired : null,
+    followUpReason: String(workOrderData?.followUpReason || "").trim() || null,
+    finalResolvedAt: toMillis(workOrderData?.finalResolvedAt),
+    reworkCycle: projectTenantSafeReworkCycle(workOrderData?.reworkCycle),
+    reworkHistory: projectTenantSafeReworkHistory(workOrderData?.reworkHistory),
+    reworkReview: projectTenantSafeReworkReview(workOrderData?.reworkReview),
+  };
+}
+
 router.get("/maintenance-requests/:id", requireTenant, async (req: any, res) => {
   try {
     const tenantId = req.user?.tenantId;
@@ -4983,144 +5108,7 @@ router.get("/maintenance-requests/:id", requireTenant, async (req: any, res) => 
     }
     const workOrderSnap = await db.collection("workOrders").doc(`maintenance_${doc.id}`).get();
     const workOrderData = workOrderSnap.exists ? ((workOrderSnap.data() as any) || {}) : {};
-    const tenantSafeEvidence = workOrderSnap.exists
-      ? await serializeEvidenceForAudience(workOrderData?.evidence, "tenant")
-      : [];
-    const payload = {
-      id: doc.id,
-      requestId: doc.id,
-      landlordId: data.landlordId ?? null,
-      tenantId: data.tenantId ?? null,
-      propertyId: data.propertyId ?? null,
-      unitId: data.unitId ?? null,
-      category: data.category ?? "GENERAL",
-      priority: data.priority ?? "NORMAL",
-      title: data.title ?? "",
-      description: data.description ?? "",
-      status: data.status ?? "NEW",
-      assignedContractorName: data.assignedContractorName ?? null,
-      contractorStatus: data.contractorStatus ?? null,
-      serviceWindowStartAt: toMillis(data.serviceWindowStartAt),
-      serviceWindowEndAt: toMillis(data.serviceWindowEndAt),
-      accessRequired: typeof data.accessRequired === "boolean" ? data.accessRequired : null,
-      tenantConfirmationStatus:
-        data.tenantConfirmationStatus === "confirmed" || data.tenantConfirmationStatus === "needs_schedule_change"
-          ? data.tenantConfirmationStatus
-          : null,
-      tenantConfirmationUpdatedAt: toMillis(data.tenantConfirmationUpdatedAt),
-      accessAcknowledgedAt: toMillis(data.accessAcknowledgedAt),
-      resolutionStatus:
-        workOrderData?.resolutionStatus === "completed_pending_review" ||
-        workOrderData?.resolutionStatus === "landlord_approved" ||
-        workOrderData?.resolutionStatus === "tenant_pending_signoff" ||
-        workOrderData?.resolutionStatus === "resolved" ||
-        workOrderData?.resolutionStatus === "follow_up_required"
-          ? workOrderData.resolutionStatus
-          : data?.resolutionStatus === "completed_pending_review" ||
-            data?.resolutionStatus === "landlord_approved" ||
-            data?.resolutionStatus === "tenant_pending_signoff" ||
-            data?.resolutionStatus === "resolved" ||
-            data?.resolutionStatus === "follow_up_required"
-          ? data.resolutionStatus
-          : null,
-      landlordApprovedAt: toMillis(workOrderData?.landlordApprovedAt ?? data?.landlordApprovedAt),
-      tenantSignoffStatus:
-        workOrderData?.tenantSignoffStatus === "pending" ||
-        workOrderData?.tenantSignoffStatus === "accepted" ||
-        workOrderData?.tenantSignoffStatus === "declined"
-          ? workOrderData.tenantSignoffStatus
-          : data?.tenantSignoffStatus === "pending" ||
-            data?.tenantSignoffStatus === "accepted" ||
-            data?.tenantSignoffStatus === "declined"
-          ? data.tenantSignoffStatus
-          : null,
-      tenantSignedOffAt: toMillis(workOrderData?.tenantSignedOffAt ?? data?.tenantSignedOffAt),
-      tenantDeclinedAt: toMillis(workOrderData?.tenantDeclinedAt ?? data?.tenantDeclinedAt),
-      tenantDeclineReason: String(workOrderData?.tenantDeclineReason || data?.tenantDeclineReason || "").trim() || null,
-      followUpRequired:
-        typeof workOrderData?.followUpRequired === "boolean"
-          ? workOrderData.followUpRequired
-          : typeof data?.followUpRequired === "boolean"
-          ? data.followUpRequired
-          : null,
-      followUpReason: String(workOrderData?.followUpReason || data?.followUpReason || "").trim() || null,
-      finalResolvedAt: toMillis(workOrderData?.finalResolvedAt ?? data?.finalResolvedAt),
-      reworkCycle:
-        workOrderData?.reworkCycle && typeof workOrderData.reworkCycle === "object"
-          ? {
-              cycleNumber: Number(workOrderData.reworkCycle.cycleNumber || 1),
-              status:
-                workOrderData.reworkCycle.status === "not_started" ||
-                workOrderData.reworkCycle.status === "assigned" ||
-                workOrderData.reworkCycle.status === "in_progress" ||
-                workOrderData.reworkCycle.status === "completed" ||
-                workOrderData.reworkCycle.status === "cancelled"
-                  ? workOrderData.reworkCycle.status
-                  : "not_started",
-              createdAt: toMillis(workOrderData.reworkCycle.createdAt),
-              assignedAt: toMillis(workOrderData.reworkCycle.assignedAt),
-              startedAt: toMillis(workOrderData.reworkCycle.startedAt),
-              completedAt: toMillis(workOrderData.reworkCycle.completedAt),
-              completionSummary: String(workOrderData.reworkCycle.completionSummary || "").trim() || null,
-              schedule:
-                workOrderData.reworkCycle.schedule && typeof workOrderData.reworkCycle.schedule === "object"
-                  ? {
-                      scheduledFor: toMillis(workOrderData.reworkCycle.schedule.scheduledFor),
-                      timeWindowStart: toMillis(workOrderData.reworkCycle.schedule.timeWindowStart),
-                      timeWindowEnd: toMillis(workOrderData.reworkCycle.schedule.timeWindowEnd),
-                      status:
-                        workOrderData.reworkCycle.schedule.status === "not_scheduled" ||
-                        workOrderData.reworkCycle.schedule.status === "scheduled" ||
-                        workOrderData.reworkCycle.schedule.status === "contractor_confirmed" ||
-                        workOrderData.reworkCycle.schedule.status === "tenant_pending" ||
-                        workOrderData.reworkCycle.schedule.status === "confirmed" ||
-                        workOrderData.reworkCycle.schedule.status === "reschedule_requested" ||
-                        workOrderData.reworkCycle.schedule.status === "cancelled"
-                          ? workOrderData.reworkCycle.schedule.status
-                          : null,
-                      requiresTenantAccess:
-                        typeof workOrderData.reworkCycle.schedule.requiresTenantAccess === "boolean"
-                          ? workOrderData.reworkCycle.schedule.requiresTenantAccess
-                          : null,
-                      tenantAccessStatus:
-                        workOrderData.reworkCycle.schedule.tenantAccessStatus === "pending" ||
-                        workOrderData.reworkCycle.schedule.tenantAccessStatus === "confirmed" ||
-                        workOrderData.reworkCycle.schedule.tenantAccessStatus === "denied" ||
-                        workOrderData.reworkCycle.schedule.tenantAccessStatus === "not_required"
-                          ? workOrderData.reworkCycle.schedule.tenantAccessStatus
-                          : null,
-                      tenantAccessNote: String(workOrderData.reworkCycle.schedule.tenantAccessNote || "").trim() || null,
-                    }
-                  : null,
-            }
-          : null,
-      reworkHistory: Array.isArray(workOrderData?.reworkHistory)
-        ? workOrderData.reworkHistory.map((entry: any) => ({
-            cycleNumber: Number(entry?.cycleNumber || 1),
-            startedAt: toMillis(entry?.startedAt),
-            completedAt: toMillis(entry?.completedAt),
-            outcome:
-              entry?.outcome === "resolved" || entry?.outcome === "failed" || entry?.outcome === "partial"
-                ? entry.outcome
-                : null,
-            notes: String(entry?.notes || "").trim() || null,
-          }))
-        : [],
-      evidence: tenantSafeEvidence,
-      tenantContact: data.tenantContact ?? null,
-      createdAt: toMillis(data.createdAt),
-      updatedAt: toMillis(data.updatedAt),
-      lastUpdatedBy: data.lastUpdatedBy ?? "TENANT",
-      statusHistory: Array.isArray(data.statusHistory)
-        ? data.statusHistory.map((entry: any) => ({
-            status: entry?.status ?? null,
-            actorRole: entry?.actorRole ?? null,
-            actorId: entry?.actorId ?? null,
-            message: entry?.message ?? null,
-            createdAt: toMillis(entry?.createdAt),
-          }))
-        : [],
-    };
+    const payload = await buildTenantMaintenanceDetailResponse(doc.id, data, workOrderData, workOrderSnap.exists);
     return res.json({ ok: true, data: payload });
   } catch (err) {
     console.error("[tenant/maintenance-requests/:id] read failed", {
@@ -5157,6 +5145,9 @@ router.post("/maintenance/:id/signoff", requireTenant, async (req: any, res) => 
     const workOrder = (workOrderSnap.data() as any) || {};
     if (String(workOrder.status || "").trim().toLowerCase() !== "completed") {
       return res.status(400).json({ ok: false, error: "WORK_ORDER_NOT_COMPLETED" });
+    }
+    if (String(workOrder?.reworkReview?.status || "").trim().toLowerCase() === "tenant_pending_signoff") {
+      return res.status(400).json({ ok: false, error: "REWORK_SIGNOFF_REQUIRED" });
     }
     if (String(workOrder.resolutionStatus || "").trim().toLowerCase() !== "tenant_pending_signoff") {
       return res.status(400).json({ ok: false, error: "TENANT_SIGNOFF_NOT_AVAILABLE" });
@@ -5261,94 +5252,7 @@ router.post("/maintenance/:id/signoff", requireTenant, async (req: any, res) => 
     const refreshedWorkOrderData = refreshedWorkOrder.exists ? ((refreshedWorkOrder.data() as any) || {}) : {};
     return res.json({
       ok: true,
-      data: {
-        ...projectTenantMaintenance(refreshed.id, refreshed.data() || {}),
-        evidence: refreshedWorkOrder.exists ? await serializeEvidenceForAudience(refreshedWorkOrderData?.evidence, "tenant") : [],
-        resolutionStatus:
-          refreshedWorkOrderData?.resolutionStatus === "completed_pending_review" ||
-          refreshedWorkOrderData?.resolutionStatus === "landlord_approved" ||
-          refreshedWorkOrderData?.resolutionStatus === "tenant_pending_signoff" ||
-          refreshedWorkOrderData?.resolutionStatus === "resolved" ||
-          refreshedWorkOrderData?.resolutionStatus === "follow_up_required"
-            ? refreshedWorkOrderData.resolutionStatus
-            : null,
-        landlordApprovedAt: toMillis(refreshedWorkOrderData?.landlordApprovedAt),
-        tenantSignoffStatus:
-          refreshedWorkOrderData?.tenantSignoffStatus === "pending" ||
-          refreshedWorkOrderData?.tenantSignoffStatus === "accepted" ||
-          refreshedWorkOrderData?.tenantSignoffStatus === "declined"
-            ? refreshedWorkOrderData.tenantSignoffStatus
-            : null,
-        tenantSignedOffAt: toMillis(refreshedWorkOrderData?.tenantSignedOffAt),
-        tenantDeclinedAt: toMillis(refreshedWorkOrderData?.tenantDeclinedAt),
-        tenantDeclineReason: String(refreshedWorkOrderData?.tenantDeclineReason || "").trim() || null,
-        followUpRequired:
-          typeof refreshedWorkOrderData?.followUpRequired === "boolean" ? refreshedWorkOrderData.followUpRequired : null,
-        followUpReason: String(refreshedWorkOrderData?.followUpReason || "").trim() || null,
-        finalResolvedAt: toMillis(refreshedWorkOrderData?.finalResolvedAt),
-        reworkCycle:
-          refreshedWorkOrderData?.reworkCycle && typeof refreshedWorkOrderData.reworkCycle === "object"
-            ? {
-                cycleNumber: Number(refreshedWorkOrderData.reworkCycle.cycleNumber || 1),
-                status:
-                  refreshedWorkOrderData.reworkCycle.status === "not_started" ||
-                  refreshedWorkOrderData.reworkCycle.status === "assigned" ||
-                  refreshedWorkOrderData.reworkCycle.status === "in_progress" ||
-                  refreshedWorkOrderData.reworkCycle.status === "completed" ||
-                  refreshedWorkOrderData.reworkCycle.status === "cancelled"
-                    ? refreshedWorkOrderData.reworkCycle.status
-                    : "not_started",
-                createdAt: toMillis(refreshedWorkOrderData.reworkCycle.createdAt),
-                assignedAt: toMillis(refreshedWorkOrderData.reworkCycle.assignedAt),
-                startedAt: toMillis(refreshedWorkOrderData.reworkCycle.startedAt),
-                completedAt: toMillis(refreshedWorkOrderData.reworkCycle.completedAt),
-                completionSummary: String(refreshedWorkOrderData.reworkCycle.completionSummary || "").trim() || null,
-                schedule:
-                  refreshedWorkOrderData.reworkCycle.schedule && typeof refreshedWorkOrderData.reworkCycle.schedule === "object"
-                    ? {
-                        scheduledFor: toMillis(refreshedWorkOrderData.reworkCycle.schedule.scheduledFor),
-                        timeWindowStart: toMillis(refreshedWorkOrderData.reworkCycle.schedule.timeWindowStart),
-                        timeWindowEnd: toMillis(refreshedWorkOrderData.reworkCycle.schedule.timeWindowEnd),
-                        status:
-                          refreshedWorkOrderData.reworkCycle.schedule.status === "not_scheduled" ||
-                          refreshedWorkOrderData.reworkCycle.schedule.status === "scheduled" ||
-                          refreshedWorkOrderData.reworkCycle.schedule.status === "contractor_confirmed" ||
-                          refreshedWorkOrderData.reworkCycle.schedule.status === "tenant_pending" ||
-                          refreshedWorkOrderData.reworkCycle.schedule.status === "confirmed" ||
-                          refreshedWorkOrderData.reworkCycle.schedule.status === "reschedule_requested" ||
-                          refreshedWorkOrderData.reworkCycle.schedule.status === "cancelled"
-                            ? refreshedWorkOrderData.reworkCycle.schedule.status
-                            : null,
-                        requiresTenantAccess:
-                          typeof refreshedWorkOrderData.reworkCycle.schedule.requiresTenantAccess === "boolean"
-                            ? refreshedWorkOrderData.reworkCycle.schedule.requiresTenantAccess
-                            : null,
-                        tenantAccessStatus:
-                          refreshedWorkOrderData.reworkCycle.schedule.tenantAccessStatus === "pending" ||
-                          refreshedWorkOrderData.reworkCycle.schedule.tenantAccessStatus === "confirmed" ||
-                          refreshedWorkOrderData.reworkCycle.schedule.tenantAccessStatus === "denied" ||
-                          refreshedWorkOrderData.reworkCycle.schedule.tenantAccessStatus === "not_required"
-                            ? refreshedWorkOrderData.reworkCycle.schedule.tenantAccessStatus
-                            : null,
-                        tenantAccessNote:
-                          String(refreshedWorkOrderData.reworkCycle.schedule.tenantAccessNote || "").trim() || null,
-                      }
-                    : null,
-              }
-            : null,
-        reworkHistory: Array.isArray(refreshedWorkOrderData?.reworkHistory)
-          ? refreshedWorkOrderData.reworkHistory.map((entry: any) => ({
-              cycleNumber: Number(entry?.cycleNumber || 1),
-              startedAt: toMillis(entry?.startedAt),
-              completedAt: toMillis(entry?.completedAt),
-              outcome:
-                entry?.outcome === "resolved" || entry?.outcome === "failed" || entry?.outcome === "partial"
-                  ? entry.outcome
-                  : null,
-              notes: String(entry?.notes || "").trim() || null,
-            }))
-          : [],
-      },
+      data: await buildTenantMaintenanceDetailResponse(refreshed.id, refreshed.data() || {}, refreshedWorkOrderData, refreshedWorkOrder.exists),
     });
   } catch (err) {
     console.error("[tenant/maintenance/:id/signoff] update failed", {
@@ -5357,6 +5261,123 @@ router.post("/maintenance/:id/signoff", requireTenant, async (req: any, res) => 
       err,
     });
     return res.status(500).json({ ok: false, error: "TENANT_MAINT_REQUEST_SIGNOFF_FAILED" });
+  }
+});
+
+router.post("/maintenance/:id/rework-signoff", requireTenant, async (req: any, res) => {
+  try {
+    const tenantId = String(req.user?.tenantId || "").trim();
+    const id = String(req.params?.id || "").trim();
+    if (!tenantId) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    if (!id) return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+
+    const docRef = db.collection("maintenanceRequests").doc(id);
+    const snap = await docRef.get();
+    if (!snap.exists) return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+    const data = (snap.data() as any) || {};
+    if (String(data.tenantId || "").trim() !== tenantId) {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+
+    const workOrderRef = db.collection("workOrders").doc(`maintenance_${id}`);
+    const workOrderSnap = await workOrderRef.get();
+    if (!workOrderSnap.exists) return res.status(404).json({ ok: false, error: "WORK_ORDER_NOT_FOUND" });
+    const workOrder = (workOrderSnap.data() as any) || {};
+    if (String(workOrder.status || "").trim().toLowerCase() !== "completed") {
+      return res.status(400).json({ ok: false, error: "WORK_ORDER_NOT_COMPLETED" });
+    }
+    if (String(workOrder?.reworkReview?.status || "").trim().toLowerCase() !== "tenant_pending_signoff") {
+      return res.status(400).json({ ok: false, error: "REWORK_SIGNOFF_NOT_AVAILABLE" });
+    }
+
+    const decision = req.body?.decision === "resolved" || req.body?.decision === "not_resolved" ? req.body.decision : null;
+    if (!decision) return res.status(400).json({ ok: false, error: "INVALID_REWORK_SIGNOFF_DECISION" });
+
+    const reason = String(req.body?.reason || "").trim().slice(0, 2000);
+    if (decision === "not_resolved" && !reason) {
+      return res.status(400).json({ ok: false, error: "TENANT_DECLINE_REASON_REQUIRED" });
+    }
+
+    const now = Date.now();
+    const historyMessage =
+      decision === "resolved"
+        ? "Tenant confirmed that the rework return visit resolved the issue."
+        : `Tenant reported the rework return visit is still not resolved: ${reason}`;
+
+    const reworkReviewUpdate =
+      decision === "resolved"
+        ? {
+            ...(workOrder.reworkReview || {}),
+            status: "closed",
+            tenantSignoffStatus: "accepted",
+            tenantSignedOffAt: now,
+            tenantDeclinedAt: null,
+            tenantDeclineReason: null,
+            closureOutcome: "resolved",
+            closedAt: now,
+          }
+        : {
+            ...(workOrder.reworkReview || {}),
+            status: "follow_up_required",
+            tenantSignoffStatus: "declined",
+            tenantSignedOffAt: null,
+            tenantDeclinedAt: now,
+            tenantDeclineReason: reason,
+            closureOutcome: "needs_more_followup",
+            closedAt: null,
+          };
+
+    await Promise.all([
+      workOrderRef.set(
+        {
+          reworkReview: reworkReviewUpdate,
+          resolutionStatus: decision === "resolved" ? "resolved" : "follow_up_required",
+          followUpRequired: decision !== "resolved",
+          followUpReason: decision === "resolved" ? null : reason,
+          finalResolvedAt: decision === "resolved" ? now : null,
+          updatedAtMs: now,
+          lastExecutionUpdateAt: now,
+        },
+        { merge: true }
+      ),
+      docRef.set(
+        {
+          contractorLastUpdate: historyMessage,
+          updatedAt: now,
+          lastUpdatedBy: "TENANT",
+          statusHistory: FieldValue.arrayUnion({
+            status: String(data.status || "completed"),
+            actorRole: "tenant",
+            actorId: tenantId,
+            message: historyMessage,
+            createdAt: now,
+          }),
+        },
+        { merge: true }
+      ),
+      db.collection("workOrderUpdates").doc().set({
+        workOrderId: workOrderRef.id,
+        actorRole: "tenant",
+        actorId: tenantId,
+        updateType: "confirmed",
+        message: historyMessage,
+        createdAtMs: now,
+      }),
+    ]);
+
+    const [refreshed, refreshedWorkOrder] = await Promise.all([docRef.get(), workOrderRef.get()]);
+    const refreshedWorkOrderData = refreshedWorkOrder.exists ? ((refreshedWorkOrder.data() as any) || {}) : {};
+    return res.json({
+      ok: true,
+      data: await buildTenantMaintenanceDetailResponse(refreshed.id, refreshed.data() || {}, refreshedWorkOrderData, refreshedWorkOrder.exists),
+    });
+  } catch (err) {
+    console.error("[tenant/maintenance/:id/rework-signoff] update failed", {
+      tenantId: req.user?.tenantId,
+      id: req.params?.id,
+      err,
+    });
+    return res.status(500).json({ ok: false, error: "TENANT_REWORK_SIGNOFF_FAILED" });
   }
 });
 
@@ -5449,53 +5470,7 @@ router.post("/maintenance/:id/confirm-rework-access", requireTenant, async (req:
     const refreshedWorkOrderData = refreshedWorkOrder.exists ? ((refreshedWorkOrder.data() as any) || {}) : {};
     return res.json({
       ok: true,
-      data: {
-        ...projectTenantMaintenance(refreshed.id, refreshed.data() || {}),
-        evidence: refreshedWorkOrder.exists ? await serializeEvidenceForAudience(refreshedWorkOrderData?.evidence, "tenant") : [],
-        resolutionStatus:
-          refreshedWorkOrderData?.resolutionStatus === "completed_pending_review" ||
-          refreshedWorkOrderData?.resolutionStatus === "landlord_approved" ||
-          refreshedWorkOrderData?.resolutionStatus === "tenant_pending_signoff" ||
-          refreshedWorkOrderData?.resolutionStatus === "resolved" ||
-          refreshedWorkOrderData?.resolutionStatus === "follow_up_required"
-            ? refreshedWorkOrderData.resolutionStatus
-            : null,
-        reworkCycle:
-          refreshedWorkOrderData?.reworkCycle && typeof refreshedWorkOrderData.reworkCycle === "object"
-            ? {
-                cycleNumber: Number(refreshedWorkOrderData.reworkCycle.cycleNumber || 1),
-                status:
-                  refreshedWorkOrderData.reworkCycle.status === "not_started" ||
-                  refreshedWorkOrderData.reworkCycle.status === "assigned" ||
-                  refreshedWorkOrderData.reworkCycle.status === "in_progress" ||
-                  refreshedWorkOrderData.reworkCycle.status === "completed" ||
-                  refreshedWorkOrderData.reworkCycle.status === "cancelled"
-                    ? refreshedWorkOrderData.reworkCycle.status
-                    : "not_started",
-                createdAt: toMillis(refreshedWorkOrderData.reworkCycle.createdAt),
-                assignedAt: toMillis(refreshedWorkOrderData.reworkCycle.assignedAt),
-                startedAt: toMillis(refreshedWorkOrderData.reworkCycle.startedAt),
-                completedAt: toMillis(refreshedWorkOrderData.reworkCycle.completedAt),
-                completionSummary: String(refreshedWorkOrderData.reworkCycle.completionSummary || "").trim() || null,
-                schedule:
-                  refreshedWorkOrderData.reworkCycle.schedule && typeof refreshedWorkOrderData.reworkCycle.schedule === "object"
-                    ? {
-                        scheduledFor: toMillis(refreshedWorkOrderData.reworkCycle.schedule.scheduledFor),
-                        timeWindowStart: toMillis(refreshedWorkOrderData.reworkCycle.schedule.timeWindowStart),
-                        timeWindowEnd: toMillis(refreshedWorkOrderData.reworkCycle.schedule.timeWindowEnd),
-                        status: refreshedWorkOrderData.reworkCycle.schedule.status || null,
-                        requiresTenantAccess:
-                          typeof refreshedWorkOrderData.reworkCycle.schedule.requiresTenantAccess === "boolean"
-                            ? refreshedWorkOrderData.reworkCycle.schedule.requiresTenantAccess
-                            : null,
-                        tenantAccessStatus: refreshedWorkOrderData.reworkCycle.schedule.tenantAccessStatus || null,
-                        tenantAccessNote:
-                          String(refreshedWorkOrderData.reworkCycle.schedule.tenantAccessNote || "").trim() || null,
-                      }
-                    : null,
-              }
-            : null,
-      },
+      data: await buildTenantMaintenanceDetailResponse(refreshed.id, refreshed.data() || {}, refreshedWorkOrderData, refreshedWorkOrder.exists),
     });
   } catch (err) {
     console.error("[tenant/maintenance/:id/confirm-rework-access] update failed", {

--- a/rentchain-api/src/routes/workOrdersRoutes.ts
+++ b/rentchain-api/src/routes/workOrdersRoutes.ts
@@ -182,6 +182,61 @@ function normalizeReworkContractorScheduleStatus(value: unknown): "pending" | "c
   return null;
 }
 
+function normalizeReworkReviewStatus(
+  value: unknown
+): "pending_review" | "landlord_approved" | "tenant_pending_signoff" | "closed" | "follow_up_required" | null {
+  const next = asString(value, 60).toLowerCase();
+  if (
+    next === "pending_review" ||
+    next === "landlord_approved" ||
+    next === "tenant_pending_signoff" ||
+    next === "closed" ||
+    next === "follow_up_required"
+  ) {
+    return next;
+  }
+  return null;
+}
+
+function normalizeReworkReviewClosureOutcome(value: unknown): "resolved" | "partial" | "needs_more_followup" | null {
+  const next = asString(value, 60).toLowerCase();
+  if (next === "resolved" || next === "partial" || next === "needs_more_followup") return next;
+  return null;
+}
+
+function upsertReworkHistoryEntry(history: any, entry: {
+  cycleNumber: number;
+  startedAt: number | null;
+  completedAt: number | null;
+  outcome: "resolved" | "failed" | "partial";
+  notes: string | null;
+}) {
+  const current = Array.isArray(history) ? history.filter((item) => item && typeof item === "object") : [];
+  const next = current.filter((item) => Number(item?.cycleNumber || 0) !== entry.cycleNumber);
+  next.push(entry);
+  next.sort((a, b) => Number(a?.cycleNumber || 0) - Number(b?.cycleNumber || 0));
+  return next;
+}
+
+function tenantSignoffRequiredForWorkOrder(data: any) {
+  return Boolean(asOptionalString(data?.tenantId, 120));
+}
+
+function buildPendingReworkReview(now: number) {
+  return {
+    status: "pending_review" as const,
+    reviewedAt: null,
+    reviewedBy: null,
+    landlordReviewNote: null,
+    tenantSignoffStatus: null,
+    tenantSignedOffAt: null,
+    tenantDeclinedAt: null,
+    tenantDeclineReason: null,
+    closureOutcome: null,
+    closedAt: null,
+  };
+}
+
 function normalizeRole(req: any): string {
   const actorRole = asString(req.user?.actorRole, 40).toLowerCase();
   const role = asString(req.user?.role, 40).toLowerCase();
@@ -1821,6 +1876,8 @@ router.post("/landlord/work-orders/:id/start-rework", requireAuth, async (req: a
         status: "assigned",
         resolutionStatus: "completed_pending_review",
         followUpRequired: false,
+        followUpReason: null,
+        reworkReview: null,
         reworkCycle: {
           cycleNumber,
           status: cycleStatus,
@@ -2149,16 +2206,20 @@ router.post("/landlord/work-orders/:id/complete-rework", requireAuth, async (req
       notes,
     };
 
+    const nextReworkHistory = upsertReworkHistoryEntry((access.item as any)?.reworkHistory, historyEntry);
+
     await db.collection("workOrders").doc(workOrderId).set(
       {
         status: "completed",
         resolutionStatus: "completed_pending_review",
         followUpRequired: false,
+        followUpReason: null,
         reworkCycle: {
           ...reworkCycle,
           status: "completed",
         },
-        reworkHistory: FieldValue.arrayUnion(historyEntry),
+        reworkHistory: nextReworkHistory,
+        reworkReview: buildPendingReworkReview(now),
         updatedAtMs: now,
         lastExecutionUpdateAt: now,
       },
@@ -2189,6 +2250,180 @@ router.post("/landlord/work-orders/:id/complete-rework", requireAuth, async (req
   } catch (err) {
     console.error("[work-orders] complete rework failed", err);
     return res.status(500).json({ ok: false, error: "WORK_ORDER_COMPLETE_REWORK_FAILED" });
+  }
+});
+
+router.post("/landlord/work-orders/:id/review-rework-resolution", requireAuth, async (req: any, res) => {
+  try {
+    if (!isLandlord(req)) return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+
+    const workOrderId = asString(req.params?.id, 120);
+    const access = await getWorkOrderAuthorized(req, workOrderId);
+    if (!access.ok) {
+      if (access.code === "NOT_FOUND") return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+
+    const reworkCycle = (access.item as any)?.reworkCycle || null;
+    if (!reworkCycle || normalizeReworkCycleStatus(reworkCycle?.status) !== "completed") {
+      return res.status(400).json({ ok: false, error: "REWORK_NOT_READY_FOR_REVIEW" });
+    }
+
+    const currentReviewStatus = normalizeReworkReviewStatus((access.item as any)?.reworkReview?.status);
+    if (currentReviewStatus === "closed") {
+      return res.status(409).json({ ok: false, error: "REWORK_ALREADY_CLOSED" });
+    }
+
+    const decision = req.body?.decision === "approve" || req.body?.decision === "follow_up_required" ? req.body.decision : null;
+    if (!decision) return res.status(400).json({ ok: false, error: "INVALID_REWORK_REVIEW_DECISION" });
+
+    const note = asOptionalString(req.body?.note, 2000);
+    const now = nowMs();
+    const requiresTenantSignoff = tenantSignoffRequiredForWorkOrder(access.item);
+    const nextReview =
+      decision === "approve"
+        ? {
+            status: requiresTenantSignoff ? "tenant_pending_signoff" : "closed",
+            reviewedAt: now,
+            reviewedBy: access.userId,
+            landlordReviewNote: note,
+            tenantSignoffStatus: requiresTenantSignoff ? "pending" : null,
+            tenantSignedOffAt: null,
+            tenantDeclinedAt: null,
+            tenantDeclineReason: null,
+            closureOutcome: requiresTenantSignoff ? null : ("resolved" as const),
+            closedAt: requiresTenantSignoff ? null : now,
+          }
+        : {
+            status: "follow_up_required",
+            reviewedAt: now,
+            reviewedBy: access.userId,
+            landlordReviewNote: note,
+            tenantSignoffStatus: null,
+            tenantSignedOffAt: null,
+            tenantDeclinedAt: null,
+            tenantDeclineReason: null,
+            closureOutcome: "needs_more_followup" as const,
+            closedAt: null,
+          };
+
+    await db.collection("workOrders").doc(workOrderId).set(
+      {
+        reworkReview: nextReview,
+        resolutionStatus: decision === "approve" ? (requiresTenantSignoff ? "tenant_pending_signoff" : "resolved") : "follow_up_required",
+        followUpRequired: decision === "follow_up_required",
+        followUpReason: decision === "follow_up_required" ? note : null,
+        finalResolvedAt: decision === "approve" && !requiresTenantSignoff ? now : null,
+        updatedAtMs: now,
+        lastExecutionUpdateAt: now,
+      },
+      { merge: true }
+    );
+
+    const message =
+      decision === "approve"
+        ? requiresTenantSignoff
+          ? `Rework cycle #${Number(reworkCycle?.cycleNumber || 1)} approved and sent for tenant signoff.`
+          : `Rework cycle #${Number(reworkCycle?.cycleNumber || 1)} approved and closed.`
+        : `Rework cycle #${Number(reworkCycle?.cycleNumber || 1)} needs more follow-up.${note ? ` ${note}` : ""}`;
+
+    await writeWorkOrderUpdate({
+      workOrderId,
+      actorRole: isAdmin(req) ? "admin" : "landlord",
+      actorId: access.userId,
+      updateType: "confirmed",
+      message,
+    });
+
+    await syncMaintenanceFromWorkOrder(workOrderId, {
+      contractorLastUpdate: message,
+    });
+    await appendMaintenanceStatusHistory({
+      maintenanceRequestId: asOptionalString((access.item as any)?.maintenanceRequestId, 120),
+      status: decision === "follow_up_required" ? "completed" : "completed",
+      actorRole: isAdmin(req) ? "admin" : "landlord",
+      actorId: access.userId,
+      message,
+    });
+
+    const refreshed = await db.collection("workOrders").doc(workOrderId).get();
+    return res.json({ ok: true, item: await toWorkOrderResponseForAudience(refreshed.id, refreshed.data(), "landlord") });
+  } catch (err) {
+    console.error("[work-orders] review rework resolution failed", err);
+    return res.status(500).json({ ok: false, error: "WORK_ORDER_REWORK_REVIEW_FAILED" });
+  }
+});
+
+router.post("/landlord/work-orders/:id/close-rework-directly", requireAuth, async (req: any, res) => {
+  try {
+    if (!isLandlord(req)) return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+
+    const workOrderId = asString(req.params?.id, 120);
+    const access = await getWorkOrderAuthorized(req, workOrderId);
+    if (!access.ok) {
+      if (access.code === "NOT_FOUND") return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+
+    const reworkCycle = (access.item as any)?.reworkCycle || null;
+    if (!reworkCycle || normalizeReworkCycleStatus(reworkCycle?.status) !== "completed") {
+      return res.status(400).json({ ok: false, error: "REWORK_NOT_READY_FOR_REVIEW" });
+    }
+    if (tenantSignoffRequiredForWorkOrder(access.item)) {
+      return res.status(400).json({ ok: false, error: "TENANT_SIGNOFF_REQUIRED" });
+    }
+    if (normalizeReworkReviewStatus((access.item as any)?.reworkReview?.status) === "closed") {
+      return res.status(409).json({ ok: false, error: "REWORK_ALREADY_CLOSED" });
+    }
+
+    const note = asOptionalString(req.body?.note, 2000);
+    const now = nowMs();
+    await db.collection("workOrders").doc(workOrderId).set(
+      {
+        reworkReview: {
+          status: "closed",
+          reviewedAt: now,
+          reviewedBy: access.userId,
+          landlordReviewNote: note,
+          tenantSignoffStatus: null,
+          tenantSignedOffAt: null,
+          tenantDeclinedAt: null,
+          tenantDeclineReason: null,
+          closureOutcome: "resolved",
+          closedAt: now,
+        },
+        resolutionStatus: "resolved",
+        followUpRequired: false,
+        followUpReason: null,
+        finalResolvedAt: now,
+        updatedAtMs: now,
+        lastExecutionUpdateAt: now,
+      },
+      { merge: true }
+    );
+
+    const message = `Rework cycle #${Number(reworkCycle?.cycleNumber || 1)} closed.${note ? ` ${note}` : ""}`;
+    await writeWorkOrderUpdate({
+      workOrderId,
+      actorRole: isAdmin(req) ? "admin" : "landlord",
+      actorId: access.userId,
+      updateType: "confirmed",
+      message,
+    });
+    await syncMaintenanceFromWorkOrder(workOrderId, { contractorLastUpdate: message });
+    await appendMaintenanceStatusHistory({
+      maintenanceRequestId: asOptionalString((access.item as any)?.maintenanceRequestId, 120),
+      status: "completed",
+      actorRole: isAdmin(req) ? "admin" : "landlord",
+      actorId: access.userId,
+      message,
+    });
+
+    const refreshed = await db.collection("workOrders").doc(workOrderId).get();
+    return res.json({ ok: true, item: await toWorkOrderResponseForAudience(refreshed.id, refreshed.data(), "landlord") });
+  } catch (err) {
+    console.error("[work-orders] close rework directly failed", err);
+    return res.status(500).json({ ok: false, error: "WORK_ORDER_REWORK_CLOSE_FAILED" });
   }
 });
 

--- a/rentchain-api/src/services/tenantPortal/tenantProjectionService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantProjectionService.ts
@@ -82,6 +82,16 @@ type TenantMaintenanceProjection = {
     outcome: "resolved" | "failed" | "partial" | null;
     notes: string | null;
   }>;
+  reworkReview: {
+    status: "pending_review" | "landlord_approved" | "tenant_pending_signoff" | "closed" | "follow_up_required" | null;
+    reviewedAt: number | null;
+    tenantSignoffStatus: "pending" | "accepted" | "declined" | null;
+    tenantSignedOffAt: number | null;
+    tenantDeclinedAt: number | null;
+    tenantDeclineReason: string | null;
+    closureOutcome: "resolved" | "partial" | "needs_more_followup" | null;
+    closedAt: number | null;
+  } | null;
   evidence: Array<{
     id: string;
     url: string | null;
@@ -298,6 +308,36 @@ export function projectTenantMaintenance(recordId: string, data: any): TenantMai
           notes: asString(entry?.notes),
         }))
       : [],
+    reworkReview:
+      data?.reworkReview && typeof data.reworkReview === "object"
+        ? {
+            status:
+              data.reworkReview.status === "pending_review" ||
+              data.reworkReview.status === "landlord_approved" ||
+              data.reworkReview.status === "tenant_pending_signoff" ||
+              data.reworkReview.status === "closed" ||
+              data.reworkReview.status === "follow_up_required"
+                ? data.reworkReview.status
+                : null,
+            reviewedAt: toMillis(data.reworkReview.reviewedAt),
+            tenantSignoffStatus:
+              data.reworkReview.tenantSignoffStatus === "pending" ||
+              data.reworkReview.tenantSignoffStatus === "accepted" ||
+              data.reworkReview.tenantSignoffStatus === "declined"
+                ? data.reworkReview.tenantSignoffStatus
+                : null,
+            tenantSignedOffAt: toMillis(data.reworkReview.tenantSignedOffAt),
+            tenantDeclinedAt: toMillis(data.reworkReview.tenantDeclinedAt),
+            tenantDeclineReason: asString(data.reworkReview.tenantDeclineReason),
+            closureOutcome:
+              data.reworkReview.closureOutcome === "resolved" ||
+              data.reworkReview.closureOutcome === "partial" ||
+              data.reworkReview.closureOutcome === "needs_more_followup"
+                ? data.reworkReview.closureOutcome
+                : null,
+            closedAt: toMillis(data.reworkReview.closedAt),
+          }
+        : null,
     evidence: Array.isArray(data?.evidence)
       ? data.evidence
           .map((entry: any) => ({

--- a/rentchain-frontend/src/api/maintenanceWorkflowApi.ts
+++ b/rentchain-frontend/src/api/maintenanceWorkflowApi.ts
@@ -5,6 +5,7 @@ import {
   listTenantWorkspaceMaintenance,
   updateTenantWorkspaceMaintenanceConfirmation,
   updateTenantWorkspaceReworkAccess,
+  updateTenantWorkspaceReworkSignoff,
   updateTenantWorkspaceMaintenanceSignoff,
 } from "./tenantPortal";
 
@@ -102,6 +103,16 @@ export type MaintenanceWorkflowItem = {
     outcome?: "resolved" | "failed" | "partial";
     notes?: string;
   }>;
+  reworkReview?: {
+    status?: "pending_review" | "landlord_approved" | "tenant_pending_signoff" | "closed" | "follow_up_required" | null;
+    reviewedAt?: number | null;
+    tenantSignoffStatus?: "pending" | "accepted" | "declined" | null;
+    tenantSignedOffAt?: number | null;
+    tenantDeclinedAt?: number | null;
+    tenantDeclineReason?: string | null;
+    closureOutcome?: "resolved" | "partial" | "needs_more_followup" | null;
+    closedAt?: number | null;
+  } | null;
   landlordNote?: string | null;
   createdAt: number;
   updatedAt: number;
@@ -214,6 +225,37 @@ function mapReworkHistory(value: any): MaintenanceWorkflowItem["reworkHistory"] 
         : undefined,
     notes: typeof entry?.notes === "string" ? entry.notes : undefined,
   }));
+}
+
+function mapReworkReview(value: any): MaintenanceWorkflowItem["reworkReview"] {
+  if (!value || typeof value !== "object") return null;
+  return {
+    status:
+      value.status === "pending_review" ||
+      value.status === "landlord_approved" ||
+      value.status === "tenant_pending_signoff" ||
+      value.status === "closed" ||
+      value.status === "follow_up_required"
+        ? value.status
+        : null,
+    reviewedAt: typeof value.reviewedAt === "number" ? value.reviewedAt : null,
+    tenantSignoffStatus:
+      value.tenantSignoffStatus === "pending" ||
+      value.tenantSignoffStatus === "accepted" ||
+      value.tenantSignoffStatus === "declined"
+        ? value.tenantSignoffStatus
+        : null,
+    tenantSignedOffAt: typeof value.tenantSignedOffAt === "number" ? value.tenantSignedOffAt : null,
+    tenantDeclinedAt: typeof value.tenantDeclinedAt === "number" ? value.tenantDeclinedAt : null,
+    tenantDeclineReason: typeof value.tenantDeclineReason === "string" ? value.tenantDeclineReason : null,
+    closureOutcome:
+      value.closureOutcome === "resolved" ||
+      value.closureOutcome === "partial" ||
+      value.closureOutcome === "needs_more_followup"
+        ? value.closureOutcome
+        : null,
+    closedAt: typeof value.closedAt === "number" ? value.closedAt : null,
+  };
 }
 
 export async function createTenantMaintenance(payload: {
@@ -416,6 +458,7 @@ export async function getTenantMaintenance(id: string) {
     finalResolvedAt: typeof item?.finalResolvedAt === "number" ? item.finalResolvedAt : null,
     reworkCycle: mapReworkCycle((item as any)?.reworkCycle),
     reworkHistory: mapReworkHistory((item as any)?.reworkHistory),
+    reworkReview: mapReworkReview((item as any)?.reworkReview),
     createdAt: item?.createdAt || Date.now(),
     updatedAt: item?.updatedAt || item?.createdAt || Date.now(),
     statusHistory: Array.isArray(item?.statusHistory)
@@ -486,6 +529,7 @@ export async function updateTenantMaintenanceConfirmation(
     evidence: Array.isArray((item as any)?.evidence) ? (item as any).evidence : [],
     reworkCycle: mapReworkCycle((item as any)?.reworkCycle),
     reworkHistory: mapReworkHistory((item as any)?.reworkHistory),
+    reworkReview: mapReworkReview((item as any)?.reworkReview),
     createdAt: item?.createdAt || Date.now(),
     updatedAt: item?.updatedAt || item?.createdAt || Date.now(),
     statusHistory: Array.isArray(item?.statusHistory)
@@ -555,6 +599,7 @@ export async function updateTenantMaintenanceSignoff(
     finalResolvedAt: typeof item?.finalResolvedAt === "number" ? item.finalResolvedAt : null,
     reworkCycle: mapReworkCycle((item as any)?.reworkCycle),
     reworkHistory: mapReworkHistory((item as any)?.reworkHistory),
+    reworkReview: mapReworkReview((item as any)?.reworkReview),
     createdAt: item?.createdAt || Date.now(),
     updatedAt: item?.updatedAt || item?.createdAt || Date.now(),
     statusHistory: Array.isArray(item?.statusHistory)
@@ -611,6 +656,78 @@ export async function updateTenantMaintenanceReworkAccess(
         : null,
     reworkCycle: mapReworkCycle((item as any)?.reworkCycle),
     reworkHistory: mapReworkHistory((item as any)?.reworkHistory),
+    reworkReview: mapReworkReview((item as any)?.reworkReview),
+    evidence: Array.isArray((item as any)?.evidence) ? (item as any).evidence : [],
+    createdAt: item?.createdAt || Date.now(),
+    updatedAt: item?.updatedAt || item?.createdAt || Date.now(),
+    statusHistory: Array.isArray(item?.statusHistory)
+      ? item.statusHistory.map((entry) => ({
+          status: String(entry?.status || ""),
+          actorRole: String(entry?.actorRole || ""),
+          actorId: entry?.actorId ? String(entry.actorId) : null,
+          message: entry?.message ? String(entry.message) : null,
+          createdAt: typeof entry?.createdAt === "number" ? entry.createdAt : undefined,
+        }))
+      : [],
+  };
+  return { ok: true, item: mapped, data: mapped };
+}
+
+export async function updateTenantMaintenanceReworkSignoff(
+  id: string,
+  payload: {
+    decision: "resolved" | "not_resolved";
+    reason?: string;
+  }
+) {
+  const item = await updateTenantWorkspaceReworkSignoff(id, payload);
+  const mapped: MaintenanceWorkflowItem = {
+    id: item?.requestId || id,
+    tenantId: "",
+    landlordId: "",
+    propertyId: null,
+    unitId: null,
+    title: item?.title || "Maintenance request",
+    description: item?.summary || "",
+    category: String(item?.category || "GENERAL"),
+    priority: String(item?.priority || "normal").toLowerCase() as "low" | "normal" | "urgent",
+    status: String(item?.status || "submitted").toLowerCase() as MaintenanceWorkflowStatus,
+    assignedContractorName: item?.assignedContractorName || null,
+    contractorStatus: item?.contractorStatus || null,
+    serviceWindowStartAt: typeof item?.serviceWindowStartAt === "number" ? item.serviceWindowStartAt : null,
+    serviceWindowEndAt: typeof item?.serviceWindowEndAt === "number" ? item.serviceWindowEndAt : null,
+    accessRequired: typeof item?.accessRequired === "boolean" ? item.accessRequired : null,
+    tenantConfirmationStatus:
+      item?.tenantConfirmationStatus === "confirmed" || item?.tenantConfirmationStatus === "needs_schedule_change"
+        ? item.tenantConfirmationStatus
+        : null,
+    tenantConfirmationUpdatedAt:
+      typeof item?.tenantConfirmationUpdatedAt === "number" ? item.tenantConfirmationUpdatedAt : null,
+    accessAcknowledgedAt: typeof item?.accessAcknowledgedAt === "number" ? item.accessAcknowledgedAt : null,
+    resolutionStatus:
+      item?.resolutionStatus === "completed_pending_review" ||
+      item?.resolutionStatus === "landlord_approved" ||
+      item?.resolutionStatus === "tenant_pending_signoff" ||
+      item?.resolutionStatus === "resolved" ||
+      item?.resolutionStatus === "follow_up_required"
+        ? item.resolutionStatus
+        : null,
+    landlordApprovedAt: typeof item?.landlordApprovedAt === "number" ? item.landlordApprovedAt : null,
+    tenantSignoffStatus:
+      item?.tenantSignoffStatus === "pending" ||
+      item?.tenantSignoffStatus === "accepted" ||
+      item?.tenantSignoffStatus === "declined"
+        ? item.tenantSignoffStatus
+        : null,
+    tenantSignedOffAt: typeof item?.tenantSignedOffAt === "number" ? item.tenantSignedOffAt : null,
+    tenantDeclinedAt: typeof item?.tenantDeclinedAt === "number" ? item.tenantDeclinedAt : null,
+    tenantDeclineReason: item?.tenantDeclineReason ? String(item.tenantDeclineReason) : null,
+    followUpRequired: typeof item?.followUpRequired === "boolean" ? item.followUpRequired : null,
+    followUpReason: item?.followUpReason ? String(item.followUpReason) : null,
+    finalResolvedAt: typeof item?.finalResolvedAt === "number" ? item.finalResolvedAt : null,
+    reworkCycle: mapReworkCycle((item as any)?.reworkCycle),
+    reworkHistory: mapReworkHistory((item as any)?.reworkHistory),
+    reworkReview: mapReworkReview((item as any)?.reworkReview),
     evidence: Array.isArray((item as any)?.evidence) ? (item as any).evidence : [],
     createdAt: item?.createdAt || Date.now(),
     updatedAt: item?.updatedAt || item?.createdAt || Date.now(),

--- a/rentchain-frontend/src/api/tenantPortal.ts
+++ b/rentchain-frontend/src/api/tenantPortal.ts
@@ -99,6 +99,16 @@ export type TenantWorkspaceMaintenance = {
     outcome?: "resolved" | "failed" | "partial" | null;
     notes?: string | null;
   }>;
+  reworkReview?: {
+    status?: "pending_review" | "landlord_approved" | "tenant_pending_signoff" | "closed" | "follow_up_required" | null;
+    reviewedAt?: number | null;
+    tenantSignoffStatus?: "pending" | "accepted" | "declined" | null;
+    tenantSignedOffAt?: number | null;
+    tenantDeclinedAt?: number | null;
+    tenantDeclineReason?: string | null;
+    closureOutcome?: "resolved" | "partial" | "needs_more_followup" | null;
+    closedAt?: number | null;
+  } | null;
   evidence?: Array<{
     id: string;
     url: string | null;
@@ -215,6 +225,23 @@ export async function updateTenantWorkspaceReworkAccess(
 ) {
   const res = await tenantApiFetch<{ ok: boolean; data: TenantWorkspaceMaintenance }>(
     `/tenant/maintenance/${encodeURIComponent(id)}/confirm-rework-access`,
+    {
+      method: "POST",
+      body: payload,
+    }
+  );
+  return res?.data;
+}
+
+export async function updateTenantWorkspaceReworkSignoff(
+  id: string,
+  payload: {
+    decision: "resolved" | "not_resolved";
+    reason?: string;
+  }
+) {
+  const res = await tenantApiFetch<{ ok: boolean; data: TenantWorkspaceMaintenance }>(
+    `/tenant/maintenance/${encodeURIComponent(id)}/rework-signoff`,
     {
       method: "POST",
       body: payload,

--- a/rentchain-frontend/src/api/workOrdersApi.ts
+++ b/rentchain-frontend/src/api/workOrdersApi.ts
@@ -15,6 +15,7 @@ export type WorkOrderStatus =
 export type WorkOrderRecord = {
   id: string;
   landlordId: string;
+  tenantId?: string | null;
   propertyId: string;
   unitId: string | null;
   title: string;
@@ -85,6 +86,18 @@ export type WorkOrderRecord = {
     outcome?: "resolved" | "failed" | "partial" | null;
     notes?: string | null;
   }> | null;
+  reworkReview?: {
+    status?: "pending_review" | "landlord_approved" | "tenant_pending_signoff" | "closed" | "follow_up_required" | null;
+    reviewedAt?: number | null;
+    reviewedBy?: string | null;
+    landlordReviewNote?: string | null;
+    tenantSignoffStatus?: "pending" | "accepted" | "declined" | null;
+    tenantSignedOffAt?: number | null;
+    tenantDeclinedAt?: number | null;
+    tenantDeclineReason?: string | null;
+    closureOutcome?: "resolved" | "partial" | "needs_more_followup" | null;
+    closedAt?: number | null;
+  } | null;
   reopenedAt?: number | null;
   reopenedByActorId?: string | null;
   reopenedByActorRole?: "landlord" | "admin" | null;
@@ -327,6 +340,30 @@ export async function rescheduleWorkOrderRework(
     { method: "POST", body: payload }
   );
   if (!res?.ok || !res.item) throw new Error("Failed to reschedule rework cycle");
+  return res.item;
+}
+
+export async function reviewWorkOrderReworkResolution(
+  workOrderId: string,
+  payload: { decision: "approve" | "follow_up_required"; note?: string }
+): Promise<WorkOrderRecord> {
+  const res = await apiFetch<{ ok: boolean; item: WorkOrderRecord }>(
+    `/landlord/work-orders/${encodeURIComponent(workOrderId)}/review-rework-resolution`,
+    { method: "POST", body: payload }
+  );
+  if (!res?.ok || !res.item) throw new Error("Failed to review rework resolution");
+  return res.item;
+}
+
+export async function closeWorkOrderReworkDirectly(
+  workOrderId: string,
+  payload?: { note?: string }
+): Promise<WorkOrderRecord> {
+  const res = await apiFetch<{ ok: boolean; item: WorkOrderRecord }>(
+    `/landlord/work-orders/${encodeURIComponent(workOrderId)}/close-rework-directly`,
+    { method: "POST", body: payload || {} }
+  );
+  if (!res?.ok || !res.item) throw new Error("Failed to close rework directly");
   return res.item;
 }
 

--- a/rentchain-frontend/src/pages/landlord/WorkOrdersPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/WorkOrdersPage.test.tsx
@@ -11,10 +11,11 @@ const mocks = vi.hoisted(() => ({
   patchWorkOrder: vi.fn(),
   approveWorkOrderResolution: vi.fn(),
   assignWorkOrderRework: vi.fn(),
-  completeWorkOrderRework: vi.fn(),
+  closeWorkOrderReworkDirectly: vi.fn(),
   confirmWorkOrderCompletion: vi.fn(),
   markWorkOrderFollowUpRequired: vi.fn(),
   reopenWorkOrder: vi.fn(),
+  reviewWorkOrderReworkResolution: vi.fn(),
   rescheduleWorkOrderRework: vi.fn(),
   scheduleWorkOrderRework: vi.fn(),
   startWorkOrderRework: vi.fn(),
@@ -35,7 +36,7 @@ vi.mock("../../api/workOrdersApi", () => ({
   addWorkOrderUpdate: mocks.addWorkOrderUpdate,
   approveWorkOrderResolution: mocks.approveWorkOrderResolution,
   assignWorkOrderRework: mocks.assignWorkOrderRework,
-  completeWorkOrderRework: mocks.completeWorkOrderRework,
+  closeWorkOrderReworkDirectly: mocks.closeWorkOrderReworkDirectly,
   completeWorkOrder: vi.fn(),
   confirmWorkOrderCompletion: mocks.confirmWorkOrderCompletion,
   getContractorProfileById: mocks.getContractorProfileById,
@@ -45,6 +46,7 @@ vi.mock("../../api/workOrdersApi", () => ({
   markWorkOrderFollowUpRequired: mocks.markWorkOrderFollowUpRequired,
   patchWorkOrder: mocks.patchWorkOrder,
   reopenWorkOrder: mocks.reopenWorkOrder,
+  reviewWorkOrderReworkResolution: mocks.reviewWorkOrderReworkResolution,
   rescheduleWorkOrderRework: mocks.rescheduleWorkOrderRework,
   scheduleWorkOrderRework: mocks.scheduleWorkOrderRework,
   startWorkOrderRework: mocks.startWorkOrderRework,
@@ -89,10 +91,11 @@ describe("WorkOrdersPage", () => {
     mocks.patchWorkOrder.mockReset();
     mocks.approveWorkOrderResolution.mockReset();
     mocks.assignWorkOrderRework.mockReset();
-    mocks.completeWorkOrderRework.mockReset();
+    mocks.closeWorkOrderReworkDirectly.mockReset();
     mocks.confirmWorkOrderCompletion.mockReset();
     mocks.markWorkOrderFollowUpRequired.mockReset();
     mocks.reopenWorkOrder.mockReset();
+    mocks.reviewWorkOrderReworkResolution.mockReset();
     mocks.rescheduleWorkOrderRework.mockReset();
     mocks.scheduleWorkOrderRework.mockReset();
     mocks.startWorkOrderRework.mockReset();
@@ -386,7 +389,7 @@ describe("WorkOrdersPage", () => {
     });
   });
 
-  it("renders the rework workflow and lets the landlord start, assign, and complete it", async () => {
+  it("renders the rework workflow and lets the landlord review a completed second-pass visit", async () => {
     mocks.canUseWorkOrders = true;
     mocks.listWorkOrders.mockResolvedValue([
       {
@@ -407,9 +410,30 @@ describe("WorkOrdersPage", () => {
         acceptedAtMs: 10,
         startedAtMs: 20,
         completedAtMs: 30,
-        resolutionStatus: "follow_up_required",
-        followUpRequired: true,
-        followUpReason: "Bedroom still not heating evenly.",
+        resolutionStatus: "completed_pending_review",
+        followUpRequired: false,
+        followUpReason: null,
+        reworkCycle: {
+          cycleNumber: 1,
+          status: "completed",
+          createdAt: 40,
+          createdBy: "landlord-1",
+          assignedContractorId: "contractor-2",
+          assignedAt: 41,
+          completedAt: 60,
+          completionSummary: "Adjusted vents and rebalanced output.",
+        },
+        reworkReview: {
+          status: "pending_review",
+          reviewedAt: null,
+          tenantSignoffStatus: null,
+          tenantSignedOffAt: null,
+          tenantDeclinedAt: null,
+          tenantDeclineReason: null,
+          closureOutcome: null,
+          closedAt: null,
+        },
+        reworkHistory: [],
         notesInternal: "",
         linkedExpenseId: null,
         createdAtMs: 1,
@@ -417,40 +441,6 @@ describe("WorkOrdersPage", () => {
       },
     ]);
     mocks.listWorkOrderUpdates.mockResolvedValue([]);
-    mocks.getWorkOrder.mockResolvedValueOnce({
-      id: "wo-rework",
-      landlordId: "landlord-1",
-      propertyId: "prop-1",
-      unitId: "unit-1",
-      title: "Return visit for heater",
-      description: "Second pass needed to balance airflow.",
-      category: "HVAC",
-      priority: "high",
-      status: "assigned",
-      visibility: "private",
-      budgetMinCents: null,
-      budgetMaxCents: null,
-      assignedContractorId: "contractor-1",
-      invitedContractorIds: [],
-      acceptedAtMs: 10,
-      startedAtMs: 20,
-      completedAtMs: 30,
-      resolutionStatus: "completed_pending_review",
-      followUpRequired: false,
-      reworkCycle: {
-        cycleNumber: 1,
-        status: "assigned",
-        createdAt: 40,
-        createdBy: "landlord-1",
-        assignedContractorId: "contractor-1",
-        assignedAt: 41,
-      },
-      reworkHistory: [],
-      notesInternal: "",
-      linkedExpenseId: null,
-      createdAtMs: 1,
-      updatedAtMs: 41,
-    });
     mocks.getWorkOrder.mockResolvedValueOnce({
       id: "wo-rework",
       landlordId: "landlord-1",
@@ -481,15 +471,23 @@ describe("WorkOrdersPage", () => {
         completedAt: 60,
         completionSummary: "Adjusted vents and rebalanced output.",
       },
+      reworkReview: {
+        status: "pending_review",
+        reviewedAt: null,
+        tenantSignoffStatus: null,
+        tenantSignedOffAt: null,
+        tenantDeclinedAt: null,
+        tenantDeclineReason: null,
+        closureOutcome: null,
+        closedAt: null,
+      },
       reworkHistory: [],
       notesInternal: "",
       linkedExpenseId: null,
       createdAtMs: 1,
       updatedAtMs: 60,
     });
-    mocks.startWorkOrderRework.mockResolvedValue({ ok: true });
-    mocks.assignWorkOrderRework.mockResolvedValue({ ok: true });
-    mocks.completeWorkOrderRework.mockResolvedValue({ ok: true });
+    mocks.reviewWorkOrderReworkResolution.mockResolvedValue({ ok: true });
 
     render(
       <MemoryRouter>
@@ -499,30 +497,16 @@ describe("WorkOrdersPage", () => {
 
     fireEvent.click(await screen.findByRole("button", { name: /timeline/i }));
     expect((await screen.findAllByText(/Rework cycle/i)).length).toBeGreaterThan(0);
-    fireEvent.click(screen.getByRole("button", { name: /Start rework/i }));
 
-    await waitFor(() => {
-      expect(mocks.startWorkOrderRework).toHaveBeenCalledWith("wo-rework");
-    });
-
-    fireEvent.change(await screen.findByPlaceholderText(/Contractor ID for rework assignment/i), {
-      target: { value: "contractor-2" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: /Assign rework/i }));
-
-    await waitFor(() => {
-      expect(mocks.assignWorkOrderRework).toHaveBeenCalledWith("wo-rework", "contractor-2");
-    });
-
-    fireEvent.change(await screen.findByPlaceholderText(/Add notes for how this rework cycle should close/i), {
+    fireEvent.change(await screen.findByPlaceholderText(/Add a landlord review note for this second-pass visit/i), {
       target: { value: "Follow-up complete after vent balancing." },
     });
-    fireEvent.click(screen.getByRole("button", { name: /Complete rework cycle/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Approve rework resolution/i }));
 
     await waitFor(() => {
-      expect(mocks.completeWorkOrderRework).toHaveBeenCalledWith("wo-rework", {
-        outcome: "resolved",
-        notes: "Follow-up complete after vent balancing.",
+      expect(mocks.reviewWorkOrderReworkResolution).toHaveBeenCalledWith("wo-rework", {
+        decision: "approve",
+        note: "Follow-up complete after vent balancing.",
       });
     });
   });

--- a/rentchain-frontend/src/pages/landlord/WorkOrdersPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/WorkOrdersPage.tsx
@@ -9,7 +9,7 @@ import {
   addWorkOrderUpdate,
   approveWorkOrderResolution,
   assignWorkOrderRework,
-  completeWorkOrderRework,
+  closeWorkOrderReworkDirectly,
   confirmWorkOrderCompletion,
   getWorkOrder,
   getContractorProfileById,
@@ -18,6 +18,7 @@ import {
   markWorkOrderFollowUpRequired,
   patchWorkOrder,
   reopenWorkOrder,
+  reviewWorkOrderReworkResolution,
   rescheduleWorkOrderRework,
   scheduleWorkOrderRework,
   startWorkOrderRework,
@@ -80,7 +81,12 @@ function canConfirmCompletion(item: WorkOrderRecord) {
 }
 
 function canApproveResolution(item: WorkOrderRecord) {
-  return item.status === "completed" && item.resolutionStatus !== "tenant_pending_signoff" && item.resolutionStatus !== "resolved";
+  return (
+    item.status === "completed" &&
+    item.resolutionStatus !== "tenant_pending_signoff" &&
+    item.resolutionStatus !== "resolved" &&
+    item.reworkCycle?.status !== "completed"
+  );
 }
 
 function canReopenWorkOrder(item: WorkOrderRecord) {
@@ -101,6 +107,25 @@ function resolutionStatusLabel(value?: WorkOrderRecord["resolutionStatus"]) {
       return "Follow-up required";
     default:
       return "Not set";
+  }
+}
+
+function reworkReviewStatusLabel(
+  value?: "pending_review" | "landlord_approved" | "tenant_pending_signoff" | "closed" | "follow_up_required" | null
+) {
+  switch (value) {
+    case "pending_review":
+      return "Pending landlord review";
+    case "landlord_approved":
+      return "Landlord approved";
+    case "tenant_pending_signoff":
+      return "Awaiting tenant signoff";
+    case "closed":
+      return "Closed";
+    case "follow_up_required":
+      return "Follow-up required again";
+    default:
+      return "Not started";
   }
 }
 
@@ -163,7 +188,6 @@ export default function WorkOrdersPage() {
   const [followUpReason, setFollowUpReason] = React.useState("");
   const [reworkContractorId, setReworkContractorId] = React.useState("");
   const [reworkNotes, setReworkNotes] = React.useState("");
-  const [reworkOutcome, setReworkOutcome] = React.useState<"resolved" | "partial">("resolved");
   const [reworkScheduledForInput, setReworkScheduledForInput] = React.useState("");
   const [reworkWindowStartInput, setReworkWindowStartInput] = React.useState("");
   const [reworkWindowEndInput, setReworkWindowEndInput] = React.useState("");
@@ -376,24 +400,49 @@ export default function WorkOrdersPage() {
     [load, refreshSelected, reworkContractorId]
   );
 
-  const handleCompleteRework = React.useCallback(
-    async (item: WorkOrderRecord) => {
+  const handleReviewReworkResolution = React.useCallback(
+    async (item: WorkOrderRecord, decision: "approve" | "follow_up_required") => {
+      if (!item.reworkCycle || item.reworkCycle.status !== "completed") return;
+      if (decision === "follow_up_required" && !reworkNotes.trim()) {
+        setError("Add a review note before marking the rework for more follow-up.");
+        return;
+      }
       setSavingAction(true);
       setError(null);
       try {
-        await completeWorkOrderRework(item.id, {
-          outcome: reworkOutcome,
-          notes: reworkNotes.trim() || undefined,
+        await reviewWorkOrderReworkResolution(item.id, {
+          decision,
+          note: reworkNotes.trim() || undefined,
         });
         await load();
         await refreshSelected(item.id);
       } catch (err: any) {
-        setError(String(err?.message || "Failed to complete rework"));
+        setError(String(err?.message || "Failed to review rework resolution"));
       } finally {
         setSavingAction(false);
       }
     },
-    [load, refreshSelected, reworkNotes, reworkOutcome]
+    [load, refreshSelected, reworkNotes]
+  );
+
+  const handleCloseReworkDirectly = React.useCallback(
+    async (item: WorkOrderRecord) => {
+      if (!item.reworkCycle || item.reworkCycle.status !== "completed") return;
+      setSavingAction(true);
+      setError(null);
+      try {
+        await closeWorkOrderReworkDirectly(item.id, {
+          note: reworkNotes.trim() || undefined,
+        });
+        await load();
+        await refreshSelected(item.id);
+      } catch (err: any) {
+        setError(String(err?.message || "Failed to close rework"));
+      } finally {
+        setSavingAction(false);
+      }
+    },
+    [load, refreshSelected, reworkNotes]
   );
 
   const handleScheduleRework = React.useCallback(
@@ -492,7 +541,6 @@ export default function WorkOrdersPage() {
       setFollowUpReason("");
       setReworkContractorId("");
       setReworkNotes("");
-      setReworkOutcome("resolved");
       setReworkScheduledForInput("");
       setReworkWindowStartInput("");
       setReworkWindowEndInput("");
@@ -513,8 +561,7 @@ export default function WorkOrdersPage() {
     setReopenReason(String(selected.reopenReason || ""));
     setFollowUpReason(String(selected.followUpReason || ""));
     setReworkContractorId(String(selected.reworkCycle?.assignedContractorId || selected.assignedContractorId || ""));
-    setReworkNotes("");
-    setReworkOutcome("resolved");
+    setReworkNotes(String(selected.reworkReview?.landlordReviewNote || ""));
     setReworkScheduledForInput(toLocalInputValue(selected.reworkCycle?.schedule?.scheduledFor));
     setReworkWindowStartInput(toLocalInputValue(selected.reworkCycle?.schedule?.timeWindowStart));
     setReworkWindowEndInput(toLocalInputValue(selected.reworkCycle?.schedule?.timeWindowEnd));
@@ -974,21 +1021,42 @@ export default function WorkOrdersPage() {
                     placeholder="Contractor ID for rework assignment"
                     style={{ width: "100%", borderRadius: 8, border: "1px solid #cbd5e1", padding: 8 }}
                   />
+                  {selected.reworkReview ? (
+                    <div
+                      style={{
+                        border: "1px solid #e2e8f0",
+                        borderRadius: 10,
+                        padding: 10,
+                        display: "grid",
+                        gap: 6,
+                        background: "#fff",
+                      }}
+                    >
+                      <div style={{ fontWeight: 600 }}>Second-pass review</div>
+                      <div style={{ color: "#64748b", fontSize: 13 }}>
+                        {reworkReviewStatusLabel(selected.reworkReview.status)}
+                        {selected.reworkReview.reviewedAt ? ` • Reviewed ${formatDate(selected.reworkReview.reviewedAt)}` : ""}
+                        {selected.reworkReview.closedAt ? ` • Closed ${formatDate(selected.reworkReview.closedAt)}` : ""}
+                      </div>
+                      {selected.reworkReview.closureOutcome ? (
+                        <div style={{ color: "#64748b", fontSize: 13 }}>
+                          Closure outcome: {selected.reworkReview.closureOutcome.replaceAll("_", " ")}
+                        </div>
+                      ) : null}
+                      {selected.reworkReview.tenantDeclineReason ? (
+                        <div style={{ color: "#64748b", fontSize: 13 }}>
+                          Tenant follow-up note: {selected.reworkReview.tenantDeclineReason}
+                        </div>
+                      ) : null}
+                    </div>
+                  ) : null}
                   <textarea
                     value={reworkNotes}
                     onChange={(e) => setReworkNotes(e.target.value)}
-                    placeholder="Add notes for how this rework cycle should close"
+                    placeholder="Add a landlord review note for this second-pass visit"
                     rows={3}
                     style={{ width: "100%", borderRadius: 8, border: "1px solid #cbd5e1", padding: 8, resize: "vertical" }}
                   />
-                  <select
-                    value={reworkOutcome}
-                    onChange={(e) => setReworkOutcome(e.target.value as "resolved" | "partial")}
-                    style={{ width: "100%", borderRadius: 8, border: "1px solid #cbd5e1", padding: 8 }}
-                  >
-                    <option value="resolved">Resolved</option>
-                    <option value="partial">Partial</option>
-                  </select>
                   <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
                     {selected.reworkCycle.status !== "completed" ? (
                       <Button variant="secondary" disabled={savingAction} onClick={() => void handleAssignRework(selected)}>
@@ -996,9 +1064,23 @@ export default function WorkOrdersPage() {
                       </Button>
                     ) : null}
                     {selected.reworkCycle.status === "completed" ? (
-                      <Button disabled={savingAction} onClick={() => void handleCompleteRework(selected)}>
-                        {savingAction ? "Saving..." : "Complete rework cycle"}
-                      </Button>
+                      <>
+                        <Button disabled={savingAction} onClick={() => void handleReviewReworkResolution(selected, "approve")}>
+                          {savingAction ? "Saving..." : "Approve rework resolution"}
+                        </Button>
+                        <Button
+                          variant="secondary"
+                          disabled={savingAction}
+                          onClick={() => void handleReviewReworkResolution(selected, "follow_up_required")}
+                        >
+                          {savingAction ? "Saving..." : "Mark follow-up required again"}
+                        </Button>
+                        {!selected.tenantId ? (
+                          <Button variant="ghost" disabled={savingAction} onClick={() => void handleCloseReworkDirectly(selected)}>
+                            {savingAction ? "Saving..." : "Close rework directly"}
+                          </Button>
+                        ) : null}
+                      </>
                     ) : null}
                   </div>
                 </>

--- a/rentchain-frontend/src/pages/tenant/TenantMaintenancePages.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantMaintenancePages.test.tsx
@@ -12,6 +12,7 @@ const maintenanceWorkflowApi = vi.hoisted(() => ({
   createTenantMaintenance: vi.fn(),
   updateTenantMaintenanceConfirmation: vi.fn(),
   updateTenantMaintenanceReworkAccess: vi.fn(),
+  updateTenantMaintenanceReworkSignoff: vi.fn(),
   updateTenantMaintenanceSignoff: vi.fn(),
 }));
 
@@ -31,6 +32,7 @@ vi.mock("../../api/maintenanceWorkflowApi", async () => {
     createTenantMaintenance: maintenanceWorkflowApi.createTenantMaintenance,
     updateTenantMaintenanceConfirmation: maintenanceWorkflowApi.updateTenantMaintenanceConfirmation,
     updateTenantMaintenanceReworkAccess: maintenanceWorkflowApi.updateTenantMaintenanceReworkAccess,
+    updateTenantMaintenanceReworkSignoff: maintenanceWorkflowApi.updateTenantMaintenanceReworkSignoff,
     updateTenantMaintenanceSignoff: maintenanceWorkflowApi.updateTenantMaintenanceSignoff,
   };
 });
@@ -281,6 +283,85 @@ describe("tenant maintenance pages", () => {
       });
     });
     expect(await screen.findByText(/This request has been marked resolved/i)).toBeInTheDocument();
+  });
+
+  it("submits tenant rework signoff from the detail page when a second-pass review is pending", async () => {
+    maintenanceWorkflowApi.getTenantMaintenance.mockResolvedValue({
+      item: {
+        id: "maint-rework-review",
+        title: "Heater follow-up",
+        description: "Bedroom still feels cool after the return visit.",
+        status: "completed",
+        priority: "urgent",
+        category: "HVAC",
+        resolutionStatus: "tenant_pending_signoff",
+        reworkCycle: {
+          cycleNumber: 1,
+          status: "completed",
+          createdAt: 200,
+          createdBy: "landlord-1",
+          completedAt: 360,
+          completionSummary: "Balanced vents and re-tested the system.",
+        },
+        reworkReview: {
+          status: "tenant_pending_signoff",
+          tenantSignoffStatus: "pending",
+        },
+        createdAt: 100,
+        updatedAt: 400,
+        statusHistory: [],
+      },
+    });
+    maintenanceWorkflowApi.updateTenantMaintenanceReworkSignoff.mockResolvedValue({
+      item: {
+        id: "maint-rework-review",
+        title: "Heater follow-up",
+        description: "Bedroom still feels cool after the return visit.",
+        status: "completed",
+        priority: "urgent",
+        category: "HVAC",
+        resolutionStatus: "resolved",
+        reworkCycle: {
+          cycleNumber: 1,
+          status: "completed",
+          createdAt: 200,
+          createdBy: "landlord-1",
+          completedAt: 360,
+          completionSummary: "Balanced vents and re-tested the system.",
+        },
+        reworkReview: {
+          status: "closed",
+          tenantSignoffStatus: "accepted",
+          tenantSignedOffAt: 500,
+          closureOutcome: "resolved",
+          closedAt: 500,
+        },
+        finalResolvedAt: 500,
+        createdAt: 100,
+        updatedAt: 500,
+        statusHistory: [],
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/tenant/maintenance/maint-rework-review"]}>
+        <Routes>
+          <Route path="/tenant/maintenance/:id" element={<TenantMaintenanceRequestDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Review the return visit/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Mark follow-up resolved/i }));
+
+    await waitFor(() => {
+      expect(maintenanceWorkflowApi.updateTenantMaintenanceReworkSignoff).toHaveBeenCalledWith("maint-rework-review", {
+        decision: "resolved",
+        reason: undefined,
+      });
+    });
+
+    expect(await screen.findByText(/The follow-up work has been closed/i)).toBeInTheDocument();
   });
 
   it("shows return-visit coordination and lets the tenant confirm access", async () => {

--- a/rentchain-frontend/src/pages/tenant/TenantMaintenanceRequestDetailPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantMaintenanceRequestDetailPage.tsx
@@ -4,6 +4,7 @@ import {
   getTenantMaintenance,
   updateTenantMaintenanceConfirmation,
   updateTenantMaintenanceReworkAccess,
+  updateTenantMaintenanceReworkSignoff,
   updateTenantMaintenanceSignoff,
   type MaintenanceWorkflowItem,
 } from "../../api/maintenanceWorkflowApi";
@@ -37,6 +38,25 @@ function resolutionStatusLabel(value?: MaintenanceWorkflowItem["resolutionStatus
       return "This request needs follow-up before it can be fully resolved.";
     default:
       return "No resolution decision has been recorded yet.";
+  }
+}
+
+function reworkReviewStatusLabel(
+  value?: "pending_review" | "landlord_approved" | "tenant_pending_signoff" | "closed" | "follow_up_required" | null
+) {
+  switch (value) {
+    case "pending_review":
+      return "The return visit is complete and waiting for landlord review.";
+    case "landlord_approved":
+      return "The landlord reviewed the return visit and is preparing final closure.";
+    case "tenant_pending_signoff":
+      return "Your review is needed before the follow-up work can be closed.";
+    case "closed":
+      return "The follow-up work has been closed.";
+    case "follow_up_required":
+      return "The follow-up work still needs more attention.";
+    default:
+      return "No second-pass review has been recorded yet.";
   }
 }
 
@@ -169,6 +189,31 @@ export default function TenantMaintenanceRequestDetailPage() {
       }
     } catch (err: any) {
       const msg = err?.payload?.error || err?.message || "Unable to update the maintenance resolution.";
+      setError(String(msg));
+    } finally {
+      setSavingAction(false);
+    }
+  };
+
+  const applyReworkResolutionSignoff = async (decision: "resolved" | "not_resolved") => {
+    if (!id) return;
+    if (decision === "not_resolved" && !signoffReason.trim()) {
+      setError("Add a reason before asking for more follow-up work.");
+      return;
+    }
+    setSavingAction(true);
+    setError(null);
+    try {
+      const res = await updateTenantMaintenanceReworkSignoff(id, {
+        decision,
+        reason: decision === "not_resolved" ? signoffReason.trim() : undefined,
+      });
+      setData((res as any)?.item || (res as any)?.data || null);
+      if (decision === "resolved") {
+        setSignoffReason("");
+      }
+    } catch (err: any) {
+      const msg = err?.payload?.error || err?.message || "Unable to update the rework review.";
       setError(String(msg));
     } finally {
       setSavingAction(false);
@@ -432,12 +477,26 @@ export default function TenantMaintenanceRequestDetailPage() {
                   ) : null}
                   <div style={{ color: textTokens.primary, fontWeight: 700 }}>What happens next</div>
                   <div style={{ color: textTokens.secondary }}>
-                    {data.reworkCycle?.status === "completed"
+                    {data.reworkReview?.status === "tenant_pending_signoff"
+                      ? "The return visit is complete. Review the updated work and let your landlord know whether the issue is now fully resolved."
+                      : data.reworkCycle?.status === "completed"
                       ? "The updated work is back with your landlord for review before final signoff."
                       : data.reworkCycle
                       ? "Your maintenance request is in an active follow-up cycle. RentChain will keep the original history while this second pass is completed."
                       : "Previous follow-up cycles stay attached to this request for a full maintenance record."}
                   </div>
+                  {data.reworkReview ? (
+                    <>
+                      <div style={{ color: textTokens.primary, fontWeight: 700 }}>Second-pass review</div>
+                      <div style={{ color: textTokens.secondary }}>{reworkReviewStatusLabel(data.reworkReview.status)}</div>
+                      {data.reworkReview.closedAt ? (
+                        <div style={{ color: textTokens.secondary }}>Closed {fmtDate(data.reworkReview.closedAt)}.</div>
+                      ) : null}
+                      {data.reworkReview.tenantDeclineReason ? (
+                        <div style={{ color: textTokens.secondary }}>Your latest note: {data.reworkReview.tenantDeclineReason}</div>
+                      ) : null}
+                    </>
+                  ) : null}
                   {data.reworkHistory?.length ? (
                     <>
                       <div style={{ color: textTokens.primary, fontWeight: 700 }}>Previous rework cycles</div>
@@ -499,6 +558,35 @@ export default function TenantMaintenanceRequestDetailPage() {
                       ) : null}
                     </>
                   ) : null}
+                  {data.reworkReview?.status === "tenant_pending_signoff" ? (
+                    <>
+                      <div style={{ color: textTokens.primary, fontWeight: 700 }}>Review the return visit</div>
+                      <div style={{ color: textTokens.secondary }}>
+                        Confirm whether the follow-up work fixed the issue, or ask for more follow-up if it still needs attention.
+                      </div>
+                      <textarea
+                        value={signoffReason}
+                        onChange={(e) => setSignoffReason(e.target.value)}
+                        placeholder="If more follow-up is needed, explain what is still incomplete or not working"
+                        rows={3}
+                        style={{
+                          width: "100%",
+                          borderRadius: 8,
+                          border: `1px solid ${colors.border}`,
+                          padding: 10,
+                          resize: "vertical",
+                        }}
+                      />
+                      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                        <Button variant="secondary" disabled={savingAction} onClick={() => void applyReworkResolutionSignoff("resolved")}>
+                          {savingAction ? "Saving..." : "Mark follow-up resolved"}
+                        </Button>
+                        <Button variant="ghost" disabled={savingAction} onClick={() => void applyReworkResolutionSignoff("not_resolved")}>
+                          {savingAction ? "Saving..." : "Request more follow-up"}
+                        </Button>
+                      </div>
+                    </>
+                  ) : null}
                 </div>
               ) : null}
               <div
@@ -531,7 +619,9 @@ export default function TenantMaintenanceRequestDetailPage() {
                     <div style={{ color: textTokens.secondary }}>{data.tenantDeclineReason}</div>
                   </>
                 ) : null}
-                {data.status === "completed" && data.resolutionStatus === "tenant_pending_signoff" ? (
+                {data.status === "completed" &&
+                data.resolutionStatus === "tenant_pending_signoff" &&
+                data.reworkReview?.status !== "tenant_pending_signoff" ? (
                   <>
                     <div style={{ color: textTokens.primary, fontWeight: 700 }}>Next step</div>
                     <div style={{ color: textTokens.secondary }}>


### PR DESCRIPTION
## Summary
Adds a structured post-rework review and second-pass closure layer for maintenance work orders.

This PR makes completed return visits explicitly reviewable and closable by separating second-pass landlord review, tenant rework signoff, and final closure from the original first-pass resolution history.

## Scope
- layered `reworkReview` state on work orders
- landlord rework review and direct-close actions
- tenant rework signoff flow
- tenant-safe projection of second-pass review state
- focused backend and frontend tests

## Second-pass review flow
Completed rework cycles now move into a distinct review lifecycle:
- pending landlord review
- tenant pending signoff
- closed
- follow-up required again

This keeps the original completion, evidence, and first-pass signoff history intact while adding a clean second-pass closure model.

## Implementation notes
- `workOrders` remain the canonical source of truth
- contractor rework completion now sets `reworkReview.status = "pending_review"`
- landlord actions add:
  - `POST /landlord/work-orders/:id/review-rework-resolution`
  - `POST /landlord/work-orders/:id/close-rework-directly`
- tenant action adds:
  - `POST /tenant/maintenance/:id/rework-signoff`
- the original `/tenant/maintenance/:id/signoff` route now rejects when second-pass signoff is required
- tenant responses expose only safe `reworkReview` fields

## Validation
- Focused backend tests passed
- Focused frontend tests passed
- Backend build passed
- Frontend build passed

## Limitations
- No new contractor review controls were added
- No expanded notification/reminder workflow in this PR
- Direct close still follows the existing tenant-signoff requirement model