### PR TITLE
feat: add decision history timeline v1

### DIFF
--- a/rentchain-api/src/lib/timeline/timelineAdapter.ts
+++ b/rentchain-api/src/lib/timeline/timelineAdapter.ts
@@ -11,6 +11,13 @@ export type TimelineItem = {
 };
 
 const TITLE_BY_TYPE: Record<string, string> = {
+  "decision.appeared": "Appeared",
+  "decision.reviewed": "Reviewed",
+  "decision.snoozed": "Snoozed",
+  "decision.dismissed": "Dismissed",
+  "decision.execution_requested": "Execution requested",
+  "decision.executed": "Executed",
+  "decision.execution_failed": "Execution failed",
   "application.created": "Application created",
   "application.submitted": "Application submitted",
   "screening.quote_generated": "Screening quote generated",

--- a/rentchain-api/src/routes/__tests__/landlordAnalyticsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordAnalyticsRoutes.test.ts
@@ -16,6 +16,7 @@ const buildLeaseNoticePreviewInputFromLease = vi.fn();
 const getLeaseForLandlordWorkflow = vi.fn();
 const normalizeLeaseRecord = vi.fn();
 const performLeaseNoticeSendFromPreviewInput = vi.fn();
+const loadLandlordDecisionTimeline = vi.fn();
 
 vi.mock("../../middleware/requireAuth", () => ({
   requireAuth: (req: any, res: any, next: any) => {
@@ -72,6 +73,10 @@ vi.mock("../../services/leaseNoticeWorkflowService", () => ({
   performLeaseNoticeSendFromPreviewInput,
 }));
 
+vi.mock("../../services/landlord/landlordDecisionHistory", () => ({
+  loadLandlordDecisionTimeline,
+}));
+
 vi.mock("../../lib/events/buildEvent", () => ({
   writeCanonicalEvent,
 }));
@@ -100,7 +105,7 @@ async function invokeRouter(
         return this.get(name);
       },
     };
-    const decisionMatch = path.match(/\/landlord\/analytics\/decisions\/([^/]+)\/(review|snooze|dismiss|execute)$/);
+    const decisionMatch = path.match(/\/landlord\/analytics\/decisions\/([^/]+)\/(review|snooze|dismiss|execute|history)$/);
     if (decisionMatch) {
       req.params.decisionId = decodeURIComponent(decisionMatch[1]);
     }
@@ -239,6 +244,24 @@ describe("landlordAnalyticsRoutes", () => {
         data,
       };
     });
+    loadLandlordDecisionTimeline.mockResolvedValue([
+      {
+        id: "event-1",
+        title: "Appeared",
+        description: "Analytics decision review_lease_renewals:prop-1 appeared.",
+        timestamp: "2026-04-20T11:00:00.000Z",
+        domain: "system",
+        actor: "System",
+      },
+      {
+        id: "event-2",
+        title: "Execution requested",
+        description: "Analytics decision review_lease_renewals:prop-1 execution requested.",
+        timestamp: "2026-04-20T11:30:00.000Z",
+        domain: "system",
+        actor: "Landlord",
+      },
+    ]);
     loadLandlordAnalyticsSnapshot.mockResolvedValue({
       summary: {
         occupiedUnits: 4,
@@ -450,6 +473,84 @@ describe("landlordAnalyticsRoutes", () => {
         state: "reviewed",
       })
     );
+  });
+
+  it("returns timeline history for a currently visible landlord decision", async () => {
+    loadLandlordAnalyticsSnapshot.mockResolvedValueOnce({
+      decisions: {
+        items: [
+          {
+            id: "review_lease_renewals:prop-1",
+            decisionType: "review_lease_renewals",
+            priority: "high",
+            explanation: "Review renewals.",
+            supportingSignals: [],
+            recommendedAction: "Review renewals",
+            actionKey: "open_lease_renewals_flow",
+            actionLabel: "Open renewals focus",
+            destination: "/portfolio-health?entry=lease-renewals&propertyId=prop-1",
+            workflowCategory: "lease_renewals",
+            automationEligible: true,
+            automationState: "ready",
+            automationReason: "This decision is active and already mapped to a deterministic automation path.",
+            executionMappingState: "mapped",
+            executionMapping: {
+              action: "lease.auto_send_notice",
+              resourceType: "lease",
+              resourceId: "lease-1",
+              prerequisitesMet: true,
+              prerequisiteReason: null,
+            },
+            executionInputState: "complete",
+            executionInputReason: null,
+            executionInputMissingFields: [],
+            executionInput: {
+              noticeType: "renewal_offer",
+              legalTemplateKey: "ns.fixed_term.renewal_offer.v1",
+              noticeRuleVersion: "ns-v1",
+              province: "NS",
+              leaseType: "fixed_term",
+              currentRent: 1650,
+              noticeDueAt: Date.UTC(2026, 1, 10, 0, 0, 0, 0),
+              rentChangeMode: "no_change",
+              proposedRent: null,
+              newTermType: "fixed_term",
+              newLeaseStartDate: "2026-05-11",
+              newLeaseEndDate: "2027-05-10",
+              responseDeadlineAt: Date.UTC(2026, 4, 1, 12, 0, 0, 0),
+            },
+            executedAt: null,
+            executionOutcomeStatus: "none",
+            executionOutcomeAt: null,
+            executionOutcomeReason: null,
+            href: "/portfolio-health?entry=lease-renewals&propertyId=prop-1",
+            state: "pending",
+            reviewedAt: null,
+          },
+        ],
+      },
+    });
+
+    const router = (await import("../landlordAnalyticsRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/analytics/decisions/review_lease_renewals%3Aprop-1/history?period=90d",
+      user: { id: "landlord-1", role: "landlord" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(loadLandlordDecisionTimeline).toHaveBeenCalledWith({
+      landlordId: "landlord-1",
+      decisionId: "review_lease_renewals:prop-1",
+    });
+    expect(response.body).toEqual({
+      ok: true,
+      decisionId: "review_lease_renewals:prop-1",
+      events: [
+        expect.objectContaining({ title: "Appeared" }),
+        expect.objectContaining({ title: "Execution requested" }),
+      ],
+    });
   });
 
   it("rejects review requests for decisions that are not currently visible", async () => {

--- a/rentchain-api/src/routes/landlordAnalyticsRoutes.ts
+++ b/rentchain-api/src/routes/landlordAnalyticsRoutes.ts
@@ -19,6 +19,7 @@ import {
   saveReviewedLandlordDecisionState,
   saveSnoozedLandlordDecisionState,
 } from "../services/landlord/landlordDecisionStates";
+import { loadLandlordDecisionTimeline } from "../services/landlord/landlordDecisionHistory";
 
 const router = Router();
 
@@ -86,6 +87,28 @@ router.get("/landlord/analytics", requireAuth, requireLandlord, async (req: any,
   } catch (err: any) {
     console.error("[landlord-analytics] fetch failed", err?.message || err);
     return res.status(500).json({ ok: false, error: "LANDLORD_ANALYTICS_FETCH_FAILED" });
+  }
+});
+
+router.get("/landlord/analytics/decisions/:decisionId/history", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const resolved = await resolveVisibleDecision(req, res);
+    if (!resolved) return;
+    const { landlordId, decisionId } = resolved;
+
+    const events = await loadLandlordDecisionTimeline({
+      landlordId,
+      decisionId,
+    });
+
+    return res.json({
+      ok: true,
+      decisionId,
+      events,
+    });
+  } catch (err: any) {
+    console.error("[landlord-analytics] decision history failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "LANDLORD_DECISION_HISTORY_FAILED" });
   }
 });
 

--- a/rentchain-api/src/services/landlord/__tests__/landlordDecisionHistory.test.ts
+++ b/rentchain-api/src/services/landlord/__tests__/landlordDecisionHistory.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type StoredDoc = { id: string; data: any };
+
+const { dbMock, resetDb, seedDoc } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, StoredDoc>>();
+
+  function ensureCollection(name: string) {
+    if (!collections.has(name)) collections.set(name, new Map());
+    return collections.get(name)!;
+  }
+
+  return {
+    dbMock: {
+      collection: (name: string) => ({
+        get: async () => {
+          const docs = Array.from(ensureCollection(name).values()).map((entry) => ({
+            id: entry.id,
+            data: () => entry.data,
+          }));
+          return { docs, empty: docs.length === 0, size: docs.length };
+        },
+      }),
+    },
+    resetDb: () => collections.clear(),
+    seedDoc: (collection: string, id: string, data: any) => {
+      ensureCollection(collection).set(id, { id, data });
+    },
+  };
+});
+
+vi.mock("../../../config/firebase", () => ({
+  db: dbMock,
+}));
+
+describe("loadLandlordDecisionTimeline", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    resetDb();
+  });
+
+  it("returns only landlord-scoped decision timeline events in chronological order", async () => {
+    seedDoc("canonicalEvents", "event-1", {
+      version: "v1",
+      type: "decision.reviewed",
+      domain: "system",
+      action: "reviewed",
+      actor: { type: "landlord", role: "landlord", id: "landlord-1" },
+      resource: { type: "analytics_decision", id: "review_lease_renewals:prop-1" },
+      occurredAt: "2026-04-22T10:00:00.000Z",
+      recordedAt: "2026-04-22T10:00:00.000Z",
+      visibility: "landlord",
+      summary: "Analytics decision reviewed.",
+      metadata: { landlordId: "landlord-1", decisionId: "review_lease_renewals:prop-1" },
+    });
+    seedDoc("canonicalEvents", "event-0", {
+      version: "v1",
+      type: "decision.appeared",
+      domain: "system",
+      action: "appeared",
+      actor: { type: "system", role: "system", id: "system" },
+      resource: { type: "analytics_decision", id: "review_lease_renewals:prop-1" },
+      occurredAt: "2026-04-22T09:00:00.000Z",
+      recordedAt: "2026-04-22T09:00:00.000Z",
+      visibility: "landlord",
+      summary: "Analytics decision appeared.",
+      metadata: { landlordId: "landlord-1", decisionId: "review_lease_renewals:prop-1" },
+    });
+    seedDoc("canonicalEvents", "event-2", {
+      version: "v1",
+      type: "decision.executed",
+      domain: "system",
+      action: "executed",
+      status: "executed",
+      actor: { type: "landlord", role: "landlord", id: "landlord-1" },
+      resource: { type: "analytics_decision", id: "review_lease_renewals:prop-1" },
+      occurredAt: "2026-04-22T11:00:00.000Z",
+      recordedAt: "2026-04-22T11:00:00.000Z",
+      visibility: "landlord",
+      summary: "Analytics decision executed.",
+      metadata: { landlordId: "landlord-1", decisionId: "review_lease_renewals:prop-1" },
+    });
+    seedDoc("canonicalEvents", "event-ignored-tenant", {
+      version: "v1",
+      type: "decision.appeared",
+      domain: "system",
+      action: "appeared",
+      actor: { type: "system", role: "system", id: "system" },
+      resource: { type: "analytics_decision", id: "review_lease_renewals:prop-1" },
+      occurredAt: "2026-04-22T08:00:00.000Z",
+      recordedAt: "2026-04-22T08:00:00.000Z",
+      visibility: "tenant",
+      summary: "Should be hidden.",
+      metadata: { landlordId: "landlord-1", decisionId: "review_lease_renewals:prop-1" },
+    });
+    seedDoc("canonicalEvents", "event-ignored-other-landlord", {
+      version: "v1",
+      type: "decision.appeared",
+      domain: "system",
+      action: "appeared",
+      actor: { type: "system", role: "system", id: "system" },
+      resource: { type: "analytics_decision", id: "review_lease_renewals:prop-1" },
+      occurredAt: "2026-04-22T07:00:00.000Z",
+      recordedAt: "2026-04-22T07:00:00.000Z",
+      visibility: "landlord",
+      summary: "Other landlord.",
+      metadata: { landlordId: "landlord-2", decisionId: "review_lease_renewals:prop-1" },
+    });
+
+    const { loadLandlordDecisionTimeline } = await import("../landlordDecisionHistory");
+    const result = await loadLandlordDecisionTimeline({
+      landlordId: "landlord-1",
+      decisionId: "review_lease_renewals:prop-1",
+    });
+
+    expect(result.map((item) => item.title)).toEqual(["Appeared", "Reviewed", "Executed"]);
+    expect(result[0]).toEqual(
+      expect.objectContaining({
+        title: "Appeared",
+        timestamp: "2026-04-22T09:00:00.000Z",
+      })
+    );
+    expect(result[2]).toEqual(
+      expect.objectContaining({
+        title: "Executed",
+        status: "executed",
+      })
+    );
+  });
+});

--- a/rentchain-api/src/services/landlord/landlordDecisionHistory.ts
+++ b/rentchain-api/src/services/landlord/landlordDecisionHistory.ts
@@ -1,0 +1,40 @@
+import { db } from "../../config/firebase";
+import { CANONICAL_EVENTS_COLLECTION } from "../../lib/events/buildEvent";
+import type { CanonicalEventV1 } from "../../lib/events/eventTypes";
+import { canonicalEventToTimelineItem, type TimelineItem } from "../../lib/timeline/timelineAdapter";
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function compareEventsAscending(a: CanonicalEventV1, b: CanonicalEventV1) {
+  const aTs = Date.parse(a.occurredAt || a.recordedAt || "");
+  const bTs = Date.parse(b.occurredAt || b.recordedAt || "");
+  if (aTs !== bTs) return aTs - bTs;
+  return String(a.id || "").localeCompare(String(b.id || ""));
+}
+
+function isDecisionHistoryEvent(event: CanonicalEventV1, landlordId: string, decisionId: string) {
+  if (asString(event.resource?.type, 120) !== "analytics_decision") return false;
+  if (asString(event.resource?.id, 240) !== decisionId) return false;
+  if (asString(event.visibility, 80) !== "landlord") return false;
+  if (asString(event.metadata?.landlordId, 240) !== landlordId) return false;
+  return asString(event.metadata?.decisionId, 240) === decisionId;
+}
+
+export async function loadLandlordDecisionTimeline(params: {
+  landlordId: string;
+  decisionId: string;
+}): Promise<TimelineItem[]> {
+  const landlordId = asString(params.landlordId, 240);
+  const decisionId = asString(params.decisionId, 240);
+  if (!landlordId || !decisionId) return [];
+
+  const snap = await db.collection(CANONICAL_EVENTS_COLLECTION).get().catch(() => ({ docs: [] } as any));
+  const events = (snap.docs || [])
+    .map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }) as CanonicalEventV1)
+    .filter((event: CanonicalEventV1) => isDecisionHistoryEvent(event, landlordId, decisionId))
+    .sort(compareEventsAscending);
+
+  return events.map(canonicalEventToTimelineItem);
+}

--- a/rentchain-frontend/src/api/landlordAnalyticsApi.ts
+++ b/rentchain-frontend/src/api/landlordAnalyticsApi.ts
@@ -1,4 +1,5 @@
 import { apiFetch } from "./apiFetch";
+import type { TimelineItem } from "./timelineApi";
 
 export type AnalyticsPeriod = "30d" | "90d" | "365d" | "month_to_date";
 
@@ -254,6 +255,12 @@ export type LandlordAnalyticsSnapshot = {
   };
 };
 
+export type LandlordDecisionHistoryResponse = {
+  ok: true;
+  decisionId: string;
+  events: TimelineItem[];
+};
+
 export async function fetchLandlordAnalyticsSnapshot(params?: {
   period?: AnalyticsPeriod;
   propertyId?: string | null;
@@ -331,6 +338,20 @@ export async function dismissLandlordDecision(params: {
   return await apiFetch(`/landlord/analytics/decisions/${encodeURIComponent(params.decisionId)}/dismiss${suffix}`, {
     method: "POST",
   });
+}
+
+export async function fetchLandlordDecisionHistory(params: {
+  decisionId: string;
+  period?: AnalyticsPeriod;
+  propertyId?: string | null;
+}): Promise<LandlordDecisionHistoryResponse> {
+  const search = new URLSearchParams();
+  if (params.period) search.set("period", params.period);
+  if (params.propertyId) search.set("propertyId", params.propertyId);
+  const suffix = search.toString() ? `?${search.toString()}` : "";
+  return await apiFetch<LandlordDecisionHistoryResponse>(
+    `/landlord/analytics/decisions/${encodeURIComponent(params.decisionId)}/history${suffix}`
+  );
 }
 
 export async function executeLandlordDecision(params: {

--- a/rentchain-frontend/src/components/analytics/AgentDecisionPanel.test.tsx
+++ b/rentchain-frontend/src/components/analytics/AgentDecisionPanel.test.tsx
@@ -16,6 +16,9 @@ const { dismissLandlordDecision } = vi.hoisted(() => ({
 const { executeLandlordDecision } = vi.hoisted(() => ({
   executeLandlordDecision: vi.fn(),
 }));
+const { fetchLandlordDecisionHistory } = vi.hoisted(() => ({
+  fetchLandlordDecisionHistory: vi.fn(),
+}));
 
 vi.mock("@/api/landlordAnalyticsApi", async () => {
   const actual = await vi.importActual<typeof import("@/api/landlordAnalyticsApi")>("@/api/landlordAnalyticsApi");
@@ -25,6 +28,7 @@ vi.mock("@/api/landlordAnalyticsApi", async () => {
     snoozeLandlordDecision,
     dismissLandlordDecision,
     executeLandlordDecision,
+    fetchLandlordDecisionHistory,
   };
 });
 
@@ -75,6 +79,28 @@ beforeEach(() => {
       updatedAt: "2026-04-22T12:00:00.000Z",
     },
     noticeId: "notice-1",
+  });
+  fetchLandlordDecisionHistory.mockResolvedValue({
+    ok: true,
+    decisionId: "review_lease_renewals:prop-1",
+    events: [
+      {
+        id: "event-1",
+        title: "Appeared",
+        description: "Analytics decision review_lease_renewals:prop-1 appeared.",
+        timestamp: "2026-04-22T09:00:00.000Z",
+        domain: "system",
+        actor: "System",
+      },
+      {
+        id: "event-2",
+        title: "Reviewed",
+        description: "Analytics decision review_lease_renewals:prop-1 reviewed.",
+        timestamp: "2026-04-22T10:00:00.000Z",
+        domain: "system",
+        actor: "Landlord",
+      },
+    ],
   });
 });
 
@@ -134,6 +160,7 @@ describe("AgentDecisionPanel", () => {
     expect(screen.queryByText(/Automation blocked/i)).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Snooze 1d/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Dismiss/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /View history/i })).toBeInTheDocument();
   });
 
   it("renders a clean empty state when no decisions are available", () => {
@@ -548,5 +575,78 @@ describe("AgentDecisionPanel", () => {
     expect(screen.getByText(/Notice sent/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Hide executed/i })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Dismiss/i })).not.toBeInTheDocument();
+  });
+
+  it("loads and renders canonical decision history inline on demand", async () => {
+    render(
+      <MemoryRouter>
+        <AgentDecisionPanel
+          period="90d"
+          decisions={[
+            {
+              id: "review_lease_renewals:prop-1",
+              decisionType: "review_lease_renewals",
+              priority: "high",
+              explanation: "Review upcoming renewals.",
+              recommendedAction: "Review renewals",
+              actionKey: "open_lease_renewals_flow",
+              actionLabel: "Open renewals focus",
+              destination: "/portfolio-health?entry=lease-renewals&propertyId=prop-1",
+              workflowCategory: "lease_renewals",
+              automationEligible: true,
+              automationState: "ready",
+              automationReason: "This decision is active and already mapped to a deterministic automation path.",
+              executionMappingState: "mapped",
+              executionMapping: {
+                action: "lease.auto_send_notice",
+                resourceType: "lease",
+                resourceId: "lease-1",
+                prerequisitesMet: true,
+                prerequisiteReason: null,
+              },
+              executionInputState: "complete",
+              executionInputReason: null,
+              executionInputMissingFields: [],
+              executionInput: {
+                noticeType: "renewal_offer",
+                legalTemplateKey: "ns.fixed_term.renewal_offer.v1",
+                noticeRuleVersion: "ns-v1",
+                province: "NS",
+                leaseType: "fixed_term",
+                currentRent: 1650,
+                noticeDueAt: Date.UTC(2026, 1, 10, 0, 0, 0, 0),
+                rentChangeMode: "no_change",
+                proposedRent: null,
+                newTermType: "fixed_term",
+                newLeaseStartDate: "2026-05-11",
+                newLeaseEndDate: "2027-05-10",
+                responseDeadlineAt: Date.UTC(2026, 4, 1, 12, 0, 0, 0),
+              },
+              executedAt: null,
+              executionOutcomeStatus: "none",
+              executionOutcomeAt: null,
+              executionOutcomeReason: null,
+              href: "/portfolio-health?entry=lease-renewals&propertyId=prop-1",
+              state: "pending",
+              reviewedAt: null,
+              supportingSignals: [],
+            },
+          ]}
+        />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /View history/i }));
+
+    await waitFor(() => {
+      expect(fetchLandlordDecisionHistory).toHaveBeenCalledWith({
+        decisionId: "review_lease_renewals:prop-1",
+        period: "90d",
+        propertyId: null,
+      });
+    });
+    expect(await screen.findByText("Appeared")).toBeInTheDocument();
+    expect(screen.getByText("Reviewed")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Hide history/i })).toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/components/analytics/AgentDecisionPanel.tsx
+++ b/rentchain-frontend/src/components/analytics/AgentDecisionPanel.tsx
@@ -1,14 +1,17 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import { Card } from "../ui/Ui";
+import { Timeline } from "../timeline/Timeline";
 import {
   dismissLandlordDecision,
   executeLandlordDecision,
+  fetchLandlordDecisionHistory,
   markLandlordDecisionReviewed,
   snoozeLandlordDecision,
   type AnalyticsPeriod,
   type LandlordAgentDecision,
 } from "@/api/landlordAnalyticsApi";
+import type { TimelineItem } from "@/api/timelineApi";
 
 const priorityTone: Record<"low" | "medium" | "high", { bg: string; text: string }> = {
   low: { bg: "rgba(14, 165, 233, 0.12)", text: "#075985" },
@@ -98,6 +101,47 @@ function sectionHeadingStyle() {
   } as const;
 }
 
+function HistoryToggle(props: {
+  decisionId: string;
+  showHistory: boolean;
+  historyItems: TimelineItem[];
+  historyLoading: boolean;
+  historyError: string | null;
+  onToggleHistory: (decisionId: string) => Promise<void>;
+}) {
+  const { decisionId, showHistory, historyItems, historyLoading, historyError, onToggleHistory } = props;
+
+  return (
+    <div style={{ display: "grid", gap: 10, width: "100%" }}>
+      <button
+        type="button"
+        onClick={() => void onToggleHistory(decisionId)}
+        style={{
+          justifySelf: "start",
+          border: "1px solid #cbd5e1",
+          borderRadius: 999,
+          background: "#fff",
+          color: "#334155",
+          fontWeight: 700,
+          padding: "6px 12px",
+          cursor: "pointer",
+        }}
+      >
+        {showHistory ? "Hide history" : "View history"}
+      </button>
+      {showHistory ? (
+        <div style={{ display: "grid", gap: 10 }}>
+          {historyLoading ? <div style={{ color: "#64748b" }}>Loading history…</div> : null}
+          {!historyLoading && historyError ? <div style={{ color: "#b91c1c" }}>{historyError}</div> : null}
+          {!historyLoading && !historyError ? (
+            <Timeline items={historyItems} emptyMessage="No canonical decision history is available yet." />
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 function ActionDecisionCard(props: {
   decision: LandlordAgentDecision;
   workingDecisionId: string | null;
@@ -106,8 +150,26 @@ function ActionDecisionCard(props: {
   onSnooze: (decisionId: string, days: number) => Promise<void>;
   onDismiss: (decisionId: string) => Promise<void>;
   onExecute: (decisionId: string) => Promise<void>;
+  showHistory: boolean;
+  historyItems: TimelineItem[];
+  historyLoading: boolean;
+  historyError: string | null;
+  onToggleHistory: (decisionId: string) => Promise<void>;
 }) {
-  const { decision, workingDecisionId, workingAction, onReview, onSnooze, onDismiss, onExecute } = props;
+  const {
+    decision,
+    workingDecisionId,
+    workingAction,
+    onReview,
+    onSnooze,
+    onDismiss,
+    onExecute,
+    showHistory,
+    historyItems,
+    historyLoading,
+    historyError,
+    onToggleHistory,
+  } = props;
   const support = supportingLine(decision);
   const categoryLabel = decision.workflowCategory ? workflowCategoryLabel[decision.workflowCategory] : null;
   const ctaDestination = decision.destination || decision.href;
@@ -282,6 +344,14 @@ function ActionDecisionCard(props: {
         >
           {workingDecisionId === decision.id && workingAction === "dismiss" ? "Saving..." : "Dismiss"}
         </button>
+        <HistoryToggle
+          decisionId={decision.id}
+          showHistory={showHistory}
+          historyItems={historyItems}
+          historyLoading={historyLoading}
+          historyError={historyError}
+          onToggleHistory={onToggleHistory}
+        />
       </div>
     </div>
   );
@@ -289,8 +359,13 @@ function ActionDecisionCard(props: {
 
 function ExecutedDecisionCard(props: {
   decision: LandlordAgentDecision;
+  showHistory: boolean;
+  historyItems: TimelineItem[];
+  historyLoading: boolean;
+  historyError: string | null;
+  onToggleHistory: (decisionId: string) => Promise<void>;
 }) {
-  const { decision } = props;
+  const { decision, showHistory, historyItems, historyLoading, historyError, onToggleHistory } = props;
   const categoryLabel = decision.workflowCategory ? workflowCategoryLabel[decision.workflowCategory] : null;
   const ctaDestination = decision.destination || decision.href;
   const ctaLabel = decision.destination
@@ -339,6 +414,14 @@ function ExecutedDecisionCard(props: {
           </Link>
         ) : null}
       </div>
+      <HistoryToggle
+        decisionId={decision.id}
+        showHistory={showHistory}
+        historyItems={historyItems}
+        historyLoading={historyLoading}
+        historyError={historyError}
+        onToggleHistory={onToggleHistory}
+      />
     </div>
   );
 }
@@ -356,6 +439,10 @@ export function AgentDecisionPanel({
   const [workingAction, setWorkingAction] = React.useState<"review" | "snooze" | "dismiss" | "execute" | null>(null);
   const [error, setError] = React.useState<string | null>(null);
   const [showExecuted, setShowExecuted] = React.useState(false);
+  const [expandedHistoryDecisionIds, setExpandedHistoryDecisionIds] = React.useState<Record<string, boolean>>({});
+  const [historyItemsByDecisionId, setHistoryItemsByDecisionId] = React.useState<Record<string, TimelineItem[]>>({});
+  const [historyLoadingByDecisionId, setHistoryLoadingByDecisionId] = React.useState<Record<string, boolean>>({});
+  const [historyErrorByDecisionId, setHistoryErrorByDecisionId] = React.useState<Record<string, string | null>>({});
 
   React.useEffect(() => {
     setItems(decisions);
@@ -363,6 +450,32 @@ export function AgentDecisionPanel({
 
   const activeItems = React.useMemo(() => items.filter((decision) => decision.state !== "executed"), [items]);
   const executedItems = React.useMemo(() => items.filter((decision) => decision.state === "executed"), [items]);
+
+  const handleToggleHistory = async (decisionId: string) => {
+    const currentlyExpanded = Boolean(expandedHistoryDecisionIds[decisionId]);
+    if (currentlyExpanded) {
+      setExpandedHistoryDecisionIds((current) => ({ ...current, [decisionId]: false }));
+      return;
+    }
+
+    setExpandedHistoryDecisionIds((current) => ({ ...current, [decisionId]: true }));
+    if (historyItemsByDecisionId[decisionId] || historyLoadingByDecisionId[decisionId]) return;
+
+    try {
+      setHistoryLoadingByDecisionId((current) => ({ ...current, [decisionId]: true }));
+      setHistoryErrorByDecisionId((current) => ({ ...current, [decisionId]: null }));
+      const response = await fetchLandlordDecisionHistory({
+        decisionId,
+        period,
+        propertyId,
+      });
+      setHistoryItemsByDecisionId((current) => ({ ...current, [decisionId]: response.events || [] }));
+    } catch (err: unknown) {
+      setHistoryErrorByDecisionId((current) => ({ ...current, [decisionId]: errorMessage(err) }));
+    } finally {
+      setHistoryLoadingByDecisionId((current) => ({ ...current, [decisionId]: false }));
+    }
+  };
 
   const handleReview = async (decisionId: string) => {
     try {
@@ -513,6 +626,11 @@ export function AgentDecisionPanel({
                     onSnooze={handleSnooze}
                     onDismiss={handleDismiss}
                     onExecute={handleExecute}
+                    showHistory={Boolean(expandedHistoryDecisionIds[decision.id])}
+                    historyItems={historyItemsByDecisionId[decision.id] || []}
+                    historyLoading={Boolean(historyLoadingByDecisionId[decision.id])}
+                    historyError={historyErrorByDecisionId[decision.id] || null}
+                    onToggleHistory={handleToggleHistory}
                   />
                 ))}
               </div>
@@ -542,7 +660,15 @@ export function AgentDecisionPanel({
               {showExecuted ? (
                 <div style={{ display: "grid", gap: 10 }}>
                   {executedItems.map((decision) => (
-                    <ExecutedDecisionCard key={decision.id} decision={decision} />
+                    <ExecutedDecisionCard
+                      key={decision.id}
+                      decision={decision}
+                      showHistory={Boolean(expandedHistoryDecisionIds[decision.id])}
+                      historyItems={historyItemsByDecisionId[decision.id] || []}
+                      historyLoading={Boolean(historyLoadingByDecisionId[decision.id])}
+                      historyError={historyErrorByDecisionId[decision.id] || null}
+                      onToggleHistory={handleToggleHistory}
+                    />
                   ))}
                 </div>
               ) : (

--- a/rentchain-frontend/src/pages/landlord/ActionRecommendationsPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/ActionRecommendationsPage.test.tsx
@@ -14,6 +14,8 @@ vi.mock("../../api/landlordAnalyticsApi", () => ({
   markLandlordDecisionReviewed: vi.fn(),
   snoozeLandlordDecision: vi.fn(),
   dismissLandlordDecision: vi.fn(),
+  executeLandlordDecision: vi.fn(),
+  fetchLandlordDecisionHistory: vi.fn(),
 }));
 
 vi.mock("@/hooks/useEntitlements", () => ({

--- a/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.test.tsx
@@ -17,6 +17,8 @@ vi.mock("../../api/landlordAnalyticsApi", () => ({
   markLandlordDecisionReviewed: vi.fn(),
   snoozeLandlordDecision: vi.fn(),
   dismissLandlordDecision: vi.fn(),
+  executeLandlordDecision: vi.fn(),
+  fetchLandlordDecisionHistory: vi.fn(),
 }));
 
 vi.mock("../../api/landlordAnalyticsAlertsApi", () => ({


### PR DESCRIPTION
## Summary
- add a landlord-scoped decision history route for visible decisions
- reuse the existing timeline adapter and `Timeline` component for a canonical event-backed timeline
- add lightweight `View history` controls to the shared decision panel while keeping landlord action surfaces lightweight by design

## Notes
- history is backed purely by canonical events
- v1 history is limited to currently visible decisions for safety
- timeline labels are canonical event labels, not derived summaries
- no second truth path or client-side reconstructed history was introduced

## Verification
- backend targeted tests passed
- frontend targeted tests passed
- `rentchain-api` build passed
- `rentchain-frontend` build passed
- targeted frontend lint passed