### PR TITLE
feat: add landlord analytics dashboard v1

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -111,6 +111,7 @@ import adminNotificationRoutes from "./routes/adminNotificationRoutes";
 import portfolioScoreRoutes from "./routes/portfolioScoreRoutes";
 import portfolioScoreHistoryRoutes from "./routes/portfolioScoreHistoryRoutes";
 import landlordPortfolioHealthRoutes from "./routes/landlordPortfolioHealthRoutes";
+import landlordAnalyticsRoutes from "./routes/landlordAnalyticsRoutes";
 import landlordPortfolioScoreRoutes from "./routes/landlordPortfolioScoreRoutes";
 import landlordPortfolioScoreSharingRoutes from "./routes/landlordPortfolioScoreSharingRoutes";
 import publicPortfolioScoreRoutes from "./routes/publicPortfolioScoreRoutes";
@@ -258,6 +259,8 @@ app.use("/api/admin", routeSource("portfolioScoreHistoryRoutes.ts"), portfolioSc
 console.log("[route-mount] portfolioScoreHistoryRoutes mounted at /api/admin");
 app.use("/api", routeSource("landlordPortfolioHealthRoutes.ts"), landlordPortfolioHealthRoutes);
 console.log("[route-mount] landlordPortfolioHealthRoutes mounted at /api");
+app.use("/api", routeSource("landlordAnalyticsRoutes.ts"), landlordAnalyticsRoutes);
+console.log("[route-mount] landlordAnalyticsRoutes mounted at /api");
 app.use("/api", routeSource("landlordPortfolioScoreRoutes.ts"), landlordPortfolioScoreRoutes);
 console.log("[route-mount] landlordPortfolioScoreRoutes mounted at /api");
 app.use("/api", routeSource("landlordPortfolioScoreSharingRoutes.ts"), landlordPortfolioScoreSharingRoutes);

--- a/rentchain-api/src/lib/analytics/__tests__/deriveLandlordAnalyticsSnapshot.test.ts
+++ b/rentchain-api/src/lib/analytics/__tests__/deriveLandlordAnalyticsSnapshot.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import { deriveLandlordAnalyticsSnapshot } from "../deriveLandlordAnalyticsSnapshot";
+
+describe("deriveLandlordAnalyticsSnapshot", () => {
+  it("derives landlord-safe summary, revenue, and insights from shared analytics inputs", () => {
+    const now = Date.UTC(2026, 3, 20, 12, 0, 0, 0);
+    const from = now - 30 * 24 * 60 * 60 * 1000;
+    const to = now;
+
+    const result = deriveLandlordAnalyticsSnapshot({
+      now,
+      from,
+      to,
+      period: "30d",
+      granularity: "daily",
+      propertyId: null,
+      applications: [
+        {
+          id: "app-1",
+          createdAt: now - 5 * 24 * 60 * 60 * 1000,
+          submittedAt: now - 5 * 24 * 60 * 60 * 1000,
+          approvedAt: now - 2 * 24 * 60 * 60 * 1000,
+          status: "approved",
+        },
+        {
+          id: "app-2",
+          createdAt: now - 4 * 24 * 60 * 60 * 1000,
+          submittedAt: now - 4 * 24 * 60 * 60 * 1000,
+          status: "in_review",
+        },
+      ],
+      screeningReconciliations: [],
+      financialTransactions: [],
+      workOrders: [
+        {
+          id: "wo-1",
+          propertyId: "prop-1",
+          status: "open",
+          createdAt: now - 3 * 24 * 60 * 60 * 1000,
+        },
+        {
+          id: "wo-2",
+          propertyId: "prop-1",
+          status: "completed",
+          serviceCompletedAt: now - 1 * 24 * 60 * 60 * 1000,
+          cost: {
+            actualCostCents: 18000,
+            submittedAt: now - 1 * 24 * 60 * 60 * 1000,
+          },
+        },
+      ],
+      properties: [{ id: "prop-1" }, { id: "prop-2" }],
+      units: [
+        { id: "unit-1", propertyId: "prop-1", status: "vacant" },
+        { id: "unit-2", propertyId: "prop-1", status: "vacant" },
+        { id: "unit-3", propertyId: "prop-2", status: "occupied" },
+      ],
+      leases: [
+        {
+          id: "lease-1",
+          propertyId: "prop-2",
+          status: "active",
+          endDate: new Date(now + 20 * 24 * 60 * 60 * 1000).toISOString(),
+          monthlyRent: 1800,
+        },
+      ],
+      events: [],
+      canonicalEvents: [],
+    });
+
+    expect(result.summary).toEqual({
+      occupiedUnits: 1,
+      vacancyRate: 2 / 3,
+      activeApplications: 1,
+      applicationConversionRate: 0.5,
+      openWorkOrders: 1,
+      maintenanceCostCents: 18000,
+      estimatedScheduledRentCents: 180000,
+      leasesEndingSoon: 1,
+    });
+    expect(result.revenue).toEqual({
+      estimatedScheduledRentCents: 180000,
+      averageRentPerOccupiedUnitCents: 180000,
+    });
+    expect(result.properties).toEqual([
+      { id: "prop-1", name: "Untitled property" },
+      { id: "prop-2", name: "Untitled property" },
+    ]);
+    expect(result.insights).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "lease_expiry",
+          message: "1 lease ends within 30 days.",
+        }),
+        expect.objectContaining({
+          type: "vacancy_concentration",
+          propertyId: "prop-1",
+        }),
+      ])
+    );
+  });
+
+  it("returns safe empty analytics output when landlord inputs are sparse", () => {
+    const now = Date.UTC(2026, 3, 20, 12, 0, 0, 0);
+    const result = deriveLandlordAnalyticsSnapshot({
+      now,
+      from: now - 7 * 24 * 60 * 60 * 1000,
+      to: now,
+      period: "30d",
+      granularity: "daily",
+      propertyId: null,
+      applications: [],
+      screeningReconciliations: [],
+      financialTransactions: [],
+      workOrders: [],
+      properties: [],
+      units: [],
+      leases: [],
+      events: [],
+      canonicalEvents: [],
+    });
+
+    expect(result.summary).toEqual({
+      occupiedUnits: 0,
+      vacancyRate: null,
+      activeApplications: 0,
+      applicationConversionRate: null,
+      openWorkOrders: 0,
+      maintenanceCostCents: 0,
+      estimatedScheduledRentCents: 0,
+      leasesEndingSoon: 0,
+    });
+    expect(result.insights).toEqual([]);
+    expect(result.properties).toEqual([]);
+  });
+});

--- a/rentchain-api/src/lib/analytics/analyticsCore.ts
+++ b/rentchain-api/src/lib/analytics/analyticsCore.ts
@@ -1,0 +1,74 @@
+import type { AdminAnalyticsGranularity, AdminAnalyticsPeriod } from "./analyticsTypes";
+import type { CanonicalEventV1 } from "../events/eventTypes";
+
+export function asAnalyticsString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+export function clampAnalyticsPeriod(value: unknown): AdminAnalyticsPeriod {
+  const raw = asAnalyticsString(value, 40).toLowerCase();
+  if (raw === "90d") return "90d";
+  if (raw === "365d") return "365d";
+  if (raw === "month_to_date") return "month_to_date";
+  return "30d";
+}
+
+export function clampAnalyticsGranularity(value: unknown): AdminAnalyticsGranularity {
+  const raw = asAnalyticsString(value, 40).toLowerCase();
+  if (raw === "weekly") return "weekly";
+  if (raw === "monthly") return "monthly";
+  return "daily";
+}
+
+export function resolveAnalyticsWindow(period: AdminAnalyticsPeriod, now: number) {
+  if (period === "month_to_date") {
+    const current = new Date(now);
+    const from = Date.UTC(current.getUTCFullYear(), current.getUTCMonth(), 1, 0, 0, 0, 0);
+    return { from, to: now };
+  }
+
+  const days = period === "365d" ? 365 : period === "90d" ? 90 : 30;
+  return {
+    from: now - days * 24 * 60 * 60 * 1000,
+    to: now,
+  };
+}
+
+export function isAnalyticsVisibleCanonicalEvent(event: CanonicalEventV1) {
+  return event.visibility !== "tenant";
+}
+
+export function latestOrderByApplication(orders: any[]) {
+  const grouped = new Map<string, any[]>();
+  for (const order of orders || []) {
+    const applicationId = asAnalyticsString(order?.applicationId, 240);
+    if (!applicationId) continue;
+    if (!grouped.has(applicationId)) grouped.set(applicationId, []);
+    grouped.get(applicationId)!.push(order);
+  }
+
+  const latest = new Map<string, any>();
+  for (const [applicationId, items] of grouped.entries()) {
+    const ordered = [...items].sort(
+      (a, b) => Number(b.updatedAt || b.createdAt || 0) - Number(a.updatedAt || a.createdAt || 0)
+    );
+    latest.set(applicationId, ordered[0]);
+  }
+
+  return latest;
+}
+
+export function shouldDeriveScreeningReconciliation(
+  application: any,
+  latestOrder: any,
+  transactionsByApplication: Set<string>
+) {
+  const applicationId = asAnalyticsString(application?.id, 240);
+  return Boolean(
+    application?.screeningMonetization ||
+      application?.screeningStatus ||
+      latestOrder ||
+      (applicationId && transactionsByApplication.has(applicationId))
+  );
+}
+

--- a/rentchain-api/src/lib/analytics/analyticsTypes.ts
+++ b/rentchain-api/src/lib/analytics/analyticsTypes.ts
@@ -110,3 +110,50 @@ export type AdminAnalyticsDerivedInput = {
   events: any[];
   canonicalEvents: any[];
 };
+
+export type LandlordAnalyticsInsight = {
+  type:
+    | "lease_expiry"
+    | "vacancy_concentration"
+    | "maintenance_cost_increase"
+    | "applications_drop"
+    | "work_order_concentration";
+  severity: "low" | "medium" | "high";
+  message: string;
+  propertyId?: string | null;
+};
+
+export type LandlordRevenueAnalytics = {
+  estimatedScheduledRentCents: number;
+  averageRentPerOccupiedUnitCents: number | null;
+};
+
+export type LandlordAnalyticsSummary = {
+  occupiedUnits: number;
+  vacancyRate: number | null;
+  activeApplications: number;
+  applicationConversionRate: number | null;
+  openWorkOrders: number;
+  maintenanceCostCents: number;
+  estimatedScheduledRentCents: number;
+  leasesEndingSoon: number;
+};
+
+export type LandlordAnalyticsSnapshot = {
+  summary: LandlordAnalyticsSummary;
+  applications: AdminApplicationsAnalytics;
+  leasing: AdminPortfolioAnalytics;
+  maintenance: AdminMaintenanceAnalytics;
+  revenue: LandlordRevenueAnalytics;
+  insights: LandlordAnalyticsInsight[];
+  properties: Array<{
+    id: string;
+    name: string;
+  }>;
+  filters: {
+    period: AdminAnalyticsPeriod;
+    propertyId: string | null;
+    from: string;
+    to: string;
+  };
+};

--- a/rentchain-api/src/lib/analytics/deriveLandlordAnalyticsSnapshot.ts
+++ b/rentchain-api/src/lib/analytics/deriveLandlordAnalyticsSnapshot.ts
@@ -1,0 +1,229 @@
+import { deriveAdminAnalyticsSnapshot } from "./deriveAdminAnalyticsSnapshot";
+import type {
+  AdminAnalyticsDerivedInput,
+  AdminAnalyticsSnapshot,
+  LandlordAnalyticsInsight,
+  LandlordAnalyticsSnapshot,
+} from "./analyticsTypes";
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function toMillis(value: unknown): number | null {
+  if (value == null || value === "") return null;
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  if (typeof (value as any)?.toMillis === "function") return (value as any).toMillis();
+  if (typeof (value as any)?.seconds === "number") return (value as any).seconds * 1000;
+  return null;
+}
+
+function isOccupiedUnit(unit: any) {
+  const status = asString(unit?.status, 80).toLowerCase();
+  if (status === "occupied" || status === "leased") return true;
+  if (status === "vacant" || status === "available") return false;
+  return Boolean(asString(unit?.tenantName, 120) || asString(unit?.tenantId, 120));
+}
+
+function isActiveLease(lease: any, now: number) {
+  const status = asString(lease?.status, 80).toLowerCase();
+  if (status === "active" || status === "current") return true;
+  const startAt = toMillis(lease?.leaseStartDate) || toMillis(lease?.startDate) || toMillis(lease?.leaseStart);
+  const endAt =
+    toMillis(lease?.leaseEndDate) || toMillis(lease?.endDate) || toMillis(lease?.leaseEnd) || toMillis(lease?.moveOutDate);
+  if (startAt != null && startAt > now) return false;
+  if (endAt != null && endAt < now) return false;
+  return startAt != null || endAt != null;
+}
+
+function numberOrNull(...values: unknown[]) {
+  for (const value of values) {
+    if (typeof value === "number" && Number.isFinite(value) && value > 0) return value;
+  }
+  return null;
+}
+
+function monthlyRentCentsFromLease(lease: any): number | null {
+  const rentCents = numberOrNull(lease?.baseRentCents, lease?.monthlyRentCents, lease?.rentCents, lease?.scheduledRentCents);
+  if (rentCents != null) return Math.round(rentCents);
+
+  const rentDollars = numberOrNull(lease?.monthlyRent, lease?.currentRent, lease?.rent, lease?.scheduledRent);
+  return rentDollars != null ? Math.round(rentDollars * 100) : null;
+}
+
+function buildPreviousInput(input: AdminAnalyticsDerivedInput): AdminAnalyticsDerivedInput {
+  const duration = Math.max(1, input.to - input.from);
+  const previousTo = input.from - 1;
+  const previousFrom = previousTo - duration;
+  return {
+    ...input,
+    from: previousFrom,
+    to: previousTo,
+  };
+}
+
+function vacancyByProperty(units: any[]) {
+  const counts = new Map<string, number>();
+  for (const unit of units || []) {
+    if (isOccupiedUnit(unit)) continue;
+    const propertyId = asString(unit?.propertyId, 120);
+    if (!propertyId) continue;
+    counts.set(propertyId, (counts.get(propertyId) || 0) + 1);
+  }
+  return Array.from(counts.entries())
+    .map(([propertyId, vacantUnits]) => ({ propertyId, vacantUnits }))
+    .sort((a, b) => {
+      if (b.vacantUnits !== a.vacantUnits) return b.vacantUnits - a.vacantUnits;
+      return a.propertyId.localeCompare(b.propertyId);
+    });
+}
+
+function openWorkOrdersByProperty(workOrders: any[]) {
+  const activeStatuses = new Set(["open", "invited", "assigned", "accepted", "scheduled", "blocked", "in_progress"]);
+  const counts = new Map<string, number>();
+  for (const workOrder of workOrders || []) {
+    const status = asString(workOrder?.status, 80).toLowerCase();
+    if (!activeStatuses.has(status)) continue;
+    const propertyId = asString(workOrder?.propertyId, 120);
+    if (!propertyId) continue;
+    counts.set(propertyId, (counts.get(propertyId) || 0) + 1);
+  }
+  return Array.from(counts.entries())
+    .map(([propertyId, openWorkOrders]) => ({ propertyId, openWorkOrders }))
+    .sort((a, b) => {
+      if (b.openWorkOrders !== a.openWorkOrders) return b.openWorkOrders - a.openWorkOrders;
+      return a.propertyId.localeCompare(b.propertyId);
+    });
+}
+
+function deriveInsights(params: {
+  current: AdminAnalyticsSnapshot;
+  previous: AdminAnalyticsSnapshot;
+  units: any[];
+  workOrders: any[];
+}) {
+  const insights: LandlordAnalyticsInsight[] = [];
+  const { current, previous, units, workOrders } = params;
+
+  if (current.portfolio.leasesEndingIn30Days > 0) {
+    insights.push({
+      type: "lease_expiry",
+      severity: current.portfolio.leasesEndingIn30Days >= 3 ? "high" : "medium",
+      message:
+        current.portfolio.leasesEndingIn30Days === 1
+          ? "1 lease ends within 30 days."
+          : `${current.portfolio.leasesEndingIn30Days} leases end within 30 days.`,
+    });
+  }
+
+  if (current.portfolio.vacantUnits > 1) {
+    const [topVacancy] = vacancyByProperty(units);
+    if (topVacancy && topVacancy.vacantUnits >= Math.max(2, Math.ceil(current.portfolio.vacantUnits / 2))) {
+      insights.push({
+        type: "vacancy_concentration",
+        severity: topVacancy.vacantUnits >= 3 ? "high" : "medium",
+        propertyId: topVacancy.propertyId,
+        message: `Vacancy is concentrated in one property with ${topVacancy.vacantUnits} vacant units.`,
+      });
+    }
+  }
+
+  if (
+    current.maintenance.maintenanceCostCents > 0 &&
+    previous.maintenance.maintenanceCostCents > 0 &&
+    current.maintenance.maintenanceCostCents > previous.maintenance.maintenanceCostCents * 1.25
+  ) {
+    insights.push({
+      type: "maintenance_cost_increase",
+      severity: "medium",
+      message: "Maintenance costs increased compared with the previous period.",
+    });
+  }
+
+  if (
+    previous.applications.submitted > 0 &&
+    current.applications.submitted < previous.applications.submitted
+  ) {
+    insights.push({
+      type: "applications_drop",
+      severity: "low",
+      message: "Applications dropped compared with the previous period.",
+    });
+  }
+
+  if (current.maintenance.openWorkOrders > 1) {
+    const [topProperty] = openWorkOrdersByProperty(workOrders);
+    if (topProperty && topProperty.openWorkOrders >= Math.max(2, Math.ceil(current.maintenance.openWorkOrders / 2))) {
+      insights.push({
+        type: "work_order_concentration",
+        severity: topProperty.openWorkOrders >= 4 ? "high" : "medium",
+        propertyId: topProperty.propertyId,
+        message: `Most open work orders are tied to one property (${topProperty.openWorkOrders}).`,
+      });
+    }
+  }
+
+  return insights.slice(0, 4);
+}
+
+export function deriveLandlordAnalyticsSnapshot(input: AdminAnalyticsDerivedInput & { propertyId?: string | null }): LandlordAnalyticsSnapshot {
+  const current = deriveAdminAnalyticsSnapshot(input);
+  const previous = deriveAdminAnalyticsSnapshot(buildPreviousInput(input));
+
+  let estimatedScheduledRentCents = 0;
+  let occupiedUnitsWithRent = 0;
+  for (const lease of input.leases || []) {
+    if (!isActiveLease(lease, input.now)) continue;
+    const rentCents = monthlyRentCentsFromLease(lease);
+    if (rentCents == null || rentCents <= 0) continue;
+    estimatedScheduledRentCents += rentCents;
+    occupiedUnitsWithRent += 1;
+  }
+
+  const activeApplications = current.applications.pendingReviewCount;
+  const leasesEndingSoon = current.portfolio.leasesEndingIn30Days;
+
+  return {
+    summary: {
+      occupiedUnits: current.portfolio.occupiedUnits,
+      vacancyRate: current.summary.vacancyRate,
+      activeApplications,
+      applicationConversionRate: current.applications.conversionRate,
+      openWorkOrders: current.maintenance.openWorkOrders,
+      maintenanceCostCents: current.maintenance.maintenanceCostCents,
+      estimatedScheduledRentCents,
+      leasesEndingSoon,
+    },
+    applications: current.applications,
+    leasing: current.portfolio,
+    maintenance: current.maintenance,
+    revenue: {
+      estimatedScheduledRentCents,
+      averageRentPerOccupiedUnitCents:
+        occupiedUnitsWithRent > 0 ? Math.round(estimatedScheduledRentCents / occupiedUnitsWithRent) : null,
+    },
+    insights: deriveInsights({
+      current,
+      previous,
+      units: input.units,
+      workOrders: input.workOrders,
+    }),
+    properties: (input.properties || [])
+      .map((property: any) => ({
+        id: asString(property?.id, 240),
+        name: asString(property?.name || property?.address || property?.title, 240) || "Untitled property",
+      }))
+      .filter((property) => property.id)
+      .sort((a, b) => a.name.localeCompare(b.name)),
+    filters: {
+      period: input.period,
+      propertyId: input.propertyId ? asString(input.propertyId, 240) : null,
+      from: new Date(input.from).toISOString(),
+      to: new Date(input.to).toISOString(),
+    },
+  };
+}

--- a/rentchain-api/src/routes/__tests__/landlordAnalyticsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordAnalyticsRoutes.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const loadLandlordAnalyticsSnapshot = vi.fn();
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!req.user) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    return next();
+  },
+}));
+
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: any, res: any, next: any) => {
+    const role = String(req.user?.role || "").trim().toLowerCase();
+    const landlordId = req.user?.landlordId || req.user?.id;
+    if (role !== "landlord" && role !== "admin") {
+      return res.status(403).json({ ok: false, error: "Forbidden" });
+    }
+    if (!landlordId) {
+      return res.status(401).json({ ok: false, error: "Missing landlord context" });
+    }
+    req.user.landlordId = landlordId;
+    return next();
+  },
+}));
+
+vi.mock("../../services/landlord/landlordAnalyticsSnapshot", () => ({
+  loadLandlordAnalyticsSnapshot,
+}));
+
+async function invokeRouter(
+  router: any,
+  options: { method: string; url: string; user?: Record<string, unknown> | null }
+) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    const query = new URLSearchParams(queryString || "");
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: options.user ?? null,
+      query: Object.fromEntries(query.entries()),
+      params: {},
+      headers: {},
+      get(name: string) {
+        return this.headers[String(name).toLowerCase()];
+      },
+      header(name: string) {
+        return this.get(name);
+      },
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, string>,
+      setHeader(name: string, value: string) {
+        this.headers[name.toLowerCase()] = value;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("landlordAnalyticsRoutes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadLandlordAnalyticsSnapshot.mockResolvedValue({
+      summary: {
+        occupiedUnits: 4,
+        vacancyRate: 0.2,
+        activeApplications: 2,
+        applicationConversionRate: 0.25,
+        openWorkOrders: 1,
+        maintenanceCostCents: 8200,
+        estimatedScheduledRentCents: 660000,
+        leasesEndingSoon: 1,
+      },
+      applications: {
+        started: 3,
+        submitted: 2,
+        approved: 1,
+        rejected: 0,
+        declined: 0,
+        pendingReviewCount: 2,
+        conversionRate: 0.5,
+      },
+      leasing: {
+        totalProperties: 2,
+        totalUnits: 5,
+        occupiedUnits: 4,
+        vacantUnits: 1,
+        occupancyRate: 0.8,
+        leasesEndingIn30Days: 1,
+        leasesEndingIn60Days: 1,
+        leasesEndingIn90Days: 1,
+        turnoverCount: 0,
+      },
+      maintenance: {
+        openWorkOrders: 1,
+        completedWorkOrders: 1,
+        reopenedWorkOrders: 0,
+        maintenanceCostCents: 8200,
+        averageCostPerCompletedWorkOrderCents: 8200,
+        costConcentrationByProperty: [],
+      },
+      revenue: {
+        estimatedScheduledRentCents: 660000,
+        averageRentPerOccupiedUnitCents: 165000,
+      },
+      insights: [],
+      properties: [{ id: "prop-123", name: "Alpha" }],
+      filters: {
+        period: "90d",
+        propertyId: null,
+        from: "2026-01-20T00:00:00.000Z",
+        to: "2026-04-20T00:00:00.000Z",
+      },
+    });
+  });
+
+  it("returns landlord-scoped analytics without allowing scope override", async () => {
+    const router = (await import("../landlordAnalyticsRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/analytics?period=90d&propertyId=prop-123&landlordId=other-landlord",
+      user: { id: "landlord-1", role: "landlord" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(loadLandlordAnalyticsSnapshot).toHaveBeenCalledWith({
+      landlordId: "landlord-1",
+      period: "90d",
+      propertyId: "prop-123",
+    });
+    expect(response.body.ok).toBe(true);
+    expect(response.body.summary.occupiedUnits).toBe(4);
+  });
+
+  it("enforces landlord authentication", async () => {
+    const router = (await import("../landlordAnalyticsRoutes")).default;
+
+    const forbidden = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/analytics",
+      user: { id: "tenant-1", role: "tenant" },
+    });
+    expect(forbidden.status).toBe(403);
+
+    const unauthorized = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/analytics",
+      user: null,
+    });
+    expect(unauthorized.status).toBe(401);
+  });
+});

--- a/rentchain-api/src/routes/landlordAnalyticsRoutes.ts
+++ b/rentchain-api/src/routes/landlordAnalyticsRoutes.ts
@@ -1,0 +1,32 @@
+import { Router } from "express";
+import { requireAuth } from "../middleware/requireAuth";
+import { requireLandlord } from "../middleware/requireLandlord";
+import { loadLandlordAnalyticsSnapshot } from "../services/landlord/landlordAnalyticsSnapshot";
+
+const router = Router();
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+router.get("/landlord/analytics", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = asString(req.user?.landlordId || req.user?.id, 240);
+    if (!landlordId) {
+      return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    }
+
+    const snapshot = await loadLandlordAnalyticsSnapshot({
+      landlordId,
+      period: req.query?.period,
+      propertyId: req.query?.propertyId,
+    });
+
+    return res.json({ ok: true, ...snapshot });
+  } catch (err: any) {
+    console.error("[landlord-analytics] fetch failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "LANDLORD_ANALYTICS_FETCH_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-api/src/services/admin/adminAnalyticsSnapshot.ts
+++ b/rentchain-api/src/services/admin/adminAnalyticsSnapshot.ts
@@ -2,77 +2,19 @@ import { db } from "../../config/firebase";
 import { CANONICAL_EVENTS_COLLECTION } from "../../lib/events/buildEvent";
 import type { CanonicalEventV1 } from "../../lib/events/eventTypes";
 import { deriveAdminAnalyticsSnapshot } from "../../lib/analytics/deriveAdminAnalyticsSnapshot";
+import {
+  asAnalyticsString,
+  clampAnalyticsGranularity,
+  clampAnalyticsPeriod,
+  isAnalyticsVisibleCanonicalEvent,
+  latestOrderByApplication,
+  resolveAnalyticsWindow,
+  shouldDeriveScreeningReconciliation,
+} from "../../lib/analytics/analyticsCore";
 import type {
-  AdminAnalyticsGranularity,
-  AdminAnalyticsPeriod,
   AdminAnalyticsSnapshot,
 } from "../../lib/analytics/analyticsTypes";
 import { deriveScreeningReconciliation } from "../../lib/reconciliation/deriveScreeningReconciliation";
-
-function asString(value: unknown, max = 240) {
-  return String(value || "").trim().slice(0, max);
-}
-
-function clampPeriod(value: unknown): AdminAnalyticsPeriod {
-  const raw = asString(value, 40).toLowerCase();
-  if (raw === "90d") return "90d";
-  if (raw === "365d") return "365d";
-  if (raw === "month_to_date") return "month_to_date";
-  return "30d";
-}
-
-function clampGranularity(value: unknown): AdminAnalyticsGranularity {
-  const raw = asString(value, 40).toLowerCase();
-  if (raw === "weekly") return "weekly";
-  if (raw === "monthly") return "monthly";
-  return "daily";
-}
-
-function resolveWindow(period: AdminAnalyticsPeriod, now: number) {
-  if (period === "month_to_date") {
-    const current = new Date(now);
-    const from = Date.UTC(current.getUTCFullYear(), current.getUTCMonth(), 1, 0, 0, 0, 0);
-    return { from, to: now };
-  }
-  const days = period === "365d" ? 365 : period === "90d" ? 90 : 30;
-  return {
-    from: now - days * 24 * 60 * 60 * 1000,
-    to: now,
-  };
-}
-
-function isVisibleToAdmin(event: CanonicalEventV1) {
-  return event.visibility !== "tenant";
-}
-
-function latestOrderByApplication(orders: any[]) {
-  const grouped = new Map<string, any[]>();
-  for (const order of orders || []) {
-    const applicationId = asString(order?.applicationId, 240);
-    if (!applicationId) continue;
-    if (!grouped.has(applicationId)) grouped.set(applicationId, []);
-    grouped.get(applicationId)!.push(order);
-  }
-
-  const latest = new Map<string, any>();
-  for (const [applicationId, items] of grouped.entries()) {
-    const ordered = [...items].sort(
-      (a, b) => Number(b.updatedAt || b.createdAt || 0) - Number(a.updatedAt || a.createdAt || 0)
-    );
-    latest.set(applicationId, ordered[0]);
-  }
-  return latest;
-}
-
-function shouldDeriveScreeningReconciliation(application: any, latestOrder: any, transactionsByApplication: Set<string>) {
-  const applicationId = asString(application?.id, 240);
-  return Boolean(
-    application?.screeningMonetization ||
-      application?.screeningStatus ||
-      latestOrder ||
-      (applicationId && transactionsByApplication.has(applicationId))
-  );
-}
 
 export async function loadAdminAnalyticsSnapshot(params?: {
   period?: string;
@@ -80,9 +22,9 @@ export async function loadAdminAnalyticsSnapshot(params?: {
   now?: number;
 }): Promise<AdminAnalyticsSnapshot> {
   const now = typeof params?.now === "number" ? params.now : Date.now();
-  const period = clampPeriod(params?.period);
-  const granularity = clampGranularity(params?.granularity);
-  const { from, to } = resolveWindow(period, now);
+  const period = clampAnalyticsPeriod(params?.period);
+  const granularity = clampAnalyticsGranularity(params?.granularity);
+  const { from, to } = resolveAnalyticsWindow(period, now);
 
   const [
     applicationsSnap,
@@ -114,7 +56,7 @@ export async function loadAdminAnalyticsSnapshot(params?: {
   const events = (eventsSnap.docs || []).map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }));
   const canonicalEvents = (canonicalEventsSnap.docs || [])
     .map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }) as CanonicalEventV1)
-    .filter(isVisibleToAdmin);
+    .filter(isAnalyticsVisibleCanonicalEvent);
   const financialTransactions = (financialTransactionsSnap.docs || []).map((doc: any) => ({
     id: doc.id,
     ...(doc.data() || {}),
@@ -123,17 +65,21 @@ export async function loadAdminAnalyticsSnapshot(params?: {
 
   const latestOrders = latestOrderByApplication(screeningOrders);
   const transactionApplications = new Set<string>(
-    financialTransactions.map((tx: any) => asString(tx?.applicationId, 240)).filter(Boolean)
+    financialTransactions.map((tx: any) => asAnalyticsString(tx?.applicationId, 240)).filter(Boolean)
   );
   const screeningReconciliations = applications
     .filter((application: any) =>
-      shouldDeriveScreeningReconciliation(application, latestOrders.get(asString(application?.id, 240)), transactionApplications)
+      shouldDeriveScreeningReconciliation(
+        application,
+        latestOrders.get(asAnalyticsString(application?.id, 240)),
+        transactionApplications
+      )
     )
     .map((application: any) =>
       deriveScreeningReconciliation({
         applicationId: application.id,
         application,
-        latestOrder: latestOrders.get(asString(application?.id, 240)) || null,
+        latestOrder: latestOrders.get(asAnalyticsString(application?.id, 240)) || null,
         canonicalEvents,
         financialTransactions,
         now,

--- a/rentchain-api/src/services/landlord/__tests__/landlordAnalyticsSnapshot.test.ts
+++ b/rentchain-api/src/services/landlord/__tests__/landlordAnalyticsSnapshot.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type StoredDoc = { id: string; data: any };
+
+const { dbMock, resetDb, seedDoc } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, StoredDoc>>();
+
+  function ensureCollection(name: string) {
+    if (!collections.has(name)) collections.set(name, new Map());
+    return collections.get(name)!;
+  }
+
+  return {
+    dbMock: {
+      collection: (name: string) => ({
+        get: async () => {
+          const docs = Array.from(ensureCollection(name).values()).map((entry) => ({
+            id: entry.id,
+            data: () => entry.data,
+          }));
+          return { docs, empty: docs.length === 0, size: docs.length };
+        },
+      }),
+    },
+    resetDb: () => {
+      collections.clear();
+    },
+    seedDoc: (collection: string, id: string, data: any) => {
+      ensureCollection(collection).set(id, { id, data });
+    },
+  };
+});
+
+vi.mock("../../../config/firebase", () => ({
+  db: dbMock,
+}));
+
+describe("loadLandlordAnalyticsSnapshot", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    resetDb();
+  });
+
+  it("returns only landlord-scoped analytics and respects property filters", async () => {
+    const now = Date.UTC(2026, 3, 20, 12, 0, 0, 0);
+
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Alpha" });
+    seedDoc("properties", "prop-2", { landlordId: "landlord-1", name: "Beta" });
+    seedDoc("properties", "prop-3", { landlordId: "landlord-2", name: "Gamma" });
+
+    seedDoc("units", "unit-1", { landlordId: "landlord-1", propertyId: "prop-1", status: "occupied" });
+    seedDoc("units", "unit-2", { landlordId: "landlord-1", propertyId: "prop-2", status: "vacant" });
+    seedDoc("units", "unit-3", { landlordId: "landlord-2", propertyId: "prop-3", status: "occupied" });
+
+    seedDoc("leases", "lease-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      status: "active",
+      endDate: new Date(now + 25 * 24 * 60 * 60 * 1000).toISOString(),
+      monthlyRent: 1650,
+    });
+
+    seedDoc("rentalApplications", "app-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      createdAt: now - 3 * 24 * 60 * 60 * 1000,
+      submittedAt: now - 3 * 24 * 60 * 60 * 1000,
+      status: "in_review",
+    });
+    seedDoc("rentalApplications", "app-2", {
+      landlordId: "landlord-2",
+      propertyId: "prop-3",
+      createdAt: now - 3 * 24 * 60 * 60 * 1000,
+      submittedAt: now - 3 * 24 * 60 * 60 * 1000,
+      status: "approved",
+      approvedAt: now - 2 * 24 * 60 * 60 * 1000,
+    });
+
+    seedDoc("workOrders", "wo-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-2",
+      status: "completed",
+      serviceCompletedAt: now - 1 * 24 * 60 * 60 * 1000,
+      cost: { actualCostCents: 8200, submittedAt: now - 1 * 24 * 60 * 60 * 1000 },
+    });
+    seedDoc("workOrders", "wo-2", {
+      landlordId: "landlord-2",
+      propertyId: "prop-3",
+      status: "open",
+      createdAt: now - 1 * 24 * 60 * 60 * 1000,
+    });
+
+    const { loadLandlordAnalyticsSnapshot } = await import("../landlordAnalyticsSnapshot");
+
+    const scoped = await loadLandlordAnalyticsSnapshot({
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      period: "90d",
+      now,
+    });
+
+    expect(scoped.filters.propertyId).toBe("prop-1");
+    expect(scoped.leasing.totalProperties).toBe(1);
+    expect(scoped.leasing.totalUnits).toBe(1);
+    expect(scoped.summary.occupiedUnits).toBe(1);
+    expect(scoped.summary.maintenanceCostCents).toBe(0);
+    expect(scoped.summary.estimatedScheduledRentCents).toBe(165000);
+    expect(scoped.summary.activeApplications).toBe(1);
+  });
+
+  it("returns a stable empty payload when a landlord has no analytics data", async () => {
+    const now = Date.UTC(2026, 3, 20, 12, 0, 0, 0);
+    const { loadLandlordAnalyticsSnapshot } = await import("../landlordAnalyticsSnapshot");
+    const result = await loadLandlordAnalyticsSnapshot({
+      landlordId: "landlord-1",
+      now,
+    });
+
+    expect(result.summary.occupiedUnits).toBe(0);
+    expect(result.summary.maintenanceCostCents).toBe(0);
+    expect(result.insights).toEqual([]);
+  });
+});

--- a/rentchain-api/src/services/landlord/landlordAnalyticsSnapshot.ts
+++ b/rentchain-api/src/services/landlord/landlordAnalyticsSnapshot.ts
@@ -1,0 +1,256 @@
+import { db } from "../../config/firebase";
+import { CANONICAL_EVENTS_COLLECTION } from "../../lib/events/buildEvent";
+import type { CanonicalEventV1 } from "../../lib/events/eventTypes";
+import {
+  asAnalyticsString,
+  clampAnalyticsPeriod,
+  isAnalyticsVisibleCanonicalEvent,
+  latestOrderByApplication,
+  resolveAnalyticsWindow,
+  shouldDeriveScreeningReconciliation,
+} from "../../lib/analytics/analyticsCore";
+import type { AdminAnalyticsDerivedInput, LandlordAnalyticsSnapshot } from "../../lib/analytics/analyticsTypes";
+import { deriveLandlordAnalyticsSnapshot } from "../../lib/analytics/deriveLandlordAnalyticsSnapshot";
+import { deriveScreeningReconciliation } from "../../lib/reconciliation/deriveScreeningReconciliation";
+
+type LandlordAnalyticsParams = {
+  landlordId: string;
+  period?: string;
+  propertyId?: string;
+  now?: number;
+};
+
+function hasLandlordScope(doc: any, landlordId: string) {
+  return [doc?.landlordId, doc?.ownerId, doc?.userId].some((value) => asAnalyticsString(value, 240) === landlordId);
+}
+
+function docPropertyId(doc: any) {
+  return asAnalyticsString(doc?.propertyId || doc?.property?.id, 240);
+}
+
+function docApplicationId(doc: any) {
+  return asAnalyticsString(doc?.applicationId, 240);
+}
+
+function matchesPropertyScope(doc: any, propertyIds: Set<string>) {
+  const propertyId = docPropertyId(doc);
+  return propertyId ? propertyIds.has(propertyId) : false;
+}
+
+function matchesScopedDoc(doc: any, landlordId: string, propertyIds: Set<string>, propertyFilterActive: boolean) {
+  if (propertyFilterActive) return matchesPropertyScope(doc, propertyIds);
+  return hasLandlordScope(doc, landlordId) || matchesPropertyScope(doc, propertyIds);
+}
+
+function isCanonicalEventScoped(params: {
+  event: CanonicalEventV1;
+  landlordId: string;
+  propertyIds: Set<string>;
+  applicationIds: Set<string>;
+  leaseIds: Set<string>;
+  workOrderIds: Set<string>;
+}) {
+  const { event, landlordId, propertyIds, applicationIds, leaseIds, workOrderIds } = params;
+  if (asAnalyticsString((event as any)?.landlordId, 240) === landlordId) return true;
+  if (propertyIds.has(asAnalyticsString((event as any)?.propertyId, 240))) return true;
+  if (propertyIds.has(asAnalyticsString(event.metadata?.propertyId, 240))) return true;
+  if (propertyIds.has(asAnalyticsString(event.resource?.id, 240)) && asAnalyticsString(event.resource?.type, 80) === "property") {
+    return true;
+  }
+  if (applicationIds.has(asAnalyticsString(event.metadata?.applicationId, 240))) return true;
+  if (applicationIds.has(asAnalyticsString(event.resource?.id, 240)) && asAnalyticsString(event.resource?.type, 80) === "rental_application") {
+    return true;
+  }
+  if (leaseIds.has(asAnalyticsString(event.metadata?.leaseId, 240))) return true;
+  if (leaseIds.has(asAnalyticsString(event.resource?.id, 240)) && asAnalyticsString(event.resource?.type, 80) === "lease") {
+    return true;
+  }
+  if (workOrderIds.has(asAnalyticsString(event.metadata?.maintenanceRequestId, 240))) return true;
+  if (workOrderIds.has(asAnalyticsString(event.metadata?.workOrderId, 240))) return true;
+  if (
+    workOrderIds.has(asAnalyticsString(event.resource?.id, 240)) &&
+    ["maintenance_request", "work_order"].includes(asAnalyticsString(event.resource?.type, 80))
+  ) {
+    return true;
+  }
+  return false;
+}
+
+async function loadCollection(name: string) {
+  return await db.collection(name).get().catch(() => ({ docs: [] } as any));
+}
+
+function buildDerivedInput(params: {
+  landlordId: string;
+  propertyId?: string;
+  now: number;
+  period: ReturnType<typeof clampAnalyticsPeriod>;
+  from: number;
+  to: number;
+  applicationsRaw: any[];
+  workOrdersRaw: any[];
+  propertiesRaw: any[];
+  unitsRaw: any[];
+  leasesRaw: any[];
+  eventsRaw: any[];
+  canonicalEventsRaw: CanonicalEventV1[];
+  financialTransactionsRaw: any[];
+  screeningOrdersRaw: any[];
+}): AdminAnalyticsDerivedInput & { propertyId?: string | null } {
+  const scopedProperties = params.propertiesRaw.filter((doc) => hasLandlordScope(doc, params.landlordId));
+  const initialPropertyIds = new Set(scopedProperties.map((doc) => asAnalyticsString(doc?.id, 240)).filter(Boolean));
+  const propertyIdFilter = asAnalyticsString(params.propertyId, 240);
+  const propertyFilterActive = Boolean(propertyIdFilter);
+  const propertyIds = propertyIdFilter
+    ? new Set(Array.from(initialPropertyIds).filter((id) => id === propertyIdFilter))
+    : initialPropertyIds;
+  const properties = scopedProperties.filter((doc) => propertyIds.has(asAnalyticsString(doc?.id, 240)));
+
+  const applications = params.applicationsRaw.filter((doc) =>
+    matchesScopedDoc(doc, params.landlordId, propertyIds, propertyFilterActive)
+  );
+  const applicationIds = new Set(applications.map((doc) => asAnalyticsString(doc?.id, 240)).filter(Boolean));
+
+  const workOrders = params.workOrdersRaw.filter((doc) =>
+    matchesScopedDoc(doc, params.landlordId, propertyIds, propertyFilterActive)
+  );
+  const workOrderIds = new Set(workOrders.map((doc) => asAnalyticsString(doc?.id, 240)).filter(Boolean));
+
+  const units = params.unitsRaw.filter((doc) => matchesScopedDoc(doc, params.landlordId, propertyIds, propertyFilterActive));
+  const leases = params.leasesRaw.filter((doc) => matchesScopedDoc(doc, params.landlordId, propertyIds, propertyFilterActive));
+  const leaseIds = new Set(leases.map((doc) => asAnalyticsString(doc?.id, 240)).filter(Boolean));
+
+  const events = params.eventsRaw.filter((doc) => {
+    if (!propertyFilterActive && hasLandlordScope(doc, params.landlordId)) return true;
+    if (matchesPropertyScope(doc, propertyIds)) return true;
+    if (applicationIds.has(docApplicationId(doc))) return true;
+    if (leaseIds.has(asAnalyticsString(doc?.leaseId, 240))) return true;
+    return false;
+  });
+
+  const canonicalEvents = params.canonicalEventsRaw.filter((event) =>
+    isCanonicalEventScoped({
+      event,
+      landlordId: params.landlordId,
+      propertyIds,
+      applicationIds,
+      leaseIds,
+      workOrderIds,
+    })
+  );
+
+  const financialTransactions = params.financialTransactionsRaw.filter(
+    (doc) => (!propertyFilterActive && hasLandlordScope(doc, params.landlordId)) || applicationIds.has(docApplicationId(doc))
+  );
+  const screeningOrders = params.screeningOrdersRaw.filter(
+    (doc) => (!propertyFilterActive && hasLandlordScope(doc, params.landlordId)) || applicationIds.has(docApplicationId(doc))
+  );
+
+  const latestOrders = latestOrderByApplication(screeningOrders);
+  const transactionApplications = new Set<string>(
+    financialTransactions.map((tx: any) => asAnalyticsString(tx?.applicationId, 240)).filter(Boolean)
+  );
+  const screeningReconciliations = applications
+    .filter((application: any) =>
+      shouldDeriveScreeningReconciliation(
+        application,
+        latestOrders.get(asAnalyticsString(application?.id, 240)),
+        transactionApplications
+      )
+    )
+    .map((application: any) =>
+      deriveScreeningReconciliation({
+        applicationId: application.id,
+        application,
+        latestOrder: latestOrders.get(asAnalyticsString(application?.id, 240)) || null,
+        canonicalEvents,
+        financialTransactions,
+        now: params.now,
+      })
+    )
+    .map((reconciliation: any) => ({
+      status: reconciliation.status,
+      summary: {
+        hasQuote: Boolean(reconciliation?.summary?.hasQuote),
+        hasCheckout: Boolean(reconciliation?.summary?.hasCheckout),
+        hasPaidEvent: Boolean(reconciliation?.summary?.hasPaidEvent),
+        hasFulfillment: Boolean(reconciliation?.summary?.hasFulfillment),
+        lastMeaningfulEventAt:
+          typeof reconciliation?.summary?.lastMeaningfulEventAt === "string"
+            ? reconciliation.summary.lastMeaningfulEventAt
+            : null,
+      },
+    }));
+
+  return {
+    now: params.now,
+    from: params.from,
+    to: params.to,
+    period: params.period,
+    granularity: "daily",
+    propertyId: propertyIdFilter || null,
+    applications,
+    screeningReconciliations,
+    financialTransactions,
+    workOrders,
+    properties,
+    units,
+    leases,
+    events,
+    canonicalEvents,
+  };
+}
+
+export async function loadLandlordAnalyticsSnapshot(params: LandlordAnalyticsParams): Promise<LandlordAnalyticsSnapshot> {
+  const landlordId = asAnalyticsString(params.landlordId, 240);
+  const now = typeof params.now === "number" ? params.now : Date.now();
+  const period = clampAnalyticsPeriod(params.period);
+  const { from, to } = resolveAnalyticsWindow(period, now);
+
+  const [
+    applicationsSnap,
+    workOrdersSnap,
+    propertiesSnap,
+    unitsSnap,
+    leasesSnap,
+    eventsSnap,
+    canonicalEventsSnap,
+    financialTransactionsSnap,
+    screeningOrdersSnap,
+  ] = await Promise.all([
+    loadCollection("rentalApplications"),
+    loadCollection("workOrders"),
+    loadCollection("properties"),
+    loadCollection("units"),
+    loadCollection("leases"),
+    loadCollection("events"),
+    loadCollection(CANONICAL_EVENTS_COLLECTION),
+    loadCollection("financialTransactions"),
+    loadCollection("screeningOrders"),
+  ]);
+
+  const derivedInput = buildDerivedInput({
+    landlordId,
+    propertyId: params.propertyId,
+    now,
+    period,
+    from,
+    to,
+    applicationsRaw: (applicationsSnap.docs || []).map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) })),
+    workOrdersRaw: (workOrdersSnap.docs || []).map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) })),
+    propertiesRaw: (propertiesSnap.docs || []).map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) })),
+    unitsRaw: (unitsSnap.docs || []).map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) })),
+    leasesRaw: (leasesSnap.docs || []).map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) })),
+    eventsRaw: (eventsSnap.docs || []).map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) })),
+    canonicalEventsRaw: (canonicalEventsSnap.docs || [])
+      .map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }) as CanonicalEventV1)
+      .filter(isAnalyticsVisibleCanonicalEvent),
+    financialTransactionsRaw: (financialTransactionsSnap.docs || []).map((doc: any) => ({
+      id: doc.id,
+      ...(doc.data() || {}),
+    })),
+    screeningOrdersRaw: (screeningOrdersSnap.docs || []).map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) })),
+  });
+
+  return deriveLandlordAnalyticsSnapshot(derivedInput);
+}

--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -86,6 +86,10 @@ vi.mock("./pages/landlord/PortfolioHealthSummaryPage", () => ({
   default: () => <h1>Portfolio Health Summary</h1>,
 }));
 
+vi.mock("./pages/landlord/LandlordAnalyticsPage", () => ({
+  default: () => <h1>Landlord Analytics Dashboard</h1>,
+}));
+
 vi.mock("./pages/landlord/PortfolioScorePage", () => ({
   default: () => <h1>Landlord Portfolio Score</h1>,
 }));
@@ -193,6 +197,20 @@ describe("Routes: /automation/timeline", () => {
     );
 
     expect(await screen.findByText(/Automation Timeline/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Routes: /analytics", () => {
+  it("renders the landlord analytics dashboard route", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/analytics"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Landlord Analytics Dashboard/i)).toBeInTheDocument();
     expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -160,6 +160,7 @@ const AdminNotificationsPage = lazy(() => import("./pages/admin/AdminNotificatio
 const PortfolioScorePage = lazy(() => import("./pages/admin/PortfolioScorePage"));
 const PortfolioScoreHistoryPage = lazy(() => import("./pages/admin/PortfolioScoreHistoryPage"));
 const PortfolioHealthSummaryPage = lazy(() => import("./pages/landlord/PortfolioHealthSummaryPage"));
+const LandlordAnalyticsPage = lazy(() => import("./pages/landlord/LandlordAnalyticsPage"));
 const LandlordPortfolioScorePage = lazy(() => import("./pages/landlord/PortfolioScorePage"));
 const SharedPortfolioScorePage = lazy(() => import("./pages/public/SharedPortfolioScorePage"));
 const ActionRecommendationsPage = lazy(() => import("./pages/landlord/ActionRecommendationsPage"));
@@ -457,6 +458,18 @@ function App() {
             <RequireAuth>
               <LandlordNav>
                 <ApplicationReviewSummaryPage />
+              </LandlordNav>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/analytics"
+          element={
+            <RequireAuth>
+              <LandlordNav>
+                <Suspense fallback={null}>
+                  <LandlordAnalyticsPage />
+                </Suspense>
               </LandlordNav>
             </RequireAuth>
           }

--- a/rentchain-frontend/src/api/landlordAnalyticsApi.ts
+++ b/rentchain-frontend/src/api/landlordAnalyticsApi.ts
@@ -1,0 +1,81 @@
+import { apiFetch } from "./apiFetch";
+
+export type AnalyticsPeriod = "30d" | "90d" | "365d" | "month_to_date";
+
+export type LandlordAnalyticsInsight = {
+  type: string;
+  severity: "low" | "medium" | "high";
+  message: string;
+  propertyId?: string | null;
+};
+
+export type LandlordAnalyticsSnapshot = {
+  summary: {
+    occupiedUnits: number;
+    vacancyRate: number | null;
+    activeApplications: number;
+    applicationConversionRate: number | null;
+    openWorkOrders: number;
+    maintenanceCostCents: number;
+    estimatedScheduledRentCents: number;
+    leasesEndingSoon: number;
+  };
+  applications: {
+    started: number;
+    submitted: number;
+    approved: number;
+    rejected: number;
+    declined: number;
+    pendingReviewCount: number;
+    conversionRate: number | null;
+  };
+  leasing: {
+    totalProperties: number;
+    totalUnits: number;
+    occupiedUnits: number;
+    vacantUnits: number;
+    occupancyRate: number | null;
+    leasesEndingIn30Days: number;
+    leasesEndingIn60Days: number;
+    leasesEndingIn90Days: number;
+    turnoverCount: number;
+  };
+  maintenance: {
+    openWorkOrders: number;
+    completedWorkOrders: number;
+    reopenedWorkOrders: number;
+    maintenanceCostCents: number;
+    averageCostPerCompletedWorkOrderCents: number | null;
+    costConcentrationByProperty: Array<{
+      propertyId: string;
+      workOrderCount: number;
+      totalCostCents: number;
+    }>;
+  };
+  revenue: {
+    estimatedScheduledRentCents: number;
+    averageRentPerOccupiedUnitCents: number | null;
+  };
+  insights: LandlordAnalyticsInsight[];
+  properties: Array<{
+    id: string;
+    name: string;
+  }>;
+  filters: {
+    period: AnalyticsPeriod;
+    propertyId: string | null;
+    from: string;
+    to: string;
+  };
+};
+
+export async function fetchLandlordAnalyticsSnapshot(params?: {
+  period?: AnalyticsPeriod;
+  propertyId?: string | null;
+}): Promise<LandlordAnalyticsSnapshot> {
+  const search = new URLSearchParams();
+  if (params?.period) search.set("period", params.period);
+  if (params?.propertyId) search.set("propertyId", params.propertyId);
+  const suffix = search.toString() ? `?${search.toString()}` : "";
+  return await apiFetch<LandlordAnalyticsSnapshot>(`/landlord/analytics${suffix}`);
+}

--- a/rentchain-frontend/src/components/analytics/AnalyticsFiltersBar.tsx
+++ b/rentchain-frontend/src/components/analytics/AnalyticsFiltersBar.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { Card } from "../ui/Ui";
+import type { AnalyticsPeriod } from "@/api/landlordAnalyticsApi";
+
+type Props = {
+  period: AnalyticsPeriod;
+  propertyId: string;
+  properties: Array<{ id: string; name: string }>;
+  disabled?: boolean;
+  onPeriodChange: (period: AnalyticsPeriod) => void;
+  onPropertyChange: (propertyId: string) => void;
+};
+
+export function AnalyticsFiltersBar({
+  period,
+  propertyId,
+  properties,
+  disabled = false,
+  onPeriodChange,
+  onPropertyChange,
+}: Props) {
+  return (
+    <Card>
+      <div
+        style={{
+          display: "grid",
+          gap: 12,
+          gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+          alignItems: "end",
+        }}
+      >
+        <label style={{ display: "grid", gap: 6 }}>
+          <span style={{ color: "#475569", fontSize: "0.88rem", fontWeight: 600 }}>Period</span>
+          <select
+            aria-label="Analytics period"
+            disabled={disabled}
+            value={period}
+            onChange={(event) => onPeriodChange(event.target.value as AnalyticsPeriod)}
+            style={{ padding: "10px 12px", borderRadius: 10, border: "1px solid #cbd5e1", background: "#fff" }}
+          >
+            <option value="30d">Last 30 days</option>
+            <option value="90d">Last 90 days</option>
+            <option value="365d">Last 365 days</option>
+            <option value="month_to_date">Month to date</option>
+          </select>
+        </label>
+
+        <label style={{ display: "grid", gap: 6 }}>
+          <span style={{ color: "#475569", fontSize: "0.88rem", fontWeight: 600 }}>Property</span>
+          <select
+            aria-label="Analytics property"
+            disabled={disabled}
+            value={propertyId}
+            onChange={(event) => onPropertyChange(event.target.value)}
+            style={{ padding: "10px 12px", borderRadius: 10, border: "1px solid #cbd5e1", background: "#fff" }}
+          >
+            <option value="">All properties</option>
+            {properties.map((property) => (
+              <option key={property.id} value={property.id}>
+                {property.name}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+    </Card>
+  );
+}
+
+export default AnalyticsFiltersBar;

--- a/rentchain-frontend/src/components/analytics/AnalyticsKpiCard.tsx
+++ b/rentchain-frontend/src/components/analytics/AnalyticsKpiCard.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { Card } from "../ui/Ui";
+
+type Props = {
+  label: string;
+  value: string;
+  hint?: string;
+};
+
+export function AnalyticsKpiCard({ label, value, hint }: Props) {
+  return (
+    <Card style={{ display: "grid", gap: 6 }}>
+      <div style={{ color: "#64748b", fontSize: "0.82rem", fontWeight: 600 }}>{label}</div>
+      <div style={{ color: "#0f172a", fontSize: "1.7rem", fontWeight: 700 }}>{value}</div>
+      {hint ? <div style={{ color: "#475569", fontSize: "0.92rem" }}>{hint}</div> : null}
+    </Card>
+  );
+}
+
+export default AnalyticsKpiCard;

--- a/rentchain-frontend/src/components/analytics/AnalyticsKpiGrid.tsx
+++ b/rentchain-frontend/src/components/analytics/AnalyticsKpiGrid.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import AnalyticsKpiCard from "./AnalyticsKpiCard";
+
+type KpiItem = {
+  label: string;
+  value: string;
+  hint?: string;
+};
+
+type Props = {
+  items: KpiItem[];
+};
+
+export function AnalyticsKpiGrid({ items }: Props) {
+  return (
+    <div
+      style={{
+        display: "grid",
+        gap: 12,
+        gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+      }}
+    >
+      {items.map((item) => (
+        <AnalyticsKpiCard key={item.label} label={item.label} value={item.value} hint={item.hint} />
+      ))}
+    </div>
+  );
+}
+
+export default AnalyticsKpiGrid;

--- a/rentchain-frontend/src/components/analytics/AnalyticsSectionPanel.tsx
+++ b/rentchain-frontend/src/components/analytics/AnalyticsSectionPanel.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { Card } from "../ui/Ui";
+
+type Metric = {
+  label: string;
+  value: string;
+  hint?: string;
+};
+
+type Props = {
+  title: string;
+  description: string;
+  metrics: Metric[];
+  emptyMessage?: string;
+};
+
+export function AnalyticsSectionPanel({ title, description, metrics, emptyMessage }: Props) {
+  return (
+    <Card>
+      <div style={{ display: "grid", gap: 12 }}>
+        <div style={{ display: "grid", gap: 4 }}>
+          <h2 style={{ margin: 0, fontSize: "1.05rem" }}>{title}</h2>
+          <div style={{ color: "#475569" }}>{description}</div>
+        </div>
+
+        {metrics.length === 0 ? (
+          <div style={{ color: "#64748b" }}>{emptyMessage || "No analytics available for this section yet."}</div>
+        ) : (
+          <div style={{ display: "grid", gap: 10 }}>
+            {metrics.map((metric) => (
+              <div
+                key={metric.label}
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  gap: 16,
+                  padding: "10px 0",
+                  borderTop: "1px solid #e2e8f0",
+                }}
+              >
+                <div style={{ display: "grid", gap: 2 }}>
+                  <div style={{ fontWeight: 600, color: "#0f172a" }}>{metric.label}</div>
+                  {metric.hint ? <div style={{ color: "#64748b", fontSize: "0.88rem" }}>{metric.hint}</div> : null}
+                </div>
+                <div style={{ fontWeight: 700, color: "#0f172a", textAlign: "right" }}>{metric.value}</div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+export default AnalyticsSectionPanel;

--- a/rentchain-frontend/src/components/analytics/InsightCardsPanel.tsx
+++ b/rentchain-frontend/src/components/analytics/InsightCardsPanel.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { Card } from "../ui/Ui";
+import type { LandlordAnalyticsInsight } from "@/api/landlordAnalyticsApi";
+
+const severityColor: Record<LandlordAnalyticsInsight["severity"], string> = {
+  low: "#0369a1",
+  medium: "#b45309",
+  high: "#b91c1c",
+};
+
+type Props = {
+  insights: LandlordAnalyticsInsight[];
+};
+
+export function InsightCardsPanel({ insights }: Props) {
+  return (
+    <Card>
+      <div style={{ display: "grid", gap: 12 }}>
+        <div style={{ display: "grid", gap: 4 }}>
+          <h2 style={{ margin: 0, fontSize: "1.05rem" }}>Attention-worthy insights</h2>
+          <div style={{ color: "#475569" }}>
+            A small set of explainable analytics signals worth reviewing first.
+          </div>
+        </div>
+
+        {insights.length === 0 ? (
+          <div style={{ color: "#64748b" }}>No standout analytics signals in this view right now.</div>
+        ) : (
+          <div style={{ display: "grid", gap: 10 }}>
+            {insights.map((insight, index) => (
+              <div
+                key={`${insight.type}-${index}`}
+                style={{
+                  border: "1px solid #e2e8f0",
+                  borderRadius: 12,
+                  padding: 14,
+                  display: "grid",
+                  gap: 6,
+                  background: "#fff",
+                }}
+              >
+                <div style={{ color: severityColor[insight.severity], fontSize: "0.82rem", fontWeight: 700, textTransform: "uppercase" }}>
+                  {insight.severity}
+                </div>
+                <div style={{ color: "#0f172a", fontWeight: 600 }}>{insight.message}</div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+export default InsightCardsPanel;

--- a/rentchain-frontend/src/components/layout/navConfig.ts
+++ b/rentchain-frontend/src/components/layout/navConfig.ts
@@ -1,5 +1,5 @@
 import type { ComponentType } from "react";
-import { LayoutDashboard, Building2, Users, ScrollText, MessagesSquare, User, ReceiptText } from "lucide-react";
+import { LayoutDashboard, Building2, Users, ScrollText, MessagesSquare, User, ReceiptText, BarChart3 } from "lucide-react";
 import { SCREENING_ENABLED } from "../../config/screening";
 
 export type NavItem = {
@@ -61,6 +61,15 @@ export const NAV_ITEMS: NavItem[] = [
     icon: ScrollText,
     showInDrawer: true,
     showInTabs: true,
+  },
+  {
+    id: "analytics",
+    label: "Analytics",
+    to: "/analytics",
+    icon: BarChart3,
+    showInDrawer: true,
+    requiresLandlordOrAdmin: true,
+    requiresFeature: "portfolio_health_summary",
   },
   {
     id: "messages",

--- a/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.test.tsx
@@ -1,0 +1,268 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import LandlordAnalyticsPage from "./LandlordAnalyticsPage";
+
+const showToast = vi.fn();
+
+vi.mock("../../api/landlordAnalyticsApi", () => ({
+  fetchLandlordAnalyticsSnapshot: vi.fn(),
+}));
+
+vi.mock("@/hooks/useEntitlements", () => ({
+  useEntitlements: vi.fn(),
+}));
+
+vi.mock("../../components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast }),
+}));
+
+vi.mock("../../components/layout/MacShell", () => ({
+  MacShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("../../components/ui/Ui", () => ({
+  Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  Section: ({ children }: any) => <section>{children}</section>,
+}));
+
+vi.mock("@/components/billing/FeatureTeaser", () => ({
+  FeatureTeaser: ({ title, description }: { title: string; description: string }) => (
+    <div>
+      <div>{title}</div>
+      <div>{description}</div>
+    </div>
+  ),
+}));
+
+beforeEach(() => {
+  showToast.mockReset();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("LandlordAnalyticsPage", () => {
+  function mockEntitlements(overrides?: Record<string, any>) {
+    return import("@/hooks/useEntitlements").then(({ useEntitlements }) => {
+      vi.mocked(useEntitlements).mockReturnValue({
+        loading: false,
+        canViewPortfolioHealthSummary: true,
+        canViewPortfolioScore: true,
+        hasCapability: (key: string) => key === "portfolio_analytics",
+        ...overrides,
+      } as any);
+    });
+  }
+
+  async function mockApiResolved() {
+    const { fetchLandlordAnalyticsSnapshot } = await import("../../api/landlordAnalyticsApi");
+    vi.mocked(fetchLandlordAnalyticsSnapshot).mockResolvedValue({
+      summary: {
+        occupiedUnits: 4,
+        vacancyRate: 0.2,
+        activeApplications: 2,
+        applicationConversionRate: 0.5,
+        openWorkOrders: 1,
+        maintenanceCostCents: 12500,
+        estimatedScheduledRentCents: 660000,
+        leasesEndingSoon: 1,
+      },
+      applications: {
+        started: 4,
+        submitted: 3,
+        approved: 2,
+        rejected: 0,
+        declined: 0,
+        pendingReviewCount: 2,
+        conversionRate: 0.5,
+      },
+      leasing: {
+        totalProperties: 2,
+        totalUnits: 5,
+        occupiedUnits: 4,
+        vacantUnits: 1,
+        occupancyRate: 0.8,
+        leasesEndingIn30Days: 1,
+        leasesEndingIn60Days: 1,
+        leasesEndingIn90Days: 2,
+        turnoverCount: 0,
+      },
+      maintenance: {
+        openWorkOrders: 1,
+        completedWorkOrders: 2,
+        reopenedWorkOrders: 0,
+        maintenanceCostCents: 12500,
+        averageCostPerCompletedWorkOrderCents: 6250,
+        costConcentrationByProperty: [],
+      },
+      revenue: {
+        estimatedScheduledRentCents: 660000,
+        averageRentPerOccupiedUnitCents: 165000,
+      },
+      insights: [{ type: "lease_expiry", severity: "medium", message: "1 lease ends within 30 days." }],
+      properties: [
+        { id: "prop-1", name: "Alpha" },
+        { id: "prop-2", name: "Beta" },
+      ],
+      filters: {
+        period: "90d",
+        propertyId: null,
+        from: "2026-01-20T00:00:00.000Z",
+        to: "2026-04-20T00:00:00.000Z",
+      },
+    } as any);
+
+    return fetchLandlordAnalyticsSnapshot;
+  }
+
+  it("renders summary KPIs and analytics sections", async () => {
+    await mockEntitlements();
+    await mockApiResolved();
+
+    render(
+      <MemoryRouter>
+        <LandlordAnalyticsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Attention-worthy insights/i)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Applications/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Revenue signal/i })).toBeInTheDocument();
+    expect(screen.getByText(/1 lease ends within 30 days/i)).toBeInTheDocument();
+  });
+
+  it("shows a loading state while analytics are being fetched", async () => {
+    await mockEntitlements();
+    const { fetchLandlordAnalyticsSnapshot } = await import("../../api/landlordAnalyticsApi");
+    vi.mocked(fetchLandlordAnalyticsSnapshot).mockReturnValue(new Promise(() => {}) as any);
+
+    render(
+      <MemoryRouter>
+        <LandlordAnalyticsPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/Loading analytics/i)).toBeInTheDocument();
+  });
+
+  it("renders a useful empty-state message for sparse portfolios", async () => {
+    await mockEntitlements();
+    const { fetchLandlordAnalyticsSnapshot } = await import("../../api/landlordAnalyticsApi");
+    vi.mocked(fetchLandlordAnalyticsSnapshot).mockResolvedValue({
+      summary: {
+        occupiedUnits: 0,
+        vacancyRate: null,
+        activeApplications: 0,
+        applicationConversionRate: null,
+        openWorkOrders: 0,
+        maintenanceCostCents: 0,
+        estimatedScheduledRentCents: 0,
+        leasesEndingSoon: 0,
+      },
+      applications: {
+        started: 0,
+        submitted: 0,
+        approved: 0,
+        rejected: 0,
+        declined: 0,
+        pendingReviewCount: 0,
+        conversionRate: null,
+      },
+      leasing: {
+        totalProperties: 0,
+        totalUnits: 0,
+        occupiedUnits: 0,
+        vacantUnits: 0,
+        occupancyRate: null,
+        leasesEndingIn30Days: 0,
+        leasesEndingIn60Days: 0,
+        leasesEndingIn90Days: 0,
+        turnoverCount: 0,
+      },
+      maintenance: {
+        openWorkOrders: 0,
+        completedWorkOrders: 0,
+        reopenedWorkOrders: 0,
+        maintenanceCostCents: 0,
+        averageCostPerCompletedWorkOrderCents: null,
+        costConcentrationByProperty: [],
+      },
+      revenue: {
+        estimatedScheduledRentCents: 0,
+        averageRentPerOccupiedUnitCents: null,
+      },
+      insights: [],
+      properties: [],
+      filters: {
+        period: "90d",
+        propertyId: null,
+        from: "2026-01-20T00:00:00.000Z",
+        to: "2026-04-20T00:00:00.000Z",
+      },
+    } as any);
+
+    render(
+      <MemoryRouter>
+        <LandlordAnalyticsPage />
+      </MemoryRouter>
+    );
+
+    expect(
+      await screen.findByText(/Analytics will become more useful as you add units, leases, applications, and maintenance activity/i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders an error state cleanly", async () => {
+    await mockEntitlements();
+    const { fetchLandlordAnalyticsSnapshot } = await import("../../api/landlordAnalyticsApi");
+    vi.mocked(fetchLandlordAnalyticsSnapshot).mockRejectedValue(new Error("Boom"));
+
+    render(
+      <MemoryRouter>
+        <LandlordAnalyticsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Failed to load analytics: Boom/i)).toBeInTheDocument();
+  });
+
+  it("re-fetches when filters change", async () => {
+    await mockEntitlements();
+    const fetchLandlordAnalyticsSnapshot = await mockApiResolved();
+
+    render(
+      <MemoryRouter>
+        <LandlordAnalyticsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Attention-worthy insights/i)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/Analytics period/i), { target: { value: "30d" } });
+    fireEvent.change(screen.getByLabelText(/Analytics property/i), { target: { value: "prop-2" } });
+
+    expect(fetchLandlordAnalyticsSnapshot).toHaveBeenCalledWith({ period: "30d", propertyId: null });
+    expect(fetchLandlordAnalyticsSnapshot).toHaveBeenLastCalledWith({ period: "30d", propertyId: "prop-2" });
+  });
+
+  it("shows upgrade guidance when deeper analytics are unavailable", async () => {
+    await mockEntitlements({
+      canViewPortfolioScore: false,
+      hasCapability: () => false,
+    });
+    await mockApiResolved();
+
+    render(
+      <MemoryRouter>
+        <LandlordAnalyticsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Unlock deeper analytics on Pro/i)).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.tsx
@@ -1,0 +1,261 @@
+import React from "react";
+import { fetchLandlordAnalyticsSnapshot, type AnalyticsPeriod, type LandlordAnalyticsSnapshot } from "../../api/landlordAnalyticsApi";
+import { MacShell } from "../../components/layout/MacShell";
+import { Card, Section } from "../../components/ui/Ui";
+import { useToast } from "../../components/ui/ToastProvider";
+import { useEntitlements } from "@/hooks/useEntitlements";
+import { FeatureTeaser } from "@/components/billing/FeatureTeaser";
+import AnalyticsFiltersBar from "../../components/analytics/AnalyticsFiltersBar";
+import AnalyticsKpiGrid from "../../components/analytics/AnalyticsKpiGrid";
+import AnalyticsSectionPanel from "../../components/analytics/AnalyticsSectionPanel";
+import InsightCardsPanel from "../../components/analytics/InsightCardsPanel";
+
+function formatPercent(value: number | null) {
+  if (value == null || !Number.isFinite(value)) return "—";
+  return `${Math.round(value * 100)}%`;
+}
+
+function formatCurrency(cents: number | null | undefined) {
+  if (typeof cents !== "number" || !Number.isFinite(cents)) return "—";
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 }).format(
+    cents / 100
+  );
+}
+
+function useAnalyticsState(enabled: boolean, period: AnalyticsPeriod, propertyId: string) {
+  const { showToast } = useToast();
+  const [snapshot, setSnapshot] = React.useState<LandlordAnalyticsSnapshot | null>(null);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (!enabled) {
+      setLoading(false);
+      return;
+    }
+
+    let mounted = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const response = await fetchLandlordAnalyticsSnapshot({
+          period,
+          propertyId: propertyId || null,
+        });
+        if (!mounted) return;
+        setSnapshot(response);
+      } catch (err: any) {
+        if (!mounted) return;
+        const message = err?.message || "Failed to load analytics";
+        setError(message);
+        showToast({
+          message: "Failed to load analytics",
+          description: message,
+          variant: "error",
+        });
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+
+    return () => {
+      mounted = false;
+    };
+  }, [enabled, period, propertyId, showToast]);
+
+  return { snapshot, loading, error };
+}
+
+export default function LandlordAnalyticsPage() {
+  const {
+    loading: entitlementLoading,
+    canViewPortfolioHealthSummary,
+    canViewPortfolioScore,
+    hasCapability,
+  } = useEntitlements();
+  const [period, setPeriod] = React.useState<AnalyticsPeriod>("90d");
+  const [propertyId, setPropertyId] = React.useState("");
+  const analyticsEnabled = !entitlementLoading && canViewPortfolioHealthSummary;
+  const canViewAdvancedAnalytics = hasCapability("portfolio_analytics");
+  const { snapshot, loading, error } = useAnalyticsState(analyticsEnabled, period, propertyId);
+
+  const summaryItems = snapshot
+    ? [
+        {
+          label: "Occupied units",
+          value: String(snapshot.summary.occupiedUnits),
+          hint: `${snapshot.leasing.totalUnits} total units in this view`,
+        },
+        {
+          label: "Vacancy rate",
+          value: formatPercent(snapshot.summary.vacancyRate),
+          hint: `${snapshot.leasing.vacantUnits} vacant units`,
+        },
+        {
+          label: "Active applications",
+          value: String(snapshot.summary.activeApplications),
+          hint: `${snapshot.applications.submitted} submitted in the period`,
+        },
+        {
+          label: "Open work orders",
+          value: String(snapshot.summary.openWorkOrders),
+          hint: formatCurrency(snapshot.summary.maintenanceCostCents),
+        },
+        {
+          label: "Scheduled rent",
+          value: formatCurrency(snapshot.summary.estimatedScheduledRentCents),
+          hint: "Estimated from active lease rent",
+        },
+        {
+          label: "Leases ending soon",
+          value: String(snapshot.summary.leasesEndingSoon),
+          hint: "Within the next 30 days",
+        },
+      ]
+    : [];
+
+  return (
+    <MacShell title="Analytics">
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "grid", gap: 6 }}>
+            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Analytics</h1>
+            <div style={{ color: "#475569", maxWidth: 840 }}>
+              A calm view of portfolio health, application activity, leasing pressure, maintenance burden, and rent signals.
+            </div>
+          </div>
+        </Section>
+
+        {entitlementLoading ? <Card>Loading analytics access…</Card> : null}
+        {!entitlementLoading && !canViewPortfolioHealthSummary ? (
+          <Card style={{ color: "#b91c1c" }}>Analytics is currently unavailable for this account.</Card>
+        ) : null}
+
+        {analyticsEnabled ? (
+          <AnalyticsFiltersBar
+            period={period}
+            propertyId={propertyId}
+            properties={snapshot?.properties || []}
+            disabled={loading}
+            onPeriodChange={setPeriod}
+            onPropertyChange={setPropertyId}
+          />
+        ) : null}
+
+        {analyticsEnabled && loading ? <Card>Loading analytics…</Card> : null}
+        {analyticsEnabled && !loading && error ? (
+          <Card style={{ color: "#b91c1c" }}>Failed to load analytics: {error}</Card>
+        ) : null}
+
+        {analyticsEnabled && !loading && !error && snapshot ? (
+          <>
+            <AnalyticsKpiGrid items={summaryItems} />
+
+            {canViewPortfolioScore ? (
+              <div
+                style={{
+                  display: "grid",
+                  gap: 16,
+                  gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
+                }}
+              >
+                <AnalyticsSectionPanel
+                  title="Applications"
+                  description="Track whether interest is turning into submitted and approved applications."
+                  emptyMessage="No applications in the selected timeframe."
+                  metrics={[
+                    { label: "Started", value: String(snapshot.applications.started) },
+                    { label: "Submitted", value: String(snapshot.applications.submitted) },
+                    { label: "Approved", value: String(snapshot.applications.approved) },
+                    { label: "Pending review", value: String(snapshot.applications.pendingReviewCount) },
+                    { label: "Conversion rate", value: formatPercent(snapshot.applications.conversionRate) },
+                  ]}
+                />
+
+                <AnalyticsSectionPanel
+                  title="Leasing"
+                  description="Watch occupancy, vacancy, and leases approaching expiry."
+                  metrics={[
+                    { label: "Total properties", value: String(snapshot.leasing.totalProperties) },
+                    { label: "Occupied units", value: String(snapshot.leasing.occupiedUnits) },
+                    { label: "Vacant units", value: String(snapshot.leasing.vacantUnits) },
+                    { label: "Occupancy rate", value: formatPercent(snapshot.leasing.occupancyRate) },
+                    { label: "Leases ending in 60 days", value: String(snapshot.leasing.leasesEndingIn60Days) },
+                  ]}
+                />
+
+                <AnalyticsSectionPanel
+                  title="Maintenance"
+                  description="See how much operational drag maintenance is creating in this period."
+                  emptyMessage="No maintenance activity in this period."
+                  metrics={[
+                    { label: "Open work orders", value: String(snapshot.maintenance.openWorkOrders) },
+                    { label: "Completed work orders", value: String(snapshot.maintenance.completedWorkOrders) },
+                    { label: "Reopened work orders", value: String(snapshot.maintenance.reopenedWorkOrders) },
+                    { label: "Maintenance cost", value: formatCurrency(snapshot.maintenance.maintenanceCostCents) },
+                    {
+                      label: "Average cost per completed order",
+                      value: formatCurrency(snapshot.maintenance.averageCostPerCompletedWorkOrderCents),
+                    },
+                  ]}
+                />
+
+                <AnalyticsSectionPanel
+                  title="Revenue signal"
+                  description="A non-accounting view of scheduled rent based on active leases."
+                  metrics={[
+                    { label: "Estimated scheduled rent", value: formatCurrency(snapshot.revenue.estimatedScheduledRentCents) },
+                    {
+                      label: "Average rent per occupied unit",
+                      value: formatCurrency(snapshot.revenue.averageRentPerOccupiedUnitCents),
+                    },
+                    {
+                      label: "Application conversion",
+                      value: formatPercent(snapshot.summary.applicationConversionRate),
+                      hint: "Helpful context when assessing demand quality",
+                    },
+                  ]}
+                />
+              </div>
+            ) : null}
+
+            {!canViewPortfolioScore ? (
+              <FeatureTeaser
+                featureKey="portfolio_score"
+                eyebrow="Pro analytics"
+                title="Unlock deeper analytics on Pro"
+                description="Move from a summary overview into detailed application, leasing, maintenance, and revenue panels."
+                ctaLabel="Upgrade to Pro"
+              />
+            ) : null}
+
+            {canViewPortfolioScore && !canViewAdvancedAnalytics ? (
+              <FeatureTeaser
+                featureKey="portfolio_analytics"
+                eyebrow="Elite analytics"
+                title="Unlock attention-worthy insights on Elite"
+                description="Surface more actionable analytics signals across vacancies, maintenance burden, and application changes."
+                ctaLabel="Upgrade to Elite"
+              />
+            ) : null}
+
+            {canViewPortfolioScore && canViewAdvancedAnalytics ? (
+              <InsightCardsPanel insights={snapshot.insights} />
+            ) : null}
+
+            {!snapshot.properties.length &&
+            snapshot.leasing.totalUnits === 0 &&
+            snapshot.applications.started === 0 &&
+            snapshot.maintenance.completedWorkOrders === 0 &&
+            snapshot.maintenance.openWorkOrders === 0 ? (
+              <Card>
+                Analytics will become more useful as you add units, leases, applications, and maintenance activity.
+              </Card>
+            ) : null}
+          </>
+        ) : null}
+      </div>
+    </MacShell>
+  );
+}


### PR DESCRIPTION
## Summary
Adds **Landlord Analytics Dashboard v1** as the first landlord-facing analytics surface built on top of the new Analytics Layer v1 foundation.

This introduces a landlord-safe backend analytics route and a new `/analytics` landlord page with KPI cards, filtering, applications/leasing/maintenance/revenue panels, deterministic insight cards, and existing entitlement-based gating for deeper views.

The implementation reuses shared analytics derivation instead of duplicating calculations in the frontend, keeping the dashboard aligned with RentChain’s current analytics architecture.

## What’s included
- New landlord analytics route: `GET /api/landlord/analytics`
- Authenticated landlord-scoped analytics service with optional `period` and `propertyId` filters
- Shared analytics core reuse across admin and landlord analytics consumers
- New landlord analytics page at `/analytics`
- KPI cards and section panels for:
  - applications
  - leasing / occupancy
  - maintenance
  - revenue signals
  - deterministic insights
- Existing plan/capability-based gating for richer views
- Targeted backend and frontend tests

## Why this matters
This is the first real product-facing consumer of the analytics foundation. It validates the usefulness of the metrics with landlords before layering on alerts, benchmarking, forecasting, or agent-driven actions.

## Verification
Backend:
- targeted analytics/service/route tests passed
- build passed

Frontend:
- targeted page/route tests passed
- build passed