### PR TITLE
Polish/transunion connect modal copy and fit follow up

### DIFF
--- a/rentchain-frontend/src/components/integrations/ConnectTransUnionModal.test.tsx
+++ b/rentchain-frontend/src/components/integrations/ConnectTransUnionModal.test.tsx
@@ -14,6 +14,11 @@ describe("ConnectTransUnionModal", () => {
     );
 
     expect(screen.getByText("Connect Your TransUnion Account")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Connect your TransUnion membership by entering the member code and passcode issued to your business. Screening requests are initiated under your TransUnion credentials within RentChain."
+      )
+    ).toBeInTheDocument();
     expect(screen.getByText("Need TransUnion access?")).toBeInTheDocument();
     expect(screen.getByText("Already credentialed?")).toBeInTheDocument();
     expect(screen.getByText("Choose path")).toBeInTheDocument();
@@ -45,6 +50,9 @@ describe("ConnectTransUnionModal", () => {
 
     expect(dialogQueries.getByText("Member code")).toBeInTheDocument();
     expect(dialogQueries.getByText("Passcode")).toBeInTheDocument();
+    expect(dialogQueries.getByRole("button", { name: "Back" })).toBeInTheDocument();
+    expect(dialogQueries.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+    expect(dialogQueries.getByRole("button", { name: "Connect Account" })).toBeInTheDocument();
     expect(dialogQueries.getByText("Business details required for setup")).toBeInTheDocument();
     expect(
       dialogQueries.getByText(/Next step: connect your membership now, then return to Applications/i),

--- a/rentchain-frontend/src/components/integrations/ConnectTransUnionModal.tsx
+++ b/rentchain-frontend/src/components/integrations/ConnectTransUnionModal.tsx
@@ -204,7 +204,7 @@ export function ConnectTransUnionModal({
               display: "grid",
               gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))",
               gap: spacing.sm,
-            }}</file>
+            }}
           >
             {[
               {

--- a/rentchain-frontend/src/components/integrations/ConnectTransUnionModal.tsx
+++ b/rentchain-frontend/src/components/integrations/ConnectTransUnionModal.tsx
@@ -178,8 +178,11 @@ export function ConnectTransUnionModal({
         elevated
         style={{
           width: "min(620px, 100%)",
-          display: "grid",
+          display: "flex",
+          flexDirection: "column",
           gap: spacing.md,
+          maxHeight: "min(760px, calc(100vh - 32px))",
+          overflow: "hidden",
           borderRadius: radius.lg,
           boxShadow: shadows.pop,
         }}
@@ -187,269 +190,272 @@ export function ConnectTransUnionModal({
         <div style={{ display: "grid", gap: spacing.xs }}>
           <h2 style={{ margin: 0, fontSize: "1.2rem" }}>Connect Your TransUnion Account</h2>
           <p style={{ margin: 0, color: text.muted }}>
-            Keep screening inside RentChain by saving your TransUnion member code and passcode
-            here. Your credentials are encrypted and never displayed back after save.
+            Connect your TransUnion membership by entering the member code and passcode issued to
+            your business. Screening requests are initiated under your TransUnion credentials within
+            RentChain.
           </p>
         </div>
 
-        <div
-          style={{
-            display: "grid",
-            gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))",
-            gap: spacing.sm,
-          }}
-        >
-          {[
-            {
-              key: "start",
-              label: "Choose path",
-              active: showChooser,
-              complete: showCredentials || success,
-            },
-            {
-              key: "connect",
-              label: "Connect membership",
-              active: showCredentials,
-              complete: success,
-            },
-            {
-              key: "ready",
-              label: "Ready to screen",
-              active: success,
-              complete: success,
-            },
-          ].map((item) => (
-            <div
-              key={item.key}
-              style={{
-                border: `1px solid ${item.active || item.complete ? colors.accent : colors.border}`,
-                background: item.active || item.complete ? colors.accentSoft : colors.bg,
-                borderRadius: radius.md,
-                padding: spacing.sm,
-                display: "grid",
-                gap: 4,
-              }}
-            >
-              <div style={{ fontWeight: 700 }}>{item.label}</div>
-              <div style={{ color: text.muted, fontSize: "0.85rem" }}>
-                {item.active ? "Current step" : item.complete ? "Completed" : "Upcoming"}
-              </div>
-            </div>
-          ))}
-        </div>
-
-        {showChooser ? (
+        <div style={{ display: "grid", gap: spacing.sm, minHeight: 0, overflowY: "auto" }}>
           <div
             style={{
               display: "grid",
-              gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+              gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))",
               gap: spacing.sm,
             }}
           >
-            <div
-              style={{
-                border: `1px solid ${colors.border}`,
-                borderRadius: radius.md,
-                background: colors.bg,
-                padding: spacing.sm,
-                display: "grid",
-                gap: 10,
-              }}
-            >
-              <div style={{ fontWeight: 700 }}>Need TransUnion access?</div>
-              <div style={{ color: text.muted, fontSize: "0.92rem", lineHeight: 1.5 }}>
-                Don&apos;t have TransUnion yet? We&apos;ll guide you through the external onboarding
-                path first. Once TransUnion issues your member code and passcode, come back here to
-                finish setup in RentChain.
-              </div>
-              <div style={{ color: text.subtle, fontSize: "0.86rem" }}>
-                Outcome: your account moves into a credentialing-in-progress state until you receive
-                the issued membership details.
-              </div>
-              {onGetAccess ? (
-                <div>
-                  <Button type="button" variant="secondary" onClick={onGetAccess}>
-                    Get TransUnion Access
-                  </Button>
+            {[
+              {
+                key: "start",
+                label: "Choose path",
+                active: showChooser,
+                complete: showCredentials || success,
+              },
+              {
+                key: "connect",
+                label: "Connect membership",
+                active: showCredentials,
+                complete: success,
+              },
+              {
+                key: "ready",
+                label: "Ready to screen",
+                active: success,
+                complete: success,
+              },
+            ].map((item) => (
+              <div
+                key={item.key}
+                style={{
+                  border: `1px solid ${item.active || item.complete ? colors.accent : colors.border}`,
+                  background: item.active || item.complete ? colors.accentSoft : colors.bg,
+                  borderRadius: radius.md,
+                  padding: spacing.sm,
+                  display: "grid",
+                  gap: 4,
+                }}
+              >
+                <div style={{ fontWeight: 700 }}>{item.label}</div>
+                <div style={{ color: text.muted, fontSize: "0.85rem" }}>
+                  {item.active ? "Current step" : item.complete ? "Completed" : "Upcoming"}
                 </div>
-              ) : null}
-            </div>
-            <div
-              style={{
-                border: `1px solid ${colors.border}`,
-                borderRadius: radius.md,
-                background: colors.bg,
-                padding: spacing.sm,
-                display: "grid",
-                gap: 10,
-              }}
-            >
-              <div style={{ fontWeight: 700 }}>Already credentialed?</div>
-              <div style={{ color: text.muted, fontSize: "0.92rem", lineHeight: 1.5 }}>
-                Already approved by TransUnion? Enter the member code and passcode that were issued
-                to your business so you can start screening in RentChain.
               </div>
-              <div style={{ color: text.subtle, fontSize: "0.86rem" }}>
-                Outcome: once the credentials are verified, your account is connected and ready to
-                screen.
-              </div>
-              <div>
-                <Button
-                  type="button"
-                  onClick={() => {
-                    onChooseExistingCredentials?.();
-                    setStep("credentials");
-                  }}
-                >
-                  I Already Have Credentials
-                </Button>
-              </div>
-            </div>
+            ))}
           </div>
-        ) : null}
 
-        {showCredentials ? (
-          <div style={{ display: "grid", gap: spacing.sm }}>
+          {showChooser ? (
             <div
               style={{
-                border: `1px solid ${colors.border}`,
-                borderRadius: radius.md,
-                background: colors.bg,
-                padding: spacing.sm,
                 display: "grid",
-                gap: 6,
-              }}
-            >
-              <div style={{ fontWeight: 700 }}>Membership credentials</div>
-              <div style={{ color: text.muted, fontSize: "0.92rem", lineHeight: 1.5 }}>
-                Enter the member code and passcode exactly as TransUnion provided them.
-              </div>
-              <div style={{ color: text.subtle, fontSize: "0.86rem" }}>
-                Next step: connect your membership now, then return to Applications to start the
-                first screening.
-              </div>
-            </div>
-
-            <label style={{ display: "grid", gap: 6 }}>
-              <span>Member code</span>
-              <Input
-                value={form.memberCode}
-                onChange={(event) => setField("memberCode", event.target.value)}
-              />
-            </label>
-            <label style={{ display: "grid", gap: 6 }}>
-              <span>Passcode</span>
-              <Input
-                type="password"
-                value={form.passcode}
-                onChange={(event) => setField("passcode", event.target.value)}
-              />
-            </label>
-
-            <div
-              style={{
-                border: `1px solid ${colors.border}`,
-                borderRadius: radius.md,
-                background: "rgba(15,23,42,0.02)",
-                padding: spacing.sm,
-                display: "grid",
+                gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
                 gap: spacing.sm,
               }}
             >
-              <div style={{ fontWeight: 700 }}>Business details required for setup</div>
-              <div style={{ color: text.muted, fontSize: "0.92rem", lineHeight: 1.5 }}>
-                RentChain also saves the business contact details tied to this TransUnion
-                connection so we can keep your setup record complete. If we already have them on
-                file, you can stay focused on the member code and passcode here.
+              <div
+                style={{
+                  border: `1px solid ${colors.border}`,
+                  borderRadius: radius.md,
+                  background: colors.bg,
+                  padding: spacing.sm,
+                  display: "grid",
+                  gap: 10,
+                }}
+              >
+                <div style={{ fontWeight: 700 }}>Need TransUnion access?</div>
+                <div style={{ color: text.muted, fontSize: "0.92rem", lineHeight: 1.5 }}>
+                  Don&apos;t have TransUnion yet? We&apos;ll guide you through the external onboarding
+                  path first. Once TransUnion issues your member code and passcode, come back here to
+                  finish setup in RentChain.
+                </div>
+                <div style={{ color: text.subtle, fontSize: "0.86rem" }}>
+                  Outcome: your account moves into a credentialing-in-progress state until you receive
+                  the issued membership details.
+                </div>
+                {onGetAccess ? (
+                  <div>
+                    <Button type="button" variant="secondary" onClick={onGetAccess}>
+                      Get TransUnion Access
+                    </Button>
+                  </div>
+                ) : null}
               </div>
-              {hasSavedBusinessDetails && !editingBusinessDetails ? (
+              <div
+                style={{
+                  border: `1px solid ${colors.border}`,
+                  borderRadius: radius.md,
+                  background: colors.bg,
+                  padding: spacing.sm,
+                  display: "grid",
+                  gap: 10,
+                }}
+              >
+                <div style={{ fontWeight: 700 }}>Already credentialed?</div>
+                <div style={{ color: text.muted, fontSize: "0.92rem", lineHeight: 1.5 }}>
+                  Already approved by TransUnion? Enter the member code and passcode that were issued
+                  to your business so you can start screening in RentChain.
+                </div>
+                <div style={{ color: text.subtle, fontSize: "0.86rem" }}>
+                  Outcome: once the credentials are verified, your account is connected and ready to
+                  screen.
+                </div>
+                <div>
+                  <Button
+                    type="button"
+                    onClick={() => {
+                      onChooseExistingCredentials?.();
+                      setStep("credentials");
+                    }}
+                  >
+                    I Already Have Credentials
+                  </Button>
+                </div>
+              </div>
+            </div>
+          ) : null}
+
+          {showCredentials ? (
+            <div style={{ display: "grid", gap: spacing.sm }}>
+              <div
+                style={{
+                  border: `1px solid ${colors.border}`,
+                  borderRadius: radius.md,
+                  background: colors.bg,
+                  padding: spacing.sm,
+                  display: "grid",
+                  gap: 6,
+                }}
+              >
+                <div style={{ fontWeight: 700 }}>Membership credentials</div>
+                <div style={{ color: text.muted, fontSize: "0.92rem", lineHeight: 1.5 }}>
+                  Enter the member code and passcode exactly as TransUnion provided them.
+                </div>
+                <div style={{ color: text.subtle, fontSize: "0.86rem" }}>
+                  Next step: connect your membership now, then return to Applications to start the
+                  first screening.
+                </div>
+              </div>
+
+              <label style={{ display: "grid", gap: 6 }}>
+                <span>Member code</span>
+                <Input
+                  value={form.memberCode}
+                  onChange={(event) => setField("memberCode", event.target.value)}
+                />
+              </label>
+              <label style={{ display: "grid", gap: 6 }}>
+                <span>Passcode</span>
+                <Input
+                  type="password"
+                  value={form.passcode}
+                  onChange={(event) => setField("passcode", event.target.value)}
+                />
+              </label>
+
+              <div
+                style={{
+                  border: `1px solid ${colors.border}`,
+                  borderRadius: radius.md,
+                  background: "rgba(15,23,42,0.02)",
+                  padding: spacing.sm,
+                  display: "grid",
+                  gap: spacing.sm,
+                }}
+              >
+                <div style={{ fontWeight: 700 }}>Business details required for setup</div>
+                <div style={{ color: text.muted, fontSize: "0.92rem", lineHeight: 1.5 }}>
+                  RentChain also saves the business contact details tied to this TransUnion
+                  connection so we can keep your setup record complete. If we already have them on
+                  file, you can stay focused on the member code and passcode here.
+                </div>
+                {hasSavedBusinessDetails && !editingBusinessDetails ? (
+                  <div
+                    style={{
+                      border: `1px solid ${colors.border}`,
+                      borderRadius: radius.md,
+                      background: "#fff",
+                      padding: spacing.sm,
+                      display: "grid",
+                      gap: 6,
+                      fontSize: "0.92rem",
+                    }}
+                  >
+                    <div>Business: {savedBusinessName}</div>
+                    <div>Contact: {savedContactName}</div>
+                    <div>Email: {savedContactEmail}</div>
+                    <div>
+                      <Button
+                        type="button"
+                        variant="secondary"
+                        onClick={() => {
+                          setForm((current) => ({
+                            ...current,
+                            businessName: savedBusinessName,
+                            contactName: savedContactName,
+                            contactEmail: savedContactEmail,
+                          }));
+                          setEditingBusinessDetails(true);
+                        }}
+                      >
+                        Edit business details
+                      </Button>
+                    </div>
+                  </div>
+                ) : (
+                  <>
+                    <label style={{ display: "grid", gap: 6 }}>
+                      <span>Legal business name</span>
+                      <Input
+                        value={form.businessName}
+                        onChange={(event) => setField("businessName", event.target.value)}
+                      />
+                    </label>
+                    <label style={{ display: "grid", gap: 6 }}>
+                      <span>Contact name</span>
+                      <Input
+                        value={form.contactName}
+                        onChange={(event) => setField("contactName", event.target.value)}
+                      />
+                    </label>
+                    <label style={{ display: "grid", gap: 6 }}>
+                      <span>Contact email</span>
+                      <Input
+                        type="email"
+                        value={form.contactEmail}
+                        onChange={(event) => setField("contactEmail", event.target.value)}
+                      />
+                    </label>
+                  </>
+                )}
+              </div>
+
+              <label style={{ display: "flex", gap: spacing.sm, alignItems: "flex-start" }}>
+                <input
+                  type="checkbox"
+                  checked={form.confirmPermissibleUse}
+                  onChange={(event) => setField("confirmPermissibleUse", event.target.checked)}
+                />
+                <span style={{ color: text.muted, lineHeight: 1.5 }}>
+                  I confirm these credentials were issued by TransUnion for permissible tenant-screening
+                  use.
+                </span>
+              </label>
+              {error ? (
                 <div
                   style={{
-                    border: `1px solid ${colors.border}`,
+                    border: `1px solid rgba(239,68,68,0.3)`,
+                    background: "rgba(239,68,68,0.08)",
                     borderRadius: radius.md,
-                    background: "#fff",
                     padding: spacing.sm,
-                    display: "grid",
-                    gap: 6,
+                    color: colors.danger,
                     fontSize: "0.92rem",
                   }}
                 >
-                  <div>Business: {savedBusinessName}</div>
-                  <div>Contact: {savedContactName}</div>
-                  <div>Email: {savedContactEmail}</div>
-                  <div>
-                    <Button
-                      type="button"
-                      variant="secondary"
-                      onClick={() => {
-                        setForm((current) => ({
-                          ...current,
-                          businessName: savedBusinessName,
-                          contactName: savedContactName,
-                          contactEmail: savedContactEmail,
-                        }));
-                        setEditingBusinessDetails(true);
-                      }}
-                    >
-                      Edit business details
-                    </Button>
-                  </div>
+                  {error}
                 </div>
-              ) : (
-                <>
-                  <label style={{ display: "grid", gap: 6 }}>
-                    <span>Legal business name</span>
-                    <Input
-                      value={form.businessName}
-                      onChange={(event) => setField("businessName", event.target.value)}
-                    />
-                  </label>
-                  <label style={{ display: "grid", gap: 6 }}>
-                    <span>Contact name</span>
-                    <Input
-                      value={form.contactName}
-                      onChange={(event) => setField("contactName", event.target.value)}
-                    />
-                  </label>
-                  <label style={{ display: "grid", gap: 6 }}>
-                    <span>Contact email</span>
-                    <Input
-                      type="email"
-                      value={form.contactEmail}
-                      onChange={(event) => setField("contactEmail", event.target.value)}
-                    />
-                  </label>
-                </>
-              )}
+              ) : null}
             </div>
-
-            <label style={{ display: "flex", gap: spacing.sm, alignItems: "flex-start" }}>
-              <input
-                type="checkbox"
-                checked={form.confirmPermissibleUse}
-                onChange={(event) => setField("confirmPermissibleUse", event.target.checked)}
-              />
-              <span style={{ color: text.muted, lineHeight: 1.5 }}>
-                I confirm these credentials were issued by TransUnion for permissible tenant-screening
-                use.
-              </span>
-            </label>
-            {error ? (
-              <div
-                style={{
-                  border: `1px solid rgba(239,68,68,0.3)`,
-                  background: "rgba(239,68,68,0.08)",
-                  borderRadius: radius.md,
-                  padding: spacing.sm,
-                  color: colors.danger,
-                  fontSize: "0.92rem",
-                }}
-              >
-                {error}
-              </div>
-            ) : null}
-          </div>
-        ) : null}
+          ) : null}
+        </div>
 
         <div style={{ display: "flex", justifyContent: "flex-end", gap: spacing.sm, flexWrap: "wrap" }}>
           {showCredentials ? (

--- a/rentchain-frontend/src/components/integrations/ConnectTransUnionModal.tsx
+++ b/rentchain-frontend/src/components/integrations/ConnectTransUnionModal.tsx
@@ -100,6 +100,7 @@ export function ConnectTransUnionModal({
         style={{
           position: "fixed",
           inset: 0,
+          minHeight: "100dvh",
           background: "rgba(15,23,42,0.42)",
           display: "flex",
           alignItems: "center",
@@ -166,6 +167,7 @@ export function ConnectTransUnionModal({
       style={{
         position: "fixed",
         inset: 0,
+        minHeight: "100dvh",
         background: "rgba(15,23,42,0.42)",
         display: "flex",
         alignItems: "center",
@@ -181,8 +183,9 @@ export function ConnectTransUnionModal({
           display: "flex",
           flexDirection: "column",
           gap: spacing.md,
-          maxHeight: "min(760px, calc(100vh - 32px))",
+          maxHeight: "min(760px, calc(100dvh - 32px))",
           overflow: "hidden",
+          margin: 0,
           borderRadius: radius.lg,
           boxShadow: shadows.pop,
         }}
@@ -196,7 +199,7 @@ export function ConnectTransUnionModal({
           </p>
         </div>
 
-        <div style={{ display: "grid", gap: spacing.sm, minHeight: 0, overflowY: "auto" }}>
+        <div style={{ display: "grid", gap: spacing.sm, minHeight: 0, flex: 1, overflowY: "auto" }}>
           <div
             style={{
               display: "grid",


### PR DESCRIPTION
Summary
This PR fixes the remaining viewport-fit issue in the TransUnion Connect modal.

Changes
use viewport-safe overlay sizing with 100dvh
constrain the modal shell height to the padded viewport
make the modal body the scrollable region with flex: 1 and minHeight: 0
keep footer actions outside the scroll body so Back, Cancel, and Connect Account stay reachable
preserve the approved compliance-aligned intro copy and existing credential flow behavior
Validation
cd rentchain-frontend && npx vitest run src/components/integrations/ConnectTransUnionModal.test.tsx
cd rentchain-frontend && npx vitest run src/pages/ApplicationsPage.test.tsx
cd rentchain-frontend && npm run test:light
cd rentchain-frontend && npm run build:app
