### PR TITLE
feat: add controlled automation execution v2

### DIFF
--- a/rentchain-api/src/lib/analytics/__tests__/deriveDecisionExecutionMappings.test.ts
+++ b/rentchain-api/src/lib/analytics/__tests__/deriveDecisionExecutionMappings.test.ts
@@ -48,6 +48,7 @@ describe("applyDecisionExecutionMappings", () => {
 
     expect(result[0]).toEqual(
       expect.objectContaining({
+        automationEligible: false,
         executionMappingState: "mapped",
         executionMapping: {
           action: "lease.auto_send_notice",
@@ -170,6 +171,7 @@ describe("applyDecisionExecutionMappings", () => {
 
     expect(result[0]).toEqual(
       expect.objectContaining({
+        automationEligible: false,
         executionMappingState: "mapped",
         executionInputState: "partial",
         executionInputReason: expect.stringContaining("newTermType"),
@@ -213,6 +215,7 @@ describe("applyDecisionExecutionMappings", () => {
 
     expect(result[0]).toEqual(
       expect.objectContaining({
+        automationEligible: true,
         executionMappingState: "mapped",
         executionMapping: expect.objectContaining({
           prerequisitesMet: true,

--- a/rentchain-api/src/lib/analytics/deriveDecisionExecutionMappings.ts
+++ b/rentchain-api/src/lib/analytics/deriveDecisionExecutionMappings.ts
@@ -49,6 +49,7 @@ function decisionPropertyId(decision: LandlordAgentDecision) {
 function baseDecision(decision: LandlordAgentDecision, mapping: LandlordDecisionExecutionMapping | null): LandlordAgentDecision {
   return {
     ...decision,
+    automationEligible: false,
     executionMappingState: mapping ? "mapped" : "none",
     executionMapping: mapping,
     executionInputState: "none",
@@ -89,6 +90,7 @@ function mapLeaseRenewalDecision(decision: LandlordAgentDecision, input: Mapping
 
   return {
     ...decision,
+    automationEligible: executionInput.state === "complete",
     executionMappingState: "mapped",
     executionMapping: mapping,
     executionInputState: executionInput.state,

--- a/rentchain-api/src/routes/__tests__/landlordAnalyticsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordAnalyticsRoutes.test.ts
@@ -5,6 +5,15 @@ const saveReviewedLandlordDecisionState = vi.fn();
 const saveSnoozedLandlordDecisionState = vi.fn();
 const saveDismissedLandlordDecisionState = vi.fn();
 const writeCanonicalEvent = vi.fn();
+const executeAutomation = vi.fn();
+const buildLeaseNoticePolicyRequest = vi.fn();
+const evaluatePolicy = vi.fn();
+const toAutopilotPolicySummary = vi.fn();
+const writePolicyEvaluatedEvent = vi.fn();
+const buildLeaseNoticePreviewInputFromLease = vi.fn();
+const getLeaseForLandlordWorkflow = vi.fn();
+const normalizeLeaseRecord = vi.fn();
+const performLeaseNoticeSendFromPreviewInput = vi.fn();
 
 vi.mock("../../middleware/requireAuth", () => ({
   requireAuth: (req: any, res: any, next: any) => {
@@ -38,6 +47,27 @@ vi.mock("../../services/landlord/landlordDecisionStates", () => ({
   saveDismissedLandlordDecisionState,
 }));
 
+vi.mock("../../lib/automation/automationExecutor", () => ({
+  executeAutomation,
+}));
+
+vi.mock("../../lib/policy/policyAdapters", () => ({
+  buildLeaseNoticePolicyRequest,
+}));
+
+vi.mock("../../lib/policy/policyEvaluator", () => ({
+  evaluatePolicy,
+  toAutopilotPolicySummary,
+  writePolicyEvaluatedEvent,
+}));
+
+vi.mock("../../services/leaseNoticeWorkflowService", () => ({
+  buildLeaseNoticePreviewInputFromLease,
+  getLeaseForLandlordWorkflow,
+  normalizeLeaseRecord,
+  performLeaseNoticeSendFromPreviewInput,
+}));
+
 vi.mock("../../lib/events/buildEvent", () => ({
   writeCanonicalEvent,
 }));
@@ -66,7 +96,7 @@ async function invokeRouter(
         return this.get(name);
       },
     };
-    const decisionMatch = path.match(/\/landlord\/analytics\/decisions\/([^/]+)\/(review|snooze|dismiss)$/);
+    const decisionMatch = path.match(/\/landlord\/analytics\/decisions\/([^/]+)\/(review|snooze|dismiss|execute)$/);
     if (decisionMatch) {
       req.params.decisionId = decodeURIComponent(decisionMatch[1]);
     }
@@ -128,6 +158,57 @@ describe("landlordAnalyticsRoutes", () => {
       updatedAt: "2026-04-20T12:00:00.000Z",
     });
     writeCanonicalEvent.mockResolvedValue(undefined);
+    buildLeaseNoticePreviewInputFromLease.mockReturnValue({
+      rentChangeMode: "no_change",
+      proposedRent: null,
+      newTermType: "fixed_term",
+      newLeaseStartDate: "2026-05-11",
+      newLeaseEndDate: "2027-05-10",
+      responseDeadlineAt: Date.UTC(2026, 4, 1, 12, 0, 0, 0),
+      noticeType: "renewal_offer",
+    });
+    getLeaseForLandlordWorkflow.mockResolvedValue({
+      ok: true,
+      lease: {
+        id: "lease-1",
+        landlordId: "landlord-1",
+        tenantId: "tenant-1",
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        province: "NS",
+        leaseType: "fixed_term",
+        latestNoticeId: null,
+      },
+    });
+    normalizeLeaseRecord.mockImplementation((_id: string, raw: any) => ({ ...raw }));
+    buildLeaseNoticePolicyRequest.mockReturnValue({
+      domain: "lease_notice",
+      action: "send_notice",
+      context: { hasRequiredLegalInputs: true },
+    });
+    evaluatePolicy.mockReturnValue({ outcome: "allow", requiresManualApproval: false });
+    toAutopilotPolicySummary.mockReturnValue({ outcome: "allow", canAutopilot: true });
+    writePolicyEvaluatedEvent.mockResolvedValue(undefined);
+    performLeaseNoticeSendFromPreviewInput.mockResolvedValue({
+      status: 201,
+      payload: {
+        ok: true,
+        noticeId: "notice-1",
+        autopilotPolicy: { outcome: "allow", canAutopilot: true },
+      },
+    });
+    executeAutomation.mockImplementation(async (input: any) => {
+      const data = await input.context.execute();
+      return {
+        automationResult: {
+          action: input.action,
+          executed: true,
+          skipped: false,
+          timestamp: "2026-04-20T12:00:00.000Z",
+        },
+        data,
+      };
+    });
     loadLandlordAnalyticsSnapshot.mockResolvedValue({
       summary: {
         occupiedUnits: 4,
@@ -410,6 +491,113 @@ describe("landlordAnalyticsRoutes", () => {
         state: "dismissed",
       })
     );
+  });
+
+  it("executes a visible ready mapped complete lease-renewal decision", async () => {
+    loadLandlordAnalyticsSnapshot.mockResolvedValueOnce({
+      decisions: {
+        items: [
+          {
+            id: "review_lease_renewals:prop-1",
+            decisionType: "review_lease_renewals",
+            priority: "high",
+            explanation: "Review renewals.",
+            supportingSignals: [],
+            recommendedAction: "Review renewals",
+            actionKey: "open_lease_renewals_flow",
+            actionLabel: "Open renewals focus",
+            destination: "/portfolio-health?entry=lease-renewals&propertyId=prop-1",
+            workflowCategory: "lease_renewals",
+            automationEligible: true,
+            automationState: "ready",
+            automationReason: "This decision is active and already mapped to a deterministic automation path.",
+            executionMappingState: "mapped",
+            executionMapping: {
+              action: "lease.auto_send_notice",
+              resourceType: "lease",
+              resourceId: "lease-1",
+              prerequisitesMet: true,
+              prerequisiteReason: null,
+            },
+            executionInputState: "complete",
+            executionInputReason: null,
+            executionInputMissingFields: [],
+            executionInput: {
+              noticeType: "renewal_offer",
+              legalTemplateKey: "ns.fixed_term.renewal_offer.v1",
+              noticeRuleVersion: "ns-v1",
+              province: "NS",
+              leaseType: "fixed_term",
+              currentRent: 1650,
+              noticeDueAt: Date.UTC(2026, 1, 10, 0, 0, 0, 0),
+              rentChangeMode: "no_change",
+              proposedRent: null,
+              newTermType: "fixed_term",
+              newLeaseStartDate: "2026-05-11",
+              newLeaseEndDate: "2027-05-10",
+              responseDeadlineAt: Date.UTC(2026, 4, 1, 12, 0, 0, 0),
+            },
+            href: "/portfolio-health?entry=lease-renewals&propertyId=prop-1",
+            state: "pending",
+            reviewedAt: null,
+          },
+        ],
+      },
+    });
+
+    const router = (await import("../landlordAnalyticsRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "POST",
+      url: "/landlord/analytics/decisions/review_lease_renewals%3Aprop-1/execute",
+      user: { id: "landlord-1", role: "landlord" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(executeAutomation).toHaveBeenCalled();
+    expect(performLeaseNoticeSendFromPreviewInput).toHaveBeenCalled();
+    expect(writeCanonicalEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "decision.execution_requested",
+        metadata: expect.objectContaining({
+          decisionId: "review_lease_renewals:prop-1",
+          action: "lease.auto_send_notice",
+          resourceId: "lease-1",
+        }),
+      })
+    );
+    expect(writeCanonicalEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "decision.executed",
+      })
+    );
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        ok: true,
+        execution: expect.objectContaining({
+          decisionId: "review_lease_renewals:prop-1",
+          action: "lease.auto_send_notice",
+          resourceId: "lease-1",
+        }),
+      })
+    );
+  });
+
+  it("fails closed when a visible decision is not ready for execution", async () => {
+    const router = (await import("../landlordAnalyticsRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "POST",
+      url: "/landlord/analytics/decisions/reduce_vacancy_risk%3Aprop-123/execute",
+      user: { id: "landlord-1", role: "landlord" },
+    });
+
+    expect(response.status).toBe(409);
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        ok: false,
+        error: "DECISION_NOT_READY",
+      })
+    );
+    expect(executeAutomation).not.toHaveBeenCalled();
   });
 
   it("enforces landlord authentication", async () => {

--- a/rentchain-api/src/routes/__tests__/leaseNoticeLandlordRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseNoticeLandlordRoutes.test.ts
@@ -74,6 +74,10 @@ const deriveLeaseRenewalOperatorInputRecord = vi.fn((lease: any) => ({
 }));
 const lookupUserEmail = vi.fn(async () => "tenant@example.com");
 const normalizeLeaseRecord = vi.fn((id: string, raw: any) => ({ id, ...(raw || {}) }));
+const performLeaseNoticeSendFromPreviewInput = vi.fn(async () => ({
+  status: 201,
+  payload: { ok: true, noticeId: "notice-1", autopilotPolicy: { outcome: "allow", canAutopilot: true } },
+}));
 const sanitizeLeaseRenewalOperatorInput = vi.fn((body: any) => ({
   ok: true,
   data: {
@@ -110,6 +114,7 @@ vi.mock("../../services/leaseNoticeWorkflowService", () => ({
   getLeaseNoticeByLeaseId: vi.fn(),
   lookupUserEmail,
   normalizeLeaseRecord,
+  performLeaseNoticeSendFromPreviewInput,
   sanitizeLeaseRenewalOperatorInput,
   sendLeaseWorkflowEmail,
 }));

--- a/rentchain-api/src/routes/landlordAnalyticsRoutes.ts
+++ b/rentchain-api/src/routes/landlordAnalyticsRoutes.ts
@@ -1,7 +1,16 @@
 import { Router } from "express";
 import { writeCanonicalEvent } from "../lib/events/buildEvent";
+import { executeAutomation } from "../lib/automation/automationExecutor";
+import { buildLeaseNoticePolicyRequest } from "../lib/policy/policyAdapters";
+import { evaluatePolicy, toAutopilotPolicySummary, writePolicyEvaluatedEvent } from "../lib/policy/policyEvaluator";
 import { requireAuth } from "../middleware/requireAuth";
 import { requireLandlord } from "../middleware/requireLandlord";
+import {
+  buildLeaseNoticePreviewInputFromLease,
+  getLeaseForLandlordWorkflow,
+  normalizeLeaseRecord,
+  performLeaseNoticeSendFromPreviewInput,
+} from "../services/leaseNoticeWorkflowService";
 import { loadLandlordAnalyticsSnapshot } from "../services/landlord/landlordAnalyticsSnapshot";
 import {
   saveDismissedLandlordDecisionState,
@@ -200,6 +209,195 @@ router.post("/landlord/analytics/decisions/:decisionId/dismiss", requireAuth, re
   } catch (err: any) {
     console.error("[landlord-analytics] decision dismiss failed", err?.message || err);
     return res.status(500).json({ ok: false, error: "LANDLORD_DECISION_DISMISS_FAILED" });
+  }
+});
+
+router.post("/landlord/analytics/decisions/:decisionId/execute", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const resolved = await resolveVisibleDecision(req, res);
+    if (!resolved) return;
+    const { landlordId, decisionId, decision } = resolved;
+    const actorId = asString(req.user?.id || landlordId, 240) || null;
+
+    if (decision.automationState !== "ready") {
+      return res.status(409).json({ ok: false, error: "DECISION_NOT_READY", reason: decision.automationReason || null });
+    }
+    if (decision.executionMappingState !== "mapped" || !decision.executionMapping) {
+      return res.status(409).json({ ok: false, error: "DECISION_NOT_MAPPED" });
+    }
+    if (decision.executionInputState !== "complete" || !decision.executionInput) {
+      return res.status(409).json({
+        ok: false,
+        error: "DECISION_INPUTS_INCOMPLETE",
+        missingFields: decision.executionInputMissingFields || [],
+        reason: decision.executionInputReason || null,
+      });
+    }
+    if (decision.executionMapping.action !== "lease.auto_send_notice" || decision.executionMapping.resourceType !== "lease") {
+      return res.status(409).json({ ok: false, error: "DECISION_EXECUTION_UNSUPPORTED" });
+    }
+
+    const leaseResult = await getLeaseForLandlordWorkflow(decision.executionMapping.resourceId, landlordId);
+    if (!leaseResult.ok) {
+      return res.status(leaseResult.status).json({ ok: false, error: leaseResult.error });
+    }
+    const lease = normalizeLeaseRecord(leaseResult.lease.id || decision.executionMapping.resourceId, leaseResult.lease);
+    const previewInput = buildLeaseNoticePreviewInputFromLease(lease);
+    if (!previewInput) {
+      return res.status(409).json({
+        ok: false,
+        error: "DECISION_INPUTS_INCOMPLETE",
+        missingFields: decision.executionInputMissingFields || [],
+        reason: decision.executionInputReason || null,
+      });
+    }
+
+    await writeCanonicalEvent({
+      type: "decision.execution_requested",
+      domain: "system",
+      action: "execution_requested",
+      actor: { type: "landlord", id: landlordId, role: "landlord" },
+      resource: { type: "analytics_decision", id: decisionId },
+      occurredAt: new Date().toISOString(),
+      visibility: "landlord",
+      summary: `Analytics decision ${decisionId} execution requested.`,
+      metadata: {
+        landlordId,
+        decisionId,
+        decisionType: decision.decisionType,
+        action: decision.executionMapping.action,
+        resourceType: decision.executionMapping.resourceType,
+        resourceId: decision.executionMapping.resourceId,
+        source: "landlord_analytics_decisions",
+      },
+    });
+
+    const requestBody = {
+      rentChangeMode: previewInput.rentChangeMode,
+      proposedRent: previewInput.proposedRent,
+      newTermType: previewInput.newTermType,
+      newLeaseStartDate: previewInput.newLeaseStartDate,
+      newLeaseEndDate: previewInput.newLeaseEndDate,
+      responseDeadlineAt: previewInput.responseDeadlineAt,
+      noticeType: previewInput.noticeType,
+    };
+    const policyRequest = buildLeaseNoticePolicyRequest({
+      action: "send_notice",
+      actorRole: asString(req.user?.role, 80).toLowerCase() || "landlord",
+      actorUserId: actorId,
+      lease,
+      leaseId: lease.id,
+      requestBody,
+    });
+    const policyResult = evaluatePolicy(policyRequest);
+    const autopilotPolicy = toAutopilotPolicySummary(policyResult);
+    await writePolicyEvaluatedEvent({
+      request: policyRequest,
+      result: policyResult,
+      actorType: "landlord",
+      metadata: {
+        landlordId,
+        tenantId: lease.tenantId,
+        propertyId: lease.propertyId,
+        unitId: lease.unitId,
+        initiatedFrom: "decision_execute",
+        decisionId,
+      },
+    });
+
+    const automation = await executeAutomation({
+      action: "lease.auto_send_notice",
+      policyResult,
+      actor: {
+        type: "landlord",
+        id: actorId,
+        role: "landlord",
+      },
+      resource: {
+        type: "lease",
+        id: lease.id,
+      },
+      visibility: "internal",
+      metadata: {
+        domain: "lease_notice",
+        initiatedFrom: "decision_execute",
+        landlordId,
+        tenantId: lease.tenantId,
+        propertyId: lease.propertyId,
+        unitId: lease.unitId,
+        decisionId,
+        policyAction: "send_notice",
+      },
+      context: {
+        noticeReady: true,
+        alreadySent: Boolean(lease.latestNoticeId),
+        hasRequiredLegalInputs: Boolean(policyRequest.context.hasRequiredLegalInputs),
+        execute: async () => {
+          const execution = await performLeaseNoticeSendFromPreviewInput({
+            leaseId: lease.id,
+            landlordId,
+            actorId,
+            lease,
+            previewInput,
+            autopilotPolicy,
+          });
+          if (execution.status >= 400 || !execution.payload.ok) {
+            const error = new Error(String(execution.payload?.error || "AUTOMATION_EXECUTION_FAILED"));
+            (error as any).code = execution.payload?.error || "AUTOMATION_EXECUTION_FAILED";
+            throw error;
+          }
+          return execution.payload;
+        },
+      },
+    });
+
+    const success = Boolean(automation.automationResult.executed);
+    await writeCanonicalEvent({
+      type: success ? "decision.executed" : "decision.execution_failed",
+      domain: "system",
+      action: success ? "executed" : "execution_failed",
+      status: success ? "executed" : "failed",
+      actor: { type: "landlord", id: landlordId, role: "landlord" },
+      resource: { type: "analytics_decision", id: decisionId },
+      occurredAt: automation.automationResult.timestamp,
+      visibility: "landlord",
+      summary: success
+        ? `Analytics decision ${decisionId} executed.`
+        : `Analytics decision ${decisionId} execution failed.`,
+      metadata: {
+        landlordId,
+        decisionId,
+        decisionType: decision.decisionType,
+        action: decision.executionMapping.action,
+        resourceType: decision.executionMapping.resourceType,
+        resourceId: decision.executionMapping.resourceId,
+        reason: automation.automationResult.reason || null,
+        source: "landlord_analytics_decisions",
+      },
+    });
+
+    if (!success) {
+      return res.status(409).json({
+        ok: false,
+        error: "DECISION_EXECUTION_FAILED",
+        automationResult: automation.automationResult,
+      });
+    }
+
+    return res.json({
+      ok: true,
+      execution: {
+        decisionId,
+        action: decision.executionMapping.action,
+        resourceType: decision.executionMapping.resourceType,
+        resourceId: decision.executionMapping.resourceId,
+      },
+      automationResult: automation.automationResult,
+      ...(automation.data && typeof automation.data === "object" ? automation.data : {}),
+    });
+  } catch (err: any) {
+    console.error("[landlord-analytics] decision execute failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "LANDLORD_DECISION_EXECUTE_FAILED" });
   }
 });
 

--- a/rentchain-api/src/routes/leaseNoticeLandlordRoutes.ts
+++ b/rentchain-api/src/routes/leaseNoticeLandlordRoutes.ts
@@ -8,6 +8,7 @@ import {
 } from "../config/leaseNoticeRules";
 import {
   appendLeaseWorkflowEvent,
+  buildLeaseNoticePreviewInputFromLease,
   buildPreview,
   computeNoResponseState,
   deriveLeaseRenewalOperatorInputRecord,
@@ -15,6 +16,7 @@ import {
   getLeaseNoticeByLeaseId,
   lookupUserEmail,
   normalizeLeaseRecord,
+  performLeaseNoticeSendFromPreviewInput,
   sanitizeLeaseRenewalOperatorInput,
   sendLeaseWorkflowEmail,
 } from "../services/leaseNoticeWorkflowService";
@@ -40,10 +42,6 @@ function asNumber(value: unknown): number | null {
   return Number.isFinite(numeric) ? numeric : null;
 }
 
-function appBaseUrl() {
-  return String(process.env.PUBLIC_APP_URL || process.env.VITE_PUBLIC_APP_URL || "https://www.rentchain.ai").replace(/\/$/, "");
-}
-
 function isAutomationRequested(body: any) {
   return Boolean(body?.automationEnabled || body?.automation?.enabled);
 }
@@ -57,7 +55,7 @@ async function performLeaseNoticeSend(params: {
   autopilotPolicy: ReturnType<typeof toAutopilotPolicySummary>;
 }) {
   const { leaseId, landlordId, actorId, lease, reqBody, autopilotPolicy } = params;
-  const previewResult = buildPreview(lease, {
+  const previewInput = {
     rentChangeMode: String(reqBody?.rentChangeMode || "").trim().toLowerCase() as RentChangeMode,
     proposedRent: asNumber(reqBody?.proposedRent),
     newTermType: String(reqBody?.newTermType || "").trim().toLowerCase() as any,
@@ -65,216 +63,15 @@ async function performLeaseNoticeSend(params: {
     newLeaseEndDate: reqBody?.newLeaseEndDate ?? null,
     responseDeadlineAt: Number(reqBody?.responseDeadlineAt || 0),
     noticeType: (String(reqBody?.noticeType || "").trim().toLowerCase() || undefined) as LeaseNoticeType | undefined,
-  });
-  if (!previewResult.ok) {
-    return { status: 400, payload: { ok: false, error: previewResult.error, autopilotPolicy } };
-  }
-
-  const noticeRef = db.collection("leaseNotices").doc();
-  const now = Date.now();
-  const baseNotice = {
-    id: noticeRef.id,
-    leaseId,
-    landlordId,
-    tenantId: lease.tenantId,
-    propertyId: lease.propertyId,
-    unitId: lease.unitId,
-    noticeType: previewResult.preview.noticeType,
-    legalTemplateKey: previewResult.preview.legalTemplateKey,
-    province: lease.province,
-    leaseType: lease.leaseType,
-    noticeDueAt: previewResult.preview.noticeDueAt,
-    sentAt: null,
-    deliveryStatus: "pending",
-    deliveryChannel: "email",
-    rentChangeMode: previewResult.preview.rentChangeMode,
-    currentRent: previewResult.preview.currentRent,
-    proposedRent: previewResult.preview.proposedRent,
-    newTermType: previewResult.preview.newTermType,
-    newTermStartDate: previewResult.preview.newTermStartDate,
-    newTermEndDate: previewResult.preview.newTermEndDate,
-    responseRequired: true,
-    responseDeadlineAt: previewResult.preview.responseDeadlineAt,
-    tenantResponse: "pending",
-    tenantRespondedAt: null,
-    tenantViewedAt: null,
-    landlordNotifiedOfResponseAt: null,
-    metadata: {
-      noticeRuleVersion: previewResult.preview.noticeRuleVersion,
-      summary: previewResult.preview.summary,
-    },
-    createdAt: now,
-    updatedAt: now,
   };
-
-  const batch = db.batch();
-  batch.set(noticeRef, baseNotice);
-  batch.set(
-    db.collection("leases").doc(leaseId),
-    {
-      status: "renewal_pending",
-      latestNoticeId: noticeRef.id,
-      noticeRuleVersion: previewResult.preview.noticeRuleVersion,
-      noticeLeadDays: previewResult.rule.noticeLeadDays,
-      nextNoticeDueAt: previewResult.preview.noticeDueAt,
-      renewalRentChangeMode: previewResult.preview.rentChangeMode,
-      renewalOfferedRent: previewResult.preview.proposedRent,
-      renewalDecisionDeadlineAt: previewResult.preview.responseDeadlineAt,
-      renewalNewTermType: previewResult.preview.newTermType,
-      renewalNewLeaseStartDate: previewResult.preview.newTermStartDate,
-      renewalNewLeaseEndDate: previewResult.preview.newTermEndDate,
-      updatedAt: now,
-    },
-    { merge: true }
-  );
-  await appendLeaseWorkflowEvent({
-    batch,
-    entityType: "leaseNotice",
-    entityId: noticeRef.id,
+  return performLeaseNoticeSendFromPreviewInput({
     leaseId,
     landlordId,
-    tenantId: lease.tenantId,
-    propertyId: lease.propertyId,
-    unitId: lease.unitId,
-    actorType: "landlord",
     actorId,
-    eventType: "lease_notice_due",
-    eventData: {
-      noticeType: baseNotice.noticeType,
-      responseDeadlineAt: baseNotice.responseDeadlineAt,
-    },
+    lease,
+    previewInput,
+    autopilotPolicy,
   });
-  await batch.commit();
-
-  const tenantEmail = await lookupUserEmail(lease.tenantId, ["tenants", "users"]);
-  const tenantUrl = `${appBaseUrl()}/tenant/login?next=${encodeURIComponent(`/tenant/lease-notices/${noticeRef.id}`)}`;
-  const emailResult = await sendLeaseWorkflowEmail({
-    eventKey: "lease_notice_sent_tenant",
-    to: tenantEmail,
-    subject: "Lease notice from your landlord",
-    intro:
-      previewResult.preview.rentChangeMode === "undecided"
-        ? "Your landlord sent a lease notice and will decide rent later. Review the next-term options in RentChain."
-        : "Your landlord sent a lease notice. Review the next-term options and choose whether to begin a new term or quit at the end of the current term.",
-    ctaText: "Review lease notice",
-    ctaUrl: tenantUrl,
-    leaseId,
-    noticeId: noticeRef.id,
-    landlordId,
-    tenantId: lease.tenantId,
-    propertyId: lease.propertyId,
-    unitId: lease.unitId,
-  });
-
-  if (!emailResult.ok) {
-    await Promise.all([
-      noticeRef.set(
-        {
-          deliveryStatus: "failed",
-          metadata: {
-            ...baseNotice.metadata,
-            lastDeliveryError: emailResult.reason,
-          },
-          updatedAt: Date.now(),
-        },
-        { merge: true }
-      ),
-      appendLeaseWorkflowEvent({
-        entityType: "leaseNotice",
-        entityId: noticeRef.id,
-        leaseId,
-        landlordId,
-        tenantId: lease.tenantId,
-        propertyId: lease.propertyId,
-        unitId: lease.unitId,
-        actorType: "system",
-        actorId: null,
-        eventType: "landlord_notified",
-        eventData: {
-          kind: "send_failed",
-          noticeId: noticeRef.id,
-          reason: emailResult.reason,
-        },
-      }),
-    ]);
-    return {
-      status: 502,
-      payload: {
-        ok: false,
-        error: "LEASE_NOTICE_DELIVERY_FAILED",
-        noticeId: noticeRef.id,
-        delivery: emailResult,
-        autopilotPolicy,
-      },
-    };
-  }
-
-  const sentAt = Date.now();
-  const sentBatch = db.batch();
-  sentBatch.set(
-    noticeRef,
-    {
-      sentAt,
-      deliveryStatus: "sent",
-      updatedAt: sentAt,
-    },
-    { merge: true }
-  );
-  await appendLeaseWorkflowEvent({
-    batch: sentBatch,
-    entityType: "leaseNotice",
-    entityId: noticeRef.id,
-    leaseId,
-    landlordId,
-    tenantId: lease.tenantId,
-    propertyId: lease.propertyId,
-    unitId: lease.unitId,
-    actorType: "landlord",
-    actorId,
-    eventType: "lease_notice_sent",
-    eventData: {
-      deliveryStatus: "sent",
-      noticeType: baseNotice.noticeType,
-    },
-  });
-  await appendLeaseWorkflowEvent({
-    batch: sentBatch,
-    entityType: "lease",
-    entityId: leaseId,
-    leaseId,
-    landlordId,
-    tenantId: lease.tenantId,
-    propertyId: lease.propertyId,
-    unitId: lease.unitId,
-    actorType: "system",
-    actorId: null,
-    eventType: "landlord_notified",
-    eventData: {
-      kind: "notice_send_success",
-      noticeId: noticeRef.id,
-    },
-  });
-  await sentBatch.commit();
-
-  console.info("[lease-notice] sent", {
-    leaseId,
-    noticeId: noticeRef.id,
-    landlordId,
-    tenantId: lease.tenantId,
-    propertyId: lease.propertyId,
-    unitId: lease.unitId,
-    deliveryStatus: "sent",
-  });
-
-  return {
-    status: 201,
-    payload: {
-      ok: true,
-      noticeId: noticeRef.id,
-      delivery: emailResult,
-      autopilotPolicy,
-    },
-  };
 }
 
 router.get("/expiring", async (req: any, res) => {

--- a/rentchain-api/src/services/landlord/__tests__/landlordAnalyticsSnapshot.test.ts
+++ b/rentchain-api/src/services/landlord/__tests__/landlordAnalyticsSnapshot.test.ts
@@ -215,4 +215,72 @@ describe("loadLandlordAnalyticsSnapshot", () => {
     expect(result.propertyMetrics).toEqual([]);
     expect(result.comparisons.deltas.summary.maintenanceCostCents.direction).toBe("flat");
   });
+
+  it("promotes a complete mapped lease-renewal decision to ready automation state", async () => {
+    const nowIso = "2026-04-20T12:00:00.000Z";
+    seedDoc("properties", "prop-1", {
+      landlordId: "landlord-1",
+      name: "Alpha",
+      createdAt: nowIso,
+      updatedAt: nowIso,
+    });
+    seedDoc("units", "unit-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitNumber: "1",
+      createdAt: nowIso,
+      updatedAt: nowIso,
+    });
+    seedDoc("leases", "lease-1", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      unitNumber: "1",
+      status: "active",
+      leaseType: "fixed_term",
+      province: "NS",
+      currentRent: 1650,
+      monthlyRent: 1650,
+      startDate: "2025-05-11",
+      endDate: "2026-05-10",
+      renewalRentChangeMode: "no_change",
+      renewalDecisionDeadlineAt: Date.UTC(2026, 4, 1, 12, 0, 0, 0),
+      renewalNewTermType: "fixed_term",
+      renewalNewLeaseStartDate: "2026-05-11",
+      renewalNewLeaseEndDate: "2027-05-10",
+      createdAt: nowIso,
+      updatedAt: nowIso,
+    });
+    seedDoc("events", "event-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      type: "lease_expiry",
+      severity: "high",
+      status: "active",
+      message: "Lease is expiring soon.",
+      createdAt: nowIso,
+      occurredAt: nowIso,
+    });
+
+    const { loadLandlordAnalyticsSnapshot } = await import("../landlordAnalyticsSnapshot");
+    const result = await loadLandlordAnalyticsSnapshot({
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      now: Date.UTC(2026, 3, 20, 12, 0, 0, 0),
+    });
+
+    expect(result.decisions.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "review_lease_renewals:prop-1",
+          automationEligible: true,
+          automationState: "ready",
+          executionMappingState: "mapped",
+          executionInputState: "complete",
+          executionInputMissingFields: [],
+        }),
+      ])
+    );
+  });
 });

--- a/rentchain-api/src/services/landlord/landlordAnalyticsSnapshot.ts
+++ b/rentchain-api/src/services/landlord/landlordAnalyticsSnapshot.ts
@@ -258,11 +258,13 @@ export async function loadLandlordAnalyticsSnapshot(params: LandlordAnalyticsPar
 
   const snapshot = deriveLandlordAnalyticsSnapshot(derivedInput);
   const decisionStates = await loadLandlordDecisionStates(landlordId);
-  const decisions = applyDecisionExecutionMappings({
-    decisions: applyDecisionAutomationRules(mergeLandlordDecisionStates(snapshot.decisions.items, decisionStates)),
-    leases: derivedInput.leases,
-    now,
-  });
+  const decisions = applyDecisionAutomationRules(
+    applyDecisionExecutionMappings({
+      decisions: mergeLandlordDecisionStates(snapshot.decisions.items, decisionStates),
+      leases: derivedInput.leases,
+      now,
+    })
+  );
 
   return {
       ...snapshot,

--- a/rentchain-api/src/services/leaseNoticeWorkflowService.ts
+++ b/rentchain-api/src/services/leaseNoticeWorkflowService.ts
@@ -8,6 +8,7 @@ import {
   type RentChangeMode,
   resolveLeaseNoticeRule,
 } from "../config/leaseNoticeRules";
+import { toAutopilotPolicySummary } from "../lib/policy/policyEvaluator";
 
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -66,6 +67,22 @@ export type LeaseNoticePreviewInput = {
   newLeaseEndDate?: string | null;
   responseDeadlineAt: number;
   noticeType?: LeaseNoticeType;
+};
+
+export type LeaseNoticeSendResult = {
+  status: number;
+  payload: {
+    ok: boolean;
+    error?: string;
+    noticeId?: string;
+    delivery?: {
+      ok?: boolean;
+      attempted?: boolean;
+      provider?: string | null;
+      reason?: string | null;
+    } | null;
+    autopilotPolicy: ReturnType<typeof toAutopilotPolicySummary>;
+  };
 };
 
 export type LeaseNoticeExecutionInputState = "none" | "partial" | "complete";
@@ -408,6 +425,29 @@ export function deriveLeaseNoticeExecutionInputSnapshot(lease: LeaseWorkflowLeas
   };
 }
 
+export function buildLeaseNoticePreviewInputFromLease(lease: LeaseWorkflowLease): LeaseNoticePreviewInput | null {
+  const snapshot = deriveLeaseNoticeExecutionInputSnapshot(lease);
+  if (snapshot.state !== "complete" || !snapshot.input) return null;
+  if (
+    !snapshot.input.rentChangeMode ||
+    !snapshot.input.newTermType ||
+    !snapshot.input.newLeaseStartDate ||
+    !snapshot.input.responseDeadlineAt
+  ) {
+    return null;
+  }
+
+  return {
+    rentChangeMode: snapshot.input.rentChangeMode,
+    proposedRent: snapshot.input.proposedRent,
+    newTermType: snapshot.input.newTermType,
+    newLeaseStartDate: snapshot.input.newLeaseStartDate,
+    newLeaseEndDate: snapshot.input.newLeaseEndDate,
+    responseDeadlineAt: snapshot.input.responseDeadlineAt,
+    noticeType: snapshot.input.noticeType || undefined,
+  };
+}
+
 export async function getLeaseForLandlordWorkflow(leaseId: string, landlordId: string) {
   const snap = await db.collection("leases").doc(leaseId).get();
   if (!snap.exists) return { ok: false as const, status: 404, error: "LEASE_NOT_FOUND" };
@@ -529,6 +569,227 @@ export function buildPreview(lease: LeaseWorkflowLease, input: LeaseNoticePrevie
     },
   };
   return { ok: true as const, rule, preview };
+}
+
+export async function performLeaseNoticeSendFromPreviewInput(params: {
+  leaseId: string;
+  landlordId: string;
+  actorId: string | null;
+  lease: LeaseWorkflowLease;
+  previewInput: LeaseNoticePreviewInput;
+  autopilotPolicy: ReturnType<typeof toAutopilotPolicySummary>;
+}): Promise<LeaseNoticeSendResult> {
+  const { leaseId, landlordId, actorId, lease, previewInput, autopilotPolicy } = params;
+  const previewResult = buildPreview(lease, previewInput);
+  if (!previewResult.ok) {
+    return { status: 400, payload: { ok: false, error: previewResult.error, autopilotPolicy } };
+  }
+
+  const noticeRef = db.collection("leaseNotices").doc();
+  const now = Date.now();
+  const baseNotice = {
+    id: noticeRef.id,
+    leaseId,
+    landlordId,
+    tenantId: lease.tenantId,
+    propertyId: lease.propertyId,
+    unitId: lease.unitId,
+    noticeType: previewResult.preview.noticeType,
+    legalTemplateKey: previewResult.preview.legalTemplateKey,
+    province: lease.province,
+    leaseType: lease.leaseType,
+    noticeDueAt: previewResult.preview.noticeDueAt,
+    sentAt: null,
+    deliveryStatus: "pending",
+    deliveryChannel: "email",
+    rentChangeMode: previewResult.preview.rentChangeMode,
+    currentRent: previewResult.preview.currentRent,
+    proposedRent: previewResult.preview.proposedRent,
+    newTermType: previewResult.preview.newTermType,
+    newTermStartDate: previewResult.preview.newTermStartDate,
+    newTermEndDate: previewResult.preview.newTermEndDate,
+    responseRequired: true,
+    responseDeadlineAt: previewResult.preview.responseDeadlineAt,
+    tenantResponse: "pending",
+    tenantRespondedAt: null,
+    tenantViewedAt: null,
+    landlordNotifiedOfResponseAt: null,
+    metadata: {
+      noticeRuleVersion: previewResult.preview.noticeRuleVersion,
+      summary: previewResult.preview.summary,
+    },
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  const batch = db.batch();
+  batch.set(noticeRef, baseNotice);
+  batch.set(
+    db.collection("leases").doc(leaseId),
+    {
+      status: "renewal_pending",
+      latestNoticeId: noticeRef.id,
+      noticeRuleVersion: previewResult.preview.noticeRuleVersion,
+      noticeLeadDays: previewResult.rule.noticeLeadDays,
+      nextNoticeDueAt: previewResult.preview.noticeDueAt,
+      renewalRentChangeMode: previewResult.preview.rentChangeMode,
+      renewalOfferedRent: previewResult.preview.proposedRent,
+      renewalDecisionDeadlineAt: previewResult.preview.responseDeadlineAt,
+      renewalNewTermType: previewResult.preview.newTermType,
+      renewalNewLeaseStartDate: previewResult.preview.newTermStartDate,
+      renewalNewLeaseEndDate: previewResult.preview.newTermEndDate,
+      updatedAt: now,
+    },
+    { merge: true }
+  );
+  await appendLeaseWorkflowEvent({
+    batch,
+    entityType: "leaseNotice",
+    entityId: noticeRef.id,
+    leaseId,
+    landlordId,
+    tenantId: lease.tenantId,
+    propertyId: lease.propertyId,
+    unitId: lease.unitId,
+    actorType: "landlord",
+    actorId,
+    eventType: "lease_notice_due",
+    eventData: {
+      noticeType: baseNotice.noticeType,
+      responseDeadlineAt: baseNotice.responseDeadlineAt,
+    },
+  });
+  await batch.commit();
+
+  const tenantEmail = await lookupUserEmail(lease.tenantId, ["tenants", "users"]);
+  const tenantUrl = `${String(process.env.PUBLIC_APP_URL || process.env.VITE_PUBLIC_APP_URL || "https://www.rentchain.ai").replace(/\/$/, "")}/tenant/login?next=${encodeURIComponent(`/tenant/lease-notices/${noticeRef.id}`)}`;
+  const emailResult = await sendLeaseWorkflowEmail({
+    eventKey: "lease_notice_sent_tenant",
+    to: tenantEmail,
+    subject: "Lease notice from your landlord",
+    intro:
+      previewResult.preview.rentChangeMode === "undecided"
+        ? "Your landlord sent a lease notice and will decide rent later. Review the next-term options in RentChain."
+        : "Your landlord sent a lease notice. Review the next-term options and choose whether to begin a new term or quit at the end of the current term.",
+    ctaText: "Review lease notice",
+    ctaUrl: tenantUrl,
+    leaseId,
+    noticeId: noticeRef.id,
+    landlordId,
+    tenantId: lease.tenantId,
+    propertyId: lease.propertyId,
+    unitId: lease.unitId,
+  });
+
+  if (!emailResult.ok) {
+    await Promise.all([
+      noticeRef.set(
+        {
+          deliveryStatus: "failed",
+          metadata: {
+            ...baseNotice.metadata,
+            lastDeliveryError: emailResult.reason,
+          },
+          updatedAt: Date.now(),
+        },
+        { merge: true }
+      ),
+      appendLeaseWorkflowEvent({
+        entityType: "leaseNotice",
+        entityId: noticeRef.id,
+        leaseId,
+        landlordId,
+        tenantId: lease.tenantId,
+        propertyId: lease.propertyId,
+        unitId: lease.unitId,
+        actorType: "system",
+        actorId: null,
+        eventType: "landlord_notified",
+        eventData: {
+          kind: "send_failed",
+          noticeId: noticeRef.id,
+          reason: emailResult.reason,
+        },
+      }),
+    ]);
+    return {
+      status: 502,
+      payload: {
+        ok: false,
+        error: "LEASE_NOTICE_DELIVERY_FAILED",
+        noticeId: noticeRef.id,
+        delivery: emailResult,
+        autopilotPolicy,
+      },
+    };
+  }
+
+  const sentAt = Date.now();
+  const sentBatch = db.batch();
+  sentBatch.set(
+    noticeRef,
+    {
+      sentAt,
+      deliveryStatus: "sent",
+      updatedAt: sentAt,
+    },
+    { merge: true }
+  );
+  await appendLeaseWorkflowEvent({
+    batch: sentBatch,
+    entityType: "leaseNotice",
+    entityId: noticeRef.id,
+    leaseId,
+    landlordId,
+    tenantId: lease.tenantId,
+    propertyId: lease.propertyId,
+    unitId: lease.unitId,
+    actorType: "landlord",
+    actorId,
+    eventType: "lease_notice_sent",
+    eventData: {
+      deliveryStatus: "sent",
+      noticeType: baseNotice.noticeType,
+    },
+  });
+  await appendLeaseWorkflowEvent({
+    batch: sentBatch,
+    entityType: "lease",
+    entityId: leaseId,
+    leaseId,
+    landlordId,
+    tenantId: lease.tenantId,
+    propertyId: lease.propertyId,
+    unitId: lease.unitId,
+    actorType: "system",
+    actorId: null,
+    eventType: "landlord_notified",
+    eventData: {
+      kind: "notice_send_success",
+      noticeId: noticeRef.id,
+    },
+  });
+  await sentBatch.commit();
+
+  console.info("[lease-notice] sent", {
+    leaseId,
+    noticeId: noticeRef.id,
+    landlordId,
+    tenantId: lease.tenantId,
+    propertyId: lease.propertyId,
+    unitId: lease.unitId,
+    deliveryStatus: "sent",
+  });
+
+  return {
+    status: 201,
+    payload: {
+      ok: true,
+      noticeId: noticeRef.id,
+      delivery: emailResult,
+      autopilotPolicy,
+    },
+  };
 }
 
 export async function appendLeaseWorkflowEvent(input: {

--- a/rentchain-frontend/src/api/landlordAnalyticsApi.ts
+++ b/rentchain-frontend/src/api/landlordAnalyticsApi.ts
@@ -328,3 +328,33 @@ export async function dismissLandlordDecision(params: {
     method: "POST",
   });
 }
+
+export async function executeLandlordDecision(params: {
+  decisionId: string;
+  period?: AnalyticsPeriod;
+  propertyId?: string | null;
+}): Promise<{
+  ok: true;
+  execution: {
+    decisionId: string;
+    action: LandlordDecisionExecutionMapping["action"];
+    resourceType: LandlordDecisionExecutionMapping["resourceType"];
+    resourceId: string;
+  };
+  automationResult: {
+    action: LandlordDecisionExecutionMapping["action"];
+    executed: boolean;
+    skipped: boolean;
+    reason?: string;
+    timestamp: string;
+  };
+  noticeId?: string;
+}> {
+  const search = new URLSearchParams();
+  if (params.period) search.set("period", params.period);
+  if (params.propertyId) search.set("propertyId", params.propertyId);
+  const suffix = search.toString() ? `?${search.toString()}` : "";
+  return await apiFetch(`/landlord/analytics/decisions/${encodeURIComponent(params.decisionId)}/execute${suffix}`, {
+    method: "POST",
+  });
+}

--- a/rentchain-frontend/src/components/analytics/AgentDecisionPanel.test.tsx
+++ b/rentchain-frontend/src/components/analytics/AgentDecisionPanel.test.tsx
@@ -13,6 +13,9 @@ const { snoozeLandlordDecision } = vi.hoisted(() => ({
 const { dismissLandlordDecision } = vi.hoisted(() => ({
   dismissLandlordDecision: vi.fn(),
 }));
+const { executeLandlordDecision } = vi.hoisted(() => ({
+  executeLandlordDecision: vi.fn(),
+}));
 
 vi.mock("@/api/landlordAnalyticsApi", async () => {
   const actual = await vi.importActual<typeof import("@/api/landlordAnalyticsApi")>("@/api/landlordAnalyticsApi");
@@ -21,6 +24,7 @@ vi.mock("@/api/landlordAnalyticsApi", async () => {
     markLandlordDecisionReviewed,
     snoozeLandlordDecision,
     dismissLandlordDecision,
+    executeLandlordDecision,
   };
 });
 
@@ -46,6 +50,22 @@ beforeEach(() => {
       dismissedAt: "2026-04-22T12:00:00.000Z",
       updatedAt: "2026-04-22T12:00:00.000Z",
     },
+  });
+  executeLandlordDecision.mockResolvedValue({
+    ok: true,
+    execution: {
+      decisionId: "review_lease_renewals:prop-1",
+      action: "lease.auto_send_notice",
+      resourceType: "lease",
+      resourceId: "lease-1",
+    },
+    automationResult: {
+      action: "lease.auto_send_notice",
+      executed: true,
+      skipped: false,
+      timestamp: "2026-04-22T12:00:00.000Z",
+    },
+    noticeId: "notice-1",
   });
 });
 
@@ -264,5 +284,72 @@ describe("AgentDecisionPanel", () => {
       });
     });
     expect(screen.queryByText(/Vacancy pressure is concentrated in Beta/i)).not.toBeInTheDocument();
+  });
+
+  it("shows an explicit execute control only for ready mapped complete decisions", async () => {
+    render(
+      <MemoryRouter>
+        <AgentDecisionPanel
+          period="90d"
+          decisions={[
+            {
+              id: "review_lease_renewals:prop-1",
+              decisionType: "review_lease_renewals",
+              priority: "high",
+              explanation: "Review upcoming renewals.",
+              recommendedAction: "Review renewals",
+              actionKey: "open_lease_renewals_flow",
+              actionLabel: "Open renewals focus",
+              destination: "/portfolio-health?entry=lease-renewals&propertyId=prop-1",
+              workflowCategory: "lease_renewals",
+              automationEligible: true,
+              automationState: "ready",
+              automationReason: "This decision is active and already mapped to a deterministic automation path.",
+              executionMappingState: "mapped",
+              executionMapping: {
+                action: "lease.auto_send_notice",
+                resourceType: "lease",
+                resourceId: "lease-1",
+                prerequisitesMet: true,
+                prerequisiteReason: null,
+              },
+              executionInputState: "complete",
+              executionInputReason: null,
+              executionInputMissingFields: [],
+              executionInput: {
+                noticeType: "renewal_offer",
+                legalTemplateKey: "ns.fixed_term.renewal_offer.v1",
+                noticeRuleVersion: "ns-v1",
+                province: "NS",
+                leaseType: "fixed_term",
+                currentRent: 1650,
+                noticeDueAt: Date.UTC(2026, 1, 10, 0, 0, 0, 0),
+                rentChangeMode: "no_change",
+                proposedRent: null,
+                newTermType: "fixed_term",
+                newLeaseStartDate: "2026-05-11",
+                newLeaseEndDate: "2027-05-10",
+                responseDeadlineAt: Date.UTC(2026, 4, 1, 12, 0, 0, 0),
+              },
+              href: "/portfolio-health?entry=lease-renewals&propertyId=prop-1",
+              state: "pending",
+              reviewedAt: null,
+              supportingSignals: [],
+            },
+          ]}
+        />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Execute now/i }));
+
+    await waitFor(() => {
+      expect(executeLandlordDecision).toHaveBeenCalledWith({
+        decisionId: "review_lease_renewals:prop-1",
+        period: "90d",
+        propertyId: null,
+      });
+    });
+    expect(screen.queryByText(/Review upcoming renewals/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/components/analytics/AgentDecisionPanel.tsx
+++ b/rentchain-frontend/src/components/analytics/AgentDecisionPanel.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { Card } from "../ui/Ui";
 import {
   dismissLandlordDecision,
+  executeLandlordDecision,
   markLandlordDecisionReviewed,
   snoozeLandlordDecision,
   type AnalyticsPeriod,
@@ -76,7 +77,7 @@ export function AgentDecisionPanel({
 }: Props) {
   const [items, setItems] = React.useState(decisions);
   const [workingDecisionId, setWorkingDecisionId] = React.useState<string | null>(null);
-  const [workingAction, setWorkingAction] = React.useState<"review" | "snooze" | "dismiss" | null>(null);
+  const [workingAction, setWorkingAction] = React.useState<"review" | "snooze" | "dismiss" | "execute" | null>(null);
   const [error, setError] = React.useState<string | null>(null);
 
   React.useEffect(() => {
@@ -152,6 +153,25 @@ export function AgentDecisionPanel({
     }
   };
 
+  const handleExecute = async (decisionId: string) => {
+    try {
+      setWorkingDecisionId(decisionId);
+      setWorkingAction("execute");
+      setError(null);
+      await executeLandlordDecision({
+        decisionId,
+        period,
+        propertyId,
+      });
+      setItems((current) => current.filter((decision) => decision.id !== decisionId));
+    } catch (err: unknown) {
+      setError(errorMessage(err));
+    } finally {
+      setWorkingDecisionId(null);
+      setWorkingAction(null);
+    }
+  };
+
   return (
     <Card>
       <div style={{ display: "grid", gap: 14 }}>
@@ -175,6 +195,10 @@ export function AgentDecisionPanel({
                 : decision.href
                   ? decision.recommendedAction
                   : null;
+              const canExecuteNow =
+                decision.automationState === "ready" &&
+                decision.executionMappingState === "mapped" &&
+                decision.executionInputState === "complete";
               return (
                 <div
                   key={decision.id}
@@ -233,6 +257,23 @@ export function AgentDecisionPanel({
                       <Link to={ctaDestination} style={{ color: "#0f766e", fontWeight: 700, textDecoration: "none" }}>
                         {ctaLabel}
                       </Link>
+                    ) : null}
+                    {canExecuteNow ? (
+                      <button
+                        type="button"
+                        onClick={() => void handleExecute(decision.id)}
+                        disabled={workingDecisionId === decision.id}
+                        style={{
+                          border: "1px solid #166534",
+                          borderRadius: 999,
+                          background: "#166534",
+                          color: "#fff",
+                          fontWeight: 700,
+                          padding: "6px 12px",
+                        }}
+                      >
+                        {workingDecisionId === decision.id && workingAction === "execute" ? "Executing…" : "Execute now"}
+                      </button>
                     ) : null}
                     {decision.state === "reviewed" ? (
                       <div


### PR DESCRIPTION
Summary

Add the first controlled explicit execution path for landlord decisions.

This PR preserves the full landlord decision stack:
	•	derived decision content
	•	structured workflow/action metadata
	•	durable lifecycle state
	•	workflow entry destinations
	•	deterministic automation rules
	•	deterministic execution mapping
	•	deterministic lease notice execution-input mapping
	•	readiness resolution
	•	canonical operator input capture

and adds a narrow, explicit execution path only for the safe lease-renewal case.

Changes
	•	Reuse existing lease notice execution infrastructure through a shared helper instead of duplicating send logic
	•	Reorder the landlord snapshot pipeline so execution mapping and input completeness feed automation readiness canonically
	•	Add a narrow landlord decision execution route gated by:
	•	visibility
	•	readiness
	•	mapping
	•	input completeness
	•	Emit canonical decision execution events
	•	Add a minimal Execute now affordance in the shared decision panel only for visible ready + mapped + complete lease-renewal decisions
	•	Preserve destination CTA behavior for all other decisions
	•	Keep lifecycle state unchanged and orthogonal to execution

Validation
	•	targeted backend tests
	•	targeted frontend tests
	•	backend build
	•	frontend build
	•	targeted frontend lint on touched files

Notes
	•	Supported execution scope is intentionally narrow:
	•	review_lease_renewals → lease.auto_send_notice
	•	No maintenance or application execution paths were added
	•	Unsupported, incomplete, unmapped, or non-ready decisions fail closed
	•	Executed decisions are not auto-reviewed or auto-dismissed in v2
	•	Existing frontend chunk-size warning remains non-blocking
