### PR TITLE
fix: repair property summary integrity

### DIFF
--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
@@ -36,6 +36,7 @@ import { PropertyRegistryStatusCard } from "@/components/properties/PropertyRegi
 import { HalifaxRegistrySubmissionAssistant } from "@/components/properties/HalifaxRegistrySubmissionAssistant";
 import type { PropertyCredibilitySummary } from "@/types/credibilitySummary";
 import { calculateConfiguredUnitRentTotal, resolveConfiguredUnitRent } from "@/lib/propertyRentSummary";
+import { buildPropertySummaryMetrics } from "@/lib/propertySummaryMetrics";
 import { getUnitsNeedingOccupancySetup } from "./occupancyPrompt";
 
 interface PropertyDetailPanelProps {
@@ -578,48 +579,16 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
     return [];
   }, [units, unitCount]);
 
-  const activeLeases = useMemo(
-    () =>
-      leases.filter((l) =>
-        ["active", "notice_pending", "renewal_pending", "renewal_accepted", "move_out_pending"].includes(
-          String(l.status || "").toLowerCase()
-        )
-      ),
-    [leases]
-  );
-  const activeLeaseUnitNumbers = useMemo(
-    () => new Set(activeLeases.map((lease) => String(lease.unitNumber || "").trim()).filter(Boolean)),
-    [activeLeases]
-  );
-  const occupiedUnits = useMemo(
-    () =>
-      displayedUnits.filter((unit) => {
-        const unitNumber = String((unit as any)?.unitNumber || "").trim();
-        const status = String((unit as any)?.occupancyStatus || (unit as any)?.status || "").trim().toLowerCase();
-        return status === "occupied" || (unitNumber && activeLeaseUnitNumbers.has(unitNumber));
-      }),
-    [activeLeaseUnitNumbers, displayedUnits]
-  );
-  const leasedUnits = occupiedUnits.length;
-  const occupancy = unitCount > 0 ? (leasedUnits / unitCount) * 100 : 0;
-  const activeLeaseRentRoll = activeLeases.reduce(
-    (sum, l) => sum + (typeof l.monthlyRent === "number" ? l.monthlyRent : 0),
-    0
-  );
-  const occupiedUnitsFallbackRent = occupiedUnits.reduce((sum, unit) => {
-    const unitNumber = String((unit as any)?.unitNumber || "").trim();
-    if (unitNumber && activeLeaseUnitNumbers.has(unitNumber)) return sum;
-    const configuredRent = resolveConfiguredUnitRent(unit);
-    return sum + (configuredRent != null ? Number(configuredRent) || 0 : 0);
-  }, 0);
-  const leaseRentRoll = activeLeaseRentRoll + occupiedUnitsFallbackRent;
+  const {
+    activeLeases,
+    leasedUnits,
+    occupancyRate,
+    activeLeaseRentTotal,
+    currentOccupiedRentTotal,
+  } = useMemo(() => buildPropertySummaryMetrics(displayedUnits, leases, unitCount), [displayedUnits, leases, unitCount]);
   const collectionRate =
-    leaseRentRoll > 0 ? totalCollectedThisMonth / leaseRentRoll : 0;
+    currentOccupiedRentTotal > 0 ? totalCollectedThisMonth / currentOccupiedRentTotal : 0;
 
-  const leasedUnitNumbers = useMemo(
-    () => new Set(occupiedUnits.map((unit: any) => String(unit?.unitNumber || "").trim()).filter(Boolean)),
-    [occupiedUnits]
-  );
   const unitsNeedingOccupancySetup = useMemo(
     () => getUnitsNeedingOccupancySetup(displayedUnits, activeLeases),
     [activeLeases, displayedUnits]
@@ -1098,7 +1067,10 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
             Leased units
           </div>
           <div className="rc-kpi-value" style={{ color: "#0b1220", fontWeight: 700, fontSize: "1.1rem" }}>
-            {leasedUnits}
+            {leasedUnits.length}
+          </div>
+          <div className="rc-kpi-subtext" style={{ color: "#4b5563", fontSize: "0.75rem", marginTop: 2 }}>
+            Counts units with an active lease record.
           </div>
         </div>
         <div
@@ -1114,7 +1086,10 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
             Occupancy
           </div>
           <div className="rc-kpi-value" style={{ color: "#0b1220", fontWeight: 700, fontSize: "1.05rem" }}>
-            {unitCount === 0 ? "--" : `${occupancy.toFixed(0)}%`}
+            {unitCount === 0 ? "--" : `${occupancyRate.toFixed(0)}%`}
+          </div>
+          <div className="rc-kpi-subtext" style={{ color: "#4b5563", fontSize: "0.75rem", marginTop: 2 }}>
+            Based on units marked occupied in the unit table.
           </div>
         </div>
         <div
@@ -1147,13 +1122,33 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
           }}
         >
           <div className="rc-kpi-label" style={{ color: "#111827", fontSize: "0.8rem" }}>
+            Active lease rent total
+          </div>
+          <div className="rc-kpi-value" style={{ color: "#0b1220", fontWeight: 700, fontSize: "1.05rem" }}>
+            {formatCurrency(activeLeaseRentTotal)}
+          </div>
+          <div className="rc-kpi-subtext" style={{ color: "#4b5563", fontSize: "0.75rem", marginTop: 2 }}>
+            Strictly from active lease records.
+          </div>
+        </div>
+
+        <div
+          className="rc-kpi-card"
+          style={{
+            padding: 12,
+            borderRadius: 12,
+            background: "rgba(255,255,255,0.02)",
+            border: "1px solid rgba(148,163,184,0.15)",
+          }}
+        >
+          <div className="rc-kpi-label" style={{ color: "#111827", fontSize: "0.8rem" }}>
             Current occupied rent total
           </div>
           <div className="rc-kpi-value" style={{ color: "#0b1220", fontWeight: 700, fontSize: "1.05rem" }}>
-            {formatCurrency(leaseRentRoll)}
+            {formatCurrency(currentOccupiedRentTotal)}
           </div>
           <div className="rc-kpi-subtext" style={{ color: "#4b5563", fontSize: "0.75rem", marginTop: 2 }}>
-            Uses active lease rent when present and occupied unit rent where current occupancy has been set manually.
+            Uses active lease rent when present and otherwise falls back to occupied unit rent.
           </div>
         </div>
 
@@ -1187,7 +1182,7 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
             Collection
           </div>
           <div className="rc-kpi-value" style={{ color: "#0b1220", fontWeight: 700, fontSize: "1.05rem" }}>
-            {leaseRentRoll === 0 ? "--" : `${(collectionRate * 100).toFixed(0)}%`}
+            {currentOccupiedRentTotal === 0 ? "--" : `${(collectionRate * 100).toFixed(0)}%`}
           </div>
         </div>
       </div>

--- a/rentchain-frontend/src/lib/propertySummaryMetrics.test.ts
+++ b/rentchain-frontend/src/lib/propertySummaryMetrics.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { buildPropertySummaryMetrics } from "./propertySummaryMetrics";
+
+describe("buildPropertySummaryMetrics", () => {
+  it("keeps leased units lease-based while occupancy stays unit-based", () => {
+    const metrics = buildPropertySummaryMetrics(
+      [
+        {
+          id: "unit-1",
+          unitNumber: "101",
+          status: "occupied",
+          rent: 1800,
+        },
+        {
+          id: "unit-2",
+          unitNumber: "102",
+          status: "vacant",
+          rent: 1700,
+        },
+      ],
+      [
+        {
+          id: "lease-1",
+          tenantId: "tenant-1",
+          propertyId: "prop-1",
+          unitId: "unit-2",
+          unitNumber: "102",
+          monthlyRent: 1900,
+          startDate: "2026-01-01",
+          status: "active",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+      2
+    );
+
+    expect(metrics.leasedUnits).toHaveLength(1);
+    expect(metrics.occupancyRate).toBe(50);
+    expect(metrics.activeLeaseRentTotal).toBe(1900);
+    expect(metrics.currentOccupiedRentTotal).toBe(1800);
+  });
+});

--- a/rentchain-frontend/src/lib/propertySummaryMetrics.ts
+++ b/rentchain-frontend/src/lib/propertySummaryMetrics.ts
@@ -1,0 +1,89 @@
+import type { Lease } from "@/api/leasesApi";
+import { resolveConfiguredUnitRent } from "@/lib/propertyRentSummary";
+
+const ACTIVE_LEASE_STATUSES = new Set([
+  "active",
+  "notice_pending",
+  "renewal_pending",
+  "renewal_accepted",
+  "move_out_pending",
+]);
+
+type UnitLike = Record<string, unknown>;
+
+function normalizeString(value: unknown): string {
+  return String(value || "").trim();
+}
+
+function unitIdentifiers(unit: UnitLike): string[] {
+  const values = [
+    normalizeString(unit.id),
+    normalizeString(unit.unitId),
+    normalizeString(unit.unitNumber),
+    normalizeString(unit.label),
+  ].filter(Boolean);
+  return Array.from(new Set(values));
+}
+
+function leaseIdentifiers(lease: Lease): string[] {
+  const values = [normalizeString(lease.unitId), normalizeString(lease.unitNumber)].filter(Boolean);
+  return Array.from(new Set(values));
+}
+
+function isOccupiedUnit(unit: UnitLike): boolean {
+  const status = normalizeString(unit.occupancyStatus || unit.status).toLowerCase();
+  return status === "occupied";
+}
+
+function isActiveLease(lease: Lease): boolean {
+  return ACTIVE_LEASE_STATUSES.has(normalizeString(lease.status).toLowerCase());
+}
+
+function getMatchingActiveLeases(unit: UnitLike, activeLeases: Lease[]): Lease[] {
+  const ids = new Set(unitIdentifiers(unit));
+  if (!ids.size) return [];
+  return activeLeases.filter((lease) => leaseIdentifiers(lease).some((identifier) => ids.has(identifier)));
+}
+
+export type PropertySummaryMetrics = {
+  activeLeases: Lease[];
+  occupiedUnits: UnitLike[];
+  leasedUnits: UnitLike[];
+  occupancyRate: number;
+  activeLeaseRentTotal: number;
+  currentOccupiedRentTotal: number;
+};
+
+export function buildPropertySummaryMetrics(units: UnitLike[], leases: Lease[], unitCount: number): PropertySummaryMetrics {
+  const displayedUnits = Array.isArray(units) ? units : [];
+  const activeLeases = (Array.isArray(leases) ? leases : []).filter(isActiveLease);
+  const occupiedUnits = displayedUnits.filter(isOccupiedUnit);
+  const leasedUnits = displayedUnits.filter((unit) => getMatchingActiveLeases(unit, activeLeases).length > 0);
+  const occupancyRate = unitCount > 0 ? (occupiedUnits.length / unitCount) * 100 : 0;
+  const activeLeaseRentTotal = activeLeases.reduce(
+    (sum, lease) => sum + (typeof lease.monthlyRent === "number" ? lease.monthlyRent : 0),
+    0
+  );
+  const currentOccupiedRentTotal = occupiedUnits.reduce((sum, unit) => {
+    const matchingLeases = getMatchingActiveLeases(unit, activeLeases);
+    if (matchingLeases.length > 0) {
+      return (
+        sum +
+        matchingLeases.reduce(
+          (leaseSum, lease) => leaseSum + (typeof lease.monthlyRent === "number" ? lease.monthlyRent : 0),
+          0
+        )
+      );
+    }
+    return sum + (resolveConfiguredUnitRent(unit) ?? 0);
+  }, 0);
+
+  return {
+    activeLeases,
+    occupiedUnits,
+    leasedUnits,
+    occupancyRate,
+    activeLeaseRentTotal,
+    currentOccupiedRentTotal,
+  };
+}


### PR DESCRIPTION
Repaired property summary integrity by separating unit occupancy metrics from lease-record metrics instead of blending them in the property panel.

This change introduces a shared `propertySummaryMetrics` helper, fixes `Leased units` and `Occupancy` so they reflect distinct canonical truths, and clarifies the UI labels for:
- Leased units
- Occupancy
- Active lease rent total
- Current occupied rent total

Key framing:
- occupancy and leased-unit counts intentionally represent different truths
- active lease rent total remains strictly lease-record-based
- current occupied rent total is intentionally hybrid and now labeled explicitly
- property summary derivation is now centralized in one shared helper
- no canonical unit or lease truth path was changed