### PR TITLE
feat: add identity portability

### DIFF
--- a/rentchain-api/src/routes/__tests__/rentalApplicationsReviewSummaryRisk.test.ts
+++ b/rentchain-api/src/routes/__tests__/rentalApplicationsReviewSummaryRisk.test.ts
@@ -322,13 +322,25 @@ describe("rentalApplications review summary risk surface", () => {
         summaryDescription: expect.any(String),
       })
     );
+    expect(res.body?.portableIdentitySummary).toEqual(
+      expect.objectContaining({
+        portabilityStatus: expect.stringMatching(/not_ready|ready|limited/),
+        portabilityLabel: expect.any(String),
+        portabilityDescription: expect.any(String),
+        reusableAcrossApplications: expect.any(Boolean),
+      })
+    );
     expect(res.body?.tenantIdentitySummary?.documents).toBeUndefined();
     expect(res.body?.tenantIdentitySummary?.screening).toBeUndefined();
     expect(res.body?.tenantCredibilitySummary?.signals).toBeUndefined();
+    expect(res.body?.portableIdentitySummary?.readiness).toBeUndefined();
+    expect(res.body?.portableIdentitySummary?.identityReference).toBeUndefined();
     expect(JSON.stringify(res.body?.tenantCredibilitySummary || {})).not.toContain("transunion");
     expect(JSON.stringify(res.body?.tenantCredibilitySummary || {})).not.toContain("ref-1");
     expect(JSON.stringify(res.body?.trustContext || {})).not.toContain("transunion");
     expect(JSON.stringify(res.body?.trustContext || {})).not.toContain("ref-1");
+    expect(JSON.stringify(res.body?.portableIdentitySummary || {})).not.toContain("token");
+    expect(JSON.stringify(res.body?.portableIdentitySummary || {})).not.toContain("approval");
   });
 
   it("returns a safe null risk state when no snapshot exists", async () => {

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -535,6 +535,24 @@ describe("tenantPortalRoutes foundation", () => {
         }),
       })
     );
+    expect(res.body?.data?.portableIdentity).toEqual(
+      expect.objectContaining({
+        portabilityStatus: expect.stringMatching(/not_ready|ready|limited/),
+        portabilityLabel: expect.any(String),
+        portabilityDescription: expect.any(String),
+        reusableAcrossApplications: expect.any(Boolean),
+        identityReference: {
+          referenceType: "tenant_identity",
+          referenceStatus: expect.stringMatching(/active|limited/),
+        },
+        readiness: expect.objectContaining({
+          identityReady: expect.any(Boolean),
+          applicationReusable: expect.any(Boolean),
+          credibilityReady: expect.any(Boolean),
+          sharingEnabled: expect.any(Boolean),
+        }),
+      })
+    );
     expect(res.body?.data?.identityTimeline).toEqual({
       events: [
         {
@@ -547,6 +565,8 @@ describe("tenantPortalRoutes foundation", () => {
     });
     expect(res.body?.data?.identityTimeline?.events?.[0]?.id).toBeUndefined();
     expect(res.body?.data?.identityTimeline?.events?.[0]?.metadata).toBeUndefined();
+    expect(JSON.stringify(res.body?.data?.portableIdentity || {})).not.toContain("token");
+    expect(JSON.stringify(res.body?.data?.portableIdentity || {})).not.toContain("drawnDataUrl");
 
     const eventDocs = Array.from(ensureCollection("event_log").values());
     expect(eventDocs.some((event) => event.event_type === "tenant_workspace_viewed")).toBe(true);

--- a/rentchain-api/src/routes/rentalApplicationsRoutes.ts
+++ b/rentchain-api/src/routes/rentalApplicationsRoutes.ts
@@ -68,6 +68,7 @@ import {
 } from "../services/tenantPortal/tenantProfileService";
 import { deriveLandlordTrustContext } from "../lib/trust/deriveLandlordTrustContext";
 import { deriveTenantCredibilitySignals } from "../services/tenantCredibility/deriveTenantCredibilitySignals";
+import { deriveIdentityPortability } from "../services/identityPortability/deriveIdentityPortability";
 import {
   buildQuoteId,
   buildScreeningMonetizationPatch,
@@ -4156,6 +4157,51 @@ router.get("/rental-applications/:id/review-summary", async (req: any, res) => {
       screeningStatus: summary?.screening?.status,
       applicationReusable: landlordSafeReusableApplication,
     });
+    const { portableIdentitySummary } = deriveIdentityPortability({
+      tenantIdentityRecord: tenantIdentitySummary
+        ? {
+            identityStatus: tenantIdentitySummary.identityStatus,
+            verification: tenantIdentitySummary.verification,
+            readinessLabel: tenantIdentitySummary.readinessLabel,
+            readinessDescription: tenantIdentitySummary.readinessDescription,
+            profile: {
+              completionStatus:
+                tenantIdentitySummary.identityStatus === "ready" ||
+                tenantIdentitySummary.identityStatus === "verified"
+                  ? "complete"
+                  : tenantIdentitySummary.identityStatus === "incomplete"
+                  ? "in_progress"
+                  : "missing",
+            },
+            application: {
+              reusable: landlordSafeReusableApplication,
+              lastSubmittedAt: null,
+            },
+            documents: {
+              completionStatus:
+                tenantIdentitySummary.verification.level === "strong"
+                  ? "complete"
+                  : tenantIdentitySummary.verification.level === "partial"
+                  ? "in_progress"
+                  : "missing",
+              missingCategories: [],
+            },
+            screening: {
+              status:
+                tenantIdentitySummary.verification.level === "strong"
+                  ? "completed"
+                  : tenantIdentitySummary.verification.level === "partial"
+                  ? "in_progress"
+                  : "not_started",
+              lastCompletedAt: null,
+            },
+            leases: { activeCount: 0, historicalCount: 0, lastSignedAt: null },
+          }
+        : null,
+      credibilitySummary: tenantCredibilitySummary,
+      shareAvailability: { sharingEnabled: false },
+      timelineAvailability: null,
+    });
     const decisionSummary = buildApplicationDecisionSummary({
       applicationId: id,
       application: access.data,
@@ -4169,6 +4215,7 @@ router.get("/rental-applications/:id/review-summary", async (req: any, res) => {
       tenantIdentitySummary,
       trustContext,
       tenantCredibilitySummary,
+      portableIdentitySummary,
     });
   } catch (err: any) {
     console.error("[review_summary] failed", err?.message || err);

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -19,6 +19,7 @@ import { redeemTenancyInvite } from "../services/tenantPortal/tenantInviteServic
 import { loadTenantIdentityRecord, loadTenantProfileProjection } from "../services/tenantPortal/tenantProfileService";
 import { deriveTenantCredibilitySignals } from "../services/tenantCredibility/deriveTenantCredibilitySignals";
 import { deriveIdentityTimeline } from "../services/identityTimeline/deriveIdentityTimeline";
+import { deriveIdentityPortability } from "../services/identityPortability/deriveIdentityPortability";
 import {
   loadTenantCommunicationsWorkspace,
   markTenantCommunicationsRead,
@@ -2922,6 +2923,17 @@ async function handleTenantWorkspaceSummary(req: any, res: any) {
     tenantIdentityRecord,
     leaseExecution: workspace.lease?.leaseExecution || null,
   });
+  const { portableIdentity } = deriveIdentityPortability({
+    tenantIdentityRecord,
+    credibilitySummary: tenantCredibilitySignals.summary,
+    shareAvailability: {
+      // Tenant-side capability signal only. This does not imply any active share link exists.
+      sharingEnabled: Boolean(context.tenantId || req.user?.tenantId || req.user?.id),
+    },
+    timelineAvailability: {
+      hasIdentityTimeline: Array.isArray(identityTimeline?.events) && identityTimeline.events.length > 0,
+    },
+  });
   await recordTenantEvent({
     eventType: "tenant_workspace_viewed",
     entityType: "tenant_workspace",
@@ -2949,6 +2961,7 @@ async function handleTenantWorkspaceSummary(req: any, res: any) {
       maintenance: workspace.maintenance,
       tenantIdentityRecord,
       tenantCredibilitySignals,
+      portableIdentity,
       identityTimeline,
     },
   });

--- a/rentchain-api/src/services/identityPortability/__tests__/deriveIdentityPortability.test.ts
+++ b/rentchain-api/src/services/identityPortability/__tests__/deriveIdentityPortability.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { deriveIdentityPortability } from "../deriveIdentityPortability";
+import type { TenantIdentityRecord } from "../../tenantPortal/tenantProfileService";
+
+function buildRecord(overrides?: Partial<TenantIdentityRecord>): TenantIdentityRecord {
+  return {
+    identityStatus: "ready",
+    profile: { completionStatus: "complete" },
+    application: { reusable: true, lastSubmittedAt: "2026-01-01T00:00:00.000Z" },
+    documents: { completionStatus: "complete", missingCategories: [] },
+    screening: { status: "completed", lastCompletedAt: "2026-01-02T00:00:00.000Z" },
+    leases: { activeCount: 1, historicalCount: 0, lastSignedAt: "2026-02-01T00:00:00.000Z" },
+    verification: { level: "strong" },
+    readinessLabel: "Ready to apply",
+    readinessDescription: "Ready",
+    ...overrides,
+  };
+}
+
+describe("deriveIdentityPortability", () => {
+  it("fails closed to not_ready when data is missing", () => {
+    const result = deriveIdentityPortability({
+      tenantIdentityRecord: null,
+      credibilitySummary: null,
+      shareAvailability: { sharingEnabled: false },
+      timelineAvailability: null,
+    });
+
+    expect(result.portableIdentity.portabilityStatus).toBe("not_ready");
+    expect(result.portableIdentity.reusableAcrossApplications).toBe(false);
+    expect(result.portableIdentity.readiness).toEqual({
+      identityReady: false,
+      applicationReusable: false,
+      credibilityReady: false,
+      sharingEnabled: false,
+    });
+  });
+
+  it("derives ready when identity, reuse, and credibility are organized", () => {
+    const result = deriveIdentityPortability({
+      tenantIdentityRecord: buildRecord(),
+      credibilitySummary: {
+        completenessLevel: "high",
+        verificationLevel: "strong",
+        summaryLabel: "Credibility established",
+        summaryDescription: "Most signals are available.",
+      },
+      shareAvailability: { sharingEnabled: true },
+      timelineAvailability: { hasIdentityTimeline: true },
+    });
+
+    expect(result.portableIdentity.portabilityStatus).toBe("ready");
+    expect(result.portableIdentity.portabilityLabel).toBe("Ready to reuse");
+    expect(result.portableIdentity.reusableAcrossApplications).toBe(true);
+    expect(result.portableIdentitySummary.reusableAcrossApplications).toBe(true);
+  });
+
+  it("derives limited for partial readiness without exposing extra internals", () => {
+    const result = deriveIdentityPortability({
+      tenantIdentityRecord: buildRecord({
+        profile: { completionStatus: "in_progress" },
+        application: { reusable: false, lastSubmittedAt: null },
+      }),
+      credibilitySummary: {
+        completenessLevel: "medium",
+        verificationLevel: "partial",
+        summaryLabel: "Building credibility",
+        summaryDescription: "Some signals are available.",
+      },
+      shareAvailability: { sharingEnabled: true },
+      timelineAvailability: null,
+    });
+
+    expect(result.portableIdentity.portabilityStatus).toBe("limited");
+    expect(result.portableIdentity.nextAction).toBe("review_reusability");
+    expect(result.portableIdentitySummary).toEqual({
+      portabilityStatus: "limited",
+      portabilityLabel: "Almost portable",
+      portabilityDescription:
+        "Some portability foundations are in place, but a few identity or application details still need attention.",
+      reusableAcrossApplications: false,
+    });
+  });
+});

--- a/rentchain-api/src/services/identityPortability/deriveIdentityPortability.ts
+++ b/rentchain-api/src/services/identityPortability/deriveIdentityPortability.ts
@@ -1,0 +1,134 @@
+import type { LandlordSafeTenantCredibilitySummary } from "../tenantCredibility/deriveTenantCredibilitySignals";
+import type { TenantIdentityRecord } from "../tenantPortal/tenantProfileService";
+
+export type PortableIdentityStatus = "not_ready" | "ready" | "limited";
+
+export type PortableIdentity = {
+  portabilityStatus: PortableIdentityStatus;
+  portabilityLabel: string;
+  portabilityDescription: string;
+  reusableAcrossApplications: boolean;
+  identityReference: {
+    referenceType: "tenant_identity";
+    referenceStatus: "active" | "limited";
+  };
+  readiness: {
+    identityReady: boolean;
+    applicationReusable: boolean;
+    credibilityReady: boolean;
+    sharingEnabled: boolean;
+  };
+  nextAction: "complete_identity" | "enable_sharing" | "review_reusability" | "none";
+};
+
+export type PortableIdentitySummary = {
+  portabilityStatus: PortableIdentityStatus;
+  portabilityLabel: string;
+  portabilityDescription: string;
+  reusableAcrossApplications: boolean;
+};
+
+type DeriveIdentityPortabilityInput = {
+  tenantIdentityRecord: TenantIdentityRecord | null;
+  credibilitySummary: LandlordSafeTenantCredibilitySummary | null;
+  shareAvailability: {
+    sharingEnabled: boolean;
+  };
+  timelineAvailability?: {
+    hasIdentityTimeline: boolean;
+  } | null;
+};
+
+function buildStatusCopy(
+  portabilityStatus: PortableIdentityStatus,
+  sharingEnabled: boolean
+): Pick<PortableIdentity, "portabilityLabel" | "portabilityDescription" | "nextAction"> {
+  if (portabilityStatus === "ready") {
+    return {
+      portabilityLabel: "Ready to reuse",
+      portabilityDescription: sharingEnabled
+        ? "Your rental identity is organized for reuse across application contexts, and sharing controls are available when you need them."
+        : "Your rental identity is organized for reuse across application contexts.",
+      nextAction: sharingEnabled ? "none" : "enable_sharing",
+    };
+  }
+
+  if (portabilityStatus === "limited") {
+    return {
+      portabilityLabel: "Almost portable",
+      portabilityDescription:
+        "Some portability foundations are in place, but a few identity or application details still need attention.",
+      nextAction: sharingEnabled ? "review_reusability" : "enable_sharing",
+    };
+  }
+
+  return {
+    portabilityLabel: "More details needed",
+    portabilityDescription:
+      "Your rental identity needs more complete profile, application, or credibility details before it is ready for broader reuse.",
+    nextAction: "complete_identity",
+  };
+}
+
+export function deriveIdentityPortability(
+  input: DeriveIdentityPortabilityInput
+): {
+  portableIdentity: PortableIdentity;
+  portableIdentitySummary: PortableIdentitySummary;
+} {
+  const record = input.tenantIdentityRecord || null;
+  const credibilitySummary = input.credibilitySummary || null;
+  const sharingEnabled = Boolean(input.shareAvailability?.sharingEnabled);
+  const hasIdentityTimeline = Boolean(input.timelineAvailability?.hasIdentityTimeline);
+
+  const identityReady = Boolean(
+    record &&
+      (record.identityStatus === "ready" || record.identityStatus === "verified") &&
+      record.profile.completionStatus === "complete"
+  );
+  const applicationReusable = Boolean(record?.application.reusable);
+  const credibilityReady = Boolean(
+    credibilitySummary &&
+      (credibilitySummary.completenessLevel === "high" ||
+        (credibilitySummary.completenessLevel === "medium" &&
+          credibilitySummary.verificationLevel !== "none"))
+  );
+
+  let portabilityStatus: PortableIdentityStatus = "not_ready";
+  if (identityReady && applicationReusable && credibilityReady) {
+    portabilityStatus = "ready";
+  } else if (identityReady || applicationReusable || credibilityReady || sharingEnabled || hasIdentityTimeline) {
+    portabilityStatus = "limited";
+  }
+
+  const copy = buildStatusCopy(portabilityStatus, sharingEnabled);
+  const reusableAcrossApplications = portabilityStatus === "ready" && applicationReusable;
+
+  const portableIdentity: PortableIdentity = {
+    portabilityStatus,
+    portabilityLabel: copy.portabilityLabel,
+    portabilityDescription: copy.portabilityDescription,
+    reusableAcrossApplications,
+    identityReference: {
+      referenceType: "tenant_identity",
+      referenceStatus: portabilityStatus === "ready" ? "active" : "limited",
+    },
+    readiness: {
+      identityReady,
+      applicationReusable,
+      credibilityReady,
+      sharingEnabled,
+    },
+    nextAction: copy.nextAction,
+  };
+
+  return {
+    portableIdentity,
+    portableIdentitySummary: {
+      portabilityStatus,
+      portabilityLabel: copy.portabilityLabel,
+      portabilityDescription: copy.portabilityDescription,
+      reusableAcrossApplications,
+    },
+  };
+}

--- a/rentchain-frontend/src/api/reviewSummaryApi.ts
+++ b/rentchain-frontend/src/api/reviewSummaryApi.ts
@@ -84,6 +84,12 @@ export type ApplicationReviewSummary = ReviewSummaryCore & {
     summaryLabel: string;
     summaryDescription: string;
   } | null;
+  portableIdentitySummary?: {
+    portabilityStatus: "not_ready" | "ready" | "limited";
+    portabilityLabel: string;
+    portabilityDescription: string;
+    reusableAcrossApplications: boolean;
+  } | null;
 };
 
 export class ReviewSummaryApiError extends Error {
@@ -132,6 +138,8 @@ export async function fetchReviewSummary(applicationId: string): Promise<Applica
     trustContext: (res?.trustContext || null) as ApplicationReviewSummary["trustContext"],
     tenantCredibilitySummary:
       (res?.tenantCredibilitySummary || null) as ApplicationReviewSummary["tenantCredibilitySummary"],
+    portableIdentitySummary:
+      (res?.portableIdentitySummary || null) as ApplicationReviewSummary["portableIdentitySummary"],
   };
 }
 

--- a/rentchain-frontend/src/api/tenantPortal.ts
+++ b/rentchain-frontend/src/api/tenantPortal.ts
@@ -246,6 +246,24 @@ export type IdentityTimeline = {
   }>;
 };
 
+export type PortableIdentity = {
+  portabilityStatus: "not_ready" | "ready" | "limited";
+  portabilityLabel: string;
+  portabilityDescription: string;
+  reusableAcrossApplications: boolean;
+  identityReference: {
+    referenceType: "tenant_identity";
+    referenceStatus: "active" | "limited";
+  };
+  readiness: {
+    identityReady: boolean;
+    applicationReusable: boolean;
+    credibilityReady: boolean;
+    sharingEnabled: boolean;
+  };
+  nextAction: "complete_identity" | "enable_sharing" | "review_reusability" | "none";
+};
+
 export type TenantWorkspaceSummary = {
   context: TenantWorkspaceContext;
   property: TenantWorkspaceProperty | null;
@@ -254,6 +272,7 @@ export type TenantWorkspaceSummary = {
   maintenance: TenantWorkspaceMaintenance[];
   tenantIdentityRecord?: TenantIdentityRecord | null;
   tenantCredibilitySignals?: TenantCredibilitySignals | null;
+  portableIdentity?: PortableIdentity | null;
   identityTimeline?: IdentityTimeline | null;
 };
 

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
@@ -131,6 +131,12 @@ describe("ApplicationReviewSummaryPage", () => {
         summaryLabel: "Credibility established",
         summaryDescription: "Most credibility signals are available in the current record.",
       },
+      portableIdentitySummary: {
+        portabilityStatus: "ready",
+        portabilityLabel: "Ready to reuse",
+        portabilityDescription: "Your rental identity is organized for reuse across application contexts.",
+        reusableAcrossApplications: true,
+      },
     } as any);
 
     renderPage();
@@ -189,8 +195,11 @@ describe("ApplicationReviewSummaryPage", () => {
     expect(await screen.findByText("Identity verification completed")).toBeInTheDocument();
     expect(await screen.findByText("Trust guidance")).toBeInTheDocument();
     expect(await screen.findByText("Credibility summary")).toBeInTheDocument();
+    expect(await screen.findByText("Portability summary")).toBeInTheDocument();
     expect(await screen.findByText("Credibility established")).toBeInTheDocument();
     expect(await screen.findByText("Most credibility signals are available in the current record.")).toBeInTheDocument();
+    expect(await screen.findByText("Ready to reuse")).toBeInTheDocument();
+    expect(await screen.findByText("Reusable across applications")).toBeInTheDocument();
     expect((await screen.findAllByText("Ready for review")).length).toBeGreaterThan(0);
     expect(await screen.findByText("Application information is mostly complete.")).toBeInTheDocument();
     expect(await screen.findByText("Employment or income details are still incomplete.")).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
@@ -1722,6 +1722,22 @@ function ApplicationReviewSummaryPageBody() {
             </Card>
           ) : null}
 
+          {summary.portableIdentitySummary ? (
+            <Card style={{ display: "grid", gap: 8 }}>
+              <div style={{ fontWeight: 700 }}>Portability summary</div>
+              <div style={{ fontSize: 13, color: text.subtle }}>
+                {summary.portableIdentitySummary.portabilityDescription}
+              </div>
+              <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 8 }}>
+                {kv("Status", summary.portableIdentitySummary.portabilityLabel)}
+                {kv(
+                  "Reusable across applications",
+                  summary.portableIdentitySummary.reusableAcrossApplications ? "Yes" : "Not yet"
+                )}
+              </div>
+            </Card>
+          ) : null}
+
           <Card style={{ display: "grid", gap: 8 }}>
             <div style={{ fontWeight: 700 }}>Applicant Overview</div>
             <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 8 }}>

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -211,6 +211,24 @@ describe("tenant workspace frontend shell", () => {
           summaryDescription: "Most credibility signals are available in your current record.",
         },
       },
+      portableIdentity: {
+        portabilityStatus: "ready",
+        portabilityLabel: "Ready to reuse",
+        portabilityDescription:
+          "Your rental identity is organized for reuse across application contexts, and sharing controls are available when you need them.",
+        reusableAcrossApplications: true,
+        identityReference: {
+          referenceType: "tenant_identity",
+          referenceStatus: "active",
+        },
+        readiness: {
+          identityReady: true,
+          applicationReusable: true,
+          credibilityReady: true,
+          sharingEnabled: true,
+        },
+        nextAction: "none",
+      },
       identityTimeline: {
         events: [
           {
@@ -479,6 +497,24 @@ describe("tenant workspace frontend shell", () => {
           summaryDescription: "Most credibility signals are available in your current record.",
         },
       },
+      portableIdentity: {
+        portabilityStatus: "ready",
+        portabilityLabel: "Ready to reuse",
+        portabilityDescription:
+          "Your rental identity is organized for reuse across application contexts, and sharing controls are available when you need them.",
+        reusableAcrossApplications: true,
+        identityReference: {
+          referenceType: "tenant_identity",
+          referenceStatus: "active",
+        },
+        readiness: {
+          identityReady: true,
+          applicationReusable: true,
+          credibilityReady: true,
+          sharingEnabled: true,
+        },
+        nextAction: "none",
+      },
       identityTimeline: {
         events: [
           {
@@ -506,10 +542,14 @@ describe("tenant workspace frontend shell", () => {
     expect(await screen.findByText(/Profile completion/i)).toBeInTheDocument();
     expect(screen.getByText(/^Your Rental Identity$/i)).toBeInTheDocument();
     expect(screen.getByText(/^Credibility signals$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^Portable Rental Identity$/i)).toBeInTheDocument();
     expect(screen.getByText(/^Activity timeline$/i)).toBeInTheDocument();
+    expect(screen.getByText("Identity ready")).toBeInTheDocument();
+    expect(screen.getByText("Sharing controls available")).toBeInTheDocument();
+    expect(screen.getByText("Reusable across applications")).toBeInTheDocument();
     expect(screen.getByText(/Credibility established/i)).toBeInTheDocument();
     expect(screen.getByText(/Profile complete/i)).toBeInTheDocument();
-    expect(screen.getByText(/Application reusable/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Application reusable/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Documents available/i)).toBeInTheDocument();
     expect(screen.getByText(/Screening completed/i)).toBeInTheDocument();
     expect(screen.getByText(/Lease history present/i)).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
@@ -298,6 +298,7 @@ export default function TenantWorkspacePage() {
   });
   const tenantIdentityRecord = data?.tenantIdentityRecord || null;
   const tenantCredibilitySignals = data?.tenantCredibilitySignals || null;
+  const portableIdentity = data?.portableIdentity || null;
   const identityTimeline = data?.identityTimeline?.events || [];
   const communicationsView = buildTenantCommunicationsWorkspaceState(communications);
   const screeningSummary = buildTenantScreeningDashboardSummary(screenings);
@@ -540,6 +541,63 @@ export default function TenantWorkspacePage() {
         ) : (
           <div style={{ color: textTokens.secondary }}>
             Credibility signals will appear here once enough tenant-safe identity signals are available.
+          </div>
+        )}
+      </TenantInfoCard>
+
+      <TenantInfoCard heading="Portable Rental Identity" accent="#1d4ed8">
+        {portableIdentity ? (
+          <div style={{ display: "grid", gap: spacing.sm }}>
+            <div style={{ display: "grid", gap: 4 }}>
+              <div style={{ fontSize: "1.02rem", fontWeight: 800, color: textTokens.primary }}>
+                {portableIdentity.portabilityLabel}
+              </div>
+              <div style={{ color: textTokens.secondary, lineHeight: 1.6 }}>
+                {portableIdentity.portabilityDescription}
+              </div>
+            </div>
+
+            <TenantKeyValueGrid
+              rows={[
+                {
+                  label: "Identity ready",
+                  value: portableIdentity.readiness.identityReady ? "Ready" : "Needs attention",
+                },
+                {
+                  label: "Application reusable",
+                  value: portableIdentity.readiness.applicationReusable ? "Ready" : "Still building",
+                },
+                {
+                  label: "Credibility ready",
+                  value: portableIdentity.readiness.credibilityReady ? "Ready" : "Still building",
+                },
+                {
+                  label: "Sharing controls available",
+                  value: portableIdentity.readiness.sharingEnabled ? "Available" : "Not available",
+                },
+                {
+                  label: "Reusable across applications",
+                  value: portableIdentity.reusableAcrossApplications ? "Yes" : "Not yet",
+                },
+              ]}
+            />
+
+            <div style={{ color: textTokens.secondary }}>
+              Next step:{" "}
+              <strong>
+                {portableIdentity.nextAction === "complete_identity"
+                  ? "Complete identity details"
+                  : portableIdentity.nextAction === "enable_sharing"
+                  ? "Review sharing controls"
+                  : portableIdentity.nextAction === "review_reusability"
+                  ? "Review reusability details"
+                  : "No immediate follow-up"}
+              </strong>
+            </div>
+          </div>
+        ) : (
+          <div style={{ color: textTokens.secondary }}>
+            Portable identity status will appear here once enough tenant-safe identity signals are available.
           </div>
         )}
       </TenantInfoCard>


### PR DESCRIPTION
This PR introduces Identity Portability v1.

Includes:
- read-derived portableIdentity on /tenant/workspace
- restricted portableIdentitySummary on review-summary
- tenant workspace Portable Rental Identity card
- landlord Portability summary section
- alignment with TIR, credibility, application reuse, and safe share capability
- focused backend/frontend test coverage

Guardrails preserved:
- no new collections or writes
- no public directory or global lookup
- no share token, URL, ID, request, or approval exposure
- no raw document/screening/signature/audit event exposure
- no permission expansion
- no landlord inbox changes
- no scoring or ranking

PR note:
- rentalApplicationsReviewSummaryRisk.test.ts required an outside-sandbox rerun because it binds a local port.
- Frontend build passed with the existing unchanged chunk-size warning.