### PR TITLE
fix: repair dashboard lease notice flow

### DIFF
--- a/rentchain-api/src/routes/__tests__/leaseNoticeLandlordRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseNoticeLandlordRoutes.test.ts
@@ -13,6 +13,25 @@ const { collections, dbMock } = vi.hoisted(() => {
 
   const dbMock = {
     collection: (name: string) => ({
+      where: (field: string, _op: string, value: any) => ({
+        limit: (_count: number) => ({
+          get: async () => {
+            const docs = Array.from(ensureCollection(name).entries())
+              .filter(([, data]) => data?.[field] === value)
+              .map(([id, data]) => ({ id, data: () => data }));
+            return { docs, empty: docs.length === 0, size: docs.length };
+          },
+        }),
+      }),
+      limit: (_count: number) => ({
+        get: async () => {
+          const docs = Array.from(ensureCollection(name).entries()).map(([id, data]) => ({
+            id,
+            data: () => data,
+          }));
+          return { docs, empty: docs.length === 0, size: docs.length };
+        },
+      }),
       doc: (id?: string) => {
         const docId = id || `${name}_${++autoId}`;
         return {
@@ -64,6 +83,7 @@ vi.mock("../../config/leaseNoticeRules", () => ({
 
 const appendLeaseWorkflowEvent = vi.fn(async () => undefined);
 const buildPreview = vi.fn(async () => undefined);
+const computeNoResponseStateMock = vi.fn(() => false);
 const deriveLeaseRenewalOperatorInputRecord = vi.fn((lease: any) => ({
   rentChangeMode: lease?.renewalRentChangeMode ?? null,
   proposedRent: lease?.renewalOfferedRent ?? null,
@@ -108,7 +128,7 @@ const getLeaseForLandlordWorkflow = vi.fn(async () => ({
 vi.mock("../../services/leaseNoticeWorkflowService", () => ({
   appendLeaseWorkflowEvent,
   buildPreview,
-  computeNoResponseState: vi.fn(),
+  computeNoResponseState: computeNoResponseStateMock,
   deriveLeaseRenewalOperatorInputRecord,
   getLeaseForLandlordWorkflow,
   getLeaseNoticeByLeaseId: vi.fn(),
@@ -121,13 +141,15 @@ vi.mock("../../services/leaseNoticeWorkflowService", () => ({
 
 async function invokeRouter(router: any, options: { method: string; url: string; body?: any }) {
   return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const parsedUrl = new URL(options.url, "http://localhost");
     const req: any = {
       method: options.method,
       url: options.url,
       originalUrl: options.url,
-      path: options.url,
+      path: parsedUrl.pathname,
       body: options.body ?? {},
       headers: {},
+      query: Object.fromEntries(parsedUrl.searchParams.entries()),
     };
     const res: any = {
       statusCode: 200,
@@ -158,6 +180,7 @@ describe("leaseNoticeLandlordRoutes policy integration", () => {
   beforeEach(() => {
     collections.clear();
     vi.clearAllMocks();
+    computeNoResponseStateMock.mockReturnValue(false);
     normalizeLeaseRecord.mockImplementation((id: string, raw: any) => ({ id, ...(raw || {}) }));
     sanitizeLeaseRenewalOperatorInput.mockImplementation((body: any) => ({
       ok: true,
@@ -315,5 +338,107 @@ describe("leaseNoticeLandlordRoutes policy integration", () => {
         responseDeadlineAt: 1700000000000,
       })
     );
+  });
+
+  it("returns only expiring workflow items when the expiring status filter is requested", async () => {
+    if (!collections.has("leases")) collections.set("leases", new Map());
+    if (!collections.has("leaseNotices")) collections.set("leaseNotices", new Map());
+    collections.get("leases")?.set("lease-expiring", {
+      landlordId: "landlord-1",
+      propertyId: "property-1",
+      unitId: "unit-1",
+      status: "active",
+      nextNoticeDueAt: Date.now() + 5 * 24 * 60 * 60 * 1000,
+    });
+    collections.get("leases")?.set("lease-pending", {
+      landlordId: "landlord-1",
+      propertyId: "property-1",
+      unitId: "unit-2",
+      status: "renewal_pending",
+      nextNoticeDueAt: Date.now() + 5 * 24 * 60 * 60 * 1000,
+    });
+    collections.get("leaseNotices")?.set("notice-pending", {
+      landlordId: "landlord-1",
+      leaseId: "lease-pending",
+      tenantResponse: "pending",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+
+    const router = (await import("../leaseNoticeLandlordRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/expiring?status=expiring",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.items).toHaveLength(1);
+    expect(res.body?.items[0]).toEqual(expect.objectContaining({ id: "lease-expiring", noticeBucket: "expiring" }));
+  });
+
+  it("returns only pending-response workflow items when that status filter is requested", async () => {
+    if (!collections.has("leases")) collections.set("leases", new Map());
+    if (!collections.has("leaseNotices")) collections.set("leaseNotices", new Map());
+    collections.get("leases")?.set("lease-expiring", {
+      landlordId: "landlord-1",
+      propertyId: "property-1",
+      unitId: "unit-1",
+      status: "active",
+      nextNoticeDueAt: Date.now() + 5 * 24 * 60 * 60 * 1000,
+    });
+    collections.get("leases")?.set("lease-pending", {
+      landlordId: "landlord-1",
+      propertyId: "property-1",
+      unitId: "unit-2",
+      status: "renewal_pending",
+      nextNoticeDueAt: Date.now() + 5 * 24 * 60 * 60 * 1000,
+    });
+    collections.get("leaseNotices")?.set("notice-pending", {
+      landlordId: "landlord-1",
+      leaseId: "lease-pending",
+      tenantResponse: "pending",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+
+    const router = (await import("../leaseNoticeLandlordRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/expiring?status=pending-response",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.items).toHaveLength(1);
+    expect(res.body?.items[0]).toEqual(expect.objectContaining({ id: "lease-pending", noticeBucket: "pending-response" }));
+  });
+
+  it("returns only no-response workflow items when that status filter is requested", async () => {
+    computeNoResponseStateMock.mockImplementation((notice: any) => String(notice?.leaseId || "").trim() === "lease-no-response");
+    if (!collections.has("leases")) collections.set("leases", new Map());
+    if (!collections.has("leaseNotices")) collections.set("leaseNotices", new Map());
+    collections.get("leases")?.set("lease-no-response", {
+      landlordId: "landlord-1",
+      propertyId: "property-1",
+      unitId: "unit-3",
+      status: "renewal_pending",
+      nextNoticeDueAt: Date.now() + 5 * 24 * 60 * 60 * 1000,
+    });
+    collections.get("leaseNotices")?.set("notice-no-response", {
+      landlordId: "landlord-1",
+      leaseId: "lease-no-response",
+      tenantResponse: "pending",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+
+    const router = (await import("../leaseNoticeLandlordRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/expiring?status=no-response",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.items).toHaveLength(1);
+    expect(res.body?.items[0]).toEqual(expect.objectContaining({ id: "lease-no-response", noticeBucket: "no-response" }));
   });
 });

--- a/rentchain-api/src/routes/leaseNoticeLandlordRoutes.ts
+++ b/rentchain-api/src/routes/leaseNoticeLandlordRoutes.ts
@@ -46,6 +46,30 @@ function isAutomationRequested(body: any) {
   return Boolean(body?.automationEnabled || body?.automation?.enabled);
 }
 
+type LeaseRenewalWorkflowBucket = "expiring" | "pending-response" | "no-response";
+
+function asLeaseRenewalWorkflowBucket(value: unknown): LeaseRenewalWorkflowBucket | null {
+  const raw = String(value || "").trim().toLowerCase();
+  if (raw === "expiring" || raw === "pending-response" || raw === "no-response") return raw;
+  return null;
+}
+
+function deriveLeaseRenewalWorkflowBucket(params: {
+  lease: any;
+  latestNotice: any | null;
+  now: number;
+  horizon: number;
+}): LeaseRenewalWorkflowBucket | null {
+  const { lease, latestNotice, now, horizon } = params;
+  const noResponse = latestNotice ? computeNoResponseState(latestNotice) : false;
+  if (noResponse) return "no-response";
+  const response = String(latestNotice?.tenantResponse || "pending").trim().toLowerCase();
+  if (latestNotice && response === "pending") return "pending-response";
+  const dueAt = Number(lease?.nextNoticeDueAt || 0);
+  if (dueAt > 0 && dueAt >= now && dueAt <= horizon) return "expiring";
+  return null;
+}
+
 async function performLeaseNoticeSend(params: {
   leaseId: string;
   landlordId: string;
@@ -79,19 +103,45 @@ router.get("/expiring", async (req: any, res) => {
     const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
     const withinDays = Math.max(1, Number(req.query?.withinDays || 120));
     const propertyId = String(req.query?.propertyId || "").trim();
+    const statusFilter = asLeaseRenewalWorkflowBucket(req.query?.status);
     const now = Date.now();
     const horizon = now + withinDays * 24 * 60 * 60 * 1000;
-    const snap = await db.collection("leases").where("landlordId", "==", landlordId).limit(400).get();
-    const items = snap.docs
+    const [leaseSnap, noticeSnap] = await Promise.all([
+      db.collection("leases").where("landlordId", "==", landlordId).limit(400).get(),
+      db.collection("leaseNotices").where("landlordId", "==", landlordId).limit(400).get(),
+    ]);
+    const latestNoticeByLeaseId = new Map<string, any>();
+    const leaseNotices = noticeSnap.docs
+      .map((doc) => ({ id: doc.id, ...(doc.data() as any) }))
+      .sort((a, b) => Number(b.updatedAt || b.createdAt || 0) - Number(a.updatedAt || a.createdAt || 0));
+    for (const notice of leaseNotices) {
+      const leaseId = String(notice?.leaseId || "").trim();
+      if (!leaseId || latestNoticeByLeaseId.has(leaseId)) continue;
+      latestNoticeByLeaseId.set(leaseId, notice);
+    }
+
+    const items = leaseSnap.docs
       .map((doc) => normalizeLeaseRecord(doc.id, doc.data() as any))
       .filter((lease) => !propertyId || lease.propertyId === propertyId)
       .filter((lease) => lease.status === "active" || lease.status === "notice_pending" || lease.status === "renewal_pending")
-      .filter((lease) => !!lease.nextNoticeDueAt && Number(lease.nextNoticeDueAt) <= horizon)
+      .map((lease) => {
+        const latestNotice = latestNoticeByLeaseId.get(lease.id) || null;
+        const noticeBucket = deriveLeaseRenewalWorkflowBucket({
+          lease,
+          latestNotice,
+          now,
+          horizon,
+        });
+        return noticeBucket ? { ...lease, noticeBucket } : null;
+      })
+      .filter((lease): lease is ReturnType<typeof normalizeLeaseRecord> & { noticeBucket: LeaseRenewalWorkflowBucket } => Boolean(lease))
+      .filter((lease: any) => !statusFilter || lease.noticeBucket === statusFilter)
       .sort((a, b) => Number(a.nextNoticeDueAt || 0) - Number(b.nextNoticeDueAt || 0));
 
     console.info("[lease-notice] expiring-list", {
       landlordId,
       withinDays,
+      statusFilter,
       count: items.length,
     });
 

--- a/rentchain-frontend/src/api/landlordLeaseRenewalApi.ts
+++ b/rentchain-frontend/src/api/landlordLeaseRenewalApi.ts
@@ -32,14 +32,20 @@ export type LandlordLeaseRenewalLease = {
   renewalNewTermType: "fixed_term" | "year_to_year" | "month_to_month" | null;
   renewalNewLeaseStartDate: string | null;
   renewalNewLeaseEndDate: string | null;
+  noticeBucket?: "expiring" | "pending-response" | "no-response";
 };
 
-export function fetchExpiringLeaseRenewals(params?: { propertyId?: string | null; withinDays?: number }) {
+export function fetchExpiringLeaseRenewals(params?: {
+  propertyId?: string | null;
+  withinDays?: number;
+  status?: "expiring" | "pending-response" | "no-response" | null;
+}) {
   const search = new URLSearchParams();
   if (params?.propertyId) search.set("propertyId", params.propertyId);
   if (typeof params?.withinDays === "number" && Number.isFinite(params.withinDays)) {
     search.set("withinDays", String(params.withinDays));
   }
+  if (params?.status) search.set("status", params.status);
   const suffix = search.size ? `?${search.toString()}` : "";
   return apiFetch<{ ok: true; items: LandlordLeaseRenewalLease[]; data: LandlordLeaseRenewalLease[] }>(
     `/landlord/leases/expiring${suffix}`

--- a/rentchain-frontend/src/pages/DashboardPage.test.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.test.tsx
@@ -439,15 +439,15 @@ describe("DashboardPage", () => {
 
     expect(await screen.findByRole("link", { name: /Expiring soon/i })).toHaveAttribute(
       "href",
-      "/portfolio-health?entry=lease-renewals"
+      "/portfolio-health?entry=lease-renewals&status=expiring"
     );
     expect(screen.getByRole("link", { name: /Pending response/i })).toHaveAttribute(
       "href",
-      "/portfolio-health?entry=lease-renewals"
+      "/portfolio-health?entry=lease-renewals&status=pending-response"
     );
     expect(screen.getByRole("link", { name: /No response/i })).toHaveAttribute(
       "href",
-      "/portfolio-health?entry=lease-renewals"
+      "/portfolio-health?entry=lease-renewals&status=no-response"
     );
     expect(screen.getByRole("link", { name: /Renewed/i })).toHaveAttribute("href", "/leases?view=active");
     expect(screen.getByRole("link", { name: /Quitting/i })).toHaveAttribute("href", "/leases?view=active");

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -680,11 +680,11 @@ const DashboardPage: React.FC = () => {
               }}
             >
               {[
-                { label: "Expiring soon", value: leaseNoticeSummary.expiringSoon, href: "/portfolio-health?entry=lease-renewals" },
-                { label: "Pending response", value: leaseNoticeSummary.pendingResponse, href: "/portfolio-health?entry=lease-renewals" },
+                { label: "Expiring soon", value: leaseNoticeSummary.expiringSoon, href: "/portfolio-health?entry=lease-renewals&status=expiring" },
+                { label: "Pending response", value: leaseNoticeSummary.pendingResponse, href: "/portfolio-health?entry=lease-renewals&status=pending-response" },
                 { label: "Renewed", value: leaseNoticeSummary.renewed, href: "/leases?view=active" },
                 { label: "Quitting", value: leaseNoticeSummary.quitting, href: "/leases?view=active" },
-                { label: "No response", value: leaseNoticeSummary.noResponse, href: "/portfolio-health?entry=lease-renewals" },
+                { label: "No response", value: leaseNoticeSummary.noResponse, href: "/portfolio-health?entry=lease-renewals&status=no-response" },
               ].map((item) => (
                 <Link
                   key={item.label}

--- a/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.test.tsx
@@ -231,14 +231,19 @@ describe("PortfolioHealthSummaryPage", () => {
     });
 
     render(
-      <MemoryRouter initialEntries={["/portfolio-health?entry=lease-renewals&propertyId=prop-2"]}>
+      <MemoryRouter initialEntries={["/portfolio-health?entry=lease-renewals&propertyId=prop-2&status=expiring"]}>
         <PortfolioHealthSummaryPage />
       </MemoryRouter>
     );
 
     expect(await screen.findByText(/Opened from decisions to review lease-renewal pressure/i)).toBeInTheDocument();
-    expect(await screen.findByText(/Lease renewal operator inputs/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Expiring soon leases/i)).toBeInTheDocument();
+    expect(screen.getByText(/Showing leases approaching notice timing/i)).toBeInTheDocument();
     expect(screen.getByText(/Taylor Tenant/i)).toBeInTheDocument();
+    expect(fetchExpiringLeaseRenewals).toHaveBeenCalledWith({
+      propertyId: "prop-2",
+      status: "expiring",
+    });
   });
 
   it("saves lease renewal operator inputs from the decision-entry workflow surface", async () => {

--- a/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.tsx
@@ -27,6 +27,8 @@ type LeaseRenewalFormState = {
   responseDeadlineAt: string;
 };
 
+type LeaseRenewalStatusScope = "expiring" | "pending-response" | "no-response";
+
 function toDatetimeLocalInput(value: number | null) {
   if (!value) return "";
   const date = new Date(value);
@@ -72,12 +74,33 @@ export default function PortfolioHealthSummaryPage() {
   const entryParams = React.useMemo(() => new URLSearchParams(location.search), [location.search]);
   const entry = entryParams.get("entry");
   const entryPropertyId = entryParams.get("propertyId");
+  const entryStatus = (() => {
+    const raw = String(entryParams.get("status") || "").trim().toLowerCase();
+    if (raw === "expiring" || raw === "pending-response" || raw === "no-response") return raw as LeaseRenewalStatusScope;
+    return null;
+  })();
   const entryMessage =
     entry === "lease-renewals"
       ? entryPropertyId
         ? "Opened from decisions to review lease-renewal pressure for a specific property."
         : "Opened from decisions to review lease-renewal pressure."
       : null;
+  const scopedRenewalHeading =
+    entryStatus === "expiring"
+      ? "Expiring soon leases"
+      : entryStatus === "pending-response"
+      ? "Pending response leases"
+      : entryStatus === "no-response"
+      ? "No response leases"
+      : "Lease renewal operator inputs";
+  const scopedRenewalHelper =
+    entryStatus === "expiring"
+      ? "Showing leases approaching notice timing so renewal inputs can be prepared before the notice window closes."
+      : entryStatus === "pending-response"
+      ? "Showing leases with a sent notice that are still awaiting a tenant response."
+      : entryStatus === "no-response"
+      ? "Showing leases where the tenant response window has elapsed without a reply."
+      : "Save renewal term and deadline choices on the lease record so readiness checks can observe them canonically.";
 
   React.useEffect(() => {
     if (entitlementLoading || !canViewPortfolioHealthSummary) return;
@@ -118,6 +141,7 @@ export default function PortfolioHealthSummaryPage() {
         setRenewalError(null);
         const response = await fetchExpiringLeaseRenewals({
           propertyId: entryPropertyId,
+          status: entryStatus,
         });
         if (!mounted) return;
         const items = response.items || [];
@@ -144,7 +168,7 @@ export default function PortfolioHealthSummaryPage() {
     return () => {
       mounted = false;
     };
-  }, [canViewPortfolioHealthSummary, entitlementLoading, entry, entryPropertyId, showToast]);
+  }, [canViewPortfolioHealthSummary, entitlementLoading, entry, entryPropertyId, entryStatus, showToast]);
 
   const scorePlanLabel = resolveRequiredPlanLabel("portfolio_score") || "Pro";
   const recommendationsPlanLabel =
@@ -275,10 +299,8 @@ export default function PortfolioHealthSummaryPage() {
         {entry === "lease-renewals" ? (
           <Card style={{ display: "grid", gap: 16 }}>
             <div style={{ display: "grid", gap: 4 }}>
-              <div style={{ fontWeight: 700 }}>Lease renewal operator inputs</div>
-              <div style={{ color: "#475569" }}>
-                Save renewal term and deadline choices on the lease record so readiness checks can observe them canonically.
-              </div>
+              <div style={{ fontWeight: 700 }}>{scopedRenewalHeading}</div>
+              <div style={{ color: "#475569" }}>{scopedRenewalHelper}</div>
             </div>
 
             {renewalLoading ? <div>Loading lease renewal inputs…</div> : null}


### PR DESCRIPTION
This PR repairs the dashboard lease notice flow.
Includes:
- dashboard Lease Notice Status links with scoped status destinations
- expiring/pending-response/no-response lease renewal entry points
- normalized notice workflow bucket support on landlord expiring leases
- portfolio health lease-renewals scoped heading/helper state
- focused backend/frontend test coverage
Guardrails preserved:
- no broad dashboard redesign
- no tenant notice UX changes
- no data migration
- no permission expansion
- no analytics/inbox/messages/export/payment/contractor work
- no lease document access changes