### PR TITLE
feat: add maintenance approval decision mapping v1

### DIFF
--- a/rentchain-api/src/lib/analytics/__tests__/deriveAgentDecisions.test.ts
+++ b/rentchain-api/src/lib/analytics/__tests__/deriveAgentDecisions.test.ts
@@ -7,6 +7,7 @@ describe("deriveAgentDecisions", () => {
       filters: {
         propertyId: null,
       },
+      workOrders: [],
       deltas: {
         summary: {
           vacancyRate: { current: 0.25, prior: 0.1, absoluteDelta: 0.15, relativeDelta: 1.5, direction: "worse" },
@@ -183,6 +184,7 @@ describe("deriveAgentDecisions", () => {
       filters: {
         propertyId: "prop-1",
       },
+      workOrders: [],
       deltas: {
         summary: {
           vacancyRate: { current: 0, prior: 0, absoluteDelta: 0, relativeDelta: 0, direction: "flat" },
@@ -233,6 +235,7 @@ describe("deriveAgentDecisions", () => {
       filters: {
         propertyId: null,
       },
+      workOrders: [],
       deltas: {
         summary: {
           vacancyRate: { current: 0.2, prior: 0.05, absoluteDelta: 0.15, relativeDelta: 3, direction: "worse" },
@@ -468,5 +471,135 @@ describe("deriveAgentDecisions", () => {
         }),
       ])
     );
+  });
+
+  it("emits one exact maintenance approval decision only when one approval-ready work order is visible", () => {
+    const result = deriveAgentDecisions({
+      filters: {
+        propertyId: null,
+      },
+      workOrders: [
+        {
+          id: "wo-1",
+          propertyId: "prop-4",
+          propertyLabel: "Delta",
+          unitLabel: "Unit 2",
+          title: "Replace sink valve",
+          cost: {
+            actualCostCents: 32000,
+            currency: "CAD",
+            reviewStatus: "pending_review",
+            linkedExpenseStatus: "not_linked",
+          },
+          costAttachments: [{ id: "attachment-1" }],
+        },
+      ],
+      deltas: {
+        summary: {
+          vacancyRate: { current: 0, prior: 0, absoluteDelta: 0, relativeDelta: 0, direction: "flat" },
+          applicationConversionRate: { current: 0.5, prior: 0.5, absoluteDelta: 0, relativeDelta: 0, direction: "flat" },
+          activeApplications: { current: 2, prior: 2, absoluteDelta: 0, relativeDelta: 0, direction: "flat" },
+          openWorkOrders: { current: 1, prior: 1, absoluteDelta: 0, relativeDelta: 0, direction: "flat" },
+          maintenanceCostCents: { current: 32000, prior: 32000, absoluteDelta: 0, relativeDelta: 0, direction: "flat" },
+          estimatedScheduledRentCents: { current: 300000, prior: 300000, absoluteDelta: 0, relativeDelta: 0, direction: "flat" },
+          leasesEndingSoon: { current: 0, prior: 0, absoluteDelta: 0, relativeDelta: 0, direction: "flat" },
+        },
+        applications: {
+          submitted: { current: 2, prior: 2, absoluteDelta: 0, relativeDelta: 0, direction: "flat" },
+          conversionRate: { current: 0.5, prior: 0.5, absoluteDelta: 0, relativeDelta: 0, direction: "flat" },
+        },
+      },
+      alerts: [],
+      predictiveMetrics: [],
+      benchmarking: {
+        summary: {
+          propertyCount: 1,
+          comparedPropertyCount: 1,
+          benchmarkDimensions: ["openWorkOrders"],
+        },
+        comparisons: [],
+        insights: [],
+        filters: {
+          period: "90d",
+          propertyId: null,
+          from: "2026-01-20T00:00:00.000Z",
+          to: "2026-04-20T00:00:00.000Z",
+        },
+      },
+    });
+
+    expect(result.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "approve_maintenance_cost:wo-1",
+          decisionType: "approve_maintenance_cost",
+          priority: "medium",
+          recommendedAction: "Review work order approval",
+          actionKey: "open_maintenance_cost_approval_flow",
+          actionLabel: "Open cost approval",
+          destination: "/work-orders?entry=maintenance-cost-approval&propertyId=prop-4&workOrderId=wo-1",
+          workflowCategory: "maintenance_cost_approval",
+          automationEligible: false,
+          automationState: "manual_only",
+          executionMappingState: "none",
+        }),
+      ])
+    );
+  });
+
+  it("does not emit the maintenance approval decision when multiple approval-ready work orders are visible", () => {
+    const result = deriveAgentDecisions({
+      filters: {
+        propertyId: null,
+      },
+      workOrders: [
+        {
+          id: "wo-1",
+          propertyId: "prop-4",
+          cost: { actualCostCents: 32000, currency: "CAD", reviewStatus: "pending_review" },
+          costAttachments: [{ id: "attachment-1" }],
+        },
+        {
+          id: "wo-2",
+          propertyId: "prop-5",
+          cost: { actualCostCents: 41000, currency: "CAD", reviewStatus: "pending_review" },
+          evidence: [{ id: "evidence-1" }],
+        },
+      ],
+      deltas: {
+        summary: {
+          vacancyRate: { current: 0, prior: 0, absoluteDelta: 0, relativeDelta: 0, direction: "flat" },
+          applicationConversionRate: { current: 0.5, prior: 0.5, absoluteDelta: 0, relativeDelta: 0, direction: "flat" },
+          activeApplications: { current: 2, prior: 2, absoluteDelta: 0, relativeDelta: 0, direction: "flat" },
+          openWorkOrders: { current: 2, prior: 2, absoluteDelta: 0, relativeDelta: 0, direction: "flat" },
+          maintenanceCostCents: { current: 73000, prior: 73000, absoluteDelta: 0, relativeDelta: 0, direction: "flat" },
+          estimatedScheduledRentCents: { current: 300000, prior: 300000, absoluteDelta: 0, relativeDelta: 0, direction: "flat" },
+          leasesEndingSoon: { current: 0, prior: 0, absoluteDelta: 0, relativeDelta: 0, direction: "flat" },
+        },
+        applications: {
+          submitted: { current: 2, prior: 2, absoluteDelta: 0, relativeDelta: 0, direction: "flat" },
+          conversionRate: { current: 0.5, prior: 0.5, absoluteDelta: 0, relativeDelta: 0, direction: "flat" },
+        },
+      },
+      alerts: [],
+      predictiveMetrics: [],
+      benchmarking: {
+        summary: {
+          propertyCount: 2,
+          comparedPropertyCount: 2,
+          benchmarkDimensions: ["openWorkOrders"],
+        },
+        comparisons: [],
+        insights: [],
+        filters: {
+          period: "90d",
+          propertyId: null,
+          from: "2026-01-20T00:00:00.000Z",
+          to: "2026-04-20T00:00:00.000Z",
+        },
+      },
+    });
+
+    expect(result.items.find((decision) => decision.decisionType === "approve_maintenance_cost")).toBeUndefined();
   });
 });

--- a/rentchain-api/src/lib/analytics/__tests__/deriveDecisionAutomationRules.test.ts
+++ b/rentchain-api/src/lib/analytics/__tests__/deriveDecisionAutomationRules.test.ts
@@ -101,6 +101,28 @@ describe("deriveDecisionAutomationRule", () => {
     const result = applyDecisionAutomationRules([
       baseDecision(),
       baseDecision({
+        id: "approve_maintenance_cost:wo-1",
+        decisionType: "approve_maintenance_cost",
+        actionKey: "open_maintenance_cost_approval_flow",
+        actionLabel: "Open cost approval",
+        workflowCategory: "maintenance_cost_approval",
+        recommendedAction: "Review work order approval",
+        destination: "/work-orders?entry=maintenance-cost-approval&workOrderId=wo-1",
+        href: "/work-orders?entry=maintenance-cost-approval&workOrderId=wo-1",
+        automationEligible: true,
+        executionMappingState: "mapped",
+        executionInputState: "complete",
+        executionInput: {
+          actualCostCents: 32000,
+          currency: "CAD",
+          reviewStatus: "pending_review",
+          linkedExpenseStatus: "not_linked",
+          hasSupportingEvidence: true,
+          thresholdCents: 100000,
+          withinAutoApprovalThreshold: true,
+        } as any,
+      }),
+      baseDecision({
         id: "focus_highest_risk_property:prop-2",
         decisionType: "focus_highest_risk_property",
         actionKey: "open_property_focus_flow",
@@ -112,6 +134,6 @@ describe("deriveDecisionAutomationRule", () => {
       }),
     ]);
 
-    expect(result.map((decision) => decision.automationState)).toEqual(["blocked", "manual_only"]);
+    expect(result.map((decision) => decision.automationState)).toEqual(["blocked", "blocked", "manual_only"]);
   });
 });

--- a/rentchain-api/src/lib/analytics/__tests__/deriveDecisionExecutionMappings.test.ts
+++ b/rentchain-api/src/lib/analytics/__tests__/deriveDecisionExecutionMappings.test.ts
@@ -47,6 +47,7 @@ describe("applyDecisionExecutionMappings", () => {
           endDate: "2026-05-10T00:00:00.000Z",
         },
       ],
+      workOrders: [],
       now: Date.UTC(2026, 3, 20, 12, 0, 0, 0),
     });
 
@@ -105,6 +106,7 @@ describe("applyDecisionExecutionMappings", () => {
           endDate: "2026-05-15T00:00:00.000Z",
         },
       ],
+      workOrders: [],
       now: Date.UTC(2026, 3, 20, 12, 0, 0, 0),
     });
 
@@ -140,6 +142,7 @@ describe("applyDecisionExecutionMappings", () => {
           endDate: "2026-05-10T00:00:00.000Z",
         },
       ],
+      workOrders: [],
       now: Date.UTC(2026, 3, 20, 12, 0, 0, 0),
     });
 
@@ -170,6 +173,7 @@ describe("applyDecisionExecutionMappings", () => {
           status: "active",
         },
       ],
+      workOrders: [],
       now: Date.UTC(2026, 3, 20, 12, 0, 0, 0),
     });
 
@@ -214,6 +218,7 @@ describe("applyDecisionExecutionMappings", () => {
           status: "active",
         },
       ],
+      workOrders: [],
       now: Date.UTC(2026, 3, 20, 12, 0, 0, 0),
     });
 
@@ -234,6 +239,65 @@ describe("applyDecisionExecutionMappings", () => {
           newLeaseStartDate: "2026-05-11",
           newLeaseEndDate: "2027-05-10",
           responseDeadlineAt: Date.UTC(2026, 4, 1, 12, 0, 0, 0),
+        }),
+      })
+    );
+  });
+
+  it("maps a deterministic maintenance approval decision to one exact work order", () => {
+    const result = applyDecisionExecutionMappings({
+      decisions: [
+        baseDecision({
+          id: "approve_maintenance_cost:wo-1",
+          decisionType: "approve_maintenance_cost",
+          actionKey: "open_maintenance_cost_approval_flow",
+          actionLabel: "Open cost approval",
+          destination: "/work-orders?entry=maintenance-cost-approval&propertyId=prop-2&workOrderId=wo-1",
+          href: "/work-orders?entry=maintenance-cost-approval&propertyId=prop-2&workOrderId=wo-1",
+          workflowCategory: "maintenance_cost_approval",
+          recommendedAction: "Review work order approval",
+          automationState: "blocked",
+          automationReason: "A deterministic maintenance approval target exists, but explicit maintenance execution is not enabled yet.",
+        }),
+      ],
+      leases: [],
+      workOrders: [
+        {
+          id: "wo-1",
+          propertyId: "prop-2",
+          cost: {
+            actualCostCents: 32000,
+            currency: "CAD",
+            reviewStatus: "pending_review",
+            linkedExpenseStatus: "not_linked",
+          },
+          costAttachments: [{ id: "attachment-1" }],
+        },
+      ],
+      now: Date.UTC(2026, 3, 20, 12, 0, 0, 0),
+    });
+
+    expect(result[0]).toEqual(
+      expect.objectContaining({
+        automationEligible: true,
+        executionMappingState: "mapped",
+        executionMapping: {
+          action: "maintenance.auto_approve_cost",
+          resourceType: "work_order",
+          resourceId: "wo-1",
+          prerequisitesMet: true,
+          prerequisiteReason: null,
+        },
+        executionInputState: "complete",
+        executionInputReason: null,
+        executionInputMissingFields: [],
+        executionInput: expect.objectContaining({
+          actualCostCents: 32000,
+          currency: "CAD",
+          reviewStatus: "pending_review",
+          hasSupportingEvidence: true,
+          thresholdCents: 100000,
+          withinAutoApprovalThreshold: true,
         }),
       })
     );

--- a/rentchain-api/src/lib/analytics/analyticsTypes.ts
+++ b/rentchain-api/src/lib/analytics/analyticsTypes.ts
@@ -1,6 +1,10 @@
 import type { AutomationAction } from "../automation/automationTypes";
 import type { LeaseNoticeType, LeaseType, RentChangeMode } from "../../config/leaseNoticeRules";
 import type { LeaseNoticeExecutionInputMissingField } from "../../services/leaseNoticeWorkflowService";
+import type {
+  MaintenanceApprovalExecutionInput,
+  MaintenanceApprovalExecutionInputMissingField,
+} from "../maintenanceApprovalReadiness";
 import type { ScreeningReconciliationStatus } from "../reconciliation/reconciliationTypes";
 
 export type AdminAnalyticsPeriod = "30d" | "90d" | "365d" | "month_to_date";
@@ -245,6 +249,7 @@ export type LandlordPredictiveMetrics = {
 
 export type LandlordAgentDecisionType =
   | "review_lease_renewals"
+  | "approve_maintenance_cost"
   | "reduce_vacancy_risk"
   | "improve_application_conversion"
   | "address_maintenance_backlog"
@@ -266,6 +271,7 @@ export type LandlordAgentDecisionSupportingSignal = {
 
 export type LandlordDecisionWorkflowCategory =
   | "lease_renewals"
+  | "maintenance_cost_approval"
   | "vacancy_readiness"
   | "application_funnel"
   | "maintenance_backlog"
@@ -274,6 +280,7 @@ export type LandlordDecisionWorkflowCategory =
 
 export type LandlordDecisionActionKey =
   | "open_lease_renewals_flow"
+  | "open_maintenance_cost_approval_flow"
   | "open_vacancy_readiness_flow"
   | "open_application_funnel_review_flow"
   | "open_maintenance_backlog_flow"
@@ -310,6 +317,14 @@ export type LandlordDecisionLeaseNoticeExecutionInput = {
   responseDeadlineAt: number | null;
 };
 
+export type LandlordDecisionExecutionInput =
+  | LandlordDecisionLeaseNoticeExecutionInput
+  | MaintenanceApprovalExecutionInput;
+
+export type LandlordDecisionExecutionInputMissingField =
+  | LeaseNoticeExecutionInputMissingField
+  | MaintenanceApprovalExecutionInputMissingField;
+
 export type LandlordAgentDecision = {
   id: string;
   decisionType: LandlordAgentDecisionType;
@@ -331,8 +346,8 @@ export type LandlordAgentDecision = {
   executionMapping: LandlordDecisionExecutionMapping | null;
   executionInputState: LandlordDecisionExecutionInputState;
   executionInputReason: string | null;
-  executionInputMissingFields: LeaseNoticeExecutionInputMissingField[];
-  executionInput: LandlordDecisionLeaseNoticeExecutionInput | null;
+  executionInputMissingFields: LandlordDecisionExecutionInputMissingField[];
+  executionInput: LandlordDecisionExecutionInput | null;
   executedAt?: string | null;
   executionOutcomeStatus: LandlordDecisionExecutionOutcomeStatus;
   executionOutcomeAt: string | null;

--- a/rentchain-api/src/lib/analytics/deriveAgentDecisions.ts
+++ b/rentchain-api/src/lib/analytics/deriveAgentDecisions.ts
@@ -12,6 +12,7 @@ import type {
   LandlordPredictiveMetric,
 } from "./analyticsTypes";
 import type { AnalyticsAlert } from "./alertTypes";
+import { deriveMaintenanceApprovalExecutionInputSnapshot } from "../maintenanceApprovalReadiness";
 
 type AgentDecisionInput = {
   filters: {
@@ -35,6 +36,7 @@ type AgentDecisionInput = {
   alerts: AnalyticsAlert[];
   predictiveMetrics: LandlordPredictiveMetric[];
   benchmarking: LandlordPortfolioBenchmarking;
+  workOrders: any[];
 };
 
 const PRIORITY_WEIGHT: Record<LandlordAgentDecisionPriority, number> = {
@@ -46,10 +48,11 @@ const PRIORITY_WEIGHT: Record<LandlordAgentDecisionPriority, number> = {
 const DECISION_ORDER: Record<LandlordAgentDecisionType, number> = {
   reduce_vacancy_risk: 0,
   review_lease_renewals: 1,
-  address_maintenance_backlog: 2,
-  improve_application_conversion: 3,
-  review_revenue_pressure: 4,
-  focus_highest_risk_property: 5,
+  approve_maintenance_cost: 2,
+  address_maintenance_backlog: 3,
+  improve_application_conversion: 4,
+  review_revenue_pressure: 5,
+  focus_highest_risk_property: 6,
 };
 
 function getPredictiveMetric(metrics: LandlordPredictiveMetric[], key: LandlordPredictiveMetric["key"]) {
@@ -139,7 +142,8 @@ function buildDestination(pathname: string, params: Record<string, string | null
 
 function deriveActionHook(
   type: LandlordAgentDecisionType,
-  propertyId?: string | null
+  propertyId?: string | null,
+  resourceId?: string | null
 ): {
   actionKey: LandlordDecisionActionKey;
   actionLabel: string;
@@ -156,6 +160,20 @@ function deriveActionHook(
         propertyId: propertyId || null,
       }),
       workflowCategory: "lease_renewals",
+      automationEligible: false,
+    };
+  }
+
+  if (type === "approve_maintenance_cost") {
+    return {
+      actionKey: "open_maintenance_cost_approval_flow",
+      actionLabel: "Open cost approval",
+      destination: buildDestination("/work-orders", {
+        entry: "maintenance-cost-approval",
+        propertyId: propertyId || null,
+        workOrderId: resourceId || null,
+      }),
+      workflowCategory: "maintenance_cost_approval",
       automationEligible: false,
     };
   }
@@ -225,8 +243,8 @@ function deriveActionHook(
   };
 }
 
-function decisionId(decisionType: LandlordAgentDecisionType, propertyId?: string | null) {
-  return propertyId ? `${decisionType}:${propertyId}` : decisionType;
+function decisionId(decisionType: LandlordAgentDecisionType, scopeId?: string | null) {
+  return scopeId ? `${decisionType}:${scopeId}` : decisionType;
 }
 
 function dedupeSignals(signals: Array<LandlordAgentDecisionSupportingSignal | null | undefined>) {
@@ -254,14 +272,16 @@ function buildDecision(params: {
   explanation: string;
   recommendedAction: string;
   propertyId?: string | null;
+  scopeId?: string | null;
   signals: Array<LandlordAgentDecisionSupportingSignal | null | undefined>;
 }) {
   if (!params.priority) return null;
   const supportingSignals = dedupeSignals(params.signals);
   if (params.priority === "low" && supportingSignals.length < 2) return null;
-  const hook = deriveActionHook(params.decisionType, params.propertyId || null);
+  const scopeId = params.scopeId ?? params.propertyId ?? null;
+  const hook = deriveActionHook(params.decisionType, params.propertyId || null, scopeId);
   return {
-    id: decisionId(params.decisionType, params.propertyId || null),
+    id: decisionId(params.decisionType, scopeId),
     decisionType: params.decisionType,
     priority: params.priority,
     explanation: params.explanation,
@@ -288,6 +308,42 @@ function buildDecision(params: {
     executionOutcomeAt: null,
     executionOutcomeReason: null,
   } satisfies LandlordAgentDecision;
+}
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function normalizeMaintenanceDecisionWorkOrder(workOrder: any) {
+  return {
+    id: asString(workOrder?.id, 240),
+    propertyId: asString(workOrder?.propertyId, 240) || null,
+    propertyLabel: asString(workOrder?.propertyLabel || workOrder?.propertyName, 240) || null,
+    unitLabel: asString(workOrder?.unitLabel || workOrder?.unitNumber || workOrder?.unitId, 120) || null,
+    summary:
+      asString(
+        workOrder?.title ||
+          workOrder?.summary ||
+          workOrder?.issue ||
+          workOrder?.issueTitle ||
+          workOrder?.description,
+        240
+      ) || null,
+  };
+}
+
+function formatCurrency(cents: number | null, currency: string | null) {
+  if (typeof cents !== "number" || !Number.isFinite(cents) || cents <= 0) return null;
+  const safeCurrency = asString(currency || "CAD", 8).toUpperCase() || "CAD";
+  try {
+    return new Intl.NumberFormat("en-CA", {
+      style: "currency",
+      currency: safeCurrency,
+      maximumFractionDigits: 2,
+    }).format(cents / 100);
+  } catch {
+    return `${(cents / 100).toFixed(2)} ${safeCurrency}`;
+  }
 }
 
 function deriveLeaseRenewalDecision(input: AgentDecisionInput) {
@@ -425,6 +481,57 @@ function deriveMaintenanceDecision(input: AgentDecisionInput) {
   });
 }
 
+function deriveMaintenanceApprovalDecision(input: AgentDecisionInput) {
+  const candidates = (input.workOrders || [])
+    .map((workOrder) => ({
+      workOrder,
+      readiness: deriveMaintenanceApprovalExecutionInputSnapshot(workOrder),
+    }))
+    .filter(({ workOrder, readiness }) => asString(workOrder?.id, 240) && readiness.state === "complete");
+
+  if (candidates.length !== 1) return null;
+
+  const { workOrder, readiness } = candidates[0];
+  const normalized = normalizeMaintenanceDecisionWorkOrder(workOrder);
+  if (!normalized.id) return null;
+
+  const alerts = input.alerts.filter(
+    (alert) =>
+      alert.status === "active" &&
+      normalized.propertyId != null &&
+      alert.propertyId === normalized.propertyId &&
+      (alert.type === "work_order_concentration" || alert.type === "maintenance_cost_spike")
+  );
+  const benchmark =
+    normalized.propertyId != null
+      ? getBenchmarkInsight(
+          input.benchmarking.insights.filter((insight) => insight.propertyId === normalized.propertyId),
+          "maintenance_concentration"
+        )
+      : null;
+
+  const priority = derivePriority([priorityFromAlert(alerts), benchmark?.severity]) || "medium";
+  const costLabel = formatCurrency(readiness.input.actualCostCents, readiness.input.currency);
+  const locationLabel = [normalized.propertyLabel, normalized.unitLabel].filter(Boolean).join(" • ");
+  const subject =
+    normalized.summary || (locationLabel ? `work order for ${locationLabel}` : `work order ${normalized.id}`);
+
+  return buildDecision({
+    decisionType: "approve_maintenance_cost",
+    priority,
+    explanation: costLabel
+      ? `${subject} has a submitted cost of ${costLabel} with supporting evidence and is within the maintenance auto-approval threshold.`
+      : `${subject} has a submitted maintenance cost with supporting evidence and is within the maintenance auto-approval threshold.`,
+    recommendedAction: "Review work order approval",
+    propertyId: normalized.propertyId,
+    scopeId: normalized.id,
+    signals: [
+      ...alerts.map(supportFromAlert),
+      benchmark ? supportFromBenchmark(benchmark) : null,
+    ],
+  });
+}
+
 function deriveRevenueDecision(input: AgentDecisionInput) {
   const predictive = getPredictiveMetric(input.predictiveMetrics, "projected_revenue_pressure_signal");
   const priority = priorityFromPredictive(predictive);
@@ -503,6 +610,7 @@ export function deriveAgentDecisions(input: AgentDecisionInput): LandlordAgentDe
   const decisions = [
     deriveVacancyDecision(input),
     deriveLeaseRenewalDecision(input),
+    deriveMaintenanceApprovalDecision(input),
     deriveMaintenanceDecision(input),
     deriveApplicationDecision(input),
     deriveRevenueDecision(input),

--- a/rentchain-api/src/lib/analytics/deriveDecisionAutomationRules.ts
+++ b/rentchain-api/src/lib/analytics/deriveDecisionAutomationRules.ts
@@ -15,6 +15,8 @@ const WORKFLOW_BLOCK_REASONS: Partial<Record<LandlordDecisionWorkflowCategory, s
     "A lease automation path exists, but this decision still needs a specific lease target and notice inputs before execution.",
   application_funnel:
     "A screening automation path exists, but this decision does not yet identify a specific application to execute against.",
+  maintenance_cost_approval:
+    "A deterministic maintenance approval target exists, but explicit maintenance execution is not enabled yet.",
   maintenance_backlog:
     "A maintenance automation path exists, but this decision does not yet identify a specific work order with execution-ready evidence.",
 };
@@ -36,6 +38,12 @@ export function deriveDecisionAutomationRule(decision: LandlordAgentDecision): A
   }
   if (decision.state === "reviewed") {
     return lifecycleBlockedRule("Reviewed decisions stay manual until a new active decision is surfaced.");
+  }
+
+  if (decision.decisionType === "approve_maintenance_cost") {
+    return lifecycleBlockedRule(
+      "A deterministic maintenance approval target exists, but explicit maintenance execution is not enabled yet."
+    );
   }
 
   if (decision.automationEligible) {

--- a/rentchain-api/src/lib/analytics/deriveDecisionExecutionMappings.ts
+++ b/rentchain-api/src/lib/analytics/deriveDecisionExecutionMappings.ts
@@ -1,9 +1,11 @@
 import type { LandlordAgentDecision, LandlordDecisionExecutionMapping } from "./analyticsTypes";
 import { deriveLeaseNoticeExecutionInputSnapshot, normalizeLeaseRecord } from "../../services/leaseNoticeWorkflowService";
+import { deriveMaintenanceApprovalExecutionInputSnapshot } from "../maintenanceApprovalReadiness";
 
 type MappingInput = {
   decisions: LandlordAgentDecision[];
   leases: any[];
+  workOrders: any[];
   now: number;
 };
 
@@ -42,6 +44,11 @@ function leaseEndsWithin30Days(lease: any, now: number) {
 }
 
 function decisionPropertyId(decision: LandlordAgentDecision) {
+  const prefix = `${decision.decisionType}:`;
+  return decision.id.startsWith(prefix) ? decision.id.slice(prefix.length) || null : null;
+}
+
+function decisionScopedResourceId(decision: LandlordAgentDecision) {
   const prefix = `${decision.decisionType}:`;
   return decision.id.startsWith(prefix) ? decision.id.slice(prefix.length) || null : null;
 }
@@ -100,10 +107,45 @@ function mapLeaseRenewalDecision(decision: LandlordAgentDecision, input: Mapping
   };
 }
 
+function mapMaintenanceApprovalDecision(decision: LandlordAgentDecision, input: MappingInput): LandlordAgentDecision {
+  const workOrderId = decisionScopedResourceId(decision);
+  if (!workOrderId) {
+    return baseDecision(decision, null);
+  }
+
+  const workOrder = (input.workOrders || []).find((entry) => asString(entry?.id, 240) === workOrderId);
+  if (!workOrder) {
+    return baseDecision(decision, null);
+  }
+
+  const executionInput = deriveMaintenanceApprovalExecutionInputSnapshot(workOrder);
+  const mapping: LandlordDecisionExecutionMapping = {
+    action: "maintenance.auto_approve_cost",
+    resourceType: "work_order",
+    resourceId: workOrderId,
+    prerequisitesMet: executionInput.state === "complete",
+    prerequisiteReason: executionInput.reason,
+  };
+
+  return {
+    ...decision,
+    automationEligible: executionInput.state === "complete",
+    executionMappingState: "mapped",
+    executionMapping: mapping,
+    executionInputState: executionInput.state,
+    executionInputReason: executionInput.reason,
+    executionInputMissingFields: executionInput.missingFields,
+    executionInput: executionInput.input,
+  };
+}
+
 export function applyDecisionExecutionMappings(input: MappingInput): LandlordAgentDecision[] {
   return input.decisions.map((decision) => {
     if (decision.decisionType === "review_lease_renewals") {
       return mapLeaseRenewalDecision(decision, input);
+    }
+    if (decision.decisionType === "approve_maintenance_cost") {
+      return mapMaintenanceApprovalDecision(decision, input);
     }
 
     return baseDecision(decision, null);

--- a/rentchain-api/src/lib/analytics/deriveLandlordAnalyticsSnapshot.ts
+++ b/rentchain-api/src/lib/analytics/deriveLandlordAnalyticsSnapshot.ts
@@ -737,6 +737,7 @@ export function deriveLandlordAnalyticsSnapshot(input: AdminAnalyticsDerivedInpu
     alerts: alerts.alerts,
     predictiveMetrics: snapshotBase.predictive.metrics,
     benchmarking,
+    workOrders: input.workOrders,
   });
 
   return {

--- a/rentchain-api/src/lib/maintenanceApprovalReadiness.ts
+++ b/rentchain-api/src/lib/maintenanceApprovalReadiness.ts
@@ -1,0 +1,107 @@
+import {
+  normalizeCostCurrency,
+  normalizeCostLinkStatus,
+  normalizeCostReviewStatus,
+  normalizeWorkOrderCost,
+  type WorkOrderCostLinkStatus,
+  type WorkOrderCostReviewStatus,
+} from "./maintenanceCost";
+import { MAINTENANCE_AUTO_APPROVAL_THRESHOLD_CENTS } from "./policy/policyRules";
+
+export type MaintenanceApprovalExecutionInputMissingField =
+  | "actualCostCents"
+  | "reviewStatus"
+  | "supportingEvidence"
+  | "autoApprovalThreshold";
+
+export type MaintenanceApprovalExecutionInput = {
+  actualCostCents: number | null;
+  currency: string | null;
+  reviewStatus: WorkOrderCostReviewStatus | null;
+  linkedExpenseStatus: WorkOrderCostLinkStatus | null;
+  hasSupportingEvidence: boolean;
+  thresholdCents: number;
+  withinAutoApprovalThreshold: boolean;
+};
+
+export type MaintenanceApprovalExecutionInputSnapshot = {
+  state: "none" | "partial" | "complete";
+  reason: string | null;
+  missingFields: MaintenanceApprovalExecutionInputMissingField[];
+  input: MaintenanceApprovalExecutionInput;
+};
+
+export function hasSupportingEvidenceForWorkOrder(workOrder: any) {
+  const evidence = Array.isArray(workOrder?.evidence) ? workOrder.evidence : [];
+  const costAttachments = Array.isArray(workOrder?.costAttachments) ? workOrder.costAttachments : [];
+  return evidence.length > 0 || costAttachments.length > 0;
+}
+
+export function deriveMaintenanceApprovalExecutionInputSnapshot(
+  workOrder: any
+): MaintenanceApprovalExecutionInputSnapshot {
+  const cost = normalizeWorkOrderCost(workOrder?.cost);
+  const actualCostCents = typeof cost?.actualCostCents === "number" ? cost.actualCostCents : null;
+  const reviewStatus = normalizeCostReviewStatus(cost?.reviewStatus);
+  const hasSupportingEvidence = hasSupportingEvidenceForWorkOrder(workOrder);
+  const withinAutoApprovalThreshold =
+    typeof actualCostCents === "number" && actualCostCents > 0
+      ? actualCostCents <= MAINTENANCE_AUTO_APPROVAL_THRESHOLD_CENTS
+      : false;
+
+  const input: MaintenanceApprovalExecutionInput = {
+    actualCostCents,
+    currency: normalizeCostCurrency(cost?.currency),
+    reviewStatus,
+    linkedExpenseStatus: normalizeCostLinkStatus(cost?.linkedExpenseStatus),
+    hasSupportingEvidence,
+    thresholdCents: MAINTENANCE_AUTO_APPROVAL_THRESHOLD_CENTS,
+    withinAutoApprovalThreshold,
+  };
+
+  const missingFields: MaintenanceApprovalExecutionInputMissingField[] = [];
+  if (typeof actualCostCents !== "number" || actualCostCents <= 0) {
+    missingFields.push("actualCostCents");
+  }
+  if (reviewStatus !== "pending_review") {
+    missingFields.push("reviewStatus");
+  }
+  if (!hasSupportingEvidence) {
+    missingFields.push("supportingEvidence");
+  }
+  if (!withinAutoApprovalThreshold) {
+    missingFields.push("autoApprovalThreshold");
+  }
+
+  if (!missingFields.length) {
+    return {
+      state: "complete",
+      reason: null,
+      missingFields,
+      input,
+    };
+  }
+
+  const state =
+    actualCostCents != null || reviewStatus != null || hasSupportingEvidence || input.linkedExpenseStatus != null
+      ? "partial"
+      : "none";
+
+  let reason = "This work order is not yet approval-ready for deterministic maintenance execution.";
+  if (missingFields.length === 1 && missingFields[0] === "actualCostCents") {
+    reason = "This work order still needs a submitted actual cost before it can become approval-ready.";
+  } else if (missingFields.length === 1 && missingFields[0] === "reviewStatus") {
+    reason = "This work order must still be in pending review before it can become approval-ready.";
+  } else if (missingFields.length === 1 && missingFields[0] === "supportingEvidence") {
+    reason = "This work order still needs supporting evidence or cost attachments before it can become approval-ready.";
+  } else if (missingFields.length === 1 && missingFields[0] === "autoApprovalThreshold") {
+    reason = "This work order exceeds the maintenance auto-approval threshold and is not execution-ready.";
+  }
+
+  return {
+    state,
+    reason,
+    missingFields,
+    input,
+  };
+}

--- a/rentchain-api/src/routes/workOrdersRoutes.ts
+++ b/rentchain-api/src/routes/workOrdersRoutes.ts
@@ -31,6 +31,7 @@ import {
 import { createTransaction } from "../services/financialTransactionService";
 import { writeCanonicalEvent } from "../lib/events/buildEvent";
 import { executeAutomation } from "../lib/automation/automationExecutor";
+import { hasSupportingEvidenceForWorkOrder } from "../lib/maintenanceApprovalReadiness";
 import { buildMaintenancePolicyRequest } from "../lib/policy/policyAdapters";
 import { evaluatePolicy, toAutopilotPolicySummary, writePolicyEvaluatedEvent } from "../lib/policy/policyEvaluator";
 import { MAINTENANCE_AUTO_APPROVAL_THRESHOLD_CENTS } from "../lib/policy/policyRules";
@@ -97,12 +98,6 @@ function asOptionalString(value: unknown, max = 2000): string | null {
 
 function isAutomationRequested(body: any) {
   return Boolean(body?.automationEnabled || body?.automation?.enabled);
-}
-
-function hasSupportingEvidenceForWorkOrder(workOrder: any) {
-  const evidence = Array.isArray(workOrder?.evidence) ? workOrder.evidence : [];
-  const costAttachments = Array.isArray(workOrder?.costAttachments) ? workOrder.costAttachments : [];
-  return evidence.length > 0 || costAttachments.length > 0;
 }
 
 function uniqueStrings(input: unknown, max = 100): string[] {

--- a/rentchain-api/src/services/landlord/__tests__/landlordAnalyticsSnapshot.test.ts
+++ b/rentchain-api/src/services/landlord/__tests__/landlordAnalyticsSnapshot.test.ts
@@ -312,6 +312,85 @@ describe("loadLandlordAnalyticsSnapshot", () => {
     );
   });
 
+  it("derives one exact maintenance approval decision when one approval-ready work order is visible", async () => {
+    const nowIso = "2026-04-20T12:00:00.000Z";
+    seedDoc("properties", "prop-2", {
+      landlordId: "landlord-1",
+      name: "Beta",
+      createdAt: nowIso,
+      updatedAt: nowIso,
+    });
+    seedDoc("workOrders", "wo-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-2",
+      propertyLabel: "Beta",
+      unitLabel: "Unit 2",
+      title: "Replace sink valve",
+      status: "completed",
+      cost: {
+        actualCostCents: 32000,
+        currency: "CAD",
+        submittedByRole: "contractor",
+        submittedById: "contractor-1",
+        submittedAt: Date.UTC(2026, 3, 19, 12, 0, 0, 0),
+        reviewStatus: "pending_review",
+        linkedExpenseStatus: "not_linked",
+        latestRevisionNumber: 1,
+      },
+      costAttachments: [
+        {
+          id: "attachment-1",
+          uploadedAt: Date.UTC(2026, 3, 19, 12, 0, 0, 0),
+          uploadedByRole: "contractor",
+          uploadedById: "contractor-1",
+          visibility: "landlord_only",
+          fileName: "invoice.pdf",
+        },
+      ],
+      createdAt: nowIso,
+      updatedAt: nowIso,
+    });
+
+    const { loadLandlordAnalyticsSnapshot } = await import("../landlordAnalyticsSnapshot");
+    const result = await loadLandlordAnalyticsSnapshot({
+      landlordId: "landlord-1",
+      propertyId: "prop-2",
+      now: Date.UTC(2026, 3, 20, 12, 0, 0, 0),
+    });
+
+    expect(result.decisions.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "approve_maintenance_cost:wo-1",
+          decisionType: "approve_maintenance_cost",
+          actionKey: "open_maintenance_cost_approval_flow",
+          actionLabel: "Open cost approval",
+          destination: "/work-orders?entry=maintenance-cost-approval&propertyId=prop-2&workOrderId=wo-1",
+          workflowCategory: "maintenance_cost_approval",
+          recommendedAction: "Review work order approval",
+          automationEligible: false,
+          automationState: "blocked",
+          automationReason: expect.stringContaining("explicit maintenance execution is not enabled yet"),
+          executionMappingState: "mapped",
+          executionMapping: expect.objectContaining({
+            action: "maintenance.auto_approve_cost",
+            resourceType: "work_order",
+            resourceId: "wo-1",
+            prerequisitesMet: true,
+          }),
+          executionInputState: "complete",
+          executionInputMissingFields: [],
+          executionInput: expect.objectContaining({
+            actualCostCents: 32000,
+            reviewStatus: "pending_review",
+            hasSupportingEvidence: true,
+            withinAutoApprovalThreshold: true,
+          }),
+        }),
+      ])
+    );
+  });
+
   it("emits a first-seen decision.appeared event once across repeated snapshot loads", async () => {
     const now = Date.UTC(2026, 3, 20, 12, 0, 0, 0);
 

--- a/rentchain-api/src/services/landlord/landlordAnalyticsSnapshot.ts
+++ b/rentchain-api/src/services/landlord/landlordAnalyticsSnapshot.ts
@@ -265,6 +265,7 @@ export async function loadLandlordAnalyticsSnapshot(params: LandlordAnalyticsPar
     applyDecisionExecutionMappings({
       decisions: mergeLandlordDecisionStates(snapshot.decisions.items, decisionStates),
       leases: derivedInput.leases,
+      workOrders: derivedInput.workOrders,
       now,
     })
   );

--- a/rentchain-frontend/src/api/landlordAnalyticsApi.ts
+++ b/rentchain-frontend/src/api/landlordAnalyticsApi.ts
@@ -30,6 +30,7 @@ export type LandlordAgentDecisionSupportingSignal = {
 
 export type LandlordDecisionWorkflowCategory =
   | "lease_renewals"
+  | "maintenance_cost_approval"
   | "vacancy_readiness"
   | "application_funnel"
   | "maintenance_backlog"
@@ -38,6 +39,7 @@ export type LandlordDecisionWorkflowCategory =
 
 export type LandlordDecisionActionKey =
   | "open_lease_renewals_flow"
+  | "open_maintenance_cost_approval_flow"
   | "open_vacancy_readiness_flow"
   | "open_application_funnel_review_flow"
   | "open_maintenance_backlog_flow"
@@ -68,6 +70,16 @@ export type LandlordDecisionLeaseNoticeExecutionInput = {
   responseDeadlineAt: number | null;
 };
 
+export type LandlordDecisionMaintenanceApprovalExecutionInput = {
+  actualCostCents: number | null;
+  currency: string | null;
+  reviewStatus: "pending_review" | "approved" | "rejected" | "revision_requested" | null;
+  linkedExpenseStatus: "not_linked" | "linked" | null;
+  hasSupportingEvidence: boolean;
+  thresholdCents: number;
+  withinAutoApprovalThreshold: boolean;
+};
+
 export type LandlordAgentDecision = {
   id: string;
   decisionType: string;
@@ -96,8 +108,12 @@ export type LandlordAgentDecision = {
     | "newLeaseStartDate"
     | "newLeaseEndDate"
     | "responseDeadlineAt"
+    | "actualCostCents"
+    | "reviewStatus"
+    | "supportingEvidence"
+    | "autoApprovalThreshold"
   )[];
-  executionInput: LandlordDecisionLeaseNoticeExecutionInput | null;
+  executionInput: (LandlordDecisionLeaseNoticeExecutionInput | LandlordDecisionMaintenanceApprovalExecutionInput) | null;
   executedAt?: string | null;
   executionOutcomeStatus: "none" | "succeeded" | "failed";
   executionOutcomeAt: string | null;

--- a/rentchain-frontend/src/components/analytics/AgentDecisionPanel.tsx
+++ b/rentchain-frontend/src/components/analytics/AgentDecisionPanel.tsx
@@ -21,6 +21,7 @@ const priorityTone: Record<"low" | "medium" | "high", { bg: string; text: string
 
 const workflowCategoryLabel: Record<NonNullable<LandlordAgentDecision["workflowCategory"]>, string> = {
   lease_renewals: "Lease renewals",
+  maintenance_cost_approval: "Maintenance cost approval",
   vacancy_readiness: "Vacancy readiness",
   application_funnel: "Application funnel",
   maintenance_backlog: "Maintenance backlog",


### PR DESCRIPTION
## Summary
- add a new `approve_maintenance_cost` landlord decision family that is distinct from maintenance backlog guidance
- emit that decision only when exactly one approval-ready work order exists canonically in scope
- add canonical maintenance mapping and readiness/input-completeness metadata without enabling execution yet

## Details
- preserve `address_maintenance_backlog` as guidance-only backlog/property context
- reuse canonical maintenance approval readiness and policy-threshold semantics to derive deterministic mapping for one exact work order
- keep maintenance execution intentionally blocked in this mission; explicit maintenance execution remains the next step
- preserve existing lease-renewal execution behavior, lifecycle/history/analytics layers, and shared landlord UI semantics

## Verification
- backend targeted tests passed
- frontend landlord targeted tests passed
- backend build passed
- frontend build passed
- targeted frontend lint passed