### PR TITLE
feat: add conversion insight feedback engine v1

### DIFF
--- a/rentchain-api/src/routes/__tests__/adminSubscriptionConversionInsightsRoute.test.ts
+++ b/rentchain-api/src/routes/__tests__/adminSubscriptionConversionInsightsRoute.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const loadAdminSubscriptionConversionFunnel = vi.fn();
+const loadAdminSubscriptionConversionInsights = vi.fn();
+
+vi.mock("../../middleware/requireAdmin", () => ({
+  requireAdmin: (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock("../../services/admin/adminSubscriptionConversionView", () => ({
+  loadAdminSubscriptionConversionFunnel,
+}));
+
+vi.mock("../../services/admin/adminSubscriptionConversionInsights", () => ({
+  loadAdminSubscriptionConversionInsights,
+}));
+
+vi.mock("../../config/firebase", () => ({
+  db: {
+    collection: vi.fn(() => ({
+      where: vi.fn(),
+      doc: vi.fn(() => ({ set: vi.fn() })),
+    })),
+  },
+}));
+
+vi.mock("../../services/telemetryService", () => ({
+  getCountersSummary: vi.fn(async () => ({ byName: {} })),
+}));
+
+vi.mock("../../services/stripeService", () => ({
+  isStripeConfigured: () => false,
+  getStripeClient: () => {
+    throw new Error("not configured");
+  },
+}));
+
+vi.mock("firebase-admin", () => ({
+  default: {
+    auth: () => ({ createUser: vi.fn() }),
+    firestore: {
+      FieldValue: {
+        serverTimestamp: () => Date.now(),
+      },
+    },
+  },
+}));
+
+async function createRouter() {
+  return (await import("../adminRoutes")).default;
+}
+
+async function invokeRouter(
+  router: any,
+  options: {
+    method: string;
+    url: string;
+    body?: any;
+  }
+) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const req: any = {
+      method: options.method,
+      url: options.url.replace(/^\/api\/admin/, ""),
+      originalUrl: options.url,
+      path: options.url.replace(/^\/api\/admin/, "").split("?")[0],
+      query: {},
+      body: options.body ?? {},
+      user: { id: "admin-1", role: "admin" },
+      cookies: {},
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, any>,
+      setHeader(name: string, value: any) {
+        this.headers[name.toLowerCase()] = value;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    const [, rawQuery] = options.url.split("?");
+    if (rawQuery) {
+      req.query = Object.fromEntries(new URLSearchParams(rawQuery).entries());
+    }
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("GET /api/admin/analytics/conversion-insights", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    loadAdminSubscriptionConversionFunnel.mockReset();
+    loadAdminSubscriptionConversionInsights.mockReset();
+  });
+
+  it("returns the admin conversion insight payload", async () => {
+    loadAdminSubscriptionConversionInsights.mockResolvedValue({
+      window: { days: 30, from: "2026-03-18T00:00:00.000Z", to: "2026-04-17T00:00:00.000Z" },
+      funnel: [{ step: "pricing_page_viewed", count: 12 }],
+      breakdowns: {
+        targetPlan: { starter: 5 },
+        surface: { billing_page: 12 },
+        source: { billing_page: 12 },
+      },
+      insights: {
+        strongestSurface: { surface: "billing_page", count: 12 },
+        strongestPlanInterest: { targetPlan: "starter", count: 5 },
+        weakestFunnelStep: { step: "pricing_page_viewed -> pricing_plan_cta_clicked", conversion: 0.5 },
+        strongestFeatureSignal: null,
+      },
+      recommendations: ["Preserve billing as the primary upgrade hub."],
+    });
+
+    const router = await createRouter();
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/api/admin/analytics/conversion-insights?days=30",
+    });
+
+    expect(res.status).toBe(200);
+    expect(loadAdminSubscriptionConversionInsights).toHaveBeenCalledWith({ days: "30" });
+    expect(res.body).toEqual({
+      ok: true,
+      window: { days: 30, from: "2026-03-18T00:00:00.000Z", to: "2026-04-17T00:00:00.000Z" },
+      funnel: [{ step: "pricing_page_viewed", count: 12 }],
+      breakdowns: {
+        targetPlan: { starter: 5 },
+        surface: { billing_page: 12 },
+        source: { billing_page: 12 },
+      },
+      insights: {
+        strongestSurface: { surface: "billing_page", count: 12 },
+        strongestPlanInterest: { targetPlan: "starter", count: 5 },
+        weakestFunnelStep: { step: "pricing_page_viewed -> pricing_plan_cta_clicked", conversion: 0.5 },
+        strongestFeatureSignal: null,
+      },
+      recommendations: ["Preserve billing as the primary upgrade hub."],
+    });
+  });
+});

--- a/rentchain-api/src/routes/adminRoutes.ts
+++ b/rentchain-api/src/routes/adminRoutes.ts
@@ -8,6 +8,7 @@ import { getPlanConfig, resolvePlanFromPriceId, type BillingPlanKey } from "../c
 import { getTuReferralMetricsForMonth } from "../services/metrics/tuReferralReport";
 import { getPublicStatusPayload } from "../services/statusService";
 import { loadAdminSubscriptionConversionFunnel } from "../services/admin/adminSubscriptionConversionView";
+import { loadAdminSubscriptionConversionInsights } from "../services/admin/adminSubscriptionConversionInsights";
 import {
   createStatusIncident,
   resolveStatusIncident,
@@ -842,6 +843,22 @@ router.get("/analytics/conversion-funnel", requireAdmin, async (req, res) => {
   } catch (err: any) {
     console.error("[admin] conversion funnel failed", err?.message || err);
     return res.status(500).json({ ok: false, error: "CONVERSION_FUNNEL_FAILED" });
+  }
+});
+
+router.get("/analytics/conversion-insights", requireAdmin, async (req, res) => {
+  try {
+    const days = req.query?.days;
+    const payload = await loadAdminSubscriptionConversionInsights({
+      days: typeof days === "string" ? days : undefined,
+    });
+    return res.json({
+      ok: true,
+      ...payload,
+    });
+  } catch (err: any) {
+    console.error("[admin] conversion insights failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "CONVERSION_INSIGHTS_FAILED" });
   }
 });
 

--- a/rentchain-api/src/services/__tests__/adminSubscriptionConversionInsights.test.ts
+++ b/rentchain-api/src/services/__tests__/adminSubscriptionConversionInsights.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type StoredDoc = { id: string; data: any };
+
+const { dbMock, resetDb, seedDoc } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, StoredDoc>>();
+
+  function ensureCollection(name: string) {
+    if (!collections.has(name)) collections.set(name, new Map());
+    return collections.get(name)!;
+  }
+
+  function buildQuery(name: string, filters: Array<{ field: string; op: string; value: any }> = []) {
+    return {
+      where: (field: string, op: string, value: any) => buildQuery(name, [...filters, { field, op, value }]),
+      get: async () => {
+        let rows = Array.from(ensureCollection(name).values());
+        rows = rows.filter((entry) =>
+          filters.every((f) => {
+            const value = entry.data?.[f.field];
+            if (f.op === ">=") return Number(value || 0) >= Number(f.value);
+            if (f.op === "<=") return Number(value || 0) <= Number(f.value);
+            return true;
+          })
+        );
+        return {
+          empty: rows.length === 0,
+          docs: rows.map((row) => ({ id: row.id, data: () => row.data })),
+        };
+      },
+    };
+  }
+
+  return {
+    dbMock: {
+      collection: (name: string) => ({
+        where: (field: string, op: string, value: any) => buildQuery(name, [{ field, op, value }]),
+      }),
+    },
+    resetDb: () => {
+      collections.clear();
+    },
+    seedDoc: (collection: string, id: string, data: any) => {
+      ensureCollection(collection).set(id, { id, data });
+    },
+  };
+});
+
+vi.mock("../../config/firebase", () => ({
+  db: dbMock,
+}));
+
+describe("adminSubscriptionConversionInsights", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    resetDb();
+  });
+
+  it("computes ranked surfaces, plan interest, weakest step, and deterministic recommendations", async () => {
+    const now = Date.now();
+    seedDoc("events", "event-1", {
+      name: "pricing_page_viewed",
+      ts: now - 1_000,
+      props: { surface: "marketing_pricing", source: "marketing_pricing" },
+    });
+    seedDoc("events", "event-2", {
+      name: "pricing_plan_cta_clicked",
+      ts: now - 900,
+      props: { targetPlan: "starter", surface: "marketing_pricing", source: "marketing_pricing" },
+    });
+    seedDoc("events", "event-3", {
+      name: "billing_page_opened",
+      ts: now - 800,
+      props: { surface: "billing_page", source: "billing_page" },
+    });
+    seedDoc("events", "event-4", {
+      name: "billing_upgrade_clicked",
+      ts: now - 700,
+      props: { targetPlan: "starter", surface: "billing_page", source: "billing_page" },
+    });
+    seedDoc("events", "event-5", {
+      name: "upgrade_cta_clicked",
+      ts: now - 650,
+      props: {
+        featureKey: "tenant_invites",
+        surface: "locked_feature",
+        source: "applications_page",
+      },
+    });
+    seedDoc("events", "mixed-1", {
+      type: "application_submitted",
+      occurredAt: new Date(now - 600).toISOString(),
+      payload: {},
+    });
+
+    const { loadAdminSubscriptionConversionInsights } = await import("../admin/adminSubscriptionConversionInsights");
+    const result = await loadAdminSubscriptionConversionInsights({ days: 30 });
+
+    expect(result.insights.strongestSurface).toEqual({
+      surface: "billing_page",
+      count: 1,
+    });
+    expect(result.insights.strongestPlanInterest).toEqual({
+      targetPlan: "starter",
+      count: 2,
+    });
+    expect(result.insights.weakestFunnelStep).toEqual({
+      step: "upgrade_cta_clicked -> upgrade_prompt_viewed",
+      conversion: 0,
+    });
+    expect(result.insights.strongestFeatureSignal).toEqual({
+      featureKey: "tenant_invites",
+      count: 1,
+    });
+    expect(result.breakdowns.featureKey).toEqual({
+      tenant_invites: 1,
+    });
+    expect(result.recommendations).toContain("Preserve billing as the primary upgrade hub.");
+    expect(result.recommendations).toContain(
+      "Strengthen Pro and Elite differentiation if Starter continues to dominate upgrade interest."
+    );
+    expect(result.recommendations).toContain(
+      "Monitor whether prompt-driven upgrade flows become meaningful before prioritizing prompt optimization."
+    );
+    expect(result.recommendations).toContain(
+      "Treat this output as directional until more conversion event volume accumulates."
+    );
+  });
+
+  it("returns safe empty insight output when no matching analytics events exist", async () => {
+    const { loadAdminSubscriptionConversionInsights } = await import("../admin/adminSubscriptionConversionInsights");
+    const result = await loadAdminSubscriptionConversionInsights({ days: 7 });
+
+    expect(result.insights.strongestSurface).toEqual({
+      surface: null,
+      count: 0,
+    });
+    expect(result.insights.strongestPlanInterest).toEqual({
+      targetPlan: null,
+      count: 0,
+    });
+    expect(result.insights.weakestFunnelStep).toEqual({
+      step: null,
+      conversion: null,
+    });
+    expect(result.recommendations).toEqual([
+      "Monitor whether prompt-driven upgrade flows become meaningful before prioritizing prompt optimization.",
+    ]);
+  });
+});

--- a/rentchain-api/src/services/admin/adminSubscriptionConversionInsights.ts
+++ b/rentchain-api/src/services/admin/adminSubscriptionConversionInsights.ts
@@ -1,0 +1,197 @@
+import {
+  loadAdminSubscriptionConversionDataset,
+  type ConversionEventRow,
+  type SubscriptionConversionSummary,
+} from "./adminSubscriptionConversionView";
+
+type FunnelStep = SubscriptionConversionSummary["funnel"][number];
+
+type RankedCount = {
+  key: string;
+  count: number;
+};
+
+export type SubscriptionConversionInsightsPayload = {
+  window: SubscriptionConversionSummary["window"];
+  funnel: SubscriptionConversionSummary["funnel"];
+  breakdowns: SubscriptionConversionSummary["breakdowns"] & {
+    featureKey?: Record<string, number>;
+  };
+  insights: {
+    strongestSurface: {
+      surface: string | null;
+      count: number;
+    };
+    strongestPlanInterest: {
+      targetPlan: string | null;
+      count: number;
+    };
+    weakestFunnelStep: {
+      step: string | null;
+      conversion: number | null;
+    };
+    strongestFeatureSignal?: {
+      featureKey: string;
+      count: number;
+    } | null;
+  };
+  recommendations: string[];
+};
+
+const UPGRADE_INTENT_EVENT_NAMES = new Set([
+  "pricing_plan_cta_clicked",
+  "upgrade_cta_clicked",
+  "upgrade_prompt_checkout_clicked",
+  "billing_upgrade_clicked",
+]);
+
+function toBreakdownKey(value: unknown) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function incrementBucket(bucket: Record<string, number>, key: string | null) {
+  if (!key) return;
+  bucket[key] = (bucket[key] || 0) + 1;
+}
+
+function topBucket(bucket: Record<string, number>): RankedCount | null {
+  const entries = Object.entries(bucket);
+  if (!entries.length) return null;
+  entries.sort((a, b) => {
+    if (b[1] !== a[1]) return b[1] - a[1];
+    return a[0].localeCompare(b[0]);
+  });
+  return { key: entries[0][0], count: entries[0][1] };
+}
+
+function weakestFunnelStep(funnel: FunnelStep[]) {
+  const candidates = funnel
+    .map((step, index) => {
+      if (index === 0) return null;
+      if (typeof step.conversionFromPrevious !== "number") return null;
+      return {
+        step: `${funnel[index - 1].step} -> ${step.step}`,
+        conversion: step.conversionFromPrevious,
+      };
+    })
+    .filter((item): item is { step: string; conversion: number } => item != null);
+
+  if (!candidates.length) {
+    return { step: null, conversion: null };
+  }
+
+  candidates.sort((a, b) => {
+    if (a.conversion !== b.conversion) return a.conversion - b.conversion;
+    return a.step.localeCompare(b.step);
+  });
+  return candidates[0];
+}
+
+function buildFeatureBreakdown(rows: ConversionEventRow[]) {
+  const bucket: Record<string, number> = {};
+  for (const row of rows) {
+    incrementBucket(bucket, toBreakdownKey(row.props.featureKey));
+  }
+  return bucket;
+}
+
+function buildIntentSurfaceBreakdown(rows: ConversionEventRow[]) {
+  const bucket: Record<string, number> = {};
+  for (const row of rows) {
+    if (!UPGRADE_INTENT_EVENT_NAMES.has(row.name)) continue;
+    incrementBucket(bucket, toBreakdownKey(row.props.surface));
+  }
+  return bucket;
+}
+
+function buildRecommendations(params: {
+  funnel: FunnelStep[];
+  strongestSurface: RankedCount | null;
+  strongestPlanInterest: RankedCount | null;
+  weakestStep: { step: string | null; conversion: number | null };
+  promptViews: number;
+  totalEvents: number;
+}) {
+  const recommendations: string[] = [];
+  const { strongestSurface, strongestPlanInterest, weakestStep, promptViews, totalEvents } = params;
+
+  if (strongestSurface?.key === "billing_page") {
+    recommendations.push("Preserve billing as the primary upgrade hub.");
+  }
+
+  if (weakestStep.step === "pricing_page_viewed -> pricing_plan_cta_clicked") {
+    recommendations.push("Strengthen plan differentiation on pricing surfaces before asking users to choose a tier.");
+  } else if (weakestStep.step === "billing_page_opened -> billing_upgrade_clicked") {
+    recommendations.push("Reduce hesitation on billing by making the selected upgrade and next checkout action more prominent.");
+  }
+
+  if (strongestPlanInterest?.key === "starter") {
+    recommendations.push("Strengthen Pro and Elite differentiation if Starter continues to dominate upgrade interest.");
+  }
+
+  if (promptViews <= 1) {
+    recommendations.push("Monitor whether prompt-driven upgrade flows become meaningful before prioritizing prompt optimization.");
+  }
+
+  if (totalEvents > 0 && totalEvents < 10) {
+    recommendations.push("Treat this output as directional until more conversion event volume accumulates.");
+  }
+
+  if (!recommendations.length) {
+    recommendations.push("Maintain the current funnel shape and keep monitoring surface and plan-interest shifts.");
+  }
+
+  return Array.from(new Set(recommendations));
+}
+
+export async function loadAdminSubscriptionConversionInsights(params?: {
+  days?: number | string;
+}): Promise<SubscriptionConversionInsightsPayload> {
+  const dataset = await loadAdminSubscriptionConversionDataset(params);
+  const featureKey = buildFeatureBreakdown(dataset.rows);
+  const intentSurfaceBreakdown = buildIntentSurfaceBreakdown(dataset.rows);
+  const strongestSurface = topBucket(intentSurfaceBreakdown);
+  const strongestPlanInterest = topBucket(dataset.breakdowns.targetPlan);
+  const strongestFeatureSignal = topBucket(featureKey);
+  const weakestStep = weakestFunnelStep(dataset.funnel);
+  const promptViews =
+    dataset.funnel.find((step) => step.step === "upgrade_prompt_viewed")?.count || 0;
+  const totalEvents = dataset.rows.length;
+
+  return {
+    window: dataset.window,
+    funnel: dataset.funnel,
+    breakdowns: {
+      ...dataset.breakdowns,
+      ...(Object.keys(featureKey).length ? { featureKey } : {}),
+    },
+    insights: {
+      strongestSurface: {
+        surface: strongestSurface?.key || null,
+        count: strongestSurface?.count || 0,
+      },
+      strongestPlanInterest: {
+        targetPlan: strongestPlanInterest?.key || null,
+        count: strongestPlanInterest?.count || 0,
+      },
+      weakestFunnelStep: weakestStep,
+      strongestFeatureSignal:
+        strongestFeatureSignal && strongestFeatureSignal.count > 0
+          ? {
+              featureKey: strongestFeatureSignal.key,
+              count: strongestFeatureSignal.count,
+            }
+          : null,
+    },
+    recommendations: buildRecommendations({
+      funnel: dataset.funnel,
+      strongestSurface,
+      strongestPlanInterest,
+      weakestStep,
+      promptViews,
+      totalEvents,
+    }),
+  };
+}

--- a/rentchain-api/src/services/admin/adminSubscriptionConversionView.ts
+++ b/rentchain-api/src/services/admin/adminSubscriptionConversionView.ts
@@ -12,13 +12,14 @@ export const SUBSCRIPTION_CONVERSION_FUNNEL_STEPS = [
 
 type FunnelStepName = (typeof SUBSCRIPTION_CONVERSION_FUNNEL_STEPS)[number];
 
-type EventProps = {
+export type EventProps = {
   targetPlan?: unknown;
   surface?: unknown;
   source?: unknown;
+  featureKey?: unknown;
 };
 
-type ConversionEventRow = {
+export type ConversionEventRow = {
   name: FunnelStepName;
   ts: number;
   props: EventProps;
@@ -86,9 +87,13 @@ function toConversionEventRow(data: any): ConversionEventRow | null {
   };
 }
 
-export async function loadAdminSubscriptionConversionFunnel(params?: {
+export type SubscriptionConversionDataset = SubscriptionConversionSummary & {
+  rows: ConversionEventRow[];
+};
+
+export async function loadAdminSubscriptionConversionDataset(params?: {
   days?: number | string;
-}): Promise<SubscriptionConversionSummary> {
+}): Promise<SubscriptionConversionDataset> {
   const days = clampDays(params?.days);
   const to = Date.now();
   const from = to - days * 24 * 60 * 60 * 1000;
@@ -141,7 +146,15 @@ export async function loadAdminSubscriptionConversionFunnel(params?: {
       from: new Date(from).toISOString(),
       to: new Date(to).toISOString(),
     },
+    rows,
     funnel,
     breakdowns,
   };
+}
+
+export async function loadAdminSubscriptionConversionFunnel(params?: {
+  days?: number | string;
+}): Promise<SubscriptionConversionSummary> {
+  const { rows: _rows, ...summary } = await loadAdminSubscriptionConversionDataset(params);
+  return summary;
 }


### PR DESCRIPTION
## Summary

Implements Conversion Insight Feedback Engine v1 by extending the Mission 30 bounded-window analysis model into a backend-only insight layer that produces aggregate funnel insight summaries and deterministic optimization recommendations.

This closes the first optimization loop without introducing a new analytics system, dashboard, or frontend dependency.

## What changed

### Backend insight engine
- Added a dedicated backend insight service:
  - `rentchain-api/src/services/admin/adminSubscriptionConversionInsights.ts`
- Extended the Mission 30 analysis layer with a reusable bounded-window dataset loader in:
  - `rentchain-api/src/services/admin/adminSubscriptionConversionView.ts`

### Admin route
- Added one new admin-only read route:
  - `GET /api/admin/analytics/conversion-insights`
- The route returns:
  - funnel data
  - aggregate breakdowns
  - strongest surface and plan-interest signals
  - weakest funnel step
  - optional feature-key signals when present
  - deterministic rule-based recommendations

### Tests
- Added targeted backend tests covering:
  - insight aggregation
  - mixed-schema `events` filtering
  - recommendation logic
  - route response behavior

## Files changed

- `rentchain-api/src/routes/adminRoutes.ts`
- `rentchain-api/src/routes/__tests__/adminSubscriptionConversionInsightsRoute.test.ts`
- `rentchain-api/src/services/admin/adminSubscriptionConversionInsights.ts`
- `rentchain-api/src/services/admin/adminSubscriptionConversionView.ts`
- `rentchain-api/src/services/__tests__/adminSubscriptionConversionInsights.test.ts`

## Verification

### Backend
- targeted backend tests passed for:
  - `adminSubscriptionConversionView`
  - `adminSubscriptionConversionInsights`
  - conversion funnel route
  - conversion insights route
- `npm run build`

## Route added

- `/api/admin/analytics/conversion-insights`

## Output shape

The route returns a lightweight aggregate structure including:
- `window`
- `funnel`
- `breakdowns`
- `insights`
- `recommendations`

Example response shape:

```json
{
  "ok": true,
  "window": {
    "days": 30,
    "from": "2026-03-19T00:00:00.000Z",
    "to": "2026-04-18T00:00:00.000Z"
  },
  "funnel": [
    { "step": "pricing_page_viewed", "count": 12 },
    { "step": "pricing_plan_cta_clicked", "count": 8, "conversionFromPrevious": 0.667 }
  ],
  "breakdowns": {
    "targetPlan": { "starter": 9 },
    "surface": { "billing_page": 39 },
    "source": { "marketing_pricing": 6 },
    "featureKey": { "tenant_invites": 4 }
  },
  "insights": {
    "strongestSurface": { "surface": "billing_page", "count": 39 },
    "strongestPlanInterest": { "targetPlan": "starter", "count": 9 },
    "weakestFunnelStep": {
      "step": "pricing_page_viewed -> pricing_plan_cta_clicked",
      "conversion": 0.667
    },
    "strongestFeatureSignal": {
      "featureKey": "tenant_invites",
      "count": 4
    }
  },
  "recommendations": [
    "Preserve billing as the primary upgrade hub."
  ]
}