### PR TITLE
feat: add lease execution workflow

### DIFF
--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -182,6 +182,11 @@ describe("leaseRoutes GET /active", () => {
           signatureDisplayName: "Jane Tenant",
         },
         leasePdfStatus: "available",
+        leaseExecution: expect.objectContaining({
+          executionStatus: "fully_executed",
+          executionLabel: "Lease fully executed",
+          requiredNextAction: "none",
+        }),
       })
     );
     expect(res.body?.leases?.[0]?.tenantSignature?.drawnDataUrl).toBeUndefined();

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -493,7 +493,112 @@ describe("tenantPortalRoutes foundation", () => {
     });
     expect(res.body?.data?.tenantSignature?.drawnDataUrl).toBeUndefined();
     expect(res.body?.data?.leasePdfStatus).toBe("available");
+    expect(res.body?.data?.leaseExecution).toEqual(
+      expect.objectContaining({
+        executionStatus: "fully_executed",
+        executionLabel: "Lease fully executed",
+        requiredNextAction: "none",
+      })
+    );
     expect(res.body?.lease?.tenantSignature?.drawnDataUrl).toBeUndefined();
+  });
+
+  it("records tenant lease signing metadata without storing raw signature data and stays idempotent", async () => {
+    ensureCollection("leases").set("lease-1", {
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      status: "ready_for_signature",
+      startDate: "2026-03-01",
+      endDate: "2027-02-28",
+      monthlyRent: 1900,
+      documentUrl: "https://example.com/sign-me.pdf",
+      tenantSignature: null,
+      tenantSignedAt: null,
+    });
+    ensureCollection("tenants").set("tenant-1", {
+      email: "tenant@example.com",
+      fullName: "Taylor Tenant",
+      phone: "902-555-0100",
+      propertyId: "prop-1",
+      currentLeaseId: "lease-1",
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const headers = {
+      "x-test-user": JSON.stringify({
+        id: "user-1",
+        email: "tenant@example.com",
+        role: "tenant",
+        tenantId: "tenant-1",
+        leaseId: "lease-sign-1",
+      }),
+    };
+
+    const first = await invokeRouter(router, {
+      method: "POST",
+      url: "/leases/lease-1/sign",
+      headers,
+    });
+    const second = await invokeRouter(router, {
+      method: "POST",
+      url: "/leases/lease-1/sign",
+      headers,
+    });
+
+    expect(first.status).toBe(200);
+    expect(first.body?.data?.tenantSignature).toEqual(
+      expect.objectContaining({
+        signatureMethod: "typed",
+        signatureDisplayName: "Taylor Tenant",
+      })
+    );
+    expect(first.body?.data?.tenantSignature?.drawnDataUrl).toBeUndefined();
+    expect(first.body?.data?.leaseExecution).toEqual(
+      expect.objectContaining({
+        executionStatus: "tenant_signed",
+        requiredNextAction: "landlord_signature",
+      })
+    );
+
+    expect(second.status).toBe(200);
+    const canonicalEvents = Array.from(ensureCollection("canonicalEvents").values());
+    expect(canonicalEvents.filter((event) => event.action === "tenant_signed")).toHaveLength(1);
+
+    const storedLease = ensureCollection("leases").get("lease-1");
+    expect(storedLease?.tenantSignedAt).toBeTruthy();
+    expect(storedLease?.tenantSignatureMethod).toBe("typed");
+    expect(storedLease?.tenantSignatureDisplayName).toBe("Taylor Tenant");
+    expect(storedLease?.tenantSignature?.drawnDataUrl).toBeUndefined();
+  });
+
+  it("forbids tenant lease signing for an unrelated lease", async () => {
+    ensureCollection("leases").set("lease-other", {
+      tenantId: "tenant-2",
+      propertyId: "prop-1",
+      status: "ready_for_signature",
+      startDate: "2026-03-01",
+      endDate: "2027-02-28",
+      monthlyRent: 1900,
+      documentUrl: "https://example.com/sign-me.pdf",
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/leases/lease-other/sign",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+          leaseId: "lease-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(403);
+    expect(res.body?.error).toBe("FORBIDDEN");
   });
 
   it("creates a tenant share package without persisting a raw token", async () => {

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -298,7 +298,7 @@ async function enrichLeaseRow(raw: any) {
     tenantName,
     tenantEmail,
     documentUrl,
-    ...deriveTenantSafeLeaseReadinessMetadata(raw, { documentUrl }),
+    ...deriveTenantSafeLeaseReadinessMetadata(raw, { documentUrl, leaseId: lease.id }),
     archivedAt: raw?.archivedAt || null,
     archivedByUserId: raw?.archivedByUserId || null,
     isArchived: Boolean(raw?.archivedAt),

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -13,6 +13,7 @@ import {
   projectTenantMaintenance,
   projectTenantProperty,
 } from "../services/tenantPortal/tenantProjectionService";
+import { deriveLeaseExecution } from "../services/leaseExecution/deriveLeaseExecution";
 import { recordTenantEvent } from "../services/tenantPortal/tenantEventLogService";
 import { redeemTenancyInvite } from "../services/tenantPortal/tenantInviteService";
 import { loadTenantIdentityRecord, loadTenantProfileProjection } from "../services/tenantPortal/tenantProfileService";
@@ -3479,6 +3480,129 @@ router.get("/lease", requireTenantWorkspaceIdentity, async (req: any, res) => {
   return res.json({ ok: true, data: workspace.lease });
 });
 
+router.post("/leases/:leaseId/sign", requireTenantWorkspaceIdentity, async (req: any, res) => {
+  const context = await resolveWorkspaceContextOrRespond(req, res);
+  if (!context) return;
+  if (context.authority !== "active_tenant" || !context.tenantId) {
+    return res.status(403).json({ ok: false, error: "TENANT_CONTEXT_REQUIRED" });
+  }
+
+  const leaseId = String(req.params?.leaseId || "").trim();
+  if (!leaseId) {
+    return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+  }
+  if (context.leaseId && String(context.leaseId).trim() !== leaseId) {
+    return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+  }
+
+  try {
+    const leaseRef = db.collection("leases").doc(leaseId);
+    const leaseSnap = await leaseRef.get();
+    if (!leaseSnap.exists) {
+      return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+    }
+
+    const leaseData = (leaseSnap.data() as any) || {};
+    const leaseTenantId = String(
+      leaseData?.tenantId || leaseData?.primaryTenantId || leaseData?.tenantIds?.[0] || ""
+    ).trim();
+    const leaseTenantIds = Array.isArray(leaseData?.tenantIds)
+      ? leaseData.tenantIds.map((value: any) => String(value || "").trim()).filter(Boolean)
+      : [];
+    if (
+      leaseTenantId !== context.tenantId &&
+      !leaseTenantIds.includes(String(context.tenantId || "").trim())
+    ) {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+
+    const alreadySignedAt =
+      String(leaseData?.tenantSignature?.signedAt || "").trim() ||
+      String(leaseData?.tenantSignedAt || leaseData?.tenantSignatureCompletedAt || "").trim();
+    if (alreadySignedAt) {
+      return res.status(200).json({ ok: true, data: projectTenantLease(leaseId, leaseData) });
+    }
+
+    const currentExecution = deriveLeaseExecution({
+      leaseId,
+      documentUrl:
+        String(leaseData?.documentUrl || leaseData?.approvedDocumentUrl || leaseData?.documentRef || "").trim() || null,
+      startDate: String(leaseData?.startDate || leaseData?.leaseStart || "").trim() || null,
+      monthlyRent:
+        typeof leaseData?.monthlyRent === "number"
+          ? leaseData.monthlyRent
+          : typeof leaseData?.rentAmount === "number"
+          ? leaseData.rentAmount
+          : typeof leaseData?.rentCents === "number"
+          ? Math.round(leaseData.rentCents) / 100
+          : null,
+      status: String(leaseData?.status || "").trim() || null,
+      raw: leaseData,
+    });
+    if (currentExecution.requiredNextAction !== "tenant_signature") {
+      return res.status(400).json({ ok: false, error: "TENANT_LEASE_SIGN_NOT_AVAILABLE" });
+    }
+
+    const tenantSnap = await db.collection("tenants").doc(String(context.tenantId)).get().catch(() => null);
+    const tenantData = tenantSnap?.exists ? ((tenantSnap.data() as any) || {}) : {};
+    const signatureDisplayName =
+      String(
+        req.body?.signatureDisplayName ||
+          tenantData?.fullName ||
+          tenantData?.name ||
+          req.user?.displayName ||
+          req.user?.email ||
+          ""
+      ).trim() || "Tenant";
+    const signatureMethod = req.body?.signatureMethod === "drawn" ? "drawn" : "typed";
+    const nowIso = new Date().toISOString();
+
+    await leaseRef.set(
+      {
+        tenantSignedAt: nowIso,
+        tenantSignatureMethod: signatureMethod,
+        tenantSignatureDisplayName: signatureDisplayName,
+        updatedAt: nowIso,
+      },
+      { merge: true }
+    );
+
+    await writeCanonicalEvent({
+      domain: "lease",
+      action: "tenant_signed",
+      status: "tenant_signed",
+      actor: {
+        type: "tenant",
+        role: "tenant",
+        id: String(context.tenantId),
+        displayName: signatureDisplayName,
+      },
+      resource: {
+        type: "lease",
+        id: leaseId,
+      },
+      occurredAt: nowIso,
+      visibility: "internal",
+      summary: "Tenant signature metadata recorded for lease execution",
+      metadata: {
+        previousStatus: String(leaseData?.status || "").trim() || null,
+        nextStatus: "tenant_signed",
+      },
+    });
+
+    const refreshedSnap = await leaseRef.get();
+    const refreshed = refreshedSnap.exists ? ((refreshedSnap.data() as any) || {}) : leaseData;
+    return res.status(200).json({ ok: true, data: projectTenantLease(leaseId, refreshed) });
+  } catch (err) {
+    console.error("[tenant/leases/:leaseId/sign] failed", {
+      tenantId: context.tenantId,
+      leaseId,
+      err,
+    });
+    return res.status(500).json({ ok: false, error: "TENANT_LEASE_SIGN_FAILED" });
+  }
+});
+
 router.get("/maintenance-requests", requireTenantWorkspaceIdentity, async (req: any, res) => {
   const context = await resolveWorkspaceContextOrRespond(req, res);
   if (!context) return;
@@ -5151,6 +5275,14 @@ router.get("/lease", requireTenant, async (req: any, res) => {
         leasePdfStatus: "not_available",
         leasePdfLabel: "Lease document unavailable",
         leasePdfDescription: "No tenant-safe lease document is available in this workspace yet.",
+        leaseExecution: deriveLeaseExecution({
+          leaseId,
+          documentUrl: null,
+          startDate: null,
+          monthlyRent: null,
+          status: null,
+          raw: {},
+        }),
       }),
       propertyId,
       propertyName,

--- a/rentchain-api/src/services/leaseExecution/__tests__/deriveLeaseExecution.test.ts
+++ b/rentchain-api/src/services/leaseExecution/__tests__/deriveLeaseExecution.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { deriveLeaseExecution } from "../deriveLeaseExecution";
+
+describe("deriveLeaseExecution", () => {
+  it("derives ready_for_tenant_signature when a document is visible and tenant signing is next", () => {
+    const result = deriveLeaseExecution({
+      leaseId: "lease-1",
+      documentUrl: "https://example.com/lease.pdf",
+      startDate: "2026-05-01",
+      monthlyRent: 1800,
+      status: "ready_for_signature",
+      raw: {},
+    });
+
+    expect(result.executionStatus).toBe("ready_for_tenant_signature");
+    expect(result.requiredNextAction).toBe("tenant_signature");
+    expect(result.tenantSignatureStatus).toBe("needed");
+  });
+
+  it("derives tenant_signed from durable tenant signature metadata without exposing a landlord model", () => {
+    const result = deriveLeaseExecution({
+      leaseId: "lease-1",
+      documentUrl: "https://example.com/lease.pdf",
+      startDate: "2026-05-01",
+      monthlyRent: 1800,
+      status: "draft",
+      raw: {
+        tenantSignedAt: "2026-05-01T12:00:00.000Z",
+        tenantSignatureMethod: "typed",
+        tenantSignatureDisplayName: "Taylor Tenant",
+      },
+    });
+
+    expect(result.executionStatus).toBe("tenant_signed");
+    expect(result.requiredNextAction).toBe("landlord_signature");
+    expect(result.landlordSignatureStatus).toBe("needed");
+  });
+
+  it("derives fully_executed from an active or signed lease record", () => {
+    const result = deriveLeaseExecution({
+      leaseId: "lease-1",
+      documentUrl: "https://example.com/lease.pdf",
+      startDate: "2026-05-01",
+      monthlyRent: 1800,
+      status: "active",
+      raw: {
+        tenantSignedAt: "2026-05-01T12:00:00.000Z",
+      },
+    });
+
+    expect(result.executionStatus).toBe("fully_executed");
+    expect(result.requiredNextAction).toBe("none");
+  });
+});

--- a/rentchain-api/src/services/leaseExecution/deriveLeaseExecution.ts
+++ b/rentchain-api/src/services/leaseExecution/deriveLeaseExecution.ts
@@ -1,0 +1,268 @@
+type LeaseExecutionStatus =
+  | "draft"
+  | "ready_for_tenant_signature"
+  | "tenant_signed"
+  | "ready_for_landlord_signature"
+  | "landlord_signed"
+  | "fully_executed"
+  | "blocked";
+
+type LeaseExecutionNextAction =
+  | "complete_lease_details"
+  | "tenant_signature"
+  | "landlord_signature"
+  | "review_signed_lease"
+  | "none";
+
+type LeaseExecutionSignatureStatus =
+  | "not_required"
+  | "needed"
+  | "completed"
+  | "blocked";
+
+type LeaseExecutionPdfStatus =
+  | "not_ready"
+  | "ready"
+  | "generated"
+  | "blocked";
+
+export type LeaseExecution = {
+  executionStatus: LeaseExecutionStatus;
+  executionLabel: string;
+  executionDescription: string;
+  requiredNextAction: LeaseExecutionNextAction;
+  tenantSignatureStatus: LeaseExecutionSignatureStatus;
+  landlordSignatureStatus: LeaseExecutionSignatureStatus;
+  pdfStatus: LeaseExecutionPdfStatus;
+  completedAt: string | null;
+};
+
+function asString(value: unknown): string | null {
+  const next = String(value || "").trim();
+  return next || null;
+}
+
+function asNumber(value: unknown): number | null {
+  const next = Number(value);
+  return Number.isFinite(next) ? next : null;
+}
+
+function toMillis(value: any): number | null {
+  if (!value) return null;
+  if (typeof value === "number") return value;
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+  if (typeof value?.toMillis === "function") return value.toMillis();
+  if (typeof value?.seconds === "number") return value.seconds * 1000;
+  return null;
+}
+
+function toIso(value: any): string | null {
+  const millis = toMillis(value);
+  return millis == null ? asString(value) : new Date(millis).toISOString();
+}
+
+function normalizeStatus(value: unknown): string {
+  return String(value || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_");
+}
+
+function firstIso(input: any, keys: string[]): string | null {
+  for (const key of keys) {
+    const value = toIso(input?.[key]);
+    if (value) return value;
+  }
+  return null;
+}
+
+type DeriveLeaseExecutionInput = {
+  leaseId?: string | null;
+  documentUrl?: string | null;
+  startDate?: string | null;
+  monthlyRent?: number | null;
+  status?: string | null;
+  raw?: any;
+};
+
+export function deriveLeaseExecution(input: DeriveLeaseExecutionInput): LeaseExecution {
+  const raw = input.raw || {};
+  const leaseId = asString(input.leaseId) || asString(raw?.leaseId) || asString(raw?.id);
+  const documentUrl =
+    asString(input.documentUrl) ||
+    asString(raw?.documentUrl) ||
+    asString(raw?.approvedDocumentUrl) ||
+    asString(raw?.documentRef);
+  const startDate =
+    asString(input.startDate) || asString(raw?.startDate) || asString(raw?.leaseStart) || asString(raw?.leaseStartDate);
+  const monthlyRent =
+    asNumber(input.monthlyRent) ??
+    asNumber(raw?.monthlyRent) ??
+    asNumber(raw?.rentAmount) ??
+    (typeof raw?.rentCents === "number" ? Math.round(raw.rentCents) / 100 : null);
+  const normalizedStatus = normalizeStatus(input.status || raw?.status);
+
+  const tenantSignedAt =
+    firstIso(raw?.tenantSignature, ["signedAt"]) ||
+    firstIso(raw, ["tenantSignedAt", "tenantSignatureCompletedAt"]);
+  const landlordSignedAt = firstIso(raw, ["landlordSignedAt", "landlordSignatureCompletedAt"]);
+  const fullyExecutedAt = firstIso(raw, ["fullyExecutedAt", "fullySignedAt", "signatureCompletedAt"]);
+
+  const hasCoreLeaseDetails = Boolean(leaseId && startDate && typeof monthlyRent === "number" && monthlyRent > 0);
+  const tenantSignatureCaptured = Boolean(tenantSignedAt);
+  const landlordSignatureCaptured = Boolean(landlordSignedAt);
+  const statusImpliesReadyForTenant = [
+    "sent",
+    "awaiting_tenant_signature",
+    "pending_tenant_signature",
+    "ready_for_signature",
+    "signature_requested",
+  ].includes(normalizedStatus);
+  const statusImpliesReadyForLandlord = [
+    "awaiting_landlord_signature",
+    "pending_landlord_signature",
+    "signed_by_tenant",
+  ].includes(normalizedStatus);
+  const statusImpliesLandlordSigned = ["landlord_signed", "signed_by_landlord"].includes(normalizedStatus);
+  const statusImpliesExecuted = ["signed", "active", "current", "fully_signed", "completed"].includes(normalizedStatus);
+
+  const executed = Boolean(fullyExecutedAt || statusImpliesExecuted);
+  const landlordSigned = Boolean(!executed && (landlordSignatureCaptured || statusImpliesLandlordSigned));
+  const readyForLandlord = Boolean(!executed && !landlordSigned && statusImpliesReadyForLandlord);
+  const tenantSigned = Boolean(
+    !executed && !landlordSigned && !readyForLandlord && tenantSignatureCaptured
+  );
+  const readyForTenant = Boolean(
+    !executed &&
+      !landlordSigned &&
+      !readyForLandlord &&
+      !tenantSigned &&
+      documentUrl &&
+      (statusImpliesReadyForTenant || hasCoreLeaseDetails)
+  );
+
+  const pdfStatus: LeaseExecutionPdfStatus = (() => {
+    if (documentUrl) return "generated";
+    if (!leaseId) return "blocked";
+    if (tenantSigned || readyForLandlord || landlordSigned || executed) return "blocked";
+    if (hasCoreLeaseDetails) return "ready";
+    return "not_ready";
+  })();
+
+  const executionStatus: LeaseExecutionStatus = (() => {
+    if (!leaseId) return "blocked";
+    if (executed) return "fully_executed";
+    if (landlordSigned) return "landlord_signed";
+    if (readyForLandlord) return "ready_for_landlord_signature";
+    if (tenantSigned) return "tenant_signed";
+    if (readyForTenant) return "ready_for_tenant_signature";
+    if (hasCoreLeaseDetails) return "draft";
+    return "blocked";
+  })();
+
+  const tenantSignatureStatus: LeaseExecutionSignatureStatus = (() => {
+    if (!leaseId) return "blocked";
+    if (tenantSigned || readyForLandlord || landlordSigned || executed) return "completed";
+    if (readyForTenant) return "needed";
+    if (hasCoreLeaseDetails) return "blocked";
+    return "not_required";
+  })();
+
+  const landlordSignatureStatus: LeaseExecutionSignatureStatus = (() => {
+    if (!leaseId) return "blocked";
+    if (landlordSigned || executed) return "completed";
+    if (readyForLandlord || tenantSigned) return "needed";
+    if (readyForTenant || hasCoreLeaseDetails) return "blocked";
+    return "not_required";
+  })();
+
+  const completedAt =
+    executionStatus === "fully_executed"
+      ? fullyExecutedAt || landlordSignedAt || tenantSignedAt || null
+      : executionStatus === "landlord_signed"
+      ? landlordSignedAt || null
+      : null;
+
+  switch (executionStatus) {
+    case "fully_executed":
+      return {
+        executionStatus,
+        executionLabel: "Lease fully executed",
+        executionDescription: "The visible lease record indicates the current execution flow is complete.",
+        requiredNextAction: "none",
+        tenantSignatureStatus,
+        landlordSignatureStatus,
+        pdfStatus,
+        completedAt,
+      };
+    case "landlord_signed":
+      return {
+        executionStatus,
+        executionLabel: "Landlord signature completed",
+        executionDescription: "Landlord signature appears complete. Review the signed lease details to confirm the current file is settled.",
+        requiredNextAction: "review_signed_lease",
+        tenantSignatureStatus,
+        landlordSignatureStatus,
+        pdfStatus,
+        completedAt,
+      };
+    case "ready_for_landlord_signature":
+      return {
+        executionStatus,
+        executionLabel: "Waiting for landlord signature",
+        executionDescription: "Tenant signing appears complete and the next visible execution step belongs to the landlord.",
+        requiredNextAction: "landlord_signature",
+        tenantSignatureStatus,
+        landlordSignatureStatus,
+        pdfStatus,
+        completedAt,
+      };
+    case "tenant_signed":
+      return {
+        executionStatus,
+        executionLabel: "Tenant signature completed",
+        executionDescription: "Tenant signature is recorded. The next supported execution step depends on landlord follow-through.",
+        requiredNextAction: "landlord_signature",
+        tenantSignatureStatus,
+        landlordSignatureStatus,
+        pdfStatus,
+        completedAt,
+      };
+    case "ready_for_tenant_signature":
+      return {
+        executionStatus,
+        executionLabel: "Waiting for tenant signature",
+        executionDescription: "The lease document is ready and the next execution step belongs to the tenant.",
+        requiredNextAction: "tenant_signature",
+        tenantSignatureStatus,
+        landlordSignatureStatus,
+        pdfStatus,
+        completedAt,
+      };
+    case "draft":
+      return {
+        executionStatus,
+        executionLabel: "Lease details ready",
+        executionDescription: "A lease record is visible, but the execution flow has not reached a tenant-signature step yet.",
+        requiredNextAction: "complete_lease_details",
+        tenantSignatureStatus,
+        landlordSignatureStatus,
+        pdfStatus,
+        completedAt,
+      };
+    default:
+      return {
+        executionStatus: "blocked",
+        executionLabel: "Some lease details are still needed",
+        executionDescription: "The current lease record does not expose enough execution detail to move forward safely.",
+        requiredNextAction: "complete_lease_details",
+        tenantSignatureStatus,
+        landlordSignatureStatus,
+        pdfStatus,
+        completedAt: null,
+      };
+  }
+}

--- a/rentchain-api/src/services/tenantPortal/tenantProjectionService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantProjectionService.ts
@@ -1,3 +1,5 @@
+import { deriveLeaseExecution, type LeaseExecution } from "../leaseExecution/deriveLeaseExecution";
+
 type TenantPropertyProjection = {
   propertyId: string;
   rc_prop_id: string | null;
@@ -32,6 +34,7 @@ type TenantLeaseProjection = {
   leasePdfStatus: "available" | "pending" | "not_available";
   leasePdfLabel: string;
   leasePdfDescription: string;
+  leaseExecution: LeaseExecution;
 };
 
 type TenantApplicationProjection = {
@@ -212,11 +215,12 @@ export type TenantSafeLeaseReadinessMetadata = Pick<
   | "leasePdfStatus"
   | "leasePdfLabel"
   | "leasePdfDescription"
+  | "leaseExecution"
 >;
 
 export function deriveTenantSafeLeaseReadinessMetadata(
   data: any,
-  options?: { documentUrl?: string | null }
+  options?: { documentUrl?: string | null; leaseId?: string | null }
 ): TenantSafeLeaseReadinessMetadata {
   const documentUrl = asString(options?.documentUrl) ?? asString(data?.documentUrl) ?? asString(data?.approvedDocumentUrl) ?? asString(data?.documentRef);
   const normalizedLeaseStatus = normalizeStatus(data?.status);
@@ -315,6 +319,17 @@ export function deriveTenantSafeLeaseReadinessMetadata(
     leasePdfStatus,
     leasePdfLabel,
     leasePdfDescription,
+    leaseExecution: deriveLeaseExecution({
+      leaseId: asString(options?.leaseId) || asString(data?.leaseId) || asString(data?.id),
+      documentUrl,
+      startDate: asString(data?.startDate) || asString(data?.leaseStart),
+      monthlyRent:
+        asNumber(data?.monthlyRent) ??
+        asNumber(data?.rentAmount) ??
+        (typeof data?.rentCents === "number" ? Math.round(data.rentCents) / 100 : null),
+      status: asString(data?.status),
+      raw: data,
+    }),
   };
 }
 
@@ -353,7 +368,7 @@ export function projectTenantLease(recordId: string, data: any): TenantLeaseProj
       (typeof data?.rentCents === "number" ? Math.round(data.rentCents) / 100 : null),
     status: asString(data?.status),
     documentUrl,
-    ...deriveTenantSafeLeaseReadinessMetadata(data, { documentUrl }),
+    ...deriveTenantSafeLeaseReadinessMetadata(data, { documentUrl, leaseId: recordId }),
   };
 }
 

--- a/rentchain-frontend/src/api/leasesApi.ts
+++ b/rentchain-frontend/src/api/leasesApi.ts
@@ -60,6 +60,28 @@ export interface LandlordActiveLease extends Lease {
   leasePdfStatus?: "available" | "pending" | "not_available";
   leasePdfLabel?: string | null;
   leasePdfDescription?: string | null;
+  leaseExecution?: {
+    executionStatus:
+      | "draft"
+      | "ready_for_tenant_signature"
+      | "tenant_signed"
+      | "ready_for_landlord_signature"
+      | "landlord_signed"
+      | "fully_executed"
+      | "blocked";
+    executionLabel: string;
+    executionDescription: string;
+    requiredNextAction:
+      | "complete_lease_details"
+      | "tenant_signature"
+      | "landlord_signature"
+      | "review_signed_lease"
+      | "none";
+    tenantSignatureStatus: "not_required" | "needed" | "completed" | "blocked";
+    landlordSignatureStatus: "not_required" | "needed" | "completed" | "blocked";
+    pdfStatus: "not_ready" | "ready" | "generated" | "blocked";
+    completedAt: string | null;
+  } | null;
   hiddenFromActiveLists?: boolean;
   cleanupReason?: string | null;
   cleanupBatch?: string | null;

--- a/rentchain-frontend/src/api/tenantPortal.ts
+++ b/rentchain-frontend/src/api/tenantPortal.ts
@@ -50,6 +50,28 @@ export type TenantWorkspaceLease = {
   leasePdfStatus?: "available" | "pending" | "not_available";
   leasePdfLabel?: string | null;
   leasePdfDescription?: string | null;
+  leaseExecution?: {
+    executionStatus:
+      | "draft"
+      | "ready_for_tenant_signature"
+      | "tenant_signed"
+      | "ready_for_landlord_signature"
+      | "landlord_signed"
+      | "fully_executed"
+      | "blocked";
+    executionLabel: string;
+    executionDescription: string;
+    requiredNextAction:
+      | "complete_lease_details"
+      | "tenant_signature"
+      | "landlord_signature"
+      | "review_signed_lease"
+      | "none";
+    tenantSignatureStatus: "not_required" | "needed" | "completed" | "blocked";
+    landlordSignatureStatus: "not_required" | "needed" | "completed" | "blocked";
+    pdfStatus: "not_ready" | "ready" | "generated" | "blocked";
+    completedAt: string | null;
+  } | null;
   depositCents?: number | null;
   depositRequired?: boolean | null;
   depositReceived?: boolean | null;
@@ -209,6 +231,18 @@ export async function getTenantApplicationStatus(): Promise<TenantWorkspaceAppli
 
 export async function getTenantLeaseWorkspace(): Promise<TenantWorkspaceLease | null> {
   const res = await tenantApiFetch<{ ok: boolean; data: TenantWorkspaceLease | null }>("/tenant/lease");
+  return res?.data ?? null;
+}
+
+export async function signTenantLease(leaseId: string): Promise<TenantWorkspaceLease | null> {
+  const res = await tenantApiFetch<{ ok: boolean; data: TenantWorkspaceLease | null }>(
+    `/tenant/leases/${encodeURIComponent(leaseId)}/sign`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    }
+  );
   return res?.data ?? null;
 }
 

--- a/rentchain-frontend/src/api/tenantPortalApi.ts
+++ b/rentchain-frontend/src/api/tenantPortalApi.ts
@@ -33,6 +33,28 @@ export interface TenantLease {
   leasePdfStatus?: "available" | "pending" | "not_available";
   leasePdfLabel?: string | null;
   leasePdfDescription?: string | null;
+  leaseExecution?: {
+    executionStatus:
+      | "draft"
+      | "ready_for_tenant_signature"
+      | "tenant_signed"
+      | "ready_for_landlord_signature"
+      | "landlord_signed"
+      | "fully_executed"
+      | "blocked";
+    executionLabel: string;
+    executionDescription: string;
+    requiredNextAction:
+      | "complete_lease_details"
+      | "tenant_signature"
+      | "landlord_signature"
+      | "review_signed_lease"
+      | "none";
+    tenantSignatureStatus: "not_required" | "needed" | "completed" | "blocked";
+    landlordSignatureStatus: "not_required" | "needed" | "completed" | "blocked";
+    pdfStatus: "not_ready" | "ready" | "generated" | "blocked";
+    completedAt: string | null;
+  } | null;
 }
 
 export interface TenantPayment {
@@ -100,6 +122,18 @@ export async function getTenantLease(): Promise<TenantLease> {
   const res = await apiFetch<any>("/tenant/lease");
   if (res?.lease && typeof res.lease === "object") {
     return res.lease as TenantLease;
+  }
+  return res as TenantLease;
+}
+
+export async function signTenantLease(leaseId: string): Promise<TenantLease> {
+  const res = await apiFetch<any>(`/tenant/leases/${encodeURIComponent(leaseId)}/sign`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "{}",
+  });
+  if (res?.data && typeof res.data === "object") {
+    return res.data as TenantLease;
   }
   return res as TenantLease;
 }

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
@@ -41,6 +41,16 @@ describe("LandlordActiveLeasesPage", () => {
           tenantName: "Jane Tenant",
           tenantEmail: "jane@example.com",
           documentUrl: "https://example.com/lease.pdf",
+          leaseExecution: {
+            executionStatus: "fully_executed",
+            executionLabel: "Lease fully executed",
+            executionDescription: "The visible lease record indicates the current execution flow is complete.",
+            requiredNextAction: "none",
+            tenantSignatureStatus: "completed",
+            landlordSignatureStatus: "completed",
+            pdfStatus: "generated",
+            completedAt: "2026-01-01T00:00:00.000Z",
+          },
         },
       ],
     });
@@ -83,6 +93,7 @@ describe("LandlordActiveLeasesPage", () => {
     );
 
     expect(await screen.findByText("Harbour View")).toBeInTheDocument();
+    expect(screen.getByText("Lease fully executed")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "View" })).toHaveAttribute("href", "/leases/lease-1/ledger");
     expect(screen.getByRole("link", { name: "Email" })).toHaveAttribute(
       "href",

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
@@ -122,6 +122,21 @@ function statusBadge(status: string | null | undefined) {
   );
 }
 
+function executionNextActionLabel(value: string | null | undefined) {
+  switch (String(value || "").trim().toLowerCase()) {
+    case "tenant_signature":
+      return "Tenant signature needed";
+    case "landlord_signature":
+      return "Landlord signature needed";
+    case "review_signed_lease":
+      return "Review signed lease";
+    case "none":
+      return "No action needed";
+    default:
+      return "Complete lease details";
+  }
+}
+
 export default function LandlordActiveLeasesPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const view = searchParams.get("view") === "archived" ? "archived" : "active";
@@ -434,6 +449,16 @@ export default function LandlordActiveLeasesPage() {
                     </td>
                     <td style={{ padding: 12 }}>
                       <div>{statusBadge(lease.status)}</div>
+                      {lease.leaseExecution ? (
+                        <div style={{ display: "grid", gap: 4, marginTop: 6 }}>
+                          <div style={{ fontSize: 12, fontWeight: 700, color: "#0f172a" }}>
+                            {lease.leaseExecution.executionLabel}
+                          </div>
+                          <div style={{ color: "#64748b", fontSize: 12 }}>
+                            {executionNextActionLabel(lease.leaseExecution.requiredNextAction)}
+                          </div>
+                        </div>
+                      ) : null}
                       {lease.archivedAt ? (
                         <div style={{ color: "#64748b", fontSize: 12, marginTop: 4 }}>
                           Archived {formatDate(lease.archivedAt)}

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
@@ -68,6 +68,16 @@ describe("LeaseLedgerPage", () => {
         unitNumber: "101",
         tenantName: "Jane Tenant",
         status: "renewal_pending",
+        leaseExecution: {
+          executionStatus: "ready_for_landlord_signature",
+          executionLabel: "Waiting for landlord signature",
+          executionDescription: "Tenant signing appears complete and the next visible execution step belongs to the landlord.",
+          requiredNextAction: "landlord_signature",
+          tenantSignatureStatus: "completed",
+          landlordSignatureStatus: "needed",
+          pdfStatus: "generated",
+          completedAt: null,
+        },
       },
     });
     mocks.getLeaseNotes.mockResolvedValue({
@@ -94,6 +104,7 @@ describe("LeaseLedgerPage", () => {
 
     expect(await screen.findByText("Harbour View · Unit 101")).toBeInTheDocument();
     expect(screen.getByText(/Renewal pending/i)).toBeInTheDocument();
+    expect(screen.getByText("Waiting for landlord signature")).toBeInTheDocument();
     expect(screen.getByText("Call tenant next week")).toBeInTheDocument();
   });
 

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
@@ -44,6 +44,21 @@ function formatDate(value: string | null | undefined) {
   return parsed.toLocaleDateString();
 }
 
+function executionNextActionLabel(value: string | null | undefined) {
+  switch (String(value || "").trim().toLowerCase()) {
+    case "tenant_signature":
+      return "Tenant signature";
+    case "landlord_signature":
+      return "Landlord signature";
+    case "review_signed_lease":
+      return "Review signed lease";
+    case "none":
+      return "No action needed";
+    default:
+      return "Complete lease details";
+  }
+}
+
 function todayIso() {
   return new Date().toISOString().slice(0, 10);
 }
@@ -338,6 +353,28 @@ export default function LeaseLedgerPage() {
           <strong>{dollars(totals.balanceCents)}</strong>
         </div>
       </div>
+
+      {lease?.leaseExecution ? (
+        <div style={{ border: "1px solid #e2e8f0", borderRadius: 10, padding: 12, background: "#fff", display: "grid", gap: 8 }}>
+          <div style={{ fontSize: 12, color: "#64748b", textTransform: "uppercase", letterSpacing: "0.04em" }}>Lease execution</div>
+          <div style={{ fontWeight: 800 }}>{lease.leaseExecution.executionLabel}</div>
+          <div style={{ color: "#475569" }}>{lease.leaseExecution.executionDescription}</div>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(170px, 1fr))", gap: 8 }}>
+            <div>
+              <div style={{ fontSize: 12, color: "#64748b" }}>Tenant signature</div>
+              <strong>{lease.leaseExecution.tenantSignatureStatus.replace(/_/g, " ")}</strong>
+            </div>
+            <div>
+              <div style={{ fontSize: 12, color: "#64748b" }}>Landlord signature</div>
+              <strong>{lease.leaseExecution.landlordSignatureStatus.replace(/_/g, " ")}</strong>
+            </div>
+            <div>
+              <div style={{ fontSize: 12, color: "#64748b" }}>Next action</div>
+              <strong>{executionNextActionLabel(lease.leaseExecution.requiredNextAction)}</strong>
+            </div>
+          </div>
+        </div>
+      ) : null}
 
       {error ? <div style={{ color: "#b91c1c" }}>{error}</div> : null}
 

--- a/rentchain-frontend/src/pages/leaseSigningWorkspaceState.test.ts
+++ b/rentchain-frontend/src/pages/leaseSigningWorkspaceState.test.ts
@@ -138,4 +138,45 @@ describe("leaseSigningWorkspaceState", () => {
     expect(result.explanation).toMatch(/next visible signing step belongs to the landlord/i);
     expect(result.currentActor).toBe("landlord");
   });
+
+  it("prefers backend lease execution metadata when execution status is already surfaced", () => {
+    const result = buildLeaseSigningWorkspaceState({
+      audience: "tenant",
+      executionWorkspace: {
+        executionState: "execution_in_progress",
+        label: "Execution in progress",
+        summary: "Lease execution workspace",
+        explanation: "Started.",
+        blockers: [],
+        nextSteps: ["Review."],
+        timelineEvent: {
+          title: "Execution started",
+          description: "Started.",
+          actionRequired: false,
+        },
+      },
+      lease: {
+        leaseId: "lease-1",
+        startDate: "2026-05-01",
+        endDate: "2027-04-30",
+        monthlyRent: 1800,
+        status: "draft",
+        documentUrl: "https://example.com/lease.pdf",
+        leaseExecution: {
+          executionStatus: "ready_for_tenant_signature",
+          executionLabel: "Waiting for tenant signature",
+          executionDescription: "The lease document is ready and the next execution step belongs to the tenant.",
+          requiredNextAction: "tenant_signature",
+          tenantSignatureStatus: "needed",
+          landlordSignatureStatus: "blocked",
+          pdfStatus: "generated",
+          completedAt: null,
+        },
+      },
+    });
+
+    expect(result.signingState).toBe("awaiting_tenant_signature");
+    expect(result.label).toBe("Waiting for tenant signature");
+    expect(result.currentActor).toBe("tenant");
+  });
 });

--- a/rentchain-frontend/src/pages/leaseSigningWorkspaceState.ts
+++ b/rentchain-frontend/src/pages/leaseSigningWorkspaceState.ts
@@ -63,6 +63,10 @@ function hasBackendLeaseSignatureTiming(lease: TenantWorkspaceLease | null | und
   return Boolean(String(lease?.signatureStatus || "").trim());
 }
 
+function hasBackendLeaseExecution(lease: TenantWorkspaceLease | null | undefined): boolean {
+  return Boolean(String(lease?.leaseExecution?.executionStatus || "").trim());
+}
+
 export function buildLeaseSigningWorkspaceState(input: {
   audience: "landlord" | "tenant";
   executionWorkspace: LeaseExecutionWorkspaceView;
@@ -75,6 +79,104 @@ export function buildLeaseSigningWorkspaceState(input: {
   const backendSignatureStatus = normalizeStatus(lease?.signatureStatus);
   const backendSignatureLabel = String(lease?.signatureReadinessLabel || "").trim() || null;
   const backendSignatureDescription = String(lease?.signatureReadinessDescription || "").trim() || null;
+  const backendExecutionStatus = normalizeStatus(lease?.leaseExecution?.executionStatus);
+  const backendExecutionLabel = String(lease?.leaseExecution?.executionLabel || "").trim() || null;
+  const backendExecutionDescription = String(lease?.leaseExecution?.executionDescription || "").trim() || null;
+
+  if (hasBackendLeaseExecution(lease)) {
+    if (backendExecutionStatus === "fully_executed" || backendExecutionStatus === "landlord_signed") {
+      return {
+        signingState: "signed_or_completed",
+        label: backendExecutionLabel || stateLabel("signed_or_completed"),
+        summary: "Lease signing",
+        explanation:
+          backendExecutionDescription ||
+          "The visible lease record shows the current signing stage as complete.",
+        currentActor: null,
+        currentActorLabel: actorLabel(null),
+        blockers: [],
+        nextActions:
+          input.audience === "landlord"
+            ? [
+                "Use the existing lease and move-in tools for any remaining operational follow-through.",
+                "Keep this signing workspace as the high-level record of how the file moved past the current signing stage.",
+              ]
+            : [
+                "Review your lease details and watch for any next tenant-visible move-in instructions.",
+                "Use the lease page if you need to revisit the current signed document.",
+              ],
+        timelineEvent: {
+          title: "Lease signing completed",
+          description:
+            backendExecutionDescription ||
+            "The visible lease status now indicates the current signing stage is complete in the authorized workspace.",
+          actionRequired: false,
+        },
+      };
+    }
+
+    if (backendExecutionStatus === "ready_for_landlord_signature" || backendExecutionStatus === "tenant_signed") {
+      return {
+        signingState: "awaiting_landlord_signature",
+        label: backendExecutionLabel || stateLabel("awaiting_landlord_signature"),
+        summary: "Lease signing",
+        explanation:
+          backendExecutionDescription ||
+          "Tenant review appears complete and landlord signature is the next visible signing step.",
+        currentActor: "landlord",
+        currentActorLabel: actorLabel("landlord"),
+        blockers: [],
+        nextActions:
+          input.audience === "landlord"
+            ? [
+                "Review the current lease details and complete the landlord-side signing step in the existing lease workflow when appropriate.",
+                "Keep this workspace as the neutral status view rather than treating it as a legal-signing tool.",
+              ]
+            : [
+                "Your lease review appears complete for now.",
+                "Watch for the landlord-side signing step to finish in the existing workflow.",
+              ],
+        timelineEvent: {
+          title: "Awaiting landlord signature",
+          description:
+            backendExecutionDescription ||
+            "The visible lease status indicates tenant review appears complete and landlord signature is the next visible step.",
+          actionRequired: input.audience === "landlord",
+        },
+      };
+    }
+
+    if (backendExecutionStatus === "ready_for_tenant_signature") {
+      return {
+        signingState: "awaiting_tenant_signature",
+        label: backendExecutionLabel || stateLabel("awaiting_tenant_signature"),
+        summary: "Lease signing",
+        explanation:
+          backendExecutionDescription ||
+          "A visible lease document is available and the next visible signing step belongs to the tenant.",
+        currentActor: "tenant",
+        currentActorLabel: actorLabel("tenant"),
+        blockers: [],
+        nextActions:
+          input.audience === "landlord"
+            ? [
+                "Wait for the tenant-side signing step to complete in the current lease workflow.",
+                "Use this workspace to explain who is expected to act next without implying provider-backed e-sign automation.",
+              ]
+            : [
+                "Review the current lease details carefully before taking the next tenant-visible signing step.",
+                "Use the existing lease page for the current document and any tenant-safe follow-through.",
+              ],
+        timelineEvent: {
+          title: "Awaiting tenant signature",
+          description:
+            backendExecutionDescription ||
+            "A visible lease document and current status indicate the next signing step belongs to the tenant.",
+          actionRequired: input.audience === "tenant",
+        },
+      };
+    }
+  }
 
   if (hasBackendLeaseSignatureTiming(lease)) {
     if (backendSignatureStatus === "signed") {

--- a/rentchain-frontend/src/pages/tenant/TenantLeasePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantLeasePage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { getTenantLeaseWorkspace } from "../../api/tenantPortal";
+import { getTenantLeaseWorkspace, signTenantLease } from "../../api/tenantPortal";
 import {
   TenantEmptyState,
   TenantErrorState,
@@ -15,6 +15,7 @@ import {
 export default function TenantLeasePage() {
   const [data, setData] = React.useState<Awaited<ReturnType<typeof getTenantLeaseWorkspace>>>(null);
   const [loading, setLoading] = React.useState(true);
+  const [signing, setSigning] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
 
   const load = React.useCallback(async () => {
@@ -33,6 +34,58 @@ export default function TenantLeasePage() {
   React.useEffect(() => {
     void load();
   }, [load]);
+
+  async function handleTenantSign() {
+    if (!data?.leaseId) return;
+    setSigning(true);
+    setError(null);
+    try {
+      setData(await signTenantLease(data.leaseId));
+    } catch (err: any) {
+      setError(err?.payload?.error || err?.message || "Unable to record your lease signature.");
+    } finally {
+      setSigning(false);
+    }
+  }
+
+  const execution = data?.leaseExecution || null;
+  const timelineRows = execution
+    ? [
+        {
+          label: "Lease details",
+          value:
+            execution.executionStatus === "blocked"
+              ? "Needs attention"
+              : "Ready",
+        },
+        {
+          label: "Tenant signature",
+          value:
+            execution.tenantSignatureStatus === "completed"
+              ? "Completed"
+              : execution.tenantSignatureStatus === "needed"
+              ? "Needed"
+              : execution.tenantSignatureStatus === "blocked"
+              ? "Blocked"
+              : "Not required",
+        },
+        {
+          label: "Landlord signature",
+          value:
+            execution.landlordSignatureStatus === "completed"
+              ? "Completed"
+              : execution.landlordSignatureStatus === "needed"
+              ? "Needed"
+              : execution.landlordSignatureStatus === "blocked"
+              ? "Blocked"
+              : "Not required",
+        },
+        {
+          label: "Fully executed",
+          value: execution.executionStatus === "fully_executed" ? "Completed" : "Pending",
+        },
+      ]
+    : [];
 
   return (
     <TenantSurfaceShell
@@ -108,6 +161,36 @@ export default function TenantLeasePage() {
               ) : null}
             </div>
           </TenantInfoCard>
+
+          {execution ? (
+            <TenantInfoCard heading="Lease Execution" accent="#0f172a">
+              <div style={{ display: "grid", gap: 12 }}>
+                <div style={{ display: "grid", gap: 6 }}>
+                  <div style={{ fontWeight: 800 }}>{execution.executionLabel}</div>
+                  <div style={{ color: "var(--text-muted, #64748b)" }}>{execution.executionDescription}</div>
+                </div>
+
+                <TenantKeyValueGrid rows={timelineRows} />
+
+                {execution.completedAt ? (
+                  <div style={{ color: "var(--text-muted, #64748b)" }}>
+                    Completed at {formatDate(execution.completedAt)}
+                  </div>
+                ) : null}
+
+                {execution.requiredNextAction === "tenant_signature" && data?.leaseId ? (
+                  <div style={{ display: "grid", gap: 8 }}>
+                    <button type="button" onClick={() => void handleTenantSign()} disabled={signing}>
+                      {signing ? "Recording signature..." : "Confirm tenant signature"}
+                    </button>
+                    <div style={{ color: "var(--text-muted, #64748b)" }}>
+                      This records tenant signature metadata for the current lease workflow without storing any drawn signature image.
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+            </TenantInfoCard>
+          ) : null}
         </>
       ) : null}
     </TenantSurfaceShell>

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -12,6 +12,7 @@ import { TenantNav } from "../../components/layout/TenantNav";
 const tenantPortalApi = vi.hoisted(() => ({
   getTenantWorkspace: vi.fn(),
   getTenantLeaseWorkspace: vi.fn(),
+  signTenantLease: vi.fn(),
   listTenantWorkspaceMaintenance: vi.fn(),
   redeemTenantWorkspaceInvite: vi.fn(),
 }));
@@ -645,6 +646,16 @@ describe("tenant workspace frontend shell", () => {
       leasePdfStatus: "available",
       leasePdfLabel: "Lease document available",
       leasePdfDescription: "A tenant-safe lease document is available in this workspace.",
+      leaseExecution: {
+        executionStatus: "fully_executed",
+        executionLabel: "Lease fully executed",
+        executionDescription: "The visible lease record indicates the current execution flow is complete.",
+        requiredNextAction: "none",
+        tenantSignatureStatus: "completed",
+        landlordSignatureStatus: "completed",
+        pdfStatus: "generated",
+        completedAt: "2026-02-02T12:00:00.000Z",
+      },
     });
 
     render(
@@ -657,9 +668,79 @@ describe("tenant workspace frontend shell", () => {
     expect(screen.getByText(/\$1,800/i)).toBeInTheDocument();
     expect(screen.getByText(/^Lease signing complete$/i)).toBeInTheDocument();
     expect(screen.getByText(/^Lease document available$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^Lease fully executed$/i)).toBeInTheDocument();
     expect(screen.getByText(/^Drawn signature$/i)).toBeInTheDocument();
     expect(screen.getByText(/^Taylor Tenant$/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Open lease document/i })).toBeInTheDocument();
+  });
+
+  it("shows the tenant lease sign action only when backend execution metadata requires it", async () => {
+    tenantPortalApi.getTenantLeaseWorkspace.mockResolvedValue({
+      leaseId: "lease-2",
+      startDate: "2026-03-01",
+      endDate: "2027-02-28",
+      monthlyRent: 1900,
+      status: "ready_for_signature",
+      documentUrl: "https://example.com/sign.pdf",
+      signatureStatus: "awaiting_tenant_signature",
+      signatureReadinessLabel: "Awaiting tenant signature",
+      signatureReadinessDescription: "A tenant-safe lease document is available, and the next visible signing step belongs to the tenant.",
+      tenantSignature: null,
+      leasePdfStatus: "available",
+      leasePdfLabel: "Lease document available",
+      leasePdfDescription: "A tenant-safe lease document is available in this workspace.",
+      leaseExecution: {
+        executionStatus: "ready_for_tenant_signature",
+        executionLabel: "Waiting for tenant signature",
+        executionDescription: "The lease document is ready and the next execution step belongs to the tenant.",
+        requiredNextAction: "tenant_signature",
+        tenantSignatureStatus: "needed",
+        landlordSignatureStatus: "blocked",
+        pdfStatus: "generated",
+        completedAt: null,
+      },
+    });
+    tenantPortalApi.signTenantLease.mockResolvedValue({
+      leaseId: "lease-2",
+      startDate: "2026-03-01",
+      endDate: "2027-02-28",
+      monthlyRent: 1900,
+      status: "ready_for_signature",
+      documentUrl: "https://example.com/sign.pdf",
+      signatureStatus: "signed",
+      signatureReadinessLabel: "Lease signing complete",
+      signatureReadinessDescription: "The visible lease record shows the current signing stage as complete.",
+      tenantSignature: {
+        signedAt: "2026-03-02T12:00:00.000Z",
+        signatureMethod: "typed",
+        signatureDisplayName: "Taylor Tenant",
+      },
+      leasePdfStatus: "available",
+      leasePdfLabel: "Lease document available",
+      leasePdfDescription: "A tenant-safe lease document is available in this workspace.",
+      leaseExecution: {
+        executionStatus: "tenant_signed",
+        executionLabel: "Tenant signature completed",
+        executionDescription: "Tenant signature is recorded. The next supported execution step depends on landlord follow-through.",
+        requiredNextAction: "landlord_signature",
+        tenantSignatureStatus: "completed",
+        landlordSignatureStatus: "needed",
+        pdfStatus: "generated",
+        completedAt: null,
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <TenantLeasePage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole("button", { name: /Confirm tenant signature/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Confirm tenant signature/i }));
+
+    await waitFor(() => expect(tenantPortalApi.signTenantLease).toHaveBeenCalledWith("lease-2"));
+    expect(await screen.findByText(/^Tenant signature completed$/i)).toBeInTheDocument();
   });
 
   it("renders maintenance page with safe projected data", async () => {


### PR DESCRIPTION
This PR introduces Lease Execution v2.

Includes:
- deterministic leaseExecution metadata
- lease execution status across tenant and landlord lease surfaces
- tenant-scoped metadata-only lease signing action
- idempotent tenant signing behavior
- lease.tenant_signed event only on real state change
- frontend execution cards, timeline/status display, and fallback compatibility
- focused backend/frontend test coverage

Guardrails preserved:
- no landlord signing model added
- no raw signature blob/base64 storage or exposure
- no application signature blob reuse
- no PDF mutation/stamping
- no external e-sign provider
- no legal overclaiming
- no reminders/jobs/notifications
- no payment activation
- no public share package changes
- no permission expansion

Note:
- leaseRoutes.active.test.ts was rerun outside sandbox because sandbox blocks local port binding.
- Backend typecheck, focused backend tests, focused frontend tests, and frontend build passed.
- Existing frontend chunk-size warning remains unchanged and out of scope.