### PR TITLE
feat: add portfolio score history and trend layer v1

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -103,6 +103,7 @@ import screeningReconciliationRoutes from "./routes/screeningReconciliationRoute
 import supportConsoleRoutes from "./routes/supportConsoleRoutes";
 import adminTriageRoutes from "./routes/adminTriageRoutes";
 import portfolioScoreRoutes from "./routes/portfolioScoreRoutes";
+import portfolioScoreHistoryRoutes from "./routes/portfolioScoreHistoryRoutes";
 import transunionRoutes from "./services/integrations/transunion/transunionRoutes";
 import viewingRoutes from "./routes/viewingRoutes";
 import screeningOpsRoutes from "./routes/screeningOpsRoutes";
@@ -228,6 +229,8 @@ app.use("/api/admin", routeSource("adminTriageRoutes.ts"), adminTriageRoutes);
 console.log("[route-mount] adminTriageRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("portfolioScoreRoutes.ts"), portfolioScoreRoutes);
 console.log("[route-mount] portfolioScoreRoutes mounted at /api/admin");
+app.use("/api/admin", routeSource("portfolioScoreHistoryRoutes.ts"), portfolioScoreHistoryRoutes);
+console.log("[route-mount] portfolioScoreHistoryRoutes mounted at /api/admin");
 
 // Current user info
 app.get("/api/me", async (req: any, res: any, next: any) => {

--- a/rentchain-api/src/lib/portfolioScoreHistory/__tests__/derivePortfolioScoreTrend.test.ts
+++ b/rentchain-api/src/lib/portfolioScoreHistory/__tests__/derivePortfolioScoreTrend.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { derivePortfolioScoreTrend } from "../derivePortfolioScoreTrend";
+import type { PortfolioScoreSnapshotV1 } from "../portfolioScoreHistoryTypes";
+
+function snapshot(overrides?: Partial<PortfolioScoreSnapshotV1>): PortfolioScoreSnapshotV1 {
+  return {
+    version: "v1",
+    portfolioId: "portfolio-1",
+    snapshotAt: "2026-04-15T12:00:00.000Z",
+    score: 80,
+    grade: "B",
+    status: "watch",
+    headline: "Portfolio is stable overall.",
+    componentScores: [
+      { key: "workflow_completion", normalizedScore: 80, contribution: 20 },
+      { key: "screening_reliability", normalizedScore: 80, contribution: 16 },
+      { key: "maintenance_stability", normalizedScore: 80, contribution: 12 },
+      { key: "automation_health", normalizedScore: 80, contribution: 8 },
+      { key: "policy_friction", normalizedScore: 80, contribution: 8 },
+      { key: "exception_burden", normalizedScore: 80, contribution: 16 },
+    ],
+    metrics: {
+      totalResourcesReviewed: 20,
+      triageItemCount: 2,
+      criticalTriageCount: 0,
+      reconciliationIssueCount: 1,
+      automationSkipCount: 1,
+      policyReviewCount: 1,
+      blockedWorkflowCount: 0,
+      maintenanceReopenCount: 0,
+    },
+    ...overrides,
+  };
+}
+
+describe("derivePortfolioScoreTrend", () => {
+  it("derives an upward trend from two snapshots", () => {
+    const trend = derivePortfolioScoreTrend([
+      snapshot({ snapshotAt: "2026-04-15T12:00:00.000Z", score: 84, grade: "B" }),
+      snapshot({ snapshotAt: "2026-04-01T12:00:00.000Z", score: 78, grade: "C" }),
+    ]);
+
+    expect(trend.direction).toBe("up");
+    expect(trend.deltaScore).toBe(6);
+    expect(trend.deltaGrade).toBe("C -> B");
+  });
+
+  it("derives a flat trend within the neutral threshold", () => {
+    const trend = derivePortfolioScoreTrend([
+      snapshot({ snapshotAt: "2026-04-15T12:00:00.000Z", score: 81 }),
+      snapshot({ snapshotAt: "2026-04-01T12:00:00.000Z", score: 80 }),
+    ]);
+
+    expect(trend.direction).toBe("flat");
+    expect(trend.deltaScore).toBe(1);
+  });
+
+  it("handles insufficient data safely", () => {
+    const trend = derivePortfolioScoreTrend([snapshot()]);
+
+    expect(trend.direction).toBe("insufficient_data");
+    expect(trend.deltaScore).toBeNull();
+    expect(trend.movers).toEqual([]);
+  });
+
+  it("sorts movers by absolute delta contribution", () => {
+    const trend = derivePortfolioScoreTrend([
+      snapshot({
+        snapshotAt: "2026-04-15T12:00:00.000Z",
+        componentScores: [
+          { key: "workflow_completion", normalizedScore: 90, contribution: 22.5 },
+          { key: "screening_reliability", normalizedScore: 60, contribution: 12 },
+          { key: "maintenance_stability", normalizedScore: 80, contribution: 12 },
+          { key: "automation_health", normalizedScore: 80, contribution: 8 },
+          { key: "policy_friction", normalizedScore: 80, contribution: 8 },
+          { key: "exception_burden", normalizedScore: 70, contribution: 14 },
+        ],
+      }),
+      snapshot({
+        snapshotAt: "2026-04-01T12:00:00.000Z",
+        componentScores: [
+          { key: "workflow_completion", normalizedScore: 82, contribution: 20.5 },
+          { key: "screening_reliability", normalizedScore: 80, contribution: 16 },
+          { key: "maintenance_stability", normalizedScore: 80, contribution: 12 },
+          { key: "automation_health", normalizedScore: 80, contribution: 8 },
+          { key: "policy_friction", normalizedScore: 80, contribution: 8 },
+          { key: "exception_burden", normalizedScore: 80, contribution: 16 },
+        ],
+      }),
+    ]);
+
+    expect(trend.movers[0]?.key).toBe("screening_reliability");
+    expect(trend.movers[0]?.direction).toBe("down");
+  });
+});
+

--- a/rentchain-api/src/lib/portfolioScoreHistory/buildPortfolioScoreSnapshot.ts
+++ b/rentchain-api/src/lib/portfolioScoreHistory/buildPortfolioScoreSnapshot.ts
@@ -1,0 +1,27 @@
+import type { PortfolioScoreV1 } from "../portfolioScore/portfolioScoreTypes";
+import type { PortfolioScoreSnapshotV1 } from "./portfolioScoreHistoryTypes";
+
+export function buildPortfolioScoreSnapshot(
+  portfolioScore: PortfolioScoreV1,
+  snapshotAt?: string
+): PortfolioScoreSnapshotV1 {
+  const timestamp = snapshotAt || new Date().toISOString();
+  return {
+    version: "v1",
+    portfolioId: portfolioScore.portfolioId,
+    snapshotAt: timestamp,
+    score: portfolioScore.score,
+    grade: portfolioScore.grade,
+    status: portfolioScore.summary.status,
+    headline: portfolioScore.summary.headline,
+    componentScores: portfolioScore.components.map((component) => ({
+      key: component.key,
+      normalizedScore: component.normalizedScore,
+      contribution: component.contribution,
+    })),
+    metrics: {
+      ...portfolioScore.metrics,
+    },
+  };
+}
+

--- a/rentchain-api/src/lib/portfolioScoreHistory/derivePortfolioScoreTrend.ts
+++ b/rentchain-api/src/lib/portfolioScoreHistory/derivePortfolioScoreTrend.ts
@@ -1,0 +1,156 @@
+import { PORTFOLIO_SCORE_TREND_DELTA_THRESHOLD } from "./portfolioScoreHistoryConstants";
+import type { PortfolioScoreSnapshotV1, PortfolioScoreTrendV1 } from "./portfolioScoreHistoryTypes";
+
+function round(value: number) {
+  return Math.round(value * 100) / 100;
+}
+
+function compareSnapshotsDescending(a: PortfolioScoreSnapshotV1, b: PortfolioScoreSnapshotV1) {
+  return Date.parse(b.snapshotAt) - Date.parse(a.snapshotAt);
+}
+
+function componentSummary(key: string, direction: "up" | "down" | "flat") {
+  if (key === "screening_reliability") {
+    return direction === "down"
+      ? "Screening reconciliation issues reduced reliability."
+      : direction === "up"
+      ? "Screening reconciliation reliability improved."
+      : "Screening reliability stayed stable.";
+  }
+  if (key === "exception_burden") {
+    return direction === "down"
+      ? "Exception burden increased and weighed on the score."
+      : direction === "up"
+      ? "Exception burden eased versus the previous snapshot."
+      : "Exception burden stayed stable.";
+  }
+  if (key === "maintenance_stability") {
+    return direction === "down"
+      ? "Maintenance reopen or stall signals reduced stability."
+      : direction === "up"
+      ? "Maintenance stability improved across recent workflows."
+      : "Maintenance stability stayed stable.";
+  }
+  if (key === "automation_health") {
+    return direction === "down"
+      ? "Automation skips increased or successful execution fell."
+      : direction === "up"
+      ? "Automation execution quality improved."
+      : "Automation health stayed stable.";
+  }
+  if (key === "policy_friction") {
+    return direction === "down"
+      ? "Policy reviews or blocks increased friction."
+      : direction === "up"
+      ? "Policy friction eased versus the previous snapshot."
+      : "Policy friction stayed stable.";
+  }
+  return direction === "down"
+    ? "Workflow completion declined versus the previous snapshot."
+    : direction === "up"
+    ? "Workflow completion improved versus the previous snapshot."
+    : "Workflow completion stayed stable.";
+}
+
+export function derivePortfolioScoreTrend(
+  snapshots: PortfolioScoreSnapshotV1[],
+  portfolioId?: string
+): PortfolioScoreTrendV1 {
+  const history = [...(snapshots || [])].sort(compareSnapshotsDescending);
+  const latest = history[0] || null;
+  const previous = history[1] || null;
+  const safePortfolioId = portfolioId || latest?.portfolioId || previous?.portfolioId || "";
+  const generatedAt = new Date().toISOString();
+
+  if (!latest || !previous) {
+    return {
+      version: "v1",
+      portfolioId: safePortfolioId,
+      generatedAt,
+      latest,
+      previous,
+      direction: "insufficient_data",
+      deltaScore: null,
+      deltaGrade: null,
+      summary: {
+        headline: latest
+          ? "More score history is needed before a trend can be established."
+          : "No portfolio score history is available yet.",
+        notes: latest
+          ? ["Create at least one more snapshot to compare score direction and component movement."]
+          : ["Create the first snapshot to start tracking portfolio score movement over time."],
+      },
+      movers: [],
+      history,
+    };
+  }
+
+  const deltaScore = round(latest.score - previous.score);
+  const direction =
+    deltaScore > PORTFOLIO_SCORE_TREND_DELTA_THRESHOLD
+      ? "up"
+      : deltaScore < -PORTFOLIO_SCORE_TREND_DELTA_THRESHOLD
+      ? "down"
+      : "flat";
+
+  const previousByKey = new Map(previous.componentScores.map((component) => [component.key, component]));
+  const movers = latest.componentScores
+    .map((component) => {
+      const previousComponent = previousByKey.get(component.key);
+      const deltaNormalizedScore = round(component.normalizedScore - (previousComponent?.normalizedScore || 0));
+      const deltaContribution = round(component.contribution - (previousComponent?.contribution || 0));
+      const moverDirection: "up" | "down" | "flat" =
+        deltaContribution > 0 ? "up" : deltaContribution < 0 ? "down" : "flat";
+      return {
+        key: component.key,
+        deltaNormalizedScore,
+        deltaContribution,
+        direction: moverDirection,
+        summary: componentSummary(component.key, moverDirection),
+      };
+    })
+    .sort((a, b) => Math.abs(b.deltaContribution) - Math.abs(a.deltaContribution));
+
+  const topMover = movers[0];
+  const headline =
+    direction === "up"
+      ? "Portfolio score improved versus the previous snapshot."
+      : direction === "down"
+      ? "Portfolio score declined versus the previous snapshot."
+      : "Portfolio score is broadly stable versus the previous snapshot.";
+
+  const notes: string[] = [];
+  if (topMover && topMover.direction !== "flat") {
+    notes.push(topMover.summary);
+  }
+  if (latest.metrics.criticalTriageCount > previous.metrics.criticalTriageCount) {
+    notes.push("Critical triage burden increased since the previous snapshot.");
+  } else if (latest.metrics.criticalTriageCount < previous.metrics.criticalTriageCount) {
+    notes.push("Critical triage burden decreased since the previous snapshot.");
+  }
+  if (latest.metrics.reconciliationIssueCount > previous.metrics.reconciliationIssueCount) {
+    notes.push("Reconciliation issue burden increased.");
+  } else if (latest.metrics.reconciliationIssueCount < previous.metrics.reconciliationIssueCount) {
+    notes.push("Reconciliation issue burden decreased.");
+  }
+  if (!notes.length) {
+    notes.push("Component movement stayed within a narrow operating band.");
+  }
+
+  return {
+    version: "v1",
+    portfolioId: safePortfolioId,
+    generatedAt,
+    latest,
+    previous,
+    direction,
+    deltaScore,
+    deltaGrade: latest.grade === previous.grade ? null : `${previous.grade} -> ${latest.grade}`,
+    summary: {
+      headline,
+      notes,
+    },
+    movers: movers.filter((mover) => Math.abs(mover.deltaContribution) > 0),
+    history,
+  };
+}

--- a/rentchain-api/src/lib/portfolioScoreHistory/loadPortfolioScoreHistory.ts
+++ b/rentchain-api/src/lib/portfolioScoreHistory/loadPortfolioScoreHistory.ts
@@ -1,0 +1,28 @@
+import { db } from "../../config/firebase";
+import { PORTFOLIO_SCORE_SNAPSHOTS_COLLECTION } from "./portfolioScoreHistoryConstants";
+import type { PortfolioScoreSnapshotV1 } from "./portfolioScoreHistoryTypes";
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function parseTimestamp(value: unknown) {
+  const raw = asString(value, 120);
+  if (!raw) return 0;
+  const parsed = Date.parse(raw);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export async function loadPortfolioScoreHistory(
+  portfolioId: string,
+  limit = 12
+): Promise<PortfolioScoreSnapshotV1[]> {
+  const safePortfolioId = asString(portfolioId, 240);
+  const snap = await db.collection(PORTFOLIO_SCORE_SNAPSHOTS_COLLECTION).get();
+  const items = (snap.docs || [])
+    .map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }) as PortfolioScoreSnapshotV1)
+    .filter((item) => asString(item.portfolioId, 240) === safePortfolioId)
+    .sort((a, b) => parseTimestamp(b.snapshotAt) - parseTimestamp(a.snapshotAt));
+  return items.slice(0, Math.max(1, Math.min(100, Math.floor(limit))));
+}
+

--- a/rentchain-api/src/lib/portfolioScoreHistory/portfolioScoreHistoryConstants.ts
+++ b/rentchain-api/src/lib/portfolioScoreHistory/portfolioScoreHistoryConstants.ts
@@ -1,0 +1,3 @@
+export const PORTFOLIO_SCORE_SNAPSHOTS_COLLECTION = "portfolioScoreSnapshots";
+export const PORTFOLIO_SCORE_TREND_DELTA_THRESHOLD = 2;
+

--- a/rentchain-api/src/lib/portfolioScoreHistory/portfolioScoreHistoryTypes.ts
+++ b/rentchain-api/src/lib/portfolioScoreHistory/portfolioScoreHistoryTypes.ts
@@ -1,0 +1,60 @@
+export type PortfolioScoreTrendDirection =
+  | "up"
+  | "down"
+  | "flat"
+  | "insufficient_data";
+
+export type PortfolioScoreSnapshotV1 = {
+  version: "v1";
+  portfolioId: string;
+  snapshotAt: string;
+  score: number;
+  grade: "A" | "B" | "C" | "D" | "E";
+  status: "healthy" | "watch" | "at_risk";
+  headline: string;
+  componentScores: Array<{
+    key:
+      | "workflow_completion"
+      | "screening_reliability"
+      | "maintenance_stability"
+      | "automation_health"
+      | "policy_friction"
+      | "exception_burden";
+    normalizedScore: number;
+    contribution: number;
+  }>;
+  metrics: {
+    totalResourcesReviewed: number;
+    triageItemCount: number;
+    criticalTriageCount: number;
+    reconciliationIssueCount: number;
+    automationSkipCount: number;
+    policyReviewCount: number;
+    blockedWorkflowCount: number;
+    maintenanceReopenCount: number;
+  };
+};
+
+export type PortfolioScoreTrendV1 = {
+  version: "v1";
+  portfolioId: string;
+  generatedAt: string;
+  latest?: PortfolioScoreSnapshotV1 | null;
+  previous?: PortfolioScoreSnapshotV1 | null;
+  direction: PortfolioScoreTrendDirection;
+  deltaScore: number | null;
+  deltaGrade?: string | null;
+  summary: {
+    headline: string;
+    notes: string[];
+  };
+  movers: Array<{
+    key: string;
+    deltaNormalizedScore: number;
+    deltaContribution: number;
+    direction: "up" | "down" | "flat";
+    summary: string;
+  }>;
+  history: PortfolioScoreSnapshotV1[];
+};
+

--- a/rentchain-api/src/lib/portfolioScoreHistory/savePortfolioScoreSnapshot.ts
+++ b/rentchain-api/src/lib/portfolioScoreHistory/savePortfolioScoreSnapshot.ts
@@ -1,0 +1,21 @@
+import { db } from "../../config/firebase";
+import { derivePortfolioScore } from "../portfolioScore/derivePortfolioScore";
+import { loadPortfolioScoreSignals } from "../portfolioScore/loadPortfolioScoreSignals";
+import { buildPortfolioScoreSnapshot } from "./buildPortfolioScoreSnapshot";
+import { PORTFOLIO_SCORE_SNAPSHOTS_COLLECTION } from "./portfolioScoreHistoryConstants";
+import type { PortfolioScoreSnapshotV1 } from "./portfolioScoreHistoryTypes";
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+export async function savePortfolioScoreSnapshot(portfolioId: string): Promise<PortfolioScoreSnapshotV1> {
+  const safePortfolioId = asString(portfolioId, 240);
+  const signals = await loadPortfolioScoreSignals(safePortfolioId);
+  const portfolioScore = derivePortfolioScore(signals);
+  const snapshot = buildPortfolioScoreSnapshot(portfolioScore);
+  const docId = `${safePortfolioId}_${snapshot.snapshotAt}`;
+  await db.collection(PORTFOLIO_SCORE_SNAPSHOTS_COLLECTION).doc(docId).set(snapshot, { merge: false });
+  return snapshot;
+}
+

--- a/rentchain-api/src/routes/__tests__/portfolioScoreHistoryRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/portfolioScoreHistoryRoutes.test.ts
@@ -1,0 +1,245 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { collections, dbMock } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, any>>();
+
+  function ensureCollection(name: string) {
+    if (!collections.has(name)) {
+      collections.set(name, new Map<string, any>());
+    }
+    return collections.get(name)!;
+  }
+
+  return {
+    collections,
+    dbMock: {
+      collection: (name: string) => ({
+        doc(id: string) {
+          return {
+            async set(payload: any) {
+              ensureCollection(name).set(id, payload);
+            },
+          };
+        },
+        async get() {
+          const docs = Array.from(ensureCollection(name).entries()).map(([id, data]) => ({
+            id,
+            data: () => data,
+          }));
+          return { docs, empty: docs.length === 0, size: docs.length };
+        },
+      }),
+    },
+  };
+});
+
+vi.mock("../../config/firebase", () => ({
+  db: dbMock,
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!req.user) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    return next();
+  },
+}));
+
+async function invokeRouter(
+  router: any,
+  options: { method: string; url: string; user?: Record<string, unknown> | null; body?: any }
+) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    const query = new URLSearchParams(queryString || "");
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: options.user ?? null,
+      query: Object.fromEntries(query.entries()),
+      params: {},
+      body: options.body || {},
+      headers: {},
+      get(name: string) {
+        return this.headers[String(name).toLowerCase()];
+      },
+      header(name: string) {
+        return this.get(name);
+      },
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, string>,
+      setHeader(name: string, value: string) {
+        this.headers[name.toLowerCase()] = value;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+function seedDoc(collectionName: string, id: string, data: any) {
+  if (!collections.has(collectionName)) {
+    collections.set(collectionName, new Map<string, any>());
+  }
+  collections.get(collectionName)!.set(id, { id, ...data });
+}
+
+describe("portfolioScoreHistoryRoutes", () => {
+  beforeEach(() => {
+    collections.clear();
+  });
+
+  it("lets an admin fetch ordered history", async () => {
+    seedDoc("portfolioScoreSnapshots", "snap-1", {
+      portfolioId: "portfolio-1",
+      snapshotAt: "2026-04-15T12:00:00.000Z",
+      score: 82,
+      grade: "B",
+      status: "watch",
+      headline: "Current snapshot",
+      componentScores: [],
+      metrics: {
+        totalResourcesReviewed: 1,
+        triageItemCount: 0,
+        criticalTriageCount: 0,
+        reconciliationIssueCount: 0,
+        automationSkipCount: 0,
+        policyReviewCount: 0,
+        blockedWorkflowCount: 0,
+        maintenanceReopenCount: 0,
+      },
+    });
+    seedDoc("portfolioScoreSnapshots", "snap-0", {
+      portfolioId: "portfolio-1",
+      snapshotAt: "2026-04-01T12:00:00.000Z",
+      score: 78,
+      grade: "C",
+      status: "watch",
+      headline: "Previous snapshot",
+      componentScores: [],
+      metrics: {
+        totalResourcesReviewed: 1,
+        triageItemCount: 0,
+        criticalTriageCount: 0,
+        reconciliationIssueCount: 0,
+        automationSkipCount: 0,
+        policyReviewCount: 0,
+        blockedWorkflowCount: 0,
+        maintenanceReopenCount: 0,
+      },
+    });
+
+    const router = (await import("../portfolioScoreHistoryRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/portfolio-score/history?portfolioId=portfolio-1&limit=12",
+      user: { id: "admin-1", role: "admin" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body?.history).toHaveLength(2);
+    expect(response.body?.history[0]?.score).toBe(82);
+  });
+
+  it("lets an admin fetch trend and handles missing portfolioId safely", async () => {
+    seedDoc("portfolioScoreSnapshots", "snap-1", {
+      portfolioId: "portfolio-1",
+      snapshotAt: "2026-04-15T12:00:00.000Z",
+      score: 82,
+      grade: "B",
+      status: "watch",
+      headline: "Current snapshot",
+      componentScores: [{ key: "workflow_completion", normalizedScore: 82, contribution: 20.5 }],
+      metrics: {
+        totalResourcesReviewed: 1,
+        triageItemCount: 0,
+        criticalTriageCount: 0,
+        reconciliationIssueCount: 0,
+        automationSkipCount: 0,
+        policyReviewCount: 0,
+        blockedWorkflowCount: 0,
+        maintenanceReopenCount: 0,
+      },
+    });
+    seedDoc("portfolioScoreSnapshots", "snap-0", {
+      portfolioId: "portfolio-1",
+      snapshotAt: "2026-04-01T12:00:00.000Z",
+      score: 78,
+      grade: "C",
+      status: "watch",
+      headline: "Previous snapshot",
+      componentScores: [{ key: "workflow_completion", normalizedScore: 78, contribution: 19.5 }],
+      metrics: {
+        totalResourcesReviewed: 1,
+        triageItemCount: 0,
+        criticalTriageCount: 0,
+        reconciliationIssueCount: 0,
+        automationSkipCount: 0,
+        policyReviewCount: 0,
+        blockedWorkflowCount: 0,
+        maintenanceReopenCount: 0,
+      },
+    });
+
+    const router = (await import("../portfolioScoreHistoryRoutes")).default;
+    const trendResponse = await invokeRouter(router, {
+      method: "GET",
+      url: "/portfolio-score/trend?portfolioId=portfolio-1&limit=12",
+      user: { id: "admin-1", role: "admin" },
+    });
+
+    expect(trendResponse.status).toBe(200);
+    expect(trendResponse.body?.trend?.direction).toBe("up");
+
+    const invalidResponse = await invokeRouter(router, {
+      method: "GET",
+      url: "/portfolio-score/trend",
+      user: { id: "admin-1", role: "admin" },
+    });
+    expect(invalidResponse.status).toBe(400);
+    expect(invalidResponse.body?.error).toBe("PORTFOLIO_ID_REQUIRED");
+  });
+
+  it("lets an admin create a snapshot and enforces admin-only access", async () => {
+    seedDoc("rentalApplications", "app-1", {
+      landlordId: "portfolio-1",
+      applicantName: "Alex Applicant",
+    });
+
+    const router = (await import("../portfolioScoreHistoryRoutes")).default;
+    const forbidden = await invokeRouter(router, {
+      method: "POST",
+      url: "/portfolio-score/snapshot",
+      user: { id: "landlord-1", role: "landlord" },
+      body: { portfolioId: "portfolio-1" },
+    });
+    expect(forbidden.status).toBe(403);
+
+    const created = await invokeRouter(router, {
+      method: "POST",
+      url: "/portfolio-score/snapshot",
+      user: { id: "admin-1", role: "admin" },
+      body: { portfolioId: "portfolio-1" },
+    });
+
+    expect(created.status).toBe(201);
+    expect(created.body?.snapshot?.portfolioId).toBe("portfolio-1");
+  });
+});
+

--- a/rentchain-api/src/routes/portfolioScoreHistoryRoutes.ts
+++ b/rentchain-api/src/routes/portfolioScoreHistoryRoutes.ts
@@ -1,0 +1,85 @@
+import { Router } from "express";
+import { requireAuth } from "../middleware/requireAuth";
+import { loadPortfolioScoreHistory } from "../lib/portfolioScoreHistory/loadPortfolioScoreHistory";
+import { derivePortfolioScoreTrend } from "../lib/portfolioScoreHistory/derivePortfolioScoreTrend";
+import { savePortfolioScoreSnapshot } from "../lib/portfolioScoreHistory/savePortfolioScoreSnapshot";
+
+const router = Router();
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function normalizeRole(req: any): "admin" | "landlord" | "other" {
+  const role = asString(req.user?.actorRole || req.user?.role, 40).toLowerCase();
+  if (role === "admin") return "admin";
+  if (role === "landlord") return "landlord";
+  return "other";
+}
+
+function parseLimit(value: unknown) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return 12;
+  return Math.max(1, Math.min(100, Math.floor(parsed)));
+}
+
+router.get("/portfolio-score/history", requireAuth, async (req: any, res) => {
+  try {
+    if (normalizeRole(req) !== "admin") {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+
+    const portfolioId = asString(req.query?.portfolioId, 240);
+    if (!portfolioId) {
+      return res.status(400).json({ ok: false, error: "PORTFOLIO_ID_REQUIRED" });
+    }
+
+    const history = await loadPortfolioScoreHistory(portfolioId, parseLimit(req.query?.limit));
+    return res.json({ history });
+  } catch (err: any) {
+    console.error("[portfolio-score-history] fetch failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "PORTFOLIO_SCORE_HISTORY_FETCH_FAILED" });
+  }
+});
+
+router.get("/portfolio-score/trend", requireAuth, async (req: any, res) => {
+  try {
+    if (normalizeRole(req) !== "admin") {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+
+    const portfolioId = asString(req.query?.portfolioId, 240);
+    if (!portfolioId) {
+      return res.status(400).json({ ok: false, error: "PORTFOLIO_ID_REQUIRED" });
+    }
+
+    const history = await loadPortfolioScoreHistory(portfolioId, parseLimit(req.query?.limit));
+    const trend = derivePortfolioScoreTrend(history, portfolioId);
+    return res.json({ trend });
+  } catch (err: any) {
+    console.error("[portfolio-score-trend] fetch failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "PORTFOLIO_SCORE_TREND_FETCH_FAILED" });
+  }
+});
+
+router.post("/portfolio-score/snapshot", requireAuth, async (req: any, res) => {
+  try {
+    if (normalizeRole(req) !== "admin") {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+
+    const portfolioId = asString(req.body?.portfolioId, 240);
+    if (!portfolioId) {
+      return res.status(400).json({ ok: false, error: "PORTFOLIO_ID_REQUIRED" });
+    }
+
+    const snapshot = await savePortfolioScoreSnapshot(portfolioId);
+    return res.status(201).json({ snapshot });
+  } catch (err: any) {
+    console.error("[portfolio-score-snapshot] create failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "PORTFOLIO_SCORE_SNAPSHOT_CREATE_FAILED" });
+  }
+});
+
+export default router;
+

--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -66,6 +66,10 @@ vi.mock("./pages/admin/PortfolioScorePage", () => ({
   default: () => <h1>Portfolio Score Foundation</h1>,
 }));
 
+vi.mock("./pages/admin/PortfolioScoreHistoryPage", () => ({
+  default: () => <h1>Portfolio Score History</h1>,
+}));
+
 vi.mock("./pages/tenant/TenantWorkspacePage", () => ({
   default: () => <h1>Tenant Dashboard</h1>,
 }));
@@ -199,6 +203,20 @@ describe("Routes: /admin/portfolio-score", () => {
     );
 
     expect(await screen.findByText(/Portfolio Score Foundation/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Routes: /admin/portfolio-score/history", () => {
+  it("renders the admin portfolio score history route", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/admin/portfolio-score/history"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Portfolio Score History/i)).toBeInTheDocument();
     expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -154,6 +154,7 @@ const AutomationTimelineV1Page = lazy(() => import("./pages/admin/AutomationTime
 const SupportDebugConsolePage = lazy(() => import("./pages/admin/SupportDebugConsolePage"));
 const AdminTriageQueuePage = lazy(() => import("./pages/admin/AdminTriageQueuePage"));
 const PortfolioScorePage = lazy(() => import("./pages/admin/PortfolioScorePage"));
+const PortfolioScoreHistoryPage = lazy(() => import("./pages/admin/PortfolioScoreHistoryPage"));
 
 const AuthLoadingScreen = () => (
   <div
@@ -899,6 +900,16 @@ function App() {
             <RequireAdmin>
               <Suspense fallback={null}>
                 <PortfolioScorePage />
+              </Suspense>
+            </RequireAdmin>
+          }
+        />
+        <Route
+          path="/admin/portfolio-score/history"
+          element={
+            <RequireAdmin>
+              <Suspense fallback={null}>
+                <PortfolioScoreHistoryPage />
               </Suspense>
             </RequireAdmin>
           }

--- a/rentchain-frontend/src/api/portfolioScoreHistoryApi.ts
+++ b/rentchain-frontend/src/api/portfolioScoreHistoryApi.ts
@@ -1,0 +1,77 @@
+import { apiFetch } from "./apiFetch";
+
+export type PortfolioScoreSnapshotV1 = {
+  version: "v1";
+  portfolioId: string;
+  snapshotAt: string;
+  score: number;
+  grade: "A" | "B" | "C" | "D" | "E";
+  status: "healthy" | "watch" | "at_risk";
+  headline: string;
+  componentScores: Array<{
+    key:
+      | "workflow_completion"
+      | "screening_reliability"
+      | "maintenance_stability"
+      | "automation_health"
+      | "policy_friction"
+      | "exception_burden";
+    normalizedScore: number;
+    contribution: number;
+  }>;
+  metrics: {
+    totalResourcesReviewed: number;
+    triageItemCount: number;
+    criticalTriageCount: number;
+    reconciliationIssueCount: number;
+    automationSkipCount: number;
+    policyReviewCount: number;
+    blockedWorkflowCount: number;
+    maintenanceReopenCount: number;
+  };
+};
+
+export type PortfolioScoreTrendV1 = {
+  version: "v1";
+  portfolioId: string;
+  generatedAt: string;
+  latest?: PortfolioScoreSnapshotV1 | null;
+  previous?: PortfolioScoreSnapshotV1 | null;
+  direction: "up" | "down" | "flat" | "insufficient_data";
+  deltaScore: number | null;
+  deltaGrade?: string | null;
+  summary: {
+    headline: string;
+    notes: string[];
+  };
+  movers: Array<{
+    key: string;
+    deltaNormalizedScore: number;
+    deltaContribution: number;
+    direction: "up" | "down" | "flat";
+    summary: string;
+  }>;
+  history: PortfolioScoreSnapshotV1[];
+};
+
+export async function fetchPortfolioScoreHistory(portfolioId: string, limit = 12): Promise<{ history: PortfolioScoreSnapshotV1[] }> {
+  const search = new URLSearchParams();
+  search.set("portfolioId", portfolioId);
+  search.set("limit", String(limit));
+  return await apiFetch<{ history: PortfolioScoreSnapshotV1[] }>(`/admin/portfolio-score/history?${search.toString()}`);
+}
+
+export async function fetchPortfolioScoreTrend(portfolioId: string, limit = 12): Promise<{ trend: PortfolioScoreTrendV1 }> {
+  const search = new URLSearchParams();
+  search.set("portfolioId", portfolioId);
+  search.set("limit", String(limit));
+  return await apiFetch<{ trend: PortfolioScoreTrendV1 }>(`/admin/portfolio-score/trend?${search.toString()}`);
+}
+
+export async function createPortfolioScoreSnapshot(portfolioId: string): Promise<{ snapshot: PortfolioScoreSnapshotV1 }> {
+  return await apiFetch<{ snapshot: PortfolioScoreSnapshotV1 }>(`/admin/portfolio-score/snapshot`, {
+    method: "POST",
+    body: { portfolioId },
+  });
+}
+

--- a/rentchain-frontend/src/components/portfolioScoreHistory/PortfolioScoreHistoryTable.tsx
+++ b/rentchain-frontend/src/components/portfolioScoreHistory/PortfolioScoreHistoryTable.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { Card } from "../ui/Ui";
+import type { PortfolioScoreSnapshotV1 } from "../../api/portfolioScoreHistoryApi";
+
+export default function PortfolioScoreHistoryTable({ history }: { history: PortfolioScoreSnapshotV1[] }) {
+  return (
+    <Card>
+      <div style={{ display: "grid", gap: 12 }}>
+        <h3 style={{ margin: 0 }}>Score history</h3>
+        {!history.length ? (
+          <div style={{ color: "#64748b" }}>No score snapshots have been stored yet.</div>
+        ) : (
+          <div style={{ overflowX: "auto" }}>
+            <table style={{ width: "100%", borderCollapse: "collapse" }}>
+              <thead>
+                <tr style={{ textAlign: "left", color: "#64748b" }}>
+                  <th style={{ padding: "8px 0" }}>Snapshot</th>
+                  <th style={{ padding: "8px 0" }}>Score</th>
+                  <th style={{ padding: "8px 0" }}>Grade</th>
+                  <th style={{ padding: "8px 0" }}>Status</th>
+                  <th style={{ padding: "8px 0" }}>Headline</th>
+                </tr>
+              </thead>
+              <tbody>
+                {history.map((snapshot) => (
+                  <tr key={snapshot.snapshotAt} style={{ borderTop: "1px solid #e2e8f0" }}>
+                    <td style={{ padding: "10px 0" }}>{new Date(snapshot.snapshotAt).toLocaleString()}</td>
+                    <td style={{ padding: "10px 0" }}>{snapshot.score}</td>
+                    <td style={{ padding: "10px 0" }}>{snapshot.grade}</td>
+                    <td style={{ padding: "10px 0" }}>{snapshot.status}</td>
+                    <td style={{ padding: "10px 0", color: "#475569" }}>{snapshot.headline}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}
+

--- a/rentchain-frontend/src/components/portfolioScoreHistory/PortfolioScoreMoverList.tsx
+++ b/rentchain-frontend/src/components/portfolioScoreHistory/PortfolioScoreMoverList.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { Card } from "../ui/Ui";
+import type { PortfolioScoreTrendV1 } from "../../api/portfolioScoreHistoryApi";
+
+export default function PortfolioScoreMoverList({ movers }: { movers: PortfolioScoreTrendV1["movers"] }) {
+  return (
+    <Card>
+      <div style={{ display: "grid", gap: 12 }}>
+        <h3 style={{ margin: 0 }}>Top movers</h3>
+        {!movers.length ? (
+          <div style={{ color: "#64748b" }}>No material component movement is available yet.</div>
+        ) : (
+          <div style={{ display: "grid", gap: 10 }}>
+            {movers.map((mover) => (
+              <div key={mover.key} style={{ border: "1px solid #e2e8f0", borderRadius: 12, padding: 12 }}>
+                <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+                  <strong>{mover.key}</strong>
+                  <span>
+                    {mover.deltaContribution > 0 ? "+" : ""}
+                    {mover.deltaContribution} contribution
+                  </span>
+                </div>
+                <div style={{ color: "#475569", marginTop: 6 }}>{mover.summary}</div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}
+

--- a/rentchain-frontend/src/components/portfolioScoreHistory/PortfolioScoreTrendHeader.tsx
+++ b/rentchain-frontend/src/components/portfolioScoreHistory/PortfolioScoreTrendHeader.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { Card, Pill } from "../ui/Ui";
+import type { PortfolioScoreTrendV1 } from "../../api/portfolioScoreHistoryApi";
+
+export default function PortfolioScoreTrendHeader({ trend }: { trend: PortfolioScoreTrendV1 }) {
+  return (
+    <Card>
+      <div style={{ display: "grid", gap: 10 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: 16, flexWrap: "wrap" }}>
+          <div style={{ display: "grid", gap: 4 }}>
+            <h2 style={{ margin: 0 }}>Portfolio Score Trend</h2>
+            <div style={{ color: "#475569" }}>{trend.summary.headline}</div>
+          </div>
+          <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+            <Pill tone="accent">{trend.direction}</Pill>
+            <Pill tone="neutral">{trend.latest?.grade || "—"}</Pill>
+            <div style={{ fontWeight: 700 }}>
+              {trend.deltaScore == null ? "No delta yet" : `${trend.deltaScore > 0 ? "+" : ""}${trend.deltaScore}`}
+            </div>
+          </div>
+        </div>
+        {trend.deltaGrade ? <div style={{ color: "#475569" }}>Grade change: {trend.deltaGrade}</div> : null}
+        {trend.summary.notes.length ? (
+          <ul style={{ margin: 0, paddingLeft: 18, color: "#475569" }}>
+            {trend.summary.notes.map((note) => (
+              <li key={note}>{note}</li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+    </Card>
+  );
+}
+

--- a/rentchain-frontend/src/pages/admin/PortfolioScoreHistoryPage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/PortfolioScoreHistoryPage.test.tsx
@@ -1,0 +1,235 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import PortfolioScoreHistoryPage from "./PortfolioScoreHistoryPage";
+
+const showToast = vi.fn();
+
+vi.mock("../../api/portfolioScoreHistoryApi", () => ({
+  fetchPortfolioScoreTrend: vi.fn(),
+  createPortfolioScoreSnapshot: vi.fn(),
+}));
+
+vi.mock("../../components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast }),
+}));
+
+vi.mock("../../components/layout/MacShell", () => ({
+  MacShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("../../components/ui/Ui", () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  Pill: ({ children }: any) => <span>{children}</span>,
+  Section: ({ children }: any) => <section>{children}</section>,
+}));
+
+beforeEach(() => {
+  showToast.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function renderPage(initialEntry = "/admin/portfolio-score/history") {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route path="/admin/portfolio-score/history" element={<PortfolioScoreHistoryPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe("PortfolioScoreHistoryPage", () => {
+  it("renders latest score, trend, movers, and history", async () => {
+    const { fetchPortfolioScoreTrend } = await import("../../api/portfolioScoreHistoryApi");
+    vi.mocked(fetchPortfolioScoreTrend).mockResolvedValue({
+      trend: {
+        version: "v1",
+        portfolioId: "portfolio-1",
+        generatedAt: "2026-04-15T12:00:00.000Z",
+        latest: {
+          version: "v1",
+          portfolioId: "portfolio-1",
+          snapshotAt: "2026-04-15T12:00:00.000Z",
+          score: 82,
+          grade: "B",
+          status: "watch",
+          headline: "Latest snapshot",
+          componentScores: [],
+          metrics: {
+            totalResourcesReviewed: 12,
+            triageItemCount: 2,
+            criticalTriageCount: 0,
+            reconciliationIssueCount: 1,
+            automationSkipCount: 1,
+            policyReviewCount: 1,
+            blockedWorkflowCount: 0,
+            maintenanceReopenCount: 0,
+          },
+        },
+        previous: {
+          version: "v1",
+          portfolioId: "portfolio-1",
+          snapshotAt: "2026-04-01T12:00:00.000Z",
+          score: 78,
+          grade: "C",
+          status: "watch",
+          headline: "Previous snapshot",
+          componentScores: [],
+          metrics: {
+            totalResourcesReviewed: 10,
+            triageItemCount: 3,
+            criticalTriageCount: 1,
+            reconciliationIssueCount: 2,
+            automationSkipCount: 1,
+            policyReviewCount: 1,
+            blockedWorkflowCount: 0,
+            maintenanceReopenCount: 0,
+          },
+        },
+        direction: "up",
+        deltaScore: 4,
+        deltaGrade: "C -> B",
+        summary: {
+          headline: "Portfolio score improved versus the previous snapshot.",
+          notes: ["Exception burden eased versus the previous snapshot."],
+        },
+        movers: [
+          {
+            key: "exception_burden",
+            deltaNormalizedScore: 8,
+            deltaContribution: 1.6,
+            direction: "up",
+            summary: "Exception burden eased versus the previous snapshot.",
+          },
+        ],
+        history: [
+          {
+            version: "v1",
+            portfolioId: "portfolio-1",
+            snapshotAt: "2026-04-15T12:00:00.000Z",
+            score: 82,
+            grade: "B",
+            status: "watch",
+            headline: "Latest snapshot",
+            componentScores: [],
+            metrics: {
+              totalResourcesReviewed: 12,
+              triageItemCount: 2,
+              criticalTriageCount: 0,
+              reconciliationIssueCount: 1,
+              automationSkipCount: 1,
+              policyReviewCount: 1,
+              blockedWorkflowCount: 0,
+              maintenanceReopenCount: 0,
+            },
+          },
+        ],
+      },
+    });
+
+    renderPage("/admin/portfolio-score/history?portfolioId=portfolio-1");
+
+    expect(await screen.findByText(/Portfolio score improved versus the previous snapshot/i)).toBeInTheDocument();
+    expect(screen.getByText(/Grade change: C -> B/i)).toBeInTheDocument();
+    expect(screen.getByText(/Top movers/i)).toBeInTheDocument();
+    expect(screen.getByText(/exception_burden/i)).toBeInTheDocument();
+    expect(screen.getByText(/Score history/i)).toBeInTheDocument();
+  });
+
+  it("renders the empty state before lookup", () => {
+    renderPage();
+    expect(
+      screen.getByText(/Enter a portfolio ID to inspect score history, trend direction, and component movers/i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders insufficient-data history safely", async () => {
+    const { fetchPortfolioScoreTrend } = await import("../../api/portfolioScoreHistoryApi");
+    vi.mocked(fetchPortfolioScoreTrend).mockResolvedValue({
+      trend: {
+        version: "v1",
+        portfolioId: "portfolio-1",
+        generatedAt: "2026-04-15T12:00:00.000Z",
+        latest: null,
+        previous: null,
+        direction: "insufficient_data",
+        deltaScore: null,
+        deltaGrade: null,
+        summary: {
+          headline: "No portfolio score history is available yet.",
+          notes: ["Create the first snapshot to start tracking portfolio score movement over time."],
+        },
+        movers: [],
+        history: [],
+      },
+    });
+
+    renderPage("/admin/portfolio-score/history?portfolioId=portfolio-1");
+
+    expect(await screen.findByText(/No score snapshots have been stored yet/i)).toBeInTheDocument();
+    expect(screen.getByText(/No material component movement is available yet/i)).toBeInTheDocument();
+  });
+
+  it("renders error state and snapshot button flow", async () => {
+    const { fetchPortfolioScoreTrend, createPortfolioScoreSnapshot } = await import("../../api/portfolioScoreHistoryApi");
+    vi.mocked(fetchPortfolioScoreTrend).mockRejectedValueOnce(new Error("Boom")).mockResolvedValueOnce({
+      trend: {
+        version: "v1",
+        portfolioId: "portfolio-1",
+        generatedAt: "2026-04-15T12:00:00.000Z",
+        latest: null,
+        previous: null,
+        direction: "insufficient_data",
+        deltaScore: null,
+        deltaGrade: null,
+        summary: {
+          headline: "More score history is needed before a trend can be established.",
+          notes: ["Create at least one more snapshot to compare score direction and component movement."],
+        },
+        movers: [],
+        history: [],
+      },
+    });
+    vi.mocked(createPortfolioScoreSnapshot).mockResolvedValue({
+      snapshot: {
+        version: "v1",
+        portfolioId: "portfolio-1",
+        snapshotAt: "2026-04-15T12:00:00.000Z",
+        score: 82,
+        grade: "B",
+        status: "watch",
+        headline: "Snapshot",
+        componentScores: [],
+        metrics: {
+          totalResourcesReviewed: 1,
+          triageItemCount: 0,
+          criticalTriageCount: 0,
+          reconciliationIssueCount: 0,
+          automationSkipCount: 0,
+          policyReviewCount: 0,
+          blockedWorkflowCount: 0,
+          maintenanceReopenCount: 0,
+        },
+      },
+    });
+
+    renderPage();
+    fireEvent.change(screen.getByLabelText(/Portfolio ID/i), { target: { value: "portfolio-1" } });
+    fireEvent.click(screen.getByRole("button", { name: /Load history/i }));
+    expect(await screen.findByText(/Failed to load portfolio score history: Boom/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Create snapshot/i }));
+    await waitFor(() => {
+      expect(vi.mocked(createPortfolioScoreSnapshot)).toHaveBeenCalledWith("portfolio-1");
+      expect(vi.mocked(fetchPortfolioScoreTrend)).toHaveBeenCalledTimes(2);
+    });
+    expect(await screen.findByText(/No score snapshots have been stored yet/i)).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/admin/PortfolioScoreHistoryPage.tsx
+++ b/rentchain-frontend/src/pages/admin/PortfolioScoreHistoryPage.tsx
@@ -1,0 +1,133 @@
+import React from "react";
+import { useSearchParams } from "react-router-dom";
+import { createPortfolioScoreSnapshot, fetchPortfolioScoreTrend, type PortfolioScoreTrendV1 } from "../../api/portfolioScoreHistoryApi";
+import { MacShell } from "../../components/layout/MacShell";
+import { Button, Card, Section } from "../../components/ui/Ui";
+import { useToast } from "../../components/ui/ToastProvider";
+import PortfolioScoreTrendHeader from "../../components/portfolioScoreHistory/PortfolioScoreTrendHeader";
+import PortfolioScoreMoverList from "../../components/portfolioScoreHistory/PortfolioScoreMoverList";
+import PortfolioScoreHistoryTable from "../../components/portfolioScoreHistory/PortfolioScoreHistoryTable";
+
+export default function PortfolioScoreHistoryPage() {
+  const { showToast } = useToast();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [portfolioId, setPortfolioId] = React.useState(searchParams.get("portfolioId") || "");
+  const [trend, setTrend] = React.useState<PortfolioScoreTrendV1 | null>(null);
+  const [loading, setLoading] = React.useState(false);
+  const [snapshotLoading, setSnapshotLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const load = React.useCallback(
+    async (nextPortfolioId: string) => {
+      const safePortfolioId = String(nextPortfolioId || "").trim();
+      if (!safePortfolioId) {
+        setTrend(null);
+        setError(null);
+        return;
+      }
+
+      try {
+        setLoading(true);
+        setError(null);
+        const response = await fetchPortfolioScoreTrend(safePortfolioId, 12);
+        setTrend(response.trend);
+        setSearchParams({ portfolioId: safePortfolioId });
+      } catch (err: any) {
+        const message = err?.message || "Failed to load portfolio score history";
+        setTrend(null);
+        setError(message);
+        showToast({
+          message: "Failed to load portfolio score history",
+          description: message,
+          variant: "error",
+        });
+      } finally {
+        setLoading(false);
+      }
+    },
+    [setSearchParams, showToast]
+  );
+
+  React.useEffect(() => {
+    const initialPortfolioId = searchParams.get("portfolioId") || "";
+    if (initialPortfolioId) {
+      setPortfolioId(initialPortfolioId);
+      void load(initialPortfolioId);
+    }
+  }, [load, searchParams]);
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    void load(portfolioId);
+  };
+
+  const handleCreateSnapshot = async () => {
+    const safePortfolioId = String(portfolioId || "").trim();
+    if (!safePortfolioId) return;
+    try {
+      setSnapshotLoading(true);
+      await createPortfolioScoreSnapshot(safePortfolioId);
+      await load(safePortfolioId);
+    } catch (err: any) {
+      showToast({
+        message: "Failed to create score snapshot",
+        description: err?.message || "Unknown error",
+        variant: "error",
+      });
+    } finally {
+      setSnapshotLoading(false);
+    }
+  };
+
+  return (
+    <MacShell title="Admin · Portfolio Score History">
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "grid", gap: 6 }}>
+            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Portfolio Score™ History + Trend</h1>
+            <div style={{ color: "#475569", maxWidth: 820 }}>
+              Internal, admin-only history layer for tracking how a portfolio score moves over time and which components changed most.
+            </div>
+          </div>
+        </Section>
+
+        <Card>
+          <form onSubmit={handleSubmit} style={{ display: "grid", gap: 12 }}>
+            <label style={{ display: "grid", gap: 4 }}>
+              <span style={{ color: "#64748b", fontSize: 12 }}>Portfolio ID</span>
+              <input
+                aria-label="Portfolio ID"
+                value={portfolioId}
+                onChange={(event) => setPortfolioId(event.target.value)}
+                placeholder="portfolio-123"
+              />
+            </label>
+            <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+              <Button type="submit" disabled={loading}>
+                {loading ? "Loading..." : "Load history"}
+              </Button>
+              <Button type="button" variant="secondary" onClick={handleCreateSnapshot} disabled={snapshotLoading || !portfolioId.trim()}>
+                {snapshotLoading ? "Creating..." : "Create snapshot"}
+              </Button>
+            </div>
+          </form>
+        </Card>
+
+        {loading ? <Card>Loading portfolio score history…</Card> : null}
+        {!loading && !error && !trend ? (
+          <Card>Enter a portfolio ID to inspect score history, trend direction, and component movers.</Card>
+        ) : null}
+        {!loading && error ? <Card style={{ color: "#b91c1c" }}>Failed to load portfolio score history: {error}</Card> : null}
+
+        {!loading && !error && trend ? (
+          <>
+            <PortfolioScoreTrendHeader trend={trend} />
+            <PortfolioScoreMoverList movers={trend.movers} />
+            <PortfolioScoreHistoryTable history={trend.history} />
+          </>
+        ) : null}
+      </div>
+    </MacShell>
+  );
+}
+


### PR DESCRIPTION
## Summary
Adds Portfolio Score™ History + Trend v1 as an admin-only history layer on top of the existing Portfolio Score™ foundation.

This introduces persisted score snapshots, deterministic trend derivation between snapshots, admin endpoints for score history and trend inspection, and a minimal admin page for reviewing score movement, grade changes, and component movers over time.

## Scope
- Adds `portfolioScoreHistory` types, constants, snapshot helpers, history loaders, and trend derivation under `src/lib/portfolioScoreHistory`
- Adds admin endpoints for:
  - `GET /api/admin/portfolio-score/history?portfolioId=&limit=`
  - `GET /api/admin/portfolio-score/trend?portfolioId=&limit=`
  - `POST /api/admin/portfolio-score/snapshot`
- Reuses Mission 10 portfolio-score derivation to create stored snapshots safely
- Adds a minimal admin route at `/admin/portfolio-score/history`
- Renders:
  - latest score/trend summary
  - delta score
  - grade change
  - mover list
  - snapshot history table
  - create-snapshot action
- Adds targeted backend and frontend tests for trend derivation, insufficient-history handling, route safety, and page rendering

## Notes
This is intentionally admin-only, additive, and read/history-focused. No workflow write behavior, billing behavior, screening provider logic, policy logic, or automation execution behavior was changed.

For v1, `portfolioId` remains mapped to the same admin-safe `landlordId` scope used by the Portfolio Score™ foundation.

The history layer uses persisted snapshots rather than inferring fake historical scores from raw events, which keeps trend comparisons explicit and operationally trustworthy.

## Validation
- Passed targeted backend history/trend tests
- Passed backend build
- Passed targeted frontend history page and route tests
- Passed frontend build
- Passed full frontend test suite