### PR TITLE
feat: add billing status and access reliability v1

### DIFF
--- a/rentchain-api/src/routes/__tests__/billingRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/billingRoutes.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const resolveLandlordAndTierMock = vi.fn();
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, _res: any, next: any) => {
+    const header = String(req.headers["x-test-user"] || "").trim();
+    if (header) req.user = JSON.parse(header);
+    next();
+  },
+}));
+
+vi.mock("../../lib/landlordResolver", () => ({
+  resolveLandlordAndTier: resolveLandlordAndTierMock,
+}));
+
+vi.mock("../../services/billingService", () => ({
+  listRecordsForLandlord: vi.fn(() => []),
+}));
+
+vi.mock("../../config/firebase", () => ({
+  db: {
+    collection: () => ({
+      doc: () => ({
+        get: async () => ({ exists: false, data: () => null }),
+        set: async () => undefined,
+      }),
+    }),
+  },
+}));
+
+vi.mock("../../services/stripeService", () => ({
+  getStripeClient: vi.fn(() => {
+    throw new Error("not needed in billingRoutes subscription-status test");
+  }),
+}));
+
+vi.mock("../../lib/stripeNotConfigured", () => ({
+  stripeNotConfiguredResponse: vi.fn(() => ({ ok: false, error: "stripe_not_configured" })),
+  isStripeNotConfiguredError: vi.fn(() => false),
+}));
+
+vi.mock("../../config/screeningConfig", () => ({
+  FRONTEND_URL: "http://localhost:5173",
+}));
+
+vi.mock("../../billing/screeningPricing", () => ({
+  getScreeningPricing: vi.fn(() => ({
+    baseAmountCents: 2500,
+    scoreAddOnCents: 500,
+    expeditedAddOnCents: 700,
+  })),
+}));
+
+async function invokeRouter(
+  router: any,
+  options: { method: string; url: string; headers?: Record<string, string> }
+) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path: options.url,
+      headers: options.headers ?? {},
+      body: {},
+      query: {},
+      get(name: string) {
+        return this.headers[String(name).toLowerCase()];
+      },
+    };
+    const res: any = {
+      statusCode: 200,
+      setHeader: vi.fn(),
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("billingRoutes subscription status", () => {
+  beforeEach(() => {
+    resolveLandlordAndTierMock.mockReset();
+  });
+
+  it("returns the effective canonical tier from landlord resolution", async () => {
+    resolveLandlordAndTierMock.mockResolvedValue({
+      tier: "elite",
+      landlordIdResolved: "landlord-1",
+      landlordDocId: "landlord-1",
+      landlordPlanRaw: "enterprise",
+      source: "landlordId",
+    });
+
+    const router = (await import("../billingRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/subscription-status",
+      headers: {
+        "x-test-user": JSON.stringify({ id: "u1", landlordId: "landlord-1", role: "landlord", plan: "starter" }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: true,
+      tier: "elite",
+      planId: "elite",
+      status: "active",
+      isActive: true,
+      interval: null,
+      renewalDate: null,
+    });
+  });
+
+  it("keeps the compatibility alias route and falls back to the token plan when needed", async () => {
+    resolveLandlordAndTierMock.mockResolvedValue({
+      tier: undefined,
+      landlordIdResolved: "landlord-1",
+      landlordDocId: null,
+      landlordPlanRaw: null,
+      source: "tokenFallback",
+    });
+
+    const router = (await import("../billingRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/billing/subscription-status",
+      headers: {
+        "x-test-user": JSON.stringify({ id: "u1", landlordId: "landlord-1", role: "landlord", plan: "business" }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: true,
+      tier: "elite",
+      planId: "elite",
+      status: "active",
+      isActive: true,
+    });
+  });
+});

--- a/rentchain-api/src/routes/billingRoutes.ts
+++ b/rentchain-api/src/routes/billingRoutes.ts
@@ -14,6 +14,7 @@ import {
   type BillingPlanKey,
 } from "../config/planMatrix";
 import { getScreeningPricing } from "../billing/screeningPricing";
+import { resolveLandlordAndTier } from "../lib/landlordResolver";
 
 const router = express.Router();
 
@@ -28,15 +29,19 @@ function normalizeSubscriptionStatusTier(input: any): SubscriptionStatusTier {
   return resolvePaidBillingPlan(input) || "free";
 }
 
-function sendSubscriptionStatus(req: any, res: any) {
-  const tier = normalizeSubscriptionStatusTier(req.user?.plan);
+async function sendSubscriptionStatus(req: any, res: any) {
+  const resolved = await resolveLandlordAndTier(req.user);
+  const tier = normalizeSubscriptionStatusTier(resolved?.tier || req.user?.plan);
   const interval: SubscriptionStatusInterval = null;
   const renewalDate: string | null = null;
   const isActive = tier !== "free";
+  const status = isActive ? "active" : "canceled";
 
   return res.status(200).json({
     ok: true,
     tier,
+    planId: tier,
+    status,
     interval,
     renewalDate,
     isActive,

--- a/rentchain-frontend/src/api/billingApi.ts
+++ b/rentchain-frontend/src/api/billingApi.ts
@@ -36,24 +36,28 @@ export async function fetchBillingHistory(): Promise<BillingRecord[]> {
 }
 
 export interface SubscriptionStatus {
-  planId: Plan;
+  tier: Plan | null;
+  planId: Plan | null;
   status: "active" | "past_due" | "canceled";
+  interval?: "month" | "year" | null;
+  renewalDate?: string | null;
+  isActive?: boolean;
 }
 
 export async function fetchSubscriptionStatus(): Promise<SubscriptionStatus> {
   try {
-    const res = await apiGetJson<any>("/billing/subscription-status", { allowStatuses: [404, 501] });
-    if (!res.ok) {
-      return { planId: "free", status: "canceled" } as SubscriptionStatus;
-    }
-    const data = res.data;
-    const payload = (data?.subscription ?? data) as SubscriptionStatus;
+    const payload = await apiFetch("/billing/subscription-status", { method: "GET" });
+    const data = ((payload as any)?.subscription ?? payload) as any;
+    const tierValue = data?.tier ?? data?.planId;
+    const tier = tierValue == null || String(tierValue).trim() === "" ? null : normalizePlan(tierValue);
     return {
-      ...payload,
-      planId: normalizePlan(payload?.planId),
+      ...data,
+      tier,
+      planId: tier,
+      status: data?.status === "past_due" ? "past_due" : data?.status === "active" ? "active" : "canceled",
     };
   } catch {
-    return { planId: "free", status: "canceled" } as SubscriptionStatus;
+    return { tier: null, planId: null, status: "canceled" } as SubscriptionStatus;
   }
 }
 

--- a/rentchain-frontend/src/components/billing/BillingPlansPanel.tsx
+++ b/rentchain-frontend/src/components/billing/BillingPlansPanel.tsx
@@ -43,7 +43,7 @@ export function BillingPlansPanel({
     }
     return map;
   }, [pricing]);
-  const currentPlanKey = normalizePlan(currentPlan);
+  const currentPlanKey = currentPlan == null ? null : normalizePlan(currentPlan);
 
   const renderPrice = (planKey: Exclude<PricingPlanKey, "free">) => {
     const fallbackPlan = CANONICAL_TIER_MATRIX[planKey];

--- a/rentchain-frontend/src/hooks/useBillingStatus.test.tsx
+++ b/rentchain-frontend/src/hooks/useBillingStatus.test.tsx
@@ -15,15 +15,43 @@ vi.mock("@/context/useAuth", () => ({
 }));
 
 describe("useBillingStatus", () => {
-  it("normalizes alias plans from capabilities and auth state", async () => {
+  it("prefers the canonical tier returned by subscription status", async () => {
     const { fetchSubscriptionStatus } = await import("@/api/billingApi");
     const { useCapabilities } = await import("@/hooks/useCapabilities");
     const { useAuth } = await import("@/context/useAuth");
 
     vi.mocked(fetchSubscriptionStatus).mockResolvedValue({
-      planId: "free",
+      tier: "starter",
+      planId: "starter",
       status: "active",
       interval: "month",
+      renewalDate: null,
+    } as any);
+    vi.mocked(useCapabilities).mockReturnValue({
+      caps: { plan: "business" },
+      loading: false,
+    } as any);
+    vi.mocked(useAuth).mockReturnValue({
+      user: { id: "u1", role: "landlord", plan: "core" },
+    } as any);
+
+    const { result } = renderHook(() => useBillingStatus());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.tier).toBe("starter");
+    expect(result.current.interval).toBe("month");
+  });
+
+  it("falls back to canonical capability or auth plan when billing status is unavailable", async () => {
+    const { fetchSubscriptionStatus } = await import("@/api/billingApi");
+    const { useCapabilities } = await import("@/hooks/useCapabilities");
+    const { useAuth } = await import("@/context/useAuth");
+
+    vi.mocked(fetchSubscriptionStatus).mockResolvedValue({
+      tier: null,
+      planId: null,
+      status: "canceled",
+      interval: null,
       renewalDate: null,
     } as any);
     vi.mocked(useCapabilities).mockReturnValue({

--- a/rentchain-frontend/src/hooks/useBillingStatus.ts
+++ b/rentchain-frontend/src/hooks/useBillingStatus.ts
@@ -15,6 +15,7 @@ type BillingStatus = {
 };
 
 type SubscriptionDetail = {
+  tier: PlanTier | null;
   interval: BillingInterval;
   renewalDate: string | null;
 };
@@ -46,6 +47,7 @@ export function useBillingStatus(): BillingStatus {
   const { caps, loading: capsLoading } = useCapabilities();
   const { user } = useAuth();
   const [subscription, setSubscription] = useState<SubscriptionDetail>({
+    tier: null,
     interval: null,
     renewalDate: null,
   });
@@ -56,17 +58,18 @@ export function useBillingStatus(): BillingStatus {
     fetchSubscriptionStatus()
       .then((raw: any) => {
         if (!active) return;
+        const tier = planFromString(raw?.tier ?? raw?.planId ?? null);
         const interval = intervalFromString(
           raw?.interval || raw?.billingInterval || raw?.period || null
         );
         const renewalDate = parseDate(
           raw?.renewalDate || raw?.currentPeriodEnd || raw?.nextBillingAt || null
         );
-        setSubscription({ interval, renewalDate });
+        setSubscription({ tier, interval, renewalDate });
       })
       .catch(() => {
         if (!active) return;
-        setSubscription({ interval: null, renewalDate: null });
+        setSubscription({ tier: null, interval: null, renewalDate: null });
       })
       .finally(() => {
         if (active) setSubscriptionLoading(false);
@@ -89,6 +92,7 @@ export function useBillingStatus(): BillingStatus {
     }
 
     const tier =
+      subscription.tier ||
       planFromString(caps?.plan) ||
       planFromString(user?.plan) ||
       planFromString((user as any)?.subscriptionPlan) ||
@@ -103,6 +107,7 @@ export function useBillingStatus(): BillingStatus {
   }, [
     caps?.plan,
     capsLoading,
+    subscription.tier,
     subscription.interval,
     subscription.renewalDate,
     subscriptionLoading,

--- a/rentchain-frontend/src/pages/BillingPage.test.tsx
+++ b/rentchain-frontend/src/pages/BillingPage.test.tsx
@@ -1,0 +1,122 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import BillingPage from "./BillingPage";
+
+const mocks = vi.hoisted(() => ({
+  useAuthMock: vi.fn(),
+  useBillingStatusMock: vi.fn(),
+  billingTierLabelMock: vi.fn(),
+  fetchBillingHistoryMock: vi.fn(),
+  fetchBillingPricingMock: vi.fn(),
+  createBillingPortalSessionMock: vi.fn(),
+  apiFetchMock: vi.fn(),
+  trackMock: vi.fn(),
+  refreshEntitlementsMock: vi.fn(),
+  billingPlansPanelMock: vi.fn(),
+}));
+
+vi.mock("../context/useAuth", () => ({
+  useAuth: mocks.useAuthMock,
+}));
+
+vi.mock("@/hooks/useBillingStatus", () => ({
+  useBillingStatus: mocks.useBillingStatusMock,
+  billingTierLabel: mocks.billingTierLabelMock,
+}));
+
+vi.mock("../api/billingApi", () => ({
+  fetchBillingHistory: mocks.fetchBillingHistoryMock,
+  fetchBillingPricing: mocks.fetchBillingPricingMock,
+  createBillingPortalSession: mocks.createBillingPortalSessionMock,
+}));
+
+vi.mock("@/lib/apiClient", () => ({
+  apiFetch: mocks.apiFetchMock,
+}));
+
+vi.mock("@/lib/analytics", () => ({
+  track: mocks.trackMock,
+}));
+
+vi.mock("@/lib/entitlements", () => ({
+  refreshEntitlements: mocks.refreshEntitlementsMock,
+}));
+
+vi.mock("../components/billing/BillingPlansPanel", () => ({
+  BillingPlansPanel: (props: any) => {
+    mocks.billingPlansPanelMock(props);
+    return <div data-testid="billing-plans-panel">{props.currentPlan ?? "none"}</div>;
+  },
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("BillingPage", () => {
+  beforeEach(() => {
+    mocks.useAuthMock.mockReturnValue({
+      user: { id: "u1", role: "landlord", actorRole: "landlord" },
+      updateUser: vi.fn(),
+    });
+    mocks.fetchBillingHistoryMock.mockResolvedValue([]);
+    mocks.fetchBillingPricingMock.mockResolvedValue({
+      ok: true,
+      plans: [
+        { key: "starter", label: "Starter", currency: "cad", monthlyAmountCents: 2900, yearlyAmountCents: 29000 },
+        { key: "pro", label: "Pro", currency: "cad", monthlyAmountCents: 5900, yearlyAmountCents: 59000 },
+        { key: "elite", label: "Elite", currency: "cad", monthlyAmountCents: 9900, yearlyAmountCents: 99000 },
+      ],
+    });
+    mocks.createBillingPortalSessionMock.mockResolvedValue({ url: "https://example.test/portal" });
+    mocks.refreshEntitlementsMock.mockResolvedValue(undefined);
+    mocks.billingTierLabelMock.mockImplementation((tier: string | null) => {
+      if (tier === "elite") return "Elite";
+      if (tier === "pro") return "Pro";
+      if (tier === "starter") return "Starter";
+      return "Free";
+    });
+  });
+
+  it("holds current-plan display in loading state until billing status resolves", async () => {
+    mocks.useBillingStatusMock.mockReturnValue({
+      tier: "elite",
+      interval: null,
+      renewalDate: null,
+      isLoading: true,
+    });
+
+    render(
+      <MemoryRouter>
+        <BillingPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getAllByText("Loading...").length).toBeGreaterThan(0);
+    expect(screen.getByTestId("billing-plans-panel")).toHaveTextContent("none");
+    expect(screen.getAllByRole("button", { name: "Upgrade plan" })).toHaveLength(2);
+    expect(screen.getAllByRole("button", { name: "Upgrade plan" }).every((button) => button.hasAttribute("disabled"))).toBe(true);
+  });
+
+  it("uses the resolved billing tier consistently in the summary and plans panel", async () => {
+    mocks.useBillingStatusMock.mockReturnValue({
+      tier: "pro",
+      interval: "month",
+      renewalDate: null,
+      isLoading: false,
+    });
+
+    render(
+      <MemoryRouter>
+        <BillingPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(screen.getByText("Pro")).toBeInTheDocument());
+    expect(screen.getByTestId("billing-plans-panel")).toHaveTextContent("pro");
+    expect(screen.getAllByRole("button", { name: "Manage subscription" })).toHaveLength(2);
+    expect(screen.getByText(/Pro includes exports, reporting, and team workflows/)).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/BillingPage.tsx
+++ b/rentchain-frontend/src/pages/BillingPage.tsx
@@ -77,8 +77,9 @@ const BillingPage: React.FC = () => {
   const [interval, setInterval] = useState<"month" | "year">("month");
   const { user, updateUser } = useAuth();
   const billingStatus = useBillingStatus();
-  const currentPlan = billingStatus.tier;
-  const isPaidPlan = currentPlan !== "free";
+  const currentPlan = billingStatus.isLoading ? null : billingStatus.tier;
+  const resolvedCurrentPlan = currentPlan || "free";
+  const isPaidPlan = resolvedCurrentPlan !== "free";
 
   const getErrorMessage = (error: unknown, fallback: string) => {
     if (error instanceof Error && error.message) return error.message;
@@ -104,7 +105,7 @@ const BillingPage: React.FC = () => {
   };
 
   useEffect(() => {
-    track("billing_page_opened", { tier: currentPlan });
+    track("billing_page_opened", { tier: resolvedCurrentPlan });
     void refreshEntitlements(updateUser);
     void load();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -136,8 +137,8 @@ const BillingPage: React.FC = () => {
 
   const handlePlanAction = async (planKey: "starter" | "pro" | "elite") => {
     if (pricingUnavailable) return;
-    if (planKey === currentPlan) return;
-    track("billing_upgrade_clicked", { toTier: planKey, interval });
+    if (planKey === resolvedCurrentPlan) return;
+    track("billing_upgrade_clicked", { fromTier: resolvedCurrentPlan, toTier: planKey, interval });
 
     try {
       setPlanActionLoading(planKey);
@@ -164,7 +165,7 @@ const BillingPage: React.FC = () => {
   };
 
   const handlePortal = async () => {
-    track("billing_manage_subscription_clicked", { tier: currentPlan });
+    track("billing_manage_subscription_clicked", { tier: resolvedCurrentPlan });
     try {
       setPortalLoading(true);
       const res = await createBillingPortalSession();
@@ -180,7 +181,13 @@ const BillingPage: React.FC = () => {
   };
 
   const nextUpgradeTier =
-    currentPlan === "free" ? "starter" : currentPlan === "starter" ? "pro" : currentPlan === "pro" ? "elite" : null;
+    resolvedCurrentPlan === "free"
+      ? "starter"
+      : resolvedCurrentPlan === "starter"
+        ? "pro"
+        : resolvedCurrentPlan === "pro"
+          ? "elite"
+          : null;
   const nextUpgradeLabel = nextUpgradeTier
     ? interval === "year"
       ? `${CANONICAL_TIER_MATRIX[nextUpgradeTier].ctaLabel} (Yearly)`
@@ -219,7 +226,7 @@ const BillingPage: React.FC = () => {
                 type="button"
                 variant="primary"
                 onClick={() => void handlePlanAction("starter")}
-                disabled={planActionLoading === "starter" || pricingUnavailable}
+                disabled={billingStatus.isLoading || planActionLoading === "starter" || pricingUnavailable}
               >
                 {planActionLoading === "starter" ? "Opening..." : "Upgrade plan"}
               </Button>
@@ -234,7 +241,9 @@ const BillingPage: React.FC = () => {
           <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: spacing.sm }}>
             <div>
               <div style={{ color: text.muted, fontSize: 12 }}>Tier</div>
-              <div style={{ fontWeight: 700 }}>{billingTierLabel(currentPlan)}</div>
+              <div style={{ fontWeight: 700 }}>
+                {billingStatus.isLoading ? "Loading..." : billingTierLabel(resolvedCurrentPlan)}
+              </div>
             </div>
             <div>
               <div style={{ color: text.muted, fontSize: 12 }}>Billing interval</div>
@@ -255,7 +264,7 @@ const BillingPage: React.FC = () => {
                 type="button"
                 variant="secondary"
                 onClick={() => void handlePlanAction("starter")}
-                disabled={planActionLoading === "starter" || pricingUnavailable}
+                disabled={billingStatus.isLoading || planActionLoading === "starter" || pricingUnavailable}
               >
                 {planActionLoading === "starter" ? "Opening..." : "Upgrade plan"}
               </Button>
@@ -264,23 +273,23 @@ const BillingPage: React.FC = () => {
               <Button
                 type="button"
                 onClick={() => void handlePlanAction(nextUpgradeTier)}
-                disabled={planActionLoading === nextUpgradeTier || pricingUnavailable}
+                disabled={billingStatus.isLoading || planActionLoading === nextUpgradeTier || pricingUnavailable}
               >
                 {nextUpgradeLabel}
               </Button>
             ) : null}
           </div>
-          {currentPlan === "free" ? (
+          {resolvedCurrentPlan === "free" ? (
             <div style={{ marginTop: spacing.xs, color: text.muted }}>
               Free includes guided setup and pay-per-use screening. Upgrade when you want richer rental operations, communication, exports, and reporting.
             </div>
           ) : null}
-          {currentPlan === "starter" ? (
+          {resolvedCurrentPlan === "starter" ? (
             <div style={{ marginTop: spacing.xs, color: text.muted, fontSize: 14 }}>
               Starter includes messaging, leases, maintenance, and work orders. Pro adds exports, screening summaries, compliance reports, and team workflows.
             </div>
           ) : null}
-          {currentPlan === "pro" ? (
+          {resolvedCurrentPlan === "pro" ? (
             <div style={{ marginTop: spacing.xs, color: text.muted, fontSize: 14 }}>
               Pro includes exports, reporting, and team workflows. Elite adds advanced analytics, AI summaries, and audit visibility.
             </div>


### PR DESCRIPTION
## Summary

Implements Billing Status and Access Reliability v1 by making `/billing/subscription-status` the authoritative backend source for billing-display tier and aligning the frontend billing-status client and UI to that response.

This improves current-plan display reliability without changing capability-based access control or broadening billing architecture scope.

## What changed

### Backend
- Hardened `/billing/subscription-status`
- Current tier is now resolved through the canonical backend landlord-tier resolver instead of trusting raw `req.user.plan`
- Response remains compatibility-safe and now returns both `tier` and `planId`, along with:
  - `status`
  - `isActive`
  - `interval`
  - `renewalDate`

### Frontend
- Fixed `fetchSubscriptionStatus()` to match the real backend response shape
- Updated `useBillingStatus()` so it prefers the billing-status tier when provided and only falls back to capability/auth state when necessary
- Normalized `BillingPage.tsx` and `BillingPlansPanel.tsx` to use the same resolved current tier
- Removed the transient stale `"free"` display/highlighting while billing status is still loading

## Files changed

### Backend
- `rentchain-api/src/routes/__tests__/billingRoutes.test.ts`
- `rentchain-api/src/routes/billingRoutes.ts`

### Frontend
- `rentchain-frontend/src/api/billingApi.ts`
- `rentchain-frontend/src/components/billing/BillingPlansPanel.tsx`
- `rentchain-frontend/src/hooks/useBillingStatus.test.tsx`
- `rentchain-frontend/src/hooks/useBillingStatus.ts`
- `rentchain-frontend/src/pages/BillingPage.test.tsx`
- `rentchain-frontend/src/pages/BillingPage.tsx`

## Verification

### Backend
- `npm run test -- src/routes/__tests__/billingRoutes.test.ts`
- `npm run build`

### Frontend
- `npm run test -- src/hooks/useBillingStatus.test.tsx src/pages/BillingPage.test.tsx`
- `npm run build`

## Authoritative tier note

- `/billing/subscription-status` is now the authoritative source for **billing-display tier**
- Capability-based access remains unchanged and still flows through:
  - `/api/capabilities`
  - `useCapabilities()`
  - `useEntitlements()`

This mission improves billing/access reliability for display and current-plan state, but does **not** replace capability-driven authorization.

## Intentionally out of scope

- checkout flow redesign
- Stripe lifecycle/webhook redesign
- portal flow redesign
- pricing route overhaul
- broader billing metadata improvements beyond tier reliability

## Remaining known limitations

- `interval` and `renewalDate` are still `null`
- this mission intentionally did not widen into checkout, portal, or pricing route testing
- billing-display tier and capability tier could diverge in the future if business rules intentionally split, though they currently use the same effective backend tier path