### PR TITLE
fix: handle tenant magic link workspace initialization

### DIFF
--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -331,6 +331,67 @@ describe("tenantPortalRoutes foundation", () => {
     expect(res.status).toBe(401);
   });
 
+  it("rejects tenant workspace access when role or tenantId is missing", async () => {
+    const router = (await import("../tenantPortalRoutes")).default;
+
+    const roleMismatch = await invokeRouter(router, {
+      method: "GET",
+      url: "/workspace",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "landlord",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    const missingTenantId = await invokeRouter(router, {
+      method: "GET",
+      url: "/workspace",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+        }),
+      },
+    });
+
+    expect(roleMismatch.status).toBe(401);
+    expect(roleMismatch.body?.error).toBe("UNAUTHORIZED");
+    expect(missingTenantId.status).toBe(401);
+    expect(missingTenantId.body?.error).toBe("UNAUTHORIZED");
+  });
+
+  it("returns tenant_not_initialized when a valid tenant lacks a resolved tenancy context", async () => {
+    ensureCollection("applications").clear();
+    ensureCollection("leases").clear();
+    ensureCollection("tenancy_invites").clear();
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/workspace",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual({
+      ok: false,
+      error: "TENANT_NOT_INITIALIZED",
+      status: "tenant_not_initialized",
+    });
+  });
+
   it("returns safe projected workspace data and writes compact events", async () => {
     const router = (await import("../tenantPortalRoutes")).default;
     const res = await invokeRouter(router, {

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -2048,8 +2048,10 @@ async function buildTenantMaintenanceUpdateItems(tenantId: string): Promise<Tena
 }
 
 function requireTenantWorkspaceIdentity(req: any, res: any, next: any) {
+  const role = String(req.user?.role || "").trim().toLowerCase();
   const userId = String(req.user?.id || "").trim();
-  if (!userId) {
+  const tenantId = String(req.user?.tenantId || "").trim();
+  if (!userId || role !== "tenant" || !tenantId) {
     return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
   }
   return next();
@@ -2114,8 +2116,21 @@ async function resolveWorkspaceContextOrRespond(req: any, res: any) {
 
   if (context.ok) return context;
 
-  const status = context.reason === "unauthenticated" ? 401 : 403;
-  res.status(status).json({ ok: false, error: context.reason === "ambiguous_authority" ? "AMBIGUOUS_TENANCY_CONTEXT" : "FORBIDDEN" });
+  if (context.reason === "unauthenticated") {
+    res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    return null;
+  }
+
+  if (context.reason === "no_authority") {
+    res.status(409).json({
+      ok: false,
+      error: "TENANT_NOT_INITIALIZED",
+      status: "tenant_not_initialized",
+    });
+    return null;
+  }
+
+  res.status(403).json({ ok: false, error: "AMBIGUOUS_TENANCY_CONTEXT" });
   return null;
 }
 

--- a/rentchain-frontend/src/components/auth/RequireTenant.test.tsx
+++ b/rentchain-frontend/src/components/auth/RequireTenant.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, render, screen } from "@testing-library/react";
+import { act } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { RequireTenant } from "./RequireTenant";
@@ -23,6 +24,7 @@ vi.mock("../../api/tenantPortal", () => ({
 
 afterEach(() => {
   cleanup();
+  vi.useRealTimers();
   vi.clearAllMocks();
 });
 
@@ -189,5 +191,106 @@ describe("RequireTenant", () => {
 
     expect(await screen.findByText("Tenant login")).toBeInTheDocument();
     expect(screen.queryByText("Tenant area")).not.toBeInTheDocument();
+  });
+
+  it("shows tenant workspace setup state and retries after initialization responses", async () => {
+    vi.useFakeTimers();
+    mocks.getTenantTokenMock.mockReturnValue("tenant-token");
+    mocks.getTenantWorkspaceMock
+      .mockRejectedValueOnce({
+        status: 409,
+        payload: { error: "TENANT_NOT_INITIALIZED", status: "tenant_not_initialized" },
+        message: "TENANT_NOT_INITIALIZED",
+      })
+      .mockRejectedValueOnce({
+        status: 409,
+        payload: { error: "TENANT_NOT_INITIALIZED", status: "tenant_not_initialized" },
+        message: "TENANT_NOT_INITIALIZED",
+      })
+      .mockResolvedValue({
+        context: {
+          authority: "active_tenant",
+          propertyId: "prop-1",
+          rc_prop_id: "rc-prop-1",
+          applicationId: "app-1",
+          leaseId: "lease-1",
+          tenantId: "tenant-1",
+          unitId: "unit-1",
+          invitedEmail: "tenant@example.com",
+        },
+        property: null,
+        application: null,
+        lease: null,
+        maintenance: [],
+      });
+
+    render(
+      <MemoryRouter initialEntries={["/tenant/dashboard"]}>
+        <Routes>
+          <Route
+            path="/tenant/dashboard"
+            element={
+              <RequireTenant>
+                <div>Tenant area</div>
+              </RequireTenant>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText(/Setting up your tenant workspace/i)).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("Tenant area")).toBeInTheDocument();
+    expect(mocks.getTenantWorkspaceMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("shows the fallback recovery state only after tenant workspace retries fail", async () => {
+    vi.useFakeTimers();
+    mocks.getTenantTokenMock.mockReturnValue("tenant-token");
+    mocks.getTenantWorkspaceMock.mockRejectedValue({
+      status: 409,
+      payload: { error: "TENANT_NOT_INITIALIZED", status: "tenant_not_initialized" },
+      message: "TENANT_NOT_INITIALIZED",
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/tenant/dashboard"]}>
+        <Routes>
+          <Route
+            path="/tenant/dashboard"
+            element={
+              <RequireTenant>
+                <div>Tenant area</div>
+              </RequireTenant>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText(/Setting up your tenant workspace/i)).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByRole("link", { name: /Request a new sign-in link/i })).toBeInTheDocument();
+    expect(screen.getByText(/workspace setup is still finishing/i)).toBeInTheDocument();
+    expect(mocks.getTenantWorkspaceMock).toHaveBeenCalledTimes(3);
   });
 });

--- a/rentchain-frontend/src/components/auth/RequireTenant.tsx
+++ b/rentchain-frontend/src/components/auth/RequireTenant.tsx
@@ -80,16 +80,31 @@ export const RequireTenant: React.FC<{ children: React.ReactNode }> = ({ childre
   const location = useLocation();
   const [workspace, setWorkspace] = React.useState<TenantWorkspaceSummary | null>(null);
   const [workspaceLoading, setWorkspaceLoading] = React.useState(false);
+  const [workspaceInitializing, setWorkspaceInitializing] = React.useState(false);
   const [workspaceError, setWorkspaceError] = React.useState<TenantWorkspaceError>(null);
   const [workspaceResolved, setWorkspaceResolved] = React.useState(false);
   const token = getTenantToken();
 
   React.useEffect(() => {
     let cancelled = false;
+    const MAX_INITIALIZATION_RETRIES = 3;
+    const INITIALIZATION_RETRY_DELAY_MS = 250;
+
+    const isTenantNotInitialized = (error: any) => {
+      const code = String(error?.payload?.error || error?.message || "").trim().toUpperCase();
+      const status = String(error?.payload?.status || "").trim().toLowerCase();
+      return code === "TENANT_NOT_INITIALIZED" || status === "tenant_not_initialized";
+    };
+
+    const wait = (ms: number) =>
+      new Promise<void>((resolve) => {
+        window.setTimeout(resolve, ms);
+      });
 
     if (!token) {
       setWorkspace(null);
       setWorkspaceLoading(false);
+      setWorkspaceInitializing(false);
       setWorkspaceError(null);
       setWorkspaceResolved(true);
       return () => {
@@ -98,28 +113,49 @@ export const RequireTenant: React.FC<{ children: React.ReactNode }> = ({ childre
     }
 
     setWorkspaceLoading(true);
+    setWorkspaceInitializing(false);
     setWorkspaceError(null);
     setWorkspaceResolved(false);
 
-    void getTenantWorkspace()
-      .then((summary) => {
-        if (cancelled) return;
-        setWorkspace(summary);
-      })
-      .catch((error) => {
-        if (cancelled) return;
-        setWorkspace(null);
-        setWorkspaceError({
-          status: error?.status,
-          message: String(error?.message || ""),
-          payload: error?.payload ?? null,
-        });
-      })
-      .finally(() => {
-        if (cancelled) return;
-        setWorkspaceLoading(false);
-        setWorkspaceResolved(true);
-      });
+    void (async () => {
+      let lastError: TenantWorkspaceError = null;
+
+      for (let attempt = 0; attempt < MAX_INITIALIZATION_RETRIES; attempt += 1) {
+        try {
+          const summary = await getTenantWorkspace();
+          if (cancelled) return;
+          setWorkspace(summary);
+          setWorkspaceInitializing(false);
+          lastError = null;
+          return;
+        } catch (error: any) {
+          if (cancelled) return;
+          const nextError = {
+            status: error?.status,
+            message: String(error?.message || ""),
+            payload: error?.payload ?? null,
+          };
+
+          lastError = nextError;
+
+          if (!isTenantNotInitialized(error) || attempt === MAX_INITIALIZATION_RETRIES - 1) {
+            break;
+          }
+
+          setWorkspaceInitializing(true);
+          await wait(INITIALIZATION_RETRY_DELAY_MS);
+        }
+      }
+
+      if (cancelled) return;
+      setWorkspace(null);
+      setWorkspaceInitializing(false);
+      setWorkspaceError(lastError);
+    })().finally(() => {
+      if (cancelled) return;
+      setWorkspaceLoading(false);
+      setWorkspaceResolved(true);
+    });
 
     return () => {
       cancelled = true;
@@ -130,6 +166,7 @@ export const RequireTenant: React.FC<{ children: React.ReactNode }> = ({ childre
     hasTenantToken: Boolean(token),
     authLoading: isLoading || !ready,
     workspaceLoading: workspaceLoading || (Boolean(token) && !workspaceResolved),
+    workspaceInitializing,
     workspace,
     workspaceError,
     requestedPath: location.pathname,

--- a/rentchain-frontend/src/lib/tenantWorkspaceAccess.ts
+++ b/rentchain-frontend/src/lib/tenantWorkspaceAccess.ts
@@ -6,6 +6,7 @@ type TenantWorkspaceError = {
   payload?: {
     error?: string;
     message?: string;
+    status?: string;
   } | null;
 } | null;
 
@@ -13,6 +14,7 @@ export type TenantWorkspaceAccessInput = {
   hasTenantToken: boolean;
   authLoading: boolean;
   workspaceLoading: boolean;
+  workspaceInitializing?: boolean;
   workspace: TenantWorkspaceSummary | null;
   workspaceError: TenantWorkspaceError;
   requestedPath: string;
@@ -58,6 +60,13 @@ function isUnauthorizedWorkspaceError(error: TenantWorkspaceError) {
   return code === "UNAUTHORIZED";
 }
 
+function isTenantWorkspaceInitializingError(error: TenantWorkspaceError) {
+  if (!error) return false;
+  const code = String(error.payload?.error || error.message || "").trim().toUpperCase();
+  const status = String(error.payload?.status || "").trim().toLowerCase();
+  return code === "TENANT_NOT_INITIALIZED" || status === "tenant_not_initialized";
+}
+
 export function getTenantWorkspaceDefaultDestination(
   workspace: TenantWorkspaceSummary | null
 ): string {
@@ -83,16 +92,29 @@ export function resolveTenantWorkspaceAccess(
     return { status: "login_required", redirectTo: loginPath };
   }
 
-  if (input.authLoading || input.workspaceLoading) {
+  if (input.workspaceInitializing || input.authLoading || input.workspaceLoading) {
     return {
       status: "loading",
-      title: "Finishing sign-in",
-      description: "We're restoring your tenant access and loading your workspace.",
+      title: input.workspaceInitializing ? "Setting up your tenant workspace..." : "Finishing sign-in",
+      description: input.workspaceInitializing
+        ? "We're restoring your tenant access and will retry automatically as your workspace becomes ready."
+        : "We're restoring your tenant access and loading your workspace.",
     };
   }
 
   if (isUnauthorizedWorkspaceError(input.workspaceError)) {
     return { status: "login_required", redirectTo: loginPath };
+  }
+
+  if (isTenantWorkspaceInitializingError(input.workspaceError)) {
+    return {
+      status: "blocked",
+      title: "We couldn't load your tenant workspace yet",
+      description:
+        "Your sign-in succeeded, but tenant workspace setup is still finishing. Request a new sign-in link only if this does not clear shortly.",
+      actionHref: loginPath,
+      actionLabel: "Request a new sign-in link",
+    };
   }
 
   if (input.workspaceError || !input.workspace) {


### PR DESCRIPTION
## Summary

This PR fixes tenant magic-link workspace access when sign-in succeeds but tenant workspace context is not immediately resolved.

## Changes

- return a structured backend `TENANT_NOT_INITIALIZED` response with HTTP `409` instead of a generic `403`
- tighten the tenant workspace identity gate to require `role=tenant` and `tenantId`
- show a tenant workspace setup/loading state on the frontend instead of an immediate hard failure
- retry workspace fetch briefly before showing the recovery CTA
- add focused backend and frontend coverage for the initialization path

## Validation

- `cd rentchain-api && npx vitest run src/routes/__tests__/tenantPortalRoutes.test.ts`
- `cd rentchain-frontend && npx vitest run src/components/auth/RequireTenant.test.tsx`
- `cd rentchain-frontend && npm run test:light`
- `cd rentchain-frontend && npm run build:app`

## Note

- non-failing `act(...)` warnings remain in the new retry tests and can be cleaned up separately