### PR TITLE
feat: add tenant-side screening consent UX

### DIFF
--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -72,6 +72,13 @@ const dbMock = {
       get: async () => queryCollection(name, [{ field, op, value }]),
     }),
   }),
+  runTransaction: async (handler: (tx: any) => Promise<any>) => {
+    const tx = {
+      get: async (docRef: any) => docRef.get(),
+      set: async (docRef: any, value: any, opts?: { merge?: boolean }) => docRef.set(value, opts),
+    };
+    return handler(tx);
+  },
 };
 
 vi.mock("../../config/firebase", () => ({
@@ -1238,5 +1245,194 @@ describe("tenantPortalRoutes foundation", () => {
 
     expect(res.status).toBe(200);
     expect(res.body?.data?.status).toBe("redeemed");
+  });
+
+  it("lets a tenant consent for their own screening request and stores strengthened metadata", async () => {
+    ensureCollection("screening_requests").set("screening-1", {
+      rentalApplicationId: "app-1",
+      landlordId: "landlord-1",
+      applicantTenantId: "tenant-1",
+      applicantUserId: "user-1",
+      applicantEmail: "tenant@example.com",
+      applicantName: "Taylor Tenant",
+      propertyId: "prop-1",
+      propertyLabel: "123 Main St",
+      unitLabel: "Unit 4",
+      providerSelection: "transunion_redirect",
+      status: "requested",
+      createdAt: 100,
+      updatedAt: 100,
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/screening/screening-1/consent",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+        "user-agent": "vitest-agent",
+      },
+      body: {
+        accepted: true,
+        providerDisclosure:
+          "The landlord is requesting screening for this rental application. A third-party screening provider may be used.",
+        disclosureVersion: "screening-consent-v2",
+        consentSummary: "Consent summary snapshot",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.screeningRequest?.consent?.acceptedAt).toBeTypeOf("number");
+    expect(res.body?.screeningRequest?.consent?.providerLabel).toBe("TransUnion");
+    expect(res.body?.screeningRequest?.consent?.consentVersion).toBe("screening-consent-v2");
+
+    const savedConsent = Array.from(ensureCollection("screening_consents").values())[0];
+    expect(savedConsent).toEqual(
+      expect.objectContaining({
+        requestId: "screening-1",
+        tenantId: "tenant-1",
+        applicantId: "user-1",
+        rentalApplicationId: "app-1",
+        landlordId: "landlord-1",
+        propertyId: "prop-1",
+        providerKey: "transunion_redirect",
+        providerLabel: "TransUnion",
+        consentVersion: "screening-consent-v2",
+        consentTextSummary: "Consent summary snapshot",
+        acceptedBy: "user-1",
+      })
+    );
+
+    expect(
+      Array.from(ensureCollection("screening_audit_log").values()).some(
+        (event) => event.eventType === "consent_accepted"
+      )
+    ).toBe(true);
+    expect(
+      Array.from(ensureCollection("canonicalEvents").values()).some(
+        (event) =>
+          event.type === "screening_consent_confirmed" &&
+          event.metadata?.requestId === "screening-1" &&
+          event.metadata?.providerKey === "transunion_redirect"
+      )
+    ).toBe(true);
+  });
+
+  it("rejects screening consent for another tenant's request", async () => {
+    ensureCollection("screening_requests").set("screening-2", {
+      rentalApplicationId: "app-1",
+      landlordId: "landlord-1",
+      applicantTenantId: "tenant-2",
+      propertyId: "prop-1",
+      status: "requested",
+      createdAt: 100,
+      updatedAt: 100,
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/screening/screening-2/consent",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+      body: {
+        accepted: true,
+      },
+    });
+
+    expect(res.status).toBe(403);
+    expect(res.body?.error).toBe("FORBIDDEN");
+  });
+
+  it("keeps screening blocked when tenant consent is missing", async () => {
+    ensureCollection("screening_requests").set("screening-3", {
+      rentalApplicationId: "app-1",
+      landlordId: "landlord-1",
+      applicantTenantId: "tenant-1",
+      applicantUserId: "user-1",
+      propertyId: "prop-1",
+      providerSelection: "manual",
+      status: "consent_pending",
+      createdAt: 100,
+      updatedAt: 100,
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/screening/screening-3/start",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body?.error).toBe("CONSENT_REQUIRED");
+    expect(res.body?.blockReason).toBe("missing_tenant_consent");
+  });
+
+  it("allows screening to proceed past the consent gate when consent exists", async () => {
+    ensureCollection("screening_requests").set("screening-4", {
+      rentalApplicationId: "app-1",
+      landlordId: "landlord-1",
+      applicantTenantId: "tenant-1",
+      applicantUserId: "user-1",
+      applicantName: "Taylor Tenant",
+      propertyId: "prop-1",
+      propertyLabel: "123 Main St",
+      unitLabel: "Unit 4",
+      providerSelection: "manual",
+      latestConsentId: "consent-4",
+      status: "consented",
+      createdAt: 100,
+      updatedAt: 100,
+    });
+    ensureCollection("screening_consents").set("consent-4", {
+      id: "consent-4",
+      requestId: "screening-4",
+      tenantId: "tenant-1",
+      applicantId: "user-1",
+      acceptedAt: 200,
+      viewedAt: 150,
+      providerKey: "manual",
+      providerLabel: "Manual review",
+      consentVersion: "screening-consent-v2",
+      providerDisclosure: "Disclosure",
+      disclosureVersion: "screening-consent-v2",
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/screening/screening-4/start",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.screeningRequest?.session?.providerKey).toBe("manual");
+    expect(res.body?.screeningRequest?.status).toBe("manual_review_required");
   });
 });

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -27,6 +27,7 @@ import {
   applyNotificationUpdate,
   buildTenantSafeWorkOrderNotifications,
 } from "../lib/maintenanceNotifications";
+import { writeCanonicalEvent } from "../lib/events/buildEvent";
 
 const router = Router();
 router.use(authenticateJwt);
@@ -400,8 +401,17 @@ type ScreeningConsentRecord = {
   id: string;
   requestId: string;
   tenantId: string;
+  applicantId?: string | null;
+  rentalApplicationId?: string | null;
+  landlordId?: string | null;
+  propertyId?: string | null;
+  providerKey?: ScreeningProviderKey | null;
+  providerLabel?: string | null;
+  consentVersion?: string | null;
+  consentTextSummary?: string | null;
   viewedAt: number | null;
   acceptedAt: number | null;
+  acceptedBy?: string | null;
   providerDisclosure: string | null;
   disclosureVersion: string | null;
 };
@@ -753,8 +763,17 @@ async function getLatestConsent(requestId: string): Promise<ScreeningConsentReco
     id: item.id,
     requestId,
     tenantId: cleanString(item.tenantId, 160) || "",
+    applicantId: cleanString(item.applicantId, 160),
+    rentalApplicationId: cleanString(item.rentalApplicationId, 160),
+    landlordId: cleanString(item.landlordId, 160),
+    propertyId: cleanString(item.propertyId, 160),
+    providerKey: ((cleanString(item.providerKey, 80) || "") as ScreeningProviderKey | "") || null,
+    providerLabel: cleanString(item.providerLabel, 120),
+    consentVersion: cleanString(item.consentVersion, 80),
+    consentTextSummary: cleanString(item.consentTextSummary, 600),
     viewedAt: Number(item.viewedAt || 0) || null,
     acceptedAt: Number(item.acceptedAt || 0) || null,
+    acceptedBy: cleanString(item.acceptedBy, 160),
     providerDisclosure: cleanString(item.providerDisclosure, 200),
     disclosureVersion: cleanString(item.disclosureVersion, 80),
   };
@@ -968,6 +987,68 @@ function screeningSummaryText(request: ScreeningRequestRecord, session: Screenin
   if (session?.handoffType === "redirect") return "Your screening partner handoff is ready. Continue when you are ready.";
   if (request.status === "consent_pending") return "Consent is required before screening can begin.";
   return "Screening is queued and ready for the next step.";
+}
+
+function getScreeningProviderLabel(providerKey: ScreeningProviderKey | null | undefined): string {
+  if (providerKey === "transunion_redirect") return "TransUnion";
+  if (providerKey === "equifax") return "Equifax";
+  if (providerKey === "manual") return "Manual review";
+  return "Selected screening provider";
+}
+
+function buildScreeningConsentSummary(input: {
+  providerKey: ScreeningProviderKey | null | undefined;
+  propertyLabel?: string | null;
+  unitLabel?: string | null;
+}) {
+  const providerLabel = getScreeningProviderLabel(input.providerKey);
+  const locationLabel = [input.propertyLabel, input.unitLabel].filter(Boolean).join(" - ");
+  const locationSegment = locationLabel ? ` for ${locationLabel}` : "";
+  return `The landlord requested tenant screening${locationSegment}. A third-party screening provider may be used, including ${providerLabel} when applicable. RentChain records consent and workflow status for audit and application review purposes.`;
+}
+
+async function writeScreeningConsentCanonicalEvent(input: {
+  request: ScreeningRequestRecord;
+  consent: ScreeningConsentRecord;
+  actorId: string;
+}) {
+  const providerKey = input.consent.providerKey || input.request.providerSelection || null;
+  const providerLabel = input.consent.providerLabel || getScreeningProviderLabel(providerKey);
+  await writeCanonicalEvent({
+    type: "screening_consent_confirmed",
+    domain: "screening",
+    action: "screening_consent_confirmed",
+    status: "confirmed",
+    actor: {
+      type: "tenant",
+      id: input.actorId,
+      role: "tenant",
+    },
+    resource: {
+      type: "screening_request",
+      id: input.request.id,
+      parentType: input.request.rentalApplicationId ? "rental_application" : input.request.landlordId ? "landlord" : "tenant",
+      parentId: input.request.rentalApplicationId || input.request.landlordId || input.request.applicantTenantId || null,
+    },
+    visibility: "internal",
+    occurredAt: input.consent.acceptedAt || Date.now(),
+    summary: "Tenant screening consent confirmed",
+    metadata: {
+      requestId: input.request.id,
+      consentId: input.consent.id,
+      tenantId: input.request.applicantTenantId || input.consent.tenantId || null,
+      applicantId: input.request.applicantUserId || input.consent.applicantId || null,
+      applicationId: input.request.rentalApplicationId || input.consent.rentalApplicationId || null,
+      landlordId: input.request.landlordId || input.consent.landlordId || null,
+      propertyId: input.request.propertyId || input.consent.propertyId || null,
+      providerKey,
+      providerLabel,
+      consentVersion: input.consent.consentVersion || input.consent.disclosureVersion || null,
+      acceptedBy: input.consent.acceptedBy || input.actorId,
+      consentTextSummary: input.consent.consentTextSummary || null,
+    },
+    tags: ["screening-consent", `provider:${providerKey || "pending"}`],
+  });
 }
 
 async function getTenantConversationIds(tenantId: string): Promise<string[]> {
@@ -1352,6 +1433,7 @@ function shapeScreeningResponse(input: {
     startedAt: request.startedAt || session?.createdAt || null,
     completedAt: request.completedAt || result?.updatedAt || null,
     provider: session?.providerKey || request.providerSelection || null,
+    providerLabel: getScreeningProviderLabel(session?.providerKey || request.providerSelection || null),
     packageType: request.packageType,
     payerType: request.payerType,
     propertyLabel: request.propertyLabel,
@@ -1361,8 +1443,19 @@ function shapeScreeningResponse(input: {
     consent: consent
       ? {
           id: consent.id,
+          requestId: consent.requestId,
+          tenantId: consent.tenantId,
+          applicantId: consent.applicantId || null,
+          rentalApplicationId: consent.rentalApplicationId || null,
+          landlordId: consent.landlordId || null,
+          propertyId: consent.propertyId || null,
+          providerKey: consent.providerKey || null,
+          providerLabel: consent.providerLabel || null,
+          consentVersion: consent.consentVersion || consent.disclosureVersion || null,
+          consentTextSummary: consent.consentTextSummary || null,
           viewedAt: consent.viewedAt,
           acceptedAt: consent.acceptedAt,
+          acceptedBy: consent.acceptedBy || null,
           providerDisclosure: consent.providerDisclosure,
           disclosureVersion: consent.disclosureVersion,
         }
@@ -3655,6 +3748,18 @@ router.post("/screening/:requestId/consent", requireTenant, async (req: any, res
       return res.status(400).json({ ok: false, error: "CONSENT_ACTION_REQUIRED" });
     }
 
+    if (accepted && existingConsent?.acceptedAt) {
+      return res.json({
+        ok: true,
+        screeningRequest: shapeScreeningResponse({
+          request,
+          consent: existingConsent,
+          session: await getLatestSession(requestId),
+          result: await getLatestResult(requestId),
+        }),
+      });
+    }
+
     const now = Date.now();
     const consentRef =
       existingConsent && !existingConsent.acceptedAt
@@ -3664,15 +3769,33 @@ router.post("/screening/:requestId/consent", requireTenant, async (req: any, res
       cleanString(req.body?.providerDisclosure, 200) ||
       (request.providerSelection ? `This screening may be completed using ${request.providerSelection}.` : "This screening may be completed by a secure screening provider selected at runtime.");
     const disclosureVersion = cleanString(req.body?.disclosureVersion, 80) || "screening-consent-v1";
+    const providerKey = request.providerSelection || null;
+    const providerLabel = getScreeningProviderLabel(providerKey);
+    const consentSummary =
+      cleanString(req.body?.consentSummary, 600) ||
+      buildScreeningConsentSummary({
+        providerKey,
+        propertyLabel: request.propertyLabel,
+        unitLabel: request.unitLabel,
+      });
 
     await consentRef.set(
       {
         id: consentRef.id,
         requestId,
         tenantId,
+        applicantId: request.applicantUserId || request.applicantTenantId || null,
+        rentalApplicationId: request.rentalApplicationId || null,
+        landlordId: request.landlordId || null,
+        propertyId: request.propertyId || null,
+        providerKey,
+        providerLabel,
+        consentVersion: disclosureVersion,
+        consentTextSummary: consentSummary,
         applicantName: request.applicantName || null,
         viewedAt: existingConsent?.viewedAt || now,
         acceptedAt: accepted ? now : existingConsent?.acceptedAt || null,
+        acceptedBy: accepted ? actorId : existingConsent?.acceptedBy || null,
         providerDisclosure,
         disclosureVersion,
         ipAddress: cleanString(req.ip, 120),
@@ -3709,11 +3832,20 @@ router.post("/screening/:requestId/consent", requireTenant, async (req: any, res
       metadata: {
         consentId: consentRef.id,
         disclosureVersion,
+        providerKey,
+        providerLabel,
       },
     });
 
     const refreshedRequest = await getScreeningRequestById(requestId);
     const refreshedConsent = await getLatestConsent(requestId);
+    if (accepted && refreshedConsent) {
+      await writeScreeningConsentCanonicalEvent({
+        request,
+        consent: refreshedConsent,
+        actorId,
+      });
+    }
     return res.json({
       ok: true,
       screeningRequest: shapeScreeningResponse({
@@ -3875,7 +4007,11 @@ router.post("/screening/:requestId/start", requireTenant, async (req: any, res) 
         : code === "SCREENING_STILL_IN_PROGRESS"
         ? 409
         : 500;
-    return res.status(status).json({ ok: false, error: status === 500 ? "TENANT_SCREENING_START_FAILED" : code });
+    return res.status(status).json({
+      ok: false,
+      error: status === 500 ? "TENANT_SCREENING_START_FAILED" : code,
+      blockReason: code === "CONSENT_REQUIRED" ? "missing_tenant_consent" : null,
+    });
   }
 });
 

--- a/rentchain-frontend/src/api/tenantScreeningApi.ts
+++ b/rentchain-frontend/src/api/tenantScreeningApi.ts
@@ -47,6 +47,7 @@ export type TenantScreeningRequest = {
   startedAt: number | null;
   completedAt: number | null;
   provider: string | null;
+  providerLabel?: string | null;
   packageType: string | null;
   payerType: string | null;
   propertyLabel: string | null;
@@ -55,8 +56,19 @@ export type TenantScreeningRequest = {
   nextAction: string | null;
   consent: {
     id: string;
+    requestId?: string;
+    tenantId?: string | null;
+    applicantId?: string | null;
+    rentalApplicationId?: string | null;
+    landlordId?: string | null;
+    propertyId?: string | null;
+    providerKey?: string | null;
+    providerLabel?: string | null;
+    consentVersion?: string | null;
+    consentTextSummary?: string | null;
     viewedAt: number | null;
     acceptedAt: number | null;
+    acceptedBy?: string | null;
     providerDisclosure: string | null;
     disclosureVersion: string | null;
   } | null;
@@ -132,7 +144,7 @@ export async function getTenantScreeningStatus(requestId: string) {
 
 export async function markTenantScreeningViewed(
   requestId: string,
-  input?: { providerDisclosure?: string; disclosureVersion?: string }
+  input?: { providerDisclosure?: string; disclosureVersion?: string; consentSummary?: string }
 ) {
   return tenantApiFetch<{ ok: boolean; screeningRequest: TenantScreeningRequest }>(
     `/tenant/screening/${encodeURIComponent(requestId)}/consent`,
@@ -142,6 +154,7 @@ export async function markTenantScreeningViewed(
         viewed: true,
         providerDisclosure: input?.providerDisclosure,
         disclosureVersion: input?.disclosureVersion,
+        consentSummary: input?.consentSummary,
       },
     }
   );
@@ -149,7 +162,7 @@ export async function markTenantScreeningViewed(
 
 export async function acceptTenantScreeningConsent(
   requestId: string,
-  input?: { providerDisclosure?: string; disclosureVersion?: string }
+  input?: { providerDisclosure?: string; disclosureVersion?: string; consentSummary?: string }
 ) {
   return tenantApiFetch<{ ok: boolean; screeningRequest: TenantScreeningRequest }>(
     `/tenant/screening/${encodeURIComponent(requestId)}/consent`,
@@ -159,6 +172,7 @@ export async function acceptTenantScreeningConsent(
         accepted: true,
         providerDisclosure: input?.providerDisclosure,
         disclosureVersion: input?.disclosureVersion,
+        consentSummary: input?.consentSummary,
       },
     }
   );

--- a/rentchain-frontend/src/components/tenant/TenantScreeningConsentCard.test.tsx
+++ b/rentchain-frontend/src/components/tenant/TenantScreeningConsentCard.test.tsx
@@ -1,0 +1,167 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import TenantScreeningConsentCard from "./TenantScreeningConsentCard";
+
+const tenantScreeningApi = vi.hoisted(() => ({
+  acceptTenantScreeningConsent: vi.fn(),
+  markTenantScreeningViewed: vi.fn(),
+}));
+
+vi.mock("../../api/tenantScreeningApi", async () => {
+  const actual = await vi.importActual<any>("../../api/tenantScreeningApi");
+  return {
+    ...actual,
+    acceptTenantScreeningConsent: tenantScreeningApi.acceptTenantScreeningConsent,
+    markTenantScreeningViewed: tenantScreeningApi.markTenantScreeningViewed,
+  };
+});
+
+function buildScreening(overrides?: Record<string, unknown>) {
+  return {
+    id: "screening-1",
+    rentalApplicationId: "app-1",
+    status: "consent_pending",
+    normalizedResultStatus: "pending",
+    requestedAt: 1710000000000,
+    consentedAt: null,
+    startedAt: null,
+    completedAt: null,
+    provider: "transunion_redirect",
+    providerLabel: "TransUnion",
+    packageType: "basic",
+    payerType: "landlord",
+    propertyLabel: "123 Main St",
+    unitLabel: "Unit 4",
+    applicantName: "Taylor Tenant",
+    nextAction: "awaiting_applicant_consent",
+    consent: null,
+    session: null,
+    result: null,
+    returnFlow: null,
+    summary: {
+      status: "consent_pending",
+      provider: "transunion_redirect",
+      requestedDate: 1710000000000,
+      package: "basic",
+      summaryResult: "Consent is required before screening can begin.",
+      nextActions: ["Provide consent"],
+    },
+    auditTrail: [],
+    ...overrides,
+  } as any;
+}
+
+describe("TenantScreeningConsentCard", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    tenantScreeningApi.markTenantScreeningViewed.mockResolvedValue({ ok: true });
+    tenantScreeningApi.acceptTenantScreeningConsent.mockResolvedValue({
+      ok: true,
+      screeningRequest: buildScreening({
+        status: "consented",
+        consentedAt: 1710000100000,
+        consent: {
+          id: "consent-1",
+          requestId: "screening-1",
+          acceptedAt: 1710000100000,
+          providerLabel: "TransUnion",
+          providerDisclosure: "Disclosure",
+          disclosureVersion: "screening-consent-v2",
+        },
+      }),
+    });
+  });
+
+  it("renders plain-English consent copy and keeps the authorize button disabled until checked", async () => {
+    render(<TenantScreeningConsentCard screening={buildScreening()} />);
+
+    expect(screen.getByText(/The landlord is requesting tenant screening for this rental application/i)).toBeInTheDocument();
+    expect(screen.getByText(/A third-party provider may be used/i)).toBeInTheDocument();
+    expect(screen.getByText(/RentChain records your consent and screening workflow status for audit/i)).toBeInTheDocument();
+
+    const button = screen.getByRole("button", { name: /Authorize screening/i });
+    expect(button).toBeDisabled();
+
+    fireEvent.click(screen.getByLabelText(/Authorize screening consent/i));
+    expect(button).not.toBeDisabled();
+
+    await waitFor(() => {
+      expect(tenantScreeningApi.markTenantScreeningViewed).toHaveBeenCalledWith(
+        "screening-1",
+        expect.objectContaining({
+          disclosureVersion: "screening-consent-v2",
+        })
+      );
+    });
+  });
+
+  it("submits explicit consent through the tenant screening API", async () => {
+    const onConsentUpdated = vi.fn();
+    render(<TenantScreeningConsentCard screening={buildScreening()} onConsentUpdated={onConsentUpdated} />);
+
+    fireEvent.click(screen.getByLabelText(/Authorize screening consent/i));
+    fireEvent.click(screen.getByRole("button", { name: /Authorize screening/i }));
+
+    await waitFor(() => {
+      expect(tenantScreeningApi.acceptTenantScreeningConsent).toHaveBeenCalledWith(
+        "screening-1",
+        expect.objectContaining({
+          disclosureVersion: "screening-consent-v2",
+          providerDisclosure: expect.stringMatching(/third-party screening provider may be used/i),
+          consentSummary: expect.stringMatching(/RentChain records consent and screening workflow status/i),
+        })
+      );
+    });
+    expect(onConsentUpdated).toHaveBeenCalled();
+  });
+
+  it("shows existing consent confirmation details without a duplicate prompt", () => {
+    render(
+      <TenantScreeningConsentCard
+        screening={buildScreening({
+          status: "consented",
+          consentedAt: 1710000100000,
+          consent: {
+            id: "consent-1",
+            requestId: "screening-1",
+            acceptedAt: 1710000100000,
+            providerLabel: "TransUnion",
+            consentTextSummary: "Consent summary snapshot",
+            providerDisclosure: "Disclosure",
+            disclosureVersion: "screening-consent-v2",
+          },
+        })}
+      />
+    );
+
+    expect(screen.getByText(/Screening consent confirmed/i)).toBeInTheDocument();
+    expect(screen.getByText(/Confirmed at:/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Provider:/i).length).toBeGreaterThan(0);
+    expect(screen.queryByRole("button", { name: /Authorize screening/i })).not.toBeInTheDocument();
+  });
+
+  it("uses neutral provider-setup copy after consent when landlord setup is still completing", () => {
+    render(
+      <TenantScreeningConsentCard
+        screening={buildScreening({
+          status: "manual_review_required",
+          consentedAt: 1710000100000,
+          consent: {
+            id: "consent-1",
+            requestId: "screening-1",
+            acceptedAt: 1710000100000,
+            providerLabel: "Manual review",
+            providerDisclosure: "Disclosure",
+            disclosureVersion: "screening-consent-v2",
+          },
+        })}
+      />
+    );
+
+    expect(
+      screen.getByText(/Screening setup is being completed by the landlord/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/tenant/TenantScreeningConsentCard.tsx
+++ b/rentchain-frontend/src/components/tenant/TenantScreeningConsentCard.tsx
@@ -1,0 +1,224 @@
+import React from "react";
+import {
+  acceptTenantScreeningConsent,
+  markTenantScreeningViewed,
+  type TenantScreeningRequest,
+} from "../../api/tenantScreeningApi";
+import { colors, radius, spacing, text as textTokens } from "../../styles/tokens";
+
+const CONSENT_VERSION = "screening-consent-v2";
+
+function formatDateTime(value: number | null | undefined) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return date.toLocaleString();
+}
+
+function resolveProviderLabel(screening: TenantScreeningRequest) {
+  if (screening.consent?.providerLabel) return screening.consent.providerLabel;
+  if (screening.providerLabel) return screening.providerLabel;
+  if (screening.provider === "transunion_redirect") return "TransUnion";
+  if (screening.provider === "equifax") return "Equifax";
+  if (screening.provider === "manual") return "Manual review";
+  return "Selected screening provider";
+}
+
+function buildConsentSummary(screening: TenantScreeningRequest) {
+  const providerLabel = resolveProviderLabel(screening);
+  const propertyContext = [screening.propertyLabel, screening.unitLabel].filter(Boolean).join(" - ");
+  const propertySegment = propertyContext ? ` for ${propertyContext}` : "";
+  return `The landlord requested tenant screening${propertySegment}. A third-party screening provider may be used, including ${providerLabel} when applicable. RentChain records consent and screening workflow status for audit and application review purposes.`;
+}
+
+function buildProviderDisclosure(screening: TenantScreeningRequest) {
+  const providerLabel = resolveProviderLabel(screening);
+  return `The landlord is requesting screening for this rental application. A third-party screening provider may be used, including ${providerLabel} when applicable.`;
+}
+
+function nextStepCopy(screening: TenantScreeningRequest) {
+  if (screening.status === "manual_review_required") {
+    return "Your consent has been recorded. Screening setup is being completed by the landlord.";
+  }
+  if (screening.status === "consented" || screening.consent?.acceptedAt) {
+    return "Your consent has been recorded. The landlord can continue reviewing your application.";
+  }
+  return "Consent is required before screening can proceed.";
+}
+
+type Props = {
+  screening: TenantScreeningRequest;
+  onConsentUpdated?: (screening: TenantScreeningRequest) => void;
+};
+
+export default function TenantScreeningConsentCard({ screening, onConsentUpdated }: Props) {
+  const [checked, setChecked] = React.useState(false);
+  const [submitting, setSubmitting] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const providerLabel = resolveProviderLabel(screening);
+  const acceptedAt = screening.consent?.acceptedAt || screening.consentedAt || null;
+  const propertyContext = [screening.propertyLabel, screening.unitLabel].filter(Boolean).join(" - ");
+  const disclosure = screening.consent?.providerDisclosure || buildProviderDisclosure(screening);
+  const consentSummary = screening.consent?.consentTextSummary || buildConsentSummary(screening);
+
+  React.useEffect(() => {
+    if (acceptedAt || screening.status !== "consent_pending") return;
+    void markTenantScreeningViewed(screening.id, {
+      providerDisclosure: disclosure,
+      disclosureVersion: CONSENT_VERSION,
+      consentSummary,
+    }).catch(() => undefined);
+  }, [acceptedAt, consentSummary, disclosure, screening.id, screening.status]);
+
+  const submitConsent = async () => {
+    if (!checked || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const response = await acceptTenantScreeningConsent(screening.id, {
+        providerDisclosure: disclosure,
+        disclosureVersion: CONSENT_VERSION,
+        consentSummary,
+      });
+      onConsentUpdated?.(response.screeningRequest);
+      setChecked(false);
+    } catch (err: any) {
+      setError(err?.message || err?.payload?.error || "Unable to record your screening consent.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        border: `1px solid ${colors.border}`,
+        borderRadius: radius.md,
+        background: colors.panel,
+        padding: spacing.md,
+        display: "grid",
+        gap: spacing.sm,
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.sm, flexWrap: "wrap" }}>
+        <div>
+          <div style={{ fontWeight: 800, color: textTokens.primary, fontSize: "1rem" }}>
+            {acceptedAt ? "Screening consent confirmed" : "Screening consent required"}
+          </div>
+          <div style={{ color: textTokens.secondary, marginTop: 4, lineHeight: 1.5 }}>
+            {nextStepCopy(screening)}
+          </div>
+        </div>
+        <div
+          style={{
+            alignSelf: "start",
+            padding: "6px 10px",
+            borderRadius: 999,
+            background: acceptedAt ? "rgba(34,197,94,0.12)" : "rgba(245,158,11,0.14)",
+            color: acceptedAt ? "#166534" : "#92400e",
+            fontWeight: 700,
+            fontSize: "0.85rem",
+          }}
+        >
+          {acceptedAt ? "Consent confirmed" : "Action needed"}
+        </div>
+      </div>
+
+      <div style={{ display: "grid", gap: 6, color: textTokens.secondary }}>
+        <div>
+          The landlord is requesting tenant screening for this rental application.
+        </div>
+        <div>
+          Provider: <strong style={{ color: textTokens.primary }}>{providerLabel}</strong>
+        </div>
+        {propertyContext ? (
+          <div>
+            Application context: <strong style={{ color: textTokens.primary }}>{propertyContext}</strong>
+          </div>
+        ) : null}
+        <div>
+          A third-party provider may be used to verify identity, credit, background, or rental suitability depending on the screening product selected.
+        </div>
+        <div>
+          Results are made available to the landlord according to the screening workflow and access rules.
+        </div>
+        <div style={{ color: textTokens.muted }}>
+          RentChain records your consent and screening workflow status for audit and application review purposes.
+        </div>
+      </div>
+
+      {acceptedAt ? (
+        <div
+          style={{
+            display: "grid",
+            gap: 6,
+            padding: "10px 12px",
+            borderRadius: radius.md,
+            background: colors.card,
+            border: `1px solid ${colors.border}`,
+            color: textTokens.secondary,
+          }}
+        >
+          <div>
+            Confirmed at: <strong style={{ color: textTokens.primary }}>{formatDateTime(acceptedAt)}</strong>
+          </div>
+          <div>
+            Provider: <strong style={{ color: textTokens.primary }}>{providerLabel}</strong>
+          </div>
+          <div>{consentSummary}</div>
+        </div>
+      ) : (
+        <>
+          <label
+            style={{
+              display: "flex",
+              alignItems: "flex-start",
+              gap: 10,
+              padding: "10px 12px",
+              borderRadius: radius.md,
+              border: `1px solid ${colors.border}`,
+              background: colors.card,
+              color: textTokens.primary,
+              cursor: "pointer",
+            }}
+          >
+            <input
+              aria-label="Authorize screening consent"
+              type="checkbox"
+              checked={checked}
+              onChange={(event) => setChecked(event.target.checked)}
+              style={{ marginTop: 2 }}
+            />
+            <span>
+              I authorize the requested tenant screening for this rental application and understand that a third-party screening provider may be used.
+            </span>
+          </label>
+
+          <div style={{ display: "flex", gap: spacing.sm, alignItems: "center", flexWrap: "wrap" }}>
+            <button
+              type="button"
+              disabled={!checked || submitting}
+              onClick={() => void submitConsent()}
+              style={{
+                padding: "10px 14px",
+                borderRadius: radius.md,
+                border: `1px solid ${colors.border}`,
+                background: !checked || submitting ? "#e2e8f0" : colors.accent,
+                color: !checked || submitting ? "#64748b" : "#fff",
+                fontWeight: 700,
+                cursor: !checked || submitting ? "not-allowed" : "pointer",
+              }}
+            >
+              {submitting ? "Authorizing..." : "Authorize screening"}
+            </button>
+            <div style={{ color: textTokens.muted, fontSize: "0.9rem" }}>
+              Consent is required before screening can proceed.
+            </div>
+          </div>
+        </>
+      )}
+
+      {error ? <div style={{ color: colors.danger }}>{error}</div> : null}
+    </div>
+  );
+}

--- a/rentchain-frontend/src/pages/tenant/TenantDashboardPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantDashboardPage.tsx
@@ -10,6 +10,7 @@ import {
 import { TenantCommunicationItem } from "../../api/tenantCommunicationsApi";
 import { TenantScreeningRequest, listTenantScreenings } from "../../api/tenantScreeningApi";
 import { CreateMaintenanceRequestModal } from "../../components/tenant/CreateMaintenanceRequestModal";
+import TenantScreeningConsentCard from "../../components/tenant/TenantScreeningConsentCard";
 import { Card, Section } from "../../components/ui/Ui";
 import { clearTenantToken, getTenantToken } from "../../lib/tenantAuth";
 import { colors, radius, shadows, spacing, text as textTokens } from "../../styles/tokens";
@@ -529,6 +530,9 @@ export default function TenantDashboardPage() {
   const unreadMessage = communications.find((item) => item.type === "message" && !item.read);
   const latestMaintenanceUpdate = communications.find((item) => item.type === "maintenance_update");
   const activeScreening = screenings[0] || null;
+  const handleScreeningUpdated = React.useCallback((next: TenantScreeningRequest) => {
+    setScreenings((current) => current.map((item) => (item.id === next.id ? next : item)));
+  }, []);
 
   const checklist = useMemo(
     () => [
@@ -822,12 +826,13 @@ export default function TenantDashboardPage() {
                   Status: <strong style={{ color: textTokens.primary }}>{activeScreening.summary.status.replace(/_/g, " ")}</strong>
                 </div>
                 <div style={{ color: textTokens.secondary }}>
-                  Provider: <strong style={{ color: textTokens.primary }}>{(activeScreening.provider || "runtime selected").replace(/_/g, " ")}</strong>
+                  Provider: <strong style={{ color: textTokens.primary }}>{activeScreening.providerLabel || (activeScreening.provider || "selected screening provider").replace(/_/g, " ")}</strong>
                 </div>
                 <div style={{ color: textTokens.secondary }}>
                   Requested: <strong style={{ color: textTokens.primary }}>{fmtDate(activeScreening.requestedAt)}</strong>
                 </div>
                 <div style={{ color: textTokens.secondary }}>{activeScreening.summary.summaryResult}</div>
+                <TenantScreeningConsentCard screening={activeScreening} onConsentUpdated={handleScreeningUpdated} />
               </div>
             ) : (
               <div style={{ color: textTokens.muted }}>


### PR DESCRIPTION
This PR improves the tenant-side screening consent experience.

Includes:
- tenant-facing consent card with plain-English copy
- explicit checkbox and Authorize screening action
- enriched consent metadata persistence
- confirmed-consent display with provider label and timestamp
- canonical screening_consent_confirmed event bridge
- fail-closed tenant consent gating before screening start
- focused backend and frontend tests

Verification:
- tenantPortalRoutes.test.ts passed
- backend typecheck passed
- TenantScreeningConsentCard.test.tsx passed
- frontend build passed

Known remaining gaps:
- consent revocation is not implemented
- canonical events were added for confirmed consent only
- no dedicated tenant screening inbox/page yet
- legacy/parallel screening paths may still need future alignment