### PR TITLE
feat: clarify institutional handoff readiness

### DIFF
--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -1262,7 +1262,9 @@ describe("tenantPortalRoutes foundation", () => {
     expect(res.body?.data?.institutionProfile?.displayName).toBe("Example Bank Sandbox");
     expect(res.body?.data?.exportStorage).toBe("metadata_only");
     expect(res.body?.data?.outboundTransfer).toBe("none");
-    expect(["ready_for_manual_review", "blocked"]).toContain(res.body?.data?.handoffStatus);
+    expect(["ready_for_manual_review", "ready_for_tenant_managed_release", "blocked"]).toContain(
+      res.body?.data?.handoffStatus
+    );
     const stored = ensureCollection("institutionalHandoffs").get(res.body?.data?.id);
     const payload = JSON.stringify(stored || {});
     expect(payload).not.toContain("\"warnings\":");

--- a/rentchain-api/src/services/institutional/__tests__/deriveInstitutionalHandoffStatus.test.ts
+++ b/rentchain-api/src/services/institutional/__tests__/deriveInstitutionalHandoffStatus.test.ts
@@ -2,17 +2,26 @@ import { describe, expect, it } from "vitest";
 import { deriveInstitutionalHandoffStatus } from "../deriveInstitutionalHandoffStatus";
 
 describe("deriveInstitutionalHandoffStatus", () => {
-  it("returns ready_for_manual_review for valid or warning exports with partial or ready compliance", () => {
+  it("returns ready_for_tenant_managed_release for fully ready valid exports", () => {
     expect(
       deriveInstitutionalHandoffStatus({
         validationStatus: "valid",
         readinessStatus: "ready",
       })
+    ).toBe("ready_for_tenant_managed_release");
+  });
+
+  it("returns ready_for_manual_review for warning exports or partially ready exports", () => {
+    expect(
+      deriveInstitutionalHandoffStatus({
+        validationStatus: "valid_with_warnings",
+        readinessStatus: "partial",
+      })
     ).toBe("ready_for_manual_review");
 
     expect(
       deriveInstitutionalHandoffStatus({
-        validationStatus: "valid_with_warnings",
+        validationStatus: "valid",
         readinessStatus: "partial",
       })
     ).toBe("ready_for_manual_review");

--- a/rentchain-api/src/services/institutional/__tests__/institutionalHandoffService.test.ts
+++ b/rentchain-api/src/services/institutional/__tests__/institutionalHandoffService.test.ts
@@ -77,6 +77,30 @@ describe("institutionalHandoffService", () => {
     expect(payload).not.toContain("documentUrl");
   });
 
+  it("marks fully ready valid drafts as ready for tenant-managed manual release", async () => {
+    const { createInstitutionalHandoffDraft } = await import("../institutionalHandoffService");
+    const created = await createInstitutionalHandoffDraft({
+      tenantId: "tenant-1",
+      institutionProfile: {
+        institutionType: "lender",
+        displayName: "Ready Lender Draft",
+        integrationMode: "manual_export",
+      },
+      schema: {
+        name: "rentchain.institutional_identity_package",
+        version: "2.0",
+      },
+      compliance: {
+        readinessStatus: "ready",
+        validationStatus: "valid",
+      },
+    });
+
+    expect(created.exportStorage).toBe("metadata_only");
+    expect(created.outboundTransfer).toBe("none");
+    expect(created.handoffStatus).toBe("ready_for_tenant_managed_release");
+  });
+
   it("lists only the tenant handoff drafts sorted by updatedAt descending and soft-voids owned drafts", async () => {
     const {
       createInstitutionalHandoffDraft,

--- a/rentchain-api/src/services/institutional/deriveInstitutionalHandoffStatus.ts
+++ b/rentchain-api/src/services/institutional/deriveInstitutionalHandoffStatus.ts
@@ -1,4 +1,9 @@
-export type InstitutionalHandoffStatus = "draft" | "ready_for_manual_review" | "blocked" | "voided";
+export type InstitutionalHandoffStatus =
+  | "draft"
+  | "ready_for_manual_review"
+  | "ready_for_tenant_managed_release"
+  | "blocked"
+  | "voided";
 
 type DeriveInstitutionalHandoffStatusInput = {
   validationStatus: "valid" | "valid_with_warnings" | "invalid";
@@ -10,6 +15,10 @@ export function deriveInstitutionalHandoffStatus(
 ): InstitutionalHandoffStatus {
   if (input.validationStatus === "invalid" || input.readinessStatus === "not_ready") {
     return "blocked";
+  }
+
+  if (input.validationStatus === "valid" && input.readinessStatus === "ready") {
+    return "ready_for_tenant_managed_release";
   }
 
   if (

--- a/rentchain-frontend/src/api/tenantPortal.ts
+++ b/rentchain-frontend/src/api/tenantPortal.ts
@@ -469,7 +469,12 @@ export type InstitutionalHandoffSummary = {
     readinessStatus: "not_ready" | "partial" | "ready";
     validationStatus: "valid" | "valid_with_warnings" | "invalid";
   };
-  handoffStatus: "draft" | "ready_for_manual_review" | "blocked" | "voided";
+  handoffStatus:
+    | "draft"
+    | "ready_for_manual_review"
+    | "ready_for_tenant_managed_release"
+    | "blocked"
+    | "voided";
   exportStorage: "metadata_only";
   outboundTransfer: "none";
   createdAt: string;

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -1153,6 +1153,7 @@ describe("tenant workspace frontend shell", () => {
     expect((await screen.findAllByText(/Institutional handoff drafts/i)).length).toBeGreaterThan(0);
     expect(screen.getByText(/No data is sent automatically/i)).toBeInTheDocument();
     expect(screen.getByText(/Institution connections are not enabled yet/i)).toBeInTheDocument();
+    expect(screen.getByText(/tenant-managed manual-release preparation only/i)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /send/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /submit to bank/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /connect institution/i })).not.toBeInTheDocument();
@@ -1175,14 +1176,20 @@ describe("tenant workspace frontend shell", () => {
       });
     });
 
-    expect(await screen.findByText(/Ready for manual review/i)).toBeInTheDocument();
+    expect(await screen.findByText(/^Ready for manual review$/i)).toBeInTheDocument();
     expect(screen.getByText(/Example Bank Sandbox/i)).toBeInTheDocument();
+    expect(screen.getByText(/ready for manual review before any tenant-managed sharing decision/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/You may manually share a downloaded export outside RentChain when you choose/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/ready to send/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/delivered/i)).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /Void draft/i }));
     await waitFor(() => {
       expect(tenantPortalApi.voidInstitutionalHandoffDraft).toHaveBeenCalledWith("handoff-1");
     });
-    expect(await screen.findByText(/Voided/i)).toBeInTheDocument();
+    expect(await screen.findByText(/^Voided$/i)).toBeInTheDocument();
   });
 
   it("lets tenants approve a pending share access request", async () => {

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
@@ -142,9 +142,18 @@ function prettyInstitutionType(
 }
 
 function prettyHandoffStatus(
-  value: "draft" | "ready_for_manual_review" | "blocked" | "voided" | null | undefined
+  value:
+    | "draft"
+    | "ready_for_manual_review"
+    | "ready_for_tenant_managed_release"
+    | "blocked"
+    | "voided"
+    | null
+    | undefined
 ) {
   switch (value) {
+    case "ready_for_tenant_managed_release":
+      return "Ready for tenant-managed release";
     case "ready_for_manual_review":
       return "Ready for manual review";
     case "blocked":
@@ -154,6 +163,31 @@ function prettyHandoffStatus(
     case "draft":
     default:
       return "Draft";
+  }
+}
+
+function institutionalHandoffStatusDescription(
+  value:
+    | "draft"
+    | "ready_for_manual_review"
+    | "ready_for_tenant_managed_release"
+    | "blocked"
+    | "voided"
+    | null
+    | undefined
+) {
+  switch (value) {
+    case "ready_for_tenant_managed_release":
+      return "This draft is ready for tenant-managed manual release. You may manually share a downloaded export outside RentChain when you choose.";
+    case "ready_for_manual_review":
+      return "This draft is ready for manual review before any tenant-managed sharing decision.";
+    case "blocked":
+      return "This draft still needs more readiness details before manual review can proceed.";
+    case "voided":
+      return "This draft has been voided and is no longer part of your current manual-release preparation.";
+    case "draft":
+    default:
+      return "This draft is still being prepared for manual review.";
   }
 }
 
@@ -1239,7 +1273,7 @@ export default function TenantWorkspacePage() {
           >
             <div style={{ fontWeight: 700, color: textTokens.primary }}>Institutional handoff drafts</div>
             <div style={{ color: textTokens.secondary, lineHeight: 1.6 }}>
-              Prepare a draft institutional handoff. This prepares a draft package for review only. No data is sent automatically. Institution connections are not enabled yet.
+              Prepare a draft institutional handoff. This supports tenant-managed manual-release preparation only. No data is sent automatically, and institution connections are not enabled yet.
             </div>
 
             <label style={{ display: "grid", gap: 6 }}>
@@ -1302,6 +1336,15 @@ export default function TenantWorkspacePage() {
                         { label: "Updated", value: formatDate(draft.updatedAt) },
                       ]}
                     />
+                    <div style={{ color: textTokens.secondary, lineHeight: 1.6 }}>
+                      {institutionalHandoffStatusDescription(draft.handoffStatus)}
+                    </div>
+                    <div style={{ color: textTokens.secondary, lineHeight: 1.6 }}>
+                      No data is sent automatically. You may manually share a downloaded export outside RentChain when you choose.
+                    </div>
+                    <div style={{ color: textTokens.secondary, lineHeight: 1.6 }}>
+                      Institution connections are not enabled yet.
+                    </div>
                     {draft.handoffStatus !== "voided" ? (
                       <div style={{ display: "flex", gap: spacing.sm }}>
                         <button type="button" onClick={() => void handleVoidInstitutionalHandoff(draft.id)} disabled={handoffBusy}>


### PR DESCRIPTION
This PR introduces Institutional Integration v3 as tenant-managed manual-release readiness.

Includes:
- new derived handoff status: ready_for_tenant_managed_release
- clarified handoff readiness derivation
- tenant workspace copy explaining manual-release preparation
- status-specific draft explanations
- no new handoff routes or workflow actions
- focused backend/frontend test coverage

Guardrails preserved:
- no real institution integration
- no outbound transfer behavior
- no stored export payloads
- no credentials or contact delivery fields
- no institution API calls
- no send/submit/deliver workflow
- no raw documents, screening details, signatures, payment methods, or audit payloads
- export remains on-demand only
- outboundTransfer remains none
- exportStorage remains metadata_only