### PR TITLE
feat: add policy-aware automation execution layer v1

### DIFF
--- a/rentchain-api/src/lib/automation/automationActions.ts
+++ b/rentchain-api/src/lib/automation/automationActions.ts
@@ -1,0 +1,75 @@
+import type {
+  AutomationAction,
+  AutomationActionContextMap,
+} from "./automationTypes";
+
+type AutomationActionOutcome<T = unknown> = {
+  executed: boolean;
+  skipped: boolean;
+  reason?: string;
+  data?: T;
+};
+
+async function runScreeningAction<T>(
+  context: AutomationActionContextMap<T>["screening.auto_start_checkout"]
+): Promise<AutomationActionOutcome<T>> {
+  if (!context.quoteExists) {
+    return { executed: false, skipped: true, reason: "SCREENING_QUOTE_REQUIRED" };
+  }
+  if (context.alreadyPaid) {
+    return { executed: false, skipped: true, reason: "SCREENING_ALREADY_PAID" };
+  }
+  if (context.existingCheckout) {
+    return { executed: false, skipped: true, reason: "SCREENING_CHECKOUT_ALREADY_EXISTS" };
+  }
+  const data = await context.execute();
+  return { executed: true, skipped: false, data };
+}
+
+async function runMaintenanceAction<T>(
+  context: AutomationActionContextMap<T>["maintenance.auto_approve_cost"]
+): Promise<AutomationActionOutcome<T>> {
+  if (context.alreadyApproved) {
+    return { executed: false, skipped: true, reason: "MAINTENANCE_ALREADY_APPROVED" };
+  }
+  if (!context.hasSupportingEvidence) {
+    return { executed: false, skipped: true, reason: "MAINTENANCE_EVIDENCE_REQUIRED" };
+  }
+  if (typeof context.actualCostCents !== "number" || context.actualCostCents <= 0) {
+    return { executed: false, skipped: true, reason: "MAINTENANCE_COST_REQUIRED" };
+  }
+  if (context.actualCostCents > context.thresholdCents) {
+    return { executed: false, skipped: true, reason: "MAINTENANCE_COST_REVIEW_REQUIRED" };
+  }
+  const data = await context.execute();
+  return { executed: true, skipped: false, data };
+}
+
+async function runLeaseAction<T>(
+  context: AutomationActionContextMap<T>["lease.auto_send_notice"]
+): Promise<AutomationActionOutcome<T>> {
+  if (!context.noticeReady) {
+    return { executed: false, skipped: true, reason: "LEASE_NOTICE_NOT_READY" };
+  }
+  if (context.alreadySent) {
+    return { executed: false, skipped: true, reason: "LEASE_NOTICE_ALREADY_SENT" };
+  }
+  if (!context.hasRequiredLegalInputs) {
+    return { executed: false, skipped: true, reason: "LEASE_NOTICE_REQUIRED_INPUTS_MISSING" };
+  }
+  const data = await context.execute();
+  return { executed: true, skipped: false, data };
+}
+
+export async function runAutomationAction<A extends AutomationAction, T = unknown>(
+  action: A,
+  context: AutomationActionContextMap<T>[A]
+): Promise<AutomationActionOutcome<T>> {
+  if (action === "screening.auto_start_checkout") {
+    return runScreeningAction(context as AutomationActionContextMap<T>["screening.auto_start_checkout"]);
+  }
+  if (action === "maintenance.auto_approve_cost") {
+    return runMaintenanceAction(context as AutomationActionContextMap<T>["maintenance.auto_approve_cost"]);
+  }
+  return runLeaseAction(context as AutomationActionContextMap<T>["lease.auto_send_notice"]);
+}

--- a/rentchain-api/src/lib/automation/automationExecutor.ts
+++ b/rentchain-api/src/lib/automation/automationExecutor.ts
@@ -1,0 +1,127 @@
+import { writeCanonicalEvent } from "../events/buildEvent";
+import { runAutomationAction } from "./automationActions";
+import type {
+  AutomationAction,
+  AutomationActionContextMap,
+  AutomationExecutionResult,
+  AutomationExecutorInput,
+} from "./automationTypes";
+
+function policySkipReason(action: AutomationAction, policyOutcome: string, requiresManualApproval: boolean) {
+  if (policyOutcome === "block") return `${action.toUpperCase().replace(/[.]/g, "_")}_POLICY_BLOCKED`;
+  if (policyOutcome === "review" || requiresManualApproval) {
+    return `${action.toUpperCase().replace(/[.]/g, "_")}_POLICY_REVIEW_REQUIRED`;
+  }
+  if (policyOutcome !== "allow") return `${action.toUpperCase().replace(/[.]/g, "_")}_POLICY_DEFERRED`;
+  return `${action.toUpperCase().replace(/[.]/g, "_")}_POLICY_SKIPPED`;
+}
+
+async function writeAutomationEvent(input: {
+  type: "automation.executed" | "automation.skipped";
+  result: AutomationExecutionResult;
+  policyOutcome: string;
+  actor: {
+    type?: "user" | "system" | "admin" | "tenant" | "landlord" | "contractor" | "service";
+    id?: string | null;
+    role?: string | null;
+  };
+  resource: {
+    type: string;
+    id: string;
+    parentType?: string | null;
+    parentId?: string | null;
+  };
+  visibility?: "internal" | "landlord" | "tenant" | "admin" | "system";
+  metadata?: Record<string, unknown>;
+}) {
+  await writeCanonicalEvent({
+    domain: "system",
+    type: input.type,
+    action: input.type === "automation.executed" ? "executed" : "skipped",
+    status: input.result.executed ? "executed" : "skipped",
+    actor: input.actor,
+    resource: input.resource,
+    occurredAt: input.result.timestamp,
+    visibility: input.visibility || "internal",
+    summary:
+      input.type === "automation.executed"
+        ? `Automation executed for ${input.result.action}`
+        : `Automation skipped for ${input.result.action}`,
+    metadata: {
+      action: input.result.action,
+      executed: input.result.executed,
+      skipped: input.result.skipped,
+      reason: input.result.reason || null,
+      policyOutcome: input.policyOutcome,
+      ...input.metadata,
+    },
+  });
+}
+
+export async function executeAutomation<A extends AutomationAction, T = unknown>(
+  input: AutomationExecutorInput<A, T>
+): Promise<{ automationResult: AutomationExecutionResult; data?: T }> {
+  const timestamp = new Date().toISOString();
+
+  if (input.policyResult.outcome !== "allow" || input.policyResult.requiresManualApproval) {
+    const automationResult: AutomationExecutionResult = {
+      action: input.action,
+      executed: false,
+      skipped: true,
+      reason: policySkipReason(input.action, input.policyResult.outcome, input.policyResult.requiresManualApproval),
+      timestamp,
+    };
+    await writeAutomationEvent({
+      type: "automation.skipped",
+      result: automationResult,
+      policyOutcome: input.policyResult.outcome,
+      actor: input.actor,
+      resource: input.resource,
+      visibility: input.visibility,
+      metadata: input.metadata,
+    });
+    return { automationResult };
+  }
+
+  try {
+    const actionResult = await runAutomationAction(
+      input.action,
+      input.context as AutomationActionContextMap<T>[A]
+    );
+    const automationResult: AutomationExecutionResult = {
+      action: input.action,
+      executed: actionResult.executed,
+      skipped: actionResult.skipped,
+      reason: actionResult.reason,
+      timestamp,
+    };
+    await writeAutomationEvent({
+      type: actionResult.executed ? "automation.executed" : "automation.skipped",
+      result: automationResult,
+      policyOutcome: input.policyResult.outcome,
+      actor: input.actor,
+      resource: input.resource,
+      visibility: input.visibility,
+      metadata: input.metadata,
+    });
+    return { automationResult, data: actionResult.data };
+  } catch (err: any) {
+    const automationResult: AutomationExecutionResult = {
+      action: input.action,
+      executed: false,
+      skipped: true,
+      reason: String(err?.code || err?.message || "AUTOMATION_EXECUTION_FAILED"),
+      timestamp,
+    };
+    await writeAutomationEvent({
+      type: "automation.skipped",
+      result: automationResult,
+      policyOutcome: input.policyResult.outcome,
+      actor: input.actor,
+      resource: input.resource,
+      visibility: input.visibility,
+      metadata: input.metadata,
+    });
+    return { automationResult };
+  }
+}

--- a/rentchain-api/src/lib/automation/automationTypes.ts
+++ b/rentchain-api/src/lib/automation/automationTypes.ts
@@ -1,0 +1,61 @@
+import type { PolicyEvaluationResult } from "../policy/policyTypes";
+
+export type AutomationAction =
+  | "screening.auto_start_checkout"
+  | "maintenance.auto_approve_cost"
+  | "lease.auto_send_notice";
+
+export type AutomationExecutionResult = {
+  action: AutomationAction;
+  executed: boolean;
+  skipped: boolean;
+  reason?: string;
+  timestamp: string;
+};
+
+export type ScreeningAutomationContext<T = unknown> = {
+  quoteExists: boolean;
+  existingCheckout: boolean;
+  alreadyPaid: boolean;
+  execute: () => Promise<T>;
+};
+
+export type MaintenanceAutomationContext<T = unknown> = {
+  alreadyApproved: boolean;
+  actualCostCents: number | null;
+  thresholdCents: number;
+  hasSupportingEvidence: boolean;
+  execute: () => Promise<T>;
+};
+
+export type LeaseAutomationContext<T = unknown> = {
+  noticeReady: boolean;
+  alreadySent: boolean;
+  hasRequiredLegalInputs: boolean;
+  execute: () => Promise<T>;
+};
+
+export type AutomationActionContextMap<T = unknown> = {
+  "screening.auto_start_checkout": ScreeningAutomationContext<T>;
+  "maintenance.auto_approve_cost": MaintenanceAutomationContext<T>;
+  "lease.auto_send_notice": LeaseAutomationContext<T>;
+};
+
+export type AutomationExecutorInput<A extends AutomationAction, T = unknown> = {
+  action: A;
+  policyResult: PolicyEvaluationResult;
+  context: AutomationActionContextMap<T>[A];
+  actor: {
+    type?: "user" | "system" | "admin" | "tenant" | "landlord" | "contractor" | "service";
+    id?: string | null;
+    role?: string | null;
+  };
+  resource: {
+    type: string;
+    id: string;
+    parentType?: string | null;
+    parentId?: string | null;
+  };
+  visibility?: "internal" | "landlord" | "tenant" | "admin" | "system";
+  metadata?: Record<string, unknown>;
+};

--- a/rentchain-api/src/lib/automation/tests/automationExecutor.test.ts
+++ b/rentchain-api/src/lib/automation/tests/automationExecutor.test.ts
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { executeAutomation } from "../automationExecutor";
+import type { PolicyEvaluationResult } from "../../policy/policyTypes";
+
+const { writeCanonicalEvent } = vi.hoisted(() => ({
+  writeCanonicalEvent: vi.fn(async () => undefined),
+}));
+
+vi.mock("../../events/buildEvent", () => ({
+  writeCanonicalEvent,
+}));
+
+function policyResult(overrides: Partial<PolicyEvaluationResult>): PolicyEvaluationResult {
+  return {
+    version: "v1",
+    domain: "screening",
+    action: "start_checkout",
+    outcome: "allow",
+    reasons: [],
+    matchedRules: [],
+    requiresManualApproval: false,
+    canAutopilot: true,
+    evaluatedAt: "2026-04-15T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+const actor = { type: "landlord" as const, id: "landlord-1", role: "landlord" };
+const resource = { type: "rental_application", id: "app-1" };
+
+describe("executeAutomation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("executes when policy allows", async () => {
+    const execute = vi.fn(async () => ({ checkoutUrl: "https://checkout.test" }));
+    const result = await executeAutomation({
+      action: "screening.auto_start_checkout",
+      policyResult: policyResult({}),
+      actor,
+      resource,
+      context: {
+        quoteExists: true,
+        existingCheckout: false,
+        alreadyPaid: false,
+        execute,
+      },
+    });
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(result.automationResult).toEqual(
+      expect.objectContaining({
+        action: "screening.auto_start_checkout",
+        executed: true,
+        skipped: false,
+      })
+    );
+    expect(result.data).toEqual({ checkoutUrl: "https://checkout.test" });
+    expect(writeCanonicalEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "automation.executed",
+      })
+    );
+  });
+
+  it("skips when blocked", async () => {
+    const execute = vi.fn();
+    const result = await executeAutomation({
+      action: "screening.auto_start_checkout",
+      policyResult: policyResult({ outcome: "block", canAutopilot: false }),
+      actor,
+      resource,
+      context: {
+        quoteExists: true,
+        existingCheckout: false,
+        alreadyPaid: false,
+        execute,
+      },
+    });
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(result.automationResult).toEqual(
+      expect.objectContaining({
+        executed: false,
+        skipped: true,
+      })
+    );
+    expect(writeCanonicalEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "automation.skipped",
+      })
+    );
+  });
+
+  it("skips when review is required", async () => {
+    const execute = vi.fn();
+    const result = await executeAutomation({
+      action: "maintenance.auto_approve_cost",
+      policyResult: policyResult({
+        domain: "maintenance",
+        action: "approve_cost",
+        outcome: "review",
+        requiresManualApproval: true,
+        canAutopilot: false,
+      }),
+      actor,
+      resource: { type: "work_order", id: "wo-1" },
+      context: {
+        alreadyApproved: false,
+        actualCostCents: 50_000,
+        thresholdCents: 100_000,
+        hasSupportingEvidence: true,
+        execute,
+      },
+    });
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(result.automationResult.skipped).toBe(true);
+    expect(result.automationResult.executed).toBe(false);
+  });
+
+  it("skips when already completed", async () => {
+    const execute = vi.fn();
+    const result = await executeAutomation({
+      action: "maintenance.auto_approve_cost",
+      policyResult: policyResult({
+        domain: "maintenance",
+        action: "approve_cost",
+      }),
+      actor,
+      resource: { type: "work_order", id: "wo-1" },
+      context: {
+        alreadyApproved: true,
+        actualCostCents: 50_000,
+        thresholdCents: 100_000,
+        hasSupportingEvidence: true,
+        execute,
+      },
+    });
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(result.automationResult.reason).toBe("MAINTENANCE_ALREADY_APPROVED");
+  });
+
+  it("does not duplicate execution when prerequisites say an action already exists", async () => {
+    const execute = vi.fn();
+    const result = await executeAutomation({
+      action: "screening.auto_start_checkout",
+      policyResult: policyResult({}),
+      actor,
+      resource,
+      context: {
+        quoteExists: true,
+        existingCheckout: true,
+        alreadyPaid: false,
+        execute,
+      },
+    });
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(result.automationResult.reason).toBe("SCREENING_CHECKOUT_ALREADY_EXISTS");
+  });
+
+  it("returns a stable result structure when execution throws", async () => {
+    const result = await executeAutomation({
+      action: "lease.auto_send_notice",
+      policyResult: policyResult({
+        domain: "lease_notice",
+        action: "send_notice",
+      }),
+      actor,
+      resource: { type: "lease", id: "lease-1" },
+      context: {
+        noticeReady: true,
+        alreadySent: false,
+        hasRequiredLegalInputs: true,
+        execute: async () => {
+          throw new Error("EMAIL_FAILED");
+        },
+      },
+    });
+
+    expect(result.automationResult).toEqual(
+      expect.objectContaining({
+        action: "lease.auto_send_notice",
+        executed: false,
+        skipped: true,
+        reason: "EMAIL_FAILED",
+      })
+    );
+  });
+});

--- a/rentchain-api/src/routes/__tests__/leaseNoticeLandlordRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseNoticeLandlordRoutes.test.ts
@@ -29,6 +29,19 @@ const { collections, dbMock } = vi.hoisted(() => {
         };
       },
     }),
+    batch: () => {
+      const ops: Array<() => Promise<void>> = [];
+      return {
+        set(ref: any, value: any, options?: { merge?: boolean }) {
+          ops.push(() => ref.set(value, options));
+        },
+        async commit() {
+          for (const op of ops) {
+            await op();
+          }
+        },
+      };
+    },
   };
 
   return { collections, dbMock };
@@ -51,6 +64,8 @@ vi.mock("../../config/leaseNoticeRules", () => ({
 
 const appendLeaseWorkflowEvent = vi.fn(async () => undefined);
 const buildPreview = vi.fn(async () => undefined);
+const lookupUserEmail = vi.fn(async () => "tenant@example.com");
+const sendLeaseWorkflowEmail = vi.fn(async () => ({ ok: true }));
 const getLeaseForLandlordWorkflow = vi.fn(async () => ({
   ok: true,
   lease: {
@@ -72,9 +87,9 @@ vi.mock("../../services/leaseNoticeWorkflowService", () => ({
   computeNoResponseState: vi.fn(),
   getLeaseForLandlordWorkflow,
   getLeaseNoticeByLeaseId: vi.fn(),
-  lookupUserEmail: vi.fn(),
+  lookupUserEmail,
   normalizeLeaseRecord: vi.fn(),
-  sendLeaseWorkflowEmail: vi.fn(),
+  sendLeaseWorkflowEmail,
 }));
 
 async function invokeRouter(router: any, options: { method: string; url: string; body?: any }) {
@@ -186,5 +201,41 @@ describe("leaseNoticeLandlordRoutes policy integration", () => {
       })
     );
     expect(appendLeaseWorkflowEvent).toHaveBeenCalled();
+  });
+
+  it("auto-sends the notice from preview when automation is requested and policy allows", async () => {
+    const router = (await import("../leaseNoticeLandlordRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/lease-1/notice-preview",
+      body: {
+        newLeaseStartDate: "2026-07-01",
+        newLeaseEndDate: "2027-06-30",
+        responseDeadlineAt: 1700000000000,
+        rentChangeMode: "no_change",
+        automationEnabled: true,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.automationResult).toEqual(
+      expect.objectContaining({
+        action: "lease.auto_send_notice",
+        executed: true,
+        skipped: false,
+      })
+    );
+    expect(res.body?.noticeId).toBeTruthy();
+    const automationEvent = Array.from((collections.get("canonicalEvents") || new Map()).values()).find(
+      (entry) => entry?.type === "automation.executed"
+    );
+    expect(automationEvent).toEqual(
+      expect.objectContaining({
+        domain: "system",
+        metadata: expect.objectContaining({
+          action: "lease.auto_send_notice",
+        }),
+      })
+    );
   });
 });

--- a/rentchain-api/src/routes/__tests__/rentalApplicationsCanonicalEvents.test.ts
+++ b/rentchain-api/src/routes/__tests__/rentalApplicationsCanonicalEvents.test.ts
@@ -258,6 +258,55 @@ describe("rentalApplicationsRoutes canonical screening events", () => {
     );
   });
 
+  it("auto-starts checkout from quote when automation is requested and policy allows", async () => {
+    const router = (await import("../rentalApplicationsRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "POST",
+      url: "/rental-applications/app-1/screening/quote",
+      headers: {
+        origin: "http://localhost:5173",
+      },
+      body: {
+        consent: {
+          given: true,
+          timestamp: "2026-03-02T10:00:00.000Z",
+          version: "v1.0",
+        },
+        automationEnabled: true,
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body?.automationResult).toEqual(
+      expect.objectContaining({
+        action: "screening.auto_start_checkout",
+        executed: true,
+        skipped: false,
+      })
+    );
+    expect(response.body?.checkoutUrl).toBe("https://checkout.test/session_1");
+    const events = Array.from((collections.get("canonicalEvents") || new Map()).values());
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "automation.executed",
+          domain: "system",
+          metadata: expect.objectContaining({
+            action: "screening.auto_start_checkout",
+          }),
+        }),
+        expect.objectContaining({
+          type: "policy.evaluated",
+          domain: "policy",
+          metadata: expect.objectContaining({
+            domain: "screening",
+            action: "start_checkout",
+          }),
+        }),
+      ])
+    );
+  });
+
   it("blocks screening checkout when the provider is degraded", async () => {
     process.env.NODE_ENV = "production";
     const { getScreeningProviderHealth } = await import("../../services/screening/providerHealth");

--- a/rentchain-api/src/routes/__tests__/workOrdersRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/workOrdersRoutes.test.ts
@@ -1021,6 +1021,81 @@ describe("workOrdersRoutes execution completion", () => {
     );
   });
 
+  it("auto-approves maintenance cost when automation is requested and policy allows", async () => {
+    const router = (await import("../workOrdersRoutes")).default;
+    ensureCollection("workOrders").set("wo-1", {
+      ...ensureCollection("workOrders").get("wo-1"),
+      status: "completed",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      maintenanceRequestId: "maint-1",
+      cost: {
+        actualCostCents: 32000,
+        currency: "CAD",
+        submittedByRole: "contractor",
+        submittedById: "contractor-1",
+        submittedAt: 700,
+        reviewStatus: "pending_review",
+        latestRevisionNumber: 1,
+      },
+      costReviewHistory: [
+        {
+          id: "history-1",
+          revisionNumber: 1,
+          submittedAt: 700,
+          submittedByRole: "contractor",
+          submittedById: "contractor-1",
+          actualCostCents: 32000,
+          currency: "CAD",
+          reviewStatus: "pending_review",
+        },
+      ],
+      costAttachments: [
+        {
+          id: "attachment-1",
+          uploadedAt: 700,
+          uploadedByRole: "contractor",
+          uploadedById: "contractor-1",
+          visibility: "landlord_only",
+          fileName: "invoice.pdf",
+        },
+      ],
+    });
+
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/landlord/work-orders/wo-1/review-cost",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "landlord-1",
+          role: "landlord",
+          landlordId: "landlord-1",
+        }),
+      },
+      body: {
+        automationEnabled: true,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.item?.cost?.reviewStatus).toBe("approved");
+    expect(res.body?.automationResult).toEqual(
+      expect.objectContaining({
+        action: "maintenance.auto_approve_cost",
+        executed: true,
+        skipped: false,
+      })
+    );
+    const automationEvent = Array.from(ensureCollection("canonicalEvents").values()).find(
+      (entry) => entry?.type === "automation.executed" && entry?.metadata?.action === "maintenance.auto_approve_cost"
+    );
+    expect(automationEvent).toEqual(
+      expect.objectContaining({
+        domain: "system",
+      })
+    );
+  });
+
   it("blocks maintenance approval when supporting evidence is missing", async () => {
     const router = (await import("../workOrdersRoutes")).default;
     ensureCollection("workOrders").set("wo-1", {

--- a/rentchain-api/src/routes/leaseNoticeLandlordRoutes.ts
+++ b/rentchain-api/src/routes/leaseNoticeLandlordRoutes.ts
@@ -16,6 +16,7 @@ import {
   normalizeLeaseRecord,
   sendLeaseWorkflowEmail,
 } from "../services/leaseNoticeWorkflowService";
+import { executeAutomation } from "../lib/automation/automationExecutor";
 import { buildLeaseNoticePolicyRequest } from "../lib/policy/policyAdapters";
 import { evaluatePolicy, toAutopilotPolicySummary, writePolicyEvaluatedEvent } from "../lib/policy/policyEvaluator";
 
@@ -39,6 +40,235 @@ function asNumber(value: unknown): number | null {
 
 function appBaseUrl() {
   return String(process.env.PUBLIC_APP_URL || process.env.VITE_PUBLIC_APP_URL || "https://www.rentchain.ai").replace(/\/$/, "");
+}
+
+function isAutomationRequested(body: any) {
+  return Boolean(body?.automationEnabled || body?.automation?.enabled);
+}
+
+async function performLeaseNoticeSend(params: {
+  leaseId: string;
+  landlordId: string;
+  actorId: string | null;
+  lease: any;
+  reqBody: any;
+  autopilotPolicy: ReturnType<typeof toAutopilotPolicySummary>;
+}) {
+  const { leaseId, landlordId, actorId, lease, reqBody, autopilotPolicy } = params;
+  const previewResult = buildPreview(lease, {
+    rentChangeMode: String(reqBody?.rentChangeMode || "").trim().toLowerCase() as RentChangeMode,
+    proposedRent: asNumber(reqBody?.proposedRent),
+    newTermType: String(reqBody?.newTermType || "").trim().toLowerCase() as any,
+    newLeaseStartDate: String(reqBody?.newLeaseStartDate || "").trim(),
+    newLeaseEndDate: reqBody?.newLeaseEndDate ?? null,
+    responseDeadlineAt: Number(reqBody?.responseDeadlineAt || 0),
+    noticeType: (String(reqBody?.noticeType || "").trim().toLowerCase() || undefined) as LeaseNoticeType | undefined,
+  });
+  if (!previewResult.ok) {
+    return { status: 400, payload: { ok: false, error: previewResult.error, autopilotPolicy } };
+  }
+
+  const noticeRef = db.collection("leaseNotices").doc();
+  const now = Date.now();
+  const baseNotice = {
+    id: noticeRef.id,
+    leaseId,
+    landlordId,
+    tenantId: lease.tenantId,
+    propertyId: lease.propertyId,
+    unitId: lease.unitId,
+    noticeType: previewResult.preview.noticeType,
+    legalTemplateKey: previewResult.preview.legalTemplateKey,
+    province: lease.province,
+    leaseType: lease.leaseType,
+    noticeDueAt: previewResult.preview.noticeDueAt,
+    sentAt: null,
+    deliveryStatus: "pending",
+    deliveryChannel: "email",
+    rentChangeMode: previewResult.preview.rentChangeMode,
+    currentRent: previewResult.preview.currentRent,
+    proposedRent: previewResult.preview.proposedRent,
+    newTermType: previewResult.preview.newTermType,
+    newTermStartDate: previewResult.preview.newTermStartDate,
+    newTermEndDate: previewResult.preview.newTermEndDate,
+    responseRequired: true,
+    responseDeadlineAt: previewResult.preview.responseDeadlineAt,
+    tenantResponse: "pending",
+    tenantRespondedAt: null,
+    tenantViewedAt: null,
+    landlordNotifiedOfResponseAt: null,
+    metadata: {
+      noticeRuleVersion: previewResult.preview.noticeRuleVersion,
+      summary: previewResult.preview.summary,
+    },
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  const batch = db.batch();
+  batch.set(noticeRef, baseNotice);
+  batch.set(
+    db.collection("leases").doc(leaseId),
+    {
+      status: "renewal_pending",
+      latestNoticeId: noticeRef.id,
+      noticeRuleVersion: previewResult.preview.noticeRuleVersion,
+      noticeLeadDays: previewResult.rule.noticeLeadDays,
+      nextNoticeDueAt: previewResult.preview.noticeDueAt,
+      renewalOfferedRent: previewResult.preview.proposedRent,
+      renewalDecisionDeadlineAt: previewResult.preview.responseDeadlineAt,
+      updatedAt: now,
+    },
+    { merge: true }
+  );
+  await appendLeaseWorkflowEvent({
+    batch,
+    entityType: "leaseNotice",
+    entityId: noticeRef.id,
+    leaseId,
+    landlordId,
+    tenantId: lease.tenantId,
+    propertyId: lease.propertyId,
+    unitId: lease.unitId,
+    actorType: "landlord",
+    actorId,
+    eventType: "lease_notice_due",
+    eventData: {
+      noticeType: baseNotice.noticeType,
+      responseDeadlineAt: baseNotice.responseDeadlineAt,
+    },
+  });
+  await batch.commit();
+
+  const tenantEmail = await lookupUserEmail(lease.tenantId, ["tenants", "users"]);
+  const tenantUrl = `${appBaseUrl()}/tenant/login?next=${encodeURIComponent(`/tenant/lease-notices/${noticeRef.id}`)}`;
+  const emailResult = await sendLeaseWorkflowEmail({
+    eventKey: "lease_notice_sent_tenant",
+    to: tenantEmail,
+    subject: "Lease notice from your landlord",
+    intro:
+      previewResult.preview.rentChangeMode === "undecided"
+        ? "Your landlord sent a lease notice and will decide rent later. Review the next-term options in RentChain."
+        : "Your landlord sent a lease notice. Review the next-term options and choose whether to begin a new term or quit at the end of the current term.",
+    ctaText: "Review lease notice",
+    ctaUrl: tenantUrl,
+    leaseId,
+    noticeId: noticeRef.id,
+    landlordId,
+    tenantId: lease.tenantId,
+    propertyId: lease.propertyId,
+    unitId: lease.unitId,
+  });
+
+  if (!emailResult.ok) {
+    await Promise.all([
+      noticeRef.set(
+        {
+          deliveryStatus: "failed",
+          metadata: {
+            ...baseNotice.metadata,
+            lastDeliveryError: emailResult.reason,
+          },
+          updatedAt: Date.now(),
+        },
+        { merge: true }
+      ),
+      appendLeaseWorkflowEvent({
+        entityType: "leaseNotice",
+        entityId: noticeRef.id,
+        leaseId,
+        landlordId,
+        tenantId: lease.tenantId,
+        propertyId: lease.propertyId,
+        unitId: lease.unitId,
+        actorType: "system",
+        actorId: null,
+        eventType: "landlord_notified",
+        eventData: {
+          kind: "send_failed",
+          noticeId: noticeRef.id,
+          reason: emailResult.reason,
+        },
+      }),
+    ]);
+    return {
+      status: 502,
+      payload: {
+        ok: false,
+        error: "LEASE_NOTICE_DELIVERY_FAILED",
+        noticeId: noticeRef.id,
+        delivery: emailResult,
+        autopilotPolicy,
+      },
+    };
+  }
+
+  const sentAt = Date.now();
+  const sentBatch = db.batch();
+  sentBatch.set(
+    noticeRef,
+    {
+      sentAt,
+      deliveryStatus: "sent",
+      updatedAt: sentAt,
+    },
+    { merge: true }
+  );
+  await appendLeaseWorkflowEvent({
+    batch: sentBatch,
+    entityType: "leaseNotice",
+    entityId: noticeRef.id,
+    leaseId,
+    landlordId,
+    tenantId: lease.tenantId,
+    propertyId: lease.propertyId,
+    unitId: lease.unitId,
+    actorType: "landlord",
+    actorId,
+    eventType: "lease_notice_sent",
+    eventData: {
+      deliveryStatus: "sent",
+      noticeType: baseNotice.noticeType,
+    },
+  });
+  await appendLeaseWorkflowEvent({
+    batch: sentBatch,
+    entityType: "lease",
+    entityId: leaseId,
+    leaseId,
+    landlordId,
+    tenantId: lease.tenantId,
+    propertyId: lease.propertyId,
+    unitId: lease.unitId,
+    actorType: "system",
+    actorId: null,
+    eventType: "landlord_notified",
+    eventData: {
+      kind: "notice_send_success",
+      noticeId: noticeRef.id,
+    },
+  });
+  await sentBatch.commit();
+
+  console.info("[lease-notice] sent", {
+    leaseId,
+    noticeId: noticeRef.id,
+    landlordId,
+    tenantId: lease.tenantId,
+    propertyId: lease.propertyId,
+    unitId: lease.unitId,
+    deliveryStatus: "sent",
+  });
+
+  return {
+    status: 201,
+    payload: {
+      ok: true,
+      noticeId: noticeRef.id,
+      delivery: emailResult,
+      autopilotPolicy,
+    },
+  };
 }
 
 router.get("/expiring", async (req: any, res) => {
@@ -141,8 +371,84 @@ router.post("/:id/notice-preview", async (req: any, res) => {
         responseDeadlineAt: previewResult.preview.responseDeadlineAt,
       },
     });
+    if (!isAutomationRequested(req.body)) {
+      return res.json({ ok: true, preview: previewResult.preview, rule: previewResult.rule, autopilotPolicy });
+    }
 
-    return res.json({ ok: true, preview: previewResult.preview, rule: previewResult.rule, autopilotPolicy });
+    const sendPolicyRequest = buildLeaseNoticePolicyRequest({
+      action: "send_notice",
+      actorRole: String(req.user?.role || "").trim().toLowerCase() || "landlord",
+      actorUserId: actorId,
+      lease: leaseResult.lease,
+      leaseId,
+      requestBody: req.body || {},
+    });
+    const sendPolicyResult = evaluatePolicy(sendPolicyRequest);
+    await writePolicyEvaluatedEvent({
+      request: sendPolicyRequest,
+      result: sendPolicyResult,
+      actorType: "landlord",
+      metadata: {
+        landlordId,
+        tenantId: leaseResult.lease.tenantId,
+        propertyId: leaseResult.lease.propertyId,
+        unitId: leaseResult.lease.unitId,
+        initiatedFrom: "notice_preview",
+      },
+    });
+    const automation = await executeAutomation({
+      action: "lease.auto_send_notice",
+      policyResult: sendPolicyResult,
+      actor: {
+        type: "landlord",
+        id: actorId,
+        role: "landlord",
+      },
+      resource: {
+        type: "lease",
+        id: leaseId,
+      },
+      visibility: "internal",
+      metadata: {
+        domain: "lease_notice",
+        initiatedFrom: "preview",
+        landlordId,
+        tenantId: leaseResult.lease.tenantId,
+        propertyId: leaseResult.lease.propertyId,
+        unitId: leaseResult.lease.unitId,
+        policyAction: "send_notice",
+      },
+      context: {
+        noticeReady: previewResult.ok,
+        alreadySent: Boolean(leaseResult.lease.latestNoticeId),
+        hasRequiredLegalInputs: Boolean(sendPolicyRequest.context.hasRequiredLegalInputs),
+        execute: async () => {
+          const execution = await performLeaseNoticeSend({
+            leaseId,
+            landlordId,
+            actorId,
+            lease: leaseResult.lease,
+            reqBody: req.body || {},
+            autopilotPolicy,
+          });
+          if (execution.status >= 400) {
+            const error = new Error(String(execution.payload?.error || "AUTOMATION_EXECUTION_FAILED"));
+            (error as any).code = execution.payload?.error || "AUTOMATION_EXECUTION_FAILED";
+            throw error;
+          }
+          return execution.payload;
+        },
+      },
+    });
+
+    return res.json({
+      ok: true,
+      preview: previewResult.preview,
+      rule: previewResult.rule,
+      autopilotPolicy,
+      ...(automation.data && typeof automation.data === "object" ? automation.data : {}),
+      automationResult: automation.automationResult,
+    });
   } catch (err: any) {
     console.error("[lease-notice] preview failed", { message: err?.message || "failed" });
     return res.status(500).json({ ok: false, error: "LEASE_NOTICE_PREVIEW_FAILED" });
@@ -183,208 +489,15 @@ router.post("/:id/send-notice", async (req: any, res) => {
     if (policyResult.outcome === "block") {
       return res.status(400).json({ ok: false, error: "LEASE_NOTICE_POLICY_BLOCKED", autopilotPolicy });
     }
-    const previewResult = buildPreview(lease, {
-      rentChangeMode: String(req.body?.rentChangeMode || "").trim().toLowerCase() as RentChangeMode,
-      proposedRent: asNumber(req.body?.proposedRent),
-      newTermType: String(req.body?.newTermType || "").trim().toLowerCase() as any,
-      newLeaseStartDate: String(req.body?.newLeaseStartDate || "").trim(),
-      newLeaseEndDate: req.body?.newLeaseEndDate ?? null,
-      responseDeadlineAt: Number(req.body?.responseDeadlineAt || 0),
-      noticeType: (String(req.body?.noticeType || "").trim().toLowerCase() || undefined) as LeaseNoticeType | undefined,
-    });
-    if (!previewResult.ok) {
-      return res.status(400).json({ ok: false, error: previewResult.error });
-    }
-
-    const noticeRef = db.collection("leaseNotices").doc();
-    const now = Date.now();
-    const baseNotice = {
-      id: noticeRef.id,
+    const execution = await performLeaseNoticeSend({
       leaseId,
       landlordId,
-      tenantId: lease.tenantId,
-      propertyId: lease.propertyId,
-      unitId: lease.unitId,
-      noticeType: previewResult.preview.noticeType,
-      legalTemplateKey: previewResult.preview.legalTemplateKey,
-      province: lease.province,
-      leaseType: lease.leaseType,
-      noticeDueAt: previewResult.preview.noticeDueAt,
-      sentAt: null,
-      deliveryStatus: "pending",
-      deliveryChannel: "email",
-      rentChangeMode: previewResult.preview.rentChangeMode,
-      currentRent: previewResult.preview.currentRent,
-      proposedRent: previewResult.preview.proposedRent,
-      newTermType: previewResult.preview.newTermType,
-      newTermStartDate: previewResult.preview.newTermStartDate,
-      newTermEndDate: previewResult.preview.newTermEndDate,
-      responseRequired: true,
-      responseDeadlineAt: previewResult.preview.responseDeadlineAt,
-      tenantResponse: "pending",
-      tenantRespondedAt: null,
-      tenantViewedAt: null,
-      landlordNotifiedOfResponseAt: null,
-      metadata: {
-        noticeRuleVersion: previewResult.preview.noticeRuleVersion,
-        summary: previewResult.preview.summary,
-      },
-      createdAt: now,
-      updatedAt: now,
-    };
-
-    const batch = db.batch();
-    batch.set(noticeRef, baseNotice);
-    batch.set(
-      db.collection("leases").doc(leaseId),
-      {
-        status: "renewal_pending",
-        latestNoticeId: noticeRef.id,
-        noticeRuleVersion: previewResult.preview.noticeRuleVersion,
-        noticeLeadDays: previewResult.rule.noticeLeadDays,
-        nextNoticeDueAt: previewResult.preview.noticeDueAt,
-        renewalOfferedRent: previewResult.preview.proposedRent,
-        renewalDecisionDeadlineAt: previewResult.preview.responseDeadlineAt,
-        updatedAt: now,
-      },
-      { merge: true }
-    );
-    await appendLeaseWorkflowEvent({
-      batch,
-      entityType: "leaseNotice",
-      entityId: noticeRef.id,
-      leaseId,
-      landlordId,
-      tenantId: lease.tenantId,
-      propertyId: lease.propertyId,
-      unitId: lease.unitId,
-      actorType: "landlord",
       actorId,
-      eventType: "lease_notice_due",
-      eventData: {
-        noticeType: baseNotice.noticeType,
-        responseDeadlineAt: baseNotice.responseDeadlineAt,
-      },
+      lease,
+      reqBody: req.body || {},
+      autopilotPolicy,
     });
-    await batch.commit();
-
-    const tenantEmail = await lookupUserEmail(lease.tenantId, ["tenants", "users"]);
-    const tenantUrl = `${appBaseUrl()}/tenant/login?next=${encodeURIComponent(`/tenant/lease-notices/${noticeRef.id}`)}`;
-    const emailResult = await sendLeaseWorkflowEmail({
-      eventKey: "lease_notice_sent_tenant",
-      to: tenantEmail,
-      subject: "Lease notice from your landlord",
-      intro:
-        previewResult.preview.rentChangeMode === "undecided"
-          ? "Your landlord sent a lease notice and will decide rent later. Review the next-term options in RentChain."
-          : "Your landlord sent a lease notice. Review the next-term options and choose whether to begin a new term or quit at the end of the current term.",
-      ctaText: "Review lease notice",
-      ctaUrl: tenantUrl,
-      leaseId,
-      noticeId: noticeRef.id,
-      landlordId,
-      tenantId: lease.tenantId,
-      propertyId: lease.propertyId,
-      unitId: lease.unitId,
-    });
-
-    if (!emailResult.ok) {
-      await Promise.all([
-        noticeRef.set(
-          {
-            deliveryStatus: "failed",
-            metadata: {
-              ...baseNotice.metadata,
-              lastDeliveryError: emailResult.reason,
-            },
-            updatedAt: Date.now(),
-          },
-          { merge: true }
-        ),
-        appendLeaseWorkflowEvent({
-          entityType: "leaseNotice",
-          entityId: noticeRef.id,
-          leaseId,
-          landlordId,
-          tenantId: lease.tenantId,
-          propertyId: lease.propertyId,
-          unitId: lease.unitId,
-          actorType: "system",
-          actorId: null,
-          eventType: "landlord_notified",
-          eventData: {
-            kind: "send_failed",
-            noticeId: noticeRef.id,
-            reason: emailResult.reason,
-          },
-        }),
-      ]);
-      return res.status(502).json({
-        ok: false,
-        error: "LEASE_NOTICE_DELIVERY_FAILED",
-        noticeId: noticeRef.id,
-        delivery: emailResult,
-      });
-    }
-
-    const sentAt = Date.now();
-    const sentBatch = db.batch();
-    sentBatch.set(
-      noticeRef,
-      {
-        sentAt,
-        deliveryStatus: "sent",
-        updatedAt: sentAt,
-      },
-      { merge: true }
-    );
-    await appendLeaseWorkflowEvent({
-      batch: sentBatch,
-      entityType: "leaseNotice",
-      entityId: noticeRef.id,
-      leaseId,
-      landlordId,
-      tenantId: lease.tenantId,
-      propertyId: lease.propertyId,
-      unitId: lease.unitId,
-      actorType: "landlord",
-      actorId,
-      eventType: "lease_notice_sent",
-      eventData: {
-        deliveryStatus: "sent",
-        noticeType: baseNotice.noticeType,
-      },
-    });
-    await appendLeaseWorkflowEvent({
-      batch: sentBatch,
-      entityType: "lease",
-      entityId: leaseId,
-      leaseId,
-      landlordId,
-      tenantId: lease.tenantId,
-      propertyId: lease.propertyId,
-      unitId: lease.unitId,
-      actorType: "system",
-      actorId: null,
-      eventType: "landlord_notified",
-      eventData: {
-        kind: "notice_send_success",
-        noticeId: noticeRef.id,
-      },
-    });
-    await sentBatch.commit();
-
-    console.info("[lease-notice] sent", {
-      leaseId,
-      noticeId: noticeRef.id,
-      landlordId,
-      tenantId: lease.tenantId,
-      propertyId: lease.propertyId,
-      unitId: lease.unitId,
-      deliveryStatus: "sent",
-    });
-
-    return res.status(201).json({ ok: true, noticeId: noticeRef.id, delivery: emailResult, autopilotPolicy });
+    return res.status(execution.status).json(execution.payload);
   } catch (err: any) {
     console.error("[lease-notice] send failed", { message: err?.message || "failed" });
     return res.status(500).json({ ok: false, error: "LEASE_NOTICE_SEND_FAILED" });

--- a/rentchain-api/src/routes/rentalApplicationsRoutes.ts
+++ b/rentchain-api/src/routes/rentalApplicationsRoutes.ts
@@ -37,6 +37,7 @@ import { buildEmailHtml, buildEmailText } from "../email/templates/baseEmailTemp
 import { sendEmail } from "../services/emailService";
 import { recordScreeningPaymentInitiated } from "../services/screeningPaymentTransactionService";
 import { writeCanonicalEvent } from "../lib/events/buildEvent";
+import { executeAutomation } from "../lib/automation/automationExecutor";
 import { buildScreeningPolicyRequest } from "../lib/policy/policyAdapters";
 import { evaluatePolicy, toAutopilotPolicySummary, writePolicyEvaluatedEvent } from "../lib/policy/policyEvaluator";
 import {
@@ -144,6 +145,511 @@ function buildRedirectUrl(params: {
     url.searchParams.set("returnTo", params.returnTo);
   }
   return url.toString();
+}
+
+function isAutomationRequested(body: any) {
+  return Boolean(body?.automationEnabled || body?.automation?.enabled);
+}
+
+async function performScreeningCheckoutExecution(params: {
+  req: any;
+  role: string;
+  actorId: string | null;
+  landlordId: string;
+  applicationId: string;
+  application: any;
+  body: any;
+  consent: { timestamp: string; version: string; textHash: string | null };
+  providerHealth: Awaited<ReturnType<typeof getScreeningProviderHealth>>;
+  autopilotPolicy: ReturnType<typeof toAutopilotPolicySummary> | null;
+  logBase: Record<string, unknown>;
+}) {
+  const {
+    req,
+    role,
+    actorId,
+    landlordId,
+    applicationId,
+    application,
+    body,
+    consent,
+    providerHealth,
+    autopilotPolicy,
+    logBase,
+  } = params;
+  const { screeningTier, addons, serviceLevel, scoreAddOn, expeditedAddOn, pricing } =
+    resolvePricingInput(body);
+  const frontendOrigin = resolveFrontendOrigin(req);
+  const rawReturnTo = String(body?.returnTo || "/dashboard");
+  const returnTo = rawReturnTo.startsWith("/") ? rawReturnTo : "/dashboard";
+  const successUrl = buildRedirectUrl({
+    input: body?.successPath,
+    fallbackPath: "/screening/success",
+    frontendOrigin,
+    applicationId,
+    returnTo,
+  });
+  const cancelUrl = buildRedirectUrl({
+    input: body?.cancelPath,
+    fallbackPath: "/screening/cancel",
+    frontendOrigin,
+    applicationId,
+    returnTo,
+  });
+  if (!successUrl || !cancelUrl) {
+    console.warn("[screening_checkout] invalid redirect origin", logBase);
+    return {
+      status: 400,
+      payload: { ok: false, error: "invalid_redirect_origin" },
+    };
+  }
+
+  if (isTransUnionReferralMode()) {
+    const now = Date.now();
+    const orderRef = db.collection("screeningOrders").doc();
+    const orderId = orderRef.id;
+    const referralUrl = buildTransUnionReferralUrl({
+      landlordId: String(landlordId),
+      applicationId,
+      orderId,
+      returnTo,
+      env: process.env.NODE_ENV || "development",
+    });
+
+    const orderPayload: any = {
+      id: orderId,
+      referenceId: buildReferenceId(orderId),
+      landlordId,
+      applicationId,
+      propertyId: application?.propertyId || null,
+      unitId: application?.unitId || null,
+      createdAt: now,
+      updatedAt: now,
+      amountCents: 0,
+      currency: "CAD",
+      status: "external_pending",
+      paymentStatus: "external_pending",
+      finalized: false,
+      finalizedAt: null,
+      lastStripeEventId: null,
+      amountTotalCents: 0,
+      screeningTier,
+      addons,
+      scoreAddOn: false,
+      scoreAddOnCents: 0,
+      expeditedAddOn: false,
+      expeditedAddOnCents: 0,
+      provider: "transunion_referral",
+      inquiryType: "soft",
+      providerRequestId: null,
+      paidAt: null,
+      error: null,
+      serviceLevel,
+      aiVerification: false,
+      aiPriceCents: 0,
+      totalAmountCents: 0,
+      reviewerStatus: "EXTERNAL_PENDING",
+      stripeSessionId: null,
+      stripeCheckoutSessionId: null,
+      stripePaymentIntentId: null,
+      stripeChargeId: null,
+      consentGiven: true,
+      consentTimestamp: consent.timestamp,
+      consentVersion: consent.version,
+      consentTextHash: consent.textHash,
+      externalRedirectUrl: referralUrl,
+      externalProvider: "transunion",
+    };
+    await orderRef.set(orderPayload, { merge: true });
+    await enqueueScreeningJob({
+      orderId,
+      applicationId,
+      landlordId: application?.landlordId || landlordId,
+      provider: "transunion_referral",
+    });
+    await db.collection("rentalApplications").doc(applicationId).set(
+      {
+        screeningStatus: "external_pending",
+        screeningOrderId: orderId,
+        screeningProvider: "transunion_referral",
+        screeningLastUpdatedAt: now,
+        screening: {
+          ...(application?.screening || {}),
+          status: "external_pending",
+          provider: "transunion_referral",
+          orderId,
+        },
+        screeningMonetization: buildScreeningMonetizationPatch({
+          current: application?.screeningMonetization,
+          eligibility: "eligible",
+          paymentStatus: "checkout_created",
+          fulfillmentStatus: "ordered",
+          checkoutSessionId: orderId,
+          checkoutCreatedAt: now,
+          amount: 0,
+          currency: "CAD",
+          lastErrorCode: null,
+          lastErrorMessage: null,
+        }),
+        updatedAt: now,
+      },
+      { merge: true }
+    );
+    await writeReferralInitiated({
+      referralId: orderId,
+      landlordId: String(landlordId),
+      applicationId,
+      orderId,
+      returnTo,
+      tuTrackingParams: extractTuTrackingParams(referralUrl),
+    });
+    logTuReferralEvent({
+      orderId,
+      applicationId,
+      landlordId: String(landlordId),
+      redirectUrl: referralUrl,
+    });
+    await writeCanonicalEvent({
+      domain: "screening",
+      action: "checkout_created",
+      actor: {
+        type: role === "admin" ? "admin" : "landlord",
+        role,
+        id: actorId,
+      },
+      resource: {
+        type: "screening_order",
+        id: orderId,
+        parentType: "rental_application",
+        parentId: applicationId,
+      },
+      occurredAt: now,
+      visibility: "internal",
+      summary: "Screening checkout session created",
+      metadata: {
+        applicationId,
+        landlordId,
+        propertyId: application?.propertyId || null,
+        unitId: application?.unitId || null,
+        serviceLevel,
+        totalAmountCents: 0,
+      },
+    });
+    return {
+      status: 200,
+      payload: {
+        ok: true,
+        mode: "transunion_referral",
+        orderId,
+        applicationId,
+        redirectUrl: referralUrl,
+        checkoutUrl: referralUrl,
+        autopilotPolicy,
+        screeningMonetizationSummary: buildScreeningMonetizationSummary(
+          normalizeScreeningMonetizationState({
+            application: {
+              ...application,
+              screeningMonetization: buildScreeningMonetizationPatch({
+                current: application?.screeningMonetization,
+                eligibility: "eligible",
+                paymentStatus: "checkout_created",
+                fulfillmentStatus: "ordered",
+                checkoutSessionId: orderId,
+                checkoutCreatedAt: now,
+                amount: 0,
+                currency: "CAD",
+              }),
+            },
+            latestOrder: { ...orderPayload, stripeCheckoutSessionId: orderId },
+            eligibility: "eligible",
+            amount: 0,
+            currency: "CAD",
+          })
+        ),
+      },
+    };
+  }
+
+  let stripe: any;
+  try {
+    stripe = getStripeClient();
+  } catch (err: any) {
+    if (err?.code === "stripe_not_configured" || err?.message === "stripe_not_configured") {
+      return {
+        status: 400,
+        payload: { ok: false, error: "stripe_not_configured" },
+      };
+    }
+    throw err;
+  }
+
+  const now = Date.now();
+  const orderRef = db.collection("screeningOrders").doc();
+  const orderId = orderRef.id;
+  const aiVerification = serviceLevel === "VERIFIED_AI";
+  const orderPayload: any = {
+    id: orderId,
+    referenceId: buildReferenceId(orderId),
+    landlordId,
+    applicationId,
+    propertyId: application?.propertyId || null,
+    unitId: application?.unitId || null,
+    createdAt: now,
+    amountCents: pricing.baseAmountCents,
+    currency: "CAD",
+    status: "unpaid",
+    paymentStatus: "unpaid",
+    finalized: false,
+    finalizedAt: null,
+    lastStripeEventId: null,
+    amountTotalCents: pricing.totalAmountCents,
+    screeningTier,
+    addons,
+    scoreAddOn,
+    scoreAddOnCents: pricing.scoreAddOnCents,
+    expeditedAddOn,
+    expeditedAddOnCents: pricing.expeditedAddOnCents,
+    provider: providerHealth.provider,
+    inquiryType: "soft",
+    providerRequestId: null,
+    paidAt: null,
+    error: null,
+    serviceLevel,
+    aiVerification,
+    aiPriceCents: aiVerification ? pricing.aiAddOnCents : 0,
+    totalAmountCents: pricing.totalAmountCents,
+    reviewerStatus: "QUEUED",
+    stripeSessionId: null,
+    stripeCheckoutSessionId: null,
+    stripePaymentIntentId: null,
+    stripeChargeId: null,
+    consentGiven: true,
+    consentTimestamp: consent.timestamp,
+    consentVersion: consent.version,
+    consentTextHash: consent.textHash,
+  };
+
+  await orderRef.set(orderPayload, { merge: true });
+
+  const currency = String(orderPayload.currency || "CAD").toLowerCase();
+  const lineItems: any[] = [
+    {
+      price_data: {
+        currency,
+        product_data: { name: "Rental screening" },
+        unit_amount: pricing.baseAmountCents,
+      },
+      quantity: 1,
+    },
+  ];
+  if (pricing.verifiedAddOnCents) {
+    lineItems.push({
+      price_data: {
+        currency,
+        product_data: { name: "Verified screening add-on" },
+        unit_amount: pricing.verifiedAddOnCents,
+      },
+      quantity: 1,
+    });
+  }
+  if (pricing.aiAddOnCents) {
+    lineItems.push({
+      price_data: {
+        currency,
+        product_data: { name: "AI verification add-on" },
+        unit_amount: pricing.aiAddOnCents,
+      },
+      quantity: 1,
+    });
+  }
+  if (pricing.scoreAddOnCents) {
+    lineItems.push({
+      price_data: {
+        currency,
+        product_data: { name: "Credit score add-on" },
+        unit_amount: pricing.scoreAddOnCents,
+      },
+      quantity: 1,
+    });
+  }
+  if (pricing.expeditedAddOnCents) {
+    lineItems.push({
+      price_data: {
+        currency,
+        product_data: { name: "Expedited processing add-on" },
+        unit_amount: pricing.expeditedAddOnCents,
+      },
+      quantity: 1,
+    });
+  }
+
+  const safeInt = (n: unknown) => {
+    const x = Number(n);
+    if (!Number.isFinite(x)) return 0;
+    return Math.round(x);
+  };
+
+  const normalizedLineItems = lineItems.map((item) => ({
+    ...item,
+    price_data: {
+      ...item.price_data,
+      unit_amount: Math.max(0, safeInt(item.price_data?.unit_amount)),
+      currency: String(item.price_data?.currency || currency).toLowerCase(),
+    },
+  }));
+
+  const session = await stripe.checkout.sessions.create({
+    mode: "payment",
+    line_items: normalizedLineItems,
+    client_reference_id: orderId,
+    success_url: successUrl,
+    cancel_url: cancelUrl,
+    metadata: {
+      orderId,
+      applicationId,
+      landlordId,
+      serviceLevel,
+      scoreAddOn: String(scoreAddOn),
+      screeningTier,
+      addons: addons.join(","),
+      totalAmountCents: String(pricing.totalAmountCents),
+    },
+    payment_intent_data: {
+      metadata: {
+        orderId,
+        applicationId,
+        landlordId,
+        serviceLevel,
+        scoreAddOn: String(scoreAddOn),
+        screeningTier,
+        addons: addons.join(","),
+        totalAmountCents: String(pricing.totalAmountCents),
+      },
+    },
+  });
+
+  await orderRef.set(
+    { stripeSessionId: session.id, stripeCheckoutSessionId: session.id, updatedAt: Date.now() },
+    { merge: true }
+  );
+
+  await db.collection("rentalApplications").doc(applicationId).set(
+    {
+      screening: {
+        requested: true,
+        requestedAt: now,
+        status: "PENDING",
+        provider: "STUB",
+        orderId,
+        amountCents: pricing.baseAmountCents,
+        currency: "CAD",
+        paidAt: null,
+        screeningTier,
+        addons,
+        scoreAddOn,
+        scoreAddOnCents: pricing.scoreAddOnCents,
+        expeditedAddOn,
+        expeditedAddOnCents: pricing.expeditedAddOnCents,
+        totalAmountCents: pricing.totalAmountCents,
+        serviceLevel,
+        aiVerification,
+        consentGiven: true,
+        consentTimestamp: consent.timestamp,
+        consentVersion: consent.version,
+        consentTextHash: consent.textHash,
+        ai: null,
+        result: null,
+      },
+      screeningMonetization: buildScreeningMonetizationPatch({
+        current: application?.screeningMonetization,
+        eligibility: "eligible",
+        paymentStatus: "checkout_created",
+        fulfillmentStatus: "ready",
+        checkoutSessionId: session.id,
+        checkoutCreatedAt: now,
+        amount: pricing.totalAmountCents,
+        currency: "CAD",
+        lastErrorCode: null,
+        lastErrorMessage: null,
+      }),
+      updatedAt: now,
+    },
+    { merge: true }
+  );
+
+  await recordScreeningPaymentInitiated({
+    landlordId,
+    propertyId: application?.propertyId || null,
+    unitId: application?.unitId || null,
+    applicationId,
+    screeningOrderId: orderId,
+    amountCents: pricing.totalAmountCents,
+    currency: "CAD",
+    stripeCheckoutSessionId: session.id,
+    serviceLevel,
+    recordedAt: now,
+  });
+  await writeCanonicalEvent({
+    domain: "screening",
+    action: "checkout_created",
+    actor: {
+      type: role === "admin" ? "admin" : "landlord",
+      role,
+      id: actorId,
+    },
+    resource: {
+      type: "screening_order",
+      id: orderId,
+      parentType: "rental_application",
+      parentId: applicationId,
+    },
+    occurredAt: now,
+    visibility: "internal",
+    summary: "Screening checkout session created",
+    metadata: {
+      applicationId,
+      landlordId,
+      propertyId: application?.propertyId || null,
+      unitId: application?.unitId || null,
+      stripeCheckoutSessionId: session.id,
+      serviceLevel,
+      totalAmountCents: pricing.totalAmountCents,
+    },
+  });
+
+  console.log("[screening_checkout] create_session_ok", {
+    ...logBase,
+    event: "create_session_ok",
+  });
+  return {
+    status: 200,
+    payload: {
+      ok: true,
+      checkoutUrl: session.url,
+      autopilotPolicy,
+      screeningMonetizationSummary: buildScreeningMonetizationSummary(
+        normalizeScreeningMonetizationState({
+          application: {
+            ...application,
+            screeningMonetization: buildScreeningMonetizationPatch({
+              current: application?.screeningMonetization,
+              eligibility: "eligible",
+              paymentStatus: "checkout_created",
+              fulfillmentStatus: "ready",
+              checkoutSessionId: session.id,
+              checkoutCreatedAt: now,
+              amount: pricing.totalAmountCents,
+              currency: "CAD",
+            }),
+          },
+          latestOrder: { ...orderPayload, stripeCheckoutSessionId: session.id },
+          eligibility: "eligible",
+          amount: pricing.totalAmountCents,
+          currency: "CAD",
+        })
+      ),
+    },
+  };
 }
 
 function applicantName(app: any): string {
@@ -1238,8 +1744,7 @@ router.post(
           unitId: data?.unitId || null,
         },
       });
-
-      return res.json({
+      const quoteResponse = {
         ...quoteResult,
         autopilotPolicy,
         screeningMonetizationSummary: buildScreeningMonetizationSummary(
@@ -1251,6 +1756,92 @@ router.post(
             currency: pricing.currency,
           })
         ),
+      };
+      if (!isAutomationRequested(body)) {
+        return res.json(quoteResponse);
+      }
+
+      const providerHealth = await getScreeningProviderHealth();
+      const startCheckoutPolicyRequest = buildScreeningPolicyRequest({
+        action: "start_checkout",
+        actorRole: role,
+        actorUserId: String(req.user?.id || req.user?.landlordId || "").trim() || null,
+        applicationId: id,
+        eligibility,
+        application: data,
+        consentComplete: consentCheck.ok,
+        providerReady:
+          isTransUnionReferralMode() ||
+          process.env.NODE_ENV !== "production" ||
+          (providerHealth.configured && providerHealth.preflightOk),
+      });
+      const startCheckoutPolicyResult = evaluatePolicy(startCheckoutPolicyRequest);
+      await writePolicyEvaluatedEvent({
+        request: startCheckoutPolicyRequest,
+        result: startCheckoutPolicyResult,
+        actorType: role === "admin" ? "admin" : "landlord",
+        metadata: {
+          landlordId: data?.landlordId || landlordId,
+          propertyId: data?.propertyId || null,
+          unitId: data?.unitId || null,
+          initiatedFrom: "screening_quote",
+        },
+      });
+      const automation = await executeAutomation({
+        action: "screening.auto_start_checkout",
+        policyResult: startCheckoutPolicyResult,
+        actor: {
+          type: role === "admin" ? "admin" : "landlord",
+          id: String(req.user?.id || req.user?.landlordId || "").trim() || null,
+          role,
+        },
+        resource: {
+          type: "rental_application",
+          id,
+        },
+        visibility: "internal",
+        metadata: {
+          domain: "screening",
+          initiatedFrom: "quote",
+          landlordId: data?.landlordId || landlordId,
+          propertyId: data?.propertyId || null,
+          unitId: data?.unitId || null,
+          policyAction: "start_checkout",
+        },
+        context: {
+          quoteExists: true,
+          existingCheckout: false,
+          alreadyPaid: false,
+          execute: async () => {
+            const execution = await performScreeningCheckoutExecution({
+              req,
+              role,
+              actorId: String(req.user?.id || req.user?.landlordId || "").trim() || null,
+              landlordId: String(landlordId),
+              applicationId: id,
+              application: { ...data, screeningMonetization: monetizationPatch },
+              body,
+              consent,
+              providerHealth,
+              autopilotPolicy,
+              logBase: { route: "screening_quote_automation", applicationId: id },
+            });
+            if (execution.status !== 200) {
+              const executionPayload = execution.payload as any;
+              const error = new Error(String(executionPayload?.error || "AUTOMATION_EXECUTION_FAILED"));
+              (error as any).code =
+                executionPayload?.errorCode || executionPayload?.error || "AUTOMATION_EXECUTION_FAILED";
+              throw error;
+            }
+            return execution.payload;
+          },
+        },
+      });
+
+      return res.json({
+        ...quoteResponse,
+        ...(automation.data && typeof automation.data === "object" ? automation.data : {}),
+        automationResult: automation.automationResult,
       });
     } catch (err: any) {
       console.error("[rental-applications] screening quote failed", err?.message || err);
@@ -1730,292 +2321,20 @@ router.post(
         });
       }
 
-      let stripe: any;
-      try {
-        stripe = getStripeClient();
-      } catch (err: any) {
-        if (err?.code === "stripe_not_configured" || err?.message === "stripe_not_configured") {
-          return res.status(400).json({ ok: false, error: "stripe_not_configured" });
-        }
-        throw err;
-      }
-
-      const now = Date.now();
-      const orderRef = db.collection("screeningOrders").doc();
-      const orderId = orderRef.id;
-      const aiVerification = serviceLevel === "VERIFIED_AI";
-        const orderPayload: any = {
-          id: orderId,
-          referenceId: buildReferenceId(orderId),
-          landlordId,
-          applicationId: id,
-          propertyId: data?.propertyId || null,
-          unitId: data?.unitId || null,
-          createdAt: now,
-          amountCents: pricing.baseAmountCents,
-          currency: "CAD",
-          status: "unpaid",
-          paymentStatus: "unpaid",
-          finalized: false,
-          finalizedAt: null,
-          lastStripeEventId: null,
-          amountTotalCents: pricing.totalAmountCents,
-          screeningTier,
-          addons,
-          scoreAddOn,
-          scoreAddOnCents: pricing.scoreAddOnCents,
-          expeditedAddOn,
-          expeditedAddOnCents: pricing.expeditedAddOnCents,
-          provider: providerHealth.provider,
-          inquiryType: "soft",
-          providerRequestId: null,
-          paidAt: null,
-          error: null,
-          serviceLevel,
-          aiVerification,
-          aiPriceCents: aiVerification ? pricing.aiAddOnCents : 0,
-          totalAmountCents: pricing.totalAmountCents,
-          reviewerStatus: "QUEUED",
-          stripeSessionId: null,
-          stripeCheckoutSessionId: null,
-          stripePaymentIntentId: null,
-          stripeChargeId: null,
-        consentGiven: true,
-        consentTimestamp: consent.timestamp,
-        consentVersion: consent.version,
-        consentTextHash: consent.textHash,
-      };
-
-      await orderRef.set(orderPayload, { merge: true });
-
-      const currency = String(orderPayload.currency || "CAD").toLowerCase();
-      const lineItems: any[] = [
-        {
-          price_data: {
-            currency,
-            product_data: { name: "Rental screening" },
-            unit_amount: pricing.baseAmountCents,
-          },
-          quantity: 1,
-        },
-      ];
-      if (pricing.verifiedAddOnCents) {
-        lineItems.push({
-          price_data: {
-            currency,
-            product_data: { name: "Verified screening add-on" },
-            unit_amount: pricing.verifiedAddOnCents,
-          },
-          quantity: 1,
-        });
-      }
-      if (pricing.aiAddOnCents) {
-        lineItems.push({
-          price_data: {
-            currency,
-            product_data: { name: "AI verification add-on" },
-            unit_amount: pricing.aiAddOnCents,
-          },
-          quantity: 1,
-        });
-      }
-      if (pricing.scoreAddOnCents) {
-        lineItems.push({
-          price_data: {
-            currency,
-            product_data: { name: "Credit score add-on" },
-            unit_amount: pricing.scoreAddOnCents,
-          },
-          quantity: 1,
-        });
-      }
-      if (pricing.expeditedAddOnCents) {
-        lineItems.push({
-          price_data: {
-            currency,
-            product_data: { name: "Expedited processing add-on" },
-            unit_amount: pricing.expeditedAddOnCents,
-          },
-          quantity: 1,
-        });
-      }
-
-      // Ensure Stripe-safe integers
-      const safeInt = (n: unknown) => {
-        const x = Number(n);
-        if (!Number.isFinite(x)) return 0;
-        return Math.round(x);
-      };
-
-      // (Optional) sanity clamp: avoid negative or zero charges accidentally
-      const normalizeLineItems = (items: any[]) =>
-        items.map((it) => ({
-          ...it,
-          price_data: {
-            ...it.price_data,
-            unit_amount: Math.max(0, safeInt(it.price_data?.unit_amount)),
-            currency: String(it.price_data?.currency || currency).toLowerCase(),
-          },
-        }));
-
-      const normalizedLineItems = normalizeLineItems(lineItems);
-
-      const session = await stripe.checkout.sessions.create({
-        mode: "payment",
-        line_items: normalizedLineItems,
-
-        // Use this to correlate in Stripe dashboard & API searches
-        client_reference_id: orderId,
-
-        success_url: successUrl,
-        cancel_url: cancelUrl,
-
-        // Keep lightweight order context here (shows up on the Session)
-        metadata: {
-          orderId,
-          applicationId: id,
-          landlordId,
-          serviceLevel,
-          scoreAddOn: String(scoreAddOn),
-          screeningTier,
-          addons: addons.join(","),
-          totalAmountCents: String(pricing.totalAmountCents),
-        },
-
-        // Recommended: also stamp the PaymentIntent so webhook handling is simpler
-        payment_intent_data: {
-          metadata: {
-            orderId,
-            applicationId: id,
-            landlordId,
-            serviceLevel,
-            scoreAddOn: String(scoreAddOn),
-            screeningTier,
-            addons: addons.join(","),
-            totalAmountCents: String(pricing.totalAmountCents),
-          },
-        },
-      });
-
-      await orderRef.set(
-        { stripeSessionId: session.id, stripeCheckoutSessionId: session.id, updatedAt: Date.now() },
-        { merge: true }
-      );
-
-      await db.collection("rentalApplications").doc(id).set(
-        {
-          screening: {
-            requested: true,
-            requestedAt: now,
-            status: "PENDING",
-            provider: "STUB",
-            orderId,
-            amountCents: pricing.baseAmountCents,
-            currency: "CAD",
-            paidAt: null,
-            screeningTier,
-            addons,
-            scoreAddOn,
-            scoreAddOnCents: pricing.scoreAddOnCents,
-            expeditedAddOn,
-            expeditedAddOnCents: pricing.expeditedAddOnCents,
-            totalAmountCents: pricing.totalAmountCents,
-            serviceLevel,
-            aiVerification,
-            consentGiven: true,
-            consentTimestamp: consent.timestamp,
-            consentVersion: consent.version,
-            consentTextHash: consent.textHash,
-            ai: null,
-            result: null,
-          },
-          screeningMonetization: buildScreeningMonetizationPatch({
-            current: data?.screeningMonetization,
-            eligibility: "eligible",
-            paymentStatus: "checkout_created",
-            fulfillmentStatus: "ready",
-            checkoutSessionId: session.id,
-            checkoutCreatedAt: now,
-            amount: pricing.totalAmountCents,
-            currency: "CAD",
-            lastErrorCode: null,
-            lastErrorMessage: null,
-          }),
-          updatedAt: now,
-        },
-        { merge: true }
-      );
-
-      await recordScreeningPaymentInitiated({
-        landlordId,
-        propertyId: data?.propertyId || null,
-        unitId: data?.unitId || null,
+      const execution = await performScreeningCheckoutExecution({
+        req,
+        role,
+        actorId: String(req.user?.id || req.user?.landlordId || "").trim() || null,
+        landlordId: String(landlordId),
         applicationId: id,
-        screeningOrderId: orderId,
-        amountCents: pricing.totalAmountCents,
-        currency: "CAD",
-        stripeCheckoutSessionId: session.id,
-        serviceLevel,
-        recordedAt: now,
-      });
-      await writeCanonicalEvent({
-        domain: "screening",
-        action: "checkout_created",
-        actor: {
-          type: role === "admin" ? "admin" : "landlord",
-          role,
-          id: String(req.user?.id || req.user?.landlordId || "").trim() || null,
-        },
-        resource: {
-          type: "screening_order",
-          id: orderId,
-          parentType: "rental_application",
-          parentId: id,
-        },
-        occurredAt: now,
-        visibility: "internal",
-        summary: "Screening checkout session created",
-        metadata: {
-          applicationId: id,
-          landlordId,
-          propertyId: data?.propertyId || null,
-          unitId: data?.unitId || null,
-          stripeCheckoutSessionId: session.id,
-          serviceLevel,
-          totalAmountCents: pricing.totalAmountCents,
-        },
-      });
-
-      console.log("[screening_checkout] create_session_ok", {
-        ...logBase,
-        event: "create_session_ok",
-      });
-      return res.json({
-        ok: true,
-        checkoutUrl: session.url,
+        application: data,
+        body,
+        consent,
+        providerHealth,
         autopilotPolicy,
-        screeningMonetizationSummary: buildScreeningMonetizationSummary(
-          normalizeScreeningMonetizationState({
-            application: {
-              ...data,
-              screeningMonetization: buildScreeningMonetizationPatch({
-                current: data?.screeningMonetization,
-                eligibility: "eligible",
-                paymentStatus: "checkout_created",
-                fulfillmentStatus: "ready",
-                checkoutSessionId: session.id,
-                checkoutCreatedAt: now,
-                amount: pricing.totalAmountCents,
-                currency: "CAD",
-              }),
-            },
-            latestOrder: { ...orderPayload, stripeCheckoutSessionId: session.id },
-            eligibility: "eligible",
-            amount: pricing.totalAmountCents,
-            currency: "CAD",
-          })
-        ),
+        logBase,
       });
+      return res.status(execution.status).json(execution.payload);
     } catch (err: any) {
       console.error("[screening_checkout] create_session_fail", {
         ...logBase,

--- a/rentchain-api/src/routes/workOrdersRoutes.ts
+++ b/rentchain-api/src/routes/workOrdersRoutes.ts
@@ -30,8 +30,10 @@ import {
 } from "../lib/maintenanceNotifications";
 import { createTransaction } from "../services/financialTransactionService";
 import { writeCanonicalEvent } from "../lib/events/buildEvent";
+import { executeAutomation } from "../lib/automation/automationExecutor";
 import { buildMaintenancePolicyRequest } from "../lib/policy/policyAdapters";
 import { evaluatePolicy, toAutopilotPolicySummary, writePolicyEvaluatedEvent } from "../lib/policy/policyEvaluator";
+import { MAINTENANCE_AUTO_APPROVAL_THRESHOLD_CENTS } from "../lib/policy/policyRules";
 
 const router = Router();
 
@@ -91,6 +93,16 @@ function asString(value: unknown, max = 2000): string {
 function asOptionalString(value: unknown, max = 2000): string | null {
   const v = asString(value, max);
   return v || null;
+}
+
+function isAutomationRequested(body: any) {
+  return Boolean(body?.automationEnabled || body?.automation?.enabled);
+}
+
+function hasSupportingEvidenceForWorkOrder(workOrder: any) {
+  const evidence = Array.isArray(workOrder?.evidence) ? workOrder.evidence : [];
+  const costAttachments = Array.isArray(workOrder?.costAttachments) ? workOrder.costAttachments : [];
+  return evidence.length > 0 || costAttachments.length > 0;
 }
 
 function uniqueStrings(input: unknown, max = 100): string[] {
@@ -2742,10 +2754,12 @@ router.post("/landlord/work-orders/:id/review-cost", requireAuth, async (req: an
       return res.status(400).json({ ok: false, error: "COST_NOT_SUBMITTED" });
     }
 
-    const decision =
+    const requestedDecision =
       req.body?.decision === "approve" || req.body?.decision === "reject" || req.body?.decision === "revision_requested"
         ? req.body.decision
         : null;
+    const automationRequested = isAutomationRequested(req.body) && !requestedDecision;
+    const decision = requestedDecision || (automationRequested ? "approve" : null);
     if (!decision) return res.status(400).json({ ok: false, error: "INVALID_COST_REVIEW_DECISION" });
     const note = asOptionalString(req.body?.note, 1000);
     if (decision === "revision_requested" && !note) {
@@ -2772,91 +2786,135 @@ router.post("/landlord/work-orders/:id/review-cost", requireAuth, async (req: an
         unitId: asOptionalString((access.item as any)?.unitId, 120),
       },
     });
-    if (decision === "approve" && policyResult.outcome === "block") {
+    if (!automationRequested && decision === "approve" && policyResult.outcome === "block") {
       return res.status(409).json({
         ok: false,
         error: "MAINTENANCE_POLICY_BLOCKED",
         autopilotPolicy,
       });
     }
-    const now = nowMs();
-    const currentRevisionNumber = getCurrentCostRevisionNumber(access.item);
-    const history = normalizeCostReviewHistory((access.item as any)?.costReviewHistory);
-    const reviewStatus = decision === "approve" ? "approved" : decision === "reject" ? "rejected" : "revision_requested";
-    const updatedHistory = history.map((entry) =>
-      entry.revisionNumber === currentRevisionNumber
-        ? {
-            ...entry,
+    const executeDecision = async () => {
+      const now = nowMs();
+      const currentRevisionNumber = getCurrentCostRevisionNumber(access.item);
+      const history = normalizeCostReviewHistory((access.item as any)?.costReviewHistory);
+      const reviewStatus = decision === "approve" ? "approved" : decision === "reject" ? "rejected" : "revision_requested";
+      const updatedHistory = history.map((entry) =>
+        entry.revisionNumber === currentRevisionNumber
+          ? {
+              ...entry,
+              reviewStatus,
+              reviewedAt: now,
+              reviewedBy: access.userId,
+              reviewNote: note,
+            }
+          : entry
+      );
+
+      await db.collection("workOrders").doc(workOrderId).set(
+        {
+          cost: {
+            ...currentCost,
             reviewStatus,
-            reviewedAt: now,
             reviewedBy: access.userId,
+            reviewedAt: now,
             reviewNote: note,
-          }
-        : entry
-    );
-
-    await db.collection("workOrders").doc(workOrderId).set(
-      {
-        cost: {
-          ...currentCost,
-          reviewStatus,
-          reviewedBy: access.userId,
-          reviewedAt: now,
-          reviewNote: note,
-          revisionRequestedAt: decision === "revision_requested" ? now : null,
-          revisionRequestedBy: decision === "revision_requested" ? access.userId : null,
+            revisionRequestedAt: decision === "revision_requested" ? now : null,
+            revisionRequestedBy: decision === "revision_requested" ? access.userId : null,
+          },
+          costReviewHistory: updatedHistory,
+          updatedAtMs: now,
         },
-        costReviewHistory: updatedHistory,
-        updatedAtMs: now,
-      },
-      { merge: true }
-    );
+        { merge: true }
+      );
 
-    await writeWorkOrderUpdate({
-      workOrderId,
-      actorRole: isAdmin(req) ? "admin" : "landlord",
-      actorId: access.userId,
-      updateType: "invoice",
-      message:
-        decision === "approve"
-          ? "Cost submission approved."
-          : decision === "reject"
-          ? `Cost submission rejected.${note ? ` ${note}` : ""}`
-          : `Cost revision requested.${note ? ` ${note}` : ""}`,
-    });
-    if (decision === "approve") {
-      await writeCanonicalEvent({
-        domain: "expense",
-        action: "approved",
-        status: "approved",
+      await writeWorkOrderUpdate({
+        workOrderId,
+        actorRole: isAdmin(req) ? "admin" : "landlord",
+        actorId: access.userId,
+        updateType: "invoice",
+        message:
+          decision === "approve"
+            ? "Cost submission approved."
+            : decision === "reject"
+            ? `Cost submission rejected.${note ? ` ${note}` : ""}`
+            : `Cost revision requested.${note ? ` ${note}` : ""}`,
+      });
+      if (decision === "approve") {
+        await writeCanonicalEvent({
+          domain: "expense",
+          action: "approved",
+          status: "approved",
+          actor: {
+            type: isAdmin(req) ? "admin" : "landlord",
+            role: isAdmin(req) ? "admin" : "landlord",
+            id: access.userId,
+          },
+          resource: {
+            type: "work_order_cost",
+            id: workOrderId,
+            parentType: "work_order",
+            parentId: workOrderId,
+          },
+          occurredAt: now,
+          visibility: "internal",
+          summary: "Maintenance cost approved for expense reconciliation",
+          metadata: {
+            maintenanceRequestId: asOptionalString((access.item as any)?.maintenanceRequestId, 120),
+            propertyId: asOptionalString((access.item as any)?.propertyId, 120),
+            unitId: asOptionalString((access.item as any)?.unitId, 120),
+            actualCostCents: currentCost.actualCostCents,
+            currency: currentCost.currency || "CAD",
+          },
+        });
+      }
+
+      const refreshed = await db.collection("workOrders").doc(workOrderId).get();
+      return await toWorkOrderResponseForAudience(refreshed.id, refreshed.data(), "landlord");
+    };
+
+    if (automationRequested) {
+      const automation = await executeAutomation({
+        action: "maintenance.auto_approve_cost",
+        policyResult,
         actor: {
           type: isAdmin(req) ? "admin" : "landlord",
-          role: isAdmin(req) ? "admin" : "landlord",
           id: access.userId,
+          role: isAdmin(req) ? "admin" : "landlord",
         },
         resource: {
-          type: "work_order_cost",
+          type: "work_order",
           id: workOrderId,
-          parentType: "work_order",
-          parentId: workOrderId,
         },
-        occurredAt: now,
         visibility: "internal",
-        summary: "Maintenance cost approved for expense reconciliation",
         metadata: {
+          domain: "maintenance",
+          landlordId: asOptionalString((access.item as any)?.landlordId, 120),
           maintenanceRequestId: asOptionalString((access.item as any)?.maintenanceRequestId, 120),
           propertyId: asOptionalString((access.item as any)?.propertyId, 120),
           unitId: asOptionalString((access.item as any)?.unitId, 120),
-          actualCostCents: currentCost.actualCostCents,
-          currency: currentCost.currency || "CAD",
+          policyAction: "approve_cost",
         },
+        context: {
+          alreadyApproved: String(currentCost.reviewStatus || "").toLowerCase() === "approved",
+          actualCostCents: currentCost.actualCostCents,
+          thresholdCents: MAINTENANCE_AUTO_APPROVAL_THRESHOLD_CENTS,
+          hasSupportingEvidence: hasSupportingEvidenceForWorkOrder(access.item),
+          execute: executeDecision,
+        },
+      });
+      const fallbackItem = await toWorkOrderResponseForAudience(workOrderId, access.item, "landlord");
+      return res.json({
+        ok: true,
+        item: automation.data || fallbackItem,
+        autopilotPolicy,
+        automationResult: automation.automationResult,
       });
     }
 
-    const refreshed = await db.collection("workOrders").doc(workOrderId).get();
+    const item = await executeDecision();
     return res.json({
       ok: true,
-      item: await toWorkOrderResponseForAudience(refreshed.id, refreshed.data(), "landlord"),
+      item,
       autopilotPolicy,
     });
   } catch (err) {


### PR DESCRIPTION
## Summary
Adds Policy-Aware Automation Actions v1 as a controlled, request-driven automation layer.

This introduces a reusable backend automation executor that only runs actions when policy evaluation explicitly allows them, then wires that executor into screening, maintenance, and lease workflows while emitting canonical automation events.

## Scope
- Adds `automationTypes`, `automationActions`, and `automationExecutor` under `src/lib/automation`
- Supports v1 automation actions:
  - `screening.auto_start_checkout`
  - `maintenance.auto_approve_cost`
  - `lease.auto_send_notice`
- Integrates opt-in automation into:
  - screening quote flow
  - maintenance cost review flow
  - lease notice preview flow
- Emits canonical:
  - `automation.executed`
  - `automation.skipped`
- Adds additive `automationResult` response payloads where automation is attempted
- Adds targeted unit and route tests for executor safety, skip behavior, and workflow integrations

## Notes
This is intentionally additive and policy-gated. Automation only runs when:
- policy outcome is `allow`
- `requiresManualApproval === false`
- prerequisites are present
- no duplicate/completed state blocks execution

There are no background workers, schedulers, or always-on automation behaviors in v1. Automation is explicitly request-driven for backward compatibility and safety.

## Validation
- Passed targeted backend automation/unit/route tests
- Passed backend build