### PR TITLE
fix: allow optional auth for events track ingestion

### DIFF
--- a/rentchain-api/src/middleware/__tests__/authMiddleware.test.ts
+++ b/rentchain-api/src/middleware/__tests__/authMiddleware.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+
+const jwtMocks = vi.hoisted(() => ({
+  verify: vi.fn(),
+}));
+
+vi.mock("jsonwebtoken", () => ({
+  default: {
+    verify: jwtMocks.verify,
+  },
+  verify: jwtMocks.verify,
+}));
+
+vi.mock("../../config/authConfig", () => ({
+  JWT_SECRET: "test-secret",
+}));
+
+function createRes() {
+  return {
+    statusCode: 200,
+    body: null as any,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: any) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+describe("authenticateJwt optional auth for events track", () => {
+  it("allows /api/events/track through without auth", async () => {
+    const { authenticateJwt } = await import("../authMiddleware");
+    const req: any = {
+      originalUrl: "/api/events/track",
+      path: "/api/events/track",
+      method: "POST",
+      headers: {},
+    };
+    const res: any = createRes();
+    const next = vi.fn();
+
+    authenticateJwt(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("allows /api/events/track through when bearer auth is invalid", async () => {
+    jwtMocks.verify.mockImplementationOnce(() => {
+      throw new Error("bad token");
+    });
+    const { authenticateJwt } = await import("../authMiddleware");
+    const req: any = {
+      originalUrl: "/api/events/track",
+      path: "/api/events/track",
+      method: "POST",
+      headers: {
+        authorization: "Bearer invalid-token",
+      },
+    };
+    const res: any = createRes();
+    const next = vi.fn();
+
+    authenticateJwt(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("still rejects invalid bearer auth on unrelated routes", async () => {
+    jwtMocks.verify.mockImplementationOnce(() => {
+      throw new Error("bad token");
+    });
+    const { authenticateJwt } = await import("../authMiddleware");
+    const req: any = {
+      originalUrl: "/api/account/limits",
+      path: "/api/account/limits",
+      method: "GET",
+      headers: {
+        authorization: "Bearer invalid-token",
+      },
+    };
+    const res: any = createRes();
+    const next = vi.fn();
+
+    authenticateJwt(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        ok: false,
+        error: "UNAUTHORIZED",
+        code: "UNAUTHORIZED",
+      })
+    );
+  });
+});

--- a/rentchain-api/src/middleware/authMiddleware.ts
+++ b/rentchain-api/src/middleware/authMiddleware.ts
@@ -16,6 +16,11 @@ export interface AuthenticatedUser {
   actorLandlordId?: string | null;
 }
 
+function isOptionalAuthPath(req: { originalUrl?: string; path?: string }) {
+  const raw = String(req.originalUrl || req.path || "").trim();
+  return /^\/api\/events\/track(?:[/?#]|$)/.test(raw);
+}
+
 export const authenticateJwt: RequestHandler = (req, res, next): void => {
   // Allow auth routes and health to be public
   if (req.path.startsWith("/api/auth/") || req.path === "/api/health") {
@@ -70,6 +75,9 @@ export const authenticateJwt: RequestHandler = (req, res, next): void => {
   }
 
   if (!authHeader.startsWith("Bearer ")) {
+    if (isOptionalAuthPath(req)) {
+      return next();
+    }
     jsonError(res, 401, "UNAUTHORIZED", "UNAUTHORIZED", undefined, (req as any).requestId);
     return;
   }
@@ -82,6 +90,9 @@ export const authenticateJwt: RequestHandler = (req, res, next): void => {
       decoded as any;
 
     if (!sub || !email) {
+      if (isOptionalAuthPath(req)) {
+        return next();
+      }
       jsonError(res, 401, "UNAUTHORIZED", "UNAUTHORIZED", undefined, (req as any).requestId);
       return;
     }
@@ -100,6 +111,9 @@ export const authenticateJwt: RequestHandler = (req, res, next): void => {
 
     next();
   } catch (err) {
+    if (isOptionalAuthPath(req)) {
+      return next();
+    }
     console.error("[authenticateJwt] verification failed", err);
     jsonError(res, 401, "UNAUTHORIZED", "UNAUTHORIZED", undefined, (req as any).requestId);
   }

--- a/rentchain-api/src/routes/__tests__/eventsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/eventsRoutes.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 type StoredDoc = { id: string; data: any };
 
-const { dbMock, resetDb, seedEvent } = vi.hoisted(() => {
+const { dbMock, resetDb, seedEvent, getCollectionDocs } = vi.hoisted(() => {
   const collections = new Map<string, Map<string, StoredDoc>>();
   let autoId = 0;
 
@@ -35,6 +35,8 @@ const { dbMock, resetDb, seedEvent } = vi.hoisted(() => {
     seedEvent: (id: string, data: any) => {
       ensureCollection("events").set(id, { id, data });
     },
+    getCollectionDocs: (name: string) =>
+      Array.from(ensureCollection(name).values()).map((entry) => ({ id: entry.id, ...(entry.data || {}) })),
   };
 });
 
@@ -134,6 +136,13 @@ describe("eventsRoutes", () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ ok: true });
     expect(telemetryMocks.incrementCounter).toHaveBeenCalledWith({ name: "registry_ready_created" });
+    expect(getCollectionDocs("events")).toEqual([
+      expect.objectContaining({
+        name: "registry_ready_created",
+        userId: null,
+        sessionId: expect.any(String),
+      }),
+    ]);
   });
 
   it("accepts billing and upgrade prompt analytics events through the generic tracker", async () => {
@@ -172,6 +181,44 @@ describe("eventsRoutes", () => {
     expect(promptRes.status).toBe(200);
     expect(telemetryMocks.incrementCounter).toHaveBeenCalledWith({ name: "billing_page_opened" });
     expect(telemetryMocks.incrementCounter).toHaveBeenCalledWith({ name: "upgrade_prompt_viewed" });
+  });
+
+  it("persists authenticated events with userId and no sessionId", async () => {
+    const router = await createRouter();
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/track",
+      user: { id: "user-123", role: "landlord" },
+      body: {
+        name: "billing_page_opened",
+        props: { surface: "billing_page" },
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(getCollectionDocs("events")).toEqual([
+      expect.objectContaining({
+        name: "billing_page_opened",
+        userId: "user-123",
+        sessionId: null,
+      }),
+    ]);
+  });
+
+  it("rejects invalid event names", async () => {
+    const router = await createRouter();
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/track",
+      body: {
+        name: "not_allowed_event",
+        props: {},
+      },
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ ok: false, error: "invalid_event_name" });
+    expect(getCollectionDocs("events")).toEqual([]);
   });
 
   it("returns a grouped registry funnel report for admins", async () => {


### PR DESCRIPTION
## Summary

Fixes analytics ingestion auth behavior for `/api/events/track` by allowing that route to operate with path-scoped optional auth.

This preserves authenticated writes when valid auth is present, while allowing analytics ingestion to continue with `sessionId` fallback when auth is missing or invalid.

## What changed

### Backend auth behavior
- Added a path-scoped optional-auth exception inside the existing global JWT decode middleware for:
  - `/api/events/track`
- Preserved normal authenticated behavior:
  - valid bearer token still populates `req.user`
- Preserved existing analytics ingestion handler semantics:
  - when auth is unavailable or invalid, the request still reaches the route
  - the route can then fall back to `sessionId`

### Tests
- Added targeted backend tests covering:
  - authenticated event writes
  - unauthenticated event writes
  - path-scoped middleware behavior for `/api/events/track`

## Files changed

- `rentchain-api/src/middleware/authMiddleware.ts`
- `rentchain-api/src/middleware/__tests__/authMiddleware.test.ts`
- `rentchain-api/src/routes/__tests__/eventsRoutes.test.ts`

## Verification

### Backend
- `npm run test -- src/middleware/__tests__/authMiddleware.test.ts src/routes/__tests__/eventsRoutes.test.ts`
- `npm run build`

## Important note

`/api/events/track` now uses **path-scoped optional auth**.

That means:
- valid auth → analytics event can still use `userId`
- missing or invalid auth → analytics ingestion falls back to `sessionId`

This is intentional for analytics continuity and remains limited to this single route.

## What did not change

- no route path changes
- no payload shape changes
- no event allowlist changes
- no persistence changes
- no counter changes
- no widening of unrelated auth boundaries

## Remaining consideration

Invalid bearer tokens on `/api/events/track` are now ignored rather than rejected.
That is a deliberate tradeoff for analytics write continuity and should remain scoped only to this route.