### PR TITLE
feat: add decision prioritization v1

### DIFF
--- a/rentchain-frontend/src/components/analytics/decisionExecutionAggregation.test.ts
+++ b/rentchain-frontend/src/components/analytics/decisionExecutionAggregation.test.ts
@@ -4,6 +4,7 @@ import {
   aggregateDecisionStates,
   deriveDecisionExecutionState,
   filterDecisionsByExecutionState,
+  prioritizeDecisions,
 } from "./decisionExecutionAggregation";
 
 function buildDecision(
@@ -99,5 +100,32 @@ describe("decisionExecutionAggregation", () => {
     expect(filterDecisionsByExecutionState([ready, blocked], "all")).toEqual([ready, blocked]);
     expect(filterDecisionsByExecutionState([ready, blocked], "executable")).toEqual([ready]);
     expect(filterDecisionsByExecutionState([ready, blocked], "blocked")).toEqual([blocked]);
+  });
+
+  it("prioritizes decisions by execution state, then by existing decision priority", () => {
+    const ready = buildDecision({
+      id: "ready",
+      priority: "low",
+      automationState: "ready",
+      executionMappingState: "mapped",
+      executionInputState: "complete",
+    });
+    const blockedHigh = buildDecision({ id: "blocked-high", priority: "high" });
+    const duplicate = buildDecision({ id: "duplicate", executionState: "unsafe_duplicate", priority: "high" });
+    const executed = buildDecision({ id: "executed", state: "executed", priority: "high" });
+
+    expect(prioritizeDecisions([executed, duplicate, blockedHigh, ready]).map((decision) => decision.id)).toEqual([
+      "ready",
+      "blocked-high",
+      "duplicate",
+      "executed",
+    ]);
+  });
+
+  it("keeps original input order when decisions tie on state and priority", () => {
+    const first = buildDecision({ id: "first", priority: "medium" });
+    const second = buildDecision({ id: "second", priority: "medium" });
+
+    expect(prioritizeDecisions([first, second]).map((decision) => decision.id)).toEqual(["first", "second"]);
   });
 });

--- a/rentchain-frontend/src/components/analytics/decisionExecutionAggregation.ts
+++ b/rentchain-frontend/src/components/analytics/decisionExecutionAggregation.ts
@@ -10,6 +10,19 @@ export type DecisionExecutionAggregate = {
   counts: Record<LandlordDecisionExecutionState, number>;
 };
 
+const EXECUTION_STATE_PRIORITY: Record<LandlordDecisionExecutionState, number> = {
+  executable: 0,
+  blocked: 1,
+  unsafe_duplicate: 2,
+  already_executed: 3,
+};
+
+const DECISION_PRIORITY_WEIGHT: Record<LandlordAgentDecision["priority"], number> = {
+  high: 0,
+  medium: 1,
+  low: 2,
+};
+
 export function deriveDecisionExecutionState(
   decision: LandlordAgentDecision
 ): LandlordDecisionExecutionState {
@@ -51,4 +64,23 @@ export function filterDecisionsByExecutionState(
 ) {
   if (filter === "all") return decisions;
   return decisions.filter((decision) => deriveDecisionExecutionState(decision) === filter);
+}
+
+export function prioritizeDecisions(decisions: LandlordAgentDecision[]) {
+  return decisions
+    .map((decision, index) => ({ decision, index }))
+    .sort((left, right) => {
+      const stateDelta =
+        EXECUTION_STATE_PRIORITY[deriveDecisionExecutionState(left.decision)] -
+        EXECUTION_STATE_PRIORITY[deriveDecisionExecutionState(right.decision)];
+      if (stateDelta !== 0) return stateDelta;
+
+      const decisionPriorityDelta =
+        DECISION_PRIORITY_WEIGHT[left.decision.priority] -
+        DECISION_PRIORITY_WEIGHT[right.decision.priority];
+      if (decisionPriorityDelta !== 0) return decisionPriorityDelta;
+
+      return left.index - right.index;
+    })
+    .map(({ decision }) => decision);
 }

--- a/rentchain-frontend/src/pages/landlord/ActionRecommendationsPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/ActionRecommendationsPage.test.tsx
@@ -77,7 +77,7 @@ describe("ActionRecommendationsPage", () => {
     });
   }
 
-  it("renders centralized inbox decisions from the analytics snapshot in server order", async () => {
+  it("renders the decision inbox in deterministic operator priority order", async () => {
     await mockEntitlements();
     const { fetchLandlordAnalyticsSnapshot } = await import("../../api/landlordAnalyticsApi");
     vi.mocked(fetchLandlordAnalyticsSnapshot).mockResolvedValue({
@@ -169,8 +169,170 @@ describe("ActionRecommendationsPage", () => {
     expect(fetchLandlordAnalyticsSnapshot).toHaveBeenCalledTimes(1);
 
     const actionLinks = screen.getAllByRole("link");
-    expect(actionLinks.map((node) => node.textContent)).toEqual(["Open lease renewals", "Open vacancy readiness"]);
+    expect(actionLinks.map((node) => node.textContent)).toEqual(["Open vacancy readiness", "Open lease renewals"]);
     expect(screen.getByText(/Workflow: Lease renewals/i)).toBeInTheDocument();
+  });
+
+  it("keeps safer operator states below ready and blocked decisions", async () => {
+    await mockEntitlements();
+    const { fetchLandlordAnalyticsSnapshot } = await import("../../api/landlordAnalyticsApi");
+    vi.mocked(fetchLandlordAnalyticsSnapshot).mockResolvedValue({
+      decisionOutcomeAnalytics: {
+        scope: "landlord_all_time",
+        appearedCount: 4,
+        reviewedCount: 0,
+        dismissedCount: 0,
+        executedCount: 2,
+        failedExecutionCount: 0,
+        resolvedCount: 2,
+        resolutionRate: 0.5,
+        medianTimeToResolutionHours: 12,
+        averageTimeToExecutionHours: 8,
+      },
+      decisions: {
+        items: [
+          {
+            id: "executed",
+            decisionType: "review_lease_renewals",
+            priority: "high",
+            explanation: "Already completed.",
+            recommendedAction: "Completed decision",
+            actionKey: "open_lease_renewals_flow",
+            actionLabel: "Open completed decision",
+            destination: "/leases/completed",
+            workflowCategory: "lease_renewals",
+            automationEligible: true,
+            automationState: "ready",
+            automationReason: null,
+            executionMappingState: "mapped",
+            executionMapping: null,
+            executionInputState: "complete",
+            executionInputReason: null,
+            executionInputMissingFields: [],
+            executionInput: null,
+            executedAt: "2026-04-22T12:00:00.000Z",
+            executionOutcomeStatus: "succeeded",
+            executionOutcomeAt: "2026-04-22T12:00:00.000Z",
+            executionOutcomeReason: null,
+            href: "/leases/completed",
+            state: "executed",
+            reviewedAt: null,
+            supportingSignals: [],
+          },
+          {
+            id: "duplicate",
+            decisionType: "approve_maintenance_cost",
+            priority: "high",
+            explanation: "Already processed once.",
+            recommendedAction: "Duplicate guarded decision",
+            actionKey: "open_maintenance_cost_approval_flow",
+            actionLabel: "Open duplicate guard",
+            destination: "/maintenance/duplicate",
+            workflowCategory: "maintenance_cost_approval",
+            automationEligible: true,
+            automationState: "ready",
+            automationReason: null,
+            executionMappingState: "mapped",
+            executionMapping: null,
+            executionInputState: "complete",
+            executionInputReason: null,
+            executionInputMissingFields: [],
+            executionInput: null,
+            executionState: "unsafe_duplicate",
+            executedAt: null,
+            executionOutcomeStatus: "none",
+            executionOutcomeAt: null,
+            executionOutcomeReason: null,
+            href: "/maintenance/duplicate",
+            state: "pending",
+            reviewedAt: null,
+            supportingSignals: [],
+          },
+          {
+            id: "blocked",
+            decisionType: "review_lease_renewals",
+            priority: "medium",
+            explanation: "Still blocked.",
+            recommendedAction: "Blocked decision",
+            actionKey: "open_lease_renewals_flow",
+            actionLabel: "Open blocked decision",
+            destination: "/leases/blocked",
+            workflowCategory: "lease_renewals",
+            automationEligible: false,
+            automationState: "blocked",
+            automationReason: "Inputs missing",
+            executionMappingState: "none",
+            executionMapping: null,
+            executionInputState: "none",
+            executionInputReason: null,
+            executionInputMissingFields: [],
+            executionInput: null,
+            executedAt: null,
+            executionOutcomeStatus: "none",
+            executionOutcomeAt: null,
+            executionOutcomeReason: null,
+            href: "/leases/blocked",
+            state: "pending",
+            reviewedAt: null,
+            supportingSignals: [],
+          },
+          {
+            id: "ready",
+            decisionType: "start_screening_checkout",
+            priority: "low",
+            explanation: "Ready to run now.",
+            recommendedAction: "Ready decision",
+            actionKey: "open_screening_checkout_flow",
+            actionLabel: "Open ready decision",
+            destination: "/applications/ready",
+            workflowCategory: "screening_checkout",
+            automationEligible: true,
+            automationState: "ready",
+            automationReason: null,
+            executionMappingState: "mapped",
+            executionMapping: null,
+            executionInputState: "complete",
+            executionInputReason: null,
+            executionInputMissingFields: [],
+            executionInput: null,
+            executedAt: null,
+            executionOutcomeStatus: "none",
+            executionOutcomeAt: null,
+            executionOutcomeReason: null,
+            href: "/applications/ready",
+            state: "pending",
+            reviewedAt: null,
+            supportingSignals: [],
+          },
+        ],
+      },
+    } as LandlordAnalyticsSnapshot);
+
+    render(
+      <MemoryRouter>
+        <ActionRecommendationsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole("heading", { name: /Decision inbox/i })).toBeInTheDocument();
+
+    const actionLinks = screen
+      .getAllByRole("link")
+      .map((node) => node.textContent)
+      .filter((value) =>
+        [
+          "Open ready decision",
+          "Open blocked decision",
+          "Open duplicate guard",
+          "Open completed decision",
+        ].includes(value || "")
+      );
+
+    expect(actionLinks).toEqual([
+      "Open ready decision",
+      "Open blocked decision",
+      "Open duplicate guard",
+    ]);
   });
 
   it("shows an operator queue summary and filters the current inbox in memory", async () => {

--- a/rentchain-frontend/src/pages/landlord/ActionRecommendationsPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/ActionRecommendationsPage.tsx
@@ -12,6 +12,7 @@ import DecisionQueueSummary from "../../components/analytics/DecisionQueueSummar
 import DecisionOutcomeAnalyticsPanel from "../../components/analytics/DecisionOutcomeAnalyticsPanel";
 import {
   filterDecisionsByExecutionState,
+  prioritizeDecisions,
   type DecisionExecutionFilter,
 } from "../../components/analytics/decisionExecutionAggregation";
 
@@ -41,6 +42,7 @@ export default function ActionRecommendationsPage() {
     () => filterDecisionsByExecutionState(decisions, executionFilter),
     [decisions, executionFilter]
   );
+  const prioritizedDecisions = React.useMemo(() => prioritizeDecisions(filteredDecisions), [filteredDecisions]);
 
   React.useEffect(() => {
     if (entitlementLoading || !canViewDecisionInbox) {
@@ -132,7 +134,7 @@ export default function ActionRecommendationsPage() {
               onFilterChange={setExecutionFilter}
             />
             <AgentDecisionPanel
-              decisions={filteredDecisions}
+              decisions={prioritizedDecisions}
               title="Decision inbox"
               description="Review the next landlord actions surfaced directly from your current analytics snapshot."
               emptyMessage="No prioritized landlord actions are surfaced for this view right now."

--- a/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.test.tsx
@@ -530,6 +530,251 @@ describe("LandlordAnalyticsPage", () => {
     expect(screen.getByText(/Beta carries the strongest vacancy pressure/i)).toBeInTheDocument();
   });
 
+  it("renders analytics decisions in deterministic operator priority order", async () => {
+    await mockEntitlements();
+    const { fetchLandlordAnalyticsSnapshot } = await import("../../api/landlordAnalyticsApi");
+    const { fetchLandlordAnalyticsAlerts } = await import("../../api/landlordAnalyticsAlertsApi");
+    const { fetchLandlordAnalyticsBenchmarking } = await import("../../api/landlordAnalyticsBenchmarkingApi");
+
+    vi.mocked(fetchLandlordAnalyticsSnapshot).mockResolvedValue({
+      summary: {
+        occupiedUnits: 4,
+        vacancyRate: 0.2,
+        activeApplications: 2,
+        applicationConversionRate: 0.5,
+        openWorkOrders: 1,
+        maintenanceCostCents: 12500,
+        estimatedScheduledRentCents: 660000,
+        leasesEndingSoon: 1,
+      },
+      applications: {
+        started: 4,
+        submitted: 3,
+        approved: 2,
+        rejected: 0,
+        declined: 0,
+        pendingReviewCount: 2,
+        conversionRate: 0.5,
+      },
+      leasing: {
+        totalProperties: 2,
+        totalUnits: 5,
+        occupiedUnits: 4,
+        vacantUnits: 1,
+        occupancyRate: 0.8,
+        leasesEndingIn30Days: 1,
+        leasesEndingIn60Days: 1,
+        leasesEndingIn90Days: 2,
+        turnoverCount: 0,
+      },
+      maintenance: {
+        openWorkOrders: 1,
+        completedWorkOrders: 2,
+        reopenedWorkOrders: 0,
+        maintenanceCostCents: 12500,
+        averageCostPerCompletedWorkOrderCents: 6250,
+        costConcentrationByProperty: [],
+      },
+      revenue: {
+        estimatedScheduledRentCents: 660000,
+        averageRentPerOccupiedUnitCents: 165000,
+      },
+      decisionOutcomeAnalytics: {
+        scope: "landlord_all_time",
+        appearedCount: 4,
+        reviewedCount: 1,
+        dismissedCount: 0,
+        executedCount: 1,
+        failedExecutionCount: 0,
+        resolvedCount: 2,
+        resolutionRate: 0.5,
+        medianTimeToResolutionHours: 12,
+        averageTimeToExecutionHours: 8,
+      },
+      decisions: {
+        items: [
+          {
+            id: "executed",
+            decisionType: "review_lease_renewals",
+            priority: "high",
+            explanation: "Completed decision explanation.",
+            recommendedAction: "Completed decision",
+            actionKey: "open_lease_renewals_flow",
+            actionLabel: "Open completed decision",
+            destination: "/analytics/completed",
+            workflowCategory: "lease_renewals",
+            automationEligible: true,
+            automationState: "ready",
+            automationReason: null,
+            executionMappingState: "mapped",
+            executionMapping: null,
+            executionInputState: "complete",
+            executionInputReason: null,
+            executionInputMissingFields: [],
+            executionInput: null,
+            executedAt: "2026-04-22T12:00:00.000Z",
+            executionOutcomeStatus: "succeeded",
+            executionOutcomeAt: "2026-04-22T12:00:00.000Z",
+            executionOutcomeReason: null,
+            href: "/analytics/completed",
+            state: "executed",
+            reviewedAt: null,
+            supportingSignals: [],
+          },
+          {
+            id: "blocked",
+            decisionType: "review_lease_renewals",
+            priority: "medium",
+            explanation: "Blocked decision explanation.",
+            recommendedAction: "Blocked decision",
+            actionKey: "open_lease_renewals_flow",
+            actionLabel: "Open blocked decision",
+            destination: "/analytics/blocked",
+            workflowCategory: "lease_renewals",
+            automationEligible: false,
+            automationState: "blocked",
+            automationReason: "Inputs missing",
+            executionMappingState: "none",
+            executionMapping: null,
+            executionInputState: "none",
+            executionInputReason: null,
+            executionInputMissingFields: [],
+            executionInput: null,
+            executedAt: null,
+            executionOutcomeStatus: "none",
+            executionOutcomeAt: null,
+            executionOutcomeReason: null,
+            href: "/analytics/blocked",
+            state: "pending",
+            reviewedAt: null,
+            supportingSignals: [],
+          },
+          {
+            id: "ready",
+            decisionType: "start_screening_checkout",
+            priority: "low",
+            explanation: "Ready decision explanation.",
+            recommendedAction: "Ready decision",
+            actionKey: "open_screening_checkout_flow",
+            actionLabel: "Open ready decision",
+            destination: "/analytics/ready",
+            workflowCategory: "screening_checkout",
+            automationEligible: true,
+            automationState: "ready",
+            automationReason: null,
+            executionMappingState: "mapped",
+            executionMapping: null,
+            executionInputState: "complete",
+            executionInputReason: null,
+            executionInputMissingFields: [],
+            executionInput: null,
+            executedAt: null,
+            executionOutcomeStatus: "none",
+            executionOutcomeAt: null,
+            executionOutcomeReason: null,
+            href: "/analytics/ready",
+            state: "pending",
+            reviewedAt: null,
+            supportingSignals: [],
+          },
+          {
+            id: "duplicate",
+            decisionType: "approve_maintenance_cost",
+            priority: "high",
+            explanation: "Duplicate decision explanation.",
+            recommendedAction: "Duplicate decision",
+            actionKey: "open_maintenance_cost_approval_flow",
+            actionLabel: "Open duplicate decision",
+            destination: "/analytics/duplicate",
+            workflowCategory: "maintenance_cost_approval",
+            automationEligible: true,
+            automationState: "ready",
+            automationReason: null,
+            executionMappingState: "mapped",
+            executionMapping: null,
+            executionInputState: "complete",
+            executionInputReason: null,
+            executionInputMissingFields: [],
+            executionInput: null,
+            executionState: "unsafe_duplicate",
+            executedAt: null,
+            executionOutcomeStatus: "none",
+            executionOutcomeAt: null,
+            executionOutcomeReason: null,
+            href: "/analytics/duplicate",
+            state: "pending",
+            reviewedAt: null,
+            supportingSignals: [],
+          },
+        ],
+      },
+      predictive: { metrics: [] },
+      insights: [],
+      comparisons: buildComparisons(),
+      properties: [{ id: "prop-1", name: "Alpha" }],
+      propertyMetrics: [],
+      filters: {
+        period: "90d",
+        propertyId: null,
+        from: "2026-01-20T00:00:00.000Z",
+        to: "2026-04-20T00:00:00.000Z",
+      },
+    } as LandlordAnalyticsSnapshot);
+
+    vi.mocked(fetchLandlordAnalyticsAlerts).mockResolvedValue({
+      summary: {
+        activeCount: 0,
+        highSeverityCount: 0,
+        mediumSeverityCount: 0,
+        lowSeverityCount: 0,
+      },
+      alerts: [],
+      filters: { period: "90d", propertyId: null, status: "active" },
+    } as LandlordAnalyticsAlertsResponse);
+
+    vi.mocked(fetchLandlordAnalyticsBenchmarking).mockResolvedValue({
+      summary: {
+        propertyCount: 0,
+        comparedPropertyCount: 0,
+        benchmarkDimensions: [],
+      },
+      comparisons: [],
+      insights: [],
+      filters: {
+        period: "90d",
+        propertyId: null,
+        from: "2026-01-20T00:00:00.000Z",
+        to: "2026-04-20T00:00:00.000Z",
+      },
+    } as LandlordAnalyticsBenchmarkingResponse);
+
+    render(
+      <MemoryRouter>
+        <LandlordAnalyticsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole("heading", { name: /Recommended next actions/i })).toBeInTheDocument();
+
+    const actionLinks = screen
+      .getAllByRole("link")
+      .map((node) => node.textContent)
+      .filter((value) =>
+        [
+          "Open ready decision",
+          "Open blocked decision",
+          "Open duplicate decision",
+          "Open completed decision",
+        ].includes(value || "")
+      );
+
+    expect(actionLinks).toEqual([
+      "Open ready decision",
+      "Open blocked decision",
+      "Open duplicate decision",
+    ]);
+  });
+
   it("hydrates analytics focus from destination query params", async () => {
     await mockEntitlements();
     const fetchLandlordAnalyticsSnapshot = await mockApiResolved();

--- a/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.tsx
@@ -26,6 +26,7 @@ import PortfolioBenchmarkingPanel from "../../components/analytics/PortfolioBenc
 import PredictiveMetricsPanel from "../../components/analytics/PredictiveMetricsPanel";
 import {
   filterDecisionsByExecutionState,
+  prioritizeDecisions,
   type DecisionExecutionFilter,
 } from "../../components/analytics/decisionExecutionAggregation";
 
@@ -179,6 +180,7 @@ export default function LandlordAnalyticsPage() {
     () => filterDecisionsByExecutionState(decisions, executionFilter),
     [decisions, executionFilter]
   );
+  const prioritizedDecisions = React.useMemo(() => prioritizeDecisions(filteredDecisions), [filteredDecisions]);
 
   const summaryItems = snapshot
     ? [
@@ -279,7 +281,7 @@ export default function LandlordAnalyticsPage() {
                   onFilterChange={setExecutionFilter}
                 />
                 <AgentDecisionPanel
-                  decisions={filteredDecisions}
+                  decisions={prioritizedDecisions}
                   period={period}
                   propertyId={propertyId}
                 />


### PR DESCRIPTION
## Summary
- add deterministic frontend prioritization for landlord decision queues using shared execution-state logic
- order decisions for operator scanning as ready first, blocked second, duplicate-guarded third, and completed last
- apply prioritization after existing in-memory filtering on `/analytics` and `/actions` without changing backend contracts, readiness, or execution behavior

## Verification
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 >/dev/null && npm test -- --run src/components/analytics/decisionExecutionAggregation.test.ts src/components/analytics/DecisionQueueSummary.test.tsx src/components/analytics/AgentDecisionPanel.test.tsx src/pages/landlord/ActionRecommendationsPage.test.tsx src/pages/landlord/LandlordAnalyticsPage.test.tsx`
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 >/dev/null && npm run build`
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 >/dev/null && ./node_modules/.bin/eslint src/components/analytics/decisionExecutionAggregation.ts src/components/analytics/decisionExecutionAggregation.test.ts src/components/analytics/DecisionQueueSummary.tsx src/components/analytics/DecisionQueueSummary.test.tsx src/components/analytics/AgentDecisionPanel.tsx src/pages/landlord/ActionRecommendationsPage.tsx src/pages/landlord/ActionRecommendationsPage.test.tsx src/pages/landlord/LandlordAnalyticsPage.tsx src/pages/landlord/LandlordAnalyticsPage.test.tsx`