### PR TITLE
feat: add activation tracking v1

### DIFF
--- a/rentchain-api/src/routes/__tests__/adminActivationSummaryRoute.test.ts
+++ b/rentchain-api/src/routes/__tests__/adminActivationSummaryRoute.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const loadAdminActivationSummary = vi.fn();
+
+vi.mock("../../middleware/requireAdmin", () => ({
+  requireAdmin: (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock("../../services/admin/adminActivationSummary", () => ({
+  loadAdminActivationSummary,
+}));
+
+vi.mock("../../config/firebase", () => ({
+  db: {
+    collection: vi.fn(() => ({
+      where: vi.fn(),
+      doc: vi.fn(() => ({ set: vi.fn() })),
+    })),
+  },
+}));
+
+vi.mock("../../services/telemetryService", () => ({
+  getCountersSummary: vi.fn(async () => ({ byName: {} })),
+}));
+
+vi.mock("../../services/stripeService", () => ({
+  isStripeConfigured: () => false,
+  getStripeClient: () => {
+    throw new Error("not configured");
+  },
+}));
+
+vi.mock("firebase-admin", () => ({
+  default: {
+    auth: () => ({ createUser: vi.fn() }),
+    firestore: {
+      FieldValue: {
+        serverTimestamp: () => Date.now(),
+      },
+    },
+  },
+}));
+
+async function createRouter() {
+  return (await import("../adminRoutes")).default;
+}
+
+async function invokeRouter(
+  router: any,
+  options: {
+    method: string;
+    url: string;
+    body?: any;
+  }
+) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const req: any = {
+      method: options.method,
+      url: options.url.replace(/^\/api\/admin/, ""),
+      originalUrl: options.url,
+      path: options.url.replace(/^\/api\/admin/, "").split("?")[0],
+      query: {},
+      body: options.body ?? {},
+      user: { id: "admin-1", role: "admin" },
+      cookies: {},
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, any>,
+      setHeader(name: string, value: any) {
+        this.headers[name.toLowerCase()] = value;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    const [, rawQuery] = options.url.split("?");
+    if (rawQuery) {
+      req.query = Object.fromEntries(new URLSearchParams(rawQuery).entries());
+    }
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("GET /api/admin/analytics/activation-summary", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    loadAdminActivationSummary.mockReset();
+  });
+
+  it("returns the admin activation summary payload", async () => {
+    loadAdminActivationSummary.mockResolvedValue({
+      window: { days: 30, from: "2026-03-19T00:00:00.000Z", to: "2026-04-18T00:00:00.000Z" },
+      activationEvents: {
+        property_created: 5,
+        unit_created: 3,
+        tenant_added: 2,
+        work_order_created: 1,
+      },
+      activatedUsers: 6,
+      activationRateEstimate: 0.4,
+      breakdowns: {
+        byEventName: { activation_property_created: 5 },
+        byPlan: { free: 4, starter: 2 },
+        bySurface: { properties_page: 5 },
+      },
+      insights: {
+        mostCommonActivationEvent: { eventName: "activation_property_created", count: 5 },
+        planSeeingActivation: { plan: "free", count: 4 },
+        activationOccurring: true,
+      },
+    });
+
+    const router = await createRouter();
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/api/admin/analytics/activation-summary?days=30",
+    });
+
+    expect(res.status).toBe(200);
+    expect(loadAdminActivationSummary).toHaveBeenCalledWith({ days: "30" });
+    expect(res.body).toEqual({
+      ok: true,
+      window: { days: 30, from: "2026-03-19T00:00:00.000Z", to: "2026-04-18T00:00:00.000Z" },
+      activationEvents: {
+        property_created: 5,
+        unit_created: 3,
+        tenant_added: 2,
+        work_order_created: 1,
+      },
+      activatedUsers: 6,
+      activationRateEstimate: 0.4,
+      breakdowns: {
+        byEventName: { activation_property_created: 5 },
+        byPlan: { free: 4, starter: 2 },
+        bySurface: { properties_page: 5 },
+      },
+      insights: {
+        mostCommonActivationEvent: { eventName: "activation_property_created", count: 5 },
+        planSeeingActivation: { plan: "free", count: 4 },
+        activationOccurring: true,
+      },
+    });
+  });
+});

--- a/rentchain-api/src/routes/__tests__/eventsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/eventsRoutes.test.ts
@@ -183,6 +183,35 @@ describe("eventsRoutes", () => {
     expect(telemetryMocks.incrementCounter).toHaveBeenCalledWith({ name: "upgrade_prompt_viewed" });
   });
 
+  it("accepts activation analytics events through the generic tracker", async () => {
+    const router = await createRouter();
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/track",
+      user: { id: "user-activation", role: "landlord" },
+      body: {
+        name: "activation_property_created",
+        props: {
+          surface: "properties_page",
+          source: "add_property_form",
+          plan: "free",
+          route: "/properties",
+        },
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+    expect(telemetryMocks.incrementCounter).toHaveBeenCalledWith({ name: "activation_property_created" });
+    expect(getCollectionDocs("events")).toEqual([
+      expect.objectContaining({
+        name: "activation_property_created",
+        userId: "user-activation",
+        sessionId: null,
+      }),
+    ]);
+  });
+
   it("persists authenticated events with userId and no sessionId", async () => {
     const router = await createRouter();
     const res = await invokeRouter(router, {

--- a/rentchain-api/src/routes/adminRoutes.ts
+++ b/rentchain-api/src/routes/adminRoutes.ts
@@ -9,6 +9,7 @@ import { getTuReferralMetricsForMonth } from "../services/metrics/tuReferralRepo
 import { getPublicStatusPayload } from "../services/statusService";
 import { loadAdminSubscriptionConversionFunnel } from "../services/admin/adminSubscriptionConversionView";
 import { loadAdminSubscriptionConversionInsights } from "../services/admin/adminSubscriptionConversionInsights";
+import { loadAdminActivationSummary } from "../services/admin/adminActivationSummary";
 import { loadAdminSubscriptionConversionValidation } from "../services/admin/adminSubscriptionConversionValidation";
 import {
   createStatusIncident,
@@ -860,6 +861,22 @@ router.get("/analytics/conversion-insights", requireAdmin, async (req, res) => {
   } catch (err: any) {
     console.error("[admin] conversion insights failed", err?.message || err);
     return res.status(500).json({ ok: false, error: "CONVERSION_INSIGHTS_FAILED" });
+  }
+});
+
+router.get("/analytics/activation-summary", requireAdmin, async (req, res) => {
+  try {
+    const days = req.query?.days;
+    const payload = await loadAdminActivationSummary({
+      days: typeof days === "string" ? days : undefined,
+    });
+    return res.json({
+      ok: true,
+      ...payload,
+    });
+  } catch (err: any) {
+    console.error("[admin] activation summary failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "ACTIVATION_SUMMARY_FAILED" });
   }
 });
 

--- a/rentchain-api/src/routes/eventsRoutes.ts
+++ b/rentchain-api/src/routes/eventsRoutes.ts
@@ -15,6 +15,7 @@ const ALLOWED_EVENT_PATTERNS = [
   /^upgrade_prompt_/,
   /^upgrade_modal_/,
   /^registry_/,
+  /^activation_/,
 ];
 
 const SESSION_COOKIE = "rc_sid";

--- a/rentchain-api/src/services/__tests__/adminActivationSummary.test.ts
+++ b/rentchain-api/src/services/__tests__/adminActivationSummary.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type StoredDoc = { id: string; data: any };
+
+const { dbMock, resetDb, seedDoc } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, StoredDoc>>();
+
+  function ensureCollection(name: string) {
+    if (!collections.has(name)) collections.set(name, new Map());
+    return collections.get(name)!;
+  }
+
+  function buildQuery(name: string, filters: Array<{ field: string; op: string; value: any }> = []) {
+    return {
+      where: (field: string, op: string, value: any) => buildQuery(name, [...filters, { field, op, value }]),
+      get: async () => {
+        let rows = Array.from(ensureCollection(name).values());
+        rows = rows.filter((entry) =>
+          filters.every((f) => {
+            const value = entry.data?.[f.field];
+            if (f.op === ">=") return Number(value || 0) >= Number(f.value);
+            if (f.op === "<=") return Number(value || 0) <= Number(f.value);
+            return true;
+          })
+        );
+        return {
+          empty: rows.length === 0,
+          docs: rows.map((row) => ({ id: row.id, data: () => row.data })),
+        };
+      },
+    };
+  }
+
+  return {
+    dbMock: {
+      collection: (name: string) => ({
+        where: (field: string, op: string, value: any) => buildQuery(name, [{ field, op, value }]),
+      }),
+    },
+    resetDb: () => {
+      collections.clear();
+    },
+    seedDoc: (collection: string, id: string, data: any) => {
+      ensureCollection(collection).set(id, { id, data });
+    },
+  };
+});
+
+vi.mock("../../config/firebase", () => ({
+  db: dbMock,
+}));
+
+describe("adminActivationSummary", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    resetDb();
+  });
+
+  it("aggregates activation events, plan/surface breakdowns, and activation insights", async () => {
+    const now = Date.now();
+    seedDoc("events", "activation-1", {
+      name: "activation_property_created",
+      ts: now - 1_000,
+      userId: "user-1",
+      props: { plan: "free", surface: "properties_page", source: "add_property_form", route: "/properties" },
+    });
+    seedDoc("events", "activation-2", {
+      name: "activation_unit_created",
+      ts: now - 900,
+      userId: "user-1",
+      props: { plan: "free", surface: "properties_page", source: "manual_units_modal", route: "/properties" },
+    });
+    seedDoc("events", "activation-3", {
+      name: "activation_tenant_added",
+      ts: now - 800,
+      sessionId: "session-2",
+      props: { plan: "starter", surface: "tenant_invite_modal", source: "tenant_invite_modal", route: "/tenants" },
+    });
+    seedDoc("events", "non-activation-1", {
+      name: "pricing_page_viewed",
+      ts: now - 700,
+      userId: "user-2",
+      props: { surface: "marketing_pricing" },
+    });
+    seedDoc("events", "mixed-1", {
+      type: "legacy_event",
+      occurredAt: new Date(now - 600).toISOString(),
+      payload: {},
+    });
+
+    const { loadAdminActivationSummary } = await import("../admin/adminActivationSummary");
+    const result = await loadAdminActivationSummary({ days: 30 });
+
+    expect(result.activationEvents).toEqual({
+      property_created: 1,
+      unit_created: 1,
+      tenant_added: 1,
+      work_order_created: 0,
+    });
+    expect(result.activatedUsers).toBe(2);
+    expect(result.activationRateEstimate).toBeCloseTo(2 / 3);
+    expect(result.breakdowns.byEventName).toEqual({
+      activation_property_created: 1,
+      activation_tenant_added: 1,
+      activation_unit_created: 1,
+    });
+    expect(result.breakdowns.byPlan).toEqual({
+      free: 2,
+      starter: 1,
+    });
+    expect(result.breakdowns.bySurface).toEqual({
+      properties_page: 2,
+      tenant_invite_modal: 1,
+    });
+    expect(result.insights).toEqual({
+      mostCommonActivationEvent: {
+        eventName: "activation_property_created",
+        count: 1,
+      },
+      planSeeingActivation: {
+        plan: "free",
+        count: 2,
+      },
+      activationOccurring: true,
+    });
+  });
+
+  it("returns safe empty output when no activation events exist", async () => {
+    const { loadAdminActivationSummary } = await import("../admin/adminActivationSummary");
+    const result = await loadAdminActivationSummary({ days: 7 });
+
+    expect(result.activationEvents).toEqual({
+      property_created: 0,
+      unit_created: 0,
+      tenant_added: 0,
+      work_order_created: 0,
+    });
+    expect(result.activatedUsers).toBe(0);
+    expect(result.activationRateEstimate).toBeNull();
+    expect(result.breakdowns).toEqual({
+      byEventName: {},
+      byPlan: {},
+      bySurface: {},
+    });
+    expect(result.insights).toEqual({
+      mostCommonActivationEvent: {
+        eventName: null,
+        count: 0,
+      },
+      planSeeingActivation: {
+        plan: null,
+        count: 0,
+      },
+      activationOccurring: false,
+    });
+  });
+});

--- a/rentchain-api/src/services/admin/adminActivationSummary.ts
+++ b/rentchain-api/src/services/admin/adminActivationSummary.ts
@@ -1,0 +1,217 @@
+import { db } from "../../config/firebase";
+
+export const ACTIVATION_EVENT_NAMES = [
+  "activation_property_created",
+  "activation_unit_created",
+  "activation_tenant_added",
+  "activation_work_order_created",
+] as const;
+
+type ActivationEventName = (typeof ACTIVATION_EVENT_NAMES)[number];
+
+type ActivationEventProps = {
+  surface?: unknown;
+  source?: unknown;
+  plan?: unknown;
+  route?: unknown;
+};
+
+type ActivationEventRow = {
+  name: ActivationEventName;
+  ts: number;
+  props: ActivationEventProps;
+  userId: string | null;
+  sessionId: string | null;
+};
+
+export type ActivationSummaryPayload = {
+  window: {
+    days: number;
+    from: string;
+    to: string;
+  };
+  activationEvents: {
+    property_created: number;
+    unit_created: number;
+    tenant_added: number;
+    work_order_created: number;
+  };
+  activatedUsers: number;
+  activationRateEstimate: number | null;
+  breakdowns: {
+    byEventName: Record<string, number>;
+    byPlan: Record<string, number>;
+    bySurface: Record<string, number>;
+  };
+  insights: {
+    mostCommonActivationEvent: {
+      eventName: string | null;
+      count: number;
+    };
+    planSeeingActivation: {
+      plan: string | null;
+      count: number;
+    };
+    activationOccurring: boolean;
+  };
+};
+
+const ACTIVATION_EVENT_SET = new Set<string>(ACTIVATION_EVENT_NAMES);
+
+function clampDays(input: unknown) {
+  const value = Number(input);
+  if (!Number.isFinite(value)) return 30;
+  return Math.min(Math.max(Math.round(value), 1), 90);
+}
+
+function toNumber(value: unknown) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+function toOptionalString(value: unknown) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isActivationEvent(data: any): data is {
+  name: ActivationEventName;
+  ts: number;
+  props: ActivationEventProps;
+  userId?: unknown;
+  sessionId?: unknown;
+} {
+  if (!ACTIVATION_EVENT_SET.has(String(data?.name || ""))) return false;
+  if (toNumber(data?.ts) == null) return false;
+  if (!isPlainObject(data?.props)) return false;
+  return true;
+}
+
+function toActivationRow(data: any): ActivationEventRow | null {
+  if (!isActivationEvent(data)) return null;
+  return {
+    name: data.name,
+    ts: Number(data.ts),
+    props: data.props,
+    userId: toOptionalString(data.userId),
+    sessionId: toOptionalString(data.sessionId),
+  };
+}
+
+function toBreakdownKey(value: unknown) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function incrementBucket(bucket: Record<string, number>, key: string | null) {
+  if (!key) return;
+  bucket[key] = (bucket[key] || 0) + 1;
+}
+
+function actorKey(row: ActivationEventRow) {
+  if (row.userId) return `user:${row.userId}`;
+  if (row.sessionId) return `session:${row.sessionId}`;
+  return null;
+}
+
+function topBucket(bucket: Record<string, number>) {
+  const entries = Object.entries(bucket);
+  if (!entries.length) return null;
+  entries.sort((a, b) => {
+    if (b[1] !== a[1]) return b[1] - a[1];
+    return a[0].localeCompare(b[0]);
+  });
+  return { key: entries[0][0], count: entries[0][1] };
+}
+
+export async function loadAdminActivationSummary(params?: {
+  days?: number | string;
+}): Promise<ActivationSummaryPayload> {
+  const days = clampDays(params?.days);
+  const to = Date.now();
+  const from = to - days * 24 * 60 * 60 * 1000;
+
+  const snapshot = await db
+    .collection("events")
+    .where("ts", ">=", from)
+    .where("ts", "<=", to)
+    .get();
+
+  const activationRows = (snapshot.docs || [])
+    .map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }))
+    .map(toActivationRow)
+    .filter((row): row is ActivationEventRow => row != null);
+
+  const activationEvents = {
+    property_created: 0,
+    unit_created: 0,
+    tenant_added: 0,
+    work_order_created: 0,
+  };
+  const byEventName: Record<string, number> = {};
+  const byPlan: Record<string, number> = {};
+  const bySurface: Record<string, number> = {};
+  const activatedActorKeys = new Set<string>();
+  const trackedActorKeys = new Set<string>();
+
+  for (const doc of snapshot.docs || []) {
+    const raw = doc.data() || {};
+    const key =
+      toOptionalString(raw.userId) ? `user:${toOptionalString(raw.userId)}` :
+      toOptionalString(raw.sessionId) ? `session:${toOptionalString(raw.sessionId)}` :
+      null;
+    if (key) trackedActorKeys.add(key);
+  }
+
+  for (const row of activationRows) {
+    if (row.name === "activation_property_created") activationEvents.property_created += 1;
+    if (row.name === "activation_unit_created") activationEvents.unit_created += 1;
+    if (row.name === "activation_tenant_added") activationEvents.tenant_added += 1;
+    if (row.name === "activation_work_order_created") activationEvents.work_order_created += 1;
+
+    incrementBucket(byEventName, row.name);
+    incrementBucket(byPlan, toBreakdownKey(row.props.plan));
+    incrementBucket(bySurface, toBreakdownKey(row.props.surface));
+    const key = actorKey(row);
+    if (key) activatedActorKeys.add(key);
+  }
+
+  const mostCommonActivationEvent = topBucket(byEventName);
+  const planSeeingActivation = topBucket(byPlan);
+  const activatedUsers = activatedActorKeys.size;
+  const activationRateEstimate =
+    trackedActorKeys.size > 0 ? activatedUsers / trackedActorKeys.size : null;
+
+  return {
+    window: {
+      days,
+      from: new Date(from).toISOString(),
+      to: new Date(to).toISOString(),
+    },
+    activationEvents,
+    activatedUsers,
+    activationRateEstimate,
+    breakdowns: {
+      byEventName,
+      byPlan,
+      bySurface,
+    },
+    insights: {
+      mostCommonActivationEvent: {
+        eventName: mostCommonActivationEvent?.key || null,
+        count: mostCommonActivationEvent?.count || 0,
+      },
+      planSeeingActivation: {
+        plan: planSeeingActivation?.key || null,
+        count: planSeeingActivation?.count || 0,
+      },
+      activationOccurring: activationRows.length > 0,
+    },
+  };
+}

--- a/rentchain-frontend/src/components/properties/AddPropertyForm.tsx
+++ b/rentchain-frontend/src/components/properties/AddPropertyForm.tsx
@@ -9,6 +9,8 @@ import { colors, radius, text } from "../../styles/tokens";
 import { setOnboardingStep } from "../../api/onboardingApi";
 import { useToast } from "@/components/ui/ToastProvider";
 import { PROVINCE_OPTIONS } from "@/lib/provinces";
+import { track } from "../../lib/analytics";
+import { useAuth } from "../../context/useAuth";
 import "../../styles/propertiesMobile.css";
 
 interface AddPropertyFormProps {
@@ -39,6 +41,7 @@ export const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
   onCreated,
   onExistingPropertyId,
 }) => {
+  const { user } = useAuth();
   const [name, setName] = useState("");
   const [pid, setPid] = useState("");
   const [addressLine1, setAddressLine1] = useState("");
@@ -244,6 +247,12 @@ export const AddPropertyForm: React.FC<AddPropertyFormProps> = ({
         });
       }
       const { property } = await createProperty(payload);
+      track("activation_property_created", {
+        surface: "properties_page",
+        source: "add_property_form",
+        plan: user?.plan || "free",
+        route: typeof window !== "undefined" ? window.location.pathname : undefined,
+      });
       setSuccessText("Property created and units captured successfully.");
       if (onCreated) {
         onCreated(property);

--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
@@ -24,6 +24,7 @@ import { SendApplicationModal } from "./SendApplicationModal";
 import { parseCsvPreview } from "../../utils/csvPreview";
 import { useToast } from "../ui/ToastProvider";
 import { setOnboardingStep } from "../../api/onboardingApi";
+import { track } from "../../lib/analytics";
 import "../../styles/propertiesMobile.css";
 import { useCapabilities } from "@/hooks/useCapabilities";
 import { useEntitlements } from "@/hooks/useEntitlements";
@@ -232,6 +233,12 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
       if (onRefresh) {
         await onRefresh();
       }
+      track("activation_unit_created", {
+        surface: "property_detail_panel",
+        source: "units_csv_import",
+        plan: currentPlan,
+        route: typeof window !== "undefined" ? window.location.pathname : undefined,
+      });
       try {
         await setOnboardingStep("unitAdded", true);
       } catch {

--- a/rentchain-frontend/src/components/tenants/InviteTenantModal.tsx
+++ b/rentchain-frontend/src/components/tenants/InviteTenantModal.tsx
@@ -5,6 +5,7 @@ import { fetchProperties } from "../../api/propertiesApi";
 import { fetchUnitsForProperty } from "../../api/unitsApi";
 import { useCapabilities } from "../../hooks/useCapabilities";
 import { dispatchUpgradePrompt, resolveRequiredPlanLabel } from "../../lib/upgradePrompt";
+import { track } from "../../lib/analytics";
 import { useAuth } from "../../context/useAuth";
 import { useLanguage } from "../../context/LanguageContext";
 import { useToast } from "../ui/ToastProvider";
@@ -234,6 +235,12 @@ export const InviteTenantModal: React.FC<Props> = ({
         setInfoMsg(emailError || "Email was not sent. You can copy or open the link below.");
       }
       setInfoMsg((prev) => (prev ? `${prev} ${copy.postInviteHint}` : copy.postInviteHint));
+      track("activation_tenant_added", {
+        surface: "tenant_invite_modal",
+        source: "tenant_invite_modal",
+        plan: user?.plan || "free",
+        route: typeof window !== "undefined" ? window.location.pathname : undefined,
+      });
       await setOnboardingStep("tenantInvited", true).catch(() => {});
       onInviteCreated?.(data);
     } catch (e: any) {

--- a/rentchain-frontend/src/lib/analytics.test.ts
+++ b/rentchain-frontend/src/lib/analytics.test.ts
@@ -61,6 +61,42 @@ describe("track", () => {
     );
   });
 
+  it("posts activation analytics events through the same tracker endpoint", async () => {
+    vi.stubEnv("MODE", "production");
+    const { track } = await import("./analytics");
+
+    track("activation_property_created", {
+      surface: "properties_page",
+      source: "add_property_form",
+      plan: "free",
+      route: "/properties",
+    });
+    await Promise.resolve();
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "https://api.rentchain.test/api/events/track",
+      expect.objectContaining({
+        method: "POST",
+        credentials: "include",
+        keepalive: true,
+      })
+    );
+    const fetchCall = vi.mocked(globalThis.fetch).mock.calls[0];
+    const payload = JSON.parse(String(fetchCall?.[1]?.body || "{}"));
+    expect(payload).toEqual(
+      expect.objectContaining({
+        name: "activation_property_created",
+        props: {
+          surface: "properties_page",
+          source: "add_property_form",
+          plan: "free",
+          route: "/properties",
+        },
+        ts: expect.any(String),
+      })
+    );
+  });
+
   it("does not post when telemetry is disabled", async () => {
     vi.stubEnv("MODE", "production");
     mocks.isTelemetryEnabled.mockReturnValue(false);

--- a/rentchain-frontend/src/pages/PropertiesPage.test.tsx
+++ b/rentchain-frontend/src/pages/PropertiesPage.test.tsx
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   fetchPropertiesMock: vi.fn(),
   fetchCountsMock: vi.fn(),
   useToastMock: vi.fn(),
+  useAuthMock: vi.fn(),
 }));
 
 vi.mock("../api/propertiesApi", () => ({
@@ -71,6 +72,10 @@ vi.mock("../components/ui/ToastProvider", () => ({
   useToast: mocks.useToastMock,
 }));
 
+vi.mock("../context/useAuth", () => ({
+  useAuth: mocks.useAuthMock,
+}));
+
 vi.mock("../lib/analytics", () => ({
   track: vi.fn(),
 }));
@@ -85,6 +90,9 @@ describe("PropertiesPage", () => {
     }));
     mocks.fetchCountsMock.mockResolvedValue({ counts: {} });
     mocks.useToastMock.mockReturnValue({ showToast: vi.fn() });
+    mocks.useAuthMock.mockReturnValue({
+      user: { id: "user-1", plan: "free", role: "landlord" },
+    });
   });
 
   it("renders active and archived property filters", async () => {

--- a/rentchain-frontend/src/pages/PropertiesPage.tsx
+++ b/rentchain-frontend/src/pages/PropertiesPage.tsx
@@ -32,10 +32,8 @@ import "../styles/propertiesMobile.css";
 import "./PropertiesPage.css";
 import { track } from "../lib/analytics";
 import { resolveReturnToParam } from "../lib/propertyGate";
-import { useAuth } from "../context/useAuth";
 
 const PropertiesPage: React.FC = () => {
-  const { user } = useAuth();
   const [properties, setProperties] = useState<Property[]>([]);
   const [propertyView, setPropertyView] = useState<"active" | "archived">("active");
   const [selectedPropertyId, setSelectedPropertyId] = useState<string | null>(
@@ -333,7 +331,6 @@ const PropertiesPage: React.FC = () => {
       track("activation_unit_created", {
         surface: "properties_page",
         source: "manual_units_modal",
-        plan: user?.plan || "free",
         route: typeof window !== "undefined" ? window.location.pathname : undefined,
       });
       // Update local state so the units panel renders immediately

--- a/rentchain-frontend/src/pages/PropertiesPage.tsx
+++ b/rentchain-frontend/src/pages/PropertiesPage.tsx
@@ -32,8 +32,10 @@ import "../styles/propertiesMobile.css";
 import "./PropertiesPage.css";
 import { track } from "../lib/analytics";
 import { resolveReturnToParam } from "../lib/propertyGate";
+import { useAuth } from "../context/useAuth";
 
 const PropertiesPage: React.FC = () => {
+  const { user } = useAuth();
   const [properties, setProperties] = useState<Property[]>([]);
   const [propertyView, setPropertyView] = useState<"active" | "archived">("active");
   const [selectedPropertyId, setSelectedPropertyId] = useState<string | null>(
@@ -328,6 +330,12 @@ const PropertiesPage: React.FC = () => {
     setSavingUnits(true);
     try {
       await addUnitsManual(activePropertyId, clean);
+      track("activation_unit_created", {
+        surface: "properties_page",
+        source: "manual_units_modal",
+        plan: user?.plan || "free",
+        route: typeof window !== "undefined" ? window.location.pathname : undefined,
+      });
       // Update local state so the units panel renders immediately
       setProperties((prev) =>
         prev.map((p) =>

--- a/rentchain-frontend/src/pages/landlord/WorkOrderNewPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/WorkOrderNewPage.tsx
@@ -4,11 +4,14 @@ import { Button, Card, Input } from "../../components/ui/Ui";
 import { fetchProperties } from "../../api/propertiesApi";
 import { fetchUnitsForProperty } from "../../api/unitsApi";
 import { createWorkOrder, listContractorInvites, type ContractorInvite, type WorkOrderPriority } from "../../api/workOrdersApi";
+import { track } from "../../lib/analytics";
+import { useAuth } from "../../context/useAuth";
 
 const priorities: WorkOrderPriority[] = ["low", "medium", "high", "urgent"];
 
 export default function WorkOrderNewPage() {
   const nav = useNavigate();
+  const { user } = useAuth();
   const [saving, setSaving] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
   const [properties, setProperties] = React.useState<Array<{ id: string; name: string }>>([]);
@@ -209,6 +212,12 @@ export default function WorkOrderNewPage() {
                   assignedContractorId: assignedContractorId || null,
                   invitedContractorIds: selectedInvites,
                   notesInternal: notesInternal.trim(),
+                });
+                track("activation_work_order_created", {
+                  surface: "work_order_new_page",
+                  source: "work_order_new_page",
+                  plan: user?.plan || "free",
+                  route: typeof window !== "undefined" ? window.location.pathname : undefined,
                 });
                 nav("/work-orders");
               } catch (err: any) {


### PR DESCRIPTION
## Summary

Implements Activation Tracking v1 by measuring first meaningful product use through the existing analytics pipeline.

This mission adds lightweight activation event capture for key landlord workflows and introduces an admin-only activation summary route so RentChain can measure real product usage beyond pricing, billing, and upgrade behavior.

## What changed

### Frontend activation event tracking
Added activation events for first meaningful product actions:

- property creation
- unit creation
- tenant invite creation
- work order creation

These events are sent through the existing frontend analytics client using the current `track(...)` pipeline.

### Backend analytics support
Extended the backend analytics layer to accept `activation_*` events through the existing `/api/events/track` path.

Added a new admin-only activation summary service and route:

- `GET /api/admin/analytics/activation-summary`

### Activation summary output
The new route returns a bounded-window activation summary including:

- `window`
- `activationEvents`
- `activatedUsers`
- `activationRateEstimate`
- `breakdowns.byEventName`
- `breakdowns.byPlan`
- `breakdowns.bySurface`
- `insights.mostCommonActivationEvent`
- `insights.planSeeingActivation`
- `insights.activationOccurring`

## Files changed

- `rentchain-api/src/services/admin/adminActivationSummary.ts`
- `rentchain-api/src/routes/adminRoutes.ts`
- `rentchain-api/src/routes/eventsRoutes.ts`
- `rentchain-api/src/services/__tests__/adminActivationSummary.test.ts`
- `rentchain-api/src/routes/__tests__/adminActivationSummaryRoute.test.ts`
- `rentchain-api/src/routes/__tests__/eventsRoutes.test.ts`
- `rentchain-frontend/src/components/properties/AddPropertyForm.tsx`
- `rentchain-frontend/src/pages/PropertiesPage.tsx`
- `rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx`
- `rentchain-frontend/src/components/tenants/InviteTenantModal.tsx`
- `rentchain-frontend/src/pages/landlord/WorkOrderNewPage.tsx`
- `rentchain-frontend/src/lib/analytics.test.ts`

## Verification

### Backend
- targeted backend tests passed for:
  - activation summary aggregation
  - activation summary route
  - events route acceptance
- `npm run build`

### Frontend
- targeted analytics transport tests passed
- `npm run build`

## Why this change was made

Previous analytics work focused on:
- pricing interaction
- billing behavior
- upgrade intent
- conversion validation

But RentChain also needs to know whether users are actually beginning to use the product.

This mission introduces a first-value measurement layer so the system can distinguish:
- browsing and pricing exploration
from
- meaningful product activation

## Important note

Activation tracking now measures first meaningful product use through the existing analytics pipeline.

It does this without changing:
- pricing
- billing
- checkout
- upgrade behavior

## Semantic note

`activation_tenant_added` is implemented on tenant invite creation in this v1 pass.

That means it currently reflects the start of tenant workflow activity rather than a later fully-completed tenant lifecycle milestone.

## Intentionally unchanged

- no pricing changes
- no billing changes
- no checkout changes
- no upgrade flow changes
- no new analytics system

## Known limitations / follow-up opportunities

- activation is still a v1 proxy for first value, not a perfect product-success model
- `activation_tenant_added` currently reflects tenant invite initiation rather than a stricter tenant-completion milestone
- `activationRateEstimate` depends on available actor identifiers and should be interpreted directionally
- future missions may refine the activation model once more real user behavior appears