### PR TITLE
feat: add portfolio score externalization v1

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -109,6 +109,7 @@ import adminAssignmentRoutes from "./routes/adminAssignmentRoutes";
 import portfolioScoreRoutes from "./routes/portfolioScoreRoutes";
 import portfolioScoreHistoryRoutes from "./routes/portfolioScoreHistoryRoutes";
 import landlordPortfolioHealthRoutes from "./routes/landlordPortfolioHealthRoutes";
+import landlordPortfolioScoreRoutes from "./routes/landlordPortfolioScoreRoutes";
 import transunionRoutes from "./services/integrations/transunion/transunionRoutes";
 import viewingRoutes from "./routes/viewingRoutes";
 import screeningOpsRoutes from "./routes/screeningOpsRoutes";
@@ -246,6 +247,8 @@ app.use("/api/admin", routeSource("portfolioScoreHistoryRoutes.ts"), portfolioSc
 console.log("[route-mount] portfolioScoreHistoryRoutes mounted at /api/admin");
 app.use("/api", routeSource("landlordPortfolioHealthRoutes.ts"), landlordPortfolioHealthRoutes);
 console.log("[route-mount] landlordPortfolioHealthRoutes mounted at /api");
+app.use("/api", routeSource("landlordPortfolioScoreRoutes.ts"), landlordPortfolioScoreRoutes);
+console.log("[route-mount] landlordPortfolioScoreRoutes mounted at /api");
 
 // Current user info
 app.get("/api/me", async (req: any, res: any, next: any) => {

--- a/rentchain-api/src/lib/portfolioScoreExternal/__tests__/derivePortfolioScoreExternal.test.ts
+++ b/rentchain-api/src/lib/portfolioScoreExternal/__tests__/derivePortfolioScoreExternal.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import type { PortfolioScoreV1 } from "../../portfolioScore/portfolioScoreTypes";
+import type { PortfolioScoreTrendV1 } from "../../portfolioScoreHistory/portfolioScoreHistoryTypes";
+import { derivePortfolioScoreExternal } from "../derivePortfolioScoreExternal";
+
+function buildScore(overrides: Partial<PortfolioScoreV1> = {}): PortfolioScoreV1 {
+  return {
+    version: "v1",
+    portfolioId: "landlord-1",
+    generatedAt: "2026-04-16T12:00:00.000Z",
+    score: 92,
+    grade: "A",
+    summary: {
+      status: "healthy",
+      headline: "Healthy",
+      notes: [],
+    },
+    components: [
+      { key: "workflow_completion", label: "Workflow completion", rawValue: 0.94, normalizedScore: 92, weight: 0.25, contribution: 23 },
+      { key: "screening_reliability", label: "Screening reliability", rawValue: 0.91, normalizedScore: 90, weight: 0.2, contribution: 18 },
+      { key: "maintenance_stability", label: "Maintenance stability", rawValue: 0.9, normalizedScore: 91, weight: 0.15, contribution: 13.65 },
+      { key: "automation_health", label: "Automation health", rawValue: 0.88, normalizedScore: 88, weight: 0.1, contribution: 8.8 },
+      { key: "policy_friction", label: "Policy friction", rawValue: 0.15, normalizedScore: 84, weight: 0.1, contribution: 8.4 },
+      { key: "exception_burden", label: "Exception burden", rawValue: 0.1, normalizedScore: 86, weight: 0.2, contribution: 17.2 },
+    ],
+    metrics: {
+      totalResourcesReviewed: 10,
+      triageItemCount: 1,
+      criticalTriageCount: 0,
+      reconciliationIssueCount: 0,
+      automationSkipCount: 0,
+      policyReviewCount: 0,
+      blockedWorkflowCount: 0,
+      maintenanceReopenCount: 0,
+    },
+    ...overrides,
+  };
+}
+
+function buildTrend(overrides: Partial<PortfolioScoreTrendV1> = {}): PortfolioScoreTrendV1 {
+  return {
+    version: "v1",
+    portfolioId: "landlord-1",
+    generatedAt: "2026-04-16T12:00:00.000Z",
+    latest: null,
+    previous: null,
+    direction: "flat",
+    deltaScore: 0,
+    deltaGrade: null,
+    summary: {
+      headline: "Stable",
+      notes: [],
+    },
+    movers: [],
+    history: [],
+    ...overrides,
+  };
+}
+
+describe("derivePortfolioScoreExternal", () => {
+  it("renders a high score safely with strong messaging", () => {
+    const external = derivePortfolioScoreExternal({
+      portfolioScore: buildScore(),
+      portfolioTrend: buildTrend({ direction: "up" }),
+    });
+
+    expect(external.score).toBe(92);
+    expect(external.grade).toBe("A");
+    expect(external.summary.headline).toMatch(/high standard/i);
+    expect(external.trend.direction).toBe("improving");
+    expect(external.components.every((component) => component.status === "strong")).toBe(true);
+  });
+
+  it("renders a lower score safely without internal admin leakage", () => {
+    const external = derivePortfolioScoreExternal({
+      portfolioScore: buildScore({
+        score: 64,
+        grade: "D",
+        summary: { status: "at_risk", headline: "At risk", notes: [] },
+        components: buildScore().components.map((component) =>
+          component.key === "screening_reliability"
+            ? { ...component, normalizedScore: 42 }
+            : { ...component, normalizedScore: Math.min(component.normalizedScore, 63) }
+        ),
+      }),
+      portfolioTrend: buildTrend({ direction: "down" }),
+    });
+
+    expect(external.summary.headline).toMatch(/areas that need attention/i);
+    expect(external.trend.direction).toBe("declining");
+    expect(external.components.some((component) => component.status === "needs_attention")).toBe(true);
+    expect(JSON.stringify(external)).not.toMatch(/triage|reconciliation|alert|sla|assignment|resolution|automation skipped/i);
+  });
+
+  it("maps trend directions safely", () => {
+    expect(
+      derivePortfolioScoreExternal({
+        portfolioScore: buildScore(),
+        portfolioTrend: buildTrend({ direction: "up" }),
+      }).trend.direction
+    ).toBe("improving");
+    expect(
+      derivePortfolioScoreExternal({
+        portfolioScore: buildScore(),
+        portfolioTrend: buildTrend({ direction: "down" }),
+      }).trend.direction
+    ).toBe("declining");
+    expect(
+      derivePortfolioScoreExternal({
+        portfolioScore: buildScore(),
+        portfolioTrend: buildTrend({ direction: "flat" }),
+      }).trend.direction
+    ).toBe("stable");
+    expect(
+      derivePortfolioScoreExternal({
+        portfolioScore: buildScore(),
+        portfolioTrend: buildTrend({ direction: "insufficient_data", deltaScore: null }),
+      }).trend.direction
+    ).toBe("insufficient_data");
+  });
+
+  it("handles sparse data conservatively", () => {
+    const external = derivePortfolioScoreExternal({
+      portfolioScore: buildScore({
+        score: 78,
+        grade: "C",
+        metrics: { ...buildScore().metrics, totalResourcesReviewed: 1 },
+      }),
+      portfolioTrend: buildTrend({ direction: "insufficient_data", deltaScore: null }),
+    });
+
+    expect(external.summary.explanation).toMatch(/become more precise as more activity is recorded/i);
+    expect(external.trend.summary).toMatch(/become clearer as more portfolio activity is recorded/i);
+  });
+});

--- a/rentchain-api/src/lib/portfolioScoreExternal/derivePortfolioScoreExternal.ts
+++ b/rentchain-api/src/lib/portfolioScoreExternal/derivePortfolioScoreExternal.ts
@@ -1,0 +1,53 @@
+import type { PortfolioScoreV1 } from "../portfolioScore/portfolioScoreTypes";
+import type { PortfolioScoreTrendV1 } from "../portfolioScoreHistory/portfolioScoreHistoryTypes";
+import {
+  componentStatus,
+  componentSummary,
+  mapExternalTrend,
+  PORTFOLIO_SCORE_EXTERNAL_SPARSE_DATA_THRESHOLD,
+  scoreExplanation,
+  scoreHeadline,
+  trendSummary,
+  trustExplanation,
+  TRUST_METHODOLOGY_NOTE,
+} from "./portfolioScoreExternalMappings";
+import type { PortfolioScoreExternalV1 } from "./portfolioScoreExternalTypes";
+
+export function derivePortfolioScoreExternal(input: {
+  portfolioScore: PortfolioScoreV1;
+  portfolioTrend: PortfolioScoreTrendV1;
+}): PortfolioScoreExternalV1 {
+  const { portfolioScore, portfolioTrend } = input;
+  const sparseData =
+    portfolioScore.metrics.totalResourcesReviewed < PORTFOLIO_SCORE_EXTERNAL_SPARSE_DATA_THRESHOLD;
+  const externalTrend = mapExternalTrend(portfolioTrend.direction);
+
+  return {
+    version: "v1",
+    portfolioId: portfolioScore.portfolioId,
+    generatedAt: new Date().toISOString(),
+    score: portfolioScore.score,
+    grade: portfolioScore.grade,
+    summary: {
+      headline: scoreHeadline(portfolioScore.score, sparseData),
+      explanation: scoreExplanation(portfolioScore.score, sparseData),
+    },
+    trend: {
+      direction: externalTrend,
+      summary: trendSummary(externalTrend, sparseData),
+    },
+    components: portfolioScore.components.map((component) => {
+      const status = componentStatus(component.normalizedScore);
+      return {
+        key: component.key,
+        label: component.label,
+        status,
+        summary: componentSummary(component.key, status, sparseData),
+      };
+    }),
+    trust: {
+      explanation: trustExplanation(portfolioScore, sparseData),
+      methodologyNote: TRUST_METHODOLOGY_NOTE,
+    },
+  };
+}

--- a/rentchain-api/src/lib/portfolioScoreExternal/portfolioScoreExternalMappings.ts
+++ b/rentchain-api/src/lib/portfolioScoreExternal/portfolioScoreExternalMappings.ts
@@ -1,0 +1,143 @@
+import type { PortfolioScoreTrendV1 } from "../portfolioScoreHistory/portfolioScoreHistoryTypes";
+import type { PortfolioScoreComponent, PortfolioScoreV1 } from "../portfolioScore/portfolioScoreTypes";
+
+export const PORTFOLIO_SCORE_EXTERNAL_SPARSE_DATA_THRESHOLD = 3;
+
+export function mapExternalTrend(
+  direction: PortfolioScoreTrendV1["direction"]
+): "improving" | "stable" | "declining" | "insufficient_data" {
+  if (direction === "up") return "improving";
+  if (direction === "down") return "declining";
+  if (direction === "flat") return "stable";
+  return "insufficient_data";
+}
+
+export function scoreHeadline(score: number, sparseData: boolean) {
+  if (sparseData) {
+    return "Your portfolio score is still taking shape.";
+  }
+  if (score >= 90) {
+    return "Your portfolio is operating at a high standard.";
+  }
+  if (score >= 70) {
+    return "Your portfolio is stable with some areas to monitor.";
+  }
+  return "Your portfolio has areas that need attention.";
+}
+
+export function scoreExplanation(score: number, sparseData: boolean) {
+  if (sparseData) {
+    return "Your portfolio score will become more precise as more activity is recorded.";
+  }
+  if (score >= 90) {
+    return "Recent portfolio activity has been consistent and well balanced across key operational areas.";
+  }
+  if (score >= 70) {
+    return "Your portfolio is performing steadily overall, with a few areas that may benefit from closer follow-through.";
+  }
+  return "Some parts of your portfolio operations may need more consistent follow-through to strengthen overall performance.";
+}
+
+export function componentStatus(score: number): "strong" | "moderate" | "needs_attention" {
+  if (score >= 80) return "strong";
+  if (score >= 60) return "moderate";
+  return "needs_attention";
+}
+
+export function componentSummary(
+  key: PortfolioScoreComponent["key"],
+  status: "strong" | "moderate" | "needs_attention",
+  sparseData: boolean
+) {
+  if (sparseData) {
+    if (key === "workflow_completion") {
+      return "Workflow performance detail will become clearer as more portfolio activity is recorded.";
+    }
+    if (key === "screening_reliability") {
+      return "Screening performance detail will become clearer as more portfolio activity is recorded.";
+    }
+    if (key === "maintenance_stability") {
+      return "Maintenance performance detail will become clearer as more portfolio activity is recorded.";
+    }
+    if (key === "automation_health") {
+      return "Operational consistency detail will become clearer as more portfolio activity is recorded.";
+    }
+    if (key === "policy_friction") {
+      return "Operational review detail will become clearer as more portfolio activity is recorded.";
+    }
+    return "Overall consistency detail will become clearer as more portfolio activity is recorded.";
+  }
+
+  if (key === "workflow_completion") {
+    return status === "strong"
+      ? "Core portfolio workflows are reaching healthy outcomes consistently."
+      : status === "moderate"
+      ? "Most portfolio workflows are progressing normally, with some room to tighten follow-through."
+      : "Portfolio workflows may need more consistent follow-through to keep progress moving.";
+  }
+  if (key === "screening_reliability") {
+    return status === "strong"
+      ? "Application and screening activity is moving through reliably."
+      : status === "moderate"
+      ? "Application and screening activity is generally steady, with a few areas to monitor."
+      : "Application and screening follow-through may need closer attention.";
+  }
+  if (key === "maintenance_stability") {
+    return status === "strong"
+      ? "Maintenance activity appears stable and well managed."
+      : status === "moderate"
+      ? "Maintenance activity is mostly stable, with some areas to watch."
+      : "Maintenance activity may need more focused follow-through.";
+  }
+  if (key === "automation_health") {
+    return status === "strong"
+      ? "Operational consistency has been supported well across recent activity."
+      : status === "moderate"
+      ? "Operational consistency is steady overall, with some room for improvement."
+      : "Operational consistency may need closer follow-through in key areas.";
+  }
+  if (key === "policy_friction") {
+    return status === "strong"
+      ? "Portfolio activity is moving with relatively low operational friction."
+      : status === "moderate"
+      ? "Portfolio activity is moving steadily, though some areas may require extra review."
+      : "Operational friction may be slowing progress in a few areas.";
+  }
+  return status === "strong"
+    ? "Overall portfolio consistency looks strong."
+    : status === "moderate"
+    ? "Overall portfolio consistency is steady, with a few areas to monitor."
+    : "Overall portfolio consistency may need more attention right now.";
+}
+
+export function trendSummary(
+  direction: "improving" | "stable" | "declining" | "insufficient_data",
+  sparseData: boolean
+) {
+  if (sparseData || direction === "insufficient_data") {
+    return "Your trend will become clearer as more portfolio activity is recorded over time.";
+  }
+  if (direction === "improving") {
+    return "Your portfolio score has been improving in recent history.";
+  }
+  if (direction === "declining") {
+    return "Your portfolio score has softened in recent history and may need closer attention.";
+  }
+  return "Your portfolio score has remained generally steady in recent history.";
+}
+
+export function trustExplanation(score: PortfolioScoreV1, sparseData: boolean) {
+  if (sparseData) {
+    return "Your score reflects early activity patterns and will become more informative as more portfolio activity is recorded.";
+  }
+  if (score.score >= 85) {
+    return "Your score reflects strong operational consistency across recent portfolio activity.";
+  }
+  if (score.score >= 70) {
+    return "Your score reflects generally steady portfolio operations, with some areas that may need attention.";
+  }
+  return "Your score reflects portfolio activity that may need more consistent follow-through in a few areas.";
+}
+
+export const TRUST_METHODOLOGY_NOTE =
+  "Scores are based on activity patterns, workflow completion, and operational consistency over time.";

--- a/rentchain-api/src/lib/portfolioScoreExternal/portfolioScoreExternalTypes.ts
+++ b/rentchain-api/src/lib/portfolioScoreExternal/portfolioScoreExternalTypes.ts
@@ -1,0 +1,31 @@
+export type PortfolioScoreExternalV1 = {
+  version: "v1";
+  portfolioId: string;
+  generatedAt: string;
+  score: number;
+  grade: "A" | "B" | "C" | "D" | "E";
+  summary: {
+    headline: string;
+    explanation: string;
+  };
+  trend: {
+    direction: "improving" | "stable" | "declining" | "insufficient_data";
+    summary: string;
+  };
+  components: Array<{
+    key:
+      | "workflow_completion"
+      | "screening_reliability"
+      | "maintenance_stability"
+      | "automation_health"
+      | "policy_friction"
+      | "exception_burden";
+    label: string;
+    status: "strong" | "moderate" | "needs_attention";
+    summary: string;
+  }>;
+  trust: {
+    explanation: string;
+    methodologyNote: string;
+  };
+};

--- a/rentchain-api/src/routes/__tests__/landlordPortfolioScoreRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordPortfolioScoreRoutes.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const loadLandlordPortfolioHealthInputs = vi.fn();
+const derivePortfolioScoreExternal = vi.fn();
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!req.user) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    return next();
+  },
+}));
+
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: any, res: any, next: any) => {
+    const role = String(req.user?.role || "").trim().toLowerCase();
+    const landlordId = req.user?.landlordId || req.user?.id;
+    if (role !== "landlord" && role !== "admin") {
+      return res.status(403).json({ ok: false, error: "Forbidden" });
+    }
+    if (!landlordId) {
+      return res.status(401).json({ ok: false, error: "Missing landlord context" });
+    }
+    req.user.landlordId = landlordId;
+    return next();
+  },
+}));
+
+vi.mock("../../lib/portfolioHealth/loadLandlordPortfolioHealthInputs", () => ({
+  loadLandlordPortfolioHealthInputs,
+}));
+
+vi.mock("../../lib/portfolioScoreExternal/derivePortfolioScoreExternal", () => ({
+  derivePortfolioScoreExternal,
+}));
+
+async function invokeRouter(
+  router: any,
+  options: { method: string; url: string; user?: Record<string, unknown> | null }
+) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    const query = new URLSearchParams(queryString || "");
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: options.user ?? null,
+      query: Object.fromEntries(query.entries()),
+      params: {},
+      headers: {},
+      get(name: string) {
+        return this.headers[String(name).toLowerCase()];
+      },
+      header(name: string) {
+        return this.get(name);
+      },
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, string>,
+      setHeader(name: string, value: string) {
+        this.headers[name.toLowerCase()] = value;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("landlordPortfolioScoreRoutes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadLandlordPortfolioHealthInputs.mockResolvedValue({
+      portfolioId: "landlord-1",
+      portfolioScore: {},
+      portfolioTrend: {},
+    });
+    derivePortfolioScoreExternal.mockReturnValue({
+      version: "v1",
+      portfolioId: "landlord-1",
+      generatedAt: "2026-04-16T12:00:00.000Z",
+      score: 84,
+      grade: "B",
+      summary: {
+        headline: "Your portfolio is stable with some areas to monitor.",
+        explanation: "Your portfolio is performing steadily overall, with a few areas that may benefit from closer follow-through.",
+      },
+      trend: {
+        direction: "stable",
+        summary: "Your portfolio score has remained generally steady in recent history.",
+      },
+      components: [],
+      trust: {
+        explanation: "Your score reflects how consistently your rental operations are performing over time.",
+        methodologyNote: "Scores are based on activity patterns, workflow completion, and operational consistency over time.",
+      },
+    });
+  });
+
+  it("returns landlord-scoped portfolio score", async () => {
+    const router = (await import("../landlordPortfolioScoreRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/portfolio-score",
+      user: { id: "landlord-1", role: "landlord" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(loadLandlordPortfolioHealthInputs).toHaveBeenCalledWith("landlord-1");
+    expect(response.body?.portfolioScore?.portfolioId).toBe("landlord-1");
+  });
+
+  it("does not allow arbitrary portfolio lookup from query params", async () => {
+    const router = (await import("../landlordPortfolioScoreRoutes")).default;
+    await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/portfolio-score?portfolioId=other-landlord",
+      user: { id: "landlord-1", role: "landlord" },
+    });
+
+    expect(loadLandlordPortfolioHealthInputs).toHaveBeenCalledWith("landlord-1");
+  });
+
+  it("enforces landlord-authenticated scope", async () => {
+    const router = (await import("../landlordPortfolioScoreRoutes")).default;
+
+    const forbidden = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/portfolio-score",
+      user: { id: "tenant-1", role: "tenant" },
+    });
+    expect(forbidden.status).toBe(403);
+
+    const unauthorized = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/portfolio-score",
+      user: null,
+    });
+    expect(unauthorized.status).toBe(401);
+  });
+
+  it("returns a stable safe payload shape", async () => {
+    const router = (await import("../landlordPortfolioScoreRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/portfolio-score",
+      user: { id: "landlord-1", role: "landlord" },
+    });
+
+    expect(response.body?.portfolioScore).toEqual(
+      expect.objectContaining({
+        score: expect.any(Number),
+        grade: expect.any(String),
+        summary: expect.objectContaining({ headline: expect.any(String), explanation: expect.any(String) }),
+        trend: expect.objectContaining({ direction: expect.any(String) }),
+        components: expect.any(Array),
+        trust: expect.objectContaining({ explanation: expect.any(String), methodologyNote: expect.any(String) }),
+      })
+    );
+  });
+});

--- a/rentchain-api/src/routes/landlordPortfolioScoreRoutes.ts
+++ b/rentchain-api/src/routes/landlordPortfolioScoreRoutes.ts
@@ -1,0 +1,29 @@
+import { Router } from "express";
+import { requireAuth } from "../middleware/requireAuth";
+import { requireLandlord } from "../middleware/requireLandlord";
+import { loadLandlordPortfolioHealthInputs } from "../lib/portfolioHealth/loadLandlordPortfolioHealthInputs";
+import { derivePortfolioScoreExternal } from "../lib/portfolioScoreExternal/derivePortfolioScoreExternal";
+
+const router = Router();
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+router.get("/landlord/portfolio-score", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = asString(req.user?.landlordId || req.user?.id, 240);
+    if (!landlordId) {
+      return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    }
+
+    const inputs = await loadLandlordPortfolioHealthInputs(landlordId);
+    const portfolioScore = derivePortfolioScoreExternal(inputs);
+    return res.json({ portfolioScore });
+  } catch (err: any) {
+    console.error("[landlord-portfolio-score] fetch failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "LANDLORD_PORTFOLIO_SCORE_FETCH_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -78,6 +78,10 @@ vi.mock("./pages/landlord/PortfolioHealthSummaryPage", () => ({
   default: () => <h1>Portfolio Health Summary</h1>,
 }));
 
+vi.mock("./pages/landlord/PortfolioScorePage", () => ({
+  default: () => <h1>Landlord Portfolio Score</h1>,
+}));
+
 vi.mock("./pages/tenant/TenantWorkspacePage", () => ({
   default: () => <h1>Tenant Dashboard</h1>,
 }));
@@ -253,6 +257,20 @@ describe("Routes: /portfolio-health", () => {
     );
 
     expect(await screen.findByText(/Portfolio Health Summary/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Routes: /portfolio-score", () => {
+  it("renders the landlord portfolio score route", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/portfolio-score"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Landlord Portfolio Score/i)).toBeInTheDocument();
     expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -157,6 +157,7 @@ const AdminAlertingPage = lazy(() => import("./pages/admin/AdminAlertingPage"));
 const PortfolioScorePage = lazy(() => import("./pages/admin/PortfolioScorePage"));
 const PortfolioScoreHistoryPage = lazy(() => import("./pages/admin/PortfolioScoreHistoryPage"));
 const PortfolioHealthSummaryPage = lazy(() => import("./pages/landlord/PortfolioHealthSummaryPage"));
+const LandlordPortfolioScorePage = lazy(() => import("./pages/landlord/PortfolioScorePage"));
 
 const AuthLoadingScreen = () => (
   <div
@@ -462,6 +463,18 @@ function App() {
               <LandlordNav>
                 <Suspense fallback={null}>
                   <PortfolioHealthSummaryPage />
+                </Suspense>
+              </LandlordNav>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/portfolio-score"
+          element={
+            <RequireAuth>
+              <LandlordNav>
+                <Suspense fallback={null}>
+                  <LandlordPortfolioScorePage />
                 </Suspense>
               </LandlordNav>
             </RequireAuth>

--- a/rentchain-frontend/src/api/landlordPortfolioScoreApi.ts
+++ b/rentchain-frontend/src/api/landlordPortfolioScoreApi.ts
@@ -1,0 +1,39 @@
+import { apiFetch } from "./apiFetch";
+
+export type PortfolioScoreExternalV1 = {
+  version: "v1";
+  portfolioId: string;
+  generatedAt: string;
+  score: number;
+  grade: "A" | "B" | "C" | "D" | "E";
+  summary: {
+    headline: string;
+    explanation: string;
+  };
+  trend: {
+    direction: "improving" | "stable" | "declining" | "insufficient_data";
+    summary: string;
+  };
+  components: Array<{
+    key:
+      | "workflow_completion"
+      | "screening_reliability"
+      | "maintenance_stability"
+      | "automation_health"
+      | "policy_friction"
+      | "exception_burden";
+    label: string;
+    status: "strong" | "moderate" | "needs_attention";
+    summary: string;
+  }>;
+  trust: {
+    explanation: string;
+    methodologyNote: string;
+  };
+};
+
+export async function fetchLandlordPortfolioScore(): Promise<{
+  portfolioScore: PortfolioScoreExternalV1;
+}> {
+  return await apiFetch<{ portfolioScore: PortfolioScoreExternalV1 }>("/landlord/portfolio-score");
+}

--- a/rentchain-frontend/src/components/portfolioScoreExternal/PortfolioScoreComponentList.tsx
+++ b/rentchain-frontend/src/components/portfolioScoreExternal/PortfolioScoreComponentList.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import type { PortfolioScoreExternalV1 } from "../../api/landlordPortfolioScoreApi";
+import { Card, Pill } from "../ui/Ui";
+
+export default function PortfolioScoreComponentList({
+  components,
+}: {
+  components: PortfolioScoreExternalV1["components"];
+}) {
+  return (
+    <Card style={{ display: "grid", gap: 12 }}>
+      <h2 style={{ margin: 0, fontSize: "1.1rem" }}>Score components</h2>
+      <div style={{ display: "grid", gap: 10 }}>
+        {components.map((component) => (
+          <div
+            key={component.key}
+            style={{
+              display: "grid",
+              gap: 6,
+              padding: 12,
+              borderRadius: 12,
+              border: "1px solid #e2e8f0",
+              background: "#f8fafc",
+            }}
+          >
+            <div style={{ display: "flex", gap: 12, justifyContent: "space-between", alignItems: "center" }}>
+              <div style={{ fontWeight: 700 }}>{component.label}</div>
+              <Pill>{component.status.replace(/_/g, " ")}</Pill>
+            </div>
+            <div style={{ color: "#475569" }}>{component.summary}</div>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}

--- a/rentchain-frontend/src/components/portfolioScoreExternal/PortfolioScoreHeader.tsx
+++ b/rentchain-frontend/src/components/portfolioScoreExternal/PortfolioScoreHeader.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import type { PortfolioScoreExternalV1 } from "../../api/landlordPortfolioScoreApi";
+import { Card, Pill } from "../ui/Ui";
+
+function trendLabel(direction: PortfolioScoreExternalV1["trend"]["direction"]) {
+  if (direction === "improving") return "Improving";
+  if (direction === "declining") return "Declining";
+  if (direction === "stable") return "Stable";
+  return "Developing";
+}
+
+export default function PortfolioScoreHeader({ portfolioScore }: { portfolioScore: PortfolioScoreExternalV1 }) {
+  return (
+    <Card elevated style={{ display: "grid", gap: 14 }}>
+      <div style={{ display: "flex", gap: 12, alignItems: "center", flexWrap: "wrap" }}>
+        <div
+          style={{
+            minWidth: 92,
+            minHeight: 92,
+            borderRadius: 20,
+            background: "linear-gradient(135deg, #0f172a 0%, #1e3a8a 100%)",
+            color: "#fff",
+            display: "grid",
+            placeItems: "center",
+            padding: 12,
+          }}
+        >
+          <div style={{ textAlign: "center" }}>
+            <div style={{ fontSize: "2rem", fontWeight: 800, lineHeight: 1 }}>{portfolioScore.score}</div>
+            <div style={{ fontSize: "0.85rem", opacity: 0.9 }}>Grade {portfolioScore.grade}</div>
+          </div>
+        </div>
+        <div style={{ display: "grid", gap: 8, flex: 1, minWidth: 240 }}>
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+            <Pill>{`Grade ${portfolioScore.grade}`}</Pill>
+            <Pill>{trendLabel(portfolioScore.trend.direction)}</Pill>
+          </div>
+          <h1 style={{ margin: 0, fontSize: "1.5rem" }}>{portfolioScore.summary.headline}</h1>
+          <div style={{ color: "#475569", maxWidth: 820 }}>{portfolioScore.summary.explanation}</div>
+          <div style={{ color: "#64748b" }}>{portfolioScore.trend.summary}</div>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/rentchain-frontend/src/components/portfolioScoreExternal/PortfolioScoreTrustPanel.tsx
+++ b/rentchain-frontend/src/components/portfolioScoreExternal/PortfolioScoreTrustPanel.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import type { PortfolioScoreExternalV1 } from "../../api/landlordPortfolioScoreApi";
+import { Card } from "../ui/Ui";
+
+export default function PortfolioScoreTrustPanel({
+  trust,
+}: {
+  trust: PortfolioScoreExternalV1["trust"];
+}) {
+  return (
+    <Card style={{ display: "grid", gap: 8 }}>
+      <h2 style={{ margin: 0, fontSize: "1.1rem" }}>How to read this score</h2>
+      <div style={{ color: "#334155" }}>{trust.explanation}</div>
+      <div style={{ color: "#64748b" }}>{trust.methodologyNote}</div>
+    </Card>
+  );
+}

--- a/rentchain-frontend/src/pages/landlord/PortfolioScorePage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/PortfolioScorePage.test.tsx
@@ -1,0 +1,128 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import PortfolioScorePage from "./PortfolioScorePage";
+
+const showToast = vi.fn();
+
+vi.mock("../../api/landlordPortfolioScoreApi", () => ({
+  fetchLandlordPortfolioScore: vi.fn(),
+}));
+
+vi.mock("../../components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast }),
+}));
+
+vi.mock("../../components/layout/MacShell", () => ({
+  MacShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("../../components/ui/Ui", () => ({
+  Card: ({ children, elevated: _elevated, ...props }: any) => <div {...props}>{children}</div>,
+  Pill: ({ children }: any) => <span>{children}</span>,
+  Section: ({ children }: any) => <section>{children}</section>,
+}));
+
+beforeEach(() => {
+  showToast.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("PortfolioScorePage", () => {
+  it("renders a high score safely", async () => {
+    const { fetchLandlordPortfolioScore } = await import("../../api/landlordPortfolioScoreApi");
+    vi.mocked(fetchLandlordPortfolioScore).mockResolvedValue({
+      portfolioScore: {
+        version: "v1",
+        portfolioId: "landlord-1",
+        generatedAt: "2026-04-16T12:00:00.000Z",
+        score: 92,
+        grade: "A",
+        summary: {
+          headline: "Your portfolio is operating at a high standard.",
+          explanation: "Recent portfolio activity has been consistent and well balanced across key operational areas.",
+        },
+        trend: {
+          direction: "improving",
+          summary: "Your portfolio score has been improving in recent history.",
+        },
+        components: [
+          {
+            key: "workflow_completion",
+            label: "Workflow completion",
+            status: "strong",
+            summary: "Core portfolio workflows are reaching healthy outcomes consistently.",
+          },
+        ],
+        trust: {
+          explanation: "Your score reflects how consistently your rental operations are performing over time.",
+          methodologyNote: "Scores are based on activity patterns, workflow completion, and operational consistency over time.",
+        },
+      },
+    } as any);
+
+    render(
+      <MemoryRouter>
+        <PortfolioScorePage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/operating at a high standard/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Grade A/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Workflow completion/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/How to read this score/i)).toBeInTheDocument();
+  });
+
+  it("renders sparse data safely", async () => {
+    const { fetchLandlordPortfolioScore } = await import("../../api/landlordPortfolioScoreApi");
+    vi.mocked(fetchLandlordPortfolioScore).mockResolvedValue({
+      portfolioScore: {
+        version: "v1",
+        portfolioId: "landlord-1",
+        generatedAt: "2026-04-16T12:00:00.000Z",
+        score: 75,
+        grade: "C",
+        summary: {
+          headline: "Your portfolio score is still taking shape.",
+          explanation: "Your portfolio score will become more precise as more activity is recorded.",
+        },
+        trend: {
+          direction: "insufficient_data",
+          summary: "Your trend will become clearer as more portfolio activity is recorded over time.",
+        },
+        components: [],
+        trust: {
+          explanation: "Your score reflects early activity patterns and will become more informative as more portfolio activity is recorded.",
+          methodologyNote: "Scores are based on activity patterns, workflow completion, and operational consistency over time.",
+        },
+      },
+    } as any);
+
+    render(
+      <MemoryRouter>
+        <PortfolioScorePage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/still taking shape/i)).toBeInTheDocument();
+    expect(screen.getByText(/become more precise as more activity is recorded/i)).toBeInTheDocument();
+  });
+
+  it("renders an error state cleanly", async () => {
+    const { fetchLandlordPortfolioScore } = await import("../../api/landlordPortfolioScoreApi");
+    vi.mocked(fetchLandlordPortfolioScore).mockRejectedValue(new Error("Boom"));
+
+    render(
+      <MemoryRouter>
+        <PortfolioScorePage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Failed to load portfolio score: Boom/i)).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/landlord/PortfolioScorePage.tsx
+++ b/rentchain-frontend/src/pages/landlord/PortfolioScorePage.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { fetchLandlordPortfolioScore, type PortfolioScoreExternalV1 } from "../../api/landlordPortfolioScoreApi";
+import { MacShell } from "../../components/layout/MacShell";
+import { Card, Section } from "../../components/ui/Ui";
+import { useToast } from "../../components/ui/ToastProvider";
+import PortfolioScoreHeader from "../../components/portfolioScoreExternal/PortfolioScoreHeader";
+import PortfolioScoreComponentList from "../../components/portfolioScoreExternal/PortfolioScoreComponentList";
+import PortfolioScoreTrustPanel from "../../components/portfolioScoreExternal/PortfolioScoreTrustPanel";
+
+export default function PortfolioScorePage() {
+  const { showToast } = useToast();
+  const [portfolioScore, setPortfolioScore] = React.useState<PortfolioScoreExternalV1 | null>(null);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const response = await fetchLandlordPortfolioScore();
+        if (!mounted) return;
+        setPortfolioScore(response.portfolioScore);
+      } catch (err: any) {
+        if (!mounted) return;
+        const message = err?.message || "Failed to load portfolio score";
+        setError(message);
+        showToast({
+          message: "Failed to load portfolio score",
+          description: message,
+          variant: "error",
+        });
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [showToast]);
+
+  return (
+    <MacShell title="Portfolio score">
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "grid", gap: 6 }}>
+            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Portfolio Score™</h1>
+            <div style={{ color: "#475569", maxWidth: 820 }}>
+              A structured view of how consistently your portfolio operations are performing over time.
+            </div>
+          </div>
+        </Section>
+
+        {loading ? <Card>Loading portfolio score…</Card> : null}
+        {!loading && error ? <Card style={{ color: "#b91c1c" }}>Failed to load portfolio score: {error}</Card> : null}
+
+        {!loading && !error && portfolioScore ? (
+          <>
+            <PortfolioScoreHeader portfolioScore={portfolioScore} />
+            <PortfolioScoreComponentList components={portfolioScore.components} />
+            <PortfolioScoreTrustPanel trust={portfolioScore.trust} />
+          </>
+        ) : null}
+      </div>
+    </MacShell>
+  );
+}


### PR DESCRIPTION
## Summary
Adds Portfolio Score™ Externalization / Shareable Profile v1 as the first landlord-facing Portfolio Score™ trust-signal layer.

This introduces a landlord-authenticated API and page that translate internal portfolio score and trend signals into a safe external score view with score, grade, simplified component explanations, trend context, and trust/methodology messaging.

## Scope
- Adds `portfolioScoreExternalTypes`, `portfolioScoreExternalMappings`, and `derivePortfolioScoreExternal` under `src/lib/portfolioScoreExternal`
- Adds a new landlord-authenticated route:
  - `GET /api/landlord/portfolio-score`
- Scopes the route strictly from authenticated landlord context
- Reuses internal portfolio score and trend derivation as inputs, but transforms them through a dedicated externalization layer
- Adds a new landlord frontend API client:
  - `fetchLandlordPortfolioScore()`
- Adds a landlord page at:
  - `/portfolio-score`
- Renders:
  - score
  - grade
  - landlord-safe headline and explanation
  - landlord-safe trend direction and summary
  - simplified component summaries for:
    - workflow completion
    - screening reliability
    - maintenance stability
    - automation health
    - policy friction
    - exception burden
  - trust explanation and methodology note
- Adds targeted backend and frontend tests for:
  - high and low score mapping
  - improving / stable / declining / insufficient-data trend mapping
  - sparse-data fallback messaging
  - landlord scope enforcement
  - landlord page rendering and error handling
  - absence of leaked admin-language patterns

## Notes
This is intentionally a landlord-safe trust-signal layer, not a direct exposure of internal admin score payloads.

The landlord route does not expose:
- raw triage items
- raw reconciliation details
- alert or SLA state
- policy or automation event details
- resolution or assignment state
- support/debug console data
- internal admin notes or diagnostics

For v1, the score is explainable and future-shareable in structure, but it is still landlord-authenticated only. No public or unauthenticated sharing route is added yet.

Sparse portfolios use neutral messaging so the score does not overclaim confidence before enough activity exists.

## Validation
- Passed targeted backend portfolio-score-externalization tests
- Passed backend build
- Passed targeted frontend landlord portfolio-score and route tests
- Passed full frontend test suite
- Passed frontend build