### PR TITLE
feat(maintenance): add resolution verification and tenant closure v1

### DIFF
--- a/rentchain-frontend/src/pages/MaintenanceRequestsPage.test.tsx
+++ b/rentchain-frontend/src/pages/MaintenanceRequestsPage.test.tsx
@@ -106,8 +106,54 @@ describe("landlord maintenance workspace", () => {
     expect(screen.getAllByText(/Not ready for service/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Execution \/ completion/i)).toBeInTheDocument();
     expect(screen.getByText(/Current service state/i)).toBeInTheDocument();
+    expect(screen.getByText(/Resolution \/ closure/i)).toBeInTheDocument();
+    expect(screen.getByText(/Verification status/i)).toBeInTheDocument();
     expect(screen.getByText(/Review the request details/i)).toBeInTheDocument();
     expect(screen.getByText(/Mark reviewed/i)).toBeInTheDocument();
+  });
+
+  it("shows pending verification and follow-up state in the landlord closure workspace", async () => {
+    maintenanceWorkflowApi.listLandlordMaintenance.mockResolvedValue({
+      items: [
+        {
+          id: "maint-1",
+          tenantId: "tenant-1",
+          landlordId: "landlord-1",
+          propertyId: "prop-1",
+          unitId: "unit-2",
+          tenantName: "Taylor Tenant",
+          propertyLabel: "123 Main St",
+          unitLabel: "Unit 4",
+          title: "Broken heater",
+          description: "Heat is not turning on.",
+          category: "HVAC",
+          priority: "urgent",
+          status: "completed",
+          assignedContractorName: "North Shore HVAC",
+          completionSummary: "Heat restored and vents balanced.",
+          resolutionStatus: "follow_up_required",
+          followUpRequired: true,
+          followUpReason: "Back bedroom is still cooler than the rest of the unit.",
+          tenantDeclineReason: "Back bedroom is still cooler than the rest of the unit.",
+          tenantDeclinedAt: Date.UTC(2026, 3, 16, 10, 0),
+          createdAt: 100,
+          updatedAt: 200,
+          statusHistory: [],
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/maintenance/maint-1"]}>
+        <Routes>
+          <Route path="/maintenance/:id" element={<MaintenanceRequestsPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Resolution \/ closure/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Still needs attention/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Back bedroom is still cooler than the rest of the unit/i).length).toBeGreaterThan(0);
   });
 
   it("records a landlord start-of-service update from the execution workspace", async () => {

--- a/rentchain-frontend/src/pages/MaintenanceRequestsPage.tsx
+++ b/rentchain-frontend/src/pages/MaintenanceRequestsPage.tsx
@@ -17,6 +17,7 @@ import { buildMaintenanceLifecycleView, buildMaintenanceWorkspaceState } from ".
 import { buildMaintenanceAssignmentRoutingView } from "./maintenanceAssignmentRoutingState";
 import { buildMaintenanceConfirmationAccessView } from "./maintenanceConfirmationAccessState";
 import { buildMaintenanceServiceExecutionView } from "./maintenanceServiceExecutionState";
+import { buildMaintenanceResolutionVerificationView } from "./maintenanceResolutionVerificationState";
 import {
   buildMaintenanceSchedulingAccessView,
   buildMaintenanceSchedulingCalendarEvents,
@@ -395,6 +396,10 @@ export default function MaintenanceRequestsPage() {
     () => (selected ? buildMaintenanceServiceExecutionView(selected, "landlord") : null),
     [selected]
   );
+  const selectedResolution = React.useMemo(
+    () => (selected ? buildMaintenanceResolutionVerificationView(selected, "landlord") : null),
+    [selected]
+  );
   const calendarEvents = React.useMemo(() => buildMaintenanceSchedulingCalendarEvents(items), [items]);
   const calendarDays = React.useMemo(() => buildCalendarDays(calendarMonth), [calendarMonth]);
   const calendarEventMap = React.useMemo(() => {
@@ -598,6 +603,7 @@ export default function MaintenanceRequestsPage() {
                     const lifecycle = buildMaintenanceLifecycleView(item, "landlord");
                     const assignment = buildMaintenanceAssignmentRoutingView(item, "landlord");
                     const execution = buildMaintenanceServiceExecutionView(item, "landlord");
+                    const resolution = buildMaintenanceResolutionVerificationView(item, "landlord");
                     return (
                       <button
                         key={item.id}
@@ -647,6 +653,7 @@ export default function MaintenanceRequestsPage() {
 </div>
 <div style={{ color: text.secondary, fontSize: 12 }}>{assignment.ownerSummary}</div>
 <div style={{ color: text.secondary, fontSize: 12 }}>{execution.executionLabel}</div>
+<div style={{ color: text.secondary, fontSize: 12 }}>{resolution.verificationLabel}</div>
 </button>
 );
 })}
@@ -889,6 +896,64 @@ export default function MaintenanceRequestsPage() {
                           </Button>
                         ) : null}
                       </div>
+                    </div>
+                  ) : null}
+
+                  {selectedResolution ? (
+                    <div
+                      style={{
+                        border: `1px solid ${colors.border}`,
+                        borderRadius: radius.md,
+                        padding: "12px 14px",
+                        background: colors.panel,
+                        display: "grid",
+                        gap: 8,
+                      }}
+                    >
+                      <div style={{ fontWeight: 700, color: text.primary }}>Resolution / closure</div>
+                      <div style={{ color: text.secondary }}>{selectedResolution.summary}</div>
+                      <div style={{ fontWeight: 700, color: text.primary }}>Verification status</div>
+                      <div style={{ color: text.secondary }}>{selectedResolution.verificationLabel}</div>
+                      <div style={{ fontWeight: 700, color: text.primary }}>Closure state</div>
+                      <div style={{ color: text.secondary }}>{selectedResolution.closureLabel}</div>
+                      {selected.followUpReason ? (
+                        <>
+                          <div style={{ fontWeight: 700, color: text.primary }}>Follow-up note</div>
+                          <div style={{ color: text.secondary }}>{selected.followUpReason}</div>
+                        </>
+                      ) : null}
+                      {selected.tenantDeclineReason ? (
+                        <>
+                          <div style={{ fontWeight: 700, color: text.primary }}>Tenant note</div>
+                          <div style={{ color: text.secondary }}>{selected.tenantDeclineReason}</div>
+                        </>
+                      ) : null}
+                      {selectedResolution.timelineEvents.length ? (
+                        <>
+                          <div style={{ fontWeight: 700, color: text.primary }}>Recent closure updates</div>
+                          {selectedResolution.timelineEvents.map((event) => (
+                            <div key={event.key} style={{ color: text.secondary }}>
+                              {event.label} • {fmtDate(event.timestamp)}
+                            </div>
+                          ))}
+                        </>
+                      ) : null}
+                      {selectedResolution.blockers.length ? (
+                        <>
+                          <div style={{ fontWeight: 700, color: text.primary }}>Needs attention</div>
+                          {selectedResolution.blockers.map((item) => (
+                            <div key={item} style={{ color: text.secondary }}>
+                              {item}
+                            </div>
+                          ))}
+                        </>
+                      ) : null}
+                      <div style={{ fontWeight: 700, color: text.primary }}>Next step</div>
+                      {selectedResolution.nextActions.map((step) => (
+                        <div key={step} style={{ color: text.secondary }}>
+                          {step}
+                        </div>
+                      ))}
                     </div>
                   ) : null}
 

--- a/rentchain-frontend/src/pages/maintenanceResolutionVerificationState.test.ts
+++ b/rentchain-frontend/src/pages/maintenanceResolutionVerificationState.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { buildMaintenanceResolutionVerificationView } from "./maintenanceResolutionVerificationState";
+
+const baseItem = {
+  id: "maint-1",
+  tenantId: "tenant-1",
+  landlordId: "landlord-1",
+  propertyId: "prop-1",
+  unitId: "unit-1",
+  title: "Leaky faucet",
+  description: "Kitchen sink is leaking",
+  category: "PLUMBING",
+  priority: "normal" as const,
+  status: "submitted" as const,
+  createdAt: 100,
+  updatedAt: 200,
+};
+
+describe("maintenanceResolutionVerificationState", () => {
+  it("marks completed work as awaiting verification when tenant review is pending", () => {
+    const view = buildMaintenanceResolutionVerificationView(
+      {
+        ...baseItem,
+        status: "completed",
+        serviceCompletedAt: 700,
+        completionConfirmedByLandlordAt: 710,
+        resolutionStatus: "tenant_pending_signoff",
+      },
+      "tenant"
+    );
+
+    expect(view.verificationState).toBe("awaiting_verification");
+    expect(view.tenantVisibleState).toBe("awaiting_your_verification");
+  });
+
+  it("marks a tenant-confirmed request as closed when final resolution is recorded", () => {
+    const view = buildMaintenanceResolutionVerificationView(
+      {
+        ...baseItem,
+        status: "completed",
+        serviceCompletedAt: 700,
+        resolutionStatus: "resolved",
+        tenantSignoffStatus: "accepted",
+        tenantSignedOffAt: 720,
+        finalResolvedAt: 720,
+      },
+      "landlord"
+    );
+
+    expect(view.verificationState).toBe("resolved");
+    expect(view.closureState).toBe("closed");
+    expect(view.timelineEvents.map((event) => event.kind)).toEqual(["resolution_verified", "request_closed"]);
+  });
+
+  it("marks declined verification as needs_follow_up", () => {
+    const view = buildMaintenanceResolutionVerificationView(
+      {
+        ...baseItem,
+        status: "completed",
+        serviceCompletedAt: 700,
+        resolutionStatus: "follow_up_required",
+        tenantSignoffStatus: "declined",
+        tenantDeclinedAt: 730,
+        followUpRequired: true,
+      },
+      "landlord"
+    );
+
+    expect(view.verificationState).toBe("needs_follow_up");
+    expect(view.closureState).toBe("needs_attention");
+    expect(view.blockers.join(" ")).toMatch(/follow-up/i);
+  });
+});

--- a/rentchain-frontend/src/pages/maintenanceResolutionVerificationState.ts
+++ b/rentchain-frontend/src/pages/maintenanceResolutionVerificationState.ts
@@ -1,0 +1,291 @@
+import type { MaintenanceWorkflowItem } from "../api/maintenanceWorkflowApi";
+
+type Audience = "tenant" | "landlord";
+
+export type MaintenanceResolutionVerificationState =
+  | "not_ready"
+  | "awaiting_verification"
+  | "resolved"
+  | "needs_follow_up"
+  | "needs_attention";
+
+export type MaintenanceResolutionClosureState = "open" | "ready_to_close" | "closed" | "needs_attention";
+
+export type MaintenanceResolutionTenantVisibleState =
+  | "not_ready"
+  | "awaiting_your_verification"
+  | "resolved"
+  | "still_needs_attention"
+  | "closed"
+  | "needs_attention";
+
+export type MaintenanceResolutionTimelineEvent = {
+  key: string;
+  kind: "awaiting_verification" | "resolution_verified" | "follow_up_needed" | "request_closed";
+  label: string;
+  timestamp: number;
+};
+
+export type MaintenanceResolutionVerificationView = {
+  verificationState: MaintenanceResolutionVerificationState;
+  verificationLabel: string;
+  closureState: MaintenanceResolutionClosureState;
+  closureLabel: string;
+  tenantVisibleState: MaintenanceResolutionTenantVisibleState;
+  tenantVisibleLabel: string;
+  readinessState: MaintenanceResolutionVerificationState;
+  readinessLabel: string;
+  summary: string;
+  blockers: string[];
+  nextActions: string[];
+  timelineEvents: MaintenanceResolutionTimelineEvent[];
+};
+
+function statusOf(item: MaintenanceWorkflowItem) {
+  return String(item.status || "").trim().toLowerCase();
+}
+
+function isCompleted(item: MaintenanceWorkflowItem) {
+  return statusOf(item) === "completed" || typeof item.serviceCompletedAt === "number";
+}
+
+function isAwaitingVerification(item: MaintenanceWorkflowItem) {
+  return (
+    isCompleted(item) &&
+    (item.resolutionStatus === "completed_pending_review" ||
+      item.resolutionStatus === "landlord_approved" ||
+      item.resolutionStatus === "tenant_pending_signoff")
+  );
+}
+
+function isResolved(item: MaintenanceWorkflowItem) {
+  return item.resolutionStatus === "resolved" || item.tenantSignoffStatus === "accepted";
+}
+
+function needsFollowUp(item: MaintenanceWorkflowItem) {
+  return (
+    item.resolutionStatus === "follow_up_required" ||
+    item.followUpRequired === true ||
+    item.tenantSignoffStatus === "declined"
+  );
+}
+
+function isClosed(item: MaintenanceWorkflowItem) {
+  return typeof item.finalResolvedAt === "number" && isResolved(item);
+}
+
+function buildTimelineEvents(item: MaintenanceWorkflowItem): MaintenanceResolutionTimelineEvent[] {
+  const events: MaintenanceResolutionTimelineEvent[] = [];
+  if (typeof item.completionConfirmedByLandlordAt === "number" && isAwaitingVerification(item)) {
+    events.push({
+      key: "awaiting_verification",
+      kind: "awaiting_verification",
+      label: "Awaiting tenant verification",
+      timestamp: item.completionConfirmedByLandlordAt,
+    });
+  }
+  if (typeof item.tenantSignedOffAt === "number") {
+    events.push({
+      key: "resolution_verified",
+      kind: "resolution_verified",
+      label: "Resolution verified",
+      timestamp: item.tenantSignedOffAt,
+    });
+  }
+  if (typeof item.tenantDeclinedAt === "number") {
+    events.push({
+      key: "follow_up_needed",
+      kind: "follow_up_needed",
+      label: "Follow-up needed",
+      timestamp: item.tenantDeclinedAt,
+    });
+  }
+  if (typeof item.finalResolvedAt === "number") {
+    events.push({
+      key: "request_closed",
+      kind: "request_closed",
+      label: "Request closed",
+      timestamp: item.finalResolvedAt,
+    });
+  }
+  return events.sort((a, b) => b.timestamp - a.timestamp);
+}
+
+function verificationLabel(state: MaintenanceResolutionVerificationState) {
+  switch (state) {
+    case "awaiting_verification":
+      return "Awaiting verification";
+    case "resolved":
+      return "Resolved";
+    case "needs_follow_up":
+      return "Still needs attention";
+    case "needs_attention":
+      return "Needs attention";
+    case "not_ready":
+    default:
+      return "Not ready";
+  }
+}
+
+function closureLabel(state: MaintenanceResolutionClosureState) {
+  switch (state) {
+    case "ready_to_close":
+      return "Ready to close";
+    case "closed":
+      return "Closed";
+    case "needs_attention":
+      return "Needs attention";
+    case "open":
+    default:
+      return "Open";
+  }
+}
+
+function tenantVisibleLabel(state: MaintenanceResolutionTenantVisibleState) {
+  switch (state) {
+    case "awaiting_your_verification":
+      return "Awaiting your verification";
+    case "resolved":
+      return "Resolved";
+    case "still_needs_attention":
+      return "Still needs attention";
+    case "closed":
+      return "Closed";
+    case "needs_attention":
+      return "Needs attention";
+    case "not_ready":
+    default:
+      return "Not ready";
+  }
+}
+
+export function buildMaintenanceResolutionVerificationView(
+  item: MaintenanceWorkflowItem,
+  audience: Audience
+): MaintenanceResolutionVerificationView {
+  const blockers: string[] = [];
+  const nextActions: string[] = [];
+
+  let verificationState: MaintenanceResolutionVerificationState = "not_ready";
+  let closureState: MaintenanceResolutionClosureState = "open";
+  let tenantState: MaintenanceResolutionTenantVisibleState = "not_ready";
+  let summary =
+    audience === "landlord"
+      ? "This request is not yet in the resolution-verification stage."
+      : "This request is not yet in the resolution-verification stage.";
+
+  if (statusOf(item) === "cancelled") {
+    verificationState = "needs_attention";
+    closureState = "needs_attention";
+    tenantState = "needs_attention";
+    blockers.push(
+      audience === "landlord"
+        ? "This request is cancelled and needs review before it can be treated as closed."
+        : "This request is cancelled and needs a new update before it can be treated as closed."
+    );
+  } else if (!isCompleted(item)) {
+    verificationState = "not_ready";
+    closureState = "open";
+    tenantState = "not_ready";
+    blockers.push(
+      audience === "landlord"
+        ? "Tenant verification is not available until service completion is recorded."
+        : "Verification becomes available after service completion is recorded."
+    );
+  } else if (needsFollowUp(item)) {
+    verificationState = "needs_follow_up";
+    closureState = "needs_attention";
+    tenantState = "still_needs_attention";
+    summary =
+      audience === "landlord"
+        ? "The tenant reported that the issue still needs attention, so this request is not closed."
+        : "You reported that the issue still needs attention, so this request stays open for follow-up.";
+    blockers.push(
+      audience === "landlord"
+        ? "Follow-up is still required before this request can close."
+        : "Your landlord still needs to coordinate follow-up before this request can close."
+    );
+  } else if (isClosed(item)) {
+    verificationState = "resolved";
+    closureState = "closed";
+    tenantState = "closed";
+    summary =
+      audience === "landlord"
+        ? "The tenant confirmed resolution and the request now has a verified closure state."
+        : "You confirmed the issue was resolved and the request is now closed.";
+  } else if (isResolved(item)) {
+    verificationState = "resolved";
+    closureState = "ready_to_close";
+    tenantState = "resolved";
+    summary =
+      audience === "landlord"
+        ? "The issue has been marked resolved and is ready to be treated as closed."
+        : "The issue has been marked resolved.";
+  } else if (isAwaitingVerification(item)) {
+    verificationState = "awaiting_verification";
+    closureState = "open";
+    tenantState = "awaiting_your_verification";
+    summary =
+      audience === "landlord"
+        ? "Completed work is waiting for tenant verification before the request can be clearly closed."
+        : "Completed work is waiting for your verification before the request can be clearly closed.";
+    blockers.push(
+      audience === "landlord"
+        ? "Tenant verification is still pending."
+        : "Your verification is still needed."
+    );
+  } else {
+    verificationState = "needs_attention";
+    closureState = "needs_attention";
+    tenantState = "needs_attention";
+    blockers.push(
+      audience === "landlord"
+        ? "The closure state is ambiguous and should be reviewed."
+        : "The closure state is ambiguous and should be reviewed."
+    );
+  }
+
+  if (verificationState === "awaiting_verification") {
+    nextActions.push(
+      audience === "landlord"
+        ? "Wait for the tenant to confirm whether the issue is resolved."
+        : "Confirm whether the issue is resolved or still needs attention."
+    );
+  }
+  if (verificationState === "needs_follow_up") {
+    nextActions.push(
+      audience === "landlord"
+        ? "Review the tenant follow-up note and decide the next service step."
+        : "Watch for the next follow-up update from your landlord."
+    );
+  }
+  if (closureState === "closed") {
+    nextActions.push(
+      audience === "landlord"
+        ? "Keep this request in closed history unless a new follow-up cycle is needed."
+        : "Keep this request in your history for future reference."
+    );
+  }
+  if (nextActions.length === 0) {
+    nextActions.push(
+      audience === "landlord"
+        ? "Use the request detail for the next closure update."
+        : "Use the request detail for the latest closure update."
+    );
+  }
+
+  return {
+    verificationState,
+    verificationLabel: verificationLabel(verificationState),
+    closureState,
+    closureLabel: closureLabel(closureState),
+    tenantVisibleState: tenantState,
+    tenantVisibleLabel: tenantVisibleLabel(tenantState),
+    readinessState: verificationState,
+    readinessLabel: verificationLabel(verificationState),
+    summary,
+    blockers,
+    nextActions,
+    timelineEvents: buildTimelineEvents(item),
+  };
+}

--- a/rentchain-frontend/src/pages/tenant/TenantMaintenancePages.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantMaintenancePages.test.tsx
@@ -96,6 +96,7 @@ describe("tenant maintenance pages", () => {
     expect(screen.getByText(/Upcoming service window: No service window has been confirmed yet/i)).toBeInTheDocument();
     expect(screen.getAllByText(/Confirmation \/ access/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Execution \/ completion/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Resolution \/ closure/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/landlord needs to confirm the service window/i)).toBeInTheDocument();
   });
 
@@ -196,6 +197,7 @@ describe("tenant maintenance pages", () => {
     expect(screen.getByText(/Access needed/i)).toBeInTheDocument();
     expect(screen.getAllByText(/Confirmation \/ access/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Execution \/ completion/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Resolution \/ closure/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Work in progress/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Completion note/i)).toBeInTheDocument();
     expect(screen.getByText(/Follow-up \/ rework/i)).toBeInTheDocument();
@@ -316,7 +318,7 @@ describe("tenant maintenance pages", () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByRole("button", { name: /Mark resolved/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /Confirm issue resolved/i }));
 
     await waitFor(() => {
       expect(maintenanceWorkflowApi.updateTenantMaintenanceSignoff).toHaveBeenCalledWith("maint-1", {
@@ -325,6 +327,40 @@ describe("tenant maintenance pages", () => {
       });
     });
     expect(await screen.findByText(/This request has been marked resolved/i)).toBeInTheDocument();
+  });
+
+  it("shows a still-needs-attention closure state in tenant detail", async () => {
+    maintenanceWorkflowApi.getTenantMaintenance.mockResolvedValue({
+      item: {
+        id: "maint-1",
+        title: "Broken heater",
+        description: "The heat is not turning on.",
+        status: "completed",
+        priority: "urgent",
+        category: "HVAC",
+        assignedContractorName: "North Shore HVAC",
+        contractorStatus: "completed",
+        resolutionStatus: "follow_up_required",
+        followUpRequired: true,
+        followUpReason: "Back bedroom still feels cold overnight.",
+        tenantDeclineReason: "Back bedroom still feels cold overnight.",
+        createdAt: 100,
+        updatedAt: 400,
+        statusHistory: [],
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/tenant/maintenance/maint-1"]}>
+        <Routes>
+          <Route path="/tenant/maintenance/:id" element={<TenantMaintenanceRequestDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect((await screen.findAllByText(/Resolution \/ closure/i)).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Still needs attention/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Back bedroom still feels cold overnight/i).length).toBeGreaterThan(0);
   });
 
   it("submits tenant rework signoff from the detail page when a second-pass review is pending", async () => {

--- a/rentchain-frontend/src/pages/tenant/TenantMaintenanceRequestDetailPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantMaintenanceRequestDetailPage.tsx
@@ -16,6 +16,7 @@ import { buildMaintenanceLifecycleView } from "../maintenanceWorkspaceState";
 import { buildMaintenanceAssignmentRoutingView } from "../maintenanceAssignmentRoutingState";
 import { buildMaintenanceConfirmationAccessView } from "../maintenanceConfirmationAccessState";
 import { buildMaintenanceServiceExecutionView } from "../maintenanceServiceExecutionState";
+import { buildMaintenanceResolutionVerificationView } from "../maintenanceResolutionVerificationState";
 import { buildMaintenanceSchedulingAccessView } from "../maintenanceSchedulingAccessState";
 
 function fmtDate(ts?: number | null) {
@@ -92,6 +93,7 @@ export default function TenantMaintenanceRequestDetailPage() {
   const schedulingView = data ? buildMaintenanceSchedulingAccessView(data, "tenant") : null;
   const confirmationView = data ? buildMaintenanceConfirmationAccessView(data, "tenant") : null;
   const executionView = data ? buildMaintenanceServiceExecutionView(data, "tenant") : null;
+  const resolutionView = data ? buildMaintenanceResolutionVerificationView(data, "tenant") : null;
   const notificationMessages = tenantNotificationMessages(data);
 
   useEffect(() => {
@@ -676,68 +678,98 @@ export default function TenantMaintenanceRequestDetailPage() {
                   ) : null}
                 </div>
               ) : null}
-              <div
-                style={{
-                  border: `1px solid ${colors.border}`,
-                  borderRadius: radius.md,
-                  padding: "12px 14px",
-                  background: colors.panel,
-                  display: "grid",
-                  gap: 8,
-                }}
-              >
-                <div style={{ fontWeight: 800, color: textTokens.primary }}>Resolution approval</div>
-                <div style={{ color: textTokens.secondary }}>{resolutionStatusLabel(data.resolutionStatus)}</div>
-                {data.landlordApprovedAt ? (
-                  <div style={{ color: textTokens.secondary }}>Landlord approved the completed work on {fmtDate(data.landlordApprovedAt)}.</div>
-                ) : null}
-                {data.finalResolvedAt ? (
-                  <div style={{ color: textTokens.secondary }}>Final resolution recorded on {fmtDate(data.finalResolvedAt)}.</div>
-                ) : null}
-                {data.followUpReason ? (
-                  <>
-                    <div style={{ color: textTokens.primary, fontWeight: 700 }}>Follow-up reason</div>
-                    <div style={{ color: textTokens.secondary }}>{data.followUpReason}</div>
-                  </>
-                ) : null}
-                {data.tenantDeclineReason ? (
-                  <>
-                    <div style={{ color: textTokens.primary, fontWeight: 700 }}>Your latest note</div>
-                    <div style={{ color: textTokens.secondary }}>{data.tenantDeclineReason}</div>
-                  </>
-                ) : null}
-                {data.status === "completed" &&
-                data.resolutionStatus === "tenant_pending_signoff" &&
-                data.reworkReview?.status !== "tenant_pending_signoff" ? (
-                  <>
-                    <div style={{ color: textTokens.primary, fontWeight: 700 }}>Next step</div>
-                    <div style={{ color: textTokens.secondary }}>
-                      Review the completed work and let your landlord know whether the issue is fully resolved.
+              {resolutionView ? (
+                <div
+                  style={{
+                    border: `1px solid ${colors.border}`,
+                    borderRadius: radius.md,
+                    padding: "12px 14px",
+                    background: colors.panel,
+                    display: "grid",
+                    gap: 8,
+                  }}
+                >
+                  <div style={{ fontWeight: 800, color: textTokens.primary }}>Resolution / closure</div>
+                  <div style={{ color: textTokens.secondary }}>{resolutionView.summary}</div>
+                  <div style={{ color: textTokens.primary, fontWeight: 700 }}>Resolution status</div>
+                  <div style={{ color: textTokens.secondary }}>{resolutionView.verificationLabel}</div>
+                  <div style={{ color: textTokens.primary, fontWeight: 700 }}>Closure state</div>
+                  <div style={{ color: textTokens.secondary }}>{resolutionView.closureLabel}</div>
+                  <div style={{ color: textTokens.primary, fontWeight: 700 }}>Current detail</div>
+                  <div style={{ color: textTokens.secondary }}>{resolutionStatusLabel(data.resolutionStatus)}</div>
+                  {data.landlordApprovedAt ? (
+                    <div style={{ color: textTokens.secondary }}>Landlord reviewed the completed work on {fmtDate(data.landlordApprovedAt)}.</div>
+                  ) : null}
+                  {data.finalResolvedAt ? (
+                    <div style={{ color: textTokens.secondary }}>Request closed on {fmtDate(data.finalResolvedAt)}.</div>
+                  ) : null}
+                  {data.followUpReason ? (
+                    <>
+                      <div style={{ color: textTokens.primary, fontWeight: 700 }}>Follow-up reason</div>
+                      <div style={{ color: textTokens.secondary }}>{data.followUpReason}</div>
+                    </>
+                  ) : null}
+                  {data.tenantDeclineReason ? (
+                    <>
+                      <div style={{ color: textTokens.primary, fontWeight: 700 }}>Your latest note</div>
+                      <div style={{ color: textTokens.secondary }}>{data.tenantDeclineReason}</div>
+                    </>
+                  ) : null}
+                  {resolutionView.timelineEvents.length ? (
+                    <>
+                      <div style={{ color: textTokens.primary, fontWeight: 700 }}>Recent closure updates</div>
+                      {resolutionView.timelineEvents.map((event) => (
+                        <div key={event.key} style={{ color: textTokens.secondary }}>
+                          {event.label} • {fmtDate(event.timestamp)}
+                        </div>
+                      ))}
+                    </>
+                  ) : null}
+                  {resolutionView.blockers.length ? (
+                    <>
+                      <div style={{ color: textTokens.primary, fontWeight: 700 }}>Needs attention</div>
+                      {resolutionView.blockers.map((item) => (
+                        <div key={item} style={{ color: textTokens.secondary }}>
+                          {item}
+                        </div>
+                      ))}
+                    </>
+                  ) : null}
+                  <div style={{ color: textTokens.primary, fontWeight: 700 }}>Next step</div>
+                  {resolutionView.nextActions.map((step) => (
+                    <div key={step} style={{ color: textTokens.secondary }}>
+                      {step}
                     </div>
-                    <textarea
-                      value={signoffReason}
-                      onChange={(e) => setSignoffReason(e.target.value)}
-                      placeholder="If follow-up is still needed, explain what is incomplete or still not working"
-                      rows={3}
-                      style={{
-                        width: "100%",
-                        borderRadius: 8,
-                        border: `1px solid ${colors.border}`,
-                        padding: 10,
-                        resize: "vertical",
-                      }}
-                    />
-                    <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-                      <Button variant="secondary" disabled={savingAction} onClick={() => void applyResolutionSignoff("resolved")}>
-                        {savingAction ? "Saving..." : "Mark resolved"}
-                      </Button>
-                      <Button variant="ghost" disabled={savingAction} onClick={() => void applyResolutionSignoff("not_resolved")}>
-                        {savingAction ? "Saving..." : "Request follow-up"}
-                      </Button>
-                    </div>
-                  </>
-                ) : null}
-              </div>
+                  ))}
+                  {data.status === "completed" &&
+                  data.resolutionStatus === "tenant_pending_signoff" &&
+                  data.reworkReview?.status !== "tenant_pending_signoff" ? (
+                    <>
+                      <textarea
+                        value={signoffReason}
+                        onChange={(e) => setSignoffReason(e.target.value)}
+                        placeholder="If the issue still needs attention, explain what is incomplete or still not working"
+                        rows={3}
+                        style={{
+                          width: "100%",
+                          borderRadius: 8,
+                          border: `1px solid ${colors.border}`,
+                          padding: 10,
+                          resize: "vertical",
+                        }}
+                      />
+                      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                        <Button variant="secondary" disabled={savingAction} onClick={() => void applyResolutionSignoff("resolved")}>
+                          {savingAction ? "Saving..." : "Confirm issue resolved"}
+                        </Button>
+                        <Button variant="ghost" disabled={savingAction} onClick={() => void applyResolutionSignoff("not_resolved")}>
+                          {savingAction ? "Saving..." : "Still needs attention"}
+                        </Button>
+                      </div>
+                    </>
+                  ) : null}
+                </div>
+              ) : null}
               {Array.isArray(data.evidence) && data.evidence.length ? (
                 <div
                   style={{

--- a/rentchain-frontend/src/pages/tenant/TenantMaintenanceRequestsPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantMaintenanceRequestsPage.tsx
@@ -7,6 +7,7 @@ import { buildMaintenanceWorkspaceState } from "../maintenanceWorkspaceState";
 import { buildMaintenanceAssignmentRoutingView } from "../maintenanceAssignmentRoutingState";
 import { buildMaintenanceConfirmationAccessView } from "../maintenanceConfirmationAccessState";
 import { buildMaintenanceServiceExecutionView } from "../maintenanceServiceExecutionState";
+import { buildMaintenanceResolutionVerificationView } from "../maintenanceResolutionVerificationState";
 import { buildMaintenanceSchedulingAccessView } from "../maintenanceSchedulingAccessState";
 import {
   TenantEmptyState,
@@ -152,6 +153,7 @@ export default function TenantMaintenanceRequestsPage() {
               const schedulingView = buildMaintenanceSchedulingAccessView(item, "tenant");
               const confirmationView = buildMaintenanceConfirmationAccessView(item, "tenant");
               const executionView = buildMaintenanceServiceExecutionView(item, "tenant");
+              const resolutionView = buildMaintenanceResolutionVerificationView(item, "tenant");
               const notificationMessages = tenantNotificationMessages(item);
               return (
                 <TenantInfoCard
@@ -239,6 +241,24 @@ export default function TenantMaintenanceRequestsPage() {
                     </div>
                     {item.completionSummary ? (
                       <div style={{ color: textTokens.secondary }}>Completion note: {item.completionSummary}</div>
+                    ) : null}
+                  </div>
+                  <div
+                    style={{
+                      border: "1px solid rgba(15,23,42,0.08)",
+                      borderRadius: 12,
+                      padding: "12px 14px",
+                      display: "grid",
+                      gap: 8,
+                    }}
+                  >
+                    <div style={{ color: textTokens.primary, fontWeight: 700 }}>Resolution / closure</div>
+                    <div style={{ color: textTokens.secondary }}>{resolutionView.summary}</div>
+                    <div style={{ color: textTokens.secondary }}>
+                      {`${resolutionView.tenantVisibleLabel} • ${resolutionView.closureLabel}`}
+                    </div>
+                    {item.followUpReason ? (
+                      <div style={{ color: textTokens.secondary }}>Follow-up note: {item.followUpReason}</div>
                     ) : null}
                   </div>
                   {requestView?.nextSteps.length ? (


### PR DESCRIPTION
## Summary
Adds a maintenance resolution verification and tenant closure layer on top of service completion.

Landlords can now clearly see whether completed work is still awaiting tenant verification, has been marked resolved, still needs follow-up, or is truly closed. Tenants now get clearer closure-state visibility and a calmer verification action surface for confirming the issue is resolved or still needs attention.

## What Changed
- Added a pure `maintenanceResolutionVerificationState` helper for derived verification/closure state
- Added landlord `Resolution / closure` visibility in maintenance request detail
- Added tenant resolution/closure visibility in maintenance list and detail views
- Reframed the existing tenant signoff action copy to:
  - `Confirm issue resolved`
  - `Still needs attention`
- Added targeted tests for helper logic and landlord/tenant rendering

## Scope Notes
- No backend changes were required
- Reused the existing tenant signoff workflow and current maintenance request fields
- No schema redesign
- No auth-core or protected-area changes

## Validation
- Frontend targeted tests passed
- Frontend build passed