### PR TITLE
feat: add decision outcome analytics v1

### DIFF
--- a/rentchain-api/src/lib/analytics/analyticsTypes.ts
+++ b/rentchain-api/src/lib/analytics/analyticsTypes.ts
@@ -343,6 +343,19 @@ export type LandlordAgentDecisions = {
   items: LandlordAgentDecision[];
 };
 
+export type LandlordDecisionOutcomeAnalytics = {
+  scope: "landlord_all_time";
+  appearedCount: number;
+  reviewedCount: number;
+  dismissedCount: number;
+  executedCount: number;
+  failedExecutionCount: number;
+  resolvedCount: number;
+  resolutionRate: number | null;
+  medianTimeToResolutionHours: number | null;
+  averageTimeToExecutionHours: number | null;
+};
+
 export type PersistedAgentDecisionState = {
   id: string;
   landlordId: string;
@@ -452,4 +465,5 @@ export type LandlordAnalyticsSnapshotBase = {
 
 export type LandlordAnalyticsSnapshot = LandlordAnalyticsSnapshotBase & {
   decisions: LandlordAgentDecisions;
+  decisionOutcomeAnalytics: LandlordDecisionOutcomeAnalytics;
 };

--- a/rentchain-api/src/lib/analytics/deriveLandlordAnalyticsSnapshot.ts
+++ b/rentchain-api/src/lib/analytics/deriveLandlordAnalyticsSnapshot.ts
@@ -742,5 +742,17 @@ export function deriveLandlordAnalyticsSnapshot(input: AdminAnalyticsDerivedInpu
   return {
     ...snapshotBase,
     decisions,
+    decisionOutcomeAnalytics: {
+      scope: "landlord_all_time",
+      appearedCount: 0,
+      reviewedCount: 0,
+      dismissedCount: 0,
+      executedCount: 0,
+      failedExecutionCount: 0,
+      resolvedCount: 0,
+      resolutionRate: null,
+      medianTimeToResolutionHours: null,
+      averageTimeToExecutionHours: null,
+    },
   };
 }

--- a/rentchain-api/src/services/landlord/__tests__/landlordAnalyticsSnapshot.test.ts
+++ b/rentchain-api/src/services/landlord/__tests__/landlordAnalyticsSnapshot.test.ts
@@ -197,6 +197,18 @@ describe("loadLandlordAnalyticsSnapshot", () => {
       ])
     );
     expect(scoped.decisions.items.find((decision) => decision.id === "reduce_vacancy_risk:prop-1")).toBeUndefined();
+    expect(scoped.decisionOutcomeAnalytics).toEqual({
+      scope: "landlord_all_time",
+      appearedCount: 3,
+      reviewedCount: 0,
+      dismissedCount: 0,
+      executedCount: 0,
+      failedExecutionCount: 0,
+      resolvedCount: 0,
+      resolutionRate: 0,
+      medianTimeToResolutionHours: null,
+      averageTimeToExecutionHours: null,
+    });
     expect(scoped.propertyMetrics).toEqual([
       expect.objectContaining({
         propertyId: "prop-1",
@@ -227,6 +239,7 @@ describe("loadLandlordAnalyticsSnapshot", () => {
     expect(result.insights).toEqual([]);
     expect(result.predictive.metrics.every((metric) => metric.status === "insufficient_data")).toBe(true);
     expect(result.decisions.items).toEqual([]);
+    expect(result.decisionOutcomeAnalytics.appearedCount).toBe(0);
     expect(result.propertyMetrics).toEqual([]);
     expect(result.comparisons.deltas.summary.maintenanceCostCents.direction).toBe("flat");
   });
@@ -366,5 +379,69 @@ describe("loadLandlordAnalyticsSnapshot", () => {
 
     expect(appearanceEvents).toHaveLength(1);
     expect(appearanceEvents[0].id).toBe("decision_appeared__landlord-1__review_lease_renewals:prop-1");
+  });
+
+  it("derives all-time decision outcome analytics from canonical decision events", async () => {
+    const nowIso = "2026-04-20T12:00:00.000Z";
+    seedDoc("properties", "prop-1", {
+      landlordId: "landlord-1",
+      name: "Alpha",
+      createdAt: nowIso,
+      updatedAt: nowIso,
+    });
+    seedDoc("canonicalEvents", "event-appeared", {
+      type: "decision.appeared",
+      visibility: "landlord",
+      resource: { type: "analytics_decision", id: "decision-1" },
+      metadata: { landlordId: "landlord-1", decisionId: "decision-1" },
+      occurredAt: "2026-04-01T12:00:00.000Z",
+    });
+    seedDoc("canonicalEvents", "event-reviewed", {
+      type: "decision.reviewed",
+      visibility: "landlord",
+      resource: { type: "analytics_decision", id: "decision-1" },
+      metadata: { landlordId: "landlord-1", decisionId: "decision-1" },
+      occurredAt: "2026-04-03T12:00:00.000Z",
+    });
+    seedDoc("canonicalEvents", "event-appeared-2", {
+      type: "decision.appeared",
+      visibility: "landlord",
+      resource: { type: "analytics_decision", id: "decision-2" },
+      metadata: { landlordId: "landlord-1", decisionId: "decision-2" },
+      occurredAt: "2026-04-05T12:00:00.000Z",
+    });
+    seedDoc("canonicalEvents", "event-executed", {
+      type: "decision.executed",
+      visibility: "landlord",
+      resource: { type: "analytics_decision", id: "decision-2" },
+      metadata: { landlordId: "landlord-1", decisionId: "decision-2" },
+      occurredAt: "2026-04-07T12:00:00.000Z",
+    });
+    seedDoc("canonicalEvents", "event-failed", {
+      type: "decision.execution_failed",
+      visibility: "landlord",
+      resource: { type: "analytics_decision", id: "decision-3" },
+      metadata: { landlordId: "landlord-1", decisionId: "decision-3" },
+      occurredAt: "2026-04-06T12:00:00.000Z",
+    });
+
+    const { loadLandlordAnalyticsSnapshot } = await import("../landlordAnalyticsSnapshot");
+    const result = await loadLandlordAnalyticsSnapshot({
+      landlordId: "landlord-1",
+      now: Date.parse(nowIso),
+    });
+
+    expect(result.decisionOutcomeAnalytics).toEqual({
+      scope: "landlord_all_time",
+      appearedCount: 2,
+      reviewedCount: 1,
+      dismissedCount: 0,
+      executedCount: 1,
+      failedExecutionCount: 1,
+      resolvedCount: 2,
+      resolutionRate: 1,
+      medianTimeToResolutionHours: 48,
+      averageTimeToExecutionHours: 48,
+    });
   });
 });

--- a/rentchain-api/src/services/landlord/__tests__/landlordDecisionOutcomeAnalytics.test.ts
+++ b/rentchain-api/src/services/landlord/__tests__/landlordDecisionOutcomeAnalytics.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import { deriveLandlordDecisionOutcomeAnalytics } from "../landlordDecisionOutcomeAnalytics";
+
+describe("deriveLandlordDecisionOutcomeAnalytics", () => {
+  it("derives all-time outcome metrics from landlord-scoped canonical decision events", () => {
+    const result = deriveLandlordDecisionOutcomeAnalytics({
+      landlordId: "landlord-1",
+      canonicalEvents: [
+        {
+          id: "event-1",
+          type: "decision.appeared",
+          visibility: "landlord",
+          resource: { type: "analytics_decision", id: "decision-1" },
+          metadata: { landlordId: "landlord-1", decisionId: "decision-1" },
+          occurredAt: "2026-04-01T00:00:00.000Z",
+        } as any,
+        {
+          id: "event-2",
+          type: "decision.reviewed",
+          visibility: "landlord",
+          resource: { type: "analytics_decision", id: "decision-1" },
+          metadata: { landlordId: "landlord-1", decisionId: "decision-1" },
+          occurredAt: "2026-04-03T00:00:00.000Z",
+        } as any,
+        {
+          id: "event-3",
+          type: "decision.appeared",
+          visibility: "landlord",
+          resource: { type: "analytics_decision", id: "decision-2" },
+          metadata: { landlordId: "landlord-1", decisionId: "decision-2" },
+          occurredAt: "2026-04-02T00:00:00.000Z",
+        } as any,
+        {
+          id: "event-4",
+          type: "decision.executed",
+          visibility: "landlord",
+          resource: { type: "analytics_decision", id: "decision-2" },
+          metadata: { landlordId: "landlord-1", decisionId: "decision-2" },
+          occurredAt: "2026-04-06T00:00:00.000Z",
+        } as any,
+        {
+          id: "event-5",
+          type: "decision.appeared",
+          visibility: "landlord",
+          resource: { type: "analytics_decision", id: "decision-3" },
+          metadata: { landlordId: "landlord-1", decisionId: "decision-3" },
+          occurredAt: "2026-04-04T00:00:00.000Z",
+        } as any,
+        {
+          id: "event-6",
+          type: "decision.execution_failed",
+          visibility: "landlord",
+          resource: { type: "analytics_decision", id: "decision-3" },
+          metadata: { landlordId: "landlord-1", decisionId: "decision-3" },
+          occurredAt: "2026-04-07T00:00:00.000Z",
+        } as any,
+        {
+          id: "event-7",
+          type: "decision.appeared",
+          visibility: "landlord",
+          resource: { type: "analytics_decision", id: "decision-4" },
+          metadata: { landlordId: "landlord-1", decisionId: "decision-4" },
+          occurredAt: "2026-04-05T00:00:00.000Z",
+        } as any,
+        {
+          id: "event-8",
+          type: "decision.dismissed",
+          visibility: "landlord",
+          resource: { type: "analytics_decision", id: "decision-4" },
+          metadata: { landlordId: "landlord-1", decisionId: "decision-4" },
+          occurredAt: "2026-04-08T00:00:00.000Z",
+        } as any,
+        {
+          id: "event-9",
+          type: "decision.appeared",
+          visibility: "landlord",
+          resource: { type: "analytics_decision", id: "decision-other" },
+          metadata: { landlordId: "landlord-2", decisionId: "decision-other" },
+          occurredAt: "2026-04-01T00:00:00.000Z",
+        } as any,
+      ],
+    });
+
+    expect(result).toEqual({
+      scope: "landlord_all_time",
+      appearedCount: 4,
+      reviewedCount: 1,
+      dismissedCount: 1,
+      executedCount: 1,
+      failedExecutionCount: 1,
+      resolvedCount: 3,
+      resolutionRate: 0.75,
+      medianTimeToResolutionHours: 72,
+      averageTimeToExecutionHours: 96,
+    });
+  });
+
+  it("ignores malformed durations while still counting valid outcomes", () => {
+    const result = deriveLandlordDecisionOutcomeAnalytics({
+      landlordId: "landlord-1",
+      canonicalEvents: [
+        {
+          id: "event-1",
+          type: "decision.appeared",
+          visibility: "landlord",
+          resource: { type: "analytics_decision", id: "decision-1" },
+          metadata: { landlordId: "landlord-1", decisionId: "decision-1" },
+          occurredAt: "2026-04-05T00:00:00.000Z",
+        } as any,
+        {
+          id: "event-2",
+          type: "decision.reviewed",
+          visibility: "landlord",
+          resource: { type: "analytics_decision", id: "decision-1" },
+          metadata: { landlordId: "landlord-1", decisionId: "decision-1" },
+          occurredAt: "2026-04-04T00:00:00.000Z",
+        } as any,
+      ],
+    });
+
+    expect(result.appearedCount).toBe(1);
+    expect(result.reviewedCount).toBe(1);
+    expect(result.resolvedCount).toBe(1);
+    expect(result.medianTimeToResolutionHours).toBeNull();
+    expect(result.averageTimeToExecutionHours).toBeNull();
+  });
+});

--- a/rentchain-api/src/services/landlord/landlordAnalyticsSnapshot.ts
+++ b/rentchain-api/src/services/landlord/landlordAnalyticsSnapshot.ts
@@ -16,6 +16,7 @@ import { deriveLandlordAnalyticsSnapshot } from "../../lib/analytics/deriveLandl
 import { deriveScreeningReconciliation } from "../../lib/reconciliation/deriveScreeningReconciliation";
 import { emitLandlordDecisionAppearanceEvents } from "./landlordDecisionAppearanceEvents";
 import { loadLandlordDecisionStates, mergeLandlordDecisionStates } from "./landlordDecisionStates";
+import { deriveLandlordDecisionOutcomeAnalytics } from "./landlordDecisionOutcomeAnalytics";
 
 type LandlordAnalyticsParams = {
   landlordId: string;
@@ -268,7 +269,7 @@ export async function loadLandlordAnalyticsSnapshot(params: LandlordAnalyticsPar
     })
   );
 
-  await emitLandlordDecisionAppearanceEvents({
+  const emittedAppearanceEvents = await emitLandlordDecisionAppearanceEvents({
     landlordId,
     decisions,
     canonicalEvents: canonicalEventsRaw,
@@ -281,5 +282,9 @@ export async function loadLandlordAnalyticsSnapshot(params: LandlordAnalyticsPar
         ...snapshot.decisions,
         items: decisions,
       },
+      decisionOutcomeAnalytics: deriveLandlordDecisionOutcomeAnalytics({
+        landlordId,
+        canonicalEvents: [...canonicalEventsRaw, ...emittedAppearanceEvents],
+      }),
   };
 }

--- a/rentchain-api/src/services/landlord/landlordDecisionAppearanceEvents.ts
+++ b/rentchain-api/src/services/landlord/landlordDecisionAppearanceEvents.ts
@@ -23,11 +23,12 @@ export async function emitLandlordDecisionAppearanceEvents(params: {
   decisions: LandlordAgentDecision[];
   canonicalEvents: CanonicalEventV1[];
   occurredAt: string;
-}): Promise<void> {
+}): Promise<CanonicalEventV1[]> {
   const landlordId = asString(params.landlordId, 240);
-  if (!landlordId) return;
+  if (!landlordId) return [];
 
   const seenDecisionIds = new Set<string>();
+  const emittedEvents: CanonicalEventV1[] = [];
   for (const event of params.canonicalEvents || []) {
     const decisionId = asString(event.metadata?.decisionId, 240);
     if (!decisionId) continue;
@@ -40,14 +41,16 @@ export async function emitLandlordDecisionAppearanceEvents(params: {
     if (!decisionId || seenDecisionIds.has(decisionId)) continue;
     seenDecisionIds.add(decisionId);
 
-    await writeCanonicalEvent({
+    const emittedEvent: CanonicalEventV1 = {
       id: decisionAppearanceEventId(landlordId, decisionId),
+      version: "v1",
       type: "decision.appeared",
       domain: "system",
       action: "appeared",
       actor: { type: "system", id: "system", role: "system" },
       resource: { type: "analytics_decision", id: decisionId },
       occurredAt: params.occurredAt,
+      recordedAt: params.occurredAt,
       visibility: "landlord",
       summary: `Analytics decision ${decisionId} appeared.`,
       metadata: {
@@ -56,6 +59,10 @@ export async function emitLandlordDecisionAppearanceEvents(params: {
         decisionType: decision.decisionType,
         source: "landlord_analytics_decisions",
       },
-    });
+    };
+    await writeCanonicalEvent(emittedEvent);
+    emittedEvents.push(emittedEvent);
   }
+
+  return emittedEvents;
 }

--- a/rentchain-api/src/services/landlord/landlordDecisionOutcomeAnalytics.ts
+++ b/rentchain-api/src/services/landlord/landlordDecisionOutcomeAnalytics.ts
@@ -1,0 +1,131 @@
+import type { LandlordDecisionOutcomeAnalytics } from "../../lib/analytics/analyticsTypes";
+import type { CanonicalEventV1 } from "../../lib/events/eventTypes";
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function eventTimestamp(event: CanonicalEventV1) {
+  const iso = asString(event.occurredAt || event.recordedAt, 80);
+  if (!iso) return null;
+  const millis = Date.parse(iso);
+  return Number.isFinite(millis) ? millis : null;
+}
+
+function median(values: number[]) {
+  if (!values.length) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    return (sorted[middle - 1] + sorted[middle]) / 2;
+  }
+  return sorted[middle];
+}
+
+function average(values: number[]) {
+  if (!values.length) return null;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function isLandlordDecisionEvent(event: CanonicalEventV1, landlordId: string) {
+  if (asString(event.visibility, 80) !== "landlord") return false;
+  if (asString(event.resource?.type, 120) !== "analytics_decision") return false;
+  if (asString(event.metadata?.landlordId, 240) !== landlordId) return false;
+  return [
+    "decision.appeared",
+    "decision.reviewed",
+    "decision.dismissed",
+    "decision.executed",
+    "decision.execution_failed",
+  ].includes(asString(event.type, 120));
+}
+
+type DecisionOutcomeEventState = {
+  appearedAt: number | null;
+  reviewedAt: number | null;
+  dismissedAt: number | null;
+  executedAt: number | null;
+  failedExecutionAt: number | null;
+};
+
+function nextEarliest(current: number | null, candidate: number | null) {
+  if (candidate == null) return current;
+  if (current == null) return candidate;
+  return Math.min(current, candidate);
+}
+
+export function deriveLandlordDecisionOutcomeAnalytics(params: {
+  landlordId: string;
+  canonicalEvents: CanonicalEventV1[];
+}): LandlordDecisionOutcomeAnalytics {
+  const landlordId = asString(params.landlordId, 240);
+  const events = (params.canonicalEvents || []).filter((event) => isLandlordDecisionEvent(event, landlordId));
+  const eventsByDecisionId = new Map<string, DecisionOutcomeEventState>();
+
+  for (const event of events) {
+    const decisionId = asString(event.metadata?.decisionId || event.resource?.id, 240);
+    if (!decisionId) continue;
+    const timestamp = eventTimestamp(event);
+    const current = eventsByDecisionId.get(decisionId) || {
+      appearedAt: null,
+      reviewedAt: null,
+      dismissedAt: null,
+      executedAt: null,
+      failedExecutionAt: null,
+    };
+
+    const eventType = asString(event.type, 120);
+    if (eventType === "decision.appeared") current.appearedAt = nextEarliest(current.appearedAt, timestamp);
+    if (eventType === "decision.reviewed") current.reviewedAt = nextEarliest(current.reviewedAt, timestamp);
+    if (eventType === "decision.dismissed") current.dismissedAt = nextEarliest(current.dismissedAt, timestamp);
+    if (eventType === "decision.executed") current.executedAt = nextEarliest(current.executedAt, timestamp);
+    if (eventType === "decision.execution_failed") {
+      current.failedExecutionAt = nextEarliest(current.failedExecutionAt, timestamp);
+    }
+    eventsByDecisionId.set(decisionId, current);
+  }
+
+  const resolutionDurationsHours: number[] = [];
+  const executionDurationsHours: number[] = [];
+  let appearedCount = 0;
+  let reviewedCount = 0;
+  let dismissedCount = 0;
+  let executedCount = 0;
+  let failedExecutionCount = 0;
+  let resolvedCount = 0;
+
+  for (const eventState of eventsByDecisionId.values()) {
+    if (eventState.appearedAt != null) appearedCount += 1;
+    if (eventState.reviewedAt != null) reviewedCount += 1;
+    if (eventState.dismissedAt != null) dismissedCount += 1;
+    if (eventState.executedAt != null) executedCount += 1;
+    if (eventState.failedExecutionAt != null) failedExecutionCount += 1;
+
+    const resolvedAt = [eventState.reviewedAt, eventState.dismissedAt, eventState.executedAt]
+      .filter((value): value is number => value != null)
+      .sort((a, b) => a - b)[0] ?? null;
+
+    if (resolvedAt != null) {
+      resolvedCount += 1;
+    }
+    if (eventState.appearedAt != null && resolvedAt != null && resolvedAt >= eventState.appearedAt) {
+      resolutionDurationsHours.push((resolvedAt - eventState.appearedAt) / (1000 * 60 * 60));
+    }
+    if (eventState.appearedAt != null && eventState.executedAt != null && eventState.executedAt >= eventState.appearedAt) {
+      executionDurationsHours.push((eventState.executedAt - eventState.appearedAt) / (1000 * 60 * 60));
+    }
+  }
+
+  return {
+    scope: "landlord_all_time",
+    appearedCount,
+    reviewedCount,
+    dismissedCount,
+    executedCount,
+    failedExecutionCount,
+    resolvedCount,
+    resolutionRate: appearedCount > 0 ? resolvedCount / appearedCount : null,
+    medianTimeToResolutionHours: median(resolutionDurationsHours),
+    averageTimeToExecutionHours: average(executionDurationsHours),
+  };
+}

--- a/rentchain-frontend/src/api/landlordAnalyticsApi.ts
+++ b/rentchain-frontend/src/api/landlordAnalyticsApi.ts
@@ -112,6 +112,19 @@ export type AnalyticsDeltaValue = {
   direction: "better" | "worse" | "flat" | "insufficient_data";
 };
 
+export type LandlordDecisionOutcomeAnalytics = {
+  scope: "landlord_all_time";
+  appearedCount: number;
+  reviewedCount: number;
+  dismissedCount: number;
+  executedCount: number;
+  failedExecutionCount: number;
+  resolvedCount: number;
+  resolutionRate: number | null;
+  medianTimeToResolutionHours: number | null;
+  averageTimeToExecutionHours: number | null;
+};
+
 export type LandlordAnalyticsSnapshot = {
   summary: {
     occupiedUnits: number;
@@ -162,6 +175,7 @@ export type LandlordAnalyticsSnapshot = {
   decisions: {
     items: LandlordAgentDecision[];
   };
+  decisionOutcomeAnalytics: LandlordDecisionOutcomeAnalytics;
   predictive: {
     metrics: LandlordPredictiveMetric[];
   };

--- a/rentchain-frontend/src/components/analytics/DecisionOutcomeAnalyticsPanel.tsx
+++ b/rentchain-frontend/src/components/analytics/DecisionOutcomeAnalyticsPanel.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import type { LandlordDecisionOutcomeAnalytics } from "@/api/landlordAnalyticsApi";
+import AnalyticsSectionPanel from "./AnalyticsSectionPanel";
+
+function formatPercent(value: number | null) {
+  if (value == null || !Number.isFinite(value)) return "—";
+  return `${Math.round(value * 100)}%`;
+}
+
+function formatDurationHours(hours: number | null) {
+  if (hours == null || !Number.isFinite(hours)) return "—";
+  if (hours >= 48) return `${(hours / 24).toFixed(1)}d`;
+  if (hours >= 1) return `${Math.round(hours)}h`;
+  return `${Math.round(hours * 60)}m`;
+}
+
+type Props = {
+  analytics: LandlordDecisionOutcomeAnalytics | null | undefined;
+};
+
+export default function DecisionOutcomeAnalyticsPanel({ analytics }: Props) {
+  if (!analytics) return null;
+
+  return (
+    <AnalyticsSectionPanel
+      title="Decision outcomes"
+      description="All-time landlord decision outcomes from canonical decision events."
+      metrics={[
+        {
+          label: "Appeared",
+          value: String(analytics.appearedCount),
+          hint: "Unique decisions first surfaced in canonical history.",
+        },
+        {
+          label: "Reviewed",
+          value: String(analytics.reviewedCount),
+          hint: "Decisions with a canonical reviewed event.",
+        },
+        {
+          label: "Executed",
+          value: String(analytics.executedCount),
+          hint: "Decisions with a canonical executed event.",
+        },
+        {
+          label: "Failed",
+          value: String(analytics.failedExecutionCount),
+          hint: "Decisions with at least one canonical execution failure.",
+        },
+        {
+          label: "Resolved",
+          value: String(analytics.resolvedCount),
+          hint: `Reviewed, dismissed, or executed. Resolution rate ${formatPercent(analytics.resolutionRate)}.`,
+        },
+        {
+          label: "Median time to resolution",
+          value: formatDurationHours(analytics.medianTimeToResolutionHours),
+          hint: "From appeared to the earliest reviewed, dismissed, or executed event.",
+        },
+      ]}
+    />
+  );
+}

--- a/rentchain-frontend/src/pages/landlord/ActionRecommendationsPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/ActionRecommendationsPage.test.tsx
@@ -81,6 +81,18 @@ describe("ActionRecommendationsPage", () => {
     await mockEntitlements();
     const { fetchLandlordAnalyticsSnapshot } = await import("../../api/landlordAnalyticsApi");
     vi.mocked(fetchLandlordAnalyticsSnapshot).mockResolvedValue({
+      decisionOutcomeAnalytics: {
+        scope: "landlord_all_time",
+        appearedCount: 8,
+        reviewedCount: 3,
+        dismissedCount: 1,
+        executedCount: 2,
+        failedExecutionCount: 1,
+        resolvedCount: 6,
+        resolutionRate: 0.75,
+        medianTimeToResolutionHours: 36,
+        averageTimeToExecutionHours: 42,
+      },
       decisions: {
         items: [
           {
@@ -151,6 +163,9 @@ describe("ActionRecommendationsPage", () => {
 
     expect(await screen.findByRole("heading", { name: /Decision inbox/i })).toBeInTheDocument();
     expect(screen.getByText(/centralized decision inbox/i)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Decision outcomes/i })).toBeInTheDocument();
+    expect(screen.getByText(/all-time landlord decision outcomes from canonical decision events/i)).toBeInTheDocument();
+    expect(screen.getByText(/resolution rate 75%/i)).toBeInTheDocument();
     expect(fetchLandlordAnalyticsSnapshot).toHaveBeenCalledTimes(1);
 
     const actionLinks = screen.getAllByRole("link");

--- a/rentchain-frontend/src/pages/landlord/ActionRecommendationsPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/ActionRecommendationsPage.tsx
@@ -8,6 +8,7 @@ import { LockedFeature } from "@/components/billing/LockedFeature";
 import { FeatureTeaser } from "@/components/billing/FeatureTeaser";
 import { resolveRequiredPlanLabel } from "@/lib/upgradePrompt";
 import AgentDecisionPanel from "../../components/analytics/AgentDecisionPanel";
+import DecisionOutcomeAnalyticsPanel from "../../components/analytics/DecisionOutcomeAnalyticsPanel";
 
 function errorMessage(error: unknown) {
   if (error instanceof Error && error.message) return error.message;
@@ -110,13 +111,16 @@ export default function ActionRecommendationsPage() {
           <Card style={{ color: "#b91c1c" }}>Failed to load recommended actions: {error}</Card>
         ) : null}
         {!entitlementLoading && canViewDecisionInbox && !loading && !error ? (
-          <AgentDecisionPanel
-            decisions={snapshot?.decisions?.items || []}
-            title="Decision inbox"
-            description="Review the next landlord actions surfaced directly from your current analytics snapshot."
-            emptyMessage="No prioritized landlord actions are surfaced for this view right now."
-            period="90d"
-          />
+          <>
+            <DecisionOutcomeAnalyticsPanel analytics={snapshot?.decisionOutcomeAnalytics} />
+            <AgentDecisionPanel
+              decisions={snapshot?.decisions?.items || []}
+              title="Decision inbox"
+              description="Review the next landlord actions surfaced directly from your current analytics snapshot."
+              emptyMessage="No prioritized landlord actions are surfaced for this view right now."
+              period="90d"
+            />
+          </>
         ) : null}
       </div>
     </MacShell>

--- a/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.test.tsx
@@ -255,6 +255,18 @@ describe("LandlordAnalyticsPage", () => {
         estimatedScheduledRentCents: 660000,
         averageRentPerOccupiedUnitCents: 165000,
       },
+      decisionOutcomeAnalytics: {
+        scope: "landlord_all_time",
+        appearedCount: 12,
+        reviewedCount: 5,
+        dismissedCount: 2,
+        executedCount: 3,
+        failedExecutionCount: 1,
+        resolvedCount: 10,
+        resolutionRate: 0.8333,
+        medianTimeToResolutionHours: 54,
+        averageTimeToExecutionHours: 61,
+      },
       decisions: {
         items: [
           {
@@ -486,6 +498,8 @@ describe("LandlordAnalyticsPage", () => {
     );
 
     expect(await screen.findByText(/Analytics alerts/i)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Decision outcomes/i })).toBeInTheDocument();
+    expect(screen.getByText(/all-time landlord decision outcomes from canonical decision events/i)).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /Recommended next actions/i })).toBeInTheDocument();
     expect(screen.getByText(/Beta carries the strongest vacancy pressure/i)).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /Predictive metrics/i })).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.tsx
@@ -19,6 +19,7 @@ import AgentDecisionPanel from "../../components/analytics/AgentDecisionPanel";
 import AnalyticsFiltersBar from "../../components/analytics/AnalyticsFiltersBar";
 import AnalyticsKpiGrid from "../../components/analytics/AnalyticsKpiGrid";
 import AnalyticsSectionPanel from "../../components/analytics/AnalyticsSectionPanel";
+import DecisionOutcomeAnalyticsPanel from "../../components/analytics/DecisionOutcomeAnalyticsPanel";
 import InsightCardsPanel from "../../components/analytics/InsightCardsPanel";
 import PortfolioBenchmarkingPanel from "../../components/analytics/PortfolioBenchmarkingPanel";
 import PredictiveMetricsPanel from "../../components/analytics/PredictiveMetricsPanel";
@@ -258,6 +259,7 @@ export default function LandlordAnalyticsPage() {
             {canViewBenchmarking ? <PortfolioBenchmarkingPanel benchmarking={benchmarking} /> : null}
             {canViewPortfolioScore && canViewAdvancedAnalytics ? (
               <>
+                <DecisionOutcomeAnalyticsPanel analytics={snapshot.decisionOutcomeAnalytics} />
                 <AgentDecisionPanel
                   decisions={snapshot.decisions?.items || []}
                   period={period}


### PR DESCRIPTION
## Summary
- add a landlord-scoped decision outcome analytics layer derived purely from canonical decision events
- expose the derived metrics through the existing landlord analytics snapshot
- render a lightweight shared summary on both landlord decision surfaces

## Metrics
- appeared
- reviewed
- dismissed
- executed
- failed
- resolved
- resolution rate
- median time to resolution
- average time to execution

## Notes
- metrics are derived purely from canonical decision events
- v1 metrics are landlord-scoped and all-time
- v1 metrics are not property-filtered
- execution failure is tracked explicitly and is not counted as resolved
- legacy state without canonical events does not contribute to rollups
- no UI- or state-based reconstruction was introduced

## Verification
- backend targeted tests passed
- frontend targeted tests passed
- `rentchain-api` build passed
- `rentchain-frontend` build passed
- targeted frontend lint passed