### PR TITLE
feat: enrich landlord decisions with trust context

### DIFF
--- a/rentchain-api/src/lib/analytics/analyticsTypes.ts
+++ b/rentchain-api/src/lib/analytics/analyticsTypes.ts
@@ -10,6 +10,7 @@ import type {
   ScreeningCheckoutExecutionInputMissingField,
 } from "../screeningCheckoutReadiness";
 import type { ScreeningReconciliationStatus } from "../reconciliation/reconciliationTypes";
+import type { LandlordTrustContext } from "../trust/deriveLandlordTrustContext";
 
 export type AdminAnalyticsPeriod = "30d" | "90d" | "365d" | "month_to_date";
 export type AdminAnalyticsGranularity = "daily" | "weekly" | "monthly";
@@ -381,6 +382,7 @@ export type LandlordAgentDecision = {
   executionOutcomeStatus: LandlordDecisionExecutionOutcomeStatus;
   executionOutcomeAt: string | null;
   executionOutcomeReason: string | null;
+  trustContext?: LandlordTrustContext | null;
 };
 
 export type LandlordAgentDecisions = {

--- a/rentchain-api/src/lib/trust/__tests__/deriveLandlordTrustContext.test.ts
+++ b/rentchain-api/src/lib/trust/__tests__/deriveLandlordTrustContext.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { deriveLandlordTrustContext } from "../deriveLandlordTrustContext";
+
+describe("deriveLandlordTrustContext", () => {
+  it("derives strong trust context from complete safe signals", () => {
+    const result = deriveLandlordTrustContext({
+      tenantIdentitySummary: {
+        identityStatus: "verified",
+        verification: { level: "strong" },
+        readinessLabel: "Well established",
+        readinessDescription: "Supporting records are strong.",
+      },
+      completenessScore: 0.92,
+      completenessFlags: [],
+      screeningStatus: "completed",
+      applicationReusable: true,
+    });
+
+    expect(result.trustReadiness).toBe("strong");
+    expect(result.recommendedNextAction).toBe("prepare_lease");
+    expect(result.positiveSignals).toContain("Application information is mostly complete.");
+    expect(result.positiveSignals).toContain("Screening status is available as a normalized signal.");
+  });
+
+  it("fails closed to limited when major signals are missing", () => {
+    const result = deriveLandlordTrustContext({
+      tenantIdentitySummary: {
+        identityStatus: "limited",
+        verification: { level: "none" },
+        readinessLabel: "Getting started",
+        readinessDescription: "Signals are still limited.",
+      },
+      completenessScore: 0.3,
+      completenessFlags: ["MISSING_EMPLOYER_NAME", "MISSING_SIGNATURE"],
+      screeningStatus: "not_run",
+      applicationReusable: false,
+    });
+
+    expect(result.trustReadiness).toBe("limited");
+    expect(result.recommendedNextAction).toBe("request_missing_info");
+    expect(result.missingSignals).toContain("Employment or income details are still incomplete.");
+    expect(result.cautionSignals.some((item) => item.toLowerCase().includes("consent or identity"))).toBe(true);
+  });
+});

--- a/rentchain-api/src/lib/trust/deriveLandlordTrustContext.ts
+++ b/rentchain-api/src/lib/trust/deriveLandlordTrustContext.ts
@@ -1,0 +1,246 @@
+import type { TenantIdentitySummary } from "../../services/tenantPortal/tenantProfileService";
+
+export type LandlordTrustReadiness = "limited" | "emerging" | "ready" | "strong";
+export type LandlordTrustRecommendedNextAction =
+  | "review_application"
+  | "request_missing_info"
+  | "review_screening_status"
+  | "review_documents"
+  | "prepare_lease"
+  | "no_action";
+export type LandlordTrustDecisionSupportLevel = "low" | "medium" | "high";
+
+export type LandlordTrustContext = {
+  trustReadiness: LandlordTrustReadiness;
+  trustLabel: string;
+  trustDescription: string;
+  positiveSignals: string[];
+  missingSignals: string[];
+  cautionSignals: string[];
+  recommendedNextAction: LandlordTrustRecommendedNextAction;
+  decisionSupportLevel: LandlordTrustDecisionSupportLevel;
+};
+
+type Input = {
+  tenantIdentitySummary: TenantIdentitySummary | null;
+  completenessScore: number | null;
+  completenessFlags: string[];
+  screeningStatus: string | null | undefined;
+  applicationReusable?: boolean | null;
+};
+
+function unique(items: string[]) {
+  return Array.from(new Set(items.filter(Boolean)));
+}
+
+function normalizeScreeningStatus(value: string | null | undefined) {
+  return String(value || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_");
+}
+
+function isScreeningComplete(status: string) {
+  return status === "complete" || status === "completed" || status === "paid";
+}
+
+function isScreeningPending(status: string) {
+  return [
+    "not_run",
+    "not_started",
+    "pending",
+    "in_progress",
+    "external_pending",
+    "unpaid",
+    "consent_pending",
+  ].includes(status);
+}
+
+function groupMissingFlags(flags: string[]) {
+  const missingSignals: string[] = [];
+  const cautionSignals: string[] = [];
+
+  const hasAddressGap = flags.some(
+    (flag) =>
+      flag.startsWith("MISSING_CURRENT_ADDRESS_") ||
+      flag === "MISSING_TIME_AT_ADDRESS" ||
+      flag === "MISSING_CURRENT_RENT",
+  );
+  const hasEmploymentGap = flags.some((flag) =>
+    ["MISSING_EMPLOYER_NAME", "MISSING_JOB_TITLE", "MISSING_INCOME", "MISSING_MONTHS_AT_JOB"].includes(flag),
+  );
+  const hasReferenceGap = flags.some((flag) =>
+    ["MISSING_WORK_REFERENCE_NAME", "MISSING_WORK_REFERENCE_PHONE"].includes(flag),
+  );
+  const hasConsentGap = flags.some((flag) =>
+    ["MISSING_SIGNATURE", "MISSING_APPLICATION_CONSENT"].includes(flag),
+  );
+
+  if (hasAddressGap) {
+    missingSignals.push("Rental history details are still incomplete.");
+  }
+  if (hasEmploymentGap) {
+    missingSignals.push("Employment or income details are still incomplete.");
+  }
+  if (hasReferenceGap) {
+    missingSignals.push("Supporting reference details are still incomplete.");
+  }
+  if (hasConsentGap) {
+    cautionSignals.push("Consent or identity confirmation is still limited in the current review package.");
+  }
+
+  return {
+    missingSignals,
+    cautionSignals,
+  };
+}
+
+function deriveRecommendedNextAction(params: {
+  trustReadiness: LandlordTrustReadiness;
+  missingSignals: string[];
+  cautionSignals: string[];
+  screeningStatus: string;
+  verificationLevel: TenantIdentitySummary["verification"]["level"] | null;
+}) {
+  const { trustReadiness, missingSignals, cautionSignals, screeningStatus, verificationLevel } = params;
+
+  if (missingSignals.length > 0) return "request_missing_info" as const;
+  if (isScreeningPending(screeningStatus)) return "review_screening_status" as const;
+  if (verificationLevel === "none" || cautionSignals.some((item) => item.toLowerCase().includes("supporting records"))) {
+    return "review_documents" as const;
+  }
+  if (trustReadiness === "strong" && isScreeningComplete(screeningStatus)) return "prepare_lease" as const;
+  if (trustReadiness === "limited") return "request_missing_info" as const;
+  if (trustReadiness === "emerging") return "review_application" as const;
+  if (trustReadiness === "ready") return "review_application" as const;
+  return "no_action" as const;
+}
+
+function deriveCopy(params: {
+  trustReadiness: LandlordTrustReadiness;
+  recommendedNextAction: LandlordTrustRecommendedNextAction;
+}) {
+  const { trustReadiness, recommendedNextAction } = params;
+
+  if (trustReadiness === "strong") {
+    return {
+      trustLabel: "Strong supporting context",
+      trustDescription:
+        recommendedNextAction === "prepare_lease"
+          ? "Application information and supporting identity signals are well organized for the landlord’s next review step."
+          : "Supporting identity and application signals are well organized in the current review package.",
+      decisionSupportLevel: "high" as LandlordTrustDecisionSupportLevel,
+    };
+  }
+
+  if (trustReadiness === "ready") {
+    return {
+      trustLabel: "Ready for review",
+      trustDescription:
+        "Application information appears organized enough for review, with only limited follow-up signals still visible.",
+      decisionSupportLevel: "medium" as LandlordTrustDecisionSupportLevel,
+    };
+  }
+
+  if (trustReadiness === "emerging") {
+    return {
+      trustLabel: "Emerging supporting signals",
+      trustDescription:
+        "Some useful identity and application signals are available, but the file still benefits from a closer landlord review.",
+      decisionSupportLevel: "medium" as LandlordTrustDecisionSupportLevel,
+    };
+  }
+
+  return {
+    trustLabel: "Limited supporting signals",
+    trustDescription:
+      "The current review package still has limited supporting context, so follow-up is advisable before the next landlord step.",
+    decisionSupportLevel: "low" as LandlordTrustDecisionSupportLevel,
+  };
+}
+
+export function deriveLandlordTrustContext(input: Input): LandlordTrustContext {
+  const tenantIdentitySummary = input.tenantIdentitySummary || null;
+  const completenessScore =
+    typeof input.completenessScore === "number" && Number.isFinite(input.completenessScore)
+      ? input.completenessScore
+      : 0;
+  const completenessFlags = Array.isArray(input.completenessFlags) ? input.completenessFlags : [];
+  const screeningStatus = normalizeScreeningStatus(input.screeningStatus);
+  const applicationReusable = input.applicationReusable === true;
+  const identityStatus = tenantIdentitySummary?.identityStatus || "limited";
+  const verificationLevel = tenantIdentitySummary?.verification?.level || "none";
+
+  const groupedFlags = groupMissingFlags(completenessFlags);
+  const positiveSignals: string[] = [];
+  const cautionSignals = [...groupedFlags.cautionSignals];
+
+  if (identityStatus === "ready" || identityStatus === "verified") {
+    positiveSignals.push("Identity profile is organized for landlord review.");
+  }
+  if (verificationLevel === "partial" || verificationLevel === "strong") {
+    positiveSignals.push("Identity profile has stronger supporting signals.");
+  }
+  if (applicationReusable) {
+    positiveSignals.push("Application information is reusable and mostly organized.");
+  }
+  if (completenessScore >= 0.8) {
+    positiveSignals.push("Application information is mostly complete.");
+  }
+  if (isScreeningComplete(screeningStatus)) {
+    positiveSignals.push("Screening status is available as a normalized signal.");
+  } else if (isScreeningPending(screeningStatus)) {
+    cautionSignals.push("Screening is not complete yet in the current normalized status view.");
+  }
+  if (verificationLevel === "none") {
+    cautionSignals.push("Supporting records are still limited in the current review package.");
+  }
+
+  let trustReadiness: LandlordTrustReadiness = "limited";
+  if (
+    (identityStatus === "verified" || identityStatus === "ready") &&
+    verificationLevel === "strong" &&
+    applicationReusable &&
+    completenessScore >= 0.85 &&
+    isScreeningComplete(screeningStatus)
+  ) {
+    trustReadiness = "strong";
+  } else if (
+    (identityStatus === "ready" || identityStatus === "verified") &&
+    completenessScore >= 0.75 &&
+    groupedFlags.missingSignals.length === 0
+  ) {
+    trustReadiness = "ready";
+  } else if (
+    identityStatus !== "limited" ||
+    verificationLevel !== "none" ||
+    completenessScore >= 0.45 ||
+    applicationReusable
+  ) {
+    trustReadiness = "emerging";
+  }
+
+  const recommendedNextAction = deriveRecommendedNextAction({
+    trustReadiness,
+    missingSignals: groupedFlags.missingSignals,
+    cautionSignals,
+    screeningStatus,
+    verificationLevel,
+  });
+
+  const copy = deriveCopy({
+    trustReadiness,
+    recommendedNextAction,
+  });
+
+  return {
+    trustReadiness,
+    trustLabel: copy.trustLabel,
+    trustDescription: copy.trustDescription,
+    positiveSignals: unique(positiveSignals),
+    missingSignals: unique(groupedFlags.missingSignals),
+    cautionSignals: unique(cautionSignals),
+    recommendedNextAction,
+    decisionSupportLevel: copy.decisionSupportLevel,
+  };
+}

--- a/rentchain-api/src/routes/__tests__/landlordAnalyticsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordAnalyticsRoutes.test.ts
@@ -461,6 +461,16 @@ describe("landlordAnalyticsRoutes", () => {
             href: "/analytics",
             state: "pending",
             reviewedAt: null,
+            trustContext: {
+              trustReadiness: "emerging",
+              trustLabel: "Emerging supporting signals",
+              trustDescription: "Some useful identity and application signals are available, but the file still benefits from a closer landlord review.",
+              positiveSignals: ["Application information is mostly complete."],
+              missingSignals: [],
+              cautionSignals: ["Supporting records are still limited in the current review package."],
+              recommendedNextAction: "review_application",
+              decisionSupportLevel: "medium",
+            },
           },
         ],
       },
@@ -588,6 +598,12 @@ describe("landlordAnalyticsRoutes", () => {
     expect(response.body.decisions.items[0].reminderTiming).toBe("blocked");
     expect(response.body.decisions.items[0].reminderTimingLabel).toBe("Blocked");
     expect(response.body.decisions.items[0].reminderBlockedReason).toBe("automation_disabled");
+    expect(response.body.decisions.items[0].trustContext).toEqual(
+      expect.objectContaining({
+        trustReadiness: "emerging",
+        recommendedNextAction: "review_application",
+      })
+    );
     expect(response.body.predictive.metrics[0].key).toBe("projected_vacancy_risk");
     expect(response.body.comparisons.deltas.summary.occupiedUnits.direction).toBe("better");
   });

--- a/rentchain-api/src/routes/__tests__/rentalApplicationsReviewSummaryRisk.test.ts
+++ b/rentchain-api/src/routes/__tests__/rentalApplicationsReviewSummaryRisk.test.ts
@@ -199,7 +199,7 @@ vi.mock("../../lib/reviewSummary", () => ({
     employment: {},
     reference: {},
     compliance: {},
-    screening: {},
+    screening: { status: "completed", provider: "transunion", referenceId: "ref-1" },
     derived: { incomeToRentRatio: null, completeness: { score: 0.8, label: "High" }, flags: [] },
     insights: [],
   })),
@@ -232,6 +232,7 @@ vi.mock("../../services/riskAgent/riskAgentService", () => ({
 
 vi.mock("../../services/tenantPortal/tenantProfileService", () => ({
   loadLandlordSafeTenantIdentitySummary: loadLandlordSafeTenantIdentitySummaryMock,
+  deriveLandlordSafeApplicationReusableFromApplication: vi.fn(() => true),
 }));
 
 async function createApp() {
@@ -300,8 +301,23 @@ describe("rentalApplications review summary risk surface", () => {
       readinessLabel: "Ready to apply",
       readinessDescription: "Your core profile and supporting records are ready for most rental workflows.",
     });
+    expect(res.body?.trustContext).toEqual(
+      expect.objectContaining({
+        trustReadiness: "ready",
+        trustLabel: "Ready for review",
+        recommendedNextAction: "review_application",
+      })
+    );
+    expect(res.body?.trustContext?.positiveSignals).toEqual(
+      expect.arrayContaining([
+        "Identity profile is organized for landlord review.",
+        "Identity profile has stronger supporting signals.",
+      ])
+    );
     expect(res.body?.tenantIdentitySummary?.documents).toBeUndefined();
     expect(res.body?.tenantIdentitySummary?.screening).toBeUndefined();
+    expect(JSON.stringify(res.body?.trustContext || {})).not.toContain("transunion");
+    expect(JSON.stringify(res.body?.trustContext || {})).not.toContain("ref-1");
   });
 
   it("returns a safe null risk state when no snapshot exists", async () => {

--- a/rentchain-api/src/routes/rentalApplicationsRoutes.ts
+++ b/rentchain-api/src/routes/rentalApplicationsRoutes.ts
@@ -62,7 +62,11 @@ import {
   normalizeApplicationLinkPartialProgress,
   sendApplicationLinkReminder,
 } from "../services/applicationReminderService";
-import { loadLandlordSafeTenantIdentitySummary } from "../services/tenantPortal/tenantProfileService";
+import {
+  deriveLandlordSafeApplicationReusableFromApplication,
+  loadLandlordSafeTenantIdentitySummary,
+} from "../services/tenantPortal/tenantProfileService";
+import { deriveLandlordTrustContext } from "../lib/trust/deriveLandlordTrustContext";
 import {
   buildQuoteId,
   buildScreeningMonetizationPatch,
@@ -4100,12 +4104,19 @@ router.get("/rental-applications/:id/review-summary", async (req: any, res) => {
       getLatestApplicationRisk({ applicationId: id }),
       loadLandlordSafeTenantIdentitySummary({ applicationId: id, application: access.data }),
     ]);
+    const trustContext = deriveLandlordTrustContext({
+      tenantIdentitySummary,
+      completenessScore: summary?.derived?.completeness?.score ?? null,
+      completenessFlags: Array.isArray(summary?.derived?.flags) ? summary.derived.flags : [],
+      screeningStatus: summary?.screening?.status,
+      applicationReusable: deriveLandlordSafeApplicationReusableFromApplication(access.data),
+    });
     const decisionSummary = buildApplicationDecisionSummary({
       applicationId: id,
       application: access.data,
       reviewSummary: summary,
     });
-    return res.json({ ok: true, summary, decisionSummary, risk, tenantIdentitySummary });
+    return res.json({ ok: true, summary, decisionSummary, risk, tenantIdentitySummary, trustContext });
   } catch (err: any) {
     console.error("[review_summary] failed", err?.message || err);
     return res.status(500).json({

--- a/rentchain-api/src/services/landlord/landlordAnalyticsSnapshot.ts
+++ b/rentchain-api/src/services/landlord/landlordAnalyticsSnapshot.ts
@@ -15,9 +15,15 @@ import { applyDecisionExecutionMappings } from "../../lib/analytics/deriveDecisi
 import { applyDecisionExecutionState } from "../../lib/analytics/deriveDecisionExecutionState";
 import { deriveLandlordAnalyticsSnapshot } from "../../lib/analytics/deriveLandlordAnalyticsSnapshot";
 import { deriveScreeningReconciliation } from "../../lib/reconciliation/deriveScreeningReconciliation";
+import { buildReviewSummary } from "../../lib/reviewSummary";
+import { deriveLandlordTrustContext } from "../../lib/trust/deriveLandlordTrustContext";
 import { emitLandlordDecisionAppearanceEvents } from "./landlordDecisionAppearanceEvents";
 import { loadLandlordDecisionStates, mergeLandlordDecisionStates } from "./landlordDecisionStates";
 import { deriveLandlordDecisionOutcomeAnalytics } from "./landlordDecisionOutcomeAnalytics";
+import {
+  deriveLandlordSafeApplicationReusableFromApplication,
+  loadLandlordSafeTenantIdentitySummary,
+} from "../tenantPortal/tenantProfileService";
 
 type LandlordAnalyticsParams = {
   landlordId: string;
@@ -284,11 +290,54 @@ export async function loadLandlordAnalyticsSnapshot(params: LandlordAnalyticsPar
     occurredAt,
   });
 
+  const decisionsWithTrustContext = await Promise.all(
+    decisions.map(async (decision) => {
+      if (decision.decisionType !== "start_screening_checkout" && decision.decisionType !== "improve_application_conversion") {
+        return decision;
+      }
+
+      let application: any | null = null;
+      if (decision.decisionType === "start_screening_checkout") {
+        const applicationId = String(decision.id || "").replace(/^start_screening_checkout:/, "").trim();
+        application =
+          derivedInput.applications.find((entry: any) => asAnalyticsString(entry?.id, 240) === applicationId) || null;
+      } else {
+        const eligibleApplications = (derivedInput.applications || []).filter((entry: any) => {
+          const status = asAnalyticsString(entry?.status, 80)?.toLowerCase() || "";
+          return ["submitted", "in_progress", "pending_review", "approved"].includes(status);
+        });
+        application = eligibleApplications.length === 1 ? eligibleApplications[0] : null;
+      }
+
+      if (!application || !asAnalyticsString(application?.id, 240)) {
+        return decision;
+      }
+
+      const applicationId = asAnalyticsString(application.id, 240)!;
+      const summary = buildReviewSummary(applicationId, application);
+      const tenantIdentitySummary = await loadLandlordSafeTenantIdentitySummary({
+        applicationId,
+        application,
+      });
+
+      return {
+        ...decision,
+        trustContext: deriveLandlordTrustContext({
+          tenantIdentitySummary,
+          completenessScore: summary?.derived?.completeness?.score ?? null,
+          completenessFlags: Array.isArray(summary?.derived?.flags) ? summary.derived.flags : [],
+          screeningStatus: summary?.screening?.status,
+          applicationReusable: deriveLandlordSafeApplicationReusableFromApplication(application),
+        }),
+      };
+    })
+  );
+
   return {
       ...snapshot,
       decisions: {
         ...snapshot.decisions,
-        items: decisions,
+        items: decisionsWithTrustContext,
       },
       decisionOutcomeAnalytics: deriveLandlordDecisionOutcomeAnalytics({
         landlordId,

--- a/rentchain-api/src/services/tenantPortal/tenantProfileService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantProfileService.ts
@@ -562,7 +562,7 @@ function deriveProfileCompletionStatusFromApplication(application: any): TenantI
   return "missing";
 }
 
-function deriveApplicationReusableFromApplication(application: any): boolean {
+export function deriveLandlordSafeApplicationReusableFromApplication(application: any): boolean {
   const currentAddress = application?.applicantProfile?.currentAddress || {};
   const employment = application?.applicantProfile?.employment || {};
 
@@ -963,7 +963,7 @@ export async function loadLandlordSafeTenantIdentitySummary(params: {
   application: any;
 }): Promise<TenantIdentitySummary> {
   const profileStatus = deriveProfileCompletionStatusFromApplication(params.application);
-  const applicationReusable = deriveApplicationReusableFromApplication(params.application);
+  const applicationReusable = deriveLandlordSafeApplicationReusableFromApplication(params.application);
   const documentSignals = deriveDocumentSignalsFromApplication(params.application);
   const screeningSignals = deriveScreeningSignalsFromApplication(params.application);
 

--- a/rentchain-frontend/src/api/landlordAnalyticsApi.ts
+++ b/rentchain-frontend/src/api/landlordAnalyticsApi.ts
@@ -1,5 +1,6 @@
 import { apiFetch } from "./apiFetch";
 import type { TimelineItem } from "./timelineApi";
+import type { LandlordTrustContext } from "./reviewSummaryApi";
 
 export type AnalyticsPeriod = "30d" | "90d" | "365d" | "month_to_date";
 
@@ -183,6 +184,7 @@ export type LandlordAgentDecision = {
   reminderPriority?: "low" | "medium" | "high" | null;
   reminderBlockedReason?: LandlordDecisionBlockedReason | null | string;
   reminderNextActionLabel?: string | null;
+  trustContext?: LandlordTrustContext | null;
 };
 
 export type AnalyticsDeltaValue = {

--- a/rentchain-frontend/src/api/reviewSummaryApi.ts
+++ b/rentchain-frontend/src/api/reviewSummaryApi.ts
@@ -49,6 +49,23 @@ type ReviewSummaryCore = {
   insights: string[];
 };
 
+export type LandlordTrustContext = {
+  trustReadiness: "limited" | "emerging" | "ready" | "strong";
+  trustLabel: string;
+  trustDescription: string;
+  positiveSignals: string[];
+  missingSignals: string[];
+  cautionSignals: string[];
+  recommendedNextAction:
+    | "review_application"
+    | "request_missing_info"
+    | "review_screening_status"
+    | "review_documents"
+    | "prepare_lease"
+    | "no_action";
+  decisionSupportLevel: "low" | "medium" | "high";
+};
+
 export type ApplicationReviewSummary = ReviewSummaryCore & {
   decisionSummary?: ApplicationDecisionSummary | null;
   risk?: RiskAgentReviewSnapshot;
@@ -60,6 +77,7 @@ export type ApplicationReviewSummary = ReviewSummaryCore & {
     readinessLabel: string;
     readinessDescription: string;
   } | null;
+  trustContext?: LandlordTrustContext | null;
 };
 
 export class ReviewSummaryApiError extends Error {
@@ -105,6 +123,7 @@ export async function fetchReviewSummary(applicationId: string): Promise<Applica
     ),
     risk: ((res?.risk || null) as RiskAgentReviewSnapshot) || null,
     tenantIdentitySummary: (res?.tenantIdentitySummary || null) as ApplicationReviewSummary["tenantIdentitySummary"],
+    trustContext: (res?.trustContext || null) as ApplicationReviewSummary["trustContext"],
   };
 }
 

--- a/rentchain-frontend/src/components/analytics/AgentDecisionPanel.test.tsx
+++ b/rentchain-frontend/src/components/analytics/AgentDecisionPanel.test.tsx
@@ -182,6 +182,16 @@ describe("AgentDecisionPanel", () => {
               reminderPriority: "medium",
               reminderBlockedReason: "automation_disabled",
               reminderNextActionLabel: "Open vacancy readiness",
+              trustContext: {
+                trustReadiness: "emerging",
+                trustLabel: "Emerging supporting signals",
+                trustDescription: "Some useful identity and application signals are available, but the file still benefits from a closer landlord review.",
+                positiveSignals: ["Application information is mostly complete."],
+                missingSignals: ["Employment or income details are still incomplete."],
+                cautionSignals: ["Screening is not complete yet in the current normalized status view."],
+                recommendedNextAction: "review_application",
+                decisionSupportLevel: "medium",
+              },
               href: "/analytics?propertyId=prop-2",
               state: "pending",
               reviewedAt: null,
@@ -207,6 +217,10 @@ describe("AgentDecisionPanel", () => {
     expect(screen.getAllByText(/Human confirmation required/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Execution disabled for this state/i)).toBeInTheDocument();
     expect(screen.getByText(/This decision is in a lifecycle state that does not allow execution/i)).toBeInTheDocument();
+    expect(screen.getByText(/Trust guidance/i)).toBeInTheDocument();
+    expect(screen.getByText(/Emerging supporting signals/i)).toBeInTheDocument();
+    expect(screen.getByText(/Employment or income details are still incomplete./i)).toBeInTheDocument();
+    expect(screen.getByText(/Recommended next action: Review application/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Open vacancy readiness/i })).toHaveAttribute("href", "/analytics?propertyId=prop-2");
     expect(screen.getByText(/Vacancy is elevated/i)).toBeInTheDocument();
     expect(screen.queryByText(/Automation blocked/i)).not.toBeInTheDocument();

--- a/rentchain-frontend/src/components/analytics/AgentDecisionPanel.tsx
+++ b/rentchain-frontend/src/components/analytics/AgentDecisionPanel.tsx
@@ -144,6 +144,95 @@ function sectionHeadingStyle() {
   } as const;
 }
 
+function trustActionLabel(
+  value:
+    | "review_application"
+    | "request_missing_info"
+    | "review_screening_status"
+    | "review_documents"
+    | "prepare_lease"
+    | "no_action"
+) {
+  switch (value) {
+    case "prepare_lease":
+      return "Prepare lease";
+    case "review_documents":
+      return "Review supporting records";
+    case "review_screening_status":
+      return "Review screening status";
+    case "request_missing_info":
+      return "Request missing information";
+    case "no_action":
+      return "No action needed";
+    case "review_application":
+    default:
+      return "Review application";
+  }
+}
+
+function TrustContextBlock({ decision }: { decision: LandlordAgentDecision }) {
+  if (!decision.trustContext) return null;
+
+  const { trustContext } = decision;
+  return (
+    <div
+      style={{
+        display: "grid",
+        gap: 8,
+        padding: 12,
+        borderRadius: 12,
+        border: "1px solid #e2e8f0",
+        background: "#f8fafc",
+      }}
+    >
+      <div style={{ display: "grid", gap: 4 }}>
+        <div style={{ color: "#0f172a", fontSize: "0.94rem", fontWeight: 700 }}>Trust guidance</div>
+        <div style={{ color: "#334155", fontSize: "0.84rem", fontWeight: 700 }}>{trustContext.trustLabel}</div>
+        <div style={{ color: "#475569", fontSize: "0.82rem" }}>{trustContext.trustDescription}</div>
+      </div>
+      {trustContext.positiveSignals.length ? (
+        <div style={{ display: "grid", gap: 2 }}>
+          <div style={{ color: "#64748b", fontSize: "0.78rem", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.04em" }}>
+            Positive signals
+          </div>
+          {trustContext.positiveSignals.map((item) => (
+            <div key={`positive-${item}`} style={{ color: "#334155", fontSize: "0.82rem" }}>
+              {item}
+            </div>
+          ))}
+        </div>
+      ) : null}
+      {trustContext.missingSignals.length ? (
+        <div style={{ display: "grid", gap: 2 }}>
+          <div style={{ color: "#64748b", fontSize: "0.78rem", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.04em" }}>
+            Missing signals
+          </div>
+          {trustContext.missingSignals.map((item) => (
+            <div key={`missing-${item}`} style={{ color: "#334155", fontSize: "0.82rem" }}>
+              {item}
+            </div>
+          ))}
+        </div>
+      ) : null}
+      {trustContext.cautionSignals.length ? (
+        <div style={{ display: "grid", gap: 2 }}>
+          <div style={{ color: "#64748b", fontSize: "0.78rem", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.04em" }}>
+            Caution signals
+          </div>
+          {trustContext.cautionSignals.map((item) => (
+            <div key={`caution-${item}`} style={{ color: "#334155", fontSize: "0.82rem" }}>
+              {item}
+            </div>
+          ))}
+        </div>
+      ) : null}
+      <div style={{ color: "#475569", fontSize: "0.82rem" }}>
+        Recommended next action: {trustActionLabel(trustContext.recommendedNextAction)}
+      </div>
+    </div>
+  );
+}
+
 const HISTORY_VISIBILITY_STORAGE_KEY = "landlordDecisionHistoryVisibilityV2";
 
 function readPersistedHistoryVisibility() {
@@ -325,6 +414,7 @@ function ActionDecisionCard(props: {
       {decision.automationState !== "manual_only" && decision.automationReason ? (
         <div style={{ color: "#64748b", fontSize: "0.84rem" }}>{decision.automationReason}</div>
       ) : null}
+      <TrustContextBlock decision={decision} />
       <div
         aria-label="Execution controls"
         style={{
@@ -668,6 +758,7 @@ function ExecutedDecisionCard(props: {
           Workflow: {categoryLabel}
         </div>
       ) : null}
+      <TrustContextBlock decision={decision} />
       <div
         aria-label="Execution controls"
         style={{

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
@@ -115,6 +115,16 @@ describe("ApplicationReviewSummaryPage", () => {
           updatedAt: "2026-04-01T00:00:00.000Z",
         },
       },
+      trustContext: {
+        trustReadiness: "ready",
+        trustLabel: "Ready for review",
+        trustDescription: "Application information appears organized enough for review, with only limited follow-up signals still visible.",
+        positiveSignals: ["Application information is mostly complete."],
+        missingSignals: ["Employment or income details are still incomplete."],
+        cautionSignals: ["Screening is not complete yet in the current normalized status view."],
+        recommendedNextAction: "review_application",
+        decisionSupportLevel: "medium",
+      },
     } as any);
 
     renderPage();
@@ -171,6 +181,11 @@ describe("ApplicationReviewSummaryPage", () => {
     expect(await screen.findByText("Jane Applicant")).toBeInTheDocument();
     expect(await screen.findByText("Landlord Decision Panel")).toBeInTheDocument();
     expect(await screen.findByText("Identity verification completed")).toBeInTheDocument();
+    expect(await screen.findByText("Trust guidance")).toBeInTheDocument();
+    expect((await screen.findAllByText("Ready for review")).length).toBeGreaterThan(0);
+    expect(await screen.findByText("Application information is mostly complete.")).toBeInTheDocument();
+    expect(await screen.findByText("Employment or income details are still incomplete.")).toBeInTheDocument();
+    expect(await screen.findByText(/Recommended next action: Review application/i)).toBeInTheDocument();
   });
 
   it("shows ready for decision when follow-up is resolved and review signals are organized", async () => {

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
@@ -224,6 +224,45 @@ function depositPaymentTone(state: "not_requested" | "requested" | "pending" | "
   return { color: "#64748b", background: "#e2e8f0", label: "Not requested" };
 }
 
+function trustReadinessTone(state: "limited" | "emerging" | "ready" | "strong") {
+  if (state === "strong") {
+    return { color: "#166534", background: "#dcfce7", label: "Strong supporting context" };
+  }
+  if (state === "ready") {
+    return { color: "#0f766e", background: "#ccfbf1", label: "Ready for review" };
+  }
+  if (state === "emerging") {
+    return { color: "#1d4ed8", background: "#dbeafe", label: "Emerging supporting signals" };
+  }
+  return { color: "#9a3412", background: "#ffedd5", label: "Limited supporting signals" };
+}
+
+function trustActionLabel(
+  value:
+    | "review_application"
+    | "request_missing_info"
+    | "review_screening_status"
+    | "review_documents"
+    | "prepare_lease"
+    | "no_action"
+) {
+  switch (value) {
+    case "prepare_lease":
+      return "Prepare lease";
+    case "review_documents":
+      return "Review supporting records";
+    case "review_screening_status":
+      return "Review screening status";
+    case "request_missing_info":
+      return "Request missing information";
+    case "no_action":
+      return "No action needed";
+    case "review_application":
+    default:
+      return "Review application";
+  }
+}
+
 type SummaryLoadError = {
   message: string;
   status?: number;
@@ -1573,6 +1612,99 @@ function ApplicationReviewSummaryPageBody() {
                 emptyLabel="Recent workflow-triggered review updates will appear here as the package changes."
                 items={structuredNotifications}
               />
+            </Card>
+          ) : null}
+
+          {summary.trustContext ? (
+            <Card style={{ display: "grid", gap: 10 }}>
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+                <div>
+                  <div style={{ fontWeight: 700 }}>Trust guidance</div>
+                  <div style={{ fontSize: 13, color: text.subtle, marginTop: 4 }}>
+                    {summary.trustContext.trustDescription}
+                  </div>
+                </div>
+                <div
+                  style={{
+                    padding: "6px 10px",
+                    borderRadius: 999,
+                    fontWeight: 700,
+                    color: trustReadinessTone(summary.trustContext.trustReadiness).color,
+                    background: trustReadinessTone(summary.trustContext.trustReadiness).background,
+                  }}
+                >
+                  {summary.trustContext.trustLabel}
+                </div>
+              </div>
+
+              <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 8 }}>
+                <div
+                  style={{
+                    border: `1px solid ${colors.border}`,
+                    borderRadius: 10,
+                    padding: 10,
+                    display: "grid",
+                    gap: 6,
+                  }}
+                >
+                  <div style={{ fontWeight: 700, color: text.main }}>Positive signals</div>
+                  {summary.trustContext.positiveSignals.length ? (
+                    summary.trustContext.positiveSignals.map((item) => (
+                      <div key={item} style={{ fontSize: 13, color: text.subtle }}>
+                        {item}
+                      </div>
+                    ))
+                  ) : (
+                    <div style={{ fontSize: 13, color: text.subtle }}>No additional positive signals are surfaced yet.</div>
+                  )}
+                </div>
+
+                <div
+                  style={{
+                    border: `1px solid ${colors.border}`,
+                    borderRadius: 10,
+                    padding: 10,
+                    display: "grid",
+                    gap: 6,
+                  }}
+                >
+                  <div style={{ fontWeight: 700, color: text.main }}>Missing signals</div>
+                  {summary.trustContext.missingSignals.length ? (
+                    summary.trustContext.missingSignals.map((item) => (
+                      <div key={item} style={{ fontSize: 13, color: text.subtle }}>
+                        {item}
+                      </div>
+                    ))
+                  ) : (
+                    <div style={{ fontSize: 13, color: text.subtle }}>No major missing signals are currently surfaced.</div>
+                  )}
+                </div>
+
+                <div
+                  style={{
+                    border: `1px solid ${colors.border}`,
+                    borderRadius: 10,
+                    padding: 10,
+                    display: "grid",
+                    gap: 6,
+                  }}
+                >
+                  <div style={{ fontWeight: 700, color: text.main }}>Caution signals</div>
+                  {summary.trustContext.cautionSignals.length ? (
+                    summary.trustContext.cautionSignals.map((item) => (
+                      <div key={item} style={{ fontSize: 13, color: text.subtle }}>
+                        {item}
+                      </div>
+                    ))
+                  ) : (
+                    <div style={{ fontSize: 13, color: text.subtle }}>No caution signals are currently surfaced.</div>
+                  )}
+                </div>
+              </div>
+
+              <div style={{ fontSize: 12, color: text.subtle }}>
+                Recommended next action: {trustActionLabel(summary.trustContext.recommendedNextAction)}. This guidance is descriptive only and does not approve, decline, or automate a landlord decision.
+              </div>
             </Card>
           ) : null}
 


### PR DESCRIPTION
This PR introduces Landlord Decision Engine v2.

Includes:
- deterministic landlord-safe trust context
- trust guidance on rental application review-summary
- trust guidance on application-related analytics decisions
- frontend Trust guidance card/block
- focused backend/frontend test coverage

Guardrails preserved:
- no tenant scoring or ranking
- no automated approve/reject
- no automation eligibility changes
- no execution mapping changes
- no raw document/screening/signature/share-token exposure
- no provider-specific screening details
- no public share package behavior changes

Verification note:
- rentalApplicationsReviewSummaryRisk.test.ts fails inside sandbox with listen EPERM 0.0.0.0, but passed outside sandbox.
- Backend typecheck, focused trust tests, landlord analytics tests, frontend analytics tests, review-summary page test, and frontend build passed.