### PR TITLE
fix: sanitize maintenance labels

### DIFF
--- a/rentchain-frontend/src/pages/MaintenanceRequestsPage.test.tsx
+++ b/rentchain-frontend/src/pages/MaintenanceRequestsPage.test.tsx
@@ -567,4 +567,42 @@ describe("landlord maintenance workspace", () => {
     expect(screen.getAllByText(/Unit 102/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Reopened \/ escalated/i).length).toBeGreaterThan(0);
   });
+
+  it("uses safe placeholders instead of raw ids when maintenance labels are missing", async () => {
+    maintenanceWorkflowApi.listLandlordMaintenance.mockResolvedValue({
+      items: [
+        {
+          id: "maint-1",
+          tenantId: "tenant-1",
+          landlordId: "landlord-1",
+          propertyId: "prop-1",
+          unitId: "unit-2",
+          tenantName: "",
+          propertyLabel: "",
+          unitLabel: "",
+          title: "Broken heater",
+          description: "Heat is not turning on.",
+          category: "HVAC",
+          priority: "urgent",
+          status: "submitted",
+          createdAt: 100,
+          updatedAt: 200,
+          statusHistory: [],
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/maintenance/maint-1"]}>
+        <Routes>
+          <Route path="/maintenance/:id" element={<MaintenanceRequestsPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findAllByText("Tenant • Property")).not.toHaveLength(0);
+    expect(screen.queryByText(/tenant-1/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/prop-1/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/unit-2/i)).not.toBeInTheDocument();
+  });
 });

--- a/rentchain-frontend/src/pages/MaintenanceRequestsPage.tsx
+++ b/rentchain-frontend/src/pages/MaintenanceRequestsPage.tsx
@@ -95,6 +95,18 @@ function fromLocalInputValue(value: string) {
   return Number.isNaN(parsed.getTime()) ? null : parsed.getTime();
 }
 
+function displayTenantLabel(item: Pick<MaintenanceWorkflowItem, "tenantName">) {
+  return String(item.tenantName || "").trim() || "Tenant";
+}
+
+function displayPropertyLabel(item: Pick<MaintenanceWorkflowItem, "propertyLabel">) {
+  return String(item.propertyLabel || "").trim() || "Property";
+}
+
+function displayUnitLabel(item: Pick<MaintenanceWorkflowItem, "unitLabel">) {
+  return String(item.unitLabel || "").trim();
+}
+
 function startOfCalendarMonth(value: Date) {
   const monthStart = new Date(value.getFullYear(), value.getMonth(), 1);
   const offset = monthStart.getDay();
@@ -1142,8 +1154,8 @@ export default function MaintenanceRequestsPage() {
                       >
                         <div style={{ fontWeight: 800, color: text.primary }}>{item.title}</div>
                         <div style={{ color: text.secondary, fontSize: 12 }}>
-                          {item.tenantName || item.tenantId} • {item.propertyLabel || item.propertyId || "No property"}
-                          {item.unitLabel ? ` • ${item.unitLabel}` : ""}
+                          {displayTenantLabel(item)} • {displayPropertyLabel(item)}
+                          {displayUnitLabel(item) ? ` • ${displayUnitLabel(item)}` : ""}
                         </div>
                         <div style={{ display: "flex", gap: 6, flexWrap: "wrap", alignItems: "center" }}>
                           <span
@@ -1219,8 +1231,8 @@ export default function MaintenanceRequestsPage() {
                     <div>
                       <div style={{ fontSize: "1.2rem", fontWeight: 800, color: text.primary }}>{selected.title}</div>
                       <div style={{ color: text.muted, marginTop: 4 }}>
-                        {selected.tenantName || selected.tenantId} • {selected.propertyLabel || selected.propertyId || "No property"}
-                        {selected.unitLabel ? ` • ${selected.unitLabel}` : ""}
+                        {displayTenantLabel(selected)} • {displayPropertyLabel(selected)}
+                        {displayUnitLabel(selected) ? ` • ${displayUnitLabel(selected)}` : ""}
                       </div>
                     </div>
                     <div

--- a/rentchain-frontend/src/pages/maintenancePortfolioCostRollupState.test.ts
+++ b/rentchain-frontend/src/pages/maintenancePortfolioCostRollupState.test.ts
@@ -92,4 +92,20 @@ describe("maintenance portfolio cost rollup state", () => {
     expect(view.propertySummaries[0]?.propertyLabel).toBe("Maple Court");
     expect(view.propertySummaries[1]?.propertyLabel).toBe("Harbour View");
   });
+
+  it("uses safe placeholder labels when property or unit labels are missing", () => {
+    const view = buildMaintenancePortfolioCostRollupView([
+      makeItem({
+        propertyId: "prop-1",
+        propertyLabel: "",
+        unitId: "unit-1",
+        unitLabel: "",
+      }),
+    ]);
+
+    expect(view.propertySummaries[0]?.propertyLabel).toBe("Unassigned property");
+    expect(view.propertySummaries[0]?.unitSummaries[0]?.unitLabel).toBe("General property area");
+    expect(view.propertySummaries[0]?.propertyLabel).not.toMatch(/prop-/i);
+    expect(view.propertySummaries[0]?.unitSummaries[0]?.unitLabel).not.toMatch(/unit-/i);
+  });
 });

--- a/rentchain-frontend/src/pages/maintenancePortfolioCostRollupState.ts
+++ b/rentchain-frontend/src/pages/maintenancePortfolioCostRollupState.ts
@@ -52,11 +52,11 @@ function normalizedStatus(item: MaintenanceWorkflowItem) {
 }
 
 function propertyLabel(item: MaintenanceWorkflowItem) {
-  return String(item.propertyLabel || item.propertyId || "Unassigned property").trim() || "Unassigned property";
+  return String(item.propertyLabel || "").trim() || "Unassigned property";
 }
 
 function unitLabel(item: MaintenanceWorkflowItem) {
-  return String(item.unitLabel || item.unitId || "General property area").trim() || "General property area";
+  return String(item.unitLabel || "").trim() || "General property area";
 }
 
 function recordedCostCents(item: MaintenanceWorkflowItem) {

--- a/rentchain-frontend/src/pages/propertyFinancialIntelligenceState.test.ts
+++ b/rentchain-frontend/src/pages/propertyFinancialIntelligenceState.test.ts
@@ -107,4 +107,20 @@ describe("property financial intelligence state", () => {
     expect(view.propertySummaries[0]?.topUnitLabel).toBe("Unit 101");
     expect(view.propertySummaries[0]?.unitActivityLabel).toMatch(/carries most visible maintenance activity/i);
   });
+
+  it("inherits safe placeholder labels from maintenance rollups when labels are missing", () => {
+    const view = buildPropertyFinancialIntelligenceView([
+      makeItem({
+        propertyId: "prop-1",
+        propertyLabel: "",
+        unitId: "unit-1",
+        unitLabel: "",
+      }),
+    ]);
+
+    expect(view.propertySummaries[0]?.propertyLabel).toBe("Unassigned property");
+    expect(view.propertySummaries[0]?.topUnitLabel).toBe("General property area");
+    expect(view.propertySummaries[0]?.propertyLabel).not.toMatch(/prop-/i);
+    expect(view.propertySummaries[0]?.topUnitLabel).not.toMatch(/unit-/i);
+  });
 });


### PR DESCRIPTION
This PR fixes landlord-facing maintenance labels.

Includes:
- safe tenant/property/unit fallbacks on maintenance request rows
- safe selected request detail labels
- sanitized property/unit labels in maintenance rollups
- property intelligence views inheriting sanitized labels
- focused frontend test coverage

Guardrails preserved:
- frontend-only
- no backend projection changes
- no workflow/status changes
- no permission changes
- no contractor/export/messages/mobile/analytics work
- no raw tenantId/propertyId/unitId fallback text in normal landlord UI