### PR TITLE
feat: add application reminder emails

### DIFF
--- a/rentchain-api/src/routes/__tests__/rentalApplicationsDecisionActions.test.ts
+++ b/rentchain-api/src/routes/__tests__/rentalApplicationsDecisionActions.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 type StoredDoc = { id: string; data: any };
 
-const { dbMock, resetDb, upsertDoc, sendEmailMock, recordRiskDecisionAuditMock } = vi.hoisted(() => {
+const { dbMock, resetDb, upsertDoc, sendEmailMock, buildEmailHtmlMock, buildEmailTextMock, recordRiskDecisionAuditMock } = vi.hoisted(() => {
   const collections = new Map<string, Map<string, StoredDoc>>();
   let autoId = 0;
 
@@ -79,6 +79,8 @@ const { dbMock, resetDb, upsertDoc, sendEmailMock, recordRiskDecisionAuditMock }
       ensureCollection(collectionName).set(id, { id, data });
     },
     sendEmailMock: vi.fn(async () => undefined),
+    buildEmailHtmlMock: vi.fn(() => "<p>email</p>"),
+    buildEmailTextMock: vi.fn(() => "email"),
     recordRiskDecisionAuditMock: vi.fn(async (payload: any) => ({
       id: "audit-1",
       createdAt: "2026-04-01T00:00:00.000Z",
@@ -233,8 +235,8 @@ vi.mock("../../services/riskAgent/riskAgentService", () => ({
 }));
 
 vi.mock("../../email/templates/baseEmailTemplate", () => ({
-  buildEmailHtml: vi.fn(() => "<p>email</p>"),
-  buildEmailText: vi.fn(() => "email"),
+  buildEmailHtml: buildEmailHtmlMock,
+  buildEmailText: buildEmailTextMock,
 }));
 
 vi.mock("../../services/emailService", () => ({
@@ -296,6 +298,10 @@ async function createRouter() {
 describe("rentalApplications decision actions", () => {
   beforeEach(() => {
     resetDb();
+    buildEmailHtmlMock.mockReset();
+    buildEmailHtmlMock.mockReturnValue("<p>email</p>");
+    buildEmailTextMock.mockReset();
+    buildEmailTextMock.mockReturnValue("email");
     process.env.EMAIL_FROM = "noreply@rentchain.test";
     process.env.PUBLIC_APP_URL = "https://www.rentchain.test";
     upsertDoc("rentalApplications", "app-1", {
@@ -406,6 +412,263 @@ describe("rentalApplications decision actions", () => {
         subject: expect.stringMatching(/update/i),
       })
     );
+  });
+
+  it("sends a one-time reminder for an eligible in-progress application link", async () => {
+    upsertDoc("applicationLinks", "link-42", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitId: "unit-9",
+      applicantEmail: "applicant@example.com",
+      applicantName: null,
+      createdAt: 1700000000000,
+      expiresAt: 4102444800000,
+      status: "ACTIVE",
+      tokenHash: "old-hash",
+      partialProgress: {
+        status: "in_progress",
+        completionPercent: 62,
+        currentStep: "employment",
+        completedSections: ["personal_info", "residential_history"],
+        missingSections: ["employment", "references_assets", "consent"],
+        hasCoApplicant: false,
+        viewingChoice: "already_viewed",
+        startedAt: 1700000000000,
+        lastActivityAt: 1700003600000,
+        submittedAt: null,
+        reminderEligibleAt: 1700000000000,
+        reminderSentAt: null,
+      },
+    });
+    upsertDoc("properties", "prop-1", {
+      id: "prop-1",
+      name: "Harbour View",
+    });
+    upsertDoc("units", "unit-9", {
+      id: "unit-9",
+      unitNumber: "9",
+    });
+
+    const router = await createRouter();
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/rental-applications/in-progress/link-42/send-reminder",
+      headers: { authorization: "Bearer landlord" },
+      body: {},
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.ok).toBe(true);
+    expect(sendEmailMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "applicant@example.com",
+        subject: "Finish your rental application",
+      })
+    );
+    expect(buildEmailTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bullets: expect.arrayContaining([
+          "Missing section: Employment",
+          "Missing section: References and assets",
+          "Missing section: Consent",
+        ]),
+      })
+    );
+    expect(buildEmailTextMock).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        intro: expect.stringMatching(/income|dob|address|reference/i),
+      })
+    );
+
+    const stored = await dbMock.collection("applicationLinks").doc("link-42").get();
+    const storedData = stored.data();
+    expect(storedData?.partialProgress?.reminderSentAt).toEqual(expect.any(Number));
+    expect(storedData?.tokenHash).not.toBe("old-hash");
+  });
+
+  it("forbids reminder sends for links not owned by the landlord", async () => {
+    upsertDoc("applicationLinks", "link-42", {
+      landlordId: "other-landlord",
+      propertyId: "prop-1",
+      applicantEmail: "applicant@example.com",
+      expiresAt: 4102444800000,
+      status: "ACTIVE",
+      partialProgress: {
+        status: "in_progress",
+        completionPercent: 62,
+        currentStep: "employment",
+        completedSections: [],
+        missingSections: ["employment"],
+        hasCoApplicant: false,
+        viewingChoice: "already_viewed",
+        startedAt: 1700000000000,
+        lastActivityAt: 1700003600000,
+        submittedAt: null,
+        reminderEligibleAt: 1700000000000,
+        reminderSentAt: null,
+      },
+    });
+
+    const router = await createRouter();
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/rental-applications/in-progress/link-42/send-reminder",
+      headers: { authorization: "Bearer landlord" },
+      body: {},
+    });
+
+    expect(res.status).toBe(403);
+    expect(res.body?.error).toBe("FORBIDDEN");
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks reminders for submitted in-progress links", async () => {
+    upsertDoc("applicationLinks", "link-42", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      applicantEmail: "applicant@example.com",
+      expiresAt: 4102444800000,
+      status: "ACTIVE",
+      partialProgress: {
+        status: "ready_to_submit",
+        completionPercent: 100,
+        currentStep: "consent",
+        completedSections: ["personal_info", "residential_history", "employment", "references_assets", "consent"],
+        missingSections: [],
+        hasCoApplicant: false,
+        viewingChoice: "already_viewed",
+        startedAt: 1700000000000,
+        lastActivityAt: 1700003600000,
+        submittedAt: 1700007200000,
+        reminderEligibleAt: 1700000000000,
+        reminderSentAt: null,
+      },
+    });
+
+    const router = await createRouter();
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/rental-applications/in-progress/link-42/send-reminder",
+      headers: { authorization: "Bearer landlord" },
+      body: {},
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body?.error).toBe("APPLICATION_REMINDER_NOT_ELIGIBLE");
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks duplicate reminders after reminderSentAt is set", async () => {
+    upsertDoc("applicationLinks", "link-42", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      applicantEmail: "applicant@example.com",
+      expiresAt: 4102444800000,
+      status: "ACTIVE",
+      partialProgress: {
+        status: "in_progress",
+        completionPercent: 62,
+        currentStep: "employment",
+        completedSections: [],
+        missingSections: ["employment"],
+        hasCoApplicant: false,
+        viewingChoice: "already_viewed",
+        startedAt: 1700000000000,
+        lastActivityAt: 1700003600000,
+        submittedAt: null,
+        reminderEligibleAt: 1700000000000,
+        reminderSentAt: 1700004000000,
+      },
+    });
+
+    const router = await createRouter();
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/rental-applications/in-progress/link-42/send-reminder",
+      headers: { authorization: "Bearer landlord" },
+      body: {},
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body?.error).toBe("APPLICATION_REMINDER_NOT_ELIGIBLE");
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks reminders when applicantEmail is missing", async () => {
+    upsertDoc("applicationLinks", "link-42", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      applicantEmail: null,
+      expiresAt: 4102444800000,
+      status: "ACTIVE",
+      partialProgress: {
+        status: "in_progress",
+        completionPercent: 62,
+        currentStep: "employment",
+        completedSections: [],
+        missingSections: ["employment"],
+        hasCoApplicant: false,
+        viewingChoice: "already_viewed",
+        startedAt: 1700000000000,
+        lastActivityAt: 1700003600000,
+        submittedAt: null,
+        reminderEligibleAt: 1700000000000,
+        reminderSentAt: null,
+      },
+    });
+
+    const router = await createRouter();
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/rental-applications/in-progress/link-42/send-reminder",
+      headers: { authorization: "Bearer landlord" },
+      body: {},
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body?.error).toBe("APPLICATION_REMINDER_NOT_ELIGIBLE");
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+
+  it("does not mark reminderSentAt when reminder email delivery fails", async () => {
+    sendEmailMock.mockRejectedValueOnce(new Error("mail_failed"));
+    upsertDoc("applicationLinks", "link-42", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      applicantEmail: "applicant@example.com",
+      expiresAt: 4102444800000,
+      status: "ACTIVE",
+      tokenHash: "old-hash",
+      partialProgress: {
+        status: "in_progress",
+        completionPercent: 62,
+        currentStep: "employment",
+        completedSections: [],
+        missingSections: ["employment"],
+        hasCoApplicant: false,
+        viewingChoice: "already_viewed",
+        startedAt: 1700000000000,
+        lastActivityAt: 1700003600000,
+        submittedAt: null,
+        reminderEligibleAt: 1700000000000,
+        reminderSentAt: null,
+      },
+    });
+
+    const router = await createRouter();
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/rental-applications/in-progress/link-42/send-reminder",
+      headers: { authorization: "Bearer landlord" },
+      body: {},
+    });
+
+    expect(res.status).toBe(500);
+    expect(res.body?.error).toBe("APPLICATION_REMINDER_SEND_FAILED");
+    const stored = await dbMock.collection("applicationLinks").doc("link-42").get();
+    const storedData = stored.data();
+    expect(storedData?.partialProgress?.reminderSentAt).toBeNull();
+    expect(storedData?.tokenHash).toBe("old-hash");
   });
 
   it("includes safe in-progress application link summaries in the landlord list", async () => {

--- a/rentchain-api/src/routes/landlordApplicationLinksRoutes.ts
+++ b/rentchain-api/src/routes/landlordApplicationLinksRoutes.ts
@@ -32,7 +32,7 @@ router.post("/", authenticateJwt, async (req: any, res) => {
     const unitId = unitIdRaw === null || unitIdRaw === undefined ? "" : String(unitIdRaw).trim();
     const expiresInDaysRaw = Number(req.body?.expiresInDays ?? 14);
     const applicantEmailRaw = req.body?.applicantEmail;
-    const applicantEmail = typeof applicantEmailRaw === "string" ? applicantEmailRaw.trim() : "";
+    const applicantEmail = typeof applicantEmailRaw === "string" ? applicantEmailRaw.trim().toLowerCase() : "";
 
     if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
 
@@ -79,10 +79,15 @@ router.post("/", authenticateJwt, async (req: any, res) => {
       : 14;
     const expiresAt = now + expiresInDays * 24 * 60 * 60 * 1000;
 
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    const hasValidEmail = !!(applicantEmail && emailRegex.test(applicantEmail));
+
     const ref = await db.collection("applicationLinks").add({
       landlordId,
       propertyId,
       unitId: unitId || null,
+      applicantEmail: hasValidEmail ? applicantEmail : null,
+      applicantName: null,
       createdAt: now,
       expiresAt,
       status: "ACTIVE",
@@ -108,8 +113,6 @@ router.post("/", authenticateJwt, async (req: any, res) => {
 
     let emailed = false;
     let emailError: string | undefined;
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    const hasValidEmail = !!(applicantEmail && emailRegex.test(applicantEmail));
 
     if (applicantEmail && !hasValidEmail) {
       emailError = "INVALID_APPLICANT_EMAIL";

--- a/rentchain-api/src/routes/rentalApplicationsRoutes.ts
+++ b/rentchain-api/src/routes/rentalApplicationsRoutes.ts
@@ -393,6 +393,78 @@ type RentalApplicationListItem = {
   partialProgress: ReturnType<typeof normalizeApplicationLinkPartialProgress> | null;
 };
 
+const APPLICATION_LINK_REMINDER_STATUSES = new Set(["started", "in_progress", "ready_to_submit"]);
+const APPLICATION_LINK_SECTION_LABELS: Record<string, string> = {
+  personal_info: "Personal information",
+  residential_history: "Residential history",
+  employment: "Employment",
+  references_assets: "References and assets",
+  consent: "Consent",
+};
+
+function buildApplicationResumeUrl(token: string) {
+  const baseUrl = (process.env.PUBLIC_APP_URL || "https://www.rentchain.ai").replace(/\/$/, "");
+  return `${baseUrl}/apply/${encodeURIComponent(token)}`;
+}
+
+function summarizeMissingSections(sections: string[]) {
+  return sections
+    .map((section) => APPLICATION_LINK_SECTION_LABELS[section] || section.replace(/_/g, " "))
+    .filter(Boolean);
+}
+
+function getApplicationLinkReminderEligibility(link: any, now: number) {
+  const partialProgress = normalizeApplicationLinkPartialProgress(link?.partialProgress);
+  const expiresAt = typeof link?.expiresAt === "number" ? link.expiresAt : Number(link?.expiresAt || 0) || null;
+  const applicantEmail = String(link?.applicantEmail || "").trim().toLowerCase();
+  const isEligible =
+    String(link?.status || "").trim().toUpperCase() === "ACTIVE" &&
+    (!expiresAt || expiresAt > now) &&
+    APPLICATION_LINK_REMINDER_STATUSES.has(partialProgress.status) &&
+    partialProgress.submittedAt == null &&
+    partialProgress.reminderEligibleAt != null &&
+    partialProgress.reminderEligibleAt <= now &&
+    partialProgress.reminderSentAt == null &&
+    Boolean(applicantEmail);
+
+  return {
+    isEligible,
+    partialProgress,
+    applicantEmail,
+  };
+}
+
+async function resolveApplicationLinkReminderContext(link: any) {
+  let propertyLabel: string | null = null;
+  let unitLabel: string | null = null;
+
+  if (link?.propertyId) {
+    try {
+      const propertySnap = await db.collection("properties").doc(String(link.propertyId)).get();
+      if (propertySnap.exists) {
+        const property = propertySnap.data() as any;
+        propertyLabel = property?.name || property?.addressLine1 || "Property";
+      }
+    } catch {
+      // ignore best-effort lookup failures
+    }
+  }
+
+  if (link?.unitId) {
+    try {
+      const unitSnap = await db.collection("units").doc(String(link.unitId)).get();
+      if (unitSnap.exists) {
+        const unit = unitSnap.data() as any;
+        unitLabel = unit?.unitNumber || unit?.name || unit?.label || null;
+      }
+    } catch {
+      // ignore best-effort lookup failures
+    }
+  }
+
+  return { propertyLabel, unitLabel };
+}
+
 function seededNumber(input: string) {
   const hash = createHash("sha256").update(input).digest("hex");
   return parseInt(hash.slice(0, 8), 16);
@@ -1175,6 +1247,121 @@ router.get("/rental-applications", async (req: any, res) => {
   } catch (err: any) {
     console.error("[rental-applications] list failed", err?.message || err);
     return res.status(500).json({ ok: false, error: "RENTAL_APPLICATIONS_LIST_FAILED" });
+  }
+});
+
+router.post("/rental-applications/in-progress/:id/send-reminder", async (req: any, res) => {
+  try {
+    const role = String(req.user?.role || "").toLowerCase();
+    if (role !== "landlord" && role !== "admin") {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+
+    const landlordId = req.user?.landlordId || req.user?.id || null;
+    if (!landlordId) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+
+    const id = String(req.params?.id || "").trim();
+    if (!id) return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+
+    const linkRef = db.collection("applicationLinks").doc(id);
+    const initialSnap = await linkRef.get();
+    if (!initialSnap.exists) {
+      return res.status(404).json({ ok: false, error: "APPLICATION_LINK_NOT_FOUND" });
+    }
+
+    const initialLink = { id: initialSnap.id, ...(initialSnap.data() as any) };
+    if (String(initialLink?.landlordId || "") !== String(landlordId)) {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+
+    const now = Date.now();
+    const initialEligibility = getApplicationLinkReminderEligibility(initialLink, now);
+    if (!initialEligibility.isEligible) {
+      return res.status(400).json({
+        ok: false,
+        error: "APPLICATION_REMINDER_NOT_ELIGIBLE",
+        message: "This in-progress application is not eligible for a reminder.",
+      });
+    }
+
+    const freshSnap = await linkRef.get();
+    if (!freshSnap.exists) {
+      return res.status(404).json({ ok: false, error: "APPLICATION_LINK_NOT_FOUND" });
+    }
+
+    const link = { id: freshSnap.id, ...(freshSnap.data() as any) };
+    if (String(link?.landlordId || "") !== String(landlordId)) {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+
+    const eligibility = getApplicationLinkReminderEligibility(link, now);
+    if (!eligibility.isEligible) {
+      return res.status(400).json({
+        ok: false,
+        error: "APPLICATION_REMINDER_NOT_ELIGIBLE",
+        message: "This in-progress application is not eligible for a reminder.",
+      });
+    }
+
+    const reminderToken = randomBytes(32).toString("hex");
+    const reminderTokenHash = createHash("sha256").update(reminderToken).digest("hex");
+    const resumeUrl = buildApplicationResumeUrl(reminderToken);
+    const { propertyLabel, unitLabel } = await resolveApplicationLinkReminderContext(link);
+    const completionPercent = eligibility.partialProgress.completionPercent;
+    const missingSections = summarizeMissingSections(eligibility.partialProgress.missingSections);
+    const propertySummary = [propertyLabel, unitLabel ? `Unit ${unitLabel}` : null].filter(Boolean).join(" - ");
+    const introParts = [
+      "You can continue your rental application using the secure link below.",
+      propertySummary ? `Property: ${propertySummary}.` : null,
+      completionPercent > 0 ? `You're ${completionPercent}% complete.` : null,
+    ].filter(Boolean);
+
+    await sendEmail({
+      to: eligibility.applicantEmail,
+      from: process.env.EMAIL_FROM || process.env.FROM_EMAIL,
+      replyTo: process.env.EMAIL_REPLY_TO || process.env.REPLY_TO_EMAIL || process.env.EMAIL_FROM || process.env.FROM_EMAIL,
+      subject: "Finish your rental application",
+      text: buildEmailText({
+        intro: `Hi,\n\n${introParts.join(" ")}`,
+        bullets: missingSections.length ? missingSections.map((section) => `Missing section: ${section}`) : undefined,
+        ctaText: "Continue where you left off",
+        ctaUrl: resumeUrl,
+        footerNote: "This reminder includes only safe progress details and never includes your draft answers.",
+      }),
+      html: buildEmailHtml({
+        title: "Finish your rental application",
+        intro: `Hi, ${introParts.join(" ")}`,
+        bullets: missingSections.length ? missingSections.map((section) => `Missing section: ${section}`) : undefined,
+        ctaText: "Continue where you left off",
+        ctaUrl: resumeUrl,
+        footerNote: "This reminder includes only safe progress details and never includes your draft answers.",
+        preheader: "Resume your rental application with your secure link.",
+      }),
+    });
+
+    const nextPartialProgress = {
+      ...eligibility.partialProgress,
+      reminderSentAt: now,
+    };
+    await linkRef.set(
+      {
+        tokenHash: reminderTokenHash,
+        partialProgress: nextPartialProgress,
+      },
+      { merge: true }
+    );
+
+    return res.json({
+      ok: true,
+      data: {
+        id: link.id,
+        sentAt: now,
+        partialProgress: nextPartialProgress,
+      },
+    });
+  } catch (err: any) {
+    console.error("[rental-applications] send reminder failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "APPLICATION_REMINDER_SEND_FAILED" });
   }
 });
 

--- a/rentchain-frontend/src/api/rentalApplicationsApi.ts
+++ b/rentchain-frontend/src/api/rentalApplicationsApi.ts
@@ -508,6 +508,20 @@ export async function submitRentalApplicationDecisionAction(
   };
 }
 
+export async function sendApplicationLinkReminder(
+  id: string
+): Promise<{ sentAt: number | null; partialProgress: RentalApplicationPartialProgressSummary | null }> {
+  const res: any = await apiFetch(`/rental-applications/in-progress/${encodeURIComponent(id)}/send-reminder`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: {},
+  });
+  return {
+    sentAt: typeof res?.data?.sentAt === "number" ? res.data.sentAt : null,
+    partialProgress: (res?.data?.partialProgress as RentalApplicationPartialProgressSummary) || null,
+  };
+}
+
 export async function fetchScreeningQuote(
   id: string,
   params?: {

--- a/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   fetchProperties: vi.fn(),
   fetchRentalApplications: vi.fn(),
   fetchRentalApplication: vi.fn(),
+  sendApplicationLinkReminder: vi.fn(),
   fetchApplicationDecisionSummary: vi.fn(),
   evaluateApplicationRiskSnapshot: vi.fn(),
   submitRentalApplicationDecisionAction: vi.fn(),
@@ -30,6 +31,7 @@ vi.mock("../api/propertiesApi", () => ({
 vi.mock("@/api/rentalApplicationsApi", () => ({
   fetchRentalApplications: mocks.fetchRentalApplications,
   fetchRentalApplication: mocks.fetchRentalApplication,
+  sendApplicationLinkReminder: mocks.sendApplicationLinkReminder,
   fetchApplicationDecisionSummary: mocks.fetchApplicationDecisionSummary,
   evaluateApplicationRiskSnapshot: mocks.evaluateApplicationRiskSnapshot,
   submitRentalApplicationDecisionAction: mocks.submitRentalApplicationDecisionAction,
@@ -294,6 +296,23 @@ describe("ApplicationsPage", () => {
       landlordNote: null,
     });
     mocks.fetchApplicationDecisionSummary.mockResolvedValue(null);
+    mocks.sendApplicationLinkReminder.mockResolvedValue({
+      sentAt: 1_710_000_100_000,
+      partialProgress: {
+        status: "in_progress",
+        completionPercent: 62,
+        currentStep: "employment",
+        completedSections: ["personal_info", "residential_history"],
+        missingSections: ["employment", "references_assets", "consent"],
+        hasCoApplicant: false,
+        viewingChoice: "already_viewed",
+        startedAt: 1_709_999_000_000,
+        lastActivityAt: 1_710_000_000_000,
+        submittedAt: null,
+        reminderEligibleAt: 1_710_086_400_000,
+        reminderSentAt: 1_710_000_100_000,
+      },
+    });
     mocks.submitRentalApplicationDecisionAction.mockReset();
     mocks.fetchScreeningQuote.mockResolvedValue({ ok: false, detail: "Screening not eligible." });
     mocks.fetchScreeningResult.mockResolvedValue({ ok: false });
@@ -549,5 +568,145 @@ describe("ApplicationsPage", () => {
     fireEvent.click(screen.getByText("In-progress applicant"));
 
     expect(mocks.fetchRentalApplication).not.toHaveBeenCalled();
+  });
+
+  it("shows Send reminder for eligible in-progress rows and updates the row after success", async () => {
+    mocks.fetchRentalApplications.mockResolvedValue([
+      {
+        id: "link-1",
+        source: "application_link",
+        applicantName: "In-progress applicant",
+        email: null,
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        status: "IN_PROGRESS",
+        submittedAt: null,
+        lastActivityAt: 1_710_000_000_000,
+        completionPercent: 62,
+        partialProgress: {
+          status: "in_progress",
+          completionPercent: 62,
+          currentStep: "employment",
+          completedSections: ["personal_info", "residential_history"],
+          missingSections: ["employment", "references_assets", "consent"],
+          hasCoApplicant: false,
+          viewingChoice: "already_viewed",
+          startedAt: 1_709_999_000_000,
+          lastActivityAt: 1_710_000_000_000,
+          submittedAt: null,
+          reminderEligibleAt: 1_710_086_400_000,
+          reminderSentAt: null,
+        },
+      },
+    ]);
+
+    render(
+      <MemoryRouter>
+        <ApplicationsPage />
+      </MemoryRouter>
+    );
+
+    const button = await screen.findByRole("button", { name: "Send reminder" });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(mocks.sendApplicationLinkReminder).toHaveBeenCalledWith("link-1");
+    });
+    expect(mocks.showToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Reminder sent",
+        variant: "success",
+      })
+    );
+    expect(await screen.findByText(/Reminder sent/i)).toBeInTheDocument();
+  });
+
+  it("hides the reminder button once a reminder has already been sent", async () => {
+    mocks.fetchRentalApplications.mockResolvedValue([
+      {
+        id: "link-1",
+        source: "application_link",
+        applicantName: "In-progress applicant",
+        email: null,
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        status: "IN_PROGRESS",
+        submittedAt: null,
+        lastActivityAt: 1_710_000_000_000,
+        completionPercent: 62,
+        partialProgress: {
+          status: "in_progress",
+          completionPercent: 62,
+          currentStep: "employment",
+          completedSections: ["personal_info", "residential_history"],
+          missingSections: ["employment", "references_assets", "consent"],
+          hasCoApplicant: false,
+          viewingChoice: "already_viewed",
+          startedAt: 1_709_999_000_000,
+          lastActivityAt: 1_710_000_000_000,
+          submittedAt: null,
+          reminderEligibleAt: 1_710_086_400_000,
+          reminderSentAt: 1_710_000_100_000,
+        },
+      },
+    ]);
+
+    render(
+      <MemoryRouter>
+        <ApplicationsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Reminder sent/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Send reminder" })).not.toBeInTheDocument();
+  });
+
+  it("shows a safe error toast when sending a reminder fails", async () => {
+    mocks.fetchRentalApplications.mockResolvedValue([
+      {
+        id: "link-1",
+        source: "application_link",
+        applicantName: "In-progress applicant",
+        email: null,
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        status: "IN_PROGRESS",
+        submittedAt: null,
+        lastActivityAt: 1_710_000_000_000,
+        completionPercent: 62,
+        partialProgress: {
+          status: "in_progress",
+          completionPercent: 62,
+          currentStep: "employment",
+          completedSections: ["personal_info", "residential_history"],
+          missingSections: ["employment", "references_assets", "consent"],
+          hasCoApplicant: false,
+          viewingChoice: "already_viewed",
+          startedAt: 1_709_999_000_000,
+          lastActivityAt: 1_710_000_000_000,
+          submittedAt: null,
+          reminderEligibleAt: 1_710_086_400_000,
+          reminderSentAt: null,
+        },
+      },
+    ]);
+    mocks.sendApplicationLinkReminder.mockRejectedValueOnce(new Error("Reminder could not be sent"));
+
+    render(
+      <MemoryRouter>
+        <ApplicationsPage />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Send reminder" }));
+
+    await waitFor(() => {
+      expect(mocks.showToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Reminder could not be sent",
+          variant: "error",
+        })
+      );
+    });
   });
 });

--- a/rentchain-frontend/src/pages/ApplicationsPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.tsx
@@ -9,6 +9,7 @@ import {
   fetchApplicationDecisionSummary,
   evaluateApplicationRiskSnapshot,
   submitRentalApplicationDecisionAction,
+  sendApplicationLinkReminder,
   updateRentalApplicationStatus,
   fetchScreeningQuote,
   createScreeningCheckout,
@@ -364,6 +365,7 @@ const ApplicationsPage: React.FC = () => {
   const [viewingActionLoading, setViewingActionLoading] = useState(false);
   const [viewingError, setViewingError] = useState<string | null>(null);
   const [selectedViewingId, setSelectedViewingId] = useState<string | null>(null);
+  const [sendingReminderId, setSendingReminderId] = useState<string | null>(null);
   const screeningSectionRef = React.useRef<HTMLDivElement | null>(null);
   const uiLocale = getUiLocale();
   const screeningComingSoonText = screeningComingSoonLabel(uiLocale);
@@ -1493,6 +1495,54 @@ const ApplicationsPage: React.FC = () => {
     }
   };
 
+  const canSendPartialReminder = useCallback((application: RentalApplicationSummary) => {
+    if (application.source !== "application_link") return false;
+    const partialProgress = application.partialProgress;
+    if (!partialProgress) return false;
+    if (partialProgress.reminderSentAt) return false;
+    if (partialProgress.submittedAt) return false;
+    if (
+      partialProgress.status !== "started" &&
+      partialProgress.status !== "in_progress" &&
+      partialProgress.status !== "ready_to_submit"
+    ) {
+      return false;
+    }
+    return (
+      typeof partialProgress.reminderEligibleAt === "number" &&
+      partialProgress.reminderEligibleAt <= Date.now()
+    );
+  }, []);
+
+  const handleSendReminder = useCallback(
+    async (application: RentalApplicationSummary) => {
+      if (application.source !== "application_link") return;
+      setSendingReminderId(application.id);
+      try {
+        const res = await sendApplicationLinkReminder(application.id);
+        setApplications((prev) =>
+          prev.map((entry) =>
+            entry.id === application.id
+              ? {
+                  ...entry,
+                  partialProgress: res.partialProgress || entry.partialProgress || null,
+                }
+              : entry
+          )
+        );
+        showToast({ message: "Reminder sent", variant: "success" });
+      } catch (err: any) {
+        showToast({
+          message: err?.message || "Unable to send reminder.",
+          variant: "error",
+        });
+      } finally {
+        setSendingReminderId(null);
+      }
+    },
+    [showToast]
+  );
+
   const runScreeningRequest = async () => {
     if (!detail) return;
     if (!SCREENING_ENABLED) {
@@ -2110,6 +2160,34 @@ const ApplicationsPage: React.FC = () => {
                             <div style={{ color: text.subtle, fontSize: 12 }}>
                               Partial application only. Full application details appear after submission.
                             </div>
+                            {app.partialProgress?.reminderSentAt ? (
+                              <div style={{ color: text.subtle, fontSize: 12 }}>
+                                Reminder sent {new Date(app.partialProgress.reminderSentAt).toLocaleString()}
+                              </div>
+                            ) : canSendPartialReminder(app) ? (
+                              <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                                <button
+                                  type="button"
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    void handleSendReminder(app);
+                                  }}
+                                  style={{
+                                    padding: "6px 10px",
+                                    borderRadius: 999,
+                                    border: `1px solid ${colors.border}`,
+                                    background: colors.accentSoft,
+                                    color: text.primary,
+                                    fontSize: 12,
+                                    fontWeight: 700,
+                                    cursor: sendingReminderId === app.id ? "wait" : "pointer",
+                                  }}
+                                  disabled={sendingReminderId === app.id}
+                                >
+                                  {sendingReminderId === app.id ? "Sending…" : "Send reminder"}
+                                </button>
+                              </div>
+                            ) : null}
                           </>
                         ) : (
                           <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>


### PR DESCRIPTION
This PR adds safe one-time reminder emails for in-progress public rental applications.

## Summary

Adds a manual landlord-triggered reminder action for eligible in-progress application links.

## Changes

- Persist applicantEmail on applicationLinks at invite creation
- Add landlord-owned reminder route
- Add Send reminder action on eligible IN_PROGRESS rows
- Send safe reminder email with resume link
- Mark reminderSentAt only after successful send
- Prevent duplicate reminders
- Exclude sensitive draft/application details from email content

## Verification

- backend focused tests passed
- backend typecheck passed
- ApplicationsPage.test.tsx passed
- npm run test:light passed: 151 files, 566 tests
- npm run build:app passed

## Expected Result

Landlords can manually send one safe reminder to applicants with in-progress applications.

## Notes

Reminder sends generate a fresh resume token and rotate the stored token hash, invalidating the prior resume link. Automated reminder scheduling is deferred to a future mission.