### PR TITLE
feat: add decision appearance events v1

### DIFF
--- a/rentchain-api/src/services/landlord/__tests__/landlordAnalyticsSnapshot.test.ts
+++ b/rentchain-api/src/services/landlord/__tests__/landlordAnalyticsSnapshot.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 type StoredDoc = { id: string; data: any };
 
-const { dbMock, resetDb, seedDoc } = vi.hoisted(() => {
+const { dbMock, resetDb, seedDoc, readDoc } = vi.hoisted(() => {
   const collections = new Map<string, Map<string, StoredDoc>>();
 
   function ensureCollection(name: string) {
@@ -20,6 +20,20 @@ const { dbMock, resetDb, seedDoc } = vi.hoisted(() => {
           }));
           return { docs, empty: docs.length === 0, size: docs.length };
         },
+        doc: (id: string) => ({
+          id,
+          get: async () => {
+            const entry = ensureCollection(name).get(id);
+            return {
+              id,
+              exists: Boolean(entry),
+              data: () => entry?.data,
+            };
+          },
+          set: async (data: any) => {
+            ensureCollection(name).set(id, { id, data });
+          },
+        }),
       }),
     },
     resetDb: () => {
@@ -28,6 +42,7 @@ const { dbMock, resetDb, seedDoc } = vi.hoisted(() => {
     seedDoc: (collection: string, id: string, data: any) => {
       ensureCollection(collection).set(id, { id, data });
     },
+    readDoc: (collection: string, id: string) => ensureCollection(collection).get(id)?.data || null,
   };
 });
 
@@ -282,5 +297,74 @@ describe("loadLandlordAnalyticsSnapshot", () => {
         }),
       ])
     );
+  });
+
+  it("emits a first-seen decision.appeared event once across repeated snapshot loads", async () => {
+    const now = Date.UTC(2026, 3, 20, 12, 0, 0, 0);
+
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Alpha" });
+    seedDoc("units", "unit-1", { landlordId: "landlord-1", propertyId: "prop-1", status: "occupied" });
+    seedDoc("leases", "lease-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      status: "active",
+      leaseType: "fixed_term",
+      province: "NS",
+      monthlyRent: 1650,
+      endDate: new Date(now + 25 * 24 * 60 * 60 * 1000).toISOString(),
+    });
+    seedDoc("events", "event-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      type: "lease_expiry",
+      severity: "high",
+      status: "active",
+      message: "Lease is expiring soon.",
+      createdAt: now,
+      occurredAt: now,
+    });
+
+    const { loadLandlordAnalyticsSnapshot } = await import("../landlordAnalyticsSnapshot");
+
+    await loadLandlordAnalyticsSnapshot({
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      now,
+    });
+
+    expect(readDoc("canonicalEvents", "decision_appeared__landlord-1__review_lease_renewals:prop-1")).toEqual(
+      expect.objectContaining({
+        type: "decision.appeared",
+        action: "appeared",
+        visibility: "landlord",
+        resource: expect.objectContaining({
+          type: "analytics_decision",
+          id: "review_lease_renewals:prop-1",
+        }),
+        metadata: expect.objectContaining({
+          landlordId: "landlord-1",
+          decisionId: "review_lease_renewals:prop-1",
+          decisionType: "review_lease_renewals",
+          source: "landlord_analytics_decisions",
+        }),
+      })
+    );
+
+    await loadLandlordAnalyticsSnapshot({
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      now: now + 60_000,
+    });
+
+    const canonicalEventDocs = await dbMock.collection("canonicalEvents").get();
+    const appearanceEvents = (canonicalEventDocs.docs || [])
+      .map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }))
+      .filter(
+        (event: any) =>
+          event.type === "decision.appeared" && event.metadata?.decisionId === "review_lease_renewals:prop-1"
+      );
+
+    expect(appearanceEvents).toHaveLength(1);
+    expect(appearanceEvents[0].id).toBe("decision_appeared__landlord-1__review_lease_renewals:prop-1");
   });
 });

--- a/rentchain-api/src/services/landlord/__tests__/landlordDecisionAppearanceEvents.test.ts
+++ b/rentchain-api/src/services/landlord/__tests__/landlordDecisionAppearanceEvents.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const writeCanonicalEvent = vi.fn();
+
+vi.mock("../../../lib/events/buildEvent", () => ({
+  writeCanonicalEvent,
+}));
+
+describe("emitLandlordDecisionAppearanceEvents", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("emits a first-seen decision.appeared event for visible decisions", async () => {
+    const { emitLandlordDecisionAppearanceEvents } = await import("../landlordDecisionAppearanceEvents");
+
+    await emitLandlordDecisionAppearanceEvents({
+      landlordId: "landlord-1",
+      occurredAt: "2026-04-22T12:00:00.000Z",
+      canonicalEvents: [],
+      decisions: [
+        {
+          id: "review_lease_renewals:prop-1",
+          decisionType: "review_lease_renewals",
+        } as any,
+      ],
+    });
+
+    expect(writeCanonicalEvent).toHaveBeenCalledTimes(1);
+    expect(writeCanonicalEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "decision_appeared__landlord-1__review_lease_renewals:prop-1",
+        type: "decision.appeared",
+        action: "appeared",
+        visibility: "landlord",
+        resource: { type: "analytics_decision", id: "review_lease_renewals:prop-1" },
+        metadata: expect.objectContaining({
+          landlordId: "landlord-1",
+          decisionId: "review_lease_renewals:prop-1",
+          decisionType: "review_lease_renewals",
+          source: "landlord_analytics_decisions",
+        }),
+      })
+    );
+  });
+
+  it("suppresses duplicate appearance events when the landlord decision was already seen", async () => {
+    const { emitLandlordDecisionAppearanceEvents } = await import("../landlordDecisionAppearanceEvents");
+
+    await emitLandlordDecisionAppearanceEvents({
+      landlordId: "landlord-1",
+      occurredAt: "2026-04-22T12:00:00.000Z",
+      canonicalEvents: [
+        {
+          id: "existing-1",
+          version: "v1",
+          type: "decision.appeared",
+          domain: "system",
+          action: "appeared",
+          actor: { type: "system", id: "system", role: "system" },
+          resource: { type: "analytics_decision", id: "review_lease_renewals:prop-1" },
+          occurredAt: "2026-04-21T10:00:00.000Z",
+          recordedAt: "2026-04-21T10:00:00.000Z",
+          visibility: "landlord",
+          summary: "Existing event",
+          metadata: {
+            landlordId: "landlord-1",
+            decisionId: "review_lease_renewals:prop-1",
+          },
+        },
+      ],
+      decisions: [
+        {
+          id: "review_lease_renewals:prop-1",
+          decisionType: "review_lease_renewals",
+        } as any,
+      ],
+    });
+
+    expect(writeCanonicalEvent).not.toHaveBeenCalled();
+  });
+
+  it("treats landlord and decision identity as the first-seen deduplication key", async () => {
+    const { emitLandlordDecisionAppearanceEvents } = await import("../landlordDecisionAppearanceEvents");
+
+    await emitLandlordDecisionAppearanceEvents({
+      landlordId: "landlord-2",
+      occurredAt: "2026-04-22T12:00:00.000Z",
+      canonicalEvents: [
+        {
+          id: "existing-1",
+          version: "v1",
+          type: "decision.appeared",
+          domain: "system",
+          action: "appeared",
+          actor: { type: "system", id: "system", role: "system" },
+          resource: { type: "analytics_decision", id: "review_lease_renewals:prop-1" },
+          occurredAt: "2026-04-21T10:00:00.000Z",
+          recordedAt: "2026-04-21T10:00:00.000Z",
+          visibility: "landlord",
+          summary: "Existing event",
+          metadata: {
+            landlordId: "landlord-1",
+            decisionId: "review_lease_renewals:prop-1",
+          },
+        },
+      ],
+      decisions: [
+        {
+          id: "review_lease_renewals:prop-1",
+          decisionType: "review_lease_renewals",
+        } as any,
+        {
+          id: "reduce_vacancy_risk:prop-2",
+          decisionType: "reduce_vacancy_risk",
+        } as any,
+      ],
+    });
+
+    expect(writeCanonicalEvent).toHaveBeenCalledTimes(2);
+    expect(writeCanonicalEvent).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          landlordId: "landlord-2",
+          decisionId: "review_lease_renewals:prop-1",
+        }),
+      })
+    );
+    expect(writeCanonicalEvent).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          landlordId: "landlord-2",
+          decisionId: "reduce_vacancy_risk:prop-2",
+        }),
+      })
+    );
+  });
+});

--- a/rentchain-api/src/services/landlord/landlordAnalyticsSnapshot.ts
+++ b/rentchain-api/src/services/landlord/landlordAnalyticsSnapshot.ts
@@ -14,6 +14,7 @@ import { applyDecisionAutomationRules } from "../../lib/analytics/deriveDecision
 import { applyDecisionExecutionMappings } from "../../lib/analytics/deriveDecisionExecutionMappings";
 import { deriveLandlordAnalyticsSnapshot } from "../../lib/analytics/deriveLandlordAnalyticsSnapshot";
 import { deriveScreeningReconciliation } from "../../lib/reconciliation/deriveScreeningReconciliation";
+import { emitLandlordDecisionAppearanceEvents } from "./landlordDecisionAppearanceEvents";
 import { loadLandlordDecisionStates, mergeLandlordDecisionStates } from "./landlordDecisionStates";
 
 type LandlordAnalyticsParams = {
@@ -208,6 +209,7 @@ function buildDerivedInput(params: {
 export async function loadLandlordAnalyticsSnapshot(params: LandlordAnalyticsParams): Promise<LandlordAnalyticsSnapshot> {
   const landlordId = asAnalyticsString(params.landlordId, 240);
   const now = typeof params.now === "number" ? params.now : Date.now();
+  const occurredAt = new Date(now).toISOString();
   const period = clampAnalyticsPeriod(params.period);
   const { from, to } = resolveAnalyticsWindow(period, now);
 
@@ -233,6 +235,8 @@ export async function loadLandlordAnalyticsSnapshot(params: LandlordAnalyticsPar
     loadCollection("screeningOrders"),
   ]);
 
+  const canonicalEventsRaw = (canonicalEventsSnap.docs || []).map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }) as CanonicalEventV1);
+
   const derivedInput = buildDerivedInput({
     landlordId,
     propertyId: params.propertyId,
@@ -246,9 +250,7 @@ export async function loadLandlordAnalyticsSnapshot(params: LandlordAnalyticsPar
     unitsRaw: (unitsSnap.docs || []).map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) })),
     leasesRaw: (leasesSnap.docs || []).map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) })),
     eventsRaw: (eventsSnap.docs || []).map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) })),
-    canonicalEventsRaw: (canonicalEventsSnap.docs || [])
-      .map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }) as CanonicalEventV1)
-      .filter(isAnalyticsVisibleCanonicalEvent),
+    canonicalEventsRaw: canonicalEventsRaw.filter(isAnalyticsVisibleCanonicalEvent),
     financialTransactionsRaw: (financialTransactionsSnap.docs || []).map((doc: any) => ({
       id: doc.id,
       ...(doc.data() || {}),
@@ -265,6 +267,13 @@ export async function loadLandlordAnalyticsSnapshot(params: LandlordAnalyticsPar
       now,
     })
   );
+
+  await emitLandlordDecisionAppearanceEvents({
+    landlordId,
+    decisions,
+    canonicalEvents: canonicalEventsRaw,
+    occurredAt,
+  });
 
   return {
       ...snapshot,

--- a/rentchain-api/src/services/landlord/landlordDecisionAppearanceEvents.ts
+++ b/rentchain-api/src/services/landlord/landlordDecisionAppearanceEvents.ts
@@ -1,0 +1,61 @@
+import { writeCanonicalEvent } from "../../lib/events/buildEvent";
+import type { CanonicalEventV1 } from "../../lib/events/eventTypes";
+import type { LandlordAgentDecision } from "../../lib/analytics/analyticsTypes";
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function decisionAppearanceEventId(landlordId: string, decisionId: string) {
+  return `decision_appeared__${landlordId}__${decisionId}`.replace(/[\/\s]+/g, "_");
+}
+
+function isDecisionAppearanceEvent(event: CanonicalEventV1, landlordId: string, decisionId: string) {
+  if (asString(event.type, 120) !== "decision.appeared") return false;
+  if (asString(event.resource?.type, 120) !== "analytics_decision") return false;
+  if (asString(event.resource?.id, 240) !== decisionId) return false;
+  if (asString(event.metadata?.landlordId, 240) !== landlordId) return false;
+  return asString(event.metadata?.decisionId, 240) === decisionId;
+}
+
+export async function emitLandlordDecisionAppearanceEvents(params: {
+  landlordId: string;
+  decisions: LandlordAgentDecision[];
+  canonicalEvents: CanonicalEventV1[];
+  occurredAt: string;
+}): Promise<void> {
+  const landlordId = asString(params.landlordId, 240);
+  if (!landlordId) return;
+
+  const seenDecisionIds = new Set<string>();
+  for (const event of params.canonicalEvents || []) {
+    const decisionId = asString(event.metadata?.decisionId, 240);
+    if (!decisionId) continue;
+    if (!isDecisionAppearanceEvent(event, landlordId, decisionId)) continue;
+    seenDecisionIds.add(decisionId);
+  }
+
+  for (const decision of params.decisions || []) {
+    const decisionId = asString(decision.id, 240);
+    if (!decisionId || seenDecisionIds.has(decisionId)) continue;
+    seenDecisionIds.add(decisionId);
+
+    await writeCanonicalEvent({
+      id: decisionAppearanceEventId(landlordId, decisionId),
+      type: "decision.appeared",
+      domain: "system",
+      action: "appeared",
+      actor: { type: "system", id: "system", role: "system" },
+      resource: { type: "analytics_decision", id: decisionId },
+      occurredAt: params.occurredAt,
+      visibility: "landlord",
+      summary: `Analytics decision ${decisionId} appeared.`,
+      metadata: {
+        landlordId,
+        decisionId,
+        decisionType: decision.decisionType,
+        source: "landlord_analytics_decisions",
+      },
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add a canonical `decision.appeared` event for landlord decisions
- emit the event from canonical landlord snapshot assembly after visible decisions are finalized
- suppress duplicates by stable landlord decision identity (`landlordId + decisionId`)

## Scope notes
- `decision.appeared` is first-seen only in v1
- resurfacing / reappearance after absence is intentionally not inferred yet
- timeline / history UI remains the next layer and is not part of this mission
- existing lifecycle, execution, readiness, mapping, and shared landlord UI behavior remain unchanged

## Verification
- backend tests passed for landlord analytics routes, landlord analytics snapshot, and landlord decision appearance events
- backend build passed