### PR TITLE
refactor: normalize export downloads

### DIFF
--- a/rentchain-frontend/src/api/expensesApi.ts
+++ b/rentchain-frontend/src/api/expensesApi.ts
@@ -1,6 +1,5 @@
 import { apiFetch } from "./apiFetch";
-import { apiUrl } from "./config";
-import { getAuthToken } from "../lib/authToken";
+import { downloadAuthenticatedExport } from "./exportDownload";
 
 export const EXPENSE_CATEGORIES = [
   "Repairs",
@@ -139,30 +138,11 @@ export async function importExpensesCsv(input: {
 }
 
 async function downloadExpenseExport(path: string) {
-  const token = getAuthToken();
-  const response = await fetch(apiUrl(path), {
-    method: "GET",
-    headers: token ? { Authorization: `Bearer ${token}` } : {},
-    credentials: "include",
+  return downloadAuthenticatedExport({
+    path,
+    fallbackFilename: "rentchain-expenses-export",
+    errorMessage: "Failed to export expenses",
   });
-  if (!response.ok) {
-    const text = await response.text().catch(() => "");
-    let message = text || "Failed to export expenses";
-    try {
-      const json = text ? JSON.parse(text) : null;
-      message = json?.message || json?.error || message;
-    } catch {
-      // ignore json parse errors
-    }
-    throw new Error(message);
-  }
-  const blob = await response.blob();
-  const disposition = response.headers.get("Content-Disposition") || "";
-  const match = disposition.match(/filename="?([^"]+)"?/i);
-  return {
-    blob,
-    filename: match?.[1] || "rentchain-expenses-export",
-  };
 }
 
 export async function exportExpenses(format: "csv" | "xlsx" | "pdf", filters?: ListExpensesFilters) {

--- a/rentchain-frontend/src/api/exportDownload.ts
+++ b/rentchain-frontend/src/api/exportDownload.ts
@@ -1,0 +1,40 @@
+import { apiUrl } from "./config";
+import { getAuthToken } from "../lib/authToken";
+
+type DownloadAuthenticatedExportOptions = {
+  path: string;
+  fallbackFilename: string;
+  errorMessage: string;
+};
+
+export async function downloadAuthenticatedExport({
+  path,
+  fallbackFilename,
+  errorMessage,
+}: DownloadAuthenticatedExportOptions): Promise<{ blob: Blob; filename: string }> {
+  const token = getAuthToken();
+  const response = await fetch(apiUrl(path), {
+    method: "GET",
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    let message = text || errorMessage;
+    try {
+      const json = text ? JSON.parse(text) : null;
+      message = json?.message || json?.error || message;
+    } catch {
+      // Ignore non-JSON responses and fall back to the provided message.
+    }
+    throw new Error(message);
+  }
+
+  const blob = await response.blob();
+  const disposition = response.headers.get("Content-Disposition") || "";
+  const match = disposition.match(/filename\*?=(?:UTF-8''|\"?)([^\";]+)/i);
+  const filename = match?.[1] ? decodeURIComponent(match[1].replace(/\"/g, "").trim()) : fallbackFilename;
+
+  return { blob, filename };
+}

--- a/rentchain-frontend/src/api/paymentsApi.ts
+++ b/rentchain-frontend/src/api/paymentsApi.ts
@@ -1,6 +1,5 @@
 import { apiFetch } from "./apiFetch";
-import { apiUrl } from "./config";
-import { getAuthToken } from "../lib/authToken";
+import { downloadAuthenticatedExport } from "./exportDownload";
 
 export interface PaymentRecord {
   id: string;
@@ -101,33 +100,10 @@ export async function getPropertyMonthlyPayments(
   return data;
 }
 
-async function downloadPaymentExport(path: string) {
-  const token = getAuthToken();
-  const response = await fetch(apiUrl(path), {
-    method: "GET",
-    headers: token ? { Authorization: `Bearer ${token}` } : {},
-    credentials: "include",
-  });
-  if (!response.ok) {
-    const text = await response.text().catch(() => "");
-    let message = text || "Failed to export payments";
-    try {
-      const json = text ? JSON.parse(text) : null;
-      message = json?.message || json?.error || message;
-    } catch {
-      // ignore
-    }
-    throw new Error(message);
-  }
-  const blob = await response.blob();
-  const disposition = response.headers.get("Content-Disposition") || "";
-  const match = disposition.match(/filename=\"?([^\"]+)\"?/i);
-  return {
-    blob,
-    filename: match?.[1] || "rentchain-payments-export",
-  };
-}
-
 export async function exportPayments(format: "csv" | "xlsx") {
-  return downloadPaymentExport(`/payments/export.${format}`);
+  return downloadAuthenticatedExport({
+    path: `/payments/export.${format}`,
+    fallbackFilename: "rentchain-payments-export",
+    errorMessage: "Failed to export payments",
+  });
 }

--- a/rentchain-frontend/src/api/workOrdersApi.ts
+++ b/rentchain-frontend/src/api/workOrdersApi.ts
@@ -1,6 +1,5 @@
 import { apiFetch } from "./apiFetch";
-import { apiUrl } from "./config";
-import { getAuthToken } from "../lib/authToken";
+import { downloadAuthenticatedExport } from "./exportDownload";
 
 export type WorkOrderPriority = "low" | "medium" | "high" | "urgent";
 export type WorkOrderStatus =
@@ -261,30 +260,11 @@ export async function listWorkOrders(status?: string): Promise<WorkOrderRecord[]
 }
 
 async function downloadWorkOrderExport(path: string) {
-  const token = getAuthToken();
-  const response = await fetch(apiUrl(path), {
-    method: "GET",
-    headers: token ? { Authorization: `Bearer ${token}` } : {},
-    credentials: "include",
+  return downloadAuthenticatedExport({
+    path,
+    fallbackFilename: "rentchain-work-orders-export",
+    errorMessage: "Failed to export work orders",
   });
-  if (!response.ok) {
-    const text = await response.text().catch(() => "");
-    let message = text || "Failed to export work orders";
-    try {
-      const json = text ? JSON.parse(text) : null;
-      message = json?.message || json?.error || message;
-    } catch {
-      // ignore
-    }
-    throw new Error(message);
-  }
-  const blob = await response.blob();
-  const disposition = response.headers.get("Content-Disposition") || "";
-  const match = disposition.match(/filename=\"?([^\"]+)\"?/i);
-  return {
-    blob,
-    filename: match?.[1] || "rentchain-work-orders-export",
-  };
 }
 
 export async function exportWorkOrders(format: "csv" | "xlsx") {

--- a/rentchain-frontend/src/pages/ExpensesPage.test.tsx
+++ b/rentchain-frontend/src/pages/ExpensesPage.test.tsx
@@ -4,6 +4,7 @@ import ExpensesPage from "./ExpensesPage";
 
 const mocks = vi.hoisted(() => ({
   listExpensesMock: vi.fn(),
+  exportExpensesMock: vi.fn(),
   fetchPropertiesMock: vi.fn(),
   useCapabilitiesMock: vi.fn(),
   previewExpenseImportMock: vi.fn(),
@@ -15,7 +16,7 @@ vi.mock("../api/expensesApi", async () => {
   return {
     ...actual,
     listExpenses: mocks.listExpensesMock,
-    exportExpenses: vi.fn(),
+    exportExpenses: mocks.exportExpensesMock,
     previewExpenseImport: mocks.previewExpenseImportMock,
     confirmExpenseImportRows: mocks.confirmExpenseImportRowsMock,
   };
@@ -49,6 +50,10 @@ describe("ExpensesPage", () => {
     ]);
     mocks.fetchPropertiesMock.mockResolvedValue({
       items: [{ id: "prop-1", name: "Alpha Property", portfolioStatus: "active" }],
+    });
+    mocks.exportExpensesMock.mockResolvedValue({
+      blob: new Blob(["csv"]),
+      filename: "expenses.csv",
     });
     mocks.previewExpenseImportMock.mockReset();
     mocks.confirmExpenseImportRowsMock.mockReset();
@@ -84,6 +89,32 @@ describe("ExpensesPage", () => {
     });
     expect(screen.getByRole("button", { name: "Export Spreadsheet" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Export PDF" })).toBeInTheDocument();
+  });
+
+  it("routes export buttons through the existing export api", async () => {
+    mocks.useCapabilitiesMock.mockReturnValue({
+      caps: { plan: "pro" },
+      features: { "expenses.import": true },
+      loading: false,
+    });
+
+    const createObjectURL = vi.fn(() => "blob:url");
+    const revokeObjectURL = vi.fn();
+    const click = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+    vi.stubGlobal("URL", { ...(window.URL || {}), createObjectURL, revokeObjectURL });
+
+    render(<ExpensesPage />);
+
+    fireEvent.click((await screen.findAllByRole("button", { name: "Export CSV" }))[0]);
+    await waitFor(() => expect(mocks.exportExpensesMock).toHaveBeenCalledWith("csv", expect.any(Object)));
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Export Spreadsheet" })[0]);
+    await waitFor(() => expect(mocks.exportExpensesMock).toHaveBeenCalledWith("xlsx", expect.any(Object)));
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Export PDF" })[0]);
+    await waitFor(() => expect(mocks.exportExpensesMock).toHaveBeenCalledWith("pdf", expect.any(Object)));
+
+    click.mockRestore();
   });
 
   it("renders preview rows and confirms reviewed imports on Pro plans", async () => {

--- a/rentchain-frontend/src/pages/ExpensesPage.tsx
+++ b/rentchain-frontend/src/pages/ExpensesPage.tsx
@@ -17,6 +17,7 @@ import { ExpenseImportReviewTable } from "../components/expenses/ExpenseImportRe
 import { ExpenseImportSummaryCard } from "../components/expenses/ExpenseImportSummaryCard";
 import { ExpenseImportUploadCard } from "../components/expenses/ExpenseImportUploadCard";
 import { useCapabilities } from "../hooks/useCapabilities";
+import { triggerBlobDownload } from "../utils/downloadBlob";
 
 function formatCents(cents: number): string {
   const amount = Number(cents || 0) / 100;
@@ -204,12 +205,7 @@ const ExpensesPage: React.FC = () => {
         dateTo: dateTo || undefined,
         includeArchivedProperties: true,
       });
-      const url = window.URL.createObjectURL(blob);
-      const link = document.createElement("a");
-      link.href = url;
-      link.download = filename;
-      link.click();
-      window.URL.revokeObjectURL(url);
+      triggerBlobDownload(blob, filename);
     } catch (err: any) {
       setError(String(err?.message || "Failed to export expenses."));
     } finally {

--- a/rentchain-frontend/src/pages/PaymentsPage.tsx
+++ b/rentchain-frontend/src/pages/PaymentsPage.tsx
@@ -7,6 +7,7 @@ import { spacing, text, colors } from "../styles/tokens";
 import { fetchProperties } from "../api/propertiesApi";
 import { fetchTenants } from "../api/tenantsApi";
 import { printSummaryDocument } from "../utils/printSummary";
+import { triggerBlobDownload } from "../utils/downloadBlob";
 
 const PaymentsPage: React.FC = () => {
   const { payments, loading, error } = usePayments();
@@ -71,12 +72,7 @@ const PaymentsPage: React.FC = () => {
     try {
       setExporting(format);
       const { blob, filename } = await exportPayments(format);
-      const url = window.URL.createObjectURL(blob);
-      const link = document.createElement("a");
-      link.href = url;
-      link.download = filename;
-      link.click();
-      window.URL.revokeObjectURL(url);
+      triggerBlobDownload(blob, filename);
     } catch (err) {
       console.error("[PaymentsPage] Failed to export payments:", err);
       window.alert(err instanceof Error ? `Failed to export payments: ${err.message}` : "Failed to export payments.");

--- a/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.test.tsx
@@ -9,6 +9,7 @@ import LandlordAnalyticsPage from "./LandlordAnalyticsPage";
 
 const showToast = vi.fn();
 const macShellSpy = vi.fn();
+const printSummaryDocument = vi.fn();
 type EntitlementOverrides = Record<string, unknown>;
 type PendingRequest = Promise<never>;
 
@@ -38,6 +39,10 @@ vi.mock("../../components/ui/ToastProvider", () => ({
   useToast: () => ({ showToast }),
 }));
 
+vi.mock("../../utils/printSummary", () => ({
+  printSummaryDocument: (...args: unknown[]) => printSummaryDocument(...args),
+}));
+
 vi.mock("../../components/layout/MacShell", () => ({
   MacShell: ({ children, ...props }: { children: React.ReactNode }) => {
     macShellSpy(props);
@@ -62,6 +67,7 @@ vi.mock("@/components/billing/FeatureTeaser", () => ({
 beforeEach(() => {
   showToast.mockReset();
   macShellSpy.mockReset();
+  printSummaryDocument.mockReset();
   vi.clearAllMocks();
 });
 
@@ -555,6 +561,20 @@ describe("LandlordAnalyticsPage", () => {
     expect(screen.getByRole("region", { name: /Operator queue/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Action required · 1/i })).toBeInTheDocument();
     expect(screen.queryByText(/Beta carries the strongest vacancy pressure/i)).not.toBeInTheDocument();
+  });
+
+  it("routes print/save pdf through the shared print helper", async () => {
+    await mockEntitlements();
+    await mockApiResolved();
+
+    render(
+      <MemoryRouter>
+        <LandlordAnalyticsPage />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Print / Save PDF" }));
+    expect(printSummaryDocument).toHaveBeenCalledWith("summary");
   });
 
   it("renders analytics decisions in deterministic operator priority order", async () => {

--- a/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.tsx
@@ -24,6 +24,7 @@ import DecisionOutcomeAnalyticsPanel from "../../components/analytics/DecisionOu
 import InsightCardsPanel from "../../components/analytics/InsightCardsPanel";
 import PortfolioBenchmarkingPanel from "../../components/analytics/PortfolioBenchmarkingPanel";
 import PredictiveMetricsPanel from "../../components/analytics/PredictiveMetricsPanel";
+import { printSummaryDocument } from "../../utils/printSummary";
 import {
   filterDecisionsByExecutionState,
   prioritizeDecisions,
@@ -285,7 +286,7 @@ export default function LandlordAnalyticsPage() {
             <button
               type="button"
               className="no-print"
-              onClick={() => window.print()}
+              onClick={() => void printSummaryDocument("summary")}
               style={{ padding: "8px 10px", borderRadius: 12, border: "1px solid #E5E7EB", background: "#FFFFFF", fontWeight: 900, cursor: "pointer" }}
             >
               Print / Save PDF

--- a/rentchain-frontend/src/pages/landlord/WorkOrdersPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/WorkOrdersPage.tsx
@@ -41,6 +41,7 @@ import {
 } from "../../api/workOrdersApi";
 import { type ExpenseCategory } from "../../api/expensesApi";
 import { printSummaryDocument } from "../../utils/printSummary";
+import { triggerBlobDownload } from "../../utils/downloadBlob";
 
 function formatDate(ms?: number | null) {
   if (!ms) return "-";
@@ -348,12 +349,7 @@ export default function WorkOrdersPage() {
     try {
       setExporting(format);
       const { blob, filename } = await exportWorkOrders(format);
-      const url = window.URL.createObjectURL(blob);
-      const link = document.createElement("a");
-      link.href = url;
-      link.download = filename;
-      link.click();
-      window.URL.revokeObjectURL(url);
+      triggerBlobDownload(blob, filename);
     } catch (err: any) {
       setError(String(err?.message || "Failed to export work orders"));
     } finally {

--- a/rentchain-frontend/src/utils/downloadBlob.ts
+++ b/rentchain-frontend/src/utils/downloadBlob.ts
@@ -1,0 +1,8 @@
+export function triggerBlobDownload(blob: Blob, filename: string): void {
+  const url = window.URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  link.click();
+  window.URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
This PR normalizes frontend export/download behavior.

Includes:
- shared authenticated export download helper
- shared browser blob download helper
- payments, expenses, and work-orders API wrappers using shared export download logic
- payments, expenses, and work-orders pages using shared blob download logic
- analytics Print / Save PDF normalized to use the shared print summary helper
- focused frontend test coverage

Guardrails preserved:
- frontend-only
- no backend route changes
- no output schema changes
- no new export formats
- no new PDF library
- no button placement redesign
- no analytics calculation changes
- no archived-property filtering
- no mobile/messages/contractor/dashboard changes