### PR TITLE
feat: add tenant share package

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -119,6 +119,7 @@ import landlordAnalyticsBenchmarkingRoutes from "./routes/landlordAnalyticsBench
 import landlordPortfolioScoreRoutes from "./routes/landlordPortfolioScoreRoutes";
 import landlordPortfolioScoreSharingRoutes from "./routes/landlordPortfolioScoreSharingRoutes";
 import publicPortfolioScoreRoutes from "./routes/publicPortfolioScoreRoutes";
+import publicTenantShareRoutes from "./routes/publicTenantShareRoutes";
 import landlordActionRecommendationRoutes from "./routes/landlordActionRecommendationRoutes";
 import tenantFeedbackRoutes from "./routes/tenantFeedbackRoutes";
 import marketplaceContractorRoutes from "./routes/marketplaceContractorRoutes";
@@ -215,6 +216,7 @@ app.use("/api", routeSource("paymentsRoutes.ts"), paymentsRoutes);
 app.use("/api", routeSource("publicRoutes.ts"), publicRoutes);
 app.use("/api/public", routeSource("publicRoutes.ts"), publicRoutes);
 app.use("/api", routeSource("publicPortfolioScoreRoutes.ts"), publicPortfolioScoreRoutes);
+app.use("/api/public", routeSource("publicTenantShareRoutes.ts"), publicTenantShareRoutes);
 app.use("/api/public", routeSource("landlordInvitesPublicRoutes.ts"), landlordInvitesPublicRoutes);
 app.use("/api/public", routeSource("landlordInquiryRoutes.ts"), landlordInquiryPublicRoutes);
 app.use("/api/public", tenantHistorySharePublicRouter);

--- a/rentchain-api/src/routes/__tests__/publicTenantShareRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/publicTenantShareRoutes.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const readTenantSharePackageByToken = vi.fn();
+
+vi.mock("../../services/tenantPortal/tenantSharePackageService", () => ({
+  readTenantSharePackageByToken,
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const path = options.url;
+    const token = path.split("/").pop() || "";
+    const req: any = {
+      method: options.method,
+      url: path,
+      originalUrl: path,
+      path,
+      params: { token },
+      query: {},
+      headers: {},
+    };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("publicTenantShareRoutes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns a safe shared tenant identity package", async () => {
+    readTenantSharePackageByToken.mockResolvedValue({
+      identity: {
+        identityStatus: "ready",
+        verification: { level: "partial" },
+        readinessLabel: "Ready to apply",
+        readinessDescription: "Your core profile and supporting records are ready for most rental workflows.",
+      },
+      profile: { completionStatus: "complete" },
+      application: { reusable: true },
+      documents: { completionStatus: "in_progress" },
+      screening: { status: "in_progress" },
+      leases: { summary: { activeCount: 1, historicalCount: 0 } },
+      generatedAt: "2026-04-26T00:00:00.000Z",
+    });
+
+    const router = (await import("../publicTenantShareRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/share/share-token-1",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.identity?.identityStatus).toBe("ready");
+    expect(res.body?.data?.documents?.missingCategories).toBeUndefined();
+    expect(res.body?.data?.screening?.provider).toBeUndefined();
+  });
+
+  it("fails closed with 404 when the share package is unavailable", async () => {
+    readTenantSharePackageByToken.mockResolvedValue(null);
+    const router = (await import("../publicTenantShareRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/share/missing-token",
+    });
+
+    expect(res.status).toBe(404);
+    expect(res.body?.error).toBe("NOT_FOUND");
+  });
+});

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -496,6 +496,100 @@ describe("tenantPortalRoutes foundation", () => {
     expect(res.body?.lease?.tenantSignature?.drawnDataUrl).toBeUndefined();
   });
 
+  it("creates a tenant share package without persisting a raw token", async () => {
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/share-packages",
+      body: { expiresInDays: 7 },
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.shareUrl).toMatch(/\/share\//);
+    const shareDocs = Array.from(ensureCollection("tenantSharePackages").values());
+    expect(shareDocs).toHaveLength(1);
+    expect(shareDocs[0]?.tenantId).toBe("tenant-1");
+    expect(shareDocs[0]?.tokenHash).toBeTruthy();
+    expect(shareDocs[0]?.token).toBeUndefined();
+  });
+
+  it("lists only active tenant share packages", async () => {
+    ensureCollection("tenantSharePackages").set("share-1", {
+      id: "share-1",
+      tenantId: "tenant-1",
+      tokenHash: "hash-1",
+      createdAt: 100,
+      expiresAt: Date.now() + 10_000,
+      status: "active",
+    });
+    ensureCollection("tenantSharePackages").set("share-2", {
+      id: "share-2",
+      tenantId: "tenant-1",
+      tokenHash: "hash-2",
+      createdAt: 90,
+      expiresAt: Date.now() - 10_000,
+      status: "active",
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/share-packages",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data).toEqual([
+      expect.objectContaining({
+        id: "share-1",
+        status: "active",
+      }),
+    ]);
+  });
+
+  it("revokes a tenant share package immediately", async () => {
+    ensureCollection("tenantSharePackages").set("share-1", {
+      id: "share-1",
+      tenantId: "tenant-1",
+      tokenHash: "hash-1",
+      createdAt: 100,
+      expiresAt: Date.now() + 10_000,
+      status: "active",
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "DELETE",
+      url: "/share-packages/share-1",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(ensureCollection("tenantSharePackages").get("share-1")?.status).toBe("revoked");
+  });
+
   it("returns a grouped tenant-safe application completion checklist", async () => {
     const router = (await import("../tenantPortalRoutes")).default;
     const res = await invokeRouter(router, {

--- a/rentchain-api/src/routes/publicTenantShareRoutes.ts
+++ b/rentchain-api/src/routes/publicTenantShareRoutes.ts
@@ -1,0 +1,25 @@
+import { Router } from "express";
+import { readTenantSharePackageByToken } from "../services/tenantPortal/tenantSharePackageService";
+
+const router = Router();
+
+router.get("/share/:token", async (req: any, res) => {
+  try {
+    const token = String(req.params?.token || "").trim();
+    if (!token) {
+      return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+    }
+
+    const payload = await readTenantSharePackageByToken(token);
+    if (!payload) {
+      return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+    }
+
+    return res.json({ ok: true, data: payload });
+  } catch (err: any) {
+    console.error("[public-tenant-share] fetch failed", err?.message || err);
+    return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+  }
+});
+
+export default router;

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -29,6 +29,11 @@ import {
 } from "../lib/maintenanceNotifications";
 import { writeCanonicalEvent } from "../lib/events/buildEvent";
 import { adaptTenantSafeScreeningState } from "../services/screening/tenantScreeningStatusAdapter";
+import {
+  createTenantSharePackage,
+  listTenantSharePackages,
+  revokeTenantSharePackage,
+} from "../services/tenantPortal/tenantSharePackageService";
 
 const router = Router();
 router.use(authenticateJwt);
@@ -2936,6 +2941,77 @@ async function handleTenantWorkspaceSummary(req: any, res: any) {
 
 router.get("/workspace", requireTenantWorkspaceIdentity, handleTenantWorkspaceSummary);
 router.get("/me", requireTenantWorkspaceIdentity, handleTenantWorkspaceSummary);
+
+router.post("/share-packages", requireTenantWorkspaceIdentity, async (req: any, res) => {
+  const context = await resolveWorkspaceContextOrRespond(req, res);
+  if (!context) return;
+
+  const tenantId = String(req.user?.tenantId || context.tenantId || "").trim();
+  if (!tenantId) {
+    return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+  }
+
+  try {
+    const created = await createTenantSharePackage({
+      tenantId,
+      expiresInDays: req.body?.expiresInDays,
+    });
+    return res.json({ ok: true, data: created });
+  } catch (err: any) {
+    console.error("[tenant/share-packages:create] failed", {
+      tenantId,
+      message: err?.message || "failed",
+    });
+    return res.status(500).json({ ok: false, error: "TENANT_SHARE_PACKAGE_CREATE_FAILED" });
+  }
+});
+
+router.get("/share-packages", requireTenantWorkspaceIdentity, async (req: any, res) => {
+  const context = await resolveWorkspaceContextOrRespond(req, res);
+  if (!context) return;
+
+  const tenantId = String(req.user?.tenantId || context.tenantId || "").trim();
+  if (!tenantId) {
+    return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+  }
+
+  try {
+    const items = await listTenantSharePackages({ tenantId });
+    return res.json({ ok: true, data: items });
+  } catch (err: any) {
+    console.error("[tenant/share-packages:list] failed", {
+      tenantId,
+      message: err?.message || "failed",
+    });
+    return res.status(500).json({ ok: false, error: "TENANT_SHARE_PACKAGE_LIST_FAILED" });
+  }
+});
+
+router.delete("/share-packages/:id", requireTenantWorkspaceIdentity, async (req: any, res) => {
+  const context = await resolveWorkspaceContextOrRespond(req, res);
+  if (!context) return;
+
+  const tenantId = String(req.user?.tenantId || context.tenantId || "").trim();
+  const sharePackageId = String(req.params?.id || "").trim();
+  if (!tenantId || !sharePackageId) {
+    return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+  }
+
+  try {
+    const revoked = await revokeTenantSharePackage({ tenantId, sharePackageId });
+    if (!revoked) {
+      return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+    }
+    return res.json({ ok: true, data: { id: sharePackageId, status: "revoked" } });
+  } catch (err: any) {
+    console.error("[tenant/share-packages:revoke] failed", {
+      tenantId,
+      sharePackageId,
+      message: err?.message || "failed",
+    });
+    return res.status(500).json({ ok: false, error: "TENANT_SHARE_PACKAGE_REVOKE_FAILED" });
+  }
+});
 
 router.get("/notification-preferences", requireTenantWorkspaceIdentity, async (req: any, res) => {
   const userId = String(req.user?.id || "").trim();

--- a/rentchain-api/src/services/tenantPortal/__tests__/tenantSharePackageService.test.ts
+++ b/rentchain-api/src/services/tenantPortal/__tests__/tenantSharePackageService.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const collections = new Map<string, Map<string, any>>();
+let generatedId = 0;
+
+function ensureCollection(name: string) {
+  if (!collections.has(name)) collections.set(name, new Map());
+  return collections.get(name)!;
+}
+
+const dbMock = {
+  collection: (name: string) => ({
+    doc: (id?: string) => {
+      const resolvedId = id || `generated-${++generatedId}`;
+      return {
+        id: resolvedId,
+        async get() {
+          const entry = ensureCollection(name).get(resolvedId);
+          return {
+            id: resolvedId,
+            exists: Boolean(entry),
+            data: () => entry,
+          };
+        },
+        async set(payload: any, options?: { merge?: boolean }) {
+          const current = ensureCollection(name).get(resolvedId) || {};
+          ensureCollection(name).set(resolvedId, options?.merge ? { ...current, ...(payload || {}) } : payload || {});
+        },
+      };
+    },
+    where: (field: string, _op: string, value: any) => ({
+      limit: (_count: number) => ({
+        async get() {
+          const docs = Array.from(ensureCollection(name).entries())
+            .filter(([, data]) => data?.[field] === value)
+            .map(([id, data]) => ({
+              id,
+              data: () => data,
+            }));
+          return { docs, empty: docs.length === 0 };
+        },
+      }),
+      async get() {
+        const docs = Array.from(ensureCollection(name).entries())
+          .filter(([, data]) => data?.[field] === value)
+          .map(([id, data]) => ({
+            id,
+            data: () => data,
+          }));
+        return { docs, empty: docs.length === 0 };
+      },
+    }),
+  }),
+};
+
+const resolveTenancyContext = vi.fn();
+const loadTenantIdentityRecord = vi.fn();
+
+vi.mock("../../../config/firebase", () => ({ db: dbMock }));
+vi.mock("../tenancyContextService", () => ({ resolveTenancyContext }));
+vi.mock("../tenantProfileService", () => ({ loadTenantIdentityRecord }));
+
+describe("tenantSharePackageService", () => {
+  beforeEach(() => {
+    collections.clear();
+    generatedId = 0;
+    vi.clearAllMocks();
+    ensureCollection("tenants").set("tenant-1", {
+      email: "tenant@example.com",
+    });
+    resolveTenancyContext.mockResolvedValue({
+      ok: true,
+      authority: "active_tenant",
+      propertyId: "prop-1",
+      rc_prop_id: "rc-prop-1",
+      applicationId: "app-1",
+      leaseId: "lease-1",
+      tenantId: "tenant-1",
+      unitId: "unit-1",
+      invitedEmail: "tenant@example.com",
+    });
+    loadTenantIdentityRecord.mockResolvedValue({
+      identityStatus: "verified",
+      profile: { completionStatus: "complete" },
+      application: { reusable: true, lastSubmittedAt: "2026-04-20T00:00:00.000Z" },
+      documents: { completionStatus: "complete", missingCategories: ["Identity"] },
+      screening: { status: "completed", lastCompletedAt: "2026-04-21T00:00:00.000Z" },
+      leases: { activeCount: 1, historicalCount: 2, lastSignedAt: "2026-04-22T00:00:00.000Z" },
+      verification: { level: "strong" },
+      readinessLabel: "Well established",
+      readinessDescription: "Your rental identity includes completed verification signals and visible lease history.",
+    });
+  });
+
+  it("creates share packages without persisting raw tokens and keeps tokens unique", async () => {
+    const service = await import("../tenantSharePackageService");
+    const createdA = await service.createTenantSharePackage({ tenantId: "tenant-1" });
+    const createdB = await service.createTenantSharePackage({ tenantId: "tenant-1" });
+
+    expect(createdA.shareUrl).not.toEqual(createdB.shareUrl);
+    const docs = Array.from(ensureCollection("tenantSharePackages").values());
+    expect(docs).toHaveLength(2);
+    expect(docs.every((entry) => entry.tokenHash && !entry.token)).toBe(true);
+  });
+
+  it("derives a safe public payload at read time", async () => {
+    const service = await import("../tenantSharePackageService");
+    const created = await service.createTenantSharePackage({ tenantId: "tenant-1" });
+    const token = created.shareUrl.split("/share/")[1];
+
+    const payload = await service.readTenantSharePackageByToken(token);
+
+    expect(payload).toEqual(
+      expect.objectContaining({
+        identity: expect.objectContaining({
+          identityStatus: "verified",
+          verification: { level: "strong" },
+        }),
+        documents: { completionStatus: "complete" },
+        screening: { status: "completed" },
+      })
+    );
+    expect((payload as any)?.documents?.missingCategories).toBeUndefined();
+    expect((payload as any)?.screening?.provider).toBeUndefined();
+    expect((payload as any)?.leases?.summary?.lastSignedAt).toBeUndefined();
+  });
+
+  it("returns null for revoked or expired share packages", async () => {
+    const service = await import("../tenantSharePackageService");
+    const created = await service.createTenantSharePackage({ tenantId: "tenant-1" });
+    const token = created.shareUrl.split("/share/")[1];
+    const recordId = created.id;
+
+    await ensureCollection("tenantSharePackages").set(recordId, {
+      ...ensureCollection("tenantSharePackages").get(recordId),
+      status: "revoked",
+    });
+    expect(await service.readTenantSharePackageByToken(token)).toBeNull();
+
+    const created2 = await service.createTenantSharePackage({ tenantId: "tenant-1" });
+    const token2 = created2.shareUrl.split("/share/")[1];
+    const recordId2 = created2.id;
+    ensureCollection("tenantSharePackages").set(recordId2, {
+      ...ensureCollection("tenantSharePackages").get(recordId2),
+      expiresAt: Date.now() - 1000,
+    });
+    expect(await service.readTenantSharePackageByToken(token2)).toBeNull();
+  });
+});

--- a/rentchain-api/src/services/tenantPortal/tenantSharePackageService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantSharePackageService.ts
@@ -1,0 +1,234 @@
+import crypto from "crypto";
+import { db } from "../../config/firebase";
+import { loadTenantIdentityRecord, type TenantIdentityRecord } from "./tenantProfileService";
+import { resolveTenancyContext } from "./tenancyContextService";
+
+const COLLECTION = "tenantSharePackages";
+const DEFAULT_EXPIRES_DAYS = 7;
+const MAX_EXPIRES_DAYS = 30;
+
+export type TenantSharePackagePublicPayload = {
+  identity: {
+    identityStatus: TenantIdentityRecord["identityStatus"];
+    verification: {
+      level: TenantIdentityRecord["verification"]["level"];
+    };
+    readinessLabel: string;
+    readinessDescription: string;
+  };
+  profile: {
+    completionStatus: TenantIdentityRecord["profile"]["completionStatus"];
+  };
+  application: {
+    reusable: boolean;
+  };
+  documents: {
+    completionStatus: TenantIdentityRecord["documents"]["completionStatus"];
+  };
+  screening: {
+    status: TenantIdentityRecord["screening"]["status"];
+  };
+  leases: {
+    summary: {
+      activeCount: number;
+      historicalCount: number;
+    };
+  };
+  generatedAt: string;
+};
+
+export type TenantSharePackageRecord = {
+  id: string;
+  tenantId: string;
+  tokenHash: string;
+  createdAt: number;
+  expiresAt: number;
+  status: "active" | "revoked";
+  revokedAt?: number;
+};
+
+function asString(value: unknown): string | null {
+  const next = String(value || "").trim();
+  return next || null;
+}
+
+function hashToken(token: string) {
+  return crypto.createHash("sha256").update(token).digest("hex");
+}
+
+function nowMs() {
+  return Date.now();
+}
+
+function buildFrontendShareUrl(token: string) {
+  const base = String(process.env.PUBLIC_APP_URL || "").trim().replace(/\/$/, "");
+  const path = `/share/${encodeURIComponent(token)}`;
+  return base ? `${base}${path}` : path;
+}
+
+function clampExpiresInDays(value: unknown) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return DEFAULT_EXPIRES_DAYS;
+  return Math.min(Math.max(Math.round(numeric), 1), MAX_EXPIRES_DAYS);
+}
+
+function mapTenantIdentityToSharePackage(record: TenantIdentityRecord): TenantSharePackagePublicPayload {
+  return {
+    identity: {
+      identityStatus: record.identityStatus,
+      verification: {
+        level: record.verification.level,
+      },
+      readinessLabel: record.readinessLabel,
+      readinessDescription: record.readinessDescription,
+    },
+    profile: {
+      completionStatus: record.profile.completionStatus,
+    },
+    application: {
+      reusable: record.application.reusable,
+    },
+    documents: {
+      completionStatus: record.documents.completionStatus,
+    },
+    screening: {
+      status: record.screening.status,
+    },
+    leases: {
+      summary: {
+        activeCount: record.leases.activeCount,
+        historicalCount: record.leases.historicalCount,
+      },
+    },
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+async function loadTenantShareRecordByToken(token: string): Promise<TenantSharePackageRecord | null> {
+  const tokenHash = hashToken(token);
+  const snap = await db.collection(COLLECTION).where("tokenHash", "==", tokenHash).limit(1).get();
+  const doc = snap.docs?.[0];
+  if (!doc) return null;
+  return {
+    id: doc.id,
+    ...((doc.data() as any) || {}),
+  } as TenantSharePackageRecord;
+}
+
+async function resolveShareTenantIdentity(params: { tenantId: string }) {
+  const tenantId = asString(params.tenantId);
+  if (!tenantId) return null;
+
+  const tenantSnap = await db.collection("tenants").doc(tenantId).get().catch(() => null as any);
+  const tenantData = tenantSnap?.exists ? ((tenantSnap.data() as any) || {}) : {};
+  const email = asString(tenantData?.email);
+
+  const context = await resolveTenancyContext({
+    uid: tenantId,
+    email,
+    tenantId,
+    leaseId: asString(tenantData?.leaseId) || asString(tenantData?.currentLeaseId),
+  });
+
+  if (!context?.ok) return null;
+
+  return await loadTenantIdentityRecord({
+    context,
+    userId: tenantId,
+    userEmail: email,
+  });
+}
+
+export async function createTenantSharePackage(params: {
+  tenantId: string;
+  expiresInDays?: number;
+}) {
+  const tenantId = asString(params.tenantId);
+  if (!tenantId) {
+    throw new Error("tenant_id_required");
+  }
+
+  const createdAt = nowMs();
+  const expiresAt = createdAt + clampExpiresInDays(params.expiresInDays) * 24 * 60 * 60 * 1000;
+  const token = crypto.randomBytes(32).toString("hex");
+  const tokenHash = hashToken(token);
+  const ref = db.collection(COLLECTION).doc();
+
+  await ref.set({
+    id: ref.id,
+    tenantId,
+    tokenHash,
+    createdAt,
+    expiresAt,
+    status: "active",
+  } satisfies TenantSharePackageRecord);
+
+  return {
+    id: ref.id,
+    createdAt,
+    expiresAt,
+    status: "active" as const,
+    shareUrl: buildFrontendShareUrl(token),
+  };
+}
+
+export async function listTenantSharePackages(params: { tenantId: string }) {
+  const tenantId = asString(params.tenantId);
+  if (!tenantId) return [];
+
+  const snap = await db.collection(COLLECTION).where("tenantId", "==", tenantId).limit(50).get();
+  const now = nowMs();
+
+  return (snap.docs || [])
+    .map((doc: any) => ({ id: doc.id, ...((doc.data() as any) || {}) }))
+    .filter((entry: any) => entry.status === "active" && Number(entry.expiresAt || 0) > now)
+    .sort((left: any, right: any) => Number(right.createdAt || 0) - Number(left.createdAt || 0))
+    .map((entry: any) => ({
+      id: String(entry.id),
+      createdAt: Number(entry.createdAt || 0),
+      expiresAt: Number(entry.expiresAt || 0),
+      status: "active" as const,
+    }));
+}
+
+export async function revokeTenantSharePackage(params: {
+  tenantId: string;
+  sharePackageId: string;
+}) {
+  const tenantId = asString(params.tenantId);
+  const sharePackageId = asString(params.sharePackageId);
+  if (!tenantId || !sharePackageId) return false;
+
+  const ref = db.collection(COLLECTION).doc(sharePackageId);
+  const snap = await ref.get();
+  if (!snap.exists) return false;
+
+  const current = ((snap.data() as any) || {}) as TenantSharePackageRecord;
+  if (String(current.tenantId || "") !== tenantId) return false;
+
+  await ref.set(
+    {
+      status: "revoked",
+      revokedAt: nowMs(),
+    },
+    { merge: true }
+  );
+  return true;
+}
+
+export async function readTenantSharePackageByToken(
+  token: string
+): Promise<TenantSharePackagePublicPayload | null> {
+  const normalized = asString(token);
+  if (!normalized) return null;
+
+  const record = await loadTenantShareRecordByToken(normalized);
+  if (!record) return null;
+  if (record.status !== "active") return null;
+  if (Number(record.expiresAt || 0) <= nowMs()) return null;
+
+  const identity = await resolveShareTenantIdentity({ tenantId: record.tenantId });
+  if (!identity) return null;
+
+  return mapTenantIdentityToSharePackage(identity);
+}

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -115,6 +115,7 @@ const PortfolioHealthSummaryPage = lazy(() => import("./pages/landlord/Portfolio
 const LandlordAnalyticsPage = lazy(() => import("./pages/landlord/LandlordAnalyticsPage"));
 const LandlordPortfolioScorePage = lazy(() => import("./pages/landlord/PortfolioScorePage"));
 const SharedPortfolioScorePage = lazy(() => import("./pages/public/SharedPortfolioScorePage"));
+const TenantSharePackagePage = lazy(() => import("./pages/public/TenantSharePackagePage"));
 const ActionRecommendationsPage = lazy(() => import("./pages/landlord/ActionRecommendationsPage"));
 const InvitesPage = lazy(() => import("./pages/landlord/InvitesPage"));
 const MessagesPage = lazy(() => import("./pages/MessagesPage"));
@@ -1257,6 +1258,7 @@ function App() {
         ))}
         <Route path="/apply/:token" element={<PublicApplyPage />} />
         <Route path="/verify/:token" element={<VerifyScreeningPage />} />
+        <Route path="/share/:token" element={suspensePage(<TenantSharePackagePage />)} />
 
         <Route path="*" element={<NotFoundPage />} />
       </Routes>

--- a/rentchain-frontend/src/api/publicTenantSharePackageApi.ts
+++ b/rentchain-frontend/src/api/publicTenantSharePackageApi.ts
@@ -1,0 +1,43 @@
+import { apiFetch } from "./apiFetch";
+
+export type PublicTenantSharePackage = {
+  identity: {
+    identityStatus: "incomplete" | "ready" | "verified" | "limited";
+    verification: {
+      level: "none" | "partial" | "strong";
+    };
+    readinessLabel: string;
+    readinessDescription: string;
+  };
+  profile: {
+    completionStatus: "complete" | "in_progress" | "missing" | "needs_attention";
+  };
+  application: {
+    reusable: boolean;
+  };
+  documents: {
+    completionStatus: "complete" | "in_progress" | "missing" | "needs_attention";
+  };
+  screening: {
+    status: "not_started" | "in_progress" | "completed" | "needs_attention" | "blocked";
+  };
+  leases: {
+    summary: {
+      activeCount: number;
+      historicalCount: number;
+    };
+  };
+  generatedAt: string;
+};
+
+export async function fetchPublicTenantSharePackage(token: string): Promise<PublicTenantSharePackage | null> {
+  const res = await apiFetch<{ ok: boolean; data: PublicTenantSharePackage }>(
+    `/public/share/${encodeURIComponent(token)}`,
+    {
+      method: "GET",
+      allow404: true,
+      suppressToasts: true,
+    }
+  );
+  return res?.data ?? null;
+}

--- a/rentchain-frontend/src/api/tenantSharePackages.ts
+++ b/rentchain-frontend/src/api/tenantSharePackages.ts
@@ -1,0 +1,31 @@
+import { tenantApiFetch } from "./tenantApiFetch";
+
+export type TenantSharePackageLink = {
+  id: string;
+  createdAt: number;
+  expiresAt: number;
+  status: "active";
+};
+
+export type TenantSharePackageCreated = TenantSharePackageLink & {
+  shareUrl: string;
+};
+
+export async function createTenantSharePackage(expiresInDays = 7): Promise<TenantSharePackageCreated> {
+  const res = await tenantApiFetch<{ ok: boolean; data: TenantSharePackageCreated }>("/tenant/share-packages", {
+    method: "POST",
+    body: { expiresInDays },
+  });
+  return res.data;
+}
+
+export async function listTenantSharePackages(): Promise<TenantSharePackageLink[]> {
+  const res = await tenantApiFetch<{ ok: boolean; data: TenantSharePackageLink[] }>("/tenant/share-packages");
+  return Array.isArray(res?.data) ? res.data : [];
+}
+
+export async function revokeTenantSharePackage(id: string): Promise<void> {
+  await tenantApiFetch(`/tenant/share-packages/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+  });
+}

--- a/rentchain-frontend/src/pages/public/TenantSharePackagePage.test.tsx
+++ b/rentchain-frontend/src/pages/public/TenantSharePackagePage.test.tsx
@@ -1,0 +1,63 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import TenantSharePackagePage from "./TenantSharePackagePage";
+
+const publicTenantSharePackageApi = vi.hoisted(() => ({
+  fetchPublicTenantSharePackage: vi.fn(),
+}));
+
+vi.mock("../../api/publicTenantSharePackageApi", () => publicTenantSharePackageApi);
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/share/token-123"]}>
+      <Routes>
+        <Route path="/share/:token" element={<TenantSharePackagePage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe("TenantSharePackagePage", () => {
+  beforeEach(() => {
+    publicTenantSharePackageApi.fetchPublicTenantSharePackage.mockReset();
+  });
+
+  it("renders the shared tenant identity summary safely", async () => {
+    publicTenantSharePackageApi.fetchPublicTenantSharePackage.mockResolvedValue({
+      identity: {
+        identityStatus: "ready",
+        verification: { level: "partial" },
+        readinessLabel: "Ready to apply",
+        readinessDescription: "Your core profile and supporting records are ready for most rental workflows.",
+      },
+      profile: { completionStatus: "complete" },
+      application: { reusable: true },
+      documents: { completionStatus: "in_progress" },
+      screening: { status: "in_progress" },
+      leases: { summary: { activeCount: 1, historicalCount: 0 } },
+      generatedAt: "2026-04-26T00:00:00.000Z",
+    });
+
+    renderPage();
+
+    expect(await screen.findByText(/Shared Rental Profile/i)).toBeInTheDocument();
+    expect(screen.getByText(/Ready to apply/i)).toBeInTheDocument();
+    expect(screen.getByText(/^Verification$/i)).toBeInTheDocument();
+    expect(screen.queryByText(/TransUnion/i)).not.toBeInTheDocument();
+  });
+
+  it("shows an unavailable state for missing share packages", async () => {
+    publicTenantSharePackageApi.fetchPublicTenantSharePackage.mockResolvedValue(null);
+
+    renderPage();
+
+    expect(await screen.findByText(/This shared rental profile is unavailable/i)).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/public/TenantSharePackagePage.tsx
+++ b/rentchain-frontend/src/pages/public/TenantSharePackagePage.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { useParams } from "react-router-dom";
+import { fetchPublicTenantSharePackage } from "../../api/publicTenantSharePackageApi";
+
+function prettyStatus(value: string | null | undefined) {
+  return String(value || "")
+    .replace(/[_-]+/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+export default function TenantSharePackagePage() {
+  const { token = "" } = useParams();
+  const [data, setData] = React.useState<Awaited<ReturnType<typeof fetchPublicTenantSharePackage>> | null>(null);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const result = await fetchPublicTenantSharePackage(token);
+        if (!mounted) return;
+        if (!result) {
+          setError("This shared rental profile is unavailable.");
+          setData(null);
+          return;
+        }
+        setData(result);
+      } catch (err: any) {
+        if (!mounted) return;
+        setError(err?.message || "This shared rental profile is unavailable.");
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [token]);
+
+  return (
+    <div style={{ minHeight: "100vh", background: "linear-gradient(180deg, #f8fafc 0%, #eef2ff 100%)", padding: 24 }}>
+      <div style={{ maxWidth: 860, margin: "0 auto", display: "grid", gap: 16 }}>
+        <div style={{ display: "grid", gap: 6 }}>
+          <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Shared Rental Profile</h1>
+          <div style={{ color: "#475569" }}>
+            A tenant-approved summary of rental readiness and verification signals.
+          </div>
+        </div>
+
+        {loading ? (
+          <div style={{ border: "1px solid rgba(15,23,42,0.08)", borderRadius: 16, background: "#fff", padding: 18 }}>
+            Loading shared rental profile…
+          </div>
+        ) : null}
+
+        {!loading && error ? (
+          <div style={{ border: "1px solid rgba(15,23,42,0.08)", borderRadius: 16, background: "#fff", padding: 18, color: "#b91c1c" }}>
+            {error}
+          </div>
+        ) : null}
+
+        {!loading && !error && data ? (
+          <div style={{ display: "grid", gap: 16 }}>
+            <div style={{ border: "1px solid rgba(15,23,42,0.08)", borderRadius: 16, background: "#fff", padding: 18, display: "grid", gap: 8 }}>
+              <div style={{ fontSize: "1.1rem", fontWeight: 800, color: "#0f172a" }}>{data.identity.readinessLabel}</div>
+              <div style={{ color: "#475569", lineHeight: 1.6 }}>{data.identity.readinessDescription}</div>
+            </div>
+
+            <div style={{ border: "1px solid rgba(15,23,42,0.08)", borderRadius: 16, background: "#fff", padding: 18 }}>
+              <div style={{ fontWeight: 800, color: "#0f172a", marginBottom: 12 }}>Summary</div>
+              <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 12 }}>
+                {[
+                  ["Identity status", prettyStatus(data.identity.identityStatus)],
+                  ["Verification", prettyStatus(data.identity.verification.level)],
+                  ["Profile", prettyStatus(data.profile.completionStatus)],
+                  ["Application reuse", data.application.reusable ? "Ready" : "Still building"],
+                  ["Documents", prettyStatus(data.documents.completionStatus)],
+                  ["Screening", prettyStatus(data.screening.status)],
+                  ["Active leases", String(data.leases.summary.activeCount)],
+                  ["Lease history", String(data.leases.summary.historicalCount)],
+                ].map(([label, value]) => (
+                  <div key={label} style={{ border: "1px solid rgba(15,23,42,0.08)", borderRadius: 12, padding: "12px 14px", display: "grid", gap: 4 }}>
+                    <div style={{ color: "#64748b", fontSize: "0.85rem" }}>{label}</div>
+                    <div style={{ color: "#0f172a", fontWeight: 700 }}>{value}</div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import TenantWorkspacePage from "./TenantWorkspacePage";
 import TenantApplicationStatusPage from "./TenantApplicationStatusPage";
@@ -49,6 +49,12 @@ const tenantScreeningApi = vi.hoisted(() => ({
   listTenantScreenings: vi.fn(),
 }));
 
+const tenantSharePackagesApi = vi.hoisted(() => ({
+  createTenantSharePackage: vi.fn(),
+  listTenantSharePackages: vi.fn(),
+  revokeTenantSharePackage: vi.fn(),
+}));
+
 vi.mock("../../api/tenantPortal", () => tenantPortalApi);
 vi.mock("../../api/tenantApplicationCompletion", () => tenantApplicationCompletionApi);
 vi.mock("../../api/tenantAccess", () => tenantAccessApi);
@@ -63,6 +69,7 @@ vi.mock("../../api/tenantScreeningApi", async () => {
     listTenantScreenings: tenantScreeningApi.listTenantScreenings,
   };
 });
+vi.mock("../../api/tenantSharePackages", () => tenantSharePackagesApi);
 vi.mock("../../api/maintenanceWorkflowApi", async () => {
   const actual = await vi.importActual<any>("../../api/maintenanceWorkflowApi");
   return {
@@ -300,6 +307,20 @@ describe("tenant workspace frontend shell", () => {
       },
       updatedAt: 1710000000000,
     });
+    tenantSharePackagesApi.listTenantSharePackages.mockResolvedValue([]);
+    tenantSharePackagesApi.createTenantSharePackage.mockResolvedValue({
+      id: "share-1",
+      createdAt: 1710000000000,
+      expiresAt: 1710600000000,
+      status: "active",
+      shareUrl: "https://app.example/share/share-token-1",
+    });
+    tenantSharePackagesApi.revokeTenantSharePackage.mockResolvedValue(undefined);
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
   });
 
   it("tenant shell renders expected navigation safely", async () => {
@@ -397,10 +418,11 @@ describe("tenant workspace frontend shell", () => {
     expect(await screen.findByText(/Recent activity \/ notifications/i)).toBeInTheDocument();
     expect(screen.getByText(/Recent workflow updates/i)).toBeInTheDocument();
     expect(await screen.findByText(/Profile completion/i)).toBeInTheDocument();
-    expect(screen.getByText(/Your Rental Identity/i)).toBeInTheDocument();
+    expect(screen.getByText(/^Your Rental Identity$/i)).toBeInTheDocument();
     expect(screen.getByText(/Ready to apply/i)).toBeInTheDocument();
     expect(screen.getByText(/Missing pieces/i)).toBeInTheDocument();
     expect(screen.getByText(/Income documents/i)).toBeInTheDocument();
+    expect(screen.getByText(/Share Your Rental Profile/i)).toBeInTheDocument();
     expect(screen.getByText(/Add missing details to keep your rental profile organized/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /View your profile/i })).toBeInTheDocument();
     expect(screen.queryByText(/^Applicant$/i)).not.toBeInTheDocument();
@@ -420,6 +442,40 @@ describe("tenant workspace frontend shell", () => {
     expect(screen.getAllByText(/No action needed/i).length).toBeGreaterThan(0);
     expect(screen.getByRole("link", { name: /Open document vault/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Open access/i })).toBeInTheDocument();
+  });
+
+  it("lets tenants generate, copy, and revoke share links", async () => {
+    tenantSharePackagesApi.listTenantSharePackages
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          id: "share-1",
+          createdAt: 1710000000000,
+          expiresAt: 1710600000000,
+          status: "active",
+        },
+      ]);
+
+    render(
+      <MemoryRouter>
+        <TenantWorkspacePage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Share Your Rental Profile/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Generate share link/i }));
+
+    expect(await screen.findByTestId("fresh-share-url")).toHaveTextContent("https://app.example/share/share-token-1");
+    expect(tenantSharePackagesApi.createTenantSharePackage).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: /Copy latest link/i }));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("https://app.example/share/share-token-1");
+
+    fireEvent.click(screen.getByRole("button", { name: /Revoke link/i }));
+    await waitFor(() => {
+      expect(tenantSharePackagesApi.revokeTenantSharePackage).toHaveBeenCalledWith("share-1");
+    });
   });
 
   it("shows an active-tenancy transition state when tenant access is active but the lease is not active yet", async () => {

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
@@ -9,6 +9,12 @@ import { getTenantNotificationPreferences } from "../../api/tenantNotificationPr
 import { getTenantCommunicationsWorkspace } from "../../api/tenantCommunicationsApi";
 import { listTenantScreenings, type TenantScreeningRequest } from "../../api/tenantScreeningApi";
 import {
+  createTenantSharePackage,
+  listTenantSharePackages,
+  revokeTenantSharePackage,
+  type TenantSharePackageLink,
+} from "../../api/tenantSharePackages";
+import {
   TenantEmptyState,
   TenantErrorState,
   TenantInfoCard,
@@ -89,6 +95,10 @@ export default function TenantWorkspacePage() {
   const [notificationPreferences, setNotificationPreferences] = React.useState<Awaited<ReturnType<typeof getTenantNotificationPreferences>> | null>(null);
   const [communications, setCommunications] = React.useState<Awaited<ReturnType<typeof getTenantCommunicationsWorkspace>> | null>(null);
   const [screenings, setScreenings] = React.useState<TenantScreeningRequest[]>([]);
+  const [sharePackages, setSharePackages] = React.useState<TenantSharePackageLink[]>([]);
+  const [freshShareUrl, setFreshShareUrl] = React.useState<string | null>(null);
+  const [shareBusy, setShareBusy] = React.useState(false);
+  const [shareError, setShareError] = React.useState<string | null>(null);
   const [profileLoading, setProfileLoading] = React.useState(true);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
@@ -97,7 +107,7 @@ export default function TenantWorkspacePage() {
     setLoading(true);
     setError(null);
     try {
-      const [workspaceResult, accessResult, attachmentsResult, completionResult, preferencesResult, communicationsResult, screeningsResult] = await Promise.allSettled([
+      const [workspaceResult, accessResult, attachmentsResult, completionResult, preferencesResult, communicationsResult, screeningsResult, sharePackagesResult] = await Promise.allSettled([
         getTenantWorkspace(),
         getTenantAccess(),
         getTenantAttachments(),
@@ -105,6 +115,7 @@ export default function TenantWorkspacePage() {
         getTenantNotificationPreferences(),
         getTenantCommunicationsWorkspace(),
         listTenantScreenings(),
+        listTenantSharePackages(),
       ]);
 
       if (workspaceResult.status === "rejected") {
@@ -122,6 +133,7 @@ export default function TenantWorkspacePage() {
           ? (screeningsResult.value as any).items
           : [],
       );
+      setSharePackages(sharePackagesResult.status === "fulfilled" ? sharePackagesResult.value : []);
     } catch (err: any) {
       setData(null);
       setAccess(null);
@@ -130,6 +142,7 @@ export default function TenantWorkspacePage() {
       setNotificationPreferences(null);
       setCommunications(null);
       setScreenings([]);
+      setSharePackages([]);
       setError(err?.payload?.error || err?.message || "Unable to load your tenant workspace.");
     } finally {
       setLoading(false);
@@ -163,6 +176,43 @@ export default function TenantWorkspacePage() {
     return () => {
       cancelled = true;
     };
+  }, []);
+
+  const handleGenerateShareLink = React.useCallback(async () => {
+    try {
+      setShareBusy(true);
+      setShareError(null);
+      const created = await createTenantSharePackage();
+      setFreshShareUrl(created.shareUrl);
+      const next = await listTenantSharePackages();
+      setSharePackages(next);
+    } catch (err: any) {
+      setShareError(err?.payload?.error || err?.message || "Unable to create a share link right now.");
+    } finally {
+      setShareBusy(false);
+    }
+  }, []);
+
+  const handleCopyShareLink = React.useCallback(async () => {
+    if (!freshShareUrl) return;
+    try {
+      await navigator.clipboard.writeText(freshShareUrl);
+    } catch {
+      setShareError("Copy is unavailable in this browser right now.");
+    }
+  }, [freshShareUrl]);
+
+  const handleRevokeShareLink = React.useCallback(async (id: string) => {
+    try {
+      setShareBusy(true);
+      setShareError(null);
+      await revokeTenantSharePackage(id);
+      setSharePackages((current) => current.filter((entry) => entry.id !== id));
+    } catch (err: any) {
+      setShareError(err?.payload?.error || err?.message || "Unable to revoke this share link right now.");
+    } finally {
+      setShareBusy(false);
+    }
   }, []);
 
   if (loading) {
@@ -421,6 +471,66 @@ export default function TenantWorkspacePage() {
             Your rental identity summary will appear here once enough tenant-safe records are available.
           </div>
         )}
+      </TenantInfoCard>
+
+      <TenantInfoCard heading="Share Your Rental Profile" accent="#1d4ed8">
+        <div style={{ display: "grid", gap: spacing.sm }}>
+          <div style={{ color: textTokens.secondary, lineHeight: 1.6 }}>
+            Generate a privacy-safe share link with your rental identity summary. The public view stays read-only and never exposes raw documents, screening provider details, or signature data.
+          </div>
+
+          <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
+            <button type="button" onClick={() => void handleGenerateShareLink()} disabled={shareBusy}>
+              {shareBusy ? "Generating..." : "Generate share link"}
+            </button>
+            {freshShareUrl ? (
+              <button type="button" onClick={() => void handleCopyShareLink()}>
+                Copy latest link
+              </button>
+            ) : null}
+          </div>
+
+          {freshShareUrl ? (
+            <div style={{ color: textTokens.secondary }} data-testid="fresh-share-url">
+              Latest link: {freshShareUrl}
+            </div>
+          ) : null}
+
+          {shareError ? (
+            <div style={{ color: "#b91c1c" }}>{shareError}</div>
+          ) : null}
+
+          <div style={{ display: "grid", gap: 8 }}>
+            <div style={{ fontWeight: 700, color: textTokens.primary }}>Active share links</div>
+            {sharePackages.length ? (
+              sharePackages.map((entry) => (
+                <div
+                  key={entry.id}
+                  style={{
+                    border: "1px solid rgba(15,23,42,0.08)",
+                    borderRadius: 12,
+                    padding: "12px 14px",
+                    display: "grid",
+                    gap: 8,
+                  }}
+                >
+                  <div style={{ color: textTokens.secondary }}>
+                    Created {formatDate(entry.createdAt)} • Expires {formatDate(entry.expiresAt)}
+                  </div>
+                  <div>
+                    <button type="button" onClick={() => void handleRevokeShareLink(entry.id)} disabled={shareBusy}>
+                      Revoke link
+                    </button>
+                  </div>
+                </div>
+              ))
+            ) : (
+              <div style={{ color: textTokens.secondary }}>
+                No active share links yet.
+              </div>
+            )}
+          </div>
+        </div>
       </TenantInfoCard>
 
       <div


### PR DESCRIPTION
This PR introduces Tenant Share Package v1.

Includes:
- tenant-controlled share package generation
- hashed token storage with no raw token persistence
- revocable and expiring share links
- summary-only public share package derived from current Tenant Identity Record
- tenant workspace share management UI
- public read-only /share/:token page
- focused backend/frontend test coverage

Guardrails preserved:
- no raw document exposure
- no provider data exposure
- no screening detail exposure
- no lease/signature timestamp exposure
- no derived payload persistence
- no analytics/view tracking
- no email sending
- no landlord account linkage
- public token access fails closed with 404

Verification note:
- the broad backend src/routes suite still has unrelated pre-existing failures in applicationReminderInternalRoutes.test.ts and rentalApplicationsMockCheckoutOverride.test.ts
- focused mission tests, backend typecheck, tenant/public frontend tests, and frontend build passed