### PR TITLE
feat: add automation timeline v1 using canonical event model

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -97,6 +97,7 @@ import statusRoutes from "./routes/statusRoutes";
 import expensesRoutes from "./routes/expensesRoutes";
 import financialTransactionsRoutes from "./routes/financialTransactionsRoutes";
 import workOrdersRoutes from "./routes/workOrdersRoutes";
+import timelineRoutes from "./routes/timelineRoutes";
 import transunionRoutes from "./services/integrations/transunion/transunionRoutes";
 import viewingRoutes from "./routes/viewingRoutes";
 import screeningOpsRoutes from "./routes/screeningOpsRoutes";
@@ -210,6 +211,8 @@ app.use("/api", routeSource("financialTransactionsRoutes.ts"), financialTransact
 console.log("[route-mount] financialTransactionsRoutes mounted at /api");
 app.use("/api", routeSource("workOrdersRoutes.ts"), workOrdersRoutes);
 console.log("[route-mount] workOrdersRoutes mounted at /api");
+app.use("/api", routeSource("timelineRoutes.ts"), timelineRoutes);
+console.log("[route-mount] timelineRoutes mounted at /api");
 
 // Current user info
 app.get("/api/me", async (req: any, res: any, next: any) => {

--- a/rentchain-api/src/lib/timeline/timelineAdapter.ts
+++ b/rentchain-api/src/lib/timeline/timelineAdapter.ts
@@ -1,0 +1,65 @@
+import type { CanonicalEventDomain, CanonicalEventV1 } from "../events/eventTypes";
+
+export type TimelineItem = {
+  id: string;
+  title: string;
+  description: string;
+  timestamp: string;
+  domain: string;
+  status?: string;
+  actor?: string;
+};
+
+const TITLE_BY_TYPE: Record<string, string> = {
+  "application.created": "Application created",
+  "application.submitted": "Application submitted",
+  "screening.quote_generated": "Screening quote generated",
+  "screening.checkout_created": "Screening checkout started",
+  "screening.paid": "Screening payment completed",
+  "screening.completed": "Screening completed",
+  "screening.blocked": "Screening blocked",
+  "maintenance.request_created": "Maintenance request submitted",
+  "maintenance.assigned": "Maintenance assigned",
+  "maintenance.completed": "Maintenance completed",
+  "maintenance.approval_requested": "Maintenance approval requested",
+  "expense.created": "Expense created",
+  "expense.linked": "Expense linked",
+  "expense.approved": "Expense approved",
+  "lease.created": "Lease created",
+  "lease.activated": "Lease activated",
+  "policy.evaluated": "Policy evaluated",
+};
+
+function startCase(value: string) {
+  return value
+    .split(/[_\s.]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function fallbackTitle(domain: CanonicalEventDomain, action: string) {
+  return `${startCase(domain)} ${startCase(action)}`;
+}
+
+function actorLabel(event: CanonicalEventV1) {
+  const displayName = String(event.actor?.displayName || "").trim();
+  if (displayName) return displayName;
+  const role = String(event.actor?.role || "").trim();
+  if (role) return startCase(role);
+  const type = String(event.actor?.type || "").trim();
+  return type ? startCase(type) : undefined;
+}
+
+export function canonicalEventToTimelineItem(event: CanonicalEventV1): TimelineItem {
+  const type = String(event.type || "").trim();
+  return {
+    id: event.id,
+    title: TITLE_BY_TYPE[type] || fallbackTitle(event.domain, event.action),
+    description: String(event.summary || "").trim(),
+    timestamp: event.occurredAt || event.recordedAt,
+    domain: event.domain,
+    status: event.status || undefined,
+    actor: actorLabel(event),
+  };
+}

--- a/rentchain-api/src/routes/__tests__/timelineRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/timelineRoutes.test.ts
@@ -1,0 +1,245 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { collections, dbMock } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, any>>();
+
+  function ensureCollection(name: string) {
+    if (!collections.has(name)) {
+      collections.set(name, new Map<string, any>());
+    }
+    return collections.get(name)!;
+  }
+
+  return {
+    collections,
+    dbMock: {
+      collection: (name: string) => ({
+        async get() {
+          const docs = Array.from(ensureCollection(name).entries()).map(([id, data]) => ({
+            id,
+            data: () => data,
+          }));
+          return { docs, empty: docs.length === 0, size: docs.length };
+        },
+      }),
+    },
+  };
+});
+
+vi.mock("../../config/firebase", () => ({
+  db: dbMock,
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!req.user) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    return next();
+  },
+}));
+
+async function invokeRouter(
+  router: any,
+  options: { method: string; url: string; user?: Record<string, unknown> | null }
+) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    const query = new URLSearchParams(queryString || "");
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: options.user ?? null,
+      query: Object.fromEntries(query.entries()),
+      params: {},
+      headers: {},
+      get(name: string) {
+        return this.headers[String(name).toLowerCase()];
+      },
+      header(name: string) {
+        return this.get(name);
+      },
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, string>,
+      setHeader(name: string, value: string) {
+        this.headers[name.toLowerCase()] = value;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+function seedCanonicalEvent(id: string, data: any) {
+  if (!collections.has("canonicalEvents")) {
+    collections.set("canonicalEvents", new Map<string, any>());
+  }
+  collections.get("canonicalEvents")!.set(id, { id, ...data });
+}
+
+describe("timelineRoutes", () => {
+  beforeEach(() => {
+    collections.clear();
+  });
+
+  it("returns timeline events in reverse chronological order", async () => {
+    seedCanonicalEvent("event-1", {
+      id: "event-1",
+      version: "v1",
+      type: "application.created",
+      domain: "application",
+      action: "created",
+      actor: { type: "landlord", role: "landlord", id: "landlord-1" },
+      resource: { type: "rental_application", id: "app-1" },
+      occurredAt: "2026-04-01T09:00:00.000Z",
+      recordedAt: "2026-04-01T09:00:00.000Z",
+      visibility: "internal",
+      summary: "Application created",
+    });
+    seedCanonicalEvent("event-2", {
+      id: "event-2",
+      version: "v1",
+      type: "lease.activated",
+      domain: "lease",
+      action: "activated",
+      status: "active",
+      actor: { type: "landlord", role: "landlord", id: "landlord-1" },
+      resource: { type: "lease", id: "lease-1" },
+      occurredAt: "2026-04-02T09:00:00.000Z",
+      recordedAt: "2026-04-02T09:00:00.000Z",
+      visibility: "landlord",
+      summary: "Lease activated",
+    });
+
+    const router = (await import("../timelineRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/timeline",
+      user: { id: "admin-1", role: "admin" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body?.events).toEqual([
+      expect.objectContaining({
+        id: "event-2",
+        title: "Lease activated",
+        domain: "lease",
+      }),
+      expect.objectContaining({
+        id: "event-1",
+        title: "Application created",
+        domain: "application",
+      }),
+    ]);
+  });
+
+  it("filters by domain and resource id", async () => {
+    seedCanonicalEvent("event-1", {
+      id: "event-1",
+      version: "v1",
+      type: "screening.paid",
+      domain: "screening",
+      action: "paid",
+      actor: { type: "system", role: "system", id: "system" },
+      resource: { type: "screening_order", id: "order-1", parentType: "rental_application", parentId: "app-1" },
+      occurredAt: "2026-04-03T10:00:00.000Z",
+      recordedAt: "2026-04-03T10:00:00.000Z",
+      visibility: "landlord",
+      summary: "Screening payment completed",
+    });
+    seedCanonicalEvent("event-2", {
+      id: "event-2",
+      version: "v1",
+      type: "maintenance.completed",
+      domain: "maintenance",
+      action: "completed",
+      actor: { type: "landlord", role: "landlord", id: "landlord-1" },
+      resource: { type: "maintenance_request", id: "maint-1" },
+      occurredAt: "2026-04-03T11:00:00.000Z",
+      recordedAt: "2026-04-03T11:00:00.000Z",
+      visibility: "landlord",
+      summary: "Maintenance request marked completed",
+    });
+
+    const router = (await import("../timelineRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/timeline?domain=screening&resourceId=app-1",
+      user: { id: "admin-1", role: "admin" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body?.events).toHaveLength(1);
+    expect(response.body?.events[0]).toEqual(
+      expect.objectContaining({
+        id: "event-1",
+        domain: "screening",
+      })
+    );
+  });
+
+  it("returns a next cursor when another page exists", async () => {
+    seedCanonicalEvent("event-1", {
+      id: "event-1",
+      version: "v1",
+      type: "application.created",
+      domain: "application",
+      action: "created",
+      actor: { type: "landlord", role: "landlord", id: "landlord-1" },
+      resource: { type: "rental_application", id: "app-1" },
+      occurredAt: "2026-04-01T09:00:00.000Z",
+      recordedAt: "2026-04-01T09:00:00.000Z",
+      visibility: "internal",
+      summary: "Application created",
+    });
+    seedCanonicalEvent("event-2", {
+      id: "event-2",
+      version: "v1",
+      type: "application.submitted",
+      domain: "application",
+      action: "submitted",
+      actor: { type: "tenant", role: "tenant", id: "tenant-1" },
+      resource: { type: "rental_application", id: "app-1" },
+      occurredAt: "2026-04-02T09:00:00.000Z",
+      recordedAt: "2026-04-02T09:00:00.000Z",
+      visibility: "internal",
+      summary: "Application submitted",
+    });
+
+    const router = (await import("../timelineRoutes")).default;
+    const firstPage = await invokeRouter(router, {
+      method: "GET",
+      url: "/timeline?limit=1",
+      user: { id: "admin-1", role: "admin" },
+    });
+
+    expect(firstPage.status).toBe(200);
+    expect(firstPage.body?.events).toHaveLength(1);
+    expect(firstPage.body?.nextCursor).toBeTruthy();
+
+    const secondPage = await invokeRouter(router, {
+      method: "GET",
+      url: `/timeline?limit=1&cursor=${encodeURIComponent(String(firstPage.body?.nextCursor))}`,
+      user: { id: "admin-1", role: "admin" },
+    });
+
+    expect(secondPage.status).toBe(200);
+    expect(secondPage.body?.events).toHaveLength(1);
+    expect(secondPage.body?.events[0]?.id).toBe("event-1");
+  });
+});

--- a/rentchain-api/src/routes/timelineRoutes.ts
+++ b/rentchain-api/src/routes/timelineRoutes.ts
@@ -1,0 +1,120 @@
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { requireAuth } from "../middleware/requireAuth";
+import type { CanonicalEventDomain, CanonicalEventV1 } from "../lib/events/eventTypes";
+import { CANONICAL_EVENTS_COLLECTION } from "../lib/events/buildEvent";
+import { canonicalEventToTimelineItem } from "../lib/timeline/timelineAdapter";
+
+const router = Router();
+
+const ALLOWED_DOMAINS = new Set<CanonicalEventDomain>([
+  "application",
+  "screening",
+  "lease",
+  "maintenance",
+  "expense",
+  "tenant",
+  "billing",
+  "policy",
+  "system",
+]);
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function normalizeRole(req: any): "admin" | "landlord" | "other" {
+  const role = asString(req.user?.actorRole || req.user?.role, 40).toLowerCase();
+  if (role === "admin") return "admin";
+  if (role === "landlord") return "landlord";
+  return "other";
+}
+
+function parseLimit(value: unknown) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return 25;
+  return Math.max(1, Math.min(100, Math.floor(parsed)));
+}
+
+function parseCursor(value: unknown): { timestamp: string; id: string } | null {
+  const raw = asString(value, 4000);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(Buffer.from(raw, "base64url").toString("utf8"));
+    const timestamp = asString(parsed?.timestamp);
+    const id = asString(parsed?.id);
+    if (!timestamp || !id) return null;
+    return { timestamp, id };
+  } catch {
+    return null;
+  }
+}
+
+function encodeCursor(event: CanonicalEventV1) {
+  return Buffer.from(JSON.stringify({ timestamp: event.occurredAt || event.recordedAt, id: event.id }), "utf8").toString(
+    "base64url"
+  );
+}
+
+function compareEventsDescending(a: CanonicalEventV1, b: CanonicalEventV1) {
+  const aTs = Date.parse(a.occurredAt || a.recordedAt || "");
+  const bTs = Date.parse(b.occurredAt || b.recordedAt || "");
+  if (bTs !== aTs) return bTs - aTs;
+  return String(b.id || "").localeCompare(String(a.id || ""));
+}
+
+function matchesResource(event: CanonicalEventV1, resourceId: string) {
+  if (!resourceId) return true;
+  return event.resource?.id === resourceId || event.resource?.parentId === resourceId;
+}
+
+function isVisibleToAdmin(event: CanonicalEventV1) {
+  return event.visibility !== "tenant";
+}
+
+router.get("/timeline", requireAuth, async (req: any, res) => {
+  try {
+    const role = normalizeRole(req);
+    if (role !== "admin") {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+
+    const domain = asString(req.query?.domain, 40).toLowerCase();
+    if (domain && !ALLOWED_DOMAINS.has(domain as CanonicalEventDomain)) {
+      return res.status(400).json({ ok: false, error: "DOMAIN_INVALID" });
+    }
+
+    const resourceId = asString(req.query?.resourceId, 240);
+    const cursor = parseCursor(req.query?.cursor);
+    const limit = parseLimit(req.query?.limit);
+
+    const snap = await db.collection(CANONICAL_EVENTS_COLLECTION).get();
+    const events = (snap.docs || [])
+      .map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }) as CanonicalEventV1)
+      .filter((event) => isVisibleToAdmin(event))
+      .filter((event) => (!domain ? true : event.domain === domain))
+      .filter((event) => matchesResource(event, resourceId))
+      .sort(compareEventsDescending);
+
+    const cursorFiltered = cursor
+      ? events.filter((event) => {
+          const eventKey = `${event.occurredAt || event.recordedAt}::${event.id}`;
+          const cursorKey = `${cursor.timestamp}::${cursor.id}`;
+          return eventKey < cursorKey;
+        })
+      : events;
+
+    const page = cursorFiltered.slice(0, limit);
+    const hasMore = cursorFiltered.length > limit;
+
+    return res.json({
+      events: page.map(canonicalEventToTimelineItem),
+      nextCursor: hasMore && page.length ? encodeCursor(page[page.length - 1]) : undefined,
+    });
+  } catch (err: any) {
+    console.error("[timeline] list failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "TIMELINE_LIST_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -50,6 +50,10 @@ vi.mock("./features/automation/timeline/AutomationTimelinePage", () => ({
   default: () => <h1>Automation Timeline</h1>,
 }));
 
+vi.mock("./pages/admin/AutomationTimelineV1Page", () => ({
+  default: () => <h1>Automation Timeline v1</h1>,
+}));
+
 vi.mock("./pages/tenant/TenantWorkspacePage", () => ({
   default: () => <h1>Tenant Dashboard</h1>,
 }));
@@ -127,6 +131,20 @@ describe("Routes: /automation/timeline", () => {
     );
 
     expect(await screen.findByText(/Automation Timeline/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Routes: /timeline", () => {
+  it("renders the canonical automation timeline admin view", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/timeline"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Automation Timeline v1/i)).toBeInTheDocument();
     expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -150,6 +150,7 @@ const AdminAuditPage = lazy(() => import("./pages/admin/AdminAuditPage"));
 const AutomationTimelinePage = lazy(
   () => import("./features/automation/timeline/AutomationTimelinePage")
 );
+const AutomationTimelineV1Page = lazy(() => import("./pages/admin/AutomationTimelineV1Page"));
 
 const AuthLoadingScreen = () => (
   <div
@@ -857,6 +858,16 @@ function App() {
                 <MaintenanceRequestsPage />
               </LandlordNav>
             </RequireAuth>
+          }
+        />
+        <Route
+          path="/timeline"
+          element={
+            <RequireAdmin>
+              <Suspense fallback={null}>
+                <AutomationTimelineV1Page />
+              </Suspense>
+            </RequireAdmin>
           }
         />
         <Route

--- a/rentchain-frontend/src/api/timelineApi.ts
+++ b/rentchain-frontend/src/api/timelineApi.ts
@@ -1,0 +1,31 @@
+import { apiFetch } from "./apiFetch";
+
+export type TimelineItem = {
+  id: string;
+  title: string;
+  description: string;
+  timestamp: string;
+  domain: string;
+  status?: string;
+  actor?: string;
+};
+
+export type TimelineResponse = {
+  events: TimelineItem[];
+  nextCursor?: string;
+};
+
+export async function fetchTimeline(params?: {
+  resourceId?: string | null;
+  domain?: string | null;
+  limit?: number | null;
+  cursor?: string | null;
+}): Promise<TimelineResponse> {
+  const search = new URLSearchParams();
+  if (params?.resourceId) search.set("resourceId", params.resourceId);
+  if (params?.domain) search.set("domain", params.domain);
+  if (typeof params?.limit === "number") search.set("limit", String(params.limit));
+  if (params?.cursor) search.set("cursor", params.cursor);
+  const query = search.toString();
+  return await apiFetch<TimelineResponse>(`/timeline${query ? `?${query}` : ""}`);
+}

--- a/rentchain-frontend/src/components/timeline/Timeline.test.tsx
+++ b/rentchain-frontend/src/components/timeline/Timeline.test.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Timeline } from "./Timeline";
+
+describe("Timeline", () => {
+  it("renders grouped timeline items", () => {
+    render(
+      <Timeline
+        items={[
+          {
+            id: "event-1",
+            title: "Lease activated",
+            description: "Lease activated for unit 4.",
+            timestamp: "2026-04-03T10:15:00.000Z",
+            domain: "lease",
+            status: "active",
+            actor: "Landlord",
+          },
+          {
+            id: "event-2",
+            title: "Screening payment completed",
+            description: "Screening payment completed for the application.",
+            timestamp: "2026-04-03T09:30:00.000Z",
+            domain: "screening",
+            actor: "System",
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getAllByText(/Lease activated/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Screening payment completed/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/2026/)).toBeInTheDocument();
+  });
+
+  it("shows an empty state when there are no items", () => {
+    render(<Timeline items={[]} emptyMessage="Nothing to show yet." />);
+    expect(screen.getByText(/Nothing to show yet/i)).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/timeline/Timeline.tsx
+++ b/rentchain-frontend/src/components/timeline/Timeline.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import type { TimelineItem } from "../../api/timelineApi";
+
+type TimelineProps = {
+  items: TimelineItem[];
+  emptyMessage?: string;
+};
+
+function formatDayHeading(value: string) {
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return "Unknown day";
+  return new Intl.DateTimeFormat(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(new Date(parsed));
+}
+
+function formatTimestamp(value: string) {
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return value || "Unknown time";
+  return new Intl.DateTimeFormat(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(parsed));
+}
+
+function groupByDay(items: TimelineItem[]) {
+  const groups = new Map<string, TimelineItem[]>();
+  for (const item of items) {
+    const parsed = Date.parse(item.timestamp);
+    const dayKey = Number.isFinite(parsed) ? new Date(parsed).toISOString().slice(0, 10) : "unknown";
+    if (!groups.has(dayKey)) groups.set(dayKey, []);
+    groups.get(dayKey)!.push(item);
+  }
+  return Array.from(groups.entries()).sort((a, b) => b[0].localeCompare(a[0]));
+}
+
+export function Timeline({ items, emptyMessage = "No timeline events yet." }: TimelineProps) {
+  if (!items.length) {
+    return <div style={{ color: "#64748b" }}>{emptyMessage}</div>;
+  }
+
+  const grouped = groupByDay(items);
+
+  return (
+    <div style={{ display: "grid", gap: 16 }}>
+      {grouped.map(([day, dayItems]) => (
+        <section key={day} style={{ display: "grid", gap: 10 }}>
+          <div style={{ fontSize: 12, fontWeight: 700, color: "#475569", letterSpacing: "0.04em", textTransform: "uppercase" }}>
+            {day === "unknown" ? "Unknown day" : formatDayHeading(day)}
+          </div>
+          <div className="timeline">
+            {dayItems.map((item) => (
+              <article key={item.id} className="timelineRow" style={{ background: "rgba(255,255,255,0.9)", borderRadius: 12, padding: 12 }}>
+                <div className="timelineDot" aria-hidden="true" />
+                <div style={{ display: "grid", gap: 6, width: "100%" }}>
+                  <div className="timelineTop">
+                    <div className="timelineTitle">{item.title}</div>
+                    <div className="timelineDate">{formatTimestamp(item.timestamp)}</div>
+                  </div>
+                  <div className="timelineDesc">{item.description}</div>
+                  <div className="timelineMeta">
+                    <span>{item.domain}</span>
+                    {item.status ? <span>• {item.status}</span> : null}
+                    {item.actor ? <span>• {item.actor}</span> : null}
+                  </div>
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+export default Timeline;

--- a/rentchain-frontend/src/pages/admin/AutomationTimelineV1Page.test.tsx
+++ b/rentchain-frontend/src/pages/admin/AutomationTimelineV1Page.test.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import AutomationTimelineV1Page from "./AutomationTimelineV1Page";
+
+const showToast = vi.fn();
+
+vi.mock("../../api/timelineApi", () => ({
+  fetchTimeline: vi.fn(),
+}));
+
+vi.mock("../../components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast }),
+}));
+
+vi.mock("../../components/layout/MacShell", () => ({
+  MacShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("../../components/ui/Ui", () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  Pill: ({ children }: any) => <span>{children}</span>,
+  Section: ({ children }: any) => <section>{children}</section>,
+}));
+
+beforeEach(() => {
+  showToast.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("AutomationTimelineV1Page", () => {
+  it("renders timeline items and filters by date client-side", async () => {
+    const { fetchTimeline } = await import("../../api/timelineApi");
+    vi.mocked(fetchTimeline).mockResolvedValue({
+      events: [
+        {
+          id: "event-1",
+          title: "Lease activated",
+          description: "Lease activated for unit 4.",
+          timestamp: "2026-04-03T10:15:00.000Z",
+          domain: "lease",
+          status: "active",
+          actor: "Landlord",
+        },
+        {
+          id: "event-2",
+          title: "Application created",
+          description: "Application created for screening.",
+          timestamp: "2026-04-01T09:00:00.000Z",
+          domain: "application",
+          actor: "Landlord",
+        },
+      ],
+    } as any);
+
+    render(<AutomationTimelineV1Page />);
+
+    expect(await screen.findByText(/Lease activated for unit 4/i)).toBeInTheDocument();
+    expect(screen.getByText(/Application created for screening/i)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/From date/i), {
+      target: { value: "2026-04-02" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Lease activated for unit 4/i)).toBeInTheDocument();
+      expect(screen.queryByText(/Application created for screening/i)).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows an empty state when no events are returned", async () => {
+    const { fetchTimeline } = await import("../../api/timelineApi");
+    vi.mocked(fetchTimeline).mockResolvedValue({ events: [] } as any);
+
+    render(<AutomationTimelineV1Page />);
+
+    expect(await screen.findByText(/No canonical timeline activity is available yet/i)).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/admin/AutomationTimelineV1Page.tsx
+++ b/rentchain-frontend/src/pages/admin/AutomationTimelineV1Page.tsx
@@ -1,0 +1,135 @@
+import React from "react";
+import { MacShell } from "../../components/layout/MacShell";
+import { Button, Card, Pill, Section } from "../../components/ui/Ui";
+import { useToast } from "../../components/ui/ToastProvider";
+import { fetchTimeline, type TimelineItem } from "../../api/timelineApi";
+import { Timeline } from "../../components/timeline/Timeline";
+
+const DOMAIN_OPTIONS = [
+  { label: "All domains", value: "" },
+  { label: "Application", value: "application" },
+  { label: "Screening", value: "screening" },
+  { label: "Lease", value: "lease" },
+  { label: "Maintenance", value: "maintenance" },
+  { label: "Expense", value: "expense" },
+  { label: "Policy", value: "policy" },
+  { label: "System", value: "system" },
+];
+
+function filterByDate(items: TimelineItem[], fromDate: string) {
+  if (!fromDate) return items;
+  const fromTs = Date.parse(`${fromDate}T00:00:00.000Z`);
+  if (!Number.isFinite(fromTs)) return items;
+  return items.filter((item) => {
+    const ts = Date.parse(item.timestamp);
+    return Number.isFinite(ts) ? ts >= fromTs : true;
+  });
+}
+
+export default function AutomationTimelineV1Page() {
+  const { showToast } = useToast();
+  const [events, setEvents] = React.useState<TimelineItem[]>([]);
+  const [loading, setLoading] = React.useState(false);
+  const [loadingMore, setLoadingMore] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [domain, setDomain] = React.useState("");
+  const [fromDate, setFromDate] = React.useState("");
+  const [nextCursor, setNextCursor] = React.useState<string | null>(null);
+
+  const load = React.useCallback(
+    async (cursor?: string | null) => {
+      const isLoadMore = Boolean(cursor);
+      try {
+        if (isLoadMore) {
+          setLoadingMore(true);
+        } else {
+          setLoading(true);
+          setError(null);
+        }
+        const response = await fetchTimeline({
+          domain: domain || null,
+          limit: 20,
+          cursor: cursor || null,
+        });
+        setEvents((current) => (isLoadMore ? [...current, ...(response.events || [])] : response.events || []));
+        setNextCursor(response.nextCursor || null);
+      } catch (err: any) {
+        const message = err?.message || "Failed to load timeline";
+        setError(message);
+        showToast({
+          message: "Failed to load timeline",
+          description: message,
+          variant: "error",
+        });
+      } finally {
+        setLoading(false);
+        setLoadingMore(false);
+      }
+    },
+    [domain, showToast]
+  );
+
+  React.useEffect(() => {
+    void load(null);
+  }, [load]);
+
+  const visibleEvents = React.useMemo(() => filterByDate(events, fromDate), [events, fromDate]);
+
+  return (
+    <MacShell title="Admin · Automation Timeline">
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 16, alignItems: "flex-start", flexWrap: "wrap" }}>
+            <div style={{ display: "grid", gap: 6 }}>
+              <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+                <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Automation Timeline</h1>
+                <Pill tone="accent">Canonical events</Pill>
+              </div>
+              <div style={{ color: "#475569", maxWidth: 760 }}>
+                Read-only chronological activity across applications, screening, maintenance, leases, expenses, and policy decisions.
+              </div>
+            </div>
+            <Button variant="secondary" onClick={() => void load(null)} disabled={loading}>
+              Refresh
+            </Button>
+          </div>
+        </Section>
+
+        <Card style={{ display: "grid", gap: 12 }}>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 12 }}>
+            <label style={{ display: "grid", gap: 4 }}>
+              <span style={{ color: "#64748b", fontSize: 12 }}>Domain</span>
+              <select value={domain} onChange={(event) => setDomain(event.target.value)}>
+                {DOMAIN_OPTIONS.map((option) => (
+                  <option key={option.value || "all"} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label style={{ display: "grid", gap: 4 }}>
+              <span style={{ color: "#64748b", fontSize: 12 }}>From date</span>
+              <input type="date" value={fromDate} onChange={(event) => setFromDate(event.target.value)} />
+            </label>
+          </div>
+        </Card>
+
+        {loading ? <Card>Loading timeline…</Card> : null}
+        {!loading && error ? <Card style={{ color: "#b91c1c" }}>Failed to load timeline: {error}</Card> : null}
+        {!loading && !error ? (
+          <Card>
+            <Timeline items={visibleEvents} emptyMessage="No canonical timeline activity is available yet." />
+          </Card>
+        ) : null}
+
+        {!loading && !error && nextCursor ? (
+          <div>
+            <Button variant="secondary" onClick={() => void load(nextCursor)} disabled={loadingMore}>
+              {loadingMore ? "Loading..." : "Load more"}
+            </Button>
+          </div>
+        ) : null}
+      </div>
+    </MacShell>
+  );
+}


### PR DESCRIPTION
## Summary
Adds Automation Timeline v1 as a read-only canonical event timeline.

This introduces a new backend `GET /api/timeline` endpoint over `canonicalEvents`, a small timeline adapter that humanizes canonical events into readable activity items, and a new admin-facing `/timeline` UI with filters and pagination.

## Scope
- Adds a canonical timeline read route in `rentchain-api`
- Adds `timelineAdapter` to transform `CanonicalEventV1` into UI-friendly timeline items
- Adds a reusable frontend `Timeline` component
- Adds a new standalone admin page at `/timeline`
- Supports:
  - domain filtering
  - resource filtering
  - basic cursor pagination
  - date filtering in the UI
- Adds targeted backend and frontend tests for route behavior, ordering, rendering, grouping, and empty states

## Notes
This is intentionally read-only and additive. No event emission, policy, monetization, or workflow logic was changed.

For v1, the new timeline route/page is admin-only for safety because canonical event visibility and landlord scoping are not yet universal across all emitters.

## Validation
- Passed backend timeline route test and backend build
- Passed frontend timeline/component/route tests and frontend build