### PR TITLE
feat: add safe execution expansion v1

### DIFF
--- a/rentchain-api/src/lib/analytics/__tests__/deriveDecisionAutomationRules.test.ts
+++ b/rentchain-api/src/lib/analytics/__tests__/deriveDecisionAutomationRules.test.ts
@@ -134,6 +134,6 @@ describe("deriveDecisionAutomationRule", () => {
       }),
     ]);
 
-    expect(result.map((decision) => decision.automationState)).toEqual(["blocked", "blocked", "manual_only"]);
+    expect(result.map((decision) => decision.automationState)).toEqual(["blocked", "ready", "manual_only"]);
   });
 });

--- a/rentchain-api/src/lib/analytics/deriveDecisionAutomationRules.ts
+++ b/rentchain-api/src/lib/analytics/deriveDecisionAutomationRules.ts
@@ -16,7 +16,7 @@ const WORKFLOW_BLOCK_REASONS: Partial<Record<LandlordDecisionWorkflowCategory, s
   application_funnel:
     "A screening automation path exists, but this decision does not yet identify a specific application to execute against.",
   maintenance_cost_approval:
-    "A deterministic maintenance approval target exists, but explicit maintenance execution is not enabled yet.",
+    "This maintenance approval decision still needs a deterministic approval-ready work order and complete approval inputs before execution.",
   maintenance_backlog:
     "A maintenance automation path exists, but this decision does not yet identify a specific work order with execution-ready evidence.",
 };
@@ -38,12 +38,6 @@ export function deriveDecisionAutomationRule(decision: LandlordAgentDecision): A
   }
   if (decision.state === "reviewed") {
     return lifecycleBlockedRule("Reviewed decisions stay manual until a new active decision is surfaced.");
-  }
-
-  if (decision.decisionType === "approve_maintenance_cost") {
-    return lifecycleBlockedRule(
-      "A deterministic maintenance approval target exists, but explicit maintenance execution is not enabled yet."
-    );
   }
 
   if (decision.automationEligible) {

--- a/rentchain-api/src/routes/__tests__/landlordAnalyticsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordAnalyticsRoutes.test.ts
@@ -17,6 +17,8 @@ const getLeaseForLandlordWorkflow = vi.fn();
 const normalizeLeaseRecord = vi.fn();
 const performLeaseNoticeSendFromPreviewInput = vi.fn();
 const loadLandlordDecisionTimeline = vi.fn();
+const loadMaintenanceApprovalWorkOrderForLandlord = vi.fn();
+const executeMaintenanceApprovalAutomation = vi.fn();
 
 vi.mock("../../middleware/requireAuth", () => ({
   requireAuth: (req: any, res: any, next: any) => {
@@ -75,6 +77,11 @@ vi.mock("../../services/leaseNoticeWorkflowService", () => ({
 
 vi.mock("../../services/landlord/landlordDecisionHistory", () => ({
   loadLandlordDecisionTimeline,
+}));
+
+vi.mock("../../services/maintenanceApprovalExecutionService", () => ({
+  loadMaintenanceApprovalWorkOrderForLandlord,
+  executeMaintenanceApprovalAutomation,
 }));
 
 vi.mock("../../lib/events/buildEvent", () => ({
@@ -262,6 +269,40 @@ describe("landlordAnalyticsRoutes", () => {
         actor: "Landlord",
       },
     ]);
+    loadMaintenanceApprovalWorkOrderForLandlord.mockResolvedValue({
+      ok: true,
+      workOrder: {
+        id: "wo-1",
+        landlordId: "landlord-1",
+        propertyId: "prop-2",
+        unitId: "unit-9",
+        maintenanceRequestId: "maint-1",
+        cost: {
+          actualCostCents: 32000,
+          currency: "CAD",
+          reviewStatus: "pending_review",
+        },
+        costAttachments: [{ id: "attachment-1" }],
+      },
+    });
+    executeMaintenanceApprovalAutomation.mockResolvedValue({
+      autopilotPolicy: {
+        outcome: "allow",
+        requiresManualApproval: false,
+        topReasonCode: "ALLOW",
+      },
+      automationResult: {
+        action: "maintenance.auto_approve_cost",
+        executed: true,
+        skipped: false,
+        timestamp: "2026-04-20T12:00:00.000Z",
+      },
+      workOrderId: "wo-1",
+      workOrder: {
+        id: "wo-1",
+        landlordId: "landlord-1",
+      },
+    });
     loadLandlordAnalyticsSnapshot.mockResolvedValue({
       summary: {
         occupiedUnits: 4,
@@ -747,6 +788,121 @@ describe("landlordAnalyticsRoutes", () => {
     expect(executeAutomation).not.toHaveBeenCalled();
   });
 
+  it("executes a ready mapped maintenance decision and persists executed state", async () => {
+    saveExecutedLandlordDecisionState.mockResolvedValueOnce({
+      id: "landlord-1__approve_maintenance_cost:wo-1",
+      landlordId: "landlord-1",
+      decisionId: "approve_maintenance_cost:wo-1",
+      state: "executed",
+      reviewedAt: null,
+      executedAt: "2026-04-20T12:00:00.000Z",
+      executionOutcomeStatus: "succeeded",
+      executionOutcomeAt: "2026-04-20T12:00:00.000Z",
+      executionOutcomeReason: null,
+      createdAt: "2026-04-20T12:00:00.000Z",
+      updatedAt: "2026-04-20T12:00:00.000Z",
+    });
+    loadLandlordAnalyticsSnapshot.mockResolvedValueOnce({
+      decisions: {
+        items: [
+          {
+            id: "approve_maintenance_cost:wo-1",
+            decisionType: "approve_maintenance_cost",
+            priority: "high",
+            explanation: "Approve this maintenance cost.",
+            supportingSignals: [],
+            recommendedAction: "Review work order approval",
+            actionKey: "open_maintenance_cost_approval_flow",
+            actionLabel: "Open cost approval",
+            destination: "/work-orders?entry=maintenance-cost-approval&propertyId=prop-2&workOrderId=wo-1",
+            workflowCategory: "maintenance_cost_approval",
+            automationEligible: true,
+            automationState: "ready",
+            automationReason: "This decision is active and already mapped to a deterministic automation path.",
+            executionMappingState: "mapped",
+            executionMapping: {
+              action: "maintenance.auto_approve_cost",
+              resourceType: "work_order",
+              resourceId: "wo-1",
+              prerequisitesMet: true,
+              prerequisiteReason: null,
+            },
+            executionInputState: "complete",
+            executionInputReason: null,
+            executionInputMissingFields: [],
+            executionInput: {
+              actualCostCents: 32000,
+              currency: "CAD",
+              reviewStatus: "pending_review",
+              linkedExpenseStatus: "not_linked",
+              hasSupportingEvidence: true,
+              thresholdCents: 100000,
+              withinAutoApprovalThreshold: true,
+            },
+            executedAt: null,
+            executionOutcomeStatus: "none",
+            executionOutcomeAt: null,
+            executionOutcomeReason: null,
+            href: "/work-orders?entry=maintenance-cost-approval&propertyId=prop-2&workOrderId=wo-1",
+            state: "pending",
+            reviewedAt: null,
+          },
+        ],
+      },
+    });
+
+    const router = (await import("../landlordAnalyticsRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "POST",
+      url: "/landlord/analytics/decisions/approve_maintenance_cost%3Awo-1/execute",
+      user: { id: "landlord-1", role: "landlord" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(loadMaintenanceApprovalWorkOrderForLandlord).toHaveBeenCalledWith({
+      landlordId: "landlord-1",
+      workOrderId: "wo-1",
+    });
+    expect(executeMaintenanceApprovalAutomation).toHaveBeenCalledWith({
+      workOrderId: "wo-1",
+      workOrder: expect.objectContaining({ id: "wo-1" }),
+      actorId: "landlord-1",
+      actorRole: "landlord",
+      landlordId: "landlord-1",
+      initiatedFrom: "decision_execute",
+      decisionId: "approve_maintenance_cost:wo-1",
+    });
+    expect(saveExecutedLandlordDecisionState).toHaveBeenCalledWith({
+      landlordId: "landlord-1",
+      decisionId: "approve_maintenance_cost:wo-1",
+    });
+    expect(writeCanonicalEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "decision.execution_requested",
+        metadata: expect.objectContaining({
+          decisionId: "approve_maintenance_cost:wo-1",
+          action: "maintenance.auto_approve_cost",
+          resourceId: "wo-1",
+        }),
+      })
+    );
+    expect(writeCanonicalEvent).toHaveBeenCalledWith(expect.objectContaining({ type: "decision.executed" }));
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        ok: true,
+        execution: expect.objectContaining({
+          decisionId: "approve_maintenance_cost:wo-1",
+          action: "maintenance.auto_approve_cost",
+          resourceId: "wo-1",
+        }),
+        state: expect.objectContaining({
+          state: "executed",
+          executionOutcomeStatus: "succeeded",
+        }),
+      })
+    );
+  });
+
   it("persists failed execution feedback without resolving the decision", async () => {
     loadLandlordAnalyticsSnapshot.mockResolvedValueOnce({
       decisions: {
@@ -834,6 +990,111 @@ describe("landlordAnalyticsRoutes", () => {
           state: "pending",
           executionOutcomeStatus: "failed",
           executionOutcomeReason: "AUTOMATION_EXECUTION_FAILED",
+        }),
+      })
+    );
+  });
+
+  it("persists failed maintenance execution feedback without resolving the decision", async () => {
+    saveFailedLandlordDecisionExecutionOutcome.mockResolvedValueOnce({
+      id: "landlord-1__approve_maintenance_cost:wo-1",
+      landlordId: "landlord-1",
+      decisionId: "approve_maintenance_cost:wo-1",
+      state: "pending",
+      reviewedAt: null,
+      executedAt: null,
+      executionOutcomeStatus: "failed",
+      executionOutcomeAt: "2026-04-20T12:00:00.000Z",
+      executionOutcomeReason: "MAINTENANCE_COST_REVIEW_REQUIRED",
+      createdAt: "2026-04-20T12:00:00.000Z",
+      updatedAt: "2026-04-20T12:00:00.000Z",
+    });
+    loadLandlordAnalyticsSnapshot.mockResolvedValueOnce({
+      decisions: {
+        items: [
+          {
+            id: "approve_maintenance_cost:wo-1",
+            decisionType: "approve_maintenance_cost",
+            priority: "high",
+            explanation: "Approve this maintenance cost.",
+            supportingSignals: [],
+            recommendedAction: "Review work order approval",
+            actionKey: "open_maintenance_cost_approval_flow",
+            actionLabel: "Open cost approval",
+            destination: "/work-orders?entry=maintenance-cost-approval&propertyId=prop-2&workOrderId=wo-1",
+            workflowCategory: "maintenance_cost_approval",
+            automationEligible: true,
+            automationState: "ready",
+            automationReason: "This decision is active and already mapped to a deterministic automation path.",
+            executionMappingState: "mapped",
+            executionMapping: {
+              action: "maintenance.auto_approve_cost",
+              resourceType: "work_order",
+              resourceId: "wo-1",
+              prerequisitesMet: true,
+              prerequisiteReason: null,
+            },
+            executionInputState: "complete",
+            executionInputReason: null,
+            executionInputMissingFields: [],
+            executionInput: {
+              actualCostCents: 32000,
+              currency: "CAD",
+              reviewStatus: "pending_review",
+              linkedExpenseStatus: "not_linked",
+              hasSupportingEvidence: true,
+              thresholdCents: 100000,
+              withinAutoApprovalThreshold: true,
+            },
+            executedAt: null,
+            executionOutcomeStatus: "none",
+            executionOutcomeAt: null,
+            executionOutcomeReason: null,
+            href: "/work-orders?entry=maintenance-cost-approval&propertyId=prop-2&workOrderId=wo-1",
+            state: "pending",
+            reviewedAt: null,
+          },
+        ],
+      },
+    });
+    executeMaintenanceApprovalAutomation.mockResolvedValueOnce({
+      autopilotPolicy: {
+        outcome: "review",
+        requiresManualApproval: true,
+        topReasonCode: "MAINTENANCE_COST_REVIEW_REQUIRED",
+      },
+      automationResult: {
+        action: "maintenance.auto_approve_cost",
+        executed: false,
+        skipped: true,
+        reason: "MAINTENANCE_COST_REVIEW_REQUIRED",
+        timestamp: "2026-04-20T12:00:00.000Z",
+      },
+      workOrderId: "wo-1",
+      workOrder: null,
+    });
+
+    const router = (await import("../landlordAnalyticsRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "POST",
+      url: "/landlord/analytics/decisions/approve_maintenance_cost%3Awo-1/execute",
+      user: { id: "landlord-1", role: "landlord" },
+    });
+
+    expect(response.status).toBe(409);
+    expect(saveFailedLandlordDecisionExecutionOutcome).toHaveBeenCalledWith({
+      landlordId: "landlord-1",
+      decisionId: "approve_maintenance_cost:wo-1",
+      reason: "MAINTENANCE_COST_REVIEW_REQUIRED",
+    });
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        ok: false,
+        error: "DECISION_EXECUTION_FAILED",
+        state: expect.objectContaining({
+          state: "pending",
+          executionOutcomeStatus: "failed",
+          executionOutcomeReason: "MAINTENANCE_COST_REVIEW_REQUIRED",
         }),
       })
     );

--- a/rentchain-api/src/routes/landlordAnalyticsRoutes.ts
+++ b/rentchain-api/src/routes/landlordAnalyticsRoutes.ts
@@ -11,6 +11,10 @@ import {
   normalizeLeaseRecord,
   performLeaseNoticeSendFromPreviewInput,
 } from "../services/leaseNoticeWorkflowService";
+import {
+  executeMaintenanceApprovalAutomation,
+  loadMaintenanceApprovalWorkOrderForLandlord,
+} from "../services/maintenanceApprovalExecutionService";
 import { loadLandlordAnalyticsSnapshot } from "../services/landlord/landlordAnalyticsSnapshot";
 import {
   saveExecutedLandlordDecisionState,
@@ -288,25 +292,6 @@ router.post("/landlord/analytics/decisions/:decisionId/execute", requireAuth, re
         reason: decision.executionInputReason || null,
       });
     }
-    if (decision.executionMapping.action !== "lease.auto_send_notice" || decision.executionMapping.resourceType !== "lease") {
-      return res.status(409).json({ ok: false, error: "DECISION_EXECUTION_UNSUPPORTED" });
-    }
-
-    const leaseResult = await getLeaseForLandlordWorkflow(decision.executionMapping.resourceId, landlordId);
-    if (!leaseResult.ok) {
-      return res.status(leaseResult.status).json({ ok: false, error: leaseResult.error });
-    }
-    const lease = normalizeLeaseRecord(leaseResult.lease.id || decision.executionMapping.resourceId, leaseResult.lease);
-    const previewInput = buildLeaseNoticePreviewInputFromLease(lease);
-    if (!previewInput) {
-      return res.status(409).json({
-        ok: false,
-        error: "DECISION_INPUTS_INCOMPLETE",
-        missingFields: decision.executionInputMissingFields || [],
-        reason: decision.executionInputReason || null,
-      });
-    }
-
     await writeCanonicalEvent({
       type: "decision.execution_requested",
       domain: "system",
@@ -327,86 +312,129 @@ router.post("/landlord/analytics/decisions/:decisionId/execute", requireAuth, re
       },
     });
 
-    const requestBody = {
-      rentChangeMode: previewInput.rentChangeMode,
-      proposedRent: previewInput.proposedRent,
-      newTermType: previewInput.newTermType,
-      newLeaseStartDate: previewInput.newLeaseStartDate,
-      newLeaseEndDate: previewInput.newLeaseEndDate,
-      responseDeadlineAt: previewInput.responseDeadlineAt,
-      noticeType: previewInput.noticeType,
-    };
-    const policyRequest = buildLeaseNoticePolicyRequest({
-      action: "send_notice",
-      actorRole: asString(req.user?.role, 80).toLowerCase() || "landlord",
-      actorUserId: actorId,
-      lease,
-      leaseId: lease.id,
-      requestBody,
-    });
-    const policyResult = evaluatePolicy(policyRequest);
-    const autopilotPolicy = toAutopilotPolicySummary(policyResult);
-    await writePolicyEvaluatedEvent({
-      request: policyRequest,
-      result: policyResult,
-      actorType: "landlord",
-      metadata: {
-        landlordId,
-        tenantId: lease.tenantId,
-        propertyId: lease.propertyId,
-        unitId: lease.unitId,
-        initiatedFrom: "decision_execute",
-        decisionId,
-      },
-    });
-
     let automation;
     try {
-      automation = await executeAutomation({
-        action: "lease.auto_send_notice",
-        policyResult,
-        actor: {
-          type: "landlord",
-          id: actorId,
-          role: "landlord",
-        },
-        resource: {
-          type: "lease",
-          id: lease.id,
-        },
-        visibility: "internal",
-        metadata: {
-          domain: "lease_notice",
-          initiatedFrom: "decision_execute",
-          landlordId,
-          tenantId: lease.tenantId,
-          propertyId: lease.propertyId,
-          unitId: lease.unitId,
-          decisionId,
-          policyAction: "send_notice",
-        },
-        context: {
-          noticeReady: true,
-          alreadySent: Boolean(lease.latestNoticeId),
-          hasRequiredLegalInputs: Boolean(policyRequest.context.hasRequiredLegalInputs),
-          execute: async () => {
-            const execution = await performLeaseNoticeSendFromPreviewInput({
-              leaseId: lease.id,
-              landlordId,
-              actorId,
-              lease,
-              previewInput,
-              autopilotPolicy,
-            });
-            if (execution.status >= 400 || !execution.payload.ok) {
-              const error = new Error(String(execution.payload?.error || "AUTOMATION_EXECUTION_FAILED"));
-              (error as any).code = execution.payload?.error || "AUTOMATION_EXECUTION_FAILED";
-              throw error;
-            }
-            return execution.payload;
+      if (decision.executionMapping.action === "lease.auto_send_notice" && decision.executionMapping.resourceType === "lease") {
+        const leaseResult = await getLeaseForLandlordWorkflow(decision.executionMapping.resourceId, landlordId);
+        if (!leaseResult.ok) {
+          return res.status(leaseResult.status).json({ ok: false, error: leaseResult.error });
+        }
+        const lease = normalizeLeaseRecord(leaseResult.lease.id || decision.executionMapping.resourceId, leaseResult.lease);
+        const previewInput = buildLeaseNoticePreviewInputFromLease(lease);
+        if (!previewInput) {
+          return res.status(409).json({
+            ok: false,
+            error: "DECISION_INPUTS_INCOMPLETE",
+            missingFields: decision.executionInputMissingFields || [],
+            reason: decision.executionInputReason || null,
+          });
+        }
+
+        const requestBody = {
+          rentChangeMode: previewInput.rentChangeMode,
+          proposedRent: previewInput.proposedRent,
+          newTermType: previewInput.newTermType,
+          newLeaseStartDate: previewInput.newLeaseStartDate,
+          newLeaseEndDate: previewInput.newLeaseEndDate,
+          responseDeadlineAt: previewInput.responseDeadlineAt,
+          noticeType: previewInput.noticeType,
+        };
+        const policyRequest = buildLeaseNoticePolicyRequest({
+          action: "send_notice",
+          actorRole: asString(req.user?.role, 80).toLowerCase() || "landlord",
+          actorUserId: actorId,
+          lease,
+          leaseId: lease.id,
+          requestBody,
+        });
+        const policyResult = evaluatePolicy(policyRequest);
+        const autopilotPolicy = toAutopilotPolicySummary(policyResult);
+        await writePolicyEvaluatedEvent({
+          request: policyRequest,
+          result: policyResult,
+          actorType: "landlord",
+          metadata: {
+            landlordId,
+            tenantId: lease.tenantId,
+            propertyId: lease.propertyId,
+            unitId: lease.unitId,
+            initiatedFrom: "decision_execute",
+            decisionId,
           },
-        },
-      });
+        });
+
+        automation = await executeAutomation({
+          action: "lease.auto_send_notice",
+          policyResult,
+          actor: {
+            type: "landlord",
+            id: actorId,
+            role: "landlord",
+          },
+          resource: {
+            type: "lease",
+            id: lease.id,
+          },
+          visibility: "internal",
+          metadata: {
+            domain: "lease_notice",
+            initiatedFrom: "decision_execute",
+            landlordId,
+            tenantId: lease.tenantId,
+            propertyId: lease.propertyId,
+            unitId: lease.unitId,
+            decisionId,
+            policyAction: "send_notice",
+          },
+          context: {
+            noticeReady: true,
+            alreadySent: Boolean(lease.latestNoticeId),
+            hasRequiredLegalInputs: Boolean(policyRequest.context.hasRequiredLegalInputs),
+            execute: async () => {
+              const execution = await performLeaseNoticeSendFromPreviewInput({
+                leaseId: lease.id,
+                landlordId,
+                actorId,
+                lease,
+                previewInput,
+                autopilotPolicy,
+              });
+              if (execution.status >= 400 || !execution.payload.ok) {
+                const error = new Error(String(execution.payload?.error || "AUTOMATION_EXECUTION_FAILED"));
+                (error as any).code = execution.payload?.error || "AUTOMATION_EXECUTION_FAILED";
+                throw error;
+              }
+              return execution.payload;
+            },
+          },
+        });
+      } else if (
+        decision.executionMapping.action === "maintenance.auto_approve_cost" &&
+        decision.executionMapping.resourceType === "work_order"
+      ) {
+        const workOrderResult = await loadMaintenanceApprovalWorkOrderForLandlord({
+          landlordId,
+          workOrderId: decision.executionMapping.resourceId,
+        });
+        if (!workOrderResult.ok) {
+          return res.status(workOrderResult.error === "FORBIDDEN" ? 403 : 404).json({
+            ok: false,
+            error: workOrderResult.error,
+          });
+        }
+
+        automation = await executeMaintenanceApprovalAutomation({
+          workOrderId: decision.executionMapping.resourceId,
+          workOrder: workOrderResult.workOrder,
+          actorId,
+          actorRole: "landlord",
+          landlordId,
+          initiatedFrom: "decision_execute",
+          decisionId,
+        });
+      } else {
+        return res.status(409).json({ ok: false, error: "DECISION_EXECUTION_UNSUPPORTED" });
+      }
     } catch (executionErr: any) {
       const persistedFailureState = await saveFailedLandlordDecisionExecutionOutcome({
         landlordId,
@@ -486,6 +514,9 @@ router.post("/landlord/analytics/decisions/:decisionId/execute", requireAuth, re
       });
     }
 
+    const executionPayload =
+      "data" in automation && automation.data && typeof automation.data === "object" ? automation.data : {};
+
     return res.json({
       ok: true,
       execution: {
@@ -496,7 +527,7 @@ router.post("/landlord/analytics/decisions/:decisionId/execute", requireAuth, re
       },
       automationResult: automation.automationResult,
       state: decisionStatePayload(persistedState),
-      ...(automation.data && typeof automation.data === "object" ? automation.data : {}),
+      ...executionPayload,
     });
   } catch (err: any) {
     console.error("[landlord-analytics] decision execute failed", err?.message || err);

--- a/rentchain-api/src/routes/workOrdersRoutes.ts
+++ b/rentchain-api/src/routes/workOrdersRoutes.ts
@@ -30,11 +30,9 @@ import {
 } from "../lib/maintenanceNotifications";
 import { createTransaction } from "../services/financialTransactionService";
 import { writeCanonicalEvent } from "../lib/events/buildEvent";
-import { executeAutomation } from "../lib/automation/automationExecutor";
-import { hasSupportingEvidenceForWorkOrder } from "../lib/maintenanceApprovalReadiness";
+import { executeMaintenanceApprovalAutomation } from "../services/maintenanceApprovalExecutionService";
 import { buildMaintenancePolicyRequest } from "../lib/policy/policyAdapters";
 import { evaluatePolicy, toAutopilotPolicySummary, writePolicyEvaluatedEvent } from "../lib/policy/policyEvaluator";
-import { MAINTENANCE_AUTO_APPROVAL_THRESHOLD_CENTS } from "../lib/policy/policyRules";
 
 const router = Router();
 
@@ -2760,6 +2758,25 @@ router.post("/landlord/work-orders/:id/review-cost", requireAuth, async (req: an
     if (decision === "revision_requested" && !note) {
       return res.status(400).json({ ok: false, error: "COST_REVISION_NOTE_REQUIRED" });
     }
+    if (automationRequested) {
+      const automation = await executeMaintenanceApprovalAutomation({
+        workOrderId,
+        workOrder: access.item,
+        actorId: access.userId,
+        actorRole: isAdmin(req) ? "admin" : "landlord",
+        landlordId: asOptionalString((access.item as any)?.landlordId, 120) || access.landlordId || null,
+        initiatedFrom: "work_order_review_cost",
+      });
+      const fallbackItem = await toWorkOrderResponseForAudience(workOrderId, access.item, "landlord");
+      return res.json({
+        ok: true,
+        item: automation.workOrder
+          ? await toWorkOrderResponseForAudience(automation.workOrderId, automation.workOrder, "landlord")
+          : fallbackItem,
+        autopilotPolicy: automation.autopilotPolicy,
+        automationResult: automation.automationResult,
+      });
+    }
     const policyRequest = buildMaintenancePolicyRequest({
       action: decision === "approve" ? "approve_cost" : "review_cost",
       actorRole: isAdmin(req) ? "admin" : "landlord",
@@ -2866,45 +2883,6 @@ router.post("/landlord/work-orders/:id/review-cost", requireAuth, async (req: an
       const refreshed = await db.collection("workOrders").doc(workOrderId).get();
       return await toWorkOrderResponseForAudience(refreshed.id, refreshed.data(), "landlord");
     };
-
-    if (automationRequested) {
-      const automation = await executeAutomation({
-        action: "maintenance.auto_approve_cost",
-        policyResult,
-        actor: {
-          type: isAdmin(req) ? "admin" : "landlord",
-          id: access.userId,
-          role: isAdmin(req) ? "admin" : "landlord",
-        },
-        resource: {
-          type: "work_order",
-          id: workOrderId,
-        },
-        visibility: "internal",
-        metadata: {
-          domain: "maintenance",
-          landlordId: asOptionalString((access.item as any)?.landlordId, 120),
-          maintenanceRequestId: asOptionalString((access.item as any)?.maintenanceRequestId, 120),
-          propertyId: asOptionalString((access.item as any)?.propertyId, 120),
-          unitId: asOptionalString((access.item as any)?.unitId, 120),
-          policyAction: "approve_cost",
-        },
-        context: {
-          alreadyApproved: String(currentCost.reviewStatus || "").toLowerCase() === "approved",
-          actualCostCents: currentCost.actualCostCents,
-          thresholdCents: MAINTENANCE_AUTO_APPROVAL_THRESHOLD_CENTS,
-          hasSupportingEvidence: hasSupportingEvidenceForWorkOrder(access.item),
-          execute: executeDecision,
-        },
-      });
-      const fallbackItem = await toWorkOrderResponseForAudience(workOrderId, access.item, "landlord");
-      return res.json({
-        ok: true,
-        item: automation.data || fallbackItem,
-        autopilotPolicy,
-        automationResult: automation.automationResult,
-      });
-    }
 
     const item = await executeDecision();
     return res.json({

--- a/rentchain-api/src/services/landlord/__tests__/landlordAnalyticsSnapshot.test.ts
+++ b/rentchain-api/src/services/landlord/__tests__/landlordAnalyticsSnapshot.test.ts
@@ -368,9 +368,9 @@ describe("loadLandlordAnalyticsSnapshot", () => {
           destination: "/work-orders?entry=maintenance-cost-approval&propertyId=prop-2&workOrderId=wo-1",
           workflowCategory: "maintenance_cost_approval",
           recommendedAction: "Review work order approval",
-          automationEligible: false,
-          automationState: "blocked",
-          automationReason: expect.stringContaining("explicit maintenance execution is not enabled yet"),
+          automationEligible: true,
+          automationState: "ready",
+          automationReason: "This decision is active and already mapped to a deterministic automation path.",
           executionMappingState: "mapped",
           executionMapping: expect.objectContaining({
             action: "maintenance.auto_approve_cost",

--- a/rentchain-api/src/services/maintenanceApprovalExecutionService.ts
+++ b/rentchain-api/src/services/maintenanceApprovalExecutionService.ts
@@ -1,0 +1,290 @@
+import crypto from "crypto";
+import { db } from "../config/firebase";
+import { writeCanonicalEvent } from "../lib/events/buildEvent";
+import { executeAutomation } from "../lib/automation/automationExecutor";
+import { normalizeCostReviewHistory, normalizeWorkOrderCost } from "../lib/maintenanceCost";
+import { hasSupportingEvidenceForWorkOrder } from "../lib/maintenanceApprovalReadiness";
+import { buildMaintenancePolicyRequest } from "../lib/policy/policyAdapters";
+import { evaluatePolicy, toAutopilotPolicySummary, writePolicyEvaluatedEvent } from "../lib/policy/policyEvaluator";
+import { MAINTENANCE_AUTO_APPROVAL_THRESHOLD_CENTS } from "../lib/policy/policyRules";
+
+function nowMs() {
+  return Date.now();
+}
+
+function asString(value: unknown, max = 2000): string {
+  return String(value || "").trim().slice(0, max);
+}
+
+function asOptionalString(value: unknown, max = 2000): string | null {
+  const v = asString(value, max);
+  return v || null;
+}
+
+function makeCostHistoryEntryId() {
+  return `cost_${crypto.randomBytes(8).toString("hex")}`;
+}
+
+function buildCostHistoryEntry(input: {
+  revisionNumber: number;
+  submittedAt: number;
+  submittedByRole: "contractor" | "landlord" | "admin";
+  submittedById: string;
+  actualCostCents: number;
+  currency?: string | null;
+  reviewStatus: "pending_review" | "approved" | "rejected" | "revision_requested";
+  reviewedAt?: number | null;
+  reviewedBy?: string | null;
+  reviewNote?: string | null;
+  linkedExpenseId?: string | null;
+}) {
+  return {
+    id: makeCostHistoryEntryId(),
+    revisionNumber: Math.max(1, Math.round(input.revisionNumber || 1)),
+    submittedAt: Math.round(input.submittedAt),
+    submittedByRole: input.submittedByRole,
+    submittedById: input.submittedById,
+    actualCostCents: Math.round(input.actualCostCents),
+    currency: asString(input.currency, 12) || "CAD",
+    reviewStatus: input.reviewStatus,
+    reviewedAt: typeof input.reviewedAt === "number" ? Math.round(input.reviewedAt) : null,
+    reviewedBy: asOptionalString(input.reviewedBy, 120),
+    reviewNote: asOptionalString(input.reviewNote, 1000),
+    linkedExpenseId: asOptionalString(input.linkedExpenseId, 120),
+  };
+}
+
+function getCurrentCostRevisionNumber(data: any) {
+  const current = Number(data?.cost?.latestRevisionNumber || 0);
+  const historyMax = normalizeCostReviewHistory(data?.costReviewHistory).reduce(
+    (max, entry) => Math.max(max, Number(entry.revisionNumber || 0)),
+    0
+  );
+  return Math.max(current, historyMax, 0);
+}
+
+async function writeWorkOrderUpdate(input: {
+  workOrderId: string;
+  actorRole: "landlord" | "admin";
+  actorId: string;
+  updateType: "invoice";
+  message?: string;
+  attachmentUrl?: string | null;
+}) {
+  const createdAtMs = nowMs();
+  const ref = db.collection("workOrderUpdates").doc();
+  await ref.set({
+    id: ref.id,
+    workOrderId: input.workOrderId,
+    actorRole: input.actorRole,
+    actorId: input.actorId,
+    updateType: input.updateType,
+    message: asString(input.message || "", 5000),
+    attachmentUrl: asOptionalString(input.attachmentUrl, 2000),
+    createdAtMs,
+  });
+}
+
+export async function loadMaintenanceApprovalWorkOrderForLandlord(params: {
+  landlordId: string;
+  workOrderId: string;
+}) {
+  const landlordId = asString(params.landlordId, 240);
+  const workOrderId = asString(params.workOrderId, 240);
+  if (!landlordId || !workOrderId) return { ok: false as const, error: "NOT_FOUND" as const };
+
+  const snap = await db.collection("workOrders").doc(workOrderId).get();
+  if (!snap.exists) {
+    return { ok: false as const, error: "NOT_FOUND" as const };
+  }
+
+  const workOrder = { id: snap.id, ...(snap.data() || {}) };
+  const ownerLandlordId = asString((workOrder as any)?.landlordId, 240);
+  if (ownerLandlordId && ownerLandlordId !== landlordId) {
+    return { ok: false as const, error: "FORBIDDEN" as const };
+  }
+
+  return { ok: true as const, workOrder };
+}
+
+export async function executeMaintenanceApprovalAutomation(params: {
+  workOrderId: string;
+  workOrder: any;
+  actorId: string | null;
+  actorRole: "landlord" | "admin";
+  landlordId: string | null;
+  initiatedFrom: "work_order_review_cost" | "decision_execute";
+  decisionId?: string | null;
+}) {
+  const workOrderId = asString(params.workOrderId, 240);
+  const workOrder = params.workOrder || {};
+  const actorId = asString(params.actorId, 240) || null;
+  const actorRole = params.actorRole;
+  const landlordId = asString(params.landlordId, 240) || null;
+  const currentCost = normalizeWorkOrderCost((workOrder as any)?.cost);
+  if (!currentCost?.actualCostCents) {
+    const error = new Error("COST_NOT_SUBMITTED");
+    (error as any).code = "COST_NOT_SUBMITTED";
+    throw error;
+  }
+  const actualCostCents = currentCost.actualCostCents;
+
+  const policyRequest = buildMaintenancePolicyRequest({
+    action: "approve_cost",
+    actorRole,
+    actorUserId: actorId,
+    workOrderId,
+    workOrder,
+    actualCostCents,
+  });
+  const policyResult = evaluatePolicy(policyRequest);
+  const autopilotPolicy = toAutopilotPolicySummary(policyResult);
+  await writePolicyEvaluatedEvent({
+    request: policyRequest,
+    result: policyResult,
+    actorType: actorRole,
+    metadata: {
+      landlordId: asOptionalString((workOrder as any)?.landlordId, 120) || landlordId,
+      maintenanceRequestId: asOptionalString((workOrder as any)?.maintenanceRequestId, 120),
+      propertyId: asOptionalString((workOrder as any)?.propertyId, 120),
+      unitId: asOptionalString((workOrder as any)?.unitId, 120),
+      initiatedFrom: params.initiatedFrom,
+      decisionId: asOptionalString(params.decisionId, 240),
+    },
+  });
+
+  const executeDecision = async () => {
+    const now = nowMs();
+    const currentRevisionNumber = getCurrentCostRevisionNumber(workOrder);
+    const history = normalizeCostReviewHistory((workOrder as any)?.costReviewHistory);
+    const updatedHistory =
+      history.length > 0
+        ? history.map((entry) =>
+            entry.revisionNumber === currentRevisionNumber
+              ? {
+                  ...entry,
+                  reviewStatus: "approved" as const,
+                  reviewedAt: now,
+                  reviewedBy: actorId,
+                  reviewNote: null,
+                }
+              : entry
+          )
+        : [
+            buildCostHistoryEntry({
+              revisionNumber: Math.max(1, currentRevisionNumber || 1),
+              submittedAt: Number(currentCost.submittedAt || now),
+              submittedByRole:
+                currentCost.submittedByRole === "contractor" || currentCost.submittedByRole === "admin"
+                  ? currentCost.submittedByRole
+                  : "landlord",
+              submittedById: asString(currentCost.submittedById, 120) || actorId || landlordId || "system",
+              actualCostCents,
+              currency: currentCost.currency || "CAD",
+              reviewStatus: "approved",
+              reviewedAt: now,
+              reviewedBy: actorId,
+              reviewNote: null,
+            }),
+          ];
+
+    await db.collection("workOrders").doc(workOrderId).set(
+      {
+        cost: {
+          ...currentCost,
+          reviewStatus: "approved",
+          reviewedBy: actorId,
+          reviewedAt: now,
+          reviewNote: null,
+          revisionRequestedAt: null,
+          revisionRequestedBy: null,
+        },
+        costReviewHistory: updatedHistory,
+        updatedAtMs: now,
+      },
+      { merge: true }
+    );
+
+    await writeWorkOrderUpdate({
+      workOrderId,
+      actorRole,
+      actorId: actorId || landlordId || "system",
+      updateType: "invoice",
+      message: "Cost submission approved.",
+    });
+
+    await writeCanonicalEvent({
+      domain: "expense",
+      action: "approved",
+      status: "approved",
+      actor: {
+        type: actorRole,
+        role: actorRole,
+        id: actorId,
+      },
+      resource: {
+        type: "work_order_cost",
+        id: workOrderId,
+        parentType: "work_order",
+        parentId: workOrderId,
+      },
+      occurredAt: now,
+      visibility: "internal",
+      summary: "Maintenance cost approved for expense reconciliation",
+      metadata: {
+        maintenanceRequestId: asOptionalString((workOrder as any)?.maintenanceRequestId, 120),
+        propertyId: asOptionalString((workOrder as any)?.propertyId, 120),
+        unitId: asOptionalString((workOrder as any)?.unitId, 120),
+        actualCostCents,
+        currency: currentCost.currency || "CAD",
+        initiatedFrom: params.initiatedFrom,
+        decisionId: asOptionalString(params.decisionId, 240),
+      },
+    });
+
+    const refreshed = await db.collection("workOrders").doc(workOrderId).get();
+    return {
+      workOrderId: refreshed.id,
+      workOrder: refreshed.data() || null,
+    };
+  };
+
+  const automation = await executeAutomation<"maintenance.auto_approve_cost", { workOrderId: string; workOrder: any | null }>({
+    action: "maintenance.auto_approve_cost",
+    policyResult,
+    actor: {
+      type: actorRole,
+      id: actorId,
+      role: actorRole,
+    },
+    resource: {
+      type: "work_order",
+      id: workOrderId,
+    },
+    visibility: "internal",
+    metadata: {
+      domain: "maintenance",
+      landlordId: asOptionalString((workOrder as any)?.landlordId, 120) || landlordId,
+      maintenanceRequestId: asOptionalString((workOrder as any)?.maintenanceRequestId, 120),
+      propertyId: asOptionalString((workOrder as any)?.propertyId, 120),
+      unitId: asOptionalString((workOrder as any)?.unitId, 120),
+      policyAction: "approve_cost",
+      initiatedFrom: params.initiatedFrom,
+      decisionId: asOptionalString(params.decisionId, 240),
+    },
+    context: {
+      alreadyApproved: String(currentCost.reviewStatus || "").toLowerCase() === "approved",
+      actualCostCents,
+      thresholdCents: MAINTENANCE_AUTO_APPROVAL_THRESHOLD_CENTS,
+      hasSupportingEvidence: hasSupportingEvidenceForWorkOrder(workOrder),
+      execute: executeDecision,
+    },
+  });
+
+  return {
+    autopilotPolicy,
+    automationResult: automation.automationResult,
+    workOrderId: automation.data?.workOrderId || workOrderId,
+    workOrder: automation.data?.workOrder || null,
+  };
+}


### PR DESCRIPTION
Added the second safe explicit execution family by enabling `approve_maintenance_cost -> maintenance.auto_approve_cost`.

This change removes the maintenance-specific readiness block once deterministic maintenance approval mapping/readiness is present, extracts a shared maintenance approval execution service, and reuses it from both the work-order review-cost route and the landlord decision execute route.

Key framing:
- `approve_maintenance_cost` is now the second safe explicit execution family
- execution remains one-work-order-only and explicit landlord-triggered
- maintenance execution reuses shared canonical approval infrastructure
- readiness, feedback, history, and analytics remain aligned with the existing decision execution model
- bulk approval, screening execution, and background automation remain out of scope

Execution remains explicit, fail-closed, and limited to one exact work order. Lease-renewal execution, lifecycle state, history/timeline, outcome analytics, lease integrity behavior, property summary integrity behavior, and shared landlord UI behavior remain unchanged.