### PR TITLE
feat: add admin triage queue v1

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -101,6 +101,7 @@ import timelineRoutes from "./routes/timelineRoutes";
 import insightRoutes from "./routes/insightRoutes";
 import screeningReconciliationRoutes from "./routes/screeningReconciliationRoutes";
 import supportConsoleRoutes from "./routes/supportConsoleRoutes";
+import adminTriageRoutes from "./routes/adminTriageRoutes";
 import transunionRoutes from "./services/integrations/transunion/transunionRoutes";
 import viewingRoutes from "./routes/viewingRoutes";
 import screeningOpsRoutes from "./routes/screeningOpsRoutes";
@@ -222,6 +223,8 @@ app.use("/api", routeSource("screeningReconciliationRoutes.ts"), screeningReconc
 console.log("[route-mount] screeningReconciliationRoutes mounted at /api");
 app.use("/api/admin", routeSource("supportConsoleRoutes.ts"), supportConsoleRoutes);
 console.log("[route-mount] supportConsoleRoutes mounted at /api/admin");
+app.use("/api/admin", routeSource("adminTriageRoutes.ts"), adminTriageRoutes);
+console.log("[route-mount] adminTriageRoutes mounted at /api/admin");
 
 // Current user info
 app.get("/api/me", async (req: any, res: any, next: any) => {

--- a/rentchain-api/src/lib/triage/__tests__/deriveAdminTriageQueue.test.ts
+++ b/rentchain-api/src/lib/triage/__tests__/deriveAdminTriageQueue.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "vitest";
+import { deriveAdminTriageQueue } from "../deriveAdminTriageQueue";
+
+function canonicalEvent(id: string, data: any) {
+  return {
+    id,
+    version: "v1",
+    actor: { type: "system", role: "system", id: "system" },
+    visibility: "internal",
+    recordedAt: data.occurredAt,
+    summary: data.summary || data.type,
+    ...data,
+  };
+}
+
+describe("deriveAdminTriageQueue", () => {
+  it("maps screening reconciliation states into triage items", () => {
+    const items = deriveAdminTriageQueue({
+      now: Date.parse("2026-04-15T12:00:00.000Z"),
+      applications: [
+        {
+          id: "app-1",
+          applicantName: "Alex Applicant",
+          screeningMonetization: {
+            paymentStatus: "paid",
+            paidAt: "2026-04-15T08:00:00.000Z",
+            fulfillmentStatus: "ordered",
+          },
+        },
+      ],
+      canonicalEvents: [
+        canonicalEvent("event-1", {
+          type: "screening.paid",
+          domain: "screening",
+          action: "paid",
+          resource: { type: "rental_application", id: "app-1" },
+          occurredAt: "2026-04-15T08:00:00.000Z",
+        }),
+      ],
+      screeningOrders: [],
+      financialTransactions: [
+        {
+          applicationId: "app-1",
+          type: "payment_succeeded",
+          createdAt: Date.parse("2026-04-15T08:00:00.000Z"),
+        },
+      ],
+    });
+
+    expect(items[0]).toEqual(
+      expect.objectContaining({
+        category: "screening_reconciliation",
+        severity: "critical",
+        reason: expect.objectContaining({
+          code: "TRIAGE_PAID_NOT_FULFILLED",
+        }),
+        resource: expect.objectContaining({
+          type: "application",
+          id: "app-1",
+        }),
+      })
+    );
+  });
+
+  it("maps latest policy review and block events correctly", () => {
+    const items = deriveAdminTriageQueue({
+      applications: [
+        { id: "app-1", applicantName: "Alex Applicant" },
+      ],
+      canonicalEvents: [
+        canonicalEvent("event-1", {
+          type: "policy.evaluated",
+          domain: "policy",
+          action: "evaluated",
+          status: "review",
+          resource: { type: "rental_application", id: "app-1" },
+          occurredAt: "2026-04-15T09:00:00.000Z",
+          metadata: {
+            action: "start_checkout",
+            outcome: "review",
+            topReasonCode: "SCREENING_REVIEW_REQUIRED",
+          },
+        }),
+      ],
+    });
+
+    expect(items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          category: "policy_review",
+          severity: "medium",
+          reason: expect.objectContaining({
+            code: "TRIAGE_POLICY_REVIEW_REQUIRED",
+          }),
+          signals: expect.objectContaining({
+            policyOutcome: "review",
+          }),
+        }),
+      ])
+    );
+  });
+
+  it("maps skipped automation correctly", () => {
+    const items = deriveAdminTriageQueue({
+      leases: [{ id: "lease-1", tenantName: "Taylor Tenant" }],
+      canonicalEvents: [
+        canonicalEvent("event-1", {
+          type: "automation.skipped",
+          domain: "system",
+          action: "skipped",
+          resource: { type: "lease", id: "lease-1" },
+          occurredAt: "2026-04-15T10:00:00.000Z",
+          metadata: {
+            action: "lease.auto_send_notice",
+            skipped: true,
+            reason: "LEASE_AUTO_SEND_NOTICE_POLICY_BLOCKED",
+          },
+        }),
+      ],
+    });
+
+    expect(items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          category: "automation_exception",
+          reason: expect.objectContaining({
+            code: "TRIAGE_AUTOMATION_SKIPPED",
+          }),
+          signals: expect.objectContaining({
+            automationAction: "lease.auto_send_notice",
+            automationExecuted: false,
+          }),
+        }),
+      ])
+    );
+  });
+
+  it("maps maintenance reopen and stall signals correctly", () => {
+    const items = deriveAdminTriageQueue({
+      now: Date.parse("2026-04-20T12:00:00.000Z"),
+      maintenanceRequests: [
+        { id: "maint-1", title: "Broken heater", status: "open" },
+        { id: "maint-2", title: "Leaking sink", status: "assigned" },
+      ],
+      canonicalEvents: [
+        canonicalEvent("event-1", {
+          type: "maintenance.request_created",
+          domain: "maintenance",
+          action: "request_created",
+          resource: { type: "maintenance_request", id: "maint-1" },
+          occurredAt: "2026-04-10T09:00:00.000Z",
+        }),
+        canonicalEvent("event-2", {
+          type: "maintenance.completed",
+          domain: "maintenance",
+          action: "completed",
+          resource: { type: "maintenance_request", id: "maint-1" },
+          occurredAt: "2026-04-11T09:00:00.000Z",
+        }),
+        canonicalEvent("event-3", {
+          type: "maintenance.assigned",
+          domain: "maintenance",
+          action: "assigned",
+          resource: { type: "maintenance_request", id: "maint-1" },
+          occurredAt: "2026-04-12T09:00:00.000Z",
+        }),
+        canonicalEvent("event-4", {
+          type: "maintenance.request_created",
+          domain: "maintenance",
+          action: "request_created",
+          resource: { type: "maintenance_request", id: "maint-2" },
+          occurredAt: "2026-04-15T09:00:00.000Z",
+        }),
+      ],
+    });
+
+    expect(items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          category: "maintenance_friction",
+          reason: expect.objectContaining({
+            code: "TRIAGE_MAINTENANCE_REOPENED",
+          }),
+        }),
+        expect.objectContaining({
+          category: "workflow_stall",
+          reason: expect.objectContaining({
+            code: "TRIAGE_WORKFLOW_STALLED",
+          }),
+        }),
+      ])
+    );
+  });
+
+  it("applies severity sorting correctly", () => {
+    const items = deriveAdminTriageQueue({
+      now: Date.parse("2026-04-15T12:00:00.000Z"),
+      applications: [{ id: "app-1", screeningMonetization: { paymentStatus: "paid", paidAt: "2026-04-15T08:00:00.000Z", fulfillmentStatus: "ordered" } }],
+      maintenanceRequests: [{ id: "maint-1", title: "Broken heater", status: "assigned" }],
+      canonicalEvents: [
+        canonicalEvent("event-1", {
+          type: "screening.paid",
+          domain: "screening",
+          action: "paid",
+          resource: { type: "rental_application", id: "app-1" },
+          occurredAt: "2026-04-15T08:00:00.000Z",
+        }),
+        canonicalEvent("event-2", {
+          type: "maintenance.request_created",
+          domain: "maintenance",
+          action: "request_created",
+          resource: { type: "maintenance_request", id: "maint-1" },
+          occurredAt: "2026-04-13T08:00:00.000Z",
+        }),
+      ],
+      financialTransactions: [{ applicationId: "app-1", type: "payment_succeeded", createdAt: Date.parse("2026-04-15T08:00:00.000Z") }],
+    });
+
+    expect(items[0]?.severity).toBe("critical");
+  });
+});
+

--- a/rentchain-api/src/lib/triage/deriveAdminTriageQueue.ts
+++ b/rentchain-api/src/lib/triage/deriveAdminTriageQueue.ts
@@ -1,0 +1,628 @@
+import type { CanonicalEventV1 } from "../events/eventTypes";
+import { deriveInsightForResource } from "../insights/deriveInsights";
+import { deriveScreeningReconciliation } from "../reconciliation/deriveScreeningReconciliation";
+import type { ScreeningReconciliationV1 } from "../reconciliation/reconciliationTypes";
+import type { AdminTriageItemV1, TriageCategory, TriageSeverity } from "./triageTypes";
+
+type ScreeningOrderLike = {
+  id?: string | null;
+  applicationId?: string | null;
+  updatedAt?: number | null;
+  createdAt?: number | null;
+  stripeCheckoutSessionId?: string | null;
+  stripeSessionId?: string | null;
+};
+
+type FinancialTransactionLike = {
+  type?: string | null;
+  status?: string | null;
+  applicationId?: string | null;
+  createdAt?: number | null;
+  metadata?: Record<string, unknown> | null;
+};
+
+type DeriveAdminTriageQueueInput = {
+  applications?: any[];
+  maintenanceRequests?: any[];
+  leases?: any[];
+  canonicalEvents?: CanonicalEventV1[];
+  screeningOrders?: ScreeningOrderLike[];
+  financialTransactions?: FinancialTransactionLike[];
+  now?: number;
+};
+
+const MAINTENANCE_STALL_THRESHOLD_MS = 48 * 60 * 60 * 1000;
+
+const IMPORTANT_POLICY_ACTIONS = new Set([
+  "start_checkout",
+  "approve_cost",
+  "send_notice",
+]);
+
+const SEVERITY_ORDER: Record<TriageSeverity, number> = {
+  critical: 4,
+  high: 3,
+  medium: 2,
+  low: 1,
+};
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function asOptionalString(value: unknown, max = 240) {
+  const next = asString(value, max);
+  return next || null;
+}
+
+function parseTimestamp(value: unknown) {
+  const raw = asString(value, 200);
+  if (!raw) return null;
+  const parsed = Date.parse(raw);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function toIsoFromMs(value: number | null | undefined) {
+  return typeof value === "number" && Number.isFinite(value) ? new Date(value).toISOString() : null;
+}
+
+function compareEventsAscending(a: CanonicalEventV1, b: CanonicalEventV1) {
+  const aTs = parseTimestamp(a.occurredAt) ?? parseTimestamp(a.recordedAt) ?? 0;
+  const bTs = parseTimestamp(b.occurredAt) ?? parseTimestamp(b.recordedAt) ?? 0;
+  if (aTs !== bTs) return aTs - bTs;
+  return String(a.id || "").localeCompare(String(b.id || ""));
+}
+
+function compareTriageItems(a: AdminTriageItemV1, b: AdminTriageItemV1) {
+  const severityDelta = SEVERITY_ORDER[b.severity] - SEVERITY_ORDER[a.severity];
+  if (severityDelta !== 0) return severityDelta;
+  const aTs = parseTimestamp(a.timestamps.surfacedAt) ?? 0;
+  const bTs = parseTimestamp(b.timestamps.surfacedAt) ?? 0;
+  if (bTs !== aTs) return bTs - aTs;
+  return b.id.localeCompare(a.id);
+}
+
+function resourceSummaryFromApplication(application: any) {
+  const title =
+    asOptionalString(application?.applicantName, 200) ||
+    asOptionalString(application?.fullName, 200) ||
+    asOptionalString(application?.applicantFullName, 200) ||
+    asOptionalString(application?.tenantName, 200) ||
+    `Application ${asString(application?.id, 120)}`;
+  const propertyId = asOptionalString(application?.propertyId, 120);
+  const unitId = asOptionalString(application?.unitId, 120);
+  return {
+    type: "application",
+    id: asString(application?.id, 240),
+    title,
+    subtitle: [propertyId ? `Property ${propertyId}` : null, unitId ? `Unit ${unitId}` : null]
+      .filter(Boolean)
+      .join(" • ") || null,
+    status:
+      asOptionalString(application?.screeningStatus, 120) ||
+      asOptionalString(application?.status, 120),
+  };
+}
+
+function resourceSummaryFromMaintenance(maintenance: any) {
+  const title =
+    asOptionalString(maintenance?.title, 200) ||
+    asOptionalString(maintenance?.issueTitle, 200) ||
+    asOptionalString(maintenance?.category, 200) ||
+    `Maintenance ${asString(maintenance?.id, 120)}`;
+  const propertyId = asOptionalString(maintenance?.propertyId, 120);
+  const unitId = asOptionalString(maintenance?.unitId, 120);
+  return {
+    type: "maintenance",
+    id: asString(maintenance?.id, 240),
+    title,
+    subtitle: [propertyId ? `Property ${propertyId}` : null, unitId ? `Unit ${unitId}` : null]
+      .filter(Boolean)
+      .join(" • ") || null,
+    status: asOptionalString(maintenance?.status, 120),
+  };
+}
+
+function resourceSummaryFromLease(lease: any) {
+  const title =
+    asOptionalString(lease?.tenantName, 200) ||
+    asOptionalString(lease?.primaryTenantName, 200) ||
+    (asOptionalString(lease?.unitId, 120) ? `Lease for unit ${asString(lease?.unitId, 120)}` : `Lease ${asString(lease?.id, 120)}`);
+  const propertyId = asOptionalString(lease?.propertyId, 120);
+  const unitId = asOptionalString(lease?.unitId, 120);
+  return {
+    type: "lease",
+    id: asString(lease?.id, 240),
+    title,
+    subtitle: [propertyId ? `Property ${propertyId}` : null, unitId ? `Unit ${unitId}` : null]
+      .filter(Boolean)
+      .join(" • ") || null,
+    status: asOptionalString(lease?.status, 120),
+  };
+}
+
+function supportConsolePath(resourceType: string, resourceId: string) {
+  return `/admin/support-console?resourceType=${encodeURIComponent(resourceType)}&resourceId=${encodeURIComponent(resourceId)}`;
+}
+
+function isVisibleToAdmin(event: CanonicalEventV1) {
+  return event.visibility !== "tenant";
+}
+
+function latestOrderByApplication(orders: ScreeningOrderLike[]) {
+  const grouped = new Map<string, ScreeningOrderLike[]>();
+  for (const order of orders || []) {
+    const applicationId = asString(order?.applicationId, 240);
+    if (!applicationId) continue;
+    if (!grouped.has(applicationId)) grouped.set(applicationId, []);
+    grouped.get(applicationId)!.push(order);
+  }
+  const latest = new Map<string, ScreeningOrderLike>();
+  for (const [applicationId, items] of grouped.entries()) {
+    const ordered = [...items].sort(
+      (a, b) => Number(b.updatedAt || b.createdAt || 0) - Number(a.updatedAt || a.createdAt || 0)
+    );
+    latest.set(applicationId, ordered[0]);
+  }
+  return latest;
+}
+
+function isRelatedApplicationEvent(resourceId: string, event: CanonicalEventV1) {
+  const resourceType = asString(event.resource?.type, 120);
+  const exactId = asString(event.resource?.id, 240);
+  const parentId = asString(event.resource?.parentId, 240);
+  const metadataApplicationId = asString(event.metadata?.applicationId, 240);
+  return (
+    (resourceType === "rental_application" && exactId === resourceId) ||
+    parentId === resourceId ||
+    metadataApplicationId === resourceId
+  );
+}
+
+function isRelatedMaintenanceEvent(resourceId: string, event: CanonicalEventV1) {
+  const resourceType = asString(event.resource?.type, 120);
+  const exactId = asString(event.resource?.id, 240);
+  const parentId = asString(event.resource?.parentId, 240);
+  const metadataMaintenanceRequestId = asString(event.metadata?.maintenanceRequestId, 240);
+  return (
+    (resourceType === "maintenance_request" && exactId === resourceId) ||
+    parentId === resourceId ||
+    metadataMaintenanceRequestId === resourceId
+  );
+}
+
+function isRelatedLeaseEvent(resourceId: string, event: CanonicalEventV1) {
+  return (
+    (asString(event.resource?.type, 120) === "lease" && asString(event.resource?.id, 240) === resourceId) ||
+    asString(event.resource?.parentId, 240) === resourceId
+  );
+}
+
+function latestEvent(events: CanonicalEventV1[]) {
+  return [...events].sort(compareEventsAscending).pop() || null;
+}
+
+function itemId(category: TriageCategory, resourceType: string, resourceId: string, reasonCode: string) {
+  return `${category}:${resourceType}:${resourceId}:${reasonCode}`;
+}
+
+function buildItem(input: {
+  category: TriageCategory;
+  severity: TriageSeverity;
+  resource: AdminTriageItemV1["resource"];
+  reasonCode: string;
+  reasonSummary: string;
+  reasonDetails?: string | null;
+  signals?: AdminTriageItemV1["signals"];
+  surfacedAt: string;
+  firstSeenAt?: string | null;
+  lastSeenAt?: string | null;
+  tags?: string[];
+}): AdminTriageItemV1 {
+  return {
+    id: itemId(input.category, input.resource.type, input.resource.id, input.reasonCode),
+    version: "v1",
+    category: input.category,
+    severity: input.severity,
+    resource: input.resource,
+    reason: {
+      code: input.reasonCode,
+      summary: input.reasonSummary,
+      details: input.reasonDetails || null,
+    },
+    signals: input.signals || {},
+    timestamps: {
+      surfacedAt: input.surfacedAt,
+      firstSeenAt: input.firstSeenAt || null,
+      lastSeenAt: input.lastSeenAt || null,
+    },
+    navigation: {
+      supportConsolePath: supportConsolePath(input.resource.type, input.resource.id),
+    },
+    tags: input.tags || [],
+  };
+}
+
+function severityForReconciliation(status: string): TriageSeverity | null {
+  if (status === "paid_not_fulfilled" || status === "mismatch") return "critical";
+  if (status === "duplicate_risk") return "high";
+  if (status === "abandoned") return "medium";
+  if (status === "blocked" || status === "needs_review") return "medium";
+  return null;
+}
+
+function reconciliationReason(status: string) {
+  if (status === "paid_not_fulfilled") {
+    return {
+      code: "TRIAGE_PAID_NOT_FULFILLED",
+      summary: "Payment was recorded but screening completion is missing.",
+      details: "Review fulfillment and provider completion path.",
+      tags: ["screening", "revenue"],
+    };
+  }
+  if (status === "mismatch") {
+    return {
+      code: "TRIAGE_SCREENING_MISMATCH",
+      summary: "Screening monetization signals are contradictory.",
+      details: "Inspect payment, monetization state, and canonical screening history.",
+      tags: ["screening", "integrity"],
+    };
+  }
+  if (status === "duplicate_risk") {
+    return {
+      code: "TRIAGE_DUPLICATE_RISK",
+      summary: "Multiple screening checkout signals indicate duplicate monetization risk.",
+      details: "Inspect repeated checkout creation and linked identifiers.",
+      tags: ["screening", "revenue"],
+    };
+  }
+  if (status === "abandoned") {
+    return {
+      code: "TRIAGE_ABANDONED_CHECKOUT",
+      summary: "Screening checkout appears abandoned without payment completion.",
+      details: "Inspect inactivity and whether follow-up or cleanup is needed.",
+      tags: ["screening"],
+    };
+  }
+  if (status === "blocked") {
+    return {
+      code: "TRIAGE_BLOCKED_WORKFLOW",
+      summary: "Screening monetization is blocked and may need operator review.",
+      details: "Inspect provider availability, eligibility, or explicit blocked signals.",
+      tags: ["screening", "blocked"],
+    };
+  }
+  return {
+    code: "TRIAGE_NEEDS_REVIEW",
+    summary: "Screening monetization needs review.",
+    details: "Inspect the reconciliation summary for incomplete or suspicious signals.",
+    tags: ["screening"],
+  };
+}
+
+function policySeverity(outcome: string, action: string, repeatCount: number): TriageSeverity | null {
+  if (outcome === "review") return "medium";
+  if (outcome === "block" && IMPORTANT_POLICY_ACTIONS.has(action) && repeatCount > 1) return "high";
+  if (outcome === "block" && IMPORTANT_POLICY_ACTIONS.has(action)) return "high";
+  if (outcome === "block") return "medium";
+  return null;
+}
+
+function automationSeverity(reason: string, repeatCount: number): TriageSeverity | null {
+  const normalizedReason = asString(reason, 200).toUpperCase();
+  if (!normalizedReason) return "medium";
+  if (
+    repeatCount > 1 &&
+    (normalizedReason.includes("POLICY_BLOCKED") ||
+      normalizedReason.includes("FAILED") ||
+      normalizedReason.includes("DUPLICATE"))
+  ) {
+    return "high";
+  }
+  return "medium";
+}
+
+function deriveApplicationReconciliationItems(input: {
+  applications: any[];
+  canonicalEvents: CanonicalEventV1[];
+  screeningOrders: ScreeningOrderLike[];
+  financialTransactions: FinancialTransactionLike[];
+  now: number;
+}) {
+  const latestOrders = latestOrderByApplication(input.screeningOrders || []);
+  const items: AdminTriageItemV1[] = [];
+
+  for (const application of input.applications || []) {
+    const applicationId = asString(application?.id, 240);
+    if (!applicationId) continue;
+    const reconciliation = deriveScreeningReconciliation({
+      applicationId,
+      application,
+      latestOrder: latestOrders.get(applicationId) || null,
+      canonicalEvents: input.canonicalEvents,
+      financialTransactions: input.financialTransactions,
+      now: input.now,
+    });
+    const severity = severityForReconciliation(reconciliation.status);
+    if (!severity) continue;
+    const reason = reconciliationReason(reconciliation.status);
+    const resource = {
+      ...resourceSummaryFromApplication(application),
+      status: reconciliation.status,
+    };
+    items.push(
+      buildItem({
+        category: "screening_reconciliation",
+        severity,
+        resource,
+        reasonCode: reason.code,
+        reasonSummary: reason.summary,
+        reasonDetails: reason.details,
+        signals: {
+          reconciliationStatus: reconciliation.status,
+          inactivityMs: reconciliation.metrics?.inactivityMs ?? null,
+          blockedCount: reconciliation.metrics?.blockedCount ?? null,
+        },
+        surfacedAt: reconciliation.summary.lastMeaningfulEventAt || reconciliation.generatedAt,
+        firstSeenAt: reconciliation.metrics?.quoteCount ? reconciliation.generatedAt : reconciliation.generatedAt,
+        lastSeenAt: reconciliation.summary.lastMeaningfulEventAt || reconciliation.generatedAt,
+        tags: reason.tags,
+      })
+    );
+  }
+
+  return items;
+}
+
+function derivePolicyItemsForResource(params: {
+  resourceType: "application" | "maintenance" | "lease";
+  resource: any;
+  events: CanonicalEventV1[];
+}) {
+  const policyEvents = params.events
+    .filter((event) => event.type === "policy.evaluated")
+    .sort(compareEventsAscending);
+  if (!policyEvents.length) return [] as AdminTriageItemV1[];
+  const latest = policyEvents[policyEvents.length - 1];
+  const outcome = asString(latest.metadata?.outcome || latest.status, 80).toLowerCase();
+  const action = asString(latest.metadata?.action, 120).toLowerCase();
+  const repeatedBlocks = policyEvents.filter(
+    (event) =>
+      asString(event.metadata?.outcome || event.status, 80).toLowerCase() === "block" &&
+      asString(event.metadata?.action, 120).toLowerCase() === action
+  ).length;
+  const severity = policySeverity(outcome, action, repeatedBlocks);
+  if (!severity) return [];
+
+  const resourceSummary =
+    params.resourceType === "application"
+      ? resourceSummaryFromApplication(params.resource)
+      : params.resourceType === "maintenance"
+      ? resourceSummaryFromMaintenance(params.resource)
+      : resourceSummaryFromLease(params.resource);
+
+  const firstSeenAt = policyEvents[0]?.occurredAt || policyEvents[0]?.recordedAt || null;
+  const lastSeenAt = latest.occurredAt || latest.recordedAt || null;
+  const topReasonCode = asOptionalString(latest.metadata?.topReasonCode, 120) || "POLICY_REVIEW_REQUIRED";
+  const reasonCode =
+    outcome === "review" ? "TRIAGE_POLICY_REVIEW_REQUIRED" : "TRIAGE_POLICY_BLOCKED";
+  const reasonSummary =
+    outcome === "review"
+      ? "Policy review is required before this workflow can proceed."
+      : "Policy blocked an important workflow action.";
+  return [
+    buildItem({
+      category: "policy_review",
+      severity,
+      resource: resourceSummary,
+      reasonCode,
+      reasonSummary,
+      reasonDetails: topReasonCode,
+      signals: {
+        policyOutcome: outcome || null,
+      },
+      surfacedAt: lastSeenAt || new Date().toISOString(),
+      firstSeenAt,
+      lastSeenAt,
+      tags: ["policy", action || "decision"],
+    }),
+  ];
+}
+
+function deriveAutomationItemsForResource(params: {
+  resourceType: "application" | "maintenance" | "lease";
+  resource: any;
+  events: CanonicalEventV1[];
+}) {
+  const automationEvents = params.events
+    .filter((event) => event.type === "automation.skipped")
+    .sort(compareEventsAscending);
+  if (!automationEvents.length) return [] as AdminTriageItemV1[];
+  const latest = automationEvents[automationEvents.length - 1];
+  const action = asOptionalString(latest.metadata?.action, 160);
+  const reason = asOptionalString(latest.metadata?.reason, 240) || "AUTOMATION_SKIPPED";
+  const repeatCount = automationEvents.filter(
+    (event) => asOptionalString(event.metadata?.action, 160) === action
+  ).length;
+  const severity = automationSeverity(reason, repeatCount);
+  if (!severity) return [];
+
+  const resourceSummary =
+    params.resourceType === "application"
+      ? resourceSummaryFromApplication(params.resource)
+      : params.resourceType === "maintenance"
+      ? resourceSummaryFromMaintenance(params.resource)
+      : resourceSummaryFromLease(params.resource);
+
+  const firstSeenAt = automationEvents[0]?.occurredAt || automationEvents[0]?.recordedAt || null;
+  const lastSeenAt = latest.occurredAt || latest.recordedAt || null;
+
+  return [
+    buildItem({
+      category: "automation_exception",
+      severity,
+      resource: resourceSummary,
+      reasonCode: "TRIAGE_AUTOMATION_SKIPPED",
+      reasonSummary: "Automation was skipped and may need operator follow-up.",
+      reasonDetails: reason,
+      signals: {
+        automationAction: action,
+        automationExecuted: false,
+      },
+      surfacedAt: lastSeenAt || new Date().toISOString(),
+      firstSeenAt,
+      lastSeenAt,
+      tags: ["automation", action || "skipped"],
+    }),
+  ];
+}
+
+function deriveMaintenanceInsightItems(params: {
+  maintenanceRequests: any[];
+  canonicalEvents: CanonicalEventV1[];
+  now: number;
+}) {
+  const items: AdminTriageItemV1[] = [];
+
+  for (const maintenance of params.maintenanceRequests || []) {
+    const resourceId = asString(maintenance?.id, 240);
+    if (!resourceId) continue;
+    const events = params.canonicalEvents.filter((event) => isRelatedMaintenanceEvent(resourceId, event));
+    const insight = deriveInsightForResource(events, {
+      domain: "maintenance",
+      resourceType: "maintenance_request",
+      resourceId,
+    });
+    if (!insight) continue;
+    const resource = resourceSummaryFromMaintenance(maintenance);
+    const lastSeenAt = insight.summary.lastEventAt || insight.generatedAt;
+    const inactivityMs =
+      lastSeenAt && parseTimestamp(lastSeenAt) != null
+        ? Math.max(0, params.now - Number(parseTimestamp(lastSeenAt)))
+        : null;
+
+    if ((insight.summary.reopenCount || 0) > 0) {
+      items.push(
+        buildItem({
+          category: "maintenance_friction",
+          severity: "medium",
+          resource,
+          reasonCode: "TRIAGE_MAINTENANCE_REOPENED",
+          reasonSummary: "Maintenance flow reopened after completion and may need operator review.",
+          reasonDetails: "Inspect follow-up work and completion confidence.",
+          signals: {
+            lifecycleState: asOptionalString(insight.summary.lifecycleState, 80),
+            reopenCount: insight.summary.reopenCount || 0,
+            blockedCount: insight.summary.blockedCount || 0,
+            inactivityMs,
+          },
+          surfacedAt: lastSeenAt,
+          firstSeenAt: insight.summary.firstEventAt,
+          lastSeenAt,
+          tags: ["maintenance", "reopened"],
+        })
+      );
+    }
+
+    if ((insight.summary.blockedCount || 0) > 0) {
+      items.push(
+        buildItem({
+          category: "workflow_stall",
+          severity: "high",
+          resource,
+          reasonCode: "TRIAGE_BLOCKED_WORKFLOW",
+          reasonSummary: "Maintenance workflow has explicit blocked signals.",
+          reasonDetails: "Inspect the blocked event sequence and related policy/automation decisions.",
+          signals: {
+            lifecycleState: asOptionalString(insight.summary.lifecycleState, 80),
+            blockedCount: insight.summary.blockedCount || 0,
+            reopenCount: insight.summary.reopenCount || 0,
+            inactivityMs,
+          },
+          surfacedAt: lastSeenAt,
+          firstSeenAt: insight.summary.firstEventAt,
+          lastSeenAt,
+          tags: ["maintenance", "blocked"],
+        })
+      );
+    } else if (
+      inactivityMs != null &&
+      inactivityMs > MAINTENANCE_STALL_THRESHOLD_MS &&
+      !["completed"].includes(asString(insight.summary.lifecycleState, 80).toLowerCase())
+    ) {
+      items.push(
+        buildItem({
+          category: "workflow_stall",
+          severity: "medium",
+          resource,
+          reasonCode: "TRIAGE_WORKFLOW_STALLED",
+          reasonSummary: "Maintenance workflow appears stalled without recent follow-through.",
+          reasonDetails: "Inspect assignment, completion, and any blocked or skipped automation signals.",
+          signals: {
+            lifecycleState: asOptionalString(insight.summary.lifecycleState, 80),
+            blockedCount: insight.summary.blockedCount || 0,
+            reopenCount: insight.summary.reopenCount || 0,
+            inactivityMs,
+          },
+          surfacedAt: lastSeenAt,
+          firstSeenAt: insight.summary.firstEventAt,
+          lastSeenAt,
+          tags: ["maintenance", "stalled"],
+        })
+      );
+    }
+  }
+
+  return items;
+}
+
+export function deriveAdminTriageQueue(input: DeriveAdminTriageQueueInput): AdminTriageItemV1[] {
+  const now = typeof input.now === "number" ? input.now : Date.now();
+  const canonicalEvents = (input.canonicalEvents || []).filter(isVisibleToAdmin);
+  const items: AdminTriageItemV1[] = [];
+
+  items.push(
+    ...deriveApplicationReconciliationItems({
+      applications: input.applications || [],
+      canonicalEvents,
+      screeningOrders: input.screeningOrders || [],
+      financialTransactions: input.financialTransactions || [],
+      now,
+    })
+  );
+
+  for (const application of input.applications || []) {
+    const resourceId = asString(application?.id, 240);
+    if (!resourceId) continue;
+    const events = canonicalEvents.filter((event) => isRelatedApplicationEvent(resourceId, event));
+    items.push(...derivePolicyItemsForResource({ resourceType: "application", resource: application, events }));
+    items.push(...deriveAutomationItemsForResource({ resourceType: "application", resource: application, events }));
+  }
+
+  for (const maintenance of input.maintenanceRequests || []) {
+    const resourceId = asString(maintenance?.id, 240);
+    if (!resourceId) continue;
+    const events = canonicalEvents.filter((event) => isRelatedMaintenanceEvent(resourceId, event));
+    items.push(...derivePolicyItemsForResource({ resourceType: "maintenance", resource: maintenance, events }));
+    items.push(...deriveAutomationItemsForResource({ resourceType: "maintenance", resource: maintenance, events }));
+  }
+
+  for (const lease of input.leases || []) {
+    const resourceId = asString(lease?.id, 240);
+    if (!resourceId) continue;
+    const events = canonicalEvents.filter((event) => isRelatedLeaseEvent(resourceId, event));
+    items.push(...derivePolicyItemsForResource({ resourceType: "lease", resource: lease, events }));
+    items.push(...deriveAutomationItemsForResource({ resourceType: "lease", resource: lease, events }));
+  }
+
+  items.push(
+    ...deriveMaintenanceInsightItems({
+      maintenanceRequests: input.maintenanceRequests || [],
+      canonicalEvents,
+      now,
+    })
+  );
+
+  return items.sort(compareTriageItems);
+}
+

--- a/rentchain-api/src/lib/triage/triageTypes.ts
+++ b/rentchain-api/src/lib/triage/triageTypes.ts
@@ -1,0 +1,48 @@
+export type TriageCategory =
+  | "screening_reconciliation"
+  | "policy_review"
+  | "automation_exception"
+  | "maintenance_friction"
+  | "workflow_stall"
+  | "system_attention";
+
+export type TriageSeverity = "low" | "medium" | "high" | "critical";
+
+export type AdminTriageItemV1 = {
+  id: string;
+  version: "v1";
+  category: TriageCategory;
+  severity: TriageSeverity;
+  resource: {
+    type: string;
+    id: string;
+    title?: string | null;
+    subtitle?: string | null;
+    status?: string | null;
+  };
+  reason: {
+    code: string;
+    summary: string;
+    details?: string | null;
+  };
+  signals: {
+    reconciliationStatus?: string | null;
+    lifecycleState?: string | null;
+    policyOutcome?: string | null;
+    automationAction?: string | null;
+    automationExecuted?: boolean | null;
+    blockedCount?: number | null;
+    reopenCount?: number | null;
+    inactivityMs?: number | null;
+  };
+  timestamps: {
+    surfacedAt: string;
+    firstSeenAt?: string | null;
+    lastSeenAt?: string | null;
+  };
+  navigation: {
+    supportConsolePath?: string | null;
+  };
+  tags?: string[];
+};
+

--- a/rentchain-api/src/routes/__tests__/adminTriageRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/adminTriageRoutes.test.ts
@@ -1,0 +1,250 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { collections, dbMock } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, any>>();
+
+  function ensureCollection(name: string) {
+    if (!collections.has(name)) {
+      collections.set(name, new Map<string, any>());
+    }
+    return collections.get(name)!;
+  }
+
+  return {
+    collections,
+    dbMock: {
+      collection: (name: string) => ({
+        async get() {
+          const docs = Array.from(ensureCollection(name).entries()).map(([id, data]) => ({
+            id,
+            data: () => data,
+          }));
+          return { docs, empty: docs.length === 0, size: docs.length };
+        },
+      }),
+    },
+  };
+});
+
+vi.mock("../../config/firebase", () => ({
+  db: dbMock,
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!req.user) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    return next();
+  },
+}));
+
+async function invokeRouter(
+  router: any,
+  options: { method: string; url: string; user?: Record<string, unknown> | null }
+) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    const query = new URLSearchParams(queryString || "");
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: options.user ?? null,
+      query: Object.fromEntries(query.entries()),
+      params: {},
+      headers: {},
+      get(name: string) {
+        return this.headers[String(name).toLowerCase()];
+      },
+      header(name: string) {
+        return this.get(name);
+      },
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, string>,
+      setHeader(name: string, value: string) {
+        this.headers[name.toLowerCase()] = value;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+function seedDoc(collectionName: string, id: string, data: any) {
+  if (!collections.has(collectionName)) {
+    collections.set(collectionName, new Map<string, any>());
+  }
+  collections.get(collectionName)!.set(id, { id, ...data });
+}
+
+describe("adminTriageRoutes", () => {
+  beforeEach(() => {
+    collections.clear();
+  });
+
+  it("returns triage items for admin users", async () => {
+    seedDoc("rentalApplications", "app-1", {
+      applicantName: "Alex Applicant",
+      screeningMonetization: {
+        paymentStatus: "paid",
+        paidAt: "2026-04-15T08:00:00.000Z",
+        fulfillmentStatus: "ordered",
+      },
+    });
+    seedDoc("financialTransactions", "tx-1", {
+      applicationId: "app-1",
+      type: "payment_succeeded",
+      createdAt: Date.parse("2026-04-15T08:00:00.000Z"),
+    });
+    seedDoc("canonicalEvents", "event-1", {
+      version: "v1",
+      type: "screening.paid",
+      domain: "screening",
+      action: "paid",
+      actor: { type: "system", role: "system", id: "system" },
+      resource: { type: "rental_application", id: "app-1" },
+      occurredAt: "2026-04-15T08:00:00.000Z",
+      recordedAt: "2026-04-15T08:00:00.000Z",
+      visibility: "internal",
+      summary: "Screening paid",
+    });
+
+    const router = (await import("../adminTriageRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/triage?limit=10",
+      user: { id: "admin-1", role: "admin" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body?.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          category: "screening_reconciliation",
+          severity: "critical",
+          navigation: expect.objectContaining({
+            supportConsolePath: "/admin/support-console?resourceType=application&resourceId=app-1",
+          }),
+        }),
+      ])
+    );
+  });
+
+  it("applies category, severity, and resource filters", async () => {
+    seedDoc("rentalApplications", "app-1", {
+      applicantName: "Alex Applicant",
+      screeningMonetization: {
+        paymentStatus: "paid",
+        paidAt: "2026-04-15T08:00:00.000Z",
+        fulfillmentStatus: "ordered",
+      },
+    });
+    seedDoc("leases", "lease-1", {
+      tenantName: "Taylor Tenant",
+      status: "draft",
+    });
+    seedDoc("financialTransactions", "tx-1", {
+      applicationId: "app-1",
+      type: "payment_succeeded",
+      createdAt: Date.parse("2026-04-15T08:00:00.000Z"),
+    });
+    seedDoc("canonicalEvents", "event-1", {
+      version: "v1",
+      type: "screening.paid",
+      domain: "screening",
+      action: "paid",
+      actor: { type: "system", role: "system", id: "system" },
+      resource: { type: "rental_application", id: "app-1" },
+      occurredAt: "2026-04-15T08:00:00.000Z",
+      recordedAt: "2026-04-15T08:00:00.000Z",
+      visibility: "internal",
+      summary: "Screening paid",
+    });
+    seedDoc("canonicalEvents", "event-2", {
+      version: "v1",
+      type: "automation.skipped",
+      domain: "system",
+      action: "skipped",
+      actor: { type: "landlord", role: "landlord", id: "landlord-1" },
+      resource: { type: "lease", id: "lease-1" },
+      occurredAt: "2026-04-15T09:00:00.000Z",
+      recordedAt: "2026-04-15T09:00:00.000Z",
+      visibility: "internal",
+      summary: "Automation skipped",
+      metadata: {
+        action: "lease.auto_send_notice",
+        reason: "LEASE_AUTO_SEND_NOTICE_POLICY_BLOCKED",
+        skipped: true,
+      },
+    });
+
+    const router = (await import("../adminTriageRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/triage?category=automation_exception&resourceType=lease&severity=medium",
+      user: { id: "admin-1", role: "admin" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body?.items).toHaveLength(1);
+    expect(response.body?.items[0]).toEqual(
+      expect.objectContaining({
+        category: "automation_exception",
+        resource: expect.objectContaining({
+          type: "lease",
+          id: "lease-1",
+        }),
+      })
+    );
+  });
+
+  it("enforces admin-only access and safe validation errors", async () => {
+    const router = (await import("../adminTriageRoutes")).default;
+
+    const forbidden = await invokeRouter(router, {
+      method: "GET",
+      url: "/triage",
+      user: { id: "landlord-1", role: "landlord" },
+    });
+    expect(forbidden.status).toBe(403);
+    expect(forbidden.body?.error).toBe("FORBIDDEN");
+
+    const invalidCategory = await invokeRouter(router, {
+      method: "GET",
+      url: "/triage?category=nope",
+      user: { id: "admin-1", role: "admin" },
+    });
+    expect(invalidCategory.status).toBe(400);
+    expect(invalidCategory.body?.error).toBe("CATEGORY_INVALID");
+  });
+
+  it("returns a stable empty shape when no items match", async () => {
+    const router = (await import("../adminTriageRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/triage?limit=10",
+      user: { id: "admin-1", role: "admin" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      items: [],
+      nextCursor: undefined,
+    });
+  });
+});

--- a/rentchain-api/src/routes/adminTriageRoutes.ts
+++ b/rentchain-api/src/routes/adminTriageRoutes.ts
@@ -1,0 +1,143 @@
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { requireAuth } from "../middleware/requireAuth";
+import { CANONICAL_EVENTS_COLLECTION } from "../lib/events/buildEvent";
+import type { CanonicalEventV1 } from "../lib/events/eventTypes";
+import { deriveAdminTriageQueue } from "../lib/triage/deriveAdminTriageQueue";
+import type { AdminTriageItemV1, TriageCategory, TriageSeverity } from "../lib/triage/triageTypes";
+
+const router = Router();
+
+const ALLOWED_CATEGORIES = new Set<TriageCategory>([
+  "screening_reconciliation",
+  "policy_review",
+  "automation_exception",
+  "maintenance_friction",
+  "workflow_stall",
+  "system_attention",
+]);
+
+const ALLOWED_SEVERITIES = new Set<TriageSeverity>(["low", "medium", "high", "critical"]);
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function normalizeRole(req: any): "admin" | "landlord" | "other" {
+  const role = asString(req.user?.actorRole || req.user?.role, 40).toLowerCase();
+  if (role === "admin") return "admin";
+  if (role === "landlord") return "landlord";
+  return "other";
+}
+
+function parseLimit(value: unknown) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return 20;
+  return Math.max(1, Math.min(100, Math.floor(parsed)));
+}
+
+function parseCursor(value: unknown): { surfacedAt: string; itemId: string } | null {
+  const raw = asString(value, 4000);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(Buffer.from(raw, "base64url").toString("utf8"));
+    const surfacedAt = asString(parsed?.surfacedAt);
+    const itemId = asString(parsed?.itemId);
+    if (!surfacedAt || !itemId) return null;
+    return { surfacedAt, itemId };
+  } catch {
+    return null;
+  }
+}
+
+function encodeCursor(item: AdminTriageItemV1) {
+  return Buffer.from(
+    JSON.stringify({
+      surfacedAt: item.timestamps.surfacedAt,
+      itemId: item.id,
+    }),
+    "utf8"
+  ).toString("base64url");
+}
+
+async function loadCollection(name: string) {
+  const snap = await db.collection(name).get();
+  return (snap.docs || []).map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }));
+}
+
+async function loadCanonicalEvents() {
+  const snap = await db.collection(CANONICAL_EVENTS_COLLECTION).get();
+  return (snap.docs || []).map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }) as CanonicalEventV1);
+}
+
+router.get("/triage", requireAuth, async (req: any, res) => {
+  try {
+    if (normalizeRole(req) !== "admin") {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+
+    const category = asString(req.query?.category, 80).toLowerCase();
+    if (category && !ALLOWED_CATEGORIES.has(category as TriageCategory)) {
+      return res.status(400).json({ ok: false, error: "CATEGORY_INVALID" });
+    }
+
+    const severity = asString(req.query?.severity, 40).toLowerCase();
+    if (severity && !ALLOWED_SEVERITIES.has(severity as TriageSeverity)) {
+      return res.status(400).json({ ok: false, error: "SEVERITY_INVALID" });
+    }
+
+    const resourceType = asString(req.query?.resourceType, 80).toLowerCase();
+    if (resourceType && !["application", "maintenance", "lease"].includes(resourceType)) {
+      return res.status(400).json({ ok: false, error: "RESOURCE_TYPE_INVALID" });
+    }
+
+    const includeLow = String(req.query?.includeLow || "false").toLowerCase() === "true";
+    const limit = parseLimit(req.query?.limit);
+    const cursor = parseCursor(req.query?.cursor);
+
+    const [applications, maintenanceRequests, leases, canonicalEvents, screeningOrders, financialTransactions] =
+      await Promise.all([
+        loadCollection("rentalApplications"),
+        loadCollection("maintenanceRequests"),
+        loadCollection("leases"),
+        loadCanonicalEvents(),
+        loadCollection("screeningOrders"),
+        loadCollection("financialTransactions"),
+      ]);
+
+    const allItems = deriveAdminTriageQueue({
+      applications,
+      maintenanceRequests,
+      leases,
+      canonicalEvents,
+      screeningOrders,
+      financialTransactions,
+    })
+      .filter((item) => (includeLow ? true : item.severity !== "low"))
+      .filter((item) => (category ? item.category === category : true))
+      .filter((item) => (severity ? item.severity === severity : true))
+      .filter((item) => (resourceType ? item.resource.type === resourceType : true));
+
+    const cursorFiltered = cursor
+      ? allItems.filter((item) => {
+          const itemKey = `${item.timestamps.surfacedAt}::${item.id}`;
+          const cursorKey = `${cursor.surfacedAt}::${cursor.itemId}`;
+          return itemKey < cursorKey;
+        })
+      : allItems;
+
+    const page = cursorFiltered.slice(0, limit);
+    const hasMore = cursorFiltered.length > limit;
+
+    return res.json({
+      items: page,
+      nextCursor: hasMore && page.length ? encodeCursor(page[page.length - 1]) : undefined,
+    });
+  } catch (err: any) {
+    console.error("[admin-triage] fetch failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "ADMIN_TRIAGE_FETCH_FAILED" });
+  }
+});
+
+export default router;
+

--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -58,6 +58,10 @@ vi.mock("./pages/admin/SupportDebugConsolePage", () => ({
   default: () => <h1>Support / Debug Console</h1>,
 }));
 
+vi.mock("./pages/admin/AdminTriageQueuePage", () => ({
+  default: () => <h1>Admin Triage Queue</h1>,
+}));
+
 vi.mock("./pages/tenant/TenantWorkspacePage", () => ({
   default: () => <h1>Tenant Dashboard</h1>,
 }));
@@ -166,6 +170,21 @@ describe("Routes: /admin/support-console", () => {
     expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 });
+
+describe("Routes: /admin/triage", () => {
+  it("renders the admin triage queue route", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/admin/triage"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Admin Triage Queue/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+});
+
 
 describe("Routes: /tenant/application", () => {
   it("renders the tenant application route without falling into landlord surfaces", async () => {

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -152,6 +152,7 @@ const AutomationTimelinePage = lazy(
 );
 const AutomationTimelineV1Page = lazy(() => import("./pages/admin/AutomationTimelineV1Page"));
 const SupportDebugConsolePage = lazy(() => import("./pages/admin/SupportDebugConsolePage"));
+const AdminTriageQueuePage = lazy(() => import("./pages/admin/AdminTriageQueuePage"));
 
 const AuthLoadingScreen = () => (
   <div
@@ -877,6 +878,16 @@ function App() {
             <RequireAdmin>
               <Suspense fallback={null}>
                 <SupportDebugConsolePage />
+              </Suspense>
+            </RequireAdmin>
+          }
+        />
+        <Route
+          path="/admin/triage"
+          element={
+            <RequireAdmin>
+              <Suspense fallback={null}>
+                <AdminTriageQueuePage />
               </Suspense>
             </RequireAdmin>
           }

--- a/rentchain-frontend/src/api/adminTriageApi.ts
+++ b/rentchain-frontend/src/api/adminTriageApi.ts
@@ -1,0 +1,70 @@
+import { apiFetch } from "./apiFetch";
+
+export type AdminTriageItemV1 = {
+  id: string;
+  version: "v1";
+  category:
+    | "screening_reconciliation"
+    | "policy_review"
+    | "automation_exception"
+    | "maintenance_friction"
+    | "workflow_stall"
+    | "system_attention";
+  severity: "low" | "medium" | "high" | "critical";
+  resource: {
+    type: string;
+    id: string;
+    title?: string | null;
+    subtitle?: string | null;
+    status?: string | null;
+  };
+  reason: {
+    code: string;
+    summary: string;
+    details?: string | null;
+  };
+  signals: {
+    reconciliationStatus?: string | null;
+    lifecycleState?: string | null;
+    policyOutcome?: string | null;
+    automationAction?: string | null;
+    automationExecuted?: boolean | null;
+    blockedCount?: number | null;
+    reopenCount?: number | null;
+    inactivityMs?: number | null;
+  };
+  timestamps: {
+    surfacedAt: string;
+    firstSeenAt?: string | null;
+    lastSeenAt?: string | null;
+  };
+  navigation: {
+    supportConsolePath?: string | null;
+  };
+  tags?: string[];
+};
+
+export type AdminTriageResponse = {
+  items: AdminTriageItemV1[];
+  nextCursor?: string;
+};
+
+export async function fetchAdminTriageQueue(params?: {
+  category?: string | null;
+  severity?: string | null;
+  resourceType?: string | null;
+  limit?: number | null;
+  cursor?: string | null;
+  includeLow?: boolean | null;
+}): Promise<AdminTriageResponse> {
+  const search = new URLSearchParams();
+  if (params?.category) search.set("category", params.category);
+  if (params?.severity) search.set("severity", params.severity);
+  if (params?.resourceType) search.set("resourceType", params.resourceType);
+  if (typeof params?.limit === "number") search.set("limit", String(params.limit));
+  if (params?.cursor) search.set("cursor", params.cursor);
+  if (typeof params?.includeLow === "boolean") search.set("includeLow", String(params.includeLow));
+  const query = search.toString();
+  return await apiFetch<AdminTriageResponse>(`/admin/triage${query ? `?${query}` : ""}`);
+}
+

--- a/rentchain-frontend/src/components/adminTriage/TriageFilterBar.tsx
+++ b/rentchain-frontend/src/components/adminTriage/TriageFilterBar.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { Button, Card } from "../ui/Ui";
+
+type TriageFilterBarProps = {
+  category: string;
+  severity: string;
+  resourceType: string;
+  includeLow: boolean;
+  loading?: boolean;
+  onCategoryChange: (value: string) => void;
+  onSeverityChange: (value: string) => void;
+  onResourceTypeChange: (value: string) => void;
+  onIncludeLowChange: (value: boolean) => void;
+  onRefresh: () => void;
+};
+
+export function TriageFilterBar(props: TriageFilterBarProps) {
+  return (
+    <Card style={{ display: "grid", gap: 12 }}>
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 12 }}>
+        <label style={{ display: "grid", gap: 4 }}>
+          <span style={{ color: "#64748b", fontSize: 12 }}>Category</span>
+          <select aria-label="Category filter" value={props.category} onChange={(event) => props.onCategoryChange(event.target.value)}>
+            <option value="">All categories</option>
+            <option value="screening_reconciliation">Screening reconciliation</option>
+            <option value="policy_review">Policy review</option>
+            <option value="automation_exception">Automation exception</option>
+            <option value="maintenance_friction">Maintenance friction</option>
+            <option value="workflow_stall">Workflow stall</option>
+          </select>
+        </label>
+        <label style={{ display: "grid", gap: 4 }}>
+          <span style={{ color: "#64748b", fontSize: 12 }}>Severity</span>
+          <select aria-label="Severity filter" value={props.severity} onChange={(event) => props.onSeverityChange(event.target.value)}>
+            <option value="">All severities</option>
+            <option value="critical">Critical</option>
+            <option value="high">High</option>
+            <option value="medium">Medium</option>
+            <option value="low">Low</option>
+          </select>
+        </label>
+        <label style={{ display: "grid", gap: 4 }}>
+          <span style={{ color: "#64748b", fontSize: 12 }}>Resource type</span>
+          <select aria-label="Resource type filter" value={props.resourceType} onChange={(event) => props.onResourceTypeChange(event.target.value)}>
+            <option value="">All resources</option>
+            <option value="application">Application</option>
+            <option value="maintenance">Maintenance</option>
+            <option value="lease">Lease</option>
+          </select>
+        </label>
+        <label style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 24 }}>
+          <input
+            aria-label="Include low severity"
+            type="checkbox"
+            checked={props.includeLow}
+            onChange={(event) => props.onIncludeLowChange(event.target.checked)}
+          />
+          <span>Include low severity</span>
+        </label>
+      </div>
+      <div>
+        <Button variant="secondary" onClick={props.onRefresh} disabled={props.loading}>
+          {props.loading ? "Refreshing..." : "Refresh queue"}
+        </Button>
+      </div>
+    </Card>
+  );
+}
+
+export default TriageFilterBar;
+

--- a/rentchain-frontend/src/components/adminTriage/TriageQueueTable.tsx
+++ b/rentchain-frontend/src/components/adminTriage/TriageQueueTable.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import type { AdminTriageItemV1 } from "../../api/adminTriageApi";
+import TriageSeverityBadge from "./TriageSeverityBadge";
+
+function formatTimestamp(value: string) {
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return value || "Unknown time";
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(parsed));
+}
+
+function signalLine(item: AdminTriageItemV1) {
+  const parts = [
+    item.signals.reconciliationStatus ? `Reconciliation: ${item.signals.reconciliationStatus}` : null,
+    item.signals.lifecycleState ? `Lifecycle: ${item.signals.lifecycleState}` : null,
+    item.signals.policyOutcome ? `Policy: ${item.signals.policyOutcome}` : null,
+    item.signals.automationAction ? `Automation: ${item.signals.automationAction}` : null,
+    item.signals.reopenCount ? `Reopens: ${item.signals.reopenCount}` : null,
+    item.signals.blockedCount ? `Blocked: ${item.signals.blockedCount}` : null,
+  ].filter(Boolean);
+  return parts.join(" • ");
+}
+
+export function TriageQueueTable({ items }: { items: AdminTriageItemV1[] }) {
+  if (!items.length) {
+    return <div style={{ color: "#64748b" }}>No triage items need attention right now.</div>;
+  }
+
+  return (
+    <div style={{ display: "grid", gap: 12 }}>
+      {items.map((item) => (
+        <article key={item.id} style={{ border: "1px solid rgba(15,23,42,0.08)", borderRadius: 12, padding: 14, background: "rgba(255,255,255,0.92)" }}>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "flex-start", flexWrap: "wrap" }}>
+            <div style={{ display: "grid", gap: 6 }}>
+              <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+                <TriageSeverityBadge severity={item.severity} />
+                <span style={{ color: "#475569", fontSize: 12, textTransform: "uppercase", letterSpacing: "0.04em" }}>
+                  {item.category.replace(/_/g, " ")}
+                </span>
+              </div>
+              <strong>{item.resource.title || `${item.resource.type} ${item.resource.id}`}</strong>
+              <div style={{ color: "#475569" }}>
+                {item.reason.summary}
+              </div>
+              <div style={{ color: "#64748b", fontSize: 13 }}>
+                {item.resource.type} • {item.resource.id}
+                {item.resource.status ? ` • ${item.resource.status}` : ""}
+                {item.resource.subtitle ? ` • ${item.resource.subtitle}` : ""}
+              </div>
+              {signalLine(item) ? (
+                <div style={{ color: "#334155", fontSize: 13 }}>{signalLine(item)}</div>
+              ) : null}
+            </div>
+            <div style={{ display: "grid", gap: 8, justifyItems: "end" }}>
+              <div style={{ color: "#64748b", fontSize: 12 }}>Surfaced {formatTimestamp(item.timestamps.surfacedAt)}</div>
+              {item.navigation.supportConsolePath ? (
+                <Link to={item.navigation.supportConsolePath}>Open support console</Link>
+              ) : null}
+            </div>
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+export default TriageQueueTable;
+

--- a/rentchain-frontend/src/components/adminTriage/TriageSeverityBadge.tsx
+++ b/rentchain-frontend/src/components/adminTriage/TriageSeverityBadge.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+const COLORS: Record<string, { bg: string; fg: string }> = {
+  critical: { bg: "#fee2e2", fg: "#b91c1c" },
+  high: { bg: "#ffedd5", fg: "#c2410c" },
+  medium: { bg: "#fef3c7", fg: "#a16207" },
+  low: { bg: "#e0f2fe", fg: "#0369a1" },
+};
+
+export function TriageSeverityBadge({ severity }: { severity: string }) {
+  const tone = COLORS[severity] || COLORS.low;
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        padding: "2px 8px",
+        borderRadius: 999,
+        background: tone.bg,
+        color: tone.fg,
+        fontSize: 12,
+        fontWeight: 700,
+        textTransform: "uppercase",
+      }}
+    >
+      {severity}
+    </span>
+  );
+}
+
+export default TriageSeverityBadge;
+

--- a/rentchain-frontend/src/pages/admin/AdminTriageQueuePage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminTriageQueuePage.test.tsx
@@ -1,0 +1,128 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import AdminTriageQueuePage from "./AdminTriageQueuePage";
+
+const showToast = vi.fn();
+
+vi.mock("../../api/adminTriageApi", () => ({
+  fetchAdminTriageQueue: vi.fn(),
+}));
+
+vi.mock("../../components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast }),
+}));
+
+vi.mock("../../components/layout/MacShell", () => ({
+  MacShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("../../components/ui/Ui", () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  Pill: ({ children }: any) => <span>{children}</span>,
+  Section: ({ children }: any) => <section>{children}</section>,
+}));
+
+beforeEach(() => {
+  showToast.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("AdminTriageQueuePage", () => {
+  it("renders queue items and support console links", async () => {
+    const { fetchAdminTriageQueue } = await import("../../api/adminTriageApi");
+    vi.mocked(fetchAdminTriageQueue).mockResolvedValue({
+      items: [
+        {
+          id: "triage-1",
+          version: "v1",
+          category: "screening_reconciliation",
+          severity: "critical",
+          resource: {
+            type: "application",
+            id: "app-1",
+            title: "Alex Applicant",
+            status: "paid_not_fulfilled",
+          },
+          reason: {
+            code: "TRIAGE_PAID_NOT_FULFILLED",
+            summary: "Payment was recorded but screening completion is missing.",
+          },
+          signals: {
+            reconciliationStatus: "paid_not_fulfilled",
+            lifecycleState: "paid",
+          },
+          timestamps: {
+            surfacedAt: "2026-04-15T12:00:00.000Z",
+          },
+          navigation: {
+            supportConsolePath: "/admin/support-console?resourceType=application&resourceId=app-1",
+          },
+          tags: ["screening", "revenue"],
+        },
+      ],
+    } as any);
+
+    render(
+      <MemoryRouter>
+        <AdminTriageQueuePage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Alex Applicant/i)).toBeInTheDocument();
+    expect(screen.getByText(/Payment was recorded but screening completion is missing/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/critical/i).length).toBeGreaterThan(0);
+    expect(screen.getByRole("link", { name: /Open support console/i })).toHaveAttribute(
+      "href",
+      "/admin/support-console?resourceType=application&resourceId=app-1"
+    );
+  });
+
+  it("updates request parameters when filters change", async () => {
+    const { fetchAdminTriageQueue } = await import("../../api/adminTriageApi");
+    vi.mocked(fetchAdminTriageQueue).mockResolvedValue({ items: [] } as any);
+
+    render(
+      <MemoryRouter>
+        <AdminTriageQueuePage />
+      </MemoryRouter>
+    );
+
+    await screen.findByText(/No triage items need attention right now/i);
+
+    fireEvent.change(screen.getByLabelText(/Category filter/i), {
+      target: { value: "policy_review" },
+    });
+
+    await waitFor(() => {
+      expect(vi.mocked(fetchAdminTriageQueue)).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          category: "policy_review",
+        })
+      );
+    });
+  });
+
+  it("renders empty and error states", async () => {
+    const { fetchAdminTriageQueue } = await import("../../api/adminTriageApi");
+    vi.mocked(fetchAdminTriageQueue).mockResolvedValueOnce({ items: [] } as any);
+    vi.mocked(fetchAdminTriageQueue).mockRejectedValueOnce(new Error("Boom"));
+
+    render(
+      <MemoryRouter>
+        <AdminTriageQueuePage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/No triage items need attention right now/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Refresh queue/i }));
+    expect(await screen.findByText(/Failed to load triage queue: Boom/i)).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/admin/AdminTriageQueuePage.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminTriageQueuePage.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import { MacShell } from "../../components/layout/MacShell";
+import { Button, Card, Pill, Section } from "../../components/ui/Ui";
+import { useToast } from "../../components/ui/ToastProvider";
+import { fetchAdminTriageQueue, type AdminTriageItemV1 } from "../../api/adminTriageApi";
+import TriageFilterBar from "../../components/adminTriage/TriageFilterBar";
+import TriageQueueTable from "../../components/adminTriage/TriageQueueTable";
+
+export default function AdminTriageQueuePage() {
+  const { showToast } = useToast();
+  const [items, setItems] = React.useState<AdminTriageItemV1[]>([]);
+  const [loading, setLoading] = React.useState(false);
+  const [loadingMore, setLoadingMore] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [category, setCategory] = React.useState("");
+  const [severity, setSeverity] = React.useState("");
+  const [resourceType, setResourceType] = React.useState("");
+  const [includeLow, setIncludeLow] = React.useState(false);
+  const [nextCursor, setNextCursor] = React.useState<string | null>(null);
+
+  const load = React.useCallback(
+    async (cursor?: string | null) => {
+      const isLoadMore = Boolean(cursor);
+      try {
+        if (isLoadMore) {
+          setLoadingMore(true);
+        } else {
+          setLoading(true);
+          setError(null);
+        }
+        const response = await fetchAdminTriageQueue({
+          category: category || null,
+          severity: severity || null,
+          resourceType: resourceType || null,
+          includeLow,
+          limit: 20,
+          cursor: cursor || null,
+        });
+        setItems((current) => (isLoadMore ? [...current, ...(response.items || [])] : response.items || []));
+        setNextCursor(response.nextCursor || null);
+      } catch (err: any) {
+        const message = err?.message || "Failed to load admin triage queue";
+        setError(message);
+        showToast({
+          message: "Failed to load triage queue",
+          description: message,
+          variant: "error",
+        });
+      } finally {
+        setLoading(false);
+        setLoadingMore(false);
+      }
+    },
+    [category, includeLow, resourceType, severity, showToast]
+  );
+
+  React.useEffect(() => {
+    void load(null);
+  }, [load]);
+
+  return (
+    <MacShell title="Admin · Triage Queue">
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 16, alignItems: "flex-start", flexWrap: "wrap" }}>
+            <div style={{ display: "grid", gap: 6 }}>
+              <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+                <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Admin Triage Queue</h1>
+                <Pill tone="accent">Operations</Pill>
+              </div>
+              <div style={{ color: "#475569", maxWidth: 820 }}>
+                Read-only queue of resources that need operator attention across monetization, policy, automation, and workflow friction signals.
+              </div>
+            </div>
+            <Button variant="secondary" onClick={() => void load(null)} disabled={loading}>
+              Refresh
+            </Button>
+          </div>
+        </Section>
+
+        <TriageFilterBar
+          category={category}
+          severity={severity}
+          resourceType={resourceType}
+          includeLow={includeLow}
+          loading={loading}
+          onCategoryChange={setCategory}
+          onSeverityChange={setSeverity}
+          onResourceTypeChange={setResourceType}
+          onIncludeLowChange={setIncludeLow}
+          onRefresh={() => void load(null)}
+        />
+
+        {loading ? <Card>Loading triage queue…</Card> : null}
+        {!loading && error ? <Card style={{ color: "#b91c1c" }}>Failed to load triage queue: {error}</Card> : null}
+        {!loading && !error ? (
+          <Card>
+            <TriageQueueTable items={items} />
+          </Card>
+        ) : null}
+
+        {!loading && !error && nextCursor ? (
+          <div>
+            <Button variant="secondary" onClick={() => void load(nextCursor)} disabled={loadingMore}>
+              {loadingMore ? "Loading..." : "Load more"}
+            </Button>
+          </div>
+        ) : null}
+      </div>
+    </MacShell>
+  );
+}
+


### PR DESCRIPTION
Full commit hash: `cd501a0c6eb1bd7a87d0f4c811e08f1b8151f180`

The branch is pushed to GitHub:
- `origin/feat/admin-triage-queue-v1`
- PR URL: https://github.com/rentchaincanada/rentchain/pull/new/feat/admin-triage-queue-v1

GitHub CI vs local:
- Local is green for the requested Mission 9 validation:
  - backend targeted tests passed
  - backend build passed
  - frontend targeted tests passed
  - frontend build passed
  - full frontend test suite passed
- I have not fetched fresh GitHub CI results after push in this turn, so I can confirm local is green but not yet claim final GitHub parity.

Final Mission 9 readiness summary:
- Added an admin-only triage queue that converts existing reconciliation, policy, automation, and maintenance insight signals into actionable queue items.
- Severity and category mapping are deterministic and centralized.
- Every item includes direct support-console navigation for exact-resource diagnosis.
- Stall/reopen detection stays conservative:
  - maintenance reopen uses existing derived `reopenCount`
  - workflow stall uses a centralized inactivity threshold and excludes completed flows
- The route remains admin-only and read-only.
- No write-path behavior, policy logic, automation logic, or reconciliation logic was changed.

Note:
- There was a local branch-pointer mix-up during commit/push, but I corrected it and confirmed `feat/admin-triage-queue-v1` on origin now points at the Mission 9 commit above.

I’m paused here for review and won’t start Mission 10.