### PR TITLE
feat: add billing conversion lift v2

### DIFF
--- a/rentchain-frontend/src/components/billing/BillingPlansPanel.test.tsx
+++ b/rentchain-frontend/src/components/billing/BillingPlansPanel.test.tsx
@@ -37,7 +37,9 @@ describe("BillingPlansPanel", () => {
     expect(screen.getByText("Selected from pricing")).toBeInTheDocument();
     expect(screen.getAllByText("Operations and reporting").length).toBeGreaterThan(0);
     expect(
-      screen.getByText("Selected from pricing. Opens secure checkout for the Pro plan you already chose.")
+      screen.getByText(
+        "Selected from pricing. Opens secure checkout for the Pro plan you already chose so you can review details and confirm before billing starts."
+      )
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Continue to Pro checkout" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Continue to Elite checkout" })).toBeInTheDocument();
@@ -68,7 +70,7 @@ describe("BillingPlansPanel", () => {
     expect(screen.getAllByText("Operations and reporting").length).toBeGreaterThan(0);
     expect(
       screen.getByText(
-        "Recommended next step based on your current plan. Opens secure checkout for operations and reporting."
+        "Recommended next step based on your current plan. Opens secure checkout for operations and reporting so you can review the plan before confirming any change."
       )
     ).toBeInTheDocument();
   });

--- a/rentchain-frontend/src/components/billing/BillingPlansPanel.tsx
+++ b/rentchain-frontend/src/components/billing/BillingPlansPanel.tsx
@@ -90,12 +90,12 @@ export function BillingPlansPanel({
       }
     }
     if (isSelected) {
-      return `Selected from pricing. Opens secure checkout for the ${CANONICAL_TIER_MATRIX[planKey].label} plan you already chose.`;
+      return `Selected from pricing. Opens secure checkout for the ${CANONICAL_TIER_MATRIX[planKey].label} plan you already chose so you can review details and confirm before billing starts.`;
     }
     if (isRecommended) {
-      return `Recommended next step based on your current plan. Opens secure checkout for ${TIER_POSITIONING_COPY[planKey].badge.toLowerCase()}.`;
+      return `Recommended next step based on your current plan. Opens secure checkout for ${TIER_POSITIONING_COPY[planKey].badge.toLowerCase()} so you can review the plan before confirming any change.`;
     }
-    return `Opens secure checkout so you can review and confirm ${TIER_POSITIONING_COPY[planKey].badge.toLowerCase()}.`;
+    return `Opens secure checkout so you can review the ${CANONICAL_TIER_MATRIX[planKey].label} plan, confirm billing details, and decide whether to complete the change.`;
   };
 
   return (

--- a/rentchain-frontend/src/pages/BillingPage.test.tsx
+++ b/rentchain-frontend/src/pages/BillingPage.test.tsx
@@ -121,12 +121,28 @@ describe("BillingPage", () => {
     await waitFor(() =>
       expect(screen.getByText(/Pricing selection saved: Pro on the Yearly plan/i)).toBeInTheDocument()
     );
+    expect(screen.getByText(/Billing, plans, and upgrade review/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Opening checkout does not change your plan by itself\. It takes you to a secure review step where you can confirm the upgrade first\./i
+      )
+    ).toBeInTheDocument();
     expect(
       screen.getByText(
         /Starter gives you the workflow foundation, Pro adds operational control and reporting, and Elite adds portfolio intelligence and oversight/i
       )
     ).toBeInTheDocument();
     expect(screen.getByText(/Recommended next plan: Pro from your pricing selection/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /You're continuing the Pro plan you selected on Pricing, so Billing keeps that choice visible before checkout\./i
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /After you click, secure checkout opens so you can review the Yearly Pro plan, confirm billing details, and choose whether to complete the upgrade\./i
+      )
+    ).toBeInTheDocument();
     expect(screen.getAllByRole("button", { name: "Continue to Pro checkout" }).length).toBeGreaterThan(0);
     expect(mocks.billingPlansPanelMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -158,6 +174,16 @@ describe("BillingPage", () => {
       screen.getByText(/Pro focuses on operational control and reporting\. Elite adds the portfolio intelligence layer/i)
     ).toBeInTheDocument();
     expect(screen.getByText(/Recommended next plan: Elite/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /This suggestion follows your current plan and the shared plan ladder, so the next step is clear without changing your current subscription first\./i
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /After you click, secure checkout opens so you can review the Monthly Elite plan, confirm billing details, and choose whether to complete the upgrade\./i
+      )
+    ).toBeInTheDocument();
     expect(mocks.trackMock).toHaveBeenCalledWith("billing_page_opened", {
       currentPlan: "pro",
       surface: "billing_page",

--- a/rentchain-frontend/src/pages/BillingPage.tsx
+++ b/rentchain-frontend/src/pages/BillingPage.tsx
@@ -259,6 +259,14 @@ const BillingPage: React.FC = () => {
         : resolvedCurrentPlan === "pro"
           ? TIER_POSITIONING_COPY.elite.nextStepReason || null
           : null;
+  const recommendationTrustCopy = requestedUpgradePlan
+    ? `You're continuing the ${CANONICAL_TIER_MATRIX[requestedUpgradePlan].label} plan you selected on Pricing, so Billing keeps that choice visible before checkout.`
+    : recommendedUpgradeTier
+      ? `This suggestion follows your current plan and the shared plan ladder, so the next step is clear without changing your current subscription first.`
+      : null;
+  const checkoutReassuranceCopy = nextUpgradeTier
+    ? `After you click, secure checkout opens so you can review the ${interval === "year" ? "Yearly" : "Monthly"} ${CANONICAL_TIER_MATRIX[nextUpgradeTier].label} plan, confirm billing details, and choose whether to complete the upgrade.`
+    : null;
 
   return (
     <Section
@@ -273,8 +281,10 @@ const BillingPage: React.FC = () => {
       <Card elevated>
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", flexWrap: "wrap", gap: spacing.sm }}>
           <div>
-            <h1 style={{ margin: 0, fontSize: "1.3rem", fontWeight: 700 }}>Billing & Receipts</h1>
-            <div style={{ color: text.muted, fontSize: "0.95rem" }}>Current plan, upgrade options, subscription details, and screening receipts.</div>
+            <h1 style={{ margin: 0, fontSize: "1.3rem", fontWeight: 700 }}>Billing, plans, and upgrade review</h1>
+            <div style={{ color: text.muted, fontSize: "0.95rem" }}>
+              Review your current plan, compare the next upgrade options, and open checkout only when you're ready to confirm.
+            </div>
             {requestedUpgradePlan ? (
               <div style={{ color: text.muted, fontSize: "0.9rem", marginTop: 6 }}>
                 Pricing selection saved: {CANONICAL_TIER_MATRIX[requestedUpgradePlan].label} on the {interval === "year" ? "Yearly" : "Monthly"} plan.
@@ -288,6 +298,9 @@ const BillingPage: React.FC = () => {
             ) : null}
             <div style={{ color: text.muted, fontSize: "0.9rem", marginTop: 6 }}>
               Starter gives you the workflow foundation, Pro adds operational control and reporting, and Elite adds portfolio intelligence and oversight.
+            </div>
+            <div style={{ color: text.secondary, fontSize: "0.88rem", marginTop: 6 }}>
+              Opening checkout does not change your plan by itself. It takes you to a secure review step where you can confirm the upgrade first.
             </div>
           </div>
           <div className="rc-wrap-row">
@@ -384,6 +397,9 @@ const BillingPage: React.FC = () => {
                 {recommendedUpgradeReason ? (
                   <div style={{ color: text.muted, fontSize: 14 }}>{recommendedUpgradeReason}</div>
                 ) : null}
+                {recommendationTrustCopy ? (
+                  <div style={{ color: text.secondary, fontSize: 13, lineHeight: 1.5 }}>{recommendationTrustCopy}</div>
+                ) : null}
                 {nextUpgradeHelp ? (
                   <div style={{ color: text.secondary, fontSize: 13, fontWeight: 600 }}>{nextUpgradeHelp}</div>
                 ) : null}
@@ -396,9 +412,9 @@ const BillingPage: React.FC = () => {
                     {nextUpgradeLabel}
                   </Button>
                 </div>
-                <div style={{ color: text.muted, fontSize: 12 }}>
-                  Secure checkout opens next so you can review the selected plan and confirm before any billing starts.
-                </div>
+                {checkoutReassuranceCopy ? (
+                  <div style={{ color: text.muted, fontSize: 12, lineHeight: 1.5 }}>{checkoutReassuranceCopy}</div>
+                ) : null}
               </div>
             ) : null}
           </div>


### PR DESCRIPTION
## Summary

Implements Billing Conversion Lift v2 by improving Billing-page comprehension and reducing hesitation for real users on the primary conversion path:

- Pricing → Billing → Upgrade

This mission focuses on making the upgrade decision clearer, safer, and more understandable for first-time users without changing pricing, routing, or backend checkout behavior.

## What changed

### Billing page framing
- Reframed the Billing page as an **upgrade review step**, not just an account/billing utility page
- Clarified the purpose of the page so users understand they are reviewing an upgrade decision

### Checkout reassurance
- Added explicit reassurance that checkout is a **secure review and confirmation step**, not an immediate charge
- Reinforced this consistently across:
  - Billing header
  - recommended-plan card
  - plan-panel CTA support copy

### Recommendation clarity
- Improved explanation of why a plan is being suggested:
  - continues the user’s Pricing selection when applicable
  - otherwise follows the shared plan ladder (Starter → Pro → Elite)
- Reduced the perception of arbitrary or hidden recommendation logic

### Plan-panel support copy
- Updated support text under CTAs so users understand:
  - what happens after clicking
  - that checkout is for review before billing starts
- Reduced ambiguity between:
  - current plan
  - selected plan
  - recommended plan
  - upgrade action

## Files changed

- `rentchain-frontend/src/pages/BillingPage.tsx`
- `rentchain-frontend/src/components/billing/BillingPlansPanel.tsx`
- `rentchain-frontend/src/pages/BillingPage.test.tsx`
- `rentchain-frontend/src/components/billing/BillingPlansPanel.test.tsx`

## Verification

### Frontend
- `npm run test -- src/pages/BillingPage.test.tsx src/components/billing/BillingPlansPanel.test.tsx`
- `npm run build`

## Why this change was made

Validation (Mission 38–39) showed that real-user behavior differs from internal testing:

- users reach Billing
- but do not convert at the same rate
- hesitation likely occurs before checkout

This mission targets that hesitation by:
- improving clarity
- reducing perceived risk
- increasing confidence in the next step

## Important note

- Billing now frames checkout as a **review/confirmation step**, not an immediate commitment
- Recommendation logic is explicitly explained so users understand why a plan is suggested before entering checkout

## Intentionally unchanged

- no pricing changes
- no entitlement changes
- no backend billing changes
- no checkout flow changes
- no analytics changes

## Known limitations / follow-up opportunities

- this is still a copy/clarity improvement rather than a structural flow change
- if hesitation is primarily driven by pricing/value concerns, further optimization will be needed in plan/value positioning
- additional validation with real-user traffic is required to measure impact