### PR TITLE
feat: add identity audit timeline

### DIFF
--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -53,6 +53,14 @@ function queryCollection(name: string, filters: Array<{ field: string; op: strin
 
 const dbMock = {
   collection: (name: string) => ({
+    get: async () => {
+      const docs = Array.from(ensureCollection(name).entries()).map(([id, data]) => ({
+        id,
+        exists: true,
+        data: () => clone(data),
+      }));
+      return { docs, empty: docs.length === 0, size: docs.length };
+    },
     doc: (id?: string) => {
       const docId = id || `doc_${ensureCollection(name).size + 1}`;
       return {
@@ -411,6 +419,54 @@ describe("tenantPortalRoutes foundation", () => {
   });
 
   it("returns safe projected workspace data and writes compact events", async () => {
+    ensureCollection("canonicalEvents").set("event-application-created", {
+      id: "event-application-created",
+      version: "v1",
+      type: "application.created",
+      domain: "application",
+      action: "created",
+      actor: { type: "tenant", id: "tenant-1" },
+      resource: { type: "rental_application", id: "app-1" },
+      occurredAt: "2026-01-01T09:00:00.000Z",
+      recordedAt: "2026-01-01T09:00:00.000Z",
+      visibility: "tenant",
+      summary: "Application created",
+    });
+    ensureCollection("canonicalEvents").set("event-screening-consent", {
+      id: "event-screening-consent",
+      version: "v1",
+      type: "screening_consent_confirmed",
+      domain: "screening",
+      action: "screening_consent_confirmed",
+      actor: { type: "tenant", id: "tenant-1" },
+      resource: { type: "screening_request", id: "screening-1", parentType: "rental_application", parentId: "app-1" },
+      occurredAt: "2026-01-03T09:00:00.000Z",
+      recordedAt: "2026-01-03T09:00:00.000Z",
+      visibility: "tenant",
+      summary: "Tenant screening consent confirmed",
+      metadata: {
+        tenantId: "tenant-1",
+        applicationId: "app-1",
+        providerLabel: "TransUnion",
+      },
+    });
+    ensureCollection("canonicalEvents").set("event-lease-signed", {
+      id: "event-lease-signed",
+      version: "v1",
+      type: "lease.tenant_signed",
+      domain: "lease",
+      action: "tenant_signed",
+      actor: { type: "tenant", id: "tenant-1", displayName: "Taylor Tenant" },
+      resource: { type: "lease", id: "lease-1" },
+      occurredAt: "2026-02-01T10:00:00.000Z",
+      recordedAt: "2026-02-01T10:00:00.000Z",
+      visibility: "tenant",
+      summary: "Tenant signed lease",
+      metadata: {
+        tenantId: "tenant-1",
+      },
+    });
+
     const router = (await import("../tenantPortalRoutes")).default;
     const res = await invokeRouter(router, {
       method: "GET",
@@ -479,6 +535,18 @@ describe("tenantPortalRoutes foundation", () => {
         }),
       })
     );
+    expect(res.body?.data?.identityTimeline).toEqual({
+      events: [
+        {
+          type: "lease.tenant_signed",
+          label: "Lease signed",
+          description: "Tenant lease signing was recorded.",
+          occurredAt: "2026-02-01T10:00:00.000Z",
+        },
+      ],
+    });
+    expect(res.body?.data?.identityTimeline?.events?.[0]?.id).toBeUndefined();
+    expect(res.body?.data?.identityTimeline?.events?.[0]?.metadata).toBeUndefined();
 
     const eventDocs = Array.from(ensureCollection("event_log").values());
     expect(eventDocs.some((event) => event.event_type === "tenant_workspace_viewed")).toBe(true);

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -18,6 +18,7 @@ import { recordTenantEvent } from "../services/tenantPortal/tenantEventLogServic
 import { redeemTenancyInvite } from "../services/tenantPortal/tenantInviteService";
 import { loadTenantIdentityRecord, loadTenantProfileProjection } from "../services/tenantPortal/tenantProfileService";
 import { deriveTenantCredibilitySignals } from "../services/tenantCredibility/deriveTenantCredibilitySignals";
+import { deriveIdentityTimeline } from "../services/identityTimeline/deriveIdentityTimeline";
 import {
   loadTenantCommunicationsWorkspace,
   markTenantCommunicationsRead,
@@ -2903,12 +2904,17 @@ async function handleTenantWorkspaceSummary(req: any, res: any) {
   const context = await resolveWorkspaceContextOrRespond(req, res);
   if (!context) return;
 
-  const [workspace, tenantIdentityRecord] = await Promise.all([
+  const [workspace, tenantIdentityRecord, identityTimeline] = await Promise.all([
     loadTenantWorkspaceData(context),
     loadTenantIdentityRecord({
       context,
       userId: String(req.user?.id || "").trim(),
       userEmail: req.user?.email,
+    }),
+    deriveIdentityTimeline({
+      tenantId: String(req.user?.tenantId || context.tenantId || "").trim(),
+      applicationId: context.applicationId,
+      leaseId: context.leaseId,
     }),
   ]);
   const { tenantCredibilitySignals } = deriveTenantCredibilitySignals({
@@ -2942,6 +2948,7 @@ async function handleTenantWorkspaceSummary(req: any, res: any) {
       maintenance: workspace.maintenance,
       tenantIdentityRecord,
       tenantCredibilitySignals,
+      identityTimeline,
     },
   });
 }

--- a/rentchain-api/src/services/identityTimeline/__tests__/deriveIdentityTimeline.test.ts
+++ b/rentchain-api/src/services/identityTimeline/__tests__/deriveIdentityTimeline.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { collections, dbMock } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, any>>();
+
+  function ensureCollection(name: string) {
+    if (!collections.has(name)) {
+      collections.set(name, new Map<string, any>());
+    }
+    return collections.get(name)!;
+  }
+
+  return {
+    collections,
+    dbMock: {
+      collection: (name: string) => ({
+        async get() {
+          const docs = Array.from(ensureCollection(name).entries()).map(([id, data]) => ({
+            id,
+            data: () => data,
+          }));
+          return { docs, empty: docs.length === 0, size: docs.length };
+        },
+      }),
+    },
+  };
+});
+
+vi.mock("../../../config/firebase", () => ({
+  db: dbMock,
+}));
+
+function seedCanonicalEvent(id: string, data: any) {
+  if (!collections.has("canonicalEvents")) {
+    collections.set("canonicalEvents", new Map<string, any>());
+  }
+  collections.get("canonicalEvents")!.set(id, { id, ...data });
+}
+
+describe("deriveIdentityTimeline", () => {
+  beforeEach(() => {
+    collections.clear();
+  });
+
+  it("builds a sanitized timeline in chronological order", async () => {
+    seedCanonicalEvent("b-event", {
+      version: "v1",
+      type: "application.submitted",
+      domain: "application",
+      action: "submitted",
+      actor: { type: "tenant", id: "tenant-1", displayName: "Taylor Tenant" },
+      resource: { type: "rental_application", id: "app-1" },
+      occurredAt: "2026-04-02T09:00:00.000Z",
+      recordedAt: "2026-04-02T09:00:00.000Z",
+      visibility: "tenant",
+      summary: "Application submitted",
+      metadata: { tenantId: "tenant-1", ssn: "should-not-leak" },
+      tags: ["submitted"],
+    });
+    seedCanonicalEvent("a-event", {
+      version: "v1",
+      type: "application.created",
+      domain: "application",
+      action: "created",
+      actor: { type: "tenant", id: "tenant-1" },
+      resource: { type: "rental_application", id: "app-1" },
+      occurredAt: "2026-04-01T09:00:00.000Z",
+      recordedAt: "2026-04-01T09:00:00.000Z",
+      visibility: "tenant",
+      summary: "Application created",
+    });
+    seedCanonicalEvent("c-event", {
+      version: "v1",
+      type: "screening.screening_consent_confirmed",
+      domain: "screening",
+      action: "screening_consent_confirmed",
+      actor: { type: "tenant", id: "tenant-1" },
+      resource: { type: "screening_request", id: "screening-1", parentType: "rental_application", parentId: "app-1" },
+      occurredAt: "2026-04-03T09:00:00.000Z",
+      recordedAt: "2026-04-03T09:00:00.000Z",
+      visibility: "tenant",
+      summary: "Tenant screening consent confirmed",
+      metadata: { tenantId: "tenant-1", providerLabel: "TransUnion" },
+    });
+
+    const { deriveIdentityTimeline } = await import("../deriveIdentityTimeline");
+    const result = await deriveIdentityTimeline({
+      tenantId: "tenant-1",
+      applicationId: "app-1",
+      leaseId: "lease-1",
+    });
+
+    expect(result).toEqual({
+      events: [
+        {
+          type: "application.created",
+          label: "Application created",
+          description: "A rental application record was started.",
+          occurredAt: "2026-04-01T09:00:00.000Z",
+        },
+        {
+          type: "application.submitted",
+          label: "Application submitted",
+          description: "Your rental application was submitted for review.",
+          occurredAt: "2026-04-02T09:00:00.000Z",
+        },
+        {
+          type: "screening_consent_confirmed",
+          label: "Screening authorized",
+          description: "Screening consent was recorded for this application.",
+          occurredAt: "2026-04-03T09:00:00.000Z",
+        },
+      ],
+    });
+    expect((result.events[0] as any).id).toBeUndefined();
+    expect((result.events[0] as any).metadata).toBeUndefined();
+    expect((result.events[0] as any).actor).toBeUndefined();
+  });
+
+  it("ignores unrelated, unknown, and ambiguously linked events", async () => {
+    seedCanonicalEvent("unknown", {
+      version: "v1",
+      type: "document.uploaded",
+      domain: "tenant",
+      action: "uploaded",
+      actor: { type: "tenant", id: "tenant-1" },
+      resource: { type: "tenant_document", id: "doc-1" },
+      occurredAt: "2026-04-01T09:00:00.000Z",
+      recordedAt: "2026-04-01T09:00:00.000Z",
+      visibility: "tenant",
+      summary: "Document uploaded",
+    });
+    seedCanonicalEvent("other-app", {
+      version: "v1",
+      type: "application.created",
+      domain: "application",
+      action: "created",
+      actor: { type: "tenant", id: "tenant-2" },
+      resource: { type: "rental_application", id: "app-2" },
+      occurredAt: "2026-04-01T09:00:00.000Z",
+      recordedAt: "2026-04-01T09:00:00.000Z",
+      visibility: "tenant",
+      summary: "Application created",
+    });
+    seedCanonicalEvent("mismatch-screening", {
+      version: "v1",
+      type: "screening.completed",
+      domain: "screening",
+      action: "completed",
+      actor: { type: "system", id: "system" },
+      resource: { type: "screening_request", id: "screening-2", parentType: "rental_application", parentId: "app-1" },
+      occurredAt: "2026-04-02T09:00:00.000Z",
+      recordedAt: "2026-04-02T09:00:00.000Z",
+      visibility: "tenant",
+      summary: "Screening completed",
+      metadata: { tenantId: "tenant-2", applicationId: "app-1", provider: "transunion_redirect" },
+    });
+
+    const { deriveIdentityTimeline } = await import("../deriveIdentityTimeline");
+    const result = await deriveIdentityTimeline({
+      tenantId: "tenant-1",
+      applicationId: "app-1",
+      leaseId: "lease-1",
+    });
+
+    expect(result).toEqual({ events: [] });
+  });
+
+  it("returns an empty timeline when tenant context is missing", async () => {
+    const { deriveIdentityTimeline } = await import("../deriveIdentityTimeline");
+    await expect(
+      deriveIdentityTimeline({
+        tenantId: "",
+        applicationId: "app-1",
+        leaseId: "lease-1",
+      })
+    ).resolves.toEqual({ events: [] });
+  });
+});

--- a/rentchain-api/src/services/identityTimeline/deriveIdentityTimeline.ts
+++ b/rentchain-api/src/services/identityTimeline/deriveIdentityTimeline.ts
@@ -1,0 +1,195 @@
+import { db } from "../../config/firebase";
+import { CANONICAL_EVENTS_COLLECTION } from "../../lib/events/buildEvent";
+import type { CanonicalEventV1 } from "../../lib/events/eventTypes";
+
+export type IdentityTimelineEventType =
+  | "application.created"
+  | "application.submitted"
+  | "screening_consent_confirmed"
+  | "screening.completed"
+  | "lease.created"
+  | "lease.activated"
+  | "lease.tenant_signed";
+
+export type IdentityTimeline = {
+  events: Array<{
+    type: IdentityTimelineEventType;
+    label: string;
+    description: string;
+    occurredAt: string;
+  }>;
+};
+
+export type DeriveIdentityTimelineInput = {
+  tenantId: string;
+  applicationId?: string | null;
+  leaseId?: string | null;
+};
+
+const ALLOWED_EVENT_TYPES = new Set<string>([
+  "application.created",
+  "application.submitted",
+  "screening_consent_confirmed",
+  "screening.screening_consent_confirmed",
+  "screening.completed",
+  "lease.created",
+  "lease.activated",
+  "lease.tenant_signed",
+]);
+
+function asString(value: unknown, max = 240) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function parseTimestamp(value: unknown): string | null {
+  const raw = asString(value, 120);
+  if (!raw) return null;
+  const parsed = Date.parse(raw);
+  if (!Number.isFinite(parsed)) return null;
+  return new Date(parsed).toISOString();
+}
+
+function normalizeType(rawType: string): IdentityTimelineEventType | null {
+  if (rawType === "screening.screening_consent_confirmed") {
+    return "screening_consent_confirmed";
+  }
+  return ALLOWED_EVENT_TYPES.has(rawType) ? (rawType as IdentityTimelineEventType) : null;
+}
+
+function eventLabel(type: IdentityTimelineEventType): string {
+  switch (type) {
+    case "application.created":
+      return "Application created";
+    case "application.submitted":
+      return "Application submitted";
+    case "screening_consent_confirmed":
+      return "Screening authorized";
+    case "screening.completed":
+      return "Screening completed";
+    case "lease.created":
+      return "Lease created";
+    case "lease.activated":
+      return "Lease activated";
+    case "lease.tenant_signed":
+      return "Lease signed";
+    default:
+      return "Activity recorded";
+  }
+}
+
+function eventDescription(type: IdentityTimelineEventType): string {
+  switch (type) {
+    case "application.created":
+      return "A rental application record was started.";
+    case "application.submitted":
+      return "Your rental application was submitted for review.";
+    case "screening_consent_confirmed":
+      return "Screening consent was recorded for this application.";
+    case "screening.completed":
+      return "Screening completed in the current workflow.";
+    case "lease.created":
+      return "A lease record was prepared for this tenancy.";
+    case "lease.activated":
+      return "The lease moved into its active workflow state.";
+    case "lease.tenant_signed":
+      return "Tenant lease signing was recorded.";
+    default:
+      return "Activity was recorded in the current workflow.";
+  }
+}
+
+function metadataMatchesTenantScope(event: CanonicalEventV1, tenantId: string, applicationId: string) {
+  const metadataTenantId = asString(event.metadata?.tenantId);
+  const metadataApplicationId = asString(event.metadata?.applicationId);
+  if (metadataTenantId && metadataTenantId !== tenantId) return false;
+  if (metadataApplicationId && metadataApplicationId !== applicationId) return false;
+  return true;
+}
+
+function matchesScope(event: CanonicalEventV1, tenantId: string, applicationId: string, leaseId: string) {
+  const type = asString(event.type, 160);
+  if (!ALLOWED_EVENT_TYPES.has(type)) return false;
+
+  if (type.startsWith("application.")) {
+    return Boolean(applicationId) && asString(event.resource?.id) === applicationId;
+  }
+
+  if (type === "screening_consent_confirmed" || type === "screening.screening_consent_confirmed" || type === "screening.completed") {
+    if (!applicationId) return false;
+    const resourceId = asString(event.resource?.id);
+    const parentId = asString(event.resource?.parentId);
+    if (resourceId !== applicationId && parentId !== applicationId) return false;
+    return metadataMatchesTenantScope(event, tenantId, applicationId);
+  }
+
+  if (type.startsWith("lease.")) {
+    if (!leaseId) return false;
+    if (asString(event.resource?.id) !== leaseId) return false;
+    const metadataTenantId = asString(event.metadata?.tenantId);
+    if (metadataTenantId && metadataTenantId !== tenantId) return false;
+    return true;
+  }
+
+  return false;
+}
+
+function compareEventsAscending(
+  a: CanonicalEventV1 & { __normalizedOccurredAt: string },
+  b: CanonicalEventV1 & { __normalizedOccurredAt: string }
+) {
+  const aTs = Date.parse(a.__normalizedOccurredAt);
+  const bTs = Date.parse(b.__normalizedOccurredAt);
+  if (aTs !== bTs) return aTs - bTs;
+  return asString(a.id).localeCompare(asString(b.id));
+}
+
+export async function deriveIdentityTimeline(params: DeriveIdentityTimelineInput): Promise<IdentityTimeline> {
+  const tenantId = asString(params.tenantId);
+  const applicationId = asString(params.applicationId);
+  const leaseId = asString(params.leaseId);
+
+  if (!tenantId) {
+    return { events: [] };
+  }
+
+  const snap = await db.collection(CANONICAL_EVENTS_COLLECTION).get().catch(() => ({ docs: [] } as any));
+  const events: Array<
+    CanonicalEventV1 & {
+      __normalizedOccurredAt: string;
+      __normalizedType: IdentityTimelineEventType;
+    }
+  > = (snap.docs || [])
+    .map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }) as CanonicalEventV1)
+    .filter((event: CanonicalEventV1) => matchesScope(event, tenantId, applicationId, leaseId))
+    .map((event: CanonicalEventV1) => {
+      const normalizedType = normalizeType(asString(event.type, 160));
+      const occurredAt = parseTimestamp(event.occurredAt) || parseTimestamp(event.recordedAt);
+      if (!normalizedType || !occurredAt) return null;
+      return {
+        ...event,
+        __normalizedOccurredAt: occurredAt,
+        __normalizedType: normalizedType,
+      };
+    })
+    .filter(
+      (
+        event: (CanonicalEventV1 & {
+          __normalizedOccurredAt: string;
+          __normalizedType: IdentityTimelineEventType;
+        }) | null
+      ): event is CanonicalEventV1 & {
+        __normalizedOccurredAt: string;
+        __normalizedType: IdentityTimelineEventType;
+      } => Boolean(event)
+    )
+    .sort(compareEventsAscending);
+
+  return {
+    events: events.map((event: CanonicalEventV1 & { __normalizedOccurredAt: string; __normalizedType: IdentityTimelineEventType }) => ({
+      type: event.__normalizedType,
+      label: eventLabel(event.__normalizedType),
+      description: eventDescription(event.__normalizedType),
+      occurredAt: event.__normalizedOccurredAt,
+    })),
+  };
+}

--- a/rentchain-frontend/src/api/tenantPortal.ts
+++ b/rentchain-frontend/src/api/tenantPortal.ts
@@ -230,6 +230,22 @@ export type TenantCredibilitySignals = {
   };
 };
 
+export type IdentityTimeline = {
+  events: Array<{
+    type:
+      | "application.created"
+      | "application.submitted"
+      | "screening_consent_confirmed"
+      | "screening.completed"
+      | "lease.created"
+      | "lease.activated"
+      | "lease.tenant_signed";
+    label: string;
+    description: string;
+    occurredAt: string;
+  }>;
+};
+
 export type TenantWorkspaceSummary = {
   context: TenantWorkspaceContext;
   property: TenantWorkspaceProperty | null;
@@ -238,6 +254,7 @@ export type TenantWorkspaceSummary = {
   maintenance: TenantWorkspaceMaintenance[];
   tenantIdentityRecord?: TenantIdentityRecord | null;
   tenantCredibilitySignals?: TenantCredibilitySignals | null;
+  identityTimeline?: IdentityTimeline | null;
 };
 
 export async function getTenantWorkspace(): Promise<TenantWorkspaceSummary> {

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -210,6 +210,28 @@ describe("tenant workspace frontend shell", () => {
           summaryDescription: "Most credibility signals are available in your current record.",
         },
       },
+      identityTimeline: {
+        events: [
+          {
+            type: "application.created",
+            label: "Application created",
+            description: "A rental application record was started.",
+            occurredAt: "2026-01-01T00:00:00.000Z",
+          },
+          {
+            type: "screening_consent_confirmed",
+            label: "Screening authorized",
+            description: "Screening consent was recorded for this application.",
+            occurredAt: "2026-01-03T00:00:00.000Z",
+          },
+          {
+            type: "lease.tenant_signed",
+            label: "Lease signed",
+            description: "Tenant lease signing was recorded.",
+            occurredAt: "2026-02-01T10:00:00.000Z",
+          },
+        ],
+      },
     });
     tenantAttachmentsApi.getTenantAttachments.mockResolvedValue({
       ok: true,
@@ -434,6 +456,16 @@ describe("tenant workspace frontend shell", () => {
           summaryDescription: "Most credibility signals are available in your current record.",
         },
       },
+      identityTimeline: {
+        events: [
+          {
+            type: "application.created",
+            label: "Application created",
+            description: "A rental application record was started.",
+            occurredAt: "2026-01-01T00:00:00.000Z",
+          },
+        ],
+      },
     });
 
     render(
@@ -451,6 +483,7 @@ describe("tenant workspace frontend shell", () => {
     expect(await screen.findByText(/Profile completion/i)).toBeInTheDocument();
     expect(screen.getByText(/^Your Rental Identity$/i)).toBeInTheDocument();
     expect(screen.getByText(/^Credibility signals$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^Activity timeline$/i)).toBeInTheDocument();
     expect(screen.getByText(/Credibility established/i)).toBeInTheDocument();
     expect(screen.getByText(/Profile complete/i)).toBeInTheDocument();
     expect(screen.getByText(/Application reusable/i)).toBeInTheDocument();
@@ -458,6 +491,8 @@ describe("tenant workspace frontend shell", () => {
     expect(screen.getByText(/Screening completed/i)).toBeInTheDocument();
     expect(screen.getByText(/Lease history present/i)).toBeInTheDocument();
     expect(screen.getByText(/Ready to apply/i)).toBeInTheDocument();
+    expect(screen.getByText(/^Application created$/i)).toBeInTheDocument();
+    expect(screen.getByText(/A rental application record was started\./i)).toBeInTheDocument();
     expect(screen.getByText(/Missing pieces/i)).toBeInTheDocument();
     expect(screen.getByText(/Income documents/i)).toBeInTheDocument();
     expect(screen.getByText(/Share Your Rental Profile/i)).toBeInTheDocument();
@@ -480,6 +515,41 @@ describe("tenant workspace frontend shell", () => {
     expect(screen.getAllByText(/No action needed/i).length).toBeGreaterThan(0);
     expect(screen.getByRole("link", { name: /Open document vault/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Open access/i })).toBeInTheDocument();
+  });
+
+  it("renders a safe empty activity timeline", async () => {
+    tenantPortalApi.getTenantWorkspace.mockResolvedValue({
+      context: {
+        authority: "active_tenant",
+        propertyId: "prop-1",
+        rc_prop_id: "rc-prop-1",
+        applicationId: "app-1",
+        leaseId: "lease-1",
+        tenantId: "tenant-1",
+        unitId: "unit-1",
+        invitedEmail: "tenant@example.com",
+      },
+      property: null,
+      application: null,
+      lease: null,
+      maintenance: [],
+      tenantIdentityRecord: null,
+      tenantCredibilitySignals: null,
+      identityTimeline: { events: [] },
+    });
+
+    render(
+      <MemoryRouter>
+        <TenantWorkspacePage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/^Activity timeline$/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Identity-related activity will appear here as your application, screening, and lease workflow progress\./i
+      )
+    ).toBeInTheDocument();
   });
 
   it("lets tenants generate, copy, and revoke share links", async () => {

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
@@ -262,6 +262,7 @@ export default function TenantWorkspacePage() {
   });
   const tenantIdentityRecord = data?.tenantIdentityRecord || null;
   const tenantCredibilitySignals = data?.tenantCredibilitySignals || null;
+  const identityTimeline = data?.identityTimeline?.events || [];
   const communicationsView = buildTenantCommunicationsWorkspaceState(communications);
   const screeningSummary = buildTenantScreeningDashboardSummary(screenings);
   const notificationItems = filterStructuredNotificationsByPreferences(
@@ -503,6 +504,35 @@ export default function TenantWorkspacePage() {
         ) : (
           <div style={{ color: textTokens.secondary }}>
             Credibility signals will appear here once enough tenant-safe identity signals are available.
+          </div>
+        )}
+      </TenantInfoCard>
+
+      <TenantInfoCard heading="Activity timeline" accent="#0891b2">
+        {identityTimeline.length ? (
+          <div style={{ display: "grid", gap: spacing.sm }}>
+            {identityTimeline.map((event) => (
+              <div
+                key={`${event.type}:${event.occurredAt}`}
+                style={{
+                  border: "1px solid rgba(15,23,42,0.08)",
+                  borderRadius: 12,
+                  padding: "12px 14px",
+                  display: "grid",
+                  gap: 6,
+                }}
+              >
+                <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.sm, flexWrap: "wrap" }}>
+                  <div style={{ fontWeight: 700, color: textTokens.primary }}>{event.label}</div>
+                  <div style={{ color: textTokens.secondary }}>{formatDate(event.occurredAt)}</div>
+                </div>
+                <div style={{ color: textTokens.secondary, lineHeight: 1.6 }}>{event.description}</div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div style={{ color: textTokens.secondary }}>
+            Identity-related activity will appear here as your application, screening, and lease workflow progress.
           </div>
         )}
       </TenantInfoCard>


### PR DESCRIPTION
This PR introduces Identity Audit Timeline v1.

Includes:
- tenant-safe identityTimeline on /tenant/workspace
- sanitized canonical event allowlist
- normalized tenant-safe labels/descriptions
- Activity timeline card on tenant workspace
- deterministic chronological ordering
- focused backend/frontend test coverage

Guardrails preserved:
- no new collections
- no new canonical events
- no event writes, mutations, or backfills
- no landlord timeline exposure
- no raw canonical event IDs, actor fields, resource IDs, metadata, tags, details, provider names, document names, storage paths, or screening details
- no generic timeline adapter reuse

PR note:
- Backend timeline helper tests passed.
- Tenant portal route tests passed.
- Backend typecheck passed.
- Tenant workspace frontend tests passed.
- Frontend build passed.
- Existing frontend chunk-size warning remains unchanged and out of scope.