### PR TITLE
feat: add pricing strategy reinforcement v1

### DIFF
--- a/rentchain-frontend/src/components/billing/BillingPlansPanel.test.tsx
+++ b/rentchain-frontend/src/components/billing/BillingPlansPanel.test.tsx
@@ -35,7 +35,7 @@ describe("BillingPlansPanel", () => {
 
     expect(screen.getByText("Current")).toBeInTheDocument();
     expect(screen.getByText("Selected from pricing")).toBeInTheDocument();
-    expect(screen.getByText("Operational control, exports, and reporting")).toBeInTheDocument();
+    expect(screen.getAllByText("Operations and reporting").length).toBeGreaterThan(0);
     expect(
       screen.getByText("Selected from pricing. Opens secure checkout for the Pro plan you already chose.")
     ).toBeInTheDocument();
@@ -65,10 +65,10 @@ describe("BillingPlansPanel", () => {
     );
 
     expect(screen.getByText("Recommended next step")).toBeInTheDocument();
-    expect(screen.getAllByText("Portfolio intelligence, insights, and oversight").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Operations and reporting").length).toBeGreaterThan(0);
     expect(
       screen.getByText(
-        "Recommended next step based on your current plan. Opens secure checkout for Operational control, exports, and reporting."
+        "Recommended next step based on your current plan. Opens secure checkout for operations and reporting."
       )
     ).toBeInTheDocument();
   });

--- a/rentchain-frontend/src/components/billing/BillingPlansPanel.tsx
+++ b/rentchain-frontend/src/components/billing/BillingPlansPanel.tsx
@@ -6,21 +6,10 @@ import { getVisiblePlans, type PlanKey } from "@/billing/planVisibility";
 import { normalizePlan } from "@/lib/plan";
 import {
   CANONICAL_TIER_MATRIX,
+  TIER_POSITIONING_COPY,
   TIER_MATRIX_AREAS,
   type PricingPlanKey,
 } from "@/constants/pricingPlans";
-
-const PLAN_IDENTITY_COPY: Record<Exclude<PricingPlanKey, "free">, string> = {
-  starter: "Workflow foundation for weekly rental operations",
-  pro: "Operational control, exports, and reporting",
-  elite: "Portfolio intelligence, insights, and oversight",
-};
-
-const PLAN_SUPPORT_COPY: Record<Exclude<PricingPlanKey, "free">, string> = {
-  starter: "Best when you want one place to keep applicant, tenant, and property work connected.",
-  pro: "Best when you need cleaner reporting, stronger coordination, and easier operational follow-through.",
-  elite: "Best when you need portfolio-level visibility, analytics, and higher-confidence oversight.",
-};
 
 type Props = {
   pricing: any | null;
@@ -104,9 +93,9 @@ export function BillingPlansPanel({
       return `Selected from pricing. Opens secure checkout for the ${CANONICAL_TIER_MATRIX[planKey].label} plan you already chose.`;
     }
     if (isRecommended) {
-      return `Recommended next step based on your current plan. Opens secure checkout for ${PLAN_IDENTITY_COPY[planKey]}.`;
+      return `Recommended next step based on your current plan. Opens secure checkout for ${TIER_POSITIONING_COPY[planKey].badge.toLowerCase()}.`;
     }
-    return `Opens secure checkout so you can review and confirm ${PLAN_IDENTITY_COPY[planKey]}.`;
+    return `Opens secure checkout so you can review and confirm ${TIER_POSITIONING_COPY[planKey].badge.toLowerCase()}.`;
   };
 
   return (
@@ -161,7 +150,7 @@ export function BillingPlansPanel({
                   {plan.tagline}
                 </div>
                 <div style={{ marginTop: 4, fontSize: 12, fontWeight: 700, color: text.secondary }}>
-                  {PLAN_IDENTITY_COPY[planId]}
+                  {TIER_POSITIONING_COPY[planId].badge}
                 </div>
               </div>
               {highlight ? (
@@ -178,7 +167,7 @@ export function BillingPlansPanel({
             </div>
 
             <div style={{ color: text.muted, fontSize: 12, lineHeight: 1.55 }}>
-              {PLAN_SUPPORT_COPY[planId]}
+              {TIER_POSITIONING_COPY[planId].support}
             </div>
 
             <ul

--- a/rentchain-frontend/src/constants/pricingPlans.ts
+++ b/rentchain-frontend/src/constants/pricingPlans.ts
@@ -41,6 +41,13 @@ export type TierMatrixPlan = PricingPlan & {
   capabilities: Record<TierCapabilityArea, TierCapabilityEntry>;
 };
 
+export type TierPositioning = {
+  badge: string;
+  audience: string;
+  support: string;
+  nextStepReason?: string;
+};
+
 export const TIER_MATRIX_AREAS: Array<{ key: TierCapabilityArea; label: string }> = [
   { key: "properties_units", label: "Properties / units" },
   { key: "applications", label: "Applications" },
@@ -55,6 +62,35 @@ export const TIER_MATRIX_AREAS: Array<{ key: TierCapabilityArea; label: string }
   { key: "automation", label: "Automation" },
   { key: "team_admin_tools", label: "Team / admin tools" },
 ];
+
+export const TIER_POSITIONING_COPY: Record<Exclude<PricingPlanKey, "free">, TierPositioning> = {
+  starter: {
+    badge: "Workflow foundation",
+    audience: "For landlords who need one place to run the weekly rental workflow across active rentals.",
+    support:
+      "Starter is the first paid plan built to keep applicant, tenant, and property work together in one operating flow.",
+    nextStepReason:
+      "Starter is the clearest move into the workflow foundation for active rental operations.",
+  },
+  pro: {
+    badge: "Operations and reporting",
+    audience:
+      "For operators who need stronger operational control, cleaner reporting, and better handoff between people and tasks.",
+    support:
+      "Pro is the step up when operational complexity starts growing and you need exports, reporting, and stronger coordination.",
+    nextStepReason:
+      "Pro is the next logical step when you need stronger operational control, cleaner reporting, and better coordination as work gets busier.",
+  },
+  elite: {
+    badge: "Insights and oversight",
+    audience:
+      "For portfolios that need insight-led oversight, portfolio trends, and higher-confidence decisions.",
+    support:
+      "Elite is for teams that want portfolio-level visibility, intelligence, and higher-confidence oversight on top of Pro.",
+    nextStepReason:
+      "Elite is the next logical step when you need portfolio intelligence, analytics, and oversight that sit above the operational tools already in Pro.",
+  },
+};
 
 // Canonical pricing and capability matrix used by /pricing and /billing.
 // It mirrors the current commercial truth from backend billing prices plus
@@ -98,7 +134,7 @@ export const CANONICAL_TIER_MATRIX: Record<PricingPlanKey, TierMatrixPlan> = {
     label: "Starter",
     monthlyPrice: "$29",
     yearlyPrice: "$290",
-    tagline: "Best for active landlords running day-to-day rental operations.",
+    tagline: "Best for workflow foundation across day-to-day rental operations.",
     ctaLabel: "Upgrade to Starter",
     features: [
       "Tenant invites and linked applications",
@@ -127,7 +163,7 @@ export const CANONICAL_TIER_MATRIX: Record<PricingPlanKey, TierMatrixPlan> = {
     label: "Pro",
     monthlyPrice: "$49",
     yearlyPrice: "$490",
-    tagline: "Best for growing portfolios that need exports, reporting, and team workflows.",
+    tagline: "Best for operational control, exports, and reporting as complexity grows.",
     ctaLabel: "Upgrade to Pro",
     features: [
       "CSV, spreadsheet, and PDF export paths",
@@ -156,7 +192,7 @@ export const CANONICAL_TIER_MATRIX: Record<PricingPlanKey, TierMatrixPlan> = {
     label: "Elite",
     monthlyPrice: "$79",
     yearlyPrice: "$790",
-    tagline: "Best for premium visibility, audit depth, and advanced portfolio oversight.",
+    tagline: "Best for portfolio intelligence, analytics, and advanced oversight.",
     ctaLabel: "Upgrade to Elite",
     features: [
       "Advanced exports and audit visibility",

--- a/rentchain-frontend/src/pages/BillingPage.test.tsx
+++ b/rentchain-frontend/src/pages/BillingPage.test.tsx
@@ -121,6 +121,11 @@ describe("BillingPage", () => {
     await waitFor(() =>
       expect(screen.getByText(/Pricing selection saved: Pro on the Yearly plan/i)).toBeInTheDocument()
     );
+    expect(
+      screen.getByText(
+        /Starter gives you the workflow foundation, Pro adds operational control and reporting, and Elite adds portfolio intelligence and oversight/i
+      )
+    ).toBeInTheDocument();
     expect(screen.getByText(/Recommended next plan: Pro from your pricing selection/i)).toBeInTheDocument();
     expect(screen.getAllByRole("button", { name: "Continue to Pro checkout" }).length).toBeGreaterThan(0);
     expect(mocks.billingPlansPanelMock).toHaveBeenCalledWith(

--- a/rentchain-frontend/src/pages/BillingPage.tsx
+++ b/rentchain-frontend/src/pages/BillingPage.tsx
@@ -17,7 +17,7 @@ import { apiFetch } from "@/lib/apiClient";
 import { track } from "@/lib/analytics";
 import { billingTierLabel, useBillingStatus } from "@/hooks/useBillingStatus";
 import { refreshEntitlements } from "@/lib/entitlements";
-import { CANONICAL_TIER_MATRIX } from "@/constants/pricingPlans";
+import { CANONICAL_TIER_MATRIX, TIER_POSITIONING_COPY } from "@/constants/pricingPlans";
 
 const formatAmount = (amountCents: number, currency: string) => {
   const amount = (amountCents || 0) / 100;
@@ -253,11 +253,11 @@ const BillingPage: React.FC = () => {
     : null;
   const recommendedUpgradeReason =
     resolvedCurrentPlan === "free"
-      ? "Starter is the first paid plan and the clearest move into the full workflow foundation for active rental operations."
+      ? TIER_POSITIONING_COPY.starter.nextStepReason || null
       : resolvedCurrentPlan === "starter"
-        ? "Pro is the next logical step when you need stronger operational control, cleaner reporting, and better coordination as work gets busier."
+        ? TIER_POSITIONING_COPY.pro.nextStepReason || null
         : resolvedCurrentPlan === "pro"
-          ? "Elite is the next logical step when you need portfolio intelligence, analytics, and oversight that sit above the operational tools already in Pro."
+          ? TIER_POSITIONING_COPY.elite.nextStepReason || null
           : null;
 
   return (
@@ -286,6 +286,9 @@ const BillingPage: React.FC = () => {
                 {requestedUpgradePlan ? " from your pricing selection." : "."}
               </div>
             ) : null}
+            <div style={{ color: text.muted, fontSize: "0.9rem", marginTop: 6 }}>
+              Starter gives you the workflow foundation, Pro adds operational control and reporting, and Elite adds portfolio intelligence and oversight.
+            </div>
           </div>
           <div className="rc-wrap-row">
             <Button type="button" variant="secondary" onClick={load} disabled={loading}>

--- a/rentchain-frontend/src/pages/PricingPage.test.tsx
+++ b/rentchain-frontend/src/pages/PricingPage.test.tsx
@@ -78,6 +78,11 @@ describe("PricingPage analytics", () => {
         route: "/",
       })
     );
+    expect(
+      screen.getByText(
+        /Starter gives you the workflow foundation, Pro adds operational control and reporting, and Elite adds portfolio intelligence and oversight/i
+      )
+    ).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Annual" }));
 

--- a/rentchain-frontend/src/pages/PricingPage.tsx
+++ b/rentchain-frontend/src/pages/PricingPage.tsx
@@ -10,6 +10,7 @@ import {
   CANONICAL_TIER_MATRIX,
   DEFAULT_PLANS,
   PLAN_ORDER,
+  TIER_POSITIONING_COPY,
   TIER_MATRIX_AREAS,
   type PricingInterval,
   type PricingPlanKey,
@@ -33,28 +34,6 @@ const wrappingTextStyle: React.CSSProperties = {
 const PLAN_FEATURES: Record<PlanKey, string[]> = Object.fromEntries(
   DEFAULT_PLANS.map((plan) => [plan.key, plan.features])
 ) as Record<PlanKey, string[]>;
-
-const PLAN_AUDIENCE_COPY: Record<PlanKey, string> = {
-  free: "For landlords getting started with one property and wanting to try the basics.",
-  starter: "For landlords who need one place to run the weekly rental workflow across active rentals.",
-  pro: "For operators who need stronger operational control, cleaner reporting, and better handoff between people and tasks.",
-  elite: "For portfolios that need insight-led oversight, portfolio trends, and higher-confidence decisions.",
-};
-
-const PLAN_BADGE_COPY: Partial<Record<PlanKey, string>> = {
-  starter: "Workflow foundation",
-  pro: "Operations and reporting",
-  elite: "Insights and oversight",
-};
-
-const PLAN_SUPPORT_COPY: Partial<Record<PlanKey, string>> = {
-  starter:
-    "Free helps you get started. Starter is the first plan built to keep applicant, tenant, and property work together in one operating flow.",
-  pro:
-    "Pro is the step up when operational complexity starts growing and you need exports, reporting, and stronger internal coordination.",
-  elite:
-    "Elite is for teams that want portfolio-level visibility, intelligence, and higher-confidence oversight on top of the operational tools in Pro.",
-};
 
 const PLAN_CALLOUT_COPY: Partial<
   Record<
@@ -283,6 +262,9 @@ const PricingPage: React.FC = () => {
           <p style={{ marginTop: spacing.xs, color: text.muted, maxWidth: 760, lineHeight: 1.65 }}>
             Plan prices below match the live checkout pricing when billing is available.
           </p>
+          <p style={{ marginTop: spacing.xs, color: text.secondary, maxWidth: 760, lineHeight: 1.65, fontWeight: 600 }}>
+            Starter gives you the workflow foundation, Pro adds operational control and reporting, and Elite adds portfolio intelligence and oversight.
+          </p>
         </Card>
 
         <div
@@ -363,7 +345,7 @@ const PricingPage: React.FC = () => {
                 <div style={{ fontWeight: 800, fontSize: 20, lineHeight: 1.15, ...wrappingTextStyle }}>
                   {CANONICAL_TIER_MATRIX[plan].label}
                 </div>
-                {PLAN_BADGE_COPY[plan] ? (
+                {plan !== "free" ? (
                   <span
                     style={{
                       border:
@@ -386,13 +368,15 @@ const PricingPage: React.FC = () => {
                         plan === "pro" || plan === "elite" ? "0 8px 20px rgba(37,99,235,0.12)" : "none",
                     }}
                   >
-                    {PLAN_BADGE_COPY[plan]}
+                    {TIER_POSITIONING_COPY[plan].badge}
                   </span>
                 ) : null}
               </div>
               <div style={{ fontSize: 26, fontWeight: 800, lineHeight: 1.05, ...wrappingTextStyle }}>{renderPrice(plan)}</div>
               <div style={{ color: text.muted, fontSize: 14, lineHeight: 1.65, minHeight: 68, ...wrappingTextStyle }}>
-                {PLAN_AUDIENCE_COPY[plan]}
+                {plan === "free"
+                  ? "For landlords getting started with one property and wanting to try the basics."
+                  : TIER_POSITIONING_COPY[plan].audience}
               </div>
               <ul
                 style={{
@@ -412,7 +396,7 @@ const PricingPage: React.FC = () => {
                   </li>
                 ))}
               </ul>
-              {plan === "starter" && PLAN_SUPPORT_COPY[plan] ? (
+              {plan !== "free" ? (
                 <div
                   style={{
                     color: text.muted,
@@ -427,7 +411,7 @@ const PricingPage: React.FC = () => {
                     ...wrappingTextStyle,
                   }}
                 >
-                  {PLAN_SUPPORT_COPY[plan]}
+                  {TIER_POSITIONING_COPY[plan].support}
                 </div>
               ) : null}
               {plan === "pro" || plan === "elite" ? (

--- a/rentchain-frontend/src/pages/marketing/PricingPage.test.tsx
+++ b/rentchain-frontend/src/pages/marketing/PricingPage.test.tsx
@@ -85,6 +85,11 @@ describe("Marketing PricingPage analytics", () => {
         route: "/",
       })
     );
+    expect(
+      screen.getByText(
+        /Starter gives you the workflow foundation, Pro adds operational control and reporting, and Elite adds portfolio intelligence and oversight/i
+      )
+    ).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Annual" }));
 

--- a/rentchain-frontend/src/pages/marketing/PricingPage.tsx
+++ b/rentchain-frontend/src/pages/marketing/PricingPage.tsx
@@ -9,6 +9,7 @@ import {
   CANONICAL_TIER_MATRIX,
   DEFAULT_PLANS,
   PLAN_ORDER,
+  TIER_POSITIONING_COPY,
   type PricingInterval,
   type PricingPlanKey,
 } from "../../constants/pricingPlans";
@@ -55,28 +56,6 @@ function buildBillingUpgradePath(target: Exclude<PlanKey, "free">, interval: Pri
   });
   return `/billing?${params.toString()}`;
 }
-
-const PLAN_AUDIENCE_COPY: Record<PlanKey, string> = {
-  free: "For landlords getting started and wanting to try the basics with one property.",
-  starter: "For landlords who need one place to run the weekly rental workflow across active units.",
-  pro: "For operators who need stronger operational control, cleaner reporting, and better handoff across tasks and people.",
-  elite: "For portfolios that need insight-led oversight, portfolio trends, and higher-confidence decisions.",
-};
-
-const PLAN_SUPPORT_COPY: Partial<Record<PlanKey, string>> = {
-  starter:
-    "Free helps you get started. Starter is the first plan built to keep applicant, tenant, and property work together in one operating flow.",
-  pro:
-    "Pro is the step up when operational complexity starts growing and you need exports, reporting, and stronger coordination.",
-  elite:
-    "Elite is for teams that want portfolio-level visibility, intelligence, and higher-confidence oversight on top of Pro.",
-};
-
-const PLAN_BADGE_COPY: Partial<Record<PlanKey, string>> = {
-  starter: "Workflow foundation",
-  pro: "Operations and reporting",
-  elite: "Insights and oversight",
-};
 
 const PLAN_CALLOUT_COPY: Partial<
   Record<
@@ -327,6 +306,9 @@ const PricingPage: React.FC = () => {
           <p style={{ margin: `${spacing.xs} 0 0`, color: text.muted, fontSize: "0.92rem" }}>
             Start on Free to try the basics, move to Starter for daily rental work, step up to Pro for stronger control, and use Elite for deeper portfolio oversight.
           </p>
+          <p style={{ margin: `${spacing.xs} 0 0`, color: text.secondary, fontSize: "0.92rem", fontWeight: 600 }}>
+            Starter gives you the workflow foundation, Pro adds operational control and reporting, and Elite adds portfolio intelligence and oversight.
+          </p>
         </div>
 
         <div
@@ -419,7 +401,7 @@ const PricingPage: React.FC = () => {
                 <div style={{ fontSize: 21, fontWeight: 800, lineHeight: 1.15, ...wrappingTextStyle }}>
                   {copy.pricing.tierLabels[plan]}
                 </div>
-                {PLAN_BADGE_COPY[plan] ? (
+                {plan !== "free" ? (
                   <span
                     style={{
                       border:
@@ -438,12 +420,14 @@ const PricingPage: React.FC = () => {
                       ...wrappingTextStyle,
                     }}
                   >
-                    {PLAN_BADGE_COPY[plan]}
+                    {TIER_POSITIONING_COPY[plan].badge}
                   </span>
                 ) : null}
               </div>
               <div style={{ color: text.muted, fontSize: "0.94rem", lineHeight: 1.65, minHeight: isMobile ? "auto" : 62, ...wrappingTextStyle }}>
-                {PLAN_AUDIENCE_COPY[plan]}
+                {plan === "free"
+                  ? "For landlords getting started and wanting to try the basics with one property."
+                  : TIER_POSITIONING_COPY[plan].audience}
               </div>
               <div style={{ fontSize: 28, fontWeight: 800, lineHeight: 1.05, ...wrappingTextStyle }}>{renderPrice(plan)}</div>
               <ul
@@ -507,7 +491,7 @@ const PricingPage: React.FC = () => {
                   ) : null}
                 </div>
               ) : null}
-              {plan === "starter" && PLAN_SUPPORT_COPY[plan] ? (
+              {plan !== "free" ? (
                 <div
                   style={{
                     color: text.muted,
@@ -520,7 +504,7 @@ const PricingPage: React.FC = () => {
                     ...wrappingTextStyle,
                   }}
                 >
-                  {PLAN_SUPPORT_COPY[plan]}
+                  {TIER_POSITIONING_COPY[plan].support}
                 </div>
               ) : null}
               <div style={{ marginTop: isMobile ? spacing.sm : "auto", paddingTop: spacing.sm, width: "100%" }}>


### PR DESCRIPTION
## Summary

Implements Pricing Strategy Reinforcement v1 by centralizing the paid-tier positioning story and applying it consistently across Pricing and Billing surfaces.

This reinforces the Starter → Pro → Elite progression without changing pricing values, entitlements, upgrade flow, or backend behavior.

## What changed

### Shared pricing strategy
- Centralized paid-tier positioning in:
  - `rentchain-frontend/src/constants/pricingPlans.ts`
- The shared ladder now consistently communicates:
  - Starter = workflow foundation
  - Pro = operations and reporting
  - Elite = insights and oversight

### Pricing surfaces
- Updated both Pricing pages to use the same ladder framing
- Added a short ladder-summary line so progression is explicit instead of implied

### Billing surfaces
- Updated Billing and BillingPlansPanel to use the same shared ladder copy for:
  - recommended-upgrade rationale
  - plan identity labels
  - support copy under each plan
  - CTA support text

## Files changed

- `rentchain-frontend/src/components/billing/BillingPlansPanel.test.tsx`
- `rentchain-frontend/src/components/billing/BillingPlansPanel.tsx`
- `rentchain-frontend/src/constants/pricingPlans.ts`
- `rentchain-frontend/src/pages/BillingPage.test.tsx`
- `rentchain-frontend/src/pages/BillingPage.tsx`
- `rentchain-frontend/src/pages/PricingPage.test.tsx`
- `rentchain-frontend/src/pages/PricingPage.tsx`
- `rentchain-frontend/src/pages/marketing/PricingPage.test.tsx`
- `rentchain-frontend/src/pages/marketing/PricingPage.tsx`

## Verification

### Frontend
- `npm run test -- src/pages/BillingPage.test.tsx src/components/billing/BillingPlansPanel.test.tsx src/pages/PricingPage.test.tsx src/pages/marketing/PricingPage.test.tsx`
- `npm run build`

## Why this change was made

Recent optimization work established that:
- Pricing → Billing → Upgrade is the primary live conversion path
- Billing is the strongest conversion surface
- plan differentiation has improved, but the progression story still needed stronger alignment

This mission reinforces the pricing strategy so Pricing and Billing now tell the same coherent ladder story.

## Important note

Pricing strategy and the paid-plan ladder are now centralized and consistent across Pricing and Billing surfaces.

The funnel remains stable while the progression story becomes easier to understand from one shared source of truth.

## Intentionally unchanged

- no pricing value changes
- no entitlement changes
- no backend changes
- no checkout flow changes
- no analytics changes

## Known limitations / follow-up opportunities

- this is still a messaging/positioning reinforcement, not a feature-structure redesign
- users still need to read some support copy to absorb the ladder fully
- prompt-system copy was intentionally left out of scope in this mission