### PR TITLE
feat: add pricing and funnel optimization v1

### DIFF
--- a/rentchain-frontend/src/components/billing/BillingPlansPanel.tsx
+++ b/rentchain-frontend/src/components/billing/BillingPlansPanel.tsx
@@ -17,6 +17,7 @@ type Props = {
   interval: "month" | "year";
   onIntervalChange: (value: "month" | "year") => void;
   currentPlan?: string | null;
+  selectedPlan?: "starter" | "pro" | "elite" | null;
   role?: string | null;
   mode: "billing" | "pricing";
   planActionLoading?: string | null;
@@ -30,6 +31,7 @@ export function BillingPlansPanel({
   interval,
   onIntervalChange,
   currentPlan,
+  selectedPlan,
   role,
   mode,
   planActionLoading,
@@ -80,6 +82,7 @@ export function BillingPlansPanel({
 
         const plan = CANONICAL_TIER_MATRIX[planId];
         const highlight = currentPlanKey === planId;
+        const selected = selectedPlan === planId;
         const topAreas = TIER_MATRIX_AREAS.slice(0, 4);
 
         return (
@@ -89,8 +92,14 @@ export function BillingPlansPanel({
               borderRadius: radius.lg,
               border: highlight
                 ? "1px solid rgba(59,130,246,0.45)"
-                : "1px solid rgba(148,163,184,0.25)",
-              background: highlight ? "rgba(59,130,246,0.08)" : "rgba(148,163,184,0.06)",
+                : selected
+                  ? "1px solid rgba(37,99,235,0.45)"
+                  : "1px solid rgba(148,163,184,0.25)",
+              background: highlight
+                ? "rgba(59,130,246,0.08)"
+                : selected
+                  ? "rgba(37,99,235,0.08)"
+                  : "rgba(148,163,184,0.06)",
               padding: 12,
               display: "grid",
               gap: 12,
@@ -112,6 +121,8 @@ export function BillingPlansPanel({
               </div>
               {highlight ? (
                 <span style={{ fontSize: 12, fontWeight: 700, color: colors.accent }}>Current</span>
+              ) : selected ? (
+                <span style={{ fontSize: 12, fontWeight: 700, color: "#1d4ed8" }}>Selected</span>
               ) : null}
             </div>
 

--- a/rentchain-frontend/src/pages/BillingPage.test.tsx
+++ b/rentchain-frontend/src/pages/BillingPage.test.tsx
@@ -104,6 +104,32 @@ describe("BillingPage", () => {
     ).toBe(true);
   });
 
+  it("uses the pricing-selected upgrade plan and interval when arriving from pricing", async () => {
+    mocks.useBillingStatusMock.mockReturnValue({
+      tier: "free",
+      interval: null,
+      renewalDate: null,
+      isLoading: false,
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/billing?upgradePlan=pro&upgradeInterval=year"]}>
+        <BillingPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText(/Pricing selection saved: Pro on the Yearly plan/i)).toBeInTheDocument()
+    );
+    expect(screen.getAllByRole("button", { name: "Continue to Pro checkout" }).length).toBeGreaterThan(0);
+    expect(mocks.billingPlansPanelMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        interval: "year",
+        selectedPlan: "pro",
+      })
+    );
+  });
+
   it("uses the resolved billing tier consistently in the summary and plans panel", async () => {
     mocks.useBillingStatusMock.mockReturnValue({
       tier: "pro",

--- a/rentchain-frontend/src/pages/BillingPage.tsx
+++ b/rentchain-frontend/src/pages/BillingPage.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { Card, Section, Button } from "../components/ui/Ui";
 import {
   createBillingPortalSession,
@@ -68,6 +69,25 @@ const renewalLabel = (renewalDate: string | null) => {
 const checkoutCtaLabel = (tier: "starter" | "pro" | "elite") =>
   `Continue to ${CANONICAL_TIER_MATRIX[tier].label} checkout`;
 
+function normalizeUpgradePlanParam(
+  value: string | null,
+  currentPlan: string
+): "starter" | "pro" | "elite" | null {
+  if (value !== "starter" && value !== "pro" && value !== "elite") return null;
+  const paidPlanOrder: Array<"starter" | "pro" | "elite"> = ["starter", "pro", "elite"];
+  if (currentPlan === "free") return value;
+  if (paidPlanOrder.indexOf(currentPlan as "starter" | "pro" | "elite") >= paidPlanOrder.indexOf(value)) {
+    return null;
+  }
+  return value;
+}
+
+function normalizeUpgradeIntervalParam(value: string | null): "month" | "year" | null {
+  if (value === "month") return "month";
+  if (value === "year") return "year";
+  return null;
+}
+
 const BillingPage: React.FC = () => {
   const [records, setRecords] = useState<BillingRecord[]>([]);
   const [loading, setLoading] = useState(false);
@@ -78,11 +98,17 @@ const BillingPage: React.FC = () => {
   const [pricingError, setPricingError] = useState(false);
   const [planActionLoading, setPlanActionLoading] = useState<string | null>(null);
   const [interval, setInterval] = useState<"month" | "year">("month");
+  const [searchParams] = useSearchParams();
   const { user, updateUser } = useAuth();
   const billingStatus = useBillingStatus();
   const currentPlan = billingStatus.isLoading ? null : billingStatus.tier;
   const resolvedCurrentPlan = currentPlan || "free";
   const isPaidPlan = resolvedCurrentPlan !== "free";
+  const requestedUpgradePlan = normalizeUpgradePlanParam(
+    searchParams.get("upgradePlan"),
+    resolvedCurrentPlan
+  );
+  const requestedUpgradeInterval = normalizeUpgradeIntervalParam(searchParams.get("upgradeInterval"));
 
   const getErrorMessage = (error: unknown, fallback: string) => {
     if (error instanceof Error && error.message) return error.message;
@@ -139,6 +165,11 @@ const BillingPage: React.FC = () => {
       active = false;
     };
   }, []);
+
+  useEffect(() => {
+    if (!requestedUpgradeInterval) return;
+    setInterval(requestedUpgradeInterval);
+  }, [requestedUpgradeInterval]);
 
   const pricingUnavailable = !pricingLoading && pricingError;
 
@@ -198,14 +229,15 @@ const BillingPage: React.FC = () => {
   };
 
   const nextUpgradeTier =
-    resolvedCurrentPlan === "free"
+    requestedUpgradePlan ||
+    (resolvedCurrentPlan === "free"
       ? "starter"
       : resolvedCurrentPlan === "starter"
         ? "pro"
         : resolvedCurrentPlan === "pro"
           ? "elite"
-          : null;
-  const starterUpgradeLabel = checkoutCtaLabel("starter");
+          : null);
+  const starterUpgradeLabel = checkoutCtaLabel(requestedUpgradePlan || "starter");
   const nextUpgradeLabel = nextUpgradeTier
     ? interval === "year"
       ? `${checkoutCtaLabel(nextUpgradeTier)} (Yearly)`
@@ -230,6 +262,11 @@ const BillingPage: React.FC = () => {
           <div>
             <h1 style={{ margin: 0, fontSize: "1.3rem", fontWeight: 700 }}>Billing & Receipts</h1>
             <div style={{ color: text.muted, fontSize: "0.95rem" }}>Current plan, upgrade options, subscription details, and screening receipts.</div>
+            {requestedUpgradePlan ? (
+              <div style={{ color: text.muted, fontSize: "0.9rem", marginTop: 6 }}>
+                Pricing selection saved: {CANONICAL_TIER_MATRIX[requestedUpgradePlan].label} on the {interval === "year" ? "Yearly" : "Monthly"} plan.
+              </div>
+            ) : null}
           </div>
           <div className="rc-wrap-row">
             <Button type="button" variant="secondary" onClick={load} disabled={loading}>
@@ -243,10 +280,14 @@ const BillingPage: React.FC = () => {
               <Button
                 type="button"
                 variant="primary"
-                onClick={() => void handlePlanAction("starter")}
-                disabled={billingStatus.isLoading || planActionLoading === "starter" || pricingUnavailable}
+                onClick={() => void handlePlanAction(requestedUpgradePlan || "starter")}
+                disabled={
+                  billingStatus.isLoading ||
+                  planActionLoading === (requestedUpgradePlan || "starter") ||
+                  pricingUnavailable
+                }
               >
-                {planActionLoading === "starter" ? "Opening..." : starterUpgradeLabel}
+                {planActionLoading === (requestedUpgradePlan || "starter") ? "Opening..." : starterUpgradeLabel}
               </Button>
             )}
           </div>
@@ -281,10 +322,14 @@ const BillingPage: React.FC = () => {
               <Button
                 type="button"
                 variant="secondary"
-                onClick={() => void handlePlanAction("starter")}
-                disabled={billingStatus.isLoading || planActionLoading === "starter" || pricingUnavailable}
+                onClick={() => void handlePlanAction(requestedUpgradePlan || "starter")}
+                disabled={
+                  billingStatus.isLoading ||
+                  planActionLoading === (requestedUpgradePlan || "starter") ||
+                  pricingUnavailable
+                }
               >
-                {planActionLoading === "starter" ? "Opening..." : starterUpgradeLabel}
+                {planActionLoading === (requestedUpgradePlan || "starter") ? "Opening..." : starterUpgradeLabel}
               </Button>
             )}
             {nextUpgradeTier ? (
@@ -334,6 +379,7 @@ const BillingPage: React.FC = () => {
             }
           }}
           currentPlan={currentPlan}
+          selectedPlan={requestedUpgradePlan}
           role={user?.actorRole || user?.role || null}
           mode="billing"
           planActionLoading={planActionLoading}

--- a/rentchain-frontend/src/pages/PricingPage.test.tsx
+++ b/rentchain-frontend/src/pages/PricingPage.test.tsx
@@ -8,7 +8,6 @@ const mocks = vi.hoisted(() => ({
   useCapabilities: vi.fn(),
   fetchBillingPricing: vi.fn(),
   createBillingPortalSession: vi.fn(),
-  startCheckout: vi.fn(),
   track: vi.fn(),
   navigate: vi.fn(),
 }));
@@ -32,10 +31,6 @@ vi.mock("../hooks/useCapabilities", () => ({
 vi.mock("../api/billingApi", () => ({
   fetchBillingPricing: mocks.fetchBillingPricing,
   createBillingPortalSession: mocks.createBillingPortalSession,
-}));
-
-vi.mock("../billing/startCheckout", () => ({
-  startCheckout: mocks.startCheckout,
 }));
 
 vi.mock("@/lib/analytics", () => ({
@@ -68,7 +63,7 @@ describe("PricingPage analytics", () => {
     vi.clearAllMocks();
   });
 
-  it("routes upgrade intent through billing from the workspace pricing page", async () => {
+  it("routes upgrade intent through billing with the selected plan and interval", async () => {
     render(
       <MemoryRouter>
         <PricingPage />
@@ -103,7 +98,6 @@ describe("PricingPage analytics", () => {
       action: "open_billing_hub",
       route: "/",
     });
-    expect(mocks.navigate).toHaveBeenCalledWith("/billing");
-    expect(mocks.startCheckout).not.toHaveBeenCalled();
+    expect(mocks.navigate).toHaveBeenCalledWith("/billing?upgradePlan=pro&upgradeInterval=year");
   });
 });

--- a/rentchain-frontend/src/pages/PricingPage.tsx
+++ b/rentchain-frontend/src/pages/PricingPage.tsx
@@ -5,7 +5,6 @@ import { Card, Section, Button } from "../components/ui/Ui";
 import { spacing, text } from "../styles/tokens";
 import { useAuth } from "../context/useAuth";
 import { useCapabilities } from "../hooks/useCapabilities";
-import { startCheckout } from "../billing/startCheckout";
 import { createBillingPortalSession, fetchBillingPricing, type BillingPlanPricing } from "../api/billingApi";
 import {
   CANONICAL_TIER_MATRIX,
@@ -47,6 +46,14 @@ function pricingCardShadow(plan: PlanKey, hovered: boolean) {
     return hovered ? "0 22px 42px rgba(37,99,235,0.16)" : "0 16px 34px rgba(37,99,235,0.12)";
   }
   return hovered ? "0 16px 32px rgba(15,23,42,0.10)" : "0 10px 24px rgba(15,23,42,0.06)";
+}
+
+function buildBillingUpgradePath(target: Exclude<PlanKey, "free">, interval: PricingInterval) {
+  const params = new URLSearchParams({
+    upgradePlan: target,
+    upgradeInterval: interval === "yearly" ? "year" : "month",
+  });
+  return `/billing?${params.toString()}`;
 }
 
 const PricingPage: React.FC = () => {
@@ -183,7 +190,7 @@ const PricingPage: React.FC = () => {
       return;
     }
 
-    navigate("/billing");
+    navigate(buildBillingUpgradePath(target, interval));
   };
 
   const planCtaLabel = (target: Exclude<PlanKey, "free">) => {

--- a/rentchain-frontend/src/pages/marketing/PricingPage.test.tsx
+++ b/rentchain-frontend/src/pages/marketing/PricingPage.test.tsx
@@ -8,7 +8,6 @@ const mocks = vi.hoisted(() => ({
   useCapabilities: vi.fn(),
   useLanguage: vi.fn(),
   fetchBillingPricing: vi.fn(),
-  startCheckout: vi.fn(),
   track: vi.fn(),
   navigate: vi.fn(),
 }));
@@ -35,10 +34,6 @@ vi.mock("../../context/LanguageContext", () => ({
 
 vi.mock("../../api/billingApi", () => ({
   fetchBillingPricing: mocks.fetchBillingPricing,
-}));
-
-vi.mock("../../billing/startCheckout", () => ({
-  startCheckout: mocks.startCheckout,
 }));
 
 vi.mock("../../lib/analytics", () => ({
@@ -75,7 +70,7 @@ describe("Marketing PricingPage analytics", () => {
     vi.clearAllMocks();
   });
 
-  it("routes authenticated marketing pricing upgrades through billing", async () => {
+  it("routes authenticated marketing pricing upgrades through billing with the selected plan and interval", async () => {
     render(
       <MemoryRouter>
         <PricingPage />
@@ -110,7 +105,6 @@ describe("Marketing PricingPage analytics", () => {
       action: "open_billing_hub",
       route: "/",
     });
-    expect(mocks.navigate).toHaveBeenCalledWith("/billing");
-    expect(mocks.startCheckout).not.toHaveBeenCalled();
+    expect(mocks.navigate).toHaveBeenCalledWith("/billing?upgradePlan=pro&upgradeInterval=year");
   });
 });

--- a/rentchain-frontend/src/pages/marketing/PricingPage.tsx
+++ b/rentchain-frontend/src/pages/marketing/PricingPage.tsx
@@ -5,7 +5,6 @@ import { spacing, text } from "../../styles/tokens";
 import { MarketingLayout } from "./MarketingLayout";
 import { useAuth } from "../../context/useAuth";
 import { useCapabilities } from "../../hooks/useCapabilities";
-import { startCheckout } from "../../billing/startCheckout";
 import {
   CANONICAL_TIER_MATRIX,
   DEFAULT_PLANS,
@@ -47,6 +46,14 @@ function pricingCardShadow(plan: PlanKey, hovered: boolean) {
     return hovered ? "0 22px 42px rgba(37,99,235,0.16)" : "0 16px 34px rgba(37,99,235,0.12)";
   }
   return hovered ? "0 16px 32px rgba(15,23,42,0.10)" : "0 10px 24px rgba(15,23,42,0.06)";
+}
+
+function buildBillingUpgradePath(target: Exclude<PlanKey, "free">, interval: PricingInterval) {
+  const params = new URLSearchParams({
+    upgradePlan: target,
+    upgradeInterval: interval === "yearly" ? "year" : "month",
+  });
+  return `/billing?${params.toString()}`;
 }
 
 const PLAN_AUDIENCE_COPY: Record<PlanKey, string> = {
@@ -259,7 +266,7 @@ const PricingPage: React.FC = () => {
       navigate("/billing");
       return;
     }
-    navigate("/billing");
+    navigate(buildBillingUpgradePath(plan, interval));
   };
 
   const planCtaLabel = (plan: Exclude<PlanKey, "free">) => {


### PR DESCRIPTION
## Summary

Implements Pricing + Funnel Optimization v1 by preserving pricing selection intent through the handoff into Billing and making Billing behave like a continuation of the user’s upgrade decision instead of a reset.

This reduces friction in the primary observed conversion path:

- Pricing → Billing → Upgrade

## What changed

### Pricing pages
- Pricing now carries the user’s selected upgrade plan and interval into Billing via URL params:
  - `upgradePlan=<tier>`
  - `upgradeInterval=<month|year>`

### Billing page
- Billing now reads the incoming pricing selection and uses it to:
  - preselect the billing interval
  - promote the selected upgrade target instead of defaulting to a generic path
  - show a short “Pricing selection saved” confirmation
  - pass the selected target into `BillingPlansPanel`

### Billing plans panel
- `BillingPlansPanel` now visually marks the pricing-selected plan as `Selected`
- This improves scanability and makes the next action clearer without changing pricing, entitlements, or billing backend behavior

## Files changed

- `rentchain-frontend/src/components/billing/BillingPlansPanel.tsx`
- `rentchain-frontend/src/pages/BillingPage.test.tsx`
- `rentchain-frontend/src/pages/BillingPage.tsx`
- `rentchain-frontend/src/pages/PricingPage.test.tsx`
- `rentchain-frontend/src/pages/PricingPage.tsx`
- `rentchain-frontend/src/pages/marketing/PricingPage.test.tsx`
- `rentchain-frontend/src/pages/marketing/PricingPage.tsx`

## Verification

### Frontend
- `npm run test -- src/pages/PricingPage.test.tsx src/pages/marketing/PricingPage.test.tsx src/pages/BillingPage.test.tsx src/components/billing/UpgradePromptModal.test.tsx`
- `npm run build`

## Why this change was made

Mission 30 and live funnel validation showed the strongest real conversion path is:

- Pricing → Billing → Upgrade

Mission 31 normalized routing so pricing-driven upgrade intent enters Billing consistently.

Mission 32 addresses the next friction point:
- users arrived at Billing, but their selected plan/interval context was lost
- Billing could immediately feel like a reset instead of a continuation

This mission preserves that intent and makes the Billing page a clearer continuation of the user’s pricing decision.

## Important note

- Pricing now carries selected plan and interval into Billing
- Billing continues the user’s upgrade decision instead of resetting them to a generic default path

## Intentionally unchanged

- no backend changes
- no pricing/entitlement changes
- no checkout flow rewrite
- no analytics event-model changes

## Known limitations / follow-up opportunities

- Billing selection is currently URL-driven, so other entry points must use the same query keys to benefit from the same continuity
- Prompt-driven upgrade flows still bypass Billing by design
- if you later want deeper analytics attribution on pricing-to-billing handoff, that should be a separate enhancement