### PR TITLE
feat: add institutional readiness layer

### DIFF
--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -811,6 +811,33 @@ describe("tenantPortalRoutes foundation", () => {
     ]);
   });
 
+  it("builds a tenant-only institutional identity export safely", async () => {
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/identity/export",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.identitySummary?.identityStatus).toBeTruthy();
+    expect(res.body?.data?.metadata?.consentRequired).toBe(true);
+    const payload = JSON.stringify(res.body?.data || {});
+    expect(payload).not.toContain("drawnDataUrl");
+    expect(payload).not.toContain("documentUrl");
+    expect(payload).not.toContain("paymentMethod");
+    expect(payload).not.toContain("share-token");
+    expect(payload).not.toContain("tenant-1");
+    expect(payload).not.toContain("prop-1");
+  });
+
   it("revokes a tenant share package immediately", async () => {
     ensureCollection("tenantSharePackages").set("share-1", {
       id: "share-1",

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -20,6 +20,7 @@ import { loadTenantIdentityRecord, loadTenantProfileProjection } from "../servic
 import { deriveTenantCredibilitySignals } from "../services/tenantCredibility/deriveTenantCredibilitySignals";
 import { deriveIdentityTimeline } from "../services/identityTimeline/deriveIdentityTimeline";
 import { deriveIdentityPortability } from "../services/identityPortability/deriveIdentityPortability";
+import { deriveInstitutionalIdentityPackage } from "../services/institutional/deriveInstitutionalIdentityPackage";
 import { derivePaymentReadiness } from "../services/paymentReadiness/derivePaymentReadiness";
 import {
   loadTenantCommunicationsWorkspace,
@@ -2972,6 +2973,54 @@ async function handleTenantWorkspaceSummary(req: any, res: any) {
 
 router.get("/workspace", requireTenantWorkspaceIdentity, handleTenantWorkspaceSummary);
 router.get("/me", requireTenantWorkspaceIdentity, handleTenantWorkspaceSummary);
+
+router.post("/identity/export", requireTenantWorkspaceIdentity, async (req: any, res: any) => {
+  const context = await resolveWorkspaceContextOrRespond(req, res);
+  if (!context) return;
+
+  const [workspace, tenantIdentityRecord, identityTimeline] = await Promise.all([
+    loadTenantWorkspaceData(context),
+    loadTenantIdentityRecord({
+      context,
+      userId: String(req.user?.id || "").trim(),
+      userEmail: req.user?.email,
+    }),
+    deriveIdentityTimeline({
+      tenantId: String(req.user?.tenantId || context.tenantId || "").trim(),
+      applicationId: context.applicationId,
+      leaseId: context.leaseId,
+    }),
+  ]);
+  const { tenantCredibilitySignals } = deriveTenantCredibilitySignals({
+    tenantIdentityRecord,
+    leaseExecution: workspace.lease?.leaseExecution || null,
+  });
+  const { portableIdentity } = deriveIdentityPortability({
+    tenantIdentityRecord,
+    credibilitySummary: tenantCredibilitySignals.summary,
+    shareAvailability: {
+      sharingEnabled: Boolean(context.tenantId || req.user?.tenantId || req.user?.id),
+    },
+    timelineAvailability: {
+      hasIdentityTimeline: Array.isArray(identityTimeline?.events) && identityTimeline.events.length > 0,
+    },
+  });
+
+  const institutionalIdentityPackage = deriveInstitutionalIdentityPackage({
+    tenantIdentityRecord,
+    credibilitySummary: tenantCredibilitySignals.summary,
+    leaseExecution: workspace.lease?.leaseExecution || null,
+    paymentReadiness: workspace.lease?.paymentReadiness || null,
+    identityTimeline,
+    portableIdentity,
+    leaseStatus: workspace.lease?.status || null,
+  });
+
+  return res.json({
+    ok: true,
+    data: institutionalIdentityPackage,
+  });
+});
 
 router.post("/share-packages", requireTenantWorkspaceIdentity, async (req: any, res) => {
   const context = await resolveWorkspaceContextOrRespond(req, res);

--- a/rentchain-api/src/services/institutional/__tests__/deriveInstitutionalIdentityPackage.test.ts
+++ b/rentchain-api/src/services/institutional/__tests__/deriveInstitutionalIdentityPackage.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { deriveInstitutionalIdentityPackage } from "../deriveInstitutionalIdentityPackage";
+
+describe("deriveInstitutionalIdentityPackage", () => {
+  it("builds a structured institutional package from safe reduced inputs", () => {
+    const result = deriveInstitutionalIdentityPackage({
+      tenantIdentityRecord: {
+        identityStatus: "verified",
+        profile: { completionStatus: "complete" },
+        application: { reusable: true, lastSubmittedAt: "2026-01-01T00:00:00.000Z" },
+        documents: { completionStatus: "complete", missingCategories: [] },
+        screening: { status: "completed", lastCompletedAt: "2026-01-02T00:00:00.000Z" },
+        leases: { activeCount: 1, historicalCount: 1, lastSignedAt: "2026-01-03T00:00:00.000Z" },
+        verification: { level: "strong" },
+        readinessLabel: "Ready to apply",
+        readinessDescription: "ready",
+      },
+      credibilitySummary: {
+        completenessLevel: "high",
+        verificationLevel: "strong",
+        summaryLabel: "Credibility established",
+        summaryDescription: "Most credibility signals are available.",
+      },
+      leaseExecution: {
+        executionStatus: "fully_executed",
+        executionLabel: "Lease fully executed",
+        executionDescription: "done",
+        requiredNextAction: "none",
+        tenantSignatureStatus: "completed",
+        landlordSignatureStatus: "completed",
+        pdfStatus: "generated",
+        completedAt: "2026-01-04T00:00:00.000Z",
+      },
+      paymentReadiness: {
+        readinessStatus: "ready_to_configure",
+        readinessLabel: "Rent terms ready for future setup",
+        readinessDescription: "safe",
+        requiredNextAction: "confirm_payment_setup_later",
+        rentTerms: {
+          rentAmountAvailable: true,
+          dueDateAvailable: true,
+          leaseDatesAvailable: true,
+          tenantLinked: true,
+          leaseExecuted: true,
+        },
+        paymentSetup: {
+          processorConnected: false,
+          moneyMovementEnabled: false,
+          storedPaymentMethod: false,
+        },
+      },
+      identityTimeline: {
+        events: [
+          {
+            type: "application.created",
+            label: "Application created",
+            description: "A rental application record was started.",
+            occurredAt: "2026-01-01T00:00:00.000Z",
+          },
+        ],
+      },
+      portableIdentity: {
+        portabilityStatus: "ready",
+        portabilityLabel: "Ready to reuse",
+        portabilityDescription: "ready",
+        reusableAcrossApplications: true,
+        identityReference: {
+          referenceType: "tenant_identity",
+          referenceStatus: "active",
+        },
+        readiness: {
+          identityReady: true,
+          applicationReusable: true,
+          credibilityReady: true,
+          sharingEnabled: true,
+        },
+        nextAction: "none",
+      },
+      leaseStatus: "active",
+    });
+
+    expect(result.identitySummary.identityStatus).toBe("verified");
+    expect(result.leaseSummary.activeLease).toBe(true);
+    expect(result.auditSummary.totalEvents).toBe(1);
+    expect(JSON.stringify(result)).not.toContain("documentUrl");
+    expect(JSON.stringify(result)).not.toContain("drawnDataUrl");
+    expect(JSON.stringify(result)).not.toContain("paymentMethod");
+  });
+
+  it("handles missing data safely without exposing unsupported fields", () => {
+    const result = deriveInstitutionalIdentityPackage({
+      tenantIdentityRecord: null,
+      credibilitySummary: null,
+      leaseExecution: null,
+      paymentReadiness: null,
+      identityTimeline: { events: [] },
+      portableIdentity: null,
+      leaseStatus: null,
+    });
+
+    expect(result.identitySummary.identityStatus).toBe("incomplete");
+    expect(result.paymentReadinessSummary.readinessStatus).toBe("not_available");
+    expect(result.auditSummary.totalEvents).toBe(0);
+  });
+});

--- a/rentchain-api/src/services/institutional/deriveInstitutionalIdentityPackage.ts
+++ b/rentchain-api/src/services/institutional/deriveInstitutionalIdentityPackage.ts
@@ -1,0 +1,165 @@
+import type { PortableIdentity } from "../identityPortability/deriveIdentityPortability";
+import type { LeaseExecution } from "../leaseExecution/deriveLeaseExecution";
+import type { PaymentReadiness } from "../paymentReadiness/derivePaymentReadiness";
+import type { LandlordSafeTenantCredibilitySummary } from "../tenantCredibility/deriveTenantCredibilitySignals";
+import type { IdentityTimeline } from "../identityTimeline/deriveIdentityTimeline";
+import type { TenantIdentityRecord } from "../tenantPortal/tenantProfileService";
+
+export type InstitutionalIdentityPackage = {
+  identitySummary: {
+    identityStatus: "incomplete" | "ready" | "verified" | "limited";
+    verificationLevel: "none" | "partial" | "strong";
+    completenessLevel: "low" | "medium" | "high";
+    readinessLabel: string;
+  };
+  credibilitySummary: {
+    completenessLevel: "low" | "medium" | "high";
+    verificationLevel: "none" | "partial" | "strong";
+    summaryLabel: string;
+    summaryDescription: string;
+  };
+  leaseSummary: {
+    activeLease: boolean;
+    leaseExecutionStatus:
+      | "draft"
+      | "ready_for_tenant_signature"
+      | "tenant_signed"
+      | "ready_for_landlord_signature"
+      | "landlord_signed"
+      | "fully_executed"
+      | "blocked"
+      | "not_available";
+  };
+  paymentReadinessSummary: {
+    readinessStatus: "not_ready" | "ready_to_configure" | "blocked" | "not_available";
+    readinessLabel: string;
+    readinessDescription: string;
+  };
+  auditSummary: {
+    totalEvents: number;
+    recentActivity: Array<{
+      type:
+        | "application.created"
+        | "application.submitted"
+        | "screening_consent_confirmed"
+        | "screening.completed"
+        | "lease.created"
+        | "lease.activated"
+        | "lease.tenant_signed";
+      label: string;
+      occurredAt: string;
+    }>;
+  };
+  portabilitySummary?: {
+    portabilityStatus: "not_ready" | "ready" | "limited";
+    portabilityLabel: string;
+    reusableAcrossApplications: boolean;
+  };
+  metadata: {
+    generatedAt: string;
+    dataScope: "tenant_controlled_institutional_readiness";
+    consentRequired: true;
+  };
+};
+
+type DeriveInstitutionalIdentityPackageInput = {
+  tenantIdentityRecord: TenantIdentityRecord | null;
+  credibilitySummary: LandlordSafeTenantCredibilitySummary | null;
+  leaseExecution: LeaseExecution | null;
+  paymentReadiness: PaymentReadiness | null;
+  identityTimeline: IdentityTimeline | null;
+  portableIdentity?: PortableIdentity | null;
+  leaseStatus?: string | null;
+};
+
+function deriveCompletenessLevel(
+  tenantIdentityRecord: TenantIdentityRecord | null,
+  credibilitySummary: LandlordSafeTenantCredibilitySummary | null
+): "low" | "medium" | "high" {
+  if (credibilitySummary?.completenessLevel) return credibilitySummary.completenessLevel;
+  if (!tenantIdentityRecord) return "low";
+  if (tenantIdentityRecord.identityStatus === "verified") return "high";
+  if (tenantIdentityRecord.identityStatus === "ready") return "medium";
+  return "low";
+}
+
+function normalizeLeaseExecutionStatus(
+  leaseExecution: LeaseExecution | null
+): InstitutionalIdentityPackage["leaseSummary"]["leaseExecutionStatus"] {
+  if (!leaseExecution) return "not_available";
+  return leaseExecution.executionStatus;
+}
+
+function hasActiveLease(
+  leaseStatus: string | null | undefined,
+  leaseExecution: LeaseExecution | null
+): boolean {
+  const normalized = String(leaseStatus || "").trim().toLowerCase();
+  if (["active", "current", "signed"].includes(normalized)) return true;
+  return Boolean(
+    leaseExecution &&
+      ["tenant_signed", "ready_for_landlord_signature", "landlord_signed", "fully_executed"].includes(
+        leaseExecution.executionStatus
+      )
+  );
+}
+
+export function deriveInstitutionalIdentityPackage(
+  input: DeriveInstitutionalIdentityPackageInput
+): InstitutionalIdentityPackage {
+  const tenantIdentityRecord = input.tenantIdentityRecord || null;
+  const credibilitySummary = input.credibilitySummary || null;
+  const leaseExecution = input.leaseExecution || null;
+  const paymentReadiness = input.paymentReadiness || null;
+  const identityTimeline = input.identityTimeline || { events: [] };
+  const portableIdentity = input.portableIdentity || null;
+  const completenessLevel = deriveCompletenessLevel(tenantIdentityRecord, credibilitySummary);
+
+  return {
+    identitySummary: {
+      identityStatus: tenantIdentityRecord?.identityStatus || "incomplete",
+      verificationLevel: tenantIdentityRecord?.verification.level || "none",
+      completenessLevel,
+      readinessLabel: tenantIdentityRecord?.readinessLabel || "More details needed",
+    },
+    credibilitySummary: {
+      completenessLevel: credibilitySummary?.completenessLevel || "low",
+      verificationLevel: credibilitySummary?.verificationLevel || "none",
+      summaryLabel: credibilitySummary?.summaryLabel || "Getting started",
+      summaryDescription:
+        credibilitySummary?.summaryDescription ||
+        "Credibility signals are still limited in the current tenant-controlled record.",
+    },
+    leaseSummary: {
+      activeLease: hasActiveLease(input.leaseStatus, leaseExecution),
+      leaseExecutionStatus: normalizeLeaseExecutionStatus(leaseExecution),
+    },
+    paymentReadinessSummary: paymentReadiness
+      ? {
+          readinessStatus: paymentReadiness.readinessStatus,
+          readinessLabel: paymentReadiness.readinessLabel,
+          readinessDescription: paymentReadiness.readinessDescription,
+        }
+      : {
+          readinessStatus: "not_available",
+          readinessLabel: "Payment readiness unavailable",
+          readinessDescription: "Payment readiness is not available in the current tenant-safe lease projection.",
+        },
+    auditSummary: {
+      totalEvents: Array.isArray(identityTimeline.events) ? identityTimeline.events.length : 0,
+      recentActivity: (Array.isArray(identityTimeline.events) ? identityTimeline.events : []).slice(-5).reverse(),
+    },
+    portabilitySummary: portableIdentity
+      ? {
+          portabilityStatus: portableIdentity.portabilityStatus,
+          portabilityLabel: portableIdentity.portabilityLabel,
+          reusableAcrossApplications: portableIdentity.reusableAcrossApplications,
+        }
+      : undefined,
+    metadata: {
+      generatedAt: new Date().toISOString(),
+      dataScope: "tenant_controlled_institutional_readiness",
+      consentRequired: true,
+    },
+  };
+}

--- a/rentchain-frontend/src/api/tenantPortal.ts
+++ b/rentchain-frontend/src/api/tenantPortal.ts
@@ -285,6 +285,63 @@ export type PortableIdentity = {
   nextAction: "complete_identity" | "enable_sharing" | "review_reusability" | "none";
 };
 
+export type InstitutionalIdentityPackage = {
+  identitySummary: {
+    identityStatus: "incomplete" | "ready" | "verified" | "limited";
+    verificationLevel: "none" | "partial" | "strong";
+    completenessLevel: "low" | "medium" | "high";
+    readinessLabel: string;
+  };
+  credibilitySummary: {
+    completenessLevel: "low" | "medium" | "high";
+    verificationLevel: "none" | "partial" | "strong";
+    summaryLabel: string;
+    summaryDescription: string;
+  };
+  leaseSummary: {
+    activeLease: boolean;
+    leaseExecutionStatus:
+      | "draft"
+      | "ready_for_tenant_signature"
+      | "tenant_signed"
+      | "ready_for_landlord_signature"
+      | "landlord_signed"
+      | "fully_executed"
+      | "blocked"
+      | "not_available";
+  };
+  paymentReadinessSummary: {
+    readinessStatus: "not_ready" | "ready_to_configure" | "blocked" | "not_available";
+    readinessLabel: string;
+    readinessDescription: string;
+  };
+  auditSummary: {
+    totalEvents: number;
+    recentActivity: Array<{
+      type:
+        | "application.created"
+        | "application.submitted"
+        | "screening_consent_confirmed"
+        | "screening.completed"
+        | "lease.created"
+        | "lease.activated"
+        | "lease.tenant_signed";
+      label: string;
+      occurredAt: string;
+    }>;
+  };
+  portabilitySummary?: {
+    portabilityStatus: "not_ready" | "ready" | "limited";
+    portabilityLabel: string;
+    reusableAcrossApplications: boolean;
+  };
+  metadata: {
+    generatedAt: string;
+    dataScope: "tenant_controlled_institutional_readiness";
+    consentRequired: true;
+  };
+};
+
 export type TenantWorkspaceSummary = {
   context: TenantWorkspaceContext;
   property: TenantWorkspaceProperty | null;
@@ -299,6 +356,13 @@ export type TenantWorkspaceSummary = {
 
 export async function getTenantWorkspace(): Promise<TenantWorkspaceSummary> {
   const res = await tenantApiFetch<{ ok: boolean; data: TenantWorkspaceSummary }>("/tenant/workspace");
+  return res?.data;
+}
+
+export async function exportTenantIdentityPackage(): Promise<InstitutionalIdentityPackage> {
+  const res = await tenantApiFetch<{ ok: boolean; data: InstitutionalIdentityPackage }>("/tenant/identity/export", {
+    method: "POST",
+  });
   return res?.data;
 }
 

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -12,6 +12,7 @@ import { TenantNav } from "../../components/layout/TenantNav";
 const tenantPortalApi = vi.hoisted(() => ({
   getTenantWorkspace: vi.fn(),
   getTenantLeaseWorkspace: vi.fn(),
+  exportTenantIdentityPackage: vi.fn(),
   signTenantLease: vi.fn(),
   listTenantWorkspaceMaintenance: vi.fn(),
   redeemTenantWorkspaceInvite: vi.fn(),
@@ -254,6 +255,49 @@ describe("tenant workspace frontend shell", () => {
         ],
       },
     });
+    tenantPortalApi.exportTenantIdentityPackage.mockResolvedValue({
+      identitySummary: {
+        identityStatus: "ready",
+        verificationLevel: "partial",
+        completenessLevel: "high",
+        readinessLabel: "Ready to apply",
+      },
+      credibilitySummary: {
+        completenessLevel: "high",
+        verificationLevel: "partial",
+        summaryLabel: "Credibility established",
+        summaryDescription: "Most credibility signals are available in your current record.",
+      },
+      leaseSummary: {
+        activeLease: true,
+        leaseExecutionStatus: "fully_executed",
+      },
+      paymentReadinessSummary: {
+        readinessStatus: "ready_to_configure",
+        readinessLabel: "Rent terms ready for future setup",
+        readinessDescription: "The current lease shows the core rent terms needed for future setup planning.",
+      },
+      auditSummary: {
+        totalEvents: 2,
+        recentActivity: [
+          {
+            type: "lease.activated",
+            label: "Lease activated",
+            occurredAt: "2026-02-01T00:00:00.000Z",
+          },
+        ],
+      },
+      portabilitySummary: {
+        portabilityStatus: "ready",
+        portabilityLabel: "Ready to reuse",
+        reusableAcrossApplications: true,
+      },
+      metadata: {
+        generatedAt: "2026-04-27T00:00:00.000Z",
+        dataScope: "tenant_controlled_institutional_readiness",
+        consentRequired: true,
+      },
+    });
     tenantAttachmentsApi.getTenantAttachments.mockResolvedValue({
       ok: true,
       data: [
@@ -436,6 +480,8 @@ describe("tenant workspace frontend shell", () => {
         writeText: vi.fn().mockResolvedValue(undefined),
       },
     });
+    global.URL.createObjectURL = vi.fn(() => "blob:institutional-export");
+    global.URL.revokeObjectURL = vi.fn();
   });
 
   it("tenant shell renders expected navigation safely", async () => {
@@ -730,6 +776,31 @@ describe("tenant workspace frontend shell", () => {
     await waitFor(() => {
       expect(tenantSharePackagesApi.revokeTenantSharePackage).toHaveBeenCalledWith("share-1");
     });
+  });
+
+  it("lets tenants preview and download an institutional identity export safely", async () => {
+    render(
+      <MemoryRouter>
+        <TenantWorkspacePage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Institutional readiness/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Export Rental Identity/i }));
+
+    await waitFor(() => {
+      expect(tenantPortalApi.exportTenantIdentityPackage).toHaveBeenCalledTimes(1);
+    });
+
+    expect(await screen.findByRole("button", { name: /Hide preview/i })).toBeInTheDocument();
+    expect(screen.getByText(/Export preview/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Credibility established/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Lease activated/i)).toBeInTheDocument();
+    expect(screen.queryByText(/drawnDataUrl/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/paymentMethod/i)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Download JSON/i }));
+    expect(global.URL.createObjectURL).toHaveBeenCalledTimes(1);
   });
 
   it("lets tenants approve a pending share access request", async () => {

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import { getTenantWorkspace } from "../../api/tenantPortal";
+import { exportTenantIdentityPackage, getTenantWorkspace } from "../../api/tenantPortal";
 import { getTenantAccess, type TenantAccessWorkspace } from "../../api/tenantAccess";
 import { getTenantAttachments } from "../../api/tenantAttachmentsApi";
 import { getTenantProfile } from "../../api/tenantProfile";
@@ -117,6 +117,7 @@ function prettyShareRequestItem(
 
 export default function TenantWorkspacePage() {
   const [data, setData] = React.useState<Awaited<ReturnType<typeof getTenantWorkspace>> | null>(null);
+  const [institutionalPackage, setInstitutionalPackage] = React.useState<Awaited<ReturnType<typeof exportTenantIdentityPackage>> | null>(null);
   const [access, setAccess] = React.useState<TenantAccessWorkspace | null>(null);
   const [attachments, setAttachments] = React.useState<Awaited<ReturnType<typeof getTenantAttachments>> | null>(null);
   const [profileData, setProfileData] = React.useState<Awaited<ReturnType<typeof getTenantProfile>> | null>(null);
@@ -128,6 +129,9 @@ export default function TenantWorkspacePage() {
   const [freshShareUrl, setFreshShareUrl] = React.useState<string | null>(null);
   const [shareBusy, setShareBusy] = React.useState(false);
   const [shareError, setShareError] = React.useState<string | null>(null);
+  const [exportBusy, setExportBusy] = React.useState(false);
+  const [exportError, setExportError] = React.useState<string | null>(null);
+  const [showExportPreview, setShowExportPreview] = React.useState(false);
   const [profileLoading, setProfileLoading] = React.useState(true);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
@@ -230,6 +234,39 @@ export default function TenantWorkspacePage() {
       setShareError("Copy is unavailable in this browser right now.");
     }
   }, [freshShareUrl]);
+
+  const handleExportRentalIdentity = React.useCallback(async () => {
+    try {
+      setExportBusy(true);
+      setExportError(null);
+      const next = await exportTenantIdentityPackage();
+      setInstitutionalPackage(next);
+      setShowExportPreview(true);
+    } catch (err: any) {
+      setExportError(err?.payload?.error || err?.message || "Unable to prepare this export right now.");
+    } finally {
+      setExportBusy(false);
+    }
+  }, []);
+
+  const handleDownloadExportJson = React.useCallback(() => {
+    if (!institutionalPackage) return;
+    try {
+      const blob = new Blob([JSON.stringify(institutionalPackage, null, 2)], {
+        type: "application/json",
+      });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = "rentchain-institutional-identity-package.json";
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+    } catch {
+      setExportError("JSON download is unavailable in this browser right now.");
+    }
+  }, [institutionalPackage]);
 
   const handleRevokeShareLink = React.useCallback(async (id: string) => {
     try {
@@ -717,6 +754,86 @@ export default function TenantWorkspacePage() {
             Portable identity status will appear here once enough tenant-safe identity signals are available.
           </div>
         )}
+      </TenantInfoCard>
+
+      <TenantInfoCard heading="Institutional readiness" accent="#0f766e">
+        <div style={{ display: "grid", gap: spacing.sm }}>
+          <div style={{ color: textTokens.secondary, lineHeight: 1.6 }}>
+            Prepare a tenant-controlled export of your rental identity as a structured summary for offline record sharing or future institutional review. This does not send data anywhere or create an external integration.
+          </div>
+
+          <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
+            <button type="button" onClick={() => void handleExportRentalIdentity()} disabled={exportBusy}>
+              {exportBusy ? "Preparing export..." : "Export Rental Identity"}
+            </button>
+            {institutionalPackage ? (
+              <>
+                <button type="button" onClick={handleDownloadExportJson}>
+                  Download JSON
+                </button>
+                <button type="button" className="no-print" onClick={() => window.print()}>
+                  Print / Save PDF
+                </button>
+              </>
+            ) : null}
+          </div>
+
+          {exportError ? <div style={{ color: "#b91c1c" }}>{exportError}</div> : null}
+
+          {institutionalPackage ? (
+            <div style={{ display: "grid", gap: 8 }}>
+              <button
+                type="button"
+                onClick={() => setShowExportPreview((current) => !current)}
+                style={{ justifySelf: "start" }}
+              >
+                {showExportPreview ? "Hide preview" : "Show preview"}
+              </button>
+
+              {showExportPreview ? (
+                <div
+                  style={{
+                    border: "1px solid rgba(15,23,42,0.08)",
+                    borderRadius: 12,
+                    padding: "12px 14px",
+                    display: "grid",
+                    gap: 12,
+                  }}
+                >
+                  <div style={{ fontWeight: 700, color: textTokens.primary }}>Export preview</div>
+                  <TenantKeyValueGrid
+                    rows={[
+                      { label: "Identity status", value: prettyStatus(institutionalPackage.identitySummary.identityStatus) },
+                      { label: "Verification level", value: prettyVerificationLevel(institutionalPackage.identitySummary.verificationLevel) },
+                      { label: "Completeness", value: prettyStatus(institutionalPackage.identitySummary.completenessLevel) },
+                      { label: "Credibility", value: institutionalPackage.credibilitySummary.summaryLabel },
+                      { label: "Active lease", value: institutionalPackage.leaseSummary.activeLease ? "Yes" : "No" },
+                      { label: "Lease execution", value: prettyStatus(institutionalPackage.leaseSummary.leaseExecutionStatus) },
+                      { label: "Payment readiness", value: institutionalPackage.paymentReadinessSummary.readinessLabel },
+                      { label: "Audit events", value: String(institutionalPackage.auditSummary.totalEvents) },
+                      { label: "Consent required", value: institutionalPackage.metadata.consentRequired ? "Yes" : "No" },
+                    ]}
+                  />
+
+                  <div style={{ color: textTokens.secondary, lineHeight: 1.6 }}>
+                    {institutionalPackage.credibilitySummary.summaryDescription}
+                  </div>
+
+                  {institutionalPackage.auditSummary.recentActivity.length ? (
+                    <div style={{ display: "grid", gap: 6 }}>
+                      <div style={{ fontWeight: 700, color: textTokens.primary }}>Recent activity</div>
+                      {institutionalPackage.auditSummary.recentActivity.map((event) => (
+                        <div key={`${event.type}:${event.occurredAt}`} style={{ color: textTokens.secondary }}>
+                          {event.label} • {formatDate(event.occurredAt)}
+                        </div>
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
       </TenantInfoCard>
 
       <TenantInfoCard heading="Activity timeline" accent="#0891b2">


### PR DESCRIPTION
This PR introduces Institutional Readiness Layer v1.

Includes:
- tenant-only POST /tenant/identity/export
- read-derived InstitutionalIdentityPackage
- tenant workspace Institutional readiness card
- preview, Download JSON, and Print / Save PDF actions
- reduced identity, credibility, lease, payment readiness, audit, and portability summaries
- focused backend/frontend test coverage

Guardrails preserved:
- no export storage
- no outbound transfer
- no institution onboarding UI
- no landlord-facing institutional summaries
- no public share-package coupling
- no raw documents, document names, screening details, provider names, signatures, financial account data, share tokens, internal IDs, or raw audit logs