### PR TITLE
fix: route analytics events to backend api base

### DIFF
--- a/rentchain-frontend/src/lib/analytics.test.ts
+++ b/rentchain-frontend/src/lib/analytics.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  isTelemetryEnabled: vi.fn(() => true),
+  resolveApiUrl: vi.fn((path: string) => `https://api.rentchain.test${path}`),
+}));
+
+vi.mock("./telemetry", () => ({
+  isTelemetryEnabled: mocks.isTelemetryEnabled,
+}));
+
+vi.mock("./apiClient", () => ({
+  resolveApiUrl: mocks.resolveApiUrl,
+}));
+
+describe("track", () => {
+  const originalFetch = globalThis.fetch;
+  const originalNavigator = globalThis.navigator;
+  const originalWindow = globalThis.window;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mocks.isTelemetryEnabled.mockReturnValue(true);
+    mocks.resolveApiUrl.mockImplementation((path: string) => `https://api.rentchain.test${path}`);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(new Response(null, { status: 200 }))) as typeof fetch
+    );
+    vi.stubGlobal("window", {
+      doNotTrack: "0",
+    });
+    vi.stubGlobal("navigator", {
+      doNotTrack: "0",
+      globalPrivacyControl: false,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    globalThis.fetch = originalFetch;
+    globalThis.navigator = originalNavigator;
+    globalThis.window = originalWindow;
+  });
+
+  it("posts analytics to the resolved backend API URL", async () => {
+    vi.stubEnv("MODE", "production");
+    const { track } = await import("./analytics");
+
+    track("billing_page_opened", { surface: "billing_page" });
+    await Promise.resolve();
+
+    expect(mocks.resolveApiUrl).toHaveBeenCalledWith("/api/events/track");
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "https://api.rentchain.test/api/events/track",
+      expect.objectContaining({
+        method: "POST",
+        credentials: "include",
+        keepalive: true,
+      })
+    );
+  });
+
+  it("does not post when telemetry is disabled", async () => {
+    vi.stubEnv("MODE", "production");
+    mocks.isTelemetryEnabled.mockReturnValue(false);
+    const { track } = await import("./analytics");
+
+    track("billing_page_opened", { surface: "billing_page" });
+    await Promise.resolve();
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("does not post when DNT blocks tracking", async () => {
+    vi.stubEnv("MODE", "production");
+    vi.stubGlobal("navigator", {
+      doNotTrack: "1",
+      globalPrivacyControl: false,
+    });
+    const { track } = await import("./analytics");
+
+    track("billing_page_opened", { surface: "billing_page" });
+    await Promise.resolve();
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/rentchain-frontend/src/lib/analytics.ts
+++ b/rentchain-frontend/src/lib/analytics.ts
@@ -1,4 +1,5 @@
 import { isTelemetryEnabled } from "./telemetry";
+import { resolveApiUrl } from "./apiClient";
 type AnalyticsProps = Record<string, unknown>;
 
 const hasDoNotTrack = () => {
@@ -51,7 +52,7 @@ export function track(eventName: string, props: AnalyticsProps = {}) {
     return;
   }
 
-  void fetch("/api/events/track", {
+  void fetch(resolveApiUrl("/api/events/track"), {
     method: "POST",
     headers: {
       "Content-Type": "application/json",


### PR DESCRIPTION
## Summary

Fixes frontend analytics transport so generic subscription/product events are sent to the backend API host instead of the frontend same-origin host.

This resolves a production issue where `/api/events/track` requests were returning 404 because they were being routed through the frontend origin rather than the backend service.

## What changed

### Frontend
- Updated `track(...)` in `rentchain-frontend/src/lib/analytics.ts` to use:
  - `resolveApiUrl("/api/events/track")`
- Removed reliance on same-origin relative path (`"/api/events/track"`)
- Reused the existing shared API-origin resolver used across the app
- Kept all existing analytics behavior unchanged:
  - `plausible`
  - `gtag`
  - telemetry enable/disable logic
  - DNT/GPC blocking
  - payload shape
  - `credentials: "include"`
  - `keepalive: true`

### Tests
- Added targeted test:
  - `rentchain-frontend/src/lib/analytics.test.ts`
- Verifies:
  - resolved backend URL is used
  - telemetry/DNT gating behavior remains intact

## Files changed

- `rentchain-frontend/src/lib/analytics.ts`
- `rentchain-frontend/src/lib/analytics.test.ts`

## Verification

### Frontend
- `npm run test -- src/lib/analytics.test.ts`
- `npm run build`

## Important note

- Generic analytics now uses the same backend API-origin resolution as the rest of the application
- It no longer posts to the frontend same-origin `/api/events/track` path
- This ensures that Mission 29 events are correctly ingested by `/api/events/track` in production

## Remaining considerations

- Analytics transport still depends on correct `VITE_API_BASE_URL` configuration
- `credentials: "include"` continues to rely on existing backend CORS/cookie behavior

## Impact

- Restores production analytics ingestion for subscription conversion events
- Unblocks Mission 30 conversion analysis and all subsequent optimization loop missions