### PR TITLE
feat: normalize core workflow events into canonical v1 event model

### DIFF
--- a/rentchain-api/src/lib/events/__tests__/eventBuilder.test.ts
+++ b/rentchain-api/src/lib/events/__tests__/eventBuilder.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../config/firebase", () => ({
+  db: {
+    collection: () => ({
+      doc: () => ({
+        set: async () => undefined,
+      }),
+    }),
+  },
+}));
+
+describe("buildEvent", () => {
+  it("always includes the required canonical fields", async () => {
+    const { buildEvent } = await import("../buildEvent");
+    const event = buildEvent({
+      domain: "maintenance",
+      action: "request_created",
+      actor: { type: "tenant", id: "tenant-1" },
+      resource: { type: "maintenance_request", id: "mr-1" },
+      occurredAt: 1700000000000,
+      visibility: "landlord",
+      summary: "Maintenance request created",
+    });
+
+    expect(event.version).toBe("v1");
+    expect(event.type).toBe("maintenance.request_created");
+    expect(event.domain).toBe("maintenance");
+    expect(event.action).toBe("request_created");
+    expect(event.actor).toEqual({
+      type: "tenant",
+      id: "tenant-1",
+      role: null,
+      displayName: null,
+    });
+    expect(event.resource).toEqual({
+      type: "maintenance_request",
+      id: "mr-1",
+      parentType: null,
+      parentId: null,
+    });
+    expect(event.visibility).toBe("landlord");
+    expect(event.summary).toBe("Maintenance request created");
+  });
+
+  it("keeps actor null-safe while still requiring a resource block", async () => {
+    const { buildEvent } = await import("../buildEvent");
+    const event = buildEvent({
+      domain: "application",
+      action: "submitted",
+      resource: { type: "application", id: "app-1" },
+      summary: "Application submitted",
+    });
+
+    expect(event.actor).toEqual({
+      type: undefined,
+      id: null,
+      role: null,
+      displayName: null,
+    });
+    expect(event.resource.type).toBe("application");
+    expect(event.resource.id).toBe("app-1");
+  });
+
+  it("falls back visibility to internal", async () => {
+    const { buildEvent } = await import("../buildEvent");
+    const event = buildEvent({
+      domain: "expense",
+      action: "created",
+      resource: { type: "expense", id: "expense-1" },
+      visibility: "unknown",
+      summary: "Expense created",
+    });
+
+    expect(event.visibility).toBe("internal");
+  });
+
+  it("preserves metadata payloads", async () => {
+    const { buildEvent } = await import("../buildEvent");
+    const event = buildEvent({
+      domain: "screening",
+      action: "blocked",
+      resource: { type: "rental_application", id: "app-1" },
+      summary: "Screening blocked",
+      metadata: { reasonCode: "provider_unavailable", status: "blocked" },
+    });
+
+    expect(event.metadata).toEqual({
+      reasonCode: "provider_unavailable",
+      status: "blocked",
+    });
+  });
+
+  it("emits valid ISO timestamps", async () => {
+    const { buildEvent } = await import("../buildEvent");
+    const event = buildEvent({
+      domain: "lease",
+      action: "activated",
+      resource: { type: "lease", id: "lease-1" },
+      occurredAt: "2026-01-01T12:00:00.000Z",
+      summary: "Lease activated",
+    });
+
+    expect(() => new Date(event.occurredAt).toISOString()).not.toThrow();
+    expect(() => new Date(event.recordedAt).toISOString()).not.toThrow();
+  });
+});

--- a/rentchain-api/src/lib/events/buildEvent.ts
+++ b/rentchain-api/src/lib/events/buildEvent.ts
@@ -1,0 +1,135 @@
+import crypto from "crypto";
+import { db } from "../../config/firebase";
+import { normalizeEventVisibility } from "./eventVisibility";
+import type {
+  CanonicalEventActorType,
+  CanonicalEventDomain,
+  CanonicalEventV1,
+  CanonicalEventVisibility,
+} from "./eventTypes";
+
+export const CANONICAL_EVENTS_COLLECTION = "canonicalEvents";
+
+const ALLOWED_DOMAINS = new Set<CanonicalEventDomain>([
+  "application",
+  "screening",
+  "lease",
+  "maintenance",
+  "expense",
+  "tenant",
+  "billing",
+  "policy",
+  "system",
+]);
+
+type CanonicalEventInput = {
+  id?: string;
+  type?: string;
+  domain: CanonicalEventDomain;
+  action: string;
+  status?: string | null;
+  actor?: {
+    type?: CanonicalEventActorType;
+    id?: string | null;
+    role?: string | null;
+    displayName?: string | null;
+  } | null;
+  resource?: {
+    type?: string | null;
+    id?: string | null;
+    parentType?: string | null;
+    parentId?: string | null;
+  } | null;
+  occurredAt?: string | number | Date | null;
+  visibility?: CanonicalEventVisibility | string | null;
+  summary: string;
+  metadata?: Record<string, unknown>;
+  metrics?: Record<string, number | null>;
+  tags?: string[];
+};
+
+function toIsoTimestamp(value: string | number | Date | null | undefined, fallback: Date): string {
+  if (value == null) return fallback.toISOString();
+  if (value instanceof Date) {
+    const millis = value.getTime();
+    return Number.isFinite(millis) ? value.toISOString() : fallback.toISOString();
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return new Date(value).toISOString();
+  }
+  const raw = String(value).trim();
+  const parsed = Date.parse(raw);
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : fallback.toISOString();
+}
+
+function normalizeActor(input: CanonicalEventInput["actor"]): CanonicalEventV1["actor"] {
+  return {
+    type: input?.type,
+    id: input?.id == null ? null : String(input.id).trim() || null,
+    role: input?.role == null ? null : String(input.role).trim() || null,
+    displayName: input?.displayName == null ? null : String(input.displayName).trim() || null,
+  };
+}
+
+function normalizeResource(input: CanonicalEventInput["resource"]): CanonicalEventV1["resource"] {
+  const type = String(input?.type || "")
+    .trim()
+    .slice(0, 120);
+  const id = String(input?.id || "")
+    .trim()
+    .slice(0, 240);
+  if (!type || !id) {
+    throw new Error("canonical_event_resource_required");
+  }
+  return {
+    type,
+    id,
+    parentType: input?.parentType == null ? null : String(input.parentType).trim() || null,
+    parentId: input?.parentId == null ? null : String(input.parentId).trim() || null,
+  };
+}
+
+export function buildEvent(input: CanonicalEventInput): CanonicalEventV1 {
+  const domain = String(input.domain || "").trim() as CanonicalEventDomain;
+  if (!ALLOWED_DOMAINS.has(domain)) {
+    throw new Error("canonical_event_domain_invalid");
+  }
+  const action = String(input.action || "")
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "_");
+  if (!action) {
+    throw new Error("canonical_event_action_required");
+  }
+  const summary = String(input.summary || "").trim();
+  if (!summary) {
+    throw new Error("canonical_event_summary_required");
+  }
+
+  const now = new Date();
+  const event: CanonicalEventV1 = {
+    id: String(input.id || "").trim() || crypto.randomUUID(),
+    version: "v1",
+    type: String(input.type || "").trim() || `${domain}.${action}`,
+    domain,
+    action,
+    status: input.status == null ? null : String(input.status).trim() || null,
+    actor: normalizeActor(input.actor),
+    resource: normalizeResource(input.resource),
+    occurredAt: toIsoTimestamp(input.occurredAt, now),
+    recordedAt: now.toISOString(),
+    visibility: normalizeEventVisibility(input.visibility),
+    summary,
+    metadata: input.metadata || undefined,
+    metrics: input.metrics || undefined,
+    tags: Array.isArray(input.tags) ? input.tags.filter(Boolean) : undefined,
+  };
+
+  return event;
+}
+
+export async function writeCanonicalEvent(input: CanonicalEventInput): Promise<CanonicalEventV1> {
+  const event = buildEvent(input);
+  await db.collection(CANONICAL_EVENTS_COLLECTION).doc(event.id).set(event, { merge: false });
+  return event;
+}

--- a/rentchain-api/src/lib/events/eventMappers.ts
+++ b/rentchain-api/src/lib/events/eventMappers.ts
@@ -1,0 +1,134 @@
+import { buildEvent } from "./buildEvent";
+import type { CanonicalEventV1, CanonicalEventVisibility } from "./eventTypes";
+
+function toIso(value: unknown): string | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return new Date(value).toISOString();
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) return new Date(parsed).toISOString();
+  }
+  return undefined;
+}
+
+function legacyVisibility(value: unknown): CanonicalEventVisibility {
+  const normalized = String(value || "").trim().toLowerCase();
+  if (normalized === "tenant" || normalized === "landlord" || normalized === "admin" || normalized === "system") {
+    return normalized as CanonicalEventVisibility;
+  }
+  return "internal";
+}
+
+export function mapLegacyScreeningEventToCanonical(input: {
+  id?: string;
+  applicationId?: string | null;
+  orderId?: string | null;
+  landlordId?: string | null;
+  type?: string | null;
+  at?: number | string | null;
+  actor?: string | null;
+  meta?: Record<string, unknown> | null;
+}): CanonicalEventV1 {
+  const action = String(input.type || "legacy_event").trim().toLowerCase();
+  const resourceId = String(input.applicationId || input.orderId || "").trim() || "unknown";
+  return buildEvent({
+    id: input.id,
+    domain: "screening",
+    action,
+    actor: {
+      type: input.actor === "admin" ? "admin" : input.actor === "landlord" ? "landlord" : "system",
+      id: input.landlordId || null,
+      role: input.actor || null,
+    },
+    resource: {
+      type: input.applicationId ? "rental_application" : "screening_order",
+      id: resourceId,
+      parentType: input.applicationId && input.orderId ? "screening_order" : null,
+      parentId: input.applicationId && input.orderId ? String(input.orderId) : null,
+    },
+    occurredAt: input.at || undefined,
+    visibility: "internal",
+    summary: `Legacy screening event: ${action.replace(/_/g, " ")}`,
+    metadata: {
+      legacyType: input.type || null,
+      legacyMeta: input.meta || null,
+      orderId: input.orderId || null,
+      applicationId: input.applicationId || null,
+    },
+  });
+}
+
+export function mapLegacyAuditEventToCanonical(input: {
+  id?: string;
+  kind?: string | null;
+  entityType?: string | null;
+  entityId?: string | null;
+  timestamp?: string | null;
+  summary?: string | null;
+  detail?: string | null;
+  meta?: Record<string, unknown> | null;
+}): CanonicalEventV1 {
+  const kind = String(input.kind || "system.info").trim().toLowerCase();
+  const [domainCandidate, actionCandidate] = kind.includes(".")
+    ? kind.split(".", 2)
+    : ["system", "info"];
+  const domain = domainCandidate === "application" || domainCandidate === "billing" || domainCandidate === "system"
+    ? domainCandidate
+    : "system";
+  return buildEvent({
+    id: input.id,
+    domain,
+    action: actionCandidate || "info",
+    resource: {
+      type: String(input.entityType || "entity").trim() || "entity",
+      id: String(input.entityId || "unknown").trim() || "unknown",
+    },
+    occurredAt: input.timestamp || undefined,
+    visibility: "internal",
+    summary: String(input.summary || "Legacy audit event").trim() || "Legacy audit event",
+    metadata: {
+      detail: input.detail || null,
+      legacyKind: input.kind || null,
+      legacyMeta: input.meta || null,
+    },
+  });
+}
+
+export function mapLegacyActivityEventToCanonical(input: {
+  id?: string;
+  type?: string | null;
+  propertyId?: string | null;
+  unitId?: string | null;
+  actorType?: string | null;
+  actorId?: string | null;
+  createdAt?: string | number | null;
+  summary?: string | null;
+  visibility?: string | null;
+  metadata?: Record<string, unknown> | null;
+}): CanonicalEventV1 {
+  const action = String(input.type || "activity").trim().toLowerCase().replace(/\./g, "_");
+  return buildEvent({
+    id: input.id,
+    domain: "system",
+    action,
+    actor: {
+      type: input.actorType === "admin" ? "admin" : input.actorType === "tenant" ? "tenant" : "user",
+      id: input.actorId || null,
+      role: input.actorType || null,
+    },
+    resource: {
+      type: input.unitId ? "unit" : "property",
+      id: String(input.unitId || input.propertyId || "unknown").trim() || "unknown",
+      parentType: input.unitId ? "property" : null,
+      parentId: input.unitId ? String(input.propertyId || "").trim() || null : null,
+    },
+    occurredAt: input.createdAt || undefined,
+    visibility: legacyVisibility(input.visibility),
+    summary: String(input.summary || "Legacy activity event").trim() || "Legacy activity event",
+    metadata: {
+      propertyId: input.propertyId || null,
+      unitId: input.unitId || null,
+      legacyMetadata: input.metadata || null,
+      legacyType: input.type || null,
+    },
+  });
+}

--- a/rentchain-api/src/lib/events/eventTypes.ts
+++ b/rentchain-api/src/lib/events/eventTypes.ts
@@ -1,0 +1,54 @@
+export type CanonicalEventDomain =
+  | "application"
+  | "screening"
+  | "lease"
+  | "maintenance"
+  | "expense"
+  | "tenant"
+  | "billing"
+  | "policy"
+  | "system";
+
+export type CanonicalEventActorType =
+  | "user"
+  | "system"
+  | "admin"
+  | "tenant"
+  | "landlord"
+  | "contractor"
+  | "service";
+
+export type CanonicalEventVisibility =
+  | "internal"
+  | "landlord"
+  | "tenant"
+  | "admin"
+  | "system";
+
+export type CanonicalEventV1 = {
+  id: string;
+  version: "v1";
+  type: string;
+  domain: CanonicalEventDomain;
+  action: string;
+  status?: string | null;
+  actor: {
+    type?: CanonicalEventActorType;
+    id?: string | null;
+    role?: string | null;
+    displayName?: string | null;
+  };
+  resource: {
+    type: string;
+    id: string;
+    parentType?: string | null;
+    parentId?: string | null;
+  };
+  occurredAt: string;
+  recordedAt: string;
+  visibility: CanonicalEventVisibility;
+  summary: string;
+  metadata?: Record<string, unknown>;
+  metrics?: Record<string, number | null>;
+  tags?: string[];
+};

--- a/rentchain-api/src/lib/events/eventVisibility.ts
+++ b/rentchain-api/src/lib/events/eventVisibility.ts
@@ -1,0 +1,16 @@
+import type { CanonicalEventVisibility } from "./eventTypes";
+
+const ALLOWED_VISIBILITY = new Set<CanonicalEventVisibility>([
+  "internal",
+  "landlord",
+  "tenant",
+  "admin",
+  "system",
+]);
+
+export function normalizeEventVisibility(value: unknown): CanonicalEventVisibility {
+  const normalized = String(value || "")
+    .trim()
+    .toLowerCase() as CanonicalEventVisibility;
+  return ALLOWED_VISIBILITY.has(normalized) ? normalized : "internal";
+}

--- a/rentchain-api/src/routes/__tests__/rentalApplicationsCanonicalEvents.test.ts
+++ b/rentchain-api/src/routes/__tests__/rentalApplicationsCanonicalEvents.test.ts
@@ -1,0 +1,203 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { collections, dbMock } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, any>>();
+  let autoId = 0;
+
+  function ensureCollection(name: string) {
+    if (!collections.has(name)) {
+      collections.set(name, new Map<string, any>());
+    }
+    return collections.get(name)!;
+  }
+
+  const dbMock = {
+    collection: (name: string) => ({
+      doc: (id?: string) => {
+        const docId = id || `${name}_${++autoId}`;
+        return {
+          id: docId,
+          get: async () => ({
+            id: docId,
+            exists: ensureCollection(name).has(docId),
+            data: () => ensureCollection(name).get(docId),
+          }),
+          set: async (value: any, options?: { merge?: boolean }) => {
+            const current = ensureCollection(name).get(docId) || {};
+            ensureCollection(name).set(docId, options?.merge ? { ...current, ...value } : value);
+          },
+        };
+      },
+    }),
+  };
+
+  return { collections, dbMock };
+});
+
+vi.mock("../../config/firebase", () => ({
+  db: dbMock,
+}));
+
+vi.mock("../../middleware/authMiddleware", () => ({
+  authenticateJwt: (req: any, _res: any, next: any) => {
+    req.user = { id: "admin-1", landlordId: "landlord-1", role: "admin" };
+    next();
+  },
+}));
+
+vi.mock("../../middleware/attachAccount", () => ({
+  attachAccount: (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock("../../middleware/rateLimit", () => ({
+  rateLimitScreeningIp: (_req: any, _res: any, next: any) => next(),
+  rateLimitScreeningUser: (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock("../../services/screening/providerHealth", () => ({
+  getScreeningProviderHealth: vi.fn(async () => ({
+    provider: "singlekey",
+    configured: true,
+    preflightOk: true,
+    preflightDetail: null,
+  })),
+}));
+
+vi.mock("../../services/stripeService", () => ({
+  isStripeConfigured: () => true,
+  getStripeClient: () => ({
+    checkout: {
+      sessions: {
+        create: vi.fn(async () => ({ id: "sess_1", url: "https://checkout.test/session_1" })),
+      },
+    },
+  }),
+}));
+
+vi.mock("../../services/screening/screeningEvents", () => ({
+  writeScreeningEvent: vi.fn(async () => undefined),
+}));
+
+vi.mock("../../services/screening/runPrimaryWithFallback", () => ({
+  runPrimaryWithFallback: vi.fn(async () => ({ ok: true })),
+}));
+
+vi.mock("../../services/screeningPaymentTransactionService", () => ({
+  recordScreeningPaymentInitiated: vi.fn(async () => undefined),
+}));
+
+vi.mock("../../services/integrations/transunion/transunionService", () => ({
+  assertTransUnionConnectedForScreening: vi.fn(async () => undefined),
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; body?: any; headers?: Record<string, string> }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path: options.url,
+      body: options.body ?? {},
+      headers: options.headers ?? {},
+      get(name: string) {
+        return this.headers[String(name).toLowerCase()];
+      },
+      header(name: string) {
+        return this.get(name);
+      },
+      params: {},
+      query: {},
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, string>,
+      setHeader(name: string, value: string) {
+        this.headers[name.toLowerCase()] = value;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("rentalApplicationsRoutes canonical screening events", () => {
+  beforeEach(() => {
+    collections.clear();
+    collections.set(
+      "rentalApplications",
+      new Map([
+        [
+          "app-1",
+          {
+            id: "app-1",
+            landlordId: "landlord-1",
+            propertyId: "property-1",
+            unitId: "unit-1",
+            status: "SUBMITTED",
+            screeningStatus: "unpaid",
+            consent: {
+              creditConsent: true,
+              referenceConsent: true,
+              dataSharingConsent: true,
+              acceptedAt: Date.now(),
+              version: "v1.0",
+            },
+            applicant: {
+              firstName: "Jane",
+              lastName: "Doe",
+              email: "jane@example.com",
+              dob: "1990-01-01",
+            },
+            residentialHistory: [{ address: "123 Main St" }],
+          },
+        ],
+      ])
+    );
+  });
+
+  it("emits a canonical screening.checkout_created event on successful checkout creation", async () => {
+    const router = (await import("../rentalApplicationsRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "POST",
+      url: "/rental-applications/app-1/screening/checkout",
+      headers: {
+        origin: "http://localhost:5173",
+      },
+      body: {
+        consent: {
+          given: true,
+          timestamp: "2026-03-02T10:00:00.000Z",
+          version: "v1.0",
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    const events = Array.from((collections.get("canonicalEvents") || new Map()).values());
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "screening.checkout_created",
+          domain: "screening",
+          action: "checkout_created",
+          resource: expect.objectContaining({
+            type: "screening_order",
+          }),
+        }),
+      ])
+    );
+  });
+});

--- a/rentchain-api/src/routes/__tests__/workOrdersRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/workOrdersRoutes.test.ts
@@ -548,6 +548,16 @@ describe("workOrdersRoutes execution completion", () => {
     expect(revisionRes.status).toBe(200);
     expect(revisionRes.body?.item?.cost?.reviewStatus).toBe("revision_requested");
     expect(revisionRes.body?.item?.costReviewHistory?.[0]?.reviewStatus).toBe("revision_requested");
+    const approvalRequestedEvent = Array.from(ensureCollection("canonicalEvents").values()).find(
+      (entry) => entry?.type === "maintenance.approval_requested"
+    );
+    expect(approvalRequestedEvent).toEqual(
+      expect.objectContaining({
+        type: "maintenance.approval_requested",
+        domain: "maintenance",
+        action: "approval_requested",
+      })
+    );
 
     ensureCollection("workOrders").set("wo-1", {
       ...ensureCollection("workOrders").get("wo-1"),

--- a/rentchain-api/src/routes/applicationsRoutes.ts
+++ b/rentchain-api/src/routes/applicationsRoutes.ts
@@ -26,6 +26,7 @@ import {
   getApplicationEvents,
 } from "../services/applicationEventsService";
 import { db } from "../config/firebase";
+import { writeCanonicalEvent } from "../lib/events/buildEvent";
 
 const router = Router();
 
@@ -1243,6 +1244,27 @@ function handleApplicationFormSubmit(req: Request, res: Response) {
       actor: "tenant",
       metadata: { propertyId: newApp.propertyId },
     });
+    await writeCanonicalEvent({
+      domain: "application",
+      action: "created",
+      actor: {
+        type: "tenant",
+        role: "tenant",
+        id: newApp.email || null,
+      },
+      resource: {
+        type: "application",
+        id: newApp.id,
+      },
+      occurredAt: createdAt,
+      visibility: "internal",
+      summary: "Application created by tenant",
+      metadata: {
+        propertyId: newApp.propertyId,
+        unitId: newApp.unitId || null,
+        source: "online_application_submit",
+      },
+    });
 
     return res.status(201).json(newApp);
   } catch (err: any) {
@@ -1419,7 +1441,7 @@ router.patch("/applications/:id/references", (req, res) => {
   }
 });
 
-function handleSubmitApplication(req: Request, res: Response) {
+async function handleSubmitApplication(req: Request, res: Response) {
   try {
     const { id } = req.params;
     const application = getApplicationById(id);
@@ -1450,6 +1472,25 @@ function handleSubmitApplication(req: Request, res: Response) {
       type: "submitted",
       message: "Application submitted",
       actor: "tenant",
+    });
+    await writeCanonicalEvent({
+      domain: "application",
+      action: "submitted",
+      actor: {
+        type: "tenant",
+        role: "tenant",
+        id: application.applicantEmail || application.email || null,
+      },
+      resource: {
+        type: "application",
+        id: application.id,
+      },
+      occurredAt: submittedAt,
+      visibility: "internal",
+      summary: "Application submitted",
+      metadata: {
+        status: updated.status,
+      },
     });
 
     return res.status(200).json(updated);

--- a/rentchain-api/src/routes/expensesRoutes.ts
+++ b/rentchain-api/src/routes/expensesRoutes.ts
@@ -21,6 +21,7 @@ import type {
   ExpensePropertyOption,
   ExpenseUnitOption,
 } from "../services/expenses/expenseIngestionTypes";
+import { writeCanonicalEvent } from "../lib/events/buildEvent";
 
 const router = Router();
 
@@ -1217,6 +1218,31 @@ router.post("/expenses", requireAuth, async (req: any, res) => {
     };
 
     const ref = await db.collection("expenses").add(payload);
+    await writeCanonicalEvent({
+      domain: "expense",
+      action: "created",
+      status: payload.status,
+      actor: {
+        type: role === "admin" ? "admin" : "landlord",
+        role: role === "admin" ? "admin" : "landlord",
+        id: propertyCheck.propertyLandlordId,
+      },
+      resource: {
+        type: "expense",
+        id: ref.id,
+      },
+      occurredAt: createdAtMs,
+      visibility: "internal",
+      summary: "Expense created",
+      metadata: {
+        landlordId: propertyCheck.propertyLandlordId,
+        propertyId,
+        unitId,
+        amountCents: payload.amountCents,
+        category,
+        source: payload.source,
+      },
+    });
     return res.json({ ok: true, item: { id: ref.id, ...payload } });
   } catch (err: any) {
     console.error("[expenses] create failed", err?.message || err);

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -26,6 +26,7 @@ import { loadPropertyLeaseIntegrityDiagnostics } from "../services/leaseIntegrit
 import { buildLeaseRiskPersistenceFields, computeLeaseRiskSnapshot } from "../services/risk/recomputeLeaseRisk";
 import { loadPropertyCredibilitySummary } from "../services/risk/propertyCredibilitySummary";
 import { dedupePropertyScopedLeasesByUnit, filterPropertyScopedLeases } from "../services/risk/propertyLeaseIsolation";
+import { writeCanonicalEvent } from "../lib/events/buildEvent";
 
 const router = Router();
 const LEDGER_COLLECTION = "ledgerEntries";
@@ -528,6 +529,54 @@ router.post("/drafts/:draftId/activate", requireLandlord, async (req: any, res: 
       },
       { merge: false }
     );
+    await writeCanonicalEvent({
+      domain: "lease",
+      action: "created",
+      status: "active",
+      actor: {
+        type: "landlord",
+        role: "landlord",
+        id: landlordId,
+      },
+      resource: {
+        type: "lease",
+        id: leaseRef.id,
+        parentType: "lease_draft",
+        parentId: draftId,
+      },
+      occurredAt: now,
+      visibility: "landlord",
+      summary: "Lease record created from draft",
+      metadata: {
+        propertyId,
+        unitId,
+        tenantIds,
+      },
+    });
+    await writeCanonicalEvent({
+      domain: "lease",
+      action: "activated",
+      status: "active",
+      actor: {
+        type: "landlord",
+        role: "landlord",
+        id: landlordId,
+      },
+      resource: {
+        type: "lease",
+        id: leaseRef.id,
+        parentType: "lease_draft",
+        parentId: draftId,
+      },
+      occurredAt: now,
+      visibility: "landlord",
+      summary: "Lease activated",
+      metadata: {
+        propertyId,
+        unitId,
+        tenantIds,
+      },
+    });
 
     return res.status(200).json({
       ok: true,

--- a/rentchain-api/src/routes/maintenanceRequestsRoutes.ts
+++ b/rentchain-api/src/routes/maintenanceRequestsRoutes.ts
@@ -28,6 +28,7 @@ import {
   buildTenantSafeWorkOrderNotifications,
   computeWorkOrderNotifications,
 } from "../lib/maintenanceNotifications";
+import { writeCanonicalEvent } from "../lib/events/buildEvent";
 
 const router = Router();
 
@@ -1376,6 +1377,31 @@ router.post("/tenant/maintenance", async (req: any, res) => {
       messages: [],
     };
     await ref.set(data);
+    await writeCanonicalEvent({
+      domain: "maintenance",
+      action: "request_created",
+      status: "submitted",
+      actor: {
+        type: "tenant",
+        role: "tenant",
+        id: tenantId,
+        displayName: tenantName,
+      },
+      resource: {
+        type: "maintenance_request",
+        id: ref.id,
+      },
+      occurredAt: now,
+      visibility: "landlord",
+      summary: "Maintenance request submitted",
+      metadata: {
+        landlordId,
+        propertyId,
+        unitId,
+        category,
+        priority,
+      },
+    });
 
     if (landlordId) {
       const landlordEmail = await lookupEmailFromDoc([
@@ -2040,6 +2066,33 @@ router.post("/landlord/maintenance/:id/assign", async (req: any, res) => {
         workOrderAssignedContractorId,
       });
     }
+    await writeCanonicalEvent({
+      domain: "maintenance",
+      action: "assigned",
+      status: "assigned",
+      actor: {
+        type: role === "admin" ? "admin" : "landlord",
+        role: role === "admin" ? "admin" : "landlord",
+        id: actorId,
+      },
+      resource: {
+        type: "maintenance_request",
+        id,
+      },
+      occurredAt: now,
+      visibility: "landlord",
+      summary: contractorName
+        ? `Maintenance request assigned to ${contractorName}`
+        : "Maintenance request assigned to contractor",
+      metadata: {
+        landlordId,
+        propertyId: refreshed.propertyId || null,
+        unitId: refreshed.unitId || null,
+        workOrderId,
+        assignedContractorId: resolvedContractorId,
+        assignedContractorName: contractorName,
+      },
+    });
 
     const tenantEmail = await lookupEmailFromDoc([
       ["tenants", String(refreshed.tenantId || "")],
@@ -2341,6 +2394,32 @@ router.patch("/contractor/jobs/:id/status", async (req: any, res) => {
 
     const refreshedSnap = await ref.get();
     const refreshed = { id: refreshedSnap.id, ...(refreshedSnap.data() as any) };
+    if (nextStatus === "completed") {
+      await writeCanonicalEvent({
+        domain: "maintenance",
+        action: "completed",
+        status: "completed",
+        actor: {
+          type: access.role === "admin" ? "admin" : "contractor",
+          role: access.role === "admin" ? "admin" : "contractor",
+          id: actorId,
+        },
+        resource: {
+          type: "maintenance_request",
+          id,
+        },
+        occurredAt: now,
+        visibility: "landlord",
+        summary: "Maintenance request marked completed",
+        metadata: {
+          landlordId: refreshed.landlordId || null,
+          propertyId: refreshed.propertyId || null,
+          unitId: refreshed.unitId || null,
+          workOrderId: workOrder.workOrderId,
+          completionOutcome,
+        },
+      });
+    }
 
     let notifications = null;
     if (!isAcknowledgement) {

--- a/rentchain-api/src/routes/rentalApplicationsRoutes.ts
+++ b/rentchain-api/src/routes/rentalApplicationsRoutes.ts
@@ -36,6 +36,7 @@ import { rateLimitScreeningIp, rateLimitScreeningUser } from "../middleware/rate
 import { buildEmailHtml, buildEmailText } from "../email/templates/baseEmailTemplate";
 import { sendEmail } from "../services/emailService";
 import { recordScreeningPaymentInitiated } from "../services/screeningPaymentTransactionService";
+import { writeCanonicalEvent } from "../lib/events/buildEvent";
 
 const router = Router();
 
@@ -743,6 +744,27 @@ async function createManualApplicationFromOrderBody(opts: {
   };
 
   await appRef.set(record, { merge: false });
+  await writeCanonicalEvent({
+    domain: "application",
+    action: "created",
+    actor: {
+      type: "landlord",
+      role: "landlord",
+      id: opts.landlordId,
+    },
+    resource: {
+      type: "rental_application",
+      id: appRef.id,
+    },
+    occurredAt: now,
+    visibility: "internal",
+    summary: "Manual rental application created for screening",
+    metadata: {
+      propertyId: opts.propertyId,
+      unitId: opts.unitId || null,
+      source: "manual_screening",
+    },
+  });
   return { ok: true as const, applicationId: appRef.id, data: record };
 }
 
@@ -1037,6 +1059,27 @@ router.post(
         runAdapter: async () => buildQuotePayload(pricing),
         compare: compareQuoteResponses,
       });
+      await writeCanonicalEvent({
+        domain: "screening",
+        action: "quote_generated",
+        actor: {
+          type: role === "admin" ? "admin" : "landlord",
+          role,
+          id: String(req.user?.id || req.user?.landlordId || "").trim() || null,
+        },
+        resource: {
+          type: "rental_application",
+          id,
+        },
+        occurredAt: Date.now(),
+        visibility: "internal",
+        summary: "Screening quote generated",
+        metadata: {
+          landlordId: data?.landlordId || landlordId,
+          propertyId: data?.propertyId || null,
+          unitId: data?.unitId || null,
+        },
+      });
 
       return res.json(quoteResult);
     } catch (err: any) {
@@ -1085,6 +1128,28 @@ router.post(
           meta: { status: "already_paid" },
           actor: role === "admin" ? "admin" : "landlord",
         });
+        await writeCanonicalEvent({
+          domain: "screening",
+          action: "blocked",
+          status: "already_paid",
+          actor: {
+            type: role === "admin" ? "admin" : "landlord",
+            role,
+            id: String(req.user?.id || req.user?.landlordId || "").trim() || null,
+          },
+          resource: {
+            type: "rental_application",
+            id,
+          },
+          occurredAt: Date.now(),
+          visibility: "internal",
+          summary: "Screening checkout blocked because the application is already paid",
+          metadata: {
+            reasonCode: "already_paid",
+            propertyId: data?.propertyId || null,
+            unitId: data?.unitId || null,
+          },
+        });
         return res.status(400).json({ ok: false, error: "screening_already_paid" });
       }
 
@@ -1132,6 +1197,28 @@ router.post(
           at: Date.now(),
           meta: { status: "provider_unavailable", reasonCode: providerHealth.preflightDetail || "not_ready" },
           actor: role === "admin" ? "admin" : "landlord",
+        });
+        await writeCanonicalEvent({
+          domain: "screening",
+          action: "blocked",
+          status: "provider_unavailable",
+          actor: {
+            type: role === "admin" ? "admin" : "landlord",
+            role,
+            id: String(req.user?.id || req.user?.landlordId || "").trim() || null,
+          },
+          resource: {
+            type: "rental_application",
+            id,
+          },
+          occurredAt: Date.now(),
+          visibility: "internal",
+          summary: "Screening checkout blocked because the provider is unavailable",
+          metadata: {
+            reasonCode: providerHealth.preflightDetail || "not_ready",
+            propertyId: data?.propertyId || null,
+            unitId: data?.unitId || null,
+          },
         });
         return res.status(503).json({
           ok: false,
@@ -1516,6 +1603,33 @@ router.post(
         stripeCheckoutSessionId: session.id,
         serviceLevel,
         recordedAt: now,
+      });
+      await writeCanonicalEvent({
+        domain: "screening",
+        action: "checkout_created",
+        actor: {
+          type: role === "admin" ? "admin" : "landlord",
+          role,
+          id: String(req.user?.id || req.user?.landlordId || "").trim() || null,
+        },
+        resource: {
+          type: "screening_order",
+          id: orderId,
+          parentType: "rental_application",
+          parentId: id,
+        },
+        occurredAt: now,
+        visibility: "internal",
+        summary: "Screening checkout session created",
+        metadata: {
+          applicationId: id,
+          landlordId,
+          propertyId: data?.propertyId || null,
+          unitId: data?.unitId || null,
+          stripeCheckoutSessionId: session.id,
+          serviceLevel,
+          totalAmountCents: pricing.totalAmountCents,
+        },
       });
 
       console.log("[screening_checkout] create_session_ok", {

--- a/rentchain-api/src/routes/stripeScreeningOrdersWebhookRoutes.ts
+++ b/rentchain-api/src/routes/stripeScreeningOrdersWebhookRoutes.ts
@@ -10,6 +10,7 @@ import { applyScreeningResultsFromOrder } from "../services/stripeScreeningProce
 import { beginScreening } from "../services/screening/screeningOrchestrator";
 import { writeScreeningEvent } from "../services/screening/screeningEvents";
 import { recordScreeningPaymentFailed } from "../services/screeningPaymentTransactionService";
+import { writeCanonicalEvent } from "../lib/events/buildEvent";
 
 interface StripeWebhookRequest extends Request {
   rawBody?: Buffer;
@@ -140,6 +141,29 @@ async function markApplicationScreeningPaid(params: {
     at: paidAt,
     meta: { stripeEventId: eventId, sessionId },
     actor: "system",
+  });
+  await writeCanonicalEvent({
+    domain: "screening",
+    action: "paid",
+    status: "paid",
+    actor: {
+      type: "system",
+      role: "system",
+      id: null,
+    },
+    resource: {
+      type: "rental_application",
+      id: applicationId,
+    },
+    occurredAt: paidAt,
+    visibility: "internal",
+    summary: "Screening payment confirmed",
+    metadata: {
+      landlordId: data?.landlordId || null,
+      stripeEventId: eventId,
+      stripeCheckoutSessionId: sessionId,
+      stripePaymentIntentId: paymentIntentId || null,
+    },
   });
 
   console.log("[stripe_webhook]", {

--- a/rentchain-api/src/routes/workOrdersRoutes.ts
+++ b/rentchain-api/src/routes/workOrdersRoutes.ts
@@ -29,6 +29,7 @@ import {
   buildTenantSafeWorkOrderNotifications,
 } from "../lib/maintenanceNotifications";
 import { createTransaction } from "../services/financialTransactionService";
+import { writeCanonicalEvent } from "../lib/events/buildEvent";
 
 const router = Router();
 
@@ -1492,6 +1493,32 @@ router.patch("/work-orders/:id", requireAuth, async (req: any, res) => {
         message: maintenanceHistoryMessage,
       });
     }
+    if (patch.status === "completed" && asOptionalString((refreshed.data() as any)?.maintenanceRequestId, 120)) {
+      await writeCanonicalEvent({
+        domain: "maintenance",
+        action: "completed",
+        status: "completed",
+        actor: {
+          type: access.role === "admin" ? "admin" : "landlord",
+          role: access.role,
+          id: access.userId,
+        },
+        resource: {
+          type: "maintenance_request",
+          id: asOptionalString((refreshed.data() as any)?.maintenanceRequestId, 120) || id,
+        },
+        occurredAt: patch.completedAtMs || nowMs(),
+        visibility: "landlord",
+        summary: "Maintenance request marked completed",
+        metadata: {
+          workOrderId: id,
+          landlordId: asOptionalString((refreshed.data() as any)?.landlordId, 120),
+          propertyId: asOptionalString((refreshed.data() as any)?.propertyId, 120),
+          unitId: asOptionalString((refreshed.data() as any)?.unitId, 120),
+          completionOutcome: patch.completionOutcome || null,
+        },
+      });
+    }
     return res.json({ ok: true, item: await toWorkOrderResponseForAudience(refreshed.id, refreshed.data(), "landlord") });
   } catch (err) {
     console.error("[work-orders] patch failed", err);
@@ -2764,6 +2791,34 @@ router.post("/landlord/work-orders/:id/review-cost", requireAuth, async (req: an
           ? `Cost submission rejected.${note ? ` ${note}` : ""}`
           : `Cost revision requested.${note ? ` ${note}` : ""}`,
     });
+    if (decision === "approve") {
+      await writeCanonicalEvent({
+        domain: "expense",
+        action: "approved",
+        status: "approved",
+        actor: {
+          type: isAdmin(req) ? "admin" : "landlord",
+          role: isAdmin(req) ? "admin" : "landlord",
+          id: access.userId,
+        },
+        resource: {
+          type: "work_order_cost",
+          id: workOrderId,
+          parentType: "work_order",
+          parentId: workOrderId,
+        },
+        occurredAt: now,
+        visibility: "internal",
+        summary: "Maintenance cost approved for expense reconciliation",
+        metadata: {
+          maintenanceRequestId: asOptionalString((access.item as any)?.maintenanceRequestId, 120),
+          propertyId: asOptionalString((access.item as any)?.propertyId, 120),
+          unitId: asOptionalString((access.item as any)?.unitId, 120),
+          actualCostCents: currentCost.actualCostCents,
+          currency: currentCost.currency || "CAD",
+        },
+      });
+    }
 
     const refreshed = await db.collection("workOrders").doc(workOrderId).get();
     return res.json({ ok: true, item: await toWorkOrderResponseForAudience(refreshed.id, refreshed.data(), "landlord") });
@@ -2830,6 +2885,29 @@ router.post("/landlord/work-orders/:id/request-cost-revision", requireAuth, asyn
       actorId: access.userId,
       updateType: "invoice",
       message: `Cost revision requested. ${note}`,
+    });
+    await writeCanonicalEvent({
+      domain: "maintenance",
+      action: "approval_requested",
+      status: "revision_requested",
+      actor: {
+        type: isAdmin(req) ? "admin" : "landlord",
+        role: isAdmin(req) ? "admin" : "landlord",
+        id: access.userId,
+      },
+      resource: {
+        type: "maintenance_request",
+        id: asOptionalString((access.item as any)?.maintenanceRequestId, 120) || workOrderId,
+      },
+      occurredAt: now,
+      visibility: "landlord",
+      summary: "Maintenance cost revision requested",
+      metadata: {
+        workOrderId,
+        propertyId: asOptionalString((access.item as any)?.propertyId, 120),
+        unitId: asOptionalString((access.item as any)?.unitId, 120),
+        note,
+      },
     });
 
     const refreshed = await db.collection("workOrders").doc(workOrderId).get();
@@ -2936,6 +3014,33 @@ router.post("/landlord/work-orders/:id/link-expense", requireAuth, async (req: a
       },
       createdAt: now,
       updatedAt: now,
+    });
+    await writeCanonicalEvent({
+      domain: "expense",
+      action: "linked",
+      status: "linked",
+      actor: {
+        type: isAdmin(req) ? "admin" : "landlord",
+        role: isAdmin(req) ? "admin" : "landlord",
+        id: access.userId,
+      },
+      resource: {
+        type: "expense",
+        id: expenseRef.id,
+        parentType: "work_order",
+        parentId: workOrderId,
+      },
+      occurredAt: now,
+      visibility: "internal",
+      summary: "Expense linked to maintenance work order",
+      metadata: {
+        landlordId,
+        propertyId,
+        unitId,
+        maintenanceRequestId: asOptionalString((access.item as any)?.maintenanceRequestId, 120),
+        amountCents: currentCost.actualCostCents,
+        currency: currentCost.currency || "CAD",
+      },
     });
 
     const refreshed = await db.collection("workOrders").doc(workOrderId).get();

--- a/rentchain-api/src/services/screening/screeningOrchestrator.ts
+++ b/rentchain-api/src/services/screening/screeningOrchestrator.ts
@@ -1,6 +1,7 @@
 import { db } from "../../config/firebase";
 import type { ScreeningResultSummary } from "./providers/types";
 import { writeScreeningEvent } from "./screeningEvents";
+import { writeCanonicalEvent } from "../../lib/events/buildEvent";
 
 type ScreeningStatus =
   | "unpaid"
@@ -112,6 +113,28 @@ export async function markScreeningComplete(
     at: now,
     meta: { status: "complete" },
     actor: String(actorUser?.role || "").toLowerCase() === "admin" ? "admin" : "system",
+  });
+  await writeCanonicalEvent({
+    domain: "screening",
+    action: "completed",
+    status: "complete",
+    actor: {
+      type: String(actorUser?.role || "").toLowerCase() === "admin" ? "admin" : "system",
+      role: String(actorUser?.role || "").trim() || "system",
+      id: String(actorUser?.id || "").trim() || null,
+    },
+    resource: {
+      type: "rental_application",
+      id: applicationId,
+    },
+    occurredAt: now,
+    visibility: "internal",
+    summary: "Screening completed",
+    metadata: {
+      landlordId: data?.landlordId || null,
+      resultId: resultRef.id,
+      provider: data?.screeningProvider || "manual",
+    },
   });
 
   return { ok: true, resultId: resultRef.id, idempotent: false };


### PR DESCRIPTION
## Summary
Adds a canonical v1 event model for high-value backend workflow events without disrupting existing timeline or audit consumers.

This introduces a new additive `canonicalEvents` layer with shared event types, a builder, visibility normalization, legacy mappers, and normalized event writes for key application, screening, maintenance, expense, and lease workflows.

## Scope
- Adds `CanonicalEventV1` types and event helpers under `src/lib/events`
- Writes canonical events alongside existing legacy event/audit writes
- Normalizes targeted workflow emissions for:
  - applications
  - screening
  - maintenance
  - expenses
  - leases
- Adds unit coverage for the event builder
- Adds targeted integration coverage for screening checkout and maintenance approval-request flows

## Notes
This is intentionally additive and backward compatible. Existing timeline rendering and legacy event consumers are preserved; no historical migration or event-bus/infrastructure change is included.

## Validation
- Passed targeted backend tests for the event builder and normalized workflow emissions
- Passed backend build
- Existing `supertest`-based screening route tests are still subject to sandbox `listen EPERM` behavior locally, so an in-process route test was added for canonical screening checkout verification