### PR TITLE
fix: resolve activation flow blockers v1

### DIFF
--- a/rentchain-api/src/routes/__tests__/eventsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/eventsRoutes.test.ts
@@ -212,6 +212,25 @@ describe("eventsRoutes", () => {
     ]);
   });
 
+  it("accepts empty-state analytics events used by the activation flow", async () => {
+    const router = await createRouter();
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/track",
+      body: {
+        name: "empty_state_cta_clicked",
+        props: {
+          pageKey: "properties",
+          ctaKey: "add_property",
+        },
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+    expect(telemetryMocks.incrementCounter).toHaveBeenCalledWith({ name: "empty_state_cta_clicked" });
+  });
+
   it("persists authenticated events with userId and no sessionId", async () => {
     const router = await createRouter();
     const res = await invokeRouter(router, {

--- a/rentchain-api/src/routes/eventsRoutes.ts
+++ b/rentchain-api/src/routes/eventsRoutes.ts
@@ -16,6 +16,8 @@ const ALLOWED_EVENT_PATTERNS = [
   /^upgrade_modal_/,
   /^registry_/,
   /^activation_/,
+  /^empty_state_/,
+  /^onboarding_/,
 ];
 
 const SESSION_COOKIE = "rc_sid";

--- a/rentchain-frontend/src/api/telemetryApi.ts
+++ b/rentchain-frontend/src/api/telemetryApi.ts
@@ -1,4 +1,4 @@
-import { apiFetch } from "@/lib/apiClient";
+import { apiFetch } from "./apiFetch";
 import { isTelemetryEnabled } from "@/lib/telemetry";
 
 export async function logTelemetryEvent(

--- a/rentchain-frontend/src/pages/PropertiesPage.test.tsx
+++ b/rentchain-frontend/src/pages/PropertiesPage.test.tsx
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   fetchCountsMock: vi.fn(),
   useToastMock: vi.fn(),
   useAuthMock: vi.fn(),
+  useCapabilitiesMock: vi.fn(),
 }));
 
 vi.mock("../api/propertiesApi", () => ({
@@ -19,7 +20,25 @@ vi.mock("../components/layout/MacShell", () => ({
 }));
 
 vi.mock("../components/properties/AddPropertyForm", () => ({
-  AddPropertyForm: () => <div>Add form</div>,
+  AddPropertyForm: ({ onCreated }: any) => (
+    <div>
+      <div>Add form</div>
+      {onCreated ? (
+        <button
+          type="button"
+          onClick={() =>
+            onCreated({
+              id: "prop-created",
+              name: "Created Property",
+              portfolioStatus: "active",
+            })
+          }
+        >
+          Complete property setup
+        </button>
+      ) : null}
+    </div>
+  ),
 }));
 
 vi.mock("../components/property/PropertyActivityPanel", () => ({
@@ -76,6 +95,10 @@ vi.mock("../context/useAuth", () => ({
   useAuth: mocks.useAuthMock,
 }));
 
+vi.mock("../hooks/useCapabilities", () => ({
+  useCapabilities: mocks.useCapabilitiesMock,
+}));
+
 vi.mock("../lib/analytics", () => ({
   track: vi.fn(),
 }));
@@ -92,6 +115,11 @@ describe("PropertiesPage", () => {
     mocks.useToastMock.mockReturnValue({ showToast: vi.fn() });
     mocks.useAuthMock.mockReturnValue({
       user: { id: "user-1", plan: "free", role: "landlord" },
+    });
+    mocks.useCapabilitiesMock.mockReturnValue({
+      caps: { plan: "free" },
+      features: { tenant_invites: false },
+      loading: false,
     });
   });
 
@@ -130,5 +158,25 @@ describe("PropertiesPage", () => {
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Add your first property" })).toBeInTheDocument();
     expect(screen.getByText("Start here: add your first property")).toBeInTheDocument();
+  });
+
+  it("shows a free-safe next step after property creation", async () => {
+    mocks.fetchPropertiesMock.mockResolvedValue({ items: [] });
+
+    render(
+      <MemoryRouter>
+        <PropertiesPage />
+      </MemoryRouter>
+    );
+
+    const setupButtons = await screen.findAllByRole("button", {
+      name: "Complete property setup",
+    });
+    fireEvent.click(setupButtons[0]);
+
+    expect(await screen.findByText("Your first property is set up")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add a unit" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Send application" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Invite a tenant" })).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/pages/PropertiesPage.tsx
+++ b/rentchain-frontend/src/pages/PropertiesPage.tsx
@@ -32,6 +32,7 @@ import "../styles/propertiesMobile.css";
 import "./PropertiesPage.css";
 import { track } from "../lib/analytics";
 import { resolveReturnToParam } from "../lib/propertyGate";
+import { useCapabilities } from "../hooks/useCapabilities";
 
 const PropertiesPage: React.FC = () => {
   const [properties, setProperties] = useState<Property[]>([]);
@@ -66,7 +67,9 @@ const PropertiesPage: React.FC = () => {
   const [leasePackOpen, setLeasePackOpen] = useState(false);
   const [leasePackInitialPropertyId, setLeasePackInitialPropertyId] = useState<string | null>(null);
   const { showToast } = useToast();
+  const { features } = useCapabilities();
   const currentProperties = properties?.length ?? 0;
+  const canInviteTenant = features?.tenant_invites !== false;
   const archiveHelpCopy =
     propertyView === "archived"
       ? "Archived properties are hidden from active portfolio views but preserved for records and history."
@@ -313,9 +316,9 @@ const PropertiesPage: React.FC = () => {
     navigate("/dashboard?onboarding=ready", { replace: true });
   };
 
-  const handleSaveUnits = async () => {
+  const handleSaveUnits = async (unitsOverride?: UnitInput[]) => {
     if (!activePropertyId) return;
-    const clean = draftUnits
+    const clean = (unitsOverride || draftUnits)
       .map((u) => ({
         ...u,
         unitNumber: u.unitNumber.trim(),
@@ -731,8 +734,11 @@ const PropertiesPage: React.FC = () => {
                 >
                   Add a unit
                 </Button>
-                <Button variant="secondary" onClick={() => navigate("/tenants")}>
-                  Invite a tenant
+                <Button
+                  variant="secondary"
+                  onClick={() => navigate(canInviteTenant ? "/tenants" : "/applications?openSendApplication=1")}
+                >
+                  {canInviteTenant ? "Invite a tenant" : "Send application"}
                 </Button>
               </div>
             </div>
@@ -1181,6 +1187,16 @@ const UnitsModal = ({
     ]);
   const removeRow = (idx: number) =>
     setUnits(units.length <= 1 ? units : units.filter((_, i) => i !== idx));
+  const normalizedUnits = units
+    .map((u) => ({
+      unitNumber: String(u.unitNumber || "").trim(),
+      beds: Number(u.beds),
+      baths: Number(u.baths),
+      sqft: Number(u.sqft),
+      marketRent: Number(u.marketRent),
+      status: u.status === "occupied" ? "occupied" : "vacant",
+    }))
+    .filter((u) => u.unitNumber.length > 0);
 
   return (
     <div
@@ -1353,7 +1369,7 @@ const UnitsModal = ({
             </button>
             <button
               type="button"
-              onClick={onSave}
+              onClick={() => onSave(normalizedUnits)}
               disabled={saving}
               style={{
                 padding: "8px 12px",


### PR DESCRIPTION
## Summary

Resolves a set of blockers in the new first-value activation flow that prevented users from completing or properly tracking their first meaningful actions.

This fix stabilizes the guided activation path, ensures activation events are accepted by the backend, corrects telemetry routing, and prevents Free-tier users from being directed to blocked next steps.

## What changed

### Guided activation path (Properties page)
- Fixed the `Add a unit` next-step flow so it submits a valid unit payload
- Ensured the guided success-state CTA leads to a working unit creation path instead of failing with `no units provided`

### Activation event acceptance
- Updated backend `/api/events/track` allowlist to accept activation-flow events in the `empty_state_*` / `onboarding_*` families
- Prevented `400 invalid_event_name` errors during activation tracking

### Free-tier next-step handling
- Made post-property success CTAs capability-aware
- Replaced `Invite a tenant` for Free-tier users with a safe alternative (`Send application`)
- Avoids directing users to a blocked feature

### Telemetry routing
- Fixed telemetry API calls to use the shared backend API resolver
- Prevented `POST /api/telemetry 404` by ensuring requests target the backend host instead of same-origin

## Files changed

- `rentchain-api/src/routes/eventsRoutes.ts`
- `rentchain-api/src/routes/__tests__/eventsRoutes.test.ts`
- `rentchain-frontend/src/api/telemetryApi.ts`
- `rentchain-frontend/src/pages/PropertiesPage.tsx`
- `rentchain-frontend/src/pages/PropertiesPage.test.tsx`

## Verification

### Frontend
- targeted tests passed (Properties page, related flows)
- `npm run build`

### Backend
- events route tests passed
- `npm run build`

## Why this change was made

The new activation flow introduced in First Value Activation Flow v1 exposed several real blockers:

- the guided unit creation path could submit an empty payload
- activation events were being rejected by the backend
- Free-tier users were shown a blocked next-step CTA
- telemetry calls were still hitting an incorrect endpoint

These issues prevented:
- successful activation
- accurate analytics tracking
- a coherent first-use experience

## Important note

These fixes are intentionally narrow:

- no changes to pricing
- no changes to billing or checkout
- no redesign of activation or onboarding

The goal is to make the existing activation flow **function correctly and reliably**, not to expand its scope.

## Known limitations / follow-up opportunities

- the unit-creation fix is scoped to the guided success-state path
- post-activation guidance could be further refined in future missions
- additional activation-related event names may require explicit allowlist updates if expanded