### PR TITLE
feat: add v1 autopilot policy framework and wire into core workflow 

### DIFF
--- a/rentchain-api/src/lib/policy/__tests__/policyEvaluator.test.ts
+++ b/rentchain-api/src/lib/policy/__tests__/policyEvaluator.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+import { evaluatePolicy } from "../policyEvaluator";
+
+describe("policyEvaluator", () => {
+  it("lets a higher-priority blocking rule win over allow", () => {
+    const result = evaluatePolicy({
+      domain: "screening",
+      action: "start_checkout",
+      actor: { role: "landlord", userId: "user-1" },
+      resource: { type: "rental_application", id: "app-1" },
+      context: {
+        eligible: true,
+        consentComplete: true,
+        applicationDataComplete: true,
+        providerReady: false,
+      },
+    });
+
+    expect(result.outcome).toBe("block");
+    expect(result.reasons[0]?.code).toBe("SCREENING_PROVIDER_UNAVAILABLE");
+  });
+
+  it("returns review when screening consent is missing", () => {
+    const result = evaluatePolicy({
+      domain: "screening",
+      action: "generate_quote",
+      actor: { role: "landlord", userId: "user-1" },
+      resource: { type: "rental_application", id: "app-1" },
+      context: {
+        eligible: true,
+        consentComplete: false,
+        applicationDataComplete: true,
+        providerReady: true,
+      },
+    });
+
+    expect(result.outcome).toBe("review");
+    expect(result.requiresManualApproval).toBe(true);
+  });
+
+  it("ignores disabled rules", () => {
+    const result = evaluatePolicy({
+      domain: "screening",
+      action: "generate_quote",
+      actor: { role: "landlord", userId: "user-1" },
+      resource: { type: "rental_application", id: "app-1" },
+      context: {
+        eligible: true,
+        consentComplete: true,
+        applicationDataComplete: true,
+        providerReady: false,
+      },
+    });
+
+    expect(result.outcome).toBe("allow");
+    expect(result.reasons[0]?.code).toBe("SCREENING_READY");
+  });
+
+  it("returns matched rules in deterministic order", () => {
+    const result = evaluatePolicy({
+      domain: "screening",
+      action: "start_checkout",
+      actor: { role: "landlord", userId: "user-1" },
+      resource: { type: "rental_application", id: "app-1" },
+      context: {
+        eligible: true,
+        consentComplete: false,
+        applicationDataComplete: false,
+        providerReady: true,
+      },
+    });
+
+    expect(result.matchedRules.map((entry) => entry.ruleId)).toEqual([
+      "screening-start_checkout-missing-consent",
+      "screening-start_checkout-incomplete-data",
+      "screening-start_checkout-allow",
+    ]);
+  });
+
+  it("returns serializable reasons data", () => {
+    const result = evaluatePolicy({
+      domain: "lease_notice",
+      action: "preview_notice",
+      actor: { role: "landlord", userId: "user-1" },
+      resource: { type: "lease", id: "lease-1" },
+      context: {
+        hasRequiredLegalInputs: false,
+      },
+    });
+
+    expect(JSON.parse(JSON.stringify(result.reasons))).toEqual(result.reasons);
+  });
+});

--- a/rentchain-api/src/lib/policy/policyAdapters.ts
+++ b/rentchain-api/src/lib/policy/policyAdapters.ts
@@ -1,0 +1,120 @@
+import type { PolicyEvaluationRequest } from "./policyTypes";
+
+function asString(value: unknown, max = 160) {
+  return String(value || "").trim().slice(0, max);
+}
+
+export function buildScreeningPolicyRequest(input: {
+  action: "generate_quote" | "start_checkout";
+  actorRole?: string | null;
+  actorUserId?: string | null;
+  applicationId: string;
+  eligibility: { eligible: boolean; reasonCode?: string | null; detail?: string | null };
+  application: any;
+  consentComplete: boolean;
+  providerReady?: boolean;
+}) : PolicyEvaluationRequest {
+  const applicant = input.application?.applicant || {};
+  const residentialHistory = Array.isArray(input.application?.residentialHistory)
+    ? input.application.residentialHistory
+    : [];
+  const applicationDataComplete = Boolean(
+    asString(applicant?.firstName) &&
+      asString(applicant?.lastName) &&
+      asString(applicant?.email) &&
+      asString(applicant?.dob) &&
+      residentialHistory.length > 0
+  );
+
+  return {
+    domain: "screening",
+    action: input.action,
+    actor: {
+      role: input.actorRole || null,
+      userId: input.actorUserId || null,
+    },
+    resource: {
+      type: "rental_application",
+      id: input.applicationId,
+    },
+    context: {
+      eligible: input.eligibility.eligible,
+      eligibilityReasonCode: input.eligibility.reasonCode || null,
+      consentComplete: input.consentComplete,
+      providerReady: input.providerReady ?? true,
+      applicationDataComplete,
+      propertyId: asString(input.application?.propertyId, 120) || null,
+      unitId: asString(input.application?.unitId, 120) || null,
+    },
+  };
+}
+
+export function buildMaintenancePolicyRequest(input: {
+  action: "approve_cost" | "review_cost";
+  actorRole?: string | null;
+  actorUserId?: string | null;
+  workOrderId: string;
+  workOrder: any;
+  actualCostCents: number;
+}) : PolicyEvaluationRequest {
+  const evidence = Array.isArray(input.workOrder?.evidence) ? input.workOrder.evidence : [];
+  const costAttachments = Array.isArray(input.workOrder?.costAttachments) ? input.workOrder.costAttachments : [];
+  return {
+    domain: "maintenance",
+    action: input.action,
+    actor: {
+      role: input.actorRole || null,
+      userId: input.actorUserId || null,
+    },
+    resource: {
+      type: "work_order",
+      id: input.workOrderId,
+    },
+    context: {
+      actualCostCents: input.actualCostCents,
+      hasSupportingEvidence: evidence.length > 0 || costAttachments.length > 0,
+      hasExpenseLink: String(input.workOrder?.cost?.linkedExpenseStatus || "").toLowerCase() === "linked",
+      propertyId: asString(input.workOrder?.propertyId, 120) || null,
+      unitId: asString(input.workOrder?.unitId, 120) || null,
+      maintenanceRequestId: asString(input.workOrder?.maintenanceRequestId, 120) || null,
+    },
+  };
+}
+
+export function buildLeaseNoticePolicyRequest(input: {
+  action: "preview_notice" | "send_notice";
+  actorRole?: string | null;
+  actorUserId?: string | null;
+  lease: any;
+  leaseId: string;
+  requestBody: any;
+}) : PolicyEvaluationRequest {
+  const hasRequiredLegalInputs = Boolean(
+    asString(input.lease?.province, 40) &&
+      asString(input.lease?.leaseType, 40) &&
+      asString(input.lease?.tenantId, 120) &&
+      asString(input.lease?.propertyId, 120) &&
+      asString(input.requestBody?.newLeaseStartDate, 30) &&
+      Number(input.requestBody?.responseDeadlineAt || 0) > 0
+  );
+  return {
+    domain: "lease_notice",
+    action: input.action,
+    actor: {
+      role: input.actorRole || null,
+      userId: input.actorUserId || null,
+    },
+    resource: {
+      type: "lease",
+      id: input.leaseId,
+    },
+    context: {
+      hasRequiredLegalInputs,
+      province: asString(input.lease?.province, 40) || null,
+      leaseType: asString(input.lease?.leaseType, 40) || null,
+      tenantId: asString(input.lease?.tenantId, 120) || null,
+      propertyId: asString(input.lease?.propertyId, 120) || null,
+      unitId: asString(input.lease?.unitId, 120) || null,
+    },
+  };
+}

--- a/rentchain-api/src/lib/policy/policyEvaluator.ts
+++ b/rentchain-api/src/lib/policy/policyEvaluator.ts
@@ -1,0 +1,116 @@
+import { writeCanonicalEvent } from "../events/buildEvent";
+import { getPolicyRules } from "./policyRules";
+import type {
+  AutopilotPolicySummary,
+  PolicyEvaluationRequest,
+  PolicyEvaluationResult,
+  PolicyRule,
+} from "./policyTypes";
+
+function compareRules(a: PolicyRule, b: PolicyRule) {
+  if (b.priority !== a.priority) return b.priority - a.priority;
+  return a.id.localeCompare(b.id);
+}
+
+export function evaluatePolicy(request: PolicyEvaluationRequest): PolicyEvaluationResult {
+  const rules = getPolicyRules(request.domain, request.action).sort(compareRules);
+  const matched = rules.filter((rule) => {
+    try {
+      return rule.matches(request);
+    } catch {
+      return false;
+    }
+  });
+  const selected = matched[0];
+  const evaluatedAt = new Date().toISOString();
+
+  if (!selected) {
+    return {
+      version: "v1",
+      domain: request.domain,
+      action: request.action,
+      outcome: "defer",
+      reasons: [
+        {
+          code: "POLICY_RULE_NOT_FOUND",
+          message: "No policy rule matched this request.",
+          severity: "warning",
+        },
+      ],
+      matchedRules: [],
+      requiresManualApproval: false,
+      canAutopilot: false,
+      evaluatedAt,
+    };
+  }
+
+  return {
+    version: "v1",
+    domain: request.domain,
+    action: request.action,
+    outcome: selected.outcome,
+    reasons: matched.map((rule) => ({
+      code: rule.reasonCode,
+      message: rule.reasonMessage,
+      severity: rule.severity,
+    })),
+    matchedRules: matched.map((rule) => ({
+      ruleId: rule.id,
+      ruleName: rule.ruleName,
+    })),
+    requiresManualApproval: selected.outcome === "review",
+    canAutopilot: selected.outcome === "allow",
+    evaluatedAt,
+  };
+}
+
+export function toAutopilotPolicySummary(result: PolicyEvaluationResult): AutopilotPolicySummary {
+  const topReason = result.reasons[0];
+  return {
+    outcome: result.outcome,
+    canAutopilot: result.canAutopilot,
+    requiresManualApproval: result.requiresManualApproval,
+    topReasonCode: topReason?.code || null,
+    topReasonMessage: topReason?.message || null,
+    evaluatedAt: result.evaluatedAt,
+  };
+}
+
+export async function writePolicyEvaluatedEvent(input: {
+  request: PolicyEvaluationRequest;
+  result: PolicyEvaluationResult;
+  actorType?: "user" | "system" | "admin" | "tenant" | "landlord" | "contractor" | "service";
+  visibility?: "internal" | "landlord" | "tenant" | "admin" | "system";
+  metadata?: Record<string, unknown>;
+}) {
+  const topReason = input.result.reasons[0];
+  await writeCanonicalEvent({
+    domain: "policy",
+    type: "policy.evaluated",
+    action: "evaluated",
+    status: input.result.outcome,
+    actor: {
+      type: input.actorType,
+      id: input.request.actor.userId || null,
+      role: input.request.actor.role || null,
+    },
+    resource: {
+      type: input.request.resource.type || "policy_resource",
+      id: input.request.resource.id || "unknown",
+    },
+    occurredAt: input.result.evaluatedAt,
+    visibility: input.visibility || "internal",
+    summary: `Policy evaluated for ${input.request.domain}.${input.request.action}`,
+    metadata: {
+      domain: input.request.domain,
+      action: input.request.action,
+      outcome: input.result.outcome,
+      resourceType: input.request.resource.type || null,
+      resourceId: input.request.resource.id || null,
+      topReasonCode: topReason?.code || null,
+      topReasonMessage: topReason?.message || null,
+      matchedRules: input.result.matchedRules,
+      ...input.metadata,
+    },
+  });
+}

--- a/rentchain-api/src/lib/policy/policyRules.ts
+++ b/rentchain-api/src/lib/policy/policyRules.ts
@@ -1,0 +1,183 @@
+import type { PolicyEvaluationRequest, PolicyRule } from "./policyTypes";
+
+export const MAINTENANCE_AUTO_APPROVAL_THRESHOLD_CENTS = 100_000;
+
+function contextFlag(request: PolicyEvaluationRequest, key: string) {
+  return Boolean(request.context[key]);
+}
+
+function contextNumber(request: PolicyEvaluationRequest, key: string) {
+  const value = request.context[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+const SCREENING_ACTIONS = ["generate_quote", "start_checkout"] as const;
+const LEASE_NOTICE_ACTIONS = ["preview_notice", "send_notice"] as const;
+
+export const policyRules: PolicyRule[] = [
+  ...SCREENING_ACTIONS.map(
+    (action): PolicyRule => ({
+      id: `screening-${action}-provider-unavailable`,
+      ruleName: "Block screening when provider health is degraded",
+      domain: "screening",
+      action,
+      enabled: action === "start_checkout",
+      priority: 400,
+      outcome: "block",
+      reasonCode: "SCREENING_PROVIDER_UNAVAILABLE",
+      reasonMessage: "Screening cannot continue until the provider is healthy again.",
+      severity: "blocking",
+      matches: (request) => !contextFlag(request, "providerReady"),
+    })
+  ),
+  ...SCREENING_ACTIONS.map(
+    (action): PolicyRule => ({
+      id: `screening-${action}-not-eligible`,
+      ruleName: "Block screening when the application is not eligible",
+      domain: "screening",
+      action,
+      enabled: true,
+      priority: 350,
+      outcome: "block",
+      reasonCode: "SCREENING_NOT_ELIGIBLE",
+      reasonMessage: "Screening is blocked because the application is not eligible.",
+      severity: "blocking",
+      matches: (request) =>
+        !contextFlag(request, "eligible") && String(request.context.eligibilityReasonCode || "") !== "MISSING_CONSENT",
+    })
+  ),
+  ...SCREENING_ACTIONS.map(
+    (action): PolicyRule => ({
+      id: `screening-${action}-missing-consent`,
+      ruleName: "Review screening when consent is missing",
+      domain: "screening",
+      action,
+      enabled: true,
+      priority: 300,
+      outcome: "review",
+      reasonCode: "SCREENING_CONSENT_REVIEW_REQUIRED",
+      reasonMessage: "Screening needs manual review because consent or prerequisites are incomplete.",
+      severity: "warning",
+      matches: (request) => !contextFlag(request, "consentComplete"),
+    })
+  ),
+  ...SCREENING_ACTIONS.map(
+    (action): PolicyRule => ({
+      id: `screening-${action}-incomplete-data`,
+      ruleName: "Review screening when application data is incomplete",
+      domain: "screening",
+      action,
+      enabled: true,
+      priority: 250,
+      outcome: "review",
+      reasonCode: "SCREENING_DATA_INCOMPLETE",
+      reasonMessage: "Screening needs manual review because the application data is incomplete.",
+      severity: "warning",
+      matches: (request) => !contextFlag(request, "applicationDataComplete"),
+    })
+  ),
+  ...SCREENING_ACTIONS.map(
+    (action): PolicyRule => ({
+      id: `screening-${action}-allow`,
+      ruleName: "Allow screening when prerequisites are satisfied",
+      domain: "screening",
+      action,
+      enabled: true,
+      priority: 100,
+      outcome: "allow",
+      reasonCode: "SCREENING_READY",
+      reasonMessage: "Screening prerequisites are satisfied.",
+      severity: "info",
+      matches: () => true,
+    })
+  ),
+  {
+    id: "maintenance-approve-cost-missing-evidence",
+    ruleName: "Block maintenance cost approval when evidence is missing",
+    domain: "maintenance",
+    action: "approve_cost",
+    enabled: true,
+    priority: 400,
+    outcome: "block",
+    reasonCode: "MAINTENANCE_EVIDENCE_REQUIRED",
+    reasonMessage: "Maintenance approval is blocked until evidence or attachments are present.",
+    severity: "blocking",
+    matches: (request) => !contextFlag(request, "hasSupportingEvidence"),
+  },
+  {
+    id: "maintenance-approve-cost-high-threshold",
+    ruleName: "Review maintenance cost approval when cost exceeds threshold",
+    domain: "maintenance",
+    action: "approve_cost",
+    enabled: true,
+    priority: 300,
+    outcome: "review",
+    reasonCode: "MAINTENANCE_COST_REVIEW_REQUIRED",
+    reasonMessage: "Maintenance approval needs manual review because the cost exceeds the autopilot threshold.",
+    severity: "warning",
+    matches: (request) => {
+      const amountCents = contextNumber(request, "actualCostCents");
+      return typeof amountCents === "number" && amountCents > MAINTENANCE_AUTO_APPROVAL_THRESHOLD_CENTS;
+    },
+  },
+  {
+    id: "maintenance-approve-cost-allow",
+    ruleName: "Allow maintenance cost approval when evidence exists and cost is within threshold",
+    domain: "maintenance",
+    action: "approve_cost",
+    enabled: true,
+    priority: 100,
+    outcome: "allow",
+    reasonCode: "MAINTENANCE_APPROVAL_READY",
+    reasonMessage: "Maintenance approval can proceed.",
+    severity: "info",
+    matches: () => true,
+  },
+  {
+    id: "maintenance-non-approval-allow",
+    ruleName: "Allow non-approval maintenance review decisions",
+    domain: "maintenance",
+    action: "review_cost",
+    enabled: true,
+    priority: 100,
+    outcome: "allow",
+    reasonCode: "MAINTENANCE_REVIEW_READY",
+    reasonMessage: "Maintenance review can proceed.",
+    severity: "info",
+    matches: () => true,
+  },
+  ...LEASE_NOTICE_ACTIONS.map(
+    (action): PolicyRule => ({
+      id: `lease-notice-${action}-missing-legal-inputs`,
+      ruleName: "Block lease notice automation when required legal inputs are missing",
+      domain: "lease_notice",
+      action,
+      enabled: true,
+      priority: 400,
+      outcome: "block",
+      reasonCode: "LEASE_NOTICE_REQUIRED_INPUTS_MISSING",
+      reasonMessage: "Lease notice is blocked until required legal inputs are complete.",
+      severity: "blocking",
+      matches: (request) => !contextFlag(request, "hasRequiredLegalInputs"),
+    })
+  ),
+  ...LEASE_NOTICE_ACTIONS.map(
+    (action): PolicyRule => ({
+      id: `lease-notice-${action}-allow`,
+      ruleName: "Allow lease notice automation when inputs are valid",
+      domain: "lease_notice",
+      action,
+      enabled: true,
+      priority: 100,
+      outcome: "allow",
+      reasonCode: "LEASE_NOTICE_READY",
+      reasonMessage: "Lease notice inputs are complete.",
+      severity: "info",
+      matches: () => true,
+    })
+  ),
+];
+
+export function getPolicyRules(domain: string, action: string) {
+  return policyRules.filter((rule) => rule.enabled && rule.domain === domain && rule.action === action);
+}

--- a/rentchain-api/src/lib/policy/policyTypes.ts
+++ b/rentchain-api/src/lib/policy/policyTypes.ts
@@ -1,0 +1,61 @@
+export type PolicyDomain = "screening" | "maintenance" | "lease_notice" | "application" | "general";
+
+export type PolicyOutcome = "allow" | "block" | "review" | "defer";
+
+export type PolicyReasonSeverity = "info" | "warning" | "blocking";
+
+export type PolicyEvaluationRequest = {
+  domain: PolicyDomain;
+  action: string;
+  actor: {
+    role?: string | null;
+    userId?: string | null;
+  };
+  resource: {
+    type?: string | null;
+    id?: string | null;
+  };
+  context: Record<string, unknown>;
+};
+
+export type PolicyEvaluationResult = {
+  version: "v1";
+  domain: string;
+  action: string;
+  outcome: PolicyOutcome;
+  reasons: Array<{
+    code: string;
+    message: string;
+    severity?: PolicyReasonSeverity;
+  }>;
+  matchedRules: Array<{
+    ruleId: string;
+    ruleName: string;
+  }>;
+  requiresManualApproval: boolean;
+  canAutopilot: boolean;
+  evaluatedAt: string;
+};
+
+export type PolicyRule = {
+  id: string;
+  ruleName: string;
+  domain: PolicyDomain;
+  action: string;
+  enabled: boolean;
+  priority: number;
+  outcome: PolicyOutcome;
+  reasonCode: string;
+  reasonMessage: string;
+  severity?: PolicyReasonSeverity;
+  matches: (request: PolicyEvaluationRequest) => boolean;
+};
+
+export type AutopilotPolicySummary = {
+  outcome: PolicyOutcome;
+  canAutopilot: boolean;
+  requiresManualApproval: boolean;
+  topReasonCode?: string | null;
+  topReasonMessage?: string | null;
+  evaluatedAt?: string | null;
+};

--- a/rentchain-api/src/routes/__tests__/leaseNoticeLandlordRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseNoticeLandlordRoutes.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { collections, dbMock } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, any>>();
+  let autoId = 0;
+
+  function ensureCollection(name: string) {
+    if (!collections.has(name)) {
+      collections.set(name, new Map<string, any>());
+    }
+    return collections.get(name)!;
+  }
+
+  const dbMock = {
+    collection: (name: string) => ({
+      doc: (id?: string) => {
+        const docId = id || `${name}_${++autoId}`;
+        return {
+          id: docId,
+          get: async () => ({
+            id: docId,
+            exists: ensureCollection(name).has(docId),
+            data: () => ensureCollection(name).get(docId),
+          }),
+          set: async (value: any, options?: { merge?: boolean }) => {
+            const current = ensureCollection(name).get(docId) || {};
+            ensureCollection(name).set(docId, options?.merge ? { ...current, ...value } : value);
+          },
+        };
+      },
+    }),
+  };
+
+  return { collections, dbMock };
+});
+
+vi.mock("../../config/firebase", () => ({
+  db: dbMock,
+}));
+
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: any, _res: any, next: any) => {
+    req.user = { id: "landlord-1", landlordId: "landlord-1", role: "landlord" };
+    next();
+  },
+}));
+
+vi.mock("../../config/leaseNoticeRules", () => ({
+  getLeaseNoticeWorkflowFlag: () => ({ enabled: true, source: "test" }),
+}));
+
+const appendLeaseWorkflowEvent = vi.fn(async () => undefined);
+const buildPreview = vi.fn(async () => undefined);
+const getLeaseForLandlordWorkflow = vi.fn(async () => ({
+  ok: true,
+  lease: {
+    id: "lease-1",
+    landlordId: "landlord-1",
+    tenantId: "tenant-1",
+    propertyId: "property-1",
+    unitId: "unit-1",
+    province: "NS",
+    leaseType: "fixed_term",
+    currentRent: 1800,
+    currency: "CAD",
+  },
+}));
+
+vi.mock("../../services/leaseNoticeWorkflowService", () => ({
+  appendLeaseWorkflowEvent,
+  buildPreview,
+  computeNoResponseState: vi.fn(),
+  getLeaseForLandlordWorkflow,
+  getLeaseNoticeByLeaseId: vi.fn(),
+  lookupUserEmail: vi.fn(),
+  normalizeLeaseRecord: vi.fn(),
+  sendLeaseWorkflowEmail: vi.fn(),
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; body?: any }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path: options.url,
+      body: options.body ?? {},
+      headers: {},
+    };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("leaseNoticeLandlordRoutes policy integration", () => {
+  beforeEach(() => {
+    collections.clear();
+    vi.clearAllMocks();
+    buildPreview.mockReturnValue({
+      ok: true,
+      rule: { noticeLeadDays: 90 },
+      preview: {
+        noticeType: "renewal_offer",
+        legalTemplateKey: "ns_fixed_term_renewal",
+        noticeRuleVersion: "v1",
+        noticeDueAt: 1700000000000,
+        rentChangeMode: "no_change",
+        currentRent: 1800,
+        proposedRent: 1800,
+        newTermType: "fixed_term",
+        newTermStartDate: "2026-07-01",
+        newTermEndDate: "2027-06-30",
+        responseDeadlineAt: 1700000000000,
+        summary: { title: "Lease notice preview", body: "Preview body" },
+      },
+    });
+  });
+
+  it("blocks lease notice preview when required legal inputs are missing", async () => {
+    const router = (await import("../leaseNoticeLandlordRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/lease-1/notice-preview",
+      body: {
+        responseDeadlineAt: 1700000000000,
+      },
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body?.error).toBe("LEASE_NOTICE_POLICY_BLOCKED");
+    expect(res.body?.autopilotPolicy).toEqual(
+      expect.objectContaining({
+        outcome: "block",
+        topReasonCode: "LEASE_NOTICE_REQUIRED_INPUTS_MISSING",
+      })
+    );
+    const policyEvent = Array.from((collections.get("canonicalEvents") || new Map()).values()).find(
+      (entry) => entry?.type === "policy.evaluated"
+    );
+    expect(policyEvent).toEqual(
+      expect.objectContaining({
+        domain: "policy",
+        metadata: expect.objectContaining({
+          domain: "lease_notice",
+          action: "preview_notice",
+          outcome: "block",
+        }),
+      })
+    );
+  });
+
+  it("allows lease notice preview when inputs are complete", async () => {
+    const router = (await import("../leaseNoticeLandlordRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/lease-1/notice-preview",
+      body: {
+        newLeaseStartDate: "2026-07-01",
+        newLeaseEndDate: "2027-06-30",
+        responseDeadlineAt: 1700000000000,
+        rentChangeMode: "no_change",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.autopilotPolicy).toEqual(
+      expect.objectContaining({
+        outcome: "allow",
+        canAutopilot: true,
+      })
+    );
+    expect(appendLeaseWorkflowEvent).toHaveBeenCalled();
+  });
+});

--- a/rentchain-api/src/routes/__tests__/rentalApplicationsCanonicalEvents.test.ts
+++ b/rentchain-api/src/routes/__tests__/rentalApplicationsCanonicalEvents.test.ts
@@ -136,6 +136,7 @@ async function invokeRouter(router: any, options: { method: string; url: string;
 describe("rentalApplicationsRoutes canonical screening events", () => {
   beforeEach(() => {
     collections.clear();
+    process.env.NODE_ENV = "test";
     collections.set(
       "rentalApplications",
       new Map([
@@ -186,6 +187,12 @@ describe("rentalApplicationsRoutes canonical screening events", () => {
     });
 
     expect(response.status).toBe(200);
+    expect(response.body?.autopilotPolicy).toEqual(
+      expect.objectContaining({
+        outcome: "allow",
+        canAutopilot: true,
+      })
+    );
     const events = Array.from((collections.get("canonicalEvents") || new Map()).values());
     expect(events).toEqual(
       expect.arrayContaining([
@@ -197,7 +204,51 @@ describe("rentalApplicationsRoutes canonical screening events", () => {
             type: "screening_order",
           }),
         }),
+        expect.objectContaining({
+          type: "policy.evaluated",
+          domain: "policy",
+          metadata: expect.objectContaining({
+            domain: "screening",
+            action: "start_checkout",
+            outcome: "allow",
+          }),
+        }),
       ])
+    );
+  });
+
+  it("blocks screening checkout when the provider is degraded", async () => {
+    process.env.NODE_ENV = "production";
+    const { getScreeningProviderHealth } = await import("../../services/screening/providerHealth");
+    vi.mocked(getScreeningProviderHealth).mockResolvedValueOnce({
+      provider: "singlekey",
+      configured: false,
+      preflightOk: false,
+      preflightDetail: "provider_down",
+    } as any);
+
+    const router = (await import("../rentalApplicationsRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "POST",
+      url: "/rental-applications/app-1/screening/checkout",
+      headers: {
+        origin: "http://localhost:5173",
+      },
+      body: {
+        consent: {
+          given: true,
+          timestamp: "2026-03-02T10:00:00.000Z",
+          version: "v1.0",
+        },
+      },
+    });
+
+    expect(response.status).toBe(503);
+    expect(response.body?.autopilotPolicy).toEqual(
+      expect.objectContaining({
+        outcome: "block",
+        topReasonCode: "SCREENING_PROVIDER_UNAVAILABLE",
+      })
     );
   });
 });

--- a/rentchain-api/src/routes/__tests__/workOrdersRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/workOrdersRoutes.test.ts
@@ -941,4 +941,139 @@ describe("workOrdersRoutes execution completion", () => {
     );
     expect(rescheduleRes.body?.item?.notifications?.contractor?.requiresScheduleConfirmation).toBe(true);
   });
+
+  it("returns a review policy summary when approval cost exceeds the autopilot threshold", async () => {
+    const router = (await import("../workOrdersRoutes")).default;
+    ensureCollection("workOrders").set("wo-1", {
+      ...ensureCollection("workOrders").get("wo-1"),
+      status: "completed",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      cost: {
+        actualCostCents: 180000,
+        currency: "CAD",
+        submittedByRole: "contractor",
+        submittedById: "contractor-1",
+        submittedAt: 700,
+        reviewStatus: "pending_review",
+        latestRevisionNumber: 1,
+      },
+      costReviewHistory: [
+        {
+          id: "history-1",
+          revisionNumber: 1,
+          submittedAt: 700,
+          submittedByRole: "contractor",
+          submittedById: "contractor-1",
+          actualCostCents: 180000,
+          currency: "CAD",
+          reviewStatus: "pending_review",
+        },
+      ],
+      costAttachments: [
+        {
+          id: "attachment-1",
+          uploadedAt: 700,
+          uploadedByRole: "contractor",
+          uploadedById: "contractor-1",
+          visibility: "landlord_only",
+          fileName: "invoice.pdf",
+        },
+      ],
+    });
+
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/landlord/work-orders/wo-1/review-cost",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "landlord-1",
+          role: "landlord",
+          landlordId: "landlord-1",
+        }),
+      },
+      body: {
+        decision: "approve",
+        note: "Approved after manual review.",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.autopilotPolicy).toEqual(
+      expect.objectContaining({
+        outcome: "review",
+        requiresManualApproval: true,
+        topReasonCode: "MAINTENANCE_COST_REVIEW_REQUIRED",
+      })
+    );
+    const policyEvent = Array.from(ensureCollection("canonicalEvents").values()).find(
+      (entry) => entry?.type === "policy.evaluated" && entry?.metadata?.domain === "maintenance"
+    );
+    expect(policyEvent).toEqual(
+      expect.objectContaining({
+        domain: "policy",
+        metadata: expect.objectContaining({
+          domain: "maintenance",
+          action: "approve_cost",
+          outcome: "review",
+        }),
+      })
+    );
+  });
+
+  it("blocks maintenance approval when supporting evidence is missing", async () => {
+    const router = (await import("../workOrdersRoutes")).default;
+    ensureCollection("workOrders").set("wo-1", {
+      ...ensureCollection("workOrders").get("wo-1"),
+      status: "completed",
+      propertyId: "prop-1",
+      cost: {
+        actualCostCents: 32000,
+        currency: "CAD",
+        submittedByRole: "contractor",
+        submittedById: "contractor-1",
+        submittedAt: 700,
+        reviewStatus: "pending_review",
+        latestRevisionNumber: 1,
+      },
+      costReviewHistory: [
+        {
+          id: "history-1",
+          revisionNumber: 1,
+          submittedAt: 700,
+          submittedByRole: "contractor",
+          submittedById: "contractor-1",
+          actualCostCents: 32000,
+          currency: "CAD",
+          reviewStatus: "pending_review",
+        },
+      ],
+      evidence: [],
+      costAttachments: [],
+    });
+
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/landlord/work-orders/wo-1/review-cost",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "landlord-1",
+          role: "landlord",
+          landlordId: "landlord-1",
+        }),
+      },
+      body: {
+        decision: "approve",
+      },
+    });
+
+    expect(res.status).toBe(409);
+    expect(res.body?.error).toBe("MAINTENANCE_POLICY_BLOCKED");
+    expect(res.body?.autopilotPolicy).toEqual(
+      expect.objectContaining({
+        outcome: "block",
+        topReasonCode: "MAINTENANCE_EVIDENCE_REQUIRED",
+      })
+    );
+  });
 });

--- a/rentchain-api/src/routes/leaseNoticeLandlordRoutes.ts
+++ b/rentchain-api/src/routes/leaseNoticeLandlordRoutes.ts
@@ -16,6 +16,8 @@ import {
   normalizeLeaseRecord,
   sendLeaseWorkflowEmail,
 } from "../services/leaseNoticeWorkflowService";
+import { buildLeaseNoticePolicyRequest } from "../lib/policy/policyAdapters";
+import { evaluatePolicy, toAutopilotPolicySummary, writePolicyEvaluatedEvent } from "../lib/policy/policyEvaluator";
 
 const router = Router();
 
@@ -74,6 +76,30 @@ router.post("/:id/notice-preview", async (req: any, res) => {
     if (!leaseResult.ok) {
       return res.status(leaseResult.status).json({ ok: false, error: leaseResult.error });
     }
+    const policyRequest = buildLeaseNoticePolicyRequest({
+      action: "preview_notice",
+      actorRole: String(req.user?.role || "").trim().toLowerCase() || "landlord",
+      actorUserId: actorId,
+      lease: leaseResult.lease,
+      leaseId,
+      requestBody: req.body || {},
+    });
+    const policyResult = evaluatePolicy(policyRequest);
+    const autopilotPolicy = toAutopilotPolicySummary(policyResult);
+    await writePolicyEvaluatedEvent({
+      request: policyRequest,
+      result: policyResult,
+      actorType: "landlord",
+      metadata: {
+        landlordId,
+        tenantId: leaseResult.lease.tenantId,
+        propertyId: leaseResult.lease.propertyId,
+        unitId: leaseResult.lease.unitId,
+      },
+    });
+    if (policyResult.outcome === "block") {
+      return res.status(400).json({ ok: false, error: "LEASE_NOTICE_POLICY_BLOCKED", autopilotPolicy });
+    }
 
     const previewResult = buildPreview(leaseResult.lease, {
       rentChangeMode: String(req.body?.rentChangeMode || "").trim().toLowerCase() as RentChangeMode,
@@ -116,7 +142,7 @@ router.post("/:id/notice-preview", async (req: any, res) => {
       },
     });
 
-    return res.json({ ok: true, preview: previewResult.preview, rule: previewResult.rule });
+    return res.json({ ok: true, preview: previewResult.preview, rule: previewResult.rule, autopilotPolicy });
   } catch (err: any) {
     console.error("[lease-notice] preview failed", { message: err?.message || "failed" });
     return res.status(500).json({ ok: false, error: "LEASE_NOTICE_PREVIEW_FAILED" });
@@ -133,6 +159,30 @@ router.post("/:id/send-notice", async (req: any, res) => {
       return res.status(leaseResult.status).json({ ok: false, error: leaseResult.error });
     }
     const lease = leaseResult.lease;
+    const policyRequest = buildLeaseNoticePolicyRequest({
+      action: "send_notice",
+      actorRole: String(req.user?.role || "").trim().toLowerCase() || "landlord",
+      actorUserId: actorId,
+      lease,
+      leaseId,
+      requestBody: req.body || {},
+    });
+    const policyResult = evaluatePolicy(policyRequest);
+    const autopilotPolicy = toAutopilotPolicySummary(policyResult);
+    await writePolicyEvaluatedEvent({
+      request: policyRequest,
+      result: policyResult,
+      actorType: "landlord",
+      metadata: {
+        landlordId,
+        tenantId: lease.tenantId,
+        propertyId: lease.propertyId,
+        unitId: lease.unitId,
+      },
+    });
+    if (policyResult.outcome === "block") {
+      return res.status(400).json({ ok: false, error: "LEASE_NOTICE_POLICY_BLOCKED", autopilotPolicy });
+    }
     const previewResult = buildPreview(lease, {
       rentChangeMode: String(req.body?.rentChangeMode || "").trim().toLowerCase() as RentChangeMode,
       proposedRent: asNumber(req.body?.proposedRent),
@@ -334,7 +384,7 @@ router.post("/:id/send-notice", async (req: any, res) => {
       deliveryStatus: "sent",
     });
 
-    return res.status(201).json({ ok: true, noticeId: noticeRef.id, delivery: emailResult });
+    return res.status(201).json({ ok: true, noticeId: noticeRef.id, delivery: emailResult, autopilotPolicy });
   } catch (err: any) {
     console.error("[lease-notice] send failed", { message: err?.message || "failed" });
     return res.status(500).json({ ok: false, error: "LEASE_NOTICE_SEND_FAILED" });

--- a/rentchain-api/src/routes/rentalApplicationsRoutes.ts
+++ b/rentchain-api/src/routes/rentalApplicationsRoutes.ts
@@ -37,6 +37,8 @@ import { buildEmailHtml, buildEmailText } from "../email/templates/baseEmailTemp
 import { sendEmail } from "../services/emailService";
 import { recordScreeningPaymentInitiated } from "../services/screeningPaymentTransactionService";
 import { writeCanonicalEvent } from "../lib/events/buildEvent";
+import { buildScreeningPolicyRequest } from "../lib/policy/policyAdapters";
+import { evaluatePolicy, toAutopilotPolicySummary, writePolicyEvaluatedEvent } from "../lib/policy/policyEvaluator";
 
 const router = Router();
 
@@ -1014,6 +1016,31 @@ router.post(
       }
       const seedKey = [id, data?.landlordId || landlordId].filter(Boolean).join(":");
       const eligibility = evaluateEligibility(data);
+      const body = typeof req.body === "string" ? safeParse(req.body) : req.body || {};
+      const consent = resolveConsentPayload(body, data);
+      const consentCheck = validateConsent(consent);
+      const policyRequest = buildScreeningPolicyRequest({
+        action: "generate_quote",
+        actorRole: role,
+        actorUserId: String(req.user?.id || req.user?.landlordId || "").trim() || null,
+        applicationId: id,
+        eligibility,
+        application: data,
+        consentComplete: consentCheck.ok,
+        providerReady: true,
+      });
+      const policyResult = evaluatePolicy(policyRequest);
+      const autopilotPolicy = toAutopilotPolicySummary(policyResult);
+      await writePolicyEvaluatedEvent({
+        request: policyRequest,
+        result: policyResult,
+        actorType: role === "admin" ? "admin" : "landlord",
+        metadata: {
+          landlordId: data?.landlordId || landlordId,
+          propertyId: data?.propertyId || null,
+          unitId: data?.unitId || null,
+        },
+      });
       await writeScreeningEvent({
         applicationId: id,
         landlordId: data?.landlordId || null,
@@ -1029,25 +1056,24 @@ router.post(
             ok: false,
             error: "consent_required",
             detail: eligibility.detail,
+            autopilotPolicy,
           });
         }
         logCutoverBlocked({ name: "quote", seedKey, skippedReason: "NOT_ELIGIBLE" });
-        return res.json({ ok: false, error: "NOT_ELIGIBLE", detail: eligibility.detail });
+        return res.json({ ok: false, error: "NOT_ELIGIBLE", detail: eligibility.detail, autopilotPolicy });
       }
 
-      const body = typeof req.body === "string" ? safeParse(req.body) : req.body || {};
-      const consent = resolveConsentPayload(body, data);
-      const consentCheck = validateConsent(consent);
       if (!consentCheck.ok) {
         logCutoverBlocked({ name: "quote", seedKey, skippedReason: "consent_required" });
         return res.status(400).json({
           ok: false,
           error: "consent_required",
           detail: consentCheck.error,
+          autopilotPolicy,
         });
       }
       if (isTransUnionReferralMode()) {
-        return res.json(buildReferralQuotePayload());
+        return res.json({ ...buildReferralQuotePayload(), autopilotPolicy });
       }
       const { pricing } = resolvePricingInput(body);
       const quoteResult = await runPrimaryWithFallback({
@@ -1081,7 +1107,7 @@ router.post(
         },
       });
 
-      return res.json(quoteResult);
+      return res.json({ ...quoteResult, autopilotPolicy });
     } catch (err: any) {
       console.error("[rental-applications] screening quote failed", err?.message || err);
       return res.status(500).json({ ok: false, error: "SCREENING_QUOTE_FAILED" });
@@ -1113,6 +1139,9 @@ router.post(
       if (role !== "admin" && data?.landlordId && data.landlordId !== landlordId) {
         return res.status(401).json({ ok: false, error: "unauthorized" });
       }
+      const body = typeof req.body === "string" ? safeParse(req.body) : req.body || {};
+      const consent = resolveConsentPayload(body, data);
+      const consentCheck = validateConsent(consent);
       await runAdapterPrimaryProbe({
         name: "checkout",
         seedKey: [id, data?.landlordId || landlordId].filter(Boolean).join(":"),
@@ -1171,18 +1200,45 @@ router.post(
         },
         { merge: true }
       );
+      const providerHealth = await getScreeningProviderHealth();
+      const referralMode = isTransUnionReferralMode();
+      const allowMockOverride = shouldUseMockCheckoutOverride({ role, seedKey: id });
+      const providerReady =
+        referralMode ||
+        allowMockOverride ||
+        process.env.NODE_ENV !== "production" ||
+        (providerHealth.configured && providerHealth.preflightOk);
+      const policyRequest = buildScreeningPolicyRequest({
+        action: "start_checkout",
+        actorRole: role,
+        actorUserId: String(req.user?.id || req.user?.landlordId || "").trim() || null,
+        applicationId: id,
+        eligibility,
+        application: data,
+        consentComplete: consentCheck.ok,
+        providerReady,
+      });
+      const policyResult = evaluatePolicy(policyRequest);
+      const autopilotPolicy = toAutopilotPolicySummary(policyResult);
+      await writePolicyEvaluatedEvent({
+        request: policyRequest,
+        result: policyResult,
+        actorType: role === "admin" ? "admin" : "landlord",
+        metadata: {
+          landlordId: data?.landlordId || landlordId,
+          propertyId: data?.propertyId || null,
+          unitId: data?.unitId || null,
+        },
+      });
       if (!eligibility.eligible) {
         return res.status(400).json({
           ok: false,
           error: "not_eligible",
           detail: eligibility.detail,
           reasonCode: eligibility.reasonCode,
+          autopilotPolicy,
         });
       }
-
-      const providerHealth = await getScreeningProviderHealth();
-      const referralMode = isTransUnionReferralMode();
-      const allowMockOverride = shouldUseMockCheckoutOverride({ role, seedKey: id });
       if (
         process.env.NODE_ENV === "production" &&
         !referralMode &&
@@ -1224,6 +1280,7 @@ router.post(
           ok: false,
           error: "screening_unavailable",
           detail: "provider_not_ready",
+          autopilotPolicy,
           ...(role === "admin" ? { preflightDetail: providerHealth.preflightDetail || null } : {}),
         });
       }
@@ -1255,11 +1312,8 @@ router.post(
         }
       }
 
-      const body = typeof req.body === "string" ? safeParse(req.body) : req.body || {};
-      const consent = resolveConsentPayload(body, data);
-      const consentCheck = validateConsent(consent);
       if (!consentCheck.ok) {
-        return res.status(400).json({ ok: false, error: "consent_required", detail: consentCheck.error });
+        return res.status(400).json({ ok: false, error: "consent_required", detail: consentCheck.error, autopilotPolicy });
       }
       const { screeningTier, addons, serviceLevel, scoreAddOn, expeditedAddOn, pricing } =
         resolvePricingInput(body);
@@ -1385,6 +1439,7 @@ router.post(
           applicationId: id,
           redirectUrl: referralUrl,
           checkoutUrl: referralUrl,
+          autopilotPolicy,
         });
       }
 
@@ -1636,7 +1691,7 @@ router.post(
         ...logBase,
         event: "create_session_ok",
       });
-      return res.json({ ok: true, checkoutUrl: session.url });
+      return res.json({ ok: true, checkoutUrl: session.url, autopilotPolicy });
     } catch (err: any) {
       console.error("[screening_checkout] create_session_fail", {
         ...logBase,

--- a/rentchain-api/src/routes/workOrdersRoutes.ts
+++ b/rentchain-api/src/routes/workOrdersRoutes.ts
@@ -30,6 +30,8 @@ import {
 } from "../lib/maintenanceNotifications";
 import { createTransaction } from "../services/financialTransactionService";
 import { writeCanonicalEvent } from "../lib/events/buildEvent";
+import { buildMaintenancePolicyRequest } from "../lib/policy/policyAdapters";
+import { evaluatePolicy, toAutopilotPolicySummary, writePolicyEvaluatedEvent } from "../lib/policy/policyEvaluator";
 
 const router = Router();
 
@@ -2714,7 +2716,10 @@ router.post("/landlord/work-orders/:id/submit-cost", requireAuth, async (req: an
     });
 
     const refreshed = await db.collection("workOrders").doc(workOrderId).get();
-    return res.json({ ok: true, item: await toWorkOrderResponseForAudience(refreshed.id, refreshed.data(), "landlord") });
+    return res.json({
+      ok: true,
+      item: await toWorkOrderResponseForAudience(refreshed.id, refreshed.data(), "landlord"),
+    });
   } catch (err) {
     console.error("[work-orders] landlord submit cost failed", err);
     return res.status(500).json({ ok: false, error: "WORK_ORDER_SUBMIT_COST_FAILED" });
@@ -2745,6 +2750,34 @@ router.post("/landlord/work-orders/:id/review-cost", requireAuth, async (req: an
     const note = asOptionalString(req.body?.note, 1000);
     if (decision === "revision_requested" && !note) {
       return res.status(400).json({ ok: false, error: "COST_REVISION_NOTE_REQUIRED" });
+    }
+    const policyRequest = buildMaintenancePolicyRequest({
+      action: decision === "approve" ? "approve_cost" : "review_cost",
+      actorRole: isAdmin(req) ? "admin" : "landlord",
+      actorUserId: access.userId,
+      workOrderId,
+      workOrder: access.item,
+      actualCostCents: currentCost.actualCostCents,
+    });
+    const policyResult = evaluatePolicy(policyRequest);
+    const autopilotPolicy = toAutopilotPolicySummary(policyResult);
+    await writePolicyEvaluatedEvent({
+      request: policyRequest,
+      result: policyResult,
+      actorType: isAdmin(req) ? "admin" : "landlord",
+      metadata: {
+        landlordId: asOptionalString((access.item as any)?.landlordId, 120),
+        maintenanceRequestId: asOptionalString((access.item as any)?.maintenanceRequestId, 120),
+        propertyId: asOptionalString((access.item as any)?.propertyId, 120),
+        unitId: asOptionalString((access.item as any)?.unitId, 120),
+      },
+    });
+    if (decision === "approve" && policyResult.outcome === "block") {
+      return res.status(409).json({
+        ok: false,
+        error: "MAINTENANCE_POLICY_BLOCKED",
+        autopilotPolicy,
+      });
     }
     const now = nowMs();
     const currentRevisionNumber = getCurrentCostRevisionNumber(access.item);
@@ -2821,7 +2854,11 @@ router.post("/landlord/work-orders/:id/review-cost", requireAuth, async (req: an
     }
 
     const refreshed = await db.collection("workOrders").doc(workOrderId).get();
-    return res.json({ ok: true, item: await toWorkOrderResponseForAudience(refreshed.id, refreshed.data(), "landlord") });
+    return res.json({
+      ok: true,
+      item: await toWorkOrderResponseForAudience(refreshed.id, refreshed.data(), "landlord"),
+      autopilotPolicy,
+    });
   } catch (err) {
     console.error("[work-orders] review cost failed", err);
     return res.status(500).json({ ok: false, error: "WORK_ORDER_REVIEW_COST_FAILED" });
@@ -3211,6 +3248,34 @@ router.post("/landlord/work-orders/:id/review-cost", requireAuth, async (req: an
     const decision = req.body?.decision === "approve" || req.body?.decision === "reject" ? req.body.decision : null;
     if (!decision) return res.status(400).json({ ok: false, error: "INVALID_COST_REVIEW_DECISION" });
     const note = asOptionalString(req.body?.note, 1000);
+    const policyRequest = buildMaintenancePolicyRequest({
+      action: decision === "approve" ? "approve_cost" : "review_cost",
+      actorRole: isAdmin(req) ? "admin" : "landlord",
+      actorUserId: access.userId,
+      workOrderId,
+      workOrder: access.item,
+      actualCostCents: currentCost.actualCostCents,
+    });
+    const policyResult = evaluatePolicy(policyRequest);
+    const autopilotPolicy = toAutopilotPolicySummary(policyResult);
+    await writePolicyEvaluatedEvent({
+      request: policyRequest,
+      result: policyResult,
+      actorType: isAdmin(req) ? "admin" : "landlord",
+      metadata: {
+        landlordId: asOptionalString((access.item as any)?.landlordId, 120),
+        maintenanceRequestId: asOptionalString((access.item as any)?.maintenanceRequestId, 120),
+        propertyId: asOptionalString((access.item as any)?.propertyId, 120),
+        unitId: asOptionalString((access.item as any)?.unitId, 120),
+      },
+    });
+    if (decision === "approve" && policyResult.outcome === "block") {
+      return res.status(409).json({
+        ok: false,
+        error: "MAINTENANCE_POLICY_BLOCKED",
+        autopilotPolicy,
+      });
+    }
     const now = nowMs();
 
     await db.collection("workOrders").doc(workOrderId).set(
@@ -3236,7 +3301,11 @@ router.post("/landlord/work-orders/:id/review-cost", requireAuth, async (req: an
     });
 
     const refreshed = await db.collection("workOrders").doc(workOrderId).get();
-    return res.json({ ok: true, item: await toWorkOrderResponseForAudience(refreshed.id, refreshed.data(), "landlord") });
+    return res.json({
+      ok: true,
+      item: await toWorkOrderResponseForAudience(refreshed.id, refreshed.data(), "landlord"),
+      autopilotPolicy,
+    });
   } catch (err) {
     console.error("[work-orders] review cost failed", err);
     return res.status(500).json({ ok: false, error: "WORK_ORDER_REVIEW_COST_FAILED" });


### PR DESCRIPTION
## Summary
Adds a deterministic v1 autopilot policy framework and wires it into core workflow decisions.

This introduces a reusable backend policy layer with static rules, adapters, and a normalized evaluator, then integrates it into screening, maintenance, and lease notice flows while emitting canonical `policy.evaluated` events.

## Scope
- Adds `policyTypes`, `policyRules`, `policyEvaluator`, and workflow adapters under `src/lib/policy`
- Integrates policy evaluation into:
  - screening quote / checkout eligibility
  - landlord maintenance cost review / approval
  - lease notice preview / send
- Emits canonical `policy.evaluated` events through the normalized event model
- Adds additive `autopilotPolicy` summaries to affected responses
- Adds targeted unit and route tests for rule ordering, workflow decisions, and event emission

## Notes
This is intentionally additive and code-defined. No rule-builder UI, no AI/ML rules, and no broad business-logic refactor were introduced.

## Validation
- Passed targeted backend tests for the policy evaluator and integrated screening, maintenance, and lease-notice flows
- Passed backend build
- Full local backend suite still has unrelated existing route-test harness failures in this sandbox (`reading 'port'`), so GitHub CI will be the better full-suite signal