### PR TITLE
feat: add webhook-driven billing sync v2

### DIFF
--- a/rentchain-api/src/routes/__tests__/stripeSubscriptionWebhookSync.test.ts
+++ b/rentchain-api/src/routes/__tests__/stripeSubscriptionWebhookSync.test.ts
@@ -1,0 +1,239 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { store, ensureCollection, constructEventMock, docRef } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+
+  function docRef(collectionName: string, docId: string) {
+    return {
+      id: docId,
+      path: `${collectionName}/${docId}`,
+      get: async () => ({
+        exists: ensureCollection(collectionName).has(docId),
+        data: () => ensureCollection(collectionName).get(docId),
+      }),
+      set: async (payload: Record<string, unknown>, options?: { merge?: boolean }) => {
+        const col = ensureCollection(collectionName);
+        const existing = col.get(docId) || {};
+        col.set(docId, options?.merge ? { ...existing, ...payload } : payload);
+      },
+    };
+  }
+
+  return {
+    store,
+    ensureCollection,
+    constructEventMock: vi.fn(),
+    docRef,
+  };
+});
+
+vi.mock("../../config/firebase", () => ({
+  db: {
+    collection: vi.fn((name: string) => ({
+      doc: (id: string) => docRef(name, id),
+      where: (field: string, op: string, value: any) => ({
+        limit: (count: number) => ({
+          get: async () => {
+            const docs = Array.from(ensureCollection(name).entries())
+              .filter(([, data]) => (op === "==" ? data?.[field] === value : true))
+              .slice(0, count)
+              .map(([id, data]) => ({
+                id,
+                ref: docRef(name, id),
+                data: () => data,
+              }));
+            return { empty: docs.length === 0, docs };
+          },
+        }),
+      }),
+    })),
+  },
+}));
+
+vi.mock("../../config/screeningConfig", () => ({
+  STRIPE_WEBHOOK_SECRET: "whsec_test",
+}));
+
+vi.mock("../../services/stripeService", () => ({
+  getStripeClient: () => ({
+    webhooks: {
+      constructEvent: constructEventMock,
+    },
+    checkout: {
+      sessions: {
+        list: vi.fn(async () => ({ data: [] })),
+      },
+    },
+  }),
+}));
+
+vi.mock("../../lib/stripeNotConfigured", () => ({
+  stripeNotConfiguredResponse: () => ({ ok: false, error: "stripe_not_configured" }),
+  isStripeNotConfiguredError: () => false,
+}));
+
+vi.mock("../../services/screening/screeningOrchestrator", () => ({
+  beginScreening: vi.fn(async () => ({ ok: true })),
+}));
+
+vi.mock("../../services/stripeFinalize", () => ({
+  finalizeStripePayment: vi.fn(async () => ({ ok: true })),
+}));
+
+vi.mock("../../services/stripeScreeningProcessor", () => ({
+  applyScreeningResultsFromOrder: vi.fn(async () => ({ ok: true })),
+}));
+
+vi.mock("../../services/screeningPaymentTransactionService", () => ({
+  recordScreeningPaymentFailed: vi.fn(async () => undefined),
+}));
+
+async function invokeWebhook(body: string) {
+  const { stripeWebhookHandler } = await import("../stripeScreeningOrdersWebhookRoutes");
+  return await new Promise<{ status: number; body: any; text?: string }>((resolve, reject) => {
+    const req: any = {
+      body: Buffer.from(body),
+      headers: {
+        "stripe-signature": "t=1,v1=test",
+      },
+    };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: null, text: String(payload || "") });
+        return this;
+      },
+    };
+    stripeWebhookHandler(req, res).catch(reject);
+  });
+}
+
+describe("stripe subscription webhook sync", () => {
+  beforeEach(() => {
+    store.clear();
+    constructEventMock.mockReset();
+    ensureCollection("landlords").set("landlord_1", {
+      plan: "free",
+      stripeCustomerId: null,
+      stripeSubscriptionId: null,
+      subscriptionStatus: null,
+      subscriptionInterval: null,
+      currentPeriodEnd: null,
+    });
+  });
+
+  it("syncs landlord subscription state from customer.subscription.updated", async () => {
+    constructEventMock.mockReturnValueOnce({
+      id: "evt_sub_1",
+      type: "customer.subscription.updated",
+      data: {
+        object: {
+          id: "sub_123",
+          customer: "cus_123",
+          status: "active",
+          current_period_end: 1_735_689_600,
+          metadata: {
+            landlordId: "landlord_1",
+            tier: "pro",
+            interval: "yearly",
+          },
+          items: {
+            data: [
+              {
+                price: {
+                  id: "price_any",
+                  recurring: { interval: "year" },
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const res = await invokeWebhook('{"id":"evt_sub_1","type":"customer.subscription.updated"}');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ received: true });
+    expect(ensureCollection("landlords").get("landlord_1")).toEqual(
+      expect.objectContaining({
+        plan: "pro",
+        stripeCustomerId: "cus_123",
+        stripeSubscriptionId: "sub_123",
+        subscriptionStatus: "active",
+        subscriptionInterval: "yearly",
+        currentPeriodEnd: 1_735_689_600_000,
+        subscriptionUpdatedAt: expect.any(Number),
+      })
+    );
+  });
+
+  it("keeps repeated subscription deliveries idempotent", async () => {
+    const event = {
+      id: "evt_sub_repeat",
+      type: "customer.subscription.updated",
+      data: {
+        object: {
+          id: "sub_repeat",
+          customer: "cus_repeat",
+          status: "active",
+          current_period_end: 1_735_700_000,
+          metadata: {
+            landlordId: "landlord_1",
+            tier: "starter",
+            interval: "monthly",
+          },
+          items: {
+            data: [
+              {
+                price: {
+                  id: "price_any",
+                  recurring: { interval: "month" },
+                },
+              },
+            ],
+          },
+        },
+      },
+    };
+    constructEventMock.mockReturnValue(event);
+
+    const first = await invokeWebhook('{"id":"evt_sub_repeat","type":"customer.subscription.updated"}');
+    const firstSnapshot = ensureCollection("landlords").get("landlord_1");
+
+    const second = await invokeWebhook('{"id":"evt_sub_repeat","type":"customer.subscription.updated"}');
+    const secondSnapshot = ensureCollection("landlords").get("landlord_1");
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(secondSnapshot).toEqual(
+      expect.objectContaining({
+        plan: "starter",
+        stripeCustomerId: "cus_repeat",
+        stripeSubscriptionId: "sub_repeat",
+        subscriptionStatus: "active",
+        subscriptionInterval: "monthly",
+        currentPeriodEnd: 1_735_700_000_000,
+      })
+    );
+    expect(secondSnapshot.plan).toBe(firstSnapshot.plan);
+    expect(secondSnapshot.stripeCustomerId).toBe(firstSnapshot.stripeCustomerId);
+    expect(secondSnapshot.stripeSubscriptionId).toBe(firstSnapshot.stripeSubscriptionId);
+    expect(secondSnapshot.subscriptionStatus).toBe(firstSnapshot.subscriptionStatus);
+    expect(secondSnapshot.subscriptionInterval).toBe(firstSnapshot.subscriptionInterval);
+    expect(secondSnapshot.currentPeriodEnd).toBe(firstSnapshot.currentPeriodEnd);
+  });
+});

--- a/rentchain-api/src/routes/__tests__/stripeWebhookPublicRoute.test.ts
+++ b/rentchain-api/src/routes/__tests__/stripeWebhookPublicRoute.test.ts
@@ -1,5 +1,3 @@
-import express from "express";
-import request from "supertest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const constructEventMock = vi.fn();
@@ -49,17 +47,32 @@ vi.mock("../../services/stripeScreeningProcessor", () => ({
   applyScreeningResultsFromOrder: vi.fn(async () => ({ ok: true })),
 }));
 
-async function createApp() {
+async function invokeWebhook(body: string) {
   const { stripeWebhookHandler } = await import("../stripeScreeningOrdersWebhookRoutes");
-  const app = express();
-
-  app.post("/api/stripe/webhook", express.raw({ type: "application/json" }), stripeWebhookHandler);
-
-  app.use((_req, res) => {
-    return res.status(401).json({ ok: false, error: "unauthorized" });
+  return await new Promise<{ status: number; body: any; text?: string }>((resolve, reject) => {
+    const req: any = {
+      body: Buffer.from(body),
+      headers: {
+        "stripe-signature": "t=1,v1=test",
+      },
+    };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: null, text: String(payload || "") });
+        return this;
+      },
+    };
+    stripeWebhookHandler(req, res).catch(reject);
   });
-
-  return app;
 }
 
 describe("stripe webhook public route", () => {
@@ -72,13 +85,7 @@ describe("stripe webhook public route", () => {
       type: "noop.event",
       data: { object: {} },
     });
-    const app = await createApp();
-
-    const res = await request(app)
-      .post("/api/stripe/webhook")
-      .set("stripe-signature", "t=1,v1=test")
-      .set("content-type", "application/json")
-      .send('{"id":"evt_1","type":"noop.event"}');
+    const res = await invokeWebhook('{"id":"evt_1","type":"noop.event"}');
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ received: true });
@@ -89,16 +96,33 @@ describe("stripe webhook public route", () => {
     constructEventMock.mockImplementationOnce(() => {
       throw new Error("bad signature");
     });
-    const app = await createApp();
-
-    const res = await request(app)
-      .post("/api/stripe/webhook")
-      .set("stripe-signature", "t=1,v1=bad")
-      .set("content-type", "application/json")
-      .send('{"id":"evt_1","type":"noop.event"}');
+    const { stripeWebhookHandler } = await import("../stripeScreeningOrdersWebhookRoutes");
+    const res = await new Promise<{ status: number; body: any; text?: string }>((resolve, reject) => {
+      const req: any = {
+        body: Buffer.from('{"id":"evt_1","type":"noop.event"}'),
+        headers: {
+          "stripe-signature": "t=1,v1=bad",
+        },
+      };
+      const res: any = {
+        statusCode: 200,
+        status(code: number) {
+          this.statusCode = code;
+          return this;
+        },
+        json(payload: any) {
+          resolve({ status: this.statusCode, body: payload });
+          return this;
+        },
+        send(payload: any) {
+          resolve({ status: this.statusCode, body: null, text: String(payload || "") });
+          return this;
+        },
+      };
+      stripeWebhookHandler(req, res).catch(reject);
+    });
 
     expect(res.status).toBe(400);
     expect(String(res.text || "")).toContain("Signature verification failed");
   });
 });
-

--- a/rentchain-api/src/routes/billingRoutes.ts
+++ b/rentchain-api/src/routes/billingRoutes.ts
@@ -9,13 +9,21 @@ import {
   getPlanMatrix,
   getStripeEnv,
   isCanonicalFreePlan,
-  resolvePlanFromPriceId,
   resolvePaidBillingPlan,
   resolvePlanPriceId,
   type BillingPlanKey,
 } from "../config/planMatrix";
 import { getScreeningPricing } from "../billing/screeningPricing";
 import { resolveLandlordAndTier } from "../lib/landlordResolver";
+import {
+  deriveBillingIntervalFromCheckoutSession,
+  deriveBillingTierFromCheckoutSession,
+  isVerifiedPaidSession,
+  normalizeBillingInterval,
+  updateLandlordSubscriptionState,
+  type BillingInterval as SyncedBillingInterval,
+  type BillingTier as SyncedBillingTier,
+} from "../services/billingSubscriptionSyncService";
 
 const router = express.Router();
 
@@ -105,28 +113,11 @@ function normalizeTier(input: any): BillingTier | "free" | null {
 }
 
 function normalizeInterval(input: any): BillingInterval {
-  const raw = String(input || "").trim().toLowerCase();
-  if (raw === "year" || raw === "yearly" || raw === "annual" || raw === "annually") return "yearly";
-  if (raw === "month" || raw === "monthly") return "monthly";
-  return "monthly";
+  return normalizeBillingInterval(input) || "monthly";
 }
 
 function resolvePriceId(tier: BillingTier, interval: BillingInterval) {
   return resolvePlanPriceId({ plan: tier, interval });
-}
-
-function normalizeStripeRecurringInterval(input: unknown): BillingInterval | null {
-  const raw = String(input || "").trim().toLowerCase();
-  if (raw === "month") return "monthly";
-  if (raw === "year") return "yearly";
-  return null;
-}
-
-function isVerifiedPaidSession(status: unknown, paymentStatus: unknown): boolean {
-  const normalizedStatus = String(status || "").trim().toLowerCase();
-  const normalizedPaymentStatus = String(paymentStatus || "").trim().toLowerCase();
-  if (normalizedStatus !== "complete") return false;
-  return normalizedPaymentStatus === "paid" || normalizedPaymentStatus === "no_payment_required";
 }
 
 function sanitizeRedirectTo(raw: any): string {
@@ -152,45 +143,6 @@ function appendBillingCanceled(path: string): string {
   if (!path) return "/dashboard?billing=canceled=1";
   if (path.includes("?")) return `${path}&billing=canceled=1`;
   return `${path}?billing=canceled=1`;
-}
-
-async function updateLandlordSubscription(params: {
-  landlordId: string;
-  tier: BillingTier | "free";
-  stripeCustomerId?: string | null;
-  stripeSubscriptionId?: string | null;
-  stripeCheckoutSessionId?: string | null;
-  subscriptionStatus?: string | null;
-  subscriptionInterval?: BillingInterval | null;
-  currentPeriodEnd?: number | null;
-}) {
-  const {
-    landlordId,
-    tier,
-    stripeCustomerId,
-    stripeSubscriptionId,
-    stripeCheckoutSessionId,
-    subscriptionStatus,
-    subscriptionInterval,
-    currentPeriodEnd,
-  } = params;
-
-  await db
-    .collection("landlords")
-    .doc(landlordId)
-    .set(
-      {
-        plan: tier,
-        stripeCustomerId: stripeCustomerId || null,
-        stripeSubscriptionId: stripeSubscriptionId || null,
-        stripeCheckoutSessionId: stripeCheckoutSessionId || null,
-        subscriptionStatus: subscriptionStatus || null,
-        subscriptionInterval: subscriptionInterval || null,
-        currentPeriodEnd: currentPeriodEnd ?? null,
-        subscriptionUpdatedAt: Date.now(),
-      },
-      { merge: true }
-    );
 }
 
 function isStripeConnectionError(err: any): boolean {
@@ -544,15 +496,8 @@ router.get("/session-status", requireAuth, async (req: any, res) => {
 
     const subscription =
       session.subscription && typeof session.subscription === "object" ? session.subscription : null;
-    const subscriptionPriceId = subscription?.items?.data?.[0]?.price?.id || null;
-    const resolvedPlan =
-      resolvePaidBillingPlan(session.metadata?.tier) ||
-      resolvePaidBillingPlan(subscription?.metadata?.tier) ||
-      resolvePlanFromPriceId(subscriptionPriceId);
-    const resolvedInterval =
-      normalizeInterval(session.metadata?.interval) ||
-      normalizeInterval(subscription?.metadata?.interval) ||
-      normalizeStripeRecurringInterval(subscription?.items?.data?.[0]?.price?.recurring?.interval);
+    const resolvedPlan = deriveBillingTierFromCheckoutSession(session);
+    const resolvedInterval = deriveBillingIntervalFromCheckoutSession(session);
     const paymentStatus = (asOptionalString(session.payment_status) as StripeSessionPaymentStatus) || null;
     const sessionStatus = asOptionalString(session.status) || "unknown";
     const subscriptionStatus = asOptionalString(subscription?.status) || null;
@@ -569,14 +514,14 @@ router.get("/session-status", requireAuth, async (req: any, res) => {
     const shouldActivatePlan = Boolean(resolvedPlan) && isVerifiedPaidSession(sessionStatus, paymentStatus);
 
     if (shouldActivatePlan) {
-      await updateLandlordSubscription({
+      await updateLandlordSubscriptionState({
         landlordId,
-        tier: resolvedPlan as BillingTier,
+        tier: resolvedPlan as SyncedBillingTier,
         stripeCustomerId,
         stripeSubscriptionId,
         stripeCheckoutSessionId: session.id,
-        subscriptionStatus,
-        subscriptionInterval: resolvedInterval,
+        subscriptionStatus: subscriptionStatus || null,
+        subscriptionInterval: (resolvedInterval as SyncedBillingInterval | null) || null,
         currentPeriodEnd,
       });
     }

--- a/rentchain-api/src/routes/stripeScreeningOrdersWebhookRoutes.ts
+++ b/rentchain-api/src/routes/stripeScreeningOrdersWebhookRoutes.ts
@@ -4,7 +4,6 @@ import { db } from "../config/firebase";
 import { getStripeClient } from "../services/stripeService";
 import { STRIPE_WEBHOOK_SECRET } from "../config/screeningConfig";
 import { stripeNotConfiguredResponse, isStripeNotConfiguredError } from "../lib/stripeNotConfigured";
-import { resolvePlanFromPriceId } from "../config/planMatrix";
 import { finalizeStripePayment } from "../services/stripeFinalize";
 import { applyScreeningResultsFromOrder } from "../services/stripeScreeningProcessor";
 import { beginScreening } from "../services/screening/screeningOrchestrator";
@@ -12,6 +11,11 @@ import { writeScreeningEvent } from "../services/screening/screeningEvents";
 import { recordScreeningPaymentFailed } from "../services/screeningPaymentTransactionService";
 import { writeCanonicalEvent } from "../lib/events/buildEvent";
 import { buildScreeningMonetizationPatch } from "../services/screening/screeningMonetizationService";
+import {
+  deriveBillingIntervalFromSubscription,
+  deriveBillingTierFromSubscription,
+  updateLandlordSubscriptionState,
+} from "../services/billingSubscriptionSyncService";
 
 interface StripeWebhookRequest extends Request {
   rawBody?: Buffer;
@@ -39,38 +43,6 @@ async function resolveLandlordIdFromCustomer(
     });
     return null;
   }
-}
-
-async function updateLandlordSubscription(params: {
-  landlordId: string;
-  tier: BillingTier | "free";
-  stripeCustomerId?: string | null;
-  stripeSubscriptionId?: string | null;
-  subscriptionStatus?: string | null;
-  currentPeriodEnd?: number | null;
-}) {
-  const {
-    landlordId,
-    tier,
-    stripeCustomerId,
-    stripeSubscriptionId,
-    subscriptionStatus,
-    currentPeriodEnd,
-  } = params;
-  await db
-    .collection("landlords")
-    .doc(landlordId)
-    .set(
-      {
-        plan: tier,
-        stripeCustomerId: stripeCustomerId || null,
-        stripeSubscriptionId: stripeSubscriptionId || null,
-        subscriptionStatus: subscriptionStatus || null,
-        currentPeriodEnd: currentPeriodEnd ?? null,
-        subscriptionUpdatedAt: Date.now(),
-      },
-      { merge: true }
-    );
 }
 
 async function markApplicationScreeningPaid(params: {
@@ -519,8 +491,8 @@ export const stripeWebhookHandler = async (req: StripeWebhookRequest, res: Respo
         typeof subscription.customer === "string"
           ? subscription.customer
           : subscription.customer?.id || null;
-      const priceId = subscription.items?.data?.[0]?.price?.id || null;
-      const tier = resolvePlanFromPriceId(priceId);
+      const tier = deriveBillingTierFromSubscription(subscription);
+      const interval = deriveBillingIntervalFromSubscription(subscription);
       const subscriptionStatus = subscription.status || "unknown";
       const currentPeriodEnd =
         typeof (subscription as any).current_period_end === "number"
@@ -530,7 +502,7 @@ export const stripeWebhookHandler = async (req: StripeWebhookRequest, res: Respo
       if (!tier && event.type !== "customer.subscription.deleted") {
         console.warn("[stripe-webhook-subscription] unknown price id", {
           eventId: event.id,
-          priceId,
+          subscriptionId: subscription.id,
         });
         return res.json({ received: true, ignored: true });
       }
@@ -547,12 +519,13 @@ export const stripeWebhookHandler = async (req: StripeWebhookRequest, res: Respo
       }
 
       const resolvedTier = event.type === "customer.subscription.deleted" ? "free" : tier || "free";
-      await updateLandlordSubscription({
+      await updateLandlordSubscriptionState({
         landlordId,
         tier: resolvedTier,
         stripeCustomerId: customerId,
         stripeSubscriptionId: subscription.id,
         subscriptionStatus,
+        subscriptionInterval: resolvedTier === "free" ? null : interval,
         currentPeriodEnd,
       });
       console.log("[stripe-webhook-subscription] updated landlord", {

--- a/rentchain-api/src/services/billingSubscriptionSyncService.ts
+++ b/rentchain-api/src/services/billingSubscriptionSyncService.ts
@@ -1,0 +1,93 @@
+import Stripe from "stripe";
+import { db } from "../config/firebase";
+import { resolvePlanFromPriceId, resolvePaidBillingPlan } from "../config/planMatrix";
+
+export type BillingTier = "starter" | "pro" | "elite";
+export type BillingInterval = "monthly" | "yearly";
+
+export function normalizeBillingInterval(input: unknown): BillingInterval | null {
+  const raw = String(input || "").trim().toLowerCase();
+  if (raw === "month" || raw === "monthly") return "monthly";
+  if (raw === "year" || raw === "yearly" || raw === "annual" || raw === "annually") return "yearly";
+  return null;
+}
+
+export function isVerifiedPaidSession(status: unknown, paymentStatus: unknown): boolean {
+  const normalizedStatus = String(status || "").trim().toLowerCase();
+  const normalizedPaymentStatus = String(paymentStatus || "").trim().toLowerCase();
+  if (normalizedStatus !== "complete") return false;
+  return normalizedPaymentStatus === "paid" || normalizedPaymentStatus === "no_payment_required";
+}
+
+export function deriveBillingTierFromSubscription(subscription: Stripe.Subscription): BillingTier | null {
+  const priceId = subscription.items?.data?.[0]?.price?.id || null;
+  return resolvePaidBillingPlan(subscription.metadata?.tier) || resolvePlanFromPriceId(priceId);
+}
+
+export function deriveBillingTierFromCheckoutSession(session: Stripe.Checkout.Session): BillingTier | null {
+  const subscription =
+    session.subscription && typeof session.subscription === "object" ? (session.subscription as Stripe.Subscription) : null;
+  const priceId = subscription?.items?.data?.[0]?.price?.id || null;
+  return (
+    resolvePaidBillingPlan(session.metadata?.tier) ||
+    resolvePaidBillingPlan(subscription?.metadata?.tier) ||
+    resolvePlanFromPriceId(priceId)
+  );
+}
+
+export function deriveBillingIntervalFromSubscription(subscription: Stripe.Subscription): BillingInterval | null {
+  return (
+    normalizeBillingInterval(subscription.metadata?.interval) ||
+    normalizeBillingInterval(subscription.items?.data?.[0]?.price?.recurring?.interval)
+  );
+}
+
+export function deriveBillingIntervalFromCheckoutSession(session: Stripe.Checkout.Session): BillingInterval | null {
+  const subscription =
+    session.subscription && typeof session.subscription === "object" ? (session.subscription as Stripe.Subscription) : null;
+  return (
+    normalizeBillingInterval(session.metadata?.interval) ||
+    normalizeBillingInterval(subscription?.metadata?.interval) ||
+    normalizeBillingInterval(subscription?.items?.data?.[0]?.price?.recurring?.interval)
+  );
+}
+
+export async function updateLandlordSubscriptionState(params: {
+  landlordId: string;
+  tier: BillingTier | "free";
+  stripeCustomerId?: string | null;
+  stripeSubscriptionId?: string | null;
+  stripeCheckoutSessionId?: string | null;
+  subscriptionStatus?: string | null;
+  subscriptionInterval?: BillingInterval | null;
+  currentPeriodEnd?: number | null;
+}) {
+  const {
+    landlordId,
+    tier,
+    stripeCustomerId,
+    stripeSubscriptionId,
+    stripeCheckoutSessionId,
+    subscriptionStatus,
+    subscriptionInterval,
+    currentPeriodEnd,
+  } = params;
+
+  await db
+    .collection("landlords")
+    .doc(landlordId)
+    .set(
+      {
+        plan: tier,
+        stripeCustomerId: stripeCustomerId || null,
+        stripeSubscriptionId: stripeSubscriptionId || null,
+        stripeCheckoutSessionId: stripeCheckoutSessionId || null,
+        subscriptionStatus: subscriptionStatus || null,
+        subscriptionInterval: subscriptionInterval || null,
+        currentPeriodEnd: currentPeriodEnd ?? null,
+        subscriptionUpdatedAt: Date.now(),
+      },
+      { merge: true }
+    );
+}
+


### PR DESCRIPTION
Here’s a tightened PR-ready version:

## Summary

Moves landlord billing truth toward webhook-driven synchronization by routing Stripe subscription webhook events through a shared backend sync service.

This makes Stripe webhooks the primary source of truth for subscription state updates, while keeping the checkout success page as a confirmation and fallback reconciliation path.

## What Changed

### Shared billing sync service
- Extracted shared backend billing synchronization logic into `rentchain-api/src/services/billingSubscriptionSyncService.ts`
- Centralizes updates for plan, interval, subscription status, and Stripe identifiers

### Webhook-driven billing truth
- Updated the existing public Stripe webhook route to process subscription lifecycle events through the shared sync service
- Supported webhook events:
  - `customer.subscription.created`
  - `customer.subscription.updated`
  - `customer.subscription.deleted`

### Session-status reconciliation
- Kept `GET /api/billing/session-status` in place for checkout-success UX
- Reused the same shared backend sync service there instead of maintaining a separate write path

## Files Changed

- `rentchain-api/src/services/billingSubscriptionSyncService.ts`
- `rentchain-api/src/routes/stripeScreeningOrdersWebhookRoutes.ts`
- `rentchain-api/src/routes/billingRoutes.ts`
- `rentchain-api/src/routes/__tests__/stripeWebhookPublicRoute.test.ts`
- `rentchain-api/src/routes/__tests__/stripeSubscriptionWebhookSync.test.ts`

## Synchronization Flow

- Checkout still creates Stripe subscriptions with metadata including:
  - `landlordId`
  - `tier`
  - `interval`
- Stripe subscription webhook events now drive landlord billing state updates
- Shared sync logic writes deterministic billing fields including:
  - `plan`
  - `stripeCustomerId`
  - `stripeSubscriptionId`
  - `subscriptionStatus`
  - `subscriptionInterval`
  - `currentPeriodEnd`
  - `subscriptionUpdatedAt`
- The checkout success page still verifies and reconciles state for UX, but billing truth no longer depends solely on the user returning from Stripe

## Verification

### Backend
- `npm test -- --run src/routes/__tests__/billingRoutes.test.ts src/routes/__tests__/stripeWebhookPublicRoute.test.ts src/routes/__tests__/stripeSubscriptionWebhookSync.test.ts`
- `npm run build`

### Frontend
- `npm run build`

## Why This Change Was Made

Previously, immediate upgrade sync depended heavily on the checkout success page flow.

That meant landlord billing state could lag or fail to update if:
- the user closed the tab
- the redirect did not complete
- the frontend success path did not run

This change moves billing state updates toward Stripe webhooks, which are the more reliable source of truth for subscription lifecycle changes.

## Impact

- Makes subscription state more reliable
- Reduces dependence on the user return flow
- Keeps checkout-success UX intact
- Avoids duplicated billing write paths by centralizing sync logic

## Important Note

- Stripe subscription webhooks are now the primary billing update path
- The success page remains useful for confirmation and reconciliation
- This is a strong v2 step, not the final billing architecture end state

## Known Limitations / Follow-up

- Landlord resolution still depends on metadata or known Stripe customer linkage
- There is no dedicated webhook event ledger for explicit deduplication yet
- Deterministic merge updates make repeated deliveries safe, but future work could add event-level tracking

If you want, I can also condense this into a shorter GitHub PR description version.