### PR TITLE
feat: add system observability

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -110,6 +110,7 @@ import adminSlaRoutes from "./routes/adminSlaRoutes";
 import adminAlertingRoutes from "./routes/adminAlertingRoutes";
 import adminAssignmentRoutes from "./routes/adminAssignmentRoutes";
 import adminNotificationRoutes from "./routes/adminNotificationRoutes";
+import adminObservabilityRoutes from "./routes/adminObservabilityRoutes";
 import portfolioScoreRoutes from "./routes/portfolioScoreRoutes";
 import portfolioScoreHistoryRoutes from "./routes/portfolioScoreHistoryRoutes";
 import landlordPortfolioHealthRoutes from "./routes/landlordPortfolioHealthRoutes";
@@ -260,6 +261,8 @@ app.use("/api/admin", routeSource("adminAssignmentRoutes.ts"), adminAssignmentRo
 console.log("[route-mount] adminAssignmentRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("adminNotificationRoutes.ts"), adminNotificationRoutes);
 console.log("[route-mount] adminNotificationRoutes mounted at /api/admin");
+app.use("/api/admin", routeSource("adminObservabilityRoutes.ts"), adminObservabilityRoutes);
+console.log("[route-mount] adminObservabilityRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("portfolioScoreRoutes.ts"), portfolioScoreRoutes);
 console.log("[route-mount] portfolioScoreRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("portfolioScoreHistoryRoutes.ts"), portfolioScoreHistoryRoutes);

--- a/rentchain-api/src/routes/__tests__/adminObservabilityRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/adminObservabilityRoutes.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const deriveSummaryMock = vi.fn();
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!req.user) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    return next();
+  },
+}));
+
+vi.mock("../../services/observability/deriveSystemObservabilitySummary", () => ({
+  deriveSystemObservabilitySummary: deriveSummaryMock,
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; user?: any }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    const query = new URLSearchParams(queryString || "");
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: options.user ?? null,
+      query: Object.fromEntries(query.entries()),
+      headers: {},
+      get(name: string) {
+        return this.headers[String(name).toLowerCase()];
+      },
+      header(name: string) {
+        return this.get(name);
+      },
+    };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      setHeader() {},
+    };
+    router.handle(req, res, (error: any) => (error ? reject(error) : undefined));
+  });
+}
+
+describe("adminObservabilityRoutes", () => {
+  beforeEach(() => {
+    deriveSummaryMock.mockReset();
+  });
+
+  it("requires admin permission and returns aggregate-only summary output", async () => {
+    deriveSummaryMock.mockResolvedValue({
+      generatedAt: "2026-04-28T18:00:00.000Z",
+      totals: {
+        openCritical: 1,
+        openWarnings: 2,
+        resolvedLast7Days: 3,
+      },
+      workflows: [
+        {
+          workflow: "payment",
+          openCritical: 0,
+          openWarnings: 1,
+          recentCompleted: 2,
+          health: "watch",
+        },
+      ],
+      topIssues: [
+        {
+          title: "Rent payment failed",
+          workflow: "payment",
+          severity: "warning",
+          count: 2,
+          lastSeenAt: "2026-04-28T12:00:00.000Z",
+        },
+      ],
+    });
+
+    const router = (await import("../adminObservabilityRoutes")).default;
+
+    const forbidden = await invokeRouter(router, {
+      method: "GET",
+      url: "/observability/summary",
+      user: { id: "landlord-1", role: "landlord", permissions: [] },
+    });
+    expect(forbidden.status).toBe(403);
+
+    const ok = await invokeRouter(router, {
+      method: "GET",
+      url: "/observability/summary?period=30d",
+      user: { id: "admin-1", role: "admin", permissions: ["system.admin"] },
+    });
+
+    expect(ok.status).toBe(200);
+    expect(deriveSummaryMock).toHaveBeenCalledWith({ period: "30d" });
+    expect(ok.body.ok).toBe(true);
+    expect(ok.body.summary).toEqual(
+      expect.objectContaining({
+        generatedAt: "2026-04-28T18:00:00.000Z",
+        totals: {
+          openCritical: 1,
+          openWarnings: 2,
+          resolvedLast7Days: 3,
+        },
+      })
+    );
+    expect(JSON.stringify(ok.body)).not.toContain("resourceId");
+    expect(JSON.stringify(ok.body)).not.toContain("safeContext");
+  });
+});

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -7,6 +7,17 @@ const { sendEmailMock } = vi.hoisted(() => ({
 const { stripeCheckoutCreateMock } = vi.hoisted(() => ({
   stripeCheckoutCreateMock: vi.fn(),
 }));
+const { setObservabilityWriteShouldFail, getObservabilityWriteShouldFail } = vi.hoisted(() => {
+  let observabilityWriteShouldFail = false;
+  return {
+    setObservabilityWriteShouldFail(value: boolean) {
+      observabilityWriteShouldFail = value;
+    },
+    getObservabilityWriteShouldFail() {
+      return observabilityWriteShouldFail;
+    },
+  };
+});
 
 const collections = new Map<string, Map<string, any>>();
 
@@ -74,6 +85,9 @@ const dbMock = {
           data: () => clone(ensureCollection(name).get(docId)),
         }),
         set: async (value: any, opts?: { merge?: boolean }) => {
+          if (name === "systemObservabilityEvents" && getObservabilityWriteShouldFail()) {
+            throw new Error("observability_write_failed");
+          }
           const current = ensureCollection(name).get(docId) || {};
           ensureCollection(name).set(docId, opts?.merge ? applyMerge(current, value) : clone(value));
         },
@@ -185,6 +199,7 @@ describe("tenantPortalRoutes foundation", () => {
       url: "https://checkout.stripe.test/session/cs_test_1",
       payment_intent: "pi_test_1",
     });
+    setObservabilityWriteShouldFail(false);
     process.env.EMAIL_FROM = "noreply@example.com";
     process.env.GCS_UPLOAD_BUCKET = "test-bucket";
     getSignedDownloadUrlMock.mockReset();
@@ -1255,6 +1270,34 @@ describe("tenantPortalRoutes foundation", () => {
     expect(payload).not.toContain("documentUrl");
     expect(payload).not.toContain("paymentMethod");
     expect(payload).not.toContain("share-token");
+  });
+
+  it("keeps institutional handoff creation successful when observability recording fails softly", async () => {
+    setObservabilityWriteShouldFail(true);
+    const router = (await import("../tenantPortalRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/institutional/handoffs",
+      body: {
+        institutionProfile: {
+          institutionType: "bank",
+          displayName: "Example Bank Sandbox",
+          integrationMode: "sandbox",
+        },
+      },
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.ok).toBe(true);
+    expect(ensureCollection("institutionalHandoffs").size).toBe(1);
   });
 
   it("lists only the current tenant institutional handoff drafts and soft-voids owned drafts", async () => {

--- a/rentchain-api/src/routes/adminObservabilityRoutes.ts
+++ b/rentchain-api/src/routes/adminObservabilityRoutes.ts
@@ -1,0 +1,24 @@
+import { Router } from "express";
+import { requireAuth } from "../middleware/requireAuth";
+import { requirePermission } from "../middleware/requireAuthz";
+import { deriveSystemObservabilitySummary } from "../services/observability/deriveSystemObservabilitySummary";
+
+const router = Router();
+
+router.get(
+  "/observability/summary",
+  requireAuth,
+  requirePermission("system.admin"),
+  async (req: any, res: any) => {
+    try {
+      const period = String(req.query?.period || "").trim() === "30d" ? "30d" : "7d";
+      const summary = await deriveSystemObservabilitySummary({ period });
+      return res.json({ ok: true, summary });
+    } catch (err: any) {
+      console.error("[adminObservabilityRoutes] summary failed", err?.message || err);
+      return res.status(500).json({ ok: false, error: "admin_observability_summary_failed" });
+    }
+  }
+);
+
+export default router;

--- a/rentchain-api/src/routes/stripeScreeningOrdersWebhookRoutes.ts
+++ b/rentchain-api/src/routes/stripeScreeningOrdersWebhookRoutes.ts
@@ -11,6 +11,7 @@ import { writeScreeningEvent } from "../services/screening/screeningEvents";
 import { recordScreeningPaymentFailed } from "../services/screeningPaymentTransactionService";
 import { writeCanonicalEvent } from "../lib/events/buildEvent";
 import { buildScreeningMonetizationPatch } from "../services/screening/screeningMonetizationService";
+import { recordSystemObservabilityEvent } from "../services/observability/recordSystemObservabilityEvent";
 import {
   extractRentPaymentMetadata,
   updateRentPaymentFromWebhook,
@@ -172,6 +173,26 @@ async function handleScreeningPaidFromSession(params: {
   const { session, eventType, eventId, paidAt } = params;
   const applicationId = session.metadata?.applicationId || session.metadata?.rentalApplicationId;
   if (!applicationId) {
+    await recordSystemObservabilityEvent(
+      {
+        eventType: "integration_warning",
+        workflow: "screening",
+        severity: "warning",
+        actorType: "system",
+        status: "open",
+        title: "Screening webhook missing application context",
+        description: "A screening payment webhook arrived without application metadata and could not be applied.",
+        safeContext: {
+          route: "/api/stripe/webhook",
+          actionKey: "screening_webhook_missing_application",
+          resourceType: "stripe_event",
+          resourceId: eventId,
+        },
+        idempotencyKey: `screening:webhook_missing_application:${eventId}`,
+        occurredAt: paidAt,
+      },
+      { failSoft: true }
+    );
     console.log("[stripe_webhook]", {
       route: "stripe_webhook",
       eventType,
@@ -416,6 +437,26 @@ async function handleScreeningPaymentFailure(params: {
   });
 
   if (result.ok && !result.alreadyProcessed && !result.alreadyFinalized) {
+    await recordSystemObservabilityEvent(
+      {
+        eventType: "action_failed",
+        workflow: "screening",
+        severity: "warning",
+        actorType: "system",
+        status: "open",
+        title: "Screening payment failed",
+        description: "A screening payment failed and the screening workflow is blocked until payment succeeds.",
+        safeContext: {
+          route: "/api/stripe/webhook",
+          actionKey: "screening_payment_failed",
+          resourceType: "screening_order",
+          resourceId: result.orderIdResolved || orderRef.id,
+        },
+        idempotencyKey: `screening:payment_failed:${eventId}`,
+        occurredAt: params.occurredAt,
+      },
+      { failSoft: true }
+    );
     try {
       const orderSnap = await db.collection("screeningOrders").doc(result.orderIdResolved || orderRef.id).get();
       const order = orderSnap.data() as any;
@@ -712,6 +753,26 @@ export const stripeWebhookHandler = async (req: StripeWebhookRequest, res: Respo
           applicationId: resolvedApplicationId,
           error: applyResult.error,
         });
+      } else {
+        await recordSystemObservabilityEvent(
+          {
+            eventType: "workflow_completed",
+            workflow: "screening",
+            severity: "info",
+            actorType: "system",
+            status: "resolved",
+            title: "Screening completed",
+            description: "A screening workflow completed successfully after payment processing.",
+            safeContext: {
+              route: "/api/stripe/webhook",
+              actionKey: "screening_completed",
+              resourceType: "screening_order",
+              resourceId: resolvedOrderId,
+            },
+            occurredAt: typeof event.created === "number" ? new Date(event.created * 1000).toISOString() : new Date().toISOString(),
+          },
+          { failSoft: true }
+        );
       }
     } catch (err: any) {
       console.error("[stripe-webhook-orders] handler failed", err?.stack || err);

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -58,6 +58,7 @@ import {
   revokeTenantShareVerificationRequest,
   revokeTenantSharePackage,
 } from "../services/tenantPortal/tenantSharePackageService";
+import { recordSystemObservabilityEvent } from "../services/observability/recordSystemObservabilityEvent";
 
 const router = Router();
 router.use(authenticateJwt);
@@ -3190,6 +3191,25 @@ router.post("/institutional/handoffs", requireTenantWorkspaceIdentity, async (re
         validationStatus: schemaV2.validation.status,
       },
     });
+    await recordSystemObservabilityEvent(
+      {
+        eventType: "workflow_started",
+        workflow: "institutional",
+        severity: "info",
+        actorType: "tenant",
+        status: "open",
+        title: "Institutional handoff draft created",
+        description: "A tenant created an institutional handoff draft for a downstream review workflow.",
+        safeContext: {
+          route: "/api/tenant/institutional/handoffs",
+          actionKey: "institutional_handoff_created",
+          resourceType: "institutional_handoff",
+          resourceId: created.id,
+        },
+        occurredAt: created.createdAt,
+      },
+      { failSoft: true }
+    );
     return res.json({ ok: true, data: created });
   } catch (err: any) {
     if (err?.message === "invalid_institution_display_name") {
@@ -4137,6 +4157,25 @@ router.post("/leases/:leaseId/sign", requireTenantWorkspaceIdentity, async (req:
         nextStatus: "tenant_signed",
       },
     });
+    await recordSystemObservabilityEvent(
+      {
+        eventType: "workflow_completed",
+        workflow: "lease",
+        severity: "info",
+        actorType: "tenant",
+        status: "resolved",
+        title: "Tenant lease signature recorded",
+        description: "A tenant signature milestone was recorded for lease execution.",
+        safeContext: {
+          route: "/api/tenant/leases/sign",
+          actionKey: "tenant_lease_signed",
+          resourceType: "lease",
+          resourceId: leaseId,
+        },
+        occurredAt: nowIso,
+      },
+      { failSoft: true }
+    );
 
     const refreshedSnap = await leaseRef.get();
     const refreshed = refreshedSnap.exists ? ((refreshedSnap.data() as any) || {}) : leaseData;

--- a/rentchain-api/src/services/observability/__tests__/deriveSystemObservabilitySummary.test.ts
+++ b/rentchain-api/src/services/observability/__tests__/deriveSystemObservabilitySummary.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { store, ensureCollection } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map<string, any>());
+    return store.get(name)!;
+  }
+
+  return { store, ensureCollection };
+});
+
+vi.mock("../../../config/firebase", () => ({
+  db: {
+    collection: (name: string) => ({
+      async get() {
+        const docs = Array.from(ensureCollection(name).entries()).map(([id, data]) => ({
+          id,
+          data: () => data,
+        }));
+        return { docs };
+      },
+    }),
+  },
+}));
+
+describe("deriveSystemObservabilitySummary", () => {
+  beforeEach(() => {
+    store.clear();
+  });
+
+  it("aggregates warnings, critical issues, completions, and top issues deterministically", async () => {
+    const events = ensureCollection("systemObservabilityEvents");
+    events.set("evt-1", {
+      id: "evt-1",
+      version: "v1",
+      eventType: "action_failed",
+      workflow: "payment",
+      severity: "warning",
+      actorType: "system",
+      status: "open",
+      title: "Rent payment failed",
+      description: "A payment failed.",
+      safeContext: null,
+      idempotencyKey: null,
+      source: { kind: "system_observability", sourceEventId: null },
+      occurredAt: "2026-04-26T12:00:00.000Z",
+      recordedAt: "2026-04-26T12:00:00.000Z",
+      resolvedAt: null,
+    });
+    events.set("evt-2", {
+      id: "evt-2",
+      version: "v1",
+      eventType: "integration_warning",
+      workflow: "screening",
+      severity: "critical",
+      actorType: "system",
+      status: "open",
+      title: "Screening webhook missing application context",
+      description: "Webhook missing application metadata.",
+      safeContext: null,
+      idempotencyKey: null,
+      source: { kind: "system_observability", sourceEventId: null },
+      occurredAt: "2026-04-27T13:00:00.000Z",
+      recordedAt: "2026-04-27T13:00:00.000Z",
+      resolvedAt: null,
+    });
+    events.set("evt-3", {
+      id: "evt-3",
+      version: "v1",
+      eventType: "workflow_completed",
+      workflow: "lease",
+      severity: "info",
+      actorType: "tenant",
+      status: "resolved",
+      title: "Tenant lease signature recorded",
+      description: "A tenant signature milestone was recorded.",
+      safeContext: null,
+      idempotencyKey: null,
+      source: { kind: "system_observability", sourceEventId: null },
+      occurredAt: "2026-04-28T08:00:00.000Z",
+      recordedAt: "2026-04-28T08:00:00.000Z",
+      resolvedAt: "2026-04-28T08:00:00.000Z",
+    });
+
+    const { deriveSystemObservabilitySummary } = await import("../deriveSystemObservabilitySummary");
+    const summary = await deriveSystemObservabilitySummary({
+      period: "7d",
+      now: new Date("2026-04-28T18:00:00.000Z"),
+    });
+
+    expect(summary.totals).toEqual({
+      openCritical: 1,
+      openWarnings: 1,
+      resolvedLast7Days: 1,
+    });
+    expect(summary.workflows.find((item) => item.workflow === "screening")).toEqual(
+      expect.objectContaining({
+        openCritical: 1,
+        openWarnings: 0,
+        recentCompleted: 0,
+        health: "attention",
+      })
+    );
+    expect(summary.workflows.find((item) => item.workflow === "payment")).toEqual(
+      expect.objectContaining({
+        openCritical: 0,
+        openWarnings: 1,
+        health: "watch",
+      })
+    );
+    expect(summary.workflows.find((item) => item.workflow === "lease")).toEqual(
+      expect.objectContaining({
+        recentCompleted: 1,
+        health: "healthy",
+      })
+    );
+    expect(summary.topIssues[0]).toEqual(
+      expect.objectContaining({
+        title: "Screening webhook missing application context",
+        workflow: "screening",
+        severity: "critical",
+        count: 1,
+      })
+    );
+  });
+
+  it("returns stable empty states when no observability events exist", async () => {
+    const { deriveSystemObservabilitySummary } = await import("../deriveSystemObservabilitySummary");
+    const summary = await deriveSystemObservabilitySummary({
+      period: "30d",
+      now: new Date("2026-04-28T18:00:00.000Z"),
+    });
+
+    expect(summary.totals).toEqual({
+      openCritical: 0,
+      openWarnings: 0,
+      resolvedLast7Days: 0,
+    });
+    expect(summary.workflows.every((item) => item.health === "healthy")).toBe(true);
+    expect(summary.topIssues).toEqual([]);
+  });
+});

--- a/rentchain-api/src/services/observability/__tests__/recordSystemObservabilityEvent.test.ts
+++ b/rentchain-api/src/services/observability/__tests__/recordSystemObservabilityEvent.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { store, ensureCollection, setShouldFail, getShouldFail } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+  let shouldFail = false;
+
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map<string, any>());
+    return store.get(name)!;
+  }
+
+  return {
+    store,
+    ensureCollection,
+    setShouldFail(value: boolean) {
+      shouldFail = value;
+    },
+    getShouldFail() {
+      return shouldFail;
+    },
+  };
+});
+
+vi.mock("../../../config/firebase", () => ({
+  db: {
+    collection: (name: string) => ({
+      doc: (id: string) => ({
+        id,
+        async get() {
+          return {
+            exists: ensureCollection(name).has(id),
+            data: () => ensureCollection(name).get(id),
+          };
+        },
+        async set(payload: any) {
+          if (getShouldFail()) {
+            throw new Error("write_failed");
+          }
+          ensureCollection(name).set(id, payload);
+        },
+      }),
+    }),
+  },
+}));
+
+describe("recordSystemObservabilityEvent", () => {
+  beforeEach(() => {
+    store.clear();
+    setShouldFail(false);
+  });
+
+  it("sanitizes unsafe context fields before writing", async () => {
+    const { recordSystemObservabilityEvent } = await import("../recordSystemObservabilityEvent");
+    const result = await recordSystemObservabilityEvent(
+      {
+        eventType: "integration_warning",
+        workflow: "screening",
+        severity: "warning",
+        actorType: "system",
+        title: "Unsafe context check",
+        description: "Testing sanitization behavior.",
+        safeContext: {
+          route: "/api/stripe/webhook",
+          actionKey: "screening_warning",
+          resourceType: "screening_order",
+          resourceId: "order-1",
+          // @ts-expect-error test-only unknown key
+          email: "tenant@example.com",
+          // @ts-expect-error test-only unknown key
+          signedUrl: "https://example.com/file.pdf?X-Amz-Signature=abc",
+        },
+      },
+      { failSoft: false }
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.record?.safeContext).toEqual({
+      route: "/api/stripe/webhook",
+      actionKey: "screening_warning",
+      resourceType: "screening_order",
+      resourceId: "order-1",
+    });
+    expect(JSON.stringify(result.record)).not.toContain("@");
+    expect(JSON.stringify(result.record)).not.toContain("X-Amz-Signature");
+  });
+
+  it("writes a safe event record with resolved timestamps for completed workflows", async () => {
+    const { recordSystemObservabilityEvent } = await import("../recordSystemObservabilityEvent");
+    const result = await recordSystemObservabilityEvent(
+      {
+        eventType: "workflow_completed",
+        workflow: "payment",
+        severity: "info",
+        actorType: "system",
+        title: "Rent payment completed",
+        description: "A rent payment completed successfully.",
+        safeContext: {
+          resourceType: "rent_payment",
+          resourceId: "rp-1",
+        },
+        occurredAt: "2026-04-28T12:00:00.000Z",
+      },
+      { failSoft: false }
+    );
+
+    const stored = result.record;
+    expect(stored).toEqual(
+      expect.objectContaining({
+        version: "v1",
+        eventType: "workflow_completed",
+        workflow: "payment",
+        status: "resolved",
+        resolvedAt: "2026-04-28T12:00:00.000Z",
+      })
+    );
+  });
+
+  it("deduplicates writes when the same idempotency key repeats", async () => {
+    const { recordSystemObservabilityEvent } = await import("../recordSystemObservabilityEvent");
+    const first = await recordSystemObservabilityEvent(
+      {
+        eventType: "integration_warning",
+        workflow: "screening",
+        severity: "warning",
+        actorType: "system",
+        title: "Webhook missing application",
+        description: "Webhook missing application metadata.",
+        idempotencyKey: "screening:webhook_missing_application:evt-1",
+      },
+      { failSoft: false }
+    );
+    const second = await recordSystemObservabilityEvent(
+      {
+        eventType: "integration_warning",
+        workflow: "screening",
+        severity: "warning",
+        actorType: "system",
+        title: "Webhook missing application",
+        description: "Webhook missing application metadata.",
+        idempotencyKey: "screening:webhook_missing_application:evt-1",
+      },
+      { failSoft: false }
+    );
+
+    expect(first.record?.id).toBe(second.record?.id);
+    expect(second.duplicate).toBe(true);
+    expect(Array.from(ensureCollection("systemObservabilityEvents").values())).toHaveLength(1);
+  });
+
+  it("fails softly when a write cannot be persisted", async () => {
+    const { recordSystemObservabilityEvent } = await import("../recordSystemObservabilityEvent");
+    setShouldFail(true);
+    const result = await recordSystemObservabilityEvent({
+      eventType: "action_failed",
+      workflow: "payment",
+      severity: "warning",
+      actorType: "system",
+      title: "Rent payment failed",
+      description: "A payment failed.",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      duplicate: false,
+      record: null,
+    });
+    expect(Array.from(ensureCollection("systemObservabilityEvents").values())).toHaveLength(0);
+  });
+});

--- a/rentchain-api/src/services/observability/deriveSystemObservabilitySummary.ts
+++ b/rentchain-api/src/services/observability/deriveSystemObservabilitySummary.ts
@@ -1,0 +1,132 @@
+import {
+  SYSTEM_OBSERVABILITY_EVENTS_COLLECTION,
+  SYSTEM_OBSERVABILITY_WORKFLOWS,
+  type SystemObservabilityEventRecord,
+  type SystemObservabilitySeverity,
+  type SystemObservabilitySummary,
+  type SystemObservabilityWorkflow,
+} from "./observabilityTypes";
+import { db } from "../../config/firebase";
+
+function toMillis(value: unknown): number {
+  const parsed = Date.parse(String(value || ""));
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function deriveWorkflowHealth(input: {
+  openCritical: number;
+  openWarnings: number;
+}): "healthy" | "watch" | "attention" {
+  if (input.openCritical > 0) return "attention";
+  if (input.openWarnings > 0) return "watch";
+  return "healthy";
+}
+
+function severityRank(value: SystemObservabilitySeverity): number {
+  if (value === "critical") return 3;
+  if (value === "warning") return 2;
+  return 1;
+}
+
+export async function deriveSystemObservabilitySummary(input?: {
+  period?: "7d" | "30d" | null;
+  now?: Date;
+}): Promise<SystemObservabilitySummary> {
+  const now = input?.now || new Date();
+  const period = input?.period === "30d" ? "30d" : "7d";
+  const recentWindowMs = period === "30d" ? 30 * 24 * 60 * 60 * 1000 : 7 * 24 * 60 * 60 * 1000;
+  const resolvedWindowMs = 7 * 24 * 60 * 60 * 1000;
+  const recentCutoff = now.getTime() - recentWindowMs;
+  const resolvedCutoff = now.getTime() - resolvedWindowMs;
+
+  const snapshot = await db.collection(SYSTEM_OBSERVABILITY_EVENTS_COLLECTION).get();
+  const events = (snapshot.docs || [])
+    .map((doc: any) => (doc.data ? doc.data() : null) as SystemObservabilityEventRecord | null)
+    .filter(Boolean) as SystemObservabilityEventRecord[];
+
+  const openEvents = events.filter((event) => event.status === "open");
+  const openCritical = openEvents.filter((event) => event.severity === "critical").length;
+  const openWarnings = openEvents.filter((event) => event.severity === "warning").length;
+  const resolvedLast7Days = events.filter((event) => {
+    if (event.status !== "resolved") return false;
+    return toMillis(event.resolvedAt || event.occurredAt) >= resolvedCutoff;
+  }).length;
+
+  const workflows = SYSTEM_OBSERVABILITY_WORKFLOWS.map((workflow) => {
+    const workflowEvents = events.filter((event) => event.workflow === workflow);
+    const workflowOpenCritical = workflowEvents.filter(
+      (event) => event.status === "open" && event.severity === "critical"
+    ).length;
+    const workflowOpenWarnings = workflowEvents.filter(
+      (event) => event.status === "open" && event.severity === "warning"
+    ).length;
+    const recentCompleted = workflowEvents.filter(
+      (event) => event.eventType === "workflow_completed" && toMillis(event.occurredAt) >= recentCutoff
+    ).length;
+
+    return {
+      workflow,
+      openCritical: workflowOpenCritical,
+      openWarnings: workflowOpenWarnings,
+      recentCompleted,
+      health: deriveWorkflowHealth({
+        openCritical: workflowOpenCritical,
+        openWarnings: workflowOpenWarnings,
+      }),
+    };
+  });
+
+  const groupedIssues = new Map<
+    string,
+    {
+      title: string;
+      workflow: SystemObservabilityWorkflow;
+      severity: SystemObservabilitySeverity;
+      count: number;
+      lastSeenAt: string;
+    }
+  >();
+
+  openEvents
+    .filter((event) => event.severity === "warning" || event.severity === "critical")
+    .forEach((event) => {
+      const key = `${event.workflow}::${event.severity}::${event.title}`;
+      const existing = groupedIssues.get(key);
+      if (!existing) {
+        groupedIssues.set(key, {
+          title: event.title,
+          workflow: event.workflow,
+          severity: event.severity,
+          count: 1,
+          lastSeenAt: event.occurredAt,
+        });
+        return;
+      }
+
+      groupedIssues.set(key, {
+        ...existing,
+        count: existing.count + 1,
+        lastSeenAt: toMillis(event.occurredAt) > toMillis(existing.lastSeenAt) ? event.occurredAt : existing.lastSeenAt,
+      });
+    });
+
+  const topIssues = Array.from(groupedIssues.values())
+    .sort((a, b) => {
+      const severityDiff = severityRank(b.severity) - severityRank(a.severity);
+      if (severityDiff !== 0) return severityDiff;
+      if (b.count !== a.count) return b.count - a.count;
+      return toMillis(b.lastSeenAt) - toMillis(a.lastSeenAt);
+    })
+    .slice(0, 5);
+
+  return {
+    generatedAt: now.toISOString(),
+    totals: {
+      openCritical,
+      openWarnings,
+      resolvedLast7Days,
+    },
+    workflows,
+    topIssues,
+  };
+}

--- a/rentchain-api/src/services/observability/observabilityTypes.ts
+++ b/rentchain-api/src/services/observability/observabilityTypes.ts
@@ -1,0 +1,95 @@
+export const SYSTEM_OBSERVABILITY_EVENTS_COLLECTION = "systemObservabilityEvents";
+
+export const SYSTEM_OBSERVABILITY_WORKFLOWS = [
+  "application",
+  "screening",
+  "lease",
+  "payment",
+  "maintenance",
+  "messages",
+  "institutional",
+  "dashboard",
+  "analytics",
+] as const;
+
+export type SystemObservabilityEventType =
+  | "workflow_started"
+  | "workflow_completed"
+  | "workflow_blocked"
+  | "action_failed"
+  | "integration_warning"
+  | "data_quality_warning";
+
+export type SystemObservabilityWorkflow = (typeof SYSTEM_OBSERVABILITY_WORKFLOWS)[number];
+
+export type SystemObservabilitySeverity = "info" | "warning" | "critical";
+export type SystemObservabilityActorType = "tenant" | "landlord" | "admin" | "system";
+export type SystemObservabilityStatus = "open" | "resolved" | "ignored";
+
+export type SystemObservabilitySafeContext = {
+  route?: string;
+  actionKey?: string;
+  resourceType?: string;
+  resourceId?: string;
+};
+
+export type SystemObservabilityEventSource = {
+  kind: "canonical_event" | "system_observability";
+  sourceEventId?: string | null;
+};
+
+export type SystemObservabilityEventInput = {
+  eventType: SystemObservabilityEventType;
+  workflow: SystemObservabilityWorkflow;
+  severity: SystemObservabilitySeverity;
+  actorType: SystemObservabilityActorType;
+  status?: SystemObservabilityStatus;
+  title: string;
+  description: string;
+  safeContext?: SystemObservabilitySafeContext | null;
+  idempotencyKey?: string | null;
+  source?: SystemObservabilityEventSource | null;
+  occurredAt?: string | number | Date | null;
+  resolvedAt?: string | number | Date | null;
+};
+
+export type SystemObservabilityEventRecord = {
+  id: string;
+  version: "v1";
+  eventType: SystemObservabilityEventType;
+  workflow: SystemObservabilityWorkflow;
+  severity: SystemObservabilitySeverity;
+  actorType: SystemObservabilityActorType;
+  status: SystemObservabilityStatus;
+  title: string;
+  description: string;
+  safeContext: SystemObservabilitySafeContext | null;
+  idempotencyKey: string | null;
+  source: SystemObservabilityEventSource;
+  occurredAt: string;
+  recordedAt: string;
+  resolvedAt: string | null;
+};
+
+export type SystemObservabilitySummary = {
+  generatedAt: string;
+  totals: {
+    openCritical: number;
+    openWarnings: number;
+    resolvedLast7Days: number;
+  };
+  workflows: Array<{
+    workflow: SystemObservabilityWorkflow;
+    openCritical: number;
+    openWarnings: number;
+    recentCompleted: number;
+    health: "healthy" | "watch" | "attention";
+  }>;
+  topIssues: Array<{
+    title: string;
+    workflow: SystemObservabilityWorkflow;
+    severity: SystemObservabilitySeverity;
+    count: number;
+    lastSeenAt: string;
+  }>;
+};

--- a/rentchain-api/src/services/observability/recordSystemObservabilityEvent.ts
+++ b/rentchain-api/src/services/observability/recordSystemObservabilityEvent.ts
@@ -1,0 +1,138 @@
+import crypto from "crypto";
+import { db } from "../../config/firebase";
+import {
+  SYSTEM_OBSERVABILITY_EVENTS_COLLECTION,
+  type SystemObservabilityEventInput,
+  type SystemObservabilityEventRecord,
+  type SystemObservabilitySafeContext,
+  type SystemObservabilityStatus,
+} from "./observabilityTypes";
+
+const SAFE_CONTEXT_KEYS = new Set(["route", "actionKey", "resourceType", "resourceId"]);
+const EMAIL_PATTERN = /\b[^\s@]+@[^\s@]+\.[^\s@]+\b/;
+const URL_PATTERN = /https?:\/\//i;
+const SIGNED_URL_PATTERN = /(x-amz-signature|googleaccessid|signature=|expires=|token=)/i;
+const TOKEN_PATTERN = /\b(bearer|token|whsec_|sk_live_|sk_test_|pk_live_|pk_test_|eyJ[a-zA-Z0-9._-]+)\b/i;
+const BASE64ISH_PATTERN = /^[A-Za-z0-9+/_=-]{80,}$/;
+const FILE_NAME_PATTERN = /\b[\w-]+\.(pdf|docx?|xlsx?|csv|png|jpe?g|gif)\b/i;
+
+function normalizeString(value: unknown, max: number): string {
+  return String(value || "").trim().replace(/\s+/g, " ").slice(0, max);
+}
+
+function toIsoString(value: unknown, fallback = new Date()): string {
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) return new Date(parsed).toISOString();
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return new Date(value).toISOString();
+  }
+  if (value instanceof Date && Number.isFinite(value.getTime())) {
+    return value.toISOString();
+  }
+  return fallback.toISOString();
+}
+
+function isUnsafeValue(value: string, key: keyof SystemObservabilitySafeContext): boolean {
+  if (!value) return true;
+  if (URL_PATTERN.test(value) || SIGNED_URL_PATTERN.test(value)) return true;
+  if (EMAIL_PATTERN.test(value) || TOKEN_PATTERN.test(value)) return true;
+  if (BASE64ISH_PATTERN.test(value) || FILE_NAME_PATTERN.test(value)) return true;
+  if (key !== "route" && value.includes("/")) return true;
+  if (key === "route" && !value.startsWith("/")) return true;
+  if (value.includes("projects/") || value.includes("documents/")) return true;
+  return false;
+}
+
+export function sanitizeSystemObservabilitySafeContext(
+  input?: SystemObservabilitySafeContext | null
+): SystemObservabilitySafeContext | null {
+  if (!input || typeof input !== "object") return null;
+
+  const next: SystemObservabilitySafeContext = {};
+  (Object.keys(input) as Array<keyof SystemObservabilitySafeContext>).forEach((key) => {
+    if (!SAFE_CONTEXT_KEYS.has(key)) return;
+    const max = key === "resourceId" ? 120 : 100;
+    const value = normalizeString(input[key], max);
+    if (!value) return;
+    if (isUnsafeValue(value, key)) return;
+    next[key] = value;
+  });
+
+  return Object.keys(next).length ? next : null;
+}
+
+function deriveDefaultStatus(eventType: SystemObservabilityEventInput["eventType"]): SystemObservabilityStatus {
+  if (eventType === "workflow_completed") return "resolved";
+  if (eventType === "workflow_started") return "open";
+  return "open";
+}
+
+function deriveResolvedAt(input: SystemObservabilityEventInput, occurredAt: string): string | null {
+  if (input.resolvedAt) return toIsoString(input.resolvedAt, new Date(occurredAt));
+  if ((input.status || deriveDefaultStatus(input.eventType)) === "resolved") return occurredAt;
+  return null;
+}
+
+function buildEventId(idempotencyKey?: string | null): string {
+  const normalizedKey = normalizeString(idempotencyKey, 240);
+  if (!normalizedKey) return crypto.randomUUID();
+  return `obs_${crypto.createHash("sha256").update(normalizedKey).digest("hex").slice(0, 32)}`;
+}
+
+export async function recordSystemObservabilityEvent(
+  input: SystemObservabilityEventInput,
+  options?: { failSoft?: boolean }
+): Promise<{ ok: boolean; duplicate: boolean; record: SystemObservabilityEventRecord | null }> {
+  const failSoft = options?.failSoft !== false;
+
+  try {
+    const now = new Date();
+    const occurredAt = toIsoString(input.occurredAt, now);
+    const idempotencyKey = normalizeString(input.idempotencyKey, 240) || null;
+    const id = buildEventId(idempotencyKey);
+    const ref = db.collection(SYSTEM_OBSERVABILITY_EVENTS_COLLECTION).doc(id);
+    const existingSnap = idempotencyKey ? await ref.get() : null;
+    const existing = existingSnap?.exists ? ((existingSnap.data() as SystemObservabilityEventRecord) || null) : null;
+    const recordedAt = existing?.recordedAt || now.toISOString();
+    const status = input.status || deriveDefaultStatus(input.eventType);
+
+    const record: SystemObservabilityEventRecord = {
+      id,
+      version: "v1",
+      eventType: input.eventType,
+      workflow: input.workflow,
+      severity: input.severity,
+      actorType: input.actorType,
+      status,
+      title: normalizeString(input.title, 160) || "System observability event",
+      description: normalizeString(input.description, 500) || "Operational workflow event recorded.",
+      safeContext: sanitizeSystemObservabilitySafeContext(input.safeContext),
+      idempotencyKey,
+      source: input.source?.kind
+        ? {
+            kind: input.source.kind,
+            sourceEventId: normalizeString(input.source.sourceEventId, 160) || null,
+          }
+        : {
+            kind: "system_observability",
+            sourceEventId: null,
+          },
+      occurredAt,
+      recordedAt,
+      resolvedAt: deriveResolvedAt({ ...input, status }, occurredAt),
+    };
+
+    await ref.set(record, { merge: false });
+    return { ok: true, duplicate: Boolean(existing), record };
+  } catch (err) {
+    if (!failSoft) throw err;
+    console.warn("[systemObservability] record failed softly", {
+      eventType: input?.eventType || null,
+      workflow: input?.workflow || null,
+      message: (err as any)?.message || err,
+    });
+    return { ok: false, duplicate: false, record: null };
+  }
+}

--- a/rentchain-api/src/services/rentPayments/rentPaymentService.ts
+++ b/rentchain-api/src/services/rentPayments/rentPaymentService.ts
@@ -5,6 +5,7 @@ import { FRONTEND_URL } from "../../config/screeningConfig";
 import { getStripeClient } from "../stripeService";
 import { writeCanonicalEvent } from "../../lib/events/buildEvent";
 import type { PaymentReadiness } from "../paymentReadiness/derivePaymentReadiness";
+import { recordSystemObservabilityEvent } from "../observability/recordSystemObservabilityEvent";
 
 export const RENT_PAYMENTS_COLLECTION = "rentPayments";
 
@@ -290,6 +291,97 @@ async function writeRentPaymentEvent(params: {
   });
 }
 
+async function recordRentPaymentObservabilityEvent(params: {
+  rentPaymentId: string;
+  status: RentPaymentStatus;
+  occurredAt?: string | null;
+  actorType: "tenant" | "landlord" | "admin" | "system";
+}) {
+  if (params.status === "payment_pending") return;
+
+  const titles: Record<RentPaymentStatus, { eventType: any; severity: "info" | "warning"; status?: "resolved" | "open"; title: string; description: string; actionKey: string; }> = {
+    setup_required: {
+      eventType: "workflow_blocked",
+      severity: "warning",
+      status: "open",
+      title: "Rent payment setup required",
+      description: "A rent payment workflow remains blocked until payment setup is completed.",
+      actionKey: "rent_payment_setup_required",
+    },
+    checkout_created: {
+      eventType: "workflow_started",
+      severity: "info",
+      status: "open",
+      title: "Rent payment checkout created",
+      description: "A rent payment checkout was created and is awaiting processor completion.",
+      actionKey: "rent_payment_checkout_created",
+    },
+    payment_pending: {
+      eventType: "workflow_started",
+      severity: "info",
+      status: "open",
+      title: "Rent payment pending",
+      description: "A rent payment is waiting for processor confirmation.",
+      actionKey: "rent_payment_pending",
+    },
+    paid: {
+      eventType: "workflow_completed",
+      severity: "info",
+      status: "resolved",
+      title: "Rent payment completed",
+      description: "A rent payment was confirmed successfully.",
+      actionKey: "rent_payment_paid",
+    },
+    failed: {
+      eventType: "action_failed",
+      severity: "warning",
+      status: "open",
+      title: "Rent payment failed",
+      description: "A rent payment failed after checkout creation.",
+      actionKey: "rent_payment_failed",
+    },
+    canceled: {
+      eventType: "workflow_blocked",
+      severity: "warning",
+      status: "open",
+      title: "Rent payment checkout canceled",
+      description: "A rent payment checkout was canceled before completion.",
+      actionKey: "rent_payment_canceled",
+    },
+    expired: {
+      eventType: "workflow_blocked",
+      severity: "warning",
+      status: "open",
+      title: "Rent payment checkout expired",
+      description: "A rent payment checkout expired before completion.",
+      actionKey: "rent_payment_expired",
+    },
+  };
+
+  const definition = titles[params.status];
+  await recordSystemObservabilityEvent(
+    {
+      eventType: definition.eventType,
+      workflow: "payment",
+      severity: definition.severity,
+      actorType: params.actorType,
+      status: definition.status,
+      title: definition.title,
+      description: definition.description,
+      safeContext: {
+        actionKey: definition.actionKey,
+        resourceType: "rent_payment",
+        resourceId: params.rentPaymentId,
+      },
+      occurredAt: params.occurredAt || new Date().toISOString(),
+      source: {
+        kind: "system_observability",
+      },
+    },
+    { failSoft: true }
+  );
+}
+
 export function deriveRentPaymentEligibility(input: {
   lease: LeaseLike;
   paymentReadiness: PaymentReadiness | null | undefined;
@@ -474,6 +566,12 @@ export async function createRentPaymentCheckout(input: CreateRentPaymentCheckout
       role: "tenant",
     },
   });
+  await recordRentPaymentObservabilityEvent({
+    rentPaymentId,
+    status: "checkout_created",
+    occurredAt: createdAt,
+    actorType: "tenant",
+  });
 
   return {
     ok: true as const,
@@ -519,6 +617,12 @@ export async function updateRentPaymentFromWebhook(input: UpdateRentPaymentFromW
       id: null,
       role: "system",
     },
+  });
+  await recordRentPaymentObservabilityEvent({
+    rentPaymentId: current.id,
+    status: input.nextStatus,
+    occurredAt: input.paidAt || updatedAt,
+    actorType: "system",
   });
 
   return {

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -108,6 +108,7 @@ const SupportDebugConsolePage = lazy(() => import("./pages/admin/SupportDebugCon
 const SecurityReliabilityConsolePage = lazy(() => import("./pages/admin/SecurityReliabilityConsolePage"));
 const AdminTriageQueuePage = lazy(() => import("./pages/admin/AdminTriageQueuePage"));
 const AdminAlertingPage = lazy(() => import("./pages/admin/AdminAlertingPage"));
+const AdminObservabilityPage = lazy(() => import("./pages/admin/AdminObservabilityPage"));
 const AdminNotificationsPage = lazy(() => import("./pages/admin/AdminNotificationsPage"));
 const PortfolioScorePage = lazy(() => import("./pages/admin/PortfolioScorePage"));
 const PortfolioScoreHistoryPage = lazy(() => import("./pages/admin/PortfolioScoreHistoryPage"));
@@ -1026,6 +1027,14 @@ function App() {
               element={
                 <RequireAdmin>
                   <AdminAlertingPage />
+                </RequireAdmin>
+              }
+            />
+            <Route
+              path="/admin/observability"
+              element={
+                <RequireAdmin>
+                  <AdminObservabilityPage />
                 </RequireAdmin>
               }
             />

--- a/rentchain-frontend/src/api/adminObservabilityApi.ts
+++ b/rentchain-frontend/src/api/adminObservabilityApi.ts
@@ -1,0 +1,36 @@
+import { apiFetch } from "./apiFetch";
+
+export type SystemObservabilitySummary = {
+  generatedAt: string;
+  totals: {
+    openCritical: number;
+    openWarnings: number;
+    resolvedLast7Days: number;
+  };
+  workflows: Array<{
+    workflow: string;
+    openCritical: number;
+    openWarnings: number;
+    recentCompleted: number;
+    health: "healthy" | "watch" | "attention";
+  }>;
+  topIssues: Array<{
+    title: string;
+    workflow: string;
+    severity: "info" | "warning" | "critical";
+    count: number;
+    lastSeenAt: string;
+  }>;
+};
+
+export async function fetchAdminObservabilitySummary(
+  params?: { period?: "7d" | "30d" | null }
+): Promise<SystemObservabilitySummary> {
+  const search = new URLSearchParams();
+  if (params?.period) search.set("period", params.period);
+  const query = search.toString();
+  const response = await apiFetch<{ ok: true; summary: SystemObservabilitySummary }>(
+    `/admin/observability/summary${query ? `?${query}` : ""}`
+  );
+  return response.summary;
+}

--- a/rentchain-frontend/src/pages/admin/AdminObservabilityPage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminObservabilityPage.test.tsx
@@ -1,0 +1,119 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import AdminObservabilityPage from "./AdminObservabilityPage";
+
+const showToast = vi.fn();
+
+vi.mock("../../api/adminObservabilityApi", () => ({
+  fetchAdminObservabilitySummary: vi.fn(),
+}));
+
+vi.mock("../../components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast }),
+}));
+
+vi.mock("../../components/layout/MacShell", () => ({
+  MacShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("../../components/ui/Ui", () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  Pill: ({ children }: any) => <span>{children}</span>,
+  Section: ({ children }: any) => <section>{children}</section>,
+}));
+
+beforeEach(() => {
+  showToast.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("AdminObservabilityPage", () => {
+  it("renders totals, workflow health rows, and top issues", async () => {
+    const { fetchAdminObservabilitySummary } = await import("../../api/adminObservabilityApi");
+    vi.mocked(fetchAdminObservabilitySummary).mockResolvedValue({
+      generatedAt: "2026-04-28T18:00:00.000Z",
+      totals: {
+        openCritical: 1,
+        openWarnings: 2,
+        resolvedLast7Days: 4,
+      },
+      workflows: [
+        {
+          workflow: "payment",
+          openCritical: 0,
+          openWarnings: 1,
+          recentCompleted: 2,
+          health: "watch",
+        },
+      ],
+      topIssues: [
+        {
+          title: "Rent payment failed",
+          workflow: "payment",
+          severity: "warning",
+          count: 2,
+          lastSeenAt: "2026-04-28T17:00:00.000Z",
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter>
+        <AdminObservabilityPage />
+      </MemoryRouter>
+    );
+
+    expect((await screen.findAllByText("Workflow health")).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Open critical").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Open warnings").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Recent completions").length).toBeGreaterThan(0);
+    expect(screen.getByText("Payment")).toBeInTheDocument();
+    expect(screen.getByText("Rent payment failed")).toBeInTheDocument();
+    expect(screen.queryByText("resourceId")).not.toBeInTheDocument();
+  });
+
+  it("renders an empty state when no workflow data exists", async () => {
+    const { fetchAdminObservabilitySummary } = await import("../../api/adminObservabilityApi");
+    vi.mocked(fetchAdminObservabilitySummary).mockResolvedValue({
+      generatedAt: "2026-04-28T18:00:00.000Z",
+      totals: {
+        openCritical: 0,
+        openWarnings: 0,
+        resolvedLast7Days: 0,
+      },
+      workflows: [],
+      topIssues: [],
+    });
+
+    render(
+      <MemoryRouter>
+        <AdminObservabilityPage />
+      </MemoryRouter>
+    );
+
+    expect(
+      await screen.findByText("No workflow health issues or recent completions are available right now.")
+    ).toBeInTheDocument();
+  });
+
+  it("renders an error state without leaking operational details", async () => {
+    const { fetchAdminObservabilitySummary } = await import("../../api/adminObservabilityApi");
+    vi.mocked(fetchAdminObservabilitySummary).mockRejectedValue(new Error("summary_failed"));
+
+    render(
+      <MemoryRouter>
+        <AdminObservabilityPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Failed to load workflow health: summary_failed")).toBeInTheDocument();
+    expect(showToast).toHaveBeenCalled();
+  });
+});

--- a/rentchain-frontend/src/pages/admin/AdminObservabilityPage.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminObservabilityPage.tsx
@@ -1,0 +1,202 @@
+import React from "react";
+import { MacShell } from "../../components/layout/MacShell";
+import { Button, Card, Pill, Section } from "../../components/ui/Ui";
+import { useToast } from "../../components/ui/ToastProvider";
+import {
+  fetchAdminObservabilitySummary,
+  type SystemObservabilitySummary,
+} from "../../api/adminObservabilityApi";
+
+const EMPTY_SUMMARY: SystemObservabilitySummary = {
+  generatedAt: new Date(0).toISOString(),
+  totals: {
+    openCritical: 0,
+    openWarnings: 0,
+    resolvedLast7Days: 0,
+  },
+  workflows: [],
+  topIssues: [],
+};
+
+function formatWorkflowLabel(workflow: string): string {
+  return workflow
+    .split("_")
+    .join(" ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function formatTimestamp(value: string): string {
+  const ts = Date.parse(String(value || ""));
+  if (!Number.isFinite(ts)) return "Unknown";
+  return new Date(ts).toLocaleString();
+}
+
+export default function AdminObservabilityPage() {
+  const { showToast } = useToast();
+  const [summary, setSummary] = React.useState<SystemObservabilitySummary>(EMPTY_SUMMARY);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const load = React.useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const next = await fetchAdminObservabilitySummary({ period: "7d" });
+      setSummary(next);
+    } catch (err: any) {
+      const message = err?.message || "Failed to load workflow health";
+      setError(message);
+      showToast({
+        message: "Failed to load workflow health",
+        description: message,
+        variant: "error",
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [showToast]);
+
+  React.useEffect(() => {
+    void load();
+  }, [load]);
+
+  const hasData =
+    summary.totals.openCritical > 0 ||
+    summary.totals.openWarnings > 0 ||
+    summary.totals.resolvedLast7Days > 0 ||
+    summary.workflows.some(
+      (workflow) => workflow.openCritical > 0 || workflow.openWarnings > 0 || workflow.recentCompleted > 0
+    ) ||
+    summary.topIssues.length > 0;
+
+  return (
+    <MacShell title="Admin · Workflow health">
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              gap: 16,
+              alignItems: "flex-start",
+              flexWrap: "wrap",
+            }}
+          >
+            <div style={{ display: "grid", gap: 6 }}>
+              <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+                <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Workflow health</h1>
+                <Pill tone="accent">Admin</Pill>
+              </div>
+              <div style={{ color: "#475569", maxWidth: 820 }}>
+                Internal workflow health summary across high-signal payment, screening, lease, and institutional events.
+              </div>
+            </div>
+            <Button variant="secondary" onClick={() => void load()} disabled={loading}>
+              Refresh
+            </Button>
+          </div>
+        </Section>
+
+        {loading ? <Card>Loading workflow health…</Card> : null}
+        {!loading && error ? <Card style={{ color: "#b91c1c" }}>Failed to load workflow health: {error}</Card> : null}
+
+        {!loading && !error ? (
+          <>
+            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 16 }}>
+              <Card>
+                <div style={{ fontSize: 12, color: "#64748b" }}>Open critical</div>
+                <div style={{ fontSize: 24, fontWeight: 700 }}>{summary.totals.openCritical}</div>
+              </Card>
+              <Card>
+                <div style={{ fontSize: 12, color: "#64748b" }}>Open warnings</div>
+                <div style={{ fontSize: 24, fontWeight: 700 }}>{summary.totals.openWarnings}</div>
+              </Card>
+              <Card>
+                <div style={{ fontSize: 12, color: "#64748b" }}>Recent completions</div>
+                <div style={{ fontSize: 24, fontWeight: 700 }}>{summary.totals.resolvedLast7Days}</div>
+              </Card>
+              <Card>
+                <div style={{ fontSize: 12, color: "#64748b" }}>Last generated</div>
+                <div style={{ fontSize: 14, fontWeight: 600 }}>{formatTimestamp(summary.generatedAt)}</div>
+              </Card>
+            </div>
+
+            {hasData ? (
+              <>
+                <Card>
+                  <div style={{ display: "grid", gap: 12 }}>
+                    <div style={{ fontWeight: 700 }}>Workflow health</div>
+                    <div style={{ overflowX: "auto" }}>
+                      <table style={{ width: "100%", borderCollapse: "collapse" }}>
+                        <thead>
+                          <tr style={{ textAlign: "left", color: "#64748b", fontSize: 13 }}>
+                            <th style={{ padding: "0 0 10px" }}>Workflow</th>
+                            <th style={{ padding: "0 0 10px" }}>Open critical</th>
+                            <th style={{ padding: "0 0 10px" }}>Open warnings</th>
+                            <th style={{ padding: "0 0 10px" }}>Recent completed</th>
+                            <th style={{ padding: "0 0 10px" }}>Health</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {summary.workflows.map((workflow) => (
+                            <tr key={workflow.workflow} style={{ borderTop: "1px solid rgba(15, 23, 42, 0.08)" }}>
+                              <td style={{ padding: "10px 0", fontWeight: 600 }}>
+                                {formatWorkflowLabel(workflow.workflow)}
+                              </td>
+                              <td style={{ padding: "10px 0" }}>{workflow.openCritical}</td>
+                              <td style={{ padding: "10px 0" }}>{workflow.openWarnings}</td>
+                              <td style={{ padding: "10px 0" }}>{workflow.recentCompleted}</td>
+                              <td style={{ padding: "10px 0" }}>
+                                <Pill tone={workflow.health === "attention" ? "accent" : "muted"}>
+                                  {workflow.health === "attention"
+                                    ? "Needs attention"
+                                    : workflow.health === "watch"
+                                    ? "Watch"
+                                    : "Healthy"}
+                                </Pill>
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                </Card>
+
+                <Card>
+                  <div style={{ display: "grid", gap: 12 }}>
+                    <div style={{ fontWeight: 700 }}>Top issues</div>
+                    {summary.topIssues.length ? (
+                      <div style={{ display: "grid", gap: 10 }}>
+                        {summary.topIssues.map((issue) => (
+                          <div
+                            key={`${issue.workflow}-${issue.severity}-${issue.title}`}
+                            style={{ borderTop: "1px solid rgba(15, 23, 42, 0.08)", paddingTop: 10 }}
+                          >
+                            <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+                              <div style={{ fontWeight: 600 }}>{issue.title}</div>
+                              <Pill tone={issue.severity === "critical" ? "accent" : "muted"}>
+                                {issue.severity}
+                              </Pill>
+                            </div>
+                            <div style={{ color: "#475569" }}>
+                              {formatWorkflowLabel(issue.workflow)} · Count {issue.count} · Last seen {formatTimestamp(issue.lastSeenAt)}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <div style={{ color: "#64748b" }}>No open workflow issues need attention right now.</div>
+                    )}
+                  </div>
+                </Card>
+              </>
+            ) : (
+              <Card>No workflow health issues or recent completions are available right now.</Card>
+            )}
+          </>
+        ) : null}
+      </div>
+    </MacShell>
+  );
+}


### PR DESCRIPTION
This PR introduces System Observability v1.

Includes:
- high-signal system observability event model
- sanitized systemObservabilityEvents records
- safe observability recorder and summary derivation
- admin-only GET /api/admin/observability/summary
- admin Workflow health page at /admin/observability
- instrumentation for rent payment transitions, screening webhook outcomes, tenant lease signing, and institutional handoff draft creation
- focused backend/frontend test coverage

Guardrails preserved:
- no third-party analytics
- no page-view/clickstream/session replay/keystroke tracking
- no landlord or tenant observability surfaces
- no raw event explorer
- no arbitrary metadata passthrough
- no raw provider payloads, payment methods, document URLs, share/auth tokens, signed URLs, emails, or file names
- no payment/provider behavior changes
- no permission expansion