### PR TITLE
feat: add entry value conviction v1

### DIFF
--- a/rentchain-frontend/src/content/marketingCopy.ts
+++ b/rentchain-frontend/src/content/marketingCopy.ts
@@ -144,9 +144,9 @@ export const marketingCopy: Record<Locale, MarketingCopy> = {
       authedPrimaryCta: "Go to dashboard",
     },
     pricing: {
-      headline: "Pricing that matches how RentChain works today",
+      headline: "Start using RentChain before you worry about plans",
       subheadline:
-        "Start on Free with guided setup and pay-per-use screening, then upgrade for richer workflow tools, accountant-ready exports, and stronger reporting.",
+        "Start on Free with guided setup, your first property, and the core rental workflow. Upgrade later if you need deeper operational tools, exports, and reporting.",
       intervalLabels: {
         monthly: "Monthly",
         yearly: "Annual",
@@ -166,7 +166,7 @@ export const marketingCopy: Record<Locale, MarketingCopy> = {
       tierBadges: {
         pro: "Most Popular",
       },
-      ctaStartFree: "Start Free",
+      ctaStartFree: "Start your rental workflow",
       ctaUpgrade: "Upgrade",
       ctaByTier: {
         starter: "Upgrade to Starter",

--- a/rentchain-frontend/src/pages/PricingPage.test.tsx
+++ b/rentchain-frontend/src/pages/PricingPage.test.tsx
@@ -83,6 +83,11 @@ describe("PricingPage analytics", () => {
         /Starter gives you the workflow foundation, Pro adds operational control and reporting, and Elite adds portfolio intelligence and oversight/i
       )
     ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /You do not need to pick a paid plan before you understand the workflow\. Use pricing to see what opens next after the basics are already working for you\./i
+      )
+    ).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Annual" }));
 
@@ -93,7 +98,7 @@ describe("PricingPage analytics", () => {
       route: "/",
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Review Pro plan" }));
+    fireEvent.click(screen.getByRole("button", { name: "See Pro in billing" }));
 
     expect(mocks.track).toHaveBeenCalledWith("pricing_plan_cta_clicked", {
       surface: "workspace_pricing",

--- a/rentchain-frontend/src/pages/PricingPage.tsx
+++ b/rentchain-frontend/src/pages/PricingPage.tsx
@@ -226,14 +226,14 @@ const PricingPage: React.FC = () => {
 
   const planCtaLabel = (target: Exclude<PlanKey, "free">) => {
     if (PLAN_ORDER.indexOf(currentPlan) >= PLAN_ORDER.indexOf(target)) return "Manage plan";
-    return `Review ${CANONICAL_TIER_MATRIX[target].label} plan`;
+    return `See ${CANONICAL_TIER_MATRIX[target].label} in billing`;
   };
 
   const planCtaSupport = (target: Exclude<PlanKey, "free">) => {
     if (PLAN_ORDER.indexOf(currentPlan) >= PLAN_ORDER.indexOf(target)) {
       return "Open billing to manage your current subscription details.";
     }
-    return `Billing will show the ${CANONICAL_TIER_MATRIX[target].label} plan details before secure checkout opens.`;
+    return `Billing will show the ${CANONICAL_TIER_MATRIX[target].label} plan details before secure checkout opens, so you can understand the fit before deciding.`;
   };
 
   return (
@@ -264,6 +264,9 @@ const PricingPage: React.FC = () => {
           </p>
           <p style={{ marginTop: spacing.xs, color: text.secondary, maxWidth: 760, lineHeight: 1.65, fontWeight: 600 }}>
             Starter gives you the workflow foundation, Pro adds operational control and reporting, and Elite adds portfolio intelligence and oversight.
+          </p>
+          <p style={{ marginTop: spacing.xs, color: text.secondary, maxWidth: 760, lineHeight: 1.65 }}>
+            You do not need to pick a paid plan before you understand the workflow. Use pricing to see what opens next after the basics are already working for you.
           </p>
         </Card>
 
@@ -479,7 +482,7 @@ const PricingPage: React.FC = () => {
               <div style={{ marginTop: isMobile ? spacing.sm : "auto", paddingTop: 8, width: "100%" }}>
                 {plan === "free" ? (
                   <Button type="button" variant="secondary" onClick={() => navigate("/dashboard")} style={{ width: "100%" }}>
-                    Start Free
+                    Start your rental workflow
                   </Button>
                 ) : (
                   <div style={{ display: "grid", gap: 8 }}>

--- a/rentchain-frontend/src/pages/marketing/LandingPage.test.tsx
+++ b/rentchain-frontend/src/pages/marketing/LandingPage.test.tsx
@@ -58,9 +58,14 @@ describe("Marketing LandingPage", () => {
         /RentChain helps landlords across Canada stay on top of property details, tenant activity, maintenance, and the tasks that tend to fall through the cracks\./i
       )
     ).toBeInTheDocument();
-    expect(screen.getAllByRole("button", { name: "Get started with a property" }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("button", { name: "Start your first property" }).length).toBeGreaterThan(0);
     expect(
-      screen.getByText(/Free to try\. Upgrade when you need stronger workflows and deeper support\./i)
+      screen.getByText(
+        /Start with your first property, see how the workflow works, and decide on paid plans only after you understand the value inside the product\./i
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/No commitment to explore\. Start free and upgrade only when your workflow needs more support\./i)
     ).toBeInTheDocument();
     expect(screen.getByText("Is this available across Canada?")).toBeInTheDocument();
     expect(
@@ -82,7 +87,7 @@ describe("Marketing LandingPage", () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(screen.getAllByRole("button", { name: "Get started with a property" })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: "Start your first property" })[0]);
 
     expect(mocks.navigate).toHaveBeenCalledWith("/signup?next=/properties&intent=registry_readiness");
     expect(mocks.track).toHaveBeenCalledWith(
@@ -115,7 +120,7 @@ describe("Marketing LandingPage", () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(screen.getAllByRole("button", { name: "Get started with a property" })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: "Start your first property" })[0]);
 
     expect(mocks.navigate).toHaveBeenCalledWith("/properties?intent=registry_readiness");
   });

--- a/rentchain-frontend/src/pages/marketing/LandingPage.tsx
+++ b/rentchain-frontend/src/pages/marketing/LandingPage.tsx
@@ -15,15 +15,15 @@ type HowItWorksStep = {
 const HOW_IT_WORKS: HowItWorksStep[] = [
   {
     title: "Set up your property",
-    body: "Add a property, keep the important details together, and stop chasing information across different tools.",
+    body: "Add your first property, keep the important details together, and start the workflow without piecing it together across different tools.",
   },
   {
     title: "See what needs attention",
-    body: "Catch missing details early so everyday tasks, tenant work, and filing steps are easier to finish cleanly.",
+    body: "See what is missing early so tenant work, maintenance follow-up, and rental admin are easier to finish cleanly.",
   },
   {
     title: "Add deeper support when you need it",
-    body: "Paid plans give growing landlords stronger workflow support, clearer records, and guided filing help when things get more complex.",
+    body: "Paid plans add deeper workflow support only when your rental operations outgrow the basics you can already start using now.",
   },
 ];
 
@@ -174,13 +174,25 @@ const LandingPage: React.FC = () => {
                   maintenance, and the tasks that tend to fall through the cracks. When you need deeper
                   lease, filing, or compliance support, those tools can vary by province and continue to expand.
                 </p>
+                <p
+                  style={{
+                    margin: 0,
+                    color: text.secondary,
+                    fontSize: "0.98rem",
+                    lineHeight: 1.7,
+                    maxWidth: 720,
+                    fontWeight: 600,
+                  }}
+                >
+                  Start with your first property, see how the workflow works, and decide on paid plans only after you understand the value inside the product.
+                </p>
               </div>
               <div style={{ display: "flex", flexWrap: "wrap", gap: spacing.sm, alignItems: "center" }}>
                 <Button type="button" onClick={handlePrimaryCta}>
-                  Get started with a property
+                  Start your first property
                 </Button>
                 <div style={{ color: text.secondary, fontSize: "0.93rem", fontWeight: 600 }}>
-                  Free to try. Upgrade when you need stronger workflows and deeper support.
+                  No commitment to explore. Start free and upgrade only when your workflow needs more support.
                 </div>
               </div>
               <div
@@ -192,9 +204,9 @@ const LandingPage: React.FC = () => {
                 }}
               >
                 {[
-                  "Organize a property and try the basics",
-                  "See what is missing before it becomes a problem",
-                  "Unlock guided filing support when you need it",
+                  "Set up your first property and tenant workflow in one place",
+                  "See what is missing before it becomes a larger admin problem",
+                  "Add deeper workflow support only when you actually need it",
                 ].map((item) => (
                   <div
                     key={item}
@@ -314,8 +326,8 @@ const LandingPage: React.FC = () => {
             <div style={{ display: "grid", gap: spacing.sm }}>
               <h2 style={sectionHeadingStyle}>What stays free</h2>
               <ul style={{ margin: 0, paddingLeft: "1.1rem", color: text.muted, lineHeight: 1.8 }}>
-                <li>Set up a property and keep the important details together</li>
-                <li>See missing information before a task turns messy</li>
+                <li>Set up your first property and keep the important details together</li>
+                <li>Track the basics before a task turns messy</li>
                 <li>Use the platform to get organized before paying</li>
                 <li>Try the workflow before deciding whether you need more support</li>
               </ul>
@@ -409,9 +421,9 @@ const LandingPage: React.FC = () => {
                 system to get value on day one.
               </p>
             </div>
-            <Button type="button" onClick={handlePrimaryCta}>
-              Get started with a property
-            </Button>
+              <Button type="button" onClick={handlePrimaryCta}>
+                Start your first property
+              </Button>
           </div>
         </Card>
       </div>

--- a/rentchain-frontend/src/pages/marketing/PricingPage.test.tsx
+++ b/rentchain-frontend/src/pages/marketing/PricingPage.test.tsx
@@ -90,6 +90,11 @@ describe("Marketing PricingPage analytics", () => {
         /Starter gives you the workflow foundation, Pro adds operational control and reporting, and Elite adds portfolio intelligence and oversight/i
       )
     ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /You can start and explore before committing to a paid plan\. Pricing is here to show what opens next once the workflow is working for you\./i
+      )
+    ).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Annual" }));
 
@@ -100,7 +105,7 @@ describe("Marketing PricingPage analytics", () => {
       route: "/",
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Review Pro plan" }));
+    fireEvent.click(screen.getByRole("button", { name: "See Pro in billing" }));
 
     expect(mocks.track).toHaveBeenCalledWith("pricing_plan_cta_clicked", {
       surface: "marketing_pricing",

--- a/rentchain-frontend/src/pages/marketing/PricingPage.tsx
+++ b/rentchain-frontend/src/pages/marketing/PricingPage.tsx
@@ -263,15 +263,15 @@ const PricingPage: React.FC = () => {
   };
 
   const planCtaLabel = (plan: Exclude<PlanKey, "free">) => {
-    if (!isAuthed) return `Sign in for ${copy.pricing.tierLabels[plan]}`;
+    if (!isAuthed) return `Start with ${copy.pricing.tierLabels[plan]}`;
     if (isAuthed && isAtOrAbove(currentPlan, plan)) return "Manage plan";
-    return `Review ${copy.pricing.tierLabels[plan]} plan`;
+    return `See ${copy.pricing.tierLabels[plan]} in billing`;
   };
 
   const planCtaSupport = (plan: Exclude<PlanKey, "free">) => {
-    if (!isAuthed) return "Sign in first, then review this plan in billing before checkout opens.";
+    if (!isAuthed) return "Start inside the product first, then review this plan in billing only when you want more support.";
     if (isAtOrAbove(currentPlan, plan)) return "Open billing to manage your current subscription details.";
-    return `Billing will show the ${copy.pricing.tierLabels[plan]} plan details before secure checkout opens.`;
+    return `Billing will show the ${copy.pricing.tierLabels[plan]} plan details before secure checkout opens, so you can understand the fit before deciding.`;
   };
 
   return (
@@ -308,6 +308,9 @@ const PricingPage: React.FC = () => {
           </p>
           <p style={{ margin: `${spacing.xs} 0 0`, color: text.secondary, fontSize: "0.92rem", fontWeight: 600 }}>
             Starter gives you the workflow foundation, Pro adds operational control and reporting, and Elite adds portfolio intelligence and oversight.
+          </p>
+          <p style={{ margin: `${spacing.xs} 0 0`, color: text.secondary, fontSize: "0.92rem" }}>
+            You can start and explore before committing to a paid plan. Pricing is here to show what opens next once the workflow is working for you.
           </p>
         </div>
 


### PR DESCRIPTION
## Summary

Implements Entry Value Conviction v1 by reframing the main entry surfaces around starting the product and understanding value before committing to a paid plan.

This mission reduces early pricing pressure and helps new visitors see RentChain as something they can begin using right away, while keeping the later Pricing → Billing → Upgrade path intact.

## What changed

### Landing page
- Reframed the landing hero and supporting entry messaging around concrete first actions
- Improved “what stays free” framing so users better understand the low-risk starting point
- Shifted emphasis toward starting a workflow rather than evaluating plans too early

### Pricing pages
- Updated pricing pages so they feel more like decision aids and less like early purchase gates
- Added “start before you commit” framing
- Repositioned Free as the practical entry point for exploring the product
- Updated CTA language so it leans toward starting and seeing value before choosing a paid plan

### CTA language
- Shifted key CTAs from “buy/review plan” language toward “start/explore” language
- Kept the later pricing/billing flow intact while lowering early commitment pressure

## Files changed

- `rentchain-frontend/src/content/marketingCopy.ts`
- `rentchain-frontend/src/pages/marketing/LandingPage.tsx`
- `rentchain-frontend/src/pages/marketing/LandingPage.test.tsx`
- `rentchain-frontend/src/pages/marketing/PricingPage.tsx`
- `rentchain-frontend/src/pages/marketing/PricingPage.test.tsx`
- `rentchain-frontend/src/pages/PricingPage.tsx`
- `rentchain-frontend/src/pages/PricingPage.test.tsx`

## Verification

### Frontend
- targeted frontend tests passed
- `npm run build`

## Why this change was made

Current validated data shows that RentChain still has very little real-user activity beyond pricing exploration.

That means the immediate problem is not upgrade conversion yet — it is activation:
- helping visitors understand the product
- reducing perceived risk
- making it easier to start

This mission addresses that by shifting early messaging from “choose a plan” to “start using the product.”

## Important note

Entry surfaces now emphasize:
- starting the product
- seeing value before committing
- understanding what can be done right away

This reduces early pricing pressure while preserving the later:
- Pricing → Billing → Upgrade
path for users who move deeper into the product.

## Intentionally unchanged

- no backend changes
- no pricing value changes
- no checkout flow changes
- no billing logic changes
- no analytics changes

## Known limitations / follow-up opportunities

- this is a copy/framing mission, not a signup or onboarding flow redesign
- if activation friction is mostly after signup, a follow-up activation-tracking/onboarding mission will still be needed
- pricing still necessarily discusses plans, so this reduces pressure rather than removing commercial framing entirely