### PR TITLE
feat: add analytics workspace tabs

### DIFF
--- a/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.test.tsx
@@ -499,24 +499,46 @@ describe("LandlordAnalyticsPage", () => {
     );
 
     expect(await screen.findByText(/Analytics alerts/i)).toBeInTheDocument();
+    expect(screen.getByRole("tablist", { name: /Analytics workspace sections/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Analytics alerts" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tab", { name: "Portfolio benchmarking" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Decision outcomes" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Operator queue" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Recommended next actions" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Actions to review" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Predictive metrics" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Attention-worthy insights" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Portfolio-level execution state summary" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Review leases/i })).toHaveAttribute("href", "/portfolio-health");
+
+    fireEvent.click(screen.getByRole("tab", { name: "Portfolio benchmarking" }));
+    expect(screen.getByRole("heading", { name: /Portfolio benchmarking/i })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: /Analytics alerts/i })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Decision outcomes" }));
     expect(screen.getByRole("heading", { name: /Decision outcomes/i })).toBeInTheDocument();
     expect(screen.getByText(/all-time landlord decision outcomes from canonical decision events/i)).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: /Portfolio benchmarking/i })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Recommended next actions" }));
     expect(screen.getByRole("heading", { name: /Recommended next actions/i })).toBeInTheDocument();
     expect(screen.getAllByText(/Automation preview/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Human confirmation required/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Beta carries the strongest vacancy pressure/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Predictive metrics" }));
     expect(screen.getByRole("heading", { name: /Predictive metrics/i })).toBeInTheDocument();
     expect(screen.getByText(/Vacancy pressure is present in the current view/i)).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /Portfolio benchmarking/i })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: /Recommended next actions/i })).not.toBeInTheDocument();
+
     expect(screen.getByRole("heading", { name: /Applications/i })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /Revenue signal/i })).toBeInTheDocument();
     expect(screen.getAllByText(/vs prior 90 days/i).length).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: "Print / Save PDF" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /Review leases/i })).toHaveAttribute("href", "/portfolio-health");
     expect(macShellSpy).toHaveBeenCalledWith(expect.objectContaining({ title: "Analytics", showTopNav: false }));
   });
 
-  it("shows an operator queue summary above the analytics decision list", async () => {
+  it("shows an operator queue summary tab with execution-state filters", async () => {
     await mockEntitlements();
     await mockApiResolved();
 
@@ -526,12 +548,13 @@ describe("LandlordAnalyticsPage", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByRole("region", { name: /Operator queue/i })).toBeInTheDocument();
+    await screen.findByText(/Analytics alerts/i);
+    fireEvent.click(screen.getByRole("tab", { name: "Operator queue" }));
+
+    expect(screen.getByRole("tabpanel", { name: "Operator queue" })).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: /Operator queue/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Action required · 1/i })).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole("button", { name: /Action required · 1/i }));
-
-    expect(screen.getByText(/Beta carries the strongest vacancy pressure/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Beta carries the strongest vacancy pressure/i)).not.toBeInTheDocument();
   });
 
   it("renders analytics decisions in deterministic operator priority order", async () => {
@@ -758,7 +781,10 @@ describe("LandlordAnalyticsPage", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByRole("heading", { name: /Recommended next actions/i })).toBeInTheDocument();
+    await screen.findByText(/Analytics alerts/i);
+    fireEvent.click(screen.getByRole("tab", { name: "Recommended next actions" }));
+
+    expect(screen.getByRole("heading", { name: /Recommended next actions/i })).toBeInTheDocument();
 
     const actionLinks = screen
       .getAllByRole("link")
@@ -1159,6 +1185,7 @@ describe("LandlordAnalyticsPage", () => {
     );
 
     expect(await screen.findByRole("heading", { name: /Applications/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Analytics alerts" })).toHaveAttribute("aria-selected", "true");
   });
 
   it("re-fetches when filters change", async () => {
@@ -1174,6 +1201,8 @@ describe("LandlordAnalyticsPage", () => {
     );
 
     expect(await screen.findByText(/Analytics alerts/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Analytics period/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Analytics property/i)).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText(/Analytics period/i), { target: { value: "30d" } });
     fireEvent.change(screen.getByLabelText(/Analytics property/i), { target: { value: "prop-2" } });

--- a/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.tsx
@@ -31,6 +31,28 @@ import {
 } from "../../components/analytics/decisionExecutionAggregation";
 
 const EMPTY_DECISIONS: LandlordAnalyticsSnapshot["decisions"]["items"] = [];
+type AnalyticsWorkspaceTabId =
+  | "analytics-alerts"
+  | "portfolio-benchmarking"
+  | "decision-outcomes"
+  | "operator-queue"
+  | "recommended-next-actions"
+  | "actions-to-review"
+  | "predictive-metrics"
+  | "attention-worthy-insights"
+  | "portfolio-execution-summary";
+
+const ANALYTICS_WORKSPACE_TABS: Array<{ id: AnalyticsWorkspaceTabId; label: string }> = [
+  { id: "analytics-alerts", label: "Analytics alerts" },
+  { id: "portfolio-benchmarking", label: "Portfolio benchmarking" },
+  { id: "decision-outcomes", label: "Decision outcomes" },
+  { id: "operator-queue", label: "Operator queue" },
+  { id: "recommended-next-actions", label: "Recommended next actions" },
+  { id: "actions-to-review", label: "Actions to review" },
+  { id: "predictive-metrics", label: "Predictive metrics" },
+  { id: "attention-worthy-insights", label: "Attention-worthy insights" },
+  { id: "portfolio-execution-summary", label: "Portfolio-level execution state summary" },
+];
 
 function errorMessage(error: unknown) {
   if (error instanceof Error && error.message) return error.message;
@@ -68,6 +90,16 @@ function entryLabel(entry: string | null) {
   if (entry === "vacancy-readiness") return "Vacancy readiness";
   if (entry === "revenue-pressure") return "Revenue pressure";
   if (entry === "property-focus") return "Property focus";
+  return null;
+}
+
+function workspaceTabIntro(tab: AnalyticsWorkspaceTabId) {
+  if (tab === "actions-to-review") {
+    return "This workspace keeps the focus on reviewable recommendations without changing the underlying decision queue behavior.";
+  }
+  if (tab === "portfolio-execution-summary") {
+    return "This view summarizes how decisions are distributed across execution states so you can see what is ready, blocked, or already handled.";
+  }
   return null;
 }
 
@@ -152,6 +184,7 @@ export default function LandlordAnalyticsPage() {
   const [period, setPeriod] = React.useState<AnalyticsPeriod>("90d");
   const [propertyId, setPropertyId] = React.useState("");
   const [executionFilter, setExecutionFilter] = React.useState<DecisionExecutionFilter>("all");
+  const [activeTab, setActiveTab] = React.useState<AnalyticsWorkspaceTabId>("analytics-alerts");
   const urlParams = React.useMemo(() => new URLSearchParams(location.search), [location.search]);
   const routedPropertyId = urlParams.get("propertyId");
   const routedEntryLabel = entryLabel(urlParams.get("entry"));
@@ -181,6 +214,10 @@ export default function LandlordAnalyticsPage() {
     [decisions, executionFilter]
   );
   const prioritizedDecisions = React.useMemo(() => prioritizeDecisions(filteredDecisions), [filteredDecisions]);
+  const activeTabIntro = workspaceTabIntro(activeTab);
+  const activeTabLabel = ANALYTICS_WORKSPACE_TABS.find((tab) => tab.id === activeTab)?.label || "Analytics alerts";
+  const showPortfolioScoreTeaser = canViewPortfolioScore === false;
+  const showAdvancedAnalyticsTeaser = canViewPortfolioScore && !canViewAdvancedAnalytics;
 
   const summaryItems = snapshot
     ? [
@@ -301,6 +338,48 @@ export default function LandlordAnalyticsPage() {
         ) : null}
 
         {analyticsEnabled ? (
+          <div
+            role="tablist"
+            aria-label="Analytics workspace sections"
+            style={{
+              display: "flex",
+              gap: 8,
+              overflowX: "auto",
+              paddingBottom: 4,
+              scrollbarWidth: "thin",
+            }}
+          >
+            {ANALYTICS_WORKSPACE_TABS.map((tab) => {
+              const selected = activeTab === tab.id;
+              return (
+                <button
+                  key={tab.id}
+                  id={`analytics-tab-${tab.id}`}
+                  type="button"
+                  role="tab"
+                  aria-selected={selected}
+                  aria-controls={`analytics-panel-${tab.id}`}
+                  onClick={() => setActiveTab(tab.id)}
+                  style={{
+                    borderRadius: 999,
+                    border: selected ? "1px solid #0f172a" : "1px solid #cbd5e1",
+                    background: selected ? "#0f172a" : "#fff",
+                    color: selected ? "#fff" : "#334155",
+                    fontWeight: 700,
+                    padding: "8px 12px",
+                    cursor: "pointer",
+                    whiteSpace: "nowrap",
+                    flex: "0 0 auto",
+                  }}
+                >
+                  {tab.label}
+                </button>
+              );
+            })}
+          </div>
+        ) : null}
+
+        {analyticsEnabled ? (
           <AnalyticsFiltersBar
             period={period}
             propertyId={propertyId}
@@ -318,25 +397,7 @@ export default function LandlordAnalyticsPage() {
 
         {analyticsEnabled && !loading && !error && snapshot ? (
           <>
-            <AnalyticsAlertsPanel alerts={alerts?.alerts || []} summary={alerts?.summary || null} />
             <AnalyticsKpiGrid items={summaryItems} periodLabel={periodLabel(period)} />
-            {canViewBenchmarking ? <PortfolioBenchmarkingPanel benchmarking={benchmarking} /> : null}
-            {canViewPortfolioScore && canViewAdvancedAnalytics ? (
-              <>
-                <DecisionOutcomeAnalyticsPanel analytics={snapshot.decisionOutcomeAnalytics} />
-                <DecisionQueueSummary
-                  decisions={decisions}
-                  filter={executionFilter}
-                  onFilterChange={setExecutionFilter}
-                />
-                <AgentDecisionPanel
-                  decisions={prioritizedDecisions}
-                  period={period}
-                  propertyId={propertyId}
-                />
-                <PredictiveMetricsPanel metrics={snapshot.predictive?.metrics || []} />
-              </>
-            ) : null}
 
             {canViewPortfolioScore ? (
               <div
@@ -486,7 +547,82 @@ export default function LandlordAnalyticsPage() {
               </div>
             ) : null}
 
-            {!canViewPortfolioScore ? (
+            <div
+              id={`analytics-panel-${activeTab}`}
+              role="tabpanel"
+              aria-labelledby={`analytics-tab-${activeTab}`}
+              aria-label={activeTabLabel}
+              style={{ display: "grid", gap: 12 }}
+            >
+              {activeTabIntro ? (
+                <Card style={{ color: "#475569" }}>{activeTabIntro}</Card>
+              ) : null}
+
+              {activeTab === "analytics-alerts" ? (
+                <AnalyticsAlertsPanel alerts={alerts?.alerts || []} summary={alerts?.summary || null} />
+              ) : null}
+
+              {activeTab === "portfolio-benchmarking" && canViewBenchmarking ? (
+                <PortfolioBenchmarkingPanel benchmarking={benchmarking} />
+              ) : null}
+
+              {activeTab === "decision-outcomes" && canViewPortfolioScore && canViewAdvancedAnalytics ? (
+                <DecisionOutcomeAnalyticsPanel analytics={snapshot.decisionOutcomeAnalytics} />
+              ) : null}
+
+              {(activeTab === "operator-queue" || activeTab === "portfolio-execution-summary") &&
+              canViewPortfolioScore &&
+              canViewAdvancedAnalytics ? (
+                <DecisionQueueSummary
+                  decisions={decisions}
+                  filter={executionFilter}
+                  onFilterChange={setExecutionFilter}
+                />
+              ) : null}
+
+              {(activeTab === "recommended-next-actions" || activeTab === "actions-to-review") &&
+              canViewPortfolioScore &&
+              canViewAdvancedAnalytics ? (
+                <AgentDecisionPanel
+                  decisions={prioritizedDecisions}
+                  period={period}
+                  propertyId={propertyId}
+                />
+              ) : null}
+
+              {activeTab === "predictive-metrics" && canViewPortfolioScore && canViewAdvancedAnalytics ? (
+                <PredictiveMetricsPanel metrics={snapshot.predictive?.metrics || []} />
+              ) : null}
+
+              {activeTab === "attention-worthy-insights" && canViewPortfolioScore && canViewAdvancedAnalytics ? (
+                <InsightCardsPanel insights={snapshot.insights} />
+              ) : null}
+
+              {activeTab !== "analytics-alerts" && !canViewPortfolioScore ? (
+                <FeatureTeaser
+                  featureKey="portfolio_score"
+                  eyebrow="Pro analytics"
+                  title="Unlock deeper analytics on Pro"
+                  description="Move from a summary overview into detailed application, leasing, maintenance, and revenue panels."
+                  ctaLabel="Upgrade to Pro"
+                />
+              ) : null}
+
+              {activeTab !== "analytics-alerts" &&
+              activeTab !== "portfolio-benchmarking" &&
+              canViewPortfolioScore &&
+              !canViewAdvancedAnalytics ? (
+                <FeatureTeaser
+                  featureKey="portfolio_analytics"
+                  eyebrow="Elite analytics"
+                  title="Unlock attention-worthy insights on Elite"
+                  description="Surface more actionable analytics signals across vacancies, maintenance burden, and application changes."
+                  ctaLabel="Upgrade to Elite"
+                />
+              ) : null}
+            </div>
+
+            {showPortfolioScoreTeaser ? (
               <FeatureTeaser
                 featureKey="portfolio_score"
                 eyebrow="Pro analytics"
@@ -496,7 +632,7 @@ export default function LandlordAnalyticsPage() {
               />
             ) : null}
 
-            {canViewPortfolioScore && !canViewAdvancedAnalytics ? (
+            {showAdvancedAnalyticsTeaser ? (
               <FeatureTeaser
                 featureKey="portfolio_analytics"
                 eyebrow="Elite analytics"
@@ -504,10 +640,6 @@ export default function LandlordAnalyticsPage() {
                 description="Surface more actionable analytics signals across vacancies, maintenance burden, and application changes."
                 ctaLabel="Upgrade to Elite"
               />
-            ) : null}
-
-            {canViewPortfolioScore && canViewAdvancedAnalytics ? (
-              <InsightCardsPanel insights={snapshot.insights} />
             ) : null}
 
             {!snapshot.properties.length &&


### PR DESCRIPTION
This PR improves the landlord analytics workspace.

Includes:
- top tab navigation for landlord analytics panels
- deterministic default Analytics alerts tab
- accessible tablist/tab/tabpanel behavior
- mobile-safe horizontally scrollable tab row
- preserved global filters, KPI grid, print button, and entitlement behavior
- focused frontend test coverage

Guardrails preserved:
- frontend-only
- no backend/API changes
- no analytics calculation changes
- no archived-property filtering work
- no export/PDF normalization
- no dashboard/inbox/messages/contractor/lease/payment work
- no route deep-linking added