### PR TITLE
feat: improve lease record integrity and landlord lease operations v1

### DIFF
--- a/rentchain-api/src/routes/__tests__/leaseRoutes.integrity.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.integrity.test.ts
@@ -1,0 +1,264 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getSignedDownloadUrlMock = vi.fn(async () => "https://signed.example.com/reference.pdf");
+
+const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+  let idSeq = 0;
+
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+
+  function matches(doc: any, filters: Array<{ field: string; op: string; value: any }>) {
+    return filters.every(({ field, op, value }) => {
+      const actual = doc?.data?.[field];
+      if (op === "==") return actual === value;
+      if (op === "array-contains") return Array.isArray(actual) && actual.includes(value);
+      if (op === ">=") return actual >= value;
+      if (op === "<=") return actual <= value;
+      return false;
+    });
+  }
+
+  function makeQuery(name: string, filters: Array<{ field: string; op: string; value: any }> = []) {
+    return {
+      where: (field: string, op: string, value: any) => makeQuery(name, [...filters, { field, op, value }]),
+      orderBy: () => {
+        throw new Error("orderBy should not be called in this fake query");
+      },
+      limit: () => makeQuery(name, filters),
+      get: async () => {
+        const col = ensureCollection(name);
+        const docs = Array.from(col.values())
+          .filter((doc) => matches(doc, filters))
+          .map((doc) => ({ id: doc.id, exists: true, data: () => doc.data }));
+        return { docs, empty: docs.length === 0, forEach: (fn: any) => docs.forEach(fn), size: docs.length };
+      },
+      doc: (id?: string) => makeDoc(name, id),
+    };
+  }
+
+  function makeDoc(name: string, id?: string) {
+    const actualId = id || `doc_${++idSeq}`;
+    const col = ensureCollection(name);
+    return {
+      id: actualId,
+      set: async (value: any, options?: { merge?: boolean }) => {
+        const current = col.get(actualId)?.data || {};
+        col.set(actualId, { id: actualId, data: options?.merge ? { ...current, ...value } : value });
+      },
+      get: async () => {
+        const entry = col.get(actualId);
+        return { id: actualId, exists: Boolean(entry), data: () => entry?.data };
+      },
+    };
+  }
+
+  return {
+    resetFakeDb: () => {
+      store.clear();
+      idSeq = 0;
+    },
+    seedDoc: (name: string, id: string, data: any) => ensureCollection(name).set(id, { id, data }),
+    fakeDb: {
+      collection: (name: string) => ({
+        where: (field: string, op: string, value: any) => makeQuery(name, [{ field, op, value }]),
+        orderBy: () => {
+          throw new Error("top-level orderBy should not be called");
+        },
+        limit: () => makeQuery(name),
+        get: async () => makeQuery(name).get(),
+        doc: (id?: string) => makeDoc(name, id),
+      }),
+    },
+  };
+});
+
+vi.mock("../../config/firebase", () => ({
+  db: fakeDb,
+  FieldValue: { serverTimestamp: () => "SERVER_TIMESTAMP" },
+}));
+
+vi.mock("../../services/capabilityGuard", () => ({
+  requireCapability: vi.fn(async () => ({ ok: true })),
+}));
+
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: any, _res: any, next: any) => {
+    req.user = { id: "landlord-1", landlordId: "landlord-1", role: "landlord" };
+    next();
+  },
+}));
+
+vi.mock("../../services/leaseDraftsService", () => ({
+  NS_PROVINCE: "NS",
+  NS_TEMPLATE_VERSION: "ns-schedule-a-v1",
+  applyPatch: vi.fn((existing: any) => existing),
+  validateCreateInput: vi.fn(),
+  getDraftById: vi.fn(),
+  getSnapshotById: vi.fn(),
+  generateScheduleA: vi.fn(),
+}));
+
+vi.mock("../../services/leaseCanonicalizationService", () => ({
+  CURRENT_LEASE_STATUSES: new Set(["active", "notice_pending", "renewal_pending", "renewal_accepted", "move_out_pending"]),
+  loadCanonicalPropertyLeases: vi.fn(),
+  loadUnitsForProperty: vi.fn(async (_db: any, propertyId: string) => {
+    const snap = await fakeDb.collection("units").where("propertyId", "==", propertyId).get();
+    return (snap.docs || []).map((doc: any) => ({
+      id: doc.id,
+      raw: doc.data(),
+      unitNumber: String(doc.data()?.unitNumber || "").trim(),
+      label: String(doc.data()?.unitNumber || "").trim(),
+    }));
+  }),
+  toCanonicalLeaseRecord: vi.fn((id: string, raw: any) => ({
+    id,
+    status: String(raw?.status || "").trim().toLowerCase(),
+    unitId: String(raw?.unitId || "").trim() || null,
+    unitNumber: String(raw?.unitNumber || raw?.unit || "").trim() || null,
+    propertyId: String(raw?.propertyId || "").trim() || null,
+  })),
+}));
+
+vi.mock("../../services/leasePartyConsolidationService", () => ({
+  evaluateSameLeaseAgreement: vi.fn(() => ({ decision: "separate" })),
+  groupLeaseAgreementCandidates: vi.fn(() => ({ mergeGroups: [], ambiguousGroups: [], singles: [] })),
+  pickAgreementWinner: vi.fn((candidate: any) => candidate),
+}));
+
+vi.mock("../../services/leaseIntegrityService", () => ({
+  loadPropertyLeaseIntegrityDiagnostics: vi.fn(async () => ({ diagnostics: [] })),
+}));
+
+vi.mock("../../services/risk/recomputeLeaseRisk", () => ({
+  computeLeaseRiskSnapshot: vi.fn(async () => null),
+  buildLeaseRiskPersistenceFields: vi.fn(() => ({ risk: null, riskTimeline: [] })),
+}));
+
+vi.mock("../../services/risk/propertyCredibilitySummary", () => ({
+  loadPropertyCredibilitySummary: vi.fn(async () => null),
+}));
+
+vi.mock("../../services/risk/propertyLeaseIsolation", () => ({
+  dedupePropertyScopedLeasesByUnit: vi.fn((items: any[]) => items),
+  filterPropertyScopedLeases: vi.fn((input: any) => ({ included: input.leases || [] })),
+}));
+
+vi.mock("../../lib/events/buildEvent", () => ({
+  writeCanonicalEvent: vi.fn(async () => null),
+}));
+
+vi.mock("../../lib/gcsSignedUrl", () => ({
+  getSignedDownloadUrl: getSignedDownloadUrlMock,
+}));
+
+describe("leaseRoutes integrity repairs", () => {
+  beforeEach(() => {
+    resetFakeDb();
+    getSignedDownloadUrlMock.mockClear();
+  });
+
+  async function makeApp() {
+    const router = (await import("../leaseRoutes")).default;
+    const app = express();
+    app.use(express.json());
+    app.use((req: any, _res, next) => {
+      req.user = { id: "landlord-1", landlordId: "landlord-1", role: "landlord" };
+      next();
+    });
+    app.use(router);
+    return app;
+  }
+
+  it("loads lease ledger without relying on orderBy queries", async () => {
+    seedDoc("leases", "lease-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      unitId: "unit-1",
+      unitNumber: "101",
+      status: "active",
+    });
+    seedDoc("ledgerEntries", "entry-1", {
+      landlordId: "landlord-1",
+      leaseId: "lease-1",
+      entryType: "charge",
+      category: "rent",
+      amountCents: 180000,
+      effectiveDate: "2026-04-01",
+      createdAt: 10,
+    });
+
+    const app = await makeApp();
+    const res = await request(app).get("/lease-1/ledger");
+
+    expect(res.status).toBe(200);
+    expect(res.body?.ok).toBe(true);
+    expect(res.body?.entries).toHaveLength(1);
+    expect(res.body?.totals?.chargesCents).toBe(180000);
+  });
+
+  it("converts an occupied unit reference into a canonical lease and tenant", async () => {
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Harbour View" });
+    seedDoc("units", "unit-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitNumber: "101",
+      status: "occupied",
+      occupantName: "Recovered Tenant",
+      rent: 1850,
+      leaseDocument: {
+        fileName: "lease.pdf",
+        bucket: "bucket-1",
+        path: "leases/lease.pdf",
+      },
+    });
+
+    const app = await makeApp();
+    const res = await request(app)
+      .post("/reconciliation-candidates/unit-1/convert")
+      .send({ startDate: "2026-04-01", monthlyRent: 1850 });
+
+    expect(res.status).toBe(201);
+    expect(res.body?.ok).toBe(true);
+    expect(String(res.body?.lease?.tenantName || "")).toContain("Recovered Tenant");
+
+    const leaseSnap = await fakeDb.collection("leases").doc(String(res.body?.lease?.id || "")).get();
+    expect(leaseSnap.exists).toBe(true);
+    expect(leaseSnap.data()?.referenceDocument?.fileName).toBe("lease.pdf");
+  });
+
+  it("lists notes and archive visibility metadata for landlord leases", async () => {
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Harbour View" });
+    seedDoc("tenants", "tenant-1", { landlordId: "landlord-1", fullName: "Jane Tenant", email: "jane@example.com" });
+    seedDoc("leases", "lease-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      tenantIds: ["tenant-1"],
+      primaryTenantId: "tenant-1",
+      unitId: "unit-1",
+      unitNumber: "101",
+      monthlyRent: 1850,
+      startDate: "2026-01-01",
+      endDate: "2026-12-31",
+      status: "active",
+      archivedAt: "2026-04-01T00:00:00.000Z",
+    });
+
+    const app = await makeApp();
+    const noteRes = await request(app).post("/lease-1/notes").send({ note: "Keep this for audit." });
+    expect(noteRes.status).toBe(201);
+    const archivedRes = await request(app).get("/archived");
+    expect(archivedRes.status).toBe(200);
+    expect(archivedRes.body?.leases?.[0]?.isArchived).toBe(true);
+    const notesRes = await request(app).get("/lease-1/notes");
+    expect(notesRes.status).toBe(200);
+    expect(notesRes.body?.notes?.[0]?.note).toBe("Keep this for audit.");
+  });
+});

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -27,9 +27,11 @@ import { buildLeaseRiskPersistenceFields, computeLeaseRiskSnapshot } from "../se
 import { loadPropertyCredibilitySummary } from "../services/risk/propertyCredibilitySummary";
 import { dedupePropertyScopedLeasesByUnit, filterPropertyScopedLeases } from "../services/risk/propertyLeaseIsolation";
 import { writeCanonicalEvent } from "../lib/events/buildEvent";
+import { getSignedDownloadUrl } from "../lib/gcsSignedUrl";
 
 const router = Router();
 const LEDGER_COLLECTION = "ledgerEntries";
+const LEASE_NOTES_COLLECTION = "leaseNotes";
 const PAYMENT_METHODS = new Set(["cash", "etransfer", "cheque", "bank", "card", "other"]);
 const CHARGE_CATEGORIES = new Set(["rent", "fee", "adjustment"]);
 
@@ -50,6 +52,10 @@ function cents(value: unknown): number | null {
   return n;
 }
 
+function normalizeStatus(value: unknown): string {
+  return String(value || "").trim().toLowerCase();
+}
+
 function escapeCsvCell(value: unknown): string {
   const raw = String(value ?? "");
   if (/[",\n]/.test(raw)) {
@@ -66,6 +72,23 @@ async function getLeaseForLandlord(leaseId: string, landlordId: string) {
     return { ok: false as const, status: 403, error: "Forbidden" };
   }
   return { ok: true as const, lease };
+}
+
+async function getLeaseEntityForLandlord(leaseId: string, landlordId: string) {
+  const firestoreResult = await getLeaseForLandlord(leaseId, landlordId);
+  if (firestoreResult.ok) {
+    return { ok: true as const, source: "firestore" as const, lease: firestoreResult.lease };
+  }
+
+  if (firestoreResult.status === 403) {
+    return firestoreResult;
+  }
+
+  const memoryLease = leaseService.getById(leaseId);
+  if (!memoryLease) {
+    return firestoreResult;
+  }
+  return { ok: true as const, source: "memory" as const, lease: memoryLease as any };
 }
 
 function toMillis(value: any): number {
@@ -148,6 +171,16 @@ async function loadLeaseDocumentUrlForLease(raw: any): Promise<string | null> {
     String(raw?.documentUrl || raw?.approvedDocumentUrl || raw?.documentRef || "").trim() || null;
   if (directUrl) return directUrl;
 
+  const referenceBucket = String(raw?.referenceDocument?.bucket || raw?.leaseDocument?.bucket || "").trim();
+  const referencePath = String(raw?.referenceDocument?.path || raw?.leaseDocument?.path || "").trim();
+  if (referenceBucket && referencePath) {
+    try {
+      return await getSignedDownloadUrl({ bucket: referenceBucket, path: referencePath, expiresMinutes: 30 });
+    } catch {
+      return null;
+    }
+  }
+
   const draftId = String(raw?.sourceDraftId || "").trim();
   if (!draftId) return null;
 
@@ -166,6 +199,93 @@ async function loadLeaseDocumentUrlForLease(raw: any): Promise<string | null> {
   } catch {
     return null;
   }
+}
+
+async function loadUnitLeaseDocumentForResponse(raw: any) {
+  const leaseDocument = raw?.leaseDocument;
+  if (!leaseDocument || typeof leaseDocument !== "object") return raw;
+  const bucket = String(leaseDocument.bucket || "").trim();
+  const path = String(leaseDocument.path || "").trim();
+  if (!bucket || !path) return raw;
+  try {
+    const url = await getSignedDownloadUrl({ bucket, path, expiresMinutes: 30 });
+    return {
+      ...raw,
+      leaseDocument: {
+        ...leaseDocument,
+        url,
+      },
+    };
+  } catch {
+    return raw;
+  }
+}
+
+async function enrichLeaseRow(raw: any) {
+  const lease = normalizeLeaseRow(raw.id, raw);
+  const propertyId = String(lease.propertyId || "").trim();
+  const tenantId =
+    String(lease.primaryTenantId || lease.tenantId || lease.tenantIds?.[0] || "").trim() || null;
+
+  const [propertySnap, tenantSnap, documentUrl] = await Promise.all([
+    propertyId ? db.collection("properties").doc(propertyId).get().catch(() => null) : Promise.resolve(null),
+    tenantId ? db.collection("tenants").doc(tenantId).get().catch(() => null) : Promise.resolve(null),
+    loadLeaseDocumentUrlForLease(raw),
+  ]);
+
+  const propertyName =
+    propertySnap?.exists
+      ? String(propertySnap.data()?.name || propertySnap.data()?.addressLine1 || "Property").trim() || "Property"
+      : "Property";
+  const tenantName =
+    tenantSnap?.exists
+      ? String(tenantSnap.data()?.fullName || tenantSnap.data()?.name || "").trim() || null
+      : null;
+  const tenantEmail =
+    tenantSnap?.exists ? String(tenantSnap.data()?.email || "").trim() || null : null;
+
+  return {
+    ...lease,
+    propertyName,
+    tenantName,
+    tenantEmail,
+    documentUrl,
+    archivedAt: raw?.archivedAt || null,
+    archivedByUserId: raw?.archivedByUserId || null,
+    isArchived: Boolean(raw?.archivedAt),
+  };
+}
+
+async function listLandlordLeaseRows(landlordId: string, opts?: { archived?: boolean | null }) {
+  const collectionRef: any = (db as any).collection("leases");
+  if (!collectionRef || typeof collectionRef.where !== "function") {
+    return [];
+  }
+
+  const snap = await collectionRef.where("landlordId", "==", landlordId).get();
+  const rows = (snap.docs || []).map((doc: any) => ({ id: doc.id, ...(doc.data() as any) }));
+  const archivedFlag = opts?.archived;
+  const filtered = rows.filter((row: any) => {
+    const isArchived = Boolean(row?.archivedAt);
+    if (archivedFlag === true) return isArchived;
+    if (archivedFlag === false) return !isArchived && isCurrentLeaseStatus(row?.status);
+    return true;
+  });
+
+  const leases = await Promise.all(filtered.map((row: any) => enrichLeaseRow(row)));
+  return mergeLeaseRows(leases);
+}
+
+async function listLeaseNotes(leaseId: string, landlordId: string) {
+  const notesRef: any = (db as any).collection(LEASE_NOTES_COLLECTION);
+  if (!notesRef || typeof notesRef.where !== "function") return [];
+  const snap = await notesRef
+    .where("landlordId", "==", landlordId)
+    .where("leaseId", "==", leaseId)
+    .get();
+  return (snap.docs || [])
+    .map((doc: any) => ({ id: doc.id, ...(doc.data() as any) }))
+    .sort((a: any, b: any) => toMillis(b?.createdAt) - toMillis(a?.createdAt));
 }
 
 
@@ -217,16 +337,24 @@ async function assertNoConflictingActiveAgreement(input: {
 }
 
 async function loadLedgerEntries(leaseId: string, landlordId: string, from?: string | null, to?: string | null) {
-  let query: FirebaseFirestore.Query = db
+  const snap = await db
     .collection(LEDGER_COLLECTION)
     .where("landlordId", "==", landlordId)
-    .where("leaseId", "==", leaseId);
-
-  if (from) query = query.where("effectiveDate", ">=", from);
-  if (to) query = query.where("effectiveDate", "<=", to);
-  query = query.orderBy("effectiveDate", "asc").orderBy("createdAt", "asc");
-  const snap = await query.get();
-  return snap.docs.map((doc) => ({ id: doc.id, ...(doc.data() as any) }));
+    .where("leaseId", "==", leaseId)
+    .get();
+  return snap.docs
+    .map((doc) => ({ id: doc.id, ...(doc.data() as any) }))
+    .filter((entry: any) => {
+      const effectiveDate = String(entry?.effectiveDate || "").trim();
+      if (from && effectiveDate && effectiveDate < from) return false;
+      if (to && effectiveDate && effectiveDate > to) return false;
+      return true;
+    })
+    .sort((a: any, b: any) => {
+      const dateDiff = String(a?.effectiveDate || "").localeCompare(String(b?.effectiveDate || ""));
+      if (dateDiff !== 0) return dateDiff;
+      return toMillis(a?.createdAt) - toMillis(b?.createdAt);
+    });
 }
 
 async function enforceLeaseCapability(req: any, res: Response): Promise<boolean> {
@@ -253,75 +381,250 @@ router.get("/active", requireLandlord, async (req: any, res: Response) => {
     if (!(await enforceLeaseCapability(req, res))) return;
     const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
     if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
+    const leases = await listLandlordLeaseRows(landlordId, { archived: false });
+    return res.status(200).json({ ok: true, leases });
+  } catch (err) {
+    console.error("[GET /api/leases/active] error", err);
+    return res.status(500).json({ ok: false, error: "Failed to load active leases" });
+  }
+});
 
-    const collectionRef: any = (db as any).collection("leases");
-    if (!collectionRef || typeof collectionRef.where !== "function") {
-      return res.status(200).json({ ok: true, leases: [] });
-    }
+router.get("/archived", requireLandlord, async (req: any, res: Response) => {
+  try {
+    if (!(await enforceLeaseCapability(req, res))) return;
+    const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
+    if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
+    const leases = await listLandlordLeaseRows(landlordId, { archived: true });
+    return res.status(200).json({ ok: true, leases });
+  } catch (err) {
+    console.error("[GET /api/leases/archived] error", err);
+    return res.status(500).json({ ok: false, error: "Failed to load archived leases" });
+  }
+});
 
-    const snap = await collectionRef.where("landlordId", "==", landlordId).get();
-    const rawLeases = (snap.docs || [])
-      .map((doc: any) => ({ id: doc.id, ...(doc.data() as any) }))
-      .filter((lease: any) => isCurrentLeaseStatus(lease?.status));
+router.get("/reconciliation-candidates", requireLandlord, async (req: any, res: Response) => {
+  try {
+    if (!(await enforceLeaseCapability(req, res))) return;
+    const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
+    if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
 
-    const propertyIds: string[] = Array.from(
-      new Set(rawLeases.map((lease: any) => String(lease?.propertyId || "").trim()).filter(Boolean))
-    );
-    const tenantIds: string[] = Array.from(
-      new Set(
-        rawLeases.flatMap((lease: any) =>
-          Array.isArray(lease?.tenantIds)
-            ? lease.tenantIds.map((value: any) => String(value || "").trim()).filter(Boolean)
-            : [String(lease?.tenantId || lease?.primaryTenantId || "").trim()].filter(Boolean)
-        )
-      )
-    );
-
-    const [propertyDocs, tenantDocs] = await Promise.all([
-      Promise.all(propertyIds.map((propertyId) => db.collection("properties").doc(propertyId).get().catch(() => null))),
-      Promise.all(tenantIds.map((tenantId) => db.collection("tenants").doc(tenantId).get().catch(() => null))),
+    const [unitsSnap, leasesSnap, propertiesSnap] = await Promise.all([
+      db.collection("units").where("landlordId", "==", landlordId).get(),
+      db.collection("leases").where("landlordId", "==", landlordId).get().catch(() => ({ docs: [] } as any)),
+      db.collection("properties").where("landlordId", "==", landlordId).get().catch(() => ({ docs: [] } as any)),
     ]);
 
-    const propertyNameById = new Map(
-      propertyDocs
-        .filter((doc: any) => doc?.exists)
-        .map((doc: any) => [
-          doc.id,
-          String(doc.data()?.name || doc.data()?.addressLine1 || "Property").trim() || "Property",
-        ])
-    );
-    const tenantById = new Map(
-      tenantDocs
-        .filter((doc: any) => doc?.exists)
-        .map((doc: any) => [
-          doc.id,
-          {
-            name: String(doc.data()?.fullName || doc.data()?.name || "").trim() || null,
-            email: String(doc.data()?.email || "").trim() || null,
-          },
-        ])
+    const currentLeaseKeys = new Set<string>();
+    for (const doc of leasesSnap.docs || []) {
+      const raw = doc.data() as any;
+      if (!isCurrentLeaseStatus(raw?.status)) continue;
+      const propertyId = String(raw?.propertyId || "").trim();
+      const unitId = String(raw?.unitId || "").trim();
+      const unitNumber = String(raw?.unitNumber || raw?.unit || "").trim();
+      if (propertyId && unitId) currentLeaseKeys.add(`${propertyId}::id::${unitId}`);
+      if (propertyId && unitNumber) currentLeaseKeys.add(`${propertyId}::num::${unitNumber}`);
+    }
+
+    const propertyNames = new Map(
+      (propertiesSnap.docs || []).map((doc: any) => [
+        doc.id,
+        String(doc.data()?.name || doc.data()?.addressLine1 || "Property").trim() || "Property",
+      ])
     );
 
-    const leases = await Promise.all(
-      rawLeases.map(async (raw: any) => {
-        const lease = normalizeLeaseRow(raw.id, raw);
-        const tenantId =
-          String(lease.primaryTenantId || lease.tenantId || lease.tenantIds?.[0] || "").trim() || null;
-        const tenant = tenantId ? tenantById.get(tenantId) || null : null;
+    const candidates = await Promise.all(
+      (unitsSnap.docs || []).map(async (doc: any) => {
+        const raw = doc.data() as any;
+        const propertyId = String(raw?.propertyId || "").trim();
+        const unitId = String(doc.id || raw?.id || raw?.unitId || "").trim();
+        const unitNumber = String(raw?.unitNumber || raw?.label || "").trim();
+        const status = normalizeStatus(raw?.occupancyStatus || raw?.status);
+        if (status !== "occupied") return null;
+        if (!propertyId || !unitId) return null;
+        if (
+          currentLeaseKeys.has(`${propertyId}::id::${unitId}`) ||
+          (unitNumber && currentLeaseKeys.has(`${propertyId}::num::${unitNumber}`))
+        ) {
+          return null;
+        }
+
+        const leaseDocument = await loadUnitLeaseDocumentForResponse(raw);
+        const occupantName = String(raw?.occupantName || "").trim() || null;
+        const rent = Number(raw?.rent || 0);
+        const blockingReasons: string[] = [];
+        if (!occupantName) blockingReasons.push("occupant_name_required");
+        if (!Number.isFinite(rent) || rent <= 0) blockingReasons.push("rent_required");
+
         return {
-          ...lease,
-          propertyName: propertyNameById.get(lease.propertyId) || "Property",
-          tenantName: tenant?.name || null,
-          tenantEmail: tenant?.email || null,
-          documentUrl: await loadLeaseDocumentUrlForLease(raw),
+          id: unitId,
+          unitId,
+          propertyId,
+          propertyName: propertyNames.get(propertyId) || "Property",
+          unitNumber: unitNumber || "Unit",
+          occupantName,
+          leaseEndDate: String(raw?.leaseEndDate || "").trim() || null,
+          monthlyRent: Number.isFinite(rent) ? rent : 0,
+          leaseDocument: (leaseDocument as any)?.leaseDocument || raw?.leaseDocument || null,
+          canConvert: blockingReasons.length === 0,
+          blockingReasons,
         };
       })
     );
 
-    return res.status(200).json({ ok: true, leases: mergeLeaseRows(leases) });
+    return res.status(200).json({
+      ok: true,
+      candidates: candidates.filter(Boolean).sort((a: any, b: any) => {
+        const propertyDiff = String(a?.propertyName || "").localeCompare(String(b?.propertyName || ""));
+        if (propertyDiff !== 0) return propertyDiff;
+        return String(a?.unitNumber || "").localeCompare(String(b?.unitNumber || ""));
+      }),
+    });
   } catch (err) {
-    console.error("[GET /api/leases/active] error", err);
-    return res.status(500).json({ ok: false, error: "Failed to load active leases" });
+    console.error("[GET /api/leases/reconciliation-candidates] error", err);
+    return res.status(500).json({ ok: false, error: "Failed to load lease reconciliation candidates" });
+  }
+});
+
+router.post("/reconciliation-candidates/:unitId/convert", requireLandlord, async (req: any, res: Response) => {
+  try {
+    if (!(await enforceLeaseCapability(req, res))) return;
+    const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
+    if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
+
+    const unitId = String(req.params?.unitId || "").trim();
+    if (!unitId) return res.status(400).json({ ok: false, error: "unit_id_required" });
+    const unitSnap = await db.collection("units").doc(unitId).get();
+    if (!unitSnap.exists) return res.status(404).json({ ok: false, error: "unit_not_found" });
+    const unit = unitSnap.data() as any;
+    if (String(unit?.landlordId || "").trim() !== landlordId) {
+      return res.status(403).json({ ok: false, error: "forbidden" });
+    }
+
+    const propertyId = String(unit?.propertyId || "").trim();
+    const unitNumber = String(unit?.unitNumber || unit?.label || "").trim();
+    if (!propertyId || !unitNumber) {
+      return res.status(400).json({ ok: false, error: "unit_context_incomplete" });
+    }
+    const occupancyStatus = normalizeStatus(unit?.occupancyStatus || unit?.status);
+    if (occupancyStatus !== "occupied") {
+      return res.status(400).json({ ok: false, error: "unit_not_occupied" });
+    }
+
+    const conflictingLeases = await db.collection("leases").where("landlordId", "==", landlordId).where("propertyId", "==", propertyId).get();
+    const hasCurrentLease = (conflictingLeases.docs || []).some((doc: any) => {
+      const raw = doc.data() as any;
+      if (!isCurrentLeaseStatus(raw?.status)) return false;
+      return (
+        String(raw?.unitId || "").trim() === unitId ||
+        String(raw?.unitNumber || raw?.unit || "").trim() === unitNumber
+      );
+    });
+    if (hasCurrentLease) {
+      return res.status(409).json({ ok: false, error: "current_lease_already_exists" });
+    }
+
+    const occupantName = String(req.body?.occupantName || unit?.occupantName || "").trim();
+    const tenantEmail = String(req.body?.tenantEmail || "").trim() || null;
+    const tenantPhone = String(req.body?.tenantPhone || "").trim() || null;
+    const startDate = toIsoDate(req.body?.startDate);
+    const endDate = toIsoDate(req.body?.endDate);
+    const monthlyRent = Number(req.body?.monthlyRent ?? unit?.rent);
+
+    if (!occupantName) return res.status(400).json({ ok: false, error: "occupant_name_required" });
+    if (!startDate) return res.status(400).json({ ok: false, error: "start_date_required" });
+    if (!Number.isFinite(monthlyRent) || monthlyRent <= 0) {
+      return res.status(400).json({ ok: false, error: "monthly_rent_required" });
+    }
+
+    const propertySnap = await db.collection("properties").doc(propertyId).get();
+    const property = propertySnap.data() as any;
+    const propertyName = String(property?.name || property?.addressLine1 || "Property").trim() || "Property";
+    const tenantRef = db.collection("tenants").doc();
+    const nowIso = new Date().toISOString();
+    await tenantRef.set(
+      {
+        landlordId,
+        fullName: occupantName,
+        email: tenantEmail,
+        phone: tenantPhone,
+        propertyId,
+        propertyName,
+        unitId,
+        unit: unitNumber,
+        currentLeaseId: null,
+        leaseStart: startDate,
+        leaseEnd: endDate || null,
+        monthlyRent,
+        status: "Current",
+        createdAt: nowIso,
+        updatedAt: nowIso,
+        source: "occupied_unit_reconciliation",
+      },
+      { merge: false }
+    );
+
+    const riskSnapshot = await computeLeaseRiskSnapshot({
+      landlordId,
+      propertyId,
+      unitId,
+      tenantIds: [tenantRef.id],
+      monthlyRent,
+    });
+    const riskFields = buildLeaseRiskPersistenceFields({}, riskSnapshot, {
+      trigger: "lease_create",
+      source: "occupied_unit_reconciliation",
+    });
+
+    const lease = leaseService.create({
+      tenantId: tenantRef.id,
+      tenantIds: [tenantRef.id],
+      primaryTenantId: tenantRef.id,
+      propertyId,
+      unitNumber,
+      monthlyRent,
+      startDate,
+      endDate,
+      risk: riskFields.risk,
+      riskTimeline: riskFields.riskTimeline,
+    });
+
+    const firestoreLeaseRecord = {
+      landlordId,
+      tenantId: tenantRef.id,
+      tenantIds: [tenantRef.id],
+      primaryTenantId: tenantRef.id,
+      propertyId,
+      unitId,
+      unitNumber,
+      monthlyRent,
+      startDate,
+      endDate: endDate || null,
+      automationEnabled: lease.automationEnabled ?? true,
+      renewalStatus: lease.renewalStatus ?? "unknown",
+      status: lease.status,
+      risk: lease.risk ?? null,
+      riskScore: lease.riskScore ?? lease.risk?.score ?? null,
+      riskGrade: lease.riskGrade ?? lease.risk?.grade ?? null,
+      riskConfidence: lease.riskConfidence ?? lease.risk?.confidence ?? null,
+      riskTimeline: Array.isArray((lease as any).riskTimeline) ? (lease as any).riskTimeline : [],
+      createdAt: lease.createdAt,
+      updatedAt: lease.updatedAt,
+      source: "occupied_unit_reconciliation",
+      sourceUnitId: unitId,
+      referenceDocument: unit?.leaseDocument || null,
+    };
+    await db.collection("leases").doc(lease.id).set(firestoreLeaseRecord, { merge: false });
+    await tenantRef.set({ currentLeaseId: lease.id, updatedAt: new Date().toISOString() }, { merge: true });
+
+    const enrichedLease = await enrichLeaseRow({ id: lease.id, ...firestoreLeaseRecord });
+    return res.status(201).json({
+      ok: true,
+      lease: enrichedLease,
+      tenant: { id: tenantRef.id, fullName: occupantName, email: tenantEmail, phone: tenantPhone },
+    });
+  } catch (err) {
+    console.error("[POST /api/leases/reconciliation-candidates/:unitId/convert] error", err);
+    return res.status(500).json({ ok: false, error: "Failed to convert occupied unit to lease" });
   }
 });
 
@@ -737,12 +1040,128 @@ router.get("/:id/automation/tasks", requireLandlord, (req: any, res: Response) =
   return res.status(200).json({ ok: true, tasks });
 });
 
-router.get("/:id", (req: Request, res: Response) => {
-  const lease = leaseService.getById(req.params.id);
-  if (!lease) {
-    return res.status(404).json({ error: "Lease not found" });
+router.get("/:leaseId/notes", requireLandlord, async (req: any, res: Response) => {
+  try {
+    if (!(await enforceLeaseCapability(req, res))) return;
+    const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
+    const leaseId = String(req.params?.leaseId || "").trim();
+    if (!leaseId) return res.status(400).json({ ok: false, error: "leaseId is required" });
+    const leaseCheck = await getLeaseEntityForLandlord(leaseId, landlordId);
+    if (!leaseCheck.ok) return res.status(leaseCheck.status).json({ ok: false, error: leaseCheck.error });
+    const notes = await listLeaseNotes(leaseId, landlordId);
+    return res.status(200).json({ ok: true, notes });
+  } catch (err) {
+    console.error("[GET /api/leases/:leaseId/notes] error", err);
+    return res.status(500).json({ ok: false, error: "Failed to load lease notes" });
   }
-  res.json({ lease });
+});
+
+router.post("/:leaseId/notes", requireLandlord, async (req: any, res: Response) => {
+  try {
+    if (!(await enforceLeaseCapability(req, res))) return;
+    const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
+    const actorUserId = String(req.user?.id || req.user?.email || landlordId).trim();
+    const leaseId = String(req.params?.leaseId || "").trim();
+    if (!leaseId) return res.status(400).json({ ok: false, error: "leaseId is required" });
+    const leaseCheck = await getLeaseEntityForLandlord(leaseId, landlordId);
+    if (!leaseCheck.ok) return res.status(leaseCheck.status).json({ ok: false, error: leaseCheck.error });
+    const note = String(req.body?.note || "").trim();
+    if (!note) return res.status(400).json({ ok: false, error: "note_required" });
+    const noteRef = db.collection(LEASE_NOTES_COLLECTION).doc();
+    const record = {
+      id: noteRef.id,
+      leaseId,
+      landlordId,
+      note: note.slice(0, 5000),
+      createdAt: Date.now(),
+      createdBy: actorUserId || null,
+    };
+    await noteRef.set(record, { merge: false });
+    return res.status(201).json({ ok: true, note: record });
+  } catch (err) {
+    console.error("[POST /api/leases/:leaseId/notes] error", err);
+    return res.status(500).json({ ok: false, error: "Failed to save lease note" });
+  }
+});
+
+router.post("/:leaseId/archive", requireLandlord, async (req: any, res: Response) => {
+  try {
+    if (!(await enforceLeaseCapability(req, res))) return;
+    const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
+    const actorUserId = String(req.user?.id || req.user?.email || landlordId).trim() || null;
+    const leaseId = String(req.params?.leaseId || "").trim();
+    if (!leaseId) return res.status(400).json({ ok: false, error: "leaseId is required" });
+    const leaseCheck = await getLeaseEntityForLandlord(leaseId, landlordId);
+    if (!leaseCheck.ok) return res.status(leaseCheck.status).json({ ok: false, error: leaseCheck.error });
+    if (leaseCheck.source === "firestore") {
+      await db.collection("leases").doc(leaseId).set(
+        {
+          archivedAt: new Date().toISOString(),
+          archivedByUserId: actorUserId,
+          restoredAt: null,
+          restoredByUserId: null,
+          updatedAt: new Date().toISOString(),
+        },
+        { merge: true }
+      );
+      const refreshed = await getLeaseEntityForLandlord(leaseId, landlordId);
+      if (!refreshed.ok) return res.status(refreshed.status).json({ ok: false, error: refreshed.error });
+      return res.status(200).json({ ok: true, lease: await enrichLeaseRow({ id: leaseId, ...(refreshed.lease as any) }) });
+    }
+    return res.status(400).json({ ok: false, error: "archive_requires_firestore_lease" });
+  } catch (err) {
+    console.error("[POST /api/leases/:leaseId/archive] error", err);
+    return res.status(500).json({ ok: false, error: "Failed to archive lease" });
+  }
+});
+
+router.post("/:leaseId/restore", requireLandlord, async (req: any, res: Response) => {
+  try {
+    if (!(await enforceLeaseCapability(req, res))) return;
+    const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
+    const actorUserId = String(req.user?.id || req.user?.email || landlordId).trim() || null;
+    const leaseId = String(req.params?.leaseId || "").trim();
+    if (!leaseId) return res.status(400).json({ ok: false, error: "leaseId is required" });
+    const leaseCheck = await getLeaseEntityForLandlord(leaseId, landlordId);
+    if (!leaseCheck.ok) return res.status(leaseCheck.status).json({ ok: false, error: leaseCheck.error });
+    if (leaseCheck.source === "firestore") {
+      await db.collection("leases").doc(leaseId).set(
+        {
+          archivedAt: null,
+          archivedByUserId: null,
+          restoredAt: new Date().toISOString(),
+          restoredByUserId: actorUserId,
+          updatedAt: new Date().toISOString(),
+        },
+        { merge: true }
+      );
+      const refreshed = await getLeaseEntityForLandlord(leaseId, landlordId);
+      if (!refreshed.ok) return res.status(refreshed.status).json({ ok: false, error: refreshed.error });
+      return res.status(200).json({ ok: true, lease: await enrichLeaseRow({ id: leaseId, ...(refreshed.lease as any) }) });
+    }
+    return res.status(400).json({ ok: false, error: "restore_requires_firestore_lease" });
+  } catch (err) {
+    console.error("[POST /api/leases/:leaseId/restore] error", err);
+    return res.status(500).json({ ok: false, error: "Failed to restore lease" });
+  }
+});
+
+router.get("/:id", requireLandlord, async (req: any, res: Response) => {
+  try {
+    if (!(await enforceLeaseCapability(req, res))) return;
+    const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
+    const result = await getLeaseEntityForLandlord(String(req.params?.id || "").trim(), landlordId);
+    if (!result.ok) {
+      return res.status(result.status).json({ error: result.error });
+    }
+    if (result.source === "firestore") {
+      return res.json({ lease: await enrichLeaseRow({ id: String(req.params?.id || "").trim(), ...(result.lease as any) }) });
+    }
+    return res.json({ lease: result.lease });
+  } catch (err) {
+    console.error("[GET /api/leases/:id] error", err);
+    return res.status(500).json({ error: "Failed to load lease" });
+  }
 });
 
 router.get("/tenant/:tenantId", requireLandlord, async (req: any, res: Response) => {
@@ -951,10 +1370,32 @@ router.post("/", async (req: Request, res: Response) => {
   }
 });
 
-router.put("/:id", async (req: Request, res: Response) => {
+router.put("/:id", async (req: any, res: Response) => {
   try {
     if (!(await enforceLeaseCapability(req, res))) return;
     const payload = req.body as UpdateLeasePayload;
+    const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
+    const leaseResult = await getLeaseEntityForLandlord(String(req.params?.id || "").trim(), landlordId);
+    if (!leaseResult.ok) {
+      return res.status(leaseResult.status).json({ error: leaseResult.error });
+    }
+
+    if (leaseResult.source === "firestore") {
+      const next = {
+        ...(payload.monthlyRent !== undefined ? { monthlyRent: payload.monthlyRent } : {}),
+        ...(payload.startDate !== undefined ? { startDate: payload.startDate } : {}),
+        ...(payload.endDate !== undefined ? { endDate: payload.endDate ?? null } : {}),
+        ...(payload.automationEnabled !== undefined ? { automationEnabled: payload.automationEnabled } : {}),
+        ...(payload.renewalStatus !== undefined ? { renewalStatus: payload.renewalStatus } : {}),
+        ...(payload.status !== undefined ? { status: payload.status } : {}),
+        updatedAt: new Date().toISOString(),
+      };
+      await db.collection("leases").doc(String(req.params?.id || "").trim()).set(next, { merge: true });
+      const refreshed = await getLeaseEntityForLandlord(String(req.params?.id || "").trim(), landlordId);
+      if (!refreshed.ok) return res.status(refreshed.status).json({ error: refreshed.error });
+      return res.json({ lease: await enrichLeaseRow({ id: String(req.params?.id || "").trim(), ...(refreshed.lease as any) }) });
+    }
+
     const lease = leaseService.update(req.params.id, payload);
     if (!lease) {
       return res.status(404).json({ error: "Lease not found" });
@@ -966,10 +1407,28 @@ router.put("/:id", async (req: Request, res: Response) => {
   }
 });
 
-router.post("/:id/end", async (req: Request, res: Response) => {
+router.post("/:id/end", async (req: any, res: Response) => {
   try {
     if (!(await enforceLeaseCapability(req, res))) return;
     const endDate: string = req.body?.endDate || new Date().toISOString();
+    const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
+    const leaseResult = await getLeaseEntityForLandlord(String(req.params?.id || "").trim(), landlordId);
+    if (!leaseResult.ok) {
+      return res.status(leaseResult.status).json({ error: leaseResult.error });
+    }
+    if (leaseResult.source === "firestore") {
+      await db.collection("leases").doc(String(req.params?.id || "").trim()).set(
+        {
+          status: "ended",
+          endDate,
+          updatedAt: new Date().toISOString(),
+        },
+        { merge: true }
+      );
+      const refreshed = await getLeaseEntityForLandlord(String(req.params?.id || "").trim(), landlordId);
+      if (!refreshed.ok) return res.status(refreshed.status).json({ error: refreshed.error });
+      return res.json({ lease: await enrichLeaseRow({ id: String(req.params?.id || "").trim(), ...(refreshed.lease as any) }) });
+    }
     const lease = leaseService.endLease(req.params.id, endDate);
     if (!lease) {
       return res.status(404).json({ error: "Lease not found" });
@@ -989,7 +1448,7 @@ router.get("/:leaseId/ledger", async (req: any, res: Response) => {
     const leaseId = String(req.params?.leaseId || "").trim();
     if (!leaseId) return res.status(400).json({ ok: false, error: "leaseId is required" });
 
-    const leaseCheck = await getLeaseForLandlord(leaseId, landlordId);
+    const leaseCheck = await getLeaseEntityForLandlord(leaseId, landlordId);
     if (!leaseCheck.ok) return res.status(leaseCheck.status).json({ ok: false, error: leaseCheck.error });
 
     const from = toIsoDate(req.query?.from) || null;
@@ -1049,7 +1508,7 @@ router.post("/:leaseId/ledger/charge", async (req: any, res: Response) => {
 
     const leaseId = String(req.params?.leaseId || "").trim();
     if (!leaseId) return res.status(400).json({ ok: false, error: "leaseId is required" });
-    const leaseCheck = await getLeaseForLandlord(leaseId, landlordId);
+    const leaseCheck = await getLeaseEntityForLandlord(leaseId, landlordId);
     if (!leaseCheck.ok) return res.status(leaseCheck.status).json({ ok: false, error: leaseCheck.error });
 
     const amountCents = cents(req.body?.amountCents);
@@ -1095,7 +1554,7 @@ router.post("/:leaseId/ledger/payment", async (req: any, res: Response) => {
 
     const leaseId = String(req.params?.leaseId || "").trim();
     if (!leaseId) return res.status(400).json({ ok: false, error: "leaseId is required" });
-    const leaseCheck = await getLeaseForLandlord(leaseId, landlordId);
+    const leaseCheck = await getLeaseEntityForLandlord(leaseId, landlordId);
     if (!leaseCheck.ok) return res.status(leaseCheck.status).json({ ok: false, error: leaseCheck.error });
 
     const amountCents = cents(req.body?.amountCents);
@@ -1142,7 +1601,7 @@ router.get("/:leaseId/ledger/export.csv", async (req: any, res: Response) => {
 
     const leaseId = String(req.params?.leaseId || "").trim();
     if (!leaseId) return res.status(400).json({ ok: false, error: "leaseId is required" });
-    const leaseCheck = await getLeaseForLandlord(leaseId, landlordId);
+    const leaseCheck = await getLeaseEntityForLandlord(leaseId, landlordId);
     if (!leaseCheck.ok) return res.status(leaseCheck.status).json({ ok: false, error: leaseCheck.error });
 
     const from = toIsoDate(req.query?.from) || null;

--- a/rentchain-frontend/src/api/leasesApi.ts
+++ b/rentchain-frontend/src/api/leasesApi.ts
@@ -49,6 +49,41 @@ export interface LandlordActiveLease extends Lease {
   tenantName?: string | null;
   tenantEmail?: string | null;
   documentUrl?: string | null;
+  archivedAt?: string | null;
+  archivedByUserId?: string | null;
+  isArchived?: boolean;
+}
+
+export interface LeaseReconciliationCandidate {
+  id: string;
+  unitId: string;
+  propertyId: string;
+  propertyName: string;
+  unitNumber: string;
+  occupantName?: string | null;
+  leaseEndDate?: string | null;
+  monthlyRent: number;
+  leaseDocument?: {
+    fileName?: string | null;
+    url?: string | null;
+  } | null;
+  canConvert: boolean;
+  blockingReasons: string[];
+}
+
+export interface LeaseNote {
+  id: string;
+  leaseId: string;
+  landlordId: string;
+  note: string;
+  createdAt: number | string;
+  createdBy?: string | null;
+}
+
+export interface PropertyLeaseDiagnostic {
+  code?: string;
+  message?: string;
+  severity?: string;
 }
 
 export interface CreateLeasePayload {
@@ -82,14 +117,72 @@ export async function getLeasesForTenant(
 
 export async function getLeasesForProperty(
   propertyId: string
-): Promise<{ leases: Lease[]; diagnostics?: any; credibilitySummary?: PropertyCredibilitySummary | null }> {
-  return apiJson<{ leases: Lease[]; diagnostics?: any; credibilitySummary?: PropertyCredibilitySummary | null }>(
+): Promise<{ leases: Lease[]; diagnostics?: PropertyLeaseDiagnostic[]; credibilitySummary?: PropertyCredibilitySummary | null }> {
+  return apiJson<{ leases: Lease[]; diagnostics?: PropertyLeaseDiagnostic[]; credibilitySummary?: PropertyCredibilitySummary | null }>(
     `/leases/property/${encodeURIComponent(propertyId)}`
   );
 }
 
 export async function getActiveLeasesForLandlord(): Promise<{ leases: LandlordActiveLease[] }> {
   return apiJson<{ leases: LandlordActiveLease[] }>("/leases/active");
+}
+
+export async function getArchivedLeasesForLandlord(): Promise<{ leases: LandlordActiveLease[] }> {
+  return apiJson<{ leases: LandlordActiveLease[] }>("/leases/archived");
+}
+
+export async function getLeaseReconciliationCandidates(): Promise<{ candidates: LeaseReconciliationCandidate[] }> {
+  return apiJson<{ candidates: LeaseReconciliationCandidate[] }>("/leases/reconciliation-candidates");
+}
+
+export async function convertUnitReferenceToLease(
+  unitId: string,
+  payload: {
+    occupantName?: string;
+    tenantEmail?: string;
+    tenantPhone?: string;
+    startDate: string;
+    endDate?: string | null;
+    monthlyRent?: number;
+  }
+): Promise<{ ok: true; lease: LandlordActiveLease; tenant: { id: string; fullName: string; email?: string | null; phone?: string | null } }> {
+  return apiJson(`/leases/reconciliation-candidates/${encodeURIComponent(unitId)}/convert`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function getLeaseById(id: string): Promise<{ lease: LandlordActiveLease }> {
+  return apiJson<{ lease: LandlordActiveLease }>(`/leases/${encodeURIComponent(id)}`);
+}
+
+export async function getLeaseNotes(id: string): Promise<{ ok: true; notes: LeaseNote[] }> {
+  return apiJson<{ ok: true; notes: LeaseNote[] }>(`/leases/${encodeURIComponent(id)}/notes`);
+}
+
+export async function createLeaseNote(id: string, note: string): Promise<{ ok: true; note: LeaseNote }> {
+  return apiJson<{ ok: true; note: LeaseNote }>(`/leases/${encodeURIComponent(id)}/notes`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ note }),
+  });
+}
+
+export async function archiveLeaseRecord(id: string): Promise<{ ok: true; lease: LandlordActiveLease }> {
+  return apiJson<{ ok: true; lease: LandlordActiveLease }>(`/leases/${encodeURIComponent(id)}/archive`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "{}",
+  });
+}
+
+export async function restoreLeaseRecord(id: string): Promise<{ ok: true; lease: LandlordActiveLease }> {
+  return apiJson<{ ok: true; lease: LandlordActiveLease }>(`/leases/${encodeURIComponent(id)}/restore`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "{}",
+  });
 }
 
 export async function createLease(

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
@@ -5,10 +5,20 @@ import LandlordActiveLeasesPage from "./LandlordActiveLeasesPage";
 
 const mocks = vi.hoisted(() => ({
   getActiveLeasesForLandlord: vi.fn(),
+  getArchivedLeasesForLandlord: vi.fn(),
+  getLeaseReconciliationCandidates: vi.fn(),
+  convertUnitReferenceToLease: vi.fn(),
+  archiveLeaseRecord: vi.fn(),
+  restoreLeaseRecord: vi.fn(),
 }));
 
 vi.mock("@/api/leasesApi", () => ({
   getActiveLeasesForLandlord: mocks.getActiveLeasesForLandlord,
+  getArchivedLeasesForLandlord: mocks.getArchivedLeasesForLandlord,
+  getLeaseReconciliationCandidates: mocks.getLeaseReconciliationCandidates,
+  convertUnitReferenceToLease: mocks.convertUnitReferenceToLease,
+  archiveLeaseRecord: mocks.archiveLeaseRecord,
+  restoreLeaseRecord: mocks.restoreLeaseRecord,
 }));
 
 describe("LandlordActiveLeasesPage", () => {
@@ -30,9 +40,38 @@ describe("LandlordActiveLeasesPage", () => {
         },
       ],
     });
+    mocks.getArchivedLeasesForLandlord.mockResolvedValue({ leases: [] });
+    mocks.getLeaseReconciliationCandidates.mockResolvedValue({
+      candidates: [
+        {
+          id: "unit-9",
+          unitId: "unit-9",
+          propertyId: "prop-9",
+          propertyName: "Dockside",
+          unitNumber: "9",
+          occupantName: "Recovered Tenant",
+          monthlyRent: 2100,
+          leaseEndDate: "2026-12-31",
+          canConvert: true,
+          blockingReasons: [],
+          leaseDocument: {
+            fileName: "lease.pdf",
+            url: "https://example.com/unit-lease.pdf",
+          },
+        },
+      ],
+    });
+    mocks.convertUnitReferenceToLease.mockResolvedValue({
+      ok: true,
+      lease: { id: "lease-9" },
+      tenant: { id: "tenant-9", fullName: "Recovered Tenant" },
+    });
+    mocks.archiveLeaseRecord.mockResolvedValue({ ok: true, lease: { id: "lease-1" } });
+    mocks.restoreLeaseRecord.mockResolvedValue({ ok: true, lease: { id: "lease-2" } });
+    vi.spyOn(window, "confirm").mockReturnValue(true);
   });
 
-  it("renders active leases with view, email, and save actions", async () => {
+  it("renders active leases with ledger, email, save, and archive actions", async () => {
     render(
       <MemoryRouter>
         <LandlordActiveLeasesPage />
@@ -46,17 +85,57 @@ describe("LandlordActiveLeasesPage", () => {
       expect.stringContaining("mailto:jane%40example.com")
     );
     expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Archive lease" }));
+    await waitFor(() => expect(mocks.archiveLeaseRecord).toHaveBeenCalledWith("lease-1"));
   });
 
-  it("renders an empty state when no active leases are available", async () => {
-    mocks.getActiveLeasesForLandlord.mockResolvedValue({ leases: [] });
-
+  it("shows reconciliation candidates and converts a reference into a lease", async () => {
     render(
       <MemoryRouter>
         <LandlordActiveLeasesPage />
       </MemoryRouter>
     );
 
-    expect(await screen.findByText(/No active leases were found/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Occupied units missing lease records/i)).toBeInTheDocument();
+    fireEvent.click(screen.getAllByRole("button", { name: "Convert unit 9 to lease" })[0]);
+    fireEvent.change(screen.getByLabelText("Start date"), { target: { value: "2026-04-01" } });
+    fireEvent.change(screen.getByLabelText("Monthly rent"), { target: { value: "2100" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create lease" }));
+
+    await waitFor(() =>
+      expect(mocks.convertUnitReferenceToLease).toHaveBeenCalledWith(
+        "unit-9",
+        expect.objectContaining({ startDate: "2026-04-01", monthlyRent: 2100 })
+      )
+    );
+  });
+
+  it("loads archived leases when archive view is selected", async () => {
+    mocks.getArchivedLeasesForLandlord.mockResolvedValue({
+      leases: [
+        {
+          id: "lease-2",
+          propertyId: "prop-2",
+          propertyName: "Archived Place",
+          unitNumber: "2B",
+          monthlyRent: 1200,
+          startDate: "2025-01-01",
+          endDate: "2025-12-31",
+          status: "ended",
+          archivedAt: "2026-04-01T00:00:00.000Z",
+          tenantName: "Past Tenant",
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/leases?view=archived"]}>
+        <LandlordActiveLeasesPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Archived Place")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Restore" }));
+    await waitFor(() => expect(mocks.restoreLeaseRecord).toHaveBeenCalledWith("lease-2"));
   });
 });

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
@@ -1,6 +1,15 @@
 import React from "react";
-import { Link } from "react-router-dom";
-import { getActiveLeasesForLandlord, type LandlordActiveLease } from "@/api/leasesApi";
+import { Link, useSearchParams } from "react-router-dom";
+import {
+  archiveLeaseRecord,
+  convertUnitReferenceToLease,
+  getActiveLeasesForLandlord,
+  getArchivedLeasesForLandlord,
+  getLeaseReconciliationCandidates,
+  restoreLeaseRecord,
+  type LandlordActiveLease,
+  type LeaseReconciliationCandidate,
+} from "@/api/leasesApi";
 
 function formatCurrency(value: number | null | undefined) {
   const amount = typeof value === "number" ? value : 0;
@@ -14,6 +23,16 @@ function formatDate(value: string | null | undefined) {
   return parsed.toLocaleDateString();
 }
 
+function prettyLeaseStatus(value: string | null | undefined) {
+  const normalized = String(value || "").trim().toLowerCase();
+  if (!normalized) return "Unknown";
+  if (normalized === "notice_pending") return "Renew letter needed";
+  if (normalized === "renewal_pending") return "Renewal pending";
+  if (normalized === "renewal_accepted") return "Renewing";
+  if (normalized === "move_out_pending") return "Quitting";
+  return normalized.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
 function downloadLeaseSummary(lease: LandlordActiveLease) {
   const text = [
     `Property: ${lease.propertyName || "Property"}`,
@@ -23,7 +42,7 @@ function downloadLeaseSummary(lease: LandlordActiveLease) {
     `Monthly rent: ${formatCurrency(lease.monthlyRent)}`,
     `Start date: ${lease.startDate || "—"}`,
     `End date: ${lease.endDate || "—"}`,
-    `Status: ${lease.status || "—"}`,
+    `Status: ${prettyLeaseStatus(lease.status)}`,
     `Lease document: ${lease.documentUrl || "Not available"}`,
   ].join("\n");
 
@@ -38,45 +57,218 @@ function downloadLeaseSummary(lease: LandlordActiveLease) {
   window.URL.revokeObjectURL(url);
 }
 
+function todayIso() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function errorMessage(error: unknown, fallback: string) {
+  if (error instanceof Error && error.message) return error.message;
+  return fallback;
+}
+
+function statusBadge(status: string | null | undefined) {
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        padding: "4px 8px",
+        borderRadius: 999,
+        background: "#eff6ff",
+        color: "#1d4ed8",
+        fontSize: 12,
+        fontWeight: 700,
+      }}
+    >
+      {prettyLeaseStatus(status)}
+    </span>
+  );
+}
+
 export default function LandlordActiveLeasesPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const view = searchParams.get("view") === "archived" ? "archived" : "active";
   const [leases, setLeases] = React.useState<LandlordActiveLease[]>([]);
+  const [candidates, setCandidates] = React.useState<LeaseReconciliationCandidate[]>([]);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
+  const [selectedCandidate, setSelectedCandidate] = React.useState<LeaseReconciliationCandidate | null>(null);
+  const [convertSaving, setConvertSaving] = React.useState(false);
+  const [occupantName, setOccupantName] = React.useState("");
+  const [tenantEmail, setTenantEmail] = React.useState("");
+  const [tenantPhone, setTenantPhone] = React.useState("");
+  const [startDate, setStartDate] = React.useState(todayIso());
+  const [endDate, setEndDate] = React.useState("");
+  const [monthlyRent, setMonthlyRent] = React.useState("");
+
+  const load = React.useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const [leaseResponse, candidateResponse] = await Promise.all([
+        view === "archived" ? getArchivedLeasesForLandlord() : getActiveLeasesForLandlord(),
+        view === "active" ? getLeaseReconciliationCandidates() : Promise.resolve({ candidates: [] }),
+      ]);
+      setLeases(Array.isArray(leaseResponse?.leases) ? leaseResponse.leases : []);
+      setCandidates(Array.isArray(candidateResponse?.candidates) ? candidateResponse.candidates : []);
+    } catch (err: unknown) {
+      setError(errorMessage(err, "Failed to load lease operations."));
+      setLeases([]);
+      setCandidates([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [view]);
 
   React.useEffect(() => {
-    let active = true;
-    const load = async () => {
-      try {
-        setLoading(true);
-        setError(null);
-        const response = await getActiveLeasesForLandlord();
-        if (!active) return;
-        setLeases(Array.isArray(response?.leases) ? response.leases : []);
-      } catch (err: any) {
-        if (!active) return;
-        setError(err?.message || "Failed to load active leases.");
-        setLeases([]);
-      } finally {
-        if (active) setLoading(false);
-      }
-    };
     void load();
-    return () => {
-      active = false;
-    };
-  }, []);
+  }, [load]);
+
+  React.useEffect(() => {
+    if (!selectedCandidate) return;
+    setOccupantName(String(selectedCandidate.occupantName || ""));
+    setTenantEmail("");
+    setTenantPhone("");
+    setStartDate(todayIso());
+    setEndDate(String(selectedCandidate.leaseEndDate || ""));
+    setMonthlyRent(String(selectedCandidate.monthlyRent || ""));
+  }, [selectedCandidate]);
+
+  async function handleArchive(lease: LandlordActiveLease) {
+    const confirmed = window.confirm(
+      "Archive this lease from the landlord lease workspace? You can restore it later from View archive."
+    );
+    if (!confirmed) return;
+    await archiveLeaseRecord(lease.id);
+    await load();
+  }
+
+  async function handleRestore(lease: LandlordActiveLease) {
+    await restoreLeaseRecord(lease.id);
+    await load();
+  }
+
+  async function handleConvert() {
+    if (!selectedCandidate) return;
+    setConvertSaving(true);
+    setError(null);
+    try {
+      await convertUnitReferenceToLease(selectedCandidate.unitId, {
+        occupantName,
+        tenantEmail: tenantEmail.trim() || undefined,
+        tenantPhone: tenantPhone.trim() || undefined,
+        startDate,
+        endDate: endDate || null,
+        monthlyRent: Number(monthlyRent || 0),
+      });
+      setSelectedCandidate(null);
+      await load();
+    } catch (err: unknown) {
+      setError(errorMessage(err, "Failed to convert reference to lease."));
+    } finally {
+      setConvertSaving(false);
+    }
+  }
 
   return (
     <div style={{ display: "grid", gap: 16 }}>
       <div style={{ display: "grid", gap: 6 }}>
-        <div style={{ fontSize: 24, fontWeight: 800 }}>Active leases</div>
+        <div style={{ fontSize: 24, fontWeight: 800 }}>Lease operations</div>
         <div style={{ color: "#475569", fontSize: 14 }}>
-          View the current active lease rollup for your portfolio, including quick actions to open, email, or save each lease reference.
+          Keep canonical lease records visible, reconcile occupied units missing leases, and use the ledger and archive views safely.
         </div>
       </div>
 
-      {loading ? <div>Loading active leases…</div> : null}
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+        <button
+          type="button"
+          onClick={() => setSearchParams({})}
+          style={{
+            padding: "8px 12px",
+            borderRadius: 10,
+            border: "1px solid #cbd5e1",
+            background: view === "active" ? "#0f172a" : "#fff",
+            color: view === "active" ? "#fff" : "#0f172a",
+          }}
+        >
+          Active leases
+        </button>
+        <button
+          type="button"
+          onClick={() => setSearchParams({ view: "archived" })}
+          style={{
+            padding: "8px 12px",
+            borderRadius: 10,
+            border: "1px solid #cbd5e1",
+            background: view === "archived" ? "#0f172a" : "#fff",
+            color: view === "archived" ? "#fff" : "#0f172a",
+          }}
+        >
+          View archive
+        </button>
+      </div>
+
+      {loading ? <div>Loading lease operations…</div> : null}
       {error ? <div style={{ color: "#b91c1c" }}>{error}</div> : null}
+
+      {!loading && view === "active" && candidates.length > 0 ? (
+        <div style={{ display: "grid", gap: 10, border: "1px solid #e2e8f0", borderRadius: 12, background: "#fff", padding: 16 }}>
+          <div style={{ fontWeight: 800, color: "#0f172a" }}>Occupied units missing lease records</div>
+          <div style={{ color: "#64748b", fontSize: 13 }}>
+            Units remain the occupancy source of truth. Convert these occupied reference states into real lease records only when you are ready.
+          </div>
+          {candidates.map((candidate) => (
+            <div
+              key={candidate.unitId}
+              style={{
+                display: "grid",
+                gap: 8,
+                border: "1px solid #e2e8f0",
+                borderRadius: 10,
+                padding: 12,
+              }}
+            >
+              <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+                <div>
+                  <div style={{ fontWeight: 700, color: "#0f172a" }}>
+                    {candidate.propertyName} · Unit {candidate.unitNumber}
+                  </div>
+                  <div style={{ color: "#475569", fontSize: 13 }}>
+                    {candidate.occupantName || "Occupant name missing"} · {formatCurrency(candidate.monthlyRent)}
+                    {candidate.leaseEndDate ? ` · Ends ${formatDate(candidate.leaseEndDate)}` : ""}
+                  </div>
+                </div>
+                <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                  {candidate.leaseDocument?.url ? (
+                    <a href={candidate.leaseDocument.url} target="_blank" rel="noreferrer" style={{ color: "#2563eb" }}>
+                      View reference
+                    </a>
+                  ) : null}
+                  <button
+                    type="button"
+                    aria-label={`Convert unit ${candidate.unitNumber} to lease`}
+                    disabled={!candidate.canConvert}
+                    onClick={() => setSelectedCandidate(candidate)}
+                    style={{
+                      padding: "6px 10px",
+                      borderRadius: 8,
+                      border: "1px solid #cbd5e1",
+                      background: candidate.canConvert ? "#fff" : "#f8fafc",
+                      color: candidate.canConvert ? "#0f172a" : "#94a3b8",
+                    }}
+                  >
+                    Convert to lease
+                  </button>
+                </div>
+              </div>
+              {!candidate.canConvert && candidate.blockingReasons.length > 0 ? (
+                <div style={{ color: "#b45309", fontSize: 12 }}>
+                  Missing: {candidate.blockingReasons.join(", ").replace(/_/g, " ")}
+                </div>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      ) : null}
 
       {!loading && !error && leases.length === 0 ? (
         <div
@@ -88,16 +280,16 @@ export default function LandlordActiveLeasesPage() {
             color: "#475569",
           }}
         >
-          No active leases were found for this landlord yet.
+          {view === "archived" ? "No archived leases yet." : "No active leases were found for this landlord yet."}
         </div>
       ) : null}
 
       {!loading && !error && leases.length > 0 ? (
         <div style={{ overflowX: "auto", border: "1px solid #e2e8f0", borderRadius: 12, background: "#fff" }}>
-          <table style={{ width: "100%", minWidth: 920, borderCollapse: "collapse" }}>
+          <table style={{ width: "100%", minWidth: 1040, borderCollapse: "collapse" }}>
             <thead>
               <tr style={{ background: "#f8fafc", color: "#475569" }}>
-                {["Property", "Unit", "Tenant", "Rent", "Term", "Actions"].map((label) => (
+                {["Property", "Unit", "Tenant", "Status", "Rent", "Term", "Actions"].map((label) => (
                   <th key={label} style={{ textAlign: "left", padding: 12, fontSize: 12, textTransform: "uppercase", letterSpacing: "0.04em" }}>
                     {label}
                   </th>
@@ -117,6 +309,7 @@ export default function LandlordActiveLeasesPage() {
                     `Lease reference for ${lease.propertyName} unit ${lease.unitNumber}.`,
                     "",
                     `Monthly rent: ${formatCurrency(lease.monthlyRent)}`,
+                    `Status: ${prettyLeaseStatus(lease.status)}`,
                     `Term: ${formatDate(lease.startDate)} to ${formatDate(lease.endDate)}`,
                     `View ledger: ${ledgerUrl}`,
                     lease.documentUrl ? `Lease document: ${lease.documentUrl}` : "",
@@ -138,6 +331,14 @@ export default function LandlordActiveLeasesPage() {
                     <td style={{ padding: 12 }}>
                       <div>{lease.tenantName || "Tenant not linked"}</div>
                       <div style={{ color: "#64748b", fontSize: 12 }}>{lease.tenantEmail || "No email on file"}</div>
+                    </td>
+                    <td style={{ padding: 12 }}>
+                      <div>{statusBadge(lease.status)}</div>
+                      {lease.archivedAt ? (
+                        <div style={{ color: "#64748b", fontSize: 12, marginTop: 4 }}>
+                          Archived {formatDate(lease.archivedAt)}
+                        </div>
+                      ) : null}
                     </td>
                     <td style={{ padding: 12 }}>{formatCurrency(lease.monthlyRent)}</td>
                     <td style={{ padding: 12 }}>
@@ -185,6 +386,23 @@ export default function LandlordActiveLeasesPage() {
                         >
                           Save
                         </button>
+                        {view === "archived" ? (
+                          <button
+                            type="button"
+                            onClick={() => void handleRestore(lease)}
+                            style={{ padding: "6px 10px", borderRadius: 8, border: "1px solid #cbd5e1", background: "#fff", color: "#0f172a" }}
+                          >
+                            Restore
+                          </button>
+                        ) : (
+                          <button
+                            type="button"
+                            onClick={() => void handleArchive(lease)}
+                            style={{ padding: "6px 10px", borderRadius: 8, border: "1px solid #cbd5e1", background: "#fff", color: "#0f172a" }}
+                          >
+                            Archive lease
+                          </button>
+                        )}
                       </div>
                     </td>
                   </tr>
@@ -192,6 +410,77 @@ export default function LandlordActiveLeasesPage() {
               })}
             </tbody>
           </table>
+        </div>
+      ) : null}
+
+      {selectedCandidate ? (
+        <div
+          style={{
+            position: "fixed",
+            inset: 0,
+            background: "rgba(15,23,42,0.45)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            padding: 16,
+            zIndex: 90,
+          }}
+          onClick={() => !convertSaving && setSelectedCandidate(null)}
+        >
+          <div
+            style={{
+              width: "min(520px, 96vw)",
+              borderRadius: 16,
+              border: "1px solid #e2e8f0",
+              background: "#fff",
+              boxShadow: "0 20px 50px rgba(15,23,42,0.2)",
+              padding: 18,
+              display: "grid",
+              gap: 10,
+            }}
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div style={{ fontSize: 18, fontWeight: 800 }}>
+              Convert reference to lease
+            </div>
+            <div style={{ color: "#475569", fontSize: 13 }}>
+              This creates a real lease record. The unit reference document stays as supporting context and does not remain the lease truth.
+            </div>
+            <label style={{ display: "grid", gap: 4 }}>
+              <span>Occupant name</span>
+              <input value={occupantName} onChange={(event) => setOccupantName(event.target.value)} />
+            </label>
+            <label style={{ display: "grid", gap: 4 }}>
+              <span>Tenant email (optional)</span>
+              <input value={tenantEmail} onChange={(event) => setTenantEmail(event.target.value)} />
+            </label>
+            <label style={{ display: "grid", gap: 4 }}>
+              <span>Tenant phone (optional)</span>
+              <input value={tenantPhone} onChange={(event) => setTenantPhone(event.target.value)} />
+            </label>
+            <div style={{ display: "grid", gridTemplateColumns: "repeat(3, minmax(0, 1fr))", gap: 8 }}>
+              <label style={{ display: "grid", gap: 4 }}>
+                <span>Start date</span>
+                <input type="date" value={startDate} onChange={(event) => setStartDate(event.target.value)} />
+              </label>
+              <label style={{ display: "grid", gap: 4 }}>
+                <span>End date</span>
+                <input type="date" value={endDate} onChange={(event) => setEndDate(event.target.value)} />
+              </label>
+              <label style={{ display: "grid", gap: 4 }}>
+                <span>Monthly rent</span>
+                <input type="number" min="0" step="0.01" value={monthlyRent} onChange={(event) => setMonthlyRent(event.target.value)} />
+              </label>
+            </div>
+            <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
+              <button type="button" onClick={() => setSelectedCandidate(null)} disabled={convertSaving}>
+                Cancel
+              </button>
+              <button type="button" onClick={() => void handleConvert()} disabled={convertSaving}>
+                {convertSaving ? "Converting…" : "Create lease"}
+              </button>
+            </div>
+          </div>
         </div>
       ) : null}
     </div>

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
@@ -1,0 +1,116 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import LeaseLedgerPage from "./LeaseLedgerPage";
+
+const mocks = vi.hoisted(() => ({
+  fetchLeaseLedger: vi.fn(),
+  addLeaseCharge: vi.fn(),
+  addLeasePayment: vi.fn(),
+  leaseLedgerExportUrl: vi.fn(() => "https://example.com/export.csv"),
+  getLeaseById: vi.fn(),
+  getLeaseNotes: vi.fn(),
+  createLeaseNote: vi.fn(),
+  archiveLeaseRecord: vi.fn(),
+  restoreLeaseRecord: vi.fn(),
+}));
+
+vi.mock("../api/leaseLedgerApi", () => ({
+  fetchLeaseLedger: mocks.fetchLeaseLedger,
+  addLeaseCharge: mocks.addLeaseCharge,
+  addLeasePayment: mocks.addLeasePayment,
+  leaseLedgerExportUrl: mocks.leaseLedgerExportUrl,
+}));
+
+vi.mock("@/api/leasesApi", () => ({
+  getLeaseById: mocks.getLeaseById,
+  getLeaseNotes: mocks.getLeaseNotes,
+  createLeaseNote: mocks.createLeaseNote,
+  archiveLeaseRecord: mocks.archiveLeaseRecord,
+  restoreLeaseRecord: mocks.restoreLeaseRecord,
+}));
+
+vi.mock("../lib/authToken", () => ({
+  getAuthToken: () => null,
+}));
+
+vi.mock("../lib/firebaseAuthToken", () => ({
+  getFirebaseIdToken: async () => null,
+}));
+
+describe("LeaseLedgerPage", () => {
+  beforeEach(() => {
+    mocks.fetchLeaseLedger.mockResolvedValue({
+      ok: true,
+      leaseId: "lease-1",
+      entries: [
+        {
+          id: "entry-1",
+          leaseId: "lease-1",
+          entryType: "charge",
+          category: "rent",
+          amountCents: 185000,
+          effectiveDate: "2026-04-01",
+          createdAt: 1,
+          signedAmountCents: 185000,
+          balanceCents: 185000,
+        },
+      ],
+      totals: { chargesCents: 185000, paymentsCents: 0, balanceCents: 185000 },
+      monthlyTotals: {
+        "2026-04": { chargesCents: 185000, paymentsCents: 0, netCents: 185000 },
+      },
+    });
+    mocks.getLeaseById.mockResolvedValue({
+      lease: {
+        id: "lease-1",
+        propertyName: "Harbour View",
+        unitNumber: "101",
+        tenantName: "Jane Tenant",
+        status: "renewal_pending",
+      },
+    });
+    mocks.getLeaseNotes.mockResolvedValue({
+      ok: true,
+      notes: [{ id: "note-1", leaseId: "lease-1", landlordId: "landlord-1", note: "Call tenant next week", createdAt: 1 }],
+    });
+    mocks.createLeaseNote.mockResolvedValue({
+      ok: true,
+      note: { id: "note-2", leaseId: "lease-1", landlordId: "landlord-1", note: "New note", createdAt: 2 },
+    });
+    mocks.archiveLeaseRecord.mockResolvedValue({ ok: true, lease: { id: "lease-1", archivedAt: "2026-04-01T00:00:00.000Z" } });
+    mocks.restoreLeaseRecord.mockResolvedValue({ ok: true, lease: { id: "lease-1", archivedAt: null } });
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+  });
+
+  it("loads canonical lease detail and notes with the ledger", async () => {
+    render(
+      <MemoryRouter initialEntries={["/leases/lease-1/ledger"]}>
+        <Routes>
+          <Route path="/leases/:leaseId/ledger" element={<LeaseLedgerPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Harbour View · Unit 101")).toBeInTheDocument();
+    expect(screen.getByText(/Renewal pending/i)).toBeInTheDocument();
+    expect(screen.getByText("Call tenant next week")).toBeInTheDocument();
+  });
+
+  it("adds a lease note from the ledger detail surface", async () => {
+    render(
+      <MemoryRouter initialEntries={["/leases/lease-1/ledger"]}>
+        <Routes>
+          <Route path="/leases/:leaseId/ledger" element={<LeaseLedgerPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await screen.findByText("Harbour View · Unit 101");
+    fireEvent.click(screen.getAllByRole("button", { name: "Add lease note" })[0]);
+    fireEvent.change(screen.getByLabelText("Note"), { target: { value: "Follow up on renewal" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save note" }));
+
+    await waitFor(() => expect(mocks.createLeaseNote).toHaveBeenCalledWith("lease-1", "Follow up on renewal"));
+  });
+});

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { useParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import {
   addLeaseCharge,
   addLeasePayment,
@@ -9,9 +9,23 @@ import {
 } from "../api/leaseLedgerApi";
 import { getAuthToken } from "../lib/authToken";
 import { getFirebaseIdToken } from "../lib/firebaseAuthToken";
+import {
+  archiveLeaseRecord,
+  createLeaseNote,
+  getLeaseById,
+  getLeaseNotes,
+  restoreLeaseRecord,
+  type LandlordActiveLease,
+  type LeaseNote,
+} from "@/api/leasesApi";
 
 type ChargeType = "rent" | "fee" | "adjustment";
 type PaymentMethod = "cash" | "etransfer" | "cheque" | "bank" | "card" | "other";
+
+function errorMessage(error: unknown, fallback: string) {
+  if (error instanceof Error && error.message) return error.message;
+  return fallback;
+}
 
 function centsFromInput(input: string): number | null {
   const parsed = Number(input);
@@ -21,6 +35,13 @@ function centsFromInput(input: string): number | null {
 
 function dollars(cents: number): string {
   return (cents / 100).toLocaleString(undefined, { style: "currency", currency: "CAD" });
+}
+
+function formatDate(value: string | null | undefined) {
+  if (!value) return "—";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return parsed.toLocaleDateString();
 }
 
 function todayIso() {
@@ -58,7 +79,11 @@ export default function LeaseLedgerPage() {
   const [monthlyTotals, setMonthlyTotals] = useState<Record<string, { chargesCents: number; paymentsCents: number; netCents: number }>>({});
   const [showChargeModal, setShowChargeModal] = useState(false);
   const [showPaymentModal, setShowPaymentModal] = useState(false);
+  const [showNoteModal, setShowNoteModal] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [lease, setLease] = useState<LandlordActiveLease | null>(null);
+  const [notes, setNotes] = useState<LeaseNote[]>([]);
+  const [noteText, setNoteText] = useState("");
 
   const [chargeDate, setChargeDate] = useState(todayIso());
   const [chargeType, setChargeType] = useState<ChargeType>("rent");
@@ -84,17 +109,87 @@ export default function LeaseLedgerPage() {
       setEntries(Array.isArray(res.entries) ? res.entries : []);
       setTotals(res.totals || { chargesCents: 0, paymentsCents: 0, balanceCents: 0 });
       setMonthlyTotals(res.monthlyTotals || {});
-    } catch (err: any) {
-      setError(err?.message || "Failed to load lease ledger");
+    } catch (err: unknown) {
+      setError(errorMessage(err, "Failed to load lease ledger"));
     } finally {
       setLoading(false);
     }
   };
 
+  const loadLeaseMeta = async () => {
+    if (!leaseId) return;
+    try {
+      const [leaseResponse, notesResponse] = await Promise.all([
+        getLeaseById(leaseId),
+        getLeaseNotes(leaseId),
+      ]);
+      setLease(leaseResponse.lease || null);
+      setNotes(Array.isArray(notesResponse.notes) ? notesResponse.notes : []);
+    } catch (err: unknown) {
+      setError(errorMessage(err, "Failed to load lease details"));
+    }
+  };
+
   useEffect(() => {
     loadLedger();
+    void loadLeaseMeta();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [leaseId]);
+
+  function prettyStatus(value: string | null | undefined) {
+    const normalized = String(value || "").trim().toLowerCase();
+    if (!normalized) return "Unknown";
+    if (normalized === "notice_pending") return "Renew letter needed";
+    if (normalized === "renewal_pending") return "Renewal pending";
+    if (normalized === "renewal_accepted") return "Renewing";
+    if (normalized === "move_out_pending") return "Quitting";
+    return normalized.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+  }
+
+  async function submitNote() {
+    const note = noteText.trim();
+    if (!note) {
+      setError("Note text is required.");
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      await createLeaseNote(leaseId, note);
+      setNoteText("");
+      setShowNoteModal(false);
+      await loadLeaseMeta();
+    } catch (err: unknown) {
+      setError(errorMessage(err, "Failed to save lease note"));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function toggleArchive() {
+    if (!lease) return;
+    const isArchived = Boolean(lease.archivedAt);
+    const confirmed = window.confirm(
+      isArchived
+        ? "Restore this lease to the active lease workspace?"
+        : "Archive this lease from the landlord lease workspace? You can restore it later from View archive."
+    );
+    if (!confirmed) return;
+    setSaving(true);
+    setError(null);
+    try {
+      if (isArchived) {
+        await restoreLeaseRecord(lease.id);
+      } else {
+        await archiveLeaseRecord(lease.id);
+      }
+      await loadLeaseMeta();
+    } catch (err: unknown) {
+      setError(errorMessage(err, "Failed to update archive state"));
+    } finally {
+      setSaving(false);
+    }
+  }
 
   async function submitCharge() {
     const amountCents = centsFromInput(chargeAmount);
@@ -119,8 +214,8 @@ export default function LeaseLedgerPage() {
       setChargeAmount("");
       setChargeNotes("");
       await loadLedger();
-    } catch (err: any) {
-      setError(err?.message || "Failed to add charge");
+    } catch (err: unknown) {
+      setError(errorMessage(err, "Failed to add charge"));
     } finally {
       setSaving(false);
     }
@@ -151,8 +246,8 @@ export default function LeaseLedgerPage() {
       setPaymentReference("");
       setPaymentNotes("");
       await loadLedger();
-    } catch (err: any) {
-      setError(err?.message || "Failed to record payment");
+    } catch (err: unknown) {
+      setError(errorMessage(err, "Failed to record payment"));
     } finally {
       setSaving(false);
     }
@@ -182,8 +277,8 @@ export default function LeaseLedgerPage() {
       a.click();
       a.remove();
       URL.revokeObjectURL(objectUrl);
-    } catch (err: any) {
-      setError(err?.message || "Failed to export CSV");
+    } catch (err: unknown) {
+      setError(errorMessage(err, "Failed to export CSV"));
     }
   }
 
@@ -193,11 +288,27 @@ export default function LeaseLedgerPage() {
         <div>
           <h1 style={{ margin: 0, fontSize: "1.2rem" }}>Lease Ledger</h1>
           <div style={{ color: "#475569", marginTop: 4 }}>Lease ID: {leaseId}</div>
+          {lease ? (
+            <div style={{ color: "#334155", marginTop: 6, display: "grid", gap: 2 }}>
+              <div>
+                {lease.propertyName || "Property"} · Unit {lease.unitNumber || "—"}
+              </div>
+              <div>
+                {lease.tenantName || "Tenant not linked"} · {prettyStatus(lease.status)}
+                {lease.archivedAt ? ` · Archived ${formatDate(lease.archivedAt)}` : ""}
+              </div>
+            </div>
+          ) : null}
         </div>
         <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <Link to="/leases?view=archived">View archive</Link>
+          <button aria-label="Add lease note" onClick={() => setShowNoteModal(true)}>Add note</button>
           <button onClick={() => setShowChargeModal(true)}>Add charge</button>
           <button onClick={() => setShowPaymentModal(true)}>Record payment</button>
           <button onClick={exportCsv}>Export CSV</button>
+          <button onClick={() => void toggleArchive()} disabled={saving || !lease}>
+            {lease?.archivedAt ? "Restore lease" : "Archive lease"}
+          </button>
         </div>
       </div>
 
@@ -293,6 +404,43 @@ export default function LeaseLedgerPage() {
               <span>Net: {dollars(row.netCents)}</span>
             </div>
           ))}
+        </div>
+      ) : null}
+
+      <div style={{ display: "grid", gap: 8 }}>
+        <h2 style={{ margin: 0, fontSize: "1rem" }}>Lease notes</h2>
+        <div style={{ border: "1px solid #e2e8f0", borderRadius: 12, padding: 12, display: "grid", gap: 8 }}>
+          {notes.length === 0 ? <div style={{ color: "#64748b" }}>No lease notes yet.</div> : null}
+          {notes.map((note) => (
+            <div key={note.id} style={{ border: "1px solid #e2e8f0", borderRadius: 10, padding: 10 }}>
+              <div style={{ color: "#0f172a" }}>{note.note}</div>
+              <div style={{ color: "#64748b", fontSize: 12, marginTop: 4 }}>
+                {typeof note.createdAt === "number" ? new Date(note.createdAt).toLocaleString() : String(note.createdAt || "—")}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {showNoteModal ? (
+        <div style={modalBackdrop} onClick={() => !saving && setShowNoteModal(false)}>
+          <div style={modalCard} onClick={(e) => e.stopPropagation()}>
+            <h3 style={{ marginTop: 0 }}>Add lease note</h3>
+            <div style={{ display: "grid", gap: 8 }}>
+              <label>
+                Note
+                <textarea rows={5} value={noteText} onChange={(e) => setNoteText(e.target.value)} />
+              </label>
+              <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
+                <button type="button" onClick={() => setShowNoteModal(false)} disabled={saving}>
+                  Cancel
+                </button>
+                <button type="button" onClick={() => void submitNote()} disabled={saving}>
+                  {saving ? "Saving…" : "Save note"}
+                </button>
+              </div>
+            </div>
+          </div>
         </div>
       ) : null}
 


### PR DESCRIPTION
Improved lease record integrity and landlord lease operations.

- Repaired `/api/leases/:leaseId/ledger` at the backend route/query layer
- Standardized landlord lease list/detail/ledger operations around Firestore-backed canonical lease records
- Added occupied-unit reconciliation candidates and a light convert reference -> lease flow
- Added landlord lease notes, archive/view archive/restore actions, and readable canonical lease-status labels

Framing:
- lease records remain the only lease truth
- unit lease uploads remain reference artifacts until explicit conversion
- archive is reversible workspace/archive behavior, not destructive deletion
- ledger repair was a real backend stability fix, not a UI fallback
- lease status labels surface existing canonical statuses only