### PR TITLE
feat: integrate lease PDF signatures

### DIFF
--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -140,6 +140,12 @@ describe("leaseRoutes GET /active", () => {
       startDate: "2026-01-01",
       endDate: "2026-12-31",
       status: "active",
+      tenantSignature: {
+        signedAt: "2026-01-05T12:00:00.000Z",
+        signatureMethod: "typed",
+        signatureDisplayName: "Jane Tenant",
+        drawnDataUrl: "data:image/png;base64,should-not-leak",
+      },
       sourceDraftId: "draft-1",
       createdAt: 1,
       updatedAt: 2,
@@ -168,8 +174,17 @@ describe("leaseRoutes GET /active", () => {
         tenantName: "Jane Tenant",
         tenantEmail: "jane@example.com",
         documentUrl: "https://files.example.com/lease.pdf",
+        signatureStatus: "signed",
+        signatureReadinessLabel: "Lease signing complete",
+        tenantSignature: {
+          signedAt: "2026-01-05T12:00:00.000Z",
+          signatureMethod: "typed",
+          signatureDisplayName: "Jane Tenant",
+        },
+        leasePdfStatus: "available",
       })
     );
+    expect(res.body?.leases?.[0]?.tenantSignature?.drawnDataUrl).toBeUndefined();
   });
 
   it("excludes targeted synthetic cleanup leases from landlord active lists", async () => {

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -190,6 +190,12 @@ describe("tenantPortalRoutes foundation", () => {
       endDate: "2027-01-31",
       monthlyRent: 1800,
       documentUrl: "https://example.com/lease.pdf",
+      tenantSignature: {
+        signedAt: "2026-02-01T10:00:00.000Z",
+        signatureMethod: "drawn",
+        signatureDisplayName: "Taylor Tenant",
+        drawnDataUrl: "data:image/png;base64,should-not-leak",
+      },
       confidentialNotes: "private",
     });
     ensureCollection("tenants").set("tenant-1", {
@@ -426,6 +432,15 @@ describe("tenantPortalRoutes foundation", () => {
     expect(res.body?.data?.application?.sin).toBeUndefined();
     expect(res.body?.data?.lease?.monthlyRent).toBe(1800);
     expect(res.body?.data?.lease?.confidentialNotes).toBeUndefined();
+    expect(res.body?.data?.lease?.signatureStatus).toBe("signed");
+    expect(res.body?.data?.lease?.signatureReadinessLabel).toBe("Lease signing complete");
+    expect(res.body?.data?.lease?.tenantSignature).toEqual({
+      signedAt: "2026-02-01T10:00:00.000Z",
+      signatureMethod: "drawn",
+      signatureDisplayName: "Taylor Tenant",
+    });
+    expect(res.body?.data?.lease?.tenantSignature?.drawnDataUrl).toBeUndefined();
+    expect(res.body?.data?.lease?.leasePdfStatus).toBe("available");
     expect(res.body?.data?.maintenance?.[0]?.title).toBe("Leaky tap");
     expect(res.body?.data?.maintenance?.[0]?.assignedContractorName).toBe("North Shore Plumbing");
     expect(res.body?.data?.maintenance?.[0]?.contractorStatus).toBe("assigned");
@@ -437,6 +452,35 @@ describe("tenantPortalRoutes foundation", () => {
 
     const eventDocs = Array.from(ensureCollection("event_log").values());
     expect(eventDocs.some((event) => event.event_type === "tenant_workspace_viewed")).toBe(true);
+  });
+
+  it("returns tenant-safe lease signature and PDF readiness metadata from /tenant/lease", async () => {
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/lease",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.leaseId).toBe("lease-1");
+    expect(res.body?.data?.signatureStatus).toBe("signed");
+    expect(res.body?.data?.signatureReadinessDescription).toMatch(/current signing stage as complete/i);
+    expect(res.body?.data?.tenantSignature).toEqual({
+      signedAt: "2026-02-01T10:00:00.000Z",
+      signatureMethod: "drawn",
+      signatureDisplayName: "Taylor Tenant",
+    });
+    expect(res.body?.data?.tenantSignature?.drawnDataUrl).toBeUndefined();
+    expect(res.body?.data?.leasePdfStatus).toBe("available");
+    expect(res.body?.lease?.tenantSignature?.drawnDataUrl).toBeUndefined();
   });
 
   it("returns a grouped tenant-safe application completion checklist", async () => {

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -32,6 +32,7 @@ import {
   isTargetedHiddenLeaseId,
   isTargetedHiddenTenantId,
 } from "../lib/testDataVisibilityTargets";
+import { deriveTenantSafeLeaseReadinessMetadata } from "../services/tenantPortal/tenantProjectionService";
 
 const router = Router();
 const LEDGER_COLLECTION = "ledgerEntries";
@@ -297,6 +298,7 @@ async function enrichLeaseRow(raw: any) {
     tenantName,
     tenantEmail,
     documentUrl,
+    ...deriveTenantSafeLeaseReadinessMetadata(raw, { documentUrl }),
     archivedAt: raw?.archivedAt || null,
     archivedByUserId: raw?.archivedByUserId || null,
     isArchived: Boolean(raw?.archivedAt),

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -5035,29 +5035,49 @@ router.get("/lease", requireTenant, async (req: any, res) => {
       }
     }
 
-    const rentAmount =
-      typeof leaseRecord?.monthlyRent === "number"
-        ? leaseRecord.monthlyRent
-        : typeof tenantData?.monthlyRent === "number"
-        ? tenantData.monthlyRent
-        : typeof tenantData?.rentCents === "number"
-        ? tenantData.rentCents / 100
-        : null;
+    const projectedLease = leaseId
+      ? projectTenantLease(leaseId, {
+          ...(leaseRecord || {}),
+          startDate: leaseRecord?.startDate || leaseRecord?.leaseStart || tenantData?.leaseStart || tenantData?.leaseStartDate || null,
+          endDate: leaseRecord?.endDate || tenantData?.leaseEnd || null,
+          monthlyRent:
+            typeof leaseRecord?.monthlyRent === "number"
+              ? leaseRecord.monthlyRent
+              : typeof tenantData?.monthlyRent === "number"
+              ? tenantData.monthlyRent
+              : typeof tenantData?.rentCents === "number"
+              ? tenantData.rentCents / 100
+              : null,
+          status: leaseRecord?.status || tenantData?.leaseStatus || tenantData?.status || null,
+        })
+      : null;
 
     const lease = {
-      leaseId,
+      ...(projectedLease || {
+        leaseId,
+        startDate: null,
+        endDate: null,
+        monthlyRent: null,
+        status: null,
+        documentUrl: null,
+        signatureStatus: "unavailable",
+        signatureReadinessLabel: "Lease signing unavailable",
+        signatureReadinessDescription: "Lease signing details are not available in this workspace yet.",
+        tenantSignature: null,
+        leasePdfStatus: "not_available",
+        leasePdfLabel: "Lease document unavailable",
+        leasePdfDescription: "No tenant-safe lease document is available in this workspace yet.",
+      }),
       propertyId,
       propertyName,
       unitId,
       unitNumber,
-      rentAmount,
-      leaseStart:
-        leaseRecord?.startDate || leaseRecord?.leaseStart || tenantData?.leaseStart || tenantData?.leaseStartDate || null,
-      leaseEnd: leaseRecord?.endDate || tenantData?.leaseEnd || null,
-      status: leaseRecord?.status || tenantData?.leaseStatus || tenantData?.status || null,
+      rentAmount: projectedLease?.monthlyRent ?? null,
+      leaseStart: projectedLease?.startDate ?? null,
+      leaseEnd: projectedLease?.endDate ?? null,
     };
 
-    return res.json({ ok: true, lease, ...lease });
+    return res.json({ ok: true, data: lease, lease, ...lease });
   } catch (err) {
     console.error("[tenantPortalRoutes] /tenant/lease error", err);
     return res.status(500).json({ ok: false, error: "TENANT_LEASE_FAILED" });

--- a/rentchain-api/src/services/tenantPortal/tenantProjectionService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantProjectionService.ts
@@ -16,6 +16,22 @@ type TenantLeaseProjection = {
   monthlyRent: number | null;
   status: string | null;
   documentUrl: string | null;
+  signatureStatus:
+    | "not_started"
+    | "awaiting_tenant_signature"
+    | "awaiting_landlord_signature"
+    | "signed"
+    | "unavailable";
+  signatureReadinessLabel: string;
+  signatureReadinessDescription: string;
+  tenantSignature: {
+    signedAt: string | null;
+    signatureMethod: "typed" | "drawn" | null;
+    signatureDisplayName: string | null;
+  } | null;
+  leasePdfStatus: "available" | "pending" | "not_available";
+  leasePdfLabel: string;
+  leasePdfDescription: string;
 };
 
 type TenantApplicationProjection = {
@@ -157,6 +173,151 @@ function toIso(value: any): string | null {
   return millis ? new Date(millis).toISOString() : asString(value);
 }
 
+function normalizeStatus(value: unknown): string {
+  return String(value || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_");
+}
+
+function firstIso(input: any, keys: string[]): string | null {
+  for (const key of keys) {
+    const value = toIso(input?.[key]);
+    if (value) return value;
+  }
+  return null;
+}
+
+function firstString(input: any, keys: string[]): string | null {
+  for (const key of keys) {
+    const value = asString(input?.[key]);
+    if (value) return value;
+  }
+  return null;
+}
+
+function normalizeSignatureMethod(value: unknown): "typed" | "drawn" | null {
+  const normalized = normalizeStatus(value);
+  if (normalized === "typed") return "typed";
+  if (normalized === "drawn") return "drawn";
+  return null;
+}
+
+export type TenantSafeLeaseReadinessMetadata = Pick<
+  TenantLeaseProjection,
+  | "signatureStatus"
+  | "signatureReadinessLabel"
+  | "signatureReadinessDescription"
+  | "tenantSignature"
+  | "leasePdfStatus"
+  | "leasePdfLabel"
+  | "leasePdfDescription"
+>;
+
+export function deriveTenantSafeLeaseReadinessMetadata(
+  data: any,
+  options?: { documentUrl?: string | null }
+): TenantSafeLeaseReadinessMetadata {
+  const documentUrl = asString(options?.documentUrl) ?? asString(data?.documentUrl) ?? asString(data?.approvedDocumentUrl) ?? asString(data?.documentRef);
+  const normalizedLeaseStatus = normalizeStatus(data?.status);
+  const tenantSignedAt =
+    firstIso(data?.tenantSignature, ["signedAt"]) ||
+    firstIso(data, ["tenantSignedAt", "tenantSignatureCompletedAt"]);
+  const tenantSignatureMethod =
+    normalizeSignatureMethod(data?.tenantSignature?.signatureMethod) ||
+    normalizeSignatureMethod(data?.tenantSignature?.type) ||
+    normalizeSignatureMethod(data?.tenantSignatureMethod);
+  const tenantSignatureDisplayName =
+    firstString(data?.tenantSignature, ["signatureDisplayName", "displayName", "typedName"]) ||
+    firstString(data, ["tenantSignatureDisplayName", "tenantSignedByName"]);
+
+  const tenantSignature =
+    tenantSignedAt || tenantSignatureMethod || tenantSignatureDisplayName
+      ? {
+          signedAt: tenantSignedAt,
+          signatureMethod: tenantSignatureMethod,
+          signatureDisplayName: tenantSignatureDisplayName,
+        }
+      : null;
+
+  const leasePdfStatus: TenantLeaseProjection["leasePdfStatus"] = documentUrl
+    ? "available"
+    : normalizedLeaseStatus
+    ? "pending"
+    : "not_available";
+
+  const leasePdfLabel =
+    leasePdfStatus === "available"
+      ? "Lease document available"
+      : leasePdfStatus === "pending"
+      ? "Lease document pending"
+      : "Lease document unavailable";
+  const leasePdfDescription =
+    leasePdfStatus === "available"
+      ? "A tenant-safe lease document is available in this workspace."
+      : leasePdfStatus === "pending"
+      ? "A lease record is visible, but a tenant-safe lease document is not available in this workspace yet."
+      : "No tenant-safe lease document is available in this workspace yet.";
+
+  const signatureStatus: TenantLeaseProjection["signatureStatus"] = (() => {
+    if (
+      tenantSignedAt ||
+      ["signed", "active", "current", "fully_signed", "completed"].includes(normalizedLeaseStatus)
+    ) {
+      return "signed";
+    }
+    if (
+      ["tenant_signed", "signed_by_tenant", "awaiting_landlord_signature", "pending_landlord_signature"].includes(
+        normalizedLeaseStatus
+      )
+    ) {
+      return "awaiting_landlord_signature";
+    }
+    if (
+      documentUrl &&
+      ["sent", "awaiting_tenant_signature", "pending_tenant_signature", "ready_for_signature", "signature_requested"].includes(
+        normalizedLeaseStatus
+      )
+    ) {
+      return "awaiting_tenant_signature";
+    }
+    if (normalizedLeaseStatus) return "not_started";
+    return "unavailable";
+  })();
+
+  const signatureReadinessLabel =
+    signatureStatus === "signed"
+      ? "Lease signing complete"
+      : signatureStatus === "awaiting_landlord_signature"
+      ? "Awaiting landlord signature"
+      : signatureStatus === "awaiting_tenant_signature"
+      ? "Awaiting tenant signature"
+      : signatureStatus === "not_started"
+      ? "Lease signing not started"
+      : "Lease signing unavailable";
+
+  const signatureReadinessDescription =
+    signatureStatus === "signed"
+      ? "The visible lease record shows the current signing stage as complete."
+      : signatureStatus === "awaiting_landlord_signature"
+      ? "Tenant review appears complete, and the next visible signing step belongs to the landlord."
+      : signatureStatus === "awaiting_tenant_signature"
+      ? "A tenant-safe lease document is available, and the next visible signing step belongs to the tenant."
+      : signatureStatus === "not_started"
+      ? "A lease record is visible, but a tenant-safe signing step is not surfaced here yet."
+      : "Lease signing details are not available in this workspace yet.";
+
+  return {
+    signatureStatus,
+    signatureReadinessLabel,
+    signatureReadinessDescription,
+    tenantSignature,
+    leasePdfStatus,
+    leasePdfLabel,
+    leasePdfDescription,
+  };
+}
+
 function projectFeatureList(input: any): string[] {
   const list = Array.isArray(input) ? input : Array.isArray(input?.selected) ? input.selected : [];
   return list
@@ -179,6 +340,9 @@ export function projectTenantProperty(recordId: string, data: any): TenantProper
 }
 
 export function projectTenantLease(recordId: string, data: any): TenantLeaseProjection {
+  const documentUrl =
+    asString(data?.documentUrl) || asString(data?.approvedDocumentUrl) || asString(data?.documentRef);
+
   return {
     leaseId: recordId,
     startDate: asString(data?.startDate) || asString(data?.leaseStart),
@@ -188,7 +352,8 @@ export function projectTenantLease(recordId: string, data: any): TenantLeaseProj
       asNumber(data?.rentAmount) ??
       (typeof data?.rentCents === "number" ? Math.round(data.rentCents) / 100 : null),
     status: asString(data?.status),
-    documentUrl: asString(data?.documentUrl) || asString(data?.approvedDocumentUrl) || asString(data?.documentRef),
+    documentUrl,
+    ...deriveTenantSafeLeaseReadinessMetadata(data, { documentUrl }),
   };
 }
 

--- a/rentchain-frontend/src/api/leasesApi.ts
+++ b/rentchain-frontend/src/api/leasesApi.ts
@@ -49,6 +49,17 @@ export interface LandlordActiveLease extends Lease {
   tenantName?: string | null;
   tenantEmail?: string | null;
   documentUrl?: string | null;
+  signatureStatus?: "not_started" | "awaiting_tenant_signature" | "awaiting_landlord_signature" | "signed" | "unavailable";
+  signatureReadinessLabel?: string | null;
+  signatureReadinessDescription?: string | null;
+  tenantSignature?: {
+    signedAt: string | null;
+    signatureMethod: "typed" | "drawn" | null;
+    signatureDisplayName: string | null;
+  } | null;
+  leasePdfStatus?: "available" | "pending" | "not_available";
+  leasePdfLabel?: string | null;
+  leasePdfDescription?: string | null;
   hiddenFromActiveLists?: boolean;
   cleanupReason?: string | null;
   cleanupBatch?: string | null;

--- a/rentchain-frontend/src/api/tenantPortal.ts
+++ b/rentchain-frontend/src/api/tenantPortal.ts
@@ -39,6 +39,17 @@ export type TenantWorkspaceLease = {
   monthlyRent: number | null;
   status: string | null;
   documentUrl: string | null;
+  signatureStatus?: "not_started" | "awaiting_tenant_signature" | "awaiting_landlord_signature" | "signed" | "unavailable";
+  signatureReadinessLabel?: string | null;
+  signatureReadinessDescription?: string | null;
+  tenantSignature?: {
+    signedAt: string | null;
+    signatureMethod: "typed" | "drawn" | null;
+    signatureDisplayName: string | null;
+  } | null;
+  leasePdfStatus?: "available" | "pending" | "not_available";
+  leasePdfLabel?: string | null;
+  leasePdfDescription?: string | null;
   depositCents?: number | null;
   depositRequired?: boolean | null;
   depositReceived?: boolean | null;

--- a/rentchain-frontend/src/api/tenantPortalApi.ts
+++ b/rentchain-frontend/src/api/tenantPortalApi.ts
@@ -21,6 +21,18 @@ export interface TenantLease {
   leaseStart: string | null;
   leaseEnd: string | null;
   status: string | null;
+  documentUrl?: string | null;
+  signatureStatus?: "not_started" | "awaiting_tenant_signature" | "awaiting_landlord_signature" | "signed" | "unavailable";
+  signatureReadinessLabel?: string | null;
+  signatureReadinessDescription?: string | null;
+  tenantSignature?: {
+    signedAt: string | null;
+    signatureMethod: "typed" | "drawn" | null;
+    signatureDisplayName: string | null;
+  } | null;
+  leasePdfStatus?: "available" | "pending" | "not_available";
+  leasePdfLabel?: string | null;
+  leasePdfDescription?: string | null;
 }
 
 export interface TenantPayment {

--- a/rentchain-frontend/src/pages/leaseSigningWorkspaceState.test.ts
+++ b/rentchain-frontend/src/pages/leaseSigningWorkspaceState.test.ts
@@ -103,4 +103,39 @@ describe("leaseSigningWorkspaceState", () => {
     expect(result.signingState).toBe("signed_or_completed");
     expect(result.timelineEvent?.title).toBe("Lease signing completed");
   });
+
+  it("prefers backend readiness metadata when tenant signature status is already surfaced", () => {
+    const result = buildLeaseSigningWorkspaceState({
+      audience: "landlord",
+      executionWorkspace: {
+        executionState: "ready_for_execution",
+        label: "Ready for execution",
+        summary: "Lease execution workspace",
+        explanation: "Ready.",
+        blockers: [],
+        nextSteps: ["Move into the next step."],
+        timelineEvent: {
+          title: "Ready for execution",
+          description: "Ready.",
+          actionRequired: false,
+        },
+      },
+      lease: {
+        leaseId: "lease-1",
+        startDate: "2026-05-01",
+        endDate: "2027-04-30",
+        monthlyRent: 1800,
+        status: "draft",
+        documentUrl: "https://example.com/lease.pdf",
+        signatureStatus: "awaiting_landlord_signature",
+        signatureReadinessLabel: "Awaiting landlord signature",
+        signatureReadinessDescription: "Tenant review appears complete, and the next visible signing step belongs to the landlord.",
+      },
+    });
+
+    expect(result.signingState).toBe("awaiting_landlord_signature");
+    expect(result.label).toBe("Awaiting landlord signature");
+    expect(result.explanation).toMatch(/next visible signing step belongs to the landlord/i);
+    expect(result.currentActor).toBe("landlord");
+  });
 });

--- a/rentchain-frontend/src/pages/leaseSigningWorkspaceState.ts
+++ b/rentchain-frontend/src/pages/leaseSigningWorkspaceState.ts
@@ -59,6 +59,10 @@ function actorLabel(actor: LeaseSigningWorkspaceActor): string {
   return "Not surfaced yet";
 }
 
+function hasBackendLeaseSignatureTiming(lease: TenantWorkspaceLease | null | undefined): boolean {
+  return Boolean(String(lease?.signatureStatus || "").trim());
+}
+
 export function buildLeaseSigningWorkspaceState(input: {
   audience: "landlord" | "tenant";
   executionWorkspace: LeaseExecutionWorkspaceView;
@@ -68,6 +72,104 @@ export function buildLeaseSigningWorkspaceState(input: {
   const leaseVisible = hasLeaseProjection(lease);
   const leaseDocumentVisible = hasLeaseDocument(lease);
   const normalizedLeaseStatus = normalizeStatus(lease?.status);
+  const backendSignatureStatus = normalizeStatus(lease?.signatureStatus);
+  const backendSignatureLabel = String(lease?.signatureReadinessLabel || "").trim() || null;
+  const backendSignatureDescription = String(lease?.signatureReadinessDescription || "").trim() || null;
+
+  if (hasBackendLeaseSignatureTiming(lease)) {
+    if (backendSignatureStatus === "signed") {
+      return {
+        signingState: "signed_or_completed",
+        label: backendSignatureLabel || stateLabel("signed_or_completed"),
+        summary: "Lease signing",
+        explanation:
+          backendSignatureDescription ||
+          "The visible lease record shows the current signing stage as complete.",
+        currentActor: null,
+        currentActorLabel: actorLabel(null),
+        blockers: [],
+        nextActions:
+          input.audience === "landlord"
+            ? [
+                "Use the existing lease and move-in tools for any remaining operational follow-through.",
+                "Keep this signing workspace as the high-level record of how the file moved past the first signing stage.",
+              ]
+            : [
+                "Review your lease details and watch for any next tenant-visible move-in instructions.",
+                "Use the lease page if you need to revisit the current signed document.",
+              ],
+        timelineEvent: {
+          title: "Lease signing completed",
+          description:
+            backendSignatureDescription ||
+            "The visible lease status now indicates the first signing step is complete in the authorized workspace.",
+          actionRequired: false,
+        },
+      };
+    }
+
+    if (backendSignatureStatus === "awaiting_landlord_signature") {
+      return {
+        signingState: "awaiting_landlord_signature",
+        label: backendSignatureLabel || stateLabel("awaiting_landlord_signature"),
+        summary: "Lease signing",
+        explanation:
+          backendSignatureDescription ||
+          "Tenant review appears complete and landlord signature is the next visible signing step.",
+        currentActor: "landlord",
+        currentActorLabel: actorLabel("landlord"),
+        blockers: [],
+        nextActions:
+          input.audience === "landlord"
+            ? [
+                "Review the current lease details and complete the landlord-side signing step in the existing lease workflow when appropriate.",
+                "Keep this workspace as the neutral status view rather than treating it as a legal-signing tool.",
+              ]
+            : [
+                "Your lease review appears complete for now.",
+                "Watch for the landlord-side signing step to finish in the existing workflow.",
+              ],
+        timelineEvent: {
+          title: "Awaiting landlord signature",
+          description:
+            backendSignatureDescription ||
+            "The visible lease status indicates tenant review appears complete and landlord signature is the next visible step.",
+          actionRequired: input.audience === "landlord",
+        },
+      };
+    }
+
+    if (backendSignatureStatus === "awaiting_tenant_signature") {
+      return {
+        signingState: "awaiting_tenant_signature",
+        label: backendSignatureLabel || stateLabel("awaiting_tenant_signature"),
+        summary: "Lease signing",
+        explanation:
+          backendSignatureDescription ||
+          "A visible lease document is available and the next visible signing step belongs to the tenant.",
+        currentActor: "tenant",
+        currentActorLabel: actorLabel("tenant"),
+        blockers: [],
+        nextActions:
+          input.audience === "landlord"
+            ? [
+                "Wait for the tenant-side signing step to complete in the current lease workflow.",
+                "Use this workspace to explain who is expected to act next without implying provider-backed e-sign automation.",
+              ]
+            : [
+                "Review the current lease details carefully before taking the next tenant-visible signing step.",
+                "Use the existing lease page for the current document and any tenant-safe follow-through.",
+              ],
+        timelineEvent: {
+          title: "Awaiting tenant signature",
+          description:
+            backendSignatureDescription ||
+            "A visible lease document and current status indicate the next signing step belongs to the tenant.",
+          actionRequired: input.audience === "tenant",
+        },
+      };
+    }
+  }
 
   if (["signed", "active", "current"].includes(normalizedLeaseStatus)) {
     return {

--- a/rentchain-frontend/src/pages/tenant/TenantLeasePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantLeasePage.tsx
@@ -61,6 +61,14 @@ export default function TenantLeasePage() {
           </TenantInfoCard>
 
           <TenantInfoCard heading="Lease Document" accent="#0f766e">
+            {data.leasePdfLabel ? (
+              <div style={{ display: "grid", gap: 6 }}>
+                <div style={{ fontWeight: 800 }}>{data.leasePdfLabel}</div>
+                {data.leasePdfDescription ? (
+                  <div style={{ color: "var(--text-muted, #64748b)" }}>{data.leasePdfDescription}</div>
+                ) : null}
+              </div>
+            ) : null}
             {data.documentUrl ? (
               <a href={data.documentUrl} target="_blank" rel="noreferrer">
                 Open lease document
@@ -70,6 +78,35 @@ export default function TenantLeasePage() {
                 No approved lease document link is available in this workspace yet.
               </div>
             )}
+          </TenantInfoCard>
+
+          <TenantInfoCard heading="Lease Signing" accent="#7c3aed">
+            <div style={{ display: "grid", gap: 12 }}>
+              <div style={{ display: "grid", gap: 6 }}>
+                <div style={{ fontWeight: 800 }}>{data.signatureReadinessLabel || "Lease signing unavailable"}</div>
+                <div style={{ color: "var(--text-muted, #64748b)" }}>
+                  {data.signatureReadinessDescription || "Lease signing details are not available in this workspace yet."}
+                </div>
+              </div>
+
+              {data.tenantSignature ? (
+                <TenantKeyValueGrid
+                  rows={[
+                    { label: "Signed at", value: formatDate(data.tenantSignature.signedAt) },
+                    {
+                      label: "Signature method",
+                      value:
+                        data.tenantSignature.signatureMethod === "drawn"
+                          ? "Drawn signature"
+                          : data.tenantSignature.signatureMethod === "typed"
+                          ? "Typed signature"
+                          : "—",
+                    },
+                    { label: "Signed by", value: data.tenantSignature.signatureDisplayName || "—" },
+                  ]}
+                />
+              ) : null}
+            </div>
           </TenantInfoCard>
         </>
       ) : null}

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -552,6 +552,17 @@ describe("tenant workspace frontend shell", () => {
       monthlyRent: 1800,
       status: "active",
       documentUrl: "https://example.com/lease.pdf",
+      signatureStatus: "signed",
+      signatureReadinessLabel: "Lease signing complete",
+      signatureReadinessDescription: "The visible lease record shows the current signing stage as complete.",
+      tenantSignature: {
+        signedAt: "2026-02-01T10:00:00.000Z",
+        signatureMethod: "drawn",
+        signatureDisplayName: "Taylor Tenant",
+      },
+      leasePdfStatus: "available",
+      leasePdfLabel: "Lease document available",
+      leasePdfDescription: "A tenant-safe lease document is available in this workspace.",
     });
 
     render(
@@ -562,6 +573,10 @@ describe("tenant workspace frontend shell", () => {
 
     expect(await screen.findByText(/^Lease Summary$/i)).toBeInTheDocument();
     expect(screen.getByText(/\$1,800/i)).toBeInTheDocument();
+    expect(screen.getByText(/^Lease signing complete$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^Lease document available$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^Drawn signature$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^Taylor Tenant$/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Open lease document/i })).toBeInTheDocument();
   });
 


### PR DESCRIPTION
This PR adds Lease/PDF Signature Integration v1.

Includes:
- tenant-safe lease signature/PDF readiness metadata
- tenant lease detail readiness display
- landlord-safe metadata on existing enriched lease rows/details
- lease signing workspace alignment with backend metadata
- metadata-only tenant signature display
- focused backend/frontend tests

Guardrails preserved:
- no raw signature blob/base64 exposure
- no raw application signature payload copied into lease views
- no PDF stamping
- no new signing workflow
- no external e-sign provider
- no background reminders
- no legal overclaiming