### PR TITLE
feat: add landlord inbox workflow

### DIFF
--- a/rentchain-api/src/routes/__tests__/landlordAnalyticsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordAnalyticsRoutes.test.ts
@@ -28,6 +28,7 @@ const loadLatestScreeningOrderForApplication = vi.fn();
 const executeScreeningCheckout = vi.fn();
 const isTransUnionReferralMode = vi.fn();
 const shouldUseMockScreeningCheckoutOverride = vi.fn();
+const deriveLandlordInbox = vi.fn();
 
 vi.mock("../../middleware/requireAuth", () => ({
   requireAuth: (req: any, res: any, next: any) => {
@@ -53,6 +54,10 @@ vi.mock("../../middleware/requireLandlord", () => ({
 
 vi.mock("../../services/landlord/landlordAnalyticsSnapshot", () => ({
   loadLandlordAnalyticsSnapshot,
+}));
+
+vi.mock("../../services/landlordInbox/deriveLandlordInbox", () => ({
+  deriveLandlordInbox,
 }));
 
 vi.mock("../../services/landlord/landlordApplicationFunnel", () => ({
@@ -576,6 +581,36 @@ describe("landlordAnalyticsRoutes", () => {
         medianHoursToCompleteAfterReminder: 6.5,
       },
     });
+    deriveLandlordInbox.mockResolvedValue({
+      items: [
+        {
+          id: "application:app-1",
+          type: "application",
+          subjectId: "app-1",
+          applicationId: "app-1",
+          leaseId: null,
+          title: "Application ready for review",
+          description: "Current application context is ready for landlord review.",
+          priority: "medium",
+          status: "action_required",
+          nextAction: "review_application",
+          nextActionHref: "/applications/app-1/review-summary",
+          trustSummary: {
+            readiness: "ready",
+            verificationLevel: "partial",
+          },
+          credibilitySummary: {
+            completenessLevel: "medium",
+          },
+          source: "review_summary",
+        },
+      ],
+      summary: {
+        actionRequired: 1,
+        pending: 0,
+        completed: 0,
+      },
+    });
   });
 
   it("returns landlord-scoped analytics without allowing scope override", async () => {
@@ -633,6 +668,43 @@ describe("landlordAnalyticsRoutes", () => {
         },
         conversion: {
           completionRate: 0.4286,
+        },
+      },
+    });
+  });
+
+  it("returns landlord inbox items without allowing scope override", async () => {
+    const router = (await import("../landlordAnalyticsRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/analytics/inbox?period=90d&propertyId=prop-123&landlordId=other-landlord",
+      user: { id: "landlord-1", role: "landlord" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(loadLandlordAnalyticsSnapshot).toHaveBeenCalledWith({
+      landlordId: "landlord-1",
+      period: "90d",
+      propertyId: "prop-123",
+    });
+    expect(deriveLandlordInbox).toHaveBeenCalledWith({
+      landlordId: "landlord-1",
+      propertyId: "prop-123",
+      analyticsDecisions: expect.any(Array),
+    });
+    expect(response.body).toEqual({
+      ok: true,
+      data: {
+        items: [
+          expect.objectContaining({
+            id: "application:app-1",
+            nextAction: "review_application",
+          }),
+        ],
+        summary: {
+          actionRequired: 1,
+          pending: 0,
+          completed: 0,
         },
       },
     });

--- a/rentchain-api/src/routes/landlordAnalyticsRoutes.ts
+++ b/rentchain-api/src/routes/landlordAnalyticsRoutes.ts
@@ -25,6 +25,7 @@ import {
   shouldUseMockScreeningCheckoutOverride,
 } from "../services/screeningCheckoutExecutionService";
 import { loadLandlordAnalyticsSnapshot } from "../services/landlord/landlordAnalyticsSnapshot";
+import { deriveLandlordInbox } from "../services/landlordInbox/deriveLandlordInbox";
 import {
   saveExecutedLandlordDecisionState,
   saveFailedLandlordDecisionExecutionOutcome,
@@ -267,6 +268,35 @@ router.get("/landlord/analytics", requireAuth, requireLandlord, async (req: any,
   } catch (err: any) {
     console.error("[landlord-analytics] fetch failed", err?.message || err);
     return res.status(500).json({ ok: false, error: "LANDLORD_ANALYTICS_FETCH_FAILED" });
+  }
+});
+
+router.get("/landlord/analytics/inbox", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = asString(req.user?.landlordId || req.user?.id, 240);
+    if (!landlordId) {
+      return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    }
+
+    const snapshot = await loadLandlordAnalyticsSnapshot({
+      landlordId,
+      period: req.query?.period,
+      propertyId: req.query?.propertyId,
+    });
+
+    const inbox = await deriveLandlordInbox({
+      landlordId,
+      propertyId: req.query?.propertyId,
+      analyticsDecisions: Array.isArray(snapshot?.decisions?.items) ? snapshot.decisions.items : [],
+    });
+
+    return res.json({
+      ok: true,
+      data: inbox,
+    });
+  } catch (err: any) {
+    console.error("[landlord_inbox] failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "LANDLORD_INBOX_FAILED" });
   }
 });
 

--- a/rentchain-api/src/services/landlordInbox/__tests__/deriveLandlordInbox.test.ts
+++ b/rentchain-api/src/services/landlordInbox/__tests__/deriveLandlordInbox.test.ts
@@ -1,0 +1,225 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dbMock = {
+  collection: vi.fn(),
+};
+
+const buildReviewSummary = vi.fn();
+const loadLandlordSafeTenantIdentitySummary = vi.fn();
+const deriveLandlordSafeApplicationReusableFromApplication = vi.fn();
+const deriveLandlordTrustContext = vi.fn();
+const deriveTenantCredibilitySignals = vi.fn();
+const deriveLeaseExecution = vi.fn();
+
+vi.mock("../../../config/firebase", () => ({
+  db: dbMock,
+}));
+
+vi.mock("../../../lib/reviewSummary", () => ({
+  buildReviewSummary,
+}));
+
+vi.mock("../../../lib/trust/deriveLandlordTrustContext", () => ({
+  deriveLandlordTrustContext,
+}));
+
+vi.mock("../../tenantPortal/tenantProfileService", () => ({
+  loadLandlordSafeTenantIdentitySummary,
+  deriveLandlordSafeApplicationReusableFromApplication,
+}));
+
+vi.mock("../../tenantCredibility/deriveTenantCredibilitySignals", () => ({
+  deriveTenantCredibilitySignals,
+}));
+
+vi.mock("../../leaseExecution/deriveLeaseExecution", () => ({
+  deriveLeaseExecution,
+}));
+
+function makeDoc(id: string, data: Record<string, unknown>) {
+  return {
+    id,
+    data: () => data,
+  };
+}
+
+describe("deriveLandlordInbox", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbMock.collection.mockImplementation((name: string) => ({
+      get: vi.fn().mockResolvedValue({
+        docs:
+          name === "rentalApplications"
+            ? [
+                makeDoc("app-1", {
+                  landlordId: "landlord-1",
+                  propertyId: "prop-1",
+                  status: "submitted",
+                }),
+              ]
+            : [
+                makeDoc("lease-1", {
+                  landlordId: "landlord-1",
+                  propertyId: "prop-1",
+                  applicationId: "app-1",
+                  status: "awaiting_landlord_signature",
+                }),
+              ],
+      }),
+    }));
+    buildReviewSummary.mockReturnValue({
+      derived: {
+        completeness: { score: 0.82 },
+        flags: ["income_pending"],
+      },
+      screening: {
+        status: "in_progress",
+      },
+    });
+    loadLandlordSafeTenantIdentitySummary.mockResolvedValue({
+      identityStatus: "ready",
+      verification: { level: "partial" },
+      readinessLabel: "Ready for review",
+      readinessDescription: "Current application signals are organized for review.",
+    });
+    deriveLandlordSafeApplicationReusableFromApplication.mockReturnValue(true);
+    deriveLandlordTrustContext.mockReturnValue({
+      trustReadiness: "ready",
+      trustLabel: "Ready for review",
+      trustDescription: "Current application context is ready for landlord review.",
+      positiveSignals: [],
+      missingSignals: [],
+      cautionSignals: [],
+      recommendedNextAction: "review_application",
+      decisionSupportLevel: "medium",
+    });
+    deriveTenantCredibilitySignals.mockReturnValue({
+      landlordSafeSummary: {
+        completenessLevel: "medium",
+        verificationLevel: "partial",
+        summaryLabel: "Building credibility",
+        summaryDescription: "Some credibility signals are available.",
+      },
+    });
+    deriveLeaseExecution.mockReturnValue({
+      executionStatus: "ready_for_landlord_signature",
+      executionLabel: "Waiting for landlord signature",
+      executionDescription: "Tenant signing appears complete and the next visible execution step belongs to the landlord.",
+      requiredNextAction: "landlord_signature",
+      tenantSignatureStatus: "completed",
+      landlordSignatureStatus: "needed",
+      pdfStatus: "generated",
+      completedAt: null,
+    });
+  });
+
+  it("builds inbox items from review-summary-compatible application context", async () => {
+    const { deriveLandlordInbox } = await import("../deriveLandlordInbox");
+    const result = await deriveLandlordInbox({
+      landlordId: "landlord-1",
+      analyticsDecisions: [],
+    });
+
+    expect(result.summary.actionRequired).toBe(1);
+    expect(result.items).toEqual([
+      expect.objectContaining({
+        id: "application:app-1",
+        type: "application",
+        nextAction: "review_application",
+        nextActionHref: "/applications/app-1/review-summary",
+        trustSummary: {
+          readiness: "ready",
+          verificationLevel: "partial",
+        },
+        credibilitySummary: {
+          completenessLevel: "medium",
+        },
+        source: "review_summary",
+      }),
+    ]);
+  });
+
+  it("uses analytics decisions as overlays instead of creating duplicates", async () => {
+    const { deriveLandlordInbox } = await import("../deriveLandlordInbox");
+    const result = await deriveLandlordInbox({
+      landlordId: "landlord-1",
+      analyticsDecisions: [
+        {
+          id: "start_screening_checkout:app-1",
+          decisionType: "start_screening_checkout",
+          priority: "high",
+          explanation: "Start screening",
+          supportingSignals: [],
+          recommendedAction: "Start screening",
+          actionKey: "open_screening_checkout_flow",
+          actionLabel: "Start screening checkout",
+          destination: "/applications/app-1/review-summary",
+          workflowCategory: "screening_checkout",
+          automationEligible: false,
+          automationState: "manual_only",
+          automationReason: null,
+          executionMappingState: "none",
+          executionMapping: null,
+          executionInputState: "none",
+          executionInputReason: null,
+          executionInputMissingFields: [],
+          executionInput: null,
+          executionState: "blocked",
+          blockedReason: "automation_disabled",
+          executionGuardKey: null,
+          duplicateGuardActive: false,
+          executionSummary: {
+            lastExecutedAt: null,
+            executionCount: 0,
+            lastExecutionOutcome: "none",
+            lastExecutionOutcomeAt: null,
+          },
+          executedAt: null,
+          executionOutcomeStatus: "none",
+          executionOutcomeAt: null,
+          executionOutcomeReason: null,
+          state: "pending",
+          reviewedAt: null,
+          trustContext: null,
+        },
+      ],
+    });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]?.id).toBe("application:app-1");
+    expect(result.items[0]?.priority).toBe("high");
+  });
+
+  it("creates a lease item only when it is landlord-actionable and not duplicated by an application item", async () => {
+    dbMock.collection.mockImplementation((name: string) => ({
+      get: vi.fn().mockResolvedValue({
+        docs:
+          name === "rentalApplications"
+            ? []
+            : [
+                makeDoc("lease-1", {
+                  landlordId: "landlord-1",
+                  propertyId: "prop-1",
+                  status: "awaiting_landlord_signature",
+                }),
+              ],
+      }),
+    }));
+
+    const { deriveLandlordInbox } = await import("../deriveLandlordInbox");
+    const result = await deriveLandlordInbox({
+      landlordId: "landlord-1",
+      analyticsDecisions: [],
+    });
+
+    expect(result.items).toEqual([
+      expect.objectContaining({
+        id: "lease:lease-1",
+        type: "lease",
+        nextAction: "prepare_lease",
+        nextActionHref: "/leases/lease-1/ledger",
+        source: "lease_execution",
+      }),
+    ]);
+  });
+});

--- a/rentchain-api/src/services/landlordInbox/deriveLandlordInbox.ts
+++ b/rentchain-api/src/services/landlordInbox/deriveLandlordInbox.ts
@@ -1,0 +1,464 @@
+import { db } from "../../config/firebase";
+import type { LandlordAgentDecision } from "../../lib/analytics/analyticsTypes";
+import { buildReviewSummary } from "../../lib/reviewSummary";
+import { deriveLandlordTrustContext } from "../../lib/trust/deriveLandlordTrustContext";
+import { deriveLeaseExecution } from "../leaseExecution/deriveLeaseExecution";
+import {
+  deriveTenantCredibilitySignals,
+  type LandlordSafeTenantCredibilitySummary,
+} from "../tenantCredibility/deriveTenantCredibilitySignals";
+import {
+  deriveLandlordSafeApplicationReusableFromApplication,
+  loadLandlordSafeTenantIdentitySummary,
+  type TenantIdentitySummary,
+  type TenantIdentityRecord,
+} from "../tenantPortal/tenantProfileService";
+
+type InboxPriority = "low" | "medium" | "high";
+type InboxStatus = "action_required" | "pending" | "completed";
+type InboxType = "application" | "lease" | "screening";
+type InboxNextAction =
+  | "review_application"
+  | "request_info"
+  | "review_documents"
+  | "review_screening"
+  | "prepare_lease"
+  | "no_action";
+
+export type LandlordInboxItem = {
+  id: string;
+  type: InboxType;
+  subjectId: string;
+  applicationId: string | null;
+  leaseId: string | null;
+  title: string;
+  description: string;
+  priority: InboxPriority;
+  status: InboxStatus;
+  nextAction: InboxNextAction;
+  nextActionHref: string | null;
+  trustSummary: {
+    readiness: "limited" | "emerging" | "ready" | "strong";
+    verificationLevel: "none" | "partial" | "strong";
+  } | null;
+  credibilitySummary: {
+    completenessLevel: "low" | "medium" | "high";
+  } | null;
+  source: "review_summary" | "analytics_overlay" | "lease_execution";
+};
+
+export type LandlordInboxResult = {
+  items: LandlordInboxItem[];
+  summary: {
+    actionRequired: number;
+    pending: number;
+    completed: number;
+  };
+};
+
+type DeriveLandlordInboxParams = {
+  landlordId: string;
+  propertyId?: string | null;
+  analyticsDecisions: LandlordAgentDecision[];
+};
+
+type ScopedApplicationRecord = Record<string, unknown> & {
+  id: string;
+  landlordId?: string | null;
+  ownerId?: string | null;
+  userId?: string | null;
+  propertyId?: string | null;
+  status?: string | null;
+};
+
+type ScopedLeaseRecord = Record<string, unknown> & {
+  id: string;
+  landlordId?: string | null;
+  ownerId?: string | null;
+  userId?: string | null;
+  propertyId?: string | null;
+  applicationId?: string | null;
+  documentUrl?: string | null;
+  status?: string | null;
+};
+
+function asString(value: unknown, max = 240): string | null {
+  const next = String(value || "").trim().slice(0, max);
+  return next || null;
+}
+
+function normalizeStatus(value: unknown): string {
+  return String(value || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_");
+}
+
+function hasLandlordScope(doc: { landlordId?: string | null; ownerId?: string | null; userId?: string | null }, landlordId: string) {
+  return [doc.landlordId, doc.ownerId, doc.userId].some((value) => asString(value, 240) === landlordId);
+}
+
+function matchesPropertyScope(propertyId: string | null, requestedPropertyId: string | null) {
+  if (!requestedPropertyId) return true;
+  return propertyId === requestedPropertyId;
+}
+
+async function loadCollection(name: string) {
+  return await db.collection(name).get().catch(() => ({ docs: [] } as any));
+}
+
+function maxPriority(left: InboxPriority, right: InboxPriority): InboxPriority {
+  const ranking: Record<InboxPriority, number> = { low: 1, medium: 2, high: 3 };
+  return ranking[right] > ranking[left] ? right : left;
+}
+
+function actionFromTrustNextAction(
+  nextAction:
+    | "review_application"
+    | "request_missing_info"
+    | "review_screening_status"
+    | "review_documents"
+    | "prepare_lease"
+    | "no_action"
+): InboxNextAction {
+  switch (nextAction) {
+    case "request_missing_info":
+      return "request_info";
+    case "review_screening_status":
+      return "review_screening";
+    case "review_documents":
+      return "review_documents";
+    case "prepare_lease":
+      return "prepare_lease";
+    case "no_action":
+      return "no_action";
+    case "review_application":
+    default:
+      return "review_application";
+  }
+}
+
+function titleFromNextAction(action: InboxNextAction): string {
+  switch (action) {
+    case "request_info":
+      return "Application needs more information";
+    case "review_screening":
+      return "Screening needs review";
+    case "review_documents":
+      return "Supporting records need review";
+    case "prepare_lease":
+      return "Application is ready for lease preparation";
+    case "no_action":
+      return "Application review is settled";
+    case "review_application":
+    default:
+      return "Application ready for review";
+  }
+}
+
+function statusFromNextAction(action: InboxNextAction): InboxStatus {
+  if (action === "no_action") return "completed";
+  return "action_required";
+}
+
+function priorityFromApplicationContext(params: {
+  nextAction: InboxNextAction;
+  screeningStatus: string | null;
+  completenessFlags: string[];
+}): InboxPriority {
+  const { nextAction, screeningStatus, completenessFlags } = params;
+  if (nextAction === "request_info" || nextAction === "review_screening") return "high";
+  if (nextAction === "prepare_lease") return "medium";
+  if (nextAction === "review_documents") return "medium";
+  if (nextAction === "review_application") {
+    if ((screeningStatus || "") === "needs_attention") return "high";
+    if (completenessFlags.length > 0) return "medium";
+    return "medium";
+  }
+  return "low";
+}
+
+function buildLandlordSafeIdentityRecord(params: {
+  tenantIdentitySummary: TenantIdentitySummary | null;
+  applicationReusable: boolean;
+  screeningStatus: string | null | undefined;
+}): TenantIdentityRecord | null {
+  const { tenantIdentitySummary, applicationReusable, screeningStatus } = params;
+  if (!tenantIdentitySummary) return null;
+  return {
+    identityStatus: tenantIdentitySummary.identityStatus,
+    verification: tenantIdentitySummary.verification,
+    readinessLabel: tenantIdentitySummary.readinessLabel,
+    readinessDescription: tenantIdentitySummary.readinessDescription,
+    profile: {
+      completionStatus:
+        tenantIdentitySummary.identityStatus === "ready" || tenantIdentitySummary.identityStatus === "verified"
+          ? "complete"
+          : tenantIdentitySummary.identityStatus === "incomplete"
+          ? "in_progress"
+          : "missing",
+    },
+    application: {
+      reusable: applicationReusable,
+      lastSubmittedAt: null,
+    },
+    documents: {
+      completionStatus:
+        tenantIdentitySummary.verification.level === "strong"
+          ? "complete"
+          : tenantIdentitySummary.verification.level === "partial"
+          ? "in_progress"
+          : "missing",
+      missingCategories: [],
+    },
+    screening: {
+      status:
+        screeningStatus === "completed" ||
+        screeningStatus === "in_progress" ||
+        screeningStatus === "needs_attention" ||
+        screeningStatus === "blocked"
+          ? (screeningStatus as TenantIdentityRecord["screening"]["status"])
+          : tenantIdentitySummary.verification.level === "strong"
+          ? "completed"
+          : tenantIdentitySummary.verification.level === "partial"
+          ? "in_progress"
+          : "not_started",
+      lastCompletedAt: null,
+    },
+    leases: {
+      activeCount: 0,
+      historicalCount: 0,
+      lastSignedAt: null,
+    },
+  };
+}
+
+function parseScreeningDecisionApplicationId(decisionId: string): string | null {
+  const match = decisionId.match(/^start_screening_checkout:(.+)$/);
+  return match ? asString(match[1], 240) : null;
+}
+
+function buildFallbackItemFromDecision(decision: LandlordAgentDecision): LandlordInboxItem | null {
+  if (decision.decisionType !== "start_screening_checkout" && decision.decisionType !== "improve_application_conversion") {
+    return null;
+  }
+
+  const applicationId =
+    decision.decisionType === "start_screening_checkout" ? parseScreeningDecisionApplicationId(decision.id) : null;
+  const type: InboxType = decision.decisionType === "start_screening_checkout" ? "screening" : "application";
+  const nextAction: InboxNextAction = decision.decisionType === "start_screening_checkout" ? "review_screening" : "review_application";
+
+  return {
+    id: `decision:${decision.id}`,
+    type,
+    subjectId: decision.id,
+    applicationId,
+    leaseId: null,
+    title: decision.actionLabel || titleFromNextAction(nextAction),
+    description: decision.explanation || "A current analytics decision is available for landlord follow-through.",
+    priority: decision.priority,
+    status: decision.state === "executed" || decision.state === "dismissed" ? "completed" : "action_required",
+    nextAction,
+    nextActionHref: asString(decision.destination, 400),
+    trustSummary: decision.trustContext
+      ? {
+          readiness: decision.trustContext.trustReadiness,
+          verificationLevel:
+            decision.trustContext.decisionSupportLevel === "high"
+              ? "strong"
+              : decision.trustContext.decisionSupportLevel === "medium"
+              ? "partial"
+              : "none",
+        }
+      : null,
+    credibilitySummary: null,
+    source: "analytics_overlay",
+  };
+}
+
+function sortItems(items: LandlordInboxItem[]) {
+  const statusRank: Record<InboxStatus, number> = {
+    action_required: 1,
+    pending: 2,
+    completed: 3,
+  };
+  const priorityRank: Record<InboxPriority, number> = {
+    high: 1,
+    medium: 2,
+    low: 3,
+  };
+
+  return [...items].sort((left, right) => {
+    const statusDiff = statusRank[left.status] - statusRank[right.status];
+    if (statusDiff !== 0) return statusDiff;
+    const priorityDiff = priorityRank[left.priority] - priorityRank[right.priority];
+    if (priorityDiff !== 0) return priorityDiff;
+    return left.title.localeCompare(right.title);
+  });
+}
+
+export async function deriveLandlordInbox(
+  params: DeriveLandlordInboxParams
+): Promise<LandlordInboxResult> {
+  const landlordId = asString(params.landlordId, 240);
+  if (!landlordId) {
+    return {
+      items: [],
+      summary: { actionRequired: 0, pending: 0, completed: 0 },
+    };
+  }
+
+  const propertyId = asString(params.propertyId, 240);
+  const [applicationsSnap, leasesSnap] = await Promise.all([
+    loadCollection("rentalApplications"),
+    loadCollection("leases"),
+  ]);
+
+  const applications = ((applicationsSnap.docs || []) as Array<{ id: string; data: () => unknown }>)
+    .map((doc) => ({ id: doc.id, ...((doc.data() as Record<string, unknown>) || {}) }))
+    .filter((entry): entry is ScopedApplicationRecord => Boolean(asString(entry.id, 240)))
+    .filter((entry) => hasLandlordScope(entry, landlordId))
+    .filter((entry) => matchesPropertyScope(asString(entry.propertyId, 240), propertyId));
+
+  const leases = ((leasesSnap.docs || []) as Array<{ id: string; data: () => unknown }>)
+    .map((doc) => ({ id: doc.id, ...((doc.data() as Record<string, unknown>) || {}) }))
+    .filter((entry): entry is ScopedLeaseRecord => Boolean(asString(entry.id, 240)))
+    .filter((entry) => hasLandlordScope(entry, landlordId))
+    .filter((entry) => matchesPropertyScope(asString(entry.propertyId, 240), propertyId));
+
+  const items: LandlordInboxItem[] = [];
+  const applicationItems = new Map<string, LandlordInboxItem>();
+
+  for (const application of applications) {
+    const applicationId = asString(application.id, 240);
+    if (!applicationId) continue;
+
+    const summary = buildReviewSummary(applicationId, application);
+    const completenessFlags = Array.isArray(summary?.derived?.flags)
+      ? summary.derived.flags.map((entry) => asString(entry, 240)).filter(Boolean) as string[]
+      : [];
+    const screeningStatus = asString(summary?.screening?.status, 80);
+    const applicationReusable = deriveLandlordSafeApplicationReusableFromApplication(application);
+    const tenantIdentitySummary = await loadLandlordSafeTenantIdentitySummary({
+      applicationId,
+      application,
+    });
+    const trustContext = deriveLandlordTrustContext({
+      tenantIdentitySummary,
+      completenessScore: summary?.derived?.completeness?.score ?? null,
+      completenessFlags,
+      screeningStatus,
+      applicationReusable,
+    });
+    const landlordSafeRecord = buildLandlordSafeIdentityRecord({
+      tenantIdentitySummary,
+      applicationReusable,
+      screeningStatus,
+    });
+    const { landlordSafeSummary: tenantCredibilitySummary } = deriveTenantCredibilitySignals({
+      tenantIdentityRecord: landlordSafeRecord,
+      leaseExecution: null,
+    });
+
+    const nextAction = actionFromTrustNextAction(trustContext.recommendedNextAction);
+    if (nextAction === "no_action") continue;
+
+    const item: LandlordInboxItem = {
+      id: `application:${applicationId}`,
+      type: nextAction === "review_screening" ? "screening" : "application",
+      subjectId: applicationId,
+      applicationId,
+      leaseId: null,
+      title: titleFromNextAction(nextAction),
+      description: trustContext.trustDescription,
+      priority: priorityFromApplicationContext({
+        nextAction,
+        screeningStatus,
+        completenessFlags,
+      }),
+      status: statusFromNextAction(nextAction),
+      nextAction,
+      nextActionHref: `/applications/${encodeURIComponent(applicationId)}/review-summary`,
+      trustSummary: tenantIdentitySummary
+        ? {
+            readiness: trustContext.trustReadiness,
+            verificationLevel: tenantIdentitySummary.verification.level,
+          }
+        : null,
+      credibilitySummary: {
+        completenessLevel: tenantCredibilitySummary.completenessLevel,
+      },
+      source: "review_summary",
+    };
+
+    items.push(item);
+    applicationItems.set(applicationId, item);
+  }
+
+  for (const decision of params.analyticsDecisions || []) {
+    const fallback = buildFallbackItemFromDecision(decision);
+    if (!fallback) continue;
+
+    const overlayApplicationId = fallback.applicationId;
+    if (overlayApplicationId && applicationItems.has(overlayApplicationId)) {
+      const current = applicationItems.get(overlayApplicationId)!;
+      current.priority = maxPriority(current.priority, fallback.priority);
+      continue;
+    }
+
+    items.push(fallback);
+  }
+
+  for (const lease of leases) {
+    const leaseId = asString(lease.id, 240);
+    if (!leaseId) continue;
+    const leaseExecution = deriveLeaseExecution({
+      leaseId,
+      documentUrl: asString(lease.documentUrl, 400),
+      status: asString(lease.status, 80),
+      raw: lease,
+    });
+
+    if (!["ready_for_landlord_signature", "tenant_signed", "landlord_signed"].includes(leaseExecution.executionStatus)) {
+      continue;
+    }
+
+    const linkedApplicationId = asString(lease.applicationId, 240);
+    if (linkedApplicationId && applicationItems.has(linkedApplicationId)) {
+      continue;
+    }
+
+    const completed = leaseExecution.executionStatus === "landlord_signed";
+    items.push({
+      id: `lease:${leaseId}`,
+      type: "lease",
+      subjectId: leaseId,
+      applicationId: linkedApplicationId,
+      leaseId,
+      title: leaseExecution.executionLabel,
+      description: leaseExecution.executionDescription,
+      priority:
+        leaseExecution.executionStatus === "ready_for_landlord_signature"
+          ? "high"
+          : leaseExecution.executionStatus === "tenant_signed"
+          ? "medium"
+          : "low",
+      status: completed ? "completed" : "action_required",
+      nextAction: completed ? "no_action" : "prepare_lease",
+      nextActionHref: `/leases/${encodeURIComponent(leaseId)}/ledger`,
+      trustSummary: null,
+      credibilitySummary: null,
+      source: "lease_execution",
+    });
+  }
+
+  const orderedItems = sortItems(items);
+  return {
+    items: orderedItems,
+    summary: {
+      actionRequired: orderedItems.filter((item) => item.status === "action_required").length,
+      pending: orderedItems.filter((item) => item.status === "pending").length,
+      completed: orderedItems.filter((item) => item.status === "completed").length,
+    },
+  };
+}

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -113,6 +113,7 @@ const PortfolioScorePage = lazy(() => import("./pages/admin/PortfolioScorePage")
 const PortfolioScoreHistoryPage = lazy(() => import("./pages/admin/PortfolioScoreHistoryPage"));
 const PortfolioHealthSummaryPage = lazy(() => import("./pages/landlord/PortfolioHealthSummaryPage"));
 const LandlordAnalyticsPage = lazy(() => import("./pages/landlord/LandlordAnalyticsPage"));
+const LandlordInboxPage = lazy(() => import("./pages/landlord/LandlordInboxPage"));
 const LandlordPortfolioScorePage = lazy(() => import("./pages/landlord/PortfolioScorePage"));
 const SharedPortfolioScorePage = lazy(() => import("./pages/public/SharedPortfolioScorePage"));
 const TenantSharePackagePage = lazy(() => import("./pages/public/TenantSharePackagePage"));
@@ -482,6 +483,18 @@ function App() {
               <LandlordNav>
                 <Suspense fallback={null}>
                   <LandlordAnalyticsPage />
+                </Suspense>
+              </LandlordNav>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/landlord/inbox"
+          element={
+            <RequireAuth>
+              <LandlordNav>
+                <Suspense fallback={null}>
+                  <LandlordInboxPage />
                 </Suspense>
               </LandlordNav>
             </RequireAuth>

--- a/rentchain-frontend/src/api/landlordAnalyticsApi.ts
+++ b/rentchain-frontend/src/api/landlordAnalyticsApi.ts
@@ -352,6 +352,43 @@ export type LandlordAnalyticsSnapshot = {
   };
 };
 
+export type LandlordInboxItem = {
+  id: string;
+  type: "application" | "lease" | "screening";
+  subjectId: string;
+  applicationId: string | null;
+  leaseId: string | null;
+  title: string;
+  description: string;
+  priority: "low" | "medium" | "high";
+  status: "action_required" | "pending" | "completed";
+  nextAction:
+    | "review_application"
+    | "request_info"
+    | "review_documents"
+    | "review_screening"
+    | "prepare_lease"
+    | "no_action";
+  nextActionHref: string | null;
+  trustSummary: {
+    readiness: "limited" | "emerging" | "ready" | "strong";
+    verificationLevel: "none" | "partial" | "strong";
+  } | null;
+  credibilitySummary: {
+    completenessLevel: "low" | "medium" | "high";
+  } | null;
+  source: "review_summary" | "analytics_overlay" | "lease_execution";
+};
+
+export type LandlordInboxResponse = {
+  items: LandlordInboxItem[];
+  summary: {
+    actionRequired: number;
+    pending: number;
+    completed: number;
+  };
+};
+
 export type LandlordDecisionHistoryResponse = {
   ok: true;
   decisionId: string;
@@ -391,6 +428,18 @@ export async function fetchLandlordAnalyticsSnapshot(params?: {
   if (params?.propertyId) search.set("propertyId", params.propertyId);
   const suffix = search.toString() ? `?${search.toString()}` : "";
   return await apiFetch<LandlordAnalyticsSnapshot>(`/landlord/analytics${suffix}`);
+}
+
+export async function fetchLandlordInbox(params?: {
+  period?: AnalyticsPeriod;
+  propertyId?: string | null;
+}): Promise<LandlordInboxResponse> {
+  const search = new URLSearchParams();
+  if (params?.period) search.set("period", params.period);
+  if (params?.propertyId) search.set("propertyId", params.propertyId);
+  const suffix = search.toString() ? `?${search.toString()}` : "";
+  const response = await apiFetch<{ ok: true; data: LandlordInboxResponse }>(`/landlord/analytics/inbox${suffix}`);
+  return response.data;
 }
 
 export async function fetchLandlordApplicationFunnel(params?: {

--- a/rentchain-frontend/src/components/layout/navConfig.ts
+++ b/rentchain-frontend/src/components/layout/navConfig.ts
@@ -1,5 +1,5 @@
 import type { ComponentType } from "react";
-import { LayoutDashboard, Building2, Users, ScrollText, MessagesSquare, User, ReceiptText, BarChart3 } from "lucide-react";
+import { LayoutDashboard, Building2, Users, ScrollText, MessagesSquare, User, ReceiptText, BarChart3, Inbox } from "lucide-react";
 import { SCREENING_ENABLED } from "../../config/screening";
 
 export type NavItem = {
@@ -61,6 +61,14 @@ export const NAV_ITEMS: NavItem[] = [
     icon: ScrollText,
     showInDrawer: true,
     showInTabs: true,
+  },
+  {
+    id: "landlord-inbox",
+    label: "Inbox",
+    to: "/landlord/inbox",
+    icon: Inbox,
+    showInDrawer: true,
+    requiresLandlordOrAdmin: true,
   },
   {
     id: "analytics",

--- a/rentchain-frontend/src/pages/landlord/LandlordInboxPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/LandlordInboxPage.test.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import LandlordInboxPage from "./LandlordInboxPage";
+
+const apiMocks = vi.hoisted(() => ({
+  fetchLandlordInbox: vi.fn(),
+  showToast: vi.fn(),
+}));
+
+vi.mock("../../api/landlordAnalyticsApi", async () => {
+  const actual = await vi.importActual<any>("../../api/landlordAnalyticsApi");
+  return {
+    ...actual,
+    fetchLandlordInbox: apiMocks.fetchLandlordInbox,
+  };
+});
+
+vi.mock("../../components/ui/ToastProvider", () => ({
+  useToast: () => ({
+    showToast: apiMocks.showToast,
+  }),
+}));
+
+vi.mock("../../components/layout/MacShell", () => ({
+  MacShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+describe("LandlordInboxPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders grouped inbox items with safe links", async () => {
+    apiMocks.fetchLandlordInbox.mockResolvedValue({
+      items: [
+        {
+          id: "application:app-1",
+          type: "application",
+          subjectId: "app-1",
+          applicationId: "app-1",
+          leaseId: null,
+          title: "Application ready for review",
+          description: "Current application context is ready for landlord review.",
+          priority: "medium",
+          status: "action_required",
+          nextAction: "review_application",
+          nextActionHref: "/applications/app-1/review-summary",
+          trustSummary: {
+            readiness: "ready",
+            verificationLevel: "partial",
+          },
+          credibilitySummary: {
+            completenessLevel: "medium",
+          },
+          source: "review_summary",
+        },
+      ],
+      summary: {
+        actionRequired: 1,
+        pending: 0,
+        completed: 0,
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <LandlordInboxPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole("heading", { name: "Landlord inbox" })).toBeInTheDocument();
+    expect(screen.getByText("Application ready for review")).toBeInTheDocument();
+    expect(screen.getByText(/Credibility completeness: medium/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Review application" })).toHaveAttribute(
+      "href",
+      "/applications/app-1/review-summary"
+    );
+  });
+
+  it("renders an empty state safely", async () => {
+    apiMocks.fetchLandlordInbox.mockImplementation(async () => ({
+      items: [],
+      summary: {
+        actionRequired: 0,
+        pending: 0,
+        completed: 0,
+      },
+    }));
+
+    render(
+      <MemoryRouter>
+        <LandlordInboxPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Inbox summary/i, {}, { timeout: 3000 })).toBeInTheDocument();
+    expect(screen.getByText(/No action required items are visible right now/i)).toBeInTheDocument();
+    expect(screen.getByText(/No pending items are visible right now/i)).toBeInTheDocument();
+    expect(screen.getByText(/No completed items are visible right now/i)).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/landlord/LandlordInboxPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/LandlordInboxPage.tsx
@@ -1,0 +1,206 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import {
+  fetchLandlordInbox,
+  type LandlordInboxItem,
+  type LandlordInboxResponse,
+} from "../../api/landlordAnalyticsApi";
+import { MacShell } from "../../components/layout/MacShell";
+import { Card, Section } from "../../components/ui/Ui";
+import { useToast } from "../../components/ui/ToastProvider";
+
+function errorMessage(error: unknown) {
+  if (error instanceof Error && error.message) return error.message;
+  return "Failed to load landlord inbox";
+}
+
+function priorityTone(priority: LandlordInboxItem["priority"]) {
+  if (priority === "high") return { color: "#991b1b", background: "rgba(239, 68, 68, 0.12)" };
+  if (priority === "medium") return { color: "#92400e", background: "rgba(245, 158, 11, 0.14)" };
+  return { color: "#075985", background: "rgba(14, 165, 233, 0.12)" };
+}
+
+function readinessTone(readiness: NonNullable<LandlordInboxItem["trustSummary"]>["readiness"]) {
+  if (readiness === "strong") return { color: "#166534", background: "#dcfce7" };
+  if (readiness === "ready") return { color: "#0f766e", background: "#ccfbf1" };
+  if (readiness === "emerging") return { color: "#1d4ed8", background: "#dbeafe" };
+  return { color: "#9a3412", background: "#ffedd5" };
+}
+
+function nextActionLabel(action: LandlordInboxItem["nextAction"]) {
+  switch (action) {
+    case "request_info":
+      return "Request information";
+    case "review_documents":
+      return "Review supporting records";
+    case "review_screening":
+      return "Review screening";
+    case "prepare_lease":
+      return "Open lease workflow";
+    case "no_action":
+      return "No action needed";
+    case "review_application":
+    default:
+      return "Review application";
+  }
+}
+
+function sectionLabel(status: LandlordInboxItem["status"]) {
+  if (status === "action_required") return "Action required";
+  if (status === "pending") return "Pending";
+  return "Completed";
+}
+
+function groupItems(items: LandlordInboxResponse["items"]) {
+  return items.reduce<Record<LandlordInboxItem["status"], LandlordInboxItem[]>>((acc, item) => {
+    acc[item.status].push(item);
+    return acc;
+  }, {
+    action_required: [],
+    pending: [],
+    completed: [],
+  });
+}
+
+function InboxItemCard({ item }: { item: LandlordInboxItem }) {
+  const priority = priorityTone(item.priority);
+  const trustTone = item.trustSummary ? readinessTone(item.trustSummary.readiness) : null;
+
+  return (
+    <Card style={{ display: "grid", gap: 12 }}>
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+        <span
+          style={{
+            borderRadius: 999,
+            padding: "4px 10px",
+            fontSize: "0.78rem",
+            fontWeight: 700,
+            color: priority.color,
+            background: priority.background,
+            textTransform: "uppercase",
+            letterSpacing: "0.04em",
+          }}
+        >
+          {item.priority}
+        </span>
+        <span style={{ color: "#64748b", fontSize: "0.82rem", textTransform: "capitalize" }}>{item.type.replace(/_/g, " ")}</span>
+      </div>
+      <div style={{ display: "grid", gap: 6 }}>
+        <div style={{ fontWeight: 800, color: "#0f172a" }}>{item.title}</div>
+        <div style={{ color: "#475569", lineHeight: 1.6 }}>{item.description}</div>
+      </div>
+      <div style={{ display: "grid", gap: 8 }}>
+        {item.trustSummary ? (
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+            <span
+              style={{
+                borderRadius: 999,
+                padding: "4px 10px",
+                fontSize: "0.78rem",
+                fontWeight: 700,
+                color: trustTone?.color,
+                background: trustTone?.background,
+              }}
+            >
+              {item.trustSummary.readiness.replace(/_/g, " ")}
+            </span>
+            <span style={{ color: "#64748b", fontSize: "0.82rem" }}>
+              Verification: {item.trustSummary.verificationLevel.replace(/_/g, " ")}
+            </span>
+          </div>
+        ) : null}
+        {item.credibilitySummary ? (
+          <div style={{ color: "#64748b", fontSize: "0.82rem" }}>
+            Credibility completeness: {item.credibilitySummary.completenessLevel}
+          </div>
+        ) : null}
+      </div>
+      <div>
+        {item.nextActionHref && item.nextAction !== "no_action" ? (
+          <Link to={item.nextActionHref}>{nextActionLabel(item.nextAction)}</Link>
+        ) : (
+          <span style={{ color: "#64748b", fontSize: "0.9rem" }}>{nextActionLabel(item.nextAction)}</span>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+export default function LandlordInboxPage() {
+  const { showToast } = useToast();
+  const [data, setData] = React.useState<LandlordInboxResponse | null>(null);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const response = await fetchLandlordInbox();
+        if (!mounted) return;
+        setData(response);
+      } catch (err: unknown) {
+        if (!mounted) return;
+        const message = errorMessage(err);
+        setError(message);
+        showToast({
+          message: "Failed to load landlord inbox",
+          description: message,
+          variant: "error",
+        });
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+
+    return () => {
+      mounted = false;
+    };
+  }, [showToast]);
+
+  const groups = groupItems(data?.items || []);
+
+  return (
+    <MacShell title="Landlord inbox">
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "grid", gap: 6 }}>
+            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Landlord inbox</h1>
+            <div style={{ color: "#475569", maxWidth: 860 }}>
+              A consolidated view of current landlord-safe application and lease follow-through, derived from existing review and workflow signals.
+            </div>
+          </div>
+        </Section>
+
+        {loading ? <Card>Loading landlord inbox…</Card> : null}
+        {!loading && error ? <Card style={{ color: "#b91c1c" }}>Failed to load landlord inbox: {error}</Card> : null}
+
+        {!loading && !error && data ? (
+          <>
+            <Section style={{ display: "grid", gap: 8 }}>
+              <div style={{ fontWeight: 700 }}>Inbox summary</div>
+              <div style={{ display: "flex", gap: 12, flexWrap: "wrap", color: "#475569" }}>
+                <span>Action required: {data.summary.actionRequired}</span>
+                <span>Pending: {data.summary.pending}</span>
+                <span>Completed: {data.summary.completed}</span>
+              </div>
+            </Section>
+
+            {(["action_required", "pending", "completed"] as const).map((status) => (
+              <div key={status} style={{ display: "grid", gap: 12 }}>
+                <div style={{ fontWeight: 800, color: "#0f172a" }}>{sectionLabel(status)}</div>
+                {groups[status].length ? (
+                  groups[status].map((item) => <InboxItemCard key={item.id} item={item} />)
+                ) : (
+                  <Card style={{ color: "#64748b" }}>No {sectionLabel(status).toLowerCase()} items are visible right now.</Card>
+                )}
+              </div>
+            ))}
+          </>
+        ) : null}
+      </div>
+    </MacShell>
+  );
+}


### PR DESCRIPTION
This PR introduces Landlord Inbox Workflow v2.

Includes:
- read-derived landlord inbox aggregation
- GET /landlord/analytics/inbox
- application, lease, and screening inbox items
- deterministic dedupe and priority behavior
- trust and credibility summaries on inbox items
- new /landlord/inbox page
- landlord nav entry
- focused backend/frontend test coverage

Guardrails preserved:
- no new inbox storage
- no new workflow state
- no scoring or ranking
- no automation/execution changes
- no decision ID or overlay changes
- no share-package behavior changes
- no raw document/screening/signature/share-token exposure
- no permission expansion