### PR TITLE
feat: add landlord-facing portfolio health summary v1

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -108,6 +108,7 @@ import adminAlertingRoutes from "./routes/adminAlertingRoutes";
 import adminAssignmentRoutes from "./routes/adminAssignmentRoutes";
 import portfolioScoreRoutes from "./routes/portfolioScoreRoutes";
 import portfolioScoreHistoryRoutes from "./routes/portfolioScoreHistoryRoutes";
+import landlordPortfolioHealthRoutes from "./routes/landlordPortfolioHealthRoutes";
 import transunionRoutes from "./services/integrations/transunion/transunionRoutes";
 import viewingRoutes from "./routes/viewingRoutes";
 import screeningOpsRoutes from "./routes/screeningOpsRoutes";
@@ -243,6 +244,8 @@ app.use("/api/admin", routeSource("portfolioScoreRoutes.ts"), portfolioScoreRout
 console.log("[route-mount] portfolioScoreRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("portfolioScoreHistoryRoutes.ts"), portfolioScoreHistoryRoutes);
 console.log("[route-mount] portfolioScoreHistoryRoutes mounted at /api/admin");
+app.use("/api", routeSource("landlordPortfolioHealthRoutes.ts"), landlordPortfolioHealthRoutes);
+console.log("[route-mount] landlordPortfolioHealthRoutes mounted at /api");
 
 // Current user info
 app.get("/api/me", async (req: any, res: any, next: any) => {

--- a/rentchain-api/src/lib/portfolioHealth/__tests__/deriveLandlordPortfolioHealthSummary.test.ts
+++ b/rentchain-api/src/lib/portfolioHealth/__tests__/deriveLandlordPortfolioHealthSummary.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import { deriveLandlordPortfolioHealthSummary } from "../deriveLandlordPortfolioHealthSummary";
+import type { PortfolioScoreV1 } from "../../portfolioScore/portfolioScoreTypes";
+import type { PortfolioScoreTrendV1 } from "../../portfolioScoreHistory/portfolioScoreHistoryTypes";
+
+function buildScore(overrides: Partial<PortfolioScoreV1> = {}): PortfolioScoreV1 {
+  return {
+    version: "v1",
+    portfolioId: "landlord-1",
+    generatedAt: "2026-04-16T12:00:00.000Z",
+    score: 84,
+    grade: "B",
+    summary: {
+      status: "healthy",
+      headline: "Healthy",
+      notes: [],
+    },
+    components: [
+      { key: "workflow_completion", label: "Workflow completion", rawValue: 0.9, normalizedScore: 88, weight: 0.25, contribution: 22 },
+      { key: "screening_reliability", label: "Screening reliability", rawValue: 0.8, normalizedScore: 82, weight: 0.2, contribution: 16.4 },
+      { key: "maintenance_stability", label: "Maintenance stability", rawValue: 0.86, normalizedScore: 86, weight: 0.15, contribution: 12.9 },
+      { key: "automation_health", label: "Automation health", rawValue: 0.8, normalizedScore: 81, weight: 0.1, contribution: 8.1 },
+      { key: "policy_friction", label: "Policy friction", rawValue: 0.1, normalizedScore: 83, weight: 0.1, contribution: 8.3 },
+      { key: "exception_burden", label: "Exception burden", rawValue: 0.12, normalizedScore: 84, weight: 0.2, contribution: 16.8 },
+    ],
+    metrics: {
+      totalResourcesReviewed: 8,
+      triageItemCount: 1,
+      criticalTriageCount: 0,
+      reconciliationIssueCount: 0,
+      automationSkipCount: 0,
+      policyReviewCount: 0,
+      blockedWorkflowCount: 0,
+      maintenanceReopenCount: 0,
+    },
+    ...overrides,
+  };
+}
+
+function buildTrend(overrides: Partial<PortfolioScoreTrendV1> = {}): PortfolioScoreTrendV1 {
+  return {
+    version: "v1",
+    portfolioId: "landlord-1",
+    generatedAt: "2026-04-16T12:00:00.000Z",
+    latest: null,
+    previous: null,
+    direction: "flat",
+    deltaScore: 0,
+    deltaGrade: null,
+    summary: {
+      headline: "Stable",
+      notes: [],
+    },
+    movers: [],
+    history: [],
+    ...overrides,
+  };
+}
+
+describe("deriveLandlordPortfolioHealthSummary", () => {
+  it("derives a landlord-safe healthy summary from healthy internal signals", () => {
+    const summary = deriveLandlordPortfolioHealthSummary({
+      portfolioScore: buildScore(),
+      portfolioTrend: buildTrend({ direction: "up" }),
+    });
+
+    expect(summary.overall.status).toBe("healthy");
+    expect(summary.trend.direction).toBe("improving");
+    expect(summary.overall.headline).toMatch(/health looks strong|generally healthy/i);
+    expect(summary.dimensions).toHaveLength(4);
+    expect(summary.nextFocus[0]?.summary).not.toMatch(/triage|reconciliation|automation skipped|assignment/i);
+  });
+
+  it("maps at-risk score state to attention_needed safely", () => {
+    const summary = deriveLandlordPortfolioHealthSummary({
+      portfolioScore: buildScore({
+        summary: { status: "at_risk", headline: "At risk", notes: [] },
+        components: buildScore().components.map((component) =>
+          component.key === "screening_reliability"
+            ? { ...component, normalizedScore: 45 }
+            : component
+        ),
+      }),
+      portfolioTrend: buildTrend({ direction: "down" }),
+    });
+
+    expect(summary.overall.status).toBe("attention_needed");
+    expect(summary.trend.direction).toBe("declining");
+    expect(summary.dimensions.find((dimension) => dimension.key === "screening_health")?.status).toBe(
+      "attention_needed"
+    );
+  });
+
+  it("maps trend directions safely", () => {
+    expect(
+      deriveLandlordPortfolioHealthSummary({
+        portfolioScore: buildScore(),
+        portfolioTrend: buildTrend({ direction: "up" }),
+      }).trend.direction
+    ).toBe("improving");
+    expect(
+      deriveLandlordPortfolioHealthSummary({
+        portfolioScore: buildScore(),
+        portfolioTrend: buildTrend({ direction: "down" }),
+      }).trend.direction
+    ).toBe("declining");
+    expect(
+      deriveLandlordPortfolioHealthSummary({
+        portfolioScore: buildScore(),
+        portfolioTrend: buildTrend({ direction: "flat" }),
+      }).trend.direction
+    ).toBe("stable");
+    expect(
+      deriveLandlordPortfolioHealthSummary({
+        portfolioScore: buildScore(),
+        portfolioTrend: buildTrend({ direction: "insufficient_data", deltaScore: null }),
+      }).trend.direction
+    ).toBe("insufficient_data");
+  });
+
+  it("returns sparse-data fallback messaging conservatively", () => {
+    const summary = deriveLandlordPortfolioHealthSummary({
+      portfolioScore: buildScore({
+        metrics: { ...buildScore().metrics, totalResourcesReviewed: 1 },
+      }),
+      portfolioTrend: buildTrend({ direction: "insufficient_data", deltaScore: null }),
+    });
+
+    expect(summary.overall.summary).toMatch(/still developing/i);
+    expect(summary.trend.summary).toMatch(/Trend visibility will improve/i);
+  });
+});

--- a/rentchain-api/src/lib/portfolioHealth/deriveLandlordPortfolioHealthSummary.ts
+++ b/rentchain-api/src/lib/portfolioHealth/deriveLandlordPortfolioHealthSummary.ts
@@ -1,0 +1,207 @@
+import type { PortfolioScoreComponent, PortfolioScoreV1 } from "../portfolioScore/portfolioScoreTypes";
+import type { PortfolioScoreTrendV1 } from "../portfolioScoreHistory/portfolioScoreHistoryTypes";
+import {
+  mapOverallStatus,
+  mapTrendDirection,
+  overallHeadline,
+  overallSummary,
+  PORTFOLIO_HEALTH_SPARSE_DATA_THRESHOLD,
+  sparseDataOverallSummary,
+  sparseDataTrendSummary,
+  statusFromComponentScore,
+  trendSummary,
+} from "./portfolioHealthMappings";
+import type {
+  LandlordPortfolioHealthSummaryV1,
+  PortfolioHealthDimensionV1,
+  PortfolioHealthStatus,
+  PortfolioHealthTrend,
+} from "./portfolioHealthTypes";
+
+function componentScore(
+  components: PortfolioScoreComponent[],
+  key: PortfolioScoreComponent["key"],
+  fallback = 70
+) {
+  return components.find((component) => component.key === key)?.normalizedScore ?? fallback;
+}
+
+function screeningDimension(score: PortfolioScoreV1): PortfolioHealthDimensionV1 {
+  const screeningScore = componentScore(score.components, "screening_reliability");
+  const status = statusFromComponentScore(screeningScore);
+  return {
+    key: "screening_health",
+    label: "Screening health",
+    status,
+    summary:
+      status === "healthy"
+        ? "Application and screening follow-through appears generally steady."
+        : status === "watch"
+        ? "Application and screening follow-through may need closer attention."
+        : "Application and screening follow-through may need more consistent review.",
+  };
+}
+
+function maintenanceDimension(score: PortfolioScoreV1): PortfolioHealthDimensionV1 {
+  const maintenanceScore = componentScore(score.components, "maintenance_stability");
+  const status = statusFromComponentScore(maintenanceScore);
+  return {
+    key: "maintenance_health",
+    label: "Maintenance health",
+    status,
+    summary:
+      status === "healthy"
+        ? "Maintenance activity appears generally stable."
+        : status === "watch"
+        ? "Maintenance workload is elevated in places and may need closer follow-through."
+        : "Maintenance activity may need more focused follow-through to stay on track.",
+  };
+}
+
+function workflowDimension(score: PortfolioScoreV1): PortfolioHealthDimensionV1 {
+  const completionScore = componentScore(score.components, "workflow_completion");
+  const exceptionScore = componentScore(score.components, "exception_burden");
+  const workflowScore = Math.round((completionScore + exceptionScore) / 2);
+  const status = statusFromComponentScore(workflowScore);
+  return {
+    key: "workflow_health",
+    label: "Workflow health",
+    status,
+    summary:
+      status === "healthy"
+        ? "Portfolio activity is moving through core workflows at a healthy pace."
+        : status === "watch"
+        ? "Some portfolio activity may need closer follow-through to keep progress steady."
+        : "A broader share of portfolio activity may need follow-through to keep progress moving.",
+  };
+}
+
+function responseDimension(score: PortfolioScoreV1, trend: PortfolioHealthTrend): PortfolioHealthDimensionV1 {
+  const workflowScore = componentScore(score.components, "workflow_completion");
+  const automationScore = componentScore(score.components, "automation_health");
+  const blended = Math.round((workflowScore + automationScore) / 2);
+  const status =
+    trend === "declining"
+      ? (statusFromComponentScore(Math.max(0, blended - 15)) as PortfolioHealthStatus)
+      : statusFromComponentScore(blended);
+
+  return {
+    key: "response_health",
+    label: "Response health",
+    status,
+    summary:
+      status === "healthy"
+        ? "Portfolio response and follow-through look generally timely."
+        : status === "watch"
+        ? "Keeping response times steady may need a bit more attention."
+        : "Portfolio response timing may need closer follow-through right now.",
+  };
+}
+
+function buildNextFocus(
+  dimensions: PortfolioHealthDimensionV1[],
+  trend: PortfolioHealthTrend,
+  sparseData: boolean
+) {
+  const focus: LandlordPortfolioHealthSummaryV1["nextFocus"] = [];
+
+  const screening = dimensions.find((dimension) => dimension.key === "screening_health");
+  const maintenance = dimensions.find((dimension) => dimension.key === "maintenance_health");
+  const workflow = dimensions.find((dimension) => dimension.key === "workflow_health");
+  const response = dimensions.find((dimension) => dimension.key === "response_health");
+
+  if (screening && screening.status !== "healthy") {
+    focus.push({
+      key: "screening_follow_through",
+      label: "Screening follow-through",
+      summary: "Review application and screening follow-through to keep momentum steady.",
+    });
+  }
+  if (maintenance && maintenance.status !== "healthy") {
+    focus.push({
+      key: "maintenance_follow_up",
+      label: "Maintenance follow-up",
+      summary: "Follow up on outstanding maintenance activity to help keep service work moving.",
+    });
+  }
+  if (workflow && workflow.status !== "healthy") {
+    focus.push({
+      key: "workflow_follow_through",
+      label: "Workflow follow-through",
+      summary: "Review outstanding portfolio activity to keep progress steady.",
+    });
+  }
+  if (response && response.status !== "healthy") {
+    focus.push({
+      key: "response_timing",
+      label: "Response timing",
+      summary: "Keep portfolio response times steady as new activity comes in.",
+    });
+  }
+  if (!focus.length && trend === "declining") {
+    focus.push({
+      key: "health_monitoring",
+      label: "Health monitoring",
+      summary: "Stay close to recent portfolio activity while overall health stabilizes.",
+    });
+  }
+  if (!focus.length && sparseData) {
+    focus.push({
+      key: "developing_visibility",
+      label: "Activity visibility",
+      summary: "Continue normal portfolio activity so health visibility can develop over time.",
+    });
+  }
+  if (!focus.length) {
+    focus.push({
+      key: "continue_practices",
+      label: "Current momentum",
+      summary: "Continue current portfolio health practices to keep activity moving smoothly.",
+    });
+  }
+
+  return focus.slice(0, 4);
+}
+
+export function deriveLandlordPortfolioHealthSummary(input: {
+  portfolioScore: PortfolioScoreV1;
+  portfolioTrend: PortfolioScoreTrendV1;
+}): LandlordPortfolioHealthSummaryV1 {
+  const { portfolioScore, portfolioTrend } = input;
+  const totalResourcesReviewed = portfolioScore.metrics.totalResourcesReviewed;
+  const sparseData = totalResourcesReviewed < PORTFOLIO_HEALTH_SPARSE_DATA_THRESHOLD;
+  const overallStatus = mapOverallStatus(portfolioScore.summary.status);
+  const trendDirection = mapTrendDirection(portfolioTrend.direction);
+
+  const dimensions: PortfolioHealthDimensionV1[] = [
+    screeningDimension(portfolioScore),
+    maintenanceDimension(portfolioScore),
+    workflowDimension(portfolioScore),
+    responseDimension(portfolioScore, trendDirection),
+  ];
+
+  return {
+    version: "v1",
+    portfolioId: portfolioScore.portfolioId,
+    generatedAt: new Date().toISOString(),
+    overall: {
+      status: overallStatus,
+      headline: overallHeadline(overallStatus, trendDirection),
+      summary: sparseData ? sparseDataOverallSummary() : overallSummary(overallStatus, false),
+    },
+    trend: {
+      direction: trendDirection,
+      summary:
+        sparseData || trendDirection === "insufficient_data"
+          ? sparseDataTrendSummary()
+          : trendSummary(trendDirection, false),
+    },
+    dimensions,
+    nextFocus: buildNextFocus(dimensions, trendDirection, sparseData),
+    metadata: {
+      portfolioScoreGrade: portfolioScore.grade || null,
+      portfolioScoreAvailable: true,
+      trendAvailable: portfolioTrend.direction !== "insufficient_data",
+    },
+  };
+}

--- a/rentchain-api/src/lib/portfolioHealth/loadLandlordPortfolioHealthInputs.ts
+++ b/rentchain-api/src/lib/portfolioHealth/loadLandlordPortfolioHealthInputs.ts
@@ -1,0 +1,23 @@
+import { derivePortfolioScore } from "../portfolioScore/derivePortfolioScore";
+import { loadPortfolioScoreSignals } from "../portfolioScore/loadPortfolioScoreSignals";
+import { derivePortfolioScoreTrend } from "../portfolioScoreHistory/derivePortfolioScoreTrend";
+import { loadPortfolioScoreHistory } from "../portfolioScoreHistory/loadPortfolioScoreHistory";
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+export async function loadLandlordPortfolioHealthInputs(portfolioId: string) {
+  const safePortfolioId = asString(portfolioId, 240);
+  const [signals, history] = await Promise.all([
+    loadPortfolioScoreSignals(safePortfolioId),
+    loadPortfolioScoreHistory(safePortfolioId, 12),
+  ]);
+  const portfolioScore = derivePortfolioScore(signals);
+  const portfolioTrend = derivePortfolioScoreTrend(history, safePortfolioId);
+  return {
+    portfolioId: safePortfolioId,
+    portfolioScore,
+    portfolioTrend,
+  };
+}

--- a/rentchain-api/src/lib/portfolioHealth/portfolioHealthMappings.ts
+++ b/rentchain-api/src/lib/portfolioHealth/portfolioHealthMappings.ts
@@ -1,0 +1,76 @@
+import type { PortfolioHealthStatus, PortfolioHealthTrend } from "./portfolioHealthTypes";
+import type { PortfolioScoreV1 } from "../portfolioScore/portfolioScoreTypes";
+import type { PortfolioScoreTrendV1 } from "../portfolioScoreHistory/portfolioScoreHistoryTypes";
+
+export const PORTFOLIO_HEALTH_SPARSE_DATA_THRESHOLD = 3;
+
+export function mapOverallStatus(scoreStatus: PortfolioScoreV1["summary"]["status"]): PortfolioHealthStatus {
+  if (scoreStatus === "healthy") return "healthy";
+  if (scoreStatus === "watch") return "watch";
+  return "attention_needed";
+}
+
+export function mapTrendDirection(
+  direction: PortfolioScoreTrendV1["direction"]
+): PortfolioHealthTrend {
+  if (direction === "up") return "improving";
+  if (direction === "down") return "declining";
+  if (direction === "flat") return "stable";
+  return "insufficient_data";
+}
+
+export function statusFromComponentScore(score: number): PortfolioHealthStatus {
+  if (score >= 80) return "healthy";
+  if (score >= 60) return "watch";
+  return "attention_needed";
+}
+
+export function sparseDataOverallSummary() {
+  return "Portfolio health data is still developing as more activity is recorded.";
+}
+
+export function sparseDataTrendSummary() {
+  return "Trend visibility will improve as more portfolio activity is tracked.";
+}
+
+export function overallHeadline(status: PortfolioHealthStatus, trend: PortfolioHealthTrend) {
+  if (status === "healthy" && trend === "improving") {
+    return "Your portfolio health looks strong and continues to improve.";
+  }
+  if (status === "healthy") {
+    return "Your portfolio health looks steady and generally healthy.";
+  }
+  if (status === "watch" && trend === "declining") {
+    return "Your portfolio health is stable overall, with a few areas that need closer attention.";
+  }
+  if (status === "watch") {
+    return "Your portfolio health is stable overall, with a few areas to monitor.";
+  }
+  return "Your portfolio health needs attention in a few important areas.";
+}
+
+export function overallSummary(status: PortfolioHealthStatus, sparseData: boolean) {
+  if (sparseData) {
+    return sparseDataOverallSummary();
+  }
+  if (status === "healthy") {
+    return "Most portfolio activity is progressing normally and overall health appears steady.";
+  }
+  if (status === "watch") {
+    return "Most portfolio activity is progressing normally, while a small number of areas may need closer follow-through.";
+  }
+  return "Some portfolio activity may need more consistent follow-through to keep operations moving smoothly.";
+}
+
+export function trendSummary(direction: PortfolioHealthTrend, sparseData: boolean) {
+  if (sparseData || direction === "insufficient_data") {
+    return sparseDataTrendSummary();
+  }
+  if (direction === "improving") {
+    return "Portfolio health has been improving in recent history.";
+  }
+  if (direction === "declining") {
+    return "Portfolio health has softened in recent history and may need closer follow-through.";
+  }
+  return "Portfolio health has remained generally steady in recent history.";
+}

--- a/rentchain-api/src/lib/portfolioHealth/portfolioHealthTypes.ts
+++ b/rentchain-api/src/lib/portfolioHealth/portfolioHealthTypes.ts
@@ -1,0 +1,47 @@
+export type PortfolioHealthStatus =
+  | "healthy"
+  | "watch"
+  | "attention_needed";
+
+export type PortfolioHealthTrend =
+  | "improving"
+  | "stable"
+  | "declining"
+  | "insufficient_data";
+
+export type PortfolioHealthDimensionV1 = {
+  key:
+    | "screening_health"
+    | "maintenance_health"
+    | "workflow_health"
+    | "response_health";
+  label: string;
+  status: PortfolioHealthStatus;
+  summary: string;
+};
+
+export type LandlordPortfolioHealthSummaryV1 = {
+  version: "v1";
+  portfolioId: string;
+  generatedAt: string;
+  overall: {
+    status: PortfolioHealthStatus;
+    headline: string;
+    summary: string;
+  };
+  trend: {
+    direction: PortfolioHealthTrend;
+    summary: string;
+  };
+  dimensions: PortfolioHealthDimensionV1[];
+  nextFocus: Array<{
+    key: string;
+    label: string;
+    summary: string;
+  }>;
+  metadata?: {
+    portfolioScoreGrade?: string | null;
+    portfolioScoreAvailable: boolean;
+    trendAvailable: boolean;
+  };
+};

--- a/rentchain-api/src/routes/__tests__/landlordPortfolioHealthRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordPortfolioHealthRoutes.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const loadLandlordPortfolioHealthInputs = vi.fn();
+const deriveLandlordPortfolioHealthSummary = vi.fn();
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!req.user) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    return next();
+  },
+}));
+
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: any, res: any, next: any) => {
+    const role = String(req.user?.role || "").trim().toLowerCase();
+    const landlordId = req.user?.landlordId || req.user?.id;
+    if (role !== "landlord" && role !== "admin") {
+      return res.status(403).json({ ok: false, error: "Forbidden" });
+    }
+    if (!landlordId) {
+      return res.status(401).json({ ok: false, error: "Missing landlord context" });
+    }
+    req.user.landlordId = landlordId;
+    return next();
+  },
+}));
+
+vi.mock("../../lib/portfolioHealth/loadLandlordPortfolioHealthInputs", () => ({
+  loadLandlordPortfolioHealthInputs,
+}));
+
+vi.mock("../../lib/portfolioHealth/deriveLandlordPortfolioHealthSummary", () => ({
+  deriveLandlordPortfolioHealthSummary,
+}));
+
+async function invokeRouter(
+  router: any,
+  options: { method: string; url: string; user?: Record<string, unknown> | null }
+) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    const query = new URLSearchParams(queryString || "");
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: options.user ?? null,
+      query: Object.fromEntries(query.entries()),
+      params: {},
+      headers: {},
+      get(name: string) {
+        return this.headers[String(name).toLowerCase()];
+      },
+      header(name: string) {
+        return this.get(name);
+      },
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, string>,
+      setHeader(name: string, value: string) {
+        this.headers[name.toLowerCase()] = value;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("landlordPortfolioHealthRoutes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadLandlordPortfolioHealthInputs.mockResolvedValue({
+      portfolioId: "landlord-1",
+      portfolioScore: {},
+      portfolioTrend: {},
+    });
+    deriveLandlordPortfolioHealthSummary.mockReturnValue({
+      version: "v1",
+      portfolioId: "landlord-1",
+      generatedAt: "2026-04-16T12:00:00.000Z",
+      overall: {
+        status: "watch",
+        headline: "Your portfolio health is stable overall, with a few areas to monitor.",
+        summary: "Most portfolio activity is progressing normally, while a small number of areas may need closer follow-through.",
+      },
+      trend: {
+        direction: "stable",
+        summary: "Portfolio health has remained generally steady in recent history.",
+      },
+      dimensions: [],
+      nextFocus: [],
+      metadata: {
+        portfolioScoreGrade: null,
+        portfolioScoreAvailable: true,
+        trendAvailable: true,
+      },
+    });
+  });
+
+  it("returns landlord-scoped portfolio health", async () => {
+    const router = (await import("../landlordPortfolioHealthRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/portfolio-health",
+      user: { id: "landlord-1", role: "landlord" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(loadLandlordPortfolioHealthInputs).toHaveBeenCalledWith("landlord-1");
+    expect(response.body?.portfolioHealth?.portfolioId).toBe("landlord-1");
+  });
+
+  it("does not allow arbitrary portfolio lookup from query params", async () => {
+    const router = (await import("../landlordPortfolioHealthRoutes")).default;
+    await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/portfolio-health?portfolioId=other-landlord",
+      user: { id: "landlord-1", role: "landlord" },
+    });
+
+    expect(loadLandlordPortfolioHealthInputs).toHaveBeenCalledWith("landlord-1");
+  });
+
+  it("enforces landlord-authenticated scope", async () => {
+    const router = (await import("../landlordPortfolioHealthRoutes")).default;
+
+    const forbidden = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/portfolio-health",
+      user: { id: "tenant-1", role: "tenant" },
+    });
+    expect(forbidden.status).toBe(403);
+
+    const unauthorized = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/portfolio-health",
+      user: null,
+    });
+    expect(unauthorized.status).toBe(401);
+  });
+
+  it("returns a stable payload shape even when sparse inputs are present", async () => {
+    const router = (await import("../landlordPortfolioHealthRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/portfolio-health",
+      user: { id: "landlord-1", role: "landlord" },
+    });
+
+    expect(response.body?.portfolioHealth).toEqual(
+      expect.objectContaining({
+        overall: expect.objectContaining({ status: expect.any(String) }),
+        trend: expect.objectContaining({ direction: expect.any(String) }),
+        dimensions: expect.any(Array),
+        nextFocus: expect.any(Array),
+      })
+    );
+  });
+});

--- a/rentchain-api/src/routes/landlordPortfolioHealthRoutes.ts
+++ b/rentchain-api/src/routes/landlordPortfolioHealthRoutes.ts
@@ -1,0 +1,29 @@
+import { Router } from "express";
+import { requireAuth } from "../middleware/requireAuth";
+import { requireLandlord } from "../middleware/requireLandlord";
+import { loadLandlordPortfolioHealthInputs } from "../lib/portfolioHealth/loadLandlordPortfolioHealthInputs";
+import { deriveLandlordPortfolioHealthSummary } from "../lib/portfolioHealth/deriveLandlordPortfolioHealthSummary";
+
+const router = Router();
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+router.get("/landlord/portfolio-health", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = asString(req.user?.landlordId || req.user?.id, 240);
+    if (!landlordId) {
+      return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    }
+
+    const inputs = await loadLandlordPortfolioHealthInputs(landlordId);
+    const portfolioHealth = deriveLandlordPortfolioHealthSummary(inputs);
+    return res.json({ portfolioHealth });
+  } catch (err: any) {
+    console.error("[landlord-portfolio-health] fetch failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "LANDLORD_PORTFOLIO_HEALTH_FETCH_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -74,6 +74,10 @@ vi.mock("./pages/admin/PortfolioScoreHistoryPage", () => ({
   default: () => <h1>Portfolio Score History</h1>,
 }));
 
+vi.mock("./pages/landlord/PortfolioHealthSummaryPage", () => ({
+  default: () => <h1>Portfolio Health Summary</h1>,
+}));
+
 vi.mock("./pages/tenant/TenantWorkspacePage", () => ({
   default: () => <h1>Tenant Dashboard</h1>,
 }));
@@ -235,6 +239,20 @@ describe("Routes: /admin/portfolio-score/history", () => {
     );
 
     expect(await screen.findByText(/Portfolio Score History/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Routes: /portfolio-health", () => {
+  it("renders the landlord portfolio health route", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/portfolio-health"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Portfolio Health Summary/i)).toBeInTheDocument();
     expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -156,6 +156,7 @@ const AdminTriageQueuePage = lazy(() => import("./pages/admin/AdminTriageQueuePa
 const AdminAlertingPage = lazy(() => import("./pages/admin/AdminAlertingPage"));
 const PortfolioScorePage = lazy(() => import("./pages/admin/PortfolioScorePage"));
 const PortfolioScoreHistoryPage = lazy(() => import("./pages/admin/PortfolioScoreHistoryPage"));
+const PortfolioHealthSummaryPage = lazy(() => import("./pages/landlord/PortfolioHealthSummaryPage"));
 
 const AuthLoadingScreen = () => (
   <div
@@ -450,6 +451,18 @@ function App() {
             <RequireAuth>
               <LandlordNav>
                 <ApplicationReviewSummaryPage />
+              </LandlordNav>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/portfolio-health"
+          element={
+            <RequireAuth>
+              <LandlordNav>
+                <Suspense fallback={null}>
+                  <PortfolioHealthSummaryPage />
+                </Suspense>
               </LandlordNav>
             </RequireAuth>
           }

--- a/rentchain-frontend/src/api/landlordPortfolioHealthApi.ts
+++ b/rentchain-frontend/src/api/landlordPortfolioHealthApi.ts
@@ -1,0 +1,43 @@
+import { apiFetch } from "./apiFetch";
+
+export type PortfolioHealthStatus = "healthy" | "watch" | "attention_needed";
+export type PortfolioHealthTrend = "improving" | "stable" | "declining" | "insufficient_data";
+
+export type PortfolioHealthDimensionV1 = {
+  key: "screening_health" | "maintenance_health" | "workflow_health" | "response_health";
+  label: string;
+  status: PortfolioHealthStatus;
+  summary: string;
+};
+
+export type LandlordPortfolioHealthSummaryV1 = {
+  version: "v1";
+  portfolioId: string;
+  generatedAt: string;
+  overall: {
+    status: PortfolioHealthStatus;
+    headline: string;
+    summary: string;
+  };
+  trend: {
+    direction: PortfolioHealthTrend;
+    summary: string;
+  };
+  dimensions: PortfolioHealthDimensionV1[];
+  nextFocus: Array<{
+    key: string;
+    label: string;
+    summary: string;
+  }>;
+  metadata?: {
+    portfolioScoreGrade?: string | null;
+    portfolioScoreAvailable: boolean;
+    trendAvailable: boolean;
+  };
+};
+
+export async function fetchLandlordPortfolioHealth(): Promise<{
+  portfolioHealth: LandlordPortfolioHealthSummaryV1;
+}> {
+  return await apiFetch<{ portfolioHealth: LandlordPortfolioHealthSummaryV1 }>("/landlord/portfolio-health");
+}

--- a/rentchain-frontend/src/components/portfolioHealth/PortfolioHealthDimensionList.tsx
+++ b/rentchain-frontend/src/components/portfolioHealth/PortfolioHealthDimensionList.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import type { PortfolioHealthDimensionV1 } from "../../api/landlordPortfolioHealthApi";
+import { Card, Pill } from "../ui/Ui";
+
+type Props = {
+  dimensions: PortfolioHealthDimensionV1[];
+};
+
+export default function PortfolioHealthDimensionList({ dimensions }: Props) {
+  return (
+    <Card style={{ display: "grid", gap: 12 }}>
+      <h2 style={{ margin: 0, fontSize: "1.1rem" }}>Health dimensions</h2>
+      <div style={{ display: "grid", gap: 10 }}>
+        {dimensions.map((dimension) => (
+          <div
+            key={dimension.key}
+            style={{
+              display: "grid",
+              gap: 6,
+              padding: 12,
+              borderRadius: 12,
+              border: "1px solid #e2e8f0",
+              background: "#f8fafc",
+            }}
+          >
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "center" }}>
+              <div style={{ fontWeight: 700 }}>{dimension.label}</div>
+              <Pill>{dimension.status.replace(/_/g, " ")}</Pill>
+            </div>
+            <div style={{ color: "#475569" }}>{dimension.summary}</div>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}

--- a/rentchain-frontend/src/components/portfolioHealth/PortfolioHealthNextFocusList.tsx
+++ b/rentchain-frontend/src/components/portfolioHealth/PortfolioHealthNextFocusList.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import type { LandlordPortfolioHealthSummaryV1 } from "../../api/landlordPortfolioHealthApi";
+import { Card } from "../ui/Ui";
+
+type Props = {
+  nextFocus: LandlordPortfolioHealthSummaryV1["nextFocus"];
+};
+
+export default function PortfolioHealthNextFocusList({ nextFocus }: Props) {
+  return (
+    <Card style={{ display: "grid", gap: 12 }}>
+      <h2 style={{ margin: 0, fontSize: "1.1rem" }}>Next focus</h2>
+      <div style={{ display: "grid", gap: 10 }}>
+        {nextFocus.map((item) => (
+          <div
+            key={item.key}
+            style={{
+              padding: 12,
+              borderRadius: 12,
+              border: "1px solid #e2e8f0",
+              background: "#fff",
+            }}
+          >
+            <div style={{ fontWeight: 700, marginBottom: 4 }}>{item.label}</div>
+            <div style={{ color: "#475569" }}>{item.summary}</div>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}

--- a/rentchain-frontend/src/components/portfolioHealth/PortfolioHealthStatusCard.tsx
+++ b/rentchain-frontend/src/components/portfolioHealth/PortfolioHealthStatusCard.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import type { LandlordPortfolioHealthSummaryV1, PortfolioHealthStatus, PortfolioHealthTrend } from "../../api/landlordPortfolioHealthApi";
+import { Card, Pill } from "../ui/Ui";
+
+function toneForStatus(status: PortfolioHealthStatus) {
+  if (status === "healthy") return { background: "#dcfce7", color: "#166534" };
+  if (status === "watch") return { background: "#fef3c7", color: "#92400e" };
+  return { background: "#fee2e2", color: "#991b1b" };
+}
+
+function labelForTrend(direction: PortfolioHealthTrend) {
+  if (direction === "improving") return "Improving";
+  if (direction === "declining") return "Declining";
+  if (direction === "stable") return "Stable";
+  return "Developing";
+}
+
+type Props = {
+  summary: LandlordPortfolioHealthSummaryV1;
+};
+
+export default function PortfolioHealthStatusCard({ summary }: Props) {
+  const tone = toneForStatus(summary.overall.status);
+
+  return (
+    <Card elevated style={{ display: "grid", gap: 12 }}>
+      <div style={{ display: "flex", gap: 10, flexWrap: "wrap", alignItems: "center" }}>
+        <Pill style={{ background: tone.background, color: tone.color, borderColor: "transparent" }}>
+          {summary.overall.status.replace(/_/g, " ")}
+        </Pill>
+        <Pill>{labelForTrend(summary.trend.direction)}</Pill>
+      </div>
+      <div style={{ display: "grid", gap: 6 }}>
+        <h1 style={{ margin: 0, fontSize: "1.5rem" }}>{summary.overall.headline}</h1>
+        <div style={{ color: "#475569", maxWidth: 820 }}>{summary.overall.summary}</div>
+        <div style={{ color: "#64748b" }}>{summary.trend.summary}</div>
+      </div>
+    </Card>
+  );
+}

--- a/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.test.tsx
@@ -1,0 +1,135 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import PortfolioHealthSummaryPage from "./PortfolioHealthSummaryPage";
+
+const showToast = vi.fn();
+
+vi.mock("../../api/landlordPortfolioHealthApi", () => ({
+  fetchLandlordPortfolioHealth: vi.fn(),
+}));
+
+vi.mock("../../components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast }),
+}));
+
+vi.mock("../../components/layout/MacShell", () => ({
+  MacShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("../../components/ui/Ui", () => ({
+  Card: ({ children, elevated: _elevated, ...props }: any) => <div {...props}>{children}</div>,
+  Pill: ({ children }: any) => <span>{children}</span>,
+  Section: ({ children }: any) => <section>{children}</section>,
+}));
+
+beforeEach(() => {
+  showToast.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("PortfolioHealthSummaryPage", () => {
+  it("renders overall status, dimensions, and next-focus items", async () => {
+    const { fetchLandlordPortfolioHealth } = await import("../../api/landlordPortfolioHealthApi");
+    vi.mocked(fetchLandlordPortfolioHealth).mockResolvedValue({
+      portfolioHealth: {
+        version: "v1",
+        portfolioId: "landlord-1",
+        generatedAt: "2026-04-16T12:00:00.000Z",
+        overall: {
+          status: "watch",
+          headline: "Your portfolio health is stable overall, with a few areas to monitor.",
+          summary: "Most portfolio activity is progressing normally, while a small number of areas may need closer follow-through.",
+        },
+        trend: {
+          direction: "stable",
+          summary: "Portfolio health has remained generally steady in recent history.",
+        },
+        dimensions: [
+          {
+            key: "screening_health",
+            label: "Screening health",
+            status: "watch",
+            summary: "Application and screening follow-through may need closer attention.",
+          },
+        ],
+        nextFocus: [
+          {
+            key: "workflow_follow_through",
+            label: "Workflow follow-through",
+            summary: "Review outstanding portfolio activity to keep progress steady.",
+          },
+        ],
+        metadata: {
+          portfolioScoreGrade: null,
+          portfolioScoreAvailable: true,
+          trendAvailable: true,
+        },
+      },
+    } as any);
+
+    render(
+      <MemoryRouter>
+        <PortfolioHealthSummaryPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/stable overall, with a few areas to monitor/i)).toBeInTheDocument();
+    expect(screen.getByText(/Screening health/i)).toBeInTheDocument();
+    expect(screen.getByText(/Workflow follow-through/i)).toBeInTheDocument();
+  });
+
+  it("renders sparse-data messaging", async () => {
+    const { fetchLandlordPortfolioHealth } = await import("../../api/landlordPortfolioHealthApi");
+    vi.mocked(fetchLandlordPortfolioHealth).mockResolvedValue({
+      portfolioHealth: {
+        version: "v1",
+        portfolioId: "landlord-1",
+        generatedAt: "2026-04-16T12:00:00.000Z",
+        overall: {
+          status: "watch",
+          headline: "Your portfolio health is stable overall, with a few areas to monitor.",
+          summary: "Portfolio health data is still developing as more activity is recorded.",
+        },
+        trend: {
+          direction: "insufficient_data",
+          summary: "Trend visibility will improve as more portfolio activity is tracked.",
+        },
+        dimensions: [],
+        nextFocus: [],
+        metadata: {
+          portfolioScoreGrade: null,
+          portfolioScoreAvailable: true,
+          trendAvailable: false,
+        },
+      },
+    } as any);
+
+    render(
+      <MemoryRouter>
+        <PortfolioHealthSummaryPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/still developing as more activity is recorded/i)).toBeInTheDocument();
+    expect(screen.getByText(/Trend visibility will improve/i)).toBeInTheDocument();
+  });
+
+  it("renders an error state cleanly", async () => {
+    const { fetchLandlordPortfolioHealth } = await import("../../api/landlordPortfolioHealthApi");
+    vi.mocked(fetchLandlordPortfolioHealth).mockRejectedValue(new Error("Boom"));
+
+    render(
+      <MemoryRouter>
+        <PortfolioHealthSummaryPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Failed to load portfolio health: Boom/i)).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { fetchLandlordPortfolioHealth, type LandlordPortfolioHealthSummaryV1 } from "../../api/landlordPortfolioHealthApi";
+import { MacShell } from "../../components/layout/MacShell";
+import { Card, Section } from "../../components/ui/Ui";
+import { useToast } from "../../components/ui/ToastProvider";
+import PortfolioHealthStatusCard from "../../components/portfolioHealth/PortfolioHealthStatusCard";
+import PortfolioHealthDimensionList from "../../components/portfolioHealth/PortfolioHealthDimensionList";
+import PortfolioHealthNextFocusList from "../../components/portfolioHealth/PortfolioHealthNextFocusList";
+
+export default function PortfolioHealthSummaryPage() {
+  const { showToast } = useToast();
+  const [summary, setSummary] = React.useState<LandlordPortfolioHealthSummaryV1 | null>(null);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const response = await fetchLandlordPortfolioHealth();
+        if (!mounted) return;
+        setSummary(response.portfolioHealth);
+      } catch (err: any) {
+        if (!mounted) return;
+        const message = err?.message || "Failed to load portfolio health summary";
+        setError(message);
+        showToast({
+          message: "Failed to load portfolio health summary",
+          description: message,
+          variant: "error",
+        });
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [showToast]);
+
+  return (
+    <MacShell title="Portfolio health">
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "grid", gap: 6 }}>
+            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Portfolio health</h1>
+            <div style={{ color: "#475569", maxWidth: 820 }}>
+              A high-level view of overall portfolio health, recent direction, and where follow-through may help most.
+            </div>
+          </div>
+        </Section>
+
+        {loading ? <Card>Loading portfolio health…</Card> : null}
+        {!loading && error ? <Card style={{ color: "#b91c1c" }}>Failed to load portfolio health: {error}</Card> : null}
+
+        {!loading && !error && summary ? (
+          <>
+            <PortfolioHealthStatusCard summary={summary} />
+            <PortfolioHealthDimensionList dimensions={summary.dimensions} />
+            <PortfolioHealthNextFocusList nextFocus={summary.nextFocus} />
+          </>
+        ) : null}
+      </div>
+    </MacShell>
+  );
+}


### PR DESCRIPTION
## Summary
Adds Landlord-Facing Portfolio Health Summary v1 as the first landlord-safe portfolio health externalization layer.

This introduces a landlord-authenticated API and page that translate internal portfolio score and trend signals into a high-level health summary, trend direction, safe health dimensions, and next-focus guidance without exposing internal admin operations data.

## Scope
- Adds `portfolioHealthTypes`, `portfolioHealthMappings`, a landlord-safe input loader, and `deriveLandlordPortfolioHealthSummary` under `src/lib/portfolioHealth`
- Adds a new landlord-authenticated route:
  - `GET /api/landlord/portfolio-health`
- Scopes the route strictly from authenticated landlord context
- Reuses internal portfolio score and trend derivation as inputs, but transforms them through a dedicated landlord-safe summary layer
- Adds a new landlord frontend API client:
  - `fetchLandlordPortfolioHealth()`
- Adds a landlord page at:
  - `/portfolio-health`
- Renders:
  - overall health status
  - landlord-safe headline and summary
  - trend direction and safe trend summary
  - health dimensions for:
    - screening health
    - maintenance health
    - workflow health
    - response health
  - next-focus guidance
- Adds targeted backend and frontend tests for:
  - healthy / watch / attention-needed mapping
  - improving / stable / declining / insufficient-data trend mapping
  - sparse-data fallback messaging
  - landlord scope enforcement
  - landlord page rendering and error handling

## Notes
This is intentionally a landlord-safe abstraction layer, not a direct exposure of internal admin payloads.

The landlord route does not expose:
- raw triage items
- support/debug console data
- internal resolution notes or state
- assignment/watchlist state
- raw alerting or SLA state
- raw policy or automation event history
- sensitive screening reconciliation internals

For v1, the response includes only high-level health interpretation and limited metadata flags. `portfolioScoreGrade` remains metadata-only and is not visually foregrounded in the landlord UI.

## Validation
- Passed targeted backend portfolio-health tests
- Passed backend build
- Passed targeted frontend landlord portfolio-health and route tests
- Passed full frontend test suite
- Passed frontend build