### PR TITLE
feat: add decision visibility controls v2

### DIFF
--- a/rentchain-frontend/src/components/analytics/AgentDecisionPanel.test.tsx
+++ b/rentchain-frontend/src/components/analytics/AgentDecisionPanel.test.tsx
@@ -380,8 +380,9 @@ describe("AgentDecisionPanel", () => {
         propertyId: null,
       });
     });
-    expect(await screen.findByRole("heading", { name: /Recently executed/i })).toBeInTheDocument();
-    expect(screen.getByText(/Notice sent/i)).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: /Recently executed \(1\)/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Show executed/i })).toBeInTheDocument();
+    expect(screen.queryByText(/Notice sent/i)).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Execute now/i })).not.toBeInTheDocument();
   });
 
@@ -480,7 +481,7 @@ describe("AgentDecisionPanel", () => {
     expect(screen.getByRole("button", { name: /Execute now/i })).toBeInTheDocument();
   });
 
-  it("renders executed decisions in a secondary section", () => {
+  it("renders executed decisions in a collapsible secondary section", () => {
     render(
       <MemoryRouter>
         <AgentDecisionPanel
@@ -539,9 +540,13 @@ describe("AgentDecisionPanel", () => {
     );
 
     expect(screen.getByRole("heading", { name: /Actions to review/i })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /Recently executed/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Recently executed \(1\)/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Show executed/i })).toBeInTheDocument();
     expect(screen.getByText(/No attention-worthy actions are surfaced/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Notice sent/i)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Show executed/i }));
     expect(screen.getByText(/Notice sent/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Hide executed/i })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Dismiss/i })).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/components/analytics/AgentDecisionPanel.tsx
+++ b/rentchain-frontend/src/components/analytics/AgentDecisionPanel.tsx
@@ -355,6 +355,7 @@ export function AgentDecisionPanel({
   const [workingDecisionId, setWorkingDecisionId] = React.useState<string | null>(null);
   const [workingAction, setWorkingAction] = React.useState<"review" | "snooze" | "dismiss" | "execute" | null>(null);
   const [error, setError] = React.useState<string | null>(null);
+  const [showExecuted, setShowExecuted] = React.useState(false);
 
   React.useEffect(() => {
     setItems(decisions);
@@ -520,12 +521,35 @@ export function AgentDecisionPanel({
 
           {executedItems.length ? (
             <div style={{ display: "grid", gap: 10 }}>
-              <h3 style={sectionHeadingStyle()}>Recently executed</h3>
-              <div style={{ display: "grid", gap: 10 }}>
-                {executedItems.map((decision) => (
-                  <ExecutedDecisionCard key={decision.id} decision={decision} />
-                ))}
+              <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "center", flexWrap: "wrap" }}>
+                <h3 style={sectionHeadingStyle()}>{`Recently executed (${executedItems.length})`}</h3>
+                <button
+                  type="button"
+                  onClick={() => setShowExecuted((current) => !current)}
+                  style={{
+                    border: "1px solid #cbd5e1",
+                    borderRadius: 999,
+                    background: "#fff",
+                    color: "#334155",
+                    fontWeight: 700,
+                    padding: "6px 12px",
+                    cursor: "pointer",
+                  }}
+                >
+                  {showExecuted ? "Hide executed" : "Show executed"}
+                </button>
               </div>
+              {showExecuted ? (
+                <div style={{ display: "grid", gap: 10 }}>
+                  {executedItems.map((decision) => (
+                    <ExecutedDecisionCard key={decision.id} decision={decision} />
+                  ))}
+                </div>
+              ) : (
+                <div style={{ color: "#64748b", fontSize: "0.92rem" }}>
+                  Executed decisions are hidden to keep the active action area focused.
+                </div>
+              )}
             </div>
           ) : null}
         </div>


### PR DESCRIPTION
## Summary
- add lightweight operator-facing visibility controls to the shared decision panel
- keep one canonical backend decision list and section executed decisions in the shared UI only
- preserve failed execution visibility in the active section

## Key behavior
- executed decisions are collapsed by default, not removed
- the control is local/session-only by design
- failed execution visibility is unchanged and intentionally remains in the active section

## Verification
- ran targeted frontend tests for `AgentDecisionPanel`, `ActionRecommendationsPage`, and `LandlordAnalyticsPage`
- ran frontend build
- ran targeted frontend lint on touched files