### PR TITLE
feat(maintenance): add portfolio cost rollup and property insights v1

### DIFF
--- a/rentchain-frontend/src/pages/MaintenanceRequestsPage.test.tsx
+++ b/rentchain-frontend/src/pages/MaintenanceRequestsPage.test.tsx
@@ -442,4 +442,97 @@ describe("landlord maintenance workspace", () => {
 
     expect(workOrdersApi.linkWorkOrderCostToExpense).toHaveBeenCalledWith("maintenance_maint-1");
   });
+
+  it("shows property-level maintenance cost and request insights", async () => {
+    maintenanceWorkflowApi.listLandlordMaintenance.mockResolvedValue({
+      items: [
+        {
+          id: "maint-1",
+          tenantId: "tenant-1",
+          landlordId: "landlord-1",
+          propertyId: "prop-1",
+          unitId: "unit-1",
+          tenantName: "Taylor Tenant",
+          propertyLabel: "Harbour View",
+          unitLabel: "Unit 101",
+          title: "Broken heater",
+          description: "Heat is not turning on.",
+          category: "HVAC",
+          priority: "urgent",
+          status: "completed",
+          cost: {
+            actualCostCents: 24000,
+            currency: "CAD",
+            linkedExpenseStatus: "linked",
+          },
+          expenseLink: {
+            status: "linked",
+            expenseId: "expense-1",
+          },
+          createdAt: 100,
+          updatedAt: 200,
+          statusHistory: [],
+        },
+        {
+          id: "maint-2",
+          tenantId: "tenant-2",
+          landlordId: "landlord-1",
+          propertyId: "prop-1",
+          unitId: "unit-2",
+          tenantName: "Jordan Tenant",
+          propertyLabel: "Harbour View",
+          unitLabel: "Unit 102",
+          title: "Leaky pipe",
+          description: "Pipe is dripping behind the vanity.",
+          category: "PLUMBING",
+          priority: "normal",
+          status: "scheduled",
+          cost: {
+            actualCostCents: 18000,
+            currency: "CAD",
+            linkedExpenseStatus: "not_linked",
+          },
+          createdAt: 100,
+          updatedAt: 200,
+          statusHistory: [],
+        },
+        {
+          id: "maint-3",
+          tenantId: "tenant-3",
+          landlordId: "landlord-1",
+          propertyId: "prop-2",
+          unitId: "unit-8",
+          tenantName: "Morgan Tenant",
+          propertyLabel: "Maple Court",
+          unitLabel: "Unit 8",
+          title: "Hall light out",
+          description: "Shared hallway light is out.",
+          category: "ELECTRICAL",
+          priority: "low",
+          status: "completed",
+          followUpRequired: true,
+          resolutionStatus: "follow_up_required",
+          reopenedAt: Date.UTC(2026, 3, 16, 10, 0),
+          createdAt: 100,
+          updatedAt: 200,
+          statusHistory: [],
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/maintenance/maint-1"]}>
+        <Routes>
+          <Route path="/maintenance/:id" element={<MaintenanceRequestsPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findAllByText(/Harbour View/i)).not.toHaveLength(0);
+    expect(screen.getAllByText(/Maple Court/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Unit-level activity/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Unit 101/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Unit 102/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Reopened \/ escalated/i).length).toBeGreaterThan(0);
+  });
 });

--- a/rentchain-frontend/src/pages/MaintenanceRequestsPage.tsx
+++ b/rentchain-frontend/src/pages/MaintenanceRequestsPage.tsx
@@ -21,6 +21,7 @@ import { colors, radius, spacing, text } from "../styles/tokens";
 import { buildMaintenanceLifecycleView, buildMaintenanceWorkspaceState } from "./maintenanceWorkspaceState";
 import { buildMaintenanceAssignmentRoutingView } from "./maintenanceAssignmentRoutingState";
 import { buildMaintenanceConfirmationAccessView } from "./maintenanceConfirmationAccessState";
+import { buildMaintenancePortfolioCostRollupView } from "./maintenancePortfolioCostRollupState";
 import { buildMaintenanceCostView } from "./maintenanceCostState";
 import { buildMaintenanceReopenEscalationView } from "./maintenanceReopenEscalationState";
 import { buildMaintenanceServiceExecutionView } from "./maintenanceServiceExecutionState";
@@ -162,8 +163,8 @@ export default function MaintenanceRequestsPage() {
       const nextItems = Array.isArray(requestsRes?.items)
         ? requestsRes.items
         : Array.isArray((requestsRes as any)?.data)
-        ? (requestsRes as any).data
-        : [];
+          ? (requestsRes as any).data
+          : [];
       const acceptedInvites = Array.isArray(invites)
         ? invites.filter((invite) => invite.status === "accepted" && invite.acceptedByUserId)
         : [];
@@ -450,6 +451,7 @@ export default function MaintenanceRequestsPage() {
   );
   const selectedCost = React.useMemo(() => (selected ? buildMaintenanceCostView(selected, "landlord") : null), [selected]);
   const calendarEvents = React.useMemo(() => buildMaintenanceSchedulingCalendarEvents(items), [items]);
+  const portfolioRollup = React.useMemo(() => buildMaintenancePortfolioCostRollupView(items), [items]);
   const calendarDays = React.useMemo(() => buildCalendarDays(calendarMonth), [calendarMonth]);
   const calendarEventMap = React.useMemo(() => {
     const next = new Map<string, typeof calendarEvents>();
@@ -578,6 +580,10 @@ export default function MaintenanceRequestsPage() {
             { label: "Need review", value: needsReview },
             { label: "Active jobs", value: activeJobs },
             { label: "Needs attention", value: workspaceView.counts.needs_attention },
+            { label: "Recorded maintenance cost", value: fmtMoney(portfolioRollup.totalRecordedCostCents) },
+            { label: "Expense linked", value: fmtMoney(portfolioRollup.totalLinkedExpenseCostCents) },
+            { label: "Unlinked cost", value: fmtMoney(portfolioRollup.totalUnlinkedCostCents) },
+            { label: "Properties in view", value: portfolioRollup.propertyCount },
           ].map((item) => (
             <div
               key={item.label}
@@ -624,6 +630,135 @@ export default function MaintenanceRequestsPage() {
               </option>
             ))}
           </select>
+        </div>
+      </Card>
+
+      <Card elevated>
+        <div style={{ display: "grid", gap: spacing.md }}>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "center", flexWrap: "wrap" }}>
+            <div>
+              <div style={{ fontWeight: 800, color: text.primary }}>Property insights</div>
+              <div style={{ color: text.muted, marginTop: 4 }}>{portfolioRollup.summaryDescription}</div>
+            </div>
+          </div>
+          {!portfolioRollup.propertySummaries.length ? (
+            <div style={{ color: text.muted }}>Property-level maintenance rollups will appear here when requests are in view.</div>
+          ) : (
+            <div style={{ display: "grid", gap: spacing.sm }}>
+              {portfolioRollup.nextSteps.length ? (
+                <div
+                  style={{
+                    border: `1px solid ${colors.border}`,
+                    borderRadius: radius.md,
+                    padding: "10px 12px",
+                    background: colors.panel,
+                    display: "grid",
+                    gap: 6,
+                  }}
+                >
+                  <div style={{ fontWeight: 700, color: text.primary }}>{portfolioRollup.summaryTitle}</div>
+                  {portfolioRollup.nextSteps.map((step) => (
+                    <div key={step} style={{ color: text.secondary }}>
+                      {step}
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+              {portfolioRollup.propertySummaries.map((property) => (
+                <div
+                  key={property.propertyId}
+                  style={{
+                    border: `1px solid ${colors.border}`,
+                    borderRadius: radius.md,
+                    padding: "12px 14px",
+                    background: colors.panel,
+                    display: "grid",
+                    gap: 10,
+                  }}
+                >
+                  <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+                    <div>
+                      <div style={{ fontWeight: 800, color: text.primary }}>{property.propertyLabel}</div>
+                      <div style={{ color: text.muted, marginTop: 4 }}>
+                        {property.requestCount} request{property.requestCount === 1 ? "" : "s"} in view
+                      </div>
+                    </div>
+                    <div style={{ color: text.primary, fontWeight: 800 }}>
+                      {fmtMoney(property.totalRecordedCostCents)}
+                    </div>
+                  </div>
+                  <div style={{ display: "grid", gap: 10, gridTemplateColumns: "repeat(auto-fit, minmax(130px, 1fr))" }}>
+                    <div>
+                      <div style={{ color: text.muted, fontSize: 12 }}>Recorded cost</div>
+                      <div style={{ color: text.primary, fontWeight: 700, marginTop: 6 }}>
+                        {fmtMoney(property.totalRecordedCostCents)}
+                      </div>
+                    </div>
+                    <div>
+                      <div style={{ color: text.muted, fontSize: 12 }}>Expense linked</div>
+                      <div style={{ color: text.primary, fontWeight: 700, marginTop: 6 }}>
+                        {fmtMoney(property.totalLinkedExpenseCostCents)}
+                      </div>
+                    </div>
+                    <div>
+                      <div style={{ color: text.muted, fontSize: 12 }}>Unlinked cost</div>
+                      <div style={{ color: text.primary, fontWeight: 700, marginTop: 6 }}>
+                        {fmtMoney(property.totalUnlinkedCostCents)}
+                      </div>
+                    </div>
+                    <div>
+                      <div style={{ color: text.muted, fontSize: 12 }}>Open requests</div>
+                      <div style={{ color: text.primary, fontWeight: 700, marginTop: 6 }}>{property.openCount}</div>
+                    </div>
+                    <div>
+                      <div style={{ color: text.muted, fontSize: 12 }}>In progress</div>
+                      <div style={{ color: text.primary, fontWeight: 700, marginTop: 6 }}>{property.inProgressCount}</div>
+                    </div>
+                    <div>
+                      <div style={{ color: text.muted, fontSize: 12 }}>Completed / closed</div>
+                      <div style={{ color: text.primary, fontWeight: 700, marginTop: 6 }}>{property.completedCount}</div>
+                    </div>
+                    <div>
+                      <div style={{ color: text.muted, fontSize: 12 }}>Reopened / escalated</div>
+                      <div style={{ color: text.primary, fontWeight: 700, marginTop: 6 }}>
+                        {property.reopenedOrEscalatedCount}
+                      </div>
+                    </div>
+                  </div>
+                  <div style={{ display: "grid", gap: 6 }}>
+                    <div style={{ fontWeight: 700, color: text.primary }}>Next step</div>
+                    {property.nextActions.map((step) => (
+                      <div key={step} style={{ color: text.secondary }}>
+                        {step}
+                      </div>
+                    ))}
+                  </div>
+                  {property.unitSummaries.length ? (
+                    <div style={{ display: "grid", gap: 6 }}>
+                      <div style={{ fontWeight: 700, color: text.primary }}>Unit-level activity</div>
+                      {property.unitSummaries.slice(0, 3).map((unit) => (
+                        <div
+                          key={`${property.propertyId}-${unit.unitId || unit.unitLabel}`}
+                          style={{
+                            display: "grid",
+                            gap: 6,
+                            gridTemplateColumns: "minmax(0, 1.5fr) repeat(4, minmax(0, 1fr))",
+                            color: text.secondary,
+                          }}
+                        >
+                          <div style={{ fontWeight: 600, color: text.primary }}>{unit.unitLabel}</div>
+                          <div>{unit.activityCount} activity</div>
+                          <div>{unit.openCount} open</div>
+                          <div>{unit.reopenedOrEscalatedCount} follow-up</div>
+                          <div>{fmtMoney(unit.recordedCostCents)}</div>
+                        </div>
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+              ))}
+            </div>
+          )}
         </div>
       </Card>
 

--- a/rentchain-frontend/src/pages/maintenancePortfolioCostRollupState.test.ts
+++ b/rentchain-frontend/src/pages/maintenancePortfolioCostRollupState.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import type { MaintenanceWorkflowItem } from "../api/maintenanceWorkflowApi";
+import { buildMaintenancePortfolioCostRollupView } from "./maintenancePortfolioCostRollupState";
+
+function makeItem(overrides: Partial<MaintenanceWorkflowItem>): MaintenanceWorkflowItem {
+  return {
+    id: "maint-1",
+    tenantId: "tenant-1",
+    landlordId: "landlord-1",
+    propertyId: "prop-1",
+    unitId: "unit-1",
+    propertyLabel: "Harbour View",
+    unitLabel: "Unit 101",
+    title: "Leaky faucet",
+    description: "Kitchen sink is leaking",
+    category: "PLUMBING",
+    priority: "normal",
+    status: "submitted",
+    createdAt: 100,
+    updatedAt: 200,
+    ...overrides,
+  };
+}
+
+describe("maintenance portfolio cost rollup state", () => {
+  it("summarizes property-level recorded, linked, and unlinked cost totals", () => {
+    const view = buildMaintenancePortfolioCostRollupView([
+      makeItem({
+        id: "maint-1",
+        status: "completed",
+        cost: { actualCostCents: 24000, linkedExpenseStatus: "linked", currency: "CAD" },
+        expenseLink: { status: "linked", expenseId: "expense-1" },
+      }),
+      makeItem({
+        id: "maint-2",
+        unitId: "unit-2",
+        unitLabel: "Unit 102",
+        status: "completed",
+        cost: { actualCostCents: 18000, linkedExpenseStatus: "not_linked", currency: "CAD" },
+      }),
+    ]);
+
+    expect(view.propertyCount).toBe(1);
+    expect(view.totalRecordedCostCents).toBe(42000);
+    expect(view.totalLinkedExpenseCostCents).toBe(24000);
+    expect(view.totalUnlinkedCostCents).toBe(18000);
+    expect(view.unlinkedRecordedCostCount).toBe(1);
+    expect(view.propertySummaries[0]?.unitSummaries).toHaveLength(2);
+  });
+
+  it("tracks open, in-progress, completed, and reopened attention counts", () => {
+    const view = buildMaintenancePortfolioCostRollupView([
+      makeItem({ id: "maint-1", status: "submitted" }),
+      makeItem({ id: "maint-2", status: "scheduled" }),
+      makeItem({ id: "maint-3", status: "completed" }),
+      makeItem({
+        id: "maint-4",
+        status: "completed",
+        reopenedAt: Date.UTC(2026, 3, 20, 10, 0),
+        followUpRequired: true,
+        resolutionStatus: "follow_up_required",
+      }),
+    ]);
+
+    expect(view.openCount).toBe(2);
+    expect(view.inProgressCount).toBe(1);
+    expect(view.completedCount).toBe(2);
+    expect(view.reopenedOrEscalatedCount).toBe(1);
+    expect(view.nextSteps.join(" ")).toMatch(/reopened issues/i);
+  });
+
+  it("splits summaries by property and sorts the highest-cost property first", () => {
+    const view = buildMaintenancePortfolioCostRollupView([
+      makeItem({
+        id: "maint-1",
+        propertyId: "prop-1",
+        propertyLabel: "Harbour View",
+        cost: { actualCostCents: 12000, linkedExpenseStatus: "not_linked", currency: "CAD" },
+        status: "completed",
+      }),
+      makeItem({
+        id: "maint-2",
+        propertyId: "prop-2",
+        propertyLabel: "Maple Court",
+        cost: { actualCostCents: 48000, linkedExpenseStatus: "linked", currency: "CAD" },
+        expenseLink: { status: "linked", expenseId: "expense-2" },
+        status: "completed",
+      }),
+    ]);
+
+    expect(view.propertyCount).toBe(2);
+    expect(view.propertySummaries[0]?.propertyLabel).toBe("Maple Court");
+    expect(view.propertySummaries[1]?.propertyLabel).toBe("Harbour View");
+  });
+});

--- a/rentchain-frontend/src/pages/maintenancePortfolioCostRollupState.ts
+++ b/rentchain-frontend/src/pages/maintenancePortfolioCostRollupState.ts
@@ -1,0 +1,305 @@
+import type { MaintenanceWorkflowItem } from "../api/maintenanceWorkflowApi";
+
+export type MaintenancePortfolioUnitSummary = {
+  unitId: string | null;
+  unitLabel: string;
+  activityCount: number;
+  openCount: number;
+  inProgressCount: number;
+  reopenedOrEscalatedCount: number;
+  recordedCostCents: number;
+};
+
+export type MaintenancePortfolioPropertySummary = {
+  propertyId: string;
+  propertyLabel: string;
+  totalRecordedCostCents: number;
+  totalLinkedExpenseCostCents: number;
+  totalUnlinkedCostCents: number;
+  requestCount: number;
+  openCount: number;
+  inProgressCount: number;
+  completedCount: number;
+  reopenedOrEscalatedCount: number;
+  linkedExpenseCount: number;
+  unlinkedRecordedCostCount: number;
+  nextActions: string[];
+  insightFlags: Array<"has_unlinked_cost" | "has_open_work" | "has_reopened_attention">;
+  unitSummaries: MaintenancePortfolioUnitSummary[];
+};
+
+export type MaintenancePortfolioCostRollupView = {
+  propertyCount: number;
+  totalRecordedCostCents: number;
+  totalLinkedExpenseCostCents: number;
+  totalUnlinkedCostCents: number;
+  requestCount: number;
+  openCount: number;
+  inProgressCount: number;
+  completedCount: number;
+  reopenedOrEscalatedCount: number;
+  linkedExpenseCount: number;
+  unlinkedRecordedCostCount: number;
+  summaryTitle: string;
+  summaryDescription: string;
+  nextSteps: string[];
+  insightFlags: Array<"has_unlinked_cost" | "has_open_work" | "has_reopened_attention">;
+  propertySummaries: MaintenancePortfolioPropertySummary[];
+};
+
+function normalizedStatus(item: MaintenanceWorkflowItem) {
+  return String(item.status || "").trim().toLowerCase();
+}
+
+function propertyLabel(item: MaintenanceWorkflowItem) {
+  return String(item.propertyLabel || item.propertyId || "Unassigned property").trim() || "Unassigned property";
+}
+
+function unitLabel(item: MaintenanceWorkflowItem) {
+  return String(item.unitLabel || item.unitId || "General property area").trim() || "General property area";
+}
+
+function recordedCostCents(item: MaintenanceWorkflowItem) {
+  return typeof item.cost?.actualCostCents === "number" ? Math.max(0, item.cost.actualCostCents) : 0;
+}
+
+function hasLinkedExpense(item: MaintenanceWorkflowItem) {
+  return item.expenseLink?.status === "linked" || item.cost?.linkedExpenseStatus === "linked";
+}
+
+function isOpenRequest(item: MaintenanceWorkflowItem) {
+  return !["completed", "cancelled"].includes(normalizedStatus(item));
+}
+
+function isInProgressRequest(item: MaintenanceWorkflowItem) {
+  return ["assigned", "scheduled", "in_progress", "blocked"].includes(normalizedStatus(item));
+}
+
+function isCompletedRequest(item: MaintenanceWorkflowItem) {
+  return normalizedStatus(item) === "completed";
+}
+
+function isReopenedOrEscalated(item: MaintenanceWorkflowItem) {
+  return (
+    typeof item.reopenedAt === "number" ||
+    item.followUpRequired === true ||
+    item.resolutionStatus === "follow_up_required" ||
+    item.tenantSignoffStatus === "declined" ||
+    item.reworkReview?.status === "follow_up_required" ||
+    item.reworkReview?.tenantSignoffStatus === "declined"
+  );
+}
+
+function unitKey(item: MaintenanceWorkflowItem) {
+  return String(item.unitId || item.unitLabel || "__general__");
+}
+
+function sortUnits(units: MaintenancePortfolioUnitSummary[]) {
+  return [...units].sort((a, b) => {
+    if (b.activityCount !== a.activityCount) return b.activityCount - a.activityCount;
+    if (b.recordedCostCents !== a.recordedCostCents) return b.recordedCostCents - a.recordedCostCents;
+    return a.unitLabel.localeCompare(b.unitLabel);
+  });
+}
+
+function sortProperties(properties: MaintenancePortfolioPropertySummary[]) {
+  return [...properties].sort((a, b) => {
+    if (b.totalRecordedCostCents !== a.totalRecordedCostCents) return b.totalRecordedCostCents - a.totalRecordedCostCents;
+    if (b.reopenedOrEscalatedCount !== a.reopenedOrEscalatedCount) return b.reopenedOrEscalatedCount - a.reopenedOrEscalatedCount;
+    if (b.openCount !== a.openCount) return b.openCount - a.openCount;
+    return a.propertyLabel.localeCompare(b.propertyLabel);
+  });
+}
+
+export function buildMaintenancePortfolioCostRollupView(
+  items: MaintenanceWorkflowItem[]
+): MaintenancePortfolioCostRollupView {
+  const propertyMap = new Map<
+    string,
+    {
+      propertyId: string;
+      propertyLabel: string;
+      totalRecordedCostCents: number;
+      totalLinkedExpenseCostCents: number;
+      totalUnlinkedCostCents: number;
+      requestCount: number;
+      openCount: number;
+      inProgressCount: number;
+      completedCount: number;
+      reopenedOrEscalatedCount: number;
+      linkedExpenseCount: number;
+      unlinkedRecordedCostCount: number;
+      unitMap: Map<string, MaintenancePortfolioUnitSummary>;
+    }
+  >();
+
+  let totalRecordedCostCents = 0;
+  let totalLinkedExpenseCostCents = 0;
+  let totalUnlinkedCostCents = 0;
+  let openCount = 0;
+  let inProgressCount = 0;
+  let completedCount = 0;
+  let reopenedOrEscalatedCount = 0;
+  let linkedExpenseCount = 0;
+  let unlinkedRecordedCostCount = 0;
+
+  items.forEach((item) => {
+    const propertyId = String(item.propertyId || "__unassigned__");
+    const nextProperty =
+      propertyMap.get(propertyId) ||
+      {
+        propertyId,
+        propertyLabel: propertyLabel(item),
+        totalRecordedCostCents: 0,
+        totalLinkedExpenseCostCents: 0,
+        totalUnlinkedCostCents: 0,
+        requestCount: 0,
+        openCount: 0,
+        inProgressCount: 0,
+        completedCount: 0,
+        reopenedOrEscalatedCount: 0,
+        linkedExpenseCount: 0,
+        unlinkedRecordedCostCount: 0,
+        unitMap: new Map<string, MaintenancePortfolioUnitSummary>(),
+      };
+
+    nextProperty.requestCount += 1;
+    const recordedCost = recordedCostCents(item);
+    const linkedExpense = hasLinkedExpense(item);
+    const reopened = isReopenedOrEscalated(item);
+    const isOpen = isOpenRequest(item);
+    const isProgress = isInProgressRequest(item);
+    const isCompleted = isCompletedRequest(item);
+
+    nextProperty.totalRecordedCostCents += recordedCost;
+    totalRecordedCostCents += recordedCost;
+
+    if (linkedExpense && recordedCost > 0) {
+      nextProperty.totalLinkedExpenseCostCents += recordedCost;
+      totalLinkedExpenseCostCents += recordedCost;
+      nextProperty.linkedExpenseCount += 1;
+      linkedExpenseCount += 1;
+    } else if (recordedCost > 0) {
+      nextProperty.totalUnlinkedCostCents += recordedCost;
+      totalUnlinkedCostCents += recordedCost;
+      nextProperty.unlinkedRecordedCostCount += 1;
+      unlinkedRecordedCostCount += 1;
+    }
+
+    if (isOpen) {
+      nextProperty.openCount += 1;
+      openCount += 1;
+    }
+    if (isProgress) {
+      nextProperty.inProgressCount += 1;
+      inProgressCount += 1;
+    }
+    if (isCompleted) {
+      nextProperty.completedCount += 1;
+      completedCount += 1;
+    }
+    if (reopened) {
+      nextProperty.reopenedOrEscalatedCount += 1;
+      reopenedOrEscalatedCount += 1;
+    }
+
+    const currentUnit =
+      nextProperty.unitMap.get(unitKey(item)) || {
+        unitId: item.unitId || null,
+        unitLabel: unitLabel(item),
+        activityCount: 0,
+        openCount: 0,
+        inProgressCount: 0,
+        reopenedOrEscalatedCount: 0,
+        recordedCostCents: 0,
+      };
+    currentUnit.activityCount += 1;
+    currentUnit.recordedCostCents += recordedCost;
+    if (isOpen) currentUnit.openCount += 1;
+    if (isProgress) currentUnit.inProgressCount += 1;
+    if (reopened) currentUnit.reopenedOrEscalatedCount += 1;
+    nextProperty.unitMap.set(unitKey(item), currentUnit);
+    propertyMap.set(propertyId, nextProperty);
+  });
+
+  const propertySummaries = sortProperties(
+    Array.from(propertyMap.values()).map((property) => {
+      const insightFlags: MaintenancePortfolioPropertySummary["insightFlags"] = [];
+      const nextActions: string[] = [];
+      if (property.totalUnlinkedCostCents > 0) {
+        insightFlags.push("has_unlinked_cost");
+        nextActions.push("Review recorded maintenance costs that are not linked to expenses yet.");
+      }
+      if (property.openCount > 0) {
+        insightFlags.push("has_open_work");
+        nextActions.push("Keep open maintenance work moving so requests do not linger at the property level.");
+      }
+      if (property.reopenedOrEscalatedCount > 0) {
+        insightFlags.push("has_reopened_attention");
+        nextActions.push("Review reopened or escalated requests to see where follow-up is recurring.");
+      }
+      if (!nextActions.length) {
+        nextActions.push("This property’s maintenance record is currently in a stable tracked state.");
+      }
+
+      return {
+        propertyId: property.propertyId,
+        propertyLabel: property.propertyLabel,
+        totalRecordedCostCents: property.totalRecordedCostCents,
+        totalLinkedExpenseCostCents: property.totalLinkedExpenseCostCents,
+        totalUnlinkedCostCents: property.totalUnlinkedCostCents,
+        requestCount: property.requestCount,
+        openCount: property.openCount,
+        inProgressCount: property.inProgressCount,
+        completedCount: property.completedCount,
+        reopenedOrEscalatedCount: property.reopenedOrEscalatedCount,
+        linkedExpenseCount: property.linkedExpenseCount,
+        unlinkedRecordedCostCount: property.unlinkedRecordedCostCount,
+        nextActions,
+        insightFlags,
+        unitSummaries: sortUnits(Array.from(property.unitMap.values())),
+      };
+    })
+  );
+
+  const insightFlags: MaintenancePortfolioCostRollupView["insightFlags"] = [];
+  const nextSteps: string[] = [];
+  if (totalUnlinkedCostCents > 0) {
+    insightFlags.push("has_unlinked_cost");
+    nextSteps.push("Review recorded maintenance cost that still needs an expense link.");
+  }
+  if (openCount > 0) {
+    insightFlags.push("has_open_work");
+    nextSteps.push("Use the request list to move open maintenance work through scheduling, service, and closure.");
+  }
+  if (reopenedOrEscalatedCount > 0) {
+    insightFlags.push("has_reopened_attention");
+    nextSteps.push("Pay attention to properties with repeated follow-up so reopened issues stay visible.");
+  }
+  if (!nextSteps.length) {
+    nextSteps.push("The current maintenance portfolio in view is recorded and operationally stable.");
+  }
+
+  return {
+    propertyCount: propertySummaries.length,
+    totalRecordedCostCents,
+    totalLinkedExpenseCostCents,
+    totalUnlinkedCostCents,
+    requestCount: items.length,
+    openCount,
+    inProgressCount,
+    completedCount,
+    reopenedOrEscalatedCount,
+    linkedExpenseCount,
+    unlinkedRecordedCostCount,
+    summaryTitle:
+      propertySummaries.length > 0 ? "Maintenance cost and property insights" : "No maintenance portfolio activity in view",
+    summaryDescription:
+      propertySummaries.length > 0
+        ? `${propertySummaries.length} propert${propertySummaries.length === 1 ? "y" : "ies"} currently have visible maintenance history in this workspace.`
+        : "Property-level maintenance rollups will appear here once requests are visible in the landlord maintenance workspace.",
+    nextSteps,
+    insightFlags,
+    propertySummaries,
+  };
+}


### PR DESCRIPTION
## Summary
Adds a landlord-facing maintenance portfolio rollup layer that turns request-level maintenance activity into simple property-level cost and workload insights.

Landlords can now see which properties are driving the most maintenance spend, how much recorded cost is already linked to expenses, and which properties or units still have the most open or repeated issues.

## What Changed
- Added a pure `maintenancePortfolioCostRollupState` helper for property-level maintenance rollups
- Added maintenance summary cards for recorded cost, linked expense cost, unlinked cost, and properties in view
- Added a `Property insights` section to the landlord maintenance workspace
- Added property-level request counts for:
  - open requests
  - in-progress work
  - completed / closed requests
  - reopened / escalated requests
- Added lightweight unit-level activity summaries where current request data supports it
- Added targeted frontend tests for rollup logic and landlord rendering

## Scope Notes
- Landlord-only visibility
- No backend changes required
- No tenant cost exposure
- No accounting, tax, forecasting, or reporting expansion

## Validation
- Frontend targeted tests passed
- Frontend build passed