### PR TITLE
fix: repair property units import and lease visibility flows

### DIFF
--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -1,0 +1,174 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getSignedDownloadUrlMock = vi.fn(async () => "https://signed.example.com/lease.pdf");
+
+const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+  let idSeq = 0;
+
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+
+  function matches(doc: any, filters: Array<{ field: string; op: string; value: any }>) {
+    return filters.every(({ field, op, value }) => {
+      const actual = doc?.data?.[field];
+      if (op === "==") return actual === value;
+      if (op === "array-contains") return Array.isArray(actual) && actual.includes(value);
+      return false;
+    });
+  }
+
+  function makeQuery(name: string, filters: Array<{ field: string; op: string; value: any }> = []) {
+    return {
+      where: (field: string, op: string, value: any) => makeQuery(name, [...filters, { field, op, value }]),
+      orderBy: () => makeQuery(name, filters),
+      limit: () => makeQuery(name, filters),
+      get: async () => {
+        const col = ensureCollection(name);
+        const docs = Array.from(col.values())
+          .filter((doc) => matches(doc, filters))
+          .map((doc) => ({ id: doc.id, exists: true, data: () => doc.data }));
+        return { docs, empty: docs.length === 0, forEach: (fn: any) => docs.forEach(fn), size: docs.length };
+      },
+      doc: (id?: string) => makeDoc(name, id),
+    };
+  }
+
+  function makeDoc(name: string, id?: string) {
+    const actualId = id || `doc_${++idSeq}`;
+    const col = ensureCollection(name);
+    return {
+      id: actualId,
+      set: async (value: any, options?: { merge?: boolean }) => {
+        const current = col.get(actualId)?.data || {};
+        col.set(actualId, { id: actualId, data: options?.merge ? { ...current, ...value } : value });
+      },
+      get: async () => {
+        const entry = col.get(actualId);
+        return { id: actualId, exists: Boolean(entry), data: () => entry?.data };
+      },
+    };
+  }
+
+  return {
+    resetFakeDb: () => {
+      store.clear();
+      idSeq = 0;
+    },
+    seedDoc: (name: string, id: string, data: any) => ensureCollection(name).set(id, { id, data }),
+    fakeDb: {
+      collection: (name: string) => ({
+        where: (field: string, op: string, value: any) => makeQuery(name, [{ field, op, value }]),
+        orderBy: () => makeQuery(name),
+        limit: () => makeQuery(name),
+        get: async () => makeQuery(name).get(),
+        doc: (id?: string) => makeDoc(name, id),
+      }),
+    },
+  };
+});
+
+vi.mock("../../config/firebase", () => ({
+  db: fakeDb,
+  FieldValue: { serverTimestamp: () => "SERVER_TIMESTAMP" },
+}));
+
+vi.mock("../../services/capabilityGuard", () => ({
+  requireCapability: vi.fn(async () => ({ ok: true })),
+}));
+
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: any, _res: any, next: any) => {
+    req.user = { id: "landlord-1", landlordId: "landlord-1", role: "landlord" };
+    next();
+  },
+}));
+
+vi.mock("../../services/leaseDraftsService", () => ({
+  NS_PROVINCE: "NS",
+  NS_TEMPLATE_VERSION: "ns-schedule-a-v1",
+  applyPatch: vi.fn((existing: any) => existing),
+  validateCreateInput: vi.fn(),
+  getDraftById: vi.fn(),
+  getSnapshotById: vi.fn(),
+  generateScheduleA: vi.fn(),
+}));
+
+vi.mock("../../lib/gcsSignedUrl", () => ({
+  getSignedDownloadUrl: getSignedDownloadUrlMock,
+}));
+
+describe("leaseRoutes GET /active", () => {
+  beforeEach(() => {
+    resetFakeDb();
+    getSignedDownloadUrlMock.mockClear();
+  });
+
+  async function makeApp() {
+    const router = (await import("../leaseRoutes")).default;
+    const app = express();
+    app.use(express.json());
+    app.use((req: any, _res, next) => {
+      req.user = { id: "landlord-1", landlordId: "landlord-1", role: "landlord" };
+      next();
+    });
+    app.use(router);
+    return app;
+  }
+
+  it("returns landlord-scoped active leases with tenant and document details", async () => {
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Harbour View" });
+    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", fullName: "Jane Tenant", email: "jane@example.com" });
+    seedDoc("leaseDrafts", "draft-1", { landlordId: "landlord-1", lastGeneratedSnapshotId: "snapshot-1" });
+    seedDoc("leaseSnapshots", "snapshot-1", {
+      landlordId: "landlord-1",
+      generatedFiles: [{ url: "https://files.example.com/lease.pdf" }],
+    });
+    seedDoc("leases", "lease-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      tenantIds: ["tenant-1"],
+      primaryTenantId: "tenant-1",
+      unitId: "unit-1",
+      unitNumber: "101",
+      monthlyRent: 1850,
+      startDate: "2026-01-01",
+      endDate: "2026-12-31",
+      status: "active",
+      sourceDraftId: "draft-1",
+      createdAt: 1,
+      updatedAt: 2,
+    });
+    seedDoc("leases", "lease-2", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-2",
+      unitNumber: "102",
+      monthlyRent: 1500,
+      startDate: "2026-01-01",
+      endDate: "2026-12-31",
+      status: "ended",
+    });
+
+    const app = await makeApp();
+    const res = await request(app).get("/active");
+
+    expect(res.status).toBe(200);
+    expect(res.body?.ok).toBe(true);
+    expect(res.body?.leases).toHaveLength(1);
+    expect(res.body?.leases?.[0]).toEqual(
+      expect.objectContaining({
+        id: "lease-1",
+        propertyName: "Harbour View",
+        tenantName: "Jane Tenant",
+        tenantEmail: "jane@example.com",
+        documentUrl: "https://files.example.com/lease.pdf",
+      })
+    );
+  });
+});

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -139,6 +139,35 @@ function mergeLeaseRows(rows: any[]) {
   });
 }
 
+function isCurrentLeaseStatus(status: unknown): boolean {
+  return CURRENT_LEASE_STATUSES.has(String(status || "").trim().toLowerCase());
+}
+
+async function loadLeaseDocumentUrlForLease(raw: any): Promise<string | null> {
+  const directUrl =
+    String(raw?.documentUrl || raw?.approvedDocumentUrl || raw?.documentRef || "").trim() || null;
+  if (directUrl) return directUrl;
+
+  const draftId = String(raw?.sourceDraftId || "").trim();
+  if (!draftId) return null;
+
+  try {
+    const draftSnap = await db.collection("leaseDrafts").doc(draftId).get();
+    if (!draftSnap.exists) return null;
+    const draft = draftSnap.data() as any;
+    const snapshotId = String(draft?.lastGeneratedSnapshotId || "").trim();
+    if (!snapshotId) return null;
+    const snapshotSnap = await db.collection("leaseSnapshots").doc(snapshotId).get();
+    if (!snapshotSnap.exists) return null;
+    const snapshot = snapshotSnap.data() as any;
+    const generatedFiles = Array.isArray(snapshot?.generatedFiles) ? snapshot.generatedFiles : [];
+    const firstFile = generatedFiles.find((item: any) => String(item?.url || "").trim());
+    return String(firstFile?.url || "").trim() || null;
+  } catch {
+    return null;
+  }
+}
+
 
 async function assertNoConflictingActiveAgreement(input: {
   leaseId?: string | null;
@@ -217,6 +246,83 @@ async function enforceLeaseCapability(req: any, res: Response): Promise<boolean>
 router.get("/", (_req: Request, res: Response) => {
   const leases = leaseService.getAll();
   res.json({ leases });
+});
+
+router.get("/active", requireLandlord, async (req: any, res: Response) => {
+  try {
+    if (!(await enforceLeaseCapability(req, res))) return;
+    const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
+    if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
+
+    const collectionRef: any = (db as any).collection("leases");
+    if (!collectionRef || typeof collectionRef.where !== "function") {
+      return res.status(200).json({ ok: true, leases: [] });
+    }
+
+    const snap = await collectionRef.where("landlordId", "==", landlordId).get();
+    const rawLeases = (snap.docs || [])
+      .map((doc: any) => ({ id: doc.id, ...(doc.data() as any) }))
+      .filter((lease: any) => isCurrentLeaseStatus(lease?.status));
+
+    const propertyIds: string[] = Array.from(
+      new Set(rawLeases.map((lease: any) => String(lease?.propertyId || "").trim()).filter(Boolean))
+    );
+    const tenantIds: string[] = Array.from(
+      new Set(
+        rawLeases.flatMap((lease: any) =>
+          Array.isArray(lease?.tenantIds)
+            ? lease.tenantIds.map((value: any) => String(value || "").trim()).filter(Boolean)
+            : [String(lease?.tenantId || lease?.primaryTenantId || "").trim()].filter(Boolean)
+        )
+      )
+    );
+
+    const [propertyDocs, tenantDocs] = await Promise.all([
+      Promise.all(propertyIds.map((propertyId) => db.collection("properties").doc(propertyId).get().catch(() => null))),
+      Promise.all(tenantIds.map((tenantId) => db.collection("tenants").doc(tenantId).get().catch(() => null))),
+    ]);
+
+    const propertyNameById = new Map(
+      propertyDocs
+        .filter((doc: any) => doc?.exists)
+        .map((doc: any) => [
+          doc.id,
+          String(doc.data()?.name || doc.data()?.addressLine1 || "Property").trim() || "Property",
+        ])
+    );
+    const tenantById = new Map(
+      tenantDocs
+        .filter((doc: any) => doc?.exists)
+        .map((doc: any) => [
+          doc.id,
+          {
+            name: String(doc.data()?.fullName || doc.data()?.name || "").trim() || null,
+            email: String(doc.data()?.email || "").trim() || null,
+          },
+        ])
+    );
+
+    const leases = await Promise.all(
+      rawLeases.map(async (raw: any) => {
+        const lease = normalizeLeaseRow(raw.id, raw);
+        const tenantId =
+          String(lease.primaryTenantId || lease.tenantId || lease.tenantIds?.[0] || "").trim() || null;
+        const tenant = tenantId ? tenantById.get(tenantId) || null : null;
+        return {
+          ...lease,
+          propertyName: propertyNameById.get(lease.propertyId) || "Property",
+          tenantName: tenant?.name || null,
+          tenantEmail: tenant?.email || null,
+          documentUrl: await loadLeaseDocumentUrlForLease(raw),
+        };
+      })
+    );
+
+    return res.status(200).json({ ok: true, leases: mergeLeaseRows(leases) });
+  } catch (err) {
+    console.error("[GET /api/leases/active] error", err);
+    return res.status(500).json({ ok: false, error: "Failed to load active leases" });
+  }
 });
 
 router.post("/drafts", requireLandlord, async (req: any, res: Response) => {

--- a/rentchain-api/src/routes/unitImportRoutes.ts
+++ b/rentchain-api/src/routes/unitImportRoutes.ts
@@ -319,6 +319,9 @@ async function runUnitImport(opts: {
     mode,
     requestId,
     imported: wouldInsert,
+    createdCount: wouldInsert,
+    updatedCount: 0,
+    skippedCount,
     summary,
     issues: issues.slice(0, 200),
   };

--- a/rentchain-api/src/routes/unitsRoutes.ts
+++ b/rentchain-api/src/routes/unitsRoutes.ts
@@ -1,9 +1,34 @@
 import { Router } from "express";
+import multer from "multer";
 import { db, FieldValue } from "../config/firebase";
 import { authenticateJwt } from "../middleware/authMiddleware";
 import { requireCapability } from "../services/capabilityGuard";
+import { uploadBufferToGcs } from "../lib/gcs";
+import { getSignedDownloadUrl } from "../lib/gcsSignedUrl";
 
 const router = Router();
+const leaseDocumentUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 10 * 1024 * 1024 },
+  fileFilter: (_req, file, cb) => {
+    const name = String(file?.originalname || "").toLowerCase();
+    const mime = String(file?.mimetype || "").toLowerCase();
+    const allowedMime = new Set([
+      "application/pdf",
+      "application/msword",
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      "image/jpeg",
+      "image/png",
+    ]);
+    const allowedExtension = [".pdf", ".doc", ".docx", ".jpg", ".jpeg", ".png"].some((ext) =>
+      name.endsWith(ext)
+    );
+    if (allowedMime.has(mime) || allowedExtension) {
+      return cb(null, true);
+    }
+    return cb(new Error("Unsupported lease document type"));
+  },
+});
 
 function requireLandlord(req: any, res: any, next: any) {
   if (!req.user) {
@@ -76,6 +101,26 @@ async function ensurePropertyOwned(propertyId: string, landlordId: string) {
 
 function normalizeStatus(value: any): string {
   return String(value || "").trim().toLowerCase();
+}
+
+async function attachSignedLeaseDocument(unit: any) {
+  const leaseDocument = unit?.leaseDocument;
+  if (!leaseDocument || typeof leaseDocument !== "object") return unit;
+  const bucket = String(leaseDocument.bucket || "").trim();
+  const path = String(leaseDocument.path || "").trim();
+  if (!bucket || !path) return unit;
+  try {
+    const url = await getSignedDownloadUrl({ bucket, path, expiresMinutes: 30 });
+    return {
+      ...unit,
+      leaseDocument: {
+        ...leaseDocument,
+        url,
+      },
+    };
+  } catch {
+    return unit;
+  }
 }
 
 function leaseIndicatesSigned(status: any): boolean {
@@ -157,16 +202,18 @@ router.get(
       propertyId,
       units: items,
     });
-    const normalizedItems = items.map((item) => {
+    const normalizedItems = await Promise.all(items.map(async (item) => {
       const key = String(item?.id || item?.unitId || "").trim();
       const eligibility = inviteEligibility.get(key);
-      if (!eligibility) return item;
-      return {
+      const baseItem = !eligibility
+        ? item
+        : {
         ...item,
         inviteEligible: eligibility.eligible,
         inviteEligibilityReason: eligibility.reason || null,
       };
-    });
+      return attachSignedLeaseDocument(baseItem);
+    }));
     normalizedItems.sort((a, b) => String(a.unitNumber || "").localeCompare(String(b.unitNumber || "")));
 
     const realCount = normalizedItems.length;
@@ -220,16 +267,18 @@ router.get("/units", authenticateJwt, requireLandlord, async (req: any, res) => 
     propertyId,
     units: items,
   });
-  const normalizedItems = items.map((item) => {
+  const normalizedItems = await Promise.all(items.map(async (item) => {
     const key = String(item?.id || item?.unitId || "").trim();
     const eligibility = inviteEligibility.get(key);
-    if (!eligibility) return item;
-    return {
+    const baseItem = !eligibility
+      ? item
+      : {
       ...item,
       inviteEligible: eligibility.eligible,
       inviteEligibilityReason: eligibility.reason || null,
     };
-  });
+    return attachSignedLeaseDocument(baseItem);
+  }));
   normalizedItems.sort((a, b) => String(a.unitNumber || "").localeCompare(String(b.unitNumber || "")));
 
   const realCount = normalizedItems.length;
@@ -423,5 +472,91 @@ router.patch("/units/:unitId", authenticateJwt, requireLandlord, async (req: any
   const updated = { id: unitId, ...existing, ...updates };
   return res.json({ ok: true, unit: updated });
 });
+
+router.post(
+  "/units/:unitId/lease-document",
+  authenticateJwt,
+  requireLandlord,
+  (req, res, next) => leaseDocumentUpload.single("file")(req, res, next),
+  async (req: any, res) => {
+    const landlordId = req.user?.landlordId || req.user?.id;
+    const unitId = String(req.params?.unitId || "");
+    if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
+    if (!unitId) return res.status(400).json({ ok: false, error: "Missing unitId" });
+    if (!(await enforceUnitsCapability(req, res))) return;
+
+    const ref = db.collection("units").doc(unitId);
+    const snap = await ref.get();
+    if (!snap.exists) {
+      return res.status(404).json({ ok: false, error: "UNIT_NOT_FOUND" });
+    }
+    const existing = snap.data() as any;
+    const propertyId = String(existing?.propertyId || "").trim();
+    if (existing?.landlordId !== landlordId) {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+    if (propertyId) {
+      const ownership = await ensurePropertyOwned(propertyId, landlordId);
+      if (!ownership.ok) {
+        return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+      }
+    }
+
+    const file = req.file as Express.Multer.File | undefined;
+    if (!file?.buffer) {
+      return res.status(400).json({ ok: false, error: "lease_document_file_required" });
+    }
+
+    const safeName = String(file.originalname || "lease-document").replace(/[^a-zA-Z0-9._-]+/g, "_");
+    const path = `units/lease-documents/${landlordId}/${propertyId || "property"}/${unitId}/${Date.now()}_${safeName}`;
+    const uploaded = await uploadBufferToGcs({
+      path,
+      contentType: file.mimetype || "application/octet-stream",
+      buffer: file.buffer,
+      metadata: {
+        landlordId: String(landlordId),
+        propertyId,
+        unitId,
+        originalName: file.originalname || safeName,
+      },
+    });
+
+    const leaseDocument = {
+      fileName: file.originalname || safeName,
+      contentType: file.mimetype || "application/octet-stream",
+      bucket: uploaded.bucket,
+      path: uploaded.path,
+      uploadedAt: new Date().toISOString(),
+      uploadedByUserId: String(req.user?.id || landlordId),
+    };
+
+    await ref.set(
+      {
+        leaseDocument,
+        updatedAt: new Date(),
+        updatedAtServer: FieldValue.serverTimestamp ? FieldValue.serverTimestamp() : new Date(),
+      },
+      { merge: true }
+    );
+
+    const url = await getSignedDownloadUrl({
+      bucket: uploaded.bucket,
+      path: uploaded.path,
+      expiresMinutes: 30,
+    }).catch(() => null);
+
+    return res.json({
+      ok: true,
+      unit: {
+        id: unitId,
+        ...existing,
+        leaseDocument: {
+          ...leaseDocument,
+          url,
+        },
+      },
+    });
+  }
+);
 
 export default router;

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -87,6 +87,7 @@ import TenantLeaseNoticeDetailPage from "./pages/tenant/TenantLeaseNoticeDetailP
 import MaintenanceRequestsPage from "./pages/MaintenanceRequestsPage";
 import PdfSamplePage from "./pages/PdfSamplePage";
 import LeaseLedgerPage from "./pages/LeaseLedgerPage";
+import LandlordActiveLeasesPage from "./pages/LandlordActiveLeasesPage";
 import ApplicationReviewSummaryPage from "./pages/ApplicationReviewSummaryPage";
 import ReferralsPage from "./pages/ReferralsPage";
 import AccountPage from "./pages/AccountPage";
@@ -1013,6 +1014,16 @@ function App() {
                 <Suspense fallback={<div style={{ padding: 20 }}>Loading timeline...</div>}>
                   <AutomationTimelinePage />
                 </Suspense>
+              </LandlordNav>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/leases"
+          element={
+            <RequireAuth>
+              <LandlordNav>
+                <LandlordActiveLeasesPage />
               </LandlordNav>
             </RequireAuth>
           }

--- a/rentchain-frontend/src/api/leasesApi.ts
+++ b/rentchain-frontend/src/api/leasesApi.ts
@@ -44,6 +44,13 @@ export interface Lease {
   updatedAt: string;
 }
 
+export interface LandlordActiveLease extends Lease {
+  propertyName: string;
+  tenantName?: string | null;
+  tenantEmail?: string | null;
+  documentUrl?: string | null;
+}
+
 export interface CreateLeasePayload {
   tenantId: string;
   tenantIds?: string[];
@@ -79,6 +86,10 @@ export async function getLeasesForProperty(
   return apiJson<{ leases: Lease[]; diagnostics?: any; credibilitySummary?: PropertyCredibilitySummary | null }>(
     `/leases/property/${encodeURIComponent(propertyId)}`
   );
+}
+
+export async function getActiveLeasesForLandlord(): Promise<{ leases: LandlordActiveLease[] }> {
+  return apiJson<{ leases: LandlordActiveLease[] }>("/leases/active");
 }
 
 export async function createLease(

--- a/rentchain-frontend/src/api/unitsApi.ts
+++ b/rentchain-frontend/src/api/unitsApi.ts
@@ -41,3 +41,12 @@ export async function updateUnit(unitId: string, payload: any) {
     body: JSON.stringify(payload),
   });
 }
+
+export async function uploadUnitLeaseDocument(unitId: string, file: File) {
+  const formData = new FormData();
+  formData.append("file", file);
+  return apiFetch(`/units/${unitId}/lease-document`, {
+    method: "POST",
+    body: formData,
+  });
+}

--- a/rentchain-frontend/src/components/dashboard/PortfolioCredibilitySummaryCard.test.tsx
+++ b/rentchain-frontend/src/components/dashboard/PortfolioCredibilitySummaryCard.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it } from "vitest";
 import { PortfolioCredibilitySummaryCard } from "./PortfolioCredibilitySummaryCard";
 
@@ -9,27 +10,31 @@ afterEach(() => {
 describe("PortfolioCredibilitySummaryCard", () => {
   it("renders the portfolio summary metrics when data is available", () => {
     render(
-      <PortfolioCredibilitySummaryCard
-        summary={{
-          propertyCount: 3,
-          activeLeaseCount: 5,
-          tenantScoreAverage: 77,
-          tenantScoreGradeAverage: "B",
-          leaseRiskAverage: 69,
-          leaseRiskGradeAverage: "C",
-          tenantsWithScoreCount: 4,
-          leasesWithRiskCount: 5,
-          lowConfidenceCount: 2,
-          missingCredibilityCount: 1,
-          healthStatus: "watch",
-        }}
-      />
+      <MemoryRouter>
+        <PortfolioCredibilitySummaryCard
+          summary={{
+            propertyCount: 3,
+            activeLeaseCount: 5,
+            tenantScoreAverage: 77,
+            tenantScoreGradeAverage: "B",
+            leaseRiskAverage: 69,
+            leaseRiskGradeAverage: "C",
+            tenantsWithScoreCount: 4,
+            leasesWithRiskCount: 5,
+            lowConfidenceCount: 2,
+            missingCredibilityCount: 1,
+            healthStatus: "watch",
+          }}
+          activeLeasesHref="/leases"
+        />
+      </MemoryRouter>
     );
 
     expect(screen.getByText("Portfolio credibility summary")).toBeInTheDocument();
     expect(screen.getByText("Watch")).toBeInTheDocument();
     expect(screen.getByText("Properties represented")).toBeInTheDocument();
     expect(screen.getByText("Missing credibility")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "5" })).toHaveAttribute("href", "/leases");
   });
 
   it("renders the empty state when no summary data is available", () => {

--- a/rentchain-frontend/src/components/dashboard/PortfolioCredibilitySummaryCard.tsx
+++ b/rentchain-frontend/src/components/dashboard/PortfolioCredibilitySummaryCard.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Link } from "react-router-dom";
 import { Card } from "@/components/ui/Ui";
 import { RiskScoreBadge } from "@/components/leases/RiskScoreBadge";
 import { colors, radius, spacing, text } from "@/styles/tokens";
@@ -6,6 +7,7 @@ import type { PortfolioCredibilitySummary } from "@/types/portfolioCredibilitySu
 
 interface PortfolioCredibilitySummaryCardProps {
   summary?: PortfolioCredibilitySummary | null;
+  activeLeasesHref?: string;
 }
 
 function healthTone(status?: PortfolioCredibilitySummary["healthStatus"] | null) {
@@ -40,7 +42,10 @@ const MetricTile: React.FC<{ label: string; value: React.ReactNode; caption?: Re
   </div>
 );
 
-export const PortfolioCredibilitySummaryCard: React.FC<PortfolioCredibilitySummaryCardProps> = ({ summary }) => {
+export const PortfolioCredibilitySummaryCard: React.FC<PortfolioCredibilitySummaryCardProps> = ({
+  summary,
+  activeLeasesHref,
+}) => {
   const [isMobile, setIsMobile] = React.useState(false);
 
   React.useEffect(() => {
@@ -125,7 +130,19 @@ export const PortfolioCredibilitySummaryCard: React.FC<PortfolioCredibilitySumma
           value={<RiskScoreBadge grade={summary.leaseRiskGradeAverage} score={summary.leaseRiskAverage} />}
           caption={`${summary.leasesWithRiskCount} leases with risk`}
         />
-        <MetricTile label="Active leases" value={summary.activeLeaseCount} caption="Current lease agreements in this rollup" />
+        <MetricTile
+          label="Active leases"
+          value={
+            activeLeasesHref ? (
+              <Link to={activeLeasesHref} style={{ color: text.primary, textDecoration: "underline" }}>
+                {summary.activeLeaseCount}
+              </Link>
+            ) : (
+              summary.activeLeaseCount
+            )
+          }
+          caption="Current lease agreements in this rollup"
+        />
         <MetricTile label="Properties represented" value={summary.propertyCount} caption="Properties contributing active credibility evidence" />
       </div>
 

--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.test.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.test.tsx
@@ -6,6 +6,7 @@ import { AuthProvider } from "@/context/AuthContext";
 
 const mocks = vi.hoisted(() => ({
   updateProperty: vi.fn(),
+  archiveProperty: vi.fn(),
   getLeasesForProperty: vi.fn(),
   getPropertyMonthlyPayments: vi.fn(),
   fetchUnitsForProperty: vi.fn(),
@@ -20,7 +21,7 @@ vi.mock("../../api/propertiesApi", async () => {
   return {
     ...actual,
     updateProperty: mocks.updateProperty,
-    archiveProperty: vi.fn(),
+    archiveProperty: mocks.archiveProperty,
     publishProperty: vi.fn(),
     unarchiveProperty: vi.fn(),
   };
@@ -95,6 +96,9 @@ describe("PropertyDetailPanel", () => {
   beforeEach(() => {
     mocks.updateProperty.mockResolvedValue({
       property: { id: "prop-1" },
+    });
+    mocks.archiveProperty.mockResolvedValue({
+      property: { id: "prop-1", portfolioStatus: "archived" },
     });
     mocks.getLeasesForProperty.mockResolvedValue({ leases: [], credibilitySummary: null });
     mocks.getPropertyMonthlyPayments.mockResolvedValue({ payments: [], total: 0 });
@@ -225,5 +229,85 @@ render(
         source: "property_detail_panel_units",
       })
     );
+  });
+
+  it("derives occupancy and occupied rent from canonical unit state when no active lease exists yet", async () => {
+    mocks.fetchUnitsForProperty.mockResolvedValue([
+      {
+        id: "unit-1",
+        unitNumber: "101",
+        status: "occupied",
+        occupantName: "Jane Tenant",
+        rent: 1800,
+      },
+      {
+        id: "unit-2",
+        unitNumber: "102",
+        status: "vacant",
+        rent: 1700,
+      },
+    ]);
+
+    render(
+      <AuthProvider>
+        <MemoryRouter>
+          <PropertyDetailPanel
+            property={{
+              id: "prop-1",
+              name: "Harbour View",
+              addressLine1: "12 Wharf Street",
+              city: "Halifax",
+              province: "NS",
+              postalCode: "B3H 1A1",
+              country: "Canada",
+              totalUnits: 2,
+              amenities: [],
+              units: [],
+              createdAt: new Date().toISOString(),
+            }}
+            onRefresh={vi.fn()}
+          />
+        </MemoryRouter>
+      </AuthProvider>
+    );
+
+    expect((await screen.findAllByText("Occupied")).length).toBeGreaterThan(0);
+    expect(screen.getByText("50%")).toBeInTheDocument();
+    expect(screen.getAllByText("$1,800").length).toBeGreaterThan(0);
+  });
+
+  it("uses the updated archive confirmation copy before archiving", async () => {
+    const confirmMock = vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    render(
+      <AuthProvider>
+        <MemoryRouter>
+          <PropertyDetailPanel
+            property={{
+              id: "prop-1",
+              name: "Harbour View",
+              addressLine1: "12 Wharf Street",
+              city: "Halifax",
+              province: "NS",
+              postalCode: "B3H 1A1",
+              country: "Canada",
+              totalUnits: 1,
+              amenities: [],
+              units: [],
+              createdAt: new Date().toISOString(),
+            }}
+            onRefresh={vi.fn()}
+          />
+        </MemoryRouter>
+      </AuthProvider>
+    );
+
+    fireEvent.click(screen.getAllByRole("button", { name: /archive property/i })[0]);
+
+    expect(confirmMock).toHaveBeenCalledWith(
+      "Are you sure you want to archive this property? You can reactivate this property later."
+    );
+    await waitFor(() => expect(mocks.archiveProperty).toHaveBeenCalledWith("prop-1"));
+    confirmMock.mockRestore();
   });
 });

--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
@@ -219,9 +219,15 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
       }
       const idempotencyKey = `${property.id}:${pendingFile.name}:${pendingFile.size}:${pendingFile.lastModified}`;
       const result = await importUnitsCsv(property.id, csvText, "partial", idempotencyKey);
-      const created = result?.createdCount ?? result?.created ?? 0;
+      const created = result?.createdCount ?? result?.created ?? result?.imported ?? result?.summary?.insertable ?? 0;
       const updated = result?.updatedCount ?? result?.updated ?? 0;
-      const skipped = result?.skippedCount ?? result?.skipped ?? 0;
+      const skipped =
+        result?.skippedCount ??
+        result?.skipped ??
+        ((result?.summary?.invalid ?? 0) +
+          (result?.summary?.duplicatesInCsv ?? 0) +
+          (result?.summary?.conflicts ?? 0)) ??
+        0;
       const errCount = Array.isArray(result?.errors) ? result.errors.length : 0;
       showToast({
         message: "Units imported",
@@ -581,18 +587,38 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
       ),
     [leases]
   );
-  const leasedUnits = activeLeases.length;
+  const activeLeaseUnitNumbers = useMemo(
+    () => new Set(activeLeases.map((lease) => String(lease.unitNumber || "").trim()).filter(Boolean)),
+    [activeLeases]
+  );
+  const occupiedUnits = useMemo(
+    () =>
+      displayedUnits.filter((unit) => {
+        const unitNumber = String((unit as any)?.unitNumber || "").trim();
+        const status = String((unit as any)?.occupancyStatus || (unit as any)?.status || "").trim().toLowerCase();
+        return status === "occupied" || (unitNumber && activeLeaseUnitNumbers.has(unitNumber));
+      }),
+    [activeLeaseUnitNumbers, displayedUnits]
+  );
+  const leasedUnits = occupiedUnits.length;
   const occupancy = unitCount > 0 ? (leasedUnits / unitCount) * 100 : 0;
-  const leaseRentRoll = activeLeases.reduce(
+  const activeLeaseRentRoll = activeLeases.reduce(
     (sum, l) => sum + (typeof l.monthlyRent === "number" ? l.monthlyRent : 0),
     0
   );
+  const occupiedUnitsFallbackRent = occupiedUnits.reduce((sum, unit) => {
+    const unitNumber = String((unit as any)?.unitNumber || "").trim();
+    if (unitNumber && activeLeaseUnitNumbers.has(unitNumber)) return sum;
+    const configuredRent = resolveConfiguredUnitRent(unit);
+    return sum + (configuredRent != null ? Number(configuredRent) || 0 : 0);
+  }, 0);
+  const leaseRentRoll = activeLeaseRentRoll + occupiedUnitsFallbackRent;
   const collectionRate =
     leaseRentRoll > 0 ? totalCollectedThisMonth / leaseRentRoll : 0;
 
   const leasedUnitNumbers = useMemo(
-    () => new Set(activeLeases.map((lease) => lease.unitNumber)),
-    [activeLeases]
+    () => new Set(occupiedUnits.map((unit: any) => String(unit?.unitNumber || "").trim()).filter(Boolean)),
+    [occupiedUnits]
   );
   const unitsNeedingOccupancySetup = useMemo(
     () => getUnitsNeedingOccupancySetup(displayedUnits, activeLeases),
@@ -663,8 +689,8 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
     if (!property?.id) return;
     const confirmed = window.confirm(
       isArchived
-        ? "Restore this property to your active portfolio?"
-        : "Archive this property? It will be hidden from active portfolio views but preserved for records and history."
+        ? "Restore this property to your active portfolio? You can archive it again later if needed."
+        : "Are you sure you want to archive this property? You can reactivate this property later."
     );
     if (!confirmed) return;
 
@@ -1121,13 +1147,13 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
           }}
         >
           <div className="rc-kpi-label" style={{ color: "#111827", fontSize: "0.8rem" }}>
-            Active lease rent total
+            Current occupied rent total
           </div>
           <div className="rc-kpi-value" style={{ color: "#0b1220", fontWeight: 700, fontSize: "1.05rem" }}>
             {formatCurrency(leaseRentRoll)}
           </div>
           <div className="rc-kpi-subtext" style={{ color: "#4b5563", fontSize: "0.75rem", marginTop: 2 }}>
-            Based on signed active leases for this property.
+            Uses active lease rent when present and occupied unit rent where current occupancy has been set manually.
           </div>
         </div>
 
@@ -1498,6 +1524,17 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
                                 : ""}
                             </div>
                           ) : null}
+                          {(u as any).leaseDocument?.fileName ? (
+                            <div style={{ fontSize: "0.78rem", color: "#2563eb" }}>
+                              {(u as any).leaseDocument?.url ? (
+                                <a href={(u as any).leaseDocument.url} target="_blank" rel="noreferrer">
+                                  View lease document
+                                </a>
+                              ) : (
+                                `Lease document: ${String((u as any).leaseDocument.fileName)}`
+                              )}
+                            </div>
+                          ) : null}
                         </div>
                       </td>
                       <td className="rc-units-col-actions" style={{ padding: "10px 12px" }}>
@@ -1615,6 +1652,17 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
                           : ""}
                       </div>
                     ) : null}
+                    {(u as any).leaseDocument?.fileName ? (
+                      <div style={{ fontSize: "0.78rem", color: "#2563eb", marginTop: 4 }}>
+                        {(u as any).leaseDocument?.url ? (
+                          <a href={(u as any).leaseDocument.url} target="_blank" rel="noreferrer">
+                            View lease document
+                          </a>
+                        ) : (
+                          `Lease document: ${String((u as any).leaseDocument.fileName)}`
+                        )}
+                      </div>
+                    ) : null}
                   </div>
                 </div>
                 <div className="rc-unit-card-row rc-unit-card-specs" style={{ marginTop: 8 }}>
@@ -1697,6 +1745,7 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
         onClose={() => setEditingUnit(null)}
         onSaved={(updated) => {
           setUnits((prev) => prev.map((u) => (u?.id === updated?.id ? { ...u, ...updated } : u)));
+          setEditingUnit(null);
         }}
       />
       <SendApplicationModal

--- a/rentchain-frontend/src/components/properties/UnitEditModal.tsx
+++ b/rentchain-frontend/src/components/properties/UnitEditModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { updateUnit } from "../../api/unitsApi";
+import { updateUnit, uploadUnitLeaseDocument } from "../../api/unitsApi";
 import { Button } from "../ui/Ui";
 
 type Props = {
@@ -18,6 +18,8 @@ export function UnitEditModal({ open, unit, onClose, onSaved }: Props) {
   const [status, setStatus] = useState("vacant");
   const [occupantName, setOccupantName] = useState("");
   const [leaseEndDate, setLeaseEndDate] = useState("");
+  const [leaseDocumentFile, setLeaseDocumentFile] = useState<File | null>(null);
+  const [existingLeaseDocument, setExistingLeaseDocument] = useState<any | null>(null);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -49,6 +51,8 @@ export function UnitEditModal({ open, unit, onClose, onSaved }: Props) {
     setStatus(unit.status || "vacant");
     setOccupantName(String(unit.occupantName || ""));
     setLeaseEndDate(String(unit.leaseEndDate || ""));
+    setLeaseDocumentFile(null);
+    setExistingLeaseDocument(unit.leaseDocument || null);
     setError(null);
   }, [unit]);
 
@@ -72,7 +76,11 @@ export function UnitEditModal({ open, unit, onClose, onSaved }: Props) {
       payload.occupantName = payload.status === "occupied" ? occupantName.trim() || null : null;
       payload.leaseEndDate = payload.status === "occupied" ? leaseEndDate || null : null;
       const resp: any = await updateUnit(String(unit.id), payload);
-      const updated = resp?.unit || { ...unit, ...payload };
+      let updated = resp?.unit || { ...unit, ...payload };
+      if (payload.status === "occupied" && leaseDocumentFile) {
+        const uploadedResp: any = await uploadUnitLeaseDocument(String(unit.id), leaseDocumentFile);
+        updated = uploadedResp?.unit || { ...updated, leaseDocument: uploadedResp?.leaseDocument || null };
+      }
       onSaved(updated);
       onClose();
     } catch (e: any) {
@@ -218,6 +226,35 @@ export function UnitEditModal({ open, unit, onClose, onSaved }: Props) {
                 type="date"
                 style={{ padding: "8px 10px", borderRadius: 8, border: "1px solid #d1d5db" }}
               />
+            </label>
+
+            <label style={{ display: "grid", gap: 6, fontSize: 13 }}>
+              Lease document (optional)
+              <input
+                type="file"
+                accept=".pdf,.doc,.docx,.jpg,.jpeg,.png,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,image/jpeg,image/png"
+                onChange={(e) => setLeaseDocumentFile(e.target.files?.[0] || null)}
+                style={{ padding: "8px 0", fontSize: 13 }}
+              />
+              <div style={{ color: "#64748b", fontSize: 12 }}>
+                Attach the current lease file for reference while you finish full lease setup later.
+              </div>
+              {leaseDocumentFile ? (
+                <div style={{ color: "#0f172a", fontSize: 12, fontWeight: 600 }}>
+                  Selected: {leaseDocumentFile.name}
+                </div>
+              ) : existingLeaseDocument?.fileName ? (
+                <div style={{ color: "#0f172a", fontSize: 12 }}>
+                  Attached:{" "}
+                  {existingLeaseDocument?.url ? (
+                    <a href={existingLeaseDocument.url} target="_blank" rel="noreferrer">
+                      {existingLeaseDocument.fileName}
+                    </a>
+                  ) : (
+                    existingLeaseDocument.fileName
+                  )}
+                </div>
+              ) : null}
             </label>
           </>
         ) : null}

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -594,7 +594,10 @@ const DashboardPage: React.FC = () => {
         {dataReady ? <KpiStrip kpis={kpis} loading={loading} /> : null}
         {dataReady ? (
           <div style={{ marginTop: spacing.md }}>
-            <PortfolioCredibilitySummaryCard summary={data?.portfolioCredibilitySummary ?? null} />
+            <PortfolioCredibilitySummaryCard
+              summary={data?.portfolioCredibilitySummary ?? null}
+              activeLeasesHref="/leases"
+            />
           </div>
         ) : null}
         {dataReady &&

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import LandlordActiveLeasesPage from "./LandlordActiveLeasesPage";
+
+const mocks = vi.hoisted(() => ({
+  getActiveLeasesForLandlord: vi.fn(),
+}));
+
+vi.mock("@/api/leasesApi", () => ({
+  getActiveLeasesForLandlord: mocks.getActiveLeasesForLandlord,
+}));
+
+describe("LandlordActiveLeasesPage", () => {
+  beforeEach(() => {
+    mocks.getActiveLeasesForLandlord.mockResolvedValue({
+      leases: [
+        {
+          id: "lease-1",
+          propertyId: "prop-1",
+          propertyName: "Harbour View",
+          unitNumber: "101",
+          monthlyRent: 1850,
+          startDate: "2026-01-01",
+          endDate: "2026-12-31",
+          status: "active",
+          tenantName: "Jane Tenant",
+          tenantEmail: "jane@example.com",
+          documentUrl: "https://example.com/lease.pdf",
+        },
+      ],
+    });
+  });
+
+  it("renders active leases with view, email, and save actions", async () => {
+    render(
+      <MemoryRouter>
+        <LandlordActiveLeasesPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Harbour View")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "View" })).toHaveAttribute("href", "/leases/lease-1/ledger");
+    expect(screen.getByRole("link", { name: "Email" })).toHaveAttribute(
+      "href",
+      expect.stringContaining("mailto:jane%40example.com")
+    );
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+  });
+
+  it("renders an empty state when no active leases are available", async () => {
+    mocks.getActiveLeasesForLandlord.mockResolvedValue({ leases: [] });
+
+    render(
+      <MemoryRouter>
+        <LandlordActiveLeasesPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/No active leases were found/i)).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
@@ -1,0 +1,199 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { getActiveLeasesForLandlord, type LandlordActiveLease } from "@/api/leasesApi";
+
+function formatCurrency(value: number | null | undefined) {
+  const amount = typeof value === "number" ? value : 0;
+  return amount.toLocaleString(undefined, { style: "currency", currency: "CAD" });
+}
+
+function formatDate(value: string | null | undefined) {
+  if (!value) return "—";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return parsed.toLocaleDateString();
+}
+
+function downloadLeaseSummary(lease: LandlordActiveLease) {
+  const text = [
+    `Property: ${lease.propertyName || "Property"}`,
+    `Unit: ${lease.unitNumber || "—"}`,
+    `Tenant: ${lease.tenantName || "—"}`,
+    `Tenant email: ${lease.tenantEmail || "—"}`,
+    `Monthly rent: ${formatCurrency(lease.monthlyRent)}`,
+    `Start date: ${lease.startDate || "—"}`,
+    `End date: ${lease.endDate || "—"}`,
+    `Status: ${lease.status || "—"}`,
+    `Lease document: ${lease.documentUrl || "Not available"}`,
+  ].join("\n");
+
+  const blob = new Blob([text], { type: "text/plain;charset=utf-8" });
+  const url = window.URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `lease-${lease.unitNumber || lease.id}.txt`;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  window.URL.revokeObjectURL(url);
+}
+
+export default function LandlordActiveLeasesPage() {
+  const [leases, setLeases] = React.useState<LandlordActiveLease[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    let active = true;
+    const load = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const response = await getActiveLeasesForLandlord();
+        if (!active) return;
+        setLeases(Array.isArray(response?.leases) ? response.leases : []);
+      } catch (err: any) {
+        if (!active) return;
+        setError(err?.message || "Failed to load active leases.");
+        setLeases([]);
+      } finally {
+        if (active) setLoading(false);
+      }
+    };
+    void load();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return (
+    <div style={{ display: "grid", gap: 16 }}>
+      <div style={{ display: "grid", gap: 6 }}>
+        <div style={{ fontSize: 24, fontWeight: 800 }}>Active leases</div>
+        <div style={{ color: "#475569", fontSize: 14 }}>
+          View the current active lease rollup for your portfolio, including quick actions to open, email, or save each lease reference.
+        </div>
+      </div>
+
+      {loading ? <div>Loading active leases…</div> : null}
+      {error ? <div style={{ color: "#b91c1c" }}>{error}</div> : null}
+
+      {!loading && !error && leases.length === 0 ? (
+        <div
+          style={{
+            padding: 16,
+            borderRadius: 12,
+            border: "1px solid #e2e8f0",
+            background: "#fff",
+            color: "#475569",
+          }}
+        >
+          No active leases were found for this landlord yet.
+        </div>
+      ) : null}
+
+      {!loading && !error && leases.length > 0 ? (
+        <div style={{ overflowX: "auto", border: "1px solid #e2e8f0", borderRadius: 12, background: "#fff" }}>
+          <table style={{ width: "100%", minWidth: 920, borderCollapse: "collapse" }}>
+            <thead>
+              <tr style={{ background: "#f8fafc", color: "#475569" }}>
+                {["Property", "Unit", "Tenant", "Rent", "Term", "Actions"].map((label) => (
+                  <th key={label} style={{ textAlign: "left", padding: 12, fontSize: 12, textTransform: "uppercase", letterSpacing: "0.04em" }}>
+                    {label}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {leases.map((lease) => {
+                const ledgerPath = `/leases/${encodeURIComponent(lease.id)}/ledger`;
+                const ledgerUrl =
+                  typeof window !== "undefined"
+                    ? `${window.location.origin}${ledgerPath}`
+                    : ledgerPath;
+                const emailSubject = encodeURIComponent(`Lease for ${lease.propertyName} unit ${lease.unitNumber}`);
+                const emailBody = encodeURIComponent(
+                  [
+                    `Lease reference for ${lease.propertyName} unit ${lease.unitNumber}.`,
+                    "",
+                    `Monthly rent: ${formatCurrency(lease.monthlyRent)}`,
+                    `Term: ${formatDate(lease.startDate)} to ${formatDate(lease.endDate)}`,
+                    `View ledger: ${ledgerUrl}`,
+                    lease.documentUrl ? `Lease document: ${lease.documentUrl}` : "",
+                  ]
+                    .filter(Boolean)
+                    .join("\n")
+                );
+                const emailHref = lease.tenantEmail
+                  ? `mailto:${encodeURIComponent(lease.tenantEmail)}?subject=${emailSubject}&body=${emailBody}`
+                  : null;
+
+                return (
+                  <tr key={lease.id} style={{ borderTop: "1px solid #e2e8f0" }}>
+                    <td style={{ padding: 12 }}>
+                      <div style={{ fontWeight: 700, color: "#0f172a" }}>{lease.propertyName}</div>
+                      <div style={{ color: "#64748b", fontSize: 12 }}>{lease.id}</div>
+                    </td>
+                    <td style={{ padding: 12 }}>{lease.unitNumber || "—"}</td>
+                    <td style={{ padding: 12 }}>
+                      <div>{lease.tenantName || "Tenant not linked"}</div>
+                      <div style={{ color: "#64748b", fontSize: 12 }}>{lease.tenantEmail || "No email on file"}</div>
+                    </td>
+                    <td style={{ padding: 12 }}>{formatCurrency(lease.monthlyRent)}</td>
+                    <td style={{ padding: 12 }}>
+                      <div>{formatDate(lease.startDate)}</div>
+                      <div style={{ color: "#64748b", fontSize: 12 }}>to {formatDate(lease.endDate)}</div>
+                    </td>
+                    <td style={{ padding: 12 }}>
+                      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                        <Link to={ledgerPath} style={{ padding: "6px 10px", borderRadius: 8, border: "1px solid #cbd5e1", textDecoration: "none", color: "#0f172a" }}>
+                          View
+                        </Link>
+                        {emailHref ? (
+                          <a
+                            href={emailHref}
+                            style={{ padding: "6px 10px", borderRadius: 8, border: "1px solid #cbd5e1", textDecoration: "none", color: "#0f172a" }}
+                          >
+                            Email
+                          </a>
+                        ) : (
+                          <button
+                            type="button"
+                            disabled
+                            style={{ padding: "6px 10px", borderRadius: 8, border: "1px solid #e2e8f0", background: "#f8fafc", color: "#94a3b8" }}
+                          >
+                            Email
+                          </button>
+                        )}
+                        <button
+                          type="button"
+                          onClick={() => {
+                            if (lease.documentUrl) {
+                              const a = document.createElement("a");
+                              a.href = lease.documentUrl;
+                              a.target = "_blank";
+                              a.rel = "noreferrer";
+                              a.download = "";
+                              document.body.appendChild(a);
+                              a.click();
+                              a.remove();
+                              return;
+                            }
+                            downloadLeaseSummary(lease);
+                          }}
+                          style={{ padding: "6px 10px", borderRadius: 8, border: "1px solid #cbd5e1", background: "#fff", color: "#0f172a" }}
+                        >
+                          Save
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
Repaired property unit import feedback, occupancy summary accuracy, and lease visibility.

- Fixed CSV import toast to reflect actual created/updated/skipped counts
- Recomputed property summary from canonical unit occupancy and active lease rent
- Added optional lease-document attachment during manual occupied-state updates (unit-level reference)
- Introduced a landlord active leases page and wired dashboard lease count to it
- Improved archive confirmation messaging to clearly indicate reversibility

No changes to canonical unit or lease truth paths; summary intentionally blends both.