### PR TITLE
feat: add tenant screening inbox

### DIFF
--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -69,6 +69,7 @@ import TenantNoticesCenterPage from "./pages/tenant/TenantNoticesCenterPage";
 import TenantProfilePage from "./pages/tenant/TenantProfilePage";
 import TenantAccessPage from "./pages/tenant/TenantAccessPage";
 import TenantAccountPage from "./pages/tenant/TenantAccountPage";
+import TenantScreeningInboxPage from "./pages/tenant/TenantScreeningInboxPage";
 import TenantMagicRedeemPage from "./pages/tenant/TenantMagicRedeemPage";
 import TenantInviteRedeemPage from "./pages/tenant/TenantInviteRedeemPage";
 import TenantMaintenanceRequestDetailPage from "./pages/tenant/TenantMaintenanceRequestDetailPage";
@@ -1159,6 +1160,10 @@ function App() {
         <Route
           path="/tenant/profile"
           element={renderTenantShell(<TenantProfilePage />)}
+        />
+        <Route
+          path="/tenant/screening"
+          element={renderTenantShell(<TenantScreeningInboxPage />)}
         />
         <Route
           path="/tenant/access"

--- a/rentchain-frontend/src/components/layout/TenantNav.tsx
+++ b/rentchain-frontend/src/components/layout/TenantNav.tsx
@@ -10,6 +10,7 @@ type Props = {
 
 const navItems = [
   { label: "Dashboard", to: "/tenant/dashboard" },
+  { label: "Screening Requests", to: "/tenant/screening" },
   { label: "Profile", to: "/tenant/profile" },
   { label: "Access", to: "/tenant/access" },
   { label: "Application", to: "/tenant/application" },
@@ -76,7 +77,7 @@ export const TenantNav: React.FC<Props> = ({ children }) => {
       try {
         const summary = await getTenantCommunicationSummary();
         if (!cancelled) {
-          setUnreadMessages(Number(summary?.unreadMessages || 0) + Number(summary?.unreadScreeningUpdates || 0));
+          setUnreadMessages(Number(summary?.unreadMessages || 0));
           setUnreadNotices(Number(summary?.unreadNotices || 0));
           setUnreadScreening(Number(summary?.unreadScreeningUpdates || 0));
         }
@@ -179,7 +180,7 @@ export const TenantNav: React.FC<Props> = ({ children }) => {
                       {unreadMessages > 99 ? "99+" : unreadMessages}
                     </span>
                   ) : null}
-                  {item.to === "/tenant/messages" && unreadScreening > 0 ? (
+                  {item.to === "/tenant/screening" && unreadScreening > 0 ? (
                     <span
                       style={{
                         minWidth: 18,

--- a/rentchain-frontend/src/pages/tenant/TenantProfileCommunicationsPages.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantProfileCommunicationsPages.test.tsx
@@ -101,6 +101,7 @@ describe("tenant profile and communications pages", () => {
     );
 
     expect(await screen.findByText(/RentChain Tenant Space/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Screening Requests/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Profile/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Access/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /History/i })).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/tenant/TenantScreeningInboxPage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantScreeningInboxPage.test.tsx
@@ -1,0 +1,152 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import TenantScreeningInboxPage from "./TenantScreeningInboxPage";
+
+const tenantScreeningApi = vi.hoisted(() => ({
+  listTenantScreenings: vi.fn(),
+  markTenantScreeningViewed: vi.fn(),
+  acceptTenantScreeningConsent: vi.fn(),
+}));
+
+vi.mock("../../api/tenantScreeningApi", async () => {
+  const actual = await vi.importActual<any>("../../api/tenantScreeningApi");
+  return {
+    ...actual,
+    listTenantScreenings: tenantScreeningApi.listTenantScreenings,
+    markTenantScreeningViewed: tenantScreeningApi.markTenantScreeningViewed,
+    acceptTenantScreeningConsent: tenantScreeningApi.acceptTenantScreeningConsent,
+  };
+});
+
+function buildScreening(overrides?: Record<string, unknown>) {
+  return {
+    id: "screening-1",
+    rentalApplicationId: "app-1",
+    status: "consent_pending",
+    normalizedResultStatus: "pending",
+    requestedAt: 1710000000000,
+    consentedAt: null,
+    startedAt: null,
+    completedAt: null,
+    provider: "transunion_redirect",
+    providerLabel: "TransUnion",
+    packageType: "basic",
+    payerType: "landlord",
+    propertyLabel: "123 Main St",
+    unitLabel: "Unit 4",
+    applicantName: "Taylor Tenant",
+    nextAction: "awaiting_applicant_consent",
+    consent: null,
+    session: null,
+    result: null,
+    returnFlow: null,
+    summary: {
+      status: "consent_pending",
+      provider: "transunion_redirect",
+      requestedDate: 1710000000000,
+      package: "basic",
+      summaryResult: "Consent is required before screening can begin.",
+      nextActions: ["Provide consent"],
+    },
+    auditTrail: [],
+    ...overrides,
+  } as any;
+}
+
+describe("TenantScreeningInboxPage", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    tenantScreeningApi.markTenantScreeningViewed.mockResolvedValue({ ok: true });
+    tenantScreeningApi.acceptTenantScreeningConsent.mockResolvedValue({ ok: true });
+  });
+
+  it("renders screening request cards and consent-required flow", async () => {
+    tenantScreeningApi.listTenantScreenings.mockResolvedValue({
+      ok: true,
+      items: [buildScreening()],
+    });
+
+    render(
+      <MemoryRouter>
+        <TenantScreeningInboxPage />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByRole("link", { name: /Open application checklist/i })).toBeInTheDocument();
+    expect(screen.getByText(/^Screening Requests$/i)).toBeInTheDocument();
+    expect(screen.getByText(/Requested for 123 Main St - Unit 4/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Consent required/i).length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: /Authorize screening/i })).toBeDisabled();
+  });
+
+  it("renders an empty state safely", async () => {
+    tenantScreeningApi.listTenantScreenings.mockResolvedValue({
+      ok: true,
+      items: [],
+    });
+
+    render(
+      <MemoryRouter>
+        <TenantScreeningInboxPage />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText(/No screening requests yet\./i)).toBeInTheDocument();
+    expect(screen.getByText(/If a landlord requests screening/i)).toBeInTheDocument();
+  });
+
+  it("shows confirmed consent timestamps without duplicate authorization prompts", async () => {
+    tenantScreeningApi.listTenantScreenings.mockResolvedValue({
+      ok: true,
+      items: [
+        buildScreening({
+          status: "consented",
+          consentedAt: 1710000100000,
+          consent: {
+            id: "consent-1",
+            requestId: "screening-1",
+            acceptedAt: 1710000100000,
+            providerLabel: "TransUnion",
+            consentTextSummary: "Consent summary snapshot",
+            providerDisclosure: "Disclosure",
+            disclosureVersion: "screening-consent-v2",
+          },
+        }),
+      ],
+    });
+
+    render(
+      <MemoryRouter>
+        <TenantScreeningInboxPage />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText(/Screening consent confirmed/i)).toBeInTheDocument();
+    expect(screen.getByText(/Confirmed at:/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Authorize screening/i })).not.toBeInTheDocument();
+  });
+
+  it("renders neutral copy for completed, manual review, and blocked states", async () => {
+    tenantScreeningApi.listTenantScreenings.mockResolvedValue({
+      ok: true,
+      items: [
+        buildScreening({ id: "completed", status: "completed", completedAt: 1710000200000 }),
+        buildScreening({ id: "manual", status: "manual_review_required", consentedAt: 1710000100000 }),
+        buildScreening({ id: "blocked", status: "failed", nextAction: "provider_activation_pending" }),
+      ],
+    });
+
+    render(
+      <MemoryRouter>
+        <TenantScreeningInboxPage />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText(/Screening workflow completed\./i)).toBeInTheDocument();
+    expect(screen.getByText(/This screening may require manual review\./i)).toBeInTheDocument();
+    expect(screen.getByText(/landlord may still need to complete screening setup/i)).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/tenant/TenantScreeningInboxPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantScreeningInboxPage.tsx
@@ -1,0 +1,203 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { listTenantScreenings, type TenantScreeningRequest } from "../../api/tenantScreeningApi";
+import TenantScreeningConsentCard from "../../components/tenant/TenantScreeningConsentCard";
+import { colors, radius, spacing, text as textTokens } from "../../styles/tokens";
+import {
+  TenantEmptyState,
+  TenantErrorState,
+  TenantInfoCard,
+  TenantKeyValueGrid,
+  TenantLoadingState,
+  TenantSurfaceShell,
+  TenantUnauthorizedState,
+  formatDate,
+} from "./TenantWorkspaceShared";
+import { buildTenantScreeningInboxItemView } from "./tenantScreeningInboxView";
+
+function badgeColors(status: ReturnType<typeof buildTenantScreeningInboxItemView>["status"]) {
+  switch (status) {
+    case "consent_required":
+      return { background: "rgba(245,158,11,0.14)", color: "#92400e" };
+    case "consent_confirmed":
+      return { background: "rgba(59,130,246,0.14)", color: "#1d4ed8" };
+    case "screening_in_progress":
+      return { background: "rgba(14,165,233,0.14)", color: "#0c4a6e" };
+    case "completed":
+      return { background: "rgba(34,197,94,0.12)", color: "#166534" };
+    case "manual_review":
+      return { background: "rgba(168,85,247,0.12)", color: "#6b21a8" };
+    case "blocked":
+      return { background: "rgba(239,68,68,0.12)", color: "#991b1b" };
+    default:
+      return { background: "rgba(148,163,184,0.16)", color: "#475569" };
+  }
+}
+
+export default function TenantScreeningInboxPage() {
+  const [items, setItems] = React.useState<TenantScreeningRequest[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const load = React.useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await listTenantScreenings();
+      const nextItems = Array.isArray((response as any)?.items) ? (response as any).items : [];
+      setItems(nextItems);
+    } catch (err: any) {
+      setItems([]);
+      setError(err?.payload?.error || err?.message || "Unable to load screening requests.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  React.useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleConsentUpdated = React.useCallback((screeningRequest: TenantScreeningRequest) => {
+    setItems((current) => current.map((item) => (item.id === screeningRequest.id ? screeningRequest : item)));
+  }, []);
+
+  if (loading) {
+    return (
+      <TenantSurfaceShell
+        title="Screening Requests"
+        subtitle="Review screening requests and manage consent for your rental applications."
+      >
+        <TenantLoadingState label="Loading your screening requests..." />
+      </TenantSurfaceShell>
+    );
+  }
+
+  if (error) {
+    if (/unauthorized|forbidden/i.test(error)) {
+      return (
+        <TenantSurfaceShell
+          title="Screening Requests"
+          subtitle="Review screening requests and manage consent for your rental applications."
+        >
+          <TenantUnauthorizedState />
+        </TenantSurfaceShell>
+      );
+    }
+    return (
+      <TenantSurfaceShell
+        title="Screening Requests"
+        subtitle="Review screening requests and manage consent for your rental applications."
+      >
+        <TenantErrorState message={error} retry={load} />
+      </TenantSurfaceShell>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <TenantSurfaceShell
+        title="Screening Requests"
+        subtitle="Review screening requests and manage consent for your rental applications."
+      >
+        <TenantEmptyState
+          title="No screening requests yet."
+          body="If a landlord requests screening for one of your applications, it will appear here."
+        />
+      </TenantSurfaceShell>
+    );
+  }
+
+  return (
+    <TenantSurfaceShell
+      title="Screening Requests"
+      subtitle="Review screening requests and manage consent for your rental applications."
+      action={
+        <Link
+          to="/tenant/application"
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            padding: "9px 12px",
+            borderRadius: radius.md,
+            border: `1px solid ${colors.border}`,
+            background: colors.panel,
+            color: textTokens.primary,
+            textDecoration: "none",
+            fontWeight: 700,
+          }}
+        >
+          Open application checklist
+        </Link>
+      }
+    >
+      <div style={{ display: "grid", gap: spacing.md }}>
+        {items.map((item) => {
+          const view = buildTenantScreeningInboxItemView(item);
+          const badge = badgeColors(view.status);
+          const showConsentCard = view.status === "consent_required" || view.status === "consent_confirmed";
+          return (
+            <TenantInfoCard key={item.id} heading={view.propertyContext} accent={badge.color}>
+              <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.sm, flexWrap: "wrap" }}>
+                <div style={{ display: "grid", gap: 4 }}>
+                  <div style={{ fontWeight: 700, color: textTokens.primary }}>
+                    {view.requestContext}
+                  </div>
+                  <div style={{ color: textTokens.secondary }}>{view.description}</div>
+                </div>
+                <div
+                  style={{
+                    alignSelf: "start",
+                    padding: "6px 10px",
+                    borderRadius: 999,
+                    background: badge.background,
+                    color: badge.color,
+                    fontWeight: 700,
+                    fontSize: "0.85rem",
+                  }}
+                >
+                  {view.statusLabel}
+                </div>
+              </div>
+
+              <TenantKeyValueGrid
+                rows={[
+                  { label: "Consent", value: view.consentLabel },
+                  { label: "Provider", value: view.providerLabel },
+                  { label: "Requested", value: formatDate(view.requestedAt) },
+                  { label: "Last update", value: formatDate(view.activityAt) },
+                ]}
+              />
+
+              <div
+                style={{
+                  border: `1px solid ${colors.border}`,
+                  borderRadius: radius.md,
+                  background: colors.panel,
+                  padding: "12px 14px",
+                  display: "grid",
+                  gap: 6,
+                }}
+              >
+                <div style={{ fontWeight: 700, color: textTokens.primary }}>Next step</div>
+                <div style={{ color: textTokens.secondary }}>
+                  {view.nextActionLabel}
+                </div>
+                {view.consentedAt && !showConsentCard ? (
+                  <div style={{ color: textTokens.muted }}>
+                    Consent confirmed on {formatDate(view.consentedAt)}.
+                  </div>
+                ) : null}
+              </div>
+
+              {showConsentCard ? (
+                <TenantScreeningConsentCard screening={item} onConsentUpdated={handleConsentUpdated} />
+              ) : null}
+            </TenantInfoCard>
+          );
+        })}
+      </div>
+    </TenantSurfaceShell>
+  );
+}

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -45,6 +45,10 @@ const tenantCommunicationsApi = vi.hoisted(() => ({
   getTenantCommunicationsWorkspace: vi.fn(),
 }));
 
+const tenantScreeningApi = vi.hoisted(() => ({
+  listTenantScreenings: vi.fn(),
+}));
+
 vi.mock("../../api/tenantPortal", () => tenantPortalApi);
 vi.mock("../../api/tenantApplicationCompletion", () => tenantApplicationCompletionApi);
 vi.mock("../../api/tenantAccess", () => tenantAccessApi);
@@ -52,6 +56,13 @@ vi.mock("../../api/tenantAttachmentsApi", () => tenantAttachmentsApi);
 vi.mock("../../api/tenantProfile", () => tenantProfileApi);
 vi.mock("../../api/tenantNotificationPreferences", () => tenantNotificationPreferencesApi);
 vi.mock("../../api/tenantCommunicationsApi", () => tenantCommunicationsApi);
+vi.mock("../../api/tenantScreeningApi", async () => {
+  const actual = await vi.importActual<any>("../../api/tenantScreeningApi");
+  return {
+    ...actual,
+    listTenantScreenings: tenantScreeningApi.listTenantScreenings,
+  };
+});
 vi.mock("../../api/maintenanceWorkflowApi", async () => {
   const actual = await vi.importActual<any>("../../api/maintenanceWorkflowApi");
   return {
@@ -67,7 +78,7 @@ describe("tenant workspace frontend shell", () => {
     tenantCommunicationsApi.getTenantCommunicationSummary.mockResolvedValue({
       unreadMessages: 1,
       unreadNotices: 2,
-      unreadScreeningUpdates: 0,
+      unreadScreeningUpdates: 1,
     });
     tenantCommunicationsApi.getTenantCommunicationsWorkspace.mockResolvedValue({
       canSend: true,
@@ -96,6 +107,42 @@ describe("tenant workspace frontend shell", () => {
       sections: [],
       nextSteps: ["Upload government id"],
       updatedAt: "2026-01-02T00:00:00.000Z",
+    });
+    tenantScreeningApi.listTenantScreenings.mockResolvedValue({
+      ok: true,
+      items: [
+        {
+          id: "screening-1",
+          rentalApplicationId: "app-1",
+          status: "consent_pending",
+          normalizedResultStatus: "pending",
+          requestedAt: 1710000000000,
+          consentedAt: null,
+          startedAt: null,
+          completedAt: null,
+          provider: "transunion_redirect",
+          providerLabel: "TransUnion",
+          packageType: "basic",
+          payerType: "landlord",
+          propertyLabel: "123 Main St",
+          unitLabel: "Unit 4",
+          applicantName: "Taylor Tenant",
+          nextAction: "awaiting_applicant_consent",
+          consent: null,
+          session: null,
+          result: null,
+          returnFlow: null,
+          summary: {
+            status: "consent_pending",
+            provider: "transunion_redirect",
+            requestedDate: 1710000000000,
+            package: "basic",
+            summaryResult: "Consent is required before screening can begin.",
+            nextActions: ["Provide consent"],
+          },
+          auditTrail: [],
+        },
+      ],
     });
     tenantAccessApi.getTenantAccess.mockResolvedValue({
       summary: {
@@ -252,6 +299,7 @@ describe("tenant workspace frontend shell", () => {
 
     expect(await screen.findByText(/RentChain Tenant Space/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Dashboard/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Screening Requests/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Access/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Documents/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /History/i })).toBeInTheDocument();
@@ -333,6 +381,8 @@ describe("tenant workspace frontend shell", () => {
     expect(screen.getByText(/Needs reply/i)).toBeInTheDocument();
     expect(screen.getByText(/Please confirm the final move-in details/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Open communications inbox/i })).toBeInTheDocument();
+    expect(screen.getByText(/Screening consent requested for 1 application/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Review request/i })).toBeInTheDocument();
     expect(screen.getByText(/123 Main St, Unit 4, Halifax, NS/i)).toBeInTheDocument();
     expect(screen.getByText(/finish_profile/i)).toBeInTheDocument();
     expect(screen.getAllByText(/1 active access grant/i).length).toBeGreaterThan(0);

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
@@ -7,6 +7,7 @@ import { getTenantProfile } from "../../api/tenantProfile";
 import { getTenantApplicationCompletion } from "../../api/tenantApplicationCompletion";
 import { getTenantNotificationPreferences } from "../../api/tenantNotificationPreferences";
 import { getTenantCommunicationsWorkspace } from "../../api/tenantCommunicationsApi";
+import { listTenantScreenings, type TenantScreeningRequest } from "../../api/tenantScreeningApi";
 import {
   TenantEmptyState,
   TenantErrorState,
@@ -31,6 +32,7 @@ import TenantWorkspaceModeBanner from "./TenantWorkspaceModeBanner";
 import StructuredNotificationList from "../StructuredNotificationList";
 import { buildTenantStructuredNotificationTriggers } from "../structuredNotificationTriggers";
 import { filterStructuredNotificationsByPreferences } from "../notificationChannelRouting";
+import { buildTenantScreeningDashboardSummary } from "./tenantScreeningInboxView";
 
 export default function TenantWorkspacePage() {
   const [data, setData] = React.useState<Awaited<ReturnType<typeof getTenantWorkspace>> | null>(null);
@@ -40,6 +42,7 @@ export default function TenantWorkspacePage() {
   const [completion, setCompletion] = React.useState<Awaited<ReturnType<typeof getTenantApplicationCompletion>> | null>(null);
   const [notificationPreferences, setNotificationPreferences] = React.useState<Awaited<ReturnType<typeof getTenantNotificationPreferences>> | null>(null);
   const [communications, setCommunications] = React.useState<Awaited<ReturnType<typeof getTenantCommunicationsWorkspace>> | null>(null);
+  const [screenings, setScreenings] = React.useState<TenantScreeningRequest[]>([]);
   const [profileLoading, setProfileLoading] = React.useState(true);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
@@ -48,13 +51,14 @@ export default function TenantWorkspacePage() {
     setLoading(true);
     setError(null);
     try {
-      const [workspaceResult, accessResult, attachmentsResult, completionResult, preferencesResult, communicationsResult] = await Promise.allSettled([
+      const [workspaceResult, accessResult, attachmentsResult, completionResult, preferencesResult, communicationsResult, screeningsResult] = await Promise.allSettled([
         getTenantWorkspace(),
         getTenantAccess(),
         getTenantAttachments(),
         getTenantApplicationCompletion(),
         getTenantNotificationPreferences(),
         getTenantCommunicationsWorkspace(),
+        listTenantScreenings(),
       ]);
 
       if (workspaceResult.status === "rejected") {
@@ -67,6 +71,11 @@ export default function TenantWorkspacePage() {
       setCompletion(completionResult.status === "fulfilled" ? completionResult.value : null);
       setNotificationPreferences(preferencesResult.status === "fulfilled" ? preferencesResult.value : null);
       setCommunications(communicationsResult.status === "fulfilled" ? communicationsResult.value : null);
+      setScreenings(
+        screeningsResult.status === "fulfilled" && Array.isArray((screeningsResult.value as any)?.items)
+          ? (screeningsResult.value as any).items
+          : [],
+      );
     } catch (err: any) {
       setData(null);
       setAccess(null);
@@ -74,6 +83,7 @@ export default function TenantWorkspacePage() {
       setCompletion(null);
       setNotificationPreferences(null);
       setCommunications(null);
+      setScreenings([]);
       setError(err?.payload?.error || err?.message || "Unable to load your tenant workspace.");
     } finally {
       setLoading(false);
@@ -155,6 +165,7 @@ export default function TenantWorkspacePage() {
     lease: data?.lease,
   });
   const communicationsView = buildTenantCommunicationsWorkspaceState(communications);
+  const screeningSummary = buildTenantScreeningDashboardSummary(screenings);
   const notificationItems = filterStructuredNotificationsByPreferences(
     buildTenantStructuredNotificationTriggers({
       packageCategories: reuse.packageCategories,
@@ -402,6 +413,26 @@ export default function TenantWorkspacePage() {
             <Link to="/tenant/messages">Open communications inbox</Link>
           </div>
         </TenantInfoCard>
+
+        {screenings.length ? (
+          <TenantInfoCard heading="Screening Requests" accent="#1d4ed8">
+            <div style={{ display: "grid", gap: spacing.sm }}>
+              <div style={{ color: textTokens.secondary }}>
+                {screeningSummary.pendingConsentCount > 0
+                  ? `Screening consent requested for ${screeningSummary.pendingConsentCount} application${screeningSummary.pendingConsentCount === 1 ? "" : "s"}.`
+                  : `${screeningSummary.total} screening request${screeningSummary.total === 1 ? "" : "s"} currently visible in your tenant workspace.`}
+              </div>
+              <div style={{ color: textTokens.muted }}>
+                {screeningSummary.pendingConsentCount > 0
+                  ? "Review the request and record your authorization when you are ready."
+                  : screeningSummary.latest?.description || "Review the latest screening workflow status for your applications."}
+              </div>
+              <Link to="/tenant/screening" style={{ fontWeight: 700 }}>
+                {screeningSummary.pendingConsentCount > 0 ? "Review request" : "Open screening requests"}
+              </Link>
+            </div>
+          </TenantInfoCard>
+        ) : null}
       </div>
 
       {nextActions.length ? (

--- a/rentchain-frontend/src/pages/tenant/tenantScreeningInboxView.ts
+++ b/rentchain-frontend/src/pages/tenant/tenantScreeningInboxView.ts
@@ -1,0 +1,182 @@
+import type { TenantScreeningRequest } from "../../api/tenantScreeningApi";
+
+export type TenantScreeningInboxStatus =
+  | "consent_required"
+  | "consent_confirmed"
+  | "screening_in_progress"
+  | "completed"
+  | "manual_review"
+  | "blocked"
+  | "unavailable";
+
+export type TenantScreeningInboxNextAction =
+  | "authorize_screening"
+  | "wait_for_landlord"
+  | "view_status"
+  | "no_action_needed";
+
+export type TenantScreeningInboxItemView = {
+  id: string;
+  status: TenantScreeningInboxStatus;
+  statusLabel: string;
+  description: string;
+  nextAction: TenantScreeningInboxNextAction;
+  nextActionLabel: string;
+  providerLabel: string;
+  propertyContext: string;
+  requestContext: string;
+  requestedAt: number | null;
+  activityAt: number | null;
+  consentedAt: number | null;
+  consentLabel: string;
+};
+
+function resolveProviderLabel(item: TenantScreeningRequest) {
+  if (item.consent?.providerLabel) return item.consent.providerLabel;
+  if (item.providerLabel) return item.providerLabel;
+  if (item.provider === "transunion_redirect") return "TransUnion";
+  if (item.provider === "equifax") return "Equifax";
+  if (item.provider === "manual") return "Manual review";
+  return "Selected screening provider";
+}
+
+export function normalizeTenantScreeningStatus(item: TenantScreeningRequest): TenantScreeningInboxStatus {
+  const rawStatus = String(item.status || "").trim().toLowerCase();
+  if (rawStatus === "consent_pending") return "consent_required";
+  if (rawStatus === "consented") return "consent_confirmed";
+  if (rawStatus === "in_progress" || rawStatus === "requested") return "screening_in_progress";
+  if (rawStatus === "completed") return "completed";
+  if (rawStatus === "manual_review_required") return "manual_review";
+  if (rawStatus === "failed") return "blocked";
+  return "unavailable";
+}
+
+function statusLabel(status: TenantScreeningInboxStatus) {
+  switch (status) {
+    case "consent_required":
+      return "Consent required";
+    case "consent_confirmed":
+      return "Consent confirmed";
+    case "screening_in_progress":
+      return "Screening in progress";
+    case "completed":
+      return "Completed";
+    case "manual_review":
+      return "Manual review";
+    case "blocked":
+      return "Blocked";
+    default:
+      return "Unavailable";
+  }
+}
+
+function statusDescription(item: TenantScreeningRequest, status: TenantScreeningInboxStatus) {
+  switch (status) {
+    case "consent_required":
+      return "The landlord has requested screening for this application. Your authorization is required before it can proceed.";
+    case "consent_confirmed":
+      return "Your consent has been recorded. The landlord can continue reviewing your application.";
+    case "screening_in_progress":
+      return "Screening is in progress.";
+    case "completed":
+      return "Screening workflow completed.";
+    case "manual_review":
+      return "This screening may require manual review.";
+    case "blocked":
+      if (String(item.nextAction || "").trim().toLowerCase() === "provider_activation_pending") {
+        return "Your consent may be recorded, but the landlord may still need to complete screening setup.";
+      }
+      return "Screening cannot proceed yet.";
+    default:
+      return "Screening status is currently unavailable.";
+  }
+}
+
+function nextAction(status: TenantScreeningInboxStatus): TenantScreeningInboxNextAction {
+  switch (status) {
+    case "consent_required":
+      return "authorize_screening";
+    case "consent_confirmed":
+      return "wait_for_landlord";
+    case "screening_in_progress":
+      return "view_status";
+    case "completed":
+      return "no_action_needed";
+    case "manual_review":
+      return "wait_for_landlord";
+    case "blocked":
+      return "wait_for_landlord";
+    default:
+      return "no_action_needed";
+  }
+}
+
+function nextActionLabel(action: TenantScreeningInboxNextAction) {
+  switch (action) {
+    case "authorize_screening":
+      return "Authorize screening";
+    case "wait_for_landlord":
+      return "Wait for landlord";
+    case "view_status":
+      return "View status";
+    default:
+      return "No action needed";
+  }
+}
+
+function propertyContext(item: TenantScreeningRequest) {
+  const label = [item.propertyLabel, item.unitLabel].filter(Boolean).join(" - ");
+  return label || "Rental application";
+}
+
+function requestContext(item: TenantScreeningRequest) {
+  const propertyLabel = propertyContext(item);
+  if (propertyLabel === "Rental application") {
+    return "Requested for your rental application.";
+  }
+  return `Requested for ${propertyLabel}.`;
+}
+
+function consentLabel(item: TenantScreeningRequest, status: TenantScreeningInboxStatus) {
+  if (item.consent?.acceptedAt || item.consentedAt) return "Consent confirmed";
+  if (status === "consent_required") return "Consent required";
+  return "Consent not needed yet";
+}
+
+function latestActivityAt(item: TenantScreeningRequest) {
+  return item.completedAt || item.startedAt || item.consentedAt || item.requestedAt || null;
+}
+
+export function buildTenantScreeningInboxItemView(item: TenantScreeningRequest): TenantScreeningInboxItemView {
+  const status = normalizeTenantScreeningStatus(item);
+  return {
+    id: item.id,
+    status,
+    statusLabel: statusLabel(status),
+    description: statusDescription(item, status),
+    nextAction: nextAction(status),
+    nextActionLabel: nextActionLabel(nextAction(status)),
+    providerLabel: resolveProviderLabel(item),
+    propertyContext: propertyContext(item),
+    requestContext: requestContext(item),
+    requestedAt: item.requestedAt || null,
+    activityAt: latestActivityAt(item),
+    consentedAt: item.consent?.acceptedAt || item.consentedAt || null,
+    consentLabel: consentLabel(item, status),
+  };
+}
+
+export function buildTenantScreeningDashboardSummary(items: TenantScreeningRequest[]) {
+  const ordered = [...items].sort(
+    (a, b) =>
+      (b.completedAt || b.startedAt || b.consentedAt || b.requestedAt || 0) -
+      (a.completedAt || a.startedAt || a.consentedAt || a.requestedAt || 0),
+  );
+  const views = ordered.map(buildTenantScreeningInboxItemView);
+  const pendingConsentCount = views.filter((item) => item.status === "consent_required").length;
+  return {
+    total: views.length,
+    pendingConsentCount,
+    latest: views[0] || null,
+  };
+}


### PR DESCRIPTION
This PR adds Tenant Screening Inbox v1 as a frontend-first, tenant-safe screening request workspace.

Includes:
- /tenant/screening route
- dedicated tenant screening inbox page
- tenant nav entry
- compact dashboard prompt for screening requests
- reuse of existing GET /tenant/screening payload
- reuse of existing audited POST /tenant/screening/:requestId/consent flow
- frontend-only tenant-safe status normalization
- consent-required cards using existing TenantScreeningConsentCard
- neutral copy for completed/manual review/blocked/unavailable states
- focused frontend tests

Verification:
- TenantScreeningInboxPage.test.tsx passed
- TenantScreeningConsentCard.test.tsx passed
- TenantWorkspacePage.test.tsx passed
- TenantProfileCommunicationsPages.test.tsx passed
- frontend build passed

Known remaining gaps:
- backend payload does not yet include landlord display/business label
- raw backend status remains richer than tenant-facing normalized labels
- consent revocation remains out of scope