### PR TITLE
feat: add billing conversion optimization v1

### DIFF
--- a/rentchain-frontend/src/components/billing/BillingPlansPanel.test.tsx
+++ b/rentchain-frontend/src/components/billing/BillingPlansPanel.test.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { BillingPlansPanel } from "./BillingPlansPanel";
+
+vi.mock("./PlanIntervalToggle", () => ({
+  PlanIntervalToggle: ({ value, onChange }: { value: "month" | "year"; onChange: (value: "month" | "year") => void }) => (
+    <div>
+      <button type="button" onClick={() => onChange(value === "month" ? "year" : "month")}>
+        Toggle interval
+      </button>
+    </div>
+  ),
+}));
+
+describe("BillingPlansPanel", () => {
+  it("emphasizes selected and recommended plans with supporting checkout copy", () => {
+    const onSelectPlan = vi.fn();
+
+    render(
+      <BillingPlansPanel
+        pricing={null}
+        pricingLoading={false}
+        pricingUnavailable={false}
+        interval="year"
+        onIntervalChange={vi.fn()}
+        currentPlan="starter"
+        selectedPlan="pro"
+        recommendedPlan="pro"
+        role="landlord"
+        mode="billing"
+        planActionLoading={null}
+        onSelectPlan={onSelectPlan}
+      />
+    );
+
+    expect(screen.getByText("Current")).toBeInTheDocument();
+    expect(screen.getByText("Selected from pricing")).toBeInTheDocument();
+    expect(
+      screen.getByText("Selected from pricing. Opens secure checkout for the plan you already chose.")
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Continue to Pro checkout" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Continue to Elite checkout" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Continue to Pro checkout" }));
+    expect(onSelectPlan).toHaveBeenCalledWith("pro");
+  });
+
+  it("marks the next upgrade as recommended when there is no pricing-selected plan", () => {
+    render(
+      <BillingPlansPanel
+        pricing={null}
+        pricingLoading={false}
+        pricingUnavailable={false}
+        interval="month"
+        onIntervalChange={vi.fn()}
+        currentPlan="starter"
+        selectedPlan={null}
+        recommendedPlan="pro"
+        role="landlord"
+        mode="billing"
+        planActionLoading={null}
+        onSelectPlan={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("Recommended next step")).toBeInTheDocument();
+    expect(
+      screen.getByText("Recommended next step based on your current plan. Opens secure checkout.")
+    ).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/billing/BillingPlansPanel.tsx
+++ b/rentchain-frontend/src/components/billing/BillingPlansPanel.tsx
@@ -18,6 +18,7 @@ type Props = {
   onIntervalChange: (value: "month" | "year") => void;
   currentPlan?: string | null;
   selectedPlan?: "starter" | "pro" | "elite" | null;
+  recommendedPlan?: "starter" | "pro" | "elite" | null;
   role?: string | null;
   mode: "billing" | "pricing";
   planActionLoading?: string | null;
@@ -32,6 +33,7 @@ export function BillingPlansPanel({
   onIntervalChange,
   currentPlan,
   selectedPlan,
+  recommendedPlan,
   role,
   mode,
   planActionLoading,
@@ -73,6 +75,28 @@ export function BillingPlansPanel({
     return `Continue to ${CANONICAL_TIER_MATRIX[planKey].label} checkout`;
   };
 
+  const ctaSupportCopy = (
+    planKey: Exclude<PricingPlanKey, "free">,
+    isCurrent: boolean,
+    isSelected: boolean,
+    isRecommended: boolean
+  ) => {
+    if (isCurrent) return "Your current plan is already active.";
+    if (currentPlanKey && currentPlanKey !== "free") {
+      const paidPlanOrder: Exclude<PricingPlanKey, "free">[] = ["starter", "pro", "elite"];
+      if (paidPlanOrder.indexOf(currentPlanKey as Exclude<PricingPlanKey, "free">) >= paidPlanOrder.indexOf(planKey)) {
+        return "Opens the billing portal to manage your existing subscription.";
+      }
+    }
+    if (isSelected) {
+      return "Selected from pricing. Opens secure checkout for the plan you already chose.";
+    }
+    if (isRecommended) {
+      return "Recommended next step based on your current plan. Opens secure checkout.";
+    }
+    return "Opens secure checkout so you can review and confirm this plan.";
+  };
+
   return (
     <div style={{ display: "grid", gap: 10 }}>
       <PlanIntervalToggle value={interval} onChange={onIntervalChange} />
@@ -83,6 +107,7 @@ export function BillingPlansPanel({
         const plan = CANONICAL_TIER_MATRIX[planId];
         const highlight = currentPlanKey === planId;
         const selected = selectedPlan === planId;
+        const recommended = !highlight && recommendedPlan === planId;
         const topAreas = TIER_MATRIX_AREAS.slice(0, 4);
 
         return (
@@ -94,15 +119,20 @@ export function BillingPlansPanel({
                 ? "1px solid rgba(59,130,246,0.45)"
                 : selected
                   ? "1px solid rgba(37,99,235,0.45)"
+                  : recommended
+                    ? "1px solid rgba(14,116,144,0.42)"
                   : "1px solid rgba(148,163,184,0.25)",
               background: highlight
                 ? "rgba(59,130,246,0.08)"
                 : selected
                   ? "rgba(37,99,235,0.08)"
+                  : recommended
+                    ? "rgba(14,116,144,0.08)"
                   : "rgba(148,163,184,0.06)",
               padding: 12,
               display: "grid",
               gap: 12,
+              boxShadow: recommended ? "0 14px 28px rgba(14,116,144,0.10)" : "none",
             }}
           >
             <div
@@ -122,7 +152,9 @@ export function BillingPlansPanel({
               {highlight ? (
                 <span style={{ fontSize: 12, fontWeight: 700, color: colors.accent }}>Current</span>
               ) : selected ? (
-                <span style={{ fontSize: 12, fontWeight: 700, color: "#1d4ed8" }}>Selected</span>
+                <span style={{ fontSize: 12, fontWeight: 700, color: "#1d4ed8" }}>Selected from pricing</span>
+              ) : recommended ? (
+                <span style={{ fontSize: 12, fontWeight: 700, color: "#0f766e" }}>Recommended next step</span>
               ) : null}
             </div>
 
@@ -175,6 +207,9 @@ export function BillingPlansPanel({
               >
                 {ctaLabel(planId, highlight)}
               </Button>
+            </div>
+            <div style={{ color: text.muted, fontSize: 12, lineHeight: 1.5 }}>
+              {ctaSupportCopy(planId, highlight, selected, recommended)}
             </div>
           </div>
         );

--- a/rentchain-frontend/src/pages/BillingPage.test.tsx
+++ b/rentchain-frontend/src/pages/BillingPage.test.tsx
@@ -121,11 +121,13 @@ describe("BillingPage", () => {
     await waitFor(() =>
       expect(screen.getByText(/Pricing selection saved: Pro on the Yearly plan/i)).toBeInTheDocument()
     );
+    expect(screen.getByText(/Recommended next plan: Pro from your pricing selection/i)).toBeInTheDocument();
     expect(screen.getAllByRole("button", { name: "Continue to Pro checkout" }).length).toBeGreaterThan(0);
     expect(mocks.billingPlansPanelMock).toHaveBeenCalledWith(
       expect.objectContaining({
         interval: "year",
         selectedPlan: "pro",
+        recommendedPlan: "pro",
       })
     );
   });
@@ -148,10 +150,17 @@ describe("BillingPage", () => {
     expect(screen.getByTestId("billing-plans-panel")).toHaveTextContent("pro");
     expect(screen.getAllByRole("button", { name: "Manage subscription" })).toHaveLength(2);
     expect(screen.getByText(/Pro includes exports, reporting, and team workflows/)).toBeInTheDocument();
+    expect(screen.getByText(/Recommended next plan: Elite/i)).toBeInTheDocument();
     expect(mocks.trackMock).toHaveBeenCalledWith("billing_page_opened", {
       currentPlan: "pro",
       surface: "billing_page",
       route: "/",
     });
+    expect(mocks.billingPlansPanelMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        currentPlan: "pro",
+        recommendedPlan: "elite",
+      })
+    );
   });
 });

--- a/rentchain-frontend/src/pages/BillingPage.tsx
+++ b/rentchain-frontend/src/pages/BillingPage.tsx
@@ -237,6 +237,7 @@ const BillingPage: React.FC = () => {
         : resolvedCurrentPlan === "pro"
           ? "elite"
           : null);
+  const recommendedUpgradeTier = nextUpgradeTier;
   const starterUpgradeLabel = checkoutCtaLabel(requestedUpgradePlan || "starter");
   const nextUpgradeLabel = nextUpgradeTier
     ? interval === "year"
@@ -246,6 +247,18 @@ const BillingPage: React.FC = () => {
   const nextUpgradeHelp = nextUpgradeTier
     ? `You'll be taken to checkout for the ${interval === "year" ? "Yearly" : "Monthly"} ${CANONICAL_TIER_MATRIX[nextUpgradeTier].label} plan.`
     : null;
+  const selectedPlanLabel = requestedUpgradePlan ? CANONICAL_TIER_MATRIX[requestedUpgradePlan].label : null;
+  const recommendedPlanLabel = recommendedUpgradeTier
+    ? CANONICAL_TIER_MATRIX[recommendedUpgradeTier].label
+    : null;
+  const recommendedUpgradeReason =
+    resolvedCurrentPlan === "free"
+      ? "Starter is the first paid plan and the fastest path into the full rental workflow."
+      : resolvedCurrentPlan === "starter"
+        ? "Pro is the next logical step when you need stronger reporting, exports, and team workflow control."
+        : resolvedCurrentPlan === "pro"
+          ? "Elite is the next logical step when you need deeper portfolio visibility and advanced oversight."
+          : null;
 
   return (
     <Section
@@ -265,6 +278,12 @@ const BillingPage: React.FC = () => {
             {requestedUpgradePlan ? (
               <div style={{ color: text.muted, fontSize: "0.9rem", marginTop: 6 }}>
                 Pricing selection saved: {CANONICAL_TIER_MATRIX[requestedUpgradePlan].label} on the {interval === "year" ? "Yearly" : "Monthly"} plan.
+              </div>
+            ) : null}
+            {recommendedPlanLabel ? (
+              <div style={{ color: text.secondary, fontSize: "0.92rem", marginTop: 6, fontWeight: 600 }}>
+                Recommended next plan: {recommendedPlanLabel}
+                {requestedUpgradePlan ? " from your pricing selection." : "."}
               </div>
             ) : null}
           </div>
@@ -295,25 +314,93 @@ const BillingPage: React.FC = () => {
       </Card>
 
       <Card id="plan">
-        <div style={{ display: "grid", gap: spacing.xs }}>
-          <div style={{ fontWeight: 700, fontSize: "1.05rem" }}>Current plan</div>
-          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: spacing.sm }}>
-            <div>
-              <div style={{ color: text.muted, fontSize: 12 }}>Tier</div>
-              <div style={{ fontWeight: 700 }}>
-                {billingStatus.isLoading ? "Loading..." : billingTierLabel(resolvedCurrentPlan)}
+        <div style={{ display: "grid", gap: spacing.md }}>
+          <div style={{ display: "grid", gap: spacing.sm, gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))" }}>
+            <div
+              style={{
+                border: "1px solid rgba(148,163,184,0.25)",
+                borderRadius: 16,
+                padding: 16,
+                background: "rgba(148,163,184,0.06)",
+                display: "grid",
+                gap: spacing.xs,
+              }}
+            >
+              <div style={{ fontWeight: 700, fontSize: "1.05rem" }}>Current plan</div>
+              <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))", gap: spacing.sm }}>
+                <div>
+                  <div style={{ color: text.muted, fontSize: 12 }}>Tier</div>
+                  <div style={{ fontWeight: 700 }}>
+                    {billingStatus.isLoading ? "Loading..." : billingTierLabel(resolvedCurrentPlan)}
+                  </div>
+                </div>
+                <div>
+                  <div style={{ color: text.muted, fontSize: 12 }}>Billing interval</div>
+                  <div style={{ fontWeight: 700 }}>{intervalLabel(billingStatus.interval)}</div>
+                </div>
+                <div>
+                  <div style={{ color: text.muted, fontSize: 12 }}>Renewal date</div>
+                  <div style={{ fontWeight: 700 }}>{renewalLabel(billingStatus.renewalDate)}</div>
+                </div>
               </div>
+              {resolvedCurrentPlan === "free" ? (
+                <div style={{ marginTop: spacing.xs, color: text.muted, fontSize: 14 }}>
+                  Free includes guided setup and pay-per-use screening. Upgrade when you want richer rental operations, communication, exports, and reporting.
+                </div>
+              ) : null}
+              {resolvedCurrentPlan === "starter" ? (
+                <div style={{ marginTop: spacing.xs, color: text.muted, fontSize: 14 }}>
+                  Starter includes messaging, leases, maintenance, and work orders. Pro adds exports, screening summaries, compliance reports, and team workflows.
+                </div>
+              ) : null}
+              {resolvedCurrentPlan === "pro" ? (
+                <div style={{ marginTop: spacing.xs, color: text.muted, fontSize: 14 }}>
+                  Pro includes exports, reporting, and team workflows. Elite adds advanced analytics, AI summaries, and audit visibility.
+                </div>
+              ) : null}
             </div>
-            <div>
-              <div style={{ color: text.muted, fontSize: 12 }}>Billing interval</div>
-              <div style={{ fontWeight: 700 }}>{intervalLabel(billingStatus.interval)}</div>
-            </div>
-            <div>
-              <div style={{ color: text.muted, fontSize: 12 }}>Renewal date</div>
-              <div style={{ fontWeight: 700 }}>{renewalLabel(billingStatus.renewalDate)}</div>
-            </div>
+
+            {recommendedUpgradeTier ? (
+              <div
+                style={{
+                  border: "1px solid rgba(14,116,144,0.28)",
+                  borderRadius: 16,
+                  padding: 16,
+                  background: "rgba(14,116,144,0.08)",
+                  display: "grid",
+                  gap: spacing.xs,
+                }}
+              >
+                <div style={{ color: "#0f766e", fontSize: 12, fontWeight: 800 }}>
+                  {requestedUpgradePlan ? "Selected from pricing" : "Recommended next plan"}
+                </div>
+                <div style={{ fontWeight: 800, fontSize: "1.05rem" }}>
+                  {recommendedPlanLabel}
+                  {selectedPlanLabel && requestedUpgradePlan === recommendedUpgradeTier ? " checkout path" : ""}
+                </div>
+                {recommendedUpgradeReason ? (
+                  <div style={{ color: text.muted, fontSize: 14 }}>{recommendedUpgradeReason}</div>
+                ) : null}
+                {nextUpgradeHelp ? (
+                  <div style={{ color: text.secondary, fontSize: 13, fontWeight: 600 }}>{nextUpgradeHelp}</div>
+                ) : null}
+                <div className="rc-wrap-row" style={{ marginTop: spacing.xs }}>
+                  <Button
+                    type="button"
+                    onClick={() => void handlePlanAction(recommendedUpgradeTier)}
+                    disabled={billingStatus.isLoading || planActionLoading === recommendedUpgradeTier || pricingUnavailable}
+                  >
+                    {nextUpgradeLabel}
+                  </Button>
+                </div>
+                <div style={{ color: text.muted, fontSize: 12 }}>
+                  Secure checkout opens next so you can review the selected plan and confirm before any billing starts.
+                </div>
+              </div>
+            ) : null}
           </div>
-          <div className="rc-wrap-row" style={{ marginTop: spacing.sm }}>
+
+          <div className="rc-wrap-row" style={{ marginTop: spacing.xs }}>
             {isPaidPlan ? (
               <Button type="button" variant="secondary" onClick={handlePortal} disabled={portalLoading}>
                 {portalLoading ? "Opening..." : "Manage subscription"}
@@ -332,36 +419,7 @@ const BillingPage: React.FC = () => {
                 {planActionLoading === (requestedUpgradePlan || "starter") ? "Opening..." : starterUpgradeLabel}
               </Button>
             )}
-            {nextUpgradeTier ? (
-              <Button
-                type="button"
-                onClick={() => void handlePlanAction(nextUpgradeTier)}
-                disabled={billingStatus.isLoading || planActionLoading === nextUpgradeTier || pricingUnavailable}
-              >
-                {nextUpgradeLabel}
-              </Button>
-            ) : null}
           </div>
-          {resolvedCurrentPlan === "free" ? (
-            <div style={{ marginTop: spacing.xs, color: text.muted }}>
-              Free includes guided setup and pay-per-use screening. Upgrade when you want richer rental operations, communication, exports, and reporting.
-            </div>
-          ) : null}
-          {resolvedCurrentPlan === "starter" ? (
-            <div style={{ marginTop: spacing.xs, color: text.muted, fontSize: 14 }}>
-              Starter includes messaging, leases, maintenance, and work orders. Pro adds exports, screening summaries, compliance reports, and team workflows.
-            </div>
-          ) : null}
-          {resolvedCurrentPlan === "pro" ? (
-            <div style={{ marginTop: spacing.xs, color: text.muted, fontSize: 14 }}>
-              Pro includes exports, reporting, and team workflows. Elite adds advanced analytics, AI summaries, and audit visibility.
-            </div>
-          ) : null}
-          {nextUpgradeHelp ? (
-            <div style={{ marginTop: spacing.xs, color: text.muted, fontSize: 14 }}>
-              {nextUpgradeHelp}
-            </div>
-          ) : null}
         </div>
       </Card>
 
@@ -380,6 +438,7 @@ const BillingPage: React.FC = () => {
           }}
           currentPlan={currentPlan}
           selectedPlan={requestedUpgradePlan}
+          recommendedPlan={recommendedUpgradeTier}
           role={user?.actorRole || user?.role || null}
           mode="billing"
           planActionLoading={planActionLoading}


### PR DESCRIPTION
## Summary

Implements Billing Conversion Optimization v1 by improving decision clarity on the Billing page and strengthening the live primary upgrade path:

- Pricing → Billing → Upgrade

This mission makes Billing feel more like a continuation of the user’s upgrade decision instead of a reset, with clearer emphasis on the current plan, selected pricing intent, and recommended next upgrade.

## What changed

### Billing page
- Strengthened the Billing page summary so it now explicitly shows:
  - current plan
  - recommended next plan
  - whether the recommendation came from the pricing handoff
- Added a dedicated recommended-upgrade card on Billing with:
  - the next logical plan
  - short rationale for why that plan is next
  - explicit checkout-confidence copy
  - the primary checkout action in the same decision block

### Billing plans panel
- Updated the plan panel to distinguish three states more clearly:
  - `Current`
  - `Selected from pricing`
  - `Recommended next step`
- Added supporting copy under plan CTAs so the next action is clearer:
  - current plan stays inactive
  - selected pricing plan explains that checkout opens for the plan already chosen
  - recommended plan explains it is the suggested next step
  - other upgrade CTAs explain they open secure checkout for review and confirmation

## Files changed

- `rentchain-frontend/src/components/billing/BillingPlansPanel.tsx`
- `rentchain-frontend/src/components/billing/BillingPlansPanel.test.tsx`
- `rentchain-frontend/src/pages/BillingPage.tsx`
- `rentchain-frontend/src/pages/BillingPage.test.tsx`

## Verification

### Frontend
- `npm run test -- src/pages/BillingPage.test.tsx src/components/billing/BillingPlansPanel.test.tsx src/pages/PricingPage.test.tsx src/pages/marketing/PricingPage.test.tsx`
- `npm run build`

## Why this change was made

Live funnel analysis showed:

- pricing CTA engagement is strong
- Billing is the strongest live conversion surface
- the current highest-leverage optimization point is:
  - `billing_page_opened → billing_upgrade_clicked`

This mission improves that step by reducing hesitation and making the next best upgrade action more obvious.

## Important note

Billing now emphasizes:
- the current plan
- selected pricing intent
- the recommended next plan

The goal is to make Billing feel like a continuation of the user’s upgrade decision rather than a reset.

## Intentionally unchanged

- no backend billing changes
- no checkout flow rewrite
- no pricing/entitlement changes
- no prompt-system redesign

## Known limitations / follow-up opportunities

- stronger recommendation emphasis reduces visual neutrality across paid tiers
- canonical card order remains fixed, so emphasis relies on styling rather than card position
- prompt-driven conversion remains a secondary path and was intentionally left unchanged in this mission