### PR TITLE
feat: add analytics alerts engine v1

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -112,6 +112,7 @@ import portfolioScoreRoutes from "./routes/portfolioScoreRoutes";
 import portfolioScoreHistoryRoutes from "./routes/portfolioScoreHistoryRoutes";
 import landlordPortfolioHealthRoutes from "./routes/landlordPortfolioHealthRoutes";
 import landlordAnalyticsRoutes from "./routes/landlordAnalyticsRoutes";
+import landlordAnalyticsAlertsRoutes from "./routes/landlordAnalyticsAlertsRoutes";
 import landlordPortfolioScoreRoutes from "./routes/landlordPortfolioScoreRoutes";
 import landlordPortfolioScoreSharingRoutes from "./routes/landlordPortfolioScoreSharingRoutes";
 import publicPortfolioScoreRoutes from "./routes/publicPortfolioScoreRoutes";
@@ -261,6 +262,8 @@ app.use("/api", routeSource("landlordPortfolioHealthRoutes.ts"), landlordPortfol
 console.log("[route-mount] landlordPortfolioHealthRoutes mounted at /api");
 app.use("/api", routeSource("landlordAnalyticsRoutes.ts"), landlordAnalyticsRoutes);
 console.log("[route-mount] landlordAnalyticsRoutes mounted at /api");
+app.use("/api", routeSource("landlordAnalyticsAlertsRoutes.ts"), landlordAnalyticsAlertsRoutes);
+console.log("[route-mount] landlordAnalyticsAlertsRoutes mounted at /api");
 app.use("/api", routeSource("landlordPortfolioScoreRoutes.ts"), landlordPortfolioScoreRoutes);
 console.log("[route-mount] landlordPortfolioScoreRoutes mounted at /api");
 app.use("/api", routeSource("landlordPortfolioScoreSharingRoutes.ts"), landlordPortfolioScoreSharingRoutes);

--- a/rentchain-api/src/lib/analytics/__tests__/deriveAnalyticsAlerts.test.ts
+++ b/rentchain-api/src/lib/analytics/__tests__/deriveAnalyticsAlerts.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import { deriveAnalyticsAlerts } from "../deriveAnalyticsAlerts";
+import type { LandlordAnalyticsSnapshot } from "../analyticsTypes";
+
+function buildSnapshot(overrides?: Partial<LandlordAnalyticsSnapshot>): LandlordAnalyticsSnapshot {
+  return {
+    summary: {
+      occupiedUnits: 4,
+      vacancyRate: 0.25,
+      activeApplications: 1,
+      applicationConversionRate: 0.2,
+      openWorkOrders: 3,
+      maintenanceCostCents: 90000,
+      estimatedScheduledRentCents: 660000,
+      leasesEndingSoon: 2,
+    },
+    applications: {
+      started: 1,
+      submitted: 1,
+      approved: 0,
+      rejected: 0,
+      declined: 0,
+      pendingReviewCount: 1,
+      conversionRate: 0.2,
+    },
+    leasing: {
+      totalProperties: 2,
+      totalUnits: 5,
+      occupiedUnits: 4,
+      vacantUnits: 1,
+      occupancyRate: 0.8,
+      leasesEndingIn30Days: 2,
+      leasesEndingIn60Days: 2,
+      leasesEndingIn90Days: 3,
+      turnoverCount: 1,
+    },
+    maintenance: {
+      openWorkOrders: 3,
+      completedWorkOrders: 1,
+      reopenedWorkOrders: 1,
+      maintenanceCostCents: 90000,
+      averageCostPerCompletedWorkOrderCents: 45000,
+      costConcentrationByProperty: [{ propertyId: "prop-1", workOrderCount: 3, totalCostCents: 90000 }],
+    },
+    revenue: {
+      estimatedScheduledRentCents: 660000,
+      averageRentPerOccupiedUnitCents: 165000,
+    },
+    insights: [
+      { type: "maintenance_cost_increase", severity: "medium", message: "Maintenance costs increased compared with the previous period." },
+      { type: "work_order_concentration", severity: "high", message: "Most open work orders are tied to one property (3).", propertyId: "prop-1" },
+      { type: "applications_drop", severity: "low", message: "Applications dropped compared with the previous period." },
+    ],
+    comparisons: {
+      previousPeriod: {
+        vacancyRate: 0.1,
+        applicationConversionRate: 0.6,
+        applicationsStarted: 4,
+        applicationsSubmitted: 3,
+        maintenanceCostCents: 30000,
+        openWorkOrders: 1,
+      },
+    },
+    properties: [
+      { id: "prop-1", name: "Alpha" },
+      { id: "prop-2", name: "Beta" },
+    ],
+    filters: {
+      period: "30d",
+      propertyId: null,
+      from: "2026-03-20T00:00:00.000Z",
+      to: "2026-04-20T00:00:00.000Z",
+    },
+    ...overrides,
+  };
+}
+
+describe("deriveAnalyticsAlerts", () => {
+  it("derives deterministic active alerts from the landlord analytics snapshot", () => {
+    const result = deriveAnalyticsAlerts({
+      snapshot: buildSnapshot(),
+      status: "active",
+      now: Date.UTC(2026, 3, 20, 12, 0, 0, 0),
+    });
+
+    expect(result.summary).toEqual({
+      activeCount: 8,
+      highSeverityCount: 2,
+      mediumSeverityCount: 4,
+      lowSeverityCount: 2,
+    });
+    expect(result.alerts.map((alert) => alert.type)).toEqual([
+      "application_conversion_drop",
+      "work_order_concentration",
+      "lease_expiry",
+      "maintenance_cost_spike",
+      "high_vacancy",
+      "vacancy_increase",
+      "low_application_activity",
+      "application_drop",
+    ]);
+    expect(result.alerts[0].notification.inAppEligible).toBe(true);
+  });
+
+  it("returns resolved alerts cleanly when no rules are currently active", () => {
+    const result = deriveAnalyticsAlerts({
+      snapshot: buildSnapshot({
+        summary: {
+          occupiedUnits: 4,
+          vacancyRate: 0.05,
+          activeApplications: 3,
+          applicationConversionRate: 0.6,
+          openWorkOrders: 0,
+          maintenanceCostCents: 5000,
+          estimatedScheduledRentCents: 660000,
+          leasesEndingSoon: 0,
+        },
+        applications: {
+          started: 4,
+          submitted: 3,
+          approved: 2,
+          rejected: 0,
+          declined: 0,
+          pendingReviewCount: 1,
+          conversionRate: 0.6,
+        },
+        leasing: {
+          totalProperties: 2,
+          totalUnits: 5,
+          occupiedUnits: 4,
+          vacantUnits: 1,
+          occupancyRate: 0.8,
+          leasesEndingIn30Days: 0,
+          leasesEndingIn60Days: 0,
+          leasesEndingIn90Days: 1,
+          turnoverCount: 0,
+        },
+        maintenance: {
+          openWorkOrders: 0,
+          completedWorkOrders: 2,
+          reopenedWorkOrders: 0,
+          maintenanceCostCents: 5000,
+          averageCostPerCompletedWorkOrderCents: 2500,
+          costConcentrationByProperty: [],
+        },
+        insights: [],
+        comparisons: {
+          previousPeriod: {
+            vacancyRate: 0.05,
+            applicationConversionRate: 0.5,
+            applicationsStarted: 3,
+            applicationsSubmitted: 2,
+            maintenanceCostCents: 7000,
+            openWorkOrders: 1,
+          },
+        },
+      }),
+      status: "resolved",
+    });
+
+    expect(result.summary.activeCount).toBe(0);
+    expect(result.alerts.every((alert) => alert.status === "resolved")).toBe(true);
+  });
+});

--- a/rentchain-api/src/lib/analytics/__tests__/deriveLandlordAnalyticsSnapshot.test.ts
+++ b/rentchain-api/src/lib/analytics/__tests__/deriveLandlordAnalyticsSnapshot.test.ts
@@ -82,6 +82,14 @@ describe("deriveLandlordAnalyticsSnapshot", () => {
       estimatedScheduledRentCents: 180000,
       averageRentPerOccupiedUnitCents: 180000,
     });
+    expect(result.comparisons.previousPeriod).toEqual({
+      vacancyRate: 2 / 3,
+      applicationConversionRate: null,
+      applicationsStarted: 0,
+      applicationsSubmitted: 0,
+      maintenanceCostCents: 0,
+      openWorkOrders: 1,
+    });
     expect(result.properties).toEqual([
       { id: "prop-1", name: "Untitled property" },
       { id: "prop-2", name: "Untitled property" },
@@ -132,5 +140,13 @@ describe("deriveLandlordAnalyticsSnapshot", () => {
     });
     expect(result.insights).toEqual([]);
     expect(result.properties).toEqual([]);
+    expect(result.comparisons.previousPeriod).toEqual({
+      vacancyRate: null,
+      applicationConversionRate: null,
+      applicationsStarted: 0,
+      applicationsSubmitted: 0,
+      maintenanceCostCents: 0,
+      openWorkOrders: 0,
+    });
   });
 });

--- a/rentchain-api/src/lib/analytics/alertTypes.ts
+++ b/rentchain-api/src/lib/analytics/alertTypes.ts
@@ -1,0 +1,61 @@
+import type { AdminAnalyticsPeriod } from "./analyticsTypes";
+
+export type AnalyticsAlertType =
+  | "lease_expiry"
+  | "vacancy_increase"
+  | "high_vacancy"
+  | "maintenance_cost_spike"
+  | "work_order_concentration"
+  | "application_drop"
+  | "application_conversion_drop"
+  | "low_application_activity";
+
+export type AnalyticsAlertSeverity = "low" | "medium" | "high";
+export type AnalyticsAlertStatus = "active" | "resolved";
+
+export type AnalyticsAlertAction = {
+  type: string;
+  label: string;
+  href?: string;
+};
+
+export type AnalyticsAlert = {
+  id: string;
+  type: AnalyticsAlertType;
+  severity: AnalyticsAlertSeverity;
+  status: AnalyticsAlertStatus;
+  title: string;
+  message: string;
+  propertyId?: string | null;
+  propertyName?: string | null;
+  metricValue?: number | null;
+  previousMetricValue?: number | null;
+  period?: AdminAnalyticsPeriod;
+  detectedAt: string;
+  lastEvaluatedAt: string;
+  notification: {
+    inAppEligible: boolean;
+    emailEligible: boolean;
+    automationEligible: boolean;
+  };
+  actions?: AnalyticsAlertAction[];
+};
+
+export type AnalyticsAlertsSummary = {
+  activeCount: number;
+  highSeverityCount: number;
+  mediumSeverityCount: number;
+  lowSeverityCount: number;
+};
+
+export type AnalyticsAlertsStatusFilter = "active" | "resolved" | "all";
+
+export type LandlordAnalyticsAlertsResponse = {
+  summary: AnalyticsAlertsSummary;
+  alerts: AnalyticsAlert[];
+  filters: {
+    period: AdminAnalyticsPeriod;
+    propertyId: string | null;
+    status: AnalyticsAlertsStatusFilter;
+  };
+};

--- a/rentchain-api/src/lib/analytics/analyticsTypes.ts
+++ b/rentchain-api/src/lib/analytics/analyticsTypes.ts
@@ -146,6 +146,16 @@ export type LandlordAnalyticsSnapshot = {
   maintenance: AdminMaintenanceAnalytics;
   revenue: LandlordRevenueAnalytics;
   insights: LandlordAnalyticsInsight[];
+  comparisons: {
+    previousPeriod: {
+      vacancyRate: number | null;
+      applicationConversionRate: number | null;
+      applicationsStarted: number;
+      applicationsSubmitted: number;
+      maintenanceCostCents: number;
+      openWorkOrders: number;
+    };
+  };
   properties: Array<{
     id: string;
     name: string;

--- a/rentchain-api/src/lib/analytics/deriveAnalyticsAlerts.ts
+++ b/rentchain-api/src/lib/analytics/deriveAnalyticsAlerts.ts
@@ -1,0 +1,269 @@
+import crypto from "crypto";
+import type { AnalyticsAlert, AnalyticsAlertsStatusFilter, LandlordAnalyticsAlertsResponse } from "./alertTypes";
+import type { LandlordAnalyticsSnapshot } from "./analyticsTypes";
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function alertId(type: string, propertyId: string | null, period: string) {
+  return crypto.createHash("sha256").update(`${type}:${propertyId || "portfolio"}:${period}`).digest("hex");
+}
+
+function severityCounts(alerts: AnalyticsAlert[]) {
+  const active = alerts.filter((alert) => alert.status === "active");
+  return {
+    activeCount: active.length,
+    highSeverityCount: active.filter((alert) => alert.severity === "high").length,
+    mediumSeverityCount: active.filter((alert) => alert.severity === "medium").length,
+    lowSeverityCount: active.filter((alert) => alert.severity === "low").length,
+  };
+}
+
+function buildAlert(input: Omit<AnalyticsAlert, "id" | "notification"> & { period: string }) {
+  return {
+    ...input,
+    id: alertId(input.type, input.propertyId || null, input.period),
+    notification: {
+      inAppEligible: true,
+      emailEligible: input.status === "active" && input.severity !== "low",
+      automationEligible: false,
+    },
+  } satisfies AnalyticsAlert;
+}
+
+function propertyNameById(snapshot: LandlordAnalyticsSnapshot, propertyId?: string | null) {
+  if (!propertyId) return null;
+  return snapshot.properties.find((property) => property.id === propertyId)?.name || null;
+}
+
+function actionLink(type: AnalyticsAlert["type"], propertyId?: string | null) {
+  if (type === "lease_expiry") return { type: "review_leases", label: "Review leases", href: "/portfolio-health" };
+  if (type === "high_vacancy" || type === "vacancy_increase") {
+    return {
+      type: "view_analytics",
+      label: propertyId ? "View property analytics" : "View analytics",
+      href: propertyId ? `/analytics?propertyId=${encodeURIComponent(propertyId)}` : "/analytics",
+    };
+  }
+  if (type === "application_drop" || type === "application_conversion_drop" || type === "low_application_activity") {
+    return { type: "review_applications", label: "Review applications", href: "/applications" };
+  }
+  return { type: "review_work_orders", label: "Review work orders", href: "/work-orders" };
+}
+
+export function deriveAnalyticsAlerts(params: {
+  snapshot: LandlordAnalyticsSnapshot;
+  status?: AnalyticsAlertsStatusFilter;
+  now?: number;
+}): LandlordAnalyticsAlertsResponse {
+  const snapshot = params.snapshot;
+  const period = snapshot.filters.period;
+  const propertyId = snapshot.filters.propertyId;
+  const currentIso =
+    typeof params.now === "number" ? new Date(params.now).toISOString() : new Date(snapshot.filters.to).toISOString();
+  const previous = snapshot.comparisons.previousPeriod;
+  const alerts: AnalyticsAlert[] = [];
+
+  const leaseExpiryCount = snapshot.leasing.leasesEndingIn30Days;
+  alerts.push(
+    buildAlert({
+      type: "lease_expiry",
+      severity: leaseExpiryCount >= 3 ? "high" : "medium",
+      status: leaseExpiryCount > 0 ? "active" : "resolved",
+      title: "Leases ending soon",
+      message:
+        leaseExpiryCount > 0
+          ? leaseExpiryCount === 1
+            ? "1 lease ends within 30 days."
+            : `${leaseExpiryCount} leases end within 30 days.`
+          : "No leases are ending within the next 30 days.",
+      propertyId,
+      propertyName: propertyNameById(snapshot, propertyId),
+      metricValue: leaseExpiryCount,
+      previousMetricValue: null,
+      period,
+      detectedAt: snapshot.filters.to,
+      lastEvaluatedAt: currentIso,
+      actions: [actionLink("lease_expiry", propertyId)],
+    })
+  );
+
+  const vacancyRate = snapshot.summary.vacancyRate || 0;
+  const previousVacancyRate = previous.vacancyRate || 0;
+  alerts.push(
+    buildAlert({
+      type: "high_vacancy",
+      severity: vacancyRate >= 0.35 ? "high" : "medium",
+      status: snapshot.leasing.totalUnits > 0 && vacancyRate >= 0.2 ? "active" : "resolved",
+      title: "Vacancy is elevated",
+      message:
+        snapshot.leasing.totalUnits > 0 && vacancyRate >= 0.2
+          ? `Vacancy is ${Math.round(vacancyRate * 100)}% in the current view.`
+          : "Vacancy is not elevated for this view.",
+      propertyId,
+      propertyName: propertyNameById(snapshot, propertyId),
+      metricValue: vacancyRate,
+      previousMetricValue: previousVacancyRate,
+      period,
+      detectedAt: snapshot.filters.to,
+      lastEvaluatedAt: currentIso,
+      actions: [actionLink("high_vacancy", propertyId)],
+    })
+  );
+
+  const vacancyDelta = vacancyRate - previousVacancyRate;
+  alerts.push(
+    buildAlert({
+      type: "vacancy_increase",
+      severity: vacancyDelta >= 0.2 ? "high" : "medium",
+      status: previous.vacancyRate != null && vacancyDelta >= 0.1 ? "active" : "resolved",
+      title: "Vacancy worsened",
+      message:
+        previous.vacancyRate != null && vacancyDelta >= 0.1
+          ? `Vacancy increased from ${Math.round(previousVacancyRate * 100)}% to ${Math.round(vacancyRate * 100)}%.`
+          : "Vacancy has not worsened meaningfully versus the prior period.",
+      propertyId,
+      propertyName: propertyNameById(snapshot, propertyId),
+      metricValue: vacancyRate,
+      previousMetricValue: previousVacancyRate,
+      period,
+      detectedAt: snapshot.filters.to,
+      lastEvaluatedAt: currentIso,
+      actions: [actionLink("vacancy_increase", propertyId)],
+    })
+  );
+
+  const lowApplicationActive =
+    snapshot.leasing.totalUnits > 0 &&
+    (snapshot.applications.started === 0 ||
+      (snapshot.applications.started <= 1 && snapshot.leasing.totalUnits >= 3));
+  alerts.push(
+    buildAlert({
+      type: "low_application_activity",
+      severity: snapshot.applications.started === 0 ? "medium" : "low",
+      status: lowApplicationActive ? "active" : "resolved",
+      title: "Application activity is low",
+      message: lowApplicationActive
+        ? snapshot.applications.started === 0
+          ? "No applications started in the selected period."
+          : "Application activity is light for the selected period."
+        : "Application activity is not currently low for this view.",
+      propertyId,
+      propertyName: propertyNameById(snapshot, propertyId),
+      metricValue: snapshot.applications.started,
+      previousMetricValue: previous.applicationsStarted,
+      period,
+      detectedAt: snapshot.filters.to,
+      lastEvaluatedAt: currentIso,
+      actions: [actionLink("low_application_activity", propertyId)],
+    })
+  );
+
+  const conversionRate = snapshot.applications.conversionRate || 0;
+  const previousConversionRate = previous.applicationConversionRate || 0;
+  const conversionDropActive =
+    previous.applicationConversionRate != null && previousConversionRate >= 0.2 && previousConversionRate - conversionRate >= 0.2;
+  alerts.push(
+    buildAlert({
+      type: "application_conversion_drop",
+      severity: previousConversionRate - conversionRate >= 0.35 ? "high" : "medium",
+      status: conversionDropActive ? "active" : "resolved",
+      title: "Application conversion dropped",
+      message: conversionDropActive
+        ? `Application conversion fell from ${Math.round(previousConversionRate * 100)}% to ${Math.round(conversionRate * 100)}%.`
+        : "Application conversion has not dropped materially versus the prior period.",
+      propertyId,
+      propertyName: propertyNameById(snapshot, propertyId),
+      metricValue: conversionRate,
+      previousMetricValue: previousConversionRate,
+      period,
+      detectedAt: snapshot.filters.to,
+      lastEvaluatedAt: currentIso,
+      actions: [actionLink("application_conversion_drop", propertyId)],
+    })
+  );
+
+  const applicationsDropInsight = snapshot.insights.find((insight) => insight.type === "applications_drop");
+  alerts.push(
+    buildAlert({
+      type: "application_drop",
+      severity: applicationsDropInsight?.severity || "low",
+      status: applicationsDropInsight ? "active" : "resolved",
+      title: "Applications declined",
+      message: applicationsDropInsight?.message || "Applications have not declined meaningfully versus the prior period.",
+      propertyId: applicationsDropInsight?.propertyId || propertyId,
+      propertyName: propertyNameById(snapshot, applicationsDropInsight?.propertyId || propertyId),
+      metricValue: snapshot.applications.submitted,
+      previousMetricValue: previous.applicationsSubmitted,
+      period,
+      detectedAt: snapshot.filters.to,
+      lastEvaluatedAt: currentIso,
+      actions: [actionLink("application_drop", applicationsDropInsight?.propertyId || propertyId)],
+    })
+  );
+
+  const maintenanceInsight = snapshot.insights.find((insight) => insight.type === "maintenance_cost_increase");
+  const maintenanceCost = snapshot.maintenance.maintenanceCostCents;
+  const previousMaintenanceCost = previous.maintenanceCostCents;
+  const maintenanceActive =
+    Boolean(maintenanceInsight) ||
+    (previousMaintenanceCost > 0 && maintenanceCost >= Math.max(50_000, previousMaintenanceCost * 1.5));
+  alerts.push(
+    buildAlert({
+      type: "maintenance_cost_spike",
+      severity: maintenanceCost >= Math.max(100_000, previousMaintenanceCost * 2) ? "high" : "medium",
+      status: maintenanceActive ? "active" : "resolved",
+      title: "Maintenance costs spiked",
+      message: maintenanceActive
+        ? maintenanceInsight?.message || "Maintenance costs are materially above the prior period."
+        : "Maintenance costs are not elevated versus the prior period.",
+      propertyId,
+      propertyName: propertyNameById(snapshot, propertyId),
+      metricValue: maintenanceCost,
+      previousMetricValue: previousMaintenanceCost,
+      period,
+      detectedAt: snapshot.filters.to,
+      lastEvaluatedAt: currentIso,
+      actions: [actionLink("maintenance_cost_spike", propertyId)],
+    })
+  );
+
+  const workOrderInsight = snapshot.insights.find((insight) => insight.type === "work_order_concentration");
+  alerts.push(
+    buildAlert({
+      type: "work_order_concentration",
+      severity: workOrderInsight?.severity || "medium",
+      status: workOrderInsight ? "active" : "resolved",
+      title: "Work orders are concentrated",
+      message: workOrderInsight?.message || "Open work orders are not concentrated in one property right now.",
+      propertyId: workOrderInsight?.propertyId || propertyId,
+      propertyName: propertyNameById(snapshot, workOrderInsight?.propertyId || propertyId),
+      metricValue: snapshot.maintenance.openWorkOrders,
+      previousMetricValue: previous.openWorkOrders,
+      period,
+      detectedAt: snapshot.filters.to,
+      lastEvaluatedAt: currentIso,
+      actions: [actionLink("work_order_concentration", workOrderInsight?.propertyId || propertyId)],
+    })
+  );
+
+  const statusFilter = params.status || "active";
+  const filtered =
+    statusFilter === "all" ? alerts : alerts.filter((alert) => alert.status === statusFilter);
+
+  return {
+    summary: severityCounts(alerts),
+    alerts: filtered.sort((a, b) => {
+      const severityRank = { high: 3, medium: 2, low: 1 };
+      if (a.status !== b.status) return a.status === "active" ? -1 : 1;
+      if (severityRank[b.severity] !== severityRank[a.severity]) return severityRank[b.severity] - severityRank[a.severity];
+      return a.title.localeCompare(b.title);
+    }),
+    filters: {
+      period,
+      propertyId: asString(propertyId, 240) || null,
+      status: statusFilter,
+    },
+  };
+}

--- a/rentchain-api/src/lib/analytics/deriveLandlordAnalyticsSnapshot.ts
+++ b/rentchain-api/src/lib/analytics/deriveLandlordAnalyticsSnapshot.ts
@@ -212,6 +212,16 @@ export function deriveLandlordAnalyticsSnapshot(input: AdminAnalyticsDerivedInpu
       units: input.units,
       workOrders: input.workOrders,
     }),
+    comparisons: {
+      previousPeriod: {
+        vacancyRate: previous.summary.vacancyRate,
+        applicationConversionRate: previous.applications.conversionRate,
+        applicationsStarted: previous.applications.started,
+        applicationsSubmitted: previous.applications.submitted,
+        maintenanceCostCents: previous.maintenance.maintenanceCostCents,
+        openWorkOrders: previous.maintenance.openWorkOrders,
+      },
+    },
     properties: (input.properties || [])
       .map((property: any) => ({
         id: asString(property?.id, 240),

--- a/rentchain-api/src/routes/__tests__/landlordAnalyticsAlertsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordAnalyticsAlertsRoutes.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const loadLandlordAnalyticsAlerts = vi.fn();
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!req.user) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    return next();
+  },
+}));
+
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: any, res: any, next: any) => {
+    const role = String(req.user?.role || "").trim().toLowerCase();
+    const landlordId = req.user?.landlordId || req.user?.id;
+    if (role !== "landlord" && role !== "admin") {
+      return res.status(403).json({ ok: false, error: "Forbidden" });
+    }
+    if (!landlordId) {
+      return res.status(401).json({ ok: false, error: "Missing landlord context" });
+    }
+    req.user.landlordId = landlordId;
+    return next();
+  },
+}));
+
+vi.mock("../../services/landlord/landlordAnalyticsAlerts", () => ({
+  loadLandlordAnalyticsAlerts,
+}));
+
+async function invokeRouter(
+  router: any,
+  options: { method: string; url: string; user?: Record<string, unknown> | null }
+) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    const query = new URLSearchParams(queryString || "");
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: options.user ?? null,
+      query: Object.fromEntries(query.entries()),
+      params: {},
+      headers: {},
+      get(name: string) {
+        return this.headers[String(name).toLowerCase()];
+      },
+      header(name: string) {
+        return this.get(name);
+      },
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, string>,
+      setHeader(name: string, value: string) {
+        this.headers[name.toLowerCase()] = value;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("landlordAnalyticsAlertsRoutes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadLandlordAnalyticsAlerts.mockResolvedValue({
+      summary: {
+        activeCount: 2,
+        highSeverityCount: 1,
+        mediumSeverityCount: 1,
+        lowSeverityCount: 0,
+      },
+      alerts: [
+        {
+          id: "alert-1",
+          type: "lease_expiry",
+          severity: "medium",
+          status: "active",
+          title: "Leases ending soon",
+          message: "2 leases end within 30 days.",
+          detectedAt: "2026-04-20T00:00:00.000Z",
+          lastEvaluatedAt: "2026-04-20T00:00:00.000Z",
+          period: "30d",
+          notification: { inAppEligible: true, emailEligible: true, automationEligible: false },
+          actions: [],
+        },
+      ],
+      filters: {
+        period: "30d",
+        propertyId: null,
+        status: "active",
+      },
+    });
+  });
+
+  it("returns landlord-scoped alerts without allowing scope override", async () => {
+    const router = (await import("../landlordAnalyticsAlertsRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/analytics/alerts?period=30d&status=all&propertyId=prop-1&landlordId=other",
+      user: { id: "landlord-1", role: "landlord" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(loadLandlordAnalyticsAlerts).toHaveBeenCalledWith({
+      landlordId: "landlord-1",
+      period: "30d",
+      propertyId: "prop-1",
+      status: "all",
+    });
+    expect(response.body.ok).toBe(true);
+  });
+
+  it("enforces landlord authentication", async () => {
+    const router = (await import("../landlordAnalyticsAlertsRoutes")).default;
+    const forbidden = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/analytics/alerts",
+      user: { id: "tenant-1", role: "tenant" },
+    });
+    expect(forbidden.status).toBe(403);
+
+    const unauthorized = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/analytics/alerts",
+      user: null,
+    });
+    expect(unauthorized.status).toBe(401);
+  });
+});

--- a/rentchain-api/src/routes/landlordAnalyticsAlertsRoutes.ts
+++ b/rentchain-api/src/routes/landlordAnalyticsAlertsRoutes.ts
@@ -1,0 +1,33 @@
+import { Router } from "express";
+import { requireAuth } from "../middleware/requireAuth";
+import { requireLandlord } from "../middleware/requireLandlord";
+import { loadLandlordAnalyticsAlerts } from "../services/landlord/landlordAnalyticsAlerts";
+
+const router = Router();
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+router.get("/landlord/analytics/alerts", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = asString(req.user?.landlordId || req.user?.id, 240);
+    if (!landlordId) {
+      return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    }
+
+    const result = await loadLandlordAnalyticsAlerts({
+      landlordId,
+      period: req.query?.period,
+      propertyId: req.query?.propertyId,
+      status: req.query?.status,
+    });
+
+    return res.json({ ok: true, ...result });
+  } catch (err: any) {
+    console.error("[landlord-analytics-alerts] fetch failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "LANDLORD_ANALYTICS_ALERTS_FETCH_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-api/src/services/landlord/__tests__/landlordAnalyticsAlerts.test.ts
+++ b/rentchain-api/src/services/landlord/__tests__/landlordAnalyticsAlerts.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const loadLandlordAnalyticsSnapshot = vi.fn();
+
+vi.mock("../landlordAnalyticsSnapshot", () => ({
+  loadLandlordAnalyticsSnapshot,
+}));
+
+describe("loadLandlordAnalyticsAlerts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadLandlordAnalyticsSnapshot.mockResolvedValue({
+      summary: {
+        occupiedUnits: 3,
+        vacancyRate: 0.25,
+        activeApplications: 0,
+        applicationConversionRate: 0.2,
+        openWorkOrders: 2,
+        maintenanceCostCents: 75000,
+        estimatedScheduledRentCents: 540000,
+        leasesEndingSoon: 1,
+      },
+      applications: {
+        started: 0,
+        submitted: 0,
+        approved: 0,
+        rejected: 0,
+        declined: 0,
+        pendingReviewCount: 0,
+        conversionRate: 0.2,
+      },
+      leasing: {
+        totalProperties: 1,
+        totalUnits: 4,
+        occupiedUnits: 3,
+        vacantUnits: 1,
+        occupancyRate: 0.75,
+        leasesEndingIn30Days: 1,
+        leasesEndingIn60Days: 1,
+        leasesEndingIn90Days: 1,
+        turnoverCount: 0,
+      },
+      maintenance: {
+        openWorkOrders: 2,
+        completedWorkOrders: 1,
+        reopenedWorkOrders: 0,
+        maintenanceCostCents: 75000,
+        averageCostPerCompletedWorkOrderCents: 75000,
+        costConcentrationByProperty: [],
+      },
+      revenue: {
+        estimatedScheduledRentCents: 540000,
+        averageRentPerOccupiedUnitCents: 180000,
+      },
+      insights: [{ type: "maintenance_cost_increase", severity: "medium", message: "Maintenance costs increased compared with the previous period." }],
+      comparisons: {
+        previousPeriod: {
+          vacancyRate: 0.1,
+          applicationConversionRate: 0.5,
+          applicationsStarted: 2,
+          applicationsSubmitted: 2,
+          maintenanceCostCents: 20000,
+          openWorkOrders: 1,
+        },
+      },
+      properties: [{ id: "prop-1", name: "Alpha" }],
+      filters: {
+        period: "90d",
+        propertyId: "prop-1",
+        from: "2026-01-20T00:00:00.000Z",
+        to: "2026-04-20T00:00:00.000Z",
+      },
+    });
+  });
+
+  it("composes the landlord analytics snapshot into a filtered alerts payload", async () => {
+    const { loadLandlordAnalyticsAlerts } = await import("../landlordAnalyticsAlerts");
+    const result = await loadLandlordAnalyticsAlerts({
+      landlordId: "landlord-1",
+      period: "90d",
+      propertyId: "prop-1",
+      status: "active",
+    });
+
+    expect(loadLandlordAnalyticsSnapshot).toHaveBeenCalledWith({
+      landlordId: "landlord-1",
+      period: "90d",
+      propertyId: "prop-1",
+      now: undefined,
+    });
+    expect(result.filters).toEqual({
+      period: "90d",
+      propertyId: "prop-1",
+      status: "active",
+    });
+    expect(result.alerts.some((alert) => alert.type === "maintenance_cost_spike")).toBe(true);
+  });
+});

--- a/rentchain-api/src/services/landlord/landlordAnalyticsAlerts.ts
+++ b/rentchain-api/src/services/landlord/landlordAnalyticsAlerts.ts
@@ -1,0 +1,35 @@
+import { deriveAnalyticsAlerts } from "../../lib/analytics/deriveAnalyticsAlerts";
+import type { AnalyticsAlertsStatusFilter, LandlordAnalyticsAlertsResponse } from "../../lib/analytics/alertTypes";
+import { loadLandlordAnalyticsSnapshot } from "./landlordAnalyticsSnapshot";
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function clampStatus(value: unknown): AnalyticsAlertsStatusFilter {
+  const raw = asString(value, 40).toLowerCase();
+  if (raw === "resolved") return "resolved";
+  if (raw === "all") return "all";
+  return "active";
+}
+
+export async function loadLandlordAnalyticsAlerts(params: {
+  landlordId: string;
+  period?: string;
+  propertyId?: string;
+  status?: string;
+  now?: number;
+}): Promise<LandlordAnalyticsAlertsResponse> {
+  const snapshot = await loadLandlordAnalyticsSnapshot({
+    landlordId: params.landlordId,
+    period: params.period,
+    propertyId: params.propertyId,
+    now: params.now,
+  });
+
+  return deriveAnalyticsAlerts({
+    snapshot,
+    status: clampStatus(params.status),
+    now: params.now,
+  });
+}

--- a/rentchain-frontend/src/api/landlordAnalyticsAlertsApi.ts
+++ b/rentchain-frontend/src/api/landlordAnalyticsAlertsApi.ts
@@ -1,0 +1,58 @@
+import { apiFetch } from "./apiFetch";
+import type { AnalyticsPeriod } from "./landlordAnalyticsApi";
+
+export type AnalyticsAlertStatus = "active" | "resolved" | "all";
+
+export type AnalyticsAlert = {
+  id: string;
+  type: string;
+  severity: "low" | "medium" | "high";
+  status: "active" | "resolved";
+  title: string;
+  message: string;
+  propertyId?: string | null;
+  propertyName?: string | null;
+  metricValue?: number | null;
+  previousMetricValue?: number | null;
+  period?: AnalyticsPeriod;
+  detectedAt: string;
+  lastEvaluatedAt: string;
+  notification: {
+    inAppEligible: boolean;
+    emailEligible: boolean;
+    automationEligible: boolean;
+  };
+  actions?: Array<{
+    type: string;
+    label: string;
+    href?: string;
+  }>;
+};
+
+export type LandlordAnalyticsAlertsResponse = {
+  summary: {
+    activeCount: number;
+    highSeverityCount: number;
+    mediumSeverityCount: number;
+    lowSeverityCount: number;
+  };
+  alerts: AnalyticsAlert[];
+  filters: {
+    period: AnalyticsPeriod;
+    propertyId: string | null;
+    status: AnalyticsAlertStatus;
+  };
+};
+
+export async function fetchLandlordAnalyticsAlerts(params?: {
+  period?: AnalyticsPeriod;
+  propertyId?: string | null;
+  status?: AnalyticsAlertStatus;
+}): Promise<LandlordAnalyticsAlertsResponse> {
+  const search = new URLSearchParams();
+  if (params?.period) search.set("period", params.period);
+  if (params?.propertyId) search.set("propertyId", params.propertyId);
+  if (params?.status) search.set("status", params.status);
+  const suffix = search.toString() ? `?${search.toString()}` : "";
+  return await apiFetch<LandlordAnalyticsAlertsResponse>(`/landlord/analytics/alerts${suffix}`);
+}

--- a/rentchain-frontend/src/api/landlordAnalyticsApi.ts
+++ b/rentchain-frontend/src/api/landlordAnalyticsApi.ts
@@ -57,6 +57,16 @@ export type LandlordAnalyticsSnapshot = {
     averageRentPerOccupiedUnitCents: number | null;
   };
   insights: LandlordAnalyticsInsight[];
+  comparisons: {
+    previousPeriod: {
+      vacancyRate: number | null;
+      applicationConversionRate: number | null;
+      applicationsStarted: number;
+      applicationsSubmitted: number;
+      maintenanceCostCents: number;
+      openWorkOrders: number;
+    };
+  };
   properties: Array<{
     id: string;
     name: string;

--- a/rentchain-frontend/src/components/analytics/AnalyticsAlertsPanel.test.tsx
+++ b/rentchain-frontend/src/components/analytics/AnalyticsAlertsPanel.test.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import AnalyticsAlertsPanel from "./AnalyticsAlertsPanel";
+
+describe("AnalyticsAlertsPanel", () => {
+  it("renders alert severity and action links", () => {
+    render(
+      <MemoryRouter>
+        <AnalyticsAlertsPanel
+          summary={{ activeCount: 1, highSeverityCount: 1, mediumSeverityCount: 0, lowSeverityCount: 0 }}
+          alerts={[
+            {
+              id: "alert-1",
+              type: "high_vacancy",
+              severity: "high",
+              status: "active",
+              title: "Vacancy is elevated",
+              message: "Vacancy is 25% in the current view.",
+              detectedAt: "2026-04-20T00:00:00.000Z",
+              lastEvaluatedAt: "2026-04-20T00:00:00.000Z",
+              notification: { inAppEligible: true, emailEligible: true, automationEligible: false },
+              actions: [{ type: "view_analytics", label: "View analytics", href: "/analytics" }],
+            },
+          ]}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/Vacancy is elevated/i)).toBeInTheDocument();
+    expect(screen.getByText(/1 active alerts/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /View analytics/i })).toHaveAttribute("href", "/analytics");
+  });
+
+  it("renders a calm empty state", () => {
+    render(
+      <MemoryRouter>
+        <AnalyticsAlertsPanel
+          summary={{ activeCount: 0, highSeverityCount: 0, mediumSeverityCount: 0, lowSeverityCount: 0 }}
+          alerts={[]}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/No analytics alerts right now/i)).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/analytics/AnalyticsAlertsPanel.tsx
+++ b/rentchain-frontend/src/components/analytics/AnalyticsAlertsPanel.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import type { AnalyticsAlert } from "@/api/landlordAnalyticsAlertsApi";
+import { Card } from "../ui/Ui";
+
+const severityColors: Record<AnalyticsAlert["severity"], { bg: string; text: string }> = {
+  low: { bg: "rgba(14, 165, 233, 0.12)", text: "#075985" },
+  medium: { bg: "rgba(245, 158, 11, 0.14)", text: "#92400e" },
+  high: { bg: "rgba(239, 68, 68, 0.12)", text: "#991b1b" },
+};
+
+type Props = {
+  alerts: AnalyticsAlert[];
+  summary?: {
+    activeCount: number;
+    highSeverityCount: number;
+    mediumSeverityCount: number;
+    lowSeverityCount: number;
+  } | null;
+};
+
+export function AnalyticsAlertsPanel({ alerts, summary }: Props) {
+  return (
+    <Card>
+      <div style={{ display: "grid", gap: 12 }}>
+        <div style={{ display: "grid", gap: 4 }}>
+          <h2 style={{ margin: 0, fontSize: "1.05rem" }}>Analytics alerts</h2>
+          <div style={{ color: "#475569" }}>
+            Focused portfolio conditions that need attention now.
+          </div>
+        </div>
+
+        {summary ? (
+          <div style={{ color: "#64748b", fontSize: "0.9rem" }}>
+            {summary.activeCount} active alerts
+            {summary.highSeverityCount ? ` · ${summary.highSeverityCount} high` : ""}
+            {summary.mediumSeverityCount ? ` · ${summary.mediumSeverityCount} medium` : ""}
+            {summary.lowSeverityCount ? ` · ${summary.lowSeverityCount} low` : ""}
+          </div>
+        ) : null}
+
+        {alerts.length === 0 ? (
+          <div style={{ color: "#64748b" }}>No analytics alerts right now.</div>
+        ) : (
+          <div style={{ display: "grid", gap: 10 }}>
+            {alerts.map((alert) => (
+              <div
+                key={alert.id}
+                style={{
+                  border: "1px solid #e2e8f0",
+                  borderRadius: 12,
+                  padding: 14,
+                  display: "grid",
+                  gap: 8,
+                  background: "#fff",
+                }}
+              >
+                <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "center", flexWrap: "wrap" }}>
+                  <div style={{ display: "grid", gap: 4 }}>
+                    <div style={{ fontWeight: 700, color: "#0f172a" }}>{alert.title}</div>
+                    <div style={{ color: "#475569" }}>{alert.message}</div>
+                  </div>
+                  <div
+                    style={{
+                      padding: "5px 10px",
+                      borderRadius: 999,
+                      background: severityColors[alert.severity].bg,
+                      color: severityColors[alert.severity].text,
+                      fontWeight: 700,
+                      fontSize: "0.78rem",
+                      textTransform: "uppercase",
+                    }}
+                  >
+                    {alert.severity}
+                  </div>
+                </div>
+                {alert.actions?.length ? (
+                  <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+                    {alert.actions.map((action) =>
+                      action.href ? (
+                        <Link key={`${alert.id}-${action.type}`} to={action.href} style={{ color: "#2563eb", fontWeight: 600 }}>
+                          {action.label}
+                        </Link>
+                      ) : (
+                        <span key={`${alert.id}-${action.type}`} style={{ color: "#2563eb", fontWeight: 600 }}>
+                          {action.label}
+                        </span>
+                      )
+                    )}
+                  </div>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+export default AnalyticsAlertsPanel;

--- a/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.test.tsx
@@ -5,9 +5,14 @@ import { MemoryRouter } from "react-router-dom";
 import LandlordAnalyticsPage from "./LandlordAnalyticsPage";
 
 const showToast = vi.fn();
+const macShellSpy = vi.fn();
 
 vi.mock("../../api/landlordAnalyticsApi", () => ({
   fetchLandlordAnalyticsSnapshot: vi.fn(),
+}));
+
+vi.mock("../../api/landlordAnalyticsAlertsApi", () => ({
+  fetchLandlordAnalyticsAlerts: vi.fn(),
 }));
 
 vi.mock("@/hooks/useEntitlements", () => ({
@@ -19,7 +24,10 @@ vi.mock("../../components/ui/ToastProvider", () => ({
 }));
 
 vi.mock("../../components/layout/MacShell", () => ({
-  MacShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  MacShell: ({ children, ...props }: { children: React.ReactNode }) => {
+    macShellSpy(props);
+    return <div>{children}</div>;
+  },
 }));
 
 vi.mock("../../components/ui/Ui", () => ({
@@ -38,6 +46,7 @@ vi.mock("@/components/billing/FeatureTeaser", () => ({
 
 beforeEach(() => {
   showToast.mockReset();
+  macShellSpy.mockReset();
   vi.clearAllMocks();
 });
 
@@ -61,6 +70,7 @@ describe("LandlordAnalyticsPage", () => {
 
   async function mockApiResolved() {
     const { fetchLandlordAnalyticsSnapshot } = await import("../../api/landlordAnalyticsApi");
+    const { fetchLandlordAnalyticsAlerts } = await import("../../api/landlordAnalyticsAlertsApi");
     vi.mocked(fetchLandlordAnalyticsSnapshot).mockResolvedValue({
       summary: {
         occupiedUnits: 4,
@@ -105,6 +115,16 @@ describe("LandlordAnalyticsPage", () => {
         averageRentPerOccupiedUnitCents: 165000,
       },
       insights: [{ type: "lease_expiry", severity: "medium", message: "1 lease ends within 30 days." }],
+      comparisons: {
+        previousPeriod: {
+          vacancyRate: 0.1,
+          applicationConversionRate: 0.4,
+          applicationsStarted: 3,
+          applicationsSubmitted: 3,
+          maintenanceCostCents: 5000,
+          openWorkOrders: 1,
+        },
+      },
       properties: [
         { id: "prop-1", name: "Alpha" },
         { id: "prop-2", name: "Beta" },
@@ -114,6 +134,33 @@ describe("LandlordAnalyticsPage", () => {
         propertyId: null,
         from: "2026-01-20T00:00:00.000Z",
         to: "2026-04-20T00:00:00.000Z",
+      },
+    } as any);
+    vi.mocked(fetchLandlordAnalyticsAlerts).mockResolvedValue({
+      summary: {
+        activeCount: 2,
+        highSeverityCount: 1,
+        mediumSeverityCount: 1,
+        lowSeverityCount: 0,
+      },
+      alerts: [
+        {
+          id: "alert-1",
+          type: "lease_expiry",
+          severity: "medium",
+          status: "active",
+          title: "Leases ending soon",
+          message: "1 lease ends within 30 days.",
+          detectedAt: "2026-04-20T00:00:00.000Z",
+          lastEvaluatedAt: "2026-04-20T00:00:00.000Z",
+          notification: { inAppEligible: true, emailEligible: true, automationEligible: false },
+          actions: [{ type: "review_leases", label: "Review leases", href: "/portfolio-health" }],
+        },
+      ],
+      filters: {
+        period: "90d",
+        propertyId: null,
+        status: "active",
       },
     } as any);
 
@@ -130,16 +177,19 @@ describe("LandlordAnalyticsPage", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText(/Attention-worthy insights/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Analytics alerts/i)).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /Applications/i })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /Revenue signal/i })).toBeInTheDocument();
-    expect(screen.getByText(/1 lease ends within 30 days/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Review leases/i })).toHaveAttribute("href", "/portfolio-health");
+    expect(macShellSpy).toHaveBeenCalledWith(expect.objectContaining({ title: "Analytics", showTopNav: false }));
   });
 
   it("shows a loading state while analytics are being fetched", async () => {
     await mockEntitlements();
     const { fetchLandlordAnalyticsSnapshot } = await import("../../api/landlordAnalyticsApi");
+    const { fetchLandlordAnalyticsAlerts } = await import("../../api/landlordAnalyticsAlertsApi");
     vi.mocked(fetchLandlordAnalyticsSnapshot).mockReturnValue(new Promise(() => {}) as any);
+    vi.mocked(fetchLandlordAnalyticsAlerts).mockReturnValue(new Promise(() => {}) as any);
 
     render(
       <MemoryRouter>
@@ -153,6 +203,7 @@ describe("LandlordAnalyticsPage", () => {
   it("renders a useful empty-state message for sparse portfolios", async () => {
     await mockEntitlements();
     const { fetchLandlordAnalyticsSnapshot } = await import("../../api/landlordAnalyticsApi");
+    const { fetchLandlordAnalyticsAlerts } = await import("../../api/landlordAnalyticsAlertsApi");
     vi.mocked(fetchLandlordAnalyticsSnapshot).mockResolvedValue({
       summary: {
         occupiedUnits: 0,
@@ -197,12 +248,36 @@ describe("LandlordAnalyticsPage", () => {
         averageRentPerOccupiedUnitCents: null,
       },
       insights: [],
+      comparisons: {
+        previousPeriod: {
+          vacancyRate: null,
+          applicationConversionRate: null,
+          applicationsStarted: 0,
+          applicationsSubmitted: 0,
+          maintenanceCostCents: 0,
+          openWorkOrders: 0,
+        },
+      },
       properties: [],
       filters: {
         period: "90d",
         propertyId: null,
         from: "2026-01-20T00:00:00.000Z",
         to: "2026-04-20T00:00:00.000Z",
+      },
+    } as any);
+    vi.mocked(fetchLandlordAnalyticsAlerts).mockResolvedValue({
+      summary: {
+        activeCount: 0,
+        highSeverityCount: 0,
+        mediumSeverityCount: 0,
+        lowSeverityCount: 0,
+      },
+      alerts: [],
+      filters: {
+        period: "90d",
+        propertyId: null,
+        status: "active",
       },
     } as any);
 
@@ -220,7 +295,22 @@ describe("LandlordAnalyticsPage", () => {
   it("renders an error state cleanly", async () => {
     await mockEntitlements();
     const { fetchLandlordAnalyticsSnapshot } = await import("../../api/landlordAnalyticsApi");
+    const { fetchLandlordAnalyticsAlerts } = await import("../../api/landlordAnalyticsAlertsApi");
     vi.mocked(fetchLandlordAnalyticsSnapshot).mockRejectedValue(new Error("Boom"));
+    vi.mocked(fetchLandlordAnalyticsAlerts).mockResolvedValue({
+      summary: {
+        activeCount: 0,
+        highSeverityCount: 0,
+        mediumSeverityCount: 0,
+        lowSeverityCount: 0,
+      },
+      alerts: [],
+      filters: {
+        period: "90d",
+        propertyId: null,
+        status: "active",
+      },
+    } as any);
 
     render(
       <MemoryRouter>
@@ -234,6 +324,7 @@ describe("LandlordAnalyticsPage", () => {
   it("re-fetches when filters change", async () => {
     await mockEntitlements();
     const fetchLandlordAnalyticsSnapshot = await mockApiResolved();
+    const { fetchLandlordAnalyticsAlerts } = await import("../../api/landlordAnalyticsAlertsApi");
 
     render(
       <MemoryRouter>
@@ -241,13 +332,19 @@ describe("LandlordAnalyticsPage", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText(/Attention-worthy insights/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Analytics alerts/i)).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText(/Analytics period/i), { target: { value: "30d" } });
     fireEvent.change(screen.getByLabelText(/Analytics property/i), { target: { value: "prop-2" } });
 
     expect(fetchLandlordAnalyticsSnapshot).toHaveBeenCalledWith({ period: "30d", propertyId: null });
     expect(fetchLandlordAnalyticsSnapshot).toHaveBeenLastCalledWith({ period: "30d", propertyId: "prop-2" });
+    expect(vi.mocked(fetchLandlordAnalyticsAlerts)).toHaveBeenCalledWith({ period: "30d", propertyId: null, status: "active" });
+    expect(vi.mocked(fetchLandlordAnalyticsAlerts)).toHaveBeenLastCalledWith({
+      period: "30d",
+      propertyId: "prop-2",
+      status: "active",
+    });
   });
 
   it("shows upgrade guidance when deeper analytics are unavailable", async () => {

--- a/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.tsx
@@ -1,10 +1,15 @@
 import React from "react";
 import { fetchLandlordAnalyticsSnapshot, type AnalyticsPeriod, type LandlordAnalyticsSnapshot } from "../../api/landlordAnalyticsApi";
+import {
+  fetchLandlordAnalyticsAlerts,
+  type LandlordAnalyticsAlertsResponse,
+} from "../../api/landlordAnalyticsAlertsApi";
 import { MacShell } from "../../components/layout/MacShell";
 import { Card, Section } from "../../components/ui/Ui";
 import { useToast } from "../../components/ui/ToastProvider";
 import { useEntitlements } from "@/hooks/useEntitlements";
 import { FeatureTeaser } from "@/components/billing/FeatureTeaser";
+import AnalyticsAlertsPanel from "../../components/analytics/AnalyticsAlertsPanel";
 import AnalyticsFiltersBar from "../../components/analytics/AnalyticsFiltersBar";
 import AnalyticsKpiGrid from "../../components/analytics/AnalyticsKpiGrid";
 import AnalyticsSectionPanel from "../../components/analytics/AnalyticsSectionPanel";
@@ -25,6 +30,7 @@ function formatCurrency(cents: number | null | undefined) {
 function useAnalyticsState(enabled: boolean, period: AnalyticsPeriod, propertyId: string) {
   const { showToast } = useToast();
   const [snapshot, setSnapshot] = React.useState<LandlordAnalyticsSnapshot | null>(null);
+  const [alerts, setAlerts] = React.useState<LandlordAnalyticsAlertsResponse | null>(null);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
 
@@ -39,12 +45,20 @@ function useAnalyticsState(enabled: boolean, period: AnalyticsPeriod, propertyId
       try {
         setLoading(true);
         setError(null);
-        const response = await fetchLandlordAnalyticsSnapshot({
-          period,
-          propertyId: propertyId || null,
-        });
+        const [analyticsResponse, alertsResponse] = await Promise.all([
+          fetchLandlordAnalyticsSnapshot({
+            period,
+            propertyId: propertyId || null,
+          }),
+          fetchLandlordAnalyticsAlerts({
+            period,
+            propertyId: propertyId || null,
+            status: "active",
+          }),
+        ]);
         if (!mounted) return;
-        setSnapshot(response);
+        setSnapshot(analyticsResponse);
+        setAlerts(alertsResponse);
       } catch (err: any) {
         if (!mounted) return;
         const message = err?.message || "Failed to load analytics";
@@ -64,7 +78,7 @@ function useAnalyticsState(enabled: boolean, period: AnalyticsPeriod, propertyId
     };
   }, [enabled, period, propertyId, showToast]);
 
-  return { snapshot, loading, error };
+  return { snapshot, alerts, loading, error };
 }
 
 export default function LandlordAnalyticsPage() {
@@ -78,7 +92,7 @@ export default function LandlordAnalyticsPage() {
   const [propertyId, setPropertyId] = React.useState("");
   const analyticsEnabled = !entitlementLoading && canViewPortfolioHealthSummary;
   const canViewAdvancedAnalytics = hasCapability("portfolio_analytics");
-  const { snapshot, loading, error } = useAnalyticsState(analyticsEnabled, period, propertyId);
+  const { snapshot, alerts, loading, error } = useAnalyticsState(analyticsEnabled, period, propertyId);
 
   const summaryItems = snapshot
     ? [
@@ -116,7 +130,7 @@ export default function LandlordAnalyticsPage() {
     : [];
 
   return (
-    <MacShell title="Analytics">
+    <MacShell title="Analytics" showTopNav={false}>
       <div style={{ display: "grid", gap: 16 }}>
         <Section>
           <div style={{ display: "grid", gap: 6 }}>
@@ -150,6 +164,7 @@ export default function LandlordAnalyticsPage() {
 
         {analyticsEnabled && !loading && !error && snapshot ? (
           <>
+            <AnalyticsAlertsPanel alerts={alerts?.alerts || []} summary={alerts?.summary || null} />
             <AnalyticsKpiGrid items={summaryItems} />
 
             {canViewPortfolioScore ? (


### PR DESCRIPTION
## Summary

Adds Analytics Alerts Engine v1 on top of the existing landlord analytics foundation.

This introduces deterministic, notification-ready landlord analytics alerts derived from the current analytics snapshot and insight layer, exposes them through a new landlord-safe backend route, and surfaces them in the landlord `/analytics` page.

It also fixes the duplicate top navigation/header issue on `/analytics` so the page now uses the standard landlord layout shell only once.

## What Changed

- Added a reusable backend analytics alerts model and derivation layer
- Added `GET /api/landlord/analytics/alerts`
- Reused the current landlord analytics snapshot instead of duplicating metric calculations
- Added a landlord analytics alerts panel to the `/analytics` page
- Extended the landlord analytics snapshot with prior-period comparison fields needed for deterministic alert rules
- Fixed the duplicate `/analytics` top bar by suppressing the extra `MacShell` top nav while preserving the page title/content header

## Alert Types Included

- `lease_expiry`
- `high_vacancy`
- `vacancy_increase`
- `low_application_activity`
- `application_drop`
- `application_conversion_drop`
- `maintenance_cost_spike`
- `work_order_concentration`

## Verification

### Backend
- targeted analytics alerts/helper/service/route tests
- backend build

### Frontend
- targeted analytics alerts panel and landlord analytics page tests
- frontend build

## Notes

This is a computed-on-read v1 alerting layer. It is deterministic, landlord-safe, and structured for future in-app notifications, email delivery, automation, and agent actions without introducing a second analytics or notification system.