### PR TITLE
feat: add real-user validation v1

### DIFF
--- a/rentchain-api/src/routes/__tests__/adminSubscriptionConversionValidationRoute.test.ts
+++ b/rentchain-api/src/routes/__tests__/adminSubscriptionConversionValidationRoute.test.ts
@@ -1,0 +1,214 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const loadAdminSubscriptionConversionFunnel = vi.fn();
+const loadAdminSubscriptionConversionInsights = vi.fn();
+const loadAdminSubscriptionConversionValidation = vi.fn();
+
+vi.mock("../../middleware/requireAdmin", () => ({
+  requireAdmin: (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock("../../services/admin/adminSubscriptionConversionView", () => ({
+  loadAdminSubscriptionConversionFunnel,
+}));
+
+vi.mock("../../services/admin/adminSubscriptionConversionInsights", () => ({
+  loadAdminSubscriptionConversionInsights,
+}));
+
+vi.mock("../../services/admin/adminSubscriptionConversionValidation", () => ({
+  loadAdminSubscriptionConversionValidation,
+}));
+
+vi.mock("../../config/firebase", () => ({
+  db: {
+    collection: vi.fn(() => ({
+      where: vi.fn(),
+      doc: vi.fn(() => ({ set: vi.fn() })),
+    })),
+  },
+}));
+
+vi.mock("../../services/telemetryService", () => ({
+  getCountersSummary: vi.fn(async () => ({ byName: {} })),
+}));
+
+vi.mock("../../services/stripeService", () => ({
+  isStripeConfigured: () => false,
+  getStripeClient: () => {
+    throw new Error("not configured");
+  },
+}));
+
+vi.mock("firebase-admin", () => ({
+  default: {
+    auth: () => ({ createUser: vi.fn() }),
+    firestore: {
+      FieldValue: {
+        serverTimestamp: () => Date.now(),
+      },
+    },
+  },
+}));
+
+async function createRouter() {
+  return (await import("../adminRoutes")).default;
+}
+
+async function invokeRouter(
+  router: any,
+  options: {
+    method: string;
+    url: string;
+    body?: any;
+  }
+) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const req: any = {
+      method: options.method,
+      url: options.url.replace(/^\/api\/admin/, ""),
+      originalUrl: options.url,
+      path: options.url.replace(/^\/api\/admin/, "").split("?")[0],
+      query: {},
+      body: options.body ?? {},
+      user: { id: "admin-1", role: "admin" },
+      cookies: {},
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, any>,
+      setHeader(name: string, value: any) {
+        this.headers[name.toLowerCase()] = value;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    const [, rawQuery] = options.url.split("?");
+    if (rawQuery) {
+      req.query = Object.fromEntries(new URLSearchParams(rawQuery).entries());
+    }
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("GET /api/admin/analytics/conversion-validation", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    loadAdminSubscriptionConversionFunnel.mockReset();
+    loadAdminSubscriptionConversionInsights.mockReset();
+    loadAdminSubscriptionConversionValidation.mockReset();
+  });
+
+  it("returns the admin conversion validation payload", async () => {
+    loadAdminSubscriptionConversionValidation.mockResolvedValue({
+      window: { days: 30, from: "2026-03-19T00:00:00.000Z", to: "2026-04-18T00:00:00.000Z" },
+      segmentation: {
+        strategy: "heuristic_actor_pattern_v1",
+        buckets: {
+          all_activity: { description: "All Mission 29-style conversion events in the bounded window." },
+          likely_internal_or_test: { description: "Testing-like activity." },
+          likely_external_or_real: { description: "Directional external activity." },
+        },
+        caveats: ["Heuristic only."],
+      },
+      segments: {
+        all_activity: {
+          window: { days: 30, from: "2026-03-19T00:00:00.000Z", to: "2026-04-18T00:00:00.000Z" },
+          eventCount: 12,
+          actorCount: 2,
+          funnel: [{ step: "pricing_page_viewed", count: 2 }],
+          breakdowns: {
+            targetPlan: { starter: 2 },
+            surface: { billing_page: 2 },
+            source: { billing_page: 2 },
+          },
+          insights: {
+            strongestSurface: { surface: "billing_page", count: 2 },
+            strongestPlanInterest: { targetPlan: "starter", count: 2 },
+            weakestFunnelStep: { step: "pricing_page_viewed -> pricing_plan_cta_clicked", conversion: 0.5 },
+            strongestFeatureSignal: null,
+            promptViewCount: 0,
+          },
+        },
+        likely_internal_or_test: {
+          window: { days: 30, from: "2026-03-19T00:00:00.000Z", to: "2026-04-18T00:00:00.000Z" },
+          eventCount: 8,
+          actorCount: 1,
+          funnel: [{ step: "pricing_page_viewed", count: 1 }],
+          breakdowns: {
+            targetPlan: { elite: 3 },
+            surface: { locked_feature: 3 },
+            source: { applications_page: 3 },
+          },
+          insights: {
+            strongestSurface: { surface: "locked_feature", count: 2 },
+            strongestPlanInterest: { targetPlan: "elite", count: 3 },
+            weakestFunnelStep: { step: "billing_page_opened -> billing_upgrade_clicked", conversion: 0.5 },
+            strongestFeatureSignal: null,
+            promptViewCount: 1,
+          },
+        },
+        likely_external_or_real: {
+          window: { days: 30, from: "2026-03-19T00:00:00.000Z", to: "2026-04-18T00:00:00.000Z" },
+          eventCount: 4,
+          actorCount: 1,
+          funnel: [{ step: "pricing_page_viewed", count: 1 }],
+          breakdowns: {
+            targetPlan: { starter: 2 },
+            surface: { billing_page: 2 },
+            source: { billing_page: 2 },
+          },
+          insights: {
+            strongestSurface: { surface: "billing_page", count: 1 },
+            strongestPlanInterest: { targetPlan: "starter", count: 2 },
+            weakestFunnelStep: { step: "pricing_page_viewed -> pricing_plan_cta_clicked", conversion: 1 },
+            strongestFeatureSignal: null,
+            promptViewCount: 0,
+          },
+        },
+      },
+      comparisons: {
+        dominantSegment: { segment: "likely_internal_or_test", eventCount: 8 },
+        strongestSurfaceAlignment: {
+          allActivity: "billing_page",
+          likelyInternalOrTest: "locked_feature",
+          likelyExternalOrReal: "billing_page",
+        },
+      },
+      recommendations: ["Current funnel activity is dominated by likely internal or controlled testing traffic."],
+    });
+
+    const router = await createRouter();
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/api/admin/analytics/conversion-validation?days=30",
+    });
+
+    expect(res.status).toBe(200);
+    expect(loadAdminSubscriptionConversionValidation).toHaveBeenCalledWith({ days: "30" });
+    expect(res.body.ok).toBe(true);
+    expect(res.body.comparisons).toEqual({
+      dominantSegment: { segment: "likely_internal_or_test", eventCount: 8 },
+      strongestSurfaceAlignment: {
+        allActivity: "billing_page",
+        likelyInternalOrTest: "locked_feature",
+        likelyExternalOrReal: "billing_page",
+      },
+    });
+    expect(res.body.recommendations).toEqual([
+      "Current funnel activity is dominated by likely internal or controlled testing traffic.",
+    ]);
+  });
+});

--- a/rentchain-api/src/routes/adminRoutes.ts
+++ b/rentchain-api/src/routes/adminRoutes.ts
@@ -9,6 +9,7 @@ import { getTuReferralMetricsForMonth } from "../services/metrics/tuReferralRepo
 import { getPublicStatusPayload } from "../services/statusService";
 import { loadAdminSubscriptionConversionFunnel } from "../services/admin/adminSubscriptionConversionView";
 import { loadAdminSubscriptionConversionInsights } from "../services/admin/adminSubscriptionConversionInsights";
+import { loadAdminSubscriptionConversionValidation } from "../services/admin/adminSubscriptionConversionValidation";
 import {
   createStatusIncident,
   resolveStatusIncident,
@@ -859,6 +860,22 @@ router.get("/analytics/conversion-insights", requireAdmin, async (req, res) => {
   } catch (err: any) {
     console.error("[admin] conversion insights failed", err?.message || err);
     return res.status(500).json({ ok: false, error: "CONVERSION_INSIGHTS_FAILED" });
+  }
+});
+
+router.get("/analytics/conversion-validation", requireAdmin, async (req, res) => {
+  try {
+    const days = req.query?.days;
+    const payload = await loadAdminSubscriptionConversionValidation({
+      days: typeof days === "string" ? days : undefined,
+    });
+    return res.json({
+      ok: true,
+      ...payload,
+    });
+  } catch (err: any) {
+    console.error("[admin] conversion validation failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "CONVERSION_VALIDATION_FAILED" });
   }
 });
 

--- a/rentchain-api/src/services/__tests__/adminSubscriptionConversionValidation.test.ts
+++ b/rentchain-api/src/services/__tests__/adminSubscriptionConversionValidation.test.ts
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type StoredDoc = { id: string; data: any };
+
+const { dbMock, resetDb, seedDoc } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, StoredDoc>>();
+
+  function ensureCollection(name: string) {
+    if (!collections.has(name)) collections.set(name, new Map());
+    return collections.get(name)!;
+  }
+
+  function buildQuery(name: string, filters: Array<{ field: string; op: string; value: any }> = []) {
+    return {
+      where: (field: string, op: string, value: any) => buildQuery(name, [...filters, { field, op, value }]),
+      get: async () => {
+        let rows = Array.from(ensureCollection(name).values());
+        rows = rows.filter((entry) =>
+          filters.every((f) => {
+            const value = entry.data?.[f.field];
+            if (f.op === ">=") return Number(value || 0) >= Number(f.value);
+            if (f.op === "<=") return Number(value || 0) <= Number(f.value);
+            return true;
+          })
+        );
+        return {
+          empty: rows.length === 0,
+          docs: rows.map((row) => ({ id: row.id, data: () => row.data })),
+        };
+      },
+    };
+  }
+
+  return {
+    dbMock: {
+      collection: (name: string) => ({
+        where: (field: string, op: string, value: any) => buildQuery(name, [{ field, op, value }]),
+      }),
+    },
+    resetDb: () => {
+      collections.clear();
+    },
+    seedDoc: (collection: string, id: string, data: any) => {
+      ensureCollection(collection).set(id, { id, data });
+    },
+  };
+});
+
+vi.mock("../../config/firebase", () => ({
+  db: dbMock,
+}));
+
+describe("adminSubscriptionConversionValidation", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    resetDb();
+  });
+
+  it("splits aggregate conversion data into conservative validation segments", async () => {
+    const now = Date.now();
+    seedDoc("events", "real-1", {
+      name: "pricing_page_viewed",
+      ts: now - 4_000,
+      sessionId: "sess-real-1",
+      props: { surface: "marketing_pricing", source: "marketing_pricing" },
+    });
+    seedDoc("events", "real-2", {
+      name: "pricing_plan_cta_clicked",
+      ts: now - 3_000,
+      sessionId: "sess-real-1",
+      props: { targetPlan: "starter", surface: "marketing_pricing", source: "marketing_pricing" },
+    });
+    seedDoc("events", "real-3", {
+      name: "billing_page_opened",
+      ts: now - 2_000,
+      sessionId: "sess-real-1",
+      props: { surface: "billing_page", source: "billing_page" },
+    });
+    seedDoc("events", "real-4", {
+      name: "billing_upgrade_clicked",
+      ts: now - 1_000,
+      sessionId: "sess-real-1",
+      props: { targetPlan: "starter", surface: "billing_page", source: "billing_page" },
+    });
+
+    seedDoc("events", "test-1", {
+      name: "pricing_page_viewed",
+      ts: now - 900,
+      userId: "tester-1",
+      props: { surface: "workspace_pricing", source: "workspace_pricing" },
+    });
+    seedDoc("events", "test-2", {
+      name: "pricing_plan_cta_clicked",
+      ts: now - 800,
+      userId: "tester-1",
+      props: { targetPlan: "starter", surface: "workspace_pricing", source: "workspace_pricing" },
+    });
+    seedDoc("events", "test-3", {
+      name: "pricing_plan_cta_clicked",
+      ts: now - 700,
+      userId: "tester-1",
+      props: { targetPlan: "pro", surface: "workspace_pricing", source: "workspace_pricing" },
+    });
+    seedDoc("events", "test-4", {
+      name: "billing_page_opened",
+      ts: now - 600,
+      userId: "tester-1",
+      props: { surface: "billing_page", source: "billing_page" },
+    });
+    seedDoc("events", "test-5", {
+      name: "billing_upgrade_clicked",
+      ts: now - 500,
+      userId: "tester-1",
+      props: { targetPlan: "pro", surface: "billing_page", source: "billing_page" },
+    });
+    seedDoc("events", "test-6", {
+      name: "upgrade_cta_clicked",
+      ts: now - 400,
+      userId: "tester-1",
+      props: { targetPlan: "elite", surface: "locked_feature", source: "applications_page" },
+    });
+    seedDoc("events", "test-7", {
+      name: "upgrade_prompt_viewed",
+      ts: now - 300,
+      userId: "tester-1",
+      props: {
+        targetPlan: "elite",
+        surface: "locked_feature",
+        source: "applications_page",
+        featureKey: "tenant_invites",
+      },
+    });
+    seedDoc("events", "test-8", {
+      name: "upgrade_prompt_checkout_clicked",
+      ts: now - 200,
+      userId: "tester-1",
+      props: { targetPlan: "elite", surface: "locked_feature", source: "applications_page" },
+    });
+    seedDoc("events", "mixed-1", {
+      type: "application_submitted",
+      occurredAt: new Date(now - 100).toISOString(),
+      payload: {},
+    });
+
+    const { loadAdminSubscriptionConversionValidation } = await import(
+      "../admin/adminSubscriptionConversionValidation"
+    );
+    const result = await loadAdminSubscriptionConversionValidation({ days: 30 });
+
+    expect(result.segmentation.strategy).toBe("heuristic_actor_pattern_v1");
+    expect(result.segments.all_activity.eventCount).toBe(12);
+    expect(result.segments.likely_external_or_real.eventCount).toBe(4);
+    expect(result.segments.likely_external_or_real.actorCount).toBe(1);
+    expect(result.segments.likely_external_or_real.insights.strongestSurface).toEqual({
+      surface: "billing_page",
+      count: 1,
+    });
+    expect(result.segments.likely_internal_or_test.eventCount).toBe(8);
+    expect(result.segments.likely_internal_or_test.actorCount).toBe(1);
+    expect(result.segments.likely_internal_or_test.breakdowns.featureKey).toEqual({
+      tenant_invites: 1,
+    });
+    expect(result.comparisons.dominantSegment).toEqual({
+      segment: "likely_internal_or_test",
+      eventCount: 8,
+    });
+    expect(result.recommendations).toContain(
+      "Current funnel activity is dominated by likely internal or controlled testing traffic."
+    );
+    expect(result.recommendations).toContain(
+      "Billing remains the strongest surface across both all activity and likely external activity."
+    );
+    expect(result.recommendations).toContain(
+      "Prompt usage remains negligible outside likely internal or testing activity."
+    );
+    expect(result.segmentation.caveats).toHaveLength(3);
+  });
+
+  it("returns safe empty segment output when no matching analytics events exist", async () => {
+    const { loadAdminSubscriptionConversionValidation } = await import(
+      "../admin/adminSubscriptionConversionValidation"
+    );
+    const result = await loadAdminSubscriptionConversionValidation({ days: 7 });
+
+    expect(result.segments.all_activity.eventCount).toBe(0);
+    expect(result.segments.likely_internal_or_test.eventCount).toBe(0);
+    expect(result.segments.likely_external_or_real.eventCount).toBe(0);
+    expect(result.comparisons.dominantSegment).toBeNull();
+    expect(result.recommendations).toEqual([
+      "Prompt usage remains negligible outside likely internal or testing activity.",
+    ]);
+  });
+});

--- a/rentchain-api/src/services/admin/adminSubscriptionConversionValidation.ts
+++ b/rentchain-api/src/services/admin/adminSubscriptionConversionValidation.ts
@@ -1,0 +1,364 @@
+import {
+  buildSubscriptionConversionSummary,
+  loadAdminSubscriptionConversionDataset,
+  type ConversionEventRow,
+  type SubscriptionConversionSummary,
+} from "./adminSubscriptionConversionView";
+
+type FunnelStep = SubscriptionConversionSummary["funnel"][number];
+
+type RankedCount = {
+  key: string;
+  count: number;
+};
+
+type SegmentKey = "all_activity" | "likely_internal_or_test" | "likely_external_or_real";
+
+type SegmentInsights = {
+  strongestSurface: {
+    surface: string | null;
+    count: number;
+  };
+  strongestPlanInterest: {
+    targetPlan: string | null;
+    count: number;
+  };
+  weakestFunnelStep: {
+    step: string | null;
+    conversion: number | null;
+  };
+  strongestFeatureSignal: {
+    featureKey: string;
+    count: number;
+  } | null;
+  promptViewCount: number;
+};
+
+export type SubscriptionConversionValidationSegment = SubscriptionConversionSummary & {
+  eventCount: number;
+  actorCount: number;
+  breakdowns: SubscriptionConversionSummary["breakdowns"] & {
+    featureKey?: Record<string, number>;
+  };
+  insights: SegmentInsights;
+};
+
+export type SubscriptionConversionValidationPayload = {
+  window: SubscriptionConversionSummary["window"];
+  segmentation: {
+    strategy: "heuristic_actor_pattern_v1";
+    buckets: Record<SegmentKey, { description: string }>;
+    caveats: string[];
+  };
+  segments: Record<SegmentKey, SubscriptionConversionValidationSegment>;
+  comparisons: {
+    dominantSegment: {
+      segment: Exclude<SegmentKey, "all_activity">;
+      eventCount: number;
+    } | null;
+    strongestSurfaceAlignment: {
+      allActivity: string | null;
+      likelyInternalOrTest: string | null;
+      likelyExternalOrReal: string | null;
+    };
+  };
+  recommendations: string[];
+};
+
+const UPGRADE_INTENT_EVENT_NAMES = new Set([
+  "pricing_plan_cta_clicked",
+  "upgrade_cta_clicked",
+  "upgrade_prompt_checkout_clicked",
+  "billing_upgrade_clicked",
+]);
+
+function toBreakdownKey(value: unknown) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function incrementBucket(bucket: Record<string, number>, key: string | null) {
+  if (!key) return;
+  bucket[key] = (bucket[key] || 0) + 1;
+}
+
+function topBucket(bucket: Record<string, number>): RankedCount | null {
+  const entries = Object.entries(bucket);
+  if (!entries.length) return null;
+  entries.sort((a, b) => {
+    if (b[1] !== a[1]) return b[1] - a[1];
+    return a[0].localeCompare(b[0]);
+  });
+  return { key: entries[0][0], count: entries[0][1] };
+}
+
+function weakestFunnelStep(funnel: FunnelStep[]) {
+  const candidates = funnel
+    .map((step, index) => {
+      if (index === 0) return null;
+      if (typeof step.conversionFromPrevious !== "number") return null;
+      return {
+        step: `${funnel[index - 1].step} -> ${step.step}`,
+        conversion: step.conversionFromPrevious,
+      };
+    })
+    .filter((item): item is { step: string; conversion: number } => item != null);
+
+  if (!candidates.length) {
+    return { step: null, conversion: null };
+  }
+
+  candidates.sort((a, b) => {
+    if (a.conversion !== b.conversion) return a.conversion - b.conversion;
+    return a.step.localeCompare(b.step);
+  });
+  return candidates[0];
+}
+
+function buildFeatureBreakdown(rows: ConversionEventRow[]) {
+  const bucket: Record<string, number> = {};
+  for (const row of rows) {
+    incrementBucket(bucket, toBreakdownKey(row.props.featureKey));
+  }
+  return bucket;
+}
+
+function buildIntentSurfaceBreakdown(rows: ConversionEventRow[]) {
+  const bucket: Record<string, number> = {};
+  for (const row of rows) {
+    if (!UPGRADE_INTENT_EVENT_NAMES.has(row.name)) continue;
+    incrementBucket(bucket, toBreakdownKey(row.props.surface));
+  }
+  return bucket;
+}
+
+function buildSegmentInsights(params: {
+  rows: ConversionEventRow[];
+  breakdowns: SubscriptionConversionSummary["breakdowns"];
+  funnel: SubscriptionConversionSummary["funnel"];
+}): SegmentInsights {
+  const { rows, breakdowns, funnel } = params;
+  const featureKey = buildFeatureBreakdown(rows);
+  const strongestSurface = topBucket(buildIntentSurfaceBreakdown(rows));
+  const strongestPlanInterest = topBucket(breakdowns.targetPlan);
+  const strongestFeatureSignal = topBucket(featureKey);
+  const promptViewCount = funnel.find((step) => step.step === "upgrade_prompt_viewed")?.count || 0;
+
+  return {
+    strongestSurface: {
+      surface: strongestSurface?.key || null,
+      count: strongestSurface?.count || 0,
+    },
+    strongestPlanInterest: {
+      targetPlan: strongestPlanInterest?.key || null,
+      count: strongestPlanInterest?.count || 0,
+    },
+    weakestFunnelStep: weakestFunnelStep(funnel),
+    strongestFeatureSignal:
+      strongestFeatureSignal && strongestFeatureSignal.count > 0
+        ? {
+            featureKey: strongestFeatureSignal.key,
+            count: strongestFeatureSignal.count,
+          }
+        : null,
+    promptViewCount,
+  };
+}
+
+function buildSegmentSummary(params: {
+  rows: ConversionEventRow[];
+  days: number;
+  from: number;
+  to: number;
+  actorCount: number;
+}): SubscriptionConversionValidationSegment {
+  const { rows, days, from, to, actorCount } = params;
+  const summary = buildSubscriptionConversionSummary({ rows, days, from, to });
+  const featureKey = buildFeatureBreakdown(rows);
+
+  return {
+    ...summary,
+    eventCount: rows.length,
+    actorCount,
+    breakdowns: {
+      ...summary.breakdowns,
+      ...(Object.keys(featureKey).length ? { featureKey } : {}),
+    },
+    insights: buildSegmentInsights({
+      rows,
+      breakdowns: summary.breakdowns,
+      funnel: summary.funnel,
+    }),
+  };
+}
+
+type ActorStats = {
+  actorKey: string;
+  rows: ConversionEventRow[];
+  targetPlans: Set<string>;
+  eventNames: Set<string>;
+};
+
+function toActorKey(row: ConversionEventRow) {
+  if (row.userId) return `user:${row.userId}`;
+  if (row.sessionId) return `session:${row.sessionId}`;
+  return "unknown";
+}
+
+function classifyActor(stats: ActorStats): Exclude<SegmentKey, "all_activity"> {
+  if (stats.actorKey === "unknown") return "likely_internal_or_test";
+  if (stats.targetPlans.size >= 3) return "likely_internal_or_test";
+  if (stats.targetPlans.size >= 2 && stats.rows.length >= 8) return "likely_internal_or_test";
+  if (stats.rows.length >= 12 && stats.eventNames.size >= 5) return "likely_internal_or_test";
+  return "likely_external_or_real";
+}
+
+function buildActorStats(rows: ConversionEventRow[]) {
+  const actorMap = new Map<string, ActorStats>();
+  for (const row of rows) {
+    const actorKey = toActorKey(row);
+    const existing = actorMap.get(actorKey) || {
+      actorKey,
+      rows: [],
+      targetPlans: new Set<string>(),
+      eventNames: new Set<string>(),
+    };
+    existing.rows.push(row);
+    existing.eventNames.add(row.name);
+    const targetPlan = toBreakdownKey(row.props.targetPlan);
+    if (targetPlan) existing.targetPlans.add(targetPlan);
+    actorMap.set(actorKey, existing);
+  }
+  return Array.from(actorMap.values());
+}
+
+function buildRecommendations(payload: {
+  segments: Record<SegmentKey, SubscriptionConversionValidationSegment>;
+}) {
+  const recommendations: string[] = [];
+  const internal = payload.segments.likely_internal_or_test;
+  const external = payload.segments.likely_external_or_real;
+  const all = payload.segments.all_activity;
+
+  if (internal.eventCount > external.eventCount && internal.eventCount > 0) {
+    recommendations.push("Current funnel activity is dominated by likely internal or controlled testing traffic.");
+  }
+
+  if (
+    all.insights.strongestSurface.surface === "billing_page" &&
+    external.insights.strongestSurface.surface === "billing_page"
+  ) {
+    recommendations.push("Billing remains the strongest surface across both all activity and likely external activity.");
+  }
+
+  if (external.insights.promptViewCount <= 1) {
+    recommendations.push("Prompt usage remains negligible outside likely internal or testing activity.");
+  }
+
+  if (external.eventCount > 0 && external.eventCount < 10) {
+    recommendations.push("Treat likely external activity as directional until more non-test conversion volume accumulates.");
+  }
+
+  if (!recommendations.length) {
+    recommendations.push("Use the segment split as a confidence lens, not as authoritative identity truth.");
+  }
+
+  return Array.from(new Set(recommendations));
+}
+
+export async function loadAdminSubscriptionConversionValidation(params?: {
+  days?: number | string;
+}): Promise<SubscriptionConversionValidationPayload> {
+  const dataset = await loadAdminSubscriptionConversionDataset(params);
+  const from = Date.parse(dataset.window.from);
+  const to = Date.parse(dataset.window.to);
+  const actorStats = buildActorStats(dataset.rows);
+
+  const segmentedRows: Record<Exclude<SegmentKey, "all_activity">, ConversionEventRow[]> = {
+    likely_internal_or_test: [],
+    likely_external_or_real: [],
+  };
+  const actorCounts = {
+    likely_internal_or_test: 0,
+    likely_external_or_real: 0,
+  };
+
+  for (const stats of actorStats) {
+    const segment = classifyActor(stats);
+    segmentedRows[segment].push(...stats.rows);
+    actorCounts[segment] += 1;
+  }
+
+  const segments: Record<SegmentKey, SubscriptionConversionValidationSegment> = {
+    all_activity: buildSegmentSummary({
+      rows: dataset.rows,
+      days: dataset.window.days,
+      from,
+      to,
+      actorCount: actorStats.length,
+    }),
+    likely_internal_or_test: buildSegmentSummary({
+      rows: segmentedRows.likely_internal_or_test,
+      days: dataset.window.days,
+      from,
+      to,
+      actorCount: actorCounts.likely_internal_or_test,
+    }),
+    likely_external_or_real: buildSegmentSummary({
+      rows: segmentedRows.likely_external_or_real,
+      days: dataset.window.days,
+      from,
+      to,
+      actorCount: actorCounts.likely_external_or_real,
+    }),
+  };
+
+  const dominantSegment =
+    segments.likely_internal_or_test.eventCount === segments.likely_external_or_real.eventCount
+      ? null
+      : segments.likely_internal_or_test.eventCount > segments.likely_external_or_real.eventCount
+        ? {
+            segment: "likely_internal_or_test" as const,
+            eventCount: segments.likely_internal_or_test.eventCount,
+          }
+        : {
+            segment: "likely_external_or_real" as const,
+            eventCount: segments.likely_external_or_real.eventCount,
+          };
+
+  return {
+    window: dataset.window,
+    segmentation: {
+      strategy: "heuristic_actor_pattern_v1",
+      buckets: {
+        all_activity: {
+          description: "All Mission 29-style conversion events in the bounded window.",
+        },
+        likely_internal_or_test: {
+          description:
+            "Activity from actors showing repeated multi-plan or high-volume exploration patterns consistent with testing.",
+        },
+        likely_external_or_real: {
+          description:
+            "Remaining activity after conservative internal/testing heuristics are applied. This is directional, not authoritative identity truth.",
+        },
+      },
+      caveats: [
+        "Segmentation is heuristic and actor-pattern based, not verified identity truth.",
+        "The model is intentionally conservative and may leave some testing activity in likely_external_or_real.",
+        "Output is aggregate only and should be used as a confidence lens before making stronger optimization decisions.",
+      ],
+    },
+    segments,
+    comparisons: {
+      dominantSegment,
+      strongestSurfaceAlignment: {
+        allActivity: segments.all_activity.insights.strongestSurface.surface,
+        likelyInternalOrTest: segments.likely_internal_or_test.insights.strongestSurface.surface,
+        likelyExternalOrReal: segments.likely_external_or_real.insights.strongestSurface.surface,
+      },
+    },
+    recommendations: buildRecommendations({ segments }),
+  };
+}

--- a/rentchain-api/src/services/admin/adminSubscriptionConversionView.ts
+++ b/rentchain-api/src/services/admin/adminSubscriptionConversionView.ts
@@ -23,6 +23,8 @@ export type ConversionEventRow = {
   name: FunnelStepName;
   ts: number;
   props: EventProps;
+  userId: string | null;
+  sessionId: string | null;
 };
 
 export type SubscriptionConversionSummary = {
@@ -71,7 +73,19 @@ function incrementBucket(bucket: Record<string, number>, key: string | null) {
   bucket[key] = (bucket[key] || 0) + 1;
 }
 
-function isMission29ConversionEvent(data: any): data is { name: FunnelStepName; ts: number; props: EventProps } {
+function toOptionalString(value: unknown) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function isMission29ConversionEvent(data: any): data is {
+  name: FunnelStepName;
+  ts: number;
+  props: EventProps;
+  userId?: unknown;
+  sessionId?: unknown;
+} {
   if (!FUNNEL_STEP_SET.has(String(data?.name || ""))) return false;
   if (toNumber(data?.ts) == null) return false;
   if (!isPlainObject(data?.props)) return false;
@@ -84,6 +98,8 @@ function toConversionEventRow(data: any): ConversionEventRow | null {
     name: data.name,
     ts: Number(data.ts),
     props: data.props,
+    userId: toOptionalString(data.userId),
+    sessionId: toOptionalString(data.sessionId),
   };
 }
 
@@ -91,24 +107,13 @@ export type SubscriptionConversionDataset = SubscriptionConversionSummary & {
   rows: ConversionEventRow[];
 };
 
-export async function loadAdminSubscriptionConversionDataset(params?: {
-  days?: number | string;
-}): Promise<SubscriptionConversionDataset> {
-  const days = clampDays(params?.days);
-  const to = Date.now();
-  const from = to - days * 24 * 60 * 60 * 1000;
-
-  const snapshot = await db
-    .collection("events")
-    .where("ts", ">=", from)
-    .where("ts", "<=", to)
-    .get();
-
-  const rows = (snapshot.docs || [])
-    .map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }))
-    .map(toConversionEventRow)
-    .filter((row): row is ConversionEventRow => row != null);
-
+export function buildSubscriptionConversionSummary(params: {
+  days: number;
+  from: number;
+  to: number;
+  rows: ConversionEventRow[];
+}): SubscriptionConversionSummary {
+  const { days, from, to, rows } = params;
   const counts = SUBSCRIPTION_CONVERSION_FUNNEL_STEPS.reduce<Record<FunnelStepName, number>>((acc, step) => {
     acc[step] = 0;
     return acc;
@@ -146,9 +151,33 @@ export async function loadAdminSubscriptionConversionDataset(params?: {
       from: new Date(from).toISOString(),
       to: new Date(to).toISOString(),
     },
-    rows,
     funnel,
     breakdowns,
+  };
+}
+
+export async function loadAdminSubscriptionConversionDataset(params?: {
+  days?: number | string;
+}): Promise<SubscriptionConversionDataset> {
+  const days = clampDays(params?.days);
+  const to = Date.now();
+  const from = to - days * 24 * 60 * 60 * 1000;
+
+  const snapshot = await db
+    .collection("events")
+    .where("ts", ">=", from)
+    .where("ts", "<=", to)
+    .get();
+
+  const rows = (snapshot.docs || [])
+    .map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }))
+    .map(toConversionEventRow)
+    .filter((row): row is ConversionEventRow => row != null);
+  const summary = buildSubscriptionConversionSummary({ days, from, to, rows });
+
+  return {
+    rows,
+    ...summary,
   };
 }
 


### PR DESCRIPTION
## Summary

Implements Real-User Validation v1 by adding a backend-only validation layer on top of existing conversion analytics.

This introduces a conservative, heuristic “trust lens” that helps distinguish likely internal/testing activity from likely external/real-user behavior without changing the underlying analytics system.

## What changed

### Backend validation layer
- Added a dedicated validation service:
  - `rentchain-api/src/services/admin/adminSubscriptionConversionValidation.ts`
- Reused the existing Mission 30 bounded-window event model from:
  - `adminSubscriptionConversionView.ts`

### Admin route
- Added a new admin-only route:
  - `GET /api/admin/analytics/conversion-validation`
- The route returns:
  - window metadata
  - aggregate segment summaries
  - cross-segment comparisons
  - deterministic recommendations
  - explicit caveats about heuristic classification

### Segmentation model

Introduced a conservative, aggregate-only segmentation strategy with three buckets:

- `all_activity`
- `likely_internal_or_test`
- `likely_external_or_real`

Segmentation is based on existing event signals only:
- `userId` when present
- otherwise `sessionId`
- multi-plan exploration patterns
- high-volume repeated event activity

No new identity model or tracking system was introduced.

### Tests
- Added targeted backend tests covering:
  - segmentation logic
  - mixed-schema safety
  - route response behavior

## Files changed

- `rentchain-api/src/routes/__tests__/adminSubscriptionConversionValidationRoute.test.ts`
- `rentchain-api/src/routes/adminRoutes.ts`
- `rentchain-api/src/services/__tests__/adminSubscriptionConversionValidation.test.ts`
- `rentchain-api/src/services/admin/adminSubscriptionConversionValidation.ts`
- `rentchain-api/src/services/admin/adminSubscriptionConversionView.ts`

## Verification

### Backend
- targeted tests passed for:
  - validation service
  - validation route
  - existing funnel/insight layers
- `npm run build`

## Why this change was made

Previous missions (29–37) established:
- event capture
- funnel analysis
- insight generation
- pricing and billing optimization

However, much of the observed data was generated from controlled internal testing.

This mission introduces a practical validation layer so RentChain can:
- better interpret real vs internal activity
- avoid over-optimizing on synthetic signals
- build more reliable optimization loops going forward

## Important note

- This validation layer is **heuristic**, not authoritative.
- It does NOT attempt to identify real users with certainty.
- It does NOT expose user-level or session-level data.
- It operates entirely at an aggregate level.

It also does NOT modify:
- the Mission 30 funnel contract
- the Mission 33 insight contract
- the underlying event ingestion model

## Known limitations

- some internal activity may still appear in `likely_external_or_real`
- segmentation quality depends on current event volume and patterns
- classification is intentionally conservative to avoid false precision

## Impact

- adds a trust layer to conversion analytics
- enables more reliable interpretation of funnel and insight data
- prepares the system for real-user-driven optimization loops