### PR TITLE
feat: add tenant and applicant feedback loop v1

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -112,6 +112,7 @@ import portfolioScoreHistoryRoutes from "./routes/portfolioScoreHistoryRoutes";
 import landlordPortfolioHealthRoutes from "./routes/landlordPortfolioHealthRoutes";
 import landlordPortfolioScoreRoutes from "./routes/landlordPortfolioScoreRoutes";
 import landlordActionRecommendationRoutes from "./routes/landlordActionRecommendationRoutes";
+import tenantFeedbackRoutes from "./routes/tenantFeedbackRoutes";
 import transunionRoutes from "./services/integrations/transunion/transunionRoutes";
 import viewingRoutes from "./routes/viewingRoutes";
 import screeningOpsRoutes from "./routes/screeningOpsRoutes";
@@ -255,6 +256,8 @@ app.use("/api", routeSource("landlordPortfolioScoreRoutes.ts"), landlordPortfoli
 console.log("[route-mount] landlordPortfolioScoreRoutes mounted at /api");
 app.use("/api", routeSource("landlordActionRecommendationRoutes.ts"), landlordActionRecommendationRoutes);
 console.log("[route-mount] landlordActionRecommendationRoutes mounted at /api");
+app.use("/api", routeSource("tenantFeedbackRoutes.ts"), tenantFeedbackRoutes);
+console.log("[route-mount] tenantFeedbackRoutes mounted at /api");
 
 // Current user info
 app.get("/api/me", async (req: any, res: any, next: any) => {

--- a/rentchain-api/src/lib/feedback/__tests__/deriveFeedbackSignals.test.ts
+++ b/rentchain-api/src/lib/feedback/__tests__/deriveFeedbackSignals.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { deriveFeedbackSignals } from "../deriveFeedbackSignals";
+
+describe("deriveFeedbackSignals", () => {
+  it("aggregates sentiment ratios and dominant sentiment", () => {
+    const signals = deriveFeedbackSignals([
+      {
+        version: "v1",
+        id: "f1",
+        type: "screening_experience",
+        resource: { type: "screening_order", id: "screen-1", portfolioId: "landlord-1" },
+        sentiment: "positive",
+        tags: [],
+        createdAt: "2026-04-16T12:00:00.000Z",
+      },
+      {
+        version: "v1",
+        id: "f2",
+        type: "screening_experience",
+        resource: { type: "screening_order", id: "screen-2", portfolioId: "landlord-1" },
+        sentiment: "negative",
+        tags: [],
+        createdAt: "2026-04-16T12:00:00.000Z",
+      },
+      {
+        version: "v1",
+        id: "f3",
+        type: "screening_experience",
+        resource: { type: "screening_order", id: "screen-3", portfolioId: "landlord-1" },
+        sentiment: "positive",
+        tags: [],
+        createdAt: "2026-04-16T12:00:00.000Z",
+      },
+    ]);
+
+    expect(signals).toEqual([
+      expect.objectContaining({
+        type: "screening_experience",
+        positiveRatio: 0.67,
+        negativeRatio: 0.33,
+        dominant: "positive",
+        signalStrength: "weak",
+      }),
+    ]);
+  });
+
+  it("returns empty when no feedback exists", () => {
+    expect(deriveFeedbackSignals([])).toEqual([]);
+  });
+});

--- a/rentchain-api/src/lib/feedback/deriveFeedbackSignals.ts
+++ b/rentchain-api/src/lib/feedback/deriveFeedbackSignals.ts
@@ -1,0 +1,50 @@
+import type {
+  AggregatedFeedbackSignalV1,
+  FeedbackSentiment,
+  FeedbackType,
+  TenantFeedbackV1,
+} from "./feedbackTypes";
+
+const FEEDBACK_TYPES: FeedbackType[] = [
+  "application_experience",
+  "screening_experience",
+  "maintenance_experience",
+  "communication_experience",
+];
+
+function ratio(count: number, total: number) {
+  return total > 0 ? Number((count / total).toFixed(2)) : 0;
+}
+
+function dominantSentiment(counts: Record<FeedbackSentiment, number>): FeedbackSentiment {
+  if (counts.negative > counts.positive && counts.negative >= counts.neutral) return "negative";
+  if (counts.positive >= counts.neutral) return "positive";
+  return "neutral";
+}
+
+function signalStrength(total: number): AggregatedFeedbackSignalV1["signalStrength"] {
+  if (total >= 8) return "strong";
+  if (total >= 4) return "moderate";
+  return "weak";
+}
+
+export function deriveFeedbackSignals(feedback: TenantFeedbackV1[]): AggregatedFeedbackSignalV1[] {
+  return FEEDBACK_TYPES.map((type) => {
+    const items = feedback.filter((entry) => entry.type === type);
+    const counts: Record<FeedbackSentiment, number> = {
+      positive: items.filter((entry) => entry.sentiment === "positive").length,
+      neutral: items.filter((entry) => entry.sentiment === "neutral").length,
+      negative: items.filter((entry) => entry.sentiment === "negative").length,
+    };
+    const total = items.length;
+
+    return {
+      type,
+      positiveRatio: ratio(counts.positive, total),
+      neutralRatio: ratio(counts.neutral, total),
+      negativeRatio: ratio(counts.negative, total),
+      dominant: dominantSentiment(counts),
+      signalStrength: signalStrength(total),
+    };
+  }).filter((signal) => signal.positiveRatio || signal.neutralRatio || signal.negativeRatio);
+}

--- a/rentchain-api/src/lib/feedback/deriveLandlordFeedbackSummary.ts
+++ b/rentchain-api/src/lib/feedback/deriveLandlordFeedbackSummary.ts
@@ -1,0 +1,50 @@
+import type { PortfolioHealthStatus } from "../portfolioHealth/portfolioHealthTypes";
+import type { AggregatedFeedbackSignalV1, LandlordFeedbackSummaryV1 } from "./feedbackTypes";
+
+export function deriveLandlordFeedbackSummary(signals: AggregatedFeedbackSignalV1[]): LandlordFeedbackSummaryV1 & {
+  dimensionAdjustments: Partial<
+    Record<"screening_health" | "maintenance_health" | "response_health", PortfolioHealthStatus>
+  >;
+} {
+  const summaries: string[] = [];
+  const dimensionAdjustments: Partial<
+    Record<"screening_health" | "maintenance_health" | "response_health", PortfolioHealthStatus>
+  > = {};
+
+  for (const signal of signals) {
+    if (signal.type === "screening_experience") {
+      if (signal.dominant === "positive" && signal.signalStrength !== "weak") {
+        summaries.push("Applicants generally report a smooth screening experience.");
+      } else if (signal.dominant === "negative") {
+        summaries.push("Some applicants experienced less consistent screening follow-through.");
+        dimensionAdjustments.screening_health =
+          signal.signalStrength === "strong" ? "attention_needed" : "watch";
+      }
+    }
+
+    if (signal.type === "maintenance_experience") {
+      if (signal.dominant === "positive" && signal.signalStrength !== "weak") {
+        summaries.push("Tenants generally describe maintenance follow-through as steady.");
+      } else if (signal.dominant === "negative") {
+        summaries.push("Some tenants experienced slower maintenance follow-through.");
+        dimensionAdjustments.maintenance_health =
+          signal.signalStrength === "strong" ? "attention_needed" : "watch";
+      }
+    }
+
+    if (signal.type === "communication_experience") {
+      if (signal.dominant === "positive" && signal.signalStrength !== "weak") {
+        summaries.push("Communication patterns appear generally consistent.");
+      } else if (signal.dominant === "negative") {
+        summaries.push("Some recent feedback suggests communication consistency may need attention.");
+        dimensionAdjustments.response_health =
+          signal.signalStrength === "strong" ? "attention_needed" : "watch";
+      }
+    }
+  }
+
+  return {
+    summaries: summaries.slice(0, 3),
+    dimensionAdjustments,
+  };
+}

--- a/rentchain-api/src/lib/feedback/feedbackTypes.ts
+++ b/rentchain-api/src/lib/feedback/feedbackTypes.ts
@@ -1,0 +1,41 @@
+export type FeedbackType =
+  | "application_experience"
+  | "screening_experience"
+  | "maintenance_experience"
+  | "communication_experience";
+
+export type FeedbackSentiment =
+  | "positive"
+  | "neutral"
+  | "negative";
+
+export type TenantFeedbackV1 = {
+  version: "v1";
+  id: string;
+  type: FeedbackType;
+  resource: {
+    type: string;
+    id: string;
+    portfolioId?: string | null;
+  };
+  sentiment: FeedbackSentiment;
+  tags: string[];
+  notes?: string | null;
+  createdAt: string;
+  metadata?: {
+    tenantId?: string | null;
+  };
+};
+
+export type AggregatedFeedbackSignalV1 = {
+  type: FeedbackType;
+  positiveRatio: number;
+  neutralRatio: number;
+  negativeRatio: number;
+  dominant: FeedbackSentiment;
+  signalStrength: "weak" | "moderate" | "strong";
+};
+
+export type LandlordFeedbackSummaryV1 = {
+  summaries: string[];
+};

--- a/rentchain-api/src/lib/feedback/loadFeedbackSignals.ts
+++ b/rentchain-api/src/lib/feedback/loadFeedbackSignals.ts
@@ -1,0 +1,21 @@
+import { db } from "../../config/firebase";
+import type { TenantFeedbackV1 } from "./feedbackTypes";
+
+const TENANT_FEEDBACK_COLLECTION = "tenantFeedback";
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+export async function loadFeedbackSignals(portfolioId: string, limit = 200): Promise<TenantFeedbackV1[]> {
+  const safePortfolioId = asString(portfolioId, 240);
+  if (!safePortfolioId) return [];
+
+  const snap = await db
+    .collection(TENANT_FEEDBACK_COLLECTION)
+    .where("resource.portfolioId", "==", safePortfolioId)
+    .limit(Math.max(1, Math.min(limit, 500)))
+    .get();
+
+  return snap.docs.map((doc: any) => ({ id: doc.id, ...(doc.data() as any) })) as TenantFeedbackV1[];
+}

--- a/rentchain-api/src/lib/feedback/resolveFeedbackResourceScope.ts
+++ b/rentchain-api/src/lib/feedback/resolveFeedbackResourceScope.ts
@@ -1,0 +1,93 @@
+import { db } from "../../config/firebase";
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+export async function resolveFeedbackResourceScope(input: {
+  tenantId: string;
+  email?: string | null;
+  resourceType: string;
+  resourceId: string;
+}) {
+  const tenantId = asString(input.tenantId, 240);
+  const email = asString(input.email, 240).toLowerCase();
+  const resourceType = asString(input.resourceType, 80).toLowerCase();
+  const resourceId = asString(input.resourceId, 240);
+
+  if (!tenantId || !resourceType || !resourceId) return null;
+
+  if (resourceType === "maintenance" || resourceType === "maintenance_request") {
+    const snap = await db.collection("maintenanceRequests").doc(resourceId).get();
+    const data = snap.data() as any;
+    if (!snap.exists || asString(data?.tenantId, 240) !== tenantId) return null;
+    return {
+      resourceType: "maintenance",
+      resourceId,
+      portfolioId: asString(data?.landlordId, 240) || null,
+    };
+  }
+
+  if (resourceType === "application") {
+    const snap = await db.collection("applications").doc(resourceId).get();
+    const data = snap.data() as any;
+    const applicantEmail = asString(data?.applicantEmail, 240).toLowerCase();
+    const matchesTenant =
+      asString(data?.tenantId, 240) === tenantId ||
+      (email && applicantEmail && applicantEmail === email);
+    if (!snap.exists || !matchesTenant) return null;
+    return {
+      resourceType: "application",
+      resourceId,
+      portfolioId: asString(data?.landlordId, 240) || null,
+    };
+  }
+
+  if (resourceType === "lease") {
+    const snap = await db.collection("leases").doc(resourceId).get();
+    const data = snap.data() as any;
+    const tenantIds = Array.isArray(data?.tenantIds) ? data.tenantIds.map((item: any) => asString(item, 240)) : [];
+    const matchesTenant =
+      asString(data?.tenantId, 240) === tenantId ||
+      tenantIds.includes(tenantId);
+    if (!snap.exists || !matchesTenant) return null;
+    return {
+      resourceType: "lease",
+      resourceId,
+      portfolioId: asString(data?.landlordId, 240) || null,
+    };
+  }
+
+  if (resourceType === "screening_order" || resourceType === "screening") {
+    const screeningSnap = await db.collection("screeningOrders").doc(resourceId).get();
+    const screening = screeningSnap.data() as any;
+    if (!screeningSnap.exists) return null;
+
+    const applicationId = asString(screening?.applicationId, 240);
+    if (!applicationId) {
+      const applicantEmail = asString(screening?.applicantEmail || screening?.email, 240).toLowerCase();
+      if (!email || !applicantEmail || applicantEmail !== email) return null;
+      return {
+        resourceType: "screening_order",
+        resourceId,
+        portfolioId: asString(screening?.landlordId, 240) || null,
+      };
+    }
+
+    const applicationSnap = await db.collection("applications").doc(applicationId).get();
+    const application = applicationSnap.data() as any;
+    const applicantEmail = asString(application?.applicantEmail, 240).toLowerCase();
+    const matchesTenant =
+      applicationSnap.exists &&
+      (asString(application?.tenantId, 240) === tenantId || (email && applicantEmail === email));
+    if (!matchesTenant) return null;
+
+    return {
+      resourceType: "screening_order",
+      resourceId,
+      portfolioId: asString(screening?.landlordId || application?.landlordId, 240) || null,
+    };
+  }
+
+  return null;
+}

--- a/rentchain-api/src/lib/feedback/saveTenantFeedback.ts
+++ b/rentchain-api/src/lib/feedback/saveTenantFeedback.ts
@@ -1,0 +1,49 @@
+import { db } from "../../config/firebase";
+import type { FeedbackSentiment, FeedbackType, TenantFeedbackV1 } from "./feedbackTypes";
+
+const TENANT_FEEDBACK_COLLECTION = "tenantFeedback";
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function sanitizeTags(tags: unknown): string[] {
+  if (!Array.isArray(tags)) return [];
+  return tags
+    .map((tag) => asString(tag, 64).toLowerCase())
+    .filter(Boolean)
+    .slice(0, 8);
+}
+
+export async function saveTenantFeedback(input: {
+  type: FeedbackType;
+  resourceType: string;
+  resourceId: string;
+  portfolioId?: string | null;
+  sentiment: FeedbackSentiment;
+  tags?: string[];
+  notes?: string | null;
+  tenantId?: string | null;
+}) {
+  const ref = db.collection(TENANT_FEEDBACK_COLLECTION).doc();
+  const record: TenantFeedbackV1 = {
+    version: "v1",
+    id: ref.id,
+    type: input.type,
+    resource: {
+      type: asString(input.resourceType, 80),
+      id: asString(input.resourceId, 240),
+      portfolioId: asString(input.portfolioId, 240) || null,
+    },
+    sentiment: input.sentiment,
+    tags: sanitizeTags(input.tags),
+    notes: asString(input.notes, 500) || null,
+    createdAt: new Date().toISOString(),
+    metadata: {
+      tenantId: asString(input.tenantId, 240) || null,
+    },
+  };
+
+  await ref.set(record);
+  return record;
+}

--- a/rentchain-api/src/lib/portfolioHealth/__tests__/deriveLandlordPortfolioHealthSummary.test.ts
+++ b/rentchain-api/src/lib/portfolioHealth/__tests__/deriveLandlordPortfolioHealthSummary.test.ts
@@ -129,4 +129,25 @@ describe("deriveLandlordPortfolioHealthSummary", () => {
     expect(summary.overall.summary).toMatch(/still developing/i);
     expect(summary.trend.summary).toMatch(/Trend visibility will improve/i);
   });
+
+  it("adds landlord-safe feedback summaries without exposing raw feedback", () => {
+    const summary = deriveLandlordPortfolioHealthSummary({
+      portfolioScore: buildScore(),
+      portfolioTrend: buildTrend({ direction: "flat" }),
+      feedbackSignals: [
+        {
+          type: "maintenance_experience",
+          positiveRatio: 0.1,
+          neutralRatio: 0.2,
+          negativeRatio: 0.7,
+          dominant: "negative",
+          signalStrength: "moderate",
+        },
+      ],
+    });
+
+    expect(summary.feedback?.summaries[0]).toMatch(/Some tenants experienced slower maintenance follow-through/i);
+    expect(summary.feedback?.summaries[0]).not.toMatch(/tenant-|slow_response|0\.7|count/i);
+    expect(summary.dimensions.find((dimension) => dimension.key === "maintenance_health")?.status).toBe("watch");
+  });
 });

--- a/rentchain-api/src/lib/portfolioHealth/deriveLandlordPortfolioHealthSummary.ts
+++ b/rentchain-api/src/lib/portfolioHealth/deriveLandlordPortfolioHealthSummary.ts
@@ -1,5 +1,7 @@
 import type { PortfolioScoreComponent, PortfolioScoreV1 } from "../portfolioScore/portfolioScoreTypes";
 import type { PortfolioScoreTrendV1 } from "../portfolioScoreHistory/portfolioScoreHistoryTypes";
+import type { AggregatedFeedbackSignalV1 } from "../feedback/feedbackTypes";
+import { deriveLandlordFeedbackSummary } from "../feedback/deriveLandlordFeedbackSummary";
 import {
   mapOverallStatus,
   mapTrendDirection,
@@ -26,9 +28,13 @@ function componentScore(
   return components.find((component) => component.key === key)?.normalizedScore ?? fallback;
 }
 
-function screeningDimension(score: PortfolioScoreV1): PortfolioHealthDimensionV1 {
+function screeningDimension(
+  score: PortfolioScoreV1,
+  feedbackAdjustment?: PortfolioHealthStatus | null
+): PortfolioHealthDimensionV1 {
   const screeningScore = componentScore(score.components, "screening_reliability");
-  const status = statusFromComponentScore(screeningScore);
+  const baseStatus = statusFromComponentScore(screeningScore);
+  const status = feedbackAdjustment || baseStatus;
   return {
     key: "screening_health",
     label: "Screening health",
@@ -42,9 +48,13 @@ function screeningDimension(score: PortfolioScoreV1): PortfolioHealthDimensionV1
   };
 }
 
-function maintenanceDimension(score: PortfolioScoreV1): PortfolioHealthDimensionV1 {
+function maintenanceDimension(
+  score: PortfolioScoreV1,
+  feedbackAdjustment?: PortfolioHealthStatus | null
+): PortfolioHealthDimensionV1 {
   const maintenanceScore = componentScore(score.components, "maintenance_stability");
-  const status = statusFromComponentScore(maintenanceScore);
+  const baseStatus = statusFromComponentScore(maintenanceScore);
+  const status = feedbackAdjustment || baseStatus;
   return {
     key: "maintenance_health",
     label: "Maintenance health",
@@ -76,14 +86,19 @@ function workflowDimension(score: PortfolioScoreV1): PortfolioHealthDimensionV1 
   };
 }
 
-function responseDimension(score: PortfolioScoreV1, trend: PortfolioHealthTrend): PortfolioHealthDimensionV1 {
+function responseDimension(
+  score: PortfolioScoreV1,
+  trend: PortfolioHealthTrend,
+  feedbackAdjustment?: PortfolioHealthStatus | null
+): PortfolioHealthDimensionV1 {
   const workflowScore = componentScore(score.components, "workflow_completion");
   const automationScore = componentScore(score.components, "automation_health");
   const blended = Math.round((workflowScore + automationScore) / 2);
-  const status =
+  const baseStatus =
     trend === "declining"
       ? (statusFromComponentScore(Math.max(0, blended - 15)) as PortfolioHealthStatus)
       : statusFromComponentScore(blended);
+  const status = feedbackAdjustment || baseStatus;
 
   return {
     key: "response_health",
@@ -166,18 +181,20 @@ function buildNextFocus(
 export function deriveLandlordPortfolioHealthSummary(input: {
   portfolioScore: PortfolioScoreV1;
   portfolioTrend: PortfolioScoreTrendV1;
+  feedbackSignals?: AggregatedFeedbackSignalV1[];
 }): LandlordPortfolioHealthSummaryV1 {
   const { portfolioScore, portfolioTrend } = input;
   const totalResourcesReviewed = portfolioScore.metrics.totalResourcesReviewed;
   const sparseData = totalResourcesReviewed < PORTFOLIO_HEALTH_SPARSE_DATA_THRESHOLD;
   const overallStatus = mapOverallStatus(portfolioScore.summary.status);
   const trendDirection = mapTrendDirection(portfolioTrend.direction);
+  const feedbackSummary = deriveLandlordFeedbackSummary(input.feedbackSignals || []);
 
   const dimensions: PortfolioHealthDimensionV1[] = [
-    screeningDimension(portfolioScore),
-    maintenanceDimension(portfolioScore),
+    screeningDimension(portfolioScore, feedbackSummary.dimensionAdjustments.screening_health),
+    maintenanceDimension(portfolioScore, feedbackSummary.dimensionAdjustments.maintenance_health),
     workflowDimension(portfolioScore),
-    responseDimension(portfolioScore, trendDirection),
+    responseDimension(portfolioScore, trendDirection, feedbackSummary.dimensionAdjustments.response_health),
   ];
 
   return {
@@ -198,6 +215,12 @@ export function deriveLandlordPortfolioHealthSummary(input: {
     },
     dimensions,
     nextFocus: buildNextFocus(dimensions, trendDirection, sparseData),
+    feedback:
+      feedbackSummary.summaries.length > 0
+        ? {
+            summaries: feedbackSummary.summaries,
+          }
+        : undefined,
     metadata: {
       portfolioScoreGrade: portfolioScore.grade || null,
       portfolioScoreAvailable: true,

--- a/rentchain-api/src/lib/portfolioHealth/loadLandlordPortfolioHealthInputs.ts
+++ b/rentchain-api/src/lib/portfolioHealth/loadLandlordPortfolioHealthInputs.ts
@@ -2,6 +2,8 @@ import { derivePortfolioScore } from "../portfolioScore/derivePortfolioScore";
 import { loadPortfolioScoreSignals } from "../portfolioScore/loadPortfolioScoreSignals";
 import { derivePortfolioScoreTrend } from "../portfolioScoreHistory/derivePortfolioScoreTrend";
 import { loadPortfolioScoreHistory } from "../portfolioScoreHistory/loadPortfolioScoreHistory";
+import { loadFeedbackSignals } from "../feedback/loadFeedbackSignals";
+import { deriveFeedbackSignals } from "../feedback/deriveFeedbackSignals";
 
 function asString(value: unknown, max = 240) {
   return String(value || "").trim().slice(0, max);
@@ -15,9 +17,11 @@ export async function loadLandlordPortfolioHealthInputs(portfolioId: string) {
   ]);
   const portfolioScore = derivePortfolioScore(signals);
   const portfolioTrend = derivePortfolioScoreTrend(history, safePortfolioId);
+  const feedbackSignals = deriveFeedbackSignals(await loadFeedbackSignals(safePortfolioId, 120));
   return {
     portfolioId: safePortfolioId,
     portfolioScore,
     portfolioTrend,
+    feedbackSignals,
   };
 }

--- a/rentchain-api/src/lib/portfolioHealth/portfolioHealthTypes.ts
+++ b/rentchain-api/src/lib/portfolioHealth/portfolioHealthTypes.ts
@@ -39,6 +39,9 @@ export type LandlordPortfolioHealthSummaryV1 = {
     label: string;
     summary: string;
   }>;
+  feedback?: {
+    summaries: string[];
+  };
   metadata?: {
     portfolioScoreGrade?: string | null;
     portfolioScoreAvailable: boolean;

--- a/rentchain-api/src/routes/__tests__/feedbackRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/feedbackRoutes.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const resolveFeedbackResourceScope = vi.fn();
+const saveTenantFeedback = vi.fn();
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!req.user) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    return next();
+  },
+}));
+
+vi.mock("../../lib/feedback/resolveFeedbackResourceScope", () => ({
+  resolveFeedbackResourceScope,
+}));
+
+vi.mock("../../lib/feedback/saveTenantFeedback", () => ({
+  saveTenantFeedback,
+}));
+
+async function invokeRouter(
+  router: any,
+  options: { method: string; url: string; user?: Record<string, unknown> | null; body?: any }
+) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path: options.url,
+      user: options.user ?? null,
+      body: options.body ?? {},
+      headers: {},
+      get(name: string) {
+        return this.headers[String(name).toLowerCase()];
+      },
+      header(name: string) {
+        return this.get(name);
+      },
+    };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("tenantFeedbackRoutes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolveFeedbackResourceScope.mockResolvedValue({
+      resourceType: "maintenance",
+      resourceId: "maint-1",
+      portfolioId: "landlord-1",
+    });
+    saveTenantFeedback.mockResolvedValue({
+      id: "feedback-1",
+      createdAt: "2026-04-16T12:00:00.000Z",
+    });
+  });
+
+  it("submits feedback successfully for a tenant-scoped resource", async () => {
+    const router = (await import("../tenantFeedbackRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "POST",
+      url: "/tenant/feedback",
+      user: { id: "tenant-1", tenantId: "tenant-1", role: "tenant", email: "tenant@example.com" },
+      body: {
+        type: "maintenance_experience",
+        resourceType: "maintenance",
+        resourceId: "maint-1",
+        sentiment: "negative",
+        tags: ["slow_response"],
+        notes: "Took longer than expected.",
+      },
+    });
+
+    expect(response.status).toBe(201);
+    expect(saveTenantFeedback).toHaveBeenCalled();
+    expect(response.body.feedback.id).toBe("feedback-1");
+  });
+
+  it("rejects invalid input", async () => {
+    const router = (await import("../tenantFeedbackRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "POST",
+      url: "/tenant/feedback",
+      user: { id: "tenant-1", tenantId: "tenant-1", role: "tenant" },
+      body: {
+        type: "bad_type",
+        resourceType: "maintenance",
+        resourceId: "maint-1",
+        sentiment: "negative",
+      },
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("enforces tenant-only access and resource scope", async () => {
+    const router = (await import("../tenantFeedbackRoutes")).default;
+
+    const unauthorized = await invokeRouter(router, {
+      method: "POST",
+      url: "/tenant/feedback",
+      user: { id: "landlord-1", role: "landlord" },
+      body: {},
+    });
+    expect(unauthorized.status).toBe(401);
+
+    resolveFeedbackResourceScope.mockResolvedValueOnce(null);
+    const forbidden = await invokeRouter(router, {
+      method: "POST",
+      url: "/tenant/feedback",
+      user: { id: "tenant-1", tenantId: "tenant-1", role: "tenant" },
+      body: {
+        type: "maintenance_experience",
+        resourceType: "maintenance",
+        resourceId: "maint-1",
+        sentiment: "positive",
+      },
+    });
+    expect(forbidden.status).toBe(403);
+  });
+});

--- a/rentchain-api/src/routes/tenantFeedbackRoutes.ts
+++ b/rentchain-api/src/routes/tenantFeedbackRoutes.ts
@@ -1,0 +1,76 @@
+import { Router } from "express";
+import { requireAuth } from "../middleware/requireAuth";
+import { resolveFeedbackResourceScope } from "../lib/feedback/resolveFeedbackResourceScope";
+import { saveTenantFeedback } from "../lib/feedback/saveTenantFeedback";
+import type { FeedbackSentiment, FeedbackType } from "../lib/feedback/feedbackTypes";
+
+const router = Router();
+
+const FEEDBACK_TYPES: FeedbackType[] = [
+  "application_experience",
+  "screening_experience",
+  "maintenance_experience",
+  "communication_experience",
+];
+
+const FEEDBACK_SENTIMENTS: FeedbackSentiment[] = ["positive", "neutral", "negative"];
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function requireTenant(req: any, res: any, next: any) {
+  const role = asString(req.user?.role, 80).toLowerCase();
+  const tenantId = asString(req.user?.tenantId || req.user?.id, 240);
+  if (!tenantId || role !== "tenant") {
+    return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+  }
+  req.user.tenantId = tenantId;
+  return next();
+}
+
+router.post("/tenant/feedback", requireAuth, requireTenant, async (req: any, res) => {
+  try {
+    const type = asString(req.body?.type, 80) as FeedbackType;
+    const resourceType = asString(req.body?.resourceType, 80);
+    const resourceId = asString(req.body?.resourceId, 240);
+    const sentiment = asString(req.body?.sentiment, 40) as FeedbackSentiment;
+    const tags = Array.isArray(req.body?.tags) ? req.body.tags : [];
+    const notes = asString(req.body?.notes, 500) || null;
+
+    if (!FEEDBACK_TYPES.includes(type) || !resourceType || !resourceId || !FEEDBACK_SENTIMENTS.includes(sentiment)) {
+      return res.status(400).json({ ok: false, error: "INVALID_FEEDBACK_INPUT" });
+    }
+
+    const tenantId = asString(req.user?.tenantId || req.user?.id, 240);
+    const email = asString(req.user?.email, 240);
+    const scope = await resolveFeedbackResourceScope({
+      tenantId,
+      email,
+      resourceType,
+      resourceId,
+    });
+
+    if (!scope?.portfolioId) {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+
+    const feedback = await saveTenantFeedback({
+      type,
+      resourceType: scope.resourceType,
+      resourceId: scope.resourceId,
+      portfolioId: scope.portfolioId,
+      sentiment,
+      tags,
+      notes,
+      tenantId,
+    });
+
+    return res.status(201).json({ feedback: { id: feedback.id, createdAt: feedback.createdAt } });
+  } catch (err: any) {
+    console.error("[tenant-feedback] submit failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "TENANT_FEEDBACK_SUBMIT_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -94,6 +94,10 @@ vi.mock("./pages/tenant/TenantWorkspacePage", () => ({
   default: () => <h1>Tenant Dashboard</h1>,
 }));
 
+vi.mock("./pages/tenant/FeedbackSubmissionPage", () => ({
+  default: () => <h1>Tenant Feedback Submission</h1>,
+}));
+
 vi.mock("./pages/tenant/TenantApplicationStatusPage", () => ({
   default: () => {
     const location = useLocation();
@@ -154,6 +158,20 @@ describe("Routes: /tenant/dashboard", () => {
 
     expect(await screen.findByText(/Tenant Dashboard/i)).toBeInTheDocument();
     expect(screen.queryByText(/DashboardPage/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Routes: /tenant/feedback", () => {
+  it("renders the tenant feedback submission route", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/tenant/feedback"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Tenant Feedback Submission/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 });
 

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -74,6 +74,7 @@ import TenantInviteRedeemPage from "./pages/tenant/TenantInviteRedeemPage";
 import TenantMaintenanceRequestDetailPage from "./pages/tenant/TenantMaintenanceRequestDetailPage";
 import TenantMaintenanceRequestsPage from "./pages/tenant/TenantMaintenanceRequestsPage";
 import TenantMaintenanceRequestNewPage from "./pages/tenant/TenantMaintenanceRequestNewPage";
+import FeedbackSubmissionPage from "./pages/tenant/FeedbackSubmissionPage";
 import { buildTenantApplicationEntryPath } from "./pages/tenant/tenantApplicationFlow";
 import MonthlyOpsReportPageWithNudge from "./pages/reports/MonthlyOpsReportPageWithNudge";
 import InvitesPage from "./pages/landlord/InvitesPage";
@@ -1141,6 +1142,10 @@ function App() {
         <Route
           path="/tenant/maintenance/:id"
           element={renderTenantShell(<TenantMaintenanceRequestDetailPage />)}
+        />
+        <Route
+          path="/tenant/feedback"
+          element={renderTenantShell(<FeedbackSubmissionPage />)}
         />
         <Route
           path="/tenant/invite/redeem"

--- a/rentchain-frontend/src/api/landlordPortfolioHealthApi.ts
+++ b/rentchain-frontend/src/api/landlordPortfolioHealthApi.ts
@@ -29,6 +29,9 @@ export type LandlordPortfolioHealthSummaryV1 = {
     label: string;
     summary: string;
   }>;
+  feedback?: {
+    summaries: string[];
+  };
   metadata?: {
     portfolioScoreGrade?: string | null;
     portfolioScoreAvailable: boolean;

--- a/rentchain-frontend/src/api/tenantFeedbackApi.ts
+++ b/rentchain-frontend/src/api/tenantFeedbackApi.ts
@@ -1,0 +1,26 @@
+import { apiFetch } from "./apiFetch";
+
+export type FeedbackType =
+  | "application_experience"
+  | "screening_experience"
+  | "maintenance_experience"
+  | "communication_experience";
+
+export type FeedbackSentiment =
+  | "positive"
+  | "neutral"
+  | "negative";
+
+export async function submitTenantFeedback(input: {
+  type: FeedbackType;
+  resourceType: string;
+  resourceId: string;
+  sentiment: FeedbackSentiment;
+  tags?: string[];
+  notes?: string;
+}) {
+  return await apiFetch<{ feedback: { id: string; createdAt: string } }>("/tenant/feedback", {
+    method: "POST",
+    body: input,
+  });
+}

--- a/rentchain-frontend/src/components/portfolioHealth/PortfolioFeedbackSummary.tsx
+++ b/rentchain-frontend/src/components/portfolioHealth/PortfolioFeedbackSummary.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { Card, Section } from "../ui/Ui";
+
+export default function PortfolioFeedbackSummary({
+  summaries,
+}: {
+  summaries: string[];
+}) {
+  if (!summaries.length) return null;
+
+  return (
+    <Section>
+      <Card elevated>
+        <div style={{ display: "grid", gap: 10 }}>
+          <div style={{ fontWeight: 700, fontSize: "1rem" }}>Resident feedback patterns</div>
+          <div style={{ color: "#475569" }}>
+            These summaries reflect broad feedback patterns only and do not include individual responses.
+          </div>
+          <div style={{ display: "grid", gap: 8 }}>
+            {summaries.map((summary) => (
+              <div key={summary} style={{ color: "#0f172a" }}>
+                {summary}
+              </div>
+            ))}
+          </div>
+        </div>
+      </Card>
+    </Section>
+  );
+}

--- a/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.test.tsx
@@ -65,6 +65,9 @@ describe("PortfolioHealthSummaryPage", () => {
             summary: "Review outstanding portfolio activity to keep progress steady.",
           },
         ],
+        feedback: {
+          summaries: ["Some tenants experienced slower maintenance follow-through."],
+        },
         metadata: {
           portfolioScoreGrade: null,
           portfolioScoreAvailable: true,
@@ -81,6 +84,7 @@ describe("PortfolioHealthSummaryPage", () => {
 
     expect(await screen.findByText(/stable overall, with a few areas to monitor/i)).toBeInTheDocument();
     expect(screen.getByText(/Screening health/i)).toBeInTheDocument();
+    expect(screen.getByText(/Resident feedback patterns/i)).toBeInTheDocument();
     expect(screen.getByText(/Workflow follow-through/i)).toBeInTheDocument();
   });
 

--- a/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.tsx
@@ -6,6 +6,7 @@ import { useToast } from "../../components/ui/ToastProvider";
 import PortfolioHealthStatusCard from "../../components/portfolioHealth/PortfolioHealthStatusCard";
 import PortfolioHealthDimensionList from "../../components/portfolioHealth/PortfolioHealthDimensionList";
 import PortfolioHealthNextFocusList from "../../components/portfolioHealth/PortfolioHealthNextFocusList";
+import PortfolioFeedbackSummary from "../../components/portfolioHealth/PortfolioFeedbackSummary";
 
 export default function PortfolioHealthSummaryPage() {
   const { showToast } = useToast();
@@ -59,6 +60,7 @@ export default function PortfolioHealthSummaryPage() {
           <>
             <PortfolioHealthStatusCard summary={summary} />
             <PortfolioHealthDimensionList dimensions={summary.dimensions} />
+            <PortfolioFeedbackSummary summaries={summary.feedback?.summaries || []} />
             <PortfolioHealthNextFocusList nextFocus={summary.nextFocus} />
           </>
         ) : null}

--- a/rentchain-frontend/src/pages/tenant/FeedbackSubmissionPage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/FeedbackSubmissionPage.test.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import FeedbackSubmissionPage from "./FeedbackSubmissionPage";
+
+const feedbackApi = vi.hoisted(() => ({
+  submitTenantFeedback: vi.fn(),
+}));
+
+const navigateMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../api/tenantFeedbackApi", () => ({
+  submitTenantFeedback: feedbackApi.submitTenantFeedback,
+}));
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<any>("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+describe("FeedbackSubmissionPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the form and submits feedback", async () => {
+    feedbackApi.submitTenantFeedback.mockResolvedValue({
+      feedback: { id: "fb-1", createdAt: "2026-04-16T12:00:00.000Z" },
+    });
+
+    render(
+      <MemoryRouter>
+        <FeedbackSubmissionPage />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByPlaceholderText(/maint-123/i), { target: { value: "maint-1" } });
+    fireEvent.change(screen.getByDisplayValue(/Neutral/i), { target: { value: "positive" } });
+    fireEvent.click(screen.getAllByRole("button", { name: /Submit feedback/i })[0]);
+
+    await waitFor(() => {
+      expect(feedbackApi.submitTenantFeedback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resourceId: "maint-1",
+          sentiment: "positive",
+        })
+      );
+    });
+
+    expect(await screen.findByText(/Feedback submitted/i)).toBeInTheDocument();
+  });
+
+  it("validates required fields", async () => {
+    render(
+      <MemoryRouter>
+        <FeedbackSubmissionPage />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getAllByPlaceholderText(/maintenance/i)[0], { target: { value: "" } });
+    fireEvent.click(screen.getAllByRole("button", { name: /Submit feedback/i })[0]);
+
+    expect(await screen.findByText(/Resource type and resource ID are required/i)).toBeInTheDocument();
+    expect(feedbackApi.submitTenantFeedback).not.toHaveBeenCalled();
+  });
+});

--- a/rentchain-frontend/src/pages/tenant/FeedbackSubmissionPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/FeedbackSubmissionPage.tsx
@@ -1,0 +1,203 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import { Button, Input } from "../../components/ui/Ui";
+import { submitTenantFeedback } from "../../api/tenantFeedbackApi";
+import { colors, radius, spacing, text as textTokens } from "../../styles/tokens";
+import { TenantSurfaceShell } from "./TenantWorkspaceShared";
+
+const TYPE_OPTIONS = [
+  { value: "application_experience", label: "Application experience" },
+  { value: "screening_experience", label: "Screening experience" },
+  { value: "maintenance_experience", label: "Maintenance experience" },
+  { value: "communication_experience", label: "Communication experience" },
+] as const;
+
+const SENTIMENT_OPTIONS = [
+  { value: "positive", label: "Positive" },
+  { value: "neutral", label: "Neutral" },
+  { value: "negative", label: "Negative" },
+] as const;
+
+export default function FeedbackSubmissionPage() {
+  const navigate = useNavigate();
+  const [type, setType] = React.useState<(typeof TYPE_OPTIONS)[number]["value"]>("maintenance_experience");
+  const [resourceType, setResourceType] = React.useState("maintenance");
+  const [resourceId, setResourceId] = React.useState("");
+  const [sentiment, setSentiment] = React.useState<(typeof SENTIMENT_OPTIONS)[number]["value"]>("neutral");
+  const [tags, setTags] = React.useState("");
+  const [notes, setNotes] = React.useState("");
+  const [submitting, setSubmitting] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [submitted, setSubmitted] = React.useState(false);
+
+  const submit = async () => {
+    if (!resourceType.trim() || !resourceId.trim()) {
+      setError("Resource type and resource ID are required.");
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+    try {
+      await submitTenantFeedback({
+        type,
+        resourceType: resourceType.trim(),
+        resourceId: resourceId.trim(),
+        sentiment,
+        tags: tags
+          .split(",")
+          .map((item) => item.trim())
+          .filter(Boolean),
+        notes: notes.trim(),
+      });
+      setSubmitted(true);
+    } catch (err: any) {
+      setError(err?.message || "Unable to submit feedback.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <TenantSurfaceShell
+      title="Share feedback"
+      subtitle="Help improve future portfolio health guidance by sharing a short summary of your recent experience."
+    >
+      <div style={{ display: "grid", gap: spacing.md }}>
+        <div
+          style={{
+            border: `1px solid ${colors.border}`,
+            borderRadius: radius.md,
+            background: colors.panel,
+            padding: "12px 14px",
+            display: "grid",
+            gap: 8,
+          }}
+        >
+          <div style={{ fontWeight: 800, color: textTokens.primary }}>How feedback is used</div>
+          <div style={{ color: textTokens.secondary }}>
+            Feedback is stored as a structured signal and only used in anonymized, aggregated summaries.
+          </div>
+        </div>
+
+        {submitted ? (
+          <div
+            style={{
+              border: `1px solid ${colors.border}`,
+              borderRadius: radius.md,
+              background: "#ecfdf5",
+              color: "#166534",
+              padding: "12px 14px",
+              display: "grid",
+              gap: 8,
+            }}
+          >
+            <div style={{ fontWeight: 700 }}>Feedback submitted</div>
+            <div>Thank you for sharing your experience.</div>
+          </div>
+        ) : null}
+
+        {error ? (
+          <div
+            style={{
+              border: `1px solid ${colors.borderStrong}`,
+              borderRadius: radius.md,
+              background: "#fff7ed",
+              color: "#9a3412",
+              padding: "10px 12px",
+            }}
+          >
+            {error}
+          </div>
+        ) : null}
+
+        <label style={{ display: "grid", gap: 6 }}>
+          <span style={{ color: textTokens.muted }}>Feedback type</span>
+          <select
+            value={type}
+            onChange={(e) => setType(e.target.value as typeof type)}
+            style={{
+              padding: "9px 10px",
+              borderRadius: radius.md,
+              border: `1px solid ${colors.border}`,
+              background: colors.panel,
+            }}
+          >
+            {TYPE_OPTIONS.map((item) => (
+              <option key={item.value} value={item.value}>
+                {item.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <div style={{ display: "grid", gap: spacing.sm, gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))" }}>
+          <label style={{ display: "grid", gap: 6 }}>
+            <span style={{ color: textTokens.muted }}>Resource type</span>
+            <Input value={resourceType} onChange={(e) => setResourceType(e.target.value)} placeholder="maintenance" />
+          </label>
+          <label style={{ display: "grid", gap: 6 }}>
+            <span style={{ color: textTokens.muted }}>Resource ID</span>
+            <Input value={resourceId} onChange={(e) => setResourceId(e.target.value)} placeholder="maint-123" />
+          </label>
+        </div>
+
+        <label style={{ display: "grid", gap: 6 }}>
+          <span style={{ color: textTokens.muted }}>How did it feel overall?</span>
+          <select
+            value={sentiment}
+            onChange={(e) => setSentiment(e.target.value as typeof sentiment)}
+            style={{
+              padding: "9px 10px",
+              borderRadius: radius.md,
+              border: `1px solid ${colors.border}`,
+              background: colors.panel,
+            }}
+          >
+            {SENTIMENT_OPTIONS.map((item) => (
+              <option key={item.value} value={item.value}>
+                {item.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label style={{ display: "grid", gap: 6 }}>
+          <span style={{ color: textTokens.muted }}>Optional tags</span>
+          <Input
+            value={tags}
+            onChange={(e) => setTags(e.target.value)}
+            placeholder="slow_response, clear_process"
+          />
+        </label>
+
+        <label style={{ display: "grid", gap: 6 }}>
+          <span style={{ color: textTokens.muted }}>Optional notes</span>
+          <textarea
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            rows={4}
+            placeholder="Share a short summary of your experience."
+            style={{
+              padding: "10px",
+              borderRadius: radius.md,
+              border: `1px solid ${colors.border}`,
+              background: colors.panel,
+              color: textTokens.primary,
+              resize: "vertical",
+            }}
+          />
+        </label>
+
+        <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
+          <Button onClick={() => void submit()} disabled={submitting}>
+            {submitting ? "Submitting..." : "Submit feedback"}
+          </Button>
+          <Button variant="secondary" onClick={() => navigate("/tenant/activity")}>
+            Back to activity
+          </Button>
+        </div>
+      </div>
+    </TenantSurfaceShell>
+  );
+}


### PR DESCRIPTION
## Summary
Adds Tenant + Applicant Feedback Loop v1 as the first structured tenant/applicant feedback signal layer.

This introduces tenant-only feedback capture, append-only feedback storage, portfolio-level aggregation, and landlord-safe summary integration so tenant/applicant experience can inform landlord-facing intelligence without exposing raw feedback or tenant identity.

## Scope
- Adds `feedbackTypes`, feedback storage helpers, aggregation, safe summary derivation, and resource-scope resolution under `src/lib/feedback`
- Adds a new tenant-authenticated route:
  - `POST /api/tenant/feedback`
- Enforces tenant-only access and server-side resource ownership validation before storing feedback
- Stores append-only structured feedback in a new `tenantFeedback` collection
- Aggregates feedback into safe portfolio-level signals rather than landlord-visible raw responses
- Integrates landlord-safe feedback summaries into the existing landlord portfolio health layer
- Adds a lightweight tenant feedback submission page at:
  - `/tenant/feedback`
- Adds a small landlord-safe health UI section for resident feedback patterns
- Adds targeted backend and frontend tests for:
  - feedback submission
  - invalid input rejection
  - tenant-only access enforcement
  - aggregation correctness
  - landlord-safe health summary behavior
  - tenant feedback page rendering and validation

## Notes
This is intentionally a conservative input-signal layer, not a landlord-visible ratings or review system.

The landlord-facing layer does not expose:
- raw feedback text
- feedback counts or ratios
- individual tenant/applicant responses
- tenant identity
- internal admin notes or handling state

Feedback is used only through anonymized, aggregated summaries such as broad experience patterns.

For v1:
- feedback is structured and minimal
- storage is append-only
- no workflow state changes are triggered by feedback
- no moderation or star-rating system is introduced
- recommendations benefit indirectly through the transformed health layer rather than consuming raw feedback directly

## Validation
- Passed targeted backend feedback and portfolio-health tests
- Passed backend build
- Passed targeted frontend feedback, landlord health, and route tests
- Passed full frontend test suite
- Passed frontend build