### PR TITLE
feat: add tenant identity exchange

### DIFF
--- a/rentchain-api/src/routes/__tests__/publicTenantShareRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/publicTenantShareRoutes.test.ts
@@ -2,8 +2,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const readTenantSharePackageByToken = vi.fn();
 const requestTenantSharePackageItems = vi.fn();
+const createTenantShareVerificationRequest = vi.fn();
 
 vi.mock("../../services/tenantPortal/tenantSharePackageService", () => ({
+  createTenantShareVerificationRequest,
   readTenantSharePackageByToken,
   requestTenantSharePackageItems,
 }));
@@ -11,7 +13,8 @@ vi.mock("../../services/tenantPortal/tenantSharePackageService", () => ({
 async function invokeRouter(router: any, options: { method: string; url: string; body?: any }) {
   return await new Promise<{ status: number; body: any }>((resolve, reject) => {
     const path = options.url;
-    const token = path.split("/").pop() || "";
+    const segments = path.split("/").filter(Boolean);
+    const token = segments[1] || "";
     const req: any = {
       method: options.method,
       url: path,
@@ -106,5 +109,30 @@ describe("publicTenantShareRoutes", () => {
       requestedItems: ["credibility_summary", "unknown_key", "documents_summary"],
     });
     expect(res.body?.data?.requestedItems).toEqual(["credibility_summary", "documents_summary"]);
+  });
+
+  it("creates a verification request through a valid share token without exposing request internals", async () => {
+    createTenantShareVerificationRequest.mockResolvedValue({
+      status: "requested",
+      requestedScopes: ["lease_summary", "payment_readiness_summary"],
+    });
+
+    const router = (await import("../publicTenantShareRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/share/share-token-1/verification-request",
+      body: {
+        requestedScopes: ["lease_summary", "payment_readiness_summary", "unknown_key"],
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(createTenantShareVerificationRequest).toHaveBeenCalledWith({
+      token: "share-token-1",
+      requestedScopes: ["lease_summary", "payment_readiness_summary", "unknown_key"],
+      requestedByType: "landlord",
+    });
+    expect(res.body?.data?.status).toBe("requested");
+    expect(res.body?.data?.requestId).toBeUndefined();
   });
 });

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -761,7 +761,10 @@ describe("tenantPortalRoutes foundation", () => {
       credibilitySummary: false,
       applicationSummary: false,
       documents: "none",
+      leaseSummary: false,
+      paymentReadinessSummary: false,
     });
+    expect(shareDocs[0]?.verificationRequests).toEqual([]);
   });
 
   it("lists only active tenant share packages", async () => {
@@ -803,6 +806,7 @@ describe("tenantPortalRoutes foundation", () => {
         status: "active",
         requestedItems: [],
         approvedItems: [],
+        verificationRequests: [],
       }),
     ]);
   });
@@ -880,7 +884,86 @@ describe("tenantPortalRoutes foundation", () => {
           credibilitySummary: true,
           applicationSummary: false,
           documents: "approved_only",
+          leaseSummary: false,
+          paymentReadinessSummary: false,
         },
+      })
+    );
+  });
+
+  it("lets a tenant approve and revoke verification requests only on their own share link", async () => {
+    ensureCollection("tenantSharePackages").set("share-1", {
+      id: "share-1",
+      tenantId: "tenant-1",
+      tokenHash: "hash-1",
+      createdAt: 100,
+      expiresAt: Date.now() + 10_000,
+      status: "active",
+      verificationRequests: [
+        {
+          requestId: "req-1",
+          requestedByType: "landlord",
+          requestedScopes: ["lease_summary", "payment_readiness_summary"],
+          status: "requested",
+          createdAt: Date.now(),
+        },
+      ],
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const approveRes = await invokeRouter(router, {
+      method: "POST",
+      url: "/share-packages/share-1/verification-requests/req-1/respond",
+      body: {
+        approvedScopes: ["payment_readiness_summary"],
+      },
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(approveRes.status).toBe(200);
+    expect(ensureCollection("tenantSharePackages").get("share-1")).toEqual(
+      expect.objectContaining({
+        approvedItems: ["payment_readiness_summary"],
+        verificationRequests: expect.arrayContaining([
+          expect.objectContaining({
+            requestId: "req-1",
+            status: "approved",
+            requestedScopes: ["payment_readiness_summary"],
+          }),
+        ]),
+      })
+    );
+
+    const revokeRes = await invokeRouter(router, {
+      method: "POST",
+      url: "/share-packages/share-1/verification-requests/req-1/revoke",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(revokeRes.status).toBe(200);
+    expect(ensureCollection("tenantSharePackages").get("share-1")).toEqual(
+      expect.objectContaining({
+        approvedItems: [],
+        verificationRequests: expect.arrayContaining([
+          expect.objectContaining({
+            requestId: "req-1",
+            status: "revoked",
+          }),
+        ]),
       })
     );
   });

--- a/rentchain-api/src/routes/publicTenantShareRoutes.ts
+++ b/rentchain-api/src/routes/publicTenantShareRoutes.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import {
+  createTenantShareVerificationRequest,
   readTenantSharePackageByToken,
   requestTenantSharePackageItems,
 } from "../services/tenantPortal/tenantSharePackageService";
@@ -43,6 +44,29 @@ router.post("/share/:token/request", async (req: any, res) => {
     return res.json({ ok: true, data: result });
   } catch (err: any) {
     console.error("[public-tenant-share] request failed", err?.message || err);
+    return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+  }
+});
+
+router.post("/share/:token/verification-request", async (req: any, res) => {
+  try {
+    const token = String(req.params?.token || "").trim();
+    if (!token) {
+      return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+    }
+
+    const result = await createTenantShareVerificationRequest({
+      token,
+      requestedScopes: req.body?.requestedScopes,
+      requestedByType: "landlord",
+    });
+    if (!result) {
+      return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+    }
+
+    return res.json({ ok: true, data: result });
+  } catch (err: any) {
+    console.error("[public-tenant-share] verification request failed", err?.message || err);
     return res.status(404).json({ ok: false, error: "NOT_FOUND" });
   }
 });

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -37,7 +37,9 @@ import { adaptTenantSafeScreeningState } from "../services/screening/tenantScree
 import {
   createTenantSharePackage,
   listTenantSharePackages,
+  respondToTenantShareVerificationRequest,
   respondToTenantSharePackage,
+  revokeTenantShareVerificationRequest,
   revokeTenantSharePackage,
 } from "../services/tenantPortal/tenantSharePackageService";
 
@@ -3071,6 +3073,79 @@ router.post("/share-packages/:id/respond", requireTenantWorkspaceIdentity, async
     return res.status(500).json({ ok: false, error: "TENANT_SHARE_PACKAGE_RESPOND_FAILED" });
   }
 });
+
+router.post(
+  "/share-packages/:id/verification-requests/:requestId/respond",
+  requireTenantWorkspaceIdentity,
+  async (req: any, res) => {
+    const context = await resolveWorkspaceContextOrRespond(req, res);
+    if (!context) return;
+
+    const tenantId = String(req.user?.tenantId || context.tenantId || "").trim();
+    const sharePackageId = String(req.params?.id || "").trim();
+    const requestId = String(req.params?.requestId || "").trim();
+    if (!tenantId || !sharePackageId || !requestId) {
+      return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+    }
+
+    try {
+      const updated = await respondToTenantShareVerificationRequest({
+        tenantId,
+        sharePackageId,
+        requestId,
+        approvedScopes: req.body?.approvedScopes,
+      });
+      if (!updated) {
+        return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+      }
+      return res.json({ ok: true, data: updated });
+    } catch (err: any) {
+      console.error("[tenant/share-packages:verification-respond] failed", {
+        tenantId,
+        sharePackageId,
+        requestId,
+        message: err?.message || "failed",
+      });
+      return res.status(500).json({ ok: false, error: "TENANT_SHARE_VERIFICATION_RESPOND_FAILED" });
+    }
+  }
+);
+
+router.post(
+  "/share-packages/:id/verification-requests/:requestId/revoke",
+  requireTenantWorkspaceIdentity,
+  async (req: any, res) => {
+    const context = await resolveWorkspaceContextOrRespond(req, res);
+    if (!context) return;
+
+    const tenantId = String(req.user?.tenantId || context.tenantId || "").trim();
+    const sharePackageId = String(req.params?.id || "").trim();
+    const requestId = String(req.params?.requestId || "").trim();
+    if (!tenantId || !sharePackageId || !requestId) {
+      return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+    }
+
+    try {
+      const updated = await revokeTenantShareVerificationRequest({
+        tenantId,
+        sharePackageId,
+        requestId,
+      });
+      if (!updated) {
+        return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+      }
+      return res.json({ ok: true, data: updated });
+    } catch (err: any) {
+      console.error("[tenant/share-packages:verification-revoke] failed", {
+        tenantId,
+        sharePackageId,
+        requestId,
+        message: err?.message || "failed",
+      });
+      return res.status(500).json({ ok: false, error: "TENANT_SHARE_VERIFICATION_REVOKE_FAILED" });
+    }
+  }
+);
 
 router.get("/notification-preferences", requireTenantWorkspaceIdentity, async (req: any, res) => {
   const userId = String(req.user?.id || "").trim();

--- a/rentchain-api/src/services/identityExchange/__tests__/deriveIdentityExchangeReference.test.ts
+++ b/rentchain-api/src/services/identityExchange/__tests__/deriveIdentityExchangeReference.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { deriveIdentityExchangeReference } from "../deriveIdentityExchangeReference";
+
+describe("deriveIdentityExchangeReference", () => {
+  it("derives an available reference from ready portability and safe readiness signals", () => {
+    const result = deriveIdentityExchangeReference({
+      portableIdentity: {
+        portabilityStatus: "ready",
+        portabilityLabel: "Ready to reuse",
+        portabilityDescription: "ready",
+        reusableAcrossApplications: true,
+        identityReference: {
+          referenceType: "tenant_identity",
+          referenceStatus: "active",
+        },
+        readiness: {
+          identityReady: true,
+          applicationReusable: true,
+          credibilityReady: true,
+          sharingEnabled: true,
+        },
+        nextAction: "none",
+      },
+      auditTimelineReady: true,
+      paymentReadinessAvailable: true,
+      sharingControlsReady: true,
+    });
+
+    expect(result.referenceStatus).toBe("available");
+    expect(result.referenceType).toBe("tenant_identity_reference");
+    expect(result.exchangeReadiness.identityReady).toBe(true);
+  });
+
+  it("derives a limited reference when only partial signals exist", () => {
+    const result = deriveIdentityExchangeReference({
+      portableIdentity: {
+        portabilityStatus: "limited",
+        portabilityLabel: "Almost portable",
+        portabilityDescription: "limited",
+        reusableAcrossApplications: false,
+        identityReference: {
+          referenceType: "tenant_identity",
+          referenceStatus: "limited",
+        },
+        readiness: {
+          identityReady: true,
+          applicationReusable: false,
+          credibilityReady: false,
+          sharingEnabled: false,
+        },
+        nextAction: "review_reusability",
+      },
+      auditTimelineReady: false,
+      paymentReadinessAvailable: false,
+      sharingControlsReady: false,
+    });
+
+    expect(result.referenceStatus).toBe("limited");
+  });
+
+  it("derives not_ready when no safe readiness signals are present", () => {
+    const result = deriveIdentityExchangeReference({
+      portableIdentity: null,
+      auditTimelineReady: false,
+      paymentReadinessAvailable: false,
+      sharingControlsReady: false,
+    });
+
+    expect(result.referenceStatus).toBe("not_ready");
+    expect(result.exchangeReadiness.credibilityReady).toBe(false);
+  });
+});

--- a/rentchain-api/src/services/identityExchange/deriveIdentityExchangeReference.ts
+++ b/rentchain-api/src/services/identityExchange/deriveIdentityExchangeReference.ts
@@ -1,0 +1,94 @@
+import type { PortableIdentity } from "../identityPortability/deriveIdentityPortability";
+
+export type IdentityExchangeReferenceStatus = "available" | "limited" | "not_ready";
+
+export type IdentityExchangeReference = {
+  referenceType: "tenant_identity_reference";
+  referenceStatus: IdentityExchangeReferenceStatus;
+  referenceLabel: string;
+  referenceDescription: string;
+  portabilityStatus: "ready" | "limited" | "not_ready";
+  exchangeReadiness: {
+    identityReady: boolean;
+    credibilityReady: boolean;
+    sharingControlsReady: boolean;
+    auditTimelineReady: boolean;
+    paymentReadinessAvailable: boolean;
+  };
+};
+
+type DeriveIdentityExchangeReferenceInput = {
+  portableIdentity: PortableIdentity | null;
+  auditTimelineReady: boolean;
+  paymentReadinessAvailable: boolean;
+  sharingControlsReady: boolean;
+};
+
+function buildCopy(
+  status: IdentityExchangeReferenceStatus
+): Pick<IdentityExchangeReference, "referenceLabel" | "referenceDescription"> {
+  if (status === "available") {
+    return {
+      referenceLabel: "Identity exchange available",
+      referenceDescription:
+        "This rental identity can support summary-only exchange requests within the tenant-controlled sharing flow.",
+    };
+  }
+
+  if (status === "limited") {
+    return {
+      referenceLabel: "Identity exchange limited",
+      referenceDescription:
+        "Some exchange-readiness signals are available, but a few identity or workflow details still need attention.",
+    };
+  }
+
+  return {
+    referenceLabel: "Identity exchange not ready",
+    referenceDescription:
+      "More identity or workflow detail is needed before this rental identity is ready for broader exchange scaffolding.",
+  };
+}
+
+export function deriveIdentityExchangeReference(
+  input: DeriveIdentityExchangeReferenceInput
+): IdentityExchangeReference {
+  const portableIdentity = input.portableIdentity || null;
+  const identityReady = Boolean(portableIdentity?.readiness.identityReady);
+  const credibilityReady = Boolean(portableIdentity?.readiness.credibilityReady);
+  const sharingControlsReady = Boolean(input.sharingControlsReady);
+  const auditTimelineReady = Boolean(input.auditTimelineReady);
+  const paymentReadinessAvailable = Boolean(input.paymentReadinessAvailable);
+  const portabilityStatus = portableIdentity?.portabilityStatus || "not_ready";
+
+  let referenceStatus: IdentityExchangeReferenceStatus = "not_ready";
+  if (identityReady && credibilityReady && sharingControlsReady) {
+    referenceStatus = "available";
+  } else if (
+    identityReady ||
+    credibilityReady ||
+    sharingControlsReady ||
+    auditTimelineReady ||
+    paymentReadinessAvailable ||
+    portabilityStatus === "limited" ||
+    portabilityStatus === "ready"
+  ) {
+    referenceStatus = "limited";
+  }
+
+  const copy = buildCopy(referenceStatus);
+  return {
+    referenceType: "tenant_identity_reference",
+    referenceStatus,
+    referenceLabel: copy.referenceLabel,
+    referenceDescription: copy.referenceDescription,
+    portabilityStatus,
+    exchangeReadiness: {
+      identityReady,
+      credibilityReady,
+      sharingControlsReady,
+      auditTimelineReady,
+      paymentReadinessAvailable,
+    },
+  };
+}

--- a/rentchain-api/src/services/tenantPortal/__tests__/tenantSharePackageService.test.ts
+++ b/rentchain-api/src/services/tenantPortal/__tests__/tenantSharePackageService.test.ts
@@ -10,6 +10,13 @@ function ensureCollection(name: string) {
 
 const dbMock = {
   collection: (name: string) => ({
+    async get() {
+      const docs = Array.from(ensureCollection(name).entries()).map(([id, data]) => ({
+        id,
+        data: () => data,
+      }));
+      return { docs, empty: docs.length === 0 };
+    },
     doc: (id?: string) => {
       const resolvedId = id || `generated-${++generatedId}`;
       return {
@@ -68,6 +75,16 @@ describe("tenantSharePackageService", () => {
     ensureCollection("tenants").set("tenant-1", {
       email: "tenant@example.com",
     });
+    ensureCollection("leases").set("lease-1", {
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      status: "active",
+      startDate: "2026-02-01",
+      endDate: "2027-01-31",
+      monthlyRent: 1800,
+      dueDay: 1,
+    });
     resolveTenancyContext.mockResolvedValue({
       ok: true,
       authority: "active_tenant",
@@ -106,9 +123,12 @@ describe("tenantSharePackageService", () => {
       credibilitySummary: false,
       applicationSummary: false,
       documents: "none",
+      leaseSummary: false,
+      paymentReadinessSummary: false,
     });
     expect(docs[0]?.requestedItems).toEqual([]);
     expect(docs[0]?.approvedItems).toEqual([]);
+    expect(docs[0]?.verificationRequests).toEqual([]);
   });
 
   it("derives a safe public payload at read time with identity only by default", async () => {
@@ -127,6 +147,9 @@ describe("tenantSharePackageService", () => {
         availability: expect.objectContaining({
           canRequestMore: true,
           availableSections: ["identity"],
+        }),
+        identityExchangeReference: expect.objectContaining({
+          referenceType: "tenant_identity_reference",
         }),
       })
     );
@@ -162,6 +185,8 @@ describe("tenantSharePackageService", () => {
           credibilitySummary: true,
           applicationSummary: false,
           documents: "approved_only",
+          leaseSummary: false,
+          paymentReadinessSummary: false,
         },
       })
     );
@@ -175,6 +200,95 @@ describe("tenantSharePackageService", () => {
     );
     expect(payload?.documents).toEqual({ completionStatus: "complete" });
     expect(payload?.application).toBeUndefined();
+  });
+
+  it("creates verification requests without granting access and only expands approved safe scopes", async () => {
+    const service = await import("../tenantSharePackageService");
+    const created = await service.createTenantSharePackage({ tenantId: "tenant-1" });
+    const token = created.shareUrl.split("/share/")[1];
+
+    const request = await service.createTenantShareVerificationRequest({
+      token,
+      requestedScopes: ["lease_summary", "payment_readiness_summary", "unknown_key"],
+      requestedByType: "landlord",
+    });
+
+    expect(request).toEqual({
+      status: "requested",
+      requestedScopes: ["lease_summary", "payment_readiness_summary"],
+    });
+
+    let payload = await service.readTenantSharePackageByToken(token);
+    expect(payload?.leaseSummary).toBeUndefined();
+    expect(payload?.paymentReadinessSummary).toBeUndefined();
+
+    const record = ensureCollection("tenantSharePackages").get(created.id);
+    const requestId = record?.verificationRequests?.[0]?.requestId;
+    const responded = await service.respondToTenantShareVerificationRequest({
+      tenantId: "tenant-1",
+      sharePackageId: created.id,
+      requestId,
+      approvedScopes: ["payment_readiness_summary"],
+    });
+
+    expect(responded).toEqual(
+      expect.objectContaining({
+        approvedItems: ["payment_readiness_summary"],
+        requestedItems: [],
+      })
+    );
+
+    payload = await service.readTenantSharePackageByToken(token);
+    expect(payload?.leaseSummary).toBeUndefined();
+    expect(payload?.paymentReadinessSummary).toEqual(
+      expect.objectContaining({
+        readinessStatus: expect.stringMatching(/not_ready|ready_to_configure|blocked/),
+      })
+    );
+  });
+
+  it("lets the tenant decline and revoke verification requests without exposing new access automatically", async () => {
+    const service = await import("../tenantSharePackageService");
+    const created = await service.createTenantSharePackage({ tenantId: "tenant-1" });
+    const token = created.shareUrl.split("/share/")[1];
+    await service.createTenantShareVerificationRequest({
+      token,
+      requestedScopes: ["lease_summary"],
+      requestedByType: "landlord",
+    });
+    let record = ensureCollection("tenantSharePackages").get(created.id);
+    let requestId = record?.verificationRequests?.[0]?.requestId;
+
+    const declined = await service.respondToTenantShareVerificationRequest({
+      tenantId: "tenant-1",
+      sharePackageId: created.id,
+      requestId,
+      approvedScopes: [],
+    });
+    expect(declined).toEqual(expect.objectContaining({ approvedItems: [] }));
+
+    await service.createTenantShareVerificationRequest({
+      token,
+      requestedScopes: ["lease_summary"],
+      requestedByType: "landlord",
+    });
+    record = ensureCollection("tenantSharePackages").get(created.id);
+    requestId = record?.verificationRequests?.find((entry: any) => entry.status === "requested")?.requestId;
+    const revoked = await service.revokeTenantShareVerificationRequest({
+      tenantId: "tenant-1",
+      sharePackageId: created.id,
+      requestId,
+    });
+    expect(revoked).toEqual(
+      expect.objectContaining({
+        verificationRequests: expect.arrayContaining([
+          expect.objectContaining({
+            requestId,
+            status: "revoked",
+          }),
+        ]),
+      })
+    );
   });
 
   it("only lets the owning tenant respond to a share request", async () => {

--- a/rentchain-api/src/services/tenantPortal/tenantSharePackageService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantSharePackageService.ts
@@ -3,6 +3,13 @@ import { db } from "../../config/firebase";
 import { loadTenantIdentityRecord, type TenantIdentityRecord } from "./tenantProfileService";
 import { resolveTenancyContext } from "./tenancyContextService";
 import { deriveTenantCredibilitySignals } from "../tenantCredibility/deriveTenantCredibilitySignals";
+import { deriveIdentityPortability, type PortableIdentity } from "../identityPortability/deriveIdentityPortability";
+import { deriveIdentityTimeline } from "../identityTimeline/deriveIdentityTimeline";
+import { derivePaymentReadiness, type PaymentReadiness } from "../paymentReadiness/derivePaymentReadiness";
+import {
+  deriveIdentityExchangeReference,
+  type IdentityExchangeReference,
+} from "../identityExchange/deriveIdentityExchangeReference";
 
 const COLLECTION = "tenantSharePackages";
 const DEFAULT_EXPIRES_DAYS = 7;
@@ -12,20 +19,37 @@ export type TenantSharePermissionKey =
   | "identity_summary"
   | "credibility_summary"
   | "application_summary"
-  | "documents_summary";
+  | "documents_summary"
+  | "lease_summary"
+  | "payment_readiness_summary";
 
 export type TenantSharePermissions = {
   identitySummary: boolean;
   credibilitySummary: boolean;
   applicationSummary: boolean;
   documents: "none" | "summary" | "approved_only";
+  leaseSummary: boolean;
+  paymentReadinessSummary: boolean;
 };
 
 export type TenantSharePackageAvailabilitySection =
   | "identity"
   | "credibilitySummary"
   | "application"
-  | "documents";
+  | "documents"
+  | "leaseSummary"
+  | "paymentReadinessSummary";
+
+export type TenantShareVerificationRequestScope = TenantSharePermissionKey;
+
+export type TenantShareVerificationRequest = {
+  requestId: string;
+  requestedByType: "landlord" | "internal" | "future_institution";
+  requestedScopes: TenantShareVerificationRequestScope[];
+  status: "requested" | "approved" | "declined" | "revoked" | "expired";
+  createdAt: number;
+  expiresAt?: number;
+};
 
 export type TenantSharePackagePublicPayload = {
   identity?: {
@@ -48,6 +72,20 @@ export type TenantSharePackagePublicPayload = {
   documents?: {
     completionStatus: TenantIdentityRecord["documents"]["completionStatus"];
   };
+  leaseSummary?: {
+    status: string | null;
+    startDate: string | null;
+    endDate: string | null;
+    monthlyRent: number | null;
+  };
+  paymentReadinessSummary?: Pick<
+    PaymentReadiness,
+    "readinessStatus" | "readinessLabel" | "readinessDescription" | "requiredNextAction"
+  >;
+  identityExchangeReference?: Pick<
+    IdentityExchangeReference,
+    "referenceType" | "referenceStatus" | "referenceLabel" | "referenceDescription" | "portabilityStatus"
+  >;
   availability: {
     canRequestMore: boolean;
     availableSections: TenantSharePackageAvailabilitySection[];
@@ -66,6 +104,7 @@ export type TenantSharePackageRecord = {
   permissions: TenantSharePermissions;
   requestedItems: TenantSharePermissionKey[];
   approvedItems: TenantSharePermissionKey[];
+  verificationRequests: TenantShareVerificationRequest[];
 };
 
 const ALLOWED_REQUESTED_ITEMS = new Set<TenantSharePermissionKey>([
@@ -73,6 +112,8 @@ const ALLOWED_REQUESTED_ITEMS = new Set<TenantSharePermissionKey>([
   "credibility_summary",
   "application_summary",
   "documents_summary",
+  "lease_summary",
+  "payment_readiness_summary",
 ]);
 
 const DEFAULT_PERMISSIONS: TenantSharePermissions = {
@@ -80,6 +121,8 @@ const DEFAULT_PERMISSIONS: TenantSharePermissions = {
   credibilitySummary: false,
   applicationSummary: false,
   documents: "none",
+  leaseSummary: false,
+  paymentReadinessSummary: false,
 };
 
 function asString(value: unknown): string | null {
@@ -120,6 +163,86 @@ function sanitizeRequestedItems(input: unknown): TenantSharePermissionKey[] {
   return next;
 }
 
+function sanitizeRequestedByType(
+  value: unknown
+): TenantShareVerificationRequest["requestedByType"] {
+  return value === "internal" || value === "future_institution" ? value : "landlord";
+}
+
+function generateRequestId() {
+  return crypto.randomBytes(12).toString("hex");
+}
+
+function getEffectiveVerificationRequestStatus(
+  request: TenantShareVerificationRequest
+): TenantShareVerificationRequest["status"] {
+  if (request.status === "requested" && typeof request.expiresAt === "number" && request.expiresAt <= nowMs()) {
+    return "expired";
+  }
+  return request.status;
+}
+
+function sanitizeVerificationRequests(input: unknown): TenantShareVerificationRequest[] {
+  if (!Array.isArray(input)) return [];
+  const seen = new Set<string>();
+  const next: TenantShareVerificationRequest[] = [];
+  for (const entry of input) {
+    const requestId = asString((entry as any)?.requestId);
+    if (!requestId || seen.has(requestId)) continue;
+    seen.add(requestId);
+    const status = (() => {
+      const value = asString((entry as any)?.status);
+      if (
+        value === "approved" ||
+        value === "declined" ||
+        value === "revoked" ||
+        value === "expired" ||
+        value === "requested"
+      ) {
+        return value;
+      }
+      return "requested" as const;
+    })();
+    next.push({
+      requestId,
+      requestedByType: sanitizeRequestedByType((entry as any)?.requestedByType),
+      requestedScopes: sanitizeRequestedItems((entry as any)?.requestedScopes),
+      status,
+      createdAt: Number((entry as any)?.createdAt || 0),
+      expiresAt: typeof (entry as any)?.expiresAt === "number" ? Number((entry as any)?.expiresAt) : undefined,
+    });
+  }
+  return next;
+}
+
+function deriveShareStateFromVerificationRequests(
+  requests: TenantShareVerificationRequest[],
+  fallbackApprovedItems: TenantSharePermissionKey[]
+) {
+  const approvedSet = new Set<TenantSharePermissionKey>();
+  const requestedSet = new Set<TenantSharePermissionKey>();
+
+  for (const request of requests) {
+    const effectiveStatus = getEffectiveVerificationRequestStatus(request);
+    if (effectiveStatus === "approved") {
+      for (const scope of request.requestedScopes) approvedSet.add(scope);
+    }
+    if (effectiveStatus === "requested") {
+      for (const scope of request.requestedScopes) requestedSet.add(scope);
+    }
+  }
+
+  const approvedItems = Array.from(approvedSet);
+  const requestedItems = Array.from(requestedSet);
+  const resolvedApprovedItems = requests.length ? approvedItems : fallbackApprovedItems;
+
+  return {
+    approvedItems: resolvedApprovedItems,
+    requestedItems,
+    permissions: derivePermissionsFromApprovedItems(resolvedApprovedItems),
+  };
+}
+
 function derivePermissionsFromApprovedItems(approvedItems: TenantSharePermissionKey[]): TenantSharePermissions {
   const approved = new Set(approvedItems);
   return {
@@ -127,12 +250,18 @@ function derivePermissionsFromApprovedItems(approvedItems: TenantSharePermission
     credibilitySummary: approved.has("credibility_summary"),
     applicationSummary: approved.has("application_summary"),
     documents: approved.has("documents_summary") ? "approved_only" : "none",
+    leaseSummary: approved.has("lease_summary"),
+    paymentReadinessSummary: approved.has("payment_readiness_summary"),
   };
 }
 
 function asTenantShareRecord(doc: any): TenantSharePackageRecord {
   const data = ((doc?.data?.() as any) || {}) as Partial<TenantSharePackageRecord>;
-  const approvedItems = sanitizeRequestedItems(data.approvedItems);
+  const verificationRequests = sanitizeVerificationRequests(data.verificationRequests);
+  const derived = deriveShareStateFromVerificationRequests(
+    verificationRequests,
+    sanitizeRequestedItems(data.approvedItems)
+  );
   return {
     id: String(doc?.id || data.id || ""),
     tenantId: String(data.tenantId || ""),
@@ -141,9 +270,15 @@ function asTenantShareRecord(doc: any): TenantSharePackageRecord {
     expiresAt: Number(data.expiresAt || 0),
     status: data.status === "revoked" ? "revoked" : "active",
     revokedAt: typeof data.revokedAt === "number" ? data.revokedAt : undefined,
-    permissions: data.permissions || derivePermissionsFromApprovedItems(approvedItems),
-    requestedItems: sanitizeRequestedItems(data.requestedItems),
-    approvedItems,
+    permissions: data.permissions
+      ? {
+          ...DEFAULT_PERMISSIONS,
+          ...(data.permissions as Partial<TenantSharePermissions>),
+        }
+      : derived.permissions,
+    requestedItems: derived.requestedItems.length ? derived.requestedItems : sanitizeRequestedItems(data.requestedItems),
+    approvedItems: derived.approvedItems,
+    verificationRequests,
   };
 }
 
@@ -155,7 +290,23 @@ async function loadTenantShareRecordByToken(token: string): Promise<TenantShareP
   return asTenantShareRecord(doc);
 }
 
-async function resolveShareTenantIdentity(params: { tenantId: string }) {
+type ResolvedShareTenantContext = {
+  identity: TenantIdentityRecord;
+  portableIdentity: PortableIdentity;
+  paymentReadiness: PaymentReadiness | null;
+  identityExchangeReference: IdentityExchangeReference;
+  leaseSummary: {
+    status: string | null;
+    startDate: string | null;
+    endDate: string | null;
+    monthlyRent: number | null;
+  } | null;
+};
+
+async function resolveShareTenantContext(params: {
+  tenantId: string;
+  sharingControlsReady: boolean;
+}): Promise<ResolvedShareTenantContext | null> {
   const tenantId = asString(params.tenantId);
   if (!tenantId) return null;
 
@@ -172,11 +323,70 @@ async function resolveShareTenantIdentity(params: { tenantId: string }) {
 
   if (!context?.ok) return null;
 
-  return await loadTenantIdentityRecord({
+  const identity = await loadTenantIdentityRecord({
     context,
     userId: tenantId,
     userEmail: email,
   });
+  if (!identity) return null;
+
+  const leaseSnap = context.leaseId
+    ? await db.collection("leases").doc(String(context.leaseId || "")).get().catch(() => null as any)
+    : null;
+  const lease = leaseSnap?.exists ? ((leaseSnap.data() as any) || {}) : null;
+  const paymentReadiness = lease
+    ? derivePaymentReadiness({
+        leaseId: String(context.leaseId || ""),
+        monthlyRent: lease?.monthlyRent,
+        startDate: lease?.startDate,
+        endDate: lease?.endDate,
+        dueDay: lease?.dueDay,
+        tenantId,
+        propertyId: context.propertyId,
+        unitId: context.unitId,
+        leaseExecution: null,
+      })
+    : null;
+  const { landlordSafeSummary } = deriveTenantCredibilitySignals({
+    tenantIdentityRecord: identity,
+    leaseExecution: null,
+  });
+  const identityTimeline = await deriveIdentityTimeline({
+    tenantId,
+    applicationId: context.applicationId,
+    leaseId: context.leaseId,
+  });
+  const { portableIdentity } = deriveIdentityPortability({
+    tenantIdentityRecord: identity,
+    credibilitySummary: landlordSafeSummary,
+    shareAvailability: {
+      sharingEnabled: params.sharingControlsReady,
+    },
+    timelineAvailability: {
+      hasIdentityTimeline: Array.isArray(identityTimeline?.events) && identityTimeline.events.length > 0,
+    },
+  });
+  const identityExchangeReference = deriveIdentityExchangeReference({
+    portableIdentity,
+    auditTimelineReady: Array.isArray(identityTimeline?.events) && identityTimeline.events.length > 0,
+    paymentReadinessAvailable: Boolean(paymentReadiness),
+    sharingControlsReady: params.sharingControlsReady,
+  });
+
+  return {
+    identity,
+    portableIdentity,
+    paymentReadiness,
+    identityExchangeReference,
+    leaseSummary: lease
+      ? {
+          status: asString(lease?.status),
+          startDate: asString(lease?.startDate),
+          endDate: asString(lease?.endDate),
+          monthlyRent: Number.isFinite(Number(lease?.monthlyRent)) ? Number(lease?.monthlyRent) : null,
+        }
+      : null,
+  };
 }
 
 async function loadTenantShareRecordById(sharePackageId: string): Promise<TenantSharePackageRecord | null> {
@@ -189,10 +399,25 @@ async function loadTenantShareRecordById(sharePackageId: string): Promise<Tenant
 function buildPublicPayload(params: {
   identity: TenantIdentityRecord;
   permissions: TenantSharePermissions;
+  identityExchangeReference: IdentityExchangeReference;
+  leaseSummary: {
+    status: string | null;
+    startDate: string | null;
+    endDate: string | null;
+    monthlyRent: number | null;
+  } | null;
+  paymentReadiness: PaymentReadiness | null;
 }): TenantSharePackagePublicPayload {
-  const { identity, permissions } = params;
+  const { identity, permissions, identityExchangeReference, leaseSummary, paymentReadiness } = params;
   const availableSections: TenantSharePackageAvailabilitySection[] = [];
   const payload: TenantSharePackagePublicPayload = {
+    identityExchangeReference: {
+      referenceType: identityExchangeReference.referenceType,
+      referenceStatus: identityExchangeReference.referenceStatus,
+      referenceLabel: identityExchangeReference.referenceLabel,
+      referenceDescription: identityExchangeReference.referenceDescription,
+      portabilityStatus: identityExchangeReference.portabilityStatus,
+    },
     availability: {
       canRequestMore: true,
       availableSections,
@@ -235,6 +460,21 @@ function buildPublicPayload(params: {
     availableSections.push("documents");
   }
 
+  if (permissions.leaseSummary && leaseSummary) {
+    payload.leaseSummary = leaseSummary;
+    availableSections.push("leaseSummary");
+  }
+
+  if (permissions.paymentReadinessSummary && paymentReadiness) {
+    payload.paymentReadinessSummary = {
+      readinessStatus: paymentReadiness.readinessStatus,
+      readinessLabel: paymentReadiness.readinessLabel,
+      readinessDescription: paymentReadiness.readinessDescription,
+      requiredNextAction: paymentReadiness.requiredNextAction,
+    };
+    availableSections.push("paymentReadinessSummary");
+  }
+
   return payload;
 }
 
@@ -263,7 +503,13 @@ export async function createTenantSharePackage(params: {
     permissions: DEFAULT_PERMISSIONS,
     requestedItems: [],
     approvedItems: [],
+    verificationRequests: [],
   } satisfies TenantSharePackageRecord);
+
+  const resolved = await resolveShareTenantContext({
+    tenantId,
+    sharingControlsReady: true,
+  });
 
   return {
     id: ref.id,
@@ -273,6 +519,8 @@ export async function createTenantSharePackage(params: {
     permissions: DEFAULT_PERMISSIONS,
     requestedItems: [] as TenantSharePermissionKey[],
     approvedItems: [] as TenantSharePermissionKey[],
+    verificationRequests: [] as TenantShareVerificationRequest[],
+    identityExchangeReference: resolved?.identityExchangeReference || null,
     shareUrl: buildFrontendShareUrl(token),
   };
 }
@@ -284,11 +532,19 @@ export async function listTenantSharePackages(params: { tenantId: string }) {
   const snap = await db.collection(COLLECTION).where("tenantId", "==", tenantId).limit(50).get();
   const now = nowMs();
 
-  return (snap.docs || [])
+  const entries = (snap.docs || [])
     .map((doc: any) => asTenantShareRecord(doc))
     .filter((entry) => entry.status === "active" && Number(entry.expiresAt || 0) > now)
-    .sort((left, right) => Number(right.createdAt || 0) - Number(left.createdAt || 0))
-    .map((entry) => ({
+    .sort((left, right) => Number(right.createdAt || 0) - Number(left.createdAt || 0));
+
+  const resolved = entries.length
+    ? await resolveShareTenantContext({
+        tenantId,
+        sharingControlsReady: true,
+      })
+    : null;
+
+  return entries.map((entry) => ({
       id: entry.id,
       createdAt: entry.createdAt,
       expiresAt: entry.expiresAt,
@@ -296,6 +552,11 @@ export async function listTenantSharePackages(params: { tenantId: string }) {
       permissions: entry.permissions,
       requestedItems: entry.requestedItems,
       approvedItems: entry.approvedItems,
+      verificationRequests: entry.verificationRequests.map((request) => ({
+        ...request,
+        status: getEffectiveVerificationRequestStatus(request),
+      })),
+      identityExchangeReference: resolved?.identityExchangeReference || null,
     }));
 }
 
@@ -346,6 +607,47 @@ export async function requestTenantSharePackageItems(params: {
   return { requestedItems };
 }
 
+export async function createTenantShareVerificationRequest(params: {
+  token: string;
+  requestedScopes: unknown;
+  requestedByType?: TenantShareVerificationRequest["requestedByType"];
+}) {
+  const normalized = asString(params.token);
+  if (!normalized) return null;
+  const record = await loadTenantShareRecordByToken(normalized);
+  if (!record) return null;
+  if (record.status !== "active") return null;
+  if (Number(record.expiresAt || 0) <= nowMs()) return null;
+
+  const requestedScopes = sanitizeRequestedItems(params.requestedScopes);
+  const createdAt = nowMs();
+  const request: TenantShareVerificationRequest = {
+    requestId: generateRequestId(),
+    requestedByType: sanitizeRequestedByType(params.requestedByType),
+    requestedScopes,
+    status: "requested",
+    createdAt,
+    expiresAt: Number(record.expiresAt || 0) > createdAt ? Number(record.expiresAt || 0) : undefined,
+  };
+  const verificationRequests = [...record.verificationRequests, request];
+  const derived = deriveShareStateFromVerificationRequests(verificationRequests, record.approvedItems);
+
+  await db.collection(COLLECTION).doc(record.id).set(
+    {
+      verificationRequests,
+      requestedItems: derived.requestedItems,
+      approvedItems: derived.approvedItems,
+      permissions: derived.permissions,
+    },
+    { merge: true }
+  );
+
+  return {
+    status: "requested" as const,
+    requestedScopes,
+  };
+}
+
 export async function respondToTenantSharePackage(params: {
   tenantId: string;
   sharePackageId: string;
@@ -384,6 +686,106 @@ export async function respondToTenantSharePackage(params: {
   };
 }
 
+export async function respondToTenantShareVerificationRequest(params: {
+  tenantId: string;
+  sharePackageId: string;
+  requestId: string;
+  approvedScopes: unknown;
+}) {
+  const tenantId = asString(params.tenantId);
+  const sharePackageId = asString(params.sharePackageId);
+  const requestId = asString(params.requestId);
+  if (!tenantId || !sharePackageId || !requestId) return null;
+
+  const current = await loadTenantShareRecordById(sharePackageId);
+  if (!current) return null;
+  if (current.tenantId !== tenantId) return false;
+
+  const requests = current.verificationRequests.map((entry) => ({ ...entry }));
+  const index = requests.findIndex((entry) => entry.requestId === requestId);
+  if (index < 0) return null;
+
+  const request = requests[index];
+  const approvedScopes = sanitizeRequestedItems(params.approvedScopes).filter((scope) =>
+    request.requestedScopes.includes(scope)
+  );
+  requests[index] = {
+    ...request,
+    requestedScopes: approvedScopes.length ? approvedScopes : request.requestedScopes,
+    status: approvedScopes.length ? "approved" : "declined",
+  };
+  const derived = deriveShareStateFromVerificationRequests(requests, current.approvedItems);
+
+  await db.collection(COLLECTION).doc(sharePackageId).set(
+    {
+      verificationRequests: requests,
+      requestedItems: derived.requestedItems,
+      approvedItems: derived.approvedItems,
+      permissions: derived.permissions,
+    },
+    { merge: true }
+  );
+
+  return {
+    id: sharePackageId,
+    verificationRequests: requests.map((entry) => ({
+      ...entry,
+      status: getEffectiveVerificationRequestStatus(entry),
+    })),
+    requestedItems: derived.requestedItems,
+    approvedItems: derived.approvedItems,
+    permissions: derived.permissions,
+    status: current.status,
+    createdAt: current.createdAt,
+    expiresAt: current.expiresAt,
+  };
+}
+
+export async function revokeTenantShareVerificationRequest(params: {
+  tenantId: string;
+  sharePackageId: string;
+  requestId: string;
+}) {
+  const tenantId = asString(params.tenantId);
+  const sharePackageId = asString(params.sharePackageId);
+  const requestId = asString(params.requestId);
+  if (!tenantId || !sharePackageId || !requestId) return null;
+
+  const current = await loadTenantShareRecordById(sharePackageId);
+  if (!current) return null;
+  if (current.tenantId !== tenantId) return false;
+
+  const requests = current.verificationRequests.map((entry) =>
+    entry.requestId === requestId ? { ...entry, status: "revoked" as const } : { ...entry }
+  );
+  if (!requests.some((entry) => entry.requestId === requestId)) return null;
+
+  const derived = deriveShareStateFromVerificationRequests(requests, current.approvedItems);
+  await db.collection(COLLECTION).doc(sharePackageId).set(
+    {
+      verificationRequests: requests,
+      requestedItems: derived.requestedItems,
+      approvedItems: derived.approvedItems,
+      permissions: derived.permissions,
+    },
+    { merge: true }
+  );
+
+  return {
+    id: sharePackageId,
+    verificationRequests: requests.map((entry) => ({
+      ...entry,
+      status: getEffectiveVerificationRequestStatus(entry),
+    })),
+    requestedItems: derived.requestedItems,
+    approvedItems: derived.approvedItems,
+    permissions: derived.permissions,
+    status: current.status,
+    createdAt: current.createdAt,
+    expiresAt: current.expiresAt,
+  };
+}
+
 export async function readTenantSharePackageByToken(
   token: string
 ): Promise<TenantSharePackagePublicPayload | null> {
@@ -395,11 +797,17 @@ export async function readTenantSharePackageByToken(
   if (record.status !== "active") return null;
   if (Number(record.expiresAt || 0) <= nowMs()) return null;
 
-  const identity = await resolveShareTenantIdentity({ tenantId: record.tenantId });
-  if (!identity) return null;
+  const resolved = await resolveShareTenantContext({
+    tenantId: record.tenantId,
+    sharingControlsReady: true,
+  });
+  if (!resolved) return null;
 
   return buildPublicPayload({
-    identity,
+    identity: resolved.identity,
     permissions: record.permissions || derivePermissionsFromApprovedItems(record.approvedItems || []),
+    identityExchangeReference: resolved.identityExchangeReference,
+    leaseSummary: resolved.leaseSummary,
+    paymentReadiness: resolved.paymentReadiness,
   });
 }

--- a/rentchain-frontend/src/api/publicTenantSharePackageApi.ts
+++ b/rentchain-frontend/src/api/publicTenantSharePackageApi.ts
@@ -21,9 +21,30 @@ export type PublicTenantSharePackage = {
   documents?: {
     completionStatus: "complete" | "in_progress" | "missing" | "needs_attention";
   };
+  leaseSummary?: {
+    status: string | null;
+    startDate: string | null;
+    endDate: string | null;
+    monthlyRent: number | null;
+  };
+  paymentReadinessSummary?: {
+    readinessStatus: "not_ready" | "ready_to_configure" | "blocked";
+    readinessLabel: string;
+    readinessDescription: string;
+    requiredNextAction: "complete_lease_details" | "review_rent_terms" | "confirm_payment_setup_later" | "none";
+  };
+  identityExchangeReference?: {
+    referenceType: "tenant_identity_reference";
+    referenceStatus: "available" | "limited" | "not_ready";
+    referenceLabel: string;
+    referenceDescription: string;
+    portabilityStatus: "ready" | "limited" | "not_ready";
+  };
   availability: {
     canRequestMore: boolean;
-    availableSections: Array<"identity" | "credibilitySummary" | "application" | "documents">;
+    availableSections: Array<
+      "identity" | "credibilitySummary" | "application" | "documents" | "leaseSummary" | "paymentReadinessSummary"
+    >;
   };
   generatedAt: string;
 };
@@ -49,6 +70,27 @@ export async function requestPublicTenantSharePackageItems(
     {
       method: "POST",
       body: { requestedItems },
+      suppressToasts: true,
+    }
+  );
+  return res.data;
+}
+
+export async function requestPublicTenantSharePackageVerification(
+  token: string,
+  requestedScopes: Array<
+    | "credibility_summary"
+    | "application_summary"
+    | "documents_summary"
+    | "lease_summary"
+    | "payment_readiness_summary"
+  >
+): Promise<{ status: "requested"; requestedScopes: typeof requestedScopes }> {
+  const res = await apiFetch<{ ok: boolean; data: { status: "requested"; requestedScopes: typeof requestedScopes } }>(
+    `/public/share/${encodeURIComponent(token)}/verification-request`,
+    {
+      method: "POST",
+      body: { requestedScopes },
       suppressToasts: true,
     }
   );

--- a/rentchain-frontend/src/api/tenantSharePackages.ts
+++ b/rentchain-frontend/src/api/tenantSharePackages.ts
@@ -1,5 +1,28 @@
 import { tenantApiFetch } from "./tenantApiFetch";
 
+export type TenantShareVerificationRequestScope =
+  | "identity_summary"
+  | "credibility_summary"
+  | "application_summary"
+  | "documents_summary"
+  | "lease_summary"
+  | "payment_readiness_summary";
+
+export type IdentityExchangeReference = {
+  referenceType: "tenant_identity_reference";
+  referenceStatus: "available" | "limited" | "not_ready";
+  referenceLabel: string;
+  referenceDescription: string;
+  portabilityStatus: "ready" | "limited" | "not_ready";
+  exchangeReadiness: {
+    identityReady: boolean;
+    credibilityReady: boolean;
+    sharingControlsReady: boolean;
+    auditTimelineReady: boolean;
+    paymentReadinessAvailable: boolean;
+  };
+};
+
 export type TenantSharePackageLink = {
   id: string;
   createdAt: number;
@@ -10,13 +33,20 @@ export type TenantSharePackageLink = {
     credibilitySummary: boolean;
     applicationSummary: boolean;
     documents: "none" | "summary" | "approved_only";
+    leaseSummary: boolean;
+    paymentReadinessSummary: boolean;
   };
-  requestedItems: Array<
-    "identity_summary" | "credibility_summary" | "application_summary" | "documents_summary"
-  >;
-  approvedItems: Array<
-    "identity_summary" | "credibility_summary" | "application_summary" | "documents_summary"
-  >;
+  requestedItems: TenantShareVerificationRequestScope[];
+  approvedItems: TenantShareVerificationRequestScope[];
+  verificationRequests: Array<{
+    requestId: string;
+    requestedByType: "landlord" | "internal" | "future_institution";
+    requestedScopes: TenantShareVerificationRequestScope[];
+    status: "requested" | "approved" | "declined" | "revoked" | "expired";
+    createdAt: number;
+    expiresAt?: number;
+  }>;
+  identityExchangeReference: IdentityExchangeReference | null;
 };
 
 export type TenantSharePackageCreated = TenantSharePackageLink & {
@@ -44,13 +74,41 @@ export async function revokeTenantSharePackage(id: string): Promise<void> {
 
 export async function respondToTenantSharePackage(
   id: string,
-  approvedItems: Array<"identity_summary" | "credibility_summary" | "application_summary" | "documents_summary">
+  approvedItems: TenantShareVerificationRequestScope[]
 ): Promise<TenantSharePackageLink> {
   const res = await tenantApiFetch<{ ok: boolean; data: TenantSharePackageLink }>(
     `/tenant/share-packages/${encodeURIComponent(id)}/respond`,
     {
       method: "POST",
       body: { approvedItems },
+    }
+  );
+  return res.data;
+}
+
+export async function respondToTenantShareVerificationRequest(
+  sharePackageId: string,
+  requestId: string,
+  approvedScopes: TenantShareVerificationRequestScope[]
+): Promise<TenantSharePackageLink> {
+  const res = await tenantApiFetch<{ ok: boolean; data: TenantSharePackageLink }>(
+    `/tenant/share-packages/${encodeURIComponent(sharePackageId)}/verification-requests/${encodeURIComponent(requestId)}/respond`,
+    {
+      method: "POST",
+      body: { approvedScopes },
+    }
+  );
+  return res.data;
+}
+
+export async function revokeTenantShareVerificationRequest(
+  sharePackageId: string,
+  requestId: string
+): Promise<TenantSharePackageLink> {
+  const res = await tenantApiFetch<{ ok: boolean; data: TenantSharePackageLink }>(
+    `/tenant/share-packages/${encodeURIComponent(sharePackageId)}/verification-requests/${encodeURIComponent(requestId)}/revoke`,
+    {
+      method: "POST",
     }
   );
   return res.data;

--- a/rentchain-frontend/src/pages/public/TenantSharePackagePage.test.tsx
+++ b/rentchain-frontend/src/pages/public/TenantSharePackagePage.test.tsx
@@ -5,7 +5,7 @@ import TenantSharePackagePage from "./TenantSharePackagePage";
 
 const publicTenantSharePackageApi = vi.hoisted(() => ({
   fetchPublicTenantSharePackage: vi.fn(),
-  requestPublicTenantSharePackageItems: vi.fn(),
+  requestPublicTenantSharePackageVerification: vi.fn(),
 }));
 
 vi.mock("../../api/publicTenantSharePackageApi", () => publicTenantSharePackageApi);
@@ -38,6 +38,13 @@ describe("TenantSharePackagePage", () => {
         readinessLabel: "Ready to apply",
         readinessDescription: "Your core profile and supporting records are ready for most rental workflows.",
       },
+      identityExchangeReference: {
+        referenceType: "tenant_identity_reference",
+        referenceStatus: "available",
+        referenceLabel: "Identity exchange available",
+        referenceDescription: "This rental identity can support summary-only exchange requests within the tenant-controlled sharing flow.",
+        portabilityStatus: "ready",
+      },
       availability: {
         canRequestMore: true,
         availableSections: ["identity"],
@@ -50,7 +57,8 @@ describe("TenantSharePackagePage", () => {
     expect(await screen.findByText(/Shared Rental Profile/i)).toBeInTheDocument();
     expect(screen.getByText(/Ready to apply/i)).toBeInTheDocument();
     expect(screen.getByText(/^Verification$/i)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Request additional information/i })).toBeInTheDocument();
+    expect(screen.getByText(/Identity exchange available/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Request verification/i })).toBeInTheDocument();
     expect(screen.queryByText(/TransUnion/i)).not.toBeInTheDocument();
   });
 
@@ -70,25 +78,35 @@ describe("TenantSharePackagePage", () => {
         readinessLabel: "Ready to apply",
         readinessDescription: "Your core profile and supporting records are ready for most rental workflows.",
       },
+      identityExchangeReference: {
+        referenceType: "tenant_identity_reference",
+        referenceStatus: "available",
+        referenceLabel: "Identity exchange available",
+        referenceDescription: "This rental identity can support summary-only exchange requests within the tenant-controlled sharing flow.",
+        portabilityStatus: "ready",
+      },
       availability: {
         canRequestMore: true,
         availableSections: ["identity"],
       },
       generatedAt: "2026-04-26T00:00:00.000Z",
     });
-    publicTenantSharePackageApi.requestPublicTenantSharePackageItems.mockResolvedValue({
-      requestedItems: ["credibility_summary"],
+    publicTenantSharePackageApi.requestPublicTenantSharePackageVerification.mockResolvedValue({
+      status: "requested",
+      requestedScopes: ["credibility_summary", "payment_readiness_summary"],
     });
 
     renderPage();
 
-    expect(await screen.findByRole("button", { name: /Request additional information/i })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: /Request verification/i })).toBeInTheDocument();
     fireEvent.click(screen.getByLabelText(/Credibility summary/i));
-    fireEvent.click(screen.getByRole("button", { name: /Request additional information/i }));
+    fireEvent.click(screen.getByLabelText(/Payment readiness summary/i));
+    fireEvent.click(screen.getByRole("button", { name: /Request verification/i }));
 
     await waitFor(() => {
-      expect(publicTenantSharePackageApi.requestPublicTenantSharePackageItems).toHaveBeenCalledWith("token-123", [
+      expect(publicTenantSharePackageApi.requestPublicTenantSharePackageVerification).toHaveBeenCalledWith("token-123", [
         "credibility_summary",
+        "payment_readiness_summary",
       ]);
     });
     expect(screen.getAllByText(/^Unavailable$/i).length).toBeGreaterThan(0);

--- a/rentchain-frontend/src/pages/public/TenantSharePackagePage.tsx
+++ b/rentchain-frontend/src/pages/public/TenantSharePackagePage.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useParams } from "react-router-dom";
 import {
   fetchPublicTenantSharePackage,
-  requestPublicTenantSharePackageItems,
+  requestPublicTenantSharePackageVerification,
 } from "../../api/publicTenantSharePackageApi";
 
 function prettyStatus(value: string | null | undefined) {
@@ -18,7 +18,11 @@ export default function TenantSharePackagePage() {
   const [error, setError] = React.useState<string | null>(null);
   const [requesting, setRequesting] = React.useState(false);
   const [requestError, setRequestError] = React.useState<string | null>(null);
-  const [requestedItems, setRequestedItems] = React.useState<Array<"credibility_summary" | "application_summary" | "documents_summary">>([]);
+  const [requestedItems, setRequestedItems] = React.useState<
+    Array<
+      "credibility_summary" | "application_summary" | "documents_summary" | "lease_summary" | "payment_readiness_summary"
+    >
+  >([]);
 
   React.useEffect(() => {
     let mounted = true;
@@ -47,7 +51,14 @@ export default function TenantSharePackagePage() {
   }, [token]);
 
   const toggleRequestItem = React.useCallback(
-    (item: "credibility_summary" | "application_summary" | "documents_summary") => {
+    (
+      item:
+        | "credibility_summary"
+        | "application_summary"
+        | "documents_summary"
+        | "lease_summary"
+        | "payment_readiness_summary"
+    ) => {
       setRequestedItems((current) =>
         current.includes(item) ? current.filter((entry) => entry !== item) : [...current, item]
       );
@@ -59,7 +70,7 @@ export default function TenantSharePackagePage() {
     try {
       setRequesting(true);
       setRequestError(null);
-      await requestPublicTenantSharePackageItems(token, requestedItems);
+      await requestPublicTenantSharePackageVerification(token, requestedItems);
     } catch (err: any) {
       setRequestError(err?.message || "Unable to save this request right now.");
     } finally {
@@ -111,6 +122,14 @@ export default function TenantSharePackagePage() {
               </div>
             ) : null}
 
+            {data.identityExchangeReference ? (
+              <div style={{ border: "1px solid rgba(15,23,42,0.08)", borderRadius: 16, background: "#fff", padding: 18, display: "grid", gap: 8 }}>
+                <div style={{ fontSize: "1.05rem", fontWeight: 800, color: "#0f172a" }}>Identity exchange</div>
+                <div style={{ color: "#0f172a", fontWeight: 700 }}>{data.identityExchangeReference.referenceLabel}</div>
+                <div style={{ color: "#475569", lineHeight: 1.6 }}>{data.identityExchangeReference.referenceDescription}</div>
+              </div>
+            ) : null}
+
             <div style={{ border: "1px solid rgba(15,23,42,0.08)", borderRadius: 16, background: "#fff", padding: 18, display: "grid", gap: 12 }}>
               <div style={{ fontWeight: 800, color: "#0f172a" }}>Available information</div>
               <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 12 }}>
@@ -118,6 +137,12 @@ export default function TenantSharePackagePage() {
                   ["Credibility summary", availableSections.has("credibilitySummary"), data.credibilitySummary?.summaryLabel || "Unavailable"],
                   ["Application summary", availableSections.has("application"), data.application?.reusable ? "Reusable application available" : "Unavailable"],
                   ["Documents summary", availableSections.has("documents"), data.documents ? prettyStatus(data.documents.completionStatus) : "Unavailable"],
+                  ["Lease summary", availableSections.has("leaseSummary"), data.leaseSummary?.status ? prettyStatus(data.leaseSummary.status) : "Unavailable"],
+                  [
+                    "Payment readiness summary",
+                    availableSections.has("paymentReadinessSummary"),
+                    data.paymentReadinessSummary?.readinessLabel || "Unavailable",
+                  ],
                 ].map(([label, available, value]) => (
                   <div key={String(label)} style={{ border: "1px solid rgba(15,23,42,0.08)", borderRadius: 12, padding: "12px 14px", display: "grid", gap: 4 }}>
                     <div style={{ color: "#64748b", fontSize: "0.85rem" }}>{label}</div>
@@ -127,6 +152,9 @@ export default function TenantSharePackagePage() {
               </div>
               {data.credibilitySummary ? (
                 <div style={{ color: "#475569", lineHeight: 1.6 }}>{data.credibilitySummary.summaryDescription}</div>
+              ) : null}
+              {data.paymentReadinessSummary ? (
+                <div style={{ color: "#475569", lineHeight: 1.6 }}>{data.paymentReadinessSummary.readinessDescription}</div>
               ) : null}
             </div>
 
@@ -159,9 +187,25 @@ export default function TenantSharePackagePage() {
                 />
                 Documents summary
               </label>
+              <label style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                <input
+                  type="checkbox"
+                  checked={requestedItems.includes("lease_summary")}
+                  onChange={() => toggleRequestItem("lease_summary")}
+                />
+                Lease summary
+              </label>
+              <label style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                <input
+                  type="checkbox"
+                  checked={requestedItems.includes("payment_readiness_summary")}
+                  onChange={() => toggleRequestItem("payment_readiness_summary")}
+                />
+                Payment readiness summary
+              </label>
               <div>
                 <button type="button" onClick={() => void handleRequest()} disabled={requesting || requestedItems.length === 0}>
-                  {requesting ? "Requesting..." : "Request additional information"}
+                  {requesting ? "Requesting..." : "Request verification"}
                 </button>
               </div>
               {requestError ? <div style={{ color: "#b91c1c" }}>{requestError}</div> : null}

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -55,6 +55,8 @@ const tenantSharePackagesApi = vi.hoisted(() => ({
   listTenantSharePackages: vi.fn(),
   revokeTenantSharePackage: vi.fn(),
   respondToTenantSharePackage: vi.fn(),
+  respondToTenantShareVerificationRequest: vi.fn(),
+  revokeTenantShareVerificationRequest: vi.fn(),
 }));
 
 vi.mock("../../api/tenantPortal", () => tenantPortalApi);
@@ -375,9 +377,26 @@ describe("tenant workspace frontend shell", () => {
         credibilitySummary: false,
         applicationSummary: false,
         documents: "none",
+        leaseSummary: false,
+        paymentReadinessSummary: false,
       },
       requestedItems: [],
       approvedItems: [],
+      verificationRequests: [],
+      identityExchangeReference: {
+        referenceType: "tenant_identity_reference",
+        referenceStatus: "available",
+        referenceLabel: "Identity exchange available",
+        referenceDescription: "This rental identity can support summary-only exchange requests within the tenant-controlled sharing flow.",
+        portabilityStatus: "ready",
+        exchangeReadiness: {
+          identityReady: true,
+          credibilityReady: true,
+          sharingControlsReady: true,
+          auditTimelineReady: true,
+          paymentReadinessAvailable: false,
+        },
+      },
       shareUrl: "https://app.example/share/share-token-1",
     });
     tenantSharePackagesApi.revokeTenantSharePackage.mockResolvedValue(undefined);
@@ -391,9 +410,26 @@ describe("tenant workspace frontend shell", () => {
         credibilitySummary: true,
         applicationSummary: false,
         documents: "approved_only",
+        leaseSummary: false,
+        paymentReadinessSummary: false,
       },
       requestedItems: [],
       approvedItems: ["credibility_summary", "documents_summary"],
+      verificationRequests: [],
+      identityExchangeReference: {
+        referenceType: "tenant_identity_reference",
+        referenceStatus: "available",
+        referenceLabel: "Identity exchange available",
+        referenceDescription: "This rental identity can support summary-only exchange requests within the tenant-controlled sharing flow.",
+        portabilityStatus: "ready",
+        exchangeReadiness: {
+          identityReady: true,
+          credibilityReady: true,
+          sharingControlsReady: true,
+          auditTimelineReady: true,
+          paymentReadinessAvailable: false,
+        },
+      },
     });
     Object.assign(navigator, {
       clipboard: {
@@ -651,9 +687,26 @@ describe("tenant workspace frontend shell", () => {
             credibilitySummary: false,
             applicationSummary: false,
             documents: "none",
+            leaseSummary: false,
+            paymentReadinessSummary: false,
           },
           requestedItems: [],
           approvedItems: [],
+          verificationRequests: [],
+          identityExchangeReference: {
+            referenceType: "tenant_identity_reference",
+            referenceStatus: "available",
+            referenceLabel: "Identity exchange available",
+            referenceDescription: "This rental identity can support summary-only exchange requests within the tenant-controlled sharing flow.",
+            portabilityStatus: "ready",
+            exchangeReadiness: {
+              identityReady: true,
+              credibilityReady: true,
+              sharingControlsReady: true,
+              auditTimelineReady: true,
+              paymentReadinessAvailable: false,
+            },
+          },
         },
       ]);
 
@@ -691,9 +744,34 @@ describe("tenant workspace frontend shell", () => {
           credibilitySummary: false,
           applicationSummary: false,
           documents: "none",
+          leaseSummary: false,
+          paymentReadinessSummary: false,
         },
         requestedItems: ["credibility_summary", "documents_summary"],
         approvedItems: [],
+        verificationRequests: [
+          {
+            requestId: "req-1",
+            requestedByType: "landlord",
+            requestedScopes: ["lease_summary", "payment_readiness_summary"],
+            status: "requested",
+            createdAt: 1710000000000,
+          },
+        ],
+        identityExchangeReference: {
+          referenceType: "tenant_identity_reference",
+          referenceStatus: "available",
+          referenceLabel: "Identity exchange available",
+          referenceDescription: "This rental identity can support summary-only exchange requests within the tenant-controlled sharing flow.",
+          portabilityStatus: "ready",
+          exchangeReadiness: {
+            identityReady: true,
+            credibilityReady: true,
+            sharingControlsReady: true,
+            auditTimelineReady: true,
+            paymentReadinessAvailable: true,
+          },
+        },
       },
     ]);
 
@@ -714,6 +792,150 @@ describe("tenant workspace frontend shell", () => {
       ]);
     });
     expect(await screen.findByText(/Approved: Credibility summary, Documents summary/i)).toBeInTheDocument();
+    expect(screen.getByText(/Identity exchange available/i)).toBeInTheDocument();
+  });
+
+  it("lets tenants approve and revoke verification requests", async () => {
+    tenantSharePackagesApi.listTenantSharePackages.mockResolvedValue([
+      {
+        id: "share-1",
+        createdAt: 1710000000000,
+        expiresAt: 1710600000000,
+        status: "active",
+        permissions: {
+          identitySummary: true,
+          credibilitySummary: false,
+          applicationSummary: false,
+          documents: "none",
+          leaseSummary: false,
+          paymentReadinessSummary: false,
+        },
+        requestedItems: [],
+        approvedItems: [],
+        verificationRequests: [
+          {
+            requestId: "req-1",
+            requestedByType: "landlord",
+            requestedScopes: ["lease_summary", "payment_readiness_summary"],
+            status: "requested",
+            createdAt: 1710000000000,
+          },
+        ],
+        identityExchangeReference: {
+          referenceType: "tenant_identity_reference",
+          referenceStatus: "available",
+          referenceLabel: "Identity exchange available",
+          referenceDescription: "This rental identity can support summary-only exchange requests within the tenant-controlled sharing flow.",
+          portabilityStatus: "ready",
+          exchangeReadiness: {
+            identityReady: true,
+            credibilityReady: true,
+            sharingControlsReady: true,
+            auditTimelineReady: true,
+            paymentReadinessAvailable: true,
+          },
+        },
+      },
+    ]);
+    tenantSharePackagesApi.respondToTenantShareVerificationRequest.mockResolvedValue({
+      id: "share-1",
+      createdAt: 1710000000000,
+      expiresAt: 1710600000000,
+      status: "active",
+      permissions: {
+        identitySummary: true,
+        credibilitySummary: false,
+        applicationSummary: false,
+        documents: "none",
+        leaseSummary: false,
+        paymentReadinessSummary: true,
+      },
+      requestedItems: [],
+      approvedItems: ["payment_readiness_summary"],
+      verificationRequests: [
+        {
+          requestId: "req-1",
+          requestedByType: "landlord",
+          requestedScopes: ["payment_readiness_summary"],
+          status: "approved",
+          createdAt: 1710000000000,
+        },
+      ],
+      identityExchangeReference: {
+        referenceType: "tenant_identity_reference",
+        referenceStatus: "available",
+        referenceLabel: "Identity exchange available",
+        referenceDescription: "This rental identity can support summary-only exchange requests within the tenant-controlled sharing flow.",
+        portabilityStatus: "ready",
+        exchangeReadiness: {
+          identityReady: true,
+          credibilityReady: true,
+          sharingControlsReady: true,
+          auditTimelineReady: true,
+          paymentReadinessAvailable: true,
+        },
+      },
+    });
+    tenantSharePackagesApi.revokeTenantShareVerificationRequest.mockResolvedValue({
+      id: "share-1",
+      createdAt: 1710000000000,
+      expiresAt: 1710600000000,
+      status: "active",
+      permissions: {
+        identitySummary: true,
+        credibilitySummary: false,
+        applicationSummary: false,
+        documents: "none",
+        leaseSummary: false,
+        paymentReadinessSummary: false,
+      },
+      requestedItems: [],
+      approvedItems: [],
+      verificationRequests: [
+        {
+          requestId: "req-1",
+          requestedByType: "landlord",
+          requestedScopes: ["payment_readiness_summary"],
+          status: "revoked",
+          createdAt: 1710000000000,
+        },
+      ],
+      identityExchangeReference: {
+        referenceType: "tenant_identity_reference",
+        referenceStatus: "available",
+        referenceLabel: "Identity exchange available",
+        referenceDescription: "This rental identity can support summary-only exchange requests within the tenant-controlled sharing flow.",
+        portabilityStatus: "ready",
+        exchangeReadiness: {
+          identityReady: true,
+          credibilityReady: true,
+          sharingControlsReady: true,
+          auditTimelineReady: true,
+          paymentReadinessAvailable: true,
+        },
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <TenantWorkspacePage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole("button", { name: /Approve request/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Approve request/i }));
+    await waitFor(() => {
+      expect(tenantSharePackagesApi.respondToTenantShareVerificationRequest).toHaveBeenCalledWith("share-1", "req-1", [
+        "lease_summary",
+        "payment_readiness_summary",
+      ]);
+    });
+
+    expect(await screen.findByRole("button", { name: /Revoke request/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Revoke request/i }));
+    await waitFor(() => {
+      expect(tenantSharePackagesApi.revokeTenantShareVerificationRequest).toHaveBeenCalledWith("share-1", "req-1");
+    });
   });
 
   it("shows an active-tenancy transition state when tenant access is active but the lease is not active yet", async () => {

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
@@ -11,7 +11,9 @@ import { listTenantScreenings, type TenantScreeningRequest } from "../../api/ten
 import {
   createTenantSharePackage,
   listTenantSharePackages,
+  respondToTenantShareVerificationRequest,
   revokeTenantSharePackage,
+  revokeTenantShareVerificationRequest,
   respondToTenantSharePackage,
   type TenantSharePackageLink,
 } from "../../api/tenantSharePackages";
@@ -88,7 +90,13 @@ function prettyScreeningIdentityStatus(
 }
 
 function prettyShareRequestItem(
-  value: "identity_summary" | "credibility_summary" | "application_summary" | "documents_summary"
+  value:
+    | "identity_summary"
+    | "credibility_summary"
+    | "application_summary"
+    | "documents_summary"
+    | "lease_summary"
+    | "payment_readiness_summary"
 ) {
   switch (value) {
     case "credibility_summary":
@@ -97,6 +105,10 @@ function prettyShareRequestItem(
       return "Application summary";
     case "documents_summary":
       return "Documents summary";
+    case "lease_summary":
+      return "Lease summary";
+    case "payment_readiness_summary":
+      return "Payment readiness summary";
     case "identity_summary":
     default:
       return "Identity summary";
@@ -235,7 +247,14 @@ export default function TenantWorkspacePage() {
   const handleRespondToShareRequest = React.useCallback(
     async (
       id: string,
-      approvedItems: Array<"identity_summary" | "credibility_summary" | "application_summary" | "documents_summary">
+      approvedItems: Array<
+        | "identity_summary"
+        | "credibility_summary"
+        | "application_summary"
+        | "documents_summary"
+        | "lease_summary"
+        | "payment_readiness_summary"
+      >
     ) => {
       try {
         setShareBusy(true);
@@ -250,6 +269,46 @@ export default function TenantWorkspacePage() {
     },
     []
   );
+
+  const handleRespondToVerificationRequest = React.useCallback(
+    async (
+      sharePackageId: string,
+      requestId: string,
+      approvedScopes: Array<
+        | "identity_summary"
+        | "credibility_summary"
+        | "application_summary"
+        | "documents_summary"
+        | "lease_summary"
+        | "payment_readiness_summary"
+      >
+    ) => {
+      try {
+        setShareBusy(true);
+        setShareError(null);
+        const updated = await respondToTenantShareVerificationRequest(sharePackageId, requestId, approvedScopes);
+        setSharePackages((current) => current.map((entry) => (entry.id === sharePackageId ? updated : entry)));
+      } catch (err: any) {
+        setShareError(err?.payload?.error || err?.message || "Unable to update this verification request right now.");
+      } finally {
+        setShareBusy(false);
+      }
+    },
+    []
+  );
+
+  const handleRevokeVerificationRequest = React.useCallback(async (sharePackageId: string, requestId: string) => {
+    try {
+      setShareBusy(true);
+      setShareError(null);
+      const updated = await revokeTenantShareVerificationRequest(sharePackageId, requestId);
+      setSharePackages((current) => current.map((entry) => (entry.id === sharePackageId ? updated : entry)));
+    } catch (err: any) {
+      setShareError(err?.payload?.error || err?.message || "Unable to revoke this verification request right now.");
+    } finally {
+      setShareBusy(false);
+    }
+  }, []);
 
   if (loading) {
     return (
@@ -302,6 +361,7 @@ export default function TenantWorkspacePage() {
   const identityTimeline = data?.identityTimeline?.events || [];
   const communicationsView = buildTenantCommunicationsWorkspaceState(communications);
   const screeningSummary = buildTenantScreeningDashboardSummary(screenings);
+  const identityExchangeReference = sharePackages[0]?.identityExchangeReference || null;
   const notificationItems = filterStructuredNotificationsByPreferences(
     buildTenantStructuredNotificationTriggers({
       packageCategories: reuse.packageCategories,
@@ -694,6 +754,24 @@ export default function TenantWorkspacePage() {
             Generate a privacy-safe share link, review any additional access requests, and approve only the extra summaries you want to share. Public access stays read-only and never exposes raw documents, screening provider details, or signature data.
           </div>
 
+          {identityExchangeReference ? (
+            <div
+              style={{
+                border: "1px solid rgba(15,23,42,0.08)",
+                borderRadius: 12,
+                padding: "12px 14px",
+                display: "grid",
+                gap: 6,
+              }}
+            >
+              <div style={{ fontWeight: 700, color: textTokens.primary }}>Identity exchange</div>
+              <div style={{ color: textTokens.primary }}>{identityExchangeReference.referenceLabel}</div>
+              <div style={{ color: textTokens.secondary, lineHeight: 1.6 }}>
+                {identityExchangeReference.referenceDescription}
+              </div>
+            </div>
+          ) : null}
+
           <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
             <button type="button" onClick={() => void handleGenerateShareLink()} disabled={shareBusy}>
               {shareBusy ? "Generating..." : "Generate share link"}
@@ -738,6 +816,16 @@ export default function TenantWorkspacePage() {
                       ? entry.approvedItems.map((item) => prettyShareRequestItem(item)).join(", ")
                       : "Identity summary only"}
                   </div>
+                  {entry.verificationRequests.some((request) => request.status === "approved") ? (
+                    <div style={{ color: textTokens.secondary }}>
+                      Verification approvals:{" "}
+                      {entry.verificationRequests
+                        .filter((request) => request.status === "approved")
+                        .flatMap((request) => request.requestedScopes)
+                        .map((item) => prettyShareRequestItem(item))
+                        .join(", ")}
+                    </div>
+                  ) : null}
                   {entry.requestedItems.length ? (
                     <div
                       style={{
@@ -770,6 +858,71 @@ export default function TenantWorkspacePage() {
                       </div>
                     </div>
                   ) : null}
+                  {entry.verificationRequests
+                    .filter((request) => request.status === "requested")
+                    .map((request) => (
+                      <div
+                        key={request.requestId}
+                        style={{
+                          border: "1px solid rgba(15,23,42,0.08)",
+                          borderRadius: 12,
+                          padding: "10px 12px",
+                          display: "grid",
+                          gap: 8,
+                        }}
+                      >
+                        <div style={{ fontWeight: 700, color: textTokens.primary }}>Verification request</div>
+                        <div style={{ color: textTokens.secondary }}>
+                          {request.requestedScopes.map((item) => prettyShareRequestItem(item)).join(", ")}
+                        </div>
+                        <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
+                          <button
+                            type="button"
+                            onClick={() =>
+                              void handleRespondToVerificationRequest(entry.id, request.requestId, request.requestedScopes)
+                            }
+                            disabled={shareBusy}
+                          >
+                            Approve request
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => void handleRespondToVerificationRequest(entry.id, request.requestId, [])}
+                            disabled={shareBusy}
+                          >
+                            Decline request
+                          </button>
+                        </div>
+                      </div>
+                    ))}
+                  {entry.verificationRequests
+                    .filter((request) => request.status === "approved")
+                    .map((request) => (
+                      <div
+                        key={`${request.requestId}-approved`}
+                        style={{
+                          border: "1px solid rgba(15,23,42,0.08)",
+                          borderRadius: 12,
+                          padding: "10px 12px",
+                          display: "grid",
+                          gap: 8,
+                        }}
+                      >
+                        <div style={{ fontWeight: 700, color: textTokens.primary }}>Approved verification request</div>
+                        <div style={{ color: textTokens.secondary }}>
+                          {request.requestedScopes.map((item) => prettyShareRequestItem(item)).join(", ")}
+                        </div>
+                        <div>
+                          <button
+                            type="button"
+                            onClick={() => void handleRevokeVerificationRequest(entry.id, request.requestId)}
+                            disabled={shareBusy}
+                          >
+                            Revoke request
+                          </button>
+                        </div>
+                      </div>
+                    ))}
                   <div>
                     <button type="button" onClick={() => void handleRevokeShareLink(entry.id)} disabled={shareBusy}>
                       Revoke link


### PR DESCRIPTION
This PR introduces Tenant Share Package v3.

Includes:
- read-derived identityExchangeReference
- verification request scaffolding on existing tenantSharePackages
- tenant approve/decline/revoke controls for verification scopes
- safe lease_summary and payment_readiness_summary scopes
- public verification request flow
- whitelist-filtered public share payload expansion
- focused backend/frontend test coverage

Guardrails preserved:
- no new collection
- no parallel identity/verification/permission system
- no raw token persistence or exposure
- no public identity lookup or global handle
- no external institution onboarding
- no scoring, ranking, or underwriting
- no raw document/screening/signature/payment exposure
- no provider exposure
- no landlord inbox or review-summary changes
- no canonical event wiring in v3