### PR TITLE
feat: add post-upgrade UX and retention cues v1

### DIFF
--- a/rentchain-frontend/src/components/properties/PropertyRegistryStatusCard.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyRegistryStatusCard.tsx
@@ -346,7 +346,18 @@ function copyChecklistToClipboard(checklist: { steps: string[]; notes: string[];
     checklist.notes.length ? "Notes:" : null,
     ...checklist.notes,
   ].filter(Boolean);
-  return navigator.clipboard.writeText(lines.join("\n"));
+  return writeToClipboard(lines.join("\n"));
+}
+
+function writeToClipboard(value: string) {
+  if (typeof navigator === "undefined" || !navigator.clipboard?.writeText) {
+    return Promise.reject(new Error("clipboard_unavailable"));
+  }
+  return navigator.clipboard.writeText(value);
+}
+
+function scheduleCopyStateReset(setCopyState: React.Dispatch<React.SetStateAction<"idle" | "copied" | "failed">>) {
+  setTimeout(() => setCopyState("idle"), 1800);
 }
 
 type Props = {
@@ -427,9 +438,9 @@ export const PropertyRegistryStatusCard: React.FC<Props> = ({ property, onOpenSu
     const pid = data?.pidPrompt.registryPid;
     if (!pid) return;
     try {
-      await navigator.clipboard.writeText(pid);
+      await writeToClipboard(pid);
       setCopyState("copied");
-      window.setTimeout(() => setCopyState("idle"), 1800);
+      scheduleCopyStateReset(setCopyState);
     } catch {
       setCopyState("failed");
     }
@@ -441,7 +452,7 @@ export const PropertyRegistryStatusCard: React.FC<Props> = ({ property, onOpenSu
     try {
       await copyChecklistToClipboard(checklist);
       setCopyState("copied");
-      window.setTimeout(() => setCopyState("idle"), 1800);
+      scheduleCopyStateReset(setCopyState);
     } catch {
       setCopyState("failed");
     }
@@ -1518,7 +1529,9 @@ export const PropertyRegistryStatusCard: React.FC<Props> = ({ property, onOpenSu
                       type="button"
                       variant="secondary"
                       onClick={() => {
-                        window.location.assign(`/admin/registry/properties/${encodeURIComponent(String(property?.id || ""))}`);
+                        if (typeof window !== "undefined") {
+                          window.location.assign(`/admin/registry/properties/${encodeURIComponent(String(property?.id || ""))}`);
+                        }
                       }}
                     >
                       Open registry review

--- a/rentchain-frontend/src/lib/postUpgrade.ts
+++ b/rentchain-frontend/src/lib/postUpgrade.ts
@@ -1,0 +1,102 @@
+import { planLabel, type PaidPlan } from "@/lib/plan";
+
+const POST_UPGRADE_STATE_KEY = "rentchain.postUpgrade";
+
+export type PostUpgradeState = {
+  plan: PaidPlan;
+  ts: number;
+};
+
+export type PostUpgradeAction = {
+  label: string;
+  to: string;
+};
+
+export type PostUpgradeContent = {
+  title: string;
+  benefitSummary: string;
+  unlockedFeatures: string[];
+  dashboardBanner: string;
+  primaryAction: PostUpgradeAction;
+  secondaryAction: PostUpgradeAction;
+};
+
+export function getPostUpgradeContent(plan: PaidPlan): PostUpgradeContent {
+  if (plan === "starter") {
+    return {
+      title: `You're now on ${planLabel(plan)}`,
+      benefitSummary: "You can now invite tenants and send secure application links from RentChain.",
+      unlockedFeatures: ["Tenant invites", "Application links", "Stronger workflow handoff"],
+      dashboardBanner: "You're now on Starter — tenant invites and application links are unlocked.",
+      primaryAction: {
+        label: "Send your first application",
+        to: "/applications?openSendApplication=1&autoSelectProperty=1&upgradeConfirmed=1&highlight=applications",
+      },
+      secondaryAction: {
+        label: "Invite a tenant",
+        to: "/tenants?invite=1&upgradeConfirmed=1&highlight=tenants",
+      },
+    };
+  }
+
+  if (plan === "pro") {
+    return {
+      title: `You're now on ${planLabel(plan)}`,
+      benefitSummary: "You can now run stronger screening, review, and export workflows with less friction.",
+      unlockedFeatures: ["Screening workflow", "Review and history tools", "Export-ready controls"],
+      dashboardBanner: "You're now on Pro — screening workflows, exports, and stronger review tools are unlocked.",
+      primaryAction: {
+        label: "Start screening a tenant",
+        to: "/applications?upgradeConfirmed=1&highlight=screening",
+      },
+      secondaryAction: {
+        label: "Invite a tenant",
+        to: "/tenants?invite=1&upgradeConfirmed=1&highlight=tenants",
+      },
+    };
+  }
+
+  return {
+    title: `You're now on ${planLabel(plan)}`,
+    benefitSummary: "You can now review portfolio performance and move into deeper oversight across your workspace.",
+    unlockedFeatures: ["Portfolio health", "Portfolio score", "Recommended actions"],
+    dashboardBanner: "You're now on Elite — portfolio health and deeper oversight views are unlocked.",
+    primaryAction: {
+      label: "Review your portfolio performance",
+      to: "/portfolio-health?upgradeConfirmed=1&highlight=portfolio",
+    },
+    secondaryAction: {
+      label: "Invite a tenant",
+      to: "/tenants?invite=1&upgradeConfirmed=1&highlight=tenants",
+    },
+  };
+}
+
+export function setPostUpgradeState(plan: PaidPlan) {
+  if (typeof window === "undefined") return;
+  window.sessionStorage.setItem(
+    POST_UPGRADE_STATE_KEY,
+    JSON.stringify({
+      plan,
+      ts: Date.now(),
+    } satisfies PostUpgradeState)
+  );
+}
+
+export function getPostUpgradeState(): PostUpgradeState | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.sessionStorage.getItem(POST_UPGRADE_STATE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as PostUpgradeState;
+    if (!parsed?.plan || !["starter", "pro", "elite"].includes(parsed.plan)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function clearPostUpgradeState() {
+  if (typeof window === "undefined") return;
+  window.sessionStorage.removeItem(POST_UPGRADE_STATE_KEY);
+}

--- a/rentchain-frontend/src/pages/ApplicationsPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.tsx
@@ -254,6 +254,7 @@ const normalizeTransUnionConfigError = (error: unknown) => {
 const ApplicationsPage: React.FC = () => {
   const location = useLocation();
   const navigate = useNavigate();
+  const upgradeParams = useMemo(() => new URLSearchParams(location.search), [location.search]);
   const { showToast } = useToast();
   const [applications, setApplications] = useState<RentalApplicationSummary[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -440,6 +441,8 @@ const ApplicationsPage: React.FC = () => {
     currentPlan === "starter" ||
     currentPlan === "pro" ||
     currentPlan === "elite";
+  const upgradeConfirmed = upgradeParams.get("upgradeConfirmed") === "1";
+  const upgradeHighlight = upgradeParams.get("highlight");
   const canViewScreeningHistory = entitlements.canViewScreeningHistory;
   const canExportPdf = entitlements.canExportPdf;
   const canViewReviewSummary = entitlements.canViewReviewSummary;
@@ -1693,10 +1696,33 @@ const ApplicationsPage: React.FC = () => {
               setScreeningInviteOpen(true);
             }}
             disabled={!propertiesReady || !SCREENING_ENABLED}
+            style={
+              upgradeConfirmed && upgradeHighlight === "screening"
+                ? { border: "1px solid rgba(16,185,129,0.4)", boxShadow: "0 0 0 3px rgba(16,185,129,0.14)" }
+                : undefined
+            }
           >
             {propertiesLoaded ? (SCREENING_ENABLED ? "Send screening invite" : screeningComingSoonText) : "Loading properties…"}
           </Button>
         </div>
+        {upgradeConfirmed ? (
+          <div
+            style={{
+              marginTop: 12,
+              padding: "10px 12px",
+              borderRadius: 12,
+              border: "1px solid rgba(16,185,129,0.28)",
+              background: "rgba(16,185,129,0.08)",
+              color: text.primary,
+              fontSize: 13,
+              fontWeight: 600,
+            }}
+          >
+            {upgradeHighlight === "screening"
+              ? "Upgrade confirmed. Screening workflows are now active on this page."
+              : "Upgrade confirmed. Secure application links are now active on this page."}
+          </div>
+        ) : null}
       </Card>
 
       <TransUnionConnectionCard

--- a/rentchain-frontend/src/pages/BillingCheckoutSuccessPage.test.tsx
+++ b/rentchain-frontend/src/pages/BillingCheckoutSuccessPage.test.tsx
@@ -76,9 +76,11 @@ describe("BillingCheckoutSuccessPage", () => {
     expect(screen.getByText("Confirming upgrade")).toBeInTheDocument();
 
     await waitFor(() => expect(screen.getByText("Upgrade confirmed")).toBeInTheDocument());
+    expect(screen.getByText(/invite tenants and send secure application links/i)).toBeInTheDocument();
     expect(screen.getByText("Starter")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Go to dashboard" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Continue setup" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Send your first application" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Invite a tenant" })).toBeInTheDocument();
     expect(mocks.refreshEntitlementsMock).toHaveBeenCalledTimes(1);
     expect(mocks.clearUpgradePromptMock).toHaveBeenCalledTimes(1);
   });

--- a/rentchain-frontend/src/pages/BillingCheckoutSuccessPage.tsx
+++ b/rentchain-frontend/src/pages/BillingCheckoutSuccessPage.tsx
@@ -8,6 +8,7 @@ import { useUpgrade } from "@/context/UpgradeContext";
 import { useToast } from "@/components/ui/ToastProvider";
 import { fetchCheckoutSessionStatus, type CheckoutSessionStatus } from "@/api/billingApi";
 import { planLabel } from "@/lib/plan";
+import { getPostUpgradeContent, setPostUpgradeState } from "@/lib/postUpgrade";
 
 function sanitizeRedirectTo(raw: string | null): string | null {
   if (!raw) return null;
@@ -58,6 +59,9 @@ const BillingCheckoutSuccessPage: React.FC = () => {
 
         if (isSuccess) {
           await refreshEntitlements(updateUser);
+          if (next.plan) {
+            setPostUpgradeState(next.plan);
+          }
           clearUpgradePrompt();
           setViewState("success");
           showToast({
@@ -77,6 +81,7 @@ const BillingCheckoutSuccessPage: React.FC = () => {
   }, [sessionId, updateUser, clearUpgradePrompt, showToast]);
 
   const primaryPlanLabel = result?.plan ? planLabel(result.plan) : null;
+  const postUpgradeContent = result?.plan ? getPostUpgradeContent(result.plan) : null;
   const continuePath = redirectTo || "/properties";
 
   const message = (() => {
@@ -125,26 +130,61 @@ const BillingCheckoutSuccessPage: React.FC = () => {
               </div>
               <div style={{ fontSize: "1.1rem", fontWeight: 700 }}>{primaryPlanLabel}</div>
               <div style={{ color: text.muted, fontSize: "0.95rem" }}>
-                Your account capabilities have been refreshed for this workspace.
+                {postUpgradeContent?.benefitSummary || "Your account capabilities have been refreshed for this workspace."}
               </div>
+              {postUpgradeContent?.unlockedFeatures?.length ? (
+                <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginTop: 4 }}>
+                  {postUpgradeContent.unlockedFeatures.map((feature) => (
+                    <div
+                      key={feature}
+                      style={{
+                        padding: "6px 10px",
+                        borderRadius: 999,
+                        border: "1px solid #bfdbfe",
+                        background: "#ffffff",
+                        fontSize: "0.85rem",
+                        fontWeight: 600,
+                      }}
+                    >
+                      {feature}
+                    </div>
+                  ))}
+                </div>
+              ) : null}
             </div>
           ) : null}
           {viewState !== "loading" ? (
             <div style={{ color: text.muted, fontSize: "0.9rem" }}>
               {viewState === "success"
-                ? "Next steps: go back to the dashboard or continue the workflow you started before checkout."
+                ? "Next steps: go back to the dashboard or move directly into the workflows your upgrade unlocked."
                 : "If payment already went through, give it a moment and check billing again."}
             </div>
           ) : null}
           <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
             {viewState === "success" ? (
               <>
+                {postUpgradeContent ? (
+                  <Button type="button" onClick={() => navigate(postUpgradeContent.primaryAction.to)}>
+                    {postUpgradeContent.primaryAction.label}
+                  </Button>
+                ) : null}
                 <Button type="button" onClick={() => navigate("/dashboard")}>
                   Go to dashboard
                 </Button>
-                <Button type="button" variant="secondary" onClick={() => navigate(continuePath)}>
-                  Continue setup
-                </Button>
+                {postUpgradeContent ? (
+                  <Button type="button" variant="secondary" onClick={() => navigate(postUpgradeContent.secondaryAction.to)}>
+                    {postUpgradeContent.secondaryAction.label}
+                  </Button>
+                ) : (
+                  <Button type="button" variant="secondary" onClick={() => navigate(continuePath)}>
+                    Continue setup
+                  </Button>
+                )}
+                {redirectTo ? (
+                  <Button type="button" variant="ghost" onClick={() => navigate(continuePath)}>
+                    Continue where you left off
+                  </Button>
+                ) : null}
               </>
             ) : (
               <>

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -36,6 +36,7 @@ import { UpgradeNudgeInlineCard } from "@/features/upgradeNudges/UpgradeNudgeInl
 import { canUseTimeline, normalizeTimelinePlan } from "@/features/automation/timeline/timelineEntitlements";
 import { getLandlordActivation, type LandlordActivationSummary } from "@/api/activationApi";
 import { LandlordActivationFlowCard } from "@/components/activation/LandlordActivationFlowCard";
+import { clearPostUpgradeState, getPostUpgradeContent, getPostUpgradeState } from "@/lib/postUpgrade";
 
 const StarterOnboardingPanel = React.lazy(
   () => import("../components/dashboard/StarterOnboardingPanel")
@@ -149,6 +150,7 @@ const DashboardPage: React.FC = () => {
   const [activationLoading, setActivationLoading] = React.useState(false);
   const [activationError, setActivationError] = React.useState<string | null>(null);
   const [showWelcomeModal, setShowWelcomeModal] = React.useState(false);
+  const [postUpgradePlan, setPostUpgradePlan] = React.useState<"starter" | "pro" | "elite" | null>(null);
   const onboarding = useOnboardingState();
   const prevDerivedRef = React.useRef({
     propertyAdded: false,
@@ -258,6 +260,19 @@ const DashboardPage: React.FC = () => {
     if (!meLoaded || !isLandlord) return;
     void loadActivation();
   }, [isLandlord, loadActivation, meLoaded]);
+
+  React.useEffect(() => {
+    const state = getPostUpgradeState();
+    if (!state?.plan) return;
+    setPostUpgradePlan(state.plan);
+  }, []);
+
+  const dismissPostUpgradeBanner = React.useCallback(() => {
+    clearPostUpgradeState();
+    setPostUpgradePlan(null);
+  }, []);
+
+  const postUpgradeContent = postUpgradePlan ? getPostUpgradeContent(postUpgradePlan) : null;
 
   React.useEffect(() => {
     if (typeof window === "undefined" || !meLoaded || !isLandlord || !user?.id) return;
@@ -670,6 +685,34 @@ const DashboardPage: React.FC = () => {
               Learn more
             </button>
           </div>
+        ) : null}
+        {dataReady && postUpgradeContent ? (
+          <Card
+            style={{
+              border: "1px solid rgba(16,185,129,0.28)",
+              background: "linear-gradient(135deg, rgba(16,185,129,0.08), rgba(59,130,246,0.06))",
+              display: "grid",
+              gap: spacing.sm,
+            }}
+          >
+            <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.md, flexWrap: "wrap" }}>
+              <div style={{ display: "grid", gap: 6 }}>
+                <div style={{ fontWeight: 800, fontSize: 16 }}>{postUpgradeContent.title}</div>
+                <div style={{ color: text.muted, fontSize: 14 }}>{postUpgradeContent.dashboardBanner}</div>
+              </div>
+              <Button variant="ghost" onClick={dismissPostUpgradeBanner}>
+                Dismiss
+              </Button>
+            </div>
+            <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
+              <Button onClick={() => navigate(postUpgradeContent.primaryAction.to)}>
+                {postUpgradeContent.primaryAction.label}
+              </Button>
+              <Button variant="secondary" onClick={() => navigate(postUpgradeContent.secondaryAction.to)}>
+                {postUpgradeContent.secondaryAction.label}
+              </Button>
+            </div>
+          </Card>
         ) : null}
 
         {dataReady ? (

--- a/rentchain-frontend/src/pages/PropertiesPage.tsx
+++ b/rentchain-frontend/src/pages/PropertiesPage.tsx
@@ -108,6 +108,7 @@ const PropertiesPage: React.FC = () => {
   const openLeasePack = params.get("openLeasePack") === "1";
   const deepLinkId = params.get("actionRequestId") || undefined;
   const panel = params.get("panel") || "";
+  const upgradeConfirmed = params.get("upgradeConfirmed") === "1";
 
   useEffect(() => {
     if (!(openAddLease || openAddUnit || openEditUnits || openEditProperty || openSendApplication || openLeasePack)) return;
@@ -766,25 +767,36 @@ const PropertiesPage: React.FC = () => {
                   gap: 8,
                   padding: 12,
                   borderRadius: radius.md,
-                  border: `1px solid ${colors.border}`,
-                  background: "rgba(255,255,255,0.66)",
+                  border: upgradeConfirmed ? "1px solid rgba(16,185,129,0.28)" : `1px solid ${colors.border}`,
+                  background: upgradeConfirmed ? "rgba(16,185,129,0.08)" : "rgba(255,255,255,0.66)",
                 }}
               >
                 <div style={{ color: text.secondary, fontSize: 12, fontWeight: 700, letterSpacing: "0.04em", textTransform: "uppercase" }}>
-                  Step 3 later
+                  {upgradeConfirmed ? "Upgrade unlocked" : "Step 3 later"}
                 </div>
                 <div style={{ color: text.primary, fontSize: 14, fontWeight: 700 }}>
                   {canInviteTenant ? "Move into the tenant workflow" : "Move into the application workflow"}
                 </div>
                 <div style={{ color: text.muted, fontSize: 13, lineHeight: 1.5 }}>
                   {canInviteTenant
-                    ? "Invite a tenant after at least one unit is ready so the application and lease flow has a clear place to start."
-                    : "Send an application after your first unit is in place so the next workflow step stays clear and supported on Free."}
+                    ? upgradeConfirmed
+                      ? "Tenant invites are now unlocked. Move into the tenant workflow as soon as your first unit is ready."
+                      : "Invite a tenant after at least one unit is ready so the application and lease flow has a clear place to start."
+                    : upgradeConfirmed
+                      ? "Application sending is now unlocked. Move into the application workflow as soon as your first unit is ready."
+                      : "Send an application after your first unit is in place so the next workflow step stays clear and supported on Free."}
                 </div>
                 <div>
                   <Button
                     variant="secondary"
-                    onClick={() => navigate(canInviteTenant ? "/tenants" : "/applications?openSendApplication=1")}
+                    onClick={() =>
+                      navigate(
+                        canInviteTenant
+                          ? "/tenants?invite=1&upgradeConfirmed=1&highlight=tenants"
+                          : "/applications?openSendApplication=1&upgradeConfirmed=1&highlight=applications"
+                      )
+                    }
+                    style={upgradeConfirmed ? { boxShadow: "0 0 0 3px rgba(16,185,129,0.14)" } : undefined}
                   >
                     {canInviteTenant ? "Invite a tenant" : "Send application"}
                   </Button>

--- a/rentchain-frontend/src/pages/TenantsPage.tsx
+++ b/rentchain-frontend/src/pages/TenantsPage.tsx
@@ -202,6 +202,8 @@ export const TenantsPage: React.FC = () => {
   const [selectedTenantId, setSelectedTenantId] = useState<string | null>(selectedTenantIdFromUrl);
   const { features } = useCapabilities();
   const inviteEnabled = Boolean(features?.tenant_invites || features?.tenantInvites);
+  const upgradeConfirmed = searchParams.get("upgradeConfirmed") === "1";
+  const upgradeHighlight = searchParams.get("highlight");
 
   const role = String(user?.actorRole || user?.role || "").trim().toLowerCase();
   const canViewTenants = role === "landlord" || role === "admin";
@@ -421,11 +423,31 @@ export const TenantsPage: React.FC = () => {
               background: inviteEnabled ? colors.panel : "#faf5ff",
               cursor: "pointer",
               minHeight: 44,
+              boxShadow:
+                upgradeConfirmed && upgradeHighlight === "tenants" && inviteEnabled
+                  ? "0 0 0 3px rgba(16,185,129,0.14)"
+                  : undefined,
             }}
           >
             {inviteEnabled ? "Invite tenant" : "Unlock Tenant Invites"}
           </button>
         </div>
+        {upgradeConfirmed && inviteEnabled ? (
+          <div
+            style={{
+              marginTop: 12,
+              padding: "10px 12px",
+              borderRadius: 12,
+              border: "1px solid rgba(16,185,129,0.28)",
+              background: "rgba(16,185,129,0.08)",
+              color: text.primary,
+              fontSize: 13,
+              fontWeight: 600,
+            }}
+          >
+            Upgrade confirmed. Tenant invites are now unlocked for this workspace.
+          </div>
+        ) : null}
       </Card>
 
       <Card elevated className="rc-tenants-grid">


### PR DESCRIPTION
## Summary

Improves the post-upgrade experience by clearly confirming unlocked value, guiding users to meaningful next actions, and reinforcing upgraded state across key product surfaces.

This makes the upgrade feel complete and immediately useful, rather than just a successful transaction.

## What changed

### Success page improvements
- Added plan-specific confirmation messaging
- Shows what features were unlocked
- Added strong first-action CTAs by plan:
  - Starter → Send your first application
  - Pro → Start screening a tenant
  - Elite → Review your portfolio performance
- Retained supporting CTAs:
  - Go to dashboard
  - Invite a tenant

### Dashboard upgrade confirmation
- Added a lightweight, dismissible, session-scoped upgrade banner
- Confirms successful upgrade on first return to dashboard

### Feature-level reinforcement
Added subtle upgraded-state emphasis to key entry points:
- Applications page
- Tenants page
- Properties page

This helps users immediately see that previously locked features are now available.

### Shared post-upgrade state
- Introduced `postUpgrade.ts` to store and manage session-scoped upgrade confirmation state
- Reused existing routing/query patterns instead of introducing new flow state

## Files changed

- `rentchain-frontend/src/lib/postUpgrade.ts`
- `rentchain-frontend/src/pages/BillingCheckoutSuccessPage.tsx`
- `rentchain-frontend/src/pages/BillingCheckoutSuccessPage.test.tsx`
- `rentchain-frontend/src/pages/DashboardPage.tsx`
- `rentchain-frontend/src/pages/ApplicationsPage.tsx`
- `rentchain-frontend/src/pages/TenantsPage.tsx`
- `rentchain-frontend/src/pages/PropertiesPage.tsx`

## Verification

### Frontend
- `npm test -- --run src/pages/BillingCheckoutSuccessPage.test.tsx`
- `npm run build`

## Why this change was made

Previously:
- upgrades were technically successful
- but users were not clearly guided into what to do next

This led to:
- weak perceived value immediately after upgrade
- slower activation into newly unlocked features

This change ensures:
- users understand what they unlocked
- users are guided into action immediately
- upgraded state is visibly reinforced across the product

## Impact

- improves post-upgrade clarity
- increases likelihood of immediate feature usage
- reduces post-purchase confusion
- strengthens perceived product value

## Important note

- This is a frontend-only UX improvement
- No billing logic or backend systems were modified
- It builds on top of webhook-driven billing truth and success-page verification

## Known limitations / follow-up

- Dashboard banner is session-scoped (not persistent across sessions)
- This is not a full onboarding or activation system
- Only primary unlocked routes are emphasized; additional surfaces may be enhanced in future iterations