### PR TITLE
feat: improve decision history filtering and navigation v2

### DIFF
--- a/rentchain-frontend/src/components/analytics/AgentDecisionPanel.test.tsx
+++ b/rentchain-frontend/src/components/analytics/AgentDecisionPanel.test.tsx
@@ -38,6 +38,7 @@ vi.mock("../ui/Ui", () => ({
 
 beforeEach(() => {
   vi.clearAllMocks();
+  window.localStorage.clear();
   snoozeLandlordDecision.mockResolvedValue({
     state: {
       decisionId: "reduce_vacancy_risk:prop-2",
@@ -106,6 +107,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  window.localStorage.clear();
 });
 
 describe("AgentDecisionPanel", () => {
@@ -648,5 +650,76 @@ describe("AgentDecisionPanel", () => {
     expect(await screen.findByText("Appeared")).toBeInTheDocument();
     expect(screen.getByText("Reviewed")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Hide history/i })).toBeInTheDocument();
+  });
+
+  it("persists per-decision history visibility across remounts", async () => {
+    const decision = {
+      id: "review_lease_renewals:prop-1",
+      decisionType: "review_lease_renewals",
+      priority: "high",
+      explanation: "Review upcoming renewals.",
+      recommendedAction: "Review renewals",
+      actionKey: "open_lease_renewals_flow",
+      actionLabel: "Open renewals focus",
+      destination: "/portfolio-health?entry=lease-renewals&propertyId=prop-1",
+      workflowCategory: "lease_renewals",
+      automationEligible: true,
+      automationState: "ready",
+      automationReason: "This decision is active and already mapped to a deterministic automation path.",
+      executionMappingState: "mapped",
+      executionMapping: {
+        action: "lease.auto_send_notice",
+        resourceType: "lease",
+        resourceId: "lease-1",
+        prerequisitesMet: true,
+        prerequisiteReason: null,
+      },
+      executionInputState: "complete",
+      executionInputReason: null,
+      executionInputMissingFields: [],
+      executionInput: {
+        noticeType: "renewal_offer",
+        legalTemplateKey: "ns.fixed_term.renewal_offer.v1",
+        noticeRuleVersion: "ns-v1",
+        province: "NS",
+        leaseType: "fixed_term",
+        currentRent: 1650,
+        noticeDueAt: Date.UTC(2026, 1, 10, 0, 0, 0, 0),
+        rentChangeMode: "no_change",
+        proposedRent: null,
+        newTermType: "fixed_term",
+        newLeaseStartDate: "2026-05-11",
+        newLeaseEndDate: "2027-05-10",
+        responseDeadlineAt: Date.UTC(2026, 4, 1, 12, 0, 0, 0),
+      },
+      executedAt: null,
+      executionOutcomeStatus: "none",
+      executionOutcomeAt: null,
+      executionOutcomeReason: null,
+      href: "/portfolio-health?entry=lease-renewals&propertyId=prop-1",
+      state: "pending",
+      reviewedAt: null,
+      supportingSignals: [],
+    } as const;
+
+    const { unmount } = render(
+      <MemoryRouter>
+        <AgentDecisionPanel period="90d" decisions={[decision]} />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /View history/i }));
+    await screen.findByText("Appeared");
+    unmount();
+
+    render(
+      <MemoryRouter>
+        <AgentDecisionPanel period="90d" decisions={[decision]} />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole("button", { name: /Hide history/i })).toBeInTheDocument();
+    expect(await screen.findByText("Appeared")).toBeInTheDocument();
+    expect(fetchLandlordDecisionHistory).toHaveBeenCalledTimes(2);
   });
 });

--- a/rentchain-frontend/src/components/analytics/AgentDecisionPanel.tsx
+++ b/rentchain-frontend/src/components/analytics/AgentDecisionPanel.tsx
@@ -101,6 +101,18 @@ function sectionHeadingStyle() {
   } as const;
 }
 
+const HISTORY_VISIBILITY_STORAGE_KEY = "landlordDecisionHistoryVisibilityV2";
+
+function readPersistedHistoryVisibility() {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(HISTORY_VISIBILITY_STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as Record<string, boolean>) : {};
+  } catch {
+    return {};
+  }
+}
+
 function HistoryToggle(props: {
   decisionId: string;
   showHistory: boolean;
@@ -134,7 +146,11 @@ function HistoryToggle(props: {
           {historyLoading ? <div style={{ color: "#64748b" }}>Loading history…</div> : null}
           {!historyLoading && historyError ? <div style={{ color: "#b91c1c" }}>{historyError}</div> : null}
           {!historyLoading && !historyError ? (
-            <Timeline items={historyItems} emptyMessage="No canonical decision history is available yet." />
+            <Timeline
+              items={historyItems}
+              emptyMessage="No canonical decision history is available yet."
+              storageKey={`decision-history-timeline:${decisionId}`}
+            />
           ) : null}
         </div>
       ) : null}
@@ -439,7 +455,9 @@ export function AgentDecisionPanel({
   const [workingAction, setWorkingAction] = React.useState<"review" | "snooze" | "dismiss" | "execute" | null>(null);
   const [error, setError] = React.useState<string | null>(null);
   const [showExecuted, setShowExecuted] = React.useState(false);
-  const [expandedHistoryDecisionIds, setExpandedHistoryDecisionIds] = React.useState<Record<string, boolean>>({});
+  const [expandedHistoryDecisionIds, setExpandedHistoryDecisionIds] = React.useState<Record<string, boolean>>(
+    () => readPersistedHistoryVisibility()
+  );
   const [historyItemsByDecisionId, setHistoryItemsByDecisionId] = React.useState<Record<string, TimelineItem[]>>({});
   const [historyLoadingByDecisionId, setHistoryLoadingByDecisionId] = React.useState<Record<string, boolean>>({});
   const [historyErrorByDecisionId, setHistoryErrorByDecisionId] = React.useState<Record<string, string | null>>({});
@@ -448,17 +466,19 @@ export function AgentDecisionPanel({
     setItems(decisions);
   }, [decisions]);
 
+  React.useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(HISTORY_VISIBILITY_STORAGE_KEY, JSON.stringify(expandedHistoryDecisionIds));
+    } catch {
+      // Ignore persistence failures and keep local UI state functional.
+    }
+  }, [expandedHistoryDecisionIds]);
+
   const activeItems = React.useMemo(() => items.filter((decision) => decision.state !== "executed"), [items]);
   const executedItems = React.useMemo(() => items.filter((decision) => decision.state === "executed"), [items]);
 
-  const handleToggleHistory = async (decisionId: string) => {
-    const currentlyExpanded = Boolean(expandedHistoryDecisionIds[decisionId]);
-    if (currentlyExpanded) {
-      setExpandedHistoryDecisionIds((current) => ({ ...current, [decisionId]: false }));
-      return;
-    }
-
-    setExpandedHistoryDecisionIds((current) => ({ ...current, [decisionId]: true }));
+  const loadHistory = React.useCallback(async (decisionId: string) => {
     if (historyItemsByDecisionId[decisionId] || historyLoadingByDecisionId[decisionId]) return;
 
     try {
@@ -475,6 +495,28 @@ export function AgentDecisionPanel({
     } finally {
       setHistoryLoadingByDecisionId((current) => ({ ...current, [decisionId]: false }));
     }
+  }, [historyItemsByDecisionId, historyLoadingByDecisionId, period, propertyId]);
+
+  React.useEffect(() => {
+    const visibleExpandedDecisionIds = items
+      .map((decision) => decision.id)
+      .filter((decisionId) => expandedHistoryDecisionIds[decisionId]);
+
+    for (const decisionId of visibleExpandedDecisionIds) {
+      if (historyItemsByDecisionId[decisionId] || historyLoadingByDecisionId[decisionId]) continue;
+      void loadHistory(decisionId);
+    }
+  }, [expandedHistoryDecisionIds, historyItemsByDecisionId, historyLoadingByDecisionId, items, loadHistory]);
+
+  const handleToggleHistory = async (decisionId: string) => {
+    const currentlyExpanded = Boolean(expandedHistoryDecisionIds[decisionId]);
+    if (currentlyExpanded) {
+      setExpandedHistoryDecisionIds((current) => ({ ...current, [decisionId]: false }));
+      return;
+    }
+
+    setExpandedHistoryDecisionIds((current) => ({ ...current, [decisionId]: true }));
+    await loadHistory(decisionId);
   };
 
   const handleReview = async (decisionId: string) => {

--- a/rentchain-frontend/src/components/timeline/Timeline.test.tsx
+++ b/rentchain-frontend/src/components/timeline/Timeline.test.tsx
@@ -104,4 +104,25 @@ describe("Timeline", () => {
     render(<Timeline items={[]} emptyMessage="Nothing to show yet." />);
     expect(screen.getByText(/Nothing to show yet/i)).toBeInTheDocument();
   });
+
+  it("supports overriding default bucket expansion for surfaces that should keep older history visible", () => {
+    render(
+      <Timeline
+        items={[
+          {
+            id: "event-earlier",
+            title: "Executed",
+            description: "Decision executed.",
+            timestamp: "2026-03-28T12:00:00.000Z",
+            domain: "system",
+            actor: "Landlord",
+          },
+        ]}
+        defaultExpandedBuckets={{ earlier: true }}
+      />
+    );
+
+    expect(screen.getByText(/Decision executed\./i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Hide" })).toBeInTheDocument();
+  });
 });

--- a/rentchain-frontend/src/components/timeline/Timeline.test.tsx
+++ b/rentchain-frontend/src/components/timeline/Timeline.test.tsx
@@ -1,37 +1,103 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Timeline } from "./Timeline";
 
 describe("Timeline", () => {
-  it("renders grouped timeline items", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-03T15:00:00.000Z"));
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    window.localStorage.clear();
+    cleanup();
+  });
+
+  it("renders timeline items in time buckets and collapses older history by default", () => {
     render(
       <Timeline
         items={[
           {
-            id: "event-1",
-            title: "Lease activated",
-            description: "Lease activated for unit 4.",
+            id: "event-today",
+            title: "Reviewed",
+            description: "Decision reviewed.",
             timestamp: "2026-04-03T10:15:00.000Z",
-            domain: "lease",
-            status: "active",
+            domain: "system",
+            status: "reviewed",
             actor: "Landlord",
           },
           {
-            id: "event-2",
-            title: "Screening payment completed",
-            description: "Screening payment completed for the application.",
-            timestamp: "2026-04-03T09:30:00.000Z",
-            domain: "screening",
+            id: "event-yesterday",
+            title: "Appeared",
+            description: "Decision appeared.",
+            timestamp: "2026-04-02T09:30:00.000Z",
+            domain: "system",
             actor: "System",
           },
+          {
+            id: "event-earlier",
+            title: "Executed",
+            description: "Decision executed.",
+            timestamp: "2026-03-28T12:00:00.000Z",
+            domain: "system",
+            actor: "Landlord",
+          },
         ]}
+        storageKey="timeline-test"
       />
     );
 
-    expect(screen.getAllByText(/Lease activated/i).length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/Screening payment completed/i).length).toBeGreaterThan(0);
-    expect(screen.getByText(/2026/)).toBeInTheDocument();
+    expect(screen.getByText("Today")).toBeInTheDocument();
+    expect(screen.getByText("Yesterday")).toBeInTheDocument();
+    expect(screen.getByText("Earlier")).toBeInTheDocument();
+    expect(screen.getByText("Reviewed")).toBeInTheDocument();
+    expect(screen.getByText("Appeared")).toBeInTheDocument();
+    expect(screen.queryByText(/Decision executed\./i)).not.toBeInTheDocument();
+    fireEvent.click(screen.getAllByRole("button", { name: "Show" })[0]);
+    expect(screen.getByText(/Decision executed\./i)).toBeInTheDocument();
+    expect(screen.getAllByText(/2026/).length).toBeGreaterThan(0);
+  });
+
+  it("persists bucket visibility in local storage", () => {
+    const { unmount } = render(
+      <Timeline
+        items={[
+          {
+            id: "event-earlier",
+            title: "Executed",
+            description: "Decision executed.",
+            timestamp: "2026-03-28T12:00:00.000Z",
+            domain: "system",
+            actor: "Landlord",
+          },
+        ]}
+        storageKey="timeline-persist"
+      />
+    );
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Show" })[0]);
+    unmount();
+
+    render(
+      <Timeline
+        items={[
+          {
+            id: "event-earlier",
+            title: "Executed",
+            description: "Decision executed.",
+            timestamp: "2026-03-28T12:00:00.000Z",
+            domain: "system",
+            actor: "Landlord",
+          },
+        ]}
+        storageKey="timeline-persist"
+      />
+    );
+
+    expect(screen.getByText(/Decision executed\./i)).toBeInTheDocument();
   });
 
   it("shows an empty state when there are no items", () => {

--- a/rentchain-frontend/src/components/timeline/Timeline.tsx
+++ b/rentchain-frontend/src/components/timeline/Timeline.tsx
@@ -5,6 +5,7 @@ type TimelineProps = {
   items: TimelineItem[];
   emptyMessage?: string;
   storageKey?: string;
+  defaultExpandedBuckets?: Partial<Record<TimelineBucketKey, boolean>>;
 };
 
 function formatDayHeading(value: string) {
@@ -47,12 +48,15 @@ function bucketLabel(key: TimelineBucketKey) {
   return "Unknown day";
 }
 
-function defaultBucketState(): Record<TimelineBucketKey, boolean> {
+function defaultBucketState(
+  overrides?: Partial<Record<TimelineBucketKey, boolean>>
+): Record<TimelineBucketKey, boolean> {
   return {
     today: true,
     yesterday: true,
     earlier: false,
     unknown: true,
+    ...overrides,
   };
 }
 
@@ -91,8 +95,11 @@ function groupByBucket(items: TimelineItem[]) {
     .filter((bucket) => bucket.groups.length > 0);
 }
 
-function readStoredBucketState(storageKey?: string): Record<TimelineBucketKey, boolean> {
-  const defaults = defaultBucketState();
+function readStoredBucketState(
+  storageKey?: string,
+  defaultExpandedBuckets?: Partial<Record<TimelineBucketKey, boolean>>
+): Record<TimelineBucketKey, boolean> {
+  const defaults = defaultBucketState(defaultExpandedBuckets);
   if (!storageKey || typeof window === "undefined") return defaults;
   try {
     const raw = window.localStorage.getItem(storageKey);
@@ -104,10 +111,15 @@ function readStoredBucketState(storageKey?: string): Record<TimelineBucketKey, b
   }
 }
 
-export function Timeline({ items, emptyMessage = "No timeline events yet.", storageKey }: TimelineProps) {
+export function Timeline({
+  items,
+  emptyMessage = "No timeline events yet.",
+  storageKey,
+  defaultExpandedBuckets,
+}: TimelineProps) {
   const grouped = React.useMemo(() => groupByBucket(items), [items]);
   const [expandedBuckets, setExpandedBuckets] = React.useState<Record<TimelineBucketKey, boolean>>(() =>
-    readStoredBucketState(storageKey)
+    readStoredBucketState(storageKey, defaultExpandedBuckets)
   );
 
   React.useEffect(() => {

--- a/rentchain-frontend/src/components/timeline/Timeline.tsx
+++ b/rentchain-frontend/src/components/timeline/Timeline.tsx
@@ -4,6 +4,7 @@ import type { TimelineItem } from "../../api/timelineApi";
 type TimelineProps = {
   items: TimelineItem[];
   emptyMessage?: string;
+  storageKey?: string;
 };
 
 function formatDayHeading(value: string) {
@@ -37,39 +38,163 @@ function groupByDay(items: TimelineItem[]) {
   return Array.from(groups.entries()).sort((a, b) => b[0].localeCompare(a[0]));
 }
 
-export function Timeline({ items, emptyMessage = "No timeline events yet." }: TimelineProps) {
+type TimelineBucketKey = "today" | "yesterday" | "earlier" | "unknown";
+
+function bucketLabel(key: TimelineBucketKey) {
+  if (key === "today") return "Today";
+  if (key === "yesterday") return "Yesterday";
+  if (key === "earlier") return "Earlier";
+  return "Unknown day";
+}
+
+function defaultBucketState(): Record<TimelineBucketKey, boolean> {
+  return {
+    today: true,
+    yesterday: true,
+    earlier: false,
+    unknown: true,
+  };
+}
+
+function bucketForDay(dayKey: string) {
+  if (dayKey === "unknown") return "unknown" as const;
+  const [yearRaw, monthRaw, dayRaw] = dayKey.split("-");
+  const year = Number(yearRaw);
+  const month = Number(monthRaw);
+  const day = Number(dayRaw);
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) return "unknown" as const;
+
+  const now = new Date();
+  const todayLocal = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const normalizedDay = new Date(year, month - 1, day);
+  const diffDays = Math.round((todayLocal.getTime() - normalizedDay.getTime()) / (24 * 60 * 60 * 1000));
+
+  if (diffDays <= 0) return "today" as const;
+  if (diffDays === 1) return "yesterday" as const;
+  return "earlier" as const;
+}
+
+function groupByBucket(items: TimelineItem[]) {
+  const buckets = new Map<TimelineBucketKey, Array<[string, TimelineItem[]]>>();
+  for (const [dayKey, dayItems] of groupByDay(items)) {
+    const bucketKey = bucketForDay(dayKey);
+    if (!buckets.has(bucketKey)) buckets.set(bucketKey, []);
+    buckets.get(bucketKey)!.push([dayKey, dayItems]);
+  }
+
+  return (["today", "yesterday", "earlier", "unknown"] as const)
+    .map((key) => ({
+      key,
+      label: bucketLabel(key),
+      groups: buckets.get(key) || [],
+    }))
+    .filter((bucket) => bucket.groups.length > 0);
+}
+
+function readStoredBucketState(storageKey?: string): Record<TimelineBucketKey, boolean> {
+  const defaults = defaultBucketState();
+  if (!storageKey || typeof window === "undefined") return defaults;
+  try {
+    const raw = window.localStorage.getItem(storageKey);
+    if (!raw) return defaults;
+    const parsed = JSON.parse(raw) as Partial<Record<TimelineBucketKey, boolean>>;
+    return { ...defaults, ...parsed };
+  } catch {
+    return defaults;
+  }
+}
+
+export function Timeline({ items, emptyMessage = "No timeline events yet.", storageKey }: TimelineProps) {
+  const grouped = React.useMemo(() => groupByBucket(items), [items]);
+  const [expandedBuckets, setExpandedBuckets] = React.useState<Record<TimelineBucketKey, boolean>>(() =>
+    readStoredBucketState(storageKey)
+  );
+
+  React.useEffect(() => {
+    if (!storageKey || typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(storageKey, JSON.stringify(expandedBuckets));
+    } catch {
+      // Ignore local persistence failures and keep the timeline functional.
+    }
+  }, [expandedBuckets, storageKey]);
+
   if (!items.length) {
     return <div style={{ color: "#64748b" }}>{emptyMessage}</div>;
   }
 
-  const grouped = groupByDay(items);
-
   return (
     <div style={{ display: "grid", gap: 16 }}>
-      {grouped.map(([day, dayItems]) => (
-        <section key={day} style={{ display: "grid", gap: 10 }}>
-          <div style={{ fontSize: 12, fontWeight: 700, color: "#475569", letterSpacing: "0.04em", textTransform: "uppercase" }}>
-            {day === "unknown" ? "Unknown day" : formatDayHeading(day)}
+      {grouped.map((bucket) => (
+        <section key={bucket.key} style={{ display: "grid", gap: 10 }}>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+            <div
+              style={{ fontSize: 12, fontWeight: 700, color: "#475569", letterSpacing: "0.04em", textTransform: "uppercase" }}
+            >
+              {bucket.label}
+            </div>
+            <button
+              type="button"
+              onClick={() => setExpandedBuckets((current) => ({ ...current, [bucket.key]: !current[bucket.key] }))}
+              style={{
+                border: "1px solid #cbd5e1",
+                borderRadius: 999,
+                background: "#fff",
+                color: "#334155",
+                fontWeight: 700,
+                padding: "4px 10px",
+                cursor: "pointer",
+              }}
+            >
+              {expandedBuckets[bucket.key] ? "Hide" : "Show"}
+            </button>
           </div>
-          <div className="timeline">
-            {dayItems.map((item) => (
-              <article key={item.id} className="timelineRow" style={{ background: "rgba(255,255,255,0.9)", borderRadius: 12, padding: 12 }}>
-                <div className="timelineDot" aria-hidden="true" />
-                <div style={{ display: "grid", gap: 6, width: "100%" }}>
-                  <div className="timelineTop">
-                    <div className="timelineTitle">{item.title}</div>
-                    <div className="timelineDate">{formatTimestamp(item.timestamp)}</div>
+          {expandedBuckets[bucket.key] ? (
+            <div style={{ display: "grid", gap: 16 }}>
+              {bucket.groups.map(([day, dayItems]) => (
+                <section key={day} style={{ display: "grid", gap: 10 }}>
+                  <div
+                    style={{
+                      fontSize: 12,
+                      fontWeight: 700,
+                      color: "#64748b",
+                      letterSpacing: "0.04em",
+                      textTransform: "uppercase",
+                    }}
+                  >
+                    {day === "unknown" ? "Unknown day" : formatDayHeading(day)}
                   </div>
-                  <div className="timelineDesc">{item.description}</div>
-                  <div className="timelineMeta">
-                    <span>{item.domain}</span>
-                    {item.status ? <span>• {item.status}</span> : null}
-                    {item.actor ? <span>• {item.actor}</span> : null}
+                  <div className="timeline">
+                    {dayItems.map((item) => (
+                      <article
+                        key={item.id}
+                        className="timelineRow"
+                        style={{ background: "rgba(255,255,255,0.9)", borderRadius: 12, padding: 12 }}
+                      >
+                        <div className="timelineDot" aria-hidden="true" />
+                        <div style={{ display: "grid", gap: 6, width: "100%" }}>
+                          <div className="timelineTop">
+                            <div className="timelineTitle">{item.title}</div>
+                            <div className="timelineDate">{formatTimestamp(item.timestamp)}</div>
+                          </div>
+                          <div className="timelineDesc">{item.description}</div>
+                          <div className="timelineMeta">
+                            <span>{item.domain}</span>
+                            {item.status ? <span>• {item.status}</span> : null}
+                            {item.actor ? <span>• {item.actor}</span> : null}
+                          </div>
+                        </div>
+                      </article>
+                    ))}
                   </div>
-                </div>
-              </article>
-            ))}
-          </div>
+                </section>
+              ))}
+            </div>
+          ) : (
+            <div style={{ color: "#64748b", fontSize: "0.92rem" }}>
+              {bucket.groups.reduce((count, [, dayItems]) => count + dayItems.length, 0)} events hidden in this section.
+            </div>
+          )}
         </section>
       ))}
     </div>

--- a/rentchain-frontend/src/pages/admin/AutomationTimelineV1Page.tsx
+++ b/rentchain-frontend/src/pages/admin/AutomationTimelineV1Page.tsx
@@ -118,7 +118,11 @@ export default function AutomationTimelineV1Page() {
         {!loading && error ? <Card style={{ color: "#b91c1c" }}>Failed to load timeline: {error}</Card> : null}
         {!loading && !error ? (
           <Card>
-            <Timeline items={visibleEvents} emptyMessage="No canonical timeline activity is available yet." />
+            <Timeline
+              items={visibleEvents}
+              emptyMessage="No canonical timeline activity is available yet."
+              defaultExpandedBuckets={{ earlier: true }}
+            />
           </Card>
         ) : null}
 

--- a/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.tsx
+++ b/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.tsx
@@ -197,7 +197,11 @@ export default function SupportDebugConsolePage() {
             </SupportConsoleSection>
 
             <SupportConsoleSection title="Timeline">
-              <Timeline items={payload.timeline} emptyMessage="No canonical timeline activity is available for this resource." />
+              <Timeline
+                items={payload.timeline}
+                emptyMessage="No canonical timeline activity is available for this resource."
+                defaultExpandedBuckets={{ earlier: true }}
+              />
             </SupportConsoleSection>
 
             <SupportConsoleSection title="Debug metadata">


### PR DESCRIPTION
## Summary
- improve decision history usability without changing any backend history truth path
- keep one canonical event-backed landlord decision history source
- add frontend-only browsing improvements for grouped and collapsible history

## Changes
- add higher-level time buckets: `Today`, `Yesterday`, `Earlier`, `Unknown day`
- add per-bucket collapse controls
- add lightweight local persistence for history visibility and per-decision history expansion

## Notes
- history remains backed by one canonical backend event list
- grouping and collapse behavior are frontend-only presentation improvements
- bucket labels such as `Today` / `Yesterday` depend on client timezone
- history visibility persistence is local browser storage only
- clearing browser storage resets those browsing preferences
- all canonical events remain accessible
- no backend decision, execution, or history semantics were changed

## Verification
- targeted frontend tests passed
- frontend build passed
- targeted frontend lint passed