### PR TITLE
feat: add screening decision mapping v1

### DIFF
--- a/rentchain-api/src/lib/analytics/__tests__/deriveAgentDecisions.test.ts
+++ b/rentchain-api/src/lib/analytics/__tests__/deriveAgentDecisions.test.ts
@@ -602,4 +602,95 @@ describe("deriveAgentDecisions", () => {
 
     expect(result.items.find((decision) => decision.decisionType === "approve_maintenance_cost")).toBeUndefined();
   });
+
+  it("emits a deterministic screening checkout decision only when one exact application is canonically ready", () => {
+    const result = deriveAgentDecisions({
+      filters: {
+        propertyId: null,
+      },
+      now: Date.UTC(2026, 3, 20, 11, 5, 0, 0),
+      workOrders: [],
+      applications: [
+        {
+          id: "app-1",
+          propertyId: "prop-6",
+          unitId: "unit-9",
+          status: "SUBMITTED",
+          applicant: {
+            firstName: "Jane",
+            lastName: "Doe",
+            email: "jane@example.com",
+            dob: "1990-01-01",
+          },
+          consent: {
+            creditConsent: true,
+            referenceConsent: true,
+            acceptedAt: "2026-04-20T10:00:00.000Z",
+            version: "v1.0",
+          },
+          residentialHistory: [{ address: "123 Main St" }],
+          screeningMonetization: {
+            eligibility: "eligible",
+            quoteStatus: "generated",
+            paymentStatus: "pending_checkout",
+            fulfillmentStatus: "ready",
+            quoteId: "quote_app-1",
+            quoteGeneratedAt: "2026-04-20T11:00:00.000Z",
+            quoteExpiresAt: "2026-04-20T11:30:00.000Z",
+          },
+        },
+      ],
+      screeningOrders: [],
+      deltas: {
+        summary: {
+          vacancyRate: { current: 0, prior: 0, absoluteDelta: 0, relativeDelta: 0, direction: "flat" },
+          applicationConversionRate: { current: 0.3, prior: 0.3, absoluteDelta: 0, relativeDelta: 0, direction: "flat" },
+          activeApplications: { current: 1, prior: 1, absoluteDelta: 0, relativeDelta: 0, direction: "flat" },
+          openWorkOrders: { current: 0, prior: 0, absoluteDelta: 0, relativeDelta: 0, direction: "flat" },
+          maintenanceCostCents: { current: 0, prior: 0, absoluteDelta: 0, relativeDelta: 0, direction: "flat" },
+          estimatedScheduledRentCents: { current: 300000, prior: 300000, absoluteDelta: 0, relativeDelta: 0, direction: "flat" },
+          leasesEndingSoon: { current: 0, prior: 0, absoluteDelta: 0, relativeDelta: 0, direction: "flat" },
+        },
+        applications: {
+          submitted: { current: 1, prior: 1, absoluteDelta: 0, relativeDelta: 0, direction: "flat" },
+          conversionRate: { current: 0.3, prior: 0.3, absoluteDelta: 0, relativeDelta: 0, direction: "flat" },
+        },
+      },
+      alerts: [],
+      predictiveMetrics: [],
+      benchmarking: {
+        summary: {
+          propertyCount: 1,
+          comparedPropertyCount: 1,
+          benchmarkDimensions: ["applicationConversionRate"],
+        },
+        comparisons: [],
+        insights: [],
+        filters: {
+          period: "90d",
+          propertyId: null,
+          from: "2026-01-20T00:00:00.000Z",
+          to: "2026-04-20T00:00:00.000Z",
+        },
+      },
+    });
+
+    expect(result.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "start_screening_checkout:app-1",
+          decisionType: "start_screening_checkout",
+          priority: "medium",
+          recommendedAction: "Start screening checkout",
+          actionKey: "open_screening_checkout_flow",
+          actionLabel: "Open screening checkout",
+          destination: "/applications?entry=screening-checkout&propertyId=prop-6&applicationId=app-1",
+          workflowCategory: "screening_checkout",
+          automationEligible: false,
+          automationState: "manual_only",
+          executionMappingState: "none",
+        }),
+      ])
+    );
+  });
 });

--- a/rentchain-api/src/lib/analytics/__tests__/deriveDecisionAutomationRules.test.ts
+++ b/rentchain-api/src/lib/analytics/__tests__/deriveDecisionAutomationRules.test.ts
@@ -82,6 +82,58 @@ describe("deriveDecisionAutomationRule", () => {
     );
   });
 
+  it("keeps screening checkout decisions blocked until explicit screening execution is enabled", () => {
+    expect(
+      deriveDecisionAutomationRule(
+        baseDecision({
+          id: "start_screening_checkout:app-1",
+          decisionType: "start_screening_checkout",
+          actionKey: "open_screening_checkout_flow",
+          actionLabel: "Open screening checkout",
+          workflowCategory: "screening_checkout",
+          recommendedAction: "Start screening checkout",
+          destination: "/applications?entry=screening-checkout&applicationId=app-1",
+          href: "/applications?entry=screening-checkout&applicationId=app-1",
+          executionMappingState: "mapped",
+          executionMapping: {
+            action: "screening.auto_start_checkout",
+            resourceType: "rental_application",
+            resourceId: "app-1",
+            prerequisitesMet: true,
+            prerequisiteReason: null,
+          },
+          executionInputState: "complete",
+          executionInput: {
+            applicationId: "app-1",
+            propertyId: "prop-1",
+            unitId: "unit-1",
+            applicantEmail: "jane@example.com",
+            applicationStatus: "SUBMITTED",
+            eligibility: "eligible",
+            eligibilityReasonCode: "ELIGIBLE",
+            consentVersion: "v1.0",
+            consentTimestamp: "2026-04-20T10:00:00.000Z",
+            quoteId: "quote_app-1",
+            quoteGeneratedAt: "2026-04-20T11:00:00.000Z",
+            quoteExpiresAt: "2026-04-20T11:30:00.000Z",
+            quoteStatus: "generated",
+            paymentStatus: "pending_checkout",
+            fulfillmentStatus: "ready",
+            blockingReason: null,
+            policyOutcome: "allow",
+            canStartCheckout: true,
+          } as any,
+        })
+      )
+    ).toEqual(
+      expect.objectContaining({
+        automationEligible: false,
+        automationState: "blocked",
+        automationReason: expect.stringContaining("explicit screening execution is not enabled"),
+      })
+    );
+  });
+
   it("supports a ready state when a future decision explicitly opts into a deterministic executor path", () => {
     expect(
       deriveDecisionAutomationRule(

--- a/rentchain-api/src/lib/analytics/__tests__/deriveDecisionExecutionMappings.test.ts
+++ b/rentchain-api/src/lib/analytics/__tests__/deriveDecisionExecutionMappings.test.ts
@@ -302,4 +302,86 @@ describe("applyDecisionExecutionMappings", () => {
       })
     );
   });
+
+  it("maps a deterministic screening checkout decision to one exact application but keeps execution disabled for now", () => {
+    const result = applyDecisionExecutionMappings({
+      decisions: [
+        baseDecision({
+          id: "start_screening_checkout:app-1",
+          decisionType: "start_screening_checkout",
+          actionKey: "open_screening_checkout_flow",
+          actionLabel: "Open screening checkout",
+          destination: "/applications?entry=screening-checkout&propertyId=prop-3&applicationId=app-1",
+          href: "/applications?entry=screening-checkout&propertyId=prop-3&applicationId=app-1",
+          workflowCategory: "screening_checkout",
+          recommendedAction: "Start screening checkout",
+          automationState: "blocked",
+          automationReason: "This screening checkout decision now has a deterministic application target, but explicit screening execution is not enabled in this mission.",
+        }),
+      ],
+      leases: [],
+      workOrders: [],
+      applications: [
+        {
+          id: "app-1",
+          propertyId: "prop-3",
+          unitId: "unit-7",
+          status: "SUBMITTED",
+          applicant: {
+            firstName: "Jane",
+            lastName: "Doe",
+            email: "jane@example.com",
+            dob: "1990-01-01",
+          },
+          consent: {
+            creditConsent: true,
+            referenceConsent: true,
+            acceptedAt: "2026-04-20T10:00:00.000Z",
+            version: "v1.0",
+          },
+          residentialHistory: [{ address: "123 Main St" }],
+          screeningMonetization: {
+            eligibility: "eligible",
+            quoteStatus: "generated",
+            paymentStatus: "pending_checkout",
+            fulfillmentStatus: "ready",
+            quoteId: "quote_app-1",
+            quoteGeneratedAt: "2026-04-20T11:00:00.000Z",
+            quoteExpiresAt: "2026-04-20T11:30:00.000Z",
+          },
+        },
+      ],
+      screeningOrders: [],
+      now: Date.UTC(2026, 3, 20, 11, 5, 0, 0),
+    });
+
+    expect(result[0]).toEqual(
+      expect.objectContaining({
+        automationEligible: false,
+        executionMappingState: "mapped",
+        executionMapping: {
+          action: "screening.auto_start_checkout",
+          resourceType: "rental_application",
+          resourceId: "app-1",
+          prerequisitesMet: true,
+          prerequisiteReason: null,
+        },
+        executionInputState: "complete",
+        executionInputReason: null,
+        executionInputMissingFields: [],
+        executionInput: expect.objectContaining({
+          applicationId: "app-1",
+          propertyId: "prop-3",
+          unitId: "unit-7",
+          applicantEmail: "jane@example.com",
+          quoteId: "quote_app-1",
+          quoteStatus: "generated",
+          paymentStatus: "pending_checkout",
+          fulfillmentStatus: "ready",
+          canStartCheckout: true,
+          policyOutcome: "allow",
+        }),
+      })
+    );
+  });
 });

--- a/rentchain-api/src/lib/analytics/analyticsTypes.ts
+++ b/rentchain-api/src/lib/analytics/analyticsTypes.ts
@@ -5,6 +5,10 @@ import type {
   MaintenanceApprovalExecutionInput,
   MaintenanceApprovalExecutionInputMissingField,
 } from "../maintenanceApprovalReadiness";
+import type {
+  ScreeningCheckoutExecutionInput,
+  ScreeningCheckoutExecutionInputMissingField,
+} from "../screeningCheckoutReadiness";
 import type { ScreeningReconciliationStatus } from "../reconciliation/reconciliationTypes";
 
 export type AdminAnalyticsPeriod = "30d" | "90d" | "365d" | "month_to_date";
@@ -99,6 +103,7 @@ export type AdminAnalyticsDerivedInput = {
   period: AdminAnalyticsPeriod;
   granularity: AdminAnalyticsGranularity;
   applications: any[];
+  screeningOrders: any[];
   screeningReconciliations: Array<{
     applicationId?: string;
     status: ScreeningReconciliationStatus;
@@ -250,6 +255,7 @@ export type LandlordPredictiveMetrics = {
 export type LandlordAgentDecisionType =
   | "review_lease_renewals"
   | "approve_maintenance_cost"
+  | "start_screening_checkout"
   | "reduce_vacancy_risk"
   | "improve_application_conversion"
   | "address_maintenance_backlog"
@@ -272,6 +278,7 @@ export type LandlordAgentDecisionSupportingSignal = {
 export type LandlordDecisionWorkflowCategory =
   | "lease_renewals"
   | "maintenance_cost_approval"
+  | "screening_checkout"
   | "vacancy_readiness"
   | "application_funnel"
   | "maintenance_backlog"
@@ -281,6 +288,7 @@ export type LandlordDecisionWorkflowCategory =
 export type LandlordDecisionActionKey =
   | "open_lease_renewals_flow"
   | "open_maintenance_cost_approval_flow"
+  | "open_screening_checkout_flow"
   | "open_vacancy_readiness_flow"
   | "open_application_funnel_review_flow"
   | "open_maintenance_backlog_flow"
@@ -319,11 +327,13 @@ export type LandlordDecisionLeaseNoticeExecutionInput = {
 
 export type LandlordDecisionExecutionInput =
   | LandlordDecisionLeaseNoticeExecutionInput
-  | MaintenanceApprovalExecutionInput;
+  | MaintenanceApprovalExecutionInput
+  | ScreeningCheckoutExecutionInput;
 
 export type LandlordDecisionExecutionInputMissingField =
   | LeaseNoticeExecutionInputMissingField
-  | MaintenanceApprovalExecutionInputMissingField;
+  | MaintenanceApprovalExecutionInputMissingField
+  | ScreeningCheckoutExecutionInputMissingField;
 
 export type LandlordAgentDecision = {
   id: string;

--- a/rentchain-api/src/lib/analytics/deriveAgentDecisions.ts
+++ b/rentchain-api/src/lib/analytics/deriveAgentDecisions.ts
@@ -13,6 +13,8 @@ import type {
 } from "./analyticsTypes";
 import type { AnalyticsAlert } from "./alertTypes";
 import { deriveMaintenanceApprovalExecutionInputSnapshot } from "../maintenanceApprovalReadiness";
+import { deriveScreeningCheckoutExecutionInputSnapshot } from "../screeningCheckoutReadiness";
+import { latestOrderByApplication } from "./analyticsCore";
 
 type AgentDecisionInput = {
   filters: {
@@ -37,6 +39,9 @@ type AgentDecisionInput = {
   predictiveMetrics: LandlordPredictiveMetric[];
   benchmarking: LandlordPortfolioBenchmarking;
   workOrders: any[];
+  applications?: any[];
+  screeningOrders?: any[];
+  now?: number;
 };
 
 const PRIORITY_WEIGHT: Record<LandlordAgentDecisionPriority, number> = {
@@ -49,10 +54,11 @@ const DECISION_ORDER: Record<LandlordAgentDecisionType, number> = {
   reduce_vacancy_risk: 0,
   review_lease_renewals: 1,
   approve_maintenance_cost: 2,
-  address_maintenance_backlog: 3,
-  improve_application_conversion: 4,
-  review_revenue_pressure: 5,
-  focus_highest_risk_property: 6,
+  start_screening_checkout: 3,
+  address_maintenance_backlog: 4,
+  improve_application_conversion: 5,
+  review_revenue_pressure: 6,
+  focus_highest_risk_property: 7,
 };
 
 function getPredictiveMetric(metrics: LandlordPredictiveMetric[], key: LandlordPredictiveMetric["key"]) {
@@ -174,6 +180,20 @@ function deriveActionHook(
         workOrderId: resourceId || null,
       }),
       workflowCategory: "maintenance_cost_approval",
+      automationEligible: false,
+    };
+  }
+
+  if (type === "start_screening_checkout") {
+    return {
+      actionKey: "open_screening_checkout_flow",
+      actionLabel: "Open screening checkout",
+      destination: buildDestination("/applications", {
+        entry: "screening-checkout",
+        propertyId: propertyId || null,
+        applicationId: resourceId || null,
+      }),
+      workflowCategory: "screening_checkout",
       automationEligible: false,
     };
   }
@@ -532,6 +552,66 @@ function deriveMaintenanceApprovalDecision(input: AgentDecisionInput) {
   });
 }
 
+function normalizeScreeningDecisionApplication(application: any) {
+  const applicant = application?.applicant || {};
+  const applicantName = [asString(applicant?.firstName, 120), asString(applicant?.lastName, 120)]
+    .filter(Boolean)
+    .join(" ");
+
+  return {
+    id: asString(application?.id, 240),
+    propertyId: asString(application?.propertyId, 240) || null,
+    unitId: asString(application?.unitId, 240) || null,
+    propertyLabel: asString(application?.propertyLabel || application?.propertyName, 240) || null,
+    applicantName: applicantName || asString(applicant?.email, 240) || null,
+  };
+}
+
+function deriveScreeningCheckoutDecision(input: AgentDecisionInput) {
+  const latestOrders = latestOrderByApplication(input.screeningOrders || []);
+  const candidates = (input.applications || [])
+    .map((application) => ({
+      application,
+      readiness: deriveScreeningCheckoutExecutionInputSnapshot({
+        application,
+        latestOrder: latestOrders.get(asString(application?.id, 240)) || null,
+        now: input.now,
+      }),
+    }))
+    .filter(({ application, readiness }) => asString(application?.id, 240) && readiness.state === "complete");
+
+  if (candidates.length !== 1) return null;
+
+  const { application } = candidates[0];
+  const normalized = normalizeScreeningDecisionApplication(application);
+  if (!normalized.id) return null;
+
+  const alerts = input.alerts.filter(
+    (alert) =>
+      alert.status === "active" &&
+      (alert.type === "low_application_activity" ||
+        alert.type === "application_conversion_drop" ||
+        alert.type === "application_drop") &&
+      (normalized.propertyId == null || !alert.propertyId || alert.propertyId === normalized.propertyId)
+  );
+  const predictive = getPredictiveMetric(input.predictiveMetrics, "projected_application_slowdown_risk");
+  const priority = derivePriority([priorityFromAlert(alerts), priorityFromPredictive(predictive)]) || "medium";
+  const subject =
+    normalized.applicantName ||
+    normalized.propertyLabel ||
+    (normalized.unitId ? `application for unit ${normalized.unitId}` : `application ${normalized.id}`);
+
+  return buildDecision({
+    decisionType: "start_screening_checkout",
+    priority,
+    explanation: `${subject} has complete screening consent, applicant data, and a current quote. Checkout is ready to start for this exact application.`,
+    recommendedAction: "Start screening checkout",
+    propertyId: normalized.propertyId,
+    scopeId: normalized.id,
+    signals: [...alerts.map(supportFromAlert), predictive ? supportFromPredictive(predictive) : null],
+  });
+}
+
 function deriveRevenueDecision(input: AgentDecisionInput) {
   const predictive = getPredictiveMetric(input.predictiveMetrics, "projected_revenue_pressure_signal");
   const priority = priorityFromPredictive(predictive);
@@ -611,6 +691,7 @@ export function deriveAgentDecisions(input: AgentDecisionInput): LandlordAgentDe
     deriveVacancyDecision(input),
     deriveLeaseRenewalDecision(input),
     deriveMaintenanceApprovalDecision(input),
+    deriveScreeningCheckoutDecision(input),
     deriveMaintenanceDecision(input),
     deriveApplicationDecision(input),
     deriveRevenueDecision(input),

--- a/rentchain-api/src/lib/analytics/deriveDecisionAutomationRules.ts
+++ b/rentchain-api/src/lib/analytics/deriveDecisionAutomationRules.ts
@@ -17,6 +17,8 @@ const WORKFLOW_BLOCK_REASONS: Partial<Record<LandlordDecisionWorkflowCategory, s
     "A screening automation path exists, but this decision does not yet identify a specific application to execute against.",
   maintenance_cost_approval:
     "This maintenance approval decision still needs a deterministic approval-ready work order and complete approval inputs before execution.",
+  screening_checkout:
+    "This screening checkout decision now has a deterministic application target, but explicit screening execution is not enabled in this mission.",
   maintenance_backlog:
     "A maintenance automation path exists, but this decision does not yet identify a specific work order with execution-ready evidence.",
 };

--- a/rentchain-api/src/lib/analytics/deriveDecisionExecutionMappings.ts
+++ b/rentchain-api/src/lib/analytics/deriveDecisionExecutionMappings.ts
@@ -1,11 +1,15 @@
 import type { LandlordAgentDecision, LandlordDecisionExecutionMapping } from "./analyticsTypes";
 import { deriveLeaseNoticeExecutionInputSnapshot, normalizeLeaseRecord } from "../../services/leaseNoticeWorkflowService";
 import { deriveMaintenanceApprovalExecutionInputSnapshot } from "../maintenanceApprovalReadiness";
+import { latestOrderByApplication } from "./analyticsCore";
+import { deriveScreeningCheckoutExecutionInputSnapshot } from "../screeningCheckoutReadiness";
 
 type MappingInput = {
   decisions: LandlordAgentDecision[];
   leases: any[];
   workOrders: any[];
+  applications?: any[];
+  screeningOrders?: any[];
   now: number;
 };
 
@@ -139,6 +143,43 @@ function mapMaintenanceApprovalDecision(decision: LandlordAgentDecision, input: 
   };
 }
 
+function mapScreeningCheckoutDecision(decision: LandlordAgentDecision, input: MappingInput): LandlordAgentDecision {
+  const applicationId = decisionScopedResourceId(decision);
+  if (!applicationId) {
+    return baseDecision(decision, null);
+  }
+
+  const application = (input.applications || []).find((entry) => asString(entry?.id, 240) === applicationId);
+  if (!application) {
+    return baseDecision(decision, null);
+  }
+
+  const latestOrders = latestOrderByApplication(input.screeningOrders || []);
+  const executionInput = deriveScreeningCheckoutExecutionInputSnapshot({
+    application,
+    latestOrder: latestOrders.get(applicationId) || null,
+    now: input.now,
+  });
+  const mapping: LandlordDecisionExecutionMapping = {
+    action: "screening.auto_start_checkout",
+    resourceType: "rental_application",
+    resourceId: applicationId,
+    prerequisitesMet: executionInput.state === "complete",
+    prerequisiteReason: executionInput.reason,
+  };
+
+  return {
+    ...decision,
+    automationEligible: false,
+    executionMappingState: "mapped",
+    executionMapping: mapping,
+    executionInputState: executionInput.state,
+    executionInputReason: executionInput.reason,
+    executionInputMissingFields: executionInput.missingFields,
+    executionInput: executionInput.input,
+  };
+}
+
 export function applyDecisionExecutionMappings(input: MappingInput): LandlordAgentDecision[] {
   return input.decisions.map((decision) => {
     if (decision.decisionType === "review_lease_renewals") {
@@ -146,6 +187,9 @@ export function applyDecisionExecutionMappings(input: MappingInput): LandlordAge
     }
     if (decision.decisionType === "approve_maintenance_cost") {
       return mapMaintenanceApprovalDecision(decision, input);
+    }
+    if (decision.decisionType === "start_screening_checkout") {
+      return mapScreeningCheckoutDecision(decision, input);
     }
 
     return baseDecision(decision, null);

--- a/rentchain-api/src/lib/analytics/deriveLandlordAnalyticsSnapshot.ts
+++ b/rentchain-api/src/lib/analytics/deriveLandlordAnalyticsSnapshot.ts
@@ -738,6 +738,9 @@ export function deriveLandlordAnalyticsSnapshot(input: AdminAnalyticsDerivedInpu
     predictiveMetrics: snapshotBase.predictive.metrics,
     benchmarking,
     workOrders: input.workOrders,
+    applications: input.applications,
+    screeningOrders: input.screeningOrders || [],
+    now: input.now,
   });
 
   return {

--- a/rentchain-api/src/lib/screeningCheckoutReadiness.ts
+++ b/rentchain-api/src/lib/screeningCheckoutReadiness.ts
@@ -1,0 +1,244 @@
+import { buildScreeningPolicyRequest } from "./policy/policyAdapters";
+import { evaluatePolicy } from "./policy/policyEvaluator";
+import {
+  buildScreeningMonetizationSummary,
+  normalizeScreeningMonetizationState,
+  type ScreeningMonetizationEligibility,
+  type ScreeningMonetizationFulfillmentStatus,
+  type ScreeningMonetizationPaymentStatus,
+  type ScreeningMonetizationQuoteStatus,
+} from "../services/screening/screeningMonetizationService";
+
+export const SCREENING_CONSENT_VERSION = "v1.0";
+
+const ELIGIBLE_SCREENING_APPLICATION_STATUSES = ["SUBMITTED", "IN_REVIEW"];
+
+export type ScreeningCheckoutExecutionInputMissingField =
+  | "applicationStatus"
+  | "consentTimestamp"
+  | "consentVersion"
+  | "applicationData"
+  | "screeningQuote";
+
+export type ScreeningCheckoutExecutionInput = {
+  applicationId: string | null;
+  propertyId: string | null;
+  unitId: string | null;
+  applicantEmail: string | null;
+  applicationStatus: string | null;
+  eligibility: ScreeningMonetizationEligibility;
+  eligibilityReasonCode: string | null;
+  consentVersion: string | null;
+  consentTimestamp: string | null;
+  quoteId: string | null;
+  quoteGeneratedAt: string | null;
+  quoteExpiresAt: string | null;
+  quoteStatus: ScreeningMonetizationQuoteStatus;
+  paymentStatus: ScreeningMonetizationPaymentStatus;
+  fulfillmentStatus: ScreeningMonetizationFulfillmentStatus;
+  blockingReason: string | null;
+  policyOutcome: "allow" | "block" | "review" | "defer" | null;
+  canStartCheckout: boolean;
+};
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function consentFromApplication(application?: any) {
+  return application?.consent || {};
+}
+
+export function evaluateScreeningApplicationEligibility(application: any) {
+  const status = String(application?.status || "").toUpperCase();
+  if (!ELIGIBLE_SCREENING_APPLICATION_STATUSES.includes(status)) {
+    return {
+      eligible: false,
+      detail: "Application must be submitted before screening.",
+      reasonCode: "APPLICATION_STATUS_NOT_READY",
+    };
+  }
+  const consent = consentFromApplication(application);
+  if (!consent?.creditConsent || !consent?.referenceConsent) {
+    return {
+      eligible: false,
+      detail: "Consent for credit and references is required.",
+      reasonCode: "MISSING_CONSENT",
+    };
+  }
+  const dob = String(application?.applicant?.dob || "").trim();
+  const sin = String(
+    application?.applicant?.sinLast4 ||
+      application?.applicant?.sin ||
+      application?.applicantProfile?.sinLast4 ||
+      application?.applicantProfile?.sin ||
+      ""
+  ).trim();
+  const currentAddress = String(application?.residentialHistory?.[0]?.address || "").trim();
+  if ((!dob && !sin) || !currentAddress) {
+    return {
+      eligible: false,
+      detail: "DOB (or SIN) and current address are required.",
+      reasonCode: "MISSING_TENANT_PROFILE",
+    };
+  }
+  return { eligible: true, detail: null, reasonCode: "ELIGIBLE" };
+}
+
+export function resolveScreeningConsentPayload(body: any, application?: any) {
+  const payload = body && typeof body === "object" ? body : {};
+  const nestedConsent = payload?.consent && typeof payload.consent === "object" ? payload.consent : {};
+  const consent = Object.keys(nestedConsent).length ? nestedConsent : payload;
+  const appConsent = consentFromApplication(application);
+  const timestamp = String(consent?.timestamp || appConsent?.acceptedAt || "").trim();
+  const version = String(consent?.version || appConsent?.version || SCREENING_CONSENT_VERSION).trim();
+  const textHash = consent?.textHash
+    ? String(consent.textHash).trim()
+    : appConsent?.textHash
+    ? String(appConsent.textHash).trim()
+    : null;
+  return {
+    given: Boolean(consent?.given || (appConsent?.creditConsent === true && appConsent?.referenceConsent === true)),
+    timestamp,
+    version,
+    textHash,
+  };
+}
+
+export function validateScreeningConsentPayload(consent: ReturnType<typeof resolveScreeningConsentPayload>) {
+  if (!consent.given) return { ok: false, error: "consent_required" };
+  if (!consent.timestamp) return { ok: false, error: "consent_missing_timestamp" };
+  if (consent.version !== SCREENING_CONSENT_VERSION) return { ok: false, error: "consent_version_mismatch" };
+  return { ok: true };
+}
+
+function deriveScreeningApplicationDataComplete(application: any) {
+  const applicant = application?.applicant || {};
+  const residentialHistory = Array.isArray(application?.residentialHistory) ? application.residentialHistory : [];
+  return Boolean(
+    asString(applicant?.firstName, 120) &&
+      asString(applicant?.lastName, 120) &&
+      asString(applicant?.email, 240) &&
+      asString(applicant?.dob, 40) &&
+      residentialHistory.length > 0
+  );
+}
+
+export function deriveScreeningCheckoutExecutionInputSnapshot(params: {
+  application: any;
+  latestOrder?: any;
+  now?: number;
+}) {
+  const application = params.application || {};
+  const latestOrder = params.latestOrder || null;
+  const now = typeof params.now === "number" ? params.now : Date.now();
+  const eligibilityCheck = evaluateScreeningApplicationEligibility(application);
+  const consent = resolveScreeningConsentPayload({}, application);
+  const consentCheck = validateScreeningConsentPayload(consent);
+  const monetizationEligibility: ScreeningMonetizationEligibility = eligibilityCheck.eligible ? "eligible" : "ineligible";
+  const monetizationState = normalizeScreeningMonetizationState({
+    application,
+    latestOrder,
+    eligibility: monetizationEligibility,
+    now,
+  });
+  const monetizationSummary = buildScreeningMonetizationSummary(monetizationState);
+  const policyRequest = buildScreeningPolicyRequest({
+    action: "start_checkout",
+    actorRole: "landlord",
+    actorUserId: null,
+    applicationId: asString(application?.id, 240),
+    eligibility: eligibilityCheck,
+    application,
+    consentComplete: consentCheck.ok,
+    providerReady: true,
+  });
+  const policyResult = evaluatePolicy(policyRequest);
+
+  const missingFields: ScreeningCheckoutExecutionInputMissingField[] = [];
+  if (!ELIGIBLE_SCREENING_APPLICATION_STATUSES.includes(String(application?.status || "").toUpperCase())) {
+    missingFields.push("applicationStatus");
+  }
+  if (!consent.timestamp) {
+    missingFields.push("consentTimestamp");
+  }
+  if (consent.version !== SCREENING_CONSENT_VERSION) {
+    missingFields.push("consentVersion");
+  }
+  if (!deriveScreeningApplicationDataComplete(application)) {
+    missingFields.push("applicationData");
+  }
+  if (monetizationState.quoteStatus !== "generated") {
+    missingFields.push("screeningQuote");
+  }
+
+  const input: ScreeningCheckoutExecutionInput = {
+    applicationId: asString(application?.id, 240) || null,
+    propertyId: asString(application?.propertyId, 240) || null,
+    unitId: asString(application?.unitId, 240) || null,
+    applicantEmail: asString(application?.applicant?.email, 240) || null,
+    applicationStatus: asString(application?.status, 80) || null,
+    eligibility: monetizationState.eligibility,
+    eligibilityReasonCode: eligibilityCheck.reasonCode || null,
+    consentVersion: consent.version || null,
+    consentTimestamp: consent.timestamp || null,
+    quoteId: monetizationState.quoteId || null,
+    quoteGeneratedAt: monetizationState.quoteGeneratedAt || null,
+    quoteExpiresAt: monetizationState.quoteExpiresAt || null,
+    quoteStatus: monetizationState.quoteStatus,
+    paymentStatus: monetizationState.paymentStatus,
+    fulfillmentStatus: monetizationState.fulfillmentStatus,
+    blockingReason: monetizationSummary.blockingReason || null,
+    policyOutcome: policyResult.outcome || null,
+    canStartCheckout: monetizationSummary.canStartCheckout,
+  };
+
+  if (monetizationSummary.blockingReason === "SCREENING_ALREADY_PAID") {
+    return {
+      state: "partial" as const,
+      reason: "This application already has a paid or completed screening.",
+      missingFields: [] as ScreeningCheckoutExecutionInputMissingField[],
+      input,
+    };
+  }
+  if (monetizationSummary.blockingReason === "SCREENING_ORDER_ALREADY_CREATED") {
+    return {
+      state: "partial" as const,
+      reason: "This application already has a screening order in progress.",
+      missingFields: [] as ScreeningCheckoutExecutionInputMissingField[],
+      input,
+    };
+  }
+  if (monetizationSummary.blockingReason === "SCREENING_CHECKOUT_ALREADY_EXISTS") {
+    return {
+      state: "partial" as const,
+      reason: "This application already has an active screening checkout.",
+      missingFields: [] as ScreeningCheckoutExecutionInputMissingField[],
+      input,
+    };
+  }
+  if (missingFields.length > 0) {
+    return {
+      state: "partial" as const,
+      reason: `This screening checkout still needs canonical readiness fields: ${missingFields.join(", ")}.`,
+      missingFields,
+      input,
+    };
+  }
+  if (policyResult.outcome !== "allow") {
+    return {
+      state: "partial" as const,
+      reason:
+        policyResult.reasons[0]?.message ||
+        "This screening checkout still needs manual review before it is execution-ready.",
+      missingFields: [] as ScreeningCheckoutExecutionInputMissingField[],
+      input,
+    };
+  }
+  return {
+    state: "complete" as const,
+    reason: null,
+    missingFields: [] as ScreeningCheckoutExecutionInputMissingField[],
+    input,
+  };
+}

--- a/rentchain-api/src/routes/rentalApplicationsRoutes.ts
+++ b/rentchain-api/src/routes/rentalApplicationsRoutes.ts
@@ -57,6 +57,12 @@ import {
   buildScreeningMonetizationSummary,
   normalizeScreeningMonetizationState,
 } from "../services/screening/screeningMonetizationService";
+import {
+  SCREENING_CONSENT_VERSION,
+  evaluateScreeningApplicationEligibility,
+  resolveScreeningConsentPayload,
+  validateScreeningConsentPayload,
+} from "../lib/screeningCheckoutReadiness";
 
 const router = Router();
 
@@ -70,10 +76,9 @@ const ALLOWED_STATUS = [
   "CONDITIONAL_DEPOSIT",
 ];
 
-const ELIGIBLE_STATUS = ["SUBMITTED", "IN_REVIEW"];
 const APPLICATION_DECISION_ACTIONS = ["request_info", "approve", "reject"] as const;
 const SERVICE_LEVELS = ["SELF_SERVE", "VERIFIED", "VERIFIED_AI"] as const;
-const CONSENT_VERSION = "v1.0";
+const CONSENT_VERSION = SCREENING_CONSENT_VERSION;
 const INFO_REQUEST_ITEM_LABELS: Record<string, string> = {
   upload_id: "Upload ID",
   phone_number: "Phone number",
@@ -1065,39 +1070,7 @@ function buildAiVerification(applicationId: string, seed: number) {
 }
 
 function evaluateEligibility(application: any) {
-  const status = String(application?.status || "").toUpperCase();
-  if (!ELIGIBLE_STATUS.includes(status)) {
-    return {
-      eligible: false,
-      detail: "Application must be submitted before screening.",
-      reasonCode: "APPLICATION_STATUS_NOT_READY",
-    };
-  }
-  const consent = application?.consent || {};
-  if (!consent?.creditConsent || !consent?.referenceConsent) {
-    return {
-      eligible: false,
-      detail: "Consent for credit and references is required.",
-      reasonCode: "MISSING_CONSENT",
-    };
-  }
-  const dob = String(application?.applicant?.dob || "").trim();
-  const sin = String(
-    application?.applicant?.sinLast4 ||
-      application?.applicant?.sin ||
-      application?.applicantProfile?.sinLast4 ||
-      application?.applicantProfile?.sin ||
-      ""
-  ).trim();
-  const currentAddress = String(application?.residentialHistory?.[0]?.address || "").trim();
-  if ((!dob && !sin) || !currentAddress) {
-    return {
-      eligible: false,
-      detail: "DOB (or SIN) and current address are required.",
-      reasonCode: "MISSING_TENANT_PROFILE",
-    };
-  }
-  return { eligible: true, detail: null, reasonCode: "ELIGIBLE" };
+  return evaluateScreeningApplicationEligibility(application);
 }
 
 function isScreeningAlreadyPaid(application: any) {
@@ -1129,32 +1102,11 @@ async function loadAuthorizedApplication(req: any, applicationId: string) {
 }
 
 function resolveConsentPayload(body: any, application?: any) {
-  const payload = body && typeof body === "object" ? body : {};
-  const nestedConsent = payload?.consent && typeof payload.consent === "object" ? payload.consent : {};
-  const consent = Object.keys(nestedConsent).length ? nestedConsent : payload;
-  const appConsent = application?.consent || {};
-  const timestamp = String(consent?.timestamp || appConsent?.acceptedAt || "").trim();
-  const version = String(consent?.version || appConsent?.version || CONSENT_VERSION).trim();
-  const textHash = consent?.textHash
-    ? String(consent.textHash).trim()
-    : appConsent?.textHash
-    ? String(appConsent.textHash).trim()
-    : null;
-  return {
-    given: Boolean(
-      consent?.given || (appConsent?.creditConsent === true && appConsent?.referenceConsent === true)
-    ),
-    timestamp,
-    version,
-    textHash,
-  };
+  return resolveScreeningConsentPayload(body, application);
 }
 
 function validateConsent(consent: ReturnType<typeof resolveConsentPayload>) {
-  if (!consent.given) return { ok: false, error: "consent_required" };
-  if (!consent.timestamp) return { ok: false, error: "consent_missing_timestamp" };
-  if (consent.version !== CONSENT_VERSION) return { ok: false, error: "consent_version_mismatch" };
-  return { ok: true };
+  return validateScreeningConsentPayload(consent);
 }
 
 function resolveServiceLevel(raw?: string | null) {

--- a/rentchain-api/src/services/admin/adminAnalyticsSnapshot.ts
+++ b/rentchain-api/src/services/admin/adminAnalyticsSnapshot.ts
@@ -93,6 +93,7 @@ export async function loadAdminAnalyticsSnapshot(params?: {
     period,
     granularity,
     applications,
+    screeningOrders,
     screeningReconciliations,
     financialTransactions,
     workOrders,

--- a/rentchain-api/src/services/landlord/__tests__/landlordAnalyticsSnapshot.test.ts
+++ b/rentchain-api/src/services/landlord/__tests__/landlordAnalyticsSnapshot.test.ts
@@ -523,4 +523,80 @@ describe("loadLandlordAnalyticsSnapshot", () => {
       averageTimeToExecutionHours: 48,
     });
   });
+
+  it("surfaces one exact screening checkout decision when one application is canonically ready", async () => {
+    const now = Date.UTC(2026, 3, 20, 11, 5, 0, 0);
+
+    seedDoc("properties", "prop-6", {
+      landlordId: "landlord-1",
+      name: "Delta",
+      createdAt: now,
+      updatedAt: now,
+    });
+    seedDoc("rentalApplications", "app-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-6",
+      unitId: "unit-9",
+      status: "SUBMITTED",
+      createdAt: now - 86_400_000,
+      submittedAt: now - 86_400_000,
+      applicant: {
+        firstName: "Jane",
+        lastName: "Doe",
+        email: "jane@example.com",
+        dob: "1990-01-01",
+      },
+      consent: {
+        creditConsent: true,
+        referenceConsent: true,
+        acceptedAt: "2026-04-20T10:00:00.000Z",
+        version: "v1.0",
+      },
+      residentialHistory: [{ address: "123 Main St" }],
+      screeningMonetization: {
+        eligibility: "eligible",
+        quoteStatus: "generated",
+        paymentStatus: "pending_checkout",
+        fulfillmentStatus: "ready",
+        quoteId: "quote_app-1",
+        quoteGeneratedAt: "2026-04-20T11:00:00.000Z",
+        quoteExpiresAt: "2026-04-20T11:30:00.000Z",
+      },
+    });
+
+    const { loadLandlordAnalyticsSnapshot } = await import("../landlordAnalyticsSnapshot");
+    const result = await loadLandlordAnalyticsSnapshot({
+      landlordId: "landlord-1",
+      now,
+    });
+
+    expect(result.decisions.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "start_screening_checkout:app-1",
+          decisionType: "start_screening_checkout",
+          actionKey: "open_screening_checkout_flow",
+          workflowCategory: "screening_checkout",
+          automationEligible: false,
+          automationState: "blocked",
+          automationReason: expect.stringContaining("explicit screening execution is not enabled"),
+          executionMappingState: "mapped",
+          executionMapping: expect.objectContaining({
+            action: "screening.auto_start_checkout",
+            resourceType: "rental_application",
+            resourceId: "app-1",
+            prerequisitesMet: true,
+          }),
+          executionInputState: "complete",
+          executionInput: expect.objectContaining({
+            applicationId: "app-1",
+            quoteId: "quote_app-1",
+            quoteStatus: "generated",
+            paymentStatus: "pending_checkout",
+            canStartCheckout: true,
+          }),
+        }),
+      ])
+    );
+  });
 });

--- a/rentchain-api/src/services/landlord/landlordAnalyticsSnapshot.ts
+++ b/rentchain-api/src/services/landlord/landlordAnalyticsSnapshot.ts
@@ -196,6 +196,7 @@ function buildDerivedInput(params: {
     granularity: "daily",
     propertyId: propertyIdFilter || null,
     applications,
+    screeningOrders,
     screeningReconciliations,
     financialTransactions,
     workOrders,
@@ -266,6 +267,8 @@ export async function loadLandlordAnalyticsSnapshot(params: LandlordAnalyticsPar
       decisions: mergeLandlordDecisionStates(snapshot.decisions.items, decisionStates),
       leases: derivedInput.leases,
       workOrders: derivedInput.workOrders,
+      applications: derivedInput.applications,
+      screeningOrders: derivedInput.screeningOrders,
       now,
     })
   );

--- a/rentchain-frontend/src/api/landlordAnalyticsApi.ts
+++ b/rentchain-frontend/src/api/landlordAnalyticsApi.ts
@@ -31,6 +31,7 @@ export type LandlordAgentDecisionSupportingSignal = {
 export type LandlordDecisionWorkflowCategory =
   | "lease_renewals"
   | "maintenance_cost_approval"
+  | "screening_checkout"
   | "vacancy_readiness"
   | "application_funnel"
   | "maintenance_backlog"
@@ -40,6 +41,7 @@ export type LandlordDecisionWorkflowCategory =
 export type LandlordDecisionActionKey =
   | "open_lease_renewals_flow"
   | "open_maintenance_cost_approval_flow"
+  | "open_screening_checkout_flow"
   | "open_vacancy_readiness_flow"
   | "open_application_funnel_review_flow"
   | "open_maintenance_backlog_flow"
@@ -80,6 +82,27 @@ export type LandlordDecisionMaintenanceApprovalExecutionInput = {
   withinAutoApprovalThreshold: boolean;
 };
 
+export type LandlordDecisionScreeningCheckoutExecutionInput = {
+  applicationId: string | null;
+  propertyId: string | null;
+  unitId: string | null;
+  applicantEmail: string | null;
+  applicationStatus: string | null;
+  eligibility: "eligible" | "ineligible" | "requires_upgrade" | "provider_unavailable";
+  eligibilityReasonCode: string | null;
+  consentVersion: string | null;
+  consentTimestamp: string | null;
+  quoteId: string | null;
+  quoteGeneratedAt: string | null;
+  quoteExpiresAt: string | null;
+  quoteStatus: "none" | "generated" | "expired" | "invalid";
+  paymentStatus: "none" | "pending_checkout" | "checkout_created" | "paid" | "failed" | "abandoned" | "waived";
+  fulfillmentStatus: "not_started" | "ready" | "ordered" | "completed" | "blocked";
+  blockingReason: string | null;
+  policyOutcome: "allow" | "block" | "review" | "defer" | null;
+  canStartCheckout: boolean;
+};
+
 export type LandlordAgentDecision = {
   id: string;
   decisionType: string;
@@ -112,8 +135,17 @@ export type LandlordAgentDecision = {
     | "reviewStatus"
     | "supportingEvidence"
     | "autoApprovalThreshold"
+    | "applicationStatus"
+    | "consentTimestamp"
+    | "consentVersion"
+    | "applicationData"
+    | "screeningQuote"
   )[];
-  executionInput: (LandlordDecisionLeaseNoticeExecutionInput | LandlordDecisionMaintenanceApprovalExecutionInput) | null;
+  executionInput:
+    | LandlordDecisionLeaseNoticeExecutionInput
+    | LandlordDecisionMaintenanceApprovalExecutionInput
+    | LandlordDecisionScreeningCheckoutExecutionInput
+    | null;
   executedAt?: string | null;
   executionOutcomeStatus: "none" | "succeeded" | "failed";
   executionOutcomeAt: string | null;

--- a/rentchain-frontend/src/components/analytics/AgentDecisionPanel.tsx
+++ b/rentchain-frontend/src/components/analytics/AgentDecisionPanel.tsx
@@ -22,6 +22,7 @@ const priorityTone: Record<"low" | "medium" | "high", { bg: string; text: string
 const workflowCategoryLabel: Record<NonNullable<LandlordAgentDecision["workflowCategory"]>, string> = {
   lease_renewals: "Lease renewals",
   maintenance_cost_approval: "Maintenance cost approval",
+  screening_checkout: "Screening checkout",
   vacancy_readiness: "Vacancy readiness",
   application_funnel: "Application funnel",
   maintenance_backlog: "Maintenance backlog",


### PR DESCRIPTION
Added a new deterministic landlord decision family, `start_screening_checkout`, for one exact screening-ready application.

This change preserves existing funnel guidance and introduces a semantically aligned screening decision only when exactly one application is canonically ready. It reuses canonical screening eligibility, consent, quote, monetization, and policy semantics through a shared readiness helper, then attaches deterministic mapping and family-specific input completeness in the analytics decision pipeline, without adding execution.

Key framing:
- `start_screening_checkout` is distinct from conversion/funnel guidance
- it emits only for one exact screening-ready application
- mapping and readiness are now canonical
- screening execution is still intentionally blocked and remains the next step
- no lease-renewal or maintenance execution behavior or shared landlord UX semantics were regressed

Lease-renewal execution, maintenance execution, lifecycle/history/analytics layers, and shared landlord UI behavior remain unchanged.