### PR TITLE
feat: add institutional schema v2

### DIFF
--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -1146,6 +1146,63 @@ describe("tenantPortalRoutes foundation", () => {
     expect(payload).not.toContain("prop-1");
   });
 
+  it("builds a tenant-only institutional schema v2 export safely when requested", async () => {
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/identity/export",
+      body: {
+        schemaVersion: "2.0",
+      },
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.schema?.version).toBe("2.0");
+    expect(res.body?.data?.validation?.status).toBeTruthy();
+    expect(res.body?.data?.audit?.recentActivityAvailable).toBe(false);
+    expect(res.body?.data?.audit?.recentActivity).toBeUndefined();
+    const payload = JSON.stringify(res.body?.data || {});
+    expect(payload).not.toContain("drawnDataUrl");
+    expect(payload).not.toContain("documentUrl");
+    expect(payload).not.toContain("paymentMethod");
+    expect(payload).not.toContain("share-token");
+    expect(payload).not.toContain("tenant-1");
+    expect(payload).not.toContain("prop-1");
+  });
+
+  it("rejects unsupported institutional schema versions narrowly", async () => {
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/identity/export",
+      body: {
+        schemaVersion: "3.0",
+      },
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({
+      ok: false,
+      error: "UNSUPPORTED_SCHEMA_VERSION",
+    });
+  });
+
   it("revokes a tenant share package immediately", async () => {
     ensureCollection("tenantSharePackages").set("share-1", {
       id: "share-1",

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -21,6 +21,8 @@ import { deriveTenantCredibilitySignals } from "../services/tenantCredibility/de
 import { deriveIdentityTimeline } from "../services/identityTimeline/deriveIdentityTimeline";
 import { deriveIdentityPortability } from "../services/identityPortability/deriveIdentityPortability";
 import { deriveInstitutionalIdentityPackage } from "../services/institutional/deriveInstitutionalIdentityPackage";
+import { deriveInstitutionalSchemaV2 } from "../services/institutional/deriveInstitutionalSchemaV2";
+import { validateInstitutionalSchema } from "../services/institutional/validateInstitutionalSchema";
 import { derivePaymentReadiness } from "../services/paymentReadiness/derivePaymentReadiness";
 import {
   createRentPaymentCheckout,
@@ -3014,6 +3016,10 @@ router.get("/me", requireTenantWorkspaceIdentity, handleTenantWorkspaceSummary);
 router.post("/identity/export", requireTenantWorkspaceIdentity, async (req: any, res: any) => {
   const context = await resolveWorkspaceContextOrRespond(req, res);
   if (!context) return;
+  const schemaVersion = String(req.body?.schemaVersion || "1.0").trim() || "1.0";
+  if (!["1.0", "2.0"].includes(schemaVersion)) {
+    return res.status(400).json({ ok: false, error: "UNSUPPORTED_SCHEMA_VERSION" });
+  }
 
   const [workspace, tenantIdentityRecord, identityTimeline] = await Promise.all([
     loadTenantWorkspaceData(context),
@@ -3052,6 +3058,18 @@ router.post("/identity/export", requireTenantWorkspaceIdentity, async (req: any,
     portableIdentity,
     leaseStatus: workspace.lease?.status || null,
   });
+
+  if (schemaVersion === "2.0") {
+    const schemaV2 = deriveInstitutionalSchemaV2({
+      packageV1: institutionalIdentityPackage,
+      latestPaymentStatus: workspace.lease?.rentPaymentSummary?.latestPayment?.status || null,
+    });
+    schemaV2.validation = validateInstitutionalSchema(schemaV2);
+    return res.json({
+      ok: true,
+      data: schemaV2,
+    });
+  }
 
   return res.json({
     ok: true,

--- a/rentchain-api/src/services/institutional/__tests__/deriveInstitutionalSchemaV2.test.ts
+++ b/rentchain-api/src/services/institutional/__tests__/deriveInstitutionalSchemaV2.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { deriveInstitutionalSchemaV2 } from "../deriveInstitutionalSchemaV2";
+
+describe("deriveInstitutionalSchemaV2", () => {
+  it("builds a versioned institutional schema envelope from safe v1 inputs", () => {
+    const result = deriveInstitutionalSchemaV2({
+      packageV1: {
+        identitySummary: {
+          identityStatus: "verified",
+          verificationLevel: "strong",
+          completenessLevel: "high",
+          readinessLabel: "Ready to apply",
+        },
+        credibilitySummary: {
+          completenessLevel: "high",
+          verificationLevel: "strong",
+          summaryLabel: "Credibility established",
+          summaryDescription: "Most credibility signals are available.",
+        },
+        leaseSummary: {
+          activeLease: true,
+          leaseExecutionStatus: "fully_executed",
+        },
+        paymentReadinessSummary: {
+          readinessStatus: "ready_to_configure",
+          readinessLabel: "Rent terms ready",
+          readinessDescription: "safe",
+        },
+        auditSummary: {
+          totalEvents: 2,
+          recentActivity: [
+            {
+              type: "lease.activated",
+              label: "Lease activated",
+              occurredAt: "2026-01-01T00:00:00.000Z",
+            },
+          ],
+        },
+        portabilitySummary: {
+          portabilityStatus: "ready",
+          portabilityLabel: "Ready to reuse",
+          reusableAcrossApplications: true,
+        },
+        metadata: {
+          generatedAt: "2026-04-27T00:00:00.000Z",
+          dataScope: "tenant_controlled_institutional_readiness",
+          consentRequired: true,
+        },
+      },
+      latestPaymentStatus: "payment_pending",
+    });
+
+    expect(result.schema.version).toBe("2.0");
+    expect(result.rentalHistory.leaseExecutionStatus).toBe("executed");
+    expect(result.paymentReadiness.latestPaymentStatus).toBe("pending");
+    expect(result.audit.recentActivityAvailable).toBe(true);
+    expect((result.audit as any).recentActivity).toBeUndefined();
+    expect(JSON.stringify(result)).not.toContain("paymentMethod");
+    expect(JSON.stringify(result)).not.toContain("documentUrl");
+  });
+});

--- a/rentchain-api/src/services/institutional/__tests__/validateInstitutionalSchema.test.ts
+++ b/rentchain-api/src/services/institutional/__tests__/validateInstitutionalSchema.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { validateInstitutionalSchema } from "../validateInstitutionalSchema";
+import type { InstitutionalExportV2 } from "../deriveInstitutionalSchemaV2";
+
+function buildValidExport(): InstitutionalExportV2 {
+  return {
+    schema: {
+      name: "rentchain.institutional_identity_package",
+      version: "2.0",
+      generatedAt: "2026-04-27T00:00:00.000Z",
+      jurisdiction: "CA",
+      dataScope: "tenant_controlled_export",
+      consentRequired: true,
+    },
+    subject: {
+      subjectType: "tenant",
+      identityStatus: "ready",
+      verificationLevel: "partial",
+      completenessLevel: "high",
+    },
+    identity: {
+      portabilityStatus: "limited",
+      identityReadiness: "ready",
+      credibilityReadiness: "high",
+    },
+    rentalHistory: {
+      activeLeaseAvailable: true,
+      leaseExecutionStatus: "executed",
+      leaseSummaryAvailable: true,
+    },
+    paymentReadiness: {
+      rentTermsReady: true,
+      paymentRailAvailable: true,
+      latestPaymentStatus: "paid",
+    },
+    audit: {
+      auditTrailAvailable: true,
+      totalIdentityEvents: 3,
+      recentActivityAvailable: true,
+    },
+    validation: {
+      status: "valid",
+      warnings: [],
+      missingRecommendedFields: [],
+    },
+    extensions: {
+      reserved: {},
+    },
+  };
+}
+
+describe("validateInstitutionalSchema", () => {
+  it("returns valid when required and recommended fields are present", () => {
+    expect(validateInstitutionalSchema(buildValidExport())).toEqual({
+      status: "valid",
+      warnings: [],
+      missingRecommendedFields: [],
+    });
+  });
+
+  it("returns valid_with_warnings when recommended fields are missing", () => {
+    const payload = buildValidExport();
+    (payload.identity as any).portabilityStatus = "";
+    const result = validateInstitutionalSchema(payload);
+    expect(result.status).toBe("valid_with_warnings");
+    expect(result.missingRecommendedFields).toContain("identity.portabilityStatus");
+  });
+
+  it("returns invalid when required fields are malformed", () => {
+    const payload = buildValidExport();
+    (payload.schema as any).name = "";
+    const result = validateInstitutionalSchema(payload);
+    expect(result.status).toBe("invalid");
+    expect(result.warnings[0]).toContain("schema.name");
+  });
+});

--- a/rentchain-api/src/services/institutional/deriveInstitutionalSchemaV2.ts
+++ b/rentchain-api/src/services/institutional/deriveInstitutionalSchemaV2.ts
@@ -1,0 +1,153 @@
+import type { InstitutionalIdentityPackage } from "./deriveInstitutionalIdentityPackage";
+
+export type InstitutionalExportV2 = {
+  schema: {
+    name: "rentchain.institutional_identity_package";
+    version: "2.0";
+    generatedAt: string;
+    jurisdiction: "CA";
+    dataScope: "tenant_controlled_export";
+    consentRequired: true;
+  };
+  subject: {
+    subjectType: "tenant";
+    identityStatus: "incomplete" | "limited" | "ready" | "verified";
+    verificationLevel: "none" | "partial" | "strong";
+    completenessLevel: "low" | "medium" | "high";
+  };
+  identity: {
+    portabilityStatus: "not_ready" | "limited" | "ready";
+    identityReadiness: "incomplete" | "limited" | "ready" | "verified";
+    credibilityReadiness: "low" | "medium" | "high";
+  };
+  rentalHistory: {
+    activeLeaseAvailable: boolean;
+    leaseExecutionStatus: "not_available" | "draft" | "pending_signature" | "executed" | "blocked";
+    leaseSummaryAvailable: boolean;
+  };
+  paymentReadiness: {
+    rentTermsReady: boolean;
+    paymentRailAvailable: boolean;
+    latestPaymentStatus?: "not_available" | "checkout_created" | "pending" | "paid" | "failed" | "canceled" | "expired";
+  };
+  audit: {
+    auditTrailAvailable: boolean;
+    totalIdentityEvents: number;
+    recentActivityAvailable: boolean;
+  };
+  validation: {
+    status: "valid" | "valid_with_warnings" | "invalid";
+    warnings: string[];
+    missingRecommendedFields: string[];
+  };
+  extensions: {
+    reserved: Record<string, never>;
+  };
+};
+
+type DeriveInstitutionalSchemaV2Input = {
+  packageV1: InstitutionalIdentityPackage;
+  latestPaymentStatus?:
+    | "setup_required"
+    | "checkout_created"
+    | "payment_pending"
+    | "paid"
+    | "failed"
+    | "canceled"
+    | "expired"
+    | null;
+};
+
+function normalizeLeaseExecutionStatus(
+  value: InstitutionalIdentityPackage["leaseSummary"]["leaseExecutionStatus"]
+): InstitutionalExportV2["rentalHistory"]["leaseExecutionStatus"] {
+  switch (value) {
+    case "ready_for_tenant_signature":
+    case "tenant_signed":
+    case "ready_for_landlord_signature":
+    case "landlord_signed":
+      return "pending_signature";
+    case "fully_executed":
+      return "executed";
+    case "draft":
+      return "draft";
+    case "blocked":
+      return "blocked";
+    case "not_available":
+    default:
+      return "not_available";
+  }
+}
+
+function normalizePaymentStatus(
+  value: DeriveInstitutionalSchemaV2Input["latestPaymentStatus"]
+): InstitutionalExportV2["paymentReadiness"]["latestPaymentStatus"] {
+  switch (value) {
+    case "setup_required":
+      return "not_available";
+    case "checkout_created":
+      return "checkout_created";
+    case "payment_pending":
+      return "pending";
+    case "paid":
+      return "paid";
+    case "failed":
+      return "failed";
+    case "canceled":
+      return "canceled";
+    case "expired":
+      return "expired";
+    case null:
+    case undefined:
+    default:
+      return "not_available";
+  }
+}
+
+export function deriveInstitutionalSchemaV2(input: DeriveInstitutionalSchemaV2Input): InstitutionalExportV2 {
+  const packageV1 = input.packageV1;
+  return {
+    schema: {
+      name: "rentchain.institutional_identity_package",
+      version: "2.0",
+      generatedAt: packageV1.metadata.generatedAt,
+      jurisdiction: "CA",
+      dataScope: "tenant_controlled_export",
+      consentRequired: true,
+    },
+    subject: {
+      subjectType: "tenant",
+      identityStatus: packageV1.identitySummary.identityStatus,
+      verificationLevel: packageV1.identitySummary.verificationLevel,
+      completenessLevel: packageV1.identitySummary.completenessLevel,
+    },
+    identity: {
+      portabilityStatus: packageV1.portabilitySummary?.portabilityStatus || "not_ready",
+      identityReadiness: packageV1.identitySummary.identityStatus,
+      credibilityReadiness: packageV1.credibilitySummary.completenessLevel,
+    },
+    rentalHistory: {
+      activeLeaseAvailable: packageV1.leaseSummary.activeLease,
+      leaseExecutionStatus: normalizeLeaseExecutionStatus(packageV1.leaseSummary.leaseExecutionStatus),
+      leaseSummaryAvailable: packageV1.leaseSummary.leaseExecutionStatus !== "not_available",
+    },
+    paymentReadiness: {
+      rentTermsReady: packageV1.paymentReadinessSummary.readinessStatus === "ready_to_configure",
+      paymentRailAvailable: normalizePaymentStatus(input.latestPaymentStatus) !== "not_available",
+      latestPaymentStatus: normalizePaymentStatus(input.latestPaymentStatus),
+    },
+    audit: {
+      auditTrailAvailable: packageV1.auditSummary.totalEvents > 0,
+      totalIdentityEvents: packageV1.auditSummary.totalEvents,
+      recentActivityAvailable: packageV1.auditSummary.recentActivity.length > 0,
+    },
+    validation: {
+      status: "valid",
+      warnings: [],
+      missingRecommendedFields: [],
+    },
+    extensions: {
+      reserved: {},
+    },
+  };
+}

--- a/rentchain-api/src/services/institutional/validateInstitutionalSchema.ts
+++ b/rentchain-api/src/services/institutional/validateInstitutionalSchema.ts
@@ -1,0 +1,52 @@
+import type { InstitutionalExportV2 } from "./deriveInstitutionalSchemaV2";
+
+function hasString(value: unknown): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export function validateInstitutionalSchema(
+  input: InstitutionalExportV2
+): InstitutionalExportV2["validation"] {
+  const warnings: string[] = [];
+  const missingRecommendedFields: string[] = [];
+
+  const requiredChecks: Array<[string, boolean]> = [
+    ["schema.name", hasString(input.schema?.name)],
+    ["schema.version", hasString(input.schema?.version)],
+    ["schema.generatedAt", hasString(input.schema?.generatedAt)],
+    ["schema.jurisdiction", hasString(input.schema?.jurisdiction)],
+    ["schema.dataScope", hasString(input.schema?.dataScope)],
+    ["schema.consentRequired", input.schema?.consentRequired === true],
+    ["subject.subjectType", hasString(input.subject?.subjectType)],
+  ];
+
+  const missingRequiredFields = requiredChecks.filter(([, valid]) => !valid).map(([field]) => field);
+  if (missingRequiredFields.length) {
+    return {
+      status: "invalid",
+      warnings: [`Required schema fields are missing or malformed: ${missingRequiredFields.join(", ")}`],
+      missingRecommendedFields: [],
+    };
+  }
+
+  const recommendedChecks: Array<[string, boolean]> = [
+    ["subject.identityStatus", hasString(input.subject?.identityStatus)],
+    ["subject.verificationLevel", hasString(input.subject?.verificationLevel)],
+    ["subject.completenessLevel", hasString(input.subject?.completenessLevel)],
+    ["identity.portabilityStatus", hasString(input.identity?.portabilityStatus)],
+    ["audit.auditTrailAvailable", typeof input.audit?.auditTrailAvailable === "boolean"],
+  ];
+
+  recommendedChecks.forEach(([field, valid]) => {
+    if (!valid) {
+      missingRecommendedFields.push(field);
+      warnings.push(`Recommended field unavailable: ${field}`);
+    }
+  });
+
+  return {
+    status: warnings.length ? "valid_with_warnings" : "valid",
+    warnings,
+    missingRecommendedFields,
+  };
+}

--- a/rentchain-frontend/src/api/tenantPortal.ts
+++ b/rentchain-frontend/src/api/tenantPortal.ts
@@ -383,6 +383,53 @@ export type InstitutionalIdentityPackage = {
   };
 };
 
+export type InstitutionalSchemaVersion = "1.0" | "2.0";
+
+export type InstitutionalExportV2 = {
+  schema: {
+    name: "rentchain.institutional_identity_package";
+    version: "2.0";
+    generatedAt: string;
+    jurisdiction: "CA";
+    dataScope: "tenant_controlled_export";
+    consentRequired: true;
+  };
+  subject: {
+    subjectType: "tenant";
+    identityStatus: "incomplete" | "limited" | "ready" | "verified";
+    verificationLevel: "none" | "partial" | "strong";
+    completenessLevel: "low" | "medium" | "high";
+  };
+  identity: {
+    portabilityStatus: "not_ready" | "limited" | "ready";
+    identityReadiness: "incomplete" | "limited" | "ready" | "verified";
+    credibilityReadiness: "low" | "medium" | "high";
+  };
+  rentalHistory: {
+    activeLeaseAvailable: boolean;
+    leaseExecutionStatus: "not_available" | "draft" | "pending_signature" | "executed" | "blocked";
+    leaseSummaryAvailable: boolean;
+  };
+  paymentReadiness: {
+    rentTermsReady: boolean;
+    paymentRailAvailable: boolean;
+    latestPaymentStatus?: "not_available" | "checkout_created" | "pending" | "paid" | "failed" | "canceled" | "expired";
+  };
+  audit: {
+    auditTrailAvailable: boolean;
+    totalIdentityEvents: number;
+    recentActivityAvailable: boolean;
+  };
+  validation: {
+    status: "valid" | "valid_with_warnings" | "invalid";
+    warnings: string[];
+    missingRecommendedFields: string[];
+  };
+  extensions: {
+    reserved: Record<string, never>;
+  };
+};
+
 export type TenantWorkspaceSummary = {
   context: TenantWorkspaceContext;
   property: TenantWorkspaceProperty | null;
@@ -400,10 +447,18 @@ export async function getTenantWorkspace(): Promise<TenantWorkspaceSummary> {
   return res?.data;
 }
 
-export async function exportTenantIdentityPackage(): Promise<InstitutionalIdentityPackage> {
-  const res = await tenantApiFetch<{ ok: boolean; data: InstitutionalIdentityPackage }>("/tenant/identity/export", {
-    method: "POST",
-  });
+export async function exportTenantIdentityPackage(schemaVersion?: "1.0"): Promise<InstitutionalIdentityPackage>;
+export async function exportTenantIdentityPackage(schemaVersion: "2.0"): Promise<InstitutionalExportV2>;
+export async function exportTenantIdentityPackage(
+  schemaVersion: InstitutionalSchemaVersion = "1.0"
+): Promise<InstitutionalIdentityPackage | InstitutionalExportV2> {
+  const res = await tenantApiFetch<{ ok: boolean; data: InstitutionalIdentityPackage | InstitutionalExportV2 }>(
+    "/tenant/identity/export",
+    {
+      method: "POST",
+      body: JSON.stringify({ schemaVersion }),
+    }
+  );
   return res?.data;
 }
 

--- a/rentchain-frontend/src/pages/tenant/TenantInviteRedeemPage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantInviteRedeemPage.test.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import TenantInviteRedeemPage from "./TenantInviteRedeemPage";
+
+const tenantPortalApi = vi.hoisted(() => ({
+  getTenantWorkspace: vi.fn(),
+  redeemTenantWorkspaceInvite: vi.fn(),
+}));
+
+vi.mock("../../api/tenantPortal", () => tenantPortalApi);
+
+describe("TenantInviteRedeemPage", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("stays SSR/test-safe and does not load workspace context without a browser API base", async () => {
+    render(
+      <MemoryRouter>
+        <TenantInviteRedeemPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/You are completing your invite/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Complete your invite/i })).toHaveAttribute("href", "/tenant/invite/redeem");
+  });
+
+  it("redeems an invite and links into application readiness", async () => {
+    tenantPortalApi.redeemTenantWorkspaceInvite.mockResolvedValue({
+      inviteId: "invite-1",
+      propertyId: "prop-1",
+      applicationId: "app-1",
+      rc_prop_id: "rc-prop-1",
+      status: "redeemed",
+    });
+
+    render(
+      <MemoryRouter>
+        <TenantInviteRedeemPage />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByRole("textbox", { name: /Invite token/i }), {
+      target: { value: "token-123" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Redeem invite/i }));
+
+    await waitFor(() => {
+      expect(tenantPortalApi.redeemTenantWorkspaceInvite).toHaveBeenCalledWith("token-123");
+    });
+    expect(await screen.findByText(/Invite redeemed/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Continue to application readiness/i })).toHaveAttribute(
+      "href",
+      "/tenant/application?entry=invite&inviteToken=app-1"
+    );
+  });
+});

--- a/rentchain-frontend/src/pages/tenant/TenantInviteRedeemPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantInviteRedeemPage.tsx
@@ -11,6 +11,15 @@ import { buildTenantApplicationEntryPath } from "./tenantApplicationFlow";
 import { buildTenantWorkspaceModeView } from "./tenantWorkspaceMode";
 import TenantWorkspaceModeBanner from "./TenantWorkspaceModeBanner";
 
+function canLoadWorkspaceModeContext() {
+  return (
+    typeof window !== "undefined" &&
+    typeof document !== "undefined" &&
+    typeof window.location !== "undefined" &&
+    Boolean((import.meta as any)?.env?.VITE_API_BASE_URL)
+  );
+}
+
 function mapInviteError(input: string | null) {
   const normalized = String(input || "").trim().toLowerCase();
   if (normalized === "invite_expired") return "This invite has expired. Ask your landlord to send a new one.";
@@ -78,11 +87,15 @@ export default function TenantInviteRedeemPage() {
   }, [prefilledToken]);
 
   React.useEffect(() => {
-    if (typeof window === "undefined") {
+    if (!canLoadWorkspaceModeContext()) {
       return;
     }
     let cancelled = false;
-    void getTenantWorkspace()
+    const workspaceRequest = getTenantWorkspace();
+    if (!workspaceRequest || typeof (workspaceRequest as Promise<unknown>).then !== "function") {
+      return;
+    }
+    void workspaceRequest
       .then((next) => {
         if (!cancelled) {
           setWorkspace(next);

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -258,46 +258,47 @@ describe("tenant workspace frontend shell", () => {
       },
     });
     tenantPortalApi.exportTenantIdentityPackage.mockResolvedValue({
-      identitySummary: {
+      schema: {
+        name: "rentchain.institutional_identity_package",
+        version: "2.0",
+        generatedAt: "2026-04-27T00:00:00.000Z",
+        jurisdiction: "CA",
+        dataScope: "tenant_controlled_export",
+        consentRequired: true,
+      },
+      subject: {
+        subjectType: "tenant",
         identityStatus: "ready",
         verificationLevel: "partial",
         completenessLevel: "high",
-        readinessLabel: "Ready to apply",
       },
-      credibilitySummary: {
-        completenessLevel: "high",
-        verificationLevel: "partial",
-        summaryLabel: "Credibility established",
-        summaryDescription: "Most credibility signals are available in your current record.",
-      },
-      leaseSummary: {
-        activeLease: true,
-        leaseExecutionStatus: "fully_executed",
-      },
-      paymentReadinessSummary: {
-        readinessStatus: "ready_to_configure",
-        readinessLabel: "Rent terms ready for future setup",
-        readinessDescription: "The current lease shows the core rent terms needed for future setup planning.",
-      },
-      auditSummary: {
-        totalEvents: 2,
-        recentActivity: [
-          {
-            type: "lease.activated",
-            label: "Lease activated",
-            occurredAt: "2026-02-01T00:00:00.000Z",
-          },
-        ],
-      },
-      portabilitySummary: {
+      identity: {
         portabilityStatus: "ready",
-        portabilityLabel: "Ready to reuse",
-        reusableAcrossApplications: true,
+        identityReadiness: "ready",
+        credibilityReadiness: "high",
       },
-      metadata: {
-        generatedAt: "2026-04-27T00:00:00.000Z",
-        dataScope: "tenant_controlled_institutional_readiness",
-        consentRequired: true,
+      rentalHistory: {
+        activeLeaseAvailable: true,
+        leaseExecutionStatus: "executed",
+        leaseSummaryAvailable: true,
+      },
+      paymentReadiness: {
+        rentTermsReady: true,
+        paymentRailAvailable: false,
+        latestPaymentStatus: "not_available",
+      },
+      audit: {
+        auditTrailAvailable: true,
+        totalIdentityEvents: 2,
+        recentActivityAvailable: true,
+      },
+      validation: {
+        status: "valid",
+        warnings: [],
+        missingRecommendedFields: [],
+      },
+      extensions: {
+        reserved: {},
       },
     });
     tenantPortalApi.createTenantLeasePaymentCheckout.mockResolvedValue({
@@ -1014,15 +1015,17 @@ describe("tenant workspace frontend shell", () => {
     fireEvent.click(screen.getByRole("button", { name: /Export Rental Identity/i }));
 
     await waitFor(() => {
-      expect(tenantPortalApi.exportTenantIdentityPackage).toHaveBeenCalledTimes(1);
+      expect(tenantPortalApi.exportTenantIdentityPackage).toHaveBeenCalledWith("2.0");
     });
 
     expect(await screen.findByRole("button", { name: /Hide preview/i })).toBeInTheDocument();
     expect(screen.getByText(/Export preview/i)).toBeInTheDocument();
-    expect(screen.getAllByText(/Credibility established/i).length).toBeGreaterThan(0);
-    expect(screen.getByText(/Lease activated/i)).toBeInTheDocument();
+    expect(screen.getByText(/Schema version/i)).toBeInTheDocument();
+    expect(screen.getByText(/Institution-ready structure/i)).toBeInTheDocument();
+    expect(screen.getByText(/Validation status/i)).toBeInTheDocument();
     expect(screen.queryByText(/drawnDataUrl/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/paymentMethod/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Lease activated/i)).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /Download JSON/i }));
     expect(global.URL.createObjectURL).toHaveBeenCalledTimes(1);

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
@@ -5,6 +5,7 @@ import {
   exportTenantIdentityPackage,
   getTenantLeasePaymentStatus,
   getTenantWorkspace,
+  type InstitutionalExportV2,
 } from "../../api/tenantPortal";
 import { getTenantAccess, type TenantAccessWorkspace } from "../../api/tenantAccess";
 import { getTenantAttachments } from "../../api/tenantAttachmentsApi";
@@ -73,6 +74,18 @@ function prettyVerificationLevel(value: "none" | "partial" | "strong" | null | u
     case "none":
     default:
       return "None";
+  }
+}
+
+function prettyInstitutionalSchemaStatus(value: "valid" | "valid_with_warnings" | "invalid" | null | undefined) {
+  switch (value) {
+    case "valid_with_warnings":
+      return "Valid with warnings";
+    case "invalid":
+      return "Invalid";
+    case "valid":
+    default:
+      return "Valid";
   }
 }
 
@@ -159,7 +172,7 @@ function formatPaymentExperienceStatus(value: "pending" | "paid" | "failed" | "c
 
 export default function TenantWorkspacePage() {
   const [data, setData] = React.useState<Awaited<ReturnType<typeof getTenantWorkspace>> | null>(null);
-  const [institutionalPackage, setInstitutionalPackage] = React.useState<Awaited<ReturnType<typeof exportTenantIdentityPackage>> | null>(null);
+  const [institutionalPackage, setInstitutionalPackage] = React.useState<InstitutionalExportV2 | null>(null);
   const [access, setAccess] = React.useState<TenantAccessWorkspace | null>(null);
   const [attachments, setAttachments] = React.useState<Awaited<ReturnType<typeof getTenantAttachments>> | null>(null);
   const [profileData, setProfileData] = React.useState<Awaited<ReturnType<typeof getTenantProfile>> | null>(null);
@@ -324,7 +337,7 @@ export default function TenantWorkspacePage() {
     try {
       setExportBusy(true);
       setExportError(null);
-      const next = await exportTenantIdentityPackage();
+      const next = await exportTenantIdentityPackage("2.0");
       setInstitutionalPackage(next);
       setShowExportPreview(true);
     } catch (err: any) {
@@ -343,7 +356,7 @@ export default function TenantWorkspacePage() {
       const url = URL.createObjectURL(blob);
       const link = document.createElement("a");
       link.href = url;
-      link.download = "rentchain-institutional-identity-package.json";
+      link.download = "rentchain-institutional-identity-package-v2.json";
       document.body.appendChild(link);
       link.click();
       link.remove();
@@ -983,34 +996,88 @@ export default function TenantWorkspacePage() {
                   }}
                 >
                   <div style={{ fontWeight: 700, color: textTokens.primary }}>Export preview</div>
+                  <div style={{ color: textTokens.secondary, lineHeight: 1.6 }}>
+                    Tenant-controlled export. Institution-ready structure. No data is sent automatically.
+                  </div>
                   <TenantKeyValueGrid
                     rows={[
-                      { label: "Identity status", value: prettyStatus(institutionalPackage.identitySummary.identityStatus) },
-                      { label: "Verification level", value: prettyVerificationLevel(institutionalPackage.identitySummary.verificationLevel) },
-                      { label: "Completeness", value: prettyStatus(institutionalPackage.identitySummary.completenessLevel) },
-                      { label: "Credibility", value: institutionalPackage.credibilitySummary.summaryLabel },
-                      { label: "Active lease", value: institutionalPackage.leaseSummary.activeLease ? "Yes" : "No" },
-                      { label: "Lease execution", value: prettyStatus(institutionalPackage.leaseSummary.leaseExecutionStatus) },
-                      { label: "Payment readiness", value: institutionalPackage.paymentReadinessSummary.readinessLabel },
-                      { label: "Audit events", value: String(institutionalPackage.auditSummary.totalEvents) },
-                      { label: "Consent required", value: institutionalPackage.metadata.consentRequired ? "Yes" : "No" },
+                      { label: "Schema version", value: institutionalPackage.schema.version },
+                      { label: "Schema name", value: institutionalPackage.schema.name },
+                      { label: "Jurisdiction", value: institutionalPackage.schema.jurisdiction },
+                      { label: "Data scope", value: prettyStatus(institutionalPackage.schema.dataScope) },
+                      { label: "Consent required", value: institutionalPackage.schema.consentRequired ? "Yes" : "No" },
                     ]}
                   />
 
-                  <div style={{ color: textTokens.secondary, lineHeight: 1.6 }}>
-                    {institutionalPackage.credibilitySummary.summaryDescription}
+                  <div style={{ display: "grid", gap: 6 }}>
+                    <div style={{ fontWeight: 700, color: textTokens.primary }}>Subject</div>
+                    <TenantKeyValueGrid
+                      rows={[
+                        { label: "Subject type", value: prettyStatus(institutionalPackage.subject.subjectType) },
+                        { label: "Identity status", value: prettyStatus(institutionalPackage.subject.identityStatus) },
+                        { label: "Verification level", value: prettyVerificationLevel(institutionalPackage.subject.verificationLevel) },
+                        { label: "Completeness", value: prettyStatus(institutionalPackage.subject.completenessLevel) },
+                      ]}
+                    />
                   </div>
 
-                  {institutionalPackage.auditSummary.recentActivity.length ? (
-                    <div style={{ display: "grid", gap: 6 }}>
-                      <div style={{ fontWeight: 700, color: textTokens.primary }}>Recent activity</div>
-                      {institutionalPackage.auditSummary.recentActivity.map((event) => (
-                        <div key={`${event.type}:${event.occurredAt}`} style={{ color: textTokens.secondary }}>
-                          {event.label} • {formatDate(event.occurredAt)}
-                        </div>
-                      ))}
-                    </div>
-                  ) : null}
+                  <div style={{ display: "grid", gap: 6 }}>
+                    <div style={{ fontWeight: 700, color: textTokens.primary }}>Identity</div>
+                    <TenantKeyValueGrid
+                      rows={[
+                        { label: "Portability status", value: prettyStatus(institutionalPackage.identity.portabilityStatus) },
+                        { label: "Identity readiness", value: prettyStatus(institutionalPackage.identity.identityReadiness) },
+                        { label: "Credibility readiness", value: prettyStatus(institutionalPackage.identity.credibilityReadiness) },
+                      ]}
+                    />
+                  </div>
+
+                  <div style={{ display: "grid", gap: 6 }}>
+                    <div style={{ fontWeight: 700, color: textTokens.primary }}>Rental history</div>
+                    <TenantKeyValueGrid
+                      rows={[
+                        { label: "Active lease available", value: institutionalPackage.rentalHistory.activeLeaseAvailable ? "Yes" : "No" },
+                        { label: "Lease execution", value: prettyStatus(institutionalPackage.rentalHistory.leaseExecutionStatus) },
+                        { label: "Lease summary available", value: institutionalPackage.rentalHistory.leaseSummaryAvailable ? "Yes" : "No" },
+                      ]}
+                    />
+                  </div>
+
+                  <div style={{ display: "grid", gap: 6 }}>
+                    <div style={{ fontWeight: 700, color: textTokens.primary }}>Payment readiness</div>
+                    <TenantKeyValueGrid
+                      rows={[
+                        { label: "Rent terms ready", value: institutionalPackage.paymentReadiness.rentTermsReady ? "Yes" : "No" },
+                        { label: "Payment rail available", value: institutionalPackage.paymentReadiness.paymentRailAvailable ? "Yes" : "No" },
+                        {
+                          label: "Latest payment status",
+                          value: prettyStatus(institutionalPackage.paymentReadiness.latestPaymentStatus || "not_available"),
+                        },
+                      ]}
+                    />
+                  </div>
+
+                  <div style={{ display: "grid", gap: 6 }}>
+                    <div style={{ fontWeight: 700, color: textTokens.primary }}>Audit</div>
+                    <TenantKeyValueGrid
+                      rows={[
+                        { label: "Audit trail available", value: institutionalPackage.audit.auditTrailAvailable ? "Yes" : "No" },
+                        { label: "Total identity events", value: String(institutionalPackage.audit.totalIdentityEvents) },
+                        { label: "Recent activity available", value: institutionalPackage.audit.recentActivityAvailable ? "Yes" : "No" },
+                      ]}
+                    />
+                  </div>
+
+                  <div style={{ display: "grid", gap: 6 }}>
+                    <div style={{ fontWeight: 700, color: textTokens.primary }}>Validation</div>
+                    <TenantKeyValueGrid
+                      rows={[
+                        { label: "Validation status", value: prettyInstitutionalSchemaStatus(institutionalPackage.validation.status) },
+                        { label: "Warnings", value: String(institutionalPackage.validation.warnings.length) },
+                        { label: "Missing recommended fields", value: String(institutionalPackage.validation.missingRecommendedFields.length) },
+                      ]}
+                    />
+                  </div>
                 </div>
               ) : null}
             </div>


### PR DESCRIPTION
This PR introduces Institutional Schema v2.

Includes:
- explicit schemaVersion 2.0 export support
- versioned institutional export envelope
- validation helper with required and recommended field checks
- summary-only audit and payment readiness sections
- tenant workspace v2 preview/download updates
- focused backend/frontend test coverage

Guardrails preserved:
- v1 export compatibility remains
- no outbound transmission
- no stored exports
- no institution integration
- no bank/lender submission UI
- no raw documents, screening details, provider names, signatures, payment methods, share tokens, internal IDs, raw audit logs, or event payloads
- no permission expansion

PR note:
- Backend institutional and tenant portal tests passed: 56 tests.
- Backend typecheck passed.
- Frontend tenant workspace tests passed: 100 tests.
- Frontend build passed.
- Existing jsdom navigation noise and chunk-size warning remain unchanged and out of scope.
- Defaulting all callers to v2, institution-specific schemas, stored export history, outbound send/share flows, raw audit activity export, and raw evidence export were intentionally deferred.