### PR TITLE
feat: harden screening monetization workflow lifecycle and duplicate checkout guards

### DIFF
--- a/rentchain-api/src/routes/__tests__/rentalApplicationsCanonicalEvents.test.ts
+++ b/rentchain-api/src/routes/__tests__/rentalApplicationsCanonicalEvents.test.ts
@@ -11,8 +11,49 @@ const { collections, dbMock } = vi.hoisted(() => {
     return collections.get(name)!;
   }
 
+  function applyFilter(
+    docs: Array<{ id: string; data: () => any }>,
+    field: string,
+    operator: string,
+    value: any
+  ) {
+    if (operator !== "==") return docs;
+    return docs.filter((doc) => {
+      const data = doc.data();
+      return data?.[field] === value;
+    });
+  }
+
+  function buildQuery(name: string, filters: Array<{ field: string; operator: string; value: any }> = [], limitCount?: number) {
+    return {
+      where(field: string, operator: string, value: any) {
+        return buildQuery(name, [...filters, { field, operator, value }], limitCount);
+      },
+      limit(nextLimit: number) {
+        return buildQuery(name, filters, nextLimit);
+      },
+      async get() {
+        let docs = Array.from(ensureCollection(name).entries()).map(([id, value]) => ({
+          id,
+          data: () => value,
+        }));
+        for (const filter of filters) {
+          docs = applyFilter(docs, filter.field, filter.operator, filter.value);
+        }
+        if (typeof limitCount === "number") {
+          docs = docs.slice(0, limitCount);
+        }
+        return {
+          empty: docs.length === 0,
+          docs,
+        };
+      },
+    };
+  }
+
   const dbMock = {
     collection: (name: string) => ({
+      ...buildQuery(name),
       doc: (id?: string) => {
         const docId = id || `${name}_${++autoId}`;
         return {
@@ -248,6 +289,123 @@ describe("rentalApplicationsRoutes canonical screening events", () => {
       expect.objectContaining({
         outcome: "block",
         topReasonCode: "SCREENING_PROVIDER_UNAVAILABLE",
+      })
+    );
+  });
+
+  it("blocks duplicate checkout creation when an active checkout already exists", async () => {
+    collections.set(
+      "screeningOrders",
+      new Map([
+        [
+          "order-1",
+          {
+            id: "order-1",
+            applicationId: "app-1",
+            landlordId: "landlord-1",
+            status: "unpaid",
+            paymentStatus: "unpaid",
+            stripeCheckoutSessionId: "sess_existing",
+            amountTotalCents: 4900,
+            currency: "CAD",
+            updatedAt: Date.now(),
+          },
+        ],
+      ])
+    );
+
+    const router = (await import("../rentalApplicationsRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "POST",
+      url: "/rental-applications/app-1/screening/checkout",
+      headers: {
+        origin: "http://localhost:5173",
+      },
+      body: {
+        consent: {
+          given: true,
+          timestamp: "2026-03-02T10:00:00.000Z",
+          version: "v1.0",
+        },
+      },
+    });
+
+    expect(response.status).toBe(409);
+    expect(response.body?.errorCode).toBe("SCREENING_CHECKOUT_ALREADY_EXISTS");
+    expect(response.body?.screeningMonetizationSummary).toEqual(
+      expect.objectContaining({
+        blockingReason: "SCREENING_CHECKOUT_ALREADY_EXISTS",
+        canStartCheckout: false,
+      })
+    );
+  });
+
+  it("returns a deterministic quote expired error when checkout uses a stale quote", async () => {
+    const staleQuoteAt = Date.now() - 31 * 60 * 1000;
+    collections.set(
+      "rentalApplications",
+      new Map([
+        [
+          "app-1",
+          {
+            id: "app-1",
+            landlordId: "landlord-1",
+            propertyId: "property-1",
+            unitId: "unit-1",
+            status: "SUBMITTED",
+            screeningStatus: "unpaid",
+            consent: {
+              creditConsent: true,
+              referenceConsent: true,
+              dataSharingConsent: true,
+              acceptedAt: Date.now(),
+              version: "v1.0",
+            },
+            applicant: {
+              firstName: "Jane",
+              lastName: "Doe",
+              email: "jane@example.com",
+              dob: "1990-01-01",
+            },
+            residentialHistory: [{ address: "123 Main St" }],
+            screeningMonetization: {
+              version: "v1",
+              eligibility: "eligible",
+              quoteStatus: "generated",
+              quoteId: "quote_app-1_old",
+              quoteGeneratedAt: new Date(staleQuoteAt).toISOString(),
+              quoteExpiresAt: new Date(staleQuoteAt + 30 * 60 * 1000).toISOString(),
+              amount: 4900,
+              currency: "CAD",
+            },
+          },
+        ],
+      ])
+    );
+
+    const router = (await import("../rentalApplicationsRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "POST",
+      url: "/rental-applications/app-1/screening/checkout",
+      headers: {
+        origin: "http://localhost:5173",
+      },
+      body: {
+        consent: {
+          given: true,
+          timestamp: "2026-03-02T10:00:00.000Z",
+          version: "v1.0",
+        },
+      },
+    });
+
+    expect(response.status).toBe(409);
+    expect(response.body?.errorCode).toBe("SCREENING_QUOTE_EXPIRED");
+    expect(response.body?.screeningMonetizationSummary).toEqual(
+      expect.objectContaining({
+        quoteStatus: "expired",
+        canRetryCheckout: true,
+        blockingReason: "SCREENING_QUOTE_EXPIRED",
       })
     );
   });

--- a/rentchain-api/src/routes/rentalApplicationsRoutes.ts
+++ b/rentchain-api/src/routes/rentalApplicationsRoutes.ts
@@ -39,6 +39,12 @@ import { recordScreeningPaymentInitiated } from "../services/screeningPaymentTra
 import { writeCanonicalEvent } from "../lib/events/buildEvent";
 import { buildScreeningPolicyRequest } from "../lib/policy/policyAdapters";
 import { evaluatePolicy, toAutopilotPolicySummary, writePolicyEvaluatedEvent } from "../lib/policy/policyEvaluator";
+import {
+  buildQuoteId,
+  buildScreeningMonetizationPatch,
+  buildScreeningMonetizationSummary,
+  normalizeScreeningMonetizationState,
+} from "../services/screening/screeningMonetizationService";
 
 const router = Router();
 
@@ -232,6 +238,37 @@ async function getLatestOrderByApplicationId(applicationId: string) {
     const bTs = Number(bData?.updatedAt || bData?.createdAt || 0);
     return bTs - aTs;
   });
+  return docs[0] || null;
+}
+
+async function getLatestOrderByManualCheckout(params: {
+  landlordId: string;
+  propertyId: string;
+  unitId?: string | null;
+  tenantEmail?: string | null;
+}) {
+  const snap = await db
+    .collection("screeningOrders")
+    .where("landlordId", "==", params.landlordId)
+    .limit(50)
+    .get();
+  const targetUnitId = String(params.unitId || "").trim();
+  const targetTenantEmail = String(params.tenantEmail || "").trim().toLowerCase();
+  const docs = snap.docs
+    .filter((doc) => {
+      const data = doc.data() as any;
+      if (String(data?.propertyId || "").trim() !== params.propertyId) return false;
+      if (String(data?.unitId || "").trim() !== targetUnitId) return false;
+      if (targetTenantEmail && String(data?.tenantEmail || "").trim().toLowerCase() !== targetTenantEmail) return false;
+      return true;
+    })
+    .sort((a, b) => {
+      const aData = a.data() as any;
+      const bData = b.data() as any;
+      const aTs = Number(aData?.updatedAt || aData?.createdAt || 0);
+      const bTs = Number(bData?.updatedAt || bData?.createdAt || 0);
+      return bTs - aTs;
+    });
   return docs[0] || null;
 }
 
@@ -1014,6 +1051,8 @@ router.post(
       if (data?.landlordId && data.landlordId !== landlordId) {
         return res.status(403).json({ ok: false, error: "FORBIDDEN" });
       }
+      const latestOrderDoc = await getLatestOrderByApplicationId(id);
+      const latestOrder = latestOrderDoc?.data?.() || null;
       const seedKey = [id, data?.landlordId || landlordId].filter(Boolean).join(":");
       const eligibility = evaluateEligibility(data);
       const body = typeof req.body === "string" ? safeParse(req.body) : req.body || {};
@@ -1041,6 +1080,18 @@ router.post(
           unitId: data?.unitId || null,
         },
       });
+      const currentMonetizationState = normalizeScreeningMonetizationState({
+        application: data,
+        latestOrder,
+        eligibility:
+          !eligibility.eligible && eligibility.reasonCode === "MISSING_CONSENT"
+            ? "ineligible"
+            : eligibility.eligible
+            ? "eligible"
+            : "ineligible",
+        amount: null,
+      });
+      const currentMonetizationSummary = buildScreeningMonetizationSummary(currentMonetizationState);
       await writeScreeningEvent({
         applicationId: id,
         landlordId: data?.landlordId || null,
@@ -1055,12 +1106,27 @@ router.post(
           return res.status(400).json({
             ok: false,
             error: "consent_required",
+            errorCode: "SCREENING_MONETIZATION_BLOCKED",
             detail: eligibility.detail,
             autopilotPolicy,
+            screeningMonetizationSummary: {
+              ...currentMonetizationSummary,
+              blockingReason: "SCREENING_MONETIZATION_BLOCKED",
+            },
           });
         }
         logCutoverBlocked({ name: "quote", seedKey, skippedReason: "NOT_ELIGIBLE" });
-        return res.json({ ok: false, error: "NOT_ELIGIBLE", detail: eligibility.detail, autopilotPolicy });
+        return res.json({
+          ok: false,
+          error: "NOT_ELIGIBLE",
+          errorCode: "SCREENING_MONETIZATION_BLOCKED",
+          detail: eligibility.detail,
+          autopilotPolicy,
+          screeningMonetizationSummary: {
+            ...currentMonetizationSummary,
+            blockingReason: "SCREENING_MONETIZATION_BLOCKED",
+          },
+        });
       }
 
       if (!consentCheck.ok) {
@@ -1068,14 +1134,73 @@ router.post(
         return res.status(400).json({
           ok: false,
           error: "consent_required",
+          errorCode: "SCREENING_MONETIZATION_BLOCKED",
           detail: consentCheck.error,
           autopilotPolicy,
+          screeningMonetizationSummary: {
+            ...currentMonetizationSummary,
+            blockingReason: "SCREENING_MONETIZATION_BLOCKED",
+          },
+        });
+      }
+
+      if (currentMonetizationSummary.alreadyPaid) {
+        return res.status(409).json({
+          ok: false,
+          error: "screening_already_paid",
+          errorCode: "SCREENING_ALREADY_PAID",
+          autopilotPolicy,
+          screeningMonetizationSummary: currentMonetizationSummary,
+        });
+      }
+      if (currentMonetizationSummary.blockingReason === "SCREENING_ORDER_ALREADY_CREATED") {
+        return res.status(409).json({
+          ok: false,
+          error: "screening_order_already_created",
+          errorCode: "SCREENING_ORDER_ALREADY_CREATED",
+          autopilotPolicy,
+          screeningMonetizationSummary: currentMonetizationSummary,
+        });
+      }
+      if (currentMonetizationSummary.blockingReason === "SCREENING_CHECKOUT_ALREADY_EXISTS") {
+        return res.status(409).json({
+          ok: false,
+          error: "screening_checkout_already_exists",
+          errorCode: "SCREENING_CHECKOUT_ALREADY_EXISTS",
+          autopilotPolicy,
+          screeningMonetizationSummary: currentMonetizationSummary,
         });
       }
       if (isTransUnionReferralMode()) {
-        return res.json({ ...buildReferralQuotePayload(), autopilotPolicy });
+        const state = normalizeScreeningMonetizationState({
+          application: data,
+          latestOrder,
+          eligibility: "eligible",
+          amount: 0,
+          currency: "CAD",
+        });
+        return res.json({
+          ...buildReferralQuotePayload(),
+          autopilotPolicy,
+          screeningMonetizationSummary: buildScreeningMonetizationSummary(state),
+        });
       }
       const { pricing } = resolvePricingInput(body);
+      const quoteId = buildQuoteId({ applicationId: id });
+      const monetizationPatch = buildScreeningMonetizationPatch({
+        current: data?.screeningMonetization,
+        eligibility: "eligible",
+        quoteStatus: "generated",
+        paymentStatus:
+          currentMonetizationState.paymentStatus === "failed" ? "failed" : currentMonetizationState.paymentStatus,
+        fulfillmentStatus: "ready",
+        quoteId,
+        quoteGeneratedAt: Date.now(),
+        amount: pricing.totalAmountCents,
+        currency: pricing.currency,
+        lastErrorCode: null,
+        lastErrorMessage: null,
+      });
       const quoteResult = await runPrimaryWithFallback({
         name: "quote",
         seedKey,
@@ -1085,6 +1210,13 @@ router.post(
         runAdapter: async () => buildQuotePayload(pricing),
         compare: compareQuoteResponses,
       });
+      await db.collection("rentalApplications").doc(id).set(
+        {
+          screeningMonetization: monetizationPatch,
+          updatedAt: Date.now(),
+        },
+        { merge: true }
+      );
       await writeCanonicalEvent({
         domain: "screening",
         action: "quote_generated",
@@ -1107,7 +1239,19 @@ router.post(
         },
       });
 
-      return res.json({ ...quoteResult, autopilotPolicy });
+      return res.json({
+        ...quoteResult,
+        autopilotPolicy,
+        screeningMonetizationSummary: buildScreeningMonetizationSummary(
+          normalizeScreeningMonetizationState({
+            application: { ...data, screeningMonetization: monetizationPatch },
+            latestOrder,
+            eligibility: "eligible",
+            amount: pricing.totalAmountCents,
+            currency: pricing.currency,
+          })
+        ),
+      });
     } catch (err: any) {
       console.error("[rental-applications] screening quote failed", err?.message || err);
       return res.status(500).json({ ok: false, error: "SCREENING_QUOTE_FAILED" });
@@ -1139,6 +1283,8 @@ router.post(
       if (role !== "admin" && data?.landlordId && data.landlordId !== landlordId) {
         return res.status(401).json({ ok: false, error: "unauthorized" });
       }
+      const latestOrderDoc = await getLatestOrderByApplicationId(id);
+      const latestOrder = latestOrderDoc?.data?.() || null;
       const body = typeof req.body === "string" ? safeParse(req.body) : req.body || {};
       const consent = resolveConsentPayload(body, data);
       const consentCheck = validateConsent(consent);
@@ -1149,6 +1295,12 @@ router.post(
       });
 
       if (isScreeningAlreadyPaid(data)) {
+        const monetizationState = normalizeScreeningMonetizationState({
+          application: data,
+          latestOrder,
+          eligibility: "eligible",
+        });
+        const screeningMonetizationSummary = buildScreeningMonetizationSummary(monetizationState);
         await writeScreeningEvent({
           applicationId: id,
           landlordId: data?.landlordId || null,
@@ -1179,7 +1331,12 @@ router.post(
             unitId: data?.unitId || null,
           },
         });
-        return res.status(400).json({ ok: false, error: "screening_already_paid" });
+        return res.status(400).json({
+          ok: false,
+          error: "screening_already_paid",
+          errorCode: "SCREENING_ALREADY_PAID",
+          screeningMonetizationSummary,
+        });
       }
 
       const eligibility = evaluateEligibility(data);
@@ -1230,13 +1387,69 @@ router.post(
           unitId: data?.unitId || null,
         },
       });
+      const currentMonetizationState = normalizeScreeningMonetizationState({
+        application: data,
+        latestOrder,
+        eligibility:
+          providerReady === false
+            ? "provider_unavailable"
+            : !eligibility.eligible
+            ? "ineligible"
+            : "eligible",
+      });
+      const currentMonetizationSummary = buildScreeningMonetizationSummary(currentMonetizationState);
       if (!eligibility.eligible) {
+        const blockedPatch = buildScreeningMonetizationPatch({
+          current: data?.screeningMonetization,
+          eligibility: "ineligible",
+          fulfillmentStatus: "blocked",
+          lastErrorCode: "SCREENING_MONETIZATION_BLOCKED",
+          lastErrorMessage: eligibility.detail || "not_eligible",
+        });
+        await db.collection("rentalApplications").doc(id).set({ screeningMonetization: blockedPatch }, { merge: true });
         return res.status(400).json({
           ok: false,
           error: "not_eligible",
+          errorCode: "SCREENING_MONETIZATION_BLOCKED",
           detail: eligibility.detail,
           reasonCode: eligibility.reasonCode,
           autopilotPolicy,
+          screeningMonetizationSummary: {
+            ...currentMonetizationSummary,
+            blockingReason: "SCREENING_MONETIZATION_BLOCKED",
+          },
+        });
+      }
+      if (currentMonetizationSummary.blockingReason === "SCREENING_CHECKOUT_ALREADY_EXISTS") {
+        return res.status(409).json({
+          ok: false,
+          error: "screening_checkout_already_exists",
+          errorCode: "SCREENING_CHECKOUT_ALREADY_EXISTS",
+          autopilotPolicy,
+          screeningMonetizationSummary: currentMonetizationSummary,
+        });
+      }
+      if (
+        currentMonetizationSummary.blockingReason === "SCREENING_ORDER_ALREADY_CREATED" ||
+        currentMonetizationSummary.alreadyPaid
+      ) {
+        return res.status(409).json({
+          ok: false,
+          error: currentMonetizationSummary.alreadyPaid ? "screening_already_paid" : "screening_order_already_created",
+          errorCode: currentMonetizationSummary.alreadyPaid
+            ? "SCREENING_ALREADY_PAID"
+            : "SCREENING_ORDER_ALREADY_CREATED",
+          autopilotPolicy,
+          screeningMonetizationSummary: currentMonetizationSummary,
+        });
+      }
+      if (currentMonetizationSummary.blockingReason === "SCREENING_QUOTE_EXPIRED") {
+        return res.status(409).json({
+          ok: false,
+          error: "screening_quote_expired",
+          errorCode: "SCREENING_QUOTE_EXPIRED",
+          autopilotPolicy,
+          screeningMonetizationSummary: currentMonetizationSummary,
         });
       }
       if (
@@ -1276,11 +1489,42 @@ router.post(
             unitId: data?.unitId || null,
           },
         });
+        await db.collection("rentalApplications").doc(id).set(
+          {
+            screeningMonetization: buildScreeningMonetizationPatch({
+              current: data?.screeningMonetization,
+              eligibility: "provider_unavailable",
+              fulfillmentStatus: "blocked",
+              providerHealthStatus: "provider_unavailable",
+              lastErrorCode: "SCREENING_PROVIDER_UNAVAILABLE",
+              lastErrorMessage: providerHealth.preflightDetail || "provider_not_ready",
+            }),
+          },
+          { merge: true }
+        );
         return res.status(503).json({
           ok: false,
           error: "screening_unavailable",
+          errorCode: "SCREENING_PROVIDER_UNAVAILABLE",
           detail: "provider_not_ready",
           autopilotPolicy,
+          screeningMonetizationSummary: buildScreeningMonetizationSummary(
+            normalizeScreeningMonetizationState({
+              application: {
+                ...data,
+                screeningMonetization: buildScreeningMonetizationPatch({
+                  current: data?.screeningMonetization,
+                  eligibility: "provider_unavailable",
+                  fulfillmentStatus: "blocked",
+                  providerHealthStatus: "provider_unavailable",
+                  lastErrorCode: "SCREENING_PROVIDER_UNAVAILABLE",
+                  lastErrorMessage: providerHealth.preflightDetail || "provider_not_ready",
+                }),
+              },
+              latestOrder,
+              eligibility: "provider_unavailable",
+            })
+          ),
           ...(role === "admin" ? { preflightDetail: providerHealth.preflightDetail || null } : {}),
         });
       }
@@ -1313,7 +1557,17 @@ router.post(
       }
 
       if (!consentCheck.ok) {
-        return res.status(400).json({ ok: false, error: "consent_required", detail: consentCheck.error, autopilotPolicy });
+        return res.status(400).json({
+          ok: false,
+          error: "consent_required",
+          errorCode: "SCREENING_MONETIZATION_BLOCKED",
+          detail: consentCheck.error,
+          autopilotPolicy,
+          screeningMonetizationSummary: {
+            ...currentMonetizationSummary,
+            blockingReason: "SCREENING_MONETIZATION_BLOCKED",
+          },
+        });
       }
       const { screeningTier, addons, serviceLevel, scoreAddOn, expeditedAddOn, pricing } =
         resolvePricingInput(body);
@@ -1414,6 +1668,18 @@ router.post(
               provider: "transunion_referral",
               orderId,
             },
+            screeningMonetization: buildScreeningMonetizationPatch({
+              current: data?.screeningMonetization,
+              eligibility: "eligible",
+              paymentStatus: "checkout_created",
+              fulfillmentStatus: "ordered",
+              checkoutSessionId: orderId,
+              checkoutCreatedAt: now,
+              amount: 0,
+              currency: "CAD",
+              lastErrorCode: null,
+              lastErrorMessage: null,
+            }),
             updatedAt: now,
           },
           { merge: true }
@@ -1440,6 +1706,27 @@ router.post(
           redirectUrl: referralUrl,
           checkoutUrl: referralUrl,
           autopilotPolicy,
+          screeningMonetizationSummary: buildScreeningMonetizationSummary(
+            normalizeScreeningMonetizationState({
+              application: {
+                ...data,
+                screeningMonetization: buildScreeningMonetizationPatch({
+                  current: data?.screeningMonetization,
+                  eligibility: "eligible",
+                  paymentStatus: "checkout_created",
+                  fulfillmentStatus: "ordered",
+                  checkoutSessionId: orderId,
+                  checkoutCreatedAt: now,
+                  amount: 0,
+                  currency: "CAD",
+                }),
+              },
+              latestOrder: { ...orderPayload, stripeCheckoutSessionId: orderId },
+              eligibility: "eligible",
+              amount: 0,
+              currency: "CAD",
+            })
+          ),
         });
       }
 
@@ -1642,6 +1929,18 @@ router.post(
             ai: null,
             result: null,
           },
+          screeningMonetization: buildScreeningMonetizationPatch({
+            current: data?.screeningMonetization,
+            eligibility: "eligible",
+            paymentStatus: "checkout_created",
+            fulfillmentStatus: "ready",
+            checkoutSessionId: session.id,
+            checkoutCreatedAt: now,
+            amount: pricing.totalAmountCents,
+            currency: "CAD",
+            lastErrorCode: null,
+            lastErrorMessage: null,
+          }),
           updatedAt: now,
         },
         { merge: true }
@@ -1691,7 +1990,32 @@ router.post(
         ...logBase,
         event: "create_session_ok",
       });
-      return res.json({ ok: true, checkoutUrl: session.url, autopilotPolicy });
+      return res.json({
+        ok: true,
+        checkoutUrl: session.url,
+        autopilotPolicy,
+        screeningMonetizationSummary: buildScreeningMonetizationSummary(
+          normalizeScreeningMonetizationState({
+            application: {
+              ...data,
+              screeningMonetization: buildScreeningMonetizationPatch({
+                current: data?.screeningMonetization,
+                eligibility: "eligible",
+                paymentStatus: "checkout_created",
+                fulfillmentStatus: "ready",
+                checkoutSessionId: session.id,
+                checkoutCreatedAt: now,
+                amount: pricing.totalAmountCents,
+                currency: "CAD",
+              }),
+            },
+            latestOrder: { ...orderPayload, stripeCheckoutSessionId: session.id },
+            eligibility: "eligible",
+            amount: pricing.totalAmountCents,
+            currency: "CAD",
+          })
+        ),
+      });
     } catch (err: any) {
       console.error("[screening_checkout] create_session_fail", {
         ...logBase,
@@ -1726,7 +2050,9 @@ router.post(
       let applicationId = existingApplicationId;
       const propertyIdInput = String(body?.propertyId || "").trim();
       const unitIdInput = String(body?.unitId || "").trim();
+      const tenantEmailInput = String(body?.tenantEmail || "").trim().toLowerCase();
       let data: any = null;
+      let autopilotPolicy: ReturnType<typeof toAutopilotPolicySummary> | null = null;
 
       if (!applicationId && !propertyIdInput) {
         return res.status(400).json({ ok: false, error: "missing_property" });
@@ -1742,13 +2068,50 @@ router.post(
 
         const eligibility = evaluateEligibility(data);
         if (!eligibility.eligible) {
+          const latestOrderDoc = await getLatestOrderByApplicationId(applicationId);
+          const screeningMonetizationSummary = buildScreeningMonetizationSummary(
+            normalizeScreeningMonetizationState({
+              application: data,
+              latestOrder: latestOrderDoc?.data?.() || null,
+              eligibility: "ineligible",
+            })
+          );
           return res.status(400).json({
             ok: false,
             error: "not_eligible",
+            errorCode: "SCREENING_MONETIZATION_BLOCKED",
             detail: eligibility.detail,
             reasonCode: eligibility.reasonCode,
+            screeningMonetizationSummary: {
+              ...screeningMonetizationSummary,
+              blockingReason: "SCREENING_MONETIZATION_BLOCKED",
+            },
           });
         }
+        const consent = resolveConsentPayload(body, data);
+        const consentCheck = validateConsent(consent);
+        const policyRequest = buildScreeningPolicyRequest({
+          action: "start_checkout",
+          actorRole: role,
+          actorUserId: String(req.user?.id || req.user?.landlordId || "").trim() || null,
+          applicationId,
+          eligibility,
+          application: data,
+          consentComplete: consentCheck.ok,
+          providerReady: true,
+        });
+        const policyResult = evaluatePolicy(policyRequest);
+        autopilotPolicy = toAutopilotPolicySummary(policyResult);
+        await writePolicyEvaluatedEvent({
+          request: policyRequest,
+          result: policyResult,
+          actorType: role === "admin" ? "admin" : "landlord",
+          metadata: {
+            landlordId: data?.landlordId || landlordId,
+            propertyId: data?.propertyId || propertyIdInput || null,
+            unitId: data?.unitId || unitIdInput || null,
+          },
+        });
       } else {
         const manualApp = await createManualApplicationFromOrderBody({
           landlordId: String(landlordId),
@@ -1786,9 +2149,53 @@ router.post(
           return res.status(400).json({
             ok: false,
             error: "consent_required",
+            errorCode: "SCREENING_MONETIZATION_BLOCKED",
             detail: consentCheck.error,
+            autopilotPolicy,
           });
         }
+      }
+      const latestOrderDoc = applicationId
+        ? await getLatestOrderByApplicationId(applicationId)
+        : await getLatestOrderByManualCheckout({
+            landlordId: String(landlordId),
+            propertyId: data?.propertyId || propertyIdInput,
+            unitId: data?.unitId || unitIdInput || null,
+            tenantEmail: tenantEmailInput || data?.applicant?.email || null,
+          });
+      const latestOrder = latestOrderDoc?.data?.() || null;
+      const existingMonetizationState = normalizeScreeningMonetizationState({
+        application: data,
+        latestOrder,
+        eligibility: "eligible",
+      });
+      const existingMonetizationSummary = buildScreeningMonetizationSummary(existingMonetizationState);
+      if (existingMonetizationSummary.alreadyPaid) {
+        return res.status(409).json({
+          ok: false,
+          error: "screening_already_paid",
+          errorCode: "SCREENING_ALREADY_PAID",
+          autopilotPolicy,
+          screeningMonetizationSummary: existingMonetizationSummary,
+        });
+      }
+      if (existingMonetizationSummary.blockingReason === "SCREENING_ORDER_ALREADY_CREATED") {
+        return res.status(409).json({
+          ok: false,
+          error: "screening_order_already_created",
+          errorCode: "SCREENING_ORDER_ALREADY_CREATED",
+          autopilotPolicy,
+          screeningMonetizationSummary: existingMonetizationSummary,
+        });
+      }
+      if (existingMonetizationSummary.blockingReason === "SCREENING_CHECKOUT_ALREADY_EXISTS") {
+        return res.status(409).json({
+          ok: false,
+          error: "screening_checkout_already_exists",
+          errorCode: "SCREENING_CHECKOUT_ALREADY_EXISTS",
+          autopilotPolicy,
+          screeningMonetizationSummary: existingMonetizationSummary,
+        });
       }
 
       const providerHealth = await getScreeningProviderHealth();
@@ -1812,7 +2219,16 @@ router.post(
         return res.status(503).json({
           ok: false,
           error: "screening_unavailable",
+          errorCode: "SCREENING_PROVIDER_UNAVAILABLE",
           detail: "provider_not_ready",
+          autopilotPolicy,
+          screeningMonetizationSummary: buildScreeningMonetizationSummary(
+            normalizeScreeningMonetizationState({
+              application: data,
+              latestOrder,
+              eligibility: "provider_unavailable",
+            })
+          ),
           ...(role === "admin" ? { preflightDetail: providerHealth.preflightDetail || null } : {}),
         });
       }
@@ -1912,6 +2328,18 @@ router.post(
                 provider: "transunion_referral",
                 orderId,
               },
+              screeningMonetization: buildScreeningMonetizationPatch({
+                current: data?.screeningMonetization,
+                eligibility: "eligible",
+                paymentStatus: "checkout_created",
+                fulfillmentStatus: "ordered",
+                checkoutSessionId: orderId,
+                checkoutCreatedAt: now,
+                amount: 0,
+                currency: "CAD",
+                lastErrorCode: null,
+                lastErrorMessage: null,
+              }),
               updatedAt: now,
             },
             { merge: true }
@@ -1938,6 +2366,31 @@ router.post(
           applicationId: applicationId || null,
           redirectUrl: referralUrl,
           checkoutUrl: referralUrl,
+          autopilotPolicy,
+          screeningMonetizationSummary: buildScreeningMonetizationSummary(
+            normalizeScreeningMonetizationState({
+              application:
+                applicationId && data
+                  ? {
+                      ...data,
+                      screeningMonetization: buildScreeningMonetizationPatch({
+                        current: data?.screeningMonetization,
+                        eligibility: "eligible",
+                        paymentStatus: "checkout_created",
+                        fulfillmentStatus: "ordered",
+                        checkoutSessionId: orderId,
+                        checkoutCreatedAt: now,
+                        amount: 0,
+                        currency: "CAD",
+                      }),
+                    }
+                  : data,
+              latestOrder: { ...orderPayload, stripeCheckoutSessionId: orderId },
+              eligibility: "eligible",
+              amount: 0,
+              currency: "CAD",
+            })
+          ),
         });
       }
 
@@ -2039,21 +2492,6 @@ router.post(
 
       await orderRef.set(orderPayload, { merge: true });
 
-      if (applicationId) {
-        await db.collection("rentalApplications").doc(applicationId).set(
-          {
-            screening: {
-              consentGiven: true,
-              consentTimestamp: consent.timestamp,
-              consentVersion: consent.version,
-              consentTextHash: consent.textHash,
-            },
-            updatedAt: now,
-          },
-          { merge: true }
-        );
-      }
-
       const currency = String(orderPayload.currency || "CAD").toLowerCase();
       const lineItems: any[] = [
         {
@@ -2141,6 +2579,33 @@ router.post(
         { merge: true }
       );
 
+      if (applicationId) {
+        await db.collection("rentalApplications").doc(applicationId).set(
+          {
+            screening: {
+              consentGiven: true,
+              consentTimestamp: consent.timestamp,
+              consentVersion: consent.version,
+              consentTextHash: consent.textHash,
+            },
+            screeningMonetization: buildScreeningMonetizationPatch({
+              current: data?.screeningMonetization,
+              eligibility: "eligible",
+              paymentStatus: "checkout_created",
+              fulfillmentStatus: "ready",
+              checkoutSessionId: session.id,
+              checkoutCreatedAt: now,
+              amount: pricing.totalAmountCents,
+              currency: "CAD",
+              lastErrorCode: null,
+              lastErrorMessage: null,
+            }),
+            updatedAt: now,
+          },
+          { merge: true }
+        );
+      }
+
       if (tenantEmail) {
         const apiKey = String(process.env.SENDGRID_API_KEY || "").trim();
         const from =
@@ -2176,7 +2641,37 @@ router.post(
         }
       }
 
-      return res.json({ ok: true, orderId, checkoutUrl: session.url, tenantInviteUrl });
+      return res.json({
+        ok: true,
+        orderId,
+        checkoutUrl: session.url,
+        tenantInviteUrl,
+        autopilotPolicy,
+        screeningMonetizationSummary: buildScreeningMonetizationSummary(
+          normalizeScreeningMonetizationState({
+            application:
+              applicationId && data
+                ? {
+                    ...data,
+                    screeningMonetization: buildScreeningMonetizationPatch({
+                      current: data?.screeningMonetization,
+                      eligibility: "eligible",
+                      paymentStatus: "checkout_created",
+                      fulfillmentStatus: "ready",
+                      checkoutSessionId: session.id,
+                      checkoutCreatedAt: now,
+                      amount: pricing.totalAmountCents,
+                      currency: "CAD",
+                    }),
+                  }
+                : data,
+            latestOrder: { ...orderPayload, stripeCheckoutSessionId: session.id },
+            eligibility: "eligible",
+            amount: pricing.totalAmountCents,
+            currency: "CAD",
+          })
+        ),
+      });
     } catch (err: any) {
       console.error("[screening_orders] failed", {
         ...logBase,
@@ -2210,6 +2705,8 @@ router.get(
       return res.status(403).json({ ok: false, error: "forbidden" });
     }
 
+    const appSnap = data?.applicationId ? await db.collection("rentalApplications").doc(String(data.applicationId)).get() : null;
+    const application = appSnap?.exists ? appSnap.data() : null;
     return res.json({
       ok: true,
       data: {
@@ -2230,6 +2727,12 @@ router.get(
         failureDetail: data?.failureDetail || null,
         stripeIdentitySessionId: data?.stripeIdentitySessionId || null,
         updatedAt: data?.updatedAt || null,
+        screeningMonetizationSummary: buildScreeningMonetizationSummary(
+          normalizeScreeningMonetizationState({
+            application,
+            latestOrder: data,
+          })
+        ),
       },
     });
   }
@@ -2311,11 +2814,13 @@ router.get(
     }
 
     if (!orderDoc) {
+      let authorizedApplicationData: any = null;
       if (applicationId) {
         const access = await loadAuthorizedApplication(req, applicationId);
         if (!access.ok) {
           return res.status(access.status).json({ ok: false, error: access.error });
         }
+        authorizedApplicationData = access.data;
       }
       return res.json({
         ok: true,
@@ -2329,6 +2834,11 @@ router.get(
           stripePaymentIntentId: null,
           stripeCheckoutSessionId: null,
           lastUpdatedAt: null,
+          screeningMonetizationSummary: buildScreeningMonetizationSummary(
+            normalizeScreeningMonetizationState({
+              application: authorizedApplicationData,
+            })
+          ),
         },
       });
     }
@@ -2337,7 +2847,19 @@ router.get(
     if (role !== "admin" && data?.landlordId && data.landlordId !== landlordId) {
       return res.status(403).json({ ok: false, error: "forbidden" });
     }
-    return res.json({ ok: true, data: normalizeOrderView(orderDoc.id, data) });
+    const appSnap = data?.applicationId ? await db.collection("rentalApplications").doc(String(data.applicationId)).get() : null;
+    return res.json({
+      ok: true,
+      data: {
+        ...normalizeOrderView(orderDoc.id, data),
+        screeningMonetizationSummary: buildScreeningMonetizationSummary(
+          normalizeScreeningMonetizationState({
+            application: appSnap?.exists ? appSnap.data() : null,
+            latestOrder: data,
+          })
+        ),
+      },
+    });
   }
 );
 
@@ -2382,6 +2904,9 @@ router.post(
           stripePaymentIntentId: null,
           stripeCheckoutSessionId: null,
           lastUpdatedAt: null,
+          screeningMonetizationSummary: buildScreeningMonetizationSummary(
+            normalizeScreeningMonetizationState({})
+          ),
         },
       });
     }
@@ -2393,12 +2918,40 @@ router.post(
 
     const currentStatus = normalizeOrderStatus(order);
     if (currentStatus === "paid") {
-      return res.json({ ok: true, data: normalizeOrderView(orderDoc.id, order) });
+      const appSnap = order?.applicationId
+        ? await db.collection("rentalApplications").doc(String(order.applicationId)).get()
+        : null;
+      return res.json({
+        ok: true,
+        data: {
+          ...normalizeOrderView(orderDoc.id, order),
+          screeningMonetizationSummary: buildScreeningMonetizationSummary(
+            normalizeScreeningMonetizationState({
+              application: appSnap?.exists ? appSnap.data() : null,
+              latestOrder: order,
+            })
+          ),
+        },
+      });
     }
     const now = Date.now();
     const lastReconcileAt = Number(order?.lastReconcileAt || 0);
     if (lastReconcileAt > 0 && now - lastReconcileAt < 20_000) {
-      return res.json({ ok: true, data: normalizeOrderView(orderDoc.id, order) });
+      const appSnap = order?.applicationId
+        ? await db.collection("rentalApplications").doc(String(order.applicationId)).get()
+        : null;
+      return res.json({
+        ok: true,
+        data: {
+          ...normalizeOrderView(orderDoc.id, order),
+          screeningMonetizationSummary: buildScreeningMonetizationSummary(
+            normalizeScreeningMonetizationState({
+              application: appSnap?.exists ? appSnap.data() : null,
+              latestOrder: order,
+            })
+          ),
+        },
+      });
     }
     await db.collection("screeningOrders").doc(orderDoc.id).set({ lastReconcileAt: now }, { merge: true });
 
@@ -2491,7 +3044,21 @@ router.post(
 
     const refreshed = await db.collection("screeningOrders").doc(orderDoc.id).get();
     const refreshedData = (refreshed.data() as any) || order;
-    return res.json({ ok: true, data: normalizeOrderView(orderDoc.id, refreshedData) });
+    const appSnap = refreshedData?.applicationId
+      ? await db.collection("rentalApplications").doc(String(refreshedData.applicationId)).get()
+      : null;
+    return res.json({
+      ok: true,
+      data: {
+        ...normalizeOrderView(orderDoc.id, refreshedData),
+        screeningMonetizationSummary: buildScreeningMonetizationSummary(
+          normalizeScreeningMonetizationState({
+            application: appSnap?.exists ? appSnap.data() : null,
+            latestOrder: refreshedData,
+          })
+        ),
+      },
+    });
   }
 );
 

--- a/rentchain-api/src/routes/stripeScreeningOrdersWebhookRoutes.ts
+++ b/rentchain-api/src/routes/stripeScreeningOrdersWebhookRoutes.ts
@@ -11,6 +11,7 @@ import { beginScreening } from "../services/screening/screeningOrchestrator";
 import { writeScreeningEvent } from "../services/screening/screeningEvents";
 import { recordScreeningPaymentFailed } from "../services/screeningPaymentTransactionService";
 import { writeCanonicalEvent } from "../lib/events/buildEvent";
+import { buildScreeningMonetizationPatch } from "../services/screening/screeningMonetizationService";
 
 interface StripeWebhookRequest extends Request {
   rawBody?: Buffer;
@@ -130,6 +131,16 @@ async function markApplicationScreeningPaid(params: {
       screeningSessionId: sessionId,
       screeningPaymentIntentId: String(paymentIntentId || ""),
       screeningLastUpdatedAt: paidAt,
+      screeningMonetization: buildScreeningMonetizationPatch({
+        current: data?.screeningMonetization,
+        eligibility: "eligible",
+        paymentStatus: "paid",
+        fulfillmentStatus: "ordered",
+        checkoutSessionId: sessionId,
+        paidAt,
+        lastErrorCode: null,
+        lastErrorMessage: null,
+      }),
     },
     { merge: true }
   );
@@ -406,6 +417,19 @@ async function handleScreeningPaymentFailure(params: {
             orderId: orderRef.id,
             errorCode: normalizeOptionalString(params.failureCode, 120) || null,
           },
+          screeningMonetization: buildScreeningMonetizationPatch({
+            current: (appSnap.data() as any)?.screeningMonetization,
+            eligibility: "eligible",
+            paymentStatus: "failed",
+            fulfillmentStatus: "blocked",
+            checkoutSessionId:
+              normalizeOptionalString(params.sessionId, 120) ||
+              normalizeOptionalString(order?.stripeCheckoutSessionId, 120) ||
+              normalizeOptionalString(order?.stripeSessionId, 120) ||
+              null,
+            lastErrorCode: "SCREENING_MONETIZATION_BLOCKED",
+            lastErrorMessage: normalizeOptionalString(params.failureMessage, 500) || null,
+          }),
           updatedAt: params.occurredAt,
         },
         { merge: true }

--- a/rentchain-api/src/services/screening/__tests__/screeningMonetizationService.test.ts
+++ b/rentchain-api/src/services/screening/__tests__/screeningMonetizationService.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildQuoteId,
+  buildScreeningMonetizationPatch,
+  buildScreeningMonetizationSummary,
+  normalizeScreeningMonetizationState,
+  SCREENING_QUOTE_TTL_MS,
+} from "../screeningMonetizationService";
+
+describe("screeningMonetizationService", () => {
+  it("maps legacy missing fields into a stable default summary", () => {
+    const state = normalizeScreeningMonetizationState({});
+    expect(buildScreeningMonetizationSummary(state)).toEqual({
+      eligibility: "eligible",
+      quoteStatus: "none",
+      paymentStatus: "none",
+      fulfillmentStatus: "not_started",
+      canGenerateQuote: true,
+      canStartCheckout: true,
+      canRetryCheckout: false,
+      alreadyPaid: false,
+      blockingReason: null,
+      amount: null,
+      currency: null,
+    });
+  });
+
+  it("marks quotes as expired once the TTL has elapsed", () => {
+    const now = Date.now();
+    const state = normalizeScreeningMonetizationState({
+      application: {
+        screeningMonetization: {
+          version: "v1",
+          eligibility: "eligible",
+          quoteStatus: "generated",
+          quoteId: buildQuoteId({ applicationId: "app-1", now: now - SCREENING_QUOTE_TTL_MS - 1000 }),
+          quoteGeneratedAt: new Date(now - SCREENING_QUOTE_TTL_MS - 1000).toISOString(),
+        },
+      },
+      now,
+    });
+
+    const summary = buildScreeningMonetizationSummary(state);
+    expect(state.quoteStatus).toBe("expired");
+    expect(summary.blockingReason).toBe("SCREENING_QUOTE_EXPIRED");
+    expect(summary.canRetryCheckout).toBe(true);
+  });
+
+  it("blocks duplicate checkout when an unpaid order already has a checkout session", () => {
+    const state = normalizeScreeningMonetizationState({
+      latestOrder: {
+        status: "unpaid",
+        paymentStatus: "unpaid",
+        stripeCheckoutSessionId: "sess_1",
+        amountTotalCents: 4900,
+        currency: "cad",
+      },
+    });
+
+    const summary = buildScreeningMonetizationSummary(state);
+    expect(state.paymentStatus).toBe("checkout_created");
+    expect(summary.blockingReason).toBe("SCREENING_CHECKOUT_ALREADY_EXISTS");
+  });
+
+  it("preserves paid/completed protection from current application state", () => {
+    const state = normalizeScreeningMonetizationState({
+      application: {
+        screeningStatus: "complete",
+        screeningPaidAt: Date.now(),
+      },
+    });
+
+    const summary = buildScreeningMonetizationSummary(state);
+    expect(summary.alreadyPaid).toBe(true);
+    expect(summary.blockingReason).toBe("SCREENING_ALREADY_PAID");
+  });
+
+  it("builds additive patches without dropping existing values", () => {
+    const patch = buildScreeningMonetizationPatch({
+      current: {
+        version: "v1",
+        eligibility: "eligible",
+        quoteStatus: "generated",
+        quoteId: "quote_1",
+        quoteGeneratedAt: "2026-01-01T00:00:00.000Z",
+        amount: 4900,
+        currency: "CAD",
+      },
+      paymentStatus: "checkout_created",
+      checkoutSessionId: "sess_1",
+    });
+
+    expect(patch.quoteId).toBe("quote_1");
+    expect(patch.paymentStatus).toBe("checkout_created");
+    expect(patch.checkoutSessionId).toBe("sess_1");
+  });
+});

--- a/rentchain-api/src/services/screening/screeningMonetizationService.ts
+++ b/rentchain-api/src/services/screening/screeningMonetizationService.ts
@@ -1,0 +1,368 @@
+export type ScreeningMonetizationEligibility =
+  | "eligible"
+  | "ineligible"
+  | "requires_upgrade"
+  | "provider_unavailable";
+
+export type ScreeningMonetizationQuoteStatus = "none" | "generated" | "expired" | "invalid";
+
+export type ScreeningMonetizationPaymentStatus =
+  | "none"
+  | "pending_checkout"
+  | "checkout_created"
+  | "paid"
+  | "failed"
+  | "abandoned"
+  | "waived";
+
+export type ScreeningMonetizationFulfillmentStatus =
+  | "not_started"
+  | "ready"
+  | "ordered"
+  | "completed"
+  | "blocked";
+
+export type ScreeningMonetizationStateV1 = {
+  version: "v1";
+  eligibility: ScreeningMonetizationEligibility;
+  quoteStatus: ScreeningMonetizationQuoteStatus;
+  paymentStatus: ScreeningMonetizationPaymentStatus;
+  fulfillmentStatus: ScreeningMonetizationFulfillmentStatus;
+  quoteId?: string | null;
+  quoteGeneratedAt?: string | null;
+  quoteExpiresAt?: string | null;
+  checkoutSessionId?: string | null;
+  checkoutCreatedAt?: string | null;
+  paidAt?: string | null;
+  amount?: number | null;
+  currency?: string | null;
+  providerHealthSnapshot?: {
+    status?: string | null;
+  } | null;
+  lastErrorCode?: string | null;
+  lastErrorMessage?: string | null;
+  lastUpdatedAt?: string | null;
+};
+
+export type ScreeningMonetizationSummary = {
+  eligibility: string;
+  quoteStatus: string;
+  paymentStatus: string;
+  fulfillmentStatus: string;
+  canGenerateQuote: boolean;
+  canStartCheckout: boolean;
+  canRetryCheckout: boolean;
+  alreadyPaid: boolean;
+  blockingReason?: string | null;
+  amount?: number | null;
+  currency?: string | null;
+};
+
+export const SCREENING_QUOTE_TTL_MS = 30 * 60 * 1000;
+
+function asString(value: unknown, max = 2000) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function asOptionalString(value: unknown, max = 2000) {
+  const next = asString(value, max);
+  return next || null;
+}
+
+function toIsoString(value: unknown): string | null {
+  if (value == null || value === "") return null;
+  if (typeof value === "number" && Number.isFinite(value)) return new Date(value).toISOString();
+  if (value instanceof Date) {
+    const time = value.getTime();
+    return Number.isFinite(time) ? value.toISOString() : null;
+  }
+  const raw = String(value).trim();
+  if (!raw) return null;
+  const parsed = Date.parse(raw);
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : null;
+}
+
+function toMillis(value: unknown): number | null {
+  const iso = toIsoString(value);
+  if (!iso) return null;
+  const parsed = Date.parse(iso);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function normalizeCurrency(value: unknown) {
+  const next = asString(value, 8).toUpperCase();
+  return /^[A-Z]{3}$/.test(next) ? next : null;
+}
+
+function normalizeEligibility(value: unknown): ScreeningMonetizationEligibility {
+  const next = asString(value, 60).toLowerCase();
+  if (next === "provider_unavailable") return "provider_unavailable";
+  if (next === "requires_upgrade") return "requires_upgrade";
+  if (next === "ineligible") return "ineligible";
+  return "eligible";
+}
+
+function normalizeQuoteStatus(value: unknown): ScreeningMonetizationQuoteStatus {
+  const next = asString(value, 60).toLowerCase();
+  if (next === "generated") return "generated";
+  if (next === "expired") return "expired";
+  if (next === "invalid") return "invalid";
+  return "none";
+}
+
+function normalizePaymentStatus(value: unknown): ScreeningMonetizationPaymentStatus {
+  const next = asString(value, 60).toLowerCase();
+  if (next === "pending_checkout") return "pending_checkout";
+  if (next === "checkout_created") return "checkout_created";
+  if (next === "paid") return "paid";
+  if (next === "failed") return "failed";
+  if (next === "abandoned") return "abandoned";
+  if (next === "waived") return "waived";
+  return "none";
+}
+
+function normalizeFulfillmentStatus(value: unknown): ScreeningMonetizationFulfillmentStatus {
+  const next = asString(value, 60).toLowerCase();
+  if (next === "ready") return "ready";
+  if (next === "ordered") return "ordered";
+  if (next === "completed") return "completed";
+  if (next === "blocked") return "blocked";
+  return "not_started";
+}
+
+function normalizeOrderStatus(order: any) {
+  const rawStatus = asString(order?.status, 60).toLowerCase();
+  const paymentStatus = asString(order?.paymentStatus, 60).toLowerCase();
+  if (
+    rawStatus === "paid" ||
+    rawStatus === "complete" ||
+    rawStatus === "completed" ||
+    rawStatus === "report_ready" ||
+    rawStatus === "external_completed" ||
+    paymentStatus === "paid" ||
+    order?.finalized === true
+  ) {
+    return "paid";
+  }
+  if (
+    rawStatus === "processing" ||
+    rawStatus === "external_pending" ||
+    rawStatus === "queued_external" ||
+    rawStatus === "kba_in_progress" ||
+    rawStatus === "in_progress"
+  ) {
+    return "processing";
+  }
+  if (rawStatus === "failed" || rawStatus === "kba_failed" || paymentStatus === "failed") {
+    return "failed";
+  }
+  return "unpaid";
+}
+
+function buildQuoteExpiresAt(quoteGeneratedAt: string | null, ttlMs = SCREENING_QUOTE_TTL_MS) {
+  const generatedAt = toMillis(quoteGeneratedAt);
+  if (!generatedAt) return null;
+  return new Date(generatedAt + ttlMs).toISOString();
+}
+
+export function buildQuoteId(params: { applicationId: string; now?: number }) {
+  const now = typeof params.now === "number" ? params.now : Date.now();
+  return `quote_${asString(params.applicationId, 120)}_${now}`;
+}
+
+export function normalizeScreeningMonetizationState(input: {
+  application?: any;
+  latestOrder?: any;
+  eligibility?: ScreeningMonetizationEligibility;
+  providerHealthStatus?: string | null;
+  amount?: number | null;
+  currency?: string | null;
+  now?: number;
+}): ScreeningMonetizationStateV1 {
+  const now = typeof input.now === "number" ? input.now : Date.now();
+  const app = input.application || {};
+  const order = input.latestOrder || null;
+  const existing = (app?.screeningMonetization || {}) as any;
+
+  let eligibility = normalizeEligibility(input.eligibility || existing.eligibility);
+  let quoteStatus = normalizeQuoteStatus(existing.quoteStatus);
+  let paymentStatus = normalizePaymentStatus(existing.paymentStatus);
+  let fulfillmentStatus = normalizeFulfillmentStatus(existing.fulfillmentStatus);
+
+  const appScreeningStatus = asString(app?.screeningStatus, 60).toLowerCase();
+  const orderStatus = order ? normalizeOrderStatus(order) : "unpaid";
+  const quoteGeneratedAt = toIsoString(existing.quoteGeneratedAt);
+  const quoteExpiresAt = toIsoString(existing.quoteExpiresAt) || buildQuoteExpiresAt(quoteGeneratedAt);
+  const quoteExpired = quoteStatus === "generated" && Boolean(quoteExpiresAt) && Number(toMillis(quoteExpiresAt) || 0) < now;
+
+  if (quoteExpired) {
+    quoteStatus = "expired";
+  }
+
+  if (input.providerHealthStatus === "provider_unavailable") {
+    eligibility = "provider_unavailable";
+  }
+
+  if (appScreeningStatus === "paid" || orderStatus === "paid") {
+    paymentStatus = "paid";
+  } else if (appScreeningStatus === "failed" || orderStatus === "failed") {
+    paymentStatus = "failed";
+  } else if (
+    order &&
+    (asOptionalString(order?.stripeCheckoutSessionId, 120) ||
+      asOptionalString(order?.stripeSessionId, 120) ||
+      asOptionalString(order?.externalRedirectUrl, 500))
+  ) {
+    paymentStatus = "checkout_created";
+  } else if (quoteStatus === "generated") {
+    paymentStatus = paymentStatus === "none" ? "pending_checkout" : paymentStatus;
+  }
+
+  if (appScreeningStatus === "complete") {
+    fulfillmentStatus = "completed";
+  } else if (appScreeningStatus === "processing" || orderStatus === "processing" || paymentStatus === "paid") {
+    fulfillmentStatus = "ordered";
+  } else if (
+    eligibility === "provider_unavailable" ||
+    eligibility === "ineligible" ||
+    paymentStatus === "failed"
+  ) {
+    fulfillmentStatus = "blocked";
+  } else if (quoteStatus === "generated") {
+    fulfillmentStatus = "ready";
+  } else {
+    fulfillmentStatus = "not_started";
+  }
+
+  return {
+    version: "v1",
+    eligibility,
+    quoteStatus,
+    paymentStatus,
+    fulfillmentStatus,
+    quoteId: asOptionalString(existing.quoteId, 200),
+    quoteGeneratedAt,
+    quoteExpiresAt,
+    checkoutSessionId:
+      asOptionalString(existing.checkoutSessionId, 200) ||
+      asOptionalString(order?.stripeCheckoutSessionId, 200) ||
+      asOptionalString(order?.stripeSessionId, 200),
+    checkoutCreatedAt:
+      toIsoString(existing.checkoutCreatedAt) ||
+      toIsoString(order?.updatedAt) ||
+      toIsoString(order?.createdAt),
+    paidAt: toIsoString(existing.paidAt) || toIsoString(app?.screeningPaidAt) || toIsoString(order?.paidAt),
+    amount:
+      typeof input.amount === "number"
+        ? input.amount
+        : typeof existing.amount === "number"
+        ? existing.amount
+        : typeof order?.amountTotalCents === "number"
+        ? order.amountTotalCents
+        : typeof order?.totalAmountCents === "number"
+        ? order.totalAmountCents
+        : null,
+    currency: normalizeCurrency(input.currency) || normalizeCurrency(existing.currency) || normalizeCurrency(order?.currency),
+    providerHealthSnapshot: input.providerHealthStatus
+      ? { status: input.providerHealthStatus }
+      : existing?.providerHealthSnapshot || null,
+    lastErrorCode: asOptionalString(existing.lastErrorCode, 120),
+    lastErrorMessage: asOptionalString(existing.lastErrorMessage, 500),
+    lastUpdatedAt: toIsoString(existing.lastUpdatedAt) || new Date(now).toISOString(),
+  };
+}
+
+export function buildScreeningMonetizationSummary(
+  state: ScreeningMonetizationStateV1
+): ScreeningMonetizationSummary {
+  let blockingReason: string | null = null;
+  if (state.paymentStatus === "paid" || state.fulfillmentStatus === "completed") {
+    blockingReason = "SCREENING_ALREADY_PAID";
+  } else if (state.fulfillmentStatus === "ordered") {
+    blockingReason = "SCREENING_ORDER_ALREADY_CREATED";
+  } else if (state.paymentStatus === "checkout_created") {
+    blockingReason = "SCREENING_CHECKOUT_ALREADY_EXISTS";
+  } else if (state.quoteStatus === "expired") {
+    blockingReason = "SCREENING_QUOTE_EXPIRED";
+  } else if (state.eligibility === "provider_unavailable") {
+    blockingReason = "SCREENING_PROVIDER_UNAVAILABLE";
+  } else if (state.eligibility === "requires_upgrade") {
+    blockingReason = "SCREENING_UPGRADE_REQUIRED";
+  } else if (state.eligibility !== "eligible" || state.fulfillmentStatus === "blocked") {
+    blockingReason = state.lastErrorCode || "SCREENING_MONETIZATION_BLOCKED";
+  }
+
+  return {
+    eligibility: state.eligibility,
+    quoteStatus: state.quoteStatus,
+    paymentStatus: state.paymentStatus,
+    fulfillmentStatus: state.fulfillmentStatus,
+    canGenerateQuote:
+      !blockingReason ||
+      blockingReason === "SCREENING_QUOTE_EXPIRED" ||
+      blockingReason === "SCREENING_PROVIDER_UNAVAILABLE",
+    canStartCheckout: !blockingReason || blockingReason === "SCREENING_QUOTE_EXPIRED",
+    canRetryCheckout:
+      state.paymentStatus === "failed" ||
+      state.paymentStatus === "abandoned" ||
+      state.quoteStatus === "expired",
+    alreadyPaid: state.paymentStatus === "paid" || state.fulfillmentStatus === "completed",
+    blockingReason,
+    amount: state.amount ?? null,
+    currency: state.currency ?? null,
+  };
+}
+
+export function buildScreeningMonetizationPatch(input: {
+  current?: any;
+  eligibility?: ScreeningMonetizationEligibility;
+  quoteStatus?: ScreeningMonetizationQuoteStatus;
+  paymentStatus?: ScreeningMonetizationPaymentStatus;
+  fulfillmentStatus?: ScreeningMonetizationFulfillmentStatus;
+  quoteId?: string | null;
+  quoteGeneratedAt?: string | number | Date | null;
+  quoteExpiresAt?: string | number | Date | null;
+  checkoutSessionId?: string | null;
+  checkoutCreatedAt?: string | number | Date | null;
+  paidAt?: string | number | Date | null;
+  amount?: number | null;
+  currency?: string | null;
+  providerHealthStatus?: string | null;
+  lastErrorCode?: string | null;
+  lastErrorMessage?: string | null;
+  now?: number;
+}) {
+  const now = typeof input.now === "number" ? input.now : Date.now();
+  const current = normalizeScreeningMonetizationState({
+    application: { screeningMonetization: input.current || {} },
+    now,
+  });
+  const quoteGeneratedAt = toIsoString(input.quoteGeneratedAt) || current.quoteGeneratedAt || null;
+  const quoteExpiresAt =
+    toIsoString(input.quoteExpiresAt) ||
+    (input.quoteStatus === "generated" ? buildQuoteExpiresAt(quoteGeneratedAt) : current.quoteExpiresAt);
+
+  return {
+    version: "v1" as const,
+    eligibility: input.eligibility || current.eligibility,
+    quoteStatus: input.quoteStatus || current.quoteStatus,
+    paymentStatus: input.paymentStatus || current.paymentStatus,
+    fulfillmentStatus: input.fulfillmentStatus || current.fulfillmentStatus,
+    quoteId: input.quoteId === undefined ? current.quoteId || null : input.quoteId,
+    quoteGeneratedAt,
+    quoteExpiresAt: quoteExpiresAt || null,
+    checkoutSessionId:
+      input.checkoutSessionId === undefined ? current.checkoutSessionId || null : input.checkoutSessionId,
+    checkoutCreatedAt: toIsoString(input.checkoutCreatedAt) || current.checkoutCreatedAt || null,
+    paidAt: toIsoString(input.paidAt) || current.paidAt || null,
+    amount: typeof input.amount === "number" ? input.amount : current.amount ?? null,
+    currency: normalizeCurrency(input.currency) || current.currency || null,
+    providerHealthSnapshot: input.providerHealthStatus
+      ? { status: input.providerHealthStatus }
+      : current.providerHealthSnapshot || null,
+    lastErrorCode: input.lastErrorCode === undefined ? current.lastErrorCode || null : input.lastErrorCode,
+    lastErrorMessage:
+      input.lastErrorMessage === undefined ? current.lastErrorMessage || null : input.lastErrorMessage,
+    lastUpdatedAt: new Date(now).toISOString(),
+  };
+}

--- a/rentchain-api/src/services/screening/screeningOrchestrator.ts
+++ b/rentchain-api/src/services/screening/screeningOrchestrator.ts
@@ -2,6 +2,7 @@ import { db } from "../../config/firebase";
 import type { ScreeningResultSummary } from "./providers/types";
 import { writeScreeningEvent } from "./screeningEvents";
 import { writeCanonicalEvent } from "../../lib/events/buildEvent";
+import { buildScreeningMonetizationPatch } from "./screeningMonetizationService";
 
 type ScreeningStatus =
   | "unpaid"
@@ -44,6 +45,14 @@ export async function beginScreening(
       screeningStartedAt: now,
       screeningProvider: "manual",
       screeningLastUpdatedAt: now,
+      screeningMonetization: buildScreeningMonetizationPatch({
+        current: data?.screeningMonetization,
+        eligibility: "eligible",
+        paymentStatus: "paid",
+        fulfillmentStatus: "ordered",
+        lastErrorCode: null,
+        lastErrorMessage: null,
+      }),
     },
     { merge: true }
   );
@@ -102,6 +111,14 @@ export async function markScreeningComplete(
       screeningResultId: resultRef.id,
       screeningResultSummary: summary,
       screeningLastUpdatedAt: now,
+      screeningMonetization: buildScreeningMonetizationPatch({
+        current: data?.screeningMonetization,
+        eligibility: "eligible",
+        paymentStatus: "paid",
+        fulfillmentStatus: "completed",
+        lastErrorCode: null,
+        lastErrorMessage: null,
+      }),
     },
     { merge: true }
   );
@@ -164,6 +181,14 @@ export async function markScreeningFailed(
       screeningFailureCode: failure.code,
       screeningFailureDetail: failure.detail || null,
       screeningLastUpdatedAt: now,
+      screeningMonetization: buildScreeningMonetizationPatch({
+        current: data?.screeningMonetization,
+        eligibility: "eligible",
+        paymentStatus: "failed",
+        fulfillmentStatus: "blocked",
+        lastErrorCode: "SCREENING_MONETIZATION_BLOCKED",
+        lastErrorMessage: failure.detail || failure.code,
+      }),
     },
     { merge: true }
   );

--- a/rentchain-api/src/services/stripeFinalize.ts
+++ b/rentchain-api/src/services/stripeFinalize.ts
@@ -1,6 +1,7 @@
 import { db } from "../config/firebase";
 import { enqueueScreeningJob } from "./screeningJobs";
 import { recordScreeningPaymentSucceeded } from "./screeningPaymentTransactionService";
+import { buildScreeningMonetizationPatch } from "./screening/screeningMonetizationService";
 
 export type FinalizeStripeArgs = {
   eventId: string;
@@ -203,6 +204,19 @@ export async function finalizeStripePayment(
             paidAt: finalizedAt,
             orderId: orderRef.id,
           },
+          screeningMonetization: buildScreeningMonetizationPatch({
+            current: appSnap.data()?.screeningMonetization,
+            eligibility: "eligible",
+            paymentStatus: "paid",
+            fulfillmentStatus: "ordered",
+            checkoutSessionId:
+              normStr(args.sessionId) || order.stripeCheckoutSessionId || order.stripeSessionId || null,
+            paidAt: finalizedAt,
+            amount: amountTotalCents ?? order.amountTotalCents ?? order.totalAmountCents ?? null,
+            currency: currency ?? order.currency ?? null,
+            lastErrorCode: null,
+            lastErrorMessage: null,
+          }),
           updatedAt: finalizedAt,
         },
         { merge: true }

--- a/rentchain-frontend/src/api/rentalApplicationsApi.ts
+++ b/rentchain-frontend/src/api/rentalApplicationsApi.ts
@@ -322,6 +322,20 @@ export type ScreeningQuote = {
   eligible: boolean;
 };
 
+export type ScreeningMonetizationSummary = {
+  eligibility: string;
+  quoteStatus: string;
+  paymentStatus: string;
+  fulfillmentStatus: string;
+  canGenerateQuote: boolean;
+  canStartCheckout: boolean;
+  canRetryCheckout: boolean;
+  alreadyPaid: boolean;
+  blockingReason?: string | null;
+  amount?: number | null;
+  currency?: string | null;
+};
+
 export type ScreeningRunResult = {
   orderId: string;
   status: "COMPLETE" | "FAILED" | "PENDING";
@@ -424,7 +438,14 @@ export async function fetchScreeningQuote(
     serviceLevel?: "SELF_SERVE" | "VERIFIED" | "VERIFIED_AI";
     scoreAddOn?: boolean;
   }
-): Promise<{ ok: boolean; data?: ScreeningQuote; error?: string; detail?: string }> {
+): Promise<{
+  ok: boolean;
+  data?: ScreeningQuote;
+  error?: string;
+  errorCode?: string;
+  detail?: string;
+  screeningMonetizationSummary?: ScreeningMonetizationSummary;
+}> {
   const primaryStart = nowMs();
   const res: any = await apiFetch(`/rental-applications/${encodeURIComponent(id)}/screening/quote`, {
     method: "POST",
@@ -432,7 +453,14 @@ export async function fetchScreeningQuote(
     body: JSON.stringify(params || {}),
   });
   const primaryDurationMs = Math.round(nowMs() - primaryStart);
-  const typed = res as { ok: boolean; data?: ScreeningQuote; error?: string; detail?: string };
+  const typed = res as {
+    ok: boolean;
+    data?: ScreeningQuote;
+    error?: string;
+    errorCode?: string;
+    detail?: string;
+    screeningMonetizationSummary?: ScreeningMonetizationSummary;
+  };
 
   void runShadowTask({
     name: "quote",
@@ -560,7 +588,16 @@ export async function createScreeningOrder(params: {
   returnTo?: string;
   successPath?: string;
   cancelPath?: string;
-}): Promise<{ ok: boolean; checkoutUrl?: string; orderId?: string; tenantInviteUrl?: string; error?: string; detail?: string }> {
+}): Promise<{
+  ok: boolean;
+  checkoutUrl?: string;
+  orderId?: string;
+  tenantInviteUrl?: string;
+  error?: string;
+  errorCode?: string;
+  detail?: string;
+  screeningMonetizationSummary?: ScreeningMonetizationSummary;
+}> {
   const primaryStart = nowMs();
   const res: any = await apiFetch(`/screening/orders`, {
     method: "POST",
@@ -568,7 +605,16 @@ export async function createScreeningOrder(params: {
     body: JSON.stringify(params),
   });
   const primaryDurationMs = Math.round(nowMs() - primaryStart);
-  const typed = res as { ok: boolean; checkoutUrl?: string; orderId?: string; tenantInviteUrl?: string; error?: string; detail?: string };
+  const typed = res as {
+    ok: boolean;
+    checkoutUrl?: string;
+    orderId?: string;
+    tenantInviteUrl?: string;
+    error?: string;
+    errorCode?: string;
+    detail?: string;
+    screeningMonetizationSummary?: ScreeningMonetizationSummary;
+  };
   const appId = String(params.applicationId || "");
   const seed = `checkout:${appId || params.propertyId || "unknown"}`;
 
@@ -675,7 +721,16 @@ export async function createScreeningCheckout(
       version: string;
     };
   }
-): Promise<{ ok: boolean; checkoutUrl?: string; orderId?: string; tenantInviteUrl?: string; error?: string; detail?: string }> {
+): Promise<{
+  ok: boolean;
+  checkoutUrl?: string;
+  orderId?: string;
+  tenantInviteUrl?: string;
+  error?: string;
+  errorCode?: string;
+  detail?: string;
+  screeningMonetizationSummary?: ScreeningMonetizationSummary;
+}> {
   return createScreeningOrder({ applicationId: id, ...params });
 }
 

--- a/rentchain-frontend/src/components/screening/SendScreeningInviteModal.test.tsx
+++ b/rentchain-frontend/src/components/screening/SendScreeningInviteModal.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { SendScreeningInviteModal } from "./SendScreeningInviteModal";
 
 vi.mock("../../api/propertiesApi", () => ({
@@ -26,10 +26,18 @@ vi.mock("../../context/UpgradeContext", () => ({
   useUpgrade: vi.fn(),
 }));
 
+const defaultProperty = { id: "prop-1", name: "Harbour House" };
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
 describe("SendScreeningInviteModal", () => {
   it("opens an upgrade flow instead of starting checkout when screening is not entitled", async () => {
     const { useEntitlements } = await import("@/hooks/useEntitlements");
     const { useUpgrade } = await import("../../context/UpgradeContext");
+    const { fetchProperties } = await import("../../api/propertiesApi");
     const { createScreeningOrder } = await import("../../api/rentalApplicationsApi");
     const openUpgrade = vi.fn();
 
@@ -39,6 +47,7 @@ describe("SendScreeningInviteModal", () => {
       requiredPlanFor: () => "starter",
     } as any);
     vi.mocked(useUpgrade).mockReturnValue({ openUpgrade } as any);
+    vi.mocked(fetchProperties).mockResolvedValue({ items: [defaultProperty] } as any);
 
     render(<SendScreeningInviteModal open onClose={vi.fn()} />);
 
@@ -46,5 +55,49 @@ describe("SendScreeningInviteModal", () => {
 
     expect(openUpgrade).toHaveBeenCalled();
     expect(createScreeningOrder).not.toHaveBeenCalled();
+  });
+
+  it("disables repeat submission while checkout creation is in flight", async () => {
+    const { useEntitlements } = await import("@/hooks/useEntitlements");
+    const { useUpgrade } = await import("../../context/UpgradeContext");
+    const { fetchProperties } = await import("../../api/propertiesApi");
+    const { createScreeningOrder } = await import("../../api/rentalApplicationsApi");
+
+    vi.mocked(useEntitlements).mockReturnValue({
+      canScreen: true,
+      plan: "starter",
+      requiredPlanFor: () => "starter",
+    } as any);
+    vi.mocked(useUpgrade).mockReturnValue({ openUpgrade: vi.fn() } as any);
+    vi.mocked(fetchProperties).mockResolvedValue({ items: [defaultProperty] } as any);
+
+    let resolvePromise: ((value: any) => void) | null = null;
+    vi.mocked(createScreeningOrder).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvePromise = resolve;
+        }) as any
+    );
+
+    render(<SendScreeningInviteModal open onClose={vi.fn()} />);
+
+    await screen.findByRole("option", { name: "Harbour House" });
+    fireEvent.change(screen.getByDisplayValue("Select property"), { target: { value: "prop-1" } });
+    fireEvent.change(screen.getByLabelText("Tenant email"), { target: { value: "tenant@example.com" } });
+
+    const button = screen.getByRole("button", { name: "Send invite" });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Starting..." })).toBeDisabled();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Starting..." }));
+    expect(createScreeningOrder).toHaveBeenCalledTimes(1);
+
+    resolvePromise?.({ ok: false, errorCode: "SCREENING_CHECKOUT_ALREADY_EXISTS" });
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Send invite" })).toBeEnabled();
+    });
   });
 });

--- a/rentchain-frontend/src/components/screening/SendScreeningInviteModal.tsx
+++ b/rentchain-frontend/src/components/screening/SendScreeningInviteModal.tsx
@@ -168,6 +168,21 @@ export function SendScreeningInviteModal({
         returnTo,
       });
       if (!res.ok || !res.checkoutUrl) {
+        const normalized = String(
+          res.errorCode || res.screeningMonetizationSummary?.blockingReason || res.error || ""
+        ).toLowerCase();
+        if (normalized === "screening_checkout_already_exists") {
+          throw new Error("A screening checkout already exists for this tenant. Review the existing order before retrying.");
+        }
+        if (normalized === "screening_already_paid" || normalized === "screening_order_already_created") {
+          throw new Error("Screening is already paid or in progress for this tenant.");
+        }
+        if (normalized === "screening_provider_unavailable") {
+          throw new Error("Screening is temporarily unavailable. Please try again shortly.");
+        }
+        if (normalized === "screening_quote_expired") {
+          throw new Error("The screening quote expired. Re-open the flow and try again.");
+        }
         throw new Error(res.detail || res.error || "Unable to start checkout");
       }
       if (res.tenantInviteUrl) {

--- a/rentchain-frontend/src/pages/MaintenanceRequestsPage.test.tsx
+++ b/rentchain-frontend/src/pages/MaintenanceRequestsPage.test.tsx
@@ -216,11 +216,7 @@ describe("landlord maintenance workspace", () => {
 
     expect((await screen.findAllByText(/Reopen \/ escalation/i)).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Escalated/i).length).toBeGreaterThan(0);
-    expect(
-      screen.getAllByText((_, element) =>
-        Boolean(element?.textContent?.match(/The bedroom is cold again after the return visit/i))
-      ).length
-    ).toBeGreaterThan(0);
+    expect((await screen.findAllByText(/The bedroom is cold again after the return visit/i)).length).toBeGreaterThan(0);
   });
 
   it("records a landlord start-of-service update from the execution workspace", async () => {

--- a/rentchain-frontend/src/pages/screening/ScreeningStartPage.test.tsx
+++ b/rentchain-frontend/src/pages/screening/ScreeningStartPage.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../api/apiFetch", () => ({
   apiFetch: vi.fn(async () => ({
@@ -37,6 +37,10 @@ vi.mock("../../billing/openUpgradeFlow", () => ({
 
 import ScreeningStartPage from "./ScreeningStartPage";
 
+afterEach(() => {
+  cleanup();
+});
+
 describe("ScreeningStartPage", () => {
   it("shows the TransUnion interstitial when TransUnion is not connected", async () => {
     render(
@@ -53,5 +57,51 @@ describe("ScreeningStartPage", () => {
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Connect TransUnion" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Get Access" })).toBeInTheDocument();
+  });
+});
+
+describe("ScreeningStartPage edge guidance", () => {
+  it("shows deterministic guidance when a checkout already exists", async () => {
+    const { apiFetch } = await import("../../api/apiFetch");
+    vi.mocked(apiFetch).mockResolvedValueOnce({
+      ok: false,
+      errorCode: "SCREENING_CHECKOUT_ALREADY_EXISTS",
+      screeningMonetizationSummary: {
+        blockingReason: "SCREENING_CHECKOUT_ALREADY_EXISTS",
+      },
+    } as any);
+
+    render(
+      <MemoryRouter initialEntries={["/screening/start?applicationId=app-1"]}>
+        <ScreeningStartPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Checkout already created")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "A screening checkout already exists for this application. Return to the application to review the current payment state."
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("shows already-paid status instead of a retry message", async () => {
+    const { apiFetch } = await import("../../api/apiFetch");
+    vi.mocked(apiFetch).mockResolvedValueOnce({
+      ok: false,
+      errorCode: "SCREENING_ALREADY_PAID",
+      screeningMonetizationSummary: {
+        blockingReason: "SCREENING_ALREADY_PAID",
+      },
+    } as any);
+
+    render(
+      <MemoryRouter initialEntries={["/screening/start?applicationId=app-1"]}>
+        <ScreeningStartPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Screening already paid")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Back to application" }).length).toBeGreaterThan(0);
   });
 });

--- a/rentchain-frontend/src/pages/screening/ScreeningStartPage.tsx
+++ b/rentchain-frontend/src/pages/screening/ScreeningStartPage.tsx
@@ -20,8 +20,12 @@ type CheckoutResponse = {
   ok: boolean;
   checkoutUrl?: string;
   error?: string;
+  errorCode?: string;
   detail?: string;
   reasonCode?: string;
+  screeningMonetizationSummary?: {
+    blockingReason?: string | null;
+  };
 };
 
 const reasonCopy: Record<string, string> = {
@@ -54,6 +58,18 @@ const mapErrorMessage = (code?: string | null) => {
   if (normalized === "screening_already_paid") {
     return "This application’s screening has already been paid. You can view the status in the application.";
   }
+  if (normalized === "screening_checkout_already_exists") {
+    return "A screening checkout already exists for this application. Return to the application to review the current payment state.";
+  }
+  if (normalized === "screening_order_already_created") {
+    return "A screening order already exists for this application. Return to the application to review its status.";
+  }
+  if (normalized === "screening_quote_expired") {
+    return "This screening quote expired. Return to the application to refresh pricing and start checkout again.";
+  }
+  if (normalized === "screening_provider_unavailable") {
+    return "Screening is temporarily unavailable. Please try again shortly.";
+  }
   if (normalized === "forbidden") {
     return "You don’t have access to start screening for this application.";
   }
@@ -73,6 +89,18 @@ const mapErrorTitle = (code?: string | null) => {
   const normalized = String(code || "").toLowerCase();
   if (normalized === "screening_already_paid") {
     return "Screening already paid";
+  }
+  if (normalized === "screening_checkout_already_exists") {
+    return "Checkout already created";
+  }
+  if (normalized === "screening_order_already_created") {
+    return "Screening already in progress";
+  }
+  if (normalized === "screening_quote_expired") {
+    return "Quote expired";
+  }
+  if (normalized === "screening_provider_unavailable") {
+    return "Screening unavailable";
   }
   if (normalized === "transunion_not_connected") {
     return "Connect TransUnion to start screening";
@@ -131,9 +159,11 @@ const ScreeningStartPage: React.FC = () => {
           return;
         }
 
-        const normalizedError = String(res?.error || "").toLowerCase();
+        const normalizedError = String(
+          res?.errorCode || res?.screeningMonetizationSummary?.blockingReason || res?.error || ""
+        ).toLowerCase();
         setErrorCode(normalizedError);
-        setError(mapErrorMessage(res?.error));
+        setError(mapErrorMessage(res?.errorCode || res?.error || res?.screeningMonetizationSummary?.blockingReason));
         if (normalizedError === "not_eligible") {
           setReason(mapReasonCopy(res?.reasonCode) || "Eligibility requirements aren't complete yet.");
         }


### PR DESCRIPTION
## Summary
Adds a deterministic v1 autopilot policy framework and wires it into core workflow decisions.

This introduces a reusable backend policy layer with static rules, adapters, and a normalized evaluator, then integrates it into screening, maintenance, and lease notice flows while emitting canonical `policy.evaluated` events.

## Scope
- Adds `policyTypes`, `policyRules`, `policyEvaluator`, and workflow adapters under `src/lib/policy`
- Integrates policy evaluation into:
  - screening quote / checkout eligibility
  - landlord maintenance cost review / approval
  - lease notice preview / send
- Emits canonical `policy.evaluated` events through the normalized event model
- Adds additive `autopilotPolicy` summaries to affected responses
- Adds targeted unit and route tests for rule ordering, workflow decisions, and event emission

## Notes
This is intentionally additive and code-defined. No rule-builder UI, no AI/ML rules, and no broad business-logic refactor were introduced.

## Validation
- Passed targeted backend tests for the policy evaluator and integrated screening, maintenance, and lease-notice flows
- Passed backend build
- Full local backend suite still has unrelated existing route-test harness/socket failures in this sandbox, so GitHub CI is the better full-suite signal