### PR TITLE
feat: expand identity network visibility

### DIFF
--- a/rentchain-api/src/services/networkReuse/__tests__/deriveNetworkReuseSummary.test.ts
+++ b/rentchain-api/src/services/networkReuse/__tests__/deriveNetworkReuseSummary.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { deriveNetworkReuseSummary } from "../deriveNetworkReuseSummary";
 
 describe("deriveNetworkReuseSummary", () => {
-  it("derives available reuse for apply-with-rentchain metadata with sufficient scopes", () => {
+  it("derives available reuse for apply-with-rentchain metadata with identity and application scopes", () => {
     expect(
       deriveNetworkReuseSummary({
         applicationSource: "apply_with_rentchain",
@@ -11,13 +11,20 @@ describe("deriveNetworkReuseSummary", () => {
           referenceType: "tenant_identity_reference",
           referenceStatus: "available",
         },
-        approvedScopeKeys: ["identity_summary", "credibility_summary"],
+        approvedScopeKeys: ["identity_summary", "application_summary"],
       })
     ).toEqual({
       reusable: true,
       source: "apply_with_rentchain",
       reuseStatus: "available",
       consentRequired: true,
+      reusePath: "apply_prefill_ready",
+      reusePathLabel: "Apply prefill ready",
+      reusePathDescription:
+        "Tenant-approved identity and reusable application details are already in scope for the RentChain apply path.",
+      identitySummaryApproved: true,
+      applicationSummaryApproved: true,
+      additionalConsentMayUnlock: false,
     });
   });
 
@@ -36,6 +43,67 @@ describe("deriveNetworkReuseSummary", () => {
       source: "share_package",
       reuseStatus: "limited",
       consentRequired: true,
+      reusePath: "share_summary_ready",
+      reusePathLabel: "Summary reuse ready",
+      reusePathDescription:
+        "Tenant-approved RentChain reuse metadata is available for summary-only follow-through without expanding landlord access.",
+      identitySummaryApproved: false,
+      applicationSummaryApproved: false,
+      additionalConsentMayUnlock: true,
+    });
+  });
+
+  it("derives a more-available path when identity is approved but application reuse still needs approval", () => {
+    expect(
+      deriveNetworkReuseSummary({
+        identityReference: {
+          source: "rentchain",
+          referenceType: "tenant_identity_reference",
+          referenceStatus: "available",
+        },
+        approvedScopeKeys: ["identity_summary"],
+      })
+    ).toEqual({
+      reusable: true,
+      source: "share_package",
+      reuseStatus: "available",
+      consentRequired: true,
+      reusePath: "share_summary_with_more_available",
+      reusePathLabel: "More reusable detail available with approval",
+      reusePathDescription:
+        "Some tenant-approved reuse metadata is already available, and broader reusable application detail may still require additional tenant approval.",
+      identitySummaryApproved: true,
+      applicationSummaryApproved: false,
+      additionalConsentMayUnlock: true,
+    });
+  });
+
+  it("derives not-ready when reuse metadata exists but no reusable path is available", () => {
+    expect(
+      deriveNetworkReuseSummary({
+        identityReference: {
+          source: "rentchain",
+          referenceType: "tenant_identity_reference",
+          referenceStatus: "not_ready",
+        },
+        approvedScopeKeys: [],
+        portableIdentitySummary: {
+          portabilityStatus: "not_ready",
+          reusableAcrossApplications: false,
+        },
+      })
+    ).toEqual({
+      reusable: false,
+      source: "share_package",
+      reuseStatus: "not_available",
+      consentRequired: true,
+      reusePath: "not_ready",
+      reusePathLabel: "No reusable path ready",
+      reusePathDescription:
+        "A tenant-approved RentChain reuse path is not currently ready for broader follow-through.",
+      identitySummaryApproved: false,
+      applicationSummaryApproved: false,
+      additionalConsentMayUnlock: false,
     });
   });
 

--- a/rentchain-api/src/services/networkReuse/deriveNetworkReuseSummary.ts
+++ b/rentchain-api/src/services/networkReuse/deriveNetworkReuseSummary.ts
@@ -3,6 +3,16 @@ export type NetworkReuseSummary = {
   source: "share_package" | "apply_with_rentchain";
   reuseStatus: "available" | "limited" | "not_available";
   consentRequired: true;
+  reusePath:
+    | "apply_prefill_ready"
+    | "share_summary_ready"
+    | "share_summary_with_more_available"
+    | "not_ready";
+  reusePathLabel: string;
+  reusePathDescription: string;
+  identitySummaryApproved: boolean;
+  applicationSummaryApproved: boolean;
+  additionalConsentMayUnlock: boolean;
 };
 
 type Input = {
@@ -28,6 +38,12 @@ type Input = {
 
 const REUSE_SCOPE_KEYS = new Set(["identity_summary", "application_summary"]);
 
+function hasScope(approvedScopeKeys: Input["approvedScopeKeys"], scopeKey: string): boolean {
+  return Array.isArray(approvedScopeKeys)
+    ? approvedScopeKeys.some((scope) => String(scope || "") === scopeKey)
+    : false;
+}
+
 function hasReusableScope(
   approvedScopeKeys: Input["approvedScopeKeys"]
 ): boolean {
@@ -41,6 +57,8 @@ export function deriveNetworkReuseSummary(input: Input): NetworkReuseSummary | n
     input.applicationSource === "apply_with_rentchain" ? "apply_with_rentchain" : "share_package";
   const referenceStatus = input.identityReference?.referenceStatus || null;
   const scopeReady = hasReusableScope(input.approvedScopeKeys);
+  const identitySummaryApproved = hasScope(input.approvedScopeKeys, "identity_summary");
+  const applicationSummaryApproved = hasScope(input.approvedScopeKeys, "application_summary");
   const portabilityStatus = input.portableIdentitySummary?.portabilityStatus || "not_ready";
   const reusableAcrossApplications = input.portableIdentitySummary?.reusableAcrossApplications === true;
   const hasSourceMetadata =
@@ -64,10 +82,57 @@ export function deriveNetworkReuseSummary(input: Input): NetworkReuseSummary | n
     reuseStatus = "limited";
   }
 
+  const additionalConsentMayUnlock = Boolean(referenceStatus && referenceStatus !== "not_ready" && !applicationSummaryApproved);
+
+  let reusePath: NetworkReuseSummary["reusePath"] = "not_ready";
+  if (referenceStatus === "available" && identitySummaryApproved && applicationSummaryApproved) {
+    reusePath = "apply_prefill_ready";
+  } else if (
+    (referenceStatus === "available" || referenceStatus === "limited") &&
+    (identitySummaryApproved || applicationSummaryApproved) &&
+    additionalConsentMayUnlock
+  ) {
+    reusePath = "share_summary_with_more_available";
+  } else if (reuseStatus === "limited" || (referenceStatus === "available" && scopeReady)) {
+    reusePath = "share_summary_ready";
+  }
+
+  const copy: Record<
+    NetworkReuseSummary["reusePath"],
+    Pick<NetworkReuseSummary, "reusePathLabel" | "reusePathDescription">
+  > = {
+    apply_prefill_ready: {
+      reusePathLabel: "Apply prefill ready",
+      reusePathDescription:
+        "Tenant-approved identity and reusable application details are already in scope for the RentChain apply path.",
+    },
+    share_summary_ready: {
+      reusePathLabel: "Summary reuse ready",
+      reusePathDescription:
+        "Tenant-approved RentChain reuse metadata is available for summary-only follow-through without expanding landlord access.",
+    },
+    share_summary_with_more_available: {
+      reusePathLabel: "More reusable detail available with approval",
+      reusePathDescription:
+        "Some tenant-approved reuse metadata is already available, and broader reusable application detail may still require additional tenant approval.",
+    },
+    not_ready: {
+      reusePathLabel: "No reusable path ready",
+      reusePathDescription:
+        "A tenant-approved RentChain reuse path is not currently ready for broader follow-through.",
+    },
+  };
+
   return {
     reusable: reuseStatus !== "not_available",
     source,
     reuseStatus,
     consentRequired: true,
+    reusePath,
+    reusePathLabel: copy[reusePath].reusePathLabel,
+    reusePathDescription: copy[reusePath].reusePathDescription,
+    identitySummaryApproved,
+    applicationSummaryApproved,
+    additionalConsentMayUnlock,
   };
 }

--- a/rentchain-frontend/src/api/reviewSummaryApi.ts
+++ b/rentchain-frontend/src/api/reviewSummaryApi.ts
@@ -95,6 +95,16 @@ export type ApplicationReviewSummary = ReviewSummaryCore & {
     source: "share_package" | "apply_with_rentchain";
     reuseStatus: "available" | "limited" | "not_available";
     consentRequired: true;
+    reusePath:
+      | "apply_prefill_ready"
+      | "share_summary_ready"
+      | "share_summary_with_more_available"
+      | "not_ready";
+    reusePathLabel: string;
+    reusePathDescription: string;
+    identitySummaryApproved: boolean;
+    applicationSummaryApproved: boolean;
+    additionalConsentMayUnlock: boolean;
   } | null;
 };
 

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
@@ -142,6 +142,13 @@ describe("ApplicationReviewSummaryPage", () => {
         source: "apply_with_rentchain",
         reuseStatus: "available",
         consentRequired: true,
+        reusePath: "apply_prefill_ready",
+        reusePathLabel: "Apply prefill ready",
+        reusePathDescription:
+          "Tenant-approved identity and reusable application details are already in scope for the RentChain apply path.",
+        identitySummaryApproved: true,
+        applicationSummaryApproved: true,
+        additionalConsentMayUnlock: false,
       },
     } as any);
 
@@ -206,8 +213,11 @@ describe("ApplicationReviewSummaryPage", () => {
     expect(await screen.findByText("Credibility established")).toBeInTheDocument();
     expect(await screen.findByText("Most credibility signals are available in the current record.")).toBeInTheDocument();
     expect(await screen.findByText("Ready to reuse")).toBeInTheDocument();
-    expect(await screen.findByText("Reuse available")).toBeInTheDocument();
+    expect(await screen.findByText("Apply prefill ready")).toBeInTheDocument();
     expect(await screen.findByText("RentChain application")).toBeInTheDocument();
+    expect(await screen.findByText("Identity and application summaries approved")).toBeInTheDocument();
+    expect(await screen.findByText("Additional approval may unlock more")).toBeInTheDocument();
+    expect(await screen.findByText("No")).toBeInTheDocument();
     expect(await screen.findByText("Reusable across applications")).toBeInTheDocument();
     expect((await screen.findAllByText("Ready for review")).length).toBeGreaterThan(0);
     expect(await screen.findByText("Application information is mostly complete.")).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
@@ -278,6 +278,16 @@ function networkReuseSourceLabel(value: "share_package" | "apply_with_rentchain"
   return value === "apply_with_rentchain" ? "RentChain application" : "Share package";
 }
 
+function networkReusePathSupportLabel(
+  approvedIdentity: boolean | null | undefined,
+  approvedApplication: boolean | null | undefined
+) {
+  if (approvedIdentity && approvedApplication) return "Identity and application summaries approved";
+  if (approvedIdentity) return "Identity summary approved";
+  if (approvedApplication) return "Application summary approved";
+  return "No reusable summaries approved yet";
+}
+
 type SummaryLoadError = {
   message: string;
   status?: number;
@@ -1757,12 +1767,23 @@ function ApplicationReviewSummaryPageBody() {
             <Card style={{ display: "grid", gap: 8 }}>
               <div style={{ fontWeight: 700 }}>Network reuse</div>
               <div style={{ fontSize: 13, color: text.subtle }}>
-                This application already carries tenant-approved RentChain reuse metadata. It is descriptive only and does not expand landlord permissions or visibility.
+                {summary.networkReuseSummary.reusePathDescription} It is descriptive only and does not expand landlord permissions or visibility.
               </div>
               <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 8 }}>
-                {kv("Status", networkReuseStatusLabel(summary.networkReuseSummary.reuseStatus))}
+                {kv("Status", summary.networkReuseSummary.reusePathLabel)}
                 {kv("Source", networkReuseSourceLabel(summary.networkReuseSummary.source))}
                 {kv("Consent required", summary.networkReuseSummary.consentRequired ? "Yes" : "No")}
+                {kv(
+                  "Approved reuse support",
+                  networkReusePathSupportLabel(
+                    summary.networkReuseSummary.identitySummaryApproved,
+                    summary.networkReuseSummary.applicationSummaryApproved
+                  )
+                )}
+                {kv(
+                  "Additional approval may unlock more",
+                  summary.networkReuseSummary.additionalConsentMayUnlock ? "Yes" : "No"
+                )}
               </div>
             </Card>
           ) : null}

--- a/rentchain-frontend/src/pages/public/TenantSharePackagePage.test.tsx
+++ b/rentchain-frontend/src/pages/public/TenantSharePackagePage.test.tsx
@@ -68,6 +68,11 @@ describe("TenantSharePackagePage", () => {
     expect(screen.getByText(/Identity exchange available/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Request verification/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Apply with RentChain/i })).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /This shared profile supports summary-only reuse today\. Reusable application prefill is only available when both identity and application sharing have been approved by the tenant\./i
+      )
+    ).toBeInTheDocument();
     expect(screen.queryByText(/TransUnion/i)).not.toBeInTheDocument();
   });
 
@@ -118,7 +123,77 @@ describe("TenantSharePackagePage", () => {
         "payment_readiness_summary",
       ]);
     });
+    expect(
+      screen.getByText(
+        /Requesting additional sections does not grant access automatically\. The tenant must approve any expanded scope later\./i
+      )
+    ).toBeInTheDocument();
     expect(screen.getAllByText(/^Unavailable$/i).length).toBeGreaterThan(0);
+  });
+
+  it("explains when only summary reuse is available", async () => {
+    publicTenantSharePackageApi.fetchPublicTenantSharePackage.mockResolvedValue({
+      identity: {
+        identityStatus: "ready",
+        verification: { level: "partial" },
+        readinessLabel: "Ready to apply",
+        readinessDescription: "Your core profile and supporting records are ready for most rental workflows.",
+      },
+      identityExchangeReference: {
+        referenceType: "tenant_identity_reference",
+        referenceStatus: "limited",
+        referenceLabel: "Identity exchange available",
+        referenceDescription: "This rental identity can support summary-only exchange requests within the tenant-controlled sharing flow.",
+        portabilityStatus: "limited",
+      },
+      availability: {
+        canRequestMore: true,
+        availableSections: ["identity"],
+      },
+      generatedAt: "2026-04-26T00:00:00.000Z",
+    });
+
+    renderPage();
+
+    expect(await screen.findByRole("button", { name: /Apply with RentChain/i })).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        /This shared profile supports summary-only reuse today\. Reusable application prefill is only available when both identity and application sharing have been approved by the tenant\./i
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("explains when approved identity and application details can prefill the apply path", async () => {
+    publicTenantSharePackageApi.fetchPublicTenantSharePackage.mockResolvedValue({
+      identity: {
+        identityStatus: "ready",
+        verification: { level: "partial" },
+        readinessLabel: "Ready to apply",
+        readinessDescription: "Your core profile and supporting records are ready for most rental workflows.",
+      },
+      application: { reusable: true },
+      identityExchangeReference: {
+        referenceType: "tenant_identity_reference",
+        referenceStatus: "available",
+        referenceLabel: "Identity exchange available",
+        referenceDescription: "This rental identity can support summary-only exchange requests within the tenant-controlled sharing flow.",
+        portabilityStatus: "ready",
+      },
+      availability: {
+        canRequestMore: true,
+        availableSections: ["identity", "application"],
+      },
+      generatedAt: "2026-04-26T00:00:00.000Z",
+    });
+
+    renderPage();
+
+    expect(await screen.findByRole("button", { name: /Apply with RentChain/i })).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Use the tenant-approved identity and application details already shared here to start an application faster\. Any remaining application requirements, including consent, still apply\./i
+      )
+    ).toBeInTheDocument();
   });
 
   it("routes into the applicant apply flow with visible prefill state", async () => {

--- a/rentchain-frontend/src/pages/public/TenantSharePackagePage.tsx
+++ b/rentchain-frontend/src/pages/public/TenantSharePackagePage.tsx
@@ -12,6 +12,26 @@ function prettyStatus(value: string | null | undefined) {
     .replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
+function describePublicReusePath(input: {
+  canApplyWithRentChain: boolean;
+  identityReferenceStatus: "available" | "limited" | "not_ready" | null;
+  hasIdentitySection: boolean;
+  hasApplicationSection: boolean;
+}) {
+  if (input.canApplyWithRentChain && input.hasIdentitySection && input.hasApplicationSection) {
+    return "Use the tenant-approved identity and application details already shared here to start an application faster. Any remaining application requirements, including consent, still apply.";
+  }
+
+  if (
+    (input.identityReferenceStatus === "available" || input.identityReferenceStatus === "limited") &&
+    (input.hasIdentitySection || input.hasApplicationSection)
+  ) {
+    return "This shared profile supports summary-only reuse today. Reusable application prefill is only available when both identity and application sharing have been approved by the tenant.";
+  }
+
+  return null;
+}
+
 export default function TenantSharePackagePage() {
   const { token = "" } = useParams();
   const navigate = useNavigate();
@@ -110,6 +130,12 @@ export default function TenantSharePackagePage() {
         data.identityExchangeReference.referenceStatus === "limited") &&
       (availableSections.has("identity") || availableSections.has("application"))
   );
+  const publicReusePathDescription = describePublicReusePath({
+    canApplyWithRentChain,
+    identityReferenceStatus: data?.identityExchangeReference?.referenceStatus || null,
+    hasIdentitySection: availableSections.has("identity"),
+    hasApplicationSection: availableSections.has("application"),
+  });
 
   return (
     <div style={{ minHeight: "100vh", background: "linear-gradient(180deg, #f8fafc 0%, #eef2ff 100%)", padding: 24 }}>
@@ -167,11 +193,13 @@ export default function TenantSharePackagePage() {
                     >
                       {applyLoading ? "Preparing application..." : "Apply with RentChain"}
                     </button>
-                    <div style={{ color: "#475569", fontSize: "0.92rem" }}>
-                      Use the tenant-approved profile details already shared here to start an application faster.
-                    </div>
+                    {publicReusePathDescription ? (
+                      <div style={{ color: "#475569", fontSize: "0.92rem" }}>{publicReusePathDescription}</div>
+                    ) : null}
                     {applyError ? <div style={{ color: "#b91c1c" }}>{applyError}</div> : null}
                   </div>
+                ) : publicReusePathDescription ? (
+                  <div style={{ color: "#475569", fontSize: "0.92rem" }}>{publicReusePathDescription}</div>
                 ) : null}
               </div>
             ) : null}
@@ -207,7 +235,7 @@ export default function TenantSharePackagePage() {
             <div style={{ border: "1px solid rgba(15,23,42,0.08)", borderRadius: 16, background: "#fff", padding: 18, display: "grid", gap: 12 }}>
               <div style={{ fontWeight: 800, color: "#0f172a" }}>Request additional information</div>
               <div style={{ color: "#475569", lineHeight: 1.6 }}>
-                Request additional summary sections. Access is only expanded if the tenant approves it later.
+                Request additional summary sections. Requesting additional sections does not grant access automatically. The tenant must approve any expanded scope later.
               </div>
               <label style={{ display: "flex", gap: 8, alignItems: "center" }}>
                 <input

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -1098,6 +1098,11 @@ describe("tenant workspace frontend shell", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /Copy latest link/i }));
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith("https://app.example/share/share-token-1");
+    expect(
+      screen.getByText(
+        /Reuse path: This link can support summary-only follow-through today\. Broader reuse still requires your approval\./i
+      )
+    ).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /Revoke link/i }));
     await waitFor(() => {
@@ -1241,6 +1246,11 @@ describe("tenant workspace frontend shell", () => {
     });
     expect(await screen.findByText(/Approved: Credibility summary, Documents summary/i)).toBeInTheDocument();
     expect(screen.getByText(/Identity exchange available/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Reuse path: This link can support summary-only follow-through today\. Broader reuse still requires your approval\./i
+      )
+    ).toBeInTheDocument();
   });
 
   it("lets tenants approve and revoke verification requests", async () => {

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
@@ -201,6 +201,26 @@ function prettyShareRequestItem(
   }
 }
 
+function describeShareLinkReusePath(entry: TenantSharePackageLink): string {
+  const identitySummaryApproved = entry.approvedItems.includes("identity_summary");
+  const applicationSummaryApproved = entry.approvedItems.includes("application_summary");
+  const referenceStatus = entry.identityExchangeReference?.referenceStatus || "not_ready";
+
+  if (identitySummaryApproved && applicationSummaryApproved) {
+    return "Apply with RentChain is available with your approved identity and reusable application details.";
+  }
+
+  if (identitySummaryApproved) {
+    return "This link currently shares identity summary only. Additional approval is still required before reusable application details can be used.";
+  }
+
+  if (referenceStatus === "available" || referenceStatus === "limited") {
+    return "This link can support summary-only follow-through today. Broader reuse still requires your approval.";
+  }
+
+  return "This link does not yet support a reusable RentChain application path.";
+}
+
 export default function TenantWorkspacePage() {
   const [data, setData] = React.useState<Awaited<ReturnType<typeof getTenantWorkspace>> | null>(null);
   const [institutionalPackage, setInstitutionalPackage] = React.useState<InstitutionalExportV2 | null>(null);
@@ -1398,6 +1418,9 @@ export default function TenantWorkspacePage() {
                       ? entry.approvedItems.map((item) => prettyShareRequestItem(item)).join(", ")
                       : "Identity summary only"}
                   </div>
+                  <div style={{ color: textTokens.secondary }}>
+                    Reuse path: {describeShareLinkReusePath(entry)}
+                  </div>
                   {entry.verificationRequests.some((request) => request.status === "approved") ? (
                     <div style={{ color: textTokens.secondary }}>
                       Verification approvals:{" "}
@@ -1421,6 +1444,9 @@ export default function TenantWorkspacePage() {
                       <div style={{ fontWeight: 700, color: textTokens.primary }}>Pending request</div>
                       <div style={{ color: textTokens.secondary }}>
                         {entry.requestedItems.map((item) => prettyShareRequestItem(item)).join(", ")}
+                      </div>
+                      <div style={{ color: textTokens.secondary }}>
+                        No new access is granted unless you approve it.
                       </div>
                       <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
                         <button


### PR DESCRIPTION
This PR introduces Identity Network Expansion v1.

Includes:
- additive networkReuseSummary visibility fields
- derived reuse path labels/descriptions
- landlord review-summary reuse clarity
- tenant workspace share-link reuse path copy
- public share Apply with RentChain reuse explanation
- focused backend/frontend test coverage

Guardrails preserved:
- no Apply with RentChain behavior changes
- no share token/model changes
- no application submission behavior changes
- no storage changes
- no permission changes
- no new scope keys
- no raw approved scope arrays exposed
- no documents, screening details, signatures, payments, provider data, internal IDs, tokens, or token hashes exposed