### PR TITLE
fix: remove nested button warning in applications page

### DIFF
--- a/rentchain-frontend/src/pages/ApplicationsPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.tsx
@@ -2047,11 +2047,19 @@ const ApplicationsPage: React.FC = () => {
                   ) : null}
                 <div className="rc-applications-list-scroll">
                   {filtered.map((app) => (
-                    <button
+                    <div
                       key={app.id}
-                      type="button"
+                      role="button"
+                      tabIndex={0}
                       className="rc-applications-list-item"
+                      aria-pressed={app.id === selectedId}
                       onClick={() => handleSelectApplication(app.id)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          handleSelectApplication(app.id);
+                        }
+                      }}
                       style={{
                         textAlign: "left",
                         border: `1px solid ${app.id === selectedId ? colors.accent : colors.border}`,
@@ -2097,7 +2105,7 @@ const ApplicationsPage: React.FC = () => {
                           {SCREENING_ENABLED ? "Screen tenant" : screeningComingSoonText}
                         </button>
                       </div>
-                    </button>
+                    </div>
                   ))}
                 </div>
                 </div>


### PR DESCRIPTION
## Summary

This PR fixes the nested button warning in `ApplicationsPage`.

## Changes

- change the outer application row from a native `<button>` to a `div` with `role="button"`
- preserve row click-to-select behavior
- add `Enter` and `Space` keyboard support for row selection
- keep the inner `Screen tenant` action as a real `<button>`
- remove the invalid nested interactive markup that triggered the warning

## Validation

- `cd rentchain-frontend && npx vitest run src/pages/ApplicationsPage.test.tsx`
- `cd rentchain-frontend && npm run test:light`
- `cd rentchain-frontend && npm run build:app`