### PR TITLE
feat: add stripe checkout success handling v1

### DIFF
--- a/rentchain-api/src/routes/__tests__/billingRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/billingRoutes.test.ts
@@ -61,14 +61,15 @@ async function invokeRouter(
   options: { method: string; url: string; headers?: Record<string, string>; body?: any }
 ) {
   return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const url = new URL(`http://example.test${options.url}`);
     const req: any = {
       method: options.method,
-      url: options.url,
-      originalUrl: options.url,
-      path: options.url,
+      url: `${url.pathname}${url.search}`,
+      originalUrl: `${url.pathname}${url.search}`,
+      path: url.pathname,
       headers: options.headers ?? {},
       body: options.body ?? {},
-      query: {},
+      query: Object.fromEntries(url.searchParams.entries()),
       get(name: string) {
         return this.headers[String(name).toLowerCase()];
       },
@@ -394,5 +395,109 @@ describe("billingRoutes subscription status", () => {
         },
       })
     );
+  });
+
+  it("returns verified checkout session status and syncs the landlord plan", async () => {
+    const retrieveMock = vi.fn(async () => ({
+      id: "cs_123",
+      status: "complete",
+      payment_status: "paid",
+      customer: "cus_123",
+      metadata: {
+        landlordId: "landlord-1",
+        tier: "pro",
+        interval: "monthly",
+      },
+      subscription: {
+        id: "sub_123",
+        status: "active",
+        metadata: {
+          landlordId: "landlord-1",
+          tier: "pro",
+          interval: "monthly",
+        },
+        current_period_end: 1_735_689_600,
+        items: {
+          data: [
+            {
+              price: {
+                id: "price_test_pro_monthly",
+                recurring: { interval: "month" },
+              },
+            },
+          ],
+        },
+      },
+    }));
+    getStripeClientMock.mockReturnValue({
+      checkout: {
+        sessions: {
+          retrieve: retrieveMock,
+        },
+      },
+    });
+
+    const router = (await import("../billingRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/session-status?session_id=cs_123",
+      headers: {
+        "x-test-user": JSON.stringify({ id: "u1", landlordId: "landlord-1", role: "landlord", plan: "free" }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(retrieveMock).toHaveBeenCalledWith("cs_123", { expand: ["subscription"] });
+    expect(res.body).toMatchObject({
+      ok: true,
+      sessionId: "cs_123",
+      status: "complete",
+      payment_status: "paid",
+      customer: "cus_123",
+      plan: "pro",
+      interval: "monthly",
+      subscription_status: "active",
+      current_period_end: 1_735_689_600_000,
+      plan_updated: true,
+    });
+    expect(landlordDocSetMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        plan: "pro",
+        stripeCustomerId: "cus_123",
+        stripeSubscriptionId: "sub_123",
+        stripeCheckoutSessionId: "cs_123",
+        subscriptionStatus: "active",
+        subscriptionInterval: "monthly",
+        currentPeriodEnd: 1_735_689_600_000,
+        subscriptionUpdatedAt: expect.any(Number),
+      }),
+      { merge: true }
+    );
+  });
+
+  it("returns 404 when the checkout session does not exist", async () => {
+    getStripeClientMock.mockReturnValue({
+      checkout: {
+        sessions: {
+          retrieve: vi.fn(async () => {
+            const err: any = new Error("No such checkout.session");
+            err.statusCode = 404;
+            throw err;
+          }),
+        },
+      },
+    });
+
+    const router = (await import("../billingRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/session-status?session_id=cs_missing",
+      headers: {
+        "x-test-user": JSON.stringify({ id: "u1", landlordId: "landlord-1", role: "landlord", plan: "free" }),
+      },
+    });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ ok: false, error: "session_not_found" });
   });
 });

--- a/rentchain-api/src/routes/billingRoutes.ts
+++ b/rentchain-api/src/routes/billingRoutes.ts
@@ -9,6 +9,7 @@ import {
   getPlanMatrix,
   getStripeEnv,
   isCanonicalFreePlan,
+  resolvePlanFromPriceId,
   resolvePaidBillingPlan,
   resolvePlanPriceId,
   type BillingPlanKey,
@@ -94,6 +95,7 @@ router.get("/pricing", (_req, res) => {
 
 type BillingTier = BillingPlanKey;
 type BillingInterval = "monthly" | "yearly";
+type StripeSessionPaymentStatus = "paid" | "unpaid" | "no_payment_required" | null;
 
 function normalizeTier(input: any): BillingTier | "free" | null {
   const raw = String(input || "").trim();
@@ -111,6 +113,20 @@ function normalizeInterval(input: any): BillingInterval {
 
 function resolvePriceId(tier: BillingTier, interval: BillingInterval) {
   return resolvePlanPriceId({ plan: tier, interval });
+}
+
+function normalizeStripeRecurringInterval(input: unknown): BillingInterval | null {
+  const raw = String(input || "").trim().toLowerCase();
+  if (raw === "month") return "monthly";
+  if (raw === "year") return "yearly";
+  return null;
+}
+
+function isVerifiedPaidSession(status: unknown, paymentStatus: unknown): boolean {
+  const normalizedStatus = String(status || "").trim().toLowerCase();
+  const normalizedPaymentStatus = String(paymentStatus || "").trim().toLowerCase();
+  if (normalizedStatus !== "complete") return false;
+  return normalizedPaymentStatus === "paid" || normalizedPaymentStatus === "no_payment_required";
 }
 
 function sanitizeRedirectTo(raw: any): string {
@@ -136,6 +152,45 @@ function appendBillingCanceled(path: string): string {
   if (!path) return "/dashboard?billing=canceled=1";
   if (path.includes("?")) return `${path}&billing=canceled=1`;
   return `${path}?billing=canceled=1`;
+}
+
+async function updateLandlordSubscription(params: {
+  landlordId: string;
+  tier: BillingTier | "free";
+  stripeCustomerId?: string | null;
+  stripeSubscriptionId?: string | null;
+  stripeCheckoutSessionId?: string | null;
+  subscriptionStatus?: string | null;
+  subscriptionInterval?: BillingInterval | null;
+  currentPeriodEnd?: number | null;
+}) {
+  const {
+    landlordId,
+    tier,
+    stripeCustomerId,
+    stripeSubscriptionId,
+    stripeCheckoutSessionId,
+    subscriptionStatus,
+    subscriptionInterval,
+    currentPeriodEnd,
+  } = params;
+
+  await db
+    .collection("landlords")
+    .doc(landlordId)
+    .set(
+      {
+        plan: tier,
+        stripeCustomerId: stripeCustomerId || null,
+        stripeSubscriptionId: stripeSubscriptionId || null,
+        stripeCheckoutSessionId: stripeCheckoutSessionId || null,
+        subscriptionStatus: subscriptionStatus || null,
+        subscriptionInterval: subscriptionInterval || null,
+        currentPeriodEnd: currentPeriodEnd ?? null,
+        subscriptionUpdatedAt: Date.now(),
+      },
+      { merge: true }
+    );
 }
 
 function isStripeConnectionError(err: any): boolean {
@@ -465,6 +520,97 @@ async function handleCheckout(req: any, res: any) {
 router.post("/checkout", requireAuth, handleCheckout);
 router.post("/subscribe", requireAuth, handleCheckout);
 router.post("/upgrade", requireAuth, handleCheckout);
+
+router.get("/session-status", requireAuth, async (req: any, res) => {
+  const sessionId = String(req.query?.session_id || "").trim();
+  if (!sessionId) {
+    return res.status(400).json({ ok: false, error: "missing_session_id" });
+  }
+
+  try {
+    const stripe = getStripeClient();
+    const session = await stripe.checkout.sessions.retrieve(sessionId, {
+      expand: ["subscription"],
+    });
+
+    const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
+    const metadataLandlordId = String(session.metadata?.landlordId || "").trim();
+    if (!landlordId) {
+      return res.status(401).json({ ok: false, error: "Unauthorized" });
+    }
+    if (!metadataLandlordId || metadataLandlordId !== landlordId) {
+      return res.status(403).json({ ok: false, error: "forbidden" });
+    }
+
+    const subscription =
+      session.subscription && typeof session.subscription === "object" ? session.subscription : null;
+    const subscriptionPriceId = subscription?.items?.data?.[0]?.price?.id || null;
+    const resolvedPlan =
+      resolvePaidBillingPlan(session.metadata?.tier) ||
+      resolvePaidBillingPlan(subscription?.metadata?.tier) ||
+      resolvePlanFromPriceId(subscriptionPriceId);
+    const resolvedInterval =
+      normalizeInterval(session.metadata?.interval) ||
+      normalizeInterval(subscription?.metadata?.interval) ||
+      normalizeStripeRecurringInterval(subscription?.items?.data?.[0]?.price?.recurring?.interval);
+    const paymentStatus = (asOptionalString(session.payment_status) as StripeSessionPaymentStatus) || null;
+    const sessionStatus = asOptionalString(session.status) || "unknown";
+    const subscriptionStatus = asOptionalString(subscription?.status) || null;
+    const currentPeriodEnd =
+      typeof (subscription as any)?.current_period_end === "number"
+        ? (subscription as any).current_period_end * 1000
+        : null;
+    const stripeCustomerId =
+      typeof session.customer === "string" ? session.customer : asOptionalString((session.customer as any)?.id);
+    const stripeSubscriptionId =
+      typeof session.subscription === "string"
+        ? session.subscription
+        : asOptionalString((session.subscription as any)?.id);
+    const shouldActivatePlan = Boolean(resolvedPlan) && isVerifiedPaidSession(sessionStatus, paymentStatus);
+
+    if (shouldActivatePlan) {
+      await updateLandlordSubscription({
+        landlordId,
+        tier: resolvedPlan as BillingTier,
+        stripeCustomerId,
+        stripeSubscriptionId,
+        stripeCheckoutSessionId: session.id,
+        subscriptionStatus,
+        subscriptionInterval: resolvedInterval,
+        currentPeriodEnd,
+      });
+    }
+
+    return res.status(200).json({
+      ok: true,
+      sessionId: session.id,
+      status: sessionStatus,
+      payment_status: paymentStatus,
+      customer: stripeCustomerId,
+      plan: resolvedPlan,
+      interval: resolvedInterval,
+      subscription_status: subscriptionStatus,
+      current_period_end: currentPeriodEnd,
+      plan_updated: shouldActivatePlan,
+    });
+  } catch (err: any) {
+    if (isStripeNotConfiguredError(err)) {
+      return res.status(400).json(stripeNotConfiguredResponse());
+    }
+    if (Number(err?.statusCode) === 404) {
+      return res.status(404).json({ ok: false, error: "session_not_found" });
+    }
+    return sendStripeRouteError(
+      res,
+      {
+        scope: "checkout",
+        route: String(req.originalUrl || req.path || "/api/billing/session-status"),
+        operation: "checkout.sessions.retrieve",
+      },
+      err
+    );
+  }
+});
 
 router.post("/portal", requireAuth, async (req: any, res) => {
   try {

--- a/rentchain-frontend/src/api/billingApi.ts
+++ b/rentchain-frontend/src/api/billingApi.ts
@@ -73,6 +73,30 @@ export async function createBillingPortalSession(): Promise<{ url: string }> {
   return { url: data?.url ?? "" };
 }
 
+export type CheckoutSessionStatus = {
+  ok: boolean;
+  sessionId?: string;
+  status?: string | null;
+  payment_status?: "paid" | "unpaid" | "no_payment_required" | null;
+  customer?: string | null;
+  plan?: PaidPlan | null;
+  interval?: "monthly" | "yearly" | null;
+  subscription_status?: string | null;
+  current_period_end?: number | null;
+  plan_updated?: boolean;
+};
+
+export async function fetchCheckoutSessionStatus(sessionId: string): Promise<CheckoutSessionStatus> {
+  const data = await apiJson<any>(`/billing/session-status?session_id=${encodeURIComponent(sessionId)}`, {
+    method: "GET",
+  });
+  return {
+    ...data,
+    plan: data?.plan ? normalizePaidPlan(data.plan) : null,
+    interval: data?.interval === "yearly" ? "yearly" : data?.interval === "monthly" ? "monthly" : null,
+  };
+}
+
 export async function simulateCreditPull(
   tenantId: string
 ): Promise<{ reportId: string; message: string }> {

--- a/rentchain-frontend/src/pages/BillingCheckoutSuccessPage.test.tsx
+++ b/rentchain-frontend/src/pages/BillingCheckoutSuccessPage.test.tsx
@@ -1,0 +1,131 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import BillingCheckoutSuccessPage from "./BillingCheckoutSuccessPage";
+
+const mocks = vi.hoisted(() => ({
+  useAuthMock: vi.fn(),
+  clearUpgradePromptMock: vi.fn(),
+  showToastMock: vi.fn(),
+  refreshEntitlementsMock: vi.fn(),
+  fetchCheckoutSessionStatusMock: vi.fn(),
+}));
+
+vi.mock("@/context/useAuth", () => ({
+  useAuth: mocks.useAuthMock,
+}));
+
+vi.mock("@/context/UpgradeContext", () => ({
+  useUpgrade: () => ({
+    clearUpgradePrompt: mocks.clearUpgradePromptMock,
+  }),
+}));
+
+vi.mock("@/components/ui/ToastProvider", () => ({
+  useToast: () => ({
+    showToast: mocks.showToastMock,
+  }),
+}));
+
+vi.mock("@/lib/entitlements", () => ({
+  refreshEntitlements: mocks.refreshEntitlementsMock,
+}));
+
+vi.mock("@/api/billingApi", () => ({
+  fetchCheckoutSessionStatus: mocks.fetchCheckoutSessionStatusMock,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("BillingCheckoutSuccessPage", () => {
+  beforeEach(() => {
+    mocks.useAuthMock.mockReturnValue({
+      updateUser: vi.fn(),
+    });
+    mocks.refreshEntitlementsMock.mockResolvedValue(undefined);
+  });
+
+  function renderPage(initialEntry: string) {
+    return render(
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route path="/billing/checkout-success" element={<BillingCheckoutSuccessPage />} />
+          <Route path="/dashboard" element={<div>Dashboard destination</div>} />
+          <Route path="/properties" element={<div>Properties destination</div>} />
+          <Route path="/billing" element={<div>Billing destination</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+  }
+
+  it("renders a success state for a verified paid checkout session", async () => {
+    mocks.fetchCheckoutSessionStatusMock.mockResolvedValue({
+      ok: true,
+      sessionId: "cs_123",
+      status: "complete",
+      payment_status: "paid",
+      plan: "starter",
+      interval: "monthly",
+    });
+
+    renderPage("/billing/checkout-success?session_id=cs_123&redirectTo=%2Fproperties");
+
+    expect(screen.getByText("Confirming upgrade")).toBeInTheDocument();
+
+    await waitFor(() => expect(screen.getByText("Upgrade confirmed")).toBeInTheDocument());
+    expect(screen.getByText("Starter")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Go to dashboard" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Continue setup" })).toBeInTheDocument();
+    expect(mocks.refreshEntitlementsMock).toHaveBeenCalledTimes(1);
+    expect(mocks.clearUpgradePromptMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders a failsafe state when the session id is missing", async () => {
+    renderPage("/billing/checkout-success");
+
+    expect(screen.getByText("Upgrade not confirmed")).toBeInTheDocument();
+    expect(
+      screen.getByText(/because the checkout session ID is missing/i)
+    ).toBeInTheDocument();
+    expect(mocks.fetchCheckoutSessionStatusMock).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Return to billing" })).toBeInTheDocument();
+  });
+
+  it("keeps the loading state visible until verification resolves", async () => {
+    let resolveRequest: ((value: unknown) => void) | null = null;
+    mocks.fetchCheckoutSessionStatusMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRequest = resolve;
+      })
+    );
+
+    renderPage("/billing/checkout-success?session_id=cs_123");
+
+    expect(screen.getByText("Confirming upgrade")).toBeInTheDocument();
+    expect(screen.getByText(/confirming your Stripe checkout/i)).toBeInTheDocument();
+
+    resolveRequest?.({
+      ok: true,
+      sessionId: "cs_123",
+      status: "complete",
+      payment_status: "paid",
+      plan: "pro",
+      interval: "monthly",
+    });
+
+    await waitFor(() => expect(screen.getByText("Upgrade confirmed")).toBeInTheDocument());
+  });
+
+  it("routes the failsafe CTA back to billing when verification fails", async () => {
+    mocks.fetchCheckoutSessionStatusMock.mockRejectedValue(new Error("session not found"));
+
+    renderPage("/billing/checkout-success?session_id=cs_missing");
+
+    await waitFor(() => expect(screen.getByText("Upgrade not confirmed")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "Return to billing" }));
+    expect(screen.getByText("Billing destination")).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/BillingCheckoutSuccessPage.tsx
+++ b/rentchain-frontend/src/pages/BillingCheckoutSuccessPage.tsx
@@ -6,8 +6,8 @@ import { refreshEntitlements } from "@/lib/entitlements";
 import { useAuth } from "@/context/useAuth";
 import { useUpgrade } from "@/context/UpgradeContext";
 import { useToast } from "@/components/ui/ToastProvider";
-import { fetchMe } from "@/api/meApi";
-import { canUseTimeline } from "@/features/automation/timeline/timelineEntitlements";
+import { fetchCheckoutSessionStatus, type CheckoutSessionStatus } from "@/api/billingApi";
+import { planLabel } from "@/lib/plan";
 
 function sanitizeRedirectTo(raw: string | null): string | null {
   if (!raw) return null;
@@ -22,83 +22,140 @@ const BillingCheckoutSuccessPage: React.FC = () => {
   const [params] = useSearchParams();
   const navigate = useNavigate();
   const redirectTo = useMemo(() => sanitizeRedirectTo(params.get("redirectTo")), [params]);
-  const { user, updateUser } = useAuth();
+  const sessionId = String(params.get("session_id") || "").trim();
+  const { updateUser } = useAuth();
   const { clearUpgradePrompt } = useUpgrade();
   const { showToast } = useToast();
-  const [unlockedTimeline, setUnlockedTimeline] = useState(false);
-  const [isRefreshing, setIsRefreshing] = useState(Boolean(redirectTo));
+  const [result, setResult] = useState<CheckoutSessionStatus | null>(null);
+  const [viewState, setViewState] = useState<"loading" | "success" | "pending" | "failed">(
+    sessionId ? "loading" : "failed"
+  );
   const hasHandledRef = useRef(false);
 
   useEffect(() => {
     if (hasHandledRef.current) return;
     hasHandledRef.current = true;
 
-    let alive = true;
-    const previousEntitled = canUseTimeline(user?.plan);
-
     const run = async () => {
-      try {
-        setIsRefreshing(true);
-        await Promise.race([
-          refreshEntitlements(updateUser),
-          new Promise((resolve) => setTimeout(resolve, 1200)),
-        ]);
-        const me = await fetchMe().catch(() => null);
-        const nextPlan = String((me as any)?.user?.plan || (me as any)?.plan || user?.plan || "");
-        const nowEntitled = canUseTimeline(nextPlan);
+      if (!sessionId) {
+        setViewState("failed");
+        return;
+      }
 
-        if (!previousEntitled && nowEntitled) {
-          setUnlockedTimeline(true);
+      try {
+        setViewState("loading");
+        const next = await fetchCheckoutSessionStatus(sessionId);
+        setResult(next);
+
+        const isSuccess =
+          next?.status === "complete" &&
+          (next?.payment_status === "paid" || next?.payment_status === "no_payment_required") &&
+          Boolean(next?.plan);
+        const isPending =
+          next?.status === "open" ||
+          next?.payment_status === "unpaid" ||
+          next?.payment_status == null;
+
+        if (isSuccess) {
+          await refreshEntitlements(updateUser);
+          clearUpgradePrompt();
+          setViewState("success");
           showToast({
-            message: "Upgrade successful — Timeline unlocked.",
+            message: `Upgrade confirmed${next.plan ? `: ${planLabel(next.plan)}` : ""}.`,
             variant: "success",
           });
+          return;
         }
 
-        if (redirectTo && !nowEntitled) {
-          clearUpgradePrompt();
-          navigate(redirectTo);
-        }
+        setViewState(isPending ? "pending" : "failed");
       } catch {
-        // ignore refresh errors
-      } finally {
-        if (alive) setIsRefreshing(false);
+        setViewState("failed");
       }
     };
+
     void run();
-    return () => {
-      alive = false;
-    };
-  }, [navigate, redirectTo, updateUser, clearUpgradePrompt, showToast, user?.plan]);
+  }, [sessionId, updateUser, clearUpgradePrompt, showToast]);
+
+  const primaryPlanLabel = result?.plan ? planLabel(result.plan) : null;
+  const continuePath = redirectTo || "/properties";
+
+  const message = (() => {
+    if (viewState === "loading") return "We’re confirming your Stripe checkout and syncing your plan.";
+    if (viewState === "success") {
+      return primaryPlanLabel
+        ? `Your ${primaryPlanLabel} plan is active. Premium features are now unlocked.`
+        : "Your plan is active. Premium features are now unlocked.";
+    }
+    if (viewState === "pending") {
+      return "We couldn't confirm your upgrade yet. Payment may still be processing.";
+    }
+    if (!sessionId) {
+      return "We couldn't confirm your upgrade yet because the checkout session ID is missing.";
+    }
+    return "We couldn't confirm your upgrade yet. Please return to billing and try again.";
+  })();
 
   return (
     <Section style={{ maxWidth: 560, margin: "0 auto" }}>
       <Card elevated>
         <div style={{ display: "grid", gap: spacing.sm }}>
           <h1 style={{ margin: 0, fontSize: "1.3rem", fontWeight: 700 }}>
-            Upgrade complete
+            {viewState === "loading"
+              ? "Confirming upgrade"
+              : viewState === "success"
+                ? "Upgrade confirmed"
+                : viewState === "pending"
+                  ? "Upgrade pending"
+                  : "Upgrade not confirmed"}
           </h1>
-          <div style={{ color: text.muted, fontSize: "0.95rem" }}>
-            {isRefreshing
-              ? "Refreshing your plan access..."
-              : unlockedTimeline
-                ? "Your new plan is active. Timeline is now unlocked."
-                : redirectTo
-                  ? "You're all set. Return to where you left off."
-                  : "You're all set. Return to your dashboard to continue."}
-          </div>
-          <div style={{ display: "flex", gap: spacing.sm }}>
-            <Button type="button" onClick={() => navigate(redirectTo || "/dashboard")} disabled={isRefreshing}>
-              Continue
-            </Button>
-            {unlockedTimeline ? (
-              <Button type="button" onClick={() => navigate("/automation/timeline")} disabled={isRefreshing}>
-                Go to Timeline
-              </Button>
-            ) : null}
-            <Button type="button" variant="secondary" onClick={() => navigate("/billing")}>
-              View billing
-            </Button>
+          <div style={{ color: text.muted, fontSize: "0.95rem" }}>{message}</div>
+          {viewState === "success" && primaryPlanLabel ? (
+            <div
+              style={{
+                border: "1px solid #dbeafe",
+                background: "#eff6ff",
+                borderRadius: 12,
+                padding: spacing.md,
+                display: "grid",
+                gap: 6,
+              }}
+            >
+              <div style={{ fontSize: "0.8rem", textTransform: "uppercase", letterSpacing: "0.06em", color: text.muted }}>
+                Active plan
+              </div>
+              <div style={{ fontSize: "1.1rem", fontWeight: 700 }}>{primaryPlanLabel}</div>
+              <div style={{ color: text.muted, fontSize: "0.95rem" }}>
+                Your account capabilities have been refreshed for this workspace.
+              </div>
+            </div>
+          ) : null}
+          {viewState !== "loading" ? (
+            <div style={{ color: text.muted, fontSize: "0.9rem" }}>
+              {viewState === "success"
+                ? "Next steps: go back to the dashboard or continue the workflow you started before checkout."
+                : "If payment already went through, give it a moment and check billing again."}
+            </div>
+          ) : null}
+          <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
+            {viewState === "success" ? (
+              <>
+                <Button type="button" onClick={() => navigate("/dashboard")}>
+                  Go to dashboard
+                </Button>
+                <Button type="button" variant="secondary" onClick={() => navigate(continuePath)}>
+                  Continue setup
+                </Button>
+              </>
+            ) : (
+              <>
+                <Button type="button" onClick={() => navigate("/billing")}>
+                  Return to billing
+                </Button>
+                <Button type="button" variant="secondary" onClick={() => navigate("/billing")}>
+                  Try again
+                </Button>
+              </>
+            )}
           </div>
         </div>
       </Card>


### PR DESCRIPTION
## Summary

Implements a verified Stripe checkout success flow that completes the upgrade loop end-to-end.

Adds a backend session verification endpoint and updates landlord plan state on confirmed paid sessions, ensuring upgraded access is reflected immediately in the product.

## What changed

### Backend

- Added `GET /api/billing/session-status?session_id=...`
- Retrieves Stripe Checkout session
- Verifies landlord ownership via metadata
- Derives plan + interval
- Updates Firestore landlord subscription state when session is paid

### Frontend

- Reworked `/billing/checkout-success` page to:
  - read `session_id`
  - verify session via backend
  - display:
    - loading
    - success
    - pending
    - failure states
  - confirm upgraded plan visually
  - refresh `/me` and `/capabilities`
  - provide clear next actions:
    - Go to dashboard
    - Continue setup

### API Layer

- Added `billingApi.ts` helper for session verification

### Tests

- Backend:
  - `billingRoutes.test.ts`
- Frontend:
  - `BillingCheckoutSuccessPage.test.tsx`

## Files changed

- rentchain-api/src/routes/billingRoutes.ts
- rentchain-api/src/routes/__tests__/billingRoutes.test.ts
- rentchain-frontend/src/api/billingApi.ts
- rentchain-frontend/src/pages/BillingCheckoutSuccessPage.tsx
- rentchain-frontend/src/pages/BillingCheckoutSuccessPage.test.tsx

## Verification

- Backend tests passed
- Frontend tests passed
- Backend build passed
- Frontend build passed

## Why this change was made

Previously, the success page relied on redirect-only behavior and did not verify Stripe session state or update backend plan data.

This caused:
- incomplete upgrade flow
- delayed or missing entitlement updates

This fix ensures:
- backend is the source of truth
- plan updates happen only after confirmed payment
- frontend reflects upgraded state immediately

## Impact

- completes the Stripe upgrade loop
- removes post-checkout ambiguity
- ensures users feel upgraded instantly
- unlocks full monetization flow

## Known limitations / follow-up

- still relies on success-page return for immediate sync
- users who do not return from Stripe depend on webhook handling
- future work should move full source-of-truth to webhook-driven subscription updates