### PR TITLE
feat: add decision resolution visibility filtering v1

### DIFF
--- a/rentchain-frontend/src/components/analytics/AgentDecisionPanel.test.tsx
+++ b/rentchain-frontend/src/components/analytics/AgentDecisionPanel.test.tsx
@@ -125,6 +125,7 @@ describe("AgentDecisionPanel", () => {
     );
 
     expect(screen.getByRole("heading", { name: /Recommended next actions/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Actions to review/i })).toBeInTheDocument();
     expect(screen.getByText(/Vacancy pressure is concentrated in Beta/i)).toBeInTheDocument();
     expect(screen.getByText(/high priority/i)).toBeInTheDocument();
     expect(screen.getByText(/Workflow: Vacancy readiness/i)).toBeInTheDocument();
@@ -379,8 +380,168 @@ describe("AgentDecisionPanel", () => {
         propertyId: null,
       });
     });
-    expect(await screen.findByText("Executed")).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: /Recently executed/i })).toBeInTheDocument();
     expect(screen.getByText(/Notice sent/i)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Execute now/i })).not.toBeInTheDocument();
+  });
+
+  it("keeps failed execution feedback in the active section", async () => {
+    executeLandlordDecision.mockResolvedValueOnce({
+      ok: false,
+      error: "DECISION_EXECUTION_FAILED",
+      state: {
+        decisionId: "review_lease_renewals:prop-1",
+        state: "pending",
+        executedAt: null,
+        executionOutcomeStatus: "failed",
+        executionOutcomeAt: "2026-04-22T12:00:00.000Z",
+        executionOutcomeReason: "AUTOMATION_EXECUTION_FAILED",
+        updatedAt: "2026-04-22T12:00:00.000Z",
+      },
+      automationResult: {
+        action: "lease.auto_send_notice",
+        executed: false,
+        skipped: true,
+        reason: "AUTOMATION_EXECUTION_FAILED",
+        timestamp: "2026-04-22T12:00:00.000Z",
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <AgentDecisionPanel
+          period="90d"
+          decisions={[
+            {
+              id: "review_lease_renewals:prop-1",
+              decisionType: "review_lease_renewals",
+              priority: "high",
+              explanation: "Review upcoming renewals.",
+              recommendedAction: "Review renewals",
+              actionKey: "open_lease_renewals_flow",
+              actionLabel: "Open renewals focus",
+              destination: "/portfolio-health?entry=lease-renewals&propertyId=prop-1",
+              workflowCategory: "lease_renewals",
+              automationEligible: true,
+              automationState: "ready",
+              automationReason: "This decision is active and already mapped to a deterministic automation path.",
+              executionMappingState: "mapped",
+              executionMapping: {
+                action: "lease.auto_send_notice",
+                resourceType: "lease",
+                resourceId: "lease-1",
+                prerequisitesMet: true,
+                prerequisiteReason: null,
+              },
+              executionInputState: "complete",
+              executionInputReason: null,
+              executionInputMissingFields: [],
+              executionInput: {
+                noticeType: "renewal_offer",
+                legalTemplateKey: "ns.fixed_term.renewal_offer.v1",
+                noticeRuleVersion: "ns-v1",
+                province: "NS",
+                leaseType: "fixed_term",
+                currentRent: 1650,
+                noticeDueAt: Date.UTC(2026, 1, 10, 0, 0, 0, 0),
+                rentChangeMode: "no_change",
+                proposedRent: null,
+                newTermType: "fixed_term",
+                newLeaseStartDate: "2026-05-11",
+                newLeaseEndDate: "2027-05-10",
+                responseDeadlineAt: Date.UTC(2026, 4, 1, 12, 0, 0, 0),
+              },
+              executedAt: null,
+              executionOutcomeStatus: "none",
+              executionOutcomeAt: null,
+              executionOutcomeReason: null,
+              href: "/portfolio-health?entry=lease-renewals&propertyId=prop-1",
+              state: "pending",
+              reviewedAt: null,
+              supportingSignals: [],
+            },
+          ]}
+        />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Execute now/i }));
+
+    await waitFor(() => {
+      expect(executeLandlordDecision).toHaveBeenCalledWith({
+        decisionId: "review_lease_renewals:prop-1",
+        period: "90d",
+        propertyId: null,
+      });
+    });
+    expect(screen.queryByRole("heading", { name: /Recently executed/i })).not.toBeInTheDocument();
+    expect(screen.getByText(/Execution failed/i)).toBeInTheDocument();
+    expect(screen.getByText(/AUTOMATION_EXECUTION_FAILED/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Execute now/i })).toBeInTheDocument();
+  });
+
+  it("renders executed decisions in a secondary section", () => {
+    render(
+      <MemoryRouter>
+        <AgentDecisionPanel
+          decisions={[
+            {
+              id: "review_lease_renewals:prop-1",
+              decisionType: "review_lease_renewals",
+              priority: "high",
+              explanation: "Review upcoming renewals.",
+              recommendedAction: "Review renewals",
+              actionKey: "open_lease_renewals_flow",
+              actionLabel: "Open renewals focus",
+              destination: "/portfolio-health?entry=lease-renewals&propertyId=prop-1",
+              workflowCategory: "lease_renewals",
+              automationEligible: true,
+              automationState: "ready",
+              automationReason: "This decision is active and already mapped to a deterministic automation path.",
+              executionMappingState: "mapped",
+              executionMapping: {
+                action: "lease.auto_send_notice",
+                resourceType: "lease",
+                resourceId: "lease-1",
+                prerequisitesMet: true,
+                prerequisiteReason: null,
+              },
+              executionInputState: "complete",
+              executionInputReason: null,
+              executionInputMissingFields: [],
+              executionInput: {
+                noticeType: "renewal_offer",
+                legalTemplateKey: "ns.fixed_term.renewal_offer.v1",
+                noticeRuleVersion: "ns-v1",
+                province: "NS",
+                leaseType: "fixed_term",
+                currentRent: 1650,
+                noticeDueAt: Date.UTC(2026, 1, 10, 0, 0, 0, 0),
+                rentChangeMode: "no_change",
+                proposedRent: null,
+                newTermType: "fixed_term",
+                newLeaseStartDate: "2026-05-11",
+                newLeaseEndDate: "2027-05-10",
+                responseDeadlineAt: Date.UTC(2026, 4, 1, 12, 0, 0, 0),
+              },
+              executedAt: "2026-04-22T12:00:00.000Z",
+              executionOutcomeStatus: "succeeded",
+              executionOutcomeAt: "2026-04-22T12:00:00.000Z",
+              executionOutcomeReason: null,
+              href: "/portfolio-health?entry=lease-renewals&propertyId=prop-1",
+              state: "executed",
+              reviewedAt: null,
+              supportingSignals: [],
+            },
+          ]}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("heading", { name: /Actions to review/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Recently executed/i })).toBeInTheDocument();
+    expect(screen.getByText(/No attention-worthy actions are surfaced/i)).toBeInTheDocument();
+    expect(screen.getByText(/Notice sent/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Dismiss/i })).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/components/analytics/AgentDecisionPanel.tsx
+++ b/rentchain-frontend/src/components/analytics/AgentDecisionPanel.tsx
@@ -25,7 +25,10 @@ const workflowCategoryLabel: Record<NonNullable<LandlordAgentDecision["workflowC
   property_focus: "Property focus",
 };
 
-const automationTone: Record<Exclude<LandlordAgentDecision["automationState"], "manual_only">, { bg: string; text: string; label: string }> = {
+const automationTone: Record<
+  Exclude<LandlordAgentDecision["automationState"], "manual_only">,
+  { bg: string; text: string; label: string }
+> = {
   ready: {
     bg: "rgba(21, 128, 61, 0.1)",
     text: "#166534",
@@ -38,7 +41,10 @@ const automationTone: Record<Exclude<LandlordAgentDecision["automationState"], "
   },
 };
 
-const executionOutcomeTone: Record<Exclude<LandlordAgentDecision["executionOutcomeStatus"], "none">, { bg: string; text: string; label: string }> = {
+const executionOutcomeTone: Record<
+  Exclude<LandlordAgentDecision["executionOutcomeStatus"], "none">,
+  { bg: string; text: string; label: string }
+> = {
   succeeded: {
     bg: "rgba(21, 128, 61, 0.1)",
     text: "#166534",
@@ -80,6 +86,263 @@ function supportingLine(decision: LandlordAgentDecision) {
   return parts.length ? parts.join(" • ") : null;
 }
 
+function formatExecutedCopy(executedAt?: string | null) {
+  return `Notice sent${executedAt ? ` on ${new Date(executedAt).toLocaleDateString()}` : ""}.`;
+}
+
+function sectionHeadingStyle() {
+  return {
+    margin: 0,
+    fontSize: "0.92rem",
+    color: "#0f172a",
+  } as const;
+}
+
+function ActionDecisionCard(props: {
+  decision: LandlordAgentDecision;
+  workingDecisionId: string | null;
+  workingAction: "review" | "snooze" | "dismiss" | "execute" | null;
+  onReview: (decisionId: string) => Promise<void>;
+  onSnooze: (decisionId: string, days: number) => Promise<void>;
+  onDismiss: (decisionId: string) => Promise<void>;
+  onExecute: (decisionId: string) => Promise<void>;
+}) {
+  const { decision, workingDecisionId, workingAction, onReview, onSnooze, onDismiss, onExecute } = props;
+  const support = supportingLine(decision);
+  const categoryLabel = decision.workflowCategory ? workflowCategoryLabel[decision.workflowCategory] : null;
+  const ctaDestination = decision.destination || decision.href;
+  const ctaLabel = decision.destination
+    ? decision.actionLabel || decision.recommendedAction
+    : decision.href
+      ? decision.recommendedAction
+      : null;
+  const canExecuteNow =
+    decision.automationState === "ready" &&
+    decision.executionMappingState === "mapped" &&
+    decision.executionInputState === "complete";
+
+  return (
+    <div
+      style={{
+        border: "1px solid #e2e8f0",
+        borderRadius: 12,
+        padding: 14,
+        background: "#fff",
+        display: "grid",
+        gap: 8,
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+        <div style={{ fontWeight: 700, color: "#0f172a" }}>{decision.recommendedAction}</div>
+        <div
+          style={{
+            padding: "4px 9px",
+            borderRadius: 999,
+            background: priorityTone[decision.priority].bg,
+            color: priorityTone[decision.priority].text,
+            fontWeight: 700,
+            fontSize: "0.78rem",
+            textTransform: "uppercase",
+          }}
+        >
+          {decision.priority} priority
+        </div>
+      </div>
+      <div style={{ color: "#334155" }}>{decision.explanation}</div>
+      {categoryLabel ? (
+        <div style={{ color: "#64748b", fontSize: "0.82rem", fontWeight: 600 }}>
+          Workflow: {categoryLabel}
+        </div>
+      ) : null}
+      {decision.automationState !== "manual_only" ? (
+        <div
+          style={{
+            justifySelf: "start",
+            padding: "4px 9px",
+            borderRadius: 999,
+            background: automationTone[decision.automationState].bg,
+            color: automationTone[decision.automationState].text,
+            fontWeight: 700,
+            fontSize: "0.78rem",
+          }}
+        >
+          {automationTone[decision.automationState].label}
+        </div>
+      ) : null}
+      {support ? <div style={{ color: "#64748b", fontSize: "0.88rem" }}>{support}</div> : null}
+      {decision.automationState !== "manual_only" && decision.automationReason ? (
+        <div style={{ color: "#64748b", fontSize: "0.84rem" }}>{decision.automationReason}</div>
+      ) : null}
+      {decision.executionOutcomeStatus !== "none" ? (
+        <div
+          style={{
+            justifySelf: "start",
+            padding: "4px 9px",
+            borderRadius: 999,
+            background: executionOutcomeTone[decision.executionOutcomeStatus].bg,
+            color: executionOutcomeTone[decision.executionOutcomeStatus].text,
+            fontWeight: 700,
+            fontSize: "0.78rem",
+          }}
+        >
+          {executionOutcomeTone[decision.executionOutcomeStatus].label}
+        </div>
+      ) : null}
+      {decision.executionOutcomeStatus === "failed" ? (
+        <div style={{ color: "#991b1b", fontSize: "0.84rem" }}>
+          {decision.executionOutcomeReason || "The last execution attempt failed."}
+        </div>
+      ) : null}
+      <div style={{ display: "flex", gap: 12, flexWrap: "wrap", alignItems: "center" }}>
+        {ctaDestination && ctaLabel ? (
+          <Link to={ctaDestination} style={{ color: "#0f766e", fontWeight: 700, textDecoration: "none" }}>
+            {ctaLabel}
+          </Link>
+        ) : null}
+        {canExecuteNow ? (
+          <button
+            type="button"
+            onClick={() => void onExecute(decision.id)}
+            disabled={workingDecisionId === decision.id}
+            style={{
+              border: "1px solid #166534",
+              borderRadius: 999,
+              background: "#166534",
+              color: "#fff",
+              fontWeight: 700,
+              padding: "6px 12px",
+            }}
+          >
+            {workingDecisionId === decision.id && workingAction === "execute" ? "Executing…" : "Execute now"}
+          </button>
+        ) : null}
+        {decision.state === "reviewed" ? (
+          <div
+            style={{
+              padding: "4px 9px",
+              borderRadius: 999,
+              background: "rgba(15, 118, 110, 0.1)",
+              color: "#0f766e",
+              fontWeight: 700,
+              fontSize: "0.8rem",
+            }}
+          >
+            Reviewed
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={() => void onReview(decision.id)}
+            disabled={workingDecisionId === decision.id}
+            style={{
+              border: "1px solid #cbd5e1",
+              borderRadius: 999,
+              background: "#f8fafc",
+              color: "#0f172a",
+              fontWeight: 700,
+              padding: "6px 12px",
+              cursor: workingDecisionId === decision.id ? "not-allowed" : "pointer",
+            }}
+          >
+            {workingDecisionId === decision.id && workingAction === "review" ? "Saving..." : "Mark Reviewed"}
+          </button>
+        )}
+        {SNOOZE_PRESETS.map((preset) => (
+          <button
+            key={`${decision.id}-${preset.days}`}
+            type="button"
+            onClick={() => void onSnooze(decision.id, preset.days)}
+            disabled={workingDecisionId === decision.id}
+            style={{
+              border: "1px solid #cbd5e1",
+              borderRadius: 999,
+              background: "#fff",
+              color: "#334155",
+              fontWeight: 600,
+              padding: "6px 10px",
+              cursor: workingDecisionId === decision.id ? "not-allowed" : "pointer",
+            }}
+          >
+            {workingDecisionId === decision.id && workingAction === "snooze" ? "Saving..." : preset.label}
+          </button>
+        ))}
+        <button
+          type="button"
+          onClick={() => void onDismiss(decision.id)}
+          disabled={workingDecisionId === decision.id}
+          style={{
+            border: "1px solid rgba(185, 28, 28, 0.25)",
+            borderRadius: 999,
+            background: "#fff",
+            color: "#991b1b",
+            fontWeight: 700,
+            padding: "6px 12px",
+            cursor: workingDecisionId === decision.id ? "not-allowed" : "pointer",
+          }}
+        >
+          {workingDecisionId === decision.id && workingAction === "dismiss" ? "Saving..." : "Dismiss"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ExecutedDecisionCard(props: {
+  decision: LandlordAgentDecision;
+}) {
+  const { decision } = props;
+  const categoryLabel = decision.workflowCategory ? workflowCategoryLabel[decision.workflowCategory] : null;
+  const ctaDestination = decision.destination || decision.href;
+  const ctaLabel = decision.destination
+    ? decision.actionLabel || decision.recommendedAction
+    : decision.href
+      ? decision.recommendedAction
+      : null;
+
+  return (
+    <div
+      style={{
+        border: "1px solid #dcfce7",
+        borderRadius: 12,
+        padding: 14,
+        background: "#f8fffb",
+        display: "grid",
+        gap: 8,
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+        <div style={{ fontWeight: 700, color: "#0f172a" }}>{decision.recommendedAction}</div>
+        <div
+          style={{
+            padding: "4px 9px",
+            borderRadius: 999,
+            background: executionOutcomeTone.succeeded.bg,
+            color: executionOutcomeTone.succeeded.text,
+            fontWeight: 700,
+            fontSize: "0.78rem",
+          }}
+        >
+          {executionOutcomeTone.succeeded.label}
+        </div>
+      </div>
+      <div style={{ color: "#334155" }}>{decision.explanation}</div>
+      {categoryLabel ? (
+        <div style={{ color: "#64748b", fontSize: "0.82rem", fontWeight: 600 }}>
+          Workflow: {categoryLabel}
+        </div>
+      ) : null}
+      <div style={{ color: "#166534", fontSize: "0.84rem" }}>{formatExecutedCopy(decision.executedAt)}</div>
+      <div style={{ display: "flex", gap: 12, flexWrap: "wrap", alignItems: "center" }}>
+        {ctaDestination && ctaLabel ? (
+          <Link to={ctaDestination} style={{ color: "#0f766e", fontWeight: 700, textDecoration: "none" }}>
+            {ctaLabel}
+          </Link>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
 export function AgentDecisionPanel({
   decisions,
   title = "Recommended next actions",
@@ -96,6 +359,9 @@ export function AgentDecisionPanel({
   React.useEffect(() => {
     setItems(decisions);
   }, [decisions]);
+
+  const activeItems = React.useMemo(() => items.filter((decision) => decision.state !== "executed"), [items]);
+  const executedItems = React.useMemo(() => items.filter((decision) => decision.state === "executed"), [items]);
 
   const handleReview = async (decisionId: string) => {
     try {
@@ -183,12 +449,12 @@ export function AgentDecisionPanel({
               decision.id === decisionId
                 ? {
                     ...decision,
-                    state: response.state!.state,
-                    reviewedAt: response.state!.reviewedAt ?? decision.reviewedAt ?? null,
-                    executedAt: response.state!.executedAt ?? decision.executedAt ?? null,
-                    executionOutcomeStatus: response.state!.executionOutcomeStatus,
-                    executionOutcomeAt: response.state!.executionOutcomeAt,
-                    executionOutcomeReason: response.state!.executionOutcomeReason,
+                    state: response.state.state,
+                    reviewedAt: response.state.reviewedAt ?? decision.reviewedAt ?? null,
+                    executedAt: response.state.executedAt ?? decision.executedAt ?? null,
+                    executionOutcomeStatus: response.state.executionOutcomeStatus,
+                    executionOutcomeAt: response.state.executionOutcomeAt,
+                    executionOutcomeReason: response.state.executionOutcomeReason,
                   }
                 : decision
             )
@@ -229,198 +495,40 @@ export function AgentDecisionPanel({
 
         {error ? <div style={{ color: "#b91c1c" }}>{error}</div> : null}
 
-        {!items.length ? (
-          <div style={{ color: "#64748b" }}>{emptyMessage}</div>
-        ) : (
+        <div style={{ display: "grid", gap: 14 }}>
           <div style={{ display: "grid", gap: 10 }}>
-            {items.map((decision) => {
-              const support = supportingLine(decision);
-              const categoryLabel = decision.workflowCategory ? workflowCategoryLabel[decision.workflowCategory] : null;
-              const ctaDestination = decision.destination || decision.href;
-              const ctaLabel = decision.destination
-                ? decision.actionLabel || decision.recommendedAction
-                : decision.href
-                  ? decision.recommendedAction
-                  : null;
-              const canExecuteNow =
-                decision.state !== "executed" &&
-                decision.automationState === "ready" &&
-                decision.executionMappingState === "mapped" &&
-                decision.executionInputState === "complete";
-              const isResolved = decision.state === "executed";
-              return (
-                <div
-                  key={decision.id}
-                  style={{
-                    border: "1px solid #e2e8f0",
-                    borderRadius: 12,
-                    padding: 14,
-                    background: "#fff",
-                    display: "grid",
-                    gap: 8,
-                  }}
-                >
-                  <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
-                    <div style={{ fontWeight: 700, color: "#0f172a" }}>{decision.recommendedAction}</div>
-                    <div
-                      style={{
-                        padding: "4px 9px",
-                        borderRadius: 999,
-                        background: priorityTone[decision.priority].bg,
-                        color: priorityTone[decision.priority].text,
-                        fontWeight: 700,
-                        fontSize: "0.78rem",
-                        textTransform: "uppercase",
-                      }}
-                    >
-                      {decision.priority} priority
-                    </div>
-                  </div>
-                  <div style={{ color: "#334155" }}>{decision.explanation}</div>
-                  {categoryLabel ? (
-                    <div style={{ color: "#64748b", fontSize: "0.82rem", fontWeight: 600 }}>
-                      Workflow: {categoryLabel}
-                    </div>
-                  ) : null}
-                  {decision.automationState !== "manual_only" ? (
-                    <div
-                      style={{
-                        justifySelf: "start",
-                        padding: "4px 9px",
-                        borderRadius: 999,
-                        background: automationTone[decision.automationState].bg,
-                        color: automationTone[decision.automationState].text,
-                        fontWeight: 700,
-                        fontSize: "0.78rem",
-                      }}
-                    >
-                      {automationTone[decision.automationState].label}
-                    </div>
-                  ) : null}
-                  {support ? <div style={{ color: "#64748b", fontSize: "0.88rem" }}>{support}</div> : null}
-                  {decision.automationState !== "manual_only" && decision.automationReason ? (
-                    <div style={{ color: "#64748b", fontSize: "0.84rem" }}>{decision.automationReason}</div>
-                  ) : null}
-                  {decision.executionOutcomeStatus !== "none" ? (
-                    <div
-                      style={{
-                        justifySelf: "start",
-                        padding: "4px 9px",
-                        borderRadius: 999,
-                        background: executionOutcomeTone[decision.executionOutcomeStatus].bg,
-                        color: executionOutcomeTone[decision.executionOutcomeStatus].text,
-                        fontWeight: 700,
-                        fontSize: "0.78rem",
-                      }}
-                    >
-                      {executionOutcomeTone[decision.executionOutcomeStatus].label}
-                    </div>
-                  ) : null}
-                  {decision.executionOutcomeStatus === "succeeded" ? (
-                    <div style={{ color: "#166534", fontSize: "0.84rem" }}>
-                      Notice sent{decision.executedAt ? ` on ${new Date(decision.executedAt).toLocaleDateString()}` : ""}.
-                    </div>
-                  ) : null}
-                  {decision.executionOutcomeStatus === "failed" ? (
-                    <div style={{ color: "#991b1b", fontSize: "0.84rem" }}>
-                      {decision.executionOutcomeReason || "The last execution attempt failed."}
-                    </div>
-                  ) : null}
-                  <div style={{ display: "flex", gap: 12, flexWrap: "wrap", alignItems: "center" }}>
-                    {ctaDestination && ctaLabel ? (
-                      <Link to={ctaDestination} style={{ color: "#0f766e", fontWeight: 700, textDecoration: "none" }}>
-                        {ctaLabel}
-                      </Link>
-                    ) : null}
-                    {canExecuteNow ? (
-                      <button
-                        type="button"
-                        onClick={() => void handleExecute(decision.id)}
-                        disabled={workingDecisionId === decision.id}
-                        style={{
-                          border: "1px solid #166534",
-                          borderRadius: 999,
-                          background: "#166534",
-                          color: "#fff",
-                          fontWeight: 700,
-                          padding: "6px 12px",
-                        }}
-                      >
-                        {workingDecisionId === decision.id && workingAction === "execute" ? "Executing…" : "Execute now"}
-                      </button>
-                    ) : null}
-                    {decision.state === "reviewed" ? (
-                      <div
-                        style={{
-                          padding: "4px 9px",
-                          borderRadius: 999,
-                          background: "rgba(15, 118, 110, 0.1)",
-                          color: "#0f766e",
-                          fontWeight: 700,
-                          fontSize: "0.8rem",
-                        }}
-                      >
-                        Reviewed
-                      </div>
-                    ) : (
-                      <button
-                        type="button"
-                        onClick={() => void handleReview(decision.id)}
-                        disabled={workingDecisionId === decision.id}
-                        style={{
-                          border: "1px solid #cbd5e1",
-                          borderRadius: 999,
-                          background: "#f8fafc",
-                          color: "#0f172a",
-                          fontWeight: 700,
-                          padding: "6px 12px",
-                          cursor: workingDecisionId === decision.id ? "not-allowed" : "pointer",
-                        }}
-                      >
-                        {workingDecisionId === decision.id && workingAction === "review" ? "Saving..." : "Mark Reviewed"}
-                      </button>
-                    )}
-                    {!isResolved ? SNOOZE_PRESETS.map((preset) => (
-                      <button
-                        key={`${decision.id}-${preset.days}`}
-                        type="button"
-                        onClick={() => void handleSnooze(decision.id, preset.days)}
-                        disabled={workingDecisionId === decision.id}
-                        style={{
-                          border: "1px solid #cbd5e1",
-                          borderRadius: 999,
-                          background: "#fff",
-                          color: "#334155",
-                          fontWeight: 600,
-                          padding: "6px 10px",
-                          cursor: workingDecisionId === decision.id ? "not-allowed" : "pointer",
-                        }}
-                      >
-                        {workingDecisionId === decision.id && workingAction === "snooze" ? "Saving..." : preset.label}
-                      </button>
-                    )) : null}
-                    {!isResolved ? <button
-                      type="button"
-                      onClick={() => void handleDismiss(decision.id)}
-                      disabled={workingDecisionId === decision.id}
-                      style={{
-                        border: "1px solid rgba(185, 28, 28, 0.25)",
-                        borderRadius: 999,
-                        background: "#fff",
-                        color: "#991b1b",
-                        fontWeight: 700,
-                        padding: "6px 12px",
-                        cursor: workingDecisionId === decision.id ? "not-allowed" : "pointer",
-                      }}
-                    >
-                      {workingDecisionId === decision.id && workingAction === "dismiss" ? "Saving..." : "Dismiss"}
-                    </button> : null}
-                  </div>
-                </div>
-              );
-            })}
+            <h3 style={sectionHeadingStyle()}>Actions to review</h3>
+            {!activeItems.length ? (
+              <div style={{ color: "#64748b" }}>{emptyMessage}</div>
+            ) : (
+              <div style={{ display: "grid", gap: 10 }}>
+                {activeItems.map((decision) => (
+                  <ActionDecisionCard
+                    key={decision.id}
+                    decision={decision}
+                    workingDecisionId={workingDecisionId}
+                    workingAction={workingAction}
+                    onReview={handleReview}
+                    onSnooze={handleSnooze}
+                    onDismiss={handleDismiss}
+                    onExecute={handleExecute}
+                  />
+                ))}
+              </div>
+            )}
           </div>
-        )}
+
+          {executedItems.length ? (
+            <div style={{ display: "grid", gap: 10 }}>
+              <h3 style={sectionHeadingStyle()}>Recently executed</h3>
+              <div style={{ display: "grid", gap: 10 }}>
+                {executedItems.map((decision) => (
+                  <ExecutedDecisionCard key={decision.id} decision={decision} />
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </div>
       </div>
     </Card>
   );


### PR DESCRIPTION
Summary

Improve landlord decision signal clarity by separating active and executed decisions in the shared decision panel without changing backend behavior.

This PR keeps the entire canonical decision system intact and introduces a deterministic UI-level visibility model that reduces clutter while preserving full auditability.

Changes
	•	Split the shared AgentDecisionPanel into two deterministic sections:
	•	Actions to review (all unresolved decisions)
	•	Recently executed (state === "executed")
	•	Keep one canonical decision list from the backend and apply a simple state-based UI projection
	•	Preserve failed execution in the primary section so it remains visible and actionable
	•	Suppress review/snooze/dismiss controls for executed decisions in the resolved section
	•	Retain workflow links for executed decisions to maintain auditability and traceability
	•	Add/update frontend tests to verify:
	•	executed decisions move out of the primary section
	•	failed execution remains in the active section
	•	overall rendering remains consistent

Validation
	•	targeted frontend tests (AgentDecisionPanel, landlord pages)
	•	frontend build
	•	targeted frontend lint on touched files

Notes
	•	No backend changes were introduced
	•	No changes to:
	•	decision derivation
	•	lifecycle state model
	•	automation rules
	•	execution mapping
	•	execution behavior
	•	Visibility is a direct projection of canonical state, not a new logic path
	•	Executed decisions remain visible for auditability, just lower-noise