### PR TITLE
feat: tenant record cleanup and profile actions v1

### DIFF
--- a/rentchain-api/scripts/migrations/hideListedTestTenants.ts
+++ b/rentchain-api/scripts/migrations/hideListedTestTenants.ts
@@ -1,0 +1,57 @@
+import { FieldValue, db } from "../../src/config/firebase";
+
+const TARGET_TENANTS = [
+  { id: "c43992df00d07acae140ba76", label: "test2" },
+  { id: "6b8df37863a292ead2a07401", label: "test1" },
+  { id: "b815152e3fbaf302897f6ce4", label: "bob" },
+  { id: "bcea70bf3f353746c8895bc9", label: "Unnamed Tenant" },
+  { id: "ff45a28cdfad7737958592de", label: "Unnamed Tenant" },
+];
+
+async function main() {
+  const report = {
+    generatedAt: new Date().toISOString(),
+    cleanupBatch: "tenant_record_cleanup_profile_actions_v1",
+    hiddenCount: 0,
+    missingCount: 0,
+    tenants: [] as Array<Record<string, unknown>>,
+  };
+
+  for (const target of TARGET_TENANTS) {
+    const ref = db.collection("tenants").doc(target.id);
+    const snap = await ref.get();
+    if (!snap.exists) {
+      report.missingCount += 1;
+      report.tenants.push({
+        id: target.id,
+        label: target.label,
+        status: "missing",
+      });
+      continue;
+    }
+
+    await ref.set(
+      {
+        hiddenFromActiveLists: true,
+        cleanupReason: "identified_test_tenant",
+        cleanupBatch: "tenant_record_cleanup_profile_actions_v1",
+        cleanupAppliedAt: FieldValue.serverTimestamp(),
+      },
+      { merge: true }
+    );
+
+    report.hiddenCount += 1;
+    report.tenants.push({
+      id: target.id,
+      label: target.label,
+      status: "hidden",
+    });
+  }
+
+  console.log(JSON.stringify(report, null, 2));
+}
+
+main().catch((error) => {
+  console.error("[hideListedTestTenants] fatal", error);
+  process.exitCode = 1;
+});

--- a/rentchain-api/src/routes/__tests__/tenantEventsWriteRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantEventsWriteRoutes.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const tenantDocs = new Map<string, any>();
+const createdEvents: any[] = [];
+
+vi.mock("../../config/firebase", () => ({
+  Timestamp: {
+    fromMillis: (value: number) => ({ toMillis: () => value }),
+    fromDate: (value: Date) => ({ toMillis: () => value.getTime() }),
+  },
+  db: {
+    collection: (name: string) => {
+      if (name === "tenants") {
+        return {
+          doc: (id: string) => ({
+            get: async () => ({
+              exists: tenantDocs.has(id),
+              data: () => tenantDocs.get(id),
+            }),
+          }),
+        };
+      }
+      if (name === "tenantEvents") {
+        return {
+          add: async (payload: any) => {
+            createdEvents.push(payload);
+            return { id: `event-${createdEvents.length}` };
+          },
+          where: () => ({
+            where: () => ({
+              orderBy: () => ({
+                limit: () => ({
+                  get: async () => ({ docs: [] }),
+                }),
+              }),
+            }),
+          }),
+        };
+      }
+      if (name === "tenantSummaries") {
+        return {
+          doc: () => ({
+            set: async () => undefined,
+          }),
+        };
+      }
+      throw new Error(`Unexpected collection: ${name}`);
+    },
+  },
+  FieldValue: {
+    serverTimestamp: () => "__server_timestamp__",
+  },
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, _res: any, next: any) => {
+    req.user = { id: "landlord-1", landlordId: "landlord-1", role: "landlord" };
+    next();
+  },
+}));
+
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (_req: any, _res: any, next: any) => next(),
+}));
+
+async function invokeRouter(router: any, options: {
+  method: string;
+  url: string;
+  body?: any;
+}) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path: options.url,
+      body: options.body ?? {},
+      headers: {},
+      query: {},
+      params: {},
+    };
+    const res: any = {
+      statusCode: 200,
+      setHeader: () => undefined,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("tenantEventsWriteRoutes", () => {
+  beforeEach(() => {
+    tenantDocs.clear();
+    createdEvents.length = 0;
+    tenantDocs.set("tenant-1", {
+      landlordId: "landlord-1",
+      fullName: "Taylor Tenant",
+    });
+  });
+
+  it("accepts NOTE_ADDED as an audited tenant event", async () => {
+    const router = (await import("../tenantEventsWriteRoutes")).default;
+    const result = await invokeRouter(router, {
+      method: "POST",
+      url: "/tenant-events",
+      body: {
+        tenantId: "tenant-1",
+        type: "NOTE_ADDED",
+        description: "Called tenant to confirm contact details.",
+      },
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.body?.ok).toBe(true);
+    expect(createdEvents[0]?.type).toBe("NOTE_ADDED");
+    expect(createdEvents[0]?.severity).toBe("neutral");
+    expect(createdEvents[0]?.title).toBe("Note added");
+  });
+});

--- a/rentchain-api/src/routes/__tests__/tenantsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantsRoutes.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const setMock = vi.fn(async () => undefined);
+const getTenantDetailBundleMock = vi.fn();
+const getTenantsListMock = vi.fn();
+
+vi.mock("../../config/firebase", () => ({
+  db: {
+    collection: () => ({
+      doc: () => ({
+        set: setMock,
+      }),
+    }),
+  },
+  FieldValue: {
+    serverTimestamp: () => "__server_timestamp__",
+  },
+}));
+
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: any, _res: any, next: any) => {
+    req.user = { id: "landlord-1", landlordId: "landlord-1", role: "landlord" };
+    next();
+  },
+}));
+
+vi.mock("../../services/tenantDetailsService", () => ({
+  getTenantDetailBundle: getTenantDetailBundleMock,
+  getTenantsList: getTenantsListMock,
+}));
+
+vi.mock("../../services/tenantLedgerService", () => ({
+  getTenantLedger: vi.fn(async () => []),
+}));
+
+vi.mock("../../services/tenantReportService", () => ({
+  generateTenantReportPdfBuffer: vi.fn(async () => Buffer.from("pdf")),
+}));
+
+vi.mock("../../services/tenanciesService", () => ({
+  listTenanciesByTenantId: vi.fn(async () => []),
+}));
+
+vi.mock("../../services/tenantMoveInReadinessService", () => ({
+  updateMoveInReadinessItems: vi.fn(async () => undefined),
+}));
+
+vi.mock("../../services/capabilityGuard", () => ({
+  requireCapability: vi.fn(async () => ({ ok: true })),
+}));
+
+async function invokeRouter(router: any, options: {
+  method: string;
+  url: string;
+  body?: any;
+}) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path: options.url,
+      body: options.body ?? {},
+      headers: {},
+      query: {},
+      params: { tenantId: "tenant-1" },
+    };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("tenantsRoutes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    setMock.mockClear();
+    getTenantDetailBundleMock.mockReset();
+    getTenantsListMock.mockReset();
+  });
+
+  it("filters hidden tenants from the landlord list route", async () => {
+    getTenantsListMock.mockResolvedValue([]);
+    const router = (await import("../tenantsRoutes")).default;
+
+    const result = await invokeRouter(router, {
+      method: "GET",
+      url: "/",
+    });
+
+    expect(result.status).toBe(200);
+    expect(getTenantsListMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        landlordId: "landlord-1",
+        excludeHiddenFromActiveLists: true,
+      })
+    );
+  });
+
+  it("updates only basic tenant profile fields", async () => {
+    getTenantDetailBundleMock
+      .mockResolvedValueOnce({ tenant: { id: "tenant-1", fullName: "Before" } })
+      .mockResolvedValueOnce({
+        tenant: {
+          id: "tenant-1",
+          fullName: "Taylor Tenant",
+          email: "tenant@example.com",
+          phone: "9025550100",
+        },
+      });
+
+    const router = (await import("../tenantsRoutes")).default;
+    const result = await invokeRouter(router, {
+      method: "PATCH",
+      url: "/tenant-1",
+      body: {
+        fullName: "Taylor Tenant",
+        email: "Tenant@Example.com",
+        phone: "9025550100",
+      },
+    });
+
+    expect(result.status).toBe(200);
+    expect(setMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fullName: "Taylor Tenant",
+        email: "tenant@example.com",
+        phone: "9025550100",
+      }),
+      { merge: true }
+    );
+    expect(result.body?.tenant?.fullName).toBe("Taylor Tenant");
+  });
+});

--- a/rentchain-api/src/routes/tenantEventsWriteRoutes.ts
+++ b/rentchain-api/src/routes/tenantEventsWriteRoutes.ts
@@ -11,7 +11,8 @@ type EventType =
   | "RENT_PAID"
   | "RENT_LATE"
   | "NOTICE_SERVED"
-  | "LEASE_ENDED";
+  | "LEASE_ENDED"
+  | "NOTE_ADDED";
 
 type Severity = "positive" | "neutral" | "negative";
 type RiskTier = "low" | "medium" | "high" | "neutral";
@@ -23,6 +24,7 @@ const ALLOWED_TYPES: EventType[] = [
   "RENT_LATE",
   "NOTICE_SERVED",
   "LEASE_ENDED",
+  "NOTE_ADDED",
 ];
 
 function inferSeverity(type: EventType): Severity {
@@ -34,6 +36,7 @@ function inferSeverity(type: EventType): Severity {
     case "NOTICE_SERVED":
       return "negative";
     case "LEASE_ENDED":
+    case "NOTE_ADDED":
     default:
       return "neutral";
   }
@@ -51,6 +54,8 @@ function defaultTitle(type: EventType): string {
       return "Notice served";
     case "LEASE_ENDED":
       return "Lease ended";
+    case "NOTE_ADDED":
+      return "Note added";
     default:
       return "Tenant event";
   }

--- a/rentchain-api/src/routes/tenantsRoutes.ts
+++ b/rentchain-api/src/routes/tenantsRoutes.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import { db, FieldValue } from "../config/firebase";
 import { requireLandlord } from "../middleware/requireLandlord";
 import {
   getTenantDetailBundle,
@@ -30,13 +31,77 @@ router.get("/", async (req: any, res) => {
   const landlordId = getLandlordId(req);
 
   try {
-    const tenants = await getTenantsList({ landlordId: landlordId || undefined });
+    const tenants = await getTenantsList({
+      landlordId: landlordId || undefined,
+      excludeHiddenFromActiveLists: true,
+    });
     return res.status(200).json({ ok: true, tenants });
   } catch (err: any) {
     console.error("[GET /api/tenants] error:", err);
     return res.status(500).json({
       ok: false,
       error: err?.message ?? "Failed to load tenants",
+    });
+  }
+});
+
+router.patch("/:tenantId", async (req: any, res) => {
+  const landlordId = getLandlordId(req);
+  const tenantId = String(req.params?.tenantId || "").trim();
+  if (!tenantId) return res.status(400).json({ ok: false, error: "tenantId is required" });
+
+  const fullNameInput = req.body?.fullName;
+  const emailInput = req.body?.email;
+  const phoneInput = req.body?.phone;
+  const hasSupportedField =
+    fullNameInput !== undefined || emailInput !== undefined || phoneInput !== undefined;
+  if (!hasSupportedField) {
+    return res.status(400).json({ ok: false, error: "No supported tenant profile fields provided" });
+  }
+
+  const updates: Record<string, unknown> = {
+    updatedAt: FieldValue.serverTimestamp(),
+  };
+
+  if (fullNameInput !== undefined) {
+    const fullName = String(fullNameInput || "").trim();
+    if (!fullName) {
+      return res.status(400).json({ ok: false, error: "fullName is required" });
+    }
+    updates.fullName = fullName.slice(0, 160);
+  }
+
+  if (emailInput !== undefined) {
+    const email = String(emailInput || "").trim().toLowerCase();
+    if (email && !email.includes("@")) {
+      return res.status(400).json({ ok: false, error: "email must be valid" });
+    }
+    updates.email = email || null;
+  }
+
+  if (phoneInput !== undefined) {
+    const phone = String(phoneInput || "").trim();
+    updates.phone = phone || null;
+  }
+
+  try {
+    const bundle = await getTenantDetailBundle(tenantId, { landlordId: landlordId || undefined });
+    if (!bundle?.tenant) {
+      return res.status(404).json({ ok: false, error: "Tenant not found" });
+    }
+
+    await db.collection("tenants").doc(tenantId).set(updates, { merge: true });
+    const refreshed = await getTenantDetailBundle(tenantId, { landlordId: landlordId || undefined });
+
+    return res.status(200).json({
+      ok: true,
+      tenant: refreshed?.tenant ?? bundle.tenant,
+    });
+  } catch (err: any) {
+    console.error("[PATCH /api/tenants/:tenantId] error:", err);
+    return res.status(500).json({
+      ok: false,
+      error: err?.message ?? "Failed to update tenant",
     });
   }
 });

--- a/rentchain-api/src/services/__tests__/tenantDetailsService.test.ts
+++ b/rentchain-api/src/services/__tests__/tenantDetailsService.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const tenantDocs = new Map<string, any>();
+
+vi.mock("../../config/firebase", () => ({
+  db: {
+    collection: (name: string) => {
+      if (name !== "tenants") {
+        return {
+          doc: () => ({
+            get: async () => ({ exists: false, data: () => null }),
+          }),
+          where: () => ({
+            get: async () => ({ docs: [] }),
+          }),
+          get: async () => ({ docs: [] }),
+        };
+      }
+      return {
+        where: (field: string, _op: string, value: string) => ({
+          get: async () => ({
+            forEach: (callback: (doc: any) => void) => {
+              for (const [id, data] of tenantDocs.entries()) {
+                if (data?.[field] === value) {
+                  callback({ id, data: () => data });
+                }
+              }
+            },
+          }),
+        }),
+        get: async () => ({
+          forEach: (callback: (doc: any) => void) => {
+            for (const [id, data] of tenantDocs.entries()) {
+              callback({ id, data: () => data });
+            }
+          },
+        }),
+      };
+    },
+  },
+}));
+
+vi.mock("../leaseNoticeWorkflowService", () => ({
+  computeNoResponseState: vi.fn(),
+  getLeaseNoticeByLeaseId: vi.fn(),
+}));
+
+vi.mock("../leaseCanonicalizationService", () => ({
+  loadUnitsForProperty: vi.fn(async () => []),
+  resolveUnitReference: vi.fn(() => null),
+  toCanonicalLeaseRecord: vi.fn(() => null),
+  isCurrentLeaseStatus: vi.fn(() => false),
+}));
+
+vi.mock("../leasePartyConsolidationService", () => ({
+  groupLeaseAgreementCandidates: vi.fn(() => []),
+  pickAgreementWinner: vi.fn(() => null),
+  pickTenantWinningAgreement: vi.fn(() => null),
+}));
+
+vi.mock("../risk/credibilityInsights", () => ({
+  buildCredibilityInsights: vi.fn(() => null),
+}));
+
+vi.mock("../moveInRequirements", () => ({
+  buildMoveInRequirements: vi.fn(() => null),
+}));
+
+vi.mock("../tenantMoveInReadinessService", () => ({
+  buildMoveInReadinessRecord: vi.fn(() => null),
+  getPersistedMoveInReadinessRecord: vi.fn(async () => null),
+  listMoveInReadinessEvents: vi.fn(async () => []),
+}));
+
+vi.mock("../tenanciesService", () => ({
+  buildDerivedTenancyFromTenant: vi.fn(() => null),
+  listTenanciesByTenantId: vi.fn(async () => []),
+}));
+
+describe("getTenantsList", () => {
+  beforeEach(() => {
+    tenantDocs.clear();
+    tenantDocs.set("tenant-visible", {
+      landlordId: "landlord-1",
+      fullName: "Visible Tenant",
+      createdAt: "2026-01-02T00:00:00.000Z",
+    });
+    tenantDocs.set("tenant-hidden", {
+      landlordId: "landlord-1",
+      fullName: "Hidden Tenant",
+      hiddenFromActiveLists: true,
+      createdAt: "2026-01-03T00:00:00.000Z",
+    });
+  });
+
+  it("excludes hidden tenants from landlord active lists when requested", async () => {
+    const { getTenantsList } = await import("../tenantDetailsService");
+    const tenants = await getTenantsList({
+      landlordId: "landlord-1",
+      excludeHiddenFromActiveLists: true,
+    });
+
+    expect(tenants.map((tenant) => tenant.id)).toEqual(["tenant-visible"]);
+  });
+
+  it("preserves hidden tenants when explicit filtering is not requested", async () => {
+    const { getTenantsList } = await import("../tenantDetailsService");
+    const tenants = await getTenantsList({
+      landlordId: "landlord-1",
+    });
+
+    expect(tenants.map((tenant) => tenant.id)).toEqual([
+      "tenant-hidden",
+      "tenant-visible",
+    ]);
+  });
+});

--- a/rentchain-api/src/services/tenantDetailsService.ts
+++ b/rentchain-api/src/services/tenantDetailsService.ts
@@ -33,6 +33,9 @@ export interface TenantRecord {
   fullName: string;
   email?: string;
   phone?: string;
+  hiddenFromActiveLists?: boolean;
+  cleanupReason?: string | null;
+  cleanupBatch?: string | null;
   propertyId?: string | null;
   unitId?: string | null;
   propertyName?: string;
@@ -140,6 +143,7 @@ const CONVERTED_TENANTS: TenantRecord[] = [];
 
 type TenantQueryOptions = {
   landlordId?: string | null;
+  excludeHiddenFromActiveLists?: boolean;
 };
 
 function toMillis(value: any): number | null {
@@ -195,6 +199,9 @@ function mapTenant(docId: string, data: any): TenantRecord {
     fullName: data.fullName ?? data.name ?? "Unnamed Tenant",
     email: data.email ?? null,
     phone: data.phone ?? null,
+    hiddenFromActiveLists: data.hiddenFromActiveLists === true,
+    cleanupReason: data.cleanupReason ?? null,
+    cleanupBatch: data.cleanupBatch ?? null,
     propertyId: data.propertyId ?? null,
     unitId: data.unitId ?? data.unit ?? null,
     propertyName: data.propertyName ?? data.property ?? null,
@@ -418,6 +425,7 @@ export function addConvertedTenant(tenant: TenantRecord): void {
 
 export async function getTenantsList(opts: TenantQueryOptions = {}): Promise<TenantRecord[]> {
   const landlordId = opts.landlordId?.trim?.() ? String(opts.landlordId).trim() : null;
+  const excludeHiddenFromActiveLists = opts.excludeHiddenFromActiveLists === true;
 
   try {
     const collection = db.collection("tenants");
@@ -428,7 +436,9 @@ export async function getTenantsList(opts: TenantQueryOptions = {}): Promise<Ten
     const out: TenantRecord[] = [];
     snap.forEach((doc) => {
       const data = doc.data() as any;
-      out.push(mapTenant(doc.id, data));
+      const tenant = mapTenant(doc.id, data);
+      if (excludeHiddenFromActiveLists && tenant.hiddenFromActiveLists) return;
+      out.push(tenant);
     });
 
     out.sort((a, b) => {

--- a/rentchain-frontend/src/api/tenantEventsWriteApi.ts
+++ b/rentchain-frontend/src/api/tenantEventsWriteApi.ts
@@ -2,6 +2,7 @@ import { apiFetch } from "./http";
 import { getAuthToken } from "../lib/authToken";
 
 export type TenantEventType =
+  | "NOTE_ADDED"
   | "LEASE_STARTED"
   | "RENT_PAID"
   | "RENT_LATE"
@@ -32,6 +33,8 @@ export async function createTenantEvent(input: CreateTenantEventInput) {
 
   const defaultTitleFromType = (type: string): string => {
     switch (type) {
+      case "NOTE_ADDED":
+        return "Note added";
       case "RENT_PAID":
       case "PAYMENT_RECORDED":
         return "Payment recorded";

--- a/rentchain-frontend/src/api/tenantsApi.ts
+++ b/rentchain-frontend/src/api/tenantsApi.ts
@@ -1,5 +1,17 @@
 import { apiJson, getAuthToken, resolveApiUrl } from "@/lib/apiClient";
 import { getFirebaseIdToken } from "@/lib/firebaseAuthToken";
+import { apiFetch } from "./http";
+
+type TenantListResponse = TenantApiModel[] | { tenants?: TenantApiModel[] };
+type TenanciesResponse = TenancyApiModel[] | { tenancies?: TenancyApiModel[] };
+type UpdateTenancyResponse = TenancyApiModel | { tenancy?: TenancyApiModel };
+type UpdateTenantResponse = TenantApiModel | { tenant?: TenantApiModel };
+type ApiErrorShape = Error & { payload?: unknown; status?: number };
+
+function extractErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error || "");
+}
 
 export type TenancyMoveOutReason =
   | "LEASE_TERM_END"
@@ -24,10 +36,17 @@ export interface TenantApiModel {
   id: string;
   name?: string;
   fullName?: string;
+  email?: string | null;
+  phone?: string | null;
   unit?: string;
+  unitId?: string | null;
+  unitLabel?: string | null;
   propertyName?: string;
+  propertyId?: string | null;
+  currentLeaseId?: string | null;
   status?: string;
   balance?: number;
+  hiddenFromActiveLists?: boolean;
   tenancies?: TenancyApiModel[];
 }
 
@@ -36,12 +55,12 @@ export interface TenantApiModel {
  */
 export async function fetchTenants(): Promise<TenantApiModel[]> {
   try {
-    const data = await apiJson<any>("/tenants");
+    const data = await apiJson<TenantListResponse>("/tenants");
     if (Array.isArray(data)) return data as TenantApiModel[];
     if (Array.isArray(data?.tenants)) return data.tenants as TenantApiModel[];
     return [];
-  } catch (err: any) {
-    const msg = String(err?.message || "");
+  } catch (err: unknown) {
+    const msg = extractErrorMessage(err);
     if (msg.includes("404")) {
       return [];
     }
@@ -73,16 +92,20 @@ export async function downloadTenantReport(tenantId: string): Promise<{ filename
 
   const contentType = response.headers.get("content-type") || "";
   if (!response.ok) {
-    const payload = contentType.includes("application/json")
+    const payload: unknown = contentType.includes("application/json")
       ? await response.json().catch(() => null)
       : await response.text().catch(() => "");
+    const payloadRecord =
+      payload && typeof payload === "object" ? (payload as Record<string, unknown>) : null;
     const message =
-      (payload && (payload.message || payload.error || payload.code)) ||
+      payloadRecord?.message ||
+      payloadRecord?.error ||
+      payloadRecord?.code ||
       (typeof payload === "string" ? payload : "") ||
       `Tenant report download failed (${response.status})`;
-    const err = new Error(String(message));
-    (err as any).payload = payload;
-    (err as any).status = response.status;
+    const err: ApiErrorShape = new Error(String(message));
+    err.payload = payload;
+    err.status = response.status;
     throw err;
   }
 
@@ -95,7 +118,7 @@ export async function downloadTenantReport(tenantId: string): Promise<{ filename
 }
 
 export async function fetchTenantTenancies(tenantId: string): Promise<TenancyApiModel[]> {
-  const data = await apiJson<any>(`/tenants/${encodeURIComponent(tenantId)}/tenancies`);
+  const data = await apiJson<TenanciesResponse>(`/tenants/${encodeURIComponent(tenantId)}/tenancies`);
   if (Array.isArray(data)) return data as TenancyApiModel[];
   if (Array.isArray(data?.tenancies)) return data.tenancies as TenancyApiModel[];
   return [];
@@ -111,12 +134,28 @@ export async function updateTenancy(
     status: "active" | "inactive";
   }>
 ): Promise<TenancyApiModel> {
-  const data = await apiJson<any>(`/tenancies/${encodeURIComponent(tenancyId)}`, {
+  const data = await apiJson<UpdateTenancyResponse>(`/tenancies/${encodeURIComponent(tenancyId)}`, {
     method: "PATCH",
     body: JSON.stringify(payload),
   });
   if (data?.tenancy) return data.tenancy as TenancyApiModel;
   return data as TenancyApiModel;
+}
+
+export async function updateTenantRecord(
+  tenantId: string,
+  payload: Partial<{
+    fullName: string;
+    email: string | null;
+    phone: string | null;
+  }>
+): Promise<TenantApiModel> {
+  const data = await apiJson<UpdateTenantResponse>(`/tenants/${encodeURIComponent(tenantId)}`, {
+    method: "PATCH",
+    body: JSON.stringify(payload),
+  });
+  if (data?.tenant) return data.tenant as TenantApiModel;
+  return data as TenantApiModel;
 }
 
 export async function impersonateTenant(tenantId: string): Promise<{ ok: boolean; token: string; tenantId: string; exp?: number }> {

--- a/rentchain-frontend/src/components/tenants/InviteTenantModal.tsx
+++ b/rentchain-frontend/src/components/tenants/InviteTenantModal.tsx
@@ -14,10 +14,39 @@ import { Button } from "../ui/Ui";
 interface Props {
   open: boolean;
   onClose: () => void;
-  onInviteCreated?: (payload: any) => void;
+  onInviteCreated?: (payload: unknown) => void;
   defaultPropertyId?: string;
   defaultUnitId?: string;
   defaultLeaseId?: string;
+  defaultTenantEmail?: string;
+  defaultTenantName?: string;
+}
+
+type PropertyOption = { id: string; name: string };
+type UnitOption = {
+  id: string;
+  label: string;
+  inviteEligible: boolean;
+  inviteEligibilityReason?: string | null;
+};
+type InviteResponse = {
+  ok?: boolean;
+  inviteUrl?: string;
+  invite?: { inviteUrl?: string };
+  emailed?: boolean;
+  emailError?: string;
+  error?: string;
+  capability?: string;
+  plan?: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object";
+}
+
+function extractErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error || "");
 }
 
 export const InviteTenantModal: React.FC<Props> = ({
@@ -26,6 +55,8 @@ export const InviteTenantModal: React.FC<Props> = ({
   onInviteCreated,
   defaultPropertyId,
   defaultUnitId,
+  defaultTenantEmail,
+  defaultTenantName,
 }) => {
   const [tenantEmail, setTenantEmail] = useState("");
   const [tenantName, setTenantName] = useState("");
@@ -34,10 +65,8 @@ export const InviteTenantModal: React.FC<Props> = ({
   const [successMsg, setSuccessMsg] = useState("");
   const [infoMsg, setInfoMsg] = useState("");
   const [loading, setLoading] = useState(false);
-  const [properties, setProperties] = useState<Array<{ id: string; name: string }>>([]);
-  const [units, setUnits] = useState<
-    Array<{ id: string; label: string; inviteEligible: boolean; inviteEligibilityReason?: string | null }>
-  >([]);
+  const [properties, setProperties] = useState<PropertyOption[]>([]);
+  const [units, setUnits] = useState<UnitOption[]>([]);
   const [propertyId, setPropertyId] = useState(defaultPropertyId || "");
   const [unitId, setUnitId] = useState(defaultUnitId || "");
   const [loadingProperties, setLoadingProperties] = useState(false);
@@ -84,27 +113,43 @@ export const InviteTenantModal: React.FC<Props> = ({
 
   React.useEffect(() => {
     if (!open) return;
+    setTenantEmail(String(defaultTenantEmail || ""));
+    setTenantName(String(defaultTenantName || ""));
+    setPropertyId(String(defaultPropertyId || ""));
+    setUnitId(String(defaultUnitId || ""));
+    setInviteUrl("");
+    setErr("");
+    setSuccessMsg("");
+    setInfoMsg("");
+  }, [open, defaultPropertyId, defaultTenantEmail, defaultTenantName, defaultUnitId]);
+
+  React.useEffect(() => {
+    if (!open) return;
     let mounted = true;
     (async () => {
       setLoadingProperties(true);
       try {
-        const res: any = await fetchProperties();
+        const res = await fetchProperties();
         if (!mounted) return;
-        const list = Array.isArray(res?.properties)
-          ? res.properties
-          : Array.isArray(res?.items)
-          ? res.items
+        const record = isRecord(res) ? res : null;
+        const list = Array.isArray(record?.properties)
+          ? record.properties
+          : Array.isArray(record?.items)
+          ? record.items
           : Array.isArray(res)
           ? res
           : [];
         const normalized = list
-          .map((p: any) => ({
-            id: String(p?.id || p?.propertyId || "").trim(),
-            name: String(p?.name || p?.addressLine1 || p?.id || "Property"),
-          }))
-          .filter((p: any) => Boolean(p.id));
+          .map((property) => {
+            const row = isRecord(property) ? property : null;
+            return {
+              id: String(row?.id || row?.propertyId || "").trim(),
+              name: String(row?.name || row?.addressLine1 || row?.id || "Property"),
+            };
+          })
+          .filter((property) => Boolean(property.id));
         setProperties(normalized);
-        if (!propertyId && normalized.length > 0) {
+        if (!String(defaultPropertyId || "").trim() && !propertyId && normalized.length > 0) {
           setPropertyId(String(defaultPropertyId || normalized[0].id));
         }
       } catch {
@@ -116,7 +161,7 @@ export const InviteTenantModal: React.FC<Props> = ({
     return () => {
       mounted = false;
     };
-  }, [open, defaultPropertyId]);
+  }, [open, defaultPropertyId, propertyId]);
 
   React.useEffect(() => {
     if (!open || !propertyId) {
@@ -131,19 +176,22 @@ export const InviteTenantModal: React.FC<Props> = ({
         const res = await fetchUnitsForProperty(propertyId);
         if (!mounted) return;
         const mapped = (res || [])
-          .map((u: any) => ({
-            id: String(u?.id || u?.unitId || "").trim(),
-            label: String(u?.unitNumber || u?.label || u?.name || "Unit"),
-            inviteEligible: u?.inviteEligible !== false,
+          .map((unit) => {
+            const row = isRecord(unit) ? unit : null;
+            return {
+            id: String(row?.id || row?.unitId || "").trim(),
+            label: String(row?.unitNumber || row?.label || row?.name || "Unit"),
+            inviteEligible: row?.inviteEligible !== false,
             inviteEligibilityReason:
-              u?.inviteEligibilityReason != null ? String(u.inviteEligibilityReason) : null,
-          }))
-          .filter((u: any) => Boolean(u.id));
+              row?.inviteEligibilityReason != null ? String(row.inviteEligibilityReason) : null,
+          };
+          })
+          .filter((unit) => Boolean(unit.id));
         setUnits(mapped);
-        if (defaultUnitId && mapped.some((u: any) => u.id === defaultUnitId)) {
+        if (defaultUnitId && mapped.some((unit) => unit.id === defaultUnitId)) {
           setUnitId(defaultUnitId);
         } else {
-          setUnitId((prev) => (mapped.some((u: any) => u.id === prev) ? prev : ""));
+          setUnitId((prev) => (mapped.some((unit) => unit.id === prev) ? prev : ""));
         }
       } catch {
         if (mounted) setUnits([]);
@@ -188,12 +236,12 @@ export const InviteTenantModal: React.FC<Props> = ({
         setErr("Please enter a valid tenant email.");
         return;
       }
-      const data: any = await createTenantInvite({
+      const data = (await createTenantInvite({
         tenantEmail: normalizedEmail,
         tenantName: tenantName || undefined,
         propertyId,
         unitId,
-      });
+      })) as InviteResponse;
 
       if (!data?.ok) {
         const errorCode = String(data?.error || "").trim().toLowerCase();
@@ -243,10 +291,13 @@ export const InviteTenantModal: React.FC<Props> = ({
       });
       await setOnboardingStep("tenantInvited", true).catch(() => {});
       onInviteCreated?.(data);
-    } catch (e: any) {
+    } catch (e: unknown) {
+      const errorRecord = isRecord(e) ? e : null;
+      const responseRecord = isRecord(errorRecord?.response) ? errorRecord.response : null;
+      const dataRecord = isRecord(responseRecord?.data) ? responseRecord.data : null;
       const respDetail =
-        (e as any)?.response?.data?.detail || (e as any)?.response?.data?.error;
-      const msg = String(respDetail || e?.message || "Failed to send invite");
+        dataRecord?.detail || dataRecord?.error;
+      const msg = String(respDetail || extractErrorMessage(e) || "Failed to send invite");
       console.debug("[invite-tenant] request error", {
         message: msg,
         raw: e,

--- a/rentchain-frontend/src/pages/TenantsPage.test.tsx
+++ b/rentchain-frontend/src/pages/TenantsPage.test.tsx
@@ -1,7 +1,22 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TenantsPage } from "./TenantsPage";
+
+type ResponsiveMasterDetailProps = {
+  master: ReactNode;
+  detail: ReactNode;
+  searchSlot?: ReactNode;
+};
+
+type InviteTenantModalProps = {
+  open: boolean;
+  defaultTenantEmail?: string;
+  defaultTenantName?: string;
+  defaultPropertyId?: string;
+  defaultUnitId?: string;
+};
 
 const mocks = vi.hoisted(() => ({
   useAuthMock: vi.fn(),
@@ -9,11 +24,14 @@ const mocks = vi.hoisted(() => ({
   useCapabilitiesMock: vi.fn(),
   fetchTenantsMock: vi.fn(),
   fetchTenantTenanciesMock: vi.fn(),
+  updateTenantRecordMock: vi.fn(),
   updateTenancyMock: vi.fn(),
+  createTenantEventMock: vi.fn(),
   hydrateTenantSummariesBatchMock: vi.fn(),
   getCachedTenantSummaryMock: vi.fn(),
   openUpgradeFlowMock: vi.fn(),
   trackMock: vi.fn(),
+  inviteTenantModalMock: vi.fn(),
 }));
 
 vi.mock("../context/useAuth", () => ({
@@ -31,7 +49,12 @@ vi.mock("@/hooks/useCapabilities", () => ({
 vi.mock("@/api/tenantsApi", () => ({
   fetchTenants: mocks.fetchTenantsMock,
   fetchTenantTenancies: mocks.fetchTenantTenanciesMock,
+  updateTenantRecord: mocks.updateTenantRecordMock,
   updateTenancy: mocks.updateTenancyMock,
+}));
+
+vi.mock("@/api/tenantEventsWriteApi", () => ({
+  createTenantEvent: mocks.createTenantEventMock,
 }));
 
 vi.mock("../components/tenants/TenantDetailPanel", () => ({
@@ -47,7 +70,7 @@ vi.mock("../components/tenants/TenantPaymentsPanel", () => ({
 }));
 
 vi.mock("../components/layout/ResponsiveMasterDetail", () => ({
-  ResponsiveMasterDetail: ({ master, detail, searchSlot }: any) => (
+  ResponsiveMasterDetail: ({ master, detail, searchSlot }: ResponsiveMasterDetailProps) => (
     <div>
       {searchSlot}
       {master}
@@ -57,7 +80,10 @@ vi.mock("../components/layout/ResponsiveMasterDetail", () => ({
 }));
 
 vi.mock("../components/tenants/InviteTenantModal", () => ({
-  InviteTenantModal: () => null,
+  InviteTenantModal: (props: InviteTenantModalProps) => {
+    mocks.inviteTenantModalMock(props);
+    return props.open ? <div>Invite modal open</div> : null;
+  },
 }));
 
 vi.mock("../components/tenant/TenantScorePill", () => ({
@@ -78,6 +104,10 @@ vi.mock("@/billing/openUpgradeFlow", () => ({
 }));
 
 describe("TenantsPage", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   beforeEach(() => {
     mocks.useAuthMock.mockReturnValue({
       user: { id: "user-1", role: "landlord" },
@@ -91,11 +121,14 @@ describe("TenantsPage", () => {
     });
     mocks.fetchTenantsMock.mockResolvedValue([]);
     mocks.fetchTenantTenanciesMock.mockResolvedValue([]);
+    mocks.updateTenantRecordMock.mockResolvedValue({});
     mocks.updateTenancyMock.mockResolvedValue({});
+    mocks.createTenantEventMock.mockResolvedValue({ ok: true });
     mocks.hydrateTenantSummariesBatchMock.mockResolvedValue(undefined);
     mocks.getCachedTenantSummaryMock.mockReturnValue(null);
     mocks.openUpgradeFlowMock.mockResolvedValue(true);
     mocks.trackMock.mockReset();
+    mocks.inviteTenantModalMock.mockReset();
   });
 
   it("uses the working upgrade flow for locked tenant invites", async () => {
@@ -110,5 +143,149 @@ describe("TenantsPage", () => {
     expect(mocks.openUpgradeFlowMock).toHaveBeenCalledWith(
       expect.objectContaining({ fallbackPath: "/pricing" })
     );
+  });
+
+  it("shows a tenant action hub with edit, note, and invite actions", async () => {
+    mocks.useCapabilitiesMock.mockReturnValue({
+      features: { tenant_invites: true },
+    });
+    mocks.fetchTenantsMock.mockResolvedValue([
+      {
+        id: "tenant-1",
+        fullName: "Taylor Tenant",
+        email: "tenant@example.com",
+        propertyName: "Main Street",
+        propertyId: "property-1",
+        unit: "Unit 4",
+        unitId: "unit-4",
+        currentLeaseId: "lease-1",
+      },
+    ]);
+    mocks.fetchTenantTenanciesMock.mockResolvedValue([
+      { id: "tenancy-1", tenantId: "tenant-1", status: "active", unitLabel: "Unit 4" },
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={["/tenants?tenantId=tenant-1"]}>
+        <TenantsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Tenant actions")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Edit tenant" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add note" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Send tenant invite" })).toBeInTheDocument();
+    expect(screen.getByText("lease-1")).toBeInTheDocument();
+  });
+
+  it("prefills the invite modal from the selected tenant profile", async () => {
+    mocks.useCapabilitiesMock.mockReturnValue({
+      features: { tenant_invites: true },
+    });
+    mocks.fetchTenantsMock.mockResolvedValue([
+      {
+        id: "tenant-1",
+        fullName: "Taylor Tenant",
+        email: "tenant@example.com",
+        propertyId: "property-1",
+        unitId: "unit-4",
+      },
+    ]);
+    mocks.fetchTenantTenanciesMock.mockResolvedValue([]);
+
+    render(
+      <MemoryRouter initialEntries={["/tenants?tenantId=tenant-1"]}>
+        <TenantsPage />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Send tenant invite" }));
+
+    expect(await screen.findByText("Invite modal open")).toBeInTheDocument();
+    const lastInviteCall = mocks.inviteTenantModalMock.mock.calls.at(-1)?.[0];
+    expect(lastInviteCall).toEqual(
+      expect.objectContaining({
+        defaultTenantEmail: "tenant@example.com",
+        defaultTenantName: "Taylor Tenant",
+        defaultPropertyId: "property-1",
+        defaultUnitId: "unit-4",
+      })
+    );
+  });
+
+  it("saves tenant profile edits through the landlord-safe patch path", async () => {
+    mocks.useCapabilitiesMock.mockReturnValue({
+      features: { tenant_invites: true },
+    });
+    mocks.fetchTenantsMock.mockResolvedValue([
+      {
+        id: "tenant-1",
+        fullName: "Taylor Tenant",
+        email: "tenant@example.com",
+        phone: "9025550000",
+      },
+    ]);
+    mocks.fetchTenantTenanciesMock.mockResolvedValue([]);
+    mocks.updateTenantRecordMock.mockResolvedValue({
+      id: "tenant-1",
+      fullName: "Taylor Tenant Updated",
+      email: "updated@example.com",
+      phone: "9025551111",
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/tenants?tenantId=tenant-1"]}>
+        <TenantsPage />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Edit tenant" }));
+    fireEvent.change(screen.getByLabelText("Full name"), {
+      target: { value: "Taylor Tenant Updated" },
+    });
+    fireEvent.change(screen.getByLabelText("Email"), {
+      target: { value: "updated@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText("Phone"), {
+      target: { value: "(902) 555-1111" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save tenant" }));
+
+    expect(mocks.updateTenantRecordMock).toHaveBeenCalledWith("tenant-1", {
+      fullName: "Taylor Tenant Updated",
+      email: "updated@example.com",
+      phone: "9025551111",
+    });
+  });
+
+  it("records tenant notes through the audited tenant-events path", async () => {
+    mocks.useCapabilitiesMock.mockReturnValue({
+      features: { tenant_invites: true },
+    });
+    mocks.fetchTenantsMock.mockResolvedValue([
+      {
+        id: "tenant-1",
+        fullName: "Taylor Tenant",
+      },
+    ]);
+    mocks.fetchTenantTenanciesMock.mockResolvedValue([]);
+
+    render(
+      <MemoryRouter initialEntries={["/tenants?tenantId=tenant-1"]}>
+        <TenantsPage />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Add note" }));
+    fireEvent.change(screen.getByPlaceholderText("Add a note about contact details, follow-up, or context."), {
+      target: { value: "Confirmed unit details by phone." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save note" }));
+
+    expect(mocks.createTenantEventMock).toHaveBeenCalledWith({
+      tenantId: "tenant-1",
+      type: "NOTE_ADDED",
+      description: "Confirmed unit details by phone.",
+    });
   });
 });

--- a/rentchain-frontend/src/pages/TenantsPage.tsx
+++ b/rentchain-frontend/src/pages/TenantsPage.tsx
@@ -9,8 +9,11 @@ import {
   fetchTenantTenancies,
   fetchTenants,
   type TenancyApiModel,
+  type TenantApiModel,
+  updateTenantRecord,
   updateTenancy,
 } from "@/api/tenantsApi";
+import { createTenantEvent } from "@/api/tenantEventsWriteApi";
 import { spacing, radius, colors, text } from "../styles/tokens";
 import { Card, Section, Input } from "../components/ui/Ui";
 import { ResponsiveMasterDetail } from "../components/layout/ResponsiveMasterDetail";
@@ -22,7 +25,7 @@ import { useCapabilities } from "@/hooks/useCapabilities";
 import { openUpgradeFlow } from "@/billing/openUpgradeFlow";
 import "./TenantsPage.css";
 
-type TenantWithTenancies = any & { tenancies?: TenancyApiModel[] };
+type TenantWithTenancies = TenantApiModel & { tenancies?: TenancyApiModel[] };
 type MoveOutReason = "LEASE_TERM_END" | "EARLY_LEASE_END" | "EVICTED" | "OTHER";
 
 type OccupancyEditorState = {
@@ -35,6 +38,21 @@ type OccupancyEditorState = {
   moveOutReasonNote: string;
 };
 
+type TenantEditState = {
+  open: boolean;
+  tenantId: string | null;
+  fullName: string;
+  email: string;
+  phone: string;
+};
+
+type TenantNoteState = {
+  open: boolean;
+  tenantId: string | null;
+  tenantName: string;
+  note: string;
+};
+
 const EMPTY_EDITOR: OccupancyEditorState = {
   open: false,
   tenantId: null,
@@ -43,6 +61,21 @@ const EMPTY_EDITOR: OccupancyEditorState = {
   moveOutAt: "",
   moveOutReason: "",
   moveOutReasonNote: "",
+};
+
+const EMPTY_TENANT_EDIT: TenantEditState = {
+  open: false,
+  tenantId: null,
+  fullName: "",
+  email: "",
+  phone: "",
+};
+
+const EMPTY_TENANT_NOTE: TenantNoteState = {
+  open: false,
+  tenantId: null,
+  tenantName: "",
+  note: "",
 };
 
 const MOVE_OUT_REASON_LABEL: Record<MoveOutReason, string> = {
@@ -91,6 +124,37 @@ function buildPropertyLink(tenancy: TenancyApiModel): string | null {
     return `/properties?propertyId=${propertyId}&unitId=${encodeURIComponent(String(unitRef))}`;
   }
   return `/properties?propertyId=${propertyId}`;
+}
+
+function normalizePhoneInput(value: string): string {
+  const digits = String(value || "").replace(/\D/g, "").slice(0, 15);
+  return digits;
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message) return error.message;
+  return fallback;
+}
+
+function describeTenantLinkage(tenant: TenantApiModel & { tenancies?: TenancyApiModel[] }) {
+  const tenancies = Array.isArray(tenant.tenancies) ? tenant.tenancies : [];
+  const activeTenancies = tenancies.filter((tenancy) => tenancy.status !== "inactive");
+  const primaryProperty = tenant.propertyName || tenant.propertyId || "No property linked";
+  const primaryUnit = tenant.unit || tenant.unitLabel || tenant.unitId || "No unit linked";
+  const leaseState = tenant.currentLeaseId ? tenant.currentLeaseId : "No current lease linked";
+
+  return {
+    propertyLabel: primaryProperty,
+    unitLabel: primaryUnit,
+    leaseLabel: leaseState,
+    activeTenancyCount: activeTenancies.length,
+    linkageNote:
+      !tenant.propertyId && !tenant.unitId && !tenant.currentLeaseId
+        ? "This tenant record has no canonical property, unit, or current lease linkage yet."
+        : activeTenancies.length === 0
+        ? "No active tenancy registrations are linked to this tenant."
+        : "Tenant profile links remain separate from tenancy and lease lifecycle state.",
+  };
 }
 
 type TenantsErrorBoundaryState = {
@@ -194,6 +258,10 @@ export const TenantsPage: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const [inviteOpen, setInviteOpen] = useState(false);
+  const [tenantEdit, setTenantEdit] = useState<TenantEditState>(EMPTY_TENANT_EDIT);
+  const [tenantNote, setTenantNote] = useState<TenantNoteState>(EMPTY_TENANT_NOTE);
+  const [savingTenantProfile, setSavingTenantProfile] = useState(false);
+  const [savingTenantNote, setSavingTenantNote] = useState(false);
   const [savingTenancyId, setSavingTenancyId] = useState<string | null>(null);
   const [occupancySaveError, setOccupancySaveError] = useState<string | null>(null);
   const [occupancyEditor, setOccupancyEditor] = useState<OccupancyEditorState>(EMPTY_EDITOR);
@@ -243,8 +311,8 @@ export const TenantsPage: React.FC = () => {
         rows.map(async (tenant) => {
           if (!tenant?.id) return { ...tenant, tenancies: [] };
           try {
-            const tenancies = Array.isArray((tenant as any).tenancies)
-              ? ((tenant as any).tenancies as TenancyApiModel[])
+            const tenancies = Array.isArray(tenant.tenancies)
+              ? tenant.tenancies
               : await fetchTenantTenancies(String(tenant.id));
             return { ...tenant, tenancies };
           } catch {
@@ -352,11 +420,12 @@ export const TenantsPage: React.FC = () => {
 
       showToast({ message: "Occupancy updated", variant: "success" });
       closeOccupancyEditor();
-    } catch (err: any) {
-      setOccupancySaveError(err?.message || "Failed to update occupancy.");
+    } catch (err: unknown) {
+      const message = getErrorMessage(err, "Failed to update occupancy.");
+      setOccupancySaveError(message);
       showToast({
         message: "Failed to update occupancy",
-        description: err?.message || "Please try again.",
+        description: message,
         variant: "error",
       });
     } finally {
@@ -368,6 +437,7 @@ export const TenantsPage: React.FC = () => {
     ? tenants.find((t) => t.id === selectedTenantId) || null
     : null;
   const tenantExists = Boolean(selectedTenant);
+  const selectedTenantLinkage = selectedTenant ? describeTenantLinkage(selectedTenant) : null;
 
   const filteredTenants = useMemo(() => {
     const base = tenants || [];
@@ -389,6 +459,98 @@ export const TenantsPage: React.FC = () => {
   useEffect(() => {
     void hydrateTenantSummariesBatch(visibleTenantIds);
   }, [visibleTenantIds]);
+
+  const openTenantEdit = () => {
+    if (!selectedTenant) return;
+    setTenantEdit({
+      open: true,
+      tenantId: String(selectedTenant.id),
+      fullName: String(selectedTenant.fullName || selectedTenant.name || ""),
+      email: String(selectedTenant.email || ""),
+      phone: String(selectedTenant.phone || ""),
+    });
+  };
+
+  const closeTenantEdit = () => setTenantEdit(EMPTY_TENANT_EDIT);
+
+  const openTenantNote = () => {
+    if (!selectedTenant) return;
+    setTenantNote({
+      open: true,
+      tenantId: String(selectedTenant.id),
+      tenantName: String(selectedTenant.fullName || selectedTenant.name || "Tenant"),
+      note: "",
+    });
+  };
+
+  const closeTenantNote = () => setTenantNote(EMPTY_TENANT_NOTE);
+
+  const handleSaveTenantProfile = async () => {
+    if (!tenantEdit.tenantId) return;
+    const fullName = tenantEdit.fullName.trim();
+    if (!fullName) {
+      showToast({ message: "Tenant name is required", variant: "warning" });
+      return;
+    }
+
+    try {
+      setSavingTenantProfile(true);
+      const updated = await updateTenantRecord(tenantEdit.tenantId, {
+        fullName,
+        email: tenantEdit.email.trim() || null,
+        phone: tenantEdit.phone.trim() || null,
+      });
+      setTenants((prev) =>
+        prev.map((tenant) =>
+          String(tenant.id) === String(tenantEdit.tenantId)
+            ? { ...tenant, ...updated }
+            : tenant
+        )
+      );
+      showToast({ message: "Tenant updated", variant: "success" });
+      closeTenantEdit();
+    } catch (err: unknown) {
+      showToast({
+        message: "Failed to update tenant",
+        description: getErrorMessage(err, "Please try again."),
+        variant: "error",
+      });
+    } finally {
+      setSavingTenantProfile(false);
+    }
+  };
+
+  const handleCreateTenantNote = async () => {
+    if (!tenantNote.tenantId) return;
+    const note = tenantNote.note.trim();
+    if (!note) {
+      showToast({ message: "Add a note before saving", variant: "warning" });
+      return;
+    }
+
+    try {
+      setSavingTenantNote(true);
+      await createTenantEvent({
+        tenantId: tenantNote.tenantId,
+        type: "NOTE_ADDED",
+        description: note,
+      });
+      showToast({
+        message: "Tenant note added",
+        description: `Saved to ${tenantNote.tenantName}'s timeline.`,
+        variant: "success",
+      });
+      closeTenantNote();
+    } catch (err: unknown) {
+      showToast({
+        message: "Failed to add tenant note",
+        description: getErrorMessage(err, "Please try again."),
+        variant: "error",
+      });
+    } finally {
+      setSavingTenantNote(false);
+    }
+  };
 
   if (ready && !authLoading && authStatus !== "restoring" && !canViewTenants) {
     return (
@@ -637,7 +799,7 @@ export const TenantsPage: React.FC = () => {
                 className="rc-full-width-mobile"
               >
                 <option value="">Select tenant</option>
-                {filteredTenants.map((tenant: any) => (
+                {filteredTenants.map((tenant) => (
                   <option key={tenant.id} value={tenant.id}>
                     {tenant.name || tenant.fullName || "Tenant"}
                   </option>
@@ -653,6 +815,107 @@ export const TenantsPage: React.FC = () => {
           }}
           detail={
             <div className="rc-tenants-detail">
+              {selectedTenant && selectedTenantLinkage ? (
+                <Section>
+                  <div style={{ display: "grid", gap: 12 }}>
+                    <div
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "space-between",
+                        gap: 12,
+                        flexWrap: "wrap",
+                      }}
+                    >
+                      <div style={{ display: "grid", gap: 4 }}>
+                        <div style={{ fontSize: 16, fontWeight: 700, color: text.primary }}>
+                          Tenant actions
+                        </div>
+                        <div style={{ fontSize: 12, color: text.muted }}>
+                          Manage the tenant person record separately from tenancy and lease state.
+                        </div>
+                      </div>
+                      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                        <button
+                          type="button"
+                          onClick={openTenantEdit}
+                          style={{
+                            padding: "8px 10px",
+                            borderRadius: radius.md,
+                            border: `1px solid ${colors.border}`,
+                            background: colors.card,
+                            color: text.primary,
+                            cursor: "pointer",
+                          }}
+                        >
+                          Edit tenant
+                        </button>
+                        <button
+                          type="button"
+                          onClick={openTenantNote}
+                          style={{
+                            padding: "8px 10px",
+                            borderRadius: radius.md,
+                            border: `1px solid ${colors.border}`,
+                            background: colors.card,
+                            color: text.primary,
+                            cursor: "pointer",
+                          }}
+                        >
+                          Add note
+                        </button>
+                        <button
+                          type="button"
+                          onClick={handleInviteAction}
+                          style={{
+                            padding: "8px 10px",
+                            borderRadius: radius.md,
+                            border: `1px solid ${inviteEnabled ? colors.border : "#f5d0fe"}`,
+                            background: inviteEnabled ? colors.card : "#faf5ff",
+                            color: text.primary,
+                            cursor: "pointer",
+                          }}
+                        >
+                          {inviteEnabled ? "Send tenant invite" : "Unlock Tenant Invites"}
+                        </button>
+                      </div>
+                    </div>
+                    <div
+                      style={{
+                        display: "grid",
+                        gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+                        gap: 10,
+                      }}
+                    >
+                      <Card>
+                        <div style={{ fontSize: 11, fontWeight: 700, color: text.muted }}>Property</div>
+                        <div style={{ marginTop: 4, fontSize: 14, color: text.primary }}>
+                          {selectedTenantLinkage.propertyLabel}
+                        </div>
+                      </Card>
+                      <Card>
+                        <div style={{ fontSize: 11, fontWeight: 700, color: text.muted }}>Unit</div>
+                        <div style={{ marginTop: 4, fontSize: 14, color: text.primary }}>
+                          {selectedTenantLinkage.unitLabel}
+                        </div>
+                      </Card>
+                      <Card>
+                        <div style={{ fontSize: 11, fontWeight: 700, color: text.muted }}>Current lease link</div>
+                        <div style={{ marginTop: 4, fontSize: 14, color: text.primary }}>
+                          {selectedTenantLinkage.leaseLabel}
+                        </div>
+                      </Card>
+                      <Card>
+                        <div style={{ fontSize: 11, fontWeight: 700, color: text.muted }}>Active registered units</div>
+                        <div style={{ marginTop: 4, fontSize: 14, color: text.primary }}>
+                          {selectedTenantLinkage.activeTenancyCount}
+                        </div>
+                      </Card>
+                    </div>
+                    <div style={{ fontSize: 12, color: text.muted }}>{selectedTenantLinkage.linkageNote}</div>
+                  </div>
+                </Section>
+              ) : null}
               <Section style={{ minHeight: 0 }}>
                 {!selectedTenantId && <div style={{ fontSize: 13, color: text.muted }}>Select a tenant from the list to see details.</div>}
                 {selectedTenantId && !tenantExists && !loading && (
@@ -718,10 +981,159 @@ export const TenantsPage: React.FC = () => {
       <InviteTenantModal
         open={inviteOpen}
         onClose={() => setInviteOpen(false)}
+        defaultPropertyId={selectedTenant?.propertyId || undefined}
+        defaultUnitId={selectedTenant?.unitId || undefined}
+        defaultTenantEmail={selectedTenant?.email || undefined}
+        defaultTenantName={selectedTenant?.fullName || selectedTenant?.name || undefined}
         onInviteCreated={() => {
           void loadTenants();
         }}
       />
+
+      {tenantEdit.open ? (
+        <div
+          style={{
+            position: "fixed",
+            inset: 0,
+            background: "rgba(15, 23, 42, 0.45)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            zIndex: 2200,
+            padding: 16,
+          }}
+        >
+          <Card style={{ width: "min(480px, 96vw)", borderRadius: radius.lg }}>
+            <div style={{ display: "grid", gap: 12 }}>
+              <div style={{ fontWeight: 700, fontSize: 16 }}>Edit tenant</div>
+              <label style={{ display: "grid", gap: 4, fontSize: 12, color: text.muted }}>
+                Full name
+                <input
+                  value={tenantEdit.fullName}
+                  onChange={(e) => setTenantEdit((prev) => ({ ...prev, fullName: e.target.value }))}
+                  style={{ padding: 8, borderRadius: radius.md, border: `1px solid ${colors.border}` }}
+                />
+              </label>
+              <label style={{ display: "grid", gap: 4, fontSize: 12, color: text.muted }}>
+                Email
+                <input
+                  value={tenantEdit.email}
+                  onChange={(e) => setTenantEdit((prev) => ({ ...prev, email: e.target.value }))}
+                  style={{ padding: 8, borderRadius: radius.md, border: `1px solid ${colors.border}` }}
+                />
+              </label>
+              <label style={{ display: "grid", gap: 4, fontSize: 12, color: text.muted }}>
+                Phone
+                <input
+                  value={tenantEdit.phone}
+                  onChange={(e) =>
+                    setTenantEdit((prev) => ({
+                      ...prev,
+                      phone: normalizePhoneInput(e.target.value),
+                    }))
+                  }
+                  style={{ padding: 8, borderRadius: radius.md, border: `1px solid ${colors.border}` }}
+                />
+              </label>
+              <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
+                <button
+                  type="button"
+                  onClick={closeTenantEdit}
+                  style={{
+                    padding: "8px 10px",
+                    borderRadius: radius.md,
+                    border: `1px solid ${colors.border}`,
+                    background: colors.card,
+                    color: text.primary,
+                    cursor: "pointer",
+                  }}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void handleSaveTenantProfile()}
+                  disabled={savingTenantProfile}
+                  style={{
+                    padding: "8px 10px",
+                    borderRadius: radius.md,
+                    border: `1px solid ${colors.accent}`,
+                    background: "rgba(37, 99, 235, 0.12)",
+                    color: colors.accent,
+                    cursor: "pointer",
+                    opacity: savingTenantProfile ? 0.7 : 1,
+                  }}
+                >
+                  {savingTenantProfile ? "Saving..." : "Save tenant"}
+                </button>
+              </div>
+            </div>
+          </Card>
+        </div>
+      ) : null}
+
+      {tenantNote.open ? (
+        <div
+          style={{
+            position: "fixed",
+            inset: 0,
+            background: "rgba(15, 23, 42, 0.45)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            zIndex: 2200,
+            padding: 16,
+          }}
+        >
+          <Card style={{ width: "min(480px, 96vw)", borderRadius: radius.lg }}>
+            <div style={{ display: "grid", gap: 12 }}>
+              <div style={{ fontWeight: 700, fontSize: 16 }}>Add tenant note</div>
+              <div style={{ fontSize: 12, color: text.muted }}>
+                Notes are saved as audited tenant timeline events.
+              </div>
+              <textarea
+                value={tenantNote.note}
+                onChange={(e) => setTenantNote((prev) => ({ ...prev, note: e.target.value }))}
+                rows={5}
+                placeholder="Add a note about contact details, follow-up, or context."
+                style={{ padding: 8, borderRadius: radius.md, border: `1px solid ${colors.border}`, resize: "vertical" }}
+              />
+              <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
+                <button
+                  type="button"
+                  onClick={closeTenantNote}
+                  style={{
+                    padding: "8px 10px",
+                    borderRadius: radius.md,
+                    border: `1px solid ${colors.border}`,
+                    background: colors.card,
+                    color: text.primary,
+                    cursor: "pointer",
+                  }}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void handleCreateTenantNote()}
+                  disabled={savingTenantNote}
+                  style={{
+                    padding: "8px 10px",
+                    borderRadius: radius.md,
+                    border: `1px solid ${colors.accent}`,
+                    background: "rgba(37, 99, 235, 0.12)",
+                    color: colors.accent,
+                    cursor: "pointer",
+                    opacity: savingTenantNote ? 0.7 : 1,
+                  }}
+                >
+                  {savingTenantNote ? "Saving..." : "Save note"}
+                </button>
+              </div>
+            </div>
+          </Card>
+        </div>
+      ) : null}
 
       {occupancyEditor.open ? (
         <div


### PR DESCRIPTION
## Summary
- add a safe tenant cleanup path for the identified test tenants using `hiddenFromActiveLists` plus a targeted internal repair script, without destructive deletion or lease/tenancy mutation
- add a clearer landlord tenant action hub for `Edit tenant`, `Add note`, and `Send tenant invite`, while keeping person-record actions separate from tenancy and lease lifecycle state
- preserve linked property/unit/lease integrity, reuse the audited `tenantEvents` path for notes, and keep all changes additive and fail-closed

## Audit Findings
- tenant person records are stored in `tenants`; landlord list/detail is loaded through `tenantDetailsService` and `tenantsRoutes`
- tenant `propertyId` / `unitId` fields are advisory display/linkage hints, while canonical occupancy and legal state remain in `tenancies` and `leases`
- invite history already resolves separately from `tenantInvites`, and note/timeline writes already have an audited path through `tenantEvents`
- there was no safe hide/archive pattern on landlord tenant lists before this mission, and no landlord-safe basic tenant profile patch route

## Cleanup Strategy
- chosen pattern: `hiddenFromActiveLists` plus a targeted internal repair script
- the script applies only to the listed test tenant IDs and writes:
  - `hiddenFromActiveLists: true`
  - `cleanupReason: "identified_test_tenant"`
  - `cleanupBatch: "tenant_record_cleanup_profile_actions_v1"`
- no destructive delete feature was introduced
- no tenancy or lease lifecycle fields were reused for cleanup semantics

## Safety / Integrity
- no mutation of lease, tenancy, property, unit, or `currentLeaseId` linkage was performed as part of cleanup
- hidden tenants are removed from normal active landlord lists only; linked data remains preserved and auditable
- ambiguous linkage is handled fail-closed by visibility filtering rather than speculative relinking
- landlord tenant editing is constrained to person-record fields only:
  - `fullName`
  - `email`
  - `phone`

## UX
- adds a landlord-facing tenant action hub for:
  - `Edit tenant`
  - `Add note`
  - `Send tenant invite`
- `Add note` reuses the existing audited `tenantEvents` path via `NOTE_ADDED`
- `Send tenant invite` now prefills the existing invite modal with tenant/property/unit context
- tenant detail now surfaces clearer property/unit/current-lease linkage context without changing canonical tenancy or lease behavior

## Verification
### Backend
```bash
cd rentchain-api
source ~/.nvm/nvm.sh && nvm use 20 >/dev/null
npm test -- --run src/services/__tests__/tenantDetailsService.test.ts src/routes/__tests__/tenantsRoutes.test.ts src/routes/__tests__/tenantEventsWriteRoutes.test.ts
npm run build
```

### Frontend
```bash
cd rentchain-frontend
source ~/.nvm/nvm.sh && nvm use 20 >/dev/null
npm test -- --run src/pages/TenantsPage.test.tsx
npm run build
./node_modules/.bin/eslint src/pages/TenantsPage.tsx src/pages/TenantsPage.test.tsx src/components/tenants/InviteTenantModal.tsx src/api/tenantsApi.ts src/api/tenantEventsWriteApi.ts
```

## Scope Notes
- no hard-delete landlord UI was added
- no tenancy termination, eviction, arrears, or legal workflow logic was introduced
- no payment, screening, or lease lifecycle redesign was introduced
- branch remains strictly scoped to tenant cleanup handling and tenant profile action clarity