### PR TITLE
feat: optimize reminder timing

### DIFF
--- a/rentchain-api/src/routes/__tests__/landlordAnalyticsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordAnalyticsRoutes.test.ts
@@ -585,6 +585,9 @@ describe("landlordAnalyticsRoutes", () => {
     expect(response.body.ok).toBe(true);
     expect(response.body.summary.occupiedUnits).toBe(4);
     expect(response.body.decisions.items[0].decisionType).toBe("reduce_vacancy_risk");
+    expect(response.body.decisions.items[0].reminderTiming).toBe("blocked");
+    expect(response.body.decisions.items[0].reminderTimingLabel).toBe("Blocked");
+    expect(response.body.decisions.items[0].reminderBlockedReason).toBe("automation_disabled");
     expect(response.body.predictive.metrics[0].key).toBe("projected_vacancy_risk");
     expect(response.body.comparisons.deltas.summary.occupiedUnits.direction).toBe("better");
   });

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -467,6 +467,9 @@ describe("tenantPortalRoutes foundation", () => {
     expect(res.body?.data?.sections?.flatMap((section: any) => section.items || [])).not.toEqual(
       expect.arrayContaining([expect.objectContaining({ sin: expect.anything() })])
     );
+    expect(res.body?.data?.reminderTiming).toMatch(/due_now|due_soon|scheduled_later|overdue|blocked|not_applicable/);
+    expect(typeof res.body?.data?.reminderTimingLabel).toBe("string");
+    expect(typeof res.body?.data?.reminderTimingDescription).toBe("string");
     const documentItem = res.body?.data?.sections
       ?.flatMap((section: any) => section.items || [])
       ?.find((item: any) => item.key === "upload_id");
@@ -1111,6 +1114,8 @@ describe("tenantPortalRoutes foundation", () => {
     expect(res.status).toBe(200);
     expect(res.body?.data?.status).toMatch(/not_started|in_progress|pending|needs_review/);
     expect(Array.isArray(res.body?.data?.sections)).toBe(true);
+    expect(res.body?.data?.reminderTiming).toMatch(/due_now|overdue/);
+    expect(res.body?.data?.reminderTimingLabel).toMatch(/Due now|Overdue/);
     const readinessSection = res.body?.data?.sections?.find((section: any) => section.key === "readiness");
     expect(readinessSection).toBeTruthy();
   });

--- a/rentchain-api/src/routes/landlordAnalyticsRoutes.ts
+++ b/rentchain-api/src/routes/landlordAnalyticsRoutes.ts
@@ -47,6 +47,16 @@ function asString(value: unknown, max = 240) {
   return String(value || "").trim().slice(0, max);
 }
 
+type ReminderTiming =
+  | "due_now"
+  | "due_soon"
+  | "scheduled_later"
+  | "overdue"
+  | "blocked"
+  | "not_applicable";
+
+type ReminderPriority = "low" | "medium" | "high";
+
 function resolveFrontendOriginInput(req: any) {
   return (
     req?.headers?.["x-frontend-origin"] ||
@@ -95,6 +105,68 @@ function resolveDecisionBlockedReason(decision: any) {
   }
   if (decision?.automationState === "blocked") return "unknown_state_fail_closed";
   return null;
+}
+
+function deriveDecisionReminderMetadata(decision: any) {
+  const executionState = resolveDecisionExecutionState(decision);
+  const blockedReason = resolveDecisionBlockedReason(decision);
+  const actionLabel = asString(decision?.actionLabel || decision?.recommendedAction, 240) || null;
+
+  if (executionState === "already_executed" || decision?.state === "executed") {
+    return {
+      reminderTiming: "not_applicable" as ReminderTiming,
+      reminderTimingLabel: "No action needed",
+      reminderTimingDescription: "This decision has already been handled and does not need another reminder.",
+      reminderPriority: "low" as ReminderPriority,
+      reminderBlockedReason: null,
+      reminderNextActionLabel: null,
+    };
+  }
+
+  if (decision?.state === "snoozed") {
+    return {
+      reminderTiming: "scheduled_later" as ReminderTiming,
+      reminderTimingLabel: "Scheduled for later",
+      reminderTimingDescription: "This decision is intentionally snoozed for later follow-up.",
+      reminderPriority: "low" as ReminderPriority,
+      reminderBlockedReason: null,
+      reminderNextActionLabel: actionLabel,
+    };
+  }
+
+  if (executionState === "unsafe_duplicate" || executionState === "blocked") {
+    return {
+      reminderTiming: "blocked" as ReminderTiming,
+      reminderTimingLabel: "Blocked",
+      reminderTimingDescription:
+        executionState === "unsafe_duplicate"
+          ? "Another matching action already appears active, so this reminder is safely blocked."
+          : "This decision cannot move forward until its required inputs are ready.",
+      reminderPriority: decision?.priority === "high" ? "high" : "medium",
+      reminderBlockedReason: blockedReason,
+      reminderNextActionLabel: actionLabel,
+    };
+  }
+
+  if (executionState === "executable" && decision?.state === "reviewed") {
+    return {
+      reminderTiming: "due_soon" as ReminderTiming,
+      reminderTimingLabel: "Due soon",
+      reminderTimingDescription: "This decision remains ready and can be revisited soon when you are ready to continue.",
+      reminderPriority: decision?.priority === "high" ? "high" : "medium",
+      reminderBlockedReason: null,
+      reminderNextActionLabel: actionLabel,
+    };
+  }
+
+  return {
+    reminderTiming: "due_now" as ReminderTiming,
+    reminderTimingLabel: "Due now",
+    reminderTimingDescription: "This decision is ready for landlord review or action now.",
+    reminderPriority: decision?.priority === "high" ? "high" : decision?.priority === "low" ? "low" : "medium",
+    reminderBlockedReason: null,
+    reminderNextActionLabel: actionLabel,
+  };
 }
 
 function controlledAutomationAuditMetadata(params: {
@@ -177,7 +249,21 @@ router.get("/landlord/analytics", requireAuth, requireLandlord, async (req: any,
       propertyId: req.query?.propertyId,
     });
 
-    return res.json({ ok: true, ...snapshot });
+    const decisions = Array.isArray(snapshot?.decisions?.items)
+      ? snapshot.decisions.items.map((decision: any) => ({
+          ...decision,
+          ...deriveDecisionReminderMetadata(decision),
+        }))
+      : [];
+
+    return res.json({
+      ok: true,
+      ...snapshot,
+      decisions: {
+        ...(snapshot?.decisions || {}),
+        items: decisions,
+      },
+    });
   } catch (err: any) {
     console.error("[landlord-analytics] fetch failed", err?.message || err);
     return res.status(500).json({ ok: false, error: "LANDLORD_ANALYTICS_FETCH_FAILED" });

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -109,6 +109,16 @@ type CompletionStatus =
   | "not_started"
   | "in_progress";
 
+type ReminderTiming =
+  | "due_now"
+  | "due_soon"
+  | "scheduled_later"
+  | "overdue"
+  | "blocked"
+  | "not_applicable";
+
+type ReminderPriority = "low" | "medium" | "high";
+
 type TenantCompletionItem = {
   key: string;
   label: string;
@@ -123,6 +133,15 @@ type TenantCompletionSection = {
   label: string;
   status: CompletionStatus;
   items: TenantCompletionItem[];
+};
+
+type ReminderMetadata = {
+  reminderTiming: ReminderTiming;
+  reminderTimingLabel: string;
+  reminderTimingDescription: string;
+  reminderPriority: ReminderPriority;
+  reminderBlockedReason: string | null;
+  reminderNextActionLabel: string | null;
 };
 
 type TenantDocumentStatus =
@@ -2759,16 +2778,117 @@ function buildCompletionSections(params: {
       ? "not_started"
       : "in_progress";
 
+  const updatedAt =
+    profile?.identity?.identityVerification?.updatedAt ||
+    profileSummary?.application?.updatedAt ||
+    profileSummary?.lease?.startDate ||
+    null;
+
+  const reminderMetadata = deriveCompletionReminderMetadata({
+    status,
+    progressPercent,
+    actionableItems,
+    updatedAt,
+  });
+
   return {
     status,
     progressPercent,
     sections,
     nextSteps,
-    updatedAt:
-      profile?.identity?.identityVerification?.updatedAt ||
-      profileSummary?.application?.updatedAt ||
-      profileSummary?.lease?.startDate ||
-      null,
+    updatedAt,
+    ...reminderMetadata,
+  };
+}
+
+function deriveCompletionReminderMetadata(params: {
+  status: CompletionStatus;
+  progressPercent: number;
+  actionableItems: TenantCompletionItem[];
+  updatedAt: string | number | null;
+}): ReminderMetadata {
+  const updatedAtMs = toMillis(params.updatedAt);
+  const ageDays =
+    typeof updatedAtMs === "number" && updatedAtMs > 0
+      ? Math.floor((Date.now() - updatedAtMs) / (24 * 60 * 60 * 1000))
+      : null;
+  const primaryAction = params.actionableItems[0] || null;
+  const onlyLeaseReadiness =
+    params.actionableItems.length > 0 && params.actionableItems.every((item) => item.key === "lease_readiness");
+
+  if (params.status === "completed") {
+    return {
+      reminderTiming: "not_applicable",
+      reminderTimingLabel: "No action needed",
+      reminderTimingDescription: "Your current tenant application checklist does not need any tenant action right now.",
+      reminderPriority: "low",
+      reminderBlockedReason: null,
+      reminderNextActionLabel: null,
+    };
+  }
+
+  if (params.status === "needs_review") {
+    return {
+      reminderTiming: "blocked",
+      reminderTimingLabel: "Blocked",
+      reminderTimingDescription: "Your latest updates are waiting on review before the next step can continue.",
+      reminderPriority: "medium",
+      reminderBlockedReason: "waiting_on_review",
+      reminderNextActionLabel: primaryAction?.actionLabel || "Review your checklist",
+    };
+  }
+
+  if (onlyLeaseReadiness) {
+    return {
+      reminderTiming: "scheduled_later",
+      reminderTimingLabel: "Scheduled for later",
+      reminderTimingDescription: "Your application steps look complete for now. Watch for lease updates when your review progresses.",
+      reminderPriority: "low",
+      reminderBlockedReason: null,
+      reminderNextActionLabel: primaryAction?.actionLabel || "Open feed",
+    };
+  }
+
+  if (params.status === "not_started") {
+    return {
+      reminderTiming: "due_now",
+      reminderTimingLabel: "Due now",
+      reminderTimingDescription: "Your application checklist is ready to begin whenever you are ready to continue.",
+      reminderPriority: "high",
+      reminderBlockedReason: null,
+      reminderNextActionLabel: primaryAction?.actionLabel || "Continue application",
+    };
+  }
+
+  if ((ageDays ?? 0) >= 14 && params.actionableItems.length > 0) {
+    return {
+      reminderTiming: "overdue",
+      reminderTimingLabel: "Overdue",
+      reminderTimingDescription: "Some application checklist items have been waiting for attention for a while and may delay the next review step.",
+      reminderPriority: "high",
+      reminderBlockedReason: null,
+      reminderNextActionLabel: primaryAction?.actionLabel || "Continue application",
+    };
+  }
+
+  if (params.progressPercent >= 70 && params.actionableItems.length > 0) {
+    return {
+      reminderTiming: "due_soon",
+      reminderTimingLabel: "Due soon",
+      reminderTimingDescription: "You are close to completing the current checklist. A few remaining items should be reviewed soon.",
+      reminderPriority: "medium",
+      reminderBlockedReason: null,
+      reminderNextActionLabel: primaryAction?.actionLabel || "Review checklist",
+    };
+  }
+
+  return {
+    reminderTiming: "due_now",
+    reminderTimingLabel: "Due now",
+    reminderTimingDescription: "A current checklist step is ready for your attention now.",
+    reminderPriority: params.progressPercent > 0 ? "medium" : "high",
+    reminderBlockedReason: null,
+    reminderNextActionLabel: primaryAction?.actionLabel || "Continue application",
   };
 }
 

--- a/rentchain-frontend/src/api/landlordAnalyticsApi.ts
+++ b/rentchain-frontend/src/api/landlordAnalyticsApi.ts
@@ -63,6 +63,13 @@ export type LandlordDecisionBlockedReason =
   | "automation_disabled"
   | "duplicate_prevented"
   | "unknown_state_fail_closed";
+export type ReminderTiming =
+  | "due_now"
+  | "due_soon"
+  | "scheduled_later"
+  | "overdue"
+  | "blocked"
+  | "not_applicable";
 
 export type LandlordDecisionExecutionSummary = {
   lastExecutedAt: string | null;
@@ -170,6 +177,12 @@ export type LandlordAgentDecision = {
   executionOutcomeStatus: "none" | "succeeded" | "failed";
   executionOutcomeAt: string | null;
   executionOutcomeReason: string | null;
+  reminderTiming?: ReminderTiming;
+  reminderTimingLabel?: string | null;
+  reminderTimingDescription?: string | null;
+  reminderPriority?: "low" | "medium" | "high" | null;
+  reminderBlockedReason?: LandlordDecisionBlockedReason | null | string;
+  reminderNextActionLabel?: string | null;
 };
 
 export type AnalyticsDeltaValue = {

--- a/rentchain-frontend/src/api/tenantApplicationCompletion.ts
+++ b/rentchain-frontend/src/api/tenantApplicationCompletion.ts
@@ -9,6 +9,14 @@ export type TenantApplicationCompletionStatus =
   | "not_started"
   | "in_progress";
 
+export type ReminderTiming =
+  | "due_now"
+  | "due_soon"
+  | "scheduled_later"
+  | "overdue"
+  | "blocked"
+  | "not_applicable";
+
 export type TenantApplicationCompletionItem = {
   key: string;
   label: string;
@@ -31,6 +39,12 @@ export type TenantApplicationCompletionSummary = {
   sections: TenantApplicationCompletionSection[];
   nextSteps: string[];
   updatedAt: string | null;
+  reminderTiming?: ReminderTiming;
+  reminderTimingLabel?: string | null;
+  reminderTimingDescription?: string | null;
+  reminderPriority?: "low" | "medium" | "high" | null;
+  reminderBlockedReason?: string | null;
+  reminderNextActionLabel?: string | null;
 };
 
 export async function getTenantApplicationCompletion(): Promise<TenantApplicationCompletionSummary | null> {

--- a/rentchain-frontend/src/components/analytics/AgentDecisionPanel.test.tsx
+++ b/rentchain-frontend/src/components/analytics/AgentDecisionPanel.test.tsx
@@ -176,6 +176,12 @@ describe("AgentDecisionPanel", () => {
               executionOutcomeStatus: "none",
               executionOutcomeAt: null,
               executionOutcomeReason: null,
+              reminderTiming: "blocked",
+              reminderTimingLabel: "Blocked",
+              reminderTimingDescription: "This decision cannot move forward until its required inputs are ready.",
+              reminderPriority: "medium",
+              reminderBlockedReason: "automation_disabled",
+              reminderNextActionLabel: "Open vacancy readiness",
               href: "/analytics?propertyId=prop-2",
               state: "pending",
               reviewedAt: null,
@@ -194,7 +200,8 @@ describe("AgentDecisionPanel", () => {
     expect(screen.getByText(/Vacancy pressure is concentrated in Beta/i)).toBeInTheDocument();
     expect(screen.getByText(/high priority/i)).toBeInTheDocument();
     expect(screen.getByText(/Workflow: Vacancy readiness/i)).toBeInTheDocument();
-    expect(screen.getByText(/Action required/i)).toBeInTheDocument();
+    expect(screen.getByText(/^Blocked$/i)).toBeInTheDocument();
+    expect(screen.getByText(/cannot move forward until its required inputs are ready/i)).toBeInTheDocument();
     expect(screen.getByText(/Execution controls/i)).toBeInTheDocument();
     expect(screen.getAllByText(/Automation preview/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Human confirmation required/i).length).toBeGreaterThan(0);

--- a/rentchain-frontend/src/components/analytics/AgentDecisionPanel.tsx
+++ b/rentchain-frontend/src/components/analytics/AgentDecisionPanel.tsx
@@ -72,6 +72,15 @@ const executionOutcomeTone: Record<
   },
 };
 
+const reminderTone = {
+  due_now: { bg: "rgba(245, 158, 11, 0.14)", text: "#92400e" },
+  due_soon: { bg: "rgba(59, 130, 246, 0.14)", text: "#1d4ed8" },
+  scheduled_later: { bg: "rgba(148, 163, 184, 0.16)", text: "#475569" },
+  overdue: { bg: "rgba(239, 68, 68, 0.12)", text: "#991b1b" },
+  blocked: { bg: "rgba(251, 191, 36, 0.18)", text: "#92400e" },
+  not_applicable: { bg: "#eef2f7", text: "#475569" },
+} as const;
+
 type Props = {
   decisions: LandlordAgentDecision[];
   title?: string;
@@ -278,6 +287,21 @@ function ActionDecisionCard(props: {
         </div>
       ) : null}
       <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+        {decision.reminderTiming && decision.reminderTimingLabel ? (
+          <div
+            style={{
+              justifySelf: "start",
+              padding: "4px 9px",
+              borderRadius: 999,
+              background: reminderTone[decision.reminderTiming].bg,
+              color: reminderTone[decision.reminderTiming].text,
+              fontWeight: 700,
+              fontSize: "0.78rem",
+            }}
+          >
+            {decision.reminderTimingLabel}
+          </div>
+        ) : null}
         {decision.automationState !== "manual_only" ? (
           <div
             style={{
@@ -295,6 +319,9 @@ function ActionDecisionCard(props: {
         ) : null}
       </div>
       {support ? <div style={{ color: "#64748b", fontSize: "0.88rem" }}>{support}</div> : null}
+      {decision.reminderTimingDescription ? (
+        <div style={{ color: "#64748b", fontSize: "0.84rem" }}>{decision.reminderTimingDescription}</div>
+      ) : null}
       {decision.automationState !== "manual_only" && decision.automationReason ? (
         <div style={{ color: "#64748b", fontSize: "0.84rem" }}>{decision.automationReason}</div>
       ) : null}

--- a/rentchain-frontend/src/pages/StructuredNotificationList.tsx
+++ b/rentchain-frontend/src/pages/StructuredNotificationList.tsx
@@ -3,6 +3,23 @@ import { Link } from "react-router-dom";
 import { text } from "../styles/tokens";
 import type { StructuredNotificationItem } from "./structuredNotificationTriggers";
 
+function timingTone(timing: StructuredNotificationItem["reminderTiming"]) {
+  switch (timing) {
+    case "due_now":
+      return { color: "#9a3412", background: "#ffedd5" };
+    case "due_soon":
+      return { color: "#1d4ed8", background: "#dbeafe" };
+    case "scheduled_later":
+      return { color: "#475569", background: "#e2e8f0" };
+    case "overdue":
+      return { color: "#991b1b", background: "#fee2e2" };
+    case "blocked":
+      return { color: "#92400e", background: "#fef3c7" };
+    default:
+      return { color: "#475569", background: "#f1f5f9" };
+  }
+}
+
 export default function StructuredNotificationList(props: {
   heading: string;
   emptyLabel: string;
@@ -14,6 +31,15 @@ export default function StructuredNotificationList(props: {
       <div style={{ fontWeight: 700, color: text.main }}>{props.heading}</div>
       {props.items.length ? (
         props.items.map((item) => (
+          (() => {
+            const resolvedTiming = item.reminderTiming || (item.actionRequired ? "due_now" : "not_applicable");
+            const resolvedLabel = item.reminderTimingLabel || (item.actionRequired ? "Due now" : "No action needed");
+            const resolvedDescription =
+              item.reminderTimingDescription ||
+              (item.actionRequired
+                ? "This update is ready for your attention now."
+                : "This update is informational and does not need any action right now.");
+            return (
           <div
             key={item.id}
             style={{
@@ -22,6 +48,7 @@ export default function StructuredNotificationList(props: {
               padding: "12px 14px",
               display: "grid",
               gap: 8,
+              opacity: resolvedTiming === "not_applicable" ? 0.82 : 1,
             }}
           >
             <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, flexWrap: "wrap" }}>
@@ -32,14 +59,14 @@ export default function StructuredNotificationList(props: {
                   borderRadius: 999,
                   fontSize: 12,
                   fontWeight: 700,
-                  color: item.actionRequired ? "#9a3412" : "#1d4ed8",
-                  background: item.actionRequired ? "#ffedd5" : "#dbeafe",
+                  ...timingTone(resolvedTiming),
                 }}
               >
-                {item.actionRequired ? "Action required" : "Updated"}
+                {resolvedLabel}
               </div>
             </div>
             <div style={{ color: text.subtle }}>{item.description}</div>
+            <div style={{ color: text.subtle, fontSize: 13 }}>{resolvedDescription}</div>
             {item.targetLink ? (
               <div>
                 <Link to={item.targetLink} style={{ fontWeight: 700 }}>
@@ -48,6 +75,8 @@ export default function StructuredNotificationList(props: {
               </div>
             ) : null}
           </div>
+            );
+          })()
         ))
       ) : (
         <div style={{ color: text.subtle }}>{props.emptyLabel}</div>

--- a/rentchain-frontend/src/pages/structuredNotificationTriggers.ts
+++ b/rentchain-frontend/src/pages/structuredNotificationTriggers.ts
@@ -22,7 +22,48 @@ export type StructuredNotificationItem = {
   timestamp: number;
   actionRequired: boolean;
   targetLink: string | null;
+  reminderTiming?: "due_now" | "due_soon" | "scheduled_later" | "overdue" | "blocked" | "not_applicable";
+  reminderTimingLabel?: string;
+  reminderTimingDescription?: string;
 };
+
+function deriveStructuredNotificationTiming(input: {
+  type: StructuredNotificationTriggerType;
+  timestamp: number;
+}): Pick<StructuredNotificationItem, "reminderTiming" | "reminderTimingLabel" | "reminderTimingDescription"> {
+  const ageDays = Math.floor((Date.now() - input.timestamp) / (24 * 60 * 60 * 1000));
+  switch (input.type) {
+    case "follow_up_requested":
+      if (ageDays >= 14) {
+        return {
+          reminderTiming: "overdue",
+          reminderTimingLabel: "Overdue",
+          reminderTimingDescription: "This follow-up has been waiting for attention for a while and may delay the next review step.",
+        };
+      }
+      return {
+        reminderTiming: "due_now",
+        reminderTimingLabel: "Due now",
+        reminderTimingDescription: "This follow-up is ready for attention now.",
+      };
+    case "ready_for_rereview":
+      return {
+        reminderTiming: "due_soon",
+        reminderTimingLabel: "Due soon",
+        reminderTimingDescription: "Your updates look ready for the next review step soon.",
+      };
+    case "follow_up_addressed":
+    case "readiness_improved":
+    case "documents_updated":
+    case "access_changed":
+    default:
+      return {
+        reminderTiming: "not_applicable",
+        reminderTimingLabel: "No action needed",
+        reminderTimingDescription: "This update is informational and does not need any action right now.",
+      };
+  }
+}
 
 const CATEGORY_TARGETS: Record<SharePackageCategoryKey, string> = {
   profile_details: "/tenant/profile",
@@ -60,12 +101,32 @@ function pushItem(
   items.push({
     ...item,
     timestamp,
+    ...deriveStructuredNotificationTiming({
+      type: item.type,
+      timestamp,
+    }),
   });
 }
 
 function compareNotifications(left: StructuredNotificationItem, right: StructuredNotificationItem): number {
-  if (left.actionRequired !== right.actionRequired) {
-    return left.actionRequired ? -1 : 1;
+  const rank = (value: StructuredNotificationItem["reminderTiming"]) => {
+    switch (value) {
+      case "due_now":
+        return 0;
+      case "overdue":
+        return 1;
+      case "due_soon":
+        return 2;
+      case "blocked":
+        return 3;
+      case "scheduled_later":
+        return 4;
+      default:
+        return 5;
+    }
+  };
+  if (rank(left.reminderTiming) !== rank(right.reminderTiming)) {
+    return rank(left.reminderTiming) - rank(right.reminderTiming);
   }
   return right.timestamp - left.timestamp;
 }

--- a/rentchain-frontend/src/pages/tenant/TenantApplicationStatusPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantApplicationStatusPage.tsx
@@ -65,6 +65,25 @@ function sectionSummary(status: TenantApplicationCompletionStatus) {
   return "You’ve started this section, but it still needs a few more updates.";
 }
 
+function reminderTimingTone(
+  timing?: "due_now" | "due_soon" | "scheduled_later" | "overdue" | "blocked" | "not_applicable" | null
+) {
+  switch (timing) {
+    case "due_now":
+      return { color: "#92400e", background: "rgba(245,158,11,0.14)" };
+    case "due_soon":
+      return { color: "#1d4ed8", background: "rgba(59,130,246,0.14)" };
+    case "scheduled_later":
+      return { color: "#475569", background: "rgba(148,163,184,0.16)" };
+    case "overdue":
+      return { color: "#991b1b", background: "rgba(239,68,68,0.12)" };
+    case "blocked":
+      return { color: "#92400e", background: "rgba(251,191,36,0.18)" };
+    default:
+      return { color: "#475569", background: "#eef2f7" };
+  }
+}
+
 const CompletionProgressCard: React.FC<{ progressPercent: number; status: TenantApplicationCompletionStatus }> = ({
   progressPercent,
   status,
@@ -1433,6 +1452,23 @@ export default function TenantApplicationStatusPage() {
       {data.nextSteps.length ? (
         <TenantInfoCard heading="Next Steps" accent="#0891b2">
           <div style={{ display: "grid", gap: 8 }}>
+            {data.reminderTimingLabel ? (
+              <div
+                style={{
+                  justifySelf: "start",
+                  padding: "6px 10px",
+                  borderRadius: 999,
+                  fontWeight: 700,
+                  fontSize: 12,
+                  ...reminderTimingTone(data.reminderTiming),
+                }}
+              >
+                {data.reminderTimingLabel}
+              </div>
+            ) : null}
+            {data.reminderTimingDescription ? (
+              <div style={{ color: textTokens.secondary }}>{data.reminderTimingDescription}</div>
+            ) : null}
             {data.nextSteps.map((step) => (
               <div key={step} style={{ color: textTokens.secondary }}>
                 {step}
@@ -1442,6 +1478,23 @@ export default function TenantApplicationStatusPage() {
         </TenantInfoCard>
       ) : (
         <TenantInfoCard heading="Next Steps" accent="#0891b2">
+          {data.reminderTimingLabel ? (
+            <div
+              style={{
+                justifySelf: "start",
+                padding: "6px 10px",
+                borderRadius: 999,
+                fontWeight: 700,
+                fontSize: 12,
+                ...reminderTimingTone(data.reminderTiming),
+              }}
+            >
+              {data.reminderTimingLabel}
+            </div>
+          ) : null}
+          {data.reminderTimingDescription ? (
+            <div style={{ color: textTokens.secondary }}>{data.reminderTimingDescription}</div>
+          ) : null}
           <div style={{ color: textTokens.muted }}>
             No extra actions are required right now. Keep an eye on your feed for updates.
           </div>

--- a/rentchain-frontend/src/pages/tenant/TenantScreeningInboxPage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantScreeningInboxPage.test.tsx
@@ -100,6 +100,8 @@ describe("TenantScreeningInboxPage", () => {
     expect(screen.getByText(/Requested for 123 Main St - Unit 4/i)).toBeInTheDocument();
     expect(screen.getByText(hasExactText("Requested by Harbour Homes Ltd."))).toBeInTheDocument();
     expect(screen.getAllByText(/Consent required/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Overdue/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/waiting for consent for a while/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Authorize screening/i })).toBeDisabled();
   });
 
@@ -125,6 +127,7 @@ describe("TenantScreeningInboxPage", () => {
 
     expect(await screen.findByText(/^Screening cannot proceed yet$/i)).toBeInTheDocument();
     expect(screen.getByText(/landlord may still need to complete screening setup/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Blocked/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/^Wait for landlord$/i)).toBeInTheDocument();
   });
 

--- a/rentchain-frontend/src/pages/tenant/TenantScreeningInboxPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantScreeningInboxPage.tsx
@@ -34,6 +34,23 @@ function badgeColors(status: ReturnType<typeof buildTenantScreeningInboxItemView
   }
 }
 
+function timingBadgeColors(timing: ReturnType<typeof buildTenantScreeningInboxItemView>["reminderTiming"]) {
+  switch (timing) {
+    case "due_now":
+      return { background: "rgba(245,158,11,0.14)", color: "#92400e" };
+    case "due_soon":
+      return { background: "rgba(59,130,246,0.14)", color: "#1d4ed8" };
+    case "scheduled_later":
+      return { background: "rgba(148,163,184,0.16)", color: "#475569" };
+    case "overdue":
+      return { background: "rgba(239,68,68,0.12)", color: "#991b1b" };
+    case "blocked":
+      return { background: "rgba(251,191,36,0.18)", color: "#92400e" };
+    default:
+      return { background: "rgba(226,232,240,0.8)", color: "#475569" };
+  }
+}
+
 export default function TenantScreeningInboxPage() {
   const [items, setItems] = React.useState<TenantScreeningRequest[]>([]);
   const [loading, setLoading] = React.useState(true);
@@ -136,6 +153,7 @@ export default function TenantScreeningInboxPage() {
         {items.map((item) => {
           const view = buildTenantScreeningInboxItemView(item);
           const badge = badgeColors(view.status);
+          const timingBadge = timingBadgeColors(view.reminderTiming);
           const showConsentCard = view.nextAction === "authorize_screening" || view.status === "consent_confirmed";
           return (
             <TenantInfoCard key={item.id} heading={view.propertyContext} accent={badge.color}>
@@ -149,18 +167,33 @@ export default function TenantScreeningInboxPage() {
                   </div>
                   <div style={{ color: textTokens.secondary }}>{view.description}</div>
                 </div>
-                <div
-                  style={{
-                    alignSelf: "start",
-                    padding: "6px 10px",
-                    borderRadius: 999,
-                    background: badge.background,
-                    color: badge.color,
-                    fontWeight: 700,
-                    fontSize: "0.85rem",
-                  }}
-                >
-                  {view.statusLabel}
+                <div style={{ display: "grid", gap: 8, justifyItems: "end" }}>
+                  <div
+                    style={{
+                      alignSelf: "start",
+                      padding: "6px 10px",
+                      borderRadius: 999,
+                      background: badge.background,
+                      color: badge.color,
+                      fontWeight: 700,
+                      fontSize: "0.85rem",
+                    }}
+                  >
+                    {view.statusLabel}
+                  </div>
+                  <div
+                    style={{
+                      alignSelf: "start",
+                      padding: "6px 10px",
+                      borderRadius: 999,
+                      background: timingBadge.background,
+                      color: timingBadge.color,
+                      fontWeight: 700,
+                      fontSize: "0.8rem",
+                    }}
+                  >
+                    {view.reminderTimingLabel}
+                  </div>
                 </div>
               </div>
 
@@ -168,6 +201,7 @@ export default function TenantScreeningInboxPage() {
                 rows={[
                   { label: "Consent", value: view.consentLabel },
                   { label: "Provider", value: view.providerLabel },
+                  { label: "Timing", value: view.reminderTimingLabel },
                   { label: "Requested", value: formatDate(view.requestedAt) },
                   { label: "Last update", value: formatDate(view.activityAt) },
                 ]}
@@ -187,6 +221,7 @@ export default function TenantScreeningInboxPage() {
                 <div style={{ color: textTokens.secondary }}>
                   {view.nextActionLabel}
                 </div>
+                <div style={{ color: textTokens.muted }}>{view.reminderTimingDescription}</div>
                 {view.consentedAt && !showConsentCard ? (
                   <div style={{ color: textTokens.muted }}>
                     Consent confirmed on {formatDate(view.consentedAt)}.

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -107,6 +107,9 @@ describe("tenant workspace frontend shell", () => {
       sections: [],
       nextSteps: ["Upload government id"],
       updatedAt: "2026-01-02T00:00:00.000Z",
+      reminderTiming: "due_now",
+      reminderTimingLabel: "Due now",
+      reminderTimingDescription: "A current checklist step is ready for your attention now.",
     });
     tenantScreeningApi.listTenantScreenings.mockResolvedValue({
       ok: true,
@@ -388,6 +391,7 @@ describe("tenant workspace frontend shell", () => {
     expect(screen.getAllByText(/1 active access grant/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/1 document in your vault, 1 ready to share, and 0 still needing attention/i)).toBeInTheDocument();
     expect(screen.getByText(/Documents updated/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/No action needed/i).length).toBeGreaterThan(0);
     expect(screen.getByRole("link", { name: /Open document vault/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Open access/i })).toBeInTheDocument();
   });
@@ -520,6 +524,9 @@ describe("tenant workspace frontend shell", () => {
       ],
       nextSteps: ["Upload government id"],
       updatedAt: "2026-01-02T00:00:00.000Z",
+      reminderTiming: "due_now",
+      reminderTimingLabel: "Due now",
+      reminderTimingDescription: "A current checklist step is ready for your attention now.",
     });
 
     render(
@@ -532,6 +539,8 @@ describe("tenant workspace frontend shell", () => {
     expect(screen.getByText(/Your application is in progress/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Continue your application/i })).toBeInTheDocument();
     expect(screen.getAllByText(/62%/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/^Due now$/i)).toBeInTheDocument();
+    expect(screen.getByText(/ready for your attention now/i)).toBeInTheDocument();
     expect(screen.getAllByText(/Upload government id/i).length).toBeGreaterThan(0);
   });
 

--- a/rentchain-frontend/src/pages/tenant/tenantScreeningInboxView.ts
+++ b/rentchain-frontend/src/pages/tenant/tenantScreeningInboxView.ts
@@ -22,7 +22,60 @@ export type TenantScreeningInboxItemView = {
   activityAt: number | null;
   consentedAt: number | null;
   consentLabel: string;
+  reminderTiming: "due_now" | "due_soon" | "scheduled_later" | "overdue" | "blocked" | "not_applicable";
+  reminderTimingLabel: string;
+  reminderTimingDescription: string;
 };
+
+function deriveScreeningReminderTiming(item: TenantScreeningRequest, status: TenantScreeningInboxStatus) {
+  const requestedAt = item.requestedAt || null;
+  const ageDays =
+    typeof requestedAt === "number" && requestedAt > 0
+      ? Math.floor((Date.now() - requestedAt) / (24 * 60 * 60 * 1000))
+      : null;
+
+  switch (status) {
+    case "consent_required":
+      if ((ageDays ?? 0) >= 7) {
+        return {
+          reminderTiming: "overdue" as const,
+          reminderTimingLabel: "Overdue",
+          reminderTimingDescription: "This screening request has been waiting for consent for a while and may hold up the next review step.",
+        };
+      }
+      return {
+        reminderTiming: "due_now" as const,
+        reminderTimingLabel: "Due now",
+        reminderTimingDescription: "Your consent can be completed now so screening can move forward.",
+      };
+    case "blocked":
+      return {
+        reminderTiming: "blocked" as const,
+        reminderTimingLabel: "Blocked",
+        reminderTimingDescription: "This screening step is waiting on another requirement before it can proceed.",
+      };
+    case "consent_confirmed":
+      return {
+        reminderTiming: "due_soon" as const,
+        reminderTimingLabel: "Due soon",
+        reminderTimingDescription: "Your consent is recorded. Keep this request in view while the next screening step is prepared.",
+      };
+    case "screening_in_progress":
+    case "manual_review":
+      return {
+        reminderTiming: "scheduled_later" as const,
+        reminderTimingLabel: "Scheduled for later",
+        reminderTimingDescription: "This screening request is in motion and does not need any immediate tenant action.",
+      };
+    case "completed":
+    default:
+      return {
+        reminderTiming: "not_applicable" as const,
+        reminderTimingLabel: "No action needed",
+        reminderTimingDescription: "This screening request does not need anything else from you right now.",
+      };
+  }
+}
 
 function resolveProviderLabel(item: TenantScreeningRequest) {
   if (item.consent?.providerLabel) return item.consent.providerLabel;
@@ -150,6 +203,7 @@ function latestActivityAt(item: TenantScreeningRequest) {
 export function buildTenantScreeningInboxItemView(item: TenantScreeningRequest): TenantScreeningInboxItemView {
   const status = normalizeTenantScreeningStatus(item);
   const resolvedNextAction = item.tenantNextAction || nextAction(status);
+  const timing = deriveScreeningReminderTiming(item, status);
   return {
     id: item.id,
     status,
@@ -165,6 +219,7 @@ export function buildTenantScreeningInboxItemView(item: TenantScreeningRequest):
     activityAt: latestActivityAt(item),
     consentedAt: item.consent?.acceptedAt || item.consentedAt || null,
     consentLabel: consentLabel(item, status),
+    ...timing,
   };
 }
 


### PR DESCRIPTION
This PR adds deterministic Reminder Timing Optimization v2.

Includes:
- backend-owned reminder timing metadata for tenant application completion/readiness and landlord analytics decisions
- calm timing labels/descriptions across supported tenant and landlord surfaces
- frontend-only timing adapters limited to structured notifications and tenant screening inbox
- application reuse alignment that suppresses stale/completed prompts
- focused backend/frontend test coverage

Guardrails preserved:
- no background scheduler
- no autonomous sending
- no provider changes
- no billing/entitlement changes
- no privacy boundary changes
- no global reminder subsystem