### PR TITLE
fix: hide cancelled viewing requests

### DIFF
--- a/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
@@ -199,11 +199,25 @@ vi.mock("@/components/integrations/UpdateTransUnionCredentialsModal", () => ({
 }));
 
 vi.mock("@/components/viewings/ViewingRequestList", () => ({
-  ViewingRequestList: () => <div>Viewing Request List</div>,
+  ViewingRequestList: ({ requests, selectedId, onSelect }: any) => (
+    <div data-testid="viewing-request-list">
+      {requests.length ? (
+        requests.map((request: any) => (
+          <button key={request.id} type="button" onClick={() => onSelect(request.id)}>
+            {request.applicantName} | {request.status} {selectedId === request.id ? "(selected)" : ""}
+          </button>
+        ))
+      ) : (
+        <div>No viewing requests yet.</div>
+      )}
+    </div>
+  ),
 }));
 
 vi.mock("@/components/viewings/ViewingRequestDetail", () => ({
-  ViewingRequestDetail: () => <div>Viewing Request Detail</div>,
+  ViewingRequestDetail: ({ request }: any) => (
+    <div>{request ? `Viewing Request Detail: ${request.applicantName}` : "Select a viewing request to review details."}</div>
+  ),
 }));
 
 vi.mock("@/components/screening/ScreeningHistoryTable", () => ({
@@ -371,6 +385,150 @@ describe("ApplicationsPage", () => {
     expect(container.querySelector(".rc-viewing-requests-detail-pane")).toBeTruthy();
     expect(container.querySelector(".rc-applications-list-scroll")).toBeTruthy();
     expect(container.querySelector(".rc-applications-detail")).toBeTruthy();
+  });
+
+  it("hides cancelled viewing requests by default and preserves active ordering", async () => {
+    mocks.fetchViewingRequests.mockResolvedValueOnce([
+      {
+        id: "view-3",
+        applicantName: "Scheduled Applicant",
+        applicantEmail: "scheduled@example.com",
+        applicantPhone: null,
+        requestedMessage: null,
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        applicationId: null,
+        status: "scheduled",
+        proposedSlots: [],
+        selectedSlot: null,
+        requestedAt: "2026-04-03T10:00:00.000Z",
+        createdAt: "2026-04-03T10:00:00.000Z",
+        updatedAt: "2026-04-03T10:00:00.000Z",
+      },
+      {
+        id: "view-2",
+        applicantName: "Cancelled Applicant",
+        applicantEmail: "cancelled@example.com",
+        applicantPhone: null,
+        requestedMessage: null,
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        applicationId: null,
+        status: "cancelled",
+        proposedSlots: [],
+        selectedSlot: null,
+        requestedAt: "2026-04-02T10:00:00.000Z",
+        createdAt: "2026-04-02T10:00:00.000Z",
+        updatedAt: "2026-04-02T10:00:00.000Z",
+      },
+      {
+        id: "view-1",
+        applicantName: "Requested Applicant",
+        applicantEmail: "requested@example.com",
+        applicantPhone: null,
+        requestedMessage: null,
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        applicationId: null,
+        status: "requested",
+        proposedSlots: [],
+        selectedSlot: null,
+        requestedAt: "2026-04-01T10:00:00.000Z",
+        createdAt: "2026-04-01T10:00:00.000Z",
+        updatedAt: "2026-04-01T10:00:00.000Z",
+      },
+    ]);
+
+    render(
+      <MemoryRouter>
+        <ApplicationsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Scheduled Applicant | scheduled (selected)")).toBeInTheDocument();
+    expect(screen.getByText("Requested Applicant | requested")).toBeInTheDocument();
+    expect(screen.queryByText(/Cancelled Applicant/)).not.toBeInTheDocument();
+    expect(screen.getByText("Viewing Request Detail: Scheduled Applicant")).toBeInTheDocument();
+  });
+
+  it("reveals cancelled viewing requests when the toggle is enabled", async () => {
+    mocks.fetchViewingRequests.mockResolvedValueOnce([
+      {
+        id: "view-2",
+        applicantName: "Cancelled Applicant",
+        applicantEmail: "cancelled@example.com",
+        applicantPhone: null,
+        requestedMessage: null,
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        applicationId: null,
+        status: "cancelled",
+        proposedSlots: [],
+        selectedSlot: null,
+        requestedAt: "2026-04-02T10:00:00.000Z",
+        createdAt: "2026-04-02T10:00:00.000Z",
+        updatedAt: "2026-04-02T10:00:00.000Z",
+      },
+      {
+        id: "view-1",
+        applicantName: "Requested Applicant",
+        applicantEmail: "requested@example.com",
+        applicantPhone: null,
+        requestedMessage: null,
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        applicationId: null,
+        status: "requested",
+        proposedSlots: [],
+        selectedSlot: null,
+        requestedAt: "2026-04-01T10:00:00.000Z",
+        createdAt: "2026-04-01T10:00:00.000Z",
+        updatedAt: "2026-04-01T10:00:00.000Z",
+      },
+    ]);
+
+    render(
+      <MemoryRouter>
+        <ApplicationsPage />
+      </MemoryRouter>
+    );
+
+    await screen.findByText("Requested Applicant | requested (selected)");
+    fireEvent.click(screen.getByLabelText("Show cancelled requests"));
+
+    expect(await screen.findByText("Cancelled Applicant | cancelled")).toBeInTheDocument();
+    expect(screen.getByText("Requested Applicant | requested (selected)")).toBeInTheDocument();
+  });
+
+  it("shows the empty viewing-request state when only cancelled requests exist and the toggle is off", async () => {
+    mocks.fetchViewingRequests.mockResolvedValueOnce([
+      {
+        id: "view-2",
+        applicantName: "Cancelled Applicant",
+        applicantEmail: "cancelled@example.com",
+        applicantPhone: null,
+        requestedMessage: null,
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        applicationId: null,
+        status: "cancelled",
+        proposedSlots: [],
+        selectedSlot: null,
+        requestedAt: "2026-04-02T10:00:00.000Z",
+        createdAt: "2026-04-02T10:00:00.000Z",
+        updatedAt: "2026-04-02T10:00:00.000Z",
+      },
+    ]);
+
+    render(
+      <MemoryRouter>
+        <ApplicationsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("No viewing requests yet.")).toBeInTheDocument();
+    expect(screen.getByText("Select a viewing request to review details.")).toBeInTheDocument();
+    expect(screen.queryByText(/Cancelled Applicant/)).not.toBeInTheDocument();
   });
 
   it("renders without crashing for a free-tier landlord", async () => {

--- a/rentchain-frontend/src/pages/ApplicationsPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.tsx
@@ -386,6 +386,7 @@ const ApplicationsPage: React.FC = () => {
   const [viewingLoading, setViewingLoading] = useState(false);
   const [viewingActionLoading, setViewingActionLoading] = useState(false);
   const [viewingError, setViewingError] = useState<string | null>(null);
+  const [showCancelledViewingRequests, setShowCancelledViewingRequests] = useState(false);
   const [selectedViewingId, setSelectedViewingId] = useState<string | null>(null);
   const [sendingReminderId, setSendingReminderId] = useState<string | null>(null);
   const [funnel, setFunnel] = useState<LandlordApplicationFunnelAnalytics | null>(null);
@@ -497,9 +498,16 @@ const ApplicationsPage: React.FC = () => {
     : "Application";
   const screeningOrderId = detail?.screening?.orderId || null;
   const isTransUnionConnected = transUnionIntegration.status === "connected";
+  const visibleViewingRequests = useMemo(
+    () =>
+      showCancelledViewingRequests
+        ? viewingRequests
+        : viewingRequests.filter((request) => request.status !== "cancelled"),
+    [showCancelledViewingRequests, viewingRequests]
+  );
   const selectedViewingRequest = useMemo(
-    () => viewingRequests.find((request) => request.id === selectedViewingId) || null,
-    [viewingRequests, selectedViewingId]
+    () => visibleViewingRequests.find((request) => request.id === selectedViewingId) || null,
+    [visibleViewingRequests, selectedViewingId]
   );
 
   const promptApplicationsUpgrade = useCallback(
@@ -564,7 +572,8 @@ const ApplicationsPage: React.FC = () => {
       setViewingRequests(data || []);
       setSelectedViewingId((current) => {
         if (current && data.some((item) => item.id === current)) return current;
-        return data[0]?.id || null;
+        const firstVisible = (data || []).find((item) => item.status !== "cancelled");
+        return firstVisible?.id || null;
       });
     } catch (err: any) {
       setViewingError(err?.message || "Unable to load viewing requests.");
@@ -587,6 +596,14 @@ const ApplicationsPage: React.FC = () => {
     },
     []
   );
+
+  useEffect(() => {
+    setSelectedViewingId((current) => {
+      if (!current) return visibleViewingRequests[0]?.id || null;
+      if (visibleViewingRequests.some((request) => request.id === current)) return current;
+      return visibleViewingRequests[0]?.id || null;
+    });
+  }, [visibleViewingRequests]);
 
   const loadScreeningEvents = async (applicationId: string) => {
     setScreeningEventsLoading(true);
@@ -2084,6 +2101,28 @@ const ApplicationsPage: React.FC = () => {
         {viewingError ? (
           <div style={{ color: "#b91c1c", fontSize: 13 }}>{viewingError}</div>
         ) : null}
+        <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.sm, flexWrap: "wrap" }}>
+          <div style={{ color: text.subtle, fontSize: 13 }}>
+            {showCancelledViewingRequests ? "Showing active and cancelled requests." : "Showing active requests only."}
+          </div>
+          <label
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 8,
+              color: text.muted,
+              fontSize: 13,
+              cursor: "pointer",
+            }}
+          >
+            <input
+              type="checkbox"
+              checked={showCancelledViewingRequests}
+              onChange={(event) => setShowCancelledViewingRequests(event.target.checked)}
+            />
+            <span>Show cancelled requests</span>
+          </label>
+        </div>
         <div
           className="rc-viewing-requests-layout"
           style={{
@@ -2097,7 +2136,7 @@ const ApplicationsPage: React.FC = () => {
               <div style={{ color: text.muted }}>Loading viewing requests...</div>
             ) : (
               <ViewingRequestList
-                requests={viewingRequests}
+                requests={visibleViewingRequests}
                 selectedId={selectedViewingId}
                 onSelect={setSelectedViewingId}
               />


### PR DESCRIPTION
This PR cleans up viewing request lists.

Includes:
- cancelled viewing requests hidden by default
- Show cancelled requests toggle
- existing sorted order preserved
- selected detail now resolves from visible requests only
- empty state shown when only cancelled requests exist
- focused frontend test coverage

Guardrails preserved:
- frontend-only
- no backend filtering
- no data deletion
- no archive/history data model
- no workflow/status changes
- no permission changes
- no analytics/export/dashboard/messages/contractor/lease work