### PR TITLE
feat: add internal notifications and watcher delivery v1

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -106,6 +106,7 @@ import adminResolutionRoutes from "./routes/adminResolutionRoutes";
 import adminSlaRoutes from "./routes/adminSlaRoutes";
 import adminAlertingRoutes from "./routes/adminAlertingRoutes";
 import adminAssignmentRoutes from "./routes/adminAssignmentRoutes";
+import adminNotificationRoutes from "./routes/adminNotificationRoutes";
 import portfolioScoreRoutes from "./routes/portfolioScoreRoutes";
 import portfolioScoreHistoryRoutes from "./routes/portfolioScoreHistoryRoutes";
 import landlordPortfolioHealthRoutes from "./routes/landlordPortfolioHealthRoutes";
@@ -241,6 +242,8 @@ app.use("/api/admin", routeSource("adminAlertingRoutes.ts"), adminAlertingRoutes
 console.log("[route-mount] adminAlertingRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("adminAssignmentRoutes.ts"), adminAssignmentRoutes);
 console.log("[route-mount] adminAssignmentRoutes mounted at /api/admin");
+app.use("/api/admin", routeSource("adminNotificationRoutes.ts"), adminNotificationRoutes);
+console.log("[route-mount] adminNotificationRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("portfolioScoreRoutes.ts"), portfolioScoreRoutes);
 console.log("[route-mount] portfolioScoreRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("portfolioScoreHistoryRoutes.ts"), portfolioScoreHistoryRoutes);

--- a/rentchain-api/src/lib/notifications/__tests__/deriveNotifications.test.ts
+++ b/rentchain-api/src/lib/notifications/__tests__/deriveNotifications.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import { deriveNotifications } from "../deriveNotifications";
+
+describe("deriveNotifications", () => {
+  it("derives notification types from alerts and preserves navigation", () => {
+    const notifications = deriveNotifications({
+      alerts: [
+        {
+          version: "v1",
+          id: "alert-1",
+          category: "screening_reconciliation",
+          severity: "critical",
+          resource: { type: "application", id: "app-1", portfolioId: "portfolio-1" },
+          reason: { code: "ALERT_SCREENING_MISMATCH", summary: "Screening reconciliation signals are inconsistent." },
+          signals: { triageCategory: "screening_reconciliation", triageSeverity: "critical" },
+          state: { isActive: true, isAcknowledged: false },
+          timestamps: {
+            createdAt: "2026-04-16T12:00:00.000Z",
+            updatedAt: "2026-04-16T12:00:00.000Z",
+            lastSeenAt: "2026-04-16T12:00:00.000Z",
+          },
+          navigation: {
+            supportConsolePath: "/admin/support-console?resourceType=application&resourceId=app-1",
+            triagePath: "/admin/triage?resourceType=application",
+            portfolioScorePath: "/admin/portfolio-score?portfolioId=portfolio-1",
+          },
+          tags: [],
+        } as any,
+      ],
+    });
+
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]).toEqual(
+      expect.objectContaining({
+        type: "triage_item",
+        severity: "critical",
+        navigation: expect.objectContaining({
+          supportConsolePath: expect.stringContaining("/admin/support-console"),
+          triagePath: expect.stringContaining("/admin/triage"),
+          portfolioScorePath: expect.stringContaining("/admin/portfolio-score"),
+        }),
+      })
+    );
+  });
+
+  it("derives sla escalation and portfolio score change notifications correctly", () => {
+    const notifications = deriveNotifications({
+      alerts: [
+        {
+          version: "v1",
+          id: "alert-sla",
+          category: "maintenance_friction",
+          severity: "high",
+          resource: { type: "maintenance", id: "maint-1", portfolioId: "portfolio-1" },
+          reason: { code: "ALERT_WORKFLOW_STALLED", summary: "Maintenance work has stalled." },
+          signals: { triageCategory: "workflow_stall", triageSeverity: "high" },
+          sla: { stage: "escalated", escalationLevel: "critical", ageHours: 49 },
+          state: { isActive: true, isAcknowledged: false },
+          timestamps: {
+            createdAt: "2026-04-16T12:00:00.000Z",
+            updatedAt: "2026-04-16T12:00:00.000Z",
+            lastSeenAt: "2026-04-16T12:00:00.000Z",
+          },
+          navigation: {},
+          tags: [],
+        } as any,
+        {
+          version: "v1",
+          id: "alert-portfolio",
+          category: "portfolio_score_change",
+          severity: "high",
+          resource: { type: "portfolio", id: "portfolio-1", portfolioId: "portfolio-1" },
+          reason: { code: "ALERT_PORTFOLIO_SCORE_DROP", summary: "Portfolio score declined versus the previous snapshot." },
+          signals: { portfolioScore: 74, portfolioScoreDelta: -6 },
+          state: { isActive: true, isAcknowledged: false },
+          timestamps: {
+            createdAt: "2026-04-16T12:00:00.000Z",
+            updatedAt: "2026-04-16T12:00:00.000Z",
+            lastSeenAt: "2026-04-16T12:00:00.000Z",
+          },
+          navigation: { portfolioScorePath: "/admin/portfolio-score?portfolioId=portfolio-1" },
+          tags: [],
+        } as any,
+      ],
+    });
+
+    expect(notifications.map((item) => item.type)).toEqual(
+      expect.arrayContaining(["sla_escalation", "portfolio_score_change"])
+    );
+  });
+
+  it("applies read state and watcher delivery", () => {
+    const notifications = deriveNotifications({
+      alerts: [
+        {
+          version: "v1",
+          id: "alert-1",
+          category: "screening_reconciliation",
+          severity: "high",
+          resource: { type: "application", id: "app-1", portfolioId: "portfolio-1" },
+          reason: { code: "ALERT_DUPLICATE_RISK", summary: "Duplicate risk needs review." },
+          signals: { triageCategory: "screening_reconciliation", triageSeverity: "high" },
+          state: { isActive: true, isAcknowledged: false },
+          timestamps: {
+            createdAt: "2026-04-16T12:00:00.000Z",
+            updatedAt: "2026-04-16T12:00:00.000Z",
+            lastSeenAt: "2026-04-16T12:00:00.000Z",
+          },
+          navigation: {},
+          tags: [],
+        } as any,
+      ],
+      watchlist: [
+        {
+          version: "v1",
+          id: "watch-1",
+          target: { type: "portfolio", id: "portfolio-1" },
+          createdAt: "2026-04-16T12:00:00.000Z",
+          updatedAt: "2026-04-16T12:00:00.000Z",
+          isActive: true,
+        } as any,
+      ],
+      notificationStates: [
+        {
+          id: "notification-triage_item-alert-1",
+          status: "read",
+          readAt: "2026-04-16T13:00:00.000Z",
+          updatedAt: "2026-04-16T13:00:00.000Z",
+        },
+      ],
+    });
+
+    expect(notifications[0].watched).toBe(true);
+    expect(notifications[0].state.status).toBe("read");
+    expect(notifications[0].state.readAt).toBe("2026-04-16T13:00:00.000Z");
+  });
+});

--- a/rentchain-api/src/lib/notifications/deriveNotifications.ts
+++ b/rentchain-api/src/lib/notifications/deriveNotifications.ts
@@ -1,0 +1,142 @@
+import type { AdminAlertV1 } from "../alerting/alertingTypes";
+import type { WatchlistEntryV1 } from "../watchlist/watchlistTypes";
+import type { AdminNotificationStateRecord } from "./loadNotifications";
+import type { AdminNotificationV1, NotificationType } from "./notificationTypes";
+
+type DeriveNotificationsInput = {
+  alerts?: AdminAlertV1[];
+  watchlist?: WatchlistEntryV1[];
+  notificationStates?: AdminNotificationStateRecord[];
+  resourcePortfolioIds?: Record<string, string | null | undefined>;
+};
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function resourceKey(resourceType: string, resourceId: string) {
+  return `${resourceType}:${resourceId}`;
+}
+
+function notificationId(type: NotificationType, sourceId: string) {
+  return `notification-${type}-${sourceId}`;
+}
+
+function severityRank(severity?: string | null) {
+  return { critical: 4, high: 3, medium: 2, low: 1 }[asString(severity, 40) as "critical"] || 0;
+}
+
+function isWatched(alert: AdminAlertV1, watchlist: WatchlistEntryV1[], portfolioId?: string | null) {
+  return watchlist.some((entry) => {
+    if (!entry.isActive) return false;
+    const targetType = asString(entry.target?.type, 80);
+    const targetId = asString(entry.target?.id, 240);
+    if (targetType === alert.resource.type && targetId === alert.resource.id) return true;
+    if (targetType === "portfolio" && portfolioId && targetId === portfolioId) return true;
+    return false;
+  });
+}
+
+function resolveType(alert: AdminAlertV1): NotificationType {
+  if (alert.category === "portfolio_score_change") return "portfolio_score_change";
+  if (
+    alert.sla?.stage === "overdue" ||
+    alert.sla?.stage === "escalated" ||
+    alert.sla?.escalationLevel === "high" ||
+    alert.sla?.escalationLevel === "critical"
+  ) {
+    return "sla_escalation";
+  }
+  if (alert.signals?.triageCategory || alert.signals?.triageSeverity) {
+    return "triage_item";
+  }
+  return "alert";
+}
+
+function titleForNotification(type: NotificationType, alert: AdminAlertV1) {
+  if (type === "portfolio_score_change") {
+    return "Portfolio score changed";
+  }
+  if (type === "sla_escalation") {
+    return alert.sla?.stage === "escalated"
+      ? "Issue has escalated"
+      : "Issue is overdue";
+  }
+  if (type === "triage_item") {
+    return alert.severity === "critical"
+      ? "Critical issue needs attention"
+      : "Operational issue needs attention";
+  }
+  return "New alert requires attention";
+}
+
+function messageForNotification(type: NotificationType, alert: AdminAlertV1) {
+  if (type === "portfolio_score_change") {
+    return alert.reason.summary || "Portfolio health changed enough to warrant review.";
+  }
+  if (type === "sla_escalation") {
+    const age = typeof alert.sla?.ageHours === "number" ? `${Math.round(alert.sla.ageHours)}h` : null;
+    return age
+      ? `${alert.reason.summary} This item has been open for about ${age}.`
+      : alert.reason.summary;
+  }
+  return alert.reason.summary;
+}
+
+export function deriveNotifications(input: DeriveNotificationsInput): AdminNotificationV1[] {
+  const alerts = input.alerts || [];
+  const watchlist = input.watchlist || [];
+  const stateById = new Map((input.notificationStates || []).map((item) => [item.id, item]));
+  const portfolioIndex = input.resourcePortfolioIds || {};
+
+  const notifications = alerts.map((alert) => {
+    const type = resolveType(alert);
+    const portfolioId =
+      asString(alert.resource.portfolioId, 240) ||
+      asString(portfolioIndex[resourceKey(alert.resource.type, alert.resource.id)], 240) ||
+      (alert.resource.type === "portfolio" ? alert.resource.id : "");
+    const watched = isWatched(alert, watchlist, portfolioId || null);
+    const id = notificationId(type, alert.id);
+    const state = stateById.get(id);
+    return {
+      version: "v1",
+      id,
+      type,
+      resource: {
+        type: alert.resource.type,
+        id: alert.resource.id,
+        portfolioId: portfolioId || null,
+      },
+      summary: {
+        title: titleForNotification(type, alert),
+        message: messageForNotification(type, alert),
+      },
+      severity: alert.severity,
+      watched,
+      state: {
+        status: state?.status || "unread",
+        readAt: state?.readAt || null,
+      },
+      createdAt: alert.timestamps.createdAt,
+      updatedAt: state?.updatedAt || alert.timestamps.updatedAt || alert.timestamps.createdAt,
+      navigation: {
+        supportConsolePath: alert.navigation.supportConsolePath || null,
+        triagePath: alert.navigation.triagePath || null,
+        portfolioScorePath: alert.navigation.portfolioScorePath || null,
+      },
+    } satisfies AdminNotificationV1;
+  });
+
+  return notifications.sort((a, b) => {
+    if (Number(Boolean(b.watched)) !== Number(Boolean(a.watched))) {
+      return Number(Boolean(b.watched)) - Number(Boolean(a.watched));
+    }
+    if (a.state.status !== b.state.status) {
+      return a.state.status === "unread" ? -1 : 1;
+    }
+    if (severityRank(b.severity) !== severityRank(a.severity)) {
+      return severityRank(b.severity) - severityRank(a.severity);
+    }
+    return Date.parse(b.createdAt) - Date.parse(a.createdAt);
+  });
+}

--- a/rentchain-api/src/lib/notifications/loadNotifications.ts
+++ b/rentchain-api/src/lib/notifications/loadNotifications.ts
@@ -1,0 +1,18 @@
+import { db } from "../../config/firebase";
+import type { NotificationStatus } from "./notificationTypes";
+
+export const ADMIN_NOTIFICATIONS_COLLECTION = "adminNotifications";
+
+export type AdminNotificationStateRecord = {
+  id: string;
+  status: NotificationStatus;
+  readAt?: string | null;
+  updatedAt: string;
+};
+
+export async function loadNotificationStates(): Promise<AdminNotificationStateRecord[]> {
+  const snap = await db.collection(ADMIN_NOTIFICATIONS_COLLECTION).get();
+  return (snap.docs || []).map(
+    (doc: any) => ({ id: doc.id, ...(doc.data() || {}) }) as AdminNotificationStateRecord
+  );
+}

--- a/rentchain-api/src/lib/notifications/notificationTypes.ts
+++ b/rentchain-api/src/lib/notifications/notificationTypes.ts
@@ -1,0 +1,35 @@
+export type NotificationType =
+  | "alert"
+  | "sla_escalation"
+  | "triage_item"
+  | "portfolio_score_change";
+
+export type NotificationStatus = "unread" | "read";
+
+export type AdminNotificationV1 = {
+  version: "v1";
+  id: string;
+  type: NotificationType;
+  resource: {
+    type: string;
+    id: string;
+    portfolioId?: string | null;
+  };
+  summary: {
+    title: string;
+    message: string;
+  };
+  severity?: "low" | "medium" | "high" | "critical";
+  watched?: boolean;
+  state: {
+    status: NotificationStatus;
+    readAt?: string | null;
+  };
+  createdAt: string;
+  updatedAt: string;
+  navigation: {
+    supportConsolePath?: string | null;
+    triagePath?: string | null;
+    portfolioScorePath?: string | null;
+  };
+};

--- a/rentchain-api/src/lib/notifications/saveNotificationState.ts
+++ b/rentchain-api/src/lib/notifications/saveNotificationState.ts
@@ -1,0 +1,19 @@
+import { db } from "../../config/firebase";
+import { ADMIN_NOTIFICATIONS_COLLECTION } from "./loadNotifications";
+
+export async function saveNotificationState(input: {
+  notificationId: string;
+  read: boolean;
+}) {
+  const now = new Date().toISOString();
+  const payload = {
+    id: input.notificationId,
+    status: input.read ? "read" : "unread",
+    readAt: input.read ? now : null,
+    updatedAt: now,
+  };
+  await db.collection(ADMIN_NOTIFICATIONS_COLLECTION).doc(input.notificationId).set(payload, {
+    merge: false,
+  });
+  return payload;
+}

--- a/rentchain-api/src/routes/__tests__/adminNotificationRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/adminNotificationRoutes.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const loadNotificationStates = vi.fn();
+const saveNotificationState = vi.fn();
+const deriveNotifications = vi.fn();
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!req.user) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    return next();
+  },
+}));
+
+vi.mock("../../config/firebase", () => ({
+  db: {
+    collection: () => ({
+      async get() {
+        return { docs: [], empty: true, size: 0 };
+      },
+    }),
+  },
+}));
+
+vi.mock("../../lib/notifications/loadNotifications", () => ({
+  loadNotificationStates,
+}));
+
+vi.mock("../../lib/notifications/saveNotificationState", () => ({
+  saveNotificationState,
+}));
+
+vi.mock("../../lib/notifications/deriveNotifications", () => ({
+  deriveNotifications,
+}));
+
+vi.mock("../../lib/triage/deriveAdminTriageQueue", () => ({
+  deriveAdminTriageQueue: () => [],
+}));
+
+vi.mock("../../lib/alerting/loadAlertStates", () => ({
+  loadAlertStates: async () => [],
+}));
+
+vi.mock("../../lib/watchlist/loadWatchlistEntries", () => ({
+  ADMIN_WATCHLISTS_COLLECTION: "adminWatchlists",
+  loadWatchlistEntries: async () => [],
+}));
+
+vi.mock("../../lib/alerting/deriveAdminAlerts", () => ({
+  deriveAdminAlerts: () => [],
+}));
+
+vi.mock("../../lib/portfolioScoreHistory/loadPortfolioScoreHistory", () => ({
+  loadPortfolioScoreHistory: async () => [],
+}));
+
+vi.mock("../../lib/portfolioScoreHistory/derivePortfolioScoreTrend", () => ({
+  derivePortfolioScoreTrend: (history: any[], portfolioId: string) => ({
+    version: "v1",
+    portfolioId,
+    generatedAt: "2026-04-16T12:00:00.000Z",
+    latest: null,
+    previous: null,
+    direction: "insufficient_data",
+    deltaScore: null,
+    deltaGrade: null,
+    summary: { headline: "No history", notes: [] },
+    movers: [],
+    history,
+  }),
+}));
+
+async function invokeRouter(
+  router: any,
+  options: { method: string; url: string; user?: any; body?: any }
+) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    const query = new URLSearchParams(queryString || "");
+    const paramsMatch = path.match(/\/notifications\/([^/]+)\/read$/);
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: options.user ?? null,
+      query: Object.fromEntries(query.entries()),
+      params: paramsMatch ? { notificationId: paramsMatch[1] } : {},
+      body: options.body || {},
+      headers: {},
+      get(name: string) {
+        return this.headers[String(name).toLowerCase()];
+      },
+      header(name: string) {
+        return this.get(name);
+      },
+    };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      setHeader() {},
+    };
+    router.handle(req, res, (error: any) => (error ? reject(error) : undefined));
+  });
+}
+
+describe("adminNotificationRoutes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadNotificationStates.mockResolvedValue([]);
+    deriveNotifications.mockReturnValue([]);
+    saveNotificationState.mockResolvedValue({
+      id: "notification-1",
+      status: "read",
+      readAt: "2026-04-16T12:00:00.000Z",
+      updatedAt: "2026-04-16T12:00:00.000Z",
+    });
+  });
+
+  it("returns stable empty states and enforces admin-only access", async () => {
+    const router = (await import("../adminNotificationRoutes")).default;
+    const empty = await invokeRouter(router, {
+      method: "GET",
+      url: "/notifications",
+      user: { id: "admin-1", role: "admin" },
+    });
+    expect(empty.status).toBe(200);
+    expect(empty.body).toEqual({ notifications: [], nextCursor: undefined });
+
+    const forbidden = await invokeRouter(router, {
+      method: "GET",
+      url: "/notifications",
+      user: { id: "landlord-1", role: "landlord" },
+    });
+    expect(forbidden.status).toBe(403);
+  });
+
+  it("persists read state and supports watcher filtering passthrough", async () => {
+    deriveNotifications.mockReturnValue([
+      {
+        version: "v1",
+        id: "notification-1",
+        type: "triage_item",
+        resource: { type: "application", id: "app-1", portfolioId: "portfolio-1" },
+        summary: { title: "Critical issue needs attention", message: "Screening reconciliation signals are inconsistent." },
+        severity: "critical",
+        watched: true,
+        state: { status: "unread", readAt: null },
+        createdAt: "2026-04-16T12:00:00.000Z",
+        updatedAt: "2026-04-16T12:00:00.000Z",
+        navigation: {
+          supportConsolePath: "/admin/support-console?resourceType=application&resourceId=app-1",
+          triagePath: "/admin/triage?resourceType=application",
+          portfolioScorePath: "/admin/portfolio-score?portfolioId=portfolio-1",
+        },
+      },
+    ]);
+
+    const router = (await import("../adminNotificationRoutes")).default;
+
+    const fetched = await invokeRouter(router, {
+      method: "GET",
+      url: "/notifications?watchedOnly=true",
+      user: { id: "admin-1", role: "admin" },
+    });
+    expect(fetched.status).toBe(200);
+    expect(fetched.body?.notifications).toHaveLength(1);
+    expect(fetched.body?.notifications[0]?.watched).toBe(true);
+
+    const updated = await invokeRouter(router, {
+      method: "PATCH",
+      url: "/notifications/notification-1/read",
+      user: { id: "admin-1", role: "admin" },
+      body: { read: true },
+    });
+    expect(updated.status).toBe(200);
+    expect(saveNotificationState).toHaveBeenCalledWith({
+      notificationId: "notification-1",
+      read: true,
+    });
+    expect(updated.body?.state?.status).toBe("read");
+  });
+});

--- a/rentchain-api/src/routes/adminNotificationRoutes.ts
+++ b/rentchain-api/src/routes/adminNotificationRoutes.ts
@@ -1,0 +1,207 @@
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { ADMIN_ASSIGNMENTS_COLLECTION } from "../lib/assignment/loadAssignmentRecord";
+import { deriveAdminAlerts } from "../lib/alerting/deriveAdminAlerts";
+import { loadAlertStates } from "../lib/alerting/loadAlertStates";
+import { ADMIN_RESOLUTIONS_COLLECTION } from "../lib/resolution/loadResolutionRecord";
+import { deriveAdminTriageQueue } from "../lib/triage/deriveAdminTriageQueue";
+import { ADMIN_WATCHLISTS_COLLECTION, loadWatchlistEntries } from "../lib/watchlist/loadWatchlistEntries";
+import { loadPortfolioScoreHistory } from "../lib/portfolioScoreHistory/loadPortfolioScoreHistory";
+import { derivePortfolioScoreTrend } from "../lib/portfolioScoreHistory/derivePortfolioScoreTrend";
+import { CANONICAL_EVENTS_COLLECTION } from "../lib/events/buildEvent";
+import { requireAuth } from "../middleware/requireAuth";
+import { deriveNotifications } from "../lib/notifications/deriveNotifications";
+import { loadNotificationStates } from "../lib/notifications/loadNotifications";
+import { saveNotificationState } from "../lib/notifications/saveNotificationState";
+
+const router = Router();
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function normalizeRole(req: any): "admin" | "landlord" | "other" {
+  const role = asString(req.user?.actorRole || req.user?.role, 40).toLowerCase();
+  if (role === "admin") return "admin";
+  if (role === "landlord") return "landlord";
+  return "other";
+}
+
+function parseLimit(value: unknown, fallback = 20) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(1, Math.min(100, Math.floor(parsed)));
+}
+
+function parseCursor(value: unknown): { createdAt: string; itemId: string } | null {
+  const raw = asString(value, 4000);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(Buffer.from(raw, "base64url").toString("utf8"));
+    const createdAt = asString(parsed?.createdAt);
+    const itemId = asString(parsed?.itemId);
+    if (!createdAt || !itemId) return null;
+    return { createdAt, itemId };
+  } catch {
+    return null;
+  }
+}
+
+function encodeCursor(item: { id: string; createdAt: string }) {
+  return Buffer.from(
+    JSON.stringify({
+      createdAt: item.createdAt,
+      itemId: item.id,
+    }),
+    "utf8"
+  ).toString("base64url");
+}
+
+async function loadCollection(name: string) {
+  const snap = await db.collection(name).get();
+  return (snap.docs || []).map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }));
+}
+
+async function loadCanonicalEvents() {
+  const snap = await db.collection(CANONICAL_EVENTS_COLLECTION).get();
+  return (snap.docs || []).map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }));
+}
+
+function latestUniquePortfolioIds(records: any[]) {
+  return Array.from(
+    new Set(
+      (records || [])
+        .map((record) => asString(record?.landlordId || record?.portfolioId, 240))
+        .filter(Boolean)
+    )
+  );
+}
+
+async function loadPortfolioTrends(portfolioIds: string[]) {
+  const trends = await Promise.all(
+    portfolioIds.map(async (portfolioId) => {
+      const history = await loadPortfolioScoreHistory(portfolioId, 12);
+      return derivePortfolioScoreTrend(history, portfolioId);
+    })
+  );
+  return trends;
+}
+
+function buildPortfolioIndex(records: any[], resourceType: string) {
+  return Object.fromEntries(
+    (records || []).map((record) => [
+      `${resourceType}:${asString(record.id, 240)}`,
+      asString(record.landlordId || record.portfolioId, 240) || null,
+    ])
+  );
+}
+
+router.get("/notifications", requireAuth, async (req: any, res) => {
+  try {
+    if (normalizeRole(req) !== "admin") {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+
+    const unreadOnly = String(req.query?.unreadOnly || "false").toLowerCase() === "true";
+    const watchedOnly = String(req.query?.watchedOnly || "false").toLowerCase() === "true";
+    const limit = parseLimit(req.query?.limit, 20);
+    const cursor = parseCursor(req.query?.cursor);
+
+    const [
+      applications,
+      maintenanceRequests,
+      leases,
+      canonicalEvents,
+      screeningOrders,
+      financialTransactions,
+      resolutions,
+      assignments,
+      alertStates,
+      watchlist,
+      notificationStates,
+    ] = await Promise.all([
+      loadCollection("rentalApplications"),
+      loadCollection("maintenanceRequests"),
+      loadCollection("leases"),
+      loadCanonicalEvents(),
+      loadCollection("screeningOrders"),
+      loadCollection("financialTransactions"),
+      loadCollection(ADMIN_RESOLUTIONS_COLLECTION),
+      loadCollection(ADMIN_ASSIGNMENTS_COLLECTION),
+      loadAlertStates(),
+      loadWatchlistEntries(),
+      loadNotificationStates(),
+    ]);
+
+    const triageItems = deriveAdminTriageQueue({
+      applications,
+      maintenanceRequests,
+      leases,
+      canonicalEvents,
+      screeningOrders,
+      financialTransactions,
+      resolutions,
+      assignments,
+    });
+    const portfolioTrends = await loadPortfolioTrends(
+      latestUniquePortfolioIds([...applications, ...maintenanceRequests, ...leases])
+    );
+    const alerts = deriveAdminAlerts({
+      triageItems,
+      portfolioTrends,
+      resolutions,
+      assignments,
+      alertStates,
+      watchlist,
+    });
+    const resourcePortfolioIds = {
+      ...buildPortfolioIndex(applications, "application"),
+      ...buildPortfolioIndex(maintenanceRequests, "maintenance"),
+      ...buildPortfolioIndex(leases, "lease"),
+    };
+    const notifications = deriveNotifications({
+      alerts,
+      watchlist,
+      notificationStates,
+      resourcePortfolioIds,
+    })
+      .filter((item) => (unreadOnly ? item.state.status === "unread" : true))
+      .filter((item) => (watchedOnly ? item.watched === true : true));
+
+    const cursorFiltered = cursor
+      ? notifications.filter((item) => `${item.createdAt}::${item.id}` < `${cursor.createdAt}::${cursor.itemId}`)
+      : notifications;
+    const page = cursorFiltered.slice(0, limit);
+    const hasMore = cursorFiltered.length > limit;
+
+    return res.json({
+      notifications: page,
+      nextCursor: hasMore && page.length ? encodeCursor(page[page.length - 1]) : undefined,
+    });
+  } catch (err: any) {
+    console.error("[admin-notifications] fetch failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "ADMIN_NOTIFICATIONS_FETCH_FAILED" });
+  }
+});
+
+router.patch("/notifications/:notificationId/read", requireAuth, async (req: any, res) => {
+  try {
+    if (normalizeRole(req) !== "admin") {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+
+    const notificationId = asString(req.params?.notificationId, 240);
+    if (!notificationId) {
+      return res.status(400).json({ ok: false, error: "NOTIFICATION_ID_REQUIRED" });
+    }
+
+    const read = req.body?.read === true;
+    const state = await saveNotificationState({ notificationId, read });
+    return res.json({ state });
+  } catch (err: any) {
+    console.error("[admin-notifications] read update failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "ADMIN_NOTIFICATION_STATE_UPDATE_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -66,6 +66,10 @@ vi.mock("./pages/admin/AdminAlertingPage", () => ({
   default: () => <h1>Admin Alerts</h1>,
 }));
 
+vi.mock("./pages/admin/AdminNotificationsPage", () => ({
+  default: () => <h1>Admin Notifications</h1>,
+}));
+
 vi.mock("./pages/admin/PortfolioScorePage", () => ({
   default: () => <h1>Portfolio Score Foundation</h1>,
 }));
@@ -215,6 +219,20 @@ describe("Routes: /admin/alerts", () => {
     );
 
     expect(await screen.findByText(/Admin Alerts/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Routes: /admin/notifications", () => {
+  it("renders the admin notifications route", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/admin/notifications"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Admin Notifications/i)).toBeInTheDocument();
     expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -154,6 +154,7 @@ const AutomationTimelineV1Page = lazy(() => import("./pages/admin/AutomationTime
 const SupportDebugConsolePage = lazy(() => import("./pages/admin/SupportDebugConsolePage"));
 const AdminTriageQueuePage = lazy(() => import("./pages/admin/AdminTriageQueuePage"));
 const AdminAlertingPage = lazy(() => import("./pages/admin/AdminAlertingPage"));
+const AdminNotificationsPage = lazy(() => import("./pages/admin/AdminNotificationsPage"));
 const PortfolioScorePage = lazy(() => import("./pages/admin/PortfolioScorePage"));
 const PortfolioScoreHistoryPage = lazy(() => import("./pages/admin/PortfolioScoreHistoryPage"));
 const PortfolioHealthSummaryPage = lazy(() => import("./pages/landlord/PortfolioHealthSummaryPage"));
@@ -926,6 +927,14 @@ function App() {
               element={
                 <RequireAdmin>
                   <AdminAlertingPage />
+                </RequireAdmin>
+              }
+            />
+            <Route
+              path="/admin/notifications"
+              element={
+                <RequireAdmin>
+                  <AdminNotificationsPage />
                 </RequireAdmin>
               }
             />

--- a/rentchain-frontend/src/api/adminNotificationApi.ts
+++ b/rentchain-frontend/src/api/adminNotificationApi.ts
@@ -1,0 +1,51 @@
+import { apiFetch } from "./apiFetch";
+
+export type AdminNotificationV1 = {
+  version: "v1";
+  id: string;
+  type: "alert" | "sla_escalation" | "triage_item" | "portfolio_score_change";
+  resource: {
+    type: string;
+    id: string;
+    portfolioId?: string | null;
+  };
+  summary: {
+    title: string;
+    message: string;
+  };
+  severity?: "low" | "medium" | "high" | "critical";
+  watched?: boolean;
+  state: {
+    status: "unread" | "read";
+    readAt?: string | null;
+  };
+  createdAt: string;
+  updatedAt: string;
+  navigation: {
+    supportConsolePath?: string | null;
+    triagePath?: string | null;
+    portfolioScorePath?: string | null;
+  };
+};
+
+export async function fetchNotifications(params?: {
+  unreadOnly?: boolean | null;
+  watchedOnly?: boolean | null;
+  limit?: number | null;
+  cursor?: string | null;
+}): Promise<{ notifications: AdminNotificationV1[]; nextCursor?: string }> {
+  const search = new URLSearchParams();
+  if (typeof params?.unreadOnly === "boolean") search.set("unreadOnly", String(params.unreadOnly));
+  if (typeof params?.watchedOnly === "boolean") search.set("watchedOnly", String(params.watchedOnly));
+  if (typeof params?.limit === "number") search.set("limit", String(params.limit));
+  if (params?.cursor) search.set("cursor", params.cursor);
+  const query = search.toString();
+  return await apiFetch(`/admin/notifications${query ? `?${query}` : ""}`);
+}
+
+export async function markNotificationRead(notificationId: string, payload: { read: boolean }) {
+  return await apiFetch(`/admin/notifications/${encodeURIComponent(notificationId)}/read`, {
+    method: "PATCH",
+    body: JSON.stringify(payload),
+  });
+}

--- a/rentchain-frontend/src/components/adminNotifications/NotificationBadge.tsx
+++ b/rentchain-frontend/src/components/adminNotifications/NotificationBadge.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { Pill } from "../ui/Ui";
+
+export default function NotificationBadge({
+  children,
+  tone,
+}: {
+  children: React.ReactNode;
+  tone?: "critical" | "high" | "medium" | "low" | "default";
+}) {
+  const style =
+    tone === "critical"
+      ? { background: "#fee2e2", color: "#991b1b", borderColor: "transparent" }
+      : tone === "high"
+      ? { background: "#ffedd5", color: "#9a3412", borderColor: "transparent" }
+      : tone === "medium"
+      ? { background: "#fef3c7", color: "#92400e", borderColor: "transparent" }
+      : tone === "low"
+      ? { background: "#e0f2fe", color: "#075985", borderColor: "transparent" }
+      : undefined;
+
+  return <Pill style={style}>{children}</Pill>;
+}

--- a/rentchain-frontend/src/components/adminNotifications/NotificationItem.tsx
+++ b/rentchain-frontend/src/components/adminNotifications/NotificationItem.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import type { AdminNotificationV1 } from "../../api/adminNotificationApi";
+import { Button, Card } from "../ui/Ui";
+import NotificationBadge from "./NotificationBadge";
+
+export default function NotificationItem({
+  notification,
+  onMarkRead,
+}: {
+  notification: AdminNotificationV1;
+  onMarkRead: (notification: AdminNotificationV1) => void | Promise<void>;
+}) {
+  return (
+    <Card style={{ display: "grid", gap: 10 }}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          gap: 12,
+          alignItems: "flex-start",
+          flexWrap: "wrap",
+        }}
+      >
+        <div style={{ display: "grid", gap: 6 }}>
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+            <NotificationBadge tone={notification.severity || "default"}>
+              {notification.severity || notification.type}
+            </NotificationBadge>
+            <NotificationBadge>{notification.state.status}</NotificationBadge>
+            {notification.watched ? <NotificationBadge tone="low">watched</NotificationBadge> : null}
+          </div>
+          <div style={{ fontWeight: 700 }}>{notification.summary.title}</div>
+          <div style={{ color: "#475569" }}>{notification.summary.message}</div>
+        </div>
+        {notification.state.status === "unread" ? (
+          <Button type="button" variant="secondary" onClick={() => void onMarkRead(notification)}>
+            Mark read
+          </Button>
+        ) : null}
+      </div>
+      <div style={{ display: "flex", gap: 12, flexWrap: "wrap", color: "#64748b", fontSize: "0.9rem" }}>
+        <span>{`${notification.resource.type} ${notification.resource.id}`}</span>
+        {notification.navigation.supportConsolePath ? (
+          <a href={notification.navigation.supportConsolePath}>Support console</a>
+        ) : null}
+        {notification.navigation.triagePath ? <a href={notification.navigation.triagePath}>Triage</a> : null}
+        {notification.navigation.portfolioScorePath ? (
+          <a href={notification.navigation.portfolioScorePath}>Portfolio score</a>
+        ) : null}
+      </div>
+    </Card>
+  );
+}

--- a/rentchain-frontend/src/components/adminNotifications/NotificationList.tsx
+++ b/rentchain-frontend/src/components/adminNotifications/NotificationList.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import type { AdminNotificationV1 } from "../../api/adminNotificationApi";
+import NotificationItem from "./NotificationItem";
+
+export default function NotificationList({
+  notifications,
+  onMarkRead,
+}: {
+  notifications: AdminNotificationV1[];
+  onMarkRead: (notification: AdminNotificationV1) => void | Promise<void>;
+}) {
+  if (!notifications.length) {
+    return <div>No notifications are active right now.</div>;
+  }
+
+  return (
+    <div style={{ display: "grid", gap: 12 }}>
+      {notifications.map((notification) => (
+        <NotificationItem
+          key={notification.id}
+          notification={notification}
+          onMarkRead={onMarkRead}
+        />
+      ))}
+    </div>
+  );
+}

--- a/rentchain-frontend/src/pages/admin/AdminNotificationsPage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminNotificationsPage.test.tsx
@@ -1,0 +1,143 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import AdminNotificationsPage from "./AdminNotificationsPage";
+
+const showToast = vi.fn();
+
+vi.mock("../../api/adminNotificationApi", () => ({
+  fetchNotifications: vi.fn(),
+  markNotificationRead: vi.fn(),
+}));
+
+vi.mock("../../components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast }),
+}));
+
+vi.mock("../../components/layout/MacShell", () => ({
+  MacShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("../../components/ui/Ui", () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  Pill: ({ children }: any) => <span>{children}</span>,
+  Section: ({ children }: any) => <section>{children}</section>,
+}));
+
+beforeEach(() => {
+  showToast.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("AdminNotificationsPage", () => {
+  it("renders notifications and navigation links", async () => {
+    const { fetchNotifications } = await import("../../api/adminNotificationApi");
+    vi.mocked(fetchNotifications).mockResolvedValue({
+      notifications: [
+        {
+          version: "v1",
+          id: "notification-1",
+          type: "sla_escalation",
+          resource: { type: "application", id: "app-1", portfolioId: "portfolio-1" },
+          summary: {
+            title: "Issue is overdue",
+            message: "Screening reconciliation signals are inconsistent.",
+          },
+          severity: "critical",
+          watched: true,
+          state: { status: "unread", readAt: null },
+          createdAt: "2026-04-16T12:00:00.000Z",
+          updatedAt: "2026-04-16T12:00:00.000Z",
+          navigation: {
+            supportConsolePath: "/admin/support-console?resourceType=application&resourceId=app-1",
+            triagePath: "/admin/triage?resourceType=application",
+            portfolioScorePath: "/admin/portfolio-score?portfolioId=portfolio-1",
+          },
+        },
+      ],
+    } as any);
+
+    render(
+      <MemoryRouter>
+        <AdminNotificationsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Issue is overdue/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/watched/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Support console/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Triage/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Portfolio score/i })).toBeInTheDocument();
+  });
+
+  it("supports unread and watched filters plus read state updates", async () => {
+    const { fetchNotifications, markNotificationRead } = await import("../../api/adminNotificationApi");
+    vi.mocked(fetchNotifications).mockResolvedValue({
+      notifications: [
+        {
+          version: "v1",
+          id: "notification-1",
+          type: "triage_item",
+          resource: { type: "application", id: "app-1" },
+          summary: { title: "Critical issue needs attention", message: "Policy blocked an important action." },
+          severity: "high",
+          watched: false,
+          state: { status: "unread", readAt: null },
+          createdAt: "2026-04-16T12:00:00.000Z",
+          updatedAt: "2026-04-16T12:00:00.000Z",
+          navigation: {},
+        },
+      ],
+    } as any);
+    vi.mocked(markNotificationRead).mockResolvedValue({ state: { status: "read" } } as any);
+
+    render(
+      <MemoryRouter>
+        <AdminNotificationsPage />
+      </MemoryRouter>
+    );
+
+    await screen.findByText(/Critical issue needs attention/i);
+
+    fireEvent.click(screen.getByLabelText(/Watched only/i));
+    await waitFor(() => {
+      expect(vi.mocked(fetchNotifications)).toHaveBeenLastCalledWith(
+        expect.objectContaining({ watchedOnly: true })
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Mark read/i }));
+    await waitFor(() => {
+      expect(markNotificationRead).toHaveBeenCalledWith("notification-1", { read: true });
+    });
+  });
+
+  it("renders empty and error states safely", async () => {
+    const { fetchNotifications } = await import("../../api/adminNotificationApi");
+    vi.mocked(fetchNotifications).mockResolvedValueOnce({ notifications: [] } as any);
+
+    render(
+      <MemoryRouter>
+        <AdminNotificationsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/No notifications are active right now/i)).toBeInTheDocument();
+
+    cleanup();
+    vi.mocked(fetchNotifications).mockRejectedValueOnce(new Error("Boom"));
+    render(
+      <MemoryRouter>
+        <AdminNotificationsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Failed to load notifications: Boom/i)).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/admin/AdminNotificationsPage.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminNotificationsPage.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { fetchNotifications, markNotificationRead, type AdminNotificationV1 } from "../../api/adminNotificationApi";
+import { MacShell } from "../../components/layout/MacShell";
+import { Button, Card, Pill, Section } from "../../components/ui/Ui";
+import { useToast } from "../../components/ui/ToastProvider";
+import NotificationList from "../../components/adminNotifications/NotificationList";
+
+export default function AdminNotificationsPage() {
+  const { showToast } = useToast();
+  const [notifications, setNotifications] = React.useState<AdminNotificationV1[]>([]);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [unreadOnly, setUnreadOnly] = React.useState(true);
+  const [watchedOnly, setWatchedOnly] = React.useState(false);
+
+  const load = React.useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const response = await fetchNotifications({
+        unreadOnly,
+        watchedOnly,
+        limit: 25,
+      });
+      setNotifications(response.notifications || []);
+    } catch (err: any) {
+      const message = err?.message || "Failed to load notifications";
+      setError(message);
+      showToast({
+        message: "Failed to load notifications",
+        description: message,
+        variant: "error",
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [showToast, unreadOnly, watchedOnly]);
+
+  React.useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleMarkRead = async (notification: AdminNotificationV1) => {
+    await markNotificationRead(notification.id, { read: true });
+    await load();
+  };
+
+  return (
+    <MacShell title="Admin · Notifications">
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 16, alignItems: "flex-start", flexWrap: "wrap" }}>
+            <div style={{ display: "grid", gap: 6 }}>
+              <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+                <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Admin Notifications</h1>
+                <Pill tone="accent">Delivery</Pill>
+              </div>
+              <div style={{ color: "#475569", maxWidth: 820 }}>
+                Pull-based internal delivery for alerts, SLA pressure, triage-worthy issues, and portfolio score changes.
+              </div>
+            </div>
+            <Button variant="secondary" onClick={() => void load()} disabled={loading}>
+              Refresh
+            </Button>
+          </div>
+        </Section>
+
+        <Card>
+          <div style={{ display: "flex", gap: 16, flexWrap: "wrap", alignItems: "center" }}>
+            <label style={{ display: "flex", gap: 8, alignItems: "center" }}>
+              <input
+                aria-label="Unread only"
+                type="checkbox"
+                checked={unreadOnly}
+                onChange={(event) => setUnreadOnly(event.target.checked)}
+              />
+              Unread only
+            </label>
+            <label style={{ display: "flex", gap: 8, alignItems: "center" }}>
+              <input
+                aria-label="Watched only"
+                type="checkbox"
+                checked={watchedOnly}
+                onChange={(event) => setWatchedOnly(event.target.checked)}
+              />
+              Watched only
+            </label>
+          </div>
+        </Card>
+
+        {loading ? <Card>Loading notifications…</Card> : null}
+        {!loading && error ? <Card style={{ color: "#b91c1c" }}>Failed to load notifications: {error}</Card> : null}
+        {!loading && !error ? (
+          <NotificationList notifications={notifications} onMarkRead={handleMarkRead} />
+        ) : null}
+      </div>
+    </MacShell>
+  );
+}


### PR DESCRIPTION
## Summary
Adds Internal Notifications / Watcher Delivery v1 as an admin-only in-product notification layer.

This introduces derived internal notifications from existing operational signals, persisted read/unread state, watchlist-aware prioritization, and a new admin notifications page so important issues can be surfaced proactively without adding external delivery channels or duplicating alert logic.

## Scope
- Adds `notificationTypes`, notification derivation, and notification state helpers under `src/lib/notifications`
- Adds admin endpoints for:
  - `GET /api/admin/notifications`
  - `PATCH /api/admin/notifications/:notificationId/read`
- Persists notification read/unread state in a new `adminNotifications` collection
- Derives notifications from existing signals, including:
  - admin alerts
  - SLA escalation / overdue context
  - triage-worthy operational signals
  - portfolio score change alerts
- Reuses existing watchlist state to mark watched notifications and support watcher-aware prioritization
- Adds a new admin page at:
  - `/admin/notifications`
- Renders:
  - notification list
  - severity
  - unread/read state
  - watched indicator
  - navigation links into support console, triage, and portfolio score where relevant
- Adds targeted backend and frontend tests for:
  - notification derivation
  - read/unread persistence
  - watched flag/filter behavior
  - admin-only access
  - page rendering, navigation, and empty/error states

## Notes
This is intentionally admin-only, additive, and pull-based. No emails, SMS, push notifications, schedulers, or real-time infrastructure were added.

The notification layer does not duplicate alert logic. It derives delivery from existing alert/SLA/triage/portfolio-score signals and stores only notification state such as read/unread.

For v1, notifications may still appear globally for admins even when not watched, while watched resources and portfolios receive explicit watched prioritization through the `watched` flag and `watchedOnly` filter.

## Validation
- Passed targeted backend notifications tests
- Passed backend build
- Passed targeted frontend notifications and route tests
- Passed full frontend test suite
- Passed frontend build