### PR TITLE
feat: add prompt activation strategy v1

### DIFF
--- a/rentchain-frontend/src/components/billing/FeatureGate.test.tsx
+++ b/rentchain-frontend/src/components/billing/FeatureGate.test.tsx
@@ -42,6 +42,10 @@ describe("FeatureGate", () => {
 
     expect(screen.getByText("Move-In Readiness is available on Starter")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Upgrade to Starter" })).toBeInTheDocument();
+    expect(screen.getByText("Available on Starter")).toBeInTheDocument();
+    expect(
+      screen.getByText("Opens a quick upgrade prompt first. Checkout only begins if you choose to continue.")
+    ).toBeInTheDocument();
     expect(screen.queryByText("Full feature")).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/components/billing/FeatureTeaser.tsx
+++ b/rentchain-frontend/src/components/billing/FeatureTeaser.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 import { radius, spacing, text } from "@/styles/tokens";
 import { UpgradeCTA } from "./UpgradeCTA";
+import { getUpgradeCopy } from "@/billing/upgradeCopy";
+import { normalizePlanLabel } from "@/billing/planLabel";
+import { resolveRequiredPlan } from "@/lib/upgradePrompt";
 
 type Props = {
   featureKey: string;
@@ -11,6 +14,10 @@ type Props = {
 };
 
 export function FeatureTeaser({ featureKey, eyebrow, title, description, ctaLabel }: Props) {
+  const copy = getUpgradeCopy(featureKey);
+  const requiredPlanLabel = normalizePlanLabel(resolveRequiredPlan(featureKey) || "pro");
+  const valueBullets = copy.bullets?.slice(0, 2) || [];
+
   return (
     <section
       style={{
@@ -29,7 +36,15 @@ export function FeatureTeaser({ featureKey, eyebrow, title, description, ctaLabe
       ) : null}
       <div style={{ fontSize: 16, fontWeight: 800, color: text.primary }}>{title}</div>
       <div style={{ color: text.muted, fontSize: 14, lineHeight: 1.6 }}>{description}</div>
-      <div>
+      <div style={{ color: text.secondary, fontSize: 13, fontWeight: 700 }}>Unlocks on {requiredPlanLabel}</div>
+      {valueBullets.length ? (
+        <ul style={{ margin: 0, paddingLeft: "1.1rem", color: text.muted, fontSize: 13, lineHeight: 1.55, display: "grid", gap: 4 }}>
+          {valueBullets.map((bullet) => (
+            <li key={bullet}>{bullet}</li>
+          ))}
+        </ul>
+      ) : null}
+      <div style={{ display: "grid", gap: 8 }}>
         <UpgradeCTA
           featureKey={featureKey}
           label={ctaLabel}
@@ -37,6 +52,9 @@ export function FeatureTeaser({ featureKey, eyebrow, title, description, ctaLabe
           presentation="teaser"
           variant="secondary"
         />
+        <div style={{ color: text.muted, fontSize: 12, lineHeight: 1.5 }}>
+          Opens a quick upgrade prompt so you can review the fit before deciding whether to continue.
+        </div>
       </div>
     </section>
   );

--- a/rentchain-frontend/src/components/billing/LockedFeature.tsx
+++ b/rentchain-frontend/src/components/billing/LockedFeature.tsx
@@ -2,6 +2,9 @@ import React from "react";
 import { Card } from "../ui/Ui";
 import { radius, spacing, text } from "@/styles/tokens";
 import { UpgradeCTA } from "./UpgradeCTA";
+import { getUpgradeCopy } from "@/billing/upgradeCopy";
+import { normalizePlanLabel } from "@/billing/planLabel";
+import { resolveRequiredPlan } from "@/lib/upgradePrompt";
 
 type Props = {
   featureKey: string;
@@ -20,6 +23,10 @@ export function LockedFeature({
   ctaLabel,
   compact = false,
 }: Props) {
+  const copy = getUpgradeCopy(featureKey);
+  const requiredPlanLabel = normalizePlanLabel(resolveRequiredPlan(featureKey) || "pro");
+  const valueBullets = copy.bullets?.slice(0, compact ? 2 : 3) || [];
+
   return (
     <Card
       style={{
@@ -32,11 +39,32 @@ export function LockedFeature({
       }}
     >
       <div style={{ display: "grid", gap: 6 }}>
+        <div
+          style={{
+            fontSize: 11,
+            fontWeight: 800,
+            letterSpacing: "0.06em",
+            textTransform: "uppercase",
+            color: "#1d4ed8",
+          }}
+        >
+          Locked feature
+        </div>
         <div style={{ fontSize: compact ? 15 : 16, fontWeight: 800, color: text.primary }}>{title}</div>
         <div style={{ color: text.muted, fontSize: 14, lineHeight: 1.6 }}>{description}</div>
+        <div style={{ color: text.secondary, fontSize: 13, fontWeight: 700 }}>
+          Available on {requiredPlanLabel}
+        </div>
         {hint ? <div style={{ color: text.secondary, fontSize: 12 }}>{hint}</div> : null}
+        {valueBullets.length ? (
+          <ul style={{ margin: 0, paddingLeft: "1.1rem", color: text.muted, fontSize: 13, lineHeight: 1.55, display: "grid", gap: 4 }}>
+            {valueBullets.map((bullet) => (
+              <li key={bullet}>{bullet}</li>
+            ))}
+          </ul>
+        ) : null}
       </div>
-      <div>
+      <div style={{ display: "grid", gap: 8 }}>
         <UpgradeCTA
           featureKey={featureKey}
           label={ctaLabel}
@@ -44,6 +72,9 @@ export function LockedFeature({
           presentation="locked"
           variant="secondary"
         />
+        <div style={{ color: text.muted, fontSize: 12, lineHeight: 1.5 }}>
+          Opens a quick upgrade prompt first. Checkout only begins if you choose to continue.
+        </div>
       </div>
     </Card>
   );

--- a/rentchain-frontend/src/components/billing/UpgradePromptModal.test.tsx
+++ b/rentchain-frontend/src/components/billing/UpgradePromptModal.test.tsx
@@ -69,10 +69,14 @@ describe("UpgradePromptModal", () => {
           onClose={vi.fn()}
           featureKey="tenant_invites"
           currentPlan="free"
-          source="unit_test"
+          source="locked_feature"
         />
       </MemoryRouter>
     );
+
+    expect(
+      screen.getByText("This upgrade prompt opened because this feature is locked on your current plan.")
+    ).toBeInTheDocument();
 
     fireEvent.click(screen.getAllByRole("button", { name: "Not now" })[0]);
 
@@ -80,7 +84,7 @@ describe("UpgradePromptModal", () => {
       featureKey: "tenant_invites",
       currentPlan: "free",
       requiredPlan: "starter",
-      source: "unit_test",
+      source: "locked_feature",
       route: "/",
       presentation: "modal",
     });

--- a/rentchain-frontend/src/components/billing/UpgradePromptModal.tsx
+++ b/rentchain-frontend/src/components/billing/UpgradePromptModal.tsx
@@ -37,6 +37,12 @@ export function UpgradePromptModal({
   const title = copy.title;
   const subtitle = copy.subtitle;
   const bullets = copy.bullets?.slice(0, 3) || [];
+  const sourceContext =
+    source === "locked_feature"
+      ? `This upgrade prompt opened because this feature is locked on your current plan.`
+      : source === "feature_teaser"
+        ? `This upgrade prompt opened from a feature preview so you can review the upgrade before leaving the page.`
+        : null;
 
   const primaryRef = useRef<HTMLButtonElement | null>(null);
   const modalRef = useRef<HTMLDivElement | null>(null);
@@ -203,6 +209,9 @@ export function UpgradePromptModal({
 
           {copy.trustNote ? (
             <div style={{ fontSize: 12, color: "rgba(71,85,105,0.9)" }}>{copy.trustNote}</div>
+          ) : null}
+          {sourceContext ? (
+            <div style={{ fontSize: 12, color: "rgba(71,85,105,0.9)" }}>{sourceContext}</div>
           ) : null}
 
           <div className="rc-wrap-row">


### PR DESCRIPTION
## Summary

Implements Prompt Activation Strategy v1 by improving the clarity and continuity of existing prompt-entry surfaces without changing the primary Pricing → Billing → Upgrade path.

This mission strengthens secondary upgrade entry points by making locked/teaser states easier to understand and making it clearer that the CTA opens an upgrade prompt before checkout.

## What changed

### Locked / teaser entry surfaces
- Improved `LockedFeature` and `FeatureTeaser` so they now explain:
  - what is gated
  - which plan unlocks it
  - why the feature matters
- Added clearer support copy under prompt-entry CTAs so users understand the next step before clicking

### Upgrade prompt modal
- Updated `UpgradePromptModal` to better reflect locked/teaser source context
- Reduced the “why did this open?” feeling by improving continuity between the entry surface and the modal

### Tests
- Added focused frontend coverage for the updated prompt-entry behavior and modal continuity

## Files changed

- `rentchain-frontend/src/components/billing/LockedFeature.tsx`
- `rentchain-frontend/src/components/billing/FeatureTeaser.tsx`
- `rentchain-frontend/src/components/billing/UpgradePromptModal.tsx`
- `rentchain-frontend/src/components/billing/UpgradePromptModal.test.tsx`
- `rentchain-frontend/src/components/billing/FeatureGate.test.tsx`

## Verification

### Frontend
- targeted frontend tests passed
- `npm run build`

## Why this change was made

Live funnel work showed that:

- Pricing → Billing → Upgrade is still the main conversion path
- prompt-driven upgrade events are underused
- locked/teaser surfaces exist, but their upgrade prompts were not yet clearly activated

This mission improves those secondary surfaces without disrupting the stronger primary funnel.

## Important note

Prompt-entry surfaces now:
- explain gated value more clearly
- explicitly show which plan unlocks the feature
- set expectation that the CTA opens an upgrade prompt first rather than sending the user directly into checkout

## Intentionally unchanged

- no backend changes
- no pricing model changes
- no billing routing changes
- no checkout flow changes
- no prompt-system architecture rewrite

## Known limitations / follow-up opportunities

- this mission improves only existing secondary prompt-entry surfaces
- surfaces that use `UpgradeCTA` directly outside `LockedFeature` / `FeatureTeaser` still rely more on local page context
- prompt activation remains a secondary path and should continue to be evaluated against the stronger Pricing → Billing funnel