### PR TITLE
feat: execution controls aggregation and operator queue visibility v1

### DIFF
--- a/rentchain-frontend/src/components/analytics/AgentDecisionPanel.tsx
+++ b/rentchain-frontend/src/components/analytics/AgentDecisionPanel.tsx
@@ -12,6 +12,7 @@ import {
   type LandlordAgentDecision,
 } from "@/api/landlordAnalyticsApi";
 import type { TimelineItem } from "@/api/timelineApi";
+import { deriveDecisionExecutionState } from "./decisionExecutionAggregation";
 import { blockedReasonDisplay, executionStateDisplay, formatExecutionSummary } from "./decisionExecutionDisplay";
 
 const priorityTone: Record<"low" | "medium" | "high", { bg: string; text: string }> = {
@@ -94,19 +95,6 @@ function supportingLine(decision: LandlordAgentDecision) {
 
 function formatExecutedCopy(executedAt?: string | null) {
   return `Notice sent${executedAt ? ` on ${new Date(executedAt).toLocaleDateString()}` : ""}.`;
-}
-
-function effectiveExecutionState(decision: LandlordAgentDecision): NonNullable<LandlordAgentDecision["executionState"]> {
-  if (decision.executionState) return decision.executionState;
-  if (decision.state === "executed") return "already_executed";
-  if (
-    decision.automationState === "ready" &&
-    decision.executionMappingState === "mapped" &&
-    decision.executionInputState === "complete"
-  ) {
-    return "executable";
-  }
-  return "blocked";
 }
 
 function effectiveBlockedReason(decision: LandlordAgentDecision): NonNullable<LandlordAgentDecision["blockedReason"]> | null {
@@ -232,7 +220,7 @@ function ActionDecisionCard(props: {
     : decision.href
       ? decision.recommendedAction
       : null;
-  const decisionExecutionState = effectiveExecutionState(decision);
+  const decisionExecutionState = deriveDecisionExecutionState(decision);
   const decisionBlockedReason = effectiveBlockedReason(decision);
   const canExecuteNow = decisionExecutionState === "executable";
   const governanceSummary = formatExecutionSummary(effectiveExecutionSummary(decision));

--- a/rentchain-frontend/src/components/analytics/DecisionQueueSummary.test.tsx
+++ b/rentchain-frontend/src/components/analytics/DecisionQueueSummary.test.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { LandlordAgentDecision } from "@/api/landlordAnalyticsApi";
+import DecisionQueueSummary from "./DecisionQueueSummary";
+
+afterEach(() => {
+  cleanup();
+});
+
+function buildDecision(
+  overrides?: Partial<LandlordAgentDecision>
+): LandlordAgentDecision {
+  return {
+    id: "decision-1",
+    decisionType: "review_lease_renewals",
+    priority: "medium",
+    explanation: "Review renewals",
+    supportingSignals: [],
+    recommendedAction: "Review renewals",
+    href: "/leases",
+    state: "pending",
+    reviewedAt: null,
+    actionKey: "open_lease_renewals_flow",
+    actionLabel: "Open lease renewals",
+    destination: "/leases",
+    workflowCategory: "lease_renewals",
+    automationEligible: false,
+    automationState: "blocked",
+    automationReason: "Blocked",
+    executionMappingState: "none",
+    executionMapping: null,
+    executionInputState: "none",
+    executionInputReason: null,
+    executionInputMissingFields: [],
+    executionInput: null,
+    executionState: undefined,
+    blockedReason: null,
+    executionGuardKey: null,
+    duplicateGuardActive: false,
+    executionSummary: undefined,
+    executedAt: null,
+    executionOutcomeStatus: "none",
+    executionOutcomeAt: null,
+    executionOutcomeReason: null,
+    ...overrides,
+  };
+}
+
+describe("DecisionQueueSummary", () => {
+  it("renders deterministic counts using the existing execution-state labels", () => {
+    render(
+      <DecisionQueueSummary
+        decisions={[
+          buildDecision({
+            id: "ready",
+            automationState: "ready",
+            executionMappingState: "mapped",
+            executionInputState: "complete",
+          }),
+          buildDecision({ id: "blocked" }),
+          buildDecision({ id: "executed", state: "executed" }),
+          buildDecision({ id: "duplicate", executionState: "unsafe_duplicate" }),
+        ]}
+        filter="all"
+        onFilterChange={() => undefined}
+      />
+    );
+
+    expect(screen.getByRole("region", { name: /Operator queue/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /All decisions · 4/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Ready to run · 1/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Action required · 1/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Completed · 1/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Already processed · 1/i })).toBeInTheDocument();
+  });
+
+  it("reflects the active in-memory filter state in the summary controls", () => {
+    render(
+      <DecisionQueueSummary
+        decisions={[buildDecision()]}
+        filter="blocked"
+        onFilterChange={() => undefined}
+      />
+    );
+
+    const blockedFilter = screen
+      .getAllByRole("button")
+      .find((element) => element.textContent === "Action required · 1");
+    const allFilter = screen
+      .getAllByRole("button")
+      .find((element) => element.textContent === "All decisions · 1");
+
+    expect(blockedFilter).toHaveAttribute("aria-pressed", "true");
+    expect(allFilter).toHaveAttribute("aria-pressed", "false");
+  });
+});

--- a/rentchain-frontend/src/components/analytics/DecisionQueueSummary.tsx
+++ b/rentchain-frontend/src/components/analytics/DecisionQueueSummary.tsx
@@ -1,0 +1,121 @@
+import React from "react";
+import type { LandlordAgentDecision } from "@/api/landlordAnalyticsApi";
+import { aggregateDecisionStates, type DecisionExecutionFilter } from "./decisionExecutionAggregation";
+import { executionStateDisplay } from "./decisionExecutionDisplay";
+
+type Props = {
+  decisions: LandlordAgentDecision[];
+  filter: DecisionExecutionFilter;
+  onFilterChange: (filter: DecisionExecutionFilter) => void;
+};
+
+const ORDERED_STATES = [
+  "executable",
+  "blocked",
+  "already_executed",
+  "unsafe_duplicate",
+] as const;
+
+function countLabel(value: number) {
+  return value === 1 ? "1 decision" : `${value} decisions`;
+}
+
+export default function DecisionQueueSummary(props: Props) {
+  const { decisions, filter, onFilterChange } = props;
+  const summary = aggregateDecisionStates(decisions);
+
+  return (
+    <section
+      aria-label="Operator queue"
+      style={{
+        display: "grid",
+        gap: 12,
+        padding: 16,
+        borderRadius: 16,
+        border: "1px solid #e2e8f0",
+        background: "#fff",
+      }}
+    >
+      <div style={{ display: "grid", gap: 4 }}>
+        <div style={{ fontSize: "0.78rem", fontWeight: 800, letterSpacing: "0.05em", textTransform: "uppercase", color: "#64748b" }}>
+          Operator queue
+        </div>
+        <div style={{ fontSize: "1.05rem", fontWeight: 700, color: "#0f172a" }}>
+          Portfolio-level execution state summary
+        </div>
+        <div style={{ color: "#475569", fontSize: "0.92rem" }}>
+          Scan what is ready now, what still needs attention, and what has already been handled.
+        </div>
+      </div>
+
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+        <button
+          type="button"
+          onClick={() => onFilterChange("all")}
+          aria-pressed={filter === "all"}
+          style={{
+            borderRadius: 999,
+            border: filter === "all" ? "1px solid #0f172a" : "1px solid #cbd5e1",
+            background: filter === "all" ? "#0f172a" : "#fff",
+            color: filter === "all" ? "#fff" : "#334155",
+            fontWeight: 700,
+            padding: "7px 12px",
+            cursor: "pointer",
+          }}
+        >
+          All decisions · {summary.total}
+        </button>
+        {ORDERED_STATES.map((state) => {
+          const display = executionStateDisplay[state];
+          const isActive = filter === state;
+          return (
+            <button
+              key={state}
+              type="button"
+              onClick={() => onFilterChange(state)}
+              aria-pressed={isActive}
+              style={{
+                borderRadius: 999,
+                border: `1px solid ${isActive ? display.badgeTone.border : "#cbd5e1"}`,
+                background: isActive ? display.badgeTone.bg : "#fff",
+                color: isActive ? display.badgeTone.text : "#334155",
+                fontWeight: 700,
+                padding: "7px 12px",
+                cursor: "pointer",
+              }}
+            >
+              {display.label} · {summary.counts[state]}
+            </button>
+          );
+        })}
+      </div>
+
+      <div style={{ display: "grid", gap: 10, gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))" }}>
+        {ORDERED_STATES.map((state) => {
+          const display = executionStateDisplay[state];
+          return (
+            <div
+              key={state}
+              style={{
+                display: "grid",
+                gap: 4,
+                padding: 12,
+                borderRadius: 12,
+                border: `1px solid ${display.badgeTone.border}`,
+                background: display.badgeTone.bg,
+              }}
+            >
+              <div style={{ fontSize: "0.82rem", fontWeight: 700, color: display.badgeTone.text }}>
+                {display.label}
+              </div>
+              <div style={{ fontSize: "1.3rem", fontWeight: 800, color: "#0f172a" }}>
+                {summary.counts[state]}
+              </div>
+              <div style={{ fontSize: "0.84rem", color: "#475569" }}>{countLabel(summary.counts[state])}</div>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/rentchain-frontend/src/components/analytics/decisionExecutionAggregation.test.ts
+++ b/rentchain-frontend/src/components/analytics/decisionExecutionAggregation.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import type { LandlordAgentDecision } from "@/api/landlordAnalyticsApi";
+import {
+  aggregateDecisionStates,
+  deriveDecisionExecutionState,
+  filterDecisionsByExecutionState,
+} from "./decisionExecutionAggregation";
+
+function buildDecision(
+  overrides?: Partial<LandlordAgentDecision>
+): LandlordAgentDecision {
+  return {
+    id: "decision-1",
+    decisionType: "review_lease_renewals",
+    priority: "medium",
+    explanation: "Review renewals",
+    supportingSignals: [],
+    recommendedAction: "Review renewals",
+    href: "/leases",
+    state: "pending",
+    reviewedAt: null,
+    actionKey: "open_lease_renewals_flow",
+    actionLabel: "Open lease renewals",
+    destination: "/leases",
+    workflowCategory: "lease_renewals",
+    automationEligible: false,
+    automationState: "blocked",
+    automationReason: "Blocked",
+    executionMappingState: "none",
+    executionMapping: null,
+    executionInputState: "none",
+    executionInputReason: null,
+    executionInputMissingFields: [],
+    executionInput: null,
+    executionState: undefined,
+    blockedReason: null,
+    executionGuardKey: null,
+    duplicateGuardActive: false,
+    executionSummary: undefined,
+    executedAt: null,
+    executionOutcomeStatus: "none",
+    executionOutcomeAt: null,
+    executionOutcomeReason: null,
+    ...overrides,
+  };
+}
+
+describe("decisionExecutionAggregation", () => {
+  it("derives execution state from existing decision fields when explicit state is absent", () => {
+    expect(
+      deriveDecisionExecutionState(
+        buildDecision({
+          automationState: "ready",
+          executionMappingState: "mapped",
+          executionInputState: "complete",
+        })
+      )
+    ).toBe("executable");
+
+    expect(deriveDecisionExecutionState(buildDecision({ state: "executed" }))).toBe("already_executed");
+    expect(
+      deriveDecisionExecutionState(buildDecision({ executionState: "unsafe_duplicate" }))
+    ).toBe("unsafe_duplicate");
+  });
+
+  it("aggregates counts by execution state deterministically", () => {
+    const decisions = [
+      buildDecision({
+        id: "ready",
+        automationState: "ready",
+        executionMappingState: "mapped",
+        executionInputState: "complete",
+      }),
+      buildDecision({ id: "blocked" }),
+      buildDecision({ id: "executed", state: "executed" }),
+      buildDecision({ id: "duplicate", executionState: "unsafe_duplicate" }),
+    ];
+
+    expect(aggregateDecisionStates(decisions)).toEqual({
+      total: 4,
+      counts: {
+        executable: 1,
+        blocked: 1,
+        already_executed: 1,
+        unsafe_duplicate: 1,
+      },
+    });
+  });
+
+  it("filters the in-memory decision list by execution state", () => {
+    const ready = buildDecision({
+      id: "ready",
+      automationState: "ready",
+      executionMappingState: "mapped",
+      executionInputState: "complete",
+    });
+    const blocked = buildDecision({ id: "blocked" });
+
+    expect(filterDecisionsByExecutionState([ready, blocked], "all")).toEqual([ready, blocked]);
+    expect(filterDecisionsByExecutionState([ready, blocked], "executable")).toEqual([ready]);
+    expect(filterDecisionsByExecutionState([ready, blocked], "blocked")).toEqual([blocked]);
+  });
+});

--- a/rentchain-frontend/src/components/analytics/decisionExecutionAggregation.ts
+++ b/rentchain-frontend/src/components/analytics/decisionExecutionAggregation.ts
@@ -1,0 +1,54 @@
+import type {
+  LandlordAgentDecision,
+  LandlordDecisionExecutionState,
+} from "@/api/landlordAnalyticsApi";
+
+export type DecisionExecutionFilter = LandlordDecisionExecutionState | "all";
+
+export type DecisionExecutionAggregate = {
+  total: number;
+  counts: Record<LandlordDecisionExecutionState, number>;
+};
+
+export function deriveDecisionExecutionState(
+  decision: LandlordAgentDecision
+): LandlordDecisionExecutionState {
+  if (decision.executionState) return decision.executionState;
+  if (decision.state === "executed") return "already_executed";
+  if (
+    decision.automationState === "ready" &&
+    decision.executionMappingState === "mapped" &&
+    decision.executionInputState === "complete"
+  ) {
+    return "executable";
+  }
+  return "blocked";
+}
+
+export function aggregateDecisionStates(
+  decisions: LandlordAgentDecision[]
+): DecisionExecutionAggregate {
+  const counts: Record<LandlordDecisionExecutionState, number> = {
+    executable: 0,
+    blocked: 0,
+    already_executed: 0,
+    unsafe_duplicate: 0,
+  };
+
+  for (const decision of decisions) {
+    counts[deriveDecisionExecutionState(decision)] += 1;
+  }
+
+  return {
+    total: decisions.length,
+    counts,
+  };
+}
+
+export function filterDecisionsByExecutionState(
+  decisions: LandlordAgentDecision[],
+  filter: DecisionExecutionFilter
+) {
+  if (filter === "all") return decisions;
+  return decisions.filter((decision) => deriveDecisionExecutionState(decision) === filter);
+}

--- a/rentchain-frontend/src/pages/landlord/ActionRecommendationsPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/ActionRecommendationsPage.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import type { LandlordAnalyticsSnapshot } from "../../api/landlordAnalyticsApi";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import ActionRecommendationsPage from "./ActionRecommendationsPage";
@@ -171,6 +171,106 @@ describe("ActionRecommendationsPage", () => {
     const actionLinks = screen.getAllByRole("link");
     expect(actionLinks.map((node) => node.textContent)).toEqual(["Open lease renewals", "Open vacancy readiness"]);
     expect(screen.getByText(/Workflow: Lease renewals/i)).toBeInTheDocument();
+  });
+
+  it("shows an operator queue summary and filters the current inbox in memory", async () => {
+    await mockEntitlements();
+    const { fetchLandlordAnalyticsSnapshot } = await import("../../api/landlordAnalyticsApi");
+    vi.mocked(fetchLandlordAnalyticsSnapshot).mockResolvedValue({
+      decisionOutcomeAnalytics: {
+        scope: "landlord_all_time",
+        appearedCount: 4,
+        reviewedCount: 1,
+        dismissedCount: 0,
+        executedCount: 1,
+        failedExecutionCount: 0,
+        resolvedCount: 2,
+        resolutionRate: 0.5,
+        medianTimeToResolutionHours: 12,
+        averageTimeToExecutionHours: 8,
+      },
+      decisions: {
+        items: [
+          {
+            id: "ready",
+            decisionType: "start_screening_checkout",
+            priority: "medium",
+            explanation: "A screening checkout can start now.",
+            recommendedAction: "Start screening checkout",
+            actionKey: "open_screening_checkout_flow",
+            actionLabel: "Open screening checkout",
+            destination: "/applications/app-1",
+            workflowCategory: "screening_checkout",
+            automationEligible: true,
+            automationState: "ready",
+            automationReason: null,
+            executionMappingState: "mapped",
+            executionMapping: {
+              action: "screening.auto_start_checkout",
+              resourceType: "rental_application",
+              resourceId: "app-1",
+              prerequisitesMet: true,
+              prerequisiteReason: null,
+            },
+            executionInputState: "complete",
+            executionInputReason: null,
+            executionInputMissingFields: [],
+            executionInput: null,
+            executedAt: null,
+            executionOutcomeStatus: "none",
+            executionOutcomeAt: null,
+            executionOutcomeReason: null,
+            href: "/applications/app-1",
+            state: "pending",
+            reviewedAt: null,
+            supportingSignals: [],
+          },
+          {
+            id: "blocked",
+            decisionType: "review_lease_renewals",
+            priority: "medium",
+            explanation: "Renewal inputs are still incomplete.",
+            recommendedAction: "Review renewals",
+            actionKey: "open_lease_renewals_flow",
+            actionLabel: "Open lease renewals",
+            destination: "/leases",
+            workflowCategory: "lease_renewals",
+            automationEligible: false,
+            automationState: "blocked",
+            automationReason: "Inputs missing",
+            executionMappingState: "none",
+            executionMapping: null,
+            executionInputState: "none",
+            executionInputReason: null,
+            executionInputMissingFields: [],
+            executionInput: null,
+            executedAt: null,
+            executionOutcomeStatus: "none",
+            executionOutcomeAt: null,
+            executionOutcomeReason: null,
+            href: "/leases",
+            state: "pending",
+            reviewedAt: null,
+            supportingSignals: [],
+          },
+        ],
+      },
+    } as LandlordAnalyticsSnapshot);
+
+    render(
+      <MemoryRouter>
+        <ActionRecommendationsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole("region", { name: /Operator queue/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Ready to run · 1/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Action required · 1/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Ready to run · 1/i }));
+
+    expect(screen.getByText(/A screening checkout can start now/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Renewal inputs are still incomplete/i)).not.toBeInTheDocument();
   });
 
   it("renders a clean empty state when the snapshot has no decisions", async () => {

--- a/rentchain-frontend/src/pages/landlord/ActionRecommendationsPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/ActionRecommendationsPage.tsx
@@ -8,7 +8,14 @@ import { LockedFeature } from "@/components/billing/LockedFeature";
 import { FeatureTeaser } from "@/components/billing/FeatureTeaser";
 import { resolveRequiredPlanLabel } from "@/lib/upgradePrompt";
 import AgentDecisionPanel from "../../components/analytics/AgentDecisionPanel";
+import DecisionQueueSummary from "../../components/analytics/DecisionQueueSummary";
 import DecisionOutcomeAnalyticsPanel from "../../components/analytics/DecisionOutcomeAnalyticsPanel";
+import {
+  filterDecisionsByExecutionState,
+  type DecisionExecutionFilter,
+} from "../../components/analytics/decisionExecutionAggregation";
+
+const EMPTY_DECISIONS: LandlordAnalyticsSnapshot["decisions"]["items"] = [];
 
 function errorMessage(error: unknown) {
   if (error instanceof Error && error.message) return error.message;
@@ -26,8 +33,14 @@ export default function ActionRecommendationsPage() {
   const [snapshot, setSnapshot] = React.useState<LandlordAnalyticsSnapshot | null>(null);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
+  const [executionFilter, setExecutionFilter] = React.useState<DecisionExecutionFilter>("all");
   const canViewAnalyticsDecisions = canViewPortfolioScore && hasCapability("portfolio_analytics");
   const canViewDecisionInbox = canViewActionRecommendations && canViewAnalyticsDecisions;
+  const decisions = snapshot?.decisions?.items ?? EMPTY_DECISIONS;
+  const filteredDecisions = React.useMemo(
+    () => filterDecisionsByExecutionState(decisions, executionFilter),
+    [decisions, executionFilter]
+  );
 
   React.useEffect(() => {
     if (entitlementLoading || !canViewDecisionInbox) {
@@ -113,8 +126,13 @@ export default function ActionRecommendationsPage() {
         {!entitlementLoading && canViewDecisionInbox && !loading && !error ? (
           <>
             <DecisionOutcomeAnalyticsPanel analytics={snapshot?.decisionOutcomeAnalytics} />
+            <DecisionQueueSummary
+              decisions={decisions}
+              filter={executionFilter}
+              onFilterChange={setExecutionFilter}
+            />
             <AgentDecisionPanel
-              decisions={snapshot?.decisions?.items || []}
+              decisions={filteredDecisions}
               title="Decision inbox"
               description="Review the next landlord actions surfaced directly from your current analytics snapshot."
               emptyMessage="No prioritized landlord actions are surfaced for this view right now."

--- a/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.test.tsx
@@ -512,6 +512,24 @@ describe("LandlordAnalyticsPage", () => {
     expect(macShellSpy).toHaveBeenCalledWith(expect.objectContaining({ title: "Analytics", showTopNav: false }));
   });
 
+  it("shows an operator queue summary above the analytics decision list", async () => {
+    await mockEntitlements();
+    await mockApiResolved();
+
+    render(
+      <MemoryRouter>
+        <LandlordAnalyticsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole("region", { name: /Operator queue/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Action required · 1/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Action required · 1/i }));
+
+    expect(screen.getByText(/Beta carries the strongest vacancy pressure/i)).toBeInTheDocument();
+  });
+
   it("hydrates analytics focus from destination query params", async () => {
     await mockEntitlements();
     const fetchLandlordAnalyticsSnapshot = await mockApiResolved();

--- a/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.tsx
@@ -19,10 +19,17 @@ import AgentDecisionPanel from "../../components/analytics/AgentDecisionPanel";
 import AnalyticsFiltersBar from "../../components/analytics/AnalyticsFiltersBar";
 import AnalyticsKpiGrid from "../../components/analytics/AnalyticsKpiGrid";
 import AnalyticsSectionPanel from "../../components/analytics/AnalyticsSectionPanel";
+import DecisionQueueSummary from "../../components/analytics/DecisionQueueSummary";
 import DecisionOutcomeAnalyticsPanel from "../../components/analytics/DecisionOutcomeAnalyticsPanel";
 import InsightCardsPanel from "../../components/analytics/InsightCardsPanel";
 import PortfolioBenchmarkingPanel from "../../components/analytics/PortfolioBenchmarkingPanel";
 import PredictiveMetricsPanel from "../../components/analytics/PredictiveMetricsPanel";
+import {
+  filterDecisionsByExecutionState,
+  type DecisionExecutionFilter,
+} from "../../components/analytics/decisionExecutionAggregation";
+
+const EMPTY_DECISIONS: LandlordAnalyticsSnapshot["decisions"]["items"] = [];
 
 function errorMessage(error: unknown) {
   if (error instanceof Error && error.message) return error.message;
@@ -143,6 +150,7 @@ export default function LandlordAnalyticsPage() {
   } = useEntitlements();
   const [period, setPeriod] = React.useState<AnalyticsPeriod>("90d");
   const [propertyId, setPropertyId] = React.useState("");
+  const [executionFilter, setExecutionFilter] = React.useState<DecisionExecutionFilter>("all");
   const urlParams = React.useMemo(() => new URLSearchParams(location.search), [location.search]);
   const routedPropertyId = urlParams.get("propertyId");
   const routedEntryLabel = entryLabel(urlParams.get("entry"));
@@ -166,6 +174,11 @@ export default function LandlordAnalyticsPage() {
   const leasingDeltas = snapshot?.comparisons?.deltas?.leasing;
   const maintenanceDeltas = snapshot?.comparisons?.deltas?.maintenance;
   const revenueDeltas = snapshot?.comparisons?.deltas?.revenue;
+  const decisions = snapshot?.decisions?.items ?? EMPTY_DECISIONS;
+  const filteredDecisions = React.useMemo(
+    () => filterDecisionsByExecutionState(decisions, executionFilter),
+    [decisions, executionFilter]
+  );
 
   const summaryItems = snapshot
     ? [
@@ -260,8 +273,13 @@ export default function LandlordAnalyticsPage() {
             {canViewPortfolioScore && canViewAdvancedAnalytics ? (
               <>
                 <DecisionOutcomeAnalyticsPanel analytics={snapshot.decisionOutcomeAnalytics} />
+                <DecisionQueueSummary
+                  decisions={decisions}
+                  filter={executionFilter}
+                  onFilterChange={setExecutionFilter}
+                />
                 <AgentDecisionPanel
-                  decisions={snapshot.decisions?.items || []}
+                  decisions={filteredDecisions}
                   period={period}
                   propertyId={propertyId}
                 />


### PR DESCRIPTION
## Summary
- add a read-only operator queue summary to `/analytics` and `/actions`
- aggregate existing decision execution states into portfolio-level counts using a shared helper
- add deterministic in-memory filtering by execution state without changing backend contracts, decision derivation, readiness, or execution behavior

## Verification
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 >/dev/null && npm test -- --run src/components/analytics/decisionExecutionAggregation.test.ts src/components/analytics/DecisionQueueSummary.test.tsx src/components/analytics/decisionExecutionDisplay.test.ts src/components/analytics/AgentDecisionPanel.test.tsx src/pages/landlord/ActionRecommendationsPage.test.tsx src/pages/landlord/LandlordAnalyticsPage.test.tsx`
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 >/dev/null && npm run build`
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 >/dev/null && ./node_modules/.bin/eslint src/components/analytics/decisionExecutionAggregation.ts src/components/analytics/decisionExecutionAggregation.test.ts src/components/analytics/DecisionQueueSummary.tsx src/components/analytics/DecisionQueueSummary.test.tsx src/components/analytics/AgentDecisionPanel.tsx src/pages/landlord/ActionRecommendationsPage.tsx src/pages/landlord/ActionRecommendationsPage.test.tsx src/pages/landlord/LandlordAnalyticsPage.tsx src/pages/landlord/LandlordAnalyticsPage.test.tsx`