### PR TITLE
feat: add TransUnion onboarding funnel

### DIFF
--- a/rentchain-frontend/src/components/integrations/GetTransUnionAccessModal.test.tsx
+++ b/rentchain-frontend/src/components/integrations/GetTransUnionAccessModal.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { GetTransUnionAccessModal } from "./GetTransUnionAccessModal";
+
+describe("GetTransUnionAccessModal", () => {
+  it("renders the TransUnion contact block with direct email and call actions", () => {
+    render(
+      <GetTransUnionAccessModal
+        open
+        onClose={vi.fn()}
+        onMarkInProgress={vi.fn()}
+        onEnterCredentials={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("Chhavi Kumar")).toBeInTheDocument();
+    expect(screen.getByText("Account Executive, Inside Sales")).toBeInTheDocument();
+    expect(screen.getByText("Chhavi.kumar@transunion.com")).toBeInTheDocument();
+    expect(screen.getByText("289-208-7386")).toBeInTheDocument();
+    expect(screen.getByText("Customer Support: 1-800-565-2280")).toBeInTheDocument();
+    expect(screen.getByText("Tech Support: (877) 559-5585 Option 4")).toBeInTheDocument();
+    expect(screen.getByText("clientsupport@transunion.com")).toBeInTheDocument();
+
+    const emailLink = screen.getByRole("link", { name: "Email Chhavi Kumar" });
+    expect(emailLink).toHaveAttribute("href", expect.stringContaining("mailto:Chhavi.kumar@transunion.com"));
+    expect(emailLink).toHaveAttribute(
+      "href",
+      expect.stringContaining(
+        "subject=TransUnion%20Credentialing%20Request%20for%20RentChain%20Screening"
+      )
+    );
+    expect(emailLink).toHaveAttribute(
+      "href",
+      expect.stringContaining(
+        "I%20would%20like%20to%20start%20the%20credentialing%20process%20for%20TransUnion%20tenant%20screening"
+      )
+    );
+
+    const callLink = screen.getByRole("link", { name: "Call Chhavi Kumar" });
+    expect(callLink).toHaveAttribute("href", "tel:2892087386");
+  });
+
+  it("keeps the already credentialed path in the existing connect flow", () => {
+    const onEnterCredentials = vi.fn();
+    render(
+      <GetTransUnionAccessModal
+        open
+        onClose={vi.fn()}
+        onMarkInProgress={vi.fn()}
+        onEnterCredentials={onEnterCredentials}
+      />
+    );
+
+    const buttons = screen.getAllByRole("button", { name: "Already Credentialed?" });
+    fireEvent.click(buttons[buttons.length - 1]);
+    expect(onEnterCredentials).toHaveBeenCalledTimes(1);
+  });
+});

--- a/rentchain-frontend/src/components/integrations/GetTransUnionAccessModal.tsx
+++ b/rentchain-frontend/src/components/integrations/GetTransUnionAccessModal.tsx
@@ -2,6 +2,31 @@ import React from "react";
 import { Button, Card } from "../ui/Ui";
 import { colors, radius, shadows, spacing, text } from "@/styles/tokens";
 
+const CHHAVI_EMAIL = "Chhavi.kumar@transunion.com";
+const CHHAVI_PHONE = "289-208-7386";
+const CUSTOMER_SUPPORT_PHONE = "1-800-565-2280";
+const TECH_SUPPORT_PHONE = "(877) 559-5585 Option 4";
+const TECH_SUPPORT_EMAIL = "clientsupport@transunion.com";
+const MAILTO_SUBJECT = "TransUnion Credentialing Request for RentChain Screening";
+const MAILTO_BODY = [
+  "Hello Chhavi,",
+  "",
+  "I would like to start the credentialing process for TransUnion tenant screening so I can connect my business account in RentChain.",
+  "",
+  "Business name:",
+  "Primary contact name:",
+  "Primary contact email:",
+  "Primary contact phone:",
+  "",
+  "Please let me know the next steps and any information required for credentialing.",
+  "",
+  "Thank you,",
+].join("\n");
+const CHHAVI_MAILTO = `mailto:${CHHAVI_EMAIL}?subject=${encodeURIComponent(MAILTO_SUBJECT)}&body=${encodeURIComponent(
+  MAILTO_BODY
+)}`;
+const CHHAVI_TEL = `tel:${CHHAVI_PHONE.replace(/[^\d+]/g, "")}`;
+
 type Props = {
   open: boolean;
   submitting?: boolean;
@@ -95,10 +120,70 @@ export function GetTransUnionAccessModal({
         >
           <div style={{ fontWeight: 700, color: text.primary, marginBottom: 8 }}>How credentialing works</div>
           <ol style={{ margin: 0, paddingLeft: 18, display: "grid", gap: 6 }}>
-            <li>Request TransUnion credentialing for your business.</li>
-            <li>Wait for your member code and passcode to be issued.</li>
-            <li>Return to RentChain and connect your account.</li>
+            <li>Contact TransUnion.</li>
+            <li>Get credentialed for your business.</li>
+            <li>Receive your member code and passcode.</li>
+            <li>Return to RentChain and connect your credentials.</li>
           </ol>
+        </div>
+        <div
+          style={{
+            border: `1px solid ${colors.border}`,
+            borderRadius: radius.md,
+            padding: spacing.sm,
+            background: "#fff",
+            display: "grid",
+            gap: 8,
+          }}
+        >
+          <div style={{ fontWeight: 700, color: text.primary }}>TransUnion contact</div>
+          <div style={{ color: text.primary, lineHeight: 1.6 }}>
+            <div>Chhavi Kumar</div>
+            <div>Account Executive, Inside Sales</div>
+            <div>{CHHAVI_EMAIL}</div>
+            <div>{CHHAVI_PHONE}</div>
+            <div>Customer Support: {CUSTOMER_SUPPORT_PHONE}</div>
+            <div>Tech Support: {TECH_SUPPORT_PHONE}</div>
+            <div>{TECH_SUPPORT_EMAIL}</div>
+          </div>
+          <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
+            <a
+              href={CHHAVI_MAILTO}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                padding: "10px 14px",
+                borderRadius: radius.pill,
+                border: `1px solid ${colors.border}`,
+                background: colors.accentSoft,
+                color: text.primary,
+                textDecoration: "none",
+                fontWeight: 600,
+                fontSize: "0.95rem",
+              }}
+            >
+              Email Chhavi Kumar
+            </a>
+            <a
+              href={CHHAVI_TEL}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                padding: "10px 14px",
+                borderRadius: radius.pill,
+                border: `1px solid ${colors.border}`,
+                background: "transparent",
+                color: text.primary,
+                textDecoration: "none",
+                fontWeight: 600,
+                fontSize: "0.95rem",
+              }}
+            >
+              Call Chhavi Kumar
+            </a>
+          </div>
         </div>
         <div
           style={{

--- a/rentchain-frontend/src/components/integrations/TransUnionConnectionCard.test.tsx
+++ b/rentchain-frontend/src/components/integrations/TransUnionConnectionCard.test.tsx
@@ -28,7 +28,9 @@ describe("TransUnionConnectionCard", () => {
     );
 
     expect(screen.getByText("TransUnion Connection")).toBeInTheDocument();
-    expect(screen.getByText(/Use your TransUnion membership to enable tenant screening/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Start with TransUnion credentialing if you do not have a member code and passcode yet/i)
+    ).toBeInTheDocument();
     expect(screen.getAllByText("Not connected")).toHaveLength(2);
     expect(screen.getByText("Connect or get access")).toBeInTheDocument();
     expect(screen.getByText("Ready to screen")).toBeInTheDocument();
@@ -52,7 +54,8 @@ describe("TransUnionConnectionCard", () => {
     expect(
       screen.getByText(/Your TransUnion credentialing is in progress/i)
     ).toBeInTheDocument();
-    expect(screen.getByText(/Next step: finish credentialing/i)).toBeInTheDocument();
+    expect(screen.getByText(/Contact TransUnion directly, complete credentialing/i)).toBeInTheDocument();
+    expect(screen.getByText(/Next step: finish credentialing with TransUnion/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Enter Membership Details" })).toBeInTheDocument();
   });
 
@@ -106,7 +109,7 @@ describe("TransUnionConnectionCard", () => {
       />
     );
 
-    expect(screen.getByText(/next step is to choose an applicant/i)).toBeInTheDocument();
+    expect(screen.getByText(/choose an applicant in RentChain to start the screening workflow/i)).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Choose an Applicant" }));
     expect(onChooseApplicant).toHaveBeenCalledTimes(1);
   });

--- a/rentchain-frontend/src/components/integrations/TransUnionConnectionCard.tsx
+++ b/rentchain-frontend/src/components/integrations/TransUnionConnectionCard.tsx
@@ -86,19 +86,21 @@ export function TransUnionConnectionCard({
 
   if (status === "pending_credentialing") {
     body =
-      "Your TransUnion credentialing is in progress. Once TransUnion issues your member code and passcode, return to RentChain to complete setup.";
-    helper = "This path is for landlords who still need external TransUnion approval before they can screen inside RentChain.";
-    nextStep = "Next step: finish credentialing, then enter your issued membership details here.";
+      "Your TransUnion credentialing is in progress. Contact TransUnion directly, complete credentialing, and return to RentChain once your member code and passcode are issued.";
+    helper =
+      "RentChain does not replace TransUnion onboarding. This path keeps the next step visible while you work directly with TransUnion.";
+    nextStep =
+      "Next step: finish credentialing with TransUnion, then return here and enter the issued membership details.";
     actions = [
       { label: "Enter Membership Details", onClick: onEnterDetails, variant: "primary" },
       { label: "View Instructions", onClick: onViewInstructions },
     ];
   } else if (status === "connected") {
     body = readyToScreen
-      ? "Your TransUnion membership is connected and you are ready to screen an applicant inside RentChain."
-      : "Your TransUnion membership is connected. Your next step is to choose an applicant so you can start the first screening.";
+      ? "Your TransUnion membership is connected and ready to use inside RentChain for applicant screening."
+      : "Your TransUnion membership is connected. Choose an applicant in RentChain to start the screening workflow.";
     helper = readyToScreen
-      ? "You already have an application in context, so you can move straight into screening."
+      ? "You already have an application in context, so the next step stays inside the screening workflow."
       : "Choose an applicant from Applications first, then start screening from that application context.";
     nextStep = readyToScreen
       ? `Next step: start screening${safeSelectedApplicationLabel ? ` for ${safeSelectedApplicationLabel}` : ""}.`
@@ -123,9 +125,10 @@ export function TransUnionConnectionCard({
     ];
   } else {
     body =
-      "Use your TransUnion membership to enable tenant screening in RentChain. If you are not credentialed yet, RentChain will guide you through that first.";
-    helper = "Choose the path that matches your current state so you can reach screening with fewer setup loops.";
-    nextStep = "Next step: either start TransUnion credentialing or connect your existing membership.";
+      "Start with TransUnion credentialing if you do not have a member code and passcode yet. Once TransUnion issues them, return to RentChain and connect your membership.";
+    helper =
+      "Use the guided access path first if your business still needs TransUnion approval. If you already have credentials, connect them directly here.";
+    nextStep = "Next step: get TransUnion access first, or connect your existing membership details.";
     actions = [
       { label: "Get TransUnion Access", onClick: onGetAccess, variant: "primary" },
       { label: "Connect Existing Membership", onClick: onConnectExisting },

--- a/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
@@ -187,11 +187,11 @@ vi.mock("@/components/integrations/TransUnionConnectionCard", () => ({
 }));
 
 vi.mock("@/components/integrations/GetTransUnionAccessModal", () => ({
-  GetTransUnionAccessModal: () => null,
+  GetTransUnionAccessModal: ({ open }: any) => (open ? <div>Get TransUnion Access Modal</div> : null),
 }));
 
 vi.mock("@/components/integrations/ConnectTransUnionModal", () => ({
-  ConnectTransUnionModal: () => null,
+  ConnectTransUnionModal: ({ open }: any) => (open ? <div>Connect TransUnion Modal</div> : null),
 }));
 
 vi.mock("@/components/integrations/UpdateTransUnionCredentialsModal", () => ({
@@ -512,6 +512,16 @@ describe("ApplicationsPage", () => {
       requiredPlan: "starter",
       source: "applications_page_screening",
     });
+  });
+
+  it("opens the TransUnion access modal from the approved query-param path", async () => {
+    render(
+      <MemoryRouter initialEntries={["/applications?openTransUnionAccess=1"]}>
+        <ApplicationsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Get TransUnion Access Modal")).toBeInTheDocument();
   });
 
   it("opens a request-more-info modal and sends the actionable request", async () => {

--- a/rentchain-frontend/src/pages/DashboardPage.test.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.test.tsx
@@ -16,7 +16,16 @@ const mocks = vi.hoisted(() => ({
   getLandlordActivationMock: vi.fn(),
   useOnboardingStateMock: vi.fn(),
   useUpgradeMock: vi.fn(),
+  navigateMock: vi.fn(),
 }));
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<any>("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mocks.navigateMock,
+  };
+});
 
 vi.mock("../context/useAuth", () => ({
   useAuth: mocks.useAuthMock,
@@ -62,11 +71,19 @@ vi.mock("../context/UpgradeContext", () => ({
   useUpgrade: mocks.useUpgradeMock,
 }));
 
+vi.mock("../config/screening", () => ({
+  SCREENING_ENABLED: true,
+  getUiLocale: () => "en",
+  screeningComingSoonLabel: () => "Credit screening - coming soon.",
+}));
+
 afterEach(() => {
   cleanup();
 });
 
 describe("DashboardPage", () => {
+  const assignMock = vi.fn();
+
   beforeEach(() => {
     window.localStorage.removeItem("rentchain.landlordWelcome.pending.landlord-1");
     window.localStorage.removeItem("rentchain.landlordWelcome.seen.landlord-1");
@@ -140,6 +157,15 @@ describe("DashboardPage", () => {
     });
     mocks.useUpgradeMock.mockReturnValue({
       openUpgrade: vi.fn(),
+    });
+    mocks.navigateMock.mockReset();
+    assignMock.mockReset();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        ...window.location,
+        assign: assignMock,
+      },
     });
   });
 
@@ -218,5 +244,52 @@ describe("DashboardPage", () => {
 
     expect(await screen.findByRole("link", { name: "3" })).toHaveAttribute("href", "/dashboard#open-actions");
     expect(screen.getByRole("link", { name: "2" })).toHaveAttribute("href", "/applications?status=review");
+  });
+
+  it("routes the screening setup CTA to the applications TransUnion onboarding path", async () => {
+    mocks.fetchDashboardSummaryMock.mockResolvedValue({
+      kpis: {
+        propertiesCount: 1,
+        unitsCount: 1,
+        tenantsCount: 1,
+        openActionsCount: 0,
+        delinquentCount: 0,
+        screeningsCount: 0,
+      },
+      actions: [],
+      events: [],
+      leaseNoticeSummary: {
+        expiringSoon: 0,
+        pendingResponse: 0,
+        renewed: 0,
+        quitting: 0,
+        noResponse: 0,
+      },
+      portfolioCredibilitySummary: {
+        propertyCount: 1,
+        activeLeaseCount: 0,
+        tenantScoreAverage: null,
+        tenantScoreGradeAverage: null,
+        leaseRiskAverage: null,
+        leaseRiskGradeAverage: null,
+        tenantsWithScoreCount: 0,
+        leasesWithRiskCount: 0,
+        lowConfidenceCount: 0,
+        missingCredibilityCount: 0,
+        healthStatus: "watch",
+      },
+    });
+
+    render(
+      <ToastProvider>
+        <MemoryRouter>
+          <DashboardPage />
+        </MemoryRouter>
+      </ToastProvider>
+    );
+
+    expect(await screen.findByText("Get TransUnion access")).toBeInTheDocument();
+    screen.getAllByRole("button", { name: "Open" })[0].click();
+    expect(assignMock).toHaveBeenCalledWith("/applications?openTransUnionAccess=1");
   });
 });

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -393,9 +393,9 @@ const DashboardPage: React.FC = () => {
     if (SCREENING_ENABLED && canManualScreen && (kpis.screeningsCount ?? 0) === 0) {
       items.push({
         id: "run-first-screening",
-        title: "Run a manual screening",
+        title: "Get TransUnion access",
         severity: "info",
-        href: "/screening/manual",
+        href: "/applications?openTransUnionAccess=1",
       });
     }
     if (tenantCount === 0) {
@@ -899,11 +899,13 @@ const DashboardPage: React.FC = () => {
             <div style={{ fontWeight: 700, marginBottom: 6 }}>Credit screening</div>
             <div style={{ color: text.muted, marginBottom: 12 }}>
               {SCREENING_ENABLED
-                ? "Run a pay-per-use screening without sending an application link."
+                ? "Start the TransUnion onboarding path, then return to RentChain to connect your credentials and screen applicants."
                 : screeningLabel}
             </div>
             {SCREENING_ENABLED ? (
-              <Button onClick={() => navigate("/screening/manual")}>Run Manual Screening</Button>
+              <Button onClick={() => navigate("/applications?openTransUnionAccess=1")}>
+                Get TransUnion Access
+              </Button>
             ) : (
               <Button disabled>{screeningLabel}</Button>
             )}


### PR DESCRIPTION
This PR adds a guided TransUnion onboarding funnel for landlords.

## Summary

Adds a RentChain-guided setup flow so landlords can contact TransUnion, get credentialed, return with their member code/passcode, and connect their account for screening.

## Changes

- Added Chhavi Kumar contact information to the TransUnion access modal
- Added explicit 4-step onboarding guidance
- Added prefilled Email Chhavi action
- Added click-to-call action
- Preserved the existing Already Credentialed connection path
- Updated TransUnion connection card copy for setup states
- Routed dashboard screening setup CTA to `/applications?openTransUnionAccess=1`
- Preserved existing credential connection and screening behavior

## Verification

- TransUnion modal/card/dashboard/applications focused tests passed: 32 tests
- npm run test:light passed: 155 files / 601 tests
- npm run build:app passed

## Expected Result

Landlords can clearly understand how to get TransUnion access, contact Chhavi directly, return to RentChain, connect credentials, and begin screening with less friction.

## Notes

- No backend changes were required
- No email inbox or proxy flow was added
- No XML/API integration was added
- No credential validation or screening execution behavior was changed
- Existing frontend chunk-size warning remains unchanged and out of scope