### PR TITLE
chore: add queued mission files 25 to 29 and mission queue

### DIFF
--- a/docs/execution/MISSION_QUEUE.md
+++ b/docs/execution/MISSION_QUEUE.md
@@ -1,0 +1,24 @@
+# Mission Queue
+
+## Status Key
+- queued
+- active
+- in_review
+- blocked
+- merged
+
+| Mission | Title | Branch | Status | Depends On | Purpose |
+|---|---|---|---|---|---|
+| 24 | Subscription / Tier System v2 | feat/subscription-tier-system-v2 | active | mission-system-hardening-v1 | Normalize canonical plans, pricing, entitlements, and upgrade semantics |
+| 25 | Upgrade Prompt and Locked-State System v1 | feat/upgrade-prompt-and-locked-state-system-v1 | queued | 24 | Standardize upgrade prompts, locked states, and required-plan messaging |
+| 26 | Portfolio Intelligence Entitlements v1 | feat/portfolio-intelligence-entitlements-v1 | queued | 24, 25 | Apply clean plan-aware access to portfolio intelligence surfaces |
+| 27 | Marketplace Premium Access Controls v1 | feat/marketplace-premium-access-controls-v1 | queued | 24, 25 | Add premium marketplace gating, visibility, and upgrade handling |
+| 28 | Billing Status and Access Reliability v1 | feat/billing-status-and-access-reliability-v1 | queued | 24 | Harden subscription-state resolution and access consistency |
+| 29 | Subscription Conversion Analytics v1 | feat/subscription-conversion-analytics-v1 | queued | 24, 25, 28 | Measure upgrade prompts, pricing engagement, and conversion funnel performance |
+
+## Notes
+
+- Branches are reserved in mission files but should only be created when the mission is activated.
+- Codex must validate the active branch before implementation and stop if it is incorrect.
+- Each mission should begin with a short audit of source-of-truth files before coding.
+- Do not run dependent missions until their required predecessor missions are merged unless explicitly approved.

--- a/docs/missions/mission-25-upgrade-prompt-and-locked-state-system-v1.md
+++ b/docs/missions/mission-25-upgrade-prompt-and-locked-state-system-v1.md
@@ -1,0 +1,146 @@
+# Mission
+
+MISSION: Upgrade Prompt and Locked-State System v1
+
+# Branch
+
+BRANCH:
+feat/upgrade-prompt-and-locked-state-system-v1
+
+# Base
+
+BASE:
+Start from latest `origin/main` only after Mission 24 (`Subscription / Tier System v2`) is merged and the canonical plan semantics documented there are present on base.
+
+# Objective
+
+OBJECTIVE:
+Standardize RentChain’s upgrade prompt and locked-state behavior so landlord-facing gated surfaces use one consistent upgrade UX system, one required-plan messaging pattern, and one plan-aware routing approach across frontend and backend-compatible flows.
+
+# Why This Matters
+
+Mission 24 normalizes plan semantics and entitlement foundations. The next risk is fragmented upgrade UX:
+- multiple pages manually trigger upgrade prompts
+- locked states can drift in wording, required plan, or CTA behavior
+- users may receive inconsistent nudges for the same entitlement boundary
+
+This mission should consolidate and standardize that experience without rebuilding the existing upgrade infrastructure.
+
+# Strict Requirements
+
+- Reuse the current upgrade prompt / nudge infrastructure.
+- Do not create a second locked-state system.
+- Do not create page-local plan logic where shared helper logic should be used.
+- Keep changes additive and incremental.
+- Preserve current pricing and billing route behavior.
+- Preserve current role boundaries and auth semantics.
+- Prefer soft-gating and clear upgrade messaging over destructive blocking unless an existing route already requires hard enforcement.
+
+# Non-Goals
+
+- Do not redesign billing architecture.
+- Do not redefine canonical plans established by Mission 24.
+- Do not introduce a new modal framework.
+- Do not perform broad visual redesign unrelated to locked-state or upgrade UX consistency.
+
+# Primary Files / File Families To Inspect First
+
+- `rentchain-frontend/src/lib/upgradePrompt.ts`
+- `rentchain-frontend/src/context/UpgradeContext.tsx`
+- `rentchain-frontend/src/features/upgradeNudges/UpgradeNudgeHost.tsx`
+- `rentchain-frontend/src/billing/openUpgradeFlow.ts`
+- `rentchain-frontend/src/lib/entitlements.ts`
+- `rentchain-frontend/src/hooks/useEntitlements.ts`
+- `rentchain-frontend/src/billing/requireTier.ts`
+- `rentchain-frontend/src/pages/PricingPage.tsx`
+- `rentchain-frontend/src/pages/BillingPage.tsx`
+
+Representative prompt triggers:
+- `rentchain-frontend/src/pages/ApplicationsPage.tsx`
+- `rentchain-frontend/src/pages/landlord/InvitesPage.tsx`
+- `rentchain-frontend/src/components/tenants/InviteTenantModal.tsx`
+- `rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx`
+- `rentchain-frontend/src/pages/landlord/WorkOrdersPage.tsx`
+- `rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx`
+
+# Pre-Implementation Audit
+
+Before coding, inspect and summarize:
+1. current reusable upgrade prompt entry points
+2. current required-plan message patterns
+3. current CTA destinations (`/pricing`, `/billing`, modal flows, route flows)
+4. duplicated page-local locked-state logic
+5. any prompt payload shapes or event contracts that already serve as the canonical upgrade UX pathway
+
+Required implementation rule:
+- extend and normalize the current infrastructure
+- do not replace it blindly
+- do not add a second prompt event system
+
+# Implementation Tasks
+
+1. audit and summarize existing prompt / locked-state behavior before coding
+2. define one canonical upgrade prompt message pattern for touched surfaces
+3. define one canonical required-plan label strategy for touched surfaces
+4. normalize selected landlord-facing locked states to shared helper usage
+5. ensure prompt CTA behavior routes consistently to pricing/billing flows as intended
+6. reduce duplicated page-local upgrade wording where safe
+7. update tests for touched prompt and locked-state behavior
+
+# API Surfaces
+
+Primary frontend mission. Backend changes are only allowed if needed to preserve or clarify compatible upgrade payload semantics already in use.
+
+# Frontend Integration Targets
+
+Primary:
+- upgrade prompt host and context
+- required-plan helpers
+- pricing / billing navigation entry points
+
+Representative page targets:
+- applications
+- invites
+- work orders
+- property detail
+- review summary
+- any touched gated landlord-facing surfaces
+
+# Tests Required
+
+Frontend:
+- upgrade prompt rendering tests
+- locked-state rendering tests
+- required-plan helper tests if touched
+- CTA routing / action tests where relevant
+
+Backend:
+- only if a backend upgrade payload or compatibility response is touched
+
+# Manual QA
+
+1. verify touched locked states use consistent wording
+2. verify required-plan labels match canonical Mission 24 semantics
+3. verify upgrade CTA paths are consistent
+4. verify prompts still appear in the correct contexts without blocking baseline workflows unexpectedly
+
+# Acceptance Criteria
+
+- one consistent upgrade prompt / locked-state pattern exists across touched surfaces
+- no second locked-state system is introduced
+- required-plan messaging is more consistent after the mission
+- upgrade CTAs route consistently
+- touched tests pass
+- no billing or entitlement regression is introduced
+
+# Deliverable Summary
+
+- upgrade prompt normalization across touched surfaces
+- locked-state consistency improvements
+- required-plan message normalization
+- tests for touched prompt flows
+
+# Commit
+
+COMMIT:
+feat: add upgrade prompt and locked-state system v1

--- a/docs/missions/mission-26-portfolio-intelligence-entitlements-v1.md
+++ b/docs/missions/mission-26-portfolio-intelligence-entitlements-v1.md
@@ -1,0 +1,134 @@
+# Mission
+
+MISSION: Portfolio Intelligence Entitlements v1
+
+# Branch
+
+BRANCH:
+feat/portfolio-intelligence-entitlements-v1
+
+# Base
+
+BASE:
+Start from latest `origin/main` only after Mission 24 and Mission 25 are merged.
+
+# Objective
+
+OBJECTIVE:
+Apply canonical, plan-aware entitlement behavior to RentChain’s portfolio intelligence surfaces so advanced intelligence value is clearly packaged, consistently gated, and upgrade-aware without breaking baseline landlord workflows.
+
+# Why This Matters
+
+After Subscription / Tier System v2 and upgrade UX normalization, RentChain should expose a clean value ladder for intelligence:
+- baseline portfolio visibility for lower tiers
+- stronger operational intelligence for higher tiers
+- clear teaser/locked states for upgrade conversion
+
+This mission should turn portfolio intelligence into a disciplined monetization surface without creating duplicate gating logic.
+
+# Strict Requirements
+
+- Reuse canonical plan semantics from Mission 24.
+- Reuse upgrade prompt / locked-state patterns from Mission 25.
+- Do not create page-local plan naming drift.
+- Preserve baseline landlord workflows.
+- Keep changes additive and deterministic.
+- Prefer capability-driven gating over scattered direct plan checks.
+
+# Non-Goals
+
+- Do not redesign the underlying portfolio score model.
+- Do not rebuild recommendations or trend engines from scratch.
+- Do not change unrelated dashboard or reporting behavior.
+- Do not create a second intelligence capability system.
+
+# Primary Files / File Families To Inspect First
+
+Backend / capabilities:
+- `rentchain-api/src/services/entitlements/planCapabilities.ts`
+- `rentchain-api/src/config/capabilities.ts`
+- `rentchain-api/src/routes/capabilitiesRoutes.ts`
+
+Frontend entitlement / upgrade helpers:
+- `rentchain-frontend/src/lib/entitlements.ts`
+- `rentchain-frontend/src/hooks/useCapabilities.ts`
+- `rentchain-frontend/src/hooks/useEntitlements.ts`
+- `rentchain-frontend/src/lib/upgradePrompt.ts`
+
+Representative intelligence surfaces:
+- `rentchain-frontend/src/pages/landlord/PortfolioScorePage.tsx`
+- `rentchain-frontend/src/pages/landlord/ActionRecommendationsPage.tsx`
+- portfolio health summary surfaces
+- score trend/history surfaces if present
+- related landlord dashboard intelligence cards if present
+
+# Pre-Implementation Audit
+
+Before coding, inspect and summarize:
+1. which intelligence surfaces already exist
+2. what capability keys currently drive them
+3. which pages already use upgrade prompts or partial teaser states
+4. what the intended tier ladder should be across touched intelligence features
+
+Required implementation rule:
+- normalize touched intelligence surfaces around canonical capabilities
+- do not bypass shared entitlement helpers with ad hoc plan checks
+
+# Implementation Tasks
+
+1. audit touched intelligence pages and current capability usage
+2. identify canonical capability boundaries for baseline vs advanced intelligence
+3. apply consistent locked / teaser / unlocked behavior to touched surfaces
+4. wire touched surfaces to shared entitlement and upgrade helpers
+5. ensure higher-tier value is visible without destructively blocking baseline users
+6. update tests for touched intelligence pages and helpers
+
+# API Surfaces
+
+- `/api/capabilities`
+- `/api/me` only if required for compatibility or display semantics already in use
+
+# Frontend Integration Targets
+
+Primary:
+- portfolio score page
+- action recommendations page
+- portfolio health summary surfaces
+- relevant dashboard intelligence cards
+
+# Tests Required
+
+Frontend:
+- intelligence page locked-state tests
+- upgrade prompt tests for touched surfaces
+- entitlement behavior tests for touched helpers
+
+Backend:
+- only if capability semantics are changed for touched intelligence features
+
+# Manual QA
+
+1. free/starter accounts should retain baseline visibility as intended
+2. pro/elite accounts should unlock intended advanced intelligence value
+3. teaser or locked states should clearly communicate upgrade value
+4. touched pages should remain internally consistent with `/api/capabilities`
+
+# Acceptance Criteria
+
+- touched intelligence surfaces follow canonical entitlement semantics
+- locked/teaser states are consistent and upgrade-aware
+- no duplicate intelligence gating system is introduced
+- touched tests pass
+- no baseline workflow regression is introduced
+
+# Deliverable Summary
+
+- portfolio intelligence gating normalization
+- consistent teaser / locked-state behavior
+- shared entitlement helper usage across touched intelligence surfaces
+- tests for touched intelligence flows
+
+# Commit
+
+COMMIT:
+feat: add portfolio intelligence entitlements v1

--- a/docs/missions/mission-27-marketplace-premium-access-controls-v1.md
+++ b/docs/missions/mission-27-marketplace-premium-access-controls-v1.md
@@ -1,0 +1,131 @@
+# Mission
+
+MISSION: Marketplace Premium Access Controls v1
+
+# Branch
+
+BRANCH:
+feat/marketplace-premium-access-controls-v1
+
+# Base
+
+BASE:
+Start from latest `origin/main` only after Mission 24 and Mission 25 are merged, and after any marketplace-layer-v1 dependencies are present on base.
+
+# Objective
+
+OBJECTIVE:
+Apply canonical subscription-aware access controls, visibility rules, and upgrade handling to RentChain’s marketplace / contractor workflow surfaces so premium marketplace value can be packaged cleanly without breaking baseline marketplace behavior.
+
+# Why This Matters
+
+Marketplace value is one of the clearest premium subscription surfaces. After canonical plan normalization and upgrade UX normalization, marketplace access should become plan-aware in a disciplined way:
+- baseline access where intended
+- premium visibility or workflow advantages for higher tiers
+- consistent upgrade messaging for gated marketplace features
+
+# Strict Requirements
+
+- Reuse canonical plan semantics from Mission 24.
+- Reuse upgrade prompt infrastructure from Mission 25.
+- Keep marketplace access semantics additive.
+- Preserve baseline marketplace or contractor directory behavior where already intended.
+- Do not invent a second marketplace access-control system.
+- Do not widen public or contractor-facing permissions.
+
+# Non-Goals
+
+- Do not redesign the marketplace data model from scratch.
+- Do not change contractor-side auth boundaries.
+- Do not rebuild ranking or recommendation systems unrelated to access control.
+- Do not perform unrelated marketplace UI redesign.
+
+# Primary Files / File Families To Inspect First
+
+Backend / capabilities / routing:
+- `rentchain-api/src/services/entitlements/planCapabilities.ts`
+- `rentchain-api/src/config/capabilities.ts`
+- marketplace-related routes and service files already introduced by marketplace-layer-v1
+
+Frontend entitlement / upgrade helpers:
+- `rentchain-frontend/src/lib/entitlements.ts`
+- `rentchain-frontend/src/hooks/useCapabilities.ts`
+- `rentchain-frontend/src/hooks/useEntitlements.ts`
+- `rentchain-frontend/src/lib/upgradePrompt.ts`
+
+Representative marketplace surfaces:
+- contractor directory pages
+- marketplace landlord workflow pages
+- premium placement / premium workflow surfaces if already present
+- any touched marketplace cards, filters, or CTA surfaces
+
+# Pre-Implementation Audit
+
+Before coding, inspect and summarize:
+1. what marketplace surfaces currently exist
+2. which capabilities or plan checks currently influence them
+3. what should remain baseline vs premium in touched areas
+4. which upgrade flows already exist or should be reused
+
+Required implementation rule:
+- normalize touched marketplace gating around canonical capabilities
+- preserve existing working marketplace flows unless explicitly changing them
+
+# Implementation Tasks
+
+1. audit current marketplace access and entitlement semantics
+2. define touched baseline vs premium marketplace surfaces
+3. wire touched surfaces to canonical capability and upgrade helpers
+4. apply clear locked/teaser states where premium access is introduced or normalized
+5. preserve contractor and landlord auth boundaries
+6. update tests for touched marketplace routes/pages/helpers
+
+# API Surfaces
+
+- marketplace-related capability / access surfaces already in repo
+- `/api/capabilities` if touched
+- relevant marketplace routes if access control behavior is normalized
+
+# Frontend Integration Targets
+
+- contractor directory / marketplace pages
+- premium marketplace workflow surfaces
+- touched marketplace upgrade prompts
+- landlord-facing marketplace cards or entry points
+
+# Tests Required
+
+Frontend:
+- marketplace locked-state / teaser tests
+- upgrade prompt tests for touched marketplace flows
+
+Backend:
+- selected marketplace access-control tests if touched
+- capability derivation tests if touched
+
+# Manual QA
+
+1. baseline marketplace flows still work where intended
+2. premium marketplace areas clearly communicate upgrade value
+3. touched marketplace surfaces use consistent plan naming and upgrade messaging
+4. no contractor auth or visibility regressions are introduced
+
+# Acceptance Criteria
+
+- touched marketplace surfaces follow canonical entitlement semantics
+- premium access controls are clear and additive
+- no second marketplace gating system is introduced
+- touched tests pass
+- no auth boundary regression is introduced
+
+# Deliverable Summary
+
+- marketplace premium access normalization
+- clear locked/teaser behavior for touched marketplace surfaces
+- shared entitlement / upgrade helper usage
+- tests for touched marketplace behavior
+
+# Commit
+
+COMMIT:
+feat: add marketplace premium access controls v1

--- a/docs/missions/mission-28-billing-status-and-access-reliability-v1.md
+++ b/docs/missions/mission-28-billing-status-and-access-reliability-v1.md
@@ -1,0 +1,133 @@
+# Mission
+
+MISSION: Billing Status and Access Reliability v1
+
+# Branch
+
+BRANCH:
+feat/billing-status-and-access-reliability-v1
+
+# Base
+
+BASE:
+Start from latest `origin/main` only after Mission 24 is merged.
+
+# Objective
+
+OBJECTIVE:
+Harden RentChain’s subscription-status, access-resolution, and billing-state reliability so plan access, upgrade state, and billing-driven entitlement behavior remain consistent across backend and frontend after tier normalization.
+
+# Why This Matters
+
+Mission 24 normalizes plan semantics, but monetization reliability depends on billing state resolving correctly:
+- current plan should display accurately
+- access should remain consistent after billing changes
+- route protection and upgrade UX should not drift due to stale or ambiguous subscription state
+
+This mission should focus on access reliability, not on redesigning billing architecture.
+
+# Strict Requirements
+
+- Reuse the canonical plan model from Mission 24.
+- Keep changes additive and reliability-focused.
+- Do not redesign Stripe architecture.
+- Do not create parallel subscription-state logic.
+- Preserve current pricing, checkout, and screening monetization behavior.
+- Prefer normalization and hardening of existing status/access pathways over new layers.
+
+# Non-Goals
+
+- Do not build new billing products.
+- Do not redesign checkout UX.
+- Do not introduce annual/monthly checkout architecture changes.
+- Do not rewrite admin billing operations unrelated to access reliability.
+
+# Primary Files / File Families To Inspect First
+
+Backend:
+- `rentchain-api/src/config/planMatrix.ts`
+- `rentchain-api/src/routes/billingRoutes.ts`
+- `/api/me` source in `rentchain-api/src/app.build.ts`
+- capability and entitlement helpers touched by plan resolution
+- billing/subscription-status routes if already present
+
+Frontend:
+- `rentchain-frontend/src/api/meApi.ts`
+- `rentchain-frontend/src/hooks/useCapabilities.ts`
+- `rentchain-frontend/src/hooks/useEntitlements.ts`
+- billing page and any subscription-status display surfaces
+- upgrade CTA / current plan display surfaces
+
+# Pre-Implementation Audit
+
+Before coding, inspect and summarize:
+1. how current plan is resolved and surfaced backend-to-frontend
+2. how billing/subscription status influences entitlements today
+3. where stale or duplicated access resolution could occur
+4. any touched route or UI surfaces that depend on billing state being current
+
+Required implementation rule:
+- strengthen existing status/access pathways
+- do not add a second subscription-status source of truth
+
+# Implementation Tasks
+
+1. audit current billing-status and access-resolution flow
+2. identify ambiguous or duplicated access-state logic in touched areas
+3. normalize touched plan/access resolution paths
+4. improve current plan display and access consistency where needed
+5. preserve upgrade prompt behavior and screening compatibility
+6. update tests for touched billing/access reliability behavior
+
+# API Surfaces
+
+- `/api/me`
+- `/api/capabilities`
+- `/api/billing/pricing`
+- billing/subscription-status routes if touched
+
+# Frontend Integration Targets
+
+- billing page
+- current plan display surfaces
+- plan-aware access resolution hooks
+- touched upgrade CTA entry points that depend on current plan status
+
+# Tests Required
+
+Backend:
+- touched status/access resolution tests
+- touched billing route tests
+- plan normalization compatibility tests if touched
+
+Frontend:
+- current plan display tests
+- entitlement/access reliability tests
+- billing page rendering tests if touched
+
+# Manual QA
+
+1. verify current plan display is accurate in touched surfaces
+2. verify access remains consistent after expected billing-state scenarios
+3. verify upgrade prompts do not misfire due to stale plan assumptions
+4. verify screening monetization behavior remains compatible
+
+# Acceptance Criteria
+
+- touched billing/access paths are more reliable after the mission
+- no second subscription-state logic layer is introduced
+- current plan display and access behavior are internally consistent
+- touched tests pass
+- no billing or screening regression is introduced
+
+# Deliverable Summary
+
+- billing/access reliability improvements
+- normalized touched plan-status pathways
+- current plan display consistency improvements
+- tests for touched reliability behavior
+
+# Commit
+
+COMMIT:
+feat: add billing status and access reliability v1

--- a/docs/missions/mission-29-subscription-conversion-analytics-v1.md
+++ b/docs/missions/mission-29-subscription-conversion-analytics-v1.md
@@ -1,0 +1,127 @@
+# Mission
+
+MISSION: Subscription Conversion Analytics v1
+
+# Branch
+
+BRANCH:
+feat/subscription-conversion-analytics-v1
+
+# Base
+
+BASE:
+Start from latest `origin/main` only after Mission 24, Mission 25, and Mission 28 are merged.
+
+# Objective
+
+OBJECTIVE:
+Add subscription conversion analytics for RentChain’s pricing, upgrade prompt, and billing entry surfaces so the team can measure engagement, upgrade intent, and conversion flow performance across the normalized subscription system.
+
+# Why This Matters
+
+Once plan semantics, upgrade UX, and billing reliability are in place, RentChain needs visibility into what actually converts:
+- pricing page engagement
+- locked-state CTA engagement
+- upgrade prompt interactions
+- billing surface upgrade intent
+- conversion pathway drop-offs
+
+This mission should add analytics instrumentation in a disciplined way without bloating product logic.
+
+# Strict Requirements
+
+- Keep analytics additive and lightweight.
+- Do not block user flows on analytics delivery.
+- Reuse existing event/logging conventions where present.
+- Do not embed sensitive billing data in client events.
+- Preserve current auth and privacy expectations.
+- Do not create a second analytics framework if one already exists.
+
+# Non-Goals
+
+- Do not build a full analytics warehouse.
+- Do not redesign pricing or billing UX.
+- Do not add heavy dashboarding unless a minimal internal summary already exists and can be extended safely.
+- Do not log raw payment or sensitive personal data.
+
+# Primary Files / File Families To Inspect First
+
+Frontend:
+- pricing page
+- billing page
+- upgrade prompt / nudge infrastructure
+- locked-state CTA surfaces introduced or normalized by Mission 25
+- any existing analytics helper or event utility already in repo
+
+Backend:
+- any existing analytics/event logging routes or telemetry helpers
+- structured logging/event conventions already used by the app
+
+# Pre-Implementation Audit
+
+Before coding, inspect and summarize:
+1. existing analytics/event patterns in frontend and backend
+2. pricing / billing / upgrade prompt entry points worth instrumenting
+3. any current event naming conventions
+4. safe event payload boundaries to avoid sensitive data leakage
+
+Required implementation rule:
+- extend existing telemetry/event patterns if present
+- do not add a parallel analytics stack for this mission
+
+# Implementation Tasks
+
+1. audit current analytics/event instrumentation patterns
+2. define canonical subscription-conversion event names for touched flows
+3. instrument selected pricing, billing, and upgrade-prompt interactions
+4. preserve privacy boundaries and avoid sensitive payloads
+5. optionally add lightweight internal logging or event sink integration if a compatible pattern already exists
+6. update tests for touched analytics helpers/components where relevant
+
+# API Surfaces
+
+Only if existing analytics/event routes or logging helpers are extended. Frontend-only instrumentation is preferred unless backend support is already standard.
+
+# Frontend Integration Targets
+
+Primary:
+- pricing page
+- billing page
+- upgrade prompt / nudge host
+- representative locked-state CTA surfaces
+
+# Tests Required
+
+Frontend:
+- analytics helper tests if added or touched
+- event dispatch tests for touched pricing / upgrade flows where practical
+
+Backend:
+- only if an existing event/logging helper or route is extended
+
+# Manual QA
+
+1. verify upgrade CTA events fire in touched contexts
+2. verify pricing and billing engagement events fire as intended
+3. verify analytics does not block or visibly degrade UX
+4. verify no sensitive billing or personal data is emitted in touched payloads
+
+# Acceptance Criteria
+
+- key subscription conversion touchpoints are instrumented
+- no second analytics framework is introduced
+- instrumentation is lightweight and non-blocking
+- touched tests pass
+- no privacy or UX regression is introduced
+
+# Deliverable Summary
+
+- subscription conversion event instrumentation
+- canonical event naming for touched upgrade/pricing/billing flows
+- lightweight, privacy-aware analytics additions
+- tests for touched instrumentation
+
+# Commit
+
+COMMIT:
+feat: add subscription conversion analytics v1


### PR DESCRIPTION
Adds mission queue and banked mission files for upcoming execution.

Included:
- MISSION_QUEUE.md
- Mission 25–29 definitions

Purpose:
- Pre-stage structured missions for subscription system expansion
- Improve execution discipline for Codex + ChatGPT workflow
- Avoid mid-mission ambiguity and drift

Notes:
- Documentation only
- No product code changes
- No impact to billing, entitlements, or UI behavior