### PR TITLE
feat: add controlled automation confirmation gate v1

### DIFF
--- a/rentchain-frontend/src/components/analytics/AgentDecisionPanel.test.tsx
+++ b/rentchain-frontend/src/components/analytics/AgentDecisionPanel.test.tsx
@@ -40,6 +40,7 @@ vi.mock("../ui/Ui", () => ({
 beforeEach(() => {
   vi.clearAllMocks();
   window.localStorage.clear();
+  const now = Date.now();
   snoozeLandlordDecision.mockResolvedValue({
     state: {
       decisionId: "reduce_vacancy_risk:prop-2",
@@ -90,7 +91,7 @@ beforeEach(() => {
         id: "event-1",
         title: "Appeared",
         description: "Analytics decision review_lease_renewals:prop-1 appeared.",
-        timestamp: "2026-04-22T09:00:00.000Z",
+        timestamp: new Date(now - 60 * 60 * 1000).toISOString(),
         domain: "system",
         actor: "System",
       },
@@ -98,7 +99,7 @@ beforeEach(() => {
         id: "event-2",
         title: "Reviewed",
         description: "Analytics decision review_lease_renewals:prop-1 reviewed.",
-        timestamp: "2026-04-22T10:00:00.000Z",
+        timestamp: new Date(now - 30 * 60 * 1000).toISOString(),
         domain: "system",
         actor: "Landlord",
       },

--- a/rentchain-frontend/src/components/analytics/AgentDecisionPanel.test.tsx
+++ b/rentchain-frontend/src/components/analytics/AgentDecisionPanel.test.tsx
@@ -348,7 +348,7 @@ describe("AgentDecisionPanel", () => {
     expect(screen.queryByText(/Vacancy pressure is concentrated in Beta/i)).not.toBeInTheDocument();
   });
 
-  it("shows an explicit execute control only for ready mapped complete decisions", async () => {
+  it("requires explicit human confirmation before executing a ready decision", async () => {
     render(
       <MemoryRouter>
         <AgentDecisionPanel
@@ -407,7 +407,13 @@ describe("AgentDecisionPanel", () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /Execute now/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Review action/i }));
+
+    expect(screen.getByLabelText(/Execution confirmation/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Confirm action$/i })).toBeInTheDocument();
+    expect(screen.getByText(/This action will use the existing guarded execution path only after you confirm it/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /^Confirm action$/i }));
 
     await waitFor(() => {
       expect(executeLandlordDecision).toHaveBeenCalledWith({
@@ -419,7 +425,7 @@ describe("AgentDecisionPanel", () => {
     expect(await screen.findByRole("heading", { name: /Recently executed \(1\)/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Show executed/i })).toBeInTheDocument();
     expect(screen.queryByText(/Notice sent/i)).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /Execute now/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Review action/i })).not.toBeInTheDocument();
   });
 
   it("keeps failed execution feedback in the active section", async () => {
@@ -502,7 +508,8 @@ describe("AgentDecisionPanel", () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /Execute now/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Review action/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^Confirm action$/i }));
 
     await waitFor(() => {
       expect(executeLandlordDecision).toHaveBeenCalledWith({
@@ -514,7 +521,7 @@ describe("AgentDecisionPanel", () => {
     expect(screen.queryByRole("heading", { name: /Recently executed/i })).not.toBeInTheDocument();
     expect(screen.getByText(/Execution failed/i)).toBeInTheDocument();
     expect(screen.getByText(/AUTOMATION_EXECUTION_FAILED/i)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Execute now/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Review action/i })).toBeInTheDocument();
   });
 
   it("shows execution governance summary for duplicate-prevented decisions", () => {
@@ -585,7 +592,74 @@ describe("AgentDecisionPanel", () => {
     expect(screen.getByText(/Duplicate execution prevented/i)).toBeInTheDocument();
     expect(screen.getByText(/Guard key: maintenance.auto_approve_cost:work_order:wo-1/i)).toBeInTheDocument();
     expect(screen.getByText(/Executed 1 time/i)).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /Execute now/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Review action/i })).not.toBeInTheDocument();
+  });
+
+  it("fails closed when confirmation context is incomplete even if the decision looks executable", () => {
+    render(
+      <MemoryRouter>
+        <AgentDecisionPanel
+          decisions={[
+            {
+              id: "review_lease_renewals:prop-1",
+              decisionType: "review_lease_renewals",
+              priority: "high",
+              explanation: "Review upcoming renewals.",
+              recommendedAction: "",
+              actionKey: "",
+              actionLabel: "",
+              destination: "/portfolio-health?entry=lease-renewals&propertyId=prop-1",
+              workflowCategory: "lease_renewals",
+              automationEligible: true,
+              automationState: "ready",
+              automationReason: "This decision is active and already mapped to a deterministic automation path.",
+              executionMappingState: "mapped",
+              executionMapping: {
+                action: "lease.auto_send_notice",
+                resourceType: "lease",
+                resourceId: "lease-1",
+                prerequisitesMet: true,
+                prerequisiteReason: null,
+              },
+              executionInputState: "complete",
+              executionInputReason: null,
+              executionInputMissingFields: [],
+              executionInput: {
+                noticeType: "renewal_offer",
+                legalTemplateKey: "ns.fixed_term.renewal_offer.v1",
+                noticeRuleVersion: "ns-v1",
+                province: "NS",
+                leaseType: "fixed_term",
+                currentRent: 1650,
+                noticeDueAt: Date.UTC(2026, 1, 10, 0, 0, 0, 0),
+                rentChangeMode: "no_change",
+                proposedRent: null,
+                newTermType: "fixed_term",
+                newLeaseStartDate: "2026-05-11",
+                newLeaseEndDate: "2027-05-10",
+                responseDeadlineAt: Date.UTC(2026, 4, 1, 12, 0, 0, 0),
+              },
+              executionState: "executable",
+              blockedReason: null,
+              executionGuardKey: "lease.auto_send_notice:lease:lease-1",
+              duplicateGuardActive: false,
+              executionSummary: undefined,
+              executedAt: null,
+              executionOutcomeStatus: "none",
+              executionOutcomeAt: null,
+              executionOutcomeReason: null,
+              href: "/portfolio-health?entry=lease-renewals&propertyId=prop-1",
+              state: "pending",
+              reviewedAt: null,
+              supportingSignals: [],
+            },
+          ]}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByRole("button", { name: /Review action/i })).not.toBeInTheDocument();
+    expect(screen.getByText(/Automation preview unavailable/i)).toBeInTheDocument();
   });
 
   it("renders executed decisions in a collapsible secondary section", () => {

--- a/rentchain-frontend/src/components/analytics/AgentDecisionPanel.tsx
+++ b/rentchain-frontend/src/components/analytics/AgentDecisionPanel.tsx
@@ -15,9 +15,11 @@ import type { TimelineItem } from "@/api/timelineApi";
 import { deriveDecisionExecutionState } from "./decisionExecutionAggregation";
 import {
   blockedReasonDisplay,
+  canOpenExecutionConfirmation,
   deriveAutomationPreview,
   executionStateDisplay,
   formatExecutionSummary,
+  getExecutionConfirmationDetails,
 } from "./decisionExecutionDisplay";
 
 const priorityTone: Record<"low" | "medium" | "high", { bg: string; text: string }> = {
@@ -193,9 +195,12 @@ function ActionDecisionCard(props: {
   decision: LandlordAgentDecision;
   workingDecisionId: string | null;
   workingAction: "review" | "snooze" | "dismiss" | "execute" | null;
+  confirmingDecisionId: string | null;
   onReview: (decisionId: string) => Promise<void>;
   onSnooze: (decisionId: string, days: number) => Promise<void>;
   onDismiss: (decisionId: string) => Promise<void>;
+  onOpenConfirmation: (decisionId: string) => void;
+  onCloseConfirmation: () => void;
   onExecute: (decisionId: string) => Promise<void>;
   showHistory: boolean;
   historyItems: TimelineItem[];
@@ -207,9 +212,12 @@ function ActionDecisionCard(props: {
     decision,
     workingDecisionId,
     workingAction,
+    confirmingDecisionId,
     onReview,
     onSnooze,
     onDismiss,
+    onOpenConfirmation,
+    onCloseConfirmation,
     onExecute,
     showHistory,
     historyItems,
@@ -227,11 +235,13 @@ function ActionDecisionCard(props: {
       : null;
   const decisionExecutionState = deriveDecisionExecutionState(decision);
   const decisionBlockedReason = effectiveBlockedReason(decision);
-  const canExecuteNow = decisionExecutionState === "executable";
   const governanceSummary = formatExecutionSummary(effectiveExecutionSummary(decision));
   const executionDisplay = executionStateDisplay[decisionExecutionState];
   const blockedDisplay = decisionBlockedReason ? blockedReasonDisplay[decisionBlockedReason] : null;
   const automationPreview = deriveAutomationPreview(decision);
+  const confirmationDetails = getExecutionConfirmationDetails(decision);
+  const canReviewBeforeExecute = canOpenExecutionConfirmation(decision);
+  const showConfirmation = confirmingDecisionId === decision.id;
 
   return (
     <div
@@ -412,10 +422,10 @@ function ActionDecisionCard(props: {
             {ctaLabel}
           </Link>
         ) : null}
-        {canExecuteNow ? (
+        {canReviewBeforeExecute ? (
           <button
             type="button"
-            onClick={() => void onExecute(decision.id)}
+            onClick={() => onOpenConfirmation(decision.id)}
             disabled={workingDecisionId === decision.id}
             style={{
               border: "1px solid #166534",
@@ -426,7 +436,7 @@ function ActionDecisionCard(props: {
               padding: "6px 12px",
             }}
           >
-            {workingDecisionId === decision.id && workingAction === "execute" ? "Executing…" : "Execute now"}
+            Review action
           </button>
         ) : null}
         {decision.state === "reviewed" ? (
@@ -504,6 +514,77 @@ function ActionDecisionCard(props: {
           onToggleHistory={onToggleHistory}
         />
       </div>
+      {showConfirmation ? (
+        <div
+          aria-label="Execution confirmation"
+          style={{
+            display: "grid",
+            gap: 8,
+            padding: 12,
+            borderRadius: 12,
+            border: "1px solid #bbf7d0",
+            background: "#f0fdf4",
+          }}
+        >
+          <div style={{ color: "#14532d", fontSize: "0.78rem", fontWeight: 800, letterSpacing: "0.04em", textTransform: "uppercase" }}>
+            {confirmationDetails.title}
+          </div>
+          <div style={{ color: "#0f172a", fontSize: "0.94rem", fontWeight: 700 }}>{confirmationDetails.actionLabel}</div>
+          {confirmationDetails.workflowLabel ? (
+            <div style={{ color: "#475569", fontSize: "0.82rem" }}>Workflow: {confirmationDetails.workflowLabel}</div>
+          ) : null}
+          <div style={{ color: "#475569", fontSize: "0.82rem" }}>Execution state: {confirmationDetails.stateLabel}</div>
+          {confirmationDetails.blockedTitle ? (
+            <div style={{ display: "grid", gap: 2 }}>
+              <div style={{ color: "#92400e", fontSize: "0.82rem", fontWeight: 700 }}>{confirmationDetails.blockedTitle}</div>
+              <div style={{ color: "#475569", fontSize: "0.8rem" }}>{confirmationDetails.blockedDescription}</div>
+            </div>
+          ) : null}
+          <div style={{ color: "#14532d", fontSize: "0.82rem", fontWeight: 700 }}>{confirmationDetails.warning}</div>
+          {confirmationDetails.duplicateProtectionActive ? (
+            <div style={{ color: "#991b1b", fontSize: "0.8rem", fontWeight: 700 }}>Duplicate protection remains active</div>
+          ) : null}
+          {confirmationDetails.guardKeyLabel ? (
+            <div style={{ color: "#334155", fontSize: "0.8rem" }}>{confirmationDetails.guardKeyLabel}</div>
+          ) : null}
+          <div style={{ color: "#475569", fontSize: "0.8rem" }}>{confirmationDetails.nextStep}</div>
+          {confirmationDetails.unavailableReason ? (
+            <div style={{ color: "#92400e", fontSize: "0.8rem" }}>{confirmationDetails.unavailableReason}</div>
+          ) : null}
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+            <button
+              type="button"
+              onClick={onCloseConfirmation}
+              style={{
+                border: "1px solid #cbd5e1",
+                borderRadius: 999,
+                background: "#fff",
+                color: "#334155",
+                fontWeight: 700,
+                padding: "6px 12px",
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={() => void onExecute(decision.id)}
+              disabled={!confirmationDetails.canConfirm || workingDecisionId === decision.id}
+              style={{
+                border: "1px solid #166534",
+                borderRadius: 999,
+                background: confirmationDetails.canConfirm ? "#166534" : "#cbd5e1",
+                color: "#fff",
+                fontWeight: 700,
+                padding: "6px 12px",
+                cursor: confirmationDetails.canConfirm && workingDecisionId !== decision.id ? "pointer" : "not-allowed",
+              }}
+            >
+              {workingDecisionId === decision.id && workingAction === "execute" ? "Executing…" : "Confirm action"}
+            </button>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -632,6 +713,7 @@ export function AgentDecisionPanel({
   const [items, setItems] = React.useState(decisions);
   const [workingDecisionId, setWorkingDecisionId] = React.useState<string | null>(null);
   const [workingAction, setWorkingAction] = React.useState<"review" | "snooze" | "dismiss" | "execute" | null>(null);
+  const [confirmingDecisionId, setConfirmingDecisionId] = React.useState<string | null>(null);
   const [error, setError] = React.useState<string | null>(null);
   const [showExecuted, setShowExecuted] = React.useState(false);
   const [expandedHistoryDecisionIds, setExpandedHistoryDecisionIds] = React.useState<Record<string, boolean>>(
@@ -767,6 +849,14 @@ export function AgentDecisionPanel({
     }
   };
 
+  const handleOpenConfirmation = React.useCallback((decisionId: string) => {
+    setConfirmingDecisionId(decisionId);
+  }, []);
+
+  const handleCloseConfirmation = React.useCallback(() => {
+    setConfirmingDecisionId(null);
+  }, []);
+
   const handleExecute = async (decisionId: string) => {
     try {
       setWorkingDecisionId(decisionId);
@@ -812,6 +902,7 @@ export function AgentDecisionPanel({
             : decision
         )
       );
+      setConfirmingDecisionId(null);
     } catch (err: unknown) {
       setError(errorMessage(err));
     } finally {
@@ -843,9 +934,12 @@ export function AgentDecisionPanel({
                     decision={decision}
                     workingDecisionId={workingDecisionId}
                     workingAction={workingAction}
+                    confirmingDecisionId={confirmingDecisionId}
                     onReview={handleReview}
                     onSnooze={handleSnooze}
                     onDismiss={handleDismiss}
+                    onOpenConfirmation={handleOpenConfirmation}
+                    onCloseConfirmation={handleCloseConfirmation}
                     onExecute={handleExecute}
                     showHistory={Boolean(expandedHistoryDecisionIds[decision.id])}
                     historyItems={historyItemsByDecisionId[decision.id] || []}

--- a/rentchain-frontend/src/components/analytics/decisionExecutionDisplay.test.ts
+++ b/rentchain-frontend/src/components/analytics/decisionExecutionDisplay.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from "vitest";
 import type { LandlordAgentDecision } from "@/api/landlordAnalyticsApi";
 import {
   blockedReasonDisplay,
+  canOpenExecutionConfirmation,
   deriveAutomationPreview,
   executionStateDisplay,
   formatExecutionSummary,
+  getExecutionConfirmationDetails,
 } from "./decisionExecutionDisplay";
 
 function buildDecision(overrides?: Partial<LandlordAgentDecision>): LandlordAgentDecision {
@@ -96,6 +98,7 @@ describe("decisionExecutionDisplay", () => {
     expect(result.status).toBe("Eligible for human-confirmed execution");
     expect(result.safeguardLabel).toBe("Human confirmation required");
     expect(result.guardKeyLabel).toContain("lease.auto_send_notice:lease:lease-1");
+    expect(result.nextStep).toMatch(/confirm manually/i);
   });
 
   it("derives a blocked preview without changing blocked-reason semantics", () => {
@@ -145,5 +148,43 @@ describe("decisionExecutionDisplay", () => {
 
     expect(result.status).toBe("Automation preview unavailable");
     expect(result.summary).toMatch(/not available for preview/i);
+  });
+
+  it("allows confirmation only for executable decisions with valid action context", () => {
+    expect(
+      canOpenExecutionConfirmation(
+        buildDecision({
+          automationEligible: true,
+          automationState: "ready",
+          executionMappingState: "mapped",
+          executionInputState: "complete",
+        })
+      )
+    ).toBe(true);
+    expect(canOpenExecutionConfirmation(buildDecision())).toBe(false);
+    expect(
+      canOpenExecutionConfirmation(
+        buildDecision({
+          executionState: "unsafe_duplicate",
+          duplicateGuardActive: true,
+        })
+      )
+    ).toBe(false);
+  });
+
+  it("returns fail-closed confirmation details when required context is missing", () => {
+    const result = getExecutionConfirmationDetails(
+      buildDecision({
+        automationEligible: true,
+        automationState: "ready",
+        executionMappingState: "mapped",
+        executionInputState: "complete",
+        actionKey: "",
+      })
+    );
+
+    expect(result.canConfirm).toBe(false);
+    expect(result.unavailableReason).toMatch(/execution context is incomplete/i);
+    expect(result.warning).toMatch(/guarded execution path/i);
   });
 });

--- a/rentchain-frontend/src/components/analytics/decisionExecutionDisplay.ts
+++ b/rentchain-frontend/src/components/analytics/decisionExecutionDisplay.ts
@@ -35,6 +35,21 @@ export type AutomationPreview = {
   guardKeyLabel: string | null;
 };
 
+export type ExecutionConfirmationDetails = {
+  title: string;
+  actionLabel: string;
+  workflowLabel: string | null;
+  stateLabel: string;
+  blockedTitle: string | null;
+  blockedDescription: string | null;
+  duplicateProtectionActive: boolean;
+  guardKeyLabel: string | null;
+  warning: string;
+  nextStep: string;
+  canConfirm: boolean;
+  unavailableReason: string | null;
+};
+
 export const executionStateDisplay: Record<LandlordDecisionExecutionState, ExecutionStateDisplay> = {
   executable: {
     label: "Ready to run",
@@ -123,14 +138,31 @@ export function formatExecutionSummary(summary?: LandlordDecisionExecutionSummar
 }
 
 function suggestedAction(decision: LandlordAgentDecision) {
-  return decision.actionLabel || decision.recommendedAction || "Review this decision";
+  return decision.actionLabel || decision.recommendedAction || null;
+}
+
+function workflowLabel(decision: LandlordAgentDecision) {
+  if (!decision.workflowCategory) return null;
+
+  const workflowLabels: Record<NonNullable<LandlordAgentDecision["workflowCategory"]>, string> = {
+    lease_renewals: "Lease renewals",
+    maintenance_cost_approval: "Maintenance cost approval",
+    screening_checkout: "Screening checkout",
+    vacancy_readiness: "Vacancy readiness",
+    application_funnel: "Application funnel",
+    maintenance_backlog: "Maintenance backlog",
+    revenue_follow_up: "Revenue follow-up",
+    property_focus: "Property focus",
+  };
+
+  return workflowLabels[decision.workflowCategory] || null;
 }
 
 function failClosedPreview(decision: LandlordAgentDecision): AutomationPreview {
   return {
     heading: "Automation preview",
     status: "Automation preview unavailable",
-    summary: `${suggestedAction(decision)} is not available for preview from the current decision state.`,
+    summary: `${suggestedAction(decision) || "This decision"} is not available for preview from the current decision state.`,
     safeguardLabel: "Human confirmation required",
     safeguardDescription: "Manual review is required because the current automation state is incomplete or ambiguous.",
     nextStep: "Manual review required before any execution can be considered.",
@@ -145,7 +177,7 @@ export function deriveAutomationPreview(decision: LandlordAgentDecision): Automa
   const action = suggestedAction(decision);
   const guardKeyLabel = decision.executionGuardKey ? `Guard key: ${decision.executionGuardKey}` : null;
 
-  if (!decision.actionLabel && !decision.recommendedAction) {
+  if (!action) {
     return failClosedPreview(decision);
   }
 
@@ -184,7 +216,7 @@ export function deriveAutomationPreview(decision: LandlordAgentDecision): Automa
       safeguardLabel: "Human confirmation required",
       safeguardDescription:
         "Execution remains manual. Existing mapping, readiness, and duplicate safeguards stay in place until a human confirms the action.",
-      nextStep: "Review the decision, then use the existing execute control if you want to continue.",
+      nextStep: "Review the decision, then confirm manually if you want to continue.",
       duplicateProtectionActive: Boolean(decision.duplicateGuardActive),
       guardKeyLabel,
     };
@@ -211,4 +243,46 @@ export function deriveAutomationPreview(decision: LandlordAgentDecision): Automa
   }
 
   return failClosedPreview(decision);
+}
+
+export function canOpenExecutionConfirmation(decision: LandlordAgentDecision) {
+  return Boolean(
+    deriveDecisionExecutionState(decision) === "executable" &&
+      !decision.duplicateGuardActive &&
+      suggestedAction(decision) &&
+      decision.actionKey
+  );
+}
+
+export function getExecutionConfirmationDetails(decision: LandlordAgentDecision): ExecutionConfirmationDetails {
+  const executionState = deriveDecisionExecutionState(decision);
+  const action = suggestedAction(decision);
+  const blockedDisplay = decision.blockedReason ? blockedReasonDisplay[decision.blockedReason] : null;
+  const canConfirm = canOpenExecutionConfirmation(decision);
+  const unavailableReason = !action
+    ? "Manual review required because the action context is incomplete."
+    : executionState !== "executable"
+      ? blockedDisplay?.description || executionStateDisplay[executionState].description
+      : decision.duplicateGuardActive
+        ? "Duplicate protection remains active for this decision."
+        : !decision.actionKey
+          ? "Manual review required because the execution context is incomplete."
+          : null;
+
+  return {
+    title: "Confirm action",
+    actionLabel: action || "Action unavailable",
+    workflowLabel: workflowLabel(decision),
+    stateLabel: executionStateDisplay[executionState].label,
+    blockedTitle: blockedDisplay?.title || null,
+    blockedDescription: blockedDisplay?.description || null,
+    duplicateProtectionActive: Boolean(decision.duplicateGuardActive),
+    guardKeyLabel: decision.executionGuardKey ? `Guard key: ${decision.executionGuardKey}` : null,
+    warning: "This action will use the existing guarded execution path only after you confirm it.",
+    nextStep: canConfirm
+      ? "Select Confirm action to continue through the existing guarded execution path."
+      : "Manual review required before any execution can proceed.",
+    canConfirm,
+    unavailableReason,
+  };
 }

--- a/rentchain-frontend/src/pages/landlord/ActionRecommendationsPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/ActionRecommendationsPage.test.tsx
@@ -435,6 +435,9 @@ describe("ActionRecommendationsPage", () => {
 
     expect(screen.getByText(/A screening checkout can start now/i)).toBeInTheDocument();
     expect(screen.queryByText(/Renewal inputs are still incomplete/i)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Review action/i }));
+    expect(screen.getByLabelText(/Execution confirmation/i)).toBeInTheDocument();
+    expect(screen.getByText(/This action will use the existing guarded execution path only after you confirm it/i)).toBeInTheDocument();
   });
 
   it("renders a clean empty state when the snapshot has no decisions", async () => {


### PR DESCRIPTION
## Summary
- add a human confirmation gate in front of the existing guarded decision execution path
- replace the direct execute click with a review step, local confirmation panel, and explicit confirm action for executable decisions only
- keep the change frontend-only and preserve all existing execution-state, duplicate-protection, and fail-closed safeguards

## Verification
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 >/dev/null && npm test -- --run src/components/analytics/AgentDecisionPanel.test.tsx src/components/analytics/decisionExecutionDisplay.test.ts src/pages/landlord/ActionRecommendationsPage.test.tsx src/pages/landlord/LandlordAnalyticsPage.test.tsx`
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 >/dev/null && npm run build`
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 >/dev/null && ./node_modules/.bin/eslint src/components/analytics/AgentDecisionPanel.tsx src/components/analytics/AgentDecisionPanel.test.tsx src/components/analytics/decisionExecutionDisplay.ts src/components/analytics/decisionExecutionDisplay.test.ts src/pages/landlord/ActionRecommendationsPage.tsx src/pages/landlord/ActionRecommendationsPage.test.tsx src/pages/landlord/LandlordAnalyticsPage.tsx src/pages/landlord/LandlordAnalyticsPage.test.tsx`

## Notes
- confirmation is only available when execution state is `executable`, duplicate protection is not active, and action context is complete
- blocked, duplicate-protected, and incomplete-context decisions fail closed and do not expose a runnable confirm path
- the existing `executeLandlordDecision(...)` client path is reused unchanged; no backend execution behavior, schedulers, workers, polling, or autonomous execution were introduced