### PR TITLE
feat(maintenance): add reopen and follow-up escalation v1

### DIFF
--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -525,6 +525,56 @@ describe("tenantPortalRoutes foundation", () => {
     expect(savedWorkOrder?.finalResolvedAt).toBeDefined();
   });
 
+  it("lets the tenant reopen a closed maintenance request with a required reason", async () => {
+    const router = (await import("../tenantPortalRoutes")).default;
+    ensureCollection("maintenanceRequests").set("maint-2b", {
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      status: "completed",
+      priority: "NORMAL",
+      category: "GENERAL",
+      title: "Window repair",
+      description: "The latch failed again after closure.",
+      statusHistory: [],
+      createdAt: 100,
+      updatedAt: 200,
+    });
+    ensureCollection("workOrders").set("maintenance_maint-2b", {
+      maintenanceRequestId: "maint-2b",
+      tenantId: "tenant-1",
+      status: "completed",
+      resolutionStatus: "resolved",
+      tenantSignoffStatus: "accepted",
+      finalResolvedAt: 250,
+    });
+
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/maintenance/maint-2b/reopen",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+      body: {
+        reason: "The latch failed again after closure.",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.resolutionStatus).toBe("follow_up_required");
+    expect(res.body?.data?.reopenReason).toBe("The latch failed again after closure.");
+    expect(typeof res.body?.data?.reopenedAt).toBe("number");
+
+    const savedWorkOrder = ensureCollection("workOrders").get("maintenance_maint-2b");
+    expect(savedWorkOrder?.followUpRequired).toBe(true);
+    expect(savedWorkOrder?.reopenedByActorRole).toBe("tenant");
+    expect(savedWorkOrder?.finalResolvedAt).toBeNull();
+  });
+
   it("returns tenant-safe rework state and allows rework signoff again after rework completion", async () => {
     const router = (await import("../tenantPortalRoutes")).default;
     ensureCollection("maintenanceRequests").set("maint-3", {

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -5069,6 +5069,15 @@ async function buildTenantMaintenanceDetailResponse(docId: string, maintenanceDa
   return {
     ...projectTenantMaintenance(docId, maintenanceData || {}),
     evidence: workOrderExists ? await serializeEvidenceForAudience(workOrderData?.evidence, "tenant") : [],
+    reopenedAt: toMillis(workOrderData?.reopenedAt),
+    reopenedByActorId: String(workOrderData?.reopenedByActorId || "").trim() || null,
+    reopenedByActorRole:
+      workOrderData?.reopenedByActorRole === "tenant" ||
+      workOrderData?.reopenedByActorRole === "landlord" ||
+      workOrderData?.reopenedByActorRole === "admin"
+        ? workOrderData.reopenedByActorRole
+        : null,
+    reopenReason: String(workOrderData?.reopenReason || "").trim() || null,
     resolutionStatus:
       workOrderData?.resolutionStatus === "completed_pending_review" ||
       workOrderData?.resolutionStatus === "landlord_approved" ||
@@ -5122,6 +5131,144 @@ router.get("/maintenance-requests/:id", requireTenant, async (req: any, res) => 
       err,
     });
     return res.status(500).json({ ok: false, error: "TENANT_MAINT_REQUEST_READ_FAILED" });
+  }
+});
+
+router.post("/maintenance/:id/reopen", requireTenant, async (req: any, res) => {
+  try {
+    const tenantId = String(req.user?.tenantId || "").trim();
+    const id = String(req.params?.id || "").trim();
+    if (!tenantId) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    if (!id) return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+
+    const reason = String(req.body?.reason || "").trim().slice(0, 2000);
+    if (!reason) {
+      return res.status(400).json({ ok: false, error: "REOPEN_REASON_REQUIRED" });
+    }
+
+    const docRef = db.collection("maintenanceRequests").doc(id);
+    const snap = await docRef.get();
+    if (!snap.exists) return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+
+    const data = (snap.data() as any) || {};
+    if (String(data.tenantId || "").trim() !== tenantId) {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+
+    const workOrderRef = db.collection("workOrders").doc(`maintenance_${id}`);
+    const workOrderSnap = await workOrderRef.get();
+    if (!workOrderSnap.exists) {
+      return res.status(404).json({ ok: false, error: "WORK_ORDER_NOT_FOUND" });
+    }
+
+    const workOrder = (workOrderSnap.data() as any) || {};
+    if (String(workOrder.status || "").trim().toLowerCase() !== "completed") {
+      return res.status(400).json({ ok: false, error: "REOPEN_NOT_AVAILABLE" });
+    }
+    if (String(workOrder.resolutionStatus || "").trim().toLowerCase() === "tenant_pending_signoff") {
+      return res.status(400).json({ ok: false, error: "TENANT_SIGNOFF_REQUIRED" });
+    }
+    if (String(workOrder?.reworkReview?.status || "").trim().toLowerCase() === "tenant_pending_signoff") {
+      return res.status(400).json({ ok: false, error: "REWORK_SIGNOFF_REQUIRED" });
+    }
+    if (
+      String(workOrder.resolutionStatus || "").trim().toLowerCase() === "follow_up_required" ||
+      workOrder.followUpRequired === true
+    ) {
+      return res.status(400).json({ ok: false, error: "FOLLOW_UP_ALREADY_ACTIVE" });
+    }
+
+    const hasClosedOrResolvedState =
+      typeof toMillis(workOrder.finalResolvedAt) === "number" ||
+      String(workOrder.resolutionStatus || "").trim().toLowerCase() === "resolved" ||
+      String(workOrder.tenantSignoffStatus || "").trim().toLowerCase() === "accepted" ||
+      String(workOrder?.reworkReview?.status || "").trim().toLowerCase() === "closed";
+    if (!hasClosedOrResolvedState) {
+      return res.status(400).json({ ok: false, error: "REOPEN_NOT_AVAILABLE" });
+    }
+
+    const now = Date.now();
+    const historyMessage = `Tenant reopened the request: ${reason}`;
+    const contractorLastUpdate = `Tenant reported the issue still needs attention: ${reason}`;
+
+    await workOrderRef.set(
+      {
+        tenantSignoffStatus: "declined",
+        tenantSignedOffAt: null,
+        tenantDeclinedAt: now,
+        tenantDeclineReason: reason,
+        resolutionStatus: "follow_up_required",
+        followUpRequired: true,
+        followUpReason: reason,
+        finalResolvedAt: null,
+        reopenedAt: now,
+        reopenedByActorId: tenantId,
+        reopenedByActorRole: "tenant",
+        reopenReason: reason,
+        updatedAtMs: now,
+        lastExecutionUpdateAt: now,
+      },
+      { merge: true }
+    );
+    const refreshedReopenWorkOrder = await workOrderRef.get();
+    const refreshedReopenWorkOrderData = (refreshedReopenWorkOrder.data() as any) || {};
+    const reopenNotifications = await applyNotificationUpdate(workOrderRef, refreshedReopenWorkOrderData, now);
+
+    await Promise.all([
+      docRef.set(
+        {
+          updatedAt: now,
+          lastUpdatedBy: "TENANT",
+          contractorLastUpdate,
+          tenantSignoffStatus: "declined",
+          tenantSignedOffAt: null,
+          tenantDeclinedAt: now,
+          tenantDeclineReason: reason,
+          resolutionStatus: "follow_up_required",
+          followUpRequired: true,
+          followUpReason: reason,
+          finalResolvedAt: null,
+          reopenedAt: now,
+          reopenedByActorId: tenantId,
+          reopenedByActorRole: "tenant",
+          reopenReason: reason,
+          notifications: buildTenantSafeWorkOrderNotifications({
+            ...refreshedReopenWorkOrderData,
+            notifications: reopenNotifications,
+          }),
+          statusHistory: FieldValue.arrayUnion({
+            status: String(data.status || "completed"),
+            actorRole: "tenant",
+            actorId: tenantId,
+            message: historyMessage,
+            createdAt: now,
+          }),
+        },
+        { merge: true }
+      ),
+      db.collection("workOrderUpdates").doc().set({
+        workOrderId: workOrderRef.id,
+        actorRole: "tenant",
+        actorId: tenantId,
+        updateType: "reopened",
+        message: historyMessage,
+        createdAtMs: now,
+      }),
+    ]);
+
+    const [refreshed, refreshedWorkOrder] = await Promise.all([docRef.get(), workOrderRef.get()]);
+    const refreshedWorkOrderData = refreshedWorkOrder.exists ? ((refreshedWorkOrder.data() as any) || {}) : {};
+    return res.json({
+      ok: true,
+      data: await buildTenantMaintenanceDetailResponse(refreshed.id, refreshed.data() || {}, refreshedWorkOrderData, refreshedWorkOrder.exists),
+    });
+  } catch (err) {
+    console.error("[tenant/maintenance/:id/reopen] update failed", {
+      tenantId: req.user?.tenantId,
+      id: req.params?.id,
+      err,
+    });
+    return res.status(500).json({ ok: false, error: "TENANT_MAINT_REQUEST_REOPEN_FAILED" });
   }
 });
 

--- a/rentchain-api/src/services/tenantPortal/tenantProjectionService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantProjectionService.ts
@@ -42,6 +42,10 @@ type TenantMaintenanceProjection = {
   completionSummary: string | null;
   completionOutcome: "completed" | "partially_completed" | "follow_up_required" | null;
   completionConfirmedByLandlordAt: number | null;
+  reopenedAt: number | null;
+  reopenedByActorId: string | null;
+  reopenedByActorRole: "tenant" | "landlord" | "admin" | null;
+  reopenReason: string | null;
   serviceWindowStartAt: number | null;
   serviceWindowEndAt: number | null;
   accessRequired: boolean | null;
@@ -241,6 +245,15 @@ export function projectTenantMaintenance(recordId: string, data: any): TenantMai
         ? data.completionOutcome
         : null,
     completionConfirmedByLandlordAt: toMillis(data?.completionConfirmedByLandlordAt),
+    reopenedAt: toMillis(data?.reopenedAt),
+    reopenedByActorId: asString(data?.reopenedByActorId),
+    reopenedByActorRole:
+      data?.reopenedByActorRole === "tenant" ||
+      data?.reopenedByActorRole === "landlord" ||
+      data?.reopenedByActorRole === "admin"
+        ? data.reopenedByActorRole
+        : null,
+    reopenReason: asString(data?.reopenReason),
     serviceWindowStartAt: toMillis(data?.serviceWindowStartAt),
     serviceWindowEndAt: toMillis(data?.serviceWindowEndAt),
     accessRequired: typeof data?.accessRequired === "boolean" ? data.accessRequired : null,

--- a/rentchain-frontend/src/api/maintenanceWorkflowApi.ts
+++ b/rentchain-frontend/src/api/maintenanceWorkflowApi.ts
@@ -4,6 +4,7 @@ import {
   getTenantWorkspaceMaintenance,
   listTenantWorkspaceMaintenance,
   updateTenantWorkspaceMaintenanceConfirmation,
+  updateTenantWorkspaceMaintenanceReopen,
   updateTenantWorkspaceReworkAccess,
   updateTenantWorkspaceReworkSignoff,
   updateTenantWorkspaceMaintenanceSignoff,
@@ -51,7 +52,7 @@ export type MaintenanceWorkflowItem = {
   completedByActorId?: string | null;
   reopenedAt?: number | null;
   reopenedByActorId?: string | null;
-  reopenedByActorRole?: "landlord" | "admin" | null;
+  reopenedByActorRole?: "tenant" | "landlord" | "admin" | null;
   reopenReason?: string | null;
   evidence?: WorkOrderEvidenceItem[];
   serviceWindowStartAt?: number | null;
@@ -442,7 +443,9 @@ export async function listTenantMaintenance() {
     reopenedAt: typeof (item as any).reopenedAt === "number" ? (item as any).reopenedAt : null,
     reopenedByActorId: typeof (item as any).reopenedByActorId === "string" ? (item as any).reopenedByActorId : null,
     reopenedByActorRole:
-      (item as any).reopenedByActorRole === "landlord" || (item as any).reopenedByActorRole === "admin"
+      (item as any).reopenedByActorRole === "tenant" ||
+      (item as any).reopenedByActorRole === "landlord" ||
+      (item as any).reopenedByActorRole === "admin"
         ? (item as any).reopenedByActorRole
         : null,
     reopenReason: typeof (item as any).reopenReason === "string" ? (item as any).reopenReason : null,
@@ -523,7 +526,9 @@ export async function getTenantMaintenance(id: string) {
     reopenedByActorId:
       typeof (item as any)?.reopenedByActorId === "string" ? (item as any).reopenedByActorId : null,
     reopenedByActorRole:
-      (item as any)?.reopenedByActorRole === "landlord" || (item as any)?.reopenedByActorRole === "admin"
+      (item as any)?.reopenedByActorRole === "tenant" ||
+      (item as any)?.reopenedByActorRole === "landlord" ||
+      (item as any)?.reopenedByActorRole === "admin"
         ? (item as any).reopenedByActorRole
         : null,
     reopenReason: typeof (item as any)?.reopenReason === "string" ? (item as any).reopenReason : null,
@@ -633,6 +638,117 @@ export async function updateTenantMaintenanceConfirmation(
     reworkCycle: mapReworkCycle((item as any)?.reworkCycle),
     reworkHistory: mapReworkHistory((item as any)?.reworkHistory),
     reworkReview: mapReworkReview((item as any)?.reworkReview),
+    createdAt: item?.createdAt || Date.now(),
+    updatedAt: item?.updatedAt || item?.createdAt || Date.now(),
+    statusHistory: Array.isArray(item?.statusHistory)
+      ? item.statusHistory.map((entry) => ({
+          status: String(entry?.status || ""),
+          actorRole: String(entry?.actorRole || ""),
+          actorId: entry?.actorId ? String(entry.actorId) : null,
+          message: entry?.message ? String(entry.message) : null,
+          createdAt: typeof entry?.createdAt === "number" ? entry.createdAt : undefined,
+        }))
+      : [],
+  };
+  return { ok: true, item: mapped, data: mapped };
+}
+
+export async function updateTenantMaintenanceReopen(
+  id: string,
+  payload: {
+    reason: string;
+  }
+) {
+  const item = await updateTenantWorkspaceMaintenanceReopen(id, payload);
+  const mapped: MaintenanceWorkflowItem = {
+    id: item?.requestId || id,
+    tenantId: "",
+    landlordId: "",
+    propertyId: null,
+    unitId: null,
+    title: item?.title || "Maintenance request",
+    description: item?.summary || "",
+    category: String(item?.category || "GENERAL"),
+    priority: String(item?.priority || "normal").toLowerCase() as "low" | "normal" | "urgent",
+    status: String(item?.status || "submitted").toLowerCase() as MaintenanceWorkflowStatus,
+    assignedContractorName: item?.assignedContractorName || null,
+    contractorStatus: item?.contractorStatus || null,
+    serviceWindowStartAt: typeof item?.serviceWindowStartAt === "number" ? item.serviceWindowStartAt : null,
+    serviceWindowEndAt: typeof item?.serviceWindowEndAt === "number" ? item.serviceWindowEndAt : null,
+    scheduledFor: typeof (item as any)?.scheduledFor === "number" ? (item as any).scheduledFor : null,
+    serviceStartedAt: typeof (item as any)?.serviceStartedAt === "number" ? (item as any).serviceStartedAt : null,
+    serviceCompletedAt: typeof (item as any)?.serviceCompletedAt === "number" ? (item as any).serviceCompletedAt : null,
+    lastExecutionUpdateAt:
+      typeof (item as any)?.lastExecutionUpdateAt === "number" ? (item as any).lastExecutionUpdateAt : null,
+    executionBlockedReason:
+      typeof (item as any)?.executionBlockedReason === "string" ? (item as any).executionBlockedReason : null,
+    completionSummary: typeof (item as any)?.completionSummary === "string" ? (item as any).completionSummary : null,
+    completionOutcome:
+      (item as any)?.completionOutcome === "completed" ||
+      (item as any)?.completionOutcome === "partially_completed" ||
+      (item as any)?.completionOutcome === "follow_up_required"
+        ? (item as any).completionOutcome
+        : null,
+    completionConfirmedByLandlordAt:
+      typeof (item as any)?.completionConfirmedByLandlordAt === "number"
+        ? (item as any).completionConfirmedByLandlordAt
+        : null,
+    completionConfirmedByLandlordBy:
+      typeof (item as any)?.completionConfirmedByLandlordBy === "string"
+        ? (item as any).completionConfirmedByLandlordBy
+        : null,
+    completedByActorRole:
+      (item as any)?.completedByActorRole === "contractor" ||
+      (item as any)?.completedByActorRole === "landlord" ||
+      (item as any)?.completedByActorRole === "admin"
+        ? (item as any).completedByActorRole
+        : null,
+    completedByActorId:
+      typeof (item as any)?.completedByActorId === "string" ? (item as any).completedByActorId : null,
+    reopenedAt: typeof (item as any)?.reopenedAt === "number" ? (item as any).reopenedAt : null,
+    reopenedByActorId:
+      typeof (item as any)?.reopenedByActorId === "string" ? (item as any).reopenedByActorId : null,
+    reopenedByActorRole:
+      (item as any)?.reopenedByActorRole === "tenant" ||
+      (item as any)?.reopenedByActorRole === "landlord" ||
+      (item as any)?.reopenedByActorRole === "admin"
+        ? (item as any).reopenedByActorRole
+        : null,
+    reopenReason: typeof (item as any)?.reopenReason === "string" ? (item as any).reopenReason : null,
+    accessRequired: typeof item?.accessRequired === "boolean" ? item.accessRequired : null,
+    tenantConfirmationStatus:
+      item?.tenantConfirmationStatus === "confirmed" || item?.tenantConfirmationStatus === "needs_schedule_change"
+        ? item.tenantConfirmationStatus
+        : null,
+    tenantConfirmationUpdatedAt:
+      typeof item?.tenantConfirmationUpdatedAt === "number" ? item.tenantConfirmationUpdatedAt : null,
+    accessAcknowledgedAt: typeof item?.accessAcknowledgedAt === "number" ? item.accessAcknowledgedAt : null,
+    resolutionStatus:
+      item?.resolutionStatus === "completed_pending_review" ||
+      item?.resolutionStatus === "landlord_approved" ||
+      item?.resolutionStatus === "tenant_pending_signoff" ||
+      item?.resolutionStatus === "resolved" ||
+      item?.resolutionStatus === "follow_up_required"
+        ? item.resolutionStatus
+        : null,
+    landlordApprovedAt: typeof item?.landlordApprovedAt === "number" ? item.landlordApprovedAt : null,
+    tenantSignoffStatus:
+      item?.tenantSignoffStatus === "pending" ||
+      item?.tenantSignoffStatus === "accepted" ||
+      item?.tenantSignoffStatus === "declined"
+        ? item.tenantSignoffStatus
+        : null,
+    tenantSignedOffAt: typeof item?.tenantSignedOffAt === "number" ? item.tenantSignedOffAt : null,
+    tenantDeclinedAt: typeof item?.tenantDeclinedAt === "number" ? item.tenantDeclinedAt : null,
+    tenantDeclineReason: item?.tenantDeclineReason ? String(item.tenantDeclineReason) : null,
+    followUpRequired: typeof item?.followUpRequired === "boolean" ? item.followUpRequired : null,
+    followUpReason: item?.followUpReason ? String(item.followUpReason) : null,
+    finalResolvedAt: typeof item?.finalResolvedAt === "number" ? item.finalResolvedAt : null,
+    notifications: mapNotifications((item as any)?.notifications),
+    reworkCycle: mapReworkCycle((item as any)?.reworkCycle),
+    reworkHistory: mapReworkHistory((item as any)?.reworkHistory),
+    reworkReview: mapReworkReview((item as any)?.reworkReview),
+    evidence: Array.isArray((item as any)?.evidence) ? (item as any).evidence : [],
     createdAt: item?.createdAt || Date.now(),
     updatedAt: item?.updatedAt || item?.createdAt || Date.now(),
     statusHistory: Array.isArray(item?.statusHistory)

--- a/rentchain-frontend/src/api/tenantPortal.ts
+++ b/rentchain-frontend/src/api/tenantPortal.ts
@@ -65,6 +65,10 @@ export type TenantWorkspaceMaintenance = {
   completionSummary?: string | null;
   completionOutcome?: "completed" | "partially_completed" | "follow_up_required" | null;
   completionConfirmedByLandlordAt?: number | null;
+  reopenedAt?: number | null;
+  reopenedByActorId?: string | null;
+  reopenedByActorRole?: "tenant" | "landlord" | "admin" | null;
+  reopenReason?: string | null;
   serviceWindowStartAt?: number | null;
   serviceWindowEndAt?: number | null;
   accessRequired?: boolean | null;
@@ -221,6 +225,22 @@ export async function updateTenantWorkspaceMaintenanceSignoff(
 ) {
   const res = await tenantApiFetch<{ ok: boolean; data: TenantWorkspaceMaintenance }>(
     `/tenant/maintenance/${encodeURIComponent(id)}/signoff`,
+    {
+      method: "POST",
+      body: payload,
+    }
+  );
+  return res?.data;
+}
+
+export async function updateTenantWorkspaceMaintenanceReopen(
+  id: string,
+  payload: {
+    reason: string;
+  }
+) {
+  const res = await tenantApiFetch<{ ok: boolean; data: TenantWorkspaceMaintenance }>(
+    `/tenant/maintenance/${encodeURIComponent(id)}/reopen`,
     {
       method: "POST",
       body: payload,

--- a/rentchain-frontend/src/pages/MaintenanceRequestsPage.test.tsx
+++ b/rentchain-frontend/src/pages/MaintenanceRequestsPage.test.tsx
@@ -156,6 +156,65 @@ describe("landlord maintenance workspace", () => {
     expect(screen.getAllByText(/Back bedroom is still cooler than the rest of the unit/i).length).toBeGreaterThan(0);
   });
 
+  it("shows reopened and escalated recovery state in the landlord reopen workspace", async () => {
+    maintenanceWorkflowApi.listLandlordMaintenance.mockResolvedValue({
+      items: [
+        {
+          id: "maint-1",
+          tenantId: "tenant-1",
+          landlordId: "landlord-1",
+          propertyId: "prop-1",
+          unitId: "unit-2",
+          tenantName: "Taylor Tenant",
+          propertyLabel: "123 Main St",
+          unitLabel: "Unit 4",
+          title: "Broken heater",
+          description: "Heat is not turning on.",
+          category: "HVAC",
+          priority: "urgent",
+          status: "completed",
+          assignedContractorName: "North Shore HVAC",
+          resolutionStatus: "follow_up_required",
+          followUpRequired: true,
+          followUpReason: "The bedroom is cold again after the return visit.",
+          reopenedAt: Date.UTC(2026, 3, 17, 9, 0),
+          reopenReason: "The bedroom is cold again after the return visit.",
+          reworkHistory: [
+            {
+              cycleNumber: 1,
+              completedAt: Date.UTC(2026, 3, 16, 14, 0),
+              outcome: "partial",
+              notes: "Initial return visit improved airflow but did not fully resolve it.",
+            },
+          ],
+          reworkReview: {
+            status: "follow_up_required",
+            tenantSignoffStatus: "declined",
+            tenantDeclinedAt: Date.UTC(2026, 3, 17, 9, 0),
+            tenantDeclineReason: "The bedroom is cold again after the return visit.",
+            closureOutcome: "needs_more_followup",
+            closedAt: null,
+          },
+          createdAt: 100,
+          updatedAt: 200,
+          statusHistory: [],
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/maintenance/maint-1"]}>
+        <Routes>
+          <Route path="/maintenance/:id" element={<MaintenanceRequestsPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect((await screen.findAllByText(/Reopen \/ escalation/i)).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Escalated/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/The bedroom is cold again after the return visit/i).length).toBeGreaterThan(0);
+  });
+
   it("records a landlord start-of-service update from the execution workspace", async () => {
     maintenanceWorkflowApi.listLandlordMaintenance.mockResolvedValue({
       items: [

--- a/rentchain-frontend/src/pages/MaintenanceRequestsPage.tsx
+++ b/rentchain-frontend/src/pages/MaintenanceRequestsPage.tsx
@@ -16,6 +16,7 @@ import { colors, radius, spacing, text } from "../styles/tokens";
 import { buildMaintenanceLifecycleView, buildMaintenanceWorkspaceState } from "./maintenanceWorkspaceState";
 import { buildMaintenanceAssignmentRoutingView } from "./maintenanceAssignmentRoutingState";
 import { buildMaintenanceConfirmationAccessView } from "./maintenanceConfirmationAccessState";
+import { buildMaintenanceReopenEscalationView } from "./maintenanceReopenEscalationState";
 import { buildMaintenanceServiceExecutionView } from "./maintenanceServiceExecutionState";
 import { buildMaintenanceResolutionVerificationView } from "./maintenanceResolutionVerificationState";
 import {
@@ -400,6 +401,10 @@ export default function MaintenanceRequestsPage() {
     () => (selected ? buildMaintenanceResolutionVerificationView(selected, "landlord") : null),
     [selected]
   );
+  const selectedReopen = React.useMemo(
+    () => (selected ? buildMaintenanceReopenEscalationView(selected, "landlord") : null),
+    [selected]
+  );
   const calendarEvents = React.useMemo(() => buildMaintenanceSchedulingCalendarEvents(items), [items]);
   const calendarDays = React.useMemo(() => buildCalendarDays(calendarMonth), [calendarMonth]);
   const calendarEventMap = React.useMemo(() => {
@@ -604,6 +609,7 @@ export default function MaintenanceRequestsPage() {
                     const assignment = buildMaintenanceAssignmentRoutingView(item, "landlord");
                     const execution = buildMaintenanceServiceExecutionView(item, "landlord");
                     const resolution = buildMaintenanceResolutionVerificationView(item, "landlord");
+                    const reopen = buildMaintenanceReopenEscalationView(item, "landlord");
                     return (
                       <button
                         key={item.id}
@@ -639,24 +645,29 @@ export default function MaintenanceRequestsPage() {
                           >
                             {item.status}
                           </span>
-                         <span
-  style={{
-    color: assignment.needsAttention || lifecycle.needsAttention ? "#b91c1c" : text.muted,
-    fontSize: 12,
-    fontWeight: 700,
-  }}
->
-  {assignment.assignmentLabel}
-</span>
-<span style={{ color: text.muted, fontSize: 12 }}>{item.priority}</span>
-<span style={{ color: text.muted, fontSize: 12 }}>{fmtDate(item.createdAt)}</span>
-</div>
-<div style={{ color: text.secondary, fontSize: 12 }}>{assignment.ownerSummary}</div>
-<div style={{ color: text.secondary, fontSize: 12 }}>{execution.executionLabel}</div>
-<div style={{ color: text.secondary, fontSize: 12 }}>{resolution.verificationLabel}</div>
-</button>
-);
-})}
+                          <span
+                            style={{
+                              color: assignment.needsAttention || lifecycle.needsAttention ? "#b91c1c" : text.muted,
+                              fontSize: 12,
+                              fontWeight: 700,
+                            }}
+                          >
+                            {assignment.assignmentLabel}
+                          </span>
+                          <span style={{ color: text.muted, fontSize: 12 }}>{item.priority}</span>
+                          <span style={{ color: text.muted, fontSize: 12 }}>{fmtDate(item.createdAt)}</span>
+                        </div>
+                        <div style={{ color: text.secondary, fontSize: 12 }}>{assignment.ownerSummary}</div>
+                        <div style={{ color: text.secondary, fontSize: 12 }}>{execution.executionLabel}</div>
+                        <div style={{ color: text.secondary, fontSize: 12 }}>{resolution.verificationLabel}</div>
+                        {reopen.reopenState !== "not_applicable" || reopen.escalationState !== "not_escalated" ? (
+                          <div style={{ color: text.secondary, fontSize: 12 }}>
+                            {reopen.escalationState === "escalated" ? reopen.escalationLabel : reopen.reopenLabel}
+                          </div>
+                        ) : null}
+                      </button>
+                    );
+                  })}
                 </div>
               )}
             </div>
@@ -950,6 +961,58 @@ export default function MaintenanceRequestsPage() {
                       ) : null}
                       <div style={{ fontWeight: 700, color: text.primary }}>Next step</div>
                       {selectedResolution.nextActions.map((step) => (
+                        <div key={step} style={{ color: text.secondary }}>
+                          {step}
+                        </div>
+                      ))}
+                    </div>
+                  ) : null}
+
+                  {selectedReopen ? (
+                    <div
+                      style={{
+                        border: `1px solid ${colors.border}`,
+                        borderRadius: radius.md,
+                        padding: "12px 14px",
+                        background: colors.panel,
+                        display: "grid",
+                        gap: 8,
+                      }}
+                    >
+                      <div style={{ fontWeight: 700, color: text.primary }}>Reopen / escalation</div>
+                      <div style={{ color: text.secondary }}>{selectedReopen.summary}</div>
+                      <div style={{ fontWeight: 700, color: text.primary }}>Reopen state</div>
+                      <div style={{ color: text.secondary }}>{selectedReopen.reopenLabel}</div>
+                      <div style={{ fontWeight: 700, color: text.primary }}>Escalation state</div>
+                      <div style={{ color: text.secondary }}>{selectedReopen.escalationLabel}</div>
+                      {selected.reopenReason ? (
+                        <>
+                          <div style={{ fontWeight: 700, color: text.primary }}>Reopen note</div>
+                          <div style={{ color: text.secondary }}>{selected.reopenReason}</div>
+                        </>
+                      ) : null}
+                      {selectedReopen.timelineEvents.length ? (
+                        <>
+                          <div style={{ fontWeight: 700, color: text.primary }}>Recent recovery updates</div>
+                          {selectedReopen.timelineEvents.map((event) => (
+                            <div key={event.key} style={{ color: text.secondary }}>
+                              {event.label} • {fmtDate(event.timestamp)}
+                            </div>
+                          ))}
+                        </>
+                      ) : null}
+                      {selectedReopen.blockers.length ? (
+                        <>
+                          <div style={{ fontWeight: 700, color: text.primary }}>Needs attention</div>
+                          {selectedReopen.blockers.map((item) => (
+                            <div key={item} style={{ color: text.secondary }}>
+                              {item}
+                            </div>
+                          ))}
+                        </>
+                      ) : null}
+                      <div style={{ fontWeight: 700, color: text.primary }}>Next step</div>
+                      {selectedReopen.nextActions.map((step) => (
                         <div key={step} style={{ color: text.secondary }}>
                           {step}
                         </div>

--- a/rentchain-frontend/src/pages/maintenanceReopenEscalationState.test.ts
+++ b/rentchain-frontend/src/pages/maintenanceReopenEscalationState.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { buildMaintenanceReopenEscalationView } from "./maintenanceReopenEscalationState";
+
+const baseItem = {
+  id: "maint-1",
+  tenantId: "tenant-1",
+  landlordId: "landlord-1",
+  propertyId: "prop-1",
+  unitId: "unit-1",
+  title: "Leaky faucet",
+  description: "Kitchen sink is leaking",
+  category: "PLUMBING",
+  priority: "normal" as const,
+  status: "completed" as const,
+  createdAt: 100,
+  updatedAt: 200,
+};
+
+describe("maintenanceReopenEscalationState", () => {
+  it("marks a closed request as tenant-reopenable when the issue returns after closure", () => {
+    const view = buildMaintenanceReopenEscalationView(
+      {
+        ...baseItem,
+        resolutionStatus: "resolved",
+        tenantSignoffStatus: "accepted",
+        finalResolvedAt: 300,
+      },
+      "tenant"
+    );
+
+    expect(view.reopenState).toBe("closed");
+    expect(view.canTenantReopen).toBe(true);
+    expect(view.tenantVisibleState).toBe("closed");
+  });
+
+  it("marks active follow-up as reopened when reopen metadata is present", () => {
+    const view = buildMaintenanceReopenEscalationView(
+      {
+        ...baseItem,
+        resolutionStatus: "follow_up_required",
+        followUpRequired: true,
+        followUpReason: "The leak returned overnight.",
+        reopenedAt: 310,
+        reopenReason: "The leak returned overnight.",
+      },
+      "landlord"
+    );
+
+    expect(view.reopenState).toBe("reopened");
+    expect(view.escalationState).toBe("not_escalated");
+    expect(view.timelineEvents.map((event) => event.kind)).toContain("request_reopened");
+  });
+
+  it("marks repeated follow-up as escalated after a failed return visit", () => {
+    const view = buildMaintenanceReopenEscalationView(
+      {
+        ...baseItem,
+        resolutionStatus: "follow_up_required",
+        followUpRequired: true,
+        followUpReason: "Still not heating evenly.",
+        reopenedAt: 310,
+        reworkHistory: [{ cycleNumber: 1, completedAt: 320, outcome: "partial", notes: "Initial rework reduced but did not fix the issue." }],
+        reworkReview: {
+          status: "follow_up_required",
+          tenantSignoffStatus: "declined",
+          tenantDeclinedAt: 330,
+          tenantDeclineReason: "Still not heating evenly.",
+          closureOutcome: "needs_more_followup",
+          closedAt: null,
+        },
+      },
+      "landlord"
+    );
+
+    expect(view.escalationState).toBe("escalated");
+    expect(view.tenantVisibleState).toBe("escalated");
+    expect(view.blockers.join(" ")).toMatch(/repeated attention/i);
+  });
+});

--- a/rentchain-frontend/src/pages/maintenanceReopenEscalationState.ts
+++ b/rentchain-frontend/src/pages/maintenanceReopenEscalationState.ts
@@ -1,0 +1,319 @@
+import type { MaintenanceWorkflowItem } from "../api/maintenanceWorkflowApi";
+
+type Audience = "tenant" | "landlord";
+
+export type MaintenanceReopenState =
+  | "not_applicable"
+  | "follow_up_needed"
+  | "reopened"
+  | "resolved"
+  | "closed"
+  | "needs_attention";
+
+export type MaintenanceEscalationState = "not_escalated" | "escalated" | "needs_attention";
+
+export type MaintenanceReopenTenantVisibleState =
+  | "not_applicable"
+  | "still_needs_attention"
+  | "reopened"
+  | "escalated"
+  | "resolved"
+  | "closed"
+  | "needs_attention";
+
+export type MaintenanceReopenTimelineEvent = {
+  key: string;
+  kind: "request_reopened" | "follow_up_needed" | "request_escalated" | "resolved_after_follow_up";
+  label: string;
+  timestamp: number;
+};
+
+export type MaintenanceReopenEscalationView = {
+  reopenState: MaintenanceReopenState;
+  reopenLabel: string;
+  escalationState: MaintenanceEscalationState;
+  escalationLabel: string;
+  tenantVisibleState: MaintenanceReopenTenantVisibleState;
+  tenantVisibleLabel: string;
+  readinessState: MaintenanceReopenState;
+  readinessLabel: string;
+  summary: string;
+  blockers: string[];
+  nextActions: string[];
+  timelineEvents: MaintenanceReopenTimelineEvent[];
+  canTenantReopen: boolean;
+};
+
+function statusOf(item: MaintenanceWorkflowItem) {
+  return String(item.status || "").trim().toLowerCase();
+}
+
+function hasClosureRecord(item: MaintenanceWorkflowItem) {
+  return (
+    typeof item.finalResolvedAt === "number" ||
+    item.resolutionStatus === "resolved" ||
+    item.tenantSignoffStatus === "accepted" ||
+    item.reworkReview?.status === "closed" ||
+    item.reworkReview?.tenantSignoffStatus === "accepted"
+  );
+}
+
+function hasFollowUp(item: MaintenanceWorkflowItem) {
+  return (
+    item.resolutionStatus === "follow_up_required" ||
+    item.followUpRequired === true ||
+    item.tenantSignoffStatus === "declined" ||
+    item.reworkReview?.status === "follow_up_required" ||
+    item.reworkReview?.tenantSignoffStatus === "declined"
+  );
+}
+
+function hasReopenedMarker(item: MaintenanceWorkflowItem) {
+  return typeof item.reopenedAt === "number" || Boolean(String(item.reopenReason || "").trim());
+}
+
+function followUpCycleCount(item: MaintenanceWorkflowItem) {
+  const historyCount = Array.isArray(item.reworkHistory) ? item.reworkHistory.length : 0;
+  const activeCycleCount = item.reworkCycle ? 1 : 0;
+  return historyCount + activeCycleCount;
+}
+
+function isEscalated(item: MaintenanceWorkflowItem) {
+  if (!hasFollowUp(item)) return false;
+  if (item.reworkReview?.status === "follow_up_required") return true;
+  if (followUpCycleCount(item) > 1) return true;
+  if (hasReopenedMarker(item) && followUpCycleCount(item) > 0) return true;
+  return false;
+}
+
+function canTenantReopen(item: MaintenanceWorkflowItem) {
+  const status = statusOf(item);
+  if (status !== "completed") return false;
+  if (!hasClosureRecord(item)) return false;
+  if (hasFollowUp(item)) return false;
+  if (item.resolutionStatus === "tenant_pending_signoff") return false;
+  if (item.reworkReview?.status === "tenant_pending_signoff") return false;
+  if (item.reworkCycle && item.reworkCycle.status !== "completed" && item.reworkCycle.status !== "cancelled") return false;
+  return true;
+}
+
+function buildTimelineEvents(item: MaintenanceWorkflowItem): MaintenanceReopenTimelineEvent[] {
+  const events: MaintenanceReopenTimelineEvent[] = [];
+  if (typeof item.reopenedAt === "number") {
+    events.push({
+      key: "request_reopened",
+      kind: "request_reopened",
+      label: "Request reopened",
+      timestamp: item.reopenedAt,
+    });
+  }
+  if (typeof item.tenantDeclinedAt === "number" || typeof item.reworkReview?.tenantDeclinedAt === "number") {
+    const timestamp = Math.max(item.tenantDeclinedAt || 0, item.reworkReview?.tenantDeclinedAt || 0);
+    events.push({
+      key: "follow_up_needed",
+      kind: "follow_up_needed",
+      label: "Follow-up needed",
+      timestamp,
+    });
+  }
+  if (isEscalated(item)) {
+    const escalationTimestamp =
+      item.reworkReview?.tenantDeclinedAt ||
+      item.reworkCycle?.completedAt ||
+      item.reopenedAt ||
+      item.tenantDeclinedAt ||
+      item.updatedAt ||
+      null;
+    if (typeof escalationTimestamp === "number") {
+      events.push({
+        key: "request_escalated",
+        kind: "request_escalated",
+        label: "Escalation recorded",
+        timestamp: escalationTimestamp,
+      });
+    }
+  }
+  if (typeof item.finalResolvedAt === "number" && followUpCycleCount(item) > 0) {
+    events.push({
+      key: "resolved_after_follow_up",
+      kind: "resolved_after_follow_up",
+      label: "Resolved after follow-up",
+      timestamp: item.finalResolvedAt,
+    });
+  }
+  return events.sort((a, b) => b.timestamp - a.timestamp);
+}
+
+function reopenLabel(state: MaintenanceReopenState) {
+  switch (state) {
+    case "follow_up_needed":
+      return "Follow-up needed";
+    case "reopened":
+      return "Reopened";
+    case "resolved":
+      return "Resolved";
+    case "closed":
+      return "Closed";
+    case "needs_attention":
+      return "Needs attention";
+    case "not_applicable":
+    default:
+      return "Not applicable yet";
+  }
+}
+
+function escalationLabel(state: MaintenanceEscalationState) {
+  switch (state) {
+    case "escalated":
+      return "Escalated";
+    case "needs_attention":
+      return "Needs attention";
+    case "not_escalated":
+    default:
+      return "Not escalated";
+  }
+}
+
+function tenantVisibleLabel(state: MaintenanceReopenTenantVisibleState) {
+  switch (state) {
+    case "still_needs_attention":
+      return "Still needs attention";
+    case "reopened":
+      return "Reopened";
+    case "escalated":
+      return "Escalated";
+    case "resolved":
+      return "Resolved";
+    case "closed":
+      return "Closed";
+    case "needs_attention":
+      return "Needs attention";
+    case "not_applicable":
+    default:
+      return "No follow-up recorded";
+  }
+}
+
+export function buildMaintenanceReopenEscalationView(
+  item: MaintenanceWorkflowItem,
+  audience: Audience
+): MaintenanceReopenEscalationView {
+  const blockers: string[] = [];
+  const nextActions: string[] = [];
+  const closed = typeof item.finalResolvedAt === "number";
+  const followUp = hasFollowUp(item);
+  const reopened = hasReopenedMarker(item);
+  const escalated = isEscalated(item);
+  const resolvedAfterFollowUp = followUpCycleCount(item) > 0 && hasClosureRecord(item) && !followUp;
+
+  let reopenState: MaintenanceReopenState = "not_applicable";
+  let escalationState: MaintenanceEscalationState = "not_escalated";
+  let tenantState: MaintenanceReopenTenantVisibleState = "not_applicable";
+  let summary =
+    audience === "landlord"
+      ? "This request has not entered the reopen or follow-up recovery stage."
+      : "This request has not entered the reopen or follow-up recovery stage.";
+
+  if (statusOf(item) === "cancelled") {
+    reopenState = "needs_attention";
+    escalationState = "needs_attention";
+    tenantState = "needs_attention";
+    blockers.push(
+      audience === "landlord"
+        ? "This request is cancelled, so any post-closure recovery should be reviewed carefully."
+        : "This request is cancelled, so post-closure follow-up needs a fresh review."
+    );
+  } else if (escalated) {
+    reopenState = reopened ? "reopened" : "follow_up_needed";
+    escalationState = "escalated";
+    tenantState = "escalated";
+    summary =
+      audience === "landlord"
+        ? "This request came back after a prior closure attempt and now needs escalated follow-up."
+        : "This issue came back after a prior closure attempt, so it is now in an escalated follow-up state.";
+    blockers.push(
+      audience === "landlord"
+        ? "Repeated attention is still needed before this request can be treated as resolved again."
+        : "Your landlord still needs to coordinate another follow-up step."
+    );
+  } else if (followUp) {
+    reopenState = reopened ? "reopened" : "follow_up_needed";
+    escalationState = "not_escalated";
+    tenantState = reopened ? "reopened" : "still_needs_attention";
+    summary =
+      audience === "landlord"
+        ? reopened
+          ? "The request has been reopened and is back in an active follow-up cycle."
+          : "The request still needs follow-up before it can return to a closed state."
+        : reopened
+        ? "Your request has been reopened so the issue can be worked again without starting from scratch."
+        : "This request still needs follow-up before it can return to a closed state.";
+    blockers.push(
+      audience === "landlord"
+        ? "Follow-up work is still required."
+        : "Follow-up work is still required."
+    );
+  } else if (closed) {
+    reopenState = "closed";
+    escalationState = "not_escalated";
+    tenantState = "closed";
+    summary =
+      audience === "landlord"
+        ? resolvedAfterFollowUp
+          ? "The request was resolved after follow-up and is now closed again."
+          : "The request is closed, but it can still be reopened if the issue returns."
+        : resolvedAfterFollowUp
+        ? "The issue was resolved after follow-up and is now closed again."
+        : "This request is closed, but you can still report if the issue comes back.";
+  } else if (hasClosureRecord(item)) {
+    reopenState = "resolved";
+    escalationState = "not_escalated";
+    tenantState = "resolved";
+    summary =
+      audience === "landlord"
+        ? "The issue is currently resolved with no active follow-up recorded."
+        : "The issue is currently resolved with no active follow-up recorded.";
+  }
+
+  if (followUp) {
+    nextActions.push(
+      audience === "landlord"
+        ? escalated
+          ? "Review the repeated issue history and decide the next recovery step."
+          : "Review the tenant follow-up note and coordinate the next service step."
+        : escalated
+        ? "Watch for the next escalated follow-up update from your landlord."
+        : "Watch for the next follow-up update from your landlord."
+    );
+  }
+  if (canTenantReopen(item)) {
+    nextActions.push(
+      audience === "landlord"
+        ? "Keep the request in closed history unless the tenant reports that it still needs attention."
+        : "Use the request detail if the issue comes back and still needs attention."
+    );
+  }
+  if (nextActions.length === 0) {
+    nextActions.push(
+      audience === "landlord"
+        ? "Use the request detail for the next reopen or follow-up update."
+        : "Use the request detail for the latest follow-up update."
+    );
+  }
+
+  return {
+    reopenState,
+    reopenLabel: reopenLabel(reopenState),
+    escalationState,
+    escalationLabel: escalationLabel(escalationState),
+    tenantVisibleState: tenantState,
+    tenantVisibleLabel: tenantVisibleLabel(tenantState),
+    readinessState: reopenState,
+    readinessLabel: reopenLabel(reopenState),
+    summary,
+    blockers,
+    nextActions,
+    timelineEvents: buildTimelineEvents(item),
+    canTenantReopen: audience === "tenant" ? canTenantReopen(item) : false,
+  };
+}

--- a/rentchain-frontend/src/pages/tenant/TenantMaintenancePages.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantMaintenancePages.test.tsx
@@ -11,6 +11,7 @@ const maintenanceWorkflowApi = vi.hoisted(() => ({
   getTenantMaintenance: vi.fn(),
   createTenantMaintenance: vi.fn(),
   updateTenantMaintenanceConfirmation: vi.fn(),
+  updateTenantMaintenanceReopen: vi.fn(),
   updateTenantMaintenanceReworkAccess: vi.fn(),
   updateTenantMaintenanceReworkSignoff: vi.fn(),
   updateTenantMaintenanceSignoff: vi.fn(),
@@ -31,6 +32,7 @@ vi.mock("../../api/maintenanceWorkflowApi", async () => {
     getTenantMaintenance: maintenanceWorkflowApi.getTenantMaintenance,
     createTenantMaintenance: maintenanceWorkflowApi.createTenantMaintenance,
     updateTenantMaintenanceConfirmation: maintenanceWorkflowApi.updateTenantMaintenanceConfirmation,
+    updateTenantMaintenanceReopen: maintenanceWorkflowApi.updateTenantMaintenanceReopen,
     updateTenantMaintenanceReworkAccess: maintenanceWorkflowApi.updateTenantMaintenanceReworkAccess,
     updateTenantMaintenanceReworkSignoff: maintenanceWorkflowApi.updateTenantMaintenanceReworkSignoff,
     updateTenantMaintenanceSignoff: maintenanceWorkflowApi.updateTenantMaintenanceSignoff,
@@ -97,6 +99,7 @@ describe("tenant maintenance pages", () => {
     expect(screen.getAllByText(/Confirmation \/ access/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Execution \/ completion/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Resolution \/ closure/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Reopen \/ follow-up/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/landlord needs to confirm the service window/i)).toBeInTheDocument();
   });
 
@@ -213,6 +216,67 @@ describe("tenant maintenance pages", () => {
     expect(screen.queryByText(/245\.00 CAD/i)).not.toBeInTheDocument();
   });
 
+  it("lets the tenant reopen a closed request when the issue comes back", async () => {
+    maintenanceWorkflowApi.getTenantMaintenance.mockResolvedValue({
+      item: {
+        id: "maint-closed",
+        title: "Window latch",
+        description: "The latch was repaired but failed again.",
+        status: "completed",
+        priority: "normal",
+        category: "GENERAL",
+        resolutionStatus: "resolved",
+        tenantSignoffStatus: "accepted",
+        finalResolvedAt: Date.UTC(2026, 3, 16, 12, 0),
+        createdAt: 100,
+        updatedAt: 200,
+        statusHistory: [],
+      },
+    });
+    maintenanceWorkflowApi.updateTenantMaintenanceReopen.mockResolvedValue({
+      item: {
+        id: "maint-closed",
+        title: "Window latch",
+        description: "The latch was repaired but failed again.",
+        status: "completed",
+        priority: "normal",
+        category: "GENERAL",
+        resolutionStatus: "follow_up_required",
+        followUpRequired: true,
+        followUpReason: "The latch failed again after closing.",
+        tenantSignoffStatus: "declined",
+        tenantDeclinedAt: Date.UTC(2026, 3, 17, 9, 0),
+        reopenReason: "The latch failed again after closing.",
+        reopenedAt: Date.UTC(2026, 3, 17, 9, 0),
+        reopenedByActorRole: "tenant",
+        createdAt: 100,
+        updatedAt: 300,
+        statusHistory: [],
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/tenant/maintenance/maint-closed"]}>
+        <Routes>
+          <Route path="/tenant/maintenance/:id" element={<TenantMaintenanceRequestDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect((await screen.findAllByText(/Reopen \/ follow-up/i)).length).toBeGreaterThan(0);
+    fireEvent.change(screen.getByPlaceholderText(/Explain what still needs attention/i), {
+      target: { value: "The latch failed again after closing." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Reopen request/i }));
+
+    await waitFor(() =>
+      expect(maintenanceWorkflowApi.updateTenantMaintenanceReopen).toHaveBeenCalledWith("maint-closed", {
+        reason: "The latch failed again after closing.",
+      })
+    );
+    expect(await screen.findByText(/Your request has been reopened/i)).toBeInTheDocument();
+  });
+
   it("submits tenant confirmation updates from the detail page", async () => {
     maintenanceWorkflowApi.getTenantMaintenance.mockResolvedValue({
       item: {
@@ -326,7 +390,7 @@ describe("tenant maintenance pages", () => {
         reason: undefined,
       });
     });
-    expect(await screen.findByText(/This request has been marked resolved/i)).toBeInTheDocument();
+    expect((await screen.findAllByText(/This request has been marked resolved/i)).length).toBeGreaterThan(0);
   });
 
   it("shows a still-needs-attention closure state in tenant detail", async () => {

--- a/rentchain-frontend/src/pages/tenant/TenantMaintenanceRequestDetailPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantMaintenanceRequestDetailPage.tsx
@@ -3,6 +3,7 @@ import { useParams } from "react-router-dom";
 import {
   getTenantMaintenance,
   updateTenantMaintenanceConfirmation,
+  updateTenantMaintenanceReopen,
   updateTenantMaintenanceReworkAccess,
   updateTenantMaintenanceReworkSignoff,
   updateTenantMaintenanceSignoff,
@@ -15,6 +16,7 @@ import { TenantSurfaceShell, prettyStatus } from "./TenantWorkspaceShared";
 import { buildMaintenanceLifecycleView } from "../maintenanceWorkspaceState";
 import { buildMaintenanceAssignmentRoutingView } from "../maintenanceAssignmentRoutingState";
 import { buildMaintenanceConfirmationAccessView } from "../maintenanceConfirmationAccessState";
+import { buildMaintenanceReopenEscalationView } from "../maintenanceReopenEscalationState";
 import { buildMaintenanceServiceExecutionView } from "../maintenanceServiceExecutionState";
 import { buildMaintenanceResolutionVerificationView } from "../maintenanceResolutionVerificationState";
 import { buildMaintenanceSchedulingAccessView } from "../maintenanceSchedulingAccessState";
@@ -83,6 +85,7 @@ export default function TenantMaintenanceRequestDetailPage() {
   const [error, setError] = useState<string | null>(null);
   const [savingAction, setSavingAction] = useState(false);
   const [signoffReason, setSignoffReason] = useState("");
+  const [reopenReason, setReopenReason] = useState("");
   const [reworkAccessNote, setReworkAccessNote] = useState("");
   const [sessionExpired, setSessionExpired] = useState(false);
   const [hasToken, setHasToken] = useState<boolean>(() =>
@@ -94,6 +97,7 @@ export default function TenantMaintenanceRequestDetailPage() {
   const confirmationView = data ? buildMaintenanceConfirmationAccessView(data, "tenant") : null;
   const executionView = data ? buildMaintenanceServiceExecutionView(data, "tenant") : null;
   const resolutionView = data ? buildMaintenanceResolutionVerificationView(data, "tenant") : null;
+  const reopenView = data ? buildMaintenanceReopenEscalationView(data, "tenant") : null;
   const notificationMessages = tenantNotificationMessages(data);
 
   useEffect(() => {
@@ -233,6 +237,28 @@ export default function TenantMaintenanceRequestDetailPage() {
       }
     } catch (err: any) {
       const msg = err?.payload?.error || err?.message || "Unable to update the rework review.";
+      setError(String(msg));
+    } finally {
+      setSavingAction(false);
+    }
+  };
+
+  const applyTenantReopen = async () => {
+    if (!id) return;
+    if (!reopenReason.trim()) {
+      setError("Add a note before reopening this request.");
+      return;
+    }
+    setSavingAction(true);
+    setError(null);
+    try {
+      const res = await updateTenantMaintenanceReopen(id, {
+        reason: reopenReason.trim(),
+      });
+      setData((res as any)?.item || (res as any)?.data || null);
+      setReopenReason("");
+    } catch (err: any) {
+      const msg = err?.payload?.error || err?.message || "Unable to reopen this maintenance request.";
       setError(String(msg));
     } finally {
       setSavingAction(false);
@@ -764,6 +790,83 @@ export default function TenantMaintenanceRequestDetailPage() {
                         </Button>
                         <Button variant="ghost" disabled={savingAction} onClick={() => void applyResolutionSignoff("not_resolved")}>
                           {savingAction ? "Saving..." : "Still needs attention"}
+                        </Button>
+                      </div>
+                    </>
+                  ) : null}
+                </div>
+              ) : null}
+              {reopenView ? (
+                <div
+                  style={{
+                    border: `1px solid ${colors.border}`,
+                    borderRadius: radius.md,
+                    padding: "12px 14px",
+                    background: colors.panel,
+                    display: "grid",
+                    gap: 8,
+                  }}
+                >
+                  <div style={{ fontWeight: 800, color: textTokens.primary }}>Reopen / follow-up</div>
+                  <div style={{ color: textTokens.secondary }}>{reopenView.summary}</div>
+                  <div style={{ color: textTokens.primary, fontWeight: 700 }}>Recovery state</div>
+                  <div style={{ color: textTokens.secondary }}>{reopenView.tenantVisibleLabel}</div>
+                  <div style={{ color: textTokens.primary, fontWeight: 700 }}>Escalation state</div>
+                  <div style={{ color: textTokens.secondary }}>{reopenView.escalationLabel}</div>
+                  {data.reopenReason ? (
+                    <>
+                      <div style={{ color: textTokens.primary, fontWeight: 700 }}>Reopen note</div>
+                      <div style={{ color: textTokens.secondary }}>{data.reopenReason}</div>
+                    </>
+                  ) : null}
+                  {reopenView.timelineEvents.length ? (
+                    <>
+                      <div style={{ color: textTokens.primary, fontWeight: 700 }}>Recent recovery updates</div>
+                      {reopenView.timelineEvents.map((event) => (
+                        <div key={event.key} style={{ color: textTokens.secondary }}>
+                          {event.label} • {fmtDate(event.timestamp)}
+                        </div>
+                      ))}
+                    </>
+                  ) : null}
+                  {reopenView.blockers.length ? (
+                    <>
+                      <div style={{ color: textTokens.primary, fontWeight: 700 }}>Needs attention</div>
+                      {reopenView.blockers.map((item) => (
+                        <div key={item} style={{ color: textTokens.secondary }}>
+                          {item}
+                        </div>
+                      ))}
+                    </>
+                  ) : null}
+                  <div style={{ color: textTokens.primary, fontWeight: 700 }}>Next step</div>
+                  {reopenView.nextActions.map((step) => (
+                    <div key={step} style={{ color: textTokens.secondary }}>
+                      {step}
+                    </div>
+                  ))}
+                  {reopenView.canTenantReopen ? (
+                    <>
+                      <div style={{ color: textTokens.primary, fontWeight: 700 }}>Issue came back?</div>
+                      <div style={{ color: textTokens.secondary }}>
+                        If the problem returned after closure, you can reopen this request instead of starting a new one.
+                      </div>
+                      <textarea
+                        value={reopenReason}
+                        onChange={(e) => setReopenReason(e.target.value)}
+                        placeholder="Explain what still needs attention or what returned after closure"
+                        rows={3}
+                        style={{
+                          width: "100%",
+                          borderRadius: 8,
+                          border: `1px solid ${colors.border}`,
+                          padding: 10,
+                          resize: "vertical",
+                        }}
+                      />
+                      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                        <Button variant="ghost" disabled={savingAction} onClick={() => void applyTenantReopen()}>
+                          {savingAction ? "Saving..." : "Reopen request"}
                         </Button>
                       </div>
                     </>

--- a/rentchain-frontend/src/pages/tenant/TenantMaintenanceRequestsPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantMaintenanceRequestsPage.tsx
@@ -6,6 +6,7 @@ import { colors, spacing, text as textTokens } from "../../styles/tokens";
 import { buildMaintenanceWorkspaceState } from "../maintenanceWorkspaceState";
 import { buildMaintenanceAssignmentRoutingView } from "../maintenanceAssignmentRoutingState";
 import { buildMaintenanceConfirmationAccessView } from "../maintenanceConfirmationAccessState";
+import { buildMaintenanceReopenEscalationView } from "../maintenanceReopenEscalationState";
 import { buildMaintenanceServiceExecutionView } from "../maintenanceServiceExecutionState";
 import { buildMaintenanceResolutionVerificationView } from "../maintenanceResolutionVerificationState";
 import { buildMaintenanceSchedulingAccessView } from "../maintenanceSchedulingAccessState";
@@ -154,6 +155,7 @@ export default function TenantMaintenanceRequestsPage() {
               const confirmationView = buildMaintenanceConfirmationAccessView(item, "tenant");
               const executionView = buildMaintenanceServiceExecutionView(item, "tenant");
               const resolutionView = buildMaintenanceResolutionVerificationView(item, "tenant");
+              const reopenView = buildMaintenanceReopenEscalationView(item, "tenant");
               const notificationMessages = tenantNotificationMessages(item);
               return (
                 <TenantInfoCard
@@ -259,6 +261,24 @@ export default function TenantMaintenanceRequestsPage() {
                     </div>
                     {item.followUpReason ? (
                       <div style={{ color: textTokens.secondary }}>Follow-up note: {item.followUpReason}</div>
+                    ) : null}
+                  </div>
+                  <div
+                    style={{
+                      border: "1px solid rgba(15,23,42,0.08)",
+                      borderRadius: 12,
+                      padding: "12px 14px",
+                      display: "grid",
+                      gap: 8,
+                    }}
+                  >
+                    <div style={{ color: textTokens.primary, fontWeight: 700 }}>Reopen / follow-up</div>
+                    <div style={{ color: textTokens.secondary }}>{reopenView.summary}</div>
+                    <div style={{ color: textTokens.secondary }}>
+                      {`${reopenView.tenantVisibleLabel} • ${reopenView.escalationLabel}`}
+                    </div>
+                    {item.reopenReason ? (
+                      <div style={{ color: textTokens.secondary }}>Reopen note: {item.reopenReason}</div>
                     ) : null}
                   </div>
                   {requestView?.nextSteps.length ? (


### PR DESCRIPTION
## Summary

This PR adds a post-closure recovery layer for maintenance requests.

Landlords now get a dedicated `Reopen / escalation` workspace that distinguishes follow-up, reopened, and escalated states, and tenants can now reopen a closed/resolved request with a required note instead of starting over.

## What changed

- Added a shared helper:
  - `maintenanceReopenEscalationState`
- Added derived post-closure states for:
  - follow-up needed
  - reopened
  - escalated
- Kept the workflow attached to the same maintenance request instead of creating a new ticket
- Added a narrow tenant-safe reopen route:
  - `POST /tenant/maintenance/:id/reopen`
- Extended tenant-safe maintenance projection/detail payload with:
  - `reopenedAt`
  - `reopenedByActorId`
  - `reopenedByActorRole`
  - `reopenReason`
- Refined landlord maintenance detail with a `Reopen / escalation` section
- Refined tenant maintenance list/detail views with reopen visibility and tenant reopen action

## Scope

- Narrow backend/API extension
- Frontend workflow refinement
- No schema redesign
- No new ticketing, SLA, or contractor-penalty platform

## Validation

```bash
cd rentchain-frontend && PATH="$HOME/.nvm/versions/node/v20.20.2/bin:$PATH" npm run test -- src/pages/maintenanceReopenEscalationState.test.ts src/pages/MaintenanceRequestsPage.test.tsx src/pages/tenant/TenantMaintenancePages.test.tsx
cd rentchain-frontend && PATH="$HOME/.nvm/versions/node/v20.20.2/bin:$PATH" npm run build
cd rentchain-api && PATH="$HOME/.nvm/versions/node/v20.20.2/bin:$PATH" npm run test -- src/routes/__tests__/tenantPortalRoutes.test.ts
cd rentchain-api && PATH="$HOME/.nvm/versions/node/v20.20.2/bin:$PATH" npm run build