### PR TITLE
perf: split stable frontend vendor chunks

### DIFF
--- a/rentchain-frontend/vite.config.ts
+++ b/rentchain-frontend/vite.config.ts
@@ -87,12 +87,20 @@ export default defineConfig(({ mode }) => {
           manualChunks(id) {
             if (!id.includes("node_modules")) return;
 
+            if (id.includes("/node_modules/firebase/")) {
+              return "firebase-vendor";
+            }
+
             if (
               id.includes("react") ||
               id.includes("react-dom") ||
               id.includes("react-router-dom")
             ) {
-              return "react_vendor";
+              return "react-vendor";
+            }
+
+            if (id.includes("/node_modules/recharts/")) {
+              return "charts-vendor";
             }
 
             return "vendor";


### PR DESCRIPTION
## Summary

This PR adds a conservative frontend `manualChunks` configuration for stable vendor groups.

## Changes

- update `vite.config.ts` only
- split stable vendor groups into separate chunks:
  - `react-vendor`
  - `firebase-vendor`
  - `charts-vendor` when present
  - fallback `vendor` chunk
- leave routes, pages, application code, and runtime behavior unchanged

## Validation

- `cd rentchain-frontend && npm run build:app`
- `cd rentchain-frontend && npm run test:light`

## Result

- vendor chunking is cleaner and more explicit
- the main `App` chunk did not materially improve
- the chunk-size warning remains
- the remaining optimization opportunity is in app-code splitting, not further vendor chunk tuning

## Recommendation

- no further `manualChunks` tuning at this time
- only revisit bundle optimization if there is appetite for deliberate splitting of currently eager core landlord surfaces