### PR TITLE
feat: add conversation engine dashboard and wrapper commands v1

### DIFF
--- a/tools/conversation_engine/ce.py
+++ b/tools/conversation_engine/ce.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+import textwrap
+
+
+THIS_DIR = pathlib.Path(__file__).resolve().parent
+if str(THIS_DIR) not in sys.path:
+    sys.path.insert(0, str(THIS_DIR))
+
+import v2
+
+
+def resolve_run_id(store: v2.RunStore, explicit_run_id: str | None) -> str:
+    if explicit_run_id:
+        return explicit_run_id
+    latest = store.latest_run_id()
+    if not latest:
+        raise v2.EngineError("No conversation_engine runs exist yet.")
+    return latest
+
+
+def render_status(repo: v2.Repo, store: v2.RunStore, state: v2.RunState) -> str:
+    artifacts = v2.run_artifact_paths(store, state)
+    artifact_lines = [
+        f"- mission: {'yes' if artifacts['mission'].exists() else 'no'}",
+        f"- codex audit prompt: {'yes' if artifacts['codex_audit_prompt'].exists() else 'no'}",
+        f"- chatgpt review prompt: {'yes' if artifacts['chatgpt_review_prompt'].exists() else 'no'}",
+        f"- codex implementation prompt: {'yes' if artifacts['codex_implementation_prompt'].exists() else 'no'}",
+        f"- chatgpt implementation review prompt: {'yes' if artifacts['chatgpt_implementation_review_prompt'].exists() else 'no'}",
+        f"- codex commit prompt: {'yes' if artifacts['codex_commit_prompt'].exists() else 'no'}",
+        f"- final summary: {'yes' if artifacts['final_summary'].exists() else 'no'}",
+    ]
+
+    return textwrap.dedent(
+        f"""
+        Conversation Engine Status
+
+        - Run ID: {state.run_id}
+        - Mission: {state.mission_title}
+        - Mission file: {state.mission_file}
+        - Current branch: {repo.current_branch()}
+        - Expected branch: {state.expected_branch}
+        - Branch verified: {state.mission_branch_verified}
+        - Current stage: {state.current_stage}
+        - Decision: {state.decision}
+        - Worktree clean: {'yes' if repo.is_clean() else 'no'}
+        - Latest audit: {artifacts['latest_audit']}
+
+        Artifact presence:
+        {chr(10).join(artifact_lines)}
+
+        Next step:
+        - {v2.next_step_hint(state)}
+        """
+    ).strip() + "\n"
+
+
+def mission_template(mission_title: str, branch: str, objective: str | None) -> str:
+    objective_text = objective.strip() if objective else "<One-paragraph summary of the intended workflow improvement>"
+    return textwrap.dedent(
+        f"""
+        MISSION: {mission_title}
+
+        BRANCH:
+        {branch}
+
+        ## Objective
+        {objective_text}
+
+        ## Required read order
+        1. AGENTS.md
+        2. PROCESS.md
+        3. codex.md
+        4. docs/execution/CURRENT_MISSION.md if present
+        5. Relevant mission examples in docs/missions/
+        6. Then inspect the code directly relevant to this mission
+
+        ## Context
+        - <List the existing system this mission extends>
+
+        ## In scope
+        - <scoped item>
+        - <scoped item>
+        - additive implementation only
+
+        ## Out of scope
+        - <out-of-scope item>
+        - <out-of-scope item>
+        - removing approval gates
+
+        ## Acceptance criteria
+        - implementation exists
+        - workflow remains explicit and review-gated
+        - tests/builds pass
+        """
+    ).strip() + "\n"
+
+
+def cmd_ce_new(args: argparse.Namespace) -> int:
+    repo = v2.Repo()
+    repo_root = pathlib.Path(repo.repo_root())
+    output = pathlib.Path(args.output) if args.output else repo_root / "docs" / "missions" / f"mission-{v2.slugify(args.mission_title)}.md"
+    if output.exists() and not args.force:
+        raise v2.EngineError(f"Mission file already exists: {output}")
+
+    content = mission_template(args.mission_title, args.branch, args.objective)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(content, encoding="utf-8")
+
+    print(output)
+    print(f"Next step: python tools/conversation_engine/ce.py ce-start --mission-file {output}")
+    return 0
+
+
+def cmd_ce_start(args: argparse.Namespace) -> int:
+    repo = v2.Repo()
+    store = v2.RunStore(repo.repo_root())
+    before = store.latest_run_id()
+    v2.cmd_start(argparse.Namespace(mission_file=args.mission_file))
+    after = store.latest_run_id()
+    run_id = after
+    if run_id is None or run_id == before and before is None:
+        raise v2.EngineError("Unable to determine newly created run id.")
+
+    v2.cmd_make_codex_audit_prompt(argparse.Namespace(run_id=run_id))
+    state = store.load_state(run_id)
+    prompt_path = store.run_dir(run_id) / "prompts" / "codex_audit_prompt.txt"
+
+    print(f"Run ID: {run_id}")
+    print(f"Codex audit prompt: {prompt_path}")
+    print(f"Next step: {v2.next_step_hint(state)}")
+    return 0
+
+
+def cmd_ce_status(args: argparse.Namespace) -> int:
+    repo = v2.Repo()
+    store = v2.RunStore(repo.repo_root())
+    run_id = resolve_run_id(store, args.run_id)
+    state = store.load_state(run_id)
+    print(render_status(repo, store, state), end="")
+    return 0
+
+
+def cmd_ce_next(args: argparse.Namespace) -> int:
+    repo = v2.Repo()
+    store = v2.RunStore(repo.repo_root())
+    run_id = resolve_run_id(store, args.run_id)
+    state = store.load_state(run_id)
+    print(v2.next_step_hint(state))
+    return 0
+
+
+def cmd_ce_apply_codex_audit(args: argparse.Namespace) -> int:
+    repo = v2.Repo()
+    store = v2.RunStore(repo.repo_root())
+    run_id = resolve_run_id(store, args.run_id)
+    v2.cmd_apply_codex_audit(argparse.Namespace(run_id=run_id, response_file=args.response_file))
+    v2.cmd_make_chatgpt_review_prompt(argparse.Namespace(run_id=run_id))
+    state = store.load_state(run_id)
+    prompt_path = store.run_dir(run_id) / "prompts" / "chatgpt_review_prompt.txt"
+
+    print(f"ChatGPT review prompt: {prompt_path}")
+    print(f"Next step: {v2.next_step_hint(state)}")
+    return 0
+
+
+def cmd_ce_apply_chatgpt_review(args: argparse.Namespace) -> int:
+    repo = v2.Repo()
+    store = v2.RunStore(repo.repo_root())
+    run_id = resolve_run_id(store, args.run_id)
+    v2.cmd_apply_chatgpt_review(argparse.Namespace(run_id=run_id, review_file=args.review_file))
+    state = store.load_state(run_id)
+
+    if state.decision == "approve_to_implement":
+        v2.cmd_make_codex_implementation_prompt(argparse.Namespace(run_id=run_id))
+        state = store.load_state(run_id)
+        prompt_path = store.run_dir(run_id) / "prompts" / "codex_implementation_prompt.txt"
+        print(f"Codex implementation prompt: {prompt_path}")
+    else:
+        print(f"Decision: {state.decision}")
+
+    print(f"Next step: {v2.next_step_hint(state)}")
+    return 0
+
+
+def cmd_ce_apply_codex_implementation(args: argparse.Namespace) -> int:
+    repo = v2.Repo()
+    store = v2.RunStore(repo.repo_root())
+    run_id = resolve_run_id(store, args.run_id)
+    v2.cmd_apply_codex_implementation(argparse.Namespace(run_id=run_id, response_file=args.response_file))
+    v2.cmd_make_chatgpt_implementation_review_prompt(argparse.Namespace(run_id=run_id))
+    state = store.load_state(run_id)
+    prompt_path = store.run_dir(run_id) / "prompts" / "chatgpt_implementation_review_prompt.txt"
+
+    print(f"ChatGPT implementation review prompt: {prompt_path}")
+    print(f"Next step: {v2.next_step_hint(state)}")
+    return 0
+
+
+def cmd_ce_finalize(args: argparse.Namespace) -> int:
+    repo = v2.Repo()
+    store = v2.RunStore(repo.repo_root())
+    run_id = resolve_run_id(store, args.run_id)
+    v2.cmd_finalize_summary(argparse.Namespace(run_id=run_id))
+    state = store.load_state(run_id)
+    artifacts = v2.run_artifact_paths(store, state)
+
+    print(f"Final summary: {artifacts['final_summary']}")
+    print(f"Latest audit: {artifacts['latest_audit']}")
+    print(f"Next step: {v2.next_step_hint(state)}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Conversation Engine wrapper CLI")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    ce_new = sub.add_parser("ce-new", help="Create a parser-safe mission file")
+    ce_new.add_argument("--mission-title", required=True)
+    ce_new.add_argument("--branch", required=True)
+    ce_new.add_argument("--objective")
+    ce_new.add_argument("--output")
+    ce_new.add_argument("--force", action="store_true")
+    ce_new.set_defaults(func=cmd_ce_new)
+
+    ce_start = sub.add_parser("ce-start", help="Create a run and generate the first Codex audit prompt")
+    ce_start.add_argument("--mission-file", required=True)
+    ce_start.set_defaults(func=cmd_ce_start)
+
+    ce_status = sub.add_parser("ce-status", help="Show dashboard-style run status")
+    ce_status.add_argument("--run-id")
+    ce_status.set_defaults(func=cmd_ce_status)
+
+    ce_next = sub.add_parser("ce-next", help="Print the next safe advisory step")
+    ce_next.add_argument("--run-id")
+    ce_next.set_defaults(func=cmd_ce_next)
+
+    ce_apply_codex_audit = sub.add_parser("ce-apply-codex-audit", help="Apply Codex audit and generate ChatGPT review prompt")
+    ce_apply_codex_audit.add_argument("--run-id")
+    ce_apply_codex_audit.add_argument("--response-file", required=True)
+    ce_apply_codex_audit.set_defaults(func=cmd_ce_apply_codex_audit)
+
+    ce_apply_chatgpt_review = sub.add_parser(
+        "ce-apply-chatgpt-review",
+        help="Apply ChatGPT review and generate Codex implementation prompt when approved",
+    )
+    ce_apply_chatgpt_review.add_argument("--run-id")
+    ce_apply_chatgpt_review.add_argument("--review-file", required=True)
+    ce_apply_chatgpt_review.set_defaults(func=cmd_ce_apply_chatgpt_review)
+
+    ce_apply_codex_implementation = sub.add_parser(
+        "ce-apply-codex-implementation",
+        help="Apply Codex implementation and generate ChatGPT implementation review prompt",
+    )
+    ce_apply_codex_implementation.add_argument("--run-id")
+    ce_apply_codex_implementation.add_argument("--response-file", required=True)
+    ce_apply_codex_implementation.set_defaults(func=cmd_ce_apply_codex_implementation)
+
+    ce_finalize = sub.add_parser("ce-finalize", help="Finalize the run and print summary paths")
+    ce_finalize.add_argument("--run-id")
+    ce_finalize.set_defaults(func=cmd_ce_finalize)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args_list = list(argv if argv is not None else sys.argv[1:])
+
+    if not args_list:
+        invoked_as = pathlib.Path(sys.argv[0]).name
+        if invoked_as.startswith("ce-"):
+            args_list = [invoked_as]
+
+    args = parser.parse_args(args_list)
+    try:
+        return int(args.func(args))
+    except v2.EngineError as exc:
+        print(f"Engine error: {exc}", file=sys.stderr)
+        return 1
+    except KeyboardInterrupt:
+        print("Interrupted.", file=sys.stderr)
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/conversation_engine/test_v2.py
+++ b/tools/conversation_engine/test_v2.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+TEST_DIR = pathlib.Path(__file__).resolve().parent
+if str(TEST_DIR) not in os.sys.path:
+    os.sys.path.insert(0, str(TEST_DIR))
+
+import ce
+import v2
+
+
+class ConversationEngineWrapperTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.mkdtemp(prefix="ce-tests-")
+        self.old_cwd = os.getcwd()
+        os.chdir(self.temp_dir)
+        subprocess.run(["git", "init"], check=True, capture_output=True, text=True)
+        subprocess.run(["git", "checkout", "-b", "feat/test-mission"], check=True, capture_output=True, text=True)
+        subprocess.run(["git", "config", "user.email", "ce@example.com"], check=True, capture_output=True, text=True)
+        subprocess.run(["git", "config", "user.name", "Conversation Engine"], check=True, capture_output=True, text=True)
+        pathlib.Path("README.md").write_text("test repo\n", encoding="utf-8")
+        subprocess.run(["git", "add", "README.md"], check=True, capture_output=True, text=True)
+        subprocess.run(["git", "commit", "-m", "init"], check=True, capture_output=True, text=True)
+
+    def tearDown(self) -> None:
+        os.chdir(self.old_cwd)
+        shutil.rmtree(self.temp_dir)
+
+    def write_file(self, path: str, content: str) -> pathlib.Path:
+        file_path = pathlib.Path(path)
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_text(content, encoding="utf-8")
+        return file_path
+
+    def latest_run_id(self) -> str:
+        store = v2.RunStore(self.temp_dir)
+        run_id = store.latest_run_id()
+        self.assertIsNotNone(run_id)
+        return run_id or ""
+
+    def load_state(self, run_id: str) -> v2.RunState:
+        store = v2.RunStore(self.temp_dir)
+        return store.load_state(run_id)
+
+    def test_mission_template_is_parser_safe(self) -> None:
+        content = ce.mission_template(
+            "Conversation Engine Dashboard + Wrapper Commands v1",
+            "feat/conversation-engine-dashboard-wrapper-commands-v1",
+            "Improve workflow ergonomics without changing approval gates.",
+        )
+        self.assertEqual(v2.extract_mission_title(content, "ignored.md"), "Conversation Engine Dashboard + Wrapper Commands v1")
+        self.assertEqual(v2.extract_branch(content), "feat/conversation-engine-dashboard-wrapper-commands-v1")
+
+    def test_status_renders_run_summary_and_next_step(self) -> None:
+        mission_file = self.write_file(
+            "docs/missions/mission-test.md",
+            ce.mission_template("Test Mission", "feat/test-mission", "Test objective"),
+        )
+        v2.cmd_start(argparse.Namespace(mission_file=str(mission_file)))
+        run_id = self.latest_run_id()
+        store = v2.RunStore(self.temp_dir)
+        state = store.load_state(run_id)
+        repo = v2.Repo()
+
+        rendered = ce.render_status(repo, store, state)
+        self.assertIn("Conversation Engine Status", rendered)
+        self.assertIn("Run ID: ", rendered)
+        self.assertIn("Current stage: started", rendered)
+        self.assertIn("Next step:", rendered)
+        self.assertIn("make-codex-audit-prompt", rendered)
+
+    def test_next_step_is_advisory_for_commit_ready_stage(self) -> None:
+        state = v2.RunState(
+            state_version=2,
+            run_id="run-1",
+            created_at="2026-01-01T00:00:00+00:00",
+            updated_at="2026-01-01T00:00:00+00:00",
+            mission_file="docs/missions/mission-test.md",
+            mission_title="Test Mission",
+            expected_branch="feat/test-mission",
+            current_stage="approved_for_commit",
+            repo_root=self.temp_dir,
+            mission_branch_verified=True,
+            decision="approve_to_commit",
+        )
+        hint = v2.next_step_hint(state)
+        self.assertIn("make-codex-commit-prompt", hint)
+        self.assertNotIn("Saved", hint)
+
+    def test_wrapper_flow_preserves_stage_semantics_and_latest_audit(self) -> None:
+        mission_file = self.write_file(
+            "docs/missions/mission-test.md",
+            ce.mission_template("Test Mission", "feat/test-mission", "Test objective"),
+        )
+
+        ce.cmd_ce_start(argparse.Namespace(mission_file=str(mission_file)))
+        run_id = self.latest_run_id()
+        state = self.load_state(run_id)
+        self.assertEqual(state.current_stage, "codex_audit_prompt_ready")
+
+        audit_response = self.write_file(
+            "responses/codex_audit.txt",
+            "\n".join(
+                [
+                    "1. current system structure relevant to this mission",
+                    "",
+                    "4. exact files to modify",
+                    "- `tools/conversation_engine/v2.py`",
+                    "",
+                    "5. risks",
+                    "None.",
+                    "",
+                    "6. implementation plan",
+                    "- Add wrapper commands.",
+                ]
+            ),
+        )
+        ce.cmd_ce_apply_codex_audit(argparse.Namespace(run_id=run_id, response_file=str(audit_response)))
+        state = self.load_state(run_id)
+        self.assertEqual(state.current_stage, "chatgpt_review_prompt_ready")
+        latest_audit = pathlib.Path(".conversation_engine/latest_audit.txt")
+        self.assertTrue(latest_audit.exists())
+        self.assertIn(run_id, latest_audit.read_text(encoding="utf-8"))
+
+        review_response = self.write_file(
+            "responses/chatgpt_review.txt",
+            "\n".join(
+                [
+                    "1. What Codex got right",
+                    "- preserved the state machine",
+                    "",
+                    "2. Risks or concerns",
+                    "- none",
+                    "",
+                    "3. Review decision",
+                    "APPROVED TO PROCEED WITH IMPLEMENTATION",
+                    "",
+                    "4. Exact instruction block to send back to Codex",
+                    "- proceed",
+                ]
+            ),
+        )
+        ce.cmd_ce_apply_chatgpt_review(argparse.Namespace(run_id=run_id, review_file=str(review_response)))
+        state = self.load_state(run_id)
+        self.assertEqual(state.current_stage, "codex_implementation_prompt_ready")
+        self.assertEqual(state.decision, "approve_to_implement")
+
+        implementation_response = self.write_file(
+            "responses/codex_implementation.txt",
+            "\n".join(
+                [
+                    "**Files Changed**",
+                    "- `tools/conversation_engine/v2.py`",
+                    "- `tools/conversation_engine/ce.py`",
+                    "",
+                    "**Test / Build Results**",
+                    "- python3 -m unittest discover -s tools/conversation_engine -p 'test_*.py'",
+                    "",
+                    "**Known Risks**",
+                    "- minimal",
+                ]
+            ),
+        )
+        ce.cmd_ce_apply_codex_implementation(
+            argparse.Namespace(run_id=run_id, response_file=str(implementation_response))
+        )
+        state = self.load_state(run_id)
+        self.assertEqual(state.current_stage, "chatgpt_implementation_review_prompt_ready")
+        self.assertTrue((pathlib.Path(".conversation_engine/latest_audit.txt")).exists())
+
+        ce.cmd_ce_finalize(argparse.Namespace(run_id=run_id))
+        state = self.load_state(run_id)
+        self.assertEqual(state.current_stage, "finalized")
+        self.assertTrue((pathlib.Path(".conversation_engine/runs") / run_id / "final_summary.md").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/conversation_engine/v2.py
+++ b/tools/conversation_engine/v2.py
@@ -166,6 +166,15 @@ class RunStore:
             raise EngineError(f"Run not found: {run_id}")
         return RunState.from_json(json.loads(path.read_text(encoding="utf-8")))
 
+    def list_run_ids(self) -> list[str]:
+        if not self.base.exists():
+            return []
+        return sorted(path.name for path in self.base.iterdir() if path.is_dir())
+
+    def latest_run_id(self) -> str | None:
+        run_ids = self.list_run_ids()
+        return run_ids[-1] if run_ids else None
+
     def write_text(self, run_id: str, relative_path: str, content: str) -> pathlib.Path:
         path = self.run_dir(run_id) / relative_path
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -348,6 +357,93 @@ def extract_section(text: str, heading_patterns: list[str]) -> str | None:
 
     content = "\n".join(collected).strip()
     return content or None
+
+
+def run_artifact_paths(store: RunStore, state: RunState) -> dict[str, pathlib.Path]:
+    run_dir = store.run_dir(state.run_id)
+    return {
+        "mission": run_dir / "mission.md",
+        "codex_audit_prompt": run_dir / "prompts" / "codex_audit_prompt.txt",
+        "chatgpt_review_prompt": run_dir / "prompts" / "chatgpt_review_prompt.txt",
+        "codex_implementation_prompt": run_dir / "prompts" / "codex_implementation_prompt.txt",
+        "chatgpt_implementation_review_prompt": run_dir / "prompts" / "chatgpt_implementation_review_prompt.txt",
+        "codex_commit_prompt": run_dir / "prompts" / "codex_commit_prompt.txt",
+        "final_summary": run_dir / "final_summary.md",
+        "latest_audit": pathlib.Path(state.repo_root) / ".conversation_engine" / "latest_audit.txt",
+    }
+
+
+def next_step_hint(state: RunState, *, wrapper_prefix: str = "python tools/conversation_engine/ce.py") -> str:
+    run_id = state.run_id
+
+    if state.current_stage == "started":
+        return (
+            "Generate the first Codex audit prompt with "
+            f"`python tools/conversation_engine/v2.py make-codex-audit-prompt --run-id {run_id}` "
+            "or use `python tools/conversation_engine/ce.py ce-start --mission-file <path>` for the wrapper flow."
+        )
+
+    if state.current_stage == "codex_audit_prompt_ready":
+        return (
+            "Paste the Codex audit prompt into Codex, save the response, then run "
+            f"`{wrapper_prefix} ce-apply-codex-audit --run-id {run_id} --response-file <path>`."
+        )
+
+    if state.current_stage in {"codex_audit_applied", "chatgpt_review_prompt_ready"}:
+        return (
+            "Paste the ChatGPT review prompt into ChatGPT, save the response, then run "
+            f"`{wrapper_prefix} ce-apply-chatgpt-review --run-id {run_id} --review-file <path>`."
+        )
+
+    if state.current_stage == "chatgpt_review_applied":
+        if state.decision == "approve_to_implement":
+            return (
+                "Generate the Codex implementation prompt with "
+                f"`python tools/conversation_engine/v2.py make-codex-implementation-prompt --run-id {run_id}`, "
+                "then paste it into Codex."
+            )
+        if state.decision in {"needs_patch_before_implementation", "reject_scope"}:
+            return "Follow the ChatGPT review instructions manually. The run is not yet approved for implementation."
+        return "Review the ChatGPT response and confirm whether the mission is approved for implementation."
+
+    if state.current_stage == "codex_implementation_prompt_ready":
+        return (
+            "Paste the Codex implementation prompt into Codex, save the summary, then run "
+            f"`{wrapper_prefix} ce-apply-codex-implementation --run-id {run_id} --response-file <path>`."
+        )
+
+    if state.current_stage in {"codex_implementation_applied", "chatgpt_implementation_review_prompt_ready"}:
+        return (
+            "Paste the ChatGPT implementation review prompt into ChatGPT, save the response, then run "
+            f"`python tools/conversation_engine/v2.py apply-chatgpt-patch --run-id {run_id} --review-file <path>`."
+        )
+
+    if state.current_stage in {"chatgpt_patch_applied"}:
+        if state.decision == "approve_to_commit":
+            return (
+                "Generate the Codex commit prompt with "
+                f"`python tools/conversation_engine/v2.py make-codex-commit-prompt --run-id {run_id}`."
+            )
+        if state.decision in {"needs_patch_after_implementation", "reject_scope"}:
+            return "Follow the ChatGPT implementation review instructions manually before proceeding."
+        return "Review the ChatGPT implementation review outcome before proceeding."
+
+    if state.current_stage == "approved_for_commit":
+        return (
+            "Generate the Codex commit prompt with "
+            f"`python tools/conversation_engine/v2.py make-codex-commit-prompt --run-id {run_id}`."
+        )
+
+    if state.current_stage == "codex_commit_prompt_ready":
+        return (
+            "Paste the Codex commit prompt into Codex. After commit/push are complete, run "
+            f"`{wrapper_prefix} ce-finalize --run-id {run_id}`."
+        )
+
+    if state.current_stage == "finalized":
+        return "Review `final_summary.md` and `.conversation_engine/latest_audit.txt` for the final recorded state."
+
+    return "No next-step guidance is available for the current stage."
 
 
 # Helper functions for writing latest audit


### PR DESCRIPTION
## Summary
Add a small Python wrapper CLI and status/dashboard support for `conversation_engine` v2 to reduce manual operator friction without changing the existing state machine or approval gates.

## What Changed
- added `ce.py` wrapper commands for common mission steps
- added reusable status and next-step guidance on top of the existing `v2.py` run state
- added parser-safe mission creation support
- kept prompt generation and human review stages explicit
- added targeted tests for mission parsing, status output, next-step guidance, wrapper stage preservation, and `latest_audit.txt` continuity

## Notes
- no autonomous orchestration
- no skipped review gates
- no commit/push/PR automation
- existing `v2.py` commands remain the source of truth