### PR TITLE
feat: add admin assignment and ownership layer v1

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -104,6 +104,7 @@ import supportConsoleRoutes from "./routes/supportConsoleRoutes";
 import adminTriageRoutes from "./routes/adminTriageRoutes";
 import adminResolutionRoutes from "./routes/adminResolutionRoutes";
 import adminAlertingRoutes from "./routes/adminAlertingRoutes";
+import adminAssignmentRoutes from "./routes/adminAssignmentRoutes";
 import portfolioScoreRoutes from "./routes/portfolioScoreRoutes";
 import portfolioScoreHistoryRoutes from "./routes/portfolioScoreHistoryRoutes";
 import transunionRoutes from "./services/integrations/transunion/transunionRoutes";
@@ -233,6 +234,8 @@ app.use("/api/admin", routeSource("adminResolutionRoutes.ts"), adminResolutionRo
 console.log("[route-mount] adminResolutionRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("adminAlertingRoutes.ts"), adminAlertingRoutes);
 console.log("[route-mount] adminAlertingRoutes mounted at /api/admin");
+app.use("/api/admin", routeSource("adminAssignmentRoutes.ts"), adminAssignmentRoutes);
+console.log("[route-mount] adminAssignmentRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("portfolioScoreRoutes.ts"), portfolioScoreRoutes);
 console.log("[route-mount] portfolioScoreRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("portfolioScoreHistoryRoutes.ts"), portfolioScoreHistoryRoutes);

--- a/rentchain-api/src/lib/alerting/alertingTypes.ts
+++ b/rentchain-api/src/lib/alerting/alertingTypes.ts
@@ -59,5 +59,9 @@ export type AdminAlertV1 = {
     triagePath?: string | null;
     portfolioScorePath?: string | null;
   };
+  assignment?: {
+    ownerId?: string | null;
+    ownerLabel?: string | null;
+  } | null;
   tags?: string[];
 };

--- a/rentchain-api/src/lib/alerting/deriveAdminAlerts.ts
+++ b/rentchain-api/src/lib/alerting/deriveAdminAlerts.ts
@@ -1,4 +1,5 @@
 import crypto from "crypto";
+import type { AssignmentRecordV1 } from "../assignment/assignmentTypes";
 import type { PortfolioScoreTrendV1 } from "../portfolioScoreHistory/portfolioScoreHistoryTypes";
 import type { ResolutionRecordV1 } from "../resolution/resolutionTypes";
 import type { AdminTriageItemV1 } from "../triage/triageTypes";
@@ -16,6 +17,7 @@ type DeriveAdminAlertsInput = {
   triageItems?: AdminTriageItemV1[];
   portfolioTrends?: PortfolioScoreTrendV1[];
   resolutions?: ResolutionRecordV1[];
+  assignments?: AssignmentRecordV1[];
   alertStates?: AdminAlertStateRecord[];
   watchlist?: WatchlistEntryV1[];
   now?: number;
@@ -65,6 +67,7 @@ function buildAlert(input: {
   lastSeenAt?: string | null;
   watchlist?: WatchlistEntryV1[];
   alertState?: AdminAlertStateRecord | null;
+  assignment?: AssignmentRecordV1 | null;
   tags?: string[];
 }): AdminAlertV1 {
   const id = alertId(input.category, input.reason.code, input.resource.type, input.resource.id);
@@ -101,6 +104,12 @@ function buildAlert(input: {
         input.resource.type === "portfolio" ? undefined : triagePath(input.resource.type),
       portfolioScorePath: portfolioScorePath(input.resource.portfolioId || input.resource.id),
     },
+    assignment: input.assignment
+      ? {
+          ownerId: asString(input.assignment.currentOwner?.ownerId, 240) || null,
+          ownerLabel: asString(input.assignment.currentOwner?.ownerLabel, 240) || null,
+        }
+      : null,
     tags: [...(input.tags || []), ...(watched ? ["watched"] : [])],
   };
 }
@@ -108,6 +117,7 @@ function buildAlert(input: {
 export function deriveAdminAlerts(input: DeriveAdminAlertsInput): AdminAlertV1[] {
   const now = typeof input.now === "number" ? input.now : Date.now();
   const triageItems = input.triageItems || [];
+  const assignments = input.assignments || [];
   const alertStatesById = new Map((input.alertStates || []).map((item) => [item.id, item]));
   const watchlist = input.watchlist || [];
   const alerts: AdminAlertV1[] = [];
@@ -142,6 +152,12 @@ export function deriveAdminAlerts(input: DeriveAdminAlertsInput): AdminAlertV1[]
 
     if (!category) continue;
 
+    const assignment =
+      assignments.find(
+        (record) =>
+          asString(record.resource?.type, 120) === item.resource.type &&
+          asString(record.resource?.id, 240) === item.resource.id
+      ) || null;
     const id = alertId(category, reasonCode, item.resource.type, item.resource.id);
     alerts.push(
       {
@@ -171,6 +187,7 @@ export function deriveAdminAlerts(input: DeriveAdminAlertsInput): AdminAlertV1[]
           lastSeenAt: item.timestamps.lastSeenAt || item.timestamps.surfacedAt,
           watchlist,
           alertState: alertStatesById.get(id) || null,
+          assignment,
           tags: item.tags || [],
         }),
         id,
@@ -219,6 +236,7 @@ export function deriveAdminAlerts(input: DeriveAdminAlertsInput): AdminAlertV1[]
           lastSeenAt: latest.snapshotAt,
           watchlist,
           alertState: alertStatesById.get(id) || null,
+          assignment: null,
           tags: ["portfolio"],
         }),
         id,
@@ -242,6 +260,12 @@ export function deriveAdminAlerts(input: DeriveAdminAlertsInput): AdminAlertV1[]
         ? "critical"
         : "high";
     const reasonCode = "ALERT_RESOLUTION_STALE";
+    const assignment =
+      assignments.find(
+        (record) =>
+          asString(record.resource?.type, 120) === resolution.resource.type &&
+          asString(record.resource?.id, 240) === resolution.resource.id
+      ) || null;
     const id = alertId("resolution_attention", reasonCode, resolution.resource.type, resolution.resource.id);
     alerts.push(
       {
@@ -267,6 +291,7 @@ export function deriveAdminAlerts(input: DeriveAdminAlertsInput): AdminAlertV1[]
           lastSeenAt: resolution.updatedAt,
           watchlist,
           alertState: alertStatesById.get(id) || null,
+          assignment,
           tags: ["resolution"],
         }),
         id,

--- a/rentchain-api/src/lib/assignment/__tests__/setAssignmentOwner.test.ts
+++ b/rentchain-api/src/lib/assignment/__tests__/setAssignmentOwner.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { collections, dbMock } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, any>>();
+
+  function ensureCollection(name: string) {
+    if (!collections.has(name)) {
+      collections.set(name, new Map<string, any>());
+    }
+    return collections.get(name)!;
+  }
+
+  return {
+    collections,
+    dbMock: {
+      collection: (name: string) => ({
+        doc: (id: string) => ({
+          async get() {
+            return {
+              id,
+              exists: ensureCollection(name).has(id),
+              data: () => ensureCollection(name).get(id),
+            };
+          },
+          async set(value: any) {
+            ensureCollection(name).set(id, value);
+          },
+        }),
+        async get() {
+          const docs = Array.from(ensureCollection(name).entries()).map(([id, data]) => ({
+            id,
+            data: () => data,
+          }));
+          return { docs };
+        },
+      }),
+    },
+  };
+});
+
+vi.mock("../../../config/firebase", () => ({
+  db: dbMock,
+}));
+
+describe("setAssignmentOwner", () => {
+  beforeEach(() => {
+    collections.clear();
+  });
+
+  it("creates a resource-scoped assignment record", async () => {
+    const { setAssignmentOwner } = await import("../setAssignmentOwner");
+    const record = await setAssignmentOwner({
+      resourceType: "application",
+      resourceId: "app-1",
+      ownerId: "admin-1",
+      ownerLabel: "Alex Admin",
+      note: "Taking ownership",
+    });
+
+    expect(record.resource).toEqual({ type: "application", id: "app-1" });
+    expect(record.currentOwner).toEqual({ ownerId: "admin-1", ownerLabel: "Alex Admin" });
+    expect(record.history).toHaveLength(1);
+    expect(record.history[0]).toEqual(expect.objectContaining({ action: "set", toOwnerId: "admin-1" }));
+  });
+
+  it("upserts by resource identity and appends change history", async () => {
+    const { setAssignmentOwner } = await import("../setAssignmentOwner");
+    await setAssignmentOwner({
+      resourceType: "application",
+      resourceId: "app-1",
+      ownerId: "admin-1",
+      ownerLabel: "Alex Admin",
+    });
+
+    const updated = await setAssignmentOwner({
+      resourceType: "application",
+      resourceId: "app-1",
+      ownerId: "admin-2",
+      ownerLabel: "Jordan Admin",
+    });
+
+    expect(updated.currentOwner).toEqual({ ownerId: "admin-2", ownerLabel: "Jordan Admin" });
+    expect(updated.history).toHaveLength(2);
+    expect(updated.history[1]).toEqual(
+      expect.objectContaining({
+        action: "changed",
+        fromOwnerId: "admin-1",
+        toOwnerId: "admin-2",
+      })
+    );
+  });
+
+  it("clears ownership and preserves append-only history", async () => {
+    const { setAssignmentOwner } = await import("../setAssignmentOwner");
+    await setAssignmentOwner({
+      resourceType: "maintenance",
+      resourceId: "maint-1",
+      ownerId: "admin-1",
+      ownerLabel: "Alex Admin",
+    });
+
+    const cleared = await setAssignmentOwner({
+      resourceType: "maintenance",
+      resourceId: "maint-1",
+      ownerId: null,
+      ownerLabel: null,
+      note: "Returning to unassigned",
+    });
+
+    expect(cleared.currentOwner).toEqual({ ownerId: null, ownerLabel: null });
+    expect(cleared.history).toHaveLength(2);
+    expect(cleared.history[1]).toEqual(expect.objectContaining({ action: "cleared", fromOwnerId: "admin-1" }));
+  });
+});

--- a/rentchain-api/src/lib/assignment/assignmentTypes.ts
+++ b/rentchain-api/src/lib/assignment/assignmentTypes.ts
@@ -1,0 +1,29 @@
+export type AssignmentHistoryEntryV1 = {
+  id: string;
+  timestamp: string;
+  action: "set" | "changed" | "cleared";
+  fromOwnerId?: string | null;
+  fromOwnerLabel?: string | null;
+  toOwnerId?: string | null;
+  toOwnerLabel?: string | null;
+  authorId?: string | null;
+  authorRole?: string | null;
+  note?: string | null;
+};
+
+export type AssignmentRecordV1 = {
+  version: "v1";
+  id: string;
+  resource: {
+    type: string;
+    id: string;
+  };
+  currentOwner: {
+    ownerId?: string | null;
+    ownerLabel?: string | null;
+  };
+  createdAt: string;
+  updatedAt: string;
+  history: AssignmentHistoryEntryV1[];
+  metadata?: Record<string, unknown>;
+};

--- a/rentchain-api/src/lib/assignment/loadAssignmentRecord.ts
+++ b/rentchain-api/src/lib/assignment/loadAssignmentRecord.ts
@@ -1,0 +1,33 @@
+import crypto from "crypto";
+import { db } from "../../config/firebase";
+import type { AssignmentRecordV1 } from "./assignmentTypes";
+
+export const ADMIN_ASSIGNMENTS_COLLECTION = "adminAssignments";
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+export function assignmentRecordId(resourceType: string, resourceId: string) {
+  return crypto
+    .createHash("sha256")
+    .update(`${asString(resourceType, 120)}:${asString(resourceId, 240)}`)
+    .digest("hex");
+}
+
+export async function loadAllAssignmentRecords(): Promise<AssignmentRecordV1[]> {
+  const snap = await db.collection(ADMIN_ASSIGNMENTS_COLLECTION).get();
+  return (snap.docs || []).map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }) as AssignmentRecordV1);
+}
+
+export async function loadAssignmentRecord(input: {
+  resourceType: string;
+  resourceId: string;
+}): Promise<AssignmentRecordV1 | null> {
+  const resourceType = asString(input.resourceType, 120);
+  const resourceId = asString(input.resourceId, 240);
+  if (!resourceType || !resourceId) return null;
+  const snap = await db.collection(ADMIN_ASSIGNMENTS_COLLECTION).doc(assignmentRecordId(resourceType, resourceId)).get();
+  if (!snap.exists) return null;
+  return { id: snap.id, ...(snap.data() || {}) } as AssignmentRecordV1;
+}

--- a/rentchain-api/src/lib/assignment/saveAssignmentRecord.ts
+++ b/rentchain-api/src/lib/assignment/saveAssignmentRecord.ts
@@ -1,0 +1,8 @@
+import { db } from "../../config/firebase";
+import type { AssignmentRecordV1 } from "./assignmentTypes";
+import { ADMIN_ASSIGNMENTS_COLLECTION } from "./loadAssignmentRecord";
+
+export async function saveAssignmentRecord(record: AssignmentRecordV1) {
+  await db.collection(ADMIN_ASSIGNMENTS_COLLECTION).doc(record.id).set(record, { merge: false });
+  return record;
+}

--- a/rentchain-api/src/lib/assignment/setAssignmentOwner.ts
+++ b/rentchain-api/src/lib/assignment/setAssignmentOwner.ts
@@ -1,0 +1,120 @@
+import crypto from "crypto";
+import { assignmentRecordId, loadAssignmentRecord } from "./loadAssignmentRecord";
+import { saveAssignmentRecord } from "./saveAssignmentRecord";
+import type { AssignmentHistoryEntryV1, AssignmentRecordV1 } from "./assignmentTypes";
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function toIsoNow() {
+  return new Date().toISOString();
+}
+
+function buildHistoryEntry(input: {
+  action: AssignmentHistoryEntryV1["action"];
+  fromOwnerId?: string | null;
+  fromOwnerLabel?: string | null;
+  toOwnerId?: string | null;
+  toOwnerLabel?: string | null;
+  authorId?: string | null;
+  authorRole?: string | null;
+  note?: string | null;
+}): AssignmentHistoryEntryV1 {
+  return {
+    id: crypto.randomUUID(),
+    timestamp: toIsoNow(),
+    action: input.action,
+    fromOwnerId: input.fromOwnerId ?? null,
+    fromOwnerLabel: input.fromOwnerLabel ?? null,
+    toOwnerId: input.toOwnerId ?? null,
+    toOwnerLabel: input.toOwnerLabel ?? null,
+    authorId: input.authorId ?? null,
+    authorRole: input.authorRole ?? null,
+    note: input.note ?? null,
+  };
+}
+
+export async function setAssignmentOwner(input: {
+  resourceType: string;
+  resourceId: string;
+  ownerId?: string | null;
+  ownerLabel?: string | null;
+  authorId?: string | null;
+  authorRole?: string | null;
+  note?: string | null;
+}) {
+  const resourceType = asString(input.resourceType, 120);
+  const resourceId = asString(input.resourceId, 240);
+  const ownerId = asString(input.ownerId, 240) || null;
+  const ownerLabel = asString(input.ownerLabel, 240) || null;
+  const note = asString(input.note, 2000) || null;
+  if (!resourceType || !resourceId) {
+    throw new Error("ASSIGNMENT_RESOURCE_REQUIRED");
+  }
+
+  const existing = await loadAssignmentRecord({ resourceType, resourceId });
+  const now = toIsoNow();
+
+  if (!existing) {
+    const record: AssignmentRecordV1 = {
+      version: "v1",
+      id: assignmentRecordId(resourceType, resourceId),
+      resource: {
+        type: resourceType,
+        id: resourceId,
+      },
+      currentOwner: {
+        ownerId,
+        ownerLabel,
+      },
+      createdAt: now,
+      updatedAt: now,
+      history: [
+        buildHistoryEntry({
+          action: ownerId ? "set" : "cleared",
+          toOwnerId: ownerId,
+          toOwnerLabel: ownerLabel,
+          authorId: input.authorId,
+          authorRole: input.authorRole,
+          note,
+        }),
+      ],
+      metadata: {},
+    };
+    return await saveAssignmentRecord(record);
+  }
+
+  const priorOwnerId = asString(existing.currentOwner?.ownerId, 240) || null;
+  const priorOwnerLabel = asString(existing.currentOwner?.ownerLabel, 240) || null;
+  const action: AssignmentHistoryEntryV1["action"] = !ownerId
+    ? "cleared"
+    : !priorOwnerId
+    ? "set"
+    : priorOwnerId !== ownerId || priorOwnerLabel !== ownerLabel
+    ? "changed"
+    : "changed";
+
+  const next: AssignmentRecordV1 = {
+    ...existing,
+    currentOwner: {
+      ownerId,
+      ownerLabel,
+    },
+    updatedAt: now,
+    history: [
+      ...(Array.isArray(existing.history) ? existing.history : []),
+      buildHistoryEntry({
+        action,
+        fromOwnerId: priorOwnerId,
+        fromOwnerLabel: priorOwnerLabel,
+        toOwnerId: ownerId,
+        toOwnerLabel: ownerLabel,
+        authorId: input.authorId,
+        authorRole: input.authorRole,
+        note,
+      }),
+    ],
+  };
+  return await saveAssignmentRecord(next);
+}

--- a/rentchain-api/src/lib/assignment/updateAssignmentRecord.ts
+++ b/rentchain-api/src/lib/assignment/updateAssignmentRecord.ts
@@ -1,0 +1,6 @@
+import type { AssignmentRecordV1 } from "./assignmentTypes";
+import { saveAssignmentRecord } from "./saveAssignmentRecord";
+
+export async function updateAssignmentRecord(record: AssignmentRecordV1) {
+  return await saveAssignmentRecord(record);
+}

--- a/rentchain-api/src/lib/supportConsole/buildSupportConsoleResource.ts
+++ b/rentchain-api/src/lib/supportConsole/buildSupportConsoleResource.ts
@@ -1,4 +1,5 @@
 import { db } from "../../config/firebase";
+import { loadAssignmentRecord } from "../assignment/loadAssignmentRecord";
 import { CANONICAL_EVENTS_COLLECTION } from "../events/buildEvent";
 import type { CanonicalEventV1 } from "../events/eventTypes";
 import { deriveInsightForResource } from "../insights/deriveInsights";
@@ -282,6 +283,7 @@ function emptyResponse(spec: NormalizedResourceSpec, resourceId: string): Suppor
     policyDecisions: [],
     automation: [],
     reconciliation: null,
+    assignment: null,
     resolution: null,
     watch: null,
     debug: {
@@ -316,7 +318,11 @@ export async function buildSupportConsoleResource(input: {
   });
 
   let reconciliation: Record<string, unknown> | null = null;
-  const [resolution, watchlist] = await Promise.all([
+  const [assignment, resolution, watchlist] = await Promise.all([
+    loadAssignmentRecord({
+      resourceType: spec.requestedType,
+      resourceId,
+    }),
     loadResolutionRecord({
       resourceType: spec.requestedType,
       resourceId,
@@ -353,6 +359,7 @@ export async function buildSupportConsoleResource(input: {
     policyDecisions: buildPolicyDecisions(relatedEvents),
     automation: buildAutomationHistory(relatedEvents),
     reconciliation,
+    assignment,
     resolution,
     watch,
     debug: {

--- a/rentchain-api/src/lib/supportConsole/supportConsoleTypes.ts
+++ b/rentchain-api/src/lib/supportConsole/supportConsoleTypes.ts
@@ -1,4 +1,5 @@
 import type { TimelineItem } from "../timeline/timelineAdapter";
+import type { AssignmentRecordV1 } from "../assignment/assignmentTypes";
 import type { ResolutionRecordV1 } from "../resolution/resolutionTypes";
 import type { WatchlistEntryV1 } from "../watchlist/watchlistTypes";
 
@@ -38,6 +39,7 @@ export type SupportConsoleResourceResponse = {
   policyDecisions: SupportConsolePolicyDecision[];
   automation: SupportConsoleAutomationItem[];
   reconciliation?: Record<string, unknown> | null;
+  assignment?: AssignmentRecordV1 | null;
   resolution?: ResolutionRecordV1 | null;
   watch?: WatchlistEntryV1 | null;
   debug: {

--- a/rentchain-api/src/lib/triage/deriveAdminTriageQueue.ts
+++ b/rentchain-api/src/lib/triage/deriveAdminTriageQueue.ts
@@ -1,3 +1,4 @@
+import type { AssignmentRecordV1 } from "../assignment/assignmentTypes";
 import type { CanonicalEventV1 } from "../events/eventTypes";
 import { deriveInsightForResource } from "../insights/deriveInsights";
 import { deriveScreeningReconciliation } from "../reconciliation/deriveScreeningReconciliation";
@@ -31,6 +32,7 @@ type DeriveAdminTriageQueueInput = {
   screeningOrders?: ScreeningOrderLike[];
   financialTransactions?: FinancialTransactionLike[];
   resolutions?: ResolutionRecordV1[];
+  assignments?: AssignmentRecordV1[];
   watchlist?: WatchlistEntryV1[];
   now?: number;
 };
@@ -646,8 +648,14 @@ export function deriveAdminTriageQueue(input: DeriveAdminTriageQueueInput): Admi
   );
 
   const resolutions = input.resolutions || [];
+  const assignments = input.assignments || [];
   const watchlist = input.watchlist || [];
   const enriched = items.map((item) => {
+    const assignment = assignments.find(
+      (record) =>
+        asString(record.resource?.type, 120) === item.resource.type &&
+        asString(record.resource?.id, 240) === item.resource.id
+    );
     const match = resolutions
       .filter(
         (record) =>
@@ -661,6 +669,13 @@ export function deriveAdminTriageQueue(input: DeriveAdminTriageQueueInput): Admi
     );
     return {
       ...item,
+      assignment: assignment
+        ? {
+            ownerId: asOptionalString(assignment.currentOwner?.ownerId, 240),
+            ownerLabel: asOptionalString(assignment.currentOwner?.ownerLabel, 240),
+            updatedAt: assignment.updatedAt,
+          }
+        : null,
       resolution: match
         ? {
             status: match.status,

--- a/rentchain-api/src/routes/__tests__/adminAssignmentRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/adminAssignmentRoutes.test.ts
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { collections, dbMock } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, any>>();
+
+  function ensureCollection(name: string) {
+    if (!collections.has(name)) {
+      collections.set(name, new Map<string, any>());
+    }
+    return collections.get(name)!;
+  }
+
+  return {
+    collections,
+    dbMock: {
+      collection: (name: string) => ({
+        doc: (id: string) => ({
+          async get() {
+            return {
+              id,
+              exists: ensureCollection(name).has(id),
+              data: () => ensureCollection(name).get(id),
+            };
+          },
+          async set(value: any) {
+            ensureCollection(name).set(id, value);
+          },
+        }),
+        async get() {
+          const docs = Array.from(ensureCollection(name).entries()).map(([id, data]) => ({
+            id,
+            data: () => data,
+          }));
+          return { docs };
+        },
+      }),
+    },
+  };
+});
+
+vi.mock("../../config/firebase", () => ({
+  db: dbMock,
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!req.user) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    return next();
+  },
+}));
+
+vi.mock("../../lib/events/buildEvent", () => ({
+  writeCanonicalEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+async function invokeRouter(
+  router: any,
+  options: { method: string; url: string; user?: Record<string, unknown> | null; body?: any }
+) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    const query = new URLSearchParams(queryString || "");
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: options.user ?? null,
+      query: Object.fromEntries(query.entries()),
+      body: options.body || {},
+      params: {},
+      headers: {},
+      get(name: string) {
+        return this.headers[String(name).toLowerCase()];
+      },
+      header(name: string) {
+        return this.get(name);
+      },
+    };
+    const match = path.match(/\/assignments\/([^/]+)$/);
+    if (match) {
+      req.params.assignmentId = decodeURIComponent(match[1]);
+    }
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("adminAssignmentRoutes", () => {
+  beforeEach(() => {
+    collections.clear();
+  });
+
+  it("creates and fetches an assignment record", async () => {
+    const router = (await import("../adminAssignmentRoutes")).default;
+    const created = await invokeRouter(router, {
+      method: "POST",
+      url: "/assignments",
+      user: { id: "admin-1", role: "admin" },
+      body: {
+        resourceType: "application",
+        resourceId: "app-1",
+        ownerId: "admin-2",
+        ownerLabel: "Jordan Admin",
+        note: "Taking ownership",
+      },
+    });
+
+    expect(created.status).toBe(201);
+    expect(created.body.assignment).toEqual(
+      expect.objectContaining({
+        resource: { type: "application", id: "app-1" },
+        currentOwner: { ownerId: "admin-2", ownerLabel: "Jordan Admin" },
+      })
+    );
+
+    const fetched = await invokeRouter(router, {
+      method: "GET",
+      url: "/assignments?resourceType=application&resourceId=app-1",
+      user: { id: "admin-1", role: "admin" },
+    });
+    expect(fetched.status).toBe(200);
+    expect(fetched.body.assignment.id).toBe(created.body.assignment.id);
+  });
+
+  it("upserts by exact resource and appends history on change and clear", async () => {
+    const router = (await import("../adminAssignmentRoutes")).default;
+    const created = await invokeRouter(router, {
+      method: "POST",
+      url: "/assignments",
+      user: { id: "admin-1", role: "admin" },
+      body: {
+        resourceType: "maintenance",
+        resourceId: "maint-1",
+        ownerId: "admin-2",
+        ownerLabel: "Jordan Admin",
+      },
+    });
+
+    const changed = await invokeRouter(router, {
+      method: "POST",
+      url: "/assignments",
+      user: { id: "admin-1", role: "admin" },
+      body: {
+        resourceType: "maintenance",
+        resourceId: "maint-1",
+        ownerId: "admin-3",
+        ownerLabel: "Taylor Admin",
+      },
+    });
+    expect(changed.status).toBe(200);
+    expect(changed.body.assignment.history).toHaveLength(2);
+
+    const cleared = await invokeRouter(router, {
+      method: "PATCH",
+      url: `/assignments/${created.body.assignment.id}`,
+      user: { id: "admin-1", role: "admin" },
+      body: {
+        ownerId: null,
+        ownerLabel: null,
+        note: "Clearing owner",
+      },
+    });
+    expect(cleared.status).toBe(200);
+    expect(cleared.body.assignment.currentOwner).toEqual({ ownerId: null, ownerLabel: null });
+    expect(cleared.body.assignment.history).toHaveLength(3);
+    expect(cleared.body.assignment.history.at(-1)).toEqual(expect.objectContaining({ action: "cleared" }));
+  });
+
+  it("enforces admin-only access and stable validation", async () => {
+    const router = (await import("../adminAssignmentRoutes")).default;
+    const forbidden = await invokeRouter(router, {
+      method: "GET",
+      url: "/assignments?resourceType=application&resourceId=app-1",
+      user: { id: "landlord-1", role: "landlord" },
+    });
+    expect(forbidden.status).toBe(403);
+    expect(forbidden.body.error).toBe("FORBIDDEN");
+
+    const invalid = await invokeRouter(router, {
+      method: "POST",
+      url: "/assignments",
+      user: { id: "admin-1", role: "admin" },
+      body: { resourceType: "application", resourceId: "app-1" },
+    });
+    expect(invalid.status).toBe(400);
+    expect(invalid.body.error).toBe("OWNER_ID_REQUIRED");
+  });
+
+  it("returns a stable null shape when no assignment exists", async () => {
+    const router = (await import("../adminAssignmentRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/assignments?resourceType=lease&resourceId=lease-1",
+      user: { id: "admin-1", role: "admin" },
+    });
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ assignment: null });
+  });
+});

--- a/rentchain-api/src/routes/__tests__/adminTriageRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/adminTriageRoutes.test.ts
@@ -123,6 +123,15 @@ describe("adminTriageRoutes", () => {
       visibility: "internal",
       summary: "Screening paid",
     });
+    seedDoc("adminAssignments", "assignment-1", {
+      version: "v1",
+      id: "assignment-1",
+      resource: { type: "application", id: "app-1" },
+      currentOwner: { ownerId: "admin-1", ownerLabel: "Morgan Ops" },
+      createdAt: "2026-04-15T08:05:00.000Z",
+      updatedAt: "2026-04-15T08:10:00.000Z",
+      history: [],
+    });
 
     const router = (await import("../adminTriageRoutes")).default;
     const response = await invokeRouter(router, {
@@ -137,6 +146,10 @@ describe("adminTriageRoutes", () => {
         expect.objectContaining({
           category: "screening_reconciliation",
           severity: "critical",
+          assignment: expect.objectContaining({
+            ownerId: "admin-1",
+            ownerLabel: "Morgan Ops",
+          }),
           navigation: expect.objectContaining({
             supportConsolePath:
               "/admin/support-console?resourceType=application&resourceId=app-1&triageCategory=screening_reconciliation&triageSeverity=critical&reasonCode=TRIAGE_PAID_NOT_FULFILLED",

--- a/rentchain-api/src/routes/__tests__/supportConsoleRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/supportConsoleRoutes.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { assignmentRecordId } from "../../lib/assignment/loadAssignmentRecord";
 
 const { collections, dbMock } = vi.hoisted(() => {
   const collections = new Map<string, Map<string, any>>();
@@ -127,6 +128,14 @@ describe("supportConsoleRoutes", () => {
       visibility: "internal",
       summary: "Application created",
     });
+    seedDoc("adminAssignments", assignmentRecordId("application", "app-1"), {
+      version: "v1",
+      resource: { type: "application", id: "app-1" },
+      currentOwner: { ownerId: "admin-1", ownerLabel: "Morgan Ops" },
+      createdAt: "2026-04-10T09:05:00.000Z",
+      updatedAt: "2026-04-10T09:15:00.000Z",
+      history: [],
+    });
 
     const router = (await import("../supportConsoleRoutes")).default;
     const response = await invokeRouter(router, {
@@ -145,6 +154,12 @@ describe("supportConsoleRoutes", () => {
         timeline: expect.any(Array),
         insight: expect.anything(),
         reconciliation: expect.anything(),
+        assignment: expect.objectContaining({
+          currentOwner: expect.objectContaining({
+            ownerId: "admin-1",
+            ownerLabel: "Morgan Ops",
+          }),
+        }),
         debug: expect.objectContaining({
           canonicalEventCount: 1,
         }),
@@ -264,6 +279,7 @@ describe("supportConsoleRoutes", () => {
         timeline: [],
         policyDecisions: [],
         automation: [],
+        assignment: null,
       })
     );
   });

--- a/rentchain-api/src/routes/adminAlertingRoutes.ts
+++ b/rentchain-api/src/routes/adminAlertingRoutes.ts
@@ -1,6 +1,7 @@
 import crypto from "crypto";
 import { Router } from "express";
 import { db } from "../config/firebase";
+import { ADMIN_ASSIGNMENTS_COLLECTION } from "../lib/assignment/loadAssignmentRecord";
 import { requireAuth } from "../middleware/requireAuth";
 import { deriveAdminAlerts } from "../lib/alerting/deriveAdminAlerts";
 import type { AdminAlertV1, AlertCategory, AlertSeverity } from "../lib/alerting/alertingTypes";
@@ -126,7 +127,7 @@ router.get("/alerts", requireAuth, async (req: any, res) => {
     const limit = parseLimit(req.query?.limit, 20);
     const cursor = parseCursor(req.query?.cursor);
 
-    const [applications, maintenanceRequests, leases, canonicalEvents, screeningOrders, financialTransactions, resolutions, alertStates, watchlist] =
+    const [applications, maintenanceRequests, leases, canonicalEvents, screeningOrders, financialTransactions, resolutions, assignments, alertStates, watchlist] =
       await Promise.all([
         loadCollection("rentalApplications"),
         loadCollection("maintenanceRequests"),
@@ -135,6 +136,7 @@ router.get("/alerts", requireAuth, async (req: any, res) => {
         loadCollection("screeningOrders"),
         loadCollection("financialTransactions"),
         loadCollection(ADMIN_RESOLUTIONS_COLLECTION),
+        loadCollection(ADMIN_ASSIGNMENTS_COLLECTION),
         loadAlertStates(),
         loadWatchlistEntries(),
       ]);
@@ -147,6 +149,7 @@ router.get("/alerts", requireAuth, async (req: any, res) => {
       screeningOrders,
       financialTransactions,
       resolutions,
+      assignments,
     });
     const portfolioTrends = await loadPortfolioTrends(
       latestUniquePortfolioIds([...applications, ...maintenanceRequests, ...leases])
@@ -156,6 +159,7 @@ router.get("/alerts", requireAuth, async (req: any, res) => {
       triageItems,
       portfolioTrends,
       resolutions,
+      assignments,
       alertStates,
       watchlist,
     })

--- a/rentchain-api/src/routes/adminAssignmentRoutes.ts
+++ b/rentchain-api/src/routes/adminAssignmentRoutes.ts
@@ -1,0 +1,171 @@
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { writeCanonicalEvent } from "../lib/events/buildEvent";
+import { loadAssignmentRecord, ADMIN_ASSIGNMENTS_COLLECTION } from "../lib/assignment/loadAssignmentRecord";
+import { setAssignmentOwner } from "../lib/assignment/setAssignmentOwner";
+import type { AssignmentRecordV1 } from "../lib/assignment/assignmentTypes";
+import { requireAuth } from "../middleware/requireAuth";
+
+const router = Router();
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function normalizeRole(req: any): "admin" | "landlord" | "other" {
+  const role = asString(req.user?.actorRole || req.user?.role, 40).toLowerCase();
+  if (role === "admin") return "admin";
+  if (role === "landlord") return "landlord";
+  return "other";
+}
+
+function actorFromReq(req: any) {
+  return {
+    id: asString(req.user?.uid || req.user?.id, 240) || null,
+    role: asString(req.user?.actorRole || req.user?.role, 80) || null,
+  };
+}
+
+async function emitAssignmentEvent(input: {
+  type: "assignment.set" | "assignment.changed" | "assignment.cleared";
+  summary: string;
+  assignment: AssignmentRecordV1;
+  actorId?: string | null;
+  actorRole?: string | null;
+  metadata?: Record<string, unknown>;
+}) {
+  await writeCanonicalEvent({
+    type: input.type,
+    domain: "system",
+    action: input.type.split(".").slice(1).join("_"),
+    actor: {
+      type: "admin",
+      id: input.actorId || null,
+      role: input.actorRole || null,
+    },
+    resource: {
+      type: "assignment",
+      id: input.assignment.id,
+      parentType: input.assignment.resource.type,
+      parentId: input.assignment.resource.id,
+    },
+    occurredAt: new Date().toISOString(),
+    visibility: "internal",
+    summary: input.summary,
+    metadata: {
+      ownerId: input.assignment.currentOwner?.ownerId || null,
+      ownerLabel: input.assignment.currentOwner?.ownerLabel || null,
+      ...input.metadata,
+    },
+  });
+}
+
+router.get("/assignments", requireAuth, async (req: any, res) => {
+  try {
+    if (normalizeRole(req) !== "admin") {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+    const resourceType = asString(req.query?.resourceType, 120);
+    const resourceId = asString(req.query?.resourceId, 240);
+    if (!resourceType || !resourceId) {
+      return res.status(400).json({ ok: false, error: "RESOURCE_REFERENCE_REQUIRED" });
+    }
+    const assignment = await loadAssignmentRecord({ resourceType, resourceId });
+    return res.json({ assignment: assignment || null });
+  } catch (err: any) {
+    console.error("[admin-assignment] fetch failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "ADMIN_ASSIGNMENT_FETCH_FAILED" });
+  }
+});
+
+router.post("/assignments", requireAuth, async (req: any, res) => {
+  try {
+    if (normalizeRole(req) !== "admin") {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+    const resourceType = asString(req.body?.resourceType, 120);
+    const resourceId = asString(req.body?.resourceId, 240);
+    const ownerId = asString(req.body?.ownerId, 240) || null;
+    const ownerLabel = asString(req.body?.ownerLabel, 240) || null;
+    const note = asString(req.body?.note, 2000) || null;
+    if (!resourceType || !resourceId) {
+      return res.status(400).json({ ok: false, error: "RESOURCE_REFERENCE_REQUIRED" });
+    }
+    if (!ownerId) {
+      return res.status(400).json({ ok: false, error: "OWNER_ID_REQUIRED" });
+    }
+
+    const existing = await loadAssignmentRecord({ resourceType, resourceId });
+    const actor = actorFromReq(req);
+    const assignment = await setAssignmentOwner({
+      resourceType,
+      resourceId,
+      ownerId,
+      ownerLabel,
+      note,
+      authorId: actor.id,
+      authorRole: actor.role,
+    });
+    const latestAction = assignment.history.at(-1)?.action || "set";
+    await emitAssignmentEvent({
+      type: existing ? "assignment.changed" : "assignment.set",
+      summary: `Assignment ${latestAction} for ${resourceType} ${resourceId}.`,
+      assignment,
+      actorId: actor.id,
+      actorRole: actor.role,
+      metadata: { latestAction },
+    });
+    return res.status(existing ? 200 : 201).json({ assignment });
+  } catch (err: any) {
+    console.error("[admin-assignment] create failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "ADMIN_ASSIGNMENT_CREATE_FAILED" });
+  }
+});
+
+router.patch("/assignments/:assignmentId", requireAuth, async (req: any, res) => {
+  try {
+    if (normalizeRole(req) !== "admin") {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+    const assignmentId = asString(req.params?.assignmentId, 240);
+    if (!assignmentId) {
+      return res.status(400).json({ ok: false, error: "ASSIGNMENT_ID_REQUIRED" });
+    }
+
+    const snap = await db.collection(ADMIN_ASSIGNMENTS_COLLECTION).doc(assignmentId).get();
+    if (!snap.exists) {
+      return res.status(404).json({ ok: false, error: "ASSIGNMENT_NOT_FOUND" });
+    }
+    const existing = { id: snap.id, ...(snap.data() || {}) } as AssignmentRecordV1;
+    const ownerId = req.body?.ownerId == null ? null : asString(req.body?.ownerId, 240) || null;
+    const ownerLabel = req.body?.ownerLabel == null ? null : asString(req.body?.ownerLabel, 240) || null;
+    const note = asString(req.body?.note, 2000) || null;
+    const actor = actorFromReq(req);
+
+    const assignment = await setAssignmentOwner({
+      resourceType: existing.resource.type,
+      resourceId: existing.resource.id,
+      ownerId,
+      ownerLabel,
+      note,
+      authorId: actor.id,
+      authorRole: actor.role,
+    });
+
+    const latestAction = assignment.history.at(-1)?.action || "changed";
+    await emitAssignmentEvent({
+      type: latestAction === "cleared" ? "assignment.cleared" : latestAction === "set" ? "assignment.set" : "assignment.changed",
+      summary: `Assignment ${latestAction} for ${existing.resource.type} ${existing.resource.id}.`,
+      assignment,
+      actorId: actor.id,
+      actorRole: actor.role,
+      metadata: { latestAction },
+    });
+    return res.json({ assignment });
+  } catch (err: any) {
+    console.error("[admin-assignment] update failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "ADMIN_ASSIGNMENT_UPDATE_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-api/src/routes/adminTriageRoutes.ts
+++ b/rentchain-api/src/routes/adminTriageRoutes.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { db } from "../config/firebase";
+import { ADMIN_ASSIGNMENTS_COLLECTION } from "../lib/assignment/loadAssignmentRecord";
 import { requireAuth } from "../middleware/requireAuth";
 import { CANONICAL_EVENTS_COLLECTION } from "../lib/events/buildEvent";
 import type { CanonicalEventV1 } from "../lib/events/eventTypes";
@@ -97,7 +98,7 @@ router.get("/triage", requireAuth, async (req: any, res) => {
     const limit = parseLimit(req.query?.limit);
     const cursor = parseCursor(req.query?.cursor);
 
-    const [applications, maintenanceRequests, leases, canonicalEvents, screeningOrders, financialTransactions, resolutions, watchlist] =
+    const [applications, maintenanceRequests, leases, canonicalEvents, screeningOrders, financialTransactions, resolutions, assignments, watchlist] =
       await Promise.all([
         loadCollection("rentalApplications"),
         loadCollection("maintenanceRequests"),
@@ -106,6 +107,7 @@ router.get("/triage", requireAuth, async (req: any, res) => {
         loadCollection("screeningOrders"),
         loadCollection("financialTransactions"),
         loadCollection(ADMIN_RESOLUTIONS_COLLECTION),
+        loadCollection(ADMIN_ASSIGNMENTS_COLLECTION),
         loadCollection(ADMIN_WATCHLISTS_COLLECTION),
       ]);
 
@@ -117,6 +119,7 @@ router.get("/triage", requireAuth, async (req: any, res) => {
       screeningOrders,
       financialTransactions,
       resolutions,
+      assignments,
       watchlist,
     })
       .filter((item) => (includeLow ? true : item.severity !== "low"))

--- a/rentchain-frontend/src/api/adminAlertingApi.ts
+++ b/rentchain-frontend/src/api/adminAlertingApi.ts
@@ -53,6 +53,10 @@ export type AdminAlertV1 = {
     triagePath?: string | null;
     portfolioScorePath?: string | null;
   };
+  assignment?: {
+    ownerId?: string | null;
+    ownerLabel?: string | null;
+  } | null;
   tags?: string[];
 };
 

--- a/rentchain-frontend/src/api/adminAssignmentApi.ts
+++ b/rentchain-frontend/src/api/adminAssignmentApi.ts
@@ -1,0 +1,36 @@
+import { apiFetch } from "./apiFetch";
+import type { AssignmentRecordV1 } from "./supportConsoleApi";
+
+export async function fetchAssignment(resourceType: string, resourceId: string): Promise<{ assignment: AssignmentRecordV1 | null }> {
+  const search = new URLSearchParams();
+  search.set("resourceType", resourceType);
+  search.set("resourceId", resourceId);
+  return await apiFetch<{ assignment: AssignmentRecordV1 | null }>(`/admin/assignments?${search.toString()}`);
+}
+
+export async function createAssignment(payload: {
+  resourceType: string;
+  resourceId: string;
+  ownerId?: string | null;
+  ownerLabel?: string | null;
+  note?: string | null;
+}): Promise<{ assignment: AssignmentRecordV1 }> {
+  return await apiFetch<{ assignment: AssignmentRecordV1 }>(`/admin/assignments`, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function updateAssignment(
+  assignmentId: string,
+  payload: {
+    ownerId?: string | null;
+    ownerLabel?: string | null;
+    note?: string | null;
+  }
+): Promise<{ assignment: AssignmentRecordV1 }> {
+  return await apiFetch<{ assignment: AssignmentRecordV1 }>(`/admin/assignments/${encodeURIComponent(assignmentId)}`, {
+    method: "PATCH",
+    body: JSON.stringify(payload),
+  });
+}

--- a/rentchain-frontend/src/api/adminTriageApi.ts
+++ b/rentchain-frontend/src/api/adminTriageApi.ts
@@ -41,6 +41,11 @@ export type AdminTriageItemV1 = {
   navigation: {
     supportConsolePath?: string | null;
   };
+  assignment?: {
+    ownerId?: string | null;
+    ownerLabel?: string | null;
+    updatedAt: string;
+  } | null;
   resolution?: {
     status: "open" | "acknowledged" | "in_progress" | "resolved" | "dismissed";
     updatedAt: string;

--- a/rentchain-frontend/src/api/supportConsoleApi.ts
+++ b/rentchain-frontend/src/api/supportConsoleApi.ts
@@ -31,6 +31,7 @@ export type SupportConsoleResourceResponse = {
     summary?: string | null;
   }>;
   reconciliation?: Record<string, unknown> | null;
+  assignment?: AssignmentRecordV1 | null;
   resolution?: ResolutionRecordV1 | null;
   watch?: {
     version: "v1";
@@ -55,6 +56,34 @@ export type SupportConsoleResourceResponse = {
 };
 
 export type ResolutionStatus = "open" | "acknowledged" | "in_progress" | "resolved" | "dismissed";
+
+export type AssignmentRecordV1 = {
+  version: "v1";
+  id: string;
+  resource: {
+    type: string;
+    id: string;
+  };
+  currentOwner: {
+    ownerId?: string | null;
+    ownerLabel?: string | null;
+  };
+  createdAt: string;
+  updatedAt: string;
+  history: Array<{
+    id: string;
+    timestamp: string;
+    action: "set" | "changed" | "cleared";
+    fromOwnerId?: string | null;
+    fromOwnerLabel?: string | null;
+    toOwnerId?: string | null;
+    toOwnerLabel?: string | null;
+    authorId?: string | null;
+    authorRole?: string | null;
+    note?: string | null;
+  }>;
+  metadata?: Record<string, unknown>;
+};
 
 export type ResolutionRecordV1 = {
   version: "v1";

--- a/rentchain-frontend/src/components/adminAlerting/AlertTable.tsx
+++ b/rentchain-frontend/src/components/adminAlerting/AlertTable.tsx
@@ -27,6 +27,11 @@ export default function AlertTable(props: {
                 {alert.resource.type} • {alert.resource.id}
                 {alert.resource.status ? ` • ${alert.resource.status}` : ""}
               </div>
+              {alert.assignment?.ownerId ? (
+                <div style={{ color: "#334155", fontSize: 13 }}>
+                  Owner: {alert.assignment.ownerLabel || alert.assignment.ownerId}
+                </div>
+              ) : null}
             </div>
             <div style={{ display: "grid", gap: 8, justifyItems: "end" }}>
               <button type="button" onClick={() => props.onAcknowledge(alert)}>

--- a/rentchain-frontend/src/components/adminAssignment/AssignmentBadge.tsx
+++ b/rentchain-frontend/src/components/adminAssignment/AssignmentBadge.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+export default function AssignmentBadge(props: {
+  ownerId?: string | null;
+  ownerLabel?: string | null;
+}) {
+  const assigned = Boolean(props.ownerId);
+  const label = props.ownerLabel || props.ownerId || "Unassigned";
+
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 6,
+        padding: "4px 10px",
+        borderRadius: 999,
+        fontSize: 12,
+        fontWeight: 700,
+        background: assigned ? "rgba(14, 116, 144, 0.14)" : "rgba(100, 116, 139, 0.14)",
+        color: assigned ? "#155e75" : "#475569",
+      }}
+    >
+      {assigned ? "Assigned" : "Unassigned"}: {label}
+    </span>
+  );
+}

--- a/rentchain-frontend/src/components/adminAssignment/AssignmentHistoryList.tsx
+++ b/rentchain-frontend/src/components/adminAssignment/AssignmentHistoryList.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import type { AssignmentRecordV1 } from "../../api/supportConsoleApi";
+
+type AssignmentHistory = AssignmentRecordV1["history"];
+
+export default function AssignmentHistoryList(props: { history: AssignmentHistory }) {
+  if (!props.history.length) {
+    return <div style={{ color: "#64748b" }}>No assignment history yet.</div>;
+  }
+
+  return (
+    <div style={{ display: "grid", gap: 10 }}>
+      {props.history.map((entry) => (
+        <article
+          key={entry.id}
+          style={{
+            border: "1px solid rgba(15,23,42,0.08)",
+            borderRadius: 10,
+            padding: 10,
+            background: "rgba(248,250,252,0.8)",
+          }}
+        >
+          <div style={{ display: "grid", gap: 4 }}>
+            <strong style={{ textTransform: "capitalize" }}>{entry.action}</strong>
+            <div style={{ color: "#475569", fontSize: 13 }}>
+              {entry.fromOwnerLabel || entry.fromOwnerId || "Unassigned"} {"->"}{" "}
+              {entry.toOwnerLabel || entry.toOwnerId || "Unassigned"}
+            </div>
+            <div style={{ color: "#64748b", fontSize: 12 }}>
+              {new Date(entry.timestamp).toLocaleString()}
+            </div>
+            {entry.note ? <div style={{ color: "#334155", fontSize: 13 }}>{entry.note}</div> : null}
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}

--- a/rentchain-frontend/src/components/adminAssignment/AssignmentOwnerForm.tsx
+++ b/rentchain-frontend/src/components/adminAssignment/AssignmentOwnerForm.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+
+export default function AssignmentOwnerForm(props: {
+  ownerId: string;
+  ownerLabel: string;
+  note: string;
+  saving: boolean;
+  submitLabel: string;
+  onOwnerIdChange: (value: string) => void;
+  onOwnerLabelChange: (value: string) => void;
+  onNoteChange: (value: string) => void;
+  onSubmit: () => void;
+}) {
+  return (
+    <div style={{ display: "grid", gap: 8 }}>
+      <label style={{ display: "grid", gap: 4 }}>
+        <span style={{ color: "#64748b", fontSize: 12 }}>Owner ID</span>
+        <input
+          aria-label="Assignment owner ID"
+          value={props.ownerId}
+          onChange={(event) => props.onOwnerIdChange(event.target.value)}
+          placeholder="admin-1"
+        />
+      </label>
+      <label style={{ display: "grid", gap: 4 }}>
+        <span style={{ color: "#64748b", fontSize: 12 }}>Owner label</span>
+        <input
+          aria-label="Assignment owner label"
+          value={props.ownerLabel}
+          onChange={(event) => props.onOwnerLabelChange(event.target.value)}
+          placeholder="Operations lead"
+        />
+      </label>
+      <label style={{ display: "grid", gap: 4 }}>
+        <span style={{ color: "#64748b", fontSize: 12 }}>Assignment note</span>
+        <textarea
+          aria-label="Assignment note"
+          value={props.note}
+          onChange={(event) => props.onNoteChange(event.target.value)}
+          rows={3}
+          placeholder="Add context for this ownership change"
+        />
+      </label>
+      <div>
+        <button type="button" onClick={props.onSubmit} disabled={props.saving || !props.ownerId.trim()}>
+          {props.saving ? "Saving..." : props.submitLabel}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/rentchain-frontend/src/components/adminAssignment/AssignmentPanel.test.tsx
+++ b/rentchain-frontend/src/components/adminAssignment/AssignmentPanel.test.tsx
@@ -1,0 +1,164 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import AssignmentPanel from "./AssignmentPanel";
+
+vi.mock("../../api/adminAssignmentApi", () => ({
+  createAssignment: vi.fn(),
+  updateAssignment: vi.fn(),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("AssignmentPanel", () => {
+  it("renders empty state and creates an assignment", async () => {
+    const { createAssignment } = await import("../../api/adminAssignmentApi");
+    vi.mocked(createAssignment).mockResolvedValue({
+      assignment: {
+        version: "v1",
+        id: "assignment-1",
+        resource: { type: "application", id: "app-1" },
+        currentOwner: { ownerId: "admin-1", ownerLabel: "Morgan Ops" },
+        createdAt: "2026-04-16T12:00:00.000Z",
+        updatedAt: "2026-04-16T12:00:00.000Z",
+        history: [],
+      },
+    } as any);
+    const onChange = vi.fn();
+
+    render(
+      <AssignmentPanel
+        resourceType="application"
+        resourceId="app-1"
+        assignment={null}
+        onChange={onChange}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText(/Assignment owner ID/i), {
+      target: { value: "admin-1" },
+    });
+    fireEvent.change(screen.getByLabelText(/Assignment owner label/i), {
+      target: { value: "Morgan Ops" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Assign owner/i }));
+
+    await waitFor(() => {
+      expect(createAssignment).toHaveBeenCalledWith({
+        resourceType: "application",
+        resourceId: "app-1",
+        ownerId: "admin-1",
+        ownerLabel: "Morgan Ops",
+        note: null,
+      });
+      expect(onChange).toHaveBeenCalled();
+    });
+  });
+
+  it("changes owner and clears owner while showing history", async () => {
+    const { updateAssignment } = await import("../../api/adminAssignmentApi");
+    vi.mocked(updateAssignment)
+      .mockResolvedValueOnce({
+        assignment: {
+          version: "v1",
+          id: "assignment-1",
+          resource: { type: "application", id: "app-1" },
+          currentOwner: { ownerId: "admin-2", ownerLabel: "Taylor Ops" },
+          createdAt: "2026-04-16T12:00:00.000Z",
+          updatedAt: "2026-04-16T12:10:00.000Z",
+          history: [
+            {
+              id: "hist-1",
+              timestamp: "2026-04-16T12:00:00.000Z",
+              action: "set",
+              toOwnerId: "admin-1",
+              toOwnerLabel: "Morgan Ops",
+            },
+          ],
+        },
+      } as any)
+      .mockResolvedValueOnce({
+        assignment: {
+          version: "v1",
+          id: "assignment-1",
+          resource: { type: "application", id: "app-1" },
+          currentOwner: {},
+          createdAt: "2026-04-16T12:00:00.000Z",
+          updatedAt: "2026-04-16T12:15:00.000Z",
+          history: [
+            {
+              id: "hist-1",
+              timestamp: "2026-04-16T12:00:00.000Z",
+              action: "set",
+              toOwnerId: "admin-1",
+              toOwnerLabel: "Morgan Ops",
+            },
+            {
+              id: "hist-2",
+              timestamp: "2026-04-16T12:15:00.000Z",
+              action: "cleared",
+              fromOwnerId: "admin-2",
+              fromOwnerLabel: "Taylor Ops",
+            },
+          ],
+        },
+      } as any);
+
+    const onChange = vi.fn();
+    render(
+      <AssignmentPanel
+        resourceType="application"
+        resourceId="app-1"
+        assignment={{
+          version: "v1",
+          id: "assignment-1",
+          resource: { type: "application", id: "app-1" },
+          currentOwner: { ownerId: "admin-1", ownerLabel: "Morgan Ops" },
+          createdAt: "2026-04-16T12:00:00.000Z",
+          updatedAt: "2026-04-16T12:00:00.000Z",
+          history: [
+            {
+              id: "hist-1",
+              timestamp: "2026-04-16T12:00:00.000Z",
+              action: "set",
+              toOwnerId: "admin-1",
+              toOwnerLabel: "Morgan Ops",
+            },
+          ],
+        }}
+        onChange={onChange}
+      />
+    );
+
+    expect(screen.getByText(/Assigned:\s*Morgan Ops/i)).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText(/Assignment owner ID/i), {
+      target: { value: "admin-2" },
+    });
+    fireEvent.change(screen.getByLabelText(/Assignment owner label/i), {
+      target: { value: "Taylor Ops" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Change owner/i }));
+
+    await waitFor(() => {
+      expect(updateAssignment).toHaveBeenCalledWith("assignment-1", {
+        ownerId: "admin-2",
+        ownerLabel: "Taylor Ops",
+        note: null,
+      });
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Clear owner/i }));
+
+    await waitFor(() => {
+      expect(updateAssignment).toHaveBeenLastCalledWith("assignment-1", {
+        ownerId: null,
+        ownerLabel: null,
+        note: null,
+      });
+      expect(onChange).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/rentchain-frontend/src/components/adminAssignment/AssignmentPanel.tsx
+++ b/rentchain-frontend/src/components/adminAssignment/AssignmentPanel.tsx
@@ -1,0 +1,121 @@
+import React from "react";
+import { createAssignment, updateAssignment } from "../../api/adminAssignmentApi";
+import type { AssignmentRecordV1 } from "../../api/supportConsoleApi";
+import AssignmentBadge from "./AssignmentBadge";
+import AssignmentHistoryList from "./AssignmentHistoryList";
+import AssignmentOwnerForm from "./AssignmentOwnerForm";
+
+export default function AssignmentPanel(props: {
+  resourceType: string;
+  resourceId: string;
+  assignment: AssignmentRecordV1 | null;
+  onChange: (assignment: AssignmentRecordV1) => void;
+}) {
+  const [ownerId, setOwnerId] = React.useState("");
+  const [ownerLabel, setOwnerLabel] = React.useState("");
+  const [note, setNote] = React.useState("");
+  const [saving, setSaving] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    setOwnerId(props.assignment?.currentOwner.ownerId || "");
+    setOwnerLabel(props.assignment?.currentOwner.ownerLabel || "");
+  }, [props.assignment]);
+
+  const handleCreate = async () => {
+    try {
+      setSaving(true);
+      setError(null);
+      const response = await createAssignment({
+        resourceType: props.resourceType,
+        resourceId: props.resourceId,
+        ownerId: ownerId || null,
+        ownerLabel: ownerLabel || null,
+        note: note || null,
+      });
+      props.onChange(response.assignment);
+      setNote("");
+    } catch (err: any) {
+      setError(err?.message || "Failed to create assignment");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleUpdate = async (nextOwnerId?: string | null, nextOwnerLabel?: string | null) => {
+    if (!props.assignment) return;
+    try {
+      setSaving(true);
+      setError(null);
+      const response = await updateAssignment(props.assignment.id, {
+        ownerId: nextOwnerId ?? null,
+        ownerLabel: nextOwnerLabel ?? null,
+        note: note || null,
+      });
+      props.onChange(response.assignment);
+      setOwnerId(response.assignment.currentOwner.ownerId || "");
+      setOwnerLabel(response.assignment.currentOwner.ownerLabel || "");
+      setNote("");
+    } catch (err: any) {
+      setError(err?.message || "Failed to update assignment");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div style={{ display: "grid", gap: 16 }}>
+      {props.assignment ? (
+        <>
+          <div style={{ display: "flex", gap: 10, alignItems: "center", flexWrap: "wrap" }}>
+            <AssignmentBadge
+              ownerId={props.assignment.currentOwner.ownerId}
+              ownerLabel={props.assignment.currentOwner.ownerLabel}
+            />
+            <span style={{ color: "#64748b", fontSize: 13 }}>
+              Updated {new Date(props.assignment.updatedAt).toLocaleString()}
+            </span>
+          </div>
+          <AssignmentOwnerForm
+            ownerId={ownerId}
+            ownerLabel={ownerLabel}
+            note={note}
+            saving={saving}
+            submitLabel="Change owner"
+            onOwnerIdChange={setOwnerId}
+            onOwnerLabelChange={setOwnerLabel}
+            onNoteChange={setNote}
+            onSubmit={() => void handleUpdate(ownerId || null, ownerLabel || null)}
+          />
+          <div>
+            <button type="button" onClick={() => void handleUpdate(null, null)} disabled={saving}>
+              Clear owner
+            </button>
+          </div>
+        </>
+      ) : (
+        <div style={{ display: "grid", gap: 10 }}>
+          <div style={{ color: "#64748b" }}>No assignment exists yet for this resource.</div>
+          <AssignmentOwnerForm
+            ownerId={ownerId}
+            ownerLabel={ownerLabel}
+            note={note}
+            saving={saving}
+            submitLabel="Assign owner"
+            onOwnerIdChange={setOwnerId}
+            onOwnerLabelChange={setOwnerLabel}
+            onNoteChange={setNote}
+            onSubmit={() => void handleCreate()}
+          />
+        </div>
+      )}
+
+      {error ? <div style={{ color: "#b91c1c" }}>{error}</div> : null}
+
+      <div style={{ display: "grid", gap: 8 }}>
+        <strong>Assignment history</strong>
+        <AssignmentHistoryList history={props.assignment?.history || []} />
+      </div>
+    </div>
+  );
+}

--- a/rentchain-frontend/src/components/adminTriage/TriageQueueTable.tsx
+++ b/rentchain-frontend/src/components/adminTriage/TriageQueueTable.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Link } from "react-router-dom";
 import type { AdminTriageItemV1 } from "../../api/adminTriageApi";
 import ResolutionStatusBadge from "../adminResolution/ResolutionStatusBadge";
+import AssignmentBadge from "../adminAssignment/AssignmentBadge";
 import TriageSeverityBadge from "./TriageSeverityBadge";
 
 function formatTimestamp(value: string) {
@@ -62,6 +63,13 @@ export function TriageQueueTable({ items }: { items: AdminTriageItemV1[] }) {
                   <ResolutionStatusBadge status={item.resolution.status} />
                 </div>
               ) : null}
+              <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+                <span style={{ color: "#64748b", fontSize: 13 }}>Owner</span>
+                <AssignmentBadge
+                  ownerId={item.assignment?.ownerId || null}
+                  ownerLabel={item.assignment?.ownerLabel || null}
+                />
+              </div>
               {item.watch?.isActive ? (
                 <div style={{ color: "#1d4ed8", fontSize: 13, fontWeight: 600 }}>Watched</div>
               ) : null}

--- a/rentchain-frontend/src/pages/admin/AdminAlertingPage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminAlertingPage.test.tsx
@@ -55,6 +55,7 @@ describe("AdminAlertingPage", () => {
           resource: { type: "application", id: "app-1", title: "Application app-1" },
           reason: { code: "ALERT_SCREENING_MISMATCH", summary: "Screening reconciliation signals are inconsistent." },
           signals: {},
+          assignment: { ownerId: "admin-1", ownerLabel: "Morgan Ops" },
           state: { isActive: true, isAcknowledged: false },
           timestamps: { createdAt: "2026-04-16T12:00:00.000Z", updatedAt: "2026-04-16T12:00:00.000Z" },
           navigation: { supportConsolePath: "/admin/support-console?resourceType=application&resourceId=app-1" },
@@ -84,6 +85,7 @@ describe("AdminAlertingPage", () => {
 
     expect(await screen.findByText(/Screening reconciliation signals are inconsistent/i)).toBeInTheDocument();
     expect(screen.getByText(/Keep an eye on this workflow/i)).toBeInTheDocument();
+    expect(screen.getByText(/Owner: Morgan Ops/i)).toBeInTheDocument();
   });
 
   it("updates filter requests and acknowledges alerts", async () => {

--- a/rentchain-frontend/src/pages/admin/AdminTriageQueuePage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminTriageQueuePage.test.tsx
@@ -69,6 +69,11 @@ describe("AdminTriageQueuePage", () => {
             status: "acknowledged",
             updatedAt: "2026-04-15T12:10:00.000Z",
           },
+          assignment: {
+            ownerId: "admin-1",
+            ownerLabel: "Morgan Ops",
+            updatedAt: "2026-04-15T12:05:00.000Z",
+          },
           tags: ["screening", "revenue"],
         },
       ],
@@ -84,6 +89,7 @@ describe("AdminTriageQueuePage", () => {
     expect(screen.getByText(/Payment was recorded but screening completion is missing/i)).toBeInTheDocument();
     expect(screen.getAllByText(/critical/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/acknowledged/i)).toBeInTheDocument();
+    expect(screen.getByText(/Assigned: Morgan Ops/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Open support console/i })).toHaveAttribute(
       "href",
       "/admin/support-console?resourceType=application&resourceId=app-1&triageCategory=screening_reconciliation&triageSeverity=critical&reasonCode=TRIAGE_PAID_NOT_FULFILLED"

--- a/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.test.tsx
@@ -100,6 +100,15 @@ describe("SupportDebugConsolePage", () => {
         status: "fulfilled",
         reasons: [{ code: "RECON_FULFILLED" }],
       },
+      assignment: {
+        version: "v1",
+        id: "assignment-1",
+        resource: { type: "application", id: "app-1" },
+        currentOwner: { ownerId: "admin-1", ownerLabel: "Morgan Ops" },
+        createdAt: "2026-04-12T11:00:00.000Z",
+        updatedAt: "2026-04-12T11:20:00.000Z",
+        history: [{ id: "assign-1", timestamp: "2026-04-12T11:00:00.000Z", action: "set", toOwnerId: "admin-1", toOwnerLabel: "Morgan Ops" }],
+      },
       resolution: {
         version: "v1",
         id: "resolution-1",
@@ -123,11 +132,13 @@ describe("SupportDebugConsolePage", () => {
     expect(await screen.findByText(/Alex Tenant/i)).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /Derived insight/i })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /^Reconciliation$/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /^Assignment$/i })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /^Resolution$/i })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /Policy decisions/i })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /Automation history/i })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /^Timeline$/i })).toBeInTheDocument();
     expect(screen.getByText(/Screening completed for this application/i)).toBeInTheDocument();
+    expect(screen.getByText(/Assigned:\s*Morgan Ops/i)).toBeInTheDocument();
   });
 
   it("renders an empty state before a lookup", async () => {
@@ -178,6 +189,7 @@ describe("SupportDebugConsolePage", () => {
         },
       ],
       reconciliation: null,
+      assignment: null,
       resolution: null,
       debug: {
         canonicalEventCount: 2,

--- a/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.tsx
+++ b/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.tsx
@@ -10,6 +10,7 @@ import SupportConsoleSection from "../../components/supportConsole/SupportConsol
 import PolicyDecisionList from "../../components/supportConsole/PolicyDecisionList";
 import AutomationHistoryList from "../../components/supportConsole/AutomationHistoryList";
 import ResolutionPanel from "../../components/adminResolution/ResolutionPanel";
+import AssignmentPanel from "../../components/adminAssignment/AssignmentPanel";
 
 const RESOURCE_OPTIONS = [
   { label: "Application", value: "application" },
@@ -159,6 +160,15 @@ export default function SupportDebugConsolePage() {
               ) : (
                 <div style={{ color: "#64748b" }}>This resource is not currently on the watchlist.</div>
               )}
+            </SupportConsoleSection>
+
+            <SupportConsoleSection title="Assignment">
+              <AssignmentPanel
+                resourceType={payload.resource.type}
+                resourceId={payload.resource.id}
+                assignment={payload.assignment || null}
+                onChange={(assignment) => setPayload((current) => (current ? { ...current, assignment } : current))}
+              />
             </SupportConsoleSection>
 
             <SupportConsoleSection title="Resolution">


### PR DESCRIPTION
## Summary
Adds Admin Assignment & Ownership Layer v1 as an admin-only operational ownership overlay.

This introduces exact-resource assignment records, append-only ownership history, support-console assignment management, and additive ownership visibility in triage and alerting so operators can see and update who is responsible for a surfaced issue without changing the underlying workflow state.

## Scope
- Adds `assignmentTypes`, assignment storage/update helpers, and `setAssignmentOwner` under `src/lib/assignment`
- Adds admin endpoints for:
  - `GET /api/admin/assignments?resourceType=&resourceId=`
  - `POST /api/admin/assignments`
  - `PATCH /api/admin/assignments/:assignmentId`
- Stores additive assignment records in a new `adminAssignments` collection
- Emits additive canonical audit events for:
  - `assignment.set`
  - `assignment.changed`
  - `assignment.cleared`
- Extends the admin support/debug console with assignment management as the primary interaction surface
- Extends admin triage items with current owner visibility
- Extends admin alerts with lightweight owner visibility when assignment data exists
- Adds a new frontend admin assignment API client and lightweight assignment UI components
- Adds targeted backend and frontend tests for:
  - create/upsert behavior
  - owner changes and clear-owner flows
  - append-only history preservation
  - support-console / triage / alert integration
  - admin-only access

## Notes
This is intentionally admin-only, additive, and operational. Assignment state is a human ownership overlay and does not overwrite or auto-change the underlying application, maintenance, lease, policy, automation, or monetization workflow state.

For v1:
- one assignment record exists per exact `resourceType + resourceId`
- assigned vs unassigned is derived from `currentOwner.ownerId`
- history is append-only and records `set`, `changed`, and `cleared` actions
- support console is the primary assignment management surface
- triage and alerts remain display-only for ownership

## Validation
- Passed targeted backend assignment, support-console, triage, and alerting tests
- Passed backend build
- Passed targeted frontend assignment, support-console, triage, and alerting tests
- Passed full frontend test suite
- Passed frontend build