### PR TITLE
feat(finance): add narrow financial transaction ledger v1

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -95,6 +95,7 @@ import internalReportsRoutes from "./routes/internalReportsRoutes";
 import identityOracleInternalRoutes from "./routes/identityOracleInternalRoutes";
 import statusRoutes from "./routes/statusRoutes";
 import expensesRoutes from "./routes/expensesRoutes";
+import financialTransactionsRoutes from "./routes/financialTransactionsRoutes";
 import workOrdersRoutes from "./routes/workOrdersRoutes";
 import transunionRoutes from "./services/integrations/transunion/transunionRoutes";
 import viewingRoutes from "./routes/viewingRoutes";
@@ -205,6 +206,8 @@ app.use("/api/status", routeSource("statusRoutes.ts"), statusRoutes);
 app.use(authenticateJwt);
 app.use("/api", routeSource("expensesRoutes.ts"), expensesRoutes);
 console.log("[route-mount] expensesRoutes mounted at /api");
+app.use("/api", routeSource("financialTransactionsRoutes.ts"), financialTransactionsRoutes);
+console.log("[route-mount] financialTransactionsRoutes mounted at /api");
 app.use("/api", routeSource("workOrdersRoutes.ts"), workOrdersRoutes);
 console.log("[route-mount] workOrdersRoutes mounted at /api");
 

--- a/rentchain-api/src/routes/__tests__/financialTransactionsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/financialTransactionsRoutes.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type StoredDoc = { id: string; data: any };
+
+const { dbMock, resetDb, seedDoc } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, StoredDoc>>();
+  let autoId = 0;
+
+  function ensureCollection(name: string) {
+    if (!collections.has(name)) collections.set(name, new Map());
+    return collections.get(name)!;
+  }
+
+  function buildQuery(name: string, filters: Array<{ field: string; op: string; value: any }> = []) {
+    return {
+      where: (field: string, op: string, value: any) => buildQuery(name, [...filters, { field, op, value }]),
+      get: async () => {
+        const rows = Array.from(ensureCollection(name).values()).filter((entry) =>
+          filters.every((filter) => (filter.op === "==" ? entry.data?.[filter.field] === filter.value : true))
+        );
+        return {
+          docs: rows.map((row) => ({ id: row.id, data: () => row.data })),
+        };
+      },
+      limit: (_n: number) => buildQuery(name, filters),
+      doc: (id?: string) => {
+        const docId = id || `auto_${++autoId}`;
+        return {
+          id: docId,
+          set: async (payload: any) => ensureCollection(name).set(docId, { id: docId, data: payload }),
+          get: async () => {
+            const row = ensureCollection(name).get(docId);
+            return { id: docId, exists: Boolean(row), data: () => row?.data };
+          },
+        };
+      },
+    };
+  }
+
+  return {
+    dbMock: {
+      collection: (name: string) => buildQuery(name),
+    },
+    resetDb: () => {
+      collections.clear();
+      autoId = 0;
+    },
+    seedDoc: (collection: string, id: string, data: any) => ensureCollection(collection).set(id, { id, data }),
+  };
+});
+
+vi.mock("../../config/firebase", () => ({
+  db: dbMock,
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, _res: any, next: any) => next(),
+}));
+
+async function invokeRouter(
+  router: any,
+  options: {
+    method: string;
+    url: string;
+    role?: "landlord" | "admin";
+    query?: Record<string, string>;
+  }
+) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path: options.url,
+      query: options.query ?? {},
+      user: { id: "landlord-1", landlordId: "landlord-1", role: options.role || "landlord" },
+    };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("financialTransactionsRoutes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    resetDb();
+  });
+
+  it("lists landlord-scoped transactions filtered by property and work order", async () => {
+    const router = (await import("../financialTransactionsRoutes")).default;
+    seedDoc("financialTransactions", "txn-1", {
+      id: "txn-1",
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      workOrderId: "wo-1",
+      type: "maintenance_cost_recorded",
+      amountCents: 24500,
+      currency: "CAD",
+      status: "recorded",
+      createdAt: 1000,
+    });
+    seedDoc("financialTransactions", "txn-2", {
+      id: "txn-2",
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      workOrderId: "wo-2",
+      type: "maintenance_cost_linked_to_expense",
+      amountCents: 32000,
+      currency: "CAD",
+      status: "linked",
+      createdAt: 2000,
+    });
+    seedDoc("financialTransactions", "txn-3", {
+      id: "txn-3",
+      landlordId: "landlord-2",
+      propertyId: "prop-1",
+      workOrderId: "wo-1",
+      type: "maintenance_cost_recorded",
+      amountCents: 9999,
+      currency: "CAD",
+      status: "recorded",
+      createdAt: 3000,
+    });
+
+    const propertyRes = await invokeRouter(router, {
+      method: "GET",
+      url: "/financial-transactions",
+      query: { propertyId: "prop-1" },
+    });
+    const workOrderRes = await invokeRouter(router, {
+      method: "GET",
+      url: "/financial-transactions",
+      query: { workOrderId: "wo-2" },
+    });
+
+    expect(propertyRes.status).toBe(200);
+    expect(propertyRes.body.items).toHaveLength(2);
+    expect(propertyRes.body.items.every((item: any) => item.landlordId === "landlord-1")).toBe(true);
+
+    expect(workOrderRes.status).toBe(200);
+    expect(workOrderRes.body.items).toHaveLength(1);
+    expect(workOrderRes.body.items[0]?.id).toBe("txn-2");
+  });
+});

--- a/rentchain-api/src/routes/__tests__/workOrdersRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/workOrdersRoutes.test.ts
@@ -4,6 +4,7 @@ const uploadBufferToGcsMock = vi.fn();
 const getSignedDownloadUrlMock = vi.fn();
 
 const collections = new Map<string, Map<string, any>>();
+let autoId = 0;
 
 function ensureCollection(name: string) {
   if (!collections.has(name)) {
@@ -31,22 +32,25 @@ function applyMerge(current: any, incoming: any) {
 
 const dbMock = {
   collection: (name: string) => ({
-    doc: (id: string) => ({
-      id,
-      get: async () => ({
-        id,
-        exists: ensureCollection(name).has(id),
-        data: () => clone(ensureCollection(name).get(id)),
-      }),
-      set: async (value: any, opts?: { merge?: boolean }) => {
-        const current = ensureCollection(name).get(id);
-        ensureCollection(name).set(id, opts?.merge ? applyMerge(current, value) : clone(value));
-      },
-      update: async (value: any) => {
-        const current = ensureCollection(name).get(id) || {};
-        ensureCollection(name).set(id, applyMerge(current, value));
-      },
-    }),
+    doc: (id?: string) => {
+      const docId = id || `${name}_${++autoId}`;
+      return {
+        id: docId,
+        get: async () => ({
+          id: docId,
+          exists: ensureCollection(name).has(docId),
+          data: () => clone(ensureCollection(name).get(docId)),
+        }),
+        set: async (value: any, opts?: { merge?: boolean }) => {
+          const current = ensureCollection(name).get(docId);
+          ensureCollection(name).set(docId, opts?.merge ? applyMerge(current, value) : clone(value));
+        },
+        update: async (value: any) => {
+          const current = ensureCollection(name).get(docId) || {};
+          ensureCollection(name).set(docId, applyMerge(current, value));
+        },
+      };
+    },
   }),
 };
 
@@ -137,6 +141,7 @@ describe("workOrdersRoutes execution completion", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     collections.clear();
+    autoId = 0;
     process.env.GCS_UPLOAD_BUCKET = "test-bucket";
     uploadBufferToGcsMock.mockResolvedValue(undefined);
     getSignedDownloadUrlMock.mockImplementation(async ({ path }: { path: string }) => `https://signed.example/${path}`);
@@ -423,6 +428,19 @@ describe("workOrdersRoutes execution completion", () => {
     expect(submitRes.body?.item?.cost?.latestRevisionNumber).toBe(1);
     expect(submitRes.body?.item?.costLineItems).toHaveLength(2);
     expect(submitRes.body?.item?.costReviewHistory).toHaveLength(1);
+    expect(Array.from(ensureCollection("financialTransactions").values())).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          landlordId: "landlord-1",
+          workOrderId: "wo-1",
+          maintenanceRequestId: "maint-1",
+          type: "maintenance_cost_recorded",
+          amountCents: 24500,
+          currency: "CAD",
+          status: "recorded",
+        }),
+      ])
+    );
 
     ensureCollection("workOrders").set("wo-1", {
       ...ensureCollection("workOrders").get("wo-1"),
@@ -574,6 +592,24 @@ describe("workOrdersRoutes execution completion", () => {
     expect(linkRes.body?.item?.cost?.linkedExpenseStatus).toBe("linked");
     expect(linkRes.body?.item?.expenseLink?.status).toBe("linked");
     expect(ensureCollection("expenses").size).toBeGreaterThan(0);
+    expect(Array.from(ensureCollection("financialTransactions").values())).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          landlordId: "landlord-1",
+          propertyId: "prop-1",
+          unitId: "unit-1",
+          maintenanceRequestId: "maint-1",
+          workOrderId: "wo-1",
+          type: "maintenance_cost_linked_to_expense",
+          amountCents: 32000,
+          currency: "CAD",
+          status: "linked",
+          metadata: expect.objectContaining({
+            source: "work_order_link_expense",
+          }),
+        }),
+      ])
+    );
   });
 
   it("rejects unsupported evidence file types", async () => {

--- a/rentchain-api/src/routes/financialTransactionsRoutes.ts
+++ b/rentchain-api/src/routes/financialTransactionsRoutes.ts
@@ -1,0 +1,47 @@
+import { Router } from "express";
+import { requireAuth } from "../middleware/requireAuth";
+import { listFinancialTransactions } from "../services/financialTransactionService";
+
+const router = Router();
+
+function asString(value: unknown, max = 2000): string {
+  return String(value || "").trim().slice(0, max);
+}
+
+function normalizeRole(req: any): "admin" | "landlord" | "other" {
+  const role = asString(req.user?.actorRole || req.user?.role, 40).toLowerCase();
+  if (role === "admin") return "admin";
+  if (role === "landlord") return "landlord";
+  return "other";
+}
+
+function landlordIdFromReq(req: any): string {
+  return asString(req.user?.landlordId || req.user?.id, 120);
+}
+
+router.get("/financial-transactions", requireAuth, async (req: any, res) => {
+  try {
+    const role = normalizeRole(req);
+    if (role !== "admin" && role !== "landlord") {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+
+    const landlordId =
+      role === "admin" ? asString(req.query?.landlordId, 120) || landlordIdFromReq(req) : landlordIdFromReq(req);
+    if (!landlordId) {
+      return res.status(400).json({ ok: false, error: "LANDLORD_REQUIRED" });
+    }
+
+    const items = await listFinancialTransactions({
+      landlordId,
+      propertyId: asString(req.query?.propertyId, 120) || null,
+      workOrderId: asString(req.query?.workOrderId, 120) || null,
+    });
+    return res.json({ ok: true, items });
+  } catch (err: any) {
+    console.error("[financial-transactions] list failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "FINANCIAL_TRANSACTION_LIST_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-api/src/routes/workOrdersRoutes.ts
+++ b/rentchain-api/src/routes/workOrdersRoutes.ts
@@ -28,6 +28,7 @@ import {
   applyNotificationUpdate,
   buildTenantSafeWorkOrderNotifications,
 } from "../lib/maintenanceNotifications";
+import { createTransaction } from "../services/financialTransactionService";
 
 const router = Router();
 
@@ -2667,6 +2668,24 @@ router.post("/landlord/work-orders/:id/submit-cost", requireAuth, async (req: an
       message: `Landlord recorded ${formatCostForMessage(actualCostCents, currency)} for this work order.`,
     });
 
+    await createTransaction({
+      landlordId: asString((access.item as any)?.landlordId, 120) || access.landlordId,
+      propertyId: asOptionalString((access.item as any)?.propertyId, 120) || undefined,
+      unitId: asOptionalString((access.item as any)?.unitId, 120) || undefined,
+      maintenanceRequestId: asOptionalString((access.item as any)?.maintenanceRequestId, 120) || undefined,
+      workOrderId,
+      type: "maintenance_cost_recorded",
+      amountCents: actualCostCents,
+      currency,
+      status: "recorded",
+      metadata: {
+        source: "work_order_submit_cost",
+        revisionNumber,
+      },
+      createdAt: now,
+      updatedAt: now,
+    });
+
     const refreshed = await db.collection("workOrders").doc(workOrderId).get();
     return res.json({ ok: true, item: await toWorkOrderResponseForAudience(refreshed.id, refreshed.data(), "landlord") });
   } catch (err) {
@@ -2899,6 +2918,24 @@ router.post("/landlord/work-orders/:id/link-expense", requireAuth, async (req: a
       actorId: access.userId,
       updateType: "invoice",
       message: "Approved maintenance cost linked to an expense record.",
+    });
+
+    await createTransaction({
+      landlordId,
+      propertyId,
+      unitId: unitId || undefined,
+      maintenanceRequestId: asOptionalString((access.item as any)?.maintenanceRequestId, 120) || undefined,
+      workOrderId,
+      type: "maintenance_cost_linked_to_expense",
+      amountCents: currentCost.actualCostCents,
+      currency: currentCost.currency || "CAD",
+      status: "linked",
+      metadata: {
+        expenseId: expenseRef.id,
+        source: "work_order_link_expense",
+      },
+      createdAt: now,
+      updatedAt: now,
     });
 
     const refreshed = await db.collection("workOrders").doc(workOrderId).get();

--- a/rentchain-api/src/services/__tests__/financialTransactionService.test.ts
+++ b/rentchain-api/src/services/__tests__/financialTransactionService.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type StoredDoc = { id: string; data: any };
+
+const { dbMock, resetDb, seedDoc } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, StoredDoc>>();
+  let autoId = 0;
+
+  function ensureCollection(name: string) {
+    if (!collections.has(name)) collections.set(name, new Map());
+    return collections.get(name)!;
+  }
+
+  function buildQuery(name: string, filters: Array<{ field: string; op: string; value: any }> = []) {
+    return {
+      where: (field: string, op: string, value: any) => buildQuery(name, [...filters, { field, op, value }]),
+      get: async () => {
+        const rows = Array.from(ensureCollection(name).values()).filter((entry) =>
+          filters.every((filter) => (filter.op === "==" ? entry.data?.[filter.field] === filter.value : true))
+        );
+        return {
+          docs: rows.map((row) => ({ id: row.id, data: () => row.data })),
+        };
+      },
+    };
+  }
+
+  return {
+    dbMock: {
+      collection: (name: string) => ({
+        doc: (id?: string) => {
+          const docId = id || `auto_${++autoId}`;
+          return {
+            id: docId,
+            set: async (payload: any) => {
+              ensureCollection(name).set(docId, { id: docId, data: payload });
+            },
+            get: async () => {
+              const row = ensureCollection(name).get(docId);
+              return { id: docId, exists: Boolean(row), data: () => row?.data };
+            },
+          };
+        },
+        where: (field: string, op: string, value: any) => buildQuery(name, [{ field, op, value }]),
+      }),
+    },
+    resetDb: () => {
+      collections.clear();
+      autoId = 0;
+    },
+    seedDoc: (collection: string, id: string, data: any) => ensureCollection(collection).set(id, { id, data }),
+  };
+});
+
+vi.mock("../../config/firebase", () => ({
+  db: dbMock,
+}));
+
+describe("financialTransactionService", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    resetDb();
+  });
+
+  it("creates a financial transaction with the controlled event model", async () => {
+    const { createTransaction } = await import("../financialTransactionService");
+    const item = await createTransaction({
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      maintenanceRequestId: "maint-1",
+      workOrderId: "wo-1",
+      type: "maintenance_cost_recorded",
+      amountCents: 24500,
+      currency: "cad",
+      status: "recorded",
+      metadata: { source: "test" },
+      createdAt: 1000,
+      updatedAt: 1000,
+    });
+
+    expect(item.id).toMatch(/^auto_/);
+    expect(item.currency).toBe("CAD");
+    expect(item.type).toBe("maintenance_cost_recorded");
+    expect(item.status).toBe("recorded");
+  });
+
+  it("returns landlord-scoped property and work-order queries", async () => {
+    const { getTransactionsByProperty, getTransactionsByWorkOrder } = await import("../financialTransactionService");
+    seedDoc("financialTransactions", "txn-1", {
+      id: "txn-1",
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      workOrderId: "wo-1",
+      type: "maintenance_cost_recorded",
+      amountCents: 24500,
+      currency: "CAD",
+      status: "recorded",
+      createdAt: 2000,
+    });
+    seedDoc("financialTransactions", "txn-2", {
+      id: "txn-2",
+      landlordId: "landlord-1",
+      propertyId: "prop-2",
+      workOrderId: "wo-2",
+      type: "maintenance_cost_linked_to_expense",
+      amountCents: 32000,
+      currency: "CAD",
+      status: "linked",
+      createdAt: 3000,
+    });
+    seedDoc("financialTransactions", "txn-3", {
+      id: "txn-3",
+      landlordId: "landlord-2",
+      propertyId: "prop-1",
+      workOrderId: "wo-1",
+      type: "maintenance_cost_recorded",
+      amountCents: 9999,
+      currency: "CAD",
+      status: "recorded",
+      createdAt: 4000,
+    });
+
+    const byProperty = await getTransactionsByProperty("landlord-1", "prop-1");
+    const byWorkOrder = await getTransactionsByWorkOrder("landlord-1", "wo-2");
+
+    expect(byProperty).toHaveLength(1);
+    expect(byProperty[0]?.id).toBe("txn-1");
+    expect(byWorkOrder).toHaveLength(1);
+    expect(byWorkOrder[0]?.id).toBe("txn-2");
+  });
+});

--- a/rentchain-api/src/services/financialTransactionService.ts
+++ b/rentchain-api/src/services/financialTransactionService.ts
@@ -1,0 +1,179 @@
+import { db } from "../config/firebase";
+
+export const FINANCIAL_TRANSACTION_TYPES = [
+  "maintenance_cost_recorded",
+  "maintenance_cost_linked_to_expense",
+  "screening_fee_charged",
+  "screening_cost_incurred",
+  "platform_fee_recognized",
+  "payment_initiated",
+  "payment_succeeded",
+  "payment_failed",
+] as const;
+
+export const FINANCIAL_TRANSACTION_STATUSES = ["pending", "recorded", "linked", "completed", "failed"] as const;
+
+export type FinancialTransactionType = (typeof FINANCIAL_TRANSACTION_TYPES)[number];
+export type FinancialTransactionStatus = (typeof FINANCIAL_TRANSACTION_STATUSES)[number];
+
+export type FinancialTransaction = {
+  id: string;
+  landlordId: string;
+  propertyId?: string;
+  unitId?: string;
+  maintenanceRequestId?: string;
+  workOrderId?: string;
+  type: FinancialTransactionType;
+  amountCents: number;
+  currency: string;
+  status: FinancialTransactionStatus;
+  metadata?: Record<string, unknown>;
+  createdAt: number;
+  updatedAt?: number;
+};
+
+type CreateFinancialTransactionInput = Omit<FinancialTransaction, "id" | "createdAt" | "updatedAt"> & {
+  createdAt?: number;
+  updatedAt?: number;
+};
+
+function nowMs() {
+  return Date.now();
+}
+
+function asString(value: unknown, max = 2000): string {
+  return String(value || "").trim().slice(0, max);
+}
+
+function asOptionalString(value: unknown, max = 2000): string | undefined {
+  const next = asString(value, max);
+  return next || undefined;
+}
+
+function asOptionalMetadata(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  return value as Record<string, unknown>;
+}
+
+function normalizeTransactionType(value: unknown): FinancialTransactionType {
+  const next = asString(value, 80).toLowerCase();
+  if ((FINANCIAL_TRANSACTION_TYPES as readonly string[]).includes(next)) {
+    return next as FinancialTransactionType;
+  }
+  throw new Error("INVALID_FINANCIAL_TRANSACTION_TYPE");
+}
+
+function normalizeTransactionStatus(value: unknown): FinancialTransactionStatus {
+  const next = asString(value, 40).toLowerCase();
+  if ((FINANCIAL_TRANSACTION_STATUSES as readonly string[]).includes(next)) {
+    return next as FinancialTransactionStatus;
+  }
+  throw new Error("INVALID_FINANCIAL_TRANSACTION_STATUS");
+}
+
+function normalizeAmountCents(value: unknown): number {
+  const next = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(next) || next <= 0) {
+    throw new Error("INVALID_FINANCIAL_TRANSACTION_AMOUNT");
+  }
+  return Math.round(next);
+}
+
+function normalizeCurrency(value: unknown): string {
+  const next = asString(value, 8).toUpperCase();
+  if (!/^[A-Z]{3}$/.test(next)) {
+    throw new Error("INVALID_FINANCIAL_TRANSACTION_CURRENCY");
+  }
+  return next;
+}
+
+function normalizeTimestamp(value: unknown, fallback: number): number {
+  const next = typeof value === "number" ? Math.round(value) : Number(value);
+  return Number.isFinite(next) && next > 0 ? next : fallback;
+}
+
+function toFinancialTransaction(id: string, data: any): FinancialTransaction {
+  return {
+    id,
+    landlordId: asString(data?.landlordId, 120),
+    propertyId: asOptionalString(data?.propertyId, 120),
+    unitId: asOptionalString(data?.unitId, 120),
+    maintenanceRequestId: asOptionalString(data?.maintenanceRequestId, 120),
+    workOrderId: asOptionalString(data?.workOrderId, 120),
+    type: normalizeTransactionType(data?.type),
+    amountCents: normalizeAmountCents(data?.amountCents),
+    currency: normalizeCurrency(data?.currency),
+    status: normalizeTransactionStatus(data?.status),
+    metadata: asOptionalMetadata(data?.metadata),
+    createdAt: normalizeTimestamp(data?.createdAt, 0),
+    updatedAt: typeof data?.updatedAt === "number" ? Math.round(data.updatedAt) : undefined,
+  };
+}
+
+export async function createTransaction(input: CreateFinancialTransactionInput): Promise<FinancialTransaction> {
+  const createdAt = normalizeTimestamp(input.createdAt, nowMs());
+  const updatedAt = normalizeTimestamp(input.updatedAt, createdAt);
+  const ref = db.collection("financialTransactions").doc();
+  const record: FinancialTransaction = {
+    id: ref.id,
+    landlordId: asString(input.landlordId, 120),
+    propertyId: asOptionalString(input.propertyId, 120),
+    unitId: asOptionalString(input.unitId, 120),
+    maintenanceRequestId: asOptionalString(input.maintenanceRequestId, 120),
+    workOrderId: asOptionalString(input.workOrderId, 120),
+    type: normalizeTransactionType(input.type),
+    amountCents: normalizeAmountCents(input.amountCents),
+    currency: normalizeCurrency(input.currency),
+    status: normalizeTransactionStatus(input.status),
+    metadata: asOptionalMetadata(input.metadata),
+    createdAt,
+    updatedAt,
+  };
+
+  if (!record.landlordId) {
+    throw new Error("FINANCIAL_TRANSACTION_LANDLORD_REQUIRED");
+  }
+
+  await ref.set(record);
+  return record;
+}
+
+async function listTransactionsForLandlord(landlordId: string): Promise<FinancialTransaction[]> {
+  const scope = asString(landlordId, 120);
+  if (!scope) throw new Error("FINANCIAL_TRANSACTION_LANDLORD_REQUIRED");
+  const snap = await db.collection("financialTransactions").where("landlordId", "==", scope).get();
+  return snap.docs
+    .map((doc) => toFinancialTransaction(doc.id, doc.data()))
+    .sort((a, b) => Number(b.createdAt || 0) - Number(a.createdAt || 0));
+}
+
+export async function getTransactionsByProperty(landlordId: string, propertyId: string): Promise<FinancialTransaction[]> {
+  const scopedPropertyId = asString(propertyId, 120);
+  if (!scopedPropertyId) return [];
+  const items = await listTransactionsForLandlord(landlordId);
+  return items.filter((item) => item.propertyId === scopedPropertyId);
+}
+
+export async function getTransactionsByWorkOrder(landlordId: string, workOrderId: string): Promise<FinancialTransaction[]> {
+  const scopedWorkOrderId = asString(workOrderId, 120);
+  if (!scopedWorkOrderId) return [];
+  const items = await listTransactionsForLandlord(landlordId);
+  return items.filter((item) => item.workOrderId === scopedWorkOrderId);
+}
+
+export async function listFinancialTransactions(filters: {
+  landlordId: string;
+  propertyId?: string | null;
+  workOrderId?: string | null;
+}): Promise<FinancialTransaction[]> {
+  const landlordId = asString(filters.landlordId, 120);
+  const propertyId = asOptionalString(filters.propertyId, 120);
+  const workOrderId = asOptionalString(filters.workOrderId, 120);
+
+  if (!landlordId) throw new Error("FINANCIAL_TRANSACTION_LANDLORD_REQUIRED");
+
+  let items = await listTransactionsForLandlord(landlordId);
+  if (propertyId) items = items.filter((item) => item.propertyId === propertyId);
+  if (workOrderId) items = items.filter((item) => item.workOrderId === workOrderId);
+  return items;
+}


### PR DESCRIPTION
## Summary
Adds a narrow operational financial transaction ledger for backend event recording.

This introduces a Firestore-backed `financialTransactions` layer, a minimal read route at `GET /api/financial-transactions`, and append-only maintenance workflow hooks for:
- `maintenance_cost_recorded`
- `maintenance_cost_linked_to_expense`

## Scope
- New `financialTransactionService` for controlled event creation and landlord-scoped queries
- New read-only financial transactions route
- Maintenance cost submission now records a transaction event
- Expense linkage from work orders now records a transaction event
- Targeted backend tests for creation, filtering, and maintenance integration

## Notes
This is not an accounting system. It is a minimal system-of-record event layer for money-related operational workflows.

## Validation
- Passed targeted backend tests for the new service, route, and work-order integration
- Passed backend build
- Full backend test suite is still blocked in sandbox by unrelated existing `supertest` socket permission failures (`listen EPERM`)