### PR TITLE
feat: fix mobile dashboard reporting issues

### DIFF
--- a/rentchain-api/src/routes/__tests__/dashboardRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/dashboardRoutes.test.ts
@@ -1,0 +1,195 @@
+import express from "express";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const computePortfolioCredibilitySummaryMock = vi.fn();
+const resolveLandlordAndTierMock = vi.fn();
+
+const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+
+  function makeDocs(name: string, filters: Array<{ field: string; value: any }>) {
+    return Array.from(ensureCollection(name).entries())
+      .filter(([, data]) => filters.every((filter) => data?.[filter.field] === filter.value))
+      .map(([id, data]) => ({ id, data: () => data }));
+  }
+
+  function makeQuery(name: string, filters: Array<{ field: string; value: any }> = []) {
+    return {
+      where: (field: string, _op: string, value: any) => makeQuery(name, [...filters, { field, value }]),
+      limit: () => makeQuery(name, filters),
+      get: async () => {
+        const docs = makeDocs(name, filters);
+        return {
+          docs,
+          empty: docs.length === 0,
+          size: docs.length,
+          forEach: (fn: any) => docs.forEach(fn),
+        };
+      },
+    };
+  }
+
+  return {
+    resetFakeDb: () => store.clear(),
+    seedDoc: (name: string, id: string, data: any) => ensureCollection(name).set(id, data),
+    fakeDb: {
+      collection: (name: string) => ({
+        where: (field: string, op: string, value: any) => makeQuery(name, [{ field, value }]),
+        limit: () => makeQuery(name),
+        get: async () => makeQuery(name).get(),
+      }),
+    },
+  };
+});
+
+vi.mock("../../config/firebase", () => ({
+  db: fakeDb,
+}));
+
+vi.mock("../../middleware/authMiddleware", () => ({
+  authenticateJwt: (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, _res: any, next: any) => {
+    req.user = { id: "landlord-1", landlordId: "landlord-1", role: "landlord" };
+    next();
+  },
+}));
+
+vi.mock("../../lib/landlordResolver", () => ({
+  resolveLandlordAndTier: resolveLandlordAndTierMock,
+}));
+
+vi.mock("../../services/leaseNoticeWorkflowService", () => ({
+  computeNoResponseState: vi.fn(() => false),
+  normalizeLeaseRecord: vi.fn((id: string, raw: any) => ({ id, ...raw })),
+}));
+
+vi.mock("../../services/risk/portfolioCredibilitySummary", () => ({
+  computePortfolioCredibilitySummary: computePortfolioCredibilitySummaryMock,
+}));
+
+describe("dashboardRoutes GET /summary", () => {
+  beforeEach(() => {
+    resetFakeDb();
+    computePortfolioCredibilitySummaryMock.mockReset();
+    resolveLandlordAndTierMock.mockReset();
+    resolveLandlordAndTierMock.mockResolvedValue({ tier: "pro" });
+    computePortfolioCredibilitySummaryMock.mockImplementation(({ leases }: any) => ({
+      propertyCount: 1,
+      activeLeaseCount: Array.isArray(leases) ? leases.length : 0,
+      tenantScoreAverage: null,
+      tenantScoreGradeAverage: null,
+      leaseRiskAverage: null,
+      leaseRiskGradeAverage: null,
+      tenantsWithScoreCount: 0,
+      leasesWithRiskCount: 0,
+      lowConfidenceCount: 0,
+      missingCredibilityCount: 0,
+      healthStatus: "unknown",
+    }));
+  });
+
+  async function makeApp() {
+    const router = (await import("../dashboardRoutes")).default;
+    const app = express();
+    app.use(express.json());
+    app.use("/api/dashboard", router);
+    return app;
+  }
+
+  async function invokeSummary(app: express.Express) {
+    return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+      const req: any = {
+        method: "GET",
+        url: "/api/dashboard/summary",
+        originalUrl: "/api/dashboard/summary",
+        path: "/api/dashboard/summary",
+        headers: {},
+        body: {},
+        query: {},
+        params: {},
+      };
+      const res: any = {
+        statusCode: 200,
+        setHeader: vi.fn(),
+        status(code: number) {
+          this.statusCode = code;
+          return this;
+        },
+        json(payload: any) {
+          resolve({ status: this.statusCode, body: payload });
+          return this;
+        },
+      };
+      app.handle(req, res, (error: any) => {
+        if (error) reject(error);
+      });
+    });
+  }
+
+  it("counts only active-property tenants and visible live leases", async () => {
+    seedDoc("properties", "prop-active", {
+      landlordId: "landlord-1",
+      portfolioStatus: "active",
+      units: [{ id: "unit-1" }],
+    });
+    seedDoc("properties", "prop-archived", {
+      landlordId: "landlord-1",
+      portfolioStatus: "archived",
+      units: [{ id: "unit-2" }],
+    });
+    seedDoc("tenants", "tenant-active", {
+      landlordId: "landlord-1",
+      propertyId: "prop-active",
+      hiddenFromActiveLists: false,
+    });
+    seedDoc("tenants", "tenant-archived", {
+      landlordId: "landlord-1",
+      propertyId: "prop-archived",
+      hiddenFromActiveLists: false,
+    });
+    seedDoc("tenants", "tenant-hidden", {
+      landlordId: "landlord-1",
+      propertyId: "prop-active",
+      hiddenFromActiveLists: true,
+    });
+    seedDoc("leases", "lease-visible", {
+      landlordId: "landlord-1",
+      propertyId: "prop-active",
+      tenantId: "tenant-active",
+      status: "active",
+    });
+    seedDoc("leases", "lease-hidden", {
+      landlordId: "landlord-1",
+      propertyId: "prop-active",
+      tenantId: "tenant-active",
+      status: "active",
+      hiddenFromActiveLists: true,
+    });
+    seedDoc("leases", "test_lease_quit_01", {
+      landlordId: "landlord-1",
+      propertyId: "prop-active",
+      tenantId: "tenant-active",
+      status: "active",
+    });
+
+    const app = await makeApp();
+    const response = await invokeSummary(app);
+
+    expect(response.status).toBe(200);
+    expect(response.body?.data?.kpis?.tenantsCount).toBe(1);
+    expect(response.body?.data?.portfolioCredibilitySummary?.activeLeaseCount).toBe(1);
+    expect(computePortfolioCredibilitySummaryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        leases: [expect.objectContaining({ id: "lease-visible" })],
+      })
+    );
+  });
+});

--- a/rentchain-api/src/routes/__tests__/messagesRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/messagesRoutes.test.ts
@@ -156,6 +156,15 @@ describe("messagesRoutes notifications", () => {
     });
     ensureCollection("tenants").set("tenant-1", {
       email: "tenant@example.com",
+      fullName: "Taylor Tenant",
+    });
+    ensureCollection("properties").set("prop-1", {
+      name: "Harbour View",
+      units: [{ id: "unit-1", unitNumber: "2A" }],
+    });
+    ensureCollection("units").set("unit-1", {
+      propertyId: "prop-1",
+      unitNumber: "2A",
     });
     ensureCollection("users").set("landlord-1", {
       email: "landlord@example.com",
@@ -186,5 +195,23 @@ describe("messagesRoutes notifications", () => {
 
     expect(res.status).toBe(201);
     expect(sendEmailMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns landlord-safe conversation display labels", async () => {
+    const router = await createRouter();
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/messages/conversations",
+      headers: { "x-test-user": JSON.stringify({ id: "landlord-1", landlordId: "landlord-1", role: "landlord" }) },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.conversations?.[0]).toEqual(
+      expect.objectContaining({
+        tenantDisplayName: "Taylor Tenant",
+        propertyDisplayLabel: "Harbour View",
+        unitDisplayLabel: "Unit 2A",
+      })
+    );
   });
 });

--- a/rentchain-api/src/routes/dashboardRoutes.ts
+++ b/rentchain-api/src/routes/dashboardRoutes.ts
@@ -5,8 +5,24 @@ import { db } from "../config/firebase";
 import { resolveLandlordAndTier } from "../lib/landlordResolver";
 import { computeNoResponseState, normalizeLeaseRecord } from "../services/leaseNoticeWorkflowService";
 import { computePortfolioCredibilitySummary } from "../services/risk/portfolioCredibilitySummary";
+import {
+  isTargetedHiddenLeaseId,
+  isTargetedHiddenTenantId,
+} from "../lib/testDataVisibilityTargets";
 
 const router = express.Router();
+
+function normalizePortfolioStatus(value: unknown): "active" | "archived" {
+  return String(value || "").trim().toLowerCase() === "archived" ? "archived" : "active";
+}
+
+function isVisibleActiveLease(raw: any) {
+  return raw?.hiddenFromActiveLists !== true && !isTargetedHiddenLeaseId(raw?.id);
+}
+
+function isVisibleActiveTenant(raw: any) {
+  return raw?.hiddenFromActiveLists !== true && !isTargetedHiddenTenantId(raw?.id);
+}
 
 // Set route source header for debugging
 router.use((req, res, next) => {
@@ -144,6 +160,12 @@ router.get("/summary", requireAuth, async (req: any, res) => {
   ]);
 
   const properties = propertiesSnap.docs.map((doc) => ({ id: doc.id, ...(doc.data() as any) }));
+  const activePropertyIds = new Set(
+    properties
+      .filter((property) => normalizePortfolioStatus(property?.portfolioStatus) === "active")
+      .map((property) => String(property?.id || "").trim())
+      .filter(Boolean)
+  );
   const unitsCount = properties.reduce((sum, property) => {
     const units = Array.isArray(property?.units) ? property.units.length : 0;
     return sum + units;
@@ -169,6 +191,13 @@ router.get("/summary", requireAuth, async (req: any, res) => {
           : null,
     };
   });
+  const activeTenantsCount = tenantsSnap.docs.reduce((count, doc) => {
+    const raw = { id: doc.id, ...(doc.data() as any) };
+    const propertyId = String(raw?.propertyId || "").trim();
+    if (!propertyId || !activePropertyIds.has(propertyId)) return count;
+    if (!isVisibleActiveTenant(raw)) return count;
+    return count + 1;
+  }, 0);
 
   const recentActivityRaw: Array<{
     id: string;
@@ -242,6 +271,7 @@ router.get("/summary", requireAuth, async (req: any, res) => {
   const leases = leasesSnap.docs
     .map((doc) => normalizeLeaseRecord(doc.id, doc.data() as any))
     .filter((lease) => currentLeaseStatuses.has(String(lease.status || "").toLowerCase()));
+  const visibleLeases = leases.filter(isVisibleActiveLease);
   const leaseNotices = leaseNoticesSnap.docs.map((doc) => ({ id: doc.id, ...(doc.data() as any) }));
   const latestNoticeByLeaseId = new Map<string, any>();
   for (const notice of leaseNotices.sort((a, b) => Number(b.createdAt || 0) - Number(a.createdAt || 0))) {
@@ -251,7 +281,7 @@ router.get("/summary", requireAuth, async (req: any, res) => {
   }
   const soonWindowMs = 120 * 24 * 60 * 60 * 1000;
   const portfolioCredibilitySummary = computePortfolioCredibilitySummary({
-    leases: leases.map((lease) => ({
+    leases: visibleLeases.map((lease) => ({
       id: lease.id,
       propertyId: lease.propertyId,
       status: lease.status,
@@ -274,7 +304,7 @@ router.get("/summary", requireAuth, async (req: any, res) => {
   });
 
   const leaseNoticeSummary = {
-    expiringSoon: leases.filter((lease) => {
+    expiringSoon: visibleLeases.filter((lease) => {
       const dueAt = Number(lease.nextNoticeDueAt || 0);
       return dueAt > 0 && dueAt <= now + soonWindowMs;
     }).length,
@@ -285,7 +315,8 @@ router.get("/summary", requireAuth, async (req: any, res) => {
   };
   latestNoticeByLeaseId.forEach((notice, leaseId) => {
     const response = String(notice?.tenantResponse || "pending").trim().toLowerCase();
-    const lease = leases.find((row) => row.id === leaseId) || null;
+    const lease = visibleLeases.find((row) => row.id === leaseId) || null;
+    if (!lease) return;
     const noResponse = computeNoResponseState(notice);
     if (noResponse) {
       leaseNoticeSummary.noResponse += 1;
@@ -328,7 +359,7 @@ router.get("/summary", requireAuth, async (req: any, res) => {
         href: "/applications",
       });
     }
-    if (tenantsSnap.empty) {
+    if (activeTenantsCount === 0) {
       actions.push({
         id: "invite-tenant",
         title: "Invite a tenant",
@@ -350,7 +381,7 @@ router.get("/summary", requireAuth, async (req: any, res) => {
     kpis: {
       propertiesCount: propertiesSnap.size,
       unitsCount,
-      tenantsCount: tenantsSnap.size,
+      tenantsCount: activeTenantsCount,
       openActionsCount: actions.length,
       delinquentCount: 0,
       screeningsCount,

--- a/rentchain-api/src/routes/messagesRoutes.ts
+++ b/rentchain-api/src/routes/messagesRoutes.ts
@@ -32,12 +32,91 @@ function normalizeConversation(doc: any) {
     id,
     landlordId: data.landlordId || null,
     tenantId: data.tenantId || null,
+    propertyId: data.propertyId || null,
     unitId: data.unitId || null,
     lastMessageAt: toMillis(data.lastMessageAt) || null,
     lastReadAtLandlord: toMillis(data.lastReadAtLandlord) || null,
     lastReadAtTenant: toMillis(data.lastReadAtTenant) || null,
     createdAt: toMillis(data.createdAt) || null,
   };
+}
+
+function normalizeUnitLabel(value: any) {
+  const raw = String(value || "").trim();
+  if (!raw) return null;
+  return /^unit\b/i.test(raw) ? raw : `Unit ${raw}`;
+}
+
+function buildPropertyLabel(property: any) {
+  return stringOrNull(property?.name) || stringOrNull(property?.addressLine1) || null;
+}
+
+function buildTenantLabel(tenant: any) {
+  return stringOrNull(tenant?.fullName) || stringOrNull(tenant?.name) || null;
+}
+
+async function enrichConversationDisplay<T extends ReturnType<typeof normalizeConversation>>(conversations: T[]) {
+  const tenantIds = Array.from(
+    new Set(conversations.map((conversation) => stringOrNull(conversation.tenantId)).filter(Boolean))
+  ) as string[];
+  const propertyIds = Array.from(
+    new Set(conversations.map((conversation) => stringOrNull((conversation as any).propertyId)).filter(Boolean))
+  ) as string[];
+  const unitIds = Array.from(
+    new Set(conversations.map((conversation) => stringOrNull(conversation.unitId)).filter(Boolean))
+  ) as string[];
+
+  const [tenants, properties, units] = await Promise.all([
+    Promise.all(
+      tenantIds.map(async (tenantId) => {
+        const snap = await db.collection("tenants").doc(tenantId).get();
+        return [tenantId, snap.exists ? buildTenantLabel(snap.data() as any) : null] as const;
+      })
+    ),
+    Promise.all(
+      propertyIds.map(async (propertyId) => {
+        const snap = await db.collection("properties").doc(propertyId).get();
+        return [propertyId, snap.exists ? (snap.data() as any) : null] as const;
+      })
+    ),
+    Promise.all(
+      unitIds.map(async (unitId) => {
+        const snap = await db.collection("units").doc(unitId).get();
+        const raw = snap.exists ? (snap.data() as any) : null;
+        return [unitId, raw ? normalizeUnitLabel(raw?.unitNumber || raw?.unitLabel || raw?.label || raw?.name) : null] as const;
+      })
+    ),
+  ]);
+
+  const tenantNameById = new Map<string, string | null>(tenants);
+  const propertyById = new Map<string, any>(properties);
+  const unitLabelById = new Map<string, string | null>(units);
+
+  return conversations.map((conversation) => {
+    const propertyId = stringOrNull((conversation as any).propertyId);
+    const unitId = stringOrNull(conversation.unitId);
+    const property = propertyId ? propertyById.get(propertyId) : null;
+    const fallbackUnitFromProperty = Array.isArray(property?.units)
+      ? property.units.find((unit: any) => {
+          const candidateId = stringOrNull(unit?.id) || stringOrNull(unit?.unitId) || stringOrNull(unit?.uid);
+          return candidateId && unitId && candidateId === unitId;
+        })
+      : null;
+
+    return {
+      ...conversation,
+      tenantDisplayName: tenantNameById.get(String(conversation.tenantId || "").trim()) || null,
+      propertyDisplayLabel: buildPropertyLabel(property),
+      unitDisplayLabel:
+        (unitId ? unitLabelById.get(unitId) : null) ||
+        normalizeUnitLabel(
+          fallbackUnitFromProperty?.unitNumber ||
+            fallbackUnitFromProperty?.label ||
+            fallbackUnitFromProperty?.name
+        ) ||
+        null,
+    };
+  });
 }
 
 function uniqueEmails(values: Array<string | null | undefined>) {
@@ -196,7 +275,8 @@ router.get("/landlord/messages/conversations", requireLandlord, async (req: any,
       .limit(100)
       .get();
 
-    const items = snap.docs.map(normalizeConversation).map((c: any) => ({
+    const normalized = snap.docs.map(normalizeConversation);
+    const items = (await enrichConversationDisplay(normalized)).map((c: any) => ({
       ...c,
       hasUnread:
         c.lastMessageAt != null &&
@@ -221,7 +301,7 @@ router.get("/landlord/messages/conversations/:id", requireLandlord, async (req: 
   try {
     const convoSnap = await db.collection("conversations").doc(id).get();
     if (!convoSnap.exists) return res.status(404).json({ ok: false, error: "Conversation not found" });
-    const convo = normalizeConversation(convoSnap);
+    const convo = (await enrichConversationDisplay([normalizeConversation(convoSnap)]))[0];
     if (convo.landlordId !== landlordId) return res.status(403).json({ ok: false, error: "Forbidden" });
 
     const msgSnap = await db
@@ -251,7 +331,7 @@ router.post("/landlord/messages/conversations/:id", requireLandlord, async (req:
   try {
     const convoSnap = await db.collection("conversations").doc(id).get();
     if (!convoSnap.exists) return res.status(404).json({ ok: false, error: "Conversation not found" });
-    const convo = normalizeConversation(convoSnap);
+    const convo = (await enrichConversationDisplay([normalizeConversation(convoSnap)]))[0];
     if (convo.landlordId !== landlordId) return res.status(403).json({ ok: false, error: "Forbidden" });
 
     const msg = await addMessage({ conversationId: id, senderRole: "landlord", body });

--- a/rentchain-frontend/src/api/messagesApi.ts
+++ b/rentchain-frontend/src/api/messagesApi.ts
@@ -4,7 +4,11 @@ export type Conversation = {
   id: string;
   landlordId?: string | null;
   tenantId?: string | null;
+  propertyId?: string | null;
   unitId?: string | null;
+  tenantDisplayName?: string | null;
+  propertyDisplayLabel?: string | null;
+  unitDisplayLabel?: string | null;
   lastMessageAt?: number | null;
   createdAt?: number | null;
   hasUnread?: boolean;

--- a/rentchain-frontend/src/components/dashboard/KpiStrip.tsx
+++ b/rentchain-frontend/src/components/dashboard/KpiStrip.tsx
@@ -1,6 +1,14 @@
 import React from "react";
+import { Link } from "react-router-dom";
 import { Card } from "../ui/Ui";
 import { colors, spacing, text } from "../../styles/tokens";
+const itemsOrder = [
+  { key: "propertiesCount", label: "Properties" },
+  { key: "unitsCount", label: "Units" },
+  { key: "tenantsCount", label: "Tenants" },
+  { key: "openActionsCount", label: "Open Actions" },
+  { key: "delinquentCount", label: "Delinquencies" },
+] as const;
 
 type Props = {
   kpis?: {
@@ -11,17 +19,10 @@ type Props = {
     delinquentCount: number;
   } | null;
   loading?: boolean;
+  links?: Partial<Record<(typeof itemsOrder)[number]["key"], string>>;
 };
 
-const itemsOrder = [
-  { key: "propertiesCount", label: "Properties" },
-  { key: "unitsCount", label: "Units" },
-  { key: "tenantsCount", label: "Tenants" },
-  { key: "openActionsCount", label: "Open Actions" },
-  { key: "delinquentCount", label: "Delinquencies" },
-] as const;
-
-export function KpiStrip({ kpis, loading }: Props) {
+export function KpiStrip({ kpis, loading, links }: Props) {
   const [isMobile, setIsMobile] = React.useState(false);
 
   React.useEffect(() => {
@@ -70,6 +71,13 @@ export function KpiStrip({ kpis, loading }: Props) {
                   marginBottom: 8,
                 }}
               />
+            ) : links?.[item.key] ? (
+              <Link
+                to={String(links[item.key])}
+                style={{ fontSize: isMobile ? 18 : 20, fontWeight: 800, color: text.primary, textDecoration: "underline" }}
+              >
+                {Number(value).toLocaleString()}
+              </Link>
             ) : (
               <div style={{ fontSize: isMobile ? 18 : 20, fontWeight: 800 }}>
                 {Number(value).toLocaleString()}

--- a/rentchain-frontend/src/components/dashboard/PortfolioCredibilitySummaryCard.tsx
+++ b/rentchain-frontend/src/components/dashboard/PortfolioCredibilitySummaryCard.tsx
@@ -8,6 +8,7 @@ import type { PortfolioCredibilitySummary } from "@/types/portfolioCredibilitySu
 interface PortfolioCredibilitySummaryCardProps {
   summary?: PortfolioCredibilitySummary | null;
   activeLeasesHref?: string;
+  reviewItemsHref?: string;
 }
 
 function healthTone(status?: PortfolioCredibilitySummary["healthStatus"] | null) {
@@ -45,6 +46,7 @@ const MetricTile: React.FC<{ label: string; value: React.ReactNode; caption?: Re
 export const PortfolioCredibilitySummaryCard: React.FC<PortfolioCredibilitySummaryCardProps> = ({
   summary,
   activeLeasesHref,
+  reviewItemsHref,
 }) => {
   const [isMobile, setIsMobile] = React.useState(false);
 
@@ -94,7 +96,7 @@ export const PortfolioCredibilitySummaryCard: React.FC<PortfolioCredibilitySumma
   const tone = healthTone(summary.healthStatus);
 
   return (
-    <Card style={{ display: "grid", gap: spacing.md }}>
+    <Card style={{ display: "grid", gap: spacing.md, overflowX: isMobile ? "auto" : "visible" }}>
       <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.md, alignItems: "flex-start", flexWrap: "wrap" }}>
         <div style={{ display: "grid", gap: 6 }}>
           <div style={{ color: text.primary, fontSize: "1rem", fontWeight: 800 }}>Portfolio credibility summary</div>
@@ -147,7 +149,19 @@ export const PortfolioCredibilitySummaryCard: React.FC<PortfolioCredibilitySumma
       </div>
 
       <div style={{ display: "grid", gridTemplateColumns: metricsGridColumns, gap: spacing.md }}>
-        <MetricTile label="Review items" value={summary.lowConfidenceCount} caption="Low-confidence records to review" />
+        <MetricTile
+          label="Review items"
+          value={
+            reviewItemsHref ? (
+              <Link to={reviewItemsHref} style={{ color: text.primary, textDecoration: "underline" }}>
+                {summary.lowConfidenceCount}
+              </Link>
+            ) : (
+              summary.lowConfidenceCount
+            )
+          }
+          caption="Low-confidence records to review"
+        />
         <MetricTile label="Missing credibility" value={summary.missingCredibilityCount} caption="Records without current score or risk data" />
       </div>
     </Card>

--- a/rentchain-frontend/src/components/integrations/ConnectTransUnionModal.test.tsx
+++ b/rentchain-frontend/src/components/integrations/ConnectTransUnionModal.test.tsx
@@ -19,6 +19,9 @@ describe("ConnectTransUnionModal", () => {
         "Connect your TransUnion membership by entering the member code and passcode issued to your business. Screening requests are initiated under your TransUnion credentials within RentChain."
       )
     ).toBeInTheDocument();
+    expect(
+      screen.getByText(/If connection details are not available yet, use the access flow first/i)
+    ).toBeInTheDocument();
     expect(screen.getByText("Need TransUnion access?")).toBeInTheDocument();
     expect(screen.getByText("Already credentialed?")).toBeInTheDocument();
     expect(screen.getByText("Choose path")).toBeInTheDocument();

--- a/rentchain-frontend/src/components/integrations/ConnectTransUnionModal.tsx
+++ b/rentchain-frontend/src/components/integrations/ConnectTransUnionModal.tsx
@@ -197,6 +197,9 @@ export function ConnectTransUnionModal({
             your business. Screening requests are initiated under your TransUnion credentials within
             RentChain.
           </p>
+          <p style={{ margin: 0, color: text.subtle, fontSize: "0.92rem" }}>
+            If connection details are not available yet, use the access flow first. If the connection window does not open on mobile, try again or continue on desktop.
+          </p>
         </div>
         <div style={{ display: "grid", gap: spacing.sm, minHeight: 0, flex: 1, overflowY: "auto" }}>
           <div

--- a/rentchain-frontend/src/components/integrations/GetTransUnionAccessModal.tsx
+++ b/rentchain-frontend/src/components/integrations/GetTransUnionAccessModal.tsx
@@ -119,6 +119,19 @@ export function GetTransUnionAccessModal({
             border: `1px solid ${colors.border}`,
             borderRadius: radius.md,
             padding: spacing.sm,
+            background: colors.bg,
+            color: text.muted,
+            fontSize: "0.92rem",
+            lineHeight: 1.6,
+          }}
+        >
+          Connection details are not available yet. If the connection window does not open on mobile, try again or continue on desktop.
+        </div>
+        <div
+          style={{
+            border: `1px solid ${colors.border}`,
+            borderRadius: radius.md,
+            padding: spacing.sm,
             background: "rgba(15,118,110,0.06)",
             color: text.muted,
             fontSize: "0.92rem",

--- a/rentchain-frontend/src/components/integrations/TransUnionConnectionCard.test.tsx
+++ b/rentchain-frontend/src/components/integrations/TransUnionConnectionCard.test.tsx
@@ -110,4 +110,27 @@ describe("TransUnionConnectionCard", () => {
     fireEvent.click(screen.getByRole("button", { name: "Choose an Applicant" }));
     expect(onChooseApplicant).toHaveBeenCalledTimes(1);
   });
+
+  it("does not render literal null text in the next-step copy", () => {
+    render(
+      <TransUnionConnectionCard
+        integration={buildIntegration({
+          status: "connected",
+          memberCodeMasked: "*******7788",
+        })}
+        onGetAccess={vi.fn()}
+        onConnectExisting={vi.fn()}
+        onEnterDetails={vi.fn()}
+        onViewInstructions={vi.fn()}
+        onUpdateCredentials={vi.fn()}
+        onDisconnect={vi.fn()}
+        onStartScreening={vi.fn()}
+        readyToScreen
+        selectedApplicationLabel={"null" as any}
+      />
+    );
+
+    expect(screen.queryByText(/null\/null/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/\bnull\b/i)).not.toBeInTheDocument();
+  });
 });

--- a/rentchain-frontend/src/components/integrations/TransUnionConnectionCard.tsx
+++ b/rentchain-frontend/src/components/integrations/TransUnionConnectionCard.tsx
@@ -21,6 +21,13 @@ type Props = {
   lastScreeningDate?: string | number | null;
 };
 
+function safeLabel(value: unknown) {
+  const raw = String(value ?? "").trim();
+  if (!raw) return null;
+  if (raw.toLowerCase() === "null" || raw.toLowerCase() === "undefined") return null;
+  return raw;
+}
+
 function ActionRow({
   actions,
 }: {
@@ -64,8 +71,11 @@ export function TransUnionConnectionCard({
   const completedCount = Number.isFinite(Number(screeningsCompletedCount))
     ? Number(screeningsCompletedCount)
     : null;
+  const safeSelectedApplicationLabel = safeLabel(selectedApplicationLabel);
   const formattedLastScreeningDate =
     lastScreeningDate == null
+      ? null
+      : Number.isNaN(new Date(lastScreeningDate).getTime())
       ? null
       : new Date(lastScreeningDate).toLocaleDateString();
 
@@ -91,7 +101,7 @@ export function TransUnionConnectionCard({
       ? "You already have an application in context, so you can move straight into screening."
       : "Choose an applicant from Applications first, then start screening from that application context.";
     nextStep = readyToScreen
-      ? `Next step: start screening${selectedApplicationLabel ? ` for ${selectedApplicationLabel}` : ""}.`
+      ? `Next step: start screening${safeSelectedApplicationLabel ? ` for ${safeSelectedApplicationLabel}` : ""}.`
       : "Next step: choose an applicant below, then start your first screening.";
     actions = [
       { label: "Update Credentials", onClick: onUpdateCredentials },

--- a/rentchain-frontend/src/pages/ApplicationsPage.css
+++ b/rentchain-frontend/src/pages/ApplicationsPage.css
@@ -108,6 +108,10 @@
 }
 
 @media (max-width: 768px) {
+  .rc-applications-grid {
+    overflow: visible;
+  }
+
   .rc-applications-header {
     position: sticky;
     top: 0;
@@ -135,10 +139,19 @@
 
   .rc-applications-list-scroll {
     overflow: visible;
+    max-height: none;
   }
 
   .rc-applications-card-header {
     align-items: flex-start;
+  }
+
+  .rc-applications-list-item {
+    align-items: flex-start;
+  }
+
+  .rc-applications-detail {
+    overflow-x: auto;
   }
 
   .rc-applications-screening-grid {

--- a/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
@@ -358,6 +358,18 @@ describe("ApplicationsPage", () => {
     mocks.openUpgrade.mockReset();
   });
 
+  it("keeps the applications master-detail containers in the mobile-safe layout structure", async () => {
+    const { container } = render(
+      <MemoryRouter>
+        <ApplicationsPage />
+      </MemoryRouter>
+    );
+
+    await screen.findByText("Jamie Stone");
+    expect(container.querySelector(".rc-applications-list-scroll")).toBeTruthy();
+    expect(container.querySelector(".rc-applications-detail")).toBeTruthy();
+  });
+
   it("renders without crashing for a free-tier landlord", async () => {
     render(
       <MemoryRouter>

--- a/rentchain-frontend/src/pages/ApplicationsPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.tsx
@@ -271,6 +271,14 @@ const normalizeTransUnionConfigError = (error: unknown) => {
   return error;
 };
 
+const buildApplicantLabel = (detail: RentalApplication | null) => {
+  if (!detail) return null;
+  const parts = [detail.applicant.firstName, detail.applicant.lastName]
+    .map((value) => String(value ?? "").trim())
+    .filter((value) => value && value.toLowerCase() !== "null" && value.toLowerCase() !== "undefined");
+  return parts.join(" ").trim() || null;
+};
+
 const ApplicationsPage: React.FC = () => {
   const location = useLocation();
   const navigate = useNavigate();
@@ -2008,9 +2016,7 @@ const ApplicationsPage: React.FC = () => {
         integration={transUnionIntegration}
         loading={transUnionLoading}
         readyToScreen={Boolean(detail)}
-        selectedApplicationLabel={
-          detail ? `${detail.applicant.firstName} ${detail.applicant.lastName}`.trim() : null
-        }
+        selectedApplicationLabel={buildApplicantLabel(detail)}
         onChooseApplicant={guideToApplicationsForScreening}
         screeningsCompletedCount={
           detail

--- a/rentchain-frontend/src/pages/DashboardPage.test.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.test.tsx
@@ -173,4 +173,50 @@ describe("DashboardPage", () => {
     expect(await screen.findByText("Welcome to RentChain")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Start setup" })).toBeInTheDocument();
   });
+
+  it("links open actions and review items to the approved destinations", async () => {
+    mocks.fetchDashboardSummaryMock.mockResolvedValue({
+      kpis: {
+        propertiesCount: 1,
+        unitsCount: 2,
+        tenantsCount: 1,
+        openActionsCount: 3,
+        delinquentCount: 0,
+        screeningsCount: 0,
+      },
+      actions: [{ id: "a-1", title: "Invite a tenant", severity: "info", href: "/tenants" }],
+      events: [],
+      leaseNoticeSummary: {
+        expiringSoon: 0,
+        pendingResponse: 0,
+        renewed: 0,
+        quitting: 0,
+        noResponse: 0,
+      },
+      portfolioCredibilitySummary: {
+        propertyCount: 1,
+        activeLeaseCount: 5,
+        tenantScoreAverage: null,
+        tenantScoreGradeAverage: null,
+        leaseRiskAverage: null,
+        leaseRiskGradeAverage: null,
+        tenantsWithScoreCount: 0,
+        leasesWithRiskCount: 0,
+        lowConfidenceCount: 2,
+        missingCredibilityCount: 1,
+        healthStatus: "watch",
+      },
+    });
+
+    render(
+      <ToastProvider>
+        <MemoryRouter>
+          <DashboardPage />
+        </MemoryRouter>
+      </ToastProvider>
+    );
+
+    expect(await screen.findByRole("link", { name: "3" })).toHaveAttribute("href", "/dashboard#open-actions");
+    expect(screen.getByRole("link", { name: "2" })).toHaveAttribute("href", "/applications?status=review");
+  });
 });

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -591,12 +591,19 @@ const DashboardPage: React.FC = () => {
           </Card>
         ) : null}
 
-        {dataReady ? <KpiStrip kpis={kpis} loading={loading} /> : null}
+        {dataReady ? (
+          <KpiStrip
+            kpis={kpis}
+            loading={loading}
+            links={{ openActionsCount: "/dashboard#open-actions" }}
+          />
+        ) : null}
         {dataReady ? (
           <div style={{ marginTop: spacing.md }}>
             <PortfolioCredibilitySummaryCard
               summary={data?.portfolioCredibilitySummary ?? null}
               activeLeasesHref="/leases"
+              reviewItemsHref="/applications?status=review"
             />
           </div>
         ) : null}
@@ -726,13 +733,15 @@ const DashboardPage: React.FC = () => {
               gap: spacing.md,
             }}
           >
-            <ActionRequiredPanel
-              items={actions}
-              loading={loading}
-              viewAllEnabled={false}
-              title="Action required"
-              emptyLabel="No pending actions. Add a property or invite a tenant to begin."
-            />
+            <div id="open-actions">
+              <ActionRequiredPanel
+                items={actions}
+                loading={loading}
+                viewAllEnabled={false}
+                title="Action required"
+                emptyLabel="No pending actions. Add a property or invite a tenant to begin."
+              />
+            </div>
             <Card style={{ padding: spacing.md, border: `1px solid ${colors.border}` }}>
               <div style={{ fontWeight: 700, marginBottom: spacing.sm }}>Quick actions</div>
               <div style={{ display: "flex", flexWrap: "wrap", gap: spacing.sm }}>

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
@@ -92,8 +92,9 @@ describe("LandlordActiveLeasesPage", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText("Harbour View")).toBeInTheDocument();
-    expect(screen.getByText("Lease fully executed")).toBeInTheDocument();
+    expect((await screen.findAllByText("Harbour View")).length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: "Print / Save PDF" })).toBeInTheDocument();
+    expect(screen.getAllByText("Lease fully executed").length).toBeGreaterThan(0);
     expect(screen.getByRole("link", { name: "View" })).toHaveAttribute("href", "/leases/lease-1/ledger");
     expect(screen.getByRole("link", { name: "Email" })).toHaveAttribute(
       "href",
@@ -191,7 +192,7 @@ describe("LandlordActiveLeasesPage", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText("Archived Place")).toBeInTheDocument();
+    expect((await screen.findAllByText("Archived Place")).length).toBeGreaterThan(0);
     fireEvent.click(screen.getByRole("button", { name: "Restore" }));
     await waitFor(() => expect(mocks.restoreLeaseRecord).toHaveBeenCalledWith("lease-2"));
   });
@@ -246,8 +247,8 @@ describe("LandlordActiveLeasesPage", () => {
     expect(screen.queryByText("Jane Tenant")).not.toBeInTheDocument();
 
     fireEvent.change(search, { target: { value: "dockside" } });
-    expect(screen.getByText("Dockside Flats")).toBeInTheDocument();
-    expect(screen.queryByText("Harbour View")).not.toBeInTheDocument();
+    expect(screen.getAllByText("Dockside Flats").length).toBeGreaterThan(0);
+    expect(screen.queryAllByText("Harbour View")).toHaveLength(0);
 
     fireEvent.change(search, { target: { value: "no-match" } });
     expect(screen.getByText("No leases match your search.")).toBeInTheDocument();
@@ -293,8 +294,8 @@ describe("LandlordActiveLeasesPage", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText("Harbour View")).toBeInTheDocument();
-    expect(screen.queryByText("Property_test")).not.toBeInTheDocument();
-    expect(screen.queryByText("test2")).not.toBeInTheDocument();
+    expect((await screen.findAllByText("Harbour View")).length).toBeGreaterThan(0);
+    expect(screen.queryAllByText("Property_test")).toHaveLength(0);
+    expect(screen.queryAllByText("test2")).toHaveLength(0);
   });
 });

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
@@ -240,11 +240,51 @@ export default function LandlordActiveLeasesPage() {
 
   return (
     <div style={{ display: "grid", gap: 16 }}>
-      <div style={{ display: "grid", gap: 6 }}>
-        <div style={{ fontSize: 24, fontWeight: 800 }}>Lease operations</div>
-        <div style={{ color: "#475569", fontSize: 14 }}>
-          Keep canonical lease records visible, reconcile occupied units missing leases, and use the ledger and archive views safely.
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "flex-start" }}>
+        <div style={{ display: "grid", gap: 6 }}>
+          <div style={{ fontSize: 24, fontWeight: 800 }}>Lease operations</div>
+          <div style={{ color: "#475569", fontSize: 14 }}>
+            Keep canonical lease records visible, reconcile occupied units missing leases, and use the ledger and archive views safely.
+          </div>
         </div>
+        <button
+          type="button"
+          className="no-print"
+          onClick={() => window.print()}
+          style={{ padding: "8px 10px", borderRadius: 12, border: "1px solid #E5E7EB", background: "#FFFFFF", fontWeight: 900, cursor: "pointer" }}
+        >
+          Print / Save PDF
+        </button>
+      </div>
+
+      <div className="print-only print-only-summary">
+        <div className="printHeader">
+          <div className="printTitle">Lease operations summary</div>
+          <div className="printMeta">
+            <div>View: {view === "archived" ? "Archived leases" : "Active leases"}</div>
+            <div>Visible leases: {filteredLeases.length}</div>
+          </div>
+        </div>
+        <table className="printTable">
+          <thead>
+            <tr>
+              <th>Property</th>
+              <th>Unit</th>
+              <th>Tenant</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filteredLeases.map((lease) => (
+              <tr key={lease.id}>
+                <td>{lease.propertyName || "Property"}</td>
+                <td>{lease.unitNumber || "—"}</td>
+                <td>{lease.tenantName || "—"}</td>
+                <td>{prettyLeaseStatus(lease.status)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       </div>
 
       <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>

--- a/rentchain-frontend/src/pages/MessagesPage.test.tsx
+++ b/rentchain-frontend/src/pages/MessagesPage.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import MessagesPage from "./MessagesPage";
+
+const mocks = vi.hoisted(() => ({
+  fetchLandlordConversationsMock: vi.fn(),
+  fetchLandlordConversationMessagesMock: vi.fn(),
+  markLandlordConversationReadMock: vi.fn(),
+  sendLandlordMessageMock: vi.fn(),
+  useCapabilitiesMock: vi.fn(),
+  openUpgradeMock: vi.fn(),
+}));
+
+vi.mock("@/api/messagesApi", () => ({
+  fetchLandlordConversations: mocks.fetchLandlordConversationsMock,
+  fetchLandlordConversationMessages: mocks.fetchLandlordConversationMessagesMock,
+  markLandlordConversationRead: mocks.markLandlordConversationReadMock,
+  sendLandlordMessage: mocks.sendLandlordMessageMock,
+}));
+
+vi.mock("@/hooks/useCapabilities", () => ({
+  useCapabilities: mocks.useCapabilitiesMock,
+}));
+
+vi.mock("@/context/UpgradeContext", () => ({
+  useUpgrade: () => ({ openUpgrade: mocks.openUpgradeMock }),
+}));
+
+vi.mock("@/components/layout/ResponsiveMasterDetail", () => ({
+  ResponsiveMasterDetail: ({ masterTitle, selectedLabel, masterDropdown, master, detail }: any) => (
+    <div>
+      <div>{masterTitle}</div>
+      <div>{selectedLabel}</div>
+      {masterDropdown}
+      {master}
+      {detail}
+    </div>
+  ),
+}));
+
+describe("MessagesPage", () => {
+  beforeEach(() => {
+    mocks.useCapabilitiesMock.mockReturnValue({
+      features: { messaging: true },
+      loading: false,
+    });
+    mocks.fetchLandlordConversationsMock.mockResolvedValue([
+      {
+        id: "conv-1",
+        tenantDisplayName: "Taylor Tenant",
+        propertyDisplayLabel: "Harbour View",
+        unitDisplayLabel: "Unit 2A",
+      },
+    ]);
+    mocks.fetchLandlordConversationMessagesMock.mockResolvedValue({
+      conversation: {
+        id: "conv-1",
+        tenantDisplayName: "Taylor Tenant",
+        propertyDisplayLabel: "Harbour View",
+        unitDisplayLabel: "Unit 2A",
+      },
+      messages: [],
+    });
+    mocks.markLandlordConversationReadMock.mockResolvedValue(undefined);
+    mocks.sendLandlordMessageMock.mockResolvedValue(undefined);
+  });
+
+  it("prefers tenant and property/unit labels over raw ids", async () => {
+    render(
+      <MemoryRouter>
+        <MessagesPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Taylor Tenant • Harbour View / Unit 2A").length).toBeGreaterThan(0);
+    });
+    expect(screen.queryByText(/Tenant tenant-/i)).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/MessagesPage.tsx
+++ b/rentchain-frontend/src/pages/MessagesPage.tsx
@@ -19,6 +19,24 @@ const POLL_CONVERSATIONS_MS = 15000;
 const POLL_THREAD_MS = 12000;
 const MAX_CONVERSATIONS_BACKOFF_MS = 120000;
 
+function buildConversationTitle(conversation: Conversation | null) {
+  if (!conversation) return "Conversation";
+  const tenantName = String(conversation.tenantDisplayName || "").trim();
+  const propertyLabel = String(conversation.propertyDisplayLabel || "").trim();
+  const unitLabel = String(conversation.unitDisplayLabel || "").trim();
+  const locationLabel = [propertyLabel, unitLabel].filter(Boolean).join(" / ");
+  if (tenantName && locationLabel) return `${tenantName} • ${locationLabel}`;
+  if (tenantName) return tenantName;
+  if (locationLabel) return locationLabel;
+  return "Conversation";
+}
+
+function buildConversationMeta(conversation: Conversation) {
+  const propertyLabel = String(conversation.propertyDisplayLabel || "").trim();
+  const unitLabel = String(conversation.unitDisplayLabel || "").trim();
+  return [propertyLabel, unitLabel].filter(Boolean).join(" / ") || "Tenant conversation";
+}
+
 export default function MessagesPage() {
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -143,6 +161,7 @@ export default function MessagesPage() {
     () => conversations.find((c) => c.id === selectedId) || null,
     [conversations, selectedId]
   );
+  const selectedConversationTitle = buildConversationTitle(selectedConversation);
 
   return (
     <div className="rc-messages-page">
@@ -187,7 +206,7 @@ export default function MessagesPage() {
         <ResponsiveMasterDetail
           masterTitle="Conversations"
           hasSelection={Boolean(selectedId)}
-          selectedLabel={`Tenant ${selectedConversation?.tenantId || "unknown"}`}
+          selectedLabel={selectedConversationTitle}
           onClearSelection={() => {
             setSelectedId(null);
             navigate("/messages");
@@ -207,7 +226,7 @@ export default function MessagesPage() {
                 <option value="">Select conversation</option>
                 {conversations.map((c) => (
                   <option key={c.id} value={c.id}>
-                    Tenant {c.tenantId || "unknown"}
+                    {buildConversationTitle(c)}
                   </option>
                 ))}
               </select>
@@ -237,14 +256,14 @@ export default function MessagesPage() {
                     >
                       <div className="rc-messages-list-item-row">
                         <div className="rc-messages-list-item-title">
-                          Tenant {c.tenantId || "unknown"}
+                          {buildConversationTitle(c)}
                         </div>
                         {c.hasUnread ? (
                           <span className="rc-messages-unread-dot" />
                         ) : null}
                       </div>
                       <div className="rc-messages-list-item-meta">
-                        Unit {c.unitId || "n/a"}
+                        {buildConversationMeta(c)}
                       </div>
                     </button>
                   );
@@ -258,7 +277,7 @@ export default function MessagesPage() {
                 <>
                   <div className="rc-messages-thread-header">
                     <div className="rc-messages-thread-title">
-                      Conversation with tenant {selectedConversation.tenantId || "unknown"}
+                      {selectedConversationTitle}
                     </div>
                   </div>
                   <div className="rc-messages-thread-body">

--- a/rentchain-frontend/src/pages/PropertiesPage.test.tsx
+++ b/rentchain-frontend/src/pages/PropertiesPage.test.tsx
@@ -143,6 +143,18 @@ describe("PropertiesPage", () => {
     expect(screen.getByText("Archived properties are hidden from active portfolio views but preserved for records and history.")).toBeInTheDocument();
   });
 
+  it("shows a print action when a property is selected", async () => {
+    render(
+      <MemoryRouter>
+        <PropertiesPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByRole("button", { name: "Print / Save PDF" }).length).toBeGreaterThan(0);
+    });
+  });
+
   it("shows a guided first-property empty state for new users", async () => {
     mocks.fetchPropertiesMock.mockResolvedValue({ items: [] });
 

--- a/rentchain-frontend/src/pages/PropertiesPage.tsx
+++ b/rentchain-frontend/src/pages/PropertiesPage.tsx
@@ -867,6 +867,44 @@ const PropertiesPage: React.FC = () => {
                   <strong>Edit Units (stub)</strong>  wire this to your Units edit flow.
                 </div>
               ) : null}
+              {selectedProperty ? (
+                <>
+                  <div style={{ display: "flex", justifyContent: "flex-end" }}>
+                    <Button
+                      type="button"
+                      className="no-print"
+                      onClick={() => window.print()}
+                    >
+                      Print / Save PDF
+                    </Button>
+                  </div>
+                  <div className="print-only print-only-summary">
+                    <div className="printHeader">
+                      <div className="printTitle">{selectedProperty.name || selectedProperty.addressLine1 || "Property summary"}</div>
+                      <div className="printMeta">
+                        <div>{[selectedProperty.addressLine1, selectedProperty.city].filter(Boolean).join(", ") || "Address not available"}</div>
+                        <div>Status: {selectedProperty.portfolioStatus || "active"}</div>
+                      </div>
+                    </div>
+                    <table className="printTable">
+                      <thead>
+                        <tr>
+                          <th>Unit</th>
+                          <th>Status</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {(Array.isArray((selectedProperty as any)?.units) ? (selectedProperty as any).units : []).map((unit: any, index: number) => (
+                          <tr key={String(unit?.id || unit?.unitId || unit?.uid || index)}>
+                            <td>{String(unit?.unitNumber || unit?.label || unit?.name || "—")}</td>
+                            <td>{String(unit?.status || unit?.occupancyStatus || "unknown")}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </>
+              ) : null}
               <PropertyDetailPanel
                 property={selectedProperty}
                 onRefresh={loadProperties}

--- a/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.test.tsx
@@ -511,6 +511,7 @@ describe("LandlordAnalyticsPage", () => {
     expect(screen.getByRole("heading", { name: /Applications/i })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /Revenue signal/i })).toBeInTheDocument();
     expect(screen.getAllByText(/vs prior 90 days/i).length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: "Print / Save PDF" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Review leases/i })).toHaveAttribute("href", "/portfolio-health");
     expect(macShellSpy).toHaveBeenCalledWith(expect.objectContaining({ title: "Analytics", showTopNav: false }));
   });

--- a/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.tsx
@@ -233,18 +233,67 @@ export default function LandlordAnalyticsPage() {
     <MacShell title="Analytics" showTopNav={false}>
       <div style={{ display: "grid", gap: 16 }}>
         <Section>
-          <div style={{ display: "grid", gap: 6 }}>
-            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Analytics</h1>
-            <div style={{ color: "#475569", maxWidth: 840 }}>
-              A calm view of portfolio health, application activity, leasing pressure, maintenance burden, and rent signals.
-            </div>
-            {routedEntryLabel ? (
-              <div style={{ color: "#0f766e", fontWeight: 600, fontSize: "0.92rem" }}>
-                Focused from decisions: {routedEntryLabel}
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "flex-start" }}>
+            <div style={{ display: "grid", gap: 6 }}>
+              <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Analytics</h1>
+              <div style={{ color: "#475569", maxWidth: 840 }}>
+                A calm view of portfolio health, application activity, leasing pressure, maintenance burden, and rent signals.
               </div>
-            ) : null}
+              {routedEntryLabel ? (
+                <div style={{ color: "#0f766e", fontWeight: 600, fontSize: "0.92rem" }}>
+                  Focused from decisions: {routedEntryLabel}
+                </div>
+              ) : null}
+            </div>
+            <button
+              type="button"
+              className="no-print"
+              onClick={() => window.print()}
+              style={{ padding: "8px 10px", borderRadius: 12, border: "1px solid #E5E7EB", background: "#FFFFFF", fontWeight: 900, cursor: "pointer" }}
+            >
+              Print / Save PDF
+            </button>
           </div>
         </Section>
+
+        {snapshot ? (
+          <div className="print-only print-only-summary">
+            <div className="printHeader">
+              <div className="printTitle">Analytics summary</div>
+              <div className="printMeta">
+                <div>Period: {periodLabel(period)}</div>
+                <div>Property filter: {propertyId || "All properties"}</div>
+              </div>
+            </div>
+            <div className="printKpis">
+              {summaryItems.slice(0, 4).map((item) => (
+                <div key={item.label} className="printKpi">
+                  <div className="printKpiLabel">{item.label}</div>
+                  <div className="printKpiValue">{item.value}</div>
+                </div>
+              ))}
+            </div>
+            <div className="printH3">Decision queue</div>
+            <table className="printTable">
+              <thead>
+                <tr>
+                  <th>Title</th>
+                  <th>Priority</th>
+                  <th>Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {prioritizedDecisions.slice(0, 10).map((decision) => (
+                  <tr key={decision.id}>
+                    <td>{decision.title}</td>
+                    <td>{decision.priority}</td>
+                    <td>{decision.executionState}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : null}
 
         {entitlementLoading ? <Card>Loading analytics access…</Card> : null}
         {!entitlementLoading && !canViewPortfolioHealthSummary ? (

--- a/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.test.tsx
@@ -119,8 +119,9 @@ describe("PortfolioHealthSummaryPage", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText(/stable overall, with a few areas to monitor/i)).toBeInTheDocument();
-    expect(screen.getByText(/Screening health/i)).toBeInTheDocument();
+    expect((await screen.findAllByText(/stable overall, with a few areas to monitor/i)).length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: "Print / Save PDF" })).toBeInTheDocument();
+    expect(screen.getAllByText(/Screening health/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Resident feedback patterns/i)).toBeInTheDocument();
     expect(screen.getByText(/Workflow follow-through/i)).toBeInTheDocument();
   });

--- a/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.tsx
@@ -212,13 +212,60 @@ export default function PortfolioHealthSummaryPage() {
     <MacShell title="Portfolio health">
       <div style={{ display: "grid", gap: 16 }}>
         <Section>
-          <div style={{ display: "grid", gap: 6 }}>
-            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Portfolio health</h1>
-            <div style={{ color: "#475569", maxWidth: 820 }}>
-              A high-level view of overall portfolio health, recent direction, and where follow-through may help most.
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "flex-start" }}>
+            <div style={{ display: "grid", gap: 6 }}>
+              <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Portfolio health</h1>
+              <div style={{ color: "#475569", maxWidth: 820 }}>
+                A high-level view of overall portfolio health, recent direction, and where follow-through may help most.
+              </div>
             </div>
+            <button
+              type="button"
+              className="no-print"
+              onClick={() => window.print()}
+              style={{ padding: "8px 10px", borderRadius: 12, border: "1px solid #E5E7EB", background: "#FFFFFF", fontWeight: 900, cursor: "pointer" }}
+            >
+              Print / Save PDF
+            </button>
           </div>
         </Section>
+
+        {summary ? (
+          <div className="print-only print-only-summary">
+            <div className="printHeader">
+              <div className="printTitle">Portfolio health summary</div>
+              <div className="printMeta">
+                <div>Generated: {summary.generatedAt || "Current view"}</div>
+                <div>Status: {summary.overall?.status || "unknown"}</div>
+              </div>
+            </div>
+            <div className="printH3">Overview</div>
+            <div>{summary.overall?.headline || summary.overall?.summary || "Portfolio health summary is not available."}</div>
+            {summary.dimensions?.length ? (
+              <>
+                <div className="printH3">Dimensions</div>
+                <table className="printTable">
+                  <thead>
+                    <tr>
+                      <th>Area</th>
+                      <th>Status</th>
+                      <th>Summary</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {summary.dimensions.map((dimension) => (
+                      <tr key={dimension.key}>
+                        <td>{dimension.label}</td>
+                        <td>{dimension.status}</td>
+                        <td>{dimension.summary}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </>
+            ) : null}
+          </div>
+        ) : null}
 
         {entryMessage ? (
           <Card style={{ borderColor: "#99f6e4", background: "#f0fdfa", color: "#115e59" }}>{entryMessage}</Card>


### PR DESCRIPTION
This PR fixes mobile dashboard and reporting issues.

Includes:
- active-only dashboard tenant count excluding archived-property tenants
- dashboard active lease count aligned with /leases live-lease visibility
- Open Actions and Review Items dashboard links
- browser Print / Save PDF actions for analytics, portfolio health, leases, and properties
- print-friendly summaries including selected property unit/status table
- mobile layout improvements for dashboard lease/portfolio card and applications page
- messages conversation labels using tenant/property/unit context
- null-safe TransUnion connection instruction copy
- focused backend/frontend test coverage

Guardrails preserved:
- no provider-side TransUnion changes
- no backend PDF/export system
- no broad dashboard redesign
- no billing/auth/infra changes
- desktop behavior preserved where possible