### PR TITLE
feat: add tenant credibility signals

### DIFF
--- a/rentchain-api/src/routes/__tests__/rentalApplicationsReviewSummaryRisk.test.ts
+++ b/rentchain-api/src/routes/__tests__/rentalApplicationsReviewSummaryRisk.test.ts
@@ -314,8 +314,19 @@ describe("rentalApplications review summary risk surface", () => {
         "Identity profile has stronger supporting signals.",
       ])
     );
+    expect(res.body?.tenantCredibilitySummary).toEqual(
+      expect.objectContaining({
+        completenessLevel: expect.stringMatching(/low|medium|high/),
+        verificationLevel: expect.stringMatching(/none|partial|strong/),
+        summaryLabel: expect.any(String),
+        summaryDescription: expect.any(String),
+      })
+    );
     expect(res.body?.tenantIdentitySummary?.documents).toBeUndefined();
     expect(res.body?.tenantIdentitySummary?.screening).toBeUndefined();
+    expect(res.body?.tenantCredibilitySummary?.signals).toBeUndefined();
+    expect(JSON.stringify(res.body?.tenantCredibilitySummary || {})).not.toContain("transunion");
+    expect(JSON.stringify(res.body?.tenantCredibilitySummary || {})).not.toContain("ref-1");
     expect(JSON.stringify(res.body?.trustContext || {})).not.toContain("transunion");
     expect(JSON.stringify(res.body?.trustContext || {})).not.toContain("ref-1");
   });

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -462,6 +462,23 @@ describe("tenantPortalRoutes foundation", () => {
     expect(res.body?.data?.maintenance?.[0]?.internalCost).toBeUndefined();
     expect(res.body?.data?.tenantIdentityRecord?.documents?.documentChecklist).toBeUndefined();
     expect(res.body?.data?.tenantIdentityRecord?.screening?.provider).toBeUndefined();
+    expect(res.body?.data?.tenantCredibilitySignals).toEqual(
+      expect.objectContaining({
+        signals: expect.arrayContaining([
+          expect.objectContaining({ key: "profile_complete" }),
+          expect.objectContaining({ key: "application_reusable" }),
+          expect.objectContaining({ key: "documents_available" }),
+          expect.objectContaining({ key: "screening_completed" }),
+          expect.objectContaining({ key: "lease_history_present" }),
+        ]),
+        summary: expect.objectContaining({
+          completenessLevel: expect.stringMatching(/low|medium|high/),
+          verificationLevel: expect.stringMatching(/none|partial|strong/),
+          summaryLabel: expect.any(String),
+          summaryDescription: expect.any(String),
+        }),
+      })
+    );
 
     const eventDocs = Array.from(ensureCollection("event_log").values());
     expect(eventDocs.some((event) => event.event_type === "tenant_workspace_viewed")).toBe(true);

--- a/rentchain-api/src/routes/rentalApplicationsRoutes.ts
+++ b/rentchain-api/src/routes/rentalApplicationsRoutes.ts
@@ -67,6 +67,7 @@ import {
   loadLandlordSafeTenantIdentitySummary,
 } from "../services/tenantPortal/tenantProfileService";
 import { deriveLandlordTrustContext } from "../lib/trust/deriveLandlordTrustContext";
+import { deriveTenantCredibilitySignals } from "../services/tenantCredibility/deriveTenantCredibilitySignals";
 import {
   buildQuoteId,
   buildScreeningMonetizationPatch,
@@ -4104,19 +4105,71 @@ router.get("/rental-applications/:id/review-summary", async (req: any, res) => {
       getLatestApplicationRisk({ applicationId: id }),
       loadLandlordSafeTenantIdentitySummary({ applicationId: id, application: access.data }),
     ]);
+    const landlordSafeReusableApplication = deriveLandlordSafeApplicationReusableFromApplication(access.data);
+    const { landlordSafeSummary: tenantCredibilitySummary } = deriveTenantCredibilitySignals({
+      tenantIdentityRecord: tenantIdentitySummary
+        ? {
+            identityStatus: tenantIdentitySummary.identityStatus,
+            verification: tenantIdentitySummary.verification,
+            readinessLabel: tenantIdentitySummary.readinessLabel,
+            readinessDescription: tenantIdentitySummary.readinessDescription,
+            profile: {
+              completionStatus:
+                tenantIdentitySummary.identityStatus === "ready" ||
+                tenantIdentitySummary.identityStatus === "verified"
+                  ? "complete"
+                  : tenantIdentitySummary.identityStatus === "incomplete"
+                  ? "in_progress"
+                  : "missing",
+            },
+            application: {
+              reusable: landlordSafeReusableApplication,
+              lastSubmittedAt: null,
+            },
+            documents: {
+              completionStatus:
+                tenantIdentitySummary.verification.level === "strong"
+                  ? "complete"
+                  : tenantIdentitySummary.verification.level === "partial"
+                  ? "in_progress"
+                  : "missing",
+              missingCategories: [],
+            },
+            screening: {
+              status:
+                tenantIdentitySummary.verification.level === "strong"
+                  ? "completed"
+                  : tenantIdentitySummary.verification.level === "partial"
+                  ? "in_progress"
+                  : "not_started",
+              lastCompletedAt: null,
+            },
+            leases: { activeCount: 0, historicalCount: 0, lastSignedAt: null },
+          }
+        : null,
+      leaseExecution: null,
+    });
     const trustContext = deriveLandlordTrustContext({
       tenantIdentitySummary,
       completenessScore: summary?.derived?.completeness?.score ?? null,
       completenessFlags: Array.isArray(summary?.derived?.flags) ? summary.derived.flags : [],
       screeningStatus: summary?.screening?.status,
-      applicationReusable: deriveLandlordSafeApplicationReusableFromApplication(access.data),
+      applicationReusable: landlordSafeReusableApplication,
     });
     const decisionSummary = buildApplicationDecisionSummary({
       applicationId: id,
       application: access.data,
       reviewSummary: summary,
     });
-    return res.json({ ok: true, summary, decisionSummary, risk, tenantIdentitySummary, trustContext });
+    return res.json({
+      ok: true,
+      summary,
+      decisionSummary,
+      risk,
+      tenantIdentitySummary,
+      trustContext,
+      tenantCredibilitySummary,
+    });
   } catch (err: any) {
     console.error("[review_summary] failed", err?.message || err);
     return res.status(500).json({

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -17,6 +17,7 @@ import { deriveLeaseExecution } from "../services/leaseExecution/deriveLeaseExec
 import { recordTenantEvent } from "../services/tenantPortal/tenantEventLogService";
 import { redeemTenancyInvite } from "../services/tenantPortal/tenantInviteService";
 import { loadTenantIdentityRecord, loadTenantProfileProjection } from "../services/tenantPortal/tenantProfileService";
+import { deriveTenantCredibilitySignals } from "../services/tenantCredibility/deriveTenantCredibilitySignals";
 import {
   loadTenantCommunicationsWorkspace,
   markTenantCommunicationsRead,
@@ -2910,6 +2911,10 @@ async function handleTenantWorkspaceSummary(req: any, res: any) {
       userEmail: req.user?.email,
     }),
   ]);
+  const { tenantCredibilitySignals } = deriveTenantCredibilitySignals({
+    tenantIdentityRecord,
+    leaseExecution: workspace.lease?.leaseExecution || null,
+  });
   await recordTenantEvent({
     eventType: "tenant_workspace_viewed",
     entityType: "tenant_workspace",
@@ -2936,6 +2941,7 @@ async function handleTenantWorkspaceSummary(req: any, res: any) {
       lease: workspace.lease,
       maintenance: workspace.maintenance,
       tenantIdentityRecord,
+      tenantCredibilitySignals,
     },
   });
 }

--- a/rentchain-api/src/services/tenantCredibility/__tests__/deriveTenantCredibilitySignals.test.ts
+++ b/rentchain-api/src/services/tenantCredibility/__tests__/deriveTenantCredibilitySignals.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { deriveTenantCredibilitySignals } from "../deriveTenantCredibilitySignals";
+
+describe("deriveTenantCredibilitySignals", () => {
+  it("derives full signals from an available tenant identity record", () => {
+    const result = deriveTenantCredibilitySignals({
+      tenantIdentityRecord: {
+        identityStatus: "verified",
+        profile: { completionStatus: "complete" },
+        application: { reusable: true, lastSubmittedAt: null },
+        documents: { completionStatus: "complete", missingCategories: [] },
+        screening: { status: "completed", lastCompletedAt: null },
+        leases: { activeCount: 1, historicalCount: 1, lastSignedAt: null },
+        verification: { level: "strong" },
+        readinessLabel: "Well established",
+        readinessDescription: "desc",
+      },
+      leaseExecution: {
+        executionStatus: "fully_executed",
+        executionLabel: "Lease fully executed",
+        executionDescription: "desc",
+        requiredNextAction: "none",
+        tenantSignatureStatus: "completed",
+        landlordSignatureStatus: "completed",
+        pdfStatus: "generated",
+        completedAt: "2026-01-01T00:00:00.000Z",
+      },
+    });
+
+    expect(result.tenantCredibilitySignals.summary).toEqual({
+      completenessLevel: "high",
+      verificationLevel: "strong",
+      summaryLabel: "Credibility established",
+      summaryDescription: "Most credibility signals are available in your current record.",
+    });
+    expect(result.tenantCredibilitySignals.signals).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: "profile_complete", status: "verified" }),
+        expect.objectContaining({ key: "application_reusable", status: "available" }),
+        expect.objectContaining({ key: "documents_available", status: "available" }),
+        expect.objectContaining({ key: "screening_completed", status: "verified" }),
+        expect.objectContaining({ key: "lease_history_present", status: "verified" }),
+      ])
+    );
+  });
+
+  it("fails closed when no tenant identity record is available", () => {
+    const result = deriveTenantCredibilitySignals({
+      tenantIdentityRecord: null,
+      leaseExecution: null,
+    });
+
+    expect(result.tenantCredibilitySignals.signals.every((signal) => signal.status === "not_available")).toBe(true);
+    expect(result.landlordSafeSummary).toEqual({
+      completenessLevel: "low",
+      verificationLevel: "none",
+      summaryLabel: "Getting started",
+      summaryDescription: "Credibility signals are still limited in the current record.",
+    });
+  });
+});

--- a/rentchain-api/src/services/tenantCredibility/deriveTenantCredibilitySignals.ts
+++ b/rentchain-api/src/services/tenantCredibility/deriveTenantCredibilitySignals.ts
@@ -1,0 +1,197 @@
+import type {
+  TenantIdentityRecord,
+  TenantIdentityVerificationLevel,
+} from "../tenantPortal/tenantProfileService";
+import type { LeaseExecution } from "../leaseExecution/deriveLeaseExecution";
+
+export type TenantCredibilitySignalStatus =
+  | "not_available"
+  | "available"
+  | "verified"
+  | "incomplete";
+
+export type TenantCredibilitySignalKey =
+  | "profile_complete"
+  | "application_reusable"
+  | "documents_available"
+  | "screening_completed"
+  | "lease_history_present";
+
+export type TenantCredibilitySignals = {
+  signals: Array<{
+    key: TenantCredibilitySignalKey;
+    label: string;
+    description: string;
+    status: TenantCredibilitySignalStatus;
+  }>;
+  summary: {
+    completenessLevel: "low" | "medium" | "high";
+    verificationLevel: TenantIdentityVerificationLevel;
+    summaryLabel: string;
+    summaryDescription: string;
+  };
+};
+
+export type LandlordSafeTenantCredibilitySummary = TenantCredibilitySignals["summary"];
+
+type DeriveTenantCredibilitySignalsInput = {
+  tenantIdentityRecord: TenantIdentityRecord | null;
+  leaseExecution?: LeaseExecution | null;
+};
+
+export function deriveTenantCredibilitySignals(
+  input: DeriveTenantCredibilitySignalsInput
+): {
+  tenantCredibilitySignals: TenantCredibilitySignals;
+  landlordSafeSummary: LandlordSafeTenantCredibilitySummary;
+} {
+  const record = input.tenantIdentityRecord || null;
+  const leaseExecution = input.leaseExecution || null;
+
+  const profileSignalStatus: TenantCredibilitySignalStatus = !record
+    ? "not_available"
+    : record.profile.completionStatus === "complete"
+    ? "verified"
+    : record.profile.completionStatus === "missing"
+    ? "not_available"
+    : "incomplete";
+
+  const applicationSignalStatus: TenantCredibilitySignalStatus = !record
+    ? "not_available"
+    : record.application.reusable
+    ? "available"
+    : "incomplete";
+
+  const documentSignalStatus: TenantCredibilitySignalStatus = !record
+    ? "not_available"
+    : record.documents.completionStatus === "complete"
+    ? "available"
+    : record.documents.completionStatus === "missing"
+    ? "not_available"
+    : "incomplete";
+
+  const screeningSignalStatus: TenantCredibilitySignalStatus = !record
+    ? "not_available"
+    : record.screening.status === "completed"
+    ? "verified"
+    : record.screening.status === "in_progress"
+    ? "available"
+    : record.screening.status === "not_started"
+    ? "not_available"
+    : "incomplete";
+
+  const hasLeaseHistory = Boolean(
+    record && (record.leases.activeCount > 0 || record.leases.historicalCount > 0)
+  );
+  const leaseExecutionVerified = Boolean(
+    leaseExecution &&
+      (leaseExecution.executionStatus === "fully_executed" ||
+        leaseExecution.executionStatus === "landlord_signed")
+  );
+  const leaseSignalStatus: TenantCredibilitySignalStatus = !record
+    ? "not_available"
+    : hasLeaseHistory
+    ? leaseExecutionVerified
+      ? "verified"
+      : "available"
+    : "not_available";
+
+  const signals: TenantCredibilitySignals["signals"] = [
+    {
+      key: "profile_complete",
+      label: "Profile complete",
+      description:
+        profileSignalStatus === "verified"
+          ? "Your core profile details are organized and available."
+          : profileSignalStatus === "incomplete"
+          ? "Some core profile details still need attention."
+          : "Profile details are not available yet.",
+      status: profileSignalStatus,
+    },
+    {
+      key: "application_reusable",
+      label: "Application reusable",
+      description:
+        applicationSignalStatus === "available"
+          ? "Your application details are organized for reuse."
+          : applicationSignalStatus === "incomplete"
+          ? "Your application details are still being organized."
+          : "Reusable application details are not available yet.",
+      status: applicationSignalStatus,
+    },
+    {
+      key: "documents_available",
+      label: "Documents available",
+      description:
+        documentSignalStatus === "available"
+          ? "Supporting documents are available in your current tenant-safe record."
+          : documentSignalStatus === "incomplete"
+          ? "Supporting documents are still incomplete or under review."
+          : "Supporting documents are not available yet.",
+      status: documentSignalStatus,
+    },
+    {
+      key: "screening_completed",
+      label: "Screening completed",
+      description:
+        screeningSignalStatus === "verified"
+          ? "Screening is complete in the current normalized status view."
+          : screeningSignalStatus === "available"
+          ? "Screening is underway in the current normalized status view."
+          : screeningSignalStatus === "incomplete"
+          ? "Screening still needs attention in the current normalized status view."
+          : "Screening is not available yet in the current normalized status view.",
+      status: screeningSignalStatus,
+    },
+    {
+      key: "lease_history_present",
+      label: "Lease history present",
+      description:
+        leaseSignalStatus === "verified"
+          ? "Lease history is present with a completed execution signal."
+          : leaseSignalStatus === "available"
+          ? "Lease history is present in your current record."
+          : "Lease history is not available yet.",
+      status: leaseSignalStatus,
+    },
+  ];
+
+  const availableCount = signals.filter(
+    (signal) => signal.status === "available" || signal.status === "verified"
+  ).length;
+  const verifiedCount = signals.filter((signal) => signal.status === "verified").length;
+  const completenessLevel: TenantCredibilitySignals["summary"]["completenessLevel"] =
+    availableCount >= 4 ? "high" : availableCount >= 2 ? "medium" : "low";
+  const verificationLevel: TenantIdentityVerificationLevel =
+    record?.verification.level || "none";
+
+  const summaryLabel =
+    completenessLevel === "high"
+      ? "Credibility established"
+      : completenessLevel === "medium"
+      ? "Building credibility"
+      : "Getting started";
+  const summaryDescription =
+    completenessLevel === "high"
+      ? "Most credibility signals are available in your current record."
+      : completenessLevel === "medium"
+      ? "Some credibility signals are available, while others are still being organized."
+      : verifiedCount > 0
+      ? "Only a limited set of credibility signals is available so far."
+      : "Credibility signals are still limited in the current record.";
+
+  const summary: TenantCredibilitySignals["summary"] = {
+    completenessLevel,
+    verificationLevel,
+    summaryLabel,
+    summaryDescription,
+  };
+
+  return {
+    tenantCredibilitySignals: {
+      signals,
+      summary,
+    },
+    landlordSafeSummary: summary,
+  };
+}

--- a/rentchain-frontend/src/api/reviewSummaryApi.ts
+++ b/rentchain-frontend/src/api/reviewSummaryApi.ts
@@ -78,6 +78,12 @@ export type ApplicationReviewSummary = ReviewSummaryCore & {
     readinessDescription: string;
   } | null;
   trustContext?: LandlordTrustContext | null;
+  tenantCredibilitySummary?: {
+    completenessLevel: "low" | "medium" | "high";
+    verificationLevel: "none" | "partial" | "strong";
+    summaryLabel: string;
+    summaryDescription: string;
+  } | null;
 };
 
 export class ReviewSummaryApiError extends Error {
@@ -124,6 +130,8 @@ export async function fetchReviewSummary(applicationId: string): Promise<Applica
     risk: ((res?.risk || null) as RiskAgentReviewSnapshot) || null,
     tenantIdentitySummary: (res?.tenantIdentitySummary || null) as ApplicationReviewSummary["tenantIdentitySummary"],
     trustContext: (res?.trustContext || null) as ApplicationReviewSummary["trustContext"],
+    tenantCredibilitySummary:
+      (res?.tenantCredibilitySummary || null) as ApplicationReviewSummary["tenantCredibilitySummary"],
   };
 }
 

--- a/rentchain-frontend/src/api/tenantPortal.ts
+++ b/rentchain-frontend/src/api/tenantPortal.ts
@@ -210,6 +210,26 @@ export type TenantIdentityRecord = {
   readinessDescription: string;
 };
 
+export type TenantCredibilitySignals = {
+  signals: Array<{
+    key:
+      | "profile_complete"
+      | "application_reusable"
+      | "documents_available"
+      | "screening_completed"
+      | "lease_history_present";
+    label: string;
+    description: string;
+    status: "not_available" | "available" | "verified" | "incomplete";
+  }>;
+  summary: {
+    completenessLevel: "low" | "medium" | "high";
+    verificationLevel: "none" | "partial" | "strong";
+    summaryLabel: string;
+    summaryDescription: string;
+  };
+};
+
 export type TenantWorkspaceSummary = {
   context: TenantWorkspaceContext;
   property: TenantWorkspaceProperty | null;
@@ -217,6 +237,7 @@ export type TenantWorkspaceSummary = {
   lease: TenantWorkspaceLease | null;
   maintenance: TenantWorkspaceMaintenance[];
   tenantIdentityRecord?: TenantIdentityRecord | null;
+  tenantCredibilitySignals?: TenantCredibilitySignals | null;
 };
 
 export async function getTenantWorkspace(): Promise<TenantWorkspaceSummary> {

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
@@ -125,6 +125,12 @@ describe("ApplicationReviewSummaryPage", () => {
         recommendedNextAction: "review_application",
         decisionSupportLevel: "medium",
       },
+      tenantCredibilitySummary: {
+        completenessLevel: "high",
+        verificationLevel: "partial",
+        summaryLabel: "Credibility established",
+        summaryDescription: "Most credibility signals are available in the current record.",
+      },
     } as any);
 
     renderPage();
@@ -182,6 +188,9 @@ describe("ApplicationReviewSummaryPage", () => {
     expect(await screen.findByText("Landlord Decision Panel")).toBeInTheDocument();
     expect(await screen.findByText("Identity verification completed")).toBeInTheDocument();
     expect(await screen.findByText("Trust guidance")).toBeInTheDocument();
+    expect(await screen.findByText("Credibility summary")).toBeInTheDocument();
+    expect(await screen.findByText("Credibility established")).toBeInTheDocument();
+    expect(await screen.findByText("Most credibility signals are available in the current record.")).toBeInTheDocument();
     expect((await screen.findAllByText("Ready for review")).length).toBeGreaterThan(0);
     expect(await screen.findByText("Application information is mostly complete.")).toBeInTheDocument();
     expect(await screen.findByText("Employment or income details are still incomplete.")).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
@@ -1708,6 +1708,20 @@ function ApplicationReviewSummaryPageBody() {
             </Card>
           ) : null}
 
+          {summary.tenantCredibilitySummary ? (
+            <Card style={{ display: "grid", gap: 8 }}>
+              <div style={{ fontWeight: 700 }}>Credibility summary</div>
+              <div style={{ fontSize: 13, color: text.subtle }}>
+                {summary.tenantCredibilitySummary.summaryDescription}
+              </div>
+              <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 8 }}>
+                {kv("Summary", summary.tenantCredibilitySummary.summaryLabel)}
+                {kv("Completeness level", summary.tenantCredibilitySummary.completenessLevel)}
+                {kv("Verification level", summary.tenantCredibilitySummary.verificationLevel)}
+              </div>
+            </Card>
+          ) : null}
+
           <Card style={{ display: "grid", gap: 8 }}>
             <div style={{ fontWeight: 700 }}>Applicant Overview</div>
             <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 8 }}>

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -195,6 +195,21 @@ describe("tenant workspace frontend shell", () => {
         readinessLabel: "Ready to apply",
         readinessDescription: "Your core profile, reusable application details, and supporting records are ready for most rental workflows.",
       },
+      tenantCredibilitySignals: {
+        signals: [
+          { key: "profile_complete", label: "Profile complete", description: "desc", status: "verified" },
+          { key: "application_reusable", label: "Application reusable", description: "desc", status: "available" },
+          { key: "documents_available", label: "Documents available", description: "desc", status: "incomplete" },
+          { key: "screening_completed", label: "Screening completed", description: "desc", status: "available" },
+          { key: "lease_history_present", label: "Lease history present", description: "desc", status: "verified" },
+        ],
+        summary: {
+          completenessLevel: "high",
+          verificationLevel: "partial",
+          summaryLabel: "Credibility established",
+          summaryDescription: "Most credibility signals are available in your current record.",
+        },
+      },
     });
     tenantAttachmentsApi.getTenantAttachments.mockResolvedValue({
       ok: true,
@@ -404,6 +419,21 @@ describe("tenant workspace frontend shell", () => {
         readinessLabel: "Ready to apply",
         readinessDescription: "Your core profile, reusable application details, and supporting records are ready for most rental workflows.",
       },
+      tenantCredibilitySignals: {
+        signals: [
+          { key: "profile_complete", label: "Profile complete", description: "desc", status: "verified" },
+          { key: "application_reusable", label: "Application reusable", description: "desc", status: "available" },
+          { key: "documents_available", label: "Documents available", description: "desc", status: "incomplete" },
+          { key: "screening_completed", label: "Screening completed", description: "desc", status: "available" },
+          { key: "lease_history_present", label: "Lease history present", description: "desc", status: "verified" },
+        ],
+        summary: {
+          completenessLevel: "high",
+          verificationLevel: "partial",
+          summaryLabel: "Credibility established",
+          summaryDescription: "Most credibility signals are available in your current record.",
+        },
+      },
     });
 
     render(
@@ -420,6 +450,13 @@ describe("tenant workspace frontend shell", () => {
     expect(screen.getByText(/Recent workflow updates/i)).toBeInTheDocument();
     expect(await screen.findByText(/Profile completion/i)).toBeInTheDocument();
     expect(screen.getByText(/^Your Rental Identity$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^Credibility signals$/i)).toBeInTheDocument();
+    expect(screen.getByText(/Credibility established/i)).toBeInTheDocument();
+    expect(screen.getByText(/Profile complete/i)).toBeInTheDocument();
+    expect(screen.getByText(/Application reusable/i)).toBeInTheDocument();
+    expect(screen.getByText(/Documents available/i)).toBeInTheDocument();
+    expect(screen.getByText(/Screening completed/i)).toBeInTheDocument();
+    expect(screen.getByText(/Lease history present/i)).toBeInTheDocument();
     expect(screen.getByText(/Ready to apply/i)).toBeInTheDocument();
     expect(screen.getByText(/Missing pieces/i)).toBeInTheDocument();
     expect(screen.getByText(/Income documents/i)).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
@@ -261,6 +261,7 @@ export default function TenantWorkspacePage() {
     lease: data?.lease,
   });
   const tenantIdentityRecord = data?.tenantIdentityRecord || null;
+  const tenantCredibilitySignals = data?.tenantCredibilitySignals || null;
   const communicationsView = buildTenantCommunicationsWorkspaceState(communications);
   const screeningSummary = buildTenantScreeningDashboardSummary(screenings);
   const notificationItems = filterStructuredNotificationsByPreferences(
@@ -469,6 +470,39 @@ export default function TenantWorkspacePage() {
         ) : (
           <div style={{ color: textTokens.secondary }}>
             Your rental identity summary will appear here once enough tenant-safe records are available.
+          </div>
+        )}
+      </TenantInfoCard>
+
+      <TenantInfoCard heading="Credibility signals" accent="#0f766e">
+        {tenantCredibilitySignals ? (
+          <div style={{ display: "grid", gap: spacing.sm }}>
+            <div style={{ display: "grid", gap: 4 }}>
+              <div style={{ fontSize: "1.02rem", fontWeight: 800, color: textTokens.primary }}>
+                {tenantCredibilitySignals.summary.summaryLabel}
+              </div>
+              <div style={{ color: textTokens.secondary, lineHeight: 1.6 }}>
+                {tenantCredibilitySignals.summary.summaryDescription}
+              </div>
+            </div>
+
+            <TenantKeyValueGrid
+              rows={tenantCredibilitySignals.signals.map((signal) => ({
+                label: signal.label,
+                value:
+                  signal.status === "verified"
+                    ? "Verified"
+                    : signal.status === "available"
+                    ? "Available"
+                    : signal.status === "incomplete"
+                    ? "Incomplete"
+                    : "Not available",
+              }))}
+            />
+          </div>
+        ) : (
+          <div style={{ color: textTokens.secondary }}>
+            Credibility signals will appear here once enough tenant-safe identity signals are available.
           </div>
         )}
       </TenantInfoCard>


### PR DESCRIPTION
This PR introduces Tenant Credibility Signals v1.

Includes:
- read-derived tenant credibility signals
- tenant workspace Credibility signals card
- restricted landlord-safe tenantCredibilitySummary on review-summary
- neutral signal language for profile, application reuse, documents, screening, and lease history
- focused backend/frontend test coverage

Guardrails preserved:
- no new collections or writes
- no scoring, ranking, or predictive logic
- no provider-specific screening exposure
- no raw document/screening/signature/share-token exposure
- no landlord exposure of individual signals
- no AgentDecisionPanel or analytics decision integration
- no public share package changes
- no permission expansion

Note:
- rentalApplicationsReviewSummaryRisk.test.ts required an outside-sandbox rerun because sandbox blocks local port binding.
- build:app still emits the existing chunk-size warning; unchanged and out of scope.