### PR TITLE
fix: stabilize frontend test localStorage and context mocks

### DIFF
--- a/rentchain-frontend/src/test/setup.ts
+++ b/rentchain-frontend/src/test/setup.ts
@@ -1,1 +1,58 @@
 import "@testing-library/jest-dom/vitest";
+import { beforeEach } from "vitest";
+
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>();
+
+  get length() {
+    return this.store.size;
+  }
+
+  clear() {
+    this.store.clear();
+  }
+
+  getItem(key: string) {
+    return this.store.has(key) ? this.store.get(key)! : null;
+  }
+
+  key(index: number) {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+
+  removeItem(key: string) {
+    this.store.delete(String(key));
+  }
+
+  setItem(key: string, value: string) {
+    this.store.set(String(key), String(value));
+  }
+}
+
+const localStorageMock = new MemoryStorage();
+const sessionStorageMock = new MemoryStorage();
+
+Object.defineProperty(window, "localStorage", {
+  value: localStorageMock,
+  configurable: true,
+});
+
+Object.defineProperty(window, "sessionStorage", {
+  value: sessionStorageMock,
+  configurable: true,
+});
+
+Object.defineProperty(globalThis, "localStorage", {
+  value: localStorageMock,
+  configurable: true,
+});
+
+Object.defineProperty(globalThis, "sessionStorage", {
+  value: sessionStorageMock,
+  configurable: true,
+});
+
+beforeEach(() => {
+  localStorageMock.clear();
+  sessionStorageMock.clear();
+});


### PR DESCRIPTION
## Summary

- repair the shared frontend test harness so `localStorage` and `sessionStorage` behave like real Storage APIs during Vitest runs
- stabilize AuthContext and UpgradeContext test execution without changing runtime product behavior
- remove the unhandled error that was cascading through the failing frontend test cluster

## Changes

- add a central in-memory Storage-compatible mock in `rentchain-frontend/src/test/setup.ts`
- support `getItem`, `setItem`, `removeItem`, `clear`, `key`, and `length`
- install the mock for both `window` and `globalThis` storage objects
- reset storage state before each test to prevent cross-test leakage
- keep all fixes in shared test setup rather than patching product code or rewriting component tests

## Validation

- focused failing cluster passed:
  - `UpgradeContext.test.tsx`
  - `DashboardPage.test.tsx`
  - `AgentDecisionPanel.test.tsx`
  - `PropertyDetailPanel.test.tsx`
  - `PropertyRegistryStatusCard.test.tsx`
  - `Timeline.test.tsx`
  - `LandingPage.test.tsx`
- `cd rentchain-frontend && npm run test:light`
  - `151` files passed
  - `552` tests passed
  - `0` failed
  - `0` unhandled errors
- `cd rentchain-frontend && npm run build:app` passed