### PR TITLE
feat: refine institutional schema

### DIFF
--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -1168,12 +1168,16 @@ describe("tenantPortalRoutes foundation", () => {
     expect(res.body?.data?.schema?.version).toBe("2.0");
     expect(res.body?.data?.validation?.status).toBeTruthy();
     expect(res.body?.data?.complianceReadiness?.readinessStatus).toBeTruthy();
+    expect(res.body?.data?.complianceReadiness?.checks).toBeInstanceOf(Array);
     expect(res.body?.data?.complianceReadiness?.exportTraceability).toEqual({
       exportAvailable: true,
       schemaVersion: "2.0",
       exportStorage: "not_stored",
       outboundTransfer: "none",
     });
+    expect(res.body?.data?.validation?.warnings).toContain("Recommended signal limited: identity trace unavailable");
+    expect(res.body?.data?.validation?.warnings).toContain("Recommended signal limited: payment readiness unavailable");
+    expect(res.body?.data?.validation?.warnings).toContain("Recommended signal limited: consent controls limited");
     expect(res.body?.data?.audit?.recentActivityAvailable).toBe(false);
     expect(res.body?.data?.audit?.recentActivity).toBeUndefined();
     const payload = JSON.stringify(res.body?.data || {});
@@ -1184,6 +1188,7 @@ describe("tenantPortalRoutes foundation", () => {
     expect(payload).not.toContain("tenant-1");
     expect(payload).not.toContain("prop-1");
     expect(payload).not.toContain("occurredAt");
+    expect(payload).not.toContain("requestId");
   });
 
   it("rejects unsupported institutional schema versions narrowly", async () => {

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -3065,18 +3065,24 @@ router.post("/identity/export", requireTenantWorkspaceIdentity, async (req: any,
       packageV1: institutionalIdentityPackage,
       latestPaymentStatus: workspace.lease?.rentPaymentSummary?.latestPayment?.status || null,
     });
-    schemaV2.validation = validateInstitutionalSchema(schemaV2);
+    const consentControls = {
+      sharingEnabled: Boolean(portableIdentity?.readiness?.sharingEnabled),
+      verificationRequestsAvailable: false,
+      approvedScopeCount: 0,
+    };
+    schemaV2.validation = validateInstitutionalSchema(schemaV2, {
+      consentControlsLimited:
+        consentControls.sharingEnabled &&
+        !consentControls.verificationRequestsAvailable &&
+        consentControls.approvedScopeCount === 0,
+    });
     schemaV2.complianceReadiness = deriveComplianceReadiness({
       validation: schemaV2.validation,
       identityTimeline: {
         totalEvents: schemaV2.audit.totalIdentityEvents,
         recentActivityAvailable: schemaV2.audit.recentActivityAvailable,
       },
-      consentControls: {
-        sharingEnabled: Boolean(portableIdentity?.readiness?.sharingEnabled),
-        verificationRequestsAvailable: false,
-        approvedScopeCount: 0,
-      },
+      consentControls,
       exportContext: {
         schemaVersion: "2.0",
         dataScope: schemaV2.schema.dataScope,

--- a/rentchain-api/src/services/institutional/__tests__/deriveInstitutionalSchemaV2.test.ts
+++ b/rentchain-api/src/services/institutional/__tests__/deriveInstitutionalSchemaV2.test.ts
@@ -54,6 +54,7 @@ describe("deriveInstitutionalSchemaV2", () => {
     expect(result.rentalHistory.leaseExecutionStatus).toBe("executed");
     expect(result.paymentReadiness.latestPaymentStatus).toBe("pending");
     expect(result.audit.recentActivityAvailable).toBe(true);
+    expect(result.complianceReadiness.exportTraceability.schemaVersion).toBe("2.0");
     expect((result.audit as any).recentActivity).toBeUndefined();
     expect(JSON.stringify(result)).not.toContain("paymentMethod");
     expect(JSON.stringify(result)).not.toContain("documentUrl");

--- a/rentchain-api/src/services/institutional/__tests__/validateInstitutionalSchema.test.ts
+++ b/rentchain-api/src/services/institutional/__tests__/validateInstitutionalSchema.test.ts
@@ -66,6 +66,31 @@ describe("validateInstitutionalSchema", () => {
     expect(result.missingRecommendedFields).toContain("identity.portabilityStatus");
   });
 
+  it("adds safe summary warnings for portability, trace, payment readiness, and consent limits", () => {
+    const payload = buildValidExport();
+    payload.identity.portabilityStatus = "not_ready";
+    payload.audit.auditTrailAvailable = false;
+    payload.audit.totalIdentityEvents = 0;
+    payload.paymentReadiness = {
+      rentTermsReady: false,
+      paymentRailAvailable: false,
+      latestPaymentStatus: "not_available",
+    };
+
+    const result = validateInstitutionalSchema(payload, {
+      consentControlsLimited: true,
+    });
+
+    expect(result.status).toBe("valid_with_warnings");
+    expect(result.warnings).toContain("Recommended signal limited: portability unavailable");
+    expect(result.warnings).toContain("Recommended signal limited: identity trace unavailable");
+    expect(result.warnings).toContain("Recommended signal limited: payment readiness unavailable");
+    expect(result.warnings).toContain("Recommended signal limited: consent controls limited");
+    expect(JSON.stringify(result)).not.toContain("tokenHash");
+    expect(JSON.stringify(result)).not.toContain("requestId");
+    expect(JSON.stringify(result)).not.toContain("occurredAt");
+  });
+
   it("returns invalid when required fields are malformed", () => {
     const payload = buildValidExport();
     (payload.schema as any).name = "";

--- a/rentchain-api/src/services/institutional/deriveInstitutionalSchemaV2.ts
+++ b/rentchain-api/src/services/institutional/deriveInstitutionalSchemaV2.ts
@@ -41,7 +41,7 @@ export type InstitutionalExportV2 = {
     warnings: string[];
     missingRecommendedFields: string[];
   };
-  complianceReadiness?: ComplianceReadiness;
+  complianceReadiness: ComplianceReadiness;
   extensions: {
     reserved: Record<string, never>;
   };
@@ -147,6 +147,19 @@ export function deriveInstitutionalSchemaV2(input: DeriveInstitutionalSchemaV2In
       status: "valid",
       warnings: [],
       missingRecommendedFields: [],
+    },
+    complianceReadiness: {
+      readinessStatus: "partial",
+      readinessLabel: "Compliance readiness pending",
+      readinessDescription:
+        "Compliance readiness is attached during tenant-controlled schema export generation.",
+      checks: [],
+      exportTraceability: {
+        exportAvailable: false,
+        schemaVersion: "2.0",
+        exportStorage: "not_stored",
+        outboundTransfer: "none",
+      },
     },
     extensions: {
       reserved: {},

--- a/rentchain-api/src/services/institutional/validateInstitutionalSchema.ts
+++ b/rentchain-api/src/services/institutional/validateInstitutionalSchema.ts
@@ -4,8 +4,13 @@ function hasString(value: unknown): boolean {
   return typeof value === "string" && value.trim().length > 0;
 }
 
+type InstitutionalValidationContext = {
+  consentControlsLimited?: boolean;
+};
+
 export function validateInstitutionalSchema(
-  input: InstitutionalExportV2
+  input: InstitutionalExportV2,
+  context: InstitutionalValidationContext = {}
 ): InstitutionalExportV2["validation"] {
   const warnings: string[] = [];
   const missingRecommendedFields: string[] = [];
@@ -43,6 +48,25 @@ export function validateInstitutionalSchema(
       warnings.push(`Recommended field unavailable: ${field}`);
     }
   });
+
+  if (input.identity?.portabilityStatus === "not_ready") {
+    warnings.push("Recommended signal limited: portability unavailable");
+  }
+
+  if (!input.audit?.auditTrailAvailable || input.audit?.totalIdentityEvents === 0) {
+    warnings.push("Recommended signal limited: identity trace unavailable");
+  }
+
+  if (
+    input.paymentReadiness?.latestPaymentStatus === "not_available" ||
+    (!input.paymentReadiness?.rentTermsReady && !input.paymentReadiness?.paymentRailAvailable)
+  ) {
+    warnings.push("Recommended signal limited: payment readiness unavailable");
+  }
+
+  if (context.consentControlsLimited) {
+    warnings.push("Recommended signal limited: consent controls limited");
+  }
 
   return {
     status: warnings.length ? "valid_with_warnings" : "valid",


### PR DESCRIPTION
This PR introduces Institutional Schema Refinement v2.1.

Includes:
- schemaVersion 2.0 retained
- v1 export compatibility preserved
- complianceReadiness guaranteed on schemaVersion 2.0 exports
- summary-only validation warning alignment for portability, identity trace, payment readiness, and consent controls
- focused backend test coverage

Guardrails preserved:
- no schemaVersion 2.1 introduced
- no new top-level schema sections
- no frontend workflow expansion
- no outbound transfer
- no stored exports
- no raw audit/event details
- no raw documents, screening/provider details, signatures, payment-method data, share tokens, or internal IDs
- no payment/provider changes
- no share permission changes
- no landlord/public payload changes
- no certification/legal compliance language

PR note:
- Backend focused institutional/compliance/tenant portal tests passed: 60 tests.
- Backend typecheck passed.
- Frontend tests/build were not rerun because no frontend files changed.
- SchemaVersion 2.1, new consent-control subsection, frontend workflow/UI expansion, export persistence/transmission, and raw trace/evidence exposure were intentionally deferred.