### PR TITLE
feat: improve landlord network reuse clarity

### DIFF
--- a/rentchain-frontend/src/lib/reuse/landlordNetworkReuseCopy.ts
+++ b/rentchain-frontend/src/lib/reuse/landlordNetworkReuseCopy.ts
@@ -1,0 +1,58 @@
+import type { ApplicationReviewSummary } from "../../api/reviewSummaryApi";
+
+type NetworkReuseSummary = NonNullable<ApplicationReviewSummary["networkReuseSummary"]>;
+
+export type LandlordNetworkReuseCopy = {
+  headline: string;
+  description: string;
+  sourceLabel: string;
+  guardrailCopy: string;
+};
+
+function sourceLabel(value: NetworkReuseSummary["source"]) {
+  return value === "apply_with_rentchain" ? "RentChain application" : "Share package";
+}
+
+export function buildLandlordNetworkReuseCopy(
+  summary: NetworkReuseSummary
+): LandlordNetworkReuseCopy {
+  switch (summary.reusePath) {
+    case "apply_prefill_ready":
+      return {
+        headline: "Tenant-approved reusable application path is available",
+        description:
+          "Identity and reusable application context are already in scope for this review path.",
+        sourceLabel: sourceLabel(summary.source),
+        guardrailCopy:
+          "Use this as review context only. It does not expand landlord access or permissions.",
+      };
+    case "share_summary_with_more_available":
+      return {
+        headline: "Some reuse context is available now",
+        description:
+          "Summary-level reuse is available for follow-through, and broader reusable application detail still requires tenant approval.",
+        sourceLabel: sourceLabel(summary.source),
+        guardrailCopy:
+          "Use this as review context only. It does not expand landlord access or permissions.",
+      };
+    case "share_summary_ready":
+      return {
+        headline: "Summary-only reuse is available",
+        description:
+          "Tenant-approved reuse context is available for review follow-through without broadening landlord visibility.",
+        sourceLabel: sourceLabel(summary.source),
+        guardrailCopy:
+          "Use this as review context only. It does not expand landlord access or permissions.",
+      };
+    case "not_ready":
+    default:
+      return {
+        headline: "No reusable path is currently ready",
+        description:
+          "This review does not currently include a reusable RentChain application path.",
+        sourceLabel: sourceLabel(summary.source),
+        guardrailCopy:
+          "Use this as review context only. It does not expand landlord access or permissions.",
+      };
+  }
+}

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
@@ -213,11 +213,13 @@ describe("ApplicationReviewSummaryPage", () => {
     expect(await screen.findByText("Credibility established")).toBeInTheDocument();
     expect(await screen.findByText("Most credibility signals are available in the current record.")).toBeInTheDocument();
     expect(await screen.findByText("Ready to reuse")).toBeInTheDocument();
-    expect(await screen.findByText("Apply prefill ready")).toBeInTheDocument();
+    expect(await screen.findByText("Tenant-approved reusable application path is available")).toBeInTheDocument();
     expect(await screen.findByText("RentChain application")).toBeInTheDocument();
+    expect(await screen.findByText("Identity and reusable application context are already in scope for this review path.")).toBeInTheDocument();
     expect(await screen.findByText("Identity and application summaries approved")).toBeInTheDocument();
     expect(await screen.findByText("Additional approval may unlock more")).toBeInTheDocument();
     expect(await screen.findByText("No")).toBeInTheDocument();
+    expect(await screen.findByText("Use this as review context only. It does not expand landlord access or permissions.")).toBeInTheDocument();
     expect(await screen.findByText("Reusable across applications")).toBeInTheDocument();
     expect((await screen.findAllByText("Ready for review")).length).toBeGreaterThan(0);
     expect(await screen.findByText("Application information is mostly complete.")).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
@@ -34,6 +34,7 @@ import { buildDepositPaymentFlowState } from "./depositPaymentFlowState";
 import StructuredNotificationList from "./StructuredNotificationList";
 import { buildLandlordStructuredNotificationTriggers } from "./structuredNotificationTriggers";
 import { resolveRequiredPlanLabel } from "@/lib/upgradePrompt";
+import { buildLandlordNetworkReuseCopy } from "../lib/reuse/landlordNetworkReuseCopy";
 
 function money(cents: number | null): string {
   if (cents == null || !Number.isFinite(cents)) return "Not provided";
@@ -261,21 +262,6 @@ function trustActionLabel(
     default:
       return "Review application";
   }
-}
-
-function networkReuseStatusLabel(value: "available" | "limited" | "not_available" | null | undefined) {
-  switch (value) {
-    case "available":
-      return "Reuse available";
-    case "limited":
-      return "Reuse limited";
-    default:
-      return "Reuse not available";
-  }
-}
-
-function networkReuseSourceLabel(value: "share_package" | "apply_with_rentchain" | null | undefined) {
-  return value === "apply_with_rentchain" ? "RentChain application" : "Share package";
 }
 
 function networkReusePathSupportLabel(
@@ -1765,13 +1751,17 @@ function ApplicationReviewSummaryPageBody() {
 
           {summary.networkReuseSummary ? (
             <Card style={{ display: "grid", gap: 8 }}>
+              {(() => {
+                const networkReuseCopy = buildLandlordNetworkReuseCopy(summary.networkReuseSummary);
+                return (
+                  <>
               <div style={{ fontWeight: 700 }}>Network reuse</div>
               <div style={{ fontSize: 13, color: text.subtle }}>
-                {summary.networkReuseSummary.reusePathDescription} It is descriptive only and does not expand landlord permissions or visibility.
+                {networkReuseCopy.description}
               </div>
               <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 8 }}>
-                {kv("Status", summary.networkReuseSummary.reusePathLabel)}
-                {kv("Source", networkReuseSourceLabel(summary.networkReuseSummary.source))}
+                {kv("Status", networkReuseCopy.headline)}
+                {kv("Source", networkReuseCopy.sourceLabel)}
                 {kv("Consent required", summary.networkReuseSummary.consentRequired ? "Yes" : "No")}
                 {kv(
                   "Approved reuse support",
@@ -1785,6 +1775,10 @@ function ApplicationReviewSummaryPageBody() {
                   summary.networkReuseSummary.additionalConsentMayUnlock ? "Yes" : "No"
                 )}
               </div>
+              <div style={{ fontSize: 12, color: text.subtle }}>{networkReuseCopy.guardrailCopy}</div>
+                  </>
+                );
+              })()}
             </Card>
           ) : null}
 

--- a/rentchain-frontend/src/pages/landlord/LandlordInboxPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/LandlordInboxPage.test.tsx
@@ -67,6 +67,13 @@ describe("LandlordInboxPage", () => {
           source: "apply_with_rentchain",
           reuseStatus: "available",
           consentRequired: true,
+          reusePath: "apply_prefill_ready",
+          reusePathLabel: "Apply prefill ready",
+          reusePathDescription:
+            "Tenant-approved identity and reusable application details are already in scope for the RentChain apply path.",
+          identitySummaryApproved: true,
+          applicationSummaryApproved: true,
+          additionalConsentMayUnlock: false,
         },
         source: "review_summary",
       },
@@ -99,7 +106,9 @@ describe("LandlordInboxPage", () => {
     expect(screen.getByText("Application ready for review")).toBeInTheDocument();
     expect(screen.getByText(/Verification level: partial/i)).toBeInTheDocument();
     expect(screen.getByText(/Application completeness: medium/i)).toBeInTheDocument();
-    expect(screen.getByText(/Reusable application available · Source: RentChain application/i)).toBeInTheDocument();
+    expect(screen.getByText(/Tenant-approved reusable application path is available · Source: RentChain application/i)).toBeInTheDocument();
+    expect(screen.getByText(/Identity and reusable application context are already in scope for this review path\./i)).toBeInTheDocument();
+    expect(screen.getByText(/Use this as review context only\. It does not expand landlord access or permissions\./i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Review application" })).toHaveAttribute(
       "href",
       "/applications/app-1/review-summary"

--- a/rentchain-frontend/src/pages/landlord/LandlordInboxPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/LandlordInboxPage.tsx
@@ -8,6 +8,7 @@ import {
 import { MacShell } from "../../components/layout/MacShell";
 import { Card, Section } from "../../components/ui/Ui";
 import { useToast } from "../../components/ui/ToastProvider";
+import { buildLandlordNetworkReuseCopy } from "../../lib/reuse/landlordNetworkReuseCopy";
 
 function errorMessage(error: unknown) {
   if (error instanceof Error && error.message) return error.message;
@@ -45,21 +46,6 @@ function nextActionLabel(action: LandlordInboxItem["nextAction"]) {
   }
 }
 
-function networkReuseStatusLabel(value: NonNullable<LandlordInboxItem["networkReuseSummary"]>["reuseStatus"]) {
-  switch (value) {
-    case "available":
-      return "Reusable application available";
-    case "limited":
-      return "Reusable application limited";
-    default:
-      return "Reusable application not available";
-  }
-}
-
-function networkReuseSourceLabel(value: NonNullable<LandlordInboxItem["networkReuseSummary"]>["source"]) {
-  return value === "apply_with_rentchain" ? "RentChain application" : "Share package";
-}
-
 function sectionLabel(status: LandlordInboxItem["status"]) {
   if (status === "action_required") return "Needs attention";
   if (status === "pending") return "Waiting on follow-up";
@@ -92,6 +78,7 @@ function groupItems(items: LandlordInboxResponse["items"]) {
 function InboxItemCard({ item }: { item: LandlordInboxItem }) {
   const priority = priorityTone(item.priority);
   const trustTone = item.trustSummary ? readinessTone(item.trustSummary.readiness) : null;
+  const networkReuseCopy = item.networkReuseSummary ? buildLandlordNetworkReuseCopy(item.networkReuseSummary as any) : null;
 
   return (
     <Card style={{ display: "grid", gap: 12 }}>
@@ -142,9 +129,12 @@ function InboxItemCard({ item }: { item: LandlordInboxItem }) {
           </div>
         ) : null}
         {item.networkReuseSummary ? (
-          <div style={{ color: "#64748b", fontSize: "0.82rem" }}>
-            {networkReuseStatusLabel(item.networkReuseSummary.reuseStatus)} · Source:{" "}
-            {networkReuseSourceLabel(item.networkReuseSummary.source)}
+          <div style={{ display: "grid", gap: 4 }}>
+            <div style={{ color: "#64748b", fontSize: "0.82rem" }}>
+              {networkReuseCopy?.headline} · Source: {networkReuseCopy?.sourceLabel}
+            </div>
+            <div style={{ color: "#64748b", fontSize: "0.82rem" }}>{networkReuseCopy?.description}</div>
+            <div style={{ color: "#64748b", fontSize: "0.82rem" }}>{networkReuseCopy?.guardrailCopy}</div>
           </div>
         ) : null}
       </div>


### PR DESCRIPTION
This PR improves landlord-side network reuse clarity.

Includes:
- shared landlord network reuse copy helper
- clearer reuse-path wording in landlord inbox
- aligned network reuse wording in application review summary
- no backend changes
- focused frontend test coverage

Guardrails preserved:
- frontend-only
- no Apply with RentChain behavior changes
- no permission/model/storage changes
- no backend files changed