### PR TITLE
feat: add payment rails

### DIFF
--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -1,5 +1,3 @@
-import express from "express";
-import request from "supertest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const getSignedDownloadUrlMock = vi.fn(async () => "https://signed.example.com/lease.pdf");
@@ -102,22 +100,54 @@ vi.mock("../../lib/gcsSignedUrl", () => ({
   getSignedDownloadUrl: getSignedDownloadUrlMock,
 }));
 
+vi.mock("../../services/stripeService", () => ({
+  isStripeConfigured: () => true,
+}));
+
 describe("leaseRoutes GET /active", () => {
   beforeEach(() => {
     resetFakeDb();
     getSignedDownloadUrlMock.mockClear();
   });
 
-  async function makeApp() {
-    const router = (await import("../leaseRoutes")).default;
-    const app = express();
-    app.use(express.json());
-    app.use((req: any, _res, next) => {
-      req.user = { id: "landlord-1", landlordId: "landlord-1", role: "landlord" };
-      next();
+  async function invokeRouter(router: any, options: {
+    method: string;
+    url: string;
+    body?: any;
+    headers?: Record<string, string>;
+  }) {
+    return await new Promise<{ status: number; body: any; headers: Record<string, any> }>((resolve, reject) => {
+      const headers: Record<string, any> = {};
+      const req: any = {
+        method: options.method,
+        url: options.url,
+        originalUrl: options.url,
+        path: options.url,
+        body: options.body ?? {},
+        headers: options.headers ?? {},
+      };
+      const res: any = {
+        statusCode: 200,
+        setHeader: (key: string, value: any) => {
+          headers[key.toLowerCase()] = value;
+        },
+        status(code: number) {
+          this.statusCode = code;
+          return this;
+        },
+        json(payload: any) {
+          resolve({ status: this.statusCode, body: payload, headers });
+          return this;
+        },
+        send(payload: any) {
+          resolve({ status: this.statusCode, body: payload, headers });
+          return this;
+        },
+      };
+      router.handle(req, res, (error: any) => {
+        if (error) reject(error);
+      });
     });
-    app.use(router);
-    return app;
   }
 
   it("returns landlord-scoped active leases with tenant and document details", async () => {
@@ -162,8 +192,8 @@ describe("leaseRoutes GET /active", () => {
       status: "ended",
     });
 
-    const app = await makeApp();
-    const res = await request(app).get("/active");
+    const router = (await import("../leaseRoutes")).default;
+    const res = await invokeRouter(router, { method: "GET", url: "/active" });
 
     expect(res.status).toBe(200);
     expect(res.body?.ok).toBe(true);
@@ -196,6 +226,15 @@ describe("leaseRoutes GET /active", () => {
             moneyMovementEnabled: false,
             storedPaymentMethod: false,
           },
+        }),
+        rentPaymentSummary: expect.objectContaining({
+          paymentRail: {
+            enabled: false,
+            enabledAt: null,
+            processor: null,
+            blockedReason: null,
+          },
+          latestPayment: null,
         }),
       })
     );
@@ -235,10 +274,150 @@ describe("leaseRoutes GET /active", () => {
       updatedAt: 3,
     });
 
-    const app = await makeApp();
-    const res = await request(app).get("/active");
+    const router = (await import("../leaseRoutes")).default;
+    const res = await invokeRouter(router, { method: "GET", url: "/active" });
 
     expect(res.status).toBe(200);
     expect(res.body?.leases.map((lease: { id: string }) => lease.id)).toEqual(["lease-visible"]);
+  });
+
+  it("enables rent collection for an owned eligible lease", async () => {
+    seedDoc("leases", "lease-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      tenantIds: ["tenant-1"],
+      primaryTenantId: "tenant-1",
+      unitId: "unit-1",
+      unitNumber: "101",
+      monthlyRent: 1850,
+      dueDay: 1,
+      startDate: "2026-01-01",
+      endDate: "2026-12-31",
+      status: "active",
+    });
+
+    const router = (await import("../leaseRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/lease-1/payment-rails/enable",
+      body: {},
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      data: {
+        leaseId: "lease-1",
+        paymentRail: {
+          enabled: true,
+          enabledAt: expect.any(String),
+          processor: "stripe",
+          eligibility: "eligible",
+          blockedReason: null,
+        },
+      },
+    });
+
+    const storedLease = await fakeDb.collection("leases").doc("lease-1").get();
+    expect(storedLease.data()).toEqual(
+      expect.objectContaining({
+        paymentRailEnabled: true,
+        paymentRailEnabledAt: expect.any(String),
+        paymentRailProcessor: "stripe",
+      })
+    );
+  });
+
+  it("returns safe blocked detail for an ineligible lease payment rail", async () => {
+    seedDoc("leases", "lease-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      tenantIds: ["tenant-1"],
+      primaryTenantId: "tenant-1",
+      unitId: "unit-1",
+      unitNumber: "101",
+      monthlyRent: 1850,
+      dueDay: null,
+      startDate: "2026-01-01",
+      endDate: "2026-12-31",
+      status: "active",
+    });
+
+    const router = (await import("../leaseRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/lease-1/payment-rails/enable",
+      body: {},
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({
+      ok: false,
+      error: "LEASE_PAYMENT_RAIL_INELIGIBLE",
+      detail: "payment_readiness_not_ready",
+    });
+  });
+
+  it("returns landlord payment status summary for a lease", async () => {
+    seedDoc("leases", "lease-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      tenantIds: ["tenant-1"],
+      primaryTenantId: "tenant-1",
+      unitId: "unit-1",
+      unitNumber: "101",
+      monthlyRent: 1850,
+      dueDay: 1,
+      startDate: "2026-01-01",
+      endDate: "2026-12-31",
+      status: "active",
+      paymentRailEnabled: true,
+      paymentRailEnabledAt: "2026-04-27T10:00:00.000Z",
+      paymentRailProcessor: "stripe",
+    });
+    seedDoc("rentPayments", "rp-1", {
+      id: "rp-1",
+      leaseId: "lease-1",
+      tenantId: "tenant-1",
+      landlordId: "landlord-1",
+      amountCents: 185000,
+      currency: "cad",
+      status: "paid",
+      processor: "stripe",
+      createdAt: "2026-04-27T10:05:00.000Z",
+      updatedAt: "2026-04-27T10:06:00.000Z",
+      paidAt: "2026-04-27T10:06:00.000Z",
+    });
+
+    const router = (await import("../leaseRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/lease-1/payments",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      data: {
+        paymentRail: {
+          enabled: true,
+          enabledAt: "2026-04-27T10:00:00.000Z",
+          processor: "stripe",
+          blockedReason: null,
+        },
+        latestPayment: {
+          id: "rp-1",
+          amountCents: 185000,
+          currency: "cad",
+          status: "paid",
+          createdAt: "2026-04-27T10:05:00.000Z",
+          updatedAt: "2026-04-27T10:06:00.000Z",
+          paidAt: "2026-04-27T10:06:00.000Z",
+        },
+      },
+    });
   });
 });

--- a/rentchain-api/src/routes/__tests__/rentPaymentWebhook.test.ts
+++ b/rentchain-api/src/routes/__tests__/rentPaymentWebhook.test.ts
@@ -1,0 +1,231 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { store, ensureCollection, constructEventMock, docRef } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+
+  function docRef(collectionName: string, docId: string) {
+    return {
+      id: docId,
+      path: `${collectionName}/${docId}`,
+      get: async () => ({
+        exists: ensureCollection(collectionName).has(docId),
+        data: () => ensureCollection(collectionName).get(docId),
+      }),
+      set: async (payload: Record<string, unknown>, options?: { merge?: boolean }) => {
+        const col = ensureCollection(collectionName);
+        const existing = col.get(docId) || {};
+        col.set(docId, options?.merge ? { ...existing, ...payload } : payload);
+      },
+    };
+  }
+
+  return {
+    store,
+    ensureCollection,
+    constructEventMock: vi.fn(),
+    docRef,
+  };
+});
+
+vi.mock("../../config/firebase", () => ({
+  db: {
+    collection: vi.fn((name: string) => ({
+      doc: (id: string) => docRef(name, id),
+      where: (field: string, op: string, value: any) => ({
+        limit: (count: number) => ({
+          get: async () => {
+            const docs = Array.from(ensureCollection(name).entries())
+              .filter(([, data]) => (op === "==" ? data?.[field] === value : true))
+              .slice(0, count)
+              .map(([id, data]) => ({
+                id,
+                ref: docRef(name, id),
+                data: () => data,
+              }));
+            return { empty: docs.length === 0, docs };
+          },
+        }),
+        get: async () => {
+          const docs = Array.from(ensureCollection(name).entries())
+            .filter(([, data]) => (op === "==" ? data?.[field] === value : true))
+            .map(([id, data]) => ({
+              id,
+              ref: docRef(name, id),
+              data: () => data,
+            }));
+          return { empty: docs.length === 0, docs };
+        },
+      }),
+    })),
+  },
+}));
+
+vi.mock("../../config/screeningConfig", () => ({
+  STRIPE_WEBHOOK_SECRET: "whsec_test",
+}));
+
+vi.mock("../../services/stripeService", () => ({
+  getStripeClient: () => ({
+    webhooks: {
+      constructEvent: constructEventMock,
+    },
+    checkout: {
+      sessions: {
+        list: vi.fn(async () => ({ data: [] })),
+      },
+    },
+  }),
+}));
+
+vi.mock("../../lib/stripeNotConfigured", () => ({
+  stripeNotConfiguredResponse: () => ({ ok: false, error: "stripe_not_configured" }),
+  isStripeNotConfiguredError: () => false,
+}));
+
+vi.mock("../../services/screening/screeningOrchestrator", () => ({
+  beginScreening: vi.fn(async () => ({ ok: true })),
+}));
+
+vi.mock("../../services/stripeFinalize", () => ({
+  finalizeStripePayment: vi.fn(async () => ({ ok: true })),
+}));
+
+vi.mock("../../services/stripeScreeningProcessor", () => ({
+  applyScreeningResultsFromOrder: vi.fn(async () => ({ ok: true })),
+}));
+
+vi.mock("../../services/screeningPaymentTransactionService", () => ({
+  recordScreeningPaymentFailed: vi.fn(async () => undefined),
+}));
+
+async function invokeWebhook(body: string) {
+  const { stripeWebhookHandler } = await import("../stripeScreeningOrdersWebhookRoutes");
+  return await new Promise<{ status: number; body: any; text?: string }>((resolve, reject) => {
+    const req: any = {
+      body: Buffer.from(body),
+      headers: {
+        "stripe-signature": "t=1,v1=test",
+      },
+    };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: null, text: String(payload || "") });
+        return this;
+      },
+    };
+    stripeWebhookHandler(req, res).catch(reject);
+  });
+}
+
+describe("rent payment webhook reconciliation", () => {
+  beforeEach(() => {
+    store.clear();
+    constructEventMock.mockReset();
+    ensureCollection("rentPayments").set("rp-1", {
+      id: "rp-1",
+      leaseId: "lease-1",
+      tenantId: "tenant-1",
+      landlordId: "landlord-1",
+      amountCents: 180000,
+      currency: "cad",
+      status: "checkout_created",
+      processor: "stripe",
+      processorCheckoutSessionId: "cs_test_1",
+      processorPaymentIntentId: "pi_test_1",
+      createdAt: "2026-04-27T10:00:00.000Z",
+      updatedAt: "2026-04-27T10:00:00.000Z",
+      paidAt: null,
+    });
+  });
+
+  it("marks a rent payment paid idempotently from checkout completion metadata", async () => {
+    constructEventMock.mockReturnValue({
+      id: "evt_rent_paid_1",
+      created: 1_714_213_200,
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_test_1",
+          payment_intent: "pi_test_1",
+          payment_status: "paid",
+          metadata: {
+            rentPaymentId: "rp-1",
+            leaseId: "lease-1",
+            tenantId: "tenant-1",
+            landlordId: "landlord-1",
+          },
+        },
+      },
+    });
+
+    const first = await invokeWebhook('{"id":"evt_rent_paid_1","type":"checkout.session.completed"}');
+    const second = await invokeWebhook('{"id":"evt_rent_paid_1","type":"checkout.session.completed"}');
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+
+    const stored = ensureCollection("rentPayments").get("rp-1");
+    expect(stored).toEqual(
+      expect.objectContaining({
+        status: "paid",
+        processorCheckoutSessionId: "cs_test_1",
+        processorPaymentIntentId: "pi_test_1",
+        paidAt: expect.any(String),
+      })
+    );
+
+    const canonicalEvents = Array.from(ensureCollection("canonicalEvents").values());
+    expect(canonicalEvents.filter((event: any) => event.type === "rent_payment.paid")).toHaveLength(1);
+    expect(JSON.stringify(canonicalEvents[0] || {})).not.toContain("card");
+    expect(JSON.stringify(canonicalEvents[0] || {})).not.toContain("receipt");
+    expect(JSON.stringify(canonicalEvents[0] || {})).not.toContain("@");
+  });
+
+  it("updates a rent payment to failed from async payment failure metadata", async () => {
+    constructEventMock.mockReturnValue({
+      id: "evt_rent_failed_1",
+      created: 1_714_213_200,
+      type: "checkout.session.async_payment_failed",
+      data: {
+        object: {
+          id: "cs_test_1",
+          payment_intent: "pi_test_1",
+          metadata: {
+            rentPaymentId: "rp-1",
+            leaseId: "lease-1",
+            tenantId: "tenant-1",
+            landlordId: "landlord-1",
+          },
+        },
+      },
+    });
+
+    const res = await invokeWebhook('{"id":"evt_rent_failed_1","type":"checkout.session.async_payment_failed"}');
+
+    expect(res.status).toBe(200);
+    expect(ensureCollection("rentPayments").get("rp-1")).toEqual(
+      expect.objectContaining({
+        status: "failed",
+        processorCheckoutSessionId: "cs_test_1",
+        processorPaymentIntentId: "pi_test_1",
+      })
+    );
+
+    const canonicalEvents = Array.from(ensureCollection("canonicalEvents").values());
+    expect(canonicalEvents.some((event: any) => event.type === "rent_payment.failed")).toBe(true);
+  });
+});

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -4,6 +4,9 @@ const getSignedDownloadUrlMock = vi.fn();
 const { sendEmailMock } = vi.hoisted(() => ({
   sendEmailMock: vi.fn(),
 }));
+const { stripeCheckoutCreateMock } = vi.hoisted(() => ({
+  stripeCheckoutCreateMock: vi.fn(),
+}));
 
 const collections = new Map<string, Map<string, any>>();
 
@@ -106,6 +109,17 @@ vi.mock("../../config/requiredEnv", () => ({
   getEnvFlags: () => ({ emailConfigured: true, emailProvider: "mailgun" }),
 }));
 
+vi.mock("../../services/stripeService", () => ({
+  isStripeConfigured: () => true,
+  getStripeClient: () => ({
+    checkout: {
+      sessions: {
+        create: stripeCheckoutCreateMock,
+      },
+    },
+  }),
+}));
+
 vi.mock("../../middleware/authMiddleware", () => ({
   authenticateJwt: (req: any, _res: any, next: any) => {
     const header = String(req.headers["x-test-user"] || "").trim();
@@ -165,6 +179,12 @@ describe("tenantPortalRoutes foundation", () => {
     collections.clear();
     sendEmailMock.mockReset();
     sendEmailMock.mockResolvedValue(undefined);
+    stripeCheckoutCreateMock.mockReset();
+    stripeCheckoutCreateMock.mockResolvedValue({
+      id: "cs_test_1",
+      url: "https://checkout.stripe.test/session/cs_test_1",
+      payment_intent: "pi_test_1",
+    });
     process.env.EMAIL_FROM = "noreply@example.com";
     process.env.GCS_UPLOAD_BUCKET = "test-bucket";
     getSignedDownloadUrlMock.mockReset();
@@ -631,8 +651,194 @@ describe("tenantPortalRoutes foundation", () => {
         },
       })
     );
+    expect(res.body?.data?.rentPaymentSummary).toEqual({
+      paymentRail: {
+        enabled: false,
+        enabledAt: null,
+        processor: null,
+        blockedReason: null,
+      },
+      latestPayment: null,
+    });
     expect(res.body?.lease?.tenantSignature?.drawnDataUrl).toBeUndefined();
     expect(res.body?.data?.paymentMethod).toBeUndefined();
+  });
+
+  it("creates a tenant rent payment checkout only for an eligible enabled lease", async () => {
+    ensureCollection("leases").set("lease-1", {
+      ...(ensureCollection("leases").get("lease-1") || {}),
+      landlordId: "landlord-1",
+      paymentRailEnabled: true,
+      paymentRailEnabledAt: "2026-04-27T10:00:00.000Z",
+      paymentRailProcessor: "stripe",
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/leases/lease-1/payments/checkout",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      data: {
+        rentPaymentId: expect.any(String),
+        status: "checkout_created",
+        redirectUrl: "https://checkout.stripe.test/session/cs_test_1",
+      },
+    });
+    expect(stripeCheckoutCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "payment",
+        success_url: expect.stringContaining("/tenant/lease"),
+        cancel_url: expect.stringContaining("/tenant/lease"),
+        metadata: expect.objectContaining({
+          leaseId: "lease-1",
+          tenantId: "tenant-1",
+          landlordId: "landlord-1",
+          rentPaymentId: expect.any(String),
+        }),
+        payment_intent_data: expect.objectContaining({
+          metadata: expect.objectContaining({
+            leaseId: "lease-1",
+            tenantId: "tenant-1",
+            landlordId: "landlord-1",
+            rentPaymentId: expect.any(String),
+          }),
+        }),
+      })
+    );
+
+    const storedPayments = Array.from(ensureCollection("rentPayments").values());
+    expect(storedPayments).toHaveLength(1);
+    expect(storedPayments[0]).toEqual(
+      expect.objectContaining({
+        leaseId: "lease-1",
+        tenantId: "tenant-1",
+        landlordId: "landlord-1",
+        amountCents: 180000,
+        currency: "cad",
+        status: "checkout_created",
+        processor: "stripe",
+        processorCheckoutSessionId: "cs_test_1",
+        processorPaymentIntentId: "pi_test_1",
+      })
+    );
+    expect(JSON.stringify(storedPayments[0])).not.toContain("card");
+    expect(JSON.stringify(storedPayments[0])).not.toContain("bank");
+    expect(JSON.stringify(stripeCheckoutCreateMock.mock.calls[0][0]?.metadata || {})).not.toContain("@");
+  });
+
+  it("blocks duplicate tenant checkout creation when one is already pending", async () => {
+    ensureCollection("leases").set("lease-1", {
+      ...(ensureCollection("leases").get("lease-1") || {}),
+      landlordId: "landlord-1",
+      paymentRailEnabled: true,
+      paymentRailEnabledAt: "2026-04-27T10:00:00.000Z",
+      paymentRailProcessor: "stripe",
+    });
+    ensureCollection("rentPayments").set("rp-open", {
+      id: "rp-open",
+      leaseId: "lease-1",
+      tenantId: "tenant-1",
+      landlordId: "landlord-1",
+      amountCents: 180000,
+      currency: "cad",
+      status: "checkout_created",
+      processor: "stripe",
+      createdAt: "2026-04-27T10:01:00.000Z",
+      updatedAt: "2026-04-27T10:01:00.000Z",
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/leases/lease-1/payments/checkout",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({
+      ok: false,
+      error: "TENANT_RENT_PAYMENT_BLOCKED",
+      detail: "payment_already_pending",
+    });
+    expect(stripeCheckoutCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns tenant-safe rent payment status for the current lease", async () => {
+    ensureCollection("leases").set("lease-1", {
+      ...(ensureCollection("leases").get("lease-1") || {}),
+      landlordId: "landlord-1",
+      paymentRailEnabled: true,
+      paymentRailEnabledAt: "2026-04-27T10:00:00.000Z",
+      paymentRailProcessor: "stripe",
+    });
+    ensureCollection("rentPayments").set("rp-1", {
+      id: "rp-1",
+      leaseId: "lease-1",
+      tenantId: "tenant-1",
+      landlordId: "landlord-1",
+      amountCents: 180000,
+      currency: "cad",
+      status: "paid",
+      processor: "stripe",
+      createdAt: "2026-04-27T10:05:00.000Z",
+      updatedAt: "2026-04-27T10:06:00.000Z",
+      paidAt: "2026-04-27T10:06:00.000Z",
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/leases/lease-1/payments",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      data: {
+        paymentRail: {
+          enabled: true,
+          enabledAt: "2026-04-27T10:00:00.000Z",
+          processor: "stripe",
+          blockedReason: null,
+        },
+        latestPayment: {
+          id: "rp-1",
+          amountCents: 180000,
+          currency: "cad",
+          status: "paid",
+          createdAt: "2026-04-27T10:05:00.000Z",
+          updatedAt: "2026-04-27T10:06:00.000Z",
+          paidAt: "2026-04-27T10:06:00.000Z",
+        },
+      },
+    });
   });
 
   it("records tenant lease signing metadata without storing raw signature data and stays idempotent", async () => {

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -34,6 +34,12 @@ import {
 } from "../lib/testDataVisibilityTargets";
 import { deriveTenantSafeLeaseReadinessMetadata } from "../services/tenantPortal/tenantProjectionService";
 import { derivePaymentReadiness } from "../services/paymentReadiness/derivePaymentReadiness";
+import {
+  deriveRentPaymentEligibility,
+  enableRentCollectionForLease,
+  getRentPaymentSummaryForLease,
+} from "../services/rentPayments/rentPaymentService";
+import { isStripeConfigured } from "../services/stripeService";
 
 const router = Router();
 const LEDGER_COLLECTION = "ledgerEntries";
@@ -293,6 +299,29 @@ async function enrichLeaseRow(raw: any) {
   const tenantEmail =
     tenantSnap?.exists ? String(tenantSnap.data()?.email || "").trim() || null : null;
   const leaseReadiness = deriveTenantSafeLeaseReadinessMetadata(raw, { documentUrl, leaseId: lease.id });
+  const paymentReadiness = derivePaymentReadiness({
+    leaseId: lease.id,
+    monthlyRent: lease.monthlyRent,
+    startDate: lease.startDate,
+    endDate: lease.endDate,
+    dueDay: typeof raw?.dueDay === "number" ? raw.dueDay : null,
+    tenantId,
+    propertyId,
+    unitId: String(lease.unitId || lease.unitNumber || "").trim() || null,
+    leaseExecution: leaseReadiness.leaseExecution,
+  });
+  const eligibility = deriveRentPaymentEligibility({
+    lease,
+    paymentReadiness,
+    stripeConfigured: isStripeConfigured(),
+  });
+  const rentPaymentSummary = await getRentPaymentSummaryForLease({
+    leaseId: lease.id,
+    paymentRailEnabled: raw?.paymentRailEnabled === true,
+    paymentRailEnabledAt: raw?.paymentRailEnabledAt || null,
+    paymentRailProcessor: raw?.paymentRailProcessor || null,
+    blockedReason: eligibility.blockedReason,
+  });
 
   return {
     ...lease,
@@ -301,17 +330,8 @@ async function enrichLeaseRow(raw: any) {
     tenantEmail,
     documentUrl,
     ...leaseReadiness,
-    paymentReadiness: derivePaymentReadiness({
-      leaseId: lease.id,
-      monthlyRent: lease.monthlyRent,
-      startDate: lease.startDate,
-      endDate: lease.endDate,
-      dueDay: typeof raw?.dueDay === "number" ? raw.dueDay : null,
-      tenantId,
-      propertyId,
-      unitId: String(lease.unitId || lease.unitNumber || "").trim() || null,
-      leaseExecution: leaseReadiness.leaseExecution,
-    }),
+    paymentReadiness,
+    rentPaymentSummary,
     archivedAt: raw?.archivedAt || null,
     archivedByUserId: raw?.archivedByUserId || null,
     isArchived: Boolean(raw?.archivedAt),
@@ -1218,6 +1238,116 @@ router.post("/:leaseId/archive", requireLandlord, async (req: any, res: Response
   } catch (err) {
     console.error("[POST /api/leases/:leaseId/archive] error", err);
     return res.status(500).json({ ok: false, error: "Failed to archive lease" });
+  }
+});
+
+router.post("/:leaseId/payment-rails/enable", requireLandlord, async (req: any, res: Response) => {
+  try {
+    if (!(await enforceLeaseCapability(req, res))) return;
+    const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
+    const leaseId = String(req.params?.leaseId || "").trim();
+    if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
+    if (!leaseId) return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+
+    const result = await getLeaseEntityForLandlord(leaseId, landlordId);
+    if (!result.ok) {
+      return res.status(result.status).json({ ok: false, error: result.error });
+    }
+
+    const raw = result.lease as any;
+    const lease = normalizeLeaseRow(leaseId, raw);
+    const paymentReadiness = derivePaymentReadiness({
+      leaseId,
+      monthlyRent: lease.monthlyRent,
+      startDate: lease.startDate,
+      endDate: lease.endDate,
+      dueDay: typeof raw?.dueDay === "number" ? raw.dueDay : null,
+      tenantId: String(lease.primaryTenantId || lease.tenantId || lease.tenantIds?.[0] || "").trim() || null,
+      propertyId: lease.propertyId,
+      unitId: String(lease.unitId || lease.unitNumber || "").trim() || null,
+      leaseExecution: deriveTenantSafeLeaseReadinessMetadata(raw, { leaseId, documentUrl: null }).leaseExecution,
+    });
+    const eligibility = deriveRentPaymentEligibility({
+      lease,
+      paymentReadiness,
+      stripeConfigured: isStripeConfigured(),
+    });
+    if (!eligibility.eligible) {
+      return res.status(400).json({
+        ok: false,
+        error: "LEASE_PAYMENT_RAIL_INELIGIBLE",
+        detail: eligibility.blockedReason,
+      });
+    }
+
+    const tenantId = String(lease.primaryTenantId || lease.tenantId || lease.tenantIds?.[0] || "").trim();
+    const enabled = await enableRentCollectionForLease({
+      leaseId,
+      tenantId,
+      landlordId,
+      actorId: String(req.user?.id || landlordId),
+    });
+    return res.status(200).json({
+      ok: true,
+      data: {
+        leaseId,
+        paymentRail: {
+          enabled: enabled.enabled,
+          enabledAt: enabled.enabledAt,
+          processor: enabled.processor,
+          eligibility: "eligible",
+          blockedReason: null,
+        },
+      },
+    });
+  } catch (err) {
+    console.error("[POST /api/leases/:leaseId/payment-rails/enable] error", err);
+    return res.status(500).json({ ok: false, error: "LEASE_PAYMENT_RAIL_ENABLE_FAILED" });
+  }
+});
+
+router.get("/:leaseId/payments", requireLandlord, async (req: any, res: Response) => {
+  try {
+    if (!(await enforceLeaseCapability(req, res))) return;
+    const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
+    const leaseId = String(req.params?.leaseId || "").trim();
+    if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
+    if (!leaseId) return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+
+    const result = await getLeaseEntityForLandlord(leaseId, landlordId);
+    if (!result.ok) {
+      return res.status(result.status).json({ ok: false, error: result.error });
+    }
+
+    const raw = result.lease as any;
+    const lease = normalizeLeaseRow(leaseId, raw);
+    const paymentReadiness = derivePaymentReadiness({
+      leaseId,
+      monthlyRent: lease.monthlyRent,
+      startDate: lease.startDate,
+      endDate: lease.endDate,
+      dueDay: typeof raw?.dueDay === "number" ? raw.dueDay : null,
+      tenantId: String(lease.primaryTenantId || lease.tenantId || lease.tenantIds?.[0] || "").trim() || null,
+      propertyId: lease.propertyId,
+      unitId: String(lease.unitId || lease.unitNumber || "").trim() || null,
+      leaseExecution: deriveTenantSafeLeaseReadinessMetadata(raw, { leaseId, documentUrl: null }).leaseExecution,
+    });
+    const eligibility = deriveRentPaymentEligibility({
+      lease,
+      paymentReadiness,
+      stripeConfigured: isStripeConfigured(),
+    });
+    const data = await getRentPaymentSummaryForLease({
+      leaseId,
+      paymentRailEnabled: raw?.paymentRailEnabled === true,
+      paymentRailEnabledAt: raw?.paymentRailEnabledAt || null,
+      paymentRailProcessor: raw?.paymentRailProcessor || null,
+      blockedReason: eligibility.blockedReason,
+    });
+    return res.status(200).json({ ok: true, data });
+  } catch (err) {
+    console.error("[GET /api/leases/:leaseId/payments] error", err);
+    return res.status(500).json({ ok: false, error: "LEASE_PAYMENT_STATUS_FAILED" });
   }
 });
 

--- a/rentchain-api/src/routes/stripeScreeningOrdersWebhookRoutes.ts
+++ b/rentchain-api/src/routes/stripeScreeningOrdersWebhookRoutes.ts
@@ -12,6 +12,10 @@ import { recordScreeningPaymentFailed } from "../services/screeningPaymentTransa
 import { writeCanonicalEvent } from "../lib/events/buildEvent";
 import { buildScreeningMonetizationPatch } from "../services/screening/screeningMonetizationService";
 import {
+  extractRentPaymentMetadata,
+  updateRentPaymentFromWebhook,
+} from "../services/rentPayments/rentPaymentService";
+import {
   deriveBillingIntervalFromSubscription,
   deriveBillingTierFromSubscription,
   updateLandlordSubscriptionState,
@@ -543,9 +547,23 @@ export const stripeWebhookHandler = async (req: StripeWebhookRequest, res: Respo
   if (
     event.type === "checkout.session.completed" ||
     event.type === "checkout.session.async_payment_succeeded" ||
-    event.type === "payment_intent.succeeded"
+    event.type === "payment_intent.succeeded" ||
+    event.type === "checkout.session.expired"
   ) {
     try {
+      const rentPaymentEvent = extractRentPaymentMetadata(event);
+      if (rentPaymentEvent.rentPaymentId && rentPaymentEvent.nextStatus) {
+        await updateRentPaymentFromWebhook({
+          rentPaymentId: rentPaymentEvent.rentPaymentId,
+          nextStatus: rentPaymentEvent.nextStatus,
+          processorCheckoutSessionId: rentPaymentEvent.checkoutSessionId,
+          processorPaymentIntentId: rentPaymentEvent.paymentIntentId,
+          paidAt: rentPaymentEvent.paidAt,
+          eventId: event.id,
+        });
+        return res.status(200).json({ received: true });
+      }
+
       let orderId: string | undefined;
       let sessionId: string | undefined;
       let paymentIntentId: string | undefined;
@@ -702,6 +720,19 @@ export const stripeWebhookHandler = async (req: StripeWebhookRequest, res: Respo
 
   if (event.type === "checkout.session.async_payment_failed" || event.type === "payment_intent.payment_failed") {
     try {
+      const rentPaymentEvent = extractRentPaymentMetadata(event);
+      if (rentPaymentEvent.rentPaymentId && rentPaymentEvent.nextStatus) {
+        await updateRentPaymentFromWebhook({
+          rentPaymentId: rentPaymentEvent.rentPaymentId,
+          nextStatus: rentPaymentEvent.nextStatus,
+          processorCheckoutSessionId: rentPaymentEvent.checkoutSessionId,
+          processorPaymentIntentId: rentPaymentEvent.paymentIntentId,
+          paidAt: rentPaymentEvent.paidAt,
+          eventId: event.id,
+        });
+        return res.status(200).json({ received: true });
+      }
+
       let orderId: string | undefined;
       let sessionId: string | undefined;
       let paymentIntentId: string | undefined;

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -23,6 +23,12 @@ import { deriveIdentityPortability } from "../services/identityPortability/deriv
 import { deriveInstitutionalIdentityPackage } from "../services/institutional/deriveInstitutionalIdentityPackage";
 import { derivePaymentReadiness } from "../services/paymentReadiness/derivePaymentReadiness";
 import {
+  createRentPaymentCheckout,
+  deriveRentPaymentEligibility,
+  getRentPaymentSummaryForLease,
+} from "../services/rentPayments/rentPaymentService";
+import { isStripeConfigured } from "../services/stripeService";
+import {
   loadTenantCommunicationsWorkspace,
   markTenantCommunicationsRead,
   sendTenantCommunicationMessage,
@@ -81,6 +87,11 @@ function toMillis(value: any): number | null {
   if (typeof value?.toMillis === "function") return value.toMillis();
   if (typeof value?.seconds === "number") return value.seconds * 1000;
   return null;
+}
+
+function asString(value: unknown): string | null {
+  const next = String(value || "").trim();
+  return next || null;
 }
 
 function makeCorrelationId(prefix: string): string {
@@ -2227,10 +2238,36 @@ async function loadTenantWorkspaceData(context: Awaited<ReturnType<typeof resolv
     }
   }
 
+  const lease = leaseDoc ? projectTenantLease(leaseDoc.id, leaseDoc.data) : null;
+  const rentPaymentSummary = lease
+    ? await getRentPaymentSummaryForLease({
+        leaseId: lease.leaseId,
+        paymentRailEnabled: leaseDoc?.data?.paymentRailEnabled === true,
+        paymentRailEnabledAt: leaseDoc?.data?.paymentRailEnabledAt || null,
+        paymentRailProcessor: leaseDoc?.data?.paymentRailProcessor || null,
+        blockedReason: deriveRentPaymentEligibility({
+          lease: {
+            id: lease.leaseId,
+            landlordId: asString(leaseDoc?.data?.landlordId),
+            tenantId: asString(leaseDoc?.data?.tenantId),
+            tenantIds: Array.isArray(leaseDoc?.data?.tenantIds) ? leaseDoc?.data?.tenantIds : [],
+            primaryTenantId: asString(leaseDoc?.data?.primaryTenantId),
+            propertyId: asString(leaseDoc?.data?.propertyId),
+            unitId: asString(leaseDoc?.data?.unitId),
+            unitNumber: asString(leaseDoc?.data?.unitNumber),
+            monthlyRent: lease.monthlyRent,
+            status: lease.status,
+          },
+          paymentReadiness: lease.paymentReadiness || null,
+          stripeConfigured: isStripeConfigured(),
+        }).blockedReason,
+      })
+    : null;
+
   return {
     property: propertyDoc ? projectTenantProperty(propertyDoc.id, propertyDoc.data) : null,
     application: applicationDoc ? projectTenantApplication(applicationDoc.id, applicationDoc.data) : null,
-    lease: leaseDoc ? projectTenantLease(leaseDoc.id, leaseDoc.data) : null,
+    lease: lease ? { ...lease, rentPaymentSummary } : null,
     maintenance: maintenanceItems
       .map((item) => projectTenantMaintenance(item.id, item.data))
       .sort((left, right) => Number(right.updatedAt || 0) - Number(left.updatedAt || 0)),
@@ -3660,6 +3697,160 @@ router.get("/lease", requireTenantWorkspaceIdentity, async (req: any, res) => {
   if (!context) return;
   const workspace = await loadTenantWorkspaceData(context);
   return res.json({ ok: true, data: workspace.lease });
+});
+
+router.post("/leases/:leaseId/payments/checkout", requireTenantWorkspaceIdentity, async (req: any, res: any) => {
+  const context = await resolveWorkspaceContextOrRespond(req, res);
+  if (!context) return;
+  if (context.authority !== "active_tenant" || !context.tenantId) {
+    return res.status(403).json({ ok: false, error: "TENANT_CONTEXT_REQUIRED" });
+  }
+
+  const leaseId = String(req.params?.leaseId || "").trim();
+  if (!leaseId) {
+    return res.status(404).json({ ok: false, error: "lease_not_found" });
+  }
+  if (context.leaseId && String(context.leaseId).trim() !== leaseId) {
+    return res.status(403).json({ ok: false, error: "lease_not_owned_by_tenant" });
+  }
+
+  try {
+    const leaseSnap = await db.collection("leases").doc(leaseId).get();
+    if (!leaseSnap.exists) {
+      return res.status(404).json({ ok: false, error: "lease_not_found" });
+    }
+    const leaseData = (leaseSnap.data() as any) || {};
+    const leaseTenantId = String(
+      leaseData?.tenantId || leaseData?.primaryTenantId || leaseData?.tenantIds?.[0] || ""
+    ).trim();
+    const leaseTenantIds = Array.isArray(leaseData?.tenantIds)
+      ? leaseData.tenantIds.map((value: any) => String(value || "").trim()).filter(Boolean)
+      : [];
+    if (
+      leaseTenantId !== String(context.tenantId || "").trim() &&
+      !leaseTenantIds.includes(String(context.tenantId || "").trim())
+    ) {
+      return res.status(403).json({ ok: false, error: "lease_not_owned_by_tenant" });
+    }
+    if (leaseData?.paymentRailEnabled !== true || String(leaseData?.paymentRailProcessor || "").trim() !== "stripe") {
+      return res.status(400).json({ ok: false, error: "TENANT_RENT_PAYMENT_BLOCKED", detail: "payment_rail_not_enabled" });
+    }
+
+    const projectedLease = projectTenantLease(leaseId, leaseData);
+    const eligibility = deriveRentPaymentEligibility({
+      lease: {
+        id: leaseId,
+        landlordId: asString(leaseData?.landlordId),
+        tenantId: leaseTenantId,
+        tenantIds: leaseTenantIds,
+        primaryTenantId: asString(leaseData?.primaryTenantId),
+        propertyId: asString(leaseData?.propertyId),
+        unitId: asString(leaseData?.unitId),
+        unitNumber: asString(leaseData?.unitNumber),
+        monthlyRent: projectedLease.monthlyRent,
+        status: projectedLease.status,
+      },
+      paymentReadiness: projectedLease.paymentReadiness || null,
+      stripeConfigured: isStripeConfigured(),
+    });
+    if (!eligibility.eligible) {
+      return res.status(400).json({ ok: false, error: "TENANT_RENT_PAYMENT_BLOCKED", detail: eligibility.blockedReason });
+    }
+
+    const created = await createRentPaymentCheckout({
+      lease: {
+        id: leaseId,
+        landlordId: asString(leaseData?.landlordId),
+        tenantId: leaseTenantId,
+        tenantIds: leaseTenantIds,
+        primaryTenantId: asString(leaseData?.primaryTenantId),
+        propertyId: asString(leaseData?.propertyId),
+        unitId: asString(leaseData?.unitId),
+        unitNumber: asString(leaseData?.unitNumber),
+        monthlyRent: projectedLease.monthlyRent,
+        status: projectedLease.status,
+      },
+      tenantId: String(context.tenantId || "").trim(),
+      successPath: "/tenant/lease",
+      cancelPath: "/tenant/lease",
+    });
+
+    if (!created.ok) {
+      return res.status(400).json({ ok: false, error: "TENANT_RENT_PAYMENT_BLOCKED", detail: created.error });
+    }
+
+    return res.json({
+      ok: true,
+      data: {
+        rentPaymentId: created.rentPaymentId,
+        status: created.status,
+        redirectUrl: created.redirectUrl,
+      },
+    });
+  } catch (err: any) {
+    console.error("[tenant/leases/:leaseId/payments/checkout] failed", {
+      tenantId: context.tenantId,
+      leaseId,
+      message: err?.message || "failed",
+    });
+    return res.status(500).json({ ok: false, error: "TENANT_RENT_PAYMENT_CHECKOUT_FAILED" });
+  }
+});
+
+router.get("/leases/:leaseId/payments", requireTenantWorkspaceIdentity, async (req: any, res: any) => {
+  const context = await resolveWorkspaceContextOrRespond(req, res);
+  if (!context) return;
+  if (context.authority !== "active_tenant" || !context.tenantId) {
+    return res.status(403).json({ ok: false, error: "TENANT_CONTEXT_REQUIRED" });
+  }
+
+  const leaseId = String(req.params?.leaseId || "").trim();
+  if (!leaseId) {
+    return res.status(404).json({ ok: false, error: "lease_not_found" });
+  }
+  if (context.leaseId && String(context.leaseId).trim() !== leaseId) {
+    return res.status(403).json({ ok: false, error: "lease_not_owned_by_tenant" });
+  }
+
+  try {
+    const leaseSnap = await db.collection("leases").doc(leaseId).get();
+    if (!leaseSnap.exists) {
+      return res.status(404).json({ ok: false, error: "lease_not_found" });
+    }
+    const leaseData = (leaseSnap.data() as any) || {};
+    const projectedLease = projectTenantLease(leaseId, leaseData);
+    const eligibility = deriveRentPaymentEligibility({
+      lease: {
+        id: leaseId,
+        landlordId: asString(leaseData?.landlordId),
+        tenantId: asString(leaseData?.tenantId),
+        tenantIds: Array.isArray(leaseData?.tenantIds) ? leaseData.tenantIds : [],
+        primaryTenantId: asString(leaseData?.primaryTenantId),
+        propertyId: asString(leaseData?.propertyId),
+        unitId: asString(leaseData?.unitId),
+        unitNumber: asString(leaseData?.unitNumber),
+        monthlyRent: projectedLease.monthlyRent,
+        status: projectedLease.status,
+      },
+      paymentReadiness: projectedLease.paymentReadiness || null,
+      stripeConfigured: isStripeConfigured(),
+    });
+    const data = await getRentPaymentSummaryForLease({
+      leaseId,
+      paymentRailEnabled: leaseData?.paymentRailEnabled === true,
+      paymentRailEnabledAt: leaseData?.paymentRailEnabledAt || null,
+      paymentRailProcessor: leaseData?.paymentRailProcessor || null,
+      blockedReason: eligibility.blockedReason,
+    });
+    return res.json({ ok: true, data });
+  } catch (err: any) {
+    console.error("[tenant/leases/:leaseId/payments] failed", {
+      tenantId: context.tenantId,
+      leaseId,
+      message: err?.message || "failed",
+    });
+    return res.status(500).json({ ok: false, error: "TENANT_RENT_PAYMENT_STATUS_FAILED" });
+  }
 });
 
 router.post("/leases/:leaseId/sign", requireTenantWorkspaceIdentity, async (req: any, res) => {

--- a/rentchain-api/src/services/rentPayments/rentPaymentService.ts
+++ b/rentchain-api/src/services/rentPayments/rentPaymentService.ts
@@ -1,0 +1,534 @@
+import crypto from "crypto";
+import Stripe from "stripe";
+import { db } from "../../config/firebase";
+import { FRONTEND_URL } from "../../config/screeningConfig";
+import { getStripeClient } from "../stripeService";
+import { writeCanonicalEvent } from "../../lib/events/buildEvent";
+import type { PaymentReadiness } from "../paymentReadiness/derivePaymentReadiness";
+
+export const RENT_PAYMENTS_COLLECTION = "rentPayments";
+
+export type RentPaymentStatus =
+  | "setup_required"
+  | "checkout_created"
+  | "payment_pending"
+  | "paid"
+  | "failed"
+  | "canceled"
+  | "expired";
+
+export type RentPaymentRecord = {
+  id: string;
+  leaseId: string;
+  tenantId: string;
+  landlordId: string;
+  propertyId?: string | null;
+  unitId?: string | null;
+  amountCents: number;
+  currency: "cad";
+  status: RentPaymentStatus;
+  processor: "stripe";
+  processorCheckoutSessionId?: string | null;
+  processorPaymentIntentId?: string | null;
+  createdAt: string;
+  updatedAt: string;
+  paidAt?: string | null;
+};
+
+export type RentPaymentSummary = {
+  paymentRail: {
+    enabled: boolean;
+    enabledAt: string | null;
+    processor: "stripe" | null;
+    blockedReason: string | null;
+  };
+  latestPayment: {
+    id: string;
+    amountCents: number;
+    currency: "cad";
+    status: RentPaymentStatus;
+    createdAt: string;
+    updatedAt: string;
+    paidAt: string | null;
+  } | null;
+};
+
+export type RentPaymentEligibility = {
+  eligible: boolean;
+  blockedReason:
+    | "payment_readiness_not_ready"
+    | "lease_not_active"
+    | "missing_rent_amount"
+    | "missing_tenant_link"
+    | "invalid_currency"
+    | "stripe_not_configured"
+    | null;
+};
+
+type LeaseLike = {
+  id: string;
+  landlordId?: string | null;
+  tenantId?: string | null;
+  tenantIds?: string[] | null;
+  primaryTenantId?: string | null;
+  propertyId?: string | null;
+  unitId?: string | null;
+  unitNumber?: string | null;
+  monthlyRent?: number | null;
+  status?: string | null;
+  paymentRailEnabled?: boolean | null;
+  paymentRailEnabledAt?: string | null;
+  paymentRailProcessor?: string | null;
+};
+
+type CreateRentPaymentCheckoutInput = {
+  lease: LeaseLike;
+  tenantId: string;
+  successPath: string;
+  cancelPath: string;
+};
+
+type UpdateRentPaymentFromWebhookInput = {
+  rentPaymentId: string;
+  nextStatus: RentPaymentStatus;
+  processorCheckoutSessionId?: string | null;
+  processorPaymentIntentId?: string | null;
+  paidAt?: string | null;
+  eventId: string;
+};
+
+function asString(value: unknown): string | null {
+  const next = String(value || "").trim();
+  return next || null;
+}
+
+function asNumber(value: unknown): number | null {
+  const next = Number(value);
+  return Number.isFinite(next) ? next : null;
+}
+
+function toIsoString(value: unknown, fallback = new Date()): string {
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) return new Date(parsed).toISOString();
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return new Date(value).toISOString();
+  }
+  if (value instanceof Date && Number.isFinite(value.getTime())) {
+    return value.toISOString();
+  }
+  return fallback.toISOString();
+}
+
+function toMillis(value: unknown): number {
+  const iso = toIsoString(value, new Date(0));
+  return Date.parse(iso);
+}
+
+function resolveFrontendBase(): string {
+  const fallback =
+    process.env.NODE_ENV === "production" ? "https://www.rentchain.ai" : "http://localhost:5173";
+  return String(process.env.FRONTEND_URL || FRONTEND_URL || fallback).trim().replace(/\/$/, "");
+}
+
+function sanitizeRelativePath(value: string, fallback: string): string {
+  const next = String(value || "").trim();
+  if (!next.startsWith("/")) return fallback;
+  if (next.startsWith("//")) return fallback;
+  if (next.includes("://")) return fallback;
+  return next;
+}
+
+function normalizeCurrency(value: unknown): "cad" | null {
+  const next = String(value || "cad").trim().toLowerCase();
+  return next === "cad" ? "cad" : null;
+}
+
+function isLeaseStatusEligible(status: unknown): boolean {
+  return new Set(["active", "notice_pending", "renewal_pending", "renewal_accepted", "move_out_pending"]).has(
+    String(status || "").trim().toLowerCase()
+  );
+}
+
+function isOpenPaymentStatus(status: RentPaymentStatus): boolean {
+  return status === "checkout_created" || status === "payment_pending";
+}
+
+function isSameOrMoreFinal(current: RentPaymentStatus, next: RentPaymentStatus): boolean {
+  if (current === next) return true;
+  if (current === "paid") return true;
+  if ((current === "failed" || current === "canceled" || current === "expired") && next !== "paid") return true;
+  return false;
+}
+
+function summarizePayment(record: RentPaymentRecord | null): RentPaymentSummary["latestPayment"] {
+  if (!record) return null;
+  return {
+    id: record.id,
+    amountCents: record.amountCents,
+    currency: record.currency,
+    status: record.status,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+    paidAt: record.paidAt || null,
+  };
+}
+
+function eventSummaryForStatus(status: RentPaymentStatus): string {
+  switch (status) {
+    case "checkout_created":
+      return "Rent payment checkout created";
+    case "payment_pending":
+      return "Rent payment pending";
+    case "paid":
+      return "Rent payment confirmed";
+    case "failed":
+      return "Rent payment failed";
+    case "canceled":
+      return "Rent payment canceled";
+    case "expired":
+      return "Rent payment expired";
+    default:
+      return "Rent payment updated";
+  }
+}
+
+async function writeRentPaymentEvent(params: {
+  leaseId: string;
+  tenantId: string;
+  landlordId: string;
+  rentPaymentId: string;
+  status: RentPaymentStatus | "rail_enabled";
+  occurredAt?: string;
+  actor: {
+    type: "tenant" | "landlord" | "system";
+    id: string | null;
+    role: string | null;
+  };
+}) {
+  const eventType = params.status === "rail_enabled" ? "rent_payment.rail_enabled" : `rent_payment.${params.status}`;
+  const action = params.status === "rail_enabled" ? "rail_enabled" : params.status;
+  await writeCanonicalEvent({
+    type: eventType,
+    domain: "billing",
+    action,
+    status: params.status === "rail_enabled" ? "enabled" : params.status,
+    actor: params.actor,
+    resource: {
+      type: params.status === "rail_enabled" ? "lease" : "rent_payment",
+      id: params.status === "rail_enabled" ? params.leaseId : params.rentPaymentId,
+    },
+    occurredAt: params.occurredAt || new Date().toISOString(),
+    visibility: "internal",
+    summary: params.status === "rail_enabled" ? "Rent collection enabled" : eventSummaryForStatus(params.status),
+    metadata: {
+      leaseId: params.leaseId,
+      tenantId: params.tenantId,
+      landlordId: params.landlordId,
+      rentPaymentId: params.status === "rail_enabled" ? null : params.rentPaymentId,
+      processor: "stripe",
+      status: params.status === "rail_enabled" ? "enabled" : params.status,
+    },
+  });
+}
+
+export function deriveRentPaymentEligibility(input: {
+  lease: LeaseLike;
+  paymentReadiness: PaymentReadiness | null | undefined;
+  stripeConfigured: boolean;
+}): RentPaymentEligibility {
+  const lease = input.lease;
+  const paymentReadiness = input.paymentReadiness || null;
+  if (!input.stripeConfigured) {
+    return { eligible: false, blockedReason: "stripe_not_configured" };
+  }
+  if (paymentReadiness?.readinessStatus !== "ready_to_configure") {
+    return { eligible: false, blockedReason: "payment_readiness_not_ready" };
+  }
+  if (!isLeaseStatusEligible(lease.status)) {
+    return { eligible: false, blockedReason: "lease_not_active" };
+  }
+  if (!(typeof lease.monthlyRent === "number" && lease.monthlyRent > 0)) {
+    return { eligible: false, blockedReason: "missing_rent_amount" };
+  }
+  if (!paymentReadiness.rentTerms.tenantLinked) {
+    return { eligible: false, blockedReason: "missing_tenant_link" };
+  }
+  if (!normalizeCurrency("cad")) {
+    return { eligible: false, blockedReason: "invalid_currency" };
+  }
+  return { eligible: true, blockedReason: null };
+}
+
+export async function listRentPaymentsForLease(leaseId: string): Promise<RentPaymentRecord[]> {
+  const id = String(leaseId || "").trim();
+  if (!id) return [];
+  const snap = await db.collection(RENT_PAYMENTS_COLLECTION).where("leaseId", "==", id).get();
+  return (snap.docs || [])
+    .map((doc: any) => ({ id: doc.id, ...(doc.data() as any) }))
+    .sort((a: any, b: any) => {
+      const updatedDiff = toMillis(b?.updatedAt) - toMillis(a?.updatedAt);
+      if (updatedDiff !== 0) return updatedDiff;
+      return toMillis(b?.createdAt) - toMillis(a?.createdAt);
+    });
+}
+
+export async function getLatestRentPaymentForLease(leaseId: string): Promise<RentPaymentRecord | null> {
+  const items = await listRentPaymentsForLease(leaseId);
+  return items[0] || null;
+}
+
+export async function getRentPaymentSummaryForLease(input: {
+  leaseId: string;
+  paymentRailEnabled?: boolean | null;
+  paymentRailEnabledAt?: string | null;
+  paymentRailProcessor?: string | null;
+  blockedReason?: string | null;
+}): Promise<RentPaymentSummary> {
+  const latestPayment = await getLatestRentPaymentForLease(input.leaseId);
+  return {
+    paymentRail: {
+      enabled: input.paymentRailEnabled === true,
+      enabledAt: asString(input.paymentRailEnabledAt),
+      processor: input.paymentRailProcessor === "stripe" ? "stripe" : null,
+      blockedReason: asString(input.blockedReason),
+    },
+    latestPayment: summarizePayment(latestPayment),
+  };
+}
+
+export async function enableRentCollectionForLease(params: {
+  leaseId: string;
+  tenantId: string;
+  landlordId: string;
+  actorId: string | null;
+}): Promise<{ enabled: true; enabledAt: string; processor: "stripe" }> {
+  const enabledAt = new Date().toISOString();
+  await db.collection("leases").doc(params.leaseId).set(
+    {
+      paymentRailEnabled: true,
+      paymentRailEnabledAt: enabledAt,
+      paymentRailProcessor: "stripe",
+    },
+    { merge: true }
+  );
+  await writeRentPaymentEvent({
+    leaseId: params.leaseId,
+    tenantId: params.tenantId,
+    landlordId: params.landlordId,
+    rentPaymentId: params.leaseId,
+    status: "rail_enabled",
+    occurredAt: enabledAt,
+    actor: {
+      type: "landlord",
+      id: params.actorId,
+      role: "landlord",
+    },
+  });
+  return { enabled: true, enabledAt, processor: "stripe" };
+}
+
+export async function createRentPaymentCheckout(input: CreateRentPaymentCheckoutInput) {
+  const lease = input.lease;
+  const tenantId = String(input.tenantId || "").trim();
+  const landlordId = String(lease.landlordId || "").trim();
+  const leaseId = String(lease.id || "").trim();
+  const existing = await getLatestRentPaymentForLease(leaseId);
+  if (existing && isOpenPaymentStatus(existing.status)) {
+    return { ok: false as const, error: "payment_already_pending" };
+  }
+  if (existing?.status === "paid") {
+    return { ok: false as const, error: "payment_already_paid" };
+  }
+
+  const amountCents = Math.round((asNumber(lease.monthlyRent) || 0) * 100);
+  const rentPaymentId = crypto.randomUUID();
+  const createdAt = new Date().toISOString();
+  const checkoutRef = db.collection(RENT_PAYMENTS_COLLECTION).doc(rentPaymentId);
+  const stripe = getStripeClient();
+  const frontendBase = resolveFrontendBase();
+  const successUrl = `${frontendBase}${sanitizeRelativePath(input.successPath, "/tenant/lease")}`;
+  const cancelUrl = `${frontendBase}${sanitizeRelativePath(input.cancelPath, "/tenant/lease")}`;
+
+  const session = await stripe.checkout.sessions.create({
+    mode: "payment",
+    payment_method_types: ["card"],
+    line_items: [
+      {
+        price_data: {
+          currency: "cad",
+          product_data: {
+            name: "Monthly rent payment",
+          },
+          unit_amount: amountCents,
+        },
+        quantity: 1,
+      },
+    ],
+    metadata: {
+      leaseId,
+      tenantId,
+      landlordId,
+      rentPaymentId,
+    },
+    payment_intent_data: {
+      metadata: {
+        leaseId,
+        tenantId,
+        landlordId,
+        rentPaymentId,
+      },
+    },
+    success_url: `${successUrl}${successUrl.includes("?") ? "&" : "?"}rentPaymentStatus=success`,
+    cancel_url: `${cancelUrl}${cancelUrl.includes("?") ? "&" : "?"}rentPaymentStatus=canceled`,
+  });
+
+  const record: RentPaymentRecord = {
+    id: rentPaymentId,
+    leaseId,
+    tenantId,
+    landlordId,
+    propertyId: asString(lease.propertyId),
+    unitId: asString(lease.unitId) || asString(lease.unitNumber),
+    amountCents,
+    currency: "cad",
+    status: "checkout_created",
+    processor: "stripe",
+    processorCheckoutSessionId: session.id,
+    processorPaymentIntentId: typeof session.payment_intent === "string" ? session.payment_intent : null,
+    createdAt,
+    updatedAt: createdAt,
+    paidAt: null,
+  };
+  await checkoutRef.set(record, { merge: false });
+  await writeRentPaymentEvent({
+    leaseId,
+    tenantId,
+    landlordId,
+    rentPaymentId,
+    status: "checkout_created",
+    occurredAt: createdAt,
+    actor: {
+      type: "tenant",
+      id: tenantId,
+      role: "tenant",
+    },
+  });
+
+  return {
+    ok: true as const,
+    rentPaymentId,
+    status: "checkout_created" as const,
+    redirectUrl: String(session.url || "").trim(),
+  };
+}
+
+export async function updateRentPaymentFromWebhook(input: UpdateRentPaymentFromWebhookInput) {
+  const rentPaymentId = String(input.rentPaymentId || "").trim();
+  if (!rentPaymentId) return { handled: false as const, reason: "missing_rent_payment_id" };
+  const ref = db.collection(RENT_PAYMENTS_COLLECTION).doc(rentPaymentId);
+  const snap = await ref.get();
+  if (!snap.exists) return { handled: false as const, reason: "rent_payment_not_found" };
+
+  const current = { id: rentPaymentId, ...(snap.data() as any) } as RentPaymentRecord;
+  if (isSameOrMoreFinal(current.status, input.nextStatus)) {
+    return { handled: true as const, changed: false as const, record: current };
+  }
+
+  const updatedAt = new Date().toISOString();
+  const next: Partial<RentPaymentRecord> = {
+    status: input.nextStatus,
+    updatedAt,
+    processorCheckoutSessionId:
+      input.processorCheckoutSessionId === undefined ? current.processorCheckoutSessionId || null : input.processorCheckoutSessionId,
+    processorPaymentIntentId:
+      input.processorPaymentIntentId === undefined ? current.processorPaymentIntentId || null : input.processorPaymentIntentId,
+    paidAt: input.nextStatus === "paid" ? asString(input.paidAt) || updatedAt : current.paidAt || null,
+  };
+  await ref.set(next, { merge: true });
+
+  await writeRentPaymentEvent({
+    leaseId: current.leaseId,
+    tenantId: current.tenantId,
+    landlordId: current.landlordId,
+    rentPaymentId: current.id,
+    status: input.nextStatus,
+    occurredAt: input.paidAt || updatedAt,
+    actor: {
+      type: "system",
+      id: null,
+      role: "system",
+    },
+  });
+
+  return {
+    handled: true as const,
+    changed: true as const,
+    record: {
+      ...current,
+      ...next,
+    } as RentPaymentRecord,
+  };
+}
+
+export function extractRentPaymentMetadata(event: Stripe.Event): {
+  rentPaymentId: string | null;
+  checkoutSessionId: string | null;
+  paymentIntentId: string | null;
+  nextStatus: RentPaymentStatus | null;
+  paidAt: string | null;
+} {
+  if (event.type === "checkout.session.completed" || event.type === "checkout.session.async_payment_succeeded") {
+    const session = event.data.object as Stripe.Checkout.Session;
+    return {
+      rentPaymentId: asString(session.metadata?.rentPaymentId),
+      checkoutSessionId: asString(session.id),
+      paymentIntentId: typeof session.payment_intent === "string" ? session.payment_intent : null,
+      nextStatus:
+        event.type === "checkout.session.async_payment_succeeded"
+          ? "paid"
+          : session.payment_status === "paid" || session.payment_status === "no_payment_required"
+          ? "paid"
+          : "payment_pending",
+      paidAt: typeof event.created === "number" ? new Date(event.created * 1000).toISOString() : null,
+    };
+  }
+  if (event.type === "checkout.session.async_payment_failed") {
+    const session = event.data.object as Stripe.Checkout.Session;
+    return {
+      rentPaymentId: asString(session.metadata?.rentPaymentId),
+      checkoutSessionId: asString(session.id),
+      paymentIntentId: typeof session.payment_intent === "string" ? session.payment_intent : null,
+      nextStatus: "failed",
+      paidAt: null,
+    };
+  }
+  if (event.type === "payment_intent.succeeded" || event.type === "payment_intent.payment_failed") {
+    const paymentIntent = event.data.object as Stripe.PaymentIntent;
+    return {
+      rentPaymentId: asString(paymentIntent.metadata?.rentPaymentId),
+      checkoutSessionId: null,
+      paymentIntentId: asString(paymentIntent.id),
+      nextStatus: event.type === "payment_intent.succeeded" ? "paid" : "failed",
+      paidAt: typeof event.created === "number" ? new Date(event.created * 1000).toISOString() : null,
+    };
+  }
+  if (event.type === "checkout.session.expired") {
+    const session = event.data.object as Stripe.Checkout.Session;
+    return {
+      rentPaymentId: asString(session.metadata?.rentPaymentId),
+      checkoutSessionId: asString(session.id),
+      paymentIntentId: typeof session.payment_intent === "string" ? session.payment_intent : null,
+      nextStatus: "expired",
+      paidAt: null,
+    };
+  }
+  return {
+    rentPaymentId: null,
+    checkoutSessionId: null,
+    paymentIntentId: null,
+    nextStatus: null,
+    paidAt: null,
+  };
+}

--- a/rentchain-frontend/src/api/leasesApi.ts
+++ b/rentchain-frontend/src/api/leasesApi.ts
@@ -100,6 +100,23 @@ export interface LandlordActiveLease extends Lease {
       storedPaymentMethod: false;
     };
   } | null;
+  rentPaymentSummary?: {
+    paymentRail: {
+      enabled: boolean;
+      enabledAt: string | null;
+      processor: "stripe" | null;
+      blockedReason: string | null;
+    };
+    latestPayment: {
+      id: string;
+      amountCents: number;
+      currency: "cad";
+      status: "setup_required" | "checkout_created" | "payment_pending" | "paid" | "failed" | "canceled" | "expired";
+      createdAt: string;
+      updatedAt: string;
+      paidAt: string | null;
+    } | null;
+  } | null;
   hiddenFromActiveLists?: boolean;
   cleanupReason?: string | null;
   cleanupBatch?: string | null;
@@ -239,6 +256,49 @@ export async function restoreLeaseRecord(id: string): Promise<{ ok: true; lease:
     headers: { "Content-Type": "application/json" },
     body: "{}",
   });
+}
+
+export async function enableLeasePaymentRail(
+  id: string
+): Promise<{
+  ok: true;
+  data: {
+    leaseId: string;
+    paymentRail: {
+      enabled: true;
+      enabledAt: string;
+      processor: "stripe";
+      eligibility: "eligible";
+      blockedReason: null;
+    };
+  };
+}> {
+  return apiJson(`/leases/${encodeURIComponent(id)}/payment-rails/enable`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "{}",
+  });
+}
+
+export async function getLeasePaymentStatus(id: string): Promise<{
+  paymentRail: {
+    enabled: boolean;
+    enabledAt: string | null;
+    processor: "stripe" | null;
+    blockedReason: string | null;
+  };
+  latestPayment: {
+    id: string;
+    amountCents: number;
+    currency: "cad";
+    status: "setup_required" | "checkout_created" | "payment_pending" | "paid" | "failed" | "canceled" | "expired";
+    createdAt: string;
+    updatedAt: string;
+    paidAt: string | null;
+  } | null;
+}> {
+  const res = await apiJson<{ ok: boolean; data: any }>(`/leases/${encodeURIComponent(id)}/payments`);
+  return res?.data;
 }
 
 export async function createLease(

--- a/rentchain-frontend/src/api/tenantPortal.ts
+++ b/rentchain-frontend/src/api/tenantPortal.ts
@@ -82,6 +82,23 @@ export type TenantWorkspaceLease = {
   paymentStatus?: string | null;
   paymentRequestedAt?: string | null;
   paymentCompletedAt?: string | null;
+  rentPaymentSummary?: {
+    paymentRail: {
+      enabled: boolean;
+      enabledAt: string | null;
+      processor: "stripe" | null;
+      blockedReason: string | null;
+    };
+    latestPayment: {
+      id: string;
+      amountCents: number;
+      currency: "cad";
+      status: "setup_required" | "checkout_created" | "payment_pending" | "paid" | "failed" | "canceled" | "expired";
+      createdAt: string;
+      updatedAt: string;
+      paidAt: string | null;
+    } | null;
+  } | null;
 };
 
 export type PaymentReadiness = {
@@ -374,6 +391,43 @@ export async function getTenantApplicationStatus(): Promise<TenantWorkspaceAppli
 export async function getTenantLeaseWorkspace(): Promise<TenantWorkspaceLease | null> {
   const res = await tenantApiFetch<{ ok: boolean; data: TenantWorkspaceLease | null }>("/tenant/lease");
   return res?.data ?? null;
+}
+
+export async function createTenantLeasePaymentCheckout(
+  leaseId: string
+): Promise<{ rentPaymentId: string; status: "checkout_created"; redirectUrl: string }> {
+  const res = await tenantApiFetch<{ ok: boolean; data: { rentPaymentId: string; status: "checkout_created"; redirectUrl: string } }>(
+    `/tenant/leases/${encodeURIComponent(leaseId)}/payments/checkout`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    }
+  );
+  return res?.data;
+}
+
+export async function getTenantLeasePaymentStatus(
+  leaseId: string
+): Promise<{
+  paymentRail: {
+    enabled: boolean;
+    enabledAt: string | null;
+    processor: "stripe" | null;
+    blockedReason: string | null;
+  };
+  latestPayment: {
+    id: string;
+    amountCents: number;
+    currency: "cad";
+    status: "setup_required" | "checkout_created" | "payment_pending" | "paid" | "failed" | "canceled" | "expired";
+    createdAt: string;
+    updatedAt: string;
+    paidAt: string | null;
+  } | null;
+}> {
+  const res = await tenantApiFetch<{ ok: boolean; data: any }>(`/tenant/leases/${encodeURIComponent(leaseId)}/payments`);
+  return res?.data;
 }
 
 export async function signTenantLease(leaseId: string): Promise<TenantWorkspaceLease | null> {

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
@@ -6,6 +6,7 @@ import LandlordActiveLeasesPage from "./LandlordActiveLeasesPage";
 const mocks = vi.hoisted(() => ({
   getActiveLeasesForLandlord: vi.fn(),
   getArchivedLeasesForLandlord: vi.fn(),
+  enableLeasePaymentRail: vi.fn(),
   getLeaseReconciliationCandidates: vi.fn(),
   convertUnitReferenceToLease: vi.fn(),
   archiveLeaseRecord: vi.fn(),
@@ -15,6 +16,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock("@/api/leasesApi", () => ({
   getActiveLeasesForLandlord: mocks.getActiveLeasesForLandlord,
   getArchivedLeasesForLandlord: mocks.getArchivedLeasesForLandlord,
+  enableLeasePaymentRail: mocks.enableLeasePaymentRail,
   getLeaseReconciliationCandidates: mocks.getLeaseReconciliationCandidates,
   convertUnitReferenceToLease: mocks.convertUnitReferenceToLease,
   archiveLeaseRecord: mocks.archiveLeaseRecord,
@@ -70,6 +72,15 @@ describe("LandlordActiveLeasesPage", () => {
               storedPaymentMethod: false,
             },
           },
+          rentPaymentSummary: {
+            paymentRail: {
+              enabled: false,
+              enabledAt: null,
+              processor: null,
+              blockedReason: null,
+            },
+            latestPayment: null,
+          },
         },
       ],
     });
@@ -99,6 +110,16 @@ describe("LandlordActiveLeasesPage", () => {
       lease: { id: "lease-9" },
       tenant: { id: "tenant-9", fullName: "Recovered Tenant" },
     });
+    mocks.enableLeasePaymentRail.mockResolvedValue({
+      leaseId: "lease-1",
+      paymentRail: {
+        enabled: true,
+        enabledAt: "2026-04-27T10:00:00.000Z",
+        processor: "stripe",
+        eligibility: "eligible",
+        blockedReason: null,
+      },
+    });
     mocks.archiveLeaseRecord.mockResolvedValue({ ok: true, lease: { id: "lease-1" } });
     mocks.restoreLeaseRecord.mockResolvedValue({ ok: true, lease: { id: "lease-2" } });
     vi.spyOn(window, "confirm").mockReturnValue(true);
@@ -115,12 +136,15 @@ describe("LandlordActiveLeasesPage", () => {
     expect(screen.getByRole("button", { name: "Print / Save PDF" })).toBeInTheDocument();
     expect(screen.getAllByText("Lease fully executed").length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Rent terms ready for future setup/i).length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: /Enable rent collection/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "View" })).toHaveAttribute("href", "/leases/lease-1/ledger");
     expect(screen.getByRole("link", { name: "Email" })).toHaveAttribute(
       "href",
       expect.stringContaining("mailto:jane%40example.com")
     );
     expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Enable rent collection/i }));
+    await waitFor(() => expect(mocks.enableLeasePaymentRail).toHaveBeenCalledWith("lease-1"));
     fireEvent.click(screen.getByRole("button", { name: "Archive lease" }));
     await waitFor(() => expect(mocks.archiveLeaseRecord).toHaveBeenCalledWith("lease-1"));
   });

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
@@ -3,6 +3,7 @@ import { Link, useSearchParams } from "react-router-dom";
 import {
   archiveLeaseRecord,
   convertUnitReferenceToLease,
+  enableLeasePaymentRail,
   getActiveLeasesForLandlord,
   getArchivedLeasesForLandlord,
   getLeaseReconciliationCandidates,
@@ -149,6 +150,12 @@ function paymentReadinessChecklist(lease: LandlordActiveLease) {
   return missing.join(" · ");
 }
 
+function prettyRentPaymentStatus(status: string | null | undefined) {
+  const normalized = String(status || "").trim().toLowerCase();
+  if (!normalized) return "No payment started";
+  return normalized.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
 export default function LandlordActiveLeasesPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const view = searchParams.get("view") === "archived" ? "archived" : "active";
@@ -159,6 +166,7 @@ export default function LandlordActiveLeasesPage() {
   const [searchQuery, setSearchQuery] = React.useState("");
   const [selectedCandidate, setSelectedCandidate] = React.useState<LeaseReconciliationCandidate | null>(null);
   const [convertSaving, setConvertSaving] = React.useState(false);
+  const [paymentRailBusyLeaseId, setPaymentRailBusyLeaseId] = React.useState<string | null>(null);
   const [occupantName, setOccupantName] = React.useState("");
   const [tenantEmail, setTenantEmail] = React.useState("");
   const [tenantPhone, setTenantPhone] = React.useState("");
@@ -218,6 +226,19 @@ export default function LandlordActiveLeasesPage() {
   async function handleRestore(lease: LandlordActiveLease) {
     await restoreLeaseRecord(lease.id);
     await load();
+  }
+
+  async function handleEnableRentCollection(lease: LandlordActiveLease) {
+    setPaymentRailBusyLeaseId(lease.id);
+    setError(null);
+    try {
+      await enableLeasePaymentRail(lease.id);
+      await load();
+    } catch (err: unknown) {
+      setError(errorMessage(err, "Failed to enable rent collection."));
+    } finally {
+      setPaymentRailBusyLeaseId(null);
+    }
   }
 
   async function handleConvert() {
@@ -528,6 +549,20 @@ export default function LandlordActiveLeasesPage() {
                           </div>
                         </div>
                       ) : null}
+                      {lease.rentPaymentSummary ? (
+                        <div style={{ display: "grid", gap: 4, marginTop: 6 }}>
+                          <div style={{ fontSize: 12, fontWeight: 700, color: "#0f172a" }}>
+                            {lease.rentPaymentSummary.paymentRail.enabled ? "Rent collection enabled" : "Rent collection not enabled"}
+                          </div>
+                          <div style={{ color: "#64748b", fontSize: 12 }}>
+                            {lease.rentPaymentSummary.latestPayment
+                              ? prettyRentPaymentStatus(lease.rentPaymentSummary.latestPayment.status)
+                              : lease.rentPaymentSummary.paymentRail.blockedReason
+                              ? lease.rentPaymentSummary.paymentRail.blockedReason.replace(/_/g, " ")
+                              : "No payment started"}
+                          </div>
+                        </div>
+                      ) : null}
                     </td>
                     <td style={{ padding: 12 }}>{formatCurrency(lease.monthlyRent)}</td>
                     <td style={{ padding: 12 }}>
@@ -584,13 +619,26 @@ export default function LandlordActiveLeasesPage() {
                             Restore
                           </button>
                         ) : (
-                          <button
-                            type="button"
-                            onClick={() => void handleArchive(lease)}
-                            style={{ padding: "6px 10px", borderRadius: 8, border: "1px solid #cbd5e1", background: "#fff", color: "#0f172a" }}
-                          >
-                            Archive lease
-                          </button>
+                          <>
+                            {lease.rentPaymentSummary?.paymentRail.enabled !== true &&
+                            lease.paymentReadiness?.readinessStatus === "ready_to_configure" ? (
+                              <button
+                                type="button"
+                                onClick={() => void handleEnableRentCollection(lease)}
+                                disabled={paymentRailBusyLeaseId === lease.id}
+                                style={{ padding: "6px 10px", borderRadius: 8, border: "1px solid #cbd5e1", background: "#fff", color: "#0f172a" }}
+                              >
+                                {paymentRailBusyLeaseId === lease.id ? "Enabling..." : "Enable rent collection"}
+                              </button>
+                            ) : null}
+                            <button
+                              type="button"
+                              onClick={() => void handleArchive(lease)}
+                              style={{ padding: "6px 10px", borderRadius: 8, border: "1px solid #cbd5e1", background: "#fff", color: "#0f172a" }}
+                            >
+                              Archive lease
+                            </button>
+                          </>
                         )}
                       </div>
                     </td>

--- a/rentchain-frontend/src/pages/tenant/TenantLeasePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantLeasePage.tsx
@@ -1,5 +1,9 @@
 import React from "react";
-import { getTenantLeaseWorkspace, signTenantLease } from "../../api/tenantPortal";
+import {
+  createTenantLeasePaymentCheckout,
+  getTenantLeaseWorkspace,
+  signTenantLease,
+} from "../../api/tenantPortal";
 import {
   TenantEmptyState,
   TenantErrorState,
@@ -16,6 +20,7 @@ export default function TenantLeasePage() {
   const [data, setData] = React.useState<Awaited<ReturnType<typeof getTenantLeaseWorkspace>>>(null);
   const [loading, setLoading] = React.useState(true);
   const [signing, setSigning] = React.useState(false);
+  const [paying, setPaying] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
 
   const load = React.useCallback(async () => {
@@ -45,6 +50,24 @@ export default function TenantLeasePage() {
       setError(err?.payload?.error || err?.message || "Unable to record your lease signature.");
     } finally {
       setSigning(false);
+    }
+  }
+
+  async function handlePayRent() {
+    if (!data?.leaseId) return;
+    setPaying(true);
+    setError(null);
+    try {
+      const result = await createTenantLeasePaymentCheckout(data.leaseId);
+      if (result?.redirectUrl) {
+        window.location.assign(result.redirectUrl);
+        return;
+      }
+      setError("Unable to start rent payment checkout.");
+    } catch (err: any) {
+      setError(err?.payload?.detail || err?.payload?.error || err?.message || "Unable to start rent payment checkout.");
+    } finally {
+      setPaying(false);
     }
   }
 
@@ -145,6 +168,36 @@ export default function TenantLeasePage() {
                     },
                   ]}
                 />
+                {data.rentPaymentSummary ? (
+                  <div style={{ display: "grid", gap: 8 }}>
+                    <TenantKeyValueGrid
+                      rows={[
+                        {
+                          label: "Rent collection",
+                          value: data.rentPaymentSummary.paymentRail.enabled ? "Enabled" : "Not enabled",
+                        },
+                        {
+                          label: "Payment status",
+                          value: data.rentPaymentSummary.latestPayment
+                            ? String(data.rentPaymentSummary.latestPayment.status).replace(/_/g, " ")
+                            : "No payment started",
+                        },
+                      ]}
+                    />
+                    <div style={{ color: "var(--text-muted, #64748b)" }}>
+                      Payment processed by Stripe. RentChain does not store card or bank payment details.
+                    </div>
+                    {data.rentPaymentSummary.paymentRail.enabled &&
+                    paymentReadiness.readinessStatus === "ready_to_configure" &&
+                    !["checkout_created", "payment_pending", "paid"].includes(
+                      String(data.rentPaymentSummary.latestPayment?.status || "")
+                    ) ? (
+                      <button type="button" onClick={() => void handlePayRent()} disabled={paying}>
+                        {paying ? "Opening checkout..." : "Pay rent"}
+                      </button>
+                    ) : null}
+                  </div>
+                ) : null}
               </div>
             </TenantInfoCard>
           ) : null}

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -13,6 +13,7 @@ const tenantPortalApi = vi.hoisted(() => ({
   getTenantWorkspace: vi.fn(),
   getTenantLeaseWorkspace: vi.fn(),
   exportTenantIdentityPackage: vi.fn(),
+  createTenantLeasePaymentCheckout: vi.fn(),
   signTenantLease: vi.fn(),
   listTenantWorkspaceMaintenance: vi.fn(),
   redeemTenantWorkspaceInvite: vi.fn(),
@@ -298,6 +299,11 @@ describe("tenant workspace frontend shell", () => {
         consentRequired: true,
       },
     });
+    tenantPortalApi.createTenantLeasePaymentCheckout.mockResolvedValue({
+      rentPaymentId: "rp-1",
+      status: "checkout_created",
+      redirectUrl: "https://checkout.stripe.test/session/cs_test_1",
+    });
     tenantAttachmentsApi.getTenantAttachments.mockResolvedValue({
       ok: true,
       data: [
@@ -570,6 +576,15 @@ describe("tenant workspace frontend shell", () => {
             storedPaymentMethod: false,
           },
         },
+        rentPaymentSummary: {
+          paymentRail: {
+            enabled: true,
+            enabledAt: "2026-04-27T10:00:00.000Z",
+            processor: "stripe",
+            blockedReason: null,
+          },
+          latestPayment: null,
+        },
       },
       maintenance: [],
       tenantIdentityRecord: {
@@ -668,6 +683,8 @@ describe("tenant workspace frontend shell", () => {
     expect(screen.queryByText(/^Applicant$/i)).not.toBeInTheDocument();
     expect(screen.getAllByText(/Active tenancy/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/A lease reference is visible in your tenant workspace/i)).toBeInTheDocument();
+    expect(screen.getByText(/Payment processed by Stripe\. RentChain does not store card or bank payment details\./i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Pay rent/i })).toBeInTheDocument();
     expect(screen.getAllByRole("link", { name: /Open payments/i }).length).toBeGreaterThan(0);
     expect(screen.getByText(/Needs reply/i)).toBeInTheDocument();
     expect(screen.getByText(/Please confirm the final move-in details/i)).toBeInTheDocument();
@@ -682,6 +699,74 @@ describe("tenant workspace frontend shell", () => {
     expect(screen.getAllByText(/No action needed/i).length).toBeGreaterThan(0);
     expect(screen.getByRole("link", { name: /Open document vault/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Open access/i })).toBeInTheDocument();
+  });
+
+  it("starts tenant checkout from the workspace when rent collection is enabled", async () => {
+    tenantPortalApi.getTenantWorkspace.mockResolvedValue({
+      context: {
+        authority: "active_tenant",
+        propertyId: "prop-1",
+        rc_prop_id: "rc-prop-1",
+        applicationId: "app-1",
+        leaseId: "lease-1",
+        tenantId: "tenant-1",
+        unitId: "unit-1",
+        invitedEmail: "tenant@example.com",
+      },
+      property: null,
+      application: null,
+      lease: {
+        leaseId: "lease-1",
+        startDate: "2026-02-01",
+        endDate: "2027-01-31",
+        monthlyRent: 1800,
+        status: "active",
+        documentUrl: null,
+        paymentReadiness: {
+          readinessStatus: "ready_to_configure",
+          readinessLabel: "Rent terms ready for future setup",
+          readinessDescription: "Ready.",
+          requiredNextAction: "confirm_payment_setup_later",
+          rentTerms: {
+            rentAmountAvailable: true,
+            dueDateAvailable: true,
+            leaseDatesAvailable: true,
+            tenantLinked: true,
+            leaseExecuted: true,
+          },
+          paymentSetup: {
+            processorConnected: false,
+            moneyMovementEnabled: false,
+            storedPaymentMethod: false,
+          },
+        },
+        rentPaymentSummary: {
+          paymentRail: {
+            enabled: true,
+            enabledAt: "2026-04-27T10:00:00.000Z",
+            processor: "stripe",
+            blockedReason: null,
+          },
+          latestPayment: null,
+        },
+      },
+      maintenance: [],
+      tenantIdentityRecord: null,
+      tenantCredibilitySignals: null,
+      identityTimeline: { events: [] },
+    });
+
+    render(
+      <MemoryRouter>
+        <TenantWorkspacePage />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /Pay rent/i }));
+
+    await waitFor(() => {
+      expect(tenantPortalApi.createTenantLeasePaymentCheckout).toHaveBeenCalledWith("lease-1");
+    });
   });
 
   it("renders a safe empty activity timeline", async () => {
@@ -1205,6 +1290,15 @@ describe("tenant workspace frontend shell", () => {
           storedPaymentMethod: false,
         },
       },
+      rentPaymentSummary: {
+        paymentRail: {
+          enabled: true,
+          enabledAt: "2026-04-27T10:00:00.000Z",
+          processor: "stripe",
+          blockedReason: null,
+        },
+        latestPayment: null,
+      },
     });
 
     render(
@@ -1219,6 +1313,8 @@ describe("tenant workspace frontend shell", () => {
     expect(screen.getByText(/^Lease document available$/i)).toBeInTheDocument();
     expect(screen.getByText(/^Lease fully executed$/i)).toBeInTheDocument();
     expect(screen.getByText(/Rent terms ready for future setup/i)).toBeInTheDocument();
+    expect(screen.getByText(/Payment processed by Stripe\. RentChain does not store card or bank payment details\./i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Pay rent/i })).toBeInTheDocument();
     expect(screen.getByText(/^Drawn signature$/i)).toBeInTheDocument();
     expect(screen.getByText(/^Taylor Tenant$/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Open lease document/i })).toBeInTheDocument();
@@ -1291,6 +1387,77 @@ describe("tenant workspace frontend shell", () => {
 
     await waitFor(() => expect(tenantPortalApi.signTenantLease).toHaveBeenCalledWith("lease-2"));
     expect(await screen.findByText(/^Tenant signature completed$/i)).toBeInTheDocument();
+  });
+
+  it("starts tenant checkout from the lease page when rent collection is enabled", async () => {
+    tenantPortalApi.getTenantLeaseWorkspace.mockResolvedValue({
+      leaseId: "lease-1",
+      startDate: "2026-02-01",
+      endDate: "2027-01-31",
+      monthlyRent: 1800,
+      status: "active",
+      documentUrl: "https://example.com/lease.pdf",
+      signatureStatus: "signed",
+      signatureReadinessLabel: "Lease signing complete",
+      signatureReadinessDescription: "Complete.",
+      tenantSignature: {
+        signedAt: "2026-02-01T10:00:00.000Z",
+        signatureMethod: "typed",
+        signatureDisplayName: "Taylor Tenant",
+      },
+      leasePdfStatus: "available",
+      leasePdfLabel: "Lease document available",
+      leasePdfDescription: "Available.",
+      leaseExecution: {
+        executionStatus: "fully_executed",
+        executionLabel: "Lease fully executed",
+        executionDescription: "Complete.",
+        requiredNextAction: "none",
+        tenantSignatureStatus: "completed",
+        landlordSignatureStatus: "completed",
+        pdfStatus: "generated",
+        completedAt: "2026-02-02T12:00:00.000Z",
+      },
+      paymentReadiness: {
+        readinessStatus: "ready_to_configure",
+        readinessLabel: "Rent terms ready for future setup",
+        readinessDescription: "Ready.",
+        requiredNextAction: "confirm_payment_setup_later",
+        rentTerms: {
+          rentAmountAvailable: true,
+          dueDateAvailable: true,
+          leaseDatesAvailable: true,
+          tenantLinked: true,
+          leaseExecuted: true,
+        },
+        paymentSetup: {
+          processorConnected: false,
+          moneyMovementEnabled: false,
+          storedPaymentMethod: false,
+        },
+      },
+      rentPaymentSummary: {
+        paymentRail: {
+          enabled: true,
+          enabledAt: "2026-04-27T10:00:00.000Z",
+          processor: "stripe",
+          blockedReason: null,
+        },
+        latestPayment: null,
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <TenantLeasePage />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /Pay rent/i }));
+
+    await waitFor(() => {
+      expect(tenantPortalApi.createTenantLeasePaymentCheckout).toHaveBeenCalledWith("lease-1");
+    });
   });
 
   it("renders maintenance page with safe projected data", async () => {

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import { exportTenantIdentityPackage, getTenantWorkspace } from "../../api/tenantPortal";
+import {
+  createTenantLeasePaymentCheckout,
+  exportTenantIdentityPackage,
+  getTenantWorkspace,
+} from "../../api/tenantPortal";
 import { getTenantAccess, type TenantAccessWorkspace } from "../../api/tenantAccess";
 import { getTenantAttachments } from "../../api/tenantAttachmentsApi";
 import { getTenantProfile } from "../../api/tenantProfile";
@@ -115,6 +119,28 @@ function prettyShareRequestItem(
   }
 }
 
+function prettyRentPaymentStatus(
+  value: "setup_required" | "checkout_created" | "payment_pending" | "paid" | "failed" | "canceled" | "expired" | null | undefined
+) {
+  switch (value) {
+    case "checkout_created":
+      return "Checkout created";
+    case "payment_pending":
+      return "Payment pending";
+    case "paid":
+      return "Paid";
+    case "failed":
+      return "Failed";
+    case "canceled":
+      return "Canceled";
+    case "expired":
+      return "Expired";
+    case "setup_required":
+    default:
+      return "Setup required";
+  }
+}
+
 export default function TenantWorkspacePage() {
   const [data, setData] = React.useState<Awaited<ReturnType<typeof getTenantWorkspace>> | null>(null);
   const [institutionalPackage, setInstitutionalPackage] = React.useState<Awaited<ReturnType<typeof exportTenantIdentityPackage>> | null>(null);
@@ -132,6 +158,8 @@ export default function TenantWorkspacePage() {
   const [exportBusy, setExportBusy] = React.useState(false);
   const [exportError, setExportError] = React.useState<string | null>(null);
   const [showExportPreview, setShowExportPreview] = React.useState(false);
+  const [rentPaymentBusy, setRentPaymentBusy] = React.useState(false);
+  const [rentPaymentError, setRentPaymentError] = React.useState<string | null>(null);
   const [profileLoading, setProfileLoading] = React.useState(true);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
@@ -185,6 +213,24 @@ export default function TenantWorkspacePage() {
   React.useEffect(() => {
     void load();
   }, [load]);
+
+  async function handlePayRent() {
+    if (!data?.lease?.leaseId) return;
+    setRentPaymentBusy(true);
+    setRentPaymentError(null);
+    try {
+      const result = await createTenantLeasePaymentCheckout(data.lease.leaseId);
+      if (result?.redirectUrl) {
+        window.location.assign(result.redirectUrl);
+        return;
+      }
+      setRentPaymentError("Unable to start rent payment checkout.");
+    } catch (err: any) {
+      setRentPaymentError(err?.payload?.detail || err?.payload?.error || err?.message || "Unable to start rent payment checkout.");
+    } finally {
+      setRentPaymentBusy(false);
+    }
+  }
 
   React.useEffect(() => {
     let cancelled = false;
@@ -573,6 +619,49 @@ export default function TenantWorkspacePage() {
                   : "No immediate follow-up"}
               </strong>
             </div>
+
+            {data.lease.rentPaymentSummary ? (
+              <div
+                style={{
+                  display: "grid",
+                  gap: spacing.xs,
+                  padding: spacing.sm,
+                  border: "1px solid rgba(148,163,184,0.35)",
+                  borderRadius: 12,
+                }}
+              >
+                <div style={{ fontWeight: 700, color: textTokens.primary }}>Rent payment checkout</div>
+                <div style={{ color: textTokens.secondary }}>
+                  Payment processed by Stripe. RentChain does not store card or bank payment details.
+                </div>
+                <TenantKeyValueGrid
+                  rows={[
+                    {
+                      label: "Rent collection",
+                      value: data.lease.rentPaymentSummary.paymentRail.enabled ? "Enabled" : "Not enabled",
+                    },
+                    {
+                      label: "Payment status",
+                      value: data.lease.rentPaymentSummary.latestPayment
+                        ? prettyRentPaymentStatus(data.lease.rentPaymentSummary.latestPayment.status)
+                        : "No payment started",
+                    },
+                  ]}
+                />
+                {data.lease.rentPaymentSummary.paymentRail.enabled &&
+                data.lease.paymentReadiness.readinessStatus === "ready_to_configure" &&
+                !["checkout_created", "payment_pending", "paid"].includes(
+                  String(data.lease.rentPaymentSummary.latestPayment?.status || "")
+                ) ? (
+                  <div style={{ display: "grid", gap: spacing.xs }}>
+                    <button type="button" onClick={() => void handlePayRent()} disabled={rentPaymentBusy}>
+                      {rentPaymentBusy ? "Opening checkout..." : "Pay rent"}
+                    </button>
+                    {rentPaymentError ? <div style={{ color: "#b91c1c" }}>{rentPaymentError}</div> : null}
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
           </div>
         ) : (
           <div style={{ color: textTokens.secondary }}>


### PR DESCRIPTION
This PR introduces Payment Rails v2.

Includes:
- Stripe-hosted rent payment checkout foundation
- landlord-controlled lease-scoped rent collection enablement
- tenant lease-scoped checkout initiation
- rentPayments metadata/status records
- verified webhook reconciliation with idempotent final-state handling
- safe tenant/landlord payment status summaries
- focused backend/frontend test coverage

Guardrails preserved:
- no wallet or stored value
- no card/bank/payment-method storage
- no custom custody or internal money movement
- no autopay or recurring rent subscriptions
- no refunds, chargebacks, late fees, invoices, or receipts
- no tenant scoring or underwriting
- no external institution integrations
- no broad billing cleanup
- SaaS billing and screening payment semantics remain separate

PR note:
- Backend focused payment/webhook/lease/tenant tests passed: 58 tests.
- Backend typecheck passed.
- Frontend focused tests passed: 27 tests.
- Frontend build passed.
- jsdom navigation noise appears during redirect tests but tests pass.
- Existing frontend chunk-size warning remains unchanged and out of scope.
- Broad tenant payments/rent-charges integration, dashboard rollups, autopay, partial payments, refunds/chargebacks, late fees, invoices/receipts, non-Stripe processors, and direct bank/ACH handling were intentionally deferred.