### PR TITLE
feat: add screening monetization reconciliation layer v1

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -99,6 +99,7 @@ import financialTransactionsRoutes from "./routes/financialTransactionsRoutes";
 import workOrdersRoutes from "./routes/workOrdersRoutes";
 import timelineRoutes from "./routes/timelineRoutes";
 import insightRoutes from "./routes/insightRoutes";
+import screeningReconciliationRoutes from "./routes/screeningReconciliationRoutes";
 import transunionRoutes from "./services/integrations/transunion/transunionRoutes";
 import viewingRoutes from "./routes/viewingRoutes";
 import screeningOpsRoutes from "./routes/screeningOpsRoutes";
@@ -216,6 +217,8 @@ app.use("/api", routeSource("timelineRoutes.ts"), timelineRoutes);
 console.log("[route-mount] timelineRoutes mounted at /api");
 app.use("/api", routeSource("insightRoutes.ts"), insightRoutes);
 console.log("[route-mount] insightRoutes mounted at /api");
+app.use("/api", routeSource("screeningReconciliationRoutes.ts"), screeningReconciliationRoutes);
+console.log("[route-mount] screeningReconciliationRoutes mounted at /api");
 
 // Current user info
 app.get("/api/me", async (req: any, res: any, next: any) => {

--- a/rentchain-api/src/lib/reconciliation/deriveScreeningReconciliation.ts
+++ b/rentchain-api/src/lib/reconciliation/deriveScreeningReconciliation.ts
@@ -1,0 +1,298 @@
+import type { CanonicalEventV1 } from "../events/eventTypes";
+import { SCREENING_QUOTE_TTL_MS, normalizeScreeningMonetizationState } from "../../services/screening/screeningMonetizationService";
+import type { ScreeningReconciliationStatus, ScreeningReconciliationV1 } from "./reconciliationTypes";
+
+type FinancialTransactionLike = {
+  type?: string | null;
+  status?: string | null;
+  applicationId?: string | null;
+  createdAt?: number | null;
+  metadata?: Record<string, unknown> | null;
+};
+
+type DeriveScreeningReconciliationInput = {
+  applicationId: string;
+  application?: any;
+  latestOrder?: any;
+  canonicalEvents?: CanonicalEventV1[];
+  financialTransactions?: FinancialTransactionLike[];
+  now?: number;
+};
+
+type NormalizedEvent = CanonicalEventV1 & {
+  __timestampMs: number;
+  __timestampIso: string;
+};
+
+const CHECKOUT_STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000;
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function toIso(value: unknown): string | null {
+  if (value == null || value === "") return null;
+  if (typeof value === "number" && Number.isFinite(value)) return new Date(value).toISOString();
+  const raw = String(value).trim();
+  if (!raw) return null;
+  const parsed = Date.parse(raw);
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : null;
+}
+
+function toMillis(value: unknown): number | null {
+  const iso = toIso(value);
+  if (!iso) return null;
+  const parsed = Date.parse(iso);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function normalizeEvent(event: CanonicalEventV1 | null | undefined): NormalizedEvent | null {
+  if (!event) return null;
+  const timestampMs = toMillis(event.occurredAt) ?? toMillis(event.recordedAt);
+  if (timestampMs == null) return null;
+  const resourceType = asString(event.resource?.type, 120);
+  const resourceId = asString(event.resource?.id, 240);
+  if (!resourceType || !resourceId) return null;
+  return {
+    ...event,
+    __timestampMs: timestampMs,
+    __timestampIso: new Date(timestampMs).toISOString(),
+  };
+}
+
+function sortChronologically(events: NormalizedEvent[]) {
+  return [...events].sort((a, b) => {
+    if (a.__timestampMs !== b.__timestampMs) return a.__timestampMs - b.__timestampMs;
+    return String(a.id || "").localeCompare(String(b.id || ""));
+  });
+}
+
+function firstEventAt(events: NormalizedEvent[], action: string) {
+  return events.find((event) => event.action === action)?.__timestampMs ?? null;
+}
+
+function durationBetween(start: number | null, end: number | null) {
+  if (start == null || end == null || end < start) return null;
+  return end - start;
+}
+
+function countByAction(events: NormalizedEvent[]) {
+  return events.reduce<Record<string, number>>((acc, event) => {
+    const action = asString(event.action, 80).toLowerCase();
+    if (!action) return acc;
+    acc[action] = (acc[action] || 0) + 1;
+    return acc;
+  }, {});
+}
+
+function extractRelatedScreeningEvents(applicationId: string, events: CanonicalEventV1[]) {
+  return sortChronologically(
+    events
+      .map(normalizeEvent)
+      .filter(Boolean)
+      .filter((event) => {
+        if (!event || event.domain !== "screening") return false;
+        const resourceId = asString(event.resource?.id, 240);
+        const parentId = asString(event.resource?.parentId, 240);
+        const metadataApplicationId = asString(event.metadata?.applicationId, 240);
+        return resourceId === applicationId || parentId === applicationId || metadataApplicationId === applicationId;
+      }) as NormalizedEvent[]
+  );
+}
+
+function extractRelatedTransactions(applicationId: string, transactions: FinancialTransactionLike[]) {
+  return (transactions || [])
+    .filter((tx) => asString(tx.applicationId, 240) === applicationId)
+    .sort((a, b) => Number(b.createdAt || 0) - Number(a.createdAt || 0));
+}
+
+function uniqueStrings(values: Array<string | null | undefined>) {
+  return Array.from(new Set(values.map((value) => asString(value, 240)).filter(Boolean)));
+}
+
+function latestMeaningfulTimestamp(params: {
+  events: NormalizedEvent[];
+  latestOrder?: any;
+  monetizationState: ReturnType<typeof normalizeScreeningMonetizationState>;
+}) {
+  const eventTs = params.events[params.events.length - 1]?.__timestampMs ?? null;
+  const orderTs = toMillis(params.latestOrder?.updatedAt) ?? toMillis(params.latestOrder?.createdAt);
+  const stateTs =
+    toMillis(params.monetizationState.paidAt) ??
+    toMillis(params.monetizationState.checkoutCreatedAt) ??
+    toMillis(params.monetizationState.quoteGeneratedAt) ??
+    toMillis(params.monetizationState.lastUpdatedAt);
+  const maxTs = Math.max(eventTs || 0, orderTs || 0, stateTs || 0);
+  return maxTs > 0 ? new Date(maxTs).toISOString() : null;
+}
+
+function buildReason(
+  code: string,
+  message: string,
+  severity: "info" | "warning" | "blocking"
+) {
+  return { code, message, severity };
+}
+
+export function deriveScreeningReconciliation(
+  input: DeriveScreeningReconciliationInput
+): ScreeningReconciliationV1 {
+  const now = typeof input.now === "number" ? input.now : Date.now();
+  const applicationId = asString(input.applicationId, 240);
+  const events = extractRelatedScreeningEvents(applicationId, input.canonicalEvents || []);
+  const transactions = extractRelatedTransactions(applicationId, input.financialTransactions || []);
+  const latestOrder = input.latestOrder || null;
+  const monetizationState = normalizeScreeningMonetizationState({
+    application: input.application,
+    latestOrder,
+    now,
+  });
+
+  const counts = countByAction(events);
+  const quoteCount = counts.quote_generated || 0;
+  const checkoutCount = counts.checkout_created || 0;
+  const paidCount = counts.paid || 0;
+  const completedCount = counts.completed || 0;
+  const blockedCount = counts.blocked || 0;
+
+  const paymentInitiatedCount = transactions.filter((tx) => asString(tx.type, 80) === "payment_initiated").length;
+  const paymentSucceededCount = transactions.filter((tx) => asString(tx.type, 80) === "payment_succeeded").length;
+  const paymentFailedCount = transactions.filter((tx) => asString(tx.type, 80) === "payment_failed").length;
+
+  const hasQuote = quoteCount > 0 || monetizationState.quoteStatus === "generated" || monetizationState.quoteStatus === "expired";
+  const hasCheckout =
+    checkoutCount > 0 ||
+    Boolean(asString(monetizationState.checkoutSessionId, 240)) ||
+    Boolean(asString(latestOrder?.stripeCheckoutSessionId || latestOrder?.stripeSessionId, 240));
+  const hasExplicitPaidSignal = paidCount > 0 || paymentSucceededCount > 0;
+  const hasPaidStateSignal =
+    monetizationState.paymentStatus === "paid" || asString(input.application?.screeningStatus, 80).toLowerCase() === "paid";
+  const hasPaidEvent = hasExplicitPaidSignal;
+  const hasFulfillment =
+    completedCount > 0 || monetizationState.fulfillmentStatus === "completed" || asString(input.application?.screeningStatus, 80).toLowerCase() === "complete";
+  const hasBlockedEvent =
+    blockedCount > 0 ||
+    monetizationState.fulfillmentStatus === "blocked" ||
+    monetizationState.eligibility === "provider_unavailable" ||
+    asString(monetizationState.lastErrorCode, 120) === "SCREENING_PROVIDER_UNAVAILABLE";
+
+  const quoteAt = firstEventAt(events, "quote_generated") ?? toMillis(monetizationState.quoteGeneratedAt);
+  const checkoutAt = firstEventAt(events, "checkout_created") ?? toMillis(monetizationState.checkoutCreatedAt);
+  const paidAt = firstEventAt(events, "paid") ?? toMillis(monetizationState.paidAt);
+  const completedAt = firstEventAt(events, "completed") ?? toMillis(input.application?.screeningCompletedAt);
+  const lastMeaningfulEventAt = latestMeaningfulTimestamp({ events, latestOrder, monetizationState });
+  const inactivityMs = lastMeaningfulEventAt ? Math.max(0, now - Date.parse(lastMeaningfulEventAt)) : null;
+
+  const quoteIds = uniqueStrings([monetizationState.quoteId]);
+  const checkoutIds = uniqueStrings([
+    monetizationState.checkoutSessionId,
+    latestOrder?.stripeCheckoutSessionId,
+    latestOrder?.stripeSessionId,
+    ...events
+      .map((event) => asString(event.metadata?.stripeCheckoutSessionId, 240) || asString(event.metadata?.sessionId, 240))
+      .filter(Boolean),
+  ]);
+  const screeningOrderIds = uniqueStrings([
+    asString(latestOrder?.id, 240),
+    ...events
+      .filter((event) => asString(event.resource?.type, 120) === "screening_order")
+      .map((event) => asString(event.resource?.id, 240)),
+    ...transactions
+      .map((tx) => asString(tx.metadata?.screeningOrderId, 240))
+      .filter(Boolean),
+  ]);
+
+  const hasDuplicateRisk =
+    checkoutCount > 1 || checkoutIds.length > 1 || screeningOrderIds.length > 1;
+
+  const hasMismatch =
+    (hasFulfillment && !hasExplicitPaidSignal) ||
+    ((hasPaidStateSignal || monetizationState.fulfillmentStatus === "completed") && !hasExplicitPaidSignal) ||
+    (paymentFailedCount > 0 && (hasPaidEvent || hasFulfillment)) ||
+    false;
+
+  const reasons: ScreeningReconciliationV1["reasons"] = [];
+  let status: ScreeningReconciliationStatus = "not_started";
+
+  if (hasDuplicateRisk) {
+    status = "duplicate_risk";
+    reasons.push(buildReason("RECON_DUPLICATE_CHECKOUT_RISK", "Multiple screening checkout signals were detected for this application.", "warning"));
+  } else if (hasMismatch) {
+    status = "mismatch";
+    reasons.push(buildReason("RECON_STATE_MISMATCH", "The screening monetization signals are contradictory and need investigation.", "blocking"));
+  } else if (hasBlockedEvent) {
+    status = "blocked";
+    reasons.push(buildReason("RECON_BLOCKED", "The screening monetization flow is explicitly blocked.", "blocking"));
+  } else if (hasPaidEvent && hasFulfillment) {
+    status = "fulfilled";
+    reasons.push(buildReason("RECON_FULFILLED", "Payment and fulfillment signals are both present.", "info"));
+  } else if (hasPaidEvent && !hasFulfillment) {
+    status = "paid_not_fulfilled";
+    reasons.push(buildReason("RECON_PAID_NOT_FULFILLED", "Payment is confirmed but fulfillment has not completed yet.", "warning"));
+  } else if (hasCheckout && paymentInitiatedCount > 0 && !hasPaidEvent) {
+    status = inactivityMs != null && inactivityMs > CHECKOUT_STALE_THRESHOLD_MS ? "abandoned" : "payment_pending";
+    reasons.push(
+      status === "payment_pending"
+        ? buildReason("RECON_ACTIVE_CHECKOUT", "Checkout is active and payment is still pending confirmation.", "info")
+        : buildReason("RECON_ABANDONED_CHECKOUT", "Checkout was created but has gone inactive without payment.", "warning")
+    );
+  } else if (hasCheckout && !hasPaidEvent) {
+    status = inactivityMs != null && inactivityMs > CHECKOUT_STALE_THRESHOLD_MS ? "abandoned" : "checkout_created";
+    reasons.push(
+      status === "checkout_created"
+        ? buildReason("RECON_ACTIVE_CHECKOUT", "Checkout exists and is still within the active window.", "info")
+        : buildReason("RECON_ABANDONED_CHECKOUT", "Checkout was created but appears inactive without payment.", "warning")
+    );
+  } else if (hasQuote && !hasCheckout) {
+    const quoteExpired =
+      monetizationState.quoteStatus === "expired" ||
+      (quoteAt != null && now - quoteAt > SCREENING_QUOTE_TTL_MS);
+    if (quoteExpired) {
+      status = "expired";
+      reasons.push(buildReason("RECON_QUOTE_EXPIRED", "The screening quote expired before checkout started.", "warning"));
+    } else {
+      status = "quoted";
+      reasons.push(buildReason("RECON_QUOTE_ONLY", "A screening quote exists but checkout has not started yet.", "info"));
+    }
+  } else if (!hasQuote && !hasCheckout && !hasPaidEvent && !hasFulfillment) {
+    status = "not_started";
+    reasons.push(buildReason("RECON_NOT_STARTED", "No screening monetization activity has started yet.", "info"));
+  } else {
+    status = "needs_review";
+    reasons.push(buildReason("RECON_NEEDS_REVIEW", "The screening monetization flow has incomplete or suspicious signals and needs review.", "warning"));
+  }
+
+  return {
+    version: "v1",
+    applicationId,
+    generatedAt: new Date(now).toISOString(),
+    status,
+    summary: {
+      hasQuote,
+      hasCheckout,
+      hasPaidEvent,
+      hasFulfillment,
+      hasBlockedEvent,
+      hasDuplicateRisk,
+      hasMismatch,
+      lastMeaningfulEventAt,
+    },
+    metrics: {
+      quoteCount,
+      checkoutCount,
+      paidCount,
+      completedCount,
+      blockedCount,
+      durationQuoteToCheckoutMs: durationBetween(quoteAt, checkoutAt),
+      durationCheckoutToPaidMs: durationBetween(checkoutAt, paidAt),
+      durationPaidToCompletedMs: durationBetween(paidAt, completedAt),
+      inactivityMs,
+    },
+    reasons,
+    linkedIds: {
+      checkoutSessionId: checkoutIds[0] || null,
+      screeningOrderId: screeningOrderIds[0] || null,
+      quoteId: quoteIds[0] || null,
+    },
+  };
+}

--- a/rentchain-api/src/lib/reconciliation/reconciliationTypes.ts
+++ b/rentchain-api/src/lib/reconciliation/reconciliationTypes.ts
@@ -1,0 +1,51 @@
+export type ScreeningReconciliationStatus =
+  | "not_started"
+  | "quoted"
+  | "checkout_created"
+  | "payment_pending"
+  | "paid_not_fulfilled"
+  | "fulfilled"
+  | "blocked"
+  | "expired"
+  | "abandoned"
+  | "mismatch"
+  | "duplicate_risk"
+  | "needs_review";
+
+export type ScreeningReconciliationV1 = {
+  version: "v1";
+  applicationId: string;
+  generatedAt: string;
+  status: ScreeningReconciliationStatus;
+  summary: {
+    hasQuote: boolean;
+    hasCheckout: boolean;
+    hasPaidEvent: boolean;
+    hasFulfillment: boolean;
+    hasBlockedEvent: boolean;
+    hasDuplicateRisk: boolean;
+    hasMismatch: boolean;
+    lastMeaningfulEventAt?: string | null;
+  };
+  metrics: {
+    quoteCount?: number;
+    checkoutCount?: number;
+    paidCount?: number;
+    completedCount?: number;
+    blockedCount?: number;
+    durationQuoteToCheckoutMs?: number | null;
+    durationCheckoutToPaidMs?: number | null;
+    durationPaidToCompletedMs?: number | null;
+    inactivityMs?: number | null;
+  };
+  reasons: Array<{
+    code: string;
+    message: string;
+    severity: "info" | "warning" | "blocking";
+  }>;
+  linkedIds?: {
+    checkoutSessionId?: string | null;
+    screeningOrderId?: string | null;
+    quoteId?: string | null;
+  };
+};

--- a/rentchain-api/src/lib/reconciliation/tests/deriveScreeningReconciliation.test.ts
+++ b/rentchain-api/src/lib/reconciliation/tests/deriveScreeningReconciliation.test.ts
@@ -1,0 +1,302 @@
+import { describe, expect, it } from "vitest";
+import { deriveScreeningReconciliation } from "../deriveScreeningReconciliation";
+import type { CanonicalEventV1 } from "../../events/eventTypes";
+
+function canonicalEvent(overrides: Partial<CanonicalEventV1>): CanonicalEventV1 {
+  return {
+    id: overrides.id || "event-1",
+    version: "v1",
+    type: overrides.type || "screening.quote_generated",
+    domain: overrides.domain || "screening",
+    action: overrides.action || "quote_generated",
+    status: overrides.status ?? null,
+    actor: overrides.actor || { type: "system", role: "system", id: "system" },
+    resource: overrides.resource || { type: "rental_application", id: "app-1" },
+    occurredAt: overrides.occurredAt || "2026-04-01T10:00:00.000Z",
+    recordedAt: overrides.recordedAt || "2026-04-01T10:00:00.000Z",
+    visibility: overrides.visibility || "internal",
+    summary: overrides.summary || "Screening quote generated",
+    metadata: overrides.metadata,
+    metrics: overrides.metrics,
+    tags: overrides.tags,
+  };
+}
+
+describe("deriveScreeningReconciliation", () => {
+  it("derives quoted correctly", () => {
+    const reconciliation = deriveScreeningReconciliation({
+      applicationId: "app-1",
+      application: {
+        screeningMonetization: {
+          quoteStatus: "generated",
+          quoteId: "quote-1",
+          quoteGeneratedAt: "2026-04-01T10:00:00.000Z",
+        },
+      },
+      canonicalEvents: [
+        canonicalEvent({
+          type: "screening.quote_generated",
+          action: "quote_generated",
+        }),
+      ],
+      now: Date.parse("2026-04-01T10:10:00.000Z"),
+    });
+
+    expect(reconciliation.status).toBe("quoted");
+    expect(reconciliation.reasons[0]?.code).toBe("RECON_QUOTE_ONLY");
+  });
+
+  it("derives checkout_created correctly", () => {
+    const reconciliation = deriveScreeningReconciliation({
+      applicationId: "app-1",
+      application: {
+        screeningMonetization: {
+          quoteStatus: "generated",
+          paymentStatus: "checkout_created",
+          checkoutSessionId: "sess_1",
+          checkoutCreatedAt: "2026-04-01T10:05:00.000Z",
+        },
+      },
+      canonicalEvents: [
+        canonicalEvent({ type: "screening.quote_generated", action: "quote_generated" }),
+        canonicalEvent({
+          id: "event-2",
+          type: "screening.checkout_created",
+          action: "checkout_created",
+          resource: { type: "screening_order", id: "order-1", parentType: "rental_application", parentId: "app-1" },
+          occurredAt: "2026-04-01T10:05:00.000Z",
+          summary: "Screening checkout started",
+        }),
+      ],
+      now: Date.parse("2026-04-01T10:10:00.000Z"),
+    });
+
+    expect(reconciliation.status).toBe("checkout_created");
+    expect(reconciliation.reasons[0]?.code).toBe("RECON_ACTIVE_CHECKOUT");
+  });
+
+  it("derives paid_not_fulfilled correctly", () => {
+    const reconciliation = deriveScreeningReconciliation({
+      applicationId: "app-1",
+      application: {
+        screeningMonetization: {
+          paymentStatus: "paid",
+          fulfillmentStatus: "ordered",
+          paidAt: "2026-04-01T10:10:00.000Z",
+        },
+      },
+      canonicalEvents: [
+        canonicalEvent({ type: "screening.quote_generated", action: "quote_generated" }),
+        canonicalEvent({
+          id: "event-2",
+          type: "screening.paid",
+          action: "paid",
+          occurredAt: "2026-04-01T10:10:00.000Z",
+          summary: "Screening payment confirmed",
+        }),
+      ],
+      financialTransactions: [
+        {
+          type: "payment_succeeded",
+          applicationId: "app-1",
+          createdAt: Date.parse("2026-04-01T10:10:00.000Z"),
+        },
+      ],
+    });
+
+    expect(reconciliation.status).toBe("paid_not_fulfilled");
+    expect(reconciliation.reasons[0]?.code).toBe("RECON_PAID_NOT_FULFILLED");
+  });
+
+  it("derives fulfilled correctly", () => {
+    const reconciliation = deriveScreeningReconciliation({
+      applicationId: "app-1",
+      application: {
+        screeningStatus: "complete",
+        screeningCompletedAt: "2026-04-01T10:30:00.000Z",
+        screeningMonetization: {
+          paymentStatus: "paid",
+          fulfillmentStatus: "completed",
+          paidAt: "2026-04-01T10:10:00.000Z",
+        },
+      },
+      canonicalEvents: [
+        canonicalEvent({ type: "screening.quote_generated", action: "quote_generated" }),
+        canonicalEvent({
+          id: "event-2",
+          type: "screening.paid",
+          action: "paid",
+          occurredAt: "2026-04-01T10:10:00.000Z",
+          summary: "Screening payment confirmed",
+        }),
+        canonicalEvent({
+          id: "event-3",
+          type: "screening.completed",
+          action: "completed",
+          occurredAt: "2026-04-01T10:30:00.000Z",
+          summary: "Screening completed",
+        }),
+      ],
+    });
+
+    expect(reconciliation.status).toBe("fulfilled");
+    expect(reconciliation.reasons[0]?.code).toBe("RECON_FULFILLED");
+  });
+
+  it("derives blocked correctly", () => {
+    const reconciliation = deriveScreeningReconciliation({
+      applicationId: "app-1",
+      application: {
+        screeningMonetization: {
+          fulfillmentStatus: "blocked",
+          lastErrorCode: "SCREENING_PROVIDER_UNAVAILABLE",
+        },
+      },
+      canonicalEvents: [
+        canonicalEvent({
+          type: "screening.blocked",
+          action: "blocked",
+          status: "provider_unavailable",
+          summary: "Screening blocked",
+        }),
+      ],
+    });
+
+    expect(reconciliation.status).toBe("blocked");
+    expect(reconciliation.reasons[0]?.code).toBe("RECON_BLOCKED");
+  });
+
+  it("derives expired correctly", () => {
+    const reconciliation = deriveScreeningReconciliation({
+      applicationId: "app-1",
+      application: {
+        screeningMonetization: {
+          quoteStatus: "generated",
+          quoteGeneratedAt: "2026-04-01T10:00:00.000Z",
+        },
+      },
+      canonicalEvents: [canonicalEvent({ type: "screening.quote_generated", action: "quote_generated" })],
+      now: Date.parse("2026-04-01T10:45:00.000Z"),
+    });
+
+    expect(reconciliation.status).toBe("expired");
+    expect(reconciliation.reasons[0]?.code).toBe("RECON_QUOTE_EXPIRED");
+  });
+
+  it("derives abandoned correctly", () => {
+    const reconciliation = deriveScreeningReconciliation({
+      applicationId: "app-1",
+      application: {
+        screeningMonetization: {
+          paymentStatus: "checkout_created",
+          checkoutSessionId: "sess_1",
+          checkoutCreatedAt: "2026-04-01T10:05:00.000Z",
+        },
+      },
+      canonicalEvents: [
+        canonicalEvent({ type: "screening.quote_generated", action: "quote_generated" }),
+        canonicalEvent({
+          id: "event-2",
+          type: "screening.checkout_created",
+          action: "checkout_created",
+          occurredAt: "2026-04-01T10:05:00.000Z",
+          resource: { type: "screening_order", id: "order-1", parentType: "rental_application", parentId: "app-1" },
+          summary: "Screening checkout started",
+        }),
+      ],
+      now: Date.parse("2026-04-02T12:05:00.000Z"),
+    });
+
+    expect(reconciliation.status).toBe("abandoned");
+    expect(reconciliation.reasons[0]?.code).toBe("RECON_ABANDONED_CHECKOUT");
+  });
+
+  it("derives duplicate_risk correctly", () => {
+    const reconciliation = deriveScreeningReconciliation({
+      applicationId: "app-1",
+      application: {
+        screeningMonetization: {
+          paymentStatus: "checkout_created",
+          checkoutSessionId: "sess_2",
+        },
+      },
+      latestOrder: {
+        id: "order-2",
+        applicationId: "app-1",
+        stripeCheckoutSessionId: "sess_2",
+      },
+      canonicalEvents: [
+        canonicalEvent({ type: "screening.quote_generated", action: "quote_generated" }),
+        canonicalEvent({
+          id: "event-2",
+          type: "screening.checkout_created",
+          action: "checkout_created",
+          occurredAt: "2026-04-01T10:05:00.000Z",
+          resource: { type: "screening_order", id: "order-1", parentType: "rental_application", parentId: "app-1" },
+          metadata: { stripeCheckoutSessionId: "sess_1", applicationId: "app-1" },
+          summary: "Screening checkout started",
+        }),
+        canonicalEvent({
+          id: "event-3",
+          type: "screening.checkout_created",
+          action: "checkout_created",
+          occurredAt: "2026-04-01T10:06:00.000Z",
+          resource: { type: "screening_order", id: "order-2", parentType: "rental_application", parentId: "app-1" },
+          metadata: { stripeCheckoutSessionId: "sess_2", applicationId: "app-1" },
+          summary: "Screening checkout started again",
+        }),
+      ],
+    });
+
+    expect(reconciliation.status).toBe("duplicate_risk");
+    expect(reconciliation.reasons[0]?.code).toBe("RECON_DUPLICATE_CHECKOUT_RISK");
+  });
+
+  it("derives mismatch correctly", () => {
+    const reconciliation = deriveScreeningReconciliation({
+      applicationId: "app-1",
+      application: {
+        screeningStatus: "complete",
+        screeningMonetization: {
+          paymentStatus: "paid",
+          fulfillmentStatus: "completed",
+        },
+      },
+      canonicalEvents: [
+        canonicalEvent({
+          type: "screening.completed",
+          action: "completed",
+          summary: "Screening completed",
+        }),
+      ],
+      financialTransactions: [],
+    });
+
+    expect(reconciliation.status).toBe("mismatch");
+    expect(reconciliation.reasons[0]?.code).toBe("RECON_STATE_MISMATCH");
+  });
+
+  it("safely handles partial or malformed event history", () => {
+    const reconciliation = deriveScreeningReconciliation({
+      applicationId: "app-1",
+      application: {},
+      canonicalEvents: [
+        canonicalEvent({
+          occurredAt: "not-a-date",
+          recordedAt: "2026-04-01T10:00:00.000Z",
+          summary: "Broken but recoverable event",
+        }),
+        {
+          ...canonicalEvent({
+            id: "broken-2",
+            resource: { type: "", id: "" } as any,
+          }),
+        },
+      ],
+      now: Date.parse("2026-04-01T10:10:00.000Z"),
+    });
+
+    expect(reconciliation.applicationId).toBe("app-1");
+    expect(reconciliation.status).toBe("quoted");
+  });
+});

--- a/rentchain-api/src/routes/screeningReconciliationRoutes.ts
+++ b/rentchain-api/src/routes/screeningReconciliationRoutes.ts
@@ -1,0 +1,216 @@
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { requireAuth } from "../middleware/requireAuth";
+import type { CanonicalEventV1 } from "../lib/events/eventTypes";
+import { CANONICAL_EVENTS_COLLECTION } from "../lib/events/buildEvent";
+import { deriveScreeningReconciliation } from "../lib/reconciliation/deriveScreeningReconciliation";
+import type { ScreeningReconciliationStatus, ScreeningReconciliationV1 } from "../lib/reconciliation/reconciliationTypes";
+
+const router = Router();
+
+const ALLOWED_STATUSES = new Set<ScreeningReconciliationStatus>([
+  "not_started",
+  "quoted",
+  "checkout_created",
+  "payment_pending",
+  "paid_not_fulfilled",
+  "fulfilled",
+  "blocked",
+  "expired",
+  "abandoned",
+  "mismatch",
+  "duplicate_risk",
+  "needs_review",
+]);
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function normalizeRole(req: any): "admin" | "landlord" | "other" {
+  const role = asString(req.user?.actorRole || req.user?.role, 40).toLowerCase();
+  if (role === "admin") return "admin";
+  if (role === "landlord") return "landlord";
+  return "other";
+}
+
+function parseLimit(value: unknown) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return 20;
+  return Math.max(1, Math.min(100, Math.floor(parsed)));
+}
+
+function parseCursor(value: unknown): { timestamp: string; applicationId: string } | null {
+  const raw = asString(value, 4000);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(Buffer.from(raw, "base64url").toString("utf8"));
+    const timestamp = asString(parsed?.timestamp);
+    const applicationId = asString(parsed?.applicationId);
+    if (!timestamp || !applicationId) return null;
+    return { timestamp, applicationId };
+  } catch {
+    return null;
+  }
+}
+
+function encodeCursor(reconciliation: ScreeningReconciliationV1) {
+  return Buffer.from(
+    JSON.stringify({
+      timestamp: reconciliation.summary.lastMeaningfulEventAt || reconciliation.generatedAt,
+      applicationId: reconciliation.applicationId,
+    }),
+    "utf8"
+  ).toString("base64url");
+}
+
+function compareReconciliationsDescending(a: ScreeningReconciliationV1, b: ScreeningReconciliationV1) {
+  const aTs = Date.parse(a.summary.lastMeaningfulEventAt || a.generatedAt || "");
+  const bTs = Date.parse(b.summary.lastMeaningfulEventAt || b.generatedAt || "");
+  if (bTs !== aTs) return bTs - aTs;
+  return String(b.applicationId || "").localeCompare(String(a.applicationId || ""));
+}
+
+function isVisibleToAdmin(event: CanonicalEventV1) {
+  return event.visibility !== "tenant";
+}
+
+async function loadCanonicalEvents() {
+  const snap = await db.collection(CANONICAL_EVENTS_COLLECTION).get();
+  return (snap.docs || [])
+    .map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }) as CanonicalEventV1)
+    .filter(isVisibleToAdmin);
+}
+
+async function loadFinancialTransactions() {
+  const snap = await db.collection("financialTransactions").get();
+  return (snap.docs || []).map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }));
+}
+
+async function loadScreeningOrders() {
+  const snap = await db.collection("screeningOrders").get();
+  return (snap.docs || []).map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }));
+}
+
+async function loadApplications() {
+  const snap = await db.collection("rentalApplications").get();
+  return (snap.docs || []).map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }));
+}
+
+function latestOrderByApplication(orders: any[]) {
+  const grouped = new Map<string, any[]>();
+  for (const order of orders) {
+    const applicationId = asString(order?.applicationId, 240);
+    if (!applicationId) continue;
+    if (!grouped.has(applicationId)) grouped.set(applicationId, []);
+    grouped.get(applicationId)!.push(order);
+  }
+  const latest = new Map<string, any>();
+  for (const [applicationId, items] of grouped.entries()) {
+    const ordered = [...items].sort(
+      (a, b) => Number(b.updatedAt || b.createdAt || 0) - Number(a.updatedAt || a.createdAt || 0)
+    );
+    latest.set(applicationId, ordered[0]);
+  }
+  return latest;
+}
+
+router.get("/screening-reconciliation/application/:applicationId", requireAuth, async (req: any, res) => {
+  try {
+    if (normalizeRole(req) !== "admin") {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+    const applicationId = asString(req.params?.applicationId, 240);
+    if (!applicationId) {
+      return res.status(400).json({ ok: false, error: "APPLICATION_ID_INVALID" });
+    }
+    const appSnap = await db.collection("rentalApplications").doc(applicationId).get();
+    if (!appSnap.exists) {
+      return res.json({ reconciliation: null });
+    }
+
+    const [canonicalEvents, financialTransactions, orders] = await Promise.all([
+      loadCanonicalEvents(),
+      loadFinancialTransactions(),
+      loadScreeningOrders(),
+    ]);
+    const latestOrder = latestOrderByApplication(orders).get(applicationId) || null;
+    const reconciliation = deriveScreeningReconciliation({
+      applicationId,
+      application: appSnap.data(),
+      latestOrder,
+      canonicalEvents,
+      financialTransactions,
+    });
+
+    return res.json({ reconciliation });
+  } catch (err: any) {
+    console.error("[screening-reconciliation] application fetch failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "SCREENING_RECONCILIATION_FETCH_FAILED" });
+  }
+});
+
+router.get("/screening-reconciliation/summary", requireAuth, async (req: any, res) => {
+  try {
+    if (normalizeRole(req) !== "admin") {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+
+    const status = asString(req.query?.status, 80).toLowerCase();
+    if (status && !ALLOWED_STATUSES.has(status as ScreeningReconciliationStatus)) {
+      return res.status(400).json({ ok: false, error: "STATUS_INVALID" });
+    }
+    const includeNeedsReview = String(req.query?.includeNeedsReview || "true").toLowerCase() !== "false";
+    const limit = parseLimit(req.query?.limit);
+    const cursor = parseCursor(req.query?.cursor);
+
+    const [applications, canonicalEvents, financialTransactions, orders] = await Promise.all([
+      loadApplications(),
+      loadCanonicalEvents(),
+      loadFinancialTransactions(),
+      loadScreeningOrders(),
+    ]);
+    const latestOrders = latestOrderByApplication(orders);
+
+    const reconciliations = applications
+      .filter((application) => {
+        return Boolean(
+          application?.screeningMonetization ||
+            application?.screeningStatus ||
+            latestOrders.has(application.id)
+        );
+      })
+      .map((application) =>
+        deriveScreeningReconciliation({
+          applicationId: application.id,
+          application,
+          latestOrder: latestOrders.get(application.id) || null,
+          canonicalEvents,
+          financialTransactions,
+        })
+      )
+      .filter((reconciliation) => (status ? reconciliation.status === status : true))
+      .filter((reconciliation) => (includeNeedsReview ? true : reconciliation.status !== "needs_review"))
+      .sort(compareReconciliationsDescending);
+
+    const cursorFiltered = cursor
+      ? reconciliations.filter((reconciliation) => {
+          const reconciliationKey = `${reconciliation.summary.lastMeaningfulEventAt || reconciliation.generatedAt}::${reconciliation.applicationId}`;
+          const cursorKey = `${cursor.timestamp}::${cursor.applicationId}`;
+          return reconciliationKey < cursorKey;
+        })
+      : reconciliations;
+
+    const page = cursorFiltered.slice(0, limit);
+    const hasMore = cursorFiltered.length > limit;
+    return res.json({
+      reconciliations: page,
+      nextCursor: hasMore && page.length ? encodeCursor(page[page.length - 1]) : undefined,
+    });
+  } catch (err: any) {
+    console.error("[screening-reconciliation] summary fetch failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "SCREENING_RECONCILIATION_SUMMARY_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-api/src/routes/tests/screeningReconciliationRoutes.test.ts
+++ b/rentchain-api/src/routes/tests/screeningReconciliationRoutes.test.ts
@@ -1,0 +1,289 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { collections, dbMock } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, any>>();
+
+  function ensureCollection(name: string) {
+    if (!collections.has(name)) {
+      collections.set(name, new Map<string, any>());
+    }
+    return collections.get(name)!;
+  }
+
+  return {
+    collections,
+    dbMock: {
+      collection: (name: string) => ({
+        doc: (id?: string) => ({
+          id,
+          async get() {
+            return {
+              id,
+              exists: ensureCollection(name).has(String(id)),
+              data: () => ensureCollection(name).get(String(id)),
+            };
+          },
+        }),
+        async get() {
+          const docs = Array.from(ensureCollection(name).entries()).map(([id, data]) => ({
+            id,
+            data: () => data,
+          }));
+          return { docs, empty: docs.length === 0, size: docs.length };
+        },
+      }),
+    },
+  };
+});
+
+vi.mock("../../config/firebase", () => ({
+  db: dbMock,
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!req.user) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    return next();
+  },
+}));
+
+async function invokeRouter(
+  router: any,
+  options: { method: string; url: string; user?: Record<string, unknown> | null }
+) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    const query = new URLSearchParams(queryString || "");
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: options.user ?? null,
+      query: Object.fromEntries(query.entries()),
+      params: path.split("/").length > 3 ? { applicationId: path.split("/").pop() } : {},
+      headers: {},
+      get(name: string) {
+        return this.headers[String(name).toLowerCase()];
+      },
+      header(name: string) {
+        return this.get(name);
+      },
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, string>,
+      setHeader(name: string, value: string) {
+        this.headers[name.toLowerCase()] = value;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+function seedDoc(collectionName: string, id: string, data: any) {
+  if (!collections.has(collectionName)) {
+    collections.set(collectionName, new Map<string, any>());
+  }
+  collections.get(collectionName)!.set(id, { id, ...data });
+}
+
+describe("screeningReconciliationRoutes", () => {
+  beforeEach(() => {
+    collections.clear();
+  });
+
+  it("lets an admin fetch application reconciliation", async () => {
+    const recentQuoteAt = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    seedDoc("rentalApplications", "app-1", {
+      screeningMonetization: {
+        quoteStatus: "generated",
+        quoteId: "quote-1",
+        quoteGeneratedAt: recentQuoteAt,
+      },
+    });
+    seedDoc("canonicalEvents", "event-1", {
+      version: "v1",
+      type: "screening.quote_generated",
+      domain: "screening",
+      action: "quote_generated",
+      actor: { type: "landlord", role: "landlord", id: "landlord-1" },
+      resource: { type: "rental_application", id: "app-1" },
+      occurredAt: recentQuoteAt,
+      recordedAt: recentQuoteAt,
+      visibility: "internal",
+      summary: "Screening quote generated",
+    });
+
+    const router = (await import("../screeningReconciliationRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/screening-reconciliation/application/app-1",
+      user: { id: "admin-1", role: "admin" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body?.reconciliation).toEqual(
+      expect.objectContaining({
+        applicationId: "app-1",
+        status: "quoted",
+      })
+    );
+  });
+
+  it("lets an admin fetch summary reconciliations", async () => {
+    seedDoc("rentalApplications", "app-1", {
+      screeningMonetization: {
+        quoteStatus: "generated",
+        quoteGeneratedAt: "2026-04-01T10:00:00.000Z",
+      },
+    });
+    seedDoc("rentalApplications", "app-2", {
+      screeningMonetization: {
+        paymentStatus: "paid",
+        fulfillmentStatus: "ordered",
+        paidAt: "2026-04-02T10:00:00.000Z",
+      },
+    });
+    seedDoc("canonicalEvents", "event-1", {
+      version: "v1",
+      type: "screening.quote_generated",
+      domain: "screening",
+      action: "quote_generated",
+      actor: { type: "landlord", role: "landlord", id: "landlord-1" },
+      resource: { type: "rental_application", id: "app-1" },
+      occurredAt: "2026-04-01T10:00:00.000Z",
+      recordedAt: "2026-04-01T10:00:00.000Z",
+      visibility: "internal",
+      summary: "Screening quote generated",
+    });
+    seedDoc("canonicalEvents", "event-2", {
+      version: "v1",
+      type: "screening.paid",
+      domain: "screening",
+      action: "paid",
+      actor: { type: "system", role: "system", id: null },
+      resource: { type: "rental_application", id: "app-2" },
+      occurredAt: "2026-04-02T10:00:00.000Z",
+      recordedAt: "2026-04-02T10:00:00.000Z",
+      visibility: "internal",
+      summary: "Screening paid",
+    });
+    seedDoc("financialTransactions", "tx-1", {
+      applicationId: "app-2",
+      type: "payment_succeeded",
+      createdAt: Date.parse("2026-04-02T10:00:00.000Z"),
+    });
+
+    const router = (await import("../screeningReconciliationRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/screening-reconciliation/summary?limit=10",
+      user: { id: "admin-1", role: "admin" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body?.reconciliations).toHaveLength(2);
+  });
+
+  it("filters summary by status", async () => {
+    seedDoc("rentalApplications", "app-1", {
+      screeningMonetization: {
+        quoteStatus: "generated",
+        quoteGeneratedAt: "2026-04-01T10:00:00.000Z",
+      },
+    });
+    seedDoc("rentalApplications", "app-2", {
+      screeningMonetization: {
+        paymentStatus: "paid",
+        fulfillmentStatus: "ordered",
+        paidAt: "2026-04-02T10:00:00.000Z",
+      },
+    });
+    seedDoc("canonicalEvents", "event-1", {
+      version: "v1",
+      type: "screening.quote_generated",
+      domain: "screening",
+      action: "quote_generated",
+      actor: { type: "landlord", role: "landlord", id: "landlord-1" },
+      resource: { type: "rental_application", id: "app-1" },
+      occurredAt: "2026-04-01T10:00:00.000Z",
+      recordedAt: "2026-04-01T10:00:00.000Z",
+      visibility: "internal",
+      summary: "Screening quote generated",
+    });
+    seedDoc("canonicalEvents", "event-2", {
+      version: "v1",
+      type: "screening.paid",
+      domain: "screening",
+      action: "paid",
+      actor: { type: "system", role: "system", id: null },
+      resource: { type: "rental_application", id: "app-2" },
+      occurredAt: "2026-04-02T10:00:00.000Z",
+      recordedAt: "2026-04-02T10:00:00.000Z",
+      visibility: "internal",
+      summary: "Screening paid",
+    });
+    seedDoc("financialTransactions", "tx-1", {
+      applicationId: "app-2",
+      type: "payment_succeeded",
+      createdAt: Date.parse("2026-04-02T10:00:00.000Z"),
+    });
+
+    const router = (await import("../screeningReconciliationRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/screening-reconciliation/summary?status=paid_not_fulfilled",
+      user: { id: "admin-1", role: "admin" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body?.reconciliations).toHaveLength(1);
+    expect(response.body?.reconciliations[0]?.applicationId).toBe("app-2");
+  });
+
+  it("returns stable validation errors for malformed queries", async () => {
+    const router = (await import("../screeningReconciliationRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/screening-reconciliation/summary?status=nope",
+      user: { id: "admin-1", role: "admin" },
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body?.error).toBe("STATUS_INVALID");
+  });
+
+  it("returns stable empty response shapes", async () => {
+    const router = (await import("../screeningReconciliationRoutes")).default;
+    const applicationResponse = await invokeRouter(router, {
+      method: "GET",
+      url: "/screening-reconciliation/application/app-missing",
+      user: { id: "admin-1", role: "admin" },
+    });
+    expect(applicationResponse.status).toBe(200);
+    expect(applicationResponse.body).toEqual({ reconciliation: null });
+
+    const summaryResponse = await invokeRouter(router, {
+      method: "GET",
+      url: "/screening-reconciliation/summary?limit=10",
+      user: { id: "admin-1", role: "admin" },
+    });
+    expect(summaryResponse.status).toBe(200);
+    expect(summaryResponse.body).toEqual({ reconciliations: [], nextCursor: undefined });
+  });
+});


### PR DESCRIPTION
## Summary
Adds Screening Monetization Reconciliation v1 as an admin-only, read-focused reconciliation layer over normalized monetization state, canonical screening events, screening orders, and payment transaction signals.

This introduces deterministic classification for screening monetization lifecycle states such as `quoted`, `checkout_created`, `payment_pending`, `paid_not_fulfilled`, `fulfilled`, `blocked`, `expired`, `abandoned`, `mismatch`, and `duplicate_risk`.

## Scope
- Adds `reconciliationTypes` and `deriveScreeningReconciliation` under `src/lib/reconciliation`
- Adds:
  - `GET /api/screening-reconciliation/application/:applicationId`
  - `GET /api/screening-reconciliation/summary`
- Supports:
  - status filtering
  - basic cursor pagination
  - optional `includeNeedsReview`
- Derives stable reason codes, summary flags, linked IDs, lifecycle status, and timing metrics
- Adds targeted backend tests for classification correctness, validation, filtering, and empty-state behavior

## Notes
This is intentionally additive and reconciliation-focused. No screening checkout flow, Stripe integration, payment provider architecture, refund logic, or canonical event emission behavior was redesigned.

For v1, the endpoints are admin-only for safety.

A key design rule in this PR is conservative payment evidence:
- explicit paid signals come from canonical events or payment transactions
- state-only “paid” without supporting history is classified as `mismatch`

## Validation
- Passed targeted backend reconciliation tests
- Passed backend build