### PR TITLE
fix: harden stripe connection error handling

### DIFF
--- a/rentchain-api/src/routes/__tests__/billingRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/billingRoutes.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const resolveLandlordAndTierMock = vi.fn();
+const getStripeClientMock = vi.fn();
+const stripeNotConfiguredResponseMock = vi.fn(() => ({ ok: false, error: "stripe_not_configured" }));
+const isStripeNotConfiguredErrorMock = vi.fn((err: any) => String(err?.code || err?.message || "").trim() === "stripe_not_configured");
+const landlordDocGetMock = vi.fn(async () => ({ exists: false, data: () => null }));
+const landlordDocSetMock = vi.fn(async () => undefined);
 
 vi.mock("../../middleware/requireAuth", () => ({
   requireAuth: (req: any, _res: any, next: any) => {
@@ -22,22 +27,20 @@ vi.mock("../../config/firebase", () => ({
   db: {
     collection: () => ({
       doc: () => ({
-        get: async () => ({ exists: false, data: () => null }),
-        set: async () => undefined,
+        get: landlordDocGetMock,
+        set: landlordDocSetMock,
       }),
     }),
   },
 }));
 
 vi.mock("../../services/stripeService", () => ({
-  getStripeClient: vi.fn(() => {
-    throw new Error("not needed in billingRoutes subscription-status test");
-  }),
+  getStripeClient: getStripeClientMock,
 }));
 
 vi.mock("../../lib/stripeNotConfigured", () => ({
-  stripeNotConfiguredResponse: vi.fn(() => ({ ok: false, error: "stripe_not_configured" })),
-  isStripeNotConfiguredError: vi.fn(() => false),
+  stripeNotConfiguredResponse: stripeNotConfiguredResponseMock,
+  isStripeNotConfiguredError: isStripeNotConfiguredErrorMock,
 }));
 
 vi.mock("../../config/screeningConfig", () => ({
@@ -54,7 +57,7 @@ vi.mock("../../billing/screeningPricing", () => ({
 
 async function invokeRouter(
   router: any,
-  options: { method: string; url: string; headers?: Record<string, string> }
+  options: { method: string; url: string; headers?: Record<string, string>; body?: any }
 ) {
   return await new Promise<{ status: number; body: any }>((resolve, reject) => {
     const req: any = {
@@ -63,7 +66,7 @@ async function invokeRouter(
       originalUrl: options.url,
       path: options.url,
       headers: options.headers ?? {},
-      body: {},
+      body: options.body ?? {},
       query: {},
       get(name: string) {
         return this.headers[String(name).toLowerCase()];
@@ -94,6 +97,17 @@ async function invokeRouter(
 describe("billingRoutes subscription status", () => {
   beforeEach(() => {
     resolveLandlordAndTierMock.mockReset();
+    getStripeClientMock.mockReset();
+    stripeNotConfiguredResponseMock.mockClear();
+    isStripeNotConfiguredErrorMock.mockClear();
+    landlordDocGetMock.mockReset();
+    landlordDocSetMock.mockReset();
+    getStripeClientMock.mockImplementation(() => {
+      throw new Error("not needed in billingRoutes subscription-status test");
+    });
+    landlordDocGetMock.mockResolvedValue({ exists: false, data: () => null });
+    landlordDocSetMock.mockResolvedValue(undefined);
+    process.env.STRIPE_PRICE_STARTER_MONTHLY_TEST = "price_test_starter_monthly";
   });
 
   it("returns the effective canonical tier from landlord resolution", async () => {
@@ -152,5 +166,80 @@ describe("billingRoutes subscription status", () => {
       status: "active",
       isActive: true,
     });
+  });
+
+  it("returns a controlled 503 when Stripe checkout hits a connection failure", async () => {
+    getStripeClientMock.mockReturnValue({
+      checkout: {
+        sessions: {
+          create: vi.fn(async () => {
+            const err: any = new Error("An error occurred with our connection to Stripe.");
+            err.name = "StripeConnectionError";
+            err.type = "StripeConnectionError";
+            throw err;
+          }),
+        },
+      },
+    });
+
+    const router = (await import("../billingRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/checkout",
+      headers: {
+        "x-test-user": JSON.stringify({ id: "u1", landlordId: "landlord-1", role: "landlord", plan: "free" }),
+      },
+      body: {
+        tier: "starter",
+        interval: "monthly",
+      },
+    });
+
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({ ok: false, error: "checkout_temporarily_unavailable" });
+  });
+
+  it("returns a controlled 503 when Stripe billing portal hits a connection failure", async () => {
+    landlordDocGetMock.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        stripeCustomerId: "cus_123",
+        email: "owner@example.com",
+        name: "Owner",
+      }),
+    });
+    getStripeClientMock.mockReturnValue({
+      billingPortal: {
+        sessions: {
+          create: vi.fn(async () => {
+            const err: any = new Error("An error occurred with our connection to Stripe.");
+            err.name = "StripeConnectionError";
+            err.type = "StripeConnectionError";
+            throw err;
+          }),
+        },
+      },
+      customers: {
+        create: vi.fn(),
+      },
+    });
+
+    const router = (await import("../billingRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/portal",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "u1",
+          landlordId: "landlord-1",
+          role: "landlord",
+          plan: "starter",
+          email: "owner@example.com",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({ ok: false, error: "billing_portal_temporarily_unavailable" });
   });
 });

--- a/rentchain-api/src/routes/billingRoutes.ts
+++ b/rentchain-api/src/routes/billingRoutes.ts
@@ -137,6 +137,52 @@ function appendBillingCanceled(path: string): string {
   if (path.includes("?")) return `${path}&billing=canceled=1`;
   return `${path}?billing=canceled=1`;
 }
+
+function isStripeConnectionError(err: any): boolean {
+  const name = String(err?.name || "").trim();
+  const type = String(err?.type || "").trim();
+  const code = String(err?.code || "").trim();
+  const message = String(err?.message || "").trim();
+  return (
+    name === "StripeConnectionError" ||
+    type === "StripeConnectionError" ||
+    code === "StripeConnectionError" ||
+    /connection to stripe/i.test(message)
+  );
+}
+
+function logStripeFailure(scope: string, err: any, extra: Record<string, unknown> = {}) {
+  console.error(`[billing/${scope}] Stripe request failed`, {
+    message: err?.message,
+    name: err?.name,
+    type: err?.type,
+    code: err?.code,
+    statusCode: err?.statusCode,
+    requestId: err?.requestId || err?.raw?.requestId || null,
+    ...extra,
+  });
+}
+
+function sendStripeRouteError(res: any, scope: "checkout" | "portal", err: any) {
+  if (isStripeNotConfiguredError(err)) {
+    return res.status(400).json(stripeNotConfiguredResponse());
+  }
+
+  if (isStripeConnectionError(err)) {
+    logStripeFailure(scope, err);
+    return res.status(503).json({
+      ok: false,
+      error: scope === "checkout" ? "checkout_temporarily_unavailable" : "billing_portal_temporarily_unavailable",
+    });
+  }
+
+  logStripeFailure(scope, err);
+  return res.status(500).json({
+    ok: false,
+    error: scope === "checkout" ? "checkout_failed" : "billing_portal_failed",
+  });
+}
+
 router.use((req, res, next) => {
   res.setHeader("x-billing-routes", "present");
   next();
@@ -170,48 +216,39 @@ router.get(
 );
 
 async function handleCheckout(req: any, res: any) {
-  const landlordId = req.user?.landlordId || req.user?.id;
-  const userId = req.user?.id || null;
-  if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
-
-  const { tier, interval, plan, requiredPlan, planKey, featureKey, source, redirectTo } =
-    req.body || {};
-  const resolvedTier = normalizeTier(tier || plan || requiredPlan || planKey);
-  if (!resolvedTier) {
-    return res.status(400).json({ ok: false, error: "missing_tier" });
-  }
-  if (resolvedTier === "free") {
-    return res.status(400).json({ ok: false, error: "invalid_tier" });
-  }
-  const resolvedInterval = normalizeInterval(interval);
-
-  const resolved = resolvePriceId(resolvedTier, resolvedInterval);
-  if (!resolved.priceId) {
-    console.error("[billing/checkout] price not configured or invalid", { envKey: resolved.envKey });
-    const statusCode = process.env.NODE_ENV === "production" ? 503 : 400;
-    return res.status(statusCode).json({
-      ok: false,
-      error: "price_not_configured",
-      detail: `${resolved.envKey} must be Stripe price id price_...`,
-    });
-  }
-
-  let stripe: any;
   try {
-    stripe = getStripeClient();
-  } catch (err) {
-    if (isStripeNotConfiguredError(err)) {
-      return res.status(400).json(stripeNotConfiguredResponse());
+    const landlordId = req.user?.landlordId || req.user?.id;
+    const userId = req.user?.id || null;
+    if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
+
+    const { tier, interval, plan, requiredPlan, planKey, featureKey, source, redirectTo } =
+      req.body || {};
+    const resolvedTier = normalizeTier(tier || plan || requiredPlan || planKey);
+    if (!resolvedTier) {
+      return res.status(400).json({ ok: false, error: "missing_tier" });
     }
-    throw err;
-  }
+    if (resolvedTier === "free") {
+      return res.status(400).json({ ok: false, error: "invalid_tier" });
+    }
+    const resolvedInterval = normalizeInterval(interval);
 
-  const featureKeyValue = String(featureKey || "unknown").trim().slice(0, 80);
-  const sourceValue = String(source || "unknown").trim().slice(0, 80);
-  const redirectToValue = sanitizeRedirectTo(redirectTo);
-  const frontendUrl = resolveFrontendBase();
+    const resolved = resolvePriceId(resolvedTier, resolvedInterval);
+    if (!resolved.priceId) {
+      console.error("[billing/checkout] price not configured or invalid", { envKey: resolved.envKey });
+      const statusCode = process.env.NODE_ENV === "production" ? 503 : 400;
+      return res.status(statusCode).json({
+        ok: false,
+        error: "price_not_configured",
+        detail: `${resolved.envKey} must be Stripe price id price_...`,
+      });
+    }
 
-  try {
+    const stripe = getStripeClient();
+    const featureKeyValue = String(featureKey || "unknown").trim().slice(0, 80);
+    const sourceValue = String(source || "unknown").trim().slice(0, 80);
+    const redirectToValue = sanitizeRedirectTo(redirectTo);
+    const frontendUrl = resolveFrontendBase();
+
     const session = await stripe.checkout.sessions.create({
       mode: "subscription",
       payment_method_types: ["card"],
@@ -242,10 +279,7 @@ async function handleCheckout(req: any, res: any) {
 
     return res.status(200).json({ ok: true, url: session.url });
   } catch (err: any) {
-    console.error("[billing/checkout] Failed to create Checkout Session", {
-      message: err?.message,
-    });
-    return res.status(500).json({ ok: false, error: "checkout_failed" });
+    return sendStripeRouteError(res, "checkout", err);
   }
 }
 
@@ -254,46 +288,41 @@ router.post("/subscribe", requireAuth, handleCheckout);
 router.post("/upgrade", requireAuth, handleCheckout);
 
 router.post("/portal", requireAuth, async (req: any, res) => {
-  const landlordId = req.user?.landlordId || req.user?.id;
-  if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
-
-  let stripe: any;
   try {
-    stripe = getStripeClient();
-  } catch (err) {
-    if (isStripeNotConfiguredError(err)) {
-      return res.status(400).json(stripeNotConfiguredResponse());
+    const landlordId = req.user?.landlordId || req.user?.id;
+    if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
+
+    const stripe = getStripeClient();
+    const landlordRef = db.collection("landlords").doc(String(landlordId));
+    const landlordSnap = await landlordRef.get();
+    if (!landlordSnap.exists) {
+      return res.status(404).json({ ok: false, error: "landlord_not_found" });
     }
-    throw err;
-  }
+    const landlord = landlordSnap.data() as any;
 
-  const landlordRef = db.collection("landlords").doc(String(landlordId));
-  const landlordSnap = await landlordRef.get();
-  if (!landlordSnap.exists) {
-    return res.status(404).json({ ok: false, error: "landlord_not_found" });
-  }
-  const landlord = landlordSnap.data() as any;
+    let stripeCustomerId = String(landlord?.stripeCustomerId || "").trim();
+    if (!stripeCustomerId) {
+      const email = String(landlord?.email || req.user?.email || "").trim() || undefined;
+      const name = String(landlord?.name || landlord?.companyName || "").trim() || undefined;
+      const customer = await stripe.customers.create({
+        email,
+        name,
+        metadata: { landlordId: String(landlordId) },
+      });
+      stripeCustomerId = customer.id;
+      await landlordRef.set({ stripeCustomerId }, { merge: true });
+    }
 
-  let stripeCustomerId = String(landlord?.stripeCustomerId || "").trim();
-  if (!stripeCustomerId) {
-    const email = String(landlord?.email || req.user?.email || "").trim() || undefined;
-    const name = String(landlord?.name || landlord?.companyName || "").trim() || undefined;
-    const customer = await stripe.customers.create({
-      email,
-      name,
-      metadata: { landlordId: String(landlordId) },
+    const frontendUrl = resolveFrontendBase();
+    const session = await stripe.billingPortal.sessions.create({
+      customer: stripeCustomerId,
+      return_url: `${frontendUrl}/billing`,
     });
-    stripeCustomerId = customer.id;
-    await landlordRef.set({ stripeCustomerId }, { merge: true });
+
+    return res.status(200).json({ ok: true, url: session.url });
+  } catch (err: any) {
+    return sendStripeRouteError(res, "portal", err);
   }
-
-  const frontendUrl = resolveFrontendBase();
-  const session = await stripe.billingPortal.sessions.create({
-    customer: stripeCustomerId,
-    return_url: `${frontendUrl}/billing`,
-  });
-
-  return res.status(200).json({ ok: true, url: session.url });
 });
 
 export default router;


### PR DESCRIPTION
## Summary

Hardens the billing checkout and billing portal routes against Stripe connection failures.

This change ensures Stripe network/connectivity issues return controlled 503 responses instead of surfacing as fatal unhandled rejections, while also improving production logging for diagnosis.

## What changed

### Billing checkout
- Added explicit Stripe connection failure classification
- Improved route-level logging for Stripe request failures
- Returns controlled:
  - `503 { ok: false, error: "checkout_temporarily_unavailable" }`
  when Stripe connectivity fails

### Billing portal
- Wrapped the route in route-level `try/catch`
- Prevented Stripe connection failures from escaping as process-level unhandled rejections
- Returns controlled:
  - `503 { ok: false, error: "billing_portal_temporarily_unavailable" }`
  when Stripe connectivity fails

### Logging
- Added clearer Stripe failure logging including useful diagnostic fields when available:
  - `message`
  - `name`
  - `type`
  - `code`
  - `statusCode`
  - `requestId`

### Tests
- Added backend coverage for controlled 503 behavior on both checkout and billing portal routes when Stripe connectivity fails

## Files changed

- `rentchain-api/src/routes/billingRoutes.ts`
- `rentchain-api/src/routes/__tests__/billingRoutes.test.ts`

## Verification

### Backend
- `npm run test -- src/routes/__tests__/billingRoutes.test.ts`
- `npm run build`

## Why this change was made

Production logs showed Stripe connection failures of the form:

- `StripeConnectionError: An error occurred with our connection to Stripe. Request was retried 2 times.`

Those failures were not handled consistently across billing routes, and at least one route (`/api/billing/portal`) could let the rejection surface into fatal process-level handling.

This fix contains those failures at the route level and makes production diagnosis clearer.

## Important note

This change fixes **application-level handling** of Stripe connectivity failures.

It does **not** resolve the underlying Cloud Run → Stripe network/connectivity issue, which still requires separate infrastructure review.

## Impact

- prevents fatal unhandled rejection behavior from Stripe connection failures
- gives users controlled 503 responses instead of opaque server failures
- improves production logs for troubleshooting Stripe connectivity problems

## Known limitations / follow-up opportunities

- underlying Cloud Run outbound connectivity to Stripe still needs manual review
- this change is intentionally narrow and does not redesign billing architecture