### PR TITLE
feat: add portfolio score sharing and visibility controls v1

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -111,6 +111,8 @@ import portfolioScoreRoutes from "./routes/portfolioScoreRoutes";
 import portfolioScoreHistoryRoutes from "./routes/portfolioScoreHistoryRoutes";
 import landlordPortfolioHealthRoutes from "./routes/landlordPortfolioHealthRoutes";
 import landlordPortfolioScoreRoutes from "./routes/landlordPortfolioScoreRoutes";
+import landlordPortfolioScoreSharingRoutes from "./routes/landlordPortfolioScoreSharingRoutes";
+import publicPortfolioScoreRoutes from "./routes/publicPortfolioScoreRoutes";
 import landlordActionRecommendationRoutes from "./routes/landlordActionRecommendationRoutes";
 import tenantFeedbackRoutes from "./routes/tenantFeedbackRoutes";
 import transunionRoutes from "./services/integrations/transunion/transunionRoutes";
@@ -205,6 +207,7 @@ app.use("/api", routeSource("paymentsRoutes.ts"), paymentsRoutes);
 // Public + Auth (MUST be before authenticateJwt)
 app.use("/api", routeSource("publicRoutes.ts"), publicRoutes);
 app.use("/api/public", routeSource("publicRoutes.ts"), publicRoutes);
+app.use("/api", routeSource("publicPortfolioScoreRoutes.ts"), publicPortfolioScoreRoutes);
 app.use("/api/public", routeSource("landlordInvitesPublicRoutes.ts"), landlordInvitesPublicRoutes);
 app.use("/api/public", routeSource("landlordInquiryRoutes.ts"), landlordInquiryPublicRoutes);
 app.use("/api/public", tenantHistorySharePublicRouter);
@@ -254,6 +257,8 @@ app.use("/api", routeSource("landlordPortfolioHealthRoutes.ts"), landlordPortfol
 console.log("[route-mount] landlordPortfolioHealthRoutes mounted at /api");
 app.use("/api", routeSource("landlordPortfolioScoreRoutes.ts"), landlordPortfolioScoreRoutes);
 console.log("[route-mount] landlordPortfolioScoreRoutes mounted at /api");
+app.use("/api", routeSource("landlordPortfolioScoreSharingRoutes.ts"), landlordPortfolioScoreSharingRoutes);
+console.log("[route-mount] landlordPortfolioScoreSharingRoutes mounted at /api");
 app.use("/api", routeSource("landlordActionRecommendationRoutes.ts"), landlordActionRecommendationRoutes);
 console.log("[route-mount] landlordActionRecommendationRoutes mounted at /api");
 app.use("/api", routeSource("tenantFeedbackRoutes.ts"), tenantFeedbackRoutes);

--- a/rentchain-api/src/lib/portfolioScoreSharing/__tests__/deriveSharedPortfolioScoreView.test.ts
+++ b/rentchain-api/src/lib/portfolioScoreSharing/__tests__/deriveSharedPortfolioScoreView.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveSharedPortfolioScoreView } from "../deriveSharedPortfolioScoreView";
+
+describe("deriveSharedPortfolioScoreView", () => {
+  it("returns a safe shared score payload from external score input", () => {
+    const result = deriveSharedPortfolioScoreView({
+      version: "v1",
+      portfolioId: "portfolio-1",
+      generatedAt: "2026-04-16T12:00:00.000Z",
+      score: 88,
+      grade: "B",
+      summary: {
+        headline: "Your portfolio is stable with some areas to monitor.",
+        explanation: "Operations are generally consistent overall.",
+      },
+      trend: {
+        direction: "stable",
+        summary: "The score has remained generally steady.",
+      },
+      components: [
+        {
+          key: "workflow_completion",
+          label: "Workflow completion",
+          status: "strong",
+          summary: "Core workflows are completing consistently.",
+        },
+      ],
+      trust: {
+        explanation: "Your score reflects operational consistency over time.",
+        methodologyNote: "Scores are based on activity patterns and consistency.",
+      },
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        version: "v1",
+        portfolioId: "portfolio-1",
+        score: 88,
+        grade: "B",
+        components: expect.any(Array),
+        trust: expect.objectContaining({
+          explanation: expect.any(String),
+          methodologyNote: expect.any(String),
+        }),
+      })
+    );
+  });
+
+  it("returns null when external score input is missing", () => {
+    expect(deriveSharedPortfolioScoreView(null)).toBeNull();
+  });
+});

--- a/rentchain-api/src/lib/portfolioScoreSharing/deriveSharedPortfolioScoreView.ts
+++ b/rentchain-api/src/lib/portfolioScoreSharing/deriveSharedPortfolioScoreView.ts
@@ -1,0 +1,33 @@
+import type { PortfolioScoreExternalV1 } from "../portfolioScoreExternal/portfolioScoreExternalTypes";
+import type { PortfolioScoreSharedViewV1 } from "./portfolioScoreSharingTypes";
+
+export function deriveSharedPortfolioScoreView(
+  portfolioScore: PortfolioScoreExternalV1 | null | undefined
+): PortfolioScoreSharedViewV1 | null {
+  if (!portfolioScore) return null;
+  return {
+    version: "v1",
+    portfolioId: portfolioScore.portfolioId,
+    generatedAt: portfolioScore.generatedAt,
+    score: portfolioScore.score,
+    grade: portfolioScore.grade,
+    summary: {
+      headline: portfolioScore.summary.headline,
+      explanation: portfolioScore.summary.explanation,
+    },
+    trend: {
+      direction: portfolioScore.trend.direction,
+      summary: portfolioScore.trend.summary,
+    },
+    components: portfolioScore.components.map((component) => ({
+      key: component.key,
+      label: component.label,
+      status: component.status,
+      summary: component.summary,
+    })),
+    trust: {
+      explanation: portfolioScore.trust.explanation,
+      methodologyNote: portfolioScore.trust.methodologyNote,
+    },
+  };
+}

--- a/rentchain-api/src/lib/portfolioScoreSharing/loadPortfolioScoreShareState.ts
+++ b/rentchain-api/src/lib/portfolioScoreSharing/loadPortfolioScoreShareState.ts
@@ -1,0 +1,52 @@
+import { db } from "../../config/firebase";
+import type {
+  PortfolioScoreShareRecordV1,
+  PortfolioScoreVisibility,
+} from "./portfolioScoreSharingTypes";
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function toIsoString(value: unknown) {
+  const raw = String(value || "").trim();
+  if (!raw) return null;
+  const parsed = Date.parse(raw);
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : null;
+}
+
+function normalizeVisibility(value: unknown): PortfolioScoreVisibility {
+  const raw = asString(value, 40).toLowerCase();
+  if (raw === "landlord_visible") return "landlord_visible";
+  if (raw === "shareable_link") return "shareable_link";
+  return "private";
+}
+
+export function normalizePortfolioScoreShareState(input: {
+  portfolioId: string;
+  record?: any;
+  now?: number;
+}): PortfolioScoreShareRecordV1 {
+  const now = typeof input.now === "number" ? input.now : Date.now();
+  const record = input.record || {};
+  return {
+    version: "v1",
+    portfolioId: input.portfolioId,
+    visibility: normalizeVisibility(record.visibility),
+    shareToken: asString(record.shareToken, 240) || null,
+    shareEnabledAt: toIsoString(record.shareEnabledAt) || null,
+    revokedAt: toIsoString(record.revokedAt) || null,
+    updatedAt: toIsoString(record.updatedAt) || new Date(now).toISOString(),
+  };
+}
+
+export async function loadPortfolioScoreShareState(
+  portfolioId: string
+): Promise<PortfolioScoreShareRecordV1> {
+  const normalizedId = asString(portfolioId, 240);
+  const snap = await db.collection("portfolioScoreSharing").doc(normalizedId).get();
+  return normalizePortfolioScoreShareState({
+    portfolioId: normalizedId,
+    record: snap.exists ? snap.data() : null,
+  });
+}

--- a/rentchain-api/src/lib/portfolioScoreSharing/portfolioScoreSharingTypes.ts
+++ b/rentchain-api/src/lib/portfolioScoreSharing/portfolioScoreSharingTypes.ts
@@ -1,0 +1,43 @@
+export type PortfolioScoreVisibility = "private" | "landlord_visible" | "shareable_link";
+
+export type PortfolioScoreShareRecordV1 = {
+  version: "v1";
+  portfolioId: string;
+  visibility: PortfolioScoreVisibility;
+  shareToken?: string | null;
+  shareEnabledAt?: string | null;
+  revokedAt?: string | null;
+  updatedAt: string;
+};
+
+export type PortfolioScoreSharedViewV1 = {
+  version: "v1";
+  portfolioId: string;
+  generatedAt: string;
+  score: number;
+  grade: "A" | "B" | "C" | "D" | "E";
+  summary: {
+    headline: string;
+    explanation: string;
+  };
+  trend: {
+    direction: "improving" | "stable" | "declining" | "insufficient_data";
+    summary: string;
+  };
+  components: Array<{
+    key:
+      | "workflow_completion"
+      | "screening_reliability"
+      | "maintenance_stability"
+      | "automation_health"
+      | "policy_friction"
+      | "exception_burden";
+    label: string;
+    status: "strong" | "moderate" | "needs_attention";
+    summary: string;
+  }>;
+  trust: {
+    explanation: string;
+    methodologyNote: string;
+  };
+};

--- a/rentchain-api/src/lib/portfolioScoreSharing/rotatePortfolioScoreShareToken.ts
+++ b/rentchain-api/src/lib/portfolioScoreSharing/rotatePortfolioScoreShareToken.ts
@@ -1,0 +1,34 @@
+import crypto from "crypto";
+import { loadPortfolioScoreShareState } from "./loadPortfolioScoreShareState";
+import { savePortfolioScoreShareState } from "./savePortfolioScoreShareState";
+
+function buildShareToken() {
+  return crypto.randomBytes(24).toString("hex");
+}
+
+export function buildPortfolioScoreSharePath(token: string) {
+  return `/portfolio-score/shared/${encodeURIComponent(token)}`;
+}
+
+export async function rotatePortfolioScoreShareToken(portfolioId: string) {
+  const current = await loadPortfolioScoreShareState(portfolioId);
+  const token = buildShareToken();
+  return await savePortfolioScoreShareState({
+    portfolioId,
+    visibility: "shareable_link",
+    shareToken: token,
+    shareEnabledAt: new Date().toISOString(),
+    revokedAt: null,
+  });
+}
+
+export async function revokePortfolioScoreSharing(portfolioId: string, visibility: "private" | "landlord_visible") {
+  const current = await loadPortfolioScoreShareState(portfolioId);
+  return await savePortfolioScoreShareState({
+    portfolioId,
+    visibility,
+    shareToken: null,
+    shareEnabledAt: current.shareEnabledAt || null,
+    revokedAt: new Date().toISOString(),
+  });
+}

--- a/rentchain-api/src/lib/portfolioScoreSharing/savePortfolioScoreShareState.ts
+++ b/rentchain-api/src/lib/portfolioScoreSharing/savePortfolioScoreShareState.ts
@@ -1,0 +1,48 @@
+import { db } from "../../config/firebase";
+import {
+  loadPortfolioScoreShareState,
+  normalizePortfolioScoreShareState,
+} from "./loadPortfolioScoreShareState";
+import type {
+  PortfolioScoreShareRecordV1,
+  PortfolioScoreVisibility,
+} from "./portfolioScoreSharingTypes";
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function toIsoString(value: unknown) {
+  if (value == null || value === "") return null;
+  const parsed = Date.parse(String(value));
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : null;
+}
+
+export async function savePortfolioScoreShareState(input: {
+  portfolioId: string;
+  visibility: PortfolioScoreVisibility;
+  shareToken?: string | null;
+  shareEnabledAt?: string | null;
+  revokedAt?: string | null;
+  now?: number;
+}): Promise<PortfolioScoreShareRecordV1> {
+  const now = typeof input.now === "number" ? input.now : Date.now();
+  const portfolioId = asString(input.portfolioId, 240);
+  const current = await loadPortfolioScoreShareState(portfolioId);
+  const next = normalizePortfolioScoreShareState({
+    portfolioId,
+    record: {
+      ...current,
+      visibility: input.visibility,
+      shareToken: input.shareToken === undefined ? current.shareToken : input.shareToken,
+      shareEnabledAt:
+        input.shareEnabledAt === undefined ? current.shareEnabledAt : toIsoString(input.shareEnabledAt),
+      revokedAt: input.revokedAt === undefined ? current.revokedAt : toIsoString(input.revokedAt),
+      updatedAt: new Date(now).toISOString(),
+    },
+    now,
+  });
+
+  await db.collection("portfolioScoreSharing").doc(portfolioId).set(next, { merge: true });
+  return next;
+}

--- a/rentchain-api/src/routes/__tests__/landlordPortfolioScoreSharingRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordPortfolioScoreSharingRoutes.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const loadPortfolioScoreShareState = vi.fn();
+const savePortfolioScoreShareState = vi.fn();
+const rotatePortfolioScoreShareToken = vi.fn();
+const revokePortfolioScoreSharing = vi.fn();
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!req.user) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    return next();
+  },
+}));
+
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: any, res: any, next: any) => {
+    const role = String(req.user?.role || "").trim().toLowerCase();
+    const landlordId = req.user?.landlordId || req.user?.id;
+    if (role !== "landlord" && role !== "admin") {
+      return res.status(403).json({ ok: false, error: "Forbidden" });
+    }
+    if (!landlordId) {
+      return res.status(401).json({ ok: false, error: "Missing landlord context" });
+    }
+    req.user.landlordId = landlordId;
+    return next();
+  },
+}));
+
+vi.mock("../../lib/portfolioScoreSharing/loadPortfolioScoreShareState", () => ({
+  loadPortfolioScoreShareState,
+}));
+
+vi.mock("../../lib/portfolioScoreSharing/savePortfolioScoreShareState", () => ({
+  savePortfolioScoreShareState,
+}));
+
+vi.mock("../../lib/portfolioScoreSharing/rotatePortfolioScoreShareToken", () => ({
+  buildPortfolioScoreSharePath: (token: string) => `/portfolio-score/shared/${token}`,
+  rotatePortfolioScoreShareToken,
+  revokePortfolioScoreSharing,
+}));
+
+async function invokeRouter(
+  router: any,
+  options: { method: string; url: string; user?: Record<string, unknown> | null; body?: any }
+) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path] = options.url.split("?");
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: options.user ?? null,
+      query: {},
+      params: {},
+      body: options.body || {},
+      headers: {},
+      get(name: string) {
+        return this.headers[String(name).toLowerCase()];
+      },
+      header(name: string) {
+        return this.get(name);
+      },
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, string>,
+      setHeader(name: string, value: string) {
+        this.headers[name.toLowerCase()] = value;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("landlordPortfolioScoreSharingRoutes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadPortfolioScoreShareState.mockResolvedValue({
+      version: "v1",
+      portfolioId: "landlord-1",
+      visibility: "private",
+      shareToken: null,
+      shareEnabledAt: null,
+      revokedAt: null,
+      updatedAt: "2026-04-16T12:00:00.000Z",
+    });
+    savePortfolioScoreShareState.mockResolvedValue({
+      version: "v1",
+      portfolioId: "landlord-1",
+      visibility: "shareable_link",
+      shareToken: "token-1",
+      shareEnabledAt: "2026-04-16T12:00:00.000Z",
+      revokedAt: null,
+      updatedAt: "2026-04-16T12:00:00.000Z",
+    });
+    rotatePortfolioScoreShareToken.mockResolvedValue({
+      version: "v1",
+      portfolioId: "landlord-1",
+      visibility: "shareable_link",
+      shareToken: "token-2",
+      shareEnabledAt: "2026-04-16T12:00:00.000Z",
+      revokedAt: null,
+      updatedAt: "2026-04-16T12:00:00.000Z",
+    });
+    revokePortfolioScoreSharing.mockResolvedValue({
+      version: "v1",
+      portfolioId: "landlord-1",
+      visibility: "private",
+      shareToken: null,
+      shareEnabledAt: "2026-04-16T12:00:00.000Z",
+      revokedAt: "2026-04-16T13:00:00.000Z",
+      updatedAt: "2026-04-16T13:00:00.000Z",
+    });
+  });
+
+  it("returns the default private sharing state", async () => {
+    const router = (await import("../landlordPortfolioScoreSharingRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/portfolio-score-sharing",
+      user: { id: "landlord-1", role: "landlord" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(loadPortfolioScoreShareState).toHaveBeenCalledWith("landlord-1");
+    expect(response.body?.sharing?.visibility).toBe("private");
+    expect(response.body?.shareUrl).toBeNull();
+  });
+
+  it("enables shareable link mode and returns a share url", async () => {
+    const router = (await import("../landlordPortfolioScoreSharingRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "PATCH",
+      url: "/landlord/portfolio-score-sharing",
+      user: { id: "landlord-1", role: "landlord" },
+      body: { visibility: "shareable_link" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(rotatePortfolioScoreShareToken).toHaveBeenCalledWith("landlord-1");
+    expect(response.body?.shareUrl).toBe("/portfolio-score/shared/token-2");
+  });
+
+  it("revokes sharing when switching back to private", async () => {
+    const router = (await import("../landlordPortfolioScoreSharingRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "PATCH",
+      url: "/landlord/portfolio-score-sharing",
+      user: { id: "landlord-1", role: "landlord" },
+      body: { visibility: "private" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(revokePortfolioScoreSharing).toHaveBeenCalledWith("landlord-1", "private");
+    expect(response.body?.sharing?.visibility).toBe("private");
+  });
+
+  it("rotates tokens explicitly", async () => {
+    const router = (await import("../landlordPortfolioScoreSharingRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "POST",
+      url: "/landlord/portfolio-score-sharing/rotate",
+      user: { id: "landlord-1", role: "landlord" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(rotatePortfolioScoreShareToken).toHaveBeenCalledWith("landlord-1");
+    expect(response.body?.shareUrl).toContain("token-2");
+  });
+
+  it("enforces landlord-scoped auth", async () => {
+    const router = (await import("../landlordPortfolioScoreSharingRoutes")).default;
+    const forbidden = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/portfolio-score-sharing",
+      user: { id: "tenant-1", role: "tenant" },
+    });
+    const unauthorized = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/portfolio-score-sharing",
+      user: null,
+    });
+
+    expect(forbidden.status).toBe(403);
+    expect(unauthorized.status).toBe(401);
+  });
+});

--- a/rentchain-api/src/routes/__tests__/publicPortfolioScoreRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/publicPortfolioScoreRoutes.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const whereMock = vi.fn();
+const limitMock = vi.fn();
+const getMock = vi.fn();
+const loadLandlordPortfolioHealthInputs = vi.fn();
+const derivePortfolioScoreExternal = vi.fn();
+
+vi.mock("../../config/firebase", () => ({
+  db: {
+    collection: vi.fn(() => ({
+      where: whereMock,
+    })),
+  },
+}));
+
+vi.mock("../../lib/portfolioHealth/loadLandlordPortfolioHealthInputs", () => ({
+  loadLandlordPortfolioHealthInputs,
+}));
+
+vi.mock("../../lib/portfolioScoreExternal/derivePortfolioScoreExternal", () => ({
+  derivePortfolioScoreExternal,
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const path = options.url;
+    const token = path.split("/").pop() || "";
+    const req: any = {
+      method: options.method,
+      url: path,
+      originalUrl: path,
+      path,
+      params: { token },
+      query: {},
+      headers: {},
+      get(name: string) {
+        return this.headers[String(name).toLowerCase()];
+      },
+      header(name: string) {
+        return this.get(name);
+      },
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, string>,
+      setHeader(name: string, value: string) {
+        this.headers[name.toLowerCase()] = value;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("publicPortfolioScoreRoutes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    whereMock.mockReturnValue({ where: whereMock, limit: limitMock });
+    limitMock.mockReturnValue({ get: getMock });
+    getMock.mockResolvedValue({
+      empty: false,
+      docs: [
+        {
+          data: () => ({
+            portfolioId: "landlord-1",
+            visibility: "shareable_link",
+            shareToken: "token-1",
+            revokedAt: null,
+          }),
+        },
+      ],
+    });
+    loadLandlordPortfolioHealthInputs.mockResolvedValue({
+      portfolioId: "landlord-1",
+      portfolioScore: {},
+      portfolioTrend: {},
+    });
+    derivePortfolioScoreExternal.mockReturnValue({
+      version: "v1",
+      portfolioId: "landlord-1",
+      generatedAt: "2026-04-16T12:00:00.000Z",
+      score: 81,
+      grade: "B",
+      summary: {
+        headline: "Your portfolio is stable with some areas to monitor.",
+        explanation: "Operations are performing steadily overall.",
+      },
+      trend: {
+        direction: "stable",
+        summary: "The portfolio score has remained generally steady.",
+      },
+      components: [],
+      trust: {
+        explanation: "The score reflects operational consistency over time.",
+        methodologyNote: "Scores are based on activity patterns and consistency.",
+      },
+    });
+  });
+
+  it("returns a safe shared payload for an active token", async () => {
+    const router = (await import("../publicPortfolioScoreRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/portfolio-score/shared/token-1",
+    });
+
+    expect(response.status).toBe(200);
+    expect(loadLandlordPortfolioHealthInputs).toHaveBeenCalledWith("landlord-1");
+    expect(response.body?.portfolioScore).toEqual(
+      expect.objectContaining({
+        score: 81,
+        grade: "B",
+        summary: expect.objectContaining({ headline: expect.any(String) }),
+        components: expect.any(Array),
+      })
+    );
+  });
+
+  it("returns a safe not found response for invalid tokens", async () => {
+    getMock.mockResolvedValueOnce({ empty: true, docs: [] });
+    const router = (await import("../publicPortfolioScoreRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/portfolio-score/shared/missing-token",
+    });
+
+    expect(response.status).toBe(404);
+    expect(response.body?.error).toBe("NOT_FOUND");
+  });
+
+  it("blocks revoked sharing state", async () => {
+    getMock.mockResolvedValueOnce({
+      empty: false,
+      docs: [
+        {
+          data: () => ({
+            portfolioId: "landlord-1",
+            visibility: "shareable_link",
+            shareToken: "token-1",
+            revokedAt: "2026-04-16T13:00:00.000Z",
+          }),
+        },
+      ],
+    });
+    const router = (await import("../publicPortfolioScoreRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/portfolio-score/shared/token-1",
+    });
+
+    expect(response.status).toBe(404);
+    expect(response.body?.error).toBe("NOT_FOUND");
+  });
+});

--- a/rentchain-api/src/routes/landlordPortfolioScoreSharingRoutes.ts
+++ b/rentchain-api/src/routes/landlordPortfolioScoreSharingRoutes.ts
@@ -1,0 +1,90 @@
+import { Router } from "express";
+import { requireAuth } from "../middleware/requireAuth";
+import { requireLandlord } from "../middleware/requireLandlord";
+import { loadPortfolioScoreShareState } from "../lib/portfolioScoreSharing/loadPortfolioScoreShareState";
+import {
+  buildPortfolioScoreSharePath,
+  revokePortfolioScoreSharing,
+  rotatePortfolioScoreShareToken,
+} from "../lib/portfolioScoreSharing/rotatePortfolioScoreShareToken";
+import { savePortfolioScoreShareState } from "../lib/portfolioScoreSharing/savePortfolioScoreShareState";
+
+const router = Router();
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function sharePayload(sharing: any) {
+  return {
+    sharing,
+    shareUrl: sharing.visibility === "shareable_link" && sharing.shareToken
+      ? buildPortfolioScoreSharePath(sharing.shareToken)
+      : null,
+  };
+}
+
+router.get("/landlord/portfolio-score-sharing", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const portfolioId = asString(req.user?.landlordId || req.user?.id, 240);
+    if (!portfolioId) {
+      return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    }
+    const sharing = await loadPortfolioScoreShareState(portfolioId);
+    return res.json(sharePayload(sharing));
+  } catch (err: any) {
+    console.error("[portfolio-score-sharing] fetch failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "PORTFOLIO_SCORE_SHARING_FETCH_FAILED" });
+  }
+});
+
+router.patch("/landlord/portfolio-score-sharing", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const portfolioId = asString(req.user?.landlordId || req.user?.id, 240);
+    const visibility = asString(req.body?.visibility, 40).toLowerCase();
+    if (!portfolioId) {
+      return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    }
+    if (visibility !== "private" && visibility !== "landlord_visible" && visibility !== "shareable_link") {
+      return res.status(400).json({ ok: false, error: "INVALID_VISIBILITY" });
+    }
+
+    let sharing;
+    if (visibility === "shareable_link") {
+      const current = await loadPortfolioScoreShareState(portfolioId);
+      sharing =
+        current.shareToken && current.visibility === "shareable_link"
+          ? await savePortfolioScoreShareState({
+              portfolioId,
+              visibility: "shareable_link",
+              shareToken: current.shareToken,
+              shareEnabledAt: current.shareEnabledAt || new Date().toISOString(),
+              revokedAt: null,
+            })
+          : await rotatePortfolioScoreShareToken(portfolioId);
+    } else {
+      sharing = await revokePortfolioScoreSharing(portfolioId, visibility);
+    }
+
+    return res.json(sharePayload(sharing));
+  } catch (err: any) {
+    console.error("[portfolio-score-sharing] update failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "PORTFOLIO_SCORE_SHARING_UPDATE_FAILED" });
+  }
+});
+
+router.post("/landlord/portfolio-score-sharing/rotate", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const portfolioId = asString(req.user?.landlordId || req.user?.id, 240);
+    if (!portfolioId) {
+      return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    }
+    const sharing = await rotatePortfolioScoreShareToken(portfolioId);
+    return res.json(sharePayload(sharing));
+  } catch (err: any) {
+    console.error("[portfolio-score-sharing] rotate failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "PORTFOLIO_SCORE_SHARING_ROTATE_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-api/src/routes/publicPortfolioScoreRoutes.ts
+++ b/rentchain-api/src/routes/publicPortfolioScoreRoutes.ts
@@ -1,0 +1,51 @@
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { deriveSharedPortfolioScoreView } from "../lib/portfolioScoreSharing/deriveSharedPortfolioScoreView";
+import { derivePortfolioScoreExternal } from "../lib/portfolioScoreExternal/derivePortfolioScoreExternal";
+import { loadLandlordPortfolioHealthInputs } from "../lib/portfolioHealth/loadLandlordPortfolioHealthInputs";
+
+const router = Router();
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+router.get("/portfolio-score/shared/:token", async (req: any, res) => {
+  try {
+    const token = asString(req.params?.token, 240);
+    if (!token) {
+      return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+    }
+
+    const snap = await db
+      .collection("portfolioScoreSharing")
+      .where("shareToken", "==", token)
+      .where("visibility", "==", "shareable_link")
+      .limit(1)
+      .get();
+
+    if (snap.empty) {
+      return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+    }
+
+    const record = snap.docs[0].data() as any;
+    const portfolioId = asString(record?.portfolioId, 240);
+    if (!portfolioId || record?.revokedAt) {
+      return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+    }
+
+    const inputs = await loadLandlordPortfolioHealthInputs(portfolioId);
+    const externalScore = derivePortfolioScoreExternal(inputs);
+    const portfolioScore = deriveSharedPortfolioScoreView(externalScore);
+    if (!portfolioScore) {
+      return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+    }
+
+    return res.json({ portfolioScore });
+  } catch (err: any) {
+    console.error("[public-portfolio-score] fetch failed", err?.message || err);
+    return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+  }
+});
+
+export default router;

--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -86,6 +86,10 @@ vi.mock("./pages/landlord/PortfolioScorePage", () => ({
   default: () => <h1>Landlord Portfolio Score</h1>,
 }));
 
+vi.mock("./pages/public/SharedPortfolioScorePage", () => ({
+  default: () => <h1>Shared Portfolio Score Page</h1>,
+}));
+
 vi.mock("./pages/landlord/ActionRecommendationsPage", () => ({
   default: () => <h1>Landlord Action Recommendations</h1>,
 }));
@@ -311,6 +315,20 @@ describe("Routes: /portfolio-score", () => {
     );
 
     expect(await screen.findByText(/Landlord Portfolio Score/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Routes: /portfolio-score/shared/:token", () => {
+  it("renders the shared portfolio score route", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/portfolio-score/shared/token-1"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Shared Portfolio Score Page/i)).toBeInTheDocument();
     expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -160,6 +160,7 @@ const PortfolioScorePage = lazy(() => import("./pages/admin/PortfolioScorePage")
 const PortfolioScoreHistoryPage = lazy(() => import("./pages/admin/PortfolioScoreHistoryPage"));
 const PortfolioHealthSummaryPage = lazy(() => import("./pages/landlord/PortfolioHealthSummaryPage"));
 const LandlordPortfolioScorePage = lazy(() => import("./pages/landlord/PortfolioScorePage"));
+const SharedPortfolioScorePage = lazy(() => import("./pages/public/SharedPortfolioScorePage"));
 const ActionRecommendationsPage = lazy(() => import("./pages/landlord/ActionRecommendationsPage"));
 
 const AuthLoadingScreen = () => (
@@ -481,6 +482,14 @@ function App() {
                 </Suspense>
               </LandlordNav>
             </RequireAuth>
+          }
+        />
+        <Route
+          path="/portfolio-score/shared/:token"
+          element={
+            <Suspense fallback={null}>
+              <SharedPortfolioScorePage />
+            </Suspense>
           }
         />
         <Route

--- a/rentchain-frontend/src/api/landlordPortfolioScoreSharingApi.ts
+++ b/rentchain-frontend/src/api/landlordPortfolioScoreSharingApi.ts
@@ -1,0 +1,41 @@
+import { apiFetch } from "./apiFetch";
+
+export type PortfolioScoreVisibility = "private" | "landlord_visible" | "shareable_link";
+
+export type PortfolioScoreShareRecordV1 = {
+  version: "v1";
+  portfolioId: string;
+  visibility: PortfolioScoreVisibility;
+  shareToken?: string | null;
+  shareEnabledAt?: string | null;
+  revokedAt?: string | null;
+  updatedAt: string;
+};
+
+export async function fetchPortfolioScoreSharing(): Promise<{
+  sharing: PortfolioScoreShareRecordV1;
+  shareUrl?: string | null;
+}> {
+  return await apiFetch("/landlord/portfolio-score-sharing");
+}
+
+export async function updatePortfolioScoreSharing(payload: {
+  visibility: PortfolioScoreVisibility;
+}): Promise<{
+  sharing: PortfolioScoreShareRecordV1;
+  shareUrl?: string | null;
+}> {
+  return await apiFetch("/landlord/portfolio-score-sharing", {
+    method: "PATCH",
+    body: payload,
+  });
+}
+
+export async function rotatePortfolioScoreSharingToken(): Promise<{
+  sharing: PortfolioScoreShareRecordV1;
+  shareUrl?: string | null;
+}> {
+  return await apiFetch("/landlord/portfolio-score-sharing/rotate", {
+    method: "POST",
+  });
+}

--- a/rentchain-frontend/src/api/publicPortfolioScoreApi.ts
+++ b/rentchain-frontend/src/api/publicPortfolioScoreApi.ts
@@ -1,0 +1,10 @@
+import { apiFetch } from "./apiFetch";
+import type { PortfolioScoreExternalV1 } from "./landlordPortfolioScoreApi";
+
+export type PortfolioScoreSharedViewV1 = PortfolioScoreExternalV1;
+
+export async function fetchSharedPortfolioScore(token: string): Promise<{
+  portfolioScore: PortfolioScoreSharedViewV1;
+}> {
+  return await apiFetch(`/portfolio-score/shared/${encodeURIComponent(token)}`);
+}

--- a/rentchain-frontend/src/components/portfolioScoreSharing/PortfolioScoreShareControls.tsx
+++ b/rentchain-frontend/src/components/portfolioScoreSharing/PortfolioScoreShareControls.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import type {
+  PortfolioScoreShareRecordV1,
+  PortfolioScoreVisibility,
+} from "../../api/landlordPortfolioScoreSharingApi";
+import { Button, Card } from "../ui/Ui";
+
+export default function PortfolioScoreShareControls({
+  sharing,
+  shareUrl,
+  updating,
+  onChangeVisibility,
+  onRotate,
+}: {
+  sharing: PortfolioScoreShareRecordV1 | null;
+  shareUrl?: string | null;
+  updating?: boolean;
+  onChangeVisibility: (visibility: PortfolioScoreVisibility) => void;
+  onRotate: () => void;
+}) {
+  const visibility = sharing?.visibility || "private";
+  return (
+    <Card elevated style={{ display: "grid", gap: 12 }}>
+      <div style={{ display: "grid", gap: 6 }}>
+        <h2 style={{ margin: 0, fontSize: "1.05rem" }}>Share controls</h2>
+        <div style={{ color: "#475569" }}>
+          Sharing stays private by default. Enable a tokenized link only when you want to share this score outside your landlord account.
+        </div>
+      </div>
+
+      <div style={{ display: "grid", gap: 8 }}>
+        {[
+          { key: "private", label: "Private", summary: "Visible only inside your landlord account." },
+          { key: "landlord_visible", label: "Landlord visible", summary: "Explicit in-app visibility preference for future use." },
+          { key: "shareable_link", label: "Shareable link", summary: "Generate a tokenized link that can be revoked or rotated." },
+        ].map((option) => (
+          <label
+            key={option.key}
+            style={{
+              display: "flex",
+              gap: 8,
+              padding: 12,
+              borderRadius: 12,
+              border: `1px solid ${visibility === option.key ? "rgba(37,99,235,0.55)" : "rgba(15,23,42,0.12)"}`,
+              background: visibility === option.key ? "rgba(37,99,235,0.05)" : "#fff",
+            }}
+          >
+            <input
+              type="radio"
+              checked={visibility === option.key}
+              disabled={updating}
+              onChange={() => onChangeVisibility(option.key as PortfolioScoreVisibility)}
+            />
+            <div style={{ display: "grid", gap: 4 }}>
+              <strong>{option.label}</strong>
+              <span style={{ color: "#64748b", fontSize: "0.92rem" }}>{option.summary}</span>
+            </div>
+          </label>
+        ))}
+      </div>
+
+      {visibility === "shareable_link" && shareUrl ? (
+        <div style={{ display: "grid", gap: 8 }}>
+          <div style={{ fontWeight: 700 }}>Share URL</div>
+          <code style={{ padding: 12, borderRadius: 12, background: "rgba(15,23,42,0.05)", overflowWrap: "anywhere" }}>
+            {shareUrl}
+          </code>
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+            <Button type="button" onClick={onRotate} disabled={updating}>
+              Rotate link
+            </Button>
+          </div>
+        </div>
+      ) : null}
+    </Card>
+  );
+}

--- a/rentchain-frontend/src/components/portfolioScoreSharing/PortfolioScoreVisibilityCard.tsx
+++ b/rentchain-frontend/src/components/portfolioScoreSharing/PortfolioScoreVisibilityCard.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import type { PortfolioScoreShareRecordV1 } from "../../api/landlordPortfolioScoreSharingApi";
+import { Card, Pill } from "../ui/Ui";
+
+function labelForVisibility(visibility: PortfolioScoreShareRecordV1["visibility"]) {
+  if (visibility === "shareable_link") return "Shareable link";
+  if (visibility === "landlord_visible") return "Landlord visible";
+  return "Private";
+}
+
+export default function PortfolioScoreVisibilityCard({
+  sharing,
+}: {
+  sharing: PortfolioScoreShareRecordV1 | null;
+}) {
+  const visibility = sharing?.visibility || "private";
+  return (
+    <Card elevated style={{ display: "grid", gap: 10 }}>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "center" }}>
+        <div style={{ display: "grid", gap: 6 }}>
+          <h2 style={{ margin: 0, fontSize: "1.05rem" }}>Sharing visibility</h2>
+          <div style={{ color: "#475569" }}>
+            Control whether your Portfolio Score™ stays private or is available through a tokenized shared link.
+          </div>
+        </div>
+        <Pill>{labelForVisibility(visibility)}</Pill>
+      </div>
+      {sharing?.shareEnabledAt ? (
+        <div style={{ color: "#64748b", fontSize: "0.95rem" }}>
+          Sharing enabled: {new Date(sharing.shareEnabledAt).toLocaleString()}
+        </div>
+      ) : null}
+      {sharing?.revokedAt ? (
+        <div style={{ color: "#64748b", fontSize: "0.95rem" }}>
+          Last revoked: {new Date(sharing.revokedAt).toLocaleString()}
+        </div>
+      ) : null}
+    </Card>
+  );
+}

--- a/rentchain-frontend/src/pages/landlord/PortfolioScorePage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/PortfolioScorePage.test.tsx
@@ -10,6 +10,12 @@ vi.mock("../../api/landlordPortfolioScoreApi", () => ({
   fetchLandlordPortfolioScore: vi.fn(),
 }));
 
+vi.mock("../../api/landlordPortfolioScoreSharingApi", () => ({
+  fetchPortfolioScoreSharing: vi.fn(),
+  updatePortfolioScoreSharing: vi.fn(),
+  rotatePortfolioScoreSharingToken: vi.fn(),
+}));
+
 vi.mock("../../components/ui/ToastProvider", () => ({
   useToast: () => ({ showToast }),
 }));
@@ -22,6 +28,7 @@ vi.mock("../../components/ui/Ui", () => ({
   Card: ({ children, elevated: _elevated, ...props }: any) => <div {...props}>{children}</div>,
   Pill: ({ children }: any) => <span>{children}</span>,
   Section: ({ children }: any) => <section>{children}</section>,
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
 }));
 
 beforeEach(() => {
@@ -36,6 +43,7 @@ afterEach(() => {
 describe("PortfolioScorePage", () => {
   it("renders a high score safely", async () => {
     const { fetchLandlordPortfolioScore } = await import("../../api/landlordPortfolioScoreApi");
+    const { fetchPortfolioScoreSharing } = await import("../../api/landlordPortfolioScoreSharingApi");
     vi.mocked(fetchLandlordPortfolioScore).mockResolvedValue({
       portfolioScore: {
         version: "v1",
@@ -65,6 +73,16 @@ describe("PortfolioScorePage", () => {
         },
       },
     } as any);
+    vi.mocked(fetchPortfolioScoreSharing).mockResolvedValue({
+      sharing: {
+        version: "v1",
+        portfolioId: "landlord-1",
+        visibility: "private",
+        shareToken: null,
+        updatedAt: "2026-04-16T12:00:00.000Z",
+      },
+      shareUrl: null,
+    } as any);
 
     render(
       <MemoryRouter>
@@ -76,10 +94,13 @@ describe("PortfolioScorePage", () => {
     expect(screen.getAllByText(/Grade A/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Workflow completion/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/How to read this score/i)).toBeInTheDocument();
+    expect(screen.getByText(/Sharing visibility/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Private/i).length).toBeGreaterThan(0);
   });
 
   it("renders sparse data safely", async () => {
     const { fetchLandlordPortfolioScore } = await import("../../api/landlordPortfolioScoreApi");
+    const { fetchPortfolioScoreSharing } = await import("../../api/landlordPortfolioScoreSharingApi");
     vi.mocked(fetchLandlordPortfolioScore).mockResolvedValue({
       portfolioScore: {
         version: "v1",
@@ -102,6 +123,16 @@ describe("PortfolioScorePage", () => {
         },
       },
     } as any);
+    vi.mocked(fetchPortfolioScoreSharing).mockResolvedValue({
+      sharing: {
+        version: "v1",
+        portfolioId: "landlord-1",
+        visibility: "landlord_visible",
+        shareToken: null,
+        updatedAt: "2026-04-16T12:00:00.000Z",
+      },
+      shareUrl: null,
+    } as any);
 
     render(
       <MemoryRouter>
@@ -115,7 +146,18 @@ describe("PortfolioScorePage", () => {
 
   it("renders an error state cleanly", async () => {
     const { fetchLandlordPortfolioScore } = await import("../../api/landlordPortfolioScoreApi");
+    const { fetchPortfolioScoreSharing } = await import("../../api/landlordPortfolioScoreSharingApi");
     vi.mocked(fetchLandlordPortfolioScore).mockRejectedValue(new Error("Boom"));
+    vi.mocked(fetchPortfolioScoreSharing).mockResolvedValue({
+      sharing: {
+        version: "v1",
+        portfolioId: "landlord-1",
+        visibility: "private",
+        shareToken: null,
+        updatedAt: "2026-04-16T12:00:00.000Z",
+      },
+      shareUrl: null,
+    } as any);
 
     render(
       <MemoryRouter>
@@ -124,5 +166,53 @@ describe("PortfolioScorePage", () => {
     );
 
     expect(await screen.findByText(/Failed to load portfolio score: Boom/i)).toBeInTheDocument();
+  });
+
+  it("shows share url controls when sharing is enabled", async () => {
+    const { fetchLandlordPortfolioScore } = await import("../../api/landlordPortfolioScoreApi");
+    const { fetchPortfolioScoreSharing } = await import("../../api/landlordPortfolioScoreSharingApi");
+    vi.mocked(fetchLandlordPortfolioScore).mockResolvedValue({
+      portfolioScore: {
+        version: "v1",
+        portfolioId: "landlord-1",
+        generatedAt: "2026-04-16T12:00:00.000Z",
+        score: 84,
+        grade: "B",
+        summary: {
+          headline: "Your portfolio is stable with some areas to monitor.",
+          explanation: "Operations are generally steady overall.",
+        },
+        trend: {
+          direction: "stable",
+          summary: "Your portfolio score has remained generally steady.",
+        },
+        components: [],
+        trust: {
+          explanation: "Your score reflects how consistently your rental operations are performing over time.",
+          methodologyNote: "Scores are based on activity patterns, workflow completion, and operational consistency over time.",
+        },
+      },
+    } as any);
+    vi.mocked(fetchPortfolioScoreSharing).mockResolvedValue({
+      sharing: {
+        version: "v1",
+        portfolioId: "landlord-1",
+        visibility: "shareable_link",
+        shareToken: "token-1",
+        shareEnabledAt: "2026-04-16T12:00:00.000Z",
+        updatedAt: "2026-04-16T12:00:00.000Z",
+      },
+      shareUrl: "/portfolio-score/shared/token-1",
+    } as any);
+
+    render(
+      <MemoryRouter>
+        <PortfolioScorePage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Share URL/i)).toBeInTheDocument();
+    expect(screen.getByText(/token-1/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Rotate link/i })).toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/pages/landlord/PortfolioScorePage.tsx
+++ b/rentchain-frontend/src/pages/landlord/PortfolioScorePage.tsx
@@ -1,16 +1,28 @@
 import React from "react";
 import { fetchLandlordPortfolioScore, type PortfolioScoreExternalV1 } from "../../api/landlordPortfolioScoreApi";
+import {
+  fetchPortfolioScoreSharing,
+  rotatePortfolioScoreSharingToken,
+  updatePortfolioScoreSharing,
+  type PortfolioScoreShareRecordV1,
+  type PortfolioScoreVisibility,
+} from "../../api/landlordPortfolioScoreSharingApi";
 import { MacShell } from "../../components/layout/MacShell";
 import { Card, Section } from "../../components/ui/Ui";
 import { useToast } from "../../components/ui/ToastProvider";
 import PortfolioScoreHeader from "../../components/portfolioScoreExternal/PortfolioScoreHeader";
 import PortfolioScoreComponentList from "../../components/portfolioScoreExternal/PortfolioScoreComponentList";
 import PortfolioScoreTrustPanel from "../../components/portfolioScoreExternal/PortfolioScoreTrustPanel";
+import PortfolioScoreVisibilityCard from "../../components/portfolioScoreSharing/PortfolioScoreVisibilityCard";
+import PortfolioScoreShareControls from "../../components/portfolioScoreSharing/PortfolioScoreShareControls";
 
 export default function PortfolioScorePage() {
   const { showToast } = useToast();
   const [portfolioScore, setPortfolioScore] = React.useState<PortfolioScoreExternalV1 | null>(null);
+  const [sharing, setSharing] = React.useState<PortfolioScoreShareRecordV1 | null>(null);
+  const [shareUrl, setShareUrl] = React.useState<string | null>(null);
   const [loading, setLoading] = React.useState(true);
+  const [updatingSharing, setUpdatingSharing] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
 
   React.useEffect(() => {
@@ -19,9 +31,16 @@ export default function PortfolioScorePage() {
       try {
         setLoading(true);
         setError(null);
-        const response = await fetchLandlordPortfolioScore();
+        const [scoreResponse, sharingResponse] = await Promise.all([
+          fetchLandlordPortfolioScore(),
+          fetchPortfolioScoreSharing(),
+        ]);
         if (!mounted) return;
-        setPortfolioScore(response.portfolioScore);
+        setPortfolioScore(scoreResponse.portfolioScore);
+        setSharing(sharingResponse.sharing);
+        setShareUrl(
+          sharingResponse.shareUrl ? `${window.location.origin}${sharingResponse.shareUrl}` : null
+        );
       } catch (err: any) {
         if (!mounted) return;
         const message = err?.message || "Failed to load portfolio score";
@@ -39,6 +58,40 @@ export default function PortfolioScorePage() {
       mounted = false;
     };
   }, [showToast]);
+
+  const handleChangeVisibility = async (visibility: PortfolioScoreVisibility) => {
+    try {
+      setUpdatingSharing(true);
+      const response = await updatePortfolioScoreSharing({ visibility });
+      setSharing(response.sharing);
+      setShareUrl(response.shareUrl ? `${window.location.origin}${response.shareUrl}` : null);
+    } catch (err: any) {
+      showToast({
+        message: "Failed to update sharing",
+        description: err?.message || "Unable to update Portfolio Score™ sharing controls.",
+        variant: "error",
+      });
+    } finally {
+      setUpdatingSharing(false);
+    }
+  };
+
+  const handleRotate = async () => {
+    try {
+      setUpdatingSharing(true);
+      const response = await rotatePortfolioScoreSharingToken();
+      setSharing(response.sharing);
+      setShareUrl(response.shareUrl ? `${window.location.origin}${response.shareUrl}` : null);
+    } catch (err: any) {
+      showToast({
+        message: "Failed to rotate sharing link",
+        description: err?.message || "Unable to rotate Portfolio Score™ share link.",
+        variant: "error",
+      });
+    } finally {
+      setUpdatingSharing(false);
+    }
+  };
 
   return (
     <MacShell title="Portfolio score">
@@ -58,6 +111,14 @@ export default function PortfolioScorePage() {
         {!loading && !error && portfolioScore ? (
           <>
             <PortfolioScoreHeader portfolioScore={portfolioScore} />
+            <PortfolioScoreVisibilityCard sharing={sharing} />
+            <PortfolioScoreShareControls
+              sharing={sharing}
+              shareUrl={shareUrl}
+              updating={updatingSharing}
+              onChangeVisibility={handleChangeVisibility}
+              onRotate={handleRotate}
+            />
             <PortfolioScoreComponentList components={portfolioScore.components} />
             <PortfolioScoreTrustPanel trust={portfolioScore.trust} />
           </>

--- a/rentchain-frontend/src/pages/public/SharedPortfolioScorePage.test.tsx
+++ b/rentchain-frontend/src/pages/public/SharedPortfolioScorePage.test.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import SharedPortfolioScorePage from "./SharedPortfolioScorePage";
+
+vi.mock("../../api/publicPortfolioScoreApi", () => ({
+  fetchSharedPortfolioScore: vi.fn(),
+}));
+
+vi.mock("../../components/ui/Ui", () => ({
+  Card: ({ children, elevated: _elevated, ...props }: any) => <div {...props}>{children}</div>,
+  Pill: ({ children }: any) => <span>{children}</span>,
+  Section: ({ children, ...props }: any) => <section {...props}>{children}</section>,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("SharedPortfolioScorePage", () => {
+  it("renders a safe shared score payload", async () => {
+    const { fetchSharedPortfolioScore } = await import("../../api/publicPortfolioScoreApi");
+    vi.mocked(fetchSharedPortfolioScore).mockResolvedValue({
+      portfolioScore: {
+        version: "v1",
+        portfolioId: "portfolio-1",
+        generatedAt: "2026-04-16T12:00:00.000Z",
+        score: 90,
+        grade: "A",
+        summary: {
+          headline: "Your portfolio is operating at a high standard.",
+          explanation: "Recent portfolio activity has been consistent across key areas.",
+        },
+        trend: {
+          direction: "improving",
+          summary: "The score has been improving in recent history.",
+        },
+        components: [],
+        trust: {
+          explanation: "The score reflects operational consistency over time.",
+          methodologyNote: "Scores are based on activity patterns and consistency.",
+        },
+      },
+    } as any);
+
+    render(
+      <MemoryRouter initialEntries={["/portfolio-score/shared/token-1"]}>
+        <Routes>
+          <Route path="/portfolio-score/shared/:token" element={<SharedPortfolioScorePage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Shared Portfolio Score™/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Grade A/i).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/Share controls/i)).not.toBeInTheDocument();
+  });
+
+  it("renders a revoked or invalid token state cleanly", async () => {
+    const { fetchSharedPortfolioScore } = await import("../../api/publicPortfolioScoreApi");
+    vi.mocked(fetchSharedPortfolioScore).mockRejectedValue(new Error("NOT_FOUND"));
+
+    render(
+      <MemoryRouter initialEntries={["/portfolio-score/shared/missing-token"]}>
+        <Routes>
+          <Route path="/portfolio-score/shared/:token" element={<SharedPortfolioScorePage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Shared score unavailable/i)).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/public/SharedPortfolioScorePage.tsx
+++ b/rentchain-frontend/src/pages/public/SharedPortfolioScorePage.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { useParams } from "react-router-dom";
+import { fetchSharedPortfolioScore, type PortfolioScoreSharedViewV1 } from "../../api/publicPortfolioScoreApi";
+import { Card, Section } from "../../components/ui/Ui";
+import PortfolioScoreHeader from "../../components/portfolioScoreExternal/PortfolioScoreHeader";
+import PortfolioScoreComponentList from "../../components/portfolioScoreExternal/PortfolioScoreComponentList";
+import PortfolioScoreTrustPanel from "../../components/portfolioScoreExternal/PortfolioScoreTrustPanel";
+
+export default function SharedPortfolioScorePage() {
+  const { token = "" } = useParams();
+  const [portfolioScore, setPortfolioScore] = React.useState<PortfolioScoreSharedViewV1 | null>(null);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const response = await fetchSharedPortfolioScore(token);
+        if (!mounted) return;
+        setPortfolioScore(response.portfolioScore);
+      } catch (err: any) {
+        if (!mounted) return;
+        setError(err?.message || "This shared score is unavailable.");
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [token]);
+
+  return (
+    <div style={{ minHeight: "100vh", background: "linear-gradient(180deg, #f8fafc 0%, #eef2ff 100%)", padding: 24 }}>
+      <Section style={{ maxWidth: 900, margin: "0 auto" }}>
+        <div style={{ display: "grid", gap: 16 }}>
+          <div style={{ display: "grid", gap: 6 }}>
+            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Shared Portfolio Score™</h1>
+            <div style={{ color: "#475569" }}>
+              A landlord-approved view of portfolio consistency and operational quality over time.
+            </div>
+          </div>
+
+          {loading ? <Card>Loading shared portfolio score…</Card> : null}
+          {!loading && error ? <Card style={{ color: "#b91c1c" }}>Shared score unavailable: {error}</Card> : null}
+
+          {!loading && !error && portfolioScore ? (
+            <>
+              <PortfolioScoreHeader portfolioScore={portfolioScore} />
+              <PortfolioScoreComponentList components={portfolioScore.components} />
+              <PortfolioScoreTrustPanel trust={portfolioScore.trust} />
+            </>
+          ) : null}
+        </div>
+      </Section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Adds Portfolio Score™ Sharing / Visibility Controls v1 as the first controlled distribution layer for landlord-facing Portfolio Score™.

This introduces landlord-controlled visibility state, token-based shared score access, share rotation/revocation controls, and a safe public shared score page built strictly from the existing landlord-safe Portfolio Score™ externalization layer.

## Scope
- Adds `portfolioScoreSharingTypes`, share-state storage helpers, token rotation helpers, and `deriveSharedPortfolioScoreView` under `src/lib/portfolioScoreSharing`
- Adds new landlord-authenticated sharing control endpoints:
  - `GET /api/landlord/portfolio-score-sharing`
  - `PATCH /api/landlord/portfolio-score-sharing`
  - `POST /api/landlord/portfolio-score-sharing/rotate`
- Adds a new token-only shared access endpoint:
  - `GET /api/portfolio-score/shared/:token`
- Stores additive share state in a new `portfolioScoreSharing` collection
- Keeps one share-state record per portfolio with:
  - visibility mode
  - active share token when enabled
  - timestamps for enable/update/revocation
- Updates the landlord Portfolio Score page to render:
  - visibility state
  - sharing controls
  - share URL when enabled
  - rotate/revoke behavior
- Adds a public shared score page at:
  - `/portfolio-score/shared/:token`
- Reuses only landlord-safe score display content:
  - score
  - grade
  - safe summary
  - safe trend
  - simplified components
  - trust/methodology note
- Adds targeted backend and frontend tests for:
  - default-private behavior
  - enabling sharing
  - token rotation
  - revocation
  - invalid-token handling
  - landlord scope enforcement
  - shared page rendering and safety

## Notes
This is intentionally a visibility-control and safe-sharing layer, not a public discovery or ranking system.

For v1:
- sharing is private by default
- only `shareable_link` enables token-based external-style access
- `landlord_visible` is stored as an explicit preference state but remains functionally in-app only
- token rotation invalidates the previous link immediately
- revoking visibility disables shared access immediately

The shared route does not expose:
- internal triage or alert data
- SLA, assignment, or resolution state
- support/debug data
- raw reconciliation or workflow internals
- admin controls or landlord account management UI

No public search, indexing, or leaderboard functionality is added.

## Validation
- Passed targeted backend portfolio-score-sharing tests
- Passed backend build
- Passed targeted frontend portfolio-score sharing/shared-page/route tests
- Passed full frontend test suite
- Passed frontend build