### PR TITLE
fix: repair properties, lease conversion, and tenant cleanup workflows

### DIFF
--- a/rentchain-api/src/routes/__tests__/leaseRoutes.integrity.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.integrity.test.ts
@@ -222,7 +222,13 @@ describe("leaseRoutes integrity repairs", () => {
     const app = await makeApp();
     const res = await request(app)
       .post("/reconciliation-candidates/unit-1/convert")
-      .send({ startDate: "2026-04-01", monthlyRent: 1850 });
+      .send({
+        startDate: "2026-04-01",
+        monthlyRent: 1850,
+        tenantPhone: "(902) 555-1111 ext 9",
+        coApplicantEmail: "coapplicant@example.com",
+        coApplicantPhone: "902-555-3333",
+      });
 
     expect(res.status).toBe(201);
     expect(res.body?.ok).toBe(true);
@@ -231,6 +237,11 @@ describe("leaseRoutes integrity repairs", () => {
     const leaseSnap = await fakeDb.collection("leases").doc(String(res.body?.lease?.id || "")).get();
     expect(leaseSnap.exists).toBe(true);
     expect(leaseSnap.data()?.referenceDocument?.fileName).toBe("lease.pdf");
+    expect(leaseSnap.data()?.coApplicant).toEqual({
+      email: "coapplicant@example.com",
+      phone: "9025553333",
+    });
+    expect(res.body?.tenant?.phone).toBe("90255511119");
   });
 
   it("lists notes and archive visibility metadata for landlord leases", async () => {

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -56,6 +56,11 @@ function normalizeStatus(value: unknown): string {
   return String(value || "").trim().toLowerCase();
 }
 
+function normalizePhoneDigits(value: unknown): string | null {
+  const digits = String(value || "").replace(/\D/g, "").slice(0, 15);
+  return digits || null;
+}
+
 function escapeCsvCell(value: unknown): string {
   const raw = String(value ?? "");
   if (/[",\n]/.test(raw)) {
@@ -524,11 +529,20 @@ router.post("/reconciliation-candidates/:unitId/convert", requireLandlord, async
     }
 
     const occupantName = String(req.body?.occupantName || unit?.occupantName || "").trim();
-    const tenantEmail = String(req.body?.tenantEmail || "").trim() || null;
-    const tenantPhone = String(req.body?.tenantPhone || "").trim() || null;
+    const tenantEmail = String(req.body?.tenantEmail || "").trim().toLowerCase() || null;
+    const tenantPhone = normalizePhoneDigits(req.body?.tenantPhone);
+    const coApplicantEmail = String(req.body?.coApplicantEmail || "").trim().toLowerCase() || null;
+    const coApplicantPhone = normalizePhoneDigits(req.body?.coApplicantPhone);
     const startDate = toIsoDate(req.body?.startDate);
     const endDate = toIsoDate(req.body?.endDate);
     const monthlyRent = Number(req.body?.monthlyRent ?? unit?.rent);
+    const coApplicant =
+      coApplicantEmail || coApplicantPhone
+        ? {
+            email: coApplicantEmail,
+            phone: coApplicantPhone,
+          }
+        : null;
 
     if (!occupantName) return res.status(400).json({ ok: false, error: "occupant_name_required" });
     if (!startDate) return res.status(400).json({ ok: false, error: "start_date_required" });
@@ -555,6 +569,7 @@ router.post("/reconciliation-candidates/:unitId/convert", requireLandlord, async
         leaseStart: startDate,
         leaseEnd: endDate || null,
         monthlyRent,
+        coApplicant,
         status: "Current",
         createdAt: nowIso,
         updatedAt: nowIso,
@@ -612,6 +627,7 @@ router.post("/reconciliation-candidates/:unitId/convert", requireLandlord, async
       source: "occupied_unit_reconciliation",
       sourceUnitId: unitId,
       referenceDocument: unit?.leaseDocument || null,
+      coApplicant,
     };
     await db.collection("leases").doc(lease.id).set(firestoreLeaseRecord, { merge: false });
     await tenantRef.set({ currentLeaseId: lease.id, updatedAt: new Date().toISOString() }, { merge: true });

--- a/rentchain-api/src/services/__tests__/tenantDetailsService.test.ts
+++ b/rentchain-api/src/services/__tests__/tenantDetailsService.test.ts
@@ -114,4 +114,20 @@ describe("getTenantsList", () => {
       "tenant-visible",
     ]);
   });
+
+  it("hides the targeted test-tenant ids even if the cleanup flag was never written", async () => {
+    tenantDocs.set("c43992df00d07acae140ba76", {
+      landlordId: "landlord-1",
+      fullName: "test2",
+      createdAt: "2026-01-04T00:00:00.000Z",
+    });
+
+    const { getTenantsList } = await import("../tenantDetailsService");
+    const tenants = await getTenantsList({
+      landlordId: "landlord-1",
+      excludeHiddenFromActiveLists: true,
+    });
+
+    expect(tenants.map((tenant) => tenant.id)).toEqual(["tenant-visible"]);
+  });
 });

--- a/rentchain-api/src/services/tenantDetailsService.ts
+++ b/rentchain-api/src/services/tenantDetailsService.ts
@@ -140,6 +140,13 @@ const FALLBACK_TENANTS: TenantRecord[] = [
 ];
 
 const CONVERTED_TENANTS: TenantRecord[] = [];
+const TARGETED_HIDDEN_TENANT_IDS = new Set([
+  "c43992df00d07acae140ba76",
+  "6b8df37863a292ead2a07401",
+  "b815152e3fbaf302897f6ce4",
+  "bcea70bf3f353746c8895bc9",
+  "ff45a28cdfad7737958592de",
+]);
 
 type TenantQueryOptions = {
   landlordId?: string | null;
@@ -181,6 +188,10 @@ function pickString(...values: any[]): string | null {
     if (next) return next;
   }
   return null;
+}
+
+function isHiddenFromActiveLists(tenant: Pick<TenantRecord, "id" | "hiddenFromActiveLists">) {
+  return tenant.hiddenFromActiveLists === true || TARGETED_HIDDEN_TENANT_IDS.has(String(tenant.id || "").trim());
 }
 
 function mapTenant(docId: string, data: any): TenantRecord {
@@ -437,7 +448,7 @@ export async function getTenantsList(opts: TenantQueryOptions = {}): Promise<Ten
     snap.forEach((doc) => {
       const data = doc.data() as any;
       const tenant = mapTenant(doc.id, data);
-      if (excludeHiddenFromActiveLists && tenant.hiddenFromActiveLists) return;
+      if (excludeHiddenFromActiveLists && isHiddenFromActiveLists(tenant)) return;
       out.push(tenant);
     });
 

--- a/rentchain-frontend/src/api/leasesApi.ts
+++ b/rentchain-frontend/src/api/leasesApi.ts
@@ -141,6 +141,8 @@ export async function convertUnitReferenceToLease(
     occupantName?: string;
     tenantEmail?: string;
     tenantPhone?: string;
+    coApplicantEmail?: string;
+    coApplicantPhone?: string;
     startDate: string;
     endDate?: string | null;
     monthlyRent?: number;

--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.test.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.test.tsx
@@ -276,6 +276,59 @@ render(
     expect(screen.getAllByText("$1,800").length).toBeGreaterThan(0);
   });
 
+  it("renders safely when lease-backed occupancy falls back from active leases", async () => {
+    mocks.fetchUnitsForProperty.mockResolvedValue([
+      {
+        id: "unit-1",
+        unitNumber: "101",
+        rent: 1850,
+      },
+    ]);
+    mocks.getLeasesForProperty.mockResolvedValue({
+      leases: [
+        {
+          id: "lease-1",
+          tenantId: "tenant-1",
+          propertyId: "prop-1",
+          unitId: "unit-1",
+          unitNumber: "101",
+          monthlyRent: 1850,
+          startDate: "2026-01-01",
+          endDate: "2026-12-31",
+          status: "active",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+      credibilitySummary: null,
+    });
+
+    render(
+      <AuthProvider>
+        <MemoryRouter>
+          <PropertyDetailPanel
+            property={{
+              id: "prop-1",
+              name: "Harbour View",
+              addressLine1: "12 Wharf Street",
+              city: "Halifax",
+              province: "NS",
+              postalCode: "B3H 1A1",
+              country: "Canada",
+              totalUnits: 1,
+              amenities: [],
+              units: [],
+              createdAt: new Date().toISOString(),
+            }}
+            onRefresh={vi.fn()}
+          />
+        </MemoryRouter>
+      </AuthProvider>
+    );
+
+    expect((await screen.findAllByText("Occupied")).length).toBeGreaterThan(0);
+  });
+
   it("uses the updated archive confirmation copy before archiving", async () => {
     const confirmMock = vi.spyOn(window, "confirm").mockReturnValue(true);
 

--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
@@ -586,8 +586,24 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
     activeLeaseRentTotal,
     currentOccupiedRentTotal,
   } = useMemo(() => buildPropertySummaryMetrics(displayedUnits, leases, unitCount), [displayedUnits, leases, unitCount]);
+  const leasedUnitIds = useMemo(
+    () => new Set(activeLeases.map((lease) => String(lease.unitId || "").trim()).filter(Boolean)),
+    [activeLeases]
+  );
+  const leasedUnitNumbers = useMemo(
+    () => new Set(activeLeases.map((lease) => String(lease.unitNumber || "").trim()).filter(Boolean)),
+    [activeLeases]
+  );
   const collectionRate =
     currentOccupiedRentTotal > 0 ? totalCollectedThisMonth / currentOccupiedRentTotal : 0;
+  const isLeaseBackedUnit = useCallback(
+    (unit: any) => {
+      const unitId = String(unit?.id || unit?.unitId || "").trim();
+      const unitNumber = String(unit?.unitNumber || unit?.label || "").trim();
+      return (unitId && leasedUnitIds.has(unitId)) || (unitNumber && leasedUnitNumbers.has(unitNumber));
+    },
+    [leasedUnitIds, leasedUnitNumbers]
+  );
 
   const unitsNeedingOccupancySetup = useMemo(
     () => getUnitsNeedingOccupancySetup(displayedUnits, activeLeases),
@@ -1430,7 +1446,7 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
                     (u as any).baths ?? (u as any).bathrooms ?? (u as any).bathroomsCount ?? null;
                   const rentVal = resolveConfiguredUnitRent(u);
                   const sqftVal = (u as any).sqft ?? null;
-                  const statusVal = (u as any).status || (leasedUnitNumbers.has(unitNum) ? "occupied" : "vacant");
+                  const statusVal = (u as any).status || (isLeaseBackedUnit(u) ? "occupied" : "vacant");
                   const isLeased = String(statusVal || "").toLowerCase() === "occupied";
                   const rentDisplay =
                     rentVal !== null && rentVal !== undefined
@@ -1599,7 +1615,7 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
               (u as any).baths ?? (u as any).bathrooms ?? (u as any).bathroomsCount ?? null;
             const rentVal = resolveConfiguredUnitRent(u);
             const sqftVal = (u as any).sqft ?? null;
-            const statusVal = (u as any).status || (leasedUnitNumbers.has(unitNum) ? "occupied" : "vacant");
+            const statusVal = (u as any).status || (isLeaseBackedUnit(u) ? "occupied" : "vacant");
             const isLeased = String(statusVal || "").toLowerCase() === "occupied";
             const rentDisplay =
               rentVal !== null && rentVal !== undefined

--- a/rentchain-frontend/src/components/tenants/TenantActivityPanel.test.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantActivityPanel.test.tsx
@@ -1,0 +1,76 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TenantActivityPanel } from "./TenantActivityPanel";
+
+const mocks = vi.hoisted(() => ({
+  listTenantEvents: vi.fn(),
+}));
+
+vi.mock("../../api/tenantEvents", () => ({
+  listTenantEvents: mocks.listTenantEvents,
+}));
+
+describe("TenantActivityPanel", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    mocks.listTenantEvents.mockReset();
+  });
+
+  it("renders audited tenant notes from the landlord tenant-events feed", async () => {
+    mocks.listTenantEvents.mockResolvedValue({
+      ok: true,
+      items: [
+        {
+          id: "event-1",
+          tenantId: "tenant-1",
+          landlordId: "landlord-1",
+          type: "NOTE_ADDED",
+          title: "Note added",
+          description: "Called tenant to confirm contact details.",
+          createdAt: "2026-04-23T10:00:00.000Z",
+        },
+      ],
+      nextCursor: null,
+    });
+
+    render(<TenantActivityPanel tenantId="tenant-1" />);
+
+    expect(await screen.findByText("Note added")).toBeInTheDocument();
+    expect(screen.getByText("Called tenant to confirm contact details.")).toBeInTheDocument();
+    expect(mocks.listTenantEvents).toHaveBeenCalledWith({
+      tenantId: "tenant-1",
+      limit: 25,
+      cursor: undefined,
+    });
+  });
+
+  it("reloads the audited activity feed when refreshed", async () => {
+    mocks.listTenantEvents
+      .mockResolvedValueOnce({ ok: true, items: [], nextCursor: null })
+      .mockResolvedValueOnce({
+        ok: true,
+        items: [
+          {
+            id: "event-2",
+            tenantId: "tenant-1",
+            landlordId: "landlord-1",
+            type: "NOTE_ADDED",
+            title: "Note added",
+            description: "Refreshed note",
+            createdAt: "2026-04-23T11:00:00.000Z",
+          },
+        ],
+        nextCursor: null,
+      });
+
+    render(<TenantActivityPanel tenantId="tenant-1" />);
+
+    expect(await screen.findByText("No recent activity recorded for this tenant.")).toBeInTheDocument();
+    fireEvent.click(screen.getAllByRole("button", { name: "Refresh" })[0]);
+
+    await waitFor(() => expect(screen.getByText("Refreshed note")).toBeInTheDocument());
+  });
+});

--- a/rentchain-frontend/src/components/tenants/TenantActivityPanel.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantActivityPanel.tsx
@@ -1,23 +1,32 @@
 import React, { useEffect, useState } from "react";
 import { colors, radius, text } from "../../styles/tokens";
-import { getMyTenantEvents, type TenantEvent } from "../../api/tenantEvents";
+import { listTenantEvents, type TenantEvent } from "../../api/tenantEvents";
 
 type Props = {
   tenantId: string | null | undefined;
+  refreshKey?: number;
 };
 
-function toMillis(ts: any): number | null {
+function toMillis(ts: unknown): number | null {
   if (ts == null) return null;
   if (typeof ts === "number") return ts;
-  if (typeof ts?.toMillis === "function") return ts.toMillis();
-  if (typeof ts?.seconds === "number") return ts.seconds * 1000;
+  if (typeof ts === "object" && ts !== null) {
+    const candidate = ts as { toMillis?: () => number; seconds?: number };
+    if (typeof candidate.toMillis === "function") return candidate.toMillis();
+    if (typeof candidate.seconds === "number") return candidate.seconds * 1000;
+  }
   const d = new Date(ts);
   return Number.isNaN(d.getTime()) ? null : d.getTime();
 }
 
-export const TenantActivityPanel: React.FC<Props> = ({ tenantId }) => {
+function getErrorMessage(error: unknown) {
+  if (error instanceof Error && error.message) return error.message;
+  return "Failed to load tenant activity";
+}
+
+export const TenantActivityPanel: React.FC<Props> = ({ tenantId, refreshKey = 0 }) => {
   const [items, setItems] = useState<TenantEvent[]>([]);
-  const [nextCursor, setNextCursor] = useState<any>(null);
+  const [nextCursor, setNextCursor] = useState<string | number | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -32,12 +41,16 @@ export const TenantActivityPanel: React.FC<Props> = ({ tenantId }) => {
     setLoading(true);
     setError(null);
     try {
-      const resp = await getMyTenantEvents(25);
-      const newItems = (resp as any)?.items || [];
-      setItems(initial ? newItems : [...items, ...newItems]);
-      setNextCursor(null);
-    } catch (e: any) {
-      setError(e?.message || "Failed to load tenant activity");
+      const resp = await listTenantEvents({
+        tenantId,
+        limit: 25,
+        cursor: initial ? undefined : nextCursor ?? undefined,
+      });
+      const newItems = Array.isArray(resp?.items) ? resp.items : [];
+      setItems((prev) => (initial ? newItems : [...prev, ...newItems]));
+      setNextCursor(resp?.nextCursor ?? null);
+    } catch (error: unknown) {
+      setError(getErrorMessage(error));
     } finally {
       setLoading(false);
     }
@@ -56,7 +69,7 @@ export const TenantActivityPanel: React.FC<Props> = ({ tenantId }) => {
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tenantId]);
+  }, [tenantId, refreshKey]);
 
   const canLoadMore = !!nextCursor && !loading;
 

--- a/rentchain-frontend/src/components/tenants/TenantDetailPanel.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantDetailPanel.tsx
@@ -19,11 +19,13 @@ import { upgradeStarterButtonStyle } from "../../lib/upgradeButtonStyles";
 import { useAuth } from "@/context/useAuth";
 import { CredibilityInsightsCard } from "./CredibilityInsightsCard";
 import { MoveInReadinessPanel } from "./MoveInReadinessPanel";
+import { TenantActivityPanel } from "./TenantActivityPanel";
 import { FeatureGate } from "@/components/billing/FeatureGate";
 import { LockedFeature } from "@/components/billing/LockedFeature";
 
 interface TenantDetailPanelProps {
   tenantId: string | null;
+  activityRefreshKey?: number;
 }
 
 const riskBgMap: Record<string, string> = {
@@ -64,7 +66,7 @@ function formatNoticeResponse(value?: string | null, noResponse?: boolean) {
   return normalized.replace(/_/g, " ").replace(/\b\w/g, (match) => match.toUpperCase());
 }
 
-export const TenantDetailPanel: React.FC<TenantDetailPanelProps> = ({ tenantId }) => {
+export const TenantDetailPanel: React.FC<TenantDetailPanelProps> = ({ tenantId, activityRefreshKey = 0 }) => {
   const { bundle, loading, error } = useTenantDetail(tenantId ?? null);
 
   if (!tenantId) {
@@ -100,15 +102,16 @@ export const TenantDetailPanel: React.FC<TenantDetailPanelProps> = ({ tenantId }
     );
   }
 
-  return <TenantDetailLayout bundle={bundle as any} tenantId={tenantId} />;
+  return <TenantDetailLayout bundle={bundle as any} tenantId={tenantId} activityRefreshKey={activityRefreshKey} />;
 };
 
 interface LayoutProps {
   bundle: any;
   tenantId: string;
+  activityRefreshKey: number;
 }
 
-const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId }) => {
+const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityRefreshKey }) => {
   const navigate = useNavigate();
   const { user } = useAuth();
   const { showToast } = useToast();
@@ -688,6 +691,7 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId }) => {
           <LedgerTimeline items={ledgerItems || []} compact />
         )}
       </div>
+      <TenantActivityPanel tenantId={tenantId} refreshKey={activityRefreshKey} />
         </>
       )}
 

--- a/rentchain-frontend/src/components/tenants/TenantLeasePanel.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantLeasePanel.tsx
@@ -486,7 +486,7 @@ export const TenantLeasePanel: React.FC<TenantLeasePanelProps> = ({ tenantId }) 
               background: "rgba(255,255,255,0.01)",
             }}
           >
-            <div style={{ color: "#9ca3af", fontSize: 12, marginBottom: 6 }}>
+            <div style={{ color: "#475569", fontSize: 12, marginBottom: 6, fontWeight: 600 }}>
               Lease History
             </div>
             <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
@@ -500,7 +500,7 @@ export const TenantLeasePanel: React.FC<TenantLeasePanelProps> = ({ tenantId }) 
                     display: "flex",
                     justifyContent: "space-between",
                     alignItems: "center",
-                    color: "#e5e7eb",
+                    color: "#0f172a",
                     fontSize: 13,
                   }}
                 >
@@ -508,7 +508,7 @@ export const TenantLeasePanel: React.FC<TenantLeasePanelProps> = ({ tenantId }) 
                     <div style={{ fontWeight: 600 }}>
                       {lease.propertyId} - Unit {lease.unitNumber}
                     </div>
-                    <div style={{ color: "#9ca3af", fontSize: 12 }}>
+                    <div style={{ color: "#475569", fontSize: 12 }}>
                       {formatDate(lease.startDate)} → {formatDate(lease.endDate)}
                     </div>
                   </div>
@@ -526,7 +526,7 @@ export const TenantLeasePanel: React.FC<TenantLeasePanelProps> = ({ tenantId }) 
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
-      <div style={{ fontWeight: 600, color: "#e5e7eb", fontSize: "1rem" }}>
+      <div style={{ fontWeight: 700, color: "#0f172a", fontSize: "1rem" }}>
         Lease Info
       </div>
       {content}

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
@@ -1,6 +1,6 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import LandlordActiveLeasesPage from "./LandlordActiveLeasesPage";
 
 const mocks = vi.hoisted(() => ({
@@ -22,6 +22,10 @@ vi.mock("@/api/leasesApi", () => ({
 }));
 
 describe("LandlordActiveLeasesPage", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   beforeEach(() => {
     mocks.getActiveLeasesForLandlord.mockResolvedValue({
       leases: [
@@ -98,6 +102,9 @@ describe("LandlordActiveLeasesPage", () => {
 
     expect(await screen.findByText(/Occupied units missing lease records/i)).toBeInTheDocument();
     fireEvent.click(screen.getAllByRole("button", { name: "Convert unit 9 to lease" })[0]);
+    fireEvent.change(screen.getByLabelText("Tenant phone (optional)"), { target: { value: "(902) 555-1111 ext 9" } });
+    fireEvent.change(screen.getByLabelText("Co-applicant email (optional)"), { target: { value: "coapplicant@example.com" } });
+    fireEvent.change(screen.getByLabelText("Co-applicant phone (optional)"), { target: { value: "902-555-3333" } });
     fireEvent.change(screen.getByLabelText("Start date"), { target: { value: "2026-04-01" } });
     fireEvent.change(screen.getByLabelText("Monthly rent"), { target: { value: "2100" } });
     fireEvent.click(screen.getByRole("button", { name: "Create lease" }));
@@ -105,9 +112,48 @@ describe("LandlordActiveLeasesPage", () => {
     await waitFor(() =>
       expect(mocks.convertUnitReferenceToLease).toHaveBeenCalledWith(
         "unit-9",
-        expect.objectContaining({ startDate: "2026-04-01", monthlyRent: 2100 })
+        expect.objectContaining({
+          tenantPhone: "90255511119",
+          coApplicantEmail: "coapplicant@example.com",
+          coApplicantPhone: "9025553333",
+          startDate: "2026-04-01",
+          monthlyRent: 2100,
+        })
       )
     );
+  });
+
+  it("shows a recovery action when conversion is blocked by missing info", async () => {
+    mocks.getLeaseReconciliationCandidates.mockResolvedValue({
+      candidates: [
+        {
+          id: "unit-3",
+          unitId: "unit-3",
+          propertyId: "prop-3",
+          propertyName: "Dockside",
+          unitNumber: "3",
+          occupantName: null,
+          monthlyRent: 0,
+          leaseEndDate: null,
+          canConvert: false,
+          blockingReasons: ["occupant_name_required", "rent_required"],
+          leaseDocument: null,
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter>
+        <LandlordActiveLeasesPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Complete tenant info")).toHaveAttribute(
+      "href",
+      "/properties?propertyId=prop-3&unitId=unit-3"
+    );
+    expect(screen.queryByRole("button", { name: "Convert unit 3 to lease" })).not.toBeInTheDocument();
+    expect(screen.getByText("Missing: Occupant name required, Monthly rent required")).toBeInTheDocument();
   });
 
   it("loads archived leases when archive view is selected", async () => {
@@ -137,5 +183,66 @@ describe("LandlordActiveLeasesPage", () => {
     expect(await screen.findByText("Archived Place")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Restore" }));
     await waitFor(() => expect(mocks.restoreLeaseRecord).toHaveBeenCalledWith("lease-2"));
+  });
+
+  it("filters the current lease list by tenant, unit, and property with a no-match state", async () => {
+    mocks.getActiveLeasesForLandlord.mockResolvedValue({
+      leases: [
+        {
+          id: "lease-1",
+          propertyId: "prop-1",
+          propertyName: "Harbour View",
+          unitNumber: "101",
+          monthlyRent: 1850,
+          startDate: "2026-01-01",
+          endDate: "2026-12-31",
+          status: "active",
+          tenantName: "Jane Tenant",
+          tenantEmail: "jane@example.com",
+        },
+        {
+          id: "lease-2",
+          propertyId: "prop-2",
+          propertyName: "Dockside Flats",
+          unitNumber: "9B",
+          monthlyRent: 2100,
+          startDate: "2026-02-01",
+          endDate: "2027-01-31",
+          status: "active",
+          tenantName: "Mark Harbor",
+          tenantEmail: "mark@example.com",
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter>
+        <LandlordActiveLeasesPage />
+      </MemoryRouter>
+    );
+
+    expect((await screen.findAllByText("Jane Tenant")).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Mark Harbor").length).toBeGreaterThan(0);
+
+    const search = screen.getByLabelText("Search leases");
+
+    fireEvent.change(search, { target: { value: "jane" } });
+    expect(screen.getAllByText("Jane Tenant").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Mark Harbor")).not.toBeInTheDocument();
+
+    fireEvent.change(search, { target: { value: " 9b " } });
+    expect(screen.getAllByText("Mark Harbor").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Jane Tenant")).not.toBeInTheDocument();
+
+    fireEvent.change(search, { target: { value: "dockside" } });
+    expect(screen.getByText("Dockside Flats")).toBeInTheDocument();
+    expect(screen.queryByText("Harbour View")).not.toBeInTheDocument();
+
+    fireEvent.change(search, { target: { value: "no-match" } });
+    expect(screen.getByText("No leases match your search.")).toBeInTheDocument();
+
+    fireEvent.change(search, { target: { value: "" } });
+    expect(screen.getAllByText("Jane Tenant").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Mark Harbor").length).toBeGreaterThan(0);
   });
 });

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
@@ -66,6 +66,39 @@ function errorMessage(error: unknown, fallback: string) {
   return fallback;
 }
 
+function normalizePhoneInput(value: string) {
+  return String(value || "").replace(/\D/g, "").slice(0, 15);
+}
+
+function formatBlockingReason(reason: string) {
+  switch (String(reason || "").trim().toLowerCase()) {
+    case "occupant_name_required":
+      return "Occupant name required";
+    case "rent_required":
+      return "Monthly rent required";
+    default:
+      return String(reason || "")
+        .replace(/_/g, " ")
+        .replace(/\b\w/g, (char) => char.toUpperCase());
+  }
+}
+
+function buildCompleteTenantInfoHref(candidate: LeaseReconciliationCandidate) {
+  const params = new URLSearchParams();
+  params.set("propertyId", String(candidate.propertyId));
+  params.set("unitId", String(candidate.unitId));
+  return `/properties?${params.toString()}`;
+}
+
+function matchesLeaseSearch(lease: LandlordActiveLease, normalizedQuery: string) {
+  if (!normalizedQuery) return true;
+  const haystack = [lease.tenantName, lease.unitNumber, lease.propertyName]
+    .map((value) => String(value || "").trim().toLowerCase())
+    .filter(Boolean)
+    .join(" ");
+  return haystack.includes(normalizedQuery);
+}
+
 function statusBadge(status: string | null | undefined) {
   return (
     <span
@@ -91,11 +124,14 @@ export default function LandlordActiveLeasesPage() {
   const [candidates, setCandidates] = React.useState<LeaseReconciliationCandidate[]>([]);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = React.useState("");
   const [selectedCandidate, setSelectedCandidate] = React.useState<LeaseReconciliationCandidate | null>(null);
   const [convertSaving, setConvertSaving] = React.useState(false);
   const [occupantName, setOccupantName] = React.useState("");
   const [tenantEmail, setTenantEmail] = React.useState("");
   const [tenantPhone, setTenantPhone] = React.useState("");
+  const [coApplicantEmail, setCoApplicantEmail] = React.useState("");
+  const [coApplicantPhone, setCoApplicantPhone] = React.useState("");
   const [startDate, setStartDate] = React.useState(todayIso());
   const [endDate, setEndDate] = React.useState("");
   const [monthlyRent, setMonthlyRent] = React.useState("");
@@ -128,6 +164,8 @@ export default function LandlordActiveLeasesPage() {
     setOccupantName(String(selectedCandidate.occupantName || ""));
     setTenantEmail("");
     setTenantPhone("");
+    setCoApplicantEmail("");
+    setCoApplicantPhone("");
     setStartDate(todayIso());
     setEndDate(String(selectedCandidate.leaseEndDate || ""));
     setMonthlyRent(String(selectedCandidate.monthlyRent || ""));
@@ -156,6 +194,8 @@ export default function LandlordActiveLeasesPage() {
         occupantName,
         tenantEmail: tenantEmail.trim() || undefined,
         tenantPhone: tenantPhone.trim() || undefined,
+        coApplicantEmail: coApplicantEmail.trim() || undefined,
+        coApplicantPhone: coApplicantPhone.trim() || undefined,
         startDate,
         endDate: endDate || null,
         monthlyRent: Number(monthlyRent || 0),
@@ -168,6 +208,12 @@ export default function LandlordActiveLeasesPage() {
       setConvertSaving(false);
     }
   }
+
+  const normalizedSearchQuery = searchQuery.trim().toLowerCase();
+  const filteredLeases = React.useMemo(
+    () => leases.filter((lease) => matchesLeaseSearch(lease, normalizedSearchQuery)),
+    [leases, normalizedSearchQuery]
+  );
 
   return (
     <div style={{ display: "grid", gap: 16 }}>
@@ -207,6 +253,23 @@ export default function LandlordActiveLeasesPage() {
         </button>
       </div>
 
+      <label style={{ display: "grid", gap: 6, maxWidth: 420 }}>
+        <span style={{ fontSize: 13, fontWeight: 700, color: "#0f172a" }}>Search leases</span>
+        <input
+          aria-label="Search leases"
+          value={searchQuery}
+          onChange={(event) => setSearchQuery(event.target.value)}
+          placeholder="Search by tenant, unit, or property"
+          style={{
+            padding: "10px 12px",
+            borderRadius: 10,
+            border: "1px solid #cbd5e1",
+            background: "#fff",
+            color: "#0f172a",
+          }}
+        />
+      </label>
+
       {loading ? <div>Loading lease operations…</div> : null}
       {error ? <div style={{ color: "#b91c1c" }}>{error}</div> : null}
 
@@ -243,26 +306,41 @@ export default function LandlordActiveLeasesPage() {
                       View reference
                     </a>
                   ) : null}
-                  <button
-                    type="button"
-                    aria-label={`Convert unit ${candidate.unitNumber} to lease`}
-                    disabled={!candidate.canConvert}
-                    onClick={() => setSelectedCandidate(candidate)}
-                    style={{
-                      padding: "6px 10px",
-                      borderRadius: 8,
-                      border: "1px solid #cbd5e1",
-                      background: candidate.canConvert ? "#fff" : "#f8fafc",
-                      color: candidate.canConvert ? "#0f172a" : "#94a3b8",
-                    }}
-                  >
-                    Convert to lease
-                  </button>
+                  {candidate.canConvert ? (
+                    <button
+                      type="button"
+                      aria-label={`Convert unit ${candidate.unitNumber} to lease`}
+                      onClick={() => setSelectedCandidate(candidate)}
+                      style={{
+                        padding: "6px 10px",
+                        borderRadius: 8,
+                        border: "1px solid #cbd5e1",
+                        background: "#fff",
+                        color: "#0f172a",
+                      }}
+                    >
+                      Convert to lease
+                    </button>
+                  ) : (
+                    <Link
+                      to={buildCompleteTenantInfoHref(candidate)}
+                      style={{
+                        padding: "6px 10px",
+                        borderRadius: 8,
+                        border: "1px solid #cbd5e1",
+                        background: "#fff",
+                        color: "#0f172a",
+                        textDecoration: "none",
+                      }}
+                    >
+                      Complete tenant info
+                    </Link>
+                  )}
                 </div>
               </div>
               {!candidate.canConvert && candidate.blockingReasons.length > 0 ? (
                 <div style={{ color: "#b45309", fontSize: 12 }}>
-                  Missing: {candidate.blockingReasons.join(", ").replace(/_/g, " ")}
+                  Missing: {candidate.blockingReasons.map(formatBlockingReason).join(", ")}
                 </div>
               ) : null}
             </div>
@@ -284,7 +362,21 @@ export default function LandlordActiveLeasesPage() {
         </div>
       ) : null}
 
-      {!loading && !error && leases.length > 0 ? (
+      {!loading && !error && leases.length > 0 && filteredLeases.length === 0 ? (
+        <div
+          style={{
+            padding: 16,
+            borderRadius: 12,
+            border: "1px solid #e2e8f0",
+            background: "#fff",
+            color: "#475569",
+          }}
+        >
+          No leases match your search.
+        </div>
+      ) : null}
+
+      {!loading && !error && filteredLeases.length > 0 ? (
         <div style={{ overflowX: "auto", border: "1px solid #e2e8f0", borderRadius: 12, background: "#fff" }}>
           <table style={{ width: "100%", minWidth: 1040, borderCollapse: "collapse" }}>
             <thead>
@@ -297,7 +389,7 @@ export default function LandlordActiveLeasesPage() {
               </tr>
             </thead>
             <tbody>
-              {leases.map((lease) => {
+              {filteredLeases.map((lease) => {
                 const ledgerPath = `/leases/${encodeURIComponent(lease.id)}/ledger`;
                 const ledgerUrl =
                   typeof window !== "undefined"
@@ -456,7 +548,23 @@ export default function LandlordActiveLeasesPage() {
             </label>
             <label style={{ display: "grid", gap: 4 }}>
               <span>Tenant phone (optional)</span>
-              <input value={tenantPhone} onChange={(event) => setTenantPhone(event.target.value)} />
+              <input
+                inputMode="numeric"
+                value={tenantPhone}
+                onChange={(event) => setTenantPhone(normalizePhoneInput(event.target.value))}
+              />
+            </label>
+            <label style={{ display: "grid", gap: 4 }}>
+              <span>Co-applicant email (optional)</span>
+              <input value={coApplicantEmail} onChange={(event) => setCoApplicantEmail(event.target.value)} />
+            </label>
+            <label style={{ display: "grid", gap: 4 }}>
+              <span>Co-applicant phone (optional)</span>
+              <input
+                inputMode="numeric"
+                value={coApplicantPhone}
+                onChange={(event) => setCoApplicantPhone(normalizePhoneInput(event.target.value))}
+              />
             </label>
             <div style={{ display: "grid", gridTemplateColumns: "repeat(3, minmax(0, 1fr))", gap: 8 }}>
               <label style={{ display: "grid", gap: 4 }}>

--- a/rentchain-frontend/src/pages/TenantsPage.test.tsx
+++ b/rentchain-frontend/src/pages/TenantsPage.test.tsx
@@ -288,4 +288,31 @@ describe("TenantsPage", () => {
       description: "Confirmed unit details by phone.",
     });
   });
+
+  it("filters hidden tenants from the active landlord list even if they are returned by the API", async () => {
+    mocks.useCapabilitiesMock.mockReturnValue({
+      features: { tenant_invites: true },
+    });
+    mocks.fetchTenantsMock.mockResolvedValue([
+      {
+        id: "tenant-hidden",
+        fullName: "Hidden Test Tenant",
+        hiddenFromActiveLists: true,
+      },
+      {
+        id: "tenant-visible",
+        fullName: "Visible Tenant",
+      },
+    ]);
+    mocks.fetchTenantTenanciesMock.mockResolvedValue([]);
+
+    render(
+      <MemoryRouter>
+        <TenantsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Visible Tenant")).toBeInTheDocument();
+    expect(screen.queryByText("Hidden Test Tenant")).not.toBeInTheDocument();
+  });
 });

--- a/rentchain-frontend/src/pages/TenantsPage.tsx
+++ b/rentchain-frontend/src/pages/TenantsPage.tsx
@@ -262,6 +262,7 @@ export const TenantsPage: React.FC = () => {
   const [tenantNote, setTenantNote] = useState<TenantNoteState>(EMPTY_TENANT_NOTE);
   const [savingTenantProfile, setSavingTenantProfile] = useState(false);
   const [savingTenantNote, setSavingTenantNote] = useState(false);
+  const [activityRefreshKey, setActivityRefreshKey] = useState(0);
   const [savingTenancyId, setSavingTenancyId] = useState<string | null>(null);
   const [occupancySaveError, setOccupancySaveError] = useState<string | null>(null);
   const [occupancyEditor, setOccupancyEditor] = useState<OccupancyEditorState>(EMPTY_EDITOR);
@@ -307,8 +308,9 @@ export const TenantsPage: React.FC = () => {
       setLoading(true);
       setError(null);
       const rows = await fetchTenants();
+      const visibleRows = rows.filter((tenant) => tenant?.hiddenFromActiveLists !== true);
       const enriched = await Promise.all(
-        rows.map(async (tenant) => {
+        visibleRows.map(async (tenant) => {
           if (!tenant?.id) return { ...tenant, tenancies: [] };
           try {
             const tenancies = Array.isArray(tenant.tenancies)
@@ -540,6 +542,7 @@ export const TenantsPage: React.FC = () => {
         description: `Saved to ${tenantNote.tenantName}'s timeline.`,
         variant: "success",
       });
+      setActivityRefreshKey((prev) => prev + 1);
       closeTenantNote();
     } catch (err: unknown) {
       showToast({
@@ -963,7 +966,9 @@ export const TenantsPage: React.FC = () => {
                     </div>
                   </div>
                 )}
-                {selectedTenantId && tenantExists && <TenantDetailPanel tenantId={selectedTenantId} />}
+                {selectedTenantId && tenantExists && (
+                  <TenantDetailPanel tenantId={selectedTenantId} activityRefreshKey={activityRefreshKey} />
+                )}
               </Section>
 
               <Section>


### PR DESCRIPTION
## Summary
- repair the `/properties` render crash by replacing the stale `leasedUnitNumbers` reference with deterministic lease-backed unit derivation that fails closed on partial data
- repair `/leases` conversion recovery with explicit blocked-vs-ready states, `Complete tenant info`, numeric-safe phone handling, optional co-applicant contact fields, and a small frontend-only lease search by tenant, unit, and property
- repair tenant workflow stability by hiding the exact known test tenants from active landlord lists, reading tenant notes from the canonical `tenantEvents` source, and fixing lease-info panel contrast

## Notes
- the five-ID tenant hide fallback is a temporary defensive layer and should be removed once data-side cleanup is confirmed in all environments
- the tenant note visibility repair reads from the canonical `tenantEvents` source rather than the ledger-only timeline
- the lease search is frontend-only and does not modify backend query or pagination behavior
- no new lint violations were introduced by this branch; remaining failures are pre-existing legacy debt in touched legacy files

## Verification
- targeted frontend tests passed
- targeted backend tests passed
- frontend build passed
- backend build passed
