### PR TITLE
feat: automate application reminder emails

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -95,6 +95,7 @@ import accessRoutes from "./routes/accessRoutes";
 import complianceRoutes from "./routes/complianceRoutes";
 import internalReportsRoutes from "./routes/internalReportsRoutes";
 import identityOracleInternalRoutes from "./routes/identityOracleInternalRoutes";
+import applicationReminderInternalRoutes from "./routes/applicationReminderInternalRoutes";
 import statusRoutes from "./routes/statusRoutes";
 import expensesRoutes from "./routes/expensesRoutes";
 import financialTransactionsRoutes from "./routes/financialTransactionsRoutes";
@@ -225,6 +226,7 @@ app.use("/api/access", routeSource("accessRoutes.ts"), accessRoutes);
 app.use("/api/capabilities", routeSource("capabilitiesRoutes.ts"), capabilitiesRoutes);
 app.use("/api/internal", routeSource("internalReportsRoutes.ts"), internalReportsRoutes);
 app.use("/api/internal", routeSource("identityOracleInternalRoutes.ts"), identityOracleInternalRoutes);
+app.use("/api/internal", routeSource("applicationReminderInternalRoutes.ts"), applicationReminderInternalRoutes);
 app.use("/api/status", routeSource("statusRoutes.ts"), statusRoutes);
 
 // Auth decode (non-blocking if header missing)

--- a/rentchain-api/src/routes/__tests__/applicationReminderInternalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/applicationReminderInternalRoutes.test.ts
@@ -1,0 +1,323 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type StoredDoc = { id: string; data: any };
+
+const { dbMock, resetDb, upsertDoc, sendEmailMock } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, StoredDoc>>();
+  let autoId = 0;
+
+  function ensureCollection(name: string) {
+    if (!collections.has(name)) collections.set(name, new Map());
+    return collections.get(name)!;
+  }
+
+  function toDocRef(collectionName: string, docId: string) {
+    const col = ensureCollection(collectionName);
+    return {
+      id: docId,
+      path: `${collectionName}/${docId}`,
+      get: async () => {
+        const entry = col.get(docId);
+        return {
+          id: docId,
+          exists: Boolean(entry),
+          data: () => entry?.data,
+        };
+      },
+      set: async (payload: any, options?: { merge?: boolean }) => {
+        if (options?.merge && col.has(docId)) {
+          const existing = col.get(docId)!;
+          col.set(docId, { id: docId, data: { ...(existing.data || {}), ...(payload || {}) } });
+          return;
+        }
+        col.set(docId, { id: docId, data: payload });
+      },
+    };
+  }
+
+  function buildQuery(collectionName: string, predicates: Array<{ field: string; value: any }> = []) {
+    return {
+      where: (field: string, _op: string, value: any) =>
+        buildQuery(collectionName, [...predicates, { field, value }]),
+      limit: (_count: number) => ({
+        get: async () => {
+          const docs = Array.from(ensureCollection(collectionName).values())
+            .filter((entry) => predicates.every((predicate) => entry.data?.[predicate.field] === predicate.value))
+            .map((entry) => ({
+              id: entry.id,
+              data: () => entry.data,
+            }));
+          return { docs, empty: docs.length === 0 };
+        },
+      }),
+      get: async () => {
+        const docs = Array.from(ensureCollection(collectionName).values())
+          .filter((entry) => predicates.every((predicate) => entry.data?.[predicate.field] === predicate.value))
+          .map((entry) => ({
+            id: entry.id,
+            data: () => entry.data,
+          }));
+        return { docs, empty: docs.length === 0 };
+      },
+    };
+  }
+
+  return {
+    dbMock: {
+      collection: (name: string) => ({
+        doc: (id?: string) => toDocRef(name, id || `auto_${++autoId}`),
+        where: (field: string, op: string, value: any) => buildQuery(name).where(field, op, value),
+      }),
+    },
+    resetDb: () => {
+      collections.clear();
+      autoId = 0;
+      sendEmailMock.mockReset();
+    },
+    upsertDoc: (collectionName: string, id: string, data: any) => {
+      ensureCollection(collectionName).set(id, { id, data });
+    },
+    sendEmailMock: vi.fn(async () => undefined),
+  };
+});
+
+vi.mock("../../config/firebase", () => ({ db: dbMock }));
+
+vi.mock("../../email/templates/baseEmailTemplate", () => ({
+  buildEmailHtml: vi.fn(() => "<p>email</p>"),
+  buildEmailText: vi.fn(() => "email"),
+}));
+
+vi.mock("../../services/emailService", () => ({
+  sendEmail: sendEmailMock,
+}));
+
+async function invokeRouter(params: {
+  method: string;
+  url: string;
+  headers?: Record<string, string>;
+  body?: any;
+}) {
+  const router = (await import("../applicationReminderInternalRoutes")).default;
+  return await new Promise<{ statusCode: number; body: any }>((resolve, reject) => {
+    const req: any = {
+      method: params.method,
+      url: params.url,
+      originalUrl: params.url,
+      path: params.url,
+      headers: params.headers || {},
+      body: params.body ?? {},
+    };
+    const res: any = {
+      statusCode: 200,
+      payload: undefined,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        this.payload = payload;
+        resolve({ statusCode: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        this.payload = payload;
+        resolve({ statusCode: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (err: any) => {
+      if (err) reject(err);
+      else resolve({ statusCode: res.statusCode, body: res.payload });
+    });
+  });
+}
+
+function buildPartialProgress(overrides?: Partial<any>) {
+  return {
+    status: "in_progress",
+    completionPercent: 62,
+    currentStep: "employment",
+    completedSections: ["personal_info", "residential_history"],
+    missingSections: ["employment", "references_assets", "consent"],
+    hasCoApplicant: false,
+    viewingChoice: "already_viewed",
+    startedAt: 1700000000000,
+    lastActivityAt: 1700003600000,
+    submittedAt: null,
+    reminderEligibleAt: 1700000000000,
+    reminderSentAt: null,
+    ...overrides,
+  };
+}
+
+describe("applicationReminderInternalRoutes", () => {
+  beforeEach(() => {
+    resetDb();
+    process.env.INTERNAL_JOB_TOKEN = "secret-token";
+    process.env.EMAIL_FROM = "noreply@rentchain.test";
+    process.env.PUBLIC_APP_URL = "https://www.rentchain.test";
+  });
+
+  it("rejects requests without the internal job token", async () => {
+    const res = await invokeRouter({
+      method: "POST",
+      url: "/application-links/process-reminders",
+      body: {},
+    });
+    expect(res.statusCode).toBe(401);
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+
+  it("processes an eligible link once and marks it sent", async () => {
+    upsertDoc("applicationLinks", "link-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      applicantEmail: "applicant@example.com",
+      expiresAt: 4102444800000,
+      status: "ACTIVE",
+      tokenHash: "old-hash",
+      partialProgress: buildPartialProgress(),
+    });
+    upsertDoc("properties", "prop-1", { name: "Harbour View" });
+    upsertDoc("units", "unit-1", { unitNumber: "1A" });
+
+    const res = await invokeRouter({
+      method: "POST",
+      url: "/application-links/process-reminders",
+      headers: { "x-internal-job-token": "secret-token" },
+      body: {},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body?.ok).toBe(true);
+    expect(res.body?.data).toMatchObject({
+      scanned: 1,
+      eligible: 1,
+      sent: 1,
+      skipped: 0,
+      failed: 0,
+      processedLinkIds: ["link-1"],
+    });
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+    const stored = await dbMock.collection("applicationLinks").doc("link-1").get();
+    expect(stored.data()?.partialProgress?.reminderSentAt).toEqual(expect.any(Number));
+    expect(stored.data()?.tokenHash).not.toBe("old-hash");
+  });
+
+  it("skips submitted, already-sent, and missing-email links", async () => {
+    upsertDoc("applicationLinks", "link-submitted", {
+      landlordId: "landlord-1",
+      applicantEmail: "submitted@example.com",
+      expiresAt: 4102444800000,
+      status: "ACTIVE",
+      partialProgress: buildPartialProgress({ submittedAt: 1700007200000 }),
+    });
+    upsertDoc("applicationLinks", "link-sent", {
+      landlordId: "landlord-1",
+      applicantEmail: "sent@example.com",
+      expiresAt: 4102444800000,
+      status: "ACTIVE",
+      partialProgress: buildPartialProgress({ reminderSentAt: 1700007200000 }),
+    });
+    upsertDoc("applicationLinks", "link-no-email", {
+      landlordId: "landlord-1",
+      applicantEmail: null,
+      expiresAt: 4102444800000,
+      status: "ACTIVE",
+      partialProgress: buildPartialProgress(),
+    });
+
+    const res = await invokeRouter({
+      method: "POST",
+      url: "/application-links/process-reminders",
+      headers: { "x-internal-job-token": "secret-token" },
+      body: {},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body?.data).toMatchObject({
+      scanned: 3,
+      eligible: 0,
+      sent: 0,
+      skipped: 3,
+      failed: 0,
+      processedLinkIds: [],
+    });
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+
+  it("does not mark reminderSentAt when email delivery fails", async () => {
+    sendEmailMock.mockRejectedValueOnce(new Error("mail_failed"));
+    upsertDoc("applicationLinks", "link-1", {
+      landlordId: "landlord-1",
+      applicantEmail: "applicant@example.com",
+      expiresAt: 4102444800000,
+      status: "ACTIVE",
+      tokenHash: "old-hash",
+      partialProgress: buildPartialProgress(),
+    });
+
+    const res = await invokeRouter({
+      method: "POST",
+      url: "/application-links/process-reminders",
+      headers: { "x-internal-job-token": "secret-token" },
+      body: {},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body?.data).toMatchObject({
+      scanned: 1,
+      eligible: 1,
+      sent: 0,
+      skipped: 0,
+      failed: 1,
+      processedLinkIds: ["link-1"],
+    });
+    const stored = await dbMock.collection("applicationLinks").doc("link-1").get();
+    expect(stored.data()?.partialProgress?.reminderSentAt).toBeNull();
+    expect(stored.data()?.tokenHash).toBe("old-hash");
+  });
+
+  it("respects the per-request limit", async () => {
+    upsertDoc("applicationLinks", "link-1", {
+      landlordId: "landlord-1",
+      applicantEmail: "one@example.com",
+      expiresAt: 4102444800000,
+      status: "ACTIVE",
+      partialProgress: buildPartialProgress(),
+    });
+    upsertDoc("applicationLinks", "link-2", {
+      landlordId: "landlord-1",
+      applicantEmail: "two@example.com",
+      expiresAt: 4102444800000,
+      status: "ACTIVE",
+      partialProgress: buildPartialProgress(),
+    });
+    upsertDoc("applicationLinks", "link-3", {
+      landlordId: "landlord-1",
+      applicantEmail: "three@example.com",
+      expiresAt: 4102444800000,
+      status: "ACTIVE",
+      partialProgress: buildPartialProgress(),
+    });
+
+    const res = await invokeRouter({
+      method: "POST",
+      url: "/application-links/process-reminders",
+      headers: { "x-internal-job-token": "secret-token" },
+      body: { limit: 2 },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body?.data).toMatchObject({
+      scanned: 3,
+      eligible: 3,
+      sent: 2,
+      failed: 0,
+      processedLinkIds: ["link-1", "link-2"],
+    });
+    expect(sendEmailMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/rentchain-api/src/routes/applicationReminderInternalRoutes.ts
+++ b/rentchain-api/src/routes/applicationReminderInternalRoutes.ts
@@ -1,0 +1,37 @@
+import { Router } from "express";
+import { processEligibleApplicationLinkReminders } from "../services/applicationReminderService";
+
+const router = Router();
+
+function requireInternalJobToken(req: any, res: any, next: any) {
+  const expected = String(process.env.INTERNAL_JOB_TOKEN || "").trim();
+  const received = String(req.headers["x-internal-job-token"] || "").trim();
+  if (!expected || received !== expected) {
+    return res.status(401).json({ ok: false, error: "unauthorized" });
+  }
+  return next();
+}
+
+router.post("/application-links/process-reminders", requireInternalJobToken, async (req: any, res) => {
+  try {
+    const limit = req.body?.limit;
+    const result = await processEligibleApplicationLinkReminders(limit);
+    console.info(
+      "[application_reminder_process]",
+      JSON.stringify({
+        scanned: result.scanned,
+        eligible: result.eligible,
+        sent: result.sent,
+        skipped: result.skipped,
+        failed: result.failed,
+        processedLinkIds: result.processedLinkIds,
+      })
+    );
+    return res.json({ ok: true, data: result });
+  } catch (err: any) {
+    console.error("[application_reminder_process] failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "application_reminder_process_failed" });
+  }
+});
+
+export default router;

--- a/rentchain-api/src/routes/rentalApplicationsRoutes.ts
+++ b/rentchain-api/src/routes/rentalApplicationsRoutes.ts
@@ -58,6 +58,11 @@ import { executeAutomation } from "../lib/automation/automationExecutor";
 import { buildScreeningPolicyRequest } from "../lib/policy/policyAdapters";
 import { evaluatePolicy, toAutopilotPolicySummary, writePolicyEvaluatedEvent } from "../lib/policy/policyEvaluator";
 import {
+  getApplicationLinkReminderEligibility,
+  normalizeApplicationLinkPartialProgress,
+  sendApplicationLinkReminder,
+} from "../services/applicationReminderService";
+import {
   buildQuoteId,
   buildScreeningMonetizationPatch,
   buildScreeningMonetizationSummary,
@@ -344,41 +349,6 @@ function applicantName(app: any): string {
   return `${first} ${last}`.trim() || "Applicant";
 }
 
-function normalizeApplicationLinkPartialProgress(value: any) {
-  const statusRaw = String(value?.status || "").trim();
-  const currentStepRaw = String(value?.currentStep || "").trim();
-  const viewingChoiceRaw = String(value?.viewingChoice || "").trim();
-  const completionPercentRaw = Number(value?.completionPercent);
-  return {
-    status:
-      statusRaw === "started" ||
-      statusRaw === "in_progress" ||
-      statusRaw === "ready_to_submit" ||
-      statusRaw === "submitted" ||
-      statusRaw === "not_started"
-        ? statusRaw
-        : "not_started",
-    completionPercent: Number.isFinite(completionPercentRaw)
-      ? Math.min(100, Math.max(0, Math.round(completionPercentRaw)))
-      : 0,
-    currentStep: currentStepRaw || null,
-    completedSections: Array.isArray(value?.completedSections)
-      ? value.completedSections.map((entry: any) => String(entry || "").trim()).filter(Boolean)
-      : [],
-    missingSections: Array.isArray(value?.missingSections)
-      ? value.missingSections.map((entry: any) => String(entry || "").trim()).filter(Boolean)
-      : [],
-    hasCoApplicant: value?.hasCoApplicant === true,
-    viewingChoice:
-      viewingChoiceRaw === "already_viewed" || viewingChoiceRaw === "request_viewing" ? viewingChoiceRaw : null,
-    startedAt: typeof value?.startedAt === "number" ? value.startedAt : null,
-    lastActivityAt: typeof value?.lastActivityAt === "number" ? value.lastActivityAt : null,
-    submittedAt: typeof value?.submittedAt === "number" ? value.submittedAt : null,
-    reminderEligibleAt: typeof value?.reminderEligibleAt === "number" ? value.reminderEligibleAt : null,
-    reminderSentAt: typeof value?.reminderSentAt === "number" ? value.reminderSentAt : null,
-  };
-}
-
 type RentalApplicationListItem = {
   id: string;
   source: "rental_application" | "application_link";
@@ -392,78 +362,6 @@ type RentalApplicationListItem = {
   completionPercent: number;
   partialProgress: ReturnType<typeof normalizeApplicationLinkPartialProgress> | null;
 };
-
-const APPLICATION_LINK_REMINDER_STATUSES = new Set(["started", "in_progress", "ready_to_submit"]);
-const APPLICATION_LINK_SECTION_LABELS: Record<string, string> = {
-  personal_info: "Personal information",
-  residential_history: "Residential history",
-  employment: "Employment",
-  references_assets: "References and assets",
-  consent: "Consent",
-};
-
-function buildApplicationResumeUrl(token: string) {
-  const baseUrl = (process.env.PUBLIC_APP_URL || "https://www.rentchain.ai").replace(/\/$/, "");
-  return `${baseUrl}/apply/${encodeURIComponent(token)}`;
-}
-
-function summarizeMissingSections(sections: string[]) {
-  return sections
-    .map((section) => APPLICATION_LINK_SECTION_LABELS[section] || section.replace(/_/g, " "))
-    .filter(Boolean);
-}
-
-function getApplicationLinkReminderEligibility(link: any, now: number) {
-  const partialProgress = normalizeApplicationLinkPartialProgress(link?.partialProgress);
-  const expiresAt = typeof link?.expiresAt === "number" ? link.expiresAt : Number(link?.expiresAt || 0) || null;
-  const applicantEmail = String(link?.applicantEmail || "").trim().toLowerCase();
-  const isEligible =
-    String(link?.status || "").trim().toUpperCase() === "ACTIVE" &&
-    (!expiresAt || expiresAt > now) &&
-    APPLICATION_LINK_REMINDER_STATUSES.has(partialProgress.status) &&
-    partialProgress.submittedAt == null &&
-    partialProgress.reminderEligibleAt != null &&
-    partialProgress.reminderEligibleAt <= now &&
-    partialProgress.reminderSentAt == null &&
-    Boolean(applicantEmail);
-
-  return {
-    isEligible,
-    partialProgress,
-    applicantEmail,
-  };
-}
-
-async function resolveApplicationLinkReminderContext(link: any) {
-  let propertyLabel: string | null = null;
-  let unitLabel: string | null = null;
-
-  if (link?.propertyId) {
-    try {
-      const propertySnap = await db.collection("properties").doc(String(link.propertyId)).get();
-      if (propertySnap.exists) {
-        const property = propertySnap.data() as any;
-        propertyLabel = property?.name || property?.addressLine1 || "Property";
-      }
-    } catch {
-      // ignore best-effort lookup failures
-    }
-  }
-
-  if (link?.unitId) {
-    try {
-      const unitSnap = await db.collection("units").doc(String(link.unitId)).get();
-      if (unitSnap.exists) {
-        const unit = unitSnap.data() as any;
-        unitLabel = unit?.unitNumber || unit?.name || unit?.label || null;
-      }
-    } catch {
-      // ignore best-effort lookup failures
-    }
-  }
-
-  return { propertyLabel, unitLabel };
-}
 
 function seededNumber(input: string) {
   const hash = createHash("sha256").update(input).digest("hex");
@@ -1302,61 +1200,17 @@ router.post("/rental-applications/in-progress/:id/send-reminder", async (req: an
         message: "This in-progress application is not eligible for a reminder.",
       });
     }
-
-    const reminderToken = randomBytes(32).toString("hex");
-    const reminderTokenHash = createHash("sha256").update(reminderToken).digest("hex");
-    const resumeUrl = buildApplicationResumeUrl(reminderToken);
-    const { propertyLabel, unitLabel } = await resolveApplicationLinkReminderContext(link);
-    const completionPercent = eligibility.partialProgress.completionPercent;
-    const missingSections = summarizeMissingSections(eligibility.partialProgress.missingSections);
-    const propertySummary = [propertyLabel, unitLabel ? `Unit ${unitLabel}` : null].filter(Boolean).join(" - ");
-    const introParts = [
-      "You can continue your rental application using the secure link below.",
-      propertySummary ? `Property: ${propertySummary}.` : null,
-      completionPercent > 0 ? `You're ${completionPercent}% complete.` : null,
-    ].filter(Boolean);
-
-    await sendEmail({
-      to: eligibility.applicantEmail,
-      from: process.env.EMAIL_FROM || process.env.FROM_EMAIL,
-      replyTo: process.env.EMAIL_REPLY_TO || process.env.REPLY_TO_EMAIL || process.env.EMAIL_FROM || process.env.FROM_EMAIL,
-      subject: "Finish your rental application",
-      text: buildEmailText({
-        intro: `Hi,\n\n${introParts.join(" ")}`,
-        bullets: missingSections.length ? missingSections.map((section) => `Missing section: ${section}`) : undefined,
-        ctaText: "Continue where you left off",
-        ctaUrl: resumeUrl,
-        footerNote: "This reminder includes only safe progress details and never includes your draft answers.",
-      }),
-      html: buildEmailHtml({
-        title: "Finish your rental application",
-        intro: `Hi, ${introParts.join(" ")}`,
-        bullets: missingSections.length ? missingSections.map((section) => `Missing section: ${section}`) : undefined,
-        ctaText: "Continue where you left off",
-        ctaUrl: resumeUrl,
-        footerNote: "This reminder includes only safe progress details and never includes your draft answers.",
-        preheader: "Resume your rental application with your secure link.",
-      }),
-    });
-
-    const nextPartialProgress = {
-      ...eligibility.partialProgress,
-      reminderSentAt: now,
-    };
-    await linkRef.set(
-      {
-        tokenHash: reminderTokenHash,
-        partialProgress: nextPartialProgress,
-      },
-      { merge: true }
-    );
+    const result = await sendApplicationLinkReminder(link.id, { actorType: "landlord" });
+    if (!result.ok) {
+      return res.status(500).json({ ok: false, error: "APPLICATION_REMINDER_SEND_FAILED" });
+    }
 
     return res.json({
       ok: true,
       data: {
-        id: link.id,
-        sentAt: now,
-        partialProgress: nextPartialProgress,
+        id: result.data.id,
+        sentAt: result.data.sentAt,
+        partialProgress: result.data.partialProgress,
       },
     });
   } catch (err: any) {

--- a/rentchain-api/src/services/applicationReminderService.ts
+++ b/rentchain-api/src/services/applicationReminderService.ts
@@ -1,0 +1,263 @@
+import { createHash, randomBytes } from "crypto";
+import { db } from "../config/firebase";
+import { buildEmailHtml, buildEmailText } from "../email/templates/baseEmailTemplate";
+import { sendEmail } from "./emailService";
+
+const APPLICATION_LINK_REMINDER_STATUSES = new Set(["started", "in_progress", "ready_to_submit"]);
+const APPLICATION_LINK_SECTION_LABELS: Record<string, string> = {
+  personal_info: "Personal information",
+  residential_history: "Residential history",
+  employment: "Employment",
+  references_assets: "References and assets",
+  consent: "Consent",
+};
+
+export type NormalizedApplicationLinkPartialProgress = {
+  status: "not_started" | "started" | "in_progress" | "ready_to_submit" | "submitted";
+  completionPercent: number;
+  currentStep: string | null;
+  completedSections: string[];
+  missingSections: string[];
+  hasCoApplicant: boolean;
+  viewingChoice: "already_viewed" | "request_viewing" | null;
+  startedAt: number | null;
+  lastActivityAt: number | null;
+  submittedAt: number | null;
+  reminderEligibleAt: number | null;
+  reminderSentAt: number | null;
+};
+
+export function normalizeApplicationLinkPartialProgress(value: any): NormalizedApplicationLinkPartialProgress {
+  const statusRaw = String(value?.status || "").trim();
+  const currentStepRaw = String(value?.currentStep || "").trim();
+  const viewingChoiceRaw = String(value?.viewingChoice || "").trim();
+  const completionPercentRaw = Number(value?.completionPercent);
+  return {
+    status:
+      statusRaw === "started" ||
+      statusRaw === "in_progress" ||
+      statusRaw === "ready_to_submit" ||
+      statusRaw === "submitted" ||
+      statusRaw === "not_started"
+        ? statusRaw
+        : "not_started",
+    completionPercent: Number.isFinite(completionPercentRaw)
+      ? Math.min(100, Math.max(0, Math.round(completionPercentRaw)))
+      : 0,
+    currentStep: currentStepRaw || null,
+    completedSections: Array.isArray(value?.completedSections)
+      ? value.completedSections.map((entry: any) => String(entry || "").trim()).filter(Boolean)
+      : [],
+    missingSections: Array.isArray(value?.missingSections)
+      ? value.missingSections.map((entry: any) => String(entry || "").trim()).filter(Boolean)
+      : [],
+    hasCoApplicant: value?.hasCoApplicant === true,
+    viewingChoice:
+      viewingChoiceRaw === "already_viewed" || viewingChoiceRaw === "request_viewing" ? viewingChoiceRaw : null,
+    startedAt: typeof value?.startedAt === "number" ? value.startedAt : null,
+    lastActivityAt: typeof value?.lastActivityAt === "number" ? value.lastActivityAt : null,
+    submittedAt: typeof value?.submittedAt === "number" ? value.submittedAt : null,
+    reminderEligibleAt: typeof value?.reminderEligibleAt === "number" ? value.reminderEligibleAt : null,
+    reminderSentAt: typeof value?.reminderSentAt === "number" ? value.reminderSentAt : null,
+  };
+}
+
+export function buildApplicationResumeUrl(token: string) {
+  const baseUrl = (process.env.PUBLIC_APP_URL || "https://www.rentchain.ai").replace(/\/$/, "");
+  return `${baseUrl}/apply/${encodeURIComponent(token)}`;
+}
+
+function summarizeMissingSections(sections: string[]) {
+  return sections
+    .map((section) => APPLICATION_LINK_SECTION_LABELS[section] || section.replace(/_/g, " "))
+    .filter(Boolean);
+}
+
+export function getApplicationLinkReminderEligibility(link: any, now: number) {
+  const partialProgress = normalizeApplicationLinkPartialProgress(link?.partialProgress);
+  const expiresAt = typeof link?.expiresAt === "number" ? link.expiresAt : Number(link?.expiresAt || 0) || null;
+  const applicantEmail = String(link?.applicantEmail || "").trim().toLowerCase();
+  const isEligible =
+    String(link?.status || "").trim().toUpperCase() === "ACTIVE" &&
+    (!expiresAt || expiresAt > now) &&
+    APPLICATION_LINK_REMINDER_STATUSES.has(partialProgress.status) &&
+    partialProgress.submittedAt == null &&
+    partialProgress.reminderEligibleAt != null &&
+    partialProgress.reminderEligibleAt <= now &&
+    partialProgress.reminderSentAt == null &&
+    Boolean(applicantEmail);
+
+  return {
+    isEligible,
+    partialProgress,
+    applicantEmail,
+  };
+}
+
+async function resolveApplicationLinkReminderContext(link: any) {
+  let propertyLabel: string | null = null;
+  let unitLabel: string | null = null;
+
+  if (link?.propertyId) {
+    try {
+      const propertySnap = await db.collection("properties").doc(String(link.propertyId)).get();
+      if (propertySnap.exists) {
+        const property = propertySnap.data() as any;
+        propertyLabel = property?.name || property?.addressLine1 || "Property";
+      }
+    } catch {
+      // ignore best-effort lookup failures
+    }
+  }
+
+  if (link?.unitId) {
+    try {
+      const unitSnap = await db.collection("units").doc(String(link.unitId)).get();
+      if (unitSnap.exists) {
+        const unit = unitSnap.data() as any;
+        unitLabel = unit?.unitNumber || unit?.name || unit?.label || null;
+      }
+    } catch {
+      // ignore best-effort lookup failures
+    }
+  }
+
+  return { propertyLabel, unitLabel };
+}
+
+export async function sendApplicationLinkReminder(linkId: string, options?: { actorType?: "landlord" | "internal" }) {
+  const now = Date.now();
+  const linkRef = db.collection("applicationLinks").doc(String(linkId).trim());
+  const freshSnap = await linkRef.get();
+  if (!freshSnap.exists) {
+    return { ok: false as const, error: "APPLICATION_LINK_NOT_FOUND" as const };
+  }
+
+  const link = { id: freshSnap.id, ...(freshSnap.data() as any) };
+  const eligibility = getApplicationLinkReminderEligibility(link, now);
+  if (!eligibility.isEligible) {
+    return { ok: false as const, error: "APPLICATION_REMINDER_NOT_ELIGIBLE" as const };
+  }
+
+  const reminderToken = randomBytes(32).toString("hex");
+  const reminderTokenHash = createHash("sha256").update(reminderToken).digest("hex");
+  const resumeUrl = buildApplicationResumeUrl(reminderToken);
+  const { propertyLabel, unitLabel } = await resolveApplicationLinkReminderContext(link);
+  const completionPercent = eligibility.partialProgress.completionPercent;
+  const missingSections = summarizeMissingSections(eligibility.partialProgress.missingSections);
+  const propertySummary = [propertyLabel, unitLabel ? `Unit ${unitLabel}` : null].filter(Boolean).join(" - ");
+  const introParts = [
+    "You can continue your rental application using the secure link below.",
+    propertySummary ? `Property: ${propertySummary}.` : null,
+    completionPercent > 0 ? `You're ${completionPercent}% complete.` : null,
+  ].filter(Boolean);
+
+  await sendEmail({
+    to: eligibility.applicantEmail,
+    from: process.env.EMAIL_FROM || process.env.FROM_EMAIL,
+    replyTo:
+      process.env.EMAIL_REPLY_TO || process.env.REPLY_TO_EMAIL || process.env.EMAIL_FROM || process.env.FROM_EMAIL,
+    subject: "Finish your rental application",
+    text: buildEmailText({
+      intro: `Hi,\n\n${introParts.join(" ")}`,
+      bullets: missingSections.length ? missingSections.map((section) => `Missing section: ${section}`) : undefined,
+      ctaText: "Continue where you left off",
+      ctaUrl: resumeUrl,
+      footerNote: "This reminder includes only safe progress details and never includes your draft answers.",
+    }),
+    html: buildEmailHtml({
+      title: "Finish your rental application",
+      intro: `Hi, ${introParts.join(" ")}`,
+      bullets: missingSections.length ? missingSections.map((section) => `Missing section: ${section}`) : undefined,
+      ctaText: "Continue where you left off",
+      ctaUrl: resumeUrl,
+      footerNote: "This reminder includes only safe progress details and never includes your draft answers.",
+      preheader: "Resume your rental application with your secure link.",
+    }),
+  });
+
+  const nextPartialProgress = {
+    ...eligibility.partialProgress,
+    reminderSentAt: now,
+  };
+  await linkRef.set(
+    {
+      tokenHash: reminderTokenHash,
+      partialProgress: nextPartialProgress,
+    },
+    { merge: true }
+  );
+
+  console.info(
+    "[application_reminder_send]",
+    JSON.stringify({
+      applicationLinkId: link.id,
+      landlordId: String(link?.landlordId || ""),
+      actorType: options?.actorType || "landlord",
+      success: true,
+    })
+  );
+
+  return {
+    ok: true as const,
+    data: {
+      id: link.id,
+      sentAt: now,
+      partialProgress: nextPartialProgress,
+    },
+  };
+}
+
+export async function processEligibleApplicationLinkReminders(limitRaw?: number) {
+  const requestedLimit = Number(limitRaw);
+  const limit = Number.isFinite(requestedLimit)
+    ? Math.min(20, Math.max(1, Math.round(requestedLimit)))
+    : 10;
+  const scanLimit = Math.min(200, Math.max(limit * 5, limit));
+  const now = Date.now();
+
+  const snap = await db.collection("applicationLinks").where("status", "==", "ACTIVE").limit(scanLimit).get();
+  const scannedDocs = snap.docs.map((doc) => ({ id: doc.id, ...(doc.data() as any) }));
+  const eligibleCandidates = scannedDocs.filter((link) => getApplicationLinkReminderEligibility(link, now).isEligible);
+  const candidates = eligibleCandidates.slice(0, limit);
+
+  const processedLinkIds: string[] = [];
+  const skippedLinkIds: string[] = scannedDocs
+    .filter((link) => !getApplicationLinkReminderEligibility(link, now).isEligible)
+    .map((link) => link.id);
+  const failedLinkIds: string[] = [];
+  let sent = 0;
+
+  for (const candidate of candidates) {
+    processedLinkIds.push(candidate.id);
+    try {
+      const result = await sendApplicationLinkReminder(candidate.id, { actorType: "internal" });
+      if (result.ok) {
+        sent += 1;
+      } else {
+        skippedLinkIds.push(candidate.id);
+      }
+    } catch (err: any) {
+      failedLinkIds.push(candidate.id);
+      console.error(
+        "[application_reminder_send]",
+        JSON.stringify({
+          applicationLinkId: candidate.id,
+          landlordId: String(candidate?.landlordId || ""),
+          actorType: "internal",
+          success: false,
+          error: err?.message || String(err),
+        })
+      );
+    }
+  }
+
+  return {
+    scanned: scannedDocs.length,
+    eligible: eligibleCandidates.length,
+    sent,
+    skipped: skippedLinkIds.length,
+    failed: failedLinkIds.length,
+    processedLinkIds,
+  };
+}


### PR DESCRIPTION
This PR adds a backend-only automation entrypoint for application reminder emails.

## Summary

Adds a guarded internal endpoint to process one-time reminder emails for eligible in-progress application links using the existing reminder email flow.

## Changes

- Extracted application reminder sending into a shared backend helper
- Kept the manual landlord reminder route using the shared helper
- Added internal endpoint:
  - POST /api/internal/application-links/process-reminders
- Guarded endpoint with existing x-internal-job-token pattern
- Added bounded processing:
  - default limit 10
  - hard cap 20
- Re-fetches and re-checks each candidate before sending
- Marks reminderSentAt only after successful email send
- Preserves v1 token rotation behavior
- Returns safe summary counts only
- Adds structured safe logging

## Verification

- cd rentchain-api && npx vitest run src/routes/__tests__/applicationReminderInternalRoutes.test.ts src/routes/__tests__/rentalApplicationsDecisionActions.test.ts
- cd rentchain-api && npx tsc -p tsconfig.build.json

All passed.

## Expected Result

Eligible in-progress application links can be processed through a safe internal automation endpoint without landlord page-load side effects, duplicate sends, or sensitive data exposure.

## Notes

No scheduler or recurring campaign was added. A future approved job runner can call this internal endpoint.