### PR TITLE
fix: resolve tenant workspace from tenant records

### DIFF
--- a/rentchain-api/src/services/__tests__/tenancyContextService.test.ts
+++ b/rentchain-api/src/services/__tests__/tenancyContextService.test.ts
@@ -114,6 +114,127 @@ describe("resolveTenancyContext", () => {
     expect(result.unitId).toBe("unit-9");
   });
 
+  it("resolves workspace authority from the tenant record and currentLeaseId when leaseId is null", async () => {
+    ensureCollection("tenants").set("bcea70bf3f353746c8895bc9", {
+      tenantId: "bcea70bf3f353746c8895bc9",
+      email: "hello+tenant1@rentchain.ai",
+      landlordId: "PXbRIbJdZpV2eBjzNmLaISgDa852",
+      propertyId: "mAdeNtAtzAOrxGA4Dx9H",
+      unitId: "ufSsrCIiWSOHPCDtUAS5",
+      currentLeaseId: "HMqzstV4BcZszl9dgPGP",
+      leaseId: null,
+      source: "invite",
+    });
+    ensureCollection("leases").set("HMqzstV4BcZszl9dgPGP", {
+      tenantId: "bcea70bf3f353746c8895bc9",
+      propertyId: "mAdeNtAtzAOrxGA4Dx9H",
+      unitId: "ufSsrCIiWSOHPCDtUAS5",
+      status: "active",
+    });
+    ensureCollection("properties").set("mAdeNtAtzAOrxGA4Dx9H", {
+      rc_prop_id: "rc-prop-tenant-1",
+    });
+
+    const { resolveTenancyContext } = await import("../tenantPortal/tenancyContextService");
+    const result = await resolveTenancyContext({
+      uid: "bcea70bf3f353746c8895bc9",
+      email: "hello+tenant1@rentchain.ai",
+      tenantId: "bcea70bf3f353746c8895bc9",
+      leaseId: null,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.authority).toBe("active_tenant");
+    expect(result.propertyId).toBe("mAdeNtAtzAOrxGA4Dx9H");
+    expect(result.leaseId).toBe("HMqzstV4BcZszl9dgPGP");
+    expect(result.unitId).toBe("ufSsrCIiWSOHPCDtUAS5");
+    expect(result.tenantId).toBe("bcea70bf3f353746c8895bc9");
+  });
+
+  it("falls back to exact tenant email match only when the authenticated email matches the existing tenant record", async () => {
+    ensureCollection("tenants").set("tenant-by-email", {
+      tenantId: "tenant-by-email",
+      email: "tenant@example.com",
+      propertyId: "prop-email",
+      unitId: "unit-email",
+      currentLeaseId: "lease-email",
+    });
+    ensureCollection("leases").set("lease-email", {
+      tenantId: "tenant-by-email",
+      propertyId: "prop-email",
+      unitId: "unit-email",
+      status: "active",
+    });
+
+    const { resolveTenancyContext } = await import("../tenantPortal/tenancyContextService");
+    const result = await resolveTenancyContext({
+      uid: "auth-user-1",
+      email: "tenant@example.com",
+      tenantId: null,
+      leaseId: null,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.authority).toBe("active_tenant");
+    expect(result.tenantId).toBe("tenant-by-email");
+    expect(result.leaseId).toBe("lease-email");
+  });
+
+  it("does not grant tenant authority from an arbitrary mismatched email", async () => {
+    ensureCollection("tenants").set("tenant-by-email", {
+      tenantId: "tenant-by-email",
+      email: "tenant@example.com",
+      propertyId: "prop-email",
+      unitId: "unit-email",
+      currentLeaseId: "lease-email",
+    });
+    ensureCollection("leases").set("lease-email", {
+      tenantId: "tenant-by-email",
+      propertyId: "prop-email",
+      unitId: "unit-email",
+      status: "active",
+    });
+
+    const { resolveTenancyContext } = await import("../tenantPortal/tenancyContextService");
+    const result = await resolveTenancyContext({
+      uid: "auth-user-2",
+      email: "other@example.com",
+      tenantId: null,
+      leaseId: null,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("no_authority");
+  });
+
+  it("resolves a tenant record when the tenantId claim matches the tenantId field even if doc id differs", async () => {
+    ensureCollection("tenants").set("doc-1", {
+      tenantId: "tenant-claim-1",
+      email: "tenant-claim@example.com",
+      propertyId: "prop-claim",
+      unitId: "unit-claim",
+      currentLeaseId: "lease-claim",
+    });
+    ensureCollection("leases").set("lease-claim", {
+      tenantId: "tenant-claim-1",
+      propertyId: "prop-claim",
+      unitId: "unit-claim",
+      status: "active",
+    });
+
+    const { resolveTenancyContext } = await import("../tenantPortal/tenancyContextService");
+    const result = await resolveTenancyContext({
+      uid: "tenant-claim-1",
+      email: "tenant-claim@example.com",
+      tenantId: "tenant-claim-1",
+      leaseId: null,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.tenantId).toBe("tenant-claim-1");
+    expect(result.leaseId).toBe("lease-claim");
+  });
+
   it("fails closed when no authority exists", async () => {
     const { resolveTenancyContext } = await import("../tenantPortal/tenancyContextService");
     const result = await resolveTenancyContext({

--- a/rentchain-api/src/services/tenantPortal/tenancyContextService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenancyContextService.ts
@@ -33,6 +33,11 @@ type Candidate = {
   score: number;
 };
 
+type TenantRecordMatch = {
+  id: string;
+  data: any;
+};
+
 const ACTIVE_LEASE_STATUSES = new Set([
   "active",
   "current",
@@ -64,6 +69,47 @@ async function safeGetDocs(collectionName: string, field: string, value: string,
   } catch {
     return [];
   }
+}
+
+async function resolveTenantRecordMatch(identity: TenantWorkspaceIdentity): Promise<TenantRecordMatch | null> {
+  const tenantId = asString(identity.tenantId);
+  const email = normalizeEmail(identity.email);
+
+  if (tenantId) {
+    try {
+      const direct = await db.collection("tenants").doc(tenantId).get();
+      if (direct.exists) {
+        return {
+          id: direct.id,
+          data: (direct.data() || {}) as any,
+        };
+      }
+    } catch {
+      // ignore direct lookup errors
+    }
+
+    const byTenantId = await safeGetDocs("tenants", "tenantId", tenantId);
+    if (byTenantId.length === 1) {
+      return {
+        id: byTenantId[0].id,
+        data: (byTenantId[0].data() || {}) as any,
+      };
+    }
+  }
+
+  if (!email) return null;
+  const byEmail = await safeGetDocs("tenants", "email", email);
+  if (byEmail.length !== 1) return null;
+
+  const match = byEmail[0];
+  const data = (match.data() || {}) as any;
+  const recordEmail = normalizeEmail(data?.email);
+  if (!recordEmail || recordEmail !== email) return null;
+
+  return {
+    id: match.id,
+    data,
+  };
 }
 
 function candidateKey(candidate: Candidate): string {
@@ -115,12 +161,39 @@ export async function resolveTenancyContext(identity: TenantWorkspaceIdentity): 
     candidates.set(candidateKey(candidate), candidate);
   };
 
+  const tenantRecord = await resolveTenantRecordMatch(identity);
+  const tenantRecordId = tenantRecord?.id || tenantId;
+  const tenantRecordData = tenantRecord?.data || null;
+  const tenantRecordLeaseId =
+    asString(tenantRecordData?.leaseId) ||
+    asString(tenantRecordData?.currentLeaseId) ||
+    asString(identity.leaseId);
+  const tenantRecordPropertyId = asString(tenantRecordData?.propertyId);
+  const tenantRecordUnitId =
+    asString(tenantRecordData?.unitId) ||
+    asString(tenantRecordData?.unit) ||
+    null;
+  const tenantRecordEmail = normalizeEmail(tenantRecordData?.email) || email;
+
+  if (tenantRecordPropertyId) {
+    pushCandidate({
+      authority: "active_tenant",
+      propertyId: tenantRecordPropertyId,
+      applicationId: null,
+      leaseId: tenantRecordLeaseId,
+      tenantId: asString(tenantRecordData?.tenantId) || tenantRecordId,
+      unitId: tenantRecordUnitId,
+      invitedEmail: tenantRecordEmail,
+      score: tenantRecordLeaseId ? 95 : 80,
+    });
+  }
+
   const applicationDocs = [
     ...(email ? await safeGetDocs("applications", "applicantEmail", email) : []),
     ...(email ? await safeGetDocs("applications", "email", email) : []),
     ...(uid ? await safeGetDocs("applications", "applicantUserId", uid) : []),
     ...(uid ? await safeGetDocs("applications", "userId", uid) : []),
-    ...(tenantId ? await safeGetDocs("applications", "tenantId", tenantId) : []),
+    ...(tenantRecordId ? await safeGetDocs("applications", "tenantId", tenantRecordId) : []),
   ];
 
   for (const doc of applicationDocs) {
@@ -132,7 +205,7 @@ export async function resolveTenancyContext(identity: TenantWorkspaceIdentity): 
       propertyId,
       applicationId: doc.id,
       leaseId: asString(data?.leaseId),
-      tenantId: asString(data?.tenantId) || tenantId,
+      tenantId: asString(data?.tenantId) || tenantRecordId,
       unitId: asString(data?.unitId) || asString(data?.unitApplied) || asString(data?.unit),
       invitedEmail: email,
       score: 20,
@@ -140,9 +213,9 @@ export async function resolveTenancyContext(identity: TenantWorkspaceIdentity): 
   }
 
   const leaseDocs = [
-    ...(tenantId ? await safeGetDocs("leases", "tenantId", tenantId) : []),
-    ...(tenantId ? await safeGetDocs("leases", "tenantIds", tenantId, "array-contains") : []),
-    ...(asString(identity.leaseId) ? [await db.collection("leases").doc(String(identity.leaseId)).get().catch(() => null as any)] : []),
+    ...(tenantRecordId ? await safeGetDocs("leases", "tenantId", tenantRecordId) : []),
+    ...(tenantRecordId ? await safeGetDocs("leases", "tenantIds", tenantRecordId, "array-contains") : []),
+    ...(tenantRecordLeaseId ? [await db.collection("leases").doc(String(tenantRecordLeaseId)).get().catch(() => null as any)] : []),
   ].filter(Boolean);
 
   for (const doc of leaseDocs as any[]) {
@@ -156,14 +229,14 @@ export async function resolveTenancyContext(identity: TenantWorkspaceIdentity): 
       propertyId,
       applicationId: asString(data?.applicationId),
       leaseId: doc.id,
-      tenantId: asString(data?.tenantId) || tenantId,
+      tenantId: asString(data?.tenantId) || tenantRecordId,
       unitId: asString(data?.unitId) || asString(data?.unitNumber) || asString(data?.unitLabel),
       invitedEmail: email,
       score: 100,
     });
   }
 
-  const tenancyDocs = tenantId ? await safeGetDocs("tenancies", "tenantId", tenantId) : [];
+  const tenancyDocs = tenantRecordId ? await safeGetDocs("tenancies", "tenantId", tenantRecordId) : [];
   for (const doc of tenancyDocs) {
     const data = (doc.data() || {}) as any;
     if (String(data?.status || "").trim().toLowerCase() !== "active") continue;
@@ -174,7 +247,7 @@ export async function resolveTenancyContext(identity: TenantWorkspaceIdentity): 
       propertyId,
       applicationId: null,
       leaseId: asString(data?.leaseId),
-      tenantId,
+      tenantId: tenantRecordId,
       unitId: asString(data?.unitId) || asString(data?.unitLabel),
       invitedEmail: email,
       score: 90,
@@ -212,9 +285,9 @@ export async function resolveTenancyContext(identity: TenantWorkspaceIdentity): 
       rc_prop_id: null,
       applicationId: null,
       leaseId: null,
-      tenantId,
+      tenantId: tenantRecordId,
       unitId: null,
-      invitedEmail: email,
+      invitedEmail: tenantRecordEmail,
       reason: "no_authority",
     };
   }
@@ -228,9 +301,9 @@ export async function resolveTenancyContext(identity: TenantWorkspaceIdentity): 
       rc_prop_id: null,
       applicationId: null,
       leaseId: null,
-      tenantId,
+      tenantId: tenantRecordId,
       unitId: null,
-      invitedEmail: email,
+      invitedEmail: tenantRecordEmail,
       reason: "ambiguous_authority",
     };
   }


### PR DESCRIPTION
This PR fixes tenant workspace resolution for magic-link users with existing tenant records.

## Summary

Tenants were successfully authenticating via magic link but receiving a `TENANT_NOT_INITIALIZED` response due to incomplete workspace context resolution.

This PR updates the tenancy resolver to properly resolve existing tenant records and associated workspace authority.

## Changes

- Resolve tenancy context from `tenants/{tenantId}` directly
- Add fallback resolution:
  - `tenants.tenantId == claimTenantId`
  - exact `tenants.email == authenticatedEmail`
- Treat `currentLeaseId` as a valid lease reference when `leaseId` is null
- Preserve existing resolution paths:
  - applications
  - leases
  - tenancies
  - tenancy invites
- Maintain strict safety checks:
  - no auto-access by email alone
  - only allow email fallback when a tenant record exists and matches exactly

## Verification

- tenancyContextService.test.ts passed
- tenantPortalRoutes.test.ts passed
- 39 backend tests passed in focused run

## Expected Result

Known tenant records (e.g. `bcea70bf3f353746c8895bc9`) now correctly resolve workspace context using:
- landlordId
- propertyId
- unitId
- currentLeaseId

Magic-link login flow should now land tenants directly into their workspace without 403/409 errors.

## Notes

- No route order changes
- No auth provider changes
- No landlord, billing, registry, or screening logic changes