### PR TITLE
feat: add value objection handling v1

### DIFF
--- a/rentchain-frontend/src/components/billing/BillingPlansPanel.test.tsx
+++ b/rentchain-frontend/src/components/billing/BillingPlansPanel.test.tsx
@@ -38,7 +38,7 @@ describe("BillingPlansPanel", () => {
     expect(screen.getAllByText("Operations and reporting").length).toBeGreaterThan(0);
     expect(
       screen.getByText(
-        "Selected from pricing. Opens secure checkout for the Pro plan you already chose so you can review details and confirm before billing starts."
+        "Selected from pricing. Opens secure checkout for the Pro plan you already chose so you can keep building in the same workflow, review details, and confirm before billing starts."
       )
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Continue to Pro checkout" })).toBeInTheDocument();
@@ -70,7 +70,7 @@ describe("BillingPlansPanel", () => {
     expect(screen.getAllByText("Operations and reporting").length).toBeGreaterThan(0);
     expect(
       screen.getByText(
-        "Recommended next step based on your current plan. Opens secure checkout for operations and reporting so you can review the plan before confirming any change."
+        "Recommended next step based on your current plan. Opens secure checkout for operations and reporting so you can extend the workflow you already use and review the plan before confirming any change."
       )
     ).toBeInTheDocument();
   });

--- a/rentchain-frontend/src/components/billing/BillingPlansPanel.tsx
+++ b/rentchain-frontend/src/components/billing/BillingPlansPanel.tsx
@@ -90,12 +90,12 @@ export function BillingPlansPanel({
       }
     }
     if (isSelected) {
-      return `Selected from pricing. Opens secure checkout for the ${CANONICAL_TIER_MATRIX[planKey].label} plan you already chose so you can review details and confirm before billing starts.`;
+      return `Selected from pricing. Opens secure checkout for the ${CANONICAL_TIER_MATRIX[planKey].label} plan you already chose so you can keep building in the same workflow, review details, and confirm before billing starts.`;
     }
     if (isRecommended) {
-      return `Recommended next step based on your current plan. Opens secure checkout for ${TIER_POSITIONING_COPY[planKey].badge.toLowerCase()} so you can review the plan before confirming any change.`;
+      return `Recommended next step based on your current plan. Opens secure checkout for ${TIER_POSITIONING_COPY[planKey].badge.toLowerCase()} so you can extend the workflow you already use and review the plan before confirming any change.`;
     }
-    return `Opens secure checkout so you can review the ${CANONICAL_TIER_MATRIX[planKey].label} plan, confirm billing details, and decide whether to complete the change.`;
+    return `Opens secure checkout so you can review the ${CANONICAL_TIER_MATRIX[planKey].label} plan, see what it adds next in RentChain, confirm billing details, and decide whether to complete the change.`;
   };
 
   return (

--- a/rentchain-frontend/src/pages/BillingPage.test.tsx
+++ b/rentchain-frontend/src/pages/BillingPage.test.tsx
@@ -132,10 +132,25 @@ describe("BillingPage", () => {
         /Starter gives you the workflow foundation, Pro adds operational control and reporting, and Elite adds portfolio intelligence and oversight/i
       )
     ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Upgrading helps you keep your tenant, application, and property work in one place as your workflow gets more active\./i
+      )
+    ).toBeInTheDocument();
     expect(screen.getByText(/Recommended next plan: Pro from your pricing selection/i)).toBeInTheDocument();
     expect(
       screen.getByText(
+        /This plan helps you keep building in RentChain without switching tools, while adding the next layer of operations and reporting to the workflow you already started\./i
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
         /You're continuing the Pro plan you selected on Pricing, so Billing keeps that choice visible before checkout\./i
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Staying on Free keeps setup usable, but the richer operating workflow stays limited once you need messaging, tenant coordination, and ongoing rental follow-through\./i
       )
     ).toBeInTheDocument();
     expect(
@@ -173,10 +188,25 @@ describe("BillingPage", () => {
     expect(
       screen.getByText(/Pro focuses on operational control and reporting\. Elite adds the portfolio intelligence layer/i)
     ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Upgrading keeps your operational workflow intact, while adding the portfolio visibility and intelligence layer that helps you make stronger decisions\./i
+      )
+    ).toBeInTheDocument();
     expect(screen.getByText(/Recommended next plan: Elite/i)).toBeInTheDocument();
     expect(
       screen.getByText(
+        /This plan helps you keep building in RentChain without switching tools, while adding the next layer of insights and oversight to the workflow you already started\./i
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
         /This suggestion follows your current plan and the shared plan ladder, so the next step is clear without changing your current subscription first\./i
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Staying on Pro keeps strong operational tooling, but portfolio-level intelligence, advanced oversight, and the clearest trend visibility stay limited\./i
       )
     ).toBeInTheDocument();
     expect(

--- a/rentchain-frontend/src/pages/BillingPage.tsx
+++ b/rentchain-frontend/src/pages/BillingPage.tsx
@@ -267,6 +267,25 @@ const BillingPage: React.FC = () => {
   const checkoutReassuranceCopy = nextUpgradeTier
     ? `After you click, secure checkout opens so you can review the ${interval === "year" ? "Yearly" : "Monthly"} ${CANONICAL_TIER_MATRIX[nextUpgradeTier].label} plan, confirm billing details, and choose whether to complete the upgrade.`
     : null;
+  const billingMomentumCopy =
+    resolvedCurrentPlan === "free"
+      ? "Upgrading helps you keep your tenant, application, and property work in one place as your workflow gets more active."
+      : resolvedCurrentPlan === "starter"
+        ? "Upgrading keeps the workflow you already started in RentChain, while adding the reporting and control layer that reduces manual follow-up."
+        : resolvedCurrentPlan === "pro"
+          ? "Upgrading keeps your operational workflow intact, while adding the portfolio visibility and intelligence layer that helps you make stronger decisions."
+          : null;
+  const limitationCopy =
+    resolvedCurrentPlan === "free"
+      ? "Staying on Free keeps setup usable, but the richer operating workflow stays limited once you need messaging, tenant coordination, and ongoing rental follow-through."
+      : resolvedCurrentPlan === "starter"
+        ? "Staying on Starter keeps the core workflow running, but exports, deeper reporting, and stronger portfolio coordination stay limited."
+        : resolvedCurrentPlan === "pro"
+          ? "Staying on Pro keeps strong operational tooling, but portfolio-level intelligence, advanced oversight, and the clearest trend visibility stay limited."
+          : null;
+  const recommendationOutcomeCopy = recommendedUpgradeTier
+    ? `This plan helps you keep building in RentChain without switching tools, while adding the next layer of ${TIER_POSITIONING_COPY[recommendedUpgradeTier].badge.toLowerCase()} to the workflow you already started.`
+    : null;
 
   return (
     <Section
@@ -299,6 +318,9 @@ const BillingPage: React.FC = () => {
             <div style={{ color: text.muted, fontSize: "0.9rem", marginTop: 6 }}>
               Starter gives you the workflow foundation, Pro adds operational control and reporting, and Elite adds portfolio intelligence and oversight.
             </div>
+            {billingMomentumCopy ? (
+              <div style={{ color: text.secondary, fontSize: "0.88rem", marginTop: 6 }}>{billingMomentumCopy}</div>
+            ) : null}
             <div style={{ color: text.secondary, fontSize: "0.88rem", marginTop: 6 }}>
               Opening checkout does not change your plan by itself. It takes you to a secure review step where you can confirm the upgrade first.
             </div>
@@ -397,8 +419,14 @@ const BillingPage: React.FC = () => {
                 {recommendedUpgradeReason ? (
                   <div style={{ color: text.muted, fontSize: 14 }}>{recommendedUpgradeReason}</div>
                 ) : null}
+                {recommendationOutcomeCopy ? (
+                  <div style={{ color: text.muted, fontSize: 13, lineHeight: 1.5 }}>{recommendationOutcomeCopy}</div>
+                ) : null}
                 {recommendationTrustCopy ? (
                   <div style={{ color: text.secondary, fontSize: 13, lineHeight: 1.5 }}>{recommendationTrustCopy}</div>
+                ) : null}
+                {limitationCopy ? (
+                  <div style={{ color: text.secondary, fontSize: 12, lineHeight: 1.5 }}>{limitationCopy}</div>
                 ) : null}
                 {nextUpgradeHelp ? (
                   <div style={{ color: text.secondary, fontSize: 13, fontWeight: 600 }}>{nextUpgradeHelp}</div>


### PR DESCRIPTION
## Summary

Implements Value Objection Handling v1 by adding calm, confidence-building support copy to the Billing page and Billing plan cards.

This mission helps real users understand why upgrading is the natural continuation of work already started in RentChain, without introducing aggressive or urgency-based upgrade tactics.

## What changed

### Billing page
- Added short value-confidence lines to the Billing header and recommendation card
- Clarified why upgrading helps the user keep building inside RentChain
- Added calm limitation framing that explains what remains constrained on the current plan without using pressure or urgency

### Billing plans panel
- Updated plan-card support copy so checkout is framed as continuing the workflow in RentChain, not just buying access
- Strengthened plan support language so users better understand:
  - what they gain next
  - what stays limited on lower tiers
  - why the recommended plan is useful

### Tests
- Updated focused frontend tests covering:
  - value-support language
  - continuity framing
  - recommendation usefulness on Billing surfaces

## Files changed

- `rentchain-frontend/src/pages/BillingPage.tsx`
- `rentchain-frontend/src/components/billing/BillingPlansPanel.tsx`
- `rentchain-frontend/src/pages/BillingPage.test.tsx`
- `rentchain-frontend/src/components/billing/BillingPlansPanel.test.tsx`

## Verification

### Frontend
- `npm run test -- src/pages/BillingPage.test.tsx src/components/billing/BillingPlansPanel.test.tsx`
- `npm run build`

## Why this change was made

Validation and real-user-oriented analysis showed that:
- users reach Billing
- but hesitation remains before upgrade
- the remaining friction appears to be more about value confidence and commitment hesitation than navigation

This mission addresses that by:
- reinforcing continuity and progress inside RentChain
- clarifying what upgrading adds next
- helping users understand what remains limited if they stay on a lower tier
- keeping the tone calm and professional rather than sales-heavy

## Important note

Billing now reinforces:
- value
- continuity
- next-step confidence

without using aggressive or urgency-based upgrade tactics.

The flow remains:
- Pricing → Billing → Checkout

## Intentionally unchanged

- no pricing changes
- no plan/entitlement changes
- no backend billing changes
- no checkout flow changes
- no analytics changes

## Known limitations / follow-up opportunities

- this is still a copy/framing improvement rather than a structural funnel change
- if hesitation is primarily driven by price sensitivity, additional work may be needed later
- added support copy slightly increases page density, though it was kept intentionally concise