### PR TITLE
feat: add event insight layer v1 for derived workflow signals

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -98,6 +98,7 @@ import expensesRoutes from "./routes/expensesRoutes";
 import financialTransactionsRoutes from "./routes/financialTransactionsRoutes";
 import workOrdersRoutes from "./routes/workOrdersRoutes";
 import timelineRoutes from "./routes/timelineRoutes";
+import insightRoutes from "./routes/insightRoutes";
 import transunionRoutes from "./services/integrations/transunion/transunionRoutes";
 import viewingRoutes from "./routes/viewingRoutes";
 import screeningOpsRoutes from "./routes/screeningOpsRoutes";
@@ -213,6 +214,8 @@ app.use("/api", routeSource("workOrdersRoutes.ts"), workOrdersRoutes);
 console.log("[route-mount] workOrdersRoutes mounted at /api");
 app.use("/api", routeSource("timelineRoutes.ts"), timelineRoutes);
 console.log("[route-mount] timelineRoutes mounted at /api");
+app.use("/api", routeSource("insightRoutes.ts"), insightRoutes);
+console.log("[route-mount] insightRoutes mounted at /api");
 
 // Current user info
 app.get("/api/me", async (req: any, res: any, next: any) => {

--- a/rentchain-api/src/lib/insights/deriveInsights.ts
+++ b/rentchain-api/src/lib/insights/deriveInsights.ts
@@ -1,0 +1,337 @@
+import type { CanonicalEventV1 } from "../events/eventTypes";
+import type { DerivedInsightV1, InsightDomain } from "./insightTypes";
+
+const SUPPORTED_DOMAINS = new Set<InsightDomain>([
+  "screening",
+  "maintenance",
+  "lease",
+  "expense",
+  "application",
+  "system",
+]);
+
+type NormalizedCanonicalEvent = CanonicalEventV1 & {
+  __timestampIso: string;
+  __timestampMs: number;
+};
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function toTimestamp(value: unknown) {
+  const raw = asString(value, 120);
+  if (!raw) return null;
+  const parsed = Date.parse(raw);
+  if (!Number.isFinite(parsed)) return null;
+  return {
+    iso: new Date(parsed).toISOString(),
+    ms: parsed,
+  };
+}
+
+function normalizeCanonicalEvent(event: CanonicalEventV1 | null | undefined): NormalizedCanonicalEvent | null {
+  if (!event) return null;
+  const resourceType = asString(event.resource?.type, 120);
+  const resourceId = asString(event.resource?.id, 240);
+  if (!resourceType || !resourceId) return null;
+  const timestamp = toTimestamp(event.occurredAt) || toTimestamp(event.recordedAt);
+  if (!timestamp) return null;
+  return {
+    ...event,
+    __timestampIso: timestamp.iso,
+    __timestampMs: timestamp.ms,
+  };
+}
+
+function sortChronologically(events: NormalizedCanonicalEvent[]) {
+  return [...events].sort((a, b) => {
+    if (a.__timestampMs !== b.__timestampMs) return a.__timestampMs - b.__timestampMs;
+    return String(a.id || "").localeCompare(String(b.id || ""));
+  });
+}
+
+function isSupportedInsightDomain(value: unknown): value is InsightDomain {
+  return typeof value === "string" && SUPPORTED_DOMAINS.has(value as InsightDomain);
+}
+
+function pickInsightDomain(events: NormalizedCanonicalEvent[]): InsightDomain | null {
+  const latestSupported = [...events]
+    .reverse()
+    .find((event) => isSupportedInsightDomain(event.domain));
+  return latestSupported && isSupportedInsightDomain(latestSupported.domain) ? latestSupported.domain : null;
+}
+
+function firstEventAt(events: NormalizedCanonicalEvent[]) {
+  return events[0]?.__timestampIso || null;
+}
+
+function lastEventAt(events: NormalizedCanonicalEvent[]) {
+  return events[events.length - 1]?.__timestampIso || null;
+}
+
+function firstTimestampForAction(events: NormalizedCanonicalEvent[], action: string) {
+  return events.find((event) => event.action === action)?.__timestampMs ?? null;
+}
+
+function durationBetween(start: number | null, end: number | null) {
+  if (start == null || end == null || end < start) return null;
+  return end - start;
+}
+
+function countByAction(events: NormalizedCanonicalEvent[]) {
+  return events.reduce<Record<string, number>>((acc, event) => {
+    const action = asString(event.action, 80).toLowerCase();
+    if (!action) return acc;
+    acc[action] = (acc[action] || 0) + 1;
+    return acc;
+  }, {});
+}
+
+function hasBlockedMarker(event: NormalizedCanonicalEvent) {
+  if (event.action === "blocked") return true;
+  if (asString(event.status, 80).toLowerCase() === "blocked") return true;
+  if (asString((event.metadata || {})["status"], 80).toLowerCase() === "blocked") return true;
+  if (Array.isArray(event.tags) && event.tags.some((tag) => asString(tag, 80).toLowerCase() === "blocked")) return true;
+  return false;
+}
+
+function baseInsight(events: NormalizedCanonicalEvent[], domain: InsightDomain): DerivedInsightV1 {
+  const firstAt = firstEventAt(events);
+  const lastAt = lastEventAt(events);
+  return {
+    version: "v1",
+    resourceType: events[0]?.resource?.type || "unknown",
+    resourceId: events[0]?.resource?.id || "unknown",
+    domain,
+    generatedAt: new Date().toISOString(),
+    summary: {
+      lifecycleState: null,
+      blockedCount: events.filter(hasBlockedMarker).length,
+      reopenCount: 0,
+      eventCount: events.length,
+      firstEventAt: firstAt,
+      lastEventAt: lastAt,
+      durationMs:
+        firstAt && lastAt ? Math.max(0, Date.parse(lastAt) - Date.parse(firstAt)) : null,
+    },
+    metrics: {},
+    tags: [],
+    notes: [],
+  };
+}
+
+function deriveScreeningInsight(events: NormalizedCanonicalEvent[]) {
+  const insight = baseInsight(events, "screening");
+  const counts = countByAction(events);
+  const quoteAt = firstTimestampForAction(events, "quote_generated");
+  const checkoutAt = firstTimestampForAction(events, "checkout_created");
+  const paidAt = firstTimestampForAction(events, "paid");
+  const completedAt = firstTimestampForAction(events, "completed");
+  const latestAction = events[events.length - 1]?.action || "";
+
+  insight.summary.lifecycleState =
+    latestAction === "blocked"
+      ? "blocked"
+      : latestAction === "completed"
+      ? "completed"
+      : latestAction === "paid"
+      ? "paid"
+      : latestAction === "checkout_created"
+      ? "checkout_started"
+      : latestAction === "quote_generated"
+      ? "quoted"
+      : "not_started";
+
+  insight.summary.blockedCount = counts.blocked || 0;
+  insight.metrics = {
+    quoteGeneratedCount: counts.quote_generated || 0,
+    checkoutStartedCount: counts.checkout_created || 0,
+    paidCount: counts.paid || 0,
+    completedCount: counts.completed || 0,
+    blockedCount: counts.blocked || 0,
+    timeQuoteToCheckoutMs: durationBetween(quoteAt, checkoutAt),
+    timeCheckoutToPaidMs: durationBetween(checkoutAt, paidAt),
+    timePaidToCompletedMs: durationBetween(paidAt, completedAt),
+  };
+
+  if ((counts.blocked || 0) > 0) insight.tags?.push("blocked");
+  if ((counts.completed || 0) > 0) insight.tags?.push("completed");
+  return insight;
+}
+
+function deriveMaintenanceInsight(events: NormalizedCanonicalEvent[]) {
+  const insight = baseInsight(events, "maintenance");
+  const counts = countByAction(events);
+  const requestAt = firstTimestampForAction(events, "request_created");
+  const assignedAt = firstTimestampForAction(events, "assigned");
+  const completedAt = firstTimestampForAction(events, "completed");
+  const blockedCount = events.filter(hasBlockedMarker).length;
+  const latest = events[events.length - 1];
+  let completedSeen = false;
+  let reopenSequenceActive = false;
+  let reopenCount = 0;
+
+  for (const event of events) {
+    if (event.action === "completed") {
+      completedSeen = true;
+      reopenSequenceActive = false;
+      continue;
+    }
+    if (!completedSeen || reopenSequenceActive) continue;
+    if (event.action === "request_created" || event.action === "assigned" || event.action === "approval_requested" || hasBlockedMarker(event)) {
+      reopenCount += 1;
+      reopenSequenceActive = true;
+    }
+  }
+
+  insight.summary.reopenCount = reopenCount;
+  insight.summary.blockedCount = blockedCount;
+  insight.summary.lifecycleState = hasBlockedMarker(latest)
+    ? "escalated"
+    : latest?.action === "completed"
+    ? "completed"
+    : reopenCount > 0 && completedSeen
+    ? "reopened"
+    : asString(latest?.status, 80).toLowerCase() === "in_progress"
+    ? "in_progress"
+    : latest?.action === "approval_requested"
+    ? "in_progress"
+    : latest?.action === "assigned"
+    ? "assigned"
+    : "requested";
+
+  insight.metrics = {
+    requestCreatedCount: counts.request_created || 0,
+    assignedCount: counts.assigned || 0,
+    completedCount: counts.completed || 0,
+    approvalRequestedCount: counts.approval_requested || 0,
+    reopenCount,
+    blockedCount,
+    timeRequestToAssignedMs: durationBetween(requestAt, assignedAt),
+    timeRequestToCompletedMs: durationBetween(requestAt, completedAt),
+  };
+
+  if (reopenCount > 0) insight.tags?.push("reopened");
+  if (blockedCount > 0) insight.tags?.push("blocked");
+  if ((counts.completed || 0) > 0) insight.tags?.push("completed");
+  return insight;
+}
+
+function deriveLeaseInsight(events: NormalizedCanonicalEvent[]) {
+  const insight = baseInsight(events, "lease");
+  const counts = countByAction(events);
+  const createdAt = firstTimestampForAction(events, "created");
+  const activatedAt = firstTimestampForAction(events, "activated");
+  const latestAction = events[events.length - 1]?.action || "";
+
+  insight.summary.lifecycleState =
+    latestAction === "notice_generated"
+      ? "notice_generated"
+      : latestAction === "activated"
+      ? "activated"
+      : "created";
+
+  insight.metrics = {
+    createdCount: counts.created || 0,
+    activatedCount: counts.activated || 0,
+    noticeGeneratedCount: counts.notice_generated || 0,
+    timeCreatedToActivatedMs: durationBetween(createdAt, activatedAt),
+  };
+
+  if ((counts.activated || 0) > 0) insight.tags?.push("activated");
+  return insight;
+}
+
+function deriveApplicationInsight(events: NormalizedCanonicalEvent[]) {
+  const insight = baseInsight(events, "application");
+  const counts = countByAction(events);
+  const createdAt = firstTimestampForAction(events, "created");
+  const submittedAt = firstTimestampForAction(events, "submitted");
+
+  insight.summary.lifecycleState = (counts.submitted || 0) > 0 ? "submitted" : "created";
+  insight.metrics = {
+    createdCount: counts.created || 0,
+    submittedCount: counts.submitted || 0,
+    timeCreatedToSubmittedMs: durationBetween(createdAt, submittedAt),
+  };
+
+  if ((counts.submitted || 0) > 0) insight.tags?.push("submitted");
+  return insight;
+}
+
+function deriveExpenseInsight(events: NormalizedCanonicalEvent[]) {
+  const insight = baseInsight(events, "expense");
+  const counts = countByAction(events);
+  const latestAction = events[events.length - 1]?.action || "";
+
+  insight.summary.lifecycleState =
+    latestAction === "approved" ? "approved" : latestAction === "linked" ? "linked" : "created";
+  insight.metrics = {
+    createdCount: counts.created || 0,
+    linkedCount: counts.linked || 0,
+    approvedCount: counts.approved || 0,
+  };
+
+  return insight;
+}
+
+function deriveSystemInsight(events: NormalizedCanonicalEvent[]) {
+  const insight = baseInsight(events, "system");
+  const counts = countByAction(events);
+  const latestAction = events[events.length - 1]?.action || "";
+  insight.summary.lifecycleState = latestAction || "observed";
+  insight.metrics = {
+    eventCount: events.length,
+    blockedCount: counts.blocked || 0,
+  };
+  return insight;
+}
+
+export function deriveInsightForResource(
+  events: CanonicalEventV1[],
+  options?: {
+    resourceType?: string | null;
+    resourceId?: string | null;
+    domain?: InsightDomain | null;
+  }
+): DerivedInsightV1 | null {
+  const normalized = sortChronologically(events.map(normalizeCanonicalEvent).filter(Boolean) as NormalizedCanonicalEvent[]);
+  if (!normalized.length) return null;
+
+  const domain = options?.domain || pickInsightDomain(normalized);
+  if (!domain) return null;
+
+  const domainEvents = normalized.filter((event) => event.domain === domain);
+  if (!domainEvents.length) return null;
+
+  const exactResourceType = asString(options?.resourceType || domainEvents[0]?.resource?.type, 120);
+  const exactResourceId = asString(options?.resourceId || domainEvents[0]?.resource?.id, 240);
+  const resourceEvents = domainEvents.filter(
+    (event) => event.resource?.type === exactResourceType && event.resource?.id === exactResourceId
+  );
+  const relevantEvents = resourceEvents.length ? resourceEvents : domainEvents;
+  if (!relevantEvents.length) return null;
+
+  if (domain === "screening") return deriveScreeningInsight(relevantEvents);
+  if (domain === "maintenance") return deriveMaintenanceInsight(relevantEvents);
+  if (domain === "lease") return deriveLeaseInsight(relevantEvents);
+  if (domain === "application") return deriveApplicationInsight(relevantEvents);
+  if (domain === "expense") return deriveExpenseInsight(relevantEvents);
+  return deriveSystemInsight(relevantEvents);
+}
+
+export function groupCanonicalEventsByResource(
+  events: CanonicalEventV1[],
+  domain: InsightDomain
+) {
+  const groups = new Map<string, CanonicalEventV1[]>();
+  for (const event of events) {
+    const normalized = normalizeCanonicalEvent(event);
+    if (!normalized || normalized.domain !== domain) continue;
+    const key = `${normalized.resource.type}::${normalized.resource.id}`;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key)!.push(event);
+  }
+  return groups;
+}

--- a/rentchain-api/src/lib/insights/insightTypes.ts
+++ b/rentchain-api/src/lib/insights/insightTypes.ts
@@ -1,0 +1,27 @@
+export type InsightDomain =
+  | "screening"
+  | "maintenance"
+  | "lease"
+  | "expense"
+  | "application"
+  | "system";
+
+export type DerivedInsightV1 = {
+  version: "v1";
+  resourceType: string;
+  resourceId: string;
+  domain: InsightDomain;
+  generatedAt: string;
+  summary: {
+    lifecycleState?: string | null;
+    blockedCount?: number;
+    reopenCount?: number;
+    eventCount?: number;
+    firstEventAt?: string | null;
+    lastEventAt?: string | null;
+    durationMs?: number | null;
+  };
+  metrics?: Record<string, number | null>;
+  tags?: string[];
+  notes?: string[];
+};

--- a/rentchain-api/src/lib/insights/tests/deriveInsights.test.ts
+++ b/rentchain-api/src/lib/insights/tests/deriveInsights.test.ts
@@ -1,0 +1,263 @@
+import { describe, expect, it } from "vitest";
+import { deriveInsightForResource } from "../deriveInsights";
+import type { CanonicalEventV1 } from "../../events/eventTypes";
+
+function canonicalEvent(overrides: Partial<CanonicalEventV1>): CanonicalEventV1 {
+  return {
+    id: overrides.id || "event-1",
+    version: "v1",
+    type: overrides.type || "application.created",
+    domain: overrides.domain || "application",
+    action: overrides.action || "created",
+    status: overrides.status ?? null,
+    actor: overrides.actor || { type: "system", role: "system", id: "system" },
+    resource: overrides.resource || { type: "rental_application", id: "app-1" },
+    occurredAt: overrides.occurredAt || "2026-04-01T10:00:00.000Z",
+    recordedAt: overrides.recordedAt || "2026-04-01T10:00:00.000Z",
+    visibility: overrides.visibility || "internal",
+    summary: overrides.summary || "Application created",
+    metadata: overrides.metadata,
+    metrics: overrides.metrics,
+    tags: overrides.tags,
+  };
+}
+
+describe("deriveInsightForResource", () => {
+  it("derives screening lifecycle correctly", () => {
+    const insight = deriveInsightForResource([
+      canonicalEvent({
+        id: "event-1",
+        type: "screening.quote_generated",
+        domain: "screening",
+        action: "quote_generated",
+        resource: { type: "screening_order", id: "order-1" },
+        occurredAt: "2026-04-01T10:00:00.000Z",
+        summary: "Screening quote generated",
+      }),
+      canonicalEvent({
+        id: "event-2",
+        type: "screening.checkout_created",
+        domain: "screening",
+        action: "checkout_created",
+        resource: { type: "screening_order", id: "order-1" },
+        occurredAt: "2026-04-01T10:05:00.000Z",
+        summary: "Screening checkout started",
+      }),
+      canonicalEvent({
+        id: "event-3",
+        type: "screening.paid",
+        domain: "screening",
+        action: "paid",
+        resource: { type: "screening_order", id: "order-1" },
+        occurredAt: "2026-04-01T10:10:00.000Z",
+        summary: "Screening payment completed",
+      }),
+      canonicalEvent({
+        id: "event-4",
+        type: "screening.completed",
+        domain: "screening",
+        action: "completed",
+        resource: { type: "screening_order", id: "order-1" },
+        occurredAt: "2026-04-01T10:20:00.000Z",
+        summary: "Screening completed",
+      }),
+    ]);
+
+    expect(insight).toEqual(
+      expect.objectContaining({
+        domain: "screening",
+        resourceType: "screening_order",
+        resourceId: "order-1",
+        summary: expect.objectContaining({
+          lifecycleState: "completed",
+          blockedCount: 0,
+          eventCount: 4,
+        }),
+        metrics: expect.objectContaining({
+          quoteGeneratedCount: 1,
+          checkoutStartedCount: 1,
+          paidCount: 1,
+          completedCount: 1,
+          timeQuoteToCheckoutMs: 5 * 60 * 1000,
+          timeCheckoutToPaidMs: 5 * 60 * 1000,
+          timePaidToCompletedMs: 10 * 60 * 1000,
+        }),
+      })
+    );
+  });
+
+  it("derives maintenance reopen count correctly", () => {
+    const insight = deriveInsightForResource([
+      canonicalEvent({
+        id: "event-1",
+        type: "maintenance.request_created",
+        domain: "maintenance",
+        action: "request_created",
+        resource: { type: "maintenance_request", id: "maint-1" },
+        occurredAt: "2026-04-01T10:00:00.000Z",
+        summary: "Maintenance request submitted",
+      }),
+      canonicalEvent({
+        id: "event-2",
+        type: "maintenance.completed",
+        domain: "maintenance",
+        action: "completed",
+        resource: { type: "maintenance_request", id: "maint-1" },
+        occurredAt: "2026-04-01T11:00:00.000Z",
+        summary: "Maintenance completed",
+      }),
+      canonicalEvent({
+        id: "event-3",
+        type: "maintenance.assigned",
+        domain: "maintenance",
+        action: "assigned",
+        resource: { type: "maintenance_request", id: "maint-1" },
+        occurredAt: "2026-04-01T12:00:00.000Z",
+        summary: "Maintenance assigned again",
+      }),
+      canonicalEvent({
+        id: "event-4",
+        type: "maintenance.completed",
+        domain: "maintenance",
+        action: "completed",
+        resource: { type: "maintenance_request", id: "maint-1" },
+        occurredAt: "2026-04-01T13:00:00.000Z",
+        summary: "Maintenance completed again",
+      }),
+    ]);
+
+    expect(insight?.summary.reopenCount).toBe(1);
+    expect(insight?.summary.lifecycleState).toBe("completed");
+    expect(insight?.metrics).toEqual(
+      expect.objectContaining({
+        requestCreatedCount: 1,
+        assignedCount: 1,
+        completedCount: 2,
+        reopenCount: 1,
+      })
+    );
+  });
+
+  it("derives durations correctly when timestamps exist even if events arrive out of order", () => {
+    const insight = deriveInsightForResource([
+      canonicalEvent({
+        id: "event-2",
+        type: "application.submitted",
+        domain: "application",
+        action: "submitted",
+        resource: { type: "rental_application", id: "app-1" },
+        occurredAt: "2026-04-02T10:00:00.000Z",
+        summary: "Application submitted",
+      }),
+      canonicalEvent({
+        id: "event-1",
+        type: "application.created",
+        domain: "application",
+        action: "created",
+        resource: { type: "rental_application", id: "app-1" },
+        occurredAt: "2026-04-01T10:00:00.000Z",
+        summary: "Application created",
+      }),
+    ]);
+
+    expect(insight?.summary.firstEventAt).toBe("2026-04-01T10:00:00.000Z");
+    expect(insight?.summary.lastEventAt).toBe("2026-04-02T10:00:00.000Z");
+    expect(insight?.metrics?.timeCreatedToSubmittedMs).toBe(24 * 60 * 60 * 1000);
+  });
+
+  it("safely handles missing or partial events", () => {
+    const insight = deriveInsightForResource([
+      canonicalEvent({
+        id: "event-1",
+        type: "application.created",
+        domain: "application",
+        action: "created",
+        resource: { type: "rental_application", id: "app-1" },
+        occurredAt: "not-a-date",
+        recordedAt: "2026-04-01T10:00:00.000Z",
+        summary: "Application created",
+      }),
+      canonicalEvent({
+        id: "event-2",
+        type: "application.submitted",
+        domain: "application",
+        action: "submitted",
+        resource: { type: "", id: "" } as any,
+        occurredAt: "2026-04-02T10:00:00.000Z",
+        summary: "Broken event",
+      }),
+    ]);
+
+    expect(insight).toEqual(
+      expect.objectContaining({
+        domain: "application",
+        summary: expect.objectContaining({
+          eventCount: 1,
+          lifecycleState: "created",
+        }),
+      })
+    );
+  });
+
+  it("increments blocked count only on explicit blocked events", () => {
+    const insight = deriveInsightForResource([
+      canonicalEvent({
+        id: "event-1",
+        type: "screening.quote_generated",
+        domain: "screening",
+        action: "quote_generated",
+        resource: { type: "screening_order", id: "order-1" },
+        occurredAt: "2026-04-01T10:00:00.000Z",
+        summary: "Screening quote generated",
+      }),
+      canonicalEvent({
+        id: "event-2",
+        type: "screening.blocked",
+        domain: "screening",
+        action: "blocked",
+        status: "blocked",
+        resource: { type: "screening_order", id: "order-1" },
+        occurredAt: "2026-04-01T10:05:00.000Z",
+        summary: "Screening blocked",
+      }),
+      canonicalEvent({
+        id: "event-3",
+        type: "screening.completed",
+        domain: "screening",
+        action: "completed",
+        resource: { type: "screening_order", id: "order-1" },
+        occurredAt: "2026-04-01T10:10:00.000Z",
+        summary: "Screening completed",
+      }),
+    ]);
+
+    expect(insight?.summary.blockedCount).toBe(1);
+    expect(insight?.metrics?.blockedCount).toBe(1);
+  });
+
+  it("normalizes chronological ordering before deriving lifecycle state", () => {
+    const insight = deriveInsightForResource([
+      canonicalEvent({
+        id: "event-2",
+        type: "lease.activated",
+        domain: "lease",
+        action: "activated",
+        resource: { type: "lease", id: "lease-1" },
+        occurredAt: "2026-04-02T10:00:00.000Z",
+        summary: "Lease activated",
+      }),
+      canonicalEvent({
+        id: "event-1",
+        type: "lease.created",
+        domain: "lease",
+        action: "created",
+        resource: { type: "lease", id: "lease-1" },
+        occurredAt: "2026-04-01T10:00:00.000Z",
+        summary: "Lease created",
+      }),
+    ]);
+
+    expect(insight?.summary.lifecycleState).toBe("activated");
+    expect(insight?.metrics?.timeCreatedToActivatedMs).toBe(24 * 60 * 60 * 1000);
+  });
+});

--- a/rentchain-api/src/routes/insightRoutes.ts
+++ b/rentchain-api/src/routes/insightRoutes.ts
@@ -1,0 +1,152 @@
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { requireAuth } from "../middleware/requireAuth";
+import { CANONICAL_EVENTS_COLLECTION } from "../lib/events/buildEvent";
+import type { CanonicalEventV1 } from "../lib/events/eventTypes";
+import { deriveInsightForResource, groupCanonicalEventsByResource } from "../lib/insights/deriveInsights";
+import type { DerivedInsightV1, InsightDomain } from "../lib/insights/insightTypes";
+
+const router = Router();
+
+const ALLOWED_DOMAINS = new Set<InsightDomain>([
+  "screening",
+  "maintenance",
+  "lease",
+  "expense",
+  "application",
+  "system",
+]);
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function normalizeRole(req: any): "admin" | "landlord" | "other" {
+  const role = asString(req.user?.actorRole || req.user?.role, 40).toLowerCase();
+  if (role === "admin") return "admin";
+  if (role === "landlord") return "landlord";
+  return "other";
+}
+
+function parseLimit(value: unknown) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return 20;
+  return Math.max(1, Math.min(100, Math.floor(parsed)));
+}
+
+function parseCursor(value: unknown): { timestamp: string; resourceKey: string } | null {
+  const raw = asString(value, 4000);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(Buffer.from(raw, "base64url").toString("utf8"));
+    const timestamp = asString(parsed?.timestamp);
+    const resourceKey = asString(parsed?.resourceKey);
+    if (!timestamp || !resourceKey) return null;
+    return { timestamp, resourceKey };
+  } catch {
+    return null;
+  }
+}
+
+function encodeCursor(insight: DerivedInsightV1) {
+  return Buffer.from(
+    JSON.stringify({
+      timestamp: insight.summary.lastEventAt || insight.generatedAt,
+      resourceKey: `${insight.resourceType}::${insight.resourceId}`,
+    }),
+    "utf8"
+  ).toString("base64url");
+}
+
+function compareInsightsDescending(a: DerivedInsightV1, b: DerivedInsightV1) {
+  const aTs = Date.parse(a.summary.lastEventAt || a.generatedAt || "");
+  const bTs = Date.parse(b.summary.lastEventAt || b.generatedAt || "");
+  if (bTs !== aTs) return bTs - aTs;
+  const aKey = `${a.resourceType}::${a.resourceId}`;
+  const bKey = `${b.resourceType}::${b.resourceId}`;
+  return bKey.localeCompare(aKey);
+}
+
+function isVisibleToAdmin(event: CanonicalEventV1) {
+  return event.visibility !== "tenant";
+}
+
+async function loadCanonicalEvents() {
+  const snap = await db.collection(CANONICAL_EVENTS_COLLECTION).get();
+  return (snap.docs || [])
+    .map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }) as CanonicalEventV1)
+    .filter(isVisibleToAdmin);
+}
+
+router.get("/insights/resource", requireAuth, async (req: any, res) => {
+  try {
+    if (normalizeRole(req) !== "admin") {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+
+    const resourceType = asString(req.query?.resourceType, 120);
+    const resourceId = asString(req.query?.resourceId, 240);
+    if (!resourceType || !resourceId) {
+      return res.status(400).json({ ok: false, error: "RESOURCE_QUERY_INVALID" });
+    }
+
+    const events = (await loadCanonicalEvents()).filter(
+      (event) => event.resource?.type === resourceType && event.resource?.id === resourceId
+    );
+    const insight = deriveInsightForResource(events, { resourceType, resourceId });
+
+    return res.json({ insight });
+  } catch (err: any) {
+    console.error("[insights] resource fetch failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "INSIGHT_RESOURCE_FETCH_FAILED" });
+  }
+});
+
+router.get("/insights/summary", requireAuth, async (req: any, res) => {
+  try {
+    if (normalizeRole(req) !== "admin") {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+
+    const domain = asString(req.query?.domain, 40).toLowerCase();
+    if (!ALLOWED_DOMAINS.has(domain as InsightDomain)) {
+      return res.status(400).json({ ok: false, error: "DOMAIN_INVALID" });
+    }
+
+    const limit = parseLimit(req.query?.limit);
+    const cursor = parseCursor(req.query?.cursor);
+    const grouped = groupCanonicalEventsByResource(await loadCanonicalEvents(), domain as InsightDomain);
+    const insights = Array.from(grouped.entries())
+      .map(([resourceKey, resourceEvents]) => {
+        const [resourceType, resourceId] = resourceKey.split("::");
+        return deriveInsightForResource(resourceEvents, {
+          domain: domain as InsightDomain,
+          resourceType,
+          resourceId,
+        });
+      })
+      .filter(Boolean) as DerivedInsightV1[];
+
+    const ordered = insights.sort(compareInsightsDescending);
+    const cursorFiltered = cursor
+      ? ordered.filter((insight) => {
+          const insightKey = `${insight.summary.lastEventAt || insight.generatedAt}::${insight.resourceType}::${insight.resourceId}`;
+          const cursorKey = `${cursor.timestamp}::${cursor.resourceKey}`;
+          return insightKey < cursorKey;
+        })
+      : ordered;
+
+    const page = cursorFiltered.slice(0, limit);
+    const hasMore = cursorFiltered.length > limit;
+
+    return res.json({
+      insights: page,
+      nextCursor: hasMore && page.length ? encodeCursor(page[page.length - 1]) : undefined,
+    });
+  } catch (err: any) {
+    console.error("[insights] summary fetch failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "INSIGHT_SUMMARY_FETCH_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-api/src/routes/tests/insightRoutes.test.ts
+++ b/rentchain-api/src/routes/tests/insightRoutes.test.ts
@@ -1,0 +1,232 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { collections, dbMock } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, any>>();
+
+  function ensureCollection(name: string) {
+    if (!collections.has(name)) {
+      collections.set(name, new Map<string, any>());
+    }
+    return collections.get(name)!;
+  }
+
+  return {
+    collections,
+    dbMock: {
+      collection: (name: string) => ({
+        async get() {
+          const docs = Array.from(ensureCollection(name).entries()).map(([id, data]) => ({
+            id,
+            data: () => data,
+          }));
+          return { docs, empty: docs.length === 0, size: docs.length };
+        },
+      }),
+    },
+  };
+});
+
+vi.mock("../../config/firebase", () => ({
+  db: dbMock,
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!req.user) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    return next();
+  },
+}));
+
+async function invokeRouter(
+  router: any,
+  options: { method: string; url: string; user?: Record<string, unknown> | null }
+) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    const query = new URLSearchParams(queryString || "");
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: options.user ?? null,
+      query: Object.fromEntries(query.entries()),
+      params: {},
+      headers: {},
+      get(name: string) {
+        return this.headers[String(name).toLowerCase()];
+      },
+      header(name: string) {
+        return this.get(name);
+      },
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, string>,
+      setHeader(name: string, value: string) {
+        this.headers[name.toLowerCase()] = value;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+function seedCanonicalEvent(id: string, data: any) {
+  if (!collections.has("canonicalEvents")) {
+    collections.set("canonicalEvents", new Map<string, any>());
+  }
+  collections.get("canonicalEvents")!.set(id, { id, ...data });
+}
+
+describe("insightRoutes", () => {
+  beforeEach(() => {
+    collections.clear();
+  });
+
+  it("lets an admin fetch a resource insight", async () => {
+    seedCanonicalEvent("event-1", {
+      version: "v1",
+      type: "application.created",
+      domain: "application",
+      action: "created",
+      actor: { type: "landlord", role: "landlord", id: "landlord-1" },
+      resource: { type: "rental_application", id: "app-1" },
+      occurredAt: "2026-04-01T09:00:00.000Z",
+      recordedAt: "2026-04-01T09:00:00.000Z",
+      visibility: "internal",
+      summary: "Application created",
+    });
+    seedCanonicalEvent("event-2", {
+      version: "v1",
+      type: "application.submitted",
+      domain: "application",
+      action: "submitted",
+      actor: { type: "tenant", role: "tenant", id: "tenant-1" },
+      resource: { type: "rental_application", id: "app-1" },
+      occurredAt: "2026-04-02T09:00:00.000Z",
+      recordedAt: "2026-04-02T09:00:00.000Z",
+      visibility: "internal",
+      summary: "Application submitted",
+    });
+
+    const router = (await import("../insightRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/insights/resource?resourceType=rental_application&resourceId=app-1",
+      user: { id: "admin-1", role: "admin" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body?.insight).toEqual(
+      expect.objectContaining({
+        domain: "application",
+        resourceType: "rental_application",
+        resourceId: "app-1",
+        summary: expect.objectContaining({
+          lifecycleState: "submitted",
+        }),
+      })
+    );
+  });
+
+  it("lets an admin fetch a summary insight list with paging", async () => {
+    seedCanonicalEvent("event-1", {
+      version: "v1",
+      type: "screening.quote_generated",
+      domain: "screening",
+      action: "quote_generated",
+      actor: { type: "system", role: "system", id: "system" },
+      resource: { type: "screening_order", id: "order-1" },
+      occurredAt: "2026-04-01T09:00:00.000Z",
+      recordedAt: "2026-04-01T09:00:00.000Z",
+      visibility: "internal",
+      summary: "Screening quote generated",
+    });
+    seedCanonicalEvent("event-2", {
+      version: "v1",
+      type: "screening.paid",
+      domain: "screening",
+      action: "paid",
+      actor: { type: "system", role: "system", id: "system" },
+      resource: { type: "screening_order", id: "order-2" },
+      occurredAt: "2026-04-02T09:00:00.000Z",
+      recordedAt: "2026-04-02T09:00:00.000Z",
+      visibility: "internal",
+      summary: "Screening paid",
+    });
+
+    const router = (await import("../insightRoutes")).default;
+    const firstPage = await invokeRouter(router, {
+      method: "GET",
+      url: "/insights/summary?domain=screening&limit=1",
+      user: { id: "admin-1", role: "admin" },
+    });
+
+    expect(firstPage.status).toBe(200);
+    expect(firstPage.body?.insights).toHaveLength(1);
+    expect(firstPage.body?.insights[0]?.resourceId).toBe("order-2");
+    expect(firstPage.body?.nextCursor).toBeTruthy();
+
+    const secondPage = await invokeRouter(router, {
+      method: "GET",
+      url: `/insights/summary?domain=screening&limit=1&cursor=${encodeURIComponent(String(firstPage.body?.nextCursor))}`,
+      user: { id: "admin-1", role: "admin" },
+    });
+
+    expect(secondPage.status).toBe(200);
+    expect(secondPage.body?.insights).toHaveLength(1);
+    expect(secondPage.body?.insights[0]?.resourceId).toBe("order-1");
+  });
+
+  it("returns a safe validation error for malformed queries", async () => {
+    const router = (await import("../insightRoutes")).default;
+    const resourceResponse = await invokeRouter(router, {
+      method: "GET",
+      url: "/insights/resource?resourceType=rental_application",
+      user: { id: "admin-1", role: "admin" },
+    });
+    expect(resourceResponse.status).toBe(400);
+    expect(resourceResponse.body?.error).toBe("RESOURCE_QUERY_INVALID");
+
+    const summaryResponse = await invokeRouter(router, {
+      method: "GET",
+      url: "/insights/summary?domain=nope",
+      user: { id: "admin-1", role: "admin" },
+    });
+    expect(summaryResponse.status).toBe(400);
+    expect(summaryResponse.body?.error).toBe("DOMAIN_INVALID");
+  });
+
+  it("returns a stable empty response shape when no events match", async () => {
+    const router = (await import("../insightRoutes")).default;
+    const resourceResponse = await invokeRouter(router, {
+      method: "GET",
+      url: "/insights/resource?resourceType=rental_application&resourceId=missing",
+      user: { id: "admin-1", role: "admin" },
+    });
+    expect(resourceResponse.status).toBe(200);
+    expect(resourceResponse.body).toEqual({ insight: null });
+
+    const summaryResponse = await invokeRouter(router, {
+      method: "GET",
+      url: "/insights/summary?domain=application&limit=10",
+      user: { id: "admin-1", role: "admin" },
+    });
+    expect(summaryResponse.status).toBe(200);
+    expect(summaryResponse.body).toEqual({ insights: [], nextCursor: undefined });
+  });
+});


### PR DESCRIPTION
## Summary
Adds Event → Insight Layer v1 as a read-only derivation layer over canonical events.

This introduces a deterministic backend insight system that converts `canonicalEvents` into reusable workflow insight summaries, plus new admin-only endpoints for exact-resource insights and shallow domain summary listings.

## Scope
- Adds `insightTypes` and `deriveInsights` under `src/lib/insights`
- Derives v1 insights for:
  - screening
  - maintenance
  - lease
  - application
  - expense
  - system
- Adds:
  - `GET /api/insights/resource?resourceType=&resourceId=`
  - `GET /api/insights/summary?domain=&limit=&cursor=`
- Computes lifecycle state, event counts, blocked counts, reopen counts, first/last event timestamps, and duration metrics where possible
- Adds targeted unit and route tests for derivation correctness, ordering normalization, validation, empty states, and admin-only access patterns

## Notes
This is intentionally read-only and additive. No canonical event emission, policy logic, monetization logic, or workflow write behavior was changed.

For v1, the insight endpoints are admin-only and exact-resource scoped for safety because cross-resource landlord scoping is not yet universal across all canonical emitters.

## Validation
- Passed targeted backend tests for insight derivation and route behavior
- Passed backend build