### PR TITLE
feat(maintenance): add service execution and completion tracking v1

### DIFF
--- a/rentchain-api/src/routes/__tests__/maintenanceRequestsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/maintenanceRequestsRoutes.test.ts
@@ -209,6 +209,93 @@ describe("maintenanceRequestsRoutes scheduling access", () => {
     expect(savedWorkOrder?.accessRequired).toBe(true);
   });
 
+  it("records landlord-started service through the landlord patch route", async () => {
+    const router = (await import("../maintenanceRequestsRoutes")).default;
+    ensureCollection("maintenanceRequests").set("maint-1", {
+      ...ensureCollection("maintenanceRequests").get("maint-1"),
+      status: "scheduled",
+      serviceWindowStartAt: 500,
+      serviceWindowEndAt: 900,
+      accessRequired: true,
+    });
+
+    const res = await invokeRouter(router, {
+      method: "PATCH",
+      url: "/landlord/maintenance/maint-1",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "landlord-1",
+          role: "landlord",
+          landlordId: "landlord-1",
+        }),
+      },
+      body: {
+        status: "in_progress",
+        message: "Landlord marked service as started.",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.item?.status).toBe("in_progress");
+    expect(res.body?.item?.serviceStartedAt).toBeDefined();
+
+    const savedMaintenance = ensureCollection("maintenanceRequests").get("maint-1");
+    expect(savedMaintenance?.serviceStartedAt).toBeDefined();
+    expect(savedMaintenance?.lastExecutionUpdateAt).toBeDefined();
+    expect(savedMaintenance?.statusHistory).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ status: "in_progress", message: "Landlord marked service as started." }),
+      ])
+    );
+
+    const savedWorkOrder = ensureCollection("workOrders").get("maintenance_maint-1");
+    expect(savedWorkOrder?.status).toBe("in_progress");
+    expect(savedWorkOrder?.serviceStartedAt).toBeDefined();
+  });
+
+  it("records landlord completion metadata through the landlord patch route", async () => {
+    const router = (await import("../maintenanceRequestsRoutes")).default;
+    ensureCollection("maintenanceRequests").set("maint-1", {
+      ...ensureCollection("maintenanceRequests").get("maint-1"),
+      status: "in_progress",
+      serviceStartedAt: 500,
+    });
+
+    const res = await invokeRouter(router, {
+      method: "PATCH",
+      url: "/landlord/maintenance/maint-1",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "landlord-1",
+          role: "landlord",
+          landlordId: "landlord-1",
+        }),
+      },
+      body: {
+        status: "completed",
+        completionSummary: "Technician restored heat and confirmed stable airflow.",
+        completionOutcome: "completed",
+        message: "Landlord recorded service completion.",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.item?.status).toBe("completed");
+    expect(res.body?.item?.completionSummary).toMatch(/restored heat/i);
+    expect(res.body?.item?.serviceCompletedAt).toBeDefined();
+    expect(res.body?.item?.completionConfirmedByLandlordAt).toBeDefined();
+
+    const savedMaintenance = ensureCollection("maintenanceRequests").get("maint-1");
+    expect(savedMaintenance?.resolutionStatus).toBe("completed_pending_review");
+    expect(savedMaintenance?.completedByActorRole).toBe("landlord");
+    expect(savedMaintenance?.followUpRequired).toBe(false);
+
+    const savedWorkOrder = ensureCollection("workOrders").get("maintenance_maint-1");
+    expect(savedWorkOrder?.serviceCompletedAt).toBeDefined();
+    expect(savedWorkOrder?.completionSummary).toMatch(/stable airflow/i);
+    expect(savedWorkOrder?.completionConfirmedByLandlordAt).toBeDefined();
+  });
+
   it("allows a contractor to schedule service with structured execution metadata", async () => {
     const router = (await import("../maintenanceRequestsRoutes")).default;
 

--- a/rentchain-api/src/routes/maintenanceRequestsRoutes.ts
+++ b/rentchain-api/src/routes/maintenanceRequestsRoutes.ts
@@ -1496,6 +1496,10 @@ router.patch("/landlord/maintenance/:id", async (req: any, res) => {
     const requestedWindowStartAt = req.body?.serviceWindowStartAt === undefined ? undefined : toMillis(req.body?.serviceWindowStartAt);
     const requestedWindowEndAt = req.body?.serviceWindowEndAt === undefined ? undefined : toMillis(req.body?.serviceWindowEndAt);
     const requestedAccessRequired = normalizeOptionalBoolean(req.body?.accessRequired);
+    const requestedCompletionSummary =
+      req.body?.completionSummary === undefined ? undefined : String(req.body?.completionSummary || "").trim().slice(0, 2000);
+    const requestedCompletionOutcome =
+      req.body?.completionOutcome === undefined ? undefined : normalizeCompletionOutcome(req.body?.completionOutcome);
     if (req.body?.serviceWindowStartAt !== undefined && requestedWindowStartAt === null && req.body?.serviceWindowStartAt !== null) {
       return res.status(400).json({ ok: false, error: "INVALID_SERVICE_WINDOW_START" });
     }
@@ -1508,6 +1512,12 @@ router.patch("/landlord/maintenance/:id", async (req: any, res) => {
       requestedWindowEndAt < requestedWindowStartAt
     ) {
       return res.status(400).json({ ok: false, error: "INVALID_SERVICE_WINDOW_RANGE" });
+    }
+    if (requestedCompletionSummary !== undefined && !(currentStatus === "completed" || nextStatus === "completed")) {
+      return res.status(400).json({ ok: false, error: "INVALID_COMPLETION_UPDATE" });
+    }
+    if (requestedCompletionOutcome !== undefined && !(currentStatus === "completed" || nextStatus === "completed")) {
+      return res.status(400).json({ ok: false, error: "INVALID_COMPLETION_UPDATE" });
     }
 
     let effectiveNextStatus = nextStatus;
@@ -1524,8 +1534,20 @@ router.patch("/landlord/maintenance/:id", async (req: any, res) => {
       });
     }
 
+    if (effectiveNextStatus === "completed" && !requestedCompletionSummary && !String(current.completionSummary || "").trim()) {
+      return res.status(400).json({ ok: false, error: "COMPLETION_SUMMARY_REQUIRED" });
+    }
+
+    const now = Date.now();
+    const completionSummary =
+      requestedCompletionSummary !== undefined ? requestedCompletionSummary || null : String(current.completionSummary || "").trim() || null;
+    const completionOutcome =
+      requestedCompletionOutcome !== undefined
+        ? requestedCompletionOutcome || "completed"
+        : normalizeCompletionOutcome(current.completionOutcome) || "completed";
+
     const update: any = {
-      updatedAt: Date.now(),
+      updatedAt: now,
       lastUpdatedBy: "LANDLORD",
     };
     if (effectiveNextStatus) update.status = effectiveNextStatus;
@@ -1544,6 +1566,41 @@ router.patch("/landlord/maintenance/:id", async (req: any, res) => {
     }
     if (requestedAccessRequired !== undefined) {
       update.accessRequired = requestedAccessRequired;
+    }
+    if (effectiveNextStatus === "in_progress") {
+      update.serviceStartedAt = toMillis(current.serviceStartedAt) ?? now;
+      update.lastExecutionUpdateAt = now;
+      update.executionBlockedReason = null;
+    }
+    if (requestedCompletionSummary !== undefined || effectiveNextStatus === "completed") {
+      update.completionSummary = completionSummary;
+    }
+    if (requestedCompletionOutcome !== undefined || effectiveNextStatus === "completed") {
+      update.completionOutcome = completionOutcome;
+    }
+    if (effectiveNextStatus === "completed") {
+      update.serviceStartedAt = toMillis(current.serviceStartedAt) ?? now;
+      update.serviceCompletedAt = now;
+      update.lastExecutionUpdateAt = now;
+      update.executionBlockedReason = null;
+      update.completedByActorRole = role === "admin" ? "admin" : "landlord";
+      update.completedByActorId = actorId;
+      update.completionConfirmedByLandlordAt = now;
+      update.completionConfirmedByLandlordBy = actorId;
+      update.resolutionStatus = "completed_pending_review";
+      update.landlordApprovedAt = null;
+      update.landlordApprovedBy = null;
+      update.tenantSignoffStatus = null;
+      update.tenantSignedOffAt = null;
+      update.tenantDeclinedAt = null;
+      update.tenantDeclineReason = null;
+      update.followUpRequired = false;
+      update.followUpReason = null;
+      update.finalResolvedAt = null;
+      update.reopenedAt = null;
+      update.reopenedByActorId = null;
+      update.reopenedByActorRole = null;
+      update.reopenReason = null;
     }
     if (req.body?.serviceWindowStartAt !== undefined || req.body?.serviceWindowEndAt !== undefined) {
       update.tenantConfirmationStatus = null;
@@ -1602,6 +1659,29 @@ router.patch("/landlord/maintenance/:id", async (req: any, res) => {
         message: "Tenant access acknowledgement was reset because the access requirement changed.",
       });
     }
+    if (effectiveNextStatus === "in_progress" && currentStatus !== "in_progress") {
+      await appendStatusHistory(id, {
+        status: effectiveNextStatus,
+        actorRole: role === "admin" ? "admin" : "landlord",
+        actorId,
+        message: String(req.body?.message || "Service started.").slice(0, 500),
+      });
+    }
+    if (effectiveNextStatus === "completed") {
+      await appendStatusHistory(id, {
+        status: effectiveNextStatus,
+        actorRole: role === "admin" ? "admin" : "landlord",
+        actorId,
+        message: `Service completed${completionSummary ? `: ${completionSummary}` : "."}`.slice(0, 500),
+      });
+    } else if (requestedCompletionSummary !== undefined && completionSummary !== String(current.completionSummary || "").trim()) {
+      await appendStatusHistory(id, {
+        status: effectiveNextStatus || currentStatus,
+        actorRole: role === "admin" ? "admin" : "landlord",
+        actorId,
+        message: "Completion updated.",
+      });
+    }
 
     const refreshedSnap = await ref.get();
     const refreshed = { id: refreshedSnap.id, ...(refreshedSnap.data() as any) };
@@ -1624,11 +1704,31 @@ router.patch("/landlord/maintenance/:id", async (req: any, res) => {
         serviceWindowEndAt: toMillis(refreshed.serviceWindowEndAt),
         accessRequired: typeof refreshed.accessRequired === "boolean" ? refreshed.accessRequired : null,
         scheduledFor: toMillis(refreshed.serviceWindowStartAt) ?? toMillis(refreshed.scheduledFor),
+        serviceStartedAt: toMillis(refreshed.serviceStartedAt),
         serviceCompletedAt: toMillis(refreshed.serviceCompletedAt),
+        lastExecutionUpdateAt: toMillis(refreshed.lastExecutionUpdateAt),
+        executionBlockedReason: String(refreshed.executionBlockedReason || "").trim() || null,
         completionSummary: String(refreshed.completionSummary || "").trim() || null,
         completionOutcome: normalizeCompletionOutcome(refreshed.completionOutcome),
+        completedByActorRole:
+          refreshed.completedByActorRole === "contractor" ||
+          refreshed.completedByActorRole === "landlord" ||
+          refreshed.completedByActorRole === "admin"
+            ? refreshed.completedByActorRole
+            : null,
+        completedByActorId: String(refreshed.completedByActorId || "").trim() || null,
         completionConfirmedByLandlordAt: toMillis(refreshed.completionConfirmedByLandlordAt),
         completionConfirmedByLandlordBy: String(refreshed.completionConfirmedByLandlordBy || "").trim() || null,
+        resolutionStatus: normalizeResolutionStatus(refreshed.resolutionStatus),
+        landlordApprovedAt: toMillis(refreshed.landlordApprovedAt),
+        landlordApprovedBy: String(refreshed.landlordApprovedBy || "").trim() || null,
+        tenantSignoffStatus: normalizeTenantSignoffStatus(refreshed.tenantSignoffStatus),
+        tenantSignedOffAt: toMillis(refreshed.tenantSignedOffAt),
+        tenantDeclinedAt: toMillis(refreshed.tenantDeclinedAt),
+        tenantDeclineReason: String(refreshed.tenantDeclineReason || "").trim() || null,
+        followUpRequired: typeof refreshed.followUpRequired === "boolean" ? refreshed.followUpRequired : null,
+        followUpReason: String(refreshed.followUpReason || "").trim() || null,
+        finalResolvedAt: toMillis(refreshed.finalResolvedAt),
       });
       workOrderId = workOrder.workOrderId;
     }

--- a/rentchain-api/src/services/tenantPortal/tenantProjectionService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantProjectionService.ts
@@ -36,6 +36,12 @@ type TenantMaintenanceProjection = {
   summary: string | null;
   assignedContractorName: string | null;
   contractorStatus: string | null;
+  serviceStartedAt: number | null;
+  serviceCompletedAt: number | null;
+  lastExecutionUpdateAt: number | null;
+  completionSummary: string | null;
+  completionOutcome: "completed" | "partially_completed" | "follow_up_required" | null;
+  completionConfirmedByLandlordAt: number | null;
   serviceWindowStartAt: number | null;
   serviceWindowEndAt: number | null;
   accessRequired: boolean | null;
@@ -224,6 +230,17 @@ export function projectTenantMaintenance(recordId: string, data: any): TenantMai
     summary: asString(data?.summary) || asString(data?.description),
     assignedContractorName: asString(data?.assignedContractorName),
     contractorStatus: asString(data?.contractorStatus),
+    serviceStartedAt: toMillis(data?.serviceStartedAt),
+    serviceCompletedAt: toMillis(data?.serviceCompletedAt),
+    lastExecutionUpdateAt: toMillis(data?.lastExecutionUpdateAt),
+    completionSummary: asString(data?.completionSummary),
+    completionOutcome:
+      data?.completionOutcome === "completed" ||
+      data?.completionOutcome === "partially_completed" ||
+      data?.completionOutcome === "follow_up_required"
+        ? data.completionOutcome
+        : null,
+    completionConfirmedByLandlordAt: toMillis(data?.completionConfirmedByLandlordAt),
     serviceWindowStartAt: toMillis(data?.serviceWindowStartAt),
     serviceWindowEndAt: toMillis(data?.serviceWindowEndAt),
     accessRequired: typeof data?.accessRequired === "boolean" ? data.accessRequired : null,

--- a/rentchain-frontend/src/api/maintenanceWorkflowApi.ts
+++ b/rentchain-frontend/src/api/maintenanceWorkflowApi.ts
@@ -871,6 +871,8 @@ export async function patchLandlordMaintenance(
     serviceWindowStartAt?: number | null;
     serviceWindowEndAt?: number | null;
     accessRequired?: boolean | null;
+    completionSummary?: string;
+    completionOutcome?: "completed" | "partially_completed" | "follow_up_required";
     message?: string;
   }
 ) {

--- a/rentchain-frontend/src/api/tenantPortal.ts
+++ b/rentchain-frontend/src/api/tenantPortal.ts
@@ -59,6 +59,12 @@ export type TenantWorkspaceMaintenance = {
   summary: string | null;
   assignedContractorName?: string | null;
   contractorStatus?: string | null;
+  serviceStartedAt?: number | null;
+  serviceCompletedAt?: number | null;
+  lastExecutionUpdateAt?: number | null;
+  completionSummary?: string | null;
+  completionOutcome?: "completed" | "partially_completed" | "follow_up_required" | null;
+  completionConfirmedByLandlordAt?: number | null;
   serviceWindowStartAt?: number | null;
   serviceWindowEndAt?: number | null;
   accessRequired?: boolean | null;

--- a/rentchain-frontend/src/pages/MaintenanceRequestsPage.test.tsx
+++ b/rentchain-frontend/src/pages/MaintenanceRequestsPage.test.tsx
@@ -104,8 +104,58 @@ describe("landlord maintenance workspace", () => {
     expect(screen.getByText(/Awaiting schedule/i)).toBeInTheDocument();
     expect(screen.getByText(/Confirmation \/ access/i)).toBeInTheDocument();
     expect(screen.getAllByText(/Not ready for service/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Execution \/ completion/i)).toBeInTheDocument();
+    expect(screen.getByText(/Current service state/i)).toBeInTheDocument();
     expect(screen.getByText(/Review the request details/i)).toBeInTheDocument();
     expect(screen.getByText(/Mark reviewed/i)).toBeInTheDocument();
+  });
+
+  it("records a landlord start-of-service update from the execution workspace", async () => {
+    maintenanceWorkflowApi.listLandlordMaintenance.mockResolvedValue({
+      items: [
+        {
+          id: "maint-1",
+          tenantId: "tenant-1",
+          landlordId: "landlord-1",
+          propertyId: "prop-1",
+          unitId: "unit-2",
+          tenantName: "Taylor Tenant",
+          propertyLabel: "123 Main St",
+          unitLabel: "Unit 4",
+          title: "Broken heater",
+          description: "Heat is not turning on.",
+          category: "HVAC",
+          priority: "urgent",
+          status: "scheduled",
+          assignedContractorName: "North Shore HVAC",
+          serviceWindowStartAt: Date.UTC(2026, 3, 15, 13, 0),
+          serviceWindowEndAt: Date.UTC(2026, 3, 15, 15, 0),
+          accessRequired: true,
+          tenantConfirmationStatus: "confirmed",
+          accessAcknowledgedAt: Date.UTC(2026, 3, 14, 11, 0),
+          createdAt: 100,
+          updatedAt: 200,
+          statusHistory: [],
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/maintenance/maint-1"]}>
+        <Routes>
+          <Route path="/maintenance/:id" element={<MaintenanceRequestsPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /Mark service started/i }));
+
+    expect(maintenanceWorkflowApi.patchLandlordMaintenance).toHaveBeenCalledWith("maint-1", {
+      status: "in_progress",
+      priority: "urgent",
+      landlordNote: "",
+      message: "Landlord marked service as started.",
+    });
   });
 
   it("opens the related request from the scheduled maintenance calendar", async () => {

--- a/rentchain-frontend/src/pages/MaintenanceRequestsPage.tsx
+++ b/rentchain-frontend/src/pages/MaintenanceRequestsPage.tsx
@@ -16,6 +16,7 @@ import { colors, radius, spacing, text } from "../styles/tokens";
 import { buildMaintenanceLifecycleView, buildMaintenanceWorkspaceState } from "./maintenanceWorkspaceState";
 import { buildMaintenanceAssignmentRoutingView } from "./maintenanceAssignmentRoutingState";
 import { buildMaintenanceConfirmationAccessView } from "./maintenanceConfirmationAccessState";
+import { buildMaintenanceServiceExecutionView } from "./maintenanceServiceExecutionState";
 import {
   buildMaintenanceSchedulingAccessView,
   buildMaintenanceSchedulingCalendarEvents,
@@ -121,6 +122,7 @@ export default function MaintenanceRequestsPage() {
   const [filter, setFilter] = React.useState<"all" | MaintenanceWorkflowStatus>("all");
   const [saving, setSaving] = React.useState(false);
   const [landlordNote, setLandlordNote] = React.useState("");
+  const [completionSummary, setCompletionSummary] = React.useState("");
   const [priority, setPriority] = React.useState<"low" | "normal" | "urgent">("normal");
   const [contractorId, setContractorId] = React.useState("");
   const [serviceWindowStart, setServiceWindowStart] = React.useState("");
@@ -214,6 +216,7 @@ export default function MaintenanceRequestsPage() {
   React.useEffect(() => {
     if (selected) {
       setLandlordNote(String(selected.landlordNote || ""));
+      setCompletionSummary(String(selected.completionSummary || ""));
       setPriority(selected.priority || "normal");
       setContractorId(String(selected.assignedContractorId || ""));
       setServiceWindowStart(toLocalInputValue(selected.serviceWindowStartAt));
@@ -227,6 +230,7 @@ export default function MaintenanceRequestsPage() {
       const first = filtered[0];
       setSelectedId(first.id);
       setLandlordNote(String(first.landlordNote || ""));
+      setCompletionSummary(String(first.completionSummary || ""));
       setPriority(first.priority || "normal");
       setContractorId(String(first.assignedContractorId || ""));
       setServiceWindowStart(toLocalInputValue(first.serviceWindowStartAt));
@@ -356,11 +360,10 @@ export default function MaintenanceRequestsPage() {
         onClick: () => updateStatus("scheduled", "Visit scheduled with the assigned contractor."),
       });
     }
-    if (["reviewed", "assigned", "scheduled", "in_progress"].includes(selected.status)) {
+    if (selected.status === "scheduled") {
       actions.push({
-        label: "Mark completed",
-        onClick: () =>
-          updateStatus("completed", "Landlord marked the request completed."),
+        label: "Mark in progress",
+        onClick: () => updateStatus("in_progress", "Landlord marked service as started."),
       });
     }
     if (!["completed", "cancelled"].includes(selected.status)) {
@@ -386,6 +389,10 @@ export default function MaintenanceRequestsPage() {
   );
   const selectedConfirmation = React.useMemo(
     () => (selected ? buildMaintenanceConfirmationAccessView(selected, "landlord") : null),
+    [selected]
+  );
+  const selectedExecution = React.useMemo(
+    () => (selected ? buildMaintenanceServiceExecutionView(selected, "landlord") : null),
     [selected]
   );
   const calendarEvents = React.useMemo(() => buildMaintenanceSchedulingCalendarEvents(items), [items]);
@@ -590,6 +597,7 @@ export default function MaintenanceRequestsPage() {
                     const active = item.id === selected?.id;
                     const lifecycle = buildMaintenanceLifecycleView(item, "landlord");
                     const assignment = buildMaintenanceAssignmentRoutingView(item, "landlord");
+                    const execution = buildMaintenanceServiceExecutionView(item, "landlord");
                     return (
                       <button
                         key={item.id}
@@ -638,6 +646,7 @@ export default function MaintenanceRequestsPage() {
 <span style={{ color: text.muted, fontSize: 12 }}>{fmtDate(item.createdAt)}</span>
 </div>
 <div style={{ color: text.secondary, fontSize: 12 }}>{assignment.ownerSummary}</div>
+<div style={{ color: text.secondary, fontSize: 12 }}>{execution.executionLabel}</div>
 </button>
 );
 })}
@@ -769,6 +778,117 @@ export default function MaintenanceRequestsPage() {
                           {step}
                         </div>
                       ))}
+                    </div>
+                  ) : null}
+
+                  {selectedExecution ? (
+                    <div
+                      style={{
+                        border: `1px solid ${colors.border}`,
+                        borderRadius: radius.md,
+                        padding: "12px 14px",
+                        background: colors.panel,
+                        display: "grid",
+                        gap: 8,
+                      }}
+                    >
+                      <div style={{ fontWeight: 700, color: text.primary }}>Execution / completion</div>
+                      <div style={{ color: text.secondary }}>{selectedExecution.summary}</div>
+                      <div style={{ fontWeight: 700, color: text.primary }}>Current service state</div>
+                      <div style={{ color: text.secondary }}>{selectedExecution.executionLabel}</div>
+                      <div style={{ fontWeight: 700, color: text.primary }}>Completion state</div>
+                      <div style={{ color: text.secondary }}>{selectedExecution.completionLabel}</div>
+                      {selectedExecution.timelineEvents.length ? (
+                        <>
+                          <div style={{ fontWeight: 700, color: text.primary }}>Recent service updates</div>
+                          {selectedExecution.timelineEvents.map((event) => (
+                            <div key={event.key} style={{ color: text.secondary }}>
+                              {event.label} • {fmtDate(event.timestamp)}
+                            </div>
+                          ))}
+                        </>
+                      ) : null}
+                      {selected.completionSummary ? (
+                        <>
+                          <div style={{ fontWeight: 700, color: text.primary }}>Completion note</div>
+                          <div style={{ color: text.secondary }}>{selected.completionSummary}</div>
+                        </>
+                      ) : null}
+                      {selectedExecution.blockers.length ? (
+                        <>
+                          <div style={{ fontWeight: 700, color: text.primary }}>Needs attention</div>
+                          {selectedExecution.blockers.map((item) => (
+                            <div key={item} style={{ color: text.secondary }}>
+                              {item}
+                            </div>
+                          ))}
+                        </>
+                      ) : null}
+                      <div style={{ fontWeight: 700, color: text.primary }}>Next step</div>
+                      {selectedExecution.nextActions.map((step) => (
+                        <div key={step} style={{ color: text.secondary }}>
+                          {step}
+                        </div>
+                      ))}
+                      {selectedExecution.executionState === "in_progress" ? (
+                        <textarea
+                          value={completionSummary}
+                          onChange={(e) => setCompletionSummary(e.target.value)}
+                          placeholder="Add a completion note before closing the request"
+                          rows={3}
+                          style={{
+                            width: "100%",
+                            borderRadius: radius.md,
+                            border: `1px solid ${colors.border}`,
+                            padding: 10,
+                            resize: "vertical",
+                            background: colors.card,
+                            color: text.primary,
+                          }}
+                        />
+                      ) : null}
+                      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                        {selectedExecution.executionState === "ready_for_service" ? (
+                          <Button
+                            variant="secondary"
+                            disabled={saving}
+                            onClick={() => void updateStatus("in_progress", "Landlord marked service as started.")}
+                          >
+                            {saving ? "Saving..." : "Mark service started"}
+                          </Button>
+                        ) : null}
+                        {selectedExecution.executionState === "in_progress" ? (
+                          <Button
+                            variant="secondary"
+                            disabled={saving}
+                            onClick={async () => {
+                              if (!selected) return;
+                              if (!completionSummary.trim()) {
+                                setError("Add a completion note before marking service completed.");
+                                return;
+                              }
+                              setSaving(true);
+                              setError(null);
+                              try {
+                                await patchLandlordMaintenance(selected.id, {
+                                  status: "completed",
+                                  completionSummary: completionSummary.trim(),
+                                  completionOutcome: "completed",
+                                  message: "Landlord recorded service completion.",
+                                });
+                                showToast({ message: "Service completion recorded.", variant: "success" });
+                                await load();
+                              } catch (err: any) {
+                                setError(String(err?.message || "Failed to record service completion"));
+                              } finally {
+                                setSaving(false);
+                              }
+                            }}
+                          >
+                            {saving ? "Saving..." : "Mark service completed"}
+                          </Button>
+                        ) : null}
+                      </div>
                     </div>
                   ) : null}
 

--- a/rentchain-frontend/src/pages/maintenanceServiceExecutionState.test.ts
+++ b/rentchain-frontend/src/pages/maintenanceServiceExecutionState.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { buildMaintenanceServiceExecutionView } from "./maintenanceServiceExecutionState";
+
+const baseItem = {
+  id: "maint-1",
+  tenantId: "tenant-1",
+  landlordId: "landlord-1",
+  propertyId: "prop-1",
+  unitId: "unit-1",
+  title: "Leaky faucet",
+  description: "Kitchen sink is leaking",
+  category: "PLUMBING",
+  priority: "normal" as const,
+  status: "submitted" as const,
+  createdAt: 100,
+  updatedAt: 200,
+};
+
+describe("maintenance service execution state", () => {
+  it("marks a scheduled and confirmed request as ready for service", () => {
+    const view = buildMaintenanceServiceExecutionView(
+      {
+        ...baseItem,
+        status: "scheduled",
+        serviceWindowStartAt: 400,
+        tenantConfirmationStatus: "confirmed",
+        accessRequired: true,
+        accessAcknowledgedAt: 420,
+      },
+      "landlord"
+    );
+
+    expect(view.executionState).toBe("ready_for_service");
+    expect(view.nextActions[0]).toMatch(/mark service started/i);
+  });
+
+  it("marks a started request as in progress", () => {
+    const view = buildMaintenanceServiceExecutionView(
+      {
+        ...baseItem,
+        status: "in_progress",
+        serviceStartedAt: 500,
+      },
+      "tenant"
+    );
+
+    expect(view.executionState).toBe("in_progress");
+    expect(view.completionState).toBe("awaiting_completion");
+    expect(view.tenantVisibleState).toBe("work_in_progress");
+  });
+
+  it("marks a completed request with follow-up as completion_needs_attention", () => {
+    const view = buildMaintenanceServiceExecutionView(
+      {
+        ...baseItem,
+        status: "completed",
+        serviceStartedAt: 500,
+        serviceCompletedAt: 700,
+        completionSummary: "Replaced the faucet cartridge.",
+        followUpRequired: true,
+        resolutionStatus: "follow_up_required",
+      },
+      "landlord"
+    );
+
+    expect(view.completionState).toBe("completion_needs_attention");
+    expect(view.blockers.join(" ")).toMatch(/follow-up/i);
+    expect(view.timelineEvents.map((event) => event.kind)).toEqual(["service_completed", "service_started"]);
+  });
+});

--- a/rentchain-frontend/src/pages/maintenanceServiceExecutionState.ts
+++ b/rentchain-frontend/src/pages/maintenanceServiceExecutionState.ts
@@ -1,0 +1,316 @@
+import type { MaintenanceWorkflowItem } from "../api/maintenanceWorkflowApi";
+
+type Audience = "tenant" | "landlord";
+
+export type MaintenanceServiceExecutionState =
+  | "not_ready"
+  | "ready_for_service"
+  | "in_progress"
+  | "completed"
+  | "needs_attention";
+
+export type MaintenanceServiceCompletionState =
+  | "not_started"
+  | "awaiting_completion"
+  | "completed"
+  | "completion_needs_attention";
+
+export type MaintenanceServiceTenantVisibleState =
+  | "not_ready"
+  | "ready_for_service"
+  | "work_in_progress"
+  | "service_completed"
+  | "needs_attention";
+
+export type MaintenanceServiceTimelineEvent = {
+  key: string;
+  kind: "service_started" | "service_completed" | "completion_recorded";
+  label: string;
+  timestamp: number;
+};
+
+export type MaintenanceServiceExecutionView = {
+  executionState: MaintenanceServiceExecutionState;
+  executionLabel: string;
+  completionState: MaintenanceServiceCompletionState;
+  completionLabel: string;
+  tenantVisibleState: MaintenanceServiceTenantVisibleState;
+  tenantVisibleLabel: string;
+  readinessState: MaintenanceServiceExecutionState;
+  readinessLabel: string;
+  summary: string;
+  blockers: string[];
+  nextActions: string[];
+  timelineEvents: MaintenanceServiceTimelineEvent[];
+};
+
+function statusOf(item: MaintenanceWorkflowItem) {
+  return String(item.status || "").trim().toLowerCase();
+}
+
+function hasServiceWindow(item: MaintenanceWorkflowItem) {
+  return typeof item.serviceWindowStartAt === "number";
+}
+
+function hasConfirmedAccess(item: MaintenanceWorkflowItem) {
+  if (item.accessRequired !== true) return true;
+  return typeof item.accessAcknowledgedAt === "number";
+}
+
+function isReadyForService(item: MaintenanceWorkflowItem) {
+  return (
+    statusOf(item) === "scheduled" &&
+    hasServiceWindow(item) &&
+    item.tenantConfirmationStatus === "confirmed" &&
+    hasConfirmedAccess(item)
+  );
+}
+
+function hasStarted(item: MaintenanceWorkflowItem) {
+  return typeof item.serviceStartedAt === "number" || ["in_progress", "completed"].includes(statusOf(item));
+}
+
+function hasCompleted(item: MaintenanceWorkflowItem) {
+  return typeof item.serviceCompletedAt === "number" || statusOf(item) === "completed";
+}
+
+function hasCompletionAttention(item: MaintenanceWorkflowItem) {
+  return (
+    item.followUpRequired === true ||
+    item.resolutionStatus === "follow_up_required" ||
+    item.tenantSignoffStatus === "declined"
+  );
+}
+
+function buildTimelineEvents(item: MaintenanceWorkflowItem): MaintenanceServiceTimelineEvent[] {
+  const events: MaintenanceServiceTimelineEvent[] = [];
+  if (typeof item.serviceStartedAt === "number") {
+    events.push({
+      key: "service_started",
+      kind: "service_started",
+      label: "Service started",
+      timestamp: item.serviceStartedAt,
+    });
+  }
+  if (typeof item.serviceCompletedAt === "number") {
+    events.push({
+      key: "service_completed",
+      kind: "service_completed",
+      label: "Service completed",
+      timestamp: item.serviceCompletedAt,
+    });
+  }
+  if (typeof item.completionConfirmedByLandlordAt === "number") {
+    events.push({
+      key: "completion_recorded",
+      kind: "completion_recorded",
+      label: "Completion recorded",
+      timestamp: item.completionConfirmedByLandlordAt,
+    });
+  }
+  return events.sort((a, b) => b.timestamp - a.timestamp);
+}
+
+function executionLabel(state: MaintenanceServiceExecutionState) {
+  switch (state) {
+    case "ready_for_service":
+      return "Ready for service";
+    case "in_progress":
+      return "Work in progress";
+    case "completed":
+      return "Service completed";
+    case "needs_attention":
+      return "Needs attention";
+    case "not_ready":
+    default:
+      return "Not ready";
+  }
+}
+
+function completionLabel(state: MaintenanceServiceCompletionState) {
+  switch (state) {
+    case "awaiting_completion":
+      return "Awaiting completion";
+    case "completed":
+      return "Completed";
+    case "completion_needs_attention":
+      return "Completion needs attention";
+    case "not_started":
+    default:
+      return "Not started";
+  }
+}
+
+function tenantVisibleLabel(state: MaintenanceServiceTenantVisibleState) {
+  switch (state) {
+    case "ready_for_service":
+      return "Ready for service";
+    case "work_in_progress":
+      return "Work in progress";
+    case "service_completed":
+      return "Service completed";
+    case "needs_attention":
+      return "Needs attention";
+    case "not_ready":
+    default:
+      return "Not ready";
+  }
+}
+
+export function buildMaintenanceServiceExecutionView(
+  item: MaintenanceWorkflowItem,
+  audience: Audience
+): MaintenanceServiceExecutionView {
+  const status = statusOf(item);
+  const blockers: string[] = [];
+  const nextActions: string[] = [];
+  const started = hasStarted(item);
+  const completed = hasCompleted(item);
+  const ready = isReadyForService(item);
+  const completionNeedsAttention = hasCompletionAttention(item);
+
+  let executionState: MaintenanceServiceExecutionState = "not_ready";
+  let completionState: MaintenanceServiceCompletionState = "not_started";
+  let tenantState: MaintenanceServiceTenantVisibleState = "not_ready";
+  let summary =
+    audience === "landlord"
+      ? "This request is still moving through setup and is not yet clearly ready to begin service."
+      : "This request is still moving through setup and is not yet clearly ready for service.";
+
+  if (status === "cancelled") {
+    executionState = "needs_attention";
+    completionState = "completion_needs_attention";
+    tenantState = "needs_attention";
+    blockers.push(
+      audience === "landlord"
+        ? "This request is cancelled and needs review before service can continue."
+        : "This request is cancelled and needs a new property-side update before service can continue."
+    );
+    summary =
+      audience === "landlord"
+        ? "This request is not in an active service path right now."
+        : "This request is not in an active service path right now.";
+  } else if (completed) {
+    executionState = completionNeedsAttention ? "needs_attention" : "completed";
+    completionState = completionNeedsAttention ? "completion_needs_attention" : "completed";
+    tenantState = completionNeedsAttention ? "needs_attention" : "service_completed";
+    if (!item.completionSummary) {
+      blockers.push(
+        audience === "landlord"
+          ? "A completion note has not been recorded yet."
+          : "A detailed completion note has not been shared yet."
+      );
+    }
+    if (completionNeedsAttention) {
+      blockers.push(
+        audience === "landlord"
+          ? "Follow-up is still open, so this request is not operationally closed yet."
+          : "Follow-up is still open, so this request is not fully closed yet."
+      );
+      summary =
+        audience === "landlord"
+          ? "Service completion was recorded, but the request still needs follow-up before closure."
+          : "Service completion was recorded, but the request still needs follow-up before closure.";
+    } else {
+      summary =
+        audience === "landlord"
+          ? "Service completion has been recorded and the request now has a clear closure state."
+          : "Service completion has been recorded so you can see that the service visit finished.";
+    }
+  } else if (started) {
+    executionState = "in_progress";
+    completionState = "awaiting_completion";
+    tenantState = "work_in_progress";
+    summary =
+      audience === "landlord"
+        ? "Service has started and is still open until completion is recorded."
+        : "Service is underway and the request will stay active until completion is recorded.";
+  } else if (item.tenantConfirmationStatus === "needs_schedule_change") {
+    executionState = "needs_attention";
+    completionState = "not_started";
+    tenantState = "needs_attention";
+    blockers.push(
+      audience === "landlord"
+        ? "The tenant asked for a schedule change before service begins."
+        : "You asked for a schedule change before service begins."
+    );
+    summary =
+      audience === "landlord"
+        ? "This request is paused at scheduling because the current service window needs attention."
+        : "This request is paused at scheduling because the current service window needs attention.";
+  } else if (ready) {
+    executionState = "ready_for_service";
+    completionState = "not_started";
+    tenantState = "ready_for_service";
+    summary =
+      audience === "landlord"
+        ? "This request is ready for service and can be marked in progress when work begins."
+        : "This request is ready for service and should move to work in progress once the visit begins.";
+  } else {
+    if (!hasServiceWindow(item) && ["assigned", "scheduled"].includes(status)) {
+      blockers.push(
+        audience === "landlord"
+          ? "A confirmed service window is still missing."
+          : "A confirmed service window is still missing."
+      );
+    }
+    if (status === "scheduled" && item.tenantConfirmationStatus !== "confirmed") {
+      blockers.push(
+        audience === "landlord"
+          ? "Tenant confirmation is still pending."
+          : "Tenant confirmation is still pending."
+      );
+    }
+    if (item.accessRequired === true && !hasConfirmedAccess(item)) {
+      blockers.push(
+        audience === "landlord"
+          ? "Access still needs to be acknowledged before service is clearly ready."
+          : "Access still needs to be acknowledged before service is clearly ready."
+      );
+    }
+  }
+
+  if (executionState === "ready_for_service") {
+    nextActions.push(
+      audience === "landlord"
+        ? "Mark service started when the visit begins."
+        : "Watch this request for the service-start update."
+    );
+  }
+  if (executionState === "in_progress") {
+    nextActions.push(
+      audience === "landlord"
+        ? "Record completion when the work is done."
+        : "Watch this request for the completion update."
+    );
+  }
+  if (completionState === "completion_needs_attention") {
+    nextActions.push(
+      audience === "landlord"
+        ? "Review the follow-up state before treating this request as closed."
+        : "Review the latest follow-up update from your landlord."
+    );
+  }
+  if (nextActions.length === 0) {
+    nextActions.push(
+      audience === "landlord"
+        ? "Use the request detail to keep the service state current."
+        : "Use the request detail for the latest service update."
+    );
+  }
+
+  return {
+    executionState,
+    executionLabel: executionLabel(executionState),
+    completionState,
+    completionLabel: completionLabel(completionState),
+    tenantVisibleState: tenantState,
+    tenantVisibleLabel: tenantVisibleLabel(tenantState),
+    readinessState: executionState,
+    readinessLabel: executionLabel(executionState),
+    summary,
+    blockers,
+    nextActions,
+    timelineEvents: buildTimelineEvents(item),
+  };
+}

--- a/rentchain-frontend/src/pages/tenant/TenantMaintenancePages.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantMaintenancePages.test.tsx
@@ -95,6 +95,7 @@ describe("tenant maintenance pages", () => {
     expect(screen.getAllByText(/Scheduling \/ access/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Upcoming service window: No service window has been confirmed yet/i)).toBeInTheDocument();
     expect(screen.getAllByText(/Confirmation \/ access/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Execution \/ completion/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/landlord needs to confirm the service window/i)).toBeInTheDocument();
   });
 
@@ -109,9 +110,11 @@ describe("tenant maintenance pages", () => {
         category: "HVAC",
         assignedContractorName: "North Shore HVAC",
         contractorStatus: "assigned",
+        serviceStartedAt: Date.UTC(2026, 3, 15, 13, 15),
         serviceWindowStartAt: Date.UTC(2026, 3, 15, 13, 0),
         serviceWindowEndAt: Date.UTC(2026, 3, 15, 15, 0),
         accessRequired: true,
+        completionSummary: "Heat was restored and the thermostat was recalibrated.",
         notifications: {
           tenant: {
             requiresAccessConfirmation: true,
@@ -192,6 +195,9 @@ describe("tenant maintenance pages", () => {
     expect(screen.getAllByText(/Scheduling \/ access/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Access needed/i)).toBeInTheDocument();
     expect(screen.getAllByText(/Confirmation \/ access/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Execution \/ completion/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Work in progress/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Completion note/i)).toBeInTheDocument();
     expect(screen.getByText(/Follow-up \/ rework/i)).toBeInTheDocument();
     expect(screen.getByText(/Rework #1 is in progress/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Confirm service window/i })).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/tenant/TenantMaintenanceRequestDetailPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantMaintenanceRequestDetailPage.tsx
@@ -15,6 +15,7 @@ import { TenantSurfaceShell, prettyStatus } from "./TenantWorkspaceShared";
 import { buildMaintenanceLifecycleView } from "../maintenanceWorkspaceState";
 import { buildMaintenanceAssignmentRoutingView } from "../maintenanceAssignmentRoutingState";
 import { buildMaintenanceConfirmationAccessView } from "../maintenanceConfirmationAccessState";
+import { buildMaintenanceServiceExecutionView } from "../maintenanceServiceExecutionState";
 import { buildMaintenanceSchedulingAccessView } from "../maintenanceSchedulingAccessState";
 
 function fmtDate(ts?: number | null) {
@@ -90,6 +91,7 @@ export default function TenantMaintenanceRequestDetailPage() {
   const assignmentView = data ? buildMaintenanceAssignmentRoutingView(data, "tenant") : null;
   const schedulingView = data ? buildMaintenanceSchedulingAccessView(data, "tenant") : null;
   const confirmationView = data ? buildMaintenanceConfirmationAccessView(data, "tenant") : null;
+  const executionView = data ? buildMaintenanceServiceExecutionView(data, "tenant") : null;
   const notificationMessages = tenantNotificationMessages(data);
 
   useEffect(() => {
@@ -465,6 +467,57 @@ export default function TenantMaintenanceRequestDetailPage() {
                       ) : null}
                     </div>
                   ) : null}
+                </div>
+              ) : null}
+              {executionView ? (
+                <div
+                  style={{
+                    border: `1px solid ${colors.border}`,
+                    borderRadius: radius.md,
+                    padding: "12px 14px",
+                    background: colors.panel,
+                    display: "grid",
+                    gap: 8,
+                  }}
+                >
+                  <div style={{ fontWeight: 800, color: textTokens.primary }}>Execution / completion</div>
+                  <div style={{ color: textTokens.secondary }}>{executionView.summary}</div>
+                  <div style={{ color: textTokens.primary, fontWeight: 700 }}>Current service state</div>
+                  <div style={{ color: textTokens.secondary }}>{executionView.tenantVisibleLabel}</div>
+                  <div style={{ color: textTokens.primary, fontWeight: 700 }}>Completion state</div>
+                  <div style={{ color: textTokens.secondary }}>{executionView.completionLabel}</div>
+                  {data.completionSummary ? (
+                    <>
+                      <div style={{ color: textTokens.primary, fontWeight: 700 }}>Completion note</div>
+                      <div style={{ color: textTokens.secondary }}>{data.completionSummary}</div>
+                    </>
+                  ) : null}
+                  {executionView.timelineEvents.length ? (
+                    <>
+                      <div style={{ color: textTokens.primary, fontWeight: 700 }}>Recent service updates</div>
+                      {executionView.timelineEvents.map((event) => (
+                        <div key={event.key} style={{ color: textTokens.secondary }}>
+                          {event.label} • {fmtDate(event.timestamp)}
+                        </div>
+                      ))}
+                    </>
+                  ) : null}
+                  {executionView.blockers.length ? (
+                    <>
+                      <div style={{ color: textTokens.primary, fontWeight: 700 }}>Needs attention</div>
+                      {executionView.blockers.map((item) => (
+                        <div key={item} style={{ color: textTokens.secondary }}>
+                          {item}
+                        </div>
+                      ))}
+                    </>
+                  ) : null}
+                  <div style={{ color: textTokens.primary, fontWeight: 700 }}>Next step</div>
+                  {executionView.nextActions.map((step) => (
+                    <div key={step} style={{ color: textTokens.secondary }}>
+                      {step}
+                    </div>
+                  ))}
                 </div>
               ) : null}
               {notificationMessages.length ? (

--- a/rentchain-frontend/src/pages/tenant/TenantMaintenanceRequestsPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantMaintenanceRequestsPage.tsx
@@ -6,6 +6,7 @@ import { colors, spacing, text as textTokens } from "../../styles/tokens";
 import { buildMaintenanceWorkspaceState } from "../maintenanceWorkspaceState";
 import { buildMaintenanceAssignmentRoutingView } from "../maintenanceAssignmentRoutingState";
 import { buildMaintenanceConfirmationAccessView } from "../maintenanceConfirmationAccessState";
+import { buildMaintenanceServiceExecutionView } from "../maintenanceServiceExecutionState";
 import { buildMaintenanceSchedulingAccessView } from "../maintenanceSchedulingAccessState";
 import {
   TenantEmptyState,
@@ -150,6 +151,7 @@ export default function TenantMaintenanceRequestsPage() {
               const assignmentView = buildMaintenanceAssignmentRoutingView(item, "tenant");
               const schedulingView = buildMaintenanceSchedulingAccessView(item, "tenant");
               const confirmationView = buildMaintenanceConfirmationAccessView(item, "tenant");
+              const executionView = buildMaintenanceServiceExecutionView(item, "tenant");
               const notificationMessages = tenantNotificationMessages(item);
               return (
                 <TenantInfoCard
@@ -220,6 +222,24 @@ export default function TenantMaintenanceRequestsPage() {
                     <div style={{ color: textTokens.secondary }}>
                       {`${confirmationView.tenantVisibleState} • ${confirmationView.accessLabel}`}
                     </div>
+                  </div>
+                  <div
+                    style={{
+                      border: "1px solid rgba(15,23,42,0.08)",
+                      borderRadius: 12,
+                      padding: "12px 14px",
+                      display: "grid",
+                      gap: 8,
+                    }}
+                  >
+                    <div style={{ color: textTokens.primary, fontWeight: 700 }}>Execution / completion</div>
+                    <div style={{ color: textTokens.secondary }}>{executionView.summary}</div>
+                    <div style={{ color: textTokens.secondary }}>
+                      {`${executionView.tenantVisibleLabel} • ${executionView.completionLabel}`}
+                    </div>
+                    {item.completionSummary ? (
+                      <div style={{ color: textTokens.secondary }}>Completion note: {item.completionSummary}</div>
+                    ) : null}
                   </div>
                   {requestView?.nextSteps.length ? (
                     <div style={{ display: "grid", gap: 4 }}>


### PR DESCRIPTION
## Summary
Adds a structured maintenance service execution/closure layer across landlord and tenant maintenance workspaces.

Landlords can now clearly see when a request is ready for service, mark when work starts, and record completion with a completion note. Tenants now get clearer in-progress/completed visibility and tenant-safe completion context.

## What Changed
- Added a pure `maintenanceServiceExecutionState` helper for derived execution/completion state
- Added landlord execution/completion workspace UI in maintenance request detail
- Added narrow server-authoritative landlord actions for:
  - marking service as started
  - marking service as completed
- Exposed tenant-safe execution/completion fields through the tenant maintenance projection
- Added tenant execution/completion visibility in maintenance list/detail views
- Added targeted frontend and backend tests

## Scope Notes
- No schema redesign
- No auth-core changes
- No protected-area changes
- Reused the existing landlord maintenance PATCH route instead of introducing new workflow endpoints

## Validation
- Frontend targeted tests passed
- Frontend build passed
- Backend targeted tests passed
- Backend build passed