### PR TITLE
feat: make application decision actions actionable v1

### DIFF
--- a/rentchain-api/src/routes/__tests__/rentalApplicationsDecisionActions.test.ts
+++ b/rentchain-api/src/routes/__tests__/rentalApplicationsDecisionActions.test.ts
@@ -1,0 +1,387 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type StoredDoc = { id: string; data: any };
+
+const { dbMock, resetDb, upsertDoc, sendEmailMock, recordRiskDecisionAuditMock } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, StoredDoc>>();
+  let autoId = 0;
+
+  function ensureCollection(name: string) {
+    if (!collections.has(name)) collections.set(name, new Map());
+    return collections.get(name)!;
+  }
+
+  function toDocRef(collectionName: string, docId: string) {
+    const col = ensureCollection(collectionName);
+    return {
+      id: docId,
+      path: `${collectionName}/${docId}`,
+      get: async () => {
+        const entry = col.get(docId);
+        return {
+          id: docId,
+          exists: Boolean(entry),
+          data: () => entry?.data,
+        };
+      },
+      set: async (payload: any, options?: { merge?: boolean }) => {
+        if (options?.merge && col.has(docId)) {
+          const existing = col.get(docId)!;
+          col.set(docId, { id: docId, data: { ...(existing.data || {}), ...(payload || {}) } });
+          return;
+        }
+        col.set(docId, { id: docId, data: payload });
+      },
+    };
+  }
+
+  return {
+    dbMock: {
+      collection: (name: string) => ({
+        doc: (id?: string) => toDocRef(name, id || `auto_${++autoId}`),
+        where: (_field: string, _op: string, _value: any) => ({
+          limit: (_count: number) => ({
+            get: async () => ({ docs: [], empty: true }),
+          }),
+        }),
+      }),
+    },
+    resetDb: () => {
+      collections.clear();
+      autoId = 0;
+      sendEmailMock.mockReset();
+      recordRiskDecisionAuditMock.mockReset();
+    },
+    upsertDoc: (collectionName: string, id: string, data: any) => {
+      ensureCollection(collectionName).set(id, { id, data });
+    },
+    sendEmailMock: vi.fn(async () => undefined),
+    recordRiskDecisionAuditMock: vi.fn(async (payload: any) => ({
+      id: "audit-1",
+      createdAt: "2026-04-01T00:00:00.000Z",
+      ...payload,
+    })),
+  };
+});
+
+vi.mock("../../config/firebase", () => ({ db: dbMock }));
+
+vi.mock("../../middleware/authMiddleware", () => ({
+  authenticateJwt: (req: any, _res: any, next: any) => {
+    const token = String(req.headers?.authorization || "").replace(/^Bearer\s+/i, "").trim().toLowerCase();
+    if (token === "admin") {
+      req.user = { id: "admin-1", landlordId: "admin-1", role: "admin", email: "admin@example.com" };
+      return next();
+    }
+    if (token === "missing-email") {
+      req.user = { id: "landlord-1", landlordId: "landlord-1", role: "landlord", email: "" };
+      return next();
+    }
+    req.user = { id: "landlord-1", landlordId: "landlord-1", role: "landlord", email: "owner@example.com" };
+    return next();
+  },
+}));
+
+vi.mock("../../middleware/attachAccount", () => ({
+  attachAccount: (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock("../../middleware/rateLimit", () => ({
+  rateLimitScreeningIp: (_req: any, _res: any, next: any) => next(),
+  rateLimitScreeningUser: (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock("../../services/stripeService", () => ({
+  isStripeConfigured: () => false,
+  getStripeClient: () => null,
+}));
+
+vi.mock("../../services/capabilityGuard", () => ({
+  requireCapability: vi.fn(async () => ({ ok: true })),
+}));
+
+vi.mock("../../billing/screeningPricing", () => ({
+  getScreeningPricing: vi.fn(() => ({
+    baseAmountCents: 0,
+    verifiedAddOnCents: 0,
+    aiAddOnCents: 0,
+    scoreAddOnCents: 0,
+    expeditedAddOnCents: 0,
+    totalAmountCents: 0,
+    currency: "cad",
+  })),
+}));
+
+vi.mock("../../services/stripeFinalize", () => ({
+  finalizeStripePayment: vi.fn(),
+}));
+
+vi.mock("../../services/stripeScreeningProcessor", () => ({
+  applyScreeningResultsFromOrder: vi.fn(),
+}));
+
+vi.mock("../../services/screening/screeningPayload", () => ({
+  buildScreeningStatusPayload: vi.fn(),
+}));
+
+vi.mock("../../services/screening/screeningEvents", () => ({
+  writeScreeningEvent: vi.fn(async () => undefined),
+}));
+
+vi.mock("../../services/screening/reportPdf", () => ({
+  buildScreeningPdf: vi.fn(),
+}));
+
+vi.mock("../../services/screening/reportExportService", () => ({
+  buildShareUrl: vi.fn(),
+  createReportExport: vi.fn(),
+}));
+
+vi.mock("../../services/screening/providerHealth", () => ({
+  getScreeningProviderHealth: vi.fn(),
+}));
+
+vi.mock("../../services/integrations/transunion/transunionService", () => ({
+  assertTransUnionConnectedForScreening: vi.fn(),
+}));
+
+vi.mock("../../services/screening/providers/bureauProvider", () => ({
+  getBureauProvider: vi.fn(() => ({
+    preflight: vi.fn(async () => ({ ok: true })),
+    name: "mock",
+  })),
+}));
+
+vi.mock("../../services/screening/cutoverCompare", () => ({
+  compareQuoteResponses: vi.fn(),
+}));
+
+vi.mock("../../services/screening/cutoverConfig", () => ({
+  getPrimaryTimeoutMs: vi.fn(() => 1000),
+  hashSeedKey: vi.fn(() => "hash"),
+  isAllowlistedSeed: vi.fn(() => false),
+  parseAllowlist: vi.fn(() => []),
+}));
+
+vi.mock("../../services/screening/cutoverTelemetry", () => ({
+  logCutoverEvent: vi.fn(),
+}));
+
+vi.mock("../../services/screening/runPrimaryWithFallback", () => ({
+  runPrimaryWithFallback: vi.fn(async ({ runLegacy }: any) => (runLegacy ? runLegacy() : { ok: true })),
+}));
+
+vi.mock("../../services/screening/inviteTokens", () => ({
+  buildTenantInviteUrl: vi.fn(),
+  createInviteToken: vi.fn(),
+}));
+
+vi.mock("../../services/screening/transunionReferral", () => ({
+  buildTransUnionReferralUrl: vi.fn(),
+}));
+
+vi.mock("../../services/screening/referralTracking", () => ({
+  findReferralDoc: vi.fn(),
+  hashLandlordId: vi.fn(),
+  markReferralCompleted: vi.fn(),
+  writeReferralInitiated: vi.fn(),
+}));
+
+vi.mock("../../services/screeningJobs", () => ({
+  enqueueScreeningJob: vi.fn(),
+}));
+
+vi.mock("../../storage/pdfStore", () => ({
+  createSignedUrl: vi.fn(),
+  putPdfObject: vi.fn(),
+}));
+
+vi.mock("../../lib/reviewSummary", () => ({
+  buildReviewSummary: vi.fn(),
+  buildReviewSummaryPdf: vi.fn(),
+}));
+
+vi.mock("../../services/risk/applicationDecisionSummary", () => ({
+  buildApplicationDecisionSummary: vi.fn(() => null),
+}));
+
+vi.mock("../../services/riskAgent/riskAgentService", () => ({
+  getLatestApplicationRisk: vi.fn(),
+}));
+
+vi.mock("../../email/templates/baseEmailTemplate", () => ({
+  buildEmailHtml: vi.fn(() => "<p>email</p>"),
+  buildEmailText: vi.fn(() => "email"),
+}));
+
+vi.mock("../../services/emailService", () => ({
+  sendEmail: sendEmailMock,
+}));
+
+vi.mock("../../services/riskAgent/riskDecisionAuditService", () => ({
+  recordRiskDecisionAudit: recordRiskDecisionAuditMock,
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; body?: any; headers?: Record<string, string> }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path: options.url,
+      body: options.body ?? {},
+      headers: options.headers ?? {},
+      get(name: string) {
+        return this.headers[String(name).toLowerCase()];
+      },
+      header(name: string) {
+        return this.get(name);
+      },
+      params: {},
+      query: {},
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, string>,
+      setHeader(name: string, value: string) {
+        this.headers[name.toLowerCase()] = value;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+async function createRouter() {
+  const router = (await import("../rentalApplicationsRoutes")).default;
+  return router;
+}
+
+describe("rentalApplications decision actions", () => {
+  beforeEach(() => {
+    resetDb();
+    process.env.EMAIL_FROM = "noreply@rentchain.test";
+    process.env.PUBLIC_APP_URL = "https://www.rentchain.test";
+    upsertDoc("rentalApplications", "app-1", {
+      id: "app-1",
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      propertyName: "Harbour View",
+      status: "SUBMITTED",
+      applicant: {
+        firstName: "Jamie",
+        lastName: "Stone",
+        email: "jamie@example.com",
+      },
+    });
+    upsertDoc("landlords", "landlord-1", {
+      id: "landlord-1",
+      email: "payments@example.com",
+    });
+  });
+
+  it("stores structured request-info state and sends an applicant email", async () => {
+    const router = await createRouter();
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/rental-applications/app-1/decision-action",
+      headers: { authorization: "Bearer landlord" },
+      body: {
+        action: "request_info",
+        requestedItems: ["upload_id", "references"],
+        customMessage: "Please send the missing documents by Friday.",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.ok).toBe(true);
+    expect(res.body?.data?.status).toBe("IN_REVIEW");
+    expect(res.body?.data?.landlordInfoRequest).toMatchObject({
+      requestedItems: ["upload_id", "references"],
+      customMessage: "Please send the missing documents by Friday.",
+    });
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+    expect(recordRiskDecisionAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        applicationId: "app-1",
+        decision: "request_info",
+      })
+    );
+  });
+
+  it("approves the application and includes the configured landlord payment email", async () => {
+    const router = await createRouter();
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/rental-applications/app-1/decision-action",
+      headers: { authorization: "Bearer landlord" },
+      body: {
+        action: "approve",
+        note: "Looks good to move forward.",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.status).toBe("APPROVED");
+    expect(res.body?.action?.paymentEmail).toBe("payments@example.com");
+    expect(sendEmailMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "jamie@example.com",
+        replyTo: "payments@example.com",
+        subject: expect.stringMatching(/approved/i),
+      })
+    );
+  });
+
+  it("fails closed when approval is attempted without a landlord payment email", async () => {
+    upsertDoc("landlords", "landlord-1", { id: "landlord-1", email: "" });
+    const router = await createRouter();
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/rental-applications/app-1/decision-action",
+      headers: { authorization: "Bearer missing-email" },
+      body: {
+        action: "approve",
+      },
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body?.error).toBe("LANDLORD_PAYMENT_EMAIL_MISSING");
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects the application and sends a polite applicant update", async () => {
+    const router = await createRouter();
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/rental-applications/app-1/decision-action",
+      headers: { authorization: "Bearer landlord" },
+      body: {
+        action: "reject",
+        note: "Thank you for applying.",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.status).toBe("DECLINED");
+    expect(sendEmailMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "jamie@example.com",
+        subject: expect.stringMatching(/update/i),
+      })
+    );
+  });
+});

--- a/rentchain-api/src/routes/rentalApplicationsRoutes.ts
+++ b/rentchain-api/src/routes/rentalApplicationsRoutes.ts
@@ -42,6 +42,7 @@ import { createSignedUrl, putPdfObject } from "../storage/pdfStore";
 import { buildReviewSummary, buildReviewSummaryPdf } from "../lib/reviewSummary";
 import { buildApplicationDecisionSummary } from "../services/risk/applicationDecisionSummary";
 import { getLatestApplicationRisk } from "../services/riskAgent/riskAgentService";
+import { recordRiskDecisionAudit } from "../services/riskAgent/riskDecisionAuditService";
 import { rateLimitScreeningIp, rateLimitScreeningUser } from "../middleware/rateLimit";
 import { buildEmailHtml, buildEmailText } from "../email/templates/baseEmailTemplate";
 import { sendEmail } from "../services/emailService";
@@ -70,8 +71,15 @@ const ALLOWED_STATUS = [
 ];
 
 const ELIGIBLE_STATUS = ["SUBMITTED", "IN_REVIEW"];
+const APPLICATION_DECISION_ACTIONS = ["request_info", "approve", "reject"] as const;
 const SERVICE_LEVELS = ["SELF_SERVE", "VERIFIED", "VERIFIED_AI"] as const;
 const CONSENT_VERSION = "v1.0";
+const INFO_REQUEST_ITEM_LABELS: Record<string, string> = {
+  upload_id: "Upload ID",
+  phone_number: "Phone number",
+  employer_contact: "Employer contact",
+  references: "References",
+};
 
 const ALLOWED_REDIRECT_ORIGINS = ["https://www.rentchain.ai", "https://rentchain.ai", "http://localhost:5173"];
 const REVIEW_SUMMARY_TEMPLATE_PATH = "src/lib/reviewSummary.ts";
@@ -115,6 +123,164 @@ function resolveFrontendOrigin(req: any) {
       : "http://localhost:5173";
   const base = String(process.env.FRONTEND_URL || fallback).trim();
   return normalizeOrigin(base) || null;
+}
+
+function getPublicAppBaseUrl() {
+  const raw = String(process.env.PUBLIC_APP_URL || process.env.FRONTEND_ORIGIN || "https://www.rentchain.ai").trim();
+  return raw.replace(/\/$/, "");
+}
+
+function normalizeRequestInfoItems(value: any): string[] {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<string>();
+  const items: string[] = [];
+  for (const item of value) {
+    const normalized = String(item || "").trim().toLowerCase();
+    if (!normalized || !INFO_REQUEST_ITEM_LABELS[normalized] || seen.has(normalized)) continue;
+    seen.add(normalized);
+    items.push(normalized);
+  }
+  return items;
+}
+
+async function resolveLandlordContactEmail(landlordId: string, fallbackEmail?: string | null) {
+  const normalizedLandlordId = String(landlordId || "").trim();
+  const fallback = String(fallbackEmail || "").trim();
+  if (!normalizedLandlordId) return fallback || null;
+  try {
+    const snap = await db.collection("landlords").doc(normalizedLandlordId).get();
+    if (!snap.exists) return fallback || null;
+    const data = snap.data() as any;
+    return String(data?.email || fallback || "").trim() || null;
+  } catch {
+    return fallback || null;
+  }
+}
+
+async function sendRentalApplicationDecisionEmail(params: {
+  action: (typeof APPLICATION_DECISION_ACTIONS)[number];
+  application: any;
+  landlordEmail: string | null;
+  requestInfoItems?: string[];
+  customMessage?: string | null;
+}) {
+  const applicantEmail = String(params.application?.applicant?.email || "").trim();
+  if (!applicantEmail) {
+    throw new Error("APPLICANT_EMAIL_MISSING");
+  }
+
+  const applicantFirstName = String(params.application?.applicant?.firstName || "").trim() || "there";
+  const applicantLastName = String(params.application?.applicant?.lastName || "").trim();
+  const applicantName = `${applicantFirstName} ${applicantLastName}`.trim();
+  const propertyLabel = String(params.application?.propertyName || params.application?.propertyId || "the property").trim();
+  const publicAppBaseUrl = getPublicAppBaseUrl();
+  const ctaUrl = params.landlordEmail ? `mailto:${encodeURIComponent(params.landlordEmail)}` : `${publicAppBaseUrl}/login`;
+  const replyTo = params.landlordEmail || undefined;
+  const from = process.env.EMAIL_FROM || process.env.FROM_EMAIL;
+  const customMessage = String(params.customMessage || "").trim();
+
+  if (!from) {
+    throw new Error("EMAIL_FROM missing");
+  }
+
+  if (params.action === "approve") {
+    const paymentEmail = String(params.landlordEmail || "").trim();
+    if (!paymentEmail) {
+      throw new Error("LANDLORD_PAYMENT_EMAIL_MISSING");
+    }
+    const intro = `Hi ${applicantFirstName}, your rental application for ${propertyLabel} has been approved. To hold the unit, please send an e-transfer for one half of one month's rent to ${paymentEmail}.`;
+    const bullets = [
+      `Send the e-transfer to ${paymentEmail}.`,
+      "Include your full name and the property or unit reference in the transfer note.",
+      "Reply to this email if you need to confirm the next leasing steps.",
+    ];
+    await sendEmail({
+      to: applicantEmail,
+      from,
+      replyTo,
+      subject: `Your RentChain application is approved`,
+      text: buildEmailText({
+        intro,
+        bullets,
+        ctaText: "Reply to confirm next steps",
+        ctaUrl,
+        footerNote: "This approval was sent by your landlord through RentChain.",
+      }),
+      html: buildEmailHtml({
+        title: "Application approved",
+        intro,
+        bullets,
+        ctaText: "Reply to confirm next steps",
+        ctaUrl,
+        footerNote: "This approval was sent by your landlord through RentChain.",
+        preheader: "Your landlord approved the application and shared the next payment step.",
+      }),
+    });
+    return { ok: true, paymentEmail };
+  }
+
+  if (params.action === "reject") {
+    const intro = `Hi ${applicantFirstName}, thank you for your interest in ${propertyLabel}. After review, the landlord has decided not to move forward with this application.`;
+    const bullets = [
+      "Your application has been closed in RentChain.",
+      "This message is intended to keep the decision clear and timely.",
+    ];
+    await sendEmail({
+      to: applicantEmail,
+      from,
+      replyTo,
+      subject: `Update on your RentChain rental application`,
+      text: buildEmailText({
+        intro,
+        bullets,
+        ctaText: "View RentChain",
+        ctaUrl: `${publicAppBaseUrl}/login`,
+        footerNote: "Thank you again for applying.",
+      }),
+      html: buildEmailHtml({
+        title: "Application update",
+        intro,
+        bullets,
+        ctaText: "View RentChain",
+        ctaUrl: `${publicAppBaseUrl}/login`,
+        footerNote: "Thank you again for applying.",
+        preheader: "Your landlord has shared the outcome of the application review.",
+      }),
+    });
+    return { ok: true, paymentEmail: null };
+  }
+
+  const items = normalizeRequestInfoItems(params.requestInfoItems);
+  const labeledItems = items.map((item) => INFO_REQUEST_ITEM_LABELS[item]);
+  const bullets = labeledItems.length
+    ? labeledItems.map((item) => `Please send: ${item}.`)
+    : ["Please reply with the additional information your landlord requested."];
+  if (customMessage) {
+    bullets.push(`Landlord note: ${customMessage}`);
+  }
+  await sendEmail({
+    to: applicantEmail,
+    from,
+    replyTo,
+    subject: `More information requested for your RentChain application`,
+    text: buildEmailText({
+      intro: `Hi ${applicantName || applicantFirstName}, your landlord needs a little more information before finishing the review for ${propertyLabel}.`,
+      bullets,
+      ctaText: params.landlordEmail ? "Reply to your landlord" : "Open RentChain",
+      ctaUrl,
+      footerNote: "This request was sent after an explicit landlord review action in RentChain.",
+    }),
+    html: buildEmailHtml({
+      title: "More information requested",
+      intro: `Hi ${applicantName || applicantFirstName}, your landlord needs a little more information before finishing the review for ${propertyLabel}.`,
+      bullets,
+      ctaText: params.landlordEmail ? "Reply to your landlord" : "Open RentChain",
+      ctaUrl,
+      footerNote: "This request was sent after an explicit landlord review action in RentChain.",
+      preheader: "Your landlord requested a few follow-up items before finishing the review.",
+    }),
+  });
+  return { ok: true, paymentEmail: null };
 }
 
 function buildRedirectUrl(params: {
@@ -1620,6 +1786,114 @@ router.patch("/rental-applications/:id", async (req: any, res) => {
   } catch (err: any) {
     console.error("[rental-applications] update failed", err?.message || err);
     return res.status(500).json({ ok: false, error: "RENTAL_APPLICATION_UPDATE_FAILED" });
+  }
+});
+
+router.post("/rental-applications/:id/decision-action", async (req: any, res) => {
+  try {
+    const role = String(req.user?.role || "").toLowerCase();
+    if (role !== "landlord" && role !== "admin") {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+    const actorUserId = String(req.user?.id || "").trim() || null;
+    const actorEmail = String(req.user?.email || "").trim() || null;
+    const fallbackLandlordId = String(req.user?.landlordId || req.user?.id || "").trim() || null;
+    if (!fallbackLandlordId) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+
+    const id = String(req.params?.id || "").trim();
+    if (!id) return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+
+    const action = String(req.body?.action || "").trim().toLowerCase();
+    if (!APPLICATION_DECISION_ACTIONS.includes(action as (typeof APPLICATION_DECISION_ACTIONS)[number])) {
+      return res.status(400).json({ ok: false, error: "INVALID_ACTION" });
+    }
+
+    const snap = await db.collection("rentalApplications").doc(id).get();
+    if (!snap.exists) return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+    const data = snap.data() as any;
+    const applicationLandlordId = String(data?.landlordId || fallbackLandlordId || "").trim() || null;
+    if (applicationLandlordId && role !== "admin" && applicationLandlordId !== fallbackLandlordId) {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+
+    const requestedItems = normalizeRequestInfoItems(req.body?.requestedItems);
+    const note = String(req.body?.note || req.body?.customMessage || "").trim().slice(0, 5000) || null;
+    const landlordEmail = await resolveLandlordContactEmail(applicationLandlordId || fallbackLandlordId, actorEmail);
+
+    if (action === "request_info" && requestedItems.length === 0 && !note) {
+      return res.status(400).json({ ok: false, error: "REQUEST_INFO_EMPTY" });
+    }
+
+    const emailResult = await sendRentalApplicationDecisionEmail({
+      action: action as (typeof APPLICATION_DECISION_ACTIONS)[number],
+      application: data,
+      landlordEmail,
+      requestInfoItems: requestedItems,
+      customMessage: note,
+    });
+
+    const now = Date.now();
+    const nextStatus =
+      action === "approve" ? "APPROVED" : action === "reject" ? "DECLINED" : "IN_REVIEW";
+    const updates: any = {
+      updatedAt: now,
+      status: nextStatus,
+      landlordNote: note,
+      lastLandlordAction: {
+        type: action,
+        actedAt: now,
+        actedBy: actorUserId,
+        actorRole: role,
+        emailSentAt: now,
+        paymentEmail: emailResult?.paymentEmail || null,
+        note,
+        requestedItems: action === "request_info" ? requestedItems : [],
+      },
+    };
+
+    if (action === "request_info") {
+      updates.landlordInfoRequest = {
+        requestedItems,
+        customMessage: note,
+        requestedAt: now,
+        requestedBy: actorUserId,
+      };
+    } else {
+      updates.landlordInfoRequest = null;
+    }
+
+    await db.collection("rentalApplications").doc(id).set(updates, { merge: true });
+
+    await recordRiskDecisionAudit({
+      applicationId: id,
+      landlordId: applicationLandlordId || fallbackLandlordId,
+      userId: actorUserId,
+      role,
+      decision: action as "approve" | "reject" | "request_info",
+      notes: note,
+    });
+
+    const refreshed = await db.collection("rentalApplications").doc(id).get();
+    return res.json({
+      ok: true,
+      data: { id: refreshed.id, ...(refreshed.data() as any) },
+      action: {
+        type: action,
+        status: nextStatus,
+        emailSent: true,
+        paymentEmail: emailResult?.paymentEmail || null,
+      },
+    });
+  } catch (err: any) {
+    const message = String(err?.message || "RENTAL_APPLICATION_ACTION_FAILED");
+    const status =
+      message === "LANDLORD_PAYMENT_EMAIL_MISSING" || message === "APPLICANT_EMAIL_MISSING" || message === "EMAIL_FROM missing"
+        ? 400
+        : 500;
+    if (status >= 500) {
+      console.error("[rental-applications] decision action failed", err?.message || err);
+    }
+    return res.status(status).json({ ok: false, error: message });
   }
 });
 

--- a/rentchain-frontend/src/api/rentalApplicationsApi.ts
+++ b/rentchain-frontend/src/api/rentalApplicationsApi.ts
@@ -21,6 +21,9 @@ export type RentalApplicationStatus =
   | "CONDITIONAL_COSIGNER"
   | "CONDITIONAL_DEPOSIT";
 
+export type RentalApplicationDecisionAction = "request_info" | "approve" | "reject";
+export type RequestInfoChecklistItem = "upload_id" | "phone_number" | "employer_contact" | "references";
+
 export type RentalApplicationSummary = {
   id: string;
   applicantName: string;
@@ -309,6 +312,22 @@ export type RentalApplication = {
   screeningLastEligibilityReasonCode?: string | null;
   screeningLastEligibilityCheckedAt?: number | null;
   landlordNote?: string | null;
+  landlordInfoRequest?: {
+    requestedItems: RequestInfoChecklistItem[];
+    customMessage?: string | null;
+    requestedAt?: number | null;
+    requestedBy?: string | null;
+  } | null;
+  lastLandlordAction?: {
+    type: RentalApplicationDecisionAction;
+    actedAt?: number | null;
+    actedBy?: string | null;
+    actorRole?: string | null;
+    emailSentAt?: number | null;
+    paymentEmail?: string | null;
+    note?: string | null;
+    requestedItems?: RequestInfoChecklistItem[];
+  } | null;
 };
 
 export type ScreeningQuote = {
@@ -427,6 +446,44 @@ export async function updateRentalApplicationStatus(
     body: JSON.stringify({ status, note }),
   });
   return res?.data as RentalApplication;
+}
+
+export async function submitRentalApplicationDecisionAction(
+  id: string,
+  payload: {
+    action: RentalApplicationDecisionAction;
+    note?: string | null;
+    customMessage?: string | null;
+    requestedItems?: RequestInfoChecklistItem[];
+  }
+): Promise<{
+  application: RentalApplication;
+  action: {
+    type: RentalApplicationDecisionAction;
+    status: RentalApplicationStatus;
+    emailSent: boolean;
+    paymentEmail?: string | null;
+  };
+}> {
+  const res: any = await apiFetch(`/rental-applications/${encodeURIComponent(id)}/decision-action`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      action: payload.action,
+      note: payload.note,
+      customMessage: payload.customMessage,
+      requestedItems: payload.requestedItems || [],
+    }),
+  });
+  return {
+    application: res?.data as RentalApplication,
+    action: res?.action as {
+      type: RentalApplicationDecisionAction;
+      status: RentalApplicationStatus;
+      emailSent: boolean;
+      paymentEmail?: string | null;
+    },
+  };
 }
 
 export async function fetchScreeningQuote(

--- a/rentchain-frontend/src/components/applications/LandlordDecisionPanel.tsx
+++ b/rentchain-frontend/src/components/applications/LandlordDecisionPanel.tsx
@@ -168,7 +168,7 @@ export const LandlordDecisionPanel: React.FC<LandlordDecisionPanelProps> = ({
       <div style={{ display: "grid", gap: 4 }}>
         <div style={{ color: text.primary, fontWeight: 800, fontSize: 16 }}>Landlord Decision Panel</div>
         <div style={{ color: text.muted, fontSize: 12, lineHeight: 1.55 }}>
-          Use the latest Risk Agent snapshot to decide whether to approve, reject, or request more information. This panel never changes application status automatically.
+          Use the latest Risk Agent snapshot to decide whether to approve, reject, or request more information. These actions stay landlord-triggered and only update the application after you confirm them.
         </div>
       </div>
 

--- a/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import ApplicationsPage from "./ApplicationsPage";
@@ -9,7 +9,7 @@ const mocks = vi.hoisted(() => ({
   fetchRentalApplication: vi.fn(),
   fetchApplicationDecisionSummary: vi.fn(),
   evaluateApplicationRiskSnapshot: vi.fn(),
-  recordApplicationRiskDecision: vi.fn(),
+  submitRentalApplicationDecisionAction: vi.fn(),
   fetchScreeningQuote: vi.fn(),
   fetchScreeningResult: vi.fn(),
   fetchScreeningReceipt: vi.fn(),
@@ -31,7 +31,7 @@ vi.mock("@/api/rentalApplicationsApi", () => ({
   fetchRentalApplication: mocks.fetchRentalApplication,
   fetchApplicationDecisionSummary: mocks.fetchApplicationDecisionSummary,
   evaluateApplicationRiskSnapshot: mocks.evaluateApplicationRiskSnapshot,
-  recordApplicationRiskDecision: mocks.recordApplicationRiskDecision,
+  submitRentalApplicationDecisionAction: mocks.submitRentalApplicationDecisionAction,
   updateRentalApplicationStatus: vi.fn(),
   fetchScreeningQuote: mocks.fetchScreeningQuote,
   createScreeningCheckout: vi.fn(),
@@ -147,7 +147,19 @@ vi.mock("../components/billing/SamplePdfModal", () => ({
 }));
 
 vi.mock("@/components/applications/ApplicationDecisionSummaryCard", () => ({
-  ApplicationDecisionSummaryCard: () => <div>Decision Summary</div>,
+  ApplicationDecisionSummaryCard: ({ onDecision, submittingDecision }: any) => (
+    <div>
+      <button type="button" onClick={() => onDecision?.("request_info", "Need paystub")} disabled={submittingDecision}>
+        Trigger Request More Info
+      </button>
+      <button type="button" onClick={() => onDecision?.("approve", "Looks good")} disabled={submittingDecision}>
+        Trigger Approve
+      </button>
+      <button type="button" onClick={() => onDecision?.("reject", "Not a fit")} disabled={submittingDecision}>
+        Trigger Reject
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock("@/components/integrations/TransUnionConnectionCard", () => ({
@@ -236,9 +248,36 @@ describe("ApplicationsPage", () => {
     mocks.fetchProperties.mockResolvedValue({
       items: [{ id: "prop-1", name: "Harbour View" }],
     });
-    mocks.fetchRentalApplications.mockResolvedValue([]);
-    mocks.fetchRentalApplication.mockResolvedValue(null);
+    mocks.fetchRentalApplications.mockResolvedValue([
+      {
+        id: "app-1",
+        applicantName: "Jamie Stone",
+        email: "jamie@example.com",
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        status: "SUBMITTED",
+        submittedAt: Date.now(),
+      },
+    ]);
+    mocks.fetchRentalApplication.mockResolvedValue({
+      id: "app-1",
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      applicationLinkId: "link-1",
+      createdAt: Date.now(),
+      submittedAt: Date.now(),
+      updatedAt: Date.now(),
+      status: "SUBMITTED",
+      applicant: { firstName: "Jamie", lastName: "Stone", email: "jamie@example.com" },
+      residentialHistory: [],
+      employment: { applicant: {} },
+      consent: { creditConsent: true, referenceConsent: true, dataSharingConsent: true, acceptedAt: Date.now() },
+      screening: { requested: false },
+      landlordNote: null,
+    });
     mocks.fetchApplicationDecisionSummary.mockResolvedValue(null);
+    mocks.submitRentalApplicationDecisionAction.mockReset();
     mocks.fetchScreeningQuote.mockResolvedValue({ ok: false, detail: "Screening not eligible." });
     mocks.fetchScreeningResult.mockResolvedValue({ ok: false });
     mocks.fetchScreeningReceipt.mockResolvedValue({ ok: false });
@@ -290,6 +329,121 @@ describe("ApplicationsPage", () => {
       currentPlan: "free",
       requiredPlan: "starter",
       source: "applications_page_screening",
+    });
+  });
+
+  it("opens a request-more-info modal and sends the actionable request", async () => {
+    mocks.submitRentalApplicationDecisionAction.mockResolvedValue({
+      application: {
+        id: "app-1",
+        landlordId: "landlord-1",
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        applicationLinkId: "link-1",
+        createdAt: Date.now(),
+        submittedAt: Date.now(),
+        updatedAt: Date.now(),
+        status: "IN_REVIEW",
+        applicant: { firstName: "Jamie", lastName: "Stone", email: "jamie@example.com" },
+        residentialHistory: [],
+        employment: { applicant: {} },
+        consent: { creditConsent: true, referenceConsent: true, dataSharingConsent: true, acceptedAt: Date.now() },
+        screening: { requested: false },
+        landlordNote: "Need paystub",
+      },
+      action: { type: "request_info", status: "IN_REVIEW", emailSent: true },
+    });
+
+    render(
+      <MemoryRouter>
+        <ApplicationsPage />
+      </MemoryRouter>
+    );
+
+    await screen.findAllByText("Jamie Stone");
+    fireEvent.click(screen.getAllByText("Jamie Stone")[0]);
+    fireEvent.click(await screen.findByRole("button", { name: "Trigger Request More Info" }));
+
+    expect(await screen.findByRole("dialog", { name: /request more information/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText("Upload ID"));
+    fireEvent.click(screen.getByRole("button", { name: /send request/i }));
+
+    await waitFor(() => {
+      expect(mocks.submitRentalApplicationDecisionAction).toHaveBeenCalledWith("app-1", {
+        action: "request_info",
+        requestedItems: ["upload_id"],
+        customMessage: "Need paystub",
+      });
+    });
+  });
+
+  it("sends approve and reject actions through the canonical action route", async () => {
+    mocks.submitRentalApplicationDecisionAction.mockResolvedValue({
+      application: {
+        id: "app-1",
+        landlordId: "landlord-1",
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        applicationLinkId: "link-1",
+        createdAt: Date.now(),
+        submittedAt: Date.now(),
+        updatedAt: Date.now(),
+        status: "APPROVED",
+        applicant: { firstName: "Jamie", lastName: "Stone", email: "jamie@example.com" },
+        residentialHistory: [],
+        employment: { applicant: {} },
+        consent: { creditConsent: true, referenceConsent: true, dataSharingConsent: true, acceptedAt: Date.now() },
+        screening: { requested: false },
+        landlordNote: "Looks good",
+      },
+      action: { type: "approve", status: "APPROVED", emailSent: true, paymentEmail: "owner@example.com" },
+    });
+
+    render(
+      <MemoryRouter>
+        <ApplicationsPage />
+      </MemoryRouter>
+    );
+
+    await screen.findAllByText("Jamie Stone");
+    fireEvent.click(screen.getAllByText("Jamie Stone")[0]);
+    fireEvent.click(await screen.findByRole("button", { name: "Trigger Approve" }));
+
+    await waitFor(() => {
+      expect(mocks.submitRentalApplicationDecisionAction).toHaveBeenCalledWith("app-1", {
+        action: "approve",
+        note: "Looks good",
+      });
+    });
+
+    mocks.submitRentalApplicationDecisionAction.mockResolvedValueOnce({
+      application: {
+        id: "app-1",
+        landlordId: "landlord-1",
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        applicationLinkId: "link-1",
+        createdAt: Date.now(),
+        submittedAt: Date.now(),
+        updatedAt: Date.now(),
+        status: "DECLINED",
+        applicant: { firstName: "Jamie", lastName: "Stone", email: "jamie@example.com" },
+        residentialHistory: [],
+        employment: { applicant: {} },
+        consent: { creditConsent: true, referenceConsent: true, dataSharingConsent: true, acceptedAt: Date.now() },
+        screening: { requested: false },
+        landlordNote: "Not a fit",
+      },
+      action: { type: "reject", status: "DECLINED", emailSent: true },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Trigger Reject" }));
+
+    await waitFor(() => {
+      expect(mocks.submitRentalApplicationDecisionAction).toHaveBeenCalledWith("app-1", {
+        action: "reject",
+        note: "Not a fit",
+      });
     });
   });
 });

--- a/rentchain-frontend/src/pages/ApplicationsPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.tsx
@@ -8,7 +8,7 @@ import {
   fetchRentalApplication,
   fetchApplicationDecisionSummary,
   evaluateApplicationRiskSnapshot,
-  recordApplicationRiskDecision,
+  submitRentalApplicationDecisionAction,
   updateRentalApplicationStatus,
   fetchScreeningQuote,
   createScreeningCheckout,
@@ -22,8 +22,10 @@ import {
   adminRecomputeScreening,
   exportScreeningReport,
   type RentalApplication,
+  type RentalApplicationDecisionAction,
   type RentalApplicationStatus,
   type RentalApplicationSummary,
+  type RequestInfoChecklistItem,
   type ScreeningQuote,
   type ScreeningPipeline,
   type ScreeningResult,
@@ -148,6 +150,13 @@ const SCREENING_REASON_LABELS: Record<string, string> = {
   LANDLORD_NOT_AUTHORIZED: "You don’t have access to start screening for this application.",
 };
 
+const REQUEST_INFO_OPTIONS: Array<{ value: RequestInfoChecklistItem; label: string }> = [
+  { value: "upload_id", label: "Upload ID" },
+  { value: "phone_number", label: "Phone number" },
+  { value: "employer_contact", label: "Employer contact" },
+  { value: "references", label: "References" },
+];
+
 const formatScreeningStatus = (value?: string | null) => {
   if (!value) return "unknown";
   return value.replace(/_/g, " ");
@@ -262,6 +271,9 @@ const ApplicationsPage: React.FC = () => {
   const [decisionSummary, setDecisionSummary] = useState<ApplicationDecisionSummary | null>(null);
   const [evaluatingRisk, setEvaluatingRisk] = useState(false);
   const [savingDecision, setSavingDecision] = useState(false);
+  const [requestInfoOpen, setRequestInfoOpen] = useState(false);
+  const [requestInfoItems, setRequestInfoItems] = useState<RequestInfoChecklistItem[]>([]);
+  const [requestInfoMessage, setRequestInfoMessage] = useState("");
   const [loading, setLoading] = useState(false);
   const [loadingDetail, setLoadingDetail] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -718,18 +730,38 @@ const ApplicationsPage: React.FC = () => {
     async (decision: LandlordDecisionAction, notes: string) => {
       const id = String(detail?.id || "").trim();
       if (!id) return;
+      if (decision === "request_info") {
+        setRequestInfoItems([]);
+        setRequestInfoMessage(notes);
+        setRequestInfoOpen(true);
+        return;
+      }
       setSavingDecision(true);
       try {
-        await recordApplicationRiskDecision(id, { decision, notes });
+        const result = await submitRentalApplicationDecisionAction(id, {
+          action: decision as RentalApplicationDecisionAction,
+          note: notes,
+        });
+        setDetail(result.application);
+        setApplications((prev) =>
+          prev.map((application) =>
+            application.id === result.application.id
+              ? { ...application, status: result.application.status }
+              : application
+          )
+        );
         showToast({
-          message: "Decision note saved",
-          description: "Your landlord decision was captured without changing application status.",
+          message: decision === "approve" ? "Application approved" : "Application rejected",
+          description:
+            decision === "approve"
+              ? "The applicant was notified and the application status was updated."
+              : "The applicant was notified and the application status was updated.",
           variant: "success",
         });
       } catch (err: any) {
         showToast({
-          message: "Decision note failed",
-          description: err?.message || "Unable to save the landlord decision note.",
+          message: "Decision action failed",
+          description: err?.message || "Unable to complete the landlord action.",
           variant: "error",
         });
       } finally {
@@ -738,6 +770,55 @@ const ApplicationsPage: React.FC = () => {
     },
     [detail?.id, showToast]
   );
+
+  const toggleRequestInfoItem = useCallback((item: RequestInfoChecklistItem) => {
+    setRequestInfoItems((current) => (current.includes(item) ? current.filter((value) => value !== item) : [...current, item]));
+  }, []);
+
+  const handleSubmitRequestInfo = useCallback(async () => {
+    const id = String(detail?.id || "").trim();
+    if (!id) return;
+    if (!requestInfoItems.length && !requestInfoMessage.trim()) {
+      showToast({
+        message: "Select at least one follow-up item",
+        description: "Choose a checklist item or add a custom request before sending the email.",
+        variant: "error",
+      });
+      return;
+    }
+    setSavingDecision(true);
+    try {
+      const result = await submitRentalApplicationDecisionAction(id, {
+        action: "request_info",
+        requestedItems: requestInfoItems,
+        customMessage: requestInfoMessage.trim() || null,
+      });
+      setDetail(result.application);
+      setApplications((prev) =>
+        prev.map((application) =>
+          application.id === result.application.id
+            ? { ...application, status: result.application.status }
+            : application
+        )
+      );
+      setRequestInfoOpen(false);
+      setRequestInfoItems([]);
+      setRequestInfoMessage("");
+      showToast({
+        message: "More information requested",
+        description: "The applicant was emailed and the application remains in review.",
+        variant: "success",
+      });
+    } catch (err: any) {
+      showToast({
+        message: "Request failed",
+        description: err?.message || "Unable to send the information request.",
+        variant: "error",
+      });
+    } finally {
+      setSavingDecision(false);
+    }
+  }, [detail?.id, requestInfoItems, requestInfoMessage, showToast]);
 
   useEffect(() => {
     let alive = true;
@@ -1278,6 +1359,12 @@ const ApplicationsPage: React.FC = () => {
       setTransUnionSubmitting(false);
     }
   }, [showToast]);
+
+  useEffect(() => {
+    setRequestInfoOpen(false);
+    setRequestInfoItems([]);
+    setRequestInfoMessage("");
+  }, [selectedId]);
 
   const handleExportReport = async (copyOnly: boolean) => {
     if (!detail?.id) return;
@@ -2003,6 +2090,84 @@ const ApplicationsPage: React.FC = () => {
                 onDecision={saveLandlordDecision}
                 submittingDecision={savingDecision}
               />
+              {requestInfoOpen ? (
+                <Card
+                  role="dialog"
+                  aria-modal="true"
+                  aria-label="Request more information"
+                  style={{
+                    border: `1px solid ${colors.accent}`,
+                    background: "rgba(239,246,255,0.98)",
+                    display: "grid",
+                    gap: spacing.md,
+                  }}
+                >
+                  <div style={{ display: "grid", gap: 4 }}>
+                    <div style={{ fontSize: 18, fontWeight: 800, color: text.primary }}>Request More Info</div>
+                    <div style={{ color: text.muted, fontSize: 13, lineHeight: 1.6 }}>
+                      Choose the missing items to request and add an optional note for the applicant email.
+                    </div>
+                  </div>
+                  <div style={{ display: "grid", gap: 10 }}>
+                    {REQUEST_INFO_OPTIONS.map((option) => (
+                      <label
+                        key={option.value}
+                        style={{
+                          display: "flex",
+                          alignItems: "center",
+                          gap: 10,
+                          color: text.primary,
+                          fontSize: 14,
+                        }}
+                      >
+                        <input
+                          type="checkbox"
+                          checked={requestInfoItems.includes(option.value)}
+                          onChange={() => toggleRequestInfoItem(option.value)}
+                        />
+                        <span>{option.label}</span>
+                      </label>
+                    ))}
+                  </div>
+                  <div style={{ display: "grid", gap: 6 }}>
+                    <div style={{ color: text.muted, fontSize: 12, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.05em" }}>
+                      Optional note
+                    </div>
+                    <textarea
+                      value={requestInfoMessage}
+                      onChange={(event) => setRequestInfoMessage(event.target.value)}
+                      placeholder="Add any extra context for the applicant."
+                      rows={4}
+                      style={{
+                        width: "100%",
+                        boxSizing: "border-box",
+                        resize: "vertical",
+                        padding: "10px 12px",
+                        borderRadius: radius.md,
+                        border: `1px solid ${colors.border}`,
+                        background: colors.card,
+                        color: text.primary,
+                      }}
+                    />
+                  </div>
+                  <div style={{ display: "flex", gap: 10, justifyContent: "flex-end", flexWrap: "wrap" }}>
+                    <Button
+                      variant="secondary"
+                      onClick={() => {
+                        setRequestInfoOpen(false);
+                        setRequestInfoItems([]);
+                        setRequestInfoMessage("");
+                      }}
+                      disabled={savingDecision}
+                    >
+                      Cancel
+                    </Button>
+                    <Button onClick={() => void handleSubmitRequestInfo()} disabled={savingDecision}>
+                      {savingDecision ? "Sending..." : "Send request"}
+                    </Button>
+                  </div>
+                </Card>
+              ) : null}
               <div ref={screeningSectionRef}>
                 <Card>
                   <div className="rc-applications-card-header" style={{ marginBottom: 8 }}>


### PR DESCRIPTION
Application Decision Actions v1

- Replaced placeholder landlord decision-note behavior on `/applications` with real canonical application actions.
- Added a backend `decision-action` route on `rentalApplications` for:
  - `request_info`
  - `approve`
  - `reject`
- `Request More Info` now opens a real modal with:
  - predefined checklist items
  - optional custom note
  - applicant email delivery
- `Approve` now:
  - updates canonical application status to `APPROVED`
  - sends an approval email
  - requests e-transfer of 1/2 month rent only when canonical landlord payment/contact email exists
- `Reject` now:
  - updates canonical application status to `DECLINED`
  - sends a polite neutral rejection email
- Added canonical application-side metadata for:
  - structured info-request items
  - last landlord action
- Reused existing email infrastructure and kept supplemental risk-decision audit support without using it as the source of action truth.

Important scope notes:
- application action truth now lives on canonical application records
- request-more-info remains in `IN_REVIEW` because no dedicated canonical info-requested status exists
- approval email is fail-closed when landlord payment/contact email is missing
- payment handling is communication-only, not payment tracking

Out of scope:
- This PR does not address unrelated property summary inconsistencies in `/properties`, including mismatches between occupied units, leased units, occupancy %, and current occupied rent total. Those remain a separate follow-up issue in the property/unit/lease summary layer.