### PR TITLE
feat: add internal actor allowlist v1

### DIFF
--- a/rentchain-api/src/routes/__tests__/adminSubscriptionConversionValidationRoute.test.ts
+++ b/rentchain-api/src/routes/__tests__/adminSubscriptionConversionValidationRoute.test.ts
@@ -115,7 +115,7 @@ describe("GET /api/admin/analytics/conversion-validation", () => {
     loadAdminSubscriptionConversionValidation.mockResolvedValue({
       window: { days: 30, from: "2026-03-19T00:00:00.000Z", to: "2026-04-18T00:00:00.000Z" },
       segmentation: {
-        strategy: "heuristic_actor_pattern_v1",
+        strategy: "internal_allowlist_plus_heuristics_v1",
         buckets: {
           all_activity: { description: "All Mission 29-style conversion events in the bounded window." },
           likely_internal_or_test: { description: "Testing-like activity." },

--- a/rentchain-api/src/services/__tests__/adminSubscriptionConversionValidation.test.ts
+++ b/rentchain-api/src/services/__tests__/adminSubscriptionConversionValidation.test.ts
@@ -35,6 +35,15 @@ const { dbMock, resetDb, seedDoc } = vi.hoisted(() => {
     dbMock: {
       collection: (name: string) => ({
         where: (field: string, op: string, value: any) => buildQuery(name, [{ field, op, value }]),
+        doc: (id: string) => ({
+          get: async () => {
+            const row = ensureCollection(name).get(id);
+            return {
+              exists: Boolean(row),
+              data: () => row?.data || undefined,
+            };
+          },
+        }),
       }),
     },
     resetDb: () => {
@@ -56,7 +65,7 @@ describe("adminSubscriptionConversionValidation", () => {
     resetDb();
   });
 
-  it("splits aggregate conversion data into conservative validation segments", async () => {
+  it("classifies allowlisted internal accounts explicitly before falling back to heuristics", async () => {
     const now = Date.now();
     seedDoc("events", "real-1", {
       name: "pricing_page_viewed",
@@ -141,13 +150,16 @@ describe("adminSubscriptionConversionValidation", () => {
       occurredAt: new Date(now - 100).toISOString(),
       payload: {},
     });
+    seedDoc("users", "tester-1", {
+      email: "admin+pro@rentchain.ai",
+    });
 
     const { loadAdminSubscriptionConversionValidation } = await import(
       "../admin/adminSubscriptionConversionValidation"
     );
     const result = await loadAdminSubscriptionConversionValidation({ days: 30 });
 
-    expect(result.segmentation.strategy).toBe("heuristic_actor_pattern_v1");
+    expect(result.segmentation.strategy).toBe("internal_allowlist_plus_heuristics_v1");
     expect(result.segments.all_activity.eventCount).toBe(12);
     expect(result.segments.likely_external_or_real.eventCount).toBe(4);
     expect(result.segments.likely_external_or_real.actorCount).toBe(1);
@@ -173,7 +185,29 @@ describe("adminSubscriptionConversionValidation", () => {
     expect(result.recommendations).toContain(
       "Prompt usage remains negligible outside likely internal or testing activity."
     );
-    expect(result.segmentation.caveats).toHaveLength(3);
+    expect(result.segmentation.caveats).toHaveLength(4);
+    expect(result.segmentation.caveats[0]).toContain("allowlist");
+  });
+
+  it("falls back to account email lookup when the users document does not exist", async () => {
+    const now = Date.now();
+    seedDoc("events", "test-1", {
+      name: "pricing_page_viewed",
+      ts: now - 500,
+      userId: "tester-2",
+      props: { surface: "workspace_pricing", source: "workspace_pricing" },
+    });
+    seedDoc("accounts", "tester-2", {
+      email: "admin+elite@rentchain.ai",
+    });
+
+    const { loadAdminSubscriptionConversionValidation } = await import(
+      "../admin/adminSubscriptionConversionValidation"
+    );
+    const result = await loadAdminSubscriptionConversionValidation({ days: 30 });
+
+    expect(result.segments.likely_internal_or_test.eventCount).toBe(1);
+    expect(result.segments.likely_external_or_real.eventCount).toBe(0);
   });
 
   it("returns safe empty segment output when no matching analytics events exist", async () => {

--- a/rentchain-api/src/services/admin/adminSubscriptionConversionValidation.ts
+++ b/rentchain-api/src/services/admin/adminSubscriptionConversionValidation.ts
@@ -1,3 +1,4 @@
+import { db } from "../../config/firebase";
 import {
   buildSubscriptionConversionSummary,
   loadAdminSubscriptionConversionDataset,
@@ -46,7 +47,7 @@ export type SubscriptionConversionValidationSegment = SubscriptionConversionSumm
 export type SubscriptionConversionValidationPayload = {
   window: SubscriptionConversionSummary["window"];
   segmentation: {
-    strategy: "heuristic_actor_pattern_v1";
+    strategy: "internal_allowlist_plus_heuristics_v1";
     buckets: Record<SegmentKey, { description: string }>;
     caveats: string[];
   };
@@ -70,6 +71,13 @@ const UPGRADE_INTENT_EVENT_NAMES = new Set([
   "upgrade_cta_clicked",
   "upgrade_prompt_checkout_clicked",
   "billing_upgrade_clicked",
+]);
+
+const INTERNAL_TEST_EMAILS = new Set([
+  "admin+free@rentchain.ai",
+  "admin+starter@rentchain.ai",
+  "admin+pro@rentchain.ai",
+  "admin+elite@rentchain.ai",
 ]);
 
 function toBreakdownKey(value: unknown) {
@@ -198,6 +206,7 @@ type ActorStats = {
   rows: ConversionEventRow[];
   targetPlans: Set<string>;
   eventNames: Set<string>;
+  email: string | null;
 };
 
 function toActorKey(row: ConversionEventRow) {
@@ -207,6 +216,7 @@ function toActorKey(row: ConversionEventRow) {
 }
 
 function classifyActor(stats: ActorStats): Exclude<SegmentKey, "all_activity"> {
+  if (stats.email && INTERNAL_TEST_EMAILS.has(stats.email)) return "likely_internal_or_test";
   if (stats.actorKey === "unknown") return "likely_internal_or_test";
   if (stats.targetPlans.size >= 3) return "likely_internal_or_test";
   if (stats.targetPlans.size >= 2 && stats.rows.length >= 8) return "likely_internal_or_test";
@@ -214,7 +224,35 @@ function classifyActor(stats: ActorStats): Exclude<SegmentKey, "all_activity"> {
   return "likely_external_or_real";
 }
 
-function buildActorStats(rows: ConversionEventRow[]) {
+function toNormalizedEmail(value: unknown) {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  return normalized || null;
+}
+
+async function loadActorEmails(userIds: string[]) {
+  const uniqueUserIds = Array.from(new Set(userIds.filter(Boolean)));
+  const emailByUserId = new Map<string, string | null>();
+
+  await Promise.all(
+    uniqueUserIds.map(async (userId) => {
+      const [userSnap, accountSnap] = await Promise.all([
+        db.collection("users").doc(userId).get(),
+        db.collection("accounts").doc(userId).get(),
+      ]);
+      const email =
+        toNormalizedEmail(userSnap.data()?.email) ||
+        toNormalizedEmail(accountSnap.data()?.email) ||
+        null;
+      emailByUserId.set(userId, email);
+    })
+  );
+
+  return emailByUserId;
+}
+
+async function buildActorStats(rows: ConversionEventRow[]) {
+  const emailByUserId = await loadActorEmails(rows.map((row) => row.userId).filter((id): id is string => Boolean(id)));
   const actorMap = new Map<string, ActorStats>();
   for (const row of rows) {
     const actorKey = toActorKey(row);
@@ -223,6 +261,7 @@ function buildActorStats(rows: ConversionEventRow[]) {
       rows: [],
       targetPlans: new Set<string>(),
       eventNames: new Set<string>(),
+      email: row.userId ? emailByUserId.get(row.userId) || null : null,
     };
     existing.rows.push(row);
     existing.eventNames.add(row.name);
@@ -273,7 +312,7 @@ export async function loadAdminSubscriptionConversionValidation(params?: {
   const dataset = await loadAdminSubscriptionConversionDataset(params);
   const from = Date.parse(dataset.window.from);
   const to = Date.parse(dataset.window.to);
-  const actorStats = buildActorStats(dataset.rows);
+  const actorStats = await buildActorStats(dataset.rows);
 
   const segmentedRows: Record<Exclude<SegmentKey, "all_activity">, ConversionEventRow[]> = {
     likely_internal_or_test: [],
@@ -330,22 +369,23 @@ export async function loadAdminSubscriptionConversionValidation(params?: {
   return {
     window: dataset.window,
     segmentation: {
-      strategy: "heuristic_actor_pattern_v1",
+      strategy: "internal_allowlist_plus_heuristics_v1",
       buckets: {
         all_activity: {
           description: "All Mission 29-style conversion events in the bounded window.",
         },
         likely_internal_or_test: {
           description:
-            "Activity from actors showing repeated multi-plan or high-volume exploration patterns consistent with testing.",
+            "Activity from allowlisted internal actors or from actors showing repeated multi-plan or high-volume exploration patterns consistent with testing.",
         },
         likely_external_or_real: {
           description:
-            "Remaining activity after conservative internal/testing heuristics are applied. This is directional, not authoritative identity truth.",
+            "Remaining activity after explicit internal allowlist checks and conservative internal/testing heuristics are applied. This is directional, not authoritative identity truth.",
         },
       },
       caveats: [
-        "Segmentation is heuristic and actor-pattern based, not verified identity truth.",
+        "Known internal test accounts are classified explicitly through an internal allowlist when their userId resolves to a matching email.",
+        "All remaining segmentation is heuristic and actor-pattern based, not verified identity truth.",
         "The model is intentionally conservative and may leave some testing activity in likely_external_or_real.",
         "Output is aggregate only and should be used as a confidence lens before making stronger optimization decisions.",
       ],


### PR DESCRIPTION
## Summary

Improves the accuracy of conversion-validation analytics by introducing an explicit internal actor allowlist.

This ensures known internal test accounts are classified deterministically, reducing reliance on heuristics and improving trust in validation output.

## What changed

### Backend validation layer
- Updated `adminSubscriptionConversionValidation` to support explicit-first classification:
  - known internal test accounts are identified via an allowlist
  - classification now resolves `userId → email` using existing Firestore documents:
    - `users/{userId}`
    - fallback `accounts/{userId}`

### Classification strategy
- New classification order:
  1. allowlist (explicit internal accounts)
  2. heuristic patterns (fallback)
  3. remaining activity treated as likely external

### Tests
- Updated validation service tests to cover:
  - explicit allowlist classification
  - fallback heuristic behavior
- Updated route tests to ensure contract remains unchanged

## Files changed

- `rentchain-api/src/services/admin/adminSubscriptionConversionValidation.ts`
- `rentchain-api/src/services/__tests__/adminSubscriptionConversionValidation.test.ts`
- `rentchain-api/src/routes/__tests__/adminSubscriptionConversionValidationRoute.test.ts`

## Verification

### Backend
- targeted validation tests passed
- `npm run build`

## Why this change was made

Previous validation relied entirely on heuristics such as:
- multi-plan exploration
- high event volume patterns

However, RentChain has known internal test accounts.

This mission:
- removes guesswork for those accounts
- improves segmentation accuracy
- increases confidence in distinguishing internal vs external activity

## Important note

- Known internal test accounts are now classified explicitly before heuristic fallback.
- This does not change:
  - funnel computation
  - insight computation
  - analytics ingestion
- All output remains:
  - aggregate-only
  - privacy-safe
  - free of user-level identifiers

## Known limitations

- session-only internal traffic still relies on heuristics
- accuracy depends on `userId` being present and resolvable
- this is not a full identity-verification system, but a practical classification hardening step

## Impact

- improves trust in conversion-validation output
- enables cleaner interpretation of real vs internal activity
- prepares the system for real-user-driven optimization loops