### PR TITLE
Feat/marketplace premium access controls v1

### DIFF
--- a/rentchain-api/src/routes/__tests__/marketplaceContractorRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/marketplaceContractorRoutes.test.ts
@@ -123,7 +123,7 @@ describe("marketplaceContractorRoutes", () => {
       method: "POST",
       url: "/marketplace/contractors",
       headers: {
-        "x-test-user": JSON.stringify({ id: "landlord-1", role: "landlord", landlordId: "landlord-1" }),
+        "x-test-user": JSON.stringify({ id: "landlord-1", role: "landlord", landlordId: "landlord-1", plan: "pro" }),
       },
       body: {
         displayName: "North Shore Electric",
@@ -143,7 +143,7 @@ describe("marketplaceContractorRoutes", () => {
       method: "GET",
       url: "/marketplace/contractors",
       headers: {
-        "x-test-user": JSON.stringify({ id: "landlord-1", role: "landlord", landlordId: "landlord-1" }),
+        "x-test-user": JSON.stringify({ id: "landlord-1", role: "landlord", landlordId: "landlord-1", plan: "pro" }),
       },
       query: {
         serviceCategory: "plumbing",
@@ -162,7 +162,7 @@ describe("marketplaceContractorRoutes", () => {
       method: "PATCH",
       url: "/marketplace/contractors/contractor-1",
       headers: {
-        "x-test-user": JSON.stringify({ id: "landlord-1", role: "landlord", landlordId: "landlord-1" }),
+        "x-test-user": JSON.stringify({ id: "landlord-1", role: "landlord", landlordId: "landlord-1", plan: "pro" }),
       },
       body: {
         availabilityStatus: "limited",
@@ -179,7 +179,7 @@ describe("marketplaceContractorRoutes", () => {
       method: "POST",
       url: "/marketplace/work-orders/wo-1/assign-contractor",
       headers: {
-        "x-test-user": JSON.stringify({ id: "landlord-1", role: "landlord", landlordId: "landlord-1" }),
+        "x-test-user": JSON.stringify({ id: "landlord-1", role: "landlord", landlordId: "landlord-1", plan: "elite" }),
       },
       body: {
         contractorId: "contractor-1",
@@ -203,5 +203,37 @@ describe("marketplaceContractorRoutes", () => {
     });
 
     expect(res.status).toBe(403);
+  });
+
+  it("keeps contractor directory role-protected without premium-blocking it", async () => {
+    const router = (await import("../marketplaceContractorRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/marketplace/contractors",
+      headers: {
+        "x-test-user": JSON.stringify({ id: "landlord-1", role: "landlord", landlordId: "landlord-1", plan: "starter" }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.items?.[0]?.id).toBe("contractor-1");
+  });
+
+  it("requires Elite marketplace access for contractor assignment", async () => {
+    const router = (await import("../marketplaceContractorRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/marketplace/work-orders/wo-1/assign-contractor",
+      headers: {
+        "x-test-user": JSON.stringify({ id: "landlord-1", role: "landlord", landlordId: "landlord-1", plan: "pro" }),
+      },
+      body: {
+        contractorId: "contractor-1",
+      },
+    });
+
+    expect(res.status).toBe(403);
+    expect(res.body?.featureKey).toBe("marketplace_contractor_assignment");
+    expect(res.body?.requiredPlan).toBe("elite");
   });
 });

--- a/rentchain-api/src/routes/marketplaceContractorRoutes.ts
+++ b/rentchain-api/src/routes/marketplaceContractorRoutes.ts
@@ -1,5 +1,7 @@
 import { Router } from "express";
 import { db } from "../config/firebase";
+import { capabilitiesForPlan, requiredPlanForCapability } from "../services/entitlements/planCapabilities";
+import { resolveLandlordAndTier } from "../lib/landlordResolver";
 import { requireAuth } from "../middleware/requireAuth";
 import { findContractorsForWorkOrder, normalizeServiceCategory } from "../lib/marketplace/findContractorsForWorkOrder";
 import { loadContractorProfilesForActor, normalizeContractorProfile } from "../lib/marketplace/loadContractorProfiles";
@@ -38,6 +40,27 @@ function getLandlordId(req: any) {
 
 function getUserId(req: any) {
   return asString(req.user?.id, 120);
+}
+
+async function hasMarketplaceCapability(req: any, capability: string) {
+  if (isAdmin(req)) return true;
+  const resolved = await resolveLandlordAndTier(req.user);
+  const features = new Set(capabilitiesForPlan(resolved.tier));
+  return features.has(capability);
+}
+
+async function ensureMarketplaceCapability(req: any, res: any, capability: string) {
+  if (await hasMarketplaceCapability(req, capability)) return true;
+  const resolved = await resolveLandlordAndTier(req.user);
+  res.status(403).json({
+    ok: false,
+    error: "UPGRADE_REQUIRED",
+    upgradeRequired: true,
+    featureKey: capability,
+    requiredPlan: requiredPlanForCapability(capability),
+    plan: resolved.tier,
+  });
+  return false;
 }
 
 function uniqueStrings(input: unknown, max = 50) {
@@ -167,6 +190,7 @@ router.patch("/marketplace/contractors/:contractorId", requireAuth, async (req: 
 router.post("/marketplace/work-orders/:workOrderId/assign-contractor", requireAuth, async (req: any, res) => {
   try {
     if (!isLandlord(req)) return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    if (!(await ensureMarketplaceCapability(req, res, "marketplace_contractor_assignment"))) return;
     const landlordId = getLandlordId(req);
     const actorId = getUserId(req);
     const workOrderId = asString(req.params?.workOrderId, 120);

--- a/rentchain-api/src/services/__tests__/planCapabilities.test.ts
+++ b/rentchain-api/src/services/__tests__/planCapabilities.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   canonicalPlanLabel,
   capabilitiesForPlan,
+  requiredPlanForCapability,
   resolveCanonicalPlan,
 } from "../entitlements/planCapabilities";
 
@@ -15,6 +16,7 @@ describe("planCapabilities entitlement aliases", () => {
 
   it("includes export and review aliases on pro and above", () => {
     const pro = capabilitiesForPlan("pro");
+    expect(pro).toContain("marketplace_directory");
     expect(pro).toContain("portfolio_score");
     expect(pro).toContain("pdf_export");
     expect(pro).toContain("review_summary");
@@ -25,9 +27,15 @@ describe("planCapabilities entitlement aliases", () => {
 
   it("includes advanced recommendation intelligence on elite", () => {
     const elite = capabilitiesForPlan("elite");
+    expect(elite).toContain("marketplace_contractor_assignment");
     expect(elite).toContain("portfolio_action_recommendations");
     expect(elite).toContain("portfolio_score");
     expect(elite).toContain("portfolio_health_summary");
+  });
+
+  it("resolves required plan for marketplace capabilities", () => {
+    expect(requiredPlanForCapability("marketplace_directory")).toBe("pro");
+    expect(requiredPlanForCapability("marketplace_contractor_assignment")).toBe("elite");
   });
 
   it("normalizes legacy aliases into canonical plans", () => {

--- a/rentchain-api/src/services/entitlements/planCapabilities.ts
+++ b/rentchain-api/src/services/entitlements/planCapabilities.ts
@@ -35,6 +35,7 @@ const PLAN_ADDITIONS: Record<Plan, string[]> = {
     "pdf_export",
     "review_summary",
     "compliance_reports",
+    "marketplace_directory",
     "portfolio_dashboard",
     "portfolio_score",
     "team.invites",
@@ -46,6 +47,7 @@ const PLAN_ADDITIONS: Record<Plan, string[]> = {
     "ai_summaries",
     "exports_advanced",
     "audit_logs",
+    "marketplace_contractor_assignment",
     "portfolio_analytics",
     "portfolio_action_recommendations",
   ],
@@ -88,4 +90,17 @@ export function canonicalPlanLabel(planInput?: string | null): "Free" | "Starter
   if (plan === "pro") return "Pro";
   if (plan === "elite") return "Elite";
   return "Free";
+}
+
+export function requiredPlanForCapability(capabilityInput?: string | null): Plan | null {
+  const capability = String(capabilityInput || "").trim().toLowerCase();
+  if (!capability) return null;
+
+  for (const plan of CANONICAL_PLAN_ORDER) {
+    if (PLAN_ADDITIONS[plan].includes(capability)) {
+      return plan;
+    }
+  }
+
+  return null;
 }

--- a/rentchain-frontend/src/billing/upgradeCopy.ts
+++ b/rentchain-frontend/src/billing/upgradeCopy.ts
@@ -161,6 +161,30 @@ const COPY_MAP: Record<string, UpgradeCopy> = {
     secondaryCta: "Not now",
     requiredPlanLabel: "Elite",
   },
+  marketplace_directory: {
+    title: "Upgrade to unlock the contractor directory",
+    subtitle: "Pro adds a private contractor network so you can manage marketplace-ready service profiles inside RentChain.",
+    bullets: [
+      "Build and maintain a private contractor directory",
+      "Filter service providers by category, area, and availability",
+      "Keep contractor invites and profile management in one place",
+    ],
+    primaryCta: "Upgrade to Pro",
+    secondaryCta: "Not now",
+    requiredPlanLabel: "Pro",
+  },
+  marketplace_contractor_assignment: {
+    title: "Upgrade to unlock contractor assignment",
+    subtitle: "Elite adds embedded marketplace assignment inside work orders so you can match maintenance demand to your contractor network faster.",
+    bullets: [
+      "Discover contractor candidates directly from a work order",
+      "Assign the right contractor without leaving the maintenance workflow",
+      "Keep contractor assignment tied to the job record",
+    ],
+    primaryCta: "Upgrade to Elite",
+    secondaryCta: "Not now",
+    requiredPlanLabel: "Elite",
+  },
 };
 
 function normalizeKey(featureKey: string) {
@@ -183,6 +207,8 @@ export function getUpgradeCopy(featureKey?: string): UpgradeCopy {
   if (key === "units.create") return COPY_MAP.units;
   if (key === "portfolio_score") return COPY_MAP.portfolio_score;
   if (key === "portfolio_action_recommendations") return COPY_MAP.portfolio_action_recommendations;
+  if (key === "marketplace_directory") return COPY_MAP.marketplace_directory;
+  if (key === "marketplace_contractor_assignment") return COPY_MAP.marketplace_contractor_assignment;
   if (key === "portfolio.ai" || key === "ai.summary") return COPY_MAP["ai.insights"];
   if (key.includes("screening")) return COPY_MAP.tenant_screening;
   if (key.includes("application") || key.includes("apply")) return COPY_MAP.applications;

--- a/rentchain-frontend/src/hooks/useEntitlements.test.tsx
+++ b/rentchain-frontend/src/hooks/useEntitlements.test.tsx
@@ -23,6 +23,8 @@ describe("useEntitlements", () => {
         pdf_export: true,
         move_in_readiness: true,
         work_orders: true,
+        marketplace_directory: true,
+        marketplace_contractor_assignment: true,
         review_summary: true,
         portfolio_health_summary: true,
         portfolio_score: true,
@@ -42,6 +44,8 @@ describe("useEntitlements", () => {
     expect(result.current.canExportPdf).toBe(true);
     expect(result.current.hasMoveInReadiness).toBe(true);
     expect(result.current.canUseWorkOrders).toBe(true);
+    expect(result.current.canViewMarketplaceDirectory).toBe(true);
+    expect(result.current.canUseMarketplaceContractorAssignment).toBe(true);
     expect(result.current.canViewReviewSummary).toBe(true);
     expect(result.current.canViewPortfolioHealthSummary).toBe(true);
     expect(result.current.canViewPortfolioScore).toBe(true);
@@ -60,6 +64,8 @@ describe("useEntitlements", () => {
         maintenance: true,
         exports_basic: false,
         portfolio_health_summary: true,
+        marketplace_directory: false,
+        marketplace_contractor_assignment: false,
       },
       loading: false,
     } as any);
@@ -73,6 +79,8 @@ describe("useEntitlements", () => {
     expect(result.current.canViewScreeningHistory).toBe(true);
     expect(result.current.hasMoveInReadiness).toBe(true);
     expect(result.current.canUseWorkOrders).toBe(true);
+    expect(result.current.canViewMarketplaceDirectory).toBe(false);
+    expect(result.current.canUseMarketplaceContractorAssignment).toBe(false);
     expect(result.current.canExportPdf).toBe(false);
     expect(result.current.canViewReviewSummary).toBe(false);
     expect(result.current.canViewPortfolioHealthSummary).toBe(true);
@@ -100,6 +108,8 @@ describe("useEntitlements", () => {
 
     expect(result.current.canScreen).toBe(true);
     expect(result.current.canViewScreeningHistory).toBe(false);
+    expect(result.current.canViewMarketplaceDirectory).toBe(false);
+    expect(result.current.canUseMarketplaceContractorAssignment).toBe(false);
     expect(result.current.canViewPortfolioHealthSummary).toBe(false);
     expect(result.current.canViewPortfolioScore).toBe(false);
     expect(result.current.canViewActionRecommendations).toBe(false);

--- a/rentchain-frontend/src/hooks/useEntitlements.ts
+++ b/rentchain-frontend/src/hooks/useEntitlements.ts
@@ -26,6 +26,9 @@ export function useEntitlements() {
     const canExportPdf = isAdmin || hasFeature(featureMap, ["pdf_export", "exports_basic", "tenantPdfReport"]);
     const hasMoveInReadiness = isAdmin || hasFeature(featureMap, ["move_in_readiness", "tenant_invites"]);
     const canUseWorkOrders = isAdmin || hasFeature(featureMap, ["work_orders", "maintenance"]);
+    const canViewMarketplaceDirectory = isAdmin || hasFeature(featureMap, ["marketplace_directory"]);
+    const canUseMarketplaceContractorAssignment =
+      isAdmin || hasFeature(featureMap, ["marketplace_contractor_assignment"]);
     const canViewReviewSummary = isAdmin || hasFeature(featureMap, ["review_summary", "pdf_export", "exports_basic"]);
     const canViewPortfolioHealthSummary = isAdmin || hasFeature(featureMap, ["portfolio_health_summary"]);
     const canViewPortfolioScore = isAdmin || hasFeature(featureMap, [
@@ -52,6 +55,8 @@ export function useEntitlements() {
       canExportPdf,
       hasMoveInReadiness,
       canUseWorkOrders,
+      canViewMarketplaceDirectory,
+      canUseMarketplaceContractorAssignment,
       canViewReviewSummary,
       canViewPortfolioHealthSummary,
       canViewPortfolioScore,

--- a/rentchain-frontend/src/lib/entitlements.ts
+++ b/rentchain-frontend/src/lib/entitlements.ts
@@ -32,6 +32,8 @@ export const DEFAULT_CAPABILITIES: CapabilitiesResponse = {
     exports_basic: false,
     exports_advanced: false,
     compliance_reports: false,
+    marketplace_directory: false,
+    marketplace_contractor_assignment: false,
     portfolio_health_summary: true,
     portfolio_score: false,
     portfolio_dashboard: false,

--- a/rentchain-frontend/src/lib/upgradePrompt.ts
+++ b/rentchain-frontend/src/lib/upgradePrompt.ts
@@ -32,6 +32,8 @@ const FEATURE_REQUIRED_PLAN: Record<string, string> = {
   ledger_verified: "pro",
   ledger: "starter",
   "team.invites": "pro",
+  marketplace_directory: "pro",
+  marketplace_contractor_assignment: "elite",
   portfolio_health_summary: "free",
   portfolio_score: "pro",
   portfolio_action_recommendations: "elite",

--- a/rentchain-frontend/src/pages/landlord/ContractorsPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/ContractorsPage.test.tsx
@@ -10,6 +10,20 @@ const mocks = vi.hoisted(() => ({
   fetchContractors: vi.fn(),
   createContractorProfile: vi.fn(),
   updateContractorProfile: vi.fn(),
+  useEntitlements: vi.fn(),
+}));
+
+vi.mock("@/hooks/useEntitlements", () => ({
+  useEntitlements: mocks.useEntitlements,
+}));
+
+vi.mock("@/components/billing/FeatureTeaser", () => ({
+  FeatureTeaser: ({ title, description }: { title: string; description: string }) => (
+    <div>
+      <div>{title}</div>
+      <div>{description}</div>
+    </div>
+  ),
 }));
 
 vi.mock("../../api/workOrdersApi", () => ({
@@ -33,6 +47,11 @@ describe("ContractorsPage", () => {
     mocks.fetchContractors.mockReset();
     mocks.createContractorProfile.mockReset();
     mocks.updateContractorProfile.mockReset();
+    mocks.useEntitlements.mockReset();
+    mocks.useEntitlements.mockReturnValue({
+      loading: false,
+      canViewMarketplaceDirectory: true,
+    });
     mocks.listContractorInvites.mockResolvedValue([]);
     mocks.fetchContractors.mockResolvedValue({
       items: [
@@ -67,6 +86,25 @@ describe("ContractorsPage", () => {
     expect(await screen.findByText(/Contractor directory/i)).toBeInTheDocument();
     expect(screen.getByText(/Harbor Plumbing Ltd\./i)).toBeInTheDocument();
     expect(screen.getByText(/No invites yet\./i)).toBeInTheDocument();
+  });
+
+  it("renders a teaser state when marketplace directory access is unavailable", async () => {
+    mocks.useEntitlements.mockReturnValue({
+      loading: false,
+      canViewMarketplaceDirectory: false,
+    });
+
+    render(
+      <MemoryRouter>
+        <ContractorsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Unlock the full contractor directory on Pro/i)).toBeInTheDocument();
+    expect(mocks.listContractorInvites).toHaveBeenCalled();
+    expect(mocks.fetchContractors).toHaveBeenCalled();
+    expect(screen.queryByText(/Create contractor profile/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Invite contractor/i)).not.toBeInTheDocument();
   });
 
   it("creates a contractor profile from the embedded directory form", async () => {

--- a/rentchain-frontend/src/pages/landlord/ContractorsPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/ContractorsPage.tsx
@@ -1,5 +1,8 @@
 import React from "react";
 import { Button, Card, Input } from "../../components/ui/Ui";
+import { useEntitlements } from "@/hooks/useEntitlements";
+import { FeatureTeaser } from "@/components/billing/FeatureTeaser";
+import { resolveRequiredPlanLabel } from "@/lib/upgradePrompt";
 import {
   createContractorInvite,
   listContractorInvites,
@@ -22,6 +25,7 @@ function formatDate(ms?: number | null) {
 }
 
 export default function ContractorsPage() {
+  const { canViewMarketplaceDirectory, loading: entitlementsLoading } = useEntitlements();
   const [loading, setLoading] = React.useState(true);
   const [savingProfile, setSavingProfile] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
@@ -59,8 +63,15 @@ export default function ContractorsPage() {
   }, [availabilityStatus, serviceArea, serviceCategory]);
 
   React.useEffect(() => {
+    if (entitlementsLoading) return;
     void load();
-  }, [load]);
+  }, [entitlementsLoading, load]);
+
+  const marketplacePlanLabel = resolveRequiredPlanLabel("marketplace_directory") || "Pro";
+
+  if (entitlementsLoading) {
+    return <Card>Loading contractor directory...</Card>;
+  }
 
   return (
     <div style={{ display: "grid", gap: 14 }}>
@@ -70,6 +81,16 @@ export default function ContractorsPage() {
           Manage your private contractor network, service coverage, and assignment-ready profiles.
         </div>
       </Card>
+
+      {!canViewMarketplaceDirectory ? (
+        <FeatureTeaser
+          featureKey="marketplace_directory"
+          eyebrow={`${marketplacePlanLabel} marketplace`}
+          title={`Unlock the full contractor directory on ${marketplacePlanLabel}`}
+          description="Preview your existing contractor network now, then upgrade to create profiles, manage invite flows, and use the full marketplace directory experience."
+          ctaLabel={`Upgrade to ${marketplacePlanLabel}`}
+        />
+      ) : null}
 
       <ContractorFilterBar
         serviceCategory={serviceCategory}
@@ -83,27 +104,29 @@ export default function ContractorsPage() {
         onRefresh={() => void load()}
       />
 
-      <ContractorProfileForm
-        initialValue={editing}
-        submitting={savingProfile}
-        onSubmit={async (payload) => {
-          setSavingProfile(true);
-          setError(null);
-          try {
-            if (editing?.id) {
-              await updateContractorProfile(editing.id, payload);
-            } else {
-              await createContractorProfile(payload);
+      {canViewMarketplaceDirectory ? (
+        <ContractorProfileForm
+          initialValue={editing}
+          submitting={savingProfile}
+          onSubmit={async (payload) => {
+            setSavingProfile(true);
+            setError(null);
+            try {
+              if (editing?.id) {
+                await updateContractorProfile(editing.id, payload);
+              } else {
+                await createContractorProfile(payload);
+              }
+              setEditing(null);
+              await load();
+            } catch (err: any) {
+              setError(String(err?.message || "Failed to save contractor profile"));
+            } finally {
+              setSavingProfile(false);
             }
-            setEditing(null);
-            await load();
-          } catch (err: any) {
-            setError(String(err?.message || "Failed to save contractor profile"));
-          } finally {
-            setSavingProfile(false);
-          }
-        }}
-      />
+          }}
+        />
+      ) : null}
 
       {loading ? (
         <Card>Loading contractor directory...</Card>
@@ -115,105 +138,109 @@ export default function ContractorsPage() {
             <ContractorCard
               key={contractor.id}
               contractor={contractor}
-              actionLabel="Edit profile"
-              onAction={() => setEditing(contractor)}
+              actionLabel={canViewMarketplaceDirectory ? "Edit profile" : undefined}
+              onAction={canViewMarketplaceDirectory ? () => setEditing(contractor) : undefined}
             />
           ))}
         </div>
       )}
 
-      <Card style={{ display: "grid", gap: 10 }}>
-        <div style={{ fontWeight: 600 }}>Invite contractor</div>
-        <div style={{ display: "grid", gap: 8, gridTemplateColumns: "repeat(auto-fit,minmax(220px,1fr))" }}>
-          <Input value={email} onChange={(e) => setEmail(e.target.value)} placeholder="contractor@email.com" />
-          <Input value={message} onChange={(e) => setMessage(e.target.value)} placeholder="Optional message" />
-        </div>
-        <div style={{ display: "flex", gap: 8 }}>
-          <Button
-            disabled={savingInvite || !email.trim()}
-            onClick={async () => {
-              setSavingInvite(true);
-              setError(null);
-              try {
-                await createContractorInvite({ email: email.trim(), message: message.trim() });
-                setEmail("");
-                setMessage("");
-                await load();
-              } catch (err: any) {
-                setError(String(err?.message || "Failed to create invite"));
-              } finally {
-                setSavingInvite(false);
-              }
-            }}
-          >
-            {savingInvite ? "Sending..." : "Send Invite"}
-          </Button>
-        </div>
-      </Card>
+      {canViewMarketplaceDirectory ? (
+        <Card style={{ display: "grid", gap: 10 }}>
+          <div style={{ fontWeight: 600 }}>Invite contractor</div>
+          <div style={{ display: "grid", gap: 8, gridTemplateColumns: "repeat(auto-fit,minmax(220px,1fr))" }}>
+            <Input value={email} onChange={(e) => setEmail(e.target.value)} placeholder="contractor@email.com" />
+            <Input value={message} onChange={(e) => setMessage(e.target.value)} placeholder="Optional message" />
+          </div>
+          <div style={{ display: "flex", gap: 8 }}>
+            <Button
+              disabled={savingInvite || !email.trim()}
+              onClick={async () => {
+                setSavingInvite(true);
+                setError(null);
+                try {
+                  await createContractorInvite({ email: email.trim(), message: message.trim() });
+                  setEmail("");
+                  setMessage("");
+                  await load();
+                } catch (err: any) {
+                  setError(String(err?.message || "Failed to create invite"));
+                } finally {
+                  setSavingInvite(false);
+                }
+              }}
+            >
+              {savingInvite ? "Sending..." : "Send Invite"}
+            </Button>
+          </div>
+        </Card>
+      ) : null}
 
       {error ? <Card style={{ borderColor: "#ef4444", color: "#991b1b" }}>{error}</Card> : null}
 
-      <Card>
-        <div style={{ fontWeight: 600, marginBottom: 8 }}>Invite history</div>
-        {loading ? (
-          <div>Loading invites...</div>
-        ) : invites.length === 0 ? (
-          <div style={{ color: "#64748b" }}>No invites yet.</div>
-        ) : (
-          <table style={{ width: "100%", borderCollapse: "collapse" }}>
-            <thead>
-              <tr style={{ textAlign: "left", borderBottom: "1px solid #e2e8f0" }}>
-                <th style={{ padding: 8 }}>Email</th>
-                <th style={{ padding: 8 }}>Status</th>
-                <th style={{ padding: 8 }}>Created</th>
-                <th style={{ padding: 8 }}>Expires</th>
-                <th style={{ padding: 8 }}>Accepted</th>
-                <th style={{ padding: 8 }}>Invite Link</th>
-                <th style={{ padding: 8 }}>Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {invites.map((invite) => (
-                <tr key={invite.id} style={{ borderBottom: "1px solid #f1f5f9" }}>
-                  <td style={{ padding: 8 }}>{invite.email}</td>
-                  <td style={{ padding: 8 }}>{invite.status}</td>
-                  <td style={{ padding: 8 }}>{formatDate(invite.createdAtMs)}</td>
-                  <td style={{ padding: 8 }}>{formatDate(invite.expiresAtMs || null)}</td>
-                  <td style={{ padding: 8 }}>{formatDate(invite.acceptedAtMs)}</td>
-                  <td style={{ padding: 8 }}>
-                    {invite.inviteLink ? (
-                      <a href={invite.inviteLink} target="_blank" rel="noreferrer">
-                        Open
-                      </a>
-                    ) : (
-                      "-"
-                    )}
-                  </td>
-                  <td style={{ padding: 8 }}>
-                    {invite.status !== "accepted" ? (
-                      <Button
-                        variant="ghost"
-                        onClick={async () => {
-                          try {
-                            await resendContractorInvite(invite.id);
-                            await load();
-                          } catch (err: any) {
-                            setError(String(err?.message || "Failed to resend invite"));
-                          }
-                        }}
-                      >
-                        Resend
-                      </Button>
-                    ) : (
-                      "-"
-                    )}
-                  </td>
+      {canViewMarketplaceDirectory ? (
+        <Card>
+          <div style={{ fontWeight: 600, marginBottom: 8 }}>Invite history</div>
+          {loading ? (
+            <div>Loading invites...</div>
+          ) : invites.length === 0 ? (
+            <div style={{ color: "#64748b" }}>No invites yet.</div>
+          ) : (
+            <table style={{ width: "100%", borderCollapse: "collapse" }}>
+              <thead>
+                <tr style={{ textAlign: "left", borderBottom: "1px solid #e2e8f0" }}>
+                  <th style={{ padding: 8 }}>Email</th>
+                  <th style={{ padding: 8 }}>Status</th>
+                  <th style={{ padding: 8 }}>Created</th>
+                  <th style={{ padding: 8 }}>Expires</th>
+                  <th style={{ padding: 8 }}>Accepted</th>
+                  <th style={{ padding: 8 }}>Invite Link</th>
+                  <th style={{ padding: 8 }}>Actions</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
-      </Card>
+              </thead>
+              <tbody>
+                {invites.map((invite) => (
+                  <tr key={invite.id} style={{ borderBottom: "1px solid #f1f5f9" }}>
+                    <td style={{ padding: 8 }}>{invite.email}</td>
+                    <td style={{ padding: 8 }}>{invite.status}</td>
+                    <td style={{ padding: 8 }}>{formatDate(invite.createdAtMs)}</td>
+                    <td style={{ padding: 8 }}>{formatDate(invite.expiresAtMs || null)}</td>
+                    <td style={{ padding: 8 }}>{formatDate(invite.acceptedAtMs)}</td>
+                    <td style={{ padding: 8 }}>
+                      {invite.inviteLink ? (
+                        <a href={invite.inviteLink} target="_blank" rel="noreferrer">
+                          Open
+                        </a>
+                      ) : (
+                        "-"
+                      )}
+                    </td>
+                    <td style={{ padding: 8 }}>
+                      {invite.status !== "accepted" ? (
+                        <Button
+                          variant="ghost"
+                          onClick={async () => {
+                            try {
+                              await resendContractorInvite(invite.id);
+                              await load();
+                            } catch (err: any) {
+                              setError(String(err?.message || "Failed to resend invite"));
+                            }
+                          }}
+                        >
+                          Resend
+                        </Button>
+                      ) : (
+                        "-"
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </Card>
+      ) : null}
     </div>
   );
 }

--- a/rentchain-frontend/src/pages/landlord/WorkOrdersPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/WorkOrdersPage.test.tsx
@@ -5,6 +5,8 @@ import WorkOrdersPage from "./WorkOrdersPage";
 
 const mocks = vi.hoisted(() => ({
   canUseWorkOrders: false,
+  canViewMarketplaceDirectory: false,
+  canUseMarketplaceContractorAssignment: false,
   listWorkOrders: vi.fn(),
   listWorkOrderUpdates: vi.fn(),
   getWorkOrder: vi.fn(),
@@ -36,6 +38,8 @@ const mocks = vi.hoisted(() => ({
 vi.mock("@/hooks/useEntitlements", () => ({
   useEntitlements: () => ({
     canUseWorkOrders: mocks.canUseWorkOrders,
+    canViewMarketplaceDirectory: mocks.canViewMarketplaceDirectory,
+    canUseMarketplaceContractorAssignment: mocks.canUseMarketplaceContractorAssignment,
   }),
 }));
 
@@ -88,6 +92,15 @@ vi.mock("@/components/billing/LockedFeature", () => ({
   ),
 }));
 
+vi.mock("@/components/billing/FeatureTeaser", () => ({
+  FeatureTeaser: ({ title, description }: { title: string; description: string }) => (
+    <div>
+      <div>{title}</div>
+      <div>{description}</div>
+    </div>
+  ),
+}));
+
 describe("WorkOrdersPage", () => {
   beforeEach(() => {
     cleanup();
@@ -102,6 +115,8 @@ describe("WorkOrdersPage", () => {
       })),
     });
     mocks.canUseWorkOrders = false;
+    mocks.canViewMarketplaceDirectory = false;
+    mocks.canUseMarketplaceContractorAssignment = false;
     mocks.listWorkOrders.mockReset();
     mocks.listWorkOrderUpdates.mockReset();
     mocks.getWorkOrder.mockReset();
@@ -312,6 +327,8 @@ describe("WorkOrdersPage", () => {
 
   it("shows contractor marketplace candidates and assigns one to the selected work order", async () => {
     mocks.canUseWorkOrders = true;
+    mocks.canViewMarketplaceDirectory = true;
+    mocks.canUseMarketplaceContractorAssignment = true;
     mocks.fetchProperties.mockResolvedValue({
       items: [{ id: "prop-1", name: "Harbor Place", city: "Halifax", province: "NS" }],
     });
@@ -407,6 +424,85 @@ describe("WorkOrdersPage", () => {
         )
       ).length
     ).toBeGreaterThan(0);
+  });
+
+  it("keeps baseline work orders visible while teasing the contractor directory on lower tiers", async () => {
+    mocks.canUseWorkOrders = true;
+    mocks.canViewMarketplaceDirectory = false;
+    mocks.canUseMarketplaceContractorAssignment = false;
+    mocks.listWorkOrders.mockResolvedValue([
+      {
+        id: "wo-plain-1",
+        landlordId: "landlord-1",
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        title: "Hallway light out",
+        description: "Replace hallway bulb and fixture cover",
+        category: "Electrical",
+        priority: "medium",
+        status: "open",
+        visibility: "private",
+        budgetMinCents: null,
+        budgetMaxCents: null,
+        assignedContractorId: null,
+        invitedContractorIds: [],
+        notesInternal: "",
+        linkedExpenseId: null,
+        createdAtMs: 1,
+        updatedAtMs: 2,
+      },
+    ]);
+    mocks.listWorkOrderUpdates.mockResolvedValue([]);
+
+    render(
+      <MemoryRouter>
+        <WorkOrdersPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Work Orders/i)).toBeInTheDocument();
+    fireEvent.click(await screen.findByRole("button", { name: /timeline/i }));
+    expect(await screen.findByText(/Unlock the contractor directory on Pro/i)).toBeInTheDocument();
+    expect(mocks.fetchContractors).not.toHaveBeenCalled();
+  });
+
+  it("shows an assignment teaser when directory access exists but assignment is still premium", async () => {
+    mocks.canUseWorkOrders = true;
+    mocks.canViewMarketplaceDirectory = true;
+    mocks.canUseMarketplaceContractorAssignment = false;
+    mocks.listWorkOrders.mockResolvedValue([
+      {
+        id: "wo-tease-1",
+        landlordId: "landlord-1",
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        title: "Kitchen faucet drip",
+        description: "Check the faucet cartridge",
+        category: "Plumbing",
+        priority: "medium",
+        status: "open",
+        visibility: "private",
+        budgetMinCents: null,
+        budgetMaxCents: null,
+        assignedContractorId: null,
+        invitedContractorIds: [],
+        notesInternal: "",
+        linkedExpenseId: null,
+        createdAtMs: 1,
+        updatedAtMs: 2,
+      },
+    ]);
+    mocks.listWorkOrderUpdates.mockResolvedValue([]);
+
+    render(
+      <MemoryRouter>
+        <WorkOrdersPage />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /timeline/i }));
+    expect(await screen.findByText(/Unlock contractor assignment on Elite/i)).toBeInTheDocument();
+    expect(mocks.fetchContractors).not.toHaveBeenCalled();
   });
 
   it("renders the cost panel and lets the landlord save and review cost details", async () => {

--- a/rentchain-frontend/src/pages/landlord/WorkOrdersPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/WorkOrdersPage.tsx
@@ -5,6 +5,8 @@ import { AddExpenseModal } from "../../components/expenses/AddExpenseModal";
 import ContractorAssignmentPanel from "../../components/marketplace/ContractorAssignmentPanel";
 import { useEntitlements } from "@/hooks/useEntitlements";
 import { LockedFeature } from "@/components/billing/LockedFeature";
+import { FeatureTeaser } from "@/components/billing/FeatureTeaser";
+import { resolveRequiredPlanLabel } from "@/lib/upgradePrompt";
 import { fetchProperties } from "../../api/propertiesApi";
 import { assignContractorToWorkOrder, fetchContractors, type ContractorProfileV1 } from "../../api/marketplaceContractorApi";
 import {
@@ -259,6 +261,11 @@ export default function WorkOrdersPage() {
   const [costLineItemsJson, setCostLineItemsJson] = React.useState("");
   const [costAttachmentFile, setCostAttachmentFile] = React.useState<File | null>(null);
   const canUseWorkOrders = entitlements.canUseWorkOrders;
+  const canViewMarketplaceDirectory = entitlements.canViewMarketplaceDirectory;
+  const canUseMarketplaceContractorAssignment = entitlements.canUseMarketplaceContractorAssignment;
+  const marketplaceDirectoryPlanLabel = resolveRequiredPlanLabel("marketplace_directory") || "Pro";
+  const marketplaceAssignmentPlanLabel =
+    resolveRequiredPlanLabel("marketplace_contractor_assignment") || "Elite";
 
   const normalizeCategory = React.useCallback((input: string): ExpenseCategory => {
     const raw = String(input || "").trim().toLowerCase();
@@ -836,7 +843,7 @@ export default function WorkOrdersPage() {
   }, [canUseWorkOrders]);
 
   React.useEffect(() => {
-    if (!canUseWorkOrders || !selected) {
+    if (!canUseWorkOrders || !canUseMarketplaceContractorAssignment || !selected) {
       setMarketplaceContractors([]);
       return;
     }
@@ -856,7 +863,7 @@ export default function WorkOrdersPage() {
       }
     };
     void run();
-  }, [canUseWorkOrders, selected, selectedServiceArea]);
+  }, [canUseMarketplaceContractorAssignment, canUseWorkOrders, selected, selectedServiceArea]);
 
   if (!canUseWorkOrders) {
     return (
@@ -1165,13 +1172,31 @@ export default function WorkOrdersPage() {
                 </div>
               ) : null}
             </div>
-            <ContractorAssignmentPanel
-              currentAssignment={selected.contractorAssignment || null}
-              contractors={marketplaceContractors}
-              loading={loadingMarketplaceContractors}
-              assigning={assigningMarketplaceContractor}
-              onAssign={(contractorId) => void handleAssignMarketplaceContractor(contractorId)}
-            />
+            {canUseMarketplaceContractorAssignment ? (
+              <ContractorAssignmentPanel
+                currentAssignment={selected.contractorAssignment || null}
+                contractors={marketplaceContractors}
+                loading={loadingMarketplaceContractors}
+                assigning={assigningMarketplaceContractor}
+                onAssign={(contractorId) => void handleAssignMarketplaceContractor(contractorId)}
+              />
+            ) : canViewMarketplaceDirectory ? (
+              <FeatureTeaser
+                featureKey="marketplace_contractor_assignment"
+                eyebrow={`${marketplaceAssignmentPlanLabel} marketplace`}
+                title={`Unlock contractor assignment on ${marketplaceAssignmentPlanLabel}`}
+                description="Keep baseline work orders in place, then upgrade to discover contractor candidates and assign them directly from the job workflow."
+                ctaLabel={`Upgrade to ${marketplaceAssignmentPlanLabel}`}
+              />
+            ) : (
+              <FeatureTeaser
+                featureKey="marketplace_directory"
+                eyebrow={`${marketplaceDirectoryPlanLabel} marketplace`}
+                title={`Unlock the contractor directory on ${marketplaceDirectoryPlanLabel}`}
+                description="Upgrade to build a private contractor network first, then unlock embedded contractor assignment inside work orders on higher tiers."
+                ctaLabel={`Upgrade to ${marketplaceDirectoryPlanLabel}`}
+              />
+            )}
             <div
               style={{
                 display: "grid",


### PR DESCRIPTION
## Summary

Implements Marketplace Premium Access Controls v1 by introducing explicit marketplace capability keys, normalizing entitlement handling across backend and frontend, and applying the shared upgrade/teaser UX to landlord marketplace surfaces.

This creates a clear marketplace monetization layer while preserving baseline maintenance workflows and existing contractor access boundaries.

## What changed

### Backend

- Added canonical marketplace capability keys:
  - `marketplace_directory`
  - `marketplace_contractor_assignment`
- Extended `planCapabilities.ts` and `/api/capabilities` to expose marketplace access semantics
- Normalized marketplace route behavior:
  - contractor directory routes remain role-protected (no premium hard block)
  - contractor assignment routes now enforce premium capability (`marketplace_contractor_assignment`)

### Frontend

- Extended entitlement helpers:
  - `canViewMarketplaceDirectory`
  - `canUseMarketplaceContractorAssignment`
- Reused Mission 25 upgrade / locked-state system:
  - `upgradePrompt.ts`
  - `LockedFeature`
  - `FeatureTeaser`
  - `UpgradeCTA`
- Removed need for page-level plan checks

### Marketplace UX behavior

#### ContractorsPage
- **Unlocked (premium):**
  - full directory
  - create/edit contractor profiles
  - invite + history management

- **Teaser (non-premium):**
  - directory visible in read-only preview form
  - management actions hidden
  - upgrade prompts shown via shared system

#### WorkOrdersPage

- **Baseline:**
  - work order creation and management unchanged (`work_orders`)

- **Marketplace layer:**
  - no directory access → teaser for contractor directory
  - directory access but no assignment → teaser for assignment
  - full capability → contractor discovery + assignment available

## Capability model

- `work_orders` remains baseline operational capability
- `marketplace_directory` controls directory access
- `marketplace_contractor_assignment` controls embedded assignment flow

No plan logic is implemented directly in page code — all behavior is capability-driven.

## Verification

### Backend
- `npm run test -- src/services/__tests__/planCapabilities.test.ts src/routes/__tests__/marketplaceContractorRoutes.test.ts`
- `npm run build`

### Frontend
- `npm run test -- src/hooks/useEntitlements.test.tsx src/pages/landlord/ContractorsPage.test.tsx src/pages/landlord/WorkOrdersPage.test.tsx`
- `npm run build`

## Important design note

Marketplace premiumization is intentionally **frontend-led for directory access**:

- contractor directory endpoints are not premium-blocked server-side
- backend enforcement is applied only to contractor assignment
- this supports an additive teaser-driven UX rather than a hard access wall

This is a deliberate tradeoff for conversion optimization and can be revisited in a future hardening pass if stricter enforcement is required.

## Intentionally out of scope

- contractor-facing pages (`/contractor/*`)
- marketplace ranking or recommendation logic
- public marketplace expansion
- data model redesign
- repo-wide cleanup of all legacy marketplace access patterns