### PR TITLE
feat: improve reporting export reliability

### DIFF
--- a/rentchain-api/src/routes/__tests__/paymentsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/paymentsRoutes.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const collections = new Map<string, Map<string, any>>();
+
+function ensureCollection(name: string) {
+  if (!collections.has(name)) collections.set(name, new Map());
+  return collections.get(name)!;
+}
+
+vi.mock("../../config/firebase", () => ({
+  db: {
+    collection: (name: string) => ({
+      doc: (id: string) => ({
+        get: async () => {
+          const value = ensureCollection(name).get(id);
+          return {
+            id,
+            exists: Boolean(value),
+            data: () => value,
+          };
+        },
+      }),
+    }),
+  },
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, _res: any, next: any) => {
+    req.user = { id: "landlord-1", landlordId: "landlord-1", role: "landlord" };
+    next();
+  },
+}));
+
+vi.mock("../../middleware/requireAuthz", () => ({
+  requirePermission: () => (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock("../../services/ledgerEventsService", () => ({
+  recordPaymentEvent: vi.fn(),
+}));
+
+vi.mock("../../services/leaseService", () => ({
+  leaseService: {},
+}));
+
+describe("paymentsRoutes exports", () => {
+  beforeEach(async () => {
+    collections.clear();
+    ensureCollection("tenants").set("tenant-1", {
+      id: "tenant-1",
+      fullName: "Taylor Tenant",
+    });
+    ensureCollection("properties").set("prop-1", {
+      id: "prop-1",
+      name: "123 Main St",
+    });
+    const { paymentsService } = await import("../../services/paymentsService");
+    paymentsService.getAll().splice(0, paymentsService.getAll().length);
+    paymentsService.create({
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      amount: 1800,
+      paidAt: "2026-04-01",
+      method: "e-transfer",
+      notes: "April rent",
+    });
+  });
+
+  async function invokeRouter(
+    router: any,
+    options: {
+      method: string;
+      url: string;
+    }
+  ) {
+    return await new Promise<{ status: number; body: any; headers: Record<string, string> }>((resolve, reject) => {
+      const req: any = {
+        method: options.method,
+        url: options.url,
+        originalUrl: options.url,
+        path: options.url,
+        headers: {},
+        body: {},
+        query: {},
+        params: {},
+      };
+      const res: any = {
+        statusCode: 200,
+        headers: {} as Record<string, string>,
+        setHeader(name: string, value: string) {
+          this.headers[String(name).toLowerCase()] = value;
+        },
+        status(code: number) {
+          this.statusCode = code;
+          return this;
+        },
+        json(payload: any) {
+          resolve({ status: this.statusCode, body: payload, headers: this.headers });
+          return this;
+        },
+        send(payload: any) {
+          resolve({ status: this.statusCode, body: payload, headers: this.headers });
+          return this;
+        },
+      };
+      router.handle(req, res, (error: any) => {
+        if (error) reject(error);
+      });
+    });
+  }
+
+  it("exports csv with safe tenant and property labels", async () => {
+    const router = (await import("../paymentsRoutes")).default;
+    const res = await invokeRouter(router, { method: "GET", url: "/payments/export.csv" });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toContain("text/csv");
+    expect(String(res.body)).toContain("Taylor Tenant");
+    expect(String(res.body)).toContain("123 Main St");
+    expect(String(res.body)).not.toContain("tenant-1");
+    expect(String(res.body)).not.toContain("prop-1");
+  });
+
+  it("exports spreadsheet xml with safe labels", async () => {
+    const router = (await import("../paymentsRoutes")).default;
+    const res = await invokeRouter(router, { method: "GET", url: "/payments/export.xlsx" });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toContain("application/vnd.ms-excel");
+    expect(String(res.body)).toContain("Taylor Tenant");
+    expect(String(res.body)).toContain("123 Main St");
+  });
+});

--- a/rentchain-api/src/routes/__tests__/workOrdersRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/workOrdersRoutes.test.ts
@@ -13,6 +13,42 @@ function ensureCollection(name: string) {
   return collections.get(name)!;
 }
 
+function matches(entry: any, filters: Array<{ field: string; value: any }>) {
+  return filters.every((filter) => {
+    const value = entry?.[filter.field];
+    if (Array.isArray(value)) return value.includes(filter.value);
+    return value === filter.value;
+  });
+}
+
+function buildQuery(name: string, filters: Array<{ field: string; value: any }> = []) {
+  return {
+    where: (field: string, _op: string, value: any) => buildQuery(name, [...filters, { field, value }]),
+    limit: (n: number) => ({
+      get: async () => {
+        const rows = Array.from(ensureCollection(name).entries())
+          .map(([id, data]) => ({ id, data }))
+          .filter((entry) => matches(entry.data, filters))
+          .slice(0, n);
+        return {
+          empty: rows.length === 0,
+          size: rows.length,
+          docs: rows.map((row) => ({
+            id: row.id,
+            data: () => clone(row.data),
+            ref: {
+              set: async (value: any, opts?: { merge?: boolean }) => {
+                const current = ensureCollection(name).get(row.id);
+                ensureCollection(name).set(row.id, opts?.merge ? applyMerge(current, value) : clone(value));
+              },
+            },
+          })),
+        };
+      },
+    }),
+  };
+}
+
 function clone<T>(value: T): T {
   return value === undefined ? value : JSON.parse(JSON.stringify(value));
 }
@@ -51,6 +87,8 @@ const dbMock = {
         },
       };
     },
+    where: (field: string, _op: string, value: any) => buildQuery(name, [{ field, value }]),
+    limit: (n: number) => buildQuery(name).limit(n),
   }),
 };
 
@@ -107,7 +145,7 @@ describe("workOrdersRoutes execution completion", () => {
       headers?: Record<string, string>;
     }
   ) {
-    return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    return await new Promise<{ status: number; body: any; headers: Record<string, string> }>((resolve, reject) => {
       const req: any = {
         method: options.method,
         url: options.url,
@@ -119,16 +157,20 @@ describe("workOrdersRoutes execution completion", () => {
       };
       const res: any = {
         statusCode: 200,
+        headers: {} as Record<string, string>,
+        setHeader(name: string, value: string) {
+          this.headers[String(name).toLowerCase()] = value;
+        },
         status(code: number) {
           this.statusCode = code;
           return this;
         },
         json(payload: any) {
-          resolve({ status: this.statusCode, body: payload });
+          resolve({ status: this.statusCode, body: payload, headers: this.headers });
           return this;
         },
         send(payload: any) {
-          resolve({ status: this.statusCode, body: payload });
+          resolve({ status: this.statusCode, body: payload, headers: this.headers });
           return this;
         },
       };
@@ -156,11 +198,20 @@ describe("workOrdersRoutes execution completion", () => {
       id: "wo-1",
       landlordId: "landlord-1",
       maintenanceRequestId: "maint-1",
+      propertyId: "prop-1",
+      category: "HVAC",
+      priority: "urgent",
+      visibility: "private",
       status: "assigned",
       title: "Broken heater",
       assignedContractorId: null,
       createdAtMs: 100,
       updatedAtMs: 100,
+    });
+    ensureCollection("properties").set("prop-1", {
+      id: "prop-1",
+      landlordId: "landlord-1",
+      name: "123 Main St",
     });
   });
 
@@ -1150,5 +1201,42 @@ describe("workOrdersRoutes execution completion", () => {
         topReasonCode: "MAINTENANCE_EVIDENCE_REQUIRED",
       })
     );
+  });
+
+  it("exports landlord-safe work order csv rows without raw attachment fields", async () => {
+    const router = (await import("../workOrdersRoutes")).default;
+    ensureCollection("workOrders").set("wo-1", {
+      ...ensureCollection("workOrders").get("wo-1"),
+      completionSummary: "Heat restored and tested.",
+      serviceStartedAt: 150,
+      serviceCompletedAt: 190,
+      evidence: [{ id: "evidence-1", url: "https://example.com/photo.jpg" }],
+      costAttachments: [{ id: "attach-1", url: "https://example.com/invoice.pdf" }],
+    });
+    ensureCollection("workOrderUpdates").set("upd-1", {
+      id: "upd-1",
+      workOrderId: "wo-1",
+      message: "Landlord confirmed the service window.",
+      createdAtMs: 200,
+    });
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/work-orders/export.csv",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "landlord-1",
+          role: "landlord",
+          landlordId: "landlord-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toContain("text/csv");
+    expect(String(res.body)).toContain("123 Main St");
+    expect(String(res.body)).toContain("Landlord confirmed the service window.");
+    expect(String(res.body)).not.toContain("https://example.com/photo.jpg");
+    expect(String(res.body)).not.toContain("https://example.com/invoice.pdf");
   });
 });

--- a/rentchain-api/src/routes/paymentsRoutes.ts
+++ b/rentchain-api/src/routes/paymentsRoutes.ts
@@ -10,8 +10,94 @@ import { leaseService } from "../services/leaseService";
 import { recordPaymentEvent } from "../services/ledgerEventsService";
 import { requireAuth } from "../middleware/requireAuth";
 import { requirePermission } from "../middleware/requireAuthz";
+import { db } from "../config/firebase";
 
 const router = Router();
+
+const csvEscape = (value: unknown) => {
+  const text = String(value ?? "");
+  if (/[",\n]/.test(text)) {
+    return `"${text.replace(/"/g, '""')}"`;
+  }
+  return text;
+};
+
+const xmlEscape = (value: unknown) =>
+  String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+
+const roleForReq = (req: any) => String(req.user?.actorRole || req.user?.role || "").trim().toLowerCase();
+
+async function buildPaymentLabelMaps(payments: Payment[]) {
+  const tenantIds = Array.from(new Set(payments.map((payment) => String(payment.tenantId || "").trim()).filter(Boolean)));
+  const propertyIds = Array.from(new Set(payments.map((payment) => String(payment.propertyId || "").trim()).filter(Boolean)));
+
+  const [tenantSnaps, propertySnaps] = await Promise.all([
+    Promise.all(tenantIds.map((id) => db.collection("tenants").doc(id).get())),
+    Promise.all(propertyIds.map((id) => db.collection("properties").doc(id).get())),
+  ]);
+
+  const tenantLabels = new Map<string, string>();
+  tenantSnaps.forEach((snap) => {
+    if (!snap.exists) return;
+    const data = snap.data() as any;
+    const label =
+      String(data?.fullName || data?.name || data?.displayName || "").trim()
+      || [String(data?.firstName || "").trim(), String(data?.lastName || "").trim()].filter(Boolean).join(" ")
+      || "Tenant";
+    tenantLabels.set(snap.id, label);
+  });
+
+  const propertyLabels = new Map<string, string>();
+  propertySnaps.forEach((snap) => {
+    if (!snap.exists) return;
+    const data = snap.data() as any;
+    const label = String(data?.name || data?.addressLine1 || data?.address || "").trim() || "Property";
+    propertyLabels.set(snap.id, label);
+  });
+
+  return { tenantLabels, propertyLabels };
+}
+
+async function buildPaymentExportRows(payments: Payment[]) {
+  const { tenantLabels, propertyLabels } = await buildPaymentLabelMaps(payments);
+  return payments.map((payment) => ({
+    paidDate: String(payment.paidAt || "").trim(),
+    tenant: tenantLabels.get(String(payment.tenantId || "").trim()) || "Tenant",
+    property: propertyLabels.get(String(payment.propertyId || "").trim()) || "Property",
+    amount: Number(payment.amount || 0).toFixed(2),
+    method: String(payment.method || "").trim(),
+    notes: String(payment.notes || "").trim(),
+  }));
+}
+
+function renderPaymentSpreadsheetXml(rows: Array<Record<string, string>>) {
+  const headers = ["Paid Date", "Tenant", "Property", "Amount", "Method", "Notes"];
+  const rowXml = rows
+    .map((row) => {
+      const cells = [row.paidDate, row.tenant, row.property, row.amount, row.method, row.notes]
+        .map((value) => `<Cell><Data ss:Type="String">${xmlEscape(value)}</Data></Cell>`)
+        .join("");
+      return `<Row>${cells}</Row>`;
+    })
+    .join("");
+
+  return `<?xml version="1.0"?>
+<?mso-application progid="Excel.Sheet"?>
+<Workbook xmlns="urn:schemas-microsoft-com:office:spreadsheet"
+ xmlns:o="urn:schemas-microsoft-com:office:office"
+ xmlns:x="urn:schemas-microsoft-com:office:excel"
+ xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet">
+  <Worksheet ss:Name="Payments">
+    <Table>
+      <Row>${headers.map((header) => `<Cell><Data ss:Type="String">${xmlEscape(header)}</Data></Cell>`).join("")}</Row>
+      ${rowXml}
+    </Table>
+  </Worksheet>
+</Workbook>`;
+}
 
 const parseYearMonth = (req: Request): { year: number; month: number } | null => {
   const year = Number((req.query.year as string) ?? "");
@@ -35,6 +121,47 @@ router.get("/payments", (req: Request, res: Response) => {
   }
 
   res.json(results);
+});
+
+router.get("/payments/export.csv", requireAuth, async (req: any, res: Response) => {
+  try {
+    const role = roleForReq(req);
+    if (role !== "landlord" && role !== "admin") {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+
+    const rows = await buildPaymentExportRows(paymentsService.getAll());
+    const csv = [
+      ["paid_date", "tenant", "property", "amount", "method", "notes"].join(","),
+      ...rows.map((row) => [row.paidDate, row.tenant, row.property, row.amount, row.method, row.notes].map(csvEscape).join(",")),
+    ].join("\n");
+
+    res.setHeader("Content-Type", "text/csv; charset=utf-8");
+    res.setHeader("Content-Disposition", `attachment; filename="rentchain-payments-${new Date().toISOString().slice(0, 10)}.csv"`);
+    return res.status(200).send(csv);
+  } catch (err) {
+    console.error("[paymentsRoutes] csv export failed", err);
+    return res.status(500).json({ ok: false, error: "PAYMENTS_EXPORT_FAILED" });
+  }
+});
+
+router.get("/payments/export.xlsx", requireAuth, async (req: any, res: Response) => {
+  try {
+    const role = roleForReq(req);
+    if (role !== "landlord" && role !== "admin") {
+      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    }
+
+    const rows = await buildPaymentExportRows(paymentsService.getAll());
+    const xml = renderPaymentSpreadsheetXml(rows);
+
+    res.setHeader("Content-Type", "application/vnd.ms-excel; charset=utf-8");
+    res.setHeader("Content-Disposition", `attachment; filename="rentchain-payments-${new Date().toISOString().slice(0, 10)}.xlsx"`);
+    return res.status(200).send(xml);
+  } catch (err) {
+    console.error("[paymentsRoutes] xlsx export failed", err);
+    return res.status(500).json({ ok: false, error: "PAYMENTS_EXPORT_FAILED" });
+  }
 });
 
 // POST /api/payments

--- a/rentchain-api/src/routes/workOrdersRoutes.ts
+++ b/rentchain-api/src/routes/workOrdersRoutes.ts
@@ -709,6 +709,145 @@ function replaceEvidenceItem(
     return updater(normalized);
   });
 }
+
+function exportCsvEscape(value: unknown): string {
+  const text = String(value ?? "");
+  if (/[",\n]/.test(text)) {
+    return `"${text.replace(/"/g, '""')}"`;
+  }
+  return text;
+}
+
+function exportXmlEscape(value: unknown) {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function exportDateTime(value: unknown) {
+  const ms = toMillis(value);
+  if (!ms) return "";
+  return new Date(ms).toISOString();
+}
+
+async function listLandlordWorkOrdersForExport(req: any) {
+  const landlordId = getLandlordId(req);
+  if (!landlordId) return [];
+  const snap = await db.collection("workOrders").where("landlordId", "==", landlordId).limit(500).get();
+  return Promise.all(snap.docs.map((doc) => toWorkOrderResponseForAudience(doc.id, doc.data(), "landlord")));
+}
+
+async function buildWorkOrderExportRows(items: any[]) {
+  const propertyIds = Array.from(new Set(items.map((item) => asString(item.propertyId, 120)).filter(Boolean)));
+  const propertySnaps = await Promise.all(propertyIds.map((id) => db.collection("properties").doc(id).get()));
+  const propertyLabels = new Map<string, string>();
+  propertySnaps.forEach((snap) => {
+    if (!snap.exists) return;
+    const data = snap.data() as any;
+    propertyLabels.set(snap.id, asString(data?.name || data?.addressLine1 || data?.address, 200) || "Property");
+  });
+
+  const latestComments = new Map<string, string>();
+  await Promise.all(
+    items.map(async (item) => {
+      const snap = await db.collection("workOrderUpdates").where("workOrderId", "==", asString(item.id, 120)).limit(50).get();
+      const messages = snap.docs
+        .map((doc) => doc.data() as any)
+        .sort((a, b) => Number(b?.createdAtMs || 0) - Number(a?.createdAtMs || 0))
+        .map((entry) => asString(entry?.message, 500))
+        .filter(Boolean);
+      latestComments.set(asString(item.id, 120), messages[0] || "");
+    })
+  );
+
+  return items.map((item) => ({
+    title: asString(item.title, 200),
+    property: propertyLabels.get(asString(item.propertyId, 120)) || "Property",
+    unit: "",
+    category: asString(item.category, 120),
+    priority: asString(item.priority, 40),
+    status: asString(item.status, 40),
+    visibility: asString(item.visibility, 40),
+    assignedContractor:
+      asString(item.contractorAssignment?.displayName || item.contractorAssignment?.businessName, 180) ||
+      (asString(item.assignedContractorId, 120) ? "Assigned" : ""),
+    scheduledFor: exportDateTime(item.scheduledFor),
+    serviceStartedAt: exportDateTime(item.serviceStartedAt),
+    serviceCompletedAt: exportDateTime(item.serviceCompletedAt),
+    updatedAt: exportDateTime(item.updatedAtMs),
+    completionSummary: asString(item.completionSummary, 500),
+    completionOutcome: asString(item.completionOutcome, 60),
+    resolutionStatus: asString(item.resolutionStatus, 80),
+    followUpRequired: item.followUpRequired ? "yes" : "no",
+    linkedExpenseStatus: asString(item.expenseLink?.status || item.cost?.linkedExpenseStatus, 40),
+    latestComment: latestComments.get(asString(item.id, 120)) || "",
+  }));
+}
+
+function renderWorkOrderSpreadsheetXml(rows: Array<Record<string, string>>) {
+  const headers = [
+    "Title",
+    "Property",
+    "Unit",
+    "Category",
+    "Priority",
+    "Status",
+    "Visibility",
+    "Assigned Contractor",
+    "Scheduled For",
+    "Service Started At",
+    "Service Completed At",
+    "Updated At",
+    "Completion Summary",
+    "Completion Outcome",
+    "Resolution Status",
+    "Follow Up Required",
+    "Linked Expense Status",
+    "Latest Comment",
+  ];
+  const rowXml = rows
+    .map((row) => {
+      const values = [
+        row.title,
+        row.property,
+        row.unit,
+        row.category,
+        row.priority,
+        row.status,
+        row.visibility,
+        row.assignedContractor,
+        row.scheduledFor,
+        row.serviceStartedAt,
+        row.serviceCompletedAt,
+        row.updatedAt,
+        row.completionSummary,
+        row.completionOutcome,
+        row.resolutionStatus,
+        row.followUpRequired,
+        row.linkedExpenseStatus,
+        row.latestComment,
+      ];
+      return `<Row>${values
+        .map((value) => `<Cell><Data ss:Type="String">${exportXmlEscape(value)}</Data></Cell>`)
+        .join("")}</Row>`;
+    })
+    .join("");
+
+  return `<?xml version="1.0"?>
+<?mso-application progid="Excel.Sheet"?>
+<Workbook xmlns="urn:schemas-microsoft-com:office:spreadsheet"
+ xmlns:o="urn:schemas-microsoft-com:office:office"
+ xmlns:x="urn:schemas-microsoft-com:office:excel"
+ xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet">
+  <Worksheet ss:Name="Work Orders">
+    <Table>
+      <Row>${headers.map((header) => `<Cell><Data ss:Type="String">${exportXmlEscape(header)}</Data></Cell>`).join("")}</Row>
+      ${rowXml}
+    </Table>
+  </Worksheet>
+</Workbook>`;
+}
 router.post("/contractor/profile", requireAuth, async (req: any, res) => {
   try {
     if (!isContractor(req)) return res.status(403).json({ ok: false, error: "FORBIDDEN" });
@@ -1333,6 +1472,81 @@ router.get("/work-orders", requireAuth, async (req: any, res) => {
   } catch (err) {
     console.error("[work-orders] list failed", err);
     return res.status(500).json({ ok: false, error: "WORK_ORDER_LIST_FAILED" });
+  }
+});
+
+router.get("/work-orders/export.csv", requireAuth, async (req: any, res) => {
+  try {
+    if (!isLandlord(req)) return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    const rows = await buildWorkOrderExportRows(await listLandlordWorkOrdersForExport(req));
+    const csv = [
+      [
+        "title",
+        "property",
+        "unit",
+        "category",
+        "priority",
+        "status",
+        "visibility",
+        "assigned_contractor",
+        "scheduled_for",
+        "service_started_at",
+        "service_completed_at",
+        "updated_at",
+        "completion_summary",
+        "completion_outcome",
+        "resolution_status",
+        "follow_up_required",
+        "linked_expense_status",
+        "latest_comment",
+      ].join(","),
+      ...rows.map((row) =>
+        [
+          row.title,
+          row.property,
+          row.unit,
+          row.category,
+          row.priority,
+          row.status,
+          row.visibility,
+          row.assignedContractor,
+          row.scheduledFor,
+          row.serviceStartedAt,
+          row.serviceCompletedAt,
+          row.updatedAt,
+          row.completionSummary,
+          row.completionOutcome,
+          row.resolutionStatus,
+          row.followUpRequired,
+          row.linkedExpenseStatus,
+          row.latestComment,
+        ]
+          .map(exportCsvEscape)
+          .join(",")
+      ),
+    ].join("\n");
+
+    res.setHeader("Content-Type", "text/csv; charset=utf-8");
+    res.setHeader("Content-Disposition", `attachment; filename="rentchain-work-orders-${new Date().toISOString().slice(0, 10)}.csv"`);
+    return res.status(200).send(csv);
+  } catch (err) {
+    console.error("[work-orders] csv export failed", err);
+    return res.status(500).json({ ok: false, error: "WORK_ORDER_EXPORT_FAILED" });
+  }
+});
+
+router.get("/work-orders/export.xlsx", requireAuth, async (req: any, res) => {
+  try {
+    if (!isLandlord(req)) return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    const rows = await buildWorkOrderExportRows(await listLandlordWorkOrdersForExport(req));
+    const xml = renderWorkOrderSpreadsheetXml(rows);
+
+    res.setHeader("Content-Type", "application/vnd.ms-excel; charset=utf-8");
+    res.setHeader("Content-Disposition", `attachment; filename="rentchain-work-orders-${new Date().toISOString().slice(0, 10)}.xlsx"`);
+    return res.status(200).send(xml);
+  } catch (err) {
+    console.error("[work-orders] xlsx export failed", err);
+    return res.status(500).json({ ok: false, error: "WORK_ORDER_EXPORT_FAILED" });
   }
 });
 

--- a/rentchain-frontend/src/api/paymentsApi.ts
+++ b/rentchain-frontend/src/api/paymentsApi.ts
@@ -1,4 +1,6 @@
 import { apiFetch } from "./apiFetch";
+import { apiUrl } from "./config";
+import { getAuthToken } from "../lib/authToken";
 
 export interface PaymentRecord {
   id: string;
@@ -97,4 +99,35 @@ export async function getPropertyMonthlyPayments(
   );
   if (!data) return { payments: [], total: 0 };
   return data;
+}
+
+async function downloadPaymentExport(path: string) {
+  const token = getAuthToken();
+  const response = await fetch(apiUrl(path), {
+    method: "GET",
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+    credentials: "include",
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    let message = text || "Failed to export payments";
+    try {
+      const json = text ? JSON.parse(text) : null;
+      message = json?.message || json?.error || message;
+    } catch {
+      // ignore
+    }
+    throw new Error(message);
+  }
+  const blob = await response.blob();
+  const disposition = response.headers.get("Content-Disposition") || "";
+  const match = disposition.match(/filename=\"?([^\"]+)\"?/i);
+  return {
+    blob,
+    filename: match?.[1] || "rentchain-payments-export",
+  };
+}
+
+export async function exportPayments(format: "csv" | "xlsx") {
+  return downloadPaymentExport(`/payments/export.${format}`);
 }

--- a/rentchain-frontend/src/api/workOrdersApi.ts
+++ b/rentchain-frontend/src/api/workOrdersApi.ts
@@ -1,4 +1,6 @@
 import { apiFetch } from "./apiFetch";
+import { apiUrl } from "./config";
+import { getAuthToken } from "../lib/authToken";
 
 export type WorkOrderPriority = "low" | "medium" | "high" | "urgent";
 export type WorkOrderStatus =
@@ -256,6 +258,37 @@ export async function listWorkOrders(status?: string): Promise<WorkOrderRecord[]
     method: "GET",
   });
   return Array.isArray(res?.items) ? res.items : [];
+}
+
+async function downloadWorkOrderExport(path: string) {
+  const token = getAuthToken();
+  const response = await fetch(apiUrl(path), {
+    method: "GET",
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+    credentials: "include",
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    let message = text || "Failed to export work orders";
+    try {
+      const json = text ? JSON.parse(text) : null;
+      message = json?.message || json?.error || message;
+    } catch {
+      // ignore
+    }
+    throw new Error(message);
+  }
+  const blob = await response.blob();
+  const disposition = response.headers.get("Content-Disposition") || "";
+  const match = disposition.match(/filename=\"?([^\"]+)\"?/i);
+  return {
+    blob,
+    filename: match?.[1] || "rentchain-work-orders-export",
+  };
+}
+
+export async function exportWorkOrders(format: "csv" | "xlsx") {
+  return downloadWorkOrderExport(`/work-orders/export.${format}`);
 }
 
 export async function getWorkOrder(workOrderId: string): Promise<WorkOrderRecord> {

--- a/rentchain-frontend/src/pages/ExpensesPage.test.tsx
+++ b/rentchain-frontend/src/pages/ExpensesPage.test.tsx
@@ -64,7 +64,9 @@ describe("ExpensesPage", () => {
     render(<ExpensesPage />);
 
     expect(await screen.findByText("Upgrade to Pro to import receipts, PDFs, CSVs, and spreadsheets with AI-assisted review.")).toBeInTheDocument();
-    expect(screen.getByText("Upgrade to Pro for CSV import and accountant-ready exports.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Export CSV" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Export Spreadsheet" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Export PDF" })).not.toBeInTheDocument();
     expect(screen.getAllByText("Alpha Property").length).toBeGreaterThan(0);
   });
 

--- a/rentchain-frontend/src/pages/ExpensesPage.tsx
+++ b/rentchain-frontend/src/pages/ExpensesPage.tsx
@@ -305,7 +305,22 @@ const ExpensesPage: React.FC = () => {
             Track operating expenses across your properties.
           </div>
         </div>
-        <Button onClick={() => setShowAdd(true)}>Add Expense</Button>
+        <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap", justifyContent: "flex-end" }}>
+          {capsLoading ? null : proExpensesEnabled ? (
+            <>
+              <Button variant="secondary" onClick={() => void triggerDownload("csv")} disabled={exporting !== null}>
+                {exporting === "csv" ? "Exporting..." : "Export CSV"}
+              </Button>
+              <Button variant="secondary" onClick={() => void triggerDownload("xlsx")} disabled={exporting !== null}>
+                {exporting === "xlsx" ? "Exporting..." : "Export Spreadsheet"}
+              </Button>
+              <Button variant="secondary" onClick={() => void triggerDownload("pdf")} disabled={exporting !== null}>
+                {exporting === "pdf" ? "Exporting..." : "Export PDF"}
+              </Button>
+            </>
+          ) : null}
+          <Button onClick={() => setShowAdd(true)}>Add Expense</Button>
+        </div>
       </Card>
 
       <Card style={{ display: "grid", gap: spacing.md }}>
@@ -380,30 +395,6 @@ const ExpensesPage: React.FC = () => {
           </div>
         </Card>
       )}
-
-      <Card style={{ display: "grid", gap: spacing.md }}>
-        <div style={{ fontWeight: 700 }}>Export expenses</div>
-        <div style={{ color: text.muted, fontSize: 13 }}>
-          Export a clean expense table for your accountant.
-        </div>
-        {capsLoading ? null : proExpensesEnabled ? (
-          <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
-            <Button variant="secondary" onClick={() => void triggerDownload("csv")} disabled={exporting !== null}>
-              {exporting === "csv" ? "Exporting..." : "Export CSV"}
-            </Button>
-            <Button variant="secondary" onClick={() => void triggerDownload("xlsx")} disabled={exporting !== null}>
-              {exporting === "xlsx" ? "Exporting..." : "Export Spreadsheet"}
-            </Button>
-            <Button variant="secondary" onClick={() => void triggerDownload("pdf")} disabled={exporting !== null}>
-              {exporting === "pdf" ? "Exporting..." : "Export PDF"}
-            </Button>
-          </div>
-        ) : (
-          <div style={{ color: text.muted, fontSize: 13 }}>
-            Upgrade to Pro for CSV import and accountant-ready exports.
-          </div>
-        )}
-      </Card>
 
       {previewSummary ? (
         <ExpenseImportSummaryCard

--- a/rentchain-frontend/src/pages/MaintenanceRequestsPage.test.tsx
+++ b/rentchain-frontend/src/pages/MaintenanceRequestsPage.test.tsx
@@ -18,6 +18,7 @@ const workOrdersApi = vi.hoisted(() => ({
 }));
 
 const showToast = vi.fn();
+const printSummaryDocumentMock = vi.fn();
 
 vi.mock("../api/maintenanceWorkflowApi", async () => {
   const actual = await vi.importActual<any>("../api/maintenanceWorkflowApi");
@@ -34,9 +35,14 @@ vi.mock("../components/ui/ToastProvider", () => ({
   useToast: () => ({ showToast }),
 }));
 
+vi.mock("../utils/printSummary", () => ({
+  printSummaryDocument: (...args: unknown[]) => printSummaryDocumentMock(...args),
+}));
+
 describe("landlord maintenance workspace", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    printSummaryDocumentMock.mockReset();
     Object.defineProperty(window, "matchMedia", {
       writable: true,
       value: vi.fn().mockImplementation((query: string) => ({
@@ -97,11 +103,11 @@ describe("landlord maintenance workspace", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText(/Maintenance Workflow/i)).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Maintenance Workflow" })).toBeInTheDocument();
     expect(screen.getByText(/A request is waiting for review/i)).toBeInTheDocument();
     expect(screen.getAllByText(/Needs attention/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Broken heater/i).length).toBeGreaterThan(0);
-    expect(screen.getByText(/Lifecycle summary/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Lifecycle summary/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Assignment \/ handling/i)).toBeInTheDocument();
     expect(screen.getAllByText(/No handler has been assigned to this request yet/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Scheduling \/ access/i)).toBeInTheDocument();
@@ -114,6 +120,19 @@ describe("landlord maintenance workspace", () => {
     expect(screen.getByText(/Verification status/i)).toBeInTheDocument();
     expect(screen.getByText(/Review the request details/i)).toBeInTheDocument();
     expect(screen.getByText(/Mark reviewed/i)).toBeInTheDocument();
+  });
+
+  it("renders the PDF summary action and routes it through the shared print helper", async () => {
+    render(
+      <MemoryRouter initialEntries={["/maintenance/maint-1"]}>
+        <Routes>
+          <Route path="/maintenance/:id" element={<MaintenanceRequestsPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click((await screen.findAllByRole("button", { name: "Export PDF Summary" }))[0]);
+    expect(printSummaryDocumentMock).toHaveBeenCalledWith("summary");
   });
 
   it("shows pending verification and follow-up state in the landlord closure workspace", async () => {

--- a/rentchain-frontend/src/pages/MaintenanceRequestsPage.tsx
+++ b/rentchain-frontend/src/pages/MaintenanceRequestsPage.tsx
@@ -27,6 +27,7 @@ import { buildPropertyFinancialIntelligenceView } from "./propertyFinancialIntel
 import { buildMaintenanceReopenEscalationView } from "./maintenanceReopenEscalationState";
 import { buildMaintenanceServiceExecutionView } from "./maintenanceServiceExecutionState";
 import { buildMaintenanceResolutionVerificationView } from "./maintenanceResolutionVerificationState";
+import { printSummaryDocument } from "../utils/printSummary";
 import {
   buildMaintenanceSchedulingAccessView,
   buildMaintenanceSchedulingCalendarEvents,
@@ -572,9 +573,14 @@ export default function MaintenanceRequestsPage() {
               Review tenant requests, assign contractors, and track operational progress.
             </div>
           </div>
-          <Button variant="secondary" onClick={() => void load()} disabled={loading || saving}>
-            Refresh
-          </Button>
+          <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
+            <Button variant="secondary" onClick={() => void printSummaryDocument("summary")}>
+              Export PDF Summary
+            </Button>
+            <Button variant="secondary" onClick={() => void load()} disabled={loading || saving}>
+              Refresh
+            </Button>
+          </div>
         </div>
         <div style={{ display: "grid", gap: 10, gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))", marginTop: spacing.md }}>
           {[
@@ -607,6 +613,84 @@ export default function MaintenanceRequestsPage() {
       </Card>
 
       {error ? <Card style={{ borderColor: colors.danger, color: colors.danger }}>{error}</Card> : null}
+
+      <div className="print-only print-only-summary">
+        <div className="printHeader">
+          <div className="printTitle">Maintenance workflow summary</div>
+          <div className="printMeta">
+            <div>Generated: {new Date().toLocaleString()}</div>
+            <div>Requests in view: {items.length}</div>
+          </div>
+        </div>
+        <div className="printH3">Portfolio summary</div>
+        <table className="printTable">
+          <tbody>
+            <tr><th>Open requests</th><td>{totalOpen}</td></tr>
+            <tr><th>Need review</th><td>{needsReview}</td></tr>
+            <tr><th>Active jobs</th><td>{activeJobs}</td></tr>
+            <tr><th>Needs attention</th><td>{workspaceView.counts.needs_attention}</td></tr>
+            <tr><th>Recorded maintenance cost</th><td>{fmtMoney(portfolioRollup.totalRecordedCostCents)}</td></tr>
+            <tr><th>Expense linked</th><td>{fmtMoney(portfolioRollup.totalLinkedExpenseCostCents)}</td></tr>
+            <tr><th>Unlinked cost</th><td>{fmtMoney(portfolioRollup.totalUnlinkedCostCents)}</td></tr>
+          </tbody>
+        </table>
+        <div className="printH3">Requests</div>
+        <table className="printTable">
+          <thead>
+            <tr>
+              <th>Title</th>
+              <th>Tenant</th>
+              <th>Property</th>
+              <th>Unit</th>
+              <th>Priority</th>
+              <th>Status</th>
+              <th>Contractor</th>
+              <th>Created</th>
+              <th>Updated</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((item) => (
+              <tr key={item.id}>
+                <td>{item.title}</td>
+                <td>{item.tenantName || "Tenant"}</td>
+                <td>{item.propertyLabel || "Property"}</td>
+                <td>{item.unitLabel || "-"}</td>
+                <td>{item.priority || "-"}</td>
+                <td>{item.status || "-"}</td>
+                <td>{item.assignedContractorName || "-"}</td>
+                <td>{fmtDate(item.createdAt)}</td>
+                <td>{fmtDate(item.updatedAt)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {selected ? (
+          <>
+            <div className="printH3">Selected request</div>
+            <table className="printTable">
+              <tbody>
+                <tr><th>Title</th><td>{selected.title}</td></tr>
+                <tr><th>Category</th><td>{selected.category || "-"}</td></tr>
+                <tr><th>Tenant</th><td>{selected.tenantName || "Tenant"}</td></tr>
+                <tr><th>Property</th><td>{selected.propertyLabel || "Property"}</td></tr>
+                <tr><th>Unit</th><td>{selected.unitLabel || "-"}</td></tr>
+                <tr><th>Priority</th><td>{selected.priority || "-"}</td></tr>
+                <tr><th>Status</th><td>{selected.status || "-"}</td></tr>
+                <tr><th>Assigned contractor</th><td>{selected.assignedContractorName || "-"}</td></tr>
+                <tr><th>Service window start</th><td>{fmtDate(selected.serviceWindowStartAt)}</td></tr>
+                <tr><th>Service window end</th><td>{fmtDate(selected.serviceWindowEndAt)}</td></tr>
+                <tr><th>Access required</th><td>{selected.accessRequired == null ? "-" : selected.accessRequired ? "Yes" : "No"}</td></tr>
+                <tr><th>Lifecycle summary</th><td>{selectedLifecycle.summary}</td></tr>
+                <tr><th>Execution summary</th><td>{selectedExecution.summary}</td></tr>
+                <tr><th>Resolution summary</th><td>{selectedResolution.summary}</td></tr>
+                <tr><th>Landlord note</th><td>{String(selected.landlordNote || "").trim() || "-"}</td></tr>
+                <tr><th>Completion summary</th><td>{String(selected.completionSummary || "").trim() || "-"}</td></tr>
+              </tbody>
+            </table>
+          </>
+        ) : null}
+      </div>
 
       <Card elevated>
         <div style={{ display: "grid", gap: spacing.sm, gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))" }}>

--- a/rentchain-frontend/src/pages/PaymentsPage.test.tsx
+++ b/rentchain-frontend/src/pages/PaymentsPage.test.tsx
@@ -1,0 +1,102 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import PaymentsPage from "./PaymentsPage";
+
+const mocks = vi.hoisted(() => ({
+  usePayments: vi.fn(),
+  updatePayment: vi.fn(),
+  exportPayments: vi.fn(),
+  fetchProperties: vi.fn(),
+  fetchTenants: vi.fn(),
+  printSummaryDocument: vi.fn(),
+}));
+
+vi.mock("../hooks/usePayments", () => ({
+  usePayments: mocks.usePayments,
+}));
+
+vi.mock("../api/paymentsApi", () => ({
+  updatePayment: mocks.updatePayment,
+  exportPayments: mocks.exportPayments,
+}));
+
+vi.mock("../api/propertiesApi", () => ({
+  fetchProperties: mocks.fetchProperties,
+}));
+
+vi.mock("../api/tenantsApi", () => ({
+  fetchTenants: mocks.fetchTenants,
+}));
+
+vi.mock("../utils/printSummary", () => ({
+  printSummaryDocument: (...args: unknown[]) => mocks.printSummaryDocument(...args),
+}));
+
+describe("PaymentsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.usePayments.mockReturnValue({
+      payments: [
+        {
+          id: "payment-1",
+          tenantId: "tenant-1",
+          propertyId: "prop-1",
+          amount: 1800,
+          paidAt: "2026-04-01",
+          method: "e-transfer",
+          notes: "April rent",
+        },
+      ],
+      loading: false,
+      error: null,
+    });
+    mocks.fetchTenants.mockResolvedValue([{ id: "tenant-1", fullName: "Taylor Tenant" }]);
+    mocks.fetchProperties.mockResolvedValue({ items: [{ id: "prop-1", name: "123 Main St" }] });
+    mocks.exportPayments.mockResolvedValue({
+      blob: new Blob(["csv"]),
+      filename: "payments.csv",
+    });
+  });
+
+  it("renders export controls and payment labels", async () => {
+    render(<PaymentsPage />);
+
+    expect(await screen.findByRole("button", { name: "Export CSV" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Export Spreadsheet" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Export PDF" })).toBeInTheDocument();
+    expect((await screen.findAllByText("Taylor Tenant")).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("123 Main St").length).toBeGreaterThan(0);
+  });
+
+  it("routes PDF export through the shared print helper", async () => {
+    render(<PaymentsPage />);
+
+    fireEvent.click((await screen.findAllByRole("button", { name: "Export PDF" }))[0]);
+    expect(mocks.printSummaryDocument).toHaveBeenCalledWith("summary");
+  });
+
+  it("calls the export api for CSV and spreadsheet downloads", async () => {
+    const createObjectURL = vi.fn(() => "blob:url");
+    const revokeObjectURL = vi.fn();
+    const originalCreateElement = document.createElement.bind(document);
+    const click = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+    vi.stubGlobal("URL", { ...(window.URL || {}), createObjectURL, revokeObjectURL });
+    const createElementSpy = vi.spyOn(document, "createElement").mockImplementation(((tagName: string) => {
+      if (tagName === "a") {
+        return originalCreateElement("a");
+      }
+      return originalCreateElement(tagName);
+    }) as any);
+
+    render(<PaymentsPage />);
+
+    fireEvent.click((await screen.findAllByRole("button", { name: "Export CSV" }))[0]);
+    await waitFor(() => expect(mocks.exportPayments).toHaveBeenCalledWith("csv"));
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Export Spreadsheet" })[0]);
+    await waitFor(() => expect(mocks.exportPayments).toHaveBeenCalledWith("xlsx"));
+
+    createElementSpy.mockRestore();
+    click.mockRestore();
+  });
+});

--- a/rentchain-frontend/src/pages/PaymentsPage.tsx
+++ b/rentchain-frontend/src/pages/PaymentsPage.tsx
@@ -1,17 +1,89 @@
 // rentchain-frontend/src/pages/PaymentsPage.tsx
 import React, { useEffect, useState } from "react";
 import { usePayments } from "../hooks/usePayments";
-import { updatePayment, type PaymentRecord } from "@/api/paymentsApi";
+import { exportPayments, updatePayment, type PaymentRecord } from "@/api/paymentsApi";
 import { Card, Button } from "../components/ui/Ui";
 import { spacing, text, colors } from "../styles/tokens";
+import { fetchProperties } from "../api/propertiesApi";
+import { fetchTenants } from "../api/tenantsApi";
+import { printSummaryDocument } from "../utils/printSummary";
 
 const PaymentsPage: React.FC = () => {
   const { payments, loading, error } = usePayments();
   const [rows, setRows] = useState<PaymentRecord[]>([]);
+  const [exporting, setExporting] = useState<null | "csv" | "xlsx">(null);
+  const [labelMap, setLabelMap] = useState<{ tenants: Map<string, string>; properties: Map<string, string> }>({
+    tenants: new Map(),
+    properties: new Map(),
+  });
 
   useEffect(() => {
     setRows(payments);
   }, [payments]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadLabels() {
+      try {
+        const [tenantList, propertyRes] = await Promise.all([fetchTenants(), fetchProperties({ includeArchived: true })]);
+        if (cancelled) return;
+        const propertyItems = Array.isArray((propertyRes as any)?.items)
+          ? (propertyRes as any).items
+          : Array.isArray((propertyRes as any)?.properties)
+          ? (propertyRes as any).properties
+          : Array.isArray(propertyRes)
+          ? propertyRes
+          : [];
+        setLabelMap({
+          tenants: new Map(
+            tenantList.map((tenant) => [
+              String(tenant.id || ""),
+              String(tenant.fullName || tenant.name || tenant.unitLabel || "").trim(),
+            ])
+          ),
+          properties: new Map(
+            propertyItems.map((property: any) => [
+              String(property?.id || ""),
+              String(property?.name || property?.addressLine1 || property?.address || "").trim(),
+            ])
+          ),
+        });
+      } catch {
+        if (!cancelled) {
+          setLabelMap({ tenants: new Map(), properties: new Map() });
+        }
+      }
+    }
+
+    void loadLabels();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const getTenantLabel = (payment: PaymentRecord) =>
+    labelMap.tenants.get(String(payment.tenantId || "").trim()) || "Tenant";
+  const getPropertyLabel = (payment: PaymentRecord) =>
+    labelMap.properties.get(String(payment.propertyId || "").trim()) || "Property";
+
+  const triggerExport = async (format: "csv" | "xlsx") => {
+    try {
+      setExporting(format);
+      const { blob, filename } = await exportPayments(format);
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = filename;
+      link.click();
+      window.URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error("[PaymentsPage] Failed to export payments:", err);
+      window.alert(err instanceof Error ? `Failed to export payments: ${err.message}` : "Failed to export payments.");
+    } finally {
+      setExporting(null);
+    }
+  };
 
   const handleEditPayment = async (p: PaymentRecord) => {
     if (!p.id) return;
@@ -89,6 +161,15 @@ const PaymentsPage: React.FC = () => {
               All recorded payments across tenants and properties.
             </div>
           </div>
+          <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap", justifyContent: "flex-end" }}>
+            <Button variant="secondary" onClick={() => void triggerExport("csv")} disabled={exporting !== null}>
+              {exporting === "csv" ? "Exporting..." : "Export CSV"}
+            </Button>
+            <Button variant="secondary" onClick={() => void triggerExport("xlsx")} disabled={exporting !== null}>
+              {exporting === "xlsx" ? "Exporting..." : "Export Spreadsheet"}
+            </Button>
+            <Button variant="secondary" onClick={() => void printSummaryDocument("summary")}>Export PDF</Button>
+          </div>
         </div>
       </Card>
 
@@ -128,8 +209,8 @@ const PaymentsPage: React.FC = () => {
               <tbody>
                 {rows.map((p) => (
                   <tr key={p.id} style={{ borderBottom: `1px solid ${colors.border}` }}>
-                    <td style={{ padding: "0.5rem 0.4rem" }}>{p.tenantId ?? "—"}</td>
-                    <td style={{ padding: "0.5rem 0.4rem" }}>{p.propertyId ?? "—"}</td>
+                    <td style={{ padding: "0.5rem 0.4rem" }}>{getTenantLabel(p)}</td>
+                    <td style={{ padding: "0.5rem 0.4rem" }}>{getPropertyLabel(p)}</td>
                     <td
                       style={{
                         padding: "0.5rem 0.4rem",
@@ -176,6 +257,41 @@ const PaymentsPage: React.FC = () => {
           </div>
         )}
       </Card>
+
+      <div className="print-only print-only-summary">
+        <div className="printHeader">
+          <div className="printTitle">Payments summary</div>
+          <div className="printMeta">
+            <div>Generated: {new Date().toLocaleString()}</div>
+            <div>Rows: {rows.length}</div>
+          </div>
+        </div>
+        <div className="printH3">Recorded payments</div>
+        <table className="printTable">
+          <thead>
+            <tr>
+              <th>Tenant</th>
+              <th>Property</th>
+              <th>Amount</th>
+              <th>Paid date</th>
+              <th>Method</th>
+              <th>Notes</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((payment) => (
+              <tr key={payment.id}>
+                <td>{getTenantLabel(payment)}</td>
+                <td>{getPropertyLabel(payment)}</td>
+                <td>{payment.amount ? `$${Number(payment.amount).toLocaleString()}` : "$0"}</td>
+                <td>{payment.paidAt ? new Date(payment.paidAt).toLocaleDateString() : "-"}</td>
+                <td>{payment.method || "-"}</td>
+                <td>{String(payment.notes || "").trim() || "-"}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 };

--- a/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.test.tsx
@@ -7,6 +7,7 @@ import PortfolioHealthSummaryPage from "./PortfolioHealthSummaryPage";
 
 const showToast = vi.fn();
 const macShellProps = vi.fn();
+const printSummaryDocumentMock = vi.fn();
 
 vi.mock("../../api/landlordPortfolioHealthApi", () => ({
   fetchLandlordPortfolioHealth: vi.fn(),
@@ -32,6 +33,10 @@ vi.mock("../../components/layout/MacShell", () => ({
   },
 }));
 
+vi.mock("../../utils/printSummary", () => ({
+  printSummaryDocument: (...args: unknown[]) => printSummaryDocumentMock(...args),
+}));
+
 vi.mock("../../components/ui/Ui", () => ({
   Card: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => {
     const { elevated, ...rest } = props;
@@ -54,6 +59,7 @@ vi.mock("@/components/billing/FeatureTeaser", () => ({
 beforeEach(() => {
   showToast.mockReset();
   macShellProps.mockReset();
+  printSummaryDocumentMock.mockReset();
   vi.clearAllMocks();
 });
 
@@ -130,6 +136,40 @@ describe("PortfolioHealthSummaryPage", () => {
     expect(screen.getByText(/Resident feedback patterns/i)).toBeInTheDocument();
     expect(screen.getByText(/Workflow follow-through/i)).toBeInTheDocument();
     expect(macShellProps).toHaveBeenCalledWith(expect.objectContaining({ showTopNav: false }));
+  });
+
+  it("routes print actions through the shared summary print helper", async () => {
+    await mockEntitlements();
+    const { fetchLandlordPortfolioHealth } = await import("../../api/landlordPortfolioHealthApi");
+    vi.mocked(fetchLandlordPortfolioHealth).mockResolvedValue({
+      portfolioHealth: {
+        version: "v1",
+        portfolioId: "landlord-1",
+        generatedAt: "2026-04-16T12:00:00.000Z",
+        overall: {
+          status: "watch",
+          headline: "Your portfolio health is stable overall.",
+          summary: "Most portfolio activity is progressing normally.",
+        },
+        trend: { direction: "stable", summary: "Stable." },
+        dimensions: [],
+        nextFocus: [],
+        metadata: {
+          portfolioScoreGrade: null,
+          portfolioScoreAvailable: true,
+          trendAvailable: true,
+        },
+      },
+    } as { portfolioHealth: LandlordPortfolioHealthSummaryV1 });
+
+    render(
+      <MemoryRouter>
+        <PortfolioHealthSummaryPage />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Print / Save PDF" }));
+    expect(printSummaryDocumentMock).toHaveBeenCalledWith("summary");
   });
 
   it("shows a compact decision-entry hint for lease renewal destinations", async () => {

--- a/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.tsx
@@ -12,6 +12,7 @@ import { useToast } from "../../components/ui/ToastProvider";
 import { useEntitlements } from "@/hooks/useEntitlements";
 import { FeatureTeaser } from "@/components/billing/FeatureTeaser";
 import { resolveRequiredPlanLabel } from "@/lib/upgradePrompt";
+import { printSummaryDocument } from "../../utils/printSummary";
 import PortfolioHealthStatusCard from "../../components/portfolioHealth/PortfolioHealthStatusCard";
 import PortfolioHealthDimensionList from "../../components/portfolioHealth/PortfolioHealthDimensionList";
 import PortfolioHealthNextFocusList from "../../components/portfolioHealth/PortfolioHealthNextFocusList";
@@ -222,7 +223,7 @@ export default function PortfolioHealthSummaryPage() {
             <button
               type="button"
               className="no-print"
-              onClick={() => window.print()}
+              onClick={() => void printSummaryDocument("summary")}
               style={{ padding: "8px 10px", borderRadius: 12, border: "1px solid #E5E7EB", background: "#FFFFFF", fontWeight: 900, cursor: "pointer" }}
             >
               Print / Save PDF

--- a/rentchain-frontend/src/pages/landlord/WorkOrdersPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/WorkOrdersPage.test.tsx
@@ -29,10 +29,12 @@ const mocks = vi.hoisted(() => ({
   uploadWorkOrderCostAttachment: vi.fn(),
   updateWorkOrderEvidence: vi.fn(),
   addWorkOrderUpdate: vi.fn(),
+  exportWorkOrders: vi.fn(),
   getContractorProfileById: vi.fn(),
   fetchContractors: vi.fn(),
   assignContractorToWorkOrder: vi.fn(),
   fetchProperties: vi.fn(),
+  printSummaryDocument: vi.fn(),
 }));
 
 vi.mock("@/hooks/useEntitlements", () => ({
@@ -50,6 +52,7 @@ vi.mock("../../api/workOrdersApi", () => ({
   closeWorkOrderReworkDirectly: mocks.closeWorkOrderReworkDirectly,
   completeWorkOrder: vi.fn(),
   confirmWorkOrderCompletion: mocks.confirmWorkOrderCompletion,
+  exportWorkOrders: mocks.exportWorkOrders,
   getContractorProfileById: mocks.getContractorProfileById,
   getWorkOrder: mocks.getWorkOrder,
   linkWorkOrderCostToExpense: mocks.linkWorkOrderCostToExpense,
@@ -68,6 +71,10 @@ vi.mock("../../api/workOrdersApi", () => ({
   updateWorkOrderEvidence: mocks.updateWorkOrderEvidence,
   uploadWorkOrderCostAttachment: mocks.uploadWorkOrderCostAttachment,
   uploadWorkOrderEvidence: mocks.uploadWorkOrderEvidence,
+}));
+
+vi.mock("../../utils/printSummary", () => ({
+  printSummaryDocument: (...args: unknown[]) => mocks.printSummaryDocument(...args),
 }));
 
 vi.mock("../../api/marketplaceContractorApi", () => ({
@@ -139,10 +146,12 @@ describe("WorkOrdersPage", () => {
     mocks.uploadWorkOrderCostAttachment.mockReset();
     mocks.updateWorkOrderEvidence.mockReset();
     mocks.addWorkOrderUpdate.mockReset();
+    mocks.exportWorkOrders.mockReset();
     mocks.getContractorProfileById.mockReset();
     mocks.fetchContractors.mockReset();
     mocks.assignContractorToWorkOrder.mockReset();
     mocks.fetchProperties.mockReset();
+    mocks.printSummaryDocument.mockReset();
     mocks.fetchProperties.mockResolvedValue({ items: [] });
     mocks.fetchContractors.mockResolvedValue({ items: [] });
   });
@@ -285,7 +294,7 @@ describe("WorkOrdersPage", () => {
     expect(await screen.findByText(/Execution and completion/i)).toBeInTheDocument();
     expect(await screen.findByText(/Action required/i)).toBeInTheDocument();
     expect(screen.getByText(/Review completed rework/i)).toBeInTheDocument();
-    expect(screen.getByText(/Replaced igniter and restored heat/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Replaced igniter and restored heat/i).length).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: /confirm completion/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /approve resolution/i })).toBeInTheDocument();
 
@@ -323,6 +332,42 @@ describe("WorkOrdersPage", () => {
         status: "blocked",
       });
     });
+  });
+
+  it("renders export controls and routes PDF export through the summary print helper", async () => {
+    mocks.canUseWorkOrders = true;
+    mocks.listWorkOrders.mockResolvedValue([
+      {
+        id: "wo-1",
+        landlordId: "landlord-1",
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        title: "Broken heater",
+        description: "Restore heat in unit 3A",
+        category: "HVAC",
+        priority: "urgent",
+        status: "completed",
+        visibility: "private",
+        assignedContractorId: null,
+        invitedContractorIds: [],
+        notesInternal: "",
+        linkedExpenseId: null,
+        createdAtMs: 1,
+        updatedAtMs: 35,
+      },
+    ]);
+    mocks.fetchProperties.mockResolvedValue({ items: [{ id: "prop-1", name: "123 Main St" }] });
+
+    render(
+      <MemoryRouter>
+        <WorkOrdersPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole("button", { name: "Export CSV" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Export Spreadsheet" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Export PDF" }));
+    expect(mocks.printSummaryDocument).toHaveBeenCalledWith("summary");
   });
 
   it("shows contractor marketplace candidates and assigns one to the selected work order", async () => {
@@ -404,7 +449,7 @@ describe("WorkOrdersPage", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText(/Kitchen sink leak/i)).toBeInTheDocument();
+    expect((await screen.findAllByText(/Kitchen sink leak/i)).length).toBeGreaterThan(0);
     fireEvent.click(screen.getByRole("button", { name: /Timeline/i }));
 
     expect(await screen.findByText(/Marketplace contractor assignment/i)).toBeInTheDocument();
@@ -460,7 +505,7 @@ describe("WorkOrdersPage", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText(/Work Orders/i)).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "Create Work Order" })).toBeInTheDocument();
     fireEvent.click(await screen.findByRole("button", { name: /timeline/i }));
     expect(await screen.findByText(/Unlock the contractor directory on Pro/i)).toBeInTheDocument();
     expect(mocks.fetchContractors).not.toHaveBeenCalled();

--- a/rentchain-frontend/src/pages/landlord/WorkOrdersPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/WorkOrdersPage.tsx
@@ -15,6 +15,7 @@ import {
   assignWorkOrderRework,
   closeWorkOrderReworkDirectly,
   confirmWorkOrderCompletion,
+  exportWorkOrders,
   getWorkOrder,
   getContractorProfileById,
   linkWorkOrderCostToExpense,
@@ -39,6 +40,7 @@ import {
   type WorkOrderUpdateRecord,
 } from "../../api/workOrdersApi";
 import { type ExpenseCategory } from "../../api/expensesApi";
+import { printSummaryDocument } from "../../utils/printSummary";
 
 function formatDate(ms?: number | null) {
   if (!ms) return "-";
@@ -251,6 +253,7 @@ export default function WorkOrdersPage() {
   const [convertTarget, setConvertTarget] = React.useState<WorkOrderRecord | null>(null);
   const [convertVendor, setConvertVendor] = React.useState("");
   const [isMobile, setIsMobile] = React.useState(false);
+  const [exporting, setExporting] = React.useState<null | "csv" | "xlsx">(null);
   const [evidenceFile, setEvidenceFile] = React.useState<File | null>(null);
   const [evidenceType, setEvidenceType] = React.useState<WorkOrderEvidenceType>("inspection");
   const [evidenceCaption, setEvidenceCaption] = React.useState("");
@@ -328,6 +331,35 @@ export default function WorkOrdersPage() {
     const province = String(selectedProperty.province || "").trim();
     return [city, province].filter(Boolean).join(", ") || city || province || "";
   }, [selectedProperty]);
+
+  const getPropertyLabel = React.useCallback(
+    (item: WorkOrderRecord) => properties.find((property) => property.id === item.propertyId)?.name || "Property",
+    [properties]
+  );
+
+  const getAssignedContractorLabel = React.useCallback((item: WorkOrderRecord) => {
+    return (
+      String(item.contractorAssignment?.displayName || item.contractorAssignment?.businessName || "").trim() ||
+      (String(item.assignedContractorId || "").trim() ? "Assigned" : "-")
+    );
+  }, []);
+
+  const triggerExport = React.useCallback(async (format: "csv" | "xlsx") => {
+    try {
+      setExporting(format);
+      const { blob, filename } = await exportWorkOrders(format);
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = filename;
+      link.click();
+      window.URL.revokeObjectURL(url);
+    } catch (err: any) {
+      setError(String(err?.message || "Failed to export work orders"));
+    } finally {
+      setExporting(null);
+    }
+  }, []);
 
   const markCompleted = React.useCallback(
     async (item: WorkOrderRecord) => {
@@ -885,6 +917,15 @@ export default function WorkOrdersPage() {
           <div style={{ color: "#64748b", marginTop: 4 }}>Create, assign, and track landlord maintenance jobs.</div>
         </div>
         <div style={{ display: "flex", gap: 8 }}>
+          <Button variant="secondary" onClick={() => void triggerExport("csv")} disabled={exporting !== null}>
+            {exporting === "csv" ? "Exporting..." : "Export CSV"}
+          </Button>
+          <Button variant="secondary" onClick={() => void triggerExport("xlsx")} disabled={exporting !== null}>
+            {exporting === "xlsx" ? "Exporting..." : "Export Spreadsheet"}
+          </Button>
+          <Button variant="secondary" onClick={() => void printSummaryDocument("summary")}>
+            Export PDF
+          </Button>
           <Button variant="secondary" onClick={() => void load()}>
             Refresh
           </Button>
@@ -897,6 +938,94 @@ export default function WorkOrdersPage() {
       {error ? (
         <Card style={{ borderColor: "#ef4444", color: "#991b1b" }}>{error}</Card>
       ) : null}
+
+      <div className="print-only print-only-summary">
+        <div className="printHeader">
+          <div className="printTitle">Work orders summary</div>
+          <div className="printMeta">
+            <div>Generated: {new Date().toLocaleString()}</div>
+            <div>Rows: {items.length}</div>
+          </div>
+        </div>
+        <div className="printH3">Work orders</div>
+        <table className="printTable">
+          <thead>
+            <tr>
+              <th>Title</th>
+              <th>Property</th>
+              <th>Category</th>
+              <th>Priority</th>
+              <th>Status</th>
+              <th>Assigned contractor</th>
+              <th>Scheduled</th>
+              <th>Started</th>
+              <th>Completed</th>
+              <th>Comments</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((item) => (
+              <tr key={item.id}>
+                <td>{item.title}</td>
+                <td>{getPropertyLabel(item)}</td>
+                <td>{item.category || "-"}</td>
+                <td>{item.priority || "-"}</td>
+                <td>{item.status || "-"}</td>
+                <td>{getAssignedContractorLabel(item)}</td>
+                <td>{formatDate(item.scheduledFor)}</td>
+                <td>{formatDate(item.serviceStartedAt)}</td>
+                <td>{formatDate(item.serviceCompletedAt)}</td>
+                <td>{String(item.completionSummary || "").trim() || "-"}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {selected ? (
+          <>
+            <div className="printH3">Selected work order</div>
+            <table className="printTable">
+              <tbody>
+                <tr><th>Title</th><td>{selected.title}</td></tr>
+                <tr><th>Property</th><td>{getPropertyLabel(selected)}</td></tr>
+                <tr><th>Category</th><td>{selected.category || "-"}</td></tr>
+                <tr><th>Priority</th><td>{selected.priority || "-"}</td></tr>
+                <tr><th>Status</th><td>{selected.status || "-"}</td></tr>
+                <tr><th>Assigned contractor</th><td>{getAssignedContractorLabel(selected)}</td></tr>
+                <tr><th>Scheduled for</th><td>{formatDate(selected.scheduledFor)}</td></tr>
+                <tr><th>Service started</th><td>{formatDate(selected.serviceStartedAt)}</td></tr>
+                <tr><th>Service completed</th><td>{formatDate(selected.serviceCompletedAt)}</td></tr>
+                <tr><th>Completion outcome</th><td>{completionOutcomeLabel(selected.completionOutcome)}</td></tr>
+                <tr><th>Resolution status</th><td>{resolutionStatusLabel(selected.resolutionStatus)}</td></tr>
+                <tr><th>Completion summary</th><td>{String(selected.completionSummary || "").trim() || "-"}</td></tr>
+                <tr><th>Blocked reason</th><td>{String(selected.executionBlockedReason || "").trim() || "-"}</td></tr>
+              </tbody>
+            </table>
+            {updates.length ? (
+              <>
+                <div className="printH3">Latest comments</div>
+                <table className="printTable">
+                  <thead>
+                    <tr>
+                      <th>When</th>
+                      <th>Type</th>
+                      <th>Comment</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {updates.map((update) => (
+                      <tr key={update.id}>
+                        <td>{formatDate(update.createdAtMs)}</td>
+                        <td>{update.updateType}</td>
+                        <td>{String(update.message || "").trim() || "-"}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </>
+            ) : null}
+          </>
+        ) : null}
+      </div>
 
       <div style={{ display: "grid", gap: 12, gridTemplateColumns: "minmax(0,1fr)", alignItems: "start" }}>
         <Card>

--- a/rentchain-frontend/src/utils/printSummary.ts
+++ b/rentchain-frontend/src/utils/printSummary.ts
@@ -1,0 +1,19 @@
+export async function printSummaryDocument(mode: "summary" = "summary"): Promise<void> {
+  if (typeof window === "undefined" || typeof document === "undefined") return;
+
+  const body = document.body;
+  const previousMode = body.getAttribute("data-print-mode");
+  body.setAttribute("data-print-mode", mode);
+
+  try {
+    window.print();
+  } finally {
+    window.setTimeout(() => {
+      if (previousMode) {
+        body.setAttribute("data-print-mode", previousMode);
+      } else {
+        body.removeAttribute("data-print-mode");
+      }
+    }, 0);
+  }
+}


### PR DESCRIPTION
This PR introduces Reporting / Export Reliability v1.

Includes:
- shared browser print/save PDF helper
- portfolio health print/save PDF repair
- payments CSV/XLSX export routes and frontend buttons
- payments browser-print PDF summary
- work-orders CSV/XLSX export routes and frontend buttons
- work-orders browser-print PDF summary
- maintenance PDF summary
- expenses export controls moved into the header
- focused backend/frontend test coverage

Guardrails preserved:
- no new PDF library
- no payment behavior changes
- no billing/provider changes
- no data migrations
- no unrelated mobile/layout/messages/contractor/analytics-tab work
- no raw IDs, evidence URLs, attachments, or internal actor IDs in exports