### PR TITLE
feat: add identity portability v2

### DIFF
--- a/rentchain-api/src/routes/__tests__/applicationsRoutes.applyWithRentChain.test.ts
+++ b/rentchain-api/src/routes/__tests__/applicationsRoutes.applyWithRentChain.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { APPLICATIONS } from "../../services/applicationsService";
+
+const writeCanonicalEvent = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("../../lib/events/buildEvent", () => ({
+  writeCanonicalEvent,
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; body?: any }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path: options.url,
+      params: {},
+      query: {},
+      body: options.body || {},
+      headers: {},
+    };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+function buildPayload(overrides: Record<string, any> = {}) {
+  return {
+    propertyId: "public-apply",
+    propertyName: "Tenant Application",
+    unit: "12B",
+    unitApplied: "12B",
+    leaseStartDate: "2026-06-01",
+    requestedRent: 0,
+    primaryApplicant: {
+      firstName: "Jordan",
+      lastName: "Lee",
+      email: "jordan@example.com",
+      phone: "5551112222",
+      dateOfBirth: "1990-01-01",
+      recentAddress: {
+        streetNumber: "123",
+        streetName: "King St",
+        city: "Halifax",
+        province: "NS",
+        postalCode: "B3H1A1",
+      },
+    },
+    creditConsent: true,
+    applicantProfile: {
+      currentAddress: {
+        line1: "123 King St",
+        city: "Halifax",
+        provinceState: "NS",
+        postalCode: "B3H1A1",
+        country: "CA",
+      },
+      timeAtCurrentAddressMonths: 12,
+      currentRentAmountCents: 180000,
+      employment: {
+        employerName: "Harbour Labs",
+        jobTitle: "Designer",
+        incomeAmountCents: 720000,
+        incomeFrequency: "monthly",
+        monthsAtJob: 12,
+      },
+      workReference: {
+        name: "Taylor Grant",
+        phone: "5550001111",
+      },
+      signature: {
+        type: "typed",
+        typedName: "Jordan Lee",
+        typedAcknowledge: true,
+        signedAt: "2026-04-27T12:00:00.000Z",
+      },
+    },
+    applicationConsent: {
+      version: "v1.0",
+      accepted: true,
+      acceptedAt: "2026-04-27T12:00:00.000Z",
+    },
+    ...overrides,
+  };
+}
+
+describe("applicationsRoutes apply with RentChain metadata", () => {
+  beforeEach(() => {
+    APPLICATIONS.splice(0, APPLICATIONS.length);
+    vi.clearAllMocks();
+  });
+
+  it("stores only safe apply-with-rentchain source metadata", async () => {
+    const router = (await import("../applicationsRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/submit",
+      body: buildPayload({
+        applicationSource: "apply_with_rentchain",
+        identityReference: {
+          source: "rentchain",
+          referenceType: "tenant_identity_reference",
+          referenceStatus: "available",
+        },
+        approvedScopeKeys: [
+          "identity_summary",
+          "application_summary",
+          "documents_summary",
+          "bad_scope",
+        ],
+        shareToken: "should-not-store",
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body?.applicationSource).toBe("apply_with_rentchain");
+    expect(res.body?.identityReference).toEqual({
+      source: "rentchain",
+      referenceType: "tenant_identity_reference",
+      referenceStatus: "available",
+    });
+    expect(res.body?.approvedScopeKeys).toEqual([
+      "identity_summary",
+      "application_summary",
+      "documents_summary",
+    ]);
+    expect(res.body?.shareToken).toBeUndefined();
+    expect(writeCanonicalEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          source: "apply_with_rentchain",
+        }),
+      })
+    );
+  });
+});

--- a/rentchain-api/src/routes/__tests__/publicTenantShareRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/publicTenantShareRoutes.test.ts
@@ -1,11 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const readTenantSharePackageByToken = vi.fn();
+const readTenantShareApplyContextByToken = vi.fn();
 const requestTenantSharePackageItems = vi.fn();
 const createTenantShareVerificationRequest = vi.fn();
 
 vi.mock("../../services/tenantPortal/tenantSharePackageService", () => ({
   createTenantShareVerificationRequest,
+  readTenantShareApplyContextByToken,
   readTenantSharePackageByToken,
   requestTenantSharePackageItems,
 }));
@@ -134,5 +136,55 @@ describe("publicTenantShareRoutes", () => {
     });
     expect(res.body?.data?.status).toBe("requested");
     expect(res.body?.data?.requestId).toBeUndefined();
+  });
+
+  it("returns a safe apply-with-rentchain prefill context for a valid token", async () => {
+    readTenantShareApplyContextByToken.mockResolvedValue({
+      applyWithRentChain: {
+        source: "share_token",
+        tokenValidated: true,
+        scopesApproved: ["identity_summary", "application_summary"],
+        identityReference: {
+          referenceStatus: "available",
+          portabilityStatus: "ready",
+        },
+        applicationContext: {
+          prefilled: true,
+          requiredRemaining: ["credit_consent"],
+          prefill: {
+            applicant: {
+              firstName: "Jordan",
+              lastName: "Lee",
+              email: "jordan@example.com",
+              phone: "5551112222",
+            },
+            currentAddress: {
+              line1: "123 King St",
+              city: "Halifax",
+              province: "NS",
+              postalCode: "B3H1A1",
+            },
+            employment: {
+              employerName: "Harbour Labs",
+              jobTitle: "Designer",
+              incomeAmountCents: 720000,
+              incomeFrequency: "monthly",
+              monthsAtJob: 12,
+            },
+          },
+        },
+      },
+    });
+
+    const router = (await import("../publicTenantShareRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/share/share-token-1/apply",
+    });
+
+    expect(res.status).toBe(200);
+    expect(readTenantShareApplyContextByToken).toHaveBeenCalledWith("share-token-1");
+    expect(res.body?.data?.applyWithRentChain?.tokenValidated).toBe(true);
+    expect(res.body?.data?.applyWithRentChain?.applicationContext?.prefill?.applicant?.firstName).toBe("Jordan");
   });
 });

--- a/rentchain-api/src/routes/applicationsRoutes.ts
+++ b/rentchain-api/src/routes/applicationsRoutes.ts
@@ -133,6 +133,69 @@ interface NewApplicationPayload {
     acceptedAt: string;
     textHash?: string;
   };
+  applicationSource?: "apply_with_rentchain";
+  identityReference?: {
+    source?: "rentchain";
+    referenceType?: "tenant_identity_reference";
+    referenceStatus?: "available" | "limited" | "not_ready";
+  };
+  approvedScopeKeys?: Array<
+    | "identity_summary"
+    | "credibility_summary"
+    | "application_summary"
+    | "documents_summary"
+    | "lease_summary"
+    | "payment_readiness_summary"
+  >;
+}
+
+const APPLY_WITH_RENTCHAIN_SCOPE_KEYS = new Set([
+  "identity_summary",
+  "credibility_summary",
+  "application_summary",
+  "documents_summary",
+  "lease_summary",
+  "payment_readiness_summary",
+]);
+
+function sanitizeApplyWithRentChainMetadata(payload: NewApplicationPayload) {
+  const applicationSource = payload.applicationSource === "apply_with_rentchain" ? "apply_with_rentchain" : null;
+  if (!applicationSource) {
+    return {
+      applicationSource: null,
+      identityReference: null,
+      approvedScopeKeys: null,
+    };
+  }
+
+  const referenceStatus =
+    payload.identityReference?.referenceStatus === "available" ||
+    payload.identityReference?.referenceStatus === "limited" ||
+    payload.identityReference?.referenceStatus === "not_ready"
+      ? payload.identityReference.referenceStatus
+      : null;
+
+  const approvedScopeKeys = Array.isArray(payload.approvedScopeKeys)
+    ? Array.from(
+        new Set(
+          payload.approvedScopeKeys.filter((scope) =>
+            APPLY_WITH_RENTCHAIN_SCOPE_KEYS.has(String(scope || ""))
+          )
+        )
+      )
+    : [];
+
+  return {
+    applicationSource,
+    identityReference: referenceStatus
+      ? {
+          source: "rentchain" as const,
+          referenceType: "tenant_identity_reference" as const,
+          referenceStatus,
+        }
+      : null,
+    approvedScopeKeys,
+  };
 }
 
 async function streamApplicationPdf(app: Application, res: Response) {
@@ -955,9 +1018,10 @@ router.post(
  * POST /api/applications/submit
  * MVP endpoint for the online Apply wizard.
  */
-function handleApplicationFormSubmit(req: Request, res: Response) {
+async function handleApplicationFormSubmit(req: Request, res: Response) {
   try {
     const payload = req.body as NewApplicationPayload;
+    const applyWithRentChainMetadata = sanitizeApplyWithRentChainMetadata(payload);
 
     const applicant = payload.primaryApplicant;
     const missing: string[] = [];
@@ -1233,6 +1297,9 @@ function handleApplicationFormSubmit(req: Request, res: Response) {
       applicantProfile: profile || null,
       applicationConsent: consent || null,
       formVersion: payload.formVersion || "v2",
+      applicationSource: applyWithRentChainMetadata.applicationSource,
+      identityReference: applyWithRentChainMetadata.identityReference,
+      approvedScopeKeys: applyWithRentChainMetadata.approvedScopeKeys,
     };
 
     APPLICATIONS.unshift(newApp);
@@ -1262,7 +1329,7 @@ function handleApplicationFormSubmit(req: Request, res: Response) {
       metadata: {
         propertyId: newApp.propertyId,
         unitId: newApp.unitId || null,
-        source: "online_application_submit",
+        source: newApp.applicationSource || "online_application_submit",
       },
     });
 

--- a/rentchain-api/src/routes/publicTenantShareRoutes.ts
+++ b/rentchain-api/src/routes/publicTenantShareRoutes.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import {
   createTenantShareVerificationRequest,
+  readTenantShareApplyContextByToken,
   readTenantSharePackageByToken,
   requestTenantSharePackageItems,
 } from "../services/tenantPortal/tenantSharePackageService";
@@ -67,6 +68,25 @@ router.post("/share/:token/verification-request", async (req: any, res) => {
     return res.json({ ok: true, data: result });
   } catch (err: any) {
     console.error("[public-tenant-share] verification request failed", err?.message || err);
+    return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+  }
+});
+
+router.post("/share/:token/apply", async (req: any, res) => {
+  try {
+    const token = String(req.params?.token || "").trim();
+    if (!token) {
+      return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+    }
+
+    const result = await readTenantShareApplyContextByToken(token);
+    if (!result) {
+      return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+    }
+
+    return res.json({ ok: true, data: result });
+  } catch (err: any) {
+    console.error("[public-tenant-share] apply failed", err?.message || err);
     return res.status(404).json({ ok: false, error: "NOT_FOUND" });
   }
 });

--- a/rentchain-api/src/services/identityPortability/__tests__/deriveApplyWithRentChainContext.test.ts
+++ b/rentchain-api/src/services/identityPortability/__tests__/deriveApplyWithRentChainContext.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { deriveApplyWithRentChainContext } from "../deriveApplyWithRentChainContext";
+
+describe("deriveApplyWithRentChainContext", () => {
+  it("maps approved identity and application scopes into safe prefill only", () => {
+    const result = deriveApplyWithRentChainContext({
+      approvedScopeKeys: [
+        "identity_summary",
+        "application_summary",
+        "documents_summary",
+        "lease_summary",
+        "payment_readiness_summary",
+      ],
+      identityExchangeReference: {
+        referenceType: "tenant_identity_reference",
+        referenceStatus: "available",
+        referenceLabel: "Identity exchange available",
+        referenceDescription: "safe",
+        portabilityStatus: "ready",
+        exchangeReadiness: {
+          identityReady: true,
+          credibilityReady: true,
+          sharingControlsReady: true,
+          auditTimelineReady: true,
+          paymentReadinessAvailable: true,
+        },
+      },
+      applicationReuse: {
+        applicant: {
+          firstName: "Jordan",
+          lastName: "Lee",
+          email: "jordan@example.com",
+          phone: "5551112222",
+        },
+        currentAddress: {
+          line1: "123 King St",
+          line2: null,
+          city: "Halifax",
+          provinceState: "NS",
+          postalCode: "B3H1A1",
+          country: "CA",
+        },
+        timeAtCurrentAddressMonths: 18,
+        currentRentAmountCents: 180000,
+        employment: {
+          employerName: "Harbour Labs",
+          jobTitle: "Designer",
+          incomeAmountCents: 720000,
+          incomeFrequency: "monthly",
+          monthsAtJob: 12,
+        },
+        workReference: {
+          name: "Taylor Grant",
+          phone: "5550001111",
+        },
+        nextOfKin: null,
+      },
+    });
+
+    expect(result.scopesApproved).toEqual([
+      "identity_summary",
+      "application_summary",
+      "documents_summary",
+      "lease_summary",
+      "payment_readiness_summary",
+    ]);
+    expect(result.applicationContext.prefill.applicant.firstName).toBe("Jordan");
+    expect(result.applicationContext.prefill.currentAddress?.line1).toBe("123 King St");
+    expect(result.applicationContext.prefill.employment?.employerName).toBe("Harbour Labs");
+    expect(result.applicationContext.requiredRemaining).toContain("credit_consent");
+  });
+
+  it("does not derive document or lease details into application prefill", () => {
+    const result = deriveApplyWithRentChainContext({
+      approvedScopeKeys: ["documents_summary", "lease_summary", "payment_readiness_summary"],
+      identityExchangeReference: {
+        referenceType: "tenant_identity_reference",
+        referenceStatus: "limited",
+        referenceLabel: "Identity exchange limited",
+        referenceDescription: "safe",
+        portabilityStatus: "limited",
+        exchangeReadiness: {
+          identityReady: false,
+          credibilityReady: true,
+          sharingControlsReady: true,
+          auditTimelineReady: false,
+          paymentReadinessAvailable: true,
+        },
+      },
+      applicationReuse: {
+        applicant: {
+          firstName: "Jordan",
+          lastName: "Lee",
+          email: "jordan@example.com",
+          phone: "5551112222",
+        },
+        currentAddress: null,
+        timeAtCurrentAddressMonths: null,
+        currentRentAmountCents: null,
+        employment: null,
+        workReference: null,
+        nextOfKin: null,
+      },
+    });
+
+    expect(result.applicationContext.prefill.applicant.firstName).toBeUndefined();
+    expect(result.applicationContext.prefill.currentAddress).toBeUndefined();
+    expect(result.applicationContext.prefill.employment).toBeUndefined();
+  });
+});

--- a/rentchain-api/src/services/identityPortability/deriveApplyWithRentChainContext.ts
+++ b/rentchain-api/src/services/identityPortability/deriveApplyWithRentChainContext.ts
@@ -1,0 +1,143 @@
+import type { IdentityExchangeReference } from "../identityExchange/deriveIdentityExchangeReference";
+import type { TenantApplicationReuseProjection } from "../tenantPortal/tenantProfileService";
+import type { TenantSharePermissionKey } from "../tenantPortal/tenantSharePackageService";
+
+export type ApplyWithRentChainScope = TenantSharePermissionKey;
+
+export type ApplyWithRentChainPrefill = {
+  applicant: {
+    firstName?: string | null;
+    lastName?: string | null;
+    email?: string | null;
+    phone?: string | null;
+  };
+  currentAddress?: {
+    line1?: string | null;
+    city?: string | null;
+    province?: string | null;
+    postalCode?: string | null;
+  } | null;
+  employment?: {
+    employerName?: string | null;
+    jobTitle?: string | null;
+    incomeAmountCents?: number | null;
+    incomeFrequency?: "monthly" | "annual" | null;
+    monthsAtJob?: number | null;
+  } | null;
+};
+
+export type ApplyWithRentChainContext = {
+  source: "share_token";
+  tokenValidated: true;
+  scopesApproved: ApplyWithRentChainScope[];
+  identityReference: {
+    referenceStatus: "available" | "limited" | "not_ready";
+    portabilityStatus: "ready" | "limited" | "not_ready";
+  };
+  applicationContext: {
+    prefilled: boolean;
+    requiredRemaining: string[];
+    prefill: ApplyWithRentChainPrefill;
+  };
+};
+
+type DeriveApplyWithRentChainContextInput = {
+  approvedScopeKeys: ApplyWithRentChainScope[];
+  identityExchangeReference: IdentityExchangeReference;
+  applicationReuse: TenantApplicationReuseProjection;
+};
+
+function uniq(values: string[]) {
+  return Array.from(new Set(values));
+}
+
+export function deriveApplyWithRentChainContext(
+  input: DeriveApplyWithRentChainContextInput
+): ApplyWithRentChainContext {
+  const approvedScopes = Array.from(new Set(input.approvedScopeKeys));
+  const allowIdentity = approvedScopes.includes("identity_summary");
+  const allowApplication = approvedScopes.includes("application_summary");
+
+  const prefill: ApplyWithRentChainPrefill = {
+    applicant: {},
+  };
+
+  if (allowIdentity) {
+    prefill.applicant = {
+      firstName: input.applicationReuse.applicant.firstName,
+      lastName: input.applicationReuse.applicant.lastName,
+      email: input.applicationReuse.applicant.email,
+      phone: input.applicationReuse.applicant.phone,
+    };
+  }
+
+  if (allowApplication) {
+    prefill.currentAddress = input.applicationReuse.currentAddress
+      ? {
+          line1: input.applicationReuse.currentAddress.line1,
+          city: input.applicationReuse.currentAddress.city,
+          province: input.applicationReuse.currentAddress.provinceState,
+          postalCode: input.applicationReuse.currentAddress.postalCode,
+        }
+      : null;
+    prefill.employment = input.applicationReuse.employment
+      ? {
+          employerName: input.applicationReuse.employment.employerName,
+          jobTitle: input.applicationReuse.employment.jobTitle,
+          incomeAmountCents: input.applicationReuse.employment.incomeAmountCents,
+          incomeFrequency: input.applicationReuse.employment.incomeFrequency,
+          monthsAtJob: input.applicationReuse.employment.monthsAtJob,
+        }
+      : null;
+  }
+
+  const requiredRemaining: string[] = [];
+
+  if (!prefill.applicant.firstName) requiredRemaining.push("first_name");
+  if (!prefill.applicant.lastName) requiredRemaining.push("last_name");
+  if (!prefill.applicant.email) requiredRemaining.push("email");
+  if (!prefill.applicant.phone) requiredRemaining.push("phone");
+
+  if (!prefill.currentAddress?.line1) requiredRemaining.push("current_address_line1");
+  if (!prefill.currentAddress?.city) requiredRemaining.push("current_address_city");
+  if (!prefill.currentAddress?.province) requiredRemaining.push("current_address_province");
+  if (!prefill.currentAddress?.postalCode) requiredRemaining.push("current_address_postal_code");
+
+  if (!prefill.employment?.employerName) requiredRemaining.push("employment_employer_name");
+  if (!prefill.employment?.jobTitle) requiredRemaining.push("employment_job_title");
+  if (prefill.employment?.incomeAmountCents == null) requiredRemaining.push("employment_income_amount");
+  if (!prefill.employment?.incomeFrequency) requiredRemaining.push("employment_income_frequency");
+  if (prefill.employment?.monthsAtJob == null) requiredRemaining.push("employment_months_at_job");
+
+  requiredRemaining.push("credit_consent");
+
+  const prefilled = Boolean(
+    prefill.applicant.firstName ||
+      prefill.applicant.lastName ||
+      prefill.applicant.email ||
+      prefill.applicant.phone ||
+      prefill.currentAddress?.line1 ||
+      prefill.currentAddress?.city ||
+      prefill.currentAddress?.province ||
+      prefill.currentAddress?.postalCode ||
+      prefill.employment?.employerName ||
+      prefill.employment?.jobTitle ||
+      prefill.employment?.incomeAmountCents != null ||
+      prefill.employment?.monthsAtJob != null
+  );
+
+  return {
+    source: "share_token",
+    tokenValidated: true,
+    scopesApproved: approvedScopes,
+    identityReference: {
+      referenceStatus: input.identityExchangeReference.referenceStatus,
+      portabilityStatus: input.identityExchangeReference.portabilityStatus,
+    },
+    applicationContext: {
+      prefilled,
+      requiredRemaining: uniq(requiredRemaining),
+      prefill,
+    },
+  };
+}

--- a/rentchain-api/src/services/tenantPortal/tenantSharePackageService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantSharePackageService.ts
@@ -1,9 +1,18 @@
 import crypto from "crypto";
 import { db } from "../../config/firebase";
-import { loadTenantIdentityRecord, type TenantIdentityRecord } from "./tenantProfileService";
+import {
+  loadTenantApplicationReuseProjection,
+  loadTenantIdentityRecord,
+  type TenantApplicationReuseProjection,
+  type TenantIdentityRecord,
+} from "./tenantProfileService";
 import { resolveTenancyContext } from "./tenancyContextService";
 import { deriveTenantCredibilitySignals } from "../tenantCredibility/deriveTenantCredibilitySignals";
 import { deriveIdentityPortability, type PortableIdentity } from "../identityPortability/deriveIdentityPortability";
+import {
+  deriveApplyWithRentChainContext,
+  type ApplyWithRentChainContext,
+} from "../identityPortability/deriveApplyWithRentChainContext";
 import { deriveIdentityTimeline } from "../identityTimeline/deriveIdentityTimeline";
 import { derivePaymentReadiness, type PaymentReadiness } from "../paymentReadiness/derivePaymentReadiness";
 import {
@@ -91,6 +100,10 @@ export type TenantSharePackagePublicPayload = {
     availableSections: TenantSharePackageAvailabilitySection[];
   };
   generatedAt: string;
+};
+
+export type TenantShareApplyPayload = {
+  applyWithRentChain: ApplyWithRentChainContext;
 };
 
 export type TenantSharePackageRecord = {
@@ -292,6 +305,7 @@ async function loadTenantShareRecordByToken(token: string): Promise<TenantShareP
 
 type ResolvedShareTenantContext = {
   identity: TenantIdentityRecord;
+  applicationReuse: TenantApplicationReuseProjection;
   portableIdentity: PortableIdentity;
   paymentReadiness: PaymentReadiness | null;
   identityExchangeReference: IdentityExchangeReference;
@@ -329,6 +343,10 @@ async function resolveShareTenantContext(params: {
     userEmail: email,
   });
   if (!identity) return null;
+  const applicationReuse = await loadTenantApplicationReuseProjection({
+    context,
+    userEmail: email,
+  });
 
   const leaseSnap = context.leaseId
     ? await db.collection("leases").doc(String(context.leaseId || "")).get().catch(() => null as any)
@@ -375,6 +393,7 @@ async function resolveShareTenantContext(params: {
 
   return {
     identity,
+    applicationReuse,
     portableIdentity,
     paymentReadiness,
     identityExchangeReference,
@@ -476,6 +495,21 @@ function buildPublicPayload(params: {
   }
 
   return payload;
+}
+
+function deriveApprovedScopeKeysFromPermissions(
+  permissions: TenantSharePermissions
+): TenantSharePermissionKey[] {
+  const approved: TenantSharePermissionKey[] = [];
+  if (permissions.identitySummary) approved.push("identity_summary");
+  if (permissions.credibilitySummary) approved.push("credibility_summary");
+  if (permissions.applicationSummary) approved.push("application_summary");
+  if (permissions.documents === "summary" || permissions.documents === "approved_only") {
+    approved.push("documents_summary");
+  }
+  if (permissions.leaseSummary) approved.push("lease_summary");
+  if (permissions.paymentReadinessSummary) approved.push("payment_readiness_summary");
+  return approved;
 }
 
 export async function createTenantSharePackage(params: {
@@ -810,4 +844,32 @@ export async function readTenantSharePackageByToken(
     leaseSummary: resolved.leaseSummary,
     paymentReadiness: resolved.paymentReadiness,
   });
+}
+
+export async function readTenantShareApplyContextByToken(
+  token: string
+): Promise<TenantShareApplyPayload | null> {
+  const normalized = asString(token);
+  if (!normalized) return null;
+
+  const record = await loadTenantShareRecordByToken(normalized);
+  if (!record) return null;
+  if (record.status !== "active") return null;
+  if (Number(record.expiresAt || 0) <= nowMs()) return null;
+
+  const resolved = await resolveShareTenantContext({
+    tenantId: record.tenantId,
+    sharingControlsReady: true,
+  });
+  if (!resolved) return null;
+
+  return {
+    applyWithRentChain: deriveApplyWithRentChainContext({
+      approvedScopeKeys: deriveApprovedScopeKeysFromPermissions(
+        record.permissions || derivePermissionsFromApprovedItems(record.approvedItems || [])
+      ),
+      identityExchangeReference: resolved.identityExchangeReference,
+      applicationReuse: resolved.applicationReuse,
+    }),
+  };
 }

--- a/rentchain-api/src/types/applications.ts
+++ b/rentchain-api/src/types/applications.ts
@@ -116,4 +116,18 @@ export interface Application {
   convertedTenantId?: string | null;
   screeningId?: string | null;
   updatedAt?: string | null;
+  applicationSource?: "apply_with_rentchain" | null;
+  identityReference?: {
+    source: "rentchain";
+    referenceType: "tenant_identity_reference";
+    referenceStatus: "available" | "limited" | "not_ready";
+  } | null;
+  approvedScopeKeys?: Array<
+    | "identity_summary"
+    | "credibility_summary"
+    | "application_summary"
+    | "documents_summary"
+    | "lease_summary"
+    | "payment_readiness_summary"
+  > | null;
 }

--- a/rentchain-frontend/src/api/applicationsApi.ts
+++ b/rentchain-frontend/src/api/applicationsApi.ts
@@ -205,6 +205,20 @@ export interface Application {
   applicantProfile?: ApplicantProfile | null;
   applicationConsent?: ApplicationConsent | null;
   formVersion?: string | null;
+  applicationSource?: "apply_with_rentchain" | null;
+  identityReference?: {
+    source: "rentchain";
+    referenceType: "tenant_identity_reference";
+    referenceStatus: "available" | "limited" | "not_ready";
+  } | null;
+  approvedScopeKeys?: Array<
+    | "identity_summary"
+    | "credibility_summary"
+    | "application_summary"
+    | "documents_summary"
+    | "lease_summary"
+    | "payment_readiness_summary"
+  > | null;
 }
 
 /**
@@ -270,6 +284,20 @@ export interface SubmitApplicationPayload {
   applicantProfile?: ApplicantProfile;
   applicationConsent?: ApplicationConsent;
   formVersion?: string;
+  applicationSource?: "apply_with_rentchain";
+  identityReference?: {
+    source: "rentchain";
+    referenceType: "tenant_identity_reference";
+    referenceStatus: "available" | "limited" | "not_ready";
+  };
+  approvedScopeKeys?: Array<
+    | "identity_summary"
+    | "credibility_summary"
+    | "application_summary"
+    | "documents_summary"
+    | "lease_summary"
+    | "payment_readiness_summary"
+  >;
 }
 
 export interface UpdateApplicationPayload {

--- a/rentchain-frontend/src/api/publicTenantSharePackageApi.ts
+++ b/rentchain-frontend/src/api/publicTenantSharePackageApi.ts
@@ -49,6 +49,50 @@ export type PublicTenantSharePackage = {
   generatedAt: string;
 };
 
+export type ApplyWithRentChainResponse = {
+  applyWithRentChain: {
+    source: "share_token";
+    tokenValidated: true;
+    scopesApproved: Array<
+      | "identity_summary"
+      | "credibility_summary"
+      | "application_summary"
+      | "documents_summary"
+      | "lease_summary"
+      | "payment_readiness_summary"
+    >;
+    identityReference: {
+      referenceStatus: "available" | "limited" | "not_ready";
+      portabilityStatus: "ready" | "limited" | "not_ready";
+    };
+    applicationContext: {
+      prefilled: boolean;
+      requiredRemaining: string[];
+      prefill: {
+        applicant: {
+          firstName?: string | null;
+          lastName?: string | null;
+          email?: string | null;
+          phone?: string | null;
+        };
+        currentAddress?: {
+          line1?: string | null;
+          city?: string | null;
+          province?: string | null;
+          postalCode?: string | null;
+        } | null;
+        employment?: {
+          employerName?: string | null;
+          jobTitle?: string | null;
+          incomeAmountCents?: number | null;
+          incomeFrequency?: "monthly" | "annual" | null;
+          monthsAtJob?: number | null;
+        } | null;
+      };
+    };
+  };
+};
+
 export async function fetchPublicTenantSharePackage(token: string): Promise<PublicTenantSharePackage | null> {
   const res = await apiFetch<{ ok: boolean; data: PublicTenantSharePackage }>(
     `/public/share/${encodeURIComponent(token)}`,
@@ -95,4 +139,16 @@ export async function requestPublicTenantSharePackageVerification(
     }
   );
   return res.data;
+}
+
+export async function createApplyWithRentChainContext(token: string): Promise<ApplyWithRentChainResponse | null> {
+  const res = await apiFetch<{ ok: boolean; data: ApplyWithRentChainResponse }>(
+    `/public/share/${encodeURIComponent(token)}/apply`,
+    {
+      method: "POST",
+      allow404: true,
+      suppressToasts: true,
+    }
+  );
+  return res?.data ?? null;
 }

--- a/rentchain-frontend/src/pages/ApplicantApplyPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicantApplyPage.test.tsx
@@ -1,0 +1,111 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import ApplicantApplyPage from "./ApplicantApplyPage";
+
+const applicationsApi = vi.hoisted(() => ({
+  createApplication: vi.fn(),
+  submitApplication: vi.fn(),
+  sendApplicationPhoneCode: vi.fn(),
+  confirmApplicationPhoneCode: vi.fn(),
+}));
+
+vi.mock("@/api/applicationsApi", () => applicationsApi);
+
+function renderPage(state?: any) {
+  return render(
+    <MemoryRouter initialEntries={[{ pathname: "/apply", state }]}>
+      <Routes>
+        <Route path="/apply" element={<ApplicantApplyPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe("ApplicantApplyPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows the RentChain profile banner and visible prefilled fields", async () => {
+    renderPage({
+      applyWithRentChain: {
+        source: "share_token",
+        tokenValidated: true,
+        scopesApproved: ["identity_summary", "application_summary"],
+        identityReference: {
+          referenceStatus: "available",
+          portabilityStatus: "ready",
+        },
+        applicationContext: {
+          prefilled: true,
+          requiredRemaining: ["credit_consent"],
+          prefill: {
+            applicant: {
+              firstName: "Jordan",
+              lastName: "Lee",
+              email: "jordan@example.com",
+              phone: "5551112222",
+            },
+            currentAddress: {
+              line1: "123 King St",
+              city: "Halifax",
+              province: "NS",
+              postalCode: "B3H1A1",
+            },
+            employment: {
+              employerName: "Harbour Labs",
+              jobTitle: "Designer",
+              incomeAmountCents: 720000,
+              incomeFrequency: "monthly",
+              monthsAtJob: 12,
+            },
+          },
+        },
+      },
+    });
+
+    expect(screen.getByText(/Using your RentChain profile/i)).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Jordan")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Lee")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("jordan@example.com")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("5551112222")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("123")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("King St")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Halifax")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Harbour Labs")).toBeInTheDocument();
+    expect(screen.getByText(/Still needed: credit consent/i)).toBeInTheDocument();
+  });
+
+  it("keeps prefilled fields editable", async () => {
+    renderPage({
+      applyWithRentChain: {
+        source: "share_token",
+        tokenValidated: true,
+        scopesApproved: ["identity_summary"],
+        identityReference: {
+          referenceStatus: "limited",
+          portabilityStatus: "limited",
+        },
+        applicationContext: {
+          prefilled: true,
+          requiredRemaining: ["credit_consent"],
+          prefill: {
+            applicant: {
+              firstName: "Jordan",
+              lastName: "Lee",
+              email: "jordan@example.com",
+              phone: "5551112222",
+            },
+            currentAddress: null,
+            employment: null,
+          },
+        },
+      },
+    });
+
+    const firstName = screen.getAllByDisplayValue("Jordan")[0] as HTMLInputElement;
+    fireEvent.change(firstName, { target: { value: "Alex" } });
+    expect(firstName.value).toBe("Alex");
+  });
+});

--- a/rentchain-frontend/src/pages/ApplicantApplyPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicantApplyPage.tsx
@@ -1,10 +1,12 @@
 // rentchain-frontend/src/pages/ApplicantApplyPage.tsx
 import React, { useState } from "react";
+import { useLocation } from "react-router-dom";
 import { createApplication, submitApplication } from "@/api/applicationsApi";
 import {
   sendApplicationPhoneCode,
   confirmApplicationPhoneCode,
 } from "@/api/applicationsApi";
+import type { ApplyWithRentChainResponse } from "@/api/publicTenantSharePackageApi";
 
 const fieldStyle: React.CSSProperties = {
   width: "100%",
@@ -23,21 +25,79 @@ const labelStyle: React.CSSProperties = {
   color: "#cbd5e1",
 };
 
+type ApplyWithRentChainState = {
+  applyWithRentChain?: ApplyWithRentChainResponse["applyWithRentChain"];
+};
+
+function splitAddressLine1(value: string | null | undefined) {
+  const normalized = String(value || "").trim();
+  if (!normalized) return { streetNumber: "", streetName: "" };
+  const match = normalized.match(/^(\d[\w-]*)\s+(.*)$/);
+  if (!match) {
+    return { streetNumber: "", streetName: normalized };
+  }
+  return { streetNumber: match[1] || "", streetName: match[2] || "" };
+}
+
+function formatMissingFieldLabel(key: string) {
+  const mapping: Record<string, string> = {
+    first_name: "first name",
+    last_name: "last name",
+    email: "email",
+    phone: "phone",
+    current_address_line1: "street address",
+    current_address_city: "city",
+    current_address_province: "province",
+    current_address_postal_code: "postal code",
+    employment_employer_name: "employer name",
+    employment_job_title: "job title",
+    employment_income_amount: "monthly income",
+    employment_income_frequency: "income frequency",
+    employment_months_at_job: "months at job",
+    credit_consent: "credit consent",
+  };
+  return mapping[key] || key.replace(/_/g, " ");
+}
+
 const ApplicantApplyPage: React.FC = () => {
-  const [firstName, setFirstName] = useState("");
+  const location = useLocation();
+  const applyWithRentChain = (location.state as ApplyWithRentChainState | null)?.applyWithRentChain || null;
+  const prefill = applyWithRentChain?.applicationContext?.prefill;
+  const splitAddress = splitAddressLine1(prefill?.currentAddress?.line1);
+  const prefilledMonthlyIncome =
+    prefill?.employment?.incomeAmountCents != null
+      ? String(
+          Math.round(
+            ((prefill.employment.incomeFrequency === "annual"
+              ? prefill.employment.incomeAmountCents / 12
+              : prefill.employment.incomeAmountCents) /
+              100) *
+              100
+          ) / 100
+        )
+      : "";
+
+  const [firstName, setFirstName] = useState(prefill?.applicant?.firstName || "");
   const [middleName, setMiddleName] = useState("");
-  const [lastName, setLastName] = useState("");
-  const [email, setEmail] = useState("");
-  const [phone, setPhone] = useState("");
+  const [lastName, setLastName] = useState(prefill?.applicant?.lastName || "");
+  const [email, setEmail] = useState(prefill?.applicant?.email || "");
+  const [phone, setPhone] = useState(prefill?.applicant?.phone || "");
   const [dateOfBirth, setDateOfBirth] = useState("");
-  const [streetNumber, setStreetNumber] = useState("");
-  const [streetName, setStreetName] = useState("");
-  const [city, setCity] = useState("");
-  const [province, setProvince] = useState("");
-  const [postalCode, setPostalCode] = useState("");
+  const [streetNumber, setStreetNumber] = useState(splitAddress.streetNumber);
+  const [streetName, setStreetName] = useState(splitAddress.streetName);
+  const [city, setCity] = useState(prefill?.currentAddress?.city || "");
+  const [province, setProvince] = useState(prefill?.currentAddress?.province || "");
+  const [postalCode, setPostalCode] = useState(prefill?.currentAddress?.postalCode || "");
   const [unitApplied, setUnitApplied] = useState("");
   const [leaseStartDate, setLeaseStartDate] = useState("");
   const [propertyName, setPropertyName] = useState("");
+  const [employerName, setEmployerName] = useState(prefill?.employment?.employerName || "");
+  const [jobTitle, setJobTitle] = useState(prefill?.employment?.jobTitle || "");
+  const [monthlyIncome, setMonthlyIncome] = useState(prefilledMonthlyIncome);
+  const [incomeFrequency, setIncomeFrequency] = useState(prefill?.employment?.incomeFrequency || "");
+  const [monthsAtJob, setMonthsAtJob] = useState(
+    prefill?.employment?.monthsAtJob != null ? String(prefill.employment.monthsAtJob) : ""
+  );
   const [consentCreditCheck, setConsentCreditCheck] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -62,6 +122,11 @@ const ApplicantApplyPage: React.FC = () => {
     { key: "postal code", value: postalCode },
     { key: "unit applied", value: unitApplied },
     { key: "lease start date", value: leaseStartDate },
+    { key: "employer name", value: employerName },
+    { key: "job title", value: jobTitle },
+    { key: "monthly income", value: monthlyIncome },
+    { key: "income frequency", value: incomeFrequency },
+    { key: "months at job", value: monthsAtJob },
     { key: "credit consent", value: consentCreditCheck ? "yes" : "" },
   ]
     .filter((item) => !String(item.value ?? "").trim())
@@ -120,7 +185,21 @@ const ApplicantApplyPage: React.FC = () => {
               postalCode: postalCode.trim(),
             },
           },
+          employment: {
+            employer: employerName.trim() || undefined,
+            position: jobTitle.trim() || undefined,
+            monthlyIncome: monthlyIncome.trim() ? Number(monthlyIncome.trim()) : undefined,
+          },
           creditConsent: consentCreditCheck,
+          applicationSource: applyWithRentChain ? "apply_with_rentchain" : undefined,
+          identityReference: applyWithRentChain
+            ? {
+                source: "rentchain",
+                referenceType: "tenant_identity_reference",
+                referenceStatus: applyWithRentChain.identityReference.referenceStatus,
+              }
+            : undefined,
+          approvedScopeKeys: applyWithRentChain?.scopesApproved,
         } as const;
 
         const created = await createApplication(payload);
@@ -223,6 +302,31 @@ const ApplicantApplyPage: React.FC = () => {
             application record.
           </p>
         </div>
+
+        {applyWithRentChain ? (
+          <div
+            style={{
+              marginBottom: "1rem",
+              padding: "0.9rem 0.95rem",
+              borderRadius: "0.9rem",
+              border: "1px solid rgba(59,130,246,0.55)",
+              backgroundColor: "rgba(30,41,59,0.9)",
+              display: "grid",
+              gap: "0.4rem",
+            }}
+          >
+            <div style={{ fontWeight: 700 }}>Using your RentChain profile</div>
+            <div style={{ fontSize: "0.92rem", color: "rgba(226,232,240,0.85)" }}>
+              Review and edit every prefilled field below before you submit your application.
+            </div>
+            {applyWithRentChain.applicationContext.requiredRemaining.length ? (
+              <div style={{ fontSize: "0.84rem", color: "rgba(191,219,254,0.9)" }}>
+                Still needed:{" "}
+                {applyWithRentChain.applicationContext.requiredRemaining.map(formatMissingFieldLabel).join(", ")}
+              </div>
+            ) : null}
+          </div>
+        ) : null}
 
         {error && (
           <div
@@ -354,7 +458,7 @@ const ApplicantApplyPage: React.FC = () => {
             <div
               style={{
                 display: "grid",
-                gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+                gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
                 gap: "0.75rem",
               }}
             >
@@ -460,6 +564,78 @@ const ApplicantApplyPage: React.FC = () => {
                 style={fieldStyle}
                 required
               />
+            </div>
+
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+                gap: "0.75rem",
+              }}
+            >
+              <div>
+                <div style={labelStyle}>Employer name *</div>
+                <input
+                  type="text"
+                  value={employerName}
+                  onChange={(e) => setEmployerName(e.target.value)}
+                  style={fieldStyle}
+                />
+              </div>
+              <div>
+                <div style={labelStyle}>Job title *</div>
+                <input
+                  type="text"
+                  value={jobTitle}
+                  onChange={(e) => setJobTitle(e.target.value)}
+                  style={fieldStyle}
+                />
+              </div>
+            </div>
+
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+                gap: "0.75rem",
+              }}
+            >
+              <div>
+                <div style={labelStyle}>Monthly income *</div>
+                <input
+                  type="number"
+                  inputMode="decimal"
+                  min="0"
+                  step="0.01"
+                  value={monthlyIncome}
+                  onChange={(e) => setMonthlyIncome(e.target.value)}
+                  style={fieldStyle}
+                />
+              </div>
+              <div>
+                <div style={labelStyle}>Income frequency *</div>
+                <select
+                  value={incomeFrequency}
+                  onChange={(e) => setIncomeFrequency(e.target.value)}
+                  style={fieldStyle}
+                >
+                  <option value="">Select</option>
+                  <option value="monthly">Monthly</option>
+                  <option value="annual">Annual</option>
+                </select>
+              </div>
+              <div>
+                <div style={labelStyle}>Months at job *</div>
+                <input
+                  type="number"
+                  inputMode="numeric"
+                  min="0"
+                  step="1"
+                  value={monthsAtJob}
+                  onChange={(e) => setMonthsAtJob(e.target.value.replace(/[^0-9]/g, ""))}
+                  style={fieldStyle}
+                />
+              </div>
             </div>
 
             <div

--- a/rentchain-frontend/src/pages/public/TenantSharePackagePage.test.tsx
+++ b/rentchain-frontend/src/pages/public/TenantSharePackagePage.test.tsx
@@ -1,9 +1,10 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import TenantSharePackagePage from "./TenantSharePackagePage";
 
 const publicTenantSharePackageApi = vi.hoisted(() => ({
+  createApplyWithRentChainContext: vi.fn(),
   fetchPublicTenantSharePackage: vi.fn(),
   requestPublicTenantSharePackageVerification: vi.fn(),
 }));
@@ -16,10 +17,16 @@ afterEach(() => {
 });
 
 function renderPage() {
+  function ApplyCapture() {
+    const location = useLocation();
+    return <div data-testid="apply-state">{JSON.stringify(location.state || {})}</div>;
+  }
+
   return render(
     <MemoryRouter initialEntries={["/share/token-123"]}>
       <Routes>
         <Route path="/share/:token" element={<TenantSharePackagePage />} />
+        <Route path="/apply" element={<ApplyCapture />} />
       </Routes>
     </MemoryRouter>
   );
@@ -28,6 +35,7 @@ function renderPage() {
 describe("TenantSharePackagePage", () => {
   beforeEach(() => {
     publicTenantSharePackageApi.fetchPublicTenantSharePackage.mockReset();
+    publicTenantSharePackageApi.createApplyWithRentChainContext.mockReset();
   });
 
   it("renders the shared tenant identity summary safely", async () => {
@@ -59,6 +67,7 @@ describe("TenantSharePackagePage", () => {
     expect(screen.getByText(/^Verification$/i)).toBeInTheDocument();
     expect(screen.getByText(/Identity exchange available/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Request verification/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Apply with RentChain/i })).toBeInTheDocument();
     expect(screen.queryByText(/TransUnion/i)).not.toBeInTheDocument();
   });
 
@@ -110,5 +119,59 @@ describe("TenantSharePackagePage", () => {
       ]);
     });
     expect(screen.getAllByText(/^Unavailable$/i).length).toBeGreaterThan(0);
+  });
+
+  it("routes into the applicant apply flow with visible prefill state", async () => {
+    publicTenantSharePackageApi.fetchPublicTenantSharePackage.mockResolvedValue({
+      identity: {
+        identityStatus: "ready",
+        verification: { level: "partial" },
+        readinessLabel: "Ready to apply",
+        readinessDescription: "Your core profile and supporting records are ready for most rental workflows.",
+      },
+      application: { reusable: true },
+      identityExchangeReference: {
+        referenceType: "tenant_identity_reference",
+        referenceStatus: "available",
+        referenceLabel: "Identity exchange available",
+        referenceDescription: "This rental identity can support summary-only exchange requests within the tenant-controlled sharing flow.",
+        portabilityStatus: "ready",
+      },
+      availability: {
+        canRequestMore: true,
+        availableSections: ["identity", "application"],
+      },
+      generatedAt: "2026-04-26T00:00:00.000Z",
+    });
+    publicTenantSharePackageApi.createApplyWithRentChainContext.mockResolvedValue({
+      applyWithRentChain: {
+        source: "share_token",
+        tokenValidated: true,
+        scopesApproved: ["identity_summary", "application_summary"],
+        identityReference: {
+          referenceStatus: "available",
+          portabilityStatus: "ready",
+        },
+        applicationContext: {
+          prefilled: true,
+          requiredRemaining: ["credit_consent"],
+          prefill: {
+            applicant: { firstName: "Jordan", lastName: "Lee", email: "jordan@example.com", phone: "5551112222" },
+            currentAddress: { line1: "123 King St", city: "Halifax", province: "NS", postalCode: "B3H1A1" },
+            employment: null,
+          },
+        },
+      },
+    });
+
+    renderPage();
+
+    fireEvent.click(await screen.findByRole("button", { name: /Apply with RentChain/i }));
+
+    await waitFor(() => {
+      expect(publicTenantSharePackageApi.createApplyWithRentChainContext).toHaveBeenCalledWith("token-123");
+    });
+    expect(await screen.findByTestId("apply-state")).toHaveTextContent("Jordan");
+    expect(screen.getByTestId("apply-state")).toHaveTextContent("identity_summary");
   });
 });

--- a/rentchain-frontend/src/pages/public/TenantSharePackagePage.tsx
+++ b/rentchain-frontend/src/pages/public/TenantSharePackagePage.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import {
+  createApplyWithRentChainContext,
   fetchPublicTenantSharePackage,
   requestPublicTenantSharePackageVerification,
 } from "../../api/publicTenantSharePackageApi";
@@ -13,11 +14,14 @@ function prettyStatus(value: string | null | undefined) {
 
 export default function TenantSharePackagePage() {
   const { token = "" } = useParams();
+  const navigate = useNavigate();
   const [data, setData] = React.useState<Awaited<ReturnType<typeof fetchPublicTenantSharePackage>> | null>(null);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
   const [requesting, setRequesting] = React.useState(false);
   const [requestError, setRequestError] = React.useState<string | null>(null);
+  const [applyLoading, setApplyLoading] = React.useState(false);
+  const [applyError, setApplyError] = React.useState<string | null>(null);
   const [requestedItems, setRequestedItems] = React.useState<
     Array<
       "credibility_summary" | "application_summary" | "documents_summary" | "lease_summary" | "payment_readiness_summary"
@@ -78,7 +82,34 @@ export default function TenantSharePackagePage() {
     }
   }, [requestedItems, token]);
 
+  const handleApplyWithRentChain = React.useCallback(async () => {
+    try {
+      setApplyLoading(true);
+      setApplyError(null);
+      const result = await createApplyWithRentChainContext(token);
+      if (!result?.applyWithRentChain) {
+        setApplyError("This shared rental profile is unavailable.");
+        return;
+      }
+      navigate("/apply", {
+        state: {
+          applyWithRentChain: result.applyWithRentChain,
+        },
+      });
+    } catch (err: any) {
+      setApplyError(err?.message || "Unable to prepare this application right now.");
+    } finally {
+      setApplyLoading(false);
+    }
+  }, [navigate, token]);
+
   const availableSections = new Set(data?.availability?.availableSections || []);
+  const canApplyWithRentChain = Boolean(
+    data?.identityExchangeReference &&
+      (data.identityExchangeReference.referenceStatus === "available" ||
+        data.identityExchangeReference.referenceStatus === "limited") &&
+      (availableSections.has("identity") || availableSections.has("application"))
+  );
 
   return (
     <div style={{ minHeight: "100vh", background: "linear-gradient(180deg, #f8fafc 0%, #eef2ff 100%)", padding: 24 }}>
@@ -127,6 +158,21 @@ export default function TenantSharePackagePage() {
                 <div style={{ fontSize: "1.05rem", fontWeight: 800, color: "#0f172a" }}>Identity exchange</div>
                 <div style={{ color: "#0f172a", fontWeight: 700 }}>{data.identityExchangeReference.referenceLabel}</div>
                 <div style={{ color: "#475569", lineHeight: 1.6 }}>{data.identityExchangeReference.referenceDescription}</div>
+                {canApplyWithRentChain ? (
+                  <div style={{ display: "grid", gap: 8, justifyItems: "start" }}>
+                    <button
+                      type="button"
+                      onClick={() => void handleApplyWithRentChain()}
+                      disabled={applyLoading}
+                    >
+                      {applyLoading ? "Preparing application..." : "Apply with RentChain"}
+                    </button>
+                    <div style={{ color: "#475569", fontSize: "0.92rem" }}>
+                      Use the tenant-approved profile details already shared here to start an application faster.
+                    </div>
+                    {applyError ? <div style={{ color: "#b91c1c" }}>{applyError}</div> : null}
+                  </div>
+                ) : null}
               </div>
             ) : null}
 


### PR DESCRIPTION
This PR introduces Identity Portability v2.

Includes:
- Apply with RentChain flow from public share packages
- POST /api/public/share/:token/apply
- permission-scoped application prefill
- visible/editable applicant prefill on /apply
- safe identityReference metadata on application submission
- focused backend/frontend test coverage

Guardrails preserved:
- no auto-submit
- no silent permission expansion
- no public directory or global identity handle
- no share token/hash/request/share ID persistence in application storage
- no raw documents, screening details, signatures, payment data, provider data, hidden IDs, or audit timeline data copied into applications
- no landlord inbox changes
- no payment rails / Stripe changes

PR note:
- Backend focused tests passed: 8 tests.
- Backend typecheck passed.
- Frontend focused tests passed: 6 tests.
- Frontend build passed.
- Existing frontend chunk-size warning remains unchanged and out of scope.
- Landlord inbox changes, review-summary semantic changes, public application-link bridging, and any document/screening/signature/payment/provider/timeline ingestion were intentionally deferred.