### PR TITLE
feat: add lease renewal operator input capture v1

### DIFF
--- a/rentchain-api/src/lib/analytics/__tests__/deriveDecisionExecutionMappings.test.ts
+++ b/rentchain-api/src/lib/analytics/__tests__/deriveDecisionExecutionMappings.test.ts
@@ -185,4 +185,50 @@ describe("applyDecisionExecutionMappings", () => {
       })
     );
   });
+
+  it("promotes a lease-renewal decision to complete when canonical renewal inputs are fully stored", () => {
+    const result = applyDecisionExecutionMappings({
+      decisions: [baseDecision()],
+      leases: [
+        {
+          id: "lease-1",
+          landlordId: "landlord-1",
+          tenantId: "tenant-1",
+          propertyId: "prop-1",
+          unitId: "unit-1",
+          province: "NS",
+          leaseType: "fixed_term",
+          currentRent: 1650,
+          renewalRentChangeMode: "no_change",
+          renewalDecisionDeadlineAt: Date.UTC(2026, 4, 1, 12, 0, 0, 0),
+          renewalNewTermType: "fixed_term",
+          renewalNewLeaseStartDate: "2026-05-11",
+          renewalNewLeaseEndDate: "2027-05-10",
+          leaseEndDate: "2026-05-10",
+          status: "active",
+        },
+      ],
+      now: Date.UTC(2026, 3, 20, 12, 0, 0, 0),
+    });
+
+    expect(result[0]).toEqual(
+      expect.objectContaining({
+        executionMappingState: "mapped",
+        executionMapping: expect.objectContaining({
+          prerequisitesMet: true,
+          prerequisiteReason: null,
+        }),
+        executionInputState: "complete",
+        executionInputReason: null,
+        executionInputMissingFields: [],
+        executionInput: expect.objectContaining({
+          rentChangeMode: "no_change",
+          newTermType: "fixed_term",
+          newLeaseStartDate: "2026-05-11",
+          newLeaseEndDate: "2027-05-10",
+          responseDeadlineAt: Date.UTC(2026, 4, 1, 12, 0, 0, 0),
+        }),
+      })
+    );
+  });
 });

--- a/rentchain-api/src/routes/__tests__/leaseNoticeLandlordRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseNoticeLandlordRoutes.test.ts
@@ -64,7 +64,27 @@ vi.mock("../../config/leaseNoticeRules", () => ({
 
 const appendLeaseWorkflowEvent = vi.fn(async () => undefined);
 const buildPreview = vi.fn(async () => undefined);
+const deriveLeaseRenewalOperatorInputRecord = vi.fn((lease: any) => ({
+  rentChangeMode: lease?.renewalRentChangeMode ?? null,
+  proposedRent: lease?.renewalOfferedRent ?? null,
+  newTermType: lease?.renewalNewTermType ?? null,
+  newLeaseStartDate: lease?.renewalNewLeaseStartDate ?? null,
+  newLeaseEndDate: lease?.renewalNewLeaseEndDate ?? null,
+  responseDeadlineAt: lease?.renewalDecisionDeadlineAt ?? null,
+}));
 const lookupUserEmail = vi.fn(async () => "tenant@example.com");
+const normalizeLeaseRecord = vi.fn((id: string, raw: any) => ({ id, ...(raw || {}) }));
+const sanitizeLeaseRenewalOperatorInput = vi.fn((body: any) => ({
+  ok: true,
+  data: {
+    rentChangeMode: body?.rentChangeMode ?? null,
+    proposedRent: body?.proposedRent ?? null,
+    newTermType: body?.newTermType ?? null,
+    newLeaseStartDate: body?.newLeaseStartDate ?? null,
+    newLeaseEndDate: body?.newLeaseEndDate ?? null,
+    responseDeadlineAt: body?.responseDeadlineAt ?? null,
+  },
+}));
 const sendLeaseWorkflowEmail = vi.fn(async () => ({ ok: true }));
 const getLeaseForLandlordWorkflow = vi.fn(async () => ({
   ok: true,
@@ -85,10 +105,12 @@ vi.mock("../../services/leaseNoticeWorkflowService", () => ({
   appendLeaseWorkflowEvent,
   buildPreview,
   computeNoResponseState: vi.fn(),
+  deriveLeaseRenewalOperatorInputRecord,
   getLeaseForLandlordWorkflow,
   getLeaseNoticeByLeaseId: vi.fn(),
   lookupUserEmail,
-  normalizeLeaseRecord: vi.fn(),
+  normalizeLeaseRecord,
+  sanitizeLeaseRenewalOperatorInput,
   sendLeaseWorkflowEmail,
 }));
 
@@ -123,10 +145,26 @@ async function invokeRouter(router: any, options: { method: string; url: string;
   });
 }
 
+function readCollectionDoc(name: string, id: string) {
+  return collections.get(name)?.get(id) ?? null;
+}
+
 describe("leaseNoticeLandlordRoutes policy integration", () => {
   beforeEach(() => {
     collections.clear();
     vi.clearAllMocks();
+    normalizeLeaseRecord.mockImplementation((id: string, raw: any) => ({ id, ...(raw || {}) }));
+    sanitizeLeaseRenewalOperatorInput.mockImplementation((body: any) => ({
+      ok: true,
+      data: {
+        rentChangeMode: body?.rentChangeMode ?? null,
+        proposedRent: body?.proposedRent ?? null,
+        newTermType: body?.newTermType ?? null,
+        newLeaseStartDate: body?.newLeaseStartDate ?? null,
+        newLeaseEndDate: body?.newLeaseEndDate ?? null,
+        responseDeadlineAt: body?.responseDeadlineAt ?? null,
+      },
+    }));
     buildPreview.mockReturnValue({
       ok: true,
       rule: { noticeLeadDays: 90 },
@@ -235,6 +273,41 @@ describe("leaseNoticeLandlordRoutes policy integration", () => {
         metadata: expect.objectContaining({
           action: "lease.auto_send_notice",
         }),
+      })
+    );
+  });
+
+  it("persists renewal operator inputs canonically on the lease record", async () => {
+    const router = (await import("../leaseNoticeLandlordRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "PUT",
+      url: "/lease-1/renewal-inputs",
+      body: {
+        rentChangeMode: "no_change",
+        newTermType: "fixed_term",
+        newLeaseStartDate: "2026-07-01",
+        newLeaseEndDate: "2027-06-30",
+        responseDeadlineAt: 1700000000000,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(readCollectionDoc("leases", "lease-1")).toEqual(
+      expect.objectContaining({
+        renewalRentChangeMode: "no_change",
+        renewalNewTermType: "fixed_term",
+        renewalNewLeaseStartDate: "2026-07-01",
+        renewalNewLeaseEndDate: "2027-06-30",
+        renewalDecisionDeadlineAt: 1700000000000,
+      })
+    );
+    expect(res.body?.renewalInputs).toEqual(
+      expect.objectContaining({
+        rentChangeMode: "no_change",
+        newTermType: "fixed_term",
+        newLeaseStartDate: "2026-07-01",
+        newLeaseEndDate: "2027-06-30",
+        responseDeadlineAt: 1700000000000,
       })
     );
   });

--- a/rentchain-api/src/routes/leaseNoticeLandlordRoutes.ts
+++ b/rentchain-api/src/routes/leaseNoticeLandlordRoutes.ts
@@ -10,10 +10,12 @@ import {
   appendLeaseWorkflowEvent,
   buildPreview,
   computeNoResponseState,
+  deriveLeaseRenewalOperatorInputRecord,
   getLeaseForLandlordWorkflow,
   getLeaseNoticeByLeaseId,
   lookupUserEmail,
   normalizeLeaseRecord,
+  sanitizeLeaseRenewalOperatorInput,
   sendLeaseWorkflowEmail,
 } from "../services/leaseNoticeWorkflowService";
 import { executeAutomation } from "../lib/automation/automationExecutor";
@@ -115,8 +117,12 @@ async function performLeaseNoticeSend(params: {
       noticeRuleVersion: previewResult.preview.noticeRuleVersion,
       noticeLeadDays: previewResult.rule.noticeLeadDays,
       nextNoticeDueAt: previewResult.preview.noticeDueAt,
+      renewalRentChangeMode: previewResult.preview.rentChangeMode,
       renewalOfferedRent: previewResult.preview.proposedRent,
       renewalDecisionDeadlineAt: previewResult.preview.responseDeadlineAt,
+      renewalNewTermType: previewResult.preview.newTermType,
+      renewalNewLeaseStartDate: previewResult.preview.newTermStartDate,
+      renewalNewLeaseEndDate: previewResult.preview.newTermEndDate,
       updatedAt: now,
     },
     { merge: true }
@@ -275,11 +281,13 @@ router.get("/expiring", async (req: any, res) => {
   try {
     const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
     const withinDays = Math.max(1, Number(req.query?.withinDays || 120));
+    const propertyId = String(req.query?.propertyId || "").trim();
     const now = Date.now();
     const horizon = now + withinDays * 24 * 60 * 60 * 1000;
     const snap = await db.collection("leases").where("landlordId", "==", landlordId).limit(400).get();
     const items = snap.docs
       .map((doc) => normalizeLeaseRecord(doc.id, doc.data() as any))
+      .filter((lease) => !propertyId || lease.propertyId === propertyId)
       .filter((lease) => lease.status === "active" || lease.status === "notice_pending" || lease.status === "renewal_pending")
       .filter((lease) => !!lease.nextNoticeDueAt && Number(lease.nextNoticeDueAt) <= horizon)
       .sort((a, b) => Number(a.nextNoticeDueAt || 0) - Number(b.nextNoticeDueAt || 0));
@@ -294,6 +302,97 @@ router.get("/expiring", async (req: any, res) => {
   } catch (err: any) {
     console.error("[lease-notice] expiring-list failed", { message: err?.message || "failed" });
     return res.status(500).json({ ok: false, error: "LEASE_EXPIRING_LIST_FAILED" });
+  }
+});
+
+router.get("/:id/renewal-inputs", async (req: any, res) => {
+  try {
+    const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
+    const leaseId = String(req.params?.id || "").trim();
+    const leaseResult = await getLeaseForLandlordWorkflow(leaseId, landlordId);
+    if (!leaseResult.ok) {
+      return res.status(leaseResult.status).json({ ok: false, error: leaseResult.error });
+    }
+    const lease = normalizeLeaseRecord(leaseId, leaseResult.lease);
+    return res.json({
+      ok: true,
+      lease,
+      renewalInputs: deriveLeaseRenewalOperatorInputRecord(lease),
+    });
+  } catch (err: any) {
+    console.error("[lease-notice] renewal-inputs load failed", { message: err?.message || "failed" });
+    return res.status(500).json({ ok: false, error: "LEASE_RENEWAL_INPUT_LOAD_FAILED" });
+  }
+});
+
+router.put("/:id/renewal-inputs", async (req: any, res) => {
+  try {
+    const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
+    const actorId = String(req.user?.id || landlordId || "").trim() || null;
+    const leaseId = String(req.params?.id || "").trim();
+    const leaseResult = await getLeaseForLandlordWorkflow(leaseId, landlordId);
+    if (!leaseResult.ok) {
+      return res.status(leaseResult.status).json({ ok: false, error: leaseResult.error });
+    }
+
+    const sanitized = sanitizeLeaseRenewalOperatorInput(req.body || {});
+    if (!sanitized.ok) {
+      return res.status(400).json({ ok: false, error: sanitized.error });
+    }
+
+    const now = Date.now();
+    await db.collection("leases").doc(leaseId).set(
+      {
+        renewalRentChangeMode: sanitized.data.rentChangeMode,
+        renewalOfferedRent: sanitized.data.proposedRent,
+        renewalDecisionDeadlineAt: sanitized.data.responseDeadlineAt,
+        renewalNewTermType: sanitized.data.newTermType,
+        renewalNewLeaseStartDate: sanitized.data.newLeaseStartDate,
+        renewalNewLeaseEndDate: sanitized.data.newLeaseEndDate,
+        updatedAt: now,
+      },
+      { merge: true }
+    );
+
+    const lease = normalizeLeaseRecord(leaseId, {
+      ...(leaseResult.lease || {}),
+      renewalRentChangeMode: sanitized.data.rentChangeMode,
+      renewalOfferedRent: sanitized.data.proposedRent,
+      renewalDecisionDeadlineAt: sanitized.data.responseDeadlineAt,
+      renewalNewTermType: sanitized.data.newTermType,
+      renewalNewLeaseStartDate: sanitized.data.newLeaseStartDate,
+      renewalNewLeaseEndDate: sanitized.data.newLeaseEndDate,
+      updatedAt: now,
+    });
+
+    await appendLeaseWorkflowEvent({
+      entityType: "lease",
+      entityId: leaseId,
+      leaseId,
+      landlordId,
+      tenantId: lease.tenantId,
+      propertyId: lease.propertyId,
+      unitId: lease.unitId,
+      actorType: "landlord",
+      actorId,
+      eventType: "lease_notice_preview_generated",
+      eventData: {
+        kind: "renewal_inputs_saved",
+        rentChangeMode: sanitized.data.rentChangeMode,
+        proposedRent: sanitized.data.proposedRent,
+        newTermType: sanitized.data.newTermType,
+        responseDeadlineAt: sanitized.data.responseDeadlineAt,
+      },
+    });
+
+    return res.json({
+      ok: true,
+      lease,
+      renewalInputs: deriveLeaseRenewalOperatorInputRecord(lease),
+    });
+  } catch (err: any) {
+    console.error("[lease-notice] renewal-inputs save failed", { message: err?.message || "failed" });
+    return res.status(500).json({ ok: false, error: "LEASE_RENEWAL_INPUT_SAVE_FAILED" });
   }
 });
 

--- a/rentchain-api/src/services/__tests__/leaseNoticeWorkflowService.test.ts
+++ b/rentchain-api/src/services/__tests__/leaseNoticeWorkflowService.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveLeaseNoticeExecutionInputSnapshot,
+  normalizeLeaseRecord,
+  sanitizeLeaseRenewalOperatorInput,
+} from "../leaseNoticeWorkflowService";
+
+describe("leaseNoticeWorkflowService renewal operator inputs", () => {
+  it("keeps readiness partial when term fields are still unset", () => {
+    const lease = normalizeLeaseRecord("lease-1", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      leaseType: "fixed_term",
+      province: "NS",
+      currentRent: 1650,
+      leaseEndDate: "2026-05-10",
+      renewalRentChangeMode: "no_change",
+      renewalDecisionDeadlineAt: Date.UTC(2026, 4, 1, 12, 0, 0, 0),
+      status: "active",
+    });
+
+    expect(deriveLeaseNoticeExecutionInputSnapshot(lease)).toEqual(
+      expect.objectContaining({
+        state: "partial",
+        missingFields: ["newTermType", "newLeaseStartDate", "newLeaseEndDate"],
+        input: expect.objectContaining({
+          rentChangeMode: "no_change",
+          responseDeadlineAt: Date.UTC(2026, 4, 1, 12, 0, 0, 0),
+          newTermType: null,
+        }),
+      })
+    );
+  });
+
+  it("promotes readiness to complete when canonical renewal inputs are fully stored on the lease", () => {
+    const lease = normalizeLeaseRecord("lease-1", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      leaseType: "fixed_term",
+      province: "NS",
+      currentRent: 1650,
+      leaseEndDate: "2026-05-10",
+      renewalRentChangeMode: "no_change",
+      renewalDecisionDeadlineAt: Date.UTC(2026, 4, 1, 12, 0, 0, 0),
+      renewalNewTermType: "fixed_term",
+      renewalNewLeaseStartDate: "2026-05-11",
+      renewalNewLeaseEndDate: "2027-05-10",
+      status: "active",
+    });
+
+    expect(deriveLeaseNoticeExecutionInputSnapshot(lease)).toEqual(
+      expect.objectContaining({
+        state: "complete",
+        reason: null,
+        missingFields: [],
+        input: expect.objectContaining({
+          rentChangeMode: "no_change",
+          newTermType: "fixed_term",
+          newLeaseStartDate: "2026-05-11",
+          newLeaseEndDate: "2027-05-10",
+        }),
+      })
+    );
+  });
+
+  it("rejects contradictory saved operator input payloads", () => {
+    expect(
+      sanitizeLeaseRenewalOperatorInput({
+        rentChangeMode: "no_change",
+        proposedRent: 1900,
+      })
+    ).toEqual({
+      ok: false,
+      error: "PROPOSED_RENT_NOT_ALLOWED_FOR_RENT_CHANGE_MODE",
+    });
+  });
+});

--- a/rentchain-api/src/services/leaseNoticeWorkflowService.ts
+++ b/rentchain-api/src/services/leaseNoticeWorkflowService.ts
@@ -44,8 +44,12 @@ export type LeaseWorkflowLease = {
   latestNoticeId: string | null;
   latestRenewalIntent: string | null;
   latestRenewalIntentAt: number | null;
+  renewalRentChangeMode: RentChangeMode | null;
   renewalOfferedRent: number | null;
   renewalDecisionDeadlineAt: number | null;
+  renewalNewTermType: LeaseType | null;
+  renewalNewLeaseStartDate: string | null;
+  renewalNewLeaseEndDate: string | null;
   moveOutDate: string | null;
   createdAt: number;
   updatedAt: number;
@@ -81,6 +85,15 @@ export type LeaseNoticeExecutionInputSnapshot = {
   leaseType: LeaseType | null;
   currentRent: number | null;
   noticeDueAt: number | null;
+  rentChangeMode: RentChangeMode | null;
+  proposedRent: number | null;
+  newTermType: LeaseType | null;
+  newLeaseStartDate: string | null;
+  newLeaseEndDate: string | null;
+  responseDeadlineAt: number | null;
+};
+
+export type LeaseRenewalOperatorInputRecord = {
   rentChangeMode: RentChangeMode | null;
   proposedRent: number | null;
   newTermType: LeaseType | null;
@@ -132,6 +145,12 @@ function asLeaseType(value: unknown): LeaseType {
   return "fixed_term";
 }
 
+function asOptionalLeaseType(value: unknown): LeaseType | null {
+  const raw = String(value || "").trim().toLowerCase();
+  if (raw === "fixed_term" || raw === "year_to_year" || raw === "month_to_month") return raw;
+  return null;
+}
+
 function determineNoticeType(lease: LeaseWorkflowLease): LeaseNoticeType {
   if (lease.leaseType === "month_to_month") return "month_to_month_notice";
   return "renewal_offer";
@@ -141,7 +160,16 @@ function addMissingField(target: Set<string>, field: string, condition: boolean)
   if (!condition) target.add(field);
 }
 
+function asRentChangeMode(value: unknown): RentChangeMode | null {
+  const raw = String(value || "").trim().toLowerCase();
+  if (raw === "no_change" || raw === "increase" || raw === "decrease" || raw === "undecided") {
+    return raw;
+  }
+  return null;
+}
+
 function deriveRentChangeModeFromLease(lease: LeaseWorkflowLease): RentChangeMode | null {
+  if (lease.renewalRentChangeMode) return lease.renewalRentChangeMode;
   if (typeof lease.renewalOfferedRent !== "number" || !Number.isFinite(lease.renewalOfferedRent) || lease.renewalOfferedRent <= 0) {
     return null;
   }
@@ -195,15 +223,120 @@ export function normalizeLeaseRecord(id: string, raw: any): LeaseWorkflowLease {
     latestNoticeId: String(raw?.latestNoticeId || "").trim() || null,
     latestRenewalIntent: String(raw?.latestRenewalIntent || "").trim() || null,
     latestRenewalIntentAt: toMillis(raw?.latestRenewalIntentAt),
+    renewalRentChangeMode: asRentChangeMode(raw?.renewalRentChangeMode),
     renewalOfferedRent:
       typeof raw?.renewalOfferedRent === "number" ? raw.renewalOfferedRent : null,
     renewalDecisionDeadlineAt: toMillis(raw?.renewalDecisionDeadlineAt),
+    renewalNewTermType: asOptionalLeaseType(raw?.renewalNewTermType || raw?.newTermType || null),
+    renewalNewLeaseStartDate: toDateOnly(raw?.renewalNewLeaseStartDate || raw?.newLeaseStartDate || null),
+    renewalNewLeaseEndDate: toDateOnly(raw?.renewalNewLeaseEndDate || raw?.newLeaseEndDate || null),
     moveOutDate: toDateOnly(raw?.moveOutDate || null),
     createdAt,
     updatedAt,
     tenantName: String(raw?.tenantName || raw?.residentName || "").trim() || null,
     unitLabel: String(raw?.unitLabel || raw?.unitNumber || raw?.unit || "").trim() || null,
     propertyLabel: String(raw?.propertyLabel || raw?.propertyName || "").trim() || null,
+  };
+}
+
+export function deriveLeaseRenewalOperatorInputRecord(lease: LeaseWorkflowLease): LeaseRenewalOperatorInputRecord {
+  return {
+    rentChangeMode: deriveRentChangeModeFromLease(lease),
+    proposedRent:
+      typeof lease.renewalOfferedRent === "number" && Number.isFinite(lease.renewalOfferedRent) && lease.renewalOfferedRent > 0
+        ? lease.renewalOfferedRent
+        : null,
+    newTermType: lease.renewalNewTermType || null,
+    newLeaseStartDate: lease.renewalNewLeaseStartDate || null,
+    newLeaseEndDate: lease.renewalNewLeaseEndDate || null,
+    responseDeadlineAt: typeof lease.renewalDecisionDeadlineAt === "number" ? lease.renewalDecisionDeadlineAt : null,
+  };
+}
+
+export function sanitizeLeaseRenewalOperatorInput(input: any): {
+  ok: true;
+  data: LeaseRenewalOperatorInputRecord;
+} | {
+  ok: false;
+  error: string;
+} {
+  const rentChangeMode = asRentChangeMode(input?.rentChangeMode);
+  const proposedRentRaw = input?.proposedRent;
+  const proposedRent =
+    proposedRentRaw == null || proposedRentRaw === ""
+      ? null
+      : typeof proposedRentRaw === "number" && Number.isFinite(proposedRentRaw) && proposedRentRaw > 0
+      ? proposedRentRaw
+      : Number.isFinite(Number(proposedRentRaw)) && Number(proposedRentRaw) > 0
+      ? Number(proposedRentRaw)
+      : NaN;
+  if (Number.isNaN(proposedRent)) {
+    return { ok: false, error: "INVALID_PROPOSED_RENT" };
+  }
+
+  const newTermTypeRaw = input?.newTermType;
+  const newTermType =
+    newTermTypeRaw == null || newTermTypeRaw === ""
+      ? null
+      : (() => {
+          const value = String(newTermTypeRaw || "").trim().toLowerCase();
+          if (value === "fixed_term" || value === "year_to_year" || value === "month_to_month") return value;
+          return "__invalid__";
+        })();
+  if (newTermType === "__invalid__") {
+    return { ok: false, error: "INVALID_NEW_TERM_TYPE" };
+  }
+
+  const newLeaseStartDate =
+    input?.newLeaseStartDate == null || input?.newLeaseStartDate === "" ? null : toDateOnly(input?.newLeaseStartDate);
+  if (input?.newLeaseStartDate != null && input?.newLeaseStartDate !== "" && !newLeaseStartDate) {
+    return { ok: false, error: "INVALID_NEW_LEASE_START_DATE" };
+  }
+
+  const newLeaseEndDate =
+    input?.newLeaseEndDate == null || input?.newLeaseEndDate === "" ? null : toDateOnly(input?.newLeaseEndDate);
+  if (input?.newLeaseEndDate != null && input?.newLeaseEndDate !== "" && !newLeaseEndDate) {
+    return { ok: false, error: "INVALID_NEW_LEASE_END_DATE" };
+  }
+
+  const responseDeadlineAt =
+    input?.responseDeadlineAt == null || input?.responseDeadlineAt === "" ? null : toMillis(input?.responseDeadlineAt);
+  if (input?.responseDeadlineAt != null && input?.responseDeadlineAt !== "" && !responseDeadlineAt) {
+    return { ok: false, error: "INVALID_RESPONSE_DEADLINE" };
+  }
+
+  if ((rentChangeMode === "increase" || rentChangeMode === "decrease") && proposedRent == null) {
+    return {
+      ok: true,
+      data: {
+        rentChangeMode,
+        proposedRent: null,
+        newTermType: newTermType as LeaseType | null,
+        newLeaseStartDate,
+        newLeaseEndDate,
+        responseDeadlineAt,
+      },
+    };
+  }
+
+  if ((rentChangeMode === "no_change" || rentChangeMode === "undecided") && proposedRent != null) {
+    return { ok: false, error: "PROPOSED_RENT_NOT_ALLOWED_FOR_RENT_CHANGE_MODE" };
+  }
+
+  if (!rentChangeMode && proposedRent != null) {
+    return { ok: false, error: "RENT_CHANGE_MODE_REQUIRED_FOR_PROPOSED_RENT" };
+  }
+
+  return {
+    ok: true,
+    data: {
+      rentChangeMode,
+      proposedRent,
+      newTermType: newTermType as LeaseType | null,
+      newLeaseStartDate,
+      newLeaseEndDate,
+      responseDeadlineAt,
+    },
   };
 }
 
@@ -225,12 +358,10 @@ export function deriveLeaseNoticeExecutionInputSnapshot(lease: LeaseWorkflowLeas
 
   const noticeType = determineNoticeType(lease);
   const noticeDueAt = lease.nextNoticeDueAt || (lease.leaseEndDate ? minusDays(lease.leaseEndDate, rule.noticeLeadDays) : null);
-  const rentChangeMode = deriveRentChangeModeFromLease(lease);
-  const proposedRent =
-    typeof lease.renewalOfferedRent === "number" && Number.isFinite(lease.renewalOfferedRent) && lease.renewalOfferedRent > 0
-      ? lease.renewalOfferedRent
-      : null;
-  const responseDeadlineAt = typeof lease.renewalDecisionDeadlineAt === "number" ? lease.renewalDecisionDeadlineAt : null;
+  const persistedInput = deriveLeaseRenewalOperatorInputRecord(lease);
+  const rentChangeMode = persistedInput.rentChangeMode;
+  const proposedRent = persistedInput.proposedRent;
+  const responseDeadlineAt = persistedInput.responseDeadlineAt;
 
   const input: LeaseNoticeExecutionInputSnapshot = {
     noticeType,
@@ -242,9 +373,9 @@ export function deriveLeaseNoticeExecutionInputSnapshot(lease: LeaseWorkflowLeas
     noticeDueAt,
     rentChangeMode,
     proposedRent,
-    newTermType: null,
-    newLeaseStartDate: null,
-    newLeaseEndDate: null,
+    newTermType: persistedInput.newTermType,
+    newLeaseStartDate: persistedInput.newLeaseStartDate,
+    newLeaseEndDate: persistedInput.newLeaseEndDate,
     responseDeadlineAt,
   };
 

--- a/rentchain-frontend/src/api/landlordLeaseRenewalApi.ts
+++ b/rentchain-frontend/src/api/landlordLeaseRenewalApi.ts
@@ -1,0 +1,58 @@
+import { apiFetch } from "./apiFetch";
+
+export type LandlordLeaseRenewalOperatorInput = {
+  rentChangeMode: "no_change" | "increase" | "decrease" | "undecided" | null;
+  proposedRent: number | null;
+  newTermType: "fixed_term" | "year_to_year" | "month_to_month" | null;
+  newLeaseStartDate: string | null;
+  newLeaseEndDate: string | null;
+  responseDeadlineAt: number | null;
+};
+
+export type LandlordLeaseRenewalLease = {
+  id: string;
+  tenantId: string;
+  propertyId: string | null;
+  unitId: string | null;
+  status: string;
+  leaseType: "fixed_term" | "year_to_year" | "month_to_month";
+  province: string;
+  leaseStartDate: string | null;
+  leaseEndDate: string | null;
+  currentRent: number | null;
+  currency: string;
+  nextNoticeDueAt: number | null;
+  latestNoticeId: string | null;
+  tenantName: string | null;
+  unitLabel: string | null;
+  propertyLabel: string | null;
+  renewalRentChangeMode: "no_change" | "increase" | "decrease" | "undecided" | null;
+  renewalOfferedRent: number | null;
+  renewalDecisionDeadlineAt: number | null;
+  renewalNewTermType: "fixed_term" | "year_to_year" | "month_to_month" | null;
+  renewalNewLeaseStartDate: string | null;
+  renewalNewLeaseEndDate: string | null;
+};
+
+export function fetchExpiringLeaseRenewals(params?: { propertyId?: string | null; withinDays?: number }) {
+  const search = new URLSearchParams();
+  if (params?.propertyId) search.set("propertyId", params.propertyId);
+  if (typeof params?.withinDays === "number" && Number.isFinite(params.withinDays)) {
+    search.set("withinDays", String(params.withinDays));
+  }
+  const suffix = search.size ? `?${search.toString()}` : "";
+  return apiFetch<{ ok: true; items: LandlordLeaseRenewalLease[]; data: LandlordLeaseRenewalLease[] }>(
+    `/landlord/leases/expiring${suffix}`
+  );
+}
+
+export function saveLeaseRenewalInputs(leaseId: string, payload: LandlordLeaseRenewalOperatorInput) {
+  return apiFetch<{
+    ok: true;
+    lease: LandlordLeaseRenewalLease;
+    renewalInputs: LandlordLeaseRenewalOperatorInput;
+  }>(`/landlord/leases/${encodeURIComponent(leaseId)}/renewal-inputs`, {
+    method: "PUT",
+    body: payload,
+  });
+}

--- a/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import type { LandlordPortfolioHealthSummaryV1 } from "../../api/landlordPortfolioHealthApi";
@@ -9,6 +9,11 @@ const showToast = vi.fn();
 
 vi.mock("../../api/landlordPortfolioHealthApi", () => ({
   fetchLandlordPortfolioHealth: vi.fn(),
+}));
+
+vi.mock("../../api/landlordLeaseRenewalApi", () => ({
+  fetchExpiringLeaseRenewals: vi.fn(),
+  saveLeaseRenewalInputs: vi.fn(),
 }));
 
 vi.mock("@/hooks/useEntitlements", () => ({
@@ -123,6 +128,7 @@ describe("PortfolioHealthSummaryPage", () => {
   it("shows a compact decision-entry hint for lease renewal destinations", async () => {
     await mockEntitlements();
     const { fetchLandlordPortfolioHealth } = await import("../../api/landlordPortfolioHealthApi");
+    const { fetchExpiringLeaseRenewals } = await import("../../api/landlordLeaseRenewalApi");
     vi.mocked(fetchLandlordPortfolioHealth).mockResolvedValue({
       portfolioHealth: {
         version: "v1",
@@ -146,6 +152,36 @@ describe("PortfolioHealthSummaryPage", () => {
         },
       },
     } as { portfolioHealth: LandlordPortfolioHealthSummaryV1 });
+    vi.mocked(fetchExpiringLeaseRenewals).mockResolvedValue({
+      ok: true,
+      items: [
+        {
+          id: "lease-1",
+          tenantId: "tenant-1",
+          propertyId: "prop-2",
+          unitId: "unit-2",
+          status: "active",
+          leaseType: "fixed_term",
+          province: "NS",
+          leaseStartDate: "2025-07-01",
+          leaseEndDate: "2026-06-30",
+          currentRent: 1800,
+          currency: "CAD",
+          nextNoticeDueAt: Date.UTC(2026, 3, 1, 0, 0, 0, 0),
+          latestNoticeId: null,
+          tenantName: "Taylor Tenant",
+          unitLabel: "Unit 2",
+          propertyLabel: "Beta",
+          renewalRentChangeMode: null,
+          renewalOfferedRent: null,
+          renewalDecisionDeadlineAt: null,
+          renewalNewTermType: null,
+          renewalNewLeaseStartDate: null,
+          renewalNewLeaseEndDate: null,
+        },
+      ],
+      data: [],
+    });
 
     render(
       <MemoryRouter initialEntries={["/portfolio-health?entry=lease-renewals&propertyId=prop-2"]}>
@@ -154,6 +190,133 @@ describe("PortfolioHealthSummaryPage", () => {
     );
 
     expect(await screen.findByText(/Opened from decisions to review lease-renewal pressure/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Lease renewal operator inputs/i)).toBeInTheDocument();
+    expect(screen.getByText(/Taylor Tenant/i)).toBeInTheDocument();
+  });
+
+  it("saves lease renewal operator inputs from the decision-entry workflow surface", async () => {
+    await mockEntitlements();
+    const { fetchLandlordPortfolioHealth } = await import("../../api/landlordPortfolioHealthApi");
+    const { fetchExpiringLeaseRenewals, saveLeaseRenewalInputs } = await import("../../api/landlordLeaseRenewalApi");
+    vi.mocked(fetchLandlordPortfolioHealth).mockResolvedValue({
+      portfolioHealth: {
+        version: "v1",
+        portfolioId: "landlord-1",
+        generatedAt: "2026-04-16T12:00:00.000Z",
+        overall: {
+          status: "watch",
+          headline: "Your portfolio health is stable overall.",
+          summary: "Most portfolio activity is progressing normally.",
+        },
+        trend: {
+          direction: "stable",
+          summary: "Portfolio health has remained generally steady in recent history.",
+        },
+        dimensions: [],
+        nextFocus: [],
+        metadata: {
+          portfolioScoreGrade: null,
+          portfolioScoreAvailable: true,
+          trendAvailable: true,
+        },
+      },
+    } as { portfolioHealth: LandlordPortfolioHealthSummaryV1 });
+    vi.mocked(fetchExpiringLeaseRenewals).mockResolvedValue({
+      ok: true,
+      items: [
+        {
+          id: "lease-1",
+          tenantId: "tenant-1",
+          propertyId: "prop-1",
+          unitId: "unit-1",
+          status: "active",
+          leaseType: "fixed_term",
+          province: "NS",
+          leaseStartDate: "2025-07-01",
+          leaseEndDate: "2026-06-30",
+          currentRent: 1800,
+          currency: "CAD",
+          nextNoticeDueAt: Date.UTC(2026, 3, 1, 0, 0, 0, 0),
+          latestNoticeId: null,
+          tenantName: "Taylor Tenant",
+          unitLabel: "Unit 1",
+          propertyLabel: "Alpha",
+          renewalRentChangeMode: null,
+          renewalOfferedRent: null,
+          renewalDecisionDeadlineAt: null,
+          renewalNewTermType: null,
+          renewalNewLeaseStartDate: null,
+          renewalNewLeaseEndDate: null,
+        },
+      ],
+      data: [],
+    });
+    vi.mocked(saveLeaseRenewalInputs).mockResolvedValue({
+      ok: true,
+      lease: {
+        id: "lease-1",
+        tenantId: "tenant-1",
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        status: "active",
+        leaseType: "fixed_term",
+        province: "NS",
+        leaseStartDate: "2025-07-01",
+        leaseEndDate: "2026-06-30",
+        currentRent: 1800,
+        currency: "CAD",
+        nextNoticeDueAt: Date.UTC(2026, 3, 1, 0, 0, 0, 0),
+        latestNoticeId: null,
+        tenantName: "Taylor Tenant",
+        unitLabel: "Unit 1",
+        propertyLabel: "Alpha",
+        renewalRentChangeMode: "no_change",
+        renewalOfferedRent: null,
+        renewalDecisionDeadlineAt: Date.UTC(2026, 4, 1, 12, 0, 0, 0),
+        renewalNewTermType: "fixed_term",
+        renewalNewLeaseStartDate: "2026-07-01",
+        renewalNewLeaseEndDate: "2027-06-30",
+      },
+      renewalInputs: {
+        rentChangeMode: "no_change",
+        proposedRent: null,
+        newTermType: "fixed_term",
+        newLeaseStartDate: "2026-07-01",
+        newLeaseEndDate: "2027-06-30",
+        responseDeadlineAt: Date.UTC(2026, 4, 1, 12, 0, 0, 0),
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/portfolio-health?entry=lease-renewals&propertyId=prop-1"]}>
+        <PortfolioHealthSummaryPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Lease renewal operator inputs/i)).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText(/Rent change mode/i), { target: { value: "no_change" } });
+    fireEvent.change(screen.getByLabelText(/New term type/i), { target: { value: "fixed_term" } });
+    fireEvent.change(screen.getByLabelText(/New lease start date/i), { target: { value: "2026-07-01" } });
+    fireEvent.change(screen.getByLabelText(/New lease end date/i), { target: { value: "2027-06-30" } });
+    fireEvent.change(screen.getByLabelText(/Response deadline/i), { target: { value: "2026-05-01T08:00" } });
+    fireEvent.click(screen.getByRole("button", { name: /Save renewal inputs/i }));
+
+    await waitFor(() => {
+      expect(saveLeaseRenewalInputs).toHaveBeenCalledWith(
+        "lease-1",
+        expect.objectContaining({
+          rentChangeMode: "no_change",
+          newTermType: "fixed_term",
+          newLeaseStartDate: "2026-07-01",
+          newLeaseEndDate: "2027-06-30",
+        })
+      );
+    });
+    expect(showToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Lease renewal inputs saved",
+      })
+    );
   });
 
   it("renders sparse-data messaging", async () => {

--- a/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.tsx
@@ -1,6 +1,11 @@
 import React from "react";
 import { useLocation } from "react-router-dom";
 import { fetchLandlordPortfolioHealth, type LandlordPortfolioHealthSummaryV1 } from "../../api/landlordPortfolioHealthApi";
+import {
+  fetchExpiringLeaseRenewals,
+  saveLeaseRenewalInputs,
+  type LandlordLeaseRenewalLease,
+} from "../../api/landlordLeaseRenewalApi";
 import { MacShell } from "../../components/layout/MacShell";
 import { Card, Section } from "../../components/ui/Ui";
 import { useToast } from "../../components/ui/ToastProvider";
@@ -11,6 +16,40 @@ import PortfolioHealthStatusCard from "../../components/portfolioHealth/Portfoli
 import PortfolioHealthDimensionList from "../../components/portfolioHealth/PortfolioHealthDimensionList";
 import PortfolioHealthNextFocusList from "../../components/portfolioHealth/PortfolioHealthNextFocusList";
 import PortfolioFeedbackSummary from "../../components/portfolioHealth/PortfolioFeedbackSummary";
+
+type LeaseRenewalFormState = {
+  rentChangeMode: "" | "no_change" | "increase" | "decrease" | "undecided";
+  proposedRent: string;
+  newTermType: "" | "fixed_term" | "year_to_year" | "month_to_month";
+  newLeaseStartDate: string;
+  newLeaseEndDate: string;
+  responseDeadlineAt: string;
+};
+
+function toDatetimeLocalInput(value: number | null) {
+  if (!value) return "";
+  const date = new Date(value);
+  const offset = date.getTimezoneOffset() * 60_000;
+  return new Date(date.getTime() - offset).toISOString().slice(0, 16);
+}
+
+function fromDatetimeLocalInput(value: string) {
+  const raw = String(value || "").trim();
+  if (!raw) return null;
+  const parsed = Date.parse(raw);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function createLeaseRenewalFormState(lease: LandlordLeaseRenewalLease): LeaseRenewalFormState {
+  return {
+    rentChangeMode: lease.renewalRentChangeMode || "",
+    proposedRent: typeof lease.renewalOfferedRent === "number" ? String(lease.renewalOfferedRent) : "",
+    newTermType: lease.renewalNewTermType || "",
+    newLeaseStartDate: lease.renewalNewLeaseStartDate || "",
+    newLeaseEndDate: lease.renewalNewLeaseEndDate || "",
+    responseDeadlineAt: toDatetimeLocalInput(lease.renewalDecisionDeadlineAt),
+  };
+}
 
 export default function PortfolioHealthSummaryPage() {
   const location = useLocation();
@@ -24,6 +63,11 @@ export default function PortfolioHealthSummaryPage() {
   const [summary, setSummary] = React.useState<LandlordPortfolioHealthSummaryV1 | null>(null);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
+  const [renewalItems, setRenewalItems] = React.useState<LandlordLeaseRenewalLease[]>([]);
+  const [renewalForms, setRenewalForms] = React.useState<Record<string, LeaseRenewalFormState>>({});
+  const [renewalLoading, setRenewalLoading] = React.useState(false);
+  const [renewalError, setRenewalError] = React.useState<string | null>(null);
+  const [savingLeaseId, setSavingLeaseId] = React.useState<string | null>(null);
   const entryParams = React.useMemo(() => new URLSearchParams(location.search), [location.search]);
   const entry = entryParams.get("entry");
   const entryPropertyId = entryParams.get("propertyId");
@@ -63,9 +107,106 @@ export default function PortfolioHealthSummaryPage() {
     };
   }, [canViewPortfolioHealthSummary, entitlementLoading, showToast]);
 
+  React.useEffect(() => {
+    if (entitlementLoading || !canViewPortfolioHealthSummary || entry !== "lease-renewals") return;
+
+    let mounted = true;
+    (async () => {
+      try {
+        setRenewalLoading(true);
+        setRenewalError(null);
+        const response = await fetchExpiringLeaseRenewals({
+          propertyId: entryPropertyId,
+        });
+        if (!mounted) return;
+        const items = response.items || [];
+        setRenewalItems(items);
+        setRenewalForms(
+          items.reduce<Record<string, LeaseRenewalFormState>>((acc, item) => {
+            acc[item.id] = createLeaseRenewalFormState(item);
+            return acc;
+          }, {})
+        );
+      } catch (err: unknown) {
+        if (!mounted) return;
+        const message = err instanceof Error && err.message ? err.message : "Failed to load lease renewal inputs";
+        setRenewalError(message);
+        showToast({
+          message: "Failed to load lease renewal inputs",
+          description: message,
+          variant: "error",
+        });
+      } finally {
+        if (mounted) setRenewalLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [canViewPortfolioHealthSummary, entitlementLoading, entry, entryPropertyId, showToast]);
+
   const scorePlanLabel = resolveRequiredPlanLabel("portfolio_score") || "Pro";
   const recommendationsPlanLabel =
     resolveRequiredPlanLabel("portfolio_action_recommendations") || "Elite";
+
+  const handleRenewalFieldChange = React.useCallback(
+    (leaseId: string, field: keyof LeaseRenewalFormState, value: string) => {
+      setRenewalForms((current) => ({
+        ...current,
+        [leaseId]: {
+          ...(current[leaseId] || {
+            rentChangeMode: "",
+            proposedRent: "",
+            newTermType: "",
+            newLeaseStartDate: "",
+            newLeaseEndDate: "",
+            responseDeadlineAt: "",
+          }),
+          [field]: value,
+        },
+      }));
+    },
+    []
+  );
+
+  const handleSaveRenewalInputs = React.useCallback(
+    async (leaseId: string) => {
+      const form = renewalForms[leaseId];
+      if (!form) return;
+
+      try {
+        setSavingLeaseId(leaseId);
+        const response = await saveLeaseRenewalInputs(leaseId, {
+          rentChangeMode: form.rentChangeMode || null,
+          proposedRent: form.proposedRent.trim() ? Number(form.proposedRent) : null,
+          newTermType: form.newTermType || null,
+          newLeaseStartDate: form.newLeaseStartDate || null,
+          newLeaseEndDate: form.newLeaseEndDate || null,
+          responseDeadlineAt: fromDatetimeLocalInput(form.responseDeadlineAt),
+        });
+        setRenewalItems((current) => current.map((item) => (item.id === leaseId ? response.lease : item)));
+        setRenewalForms((current) => ({
+          ...current,
+          [leaseId]: createLeaseRenewalFormState(response.lease),
+        }));
+        showToast({
+          message: "Lease renewal inputs saved",
+          description: "Saved values will be picked up by lease notice readiness checks.",
+          variant: "success",
+        });
+      } catch (err: unknown) {
+        const message = err instanceof Error && err.message ? err.message : "Failed to save lease renewal inputs";
+        showToast({
+          message: "Failed to save lease renewal inputs",
+          description: message,
+          variant: "error",
+        });
+      } finally {
+        setSavingLeaseId(null);
+      }
+    },
+    [renewalForms, showToast]
+  );
 
   return (
     <MacShell title="Portfolio health">
@@ -81,6 +222,125 @@ export default function PortfolioHealthSummaryPage() {
 
         {entryMessage ? (
           <Card style={{ borderColor: "#99f6e4", background: "#f0fdfa", color: "#115e59" }}>{entryMessage}</Card>
+        ) : null}
+
+        {entry === "lease-renewals" ? (
+          <Card style={{ display: "grid", gap: 16 }}>
+            <div style={{ display: "grid", gap: 4 }}>
+              <div style={{ fontWeight: 700 }}>Lease renewal operator inputs</div>
+              <div style={{ color: "#475569" }}>
+                Save renewal term and deadline choices on the lease record so readiness checks can observe them canonically.
+              </div>
+            </div>
+
+            {renewalLoading ? <div>Loading lease renewal inputs…</div> : null}
+            {!renewalLoading && renewalError ? <div style={{ color: "#b91c1c" }}>{renewalError}</div> : null}
+            {!renewalLoading && !renewalError && renewalItems.length === 0 ? (
+              <div style={{ color: "#475569" }}>No expiring leases are currently visible for this scope.</div>
+            ) : null}
+
+            {!renewalLoading && !renewalError
+              ? renewalItems.map((lease) => {
+                  const form = renewalForms[lease.id] || createLeaseRenewalFormState(lease);
+                  const isSaving = savingLeaseId === lease.id;
+                  return (
+                    <div
+                      key={lease.id}
+                      style={{
+                        display: "grid",
+                        gap: 12,
+                        padding: 16,
+                        border: "1px solid #dbe4ee",
+                        borderRadius: 12,
+                        background: "#fff",
+                      }}
+                    >
+                      <div style={{ display: "grid", gap: 2 }}>
+                        <div style={{ fontWeight: 700 }}>
+                          {lease.propertyLabel || "Property"} {lease.unitLabel ? `• ${lease.unitLabel}` : ""}
+                        </div>
+                        <div style={{ color: "#475569", fontSize: 14 }}>
+                          Lease ends {lease.leaseEndDate || "unknown"}{lease.tenantName ? ` • ${lease.tenantName}` : ""}
+                        </div>
+                      </div>
+
+                      <div style={{ display: "grid", gap: 12, gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))" }}>
+                        <label style={{ display: "grid", gap: 4 }}>
+                          <span>Rent change mode</span>
+                          <select
+                            value={form.rentChangeMode}
+                            onChange={(event) => handleRenewalFieldChange(lease.id, "rentChangeMode", event.target.value)}
+                          >
+                            <option value="">Unset</option>
+                            <option value="no_change">No change</option>
+                            <option value="increase">Increase</option>
+                            <option value="decrease">Decrease</option>
+                            <option value="undecided">Undecided</option>
+                          </select>
+                        </label>
+
+                        <label style={{ display: "grid", gap: 4 }}>
+                          <span>Proposed rent</span>
+                          <input
+                            type="number"
+                            min="0"
+                            step="0.01"
+                            value={form.proposedRent}
+                            onChange={(event) => handleRenewalFieldChange(lease.id, "proposedRent", event.target.value)}
+                          />
+                        </label>
+
+                        <label style={{ display: "grid", gap: 4 }}>
+                          <span>New term type</span>
+                          <select
+                            value={form.newTermType}
+                            onChange={(event) => handleRenewalFieldChange(lease.id, "newTermType", event.target.value)}
+                          >
+                            <option value="">Unset</option>
+                            <option value="fixed_term">Fixed term</option>
+                            <option value="year_to_year">Year to year</option>
+                            <option value="month_to_month">Month to month</option>
+                          </select>
+                        </label>
+
+                        <label style={{ display: "grid", gap: 4 }}>
+                          <span>New lease start date</span>
+                          <input
+                            type="date"
+                            value={form.newLeaseStartDate}
+                            onChange={(event) => handleRenewalFieldChange(lease.id, "newLeaseStartDate", event.target.value)}
+                          />
+                        </label>
+
+                        <label style={{ display: "grid", gap: 4 }}>
+                          <span>New lease end date</span>
+                          <input
+                            type="date"
+                            value={form.newLeaseEndDate}
+                            onChange={(event) => handleRenewalFieldChange(lease.id, "newLeaseEndDate", event.target.value)}
+                          />
+                        </label>
+
+                        <label style={{ display: "grid", gap: 4 }}>
+                          <span>Response deadline</span>
+                          <input
+                            type="datetime-local"
+                            value={form.responseDeadlineAt}
+                            onChange={(event) => handleRenewalFieldChange(lease.id, "responseDeadlineAt", event.target.value)}
+                          />
+                        </label>
+                      </div>
+
+                      <div style={{ display: "flex", justifyContent: "flex-end" }}>
+                        <button type="button" onClick={() => void handleSaveRenewalInputs(lease.id)} disabled={isSaving}>
+                          {isSaving ? "Saving…" : "Save renewal inputs"}
+                        </button>
+                      </div>
+                    </div>
+                  );
+                })
+              : null}
+          </Card>
         ) : null}
 
         {entitlementLoading ? <Card>Loading portfolio health…</Card> : null}


### PR DESCRIPTION
Summary

Add a canonical landlord save path for lease renewal operator inputs on the lease record.

This PR preserves the existing landlord decision stack:
	•	derived decision content
	•	structured workflow/action metadata
	•	durable lifecycle state
	•	workflow entry destinations
	•	deterministic automation rules
	•	deterministic execution mapping
	•	deterministic lease notice execution-input mapping
	•	readiness blocker classification

and adds canonical persistence for the remaining lease renewal operator inputs needed by lease notice readiness.

Changes
	•	Persist lease renewal operator inputs directly on the canonical leases document
	•	Add landlord-authenticated read/write support under the existing lease-notice route family
	•	Add a minimal operator input capture form on the existing lease-renewal workflow surface
	•	Update the shared lease notice readiness helper to consume persisted lease values
	•	Promote readiness through the shared helper path only when required persisted values are complete and valid
	•	Preserve execution behavior by leaving execution routes and executor invocation out of scope

Validation
	•	targeted backend tests
	•	targeted frontend tests
	•	backend build
	•	frontend build
	•	targeted frontend lint on touched files

Notes
	•	Canonical storage owner: leases document
	•	No execution route was added
	•	No executor was called
	•	Existing manual preview/send flows remain intact
	•	Existing frontend chunk-size warning remains non-blocking