### PR TITLE
ux: improve screening funnel conversion and activation flow

### DIFF
--- a/rentchain-frontend/src/components/integrations/ConnectTransUnionModal.test.tsx
+++ b/rentchain-frontend/src/components/integrations/ConnectTransUnionModal.test.tsx
@@ -16,6 +16,9 @@ describe("ConnectTransUnionModal", () => {
     expect(screen.getByText("Connect Your TransUnion Account")).toBeInTheDocument();
     expect(screen.getByText("Need TransUnion access?")).toBeInTheDocument();
     expect(screen.getByText("Already credentialed?")).toBeInTheDocument();
+    expect(screen.getByText("Choose path")).toBeInTheDocument();
+    expect(screen.getByText("Connect membership")).toBeInTheDocument();
+    expect(screen.getByText("Ready to screen")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Get TransUnion Access" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "I Already Have Credentials" })).toBeInTheDocument();
     expect(screen.queryByText("Member code")).not.toBeInTheDocument();
@@ -43,6 +46,9 @@ describe("ConnectTransUnionModal", () => {
     expect(dialogQueries.getByText("Member code")).toBeInTheDocument();
     expect(dialogQueries.getByText("Passcode")).toBeInTheDocument();
     expect(dialogQueries.getByText("Business details required for setup")).toBeInTheDocument();
+    expect(
+      dialogQueries.getByText(/Next step: connect your membership now, then return to Applications/i),
+    ).toBeInTheDocument();
   });
 
   it("opens the pending credentialing flow directly in the focused credential-entry step", async () => {

--- a/rentchain-frontend/src/components/integrations/ConnectTransUnionModal.tsx
+++ b/rentchain-frontend/src/components/integrations/ConnectTransUnionModal.tsx
@@ -192,6 +192,52 @@ export function ConnectTransUnionModal({
           </p>
         </div>
 
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))",
+            gap: spacing.sm,
+          }}
+        >
+          {[
+            {
+              key: "start",
+              label: "Choose path",
+              active: showChooser,
+              complete: showCredentials || success,
+            },
+            {
+              key: "connect",
+              label: "Connect membership",
+              active: showCredentials,
+              complete: success,
+            },
+            {
+              key: "ready",
+              label: "Ready to screen",
+              active: success,
+              complete: success,
+            },
+          ].map((item) => (
+            <div
+              key={item.key}
+              style={{
+                border: `1px solid ${item.active || item.complete ? colors.accent : colors.border}`,
+                background: item.active || item.complete ? colors.accentSoft : colors.bg,
+                borderRadius: radius.md,
+                padding: spacing.sm,
+                display: "grid",
+                gap: 4,
+              }}
+            >
+              <div style={{ fontWeight: 700 }}>{item.label}</div>
+              <div style={{ color: text.muted, fontSize: "0.85rem" }}>
+                {item.active ? "Current step" : item.complete ? "Completed" : "Upcoming"}
+              </div>
+            </div>
+          ))}
+        </div>
+
         {showChooser ? (
           <div
             style={{
@@ -212,8 +258,13 @@ export function ConnectTransUnionModal({
             >
               <div style={{ fontWeight: 700 }}>Need TransUnion access?</div>
               <div style={{ color: text.muted, fontSize: "0.92rem", lineHeight: 1.5 }}>
-                Start with credentialing first. Once TransUnion issues your member code and
-                passcode, come back here to finish setup in RentChain.
+                Don&apos;t have TransUnion yet? We&apos;ll guide you through the external onboarding
+                path first. Once TransUnion issues your member code and passcode, come back here to
+                finish setup in RentChain.
+              </div>
+              <div style={{ color: text.subtle, fontSize: "0.86rem" }}>
+                Outcome: your account moves into a credentialing-in-progress state until you receive
+                the issued membership details.
               </div>
               {onGetAccess ? (
                 <div>
@@ -235,7 +286,12 @@ export function ConnectTransUnionModal({
             >
               <div style={{ fontWeight: 700 }}>Already credentialed?</div>
               <div style={{ color: text.muted, fontSize: "0.92rem", lineHeight: 1.5 }}>
-                Use the membership details TransUnion already issued to your business.
+                Already approved by TransUnion? Enter the member code and passcode that were issued
+                to your business so you can start screening in RentChain.
+              </div>
+              <div style={{ color: text.subtle, fontSize: "0.86rem" }}>
+                Outcome: once the credentials are verified, your account is connected and ready to
+                screen.
               </div>
               <div>
                 <Button
@@ -267,6 +323,10 @@ export function ConnectTransUnionModal({
               <div style={{ fontWeight: 700 }}>Membership credentials</div>
               <div style={{ color: text.muted, fontSize: "0.92rem", lineHeight: 1.5 }}>
                 Enter the member code and passcode exactly as TransUnion provided them.
+              </div>
+              <div style={{ color: text.subtle, fontSize: "0.86rem" }}>
+                Next step: connect your membership now, then return to Applications to start the
+                first screening.
               </div>
             </div>
 

--- a/rentchain-frontend/src/components/integrations/GetTransUnionAccessModal.tsx
+++ b/rentchain-frontend/src/components/integrations/GetTransUnionAccessModal.tsx
@@ -55,6 +55,36 @@ export function GetTransUnionAccessModal({
         </div>
         <div
           style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))",
+            gap: spacing.sm,
+          }}
+        >
+          {[
+            { label: "Not connected", state: "complete" },
+            { label: "Get access", state: "current" },
+            { label: "Return to connect", state: "upcoming" },
+          ].map((step) => (
+            <div
+              key={step.label}
+              style={{
+                border: `1px solid ${step.state === "upcoming" ? colors.border : colors.accent}`,
+                background: step.state === "upcoming" ? colors.bg : colors.accentSoft,
+                borderRadius: radius.md,
+                padding: spacing.sm,
+                display: "grid",
+                gap: 4,
+              }}
+            >
+              <div style={{ fontWeight: 700 }}>{step.label}</div>
+              <div style={{ color: text.muted, fontSize: "0.85rem" }}>
+                {step.state === "current" ? "Current step" : step.state === "complete" ? "Completed" : "Upcoming"}
+              </div>
+            </div>
+          ))}
+        </div>
+        <div
+          style={{
             border: `1px solid ${colors.border}`,
             borderRadius: radius.md,
             padding: spacing.sm,
@@ -69,6 +99,20 @@ export function GetTransUnionAccessModal({
             <li>Wait for your member code and passcode to be issued.</li>
             <li>Return to RentChain and connect your account.</li>
           </ol>
+        </div>
+        <div
+          style={{
+            border: `1px solid ${colors.border}`,
+            borderRadius: radius.md,
+            padding: spacing.sm,
+            background: "#fff",
+            color: text.primary,
+            fontSize: "0.92rem",
+            lineHeight: 1.6,
+          }}
+        >
+          Expected outcome: your account will be marked as credentialing in progress so you always
+          know the next step is to return and connect the issued membership details.
         </div>
         <div
           style={{

--- a/rentchain-frontend/src/components/integrations/TransUnionConnectionCard.test.tsx
+++ b/rentchain-frontend/src/components/integrations/TransUnionConnectionCard.test.tsx
@@ -29,6 +29,9 @@ describe("TransUnionConnectionCard", () => {
 
     expect(screen.getByText("TransUnion Connection")).toBeInTheDocument();
     expect(screen.getByText(/Use your TransUnion membership to enable tenant screening/i)).toBeInTheDocument();
+    expect(screen.getAllByText("Not connected")).toHaveLength(2);
+    expect(screen.getByText("Connect or get access")).toBeInTheDocument();
+    expect(screen.getByText("Ready to screen")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Get TransUnion Access" }));
     expect(onGetAccess).toHaveBeenCalledTimes(1);
   });
@@ -49,6 +52,7 @@ describe("TransUnionConnectionCard", () => {
     expect(
       screen.getByText(/Your TransUnion credentialing is in progress/i)
     ).toBeInTheDocument();
+    expect(screen.getByText(/Next step: finish credentialing/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Enter Membership Details" })).toBeInTheDocument();
   });
 
@@ -68,12 +72,42 @@ describe("TransUnionConnectionCard", () => {
         onUpdateCredentials={vi.fn()}
         onDisconnect={vi.fn()}
         onStartScreening={vi.fn()}
+        readyToScreen
+        selectedApplicationLabel="Jamie Stone"
+        screeningsCompletedCount={2}
+        lastScreeningDate={new Date("2026-03-28T12:00:00.000Z").getTime()}
       />
     );
 
     expect(screen.getByText("Status: Connected")).toBeInTheDocument();
     expect(screen.getByText("Member code: *******7788")).toBeInTheDocument();
+    expect(screen.getByText("Screenings completed: 2")).toBeInTheDocument();
     expect(screen.queryByText(/PASS-/i)).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Start Screening" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Start Next Screening" })).toBeInTheDocument();
+  });
+
+  it("guides connected landlords to choose an applicant before first screening", () => {
+    const onChooseApplicant = vi.fn();
+    render(
+      <TransUnionConnectionCard
+        integration={buildIntegration({
+          status: "connected",
+          memberCodeMasked: "*******7788",
+          updatedAt: new Date("2026-03-27T12:00:00.000Z").getTime(),
+          credentialSource: "membership_credentials",
+        })}
+        onGetAccess={vi.fn()}
+        onConnectExisting={vi.fn()}
+        onEnterDetails={vi.fn()}
+        onViewInstructions={vi.fn()}
+        onUpdateCredentials={vi.fn()}
+        onDisconnect={vi.fn()}
+        onChooseApplicant={onChooseApplicant}
+      />
+    );
+
+    expect(screen.getByText(/next step is to choose an applicant/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Choose an Applicant" }));
+    expect(onChooseApplicant).toHaveBeenCalledTimes(1);
   });
 });

--- a/rentchain-frontend/src/components/integrations/TransUnionConnectionCard.tsx
+++ b/rentchain-frontend/src/components/integrations/TransUnionConnectionCard.tsx
@@ -14,6 +14,11 @@ type Props = {
   onUpdateCredentials: () => void;
   onDisconnect: () => void;
   onStartScreening?: () => void;
+  onChooseApplicant?: () => void;
+  selectedApplicationLabel?: string | null;
+  readyToScreen?: boolean;
+  screeningsCompletedCount?: number | null;
+  lastScreeningDate?: string | number | null;
 };
 
 function ActionRow({
@@ -42,32 +47,66 @@ export function TransUnionConnectionCard({
   onUpdateCredentials,
   onDisconnect,
   onStartScreening,
+  onChooseApplicant,
+  selectedApplicationLabel,
+  readyToScreen = false,
+  screeningsCompletedCount,
+  lastScreeningDate,
 }: Props) {
   const status = integration.status;
   const updatedAt = integration.updatedAt || integration.lastValidatedAt || integration.connectedAt;
+  const progressState =
+    status === "connected"
+      ? "ready"
+      : status === "pending_credentialing"
+        ? "get_access"
+        : "not_connected";
+  const completedCount = Number.isFinite(Number(screeningsCompletedCount))
+    ? Number(screeningsCompletedCount)
+    : null;
+  const formattedLastScreeningDate =
+    lastScreeningDate == null
+      ? null
+      : new Date(lastScreeningDate).toLocaleDateString();
 
   let body = "";
+  let helper = "";
+  let nextStep = "";
   let actions: Array<{ label: string; onClick: () => void; variant?: "primary" | "secondary" | "ghost" }> = [];
 
   if (status === "pending_credentialing") {
     body =
       "Your TransUnion credentialing is in progress. Once TransUnion issues your member code and passcode, return to RentChain to complete setup.";
+    helper = "This path is for landlords who still need external TransUnion approval before they can screen inside RentChain.";
+    nextStep = "Next step: finish credentialing, then enter your issued membership details here.";
     actions = [
       { label: "Enter Membership Details", onClick: onEnterDetails, variant: "primary" },
       { label: "View Instructions", onClick: onViewInstructions },
     ];
   } else if (status === "connected") {
-    body = "Your TransUnion membership is connected and ready for screening inside RentChain.";
+    body = readyToScreen
+      ? "Your TransUnion membership is connected and you are ready to screen an applicant inside RentChain."
+      : "Your TransUnion membership is connected. Your next step is to choose an applicant so you can start the first screening.";
+    helper = readyToScreen
+      ? "You already have an application in context, so you can move straight into screening."
+      : "Choose an applicant from Applications first, then start screening from that application context.";
+    nextStep = readyToScreen
+      ? `Next step: start screening${selectedApplicationLabel ? ` for ${selectedApplicationLabel}` : ""}.`
+      : "Next step: choose an applicant below, then start your first screening.";
     actions = [
       { label: "Update Credentials", onClick: onUpdateCredentials },
       { label: "Disconnect", onClick: onDisconnect, variant: "ghost" },
-      ...(onStartScreening
-        ? [{ label: "Start Screening", onClick: onStartScreening, variant: "primary" as const }]
-        : []),
+      ...(readyToScreen && onStartScreening
+        ? [{ label: completedCount && completedCount > 0 ? "Start Next Screening" : "Start Your First Screening", onClick: onStartScreening, variant: "primary" as const }]
+        : onChooseApplicant
+          ? [{ label: "Choose an Applicant", onClick: onChooseApplicant, variant: "primary" as const }]
+          : []),
     ];
   } else if (status === "connection_error") {
     body =
       "We could not verify your TransUnion connection details. Please review and try again.";
+    helper = "The workflow is still intact. Update the membership details and reconnect when ready.";
+    nextStep = "Next step: retry your credentials or update them if anything changed.";
     actions = [
       { label: "Retry", onClick: onConnectExisting, variant: "primary" },
       { label: "Update Credentials", onClick: onUpdateCredentials },
@@ -75,6 +114,8 @@ export function TransUnionConnectionCard({
   } else {
     body =
       "Use your TransUnion membership to enable tenant screening in RentChain. If you are not credentialed yet, RentChain will guide you through that first.";
+    helper = "Choose the path that matches your current state so you can reach screening with fewer setup loops.";
+    nextStep = "Next step: either start TransUnion credentialing or connect your existing membership.";
     actions = [
       { label: "Get TransUnion Access", onClick: onGetAccess, variant: "primary" },
       { label: "Connect Existing Membership", onClick: onConnectExisting },
@@ -87,9 +128,61 @@ export function TransUnionConnectionCard({
         <div style={{ display: "grid", gap: spacing.xs }}>
           <div style={{ fontWeight: 700, fontSize: "1.05rem" }}>TransUnion Connection</div>
           <div style={{ color: text.muted, lineHeight: 1.6 }}>{loading ? "Loading connection status..." : body}</div>
+          {!loading && helper ? (
+            <div style={{ color: text.subtle, fontSize: "0.92rem", lineHeight: 1.5 }}>{helper}</div>
+          ) : null}
         </div>
         <TransUnionStatusBadge status={status} />
       </div>
+
+      {!loading ? (
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))",
+            gap: spacing.sm,
+          }}
+        >
+          {[
+            {
+              key: "not_connected",
+              label: "Not connected",
+              active: progressState === "not_connected",
+              complete: progressState !== "not_connected",
+            },
+            {
+              key: "get_access",
+              label: "Connect or get access",
+              active: progressState === "get_access",
+              complete: progressState === "ready",
+            },
+            {
+              key: "ready",
+              label: "Ready to screen",
+              active: progressState === "ready",
+              complete: progressState === "ready",
+            },
+          ].map((step) => (
+            <div
+              key={step.key}
+              style={{
+                border: `1px solid ${step.active || step.complete ? colors.accent : colors.border}`,
+                background: step.active || step.complete ? colors.accentSoft : colors.bg,
+                color: step.active || step.complete ? text.primary : text.muted,
+                borderRadius: radius.md,
+                padding: spacing.sm,
+                display: "grid",
+                gap: 4,
+              }}
+            >
+              <div style={{ fontWeight: 700, fontSize: "0.9rem" }}>{step.label}</div>
+              <div style={{ fontSize: "0.82rem" }}>
+                {step.active ? "Current step" : step.complete ? "Completed" : "Upcoming"}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : null}
 
       {status === "connected" ? (
         <div
@@ -110,6 +203,22 @@ export function TransUnionConnectionCard({
           </div>
           <div>Connection type: Membership credentials</div>
           <div>Passcode: Stored securely and never shown again</div>
+          {completedCount != null ? <div>Screenings completed: {completedCount}</div> : null}
+          {formattedLastScreeningDate ? <div>Last screening date: {formattedLastScreeningDate}</div> : null}
+          <div>{nextStep}</div>
+        </div>
+      ) : !loading ? (
+        <div
+          style={{
+            border: `1px solid ${colors.border}`,
+            borderRadius: radius.md,
+            padding: spacing.sm,
+            background: colors.bg,
+            fontSize: "0.94rem",
+            color: text.primary,
+          }}
+        >
+          {nextStep}
         </div>
       ) : null}
 

--- a/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
@@ -165,7 +165,18 @@ vi.mock("@/components/applications/ApplicationDecisionSummaryCard", () => ({
 }));
 
 vi.mock("@/components/integrations/TransUnionConnectionCard", () => ({
-  TransUnionConnectionCard: () => <div>TransUnion Connection</div>,
+  TransUnionConnectionCard: (props: any) => (
+    <div>
+      <div>TransUnion Connection</div>
+      <div>{props.readyToScreen ? "Ready to screen now" : "Choose an applicant first"}</div>
+      <button type="button" onClick={() => props.onStartScreening?.()}>
+        Connection Primary Action
+      </button>
+      <button type="button" onClick={() => props.onChooseApplicant?.()}>
+        Choose Applicant
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock("@/components/integrations/GetTransUnionAccessModal", () => ({
@@ -312,6 +323,44 @@ describe("ApplicationsPage", () => {
     expect(screen.getByText("TransUnion Connection")).toBeInTheDocument();
   });
 
+  it("guides connected landlords back to the application list instead of showing a dead-end screening toast", async () => {
+    mocks.entitlementsMock.mockReturnValue({
+      loading: false,
+      plan: "starter",
+      role: "landlord",
+      isAdmin: false,
+      capabilities: {},
+      hasCapability: () => true,
+      requiredPlanFor: () => "starter",
+      canScreen: true,
+      canViewScreeningHistory: true,
+      canExportPdf: false,
+      hasMoveInReadiness: false,
+      canUseWorkOrders: false,
+      canViewReviewSummary: false,
+    });
+    mocks.getTransUnionIntegration.mockResolvedValue({
+      provider: "transunion",
+      status: "connected",
+      version: 1,
+    });
+
+    render(
+      <MemoryRouter>
+        <ApplicationsPage />
+      </MemoryRouter>
+    );
+
+    await screen.findAllByRole("heading", { name: "Applications" });
+    expect(screen.getAllByText("Choose an applicant first").length).toBeGreaterThan(0);
+    fireEvent.click(screen.getAllByRole("button", { name: "Connection Primary Action" })[0]);
+
+    expect(mocks.showToast).not.toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Select an application to start screening." })
+    );
+    expect(screen.getByText(/Ready to start your first screening/i)).toBeInTheDocument();
+  });
+
   it("shows Starter-aligned screening upgrade copy instead of the old Pro gate", async () => {
     const dispatchSpy = vi.spyOn(window, "dispatchEvent");
 
@@ -321,7 +370,7 @@ describe("ApplicationsPage", () => {
       </MemoryRouter>
     );
 
-    const button = await screen.findByRole("button", { name: "Send screening invite" });
+    const [button] = await screen.findAllByRole("button", { name: "Send screening invite" });
     button.click();
 
     expect(dispatchSpy).toHaveBeenCalled();

--- a/rentchain-frontend/src/pages/ApplicationsPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.tsx
@@ -324,6 +324,7 @@ const ApplicationsPage: React.FC = () => {
   const [screeningEventsRefreshedAt, setScreeningEventsRefreshedAt] = useState<number | null>(null);
   const [screeningHistory, setScreeningHistory] = useState<ScreeningHistoryRecord[]>([]);
   const [screeningHistoryLoading, setScreeningHistoryLoading] = useState(false);
+  const applicationsListRef = useRef<HTMLDivElement | null>(null);
   const [screeningDetailOpen, setScreeningDetailOpen] = useState(false);
   const [selectedScreeningId, setSelectedScreeningId] = useState<string | null>(null);
   const [selectedScreeningDetail, setSelectedScreeningDetail] = useState<ScreeningHistoryDetail | null>(null);
@@ -1285,6 +1286,13 @@ const ApplicationsPage: React.FC = () => {
     }, 150);
   };
 
+  const guideToApplicationsForScreening = useCallback(() => {
+    const listNode = applicationsListRef.current;
+    if (listNode && typeof listNode.scrollIntoView === "function") {
+      listNode.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+  }, []);
+
   const emitTransUnionUsageEvent = useCallback(
     (eventType: "tu_option_viewed" | "tu_get_access_clicked" | "tu_have_credentials_clicked", sourceSurface: string) => {
       void trackTransUnionUsageEvent({
@@ -1835,6 +1843,17 @@ const ApplicationsPage: React.FC = () => {
       <TransUnionConnectionCard
         integration={transUnionIntegration}
         loading={transUnionLoading}
+        readyToScreen={Boolean(detail)}
+        selectedApplicationLabel={
+          detail ? `${detail.applicant.firstName} ${detail.applicant.lastName}`.trim() : null
+        }
+        onChooseApplicant={guideToApplicationsForScreening}
+        screeningsCompletedCount={
+          detail
+            ? screeningHistory.filter((item) => item.status === "completed").length
+            : null
+        }
+        lastScreeningDate={detail ? screeningHistory[0]?.screenedAt || screeningHistory[0]?.requestedAt || null : null}
         onGetAccess={() => {
           emitTransUnionUsageEvent("tu_get_access_clicked", "applications_page");
           setTransUnionAccessOpen(true);
@@ -1850,7 +1869,7 @@ const ApplicationsPage: React.FC = () => {
         onStartScreening={
           detail
             ? () => handleRowScreen(detail.id)
-            : () => showToast({ message: "Select an application to start screening.", variant: "warning" })
+            : guideToApplicationsForScreening
         }
       />
 
@@ -1979,7 +1998,7 @@ const ApplicationsPage: React.FC = () => {
           }
           masterTitle="Applications"
           master={
-            <div className="rc-applications-list">
+            <div className="rc-applications-list" ref={applicationsListRef}>
               {loading ? (
                 <div style={{ color: text.muted }}>Loading applications...</div>
               ) : error ? (
@@ -2003,6 +2022,29 @@ const ApplicationsPage: React.FC = () => {
                   </Button>
                 </div>
               ) : (
+                <div style={{ display: "grid", gap: spacing.sm }}>
+                  {isTransUnionConnected && !detail ? (
+                    <Card
+                      style={{
+                        border: `1px solid ${colors.accent}`,
+                        background: colors.accentSoft,
+                        display: "grid",
+                        gap: spacing.xs,
+                      }}
+                    >
+                      <div style={{ fontWeight: 700, fontSize: "0.98rem" }}>
+                        Ready to start your first screening
+                      </div>
+                      <div style={{ color: text.muted, lineHeight: 1.6 }}>
+                        Your TransUnion connection is active. Next step: choose an applicant from this
+                        list, then open screening from that application.
+                      </div>
+                      <div style={{ color: text.subtle, fontSize: "0.9rem" }}>
+                        Start with the most review-ready applicant to reach your first completed
+                        screening faster.
+                      </div>
+                    </Card>
+                  ) : null}
                 <div className="rc-applications-list-scroll">
                   {filtered.map((app) => (
                     <button
@@ -2057,6 +2099,7 @@ const ApplicationsPage: React.FC = () => {
                       </div>
                     </button>
                   ))}
+                </div>
                 </div>
               )}
             </div>

--- a/rentchain-frontend/src/pages/admin/AdminTransUnionUsagePage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminTransUnionUsagePage.test.tsx
@@ -127,8 +127,11 @@ describe("AdminTransUnionUsagePage", () => {
     expect(screen.getByText("TransUnion Usage Summary")).toBeInTheDocument();
     expect(screen.getByText("Connected landlords")).toBeInTheDocument();
     expect(screen.getByText("Compliance Controls")).toBeInTheDocument();
+    expect(screen.getByText("Funnel Conversion")).toBeInTheDocument();
     expect(screen.getByText("Appendix")).toBeInTheDocument();
     expect(screen.getByText(/Tenant consent captured before screening: 100%/)).toBeInTheDocument();
+    expect(screen.getByText(/Viewed option → Get Access/)).toBeInTheDocument();
+    expect(screen.getByText(/Largest bottleneck:/)).toBeInTheDocument();
   });
 
   it("downloads the PDF report and shows loading state", async () => {

--- a/rentchain-frontend/src/pages/admin/AdminTransUnionUsagePage.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminTransUnionUsagePage.tsx
@@ -77,6 +77,65 @@ function pct(value: number) {
   return `${Math.round((Number(value) || 0) * 100)}%`;
 }
 
+function percentOrDash(numerator: number, denominator: number) {
+  if (!denominator) return "—";
+  return `${Math.round((numerator / denominator) * 100)}%`;
+}
+
+function buildFunnelTransitions(report: TransUnionUsageReport) {
+  const transitions = [
+    {
+      label: "Viewed option → Get Access",
+      from: report.funnel.optionViewed,
+      to: report.funnel.getAccessClicks,
+    },
+    {
+      label: "Viewed option → Connect Existing Membership",
+      from: report.funnel.optionViewed,
+      to: report.funnel.haveCredentialsClicks,
+    },
+    {
+      label: "Connect Existing Membership → Credential submitted",
+      from: report.funnel.haveCredentialsClicks,
+      to: report.funnel.credentialSubmissions,
+    },
+    {
+      label: "Credential submitted → Connected",
+      from: report.funnel.credentialSubmissions,
+      to: report.funnel.connectionSuccesses,
+    },
+    {
+      label: "Connected → First screening initiated",
+      from: report.funnel.connectionSuccesses,
+      to: report.funnel.firstScreeningInitiated,
+    },
+    {
+      label: "Screening created → Screening submitted",
+      from: report.usage.totalScreeningRequests,
+      to: report.usage.totalScreeningRequests - report.usage.blockedScreenings,
+    },
+    {
+      label: "Screening submitted → Screening completed",
+      from: report.usage.totalScreeningRequests - report.usage.blockedScreenings,
+      to: report.usage.completedScreenings,
+    },
+  ].map((item) => {
+    const conversion = item.from ? item.to / item.from : null;
+    const dropOff = item.from ? 1 - item.to / item.from : null;
+    return {
+      ...item,
+      conversion,
+      dropOff,
+    };
+  });
+
+  const bottleneck = transitions
+    .filter((item) => item.dropOff != null)
+    .sort((a, b) => Number(b.dropOff || 0) - Number(a.dropOff || 0))[0] || null;
+
+  return { transitions, bottleneck };
+}
+
 export default function AdminTransUnionUsagePage() {
   const { showToast } = useToast();
   const [period, setPeriod] = useState<"last_30_days" | "last_60_days" | "last_90_days">(
@@ -109,6 +168,7 @@ export default function AdminTransUnionUsagePage() {
   }, [period]);
 
   const jsonSummary = useMemo(() => JSON.stringify(report, null, 2), [report]);
+  const funnelInsights = useMemo(() => buildFunnelTransitions(report), [report]);
 
   const downloadPdf = async () => {
     try {
@@ -217,6 +277,20 @@ export default function AdminTransUnionUsagePage() {
                 </div>
               </Card>
               <Card style={{ display: "grid", gap: 12 }}>
+                <div style={{ fontWeight: 700 }}>Funnel Conversion</div>
+                <div style={{ display: "grid", gap: 8, color: "#475569" }}>
+                  {funnelInsights.transitions.map((item) => (
+                    <div key={item.label} style={{ display: "grid", gap: 2 }}>
+                      <div>{item.label}</div>
+                      <div style={{ fontSize: 13, color: "#64748b" }}>
+                        Conversion: {item.conversion == null ? "—" : percentOrDash(item.to, item.from)} • Drop-off:{" "}
+                        {item.dropOff == null ? "—" : pct(item.dropOff)}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </Card>
+              <Card style={{ display: "grid", gap: 12 }}>
                 <div style={{ fontWeight: 700 }}>Operational Quality</div>
                 <div style={{ display: "grid", gap: 8, color: "#475569" }}>
                   <div>Completion rate: {pct(report.quality.completionRate)}</div>
@@ -253,6 +327,14 @@ export default function AdminTransUnionUsagePage() {
                   {report.report.partnershipReadiness.notes.map((note) => (
                     <div key={note}>{note}</div>
                   ))}
+                  <div style={{ paddingTop: 8 }}>
+                    Largest bottleneck:{" "}
+                    <strong>
+                      {funnelInsights.bottleneck
+                        ? `${funnelInsights.bottleneck.label} (${pct(funnelInsights.bottleneck.dropOff || 0)} drop-off)`
+                        : "Not enough data yet"}
+                    </strong>
+                  </div>
                 </div>
               </Card>
             </div>


### PR DESCRIPTION
## Summary

- improve the frontend TransUnion screening funnel to reduce landlord drop-off between connection and first screening
- make onboarding states and next steps clearer without changing backend screening logic
- add admin-side frontend-only conversion and drop-off visibility from the existing usage report payload

## Changes

- replace the connected-state dead-end toast with a guided inline path back to the applicant list in `ApplicationsPage`
- improve TransUnion onboarding copy and state visibility in the connection card and onboarding modals
- add lightweight progress states: `Not connected`, `Connect or get access`, `Ready to screen`
- add small usage nudges such as completed screenings and last screening date when available
- extend the admin TransUnion usage page with derived conversion rates, drop-off percentages, and largest bottleneck display
- update focused frontend tests for onboarding, activation, and admin funnel readability

## Validation

- `cd rentchain-frontend && npx vitest run src/components/integrations/TransUnionConnectionCard.test.tsx src/components/integrations/ConnectTransUnionModal.test.tsx src/pages/admin/AdminTransUnionUsagePage.test.tsx src/pages/ApplicationsPage.test.tsx`
- `cd rentchain-frontend && npm run build:app`