### PR TITLE
feat(payments): add payment rails implementation v1

### DIFF
--- a/rentchain-api/src/routes/__tests__/screeningPaymentWebhook.test.ts
+++ b/rentchain-api/src/routes/__tests__/screeningPaymentWebhook.test.ts
@@ -1,24 +1,59 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { store, dbMock } = vi.hoisted(() => {
-  const store = new Map<string, any>();
+const { store, dbMock, ensureCollection } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+  let autoId = 0;
+
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+
+  function docRef(collectionName: string, docId: string) {
+    return {
+      id: docId,
+      path: `${collectionName}/${docId}`,
+      get: async () => ({
+        exists: ensureCollection(collectionName).has(docId),
+        data: () => ensureCollection(collectionName).get(docId),
+      }),
+      set: async (payload: Record<string, unknown>, options?: { merge?: boolean }) => {
+        const col = ensureCollection(collectionName);
+        const existing = col.get(docId) || {};
+        col.set(docId, options?.merge ? { ...existing, ...payload } : payload);
+      },
+    };
+  }
 
   const dbMock = {
-    collection: vi.fn(() => ({
-      doc: (id: string) => ({
-        get: async () => ({
-          exists: store.has(id),
-          data: () => store.get(id),
+    collection: vi.fn((name: string) => ({
+      doc: (id?: string) => docRef(name, id || `auto_${++autoId}`),
+      where: (field: string, op: string, value: any) => ({
+        limit: (count: number) => ({
+          get: async () => {
+            const docs = Array.from(ensureCollection(name).entries())
+              .filter(([, data]) => (op === "==" ? data?.[field] === value : true))
+              .slice(0, count)
+              .map(([id, data]) => ({
+                id,
+                ref: docRef(name, id),
+                data: () => data,
+              }));
+            return { empty: docs.length === 0, docs };
+          },
         }),
-        set: async (payload: Record<string, unknown>) => {
-          const existing = store.get(id) || {};
-          store.set(id, { ...existing, ...payload });
-        },
       }),
     })),
+    runTransaction: async (fn: any) => {
+      const tx = {
+        get: async (ref: any) => ref.get(),
+        set: (ref: any, payload: any, options?: { merge?: boolean }) => ref.set(payload, options),
+      };
+      return fn(tx);
+    },
   };
 
-  return { store, dbMock };
+  return { store, dbMock, ensureCollection };
 });
 
 vi.mock("../../config/firebase", () => ({
@@ -44,7 +79,7 @@ describe("screening payment webhook updates", () => {
   });
 
   it("marks screening paid once and is idempotent on repeat delivery", async () => {
-    store.set("app_1", { screeningStatus: "unpaid" });
+    ensureCollection("rentalApplications").set("app_1", { screeningStatus: "unpaid" });
 
     const session = {
       id: "sess_1",
@@ -60,9 +95,9 @@ describe("screening payment webhook updates", () => {
     });
 
     expect(first.status).toBe("paid_set");
-    expect(store.get("app_1")?.screeningStatus).toBe("processing");
-    expect(typeof store.get("app_1")?.screeningStartedAt).toBe("number");
-    expect(store.get("app_1")?.screeningSessionId).toBe("sess_1");
+    expect(ensureCollection("rentalApplications").get("app_1")?.screeningStatus).toBe("processing");
+    expect(typeof ensureCollection("rentalApplications").get("app_1")?.screeningStartedAt).toBe("number");
+    expect(ensureCollection("rentalApplications").get("app_1")?.screeningSessionId).toBe("sess_1");
 
     const second = await webhookTesting.handleScreeningPaidFromSession({
       session,
@@ -90,6 +125,69 @@ describe("screening payment webhook updates", () => {
 
     expect(result.status).toBe("ignored");
     expect(result.missingApplicationId).toBe(true);
+  });
+
+  it("marks screening payment failed once and records a failed ledger event", async () => {
+    ensureCollection("screeningOrders").set("order_1", {
+      id: "order_1",
+      applicationId: "app_1",
+      landlordId: "landlord_1",
+      propertyId: "prop_1",
+      unitId: "unit_1",
+      status: "unpaid",
+      paymentStatus: "unpaid",
+      finalized: false,
+      amountTotalCents: 4900,
+      currency: "cad",
+      stripePaymentIntentId: "pi_fail_1",
+    });
+    ensureCollection("rentalApplications").set("app_1", {
+      id: "app_1",
+      landlordId: "landlord_1",
+      screening: {},
+    });
+
+    const first = await webhookTesting.handleScreeningPaymentFailure({
+      eventId: "evt_fail_1",
+      eventType: "payment_intent.payment_failed",
+      paymentIntentId: "pi_fail_1",
+      applicationId: "app_1",
+      landlordId: "landlord_1",
+      amountTotalCents: 4900,
+      currency: "cad",
+      failureCode: "card_declined",
+      failureMessage: "Card declined",
+      occurredAt: 1700000000000,
+    });
+
+    expect(first.ok).toBe(true);
+    expect(first.alreadyProcessed).toBe(false);
+    expect(ensureCollection("screeningOrders").get("order_1")?.status).toBe("failed");
+    expect(ensureCollection("screeningOrders").get("order_1")?.paymentStatus).toBe("failed");
+    expect(ensureCollection("rentalApplications").get("app_1")?.screening?.status).toBe("failed");
+    expect(ensureCollection("financialTransactions").get("payment_failed_evt_fail_1")).toEqual(
+      expect.objectContaining({
+        type: "payment_failed",
+        status: "failed",
+        applicationId: "app_1",
+      })
+    );
+
+    const second = await webhookTesting.handleScreeningPaymentFailure({
+      eventId: "evt_fail_1",
+      eventType: "payment_intent.payment_failed",
+      paymentIntentId: "pi_fail_1",
+      applicationId: "app_1",
+      landlordId: "landlord_1",
+      amountTotalCents: 4900,
+      currency: "cad",
+      failureCode: "card_declined",
+      failureMessage: "Card declined",
+      occurredAt: 1700000000001,
+    });
+
+    expect(second.ok).toBe(true);
+    expect(second.alreadyProcessed).toBe(true);
   });
 });
 

--- a/rentchain-api/src/routes/rentalApplicationsRoutes.ts
+++ b/rentchain-api/src/routes/rentalApplicationsRoutes.ts
@@ -35,6 +35,7 @@ import { getLatestApplicationRisk } from "../services/riskAgent/riskAgentService
 import { rateLimitScreeningIp, rateLimitScreeningUser } from "../middleware/rateLimit";
 import { buildEmailHtml, buildEmailText } from "../email/templates/baseEmailTemplate";
 import { sendEmail } from "../services/emailService";
+import { recordScreeningPaymentInitiated } from "../services/screeningPaymentTransactionService";
 
 const router = Router();
 
@@ -1503,6 +1504,19 @@ router.post(
         },
         { merge: true }
       );
+
+      await recordScreeningPaymentInitiated({
+        landlordId,
+        propertyId: data?.propertyId || null,
+        unitId: data?.unitId || null,
+        applicationId: id,
+        screeningOrderId: orderId,
+        amountCents: pricing.totalAmountCents,
+        currency: "CAD",
+        stripeCheckoutSessionId: session.id,
+        serviceLevel,
+        recordedAt: now,
+      });
 
       console.log("[screening_checkout] create_session_ok", {
         ...logBase,

--- a/rentchain-api/src/routes/stripeScreeningOrdersWebhookRoutes.ts
+++ b/rentchain-api/src/routes/stripeScreeningOrdersWebhookRoutes.ts
@@ -9,6 +9,7 @@ import { finalizeStripePayment } from "../services/stripeFinalize";
 import { applyScreeningResultsFromOrder } from "../services/stripeScreeningProcessor";
 import { beginScreening } from "../services/screening/screeningOrchestrator";
 import { writeScreeningEvent } from "../services/screening/screeningEvents";
+import { recordScreeningPaymentFailed } from "../services/screeningPaymentTransactionService";
 
 interface StripeWebhookRequest extends Request {
   rawBody?: Buffer;
@@ -195,6 +196,230 @@ async function handleScreeningPaidFromSession(params: {
     }
   }
   return { status, missingApplicationId: false };
+}
+
+function normalizeString(value: unknown, max = 2000): string {
+  return String(value || "").trim().slice(0, max);
+}
+
+function normalizeOptionalString(value: unknown, max = 2000): string | undefined {
+  const next = normalizeString(value, max);
+  return next || undefined;
+}
+
+function normalizeFailureReason(value: unknown): { code?: string; message?: string } {
+  if (!value || typeof value !== "object") return {};
+  const item = value as any;
+  return {
+    code: normalizeOptionalString(item.code, 120),
+    message: normalizeOptionalString(item.message || item.reason, 500),
+  };
+}
+
+async function resolveOrderRefFromStripePayment(params: {
+  orderId?: string;
+  sessionId?: string;
+  paymentIntentId?: string;
+}) {
+  const orderId = normalizeOptionalString(params.orderId, 120);
+  if (orderId) return db.collection("screeningOrders").doc(orderId);
+
+  const sessionId = normalizeOptionalString(params.sessionId, 120);
+  if (sessionId) {
+    const snap = await db.collection("screeningOrders").where("stripeSessionId", "==", sessionId).limit(1).get();
+    if (!snap.empty) return snap.docs[0].ref;
+  }
+
+  const paymentIntentId = normalizeOptionalString(params.paymentIntentId, 120);
+  if (paymentIntentId) {
+    const snap = await db.collection("screeningOrders").where("stripePaymentIntentId", "==", paymentIntentId).limit(1).get();
+    if (!snap.empty) return snap.docs[0].ref;
+  }
+
+  return null;
+}
+
+async function handleScreeningPaymentFailure(params: {
+  eventId: string;
+  eventType: string;
+  orderId?: string;
+  sessionId?: string;
+  paymentIntentId?: string;
+  stripeChargeId?: string;
+  applicationId?: string;
+  landlordId?: string;
+  amountTotalCents?: number;
+  currency?: string;
+  failureCode?: string;
+  failureMessage?: string;
+  occurredAt: number;
+}): Promise<{ ok: boolean; alreadyProcessed: boolean; alreadyFinalized: boolean; orderIdResolved?: string }> {
+  const eventId = normalizeString(params.eventId, 120);
+  const eventRef = db.collection("stripeEvents").doc(eventId);
+  const orderRef = await resolveOrderRefFromStripePayment({
+    orderId: params.orderId,
+    sessionId: params.sessionId,
+    paymentIntentId: params.paymentIntentId,
+  });
+
+  if (!orderRef) {
+    await eventRef.set(
+      {
+        createdAt: params.occurredAt,
+        type: params.eventType,
+        resolved: false,
+        outcome: "failed",
+        orderId: normalizeOptionalString(params.orderId, 120) || null,
+        sessionId: normalizeOptionalString(params.sessionId, 120) || null,
+        paymentIntentId: normalizeOptionalString(params.paymentIntentId, 120) || null,
+      },
+      { merge: true }
+    );
+    return { ok: false, alreadyProcessed: false, alreadyFinalized: false };
+  }
+
+  const result = await db.runTransaction(async (tx) => {
+    const existingEvent = await tx.get(eventRef);
+    if (existingEvent.exists) {
+      return { ok: true, alreadyProcessed: true, alreadyFinalized: true, orderIdResolved: orderRef.id };
+    }
+
+    const orderSnap = await tx.get(orderRef);
+    if (!orderSnap.exists) {
+      tx.set(
+        eventRef,
+        {
+          createdAt: params.occurredAt,
+          type: params.eventType,
+          resolved: false,
+          outcome: "failed",
+          orderRef: orderRef.path,
+        },
+        { merge: true }
+      );
+      return { ok: false, alreadyProcessed: false, alreadyFinalized: false };
+    }
+
+    const order = orderSnap.data() as any;
+    const canonicalStatus = String(order?.status || "").toLowerCase();
+    const mirroredPaymentStatus = String(order?.paymentStatus || "").toLowerCase();
+    const alreadyFinalized =
+      Boolean(order?.finalized) || canonicalStatus === "paid" || mirroredPaymentStatus === "paid";
+    const applicationId = normalizeOptionalString(params.applicationId, 120) || normalizeOptionalString(order?.applicationId, 120);
+    const appRef = applicationId ? db.collection("rentalApplications").doc(applicationId) : null;
+    const appSnap = appRef ? await tx.get(appRef) : null;
+
+    tx.set(
+      eventRef,
+      {
+        createdAt: params.occurredAt,
+        type: params.eventType,
+        resolved: true,
+        outcome: "failed",
+        orderRef: orderRef.path,
+        orderId: orderRef.id,
+        sessionId: normalizeOptionalString(params.sessionId, 120) || normalizeOptionalString(order?.stripeSessionId, 120) || null,
+        stripeCheckoutSessionId:
+          normalizeOptionalString(params.sessionId, 120) ||
+          normalizeOptionalString(order?.stripeCheckoutSessionId, 120) ||
+          normalizeOptionalString(order?.stripeSessionId, 120) ||
+          null,
+        paymentIntentId:
+          normalizeOptionalString(params.paymentIntentId, 120) || normalizeOptionalString(order?.stripePaymentIntentId, 120) || null,
+        stripeChargeId: normalizeOptionalString(params.stripeChargeId, 120) || normalizeOptionalString(order?.stripeChargeId, 120) || null,
+      },
+      { merge: true }
+    );
+
+    if (alreadyFinalized) {
+      tx.set(
+        orderRef,
+        {
+          lastStripeEventId: eventId,
+          updatedAt: params.occurredAt,
+        },
+        { merge: true }
+      );
+      return { ok: true, alreadyProcessed: false, alreadyFinalized: true, orderIdResolved: orderRef.id };
+    }
+
+    tx.set(
+      orderRef,
+      {
+        status: "failed",
+        paymentStatus: "failed",
+        finalized: false,
+        lastStripeEventId: eventId,
+        stripeSessionId: normalizeOptionalString(params.sessionId, 120) || normalizeOptionalString(order?.stripeSessionId, 120) || null,
+        stripeCheckoutSessionId:
+          normalizeOptionalString(params.sessionId, 120) ||
+          normalizeOptionalString(order?.stripeCheckoutSessionId, 120) ||
+          normalizeOptionalString(order?.stripeSessionId, 120) ||
+          null,
+        stripePaymentIntentId:
+          normalizeOptionalString(params.paymentIntentId, 120) || normalizeOptionalString(order?.stripePaymentIntentId, 120) || null,
+        stripeChargeId: normalizeOptionalString(params.stripeChargeId, 120) || normalizeOptionalString(order?.stripeChargeId, 120) || null,
+        amountTotalCents:
+          typeof params.amountTotalCents === "number" ? Math.round(params.amountTotalCents) : order?.amountTotalCents || order?.totalAmountCents || null,
+        currency: normalizeOptionalString(params.currency, 8)?.toLowerCase() || order?.currency || null,
+        error: {
+          code: normalizeOptionalString(params.failureCode, 120) || null,
+          message: normalizeOptionalString(params.failureMessage, 500) || null,
+        },
+        updatedAt: params.occurredAt,
+      },
+      { merge: true }
+    );
+
+    if (appRef && appSnap?.exists) {
+      tx.set(
+        appRef,
+        {
+          screening: {
+            ...((appSnap.data() as any)?.screening || {}),
+            status: "failed",
+            failedAt: params.occurredAt,
+            orderId: orderRef.id,
+            errorCode: normalizeOptionalString(params.failureCode, 120) || null,
+          },
+          updatedAt: params.occurredAt,
+        },
+        { merge: true }
+      );
+    }
+
+    return { ok: true, alreadyProcessed: false, alreadyFinalized: false, orderIdResolved: orderRef.id };
+  });
+
+  if (result.ok && !result.alreadyProcessed && !result.alreadyFinalized) {
+    try {
+      const orderSnap = await db.collection("screeningOrders").doc(result.orderIdResolved || orderRef.id).get();
+      const order = orderSnap.data() as any;
+      await recordScreeningPaymentFailed({
+        landlordId: normalizeOptionalString(params.landlordId, 120) || normalizeOptionalString(order?.landlordId, 120) || "",
+        propertyId: normalizeOptionalString(order?.propertyId, 120) || null,
+        unitId: normalizeOptionalString(order?.unitId, 120) || null,
+        applicationId: normalizeOptionalString(params.applicationId, 120) || normalizeOptionalString(order?.applicationId, 120) || null,
+        screeningOrderId: result.orderIdResolved || orderRef.id,
+        amountCents:
+          typeof params.amountTotalCents === "number" ? Math.round(params.amountTotalCents) : Number(order?.amountTotalCents || order?.totalAmountCents || 0),
+        currency: normalizeOptionalString(params.currency, 8) || order?.currency || "cad",
+        stripeCheckoutSessionId:
+          normalizeOptionalString(params.sessionId, 120) || normalizeOptionalString(order?.stripeCheckoutSessionId, 120) || null,
+        stripePaymentIntentId: normalizeOptionalString(params.paymentIntentId, 120) || normalizeOptionalString(order?.stripePaymentIntentId, 120) || null,
+        stripeChargeId: normalizeOptionalString(params.stripeChargeId, 120) || normalizeOptionalString(order?.stripeChargeId, 120) || null,
+        stripeEventId: eventId,
+        eventType: params.eventType,
+        failureCode: params.failureCode,
+        failureMessage: params.failureMessage,
+        recordedAt: params.occurredAt,
+      });
+    } catch (err: any) {
+      console.warn("[stripe-webhook-orders] failed to record failed transaction", err?.message || err);
+    }
+  }
+
+  return result;
 }
 
 export const stripeWebhookHandler = async (req: StripeWebhookRequest, res: Response) => {
@@ -454,6 +679,89 @@ export const stripeWebhookHandler = async (req: StripeWebhookRequest, res: Respo
     }
   }
 
+  if (event.type === "checkout.session.async_payment_failed" || event.type === "payment_intent.payment_failed") {
+    try {
+      let orderId: string | undefined;
+      let sessionId: string | undefined;
+      let paymentIntentId: string | undefined;
+      let stripeChargeId: string | undefined;
+      let amountTotalCents: number | undefined;
+      let currency: string | undefined;
+      let landlordId: string | undefined;
+      let applicationId: string | undefined;
+      let failureCode: string | undefined;
+      let failureMessage: string | undefined;
+
+      if (event.type === "payment_intent.payment_failed") {
+        const pi = event.data.object as Stripe.PaymentIntent;
+        orderId = pi.metadata?.orderId;
+        applicationId = pi.metadata?.applicationId;
+        landlordId = pi.metadata?.landlordId;
+        paymentIntentId = pi.id;
+        stripeChargeId = typeof pi.latest_charge === "string" ? pi.latest_charge : undefined;
+        amountTotalCents = typeof pi.amount === "number" ? pi.amount : undefined;
+        currency = pi.currency || undefined;
+        const failure = normalizeFailureReason(pi.last_payment_error);
+        failureCode = failure.code;
+        failureMessage = failure.message;
+
+        if (!orderId) {
+          try {
+            const sessions = await stripe.checkout.sessions.list({
+              payment_intent: pi.id,
+              limit: 1,
+            });
+            const s = sessions.data?.[0];
+            if (s) {
+              sessionId = s.id;
+              orderId =
+                (s.client_reference_id as string | null) ||
+                (s.metadata?.orderId as string | undefined) ||
+                undefined;
+              applicationId = applicationId || (s.metadata?.applicationId as string | undefined) || undefined;
+              landlordId = landlordId || (s.metadata?.landlordId as string | undefined) || undefined;
+            }
+          } catch {
+            // Non-blocking: if lookup fails we still attempt direct order resolution below.
+          }
+        }
+      } else {
+        const session = event.data.object as Stripe.Checkout.Session;
+        orderId =
+          (session.client_reference_id as string | null) ||
+          (session.metadata?.orderId as string | undefined);
+        applicationId = session.metadata?.applicationId || session.metadata?.rentalApplicationId;
+        landlordId = session.metadata?.landlordId;
+        sessionId = session.id;
+        paymentIntentId = typeof session.payment_intent === "string" ? session.payment_intent : undefined;
+        amountTotalCents = typeof session.amount_total === "number" ? session.amount_total : undefined;
+        currency = session.currency || undefined;
+        failureCode = normalizeOptionalString((session as any)?.last_payment_error?.code, 120);
+        failureMessage =
+          normalizeOptionalString((session as any)?.last_payment_error?.message, 500) ||
+          normalizeOptionalString((session as any)?.status, 120);
+      }
+
+      await handleScreeningPaymentFailure({
+        eventId: event.id,
+        eventType: event.type,
+        orderId,
+        sessionId,
+        paymentIntentId,
+        stripeChargeId,
+        applicationId,
+        landlordId,
+        amountTotalCents,
+        currency,
+        failureCode,
+        failureMessage,
+        occurredAt: typeof event.created === "number" ? event.created * 1000 : Date.now(),
+      });
+    } catch (err: any) {
+      console.error("[stripe-webhook-orders] failure handler failed", err?.stack || err);
+    }
+  }
+
   return res.status(200).json({ received: true });
 };
 
@@ -464,4 +772,5 @@ export default router;
 export const __testing = {
   markApplicationScreeningPaid,
   handleScreeningPaidFromSession,
+  handleScreeningPaymentFailure,
 };

--- a/rentchain-api/src/services/__tests__/screeningPaymentTransactionService.test.ts
+++ b/rentchain-api/src/services/__tests__/screeningPaymentTransactionService.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type StoredDoc = { id: string; data: any };
+
+const { dbMock, resetDb, getDoc } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, StoredDoc>>();
+  let autoId = 0;
+
+  function ensureCollection(name: string) {
+    if (!collections.has(name)) collections.set(name, new Map());
+    return collections.get(name)!;
+  }
+
+  return {
+    dbMock: {
+      collection: (name: string) => ({
+        doc: (id?: string) => {
+          const docId = id || `auto_${++autoId}`;
+          return {
+            id: docId,
+            set: async (payload: any) => {
+              ensureCollection(name).set(docId, { id: docId, data: payload });
+            },
+            get: async () => {
+              const row = ensureCollection(name).get(docId);
+              return { id: docId, exists: Boolean(row), data: () => row?.data };
+            },
+          };
+        },
+        where: (field: string, op: string, value: any) => ({
+          get: async () => {
+            const rows = Array.from(ensureCollection(name).values()).filter((entry) =>
+              op === "==" ? entry.data?.[field] === value : true
+            );
+            return {
+              docs: rows.map((row) => ({ id: row.id, data: () => row.data })),
+            };
+          },
+        }),
+      }),
+    },
+    resetDb: () => {
+      collections.clear();
+      autoId = 0;
+    },
+    getDoc: (collectionName: string, id: string) => ensureCollection(collectionName).get(id)?.data || null,
+  };
+});
+
+vi.mock("../../config/firebase", () => ({
+  db: dbMock,
+}));
+
+describe("screeningPaymentTransactionService", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    resetDb();
+  });
+
+  it("records a deterministic initiated payment transaction for screening checkout", async () => {
+    const { recordScreeningPaymentInitiated } = await import("../screeningPaymentTransactionService");
+    await recordScreeningPaymentInitiated({
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      applicationId: "app-1",
+      screeningOrderId: "order-1",
+      amountCents: 4900,
+      currency: "cad",
+      stripeCheckoutSessionId: "sess_1",
+      serviceLevel: "VERIFIED",
+      recordedAt: 1000,
+    });
+
+    expect(getDoc("financialTransactions", "payment_initiated_order-1")).toEqual(
+      expect.objectContaining({
+        id: "payment_initiated_order-1",
+        landlordId: "landlord-1",
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        applicationId: "app-1",
+        type: "payment_initiated",
+        amountCents: 4900,
+        currency: "CAD",
+        status: "pending",
+      })
+    );
+  });
+
+  it("records deterministic success and failure transactions keyed by stripe event id", async () => {
+    const { recordScreeningPaymentSucceeded, recordScreeningPaymentFailed } = await import(
+      "../screeningPaymentTransactionService"
+    );
+
+    await recordScreeningPaymentSucceeded({
+      landlordId: "landlord-1",
+      applicationId: "app-1",
+      screeningOrderId: "order-1",
+      amountCents: 4900,
+      currency: "cad",
+      stripeEventId: "evt_success",
+      eventType: "checkout.session.completed",
+    });
+    await recordScreeningPaymentFailed({
+      landlordId: "landlord-1",
+      applicationId: "app-1",
+      screeningOrderId: "order-1",
+      amountCents: 4900,
+      currency: "cad",
+      stripeEventId: "evt_failed",
+      eventType: "payment_intent.payment_failed",
+      failureCode: "card_declined",
+      failureMessage: "Card was declined",
+    });
+
+    expect(getDoc("financialTransactions", "payment_succeeded_evt_success")).toEqual(
+      expect.objectContaining({
+        type: "payment_succeeded",
+        status: "completed",
+        applicationId: "app-1",
+      })
+    );
+    expect(getDoc("financialTransactions", "payment_failed_evt_failed")).toEqual(
+      expect.objectContaining({
+        type: "payment_failed",
+        status: "failed",
+        applicationId: "app-1",
+        metadata: expect.objectContaining({
+          failureCode: "card_declined",
+        }),
+      })
+    );
+  });
+});

--- a/rentchain-api/src/services/__tests__/stripeFinalize.test.ts
+++ b/rentchain-api/src/services/__tests__/stripeFinalize.test.ts
@@ -37,7 +37,7 @@ const { dbMock, resetDb, upsertDoc, getDoc } = vi.hoisted(() => {
   return {
     dbMock: {
       collection: (name: string) => ({
-        doc: (id: string) => docRef(name, id),
+        doc: (id?: string) => docRef(name, id || `${name}_${Date.now()}`),
         where: (field: string, op: string, value: any) => ({
           limit: (count: number) => ({
             get: async () => {
@@ -132,6 +132,10 @@ describe("finalizeStripePayment", () => {
     const app = getDoc("rentalApplications", "app_1");
     expect(app?.screening?.status).toBe("paid");
     expect(app?.screening?.orderId).toBe("order_1");
+    const transaction = getDoc("financialTransactions", "payment_succeeded_evt_1");
+    expect(transaction?.type).toBe("payment_succeeded");
+    expect(transaction?.status).toBe("completed");
+    expect(transaction?.applicationId).toBe("app_1");
     expect(enqueueScreeningJobMock).toHaveBeenCalledTimes(1);
   });
 

--- a/rentchain-api/src/services/financialTransactionService.ts
+++ b/rentchain-api/src/services/financialTransactionService.ts
@@ -21,6 +21,8 @@ export type FinancialTransaction = {
   landlordId: string;
   propertyId?: string;
   unitId?: string;
+  tenantId?: string;
+  applicationId?: string;
   maintenanceRequestId?: string;
   workOrderId?: string;
   type: FinancialTransactionType;
@@ -33,6 +35,7 @@ export type FinancialTransaction = {
 };
 
 type CreateFinancialTransactionInput = Omit<FinancialTransaction, "id" | "createdAt" | "updatedAt"> & {
+  id?: string;
   createdAt?: number;
   updatedAt?: number;
 };
@@ -98,6 +101,8 @@ function toFinancialTransaction(id: string, data: any): FinancialTransaction {
     landlordId: asString(data?.landlordId, 120),
     propertyId: asOptionalString(data?.propertyId, 120),
     unitId: asOptionalString(data?.unitId, 120),
+    tenantId: asOptionalString(data?.tenantId, 120),
+    applicationId: asOptionalString(data?.applicationId, 120),
     maintenanceRequestId: asOptionalString(data?.maintenanceRequestId, 120),
     workOrderId: asOptionalString(data?.workOrderId, 120),
     type: normalizeTransactionType(data?.type),
@@ -113,12 +118,15 @@ function toFinancialTransaction(id: string, data: any): FinancialTransaction {
 export async function createTransaction(input: CreateFinancialTransactionInput): Promise<FinancialTransaction> {
   const createdAt = normalizeTimestamp(input.createdAt, nowMs());
   const updatedAt = normalizeTimestamp(input.updatedAt, createdAt);
-  const ref = db.collection("financialTransactions").doc();
+  const requestedId = asOptionalString(input.id, 200);
+  const ref = requestedId ? db.collection("financialTransactions").doc(requestedId) : db.collection("financialTransactions").doc();
   const record: FinancialTransaction = {
     id: ref.id,
     landlordId: asString(input.landlordId, 120),
     propertyId: asOptionalString(input.propertyId, 120),
     unitId: asOptionalString(input.unitId, 120),
+    tenantId: asOptionalString(input.tenantId, 120),
+    applicationId: asOptionalString(input.applicationId, 120),
     maintenanceRequestId: asOptionalString(input.maintenanceRequestId, 120),
     workOrderId: asOptionalString(input.workOrderId, 120),
     type: normalizeTransactionType(input.type),

--- a/rentchain-api/src/services/screeningPaymentTransactionService.ts
+++ b/rentchain-api/src/services/screeningPaymentTransactionService.ts
@@ -1,0 +1,126 @@
+import { createTransaction } from "./financialTransactionService";
+
+type ScreeningPaymentTransactionContext = {
+  landlordId: string;
+  propertyId?: string | null;
+  unitId?: string | null;
+  tenantId?: string | null;
+  applicationId?: string | null;
+  screeningOrderId: string;
+  amountCents: number;
+  currency?: string | null;
+  stripeCheckoutSessionId?: string | null;
+  stripePaymentIntentId?: string | null;
+  stripeChargeId?: string | null;
+  stripeEventId?: string | null;
+  eventType?: string | null;
+  serviceLevel?: string | null;
+  failureCode?: string | null;
+  failureMessage?: string | null;
+  recordedAt?: number;
+};
+
+function asString(value: unknown, max = 2000): string {
+  return String(value || "").trim().slice(0, max);
+}
+
+function asOptionalString(value: unknown, max = 2000): string | undefined {
+  const next = asString(value, max);
+  return next || undefined;
+}
+
+function normalizeCurrency(value: unknown) {
+  const next = asString(value, 8).toUpperCase();
+  return /^[A-Z]{3}$/.test(next) ? next : "CAD";
+}
+
+function buildTransactionId(prefix: string, key: string) {
+  return `${prefix}_${String(key || "")
+    .trim()
+    .replace(/[^a-zA-Z0-9_-]/g, "_")
+    .slice(0, 160)}`;
+}
+
+export async function recordScreeningPaymentInitiated(context: ScreeningPaymentTransactionContext) {
+  const screeningOrderId = asString(context.screeningOrderId, 120);
+  const recordedAt = typeof context.recordedAt === "number" ? context.recordedAt : Date.now();
+  return createTransaction({
+    id: buildTransactionId("payment_initiated", screeningOrderId),
+    landlordId: asString(context.landlordId, 120),
+    propertyId: asOptionalString(context.propertyId, 120),
+    unitId: asOptionalString(context.unitId, 120),
+    tenantId: asOptionalString(context.tenantId, 120),
+    applicationId: asOptionalString(context.applicationId, 120),
+    type: "payment_initiated",
+    amountCents: Number(context.amountCents || 0),
+    currency: normalizeCurrency(context.currency),
+    status: "pending",
+    metadata: {
+      paymentRail: "stripe_checkout",
+      screeningOrderId,
+      stripeCheckoutSessionId: asOptionalString(context.stripeCheckoutSessionId, 120),
+      stripePaymentIntentId: asOptionalString(context.stripePaymentIntentId, 120),
+      serviceLevel: asOptionalString(context.serviceLevel, 80),
+    },
+    createdAt: recordedAt,
+    updatedAt: recordedAt,
+  });
+}
+
+export async function recordScreeningPaymentSucceeded(context: ScreeningPaymentTransactionContext) {
+  const key = asOptionalString(context.stripeEventId, 120) || asString(context.screeningOrderId, 120);
+  const recordedAt = typeof context.recordedAt === "number" ? context.recordedAt : Date.now();
+  return createTransaction({
+    id: buildTransactionId("payment_succeeded", key),
+    landlordId: asString(context.landlordId, 120),
+    propertyId: asOptionalString(context.propertyId, 120),
+    unitId: asOptionalString(context.unitId, 120),
+    tenantId: asOptionalString(context.tenantId, 120),
+    applicationId: asOptionalString(context.applicationId, 120),
+    type: "payment_succeeded",
+    amountCents: Number(context.amountCents || 0),
+    currency: normalizeCurrency(context.currency),
+    status: "completed",
+    metadata: {
+      paymentRail: "stripe_checkout",
+      screeningOrderId: asString(context.screeningOrderId, 120),
+      stripeCheckoutSessionId: asOptionalString(context.stripeCheckoutSessionId, 120),
+      stripePaymentIntentId: asOptionalString(context.stripePaymentIntentId, 120),
+      stripeChargeId: asOptionalString(context.stripeChargeId, 120),
+      stripeEventId: asOptionalString(context.stripeEventId, 120),
+      stripeEventType: asOptionalString(context.eventType, 120),
+    },
+    createdAt: recordedAt,
+    updatedAt: recordedAt,
+  });
+}
+
+export async function recordScreeningPaymentFailed(context: ScreeningPaymentTransactionContext) {
+  const key = asOptionalString(context.stripeEventId, 120) || asString(context.screeningOrderId, 120);
+  const recordedAt = typeof context.recordedAt === "number" ? context.recordedAt : Date.now();
+  return createTransaction({
+    id: buildTransactionId("payment_failed", key),
+    landlordId: asString(context.landlordId, 120),
+    propertyId: asOptionalString(context.propertyId, 120),
+    unitId: asOptionalString(context.unitId, 120),
+    tenantId: asOptionalString(context.tenantId, 120),
+    applicationId: asOptionalString(context.applicationId, 120),
+    type: "payment_failed",
+    amountCents: Number(context.amountCents || 0),
+    currency: normalizeCurrency(context.currency),
+    status: "failed",
+    metadata: {
+      paymentRail: "stripe_checkout",
+      screeningOrderId: asString(context.screeningOrderId, 120),
+      stripeCheckoutSessionId: asOptionalString(context.stripeCheckoutSessionId, 120),
+      stripePaymentIntentId: asOptionalString(context.stripePaymentIntentId, 120),
+      stripeChargeId: asOptionalString(context.stripeChargeId, 120),
+      stripeEventId: asOptionalString(context.stripeEventId, 120),
+      stripeEventType: asOptionalString(context.eventType, 120),
+      failureCode: asOptionalString(context.failureCode, 120),
+      failureMessage: asOptionalString(context.failureMessage, 500),
+    },
+    createdAt: recordedAt,
+    updatedAt: recordedAt,
+  });
+}

--- a/rentchain-api/src/services/stripeFinalize.ts
+++ b/rentchain-api/src/services/stripeFinalize.ts
@@ -1,5 +1,6 @@
 import { db } from "../config/firebase";
 import { enqueueScreeningJob } from "./screeningJobs";
+import { recordScreeningPaymentSucceeded } from "./screeningPaymentTransactionService";
 
 export type FinalizeStripeArgs = {
   eventId: string;
@@ -217,6 +218,28 @@ export async function finalizeStripePayment(
   });
 
   if (result.ok && !result.alreadyFinalized) {
+    try {
+      const orderSnap = await db.collection("screeningOrders").doc(orderRef.id).get();
+      const order = orderSnap.data() as any;
+      await recordScreeningPaymentSucceeded({
+        landlordId: normStr(args.landlordId) || normStr(order?.landlordId) || "",
+        propertyId: normStr(order?.propertyId) || null,
+        unitId: normStr(order?.unitId) || null,
+        applicationId: normStr(args.applicationId) || normStr(order?.applicationId) || null,
+        screeningOrderId: orderRef.id,
+        amountCents: amountTotalCents ?? normInt(order?.amountTotalCents) ?? normInt(order?.totalAmountCents) ?? 0,
+        currency: currency ?? normStr(order?.currency) ?? "cad",
+        stripeCheckoutSessionId:
+          normStr(args.sessionId) || normStr(order?.stripeCheckoutSessionId) || normStr(order?.stripeSessionId) || null,
+        stripePaymentIntentId: normStr(args.paymentIntentId) || normStr(order?.stripePaymentIntentId) || null,
+        stripeChargeId: normStr(args.stripeChargeId) || normStr(order?.stripeChargeId) || null,
+        stripeEventId: eventId,
+        eventType: normStr(args.eventType) || null,
+      });
+    } catch (err: any) {
+      console.warn("[stripe-finalize] failed to record success transaction", err?.message || err);
+    }
+
     try {
       let resolvedApplicationId = normStr(args.applicationId);
       let resolvedLandlordId = normStr(args.landlordId);


### PR DESCRIPTION
## Summary
Adds Payment Rails Implementation v1 on the existing screening Stripe checkout flow.

This keeps the payment rail narrow and backend-first by wiring Stripe payment lifecycle events into RentChain’s financial transaction ledger:
- `payment_initiated` on checkout creation
- `payment_succeeded` on verified webhook finalization
- `payment_failed` on verified Stripe failure webhooks

## Scope
- Reuses the existing screening checkout entry point
- Adds a small screening payment transaction service
- Extends webhook handling for failed payment outcomes
- Records ledger-backed internal payment events with idempotent transaction IDs
- Updates targeted backend tests for initiation, success, and failure flows

## Notes
This is not a billing redesign or a Connect rollout. Stripe remains the payment rail, while RentChain’s financial transaction ledger remains the internal system of record.

## Validation
- Passed targeted backend tests for screening payment initiation, success/failure webhook handling, and ledger recording
- Passed backend build