### PR TITLE
docs(architecture): add screening and payments integration planning v1

### DIFF
--- a/docs/architecture/NARROW_TRANSACTION_LEDGER_DESIGN.md
+++ b/docs/architecture/NARROW_TRANSACTION_LEDGER_DESIGN.md
@@ -1,0 +1,373 @@
+# Narrow Transaction Ledger Design v1
+
+## Purpose
+
+Define a narrow transaction ledger for RentChain that records operational financial events without becoming a full accounting ledger.
+
+This ledger is intended to support:
+
+- screening monetization
+- deposit and payment rail events
+- maintenance expense linkage visibility
+- reconciliation and control-layer readiness
+
+---
+
+## What This Ledger Is
+
+A transaction-event ledger that records financial state transitions linked to product objects and provider references.
+
+It is designed for:
+
+- operational financial truth
+- reconciliation
+- admin troubleshooting
+- platform margin visibility
+- future control-layer and automation readiness
+
+---
+
+## What This Ledger Is Not
+
+It is not:
+
+- a general ledger
+- a tax engine
+- a bank ledger
+- a trust-account ledger
+- a full invoicing system
+- a complete accounting chart of accounts
+
+It should not be used to replace formal accounting software.
+
+---
+
+## Design Principles
+
+1. Event-based, append-oriented, and immutable by default.
+2. Product objects remain the user-facing operational truth.
+3. Ledger events explain financial transitions caused by those objects.
+4. Provider references and reconciliation state are first-class fields.
+5. Derived summaries can be built later; event truth comes first.
+
+---
+
+## Core Entity Model
+
+### 1. Transaction event
+
+The core row/object written for a meaningful commercial or payment state transition.
+
+Recommended fields:
+
+| Field | Purpose |
+| --- | --- |
+| `id` | unique event id |
+| `eventType` | normalized transaction event name |
+| `occurredAt` | event timestamp |
+| `recordedAt` | ingestion/write timestamp |
+| `status` | recorded / pending / failed / reversed |
+| `amountCents` | event amount |
+| `currency` | currency code |
+| `direction` | inflow / outflow / neutral |
+| `productDomain` | screening / payments / maintenance |
+| `sourceObjectType` | screening_order / lease_payment / maintenance_cost_link / etc. |
+| `sourceObjectId` | id of the product object |
+| `landlordId` | landlord scope |
+| `tenantId` | tenant/applicant scope if relevant |
+| `propertyId` | property scope if relevant |
+| `unitId` | unit scope if relevant |
+| `leaseId` | lease scope if relevant |
+| `provider` | stripe / transunion / manual / internal |
+| `providerRefType` | checkout_session / payment_intent / payout / provider_order / expense |
+| `providerRefId` | provider or linked-object id |
+| `correlationId` | logical flow id across multiple events |
+| `reconciliationState` | unreconciled / matched / exception / ignored |
+| `meta` | constrained structured metadata |
+
+### 2. Reconciliation checkpoint
+
+Not necessarily a separate collection in v1, but a logical concept that identifies whether an event:
+
+- has a matching provider reference
+- has a matching product object transition
+- requires admin repair
+
+### 3. Derived summary
+
+Optional later read model for:
+
+- screening margin by month
+- deposit success/failure rates
+- unlinked maintenance financial events
+
+Not required in v1 ledger implementation.
+
+---
+
+## Event Taxonomy
+
+### Screening events
+
+| Event type | Direction | Meaning |
+| --- | --- | --- |
+| `screening_fee_charged` | inflow | applicant or payer successfully charged for screening |
+| `screening_fee_failed` | neutral | screening charge attempt failed |
+| `screening_provider_cost_incurred` | outflow | provider-side cost became owed/incurred |
+| `screening_provider_cost_reversed` | inflow | provider-side cost was voided or reversed |
+| `screening_margin_recognized` | neutral | derived margin event from charge minus provider cost |
+| `screening_refund_issued` | outflow | screening payment refunded |
+
+### Payment rail events
+
+| Event type | Direction | Meaning |
+| --- | --- | --- |
+| `rent_payment_initiated` | neutral | rail payment initiated but not settled |
+| `rent_payment_succeeded` | inflow | rent payment settled successfully |
+| `rent_payment_failed` | neutral | initiated payment failed |
+| `rent_payment_reversed` | outflow | previously successful payment reversed/refunded |
+| `deposit_requested` | neutral | deposit obligation created |
+| `deposit_paid` | inflow | deposit settled |
+| `deposit_failed` | neutral | deposit attempt failed |
+| `convenience_fee_assessed` | inflow | fee assessed to payer |
+| `convenience_fee_refunded` | outflow | assessed fee refunded |
+
+### Payout and settlement events
+
+| Event type | Direction | Meaning |
+| --- | --- | --- |
+| `payout_expected` | neutral | payout should happen if platform model requires it |
+| `payout_completed` | outflow | payout completed to destination |
+| `payout_failed` | neutral | payout attempt failed |
+| `processor_fee_recorded` | outflow | payment processor fee recorded |
+
+### Maintenance-financial events
+
+| Event type | Direction | Meaning |
+| --- | --- | --- |
+| `maintenance_cost_recorded` | neutral | maintenance cost finalized operationally |
+| `maintenance_expense_linked` | neutral | maintenance cost linked to expense record |
+
+These maintenance events are intentionally operational-financial, not cash-movement events.
+
+---
+
+## Recommended Direction Semantics
+
+- `inflow`
+  money or commercial value moving into platform-recognized revenue or collected value
+
+- `outflow`
+  provider costs, refunds, payouts, or processor costs
+
+- `neutral`
+  operationally important event with financial implications but no immediate net cash direction at that moment
+
+This keeps the ledger useful without pretending it is full accounting.
+
+---
+
+## Source Object Mapping
+
+| Product object | Ledger role |
+| --- | --- |
+| `screeningOrder` | primary commercial object for screening monetization |
+| `rentalApplication` | product workflow context only |
+| `payment` / future payment rail object | payment flow container |
+| `lease` | obligation context |
+| `maintenance request` / `work order` | operational cost source |
+| `expense` | accounting-adjacent linked object, not ledger replacement |
+
+Recommended rule:
+
+- write ledger events from the commercial/transaction container object, not from arbitrary UI actions
+
+---
+
+## Example Event Records
+
+### Screening fee charged
+
+```json
+{
+  "eventType": "screening_fee_charged",
+  "status": "recorded",
+  "amountCents": 3500,
+  "currency": "CAD",
+  "direction": "inflow",
+  "productDomain": "screening",
+  "sourceObjectType": "screening_order",
+  "sourceObjectId": "so_123",
+  "landlordId": "landlord_1",
+  "tenantId": "applicant_1",
+  "propertyId": "prop_1",
+  "provider": "stripe",
+  "providerRefType": "payment_intent",
+  "providerRefId": "pi_123",
+  "correlationId": "screening_flow_123",
+  "reconciliationState": "matched"
+}
+```
+
+### Screening provider cost incurred
+
+```json
+{
+  "eventType": "screening_provider_cost_incurred",
+  "status": "recorded",
+  "amountCents": 1800,
+  "currency": "CAD",
+  "direction": "outflow",
+  "productDomain": "screening",
+  "sourceObjectType": "screening_order",
+  "sourceObjectId": "so_123",
+  "landlordId": "landlord_1",
+  "provider": "transunion",
+  "providerRefType": "provider_order",
+  "providerRefId": "tu_order_987",
+  "correlationId": "screening_flow_123",
+  "reconciliationState": "matched"
+}
+```
+
+### Deposit paid
+
+```json
+{
+  "eventType": "deposit_paid",
+  "status": "recorded",
+  "amountCents": 150000,
+  "currency": "CAD",
+  "direction": "inflow",
+  "productDomain": "payments",
+  "sourceObjectType": "lease_payment",
+  "sourceObjectId": "pay_456",
+  "landlordId": "landlord_1",
+  "tenantId": "tenant_1",
+  "propertyId": "prop_1",
+  "leaseId": "lease_1",
+  "provider": "stripe",
+  "providerRefType": "payment_intent",
+  "providerRefId": "pi_456",
+  "correlationId": "deposit_flow_456",
+  "reconciliationState": "matched"
+}
+```
+
+### Maintenance expense linked
+
+```json
+{
+  "eventType": "maintenance_expense_linked",
+  "status": "recorded",
+  "amountCents": 24500,
+  "currency": "CAD",
+  "direction": "neutral",
+  "productDomain": "maintenance",
+  "sourceObjectType": "work_order",
+  "sourceObjectId": "wo_789",
+  "landlordId": "landlord_1",
+  "propertyId": "prop_1",
+  "provider": "internal",
+  "providerRefType": "expense",
+  "providerRefId": "expense_22",
+  "correlationId": "maintenance_cost_789",
+  "reconciliationState": "matched"
+}
+```
+
+---
+
+## Reconciliation Touchpoints
+
+### Screening
+
+- checkout session / payment intent vs screening fee charged
+- screening order vs provider cost incurred
+- screening order vs report-ready state
+- charge / refund / provider cost consistency
+
+### Payments
+
+- payment initiation vs success/failure webhook
+- provider success vs lease/payment visible status
+- deposit paid vs lease/deposit visible state
+- payout expected vs payout completed
+
+### Maintenance
+
+- maintenance cost approved vs expense link created
+
+---
+
+## Ledger Write Rules
+
+1. Write from backend-authoritative transitions only.
+2. Do not write ledger events from optimistic frontend actions.
+3. Prefer idempotent event creation keyed by correlation and provider reference.
+4. Use reversal/refund events instead of mutating prior events.
+5. Keep metadata constrained and operationally useful.
+
+---
+
+## Rollout Recommendation
+
+### First implementation target
+
+Implement ledger events for screening monetization first:
+
+- `screening_fee_charged`
+- `screening_fee_failed`
+- `screening_provider_cost_incurred`
+- `screening_margin_recognized`
+
+Why:
+
+- current repo already has screening order and webhook primitives
+- highest readiness for monetized event truth
+
+### Second implementation target
+
+Implement deposit-related events:
+
+- `deposit_requested`
+- `deposit_paid`
+- `deposit_failed`
+
+### Third implementation target
+
+Implement rent rail events:
+
+- `rent_payment_initiated`
+- `rent_payment_succeeded`
+- `rent_payment_failed`
+- `payout_expected`
+- `payout_completed`
+
+### Fourth implementation target
+
+Add maintenance-financial ledger mirroring only where it improves reconciliation:
+
+- `maintenance_cost_recorded`
+- `maintenance_expense_linked`
+
+---
+
+## Risks and Boundaries
+
+- If the ledger becomes a catch-all event dump, reconciliation quality will drop.
+- If event types are too abstract, later automation will be unreliable.
+- If event types are too provider-specific, future migrations become expensive.
+- If product states and ledger states drift, operations and finance teams will lose trust quickly.
+
+---
+
+## Future Mission Dependencies
+
+- screening commercial event writer
+- screening provider-cost recording design
+- deposit payment orchestration
+- payment webhook normalization
+- payout expectation tracking
+- admin reconciliation surfaces
+

--- a/docs/architecture/SCREENING_PAYMENTS_ARCHITECTURE.md
+++ b/docs/architecture/SCREENING_PAYMENTS_ARCHITECTURE.md
@@ -1,0 +1,512 @@
+# Screening / Payments Integration Architecture v1
+
+## Purpose
+
+Define a founder-grade, implementation-ready architecture blueprint for:
+
+- screening monetization
+- payment rails placement
+- narrow transaction recording
+- staged rollout sequencing
+
+This document is planning-first. It is not a provider launch plan, not a compliance buildout, and not a full accounting design.
+
+---
+
+## Non-goals
+
+This architecture does not assume:
+
+- RentChain becomes a funds-holding entity
+- a full Stripe Connect rollout in v1
+- a full general ledger or accounting platform
+- a single permanent provider choice for every screening or payment capability
+- immediate automation of reconciliation, autopilot, or control-layer decisions
+
+---
+
+## Design Principles
+
+1. Operations truth comes first.
+   Product workflows must have a durable operational state before financial events are derived from them.
+
+2. Financial truth is narrow and explicit.
+   Record only the transaction events needed for product, reconciliation, and margin visibility.
+
+3. Providers stay behind service boundaries.
+   Screening bureaus and payment rails must sit behind dedicated orchestration/service layers rather than leaking into product logic.
+
+4. Reconciliation is a first-class boundary.
+   Every charge, provider cost, settlement expectation, payout expectation, or expense link should have a clear place where it can be checked later.
+
+5. Rollout stays staged.
+   Screening monetization can mature ahead of full rent/deposit payment rails.
+
+---
+
+## Current-State Audit
+
+### Screening touchpoints already present
+
+Frontend:
+
+- `rentchain-frontend/src/api/rentalApplicationsApi.ts`
+  - screening quote
+  - screening run
+  - screening order creation / checkout
+  - screening receipt / events / result fetch
+- `rentchain-frontend/src/api/screeningApi.ts`
+  - screening request / run / checkout / history
+- `rentchain-frontend/src/api/tenantScreeningApi.ts`
+  - tenant consent / status / start / retry
+- multiple tenant/admin screening pages and detail surfaces already exist
+
+Backend:
+
+- `rentchain-api/src/types/screeningOrders.ts`
+  - screening order status
+  - payment status
+  - Stripe session / payment intent references
+- `rentchain-api/src/routes/stripeScreeningOrdersWebhookRoutes.ts`
+  - Stripe webhook processing
+  - application screening paid transition
+  - screening start trigger after payment
+- `rentchain-api/src/services/screening/*`
+  - screening orchestrator
+  - provider abstraction / adapters
+  - event writing
+  - history / report access
+- `rentchain-api/src/services/integrations/transunion/*`
+  - current bureau path exists
+
+Current-state conclusion:
+
+- screening monetization is already the most mature fintech-adjacent surface in the repo
+- screening already has order, payment, webhook, and provider orchestration primitives
+- this should be the first revenue-grade integration track
+
+### Payment and deposit touchpoints already present
+
+Frontend:
+
+- `rentchain-frontend/src/api/paymentsApi.ts`
+  - payment list / update / monthly property and tenant summaries
+- `rentchain-frontend/src/api/leaseLedgerApi.ts`
+  - lease charge / payment entries
+- `rentchain-frontend/src/api/tenantPortal.ts`
+  - deposit and payment status fields on tenant-visible lease/workspace data
+- tenant application / status / payments pages already surface:
+  - deposit requested
+  - payment status
+  - payment method expectations
+
+Backend:
+
+- `rentchain-api/src/routes/paymentsRoutes.ts`
+  - manual payment recording
+  - monthly summaries
+  - property monthly endpoint still stubbed
+- existing lease ledger and payment event patterns exist
+- current implementation appears operational/manual rather than payment-rail-native
+
+Current-state conclusion:
+
+- payments exist as product/state primitives today
+- rails-native collection, settlement, and payout logic are not yet mature
+- rent/deposit money movement should be architected, but not rushed into full implementation
+
+### Billing touchpoints already present
+
+Frontend:
+
+- `rentchain-frontend/src/api/billingApi.ts`
+  - billing history
+  - subscription status
+  - plan checkout
+  - pricing / health
+
+Backend:
+
+- `rentchain-api/src/routes/billingRoutes.ts`
+  - pricing
+  - subscription checkout / portal
+  - billing history
+- billing service/store is present but lightweight
+
+Current-state conclusion:
+
+- subscription billing exists as a separate concern from transactional money movement
+- screening monetization must not be confused with plan subscription billing
+
+### Maintenance-financial touchpoints already present
+
+Frontend:
+
+- maintenance request cost capture
+- work order cost review
+- expense linkage
+- property maintenance financial intelligence
+
+Backend:
+
+- `rentchain-api/src/lib/maintenanceCost.ts`
+  - normalized cost review state
+  - explicit linked expense status
+
+Current-state conclusion:
+
+- maintenance already demonstrates a good operational-financial pattern:
+  - operational object first
+  - reviewed cost second
+  - expense linkage third
+- this is the best current reference for how narrow reconciliation boundaries should work elsewhere
+
+---
+
+## Target Architecture Overview
+
+```text
+Product workflows
+  -> domain orchestration
+    -> provider boundary
+      -> transaction event ledger
+        -> reconciliation + reporting surfaces
+```
+
+The architecture should split into four layers:
+
+1. Product workflow layer
+   - rental application screening
+   - deposit requested / paid
+   - rent payment initiated / settled
+   - maintenance cost linked to expense
+
+2. Domain orchestration layer
+   - screening order orchestration
+   - payments orchestration
+   - payout / reconciliation orchestration
+   - ledger event writer
+
+3. Provider boundary layer
+   - screening providers
+   - payment rail providers
+   - payout provider or partner
+
+4. Financial truth layer
+   - narrow transaction ledger
+   - provider reference mapping
+   - reconciliation checkpoints
+
+---
+
+## Future-State Screening Monetization Architecture
+
+### Recommended workflow
+
+```text
+Landlord selects screening package
+  -> quote screening price
+  -> create screening order
+  -> collect payment intent / checkout session
+  -> mark screening order paid
+  -> start provider workflow
+  -> record provider outcome
+  -> record revenue / provider-cost / margin events
+  -> expose receipt + history + admin reconciliation state
+```
+
+### Boundary rules
+
+- The rental application remains the product truth for applicant state.
+- The screening order becomes the commercial transaction container.
+- Screening provider adapters handle bureau interactions.
+- Payment provider integration handles collection, intent/session references, and webhook confirmation.
+- The narrow ledger records the financial truth derived from the screening order lifecycle.
+
+### Recommended responsibilities by object
+
+`rentalApplication`
+
+- applicant workflow truth
+- landlord / property / unit context
+- screening eligibility state
+- screening status summary for product UI
+
+`screeningOrder`
+
+- price quoted
+- selected package
+- checkout/payment references
+- provider request references
+- payment and provider execution state
+
+`screeningEvent`
+
+- operational timeline
+- webhook and state audit
+
+`transaction ledger event`
+
+- commercial / financial truth
+- charge, provider cost, margin, refund, settlement expectation
+
+### Revenue model recommendation
+
+For v1 architecture:
+
+- treat applicant-paid screening as the first monetization track
+- record the charged amount as gross screening revenue event
+- record provider cost separately when known or contractually incurred
+- derive platform margin from the difference between the two
+
+Do not fold this into subscription billing records.
+
+### Reconciliation points
+
+- checkout session created but not paid
+- paid webhook received but screening not started
+- provider started but report not returned
+- report returned but provider cost not recorded
+- refund or failed payment after initial commercial event
+
+---
+
+## Future-State Payment Rails Architecture
+
+### Scope boundary
+
+Payment rails in this architecture cover:
+
+- deposit collection
+- first payment collection
+- rent payment collection
+- convenience fees if introduced later
+- payout expectations to landlord-side recipients if applicable
+
+This architecture does not assume RentChain directly holds tenant funds long term.
+
+### Recommended placement
+
+```text
+Lease / payment obligations
+  -> payments orchestration service
+    -> payment rail provider
+      -> webhook / provider callback ingestion
+        -> transaction ledger event writer
+          -> lease/payment summary updates
+```
+
+### Domain split
+
+`lease / tenancy domain`
+
+- what is owed
+- when it is due
+- who owes it
+- what status is visible to tenant / landlord
+
+`payments orchestration domain`
+
+- initiation
+- provider references
+- status mapping
+- payout expectation and settlement checkpoints
+
+`transaction ledger domain`
+
+- immutable operational-financial events
+- success / failure / reversal / payout expectation events
+
+### Payment status mapping recommendation
+
+Product-facing payment state should stay simple:
+
+- requested
+- pending
+- succeeded
+- failed
+- refunded
+- needs_attention
+
+Ledger-facing events should be more explicit:
+
+- initiated
+- authorized
+- captured
+- failed
+- reversed
+- settled
+- payout_expected
+- payout_completed
+
+### Rent and deposit architecture recommendation
+
+Phase sequencing should be:
+
+1. preserve existing manual/operational payment recording
+2. introduce transaction event recording around rail events
+3. add deposit collection rail before full rent-autopay orchestration
+4. add payout/reconciliation later
+
+Why:
+
+- deposit and screening are narrower and easier to reconcile than recurring rent
+- rent rails introduce higher support, retry, dispute, and reconciliation burden
+
+---
+
+## Provider Boundary Recommendations
+
+### Screening providers
+
+Provider abstraction should continue to support:
+
+- quote
+- checkout creation or referral handoff
+- report retrieval
+- webhook handling
+- error/status normalization
+
+Do not let provider-specific fields become product truth outside the orchestration and reference layers.
+
+### Payment providers
+
+Recommended provider-neutral capabilities:
+
+- payment intent or checkout session create
+- payment status fetch
+- webhook event normalize
+- refund request
+- payout status fetch
+
+Store provider references, not provider behavior, in product objects.
+
+---
+
+## Role Boundaries
+
+### Applicant / tenant
+
+- can consent to screening
+- can complete screening payment if applicant-paid
+- can see only their own payment/screening state
+- cannot see internal provider-cost or platform-margin details
+
+### Landlord
+
+- can trigger screening workflow
+- can view commercial completion state
+- can view payment/deposit state relevant to lease operations
+- should not directly manage provider settlement internals in v1
+
+### Admin / operations
+
+- can reconcile failed or stuck payment/screening states
+- can inspect provider references and ledger events
+- can resolve exceptions without mutating product history silently
+
+---
+
+## Reconciliation Model
+
+Every monetized workflow should define:
+
+1. product source object
+2. provider transaction reference
+3. ledger event sequence
+4. exception states
+5. admin repair path
+
+### Recommended reconciliation pairs
+
+Screening:
+
+- screening order vs Stripe payment intent/session
+- screening order vs provider request/report
+- screening gross charge vs provider cost event
+
+Payments:
+
+- payment request vs provider payment intent
+- payment success vs lease-visible payment status
+- payout expected vs payout completed
+
+Maintenance:
+
+- work order cost vs linked expense
+
+---
+
+## Recommended Rollout Sequence
+
+### Phase 1 — Screening monetization hardening
+
+Build first:
+
+- screening order commercial lifecycle cleanup
+- explicit transaction ledger events for screening charge / provider cost / margin
+- stronger admin reconciliation views for screening orders
+
+Why first:
+
+- narrowest path to monetized financial truth
+- current repo already has the most supporting primitives here
+
+### Phase 2 — Deposit collection architecture execution
+
+Build second:
+
+- deposit payment intent model
+- payment webhook normalization
+- tenant / landlord deposit state driven from provider-backed events
+
+Why second:
+
+- narrower than recurring rent
+- strong user value
+- easier reconciliation than monthly rent
+
+### Phase 3 — Narrow rent payment rails integration
+
+Build third:
+
+- payment orchestration service
+- rail-native transaction events
+- lease / ledger synchronization
+
+Hold back:
+
+- autopay
+- advanced retries
+- split payouts
+- collections/dispute automation
+
+### Phase 4 — Control layer and autopilot readiness
+
+After operational and ledger truth are stable:
+
+- exception routing
+- reconciliation ops queues
+- agentic assist / autopilot suggestions
+
+---
+
+## Risks and Watchouts
+
+- Mixing subscription billing and transactional money movement will create confusing records.
+- Treating provider webhooks as product truth without normalization will create brittle state.
+- Building a broad accounting schema too early will slow delivery and raise correctness risk.
+- Launching full rent rails before deposit/screening reconciliation is stable will widen operational risk.
+- Letting provider-specific concepts leak into UI copy will create lock-in and migration pain.
+
+---
+
+## Future Missions This Doc Enables
+
+- screening transaction ledger event implementation
+- screening reconciliation admin surface
+- deposit payment orchestration v1
+- rail-backed tenant payment status normalization
+- payout expectation tracking
+- operations control layer for payment/screening exceptions
+


### PR DESCRIPTION
## Summary
Adds a planning-first architecture blueprint for screening monetization, payment rails, and a narrow transaction ledger.

This captures the current repo touchpoints, defines the future-state system boundaries, and lays out a staged rollout path for fintech-adjacent work without prematurely building a full payments or accounting platform.

## What Changed
- Added `docs/architecture/SCREENING_PAYMENTS_ARCHITECTURE.md`
- Added `docs/architecture/NARROW_TRANSACTION_LEDGER_DESIGN.md`
- Documented:
  - current-state screening, billing, payments, deposit, and maintenance-financial touchpoints
  - future-state screening monetization flow
  - payment rails placement and system boundaries
  - a narrow transaction-event ledger model
  - reconciliation points
  - recommended rollout order and non-goals

## Scope Notes
- Docs-only
- No backend or frontend implementation changes
- No schema rollout
- No provider launch work
- No accounting-platform expansion

## Why This Matters
- Keeps future screening and payments work grounded in current repo reality
- Separates subscription billing from transactional money movement
- Establishes a narrow financial truth model before broader control-layer or automation work
- Gives future missions a durable execution reference

## Validation
- Scoped docs diff reviewed
- Verified docs-only changes
- No secrets or provider configuration changes introduced