### PR TITLE
feat: surface controlled automation audit timeline v1

### DIFF
--- a/rentchain-api/src/lib/timeline/timelineAdapter.test.ts
+++ b/rentchain-api/src/lib/timeline/timelineAdapter.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import type { CanonicalEventV1 } from "../events/eventTypes";
+import { canonicalEventToTimelineItem } from "./timelineAdapter";
+
+function buildEvent(overrides?: Partial<CanonicalEventV1>): CanonicalEventV1 {
+  return {
+    id: "event-1",
+    version: "v1",
+    type: "controlled_automation.previewed",
+    domain: "system",
+    action: "controlled_automation_previewed",
+    actor: {
+      type: "landlord",
+      id: "landlord-1",
+      role: "landlord",
+    },
+    resource: {
+      type: "analytics_decision",
+      id: "decision-1",
+    },
+    occurredAt: "2026-04-24T00:00:00.000Z",
+    recordedAt: "2026-04-24T00:00:00.000Z",
+    visibility: "landlord",
+    summary: "Controlled automation preview opened for decision-1.",
+    metadata: {
+      actionLabel: "Open renewals focus",
+      workflowCategory: "lease_renewals",
+      duplicateGuardActive: false,
+      executionGuardKey: "lease.auto_send_notice:lease:lease-1",
+    },
+    ...overrides,
+  };
+}
+
+describe("timelineAdapter", () => {
+  it("adds readable controlled automation metadata to timeline items", () => {
+    const result = canonicalEventToTimelineItem(
+      buildEvent({
+        type: "controlled_automation.failed",
+        metadata: {
+          actionLabel: "Open renewals focus",
+          workflowCategory: "lease_renewals",
+          duplicateGuardActive: true,
+          executionGuardKey: "lease.auto_send_notice:lease:lease-1",
+          failureReason: "AUTOMATION_EXECUTION_FAILED",
+        },
+      })
+    );
+
+    expect(result.title).toBe("Automation failed");
+    expect(result.details).toEqual([
+      "Action: Open renewals focus",
+      "Workflow: Lease Renewals",
+      "Duplicate protection active",
+      "Guard key: lease.auto_send_notice:lease:lease-1",
+      "Failure reason: AUTOMATION_EXECUTION_FAILED",
+    ]);
+  });
+
+  it("fails closed when controlled automation metadata is missing", () => {
+    const result = canonicalEventToTimelineItem(
+      buildEvent({
+        metadata: {
+          actionLabel: "",
+          workflowCategory: "",
+          duplicateGuardActive: false,
+          executionGuardKey: "",
+          failureReason: "",
+        },
+      })
+    );
+
+    expect(result.details).toBeUndefined();
+  });
+});

--- a/rentchain-api/src/lib/timeline/timelineAdapter.ts
+++ b/rentchain-api/src/lib/timeline/timelineAdapter.ts
@@ -8,6 +8,7 @@ export type TimelineItem = {
   domain: string;
   status?: string;
   actor?: string;
+  details?: string[];
 };
 
 const TITLE_BY_TYPE: Record<string, string> = {
@@ -62,6 +63,47 @@ function actorLabel(event: CanonicalEventV1) {
   return type ? startCase(type) : undefined;
 }
 
+function metadataString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function controlledAutomationDetails(event: CanonicalEventV1) {
+  const type = String(event.type || "").trim();
+  if (!type.startsWith("controlled_automation.")) return undefined;
+
+  const metadata = event.metadata || {};
+  const details: string[] = [];
+  const actionLabel = metadataString(metadata.actionLabel, 240);
+  const actionKey = metadataString(metadata.actionKey, 120);
+  const workflowCategory = metadataString(metadata.workflowCategory, 120);
+  const executionGuardKey = metadataString(metadata.executionGuardKey, 240);
+  const failureReason = metadataString(metadata.failureReason, 240);
+
+  if (actionLabel) {
+    details.push(`Action: ${actionLabel}`);
+  } else if (actionKey) {
+    details.push(`Action key: ${actionKey}`);
+  }
+
+  if (workflowCategory) {
+    details.push(`Workflow: ${startCase(workflowCategory)}`);
+  }
+
+  if (metadata.duplicateGuardActive === true) {
+    details.push("Duplicate protection active");
+  }
+
+  if (executionGuardKey) {
+    details.push(`Guard key: ${executionGuardKey}`);
+  }
+
+  if (type === "controlled_automation.failed" && failureReason) {
+    details.push(`Failure reason: ${failureReason}`);
+  }
+
+  return details.length ? details : undefined;
+}
+
 export function canonicalEventToTimelineItem(event: CanonicalEventV1): TimelineItem {
   const type = String(event.type || "").trim();
   return {
@@ -72,5 +114,6 @@ export function canonicalEventToTimelineItem(event: CanonicalEventV1): TimelineI
     domain: event.domain,
     status: event.status || undefined,
     actor: actorLabel(event),
+    details: controlledAutomationDetails(event),
   };
 }

--- a/rentchain-frontend/src/api/timelineApi.ts
+++ b/rentchain-frontend/src/api/timelineApi.ts
@@ -8,6 +8,7 @@ export type TimelineItem = {
   domain: string;
   status?: string;
   actor?: string;
+  details?: string[];
 };
 
 export type TimelineResponse = {

--- a/rentchain-frontend/src/components/analytics/AgentDecisionPanel.test.tsx
+++ b/rentchain-frontend/src/components/analytics/AgentDecisionPanel.test.tsx
@@ -113,6 +113,31 @@ beforeEach(() => {
         domain: "system",
         actor: "Landlord",
       },
+      {
+        id: "event-3",
+        title: "Automation preview opened",
+        description: "Controlled automation preview opened for review_lease_renewals:prop-1.",
+        timestamp: new Date(now - 20 * 60 * 1000).toISOString(),
+        domain: "system",
+        actor: "Landlord",
+        details: [
+          "Action: Open renewals focus",
+          "Workflow: Lease Renewals",
+          "Guard key: lease.auto_send_notice:lease:lease-1",
+        ],
+      },
+      {
+        id: "event-4",
+        title: "Automation failed",
+        description: "Controlled automation failed for review_lease_renewals:prop-1.",
+        timestamp: new Date(now - 10 * 60 * 1000).toISOString(),
+        domain: "system",
+        actor: "Landlord",
+        details: [
+          "Action: Open renewals focus",
+          "Failure reason: AUTOMATION_EXECUTION_FAILED",
+        ],
+      },
     ],
   });
 });
@@ -983,7 +1008,92 @@ describe("AgentDecisionPanel", () => {
     });
     expect(await screen.findByText("Appeared")).toBeInTheDocument();
     expect(screen.getByText("Reviewed")).toBeInTheDocument();
+    expect(screen.getByText("Automation preview opened")).toBeInTheDocument();
+    expect(screen.getByText("Automation failed")).toBeInTheDocument();
+    expect(screen.getAllByText("Action: Open renewals focus")).toHaveLength(2);
+    expect(screen.getByText("Workflow: Lease Renewals")).toBeInTheDocument();
+    expect(screen.getByText("Failure reason: AUTOMATION_EXECUTION_FAILED")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Hide history/i })).toBeInTheDocument();
+  });
+
+  it("fails closed when automation history metadata is missing", async () => {
+    fetchLandlordDecisionHistory.mockResolvedValueOnce({
+      ok: true,
+      decisionId: "review_lease_renewals:prop-1",
+      events: [
+        {
+          id: "event-1",
+          title: "Automation preview opened",
+          description: "Controlled automation preview opened for review_lease_renewals:prop-1.",
+          timestamp: new Date().toISOString(),
+          domain: "system",
+          actor: "Landlord",
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter>
+        <AgentDecisionPanel
+          period="90d"
+          decisions={[
+            {
+              id: "review_lease_renewals:prop-1",
+              decisionType: "review_lease_renewals",
+              priority: "high",
+              explanation: "Review upcoming renewals.",
+              recommendedAction: "Review renewals",
+              actionKey: "open_lease_renewals_flow",
+              actionLabel: "Open renewals focus",
+              destination: "/portfolio-health?entry=lease-renewals&propertyId=prop-1",
+              workflowCategory: "lease_renewals",
+              automationEligible: true,
+              automationState: "ready",
+              automationReason: "This decision is active and already mapped to a deterministic automation path.",
+              executionMappingState: "mapped",
+              executionMapping: {
+                action: "lease.auto_send_notice",
+                resourceType: "lease",
+                resourceId: "lease-1",
+                prerequisitesMet: true,
+                prerequisiteReason: null,
+              },
+              executionInputState: "complete",
+              executionInputReason: null,
+              executionInputMissingFields: [],
+              executionInput: {
+                noticeType: "renewal_offer",
+                legalTemplateKey: "ns.fixed_term.renewal_offer.v1",
+                noticeRuleVersion: "ns-v1",
+                province: "NS",
+                leaseType: "fixed_term",
+                currentRent: 1650,
+                noticeDueAt: Date.UTC(2026, 1, 10, 0, 0, 0, 0),
+                rentChangeMode: "no_change",
+                proposedRent: null,
+                newTermType: "fixed_term",
+                newLeaseStartDate: "2026-05-11",
+                newLeaseEndDate: "2027-05-10",
+                responseDeadlineAt: Date.UTC(2026, 4, 1, 12, 0, 0, 0),
+              },
+              executedAt: null,
+              executionOutcomeStatus: "none",
+              executionOutcomeAt: null,
+              executionOutcomeReason: null,
+              href: "/portfolio-health?entry=lease-renewals&propertyId=prop-1",
+              state: "pending",
+              reviewedAt: null,
+              supportingSignals: [],
+            },
+          ]}
+        />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /View history/i }));
+    expect(await screen.findByText("Automation preview opened")).toBeInTheDocument();
+    expect(screen.queryByText(/Action:/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Failure reason:/i)).not.toBeInTheDocument();
   });
 
   it("persists per-decision history visibility across remounts", async () => {

--- a/rentchain-frontend/src/components/timeline/Timeline.tsx
+++ b/rentchain-frontend/src/components/timeline/Timeline.tsx
@@ -190,6 +190,15 @@ export function Timeline({
                             <div className="timelineDate">{formatTimestamp(item.timestamp)}</div>
                           </div>
                           <div className="timelineDesc">{item.description}</div>
+                          {item.details?.length ? (
+                            <div style={{ display: "grid", gap: 4 }}>
+                              {item.details.map((detail) => (
+                                <div key={`${item.id}-${detail}`} style={{ color: "#475569", fontSize: "0.82rem" }}>
+                                  {detail}
+                                </div>
+                              ))}
+                            </div>
+                          ) : null}
                           <div className="timelineMeta">
                             <span>{item.domain}</span>
                             {item.status ? <span>• {item.status}</span> : null}


### PR DESCRIPTION
## Summary
- surface controlled automation audit events in the existing landlord decision history timeline
- reuse the canonical timeline reader path and enrich controlled automation events with minimal operator-facing details
- keep the change strictly read-only with no execution, audit-write, or decision-behavior changes

## Notes
- this reuses `loadLandlordDecisionTimeline(...)`, `canonicalEventToTimelineItem(...)`, and the existing frontend `Timeline` inside `AgentDecisionPanel`
- controlled automation events shown are `controlled_automation.previewed`, `controlled_automation.confirmed`, `controlled_automation.executed`, and `controlled_automation.failed`
- missing or malformed metadata fails closed by omitting detail lines while still rendering the event safely
