### PR TITLE
feat: add landlord network effects

### DIFF
--- a/rentchain-api/src/routes/__tests__/rentalApplicationsReviewSummaryRisk.test.ts
+++ b/rentchain-api/src/routes/__tests__/rentalApplicationsReviewSummaryRisk.test.ts
@@ -257,6 +257,13 @@ describe("rentalApplications review summary risk surface", () => {
       id: "app-1",
       landlordId: "landlord-1",
       status: "SUBMITTED",
+      applicationSource: "apply_with_rentchain",
+      identityReference: {
+        source: "rentchain",
+        referenceType: "tenant_identity_reference",
+        referenceStatus: "available",
+      },
+      approvedScopeKeys: ["identity_summary", "application_summary"],
     });
   });
 
@@ -330,6 +337,12 @@ describe("rentalApplications review summary risk surface", () => {
         reusableAcrossApplications: expect.any(Boolean),
       })
     );
+    expect(res.body?.networkReuseSummary).toEqual({
+      reusable: true,
+      source: "apply_with_rentchain",
+      reuseStatus: "available",
+      consentRequired: true,
+    });
     expect(res.body?.tenantIdentitySummary?.documents).toBeUndefined();
     expect(res.body?.tenantIdentitySummary?.screening).toBeUndefined();
     expect(res.body?.tenantCredibilitySummary?.signals).toBeUndefined();
@@ -341,6 +354,9 @@ describe("rentalApplications review summary risk surface", () => {
     expect(JSON.stringify(res.body?.trustContext || {})).not.toContain("ref-1");
     expect(JSON.stringify(res.body?.portableIdentitySummary || {})).not.toContain("token");
     expect(JSON.stringify(res.body?.portableIdentitySummary || {})).not.toContain("approval");
+    expect(JSON.stringify(res.body?.networkReuseSummary || {})).not.toContain("identity_summary");
+    expect(JSON.stringify(res.body?.networkReuseSummary || {})).not.toContain("provider");
+    expect(JSON.stringify(res.body?.networkReuseSummary || {})).not.toContain("token");
   });
 
   it("returns a safe null risk state when no snapshot exists", async () => {

--- a/rentchain-api/src/routes/rentalApplicationsRoutes.ts
+++ b/rentchain-api/src/routes/rentalApplicationsRoutes.ts
@@ -41,6 +41,7 @@ import { enqueueScreeningJob } from "../services/screeningJobs";
 import { createSignedUrl, putPdfObject } from "../storage/pdfStore";
 import { buildReviewSummary, buildReviewSummaryPdf } from "../lib/reviewSummary";
 import { buildApplicationDecisionSummary } from "../services/risk/applicationDecisionSummary";
+import { deriveNetworkReuseSummary } from "../services/networkReuse/deriveNetworkReuseSummary";
 import { getLatestApplicationRisk } from "../services/riskAgent/riskAgentService";
 import { recordRiskDecisionAudit } from "../services/riskAgent/riskDecisionAuditService";
 import { rateLimitScreeningIp, rateLimitScreeningUser } from "../middleware/rateLimit";
@@ -4207,6 +4208,13 @@ router.get("/rental-applications/:id/review-summary", async (req: any, res) => {
       application: access.data,
       reviewSummary: summary,
     });
+    const networkReuseSummary = deriveNetworkReuseSummary({
+      applicationSource:
+        access.data?.applicationSource === "apply_with_rentchain" ? "apply_with_rentchain" : null,
+      identityReference: access.data?.identityReference || null,
+      approvedScopeKeys: Array.isArray(access.data?.approvedScopeKeys) ? access.data.approvedScopeKeys : null,
+      portableIdentitySummary,
+    });
     return res.json({
       ok: true,
       summary,
@@ -4216,6 +4224,7 @@ router.get("/rental-applications/:id/review-summary", async (req: any, res) => {
       trustContext,
       tenantCredibilitySummary,
       portableIdentitySummary,
+      networkReuseSummary,
     });
   } catch (err: any) {
     console.error("[review_summary] failed", err?.message || err);

--- a/rentchain-api/src/services/landlordInbox/__tests__/deriveLandlordInbox.test.ts
+++ b/rentchain-api/src/services/landlordInbox/__tests__/deriveLandlordInbox.test.ts
@@ -55,6 +55,13 @@ describe("deriveLandlordInbox", () => {
                   landlordId: "landlord-1",
                   propertyId: "prop-1",
                   status: "submitted",
+                  applicationSource: "apply_with_rentchain",
+                  identityReference: {
+                    source: "rentchain",
+                    referenceType: "tenant_identity_reference",
+                    referenceStatus: "available",
+                  },
+                  approvedScopeKeys: ["identity_summary"],
                 }),
               ]
             : [
@@ -133,6 +140,12 @@ describe("deriveLandlordInbox", () => {
         },
         credibilitySummary: {
           completenessLevel: "medium",
+        },
+        networkReuseSummary: {
+          reusable: true,
+          source: "apply_with_rentchain",
+          reuseStatus: "available",
+          consentRequired: true,
         },
         source: "review_summary",
       }),
@@ -218,6 +231,7 @@ describe("deriveLandlordInbox", () => {
         type: "lease",
         nextAction: "prepare_lease",
         nextActionHref: "/leases/lease-1/ledger",
+        networkReuseSummary: null,
         source: "lease_execution",
       }),
     ]);

--- a/rentchain-api/src/services/landlordInbox/deriveLandlordInbox.ts
+++ b/rentchain-api/src/services/landlordInbox/deriveLandlordInbox.ts
@@ -3,6 +3,7 @@ import type { LandlordAgentDecision } from "../../lib/analytics/analyticsTypes";
 import { buildReviewSummary } from "../../lib/reviewSummary";
 import { deriveLandlordTrustContext } from "../../lib/trust/deriveLandlordTrustContext";
 import { deriveLeaseExecution } from "../leaseExecution/deriveLeaseExecution";
+import { deriveNetworkReuseSummary, type NetworkReuseSummary } from "../networkReuse/deriveNetworkReuseSummary";
 import {
   deriveTenantCredibilitySignals,
   type LandlordSafeTenantCredibilitySummary,
@@ -44,6 +45,7 @@ export type LandlordInboxItem = {
   credibilitySummary: {
     completenessLevel: "low" | "medium" | "high";
   } | null;
+  networkReuseSummary: NetworkReuseSummary | null;
   source: "review_summary" | "analytics_overlay" | "lease_execution";
 };
 
@@ -272,6 +274,7 @@ function buildFallbackItemFromDecision(decision: LandlordAgentDecision): Landlor
         }
       : null,
     credibilitySummary: null,
+    networkReuseSummary: null,
     source: "analytics_overlay",
   };
 }
@@ -388,6 +391,14 @@ export async function deriveLandlordInbox(
       credibilitySummary: {
         completenessLevel: tenantCredibilitySummary.completenessLevel,
       },
+      networkReuseSummary: deriveNetworkReuseSummary({
+        applicationSource:
+          application.applicationSource === "apply_with_rentchain" ? "apply_with_rentchain" : null,
+        identityReference: (application.identityReference as any) || null,
+        approvedScopeKeys: Array.isArray((application as any).approvedScopeKeys)
+          ? ((application as any).approvedScopeKeys as any[])
+          : null,
+      }),
       source: "review_summary",
     };
 
@@ -448,6 +459,7 @@ export async function deriveLandlordInbox(
       nextActionHref: `/leases/${encodeURIComponent(leaseId)}/ledger`,
       trustSummary: null,
       credibilitySummary: null,
+      networkReuseSummary: null,
       source: "lease_execution",
     });
   }

--- a/rentchain-api/src/services/networkReuse/__tests__/deriveNetworkReuseSummary.test.ts
+++ b/rentchain-api/src/services/networkReuse/__tests__/deriveNetworkReuseSummary.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { deriveNetworkReuseSummary } from "../deriveNetworkReuseSummary";
+
+describe("deriveNetworkReuseSummary", () => {
+  it("derives available reuse for apply-with-rentchain metadata with sufficient scopes", () => {
+    expect(
+      deriveNetworkReuseSummary({
+        applicationSource: "apply_with_rentchain",
+        identityReference: {
+          source: "rentchain",
+          referenceType: "tenant_identity_reference",
+          referenceStatus: "available",
+        },
+        approvedScopeKeys: ["identity_summary", "credibility_summary"],
+      })
+    ).toEqual({
+      reusable: true,
+      source: "apply_with_rentchain",
+      reuseStatus: "available",
+      consentRequired: true,
+    });
+  });
+
+  it("derives limited reuse for narrow or limited metadata", () => {
+    expect(
+      deriveNetworkReuseSummary({
+        identityReference: {
+          source: "rentchain",
+          referenceType: "tenant_identity_reference",
+          referenceStatus: "limited",
+        },
+        approvedScopeKeys: ["documents_summary"],
+      })
+    ).toEqual({
+      reusable: true,
+      source: "share_package",
+      reuseStatus: "limited",
+      consentRequired: true,
+    });
+  });
+
+  it("returns null when no reuse metadata exists", () => {
+    expect(deriveNetworkReuseSummary({})).toBeNull();
+  });
+});

--- a/rentchain-api/src/services/networkReuse/deriveNetworkReuseSummary.ts
+++ b/rentchain-api/src/services/networkReuse/deriveNetworkReuseSummary.ts
@@ -1,0 +1,73 @@
+export type NetworkReuseSummary = {
+  reusable: boolean;
+  source: "share_package" | "apply_with_rentchain";
+  reuseStatus: "available" | "limited" | "not_available";
+  consentRequired: true;
+};
+
+type Input = {
+  applicationSource?: "apply_with_rentchain" | null;
+  identityReference?: {
+    source?: "rentchain";
+    referenceType?: "tenant_identity_reference";
+    referenceStatus?: "available" | "limited" | "not_ready";
+  } | null;
+  approvedScopeKeys?: Array<
+    | "identity_summary"
+    | "credibility_summary"
+    | "application_summary"
+    | "documents_summary"
+    | "lease_summary"
+    | "payment_readiness_summary"
+  > | null;
+  portableIdentitySummary?: {
+    portabilityStatus: "not_ready" | "ready" | "limited";
+    reusableAcrossApplications: boolean;
+  } | null;
+};
+
+const REUSE_SCOPE_KEYS = new Set(["identity_summary", "application_summary"]);
+
+function hasReusableScope(
+  approvedScopeKeys: Input["approvedScopeKeys"]
+): boolean {
+  return Array.isArray(approvedScopeKeys)
+    ? approvedScopeKeys.some((scope) => REUSE_SCOPE_KEYS.has(String(scope || "")))
+    : false;
+}
+
+export function deriveNetworkReuseSummary(input: Input): NetworkReuseSummary | null {
+  const source =
+    input.applicationSource === "apply_with_rentchain" ? "apply_with_rentchain" : "share_package";
+  const referenceStatus = input.identityReference?.referenceStatus || null;
+  const scopeReady = hasReusableScope(input.approvedScopeKeys);
+  const portabilityStatus = input.portableIdentitySummary?.portabilityStatus || "not_ready";
+  const reusableAcrossApplications = input.portableIdentitySummary?.reusableAcrossApplications === true;
+  const hasSourceMetadata =
+    input.applicationSource === "apply_with_rentchain" ||
+    Boolean(input.identityReference) ||
+    (Array.isArray(input.approvedScopeKeys) && input.approvedScopeKeys.length > 0);
+
+  if (!hasSourceMetadata) {
+    return null;
+  }
+
+  let reuseStatus: NetworkReuseSummary["reuseStatus"] = "not_available";
+  if (referenceStatus === "available" && scopeReady) {
+    reuseStatus = "available";
+  } else if (
+    referenceStatus === "limited" ||
+    (referenceStatus === "available" && !scopeReady) ||
+    portabilityStatus === "limited" ||
+    reusableAcrossApplications
+  ) {
+    reuseStatus = "limited";
+  }
+
+  return {
+    reusable: reuseStatus !== "not_available",
+    source,
+    reuseStatus,
+    consentRequired: true,
+  };
+}

--- a/rentchain-frontend/src/api/landlordAnalyticsApi.ts
+++ b/rentchain-frontend/src/api/landlordAnalyticsApi.ts
@@ -1,6 +1,7 @@
 import { apiFetch } from "./apiFetch";
 import type { TimelineItem } from "./timelineApi";
 import type { LandlordTrustContext } from "./reviewSummaryApi";
+import type { ApplicationReviewSummary } from "./reviewSummaryApi";
 
 export type AnalyticsPeriod = "30d" | "90d" | "365d" | "month_to_date";
 
@@ -186,6 +187,8 @@ export type LandlordAgentDecision = {
   reminderNextActionLabel?: string | null;
   trustContext?: LandlordTrustContext | null;
 };
+
+export type NetworkReuseSummary = NonNullable<ApplicationReviewSummary["networkReuseSummary"]>;
 
 export type AnalyticsDeltaValue = {
   current: number | null;
@@ -377,6 +380,7 @@ export type LandlordInboxItem = {
   credibilitySummary: {
     completenessLevel: "low" | "medium" | "high";
   } | null;
+  networkReuseSummary: NetworkReuseSummary | null;
   source: "review_summary" | "analytics_overlay" | "lease_execution";
 };
 

--- a/rentchain-frontend/src/api/reviewSummaryApi.ts
+++ b/rentchain-frontend/src/api/reviewSummaryApi.ts
@@ -90,6 +90,12 @@ export type ApplicationReviewSummary = ReviewSummaryCore & {
     portabilityDescription: string;
     reusableAcrossApplications: boolean;
   } | null;
+  networkReuseSummary?: {
+    reusable: boolean;
+    source: "share_package" | "apply_with_rentchain";
+    reuseStatus: "available" | "limited" | "not_available";
+    consentRequired: true;
+  } | null;
 };
 
 export class ReviewSummaryApiError extends Error {
@@ -140,6 +146,8 @@ export async function fetchReviewSummary(applicationId: string): Promise<Applica
       (res?.tenantCredibilitySummary || null) as ApplicationReviewSummary["tenantCredibilitySummary"],
     portableIdentitySummary:
       (res?.portableIdentitySummary || null) as ApplicationReviewSummary["portableIdentitySummary"],
+    networkReuseSummary:
+      (res?.networkReuseSummary || null) as ApplicationReviewSummary["networkReuseSummary"],
   };
 }
 

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
@@ -137,6 +137,12 @@ describe("ApplicationReviewSummaryPage", () => {
         portabilityDescription: "Your rental identity is organized for reuse across application contexts.",
         reusableAcrossApplications: true,
       },
+      networkReuseSummary: {
+        reusable: true,
+        source: "apply_with_rentchain",
+        reuseStatus: "available",
+        consentRequired: true,
+      },
     } as any);
 
     renderPage();
@@ -196,9 +202,12 @@ describe("ApplicationReviewSummaryPage", () => {
     expect(await screen.findByText("Trust guidance")).toBeInTheDocument();
     expect(await screen.findByText("Credibility summary")).toBeInTheDocument();
     expect(await screen.findByText("Portability summary")).toBeInTheDocument();
+    expect(await screen.findByText("Network reuse")).toBeInTheDocument();
     expect(await screen.findByText("Credibility established")).toBeInTheDocument();
     expect(await screen.findByText("Most credibility signals are available in the current record.")).toBeInTheDocument();
     expect(await screen.findByText("Ready to reuse")).toBeInTheDocument();
+    expect(await screen.findByText("Reuse available")).toBeInTheDocument();
+    expect(await screen.findByText("RentChain application")).toBeInTheDocument();
     expect(await screen.findByText("Reusable across applications")).toBeInTheDocument();
     expect((await screen.findAllByText("Ready for review")).length).toBeGreaterThan(0);
     expect(await screen.findByText("Application information is mostly complete.")).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
@@ -263,6 +263,21 @@ function trustActionLabel(
   }
 }
 
+function networkReuseStatusLabel(value: "available" | "limited" | "not_available" | null | undefined) {
+  switch (value) {
+    case "available":
+      return "Reuse available";
+    case "limited":
+      return "Reuse limited";
+    default:
+      return "Reuse not available";
+  }
+}
+
+function networkReuseSourceLabel(value: "share_package" | "apply_with_rentchain" | null | undefined) {
+  return value === "apply_with_rentchain" ? "RentChain application" : "Share package";
+}
+
 type SummaryLoadError = {
   message: string;
   status?: number;
@@ -1734,6 +1749,20 @@ function ApplicationReviewSummaryPageBody() {
                   "Reusable across applications",
                   summary.portableIdentitySummary.reusableAcrossApplications ? "Yes" : "Not yet"
                 )}
+              </div>
+            </Card>
+          ) : null}
+
+          {summary.networkReuseSummary ? (
+            <Card style={{ display: "grid", gap: 8 }}>
+              <div style={{ fontWeight: 700 }}>Network reuse</div>
+              <div style={{ fontSize: 13, color: text.subtle }}>
+                This application already carries tenant-approved RentChain reuse metadata. It is descriptive only and does not expand landlord permissions or visibility.
+              </div>
+              <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 8 }}>
+                {kv("Status", networkReuseStatusLabel(summary.networkReuseSummary.reuseStatus))}
+                {kv("Source", networkReuseSourceLabel(summary.networkReuseSummary.source))}
+                {kv("Consent required", summary.networkReuseSummary.consentRequired ? "Yes" : "No")}
               </div>
             </Card>
           ) : null}

--- a/rentchain-frontend/src/pages/landlord/LandlordInboxPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/LandlordInboxPage.test.tsx
@@ -55,11 +55,17 @@ describe("LandlordInboxPage", () => {
             readiness: "ready",
             verificationLevel: "partial",
           },
-          credibilitySummary: {
-            completenessLevel: "medium",
-          },
-          source: "review_summary",
+        credibilitySummary: {
+          completenessLevel: "medium",
         },
+        networkReuseSummary: {
+          reusable: true,
+          source: "apply_with_rentchain",
+          reuseStatus: "available",
+          consentRequired: true,
+        },
+        source: "review_summary",
+      },
       ],
       summary: {
         actionRequired: 1,
@@ -77,6 +83,7 @@ describe("LandlordInboxPage", () => {
     expect(await screen.findByRole("heading", { name: "Landlord inbox" })).toBeInTheDocument();
     expect(screen.getByText("Application ready for review")).toBeInTheDocument();
     expect(screen.getByText(/Credibility completeness: medium/i)).toBeInTheDocument();
+    expect(screen.getByText(/Reuse available · Source: RentChain application/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Review application" })).toHaveAttribute(
       "href",
       "/applications/app-1/review-summary"

--- a/rentchain-frontend/src/pages/landlord/LandlordInboxPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/LandlordInboxPage.tsx
@@ -45,6 +45,21 @@ function nextActionLabel(action: LandlordInboxItem["nextAction"]) {
   }
 }
 
+function networkReuseStatusLabel(value: NonNullable<LandlordInboxItem["networkReuseSummary"]>["reuseStatus"]) {
+  switch (value) {
+    case "available":
+      return "Reuse available";
+    case "limited":
+      return "Reuse limited";
+    default:
+      return "Reuse not available";
+  }
+}
+
+function networkReuseSourceLabel(value: NonNullable<LandlordInboxItem["networkReuseSummary"]>["source"]) {
+  return value === "apply_with_rentchain" ? "RentChain application" : "Share package";
+}
+
 function sectionLabel(status: LandlordInboxItem["status"]) {
   if (status === "action_required") return "Action required";
   if (status === "pending") return "Pending";
@@ -112,6 +127,12 @@ function InboxItemCard({ item }: { item: LandlordInboxItem }) {
         {item.credibilitySummary ? (
           <div style={{ color: "#64748b", fontSize: "0.82rem" }}>
             Credibility completeness: {item.credibilitySummary.completenessLevel}
+          </div>
+        ) : null}
+        {item.networkReuseSummary ? (
+          <div style={{ color: "#64748b", fontSize: "0.82rem" }}>
+            {networkReuseStatusLabel(item.networkReuseSummary.reuseStatus)} · Source:{" "}
+            {networkReuseSourceLabel(item.networkReuseSummary.source)}
           </div>
         ) : null}
       </div>


### PR DESCRIPTION
Introduces Landlord Network Effects v1.

Includes:
- read-derived networkReuseSummary
- review-summary Network reuse card
- landlord inbox reuse indicator on application items
- reuse detection from existing application identity reference metadata
- focused backend/frontend test coverage

Guardrails preserved:
- no new consent/request/approval workflow
- no tenant UI
- no share lookup or token resolution at landlord read time
- no scoring/ranking
- no marketplace, browsing, or search
- no raw document/screening/signature/payment/provider/token/scope exposure
- no payment rails, billing, screening, Terraform, or auth-core changes

PR note:
- Backend focused tests passed: 9 tests.
- Backend typecheck passed.
- Frontend focused tests passed: 6 tests.
- Frontend build passed.
- Existing chunk-size warning remains unchanged and out of scope.
- Local-port route test was rerun outside sandbox as noted.