### PR TITLE
feat: add permissioned tenant share package

### DIFF
--- a/rentchain-api/src/routes/__tests__/publicTenantShareRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/publicTenantShareRoutes.test.ts
@@ -1,12 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const readTenantSharePackageByToken = vi.fn();
+const requestTenantSharePackageItems = vi.fn();
 
 vi.mock("../../services/tenantPortal/tenantSharePackageService", () => ({
   readTenantSharePackageByToken,
+  requestTenantSharePackageItems,
 }));
 
-async function invokeRouter(router: any, options: { method: string; url: string }) {
+async function invokeRouter(router: any, options: { method: string; url: string; body?: any }) {
   return await new Promise<{ status: number; body: any }>((resolve, reject) => {
     const path = options.url;
     const token = path.split("/").pop() || "";
@@ -17,6 +19,7 @@ async function invokeRouter(router: any, options: { method: string; url: string 
       path,
       params: { token },
       query: {},
+      body: options.body || {},
       headers: {},
     };
     const res: any = {
@@ -53,11 +56,10 @@ describe("publicTenantShareRoutes", () => {
         readinessLabel: "Ready to apply",
         readinessDescription: "Your core profile and supporting records are ready for most rental workflows.",
       },
-      profile: { completionStatus: "complete" },
-      application: { reusable: true },
-      documents: { completionStatus: "in_progress" },
-      screening: { status: "in_progress" },
-      leases: { summary: { activeCount: 1, historicalCount: 0 } },
+      availability: {
+        canRequestMore: true,
+        availableSections: ["identity"],
+      },
       generatedAt: "2026-04-26T00:00:00.000Z",
     });
 
@@ -69,8 +71,7 @@ describe("publicTenantShareRoutes", () => {
 
     expect(res.status).toBe(200);
     expect(res.body?.data?.identity?.identityStatus).toBe("ready");
-    expect(res.body?.data?.documents?.missingCategories).toBeUndefined();
-    expect(res.body?.data?.screening?.provider).toBeUndefined();
+    expect(res.body?.data?.documents).toBeUndefined();
   });
 
   it("fails closed with 404 when the share package is unavailable", async () => {
@@ -83,5 +84,27 @@ describe("publicTenantShareRoutes", () => {
 
     expect(res.status).toBe(404);
     expect(res.body?.error).toBe("NOT_FOUND");
+  });
+
+  it("stores a sanitized additional-information request without granting access", async () => {
+    requestTenantSharePackageItems.mockResolvedValue({
+      requestedItems: ["credibility_summary", "documents_summary"],
+    });
+
+    const router = (await import("../publicTenantShareRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/share/share-token-1/request",
+      body: {
+        requestedItems: ["credibility_summary", "unknown_key", "documents_summary"],
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(requestTenantSharePackageItems).toHaveBeenCalledWith({
+      token: "share-token-1",
+      requestedItems: ["credibility_summary", "unknown_key", "documents_summary"],
+    });
+    expect(res.body?.data?.requestedItems).toEqual(["credibility_summary", "documents_summary"]);
   });
 });

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -709,6 +709,12 @@ describe("tenantPortalRoutes foundation", () => {
     expect(shareDocs[0]?.tenantId).toBe("tenant-1");
     expect(shareDocs[0]?.tokenHash).toBeTruthy();
     expect(shareDocs[0]?.token).toBeUndefined();
+    expect(shareDocs[0]?.permissions).toEqual({
+      identitySummary: true,
+      credibilitySummary: false,
+      applicationSummary: false,
+      documents: "none",
+    });
   });
 
   it("lists only active tenant share packages", async () => {
@@ -748,6 +754,8 @@ describe("tenantPortalRoutes foundation", () => {
       expect.objectContaining({
         id: "share-1",
         status: "active",
+        requestedItems: [],
+        approvedItems: [],
       }),
     ]);
   });
@@ -778,6 +786,56 @@ describe("tenantPortalRoutes foundation", () => {
 
     expect(res.status).toBe(200);
     expect(ensureCollection("tenantSharePackages").get("share-1")?.status).toBe("revoked");
+  });
+
+  it("lets a tenant approve requested share expansions only for their own link", async () => {
+    ensureCollection("tenantSharePackages").set("share-1", {
+      id: "share-1",
+      tenantId: "tenant-1",
+      tokenHash: "hash-1",
+      createdAt: 100,
+      expiresAt: Date.now() + 10_000,
+      status: "active",
+      permissions: {
+        identitySummary: true,
+        credibilitySummary: false,
+        applicationSummary: false,
+        documents: "none",
+      },
+      requestedItems: ["credibility_summary", "documents_summary"],
+      approvedItems: [],
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/share-packages/share-1/respond",
+      body: {
+        approvedItems: ["credibility_summary", "application_summary", "documents_summary"],
+      },
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(ensureCollection("tenantSharePackages").get("share-1")).toEqual(
+      expect.objectContaining({
+        requestedItems: [],
+        approvedItems: ["credibility_summary", "documents_summary"],
+        permissions: {
+          identitySummary: true,
+          credibilitySummary: true,
+          applicationSummary: false,
+          documents: "approved_only",
+        },
+      })
+    );
   });
 
   it("returns a grouped tenant-safe application completion checklist", async () => {

--- a/rentchain-api/src/routes/publicTenantShareRoutes.ts
+++ b/rentchain-api/src/routes/publicTenantShareRoutes.ts
@@ -1,5 +1,8 @@
 import { Router } from "express";
-import { readTenantSharePackageByToken } from "../services/tenantPortal/tenantSharePackageService";
+import {
+  readTenantSharePackageByToken,
+  requestTenantSharePackageItems,
+} from "../services/tenantPortal/tenantSharePackageService";
 
 const router = Router();
 
@@ -18,6 +21,28 @@ router.get("/share/:token", async (req: any, res) => {
     return res.json({ ok: true, data: payload });
   } catch (err: any) {
     console.error("[public-tenant-share] fetch failed", err?.message || err);
+    return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+  }
+});
+
+router.post("/share/:token/request", async (req: any, res) => {
+  try {
+    const token = String(req.params?.token || "").trim();
+    if (!token) {
+      return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+    }
+
+    const result = await requestTenantSharePackageItems({
+      token,
+      requestedItems: req.body?.requestedItems,
+    });
+    if (!result) {
+      return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+    }
+
+    return res.json({ ok: true, data: result });
+  } catch (err: any) {
+    console.error("[public-tenant-share] request failed", err?.message || err);
     return res.status(404).json({ ok: false, error: "NOT_FOUND" });
   }
 });

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -35,6 +35,7 @@ import { adaptTenantSafeScreeningState } from "../services/screening/tenantScree
 import {
   createTenantSharePackage,
   listTenantSharePackages,
+  respondToTenantSharePackage,
   revokeTenantSharePackage,
 } from "../services/tenantPortal/tenantSharePackageService";
 
@@ -3024,6 +3025,36 @@ router.delete("/share-packages/:id", requireTenantWorkspaceIdentity, async (req:
       message: err?.message || "failed",
     });
     return res.status(500).json({ ok: false, error: "TENANT_SHARE_PACKAGE_REVOKE_FAILED" });
+  }
+});
+
+router.post("/share-packages/:id/respond", requireTenantWorkspaceIdentity, async (req: any, res) => {
+  const context = await resolveWorkspaceContextOrRespond(req, res);
+  if (!context) return;
+
+  const tenantId = String(req.user?.tenantId || context.tenantId || "").trim();
+  const sharePackageId = String(req.params?.id || "").trim();
+  if (!tenantId || !sharePackageId) {
+    return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+  }
+
+  try {
+    const updated = await respondToTenantSharePackage({
+      tenantId,
+      sharePackageId,
+      approvedItems: req.body?.approvedItems,
+    });
+    if (!updated) {
+      return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+    }
+    return res.json({ ok: true, data: updated });
+  } catch (err: any) {
+    console.error("[tenant/share-packages:respond] failed", {
+      tenantId,
+      sharePackageId,
+      message: err?.message || "failed",
+    });
+    return res.status(500).json({ ok: false, error: "TENANT_SHARE_PACKAGE_RESPOND_FAILED" });
   }
 });
 

--- a/rentchain-api/src/services/tenantPortal/__tests__/tenantSharePackageService.test.ts
+++ b/rentchain-api/src/services/tenantPortal/__tests__/tenantSharePackageService.test.ts
@@ -101,9 +101,17 @@ describe("tenantSharePackageService", () => {
     const docs = Array.from(ensureCollection("tenantSharePackages").values());
     expect(docs).toHaveLength(2);
     expect(docs.every((entry) => entry.tokenHash && !entry.token)).toBe(true);
+    expect(docs[0]?.permissions).toEqual({
+      identitySummary: true,
+      credibilitySummary: false,
+      applicationSummary: false,
+      documents: "none",
+    });
+    expect(docs[0]?.requestedItems).toEqual([]);
+    expect(docs[0]?.approvedItems).toEqual([]);
   });
 
-  it("derives a safe public payload at read time", async () => {
+  it("derives a safe public payload at read time with identity only by default", async () => {
     const service = await import("../tenantSharePackageService");
     const created = await service.createTenantSharePackage({ tenantId: "tenant-1" });
     const token = created.shareUrl.split("/share/")[1];
@@ -116,13 +124,75 @@ describe("tenantSharePackageService", () => {
           identityStatus: "verified",
           verification: { level: "strong" },
         }),
-        documents: { completionStatus: "complete" },
-        screening: { status: "completed" },
+        availability: expect.objectContaining({
+          canRequestMore: true,
+          availableSections: ["identity"],
+        }),
       })
     );
-    expect((payload as any)?.documents?.missingCategories).toBeUndefined();
-    expect((payload as any)?.screening?.provider).toBeUndefined();
-    expect((payload as any)?.leases?.summary?.lastSignedAt).toBeUndefined();
+    expect((payload as any)?.documents).toBeUndefined();
+    expect((payload as any)?.application).toBeUndefined();
+    expect((payload as any)?.credibilitySummary).toBeUndefined();
+  });
+
+  it("stores sanitized request items and applies tenant-approved expansions only", async () => {
+    const service = await import("../tenantSharePackageService");
+    const created = await service.createTenantSharePackage({ tenantId: "tenant-1" });
+    const token = created.shareUrl.split("/share/")[1];
+
+    const requested = await service.requestTenantSharePackageItems({
+      token,
+      requestedItems: ["documents_summary", "unknown_key", "credibility_summary", "documents_summary"],
+    });
+    expect(requested).toEqual({
+      requestedItems: ["documents_summary", "credibility_summary"],
+    });
+
+    const responded = await service.respondToTenantSharePackage({
+      tenantId: "tenant-1",
+      sharePackageId: created.id,
+      approvedItems: ["credibility_summary", "documents_summary", "application_summary"],
+    });
+    expect(responded).toEqual(
+      expect.objectContaining({
+        approvedItems: ["credibility_summary", "documents_summary"],
+        requestedItems: [],
+        permissions: {
+          identitySummary: true,
+          credibilitySummary: true,
+          applicationSummary: false,
+          documents: "approved_only",
+        },
+      })
+    );
+
+    const payload = await service.readTenantSharePackageByToken(token);
+    expect(payload?.identity).toBeTruthy();
+    expect(payload?.credibilitySummary).toEqual(
+      expect.objectContaining({
+        completenessLevel: expect.stringMatching(/low|medium|high/),
+      })
+    );
+    expect(payload?.documents).toEqual({ completionStatus: "complete" });
+    expect(payload?.application).toBeUndefined();
+  });
+
+  it("only lets the owning tenant respond to a share request", async () => {
+    const service = await import("../tenantSharePackageService");
+    const created = await service.createTenantSharePackage({ tenantId: "tenant-1" });
+    const token = created.shareUrl.split("/share/")[1];
+    await service.requestTenantSharePackageItems({
+      token,
+      requestedItems: ["application_summary"],
+    });
+
+    await expect(
+      service.respondToTenantSharePackage({
+        tenantId: "tenant-2",
+        sharePackageId: created.id,
+        approvedItems: ["application_summary"],
+      })
+    ).resolves.toBe(false);
   });
 
   it("returns null for revoked or expired share packages", async () => {

--- a/rentchain-api/src/services/tenantPortal/tenantSharePackageService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantSharePackageService.ts
@@ -2,13 +2,33 @@ import crypto from "crypto";
 import { db } from "../../config/firebase";
 import { loadTenantIdentityRecord, type TenantIdentityRecord } from "./tenantProfileService";
 import { resolveTenancyContext } from "./tenancyContextService";
+import { deriveTenantCredibilitySignals } from "../tenantCredibility/deriveTenantCredibilitySignals";
 
 const COLLECTION = "tenantSharePackages";
 const DEFAULT_EXPIRES_DAYS = 7;
 const MAX_EXPIRES_DAYS = 30;
 
+export type TenantSharePermissionKey =
+  | "identity_summary"
+  | "credibility_summary"
+  | "application_summary"
+  | "documents_summary";
+
+export type TenantSharePermissions = {
+  identitySummary: boolean;
+  credibilitySummary: boolean;
+  applicationSummary: boolean;
+  documents: "none" | "summary" | "approved_only";
+};
+
+export type TenantSharePackageAvailabilitySection =
+  | "identity"
+  | "credibilitySummary"
+  | "application"
+  | "documents";
+
 export type TenantSharePackagePublicPayload = {
-  identity: {
+  identity?: {
     identityStatus: TenantIdentityRecord["identityStatus"];
     verification: {
       level: TenantIdentityRecord["verification"]["level"];
@@ -16,23 +36,21 @@ export type TenantSharePackagePublicPayload = {
     readinessLabel: string;
     readinessDescription: string;
   };
-  profile: {
-    completionStatus: TenantIdentityRecord["profile"]["completionStatus"];
+  credibilitySummary?: {
+    completenessLevel: "low" | "medium" | "high";
+    verificationLevel: "none" | "partial" | "strong";
+    summaryLabel: string;
+    summaryDescription: string;
   };
-  application: {
+  application?: {
     reusable: boolean;
   };
-  documents: {
+  documents?: {
     completionStatus: TenantIdentityRecord["documents"]["completionStatus"];
   };
-  screening: {
-    status: TenantIdentityRecord["screening"]["status"];
-  };
-  leases: {
-    summary: {
-      activeCount: number;
-      historicalCount: number;
-    };
+  availability: {
+    canRequestMore: boolean;
+    availableSections: TenantSharePackageAvailabilitySection[];
   };
   generatedAt: string;
 };
@@ -45,6 +63,23 @@ export type TenantSharePackageRecord = {
   expiresAt: number;
   status: "active" | "revoked";
   revokedAt?: number;
+  permissions: TenantSharePermissions;
+  requestedItems: TenantSharePermissionKey[];
+  approvedItems: TenantSharePermissionKey[];
+};
+
+const ALLOWED_REQUESTED_ITEMS = new Set<TenantSharePermissionKey>([
+  "identity_summary",
+  "credibility_summary",
+  "application_summary",
+  "documents_summary",
+]);
+
+const DEFAULT_PERMISSIONS: TenantSharePermissions = {
+  identitySummary: true,
+  credibilitySummary: false,
+  applicationSummary: false,
+  documents: "none",
 };
 
 function asString(value: unknown): string | null {
@@ -72,35 +107,43 @@ function clampExpiresInDays(value: unknown) {
   return Math.min(Math.max(Math.round(numeric), 1), MAX_EXPIRES_DAYS);
 }
 
-function mapTenantIdentityToSharePackage(record: TenantIdentityRecord): TenantSharePackagePublicPayload {
+function sanitizeRequestedItems(input: unknown): TenantSharePermissionKey[] {
+  if (!Array.isArray(input)) return [];
+  const seen = new Set<TenantSharePermissionKey>();
+  const next: TenantSharePermissionKey[] = [];
+  for (const item of input) {
+    const normalized = asString(item) as TenantSharePermissionKey | null;
+    if (!normalized || !ALLOWED_REQUESTED_ITEMS.has(normalized) || seen.has(normalized)) continue;
+    seen.add(normalized);
+    next.push(normalized);
+  }
+  return next;
+}
+
+function derivePermissionsFromApprovedItems(approvedItems: TenantSharePermissionKey[]): TenantSharePermissions {
+  const approved = new Set(approvedItems);
   return {
-    identity: {
-      identityStatus: record.identityStatus,
-      verification: {
-        level: record.verification.level,
-      },
-      readinessLabel: record.readinessLabel,
-      readinessDescription: record.readinessDescription,
-    },
-    profile: {
-      completionStatus: record.profile.completionStatus,
-    },
-    application: {
-      reusable: record.application.reusable,
-    },
-    documents: {
-      completionStatus: record.documents.completionStatus,
-    },
-    screening: {
-      status: record.screening.status,
-    },
-    leases: {
-      summary: {
-        activeCount: record.leases.activeCount,
-        historicalCount: record.leases.historicalCount,
-      },
-    },
-    generatedAt: new Date().toISOString(),
+    identitySummary: true,
+    credibilitySummary: approved.has("credibility_summary"),
+    applicationSummary: approved.has("application_summary"),
+    documents: approved.has("documents_summary") ? "approved_only" : "none",
+  };
+}
+
+function asTenantShareRecord(doc: any): TenantSharePackageRecord {
+  const data = ((doc?.data?.() as any) || {}) as Partial<TenantSharePackageRecord>;
+  const approvedItems = sanitizeRequestedItems(data.approvedItems);
+  return {
+    id: String(doc?.id || data.id || ""),
+    tenantId: String(data.tenantId || ""),
+    tokenHash: String(data.tokenHash || ""),
+    createdAt: Number(data.createdAt || 0),
+    expiresAt: Number(data.expiresAt || 0),
+    status: data.status === "revoked" ? "revoked" : "active",
+    revokedAt: typeof data.revokedAt === "number" ? data.revokedAt : undefined,
+    permissions: data.permissions || derivePermissionsFromApprovedItems(approvedItems),
+    requestedItems: sanitizeRequestedItems(data.requestedItems),
+    approvedItems,
   };
 }
 
@@ -109,10 +152,7 @@ async function loadTenantShareRecordByToken(token: string): Promise<TenantShareP
   const snap = await db.collection(COLLECTION).where("tokenHash", "==", tokenHash).limit(1).get();
   const doc = snap.docs?.[0];
   if (!doc) return null;
-  return {
-    id: doc.id,
-    ...((doc.data() as any) || {}),
-  } as TenantSharePackageRecord;
+  return asTenantShareRecord(doc);
 }
 
 async function resolveShareTenantIdentity(params: { tenantId: string }) {
@@ -139,6 +179,65 @@ async function resolveShareTenantIdentity(params: { tenantId: string }) {
   });
 }
 
+async function loadTenantShareRecordById(sharePackageId: string): Promise<TenantSharePackageRecord | null> {
+  const ref = db.collection(COLLECTION).doc(sharePackageId);
+  const snap = await ref.get();
+  if (!snap.exists) return null;
+  return asTenantShareRecord(snap);
+}
+
+function buildPublicPayload(params: {
+  identity: TenantIdentityRecord;
+  permissions: TenantSharePermissions;
+}): TenantSharePackagePublicPayload {
+  const { identity, permissions } = params;
+  const availableSections: TenantSharePackageAvailabilitySection[] = [];
+  const payload: TenantSharePackagePublicPayload = {
+    availability: {
+      canRequestMore: true,
+      availableSections,
+    },
+    generatedAt: new Date().toISOString(),
+  };
+
+  if (permissions.identitySummary) {
+    payload.identity = {
+      identityStatus: identity.identityStatus,
+      verification: {
+        level: identity.verification.level,
+      },
+      readinessLabel: identity.readinessLabel,
+      readinessDescription: identity.readinessDescription,
+    };
+    availableSections.push("identity");
+  }
+
+  if (permissions.credibilitySummary) {
+    const { landlordSafeSummary } = deriveTenantCredibilitySignals({
+      tenantIdentityRecord: identity,
+      leaseExecution: null,
+    });
+    payload.credibilitySummary = landlordSafeSummary;
+    availableSections.push("credibilitySummary");
+  }
+
+  if (permissions.applicationSummary) {
+    payload.application = {
+      reusable: identity.application.reusable,
+    };
+    availableSections.push("application");
+  }
+
+  if (permissions.documents === "summary" || permissions.documents === "approved_only") {
+    payload.documents = {
+      completionStatus: identity.documents.completionStatus,
+    };
+    availableSections.push("documents");
+  }
+
+  return payload;
+}
+
 export async function createTenantSharePackage(params: {
   tenantId: string;
   expiresInDays?: number;
@@ -161,6 +260,9 @@ export async function createTenantSharePackage(params: {
     createdAt,
     expiresAt,
     status: "active",
+    permissions: DEFAULT_PERMISSIONS,
+    requestedItems: [],
+    approvedItems: [],
   } satisfies TenantSharePackageRecord);
 
   return {
@@ -168,6 +270,9 @@ export async function createTenantSharePackage(params: {
     createdAt,
     expiresAt,
     status: "active" as const,
+    permissions: DEFAULT_PERMISSIONS,
+    requestedItems: [] as TenantSharePermissionKey[],
+    approvedItems: [] as TenantSharePermissionKey[],
     shareUrl: buildFrontendShareUrl(token),
   };
 }
@@ -180,14 +285,17 @@ export async function listTenantSharePackages(params: { tenantId: string }) {
   const now = nowMs();
 
   return (snap.docs || [])
-    .map((doc: any) => ({ id: doc.id, ...((doc.data() as any) || {}) }))
-    .filter((entry: any) => entry.status === "active" && Number(entry.expiresAt || 0) > now)
-    .sort((left: any, right: any) => Number(right.createdAt || 0) - Number(left.createdAt || 0))
-    .map((entry: any) => ({
-      id: String(entry.id),
-      createdAt: Number(entry.createdAt || 0),
-      expiresAt: Number(entry.expiresAt || 0),
+    .map((doc: any) => asTenantShareRecord(doc))
+    .filter((entry) => entry.status === "active" && Number(entry.expiresAt || 0) > now)
+    .sort((left, right) => Number(right.createdAt || 0) - Number(left.createdAt || 0))
+    .map((entry) => ({
+      id: entry.id,
+      createdAt: entry.createdAt,
+      expiresAt: entry.expiresAt,
       status: "active" as const,
+      permissions: entry.permissions,
+      requestedItems: entry.requestedItems,
+      approvedItems: entry.approvedItems,
     }));
 }
 
@@ -203,7 +311,7 @@ export async function revokeTenantSharePackage(params: {
   const snap = await ref.get();
   if (!snap.exists) return false;
 
-  const current = ((snap.data() as any) || {}) as TenantSharePackageRecord;
+  const current = asTenantShareRecord(snap);
   if (String(current.tenantId || "") !== tenantId) return false;
 
   await ref.set(
@@ -214,6 +322,66 @@ export async function revokeTenantSharePackage(params: {
     { merge: true }
   );
   return true;
+}
+
+export async function requestTenantSharePackageItems(params: {
+  token: string;
+  requestedItems: unknown;
+}) {
+  const normalized = asString(params.token);
+  if (!normalized) return null;
+  const record = await loadTenantShareRecordByToken(normalized);
+  if (!record) return null;
+  if (record.status !== "active") return null;
+  if (Number(record.expiresAt || 0) <= nowMs()) return null;
+
+  const requestedItems = sanitizeRequestedItems(params.requestedItems);
+  await db.collection(COLLECTION).doc(record.id).set(
+    {
+      requestedItems,
+    },
+    { merge: true }
+  );
+
+  return { requestedItems };
+}
+
+export async function respondToTenantSharePackage(params: {
+  tenantId: string;
+  sharePackageId: string;
+  approvedItems: unknown;
+}) {
+  const tenantId = asString(params.tenantId);
+  const sharePackageId = asString(params.sharePackageId);
+  if (!tenantId || !sharePackageId) return null;
+
+  const current = await loadTenantShareRecordById(sharePackageId);
+  if (!current) return null;
+  if (current.tenantId !== tenantId) return false;
+
+  const approvedItems = sanitizeRequestedItems(params.approvedItems).filter((item) =>
+    current.requestedItems.includes(item)
+  );
+  const permissions = derivePermissionsFromApprovedItems(approvedItems);
+
+  await db.collection(COLLECTION).doc(sharePackageId).set(
+    {
+      approvedItems,
+      requestedItems: [],
+      permissions,
+    },
+    { merge: true }
+  );
+
+  return {
+    id: sharePackageId,
+    approvedItems,
+    requestedItems: [],
+    permissions,
+    status: current.status,
+    createdAt: current.createdAt,
+    expiresAt: current.expiresAt,
+  };
 }
 
 export async function readTenantSharePackageByToken(
@@ -230,5 +398,8 @@ export async function readTenantSharePackageByToken(
   const identity = await resolveShareTenantIdentity({ tenantId: record.tenantId });
   if (!identity) return null;
 
-  return mapTenantIdentityToSharePackage(identity);
+  return buildPublicPayload({
+    identity,
+    permissions: record.permissions || derivePermissionsFromApprovedItems(record.approvedItems || []),
+  });
 }

--- a/rentchain-frontend/src/api/publicTenantSharePackageApi.ts
+++ b/rentchain-frontend/src/api/publicTenantSharePackageApi.ts
@@ -1,7 +1,7 @@
 import { apiFetch } from "./apiFetch";
 
 export type PublicTenantSharePackage = {
-  identity: {
+  identity?: {
     identityStatus: "incomplete" | "ready" | "verified" | "limited";
     verification: {
       level: "none" | "partial" | "strong";
@@ -9,23 +9,21 @@ export type PublicTenantSharePackage = {
     readinessLabel: string;
     readinessDescription: string;
   };
-  profile: {
-    completionStatus: "complete" | "in_progress" | "missing" | "needs_attention";
+  credibilitySummary?: {
+    completenessLevel: "low" | "medium" | "high";
+    verificationLevel: "none" | "partial" | "strong";
+    summaryLabel: string;
+    summaryDescription: string;
   };
-  application: {
+  application?: {
     reusable: boolean;
   };
-  documents: {
+  documents?: {
     completionStatus: "complete" | "in_progress" | "missing" | "needs_attention";
   };
-  screening: {
-    status: "not_started" | "in_progress" | "completed" | "needs_attention" | "blocked";
-  };
-  leases: {
-    summary: {
-      activeCount: number;
-      historicalCount: number;
-    };
+  availability: {
+    canRequestMore: boolean;
+    availableSections: Array<"identity" | "credibilitySummary" | "application" | "documents">;
   };
   generatedAt: string;
 };
@@ -40,4 +38,19 @@ export async function fetchPublicTenantSharePackage(token: string): Promise<Publ
     }
   );
   return res?.data ?? null;
+}
+
+export async function requestPublicTenantSharePackageItems(
+  token: string,
+  requestedItems: Array<"identity_summary" | "credibility_summary" | "application_summary" | "documents_summary">
+): Promise<{ requestedItems: typeof requestedItems }> {
+  const res = await apiFetch<{ ok: boolean; data: { requestedItems: typeof requestedItems } }>(
+    `/public/share/${encodeURIComponent(token)}/request`,
+    {
+      method: "POST",
+      body: { requestedItems },
+      suppressToasts: true,
+    }
+  );
+  return res.data;
 }

--- a/rentchain-frontend/src/api/tenantSharePackages.ts
+++ b/rentchain-frontend/src/api/tenantSharePackages.ts
@@ -5,6 +5,18 @@ export type TenantSharePackageLink = {
   createdAt: number;
   expiresAt: number;
   status: "active";
+  permissions: {
+    identitySummary: boolean;
+    credibilitySummary: boolean;
+    applicationSummary: boolean;
+    documents: "none" | "summary" | "approved_only";
+  };
+  requestedItems: Array<
+    "identity_summary" | "credibility_summary" | "application_summary" | "documents_summary"
+  >;
+  approvedItems: Array<
+    "identity_summary" | "credibility_summary" | "application_summary" | "documents_summary"
+  >;
 };
 
 export type TenantSharePackageCreated = TenantSharePackageLink & {
@@ -28,4 +40,18 @@ export async function revokeTenantSharePackage(id: string): Promise<void> {
   await tenantApiFetch(`/tenant/share-packages/${encodeURIComponent(id)}`, {
     method: "DELETE",
   });
+}
+
+export async function respondToTenantSharePackage(
+  id: string,
+  approvedItems: Array<"identity_summary" | "credibility_summary" | "application_summary" | "documents_summary">
+): Promise<TenantSharePackageLink> {
+  const res = await tenantApiFetch<{ ok: boolean; data: TenantSharePackageLink }>(
+    `/tenant/share-packages/${encodeURIComponent(id)}/respond`,
+    {
+      method: "POST",
+      body: { approvedItems },
+    }
+  );
+  return res.data;
 }

--- a/rentchain-frontend/src/pages/public/TenantSharePackagePage.test.tsx
+++ b/rentchain-frontend/src/pages/public/TenantSharePackagePage.test.tsx
@@ -1,10 +1,11 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import TenantSharePackagePage from "./TenantSharePackagePage";
 
 const publicTenantSharePackageApi = vi.hoisted(() => ({
   fetchPublicTenantSharePackage: vi.fn(),
+  requestPublicTenantSharePackageItems: vi.fn(),
 }));
 
 vi.mock("../../api/publicTenantSharePackageApi", () => publicTenantSharePackageApi);
@@ -37,11 +38,10 @@ describe("TenantSharePackagePage", () => {
         readinessLabel: "Ready to apply",
         readinessDescription: "Your core profile and supporting records are ready for most rental workflows.",
       },
-      profile: { completionStatus: "complete" },
-      application: { reusable: true },
-      documents: { completionStatus: "in_progress" },
-      screening: { status: "in_progress" },
-      leases: { summary: { activeCount: 1, historicalCount: 0 } },
+      availability: {
+        canRequestMore: true,
+        availableSections: ["identity"],
+      },
       generatedAt: "2026-04-26T00:00:00.000Z",
     });
 
@@ -50,6 +50,7 @@ describe("TenantSharePackagePage", () => {
     expect(await screen.findByText(/Shared Rental Profile/i)).toBeInTheDocument();
     expect(screen.getByText(/Ready to apply/i)).toBeInTheDocument();
     expect(screen.getByText(/^Verification$/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Request additional information/i })).toBeInTheDocument();
     expect(screen.queryByText(/TransUnion/i)).not.toBeInTheDocument();
   });
 
@@ -59,5 +60,37 @@ describe("TenantSharePackagePage", () => {
     renderPage();
 
     expect(await screen.findByText(/This shared rental profile is unavailable/i)).toBeInTheDocument();
+  });
+
+  it("submits a request for additional information without exposing unapproved sections", async () => {
+    publicTenantSharePackageApi.fetchPublicTenantSharePackage.mockResolvedValue({
+      identity: {
+        identityStatus: "ready",
+        verification: { level: "partial" },
+        readinessLabel: "Ready to apply",
+        readinessDescription: "Your core profile and supporting records are ready for most rental workflows.",
+      },
+      availability: {
+        canRequestMore: true,
+        availableSections: ["identity"],
+      },
+      generatedAt: "2026-04-26T00:00:00.000Z",
+    });
+    publicTenantSharePackageApi.requestPublicTenantSharePackageItems.mockResolvedValue({
+      requestedItems: ["credibility_summary"],
+    });
+
+    renderPage();
+
+    expect(await screen.findByRole("button", { name: /Request additional information/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText(/Credibility summary/i));
+    fireEvent.click(screen.getByRole("button", { name: /Request additional information/i }));
+
+    await waitFor(() => {
+      expect(publicTenantSharePackageApi.requestPublicTenantSharePackageItems).toHaveBeenCalledWith("token-123", [
+        "credibility_summary",
+      ]);
+    });
+    expect(screen.getAllByText(/^Unavailable$/i).length).toBeGreaterThan(0);
   });
 });

--- a/rentchain-frontend/src/pages/public/TenantSharePackagePage.tsx
+++ b/rentchain-frontend/src/pages/public/TenantSharePackagePage.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 import { useParams } from "react-router-dom";
-import { fetchPublicTenantSharePackage } from "../../api/publicTenantSharePackageApi";
+import {
+  fetchPublicTenantSharePackage,
+  requestPublicTenantSharePackageItems,
+} from "../../api/publicTenantSharePackageApi";
 
 function prettyStatus(value: string | null | undefined) {
   return String(value || "")
@@ -13,6 +16,9 @@ export default function TenantSharePackagePage() {
   const [data, setData] = React.useState<Awaited<ReturnType<typeof fetchPublicTenantSharePackage>> | null>(null);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
+  const [requesting, setRequesting] = React.useState(false);
+  const [requestError, setRequestError] = React.useState<string | null>(null);
+  const [requestedItems, setRequestedItems] = React.useState<Array<"credibility_summary" | "application_summary" | "documents_summary">>([]);
 
   React.useEffect(() => {
     let mounted = true;
@@ -40,6 +46,29 @@ export default function TenantSharePackagePage() {
     };
   }, [token]);
 
+  const toggleRequestItem = React.useCallback(
+    (item: "credibility_summary" | "application_summary" | "documents_summary") => {
+      setRequestedItems((current) =>
+        current.includes(item) ? current.filter((entry) => entry !== item) : [...current, item]
+      );
+    },
+    []
+  );
+
+  const handleRequest = React.useCallback(async () => {
+    try {
+      setRequesting(true);
+      setRequestError(null);
+      await requestPublicTenantSharePackageItems(token, requestedItems);
+    } catch (err: any) {
+      setRequestError(err?.message || "Unable to save this request right now.");
+    } finally {
+      setRequesting(false);
+    }
+  }, [requestedItems, token]);
+
+  const availableSections = new Set(data?.availability?.availableSections || []);
+
   return (
     <div style={{ minHeight: "100vh", background: "linear-gradient(180deg, #f8fafc 0%, #eef2ff 100%)", padding: 24 }}>
       <div style={{ maxWidth: 860, margin: "0 auto", display: "grid", gap: 16 }}>
@@ -64,30 +93,78 @@ export default function TenantSharePackagePage() {
 
         {!loading && !error && data ? (
           <div style={{ display: "grid", gap: 16 }}>
-            <div style={{ border: "1px solid rgba(15,23,42,0.08)", borderRadius: 16, background: "#fff", padding: 18, display: "grid", gap: 8 }}>
-              <div style={{ fontSize: "1.1rem", fontWeight: 800, color: "#0f172a" }}>{data.identity.readinessLabel}</div>
-              <div style={{ color: "#475569", lineHeight: 1.6 }}>{data.identity.readinessDescription}</div>
-            </div>
+            {data.identity ? (
+              <div style={{ border: "1px solid rgba(15,23,42,0.08)", borderRadius: 16, background: "#fff", padding: 18, display: "grid", gap: 8 }}>
+                <div style={{ fontSize: "1.1rem", fontWeight: 800, color: "#0f172a" }}>{data.identity.readinessLabel}</div>
+                <div style={{ color: "#475569", lineHeight: 1.6 }}>{data.identity.readinessDescription}</div>
+                <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 12 }}>
+                  {[
+                    ["Identity status", prettyStatus(data.identity.identityStatus)],
+                    ["Verification", prettyStatus(data.identity.verification.level)],
+                  ].map(([label, value]) => (
+                    <div key={label} style={{ border: "1px solid rgba(15,23,42,0.08)", borderRadius: 12, padding: "12px 14px", display: "grid", gap: 4 }}>
+                      <div style={{ color: "#64748b", fontSize: "0.85rem" }}>{label}</div>
+                      <div style={{ color: "#0f172a", fontWeight: 700 }}>{value}</div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ) : null}
 
-            <div style={{ border: "1px solid rgba(15,23,42,0.08)", borderRadius: 16, background: "#fff", padding: 18 }}>
-              <div style={{ fontWeight: 800, color: "#0f172a", marginBottom: 12 }}>Summary</div>
+            <div style={{ border: "1px solid rgba(15,23,42,0.08)", borderRadius: 16, background: "#fff", padding: 18, display: "grid", gap: 12 }}>
+              <div style={{ fontWeight: 800, color: "#0f172a" }}>Available information</div>
               <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 12 }}>
                 {[
-                  ["Identity status", prettyStatus(data.identity.identityStatus)],
-                  ["Verification", prettyStatus(data.identity.verification.level)],
-                  ["Profile", prettyStatus(data.profile.completionStatus)],
-                  ["Application reuse", data.application.reusable ? "Ready" : "Still building"],
-                  ["Documents", prettyStatus(data.documents.completionStatus)],
-                  ["Screening", prettyStatus(data.screening.status)],
-                  ["Active leases", String(data.leases.summary.activeCount)],
-                  ["Lease history", String(data.leases.summary.historicalCount)],
-                ].map(([label, value]) => (
-                  <div key={label} style={{ border: "1px solid rgba(15,23,42,0.08)", borderRadius: 12, padding: "12px 14px", display: "grid", gap: 4 }}>
+                  ["Credibility summary", availableSections.has("credibilitySummary"), data.credibilitySummary?.summaryLabel || "Unavailable"],
+                  ["Application summary", availableSections.has("application"), data.application?.reusable ? "Reusable application available" : "Unavailable"],
+                  ["Documents summary", availableSections.has("documents"), data.documents ? prettyStatus(data.documents.completionStatus) : "Unavailable"],
+                ].map(([label, available, value]) => (
+                  <div key={String(label)} style={{ border: "1px solid rgba(15,23,42,0.08)", borderRadius: 12, padding: "12px 14px", display: "grid", gap: 4 }}>
                     <div style={{ color: "#64748b", fontSize: "0.85rem" }}>{label}</div>
-                    <div style={{ color: "#0f172a", fontWeight: 700 }}>{value}</div>
+                    <div style={{ color: "#0f172a", fontWeight: 700 }}>{available ? value : "Unavailable"}</div>
                   </div>
                 ))}
               </div>
+              {data.credibilitySummary ? (
+                <div style={{ color: "#475569", lineHeight: 1.6 }}>{data.credibilitySummary.summaryDescription}</div>
+              ) : null}
+            </div>
+
+            <div style={{ border: "1px solid rgba(15,23,42,0.08)", borderRadius: 16, background: "#fff", padding: 18, display: "grid", gap: 12 }}>
+              <div style={{ fontWeight: 800, color: "#0f172a" }}>Request additional information</div>
+              <div style={{ color: "#475569", lineHeight: 1.6 }}>
+                Request additional summary sections. Access is only expanded if the tenant approves it later.
+              </div>
+              <label style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                <input
+                  type="checkbox"
+                  checked={requestedItems.includes("credibility_summary")}
+                  onChange={() => toggleRequestItem("credibility_summary")}
+                />
+                Credibility summary
+              </label>
+              <label style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                <input
+                  type="checkbox"
+                  checked={requestedItems.includes("application_summary")}
+                  onChange={() => toggleRequestItem("application_summary")}
+                />
+                Application summary
+              </label>
+              <label style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                <input
+                  type="checkbox"
+                  checked={requestedItems.includes("documents_summary")}
+                  onChange={() => toggleRequestItem("documents_summary")}
+                />
+                Documents summary
+              </label>
+              <div>
+                <button type="button" onClick={() => void handleRequest()} disabled={requesting || requestedItems.length === 0}>
+                  {requesting ? "Requesting..." : "Request additional information"}
+                </button>
+              </div>
+              {requestError ? <div style={{ color: "#b91c1c" }}>{requestError}</div> : null}
             </div>
           </div>
         ) : null}

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -54,6 +54,7 @@ const tenantSharePackagesApi = vi.hoisted(() => ({
   createTenantSharePackage: vi.fn(),
   listTenantSharePackages: vi.fn(),
   revokeTenantSharePackage: vi.fn(),
+  respondToTenantSharePackage: vi.fn(),
 }));
 
 vi.mock("../../api/tenantPortal", () => tenantPortalApi);
@@ -351,9 +352,31 @@ describe("tenant workspace frontend shell", () => {
       createdAt: 1710000000000,
       expiresAt: 1710600000000,
       status: "active",
+      permissions: {
+        identitySummary: true,
+        credibilitySummary: false,
+        applicationSummary: false,
+        documents: "none",
+      },
+      requestedItems: [],
+      approvedItems: [],
       shareUrl: "https://app.example/share/share-token-1",
     });
     tenantSharePackagesApi.revokeTenantSharePackage.mockResolvedValue(undefined);
+    tenantSharePackagesApi.respondToTenantSharePackage.mockResolvedValue({
+      id: "share-1",
+      createdAt: 1710000000000,
+      expiresAt: 1710600000000,
+      status: "active",
+      permissions: {
+        identitySummary: true,
+        credibilitySummary: true,
+        applicationSummary: false,
+        documents: "approved_only",
+      },
+      requestedItems: [],
+      approvedItems: ["credibility_summary", "documents_summary"],
+    });
     Object.assign(navigator, {
       clipboard: {
         writeText: vi.fn().mockResolvedValue(undefined),
@@ -495,7 +518,7 @@ describe("tenant workspace frontend shell", () => {
     expect(screen.getByText(/A rental application record was started\./i)).toBeInTheDocument();
     expect(screen.getByText(/Missing pieces/i)).toBeInTheDocument();
     expect(screen.getByText(/Income documents/i)).toBeInTheDocument();
-    expect(screen.getByText(/Share Your Rental Profile/i)).toBeInTheDocument();
+    expect(screen.getByText(/Manage Shared Access/i)).toBeInTheDocument();
     expect(screen.getByText(/Add missing details to keep your rental profile organized/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /View your profile/i })).toBeInTheDocument();
     expect(screen.queryByText(/^Applicant$/i)).not.toBeInTheDocument();
@@ -561,6 +584,14 @@ describe("tenant workspace frontend shell", () => {
           createdAt: 1710000000000,
           expiresAt: 1710600000000,
           status: "active",
+          permissions: {
+            identitySummary: true,
+            credibilitySummary: false,
+            applicationSummary: false,
+            documents: "none",
+          },
+          requestedItems: [],
+          approvedItems: [],
         },
       ]);
 
@@ -570,7 +601,7 @@ describe("tenant workspace frontend shell", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText(/Share Your Rental Profile/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Manage Shared Access/i)).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /Generate share link/i }));
 
@@ -584,6 +615,43 @@ describe("tenant workspace frontend shell", () => {
     await waitFor(() => {
       expect(tenantSharePackagesApi.revokeTenantSharePackage).toHaveBeenCalledWith("share-1");
     });
+  });
+
+  it("lets tenants approve a pending share access request", async () => {
+    tenantSharePackagesApi.listTenantSharePackages.mockResolvedValue([
+      {
+        id: "share-1",
+        createdAt: 1710000000000,
+        expiresAt: 1710600000000,
+        status: "active",
+        permissions: {
+          identitySummary: true,
+          credibilitySummary: false,
+          applicationSummary: false,
+          documents: "none",
+        },
+        requestedItems: ["credibility_summary", "documents_summary"],
+        approvedItems: [],
+      },
+    ]);
+
+    render(
+      <MemoryRouter>
+        <TenantWorkspacePage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole("button", { name: /Approve requested access/i })).toBeInTheDocument();
+    expect(screen.getByText(/Credibility summary, Documents summary/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Approve requested access/i }));
+
+    await waitFor(() => {
+      expect(tenantSharePackagesApi.respondToTenantSharePackage).toHaveBeenCalledWith("share-1", [
+        "credibility_summary",
+        "documents_summary",
+      ]);
+    });
+    expect(await screen.findByText(/Approved: Credibility summary, Documents summary/i)).toBeInTheDocument();
   });
 
   it("shows an active-tenancy transition state when tenant access is active but the lease is not active yet", async () => {

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
@@ -12,6 +12,7 @@ import {
   createTenantSharePackage,
   listTenantSharePackages,
   revokeTenantSharePackage,
+  respondToTenantSharePackage,
   type TenantSharePackageLink,
 } from "../../api/tenantSharePackages";
 import {
@@ -83,6 +84,22 @@ function prettyScreeningIdentityStatus(
     case "not_started":
     default:
       return "Not started";
+  }
+}
+
+function prettyShareRequestItem(
+  value: "identity_summary" | "credibility_summary" | "application_summary" | "documents_summary"
+) {
+  switch (value) {
+    case "credibility_summary":
+      return "Credibility summary";
+    case "application_summary":
+      return "Application summary";
+    case "documents_summary":
+      return "Documents summary";
+    case "identity_summary":
+    default:
+      return "Identity summary";
   }
 }
 
@@ -214,6 +231,25 @@ export default function TenantWorkspacePage() {
       setShareBusy(false);
     }
   }, []);
+
+  const handleRespondToShareRequest = React.useCallback(
+    async (
+      id: string,
+      approvedItems: Array<"identity_summary" | "credibility_summary" | "application_summary" | "documents_summary">
+    ) => {
+      try {
+        setShareBusy(true);
+        setShareError(null);
+        const updated = await respondToTenantSharePackage(id, approvedItems);
+        setSharePackages((current) => current.map((entry) => (entry.id === id ? updated : entry)));
+      } catch (err: any) {
+        setShareError(err?.payload?.error || err?.message || "Unable to update this share request right now.");
+      } finally {
+        setShareBusy(false);
+      }
+    },
+    []
+  );
 
   if (loading) {
     return (
@@ -537,10 +573,10 @@ export default function TenantWorkspacePage() {
         )}
       </TenantInfoCard>
 
-      <TenantInfoCard heading="Share Your Rental Profile" accent="#1d4ed8">
+      <TenantInfoCard heading="Manage Shared Access" accent="#1d4ed8">
         <div style={{ display: "grid", gap: spacing.sm }}>
           <div style={{ color: textTokens.secondary, lineHeight: 1.6 }}>
-            Generate a privacy-safe share link with your rental identity summary. The public view stays read-only and never exposes raw documents, screening provider details, or signature data.
+            Generate a privacy-safe share link, review any additional access requests, and approve only the extra summaries you want to share. Public access stays read-only and never exposes raw documents, screening provider details, or signature data.
           </div>
 
           <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
@@ -581,6 +617,44 @@ export default function TenantWorkspacePage() {
                   <div style={{ color: textTokens.secondary }}>
                     Created {formatDate(entry.createdAt)} • Expires {formatDate(entry.expiresAt)}
                   </div>
+                  <div style={{ color: textTokens.secondary }}>
+                    Approved:{" "}
+                    {entry.approvedItems.length
+                      ? entry.approvedItems.map((item) => prettyShareRequestItem(item)).join(", ")
+                      : "Identity summary only"}
+                  </div>
+                  {entry.requestedItems.length ? (
+                    <div
+                      style={{
+                        border: "1px solid rgba(15,23,42,0.08)",
+                        borderRadius: 12,
+                        padding: "10px 12px",
+                        display: "grid",
+                        gap: 8,
+                      }}
+                    >
+                      <div style={{ fontWeight: 700, color: textTokens.primary }}>Pending request</div>
+                      <div style={{ color: textTokens.secondary }}>
+                        {entry.requestedItems.map((item) => prettyShareRequestItem(item)).join(", ")}
+                      </div>
+                      <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
+                        <button
+                          type="button"
+                          onClick={() => void handleRespondToShareRequest(entry.id, entry.requestedItems)}
+                          disabled={shareBusy}
+                        >
+                          Approve requested access
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => void handleRespondToShareRequest(entry.id, [])}
+                          disabled={shareBusy}
+                        >
+                          Deny request
+                        </button>
+                      </div>
+                    </div>
+                  ) : null}
                   <div>
                     <button type="button" onClick={() => void handleRevokeShareLink(entry.id)} disabled={shareBusy}>
                       Revoke link


### PR DESCRIPTION
This PR introduces Tenant Share Package v2.

Includes:
- permissioned share access metadata
- public landlord-style request flow
- tenant approve/deny response flow
- read-time permission filtering
- summary-only documents access
- tenant workspace Manage Shared Access UI
- public share page request UI
- focused backend/frontend test coverage

Guardrails preserved:
- no parallel permission system
- no raw token persistence
- no raw document access
- no document filenames, URLs, or categories
- no provider exposure
- no landlord account linkage
- no notifications/email
- no analytics/view tracking
- no permission auto-grant on request
- fail-closed 404 behavior for invalid, expired, or revoked links

PR note:
- Backend focused share-package tests passed.
- Backend typecheck passed.
- Frontend tenant/public share tests passed.
- Frontend build passed.
- Existing frontend chunk-size warning remains unchanged and out of scope.