### PR TITLE
feat: add sla aging and escalation layer v1

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -103,6 +103,7 @@ import screeningReconciliationRoutes from "./routes/screeningReconciliationRoute
 import supportConsoleRoutes from "./routes/supportConsoleRoutes";
 import adminTriageRoutes from "./routes/adminTriageRoutes";
 import adminResolutionRoutes from "./routes/adminResolutionRoutes";
+import adminSlaRoutes from "./routes/adminSlaRoutes";
 import adminAlertingRoutes from "./routes/adminAlertingRoutes";
 import adminAssignmentRoutes from "./routes/adminAssignmentRoutes";
 import portfolioScoreRoutes from "./routes/portfolioScoreRoutes";
@@ -232,6 +233,8 @@ app.use("/api/admin", routeSource("adminTriageRoutes.ts"), adminTriageRoutes);
 console.log("[route-mount] adminTriageRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("adminResolutionRoutes.ts"), adminResolutionRoutes);
 console.log("[route-mount] adminResolutionRoutes mounted at /api/admin");
+app.use("/api/admin", routeSource("adminSlaRoutes.ts"), adminSlaRoutes);
+console.log("[route-mount] adminSlaRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("adminAlertingRoutes.ts"), adminAlertingRoutes);
 console.log("[route-mount] adminAlertingRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("adminAssignmentRoutes.ts"), adminAssignmentRoutes);

--- a/rentchain-api/src/lib/alerting/alertingTypes.ts
+++ b/rentchain-api/src/lib/alerting/alertingTypes.ts
@@ -43,6 +43,11 @@ export type AdminAlertV1 = {
     resolutionStatus?: string | null;
     inactivityMs?: number | null;
   };
+  sla?: {
+    stage?: string | null;
+    escalationLevel?: string | null;
+    ageHours?: number | null;
+  } | null;
   state: {
     isActive: boolean;
     isAcknowledged: boolean;

--- a/rentchain-api/src/lib/alerting/deriveAdminAlerts.ts
+++ b/rentchain-api/src/lib/alerting/deriveAdminAlerts.ts
@@ -63,6 +63,7 @@ function buildAlert(input: {
   resource: AdminAlertV1["resource"];
   reason: AdminAlertV1["reason"];
   signals?: AdminAlertV1["signals"];
+  sla?: AdminAlertV1["sla"];
   createdAt: string;
   lastSeenAt?: string | null;
   watchlist?: WatchlistEntryV1[];
@@ -86,6 +87,7 @@ function buildAlert(input: {
     resource: input.resource,
     reason: input.reason,
     signals: input.signals || {},
+    sla: input.sla || null,
     state: {
       isActive: true,
       isAcknowledged: Boolean(state?.acknowledged),
@@ -183,6 +185,13 @@ export function deriveAdminAlerts(input: DeriveAdminAlertsInput): AdminAlertV1[]
             resolutionStatus: item.resolution?.status || null,
             inactivityMs: item.signals.inactivityMs ?? null,
           },
+          sla: item.sla
+            ? {
+                stage: item.sla.stage,
+                escalationLevel: item.sla.escalationLevel,
+                ageHours: item.sla.ageHours,
+              }
+            : null,
           createdAt: item.timestamps.surfacedAt,
           lastSeenAt: item.timestamps.lastSeenAt || item.timestamps.surfacedAt,
           watchlist,
@@ -287,6 +296,7 @@ export function deriveAdminAlerts(input: DeriveAdminAlertsInput): AdminAlertV1[]
             resolutionStatus: resolution.status,
             inactivityMs: ageMs,
           },
+          sla: null,
           createdAt: resolution.createdAt,
           lastSeenAt: resolution.updatedAt,
           watchlist,

--- a/rentchain-api/src/lib/sla/__tests__/deriveSlaState.test.ts
+++ b/rentchain-api/src/lib/sla/__tests__/deriveSlaState.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import { deriveSlaState } from "../deriveSlaState";
+
+const NOW = Date.parse("2026-04-16T14:00:00.000Z");
+
+describe("deriveSlaState", () => {
+  it("maps severity to threshold profiles deterministically", () => {
+    const critical = deriveSlaState({
+      resourceType: "application",
+      resourceId: "app-1",
+      triageCategory: "screening_reconciliation",
+      triageSeverity: "critical",
+      firstSeenAt: "2026-04-16T10:00:00.000Z",
+      now: NOW,
+    });
+    const medium = deriveSlaState({
+      resourceType: "maintenance",
+      resourceId: "maint-1",
+      triageCategory: "maintenance_friction",
+      triageSeverity: "medium",
+      firstSeenAt: "2026-04-16T10:00:00.000Z",
+      now: NOW,
+    });
+    const low = deriveSlaState({
+      resourceType: "lease",
+      resourceId: "lease-1",
+      triageCategory: "policy_review",
+      triageSeverity: "low",
+      firstSeenAt: "2026-04-16T10:00:00.000Z",
+      now: NOW,
+    });
+
+    expect(critical.sla.thresholdHours).toEqual({ aging: 6, dueSoon: 12, overdue: 24, escalated: 36 });
+    expect(medium.sla.thresholdHours).toEqual({ aging: 12, dueSoon: 24, overdue: 48, escalated: 72 });
+    expect(low.sla.thresholdHours).toEqual({ aging: 24, dueSoon: 48, overdue: 72, escalated: 96 });
+  });
+
+  it("derives stages across fresh through escalated", () => {
+    expect(
+      deriveSlaState({
+        resourceType: "application",
+        resourceId: "app-1",
+        triageSeverity: "critical",
+        firstSeenAt: "2026-04-16T10:00:00.000Z",
+        now: NOW,
+      }).sla.stage
+    ).toBe("fresh");
+    expect(
+      deriveSlaState({
+        resourceType: "application",
+        resourceId: "app-1",
+        triageSeverity: "critical",
+        firstSeenAt: "2026-04-16T07:00:00.000Z",
+        now: NOW,
+      }).sla.stage
+    ).toBe("aging");
+    expect(
+      deriveSlaState({
+        resourceType: "application",
+        resourceId: "app-1",
+        triageSeverity: "critical",
+        firstSeenAt: "2026-04-15T23:00:00.000Z",
+        now: NOW,
+      }).sla.stage
+    ).toBe("due_soon");
+    expect(
+      deriveSlaState({
+        resourceType: "application",
+        resourceId: "app-1",
+        triageSeverity: "critical",
+        firstSeenAt: "2026-04-15T10:00:00.000Z",
+        now: NOW,
+      }).sla.stage
+    ).toBe("overdue");
+    expect(
+      deriveSlaState({
+        resourceType: "application",
+        resourceId: "app-1",
+        triageSeverity: "critical",
+        firstSeenAt: "2026-04-14T22:00:00.000Z",
+        now: NOW,
+      }).sla.stage
+    ).toBe("escalated");
+  });
+
+  it("maps escalation levels from stage", () => {
+    expect(
+      deriveSlaState({
+        resourceType: "maintenance",
+        resourceId: "maint-1",
+        triageSeverity: "medium",
+        firstSeenAt: "2026-04-15T13:00:00.000Z",
+        now: NOW,
+      }).sla.escalationLevel
+    ).toBe("low");
+    expect(
+      deriveSlaState({
+        resourceType: "maintenance",
+        resourceId: "maint-1",
+        triageSeverity: "medium",
+        firstSeenAt: "2026-04-14T13:00:00.000Z",
+        now: NOW,
+      }).sla.escalationLevel
+    ).toBe("high");
+    expect(
+      deriveSlaState({
+        resourceType: "maintenance",
+        resourceId: "maint-1",
+        triageSeverity: "medium",
+        firstSeenAt: "2026-04-13T10:00:00.000Z",
+        now: NOW,
+      }).sla.escalationLevel
+    ).toBe("critical");
+  });
+
+  it("handles missing timestamp context safely", () => {
+    const result = deriveSlaState({
+      resourceType: "lease",
+      resourceId: "lease-1",
+      triageSeverity: "low",
+      now: NOW,
+    });
+
+    expect(result.age.ageMs).toBe(0);
+    expect(result.sla.stage).toBe("fresh");
+    expect(result.reason.code).toBe("SLA_FRESH");
+  });
+});

--- a/rentchain-api/src/lib/sla/deriveSlaState.ts
+++ b/rentchain-api/src/lib/sla/deriveSlaState.ts
@@ -1,0 +1,125 @@
+import { SLA_REASON_CODES, SLA_THRESHOLD_PROFILES, escalationLevelForStage, profileForUrgency } from "./slaConstants";
+import type { SlaEvaluationV1, SlaStage } from "./slaTypes";
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function parseTimestamp(value: unknown) {
+  const raw = asString(value, 200);
+  if (!raw) return null;
+  const parsed = Date.parse(raw);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function stageForAge(
+  ageHours: number,
+  thresholds: { aging: number; dueSoon: number; overdue: number; escalated: number }
+): SlaStage {
+  if (ageHours >= thresholds.escalated) return "escalated";
+  if (ageHours >= thresholds.overdue) return "overdue";
+  if (ageHours >= thresholds.dueSoon) return "due_soon";
+  if (ageHours >= thresholds.aging) return "aging";
+  return "fresh";
+}
+
+function roundHours(value: number) {
+  return Math.round(value * 10) / 10;
+}
+
+export function deriveSlaState(input: {
+  resourceType: string;
+  resourceId: string;
+  triageCategory?: string | null;
+  triageSeverity?: string | null;
+  resolutionStatus?: string | null;
+  assignmentOwnerId?: string | null;
+  assignmentOwnerLabel?: string | null;
+  firstSeenAt?: string | null;
+  lastSeenAt?: string | null;
+  now?: number;
+}): SlaEvaluationV1 {
+  const nowMs = typeof input.now === "number" && Number.isFinite(input.now) ? input.now : Date.now();
+  const firstSeenMs = parseTimestamp(input.firstSeenAt);
+  const lastSeenMs = parseTimestamp(input.lastSeenAt);
+  const anchorMs = firstSeenMs ?? lastSeenMs ?? nowMs;
+  const ageMs = Math.max(0, nowMs - anchorMs);
+  const ageHours = roundHours(ageMs / (60 * 60 * 1000));
+
+  const profile = profileForUrgency({
+    triageSeverity: input.triageSeverity,
+    triageCategory: input.triageCategory,
+  });
+  const thresholds = SLA_THRESHOLD_PROFILES[profile];
+  const stage = stageForAge(ageHours, thresholds);
+  const escalationLevel = escalationLevelForStage(stage);
+
+  const hasOwner = Boolean(asString(input.assignmentOwnerId, 240));
+  const severity = asString(input.triageSeverity, 40).toLowerCase();
+  let code: string = SLA_REASON_CODES.fresh;
+  let summary = "This issue is within the initial response window.";
+  let details: string | null = null;
+
+  if (stage === "aging") {
+    code = SLA_REASON_CODES.aging;
+    summary = "This issue is aging and should be reviewed soon.";
+  } else if (stage === "due_soon") {
+    code = SLA_REASON_CODES.dueSoon;
+    summary = "This issue is approaching the overdue threshold.";
+  } else if ((stage === "overdue" || stage === "escalated") && !hasOwner) {
+    code = SLA_REASON_CODES.unassignedOverdue;
+    summary = "This issue is overdue and still has no current owner.";
+    details = "Assign an owner or confirm why the issue remains unassigned.";
+  } else if (
+    (stage === "overdue" || stage === "escalated") &&
+    (severity === "critical" || severity === "high") &&
+    ["open", "acknowledged", "in_progress", ""].includes(asString(input.resolutionStatus, 40).toLowerCase())
+  ) {
+    code = SLA_REASON_CODES.unresolvedCritical;
+    summary = "A high-urgency issue remains unresolved beyond its SLA window.";
+    details = "Review ownership, current handling state, and whether escalation is needed now.";
+  } else if ((stage === "overdue" || stage === "escalated") && hasOwner) {
+    code = SLA_REASON_CODES.assignmentPresentButStale;
+    summary = "This issue has an owner but is still aging past the expected response window.";
+    details = "Review whether the assigned owner still has the right context and capacity.";
+  } else if (stage === "overdue") {
+    code = SLA_REASON_CODES.overdue;
+    summary = "This issue is now overdue for operational follow-through.";
+  } else if (stage === "escalated") {
+    code = SLA_REASON_CODES.escalated;
+    summary = "This issue has crossed the escalation threshold and needs immediate attention.";
+    details = "Treat this as an escalation candidate in the admin operations flow.";
+  }
+
+  return {
+    version: "v1",
+    resource: {
+      type: asString(input.resourceType, 120),
+      id: asString(input.resourceId, 240),
+    },
+    context: {
+      triageCategory: asString(input.triageCategory, 120) || null,
+      triageSeverity: asString(input.triageSeverity, 40) || null,
+      resolutionStatus: asString(input.resolutionStatus, 40) || null,
+      assignmentOwnerId: asString(input.assignmentOwnerId, 240) || null,
+      assignmentOwnerLabel: asString(input.assignmentOwnerLabel, 240) || null,
+    },
+    age: {
+      firstSeenAt: input.firstSeenAt || null,
+      lastSeenAt: input.lastSeenAt || null,
+      ageMs,
+      ageHours,
+    },
+    sla: {
+      stage,
+      escalationLevel,
+      thresholdHours: thresholds,
+    },
+    reason: {
+      code,
+      summary,
+      details,
+    },
+    evaluatedAt: new Date(nowMs).toISOString(),
+  };
+}

--- a/rentchain-api/src/lib/sla/loadSlaContext.ts
+++ b/rentchain-api/src/lib/sla/loadSlaContext.ts
@@ -1,0 +1,50 @@
+import type { AssignmentRecordV1 } from "../assignment/assignmentTypes";
+import type { ResolutionRecordV1 } from "../resolution/resolutionTypes";
+import type { AdminTriageItemV1 } from "../triage/triageTypes";
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+export type SlaContextRecord = {
+  triageItem: AdminTriageItemV1;
+  resolution: ResolutionRecordV1 | null;
+  assignment: AssignmentRecordV1 | null;
+};
+
+export function loadSlaContext(input: {
+  triageItems?: AdminTriageItemV1[];
+  resolutions?: ResolutionRecordV1[];
+  assignments?: AssignmentRecordV1[];
+  resourceType?: string | null;
+  resourceId?: string | null;
+}): SlaContextRecord[] {
+  const triageItems = input.triageItems || [];
+  const resolutions = input.resolutions || [];
+  const assignments = input.assignments || [];
+  const resourceType = asString(input.resourceType, 120);
+  const resourceId = asString(input.resourceId, 240);
+
+  return triageItems
+    .filter((item) => (resourceType ? item.resource.type === resourceType : true))
+    .filter((item) => (resourceId ? item.resource.id === resourceId : true))
+    .map((triageItem) => {
+      const resolution =
+        resolutions.find(
+          (record) =>
+            asString(record.resource?.type, 120) === triageItem.resource.type &&
+            asString(record.resource?.id, 240) === triageItem.resource.id
+        ) || null;
+      const assignment =
+        assignments.find(
+          (record) =>
+            asString(record.resource?.type, 120) === triageItem.resource.type &&
+            asString(record.resource?.id, 240) === triageItem.resource.id
+        ) || null;
+      return {
+        triageItem,
+        resolution,
+        assignment,
+      };
+    });
+}

--- a/rentchain-api/src/lib/sla/slaConstants.ts
+++ b/rentchain-api/src/lib/sla/slaConstants.ts
@@ -1,0 +1,56 @@
+import type { EscalationLevel, SlaStage } from "./slaTypes";
+
+export type SlaThresholdProfileKey = "low" | "medium" | "high";
+
+export const SLA_THRESHOLD_PROFILES: Record<
+  SlaThresholdProfileKey,
+  { aging: number; dueSoon: number; overdue: number; escalated: number }
+> = {
+  low: {
+    aging: 24,
+    dueSoon: 48,
+    overdue: 72,
+    escalated: 96,
+  },
+  medium: {
+    aging: 12,
+    dueSoon: 24,
+    overdue: 48,
+    escalated: 72,
+  },
+  high: {
+    aging: 6,
+    dueSoon: 12,
+    overdue: 24,
+    escalated: 36,
+  },
+};
+
+export const SLA_REASON_CODES = {
+  fresh: "SLA_FRESH",
+  aging: "SLA_AGING",
+  dueSoon: "SLA_DUE_SOON",
+  overdue: "SLA_OVERDUE",
+  escalated: "SLA_ESCALATED",
+  unassignedOverdue: "SLA_UNASSIGNED_OVERDUE",
+  unresolvedCritical: "SLA_UNRESOLVED_CRITICAL",
+  assignmentPresentButStale: "SLA_ASSIGNMENT_PRESENT_BUT_STALE",
+} as const;
+
+export function profileForUrgency(input: {
+  triageSeverity?: string | null;
+  triageCategory?: string | null;
+}): SlaThresholdProfileKey {
+  const severity = String(input.triageSeverity || "").toLowerCase();
+  if (severity === "critical" || severity === "high") return "high";
+  if (severity === "medium") return "medium";
+  if (input.triageCategory === "screening_reconciliation") return "high";
+  return "low";
+}
+
+export function escalationLevelForStage(stage: SlaStage): EscalationLevel {
+  if (stage === "fresh" || stage === "aging") return "none";
+  if (stage === "due_soon") return "low";
+  if (stage === "overdue") return "high";
+  return "critical";
+}

--- a/rentchain-api/src/lib/sla/slaTypes.ts
+++ b/rentchain-api/src/lib/sla/slaTypes.ts
@@ -1,0 +1,50 @@
+export type SlaStage =
+  | "fresh"
+  | "aging"
+  | "due_soon"
+  | "overdue"
+  | "escalated";
+
+export type EscalationLevel =
+  | "none"
+  | "low"
+  | "medium"
+  | "high"
+  | "critical";
+
+export type SlaEvaluationV1 = {
+  version: "v1";
+  resource: {
+    type: string;
+    id: string;
+  };
+  context: {
+    triageCategory?: string | null;
+    triageSeverity?: string | null;
+    resolutionStatus?: string | null;
+    assignmentOwnerId?: string | null;
+    assignmentOwnerLabel?: string | null;
+  };
+  age: {
+    firstSeenAt?: string | null;
+    lastSeenAt?: string | null;
+    ageMs: number;
+    ageHours: number;
+  };
+  sla: {
+    stage: SlaStage;
+    escalationLevel: EscalationLevel;
+    thresholdHours: {
+      aging: number;
+      dueSoon: number;
+      overdue: number;
+      escalated: number;
+    };
+  };
+  reason: {
+    code: string;
+    summary: string;
+    details?: string | null;
+  };
+  evaluatedAt: string;
+};

--- a/rentchain-api/src/lib/supportConsole/buildSupportConsoleResource.ts
+++ b/rentchain-api/src/lib/supportConsole/buildSupportConsoleResource.ts
@@ -5,6 +5,8 @@ import type { CanonicalEventV1 } from "../events/eventTypes";
 import { deriveInsightForResource } from "../insights/deriveInsights";
 import { deriveScreeningReconciliation } from "../reconciliation/deriveScreeningReconciliation";
 import { loadResolutionRecord } from "../resolution/loadResolutionRecord";
+import { deriveSlaState } from "../sla/deriveSlaState";
+import { deriveAdminTriageQueue } from "../triage/deriveAdminTriageQueue";
 import { loadWatchlistEntries } from "../watchlist/loadWatchlistEntries";
 import { canonicalEventToTimelineItem } from "../timeline/timelineAdapter";
 import type {
@@ -283,6 +285,7 @@ function emptyResponse(spec: NormalizedResourceSpec, resourceId: string): Suppor
     policyDecisions: [],
     automation: [],
     reconciliation: null,
+    sla: null,
     assignment: null,
     resolution: null,
     watch: null,
@@ -318,6 +321,8 @@ export async function buildSupportConsoleResource(input: {
   });
 
   let reconciliation: Record<string, unknown> | null = null;
+  let latestOrder: any = null;
+  let financialTransactions: any[] = [];
   const [assignment, resolution, watchlist] = await Promise.all([
     loadAssignmentRecord({
       resourceType: spec.requestedType,
@@ -334,7 +339,7 @@ export async function buildSupportConsoleResource(input: {
       (entry) => entry.isActive && entry.target.type === spec.requestedType && entry.target.id === resourceId
     ) || null;
   if (spec.requestedType === "application") {
-    const [latestOrder, financialTransactions] = await Promise.all([
+    [latestOrder, financialTransactions] = await Promise.all([
       loadLatestScreeningOrder(resourceId),
       loadFinancialTransactions(resourceId),
     ]);
@@ -346,6 +351,33 @@ export async function buildSupportConsoleResource(input: {
       financialTransactions,
     }) as Record<string, unknown>;
   }
+
+  const triageItem =
+    deriveAdminTriageQueue({
+      applications: spec.requestedType === "application" ? [{ id: resourceId, ...doc }] : [],
+      maintenanceRequests: spec.requestedType === "maintenance" ? [{ id: resourceId, ...doc }] : [],
+      leases: spec.requestedType === "lease" ? [{ id: resourceId, ...doc }] : [],
+      canonicalEvents: relatedEvents,
+      screeningOrders: latestOrder ? [latestOrder] : [],
+      financialTransactions,
+      resolutions: resolution ? [resolution] : [],
+      assignments: assignment ? [assignment] : [],
+      watchlist: watch ? [watch] : [],
+    }).find((item) => item.resource.type === spec.requestedType && item.resource.id === resourceId) || null;
+
+  const sla = triageItem
+    ? deriveSlaState({
+        resourceType: triageItem.resource.type,
+        resourceId: triageItem.resource.id,
+        triageCategory: triageItem.category,
+        triageSeverity: triageItem.severity,
+        resolutionStatus: resolution?.status || null,
+        assignmentOwnerId: assignment?.currentOwner?.ownerId || null,
+        assignmentOwnerLabel: assignment?.currentOwner?.ownerLabel || null,
+        firstSeenAt: triageItem.timestamps.firstSeenAt || triageItem.timestamps.surfacedAt,
+        lastSeenAt: triageItem.timestamps.lastSeenAt || triageItem.timestamps.surfacedAt,
+      })
+    : null;
 
   return {
     resource:
@@ -359,6 +391,7 @@ export async function buildSupportConsoleResource(input: {
     policyDecisions: buildPolicyDecisions(relatedEvents),
     automation: buildAutomationHistory(relatedEvents),
     reconciliation,
+    sla,
     assignment,
     resolution,
     watch,

--- a/rentchain-api/src/lib/supportConsole/supportConsoleTypes.ts
+++ b/rentchain-api/src/lib/supportConsole/supportConsoleTypes.ts
@@ -1,6 +1,7 @@
 import type { TimelineItem } from "../timeline/timelineAdapter";
 import type { AssignmentRecordV1 } from "../assignment/assignmentTypes";
 import type { ResolutionRecordV1 } from "../resolution/resolutionTypes";
+import type { SlaEvaluationV1 } from "../sla/slaTypes";
 import type { WatchlistEntryV1 } from "../watchlist/watchlistTypes";
 
 export type SupportConsoleResourceSummary = {
@@ -39,6 +40,7 @@ export type SupportConsoleResourceResponse = {
   policyDecisions: SupportConsolePolicyDecision[];
   automation: SupportConsoleAutomationItem[];
   reconciliation?: Record<string, unknown> | null;
+  sla?: SlaEvaluationV1 | null;
   assignment?: AssignmentRecordV1 | null;
   resolution?: ResolutionRecordV1 | null;
   watch?: WatchlistEntryV1 | null;

--- a/rentchain-api/src/lib/triage/deriveAdminTriageQueue.ts
+++ b/rentchain-api/src/lib/triage/deriveAdminTriageQueue.ts
@@ -4,6 +4,7 @@ import { deriveInsightForResource } from "../insights/deriveInsights";
 import { deriveScreeningReconciliation } from "../reconciliation/deriveScreeningReconciliation";
 import type { ScreeningReconciliationV1 } from "../reconciliation/reconciliationTypes";
 import type { ResolutionRecordV1 } from "../resolution/resolutionTypes";
+import { deriveSlaState } from "../sla/deriveSlaState";
 import type { WatchlistEntryV1 } from "../watchlist/watchlistTypes";
 import type { AdminTriageItemV1, TriageCategory, TriageSeverity } from "./triageTypes";
 
@@ -688,6 +689,25 @@ export function deriveAdminTriageQueue(input: DeriveAdminTriageQueueInput): Admi
             watchId: watch.id,
           }
         : null,
+      sla: (() => {
+        const evaluation = deriveSlaState({
+          resourceType: item.resource.type,
+          resourceId: item.resource.id,
+          triageCategory: item.category,
+          triageSeverity: item.severity,
+          resolutionStatus: match?.status || null,
+          assignmentOwnerId: assignment?.currentOwner?.ownerId || null,
+          assignmentOwnerLabel: assignment?.currentOwner?.ownerLabel || null,
+          firstSeenAt: item.timestamps.firstSeenAt || item.timestamps.surfacedAt,
+          lastSeenAt: item.timestamps.lastSeenAt || item.timestamps.surfacedAt,
+          now,
+        });
+        return {
+          stage: evaluation.sla.stage,
+          escalationLevel: evaluation.sla.escalationLevel,
+          ageHours: evaluation.age.ageHours,
+        };
+      })(),
     };
   });
 

--- a/rentchain-api/src/lib/triage/triageTypes.ts
+++ b/rentchain-api/src/lib/triage/triageTypes.ts
@@ -8,6 +8,12 @@ export type TriageCategory =
 
 export type TriageSeverity = "low" | "medium" | "high" | "critical";
 
+export type AdminTriageItemSla = {
+  stage: "fresh" | "aging" | "due_soon" | "overdue" | "escalated";
+  escalationLevel: "none" | "low" | "medium" | "high" | "critical";
+  ageHours: number;
+};
+
 export type AdminTriageItemV1 = {
   id: string;
   version: "v1";
@@ -43,6 +49,12 @@ export type AdminTriageItemV1 = {
   navigation: {
     supportConsolePath?: string | null;
   };
+  assignment?: {
+    ownerId?: string | null;
+    ownerLabel?: string | null;
+    updatedAt: string;
+  } | null;
+  sla?: AdminTriageItemSla | null;
   resolution?: {
     status: "open" | "acknowledged" | "in_progress" | "resolved" | "dismissed";
     updatedAt: string;

--- a/rentchain-api/src/routes/__tests__/adminSlaRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/adminSlaRoutes.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { collections, dbMock } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, any>>();
+
+  function ensureCollection(name: string) {
+    if (!collections.has(name)) collections.set(name, new Map<string, any>());
+    return collections.get(name)!;
+  }
+
+  return {
+    collections,
+    dbMock: {
+      collection: (name: string) => ({
+        async get() {
+          const docs = Array.from(ensureCollection(name).entries()).map(([id, data]) => ({
+            id,
+            data: () => data,
+          }));
+          return { docs, empty: docs.length === 0, size: docs.length };
+        },
+      }),
+    },
+  };
+});
+
+vi.mock("../../config/firebase", () => ({
+  db: dbMock,
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!req.user) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    return next();
+  },
+}));
+
+async function invokeRouter(
+  router: any,
+  options: { method: string; url: string; user?: Record<string, unknown> | null }
+) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    const query = new URLSearchParams(queryString || "");
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: options.user ?? null,
+      query: Object.fromEntries(query.entries()),
+      params: {},
+      headers: {},
+      get(name: string) {
+        return this.headers[String(name).toLowerCase()];
+      },
+      header(name: string) {
+        return this.get(name);
+      },
+    };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      setHeader() {},
+    };
+    router.handle(req, res, (error: any) => (error ? reject(error) : undefined));
+  });
+}
+
+function seedDoc(collectionName: string, id: string, data: any) {
+  if (!collections.has(collectionName)) {
+    collections.set(collectionName, new Map<string, any>());
+  }
+  collections.get(collectionName)!.set(id, { id, ...data });
+}
+
+describe("adminSlaRoutes", () => {
+  beforeEach(() => {
+    collections.clear();
+  });
+
+  it("returns a stable empty shape", async () => {
+    const router = (await import("../adminSlaRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/sla",
+      user: { id: "admin-1", role: "admin" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ items: [], nextCursor: undefined });
+  });
+
+  it("supports exact-resource fetch and list filters", async () => {
+    seedDoc("rentalApplications", "app-1", {
+      applicantName: "Alex Applicant",
+      screeningMonetization: {
+        paymentStatus: "paid",
+        paidAt: "2026-04-15T08:00:00.000Z",
+        fulfillmentStatus: "ordered",
+      },
+    });
+    seedDoc("canonicalEvents", "event-1", {
+      version: "v1",
+      type: "screening.paid",
+      domain: "screening",
+      action: "paid",
+      actor: { type: "system", role: "system", id: "system" },
+      resource: { type: "rental_application", id: "app-1" },
+      occurredAt: "2026-04-15T08:00:00.000Z",
+      recordedAt: "2026-04-15T08:00:00.000Z",
+      visibility: "internal",
+      summary: "Screening paid",
+    });
+    seedDoc("financialTransactions", "tx-1", {
+      applicationId: "app-1",
+      type: "payment_succeeded",
+      createdAt: Date.parse("2026-04-15T08:00:00.000Z"),
+    });
+    seedDoc("adminAssignments", "assign-1", {
+      version: "v1",
+      id: "assign-1",
+      resource: { type: "application", id: "app-1" },
+      currentOwner: { ownerId: "admin-1", ownerLabel: "Ops Lead" },
+      createdAt: "2026-04-15T09:00:00.000Z",
+      updatedAt: "2026-04-15T10:00:00.000Z",
+      history: [],
+    });
+
+    const router = (await import("../adminSlaRoutes")).default;
+    const exact = await invokeRouter(router, {
+      method: "GET",
+      url: "/sla?resourceType=application&resourceId=app-1",
+      user: { id: "admin-1", role: "admin" },
+    });
+
+    expect(exact.status).toBe(200);
+    expect(exact.body.items).toHaveLength(1);
+    expect(exact.body.items[0]).toEqual(
+      expect.objectContaining({
+        resource: { type: "application", id: "app-1" },
+        context: expect.objectContaining({
+          triageSeverity: "critical",
+          assignmentOwnerId: "admin-1",
+          assignmentOwnerLabel: "Ops Lead",
+        }),
+      })
+    );
+
+    const filtered = await invokeRouter(router, {
+      method: "GET",
+      url: "/sla?stage=fresh",
+      user: { id: "admin-1", role: "admin" },
+    });
+    expect(filtered.status).toBe(200);
+    expect(filtered.body.items.length).toBeGreaterThanOrEqual(0);
+  });
+
+  it("enforces admin-only access and validation errors", async () => {
+    const router = (await import("../adminSlaRoutes")).default;
+    const forbidden = await invokeRouter(router, {
+      method: "GET",
+      url: "/sla",
+      user: { id: "landlord-1", role: "landlord" },
+    });
+    expect(forbidden.status).toBe(403);
+    expect(forbidden.body.error).toBe("FORBIDDEN");
+
+    const invalidStage = await invokeRouter(router, {
+      method: "GET",
+      url: "/sla?stage=nope",
+      user: { id: "admin-1", role: "admin" },
+    });
+    expect(invalidStage.status).toBe(400);
+    expect(invalidStage.body.error).toBe("STAGE_INVALID");
+  });
+});

--- a/rentchain-api/src/routes/__tests__/adminTriageRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/adminTriageRoutes.test.ts
@@ -150,6 +150,11 @@ describe("adminTriageRoutes", () => {
             ownerId: "admin-1",
             ownerLabel: "Morgan Ops",
           }),
+          sla: expect.objectContaining({
+            stage: expect.any(String),
+            escalationLevel: expect.any(String),
+            ageHours: expect.any(Number),
+          }),
           navigation: expect.objectContaining({
             supportConsolePath:
               "/admin/support-console?resourceType=application&resourceId=app-1&triageCategory=screening_reconciliation&triageSeverity=critical&reasonCode=TRIAGE_PAID_NOT_FULFILLED",

--- a/rentchain-api/src/routes/__tests__/supportConsoleRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/supportConsoleRoutes.test.ts
@@ -154,6 +154,7 @@ describe("supportConsoleRoutes", () => {
         timeline: expect.any(Array),
         insight: expect.anything(),
         reconciliation: expect.anything(),
+        sla: null,
         assignment: expect.objectContaining({
           currentOwner: expect.objectContaining({
             ownerId: "admin-1",
@@ -279,6 +280,7 @@ describe("supportConsoleRoutes", () => {
         timeline: [],
         policyDecisions: [],
         automation: [],
+        sla: null,
         assignment: null,
       })
     );

--- a/rentchain-api/src/routes/adminSlaRoutes.ts
+++ b/rentchain-api/src/routes/adminSlaRoutes.ts
@@ -1,0 +1,161 @@
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { ADMIN_ASSIGNMENTS_COLLECTION } from "../lib/assignment/loadAssignmentRecord";
+import { CANONICAL_EVENTS_COLLECTION } from "../lib/events/buildEvent";
+import type { CanonicalEventV1 } from "../lib/events/eventTypes";
+import { ADMIN_RESOLUTIONS_COLLECTION } from "../lib/resolution/loadResolutionRecord";
+import { deriveSlaState } from "../lib/sla/deriveSlaState";
+import { loadSlaContext } from "../lib/sla/loadSlaContext";
+import type { EscalationLevel, SlaEvaluationV1, SlaStage } from "../lib/sla/slaTypes";
+import { deriveAdminTriageQueue } from "../lib/triage/deriveAdminTriageQueue";
+import { requireAuth } from "../middleware/requireAuth";
+
+const router = Router();
+
+const ALLOWED_STAGES = new Set<SlaStage>(["fresh", "aging", "due_soon", "overdue", "escalated"]);
+const ALLOWED_ESCALATION_LEVELS = new Set<EscalationLevel>(["none", "low", "medium", "high", "critical"]);
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function normalizeRole(req: any): "admin" | "landlord" | "other" {
+  const role = asString(req.user?.actorRole || req.user?.role, 40).toLowerCase();
+  if (role === "admin") return "admin";
+  if (role === "landlord") return "landlord";
+  return "other";
+}
+
+function parseLimit(value: unknown, fallback = 20) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(1, Math.min(100, Math.floor(parsed)));
+}
+
+function parseCursor(value: unknown): { evaluatedAt: string; itemId: string } | null {
+  const raw = asString(value, 4000);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(Buffer.from(raw, "base64url").toString("utf8"));
+    const evaluatedAt = asString(parsed?.evaluatedAt);
+    const itemId = asString(parsed?.itemId);
+    if (!evaluatedAt || !itemId) return null;
+    return { evaluatedAt, itemId };
+  } catch {
+    return null;
+  }
+}
+
+function encodeCursor(item: SlaEvaluationV1) {
+  return Buffer.from(
+    JSON.stringify({
+      evaluatedAt: item.evaluatedAt,
+      itemId: `${item.resource.type}:${item.resource.id}`,
+    }),
+    "utf8"
+  ).toString("base64url");
+}
+
+async function loadCollection(name: string) {
+  const snap = await db.collection(name).get();
+  return (snap.docs || []).map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }));
+}
+
+async function loadCanonicalEvents() {
+  const snap = await db.collection(CANONICAL_EVENTS_COLLECTION).get();
+  return (snap.docs || []).map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }) as CanonicalEventV1);
+}
+
+router.get("/sla", requireAuth, async (req: any, res) => {
+  try {
+    if (normalizeRole(req) !== "admin") {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+
+    const resourceType = asString(req.query?.resourceType, 80).toLowerCase();
+    const resourceId = asString(req.query?.resourceId, 240);
+    if (resourceType && !["application", "maintenance", "lease"].includes(resourceType)) {
+      return res.status(400).json({ ok: false, error: "RESOURCE_TYPE_INVALID" });
+    }
+
+    const stage = asString(req.query?.stage, 80).toLowerCase();
+    if (stage && !ALLOWED_STAGES.has(stage as SlaStage)) {
+      return res.status(400).json({ ok: false, error: "STAGE_INVALID" });
+    }
+
+    const escalationLevel = asString(req.query?.escalationLevel, 80).toLowerCase();
+    if (escalationLevel && !ALLOWED_ESCALATION_LEVELS.has(escalationLevel as EscalationLevel)) {
+      return res.status(400).json({ ok: false, error: "ESCALATION_LEVEL_INVALID" });
+    }
+
+    const limit = parseLimit(req.query?.limit, 20);
+    const cursor = parseCursor(req.query?.cursor);
+
+    const [applications, maintenanceRequests, leases, canonicalEvents, screeningOrders, financialTransactions, resolutions, assignments] =
+      await Promise.all([
+        loadCollection("rentalApplications"),
+        loadCollection("maintenanceRequests"),
+        loadCollection("leases"),
+        loadCanonicalEvents(),
+        loadCollection("screeningOrders"),
+        loadCollection("financialTransactions"),
+        loadCollection(ADMIN_RESOLUTIONS_COLLECTION),
+        loadCollection(ADMIN_ASSIGNMENTS_COLLECTION),
+      ]);
+
+    const triageItems = deriveAdminTriageQueue({
+      applications,
+      maintenanceRequests,
+      leases,
+      canonicalEvents,
+      screeningOrders,
+      financialTransactions,
+      resolutions,
+      assignments,
+    });
+
+    const items = loadSlaContext({
+      triageItems,
+      resolutions,
+      assignments,
+      resourceType: resourceType || null,
+      resourceId: resourceId || null,
+    })
+      .map(({ triageItem, resolution, assignment }) =>
+        deriveSlaState({
+          resourceType: triageItem.resource.type,
+          resourceId: triageItem.resource.id,
+          triageCategory: triageItem.category,
+          triageSeverity: triageItem.severity,
+          resolutionStatus: resolution?.status || null,
+          assignmentOwnerId: assignment?.currentOwner?.ownerId || null,
+          assignmentOwnerLabel: assignment?.currentOwner?.ownerLabel || null,
+          firstSeenAt: triageItem.timestamps.firstSeenAt || triageItem.timestamps.surfacedAt,
+          lastSeenAt: triageItem.timestamps.lastSeenAt || triageItem.timestamps.surfacedAt,
+        })
+      )
+      .filter((item) => (stage ? item.sla.stage === stage : true))
+      .filter((item) => (escalationLevel ? item.sla.escalationLevel === escalationLevel : true))
+      .sort((a, b) => Date.parse(b.evaluatedAt) - Date.parse(a.evaluatedAt));
+
+    const cursorFiltered = cursor
+      ? items.filter(
+          (item) =>
+            `${item.evaluatedAt}::${item.resource.type}:${item.resource.id}` <
+            `${cursor.evaluatedAt}::${cursor.itemId}`
+        )
+      : items;
+    const page = cursorFiltered.slice(0, limit);
+    const hasMore = cursorFiltered.length > limit;
+
+    return res.json({
+      items: page,
+      nextCursor: hasMore && page.length ? encodeCursor(page[page.length - 1]) : undefined,
+    });
+  } catch (err: any) {
+    console.error("[admin-sla] fetch failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "ADMIN_SLA_FETCH_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-frontend/src/api/adminAlertingApi.ts
+++ b/rentchain-frontend/src/api/adminAlertingApi.ts
@@ -37,6 +37,11 @@ export type AdminAlertV1 = {
     resolutionStatus?: string | null;
     inactivityMs?: number | null;
   };
+  sla?: {
+    stage?: string | null;
+    escalationLevel?: string | null;
+    ageHours?: number | null;
+  } | null;
   state: {
     isActive: boolean;
     isAcknowledged: boolean;

--- a/rentchain-frontend/src/api/adminSlaApi.ts
+++ b/rentchain-frontend/src/api/adminSlaApi.ts
@@ -1,0 +1,57 @@
+import { apiFetch } from "./apiFetch";
+
+export type SlaEvaluationV1 = {
+  version: "v1";
+  resource: {
+    type: string;
+    id: string;
+  };
+  context: {
+    triageCategory?: string | null;
+    triageSeverity?: string | null;
+    resolutionStatus?: string | null;
+    assignmentOwnerId?: string | null;
+    assignmentOwnerLabel?: string | null;
+  };
+  age: {
+    firstSeenAt?: string | null;
+    lastSeenAt?: string | null;
+    ageMs: number;
+    ageHours: number;
+  };
+  sla: {
+    stage: "fresh" | "aging" | "due_soon" | "overdue" | "escalated";
+    escalationLevel: "none" | "low" | "medium" | "high" | "critical";
+    thresholdHours: {
+      aging: number;
+      dueSoon: number;
+      overdue: number;
+      escalated: number;
+    };
+  };
+  reason: {
+    code: string;
+    summary: string;
+    details?: string | null;
+  };
+  evaluatedAt: string;
+};
+
+export async function fetchSlaItems(params?: {
+  resourceType?: string | null;
+  resourceId?: string | null;
+  stage?: string | null;
+  escalationLevel?: string | null;
+  limit?: number | null;
+  cursor?: string | null;
+}): Promise<{ items: SlaEvaluationV1[]; nextCursor?: string }> {
+  const search = new URLSearchParams();
+  if (params?.resourceType) search.set("resourceType", params.resourceType);
+  if (params?.resourceId) search.set("resourceId", params.resourceId);
+  if (params?.stage) search.set("stage", params.stage);
+  if (params?.escalationLevel) search.set("escalationLevel", params.escalationLevel);
+  if (typeof params?.limit === "number") search.set("limit", String(params.limit));
+  if (params?.cursor) search.set("cursor", params.cursor);
+  const query = search.toString();
+  return await apiFetch(`/admin/sla${query ? `?${query}` : ""}`);
+}

--- a/rentchain-frontend/src/api/adminTriageApi.ts
+++ b/rentchain-frontend/src/api/adminTriageApi.ts
@@ -1,4 +1,5 @@
 import { apiFetch } from "./apiFetch";
+import type { SlaEvaluationV1 } from "./adminSlaApi";
 
 export type AdminTriageItemV1 = {
   id: string;
@@ -45,6 +46,9 @@ export type AdminTriageItemV1 = {
     ownerId?: string | null;
     ownerLabel?: string | null;
     updatedAt: string;
+  } | null;
+  sla?: Pick<SlaEvaluationV1["sla"], "stage" | "escalationLevel"> & {
+    ageHours: number;
   } | null;
   resolution?: {
     status: "open" | "acknowledged" | "in_progress" | "resolved" | "dismissed";

--- a/rentchain-frontend/src/api/supportConsoleApi.ts
+++ b/rentchain-frontend/src/api/supportConsoleApi.ts
@@ -1,4 +1,5 @@
 import { apiFetch } from "./apiFetch";
+import type { SlaEvaluationV1 } from "./adminSlaApi";
 import type { TimelineItem } from "./timelineApi";
 
 export type SupportConsoleResourceResponse = {
@@ -31,6 +32,7 @@ export type SupportConsoleResourceResponse = {
     summary?: string | null;
   }>;
   reconciliation?: Record<string, unknown> | null;
+  sla?: SlaEvaluationV1 | null;
   assignment?: AssignmentRecordV1 | null;
   resolution?: ResolutionRecordV1 | null;
   watch?: {

--- a/rentchain-frontend/src/components/adminAlerting/AlertTable.tsx
+++ b/rentchain-frontend/src/components/adminAlerting/AlertTable.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import type { AdminAlertV1 } from "../../api/adminAlertingApi";
+import EscalationBadge from "../adminSla/EscalationBadge";
+import SlaStageBadge from "../adminSla/SlaStageBadge";
 import AlertSeverityBadge from "./AlertSeverityBadge";
 
 export default function AlertTable(props: {
@@ -30,6 +32,12 @@ export default function AlertTable(props: {
               {alert.assignment?.ownerId ? (
                 <div style={{ color: "#334155", fontSize: 13 }}>
                   Owner: {alert.assignment.ownerLabel || alert.assignment.ownerId}
+                </div>
+              ) : null}
+              {alert.sla?.stage ? (
+                <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+                  <SlaStageBadge stage={alert.sla.stage} />
+                  <EscalationBadge level={alert.sla.escalationLevel || "none"} />
                 </div>
               ) : null}
             </div>

--- a/rentchain-frontend/src/components/adminSla/EscalationBadge.tsx
+++ b/rentchain-frontend/src/components/adminSla/EscalationBadge.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+const LEVEL_STYLES: Record<string, { background: string; color: string }> = {
+  none: { background: "rgba(100, 116, 139, 0.14)", color: "#475569" },
+  low: { background: "rgba(59, 130, 246, 0.14)", color: "#1d4ed8" },
+  medium: { background: "rgba(245, 158, 11, 0.16)", color: "#b45309" },
+  high: { background: "rgba(249, 115, 22, 0.16)", color: "#c2410c" },
+  critical: { background: "rgba(220, 38, 38, 0.16)", color: "#b91c1c" },
+};
+
+export default function EscalationBadge(props: { level: string }) {
+  const style = LEVEL_STYLES[props.level] || LEVEL_STYLES.none;
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        padding: "4px 10px",
+        borderRadius: 999,
+        fontSize: 12,
+        fontWeight: 700,
+        background: style.background,
+        color: style.color,
+      }}
+    >
+      Escalation {props.level}
+    </span>
+  );
+}

--- a/rentchain-frontend/src/components/adminSla/SlaStageBadge.tsx
+++ b/rentchain-frontend/src/components/adminSla/SlaStageBadge.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+const STAGE_STYLES: Record<string, { background: string; color: string }> = {
+  fresh: { background: "rgba(16, 185, 129, 0.14)", color: "#047857" },
+  aging: { background: "rgba(59, 130, 246, 0.14)", color: "#1d4ed8" },
+  due_soon: { background: "rgba(245, 158, 11, 0.16)", color: "#b45309" },
+  overdue: { background: "rgba(249, 115, 22, 0.16)", color: "#c2410c" },
+  escalated: { background: "rgba(220, 38, 38, 0.16)", color: "#b91c1c" },
+};
+
+export default function SlaStageBadge(props: { stage: string }) {
+  const style = STAGE_STYLES[props.stage] || STAGE_STYLES.fresh;
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        padding: "4px 10px",
+        borderRadius: 999,
+        fontSize: 12,
+        fontWeight: 700,
+        background: style.background,
+        color: style.color,
+      }}
+    >
+      SLA {props.stage.replace(/_/g, " ")}
+    </span>
+  );
+}

--- a/rentchain-frontend/src/components/adminSla/SlaSummaryPanel.test.tsx
+++ b/rentchain-frontend/src/components/adminSla/SlaSummaryPanel.test.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import SlaSummaryPanel from "./SlaSummaryPanel";
+
+describe("SlaSummaryPanel", () => {
+  it("renders an empty state without sla context", () => {
+    render(<SlaSummaryPanel sla={null} />);
+    expect(screen.getByText(/No SLA context is currently available/i)).toBeInTheDocument();
+  });
+
+  it("renders stage, escalation, and summary details", () => {
+    render(
+      <SlaSummaryPanel
+        sla={{
+          version: "v1",
+          resource: { type: "application", id: "app-1" },
+          context: {},
+          age: {
+            firstSeenAt: "2026-04-16T10:00:00.000Z",
+            lastSeenAt: "2026-04-16T14:00:00.000Z",
+            ageMs: 14_400_000,
+            ageHours: 4,
+          },
+          sla: {
+            stage: "fresh",
+            escalationLevel: "none",
+            thresholdHours: { aging: 6, dueSoon: 12, overdue: 24, escalated: 36 },
+          },
+          reason: {
+            code: "SLA_FRESH",
+            summary: "This issue is within the initial response window.",
+          },
+          evaluatedAt: "2026-04-16T14:00:00.000Z",
+        }}
+      />
+    );
+
+    expect(screen.getByText(/SLA fresh/i)).toBeInTheDocument();
+    expect(screen.getByText(/Escalation none/i)).toBeInTheDocument();
+    expect(screen.getByText(/Age/i)).toBeInTheDocument();
+    expect(screen.getByText(/within the initial response window/i)).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/adminSla/SlaSummaryPanel.tsx
+++ b/rentchain-frontend/src/components/adminSla/SlaSummaryPanel.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import type { SlaEvaluationV1 } from "../../api/adminSlaApi";
+import EscalationBadge from "./EscalationBadge";
+import SlaStageBadge from "./SlaStageBadge";
+
+function formatAge(ageHours: number) {
+  if (ageHours >= 48) return `${Math.round((ageHours / 24) * 10) / 10} days`;
+  if (ageHours >= 24) return `${Math.round((ageHours / 24) * 10) / 10} day`;
+  return `${ageHours} hours`;
+}
+
+export default function SlaSummaryPanel(props: { sla: SlaEvaluationV1 | null }) {
+  if (!props.sla) {
+    return <div style={{ color: "#64748b" }}>No SLA context is currently available for this resource.</div>;
+  }
+
+  return (
+    <div style={{ display: "grid", gap: 12 }}>
+      <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+        <SlaStageBadge stage={props.sla.sla.stage} />
+        <EscalationBadge level={props.sla.sla.escalationLevel} />
+      </div>
+      <div style={{ display: "grid", gap: 6 }}>
+        <div>
+          <strong>Age</strong>: {formatAge(props.sla.age.ageHours)}
+        </div>
+        <div>
+          <strong>Thresholds</strong>: aging {props.sla.sla.thresholdHours.aging}h • due soon {props.sla.sla.thresholdHours.dueSoon}h • overdue {props.sla.sla.thresholdHours.overdue}h • escalated {props.sla.sla.thresholdHours.escalated}h
+        </div>
+        <div>
+          <strong>Reason</strong>: {props.sla.reason.summary}
+        </div>
+        {props.sla.reason.details ? (
+          <div style={{ color: "#475569" }}>{props.sla.reason.details}</div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/rentchain-frontend/src/components/adminTriage/TriageQueueTable.tsx
+++ b/rentchain-frontend/src/components/adminTriage/TriageQueueTable.tsx
@@ -3,6 +3,8 @@ import { Link } from "react-router-dom";
 import type { AdminTriageItemV1 } from "../../api/adminTriageApi";
 import ResolutionStatusBadge from "../adminResolution/ResolutionStatusBadge";
 import AssignmentBadge from "../adminAssignment/AssignmentBadge";
+import EscalationBadge from "../adminSla/EscalationBadge";
+import SlaStageBadge from "../adminSla/SlaStageBadge";
 import TriageSeverityBadge from "./TriageSeverityBadge";
 
 function formatTimestamp(value: string) {
@@ -70,6 +72,13 @@ export function TriageQueueTable({ items }: { items: AdminTriageItemV1[] }) {
                   ownerLabel={item.assignment?.ownerLabel || null}
                 />
               </div>
+              {item.sla ? (
+                <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+                  <SlaStageBadge stage={item.sla.stage} />
+                  <EscalationBadge level={item.sla.escalationLevel} />
+                  <span style={{ color: "#64748b", fontSize: 13 }}>{item.sla.ageHours}h</span>
+                </div>
+              ) : null}
               {item.watch?.isActive ? (
                 <div style={{ color: "#1d4ed8", fontSize: 13, fontWeight: 600 }}>Watched</div>
               ) : null}

--- a/rentchain-frontend/src/pages/admin/AdminAlertingPage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminAlertingPage.test.tsx
@@ -55,6 +55,7 @@ describe("AdminAlertingPage", () => {
           resource: { type: "application", id: "app-1", title: "Application app-1" },
           reason: { code: "ALERT_SCREENING_MISMATCH", summary: "Screening reconciliation signals are inconsistent." },
           signals: {},
+          sla: { stage: "overdue", escalationLevel: "high", ageHours: 28 },
           assignment: { ownerId: "admin-1", ownerLabel: "Morgan Ops" },
           state: { isActive: true, isAcknowledged: false },
           timestamps: { createdAt: "2026-04-16T12:00:00.000Z", updatedAt: "2026-04-16T12:00:00.000Z" },
@@ -86,6 +87,7 @@ describe("AdminAlertingPage", () => {
     expect(await screen.findByText(/Screening reconciliation signals are inconsistent/i)).toBeInTheDocument();
     expect(screen.getByText(/Keep an eye on this workflow/i)).toBeInTheDocument();
     expect(screen.getByText(/Owner: Morgan Ops/i)).toBeInTheDocument();
+    expect(screen.getByText(/SLA overdue/i)).toBeInTheDocument();
   });
 
   it("updates filter requests and acknowledges alerts", async () => {

--- a/rentchain-frontend/src/pages/admin/AdminTriageQueuePage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminTriageQueuePage.test.tsx
@@ -74,6 +74,11 @@ describe("AdminTriageQueuePage", () => {
             ownerLabel: "Morgan Ops",
             updatedAt: "2026-04-15T12:05:00.000Z",
           },
+          sla: {
+            stage: "overdue",
+            escalationLevel: "high",
+            ageHours: 28,
+          },
           tags: ["screening", "revenue"],
         },
       ],
@@ -90,6 +95,8 @@ describe("AdminTriageQueuePage", () => {
     expect(screen.getAllByText(/critical/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/acknowledged/i)).toBeInTheDocument();
     expect(screen.getByText(/Assigned: Morgan Ops/i)).toBeInTheDocument();
+    expect(screen.getByText(/SLA overdue/i)).toBeInTheDocument();
+    expect(screen.getByText(/Escalation high/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Open support console/i })).toHaveAttribute(
       "href",
       "/admin/support-console?resourceType=application&resourceId=app-1&triageCategory=screening_reconciliation&triageSeverity=critical&reasonCode=TRIAGE_PAID_NOT_FULFILLED"

--- a/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.test.tsx
@@ -100,6 +100,32 @@ describe("SupportDebugConsolePage", () => {
         status: "fulfilled",
         reasons: [{ code: "RECON_FULFILLED" }],
       },
+      sla: {
+        version: "v1",
+        resource: { type: "application", id: "app-1" },
+        context: {
+          triageCategory: "screening_reconciliation",
+          triageSeverity: "critical",
+          assignmentOwnerId: "admin-1",
+          assignmentOwnerLabel: "Morgan Ops",
+        },
+        age: {
+          firstSeenAt: "2026-04-12T09:00:00.000Z",
+          lastSeenAt: "2026-04-12T11:30:00.000Z",
+          ageMs: 9_000_000,
+          ageHours: 2.5,
+        },
+        sla: {
+          stage: "fresh",
+          escalationLevel: "none",
+          thresholdHours: { aging: 6, dueSoon: 12, overdue: 24, escalated: 36 },
+        },
+        reason: {
+          code: "SLA_FRESH",
+          summary: "This issue is within the initial response window.",
+        },
+        evaluatedAt: "2026-04-12T11:30:00.000Z",
+      },
       assignment: {
         version: "v1",
         id: "assignment-1",
@@ -132,6 +158,7 @@ describe("SupportDebugConsolePage", () => {
     expect(await screen.findByText(/Alex Tenant/i)).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /Derived insight/i })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /^Reconciliation$/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /^SLA$/i })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /^Assignment$/i })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /^Resolution$/i })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /Policy decisions/i })).toBeInTheDocument();
@@ -139,6 +166,7 @@ describe("SupportDebugConsolePage", () => {
     expect(screen.getByRole("heading", { name: /^Timeline$/i })).toBeInTheDocument();
     expect(screen.getByText(/Screening completed for this application/i)).toBeInTheDocument();
     expect(screen.getByText(/Assigned:\s*Morgan Ops/i)).toBeInTheDocument();
+    expect(screen.getByText(/This issue is within the initial response window/i)).toBeInTheDocument();
   });
 
   it("renders an empty state before a lookup", async () => {
@@ -189,6 +217,7 @@ describe("SupportDebugConsolePage", () => {
         },
       ],
       reconciliation: null,
+      sla: null,
       assignment: null,
       resolution: null,
       debug: {

--- a/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.tsx
+++ b/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.tsx
@@ -11,6 +11,7 @@ import PolicyDecisionList from "../../components/supportConsole/PolicyDecisionLi
 import AutomationHistoryList from "../../components/supportConsole/AutomationHistoryList";
 import ResolutionPanel from "../../components/adminResolution/ResolutionPanel";
 import AssignmentPanel from "../../components/adminAssignment/AssignmentPanel";
+import SlaSummaryPanel from "../../components/adminSla/SlaSummaryPanel";
 
 const RESOURCE_OPTIONS = [
   { label: "Application", value: "application" },
@@ -149,6 +150,10 @@ export default function SupportDebugConsolePage() {
                 {renderKeyValueList(payload.reconciliation)}
               </SupportConsoleSection>
             ) : null}
+
+            <SupportConsoleSection title="SLA">
+              <SlaSummaryPanel sla={payload.sla || null} />
+            </SupportConsoleSection>
 
             <SupportConsoleSection title="Watchlist">
               {payload.watch ? (


### PR DESCRIPTION
Full commit hash: `66e0a7e367230f1012b7998f517edaf180c03802`

The branch is pushed to GitHub:
- `origin/feat/sla-aging-escalation-layer-v1`
- PR URL: https://github.com/rentchaincanada/rentchain/pull/new/feat/sla-aging-escalation-layer-v1

GitHub CI vs local:
- Local is green for the Mission 15 validation we ran:
  - targeted backend SLA/support-console/triage/alerting tests passed
  - backend build passed
  - targeted frontend SLA/support-console/triage/alerting tests passed
  - full frontend test suite passed
  - frontend build passed
- I have not fetched fresh GitHub CI results after push in this turn, so I can confirm local is green but not yet claim final GitHub parity.

Final Mission 15 readiness summary:
- Added a deterministic admin-only SLA / aging / escalation layer with explicit threshold profiles.
- Kept SLA evaluation exact-resource scoped and fully additive.
- Added primary SLA inspection in the support console.
- Added SLA stage and escalation display in triage and alerts.
- Kept null-safe behavior for resources without triage-worthy SLA context.
- No underlying workflow, assignment, resolution, policy, automation, or billing state is mutated by SLA evaluation.

Note:
- There was a small branch-upstream mismatch during push because this branch was tracking `origin/main`. I corrected that by pushing with an explicit refspec, and the remote branch now points at the Mission 15 commit above.

I’m paused here for review and won’t start Mission 16.