### PR TITLE
feat: add analytics layer v1

### DIFF
--- a/rentchain-api/src/lib/analytics/__tests__/deriveAdminAnalyticsSnapshot.test.ts
+++ b/rentchain-api/src/lib/analytics/__tests__/deriveAdminAnalyticsSnapshot.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from "vitest";
+import { deriveAdminAnalyticsSnapshot } from "../deriveAdminAnalyticsSnapshot";
+
+describe("deriveAdminAnalyticsSnapshot", () => {
+  it("derives deterministic analytics metrics across the core families", () => {
+    const now = Date.UTC(2026, 3, 20, 12, 0, 0, 0);
+    const from = now - 30 * 24 * 60 * 60 * 1000;
+    const to = now;
+
+    const result = deriveAdminAnalyticsSnapshot({
+      now,
+      from,
+      to,
+      period: "30d",
+      granularity: "daily",
+      applications: [
+        {
+          id: "app-1",
+          createdAt: now - 5 * 24 * 60 * 60 * 1000,
+          submittedAt: now - 5 * 24 * 60 * 60 * 1000,
+          approvedAt: now - 2 * 24 * 60 * 60 * 1000,
+          status: "approved",
+        },
+        {
+          id: "app-2",
+          createdAt: now - 4 * 24 * 60 * 60 * 1000,
+          submittedAt: now - 4 * 24 * 60 * 60 * 1000,
+          status: "in_review",
+        },
+        {
+          id: "app-3",
+          createdAt: now - 3 * 24 * 60 * 60 * 1000,
+          submittedAt: now - 3 * 24 * 60 * 60 * 1000,
+          rejectedAt: now - 1 * 24 * 60 * 60 * 1000,
+          status: "rejected",
+        },
+      ],
+      screeningReconciliations: [
+        {
+          status: "fulfilled",
+          summary: {
+            hasQuote: true,
+            hasCheckout: true,
+            hasPaidEvent: true,
+            hasFulfillment: true,
+            lastMeaningfulEventAt: new Date(now - 2 * 24 * 60 * 60 * 1000).toISOString(),
+          },
+        },
+        {
+          status: "abandoned",
+          summary: {
+            hasQuote: true,
+            hasCheckout: true,
+            hasPaidEvent: false,
+            hasFulfillment: false,
+            lastMeaningfulEventAt: new Date(now - 6 * 24 * 60 * 60 * 1000).toISOString(),
+          },
+        },
+      ],
+      financialTransactions: [
+        {
+          id: "txn-1",
+          type: "payment_succeeded",
+          amountCents: 3500,
+          createdAt: now - 2 * 24 * 60 * 60 * 1000,
+          applicationId: "app-1",
+        },
+      ],
+      workOrders: [
+        {
+          id: "wo-1",
+          propertyId: "prop-1",
+          status: "open",
+          createdAt: now - 7 * 24 * 60 * 60 * 1000,
+        },
+        {
+          id: "wo-2",
+          propertyId: "prop-1",
+          status: "completed",
+          serviceCompletedAt: now - 1 * 24 * 60 * 60 * 1000,
+          reopenedAt: now - 12 * 60 * 60 * 1000,
+          cost: {
+            actualCostCents: 12500,
+            submittedAt: now - 1 * 24 * 60 * 60 * 1000,
+          },
+        },
+      ],
+      properties: [{ id: "prop-1" }, { id: "prop-2" }],
+      units: [
+        { id: "unit-1", status: "occupied" },
+        { id: "unit-2", status: "vacant" },
+        { id: "unit-3", tenantId: "tenant-3" },
+      ],
+      leases: [
+        { id: "lease-1", status: "active", endDate: new Date(now + 20 * 24 * 60 * 60 * 1000).toISOString() },
+        { id: "lease-2", status: "active", endDate: new Date(now + 50 * 24 * 60 * 60 * 1000).toISOString() },
+        { id: "lease-3", status: "ended", endDate: new Date(now - 5 * 24 * 60 * 60 * 1000).toISOString() },
+      ],
+      events: [
+        { id: "event-1", ts: now - 1_000, userId: "user-1" },
+        { id: "event-2", ts: now - 2_000, sessionId: "session-1" },
+      ],
+      canonicalEvents: [
+        { id: "ce-1", occurredAt: new Date(now - 10_000).toISOString() },
+      ],
+    });
+
+    expect(result.summary).toEqual({
+      applicationsStarted: 3,
+      applicationsSubmitted: 3,
+      applicationConversionRate: 1 / 3,
+      screeningsPaid: 1,
+      screeningRevenueCents: 3500,
+      openWorkOrders: 1,
+      maintenanceCostCents: 12500,
+      occupiedUnits: 2,
+      vacancyRate: 1 / 3,
+    });
+    expect(result.applications).toEqual({
+      started: 3,
+      submitted: 3,
+      approved: 1,
+      rejected: 1,
+      declined: 0,
+      pendingReviewCount: 1,
+      conversionRate: 1 / 3,
+    });
+    expect(result.screening.initiated).toBe(2);
+    expect(result.screening.checkoutCreated).toBe(2);
+    expect(result.screening.paid).toBe(1);
+    expect(result.screening.fulfilled).toBe(1);
+    expect(result.screening.abandoned).toBe(1);
+    expect(result.screening.totalRevenueCents).toBe(3500);
+    expect(result.maintenance).toEqual({
+      openWorkOrders: 1,
+      completedWorkOrders: 1,
+      reopenedWorkOrders: 1,
+      maintenanceCostCents: 12500,
+      averageCostPerCompletedWorkOrderCents: 12500,
+      costConcentrationByProperty: [
+        {
+          propertyId: "prop-1",
+          workOrderCount: 1,
+          totalCostCents: 12500,
+        },
+      ],
+    });
+    expect(result.portfolio).toEqual({
+      totalProperties: 2,
+      totalUnits: 3,
+      occupiedUnits: 2,
+      vacantUnits: 1,
+      occupancyRate: 2 / 3,
+      leasesEndingIn30Days: 1,
+      leasesEndingIn60Days: 2,
+      leasesEndingIn90Days: 2,
+      turnoverCount: 1,
+    });
+    expect(result.activity).toEqual({
+      trackedEvents: 2,
+      canonicalEvents: 1,
+      activeActors: 2,
+    });
+    expect(result.filters.period).toBe("30d");
+    expect(result.filters.granularity).toBe("daily");
+  });
+
+  it("returns safe empty output when no analytics inputs are present", () => {
+    const now = Date.UTC(2026, 3, 20, 12, 0, 0, 0);
+    const result = deriveAdminAnalyticsSnapshot({
+      now,
+      from: now - 7 * 24 * 60 * 60 * 1000,
+      to: now,
+      period: "30d",
+      granularity: "daily",
+      applications: [],
+      screeningReconciliations: [],
+      financialTransactions: [],
+      workOrders: [],
+      properties: [],
+      units: [],
+      leases: [],
+      events: [],
+      canonicalEvents: [],
+    });
+
+    expect(result.summary).toEqual({
+      applicationsStarted: 0,
+      applicationsSubmitted: 0,
+      applicationConversionRate: null,
+      screeningsPaid: 0,
+      screeningRevenueCents: 0,
+      openWorkOrders: 0,
+      maintenanceCostCents: 0,
+      occupiedUnits: 0,
+      vacancyRate: null,
+    });
+    expect(result.applications.pendingReviewCount).toBe(0);
+    expect(result.screening.statusCounts.fulfilled).toBe(0);
+    expect(result.maintenance.costConcentrationByProperty).toEqual([]);
+    expect(result.portfolio).toEqual({
+      totalProperties: 0,
+      totalUnits: 0,
+      occupiedUnits: 0,
+      vacantUnits: 0,
+      occupancyRate: null,
+      leasesEndingIn30Days: 0,
+      leasesEndingIn60Days: 0,
+      leasesEndingIn90Days: 0,
+      turnoverCount: 0,
+    });
+    expect(result.activity).toEqual({
+      trackedEvents: 0,
+      canonicalEvents: 0,
+      activeActors: 0,
+    });
+  });
+});

--- a/rentchain-api/src/lib/analytics/analyticsTypes.ts
+++ b/rentchain-api/src/lib/analytics/analyticsTypes.ts
@@ -1,0 +1,112 @@
+import type { ScreeningReconciliationStatus } from "../reconciliation/reconciliationTypes";
+
+export type AdminAnalyticsPeriod = "30d" | "90d" | "365d" | "month_to_date";
+export type AdminAnalyticsGranularity = "daily" | "weekly" | "monthly";
+
+export type AdminAnalyticsSummary = {
+  applicationsStarted: number;
+  applicationsSubmitted: number;
+  applicationConversionRate: number | null;
+  screeningsPaid: number;
+  screeningRevenueCents: number;
+  openWorkOrders: number;
+  maintenanceCostCents: number;
+  occupiedUnits: number;
+  vacancyRate: number | null;
+};
+
+export type AdminApplicationsAnalytics = {
+  started: number;
+  submitted: number;
+  approved: number;
+  rejected: number;
+  declined: number;
+  pendingReviewCount: number;
+  conversionRate: number | null;
+};
+
+export type AdminScreeningAnalytics = {
+  initiated: number;
+  checkoutCreated: number;
+  paid: number;
+  fulfilled: number;
+  blocked: number;
+  expired: number;
+  abandoned: number;
+  needsReview: number;
+  totalRevenueCents: number;
+  averageRevenuePerPaidScreeningCents: number | null;
+  statusCounts: Record<ScreeningReconciliationStatus, number>;
+};
+
+export type AdminMaintenanceAnalytics = {
+  openWorkOrders: number;
+  completedWorkOrders: number;
+  reopenedWorkOrders: number;
+  maintenanceCostCents: number;
+  averageCostPerCompletedWorkOrderCents: number | null;
+  costConcentrationByProperty: Array<{
+    propertyId: string;
+    workOrderCount: number;
+    totalCostCents: number;
+  }>;
+};
+
+export type AdminPortfolioAnalytics = {
+  totalProperties: number;
+  totalUnits: number;
+  occupiedUnits: number;
+  vacantUnits: number;
+  occupancyRate: number | null;
+  leasesEndingIn30Days: number;
+  leasesEndingIn60Days: number;
+  leasesEndingIn90Days: number;
+  turnoverCount: number;
+};
+
+export type AdminActivityAnalytics = {
+  trackedEvents: number;
+  canonicalEvents: number;
+  activeActors: number;
+};
+
+export type AdminAnalyticsSnapshot = {
+  summary: AdminAnalyticsSummary;
+  applications: AdminApplicationsAnalytics;
+  screening: AdminScreeningAnalytics;
+  maintenance: AdminMaintenanceAnalytics;
+  portfolio: AdminPortfolioAnalytics;
+  activity: AdminActivityAnalytics;
+  filters: {
+    period: AdminAnalyticsPeriod;
+    granularity: AdminAnalyticsGranularity;
+    from: string;
+    to: string;
+  };
+};
+
+export type AdminAnalyticsDerivedInput = {
+  from: number;
+  to: number;
+  now: number;
+  period: AdminAnalyticsPeriod;
+  granularity: AdminAnalyticsGranularity;
+  applications: any[];
+  screeningReconciliations: Array<{
+    status: ScreeningReconciliationStatus;
+    summary: {
+      hasQuote: boolean;
+      hasCheckout: boolean;
+      hasPaidEvent: boolean;
+      hasFulfillment: boolean;
+      lastMeaningfulEventAt: string | null;
+    };
+  }>;
+  financialTransactions: any[];
+  workOrders: any[];
+  properties: any[];
+  units: any[];
+  leases: any[];
+  events: any[];
+  canonicalEvents: any[];
+};

--- a/rentchain-api/src/lib/analytics/deriveAdminAnalyticsSnapshot.ts
+++ b/rentchain-api/src/lib/analytics/deriveAdminAnalyticsSnapshot.ts
@@ -1,0 +1,385 @@
+import type {
+  AdminAnalyticsDerivedInput,
+  AdminAnalyticsSnapshot,
+  AdminApplicationsAnalytics,
+  AdminScreeningAnalytics,
+  AdminMaintenanceAnalytics,
+  AdminPortfolioAnalytics,
+  AdminActivityAnalytics,
+} from "./analyticsTypes";
+import type { ScreeningReconciliationStatus } from "../reconciliation/reconciliationTypes";
+
+const SCREENING_STATUS_KEYS: ScreeningReconciliationStatus[] = [
+  "not_started",
+  "quoted",
+  "checkout_created",
+  "payment_pending",
+  "paid_not_fulfilled",
+  "fulfilled",
+  "blocked",
+  "expired",
+  "abandoned",
+  "mismatch",
+  "duplicate_risk",
+  "needs_review",
+];
+
+const ACTIVE_WORK_ORDER_STATUSES = new Set([
+  "open",
+  "invited",
+  "assigned",
+  "accepted",
+  "scheduled",
+  "blocked",
+  "in_progress",
+]);
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function toMillis(value: unknown): number | null {
+  if (value == null || value === "") return null;
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  if (typeof (value as any)?.toMillis === "function") return (value as any).toMillis();
+  if (typeof (value as any)?.seconds === "number") return (value as any).seconds * 1000;
+  return null;
+}
+
+function isWithinRange(value: unknown, from: number, to: number) {
+  const timestamp = toMillis(value);
+  return timestamp != null && timestamp >= from && timestamp <= to;
+}
+
+function safeRate(numerator: number, denominator: number) {
+  if (denominator <= 0) return null;
+  return numerator / denominator;
+}
+
+function incrementBucket(bucket: Record<string, number>, key: string | null) {
+  if (!key) return;
+  bucket[key] = (bucket[key] || 0) + 1;
+}
+
+function deriveApplicationsAnalytics(applications: any[], from: number, to: number): AdminApplicationsAnalytics {
+  let started = 0;
+  let submitted = 0;
+  let approved = 0;
+  let rejected = 0;
+  let declined = 0;
+  let pendingReviewCount = 0;
+
+  for (const application of applications || []) {
+    const status = asString(application?.status, 80).toLowerCase();
+
+    if (status === "new" || status === "submitted" || status === "in_review") {
+      pendingReviewCount += 1;
+    }
+
+    if (isWithinRange(application?.createdAt, from, to)) {
+      started += 1;
+    }
+
+    if (
+      isWithinRange(application?.submittedAt, from, to) ||
+      (!application?.submittedAt && isWithinRange(application?.createdAt, from, to))
+    ) {
+      submitted += 1;
+    }
+
+    if (
+      isWithinRange(application?.approvedAt, from, to) ||
+      (status === "approved" && !application?.approvedAt && isWithinRange(application?.updatedAt || application?.createdAt, from, to))
+    ) {
+      approved += 1;
+    }
+
+    const rejectedInWindow =
+      isWithinRange(application?.rejectedAt, from, to) ||
+      ((status === "rejected" || status === "declined") &&
+        !application?.rejectedAt &&
+        isWithinRange(application?.updatedAt || application?.createdAt, from, to));
+
+    if (rejectedInWindow) {
+      if (status === "declined") declined += 1;
+      else rejected += 1;
+    }
+  }
+
+  return {
+    started,
+    submitted,
+    approved,
+    rejected,
+    declined,
+    pendingReviewCount,
+    conversionRate: safeRate(approved, submitted),
+  };
+}
+
+function deriveScreeningAnalytics(
+  screeningReconciliations: AdminAnalyticsDerivedInput["screeningReconciliations"],
+  financialTransactions: any[],
+  from: number,
+  to: number
+): AdminScreeningAnalytics {
+  const statusCounts = SCREENING_STATUS_KEYS.reduce<Record<ScreeningReconciliationStatus, number>>((acc, status) => {
+    acc[status] = 0;
+    return acc;
+  }, {} as Record<ScreeningReconciliationStatus, number>);
+
+  let initiated = 0;
+  let checkoutCreated = 0;
+  let paid = 0;
+  let fulfilled = 0;
+  let blocked = 0;
+  let expired = 0;
+  let abandoned = 0;
+  let needsReview = 0;
+
+  for (const reconciliation of screeningReconciliations || []) {
+    const lastActivityAt = reconciliation?.summary?.lastMeaningfulEventAt;
+    if (!isWithinRange(lastActivityAt, from, to)) continue;
+
+    const status = reconciliation.status;
+    statusCounts[status] += 1;
+
+    if (
+      reconciliation.summary?.hasQuote ||
+      reconciliation.summary?.hasCheckout ||
+      reconciliation.summary?.hasPaidEvent ||
+      reconciliation.summary?.hasFulfillment
+    ) {
+      initiated += 1;
+    }
+
+    if (reconciliation.summary?.hasCheckout) {
+      checkoutCreated += 1;
+    }
+
+    if (reconciliation.summary?.hasPaidEvent) {
+      paid += 1;
+    }
+
+    if (status === "fulfilled") fulfilled += 1;
+    if (status === "blocked") blocked += 1;
+    if (status === "expired") expired += 1;
+    if (status === "abandoned") abandoned += 1;
+    if (status === "needs_review" || status === "mismatch" || status === "duplicate_risk") {
+      needsReview += 1;
+    }
+  }
+
+  let totalRevenueCents = 0;
+  let completedRevenueCount = 0;
+  for (const transaction of financialTransactions || []) {
+    if (asString(transaction?.type, 80).toLowerCase() !== "payment_succeeded") continue;
+    if (!isWithinRange(transaction?.createdAt || transaction?.updatedAt, from, to)) continue;
+    const amount = Number(transaction?.amountCents || 0);
+    if (!Number.isFinite(amount) || amount <= 0) continue;
+    totalRevenueCents += Math.round(amount);
+    completedRevenueCount += 1;
+  }
+
+  return {
+    initiated,
+    checkoutCreated,
+    paid,
+    fulfilled,
+    blocked,
+    expired,
+    abandoned,
+    needsReview,
+    totalRevenueCents,
+    averageRevenuePerPaidScreeningCents:
+      completedRevenueCount > 0 ? Math.round(totalRevenueCents / completedRevenueCount) : null,
+    statusCounts,
+  };
+}
+
+function deriveMaintenanceAnalytics(workOrders: any[], from: number, to: number): AdminMaintenanceAnalytics {
+  let openWorkOrders = 0;
+  let completedWorkOrders = 0;
+  let reopenedWorkOrders = 0;
+  let maintenanceCostCents = 0;
+  let completedWithCostCount = 0;
+  const byPropertyCost: Record<string, { workOrderCount: number; totalCostCents: number }> = {};
+
+  for (const workOrder of workOrders || []) {
+    const status = asString(workOrder?.status, 80).toLowerCase();
+    if (ACTIVE_WORK_ORDER_STATUSES.has(status)) {
+      openWorkOrders += 1;
+    }
+
+    if (
+      isWithinRange(workOrder?.serviceCompletedAt, from, to) ||
+      (status === "completed" && !workOrder?.serviceCompletedAt && isWithinRange(workOrder?.updatedAt || workOrder?.createdAt, from, to))
+    ) {
+      completedWorkOrders += 1;
+    }
+
+    if (isWithinRange(workOrder?.reopenedAt, from, to)) {
+      reopenedWorkOrders += 1;
+    }
+
+    const actualCostCents = Number(workOrder?.cost?.actualCostCents || workOrder?.actualCostCents || 0);
+    if (!Number.isFinite(actualCostCents) || actualCostCents <= 0) continue;
+
+    const costTimestamp =
+      workOrder?.cost?.submittedAt ||
+      workOrder?.cost?.reviewedAt ||
+      workOrder?.serviceCompletedAt ||
+      workOrder?.updatedAt ||
+      workOrder?.createdAt;
+    if (!isWithinRange(costTimestamp, from, to)) continue;
+
+    const roundedCost = Math.round(actualCostCents);
+    maintenanceCostCents += roundedCost;
+    completedWithCostCount += 1;
+
+    const propertyId = asString(workOrder?.propertyId, 120);
+    if (propertyId) {
+      byPropertyCost[propertyId] = byPropertyCost[propertyId] || { workOrderCount: 0, totalCostCents: 0 };
+      byPropertyCost[propertyId].workOrderCount += 1;
+      byPropertyCost[propertyId].totalCostCents += roundedCost;
+    }
+  }
+
+  const costConcentrationByProperty = Object.entries(byPropertyCost)
+    .map(([propertyId, metrics]) => ({
+      propertyId,
+      workOrderCount: metrics.workOrderCount,
+      totalCostCents: metrics.totalCostCents,
+    }))
+    .sort((a, b) => {
+      if (b.totalCostCents !== a.totalCostCents) return b.totalCostCents - a.totalCostCents;
+      return a.propertyId.localeCompare(b.propertyId);
+    })
+    .slice(0, 5);
+
+  return {
+    openWorkOrders,
+    completedWorkOrders,
+    reopenedWorkOrders,
+    maintenanceCostCents,
+    averageCostPerCompletedWorkOrderCents:
+      completedWithCostCount > 0 ? Math.round(maintenanceCostCents / completedWithCostCount) : null,
+    costConcentrationByProperty,
+  };
+}
+
+function isOccupiedUnit(unit: any) {
+  const status = asString(unit?.status, 80).toLowerCase();
+  if (status === "occupied" || status === "leased") return true;
+  if (status === "vacant" || status === "available") return false;
+  return Boolean(asString(unit?.tenantName, 120) || asString(unit?.tenantId, 120));
+}
+
+function derivePortfolioAnalytics(
+  properties: any[],
+  units: any[],
+  leases: any[],
+  now: number,
+  from: number,
+  to: number
+): AdminPortfolioAnalytics {
+  const totalProperties = (properties || []).length;
+  const totalUnits = (units || []).length;
+  const occupiedUnits = (units || []).filter(isOccupiedUnit).length;
+  const vacantUnits = Math.max(0, totalUnits - occupiedUnits);
+
+  let leasesEndingIn30Days = 0;
+  let leasesEndingIn60Days = 0;
+  let leasesEndingIn90Days = 0;
+  let turnoverCount = 0;
+
+  for (const lease of leases || []) {
+    const endAt =
+      toMillis(lease?.leaseEndDate) ||
+      toMillis(lease?.endDate) ||
+      toMillis(lease?.leaseEnd) ||
+      toMillis(lease?.moveOutDate);
+    if (endAt != null) {
+      const deltaDays = Math.floor((endAt - now) / (24 * 60 * 60 * 1000));
+      if (deltaDays >= 0 && deltaDays <= 30) leasesEndingIn30Days += 1;
+      if (deltaDays >= 0 && deltaDays <= 60) leasesEndingIn60Days += 1;
+      if (deltaDays >= 0 && deltaDays <= 90) leasesEndingIn90Days += 1;
+      if (endAt >= from && endAt <= to) turnoverCount += 1;
+    }
+  }
+
+  return {
+    totalProperties,
+    totalUnits,
+    occupiedUnits,
+    vacantUnits,
+    occupancyRate: safeRate(occupiedUnits, totalUnits),
+    leasesEndingIn30Days,
+    leasesEndingIn60Days,
+    leasesEndingIn90Days,
+    turnoverCount,
+  };
+}
+
+function deriveActivityAnalytics(events: any[], canonicalEvents: any[], from: number, to: number): AdminActivityAnalytics {
+  let trackedEvents = 0;
+  let canonicalTracked = 0;
+  const activeActors = new Set<string>();
+
+  for (const event of events || []) {
+    if (!isWithinRange(event?.ts || event?.createdAt, from, to)) continue;
+    trackedEvents += 1;
+    const userId = asString(event?.userId, 120);
+    const sessionId = asString(event?.sessionId, 120);
+    if (userId) activeActors.add(`user:${userId}`);
+    else if (sessionId) activeActors.add(`session:${sessionId}`);
+  }
+
+  for (const event of canonicalEvents || []) {
+    if (!isWithinRange(event?.occurredAt || event?.recordedAt, from, to)) continue;
+    canonicalTracked += 1;
+  }
+
+  return {
+    trackedEvents,
+    canonicalEvents: canonicalTracked,
+    activeActors: activeActors.size,
+  };
+}
+
+export function deriveAdminAnalyticsSnapshot(input: AdminAnalyticsDerivedInput): AdminAnalyticsSnapshot {
+  const applications = deriveApplicationsAnalytics(input.applications, input.from, input.to);
+  const screening = deriveScreeningAnalytics(input.screeningReconciliations, input.financialTransactions, input.from, input.to);
+  const maintenance = deriveMaintenanceAnalytics(input.workOrders, input.from, input.to);
+  const portfolio = derivePortfolioAnalytics(input.properties, input.units, input.leases, input.now, input.from, input.to);
+  const activity = deriveActivityAnalytics(input.events, input.canonicalEvents, input.from, input.to);
+
+  return {
+    summary: {
+      applicationsStarted: applications.started,
+      applicationsSubmitted: applications.submitted,
+      applicationConversionRate: applications.conversionRate,
+      screeningsPaid: screening.paid,
+      screeningRevenueCents: screening.totalRevenueCents,
+      openWorkOrders: maintenance.openWorkOrders,
+      maintenanceCostCents: maintenance.maintenanceCostCents,
+      occupiedUnits: portfolio.occupiedUnits,
+      vacancyRate: portfolio.totalUnits > 0 ? portfolio.vacantUnits / portfolio.totalUnits : null,
+    },
+    applications,
+    screening,
+    maintenance,
+    portfolio,
+    activity,
+    filters: {
+      period: input.period,
+      granularity: input.granularity,
+      from: new Date(input.from).toISOString(),
+      to: new Date(input.to).toISOString(),
+    },
+  };
+}

--- a/rentchain-api/src/routes/__tests__/adminAnalyticsSnapshotAuthRoute.test.ts
+++ b/rentchain-api/src/routes/__tests__/adminAnalyticsSnapshotAuthRoute.test.ts
@@ -1,0 +1,249 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  verifyAuthTokenMock: vi.fn(),
+  buildCanonicalSessionUserFromClaimsMock: vi.fn(),
+  loadAdminAnalyticsSnapshotMock: vi.fn(),
+}));
+
+vi.mock("../../auth/jwt", () => ({
+  verifyAuthToken: mocks.verifyAuthTokenMock,
+}));
+
+vi.mock("../../services/sessionUserService", () => ({
+  buildCanonicalSessionUserFromClaims: mocks.buildCanonicalSessionUserFromClaimsMock,
+}));
+
+vi.mock("../../services/admin/adminAnalyticsSnapshot", () => ({
+  loadAdminAnalyticsSnapshot: mocks.loadAdminAnalyticsSnapshotMock,
+}));
+
+vi.mock("../../config/firebase", () => ({
+  db: {
+    collection: vi.fn(() => ({
+      where: vi.fn(),
+      doc: vi.fn(() => ({ set: vi.fn(), get: vi.fn(), delete: vi.fn() })),
+    })),
+  },
+}));
+
+vi.mock("../../services/telemetryService", () => ({
+  getCountersSummary: vi.fn(async () => ({ byName: {} })),
+}));
+
+vi.mock("../../services/stripeService", () => ({
+  isStripeConfigured: () => false,
+  getStripeClient: () => {
+    throw new Error("not configured");
+  },
+}));
+
+vi.mock("../../services/statusService", () => ({
+  getPublicStatusPayload: vi.fn(async () => ({ ok: true })),
+  createStatusIncident: vi.fn(),
+  resolveStatusIncident: vi.fn(),
+  updateStatusComponent: vi.fn(),
+  updateStatusMeta: vi.fn(),
+}));
+
+vi.mock("../../services/metrics/tuReferralReport", () => ({
+  getTuReferralMetricsForMonth: vi.fn(async () => ({ ok: true })),
+}));
+
+vi.mock("../../services/admin/adminSubscriptionConversionView", () => ({
+  loadAdminSubscriptionConversionFunnel: vi.fn(),
+}));
+
+vi.mock("../../services/admin/adminSubscriptionConversionInsights", () => ({
+  loadAdminSubscriptionConversionInsights: vi.fn(),
+}));
+
+vi.mock("../../services/admin/adminActivationSummary", () => ({
+  loadAdminActivationSummary: vi.fn(),
+}));
+
+vi.mock("../../services/admin/adminSubscriptionConversionValidation", () => ({
+  loadAdminSubscriptionConversionValidation: vi.fn(),
+}));
+
+vi.mock("firebase-admin", () => ({
+  default: {
+    auth: () => ({ createUser: vi.fn() }),
+    firestore: {
+      FieldValue: {
+        serverTimestamp: () => Date.now(),
+      },
+    },
+  },
+}));
+
+function createReq(headers?: Record<string, string>) {
+  return {
+    headers: headers || {},
+    query: {},
+    body: {},
+    params: {},
+  } as any;
+}
+
+function createRes() {
+  return {
+    statusCode: 200,
+    body: undefined as any,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+    send(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+    setHeader: vi.fn(),
+  } as any;
+}
+
+async function runRoute(router: any, method: "get", path: string, req: any) {
+  const layer = router.stack.find((entry: any) => entry.route?.path === path && entry.route?.methods?.[method]);
+  if (!layer) throw new Error(`route not found: ${method.toUpperCase()} ${path}`);
+  const res = createRes();
+  const stack = [...layer.route.stack];
+
+  async function next(index: number): Promise<void> {
+    const item = stack[index];
+    if (!item) return;
+    await new Promise<void>((resolve, reject) => {
+      try {
+        let nextCalled = false;
+        const maybe = item.handle(req, res, (err?: unknown) => {
+          nextCalled = true;
+          if (err) reject(err);
+          else resolve(next(index + 1));
+        });
+        if (maybe && typeof maybe.then === "function") {
+          maybe.then(() => resolve()).catch(reject);
+        } else if (item.handle.length < 3 || !nextCalled) {
+          resolve();
+        }
+      } catch (error) {
+        reject(error);
+      }
+    });
+  }
+
+  await next(0);
+  return res;
+}
+
+describe("admin analytics snapshot route auth", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.verifyAuthTokenMock.mockReset();
+    mocks.buildCanonicalSessionUserFromClaimsMock.mockReset();
+    mocks.loadAdminAnalyticsSnapshotMock.mockReset();
+    mocks.loadAdminAnalyticsSnapshotMock.mockResolvedValue({
+      summary: {
+        applicationsStarted: 0,
+        applicationsSubmitted: 0,
+        applicationConversionRate: null,
+        screeningsPaid: 0,
+        screeningRevenueCents: 0,
+        openWorkOrders: 0,
+        maintenanceCostCents: 0,
+        occupiedUnits: 0,
+        vacancyRate: null,
+      },
+      applications: {
+        started: 0,
+        submitted: 0,
+        approved: 0,
+        rejected: 0,
+        declined: 0,
+        pendingReviewCount: 0,
+        conversionRate: null,
+      },
+      screening: {
+        initiated: 0,
+        checkoutCreated: 0,
+        paid: 0,
+        fulfilled: 0,
+        blocked: 0,
+        expired: 0,
+        abandoned: 0,
+        needsReview: 0,
+        totalRevenueCents: 0,
+        averageRevenuePerPaidScreeningCents: null,
+        statusCounts: {
+          not_started: 0,
+          quoted: 0,
+          checkout_created: 0,
+          payment_pending: 0,
+          paid_not_fulfilled: 0,
+          fulfilled: 0,
+          blocked: 0,
+          expired: 0,
+          abandoned: 0,
+          mismatch: 0,
+          duplicate_risk: 0,
+          needs_review: 0,
+        },
+      },
+      maintenance: {
+        openWorkOrders: 0,
+        completedWorkOrders: 0,
+        reopenedWorkOrders: 0,
+        maintenanceCostCents: 0,
+        averageCostPerCompletedWorkOrderCents: null,
+        costConcentrationByProperty: [],
+      },
+      portfolio: {
+        totalProperties: 0,
+        totalUnits: 0,
+        occupiedUnits: 0,
+        vacantUnits: 0,
+        occupancyRate: null,
+        leasesEndingIn30Days: 0,
+        leasesEndingIn60Days: 0,
+        leasesEndingIn90Days: 0,
+        turnoverCount: 0,
+      },
+      activity: {
+        trackedEvents: 0,
+        canonicalEvents: 0,
+        activeActors: 0,
+      },
+      filters: {
+        period: "30d",
+        granularity: "daily",
+        from: "2026-03-21T00:00:00.000Z",
+        to: "2026-04-20T00:00:00.000Z",
+      },
+    });
+  });
+
+  it("returns 401 for unauthenticated requests", async () => {
+    const router = (await import("../adminRoutes")).default;
+    const res = await runRoute(router, "get", "/analytics/snapshot", createReq());
+    expect(res.statusCode).toBe(401);
+    expect(mocks.loadAdminAnalyticsSnapshotMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 for authenticated non-admin requests", async () => {
+    mocks.verifyAuthTokenMock.mockReturnValue({ sub: "landlord-1" });
+    mocks.buildCanonicalSessionUserFromClaimsMock.mockResolvedValue({
+      id: "landlord-1",
+      role: "landlord",
+      permissions: [],
+      revokedPermissions: [],
+      entitlements: {},
+    });
+
+    const router = (await import("../adminRoutes")).default;
+    const res = await runRoute(router, "get", "/analytics/snapshot", createReq({ authorization: "Bearer landlord-token" }));
+    expect(res.statusCode).toBe(401);
+    expect(mocks.loadAdminAnalyticsSnapshotMock).not.toHaveBeenCalled();
+  });
+});

--- a/rentchain-api/src/routes/__tests__/adminAnalyticsSnapshotRoute.test.ts
+++ b/rentchain-api/src/routes/__tests__/adminAnalyticsSnapshotRoute.test.ts
@@ -1,0 +1,220 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const loadAdminAnalyticsSnapshot = vi.fn();
+
+vi.mock("../../middleware/requireAdmin", () => ({
+  requireAdmin: (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock("../../services/admin/adminAnalyticsSnapshot", () => ({
+  loadAdminAnalyticsSnapshot,
+}));
+
+vi.mock("../../config/firebase", () => ({
+  db: {
+    collection: vi.fn(() => ({
+      where: vi.fn(),
+      doc: vi.fn(() => ({ set: vi.fn() })),
+    })),
+  },
+}));
+
+vi.mock("../../services/telemetryService", () => ({
+  getCountersSummary: vi.fn(async () => ({ byName: {} })),
+}));
+
+vi.mock("../../services/stripeService", () => ({
+  isStripeConfigured: () => false,
+  getStripeClient: () => {
+    throw new Error("not configured");
+  },
+}));
+
+vi.mock("../../services/statusService", () => ({
+  getPublicStatusPayload: vi.fn(async () => ({ ok: true })),
+  createStatusIncident: vi.fn(),
+  resolveStatusIncident: vi.fn(),
+  updateStatusComponent: vi.fn(),
+  updateStatusMeta: vi.fn(),
+}));
+
+vi.mock("../../services/metrics/tuReferralReport", () => ({
+  getTuReferralMetricsForMonth: vi.fn(async () => ({ ok: true })),
+}));
+
+vi.mock("../../services/admin/adminSubscriptionConversionView", () => ({
+  loadAdminSubscriptionConversionFunnel: vi.fn(),
+}));
+
+vi.mock("../../services/admin/adminSubscriptionConversionInsights", () => ({
+  loadAdminSubscriptionConversionInsights: vi.fn(),
+}));
+
+vi.mock("../../services/admin/adminActivationSummary", () => ({
+  loadAdminActivationSummary: vi.fn(),
+}));
+
+vi.mock("../../services/admin/adminSubscriptionConversionValidation", () => ({
+  loadAdminSubscriptionConversionValidation: vi.fn(),
+}));
+
+vi.mock("firebase-admin", () => ({
+  default: {
+    auth: () => ({ createUser: vi.fn() }),
+    firestore: {
+      FieldValue: {
+        serverTimestamp: () => Date.now(),
+      },
+    },
+  },
+}));
+
+async function createRouter() {
+  return (await import("../adminRoutes")).default;
+}
+
+async function invokeRouter(router: any, url: string) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const req: any = {
+      method: "GET",
+      url: url.replace(/^\/api\/admin/, ""),
+      originalUrl: url,
+      path: url.replace(/^\/api\/admin/, "").split("?")[0],
+      query: {},
+      body: {},
+      user: { id: "admin-1", role: "admin" },
+      cookies: {},
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, any>,
+      setHeader(name: string, value: any) {
+        this.headers[name.toLowerCase()] = value;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    const [, rawQuery] = url.split("?");
+    if (rawQuery) {
+      req.query = Object.fromEntries(new URLSearchParams(rawQuery).entries());
+    }
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("GET /api/admin/analytics/snapshot", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    loadAdminAnalyticsSnapshot.mockReset();
+  });
+
+  it("returns the admin analytics snapshot payload", async () => {
+    loadAdminAnalyticsSnapshot.mockResolvedValue({
+      summary: {
+        applicationsStarted: 10,
+        applicationsSubmitted: 8,
+        applicationConversionRate: 0.25,
+        screeningsPaid: 3,
+        screeningRevenueCents: 12600,
+        openWorkOrders: 4,
+        maintenanceCostCents: 22000,
+        occupiedUnits: 18,
+        vacancyRate: 0.1,
+      },
+      applications: {
+        started: 10,
+        submitted: 8,
+        approved: 2,
+        rejected: 1,
+        declined: 0,
+        pendingReviewCount: 5,
+        conversionRate: 0.25,
+      },
+      screening: {
+        initiated: 5,
+        checkoutCreated: 4,
+        paid: 3,
+        fulfilled: 2,
+        blocked: 0,
+        expired: 1,
+        abandoned: 1,
+        needsReview: 0,
+        totalRevenueCents: 12600,
+        averageRevenuePerPaidScreeningCents: 4200,
+        statusCounts: {
+          not_started: 0,
+          quoted: 0,
+          checkout_created: 1,
+          payment_pending: 0,
+          paid_not_fulfilled: 1,
+          fulfilled: 2,
+          blocked: 0,
+          expired: 1,
+          abandoned: 1,
+          mismatch: 0,
+          duplicate_risk: 0,
+          needs_review: 0,
+        },
+      },
+      maintenance: {
+        openWorkOrders: 4,
+        completedWorkOrders: 6,
+        reopenedWorkOrders: 1,
+        maintenanceCostCents: 22000,
+        averageCostPerCompletedWorkOrderCents: 3667,
+        costConcentrationByProperty: [],
+      },
+      portfolio: {
+        totalProperties: 4,
+        totalUnits: 20,
+        occupiedUnits: 18,
+        vacantUnits: 2,
+        occupancyRate: 0.9,
+        leasesEndingIn30Days: 1,
+        leasesEndingIn60Days: 2,
+        leasesEndingIn90Days: 3,
+        turnoverCount: 1,
+      },
+      activity: {
+        trackedEvents: 12,
+        canonicalEvents: 7,
+        activeActors: 5,
+      },
+      filters: {
+        period: "90d",
+        granularity: "weekly",
+        from: "2026-01-20T00:00:00.000Z",
+        to: "2026-04-20T00:00:00.000Z",
+      },
+    });
+
+    const router = await createRouter();
+    const res = await invokeRouter(router, "/api/admin/analytics/snapshot?period=90d&granularity=weekly");
+
+    expect(res.status).toBe(200);
+    expect(loadAdminAnalyticsSnapshot).toHaveBeenCalledWith({
+      period: "90d",
+      granularity: "weekly",
+    });
+    expect(res.body.ok).toBe(true);
+    expect(res.body.summary.applicationsStarted).toBe(10);
+    expect(res.body.filters).toEqual({
+      period: "90d",
+      granularity: "weekly",
+      from: "2026-01-20T00:00:00.000Z",
+      to: "2026-04-20T00:00:00.000Z",
+    });
+  });
+});

--- a/rentchain-api/src/routes/adminRoutes.ts
+++ b/rentchain-api/src/routes/adminRoutes.ts
@@ -10,6 +10,7 @@ import { getPublicStatusPayload } from "../services/statusService";
 import { loadAdminSubscriptionConversionFunnel } from "../services/admin/adminSubscriptionConversionView";
 import { loadAdminSubscriptionConversionInsights } from "../services/admin/adminSubscriptionConversionInsights";
 import { loadAdminActivationSummary } from "../services/admin/adminActivationSummary";
+import { loadAdminAnalyticsSnapshot } from "../services/admin/adminAnalyticsSnapshot";
 import { loadAdminSubscriptionConversionValidation } from "../services/admin/adminSubscriptionConversionValidation";
 import {
   createStatusIncident,
@@ -877,6 +878,22 @@ router.get("/analytics/activation-summary", requireAdmin, async (req, res) => {
   } catch (err: any) {
     console.error("[admin] activation summary failed", err?.message || err);
     return res.status(500).json({ ok: false, error: "ACTIVATION_SUMMARY_FAILED" });
+  }
+});
+
+router.get("/analytics/snapshot", requireAdmin, async (req, res) => {
+  try {
+    const payload = await loadAdminAnalyticsSnapshot({
+      period: typeof req.query?.period === "string" ? req.query.period : undefined,
+      granularity: typeof req.query?.granularity === "string" ? req.query.granularity : undefined,
+    });
+    return res.json({
+      ok: true,
+      ...payload,
+    });
+  } catch (err: any) {
+    console.error("[admin] analytics snapshot failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "ANALYTICS_SNAPSHOT_FAILED" });
   }
 });
 

--- a/rentchain-api/src/services/__tests__/adminAnalyticsSnapshot.test.ts
+++ b/rentchain-api/src/services/__tests__/adminAnalyticsSnapshot.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type StoredDoc = { id: string; data: any };
+
+const { dbMock, resetDb, seedDoc } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, StoredDoc>>();
+
+  function ensureCollection(name: string) {
+    if (!collections.has(name)) collections.set(name, new Map());
+    return collections.get(name)!;
+  }
+
+  return {
+    dbMock: {
+      collection: (name: string) => ({
+        get: async () => {
+          const docs = Array.from(ensureCollection(name).values()).map((entry) => ({
+            id: entry.id,
+            data: () => entry.data,
+          }));
+          return { docs, empty: docs.length === 0, size: docs.length };
+        },
+      }),
+    },
+    resetDb: () => {
+      collections.clear();
+    },
+    seedDoc: (collection: string, id: string, data: any) => {
+      ensureCollection(collection).set(id, { id, data });
+    },
+  };
+});
+
+vi.mock("../../config/firebase", () => ({
+  db: dbMock,
+}));
+
+describe("adminAnalyticsSnapshot", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    resetDb();
+  });
+
+  it("loads a computed admin analytics snapshot from the current Firestore-backed sources", async () => {
+    const now = Date.UTC(2026, 3, 20, 12, 0, 0, 0);
+    seedDoc("rentalApplications", "app-1", {
+      createdAt: now - 2 * 24 * 60 * 60 * 1000,
+      submittedAt: now - 2 * 24 * 60 * 60 * 1000,
+      approvedAt: now - 1 * 24 * 60 * 60 * 1000,
+      status: "approved",
+      screeningStatus: "complete",
+      screeningPaidAt: now - 1 * 24 * 60 * 60 * 1000,
+      screeningCompletedAt: now - 1 * 24 * 60 * 60 * 1000,
+    });
+    seedDoc("workOrders", "wo-1", {
+      propertyId: "prop-1",
+      status: "completed",
+      serviceCompletedAt: now - 1 * 24 * 60 * 60 * 1000,
+      cost: {
+        actualCostCents: 8000,
+        submittedAt: now - 1 * 24 * 60 * 60 * 1000,
+      },
+    });
+    seedDoc("properties", "prop-1", { name: "Property 1" });
+    seedDoc("units", "unit-1", { propertyId: "prop-1", status: "occupied" });
+    seedDoc("leases", "lease-1", {
+      propertyId: "prop-1",
+      status: "active",
+      endDate: new Date(now + 15 * 24 * 60 * 60 * 1000).toISOString(),
+    });
+    seedDoc("events", "event-1", {
+      name: "pricing_page_viewed",
+      ts: now - 10_000,
+      userId: "user-1",
+      props: { surface: "pricing_page" },
+    });
+    seedDoc("canonicalEvents", "canonical-1", {
+      id: "canonical-1",
+      version: "v1",
+      type: "screening.completed",
+      domain: "screening",
+      action: "completed",
+      actor: { type: "system" },
+      resource: { type: "rental_application", id: "app-1" },
+      occurredAt: new Date(now - 1 * 24 * 60 * 60 * 1000).toISOString(),
+      recordedAt: new Date(now - 1 * 24 * 60 * 60 * 1000).toISOString(),
+      visibility: "internal",
+      summary: "Completed screening",
+      metadata: { applicationId: "app-1" },
+    });
+    seedDoc("financialTransactions", "txn-1", {
+      type: "payment_succeeded",
+      amountCents: 4200,
+      applicationId: "app-1",
+      createdAt: now - 1 * 24 * 60 * 60 * 1000,
+    });
+    seedDoc("screeningOrders", "order-1", {
+      applicationId: "app-1",
+      status: "completed",
+      paymentStatus: "paid",
+      amountTotalCents: 4200,
+      updatedAt: now - 1 * 24 * 60 * 60 * 1000,
+    });
+
+    const { loadAdminAnalyticsSnapshot } = await import("../admin/adminAnalyticsSnapshot");
+    const result = await loadAdminAnalyticsSnapshot({ period: "30d", granularity: "weekly", now });
+
+    expect(result.filters.period).toBe("30d");
+    expect(result.filters.granularity).toBe("weekly");
+    expect(result.applications.approved).toBe(1);
+    expect(result.screening.paid).toBe(1);
+    expect(result.screening.totalRevenueCents).toBe(4200);
+    expect(result.maintenance.maintenanceCostCents).toBe(8000);
+    expect(result.portfolio.occupiedUnits).toBe(1);
+    expect(result.activity.trackedEvents).toBe(1);
+    expect(result.activity.canonicalEvents).toBe(1);
+  });
+
+  it("returns safe empty analytics output when source collections are empty", async () => {
+    const now = Date.UTC(2026, 3, 20, 12, 0, 0, 0);
+    const { loadAdminAnalyticsSnapshot } = await import("../admin/adminAnalyticsSnapshot");
+    const result = await loadAdminAnalyticsSnapshot({ now });
+
+    expect(result.summary).toEqual({
+      applicationsStarted: 0,
+      applicationsSubmitted: 0,
+      applicationConversionRate: null,
+      screeningsPaid: 0,
+      screeningRevenueCents: 0,
+      openWorkOrders: 0,
+      maintenanceCostCents: 0,
+      occupiedUnits: 0,
+      vacancyRate: null,
+    });
+    expect(result.filters.period).toBe("30d");
+    expect(result.filters.granularity).toBe("daily");
+  });
+});

--- a/rentchain-api/src/services/admin/adminAnalyticsSnapshot.ts
+++ b/rentchain-api/src/services/admin/adminAnalyticsSnapshot.ts
@@ -1,0 +1,159 @@
+import { db } from "../../config/firebase";
+import { CANONICAL_EVENTS_COLLECTION } from "../../lib/events/buildEvent";
+import type { CanonicalEventV1 } from "../../lib/events/eventTypes";
+import { deriveAdminAnalyticsSnapshot } from "../../lib/analytics/deriveAdminAnalyticsSnapshot";
+import type {
+  AdminAnalyticsGranularity,
+  AdminAnalyticsPeriod,
+  AdminAnalyticsSnapshot,
+} from "../../lib/analytics/analyticsTypes";
+import { deriveScreeningReconciliation } from "../../lib/reconciliation/deriveScreeningReconciliation";
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function clampPeriod(value: unknown): AdminAnalyticsPeriod {
+  const raw = asString(value, 40).toLowerCase();
+  if (raw === "90d") return "90d";
+  if (raw === "365d") return "365d";
+  if (raw === "month_to_date") return "month_to_date";
+  return "30d";
+}
+
+function clampGranularity(value: unknown): AdminAnalyticsGranularity {
+  const raw = asString(value, 40).toLowerCase();
+  if (raw === "weekly") return "weekly";
+  if (raw === "monthly") return "monthly";
+  return "daily";
+}
+
+function resolveWindow(period: AdminAnalyticsPeriod, now: number) {
+  if (period === "month_to_date") {
+    const current = new Date(now);
+    const from = Date.UTC(current.getUTCFullYear(), current.getUTCMonth(), 1, 0, 0, 0, 0);
+    return { from, to: now };
+  }
+  const days = period === "365d" ? 365 : period === "90d" ? 90 : 30;
+  return {
+    from: now - days * 24 * 60 * 60 * 1000,
+    to: now,
+  };
+}
+
+function isVisibleToAdmin(event: CanonicalEventV1) {
+  return event.visibility !== "tenant";
+}
+
+function latestOrderByApplication(orders: any[]) {
+  const grouped = new Map<string, any[]>();
+  for (const order of orders || []) {
+    const applicationId = asString(order?.applicationId, 240);
+    if (!applicationId) continue;
+    if (!grouped.has(applicationId)) grouped.set(applicationId, []);
+    grouped.get(applicationId)!.push(order);
+  }
+
+  const latest = new Map<string, any>();
+  for (const [applicationId, items] of grouped.entries()) {
+    const ordered = [...items].sort(
+      (a, b) => Number(b.updatedAt || b.createdAt || 0) - Number(a.updatedAt || a.createdAt || 0)
+    );
+    latest.set(applicationId, ordered[0]);
+  }
+  return latest;
+}
+
+function shouldDeriveScreeningReconciliation(application: any, latestOrder: any, transactionsByApplication: Set<string>) {
+  const applicationId = asString(application?.id, 240);
+  return Boolean(
+    application?.screeningMonetization ||
+      application?.screeningStatus ||
+      latestOrder ||
+      (applicationId && transactionsByApplication.has(applicationId))
+  );
+}
+
+export async function loadAdminAnalyticsSnapshot(params?: {
+  period?: string;
+  granularity?: string;
+  now?: number;
+}): Promise<AdminAnalyticsSnapshot> {
+  const now = typeof params?.now === "number" ? params.now : Date.now();
+  const period = clampPeriod(params?.period);
+  const granularity = clampGranularity(params?.granularity);
+  const { from, to } = resolveWindow(period, now);
+
+  const [
+    applicationsSnap,
+    workOrdersSnap,
+    propertiesSnap,
+    unitsSnap,
+    leasesSnap,
+    eventsSnap,
+    canonicalEventsSnap,
+    financialTransactionsSnap,
+    screeningOrdersSnap,
+  ] = await Promise.all([
+    db.collection("rentalApplications").get().catch(() => ({ docs: [] } as any)),
+    db.collection("workOrders").get().catch(() => ({ docs: [] } as any)),
+    db.collection("properties").get().catch(() => ({ docs: [] } as any)),
+    db.collection("units").get().catch(() => ({ docs: [] } as any)),
+    db.collection("leases").get().catch(() => ({ docs: [] } as any)),
+    db.collection("events").get().catch(() => ({ docs: [] } as any)),
+    db.collection(CANONICAL_EVENTS_COLLECTION).get().catch(() => ({ docs: [] } as any)),
+    db.collection("financialTransactions").get().catch(() => ({ docs: [] } as any)),
+    db.collection("screeningOrders").get().catch(() => ({ docs: [] } as any)),
+  ]);
+
+  const applications = (applicationsSnap.docs || []).map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }));
+  const workOrders = (workOrdersSnap.docs || []).map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }));
+  const properties = (propertiesSnap.docs || []).map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }));
+  const units = (unitsSnap.docs || []).map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }));
+  const leases = (leasesSnap.docs || []).map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }));
+  const events = (eventsSnap.docs || []).map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }));
+  const canonicalEvents = (canonicalEventsSnap.docs || [])
+    .map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }) as CanonicalEventV1)
+    .filter(isVisibleToAdmin);
+  const financialTransactions = (financialTransactionsSnap.docs || []).map((doc: any) => ({
+    id: doc.id,
+    ...(doc.data() || {}),
+  }));
+  const screeningOrders = (screeningOrdersSnap.docs || []).map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }));
+
+  const latestOrders = latestOrderByApplication(screeningOrders);
+  const transactionApplications = new Set<string>(
+    financialTransactions.map((tx: any) => asString(tx?.applicationId, 240)).filter(Boolean)
+  );
+  const screeningReconciliations = applications
+    .filter((application: any) =>
+      shouldDeriveScreeningReconciliation(application, latestOrders.get(asString(application?.id, 240)), transactionApplications)
+    )
+    .map((application: any) =>
+      deriveScreeningReconciliation({
+        applicationId: application.id,
+        application,
+        latestOrder: latestOrders.get(asString(application?.id, 240)) || null,
+        canonicalEvents,
+        financialTransactions,
+        now,
+      })
+    );
+
+  return deriveAdminAnalyticsSnapshot({
+    from,
+    to,
+    now,
+    period,
+    granularity,
+    applications,
+    screeningReconciliations,
+    financialTransactions,
+    workOrders,
+    properties,
+    units,
+    leases,
+    events,
+    canonicalEvents,
+  });
+}


### PR DESCRIPTION
Summary

Introduces Analytics Layer v1 as a backend-first, computed-on-read analytics foundation for RentChain, built on top of existing domain data, canonical events, and reconciliation logic.

This adds a centralized analytics service layer and a new admin-safe analytics snapshot route to expose structured, aggregate metrics across core platform domains (applications, screening, maintenance, portfolio, activity).

The implementation is fully additive, reuses existing sources of truth, and avoids introducing a parallel analytics system.

⸻

Why this matters

RentChain already captures rich operational data, but it was not previously aggregated into a reusable analytics layer.

This PR:
	•	creates a single, consistent analytics derivation layer
	•	establishes a stable contract for future dashboards and insights
	•	enables admin visibility into platform health and usage
	•	lays the groundwork for:
	•	landlord-facing analytics dashboards
	•	alerts/notification systems
	•	benchmarking
	•	forecasting
	•	agent-driven decision systems

⸻

Scope

New capabilities
	•	Central analytics derivation helpers
	•	Admin analytics snapshot service
	•	New route:
GET /api/admin/analytics/snapshot
	•	Support for period and granularity query parameters
	•	Structured analytics response model
	•	Targeted tests for derivation, service, and route layers

Metric domains included
	•	Applications funnel
	•	started, submitted, approved, declined, conversion rate
	•	Screening analytics
	•	derived via deriveScreeningReconciliation
	•	includes transaction/order-backed signals
	•	Maintenance analytics
	•	work order counts, cost aggregation, reopen signals
	•	Portfolio / leasing
	•	units, occupancy, vacancy signals
	•	Activity (safe aggregate)
	•	derived from events / canonicalEvents