### PR TITLE
feat: implement subscription tier system v2

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -6,6 +6,7 @@ import { routeSource } from "./middleware/routeSource";
 import { notFoundHandler, errorHandler } from "./middleware/errorHandler";
 import { corsOptions } from "./lib/cors";
 import { getPricingHealth } from "./config/planMatrix";
+import { resolveCanonicalPlan } from "./services/entitlements/planCapabilities";
 
 import publicRoutes from "./routes/publicRoutes";
 import authRoutes from "./routes/authRoutes";
@@ -278,7 +279,14 @@ app.get("/api/me", async (req: any, res: any, next: any) => {
   if (!req.user) {
     return res.status(401).json({ ok: false, error: "unauthenticated" });
   }
-  return res.json({ ok: true, user: req.user });
+  const user =
+    req.user && typeof req.user === "object"
+      ? {
+          ...req.user,
+          ...(req.user.plan != null ? { plan: resolveCanonicalPlan(req.user.plan) } : {}),
+        }
+      : req.user;
+  return res.json({ ok: true, user });
 });
 
 // Core prefixed APIs must mount before broad /api routers.

--- a/rentchain-api/src/config/planMatrix.ts
+++ b/rentchain-api/src/config/planMatrix.ts
@@ -1,3 +1,5 @@
+import { resolveCanonicalPlan, type Plan } from "../services/entitlements/planCapabilities";
+
 export type BillingPlanKey = "starter" | "pro" | "elite";
 type PlanInterval = "monthly" | "yearly";
 type StripeEnv = "live" | "test";
@@ -191,6 +193,16 @@ export function getPricingHealth() {
     amountInvalid,
     used,
   };
+}
+
+export function resolvePaidBillingPlan(input?: string | null): BillingPlanKey | null {
+  const plan = resolveCanonicalPlan(input);
+  if (plan === "starter" || plan === "pro" || plan === "elite") return plan;
+  return null;
+}
+
+export function isCanonicalFreePlan(input?: string | null): boolean {
+  return resolveCanonicalPlan(input) === "free";
 }
 
 export function resolvePlanFromPriceId(priceId?: string | null): BillingPlanKey | null {

--- a/rentchain-api/src/entitlements/plans.ts
+++ b/rentchain-api/src/entitlements/plans.ts
@@ -1,4 +1,10 @@
-export type Plan = "free" | "starter" | "pro" | "elite" | "screening" | "core";
+import {
+  resolveCanonicalPlan,
+  type Plan as CanonicalPlan,
+} from "../services/entitlements/planCapabilities";
+
+export type Plan = CanonicalPlan;
+type PlanAlias = CanonicalPlan | "screening" | "core";
 
 export type Capability =
   | "ai.insights"
@@ -9,11 +15,11 @@ export type Capability =
   | "registry_attempts_history";
 
 export interface PlanSpec {
-  plan: Plan;
+  plan: PlanAlias;
   capabilities: Record<Capability, boolean>;
 }
 
-export const PLANS: Record<Plan, PlanSpec> = {
+export const PLANS: Record<PlanAlias, PlanSpec> = {
   free: {
     plan: "free",
     capabilities: {
@@ -83,10 +89,7 @@ export const PLANS: Record<Plan, PlanSpec> = {
 };
 
 export function resolvePlan(input?: string | null): Plan {
-  const p = (input ?? "").toLowerCase().trim();
-  if (p === "starter" || p === "core") return "starter";
-  if (p === "pro") return "pro";
-  if (p === "business" || p === "elite" || p === "enterprise") return "elite";
-  if (p === "free" || p === "screening") return "free";
-  return (process.env.RENTCHAIN_DEFAULT_PLAN as Plan) || "free";
+  const normalized = resolveCanonicalPlan(input);
+  if (normalized) return normalized;
+  return resolveCanonicalPlan(process.env.RENTCHAIN_DEFAULT_PLAN) || "free";
 }

--- a/rentchain-api/src/routes/billingRoutes.ts
+++ b/rentchain-api/src/routes/billingRoutes.ts
@@ -8,6 +8,8 @@ import { FRONTEND_URL } from "../config/screeningConfig";
 import {
   getPlanMatrix,
   getStripeEnv,
+  isCanonicalFreePlan,
+  resolvePaidBillingPlan,
   resolvePlanPriceId,
   type BillingPlanKey,
 } from "../config/planMatrix";
@@ -23,11 +25,7 @@ type SubscriptionStatusTier = "free" | "starter" | "pro" | "elite";
 type SubscriptionStatusInterval = "month" | "year" | null;
 
 function normalizeSubscriptionStatusTier(input: any): SubscriptionStatusTier {
-  const raw = String(input || "").trim().toLowerCase();
-  if (raw === "pro" || raw === "professional") return "pro";
-  if (raw === "elite" || raw === "business" || raw === "enterprise") return "elite";
-  if (raw === "starter" || raw === "core") return "starter";
-  return "free";
+  return resolvePaidBillingPlan(input) || "free";
 }
 
 function sendSubscriptionStatus(req: any, res: any) {
@@ -93,13 +91,10 @@ type BillingTier = BillingPlanKey;
 type BillingInterval = "monthly" | "yearly";
 
 function normalizeTier(input: any): BillingTier | "free" | null {
-  const raw = String(input || "").trim().toLowerCase();
+  const raw = String(input || "").trim();
   if (!raw) return null;
-  if (raw === "free" || raw === "screening") return "free";
-  if (raw === "starter" || raw === "core") return "starter";
-  if (raw === "pro") return "pro";
-  if (raw === "business" || raw === "elite" || raw === "enterprise") return "elite";
-  return null;
+  if (isCanonicalFreePlan(raw)) return "free";
+  return resolvePaidBillingPlan(raw);
 }
 
 function normalizeInterval(input: any): BillingInterval {

--- a/rentchain-api/src/services/__tests__/planCapabilities.test.ts
+++ b/rentchain-api/src/services/__tests__/planCapabilities.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { capabilitiesForPlan } from "../entitlements/planCapabilities";
+import {
+  canonicalPlanLabel,
+  capabilitiesForPlan,
+  resolveCanonicalPlan,
+} from "../entitlements/planCapabilities";
 
 describe("planCapabilities entitlement aliases", () => {
   it("includes operational starter capabilities on starter and above", () => {
@@ -15,5 +19,19 @@ describe("planCapabilities entitlement aliases", () => {
     expect(pro).toContain("screening");
     expect(pro).toContain("registry_filing_access");
     expect(pro).toContain("registry_attempts_history");
+  });
+
+  it("normalizes legacy aliases into canonical plans", () => {
+    expect(resolveCanonicalPlan("screening")).toBe("free");
+    expect(resolveCanonicalPlan("core")).toBe("starter");
+    expect(resolveCanonicalPlan("business")).toBe("elite");
+    expect(resolveCanonicalPlan("enterprise")).toBe("elite");
+  });
+
+  it("returns canonical display labels", () => {
+    expect(canonicalPlanLabel("screening")).toBe("Free");
+    expect(canonicalPlanLabel("core")).toBe("Starter");
+    expect(canonicalPlanLabel("pro")).toBe("Pro");
+    expect(canonicalPlanLabel("elite")).toBe("Elite");
   });
 });

--- a/rentchain-api/src/services/entitlements/planCapabilities.ts
+++ b/rentchain-api/src/services/entitlements/planCapabilities.ts
@@ -1,6 +1,6 @@
 export type Plan = "free" | "starter" | "pro" | "elite";
 
-const PLAN_ORDER: Plan[] = ["free", "starter", "pro", "elite"];
+export const CANONICAL_PLAN_ORDER: Plan[] = ["free", "starter", "pro", "elite"];
 
 const PLAN_ADDITIONS: Record<Plan, string[]> = {
   free: [
@@ -63,11 +63,11 @@ export function resolveCanonicalPlan(input?: string | null): Plan {
 
 export function capabilitiesForPlan(planInput?: string | null): string[] {
   const plan = resolveCanonicalPlan(planInput);
-  const maxIndex = PLAN_ORDER.indexOf(plan);
+  const maxIndex = CANONICAL_PLAN_ORDER.indexOf(plan);
   const set = new Set<string>();
 
   for (let i = 0; i <= maxIndex; i += 1) {
-    for (const capability of PLAN_ADDITIONS[PLAN_ORDER[i]]) {
+    for (const capability of PLAN_ADDITIONS[CANONICAL_PLAN_ORDER[i]]) {
       set.add(capability);
     }
   }
@@ -77,4 +77,12 @@ export function capabilitiesForPlan(planInput?: string | null): string[] {
 
 export function allCanonicalCapabilities(): string[] {
   return capabilitiesForPlan("elite");
+}
+
+export function canonicalPlanLabel(planInput?: string | null): "Free" | "Starter" | "Pro" | "Elite" {
+  const plan = resolveCanonicalPlan(planInput);
+  if (plan === "starter") return "Starter";
+  if (plan === "pro") return "Pro";
+  if (plan === "elite") return "Elite";
+  return "Free";
 }

--- a/rentchain-api/src/services/subscriptionService.ts
+++ b/rentchain-api/src/services/subscriptionService.ts
@@ -9,12 +9,13 @@ export { SubscriptionPlan, PLAN_ORDER, planAtLeast };
 
 export function resolvePlanFromRequest(req: Request): SubscriptionPlan {
   const header = (req.headers["x-demo-plan"] as string | undefined)?.toLowerCase();
-  const envDefault =
-    (process.env.DEFAULT_PLAN as SubscriptionPlan | undefined) || "screening";
-
-  const candidate = (header || envDefault) as SubscriptionPlan;
-  if (PLAN_ORDER.includes(candidate)) return candidate;
-  return "screening";
+  const envDefault = (process.env.DEFAULT_PLAN as string | undefined) || "free";
+  const candidate = String(header || envDefault || "").trim().toLowerCase();
+  if (PLAN_ORDER.includes(candidate as SubscriptionPlan)) return candidate as SubscriptionPlan;
+  if (candidate === "screening") return "free";
+  if (candidate === "core") return "starter";
+  if (candidate === "business" || candidate === "enterprise") return "elite";
+  return "free";
 }
 
 /**

--- a/rentchain-api/src/types/subscription.ts
+++ b/rentchain-api/src/types/subscription.ts
@@ -1,9 +1,8 @@
-export type SubscriptionPlan = "screening" | "starter" | "core" | "pro" | "elite";
+export type SubscriptionPlan = "free" | "starter" | "pro" | "elite";
 
 export const PLAN_ORDER: SubscriptionPlan[] = [
-  "screening",
+  "free",
   "starter",
-  "core",
   "pro",
   "elite",
 ];

--- a/rentchain-api/src/types/user.ts
+++ b/rentchain-api/src/types/user.ts
@@ -1,4 +1,4 @@
-export type SubscriptionPlan = "screening" | "starter" | "core" | "pro" | "elite";
+export type SubscriptionPlan = "free" | "starter" | "pro" | "elite";
 
 export interface User {
   id: string;

--- a/rentchain-frontend/src/api/billingApi.ts
+++ b/rentchain-frontend/src/api/billingApi.ts
@@ -1,5 +1,6 @@
 import { apiFetch, apiJson } from "@/lib/apiClient";
 import { apiGetJson } from "./http";
+import { normalizePlan, normalizePaidPlan, type Plan, type PaidPlan } from "@/lib/plan";
 
 export type BillingRecord = {
   id: string;
@@ -35,7 +36,7 @@ export async function fetchBillingHistory(): Promise<BillingRecord[]> {
 }
 
 export interface SubscriptionStatus {
-  planId: "free" | "starter" | "pro" | "elite";
+  planId: Plan;
   status: "active" | "past_due" | "canceled";
 }
 
@@ -46,7 +47,11 @@ export async function fetchSubscriptionStatus(): Promise<SubscriptionStatus> {
       return { planId: "free", status: "canceled" } as SubscriptionStatus;
     }
     const data = res.data;
-    return (data?.subscription ?? data) as SubscriptionStatus;
+    const payload = (data?.subscription ?? data) as SubscriptionStatus;
+    return {
+      ...payload,
+      planId: normalizePlan(payload?.planId),
+    };
   } catch {
     return { planId: "free", status: "canceled" } as SubscriptionStatus;
   }
@@ -92,7 +97,7 @@ export async function simulateCreditPull(
 }
 
 export type BillingPlanPricing = {
-  key: "starter" | "pro" | "elite";
+  key: PaidPlan;
   label: string;
   currency: string;
   monthlyAmountCents: number;
@@ -128,7 +133,19 @@ export async function fetchBillingPricing(): Promise<BillingPricingResponse | nu
   try {
     const res = await apiFetch<any>("/billing/pricing", { method: "GET" });
     if (!res?.ok) return null;
-    return res as BillingPricingResponse;
+    const payload = res as BillingPricingResponse;
+    return {
+      ...payload,
+      plans: Array.isArray(payload?.plans)
+        ? payload.plans
+            .map((plan) => {
+              const key = normalizePaidPlan(plan?.key);
+              if (!key) return null;
+              return { ...plan, key };
+            })
+            .filter((plan): plan is BillingPlanPricing => Boolean(plan))
+        : [],
+    };
   } catch {
     return null;
   }

--- a/rentchain-frontend/src/api/meApi.ts
+++ b/rentchain-frontend/src/api/meApi.ts
@@ -1,6 +1,17 @@
 import { apiFetch } from "./http";
+import { normalizePlan } from "@/lib/plan";
 
 export async function fetchMe() {
   const res = await apiFetch("/me", { method: "GET" });
-  return res as { landlordId?: string; email?: string; role?: string; plan?: string };
+  const payload = res as { landlordId?: string; email?: string; role?: string; plan?: string; user?: any };
+  if (payload?.user && typeof payload.user === "object") {
+    payload.user = {
+      ...payload.user,
+      ...(payload.user.plan != null ? { plan: normalizePlan(payload.user.plan) } : {}),
+    };
+  }
+  if (payload?.plan != null) {
+    payload.plan = normalizePlan(payload.plan);
+  }
+  return payload;
 }

--- a/rentchain-frontend/src/billing/planLabel.ts
+++ b/rentchain-frontend/src/billing/planLabel.ts
@@ -1,10 +1,7 @@
+import { normalizePlan, planLabel } from "@/lib/plan";
+
 export type NormalizedPlanLabel = "Free" | "Starter" | "Pro" | "Elite";
 
 export function normalizePlanLabel(plan?: string | null): NormalizedPlanLabel {
-  const raw = String(plan || "").trim().toLowerCase();
-  if (!raw || raw === "screening" || raw === "free") return "Free";
-  if (raw === "starter" || raw === "core") return "Starter";
-  if (raw === "pro") return "Pro";
-  if (raw === "business" || raw === "elite" || raw === "enterprise") return "Elite";
-  return "Starter";
+  return planLabel(normalizePlan(plan)) as NormalizedPlanLabel;
 }

--- a/rentchain-frontend/src/billing/planVisibility.ts
+++ b/rentchain-frontend/src/billing/planVisibility.ts
@@ -1,4 +1,4 @@
-export type PlanKey = "starter" | "pro" | "elite" | "screening";
+export type PlanKey = "starter" | "pro" | "elite";
 
 export function getVisiblePlans(role?: string | null): PlanKey[] {
   void role;

--- a/rentchain-frontend/src/billing/requireTier.ts
+++ b/rentchain-frontend/src/billing/requireTier.ts
@@ -1,4 +1,6 @@
-export type TierKey = "starter" | "pro" | "elite";
+import { normalizePaidPlan, type PaidPlan } from "@/lib/plan";
+
+export type TierKey = PaidPlan;
 
 const TIER_ORDER: Record<TierKey, number> = {
   starter: 0,
@@ -7,10 +9,7 @@ const TIER_ORDER: Record<TierKey, number> = {
 };
 
 export function normalizeTier(input?: string | null): TierKey {
-  const value = String(input || "").trim().toLowerCase();
-  if (value === "pro" || value === "professional") return "pro";
-  if (value === "business" || value === "elite" || value === "enterprise") return "elite";
-  return "starter";
+  return normalizePaidPlan(input) || "starter";
 }
 
 export function hasTier(userTier?: string | null, requiredTier: TierKey = "pro"): boolean {

--- a/rentchain-frontend/src/billing/startCheckout.ts
+++ b/rentchain-frontend/src/billing/startCheckout.ts
@@ -1,4 +1,5 @@
 import { apiFetch } from "@/lib/apiClient";
+import { normalizePlan, normalizePaidPlan } from "@/lib/plan";
 
 export type StartCheckoutArgs = {
   tier?: "starter" | "pro" | "elite";
@@ -10,13 +11,11 @@ export type StartCheckoutArgs = {
 };
 
 function normalizeTier(input?: string): "starter" | "pro" | "elite" | "free" | null {
-  const raw = String(input || "").trim().toLowerCase();
+  const raw = String(input || "").trim();
   if (!raw) return null;
-  if (raw === "free" || raw === "screening") return "free";
-  if (raw === "starter" || raw === "core") return "starter";
-  if (raw === "pro") return "pro";
-  if (raw === "business" || raw === "elite" || raw === "enterprise") return "elite";
-  return null;
+  const paidPlan = normalizePaidPlan(raw);
+  if (paidPlan) return paidPlan;
+  return normalizePlan(raw) === "free" ? "free" : null;
 }
 
 function normalizeInterval(input?: string): "monthly" | "yearly" {

--- a/rentchain-frontend/src/components/billing/BillingPlansPanel.tsx
+++ b/rentchain-frontend/src/components/billing/BillingPlansPanel.tsx
@@ -3,6 +3,7 @@ import { Button } from "../ui/Ui";
 import { colors, radius, text } from "../../styles/tokens";
 import { PlanIntervalToggle } from "./PlanIntervalToggle";
 import { getVisiblePlans, type PlanKey } from "@/billing/planVisibility";
+import { normalizePlan } from "@/lib/plan";
 import {
   CANONICAL_TIER_MATRIX,
   TIER_MATRIX_AREAS,
@@ -20,14 +21,6 @@ type Props = {
   mode: "billing" | "pricing";
   planActionLoading?: string | null;
   onSelectPlan: (planKey: "starter" | "pro" | "elite") => void;
-};
-
-const normalizePlan = (input?: string | null): PricingPlanKey => {
-  const raw = String(input || "").trim().toLowerCase();
-  if (raw === "starter" || raw === "core") return "starter";
-  if (raw === "pro") return "pro";
-  if (raw === "business" || raw === "elite" || raw === "enterprise") return "elite";
-  return "free";
 };
 
 export function BillingPlansPanel({

--- a/rentchain-frontend/src/components/billing/UpgradeModal.tsx
+++ b/rentchain-frontend/src/components/billing/UpgradeModal.tsx
@@ -6,6 +6,7 @@ import { fetchBillingPricing, fetchPricingHealth } from "@/api/billingApi";
 import { BillingIntervalToggle } from "./BillingIntervalToggle";
 import { getVisiblePlans, type PlanKey } from "@/billing/planVisibility";
 import { track } from "@/lib/analytics";
+import { normalizePlan, planLabel as canonicalPlanLabel } from "@/lib/plan";
 
 export type UpgradeReason =
   | "propertiesMax"
@@ -37,17 +38,10 @@ export function UpgradeModal({
   const [interval, setInterval] = React.useState<"month" | "year">("month");
   const [selectedPlan, setSelectedPlan] = React.useState<PlanKey>("pro");
   const [notifyOpen, setNotifyOpen] = React.useState(false);
-  const [notifyPlan, setNotifyPlan] = React.useState<"core" | "pro" | "elite">("core");
+  const [notifyPlan, setNotifyPlan] = React.useState<"starter" | "pro" | "elite">("starter");
 
   const safeReason = reason ?? ("propertiesMax" as UpgradeReason);
-  const normalizePlan = (input?: string) => {
-    const raw = String(input || "").trim().toLowerCase();
-    if (raw === "starter" || raw === "core") return "starter";
-    if (raw === "pro") return "pro";
-    if (raw === "business" || raw === "elite" || raw === "enterprise") return "elite";
-    return "starter";
-  };
-  const currentPlanKey = normalizePlan(currentPlan);
+  const currentPlanKey = normalizePlan(currentPlan, "starter");
 
   React.useEffect(() => {
     if (!open) return;
@@ -111,16 +105,7 @@ export function UpgradeModal({
     const suffix = interval === "year" ? "year" : "month";
     return `$${Math.round(amountCents / 100)} / ${suffix}`;
   };
-  const planLabel = (planKey: PlanKey) => {
-    switch (planKey) {
-      case "pro":
-        return "Pro";
-      case "elite":
-        return "Elite";
-      default:
-        return "Starter";
-    }
-  };
+  const displayPlanLabel = (planKey: PlanKey) => canonicalPlanLabel(planKey);
   const planDescription = (planKey: PlanKey) => {
     switch (planKey) {
       case "pro":
@@ -199,11 +184,11 @@ export function UpgradeModal({
 
           <div style={{ marginTop: 20, display: "grid", gap: 10 }}>
             {visiblePlans
-              .filter((planKey) => planKey !== "screening")
+              .filter(Boolean)
               .map((planKey) => (
                 <PlanRow
                   key={planKey}
-                  name={planLabel(planKey)}
+                  name={displayPlanLabel(planKey)}
                   description={planDescription(planKey)}
                   active={currentPlanKey === planKey}
                   highlight={selectedPlan === planKey}

--- a/rentchain-frontend/src/context/SubscriptionContext.tsx
+++ b/rentchain-frontend/src/context/SubscriptionContext.tsx
@@ -8,8 +8,9 @@ import React, {
 } from "react";
 import { fetchMe } from "../api/meApi";
 import { getAuthToken } from "../lib/authToken";
+import { isPlanAtLeast, normalizePlan, type Plan } from "../lib/plan";
 
-export type SubscriptionPlan = "screening" | "starter" | "core" | "pro" | "elite";
+export type SubscriptionPlan = Plan;
 
 type SubscriptionFeatures = {
   plan: SubscriptionPlan;
@@ -49,22 +50,14 @@ function computeFeatures(plan: SubscriptionPlan): SubscriptionFeatures {
     SubscriptionPlan,
     { properties: number; units: number }
   > = {
-    screening: { properties: Infinity, units: Infinity },
+    free: { properties: Infinity, units: Infinity },
     starter: { properties: Infinity, units: Infinity },
-    core: { properties: Infinity, units: Infinity },
     pro: { properties: Infinity, units: Infinity },
     elite: { properties: Infinity, units: Infinity },
   };
 
-  const caps = capsByPlan[plan] || capsByPlan.starter;
-  const planRank: Record<SubscriptionPlan, number> = {
-    screening: 0,
-    starter: 1,
-    core: 1,
-    pro: 2,
-    elite: 3,
-  };
-  const atLeast = (min: SubscriptionPlan) => planRank[plan] >= planRank[min];
+  const caps = capsByPlan[plan] || capsByPlan.free;
+  const atLeast = (min: SubscriptionPlan) => isPlanAtLeast(plan, min);
 
   return {
     plan,
@@ -90,7 +83,7 @@ function computeFeatures(plan: SubscriptionPlan): SubscriptionFeatures {
 
 export function SubscriptionProvider({
   children,
-  initialPlan = "screening",
+  initialPlan = "free",
 }: {
   children: ReactNode;
   initialPlan?: SubscriptionPlan;
@@ -109,13 +102,13 @@ export function SubscriptionProvider({
       .then((me) => {
         const user = (me as any)?.user && typeof (me as any).user === "object" ? (me as any).user : me;
         const p = user?.plan;
-        if (p === "screening" || p === "starter" || p === "core" || p === "pro" || p === "elite") {
-          setPlan(p);
+        if (p != null) {
+          setPlan(normalizePlan(p));
           return;
         }
 
         if (user?.role === "landlord") {
-          setPlan("screening");
+          setPlan("free");
         }
       })
       .catch(() => {

--- a/rentchain-frontend/src/hooks/useBillingStatus.test.tsx
+++ b/rentchain-frontend/src/hooks/useBillingStatus.test.tsx
@@ -1,0 +1,48 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useBillingStatus, billingTierLabel } from "./useBillingStatus";
+
+vi.mock("@/api/billingApi", () => ({
+  fetchSubscriptionStatus: vi.fn(),
+}));
+
+vi.mock("@/hooks/useCapabilities", () => ({
+  useCapabilities: vi.fn(),
+}));
+
+vi.mock("@/context/useAuth", () => ({
+  useAuth: vi.fn(),
+}));
+
+describe("useBillingStatus", () => {
+  it("normalizes alias plans from capabilities and auth state", async () => {
+    const { fetchSubscriptionStatus } = await import("@/api/billingApi");
+    const { useCapabilities } = await import("@/hooks/useCapabilities");
+    const { useAuth } = await import("@/context/useAuth");
+
+    vi.mocked(fetchSubscriptionStatus).mockResolvedValue({
+      planId: "free",
+      status: "active",
+      interval: "month",
+      renewalDate: null,
+    } as any);
+    vi.mocked(useCapabilities).mockReturnValue({
+      caps: { plan: "business" },
+      loading: false,
+    } as any);
+    vi.mocked(useAuth).mockReturnValue({
+      user: { id: "u1", role: "landlord", plan: "core" },
+    } as any);
+
+    const { result } = renderHook(() => useBillingStatus());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.tier).toBe("elite");
+  });
+
+  it("exposes canonical billing labels", () => {
+    expect(billingTierLabel("screening")).toBe("Free");
+    expect(billingTierLabel("core")).toBe("Starter");
+    expect(billingTierLabel("enterprise")).toBe("Elite");
+  });
+});

--- a/rentchain-frontend/src/hooks/useBillingStatus.ts
+++ b/rentchain-frontend/src/hooks/useBillingStatus.ts
@@ -2,8 +2,9 @@ import { useEffect, useMemo, useState } from "react";
 import { fetchSubscriptionStatus } from "@/api/billingApi";
 import { useCapabilities } from "@/hooks/useCapabilities";
 import { useAuth } from "@/context/useAuth";
+import { normalizePlan, planLabel, type Plan } from "@/lib/plan";
 
-type PlanTier = "free" | "starter" | "pro" | "elite";
+type PlanTier = Plan;
 type BillingInterval = "month" | "year" | null;
 
 type BillingStatus = {
@@ -25,15 +26,8 @@ const DEFAULT_STATUS: BillingStatus = {
   isLoading: true,
 };
 
-const planFromString = (raw?: string | null): PlanTier | null => {
-  const value = String(raw || "").trim().toLowerCase();
-  if (!value) return null;
-  if (value === "pro" || value === "professional") return "pro";
-  if (value === "elite" || value === "business" || value === "enterprise") return "elite";
-  if (value === "starter" || value === "core") return "starter";
-  if (value === "screening" || value === "free") return "free";
-  return null;
-};
+const planFromString = (raw?: string | null): PlanTier | null =>
+  raw == null || String(raw).trim() === "" ? null : normalizePlan(raw);
 
 const intervalFromString = (raw?: string | null): BillingInterval => {
   const value = String(raw || "").trim().toLowerCase();
@@ -119,9 +113,5 @@ export function useBillingStatus(): BillingStatus {
 }
 
 export function billingTierLabel(tier?: string | null): string {
-  const normalized = planFromString(tier) || "free";
-  if (normalized === "free") return "Free";
-  if (normalized === "starter") return "Starter";
-  if (normalized === "pro") return "Pro";
-  return "Elite";
+  return planLabel(planFromString(tier) || "free");
 }

--- a/rentchain-frontend/src/hooks/useCapabilities.ts
+++ b/rentchain-frontend/src/hooks/useCapabilities.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { apiFetch } from "@/lib/apiClient";
+import { normalizePlan } from "@/lib/plan";
 import {
   DEFAULT_CAPABILITIES,
   getCachedCapabilities,
@@ -25,11 +26,11 @@ export function useCapabilities() {
         const res = await apiFetch("/capabilities");
         if (!alive) return;
         const next = res as Capabilities;
-        setCaps(next);
+        setCaps({ ...next, plan: normalizePlan(next?.plan) });
         if (next && typeof next === "object") {
           setCachedCapabilities({
             ok: next.ok,
-            plan: next.plan,
+            plan: normalizePlan(next.plan),
             features: next.features || {},
             ts: next.ts,
           });
@@ -47,7 +48,7 @@ export function useCapabilities() {
       if (!alive) return;
       const detail = (evt as CustomEvent<CapabilitiesResponse>).detail;
       if (detail && typeof detail === "object") {
-        setCaps({ ok: Boolean(detail.ok), ...detail });
+        setCaps({ ok: Boolean(detail.ok), ...detail, plan: normalizePlan(detail.plan) });
       }
     };
     if (typeof window !== "undefined") {

--- a/rentchain-frontend/src/hooks/useEntitlements.ts
+++ b/rentchain-frontend/src/hooks/useEntitlements.ts
@@ -1,7 +1,8 @@
 import { useMemo } from "react";
 import { useAuth } from "@/context/useAuth";
 import { useCapabilities } from "@/hooks/useCapabilities";
-import { normalizePlanName, resolveRequiredPlan } from "@/lib/upgradePrompt";
+import { normalizePlan } from "@/lib/plan";
+import { resolveRequiredPlan } from "@/lib/upgradePrompt";
 
 function hasFeature(features: Record<string, boolean>, keys: string[]) {
   return keys.some((key) => Boolean(features[key]));
@@ -15,7 +16,7 @@ export function useEntitlements() {
     const role = String(user?.actorRole || user?.role || "").toLowerCase();
     const isAdmin = role === "admin";
     const featureMap = features || {};
-    const plan = normalizePlanName(caps?.plan || user?.plan || null) || "free";
+    const plan = normalizePlan(caps?.plan || user?.plan || null);
     const hasPaidScreeningPlan = plan === "starter" || plan === "pro" || plan === "elite";
 
     const canScreen =

--- a/rentchain-frontend/src/lib/entitlements.ts
+++ b/rentchain-frontend/src/lib/entitlements.ts
@@ -1,8 +1,9 @@
 import { apiFetch } from "@/lib/apiClient";
+import { normalizePlan, type Plan } from "@/lib/plan";
 
 export type CapabilitiesResponse = {
   ok?: boolean;
-  plan?: string;
+  plan?: Plan | string;
   features: Record<string, boolean>;
   ts?: number;
 };
@@ -45,9 +46,12 @@ export function getCachedCapabilities(): CapabilitiesResponse | null {
 }
 
 export function setCachedCapabilities(next: CapabilitiesResponse) {
-  cachedCapabilities = next;
+  cachedCapabilities = {
+    ...next,
+    plan: normalizePlan(next?.plan),
+  };
   if (typeof window !== "undefined") {
-    window.dispatchEvent(new CustomEvent("capabilities:updated", { detail: next }));
+    window.dispatchEvent(new CustomEvent("capabilities:updated", { detail: cachedCapabilities }));
   }
 }
 
@@ -68,7 +72,7 @@ export async function refreshEntitlements(
     if (caps && typeof caps === "object") {
       setCachedCapabilities({
         ok: caps.ok,
-        plan: caps.plan,
+        plan: normalizePlan(caps.plan),
         features: caps.features || {},
         ts: caps.ts,
       });

--- a/rentchain-frontend/src/lib/plan.test.ts
+++ b/rentchain-frontend/src/lib/plan.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  isPlanAtLeast,
+  normalizePaidPlan,
+  normalizePlan,
+  planLabel,
+  resolvePlanFrom,
+} from "./plan";
+
+describe("plan normalization", () => {
+  it("normalizes legacy aliases to canonical plans", () => {
+    expect(normalizePlan("screening")).toBe("free");
+    expect(normalizePlan("core")).toBe("starter");
+    expect(normalizePlan("business")).toBe("elite");
+    expect(normalizePlan("enterprise")).toBe("elite");
+  });
+
+  it("resolves paid plans without treating free aliases as paid", () => {
+    expect(normalizePaidPlan("starter")).toBe("starter");
+    expect(normalizePaidPlan("core")).toBe("starter");
+    expect(normalizePaidPlan("screening")).toBeNull();
+  });
+
+  it("provides canonical labels and ordering", () => {
+    expect(planLabel("free")).toBe("Free");
+    expect(planLabel("elite")).toBe("Elite");
+    expect(isPlanAtLeast("elite", "pro")).toBe(true);
+    expect(isPlanAtLeast("free", "starter")).toBe(false);
+  });
+
+  it("prefers limits and me payloads when resolving plan context", () => {
+    expect(resolvePlanFrom({ limits: { plan: "core" } })).toBe("starter");
+    expect(resolvePlanFrom({ me: { plan: "business" } })).toBe("elite");
+    expect(resolvePlanFrom({})).toBe("free");
+  });
+});

--- a/rentchain-frontend/src/lib/plan.ts
+++ b/rentchain-frontend/src/lib/plan.ts
@@ -1,28 +1,44 @@
-// src/lib/plan.ts
-export type Plan = "starter" | "core" | "pro" | "elite";
+export const CANONICAL_PLAN_ORDER = ["free", "starter", "pro", "elite"] as const;
 
-export function normalizePlan(input: any): Plan {
-  const v = String(input ?? "").trim().toLowerCase();
-  if (v === "starter" || v === "core" || v === "pro" || v === "elite") return v;
-  return "starter";
+export type Plan = (typeof CANONICAL_PLAN_ORDER)[number];
+export type PaidPlan = Exclude<Plan, "free">;
+
+export function normalizePlan(input?: unknown, fallback: Plan = "free"): Plan {
+  const value = String(input ?? "").trim().toLowerCase();
+  if (!value) return fallback;
+  if (value === "free" || value === "screening") return "free";
+  if (value === "starter" || value === "core") return "starter";
+  if (value === "pro" || value === "professional") return "pro";
+  if (value === "elite" || value === "business" || value === "enterprise") return "elite";
+  return fallback;
+}
+
+export function normalizePaidPlan(input?: unknown): PaidPlan | null {
+  const plan = normalizePlan(input);
+  if (plan === "starter" || plan === "pro" || plan === "elite") return plan;
+  return null;
 }
 
 export function planLabel(plan: Plan): string {
   if (plan === "starter") return "Starter";
-  if (plan === "core") return "Core";
   if (plan === "pro") return "Pro";
-  return "Elite";
+  if (plan === "elite") return "Elite";
+  return "Free";
 }
 
-export function resolvePlanFrom(args: { me?: any; limits?: any }): Plan {
+export function isPlanAtLeast(current: Plan, required: Plan): boolean {
+  return CANONICAL_PLAN_ORDER.indexOf(current) >= CANONICAL_PLAN_ORDER.indexOf(required);
+}
+
+export function resolvePlanFrom(args: { me?: any; limits?: any }, fallback: Plan = "free"): Plan {
   const fromLimits =
     args?.limits?.plan ??
     args?.limits?.tier ??
     args?.limits?.entitlements?.plan;
-  if (fromLimits) return normalizePlan(fromLimits);
+  if (fromLimits) return normalizePlan(fromLimits, fallback);
 
   const fromMe = args?.me?.plan ?? args?.me?.tier;
-  if (fromMe) return normalizePlan(fromMe);
+  if (fromMe) return normalizePlan(fromMe, fallback);
 
-  return "starter";
+  return fallback;
 }

--- a/rentchain-frontend/src/lib/upgradePrompt.ts
+++ b/rentchain-frontend/src/lib/upgradePrompt.ts
@@ -1,3 +1,5 @@
+import { CANONICAL_PLAN_ORDER, normalizePlan } from "@/lib/plan";
+
 export type UpgradePromptDetail = {
   featureKey: string;
   currentPlan?: string;
@@ -5,8 +7,6 @@ export type UpgradePromptDetail = {
   source?: string;
   redirectTo?: string;
 };
-
-const PLAN_ORDER = ["free", "starter", "pro", "elite"] as const;
 
 const FEATURE_REQUIRED_PLAN: Record<string, string> = {
   applications_manual: "free",
@@ -49,11 +49,7 @@ const FEATURE_REQUIRED_PLAN: Record<string, string> = {
 export function normalizePlanName(input?: any): string | undefined {
   const raw = String(input ?? "").trim().toLowerCase();
   if (!raw) return undefined;
-  if (PLAN_ORDER.includes(raw as (typeof PLAN_ORDER)[number])) return raw;
-  if (raw === "screening") return "free";
-  if (raw === "core") return "starter";
-  if (raw === "business" || raw === "enterprise") return "elite";
-  return undefined;
+  return normalizePlan(raw);
 }
 
 export function resolveRequiredPlan(featureKey?: string, currentPlan?: string): string | undefined {
@@ -63,8 +59,8 @@ export function resolveRequiredPlan(featureKey?: string, currentPlan?: string): 
   if (required) return required;
   const current = normalizePlanName(currentPlan);
   if (!current) return "pro";
-  const idx = PLAN_ORDER.indexOf(current as (typeof PLAN_ORDER)[number]);
-  if (idx >= 0 && idx < PLAN_ORDER.length - 1) return PLAN_ORDER[idx + 1];
+  const idx = CANONICAL_PLAN_ORDER.indexOf(current as (typeof CANONICAL_PLAN_ORDER)[number]);
+  if (idx >= 0 && idx < CANONICAL_PLAN_ORDER.length - 1) return CANONICAL_PLAN_ORDER[idx + 1];
   return current || "pro";
 }
 

--- a/rentchain-frontend/src/pages/PricingPage.tsx
+++ b/rentchain-frontend/src/pages/PricingPage.tsx
@@ -16,6 +16,7 @@ import {
   type PricingPlanKey,
 } from "../constants/pricingPlans";
 import { track } from "@/lib/analytics";
+import { normalizePlan } from "@/lib/plan";
 
 type PlanKey = PricingPlanKey;
 
@@ -46,14 +47,6 @@ function pricingCardShadow(plan: PlanKey, hovered: boolean) {
     return hovered ? "0 22px 42px rgba(37,99,235,0.16)" : "0 16px 34px rgba(37,99,235,0.12)";
   }
   return hovered ? "0 16px 32px rgba(15,23,42,0.10)" : "0 10px 24px rgba(15,23,42,0.06)";
-}
-
-function normalizePlan(input?: string | null): PlanKey {
-  const raw = String(input || "").trim().toLowerCase();
-  if (raw === "starter" || raw === "core") return "starter";
-  if (raw === "pro") return "pro";
-  if (raw === "elite" || raw === "business" || raw === "enterprise") return "elite";
-  return "free";
 }
 
 function ctaLabel(plan: Exclude<PlanKey, "free">) {

--- a/rentchain-frontend/src/pages/marketing/PricingPage.tsx
+++ b/rentchain-frontend/src/pages/marketing/PricingPage.tsx
@@ -13,6 +13,7 @@ import {
   type PricingInterval,
   type PricingPlanKey,
 } from "../../constants/pricingPlans";
+import { normalizePlan } from "../../lib/plan";
 import { useLanguage } from "../../context/LanguageContext";
 import { marketingCopy } from "../../content/marketingCopy";
 import { track } from "../../lib/analytics";
@@ -32,14 +33,6 @@ const wrappingTextStyle: React.CSSProperties = {
   overflowWrap: "anywhere",
   wordBreak: "break-word",
 };
-
-function normalizePlan(input?: string | null): PlanKey {
-  const raw = String(input || "").trim().toLowerCase();
-  if (raw === "starter" || raw === "core") return "starter";
-  if (raw === "pro") return "pro";
-  if (raw === "elite" || raw === "business" || raw === "enterprise") return "elite";
-  return "free";
-}
 
 function isAtOrAbove(plan: PlanKey, target: PlanKey) {
   return PLAN_ORDER.indexOf(plan) >= PLAN_ORDER.indexOf(target);


### PR DESCRIPTION
## Summary

Implements Subscription / Tier System v2 by normalizing RentChain’s subscription semantics around the canonical plan model:

- free
- starter
- pro
- elite

This keeps the current system compatible while reducing plan, entitlement, pricing, and upgrade-surface drift across backend and frontend.

## What changed

### Backend
- Kept `planCapabilities.ts` as the canonical plan progression source
- Preserved legacy alias compatibility:
  - `screening -> free`
  - `core -> starter`
  - `business -> elite`
  - `enterprise -> elite`
- Kept `planMatrix.ts` as paid recurring billing config only
- Preserved `/api/me` behavior while minimally normalizing returned plan semantics
- Preserved `/api/billing/pricing` as backward-compatible and paid-plan-only

### Frontend
- Consolidated touched pricing, billing, entitlement, and upgrade surfaces onto a shared plan-normalization path
- Reduced page-local normalization drift in pricing/billing surfaces
- Aligned touched plan labels, tier checks, billing status handling, entitlement helpers, and upgrade prompt semantics
- Preserved screening as pay-per-use on all tiers and kept `screening` as a legacy alias to `free`

## Files changed

### Backend
- `rentchain-api/src/app.build.ts`
- `rentchain-api/src/config/planMatrix.ts`
- `rentchain-api/src/entitlements/plans.ts`
- `rentchain-api/src/routes/billingRoutes.ts`
- `rentchain-api/src/services/__tests__/planCapabilities.test.ts`
- `rentchain-api/src/services/entitlements/planCapabilities.ts`
- `rentchain-api/src/services/subscriptionService.ts`
- `rentchain-api/src/types/subscription.ts`
- `rentchain-api/src/types/user.ts`

### Frontend
- `rentchain-frontend/src/api/billingApi.ts`
- `rentchain-frontend/src/api/meApi.ts`
- `rentchain-frontend/src/billing/planLabel.ts`
- `rentchain-frontend/src/billing/planVisibility.ts`
- `rentchain-frontend/src/billing/requireTier.ts`
- `rentchain-frontend/src/billing/startCheckout.ts`
- `rentchain-frontend/src/components/billing/BillingPlansPanel.tsx`
- `rentchain-frontend/src/components/billing/UpgradeModal.tsx`
- `rentchain-frontend/src/context/SubscriptionContext.tsx`
- `rentchain-frontend/src/hooks/useBillingStatus.test.tsx`
- `rentchain-frontend/src/hooks/useBillingStatus.ts`
- `rentchain-frontend/src/hooks/useCapabilities.ts`
- `rentchain-frontend/src/hooks/useEntitlements.ts`
- `rentchain-frontend/src/lib/entitlements.ts`
- `rentchain-frontend/src/lib/plan.test.ts`
- `rentchain-frontend/src/lib/plan.ts`
- `rentchain-frontend/src/lib/upgradePrompt.ts`
- `rentchain-frontend/src/pages/PricingPage.tsx`
- `rentchain-frontend/src/pages/marketing/PricingPage.tsx`

## Verification

### Backend
- `npm run test -- src/services/__tests__/planCapabilities.test.ts`
- `npm run build`

### Frontend
- `npm run test -- src/lib/plan.test.ts src/hooks/useEntitlements.test.tsx src/hooks/useBillingStatus.test.tsx src/pages/AccountPage.test.tsx src/pages/screening/ScreeningStartPage.test.tsx`
- `npm run build`

## Compatibility notes

- `/api/billing/pricing` remains paid-plan-only
- `/api/me` remains minimally changed outside plan normalization
- `/api/capabilities` compatibility semantics remain intact through shared backend normalization
- legacy alias inputs continue to resolve safely
- screening monetization remains compatible and was not redesigned

## Intentionally out of scope

- full repo-wide cleanup of all historical legacy plan strings
- dormant onboarding/subscription preview surface cleanup
- full frontend suite execution beyond the targeted verification pass
- broader admin/internal plan label cleanup outside the main landlord monetization flow