### PR TITLE
feat: expand safe explicit execution to screening v2

### DIFF
--- a/rentchain-api/src/lib/analytics/__tests__/deriveDecisionAutomationRules.test.ts
+++ b/rentchain-api/src/lib/analytics/__tests__/deriveDecisionAutomationRules.test.ts
@@ -82,7 +82,7 @@ describe("deriveDecisionAutomationRule", () => {
     );
   });
 
-  it("keeps screening checkout decisions blocked until explicit screening execution is enabled", () => {
+  it("marks screening checkout decisions ready once deterministic execution is enabled", () => {
     expect(
       deriveDecisionAutomationRule(
         baseDecision({
@@ -94,6 +94,7 @@ describe("deriveDecisionAutomationRule", () => {
           recommendedAction: "Start screening checkout",
           destination: "/applications?entry=screening-checkout&applicationId=app-1",
           href: "/applications?entry=screening-checkout&applicationId=app-1",
+          automationEligible: true,
           executionMappingState: "mapped",
           executionMapping: {
             action: "screening.auto_start_checkout",
@@ -127,9 +128,9 @@ describe("deriveDecisionAutomationRule", () => {
       )
     ).toEqual(
       expect.objectContaining({
-        automationEligible: false,
-        automationState: "blocked",
-        automationReason: expect.stringContaining("explicit screening execution is not enabled"),
+        automationEligible: true,
+        automationState: "ready",
+        automationReason: "This decision is active and already mapped to a deterministic automation path.",
       })
     );
   });

--- a/rentchain-api/src/lib/analytics/__tests__/deriveDecisionExecutionMappings.test.ts
+++ b/rentchain-api/src/lib/analytics/__tests__/deriveDecisionExecutionMappings.test.ts
@@ -303,7 +303,7 @@ describe("applyDecisionExecutionMappings", () => {
     );
   });
 
-  it("maps a deterministic screening checkout decision to one exact application but keeps execution disabled for now", () => {
+  it("maps a deterministic screening checkout decision to one exact application and marks it execution-ready", () => {
     const result = applyDecisionExecutionMappings({
       decisions: [
         baseDecision({
@@ -316,7 +316,7 @@ describe("applyDecisionExecutionMappings", () => {
           workflowCategory: "screening_checkout",
           recommendedAction: "Start screening checkout",
           automationState: "blocked",
-          automationReason: "This screening checkout decision now has a deterministic application target, but explicit screening execution is not enabled in this mission.",
+          automationReason: "This screening checkout decision still needs one exact screening-ready application and complete checkout inputs before execution.",
         }),
       ],
       leases: [],
@@ -357,7 +357,7 @@ describe("applyDecisionExecutionMappings", () => {
 
     expect(result[0]).toEqual(
       expect.objectContaining({
-        automationEligible: false,
+        automationEligible: true,
         executionMappingState: "mapped",
         executionMapping: {
           action: "screening.auto_start_checkout",

--- a/rentchain-api/src/lib/analytics/deriveDecisionAutomationRules.ts
+++ b/rentchain-api/src/lib/analytics/deriveDecisionAutomationRules.ts
@@ -18,7 +18,7 @@ const WORKFLOW_BLOCK_REASONS: Partial<Record<LandlordDecisionWorkflowCategory, s
   maintenance_cost_approval:
     "This maintenance approval decision still needs a deterministic approval-ready work order and complete approval inputs before execution.",
   screening_checkout:
-    "This screening checkout decision now has a deterministic application target, but explicit screening execution is not enabled in this mission.",
+    "This screening checkout decision still needs one exact screening-ready application and complete checkout inputs before execution.",
   maintenance_backlog:
     "A maintenance automation path exists, but this decision does not yet identify a specific work order with execution-ready evidence.",
 };

--- a/rentchain-api/src/lib/analytics/deriveDecisionExecutionMappings.ts
+++ b/rentchain-api/src/lib/analytics/deriveDecisionExecutionMappings.ts
@@ -170,7 +170,7 @@ function mapScreeningCheckoutDecision(decision: LandlordAgentDecision, input: Ma
 
   return {
     ...decision,
-    automationEligible: false,
+    automationEligible: executionInput.state === "complete",
     executionMappingState: "mapped",
     executionMapping: mapping,
     executionInputState: executionInput.state,

--- a/rentchain-api/src/routes/__tests__/landlordAnalyticsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordAnalyticsRoutes.test.ts
@@ -9,6 +9,7 @@ const saveFailedLandlordDecisionExecutionOutcome = vi.fn();
 const writeCanonicalEvent = vi.fn();
 const executeAutomation = vi.fn();
 const buildLeaseNoticePolicyRequest = vi.fn();
+const buildScreeningPolicyRequest = vi.fn();
 const evaluatePolicy = vi.fn();
 const toAutopilotPolicySummary = vi.fn();
 const writePolicyEvaluatedEvent = vi.fn();
@@ -19,6 +20,13 @@ const performLeaseNoticeSendFromPreviewInput = vi.fn();
 const loadLandlordDecisionTimeline = vi.fn();
 const loadMaintenanceApprovalWorkOrderForLandlord = vi.fn();
 const executeMaintenanceApprovalAutomation = vi.fn();
+const getScreeningProviderHealth = vi.fn();
+const assertTransUnionConnectedForScreening = vi.fn();
+const loadScreeningApplicationForLandlord = vi.fn();
+const loadLatestScreeningOrderForApplication = vi.fn();
+const executeScreeningCheckout = vi.fn();
+const isTransUnionReferralMode = vi.fn();
+const shouldUseMockScreeningCheckoutOverride = vi.fn();
 
 vi.mock("../../middleware/requireAuth", () => ({
   requireAuth: (req: any, res: any, next: any) => {
@@ -60,6 +68,7 @@ vi.mock("../../lib/automation/automationExecutor", () => ({
 
 vi.mock("../../lib/policy/policyAdapters", () => ({
   buildLeaseNoticePolicyRequest,
+  buildScreeningPolicyRequest,
 }));
 
 vi.mock("../../lib/policy/policyEvaluator", () => ({
@@ -82,6 +91,22 @@ vi.mock("../../services/landlord/landlordDecisionHistory", () => ({
 vi.mock("../../services/maintenanceApprovalExecutionService", () => ({
   loadMaintenanceApprovalWorkOrderForLandlord,
   executeMaintenanceApprovalAutomation,
+}));
+
+vi.mock("../../services/screening/providerHealth", () => ({
+  getScreeningProviderHealth,
+}));
+
+vi.mock("../../services/integrations/transunion/transunionService", () => ({
+  assertTransUnionConnectedForScreening,
+}));
+
+vi.mock("../../services/screeningCheckoutExecutionService", () => ({
+  loadScreeningApplicationForLandlord,
+  loadLatestScreeningOrderForApplication,
+  executeScreeningCheckout,
+  isTransUnionReferralMode,
+  shouldUseMockScreeningCheckoutOverride,
 }));
 
 vi.mock("../../lib/events/buildEvent", () => ({
@@ -303,6 +328,60 @@ describe("landlordAnalyticsRoutes", () => {
         landlordId: "landlord-1",
       },
     });
+    buildScreeningPolicyRequest.mockReturnValue({
+      domain: "screening",
+      action: "start_checkout",
+      context: { providerReady: true, consentComplete: true },
+    });
+    getScreeningProviderHealth.mockResolvedValue({
+      provider: "singlekey",
+      configured: true,
+      preflightOk: true,
+      preflightDetail: null,
+    });
+    assertTransUnionConnectedForScreening.mockResolvedValue(undefined);
+    loadScreeningApplicationForLandlord.mockResolvedValue({
+      ok: true,
+      application: {
+        id: "app-1",
+        landlordId: "landlord-1",
+        propertyId: "prop-3",
+        unitId: "unit-7",
+        status: "SUBMITTED",
+        applicant: {
+          firstName: "Jane",
+          lastName: "Doe",
+          email: "jane@example.com",
+          dob: "1990-01-01",
+        },
+        consent: {
+          creditConsent: true,
+          referenceConsent: true,
+          acceptedAt: "2026-04-20T10:00:00.000Z",
+          version: "v1.0",
+        },
+        residentialHistory: [{ address: "123 Main St" }],
+        screeningMonetization: {
+          eligibility: "eligible",
+          quoteStatus: "generated",
+          paymentStatus: "pending_checkout",
+          fulfillmentStatus: "ready",
+          quoteId: "quote_app-1",
+          quoteGeneratedAt: "2026-12-20T11:00:00.000Z",
+          quoteExpiresAt: "2026-12-20T11:30:00.000Z",
+        },
+      },
+    });
+    loadLatestScreeningOrderForApplication.mockResolvedValue(null);
+    executeScreeningCheckout.mockResolvedValue({
+      status: 200,
+      payload: {
+        ok: true,
+        checkoutUrl: "https://checkout.test/session_1",
+      },
+    });
+    isTransUnionReferralMode.mockReturnValue(false);
+    shouldUseMockScreeningCheckoutOverride.mockReturnValue(false);
     loadLandlordAnalyticsSnapshot.mockResolvedValue({
       summary: {
         occupiedUnits: 4,
@@ -788,6 +867,101 @@ describe("landlordAnalyticsRoutes", () => {
     expect(executeAutomation).not.toHaveBeenCalled();
   });
 
+  it("fails closed when a screening decision is no longer input-complete at execution time", async () => {
+    loadScreeningApplicationForLandlord.mockResolvedValueOnce({
+      ok: true,
+      application: {
+        id: "app-1",
+        landlordId: "landlord-1",
+        propertyId: "prop-3",
+        unitId: "unit-7",
+        status: "SUBMITTED",
+        applicant: {
+          firstName: "Jane",
+          lastName: "Doe",
+          email: "jane@example.com",
+          dob: "1990-01-01",
+        },
+        consent: {
+          creditConsent: true,
+          referenceConsent: true,
+          acceptedAt: "2026-04-20T10:00:00.000Z",
+          version: "v1.0",
+        },
+        residentialHistory: [{ address: "123 Main St" }],
+        screeningMonetization: {
+          eligibility: "eligible",
+          quoteStatus: "expired",
+          paymentStatus: "pending_checkout",
+          fulfillmentStatus: "ready",
+          quoteId: "quote_app-1",
+          quoteGeneratedAt: "2026-04-20T11:00:00.000Z",
+          quoteExpiresAt: "2026-04-20T11:05:00.000Z",
+        },
+      },
+    });
+    loadLandlordAnalyticsSnapshot.mockResolvedValueOnce({
+      decisions: {
+        items: [
+          {
+            id: "start_screening_checkout:app-1",
+            decisionType: "start_screening_checkout",
+            priority: "high",
+            explanation: "Start screening checkout for this applicant.",
+            supportingSignals: [],
+            recommendedAction: "Start screening checkout",
+            actionKey: "open_screening_checkout_flow",
+            actionLabel: "Open screening checkout",
+            destination: "/applications?entry=screening-checkout&propertyId=prop-3&applicationId=app-1",
+            workflowCategory: "screening_checkout",
+            automationEligible: true,
+            automationState: "ready",
+            automationReason: "This decision is active and already mapped to a deterministic automation path.",
+            executionMappingState: "mapped",
+            executionMapping: {
+              action: "screening.auto_start_checkout",
+              resourceType: "rental_application",
+              resourceId: "app-1",
+              prerequisitesMet: true,
+              prerequisiteReason: null,
+            },
+            executionInputState: "complete",
+            executionInputReason: null,
+            executionInputMissingFields: [],
+            executionInput: {
+              applicationId: "app-1",
+              quoteStatus: "generated",
+            },
+            executedAt: null,
+            executionOutcomeStatus: "none",
+            executionOutcomeAt: null,
+            executionOutcomeReason: null,
+            href: "/applications?entry=screening-checkout&propertyId=prop-3&applicationId=app-1",
+            state: "pending",
+            reviewedAt: null,
+          },
+        ],
+      },
+    });
+
+    const router = (await import("../landlordAnalyticsRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "POST",
+      url: "/landlord/analytics/decisions/start_screening_checkout%3Aapp-1/execute",
+      user: { id: "landlord-1", role: "landlord" },
+    });
+
+    expect(response.status).toBe(409);
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        ok: false,
+        error: "DECISION_INPUTS_INCOMPLETE",
+      })
+    );
+    expect(executeAutomation).not.toHaveBeenCalled();
+    expect(executeScreeningCheckout).not.toHaveBeenCalled();
+  });
+
   it("executes a ready mapped maintenance decision and persists executed state", async () => {
     saveExecutedLandlordDecisionState.mockResolvedValueOnce({
       id: "landlord-1__approve_maintenance_cost:wo-1",
@@ -899,6 +1073,127 @@ describe("landlordAnalyticsRoutes", () => {
           state: "executed",
           executionOutcomeStatus: "succeeded",
         }),
+      })
+    );
+  });
+
+  it("executes a ready mapped screening decision and persists executed state", async () => {
+    saveExecutedLandlordDecisionState.mockResolvedValueOnce({
+      id: "landlord-1__start_screening_checkout:app-1",
+      landlordId: "landlord-1",
+      decisionId: "start_screening_checkout:app-1",
+      state: "executed",
+      reviewedAt: null,
+      executedAt: "2026-04-20T12:00:00.000Z",
+      executionOutcomeStatus: "succeeded",
+      executionOutcomeAt: "2026-04-20T12:00:00.000Z",
+      executionOutcomeReason: null,
+      createdAt: "2026-04-20T12:00:00.000Z",
+      updatedAt: "2026-04-20T12:00:00.000Z",
+    });
+    loadLandlordAnalyticsSnapshot.mockResolvedValueOnce({
+      decisions: {
+        items: [
+          {
+            id: "start_screening_checkout:app-1",
+            decisionType: "start_screening_checkout",
+            priority: "high",
+            explanation: "Start screening checkout for this applicant.",
+            supportingSignals: [],
+            recommendedAction: "Start screening checkout",
+            actionKey: "open_screening_checkout_flow",
+            actionLabel: "Open screening checkout",
+            destination: "/applications?entry=screening-checkout&propertyId=prop-3&applicationId=app-1",
+            workflowCategory: "screening_checkout",
+            automationEligible: true,
+            automationState: "ready",
+            automationReason: "This decision is active and already mapped to a deterministic automation path.",
+            executionMappingState: "mapped",
+            executionMapping: {
+              action: "screening.auto_start_checkout",
+              resourceType: "rental_application",
+              resourceId: "app-1",
+              prerequisitesMet: true,
+              prerequisiteReason: null,
+            },
+            executionInputState: "complete",
+            executionInputReason: null,
+            executionInputMissingFields: [],
+            executionInput: {
+              applicationId: "app-1",
+              propertyId: "prop-3",
+              unitId: "unit-7",
+              applicantEmail: "jane@example.com",
+              quoteId: "quote_app-1",
+              quoteStatus: "generated",
+              paymentStatus: "pending_checkout",
+              fulfillmentStatus: "ready",
+              blockingReason: null,
+              policyOutcome: "allow",
+              canStartCheckout: true,
+            },
+            executedAt: null,
+            executionOutcomeStatus: "none",
+            executionOutcomeAt: null,
+            executionOutcomeReason: null,
+            href: "/applications?entry=screening-checkout&propertyId=prop-3&applicationId=app-1",
+            state: "pending",
+            reviewedAt: null,
+          },
+        ],
+      },
+    });
+
+    const router = (await import("../landlordAnalyticsRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "POST",
+      url: "/landlord/analytics/decisions/start_screening_checkout%3Aapp-1/execute",
+      user: { id: "landlord-1", role: "landlord" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(loadScreeningApplicationForLandlord).toHaveBeenCalledWith({
+      landlordId: "landlord-1",
+      applicationId: "app-1",
+    });
+    expect(loadLatestScreeningOrderForApplication).toHaveBeenCalledWith("app-1");
+    expect(getScreeningProviderHealth).toHaveBeenCalled();
+    expect(executeScreeningCheckout).toHaveBeenCalledWith(
+      expect.objectContaining({
+        role: "landlord",
+        landlordId: "landlord-1",
+        applicationId: "app-1",
+        frontendOrigin: null,
+      })
+    );
+    expect(saveExecutedLandlordDecisionState).toHaveBeenCalledWith({
+      landlordId: "landlord-1",
+      decisionId: "start_screening_checkout:app-1",
+    });
+    expect(writeCanonicalEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "decision.execution_requested",
+        metadata: expect.objectContaining({
+          decisionId: "start_screening_checkout:app-1",
+          action: "screening.auto_start_checkout",
+          resourceId: "app-1",
+        }),
+      })
+    );
+    expect(writeCanonicalEvent).toHaveBeenCalledWith(expect.objectContaining({ type: "decision.executed" }));
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        ok: true,
+        execution: expect.objectContaining({
+          decisionId: "start_screening_checkout:app-1",
+          action: "screening.auto_start_checkout",
+          resourceId: "app-1",
+        }),
+        state: expect.objectContaining({
+          state: "executed",
+          executionOutcomeStatus: "succeeded",
+        }),
+        checkoutUrl: "https://checkout.test/session_1",
       })
     );
   });
@@ -1095,6 +1390,102 @@ describe("landlordAnalyticsRoutes", () => {
           state: "pending",
           executionOutcomeStatus: "failed",
           executionOutcomeReason: "MAINTENANCE_COST_REVIEW_REQUIRED",
+        }),
+      })
+    );
+  });
+
+  it("persists failed screening execution feedback without resolving the decision", async () => {
+    saveFailedLandlordDecisionExecutionOutcome.mockResolvedValueOnce({
+      id: "landlord-1__start_screening_checkout:app-1",
+      landlordId: "landlord-1",
+      decisionId: "start_screening_checkout:app-1",
+      state: "pending",
+      reviewedAt: null,
+      executedAt: null,
+      executionOutcomeStatus: "failed",
+      executionOutcomeAt: "2026-04-20T12:00:00.000Z",
+      executionOutcomeReason: "SCREENING_AUTO_START_CHECKOUT_POLICY_BLOCKED",
+      createdAt: "2026-04-20T12:00:00.000Z",
+      updatedAt: "2026-04-20T12:00:00.000Z",
+    });
+    executeAutomation.mockResolvedValueOnce({
+      automationResult: {
+        action: "screening.auto_start_checkout",
+        executed: false,
+        skipped: true,
+        reason: "SCREENING_AUTO_START_CHECKOUT_POLICY_BLOCKED",
+        timestamp: "2026-04-20T12:00:00.000Z",
+      },
+    });
+    loadLandlordAnalyticsSnapshot.mockResolvedValueOnce({
+      decisions: {
+        items: [
+          {
+            id: "start_screening_checkout:app-1",
+            decisionType: "start_screening_checkout",
+            priority: "high",
+            explanation: "Start screening checkout for this applicant.",
+            supportingSignals: [],
+            recommendedAction: "Start screening checkout",
+            actionKey: "open_screening_checkout_flow",
+            actionLabel: "Open screening checkout",
+            destination: "/applications?entry=screening-checkout&propertyId=prop-3&applicationId=app-1",
+            workflowCategory: "screening_checkout",
+            automationEligible: true,
+            automationState: "ready",
+            automationReason: "This decision is active and already mapped to a deterministic automation path.",
+            executionMappingState: "mapped",
+            executionMapping: {
+              action: "screening.auto_start_checkout",
+              resourceType: "rental_application",
+              resourceId: "app-1",
+              prerequisitesMet: true,
+              prerequisiteReason: null,
+            },
+            executionInputState: "complete",
+            executionInputReason: null,
+            executionInputMissingFields: [],
+            executionInput: {
+              applicationId: "app-1",
+              quoteStatus: "generated",
+              paymentStatus: "pending_checkout",
+              blockingReason: null,
+            },
+            executedAt: null,
+            executionOutcomeStatus: "none",
+            executionOutcomeAt: null,
+            executionOutcomeReason: null,
+            href: "/applications?entry=screening-checkout&propertyId=prop-3&applicationId=app-1",
+            state: "pending",
+            reviewedAt: null,
+          },
+        ],
+      },
+    });
+
+    const router = (await import("../landlordAnalyticsRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "POST",
+      url: "/landlord/analytics/decisions/start_screening_checkout%3Aapp-1/execute",
+      user: { id: "landlord-1", role: "landlord" },
+    });
+
+    expect(response.status).toBe(409);
+    expect(saveFailedLandlordDecisionExecutionOutcome).toHaveBeenCalledWith({
+      landlordId: "landlord-1",
+      decisionId: "start_screening_checkout:app-1",
+      reason: "SCREENING_AUTO_START_CHECKOUT_POLICY_BLOCKED",
+    });
+    expect(executeScreeningCheckout).not.toHaveBeenCalled();
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        ok: false,
+        error: "DECISION_EXECUTION_FAILED",
+        state: expect.objectContaining({
+          state: "pending",
+          executionOutcomeStatus: "failed",
+          executionOutcomeReason: "SCREENING_AUTO_START_CHECKOUT_POLICY_BLOCKED",
         }),
       })
     );

--- a/rentchain-api/src/routes/landlordAnalyticsRoutes.ts
+++ b/rentchain-api/src/routes/landlordAnalyticsRoutes.ts
@@ -1,10 +1,12 @@
 import { Router } from "express";
 import { writeCanonicalEvent } from "../lib/events/buildEvent";
 import { executeAutomation } from "../lib/automation/automationExecutor";
-import { buildLeaseNoticePolicyRequest } from "../lib/policy/policyAdapters";
+import { buildLeaseNoticePolicyRequest, buildScreeningPolicyRequest } from "../lib/policy/policyAdapters";
 import { evaluatePolicy, toAutopilotPolicySummary, writePolicyEvaluatedEvent } from "../lib/policy/policyEvaluator";
 import { requireAuth } from "../middleware/requireAuth";
 import { requireLandlord } from "../middleware/requireLandlord";
+import { getScreeningProviderHealth } from "../services/screening/providerHealth";
+import { assertTransUnionConnectedForScreening } from "../services/integrations/transunion/transunionService";
 import {
   buildLeaseNoticePreviewInputFromLease,
   getLeaseForLandlordWorkflow,
@@ -15,6 +17,13 @@ import {
   executeMaintenanceApprovalAutomation,
   loadMaintenanceApprovalWorkOrderForLandlord,
 } from "../services/maintenanceApprovalExecutionService";
+import {
+  executeScreeningCheckout,
+  isTransUnionReferralMode,
+  loadLatestScreeningOrderForApplication,
+  loadScreeningApplicationForLandlord,
+  shouldUseMockScreeningCheckoutOverride,
+} from "../services/screeningCheckoutExecutionService";
 import { loadLandlordAnalyticsSnapshot } from "../services/landlord/landlordAnalyticsSnapshot";
 import {
   saveExecutedLandlordDecisionState,
@@ -24,11 +33,26 @@ import {
   saveSnoozedLandlordDecisionState,
 } from "../services/landlord/landlordDecisionStates";
 import { loadLandlordDecisionTimeline } from "../services/landlord/landlordDecisionHistory";
+import {
+  deriveScreeningCheckoutExecutionInputSnapshot,
+  evaluateScreeningApplicationEligibility,
+  resolveScreeningConsentPayload,
+  validateScreeningConsentPayload,
+} from "../lib/screeningCheckoutReadiness";
 
 const router = Router();
 
 function asString(value: unknown, max = 240) {
   return String(value || "").trim().slice(0, max);
+}
+
+function resolveFrontendOriginInput(req: any) {
+  return (
+    req?.headers?.["x-frontend-origin"] ||
+    req?.headers?.origin ||
+    req?.headers?.referer ||
+    null
+  );
 }
 
 function decisionStatePayload(state: any) {
@@ -263,6 +287,7 @@ router.post("/landlord/analytics/decisions/:decisionId/execute", requireAuth, re
     if (!resolved) return;
     const { landlordId, decisionId, decision } = resolved;
     const actorId = asString(req.user?.id || landlordId, 240) || null;
+    const actorRole = asString(req.user?.role, 80).toLowerCase() || "landlord";
 
     if (decision.automationState !== "ready") {
       return res.status(409).json({ ok: false, error: "DECISION_NOT_READY", reason: decision.automationReason || null });
@@ -431,6 +456,166 @@ router.post("/landlord/analytics/decisions/:decisionId/execute", requireAuth, re
           landlordId,
           initiatedFrom: "decision_execute",
           decisionId,
+        });
+      } else if (
+        decision.executionMapping.action === "screening.auto_start_checkout" &&
+        decision.executionMapping.resourceType === "rental_application"
+      ) {
+        const applicationId = decision.executionMapping.resourceId;
+        const applicationResult = await loadScreeningApplicationForLandlord({
+          landlordId,
+          applicationId,
+        });
+        if (!applicationResult.ok) {
+          return res.status(applicationResult.error === "FORBIDDEN" ? 403 : 404).json({
+            ok: false,
+            error: applicationResult.error,
+          });
+        }
+        const application = applicationResult.application as any;
+
+        const latestOrder = await loadLatestScreeningOrderForApplication(applicationId);
+        const executionInput = deriveScreeningCheckoutExecutionInputSnapshot({
+          application,
+          latestOrder,
+          now: Date.now(),
+        });
+        if (executionInput.state !== "complete") {
+          return res.status(409).json({
+            ok: false,
+            error: "DECISION_INPUTS_INCOMPLETE",
+            missingFields: executionInput.missingFields || [],
+            reason: executionInput.reason || null,
+          });
+        }
+
+        const consent = resolveScreeningConsentPayload({}, application);
+        const consentCheck = validateScreeningConsentPayload(consent);
+        if (!consentCheck.ok) {
+          return res.status(409).json({
+            ok: false,
+            error: "DECISION_INPUTS_INCOMPLETE",
+            missingFields: decision.executionInputMissingFields || [],
+            reason: consentCheck.error,
+          });
+        }
+
+        const providerHealth = await getScreeningProviderHealth();
+        const referralMode = isTransUnionReferralMode();
+        const allowMockOverride = shouldUseMockScreeningCheckoutOverride({
+          role: actorRole,
+          seedKey: decision.executionMapping.resourceId,
+        });
+        const providerReady =
+          referralMode ||
+          allowMockOverride ||
+          process.env.NODE_ENV !== "production" ||
+          (providerHealth.configured && providerHealth.preflightOk);
+
+        if (
+          process.env.NODE_ENV === "production" &&
+          !referralMode &&
+          providerHealth.configured &&
+          providerHealth.preflightOk &&
+          !allowMockOverride
+        ) {
+          try {
+            await assertTransUnionConnectedForScreening(
+              asString(application?.landlordId, 240) || landlordId
+            );
+          } catch (error: any) {
+            if (error?.statusCode === 409 && error?.code === "transunion_not_connected") {
+              return res.status(409).json({
+                ok: false,
+                error: "TRANSUNION_NOT_CONNECTED",
+              });
+            }
+            throw error;
+          }
+        }
+
+        const eligibility = evaluateScreeningApplicationEligibility(application);
+        const policyRequest = buildScreeningPolicyRequest({
+          action: "start_checkout",
+          actorRole,
+          actorUserId: actorId,
+          applicationId,
+          eligibility,
+          application,
+          consentComplete: consentCheck.ok,
+          providerReady,
+        });
+        const policyResult = evaluatePolicy(policyRequest);
+        const autopilotPolicy = toAutopilotPolicySummary(policyResult);
+        await writePolicyEvaluatedEvent({
+          request: policyRequest,
+          result: policyResult,
+          actorType: actorRole === "admin" ? "admin" : "landlord",
+          metadata: {
+            landlordId,
+            propertyId: asString(application?.propertyId, 240) || null,
+            unitId: asString(application?.unitId, 240) || null,
+            initiatedFrom: "decision_execute",
+            decisionId,
+          },
+        });
+
+        automation = await executeAutomation({
+          action: "screening.auto_start_checkout",
+          policyResult,
+          actor: {
+            type: actorRole === "admin" ? "admin" : "landlord",
+            id: actorId,
+            role: actorRole,
+          },
+          resource: {
+            type: "rental_application",
+            id: applicationId,
+          },
+          visibility: "internal",
+          metadata: {
+            domain: "screening",
+            initiatedFrom: "decision_execute",
+            landlordId,
+            propertyId: application?.propertyId || null,
+            unitId: application?.unitId || null,
+            decisionId,
+            policyAction: "start_checkout",
+          },
+          context: {
+            quoteExists: executionInput.input.quoteStatus === "generated",
+            existingCheckout: executionInput.input.blockingReason === "SCREENING_CHECKOUT_ALREADY_EXISTS",
+            alreadyPaid:
+              executionInput.input.blockingReason === "SCREENING_ALREADY_PAID" ||
+              executionInput.input.paymentStatus === "paid",
+            execute: async () => {
+              const execution = await executeScreeningCheckout({
+                role: actorRole,
+                actorId,
+                landlordId,
+                applicationId,
+                application,
+                body: req.body || {},
+                consent,
+                providerHealth,
+                autopilotPolicy,
+                frontendOrigin: resolveFrontendOriginInput(req),
+                logBase: {
+                  route: "landlord_analytics_decision_execute",
+                  decisionId,
+                  applicationId,
+                },
+              });
+              if (execution.status !== 200) {
+                const executionPayload = execution.payload as any;
+                const error = new Error(String(executionPayload?.error || "AUTOMATION_EXECUTION_FAILED"));
+                (error as any).code =
+                  executionPayload?.errorCode || executionPayload?.error || "AUTOMATION_EXECUTION_FAILED";
+                throw error;
+              }
+              return execution.payload;
+            },
+          },
         });
       } else {
         return res.status(409).json({ ok: false, error: "DECISION_EXECUTION_UNSUPPORTED" });

--- a/rentchain-api/src/routes/rentalApplicationsRoutes.ts
+++ b/rentchain-api/src/routes/rentalApplicationsRoutes.ts
@@ -47,6 +47,11 @@ import { rateLimitScreeningIp, rateLimitScreeningUser } from "../middleware/rate
 import { buildEmailHtml, buildEmailText } from "../email/templates/baseEmailTemplate";
 import { sendEmail } from "../services/emailService";
 import { recordScreeningPaymentInitiated } from "../services/screeningPaymentTransactionService";
+import {
+  executeScreeningCheckout,
+  logMockProviderCheckout,
+  shouldUseMockScreeningCheckoutOverride,
+} from "../services/screeningCheckoutExecutionService";
 import { writeCanonicalEvent } from "../lib/events/buildEvent";
 import { executeAutomation } from "../lib/automation/automationExecutor";
 import { buildScreeningPolicyRequest } from "../lib/policy/policyAdapters";
@@ -330,481 +335,6 @@ function buildRedirectUrl(params: {
 
 function isAutomationRequested(body: any) {
   return Boolean(body?.automationEnabled || body?.automation?.enabled);
-}
-
-async function performScreeningCheckoutExecution(params: {
-  req: any;
-  role: string;
-  actorId: string | null;
-  landlordId: string;
-  applicationId: string;
-  application: any;
-  body: any;
-  consent: { timestamp: string; version: string; textHash: string | null };
-  providerHealth: Awaited<ReturnType<typeof getScreeningProviderHealth>>;
-  autopilotPolicy: ReturnType<typeof toAutopilotPolicySummary> | null;
-  logBase: Record<string, unknown>;
-}) {
-  const {
-    req,
-    role,
-    actorId,
-    landlordId,
-    applicationId,
-    application,
-    body,
-    consent,
-    providerHealth,
-    autopilotPolicy,
-    logBase,
-  } = params;
-  const { screeningTier, screeningPackage, addons, v2Addons, serviceLevel, scoreAddOn, expeditedAddOn, paymentResponsibility, pricing } =
-    resolvePricingInput(body);
-  const frontendOrigin = resolveFrontendOrigin(req);
-  const rawReturnTo = String(body?.returnTo || "/dashboard");
-  const returnTo = rawReturnTo.startsWith("/") ? rawReturnTo : "/dashboard";
-  const successUrl = buildRedirectUrl({
-    input: body?.successPath,
-    fallbackPath: "/screening/success",
-    frontendOrigin,
-    applicationId,
-    returnTo,
-  });
-  const cancelUrl = buildRedirectUrl({
-    input: body?.cancelPath,
-    fallbackPath: "/screening/cancel",
-    frontendOrigin,
-    applicationId,
-    returnTo,
-  });
-  if (!successUrl || !cancelUrl) {
-    console.warn("[screening_checkout] invalid redirect origin", logBase);
-    return {
-      status: 400,
-      payload: { ok: false, error: "invalid_redirect_origin" },
-    };
-  }
-
-  if (isTransUnionReferralMode()) {
-    const now = Date.now();
-    const orderRef = db.collection("screeningOrders").doc();
-    const orderId = orderRef.id;
-    const referralUrl = buildTransUnionReferralUrl({
-      landlordId: String(landlordId),
-      applicationId,
-      orderId,
-      returnTo,
-      env: process.env.NODE_ENV || "development",
-    });
-
-    const orderPayload: any = {
-      id: orderId,
-      referenceId: buildReferenceId(orderId),
-      landlordId,
-      applicationId,
-      propertyId: application?.propertyId || null,
-      unitId: application?.unitId || null,
-      createdAt: now,
-      updatedAt: now,
-      amountCents: 0,
-      currency: "CAD",
-      status: "external_pending",
-      paymentStatus: "external_pending",
-      finalized: false,
-      finalizedAt: null,
-      lastStripeEventId: null,
-      amountTotalCents: 0,
-      screeningPackage,
-      screeningTier,
-      addons: v2Addons,
-      legacyAddons: addons.filter((value) => value === "credit_score" || value === "expedited"),
-      paymentResponsibility,
-      scoreAddOn: false,
-      scoreAddOnCents: 0,
-      expeditedAddOn: false,
-      expeditedAddOnCents: 0,
-      provider: "transunion_referral",
-      inquiryType: "soft",
-      providerRequestId: null,
-      paidAt: null,
-      error: null,
-      serviceLevel,
-      aiVerification: false,
-      aiPriceCents: 0,
-      totalAmountCents: 0,
-      reviewerStatus: "EXTERNAL_PENDING",
-      stripeSessionId: null,
-      stripeCheckoutSessionId: null,
-      stripePaymentIntentId: null,
-      stripeChargeId: null,
-      consentGiven: true,
-      consentTimestamp: consent.timestamp,
-      consentVersion: consent.version,
-      consentTextHash: consent.textHash,
-      externalRedirectUrl: referralUrl,
-      externalProvider: "transunion",
-    };
-    await orderRef.set(orderPayload, { merge: true });
-    await enqueueScreeningJob({
-      orderId,
-      applicationId,
-      landlordId: application?.landlordId || landlordId,
-      provider: "transunion_referral",
-    });
-    await db.collection("rentalApplications").doc(applicationId).set(
-      {
-        screeningStatus: "external_pending",
-        screeningOrderId: orderId,
-        screeningProvider: "transunion_referral",
-        screeningLastUpdatedAt: now,
-        screening: {
-          ...(application?.screening || {}),
-          status: "external_pending",
-          provider: "transunion_referral",
-          orderId,
-        },
-        screeningMonetization: buildScreeningMonetizationPatch({
-          current: application?.screeningMonetization,
-          eligibility: "eligible",
-          paymentStatus: "checkout_created",
-          fulfillmentStatus: "ordered",
-          package: screeningPackage,
-          addons: v2Addons,
-          paymentResponsibility,
-          checkoutSessionId: orderId,
-          checkoutCreatedAt: now,
-          amount: 0,
-          currency: "CAD",
-          lastErrorCode: null,
-          lastErrorMessage: null,
-        }),
-        updatedAt: now,
-      },
-      { merge: true }
-    );
-    await writeReferralInitiated({
-      referralId: orderId,
-      landlordId: String(landlordId),
-      applicationId,
-      orderId,
-      returnTo,
-      tuTrackingParams: extractTuTrackingParams(referralUrl),
-    });
-    logTuReferralEvent({
-      orderId,
-      applicationId,
-      landlordId: String(landlordId),
-      redirectUrl: referralUrl,
-    });
-    await writeCanonicalEvent({
-      domain: "screening",
-      action: "checkout_created",
-      actor: {
-        type: role === "admin" ? "admin" : "landlord",
-        role,
-        id: actorId,
-      },
-      resource: {
-        type: "screening_order",
-        id: orderId,
-        parentType: "rental_application",
-        parentId: applicationId,
-      },
-      occurredAt: now,
-      visibility: "internal",
-      summary: "Screening checkout session created",
-      metadata: {
-        applicationId,
-        landlordId,
-        propertyId: application?.propertyId || null,
-        unitId: application?.unitId || null,
-        serviceLevel,
-        totalAmountCents: 0,
-      },
-    });
-    return {
-      status: 200,
-      payload: {
-        ok: true,
-        mode: "transunion_referral",
-        orderId,
-        applicationId,
-        redirectUrl: referralUrl,
-        checkoutUrl: referralUrl,
-        autopilotPolicy,
-        screeningMonetizationSummary: buildScreeningMonetizationSummary(
-          normalizeScreeningMonetizationState({
-            application: {
-              ...application,
-              screeningMonetization: buildScreeningMonetizationPatch({
-                current: application?.screeningMonetization,
-                eligibility: "eligible",
-                paymentStatus: "checkout_created",
-                fulfillmentStatus: "ordered",
-                checkoutSessionId: orderId,
-                checkoutCreatedAt: now,
-                amount: 0,
-                currency: "CAD",
-              }),
-            },
-            latestOrder: { ...orderPayload, stripeCheckoutSessionId: orderId },
-            eligibility: "eligible",
-            amount: 0,
-            currency: "CAD",
-          })
-        ),
-      },
-    };
-  }
-
-  let stripe: any;
-  try {
-    stripe = getStripeClient();
-  } catch (err: any) {
-    if (err?.code === "stripe_not_configured" || err?.message === "stripe_not_configured") {
-      return {
-        status: 400,
-        payload: { ok: false, error: "stripe_not_configured" },
-      };
-    }
-    throw err;
-  }
-
-  const now = Date.now();
-  const orderRef = db.collection("screeningOrders").doc();
-  const orderId = orderRef.id;
-  const aiVerification = serviceLevel === "VERIFIED_AI";
-  const orderPayload: any = {
-    id: orderId,
-    referenceId: buildReferenceId(orderId),
-    landlordId,
-    applicationId,
-    propertyId: application?.propertyId || null,
-    unitId: application?.unitId || null,
-    createdAt: now,
-    amountCents: pricing.baseAmountCents,
-    currency: "CAD",
-    status: "unpaid",
-    paymentStatus: "unpaid",
-    finalized: false,
-    finalizedAt: null,
-    lastStripeEventId: null,
-    amountTotalCents: pricing.totalAmountCents,
-    screeningPackage,
-    screeningTier,
-    addons: v2Addons,
-    legacyAddons: addons.filter((value) => value === "credit_score" || value === "expedited"),
-    paymentResponsibility,
-    scoreAddOn,
-    scoreAddOnCents: pricing.scoreAddOnCents,
-    expeditedAddOn,
-    expeditedAddOnCents: pricing.expeditedAddOnCents,
-    provider: providerHealth.provider,
-    inquiryType: "soft",
-    providerRequestId: null,
-    paidAt: null,
-    error: null,
-    serviceLevel,
-    aiVerification,
-    aiPriceCents: aiVerification ? pricing.aiAddOnCents : 0,
-    totalAmountCents: pricing.totalAmountCents,
-    reviewerStatus: "QUEUED",
-    stripeSessionId: null,
-    stripeCheckoutSessionId: null,
-    stripePaymentIntentId: null,
-    stripeChargeId: null,
-    consentGiven: true,
-    consentTimestamp: consent.timestamp,
-    consentVersion: consent.version,
-    consentTextHash: consent.textHash,
-  };
-
-  await orderRef.set(orderPayload, { merge: true });
-
-  const currency = String(orderPayload.currency || "CAD").toLowerCase();
-  const lineItems = buildScreeningLineItems({
-    currency,
-    screeningPackage,
-    addons: v2Addons,
-    pricing,
-  });
-
-  const safeInt = (n: unknown) => {
-    const x = Number(n);
-    if (!Number.isFinite(x)) return 0;
-    return Math.round(x);
-  };
-
-  const normalizedLineItems = lineItems.map((item) => ({
-    ...item,
-    price_data: {
-      ...item.price_data,
-      unit_amount: Math.max(0, safeInt(item.price_data?.unit_amount)),
-      currency: String(item.price_data?.currency || currency).toLowerCase(),
-    },
-  }));
-
-  const session = await stripe.checkout.sessions.create({
-    mode: "payment",
-    line_items: normalizedLineItems,
-    client_reference_id: orderId,
-    success_url: successUrl,
-    cancel_url: cancelUrl,
-    metadata: {
-      orderId,
-      applicationId,
-      landlordId,
-      serviceLevel,
-      screeningPackage,
-      paymentResponsibility,
-      scoreAddOn: String(scoreAddOn),
-      screeningTier,
-      addons: v2Addons.join(","),
-      totalAmountCents: String(pricing.totalAmountCents),
-    },
-    payment_intent_data: {
-      metadata: {
-        orderId,
-        applicationId,
-        landlordId,
-        serviceLevel,
-        screeningPackage,
-        paymentResponsibility,
-        scoreAddOn: String(scoreAddOn),
-        screeningTier,
-        addons: v2Addons.join(","),
-        totalAmountCents: String(pricing.totalAmountCents),
-      },
-    },
-  });
-
-  await orderRef.set(
-    { stripeSessionId: session.id, stripeCheckoutSessionId: session.id, updatedAt: Date.now() },
-    { merge: true }
-  );
-
-  await db.collection("rentalApplications").doc(applicationId).set(
-    {
-      screening: {
-        requested: true,
-        requestedAt: now,
-        status: "PENDING",
-        provider: "STUB",
-        orderId,
-        amountCents: pricing.baseAmountCents,
-        currency: "CAD",
-        screeningPackage,
-        paidAt: null,
-        screeningTier,
-        addons: v2Addons,
-        paymentResponsibility,
-        scoreAddOn,
-        scoreAddOnCents: pricing.scoreAddOnCents,
-        expeditedAddOn,
-        expeditedAddOnCents: pricing.expeditedAddOnCents,
-        totalAmountCents: pricing.totalAmountCents,
-        serviceLevel,
-        aiVerification,
-        consentGiven: true,
-        consentTimestamp: consent.timestamp,
-        consentVersion: consent.version,
-        consentTextHash: consent.textHash,
-        ai: null,
-        result: null,
-      },
-      screeningMonetization: buildScreeningMonetizationPatch({
-        current: application?.screeningMonetization,
-        eligibility: "eligible",
-        paymentStatus: "checkout_created",
-        fulfillmentStatus: "ready",
-        package: screeningPackage,
-        addons: v2Addons,
-        paymentResponsibility,
-        checkoutSessionId: session.id,
-        checkoutCreatedAt: now,
-        amount: pricing.totalAmountCents,
-        currency: "CAD",
-        lastErrorCode: null,
-        lastErrorMessage: null,
-      }),
-      updatedAt: now,
-    },
-    { merge: true }
-  );
-
-  await recordScreeningPaymentInitiated({
-    landlordId,
-    propertyId: application?.propertyId || null,
-    unitId: application?.unitId || null,
-    applicationId,
-    screeningOrderId: orderId,
-    amountCents: pricing.totalAmountCents,
-    currency: "CAD",
-    stripeCheckoutSessionId: session.id,
-    serviceLevel,
-    recordedAt: now,
-  });
-  await writeCanonicalEvent({
-    domain: "screening",
-    action: "checkout_created",
-    actor: {
-      type: role === "admin" ? "admin" : "landlord",
-      role,
-      id: actorId,
-    },
-    resource: {
-      type: "screening_order",
-      id: orderId,
-      parentType: "rental_application",
-      parentId: applicationId,
-    },
-    occurredAt: now,
-    visibility: "internal",
-    summary: "Screening checkout session created",
-    metadata: {
-      applicationId,
-      landlordId,
-      propertyId: application?.propertyId || null,
-      unitId: application?.unitId || null,
-      stripeCheckoutSessionId: session.id,
-      serviceLevel,
-      totalAmountCents: pricing.totalAmountCents,
-    },
-  });
-
-  console.log("[screening_checkout] create_session_ok", {
-    ...logBase,
-    event: "create_session_ok",
-  });
-  return {
-    status: 200,
-    payload: {
-      ok: true,
-      checkoutUrl: session.url,
-      autopilotPolicy,
-      screeningMonetizationSummary: buildScreeningMonetizationSummary(
-        normalizeScreeningMonetizationState({
-          application: {
-            ...application,
-            screeningMonetization: buildScreeningMonetizationPatch({
-              current: application?.screeningMonetization,
-              eligibility: "eligible",
-              paymentStatus: "checkout_created",
-              fulfillmentStatus: "ready",
-              checkoutSessionId: session.id,
-              checkoutCreatedAt: now,
-              amount: pricing.totalAmountCents,
-              currency: "CAD",
-            }),
-          },
-          latestOrder: { ...orderPayload, stripeCheckoutSessionId: session.id },
-          eligibility: "eligible",
-          amount: pricing.totalAmountCents,
-          currency: "CAD",
-        })
-      ),
-    },
-  };
 }
 
 function applicantName(app: any): string {
@@ -1380,36 +910,6 @@ function logCutoverBlocked(params: {
       ts: new Date().toISOString(),
       revision: process.env.K_REVISION || process.env.GIT_SHA || undefined,
       skippedReason: params.skippedReason,
-    },
-  });
-}
-
-function shouldUseMockCheckoutOverride(params: {
-  role: string;
-  seedKey: string;
-}) {
-  const allowMock = process.env.ALLOW_MOCK_PROVIDER_CHECKOUT === "true";
-  if (!allowMock) return false;
-  if (params.role !== "admin") return false;
-  return isAllowlistedSeed(params.seedKey, parseAllowlist());
-}
-
-function logMockProviderCheckout(params: { name: "checkout" | "run"; seedKey: string }) {
-  logCutoverEvent({
-    eventType: "bureau_cutover",
-    name: params.name,
-    seedHash: hashSeedKey(params.seedKey || ""),
-    selectedRoute: "adapter",
-    responseSource: "adapter",
-    fallbackUsed: false,
-    adapter: { ok: true, status: 200 },
-    legacy: { ok: false },
-    diff: { isMatch: true, fields: [] },
-    meta: {
-      env: process.env.NODE_ENV || "development",
-      ts: new Date().toISOString(),
-      revision: process.env.K_REVISION || process.env.GIT_SHA || undefined,
-      providerMode: "mock",
     },
   });
 }
@@ -2125,8 +1625,7 @@ router.post(
           existingCheckout: false,
           alreadyPaid: false,
           execute: async () => {
-            const execution = await performScreeningCheckoutExecution({
-              req,
+            const execution = await executeScreeningCheckout({
               role,
               actorId: String(req.user?.id || req.user?.landlordId || "").trim() || null,
               landlordId: String(landlordId),
@@ -2136,6 +1635,7 @@ router.post(
               consent,
               providerHealth,
               autopilotPolicy,
+              frontendOrigin: resolveFrontendOrigin(req),
               logBase: { route: "screening_quote_automation", applicationId: id },
             });
             if (execution.status !== 200) {
@@ -2262,7 +1762,7 @@ router.post(
       );
       const providerHealth = await getScreeningProviderHealth();
       const referralMode = isTransUnionReferralMode();
-      const allowMockOverride = shouldUseMockCheckoutOverride({ role, seedKey: id });
+      const allowMockOverride = shouldUseMockScreeningCheckoutOverride({ role, seedKey: id });
       const providerReady =
         referralMode ||
         allowMockOverride ||
@@ -2645,8 +2145,7 @@ router.post(
         });
       }
 
-      const execution = await performScreeningCheckoutExecution({
-        req,
+      const execution = await executeScreeningCheckout({
         role,
         actorId: String(req.user?.id || req.user?.landlordId || "").trim() || null,
         landlordId: String(landlordId),
@@ -2656,6 +2155,7 @@ router.post(
         consent,
         providerHealth,
         autopilotPolicy,
+        frontendOrigin: resolveFrontendOrigin(req),
         logBase,
       });
       return res.status(execution.status).json(execution.payload);
@@ -2843,7 +2343,7 @@ router.post(
 
       const providerHealth = await getScreeningProviderHealth();
       const referralMode = isTransUnionReferralMode();
-      const allowMockOverride = shouldUseMockCheckoutOverride({ role, seedKey: applicationId });
+      const allowMockOverride = shouldUseMockScreeningCheckoutOverride({ role, seedKey: applicationId });
       if (
         process.env.NODE_ENV === "production" &&
         !referralMode &&
@@ -3819,7 +3319,7 @@ router.post(
 
       const providerHealth = await getScreeningProviderHealth();
       const referralMode = isTransUnionReferralMode();
-      const allowMockOverride = shouldUseMockCheckoutOverride({ role, seedKey: id });
+      const allowMockOverride = shouldUseMockScreeningCheckoutOverride({ role, seedKey: id });
       if (
         process.env.NODE_ENV === "production" &&
         !referralMode &&

--- a/rentchain-api/src/services/landlord/__tests__/landlordAnalyticsSnapshot.test.ts
+++ b/rentchain-api/src/services/landlord/__tests__/landlordAnalyticsSnapshot.test.ts
@@ -577,9 +577,9 @@ describe("loadLandlordAnalyticsSnapshot", () => {
           decisionType: "start_screening_checkout",
           actionKey: "open_screening_checkout_flow",
           workflowCategory: "screening_checkout",
-          automationEligible: false,
-          automationState: "blocked",
-          automationReason: expect.stringContaining("explicit screening execution is not enabled"),
+          automationEligible: true,
+          automationState: "ready",
+          automationReason: "This decision is active and already mapped to a deterministic automation path.",
           executionMappingState: "mapped",
           executionMapping: expect.objectContaining({
             action: "screening.auto_start_checkout",

--- a/rentchain-api/src/services/screeningCheckoutExecutionService.ts
+++ b/rentchain-api/src/services/screeningCheckoutExecutionService.ts
@@ -1,0 +1,835 @@
+import { db } from "../config/firebase";
+import { getStripeClient } from "./stripeService";
+import { getScreeningPricing } from "../billing/screeningPricing";
+import {
+  PACKAGE_TO_LEGACY_TIER,
+  SCREENING_ADDONS_V2,
+  SCREENING_PACKAGES_V2,
+} from "../lib/screeningMonetizationV2/screeningPackages";
+import {
+  calculateScreeningPrice,
+  isScreeningAddonKey,
+  isScreeningPackageKey,
+} from "../lib/screeningMonetizationV2/calculateScreeningPrice";
+import { buildTransUnionReferralUrl } from "./screening/transunionReferral";
+import { writeReferralInitiated } from "./screening/referralTracking";
+import { enqueueScreeningJob } from "./screeningJobs";
+import { recordScreeningPaymentInitiated } from "./screeningPaymentTransactionService";
+import { writeCanonicalEvent } from "../lib/events/buildEvent";
+import {
+  buildScreeningMonetizationPatch,
+  buildScreeningMonetizationSummary,
+  normalizeScreeningMonetizationState,
+} from "./screening/screeningMonetizationService";
+import { hashSeedKey, isAllowlistedSeed, parseAllowlist } from "./screening/cutoverConfig";
+import { logCutoverEvent } from "./screening/cutoverTelemetry";
+
+const ALLOWED_REDIRECT_ORIGINS = ["https://www.rentchain.ai", "https://rentchain.ai", "http://localhost:5173"];
+
+function isAllowedRedirectOrigin(origin: string) {
+  if (!origin) return false;
+  if (process.env.NODE_ENV === "production" && origin.includes("localhost")) return false;
+  if (ALLOWED_REDIRECT_ORIGINS.includes(origin)) return true;
+  if (/^https:\/\/.+\.vercel\.app$/i.test(origin)) return true;
+  return false;
+}
+
+function normalizeOrigin(raw?: string | string[] | null) {
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  if (!value || typeof value !== "string") return null;
+  try {
+    const url = new URL(value);
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+function resolveFrontendOrigin(frontendOrigin?: string | null) {
+  const inputOrigin = normalizeOrigin(frontendOrigin);
+  if (inputOrigin && isAllowedRedirectOrigin(inputOrigin)) {
+    return inputOrigin;
+  }
+  const envOrigin = normalizeOrigin(process.env.FRONTEND_ORIGIN || process.env.PUBLIC_APP_URL || "");
+  if (envOrigin && isAllowedRedirectOrigin(envOrigin)) {
+    return envOrigin;
+  }
+  const fallback =
+    process.env.NODE_ENV === "production" ? "https://www.rentchain.ai" : "http://localhost:5173";
+  const base = String(process.env.FRONTEND_URL || fallback).trim();
+  return normalizeOrigin(base) || null;
+}
+
+function buildRedirectUrl(params: {
+  input?: string;
+  fallbackPath: string;
+  frontendOrigin: string | null;
+  applicationId?: string | null;
+  orderId?: string | null;
+  returnTo?: string | null;
+}) {
+  const rawInput = String(params.input || "").trim();
+  const target = rawInput || params.fallbackPath;
+  if (!target) return null;
+
+  let url: URL;
+  if (/^https?:\/\//i.test(target)) {
+    try {
+      url = new URL(target);
+    } catch {
+      return null;
+    }
+    if (!isAllowedRedirectOrigin(url.origin)) {
+      return null;
+    }
+  } else {
+    if (!params.frontendOrigin) return null;
+    const path = target.startsWith("/") ? target : `/${target}`;
+    url = new URL(path, params.frontendOrigin);
+  }
+
+  if (params.applicationId) {
+    url.searchParams.set("applicationId", params.applicationId);
+  }
+  if (params.orderId) {
+    url.searchParams.set("orderId", params.orderId);
+  }
+  if (params.returnTo) {
+    url.searchParams.set("returnTo", params.returnTo);
+  }
+  return url.toString();
+}
+
+function resolveScreeningTier(raw?: string | null): "basic" | "verify" | "verify_ai" {
+  const val = String(raw || "").trim().toLowerCase();
+  if (val === "verify" || val === "verified") return "verify";
+  if (val === "verify_ai" || val === "verified_ai" || val === "verify+ai") return "verify_ai";
+  return "basic";
+}
+
+function resolveScreeningPackage(raw?: string | null): "basic" | "standard" | "premium" | null {
+  const val = String(raw || "").trim().toLowerCase();
+  if (isScreeningPackageKey(val)) return val;
+  return null;
+}
+
+function normalizeAddons(raw: any): string[] {
+  if (!raw) return [];
+  if (Array.isArray(raw)) return raw.map((v) => String(v || "").trim().toLowerCase()).filter(Boolean);
+  if (typeof raw === "string") {
+    return raw
+      .split(",")
+      .map((v) => v.trim().toLowerCase())
+      .filter(Boolean);
+  }
+  return [];
+}
+
+function normalizeScreeningV2Addons(raw: any) {
+  return normalizeAddons(raw).filter((value) => isScreeningAddonKey(value));
+}
+
+function resolvePaymentResponsibility(raw?: string | null): "landlord" | "tenant" {
+  return String(raw || "").trim().toLowerCase() === "tenant" ? "tenant" : "landlord";
+}
+
+function resolvePricingInput(body: any) {
+  const requestedPackage = resolveScreeningPackage(body?.screeningPackage || body?.package);
+  const v2Addons = normalizeScreeningV2Addons(body?.addons);
+  const screeningTier = resolveScreeningTier(
+    body?.screeningTier || (requestedPackage ? PACKAGE_TO_LEGACY_TIER[requestedPackage] : undefined)
+  );
+  const screeningPackage =
+    requestedPackage || (screeningTier === "verify" ? "standard" : screeningTier === "verify_ai" ? "premium" : "basic");
+  const legacyAddons = normalizeAddons(body?.addons).filter(
+    (value) => value === "credit_score" || value === "expedited"
+  );
+  const addons = [...v2Addons, ...legacyAddons];
+  const serviceLevel =
+    String(
+      body?.serviceLevel ||
+        (screeningTier === "basic" ? "SELF_SERVE" : screeningTier === "verify" ? "VERIFIED" : "VERIFIED_AI")
+    )
+      .trim()
+      .toUpperCase() || "SELF_SERVE";
+  const scoreAddOn = addons.includes("credit_score") || body?.scoreAddOn === true;
+  const expeditedAddOn = addons.includes("expedited");
+  const paymentResponsibility = resolvePaymentResponsibility(body?.paymentResponsibility || body?.payer);
+  const pricing = getScreeningPricing({
+    screeningTier,
+    packageKey: screeningPackage,
+    addons,
+    currency: "CAD",
+  });
+  const packagePricing = calculateScreeningPrice({
+    packageKey: screeningPackage,
+    addons: v2Addons,
+    currency: "CAD",
+  });
+  return {
+    screeningTier,
+    screeningPackage,
+    addons,
+    v2Addons,
+    serviceLevel,
+    scoreAddOn,
+    expeditedAddOn,
+    paymentResponsibility,
+    pricing: {
+      ...pricing,
+      packageAmountCents: packagePricing.packageAmountCents,
+      addonAmountCents: packagePricing.addonAmountCents,
+    },
+  };
+}
+
+function buildScreeningLineItems(params: {
+  currency: string;
+  screeningPackage: string;
+  addons: string[];
+  pricing: any;
+}) {
+  const currency = String(params.currency || "cad").toLowerCase();
+  const packageConfig =
+    SCREENING_PACKAGES_V2[params.screeningPackage as keyof typeof SCREENING_PACKAGES_V2] ||
+    SCREENING_PACKAGES_V2.basic;
+  const items: any[] = [
+    {
+      price_data: {
+        currency,
+        product_data: { name: `${packageConfig.label} screening package` },
+        unit_amount: params.pricing.baseAmountCents,
+      },
+      quantity: 1,
+    },
+  ];
+  for (const addonKey of params.addons) {
+    if (!isScreeningAddonKey(addonKey)) continue;
+    const addon = SCREENING_ADDONS_V2[addonKey];
+    items.push({
+      price_data: {
+        currency,
+        product_data: { name: addon.label },
+        unit_amount: addon.price,
+      },
+      quantity: 1,
+    });
+  }
+  if (params.pricing.scoreAddOnCents) {
+    items.push({
+      price_data: {
+        currency,
+        product_data: { name: "Credit score add-on" },
+        unit_amount: params.pricing.scoreAddOnCents,
+      },
+      quantity: 1,
+    });
+  }
+  if (params.pricing.expeditedAddOnCents) {
+    items.push({
+      price_data: {
+        currency,
+        product_data: { name: "Expedited processing add-on" },
+        unit_amount: params.pricing.expeditedAddOnCents,
+      },
+      quantity: 1,
+    });
+  }
+  return items;
+}
+
+export function isTransUnionReferralMode() {
+  const key = String(process.env.BUREAU_PROVIDER || process.env.SCREENING_PROVIDER || "")
+    .trim()
+    .toLowerCase();
+  return key === "transunion_referral";
+}
+
+export function shouldUseMockScreeningCheckoutOverride(params: { role: string; seedKey: string }) {
+  const allowMock = process.env.ALLOW_MOCK_PROVIDER_CHECKOUT === "true";
+  if (!allowMock) return false;
+  if (params.role !== "admin") return false;
+  return isAllowlistedSeed(params.seedKey, parseAllowlist());
+}
+
+export function logMockProviderCheckout(params: { name: "checkout" | "run"; seedKey: string }) {
+  logCutoverEvent({
+    eventType: "bureau_cutover",
+    name: params.name,
+    seedHash: hashSeedKey(params.seedKey || ""),
+    selectedRoute: "adapter",
+    responseSource: "adapter",
+    fallbackUsed: false,
+    adapter: { ok: true, status: 200 },
+    legacy: { ok: false },
+    diff: { isMatch: true, fields: [] },
+    meta: {
+      env: process.env.NODE_ENV || "development",
+      ts: new Date().toISOString(),
+      revision: process.env.K_REVISION || process.env.GIT_SHA || undefined,
+      providerMode: "mock",
+    },
+  });
+}
+
+function logTuReferralEvent(params: {
+  orderId: string;
+  applicationId: string;
+  landlordId: string;
+  redirectUrl: string;
+}) {
+  let redirectDomain = "unknown";
+  try {
+    redirectDomain = new URL(params.redirectUrl).host;
+  } catch {
+    redirectDomain = "invalid_url";
+  }
+  console.info(
+    "[tu_referral]",
+    JSON.stringify({
+      eventType: "tu_referral_redirect",
+      orderHash: hashSeedKey(params.orderId),
+      applicationHash: hashSeedKey(params.applicationId),
+      landlordHash: hashSeedKey(params.landlordId),
+      redirectDomain,
+      ts: new Date().toISOString(),
+    })
+  );
+}
+
+function extractTuTrackingParams(redirectUrl: string): { source?: string; ts?: string } {
+  try {
+    const url = new URL(redirectUrl);
+    const source = String(url.searchParams.get("source") || "").trim();
+    const ts = String(url.searchParams.get("ts") || "").trim();
+    return {
+      ...(source ? { source } : {}),
+      ...(ts ? { ts } : {}),
+    };
+  } catch {
+    return {};
+  }
+}
+
+function buildReferenceId(orderId: string) {
+  const safe = String(orderId || "").replace(/[^a-z0-9]/gi, "");
+  const suffix = safe.slice(-8).toUpperCase() || "UNKNOWN";
+  return `RC-${suffix}`;
+}
+
+export async function loadScreeningApplicationForLandlord(params: {
+  landlordId: string;
+  applicationId: string;
+}) {
+  const landlordId = String(params.landlordId || "").trim();
+  const applicationId = String(params.applicationId || "").trim();
+  if (!landlordId || !applicationId) return { ok: false as const, error: "NOT_FOUND" as const };
+
+  const snap = await db.collection("rentalApplications").doc(applicationId).get();
+  if (!snap.exists) {
+    return { ok: false as const, error: "NOT_FOUND" as const };
+  }
+
+  const application = { id: snap.id, ...(snap.data() || {}) };
+  const ownerLandlordId = String((application as any)?.landlordId || "").trim();
+  if (ownerLandlordId && ownerLandlordId !== landlordId) {
+    return { ok: false as const, error: "FORBIDDEN" as const };
+  }
+
+  return { ok: true as const, application };
+}
+
+export async function loadLatestScreeningOrderForApplication(applicationId: string) {
+  const snap = await db.collection("screeningOrders").where("applicationId", "==", applicationId).limit(25).get();
+  const orders = snap.docs.map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }));
+  orders.sort((a: any, b: any) => {
+    const aUpdated = Number(a?.updatedAt || a?.createdAt || 0);
+    const bUpdated = Number(b?.updatedAt || b?.createdAt || 0);
+    return bUpdated - aUpdated;
+  });
+  return orders[0] || null;
+}
+
+export async function executeScreeningCheckout(params: {
+  role: string;
+  actorId: string | null;
+  landlordId: string;
+  applicationId: string;
+  application: any;
+  body: any;
+  consent: { timestamp: string; version: string; textHash: string | null };
+  providerHealth: { provider: string; configured: boolean; preflightOk: boolean; preflightDetail?: string | null };
+  autopilotPolicy: any;
+  frontendOrigin?: string | null;
+  logBase: Record<string, unknown>;
+}) {
+  const {
+    role,
+    actorId,
+    landlordId,
+    applicationId,
+    application,
+    body,
+    consent,
+    providerHealth,
+    autopilotPolicy,
+    frontendOrigin,
+    logBase,
+  } = params;
+  const {
+    screeningTier,
+    screeningPackage,
+    addons,
+    v2Addons,
+    serviceLevel,
+    scoreAddOn,
+    expeditedAddOn,
+    paymentResponsibility,
+    pricing,
+  } = resolvePricingInput(body);
+  const resolvedFrontendOrigin = resolveFrontendOrigin(frontendOrigin);
+  const rawReturnTo = String(body?.returnTo || "/dashboard");
+  const returnTo = rawReturnTo.startsWith("/") ? rawReturnTo : "/dashboard";
+  const successUrl = buildRedirectUrl({
+    input: body?.successPath,
+    fallbackPath: "/screening/success",
+    frontendOrigin: resolvedFrontendOrigin,
+    applicationId,
+    returnTo,
+  });
+  const cancelUrl = buildRedirectUrl({
+    input: body?.cancelPath,
+    fallbackPath: "/screening/cancel",
+    frontendOrigin: resolvedFrontendOrigin,
+    applicationId,
+    returnTo,
+  });
+  if (!successUrl || !cancelUrl) {
+    console.warn("[screening_checkout] invalid redirect origin", logBase);
+    return {
+      status: 400,
+      payload: { ok: false, error: "invalid_redirect_origin" },
+    };
+  }
+
+  if (isTransUnionReferralMode()) {
+    const now = Date.now();
+    const orderRef = db.collection("screeningOrders").doc();
+    const orderId = orderRef.id;
+    const referralUrl = buildTransUnionReferralUrl({
+      landlordId: String(landlordId),
+      applicationId,
+      orderId,
+      returnTo,
+      env: process.env.NODE_ENV || "development",
+    });
+
+    const orderPayload: any = {
+      id: orderId,
+      referenceId: buildReferenceId(orderId),
+      landlordId,
+      applicationId,
+      propertyId: application?.propertyId || null,
+      unitId: application?.unitId || null,
+      createdAt: now,
+      updatedAt: now,
+      amountCents: 0,
+      currency: "CAD",
+      status: "external_pending",
+      paymentStatus: "external_pending",
+      finalized: false,
+      finalizedAt: null,
+      lastStripeEventId: null,
+      amountTotalCents: 0,
+      screeningPackage,
+      screeningTier,
+      addons: v2Addons,
+      legacyAddons: addons.filter((value) => value === "credit_score" || value === "expedited"),
+      paymentResponsibility,
+      scoreAddOn: false,
+      scoreAddOnCents: 0,
+      expeditedAddOn: false,
+      expeditedAddOnCents: 0,
+      provider: "transunion_referral",
+      inquiryType: "soft",
+      providerRequestId: null,
+      paidAt: null,
+      error: null,
+      serviceLevel,
+      aiVerification: false,
+      aiPriceCents: 0,
+      totalAmountCents: 0,
+      reviewerStatus: "EXTERNAL_PENDING",
+      stripeSessionId: null,
+      stripeCheckoutSessionId: null,
+      stripePaymentIntentId: null,
+      stripeChargeId: null,
+      consentGiven: true,
+      consentTimestamp: consent.timestamp,
+      consentVersion: consent.version,
+      consentTextHash: consent.textHash,
+      externalRedirectUrl: referralUrl,
+      externalProvider: "transunion",
+    };
+    await orderRef.set(orderPayload, { merge: true });
+    await enqueueScreeningJob({
+      orderId,
+      applicationId,
+      landlordId: application?.landlordId || landlordId,
+      provider: "transunion_referral",
+    });
+    await db.collection("rentalApplications").doc(applicationId).set(
+      {
+        screeningStatus: "external_pending",
+        screeningOrderId: orderId,
+        screeningProvider: "transunion_referral",
+        screeningLastUpdatedAt: now,
+        screening: {
+          ...(application?.screening || {}),
+          status: "external_pending",
+          provider: "transunion_referral",
+          orderId,
+        },
+        screeningMonetization: buildScreeningMonetizationPatch({
+          current: application?.screeningMonetization,
+          eligibility: "eligible",
+          paymentStatus: "checkout_created",
+          fulfillmentStatus: "ordered",
+          package: screeningPackage,
+          addons: v2Addons,
+          paymentResponsibility,
+          checkoutSessionId: orderId,
+          checkoutCreatedAt: now,
+          amount: 0,
+          currency: "CAD",
+          lastErrorCode: null,
+          lastErrorMessage: null,
+        }),
+        updatedAt: now,
+      },
+      { merge: true }
+    );
+    await writeReferralInitiated({
+      referralId: orderId,
+      landlordId: String(landlordId),
+      applicationId,
+      orderId,
+      returnTo,
+      tuTrackingParams: extractTuTrackingParams(referralUrl),
+    });
+    logTuReferralEvent({
+      orderId,
+      applicationId,
+      landlordId: String(landlordId),
+      redirectUrl: referralUrl,
+    });
+    await writeCanonicalEvent({
+      domain: "screening",
+      action: "checkout_created",
+      actor: {
+        type: role === "admin" ? "admin" : "landlord",
+        role,
+        id: actorId,
+      },
+      resource: {
+        type: "screening_order",
+        id: orderId,
+        parentType: "rental_application",
+        parentId: applicationId,
+      },
+      occurredAt: now,
+      visibility: "internal",
+      summary: "Screening checkout session created",
+      metadata: {
+        applicationId,
+        landlordId,
+        propertyId: application?.propertyId || null,
+        unitId: application?.unitId || null,
+        serviceLevel,
+        totalAmountCents: 0,
+      },
+    });
+    return {
+      status: 200,
+      payload: {
+        ok: true,
+        mode: "transunion_referral",
+        orderId,
+        applicationId,
+        redirectUrl: referralUrl,
+        checkoutUrl: referralUrl,
+        autopilotPolicy,
+        screeningMonetizationSummary: buildScreeningMonetizationSummary(
+          normalizeScreeningMonetizationState({
+            application: {
+              ...application,
+              screeningMonetization: buildScreeningMonetizationPatch({
+                current: application?.screeningMonetization,
+                eligibility: "eligible",
+                paymentStatus: "checkout_created",
+                fulfillmentStatus: "ordered",
+                checkoutSessionId: orderId,
+                checkoutCreatedAt: now,
+                amount: 0,
+                currency: "CAD",
+              }),
+            },
+            latestOrder: { ...orderPayload, stripeCheckoutSessionId: orderId },
+            eligibility: "eligible",
+            amount: 0,
+            currency: "CAD",
+          })
+        ),
+      },
+    };
+  }
+
+  let stripe: any;
+  try {
+    stripe = getStripeClient();
+  } catch (err: any) {
+    if (err?.code === "stripe_not_configured" || err?.message === "stripe_not_configured") {
+      return {
+        status: 400,
+        payload: { ok: false, error: "stripe_not_configured" },
+      };
+    }
+    throw err;
+  }
+
+  const now = Date.now();
+  const orderRef = db.collection("screeningOrders").doc();
+  const orderId = orderRef.id;
+  const aiVerification = serviceLevel === "VERIFIED_AI";
+  const orderPayload: any = {
+    id: orderId,
+    referenceId: buildReferenceId(orderId),
+    landlordId,
+    applicationId,
+    propertyId: application?.propertyId || null,
+    unitId: application?.unitId || null,
+    createdAt: now,
+    amountCents: pricing.baseAmountCents,
+    currency: "CAD",
+    status: "unpaid",
+    paymentStatus: "unpaid",
+    finalized: false,
+    finalizedAt: null,
+    lastStripeEventId: null,
+    amountTotalCents: pricing.totalAmountCents,
+    screeningPackage,
+    screeningTier,
+    addons: v2Addons,
+    legacyAddons: addons.filter((value) => value === "credit_score" || value === "expedited"),
+    paymentResponsibility,
+    scoreAddOn,
+    scoreAddOnCents: pricing.scoreAddOnCents,
+    expeditedAddOn,
+    expeditedAddOnCents: pricing.expeditedAddOnCents,
+    provider: providerHealth.provider,
+    inquiryType: "soft",
+    providerRequestId: null,
+    paidAt: null,
+    error: null,
+    serviceLevel,
+    aiVerification,
+    aiPriceCents: aiVerification ? pricing.aiAddOnCents : 0,
+    totalAmountCents: pricing.totalAmountCents,
+    reviewerStatus: "QUEUED",
+    stripeSessionId: null,
+    stripeCheckoutSessionId: null,
+    stripePaymentIntentId: null,
+    stripeChargeId: null,
+    consentGiven: true,
+    consentTimestamp: consent.timestamp,
+    consentVersion: consent.version,
+    consentTextHash: consent.textHash,
+  };
+
+  await orderRef.set(orderPayload, { merge: true });
+
+  const currency = String(orderPayload.currency || "CAD").toLowerCase();
+  const lineItems = buildScreeningLineItems({
+    currency,
+    screeningPackage,
+    addons: v2Addons,
+    pricing,
+  });
+
+  const safeInt = (n: unknown) => {
+    const x = Number(n);
+    if (!Number.isFinite(x)) return 0;
+    return Math.round(x);
+  };
+
+  const normalizedLineItems = lineItems.map((item) => ({
+    ...item,
+    price_data: {
+      ...item.price_data,
+      unit_amount: Math.max(0, safeInt(item.price_data?.unit_amount)),
+      currency: String(item.price_data?.currency || currency).toLowerCase(),
+    },
+  }));
+
+  const session = await stripe.checkout.sessions.create({
+    mode: "payment",
+    line_items: normalizedLineItems,
+    client_reference_id: orderId,
+    success_url: successUrl,
+    cancel_url: cancelUrl,
+    metadata: {
+      orderId,
+      applicationId,
+      landlordId,
+      serviceLevel,
+      screeningPackage,
+      paymentResponsibility,
+      scoreAddOn: String(scoreAddOn),
+      screeningTier,
+      addons: v2Addons.join(","),
+      totalAmountCents: String(pricing.totalAmountCents),
+    },
+    payment_intent_data: {
+      metadata: {
+        orderId,
+        applicationId,
+        landlordId,
+        serviceLevel,
+        screeningPackage,
+        paymentResponsibility,
+        scoreAddOn: String(scoreAddOn),
+        screeningTier,
+        addons: v2Addons.join(","),
+        totalAmountCents: String(pricing.totalAmountCents),
+      },
+    },
+  });
+
+  await orderRef.set(
+    { stripeSessionId: session.id, stripeCheckoutSessionId: session.id, updatedAt: Date.now() },
+    { merge: true }
+  );
+
+  await db.collection("rentalApplications").doc(applicationId).set(
+    {
+      screening: {
+        requested: true,
+        requestedAt: now,
+        status: "PENDING",
+        provider: "STUB",
+        orderId,
+        amountCents: pricing.baseAmountCents,
+        currency: "CAD",
+        screeningPackage,
+        paidAt: null,
+        screeningTier,
+        addons: v2Addons,
+        paymentResponsibility,
+        scoreAddOn,
+        scoreAddOnCents: pricing.scoreAddOnCents,
+        expeditedAddOn,
+        expeditedAddOnCents: pricing.expeditedAddOnCents,
+        totalAmountCents: pricing.totalAmountCents,
+        serviceLevel,
+        aiVerification,
+        consentGiven: true,
+        consentTimestamp: consent.timestamp,
+        consentVersion: consent.version,
+        consentTextHash: consent.textHash,
+        ai: null,
+        result: null,
+      },
+      screeningMonetization: buildScreeningMonetizationPatch({
+        current: application?.screeningMonetization,
+        eligibility: "eligible",
+        paymentStatus: "checkout_created",
+        fulfillmentStatus: "ready",
+        package: screeningPackage,
+        addons: v2Addons,
+        paymentResponsibility,
+        checkoutSessionId: session.id,
+        checkoutCreatedAt: now,
+        amount: pricing.totalAmountCents,
+        currency: "CAD",
+        lastErrorCode: null,
+        lastErrorMessage: null,
+      }),
+      updatedAt: now,
+    },
+    { merge: true }
+  );
+
+  await recordScreeningPaymentInitiated({
+    landlordId,
+    propertyId: application?.propertyId || null,
+    unitId: application?.unitId || null,
+    applicationId,
+    screeningOrderId: orderId,
+    amountCents: pricing.totalAmountCents,
+    currency: "CAD",
+    stripeCheckoutSessionId: session.id,
+    serviceLevel,
+    recordedAt: now,
+  });
+  await writeCanonicalEvent({
+    domain: "screening",
+    action: "checkout_created",
+    actor: {
+      type: role === "admin" ? "admin" : "landlord",
+      role,
+      id: actorId,
+    },
+    resource: {
+      type: "screening_order",
+      id: orderId,
+      parentType: "rental_application",
+      parentId: applicationId,
+    },
+    occurredAt: now,
+    visibility: "internal",
+    summary: "Screening checkout session created",
+    metadata: {
+      applicationId,
+      landlordId,
+      propertyId: application?.propertyId || null,
+      unitId: application?.unitId || null,
+      stripeCheckoutSessionId: session.id,
+      serviceLevel,
+      totalAmountCents: pricing.totalAmountCents,
+    },
+  });
+
+  console.log("[screening_checkout] create_session_ok", {
+    ...logBase,
+    event: "create_session_ok",
+  });
+  return {
+    status: 200,
+    payload: {
+      ok: true,
+      checkoutUrl: session.url,
+      autopilotPolicy,
+      screeningMonetizationSummary: buildScreeningMonetizationSummary(
+        normalizeScreeningMonetizationState({
+          application: {
+            ...application,
+            screeningMonetization: buildScreeningMonetizationPatch({
+              current: application?.screeningMonetization,
+              eligibility: "eligible",
+              paymentStatus: "checkout_created",
+              fulfillmentStatus: "ready",
+              checkoutSessionId: session.id,
+              checkoutCreatedAt: now,
+              amount: pricing.totalAmountCents,
+              currency: "CAD",
+            }),
+          },
+          latestOrder: { ...orderPayload, stripeCheckoutSessionId: session.id },
+          eligibility: "eligible",
+          amount: pricing.totalAmountCents,
+          currency: "CAD",
+        })
+      ),
+    },
+  };
+}


### PR DESCRIPTION
Added the third safe explicit execution family by enabling `start_screening_checkout -> screening.auto_start_checkout`.

This change removes the intentional screening execution block once deterministic screening mapping/readiness is present, extracts a shared screening checkout execution service, and reuses it from both `rentalApplicationsRoutes` and the landlord decision execute route.

Execution remains explicit, fail-closed, and limited to one exact application. Lease-renewal execution, maintenance execution, lifecycle state, history/timeline, outcome analytics, lease integrity behavior, application action behavior, and property summary integrity remain unchanged.

Key framing:
- `start_screening_checkout` is now the third safe explicit execution family
- execution remains one-application-only and explicit landlord-triggered
- screening execution reuses shared canonical checkout infrastructure
- readiness, feedback, history, and analytics remain aligned with the existing decision execution model
- bulk screening, background automation, and provider redesign remain out of scope