### PR TITLE
feat: add admin resolution workflow v1

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -102,6 +102,7 @@ import insightRoutes from "./routes/insightRoutes";
 import screeningReconciliationRoutes from "./routes/screeningReconciliationRoutes";
 import supportConsoleRoutes from "./routes/supportConsoleRoutes";
 import adminTriageRoutes from "./routes/adminTriageRoutes";
+import adminResolutionRoutes from "./routes/adminResolutionRoutes";
 import portfolioScoreRoutes from "./routes/portfolioScoreRoutes";
 import portfolioScoreHistoryRoutes from "./routes/portfolioScoreHistoryRoutes";
 import transunionRoutes from "./services/integrations/transunion/transunionRoutes";
@@ -227,6 +228,8 @@ app.use("/api/admin", routeSource("supportConsoleRoutes.ts"), supportConsoleRout
 console.log("[route-mount] supportConsoleRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("adminTriageRoutes.ts"), adminTriageRoutes);
 console.log("[route-mount] adminTriageRoutes mounted at /api/admin");
+app.use("/api/admin", routeSource("adminResolutionRoutes.ts"), adminResolutionRoutes);
+console.log("[route-mount] adminResolutionRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("portfolioScoreRoutes.ts"), portfolioScoreRoutes);
 console.log("[route-mount] portfolioScoreRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("portfolioScoreHistoryRoutes.ts"), portfolioScoreHistoryRoutes);

--- a/rentchain-api/src/lib/resolution/__tests__/validateResolutionTransition.test.ts
+++ b/rentchain-api/src/lib/resolution/__tests__/validateResolutionTransition.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { validateResolutionTransition } from "../validateResolutionTransition";
+
+describe("validateResolutionTransition", () => {
+  it("allows valid transitions", () => {
+    expect(() => validateResolutionTransition("open", "acknowledged")).not.toThrow();
+    expect(() => validateResolutionTransition("acknowledged", "in_progress")).not.toThrow();
+    expect(() => validateResolutionTransition("in_progress", "resolved")).not.toThrow();
+  });
+
+  it("rejects invalid transitions cleanly", () => {
+    expect(() => validateResolutionTransition("open", "resolved")).toThrow(/cannot move/i);
+    expect(() => validateResolutionTransition("resolved", "acknowledged")).toThrow(/cannot move/i);
+  });
+});

--- a/rentchain-api/src/lib/resolution/addResolutionNote.ts
+++ b/rentchain-api/src/lib/resolution/addResolutionNote.ts
@@ -1,0 +1,31 @@
+import crypto from "crypto";
+import type { ResolutionNoteV1, ResolutionRecordV1 } from "./resolutionTypes";
+import { saveResolutionRecord } from "./saveResolutionRecord";
+
+function toIsoNow() {
+  return new Date().toISOString();
+}
+
+export async function addResolutionNote(
+  record: ResolutionRecordV1,
+  input: {
+    message: string;
+    authorId?: string | null;
+    authorRole?: string | null;
+  }
+) {
+  const now = toIsoNow();
+  const note: ResolutionNoteV1 = {
+    id: crypto.randomUUID(),
+    createdAt: now,
+    authorId: input.authorId ?? null,
+    authorRole: input.authorRole ?? null,
+    message: String(input.message || "").trim(),
+  };
+  const next: ResolutionRecordV1 = {
+    ...record,
+    updatedAt: now,
+    notes: [...(Array.isArray(record.notes) ? record.notes : []), note],
+  };
+  return await saveResolutionRecord(next);
+}

--- a/rentchain-api/src/lib/resolution/loadResolutionRecord.ts
+++ b/rentchain-api/src/lib/resolution/loadResolutionRecord.ts
@@ -1,0 +1,52 @@
+import { db } from "../../config/firebase";
+import type { ResolutionRecordV1, ResolutionStatus } from "./resolutionTypes";
+
+export const ADMIN_RESOLUTIONS_COLLECTION = "adminResolutions";
+
+const ACTIVE_STATUSES = new Set<ResolutionStatus>(["open", "acknowledged", "in_progress"]);
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function parseTimestamp(value: unknown) {
+  const raw = asString(value, 200);
+  if (!raw) return 0;
+  const parsed = Date.parse(raw);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function compareRecordsDescending(a: ResolutionRecordV1, b: ResolutionRecordV1) {
+  const aTs = parseTimestamp(a.updatedAt || a.createdAt);
+  const bTs = parseTimestamp(b.updatedAt || b.createdAt);
+  if (bTs !== aTs) return bTs - aTs;
+  return String(b.id || "").localeCompare(String(a.id || ""));
+}
+
+export async function loadAllResolutionRecords(): Promise<ResolutionRecordV1[]> {
+  const snap = await db.collection(ADMIN_RESOLUTIONS_COLLECTION).get();
+  return (snap.docs || []).map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }) as ResolutionRecordV1);
+}
+
+export async function loadResolutionRecord(input: {
+  resourceType: string;
+  resourceId: string;
+  reasonCode?: string | null;
+}): Promise<ResolutionRecordV1 | null> {
+  const resourceType = asString(input.resourceType, 120);
+  const resourceId = asString(input.resourceId, 240);
+  const reasonCode = asString(input.reasonCode, 160);
+  if (!resourceType || !resourceId) return null;
+
+  const records = (await loadAllResolutionRecords())
+    .filter(
+      (record) =>
+        asString(record.resource?.type, 120) === resourceType &&
+        asString(record.resource?.id, 240) === resourceId &&
+        (!reasonCode || asString(record.triage?.reasonCode, 160) === reasonCode)
+    )
+    .sort(compareRecordsDescending);
+
+  const active = records.find((record) => ACTIVE_STATUSES.has(record.status));
+  return active || records[0] || null;
+}

--- a/rentchain-api/src/lib/resolution/resolutionTypes.ts
+++ b/rentchain-api/src/lib/resolution/resolutionTypes.ts
@@ -1,0 +1,46 @@
+export type ResolutionStatus =
+  | "open"
+  | "acknowledged"
+  | "in_progress"
+  | "resolved"
+  | "dismissed";
+
+export type ResolutionNoteV1 = {
+  id: string;
+  createdAt: string;
+  authorId?: string | null;
+  authorRole?: string | null;
+  message: string;
+};
+
+export type ResolutionHistoryEntryV1 = {
+  id: string;
+  timestamp: string;
+  fromStatus?: ResolutionStatus | null;
+  toStatus: ResolutionStatus;
+  authorId?: string | null;
+  authorRole?: string | null;
+  reason?: string | null;
+};
+
+export type ResolutionRecordV1 = {
+  version: "v1";
+  id: string;
+  resource: {
+    type: string;
+    id: string;
+  };
+  triage: {
+    category?: string | null;
+    severity?: string | null;
+    reasonCode?: string | null;
+  };
+  status: ResolutionStatus;
+  createdAt: string;
+  updatedAt: string;
+  resolvedAt?: string | null;
+  dismissedAt?: string | null;
+  notes: ResolutionNoteV1[];
+  history: ResolutionHistoryEntryV1[];
+  metadata?: Record<string, unknown>;
+};

--- a/rentchain-api/src/lib/resolution/saveResolutionRecord.ts
+++ b/rentchain-api/src/lib/resolution/saveResolutionRecord.ts
@@ -1,0 +1,8 @@
+import { db } from "../../config/firebase";
+import type { ResolutionRecordV1 } from "./resolutionTypes";
+import { ADMIN_RESOLUTIONS_COLLECTION } from "./loadResolutionRecord";
+
+export async function saveResolutionRecord(record: ResolutionRecordV1) {
+  await db.collection(ADMIN_RESOLUTIONS_COLLECTION).doc(record.id).set(record, { merge: false });
+  return record;
+}

--- a/rentchain-api/src/lib/resolution/updateResolutionStatus.ts
+++ b/rentchain-api/src/lib/resolution/updateResolutionStatus.ts
@@ -1,0 +1,57 @@
+import crypto from "crypto";
+import type { ResolutionHistoryEntryV1, ResolutionRecordV1, ResolutionStatus } from "./resolutionTypes";
+import { saveResolutionRecord } from "./saveResolutionRecord";
+import { validateResolutionTransition } from "./validateResolutionTransition";
+
+function toIsoNow() {
+  return new Date().toISOString();
+}
+
+function historyEntry(input: {
+  fromStatus?: ResolutionStatus | null;
+  toStatus: ResolutionStatus;
+  authorId?: string | null;
+  authorRole?: string | null;
+  reason?: string | null;
+}): ResolutionHistoryEntryV1 {
+  return {
+    id: crypto.randomUUID(),
+    timestamp: toIsoNow(),
+    fromStatus: input.fromStatus ?? null,
+    toStatus: input.toStatus,
+    authorId: input.authorId ?? null,
+    authorRole: input.authorRole ?? null,
+    reason: input.reason ?? null,
+  };
+}
+
+export async function updateResolutionStatus(
+  record: ResolutionRecordV1,
+  input: {
+    status: ResolutionStatus;
+    authorId?: string | null;
+    authorRole?: string | null;
+    reason?: string | null;
+  }
+) {
+  validateResolutionTransition(record.status, input.status);
+  const now = toIsoNow();
+  const next: ResolutionRecordV1 = {
+    ...record,
+    status: input.status,
+    updatedAt: now,
+    resolvedAt: input.status === "resolved" ? now : record.resolvedAt ?? null,
+    dismissedAt: input.status === "dismissed" ? now : record.dismissedAt ?? null,
+    history: [
+      ...(Array.isArray(record.history) ? record.history : []),
+      historyEntry({
+        fromStatus: record.status,
+        toStatus: input.status,
+        authorId: input.authorId,
+        authorRole: input.authorRole,
+        reason: input.reason,
+      }),
+    ],
+  };
+  return await saveResolutionRecord(next);
+}

--- a/rentchain-api/src/lib/resolution/validateResolutionTransition.ts
+++ b/rentchain-api/src/lib/resolution/validateResolutionTransition.ts
@@ -1,0 +1,20 @@
+import type { ResolutionStatus } from "./resolutionTypes";
+
+export const RESOLUTION_TRANSITION_ERROR_CODE = "RESOLUTION_STATUS_TRANSITION_INVALID";
+
+const ALLOWED_TRANSITIONS: Record<ResolutionStatus, ResolutionStatus[]> = {
+  open: ["acknowledged", "dismissed"],
+  acknowledged: ["in_progress", "resolved", "dismissed"],
+  in_progress: ["resolved", "dismissed"],
+  resolved: [],
+  dismissed: [],
+};
+
+export function validateResolutionTransition(fromStatus: ResolutionStatus, toStatus: ResolutionStatus) {
+  const allowed = ALLOWED_TRANSITIONS[fromStatus] || [];
+  if (!allowed.includes(toStatus)) {
+    const error = new Error(`Resolution cannot move from ${fromStatus} to ${toStatus}.`);
+    (error as any).code = RESOLUTION_TRANSITION_ERROR_CODE;
+    throw error;
+  }
+}

--- a/rentchain-api/src/lib/supportConsole/buildSupportConsoleResource.ts
+++ b/rentchain-api/src/lib/supportConsole/buildSupportConsoleResource.ts
@@ -3,6 +3,7 @@ import { CANONICAL_EVENTS_COLLECTION } from "../events/buildEvent";
 import type { CanonicalEventV1 } from "../events/eventTypes";
 import { deriveInsightForResource } from "../insights/deriveInsights";
 import { deriveScreeningReconciliation } from "../reconciliation/deriveScreeningReconciliation";
+import { loadResolutionRecord } from "../resolution/loadResolutionRecord";
 import { canonicalEventToTimelineItem } from "../timeline/timelineAdapter";
 import type {
   SupportConsoleAutomationItem,
@@ -280,6 +281,7 @@ function emptyResponse(spec: NormalizedResourceSpec, resourceId: string): Suppor
     policyDecisions: [],
     automation: [],
     reconciliation: null,
+    resolution: null,
     debug: {
       canonicalEventCount: 0,
       domainsPresent: [],
@@ -312,6 +314,10 @@ export async function buildSupportConsoleResource(input: {
   });
 
   let reconciliation: Record<string, unknown> | null = null;
+  const resolution = await loadResolutionRecord({
+    resourceType: spec.requestedType,
+    resourceId,
+  });
   if (spec.requestedType === "application") {
     const [latestOrder, financialTransactions] = await Promise.all([
       loadLatestScreeningOrder(resourceId),
@@ -338,6 +344,7 @@ export async function buildSupportConsoleResource(input: {
     policyDecisions: buildPolicyDecisions(relatedEvents),
     automation: buildAutomationHistory(relatedEvents),
     reconciliation,
+    resolution,
     debug: {
       canonicalEventCount: relatedEvents.length,
       domainsPresent: domainsPresent(relatedEvents),
@@ -345,4 +352,3 @@ export async function buildSupportConsoleResource(input: {
     },
   };
 }
-

--- a/rentchain-api/src/lib/supportConsole/supportConsoleTypes.ts
+++ b/rentchain-api/src/lib/supportConsole/supportConsoleTypes.ts
@@ -1,4 +1,5 @@
 import type { TimelineItem } from "../timeline/timelineAdapter";
+import type { ResolutionRecordV1 } from "../resolution/resolutionTypes";
 
 export type SupportConsoleResourceSummary = {
   type: string;
@@ -36,10 +37,10 @@ export type SupportConsoleResourceResponse = {
   policyDecisions: SupportConsolePolicyDecision[];
   automation: SupportConsoleAutomationItem[];
   reconciliation?: Record<string, unknown> | null;
+  resolution?: ResolutionRecordV1 | null;
   debug: {
     canonicalEventCount: number;
     domainsPresent: string[];
     identifiers?: Record<string, string | null | undefined>;
   };
 };
-

--- a/rentchain-api/src/lib/triage/deriveAdminTriageQueue.ts
+++ b/rentchain-api/src/lib/triage/deriveAdminTriageQueue.ts
@@ -2,6 +2,7 @@ import type { CanonicalEventV1 } from "../events/eventTypes";
 import { deriveInsightForResource } from "../insights/deriveInsights";
 import { deriveScreeningReconciliation } from "../reconciliation/deriveScreeningReconciliation";
 import type { ScreeningReconciliationV1 } from "../reconciliation/reconciliationTypes";
+import type { ResolutionRecordV1 } from "../resolution/resolutionTypes";
 import type { AdminTriageItemV1, TriageCategory, TriageSeverity } from "./triageTypes";
 
 type ScreeningOrderLike = {
@@ -28,6 +29,7 @@ type DeriveAdminTriageQueueInput = {
   canonicalEvents?: CanonicalEventV1[];
   screeningOrders?: ScreeningOrderLike[];
   financialTransactions?: FinancialTransactionLike[];
+  resolutions?: ResolutionRecordV1[];
   now?: number;
 };
 
@@ -141,8 +143,20 @@ function resourceSummaryFromLease(lease: any) {
   };
 }
 
-function supportConsolePath(resourceType: string, resourceId: string) {
-  return `/admin/support-console?resourceType=${encodeURIComponent(resourceType)}&resourceId=${encodeURIComponent(resourceId)}`;
+function supportConsolePath(
+  resourceType: string,
+  resourceId: string,
+  triageCategory?: string | null,
+  triageSeverity?: string | null,
+  reasonCode?: string | null
+) {
+  const search = new URLSearchParams();
+  search.set("resourceType", resourceType);
+  search.set("resourceId", resourceId);
+  if (triageCategory) search.set("triageCategory", triageCategory);
+  if (triageSeverity) search.set("triageSeverity", triageSeverity);
+  if (reasonCode) search.set("reasonCode", reasonCode);
+  return `/admin/support-console?${search.toString()}`;
 }
 
 function isVisibleToAdmin(event: CanonicalEventV1) {
@@ -237,7 +251,13 @@ function buildItem(input: {
       lastSeenAt: input.lastSeenAt || null,
     },
     navigation: {
-      supportConsolePath: supportConsolePath(input.resource.type, input.resource.id),
+      supportConsolePath: supportConsolePath(
+        input.resource.type,
+        input.resource.id,
+        input.category,
+        input.severity,
+        input.reasonCode
+      ),
     },
     tags: input.tags || [],
   };
@@ -623,6 +643,26 @@ export function deriveAdminTriageQueue(input: DeriveAdminTriageQueueInput): Admi
     })
   );
 
-  return items.sort(compareTriageItems);
-}
+  const resolutions = input.resolutions || [];
+  const enriched = items.map((item) => {
+    const match = resolutions
+      .filter(
+        (record) =>
+          asString(record.resource?.type, 120) === item.resource.type &&
+          asString(record.resource?.id, 240) === item.resource.id &&
+          asString(record.triage?.reasonCode, 160) === item.reason.code
+      )
+      .sort((a, b) => (parseTimestamp(b.updatedAt) ?? 0) - (parseTimestamp(a.updatedAt) ?? 0))[0];
+    return {
+      ...item,
+      resolution: match
+        ? {
+            status: match.status,
+            updatedAt: match.updatedAt,
+          }
+        : null,
+    };
+  });
 
+  return enriched.sort(compareTriageItems);
+}

--- a/rentchain-api/src/lib/triage/triageTypes.ts
+++ b/rentchain-api/src/lib/triage/triageTypes.ts
@@ -43,6 +43,9 @@ export type AdminTriageItemV1 = {
   navigation: {
     supportConsolePath?: string | null;
   };
+  resolution?: {
+    status: "open" | "acknowledged" | "in_progress" | "resolved" | "dismissed";
+    updatedAt: string;
+  } | null;
   tags?: string[];
 };
-

--- a/rentchain-api/src/routes/__tests__/adminResolutionRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/adminResolutionRoutes.test.ts
@@ -1,0 +1,225 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { collections, dbMock } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, any>>();
+
+  function ensureCollection(name: string) {
+    if (!collections.has(name)) {
+      collections.set(name, new Map<string, any>());
+    }
+    return collections.get(name)!;
+  }
+
+  return {
+    collections,
+    dbMock: {
+      collection: (name: string) => ({
+        doc: (id?: string) => ({
+          id,
+          async get() {
+            return {
+              id,
+              exists: ensureCollection(name).has(String(id)),
+              data: () => ensureCollection(name).get(String(id)),
+            };
+          },
+          async set(payload: any) {
+            ensureCollection(name).set(String(id), payload);
+          },
+        }),
+        async get() {
+          const docs = Array.from(ensureCollection(name).entries()).map(([id, data]) => ({
+            id,
+            data: () => data,
+          }));
+          return { docs, empty: docs.length === 0, size: docs.length };
+        },
+      }),
+    },
+  };
+});
+
+vi.mock("../../config/firebase", () => ({
+  db: dbMock,
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!req.user) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    return next();
+  },
+}));
+
+async function invokeRouter(
+  router: any,
+  options: { method: string; url: string; user?: Record<string, unknown> | null; body?: any }
+) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    const query = new URLSearchParams(queryString || "");
+    const paramsMatch = path.match(/\/resolutions\/([^/]+)\/(status|notes)$/);
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: options.user ?? null,
+      query: Object.fromEntries(query.entries()),
+      params: paramsMatch
+        ? { resolutionId: paramsMatch[1] }
+        : {},
+      body: options.body || {},
+      headers: {},
+      get(name: string) {
+        return this.headers[String(name).toLowerCase()];
+      },
+      header(name: string) {
+        return this.get(name);
+      },
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, string>,
+      setHeader(name: string, value: string) {
+        this.headers[name.toLowerCase()] = value;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("adminResolutionRoutes", () => {
+  beforeEach(() => {
+    collections.clear();
+  });
+
+  it("creates and upserts a resolution deterministically", async () => {
+    const router = (await import("../adminResolutionRoutes")).default;
+
+    const created = await invokeRouter(router, {
+      method: "POST",
+      url: "/resolutions",
+      user: { id: "admin-1", role: "admin" },
+      body: {
+        resourceType: "application",
+        resourceId: "app-1",
+        reasonCode: "TRIAGE_PAID_NOT_FULFILLED",
+        note: "Investigating fulfillment lag.",
+      },
+    });
+
+    expect(created.status).toBe(201);
+    expect(created.body?.resolution?.status).toBe("open");
+    expect(created.body?.resolution?.notes).toHaveLength(1);
+
+    const upserted = await invokeRouter(router, {
+      method: "POST",
+      url: "/resolutions",
+      user: { id: "admin-1", role: "admin" },
+      body: {
+        resourceType: "application",
+        resourceId: "app-1",
+        reasonCode: "TRIAGE_PAID_NOT_FULFILLED",
+        note: "Second note.",
+      },
+    });
+
+    expect(upserted.status).toBe(200);
+    expect(upserted.body?.resolution?.id).toBe(created.body?.resolution?.id);
+    expect(upserted.body?.resolution?.notes).toHaveLength(2);
+  });
+
+  it("supports valid status transitions and note appends", async () => {
+    const router = (await import("../adminResolutionRoutes")).default;
+    const created = await invokeRouter(router, {
+      method: "POST",
+      url: "/resolutions",
+      user: { id: "admin-1", role: "admin" },
+      body: {
+        resourceType: "maintenance",
+        resourceId: "maint-1",
+        reasonCode: "TRIAGE_WORKFLOW_STALLED",
+      },
+    });
+    const resolutionId = created.body?.resolution?.id;
+
+    const acknowledged = await invokeRouter(router, {
+      method: "PATCH",
+      url: `/resolutions/${resolutionId}/status`,
+      user: { id: "admin-1", role: "admin" },
+      body: { status: "acknowledged", reason: "Owner has reviewed the stall." },
+    });
+    expect(acknowledged.status).toBe(200);
+    expect(acknowledged.body?.resolution?.status).toBe("acknowledged");
+
+    const noted = await invokeRouter(router, {
+      method: "POST",
+      url: `/resolutions/${resolutionId}/notes`,
+      user: { id: "admin-1", role: "admin" },
+      body: { message: "Awaiting contractor update." },
+    });
+    expect(noted.status).toBe(200);
+    expect(noted.body?.resolution?.notes).toHaveLength(1);
+  });
+
+  it("rejects invalid transitions and returns stable empty fetch shape", async () => {
+    const router = (await import("../adminResolutionRoutes")).default;
+    const empty = await invokeRouter(router, {
+      method: "GET",
+      url: "/resolutions?resourceType=lease&resourceId=lease-1",
+      user: { id: "admin-1", role: "admin" },
+    });
+    expect(empty.status).toBe(200);
+    expect(empty.body).toEqual({ resolution: null });
+
+    const created = await invokeRouter(router, {
+      method: "POST",
+      url: "/resolutions",
+      user: { id: "admin-1", role: "admin" },
+      body: {
+        resourceType: "lease",
+        resourceId: "lease-1",
+        reasonCode: "TRIAGE_POLICY_BLOCKED",
+      },
+    });
+    const resolutionId = created.body?.resolution?.id;
+
+    const invalid = await invokeRouter(router, {
+      method: "PATCH",
+      url: `/resolutions/${resolutionId}/status`,
+      user: { id: "admin-1", role: "admin" },
+      body: { status: "resolved" },
+    });
+    expect(invalid.status).toBe(400);
+    expect(invalid.body?.error).toBe("RESOLUTION_STATUS_TRANSITION_INVALID");
+  });
+
+  it("enforces admin-only access", async () => {
+    const router = (await import("../adminResolutionRoutes")).default;
+    const forbidden = await invokeRouter(router, {
+      method: "POST",
+      url: "/resolutions",
+      user: { id: "landlord-1", role: "landlord" },
+      body: {
+        resourceType: "application",
+        resourceId: "app-1",
+      },
+    });
+    expect(forbidden.status).toBe(403);
+    expect(forbidden.body?.error).toBe("FORBIDDEN");
+  });
+});

--- a/rentchain-api/src/routes/__tests__/adminTriageRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/adminTriageRoutes.test.ts
@@ -138,7 +138,8 @@ describe("adminTriageRoutes", () => {
           category: "screening_reconciliation",
           severity: "critical",
           navigation: expect.objectContaining({
-            supportConsolePath: "/admin/support-console?resourceType=application&resourceId=app-1",
+            supportConsolePath:
+              "/admin/support-console?resourceType=application&resourceId=app-1&triageCategory=screening_reconciliation&triageSeverity=critical&reasonCode=TRIAGE_PAID_NOT_FULFILLED",
           }),
         }),
       ])

--- a/rentchain-api/src/routes/adminResolutionRoutes.ts
+++ b/rentchain-api/src/routes/adminResolutionRoutes.ts
@@ -1,0 +1,288 @@
+import crypto from "crypto";
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { requireAuth } from "../middleware/requireAuth";
+import { addResolutionNote } from "../lib/resolution/addResolutionNote";
+import { loadResolutionRecord } from "../lib/resolution/loadResolutionRecord";
+import { saveResolutionRecord } from "../lib/resolution/saveResolutionRecord";
+import type { ResolutionRecordV1, ResolutionStatus } from "../lib/resolution/resolutionTypes";
+import { updateResolutionStatus } from "../lib/resolution/updateResolutionStatus";
+import { RESOLUTION_TRANSITION_ERROR_CODE } from "../lib/resolution/validateResolutionTransition";
+import { writeCanonicalEvent } from "../lib/events/buildEvent";
+
+const router = Router();
+
+const ALLOWED_STATUSES = new Set<ResolutionStatus>([
+  "acknowledged",
+  "in_progress",
+  "resolved",
+  "dismissed",
+]);
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function normalizeRole(req: any): "admin" | "landlord" | "other" {
+  const role = asString(req.user?.actorRole || req.user?.role, 40).toLowerCase();
+  if (role === "admin") return "admin";
+  if (role === "landlord") return "landlord";
+  return "other";
+}
+
+function actorFromReq(req: any) {
+  return {
+    id: asString(req.user?.uid || req.user?.id, 240) || null,
+    role: asString(req.user?.actorRole || req.user?.role, 80) || null,
+  };
+}
+
+async function emitResolutionEvent(input: {
+  type: "resolution.created" | "resolution.status_changed" | "resolution.note_added";
+  summary: string;
+  resolution: ResolutionRecordV1;
+  actorId?: string | null;
+  actorRole?: string | null;
+  metadata?: Record<string, unknown>;
+}) {
+  await writeCanonicalEvent({
+    type: input.type,
+    domain: "system",
+    action: input.type.split(".").slice(1).join("_"),
+    status: input.resolution.status,
+    actor: {
+      type: "admin",
+      id: input.actorId || null,
+      role: input.actorRole || null,
+    },
+    resource: {
+      type: "resolution",
+      id: input.resolution.id,
+      parentType: input.resolution.resource.type,
+      parentId: input.resolution.resource.id,
+    },
+    occurredAt: new Date().toISOString(),
+    visibility: "internal",
+    summary: input.summary,
+    metadata: {
+      resolutionStatus: input.resolution.status,
+      triageCategory: input.resolution.triage?.category || null,
+      triageSeverity: input.resolution.triage?.severity || null,
+      reasonCode: input.resolution.triage?.reasonCode || null,
+      ...input.metadata,
+    },
+  });
+}
+
+function createResolutionRecord(input: {
+  resourceType: string;
+  resourceId: string;
+  triageCategory?: string | null;
+  triageSeverity?: string | null;
+  reasonCode?: string | null;
+  note?: string | null;
+  actorId?: string | null;
+  actorRole?: string | null;
+}): ResolutionRecordV1 {
+  const now = new Date().toISOString();
+  const note = asString(input.note, 4000);
+  return {
+    version: "v1",
+    id: crypto.randomUUID(),
+    resource: {
+      type: asString(input.resourceType, 120),
+      id: asString(input.resourceId, 240),
+    },
+    triage: {
+      category: asString(input.triageCategory, 120) || null,
+      severity: asString(input.triageSeverity, 120) || null,
+      reasonCode: asString(input.reasonCode, 160) || null,
+    },
+    status: "open",
+    createdAt: now,
+    updatedAt: now,
+    resolvedAt: null,
+    dismissedAt: null,
+    notes: note
+      ? [
+          {
+            id: crypto.randomUUID(),
+            createdAt: now,
+            authorId: input.actorId || null,
+            authorRole: input.actorRole || null,
+            message: note,
+          },
+        ]
+      : [],
+    history: [
+      {
+        id: crypto.randomUUID(),
+        timestamp: now,
+        fromStatus: null,
+        toStatus: "open",
+        authorId: input.actorId || null,
+        authorRole: input.actorRole || null,
+        reason: "Resolution record created",
+      },
+    ],
+    metadata: {},
+  };
+}
+
+router.get("/resolutions", requireAuth, async (req: any, res) => {
+  try {
+    if (normalizeRole(req) !== "admin") {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+    const resourceType = asString(req.query?.resourceType, 120);
+    const resourceId = asString(req.query?.resourceId, 240);
+    if (!resourceType || !resourceId) {
+      return res.status(400).json({ ok: false, error: "RESOURCE_REFERENCE_REQUIRED" });
+    }
+    const resolution = await loadResolutionRecord({ resourceType, resourceId });
+    return res.json({ resolution: resolution || null });
+  } catch (err: any) {
+    console.error("[admin-resolution] fetch failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "ADMIN_RESOLUTION_FETCH_FAILED" });
+  }
+});
+
+router.post("/resolutions", requireAuth, async (req: any, res) => {
+  try {
+    if (normalizeRole(req) !== "admin") {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+    const resourceType = asString(req.body?.resourceType, 120);
+    const resourceId = asString(req.body?.resourceId, 240);
+    const triageCategory = asString(req.body?.triageCategory, 120) || null;
+    const triageSeverity = asString(req.body?.triageSeverity, 120) || null;
+    const reasonCode = asString(req.body?.reasonCode, 160) || null;
+    const note = asString(req.body?.note, 4000) || null;
+    if (!resourceType || !resourceId) {
+      return res.status(400).json({ ok: false, error: "RESOURCE_REFERENCE_REQUIRED" });
+    }
+
+    const actor = actorFromReq(req);
+    let resolution = await loadResolutionRecord({ resourceType, resourceId, reasonCode });
+    if (resolution && ["open", "acknowledged", "in_progress"].includes(resolution.status)) {
+      if (note) {
+        resolution = await addResolutionNote(resolution, {
+          message: note,
+          authorId: actor.id,
+          authorRole: actor.role,
+        });
+        await emitResolutionEvent({
+          type: "resolution.note_added",
+          summary: `Resolution note added for ${resourceType} ${resourceId}.`,
+          resolution,
+          actorId: actor.id,
+          actorRole: actor.role,
+          metadata: { noteAddedOnUpsert: true },
+        });
+      }
+      return res.json({ resolution });
+    }
+
+    resolution = createResolutionRecord({
+      resourceType,
+      resourceId,
+      triageCategory,
+      triageSeverity,
+      reasonCode,
+      note,
+      actorId: actor.id,
+      actorRole: actor.role,
+    });
+    await saveResolutionRecord(resolution);
+    await emitResolutionEvent({
+      type: "resolution.created",
+      summary: `Resolution created for ${resourceType} ${resourceId}.`,
+      resolution,
+      actorId: actor.id,
+      actorRole: actor.role,
+    });
+    return res.status(201).json({ resolution });
+  } catch (err: any) {
+    console.error("[admin-resolution] create failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "ADMIN_RESOLUTION_CREATE_FAILED" });
+  }
+});
+
+router.patch("/resolutions/:resolutionId/status", requireAuth, async (req: any, res) => {
+  try {
+    if (normalizeRole(req) !== "admin") {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+    const resolutionId = asString(req.params?.resolutionId, 240);
+    const nextStatus = asString(req.body?.status, 80) as ResolutionStatus;
+    const reason = asString(req.body?.reason, 1000) || null;
+    if (!resolutionId || !ALLOWED_STATUSES.has(nextStatus)) {
+      return res.status(400).json({ ok: false, error: "RESOLUTION_STATUS_INVALID" });
+    }
+
+    const snap = await db.collection("adminResolutions").doc(resolutionId).get();
+    if (!snap.exists) {
+      return res.status(404).json({ ok: false, error: "RESOLUTION_NOT_FOUND" });
+    }
+    const record = { id: snap.id, ...(snap.data() || {}) } as ResolutionRecordV1;
+    const actor = actorFromReq(req);
+    const resolution = await updateResolutionStatus(record, {
+      status: nextStatus,
+      reason,
+      authorId: actor.id,
+      authorRole: actor.role,
+    });
+    await emitResolutionEvent({
+      type: "resolution.status_changed",
+      summary: `Resolution status changed to ${nextStatus} for ${record.resource.type} ${record.resource.id}.`,
+      resolution,
+      actorId: actor.id,
+      actorRole: actor.role,
+      metadata: { fromStatus: record.status, toStatus: nextStatus, reason },
+    });
+    return res.json({ resolution });
+  } catch (err: any) {
+    if (err?.code === RESOLUTION_TRANSITION_ERROR_CODE) {
+      return res.status(400).json({ ok: false, error: err.code, message: err.message });
+    }
+    console.error("[admin-resolution] status update failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "ADMIN_RESOLUTION_STATUS_UPDATE_FAILED" });
+  }
+});
+
+router.post("/resolutions/:resolutionId/notes", requireAuth, async (req: any, res) => {
+  try {
+    if (normalizeRole(req) !== "admin") {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+    const resolutionId = asString(req.params?.resolutionId, 240);
+    const message = asString(req.body?.message, 4000);
+    if (!resolutionId || !message) {
+      return res.status(400).json({ ok: false, error: "RESOLUTION_NOTE_MESSAGE_REQUIRED" });
+    }
+    const snap = await db.collection("adminResolutions").doc(resolutionId).get();
+    if (!snap.exists) {
+      return res.status(404).json({ ok: false, error: "RESOLUTION_NOT_FOUND" });
+    }
+    const record = { id: snap.id, ...(snap.data() || {}) } as ResolutionRecordV1;
+    const actor = actorFromReq(req);
+    const resolution = await addResolutionNote(record, {
+      message,
+      authorId: actor.id,
+      authorRole: actor.role,
+    });
+    await emitResolutionEvent({
+      type: "resolution.note_added",
+      summary: `Resolution note added for ${record.resource.type} ${record.resource.id}.`,
+      resolution,
+      actorId: actor.id,
+      actorRole: actor.role,
+    });
+    return res.json({ resolution });
+  } catch (err: any) {
+    console.error("[admin-resolution] note add failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "ADMIN_RESOLUTION_NOTE_ADD_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-api/src/routes/adminTriageRoutes.ts
+++ b/rentchain-api/src/routes/adminTriageRoutes.ts
@@ -3,6 +3,7 @@ import { db } from "../config/firebase";
 import { requireAuth } from "../middleware/requireAuth";
 import { CANONICAL_EVENTS_COLLECTION } from "../lib/events/buildEvent";
 import type { CanonicalEventV1 } from "../lib/events/eventTypes";
+import { ADMIN_RESOLUTIONS_COLLECTION } from "../lib/resolution/loadResolutionRecord";
 import { deriveAdminTriageQueue } from "../lib/triage/deriveAdminTriageQueue";
 import type { AdminTriageItemV1, TriageCategory, TriageSeverity } from "../lib/triage/triageTypes";
 
@@ -95,7 +96,7 @@ router.get("/triage", requireAuth, async (req: any, res) => {
     const limit = parseLimit(req.query?.limit);
     const cursor = parseCursor(req.query?.cursor);
 
-    const [applications, maintenanceRequests, leases, canonicalEvents, screeningOrders, financialTransactions] =
+    const [applications, maintenanceRequests, leases, canonicalEvents, screeningOrders, financialTransactions, resolutions] =
       await Promise.all([
         loadCollection("rentalApplications"),
         loadCollection("maintenanceRequests"),
@@ -103,6 +104,7 @@ router.get("/triage", requireAuth, async (req: any, res) => {
         loadCanonicalEvents(),
         loadCollection("screeningOrders"),
         loadCollection("financialTransactions"),
+        loadCollection(ADMIN_RESOLUTIONS_COLLECTION),
       ]);
 
     const allItems = deriveAdminTriageQueue({
@@ -112,6 +114,7 @@ router.get("/triage", requireAuth, async (req: any, res) => {
       canonicalEvents,
       screeningOrders,
       financialTransactions,
+      resolutions,
     })
       .filter((item) => (includeLow ? true : item.severity !== "low"))
       .filter((item) => (category ? item.category === category : true))
@@ -140,4 +143,3 @@ router.get("/triage", requireAuth, async (req: any, res) => {
 });
 
 export default router;
-

--- a/rentchain-frontend/src/api/adminResolutionApi.ts
+++ b/rentchain-frontend/src/api/adminResolutionApi.ts
@@ -1,0 +1,43 @@
+import { apiFetch } from "./apiFetch";
+import type { ResolutionRecordV1, ResolutionStatus } from "./supportConsoleApi";
+
+export async function fetchResolution(resourceType: string, resourceId: string): Promise<{ resolution: ResolutionRecordV1 | null }> {
+  const search = new URLSearchParams();
+  search.set("resourceType", resourceType);
+  search.set("resourceId", resourceId);
+  return await apiFetch<{ resolution: ResolutionRecordV1 | null }>(`/admin/resolutions?${search.toString()}`);
+}
+
+export async function createResolution(payload: {
+  resourceType: string;
+  resourceId: string;
+  triageCategory?: string | null;
+  triageSeverity?: string | null;
+  reasonCode?: string | null;
+  note?: string | null;
+}): Promise<{ resolution: ResolutionRecordV1 }> {
+  return await apiFetch<{ resolution: ResolutionRecordV1 }>(`/admin/resolutions`, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function updateResolutionStatus(
+  resolutionId: string,
+  payload: { status: Exclude<ResolutionStatus, "open">; reason?: string | null }
+): Promise<{ resolution: ResolutionRecordV1 }> {
+  return await apiFetch<{ resolution: ResolutionRecordV1 }>(`/admin/resolutions/${encodeURIComponent(resolutionId)}/status`, {
+    method: "PATCH",
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function addResolutionNote(
+  resolutionId: string,
+  payload: { message: string }
+): Promise<{ resolution: ResolutionRecordV1 }> {
+  return await apiFetch<{ resolution: ResolutionRecordV1 }>(`/admin/resolutions/${encodeURIComponent(resolutionId)}/notes`, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}

--- a/rentchain-frontend/src/api/adminTriageApi.ts
+++ b/rentchain-frontend/src/api/adminTriageApi.ts
@@ -41,6 +41,10 @@ export type AdminTriageItemV1 = {
   navigation: {
     supportConsolePath?: string | null;
   };
+  resolution?: {
+    status: "open" | "acknowledged" | "in_progress" | "resolved" | "dismissed";
+    updatedAt: string;
+  } | null;
   tags?: string[];
 };
 
@@ -67,4 +71,3 @@ export async function fetchAdminTriageQueue(params?: {
   const query = search.toString();
   return await apiFetch<AdminTriageResponse>(`/admin/triage${query ? `?${query}` : ""}`);
 }
-

--- a/rentchain-frontend/src/api/supportConsoleApi.ts
+++ b/rentchain-frontend/src/api/supportConsoleApi.ts
@@ -31,11 +31,50 @@ export type SupportConsoleResourceResponse = {
     summary?: string | null;
   }>;
   reconciliation?: Record<string, unknown> | null;
+  resolution?: ResolutionRecordV1 | null;
   debug: {
     canonicalEventCount: number;
     domainsPresent: string[];
     identifiers?: Record<string, string | null | undefined>;
   };
+};
+
+export type ResolutionStatus = "open" | "acknowledged" | "in_progress" | "resolved" | "dismissed";
+
+export type ResolutionRecordV1 = {
+  version: "v1";
+  id: string;
+  resource: {
+    type: string;
+    id: string;
+  };
+  triage: {
+    category?: string | null;
+    severity?: string | null;
+    reasonCode?: string | null;
+  };
+  status: ResolutionStatus;
+  createdAt: string;
+  updatedAt: string;
+  resolvedAt?: string | null;
+  dismissedAt?: string | null;
+  notes: Array<{
+    id: string;
+    createdAt: string;
+    authorId?: string | null;
+    authorRole?: string | null;
+    message: string;
+  }>;
+  history: Array<{
+    id: string;
+    timestamp: string;
+    fromStatus?: ResolutionStatus | null;
+    toStatus: ResolutionStatus;
+    authorId?: string | null;
+    authorRole?: string | null;
+    reason?: string | null;
+  }>;
+  metadata?: Record<string, unknown>;
 };
 
 export async function fetchSupportConsoleResource(
@@ -49,4 +88,3 @@ export async function fetchSupportConsoleResource(
     `/admin/support-console/resource?${search.toString()}`
   );
 }
-

--- a/rentchain-frontend/src/components/adminResolution/ResolutionHistoryList.tsx
+++ b/rentchain-frontend/src/components/adminResolution/ResolutionHistoryList.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import type { ResolutionRecordV1 } from "../../api/supportConsoleApi";
+
+function formatTimestamp(value?: string | null) {
+  const parsed = Date.parse(String(value || ""));
+  if (!Number.isFinite(parsed)) return value || "-";
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(parsed));
+}
+
+export default function ResolutionHistoryList({ history }: { history: ResolutionRecordV1["history"] }) {
+  if (!history?.length) return <div style={{ color: "#64748b" }}>No resolution history yet.</div>;
+  return (
+    <div style={{ display: "grid", gap: 8 }}>
+      {history.map((entry) => (
+        <div key={entry.id} style={{ border: "1px solid rgba(15,23,42,0.08)", borderRadius: 10, padding: 10 }}>
+          <div style={{ fontWeight: 600 }}>{entry.fromStatus ? `${entry.fromStatus} -> ${entry.toStatus}` : entry.toStatus}</div>
+          <div style={{ color: "#64748b", fontSize: 13 }}>{formatTimestamp(entry.timestamp)}</div>
+          {entry.reason ? <div style={{ marginTop: 4 }}>{entry.reason}</div> : null}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/rentchain-frontend/src/components/adminResolution/ResolutionNotesList.tsx
+++ b/rentchain-frontend/src/components/adminResolution/ResolutionNotesList.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import type { ResolutionRecordV1 } from "../../api/supportConsoleApi";
+
+function formatTimestamp(value?: string | null) {
+  const parsed = Date.parse(String(value || ""));
+  if (!Number.isFinite(parsed)) return value || "-";
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(parsed));
+}
+
+export default function ResolutionNotesList({ notes }: { notes: ResolutionRecordV1["notes"] }) {
+  if (!notes?.length) return <div style={{ color: "#64748b" }}>No resolution notes yet.</div>;
+  return (
+    <div style={{ display: "grid", gap: 8 }}>
+      {notes.map((note) => (
+        <div key={note.id} style={{ border: "1px solid rgba(15,23,42,0.08)", borderRadius: 10, padding: 10 }}>
+          <div>{note.message}</div>
+          <div style={{ color: "#64748b", fontSize: 13, marginTop: 4 }}>{formatTimestamp(note.createdAt)}</div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/rentchain-frontend/src/components/adminResolution/ResolutionPanel.test.tsx
+++ b/rentchain-frontend/src/components/adminResolution/ResolutionPanel.test.tsx
@@ -1,0 +1,136 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import ResolutionPanel from "./ResolutionPanel";
+
+vi.mock("../../api/adminResolutionApi", () => ({
+  createResolution: vi.fn(),
+  updateResolutionStatus: vi.fn(),
+  addResolutionNote: vi.fn(),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("ResolutionPanel", () => {
+  it("renders empty state and creates a resolution", async () => {
+    const { createResolution } = await import("../../api/adminResolutionApi");
+    vi.mocked(createResolution).mockResolvedValue({
+      resolution: {
+        version: "v1",
+        id: "resolution-1",
+        resource: { type: "application", id: "app-1" },
+        triage: {},
+        status: "open",
+        createdAt: "2026-04-15T12:00:00.000Z",
+        updatedAt: "2026-04-15T12:00:00.000Z",
+        notes: [],
+        history: [],
+      },
+    } as any);
+    const onChange = vi.fn();
+
+    render(
+      <ResolutionPanel
+        resourceType="application"
+        resourceId="app-1"
+        triageCategory="screening_reconciliation"
+        triageSeverity="critical"
+        reasonCode="TRIAGE_PAID_NOT_FULFILLED"
+        resolution={null}
+        onChange={onChange}
+      />
+    );
+
+    expect(screen.getByText(/No resolution record exists yet for this resource/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Create resolution/i }));
+
+    await waitFor(() => {
+      expect(createResolution).toHaveBeenCalledWith({
+        resourceType: "application",
+        resourceId: "app-1",
+        triageCategory: "screening_reconciliation",
+        triageSeverity: "critical",
+        reasonCode: "TRIAGE_PAID_NOT_FULFILLED",
+        note: null,
+      });
+      expect(onChange).toHaveBeenCalled();
+    });
+  });
+
+  it("renders actions and appends notes for an existing resolution", async () => {
+    const { updateResolutionStatus, addResolutionNote } = await import("../../api/adminResolutionApi");
+    vi.mocked(updateResolutionStatus).mockResolvedValue({
+      resolution: {
+        version: "v1",
+        id: "resolution-1",
+        resource: { type: "application", id: "app-1" },
+        triage: {},
+        status: "acknowledged",
+        createdAt: "2026-04-15T12:00:00.000Z",
+        updatedAt: "2026-04-15T12:10:00.000Z",
+        notes: [],
+        history: [],
+      },
+    } as any);
+    vi.mocked(addResolutionNote).mockResolvedValue({
+      resolution: {
+        version: "v1",
+        id: "resolution-1",
+        resource: { type: "application", id: "app-1" },
+        triage: {},
+        status: "open",
+        createdAt: "2026-04-15T12:00:00.000Z",
+        updatedAt: "2026-04-15T12:05:00.000Z",
+        notes: [{ id: "note-1", createdAt: "2026-04-15T12:05:00.000Z", message: "Investigating." }],
+        history: [],
+      },
+    } as any);
+    const onChange = vi.fn();
+
+    render(
+      <ResolutionPanel
+        resourceType="application"
+        resourceId="app-1"
+        resolution={{
+          version: "v1",
+          id: "resolution-1",
+          resource: { type: "application", id: "app-1" },
+          triage: {},
+          status: "open",
+          createdAt: "2026-04-15T12:00:00.000Z",
+          updatedAt: "2026-04-15T12:00:00.000Z",
+          notes: [],
+          history: [],
+        }}
+        onChange={onChange}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText(/Resolution status reason/i), {
+      target: { value: "Starting review." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Acknowledge/i }));
+
+    await waitFor(() => {
+      expect(updateResolutionStatus).toHaveBeenCalledWith("resolution-1", {
+        status: "acknowledged",
+        reason: "Starting review.",
+      });
+    });
+
+    fireEvent.change(screen.getByLabelText(/Resolution note/i), {
+      target: { value: "Investigating." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Add note/i }));
+
+    await waitFor(() => {
+      expect(addResolutionNote).toHaveBeenCalledWith("resolution-1", {
+        message: "Investigating.",
+      });
+      expect(onChange).toHaveBeenCalled();
+    });
+  });
+});

--- a/rentchain-frontend/src/components/adminResolution/ResolutionPanel.tsx
+++ b/rentchain-frontend/src/components/adminResolution/ResolutionPanel.tsx
@@ -1,0 +1,175 @@
+import React from "react";
+import { addResolutionNote, createResolution, updateResolutionStatus } from "../../api/adminResolutionApi";
+import type { ResolutionRecordV1, ResolutionStatus } from "../../api/supportConsoleApi";
+import ResolutionHistoryList from "./ResolutionHistoryList";
+import ResolutionNotesList from "./ResolutionNotesList";
+import ResolutionStatusBadge from "./ResolutionStatusBadge";
+
+type Props = {
+  resourceType: string;
+  resourceId: string;
+  triageCategory?: string | null;
+  triageSeverity?: string | null;
+  reasonCode?: string | null;
+  resolution: ResolutionRecordV1 | null;
+  onChange: (resolution: ResolutionRecordV1) => void;
+};
+
+const TRANSITIONS: Record<ResolutionStatus, Array<{ status: Exclude<ResolutionStatus, "open">; label: string }>> = {
+  open: [
+    { status: "acknowledged", label: "Acknowledge" },
+    { status: "dismissed", label: "Dismiss" },
+  ],
+  acknowledged: [
+    { status: "in_progress", label: "Mark in progress" },
+    { status: "resolved", label: "Resolve" },
+    { status: "dismissed", label: "Dismiss" },
+  ],
+  in_progress: [
+    { status: "resolved", label: "Resolve" },
+    { status: "dismissed", label: "Dismiss" },
+  ],
+  resolved: [],
+  dismissed: [],
+};
+
+export default function ResolutionPanel({
+  resourceType,
+  resourceId,
+  triageCategory,
+  triageSeverity,
+  reasonCode,
+  resolution,
+  onChange,
+}: Props) {
+  const [note, setNote] = React.useState("");
+  const [statusReason, setStatusReason] = React.useState("");
+  const [saving, setSaving] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const handleCreate = async () => {
+    try {
+      setSaving(true);
+      setError(null);
+      const response = await createResolution({
+        resourceType,
+        resourceId,
+        triageCategory: triageCategory || null,
+        triageSeverity: triageSeverity || null,
+        reasonCode: reasonCode || null,
+        note: note || null,
+      });
+      onChange(response.resolution);
+      setNote("");
+    } catch (err: any) {
+      setError(err?.message || "Failed to create resolution");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleStatus = async (status: Exclude<ResolutionStatus, "open">) => {
+    if (!resolution) return;
+    try {
+      setSaving(true);
+      setError(null);
+      const response = await updateResolutionStatus(resolution.id, {
+        status,
+        reason: statusReason || null,
+      });
+      onChange(response.resolution);
+      setStatusReason("");
+    } catch (err: any) {
+      setError(err?.message || "Failed to update resolution");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleAddNote = async () => {
+    if (!resolution || !note.trim()) return;
+    try {
+      setSaving(true);
+      setError(null);
+      const response = await addResolutionNote(resolution.id, {
+        message: note,
+      });
+      onChange(response.resolution);
+      setNote("");
+    } catch (err: any) {
+      setError(err?.message || "Failed to add note");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div style={{ display: "grid", gap: 16 }}>
+      {resolution ? (
+        <>
+          <div style={{ display: "flex", gap: 10, alignItems: "center", flexWrap: "wrap" }}>
+            <ResolutionStatusBadge status={resolution.status} />
+            <span style={{ color: "#64748b", fontSize: 13 }}>
+              Updated {new Date(resolution.updatedAt).toLocaleString()}
+            </span>
+          </div>
+          <div style={{ display: "grid", gap: 8 }}>
+            <label style={{ display: "grid", gap: 4 }}>
+              <span style={{ color: "#64748b", fontSize: 12 }}>Status reason</span>
+              <input
+                aria-label="Resolution status reason"
+                value={statusReason}
+                onChange={(event) => setStatusReason(event.target.value)}
+                placeholder="Add a short operational reason"
+              />
+            </label>
+            <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+              {TRANSITIONS[resolution.status].map((action) => (
+                <button key={action.status} type="button" onClick={() => void handleStatus(action.status)} disabled={saving}>
+                  {action.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </>
+      ) : (
+        <div style={{ display: "grid", gap: 10 }}>
+          <div style={{ color: "#64748b" }}>No resolution record exists yet for this resource.</div>
+          <button type="button" onClick={() => void handleCreate()} disabled={saving}>
+            {saving ? "Creating..." : "Create resolution"}
+          </button>
+        </div>
+      )}
+
+      <div style={{ display: "grid", gap: 8 }}>
+        <label style={{ display: "grid", gap: 4 }}>
+          <span style={{ color: "#64748b", fontSize: 12 }}>Resolution note</span>
+          <textarea
+            aria-label="Resolution note"
+            value={note}
+            onChange={(event) => setNote(event.target.value)}
+            rows={3}
+            placeholder="Add an operational note"
+          />
+        </label>
+        <div>
+          <button type="button" onClick={() => void (resolution ? handleAddNote() : handleCreate())} disabled={saving || !note.trim()}>
+            {resolution ? "Add note" : "Create with note"}
+          </button>
+        </div>
+      </div>
+
+      {error ? <div style={{ color: "#b91c1c" }}>{error}</div> : null}
+
+      <div style={{ display: "grid", gap: 8 }}>
+        <strong>Notes</strong>
+        <ResolutionNotesList notes={resolution?.notes || []} />
+      </div>
+
+      <div style={{ display: "grid", gap: 8 }}>
+        <strong>History</strong>
+        <ResolutionHistoryList history={resolution?.history || []} />
+      </div>
+    </div>
+  );
+}

--- a/rentchain-frontend/src/components/adminResolution/ResolutionStatusBadge.tsx
+++ b/rentchain-frontend/src/components/adminResolution/ResolutionStatusBadge.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import type { ResolutionStatus } from "../../api/supportConsoleApi";
+
+const TONES: Record<ResolutionStatus, { background: string; color: string }> = {
+  open: { background: "rgba(59,130,246,0.12)", color: "#1d4ed8" },
+  acknowledged: { background: "rgba(245,158,11,0.16)", color: "#92400e" },
+  in_progress: { background: "rgba(14,165,233,0.16)", color: "#0c4a6e" },
+  resolved: { background: "rgba(34,197,94,0.14)", color: "#166534" },
+  dismissed: { background: "rgba(100,116,139,0.14)", color: "#475569" },
+};
+
+export default function ResolutionStatusBadge({ status }: { status: ResolutionStatus }) {
+  const tone = TONES[status];
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        padding: "4px 8px",
+        borderRadius: 999,
+        fontSize: 12,
+        fontWeight: 700,
+        textTransform: "uppercase",
+        letterSpacing: "0.04em",
+        background: tone.background,
+        color: tone.color,
+      }}
+    >
+      {status.replace(/_/g, " ")}
+    </span>
+  );
+}

--- a/rentchain-frontend/src/components/adminTriage/TriageQueueTable.tsx
+++ b/rentchain-frontend/src/components/adminTriage/TriageQueueTable.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import type { AdminTriageItemV1 } from "../../api/adminTriageApi";
+import ResolutionStatusBadge from "../adminResolution/ResolutionStatusBadge";
 import TriageSeverityBadge from "./TriageSeverityBadge";
 
 function formatTimestamp(value: string) {
@@ -55,6 +56,12 @@ export function TriageQueueTable({ items }: { items: AdminTriageItemV1[] }) {
               {signalLine(item) ? (
                 <div style={{ color: "#334155", fontSize: 13 }}>{signalLine(item)}</div>
               ) : null}
+              {item.resolution ? (
+                <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+                  <span style={{ color: "#64748b", fontSize: 13 }}>Resolution</span>
+                  <ResolutionStatusBadge status={item.resolution.status} />
+                </div>
+              ) : null}
             </div>
             <div style={{ display: "grid", gap: 8, justifyItems: "end" }}>
               <div style={{ color: "#64748b", fontSize: 12 }}>Surfaced {formatTimestamp(item.timestamps.surfacedAt)}</div>
@@ -70,4 +77,3 @@ export function TriageQueueTable({ items }: { items: AdminTriageItemV1[] }) {
 }
 
 export default TriageQueueTable;
-

--- a/rentchain-frontend/src/pages/admin/AdminTriageQueuePage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminTriageQueuePage.test.tsx
@@ -62,7 +62,12 @@ describe("AdminTriageQueuePage", () => {
             surfacedAt: "2026-04-15T12:00:00.000Z",
           },
           navigation: {
-            supportConsolePath: "/admin/support-console?resourceType=application&resourceId=app-1",
+            supportConsolePath:
+              "/admin/support-console?resourceType=application&resourceId=app-1&triageCategory=screening_reconciliation&triageSeverity=critical&reasonCode=TRIAGE_PAID_NOT_FULFILLED",
+          },
+          resolution: {
+            status: "acknowledged",
+            updatedAt: "2026-04-15T12:10:00.000Z",
           },
           tags: ["screening", "revenue"],
         },
@@ -78,9 +83,10 @@ describe("AdminTriageQueuePage", () => {
     expect(await screen.findByText(/Alex Applicant/i)).toBeInTheDocument();
     expect(screen.getByText(/Payment was recorded but screening completion is missing/i)).toBeInTheDocument();
     expect(screen.getAllByText(/critical/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/acknowledged/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Open support console/i })).toHaveAttribute(
       "href",
-      "/admin/support-console?resourceType=application&resourceId=app-1"
+      "/admin/support-console?resourceType=application&resourceId=app-1&triageCategory=screening_reconciliation&triageSeverity=critical&reasonCode=TRIAGE_PAID_NOT_FULFILLED"
     );
   });
 

--- a/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.test.tsx
@@ -10,6 +10,12 @@ vi.mock("../../api/supportConsoleApi", () => ({
   fetchSupportConsoleResource: vi.fn(),
 }));
 
+vi.mock("../../api/adminResolutionApi", () => ({
+  createResolution: vi.fn(),
+  updateResolutionStatus: vi.fn(),
+  addResolutionNote: vi.fn(),
+}));
+
 vi.mock("../../components/ui/ToastProvider", () => ({
   useToast: () => ({ showToast }),
 }));
@@ -94,6 +100,17 @@ describe("SupportDebugConsolePage", () => {
         status: "fulfilled",
         reasons: [{ code: "RECON_FULFILLED" }],
       },
+      resolution: {
+        version: "v1",
+        id: "resolution-1",
+        resource: { type: "application", id: "app-1" },
+        triage: { reasonCode: "TRIAGE_PAID_NOT_FULFILLED" },
+        status: "acknowledged",
+        createdAt: "2026-04-12T11:00:00.000Z",
+        updatedAt: "2026-04-12T11:30:00.000Z",
+        notes: [{ id: "note-1", createdAt: "2026-04-12T11:10:00.000Z", message: "Investigating." }],
+        history: [{ id: "hist-1", timestamp: "2026-04-12T11:00:00.000Z", toStatus: "open" }],
+      },
       debug: {
         canonicalEventCount: 4,
         domainsPresent: ["application", "screening"],
@@ -106,6 +123,7 @@ describe("SupportDebugConsolePage", () => {
     expect(await screen.findByText(/Alex Tenant/i)).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /Derived insight/i })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /^Reconciliation$/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /^Resolution$/i })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /Policy decisions/i })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /Automation history/i })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /^Timeline$/i })).toBeInTheDocument();
@@ -160,6 +178,7 @@ describe("SupportDebugConsolePage", () => {
         },
       ],
       reconciliation: null,
+      resolution: null,
       debug: {
         canonicalEventCount: 2,
         domainsPresent: ["maintenance", "policy", "system"],
@@ -178,5 +197,6 @@ describe("SupportDebugConsolePage", () => {
       expect(screen.getByText(/^maintenance\.auto_approve_cost$/i)).toBeInTheDocument();
     });
     expect(screen.queryByText(/^Reconciliation$/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/No resolution record exists yet for this resource/i)).toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.tsx
+++ b/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.tsx
@@ -9,6 +9,7 @@ import SupportConsoleHeader from "../../components/supportConsole/SupportConsole
 import SupportConsoleSection from "../../components/supportConsole/SupportConsoleSection";
 import PolicyDecisionList from "../../components/supportConsole/PolicyDecisionList";
 import AutomationHistoryList from "../../components/supportConsole/AutomationHistoryList";
+import ResolutionPanel from "../../components/adminResolution/ResolutionPanel";
 
 const RESOURCE_OPTIONS = [
   { label: "Application", value: "application" },
@@ -148,6 +149,18 @@ export default function SupportDebugConsolePage() {
               </SupportConsoleSection>
             ) : null}
 
+            <SupportConsoleSection title="Resolution">
+              <ResolutionPanel
+                resourceType={payload.resource.type}
+                resourceId={payload.resource.id}
+                triageCategory={searchParams.get("triageCategory")}
+                triageSeverity={searchParams.get("triageSeverity")}
+                reasonCode={searchParams.get("reasonCode")}
+                resolution={payload.resolution || null}
+                onChange={(resolution) => setPayload((current) => (current ? { ...current, resolution } : current))}
+              />
+            </SupportConsoleSection>
+
             <SupportConsoleSection title="Policy decisions">
               <PolicyDecisionList items={payload.policyDecisions} />
             </SupportConsoleSection>
@@ -173,4 +186,3 @@ export default function SupportDebugConsolePage() {
     </MacShell>
   );
 }
-


### PR DESCRIPTION
## Summary
Adds Admin Resolution Workflow v1 as an admin-only operational overlay for triage-worthy issues.

This introduces lightweight resolution records, status transitions, notes, and history so operators can acknowledge, track, and resolve surfaced issues inside the support/debug workflow without mutating the underlying business workflow state.

## Scope
- Adds `resolutionTypes`, storage/update helpers, and transition validation under `src/lib/resolution`
- Adds admin endpoints for:
  - `GET /api/admin/resolutions?resourceType=&resourceId=`
  - `POST /api/admin/resolutions`
  - `PATCH /api/admin/resolutions/:resolutionId/status`
  - `POST /api/admin/resolutions/:resolutionId/notes`
- Stores additive resolution records in a new `adminResolutions` collection
- Emits additive canonical audit events for:
  - `resolution.created`
  - `resolution.status_changed`
  - `resolution.note_added`
- Extends admin triage items with current resolution status where available
- Extends the admin support/debug console with a full resolution management section
- Adds a new frontend admin resolution API client and lightweight resolution UI components
- Adds targeted backend and frontend tests for:
  - create/upsert behavior
  - valid and invalid status transitions
  - append-only notes/history
  - triage/support-console integration
  - admin-only access

## Notes
This is intentionally admin-only, additive, and operational. Resolution state is a human-handling overlay and does not overwrite or auto-change the underlying application, maintenance, lease, policy, automation, or monetization workflow state.

For v1:
- one active resolution per exact `resourceType + resourceId + reasonCode` is supported through deterministic upsert behavior
- resolved and dismissed records remain visible through preserved history
- triage items are not hidden automatically when resolved

## Validation
- Passed targeted backend resolution, triage, and support-console tests
- Passed backend build
- Passed full frontend test suite
- Passed frontend build