### PR TITLE
chore: ignore local conversation engine artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,15 @@ override.tf.json
 # Local test artifacts
 playwright-report/
 test-results/
+
+# Local conversation engine artifacts
+.conversation_engine/
+
+# Local conversation engine artifacts
+.conversation_engine/
+
+# Optional local scratch files for manual paste workflows
+/tmp/codex_audit_*.txt
+/tmp/chatgpt_review_*.txt
+/tmp/codex_impl_*.txt
+/tmp/chatgpt_patch_*.txt


### PR DESCRIPTION
Description:
Adds `.conversation_engine/` and related local conversation engine artifact patterns to `.gitignore`.

Purpose:
- keep local AI handoff artifacts out of feature branches
- reduce GitHub Desktop noise
- support local-only mission audit and review workflows

Notes:
- repo hygiene only
- no product code changes
- no impact to billing, entitlements, marketplace, or UI behavior