### PR TITLE
feat(maintenance): add property-level financial intelligence v1

### DIFF
--- a/rentchain-frontend/src/pages/MaintenanceRequestsPage.test.tsx
+++ b/rentchain-frontend/src/pages/MaintenanceRequestsPage.test.tsx
@@ -216,7 +216,11 @@ describe("landlord maintenance workspace", () => {
 
     expect((await screen.findAllByText(/Reopen \/ escalation/i)).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Escalated/i).length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/The bedroom is cold again after the return visit/i).length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText((_, element) =>
+        Boolean(element?.textContent?.match(/The bedroom is cold again after the return visit/i))
+      ).length
+    ).toBeGreaterThan(0);
   });
 
   it("records a landlord start-of-service update from the execution workspace", async () => {
@@ -530,6 +534,14 @@ describe("landlord maintenance workspace", () => {
 
     expect(await screen.findAllByText(/Harbour View/i)).not.toHaveLength(0);
     expect(screen.getAllByText(/Maple Court/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Property financial intelligence/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Top maintenance cost/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Top follow-up pressure/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Unlinked cost burden/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Needs expense review/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Some follow-up pressure/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/High maintenance load/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Operational burden/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Unit-level activity/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Unit 101/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Unit 102/i).length).toBeGreaterThan(0);

--- a/rentchain-frontend/src/pages/MaintenanceRequestsPage.tsx
+++ b/rentchain-frontend/src/pages/MaintenanceRequestsPage.tsx
@@ -23,6 +23,7 @@ import { buildMaintenanceAssignmentRoutingView } from "./maintenanceAssignmentRo
 import { buildMaintenanceConfirmationAccessView } from "./maintenanceConfirmationAccessState";
 import { buildMaintenancePortfolioCostRollupView } from "./maintenancePortfolioCostRollupState";
 import { buildMaintenanceCostView } from "./maintenanceCostState";
+import { buildPropertyFinancialIntelligenceView } from "./propertyFinancialIntelligenceState";
 import { buildMaintenanceReopenEscalationView } from "./maintenanceReopenEscalationState";
 import { buildMaintenanceServiceExecutionView } from "./maintenanceServiceExecutionState";
 import { buildMaintenanceResolutionVerificationView } from "./maintenanceResolutionVerificationState";
@@ -452,6 +453,7 @@ export default function MaintenanceRequestsPage() {
   const selectedCost = React.useMemo(() => (selected ? buildMaintenanceCostView(selected, "landlord") : null), [selected]);
   const calendarEvents = React.useMemo(() => buildMaintenanceSchedulingCalendarEvents(items), [items]);
   const portfolioRollup = React.useMemo(() => buildMaintenancePortfolioCostRollupView(items), [items]);
+  const propertyIntelligence = React.useMemo(() => buildPropertyFinancialIntelligenceView(items), [items]);
   const calendarDays = React.useMemo(() => buildCalendarDays(calendarMonth), [calendarMonth]);
   const calendarEventMap = React.useMemo(() => {
     const next = new Map<string, typeof calendarEvents>();
@@ -630,6 +632,164 @@ export default function MaintenanceRequestsPage() {
               </option>
             ))}
           </select>
+        </div>
+      </Card>
+
+      <Card elevated>
+        <div style={{ display: "grid", gap: spacing.md }}>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "center", flexWrap: "wrap" }}>
+            <div>
+              <div style={{ fontWeight: 800, color: text.primary }}>Property financial intelligence</div>
+              <div style={{ color: text.muted, marginTop: 4 }}>{propertyIntelligence.summaryDescription}</div>
+            </div>
+          </div>
+          {!propertyIntelligence.propertySummaries.length ? (
+            <div style={{ color: text.muted }}>Property intelligence will appear here when requests are in view.</div>
+          ) : (
+            <div style={{ display: "grid", gap: spacing.sm }}>
+              <div style={{ display: "grid", gap: 10, gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))" }}>
+                {propertyIntelligence.spotlights.map((spotlight) => (
+                  <div
+                    key={spotlight.label}
+                    style={{
+                      border: `1px solid ${colors.border}`,
+                      borderRadius: radius.md,
+                      padding: "12px 14px",
+                      background: colors.panel,
+                      display: "grid",
+                      gap: 6,
+                    }}
+                  >
+                    <div style={{ color: text.muted, fontSize: 12 }}>{spotlight.label}</div>
+                    <div style={{ color: text.primary, fontWeight: 800 }}>{spotlight.propertyLabel}</div>
+                    <div style={{ color: text.primary, fontWeight: 700 }}>{spotlight.valueLabel}</div>
+                    <div style={{ color: text.secondary }}>{spotlight.supportingLabel}</div>
+                  </div>
+                ))}
+              </div>
+              <div style={{ display: "grid", gap: 10, gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))" }}>
+                {[
+                  { label: "High maintenance load", value: propertyIntelligence.highMaintenanceLoadCount },
+                  { label: "Follow-up heavy", value: propertyIntelligence.followUpHeavyCount },
+                  { label: "Needs expense review", value: propertyIntelligence.expenseReviewCount },
+                ].map((item) => (
+                  <div
+                    key={item.label}
+                    style={{
+                      border: `1px solid ${colors.border}`,
+                      borderRadius: radius.md,
+                      padding: "10px 12px",
+                      background: colors.panel,
+                    }}
+                  >
+                    <div style={{ color: text.muted, fontSize: 12 }}>{item.label}</div>
+                    <div style={{ color: text.primary, fontSize: 24, fontWeight: 800 }}>{item.value}</div>
+                  </div>
+                ))}
+              </div>
+              <div
+                style={{
+                  border: `1px solid ${colors.border}`,
+                  borderRadius: radius.md,
+                  padding: "10px 12px",
+                  background: colors.panel,
+                  display: "grid",
+                  gap: 6,
+                }}
+              >
+                <div style={{ fontWeight: 700, color: text.primary }}>{propertyIntelligence.summaryTitle}</div>
+                {propertyIntelligence.nextSteps.map((step) => (
+                  <div key={step} style={{ color: text.secondary }}>
+                    {step}
+                  </div>
+                ))}
+              </div>
+              <div style={{ display: "grid", gap: 10 }}>
+                {propertyIntelligence.rankedAttention.slice(0, 3).map((property) => (
+                  <div
+                    key={`intelligence-${property.propertyId}`}
+                    style={{
+                      border: `1px solid ${colors.border}`,
+                      borderRadius: radius.md,
+                      padding: "12px 14px",
+                      background: colors.panel,
+                      display: "grid",
+                      gap: 10,
+                    }}
+                  >
+                    <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+                      <div>
+                        <div style={{ fontWeight: 800, color: text.primary }}>{property.propertyLabel}</div>
+                        <div style={{ color: text.muted, marginTop: 4 }}>
+                          {property.maintenanceLoadLabel} • {property.followUpPressureLabel}
+                        </div>
+                      </div>
+                      <div style={{ color: text.primary, fontWeight: 800 }}>{fmtMoney(property.totalRecordedCostCents)}</div>
+                    </div>
+                    {property.attentionFlags.length ? (
+                      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                        {property.attentionFlags.map((flag) => {
+                          const label =
+                            flag === "high_maintenance_load"
+                              ? "High maintenance load"
+                              : flag === "follow_up_heavy"
+                                ? "Follow-up heavy"
+                                : flag === "needs_expense_review"
+                                  ? "Needs expense review"
+                                  : "Cost mostly linked";
+                          return (
+                            <span
+                              key={`${property.propertyId}-${flag}`}
+                              style={{
+                                display: "inline-flex",
+                                alignItems: "center",
+                                padding: "4px 8px",
+                                borderRadius: 999,
+                                background: colors.canvas,
+                                border: `1px solid ${colors.border}`,
+                                color: text.primary,
+                                fontSize: 12,
+                                fontWeight: 700,
+                              }}
+                            >
+                              {label}
+                            </span>
+                          );
+                        })}
+                      </div>
+                    ) : null}
+                    <div style={{ display: "grid", gap: 10, gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))" }}>
+                      <div>
+                        <div style={{ color: text.muted, fontSize: 12 }}>Unlinked maintenance cost</div>
+                        <div style={{ color: text.primary, fontWeight: 700, marginTop: 6 }}>
+                          {fmtMoney(property.totalUnlinkedCostCents)}
+                        </div>
+                      </div>
+                      <div>
+                        <div style={{ color: text.muted, fontSize: 12 }}>Open requests</div>
+                        <div style={{ color: text.primary, fontWeight: 700, marginTop: 6 }}>{property.openCount}</div>
+                      </div>
+                      <div>
+                        <div style={{ color: text.muted, fontSize: 12 }}>Reopened / escalated</div>
+                        <div style={{ color: text.primary, fontWeight: 700, marginTop: 6 }}>
+                          {property.reopenedOrEscalatedCount}
+                        </div>
+                      </div>
+                    </div>
+                    <div style={{ display: "grid", gap: 6 }}>
+                      <div style={{ fontWeight: 700, color: text.primary }}>Operational burden</div>
+                      <div style={{ color: text.secondary }}>{property.unitActivityLabel}</div>
+                      {property.nextSteps.map((step) => (
+                        <div key={step} style={{ color: text.secondary }}>
+                          {step}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
       </Card>
 

--- a/rentchain-frontend/src/pages/propertyFinancialIntelligenceState.test.ts
+++ b/rentchain-frontend/src/pages/propertyFinancialIntelligenceState.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import type { MaintenanceWorkflowItem } from "../api/maintenanceWorkflowApi";
+import { buildPropertyFinancialIntelligenceView } from "./propertyFinancialIntelligenceState";
+
+function makeItem(overrides: Partial<MaintenanceWorkflowItem>): MaintenanceWorkflowItem {
+  return {
+    id: "maint-1",
+    tenantId: "tenant-1",
+    landlordId: "landlord-1",
+    propertyId: "prop-1",
+    unitId: "unit-1",
+    propertyLabel: "Harbour View",
+    unitLabel: "Unit 101",
+    title: "Leaky faucet",
+    description: "Kitchen sink is leaking",
+    category: "PLUMBING",
+    priority: "normal",
+    status: "submitted",
+    createdAt: 100,
+    updatedAt: 200,
+    ...overrides,
+  };
+}
+
+describe("property financial intelligence state", () => {
+  it("derives transparent attention flags from visible maintenance activity", () => {
+    const view = buildPropertyFinancialIntelligenceView([
+      makeItem({
+        id: "maint-1",
+        propertyId: "prop-1",
+        propertyLabel: "Harbour View",
+        status: "scheduled",
+        cost: { actualCostCents: 18000, linkedExpenseStatus: "not_linked", currency: "CAD" },
+      }),
+      makeItem({
+        id: "maint-2",
+        propertyId: "prop-1",
+        propertyLabel: "Harbour View",
+        unitId: "unit-2",
+        unitLabel: "Unit 102",
+        status: "completed",
+        reopenedAt: Date.UTC(2026, 3, 20, 10, 0),
+        followUpRequired: true,
+        resolutionStatus: "follow_up_required",
+      }),
+    ]);
+
+    expect(view.followUpHeavyCount).toBe(1);
+    expect(view.expenseReviewCount).toBe(1);
+    expect(view.rankedAttention[0]?.propertyLabel).toBe("Harbour View");
+    expect(view.rankedAttention[0]?.attentionFlags).toContain("follow_up_heavy");
+    expect(view.rankedAttention[0]?.attentionFlags).toContain("needs_expense_review");
+  });
+
+  it("identifies cost-heavy properties and stable linked-cost properties", () => {
+    const view = buildPropertyFinancialIntelligenceView([
+      makeItem({
+        id: "maint-1",
+        propertyId: "prop-1",
+        propertyLabel: "Harbour View",
+        status: "completed",
+        cost: { actualCostCents: 52000, linkedExpenseStatus: "linked", currency: "CAD" },
+        expenseLink: { status: "linked", expenseId: "expense-1" },
+      }),
+      makeItem({
+        id: "maint-2",
+        propertyId: "prop-2",
+        propertyLabel: "Maple Court",
+        status: "completed",
+        cost: { actualCostCents: 12000, linkedExpenseStatus: "linked", currency: "CAD" },
+        expenseLink: { status: "linked", expenseId: "expense-2" },
+      }),
+    ]);
+
+    expect(view.highMaintenanceLoadCount).toBe(1);
+    expect(view.spotlights[0]?.propertyLabel).toBe("Harbour View");
+    expect(view.propertySummaries.find((item) => item.propertyLabel === "Maple Court")?.attentionFlags).toContain(
+      "cost_mostly_linked"
+    );
+  });
+
+  it("explains which unit carries most visible activity when requests concentrate in one place", () => {
+    const view = buildPropertyFinancialIntelligenceView([
+      makeItem({
+        id: "maint-1",
+        propertyId: "prop-1",
+        propertyLabel: "Harbour View",
+        unitId: "unit-1",
+        unitLabel: "Unit 101",
+      }),
+      makeItem({
+        id: "maint-2",
+        propertyId: "prop-1",
+        propertyLabel: "Harbour View",
+        unitId: "unit-1",
+        unitLabel: "Unit 101",
+      }),
+      makeItem({
+        id: "maint-3",
+        propertyId: "prop-1",
+        propertyLabel: "Harbour View",
+        unitId: "unit-2",
+        unitLabel: "Unit 102",
+      }),
+    ]);
+
+    expect(view.propertySummaries[0]?.topUnitLabel).toBe("Unit 101");
+    expect(view.propertySummaries[0]?.unitActivityLabel).toMatch(/carries most visible maintenance activity/i);
+  });
+});

--- a/rentchain-frontend/src/pages/propertyFinancialIntelligenceState.ts
+++ b/rentchain-frontend/src/pages/propertyFinancialIntelligenceState.ts
@@ -1,0 +1,253 @@
+import type { MaintenanceWorkflowItem } from "../api/maintenanceWorkflowApi";
+import { buildMaintenancePortfolioCostRollupView, type MaintenancePortfolioPropertySummary } from "./maintenancePortfolioCostRollupState";
+
+export type PropertyFinancialIntelligenceFlag =
+  | "high_maintenance_load"
+  | "follow_up_heavy"
+  | "needs_expense_review"
+  | "cost_mostly_linked";
+
+export type PropertyFinancialIntelligenceSummary = {
+  propertyId: string;
+  propertyLabel: string;
+  maintenanceLoad: "high" | "moderate" | "stable";
+  maintenanceLoadLabel: string;
+  followUpPressure: "high" | "moderate" | "low";
+  followUpPressureLabel: string;
+  totalRecordedCostCents: number;
+  totalLinkedCostCents: number;
+  totalUnlinkedCostCents: number;
+  openCount: number;
+  inProgressCount: number;
+  completedCount: number;
+  reopenedOrEscalatedCount: number;
+  topUnitLabel: string | null;
+  unitActivityLabel: string;
+  attentionFlags: PropertyFinancialIntelligenceFlag[];
+  nextSteps: string[];
+};
+
+export type PropertyFinancialIntelligenceSpotlight = {
+  label: string;
+  propertyId: string | null;
+  propertyLabel: string;
+  valueLabel: string;
+  supportingLabel: string;
+};
+
+export type PropertyFinancialIntelligenceView = {
+  summaryTitle: string;
+  summaryDescription: string;
+  nextSteps: string[];
+  highMaintenanceLoadCount: number;
+  followUpHeavyCount: number;
+  expenseReviewCount: number;
+  propertySummaries: PropertyFinancialIntelligenceSummary[];
+  rankedAttention: PropertyFinancialIntelligenceSummary[];
+  spotlights: PropertyFinancialIntelligenceSpotlight[];
+};
+
+function fmtMoney(cents: number) {
+  return new Intl.NumberFormat(undefined, { style: "currency", currency: "CAD" }).format(cents / 100);
+}
+
+function maintenanceLoad(summary: MaintenancePortfolioPropertySummary) {
+  if (summary.openCount >= 2 || summary.requestCount >= 4 || summary.totalRecordedCostCents >= 50000) {
+    return { level: "high" as const, label: "High maintenance load" };
+  }
+  if (summary.openCount >= 1 || summary.requestCount >= 2 || summary.totalRecordedCostCents >= 20000) {
+    return { level: "moderate" as const, label: "Moderate maintenance load" };
+  }
+  return { level: "stable" as const, label: "Stable maintenance load" };
+}
+
+function followUpPressure(summary: MaintenancePortfolioPropertySummary) {
+  if (summary.reopenedOrEscalatedCount >= 2) {
+    return { level: "high" as const, label: "Follow-up heavy" };
+  }
+  if (summary.reopenedOrEscalatedCount >= 1) {
+    return { level: "moderate" as const, label: "Some follow-up pressure" };
+  }
+  return { level: "low" as const, label: "Follow-up pressure is low" };
+}
+
+function describeUnitActivity(summary: MaintenancePortfolioPropertySummary) {
+  const topUnit = summary.unitSummaries[0];
+  if (!topUnit) {
+    return { topUnitLabel: null, label: "Activity is currently spread at the property level." };
+  }
+  if (summary.requestCount <= 1) {
+    return { topUnitLabel: topUnit.unitLabel, label: `${topUnit.unitLabel} is the main visible activity area.` };
+  }
+  const share = topUnit.activityCount / summary.requestCount;
+  if (share >= 0.5) {
+    return { topUnitLabel: topUnit.unitLabel, label: `${topUnit.unitLabel} carries most visible maintenance activity.` };
+  }
+  return { topUnitLabel: topUnit.unitLabel, label: "Activity is spread across multiple units." };
+}
+
+function flagsFor(summary: MaintenancePortfolioPropertySummary): PropertyFinancialIntelligenceFlag[] {
+  const flags: PropertyFinancialIntelligenceFlag[] = [];
+  if (summary.openCount >= 2 || summary.requestCount >= 4 || summary.totalRecordedCostCents >= 50000) {
+    flags.push("high_maintenance_load");
+  }
+  if (summary.reopenedOrEscalatedCount >= 1) {
+    flags.push("follow_up_heavy");
+  }
+  if (summary.totalUnlinkedCostCents > 0) {
+    flags.push("needs_expense_review");
+  }
+  if (
+    summary.totalRecordedCostCents > 0 &&
+    summary.totalLinkedExpenseCostCents === summary.totalRecordedCostCents &&
+    summary.totalUnlinkedCostCents === 0
+  ) {
+    flags.push("cost_mostly_linked");
+  }
+  return flags;
+}
+
+function nextStepsFor(summary: MaintenancePortfolioPropertySummary, flags: PropertyFinancialIntelligenceFlag[]) {
+  const steps: string[] = [];
+  if (flags.includes("follow_up_heavy")) {
+    steps.push("Review reopened or escalated requests to see whether follow-up work is repeating at this property.");
+  }
+  if (flags.includes("needs_expense_review")) {
+    steps.push("Review recorded maintenance cost that still needs to be linked to an expense record.");
+  }
+  if (flags.includes("high_maintenance_load")) {
+    steps.push("Prioritize open work at this property so operational pressure does not keep building.");
+  }
+  if (!steps.length) {
+    steps.push("This property’s visible maintenance activity is currently in a stable tracked state.");
+  }
+  return steps;
+}
+
+function sortAttention(items: PropertyFinancialIntelligenceSummary[]) {
+  return [...items].sort((a, b) => {
+    if (b.reopenedOrEscalatedCount !== a.reopenedOrEscalatedCount) return b.reopenedOrEscalatedCount - a.reopenedOrEscalatedCount;
+    if (b.openCount !== a.openCount) return b.openCount - a.openCount;
+    if (b.totalUnlinkedCostCents !== a.totalUnlinkedCostCents) return b.totalUnlinkedCostCents - a.totalUnlinkedCostCents;
+    if (b.totalRecordedCostCents !== a.totalRecordedCostCents) return b.totalRecordedCostCents - a.totalRecordedCostCents;
+    return a.propertyLabel.localeCompare(b.propertyLabel);
+  });
+}
+
+function buildSpotlight(
+  label: string,
+  summaries: PropertyFinancialIntelligenceSummary[],
+  getValue: (item: PropertyFinancialIntelligenceSummary) => number,
+  formatValue: (item: PropertyFinancialIntelligenceSummary) => string,
+  emptyLabel: string,
+  supportingLabel: (item: PropertyFinancialIntelligenceSummary) => string
+): PropertyFinancialIntelligenceSpotlight {
+  const winner = [...summaries].sort((a, b) => getValue(b) - getValue(a) || a.propertyLabel.localeCompare(b.propertyLabel))[0] || null;
+  if (!winner || getValue(winner) <= 0) {
+    return {
+      label,
+      propertyId: null,
+      propertyLabel: "No property in view",
+      valueLabel: emptyLabel,
+      supportingLabel: "Visible maintenance requests will populate this insight.",
+    };
+  }
+  return {
+    label,
+    propertyId: winner.propertyId,
+    propertyLabel: winner.propertyLabel,
+    valueLabel: formatValue(winner),
+    supportingLabel: supportingLabel(winner),
+  };
+}
+
+export function buildPropertyFinancialIntelligenceView(
+  items: MaintenanceWorkflowItem[]
+): PropertyFinancialIntelligenceView {
+  const rollup = buildMaintenancePortfolioCostRollupView(items);
+
+  const propertySummaries = rollup.propertySummaries.map((summary) => {
+    const load = maintenanceLoad(summary);
+    const pressure = followUpPressure(summary);
+    const unitActivity = describeUnitActivity(summary);
+    const attentionFlags = flagsFor(summary);
+
+    return {
+      propertyId: summary.propertyId,
+      propertyLabel: summary.propertyLabel,
+      maintenanceLoad: load.level,
+      maintenanceLoadLabel: load.label,
+      followUpPressure: pressure.level,
+      followUpPressureLabel: pressure.label,
+      totalRecordedCostCents: summary.totalRecordedCostCents,
+      totalLinkedCostCents: summary.totalLinkedExpenseCostCents,
+      totalUnlinkedCostCents: summary.totalUnlinkedCostCents,
+      openCount: summary.openCount,
+      inProgressCount: summary.inProgressCount,
+      completedCount: summary.completedCount,
+      reopenedOrEscalatedCount: summary.reopenedOrEscalatedCount,
+      topUnitLabel: unitActivity.topUnitLabel,
+      unitActivityLabel: unitActivity.label,
+      attentionFlags,
+      nextSteps: nextStepsFor(summary, attentionFlags),
+    };
+  });
+
+  const rankedAttention = sortAttention(propertySummaries);
+  const highMaintenanceLoadCount = propertySummaries.filter((item) => item.attentionFlags.includes("high_maintenance_load")).length;
+  const followUpHeavyCount = propertySummaries.filter((item) => item.attentionFlags.includes("follow_up_heavy")).length;
+  const expenseReviewCount = propertySummaries.filter((item) => item.attentionFlags.includes("needs_expense_review")).length;
+
+  const nextSteps: string[] = [];
+  if (followUpHeavyCount > 0) {
+    nextSteps.push("Review properties with repeated follow-up first so closed work does not quietly come back.");
+  }
+  if (expenseReviewCount > 0) {
+    nextSteps.push("Link recorded maintenance costs into expenses where they are still untracked.");
+  }
+  if (highMaintenanceLoadCount > 0) {
+    nextSteps.push("Watch cost-heavy or open-heavy properties for rising operational pressure.");
+  }
+  if (!nextSteps.length) {
+    nextSteps.push("Visible properties are currently in a stable maintenance state with no strong attention flags.");
+  }
+
+  return {
+    summaryTitle: propertySummaries.length ? "Property financial intelligence" : "No property intelligence available yet",
+    summaryDescription: propertySummaries.length
+      ? "Property-level maintenance intelligence highlights cost burden, follow-up pressure, and expense review needs from visible requests."
+      : "Property intelligence will appear here once maintenance requests are visible in the landlord workspace.",
+    nextSteps,
+    highMaintenanceLoadCount,
+    followUpHeavyCount,
+    expenseReviewCount,
+    propertySummaries,
+    rankedAttention,
+    spotlights: [
+      buildSpotlight(
+        "Top maintenance cost",
+        propertySummaries,
+        (item) => item.totalRecordedCostCents,
+        (item) => fmtMoney(item.totalRecordedCostCents),
+        "-",
+        (item) => `${item.openCount} open request${item.openCount === 1 ? "" : "s"} and ${item.completedCount} completed or closed.`
+      ),
+      buildSpotlight(
+        "Top follow-up pressure",
+        propertySummaries,
+        (item) => item.reopenedOrEscalatedCount,
+        (item) => `${item.reopenedOrEscalatedCount} reopened / escalated`,
+        "No repeated follow-up",
+        (item) => item.followUpPressureLabel
+      ),
+      buildSpotlight(
+        "Unlinked cost burden",
+        propertySummaries,
+        (item) => item.totalUnlinkedCostCents,
+        (item) => fmtMoney(item.totalUnlinkedCostCents),
+        "No unlinked cost",
+        () => "Recorded maintenance cost still needs expense review."
+      ),
+    ],
+  };
+}


### PR DESCRIPTION
## Summary
Adds a lightweight property financial intelligence layer to the landlord maintenance workspace.

This builds on the existing maintenance portfolio rollups to highlight which properties are carrying the most maintenance cost, repeated follow-up pressure, and unlinked maintenance expense burden without turning the page into a full analytics or accounting dashboard.

## What Changed
- Added a pure `propertyFinancialIntelligenceState` helper for landlord-side property intelligence
- Added spotlight summaries for:
  - top maintenance cost
  - top follow-up pressure
  - unlinked cost burden
- Added simple intelligence counters for:
  - high maintenance load
  - follow-up heavy properties
  - needs expense review
- Added ranked property attention rows with transparent flags like:
  - `High maintenance load`
  - `Follow-up heavy`
  - `Needs expense review`
  - `Cost mostly linked`
- Added targeted frontend tests for helper logic and landlord rendering

## Scope Notes
- Frontend-only
- No backend or schema changes
- Landlord-only visibility
- No forecasting, tax/accounting reporting, or BI-style expansion

## Validation
- Frontend targeted tests passed
- Frontend build passed