### PR TITLE
feat: add lease payment readiness

### DIFF
--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -137,6 +137,7 @@ describe("leaseRoutes GET /active", () => {
       unitId: "unit-1",
       unitNumber: "101",
       monthlyRent: 1850,
+      dueDay: 1,
       startDate: "2026-01-01",
       endDate: "2026-12-31",
       status: "active",
@@ -187,9 +188,19 @@ describe("leaseRoutes GET /active", () => {
           executionLabel: "Lease fully executed",
           requiredNextAction: "none",
         }),
+        paymentReadiness: expect.objectContaining({
+          readinessStatus: "ready_to_configure",
+          readinessLabel: "Rent terms ready for future setup",
+          paymentSetup: {
+            processorConnected: false,
+            moneyMovementEnabled: false,
+            storedPaymentMethod: false,
+          },
+        }),
       })
     );
     expect(res.body?.leases?.[0]?.tenantSignature?.drawnDataUrl).toBeUndefined();
+    expect(res.body?.leases?.[0]?.paymentMethod).toBeUndefined();
   });
 
   it("excludes targeted synthetic cleanup leases from landlord active lists", async () => {

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -193,10 +193,12 @@ describe("tenantPortalRoutes foundation", () => {
     ensureCollection("leases").set("lease-1", {
       tenantId: "tenant-1",
       propertyId: "prop-1",
+      unitId: "unit-1",
       status: "active",
       startDate: "2026-02-01",
       endDate: "2027-01-31",
       monthlyRent: 1800,
+      dueDay: 1,
       documentUrl: "https://example.com/lease.pdf",
       tenantSignature: {
         signedAt: "2026-02-01T10:00:00.000Z",
@@ -497,6 +499,18 @@ describe("tenantPortalRoutes foundation", () => {
     });
     expect(res.body?.data?.lease?.tenantSignature?.drawnDataUrl).toBeUndefined();
     expect(res.body?.data?.lease?.leasePdfStatus).toBe("available");
+    expect(res.body?.data?.lease?.paymentReadiness).toEqual(
+      expect.objectContaining({
+        readinessStatus: "ready_to_configure",
+        readinessLabel: "Rent terms ready for future setup",
+        requiredNextAction: "confirm_payment_setup_later",
+        paymentSetup: {
+          processorConnected: false,
+          moneyMovementEnabled: false,
+          storedPaymentMethod: false,
+        },
+      })
+    );
     expect(res.body?.data?.tenantIdentityRecord).toEqual(
       expect.objectContaining({
         identityStatus: expect.stringMatching(/incomplete|ready|verified|limited/),
@@ -605,7 +619,20 @@ describe("tenantPortalRoutes foundation", () => {
         requiredNextAction: "none",
       })
     );
+    expect(res.body?.data?.paymentReadiness).toEqual(
+      expect.objectContaining({
+        readinessStatus: "ready_to_configure",
+        readinessLabel: "Rent terms ready for future setup",
+        requiredNextAction: "confirm_payment_setup_later",
+        paymentSetup: {
+          processorConnected: false,
+          moneyMovementEnabled: false,
+          storedPaymentMethod: false,
+        },
+      })
+    );
     expect(res.body?.lease?.tenantSignature?.drawnDataUrl).toBeUndefined();
+    expect(res.body?.data?.paymentMethod).toBeUndefined();
   });
 
   it("records tenant lease signing metadata without storing raw signature data and stays idempotent", async () => {

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -33,6 +33,7 @@ import {
   isTargetedHiddenTenantId,
 } from "../lib/testDataVisibilityTargets";
 import { deriveTenantSafeLeaseReadinessMetadata } from "../services/tenantPortal/tenantProjectionService";
+import { derivePaymentReadiness } from "../services/paymentReadiness/derivePaymentReadiness";
 
 const router = Router();
 const LEDGER_COLLECTION = "ledgerEntries";
@@ -291,6 +292,7 @@ async function enrichLeaseRow(raw: any) {
       : null;
   const tenantEmail =
     tenantSnap?.exists ? String(tenantSnap.data()?.email || "").trim() || null : null;
+  const leaseReadiness = deriveTenantSafeLeaseReadinessMetadata(raw, { documentUrl, leaseId: lease.id });
 
   return {
     ...lease,
@@ -298,7 +300,18 @@ async function enrichLeaseRow(raw: any) {
     tenantName,
     tenantEmail,
     documentUrl,
-    ...deriveTenantSafeLeaseReadinessMetadata(raw, { documentUrl, leaseId: lease.id }),
+    ...leaseReadiness,
+    paymentReadiness: derivePaymentReadiness({
+      leaseId: lease.id,
+      monthlyRent: lease.monthlyRent,
+      startDate: lease.startDate,
+      endDate: lease.endDate,
+      dueDay: typeof raw?.dueDay === "number" ? raw.dueDay : null,
+      tenantId,
+      propertyId,
+      unitId: String(lease.unitId || lease.unitNumber || "").trim() || null,
+      leaseExecution: leaseReadiness.leaseExecution,
+    }),
     archivedAt: raw?.archivedAt || null,
     archivedByUserId: raw?.archivedByUserId || null,
     isArchived: Boolean(raw?.archivedAt),

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -20,6 +20,7 @@ import { loadTenantIdentityRecord, loadTenantProfileProjection } from "../servic
 import { deriveTenantCredibilitySignals } from "../services/tenantCredibility/deriveTenantCredibilitySignals";
 import { deriveIdentityTimeline } from "../services/identityTimeline/deriveIdentityTimeline";
 import { deriveIdentityPortability } from "../services/identityPortability/deriveIdentityPortability";
+import { derivePaymentReadiness } from "../services/paymentReadiness/derivePaymentReadiness";
 import {
   loadTenantCommunicationsWorkspace,
   markTenantCommunicationsRead,
@@ -5317,6 +5318,15 @@ router.get("/lease", requireTenant, async (req: any, res) => {
         })
       : null;
 
+    const fallbackLeaseExecution = deriveLeaseExecution({
+      leaseId,
+      documentUrl: null,
+      startDate: null,
+      monthlyRent: null,
+      status: null,
+      raw: {},
+    });
+
     const lease = {
       ...(projectedLease || {
         leaseId,
@@ -5332,13 +5342,17 @@ router.get("/lease", requireTenant, async (req: any, res) => {
         leasePdfStatus: "not_available",
         leasePdfLabel: "Lease document unavailable",
         leasePdfDescription: "No tenant-safe lease document is available in this workspace yet.",
-        leaseExecution: deriveLeaseExecution({
+        leaseExecution: fallbackLeaseExecution,
+        paymentReadiness: derivePaymentReadiness({
           leaseId,
-          documentUrl: null,
-          startDate: null,
           monthlyRent: null,
-          status: null,
-          raw: {},
+          startDate: null,
+          endDate: null,
+          dueDay: null,
+          tenantId,
+          propertyId,
+          unitId,
+          leaseExecution: fallbackLeaseExecution,
         }),
       }),
       propertyId,

--- a/rentchain-api/src/services/paymentReadiness/__tests__/derivePaymentReadiness.test.ts
+++ b/rentchain-api/src/services/paymentReadiness/__tests__/derivePaymentReadiness.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { derivePaymentReadiness } from "../derivePaymentReadiness";
+
+describe("derivePaymentReadiness", () => {
+  it("derives not_ready when required rent terms are missing", () => {
+    const result = derivePaymentReadiness({
+      leaseId: "lease-1",
+      monthlyRent: 1800,
+      startDate: "2026-02-01",
+      endDate: null,
+      dueDay: null,
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      leaseExecution: { executionStatus: "draft" },
+    });
+
+    expect(result.readinessStatus).toBe("not_ready");
+    expect(result.requiredNextAction).toBe("review_rent_terms");
+    expect(result.rentTerms.dueDateAvailable).toBe(false);
+    expect(result.paymentSetup).toEqual({
+      processorConnected: false,
+      moneyMovementEnabled: false,
+      storedPaymentMethod: false,
+    });
+  });
+
+  it("derives ready_to_configure from complete safe lease terms", () => {
+    const result = derivePaymentReadiness({
+      leaseId: "lease-1",
+      monthlyRent: 1800,
+      startDate: "2026-02-01",
+      endDate: null,
+      dueDay: 1,
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      leaseExecution: { executionStatus: "fully_executed" },
+    });
+
+    expect(result.readinessStatus).toBe("ready_to_configure");
+    expect(result.requiredNextAction).toBe("confirm_payment_setup_later");
+    expect(result.rentTerms.leaseExecuted).toBe(true);
+    expect(result.paymentSetup).toEqual({
+      processorConnected: false,
+      moneyMovementEnabled: false,
+      storedPaymentMethod: false,
+    });
+  });
+
+  it("derives blocked when the lease record is ambiguous or blocked", () => {
+    const result = derivePaymentReadiness({
+      leaseId: "lease-1",
+      monthlyRent: null,
+      startDate: null,
+      endDate: null,
+      dueDay: null,
+      tenantId: null,
+      propertyId: null,
+      unitId: null,
+      leaseExecution: { executionStatus: "blocked" },
+    });
+
+    expect(result.readinessStatus).toBe("blocked");
+    expect(result.requiredNextAction).toBe("complete_lease_details");
+    expect(result.paymentSetup.processorConnected).toBe(false);
+    expect(result.paymentSetup.moneyMovementEnabled).toBe(false);
+    expect(result.paymentSetup.storedPaymentMethod).toBe(false);
+  });
+});

--- a/rentchain-api/src/services/paymentReadiness/derivePaymentReadiness.ts
+++ b/rentchain-api/src/services/paymentReadiness/derivePaymentReadiness.ts
@@ -1,0 +1,141 @@
+type PaymentReadinessStatus = "not_ready" | "ready_to_configure" | "blocked";
+type PaymentReadinessNextAction =
+  | "complete_lease_details"
+  | "review_rent_terms"
+  | "confirm_payment_setup_later"
+  | "none";
+
+export type PaymentReadiness = {
+  readinessStatus: PaymentReadinessStatus;
+  readinessLabel: string;
+  readinessDescription: string;
+  requiredNextAction: PaymentReadinessNextAction;
+  rentTerms: {
+    rentAmountAvailable: boolean;
+    dueDateAvailable: boolean;
+    leaseDatesAvailable: boolean;
+    tenantLinked: boolean;
+    leaseExecuted: boolean;
+  };
+  paymentSetup: {
+    processorConnected: false;
+    moneyMovementEnabled: false;
+    storedPaymentMethod: false;
+  };
+};
+
+type DerivePaymentReadinessInput = {
+  leaseId?: string | null;
+  monthlyRent?: number | null;
+  startDate?: string | null;
+  endDate?: string | null;
+  dueDay?: number | null;
+  tenantId?: string | null;
+  propertyId?: string | null;
+  unitId?: string | null;
+  leaseExecution?: {
+    executionStatus:
+      | "draft"
+      | "ready_for_tenant_signature"
+      | "tenant_signed"
+      | "ready_for_landlord_signature"
+      | "landlord_signed"
+      | "fully_executed"
+      | "blocked";
+  } | null;
+};
+
+function asString(value: unknown): string | null {
+  const next = String(value || "").trim();
+  return next || null;
+}
+
+function asNumber(value: unknown): number | null {
+  const next = Number(value);
+  return Number.isFinite(next) ? next : null;
+}
+
+export function derivePaymentReadiness(input: DerivePaymentReadinessInput): PaymentReadiness {
+  const leaseId = asString(input.leaseId);
+  const monthlyRent = asNumber(input.monthlyRent);
+  const dueDay = asNumber(input.dueDay);
+  const startDate = asString(input.startDate);
+  const endDate = asString(input.endDate);
+  const tenantId = asString(input.tenantId);
+  const propertyId = asString(input.propertyId);
+  const unitId = asString(input.unitId);
+  const executionStatus = input.leaseExecution?.executionStatus || null;
+
+  const rentAmountAvailable = typeof monthlyRent === "number" && monthlyRent > 0;
+  const dueDateAvailable = typeof dueDay === "number" && dueDay >= 1 && dueDay <= 31;
+  const leaseDatesAvailable = Boolean(startDate && (endDate || !endDate));
+  const tenantLinked = Boolean(tenantId && propertyId && unitId);
+  const leaseExecuted = executionStatus === "fully_executed";
+
+  if (!leaseId || executionStatus === "blocked") {
+    return {
+      readinessStatus: "blocked",
+      readinessLabel: "Lease details needed",
+      readinessDescription:
+        "This lease record does not expose enough current rent-term detail to describe future payment setup readiness safely.",
+      requiredNextAction: "complete_lease_details",
+      rentTerms: {
+        rentAmountAvailable,
+        dueDateAvailable,
+        leaseDatesAvailable,
+        tenantLinked,
+        leaseExecuted,
+      },
+      paymentSetup: {
+        processorConnected: false,
+        moneyMovementEnabled: false,
+        storedPaymentMethod: false,
+      },
+    };
+  }
+
+  if (rentAmountAvailable && dueDateAvailable && leaseDatesAvailable && tenantLinked) {
+    return {
+      readinessStatus: "ready_to_configure",
+      readinessLabel: "Rent terms ready for future setup",
+      readinessDescription:
+        "The current lease shows the core rent terms and tenancy linkage needed for a future payment setup workflow, without enabling any payment activity today.",
+      requiredNextAction: "confirm_payment_setup_later",
+      rentTerms: {
+        rentAmountAvailable,
+        dueDateAvailable,
+        leaseDatesAvailable,
+        tenantLinked,
+        leaseExecuted,
+      },
+      paymentSetup: {
+        processorConnected: false,
+        moneyMovementEnabled: false,
+        storedPaymentMethod: false,
+      },
+    };
+  }
+
+  const missingCoreLeaseDetails = !rentAmountAvailable || !leaseDatesAvailable || !tenantLinked;
+
+  return {
+    readinessStatus: "not_ready",
+    readinessLabel: missingCoreLeaseDetails ? "Lease details needed" : "Review rent terms",
+    readinessDescription: missingCoreLeaseDetails
+      ? "Some lease details are still missing before this lease can be considered ready for any future payment setup planning."
+      : "The lease is visible, but some rent-term details should be reviewed before future payment setup planning.",
+    requiredNextAction: missingCoreLeaseDetails ? "complete_lease_details" : "review_rent_terms",
+    rentTerms: {
+      rentAmountAvailable,
+      dueDateAvailable,
+      leaseDatesAvailable,
+      tenantLinked,
+      leaseExecuted,
+    },
+    paymentSetup: {
+      processorConnected: false,
+      moneyMovementEnabled: false,
+      storedPaymentMethod: false,
+    },
+  };
+}

--- a/rentchain-api/src/services/tenantPortal/tenantProjectionService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantProjectionService.ts
@@ -1,4 +1,5 @@
 import { deriveLeaseExecution, type LeaseExecution } from "../leaseExecution/deriveLeaseExecution";
+import { derivePaymentReadiness, type PaymentReadiness } from "../paymentReadiness/derivePaymentReadiness";
 
 type TenantPropertyProjection = {
   propertyId: string;
@@ -16,6 +17,7 @@ type TenantLeaseProjection = {
   startDate: string | null;
   endDate: string | null;
   monthlyRent: number | null;
+  dueDay?: number | null;
   status: string | null;
   documentUrl: string | null;
   signatureStatus:
@@ -35,6 +37,7 @@ type TenantLeaseProjection = {
   leasePdfLabel: string;
   leasePdfDescription: string;
   leaseExecution: LeaseExecution;
+  paymentReadiness: PaymentReadiness;
 };
 
 type TenantApplicationProjection = {
@@ -357,18 +360,36 @@ export function projectTenantProperty(recordId: string, data: any): TenantProper
 export function projectTenantLease(recordId: string, data: any): TenantLeaseProjection {
   const documentUrl =
     asString(data?.documentUrl) || asString(data?.approvedDocumentUrl) || asString(data?.documentRef);
+  const startDate = asString(data?.startDate) || asString(data?.leaseStart);
+  const endDate = asString(data?.endDate) || asString(data?.leaseEnd);
+  const monthlyRent =
+    asNumber(data?.monthlyRent) ??
+    asNumber(data?.rentAmount) ??
+    (typeof data?.rentCents === "number" ? Math.round(data.rentCents) / 100 : null);
+  const dueDay = asNumber(data?.dueDay);
+  const leaseReadiness = deriveTenantSafeLeaseReadinessMetadata(data, { documentUrl, leaseId: recordId });
+  const leaseExecution = leaseReadiness.leaseExecution;
 
   return {
     leaseId: recordId,
-    startDate: asString(data?.startDate) || asString(data?.leaseStart),
-    endDate: asString(data?.endDate) || asString(data?.leaseEnd),
-    monthlyRent:
-      asNumber(data?.monthlyRent) ??
-      asNumber(data?.rentAmount) ??
-      (typeof data?.rentCents === "number" ? Math.round(data.rentCents) / 100 : null),
+    startDate,
+    endDate,
+    monthlyRent,
+    dueDay,
     status: asString(data?.status),
     documentUrl,
-    ...deriveTenantSafeLeaseReadinessMetadata(data, { documentUrl, leaseId: recordId }),
+    ...leaseReadiness,
+    paymentReadiness: derivePaymentReadiness({
+      leaseId: recordId,
+      monthlyRent,
+      startDate,
+      endDate,
+      dueDay,
+      tenantId: asString(data?.primaryTenantId) || asString(data?.tenantId) || asString(data?.tenantIds?.[0]),
+      propertyId: asString(data?.propertyId),
+      unitId: asString(data?.unitId) || asString(data?.unitNumber) || asString(data?.unit),
+      leaseExecution,
+    }),
   };
 }
 

--- a/rentchain-frontend/src/api/leasesApi.ts
+++ b/rentchain-frontend/src/api/leasesApi.ts
@@ -82,6 +82,24 @@ export interface LandlordActiveLease extends Lease {
     pdfStatus: "not_ready" | "ready" | "generated" | "blocked";
     completedAt: string | null;
   } | null;
+  paymentReadiness?: {
+    readinessStatus: "not_ready" | "ready_to_configure" | "blocked";
+    readinessLabel: string;
+    readinessDescription: string;
+    requiredNextAction: "complete_lease_details" | "review_rent_terms" | "confirm_payment_setup_later" | "none";
+    rentTerms: {
+      rentAmountAvailable: boolean;
+      dueDateAvailable: boolean;
+      leaseDatesAvailable: boolean;
+      tenantLinked: boolean;
+      leaseExecuted: boolean;
+    };
+    paymentSetup: {
+      processorConnected: false;
+      moneyMovementEnabled: false;
+      storedPaymentMethod: false;
+    };
+  } | null;
   hiddenFromActiveLists?: boolean;
   cleanupReason?: string | null;
   cleanupBatch?: string | null;

--- a/rentchain-frontend/src/api/tenantPortal.ts
+++ b/rentchain-frontend/src/api/tenantPortal.ts
@@ -37,6 +37,7 @@ export type TenantWorkspaceLease = {
   startDate: string | null;
   endDate: string | null;
   monthlyRent: number | null;
+  dueDay?: number | null;
   status: string | null;
   documentUrl: string | null;
   signatureStatus?: "not_started" | "awaiting_tenant_signature" | "awaiting_landlord_signature" | "signed" | "unavailable";
@@ -72,6 +73,7 @@ export type TenantWorkspaceLease = {
     pdfStatus: "not_ready" | "ready" | "generated" | "blocked";
     completedAt: string | null;
   } | null;
+  paymentReadiness?: PaymentReadiness | null;
   depositCents?: number | null;
   depositRequired?: boolean | null;
   depositReceived?: boolean | null;
@@ -80,6 +82,25 @@ export type TenantWorkspaceLease = {
   paymentStatus?: string | null;
   paymentRequestedAt?: string | null;
   paymentCompletedAt?: string | null;
+};
+
+export type PaymentReadiness = {
+  readinessStatus: "not_ready" | "ready_to_configure" | "blocked";
+  readinessLabel: string;
+  readinessDescription: string;
+  requiredNextAction: "complete_lease_details" | "review_rent_terms" | "confirm_payment_setup_later" | "none";
+  rentTerms: {
+    rentAmountAvailable: boolean;
+    dueDateAvailable: boolean;
+    leaseDatesAvailable: boolean;
+    tenantLinked: boolean;
+    leaseExecuted: boolean;
+  };
+  paymentSetup: {
+    processorConnected: false;
+    moneyMovementEnabled: false;
+    storedPaymentMethod: false;
+  };
 };
 
 export type TenantWorkspaceMaintenance = {

--- a/rentchain-frontend/src/api/tenantPortalApi.ts
+++ b/rentchain-frontend/src/api/tenantPortalApi.ts
@@ -55,6 +55,24 @@ export interface TenantLease {
     pdfStatus: "not_ready" | "ready" | "generated" | "blocked";
     completedAt: string | null;
   } | null;
+  paymentReadiness?: {
+    readinessStatus: "not_ready" | "ready_to_configure" | "blocked";
+    readinessLabel: string;
+    readinessDescription: string;
+    requiredNextAction: "complete_lease_details" | "review_rent_terms" | "confirm_payment_setup_later" | "none";
+    rentTerms: {
+      rentAmountAvailable: boolean;
+      dueDateAvailable: boolean;
+      leaseDatesAvailable: boolean;
+      tenantLinked: boolean;
+      leaseExecuted: boolean;
+    };
+    paymentSetup: {
+      processorConnected: false;
+      moneyMovementEnabled: false;
+      storedPaymentMethod: false;
+    };
+  } | null;
 }
 
 export interface TenantPayment {

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
@@ -51,6 +51,25 @@ describe("LandlordActiveLeasesPage", () => {
             pdfStatus: "generated",
             completedAt: "2026-01-01T00:00:00.000Z",
           },
+          paymentReadiness: {
+            readinessStatus: "ready_to_configure",
+            readinessLabel: "Rent terms ready for future setup",
+            readinessDescription:
+              "The current lease shows the core rent terms and tenancy linkage needed for a future payment setup workflow, without enabling any payment activity today.",
+            requiredNextAction: "confirm_payment_setup_later",
+            rentTerms: {
+              rentAmountAvailable: true,
+              dueDateAvailable: true,
+              leaseDatesAvailable: true,
+              tenantLinked: true,
+              leaseExecuted: true,
+            },
+            paymentSetup: {
+              processorConnected: false,
+              moneyMovementEnabled: false,
+              storedPaymentMethod: false,
+            },
+          },
         },
       ],
     });
@@ -95,6 +114,7 @@ describe("LandlordActiveLeasesPage", () => {
     expect((await screen.findAllByText("Harbour View")).length).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: "Print / Save PDF" })).toBeInTheDocument();
     expect(screen.getAllByText("Lease fully executed").length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Rent terms ready for future setup/i).length).toBeGreaterThan(0);
     expect(screen.getByRole("link", { name: "View" })).toHaveAttribute("href", "/leases/lease-1/ledger");
     expect(screen.getByRole("link", { name: "Email" })).toHaveAttribute(
       "href",

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
@@ -137,6 +137,18 @@ function executionNextActionLabel(value: string | null | undefined) {
   }
 }
 
+function paymentReadinessChecklist(lease: LandlordActiveLease) {
+  const readiness = lease.paymentReadiness;
+  if (!readiness) return "Payment readiness unavailable";
+  const missing: string[] = [];
+  if (!readiness.rentTerms.rentAmountAvailable) missing.push("Rent amount missing");
+  if (!readiness.rentTerms.dueDateAvailable) missing.push("Due day missing");
+  if (!readiness.rentTerms.leaseDatesAvailable) missing.push("Lease dates missing");
+  if (!readiness.rentTerms.tenantLinked) missing.push("Tenant or unit linkage missing");
+  if (missing.length === 0) return readiness.readinessLabel;
+  return missing.join(" · ");
+}
+
 export default function LandlordActiveLeasesPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const view = searchParams.get("view") === "archived" ? "archived" : "active";
@@ -272,6 +284,7 @@ export default function LandlordActiveLeasesPage() {
               <th>Unit</th>
               <th>Tenant</th>
               <th>Status</th>
+              <th>Payment readiness</th>
             </tr>
           </thead>
           <tbody>
@@ -281,6 +294,7 @@ export default function LandlordActiveLeasesPage() {
                 <td>{lease.unitNumber || "—"}</td>
                 <td>{lease.tenantName || "—"}</td>
                 <td>{prettyLeaseStatus(lease.status)}</td>
+                <td>{lease.paymentReadiness?.readinessLabel || "Payment readiness unavailable"}</td>
               </tr>
             ))}
           </tbody>
@@ -502,6 +516,16 @@ export default function LandlordActiveLeasesPage() {
                       {lease.archivedAt ? (
                         <div style={{ color: "#64748b", fontSize: 12, marginTop: 4 }}>
                           Archived {formatDate(lease.archivedAt)}
+                        </div>
+                      ) : null}
+                      {lease.paymentReadiness ? (
+                        <div style={{ display: "grid", gap: 4, marginTop: 6 }}>
+                          <div style={{ fontSize: 12, fontWeight: 700, color: "#0f172a" }}>
+                            {lease.paymentReadiness.readinessLabel}
+                          </div>
+                          <div style={{ color: "#64748b", fontSize: 12 }}>
+                            {paymentReadinessChecklist(lease)}
+                          </div>
                         </div>
                       ) : null}
                     </td>

--- a/rentchain-frontend/src/pages/tenant/TenantLeasePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantLeasePage.tsx
@@ -49,6 +49,7 @@ export default function TenantLeasePage() {
   }
 
   const execution = data?.leaseExecution || null;
+  const paymentReadiness = data?.paymentReadiness || null;
   const timelineRows = execution
     ? [
         {
@@ -112,6 +113,41 @@ export default function TenantLeasePage() {
               ]}
             />
           </TenantInfoCard>
+
+          {paymentReadiness ? (
+            <TenantInfoCard heading="Payment readiness" accent="#1d4ed8">
+              <div style={{ display: "grid", gap: 12 }}>
+                <div style={{ display: "grid", gap: 6 }}>
+                  <div style={{ fontWeight: 800 }}>{paymentReadiness.readinessLabel}</div>
+                  <div style={{ color: "var(--text-muted, #64748b)" }}>{paymentReadiness.readinessDescription}</div>
+                </div>
+                <TenantKeyValueGrid
+                  rows={[
+                    {
+                      label: "Rent amount",
+                      value: paymentReadiness.rentTerms.rentAmountAvailable ? "Available" : "Needed",
+                    },
+                    {
+                      label: "Due day",
+                      value: paymentReadiness.rentTerms.dueDateAvailable ? "Available" : "Needed",
+                    },
+                    {
+                      label: "Lease dates",
+                      value: paymentReadiness.rentTerms.leaseDatesAvailable ? "Available" : "Needed",
+                    },
+                    {
+                      label: "Tenant linked",
+                      value: paymentReadiness.rentTerms.tenantLinked ? "Linked" : "Needs review",
+                    },
+                    {
+                      label: "Lease executed",
+                      value: paymentReadiness.rentTerms.leaseExecuted ? "Complete" : "In progress",
+                    },
+                  ]}
+                />
+              </div>
+            </TenantInfoCard>
+          ) : null}
 
           <TenantInfoCard heading="Lease Document" accent="#0f766e">
             {data.leasePdfLabel ? (

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -469,6 +469,25 @@ describe("tenant workspace frontend shell", () => {
         monthlyRent: 1800,
         status: "active",
         documentUrl: null,
+        paymentReadiness: {
+          readinessStatus: "ready_to_configure",
+          readinessLabel: "Rent terms ready for future setup",
+          readinessDescription:
+            "The current lease shows the core rent terms and tenancy linkage needed for a future payment setup workflow, without enabling any payment activity today.",
+          requiredNextAction: "confirm_payment_setup_later",
+          rentTerms: {
+            rentAmountAvailable: true,
+            dueDateAvailable: true,
+            leaseDatesAvailable: true,
+            tenantLinked: true,
+            leaseExecuted: false,
+          },
+          paymentSetup: {
+            processorConnected: false,
+            moneyMovementEnabled: false,
+            storedPaymentMethod: false,
+          },
+        },
       },
       maintenance: [],
       tenantIdentityRecord: {
@@ -543,6 +562,7 @@ describe("tenant workspace frontend shell", () => {
     expect(screen.getByText(/^Your Rental Identity$/i)).toBeInTheDocument();
     expect(screen.getByText(/^Credibility signals$/i)).toBeInTheDocument();
     expect(screen.getByText(/^Portable Rental Identity$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^Payment readiness$/i)).toBeInTheDocument();
     expect(screen.getByText(/^Activity timeline$/i)).toBeInTheDocument();
     expect(screen.getByText("Identity ready")).toBeInTheDocument();
     expect(screen.getByText("Sharing controls available")).toBeInTheDocument();
@@ -554,6 +574,8 @@ describe("tenant workspace frontend shell", () => {
     expect(screen.getByText(/Screening completed/i)).toBeInTheDocument();
     expect(screen.getByText(/Lease history present/i)).toBeInTheDocument();
     expect(screen.getByText(/Ready to apply/i)).toBeInTheDocument();
+    expect(screen.getByText(/Rent terms ready for future setup/i)).toBeInTheDocument();
+    expect(screen.getByText(/Confirm payment setup later/i)).toBeInTheDocument();
     expect(screen.getByText(/^Application created$/i)).toBeInTheDocument();
     expect(screen.getByText(/A rental application record was started\./i)).toBeInTheDocument();
     expect(screen.getByText(/Missing pieces/i)).toBeInTheDocument();
@@ -871,6 +893,25 @@ describe("tenant workspace frontend shell", () => {
         pdfStatus: "generated",
         completedAt: "2026-02-02T12:00:00.000Z",
       },
+      paymentReadiness: {
+        readinessStatus: "ready_to_configure",
+        readinessLabel: "Rent terms ready for future setup",
+        readinessDescription:
+          "The current lease shows the core rent terms and tenancy linkage needed for a future payment setup workflow, without enabling any payment activity today.",
+        requiredNextAction: "confirm_payment_setup_later",
+        rentTerms: {
+          rentAmountAvailable: true,
+          dueDateAvailable: true,
+          leaseDatesAvailable: true,
+          tenantLinked: true,
+          leaseExecuted: true,
+        },
+        paymentSetup: {
+          processorConnected: false,
+          moneyMovementEnabled: false,
+          storedPaymentMethod: false,
+        },
+      },
     });
 
     render(
@@ -884,6 +925,7 @@ describe("tenant workspace frontend shell", () => {
     expect(screen.getByText(/^Lease signing complete$/i)).toBeInTheDocument();
     expect(screen.getByText(/^Lease document available$/i)).toBeInTheDocument();
     expect(screen.getByText(/^Lease fully executed$/i)).toBeInTheDocument();
+    expect(screen.getByText(/Rent terms ready for future setup/i)).toBeInTheDocument();
     expect(screen.getByText(/^Drawn signature$/i)).toBeInTheDocument();
     expect(screen.getByText(/^Taylor Tenant$/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Open lease document/i })).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
@@ -427,6 +427,63 @@ export default function TenantWorkspacePage() {
         />
       </TenantInfoCard>
 
+      <TenantInfoCard heading="Payment readiness" accent="#1d4ed8">
+        {data?.lease?.paymentReadiness ? (
+          <div style={{ display: "grid", gap: spacing.sm }}>
+            <div style={{ display: "grid", gap: 4 }}>
+              <div style={{ fontSize: "1.02rem", fontWeight: 800, color: textTokens.primary }}>
+                {data.lease.paymentReadiness.readinessLabel}
+              </div>
+              <div style={{ color: textTokens.secondary, lineHeight: 1.6 }}>
+                {data.lease.paymentReadiness.readinessDescription}
+              </div>
+            </div>
+
+            <TenantKeyValueGrid
+              rows={[
+                {
+                  label: "Rent amount",
+                  value: data.lease.paymentReadiness.rentTerms.rentAmountAvailable ? "Available" : "Needed",
+                },
+                {
+                  label: "Due day",
+                  value: data.lease.paymentReadiness.rentTerms.dueDateAvailable ? "Available" : "Needed",
+                },
+                {
+                  label: "Lease dates",
+                  value: data.lease.paymentReadiness.rentTerms.leaseDatesAvailable ? "Available" : "Needed",
+                },
+                {
+                  label: "Tenant linked",
+                  value: data.lease.paymentReadiness.rentTerms.tenantLinked ? "Linked" : "Needs review",
+                },
+                {
+                  label: "Lease executed",
+                  value: data.lease.paymentReadiness.rentTerms.leaseExecuted ? "Complete" : "In progress",
+                },
+              ]}
+            />
+
+            <div style={{ color: textTokens.secondary }}>
+              Next step:{" "}
+              <strong>
+                {data.lease.paymentReadiness.requiredNextAction === "complete_lease_details"
+                  ? "Complete lease details"
+                  : data.lease.paymentReadiness.requiredNextAction === "review_rent_terms"
+                  ? "Review rent terms"
+                  : data.lease.paymentReadiness.requiredNextAction === "confirm_payment_setup_later"
+                  ? "Confirm payment setup later"
+                  : "No immediate follow-up"}
+              </strong>
+            </div>
+          </div>
+        ) : (
+          <div style={{ color: textTokens.secondary }}>
+            Payment readiness will appear here when your current lease exposes enough rent-term detail for future setup planning.
+          </div>
+        )}
+      </TenantInfoCard>
+
       <TenantInfoCard heading="Recent activity / notifications" accent="#0891b2">
         <StructuredNotificationList
           heading="Recent workflow updates"


### PR DESCRIPTION
This PR introduces Payment Readiness v1.

Includes:
- read-derived paymentReadiness model across tenant and landlord lease surfaces
- tenant workspace and tenant lease payment readiness cards
- landlord active lease readiness labels/checklist
- print-friendly payment readiness summary column/line
- deterministic readiness derivation based on existing lease rent terms
- focused backend/frontend test coverage

Guardrails preserved:
- strictly pre-payment (no money movement)
- no Stripe/provider changes
- no bank/card/stored-method logic
- no invoices/receipts/ledger
- no payment initiation or rent collection UI
- all payment capability flags explicitly false
- no dashboard rollups or landlord inbox integration
- no permission expansion or unrelated changes