### PR TITLE
feat: add controlled automation preview v1

### DIFF
--- a/rentchain-frontend/src/components/analytics/AgentDecisionPanel.test.tsx
+++ b/rentchain-frontend/src/components/analytics/AgentDecisionPanel.test.tsx
@@ -160,6 +160,8 @@ describe("AgentDecisionPanel", () => {
     expect(screen.getByText(/Workflow: Vacancy readiness/i)).toBeInTheDocument();
     expect(screen.getByText(/Action required/i)).toBeInTheDocument();
     expect(screen.getByText(/Execution controls/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Automation preview/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Human confirmation required/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Execution disabled for this state/i)).toBeInTheDocument();
     expect(screen.getByText(/This decision is in a lifecycle state that does not allow execution/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Open vacancy readiness/i })).toHaveAttribute("href", "/analytics?propertyId=prop-2");
@@ -578,8 +580,10 @@ describe("AgentDecisionPanel", () => {
     );
 
     expect(screen.getByText(/Already processed/i)).toBeInTheDocument();
-    expect(screen.getByText(/Duplicate safeguard active/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Duplicate safeguard active/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Duplicate protection active/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Duplicate execution prevented/i)).toBeInTheDocument();
+    expect(screen.getByText(/Guard key: maintenance.auto_approve_cost:work_order:wo-1/i)).toBeInTheDocument();
     expect(screen.getByText(/Executed 1 time/i)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Execute now/i })).not.toBeInTheDocument();
   });

--- a/rentchain-frontend/src/components/analytics/AgentDecisionPanel.tsx
+++ b/rentchain-frontend/src/components/analytics/AgentDecisionPanel.tsx
@@ -13,7 +13,12 @@ import {
 } from "@/api/landlordAnalyticsApi";
 import type { TimelineItem } from "@/api/timelineApi";
 import { deriveDecisionExecutionState } from "./decisionExecutionAggregation";
-import { blockedReasonDisplay, executionStateDisplay, formatExecutionSummary } from "./decisionExecutionDisplay";
+import {
+  blockedReasonDisplay,
+  deriveAutomationPreview,
+  executionStateDisplay,
+  formatExecutionSummary,
+} from "./decisionExecutionDisplay";
 
 const priorityTone: Record<"low" | "medium" | "high", { bg: string; text: string }> = {
   low: { bg: "rgba(14, 165, 233, 0.12)", text: "#075985" },
@@ -226,6 +231,7 @@ function ActionDecisionCard(props: {
   const governanceSummary = formatExecutionSummary(effectiveExecutionSummary(decision));
   const executionDisplay = executionStateDisplay[decisionExecutionState];
   const blockedDisplay = decisionBlockedReason ? blockedReasonDisplay[decisionBlockedReason] : null;
+  const automationPreview = deriveAutomationPreview(decision);
 
   return (
     <div
@@ -354,6 +360,31 @@ function ActionDecisionCard(props: {
             <div style={{ color: "#334155", fontSize: "0.82rem" }}>{governanceSummary.join(" • ")}</div>
           </div>
         ) : null}
+        <div
+          style={{
+            display: "grid",
+            gap: 4,
+            padding: 10,
+            borderRadius: 10,
+            border: "1px dashed #cbd5e1",
+            background: "#fff",
+          }}
+        >
+          <div style={{ color: "#64748b", fontSize: "0.78rem", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.04em" }}>
+            {automationPreview.heading}
+          </div>
+          <div style={{ color: "#0f172a", fontSize: "0.84rem", fontWeight: 700 }}>{automationPreview.status}</div>
+          <div style={{ color: "#475569", fontSize: "0.82rem" }}>{automationPreview.summary}</div>
+          <div style={{ color: "#0f172a", fontSize: "0.8rem", fontWeight: 700 }}>{automationPreview.safeguardLabel}</div>
+          <div style={{ color: "#475569", fontSize: "0.8rem" }}>{automationPreview.safeguardDescription}</div>
+          {automationPreview.duplicateProtectionActive ? (
+            <div style={{ color: "#991b1b", fontSize: "0.8rem", fontWeight: 700 }}>Duplicate protection active</div>
+          ) : null}
+          {automationPreview.guardKeyLabel ? (
+            <div style={{ color: "#64748b", fontSize: "0.78rem", fontFamily: "monospace" }}>{automationPreview.guardKeyLabel}</div>
+          ) : null}
+          <div style={{ color: "#334155", fontSize: "0.8rem" }}>{automationPreview.nextStep}</div>
+        </div>
       </div>
       {decision.executionOutcomeStatus !== "none" ? (
         <div

--- a/rentchain-frontend/src/components/analytics/decisionExecutionDisplay.test.ts
+++ b/rentchain-frontend/src/components/analytics/decisionExecutionDisplay.test.ts
@@ -1,5 +1,48 @@
 import { describe, expect, it } from "vitest";
-import { blockedReasonDisplay, executionStateDisplay, formatExecutionSummary } from "./decisionExecutionDisplay";
+import type { LandlordAgentDecision } from "@/api/landlordAnalyticsApi";
+import {
+  blockedReasonDisplay,
+  deriveAutomationPreview,
+  executionStateDisplay,
+  formatExecutionSummary,
+} from "./decisionExecutionDisplay";
+
+function buildDecision(overrides?: Partial<LandlordAgentDecision>): LandlordAgentDecision {
+  return {
+    id: "decision-1",
+    decisionType: "review_lease_renewals",
+    priority: "medium",
+    explanation: "Review renewals",
+    supportingSignals: [],
+    recommendedAction: "Review renewals",
+    href: "/leases",
+    state: "pending",
+    reviewedAt: null,
+    actionKey: "open_lease_renewals_flow",
+    actionLabel: "Open lease renewals",
+    destination: "/leases",
+    workflowCategory: "lease_renewals",
+    automationEligible: false,
+    automationState: "blocked",
+    automationReason: "Blocked",
+    executionMappingState: "none",
+    executionMapping: null,
+    executionInputState: "none",
+    executionInputReason: null,
+    executionInputMissingFields: [],
+    executionInput: null,
+    executionState: undefined,
+    blockedReason: null,
+    executionGuardKey: null,
+    duplicateGuardActive: false,
+    executionSummary: undefined,
+    executedAt: null,
+    executionOutcomeStatus: "none",
+    executionOutcomeAt: null,
+    executionOutcomeReason: null,
+    ...overrides,
+  };
+}
 
 describe("decisionExecutionDisplay", () => {
   it("maps execution states to operator-facing labels", () => {
@@ -37,5 +80,70 @@ describe("decisionExecutionDisplay", () => {
         lastExecutionOutcomeAt: null,
       })
     ).toEqual([]);
+  });
+
+  it("derives a controlled preview for executable decisions", () => {
+    const result = deriveAutomationPreview(
+      buildDecision({
+        automationEligible: true,
+        automationState: "ready",
+        executionMappingState: "mapped",
+        executionInputState: "complete",
+        executionGuardKey: "lease.auto_send_notice:lease:lease-1",
+      })
+    );
+
+    expect(result.status).toBe("Eligible for human-confirmed execution");
+    expect(result.safeguardLabel).toBe("Human confirmation required");
+    expect(result.guardKeyLabel).toContain("lease.auto_send_notice:lease:lease-1");
+  });
+
+  it("derives a blocked preview without changing blocked-reason semantics", () => {
+    const result = deriveAutomationPreview(
+      buildDecision({
+        blockedReason: "missing_required_inputs",
+        automationReason: "Still missing notice inputs.",
+      })
+    );
+
+    expect(result.status).toBe("Automation preview unavailable");
+    expect(result.summary).toMatch(/required execution inputs/i);
+  });
+
+  it("derives a duplicate-guarded preview", () => {
+    const result = deriveAutomationPreview(
+      buildDecision({
+        executionState: "unsafe_duplicate",
+        duplicateGuardActive: true,
+        executionGuardKey: "maintenance.auto_approve_cost:work_order:wo-1",
+      })
+    );
+
+    expect(result.status).toBe("Duplicate protection active");
+    expect(result.duplicateProtectionActive).toBe(true);
+  });
+
+  it("fails closed for manual-only decisions", () => {
+    const result = deriveAutomationPreview(
+      buildDecision({
+        automationEligible: false,
+        automationState: "manual_only",
+      })
+    );
+
+    expect(result.status).toBe("Automation preview unavailable");
+    expect(result.nextStep).toMatch(/Manual review required/i);
+  });
+
+  it("fails closed when the action label is missing", () => {
+    const result = deriveAutomationPreview(
+      buildDecision({
+        actionLabel: "" as LandlordAgentDecision["actionLabel"],
+        recommendedAction: "" as LandlordAgentDecision["recommendedAction"],
+      })
+    );
+
+    expect(result.status).toBe("Automation preview unavailable");
+    expect(result.summary).toMatch(/not available for preview/i);
   });
 });

--- a/rentchain-frontend/src/components/analytics/decisionExecutionDisplay.ts
+++ b/rentchain-frontend/src/components/analytics/decisionExecutionDisplay.ts
@@ -1,8 +1,10 @@
 import type {
+  LandlordAgentDecision,
   LandlordDecisionBlockedReason,
   LandlordDecisionExecutionState,
   LandlordDecisionExecutionSummary,
 } from "@/api/landlordAnalyticsApi";
+import { deriveDecisionExecutionState } from "./decisionExecutionAggregation";
 
 type BadgeTone = {
   bg: string;
@@ -20,6 +22,17 @@ export type ExecutionStateDisplay = {
 export type BlockedReasonDisplay = {
   title: string;
   description: string;
+};
+
+export type AutomationPreview = {
+  heading: string;
+  status: string;
+  summary: string;
+  safeguardLabel: string;
+  safeguardDescription: string;
+  nextStep: string;
+  duplicateProtectionActive: boolean;
+  guardKeyLabel: string | null;
 };
 
 export const executionStateDisplay: Record<LandlordDecisionExecutionState, ExecutionStateDisplay> = {
@@ -107,4 +120,95 @@ export function formatExecutionSummary(summary?: LandlordDecisionExecutionSummar
   const lastRunLabel = lastRun ? `Last run: ${lastRun}` : null;
 
   return [countLabel, outcomeLabel, lastRunLabel].filter(Boolean) as string[];
+}
+
+function suggestedAction(decision: LandlordAgentDecision) {
+  return decision.actionLabel || decision.recommendedAction || "Review this decision";
+}
+
+function failClosedPreview(decision: LandlordAgentDecision): AutomationPreview {
+  return {
+    heading: "Automation preview",
+    status: "Automation preview unavailable",
+    summary: `${suggestedAction(decision)} is not available for preview from the current decision state.`,
+    safeguardLabel: "Human confirmation required",
+    safeguardDescription: "Manual review is required because the current automation state is incomplete or ambiguous.",
+    nextStep: "Manual review required before any execution can be considered.",
+    duplicateProtectionActive: Boolean(decision.duplicateGuardActive),
+    guardKeyLabel: decision.executionGuardKey ? `Guard key: ${decision.executionGuardKey}` : null,
+  };
+}
+
+export function deriveAutomationPreview(decision: LandlordAgentDecision): AutomationPreview {
+  const executionState = deriveDecisionExecutionState(decision);
+  const blockedReason = decision.blockedReason ? blockedReasonDisplay[decision.blockedReason] : null;
+  const action = suggestedAction(decision);
+  const guardKeyLabel = decision.executionGuardKey ? `Guard key: ${decision.executionGuardKey}` : null;
+
+  if (!decision.actionLabel && !decision.recommendedAction) {
+    return failClosedPreview(decision);
+  }
+
+  if (executionState === "unsafe_duplicate") {
+    return {
+      heading: "Automation preview",
+      status: "Duplicate protection active",
+      summary: `${action} is protected from repeat execution.`,
+      safeguardLabel: "Duplicate safeguard active",
+      safeguardDescription:
+        "A prior successful run or matching guard key was detected, so another execution preview is held fail-closed.",
+      nextStep: "Human confirmation is still required, but no repeat execution is available right now.",
+      duplicateProtectionActive: true,
+      guardKeyLabel,
+    };
+  }
+
+  if (executionState === "already_executed") {
+    return {
+      heading: "Automation preview",
+      status: "Completed preview",
+      summary: `${action} has already been completed for this decision.`,
+      safeguardLabel: "Human confirmation required",
+      safeguardDescription: "This preview is historical only. No new execution is available from this completed state.",
+      nextStep: "Review the recorded outcome if follow-up is needed.",
+      duplicateProtectionActive: Boolean(decision.duplicateGuardActive),
+      guardKeyLabel,
+    };
+  }
+
+  if (executionState === "executable" && decision.automationEligible) {
+    return {
+      heading: "Automation preview",
+      status: "Eligible for human-confirmed execution",
+      summary: `${action} would be the next controlled step if a human operator chooses to run it.`,
+      safeguardLabel: "Human confirmation required",
+      safeguardDescription:
+        "Execution remains manual. Existing mapping, readiness, and duplicate safeguards stay in place until a human confirms the action.",
+      nextStep: "Review the decision, then use the existing execute control if you want to continue.",
+      duplicateProtectionActive: Boolean(decision.duplicateGuardActive),
+      guardKeyLabel,
+    };
+  }
+
+  if (executionState === "blocked") {
+    const reasonDescription = blockedReason?.description || decision.automationReason;
+    const manualOnly = decision.automationState === "manual_only";
+    return {
+      heading: "Automation preview",
+      status: decision.automationEligible ? "Blocked until requirements are complete" : "Automation preview unavailable",
+      summary: reasonDescription
+        ? `${action} is not currently available. ${reasonDescription}`
+        : `${action} is not currently available from the current decision state.`,
+      safeguardLabel: "Human confirmation required",
+      safeguardDescription:
+        "This decision stays fail-closed until the blocking requirement is resolved and a human reviews it again.",
+      nextStep: manualOnly
+        ? "Manual review required before any execution can be considered."
+        : "Open the existing review flow to resolve the blocking requirement before execution is considered.",
+      duplicateProtectionActive: Boolean(decision.duplicateGuardActive),
+      guardKeyLabel,
+    };
+  }
+
+  return failClosedPreview(decision);
 }

--- a/rentchain-frontend/src/pages/landlord/ActionRecommendationsPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/ActionRecommendationsPage.test.tsx
@@ -167,6 +167,8 @@ describe("ActionRecommendationsPage", () => {
     expect(screen.getByText(/all-time landlord decision outcomes from canonical decision events/i)).toBeInTheDocument();
     expect(screen.getByText(/resolution rate 75%/i)).toBeInTheDocument();
     expect(fetchLandlordAnalyticsSnapshot).toHaveBeenCalledTimes(1);
+    expect(screen.getAllByText(/Automation preview/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Human confirmation required/i).length).toBeGreaterThan(0);
 
     const actionLinks = screen.getAllByRole("link");
     expect(actionLinks.map((node) => node.textContent)).toEqual(["Open vacancy readiness", "Open lease renewals"]);

--- a/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.test.tsx
@@ -501,6 +501,8 @@ describe("LandlordAnalyticsPage", () => {
     expect(screen.getByRole("heading", { name: /Decision outcomes/i })).toBeInTheDocument();
     expect(screen.getByText(/all-time landlord decision outcomes from canonical decision events/i)).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /Recommended next actions/i })).toBeInTheDocument();
+    expect(screen.getAllByText(/Automation preview/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Human confirmation required/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Beta carries the strongest vacancy pressure/i)).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /Predictive metrics/i })).toBeInTheDocument();
     expect(screen.getByText(/Vacancy pressure is present in the current view/i)).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- add a controlled automation preview block to landlord decision cards using existing deterministic execution-governance fields
- explain what action could happen next, why a decision is ready or blocked, and what safeguards apply while keeping human confirmation explicit
- keep the change frontend-only and read-only with no execution, readiness, automation-rule, or backend behavior changes

## Verification
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 >/dev/null && npm test -- --run src/components/analytics/AgentDecisionPanel.test.tsx src/components/analytics/decisionExecutionDisplay.test.ts src/components/analytics/decisionExecutionAggregation.test.ts src/pages/landlord/ActionRecommendationsPage.test.tsx src/pages/landlord/LandlordAnalyticsPage.test.tsx`
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 >/dev/null && npm run build`
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 >/dev/null && ./node_modules/.bin/eslint src/components/analytics/AgentDecisionPanel.tsx src/components/analytics/AgentDecisionPanel.test.tsx src/components/analytics/decisionExecutionDisplay.ts src/components/analytics/decisionExecutionDisplay.test.ts src/components/analytics/decisionExecutionAggregation.ts src/pages/landlord/ActionRecommendationsPage.tsx src/pages/landlord/ActionRecommendationsPage.test.tsx src/pages/landlord/LandlordAnalyticsPage.tsx src/pages/landlord/LandlordAnalyticsPage.test.tsx`

## Notes
- fail-closed preview states remain `Automation preview unavailable` and `Manual review required`
- duplicate-guarded decisions show protection rather than suggesting rerun
- this preview layer does not call any execution endpoints or change queue counts, filtering, or prioritization