### PR TITLE
feat(maintenance): add cost capture and expense linkage v1

### DIFF
--- a/rentchain-frontend/src/api/maintenanceWorkflowApi.ts
+++ b/rentchain-frontend/src/api/maintenanceWorkflowApi.ts
@@ -22,6 +22,7 @@ export type MaintenanceWorkflowStatus =
 
 export type MaintenanceWorkflowItem = {
   id: string;
+  workOrderId?: string | null;
   tenantId: string;
   landlordId: string;
   propertyId: string | null;

--- a/rentchain-frontend/src/pages/MaintenanceRequestsPage.test.tsx
+++ b/rentchain-frontend/src/pages/MaintenanceRequestsPage.test.tsx
@@ -13,6 +13,8 @@ const maintenanceWorkflowApi = vi.hoisted(() => ({
 const workOrdersApi = vi.hoisted(() => ({
   listContractorInvites: vi.fn(),
   getContractorProfileById: vi.fn(),
+  submitLandlordWorkOrderCost: vi.fn(),
+  linkWorkOrderCostToExpense: vi.fn(),
 }));
 
 const showToast = vi.fn();
@@ -82,6 +84,8 @@ describe("landlord maintenance workspace", () => {
       ],
     });
     workOrdersApi.listContractorInvites.mockResolvedValue([]);
+    workOrdersApi.submitLandlordWorkOrderCost.mockResolvedValue({});
+    workOrdersApi.linkWorkOrderCostToExpense.mockResolvedValue({});
   });
 
   it("renders the landlord maintenance workspace with lifecycle guidance", async () => {
@@ -325,5 +329,117 @@ describe("landlord maintenance workspace", () => {
 
     expect(await screen.findAllByText(/Leaky pipe/i)).not.toHaveLength(0);
     expect(screen.getAllByText(/Ready for service/i).length).toBeGreaterThan(0);
+  });
+
+  it("records landlord cost on a closed maintenance request", async () => {
+    maintenanceWorkflowApi.listLandlordMaintenance.mockResolvedValue({
+      items: [
+        {
+          id: "maint-1",
+          workOrderId: "maintenance_maint-1",
+          tenantId: "tenant-1",
+          landlordId: "landlord-1",
+          propertyId: "prop-1",
+          unitId: "unit-2",
+          tenantName: "Taylor Tenant",
+          propertyLabel: "123 Main St",
+          unitLabel: "Unit 4",
+          title: "Broken heater",
+          description: "Heat is not turning on.",
+          category: "HVAC",
+          priority: "urgent",
+          status: "completed",
+          assignedContractorName: "North Shore HVAC",
+          resolutionStatus: "resolved",
+          tenantSignoffStatus: "accepted",
+          finalResolvedAt: Date.UTC(2026, 3, 18, 10, 0),
+          createdAt: 100,
+          updatedAt: 200,
+          statusHistory: [],
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/maintenance/maint-1"]}>
+        <Routes>
+          <Route path="/maintenance/:id" element={<MaintenanceRequestsPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByLabelText(/Total cost/i)).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText(/Total cost/i), { target: { value: "245.00" } });
+    fireEvent.change(screen.getByLabelText(/Labor cost/i), { target: { value: "150.00" } });
+    fireEvent.change(screen.getByLabelText(/Material cost/i), { target: { value: "50.00" } });
+    fireEvent.change(screen.getByLabelText(/Vendor cost/i), { target: { value: "45.00" } });
+    fireEvent.change(screen.getByLabelText(/Cost note/i), {
+      target: { value: "Recorded after the final closure update." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Record cost/i }));
+
+    expect(workOrdersApi.submitLandlordWorkOrderCost).toHaveBeenCalledWith("maintenance_maint-1", {
+      actualCostCents: 24500,
+      currency: "CAD",
+      lineItems: [
+        { label: "Labor cost", amountCents: 15000, category: "labor" },
+        { label: "Material cost", amountCents: 5000, category: "materials" },
+        { label: "Vendor cost", amountCents: 4500, category: "other" },
+      ],
+      reviewNote: "Recorded after the final closure update.",
+    });
+  });
+
+  it("links a recorded maintenance cost to an expense when eligible", async () => {
+    maintenanceWorkflowApi.listLandlordMaintenance.mockResolvedValue({
+      items: [
+        {
+          id: "maint-1",
+          workOrderId: "maintenance_maint-1",
+          tenantId: "tenant-1",
+          landlordId: "landlord-1",
+          propertyId: "prop-1",
+          unitId: "unit-2",
+          tenantName: "Taylor Tenant",
+          propertyLabel: "123 Main St",
+          unitLabel: "Unit 4",
+          title: "Broken heater",
+          description: "Heat is not turning on.",
+          category: "HVAC",
+          priority: "urgent",
+          status: "completed",
+          resolutionStatus: "resolved",
+          tenantSignoffStatus: "accepted",
+          finalResolvedAt: Date.UTC(2026, 3, 18, 10, 0),
+          cost: {
+            actualCostCents: 24500,
+            currency: "CAD",
+            reviewStatus: "approved",
+            linkedExpenseStatus: "not_linked",
+          },
+          costLineItems: [
+            { id: "labor", label: "Labor cost", amountCents: 15000, category: "labor" },
+            { id: "materials", label: "Material cost", amountCents: 5000, category: "materials" },
+            { id: "vendor", label: "Vendor cost", amountCents: 4500, category: "other" },
+          ],
+          expenseLink: { status: "not_linked", expenseId: null },
+          createdAt: 100,
+          updatedAt: 200,
+          statusHistory: [],
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/maintenance/maint-1"]}>
+        <Routes>
+          <Route path="/maintenance/:id" element={<MaintenanceRequestsPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /Link to expense/i }));
+
+    expect(workOrdersApi.linkWorkOrderCostToExpense).toHaveBeenCalledWith("maintenance_maint-1");
   });
 });

--- a/rentchain-frontend/src/pages/MaintenanceRequestsPage.tsx
+++ b/rentchain-frontend/src/pages/MaintenanceRequestsPage.tsx
@@ -11,11 +11,17 @@ import {
   type MaintenanceWorkflowItem,
   type MaintenanceWorkflowStatus,
 } from "../api/maintenanceWorkflowApi";
-import { getContractorProfileById, listContractorInvites } from "../api/workOrdersApi";
+import {
+  getContractorProfileById,
+  linkWorkOrderCostToExpense,
+  listContractorInvites,
+  submitLandlordWorkOrderCost,
+} from "../api/workOrdersApi";
 import { colors, radius, spacing, text } from "../styles/tokens";
 import { buildMaintenanceLifecycleView, buildMaintenanceWorkspaceState } from "./maintenanceWorkspaceState";
 import { buildMaintenanceAssignmentRoutingView } from "./maintenanceAssignmentRoutingState";
 import { buildMaintenanceConfirmationAccessView } from "./maintenanceConfirmationAccessState";
+import { buildMaintenanceCostView } from "./maintenanceCostState";
 import { buildMaintenanceReopenEscalationView } from "./maintenanceReopenEscalationState";
 import { buildMaintenanceServiceExecutionView } from "./maintenanceServiceExecutionState";
 import { buildMaintenanceResolutionVerificationView } from "./maintenanceResolutionVerificationState";
@@ -38,6 +44,14 @@ const FILTERS: Array<{ value: "all" | MaintenanceWorkflowStatus; label: string }
 function fmtDate(ts?: number | null) {
   if (!ts) return "-";
   return new Date(ts).toLocaleString();
+}
+
+function fmtMoney(cents?: number | null, currency = "CAD") {
+  if (typeof cents !== "number") return "-";
+  return new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency: currency || "CAD",
+  }).format(cents / 100);
 }
 
 function statusTone(status: string) {
@@ -130,6 +144,11 @@ export default function MaintenanceRequestsPage() {
   const [serviceWindowStart, setServiceWindowStart] = React.useState("");
   const [serviceWindowEnd, setServiceWindowEnd] = React.useState("");
   const [accessRequired, setAccessRequired] = React.useState<"unknown" | "yes" | "no">("unknown");
+  const [costTotalInput, setCostTotalInput] = React.useState("");
+  const [laborCostInput, setLaborCostInput] = React.useState("");
+  const [materialCostInput, setMaterialCostInput] = React.useState("");
+  const [vendorCostInput, setVendorCostInput] = React.useState("");
+  const [costNote, setCostNote] = React.useState("");
   const [calendarMonth, setCalendarMonth] = React.useState(() => new Date());
 
   const load = React.useCallback(async () => {
@@ -226,6 +245,19 @@ export default function MaintenanceRequestsPage() {
       setAccessRequired(
         selected.accessRequired === true ? "yes" : selected.accessRequired === false ? "no" : "unknown"
       );
+      setCostTotalInput(
+        typeof selected.cost?.actualCostCents === "number" ? (selected.cost.actualCostCents / 100).toFixed(2) : ""
+      );
+      const laborLine = selected.costLineItems?.find((entry) => entry.category === "labor")?.amountCents ?? null;
+      const materialLine = selected.costLineItems?.find((entry) => entry.category === "materials")?.amountCents ?? null;
+      const vendorLine =
+        selected.costLineItems
+          ?.filter((entry) => entry.category !== "labor" && entry.category !== "materials")
+          .reduce((sum, entry) => sum + (typeof entry.amountCents === "number" ? entry.amountCents : 0), 0) ?? null;
+      setLaborCostInput(typeof laborLine === "number" ? (laborLine / 100).toFixed(2) : "");
+      setMaterialCostInput(typeof materialLine === "number" ? (materialLine / 100).toFixed(2) : "");
+      setVendorCostInput(typeof vendorLine === "number" && vendorLine > 0 ? (vendorLine / 100).toFixed(2) : "");
+      setCostNote(String(selected.cost?.reviewNote || ""));
       return;
     }
     if (filtered.length > 0 && !routeId) {
@@ -238,6 +270,17 @@ export default function MaintenanceRequestsPage() {
       setServiceWindowStart(toLocalInputValue(first.serviceWindowStartAt));
       setServiceWindowEnd(toLocalInputValue(first.serviceWindowEndAt));
       setAccessRequired(first.accessRequired === true ? "yes" : first.accessRequired === false ? "no" : "unknown");
+      setCostTotalInput(typeof first.cost?.actualCostCents === "number" ? (first.cost.actualCostCents / 100).toFixed(2) : "");
+      const laborLine = first.costLineItems?.find((entry) => entry.category === "labor")?.amountCents ?? null;
+      const materialLine = first.costLineItems?.find((entry) => entry.category === "materials")?.amountCents ?? null;
+      const vendorLine =
+        first.costLineItems
+          ?.filter((entry) => entry.category !== "labor" && entry.category !== "materials")
+          .reduce((sum, entry) => sum + (typeof entry.amountCents === "number" ? entry.amountCents : 0), 0) ?? null;
+      setLaborCostInput(typeof laborLine === "number" ? (laborLine / 100).toFixed(2) : "");
+      setMaterialCostInput(typeof materialLine === "number" ? (materialLine / 100).toFixed(2) : "");
+      setVendorCostInput(typeof vendorLine === "number" && vendorLine > 0 ? (vendorLine / 100).toFixed(2) : "");
+      setCostNote(String(first.cost?.reviewNote || ""));
     }
   }, [filtered, routeId, selected]);
 
@@ -405,6 +448,7 @@ export default function MaintenanceRequestsPage() {
     () => (selected ? buildMaintenanceReopenEscalationView(selected, "landlord") : null),
     [selected]
   );
+  const selectedCost = React.useMemo(() => (selected ? buildMaintenanceCostView(selected, "landlord") : null), [selected]);
   const calendarEvents = React.useMemo(() => buildMaintenanceSchedulingCalendarEvents(items), [items]);
   const calendarDays = React.useMemo(() => buildCalendarDays(calendarMonth), [calendarMonth]);
   const calendarEventMap = React.useMemo(() => {
@@ -418,6 +462,97 @@ export default function MaintenanceRequestsPage() {
     });
     return next;
   }, [calendarDays, calendarEvents]);
+
+  const saveCost = React.useCallback(async () => {
+    if (!selected || !selected.workOrderId || !selectedCost?.canRecordCost) return;
+
+    const normalizedTotal = Number(costTotalInput);
+    if (!Number.isFinite(normalizedTotal) || normalizedTotal <= 0) {
+      setError("Enter a valid total cost before saving.");
+      return;
+    }
+
+    const parseOptionalMoney = (value: string, label: string) => {
+      if (!value.trim()) return null;
+      const amount = Number(value);
+      if (!Number.isFinite(amount) || amount < 0) {
+        throw new Error(`Enter a valid ${label}.`);
+      }
+      return Math.round(amount * 100);
+    };
+
+    let laborCostCents: number | null = null;
+    let materialCostCents: number | null = null;
+    let vendorCostCents: number | null = null;
+    try {
+      laborCostCents = parseOptionalMoney(laborCostInput, "labor cost");
+      materialCostCents = parseOptionalMoney(materialCostInput, "material cost");
+      vendorCostCents = parseOptionalMoney(vendorCostInput, "vendor cost");
+    } catch (err: any) {
+      setError(String(err?.message || "Enter valid cost amounts."));
+      return;
+    }
+
+    const lineItems = [
+      laborCostCents !== null ? { label: "Labor cost", amountCents: laborCostCents, category: "labor" as const } : null,
+      materialCostCents !== null
+        ? { label: "Material cost", amountCents: materialCostCents, category: "materials" as const }
+        : null,
+      vendorCostCents !== null ? { label: "Vendor cost", amountCents: vendorCostCents, category: "other" as const } : null,
+    ].filter((entry): entry is { label: string; amountCents: number; category: "labor" | "materials" | "other" } => Boolean(entry));
+
+    const totalCostCents = Math.round(normalizedTotal * 100);
+    const lineItemTotalCents = lineItems.reduce((sum, entry) => sum + entry.amountCents, 0);
+    if (lineItems.length > 0 && lineItemTotalCents !== totalCostCents) {
+      setError("The labor, material, and vendor costs need to add up to the total cost.");
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+    try {
+      await submitLandlordWorkOrderCost(selected.workOrderId, {
+        actualCostCents: totalCostCents,
+        currency: selected.cost?.currency || "CAD",
+        lineItems,
+        reviewNote: costNote.trim() || undefined,
+      });
+      showToast({
+        message: selected.cost?.actualCostCents ? "Maintenance cost updated." : "Maintenance cost recorded.",
+        variant: "success",
+      });
+      await load();
+    } catch (err: any) {
+      setError(String(err?.message || "Failed to save maintenance cost"));
+    } finally {
+      setSaving(false);
+    }
+  }, [
+    costNote,
+    costTotalInput,
+    laborCostInput,
+    load,
+    materialCostInput,
+    selected,
+    selectedCost?.canRecordCost,
+    showToast,
+    vendorCostInput,
+  ]);
+
+  const linkExpense = React.useCallback(async () => {
+    if (!selected?.workOrderId || !selectedCost?.canLinkExpense) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await linkWorkOrderCostToExpense(selected.workOrderId);
+      showToast({ message: "Expense link recorded.", variant: "success" });
+      await load();
+    } catch (err: any) {
+      setError(String(err?.message || "Failed to link maintenance cost to an expense"));
+    } finally {
+      setSaving(false);
+    }
+  }, [load, selected?.workOrderId, selectedCost?.canLinkExpense, showToast]);
 
   const totalOpen = items.filter((item) => !["completed", "cancelled"].includes(item.status)).length;
   const needsReview = items.filter((item) => item.status === "submitted").length;
@@ -1017,6 +1152,167 @@ export default function MaintenanceRequestsPage() {
                           {step}
                         </div>
                       ))}
+                    </div>
+                  ) : null}
+
+                  {selectedCost ? (
+                    <div
+                      style={{
+                        border: `1px solid ${colors.border}`,
+                        borderRadius: radius.md,
+                        padding: "12px 14px",
+                        background: colors.panel,
+                        display: "grid",
+                        gap: 8,
+                      }}
+                    >
+                      <div style={{ fontWeight: 700, color: text.primary }}>Cost</div>
+                      <div style={{ color: text.secondary }}>{selectedCost.summary}</div>
+                      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))", gap: 10 }}>
+                        <div>
+                          <div style={{ color: text.muted, fontSize: 12 }}>Cost state</div>
+                          <div style={{ color: text.primary, fontWeight: 700, marginTop: 6 }}>{selectedCost.costLabel}</div>
+                        </div>
+                        <div>
+                          <div style={{ color: text.muted, fontSize: 12 }}>Readiness</div>
+                          <div style={{ color: text.primary, fontWeight: 700, marginTop: 6 }}>
+                            {selectedCost.readinessLabel}
+                          </div>
+                        </div>
+                        <div>
+                          <div style={{ color: text.muted, fontSize: 12 }}>Total cost</div>
+                          <div style={{ color: text.primary, fontWeight: 700, marginTop: 6 }}>
+                            {fmtMoney(selectedCost.totalCostCents, selectedCost.currency)}
+                          </div>
+                        </div>
+                      </div>
+                      {(selectedCost.breakdown.laborCostCents !== null ||
+                        selectedCost.breakdown.materialCostCents !== null ||
+                        selectedCost.breakdown.vendorCostCents !== null) ? (
+                        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))", gap: 10 }}>
+                          <div>
+                            <div style={{ color: text.muted, fontSize: 12 }}>Labor cost</div>
+                            <div style={{ color: text.primary, fontWeight: 700, marginTop: 6 }}>
+                              {fmtMoney(selectedCost.breakdown.laborCostCents, selectedCost.currency)}
+                            </div>
+                          </div>
+                          <div>
+                            <div style={{ color: text.muted, fontSize: 12 }}>Material cost</div>
+                            <div style={{ color: text.primary, fontWeight: 700, marginTop: 6 }}>
+                              {fmtMoney(selectedCost.breakdown.materialCostCents, selectedCost.currency)}
+                            </div>
+                          </div>
+                          <div>
+                            <div style={{ color: text.muted, fontSize: 12 }}>Vendor cost</div>
+                            <div style={{ color: text.primary, fontWeight: 700, marginTop: 6 }}>
+                              {fmtMoney(selectedCost.breakdown.vendorCostCents, selectedCost.currency)}
+                            </div>
+                          </div>
+                        </div>
+                      ) : null}
+                      {selectedCost.note ? (
+                        <>
+                          <div style={{ fontWeight: 700, color: text.primary }}>Cost note</div>
+                          <div style={{ color: text.secondary }}>{selectedCost.note}</div>
+                        </>
+                      ) : null}
+                      <div style={{ fontWeight: 700, color: text.primary }}>Expense linkage</div>
+                      <div style={{ color: text.secondary }}>
+                        {selectedCost.hasExpenseLink && selectedCost.linkedExpenseId
+                          ? `Linked to expense ${selectedCost.linkedExpenseId}.`
+                          : "No linked expense record yet."}
+                      </div>
+                      {selectedCost.blockers.length ? (
+                        <>
+                          <div style={{ fontWeight: 700, color: text.primary }}>Needs attention</div>
+                          {selectedCost.blockers.map((item) => (
+                            <div key={item} style={{ color: text.secondary }}>
+                              {item}
+                            </div>
+                          ))}
+                        </>
+                      ) : null}
+                      <div style={{ fontWeight: 700, color: text.primary }}>Next step</div>
+                      {selectedCost.nextSteps.map((step) => (
+                        <div key={step} style={{ color: text.secondary }}>
+                          {step}
+                        </div>
+                      ))}
+                      {selectedCost.canRecordCost ? (
+                        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))", gap: 10 }}>
+                          <label style={{ display: "grid", gap: 4 }}>
+                            <span style={{ color: text.muted, fontSize: 12 }}>Total cost</span>
+                            <Input
+                              aria-label="Total cost"
+                              inputMode="decimal"
+                              value={costTotalInput}
+                              onChange={(e) => setCostTotalInput(e.target.value)}
+                              placeholder="0.00"
+                            />
+                          </label>
+                          <label style={{ display: "grid", gap: 4 }}>
+                            <span style={{ color: text.muted, fontSize: 12 }}>Labor cost</span>
+                            <Input
+                              aria-label="Labor cost"
+                              inputMode="decimal"
+                              value={laborCostInput}
+                              onChange={(e) => setLaborCostInput(e.target.value)}
+                              placeholder="0.00"
+                            />
+                          </label>
+                          <label style={{ display: "grid", gap: 4 }}>
+                            <span style={{ color: text.muted, fontSize: 12 }}>Material cost</span>
+                            <Input
+                              aria-label="Material cost"
+                              inputMode="decimal"
+                              value={materialCostInput}
+                              onChange={(e) => setMaterialCostInput(e.target.value)}
+                              placeholder="0.00"
+                            />
+                          </label>
+                          <label style={{ display: "grid", gap: 4 }}>
+                            <span style={{ color: text.muted, fontSize: 12 }}>Vendor cost</span>
+                            <Input
+                              aria-label="Vendor cost"
+                              inputMode="decimal"
+                              value={vendorCostInput}
+                              onChange={(e) => setVendorCostInput(e.target.value)}
+                              placeholder="0.00"
+                            />
+                          </label>
+                        </div>
+                      ) : null}
+                      {selectedCost.canRecordCost ? (
+                        <label style={{ display: "grid", gap: 4 }}>
+                          <span style={{ color: text.muted, fontSize: 12 }}>Cost note</span>
+                          <textarea
+                            aria-label="Cost note"
+                            value={costNote}
+                            onChange={(e) => setCostNote(e.target.value)}
+                            rows={3}
+                            style={{
+                              padding: "10px",
+                              borderRadius: radius.md,
+                              border: `1px solid ${colors.border}`,
+                              background: colors.card,
+                              color: text.primary,
+                              resize: "vertical",
+                            }}
+                          />
+                        </label>
+                      ) : null}
+                      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                        {selectedCost.canRecordCost ? (
+                          <Button variant="secondary" onClick={() => void saveCost()} disabled={saving}>
+                            {saving ? "Saving..." : selectedCost.totalCostCents ? "Update cost" : "Record cost"}
+                          </Button>
+                        ) : null}
+                        {selectedCost.canLinkExpense ? (
+                          <Button variant="secondary" onClick={() => void linkExpense()} disabled={saving}>
+                            {saving ? "Saving..." : "Link to expense"}
+                          </Button>
+                        ) : null}
+                      </div>
                     </div>
                   ) : null}
 

--- a/rentchain-frontend/src/pages/maintenanceCostState.test.ts
+++ b/rentchain-frontend/src/pages/maintenanceCostState.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import type { MaintenanceWorkflowItem } from "../api/maintenanceWorkflowApi";
+import { buildMaintenanceCostView } from "./maintenanceCostState";
+
+function makeItem(overrides: Partial<MaintenanceWorkflowItem> = {}): MaintenanceWorkflowItem {
+  return {
+    id: "maint-1",
+    workOrderId: "maintenance_maint-1",
+    tenantId: "tenant-1",
+    landlordId: "landlord-1",
+    propertyId: "prop-1",
+    unitId: "unit-1",
+    title: "Repair sink",
+    description: "Kitchen sink leak.",
+    category: "PLUMBING",
+    priority: "normal",
+    status: "completed",
+    createdAt: 1,
+    updatedAt: 2,
+    resolutionStatus: "resolved",
+    tenantSignoffStatus: "accepted",
+    finalResolvedAt: 5,
+    statusHistory: [],
+    ...overrides,
+  };
+}
+
+describe("buildMaintenanceCostView", () => {
+  it("returns no_cost_recorded when closure is ready but no cost exists", () => {
+    const view = buildMaintenanceCostView(makeItem(), "landlord");
+    expect(view.costState).toBe("no_cost_recorded");
+    expect(view.canRecordCost).toBe(true);
+    expect(view.nextSteps).toContain(
+      "Record the total cost and any labor, material, or vendor breakdown that is available."
+    );
+  });
+
+  it("returns cost_recorded with a breakdown when settled cost is present", () => {
+    const view = buildMaintenanceCostView(
+      makeItem({
+        cost: {
+          actualCostCents: 24500,
+          currency: "CAD",
+          reviewStatus: "approved",
+          reviewNote: "Recorded after final closure.",
+          linkedExpenseStatus: "not_linked",
+        },
+        costLineItems: [
+          { id: "labor", label: "Labor cost", amountCents: 15000, category: "labor" },
+          { id: "materials", label: "Material cost", amountCents: 5000, category: "materials" },
+          { id: "vendor", label: "Vendor cost", amountCents: 4500, category: "other" },
+        ],
+      }),
+      "landlord"
+    );
+
+    expect(view.costState).toBe("cost_recorded");
+    expect(view.totalCostCents).toBe(24500);
+    expect(view.breakdown.laborCostCents).toBe(15000);
+    expect(view.breakdown.materialCostCents).toBe(5000);
+    expect(view.breakdown.vendorCostCents).toBe(4500);
+    expect(view.canLinkExpense).toBe(true);
+  });
+
+  it("returns cost_needs_review when the breakdown does not match the recorded total", () => {
+    const view = buildMaintenanceCostView(
+      makeItem({
+        cost: {
+          actualCostCents: 24500,
+          currency: "CAD",
+          reviewStatus: "approved",
+          linkedExpenseStatus: "not_linked",
+        },
+        costLineItems: [{ id: "labor", label: "Labor cost", amountCents: 20000, category: "labor" }],
+      }),
+      "landlord"
+    );
+
+    expect(view.costState).toBe("cost_needs_review");
+    expect(view.blockers).toContain("The recorded total cost does not match the current cost breakdown.");
+  });
+
+  it("blocks cost capture until the request reaches a clean closure state", () => {
+    const view = buildMaintenanceCostView(
+      makeItem({
+        resolutionStatus: "follow_up_required",
+        tenantSignoffStatus: "declined",
+        finalResolvedAt: null,
+      }),
+      "landlord"
+    );
+
+    expect(view.canRecordCost).toBe(false);
+    expect(view.readinessLabel).toBe("Not ready for cost capture");
+  });
+});

--- a/rentchain-frontend/src/pages/maintenanceCostState.ts
+++ b/rentchain-frontend/src/pages/maintenanceCostState.ts
@@ -1,0 +1,198 @@
+import type { MaintenanceWorkflowItem } from "../api/maintenanceWorkflowApi";
+
+type Audience = "landlord";
+
+export type MaintenanceCostState = "no_cost_recorded" | "cost_recorded" | "cost_needs_review";
+
+export type MaintenanceCostBreakdown = {
+  laborCostCents: number | null;
+  materialCostCents: number | null;
+  vendorCostCents: number | null;
+};
+
+export type MaintenanceCostView = {
+  costState: MaintenanceCostState;
+  costLabel: string;
+  readinessLabel: string;
+  summary: string;
+  nextSteps: string[];
+  blockers: string[];
+  totalCostCents: number | null;
+  currency: string;
+  note: string | null;
+  breakdown: MaintenanceCostBreakdown;
+  lineItemTotalCents: number | null;
+  hasExpenseLink: boolean;
+  linkedExpenseId: string | null;
+  canRecordCost: boolean;
+  canLinkExpense: boolean;
+};
+
+function statusOf(item: MaintenanceWorkflowItem) {
+  return String(item.status || "").trim().toLowerCase();
+}
+
+function hasResolvedClosure(item: MaintenanceWorkflowItem) {
+  return (
+    typeof item.finalResolvedAt === "number" ||
+    item.resolutionStatus === "resolved" ||
+    item.tenantSignoffStatus === "accepted" ||
+    item.reworkReview?.status === "closed" ||
+    item.reworkReview?.tenantSignoffStatus === "accepted"
+  );
+}
+
+function needsFollowUp(item: MaintenanceWorkflowItem) {
+  return (
+    item.followUpRequired === true ||
+    item.resolutionStatus === "follow_up_required" ||
+    item.tenantSignoffStatus === "declined" ||
+    item.reworkReview?.status === "follow_up_required" ||
+    item.reworkReview?.tenantSignoffStatus === "declined" ||
+    typeof item.reopenedAt === "number"
+  );
+}
+
+function isClosureReady(item: MaintenanceWorkflowItem) {
+  return statusOf(item) === "completed" && hasResolvedClosure(item) && !needsFollowUp(item);
+}
+
+function sumByCategory(item: MaintenanceWorkflowItem): MaintenanceCostBreakdown & { lineItemTotalCents: number | null } {
+  const lineItems = Array.isArray(item.costLineItems) ? item.costLineItems : [];
+  if (!lineItems.length) {
+    return {
+      laborCostCents: null,
+      materialCostCents: null,
+      vendorCostCents: null,
+      lineItemTotalCents: null,
+    };
+  }
+
+  let laborCostCents = 0;
+  let materialCostCents = 0;
+  let vendorCostCents = 0;
+  let lineItemTotalCents = 0;
+
+  lineItems.forEach((entry) => {
+    const amount = typeof entry?.amountCents === "number" ? entry.amountCents : 0;
+    lineItemTotalCents += amount;
+    if (entry?.category === "labor") {
+      laborCostCents += amount;
+      return;
+    }
+    if (entry?.category === "materials") {
+      materialCostCents += amount;
+      return;
+    }
+    vendorCostCents += amount;
+  });
+
+  return {
+    laborCostCents: laborCostCents || null,
+    materialCostCents: materialCostCents || null,
+    vendorCostCents: vendorCostCents || null,
+    lineItemTotalCents,
+  };
+}
+
+function costLabel(state: MaintenanceCostState) {
+  switch (state) {
+    case "cost_recorded":
+      return "Cost recorded";
+    case "cost_needs_review":
+      return "Cost needs review";
+    case "no_cost_recorded":
+    default:
+      return "No cost recorded";
+  }
+}
+
+export function buildMaintenanceCostView(item: MaintenanceWorkflowItem, _audience: Audience): MaintenanceCostView {
+  const blockers: string[] = [];
+  const nextSteps: string[] = [];
+  const totalCostCents = typeof item.cost?.actualCostCents === "number" ? item.cost.actualCostCents : null;
+  const currency = String(item.cost?.currency || "CAD").trim() || "CAD";
+  const note = typeof item.cost?.reviewNote === "string" ? item.cost.reviewNote : null;
+  const hasExpenseLink = item.expenseLink?.status === "linked" || item.cost?.linkedExpenseStatus === "linked";
+  const linkedExpenseId =
+    (typeof item.expenseLink?.expenseId === "string" && item.expenseLink.expenseId) ||
+    (typeof item.cost?.linkedExpenseId === "string" && item.cost.linkedExpenseId) ||
+    null;
+  const breakdown = sumByCategory(item);
+  const closureReady = isClosureReady(item);
+  const hasRecordedCost = typeof totalCostCents === "number" && totalCostCents > 0;
+  const lineItemMismatch =
+    hasRecordedCost &&
+    typeof breakdown.lineItemTotalCents === "number" &&
+    breakdown.lineItemTotalCents > 0 &&
+    breakdown.lineItemTotalCents !== totalCostCents;
+  const reviewStatus = item.cost?.reviewStatus || null;
+
+  let costState: MaintenanceCostState = "no_cost_recorded";
+  let summary = "No maintenance cost has been recorded for this request yet.";
+
+  if (!closureReady) {
+    blockers.push("Cost capture opens after service is resolved and the request has a clean closure state.");
+  }
+  if (!item.workOrderId) {
+    blockers.push("A linked work order is required before cost can be recorded or linked to an expense.");
+  }
+
+  if (hasRecordedCost) {
+    if (lineItemMismatch || reviewStatus === "rejected" || reviewStatus === "revision_requested") {
+      costState = "cost_needs_review";
+      summary =
+        "A maintenance cost has been recorded, but the current cost details need review before this record is fully settled.";
+      if (lineItemMismatch) {
+        blockers.push("The recorded total cost does not match the current cost breakdown.");
+      }
+      if (reviewStatus === "rejected" || reviewStatus === "revision_requested") {
+        blockers.push("The current cost record is not in a settled recorded state yet.");
+      }
+    } else {
+      costState = "cost_recorded";
+      summary = hasExpenseLink
+        ? "Maintenance cost has been recorded and linked to an expense record."
+        : "Maintenance cost has been recorded for this request.";
+    }
+  }
+
+  if (!closureReady) {
+    nextSteps.push("Finish the verification and closure steps before recording maintenance cost.");
+  } else if (!hasRecordedCost) {
+    nextSteps.push("Record the total cost and any labor, material, or vendor breakdown that is available.");
+  } else if (costState === "cost_needs_review") {
+    nextSteps.push("Review the cost totals and save an updated maintenance cost record.");
+  } else if (!hasExpenseLink) {
+    nextSteps.push("Link this recorded cost to an expense record when you are ready to track it in expenses.");
+  } else {
+    nextSteps.push("Cost is captured and linked. Keep this request for operational history and reporting context.");
+  }
+
+  return {
+    costState,
+    costLabel: costLabel(costState),
+    readinessLabel: closureReady ? "Ready for cost capture" : "Not ready for cost capture",
+    summary,
+    nextSteps,
+    blockers,
+    totalCostCents,
+    currency,
+    note,
+    breakdown: {
+      laborCostCents: breakdown.laborCostCents,
+      materialCostCents: breakdown.materialCostCents,
+      vendorCostCents: breakdown.vendorCostCents,
+    },
+    lineItemTotalCents: breakdown.lineItemTotalCents,
+    hasExpenseLink,
+    linkedExpenseId,
+    canRecordCost: closureReady && Boolean(item.workOrderId),
+    canLinkExpense:
+      closureReady &&
+      Boolean(item.workOrderId) &&
+      hasRecordedCost &&
+      !hasExpenseLink &&
+      (reviewStatus === "approved" || reviewStatus === null),
+  };
+}


### PR DESCRIPTION
Summary

Adds a lightweight maintenance cost capture layer to the landlord maintenance workspace.

Landlords can now record total maintenance cost with simple labor/material/vendor breakdowns, view recorded cost directly on the maintenance request, and link eligible recorded costs to an expense record — without introducing a broader accounting workflow.

This extends the maintenance lifecycle from operational execution into basic financial tracking.

What Changed
Added a pure maintenanceCostState helper for derived cost state and next-step guidance
Added a landlord-only Cost section in maintenance request detail
Added simple cost entry for:
total cost
labor cost
material cost
vendor cost
cost note
Restricted cost entry to requests in a clean closure state
Reused existing work-order cost submission and expense-linkage endpoints
Added targeted tests for helper logic and maintenance cost actions
Scope Notes
No backend changes were required
No tenant cost visibility
No schema redesign
No billing, invoicing, or accounting workflow expansion
Cost capture is limited to post-resolution / closure-ready requests
Validation
Frontend targeted tests passed
Frontend build passed
Strategic Impact

This PR introduces the first financial layer on top of the completed maintenance lifecycle, enabling landlords to move from service execution tracking to basic cost visibility and expense linkage without expanding into a full accounting system.