### PR TITLE
feat: add subscription conversion analytics v1

### DIFF
--- a/rentchain-api/src/routes/__tests__/eventsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/eventsRoutes.test.ts
@@ -1,6 +1,3 @@
-import cookieParser from "cookie-parser";
-import express from "express";
-import request from "supertest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 type StoredDoc = { id: string; data: any };
@@ -53,17 +50,63 @@ vi.mock("../../services/telemetryService", () => ({
   incrementCounter: telemetryMocks.incrementCounter,
 }));
 
-async function createApp(user?: Record<string, unknown>) {
+async function createRouter() {
   const router = (await import("../eventsRoutes")).default;
-  const app = express();
-  app.use(express.json());
-  app.use(cookieParser());
-  app.use((req: any, _res: any, next: any) => {
-    req.user = user || null;
-    next();
+  return router;
+}
+
+async function invokeRouter(
+  router: any,
+  options: {
+    method: string;
+    url: string;
+    user?: Record<string, unknown> | null;
+    body?: any;
+    cookies?: Record<string, string>;
+  }
+) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path: options.url.split("?")[0],
+      query: {},
+      body: options.body ?? {},
+      user: options.user || null,
+      cookies: options.cookies ?? {},
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, any>,
+      setHeader(name: string, value: any) {
+        this.headers[name.toLowerCase()] = value;
+      },
+      cookie(name: string, value: string) {
+        req.cookies[name] = value;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    const [pathOnly, rawQuery] = options.url.split("?");
+    req.path = pathOnly;
+    if (rawQuery) {
+      req.query = Object.fromEntries(new URLSearchParams(rawQuery).entries());
+    }
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
   });
-  app.use("/api/events", router);
-  return app;
 }
 
 describe("eventsRoutes", () => {
@@ -73,10 +116,11 @@ describe("eventsRoutes", () => {
   });
 
   it("accepts registry pricing-funnel events through the lightweight tracker", async () => {
-    const app = await createApp();
-    const res = await request(app)
-      .post("/api/events/track")
-      .send({
+    const router = await createRouter();
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/track",
+      body: {
         name: "registry_ready_created",
         props: {
           propertyId: "prop-1",
@@ -84,11 +128,50 @@ describe("eventsRoutes", () => {
           medium: "cpc",
           campaign: "halifax-ready",
         },
-      });
+      },
+    });
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ ok: true });
     expect(telemetryMocks.incrementCounter).toHaveBeenCalledWith({ name: "registry_ready_created" });
+  });
+
+  it("accepts billing and upgrade prompt analytics events through the generic tracker", async () => {
+    const router = await createRouter();
+
+    const billingRes = await invokeRouter(router, {
+      method: "POST",
+      url: "/track",
+      body: {
+        name: "billing_page_opened",
+        props: {
+          currentPlan: "pro",
+          surface: "billing_page",
+          route: "/billing",
+        },
+      },
+    });
+
+    const promptRes = await invokeRouter(router, {
+      method: "POST",
+      url: "/track",
+      body: {
+        name: "upgrade_prompt_viewed",
+        props: {
+          featureKey: "tenant_invites",
+          currentPlan: "free",
+          requiredPlan: "starter",
+          source: "locked_feature",
+          presentation: "modal",
+          route: "/applications",
+        },
+      },
+    });
+
+    expect(billingRes.status).toBe(200);
+    expect(promptRes.status).toBe(200);
+    expect(telemetryMocks.incrementCounter).toHaveBeenCalledWith({ name: "billing_page_opened" });
+    expect(telemetryMocks.incrementCounter).toHaveBeenCalledWith({ name: "upgrade_prompt_viewed" });
   });
 
   it("returns a grouped registry funnel report for admins", async () => {
@@ -141,10 +224,12 @@ describe("eventsRoutes", () => {
       },
     });
 
-    const app = await createApp({ id: "admin-1", role: "admin" });
-    const res = await request(app)
-      .get("/api/events/registry-funnel-report?from=2026-04-01T00:00:00.000Z&to=2026-04-03T00:00:00.000Z")
-      .send();
+    const router = await createRouter();
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/registry-funnel-report?from=2026-04-01T00:00:00.000Z&to=2026-04-03T00:00:00.000Z",
+      user: { id: "admin-1", role: "admin" },
+    });
 
     expect(res.status).toBe(200);
     expect(res.body?.totals).toEqual({
@@ -195,8 +280,12 @@ describe("eventsRoutes", () => {
   });
 
   it("blocks the funnel report for non-admin users", async () => {
-    const app = await createApp({ id: "landlord-1", role: "landlord" });
-    const res = await request(app).get("/api/events/registry-funnel-report").send();
+    const router = await createRouter();
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/registry-funnel-report",
+      user: { id: "landlord-1", role: "landlord" },
+    });
     expect(res.status).toBe(403);
     expect(res.body?.error).toBe("forbidden");
   });

--- a/rentchain-api/src/routes/eventsRoutes.ts
+++ b/rentchain-api/src/routes/eventsRoutes.ts
@@ -6,9 +6,13 @@ import { incrementCounter } from "../services/telemetryService";
 const router = express.Router();
 
 const ALLOWED_EVENT_PATTERNS = [
+  /^billing_/,
+  /^pricing_/,
   /^pricing_cta_/,
   /^demo_/,
   /^gating_/,
+  /^upgrade_cta_/,
+  /^upgrade_prompt_/,
   /^upgrade_modal_/,
   /^registry_/,
 ];

--- a/rentchain-frontend/src/components/billing/FeatureTeaser.tsx
+++ b/rentchain-frontend/src/components/billing/FeatureTeaser.tsx
@@ -30,7 +30,13 @@ export function FeatureTeaser({ featureKey, eyebrow, title, description, ctaLabe
       <div style={{ fontSize: 16, fontWeight: 800, color: text.primary }}>{title}</div>
       <div style={{ color: text.muted, fontSize: 14, lineHeight: 1.6 }}>{description}</div>
       <div>
-        <UpgradeCTA featureKey={featureKey} label={ctaLabel} variant="secondary" />
+        <UpgradeCTA
+          featureKey={featureKey}
+          label={ctaLabel}
+          source="feature_teaser"
+          presentation="teaser"
+          variant="secondary"
+        />
       </div>
     </section>
   );

--- a/rentchain-frontend/src/components/billing/LockedFeature.tsx
+++ b/rentchain-frontend/src/components/billing/LockedFeature.tsx
@@ -37,7 +37,13 @@ export function LockedFeature({
         {hint ? <div style={{ color: text.secondary, fontSize: 12 }}>{hint}</div> : null}
       </div>
       <div>
-        <UpgradeCTA featureKey={featureKey} label={ctaLabel} variant="secondary" />
+        <UpgradeCTA
+          featureKey={featureKey}
+          label={ctaLabel}
+          source="locked_feature"
+          presentation="locked"
+          variant="secondary"
+        />
       </div>
     </Card>
   );

--- a/rentchain-frontend/src/components/billing/UpgradeCTA.test.tsx
+++ b/rentchain-frontend/src/components/billing/UpgradeCTA.test.tsx
@@ -2,12 +2,20 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { UpgradeCTA } from "./UpgradeCTA";
 
+const mocks = vi.hoisted(() => ({
+  track: vi.fn(),
+}));
+
 vi.mock("@/context/useAuth", () => ({
   useAuth: () => ({
     user: {
       plan: "core",
     },
   }),
+}));
+
+vi.mock("@/lib/analytics", () => ({
+  track: mocks.track,
 }));
 
 afterEach(() => {
@@ -31,6 +39,14 @@ describe("UpgradeCTA", () => {
       requiredPlan: "starter",
       source: "unit_test",
       redirectTo: "/",
+    });
+    expect(mocks.track).toHaveBeenCalledWith("upgrade_cta_clicked", {
+      featureKey: "tenant_invites",
+      currentPlan: "core",
+      requiredPlan: "starter",
+      source: "unit_test",
+      presentation: undefined,
+      route: "/",
     });
   });
 });

--- a/rentchain-frontend/src/components/billing/UpgradeCTA.tsx
+++ b/rentchain-frontend/src/components/billing/UpgradeCTA.tsx
@@ -3,11 +3,13 @@ import { Button } from "../ui/Ui";
 import { useAuth } from "@/context/useAuth";
 import { getUpgradeCopy } from "@/billing/upgradeCopy";
 import { dispatchUpgradePrompt, resolveRequiredPlan } from "@/lib/upgradePrompt";
+import { track } from "@/lib/analytics";
 
 type Props = {
   featureKey: string;
   label?: string;
   source?: string;
+  presentation?: "locked" | "teaser" | "inline";
   variant?: "primary" | "secondary" | "ghost";
   size?: "sm" | "md";
 };
@@ -16,12 +18,14 @@ export function UpgradeCTA({
   featureKey,
   label,
   source,
+  presentation,
   variant = "primary",
   size = "md",
 }: Props) {
   const { user } = useAuth();
   const copy = getUpgradeCopy(featureKey);
   const requiredPlan = resolveRequiredPlan(featureKey, user?.plan) || "pro";
+  const safeSource = source || featureKey;
   const redirectTo =
     typeof window !== "undefined"
       ? `${window.location.pathname}${window.location.search}`
@@ -32,16 +36,24 @@ export function UpgradeCTA({
       type="button"
       variant={variant}
       style={size === "sm" ? { padding: "6px 10px", fontSize: 12 } : undefined}
-      onClick={() =>
+      onClick={() => {
+        track("upgrade_cta_clicked", {
+          featureKey,
+          currentPlan: user?.plan || "free",
+          requiredPlan,
+          source: safeSource,
+          presentation,
+          route: typeof window !== "undefined" ? window.location.pathname : undefined,
+        });
         dispatchUpgradePrompt({
           featureKey,
           currentPlan: user?.plan || "free",
           requiredPlan,
-          source: source || featureKey,
+          source: safeSource,
           redirectTo,
-        })
-      }
-      data-upgrade-source={source || featureKey}
+        });
+      }}
+      data-upgrade-source={safeSource}
     >
       {label || copy.primaryCta}
     </Button>

--- a/rentchain-frontend/src/components/billing/UpgradePromptModal.test.tsx
+++ b/rentchain-frontend/src/components/billing/UpgradePromptModal.test.tsx
@@ -1,17 +1,23 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { UpgradePromptModal } from "./UpgradePromptModal";
 
 const mocks = vi.hoisted(() => ({
   startCheckout: vi.fn(),
+  track: vi.fn(),
 }));
 
 vi.mock("@/billing/startCheckout", () => ({
   startCheckout: mocks.startCheckout,
 }));
 
+vi.mock("@/lib/analytics", () => ({
+  track: mocks.track,
+}));
+
 afterEach(() => {
+  cleanup();
   vi.clearAllMocks();
 });
 
@@ -42,6 +48,41 @@ describe("UpgradePromptModal", () => {
       featureKey: "tenant_invites",
       source: "unit_test",
       redirectTo: "/applications",
+    });
+    expect(mocks.track).toHaveBeenCalledWith("upgrade_prompt_checkout_clicked", {
+      featureKey: "tenant_invites",
+      currentPlan: "core",
+      requiredPlan: "starter",
+      source: "unit_test",
+      route: "/",
+      presentation: "modal",
+      interval: "monthly",
+      targetPlan: "starter",
+    });
+  });
+
+  it("tracks dismissals through the prompt modal", () => {
+    render(
+      <MemoryRouter>
+        <UpgradePromptModal
+          open
+          onClose={vi.fn()}
+          featureKey="tenant_invites"
+          currentPlan="free"
+          source="unit_test"
+        />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Not now" })[0]);
+
+    expect(mocks.track).toHaveBeenCalledWith("upgrade_prompt_dismissed", {
+      featureKey: "tenant_invites",
+      currentPlan: "free",
+      requiredPlan: "starter",
+      source: "unit_test",
+      route: "/",
+      presentation: "modal",
     });
   });
 });

--- a/rentchain-frontend/src/components/billing/UpgradePromptModal.tsx
+++ b/rentchain-frontend/src/components/billing/UpgradePromptModal.tsx
@@ -5,6 +5,7 @@ import { normalizePlanLabel } from "@/billing/planLabel";
 import { normalizePaidPlan } from "@/lib/plan";
 import { resolveRequiredPlan } from "@/lib/upgradePrompt";
 import { startCheckout } from "@/billing/startCheckout";
+import { track } from "@/lib/analytics";
 
 export function UpgradePromptModal({
   open,
@@ -41,6 +42,22 @@ export function UpgradePromptModal({
   const [interval, setInterval] = useState<"monthly" | "yearly">("monthly");
   const navigate = useNavigate();
   const requiredTier = normalizePaidPlan(requiredPlanKey) || "pro";
+  const trackPayload = useMemo(
+    () => ({
+      featureKey,
+      currentPlan: currentPlan || "free",
+      requiredPlan: requiredPlanKey,
+      source: source || "unknown",
+      route: typeof window !== "undefined" ? window.location.pathname : undefined,
+      presentation: "modal",
+    }),
+    [currentPlan, featureKey, requiredPlanKey, source]
+  );
+
+  const handleDismiss = React.useCallback(() => {
+    track("upgrade_prompt_dismissed", trackPayload);
+    onClose();
+  }, [onClose, trackPayload]);
 
   useEffect(() => {
     if (!open) return;
@@ -53,7 +70,7 @@ export function UpgradePromptModal({
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         e.preventDefault();
-        onClose();
+        handleDismiss();
         return;
       }
       if (e.key !== "Tab") return;
@@ -87,12 +104,12 @@ export function UpgradePromptModal({
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [open, onClose]);
+  }, [handleDismiss, open]);
 
   return (
     <>
       <div
-        onClick={onClose}
+        onClick={handleDismiss}
         style={{
           position: "fixed",
           inset: 0,
@@ -131,11 +148,10 @@ export function UpgradePromptModal({
                 display: "grid",
                 placeItems: "center",
                 color: "#1d4ed8",
-              fontWeight: 900,
-              fontSize: 18,
-            }}
+                fontWeight: 900,
+                fontSize: 18,
+              }}
           >
-              ^
             </div>
             <div>
               <div style={{ fontWeight: 900, fontSize: 20 }}>{title}</div>
@@ -221,7 +237,12 @@ export function UpgradePromptModal({
           <div style={{ display: "grid", gap: 10 }}>
             <button
               ref={primaryRef}
-              onClick={() =>
+              onClick={() => {
+                track("upgrade_prompt_checkout_clicked", {
+                  ...trackPayload,
+                  interval,
+                  targetPlan: requiredTier,
+                });
                 startCheckout({
                   tier: requiredTier,
                   interval,
@@ -229,8 +250,8 @@ export function UpgradePromptModal({
                   featureKey,
                   source,
                   redirectTo,
-                })
-              }
+                });
+              }}
               style={{
                 padding: "12px 16px",
                 borderRadius: 14,
@@ -247,7 +268,7 @@ export function UpgradePromptModal({
             </button>
             <div className="rc-wrap-row" style={{ justifyContent: "space-between" }}>
               <button
-                onClick={onClose}
+                onClick={handleDismiss}
                 style={{
                   padding: "10px 14px",
                   borderRadius: 12,

--- a/rentchain-frontend/src/context/UpgradeContext.test.tsx
+++ b/rentchain-frontend/src/context/UpgradeContext.test.tsx
@@ -1,0 +1,73 @@
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { UpgradeProvider } from "./UpgradeContext";
+
+const mocks = vi.hoisted(() => ({
+  track: vi.fn(),
+  useAuth: vi.fn(),
+  getCachedCapabilities: vi.fn(),
+}));
+
+vi.mock("./AuthContext", () => ({
+  useAuth: mocks.useAuth,
+}));
+
+vi.mock("@/lib/entitlements", () => ({
+  getCachedCapabilities: mocks.getCachedCapabilities,
+}));
+
+vi.mock("@/lib/analytics", () => ({
+  track: mocks.track,
+}));
+
+vi.mock("../components/billing/UpgradeModal", () => ({
+  UpgradeModal: () => null,
+}));
+
+vi.mock("../components/billing/UpgradePromptModal", () => ({
+  UpgradePromptModal: () => null,
+}));
+
+describe("UpgradeContext analytics", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("tracks upgrade prompt impressions from the canonical prompt handler", async () => {
+    mocks.useAuth.mockReturnValue({
+      user: { id: "u1", role: "landlord", plan: "free" },
+      ready: true,
+      isLoading: false,
+    });
+    mocks.getCachedCapabilities.mockReturnValue({ plan: "free" });
+
+    render(
+      <UpgradeProvider>
+        <div>child</div>
+      </UpgradeProvider>
+    );
+
+    window.dispatchEvent(
+      new CustomEvent("upgrade:prompt", {
+        detail: {
+          featureKey: "tenant_invites",
+          currentPlan: "free",
+          requiredPlan: "starter",
+          source: "locked_feature",
+          redirectTo: "/applications",
+        },
+      })
+    );
+
+    await waitFor(() =>
+      expect(mocks.track).toHaveBeenCalledWith("upgrade_prompt_viewed", {
+        featureKey: "tenant_invites",
+        currentPlan: "free",
+        requiredPlan: "starter",
+        source: "locked_feature",
+        presentation: "modal",
+        route: "/",
+      })
+    );
+  });
+});

--- a/rentchain-frontend/src/context/UpgradeContext.tsx
+++ b/rentchain-frontend/src/context/UpgradeContext.tsx
@@ -12,6 +12,7 @@ import { normalizePlanName, resolveRequiredPlan } from "../lib/upgradePrompt";
 import { getCachedCapabilities } from "../lib/entitlements";
 import { isPlanAtLeast, normalizePlan } from "../lib/plan";
 import { useAuth } from "./AuthContext";
+import { track } from "@/lib/analytics";
 
 type UpgradeContextValue = {
   openUpgrade: (
@@ -103,6 +104,14 @@ export function UpgradeProvider({ children }: { children: React.ReactNode }) {
         ? `${window.location.pathname}${window.location.search}`
         : "/dashboard";
     const redirectTo = detail.redirectTo || fallbackRedirect;
+    track("upgrade_prompt_viewed", {
+      featureKey,
+      currentPlan,
+      requiredPlan,
+      source,
+      presentation: "modal",
+      route: typeof window !== "undefined" ? window.location.pathname : undefined,
+    });
     setPromptFeatureKey(featureKey);
     setPromptCurrentPlan(currentPlan);
     setPromptRequiredPlan(requiredPlan);

--- a/rentchain-frontend/src/pages/BillingPage.test.tsx
+++ b/rentchain-frontend/src/pages/BillingPage.test.tsx
@@ -118,5 +118,10 @@ describe("BillingPage", () => {
     expect(screen.getByTestId("billing-plans-panel")).toHaveTextContent("pro");
     expect(screen.getAllByRole("button", { name: "Manage subscription" })).toHaveLength(2);
     expect(screen.getByText(/Pro includes exports, reporting, and team workflows/)).toBeInTheDocument();
+    expect(mocks.trackMock).toHaveBeenCalledWith("billing_page_opened", {
+      currentPlan: "pro",
+      surface: "billing_page",
+      route: "/",
+    });
   });
 });

--- a/rentchain-frontend/src/pages/BillingPage.tsx
+++ b/rentchain-frontend/src/pages/BillingPage.tsx
@@ -105,7 +105,11 @@ const BillingPage: React.FC = () => {
   };
 
   useEffect(() => {
-    track("billing_page_opened", { tier: resolvedCurrentPlan });
+    track("billing_page_opened", {
+      currentPlan: resolvedCurrentPlan,
+      surface: "billing_page",
+      route: typeof window !== "undefined" ? window.location.pathname : undefined,
+    });
     void refreshEntitlements(updateUser);
     void load();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -138,7 +142,13 @@ const BillingPage: React.FC = () => {
   const handlePlanAction = async (planKey: "starter" | "pro" | "elite") => {
     if (pricingUnavailable) return;
     if (planKey === resolvedCurrentPlan) return;
-    track("billing_upgrade_clicked", { fromTier: resolvedCurrentPlan, toTier: planKey, interval });
+    track("billing_upgrade_clicked", {
+      currentPlan: resolvedCurrentPlan,
+      targetPlan: planKey,
+      interval,
+      surface: "billing_page",
+      route: typeof window !== "undefined" ? window.location.pathname : undefined,
+    });
 
     try {
       setPlanActionLoading(planKey);
@@ -165,7 +175,11 @@ const BillingPage: React.FC = () => {
   };
 
   const handlePortal = async () => {
-    track("billing_manage_subscription_clicked", { tier: resolvedCurrentPlan });
+    track("billing_manage_subscription_clicked", {
+      currentPlan: resolvedCurrentPlan,
+      surface: "billing_page",
+      route: typeof window !== "undefined" ? window.location.pathname : undefined,
+    });
     try {
       setPortalLoading(true);
       const res = await createBillingPortalSession();

--- a/rentchain-frontend/src/pages/PricingPage.test.tsx
+++ b/rentchain-frontend/src/pages/PricingPage.test.tsx
@@ -1,0 +1,105 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import PricingPage from "./PricingPage";
+
+const mocks = vi.hoisted(() => ({
+  useAuth: vi.fn(),
+  useCapabilities: vi.fn(),
+  fetchBillingPricing: vi.fn(),
+  createBillingPortalSession: vi.fn(),
+  startCheckout: vi.fn(),
+  track: vi.fn(),
+}));
+
+vi.mock("../context/useAuth", () => ({
+  useAuth: mocks.useAuth,
+}));
+
+vi.mock("../hooks/useCapabilities", () => ({
+  useCapabilities: mocks.useCapabilities,
+}));
+
+vi.mock("../api/billingApi", () => ({
+  fetchBillingPricing: mocks.fetchBillingPricing,
+  createBillingPortalSession: mocks.createBillingPortalSession,
+}));
+
+vi.mock("../billing/startCheckout", () => ({
+  startCheckout: mocks.startCheckout,
+}));
+
+vi.mock("@/lib/analytics", () => ({
+  track: mocks.track,
+}));
+
+describe("PricingPage analytics", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation(() => ({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+      })),
+    });
+    mocks.useAuth.mockReturnValue({
+      user: { id: "u1", plan: "starter", role: "landlord" },
+    });
+    mocks.useCapabilities.mockReturnValue({
+      caps: { plan: "starter" },
+    });
+    mocks.fetchBillingPricing.mockResolvedValue({ ok: true, plans: [] });
+    mocks.createBillingPortalSession.mockResolvedValue({ url: "https://example.test/portal" });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("tracks pricing page views, interval changes, and plan CTA clicks", async () => {
+    render(
+      <MemoryRouter>
+        <PricingPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() =>
+      expect(mocks.track).toHaveBeenCalledWith("pricing_page_viewed", {
+        surface: "workspace_pricing",
+        currentPlan: "starter",
+        interval: "monthly",
+        route: "/",
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Annual" }));
+
+    expect(mocks.track).toHaveBeenCalledWith("pricing_interval_changed", {
+      surface: "workspace_pricing",
+      currentPlan: "starter",
+      interval: "yearly",
+      route: "/",
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Upgrade to Pro" }));
+
+    expect(mocks.track).toHaveBeenCalledWith("pricing_plan_cta_clicked", {
+      surface: "workspace_pricing",
+      currentPlan: "starter",
+      targetPlan: "pro",
+      interval: "yearly",
+      action: "start_checkout",
+      route: "/",
+    });
+    expect(mocks.startCheckout).toHaveBeenCalledWith({
+      tier: "pro",
+      interval: "monthly",
+      featureKey: "pricing",
+      source: "workspace_pricing",
+      redirectTo: "/billing",
+    });
+  });
+});

--- a/rentchain-frontend/src/pages/PricingPage.tsx
+++ b/rentchain-frontend/src/pages/PricingPage.tsx
@@ -63,6 +63,7 @@ const PricingPage: React.FC = () => {
   const [hoveredPlan, setHoveredPlan] = React.useState<PlanKey | null>(null);
   const [isMobile, setIsMobile] = React.useState(false);
   const [isCompactDesktop, setIsCompactDesktop] = React.useState(false);
+  const trackedInitialInterval = React.useRef(false);
   const safeTrack = (eventName: string, props: Record<string, unknown>) => {
     try {
       track(eventName, props);
@@ -95,6 +96,29 @@ const PricingPage: React.FC = () => {
       compactDesktopMedia.removeListener?.(update);
     };
   }, []);
+
+  React.useEffect(() => {
+    safeTrack("pricing_page_viewed", {
+      surface: "workspace_pricing",
+      currentPlan,
+      interval,
+      route: typeof window !== "undefined" ? window.location.pathname : undefined,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  React.useEffect(() => {
+    if (!trackedInitialInterval.current) {
+      trackedInitialInterval.current = true;
+      return;
+    }
+    safeTrack("pricing_interval_changed", {
+      surface: "workspace_pricing",
+      currentPlan,
+      interval,
+      route: typeof window !== "undefined" ? window.location.pathname : undefined,
+    });
+  }, [currentPlan, interval]);
 
   React.useEffect(() => {
     let active = true;
@@ -137,6 +161,18 @@ const PricingPage: React.FC = () => {
     if (target === "pro") {
       safeTrack("pricing_timeline_cta_clicked", { surface: "in_app" });
     }
+    const action =
+      PLAN_ORDER.indexOf(currentPlan) >= PLAN_ORDER.indexOf(target)
+        ? "manage_existing_plan"
+        : "start_checkout";
+    safeTrack("pricing_plan_cta_clicked", {
+      surface: "workspace_pricing",
+      currentPlan,
+      targetPlan: target,
+      interval,
+      action,
+      route: typeof window !== "undefined" ? window.location.pathname : undefined,
+    });
     if (PLAN_ORDER.indexOf(currentPlan) >= PLAN_ORDER.indexOf(target)) {
       try {
         const portal = await createBillingPortalSession();

--- a/rentchain-frontend/src/pages/marketing/PricingPage.test.tsx
+++ b/rentchain-frontend/src/pages/marketing/PricingPage.test.tsx
@@ -1,0 +1,112 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import PricingPage from "./PricingPage";
+
+const mocks = vi.hoisted(() => ({
+  useAuth: vi.fn(),
+  useCapabilities: vi.fn(),
+  useLanguage: vi.fn(),
+  fetchBillingPricing: vi.fn(),
+  startCheckout: vi.fn(),
+  track: vi.fn(),
+}));
+
+vi.mock("../../context/useAuth", () => ({
+  useAuth: mocks.useAuth,
+}));
+
+vi.mock("../../hooks/useCapabilities", () => ({
+  useCapabilities: mocks.useCapabilities,
+}));
+
+vi.mock("../../context/LanguageContext", () => ({
+  useLanguage: mocks.useLanguage,
+}));
+
+vi.mock("../../api/billingApi", () => ({
+  fetchBillingPricing: mocks.fetchBillingPricing,
+}));
+
+vi.mock("../../billing/startCheckout", () => ({
+  startCheckout: mocks.startCheckout,
+}));
+
+vi.mock("../../lib/analytics", () => ({
+  track: mocks.track,
+}));
+
+vi.mock("./MarketingLayout", () => ({
+  MarketingLayout: ({ children }: { children: any }) => <div>{children}</div>,
+}));
+
+describe("Marketing PricingPage analytics", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation(() => ({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+      })),
+    });
+    mocks.useAuth.mockReturnValue({
+      user: { id: "u1", plan: "free", role: "landlord" },
+    });
+    mocks.useCapabilities.mockReturnValue({
+      caps: { plan: "free" },
+    });
+    mocks.useLanguage.mockReturnValue({ locale: "en", setLocale: vi.fn(), t: (key: string) => key });
+    mocks.fetchBillingPricing.mockResolvedValue({ ok: true, plans: [] });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("tracks marketing pricing views, interval changes, and plan CTA clicks", async () => {
+    render(
+      <MemoryRouter>
+        <PricingPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() =>
+      expect(mocks.track).toHaveBeenCalledWith("pricing_page_viewed", {
+        surface: "marketing_pricing",
+        currentPlan: "free",
+        interval: "monthly",
+        route: "/",
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Annual" }));
+
+    expect(mocks.track).toHaveBeenCalledWith("pricing_interval_changed", {
+      surface: "marketing_pricing",
+      currentPlan: "free",
+      interval: "yearly",
+      route: "/",
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Upgrade to Pro" }));
+
+    expect(mocks.track).toHaveBeenCalledWith("pricing_plan_cta_clicked", {
+      surface: "marketing_pricing",
+      currentPlan: "free",
+      targetPlan: "pro",
+      interval: "yearly",
+      action: "start_checkout",
+      route: "/",
+    });
+    expect(mocks.startCheckout).toHaveBeenCalledWith({
+      tier: "pro",
+      interval: "monthly",
+      featureKey: "pricing",
+      source: "marketing_pricing",
+      redirectTo: "/billing",
+    });
+  });
+});

--- a/rentchain-frontend/src/pages/marketing/PricingPage.tsx
+++ b/rentchain-frontend/src/pages/marketing/PricingPage.tsx
@@ -107,6 +107,7 @@ const PricingPage: React.FC = () => {
   const [isCompactDesktop, setIsCompactDesktop] = React.useState(false);
   const [pricingByPlan, setPricingByPlan] = React.useState<Partial<Record<BillingPlanPricing["key"], BillingPlanPricing>>>({});
   const [hoveredPlan, setHoveredPlan] = React.useState<PlanKey | null>(null);
+  const trackedInitialInterval = React.useRef(false);
   const safeTrack = (eventName: string, props: Record<string, unknown>) => {
     try {
       track(eventName, props);
@@ -156,6 +157,29 @@ const PricingPage: React.FC = () => {
       };
     }
   }, []);
+
+  React.useEffect(() => {
+    safeTrack("pricing_page_viewed", {
+      surface: "marketing_pricing",
+      currentPlan,
+      interval,
+      route: typeof window !== "undefined" ? window.location.pathname : undefined,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  React.useEffect(() => {
+    if (!trackedInitialInterval.current) {
+      trackedInitialInterval.current = true;
+      return;
+    }
+    safeTrack("pricing_interval_changed", {
+      surface: "marketing_pricing",
+      currentPlan,
+      interval,
+      route: typeof window !== "undefined" ? window.location.pathname : undefined,
+    });
+  }, [currentPlan, interval]);
 
   React.useEffect(() => {
     let active = true;
@@ -214,6 +238,19 @@ const PricingPage: React.FC = () => {
     if (plan === "pro") {
       safeTrack("pricing_timeline_cta_clicked", { surface: "marketing" });
     }
+    const action = !isAuthed
+      ? "login_redirect"
+      : isAtOrAbove(currentPlan, plan)
+        ? "manage_existing_plan"
+        : "start_checkout";
+    safeTrack("pricing_plan_cta_clicked", {
+      surface: "marketing_pricing",
+      currentPlan,
+      targetPlan: plan,
+      interval,
+      action,
+      route: typeof window !== "undefined" ? window.location.pathname : undefined,
+    });
     if (!isAuthed) {
       navigate("/login?next=/site/pricing");
       return;


### PR DESCRIPTION
## Summary

Implements Subscription Conversion Analytics v1 by adding a lightweight, canonical event set across pricing, billing, and upgrade surfaces, and standardizing all subscription conversion analytics on the existing generic analytics pipeline.

This enables measurement of the full upgrade funnel without introducing a new analytics system or coupling analytics to core product logic.

## What changed

### Backend
- Extended `/api/events/track` allowlist to accept subscription conversion event families:
  - `billing_*`
  - `pricing_*`
  - `upgrade_cta_*`
  - `upgrade_prompt_*`
- Added targeted tests to ensure new event families are accepted and persisted

### Frontend
- Instrumented shared upgrade surfaces:
  - `UpgradeCTA` → `upgrade_cta_clicked`
  - `UpgradeContext` → `upgrade_prompt_viewed`
  - `UpgradePromptModal` → `upgrade_prompt_dismissed`, `upgrade_prompt_checkout_clicked`
- Instrumented pricing pages:
  - `pricing_page_viewed`
  - `pricing_interval_changed`
  - `pricing_plan_cta_clicked`
- Normalized billing analytics:
  - `billing_page_opened`
  - `billing_upgrade_clicked`
  - `billing_manage_subscription_clicked`
- Reused existing `track(...)` helper across all new instrumentation
- Added targeted frontend tests covering event emission

## Files changed

### Backend
- `rentchain-api/src/routes/eventsRoutes.ts`
- `rentchain-api/src/routes/__tests__/eventsRoutes.test.ts`

### Frontend
- `rentchain-frontend/src/components/billing/FeatureTeaser.tsx`
- `rentchain-frontend/src/components/billing/LockedFeature.tsx`
- `rentchain-frontend/src/components/billing/UpgradeCTA.test.tsx`
- `rentchain-frontend/src/components/billing/UpgradeCTA.tsx`
- `rentchain-frontend/src/components/billing/UpgradePromptModal.test.tsx`
- `rentchain-frontend/src/components/billing/UpgradePromptModal.tsx`
- `rentchain-frontend/src/context/UpgradeContext.test.tsx`
- `rentchain-frontend/src/context/UpgradeContext.tsx`
- `rentchain-frontend/src/pages/BillingPage.test.tsx`
- `rentchain-frontend/src/pages/BillingPage.tsx`
- `rentchain-frontend/src/pages/PricingPage.test.tsx`
- `rentchain-frontend/src/pages/PricingPage.tsx`
- `rentchain-frontend/src/pages/marketing/PricingPage.test.tsx`
- `rentchain-frontend/src/pages/marketing/PricingPage.tsx`

## Verification

### Backend
- `npm run test -- src/routes/__tests__/eventsRoutes.test.ts`
- `npm run build`

### Frontend
- `npm run test -- src/components/billing/UpgradeCTA.test.tsx src/components/billing/UpgradePromptModal.test.tsx src/context/UpgradeContext.test.tsx src/pages/BillingPage.test.tsx src/pages/PricingPage.test.tsx src/pages/marketing/PricingPage.test.tsx`
- `npm run build`

## Event model

Canonical conversion events introduced/standardized:

- `pricing_page_viewed`
- `pricing_interval_changed`
- `pricing_plan_cta_clicked`
- `upgrade_cta_clicked`
- `upgrade_prompt_viewed`
- `upgrade_prompt_dismissed`
- `upgrade_prompt_checkout_clicked`
- `billing_page_opened`
- `billing_upgrade_clicked`
- `billing_manage_subscription_clicked`

These events together form the full subscription conversion funnel.

## Analytics path design

The repository intentionally maintains two analytics paths:

- **Generic subscription/product analytics**
  - frontend: `track(...)`
  - backend: `/api/events/track`
  - used for pricing, billing, upgrade CTA, and upgrade prompt events

- **Nudge-specific telemetry**
  - frontend: `logTelemetryEvent(...)`
  - backend: `/api/telemetry`
  - used only for `nudge_*` events

This split is deliberate:
- avoids repurposing the nudge-only telemetry system
- avoids introducing a third analytics system
- keeps conversion analytics aligned with the existing generic pipeline

## Important notes

- `track(...)` posts to `/api/events/track` only outside development mode, so local QA of backend persistence may require production-like conditions or mocks
- payloads are intentionally limited to non-PII fields such as:
  - `source`
  - `surface`
  - `featureKey`
  - `currentPlan`
  - `targetPlan`
  - `interval`
  - `presentation`
  - `route/pathname`

## Intentionally out of scope

- analytics dashboards or reporting layers
- billing/checkout architecture changes
- Stripe lifecycle instrumentation
- repo-wide instrumentation of all CTAs
- changes to `/api/telemetry` or nudge analytics behavior