### PR TITLE
feat: add tenant identity record

### DIFF
--- a/rentchain-api/src/routes/__tests__/rentalApplicationsReviewSummaryRisk.test.ts
+++ b/rentchain-api/src/routes/__tests__/rentalApplicationsReviewSummaryRisk.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 type StoredDoc = { id: string; data: any };
 
-const { dbMock, resetDb, upsertDoc, getLatestApplicationRiskMock } = vi.hoisted(() => {
+const { dbMock, resetDb, upsertDoc, getLatestApplicationRiskMock, loadLandlordSafeTenantIdentitySummaryMock } = vi.hoisted(() => {
   const collections = new Map<string, Map<string, StoredDoc>>();
 
   function ensureCollection(name: string) {
@@ -55,6 +55,7 @@ const { dbMock, resetDb, upsertDoc, getLatestApplicationRiskMock } = vi.hoisted(
       ensureCollection(collectionName).set(id, { id, data });
     },
     getLatestApplicationRiskMock: vi.fn(),
+    loadLandlordSafeTenantIdentitySummaryMock: vi.fn(),
   };
 });
 
@@ -229,6 +230,10 @@ vi.mock("../../services/riskAgent/riskAgentService", () => ({
   getLatestApplicationRisk: getLatestApplicationRiskMock,
 }));
 
+vi.mock("../../services/tenantPortal/tenantProfileService", () => ({
+  loadLandlordSafeTenantIdentitySummary: loadLandlordSafeTenantIdentitySummaryMock,
+}));
+
 async function createApp() {
   const router = (await import("../rentalApplicationsRoutes")).default;
   const app = express();
@@ -240,6 +245,13 @@ async function createApp() {
 describe("rentalApplications review summary risk surface", () => {
   beforeEach(() => {
     resetDb();
+    loadLandlordSafeTenantIdentitySummaryMock.mockReset();
+    loadLandlordSafeTenantIdentitySummaryMock.mockResolvedValue({
+      identityStatus: "ready",
+      verification: { level: "partial" },
+      readinessLabel: "Ready to apply",
+      readinessDescription: "Your core profile and supporting records are ready for most rental workflows.",
+    });
     upsertDoc("rentalApplications", "app-1", {
       id: "app-1",
       landlordId: "landlord-1",
@@ -282,6 +294,14 @@ describe("rentalApplications review summary risk surface", () => {
         grade: "B",
       })
     );
+    expect(res.body?.tenantIdentitySummary).toEqual({
+      identityStatus: "ready",
+      verification: { level: "partial" },
+      readinessLabel: "Ready to apply",
+      readinessDescription: "Your core profile and supporting records are ready for most rental workflows.",
+    });
+    expect(res.body?.tenantIdentitySummary?.documents).toBeUndefined();
+    expect(res.body?.tenantIdentitySummary?.screening).toBeUndefined();
   });
 
   it("returns a safe null risk state when no snapshot exists", async () => {

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -441,6 +441,17 @@ describe("tenantPortalRoutes foundation", () => {
     });
     expect(res.body?.data?.lease?.tenantSignature?.drawnDataUrl).toBeUndefined();
     expect(res.body?.data?.lease?.leasePdfStatus).toBe("available");
+    expect(res.body?.data?.tenantIdentityRecord).toEqual(
+      expect.objectContaining({
+        identityStatus: expect.stringMatching(/incomplete|ready|verified|limited/),
+        verification: expect.objectContaining({
+          level: expect.stringMatching(/none|partial|strong/),
+        }),
+        readinessLabel: expect.any(String),
+        readinessDescription: expect.any(String),
+      })
+    );
+    expect(Array.isArray(res.body?.data?.tenantIdentityRecord?.documents?.missingCategories)).toBe(true);
     expect(res.body?.data?.maintenance?.[0]?.title).toBe("Leaky tap");
     expect(res.body?.data?.maintenance?.[0]?.assignedContractorName).toBe("North Shore Plumbing");
     expect(res.body?.data?.maintenance?.[0]?.contractorStatus).toBe("assigned");
@@ -449,6 +460,8 @@ describe("tenantPortalRoutes foundation", () => {
     expect(res.body?.data?.maintenance?.[0]?.tenantConfirmationStatus).toBeNull();
     expect(res.body?.data?.maintenance?.[0]?.statusHistory?.[0]?.message).toBe("Submitted from tenant workspace.");
     expect(res.body?.data?.maintenance?.[0]?.internalCost).toBeUndefined();
+    expect(res.body?.data?.tenantIdentityRecord?.documents?.documentChecklist).toBeUndefined();
+    expect(res.body?.data?.tenantIdentityRecord?.screening?.provider).toBeUndefined();
 
     const eventDocs = Array.from(ensureCollection("event_log").values());
     expect(eventDocs.some((event) => event.event_type === "tenant_workspace_viewed")).toBe(true);

--- a/rentchain-api/src/routes/rentalApplicationsRoutes.ts
+++ b/rentchain-api/src/routes/rentalApplicationsRoutes.ts
@@ -62,6 +62,7 @@ import {
   normalizeApplicationLinkPartialProgress,
   sendApplicationLinkReminder,
 } from "../services/applicationReminderService";
+import { loadLandlordSafeTenantIdentitySummary } from "../services/tenantPortal/tenantProfileService";
 import {
   buildQuoteId,
   buildScreeningMonetizationPatch,
@@ -4095,13 +4096,16 @@ router.get("/rental-applications/:id/review-summary", async (req: any, res) => {
       });
     }
     const summary = buildReviewSummary(id, access.data);
+    const [risk, tenantIdentitySummary] = await Promise.all([
+      getLatestApplicationRisk({ applicationId: id }),
+      loadLandlordSafeTenantIdentitySummary({ applicationId: id, application: access.data }),
+    ]);
     const decisionSummary = buildApplicationDecisionSummary({
       applicationId: id,
       application: access.data,
       reviewSummary: summary,
     });
-    const risk = await getLatestApplicationRisk({ applicationId: id });
-    return res.json({ ok: true, summary, decisionSummary, risk });
+    return res.json({ ok: true, summary, decisionSummary, risk, tenantIdentitySummary });
   } catch (err: any) {
     console.error("[review_summary] failed", err?.message || err);
     return res.status(500).json({

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -15,7 +15,7 @@ import {
 } from "../services/tenantPortal/tenantProjectionService";
 import { recordTenantEvent } from "../services/tenantPortal/tenantEventLogService";
 import { redeemTenancyInvite } from "../services/tenantPortal/tenantInviteService";
-import { loadTenantProfileProjection } from "../services/tenantPortal/tenantProfileService";
+import { loadTenantIdentityRecord, loadTenantProfileProjection } from "../services/tenantPortal/tenantProfileService";
 import {
   loadTenantCommunicationsWorkspace,
   markTenantCommunicationsRead,
@@ -2896,7 +2896,14 @@ async function handleTenantWorkspaceSummary(req: any, res: any) {
   const context = await resolveWorkspaceContextOrRespond(req, res);
   if (!context) return;
 
-  const workspace = await loadTenantWorkspaceData(context);
+  const [workspace, tenantIdentityRecord] = await Promise.all([
+    loadTenantWorkspaceData(context),
+    loadTenantIdentityRecord({
+      context,
+      userId: String(req.user?.id || "").trim(),
+      userEmail: req.user?.email,
+    }),
+  ]);
   await recordTenantEvent({
     eventType: "tenant_workspace_viewed",
     entityType: "tenant_workspace",
@@ -2922,6 +2929,7 @@ async function handleTenantWorkspaceSummary(req: any, res: any) {
       application: workspace.application,
       lease: workspace.lease,
       maintenance: workspace.maintenance,
+      tenantIdentityRecord,
     },
   });
 }

--- a/rentchain-api/src/services/tenantPortal/tenantProfileService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantProfileService.ts
@@ -76,6 +76,52 @@ export type TenantApplicationReuseProjection = {
   } | null;
 };
 
+export type TenantIdentityStatus = "incomplete" | "ready" | "verified" | "limited";
+export type TenantIdentityVerificationLevel = "none" | "partial" | "strong";
+export type TenantIdentityCompletionStatus = "complete" | "in_progress" | "missing" | "needs_attention";
+export type TenantIdentityScreeningStatus =
+  | "not_started"
+  | "in_progress"
+  | "completed"
+  | "needs_attention"
+  | "blocked";
+
+export type TenantIdentityRecord = {
+  identityStatus: TenantIdentityStatus;
+  profile: {
+    completionStatus: TenantIdentityCompletionStatus;
+  };
+  application: {
+    reusable: boolean;
+    lastSubmittedAt: string | null;
+  };
+  documents: {
+    completionStatus: TenantIdentityCompletionStatus;
+    missingCategories: string[];
+  };
+  screening: {
+    status: TenantIdentityScreeningStatus;
+    lastCompletedAt: string | null;
+  };
+  leases: {
+    activeCount: number;
+    historicalCount: number;
+    lastSignedAt: string | null;
+  };
+  verification: {
+    level: TenantIdentityVerificationLevel;
+  };
+  readinessLabel: string;
+  readinessDescription: string;
+};
+
+export type TenantIdentitySummary = Pick<
+  TenantIdentityRecord,
+  "identityStatus" | "readinessLabel" | "readinessDescription"
+> & {
+  verification: TenantIdentityRecord["verification"];
+};
+
 function asString(value: unknown): string | null {
   const next = String(value || "").trim();
   return next || null;
@@ -157,6 +203,23 @@ async function queryFirst(
   }
 }
 
+async function queryMany(
+  collectionName: string,
+  field: string,
+  value: string | null,
+  operator: "==" | "array-contains" = "==",
+  limitCount = 25
+) {
+  const normalized = operator === "array-contains" ? value : asString(value);
+  if (!normalized) return [];
+  try {
+    const snap = await db.collection(collectionName).where(field, operator, normalized).limit(limitCount).get();
+    return snap.docs.map((doc: any) => ({ id: doc.id, data: (doc.data() as any) || {} }));
+  } catch {
+    return [];
+  }
+}
+
 async function loadWorkspaceDocuments(context: TenancyContext) {
   const property = await loadDocument("properties", context.propertyId);
 
@@ -230,6 +293,334 @@ function titleCaseWords(value: string): string {
   return value
     .replace(/[_-]+/g, " ")
     .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function normalizeIdentityCompletionStatus(status: TenantVisibleStatus): TenantIdentityCompletionStatus {
+  switch (status) {
+    case "verified":
+      return "complete";
+    case "pending":
+      return "in_progress";
+    case "needs_review":
+      return "needs_attention";
+    case "missing":
+    default:
+      return "missing";
+  }
+}
+
+function uniq(values: Array<string | null | undefined>): string[] {
+  return Array.from(new Set(values.map((value) => asString(value)).filter((value): value is string => Boolean(value))));
+}
+
+function deriveReusableApplicationState(reuse: TenantApplicationReuseProjection): boolean {
+  const applicantReady = Boolean(
+    reuse.applicant.firstName && reuse.applicant.lastName && reuse.applicant.email && reuse.applicant.phone
+  );
+  const addressReady = Boolean(
+    reuse.currentAddress?.line1 &&
+      reuse.currentAddress?.city &&
+      reuse.currentAddress?.provinceState &&
+      reuse.currentAddress?.postalCode
+  );
+  const employmentReady = Boolean(
+    reuse.employment?.employerName &&
+      reuse.employment?.jobTitle &&
+      reuse.employment?.incomeAmountCents != null &&
+      reuse.employment?.monthsAtJob != null
+  );
+
+  return applicantReady && addressReady && employmentReady;
+}
+
+function deriveScreeningStatusFromVisibleStatus(status: TenantVisibleStatus): TenantIdentityScreeningStatus {
+  switch (status) {
+    case "verified":
+      return "completed";
+    case "pending":
+      return "in_progress";
+    case "needs_review":
+      return "needs_attention";
+    case "missing":
+    default:
+      return "not_started";
+  }
+}
+
+async function loadTenantLeaseHistorySignals(context: TenancyContext, userEmail?: string | null) {
+  let leases = context.tenantId ? await queryMany("leases", "tenantId", context.tenantId) : [];
+  if (!leases.length && userEmail) {
+    leases = await queryMany("leases", "tenantEmail", normalizeEmail(userEmail));
+  }
+
+  let activeCount = 0;
+  let historicalCount = 0;
+  let lastSignedAt: string | null = null;
+
+  leases.forEach((lease) => {
+    const status = String(lease.data?.status || "").trim().toLowerCase();
+    if (status === "active") {
+      activeCount += 1;
+    } else {
+      historicalCount += 1;
+    }
+    const signedAt =
+      toIso(lease.data?.tenantSignature?.signedAt) ||
+      toIso(lease.data?.tenantSignedAt) ||
+      toIso(lease.data?.tenantSignatureCompletedAt);
+    if (signedAt && (!lastSignedAt || Date.parse(signedAt) > Date.parse(lastSignedAt))) {
+      lastSignedAt = signedAt;
+    }
+  });
+
+  return {
+    activeCount,
+    historicalCount,
+    lastSignedAt,
+  };
+}
+
+function deriveTenantIdentityVerificationLevel(input: {
+  applicationReusable: boolean;
+  documentStatus: TenantIdentityCompletionStatus;
+  screeningStatus: TenantIdentityScreeningStatus;
+  leaseSignals: {
+    activeCount: number;
+    historicalCount: number;
+    lastSignedAt: string | null;
+  };
+}): TenantIdentityVerificationLevel {
+  const hasLeaseEvidence =
+    input.leaseSignals.activeCount > 0 || input.leaseSignals.historicalCount > 0 || Boolean(input.leaseSignals.lastSignedAt);
+
+  if (input.screeningStatus === "completed" && input.documentStatus === "complete" && hasLeaseEvidence) {
+    return "strong";
+  }
+
+  if (
+    input.applicationReusable ||
+    input.documentStatus === "complete" ||
+    input.documentStatus === "in_progress" ||
+    input.screeningStatus === "completed" ||
+    hasLeaseEvidence
+  ) {
+    return "partial";
+  }
+
+  return "none";
+}
+
+function deriveTenantIdentityStatus(input: {
+  profileStatus: TenantIdentityCompletionStatus;
+  applicationReusable: boolean;
+  documentStatus: TenantIdentityCompletionStatus;
+  screeningStatus: TenantIdentityScreeningStatus;
+  verificationLevel: TenantIdentityVerificationLevel;
+}): TenantIdentityStatus {
+  if (input.verificationLevel === "strong") {
+    return "verified";
+  }
+
+  if (
+    input.profileStatus === "complete" &&
+    input.applicationReusable &&
+    input.documentStatus !== "missing" &&
+    input.screeningStatus !== "needs_attention" &&
+    input.screeningStatus !== "blocked"
+  ) {
+    return "ready";
+  }
+
+  if (
+    input.profileStatus !== "missing" ||
+    input.applicationReusable ||
+    input.documentStatus !== "missing" ||
+    input.screeningStatus !== "not_started"
+  ) {
+    return "incomplete";
+  }
+
+  return "limited";
+}
+
+function deriveTenantIdentityReadinessCopy(
+  status: TenantIdentityStatus,
+  verificationLevel: TenantIdentityVerificationLevel
+) {
+  switch (status) {
+    case "verified":
+      return {
+        readinessLabel: "Well established",
+        readinessDescription:
+          verificationLevel === "strong"
+            ? "Your rental identity includes completed verification signals and visible lease history."
+            : "Your rental identity is established and ready for ongoing rental workflows.",
+      };
+    case "ready":
+      return {
+        readinessLabel: "Ready to apply",
+        readinessDescription:
+          "Your core profile, reusable application details, and supporting records are ready for most rental workflows.",
+      };
+    case "incomplete":
+      return {
+        readinessLabel: "Almost ready",
+        readinessDescription:
+          "A few important identity details are still missing, but your rental record is already taking shape.",
+      };
+    case "limited":
+    default:
+      return {
+        readinessLabel: "Getting started",
+        readinessDescription:
+          "Add your core profile and supporting records to build a stronger reusable rental identity.",
+      };
+  }
+}
+
+function toLandlordSafeTenantIdentitySummary(
+  record: TenantIdentityRecord
+): TenantIdentitySummary {
+  return {
+    identityStatus: record.identityStatus,
+    verification: record.verification,
+    readinessLabel: record.readinessLabel,
+    readinessDescription: record.readinessDescription,
+  };
+}
+
+function deriveTenantIdentityRecordFromSignals(input: {
+  profileStatus: TenantIdentityCompletionStatus;
+  applicationReusable: boolean;
+  lastSubmittedAt: string | null;
+  documentStatus: TenantIdentityCompletionStatus;
+  missingCategories: string[];
+  screeningStatus: TenantIdentityScreeningStatus;
+  screeningCompletedAt: string | null;
+  leaseSignals: {
+    activeCount: number;
+    historicalCount: number;
+    lastSignedAt: string | null;
+  };
+}): TenantIdentityRecord {
+  const verificationLevel = deriveTenantIdentityVerificationLevel({
+    applicationReusable: input.applicationReusable,
+    documentStatus: input.documentStatus,
+    screeningStatus: input.screeningStatus,
+    leaseSignals: input.leaseSignals,
+  });
+  const identityStatus = deriveTenantIdentityStatus({
+    profileStatus: input.profileStatus,
+    applicationReusable: input.applicationReusable,
+    documentStatus: input.documentStatus,
+    screeningStatus: input.screeningStatus,
+    verificationLevel,
+  });
+  const copy = deriveTenantIdentityReadinessCopy(identityStatus, verificationLevel);
+
+  return {
+    identityStatus,
+    profile: {
+      completionStatus: input.profileStatus,
+    },
+    application: {
+      reusable: input.applicationReusable,
+      lastSubmittedAt: input.lastSubmittedAt,
+    },
+    documents: {
+      completionStatus: input.documentStatus,
+      missingCategories: input.missingCategories,
+    },
+    screening: {
+      status: input.screeningStatus,
+      lastCompletedAt: input.screeningCompletedAt,
+    },
+    leases: input.leaseSignals,
+    verification: {
+      level: verificationLevel,
+    },
+    readinessLabel: copy.readinessLabel,
+    readinessDescription: copy.readinessDescription,
+  };
+}
+
+function deriveProfileCompletionStatusFromApplication(application: any): TenantIdentityCompletionStatus {
+  const hasApplicantName = Boolean(asString(application?.applicant?.firstName) || asString(application?.firstName));
+  const hasApplicantEmail = Boolean(
+    normalizeEmail(application?.applicant?.email) ||
+      normalizeEmail(application?.applicantEmail) ||
+      normalizeEmail(application?.email)
+  );
+  const hasTypedSignature = Boolean(asString(application?.applicantProfile?.signature?.typedName));
+
+  if (hasApplicantName && hasApplicantEmail && hasTypedSignature) {
+    return "complete";
+  }
+  if (hasApplicantName || hasApplicantEmail || hasTypedSignature) {
+    return "in_progress";
+  }
+  return "missing";
+}
+
+function deriveApplicationReusableFromApplication(application: any): boolean {
+  const currentAddress = application?.applicantProfile?.currentAddress || {};
+  const employment = application?.applicantProfile?.employment || {};
+
+  return Boolean(
+    (asString(application?.applicant?.firstName) || asString(application?.firstName)) &&
+      (asString(application?.applicant?.lastName) || asString(application?.lastName)) &&
+      (normalizeEmail(application?.applicant?.email) ||
+        normalizeEmail(application?.applicantEmail) ||
+        normalizeEmail(application?.email)) &&
+      asString(currentAddress?.line1) &&
+      asString(currentAddress?.city) &&
+      asString(currentAddress?.provinceState) &&
+      asString(currentAddress?.postalCode) &&
+      asString(employment?.employerName) &&
+      asString(employment?.jobTitle) &&
+      asNumber(employment?.incomeAmountCents) != null
+  );
+}
+
+function deriveDocumentSignalsFromApplication(application: any) {
+  const documentCount = Array.isArray(application?.documentRefs)
+    ? application.documentRefs.length
+    : Array.isArray(application?.documents)
+    ? application.documents.length
+    : 0;
+
+  if (documentCount > 0) {
+    return {
+      completionStatus: "complete" as TenantIdentityCompletionStatus,
+      missingCategories: [] as string[],
+    };
+  }
+
+  return {
+    completionStatus: "missing" as TenantIdentityCompletionStatus,
+    missingCategories: ["Supporting documents"],
+  };
+}
+
+function deriveScreeningSignalsFromApplication(application: any) {
+  const rawStatus = String(application?.screeningStatus || application?.screening?.status || "").trim().toLowerCase();
+  const completedAt =
+    toIso(application?.screening?.completedAt) ||
+    toIso(application?.screeningCompletedAt) ||
+    toIso(application?.screeningResultCompletedAt);
+
+  let status: TenantIdentityScreeningStatus = "not_started";
+  if (["complete", "completed", "verified"].includes(rawStatus)) {
+    status = "completed";
+  } else if (["manual_review", "manual_review_required", "failed", "ineligible"].includes(rawStatus)) {
+    status = "needs_attention";
+  } else if (["blocked"].includes(rawStatus)) {
+    status = "blocked";
+  } else if (rawStatus) {
+    status = "in_progress";
+  }
+
+  return { status, completedAt };
 }
 
 function normalizeChecklist(input: any, nextActions: string[]): TenantProfileProjection["identity"]["documentChecklist"] {
@@ -504,4 +895,97 @@ export async function loadTenantApplicationReuseProjection(params: {
         }
       : null,
   };
+}
+
+export async function loadTenantIdentityRecord(params: {
+  context: TenancyContext;
+  userId: string;
+  userEmail?: string | null;
+}): Promise<TenantIdentityRecord> {
+  const { context, userEmail } = params;
+  const [profileProjection, reuseProjection, leaseSignals] = await Promise.all([
+    loadTenantProfileProjection(params),
+    loadTenantApplicationReuseProjection({ context, userEmail }),
+    loadTenantLeaseHistorySignals(context, userEmail),
+  ]);
+
+  const profileStatus = profileProjection.profile.displayName &&
+    profileProjection.profile.email &&
+    profileProjection.profile.phone
+      ? "complete"
+      : profileProjection.profile.displayName || profileProjection.profile.email || profileProjection.profile.phone
+      ? "in_progress"
+      : "missing";
+
+  const documentStatuses = profileProjection.identity.documentChecklist.map((entry) => entry.status);
+  const documentStatus =
+    documentStatuses.includes("needs_review")
+      ? "needs_attention"
+      : documentStatuses.includes("missing")
+      ? "missing"
+      : documentStatuses.includes("pending")
+      ? "in_progress"
+      : profileProjection.identity.documentChecklist.length
+      ? "complete"
+      : "missing";
+
+  const missingCategories = uniq(
+    profileProjection.identity.documentChecklist
+      .filter((entry) => entry.status === "missing")
+      .map((entry) => entry.label)
+  );
+
+  const applicationReusable = deriveReusableApplicationState(reuseProjection);
+  const screeningStatus = deriveScreeningStatusFromVisibleStatus(
+    profileProjection.identity.identityVerification.status
+  );
+
+  return deriveTenantIdentityRecordFromSignals({
+    profileStatus,
+    applicationReusable,
+    lastSubmittedAt:
+      profileProjection.profile.application?.status === "submitted"
+        ? profileProjection.profile.application?.updatedAt || profileProjection.profile.application?.createdAt || null
+        : null,
+    documentStatus,
+    missingCategories,
+    screeningStatus,
+    screeningCompletedAt:
+      screeningStatus === "completed"
+        ? profileProjection.identity.identityVerification.updatedAt
+        : null,
+    leaseSignals,
+  });
+}
+
+export async function loadLandlordSafeTenantIdentitySummary(params: {
+  applicationId: string;
+  application: any;
+}): Promise<TenantIdentitySummary> {
+  const profileStatus = deriveProfileCompletionStatusFromApplication(params.application);
+  const applicationReusable = deriveApplicationReusableFromApplication(params.application);
+  const documentSignals = deriveDocumentSignalsFromApplication(params.application);
+  const screeningSignals = deriveScreeningSignalsFromApplication(params.application);
+
+  const leaseSignals = {
+    activeCount: 0,
+    historicalCount: 0,
+    lastSignedAt: null,
+  };
+
+  const record = deriveTenantIdentityRecordFromSignals({
+    profileStatus,
+    applicationReusable,
+    lastSubmittedAt:
+      toIso(params.application?.submittedAt) ||
+      toIso(params.application?.updatedAt) ||
+      toIso(params.application?.createdAt),
+    documentStatus: documentSignals.completionStatus,
+    missingCategories: documentSignals.missingCategories,
+    screeningStatus: screeningSignals.status,
+    screeningCompletedAt: screeningSignals.completedAt,
+    leaseSignals,
+  });
+
+  return toLandlordSafeTenantIdentitySummary(record);
 }

--- a/rentchain-frontend/src/api/reviewSummaryApi.ts
+++ b/rentchain-frontend/src/api/reviewSummaryApi.ts
@@ -52,6 +52,14 @@ type ReviewSummaryCore = {
 export type ApplicationReviewSummary = ReviewSummaryCore & {
   decisionSummary?: ApplicationDecisionSummary | null;
   risk?: RiskAgentReviewSnapshot;
+  tenantIdentitySummary?: {
+    identityStatus: "incomplete" | "ready" | "verified" | "limited";
+    verification: {
+      level: "none" | "partial" | "strong";
+    };
+    readinessLabel: string;
+    readinessDescription: string;
+  } | null;
 };
 
 export class ReviewSummaryApiError extends Error {
@@ -96,6 +104,7 @@ export async function fetchReviewSummary(applicationId: string): Promise<Applica
       (res?.risk || null) as RiskAgentReviewSnapshot
     ),
     risk: ((res?.risk || null) as RiskAgentReviewSnapshot) || null,
+    tenantIdentitySummary: (res?.tenantIdentitySummary || null) as ApplicationReviewSummary["tenantIdentitySummary"],
   };
 }
 

--- a/rentchain-frontend/src/api/tenantPortal.ts
+++ b/rentchain-frontend/src/api/tenantPortal.ts
@@ -159,12 +159,42 @@ export type TenantWorkspaceMaintenance = {
   }>;
 };
 
+export type TenantIdentityRecord = {
+  identityStatus: "incomplete" | "ready" | "verified" | "limited";
+  profile: {
+    completionStatus: "complete" | "in_progress" | "missing" | "needs_attention";
+  };
+  application: {
+    reusable: boolean;
+    lastSubmittedAt: string | null;
+  };
+  documents: {
+    completionStatus: "complete" | "in_progress" | "missing" | "needs_attention";
+    missingCategories: string[];
+  };
+  screening: {
+    status: "not_started" | "in_progress" | "completed" | "needs_attention" | "blocked";
+    lastCompletedAt: string | null;
+  };
+  leases: {
+    activeCount: number;
+    historicalCount: number;
+    lastSignedAt: string | null;
+  };
+  verification: {
+    level: "none" | "partial" | "strong";
+  };
+  readinessLabel: string;
+  readinessDescription: string;
+};
+
 export type TenantWorkspaceSummary = {
   context: TenantWorkspaceContext;
   property: TenantWorkspaceProperty | null;
   application: TenantWorkspaceApplication | null;
   lease: TenantWorkspaceLease | null;
   maintenance: TenantWorkspaceMaintenance[];
+  tenantIdentityRecord?: TenantIdentityRecord | null;
 };
 
 export async function getTenantWorkspace(): Promise<TenantWorkspaceSummary> {

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -176,6 +176,17 @@ describe("tenant workspace frontend shell", () => {
       application: null,
       lease: null,
       maintenance: [],
+      tenantIdentityRecord: {
+        identityStatus: "ready",
+        profile: { completionStatus: "complete" },
+        application: { reusable: true, lastSubmittedAt: "2026-01-02T00:00:00.000Z" },
+        documents: { completionStatus: "in_progress", missingCategories: ["Income documents"] },
+        screening: { status: "in_progress", lastCompletedAt: null },
+        leases: { activeCount: 1, historicalCount: 0, lastSignedAt: "2026-02-01T10:00:00.000Z" },
+        verification: { level: "partial" },
+        readinessLabel: "Ready to apply",
+        readinessDescription: "Your core profile, reusable application details, and supporting records are ready for most rental workflows.",
+      },
     });
     tenantAttachmentsApi.getTenantAttachments.mockResolvedValue({
       ok: true,
@@ -360,6 +371,17 @@ describe("tenant workspace frontend shell", () => {
         documentUrl: null,
       },
       maintenance: [],
+      tenantIdentityRecord: {
+        identityStatus: "ready",
+        profile: { completionStatus: "complete" },
+        application: { reusable: true, lastSubmittedAt: "2026-01-02T00:00:00.000Z" },
+        documents: { completionStatus: "in_progress", missingCategories: ["Income documents"] },
+        screening: { status: "in_progress", lastCompletedAt: null },
+        leases: { activeCount: 1, historicalCount: 0, lastSignedAt: "2026-02-01T10:00:00.000Z" },
+        verification: { level: "partial" },
+        readinessLabel: "Ready to apply",
+        readinessDescription: "Your core profile, reusable application details, and supporting records are ready for most rental workflows.",
+      },
     });
 
     render(
@@ -375,6 +397,10 @@ describe("tenant workspace frontend shell", () => {
     expect(await screen.findByText(/Recent activity \/ notifications/i)).toBeInTheDocument();
     expect(screen.getByText(/Recent workflow updates/i)).toBeInTheDocument();
     expect(await screen.findByText(/Profile completion/i)).toBeInTheDocument();
+    expect(screen.getByText(/Your Rental Identity/i)).toBeInTheDocument();
+    expect(screen.getByText(/Ready to apply/i)).toBeInTheDocument();
+    expect(screen.getByText(/Missing pieces/i)).toBeInTheDocument();
+    expect(screen.getByText(/Income documents/i)).toBeInTheDocument();
     expect(screen.getByText(/Add missing details to keep your rental profile organized/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /View your profile/i })).toBeInTheDocument();
     expect(screen.queryByText(/^Applicant$/i)).not.toBeInTheDocument();

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
@@ -34,6 +34,52 @@ import { buildTenantStructuredNotificationTriggers } from "../structuredNotifica
 import { filterStructuredNotificationsByPreferences } from "../notificationChannelRouting";
 import { buildTenantScreeningDashboardSummary } from "./tenantScreeningInboxView";
 
+function prettyIdentityCompletionStatus(
+  value: "complete" | "in_progress" | "missing" | "needs_attention" | null | undefined
+) {
+  switch (value) {
+    case "complete":
+      return "Complete";
+    case "in_progress":
+      return "In progress";
+    case "needs_attention":
+      return "Needs attention";
+    case "missing":
+    default:
+      return "Missing";
+  }
+}
+
+function prettyVerificationLevel(value: "none" | "partial" | "strong" | null | undefined) {
+  switch (value) {
+    case "strong":
+      return "Strong";
+    case "partial":
+      return "Partial";
+    case "none":
+    default:
+      return "None";
+  }
+}
+
+function prettyScreeningIdentityStatus(
+  value: "not_started" | "in_progress" | "completed" | "needs_attention" | "blocked" | null | undefined
+) {
+  switch (value) {
+    case "completed":
+      return "Completed";
+    case "in_progress":
+      return "In progress";
+    case "needs_attention":
+      return "Needs attention";
+    case "blocked":
+      return "Blocked";
+    case "not_started":
+    default:
+      return "Not started";
+  }
+}
+
 export default function TenantWorkspacePage() {
   const [data, setData] = React.useState<Awaited<ReturnType<typeof getTenantWorkspace>> | null>(null);
   const [access, setAccess] = React.useState<TenantAccessWorkspace | null>(null);
@@ -164,6 +210,7 @@ export default function TenantWorkspacePage() {
     context: data?.context,
     lease: data?.lease,
   });
+  const tenantIdentityRecord = data?.tenantIdentityRecord || null;
   const communicationsView = buildTenantCommunicationsWorkspaceState(communications);
   const screeningSummary = buildTenantScreeningDashboardSummary(screenings);
   const notificationItems = filterStructuredNotificationsByPreferences(
@@ -321,6 +368,60 @@ export default function TenantWorkspacePage() {
           </div>
         </TenantInfoCard>
       )}
+
+      <TenantInfoCard heading="Your Rental Identity" accent="#0f766e">
+        {tenantIdentityRecord ? (
+          <div style={{ display: "grid", gap: spacing.sm }}>
+            <div style={{ display: "grid", gap: 4 }}>
+              <div style={{ fontSize: "1.05rem", fontWeight: 800, color: textTokens.primary }}>
+                {tenantIdentityRecord.readinessLabel}
+              </div>
+              <div style={{ color: textTokens.secondary, lineHeight: 1.6 }}>
+                {tenantIdentityRecord.readinessDescription}
+              </div>
+            </div>
+
+            <TenantKeyValueGrid
+              rows={[
+                { label: "Identity status", value: prettyStatus(tenantIdentityRecord.identityStatus) },
+                { label: "Verification level", value: prettyVerificationLevel(tenantIdentityRecord.verification.level) },
+                { label: "Profile", value: prettyIdentityCompletionStatus(tenantIdentityRecord.profile.completionStatus) },
+                { label: "Application reuse", value: tenantIdentityRecord.application.reusable ? "Ready" : "Still building" },
+                { label: "Documents", value: prettyIdentityCompletionStatus(tenantIdentityRecord.documents.completionStatus) },
+                { label: "Screening", value: prettyScreeningIdentityStatus(tenantIdentityRecord.screening.status) },
+                {
+                  label: "Lease history",
+                  value:
+                    tenantIdentityRecord.leases.activeCount > 0 || tenantIdentityRecord.leases.historicalCount > 0
+                      ? `${tenantIdentityRecord.leases.activeCount} active / ${tenantIdentityRecord.leases.historicalCount} historical`
+                      : "No lease history yet",
+                },
+              ]}
+            />
+
+            {tenantIdentityRecord.documents.missingCategories.length ? (
+              <div
+                style={{
+                  border: "1px solid rgba(15,23,42,0.08)",
+                  borderRadius: 12,
+                  padding: "12px 14px",
+                  display: "grid",
+                  gap: 6,
+                }}
+              >
+                <div style={{ fontWeight: 700, color: textTokens.primary }}>Missing pieces</div>
+                <div style={{ color: textTokens.secondary }}>
+                  {tenantIdentityRecord.documents.missingCategories.join(", ")}
+                </div>
+              </div>
+            ) : null}
+          </div>
+        ) : (
+          <div style={{ color: textTokens.secondary }}>
+            Your rental identity summary will appear here once enough tenant-safe records are available.
+          </div>
+        )}
+      </TenantInfoCard>
 
       <div
         style={{


### PR DESCRIPTION
This PR introduces Tenant Identity Record v1.

Includes:
- read-derived tenant identity record on /tenant/workspace
- tenant workspace Your Rental Identity card
- restricted landlord-safe tenantIdentitySummary on review-summary
- privacy-safe aggregation of profile, application reuse, documents, screening, and lease history
- focused backend/frontend test coverage

Guardrails preserved:
- no new collection
- no write path
- no scoring/ranking
- no tokenization/blockchain
- no external integrations
- no background automation
- no raw document/screening/signature exposure
- no landlord overexposure