### PR TITLE
feat: add admin support and debug console v1

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -100,6 +100,7 @@ import workOrdersRoutes from "./routes/workOrdersRoutes";
 import timelineRoutes from "./routes/timelineRoutes";
 import insightRoutes from "./routes/insightRoutes";
 import screeningReconciliationRoutes from "./routes/screeningReconciliationRoutes";
+import supportConsoleRoutes from "./routes/supportConsoleRoutes";
 import transunionRoutes from "./services/integrations/transunion/transunionRoutes";
 import viewingRoutes from "./routes/viewingRoutes";
 import screeningOpsRoutes from "./routes/screeningOpsRoutes";
@@ -219,6 +220,8 @@ app.use("/api", routeSource("insightRoutes.ts"), insightRoutes);
 console.log("[route-mount] insightRoutes mounted at /api");
 app.use("/api", routeSource("screeningReconciliationRoutes.ts"), screeningReconciliationRoutes);
 console.log("[route-mount] screeningReconciliationRoutes mounted at /api");
+app.use("/api/admin", routeSource("supportConsoleRoutes.ts"), supportConsoleRoutes);
+console.log("[route-mount] supportConsoleRoutes mounted at /api/admin");
 
 // Current user info
 app.get("/api/me", async (req: any, res: any, next: any) => {

--- a/rentchain-api/src/lib/supportConsole/__tests__/buildSupportConsoleResource.test.ts
+++ b/rentchain-api/src/lib/supportConsole/__tests__/buildSupportConsoleResource.test.ts
@@ -1,0 +1,350 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { collections, dbMock } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, any>>();
+
+  function ensureCollection(name: string) {
+    if (!collections.has(name)) {
+      collections.set(name, new Map<string, any>());
+    }
+    return collections.get(name)!;
+  }
+
+  return {
+    collections,
+    dbMock: {
+      collection: (name: string) => ({
+        doc: (id?: string) => ({
+          id,
+          async get() {
+            return {
+              id,
+              exists: ensureCollection(name).has(String(id)),
+              data: () => ensureCollection(name).get(String(id)),
+            };
+          },
+        }),
+        async get() {
+          const docs = Array.from(ensureCollection(name).entries()).map(([id, data]) => ({
+            id,
+            data: () => data,
+          }));
+          return { docs, empty: docs.length === 0, size: docs.length };
+        },
+      }),
+    },
+  };
+});
+
+vi.mock("../../../config/firebase", () => ({
+  db: dbMock,
+}));
+
+function seedDoc(collectionName: string, id: string, data: any) {
+  if (!collections.has(collectionName)) {
+    collections.set(collectionName, new Map<string, any>());
+  }
+  collections.get(collectionName)!.set(id, { id, ...data });
+}
+
+describe("buildSupportConsoleResource", () => {
+  beforeEach(() => {
+    collections.clear();
+  });
+
+  it("builds an application console with timeline, insight, policy, automation, and reconciliation", async () => {
+    seedDoc("rentalApplications", "app-1", {
+      applicantName: "Alex Tenant",
+      propertyId: "prop-1",
+      unitId: "unit-2",
+      screeningStatus: "complete",
+      screeningMonetization: {
+        quoteStatus: "generated",
+        quoteGeneratedAt: "2026-04-10T09:00:00.000Z",
+        paymentStatus: "paid",
+        paidAt: "2026-04-10T10:05:00.000Z",
+        fulfillmentStatus: "completed",
+        quoteId: "quote-1",
+        checkoutSessionId: "cs_123",
+      },
+    });
+    seedDoc("screeningOrders", "order-1", {
+      applicationId: "app-1",
+      stripeCheckoutSessionId: "cs_123",
+      updatedAt: Date.parse("2026-04-10T10:10:00.000Z"),
+    });
+    seedDoc("financialTransactions", "tx-1", {
+      applicationId: "app-1",
+      type: "payment_succeeded",
+      createdAt: Date.parse("2026-04-10T10:05:00.000Z"),
+    });
+    seedDoc("canonicalEvents", "event-1", {
+      version: "v1",
+      type: "application.created",
+      domain: "application",
+      action: "created",
+      actor: { type: "landlord", role: "landlord", id: "landlord-1" },
+      resource: { type: "rental_application", id: "app-1" },
+      occurredAt: "2026-04-10T09:00:00.000Z",
+      recordedAt: "2026-04-10T09:00:00.000Z",
+      visibility: "internal",
+      summary: "Application created",
+    });
+    seedDoc("canonicalEvents", "event-2", {
+      version: "v1",
+      type: "screening.quote_generated",
+      domain: "screening",
+      action: "quote_generated",
+      actor: { type: "system", role: "system", id: "system" },
+      resource: { type: "screening_order", id: "order-1", parentType: "rental_application", parentId: "app-1" },
+      occurredAt: "2026-04-10T09:05:00.000Z",
+      recordedAt: "2026-04-10T09:05:00.000Z",
+      visibility: "internal",
+      summary: "Screening quote generated",
+      metadata: { applicationId: "app-1" },
+    });
+    seedDoc("canonicalEvents", "event-3", {
+      version: "v1",
+      type: "policy.evaluated",
+      domain: "policy",
+      action: "evaluated",
+      status: "allow",
+      actor: { type: "landlord", role: "landlord", id: "landlord-1" },
+      resource: { type: "rental_application", id: "app-1" },
+      occurredAt: "2026-04-10T09:06:00.000Z",
+      recordedAt: "2026-04-10T09:06:00.000Z",
+      visibility: "internal",
+      summary: "Policy evaluated for screening.start_checkout",
+      metadata: {
+        domain: "screening",
+        action: "start_checkout",
+        outcome: "allow",
+        topReasonCode: "SCREENING_READY",
+      },
+    });
+    seedDoc("canonicalEvents", "event-4", {
+      version: "v1",
+      type: "automation.executed",
+      domain: "system",
+      action: "executed",
+      actor: { type: "landlord", role: "landlord", id: "landlord-1" },
+      resource: { type: "rental_application", id: "app-1" },
+      occurredAt: "2026-04-10T09:07:00.000Z",
+      recordedAt: "2026-04-10T09:07:00.000Z",
+      visibility: "internal",
+      summary: "Automation executed for screening.auto_start_checkout",
+      metadata: {
+        action: "screening.auto_start_checkout",
+        executed: true,
+        skipped: false,
+        policyOutcome: "allow",
+      },
+    });
+    seedDoc("canonicalEvents", "event-5", {
+      version: "v1",
+      type: "screening.paid",
+      domain: "screening",
+      action: "paid",
+      actor: { type: "system", role: "system", id: "system" },
+      resource: { type: "screening_order", id: "order-1", parentType: "rental_application", parentId: "app-1" },
+      occurredAt: "2026-04-10T10:05:00.000Z",
+      recordedAt: "2026-04-10T10:05:00.000Z",
+      visibility: "internal",
+      summary: "Screening payment completed",
+      metadata: { applicationId: "app-1" },
+    });
+    seedDoc("canonicalEvents", "event-6", {
+      version: "v1",
+      type: "screening.completed",
+      domain: "screening",
+      action: "completed",
+      actor: { type: "system", role: "system", id: "system" },
+      resource: { type: "screening_order", id: "order-1", parentType: "rental_application", parentId: "app-1" },
+      occurredAt: "2026-04-10T10:10:00.000Z",
+      recordedAt: "2026-04-10T10:10:00.000Z",
+      visibility: "internal",
+      summary: "Screening completed",
+      metadata: { applicationId: "app-1" },
+    });
+
+    const { buildSupportConsoleResource } = await import("../buildSupportConsoleResource");
+    const result = await buildSupportConsoleResource({
+      resourceType: "application",
+      resourceId: "app-1",
+    });
+
+    expect(result?.resource).toEqual(
+      expect.objectContaining({
+        type: "application",
+        id: "app-1",
+        title: "Alex Tenant",
+      })
+    );
+    expect(result?.timeline[0]).toEqual(
+      expect.objectContaining({
+        title: "Screening completed",
+        domain: "screening",
+      })
+    );
+    expect(result?.insight).toEqual(
+      expect.objectContaining({
+        domain: "screening",
+        summary: expect.objectContaining({
+          lifecycleState: "completed",
+        }),
+      })
+    );
+    expect(result?.policyDecisions).toEqual([
+      expect.objectContaining({
+        action: "start_checkout",
+        outcome: "allow",
+        reasonCodes: ["SCREENING_READY"],
+      }),
+    ]);
+    expect(result?.automation).toEqual([
+      expect.objectContaining({
+        action: "screening.auto_start_checkout",
+        executed: true,
+        skipped: false,
+      }),
+    ]);
+    expect(result?.reconciliation).toEqual(
+      expect.objectContaining({
+        status: "fulfilled",
+      })
+    );
+    expect(result?.debug).toEqual(
+      expect.objectContaining({
+        canonicalEventCount: 6,
+        domainsPresent: ["application", "policy", "screening", "system"],
+        identifiers: expect.objectContaining({
+          propertyId: "prop-1",
+          checkoutSessionId: "cs_123",
+        }),
+      })
+    );
+  });
+
+  it("builds a maintenance console without reconciliation", async () => {
+    seedDoc("maintenanceRequests", "maint-1", {
+      title: "Leaking sink",
+      propertyId: "prop-9",
+      unitId: "unit-3",
+      status: "assigned",
+    });
+    seedDoc("canonicalEvents", "event-1", {
+      version: "v1",
+      type: "maintenance.request_created",
+      domain: "maintenance",
+      action: "request_created",
+      actor: { type: "tenant", role: "tenant", id: "tenant-1" },
+      resource: { type: "maintenance_request", id: "maint-1" },
+      occurredAt: "2026-04-11T09:00:00.000Z",
+      recordedAt: "2026-04-11T09:00:00.000Z",
+      visibility: "landlord",
+      summary: "Maintenance request submitted",
+    });
+    seedDoc("canonicalEvents", "event-2", {
+      version: "v1",
+      type: "policy.evaluated",
+      domain: "policy",
+      action: "evaluated",
+      status: "review",
+      actor: { type: "landlord", role: "landlord", id: "landlord-1" },
+      resource: { type: "work_order", id: "wo-1" },
+      occurredAt: "2026-04-11T10:00:00.000Z",
+      recordedAt: "2026-04-11T10:00:00.000Z",
+      visibility: "internal",
+      summary: "Policy evaluated for maintenance.approve_cost",
+      metadata: {
+        domain: "maintenance",
+        action: "approve_cost",
+        outcome: "review",
+        topReasonCode: "MAINTENANCE_COST_REVIEW_REQUIRED",
+        maintenanceRequestId: "maint-1",
+      },
+    });
+    seedDoc("canonicalEvents", "event-3", {
+      version: "v1",
+      type: "automation.skipped",
+      domain: "system",
+      action: "skipped",
+      actor: { type: "landlord", role: "landlord", id: "landlord-1" },
+      resource: { type: "work_order", id: "wo-1" },
+      occurredAt: "2026-04-11T10:00:01.000Z",
+      recordedAt: "2026-04-11T10:00:01.000Z",
+      visibility: "internal",
+      summary: "Automation skipped for maintenance.auto_approve_cost",
+      metadata: {
+        action: "maintenance.auto_approve_cost",
+        executed: false,
+        skipped: true,
+        reason: "MAINTENANCE_AUTO_APPROVE_COST_POLICY_REVIEW_REQUIRED",
+        maintenanceRequestId: "maint-1",
+      },
+    });
+
+    const { buildSupportConsoleResource } = await import("../buildSupportConsoleResource");
+    const result = await buildSupportConsoleResource({
+      resourceType: "maintenance",
+      resourceId: "maint-1",
+    });
+
+    expect(result?.resource).toEqual(
+      expect.objectContaining({
+        type: "maintenance",
+        title: "Leaking sink",
+      })
+    );
+    expect(result?.insight).toEqual(
+      expect.objectContaining({
+        domain: "maintenance",
+      })
+    );
+    expect(result?.policyDecisions[0]).toEqual(
+      expect.objectContaining({
+        action: "approve_cost",
+        outcome: "review",
+      })
+    );
+    expect(result?.automation[0]).toEqual(
+      expect.objectContaining({
+        action: "maintenance.auto_approve_cost",
+        executed: false,
+        skipped: true,
+      })
+    );
+    expect(result?.reconciliation).toBeNull();
+  });
+
+  it("returns a stable missing-resource response", async () => {
+    const { buildSupportConsoleResource } = await import("../buildSupportConsoleResource");
+    const result = await buildSupportConsoleResource({
+      resourceType: "lease",
+      resourceId: "lease-missing",
+    });
+
+    expect(result).toEqual({
+      resource: {
+        type: "lease",
+        id: "lease-missing",
+        title: null,
+        subtitle: null,
+        status: null,
+        parentType: null,
+        parentId: null,
+      },
+      timeline: [],
+      insight: null,
+      policyDecisions: [],
+      automation: [],
+      reconciliation: null,
+      debug: {
+        canonicalEventCount: 0,
+        domainsPresent: [],
+        identifiers: {},
+      },
+    });
+  });
+});
+

--- a/rentchain-api/src/lib/supportConsole/buildSupportConsoleResource.ts
+++ b/rentchain-api/src/lib/supportConsole/buildSupportConsoleResource.ts
@@ -1,0 +1,348 @@
+import { db } from "../../config/firebase";
+import { CANONICAL_EVENTS_COLLECTION } from "../events/buildEvent";
+import type { CanonicalEventV1 } from "../events/eventTypes";
+import { deriveInsightForResource } from "../insights/deriveInsights";
+import { deriveScreeningReconciliation } from "../reconciliation/deriveScreeningReconciliation";
+import { canonicalEventToTimelineItem } from "../timeline/timelineAdapter";
+import type {
+  SupportConsoleAutomationItem,
+  SupportConsolePolicyDecision,
+  SupportConsoleResourceResponse,
+} from "./supportConsoleTypes";
+
+type SupportedResourceType = "application" | "maintenance" | "lease";
+
+type NormalizedResourceSpec = {
+  requestedType: SupportedResourceType;
+  canonicalType: "rental_application" | "maintenance_request" | "lease";
+  collectionName: "rentalApplications" | "maintenanceRequests" | "leases";
+};
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function asOptionalString(value: unknown, max = 240) {
+  const next = asString(value, max);
+  return next || null;
+}
+
+function parseTimestamp(value: unknown) {
+  const raw = asString(value, 200);
+  if (!raw) return null;
+  const parsed = Date.parse(raw);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function normalizeResourceType(value: unknown): NormalizedResourceSpec | null {
+  const raw = asString(value, 120).toLowerCase();
+  if (raw === "application" || raw === "rental_application") {
+    return {
+      requestedType: "application",
+      canonicalType: "rental_application",
+      collectionName: "rentalApplications",
+    };
+  }
+  if (raw === "maintenance" || raw === "maintenance_request") {
+    return {
+      requestedType: "maintenance",
+      canonicalType: "maintenance_request",
+      collectionName: "maintenanceRequests",
+    };
+  }
+  if (raw === "lease") {
+    return {
+      requestedType: "lease",
+      canonicalType: "lease",
+      collectionName: "leases",
+    };
+  }
+  return null;
+}
+
+function compareEventsDescending(a: CanonicalEventV1, b: CanonicalEventV1) {
+  const aTs = parseTimestamp(a.occurredAt) ?? parseTimestamp(a.recordedAt) ?? 0;
+  const bTs = parseTimestamp(b.occurredAt) ?? parseTimestamp(b.recordedAt) ?? 0;
+  if (bTs !== aTs) return bTs - aTs;
+  return String(b.id || "").localeCompare(String(a.id || ""));
+}
+
+function domainsPresent(events: CanonicalEventV1[]) {
+  return Array.from(new Set(events.map((event) => asString(event.domain, 40)).filter(Boolean))).sort();
+}
+
+function isVisibleToAdmin(event: CanonicalEventV1) {
+  return event.visibility !== "tenant";
+}
+
+function matchesApplicationResource(resourceId: string, event: CanonicalEventV1) {
+  const exactType = asString(event.resource?.type, 120);
+  const exactId = asString(event.resource?.id, 240);
+  const parentId = asString(event.resource?.parentId, 240);
+  const metadataApplicationId = asString(event.metadata?.applicationId, 240);
+  return (
+    (exactType === "rental_application" && exactId === resourceId) ||
+    parentId === resourceId ||
+    metadataApplicationId === resourceId
+  );
+}
+
+function matchesMaintenanceResource(resourceId: string, event: CanonicalEventV1) {
+  const exactType = asString(event.resource?.type, 120);
+  const exactId = asString(event.resource?.id, 240);
+  const parentId = asString(event.resource?.parentId, 240);
+  const metadataMaintenanceRequestId = asString(event.metadata?.maintenanceRequestId, 240);
+  return (
+    (exactType === "maintenance_request" && exactId === resourceId) ||
+    parentId === resourceId ||
+    metadataMaintenanceRequestId === resourceId
+  );
+}
+
+function matchesLeaseResource(resourceId: string, event: CanonicalEventV1) {
+  return (
+    (asString(event.resource?.type, 120) === "lease" && asString(event.resource?.id, 240) === resourceId) ||
+    asString(event.resource?.parentId, 240) === resourceId
+  );
+}
+
+function isRelatedResource(spec: NormalizedResourceSpec, resourceId: string, event: CanonicalEventV1) {
+  if (spec.requestedType === "application") return matchesApplicationResource(resourceId, event);
+  if (spec.requestedType === "maintenance") return matchesMaintenanceResource(resourceId, event);
+  return matchesLeaseResource(resourceId, event);
+}
+
+function preferredInsightDomain(spec: NormalizedResourceSpec, events: CanonicalEventV1[]) {
+  const domains = new Set(events.map((event) => asString(event.domain, 40)));
+  if (spec.requestedType === "application") {
+    if (domains.has("screening")) return "screening";
+    return "application";
+  }
+  if (spec.requestedType === "maintenance") return "maintenance";
+  return "lease";
+}
+
+function buildPolicyDecisions(events: CanonicalEventV1[]): SupportConsolePolicyDecision[] {
+  return events
+    .filter((event) => event.type === "policy.evaluated")
+    .sort(compareEventsDescending)
+    .map((event) => {
+      const topReasonCode = asOptionalString(event.metadata?.topReasonCode, 120);
+      return {
+        id: event.id,
+        timestamp: event.occurredAt || event.recordedAt,
+        action: asOptionalString(event.metadata?.action, 120),
+        outcome: asOptionalString(event.metadata?.outcome || event.status, 80),
+        reasonCodes: topReasonCode ? [topReasonCode] : [],
+        summary: asOptionalString(event.summary, 500),
+      };
+    });
+}
+
+function buildAutomationHistory(events: CanonicalEventV1[]): SupportConsoleAutomationItem[] {
+  return events
+    .filter((event) => event.type === "automation.executed" || event.type === "automation.skipped")
+    .sort(compareEventsDescending)
+    .map((event) => ({
+      id: event.id,
+      timestamp: event.occurredAt || event.recordedAt,
+      action: asOptionalString(event.metadata?.action, 160),
+      executed: Boolean(event.metadata?.executed === true || event.type === "automation.executed"),
+      skipped: Boolean(event.metadata?.skipped === true || event.type === "automation.skipped"),
+      reason: asOptionalString(event.metadata?.reason, 240),
+      summary: asOptionalString(event.summary, 500),
+    }));
+}
+
+function buildApplicationHeader(resourceId: string, application: any) {
+  const applicantName =
+    asOptionalString(application?.applicantName, 200) ||
+    asOptionalString(application?.fullName, 200) ||
+    asOptionalString(application?.applicantFullName, 200) ||
+    asOptionalString(application?.tenantName, 200);
+  const propertyId = asOptionalString(application?.propertyId, 120);
+  const unitId = asOptionalString(application?.unitId, 120);
+  return {
+    type: "application",
+    id: resourceId,
+    title: applicantName || `Application ${resourceId}`,
+    subtitle:
+      [propertyId ? `Property ${propertyId}` : null, unitId ? `Unit ${unitId}` : null]
+        .filter(Boolean)
+        .join(" • ") || null,
+    status:
+      asOptionalString(application?.screeningStatus, 120) ||
+      asOptionalString(application?.status, 120),
+    parentType: null,
+    parentId: null,
+  };
+}
+
+function buildMaintenanceHeader(resourceId: string, maintenance: any) {
+  const title =
+    asOptionalString(maintenance?.title, 200) ||
+    asOptionalString(maintenance?.issueTitle, 200) ||
+    asOptionalString(maintenance?.category, 200) ||
+    `Maintenance ${resourceId}`;
+  const propertyId = asOptionalString(maintenance?.propertyId, 120);
+  const unitId = asOptionalString(maintenance?.unitId, 120);
+  return {
+    type: "maintenance",
+    id: resourceId,
+    title,
+    subtitle:
+      [propertyId ? `Property ${propertyId}` : null, unitId ? `Unit ${unitId}` : null]
+        .filter(Boolean)
+        .join(" • ") || null,
+    status: asOptionalString(maintenance?.status, 120),
+    parentType: null,
+    parentId: null,
+  };
+}
+
+function buildLeaseHeader(resourceId: string, lease: any) {
+  const tenantName =
+    asOptionalString(lease?.tenantName, 200) ||
+    asOptionalString(lease?.primaryTenantName, 200);
+  const unitId = asOptionalString(lease?.unitId, 120);
+  const propertyId = asOptionalString(lease?.propertyId, 120);
+  return {
+    type: "lease",
+    id: resourceId,
+    title: tenantName || (unitId ? `Lease for unit ${unitId}` : `Lease ${resourceId}`),
+    subtitle:
+      [propertyId ? `Property ${propertyId}` : null, unitId ? `Unit ${unitId}` : null]
+        .filter(Boolean)
+        .join(" • ") || null,
+    status: asOptionalString(lease?.status, 120),
+    parentType: null,
+    parentId: null,
+  };
+}
+
+function buildDebugIdentifiers(spec: NormalizedResourceSpec, doc: any, reconciliation: any) {
+  const identifiers: Record<string, string | null | undefined> = {
+    landlordId: asOptionalString(doc?.landlordId, 120),
+    propertyId: asOptionalString(doc?.propertyId, 120),
+    unitId: asOptionalString(doc?.unitId, 120),
+    tenantId: asOptionalString(doc?.tenantId, 120),
+  };
+
+  if (spec.requestedType === "application") {
+    identifiers.quoteId = asOptionalString(reconciliation?.linkedIds?.quoteId, 240);
+    identifiers.checkoutSessionId = asOptionalString(reconciliation?.linkedIds?.checkoutSessionId, 240);
+    identifiers.screeningOrderId = asOptionalString(reconciliation?.linkedIds?.screeningOrderId, 240);
+  }
+
+  if (spec.requestedType === "maintenance") {
+    identifiers.workOrderId = asOptionalString(doc?.workOrderId, 120);
+  }
+
+  return identifiers;
+}
+
+async function loadCanonicalEvents() {
+  const snap = await db.collection(CANONICAL_EVENTS_COLLECTION).get();
+  return (snap.docs || [])
+    .map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }) as CanonicalEventV1)
+    .filter(isVisibleToAdmin);
+}
+
+async function loadLatestScreeningOrder(applicationId: string) {
+  const snap = await db.collection("screeningOrders").get();
+  const orders = (snap.docs || [])
+    .map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }))
+    .filter((order: any) => asString(order?.applicationId, 240) === applicationId)
+    .sort((a: any, b: any) => Number(b.updatedAt || b.createdAt || 0) - Number(a.updatedAt || a.createdAt || 0));
+  return orders[0] || null;
+}
+
+async function loadFinancialTransactions(applicationId: string) {
+  const snap = await db.collection("financialTransactions").get();
+  return (snap.docs || [])
+    .map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }))
+    .filter((tx: any) => asString(tx?.applicationId, 240) === applicationId);
+}
+
+function emptyResponse(spec: NormalizedResourceSpec, resourceId: string): SupportConsoleResourceResponse {
+  return {
+    resource: {
+      type: spec.requestedType,
+      id: resourceId,
+      title: null,
+      subtitle: null,
+      status: null,
+      parentType: null,
+      parentId: null,
+    },
+    timeline: [],
+    insight: null,
+    policyDecisions: [],
+    automation: [],
+    reconciliation: null,
+    debug: {
+      canonicalEventCount: 0,
+      domainsPresent: [],
+      identifiers: {},
+    },
+  };
+}
+
+export async function buildSupportConsoleResource(input: {
+  resourceType: string;
+  resourceId: string;
+}): Promise<SupportConsoleResourceResponse | null> {
+  const spec = normalizeResourceType(input.resourceType);
+  const resourceId = asString(input.resourceId, 240);
+  if (!spec || !resourceId) return null;
+
+  const snap = await db.collection(spec.collectionName).doc(resourceId).get();
+  if (!snap.exists) {
+    return emptyResponse(spec, resourceId);
+  }
+
+  const doc = snap.data() || {};
+  const canonicalEvents = await loadCanonicalEvents();
+  const relatedEvents = canonicalEvents.filter((event) => isRelatedResource(spec, resourceId, event));
+  const sortedEvents = [...relatedEvents].sort(compareEventsDescending);
+  const insight = deriveInsightForResource(relatedEvents, {
+    resourceType: spec.canonicalType,
+    resourceId,
+    domain: preferredInsightDomain(spec, relatedEvents) as any,
+  });
+
+  let reconciliation: Record<string, unknown> | null = null;
+  if (spec.requestedType === "application") {
+    const [latestOrder, financialTransactions] = await Promise.all([
+      loadLatestScreeningOrder(resourceId),
+      loadFinancialTransactions(resourceId),
+    ]);
+    reconciliation = deriveScreeningReconciliation({
+      applicationId: resourceId,
+      application: doc,
+      latestOrder,
+      canonicalEvents,
+      financialTransactions,
+    }) as Record<string, unknown>;
+  }
+
+  return {
+    resource:
+      spec.requestedType === "application"
+        ? buildApplicationHeader(resourceId, doc)
+        : spec.requestedType === "maintenance"
+        ? buildMaintenanceHeader(resourceId, doc)
+        : buildLeaseHeader(resourceId, doc),
+    timeline: sortedEvents.map(canonicalEventToTimelineItem),
+    insight: (insight as unknown as Record<string, unknown>) || null,
+    policyDecisions: buildPolicyDecisions(relatedEvents),
+    automation: buildAutomationHistory(relatedEvents),
+    reconciliation,
+    debug: {
+      canonicalEventCount: relatedEvents.length,
+      domainsPresent: domainsPresent(relatedEvents),
+      identifiers: buildDebugIdentifiers(spec, doc, reconciliation),
+    },
+  };
+}
+

--- a/rentchain-api/src/lib/supportConsole/supportConsoleTypes.ts
+++ b/rentchain-api/src/lib/supportConsole/supportConsoleTypes.ts
@@ -1,0 +1,45 @@
+import type { TimelineItem } from "../timeline/timelineAdapter";
+
+export type SupportConsoleResourceSummary = {
+  type: string;
+  id: string;
+  title?: string | null;
+  subtitle?: string | null;
+  status?: string | null;
+  parentType?: string | null;
+  parentId?: string | null;
+};
+
+export type SupportConsolePolicyDecision = {
+  id: string;
+  timestamp: string;
+  action?: string | null;
+  outcome?: string | null;
+  reasonCodes?: string[];
+  summary?: string | null;
+};
+
+export type SupportConsoleAutomationItem = {
+  id: string;
+  timestamp: string;
+  action?: string | null;
+  executed: boolean;
+  skipped: boolean;
+  reason?: string | null;
+  summary?: string | null;
+};
+
+export type SupportConsoleResourceResponse = {
+  resource: SupportConsoleResourceSummary;
+  timeline: TimelineItem[];
+  insight?: Record<string, unknown> | null;
+  policyDecisions: SupportConsolePolicyDecision[];
+  automation: SupportConsoleAutomationItem[];
+  reconciliation?: Record<string, unknown> | null;
+  debug: {
+    canonicalEventCount: number;
+    domainsPresent: string[];
+    identifiers?: Record<string, string | null | undefined>;
+  };
+};
+

--- a/rentchain-api/src/routes/__tests__/supportConsoleRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/supportConsoleRoutes.test.ts
@@ -1,0 +1,289 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { collections, dbMock } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, any>>();
+
+  function ensureCollection(name: string) {
+    if (!collections.has(name)) {
+      collections.set(name, new Map<string, any>());
+    }
+    return collections.get(name)!;
+  }
+
+  return {
+    collections,
+    dbMock: {
+      collection: (name: string) => ({
+        doc: (id?: string) => ({
+          id,
+          async get() {
+            return {
+              id,
+              exists: ensureCollection(name).has(String(id)),
+              data: () => ensureCollection(name).get(String(id)),
+            };
+          },
+        }),
+        async get() {
+          const docs = Array.from(ensureCollection(name).entries()).map(([id, data]) => ({
+            id,
+            data: () => data,
+          }));
+          return { docs, empty: docs.length === 0, size: docs.length };
+        },
+      }),
+    },
+  };
+});
+
+vi.mock("../../config/firebase", () => ({
+  db: dbMock,
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!req.user) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    return next();
+  },
+}));
+
+async function invokeRouter(
+  router: any,
+  options: { method: string; url: string; user?: Record<string, unknown> | null }
+) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    const query = new URLSearchParams(queryString || "");
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: options.user ?? null,
+      query: Object.fromEntries(query.entries()),
+      params: {},
+      headers: {},
+      get(name: string) {
+        return this.headers[String(name).toLowerCase()];
+      },
+      header(name: string) {
+        return this.get(name);
+      },
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, string>,
+      setHeader(name: string, value: string) {
+        this.headers[name.toLowerCase()] = value;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+function seedDoc(collectionName: string, id: string, data: any) {
+  if (!collections.has(collectionName)) {
+    collections.set(collectionName, new Map<string, any>());
+  }
+  collections.get(collectionName)!.set(id, { id, ...data });
+}
+
+describe("supportConsoleRoutes", () => {
+  beforeEach(() => {
+    collections.clear();
+  });
+
+  it("returns application support data with reconciliation", async () => {
+    seedDoc("rentalApplications", "app-1", {
+      applicantName: "Jamie Applicant",
+      screeningMonetization: {
+        quoteStatus: "generated",
+        quoteGeneratedAt: "2026-04-10T09:00:00.000Z",
+      },
+    });
+    seedDoc("canonicalEvents", "event-1", {
+      version: "v1",
+      type: "application.created",
+      domain: "application",
+      action: "created",
+      actor: { type: "landlord", role: "landlord", id: "landlord-1" },
+      resource: { type: "rental_application", id: "app-1" },
+      occurredAt: "2026-04-10T09:00:00.000Z",
+      recordedAt: "2026-04-10T09:00:00.000Z",
+      visibility: "internal",
+      summary: "Application created",
+    });
+
+    const router = (await import("../supportConsoleRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/support-console/resource?resourceType=application&resourceId=app-1",
+      user: { id: "admin-1", role: "admin" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        resource: expect.objectContaining({
+          type: "application",
+          id: "app-1",
+        }),
+        timeline: expect.any(Array),
+        insight: expect.anything(),
+        reconciliation: expect.anything(),
+        debug: expect.objectContaining({
+          canonicalEventCount: 1,
+        }),
+      })
+    );
+  });
+
+  it("returns maintenance data without reconciliation", async () => {
+    seedDoc("maintenanceRequests", "maint-1", {
+      title: "Broken heater",
+      status: "submitted",
+    });
+    seedDoc("canonicalEvents", "event-1", {
+      version: "v1",
+      type: "maintenance.request_created",
+      domain: "maintenance",
+      action: "request_created",
+      actor: { type: "tenant", role: "tenant", id: "tenant-1" },
+      resource: { type: "maintenance_request", id: "maint-1" },
+      occurredAt: "2026-04-11T09:00:00.000Z",
+      recordedAt: "2026-04-11T09:00:00.000Z",
+      visibility: "landlord",
+      summary: "Maintenance request submitted",
+    });
+
+    const router = (await import("../supportConsoleRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/support-console/resource?resourceType=maintenance&resourceId=maint-1",
+      user: { id: "admin-1", role: "admin" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body?.resource?.title).toBe("Broken heater");
+    expect(response.body?.reconciliation).toBeNull();
+  });
+
+  it("extracts policy and automation histories", async () => {
+    seedDoc("leases", "lease-1", {
+      tenantName: "Taylor Tenant",
+      status: "draft",
+    });
+    seedDoc("canonicalEvents", "event-1", {
+      version: "v1",
+      type: "policy.evaluated",
+      domain: "policy",
+      action: "evaluated",
+      status: "allow",
+      actor: { type: "landlord", role: "landlord", id: "landlord-1" },
+      resource: { type: "lease", id: "lease-1" },
+      occurredAt: "2026-04-12T09:00:00.000Z",
+      recordedAt: "2026-04-12T09:00:00.000Z",
+      visibility: "internal",
+      summary: "Policy evaluated for lease_notice.send_notice",
+      metadata: {
+        domain: "lease_notice",
+        action: "send_notice",
+        outcome: "allow",
+        topReasonCode: "LEASE_NOTICE_READY",
+      },
+    });
+    seedDoc("canonicalEvents", "event-2", {
+      version: "v1",
+      type: "automation.executed",
+      domain: "system",
+      action: "executed",
+      actor: { type: "landlord", role: "landlord", id: "landlord-1" },
+      resource: { type: "lease", id: "lease-1" },
+      occurredAt: "2026-04-12T09:01:00.000Z",
+      recordedAt: "2026-04-12T09:01:00.000Z",
+      visibility: "internal",
+      summary: "Automation executed for lease.auto_send_notice",
+      metadata: {
+        action: "lease.auto_send_notice",
+        executed: true,
+        skipped: false,
+      },
+    });
+
+    const router = (await import("../supportConsoleRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/support-console/resource?resourceType=lease&resourceId=lease-1",
+      user: { id: "admin-1", role: "admin" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body?.policyDecisions).toEqual([
+      expect.objectContaining({
+        action: "send_notice",
+        outcome: "allow",
+        reasonCodes: ["LEASE_NOTICE_READY"],
+      }),
+    ]);
+    expect(response.body?.automation).toEqual([
+      expect.objectContaining({
+        action: "lease.auto_send_notice",
+        executed: true,
+      }),
+    ]);
+  });
+
+  it("returns a stable response for a missing resource", async () => {
+    const router = (await import("../supportConsoleRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/support-console/resource?resourceType=lease&resourceId=missing",
+      user: { id: "admin-1", role: "admin" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        resource: expect.objectContaining({
+          id: "missing",
+        }),
+        timeline: [],
+        policyDecisions: [],
+        automation: [],
+      })
+    );
+  });
+
+  it("enforces admin-only access and safe validation errors", async () => {
+    const router = (await import("../supportConsoleRoutes")).default;
+    const forbidden = await invokeRouter(router, {
+      method: "GET",
+      url: "/support-console/resource?resourceType=application&resourceId=app-1",
+      user: { id: "landlord-1", role: "landlord" },
+    });
+    expect(forbidden.status).toBe(403);
+    expect(forbidden.body?.error).toBe("FORBIDDEN");
+
+    const invalid = await invokeRouter(router, {
+      method: "GET",
+      url: "/support-console/resource?resourceType=unknown&resourceId=res-1",
+      user: { id: "admin-1", role: "admin" },
+    });
+    expect(invalid.status).toBe(400);
+    expect(invalid.body?.error).toBe("RESOURCE_TYPE_UNSUPPORTED");
+  });
+});

--- a/rentchain-api/src/routes/supportConsoleRoutes.ts
+++ b/rentchain-api/src/routes/supportConsoleRoutes.ts
@@ -1,0 +1,42 @@
+import { Router } from "express";
+import { requireAuth } from "../middleware/requireAuth";
+import { buildSupportConsoleResource } from "../lib/supportConsole/buildSupportConsoleResource";
+
+const router = Router();
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function normalizeRole(req: any): "admin" | "landlord" | "other" {
+  const role = asString(req.user?.actorRole || req.user?.role, 40).toLowerCase();
+  if (role === "admin") return "admin";
+  if (role === "landlord") return "landlord";
+  return "other";
+}
+
+router.get("/support-console/resource", requireAuth, async (req: any, res) => {
+  try {
+    if (normalizeRole(req) !== "admin") {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+
+    const resourceType = asString(req.query?.resourceType, 120);
+    const resourceId = asString(req.query?.resourceId, 240);
+    if (!resourceType || !resourceId) {
+      return res.status(400).json({ ok: false, error: "RESOURCE_QUERY_INVALID" });
+    }
+
+    const payload = await buildSupportConsoleResource({ resourceType, resourceId });
+    if (!payload) {
+      return res.status(400).json({ ok: false, error: "RESOURCE_TYPE_UNSUPPORTED" });
+    }
+
+    return res.json(payload);
+  } catch (err: any) {
+    console.error("[support-console] resource fetch failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "SUPPORT_CONSOLE_FETCH_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -54,6 +54,10 @@ vi.mock("./pages/admin/AutomationTimelineV1Page", () => ({
   default: () => <h1>Automation Timeline v1</h1>,
 }));
 
+vi.mock("./pages/admin/SupportDebugConsolePage", () => ({
+  default: () => <h1>Support / Debug Console</h1>,
+}));
+
 vi.mock("./pages/tenant/TenantWorkspacePage", () => ({
   default: () => <h1>Tenant Dashboard</h1>,
 }));
@@ -145,6 +149,20 @@ describe("Routes: /timeline", () => {
     );
 
     expect(await screen.findByText(/Automation Timeline v1/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Routes: /admin/support-console", () => {
+  it("renders the admin support/debug console route", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/admin/support-console"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Support \/ Debug Console/i)).toBeInTheDocument();
     expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -151,6 +151,7 @@ const AutomationTimelinePage = lazy(
   () => import("./features/automation/timeline/AutomationTimelinePage")
 );
 const AutomationTimelineV1Page = lazy(() => import("./pages/admin/AutomationTimelineV1Page"));
+const SupportDebugConsolePage = lazy(() => import("./pages/admin/SupportDebugConsolePage"));
 
 const AuthLoadingScreen = () => (
   <div
@@ -866,6 +867,16 @@ function App() {
             <RequireAdmin>
               <Suspense fallback={null}>
                 <AutomationTimelineV1Page />
+              </Suspense>
+            </RequireAdmin>
+          }
+        />
+        <Route
+          path="/admin/support-console"
+          element={
+            <RequireAdmin>
+              <Suspense fallback={null}>
+                <SupportDebugConsolePage />
               </Suspense>
             </RequireAdmin>
           }

--- a/rentchain-frontend/src/api/supportConsoleApi.ts
+++ b/rentchain-frontend/src/api/supportConsoleApi.ts
@@ -1,0 +1,52 @@
+import { apiFetch } from "./apiFetch";
+import type { TimelineItem } from "./timelineApi";
+
+export type SupportConsoleResourceResponse = {
+  resource: {
+    type: string;
+    id: string;
+    title?: string | null;
+    subtitle?: string | null;
+    status?: string | null;
+    parentType?: string | null;
+    parentId?: string | null;
+  };
+  timeline: TimelineItem[];
+  insight?: Record<string, unknown> | null;
+  policyDecisions: Array<{
+    id: string;
+    timestamp: string;
+    action?: string | null;
+    outcome?: string | null;
+    reasonCodes?: string[];
+    summary?: string | null;
+  }>;
+  automation: Array<{
+    id: string;
+    timestamp: string;
+    action?: string | null;
+    executed: boolean;
+    skipped: boolean;
+    reason?: string | null;
+    summary?: string | null;
+  }>;
+  reconciliation?: Record<string, unknown> | null;
+  debug: {
+    canonicalEventCount: number;
+    domainsPresent: string[];
+    identifiers?: Record<string, string | null | undefined>;
+  };
+};
+
+export async function fetchSupportConsoleResource(
+  resourceType: string,
+  resourceId: string
+): Promise<SupportConsoleResourceResponse> {
+  const search = new URLSearchParams();
+  search.set("resourceType", resourceType);
+  search.set("resourceId", resourceId);
+  return await apiFetch<SupportConsoleResourceResponse>(
+    `/admin/support-console/resource?${search.toString()}`
+  );
+}
+

--- a/rentchain-frontend/src/components/supportConsole/AutomationHistoryList.tsx
+++ b/rentchain-frontend/src/components/supportConsole/AutomationHistoryList.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+
+type AutomationItem = {
+  id: string;
+  timestamp: string;
+  action?: string | null;
+  executed: boolean;
+  skipped: boolean;
+  reason?: string | null;
+  summary?: string | null;
+};
+
+function formatTimestamp(value: string) {
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return value || "Unknown time";
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(parsed));
+}
+
+export function AutomationHistoryList({ items }: { items: AutomationItem[] }) {
+  if (!items.length) {
+    return <div style={{ color: "#64748b" }}>No automation history recorded for this resource.</div>;
+  }
+
+  return (
+    <div style={{ display: "grid", gap: 10 }}>
+      {items.map((item) => (
+        <article key={item.id} style={{ border: "1px solid rgba(15,23,42,0.08)", borderRadius: 12, padding: 12 }}>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+            <strong>{item.action || "Automation action"}</strong>
+            <span style={{ color: "#64748b" }}>{formatTimestamp(item.timestamp)}</span>
+          </div>
+          <div style={{ color: "#334155", marginTop: 6 }}>{item.summary || "Automation activity recorded."}</div>
+          <div style={{ color: "#475569", marginTop: 6 }}>
+            {item.executed ? "Executed" : "Skipped"}
+            {item.reason ? ` • ${item.reason}` : ""}
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+export default AutomationHistoryList;
+

--- a/rentchain-frontend/src/components/supportConsole/PolicyDecisionList.tsx
+++ b/rentchain-frontend/src/components/supportConsole/PolicyDecisionList.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+
+type PolicyDecision = {
+  id: string;
+  timestamp: string;
+  action?: string | null;
+  outcome?: string | null;
+  reasonCodes?: string[];
+  summary?: string | null;
+};
+
+function formatTimestamp(value: string) {
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return value || "Unknown time";
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(parsed));
+}
+
+export function PolicyDecisionList({ items }: { items: PolicyDecision[] }) {
+  if (!items.length) {
+    return <div style={{ color: "#64748b" }}>No policy decisions recorded for this resource.</div>;
+  }
+
+  return (
+    <div style={{ display: "grid", gap: 10 }}>
+      {items.map((item) => (
+        <article key={item.id} style={{ border: "1px solid rgba(15,23,42,0.08)", borderRadius: 12, padding: 12 }}>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+            <strong>{item.action || "Policy action"}</strong>
+            <span style={{ color: "#64748b" }}>{formatTimestamp(item.timestamp)}</span>
+          </div>
+          <div style={{ color: "#334155", marginTop: 6 }}>{item.summary || "Policy evaluation recorded."}</div>
+          <div style={{ color: "#475569", marginTop: 6 }}>
+            Outcome: {item.outcome || "unknown"}
+            {item.reasonCodes?.length ? ` • Reasons: ${item.reasonCodes.join(", ")}` : ""}
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+export default PolicyDecisionList;
+

--- a/rentchain-frontend/src/components/supportConsole/SupportConsoleHeader.tsx
+++ b/rentchain-frontend/src/components/supportConsole/SupportConsoleHeader.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { Card, Pill } from "../ui/Ui";
+
+type SupportConsoleHeaderProps = {
+  resource: {
+    type: string;
+    id: string;
+    title?: string | null;
+    subtitle?: string | null;
+    status?: string | null;
+  };
+};
+
+export function SupportConsoleHeader({ resource }: SupportConsoleHeaderProps) {
+  return (
+    <Card style={{ display: "grid", gap: 8 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+        <h1 style={{ margin: 0, fontSize: "1.5rem" }}>
+          {resource.title || `${resource.type} ${resource.id}`}
+        </h1>
+        <Pill tone="accent">{resource.type}</Pill>
+        {resource.status ? <Pill tone="default">{resource.status}</Pill> : null}
+      </div>
+      <div style={{ color: "#475569" }}>{resource.subtitle || `Resource ID: ${resource.id}`}</div>
+      <div style={{ color: "#64748b", fontSize: 13 }}>Debug ID: {resource.id}</div>
+    </Card>
+  );
+}
+
+export default SupportConsoleHeader;
+

--- a/rentchain-frontend/src/components/supportConsole/SupportConsoleSection.tsx
+++ b/rentchain-frontend/src/components/supportConsole/SupportConsoleSection.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { Card } from "../ui/Ui";
+
+type SupportConsoleSectionProps = {
+  title: string;
+  children: React.ReactNode;
+};
+
+export function SupportConsoleSection({ title, children }: SupportConsoleSectionProps) {
+  return (
+    <Card style={{ display: "grid", gap: 12 }}>
+      <h2 style={{ margin: 0, fontSize: "1.05rem" }}>{title}</h2>
+      {children}
+    </Card>
+  );
+}
+
+export default SupportConsoleSection;
+

--- a/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.test.tsx
@@ -1,0 +1,182 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import SupportDebugConsolePage from "./SupportDebugConsolePage";
+
+const showToast = vi.fn();
+
+vi.mock("../../api/supportConsoleApi", () => ({
+  fetchSupportConsoleResource: vi.fn(),
+}));
+
+vi.mock("../../components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast }),
+}));
+
+vi.mock("../../components/layout/MacShell", () => ({
+  MacShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("../../components/ui/Ui", () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  Pill: ({ children }: any) => <span>{children}</span>,
+  Section: ({ children }: any) => <section>{children}</section>,
+}));
+
+beforeEach(() => {
+  showToast.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function renderPage(initialEntry = "/admin/support-console") {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route path="/admin/support-console" element={<SupportDebugConsolePage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe("SupportDebugConsolePage", () => {
+  it("renders loaded support console sections", async () => {
+    const { fetchSupportConsoleResource } = await import("../../api/supportConsoleApi");
+    vi.mocked(fetchSupportConsoleResource).mockResolvedValue({
+      resource: {
+        type: "application",
+        id: "app-1",
+        title: "Alex Tenant",
+        subtitle: "Property prop-1 • Unit unit-1",
+        status: "complete",
+      },
+      timeline: [
+        {
+          id: "event-1",
+          title: "Screening completed",
+          description: "Screening completed for this application.",
+          timestamp: "2026-04-12T10:00:00.000Z",
+          domain: "screening",
+          status: "completed",
+          actor: "System",
+        },
+      ],
+      insight: {
+        domain: "screening",
+        summary: { lifecycleState: "completed" },
+      },
+      policyDecisions: [
+        {
+          id: "policy-1",
+          timestamp: "2026-04-12T09:00:00.000Z",
+          action: "start_checkout",
+          outcome: "allow",
+          reasonCodes: ["SCREENING_READY"],
+          summary: "Policy evaluated for screening.start_checkout",
+        },
+      ],
+      automation: [
+        {
+          id: "automation-1",
+          timestamp: "2026-04-12T09:01:00.000Z",
+          action: "screening.auto_start_checkout",
+          executed: true,
+          skipped: false,
+          summary: "Automation executed for screening.auto_start_checkout",
+        },
+      ],
+      reconciliation: {
+        status: "fulfilled",
+        reasons: [{ code: "RECON_FULFILLED" }],
+      },
+      debug: {
+        canonicalEventCount: 4,
+        domainsPresent: ["application", "screening"],
+        identifiers: { propertyId: "prop-1" },
+      },
+    } as any);
+
+    renderPage("/admin/support-console?resourceType=application&resourceId=app-1");
+
+    expect(await screen.findByText(/Alex Tenant/i)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Derived insight/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /^Reconciliation$/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Policy decisions/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Automation history/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /^Timeline$/i })).toBeInTheDocument();
+    expect(screen.getByText(/Screening completed for this application/i)).toBeInTheDocument();
+  });
+
+  it("renders an empty state before a lookup", async () => {
+    renderPage();
+    expect(
+      screen.getByText(/Enter a resource type and ID to inspect timeline, policy, automation, and reconciliation state/i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders an error state", async () => {
+    const { fetchSupportConsoleResource } = await import("../../api/supportConsoleApi");
+    vi.mocked(fetchSupportConsoleResource).mockRejectedValue(new Error("Boom"));
+
+    renderPage();
+    fireEvent.change(screen.getByLabelText(/Resource ID/i), { target: { value: "lease-1" } });
+    fireEvent.click(screen.getByRole("button", { name: /Inspect resource/i }));
+
+    expect(await screen.findByText(/Failed to load support console: Boom/i)).toBeInTheDocument();
+  });
+
+  it("renders policy and automation sections when present and hides reconciliation when not applicable", async () => {
+    const { fetchSupportConsoleResource } = await import("../../api/supportConsoleApi");
+    vi.mocked(fetchSupportConsoleResource).mockResolvedValue({
+      resource: {
+        type: "maintenance",
+        id: "maint-1",
+        title: "Broken heater",
+      },
+      timeline: [],
+      insight: { summary: { lifecycleState: "assigned" } },
+      policyDecisions: [
+        {
+          id: "policy-1",
+          timestamp: "2026-04-12T09:00:00.000Z",
+          action: "approve_cost",
+          outcome: "review",
+          reasonCodes: ["MAINTENANCE_COST_REVIEW_REQUIRED"],
+        },
+      ],
+      automation: [
+        {
+          id: "automation-1",
+          timestamp: "2026-04-12T09:01:00.000Z",
+          action: "maintenance.auto_approve_cost",
+          executed: false,
+          skipped: true,
+          reason: "MAINTENANCE_AUTO_APPROVE_COST_POLICY_REVIEW_REQUIRED",
+        },
+      ],
+      reconciliation: null,
+      debug: {
+        canonicalEventCount: 2,
+        domainsPresent: ["maintenance", "policy", "system"],
+        identifiers: {},
+      },
+    } as any);
+
+    renderPage();
+    fireEvent.change(screen.getByLabelText(/Resource type/i), { target: { value: "maintenance" } });
+    fireEvent.change(screen.getByLabelText(/Resource ID/i), { target: { value: "maint-1" } });
+    fireEvent.click(screen.getByRole("button", { name: /Inspect resource/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Broken heater/i)).toBeInTheDocument();
+      expect(screen.getByText(/^approve_cost$/i)).toBeInTheDocument();
+      expect(screen.getByText(/^maintenance\.auto_approve_cost$/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/^Reconciliation$/i)).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.tsx
+++ b/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.tsx
@@ -1,0 +1,176 @@
+import React from "react";
+import { useSearchParams } from "react-router-dom";
+import { fetchSupportConsoleResource, type SupportConsoleResourceResponse } from "../../api/supportConsoleApi";
+import { Timeline } from "../../components/timeline/Timeline";
+import { MacShell } from "../../components/layout/MacShell";
+import { Button, Card, Section } from "../../components/ui/Ui";
+import { useToast } from "../../components/ui/ToastProvider";
+import SupportConsoleHeader from "../../components/supportConsole/SupportConsoleHeader";
+import SupportConsoleSection from "../../components/supportConsole/SupportConsoleSection";
+import PolicyDecisionList from "../../components/supportConsole/PolicyDecisionList";
+import AutomationHistoryList from "../../components/supportConsole/AutomationHistoryList";
+
+const RESOURCE_OPTIONS = [
+  { label: "Application", value: "application" },
+  { label: "Maintenance", value: "maintenance" },
+  { label: "Lease", value: "lease" },
+];
+
+function renderKeyValueList(value: Record<string, unknown> | null | undefined) {
+  const entries = Object.entries(value || {}).filter(([, entry]) => entry != null && entry !== "");
+  if (!entries.length) return <div style={{ color: "#64748b" }}>No derived data available.</div>;
+  return (
+    <div style={{ display: "grid", gap: 8 }}>
+      {entries.map(([key, entry]) => (
+        <div key={key}>
+          <strong>{key}</strong>: {typeof entry === "object" ? JSON.stringify(entry) : String(entry)}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function SupportDebugConsolePage() {
+  const { showToast } = useToast();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [resourceType, setResourceType] = React.useState(searchParams.get("resourceType") || "application");
+  const [resourceId, setResourceId] = React.useState(searchParams.get("resourceId") || "");
+  const [payload, setPayload] = React.useState<SupportConsoleResourceResponse | null>(null);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const load = React.useCallback(
+    async (nextType: string, nextId: string) => {
+      const safeId = String(nextId || "").trim();
+      if (!safeId) {
+        setPayload(null);
+        setError(null);
+        return;
+      }
+
+      try {
+        setLoading(true);
+        setError(null);
+        const response = await fetchSupportConsoleResource(nextType, safeId);
+        setPayload(response);
+        setSearchParams({ resourceType: nextType, resourceId: safeId });
+      } catch (err: any) {
+        const message = err?.message || "Failed to load support console";
+        setPayload(null);
+        setError(message);
+        showToast({
+          message: "Failed to load support console",
+          description: message,
+          variant: "error",
+        });
+      } finally {
+        setLoading(false);
+      }
+    },
+    [setSearchParams, showToast]
+  );
+
+  React.useEffect(() => {
+    const initialType = searchParams.get("resourceType") || "application";
+    const initialId = searchParams.get("resourceId") || "";
+    if (initialId) {
+      setResourceType(initialType);
+      setResourceId(initialId);
+      void load(initialType, initialId);
+    }
+  }, [load, searchParams]);
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    void load(resourceType, resourceId);
+  };
+
+  return (
+    <MacShell title="Admin · Support / Debug Console">
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "grid", gap: 6 }}>
+            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Support / Debug Console</h1>
+            <div style={{ color: "#475569", maxWidth: 820 }}>
+              Inspect one resource and see its timeline, derived state, policy history, automation behavior, and screening reconciliation in a single admin-only view.
+            </div>
+          </div>
+        </Section>
+
+        <Card>
+          <form onSubmit={handleSubmit} style={{ display: "grid", gap: 12 }}>
+            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 12 }}>
+              <label style={{ display: "grid", gap: 4 }}>
+                <span style={{ color: "#64748b", fontSize: 12 }}>Resource type</span>
+                <select value={resourceType} onChange={(event) => setResourceType(event.target.value)}>
+                  {RESOURCE_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label style={{ display: "grid", gap: 4 }}>
+                <span style={{ color: "#64748b", fontSize: 12 }}>Resource ID</span>
+                <input
+                  aria-label="Resource ID"
+                  value={resourceId}
+                  onChange={(event) => setResourceId(event.target.value)}
+                  placeholder="app-123"
+                />
+              </label>
+            </div>
+            <div>
+              <Button type="submit" disabled={loading}>
+                {loading ? "Loading..." : "Inspect resource"}
+              </Button>
+            </div>
+          </form>
+        </Card>
+
+        {loading ? <Card>Loading support console…</Card> : null}
+        {!loading && !error && !payload ? (
+          <Card>Enter a resource type and ID to inspect timeline, policy, automation, and reconciliation state.</Card>
+        ) : null}
+        {!loading && error ? <Card style={{ color: "#b91c1c" }}>Failed to load support console: {error}</Card> : null}
+
+        {!loading && !error && payload ? (
+          <>
+            <SupportConsoleHeader resource={payload.resource} />
+
+            <SupportConsoleSection title="Derived insight">
+              {renderKeyValueList(payload.insight || null)}
+            </SupportConsoleSection>
+
+            {payload.reconciliation ? (
+              <SupportConsoleSection title="Reconciliation">
+                {renderKeyValueList(payload.reconciliation)}
+              </SupportConsoleSection>
+            ) : null}
+
+            <SupportConsoleSection title="Policy decisions">
+              <PolicyDecisionList items={payload.policyDecisions} />
+            </SupportConsoleSection>
+
+            <SupportConsoleSection title="Automation history">
+              <AutomationHistoryList items={payload.automation} />
+            </SupportConsoleSection>
+
+            <SupportConsoleSection title="Timeline">
+              <Timeline items={payload.timeline} emptyMessage="No canonical timeline activity is available for this resource." />
+            </SupportConsoleSection>
+
+            <SupportConsoleSection title="Debug metadata">
+              {renderKeyValueList({
+                canonicalEventCount: payload.debug.canonicalEventCount,
+                domainsPresent: payload.debug.domainsPresent.join(", "),
+                ...(payload.debug.identifiers || {}),
+              })}
+            </SupportConsoleSection>
+          </>
+        ) : null}
+      </div>
+    </MacShell>
+  );
+}
+


### PR DESCRIPTION
## Summary
Adds Support / Debug Console v1 as an admin-only diagnostic surface for single-resource inspection.

This introduces a new backend support-console aggregator route plus a new admin page that unifies canonical timeline activity, derived insights, recorded policy decisions, automation history, screening reconciliation, and debug metadata for applications, maintenance requests, and leases.

## Scope
- Adds backend support-console types and an aggregator over existing read layers
- Adds `GET /api/admin/support-console/resource?resourceType=&resourceId=`
- Supports v1 resource inspection for:
  - application
  - maintenance
  - lease
- Reuses:
  - canonical event reads
  - timeline adapter
  - insight derivation
  - screening reconciliation derivation
  - recorded canonical policy/automation events
- Adds a new admin-only frontend route at `/admin/support-console`
- Reuses the existing timeline UI and adds lightweight support/debug console components
- Adds targeted backend and frontend tests for loaded, empty, error, and null-safe states

## Notes
This is intentionally additive, admin-only, and read/diagnostic only. No write-path behavior, workflow logic, policy logic, monetization logic, or automation execution logic was changed.

For v1, the console is single-resource and exact-resource focused, with only low-risk related-event expansion where canonical metadata already makes it safe.

## Validation
- Passed targeted backend support-console tests
- Passed backend build
- Passed targeted frontend support-console and route tests
- Passed frontend build
- Passed full frontend test suite