### PR TITLE
feat: add upgrade prompt and locked-state system v1

### DIFF
--- a/rentchain-frontend/src/billing/upgradeCopy.ts
+++ b/rentchain-frontend/src/billing/upgradeCopy.ts
@@ -117,6 +117,18 @@ const COPY_MAP: Record<string, UpgradeCopy> = {
     secondaryCta: "Not now",
     requiredPlanLabel: "Starter",
   },
+  screening_workflow: {
+    title: "Upgrade to Starter",
+    subtitle: "Starter includes applicant screening workflow tools inside RentChain.",
+    bullets: [
+      "Send screening requests from the application workflow",
+      "Keep screening activity tied to the applicant record",
+      "Review screening progress without leaving RentChain",
+    ],
+    primaryCta: "Upgrade to Starter",
+    secondaryCta: "Not now",
+    requiredPlanLabel: "Starter",
+  },
   "ai.insights": {
     title: "Upgrade for AI insights",
     subtitle: "Portfolio insights are available on Pro.",
@@ -138,6 +150,7 @@ export function getUpgradeCopy(featureKey?: string): UpgradeCopy {
   if (COPY_MAP[key]) return COPY_MAP[key];
 
   if (key === "unitstable") return COPY_MAP.units;
+  if (key === "screening_workflow") return COPY_MAP.screening_workflow;
   if (key === "tenantportal") return COPY_MAP.screening;
   if (key === "move_in_readiness" || key === "work_orders") return COPY_MAP.maintenance;
   if (key === "pdf_export") return COPY_MAP.exports;

--- a/rentchain-frontend/src/components/billing/UpgradeCTA.test.tsx
+++ b/rentchain-frontend/src/components/billing/UpgradeCTA.test.tsx
@@ -1,0 +1,36 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { UpgradeCTA } from "./UpgradeCTA";
+
+vi.mock("@/context/useAuth", () => ({
+  useAuth: () => ({
+    user: {
+      plan: "core",
+    },
+  }),
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("UpgradeCTA", () => {
+  it("dispatches the canonical upgrade prompt flow", () => {
+    const dispatchSpy = vi.spyOn(window, "dispatchEvent");
+
+    render(<UpgradeCTA featureKey="tenant_invites" label="Upgrade now" source="unit_test" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Upgrade now" }));
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    const event = dispatchSpy.mock.calls[0][0] as CustomEvent;
+    expect(event.type).toBe("upgrade:prompt");
+    expect(event.detail).toMatchObject({
+      featureKey: "tenant_invites",
+      currentPlan: "starter",
+      requiredPlan: "starter",
+      source: "unit_test",
+      redirectTo: "/",
+    });
+  });
+});

--- a/rentchain-frontend/src/components/billing/UpgradeCTA.tsx
+++ b/rentchain-frontend/src/components/billing/UpgradeCTA.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 import { Button } from "../ui/Ui";
-import { useUpgrade } from "@/context/UpgradeContext";
 import { useAuth } from "@/context/useAuth";
 import { getUpgradeCopy } from "@/billing/upgradeCopy";
-import { resolveRequiredPlan } from "@/lib/upgradePrompt";
+import { dispatchUpgradePrompt, resolveRequiredPlan } from "@/lib/upgradePrompt";
 
 type Props = {
   featureKey: string;
@@ -11,16 +10,7 @@ type Props = {
   source?: string;
   variant?: "primary" | "secondary" | "ghost";
   size?: "sm" | "md";
-  title?: string;
-  description?: string;
 };
-
-function toReason(featureKey: string): "screening" | "exports" | "automation" {
-  const key = String(featureKey || "").toLowerCase();
-  if (key.includes("export") || key.includes("pdf") || key.includes("review_summary")) return "exports";
-  if (key.includes("screen")) return "screening";
-  return "automation";
-}
 
 export function UpgradeCTA({
   featureKey,
@@ -28,13 +18,14 @@ export function UpgradeCTA({
   source,
   variant = "primary",
   size = "md",
-  title,
-  description,
 }: Props) {
-  const { openUpgrade } = useUpgrade();
   const { user } = useAuth();
   const copy = getUpgradeCopy(featureKey);
-  const requiredPlan = resolveRequiredPlan(featureKey) || copy.requiredPlanLabel || "Pro";
+  const requiredPlan = resolveRequiredPlan(featureKey, user?.plan) || "pro";
+  const redirectTo =
+    typeof window !== "undefined"
+      ? `${window.location.pathname}${window.location.search}`
+      : "/dashboard";
 
   return (
     <Button
@@ -42,14 +33,12 @@ export function UpgradeCTA({
       variant={variant}
       style={size === "sm" ? { padding: "6px 10px", fontSize: 12 } : undefined}
       onClick={() =>
-        openUpgrade({
-          reason: toReason(featureKey),
-          plan: user?.plan || "free",
-          ctaLabel: label || copy.primaryCta,
-          copy: {
-            title: title || copy.title,
-            body: description || copy.subtitle,
-          },
+        dispatchUpgradePrompt({
+          featureKey,
+          currentPlan: user?.plan || "free",
+          requiredPlan,
+          source: source || featureKey,
+          redirectTo,
         })
       }
       data-upgrade-source={source || featureKey}

--- a/rentchain-frontend/src/components/billing/UpgradePromptModal.test.tsx
+++ b/rentchain-frontend/src/components/billing/UpgradePromptModal.test.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { UpgradePromptModal } from "./UpgradePromptModal";
+
+const mocks = vi.hoisted(() => ({
+  startCheckout: vi.fn(),
+}));
+
+vi.mock("@/billing/startCheckout", () => ({
+  startCheckout: mocks.startCheckout,
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("UpgradePromptModal", () => {
+  it("uses shared plan normalization for display and checkout", () => {
+    render(
+      <MemoryRouter>
+        <UpgradePromptModal
+          open
+          onClose={vi.fn()}
+          featureKey="tenant_invites"
+          currentPlan="core"
+          source="unit_test"
+          redirectTo="/applications"
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Current: Starter")).toBeInTheDocument();
+    expect(screen.getByText("Needed: Starter")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "See upgrade options" }));
+
+    expect(mocks.startCheckout).toHaveBeenCalledWith({
+      tier: "starter",
+      interval: "monthly",
+      requiredPlan: "starter",
+      featureKey: "tenant_invites",
+      source: "unit_test",
+      redirectTo: "/applications",
+    });
+  });
+});

--- a/rentchain-frontend/src/components/billing/UpgradePromptModal.tsx
+++ b/rentchain-frontend/src/components/billing/UpgradePromptModal.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { getUpgradeCopy } from "@/billing/upgradeCopy";
 import { normalizePlanLabel } from "@/billing/planLabel";
+import { normalizePaidPlan } from "@/lib/plan";
+import { resolveRequiredPlan } from "@/lib/upgradePrompt";
 import { startCheckout } from "@/billing/startCheckout";
 
 export function UpgradePromptModal({
@@ -24,9 +26,9 @@ export function UpgradePromptModal({
   if (!open) return null;
 
   const copy = useMemo(() => getUpgradeCopy(featureKey), [featureKey]);
-  const requiredPlanKey = requiredPlan;
-  const requiredLabel = copy.requiredPlanLabel || normalizePlanLabel(requiredPlan || "");
-  const currentLabel = normalizePlanLabel(currentPlan || "");
+  const requiredPlanKey = requiredPlan || resolveRequiredPlan(featureKey, currentPlan) || "pro";
+  const requiredLabel = normalizePlanLabel(requiredPlanKey);
+  const currentLabel = normalizePlanLabel(currentPlan || "free");
   const primaryLabel =
     copy.primaryCta || (requiredLabel ? `Upgrade to ${requiredLabel}` : "Upgrade now");
   const secondaryLabel = copy.secondaryCta || "Not now";
@@ -38,15 +40,7 @@ export function UpgradePromptModal({
   const modalRef = useRef<HTMLDivElement | null>(null);
   const [interval, setInterval] = useState<"monthly" | "yearly">("monthly");
   const navigate = useNavigate();
-
-  const resolveTier = (input?: string) => {
-    const raw = String(input || "").trim().toLowerCase();
-    if (raw === "starter" || raw === "core") return "starter";
-    if (raw === "pro") return "pro";
-    if (raw === "business" || raw === "elite" || raw === "enterprise") return "elite";
-    return "pro";
-  };
-  const requiredTier = resolveTier(requiredPlanKey);
+  const requiredTier = normalizePaidPlan(requiredPlanKey) || "pro";
 
   useEffect(() => {
     if (!open) return;

--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
@@ -27,9 +27,8 @@ import { setOnboardingStep } from "../../api/onboardingApi";
 import "../../styles/propertiesMobile.css";
 import { useCapabilities } from "@/hooks/useCapabilities";
 import { useEntitlements } from "@/hooks/useEntitlements";
-import { useUpgrade } from "@/context/UpgradeContext";
 import { upgradeStarterButtonStyle } from "../../lib/upgradeButtonStyles";
-import { dispatchUpgradePrompt } from "@/lib/upgradePrompt";
+import { dispatchUpgradePrompt, resolveRequiredPlanLabel } from "@/lib/upgradePrompt";
 import { RiskScoreBadge } from "@/components/leases/RiskScoreBadge";
 import { PropertyCredibilitySummaryCard } from "@/components/properties/PropertyCredibilitySummaryCard";
 import { PropertyRegistryStatusCard } from "@/components/properties/PropertyRegistryStatusCard";
@@ -101,9 +100,14 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
   const { showToast } = useToast();
   const { caps, features, loading: capsLoading } = useCapabilities();
   const entitlements = useEntitlements();
-  const { openUpgrade } = useUpgrade();
   const unitsEnabled = features?.unitsTable !== false;
   const currentPlan = entitlements.plan || "free";
+  const applicationsRequiredPlanLabel = resolveRequiredPlanLabel("applications", currentPlan) || "Starter";
+  const unitsRequiredPlanLabel = resolveRequiredPlanLabel("units", currentPlan) || "Starter";
+  const propertyUpgradeRedirect =
+    typeof window !== "undefined"
+      ? `${window.location.pathname}${window.location.search}`
+      : "/properties";
   const applicationsEnabled =
     entitlements.hasCapability("applications") ||
     currentPlan === "starter" ||
@@ -152,6 +156,30 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
   const [submissionAssistantOpen, setSubmissionAssistantOpen] = useState(false);
   const unitRowRefs = useRef<Record<string, HTMLTableRowElement | null>>({});
   const unitCardRefs = useRef<Record<string, HTMLDivElement | null>>({});
+
+  const promptApplicationsUpgrade = useCallback(
+    (source: string, currentPlanOverride?: string | null) => {
+      dispatchUpgradePrompt({
+        featureKey: "applications",
+        currentPlan: currentPlanOverride || caps?.plan || currentPlan,
+        source,
+        redirectTo: propertyUpgradeRedirect,
+      });
+    },
+    [caps?.plan, currentPlan, propertyUpgradeRedirect]
+  );
+
+  const promptUnitsUpgrade = useCallback(
+    (source: string) => {
+      dispatchUpgradePrompt({
+        featureKey: "units",
+        currentPlan: caps?.plan || currentPlan,
+        source,
+        redirectTo: propertyUpgradeRedirect,
+      });
+    },
+    [caps?.plan, currentPlan, propertyUpgradeRedirect]
+  );
 
   const readFileText = useCallback((file: File) => {
     return new Promise<string>((resolve, reject) => {
@@ -238,21 +266,12 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
   const handleSendApplication = useCallback(
     (u: any) => {
       if (!applicationsEnabled) {
-        const redirectTo =
-          typeof window !== "undefined"
-            ? `${window.location.pathname}${window.location.search}`
-            : "/properties";
-        dispatchUpgradePrompt({
-          featureKey: "applications",
-          currentPlan: caps?.plan,
-          source: "property_detail_panel",
-          redirectTo,
-        });
+        promptApplicationsUpgrade("property_detail_panel");
         return;
       }
       setSendAppUnit(u);
     },
-    [applicationsEnabled, caps?.plan]
+    [applicationsEnabled, promptApplicationsUpgrade]
   );
 
   const openEditPropertyModal = useCallback(() => {
@@ -274,7 +293,7 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
 
   const sendApplicationActionLabel = applicationsEnabled
     ? "Send application"
-    : "Upgrade to send application";
+    : `Upgrade to ${applicationsRequiredPlanLabel} to send application`;
   const sendApplicationActionStyle = applicationsEnabled
     ? {
         padding: "6px 10px",
@@ -296,22 +315,13 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
     if (!propertyId) return;
     sendApplicationOpenedRef.current = true;
     if (!applicationsEnabled) {
-      const redirectTo =
-        typeof window !== "undefined"
-          ? `${window.location.pathname}${window.location.search}`
-          : "/properties";
-      dispatchUpgradePrompt({
-        featureKey: "applications",
-        currentPlan: caps?.plan,
-        source: "property_detail_panel",
-        redirectTo,
-      });
+      promptApplicationsUpgrade("property_detail_panel");
       onSendApplicationOpened?.();
       return;
     }
     setSendAppUnit({ id: null });
     onSendApplicationOpened?.();
-  }, [openSendApplication, applicationsEnabled, caps?.plan, onSendApplicationOpened, propertyId]);
+  }, [openSendApplication, applicationsEnabled, onSendApplicationOpened, promptApplicationsUpgrade, propertyId]);
 
   useEffect(() => {
     if (!openEditProperty) return;
@@ -934,17 +944,7 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
               <button
                 type="button"
                 className="rc-units-action"
-                onClick={() =>
-                  openUpgrade({
-                    reason: "screening",
-                    plan: "Screening",
-                    copy: {
-                      title: "Upgrade to manage your rentals",
-                      body: "RentChain Screening is free. Rental management starts on Starter.",
-                    },
-                    ctaLabel: "Upgrade to Starter",
-                  })
-                }
+                onClick={() => promptUnitsUpgrade("property_detail_panel_units")}
                 style={{
                   padding: "6px 10px",
                   borderRadius: 10,
@@ -1192,24 +1192,14 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
         >
           <div style={{ fontWeight: 700, marginBottom: 6 }}>Upgrade to manage your rentals</div>
           <div style={{ fontSize: "0.9rem", color: "#475569", marginBottom: 10 }}>
-            RentChain Screening is free. Rental management starts on Starter.
+            RentChain Screening is free. Rental management starts on {unitsRequiredPlanLabel}.
           </div>
           <button
             type="button"
-            onClick={() =>
-              openUpgrade({
-                reason: "screening",
-                plan: "Screening",
-                copy: {
-                  title: "Upgrade to manage your rentals",
-                  body: "RentChain Screening is free. Rental management starts on Starter.",
-                },
-                ctaLabel: "Upgrade to Starter",
-              })
-            }
+            onClick={() => promptUnitsUpgrade("property_detail_panel_upgrade_card")}
             style={upgradeStarterButtonStyle}
           >
-            Upgrade to Starter
+            Upgrade to {unitsRequiredPlanLabel}
           </button>
         </div>
       ) : (
@@ -1659,18 +1649,9 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
           .filter((u: any) => u.id)}
         initialUnitId={(sendAppUnit as any)?.id ? String((sendAppUnit as any).id) : null}
         allowGeneration={applicationsEnabled}
-        lockedMessage="Starter unlocks tenant invites and secure application links for each unit."
+        lockedMessage={`${applicationsRequiredPlanLabel} unlocks tenant invites and secure application links for each unit.`}
         onUpgradeRequired={() => {
-          const redirectTo =
-            typeof window !== "undefined"
-              ? `${window.location.pathname}${window.location.search}`
-              : "/properties";
-          dispatchUpgradePrompt({
-            featureKey: "applications",
-            currentPlan: caps?.plan,
-            source: "property_detail_panel",
-            redirectTo,
-          });
+          promptApplicationsUpgrade("property_detail_panel");
           setSendAppUnit(null);
         }}
         unit={sendAppUnit}

--- a/rentchain-frontend/src/components/tenants/InviteTenantModal.tsx
+++ b/rentchain-frontend/src/components/tenants/InviteTenantModal.tsx
@@ -4,7 +4,7 @@ import { setOnboardingStep } from "../../api/onboardingApi";
 import { fetchProperties } from "../../api/propertiesApi";
 import { fetchUnitsForProperty } from "../../api/unitsApi";
 import { useCapabilities } from "../../hooks/useCapabilities";
-import { dispatchUpgradePrompt } from "../../lib/upgradePrompt";
+import { dispatchUpgradePrompt, resolveRequiredPlanLabel } from "../../lib/upgradePrompt";
 import { useAuth } from "../../context/useAuth";
 import { useLanguage } from "../../context/LanguageContext";
 import { useToast } from "../ui/ToastProvider";
@@ -47,6 +47,12 @@ export const InviteTenantModal: React.FC<Props> = ({
   const { showToast } = useToast();
   const role = String(user?.role || "").toLowerCase();
   const canInvite = role === "admin" || features?.tenant_invites !== false;
+  const inviteRequiredPlanLabel = resolveRequiredPlanLabel("tenant_invites", user?.plan) || "Starter";
+  const inviteUpgradeMessage = `Upgrade to ${inviteRequiredPlanLabel} to send tenant invites.`;
+  const inviteUpgradeRedirect =
+    typeof window !== "undefined"
+      ? `${window.location.pathname}${window.location.search}`
+      : "/tenants";
   const copy = React.useMemo(
     () =>
       locale === "fr"
@@ -152,6 +158,15 @@ export const InviteTenantModal: React.FC<Props> = ({
   if (!open) return null;
   const selectedUnitRequiresLease = unitId ? units.find((u) => u.id === unitId)?.inviteEligible === false : false;
 
+  const promptInviteUpgrade = (source: string, currentPlan?: string | null) => {
+    dispatchUpgradePrompt({
+      featureKey: "tenant_invites",
+      currentPlan: currentPlan || undefined,
+      source,
+      redirectTo: inviteUpgradeRedirect,
+    });
+  };
+
   async function sendInvite() {
     setErr("");
     setSuccessMsg("");
@@ -160,7 +175,7 @@ export const InviteTenantModal: React.FC<Props> = ({
     setLoading(true);
     try {
       if (!canInvite) {
-        dispatchUpgradePrompt({ featureKey: "tenant_invites", source: "tenants_invite_modal" });
+        promptInviteUpgrade("tenants_invite_modal");
         return;
       }
       if (!propertyId || !unitId) {
@@ -188,14 +203,10 @@ export const InviteTenantModal: React.FC<Props> = ({
           plan: data?.plan,
         });
         if (errorCode === "upgrade_required" && capability === "tenant_invites") {
-          dispatchUpgradePrompt({
-            featureKey: "tenant_invites",
-            currentPlan: String(data?.plan || user?.plan || "free"),
-            source: "tenants_invite_modal_api_403",
-          });
+          promptInviteUpgrade("tenants_invite_modal_api_403", String(data?.plan || user?.plan || "free"));
           showToast({
             message: "Tenant invites require an upgrade",
-            description: "Upgrade to Starter to send tenant invites.",
+            description: inviteUpgradeMessage,
             variant: "warning",
           });
           return;
@@ -234,14 +245,10 @@ export const InviteTenantModal: React.FC<Props> = ({
         raw: e,
       });
       if (msg.toLowerCase().includes("upgrade_required")) {
-        dispatchUpgradePrompt({
-          featureKey: "tenant_invites",
-          currentPlan: String(user?.plan || "free"),
-          source: "tenants_invite_modal_api_catch",
-        });
+        promptInviteUpgrade("tenants_invite_modal_api_catch", String(user?.plan || "free"));
         showToast({
           message: "Tenant invites require an upgrade",
-          description: "Upgrade to Starter to send tenant invites.",
+          description: inviteUpgradeMessage,
           variant: "warning",
         });
         return;

--- a/rentchain-frontend/src/context/UpgradeContext.tsx
+++ b/rentchain-frontend/src/context/UpgradeContext.tsx
@@ -10,6 +10,7 @@ import { UpgradeModal, type UpgradeReason } from "../components/billing/UpgradeM
 import { UpgradePromptModal } from "../components/billing/UpgradePromptModal";
 import { normalizePlanName, resolveRequiredPlan } from "../lib/upgradePrompt";
 import { getCachedCapabilities } from "../lib/entitlements";
+import { isPlanAtLeast, normalizePlan } from "../lib/plan";
 import { useAuth } from "./AuthContext";
 
 type UpgradeContextValue = {
@@ -33,7 +34,7 @@ export function UpgradeProvider({ children }: { children: React.ReactNode }) {
   const [open, setOpen] = useState(false);
   const [reason, setReason] = useState<UpgradeReason>("propertiesMax");
   const [copy, setCopy] = useState<{ title?: string; body?: string } | undefined>(undefined);
-  const [plan, setPlan] = useState<string>("Screening");
+  const [plan, setPlan] = useState<string>("free");
   const [ctaLabel, setCtaLabel] = useState<string | undefined>(undefined);
   const [promptOpen, setPromptOpen] = useState(false);
   const [promptFeatureKey, setPromptFeatureKey] = useState<string>("screening");
@@ -47,14 +48,15 @@ export function UpgradeProvider({ children }: { children: React.ReactNode }) {
       setReason(r);
       setCopy(undefined);
       setCtaLabel(undefined);
+      setPlan(normalizePlan(user?.plan || "free"));
     } else {
       setReason(r.reason);
       setCopy(r.copy);
-      if (r.plan) setPlan(r.plan);
+      setPlan(normalizePlan(r.plan || user?.plan || "free"));
       setCtaLabel(r.ctaLabel);
     }
     setOpen(true);
-  }, []);
+  }, [user?.plan]);
 
   const closeUpgradeModal = useCallback(() => {
     setOpen(false);
@@ -73,17 +75,6 @@ export function UpgradeProvider({ children }: { children: React.ReactNode }) {
     setPromptRedirectTo(undefined);
   }, []);
 
-  const isAtLeast = useCallback((current?: string, required?: string) => {
-    const order = ["free", "starter", "pro", "elite"] as const;
-    const currentNorm = normalizePlanName(current);
-    const requiredNorm = normalizePlanName(required);
-    if (!currentNorm || !requiredNorm) return false;
-    return (
-      order.indexOf(currentNorm as (typeof order)[number]) >=
-      order.indexOf(requiredNorm as (typeof order)[number])
-    );
-  }, []);
-
   const handleUpgradeEvent = useCallback((evt: Event) => {
     if (!ready || isLoading || !user?.id) return;
     const roleLower = String(user?.actorRole || user?.role || "").toLowerCase();
@@ -92,10 +83,11 @@ export function UpgradeProvider({ children }: { children: React.ReactNode }) {
     const featureKey = String(detail.featureKey || detail.limitType || detail.capability || "").trim();
     if (!featureKey) return;
     const cachedPlan = getCachedCapabilities()?.plan;
-    const currentPlan = detail.currentPlan || detail.plan || cachedPlan;
-    const requiredPlan = detail.requiredPlan || resolveRequiredPlan(featureKey, currentPlan);
+    const currentPlan = normalizePlan(detail.currentPlan || detail.plan || cachedPlan || user?.plan || "free");
+    const requiredPlan = normalizePlanName(detail.requiredPlan) || resolveRequiredPlan(featureKey, currentPlan);
     if (requiredPlan === "free") return;
-    if (isAtLeast(currentPlan, requiredPlan)) return;
+    if (!requiredPlan) return;
+    if (isPlanAtLeast(currentPlan, normalizePlan(requiredPlan))) return;
     const now = Date.now();
     if (typeof window !== "undefined") {
       const userKey = user?.id ? `upgradePromptLastShown:${user.id}` : "upgradePromptLastShown:anon";
@@ -117,7 +109,7 @@ export function UpgradeProvider({ children }: { children: React.ReactNode }) {
     setPromptSource(source);
     setPromptRedirectTo(redirectTo);
     setPromptOpen(true);
-  }, [isAtLeast, user?.id, user?.role, user?.actorRole, ready, isLoading]);
+  }, [user?.id, user?.role, user?.actorRole, user?.plan, ready, isLoading]);
 
   const ctxValue = useMemo(
     () => ({ openUpgrade, clearUpgradePrompt }),

--- a/rentchain-frontend/src/lib/upgradePrompt.test.ts
+++ b/rentchain-frontend/src/lib/upgradePrompt.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  dispatchUpgradePrompt,
+  getUpgradePromptDetail,
+  resolveRequiredPlanLabel,
+} from "./upgradePrompt";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("upgradePrompt", () => {
+  it("normalizes upgrade-required payloads into canonical prompt details", () => {
+    const detail = getUpgradePromptDetail(
+      {
+        code: "PLAN_LIMIT_REACHED",
+        capability: "tenant_invites",
+        currentPlan: "core",
+        source: "invite_modal",
+      },
+      403
+    );
+
+    expect(detail).toEqual({
+      featureKey: "tenant_invites",
+      currentPlan: "starter",
+      requiredPlan: "starter",
+      source: "invite_modal",
+      redirectTo: undefined,
+    });
+  });
+
+  it("dispatches normalized prompt details", () => {
+    const dispatchSpy = vi.spyOn(window, "dispatchEvent");
+
+    dispatchUpgradePrompt({
+      featureKey: "review_summary",
+      currentPlan: "business",
+      source: "review_page",
+    });
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    const event = dispatchSpy.mock.calls[0][0] as CustomEvent;
+    expect(event.type).toBe("upgrade:prompt");
+    expect(event.detail).toMatchObject({
+      featureKey: "review_summary",
+      currentPlan: "elite",
+      requiredPlan: "pro",
+      source: "review_page",
+    });
+  });
+
+  it("returns canonical required-plan labels", () => {
+    expect(resolveRequiredPlanLabel("tenant_invites", "free")).toBe("Starter");
+    expect(resolveRequiredPlanLabel("review_summary", "starter")).toBe("Pro");
+  });
+});

--- a/rentchain-frontend/src/lib/upgradePrompt.ts
+++ b/rentchain-frontend/src/lib/upgradePrompt.ts
@@ -1,4 +1,4 @@
-import { CANONICAL_PLAN_ORDER, normalizePlan } from "@/lib/plan";
+import { CANONICAL_PLAN_ORDER, normalizePlan, planLabel } from "@/lib/plan";
 
 export type UpgradePromptDetail = {
   featureKey: string;
@@ -14,6 +14,7 @@ const FEATURE_REQUIRED_PLAN: Record<string, string> = {
   screening: "free",
   screening_pay_per_use: "free",
   screening_history: "free",
+  screening_workflow: "starter",
   unitstable: "free",
   units: "free",
   properties: "free",
@@ -62,6 +63,12 @@ export function resolveRequiredPlan(featureKey?: string, currentPlan?: string): 
   const idx = CANONICAL_PLAN_ORDER.indexOf(current as (typeof CANONICAL_PLAN_ORDER)[number]);
   if (idx >= 0 && idx < CANONICAL_PLAN_ORDER.length - 1) return CANONICAL_PLAN_ORDER[idx + 1];
   return current || "pro";
+}
+
+export function resolveRequiredPlanLabel(featureKey?: string, currentPlan?: string): string | undefined {
+  const requiredPlan = resolveRequiredPlan(featureKey, currentPlan);
+  if (!requiredPlan) return undefined;
+  return planLabel(normalizePlan(requiredPlan));
 }
 
 function extractPlanFromPayload(payload: any): string | undefined {
@@ -139,10 +146,33 @@ export function getUpgradePromptDetail(payload: any, status?: number): UpgradePr
   return { featureKey: resolvedFeatureKey, currentPlan, requiredPlan, source, redirectTo };
 }
 
+export function normalizeUpgradePromptDetail(detail: UpgradePromptDetail | null | undefined): UpgradePromptDetail | null {
+  if (!detail) return null;
+
+  const featureKey = normalizeFeatureKey(detail);
+  if (!featureKey) return null;
+
+  const currentPlan = normalizePlanName(detail.currentPlan);
+  const requiredPlan =
+    normalizePlanName(detail.requiredPlan) || resolveRequiredPlan(featureKey, currentPlan);
+  const source = String(detail.source || "").trim() || undefined;
+  const redirectTo = String(detail.redirectTo || "").trim() || undefined;
+
+  return {
+    featureKey,
+    currentPlan,
+    requiredPlan,
+    source,
+    redirectTo,
+  };
+}
+
 export function dispatchUpgradePrompt(detail: UpgradePromptDetail) {
   if (typeof window === "undefined") return;
+  const normalizedDetail = normalizeUpgradePromptDetail(detail);
+  if (!normalizedDetail) return;
   try {
-    window.dispatchEvent(new CustomEvent("upgrade:prompt", { detail }));
+    window.dispatchEvent(new CustomEvent("upgrade:prompt", { detail: normalizedDetail }));
   } catch {
     // ignore dispatch errors
   }

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
@@ -33,6 +33,7 @@ import { buildLeaseSigningWorkspaceState } from "./leaseSigningWorkspaceState";
 import { buildDepositPaymentFlowState } from "./depositPaymentFlowState";
 import StructuredNotificationList from "./StructuredNotificationList";
 import { buildLandlordStructuredNotificationTriggers } from "./structuredNotificationTriggers";
+import { resolveRequiredPlanLabel } from "@/lib/upgradePrompt";
 
 function money(cents: number | null): string {
   if (cents == null || !Number.isFinite(cents)) return "Not provided";
@@ -508,16 +509,17 @@ function ApplicationReviewSummaryPageBody() {
     () => (summary ? buildLandlordStructuredActivityTimeline(summary).slice(0, 4) : []),
     [summary]
   );
+  const reviewSummaryRequiredPlanLabel = resolveRequiredPlanLabel("review_summary", entitlements.plan) || "Pro";
 
   return (
     <div style={{ padding: 16, display: "grid", gap: 12 }}>
       {!entitlements.canViewReviewSummary ? (
         <LockedFeature
           featureKey="review_summary"
-          title="Screening decision summaries are available on Pro"
+          title={`Screening decision summaries are available on ${reviewSummaryRequiredPlanLabel}`}
           description="Keep application risk signals, screening recommendation, and landlord-ready review notes in one place once your plan includes review summaries."
-          hint="This page stays stable, but the richer decision-support view unlocks on Pro."
-          ctaLabel="Upgrade to Pro"
+          hint={`This page stays stable, but the richer decision-support view unlocks on ${reviewSummaryRequiredPlanLabel}.`}
+          ctaLabel={`Upgrade to ${reviewSummaryRequiredPlanLabel}`}
         />
       ) : null}
       {entitlements.canViewReviewSummary ? (

--- a/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
@@ -271,6 +271,8 @@ describe("ApplicationsPage", () => {
   });
 
   it("shows Starter-aligned screening upgrade copy instead of the old Pro gate", async () => {
+    const dispatchSpy = vi.spyOn(window, "dispatchEvent");
+
     render(
       <MemoryRouter>
         <ApplicationsPage />
@@ -280,14 +282,14 @@ describe("ApplicationsPage", () => {
     const button = await screen.findByRole("button", { name: "Send screening invite" });
     button.click();
 
-    expect(mocks.openUpgrade).toHaveBeenCalledWith(
-      expect.objectContaining({
-        ctaLabel: "Upgrade to Starter",
-        copy: expect.objectContaining({
-          title: "Upgrade to Starter",
-          body: "Starter includes applicant screening inside RentChain. Upgrade to continue.",
-        }),
-      })
-    );
+    expect(dispatchSpy).toHaveBeenCalled();
+    const event = dispatchSpy.mock.calls.at(-1)?.[0] as CustomEvent;
+    expect(event.type).toBe("upgrade:prompt");
+    expect(event.detail).toMatchObject({
+      featureKey: "screening_workflow",
+      currentPlan: "free",
+      requiredPlan: "starter",
+      source: "applications_page_screening",
+    });
   });
 });

--- a/rentchain-frontend/src/pages/ApplicationsPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.tsx
@@ -35,7 +35,6 @@ import { useToast } from "../components/ui/ToastProvider";
 import { useEntitlements } from "@/hooks/useEntitlements";
 import { track } from "@/lib/analytics";
 import { useAuth } from "../context/useAuth";
-import { useUpgrade } from "../context/UpgradeContext";
 import { ResponsiveMasterDetail } from "@/components/layout/ResponsiveMasterDetail";
 import { useOnboardingState } from "../hooks/useOnboardingState";
 import { useUnitsForProperty } from "../hooks/useUnitsForProperty";
@@ -104,7 +103,7 @@ import { ScreeningDetailDrawer } from "@/components/screening/ScreeningDetailDra
 import { FeatureGate } from "@/components/billing/FeatureGate";
 import { FeatureTeaser } from "@/components/billing/FeatureTeaser";
 import { UpgradeCTA } from "@/components/billing/UpgradeCTA";
-import { dispatchUpgradePrompt } from "@/lib/upgradePrompt";
+import { dispatchUpgradePrompt, resolveRequiredPlanLabel } from "@/lib/upgradePrompt";
 const statusOptions: RentalApplicationStatus[] = [
   "SUBMITTED",
   "IN_REVIEW",
@@ -279,7 +278,6 @@ const ApplicationsPage: React.FC = () => {
   const features = entitlements.capabilities;
   const loadingCaps = entitlements.loading;
   const { user } = useAuth();
-  const { openUpgrade } = useUpgrade();
   const [screeningQuote, setScreeningQuote] = useState<ScreeningQuote | null>(null);
   const [screeningQuoteDetail, setScreeningQuoteDetail] = useState<string | null>(null);
   const [screeningLoading, setScreeningLoading] = useState(false);
@@ -429,6 +427,11 @@ const ApplicationsPage: React.FC = () => {
     return `Status: ${formatScreeningStatus(raw)}`;
   })();
   const currentPlan = entitlements.plan || "free";
+  const applicationsRequiredPlanLabel = resolveRequiredPlanLabel("applications", currentPlan) || "Starter";
+  const applicationsUpgradeRedirect =
+    typeof window !== "undefined"
+      ? `${window.location.pathname}${window.location.search}`
+      : "/applications";
   const canRunScreening =
     entitlements.canScreen || currentPlan === "starter" || currentPlan === "pro" || currentPlan === "elite";
   const canCreateApplicationLinks =
@@ -448,6 +451,18 @@ const ApplicationsPage: React.FC = () => {
   const selectedViewingRequest = useMemo(
     () => viewingRequests.find((request) => request.id === selectedViewingId) || null,
     [viewingRequests, selectedViewingId]
+  );
+
+  const promptApplicationsUpgrade = useCallback(
+    (source: string, currentPlanOverride?: string | null) => {
+      dispatchUpgradePrompt({
+        featureKey: "applications",
+        currentPlan: currentPlanOverride || caps?.plan || currentPlan,
+        source,
+        redirectTo: applicationsUpgradeRedirect,
+      });
+    },
+    [applicationsUpgradeRedirect, caps?.plan, currentPlan]
   );
 
   const loadTransUnionIntegration = useCallback(async () => {
@@ -586,25 +601,21 @@ const ApplicationsPage: React.FC = () => {
 
   const openProUpgrade = useCallback(
     (featureName: "screening" | "exports") => {
-      const requiredTier = featureName === "screening" ? "starter" : "pro";
-      track("gating_blocked", { featureName, requiredTier, userTier: currentPlan });
-      openUpgrade({
-        reason: featureName,
-        plan: currentPlan,
-        ctaLabel: requiredTier === "starter" ? "Upgrade to Starter" : "Upgrade to Pro",
-        copy:
-          featureName === "screening"
-            ? {
-                title: "Upgrade to Starter",
-                body: "Starter includes applicant screening inside RentChain. Upgrade to continue.",
-              }
-            : {
-                title: "Upgrade to Pro",
-                body: "Verified exports are available on Pro plans. Upgrade to continue.",
-              },
+      const featureKey = featureName === "screening" ? "screening_workflow" : "pdf_export";
+      const requiredPlanLabel = resolveRequiredPlanLabel(featureKey, currentPlan) || "Pro";
+      track("gating_blocked", {
+        featureName,
+        requiredTier: requiredPlanLabel.toLowerCase(),
+        userTier: currentPlan,
+      });
+      dispatchUpgradePrompt({
+        featureKey,
+        currentPlan,
+        source: `applications_page_${featureName}`,
+        redirectTo: applicationsUpgradeRedirect,
       });
     },
-    [currentPlan, openUpgrade]
+    [applicationsUpgradeRedirect, currentPlan]
   );
 
   const openScreeningReport = useCallback(
@@ -882,16 +893,7 @@ const ApplicationsPage: React.FC = () => {
     const params = new URLSearchParams(location.search);
     if (params.get("openSendApplication") !== "1") return;
     if (!canCreateApplicationLinks) {
-      const redirectTo =
-        typeof window !== "undefined"
-          ? `${window.location.pathname}${window.location.search}`
-          : "/applications";
-      dispatchUpgradePrompt({
-        featureKey: "applications",
-        currentPlan: caps?.plan,
-        source: "applications_page",
-        redirectTo,
-      });
+      promptApplicationsUpgrade("applications_page");
       params.delete("openSendApplication");
       params.delete("autoSelectProperty");
       navigate({ pathname: location.pathname, search: params.toString() }, { replace: true });
@@ -943,7 +945,7 @@ const ApplicationsPage: React.FC = () => {
     propertiesReady,
     showToast,
     canCreateApplicationLinks,
-    caps?.plan,
+    promptApplicationsUpgrade,
   ]);
 
   useEffect(() => {
@@ -1158,16 +1160,7 @@ const ApplicationsPage: React.FC = () => {
 
   const handleCreateApplication = (autoSelectProperty: boolean = false) => {
     if (!canCreateApplicationLinks) {
-      const redirectTo =
-        typeof window !== "undefined"
-          ? `${window.location.pathname}${window.location.search}`
-          : "/applications";
-      dispatchUpgradePrompt({
-        featureKey: "applications",
-        currentPlan: caps?.plan,
-        source: "applications_page",
-        redirectTo,
-      });
+      promptApplicationsUpgrade("applications_page");
       return;
     }
     if (!propertiesLoaded) {
@@ -2833,18 +2826,9 @@ const ApplicationsPage: React.FC = () => {
           setModalUnitId(nextId);
         }}
         allowGeneration={canCreateApplicationLinks}
-        lockedMessage="Starter unlocks secure application links so applicants can complete their application inside RentChain."
+        lockedMessage={`${applicationsRequiredPlanLabel} unlocks secure application links so applicants can complete their application inside RentChain.`}
         onUpgradeRequired={() => {
-          const redirectTo =
-            typeof window !== "undefined"
-              ? `${window.location.pathname}${window.location.search}`
-              : "/applications";
-          dispatchUpgradePrompt({
-            featureKey: "applications",
-            currentPlan: caps?.plan,
-            source: "applications_page",
-            redirectTo,
-          });
+          promptApplicationsUpgrade("applications_page");
         }}
         unit={null}
         onClose={() => setSendAppOpen(false)}

--- a/rentchain-frontend/src/pages/landlord/InvitesPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/InvitesPage.tsx
@@ -8,7 +8,7 @@ import {
 } from "../../api/tenantInvites";
 import { colors, spacing, text } from "../../styles/tokens";
 import { useCapabilities } from "../../hooks/useCapabilities";
-import { dispatchUpgradePrompt } from "../../lib/upgradePrompt";
+import { dispatchUpgradePrompt, resolveRequiredPlanLabel } from "../../lib/upgradePrompt";
 import { useLanguage } from "../../context/LanguageContext";
 
 function deriveInviteUrl(token: string) {
@@ -40,6 +40,12 @@ export default function InvitesPage() {
   const { features } = useCapabilities();
   const { locale } = useLanguage();
   const canInvite = features?.tenant_invites !== false;
+  const inviteRequiredPlanLabel = resolveRequiredPlanLabel("tenant_invites") || "Starter";
+  const inviteUpgradeMessage = `Upgrade to ${inviteRequiredPlanLabel} to send tenant invites.`;
+  const inviteUpgradeRedirect =
+    typeof window !== "undefined"
+      ? `${window.location.pathname}${window.location.search}`
+      : "/landlord/invites";
   const copy = useMemo(
     () =>
       locale === "fr"
@@ -132,9 +138,18 @@ export default function InvitesPage() {
     return !creating && canInvite && propertyId && unitId && tenantEmail;
   }, [creating, canInvite, propertyId, unitId, tenantEmail]);
 
+  const promptInviteUpgrade = (source: string, currentPlan?: string | null) => {
+    dispatchUpgradePrompt({
+      featureKey: "tenant_invites",
+      currentPlan: currentPlan || undefined,
+      source,
+      redirectTo: inviteUpgradeRedirect,
+    });
+  };
+
   async function handleCreate() {
     if (!canInvite) {
-      dispatchUpgradePrompt({ featureKey: "tenant_invites", source: "landlord_invites_page" });
+      promptInviteUpgrade("landlord_invites_page");
       return;
     }
     if (!canCreate) return;
@@ -156,12 +171,8 @@ export default function InvitesPage() {
           plan: res?.plan,
         });
         if (errorCode === "upgrade_required" && capability === "tenant_invites") {
-          dispatchUpgradePrompt({
-            featureKey: "tenant_invites",
-            currentPlan: String(res?.plan || "free"),
-            source: "landlord_invites_page_api_403",
-          });
-          setCreateError("Upgrade to Starter to send tenant invites.");
+          promptInviteUpgrade("landlord_invites_page_api_403", String(res?.plan || "free"));
+          setCreateError(inviteUpgradeMessage);
           if (typeof (window as any)?.toast?.warning === "function") {
             (window as any).toast.warning("Tenant invites require an upgrade");
           }
@@ -195,11 +206,8 @@ export default function InvitesPage() {
       const msg = String(e?.message || "Failed to create invite");
       console.debug("[invites-page] request error", { message: msg, raw: e });
       if (msg.toLowerCase().includes("upgrade_required")) {
-        dispatchUpgradePrompt({
-          featureKey: "tenant_invites",
-          source: "landlord_invites_page_api_catch",
-        });
-        setCreateError("Upgrade to Starter to send tenant invites.");
+        promptInviteUpgrade("landlord_invites_page_api_catch");
+        setCreateError(inviteUpgradeMessage);
         if (typeof (window as any)?.toast?.warning === "function") {
           (window as any).toast.warning("Tenant invites require an upgrade");
         }
@@ -248,7 +256,7 @@ export default function InvitesPage() {
           type="button"
           onClick={() => {
             if (!canInvite) {
-              dispatchUpgradePrompt({ featureKey: "tenant_invites", source: "landlord_invites_page" });
+              promptInviteUpgrade("landlord_invites_page");
               return;
             }
             setCreatedInviteUrl(null);


### PR DESCRIPTION
## Summary

Implements Upgrade Prompt and Locked-State System v1 by standardizing landlord-facing upgrade prompts around the canonical `dispatchUpgradePrompt(...)` payload path and reducing duplicate plan/tier logic across shared upgrade surfaces.

This mission improves upgrade UX consistency without introducing a second prompt system or redesigning billing flows.

## What changed

### Shared upgrade infrastructure
- Kept `dispatchUpgradePrompt(...)` as the primary upgrade prompt system
- Normalized prompt payload handling in `upgradePrompt.ts`
- Canonicalized `featureKey`, `currentPlan`, and `requiredPlan` before dispatch
- Kept `openUpgrade(...)` as a compatibility path rather than expanding it into a second first-class system

### Removed duplicate shared logic
- Removed local plan-order comparison from `UpgradeContext.tsx`
- Removed local tier alias resolution from `UpgradePromptModal.tsx`
- Updated `UpgradeCTA.tsx` to dispatch canonical prompt payloads directly instead of routing feature-based prompts through `openUpgrade(...)`

### Representative landlord surface normalization
Standardized shared required-plan messaging and prompt routing across:
- `PropertyDetailPanel.tsx`
- `InviteTenantModal.tsx`
- `InvitesPage.tsx`
- `ApplicationsPage.tsx`
- `ApplicationReviewSummaryPage.tsx`

### Testing
Added/updated targeted tests covering:
- canonical upgrade prompt parsing
- CTA dispatch behavior
- prompt modal checkout behavior
- updated applications page behavior

## Files changed

- `rentchain-frontend/src/billing/upgradeCopy.ts`
- `rentchain-frontend/src/components/billing/UpgradeCTA.test.tsx`
- `rentchain-frontend/src/components/billing/UpgradeCTA.tsx`
- `rentchain-frontend/src/components/billing/UpgradePromptModal.test.tsx`
- `rentchain-frontend/src/components/billing/UpgradePromptModal.tsx`
- `rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx`
- `rentchain-frontend/src/components/tenants/InviteTenantModal.tsx`
- `rentchain-frontend/src/context/UpgradeContext.tsx`
- `rentchain-frontend/src/lib/upgradePrompt.test.ts`
- `rentchain-frontend/src/lib/upgradePrompt.ts`
- `rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx`
- `rentchain-frontend/src/pages/ApplicationsPage.test.tsx`
- `rentchain-frontend/src/pages/ApplicationsPage.tsx`
- `rentchain-frontend/src/pages/landlord/InvitesPage.tsx`

## Verification

### Frontend
- `npm run test -- src/lib/upgradePrompt.test.ts src/components/billing/UpgradeCTA.test.tsx src/components/billing/UpgradePromptModal.test.tsx src/components/billing/FeatureGate.test.tsx src/pages/ApplicationReviewSummaryPage.test.tsx src/pages/ApplicationsPage.test.tsx src/components/properties/PropertyDetailPanel.test.tsx`
- `npm run build`

## Important note on screening workflow gating

Added:
- `screening_workflow -> starter`

This was added only to represent the gated landlord screening workflow inside upgrade prompt semantics.

This does **not** redesign:
- screening monetization
- screening pricing
- provider behavior
- pay-per-use screening

Existing baseline screening availability remains intact:
- `screening`
- `screening_pay_per_use`

both continue to map to `free`.

The new key only distinguishes the richer in-app landlord screening workflow gate from baseline screening availability.

## Intentionally out of scope

- repo-wide cleanup of all remaining legacy prompt call sites
- full normalization of every historical upgrade wording surface
- full frontend suite execution beyond the targeted verification pass
- broader billing or checkout redesign