### PR TITLE
feat: add TransUnion onboarding analytics

### DIFF
--- a/rentchain-api/src/routes/__tests__/landlordAnalyticsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordAnalyticsRoutes.test.ts
@@ -29,6 +29,7 @@ const executeScreeningCheckout = vi.fn();
 const isTransUnionReferralMode = vi.fn();
 const shouldUseMockScreeningCheckoutOverride = vi.fn();
 const deriveLandlordInbox = vi.fn();
+const loadLandlordTransUnionOnboardingAnalytics = vi.fn();
 
 vi.mock("../../middleware/requireAuth", () => ({
   requireAuth: (req: any, res: any, next: any) => {
@@ -58,6 +59,10 @@ vi.mock("../../services/landlord/landlordAnalyticsSnapshot", () => ({
 
 vi.mock("../../services/landlordInbox/deriveLandlordInbox", () => ({
   deriveLandlordInbox,
+}));
+
+vi.mock("../../services/landlord/loadLandlordTransUnionOnboardingAnalytics", () => ({
+  loadLandlordTransUnionOnboardingAnalytics,
 }));
 
 vi.mock("../../services/landlord/landlordApplicationFunnel", () => ({
@@ -182,6 +187,17 @@ async function invokeRouter(
 describe("landlordAnalyticsRoutes", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    loadLandlordTransUnionOnboardingAnalytics.mockResolvedValue({
+      totals: {
+        viewed: 4,
+        started: 2,
+        emailClicked: 1,
+        phoneClicked: 1,
+        alreadyCredentialedClicked: 1,
+        connected: 1,
+      },
+      conversionRate: 0.5,
+    });
     saveReviewedLandlordDecisionState.mockResolvedValue({
       id: "landlord-1__reduce_vacancy_risk:prop-123",
       landlordId: "landlord-1",
@@ -1880,5 +1896,32 @@ describe("landlordAnalyticsRoutes", () => {
       user: null,
     });
     expect(unauthorized.status).toBe(401);
+  });
+
+  it("returns landlord TransUnion onboarding analytics", async () => {
+    const router = (await import("../landlordAnalyticsRoutes")).default;
+
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/analytics/transunion-onboarding",
+      user: { id: "landlord-1", role: "landlord" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(loadLandlordTransUnionOnboardingAnalytics).toHaveBeenCalledWith("landlord-1");
+    expect(response.body).toEqual({
+      ok: true,
+      data: {
+        totals: {
+          viewed: 4,
+          started: 2,
+          emailClicked: 1,
+          phoneClicked: 1,
+          alreadyCredentialedClicked: 1,
+          connected: 1,
+        },
+        conversionRate: 0.5,
+      },
+    });
   });
 });

--- a/rentchain-api/src/routes/__tests__/transunionRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/transunionRoutes.test.ts
@@ -171,4 +171,15 @@ describe("transunionRoutes", () => {
     expect(stored?.passcodeCiphertext).toBeNull();
     expect(stored?.memberCodeMasked).toBeNull();
   });
+
+  it("accepts onboarding analytics usage event types without storing credentials", async () => {
+    const app = await createApp();
+    const res = await request(app).post("/api/integrations/transunion/usage-events").send({
+      eventType: "tu_onboarding_started",
+      sourceSurface: "applications_page",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
 });

--- a/rentchain-api/src/routes/landlordAnalyticsRoutes.ts
+++ b/rentchain-api/src/routes/landlordAnalyticsRoutes.ts
@@ -41,6 +41,7 @@ import {
   validateScreeningConsentPayload,
 } from "../lib/screeningCheckoutReadiness";
 import { loadLandlordApplicationFunnel } from "../services/landlord/landlordApplicationFunnel";
+import { loadLandlordTransUnionOnboardingAnalytics } from "../services/landlord/loadLandlordTransUnionOnboardingAnalytics";
 
 const router = Router();
 
@@ -316,6 +317,21 @@ router.get("/landlord/analytics/applications/funnel", requireAuth, requireLandlo
   } catch (err: any) {
     console.error("[landlord-analytics] application funnel failed", err?.message || err);
     return res.status(500).json({ ok: false, error: "LANDLORD_APPLICATION_FUNNEL_FETCH_FAILED" });
+  }
+});
+
+router.get("/landlord/analytics/transunion-onboarding", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = asString(req.user?.landlordId || req.user?.id, 240);
+    if (!landlordId) {
+      return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    }
+
+    const data = await loadLandlordTransUnionOnboardingAnalytics(landlordId);
+    return res.json({ ok: true, data });
+  } catch (err: any) {
+    console.error("[landlord-analytics] transunion onboarding failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "LANDLORD_TRANSUNION_ONBOARDING_FETCH_FAILED" });
   }
 });
 

--- a/rentchain-api/src/services/integrations/transunion/transunionController.ts
+++ b/rentchain-api/src/services/integrations/transunion/transunionController.ts
@@ -86,6 +86,14 @@ export async function postTransUnionConnect(req: Request, res: Response) {
       sourceSurface: String((req.body as any)?.sourceSurface || "connect_modal"),
       status: "connected",
     });
+    await writeTransUnionUsageEvent({
+      eventType: "tu_credentials_connected",
+      landlordId,
+      userId,
+      actorRole: String((req as any).user?.role || "landlord").toLowerCase(),
+      sourceSurface: String((req.body as any)?.sourceSurface || "connect_modal"),
+      status: "connected",
+    });
     return res.status(200).json(data);
   } catch (error) {
     await writeTransUnionUsageEvent({
@@ -129,6 +137,14 @@ export async function postTransUnionUpdateCredentials(req: Request, res: Respons
       sourceSurface: String((req.body as any)?.sourceSurface || "update_credentials_modal"),
       status: "connected",
     });
+    await writeTransUnionUsageEvent({
+      eventType: "tu_credentials_connected",
+      landlordId,
+      userId,
+      actorRole: String((req as any).user?.role || "landlord").toLowerCase(),
+      sourceSurface: String((req.body as any)?.sourceSurface || "update_credentials_modal"),
+      status: "connected",
+    });
     return res.status(200).json(data);
   } catch (error) {
     await writeTransUnionUsageEvent({
@@ -161,6 +177,11 @@ export async function postTransUnionUsageEvent(req: Request, res: Response) {
     "tu_option_viewed",
     "tu_get_access_clicked",
     "tu_have_credentials_clicked",
+    "tu_onboarding_viewed",
+    "tu_onboarding_started",
+    "tu_email_clicked",
+    "tu_phone_clicked",
+    "tu_already_credentialed_clicked",
   ]);
   if (!allowed.has(eventType as any)) {
     return res.status(400).json({ ok: false, error: "invalid_event_type" });

--- a/rentchain-api/src/services/landlord/__tests__/loadLandlordTransUnionOnboardingAnalytics.test.ts
+++ b/rentchain-api/src/services/landlord/__tests__/loadLandlordTransUnionOnboardingAnalytics.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { deriveLandlordTransUnionOnboardingAnalytics } from "../loadLandlordTransUnionOnboardingAnalytics";
+
+describe("deriveLandlordTransUnionOnboardingAnalytics", () => {
+  it("derives landlord-scoped onboarding counts and conversion safely", () => {
+    const result = deriveLandlordTransUnionOnboardingAnalytics(
+      [
+        {
+          type: "tu_onboarding_viewed",
+          actor: { id: "user-1", role: "landlord", type: "landlord" },
+          resource: { type: "screening_provider", id: "transunion", parentType: "landlord", parentId: "landlord-1" },
+          metadata: { providerKey: "transunion", landlordId: "landlord-1" },
+        } as any,
+        {
+          type: "tu_onboarding_started",
+          actor: { id: "user-1", role: "landlord", type: "landlord" },
+          resource: { type: "screening_provider", id: "transunion", parentType: "landlord", parentId: "landlord-1" },
+          metadata: { providerKey: "transunion", landlordId: "landlord-1" },
+        } as any,
+        {
+          type: "tu_email_clicked",
+          actor: { id: "user-1", role: "landlord", type: "landlord" },
+          resource: { type: "screening_provider", id: "transunion", parentType: "landlord", parentId: "landlord-1" },
+          metadata: { providerKey: "transunion", landlordId: "landlord-1" },
+        } as any,
+        {
+          type: "tu_phone_clicked",
+          actor: { id: "user-1", role: "landlord", type: "landlord" },
+          resource: { type: "screening_provider", id: "transunion", parentType: "landlord", parentId: "landlord-1" },
+          metadata: { providerKey: "transunion", landlordId: "landlord-1" },
+        } as any,
+        {
+          type: "tu_already_credentialed_clicked",
+          actor: { id: "user-1", role: "landlord", type: "landlord" },
+          resource: { type: "screening_provider", id: "transunion", parentType: "landlord", parentId: "landlord-1" },
+          metadata: { providerKey: "transunion", landlordId: "landlord-1" },
+        } as any,
+        {
+          type: "tu_credentials_connected",
+          actor: { id: "user-1", role: "landlord", type: "landlord" },
+          resource: { type: "screening_provider", id: "transunion", parentType: "landlord", parentId: "landlord-1" },
+          metadata: { providerKey: "transunion", landlordId: "landlord-1" },
+        } as any,
+        {
+          type: "tu_onboarding_started",
+          actor: { id: "user-2", role: "landlord", type: "landlord" },
+          resource: { type: "screening_provider", id: "transunion", parentType: "landlord", parentId: "landlord-2" },
+          metadata: { providerKey: "transunion", landlordId: "landlord-2" },
+        } as any,
+      ],
+      "landlord-1"
+    );
+
+    expect(result).toEqual({
+      totals: {
+        viewed: 1,
+        started: 1,
+        emailClicked: 1,
+        phoneClicked: 1,
+        alreadyCredentialedClicked: 1,
+        connected: 1,
+      },
+      conversionRate: 1,
+    });
+  });
+
+  it("fails closed to zero counts when no started event exists", () => {
+    const result = deriveLandlordTransUnionOnboardingAnalytics(
+      [
+        {
+          type: "tu_onboarding_viewed",
+          actor: { id: "user-1", role: "landlord", type: "landlord" },
+          resource: { type: "screening_provider", id: "transunion", parentType: "landlord", parentId: "landlord-1" },
+          metadata: { providerKey: "transunion", landlordId: "landlord-1" },
+        } as any,
+      ],
+      "landlord-1"
+    );
+
+    expect(result).toEqual({
+      totals: {
+        viewed: 1,
+        started: 0,
+        emailClicked: 0,
+        phoneClicked: 0,
+        alreadyCredentialedClicked: 0,
+        connected: 0,
+      },
+      conversionRate: null,
+    });
+  });
+});

--- a/rentchain-api/src/services/landlord/loadLandlordTransUnionOnboardingAnalytics.ts
+++ b/rentchain-api/src/services/landlord/loadLandlordTransUnionOnboardingAnalytics.ts
@@ -1,0 +1,88 @@
+import { db } from "../../config/firebase";
+import { CANONICAL_EVENTS_COLLECTION } from "../../lib/events/buildEvent";
+import type { CanonicalEventV1 } from "../../lib/events/eventTypes";
+
+export type LandlordTransUnionOnboardingAnalytics = {
+  totals: {
+    viewed: number;
+    started: number;
+    emailClicked: number;
+    phoneClicked: number;
+    alreadyCredentialedClicked: number;
+    connected: number;
+  };
+  conversionRate: number | null;
+};
+
+const ONBOARDING_EVENT_TYPES = new Set([
+  "tu_onboarding_viewed",
+  "tu_onboarding_started",
+  "tu_email_clicked",
+  "tu_phone_clicked",
+  "tu_already_credentialed_clicked",
+  "tu_credentials_connected",
+]);
+
+function cleanString(value: unknown): string | null {
+  const normalized = String(value || "").trim();
+  return normalized || null;
+}
+
+function landlordIdForEvent(event: CanonicalEventV1): string | null {
+  const metadata = (event.metadata || {}) as Record<string, unknown>;
+  return (
+    cleanString(metadata.landlordId) ||
+    cleanString((event as any).landlordId) ||
+    cleanString(event.actor?.id) ||
+    cleanString(event.resource?.parentId)
+  );
+}
+
+function isTransUnionOnboardingEvent(event: CanonicalEventV1) {
+  const type = cleanString(event.type);
+  const providerKey = cleanString((event.metadata || {})?.providerKey)?.toLowerCase();
+  return Boolean(type && ONBOARDING_EVENT_TYPES.has(type) && providerKey === "transunion");
+}
+
+function roundRatio(numerator: number, denominator: number) {
+  if (!denominator) return null;
+  return Math.round((numerator / denominator) * 1000) / 1000;
+}
+
+export function deriveLandlordTransUnionOnboardingAnalytics(
+  events: CanonicalEventV1[],
+  landlordId: string
+): LandlordTransUnionOnboardingAnalytics {
+  const scoped = events.filter(
+    (event) => isTransUnionOnboardingEvent(event) && landlordIdForEvent(event) === landlordId
+  );
+
+  const counts = scoped.reduce<Record<string, number>>((acc, event) => {
+    const type = cleanString(event.type);
+    if (!type) return acc;
+    acc[type] = (acc[type] || 0) + 1;
+    return acc;
+  }, {});
+
+  const totals = {
+    viewed: counts.tu_onboarding_viewed || 0,
+    started: counts.tu_onboarding_started || 0,
+    emailClicked: counts.tu_email_clicked || 0,
+    phoneClicked: counts.tu_phone_clicked || 0,
+    alreadyCredentialedClicked: counts.tu_already_credentialed_clicked || 0,
+    connected: counts.tu_credentials_connected || 0,
+  };
+
+  return {
+    totals,
+    conversionRate: roundRatio(totals.connected, totals.started),
+  };
+}
+
+export async function loadLandlordTransUnionOnboardingAnalytics(
+  landlordId: string
+): Promise<LandlordTransUnionOnboardingAnalytics> {
+  const snapshot = await db.collection(CANONICAL_EVENTS_COLLECTION).get();
+  const events = snapshot.docs.map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) })) as CanonicalEventV1[];
+  return deriveLandlordTransUnionOnboardingAnalytics(events, landlordId);
+}

--- a/rentchain-api/src/services/screening/transUnionUsageEvents.ts
+++ b/rentchain-api/src/services/screening/transUnionUsageEvents.ts
@@ -4,6 +4,12 @@ export const TRANSUNION_USAGE_EVENT_TYPES = [
   "tu_option_viewed",
   "tu_get_access_clicked",
   "tu_have_credentials_clicked",
+  "tu_onboarding_viewed",
+  "tu_onboarding_started",
+  "tu_email_clicked",
+  "tu_phone_clicked",
+  "tu_already_credentialed_clicked",
+  "tu_credentials_connected",
   "tu_credentials_submitted",
   "tu_connected",
   "tu_connection_failed",
@@ -39,6 +45,12 @@ const EVENT_SUMMARIES: Record<TransUnionUsageEventType, string> = {
   tu_option_viewed: "TransUnion option viewed",
   tu_get_access_clicked: "TransUnion get access clicked",
   tu_have_credentials_clicked: "TransUnion existing credentials clicked",
+  tu_onboarding_viewed: "TransUnion onboarding viewed",
+  tu_onboarding_started: "TransUnion onboarding started",
+  tu_email_clicked: "TransUnion onboarding email clicked",
+  tu_phone_clicked: "TransUnion onboarding phone clicked",
+  tu_already_credentialed_clicked: "TransUnion already credentialed clicked",
+  tu_credentials_connected: "TransUnion credentials connected",
   tu_credentials_submitted: "TransUnion credentials submitted",
   tu_connected: "TransUnion connected",
   tu_connection_failed: "TransUnion connection failed",
@@ -130,4 +142,3 @@ export async function writeTransUnionUsageEvent(
     tags: ["provider:transunion", "usage-reporting"],
   });
 }
-

--- a/rentchain-frontend/src/api/integrationsApi.ts
+++ b/rentchain-frontend/src/api/integrationsApi.ts
@@ -41,7 +41,12 @@ export type TransUnionCredentialsPayload = {
 export type TransUnionUsageEventType =
   | "tu_option_viewed"
   | "tu_get_access_clicked"
-  | "tu_have_credentials_clicked";
+  | "tu_have_credentials_clicked"
+  | "tu_onboarding_viewed"
+  | "tu_onboarding_started"
+  | "tu_email_clicked"
+  | "tu_phone_clicked"
+  | "tu_already_credentialed_clicked";
 
 export async function getTransUnionIntegration(): Promise<TransUnionIntegration> {
   return apiFetch<TransUnionIntegration>("/integrations/transunion");

--- a/rentchain-frontend/src/api/landlordAnalyticsApi.ts
+++ b/rentchain-frontend/src/api/landlordAnalyticsApi.ts
@@ -419,6 +419,18 @@ export type LandlordApplicationFunnelAnalytics = {
   };
 };
 
+export type LandlordTransUnionOnboardingAnalytics = {
+  totals: {
+    viewed: number;
+    started: number;
+    emailClicked: number;
+    phoneClicked: number;
+    alreadyCredentialedClicked: number;
+    connected: number;
+  };
+  conversionRate: number | null;
+};
+
 export async function fetchLandlordAnalyticsSnapshot(params?: {
   period?: AnalyticsPeriod;
   propertyId?: string | null;
@@ -450,6 +462,13 @@ export async function fetchLandlordApplicationFunnel(params?: {
   const suffix = search.toString() ? `?${search.toString()}` : "";
   const response = await apiFetch<{ ok: true; data: LandlordApplicationFunnelAnalytics }>(
     `/landlord/analytics/applications/funnel${suffix}`
+  );
+  return response.data;
+}
+
+export async function fetchLandlordTransUnionOnboardingAnalytics(): Promise<LandlordTransUnionOnboardingAnalytics> {
+  const response = await apiFetch<{ ok: true; data: LandlordTransUnionOnboardingAnalytics }>(
+    "/landlord/analytics/transunion-onboarding"
   );
   return response.data;
 }

--- a/rentchain-frontend/src/components/integrations/GetTransUnionAccessModal.test.tsx
+++ b/rentchain-frontend/src/components/integrations/GetTransUnionAccessModal.test.tsx
@@ -4,12 +4,16 @@ import { GetTransUnionAccessModal } from "./GetTransUnionAccessModal";
 
 describe("GetTransUnionAccessModal", () => {
   it("renders the TransUnion contact block with direct email and call actions", () => {
+    const onEmailClick = vi.fn();
+    const onPhoneClick = vi.fn();
     render(
       <GetTransUnionAccessModal
         open
         onClose={vi.fn()}
         onMarkInProgress={vi.fn()}
         onEnterCredentials={vi.fn()}
+        onEmailClick={onEmailClick}
+        onPhoneClick={onPhoneClick}
       />
     );
 
@@ -35,24 +39,31 @@ describe("GetTransUnionAccessModal", () => {
         "I%20would%20like%20to%20start%20the%20credentialing%20process%20for%20TransUnion%20tenant%20screening"
       )
     );
+    fireEvent.click(emailLink);
+    expect(onEmailClick).toHaveBeenCalledTimes(1);
 
     const callLink = screen.getByRole("link", { name: "Call Chhavi Kumar" });
     expect(callLink).toHaveAttribute("href", "tel:2892087386");
+    fireEvent.click(callLink);
+    expect(onPhoneClick).toHaveBeenCalledTimes(1);
   });
 
   it("keeps the already credentialed path in the existing connect flow", () => {
     const onEnterCredentials = vi.fn();
+    const onAlreadyCredentialedClick = vi.fn();
     render(
       <GetTransUnionAccessModal
         open
         onClose={vi.fn()}
         onMarkInProgress={vi.fn()}
         onEnterCredentials={onEnterCredentials}
+        onAlreadyCredentialedClick={onAlreadyCredentialedClick}
       />
     );
 
     const buttons = screen.getAllByRole("button", { name: "Already Credentialed?" });
     fireEvent.click(buttons[buttons.length - 1]);
+    expect(onAlreadyCredentialedClick).toHaveBeenCalledTimes(1);
     expect(onEnterCredentials).toHaveBeenCalledTimes(1);
   });
 });

--- a/rentchain-frontend/src/components/integrations/GetTransUnionAccessModal.tsx
+++ b/rentchain-frontend/src/components/integrations/GetTransUnionAccessModal.tsx
@@ -33,6 +33,9 @@ type Props = {
   onClose: () => void;
   onMarkInProgress: () => Promise<void> | void;
   onEnterCredentials?: () => void;
+  onEmailClick?: () => void;
+  onPhoneClick?: () => void;
+  onAlreadyCredentialedClick?: () => void;
 };
 
 export function GetTransUnionAccessModal({
@@ -41,6 +44,9 @@ export function GetTransUnionAccessModal({
   onClose,
   onMarkInProgress,
   onEnterCredentials,
+  onEmailClick,
+  onPhoneClick,
+  onAlreadyCredentialedClick,
 }: Props) {
   if (!open) return null;
 
@@ -149,6 +155,7 @@ export function GetTransUnionAccessModal({
           <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
             <a
               href={CHHAVI_MAILTO}
+              onClick={onEmailClick}
               style={{
                 display: "inline-flex",
                 alignItems: "center",
@@ -167,6 +174,7 @@ export function GetTransUnionAccessModal({
             </a>
             <a
               href={CHHAVI_TEL}
+              onClick={onPhoneClick}
               style={{
                 display: "inline-flex",
                 alignItems: "center",
@@ -228,7 +236,15 @@ export function GetTransUnionAccessModal({
         </div>
         <div style={{ display: "flex", justifyContent: "flex-end", gap: spacing.sm, flexWrap: "wrap" }}>
           {onEnterCredentials ? (
-            <Button type="button" variant="secondary" onClick={onEnterCredentials} disabled={submitting}>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => {
+                onAlreadyCredentialedClick?.();
+                onEnterCredentials();
+              }}
+              disabled={submitting}
+            >
               Already Credentialed?
             </Button>
           ) : null}

--- a/rentchain-frontend/src/pages/ApplicationsPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.tsx
@@ -373,10 +373,12 @@ const ApplicationsPage: React.FC = () => {
   const [transUnionAccessOpen, setTransUnionAccessOpen] = useState(false);
   const [transUnionConnectOpen, setTransUnionConnectOpen] = useState(false);
   const [transUnionUpdateOpen, setTransUnionUpdateOpen] = useState(false);
+  const [transUnionAccessSource, setTransUnionAccessSource] = useState("applications_page");
   const APPLICATION_REMINDER_RESEND_COOLDOWN_MS = 24 * 60 * 60 * 1000;
   const APPLICATION_HIGH_PRIORITY_ACTIVITY_MS = 3 * 24 * 60 * 60 * 1000;
   const APPLICATION_FOLLOW_UP_STALE_MS = 7 * 24 * 60 * 60 * 1000;
   const transUnionOptionViewedRef = useRef(false);
+  const transUnionOnboardingViewKeyRef = useRef<string | null>(null);
   const [manualScreeningStatus, setManualScreeningStatus] = useState<ScreeningStatusView | null>(null);
   const [manualScreeningLoading, setManualScreeningLoading] = useState(false);
   const [manualScreeningSubmitting, setManualScreeningSubmitting] = useState(false);
@@ -390,6 +392,10 @@ const ApplicationsPage: React.FC = () => {
   const [funnelLoading, setFunnelLoading] = useState(false);
   const [funnelError, setFunnelError] = useState<string | null>(null);
   const screeningSectionRef = React.useRef<HTMLDivElement | null>(null);
+  const openTransUnionAccess = useCallback((sourceSurface: string) => {
+    setTransUnionAccessSource(sourceSurface);
+    setTransUnionAccessOpen(true);
+  }, []);
   const uiLocale = getUiLocale();
   const screeningComingSoonText = screeningComingSoonLabel(uiLocale);
   const screeningComingSoonDetailText =
@@ -1020,12 +1026,12 @@ const ApplicationsPage: React.FC = () => {
   useEffect(() => {
     const params = new URLSearchParams(location.search);
     if (params.get("openTransUnionAccess") === "1") {
-      setTransUnionAccessOpen(true);
+      openTransUnionAccess("applications_page");
     }
     if (params.get("openTransUnionConnect") === "1") {
       setTransUnionConnectOpen(true);
     }
-  }, [location.search]);
+  }, [location.search, openTransUnionAccess]);
 
   useEffect(() => {
     const params = new URLSearchParams(location.search);
@@ -1351,7 +1357,18 @@ const ApplicationsPage: React.FC = () => {
   }, []);
 
   const emitTransUnionUsageEvent = useCallback(
-    (eventType: "tu_option_viewed" | "tu_get_access_clicked" | "tu_have_credentials_clicked", sourceSurface: string) => {
+    (
+      eventType:
+        | "tu_option_viewed"
+        | "tu_get_access_clicked"
+        | "tu_have_credentials_clicked"
+        | "tu_onboarding_viewed"
+        | "tu_onboarding_started"
+        | "tu_email_clicked"
+        | "tu_phone_clicked"
+        | "tu_already_credentialed_clicked",
+      sourceSurface: string
+    ) => {
       void trackTransUnionUsageEvent({
         eventType,
         sourceSurface,
@@ -1368,8 +1385,20 @@ const ApplicationsPage: React.FC = () => {
     emitTransUnionUsageEvent("tu_option_viewed", "applications_page");
   }, [emitTransUnionUsageEvent, transUnionLoading]);
 
+  useEffect(() => {
+    if (!transUnionAccessOpen) {
+      transUnionOnboardingViewKeyRef.current = null;
+      return;
+    }
+    const viewKey = `${transUnionAccessSource}:${location.search}`;
+    if (transUnionOnboardingViewKeyRef.current === viewKey) return;
+    transUnionOnboardingViewKeyRef.current = viewKey;
+    emitTransUnionUsageEvent("tu_onboarding_viewed", transUnionAccessSource);
+  }, [emitTransUnionUsageEvent, location.search, transUnionAccessOpen, transUnionAccessSource]);
+
   const submitTransUnionOnboardingRequest = useCallback(async () => {
     setTransUnionSubmitting(true);
+    emitTransUnionUsageEvent("tu_onboarding_started", transUnionAccessSource);
     try {
       const data = await requestTransUnionOnboarding({
         businessName: transUnionIntegration.businessName,
@@ -1389,7 +1418,9 @@ const ApplicationsPage: React.FC = () => {
       setTransUnionSubmitting(false);
     }
   }, [
+    emitTransUnionUsageEvent,
     showToast,
+    transUnionAccessSource,
     transUnionIntegration.businessName,
     transUnionIntegration.contactEmail,
     transUnionIntegration.contactName,
@@ -2026,14 +2057,14 @@ const ApplicationsPage: React.FC = () => {
         lastScreeningDate={detail ? screeningHistory[0]?.screenedAt || screeningHistory[0]?.requestedAt || null : null}
         onGetAccess={() => {
           emitTransUnionUsageEvent("tu_get_access_clicked", "applications_page");
-          setTransUnionAccessOpen(true);
+          openTransUnionAccess("applications_page");
         }}
         onConnectExisting={() => {
           emitTransUnionUsageEvent("tu_have_credentials_clicked", "applications_page");
           setTransUnionConnectOpen(true);
         }}
         onEnterDetails={() => setTransUnionConnectOpen(true)}
-        onViewInstructions={() => setTransUnionAccessOpen(true)}
+        onViewInstructions={() => openTransUnionAccess("applications_page")}
         onUpdateCredentials={() => setTransUnionUpdateOpen(true)}
         onDisconnect={() => void handleTransUnionDisconnect()}
         onStartScreening={
@@ -2835,7 +2866,7 @@ const ApplicationsPage: React.FC = () => {
                       <Button type="button" onClick={() => setTransUnionConnectOpen(true)}>
                         Connect TransUnion to Continue
                       </Button>
-                      <Button type="button" variant="secondary" onClick={() => setTransUnionAccessOpen(true)}>
+                      <Button type="button" variant="secondary" onClick={() => openTransUnionAccess("applications_page")}>
                         Get TransUnion Access
                       </Button>
                     </div>
@@ -3616,6 +3647,11 @@ const ApplicationsPage: React.FC = () => {
           }
         }}
         onMarkInProgress={submitTransUnionOnboardingRequest}
+        onEmailClick={() => emitTransUnionUsageEvent("tu_email_clicked", transUnionAccessSource)}
+        onPhoneClick={() => emitTransUnionUsageEvent("tu_phone_clicked", transUnionAccessSource)}
+        onAlreadyCredentialedClick={() =>
+          emitTransUnionUsageEvent("tu_already_credentialed_clicked", transUnionAccessSource)
+        }
         onEnterCredentials={() => {
           setTransUnionAccessOpen(false);
           setTransUnionConnectOpen(true);
@@ -3628,7 +3664,7 @@ const ApplicationsPage: React.FC = () => {
         onGetAccess={() => {
           emitTransUnionUsageEvent("tu_get_access_clicked", "connect_modal");
           setTransUnionConnectOpen(false);
-          setTransUnionAccessOpen(true);
+          openTransUnionAccess("connect_modal");
         }}
         onChooseExistingCredentials={() => {
           emitTransUnionUsageEvent("tu_have_credentials_clicked", "connect_modal");

--- a/rentchain-frontend/src/pages/DashboardPage.test.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.test.tsx
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   listTenantInvitesMock: vi.fn(),
   listReferralsMock: vi.fn(),
   getLandlordActivationMock: vi.fn(),
+  fetchLandlordTransUnionOnboardingAnalyticsMock: vi.fn(),
   useOnboardingStateMock: vi.fn(),
   useUpgradeMock: vi.fn(),
   navigateMock: vi.fn(),
@@ -61,6 +62,10 @@ vi.mock("../api/referralsApi", () => ({
 
 vi.mock("@/api/activationApi", () => ({
   getLandlordActivation: mocks.getLandlordActivationMock,
+}));
+
+vi.mock("@/api/landlordAnalyticsApi", () => ({
+  fetchLandlordTransUnionOnboardingAnalytics: mocks.fetchLandlordTransUnionOnboardingAnalyticsMock,
 }));
 
 vi.mock("../hooks/useOnboardingState", () => ({
@@ -137,6 +142,17 @@ describe("DashboardPage", () => {
           actionPath: "/properties",
         },
       ],
+    });
+    mocks.fetchLandlordTransUnionOnboardingAnalyticsMock.mockResolvedValue({
+      totals: {
+        viewed: 3,
+        started: 2,
+        emailClicked: 1,
+        phoneClicked: 0,
+        alreadyCredentialedClicked: 0,
+        connected: 1,
+      },
+      conversionRate: 0.5,
     });
     mocks.useOnboardingStateMock.mockReturnValue({
       loading: false,
@@ -291,5 +307,8 @@ describe("DashboardPage", () => {
     expect(await screen.findByText("Get TransUnion access")).toBeInTheDocument();
     screen.getAllByRole("button", { name: "Open" })[0].click();
     expect(assignMock).toHaveBeenCalledWith("/applications?openTransUnionAccess=1");
+    expect(await screen.findByText("TransUnion Setup Funnel")).toBeInTheDocument();
+    expect(screen.getByText("Started → Connected 50%")).toBeInTheDocument();
+    expect(screen.getByText("1 onboarding start still need credential connection.")).toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -35,6 +35,10 @@ import { openUpgradeFlow } from "@/billing/openUpgradeFlow";
 import { UpgradeNudgeInlineCard } from "@/features/upgradeNudges/UpgradeNudgeInlineCard";
 import { canUseTimeline, normalizeTimelinePlan } from "@/features/automation/timeline/timelineEntitlements";
 import { getLandlordActivation, type LandlordActivationSummary } from "@/api/activationApi";
+import {
+  fetchLandlordTransUnionOnboardingAnalytics,
+  type LandlordTransUnionOnboardingAnalytics,
+} from "@/api/landlordAnalyticsApi";
 import { LandlordActivationFlowCard } from "@/components/activation/LandlordActivationFlowCard";
 import { clearPostUpgradeState, getPostUpgradeContent, getPostUpgradeState } from "@/lib/postUpgrade";
 
@@ -149,6 +153,8 @@ const DashboardPage: React.FC = () => {
   const [activationSummary, setActivationSummary] = React.useState<LandlordActivationSummary | null>(null);
   const [activationLoading, setActivationLoading] = React.useState(false);
   const [activationError, setActivationError] = React.useState<string | null>(null);
+  const [transUnionFunnel, setTransUnionFunnel] = React.useState<LandlordTransUnionOnboardingAnalytics | null>(null);
+  const [transUnionFunnelLoading, setTransUnionFunnelLoading] = React.useState(false);
   const [showWelcomeModal, setShowWelcomeModal] = React.useState(false);
   const [postUpgradePlan, setPostUpgradePlan] = React.useState<"starter" | "pro" | "elite" | null>(null);
   const onboarding = useOnboardingState();
@@ -198,6 +204,31 @@ const DashboardPage: React.FC = () => {
   React.useEffect(() => {
     void loadDashboard();
   }, [loadDashboard]);
+
+  React.useEffect(() => {
+    if (!SCREENING_ENABLED || (!isLandlord && !isAdmin)) {
+      setTransUnionFunnel(null);
+      setTransUnionFunnelLoading(false);
+      return;
+    }
+
+    let alive = true;
+    (async () => {
+      try {
+        setTransUnionFunnelLoading(true);
+        const data = await fetchLandlordTransUnionOnboardingAnalytics();
+        if (alive) setTransUnionFunnel(data);
+      } catch {
+        if (alive) setTransUnionFunnel(null);
+      } finally {
+        if (alive) setTransUnionFunnelLoading(false);
+      }
+    })();
+
+    return () => {
+      alive = false;
+    };
+  }, [isAdmin, isLandlord]);
 
   React.useEffect(() => {
     let alive = true;
@@ -387,6 +418,18 @@ const DashboardPage: React.FC = () => {
     delinquentCount: data?.kpis?.delinquentCount ?? 0,
     screeningsCount: data?.kpis?.screeningsCount ?? 0,
   };
+  const transUnionStarted = transUnionFunnel?.totals.started ?? 0;
+  const transUnionConnected = transUnionFunnel?.totals.connected ?? 0;
+  const transUnionConversionLabel =
+    transUnionFunnel?.conversionRate == null ? "—" : `${Math.round(transUnionFunnel.conversionRate * 100)}%`;
+  const transUnionDropOffInsight =
+    transUnionStarted > transUnionConnected
+      ? `${transUnionStarted - transUnionConnected} onboarding start${
+          transUnionStarted - transUnionConnected === 1 ? "" : "s"
+        } still need credential connection.`
+      : transUnionStarted > 0
+        ? "No onboarding drop-off right now."
+        : "No onboarding starts recorded yet.";
   const events = Array.isArray(data?.events) ? data.events : [];
   const fallbackActions = React.useMemo(() => {
     const items: Array<{ id: string; title: string; severity: "info"; href: string }> = [];
@@ -909,6 +952,26 @@ const DashboardPage: React.FC = () => {
             ) : (
               <Button disabled>{screeningLabel}</Button>
             )}
+          </Card>
+        ) : null}
+
+        {dataReady && SCREENING_ENABLED ? (
+          <Card style={{ padding: spacing.md, border: `1px solid ${colors.border}` }}>
+            <div style={{ fontWeight: 700, marginBottom: 6 }}>TransUnion Setup Funnel</div>
+            <div style={{ color: text.muted, marginBottom: 12 }}>
+              {transUnionFunnelLoading
+                ? "Loading onboarding funnel..."
+                : `Started → Connected ${transUnionConversionLabel}`}
+            </div>
+            {!transUnionFunnelLoading ? (
+              <div style={{ display: "grid", gap: 6, color: text.primary, fontSize: 14 }}>
+                <div>Viewed: {transUnionFunnel?.totals.viewed ?? 0}</div>
+                <div>Started: {transUnionStarted}</div>
+                <div>Email clicked: {transUnionFunnel?.totals.emailClicked ?? 0}</div>
+                <div>Connected: {transUnionConnected}</div>
+                <div style={{ color: text.muted }}>{transUnionDropOffInsight}</div>
+              </div>
+            ) : null}
           </Card>
         ) : null}
 


### PR DESCRIPTION
Adds TransUnion onboarding funnel analytics for landlord visibility.

## Summary

Tracks landlord progress through the TransUnion onboarding funnel using the existing usage-events and canonical event pipeline.

## Changes

- Added onboarding usage events:
  - tu_onboarding_viewed
  - tu_onboarding_started
  - tu_email_clicked
  - tu_phone_clicked
  - tu_already_credentialed_clicked
  - tu_credentials_connected
- Added `GET /api/landlord/analytics/transunion-onboarding`
- Added landlord-scoped onboarding funnel counts and conversion rate
- Added Dashboard `TransUnion Setup Funnel` card
- Added email/phone/already-credentialed analytics callbacks
- Preserved existing credential connection and screening behavior
- No new analytics storage or schema changes

## Verification

- landlordAnalyticsRoutes.test.ts and loadLandlordTransUnionOnboardingAnalytics.test.ts passed: 23 tests
- transunionRoutes.test.ts passed: 5 tests
- frontend TransUnion/dashboard/applications focused tests passed: 32 tests
- npm run test:light passed: 155 files / 601 tests
- npm run build:app passed

## Expected Result

Landlords and RentChain can track how many users view/start TransUnion onboarding, click contact actions, and connect credentials, creating measurable onboarding conversion visibility.

## Notes

- No credentials are logged or stored in events
- No provider logic, credential validation, or screening execution was changed
- Existing frontend chunk-size warning remains unchanged and out of scope