### PR TITLE
feat: add compliance audit traceability

### DIFF
--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -1190,6 +1190,26 @@ describe("tenantPortalRoutes foundation", () => {
       exportStorage: "not_stored",
       outboundTransfer: "none",
     });
+    expect(res.body?.data?.complianceReadiness?.auditTraceability).toEqual({
+      traceabilityStatus: "limited",
+      traceabilityLabel: "Limited",
+      traceabilityDescription:
+        "Some reduced audit traceability signals are available, but institutional export and lifecycle evidence coverage is still limited in the current tenant-controlled summary.",
+      evidenceCoverage: {
+        identityTimelineAvailable: false,
+        exportGeneratedOnDemand: true,
+        exportStoredByRentChain: false,
+        handoffDraftMetadataAvailable: true,
+        manualReleasePreparationAvailable: true,
+        observabilityCoverage: "draft_creation_only",
+        canonicalInstitutionEventsAvailable: false,
+      },
+      readinessGaps: [
+        "institutional_export_events_not_recorded",
+        "institutional_handoff_lifecycle_events_limited",
+        "access_audit_summary_not_available",
+      ],
+    });
     expect(res.body?.data?.validation?.warnings).toContain("Recommended signal limited: identity trace unavailable");
     expect(res.body?.data?.validation?.warnings).toContain("Recommended signal limited: payment readiness unavailable");
     expect(res.body?.data?.validation?.warnings).toContain("Recommended signal limited: consent controls limited");

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -2353,6 +2353,12 @@ async function buildInstitutionalSchemaV2ExportForTenant(
       dataScope: schemaV2.schema.dataScope,
       consentRequired: schemaV2.schema.consentRequired,
     },
+    auditTraceabilityContext: {
+      handoffDraftMetadataAvailable: true,
+      manualReleasePreparationAvailable: true,
+      observabilityCoverage: "draft_creation_only",
+      canonicalInstitutionEventsAvailable: false,
+    },
   });
 
   return schemaV2;

--- a/rentchain-api/src/services/compliance/__tests__/deriveComplianceReadiness.test.ts
+++ b/rentchain-api/src/services/compliance/__tests__/deriveComplianceReadiness.test.ts
@@ -23,6 +23,12 @@ describe("deriveComplianceReadiness", () => {
         dataScope: "tenant_controlled_export",
         consentRequired: true,
       },
+      auditTraceabilityContext: {
+        handoffDraftMetadataAvailable: true,
+        manualReleasePreparationAvailable: true,
+        observabilityCoverage: "draft_creation_only",
+        canonicalInstitutionEventsAvailable: false,
+      },
     });
 
     expect(result.readinessStatus).toBe("ready");
@@ -31,6 +37,26 @@ describe("deriveComplianceReadiness", () => {
       schemaVersion: "2.0",
       exportStorage: "not_stored",
       outboundTransfer: "none",
+    });
+    expect(result.auditTraceability).toEqual({
+      traceabilityStatus: "ready",
+      traceabilityLabel: "Ready for summary-only review",
+      traceabilityDescription:
+        "Reduced, tenant-safe audit traceability is available for on-demand exports and metadata-only handoff preparation, with some institutional logging gaps still disclosed.",
+      evidenceCoverage: {
+        identityTimelineAvailable: true,
+        exportGeneratedOnDemand: true,
+        exportStoredByRentChain: false,
+        handoffDraftMetadataAvailable: true,
+        manualReleasePreparationAvailable: true,
+        observabilityCoverage: "draft_creation_only",
+        canonicalInstitutionEventsAvailable: false,
+      },
+      readinessGaps: [
+        "institutional_export_events_not_recorded",
+        "institutional_handoff_lifecycle_events_limited",
+        "access_audit_summary_not_available",
+      ],
     });
   });
 
@@ -55,9 +81,16 @@ describe("deriveComplianceReadiness", () => {
         dataScope: "tenant_controlled_export",
         consentRequired: true,
       },
+      auditTraceabilityContext: {
+        handoffDraftMetadataAvailable: true,
+        manualReleasePreparationAvailable: true,
+        observabilityCoverage: "draft_creation_only",
+        canonicalInstitutionEventsAvailable: false,
+      },
     });
 
     expect(result.readinessStatus).toBe("partial");
+    expect(result.auditTraceability.traceabilityStatus).toBe("limited");
     expect(result.checks.find((check) => check.key === "identity_trace_available")?.status).toBe("warning");
     expect(result.checks.find((check) => check.key === "consent_controls_available")?.status).toBe("warning");
   });
@@ -83,10 +116,21 @@ describe("deriveComplianceReadiness", () => {
         dataScope: "tenant_controlled_export",
         consentRequired: true,
       },
+      auditTraceabilityContext: {
+        handoffDraftMetadataAvailable: true,
+        manualReleasePreparationAvailable: true,
+        observabilityCoverage: "draft_creation_only",
+        canonicalInstitutionEventsAvailable: false,
+      },
     });
 
     expect(result.readinessStatus).toBe("not_ready");
     expect(result.checks.find((check) => check.key === "schema_validated")?.status).toBe("missing");
+    expect(result.auditTraceability.readinessGaps).toEqual([
+      "institutional_export_events_not_recorded",
+      "institutional_handoff_lifecycle_events_limited",
+      "access_audit_summary_not_available",
+    ]);
     expect(JSON.stringify(result)).not.toContain("tokenHash");
     expect(JSON.stringify(result)).not.toContain("documentUrl");
     expect(JSON.stringify(result)).not.toContain("paymentMethod");

--- a/rentchain-api/src/services/compliance/deriveComplianceReadiness.ts
+++ b/rentchain-api/src/services/compliance/deriveComplianceReadiness.ts
@@ -5,6 +5,11 @@ export type ComplianceReadinessCheckKey =
   | "export_tenant_controlled"
   | "sensitive_data_minimized";
 
+export type ComplianceAuditTraceabilityGap =
+  | "institutional_export_events_not_recorded"
+  | "institutional_handoff_lifecycle_events_limited"
+  | "access_audit_summary_not_available";
+
 export type ComplianceReadiness = {
   readinessStatus: "not_ready" | "partial" | "ready";
   readinessLabel: string;
@@ -20,6 +25,21 @@ export type ComplianceReadiness = {
     schemaVersion: "2.0";
     exportStorage: "not_stored";
     outboundTransfer: "none";
+  };
+  auditTraceability: {
+    traceabilityStatus: "limited" | "ready";
+    traceabilityLabel: string;
+    traceabilityDescription: string;
+    evidenceCoverage: {
+      identityTimelineAvailable: boolean;
+      exportGeneratedOnDemand: true;
+      exportStoredByRentChain: false;
+      handoffDraftMetadataAvailable: boolean;
+      manualReleasePreparationAvailable: boolean;
+      observabilityCoverage: "draft_creation_only" | "none";
+      canonicalInstitutionEventsAvailable: false;
+    };
+    readinessGaps: ComplianceAuditTraceabilityGap[];
   };
 };
 
@@ -42,6 +62,12 @@ type DeriveComplianceReadinessInput = {
     schemaVersion: "2.0";
     dataScope: "tenant_controlled_export";
     consentRequired: true;
+  };
+  auditTraceabilityContext: {
+    handoffDraftMetadataAvailable: boolean;
+    manualReleasePreparationAvailable: boolean;
+    observabilityCoverage: "draft_creation_only" | "none";
+    canonicalInstitutionEventsAvailable: false;
   };
 };
 
@@ -73,6 +99,55 @@ function buildOverallReadiness(
     readinessLabel: "Ready for structured institutional review",
     readinessDescription:
       "The current tenant-controlled export shows validated structure, traceability, consent-aware controls, and minimized data exposure.",
+  };
+}
+
+function deriveAuditTraceability(
+  input: DeriveComplianceReadinessInput
+): ComplianceReadiness["auditTraceability"] {
+  const identityTimelineAvailable = input.identityTimeline.totalEvents > 0;
+  const evidenceCoverage: ComplianceReadiness["auditTraceability"]["evidenceCoverage"] = {
+    identityTimelineAvailable,
+    exportGeneratedOnDemand: true,
+    exportStoredByRentChain: false,
+    handoffDraftMetadataAvailable: input.auditTraceabilityContext.handoffDraftMetadataAvailable,
+    manualReleasePreparationAvailable: input.auditTraceabilityContext.manualReleasePreparationAvailable,
+    observabilityCoverage: input.auditTraceabilityContext.observabilityCoverage,
+    canonicalInstitutionEventsAvailable: input.auditTraceabilityContext.canonicalInstitutionEventsAvailable,
+  };
+
+  const readinessGaps: ComplianceAuditTraceabilityGap[] = [
+    "institutional_export_events_not_recorded",
+    "institutional_handoff_lifecycle_events_limited",
+    "access_audit_summary_not_available",
+  ];
+
+  const traceabilityStatus =
+    identityTimelineAvailable &&
+    evidenceCoverage.handoffDraftMetadataAvailable &&
+    evidenceCoverage.manualReleasePreparationAvailable &&
+    evidenceCoverage.observabilityCoverage === "draft_creation_only"
+      ? "ready"
+      : "limited";
+
+  if (traceabilityStatus === "ready") {
+    return {
+      traceabilityStatus,
+      traceabilityLabel: "Ready for summary-only review",
+      traceabilityDescription:
+        "Reduced, tenant-safe audit traceability is available for on-demand exports and metadata-only handoff preparation, with some institutional logging gaps still disclosed.",
+      evidenceCoverage,
+      readinessGaps,
+    };
+  }
+
+  return {
+    traceabilityStatus,
+    traceabilityLabel: "Limited",
+    traceabilityDescription:
+      "Some reduced audit traceability signals are available, but institutional export and lifecycle evidence coverage is still limited in the current tenant-controlled summary.",
+    evidenceCoverage,
+    readinessGaps,
   };
 }
 
@@ -155,5 +230,6 @@ export function deriveComplianceReadiness(
       exportStorage: "not_stored",
       outboundTransfer: "none",
     },
+    auditTraceability: deriveAuditTraceability(input),
   };
 }

--- a/rentchain-api/src/services/institutional/deriveInstitutionalSchemaV2.ts
+++ b/rentchain-api/src/services/institutional/deriveInstitutionalSchemaV2.ts
@@ -160,6 +160,26 @@ export function deriveInstitutionalSchemaV2(input: DeriveInstitutionalSchemaV2In
         exportStorage: "not_stored",
         outboundTransfer: "none",
       },
+      auditTraceability: {
+        traceabilityStatus: "limited",
+        traceabilityLabel: "Limited",
+        traceabilityDescription:
+          "Audit traceability is attached during tenant-controlled schema export generation.",
+        evidenceCoverage: {
+          identityTimelineAvailable: false,
+          exportGeneratedOnDemand: true,
+          exportStoredByRentChain: false,
+          handoffDraftMetadataAvailable: false,
+          manualReleasePreparationAvailable: false,
+          observabilityCoverage: "none",
+          canonicalInstitutionEventsAvailable: false,
+        },
+        readinessGaps: [
+          "institutional_export_events_not_recorded",
+          "institutional_handoff_lifecycle_events_limited",
+          "access_audit_summary_not_available",
+        ],
+      },
     },
     extensions: {
       reserved: {},

--- a/rentchain-frontend/src/api/tenantPortal.ts
+++ b/rentchain-frontend/src/api/tenantPortal.ts
@@ -446,6 +446,25 @@ export type InstitutionalExportV2 = {
       exportStorage: "not_stored";
       outboundTransfer: "none";
     };
+    auditTraceability: {
+      traceabilityStatus: "limited" | "ready";
+      traceabilityLabel: string;
+      traceabilityDescription: string;
+      evidenceCoverage: {
+        identityTimelineAvailable: boolean;
+        exportGeneratedOnDemand: true;
+        exportStoredByRentChain: false;
+        handoffDraftMetadataAvailable: boolean;
+        manualReleasePreparationAvailable: boolean;
+        observabilityCoverage: "draft_creation_only" | "none";
+        canonicalInstitutionEventsAvailable: false;
+      };
+      readinessGaps: Array<
+        | "institutional_export_events_not_recorded"
+        | "institutional_handoff_lifecycle_events_limited"
+        | "access_audit_summary_not_available"
+      >;
+    };
   };
   extensions: {
     reserved: Record<string, never>;

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -389,12 +389,27 @@ describe("tenant workspace frontend shell", () => {
           schemaVersion: "2.0",
           exportStorage: "not_stored",
           outboundTransfer: "none",
-      },
-      },
-      validation: {
-        status: "valid",
-        warnings: [],
-        missingRecommendedFields: [],
+        },
+        auditTraceability: {
+          traceabilityStatus: "ready",
+          traceabilityLabel: "Ready for summary-only review",
+          traceabilityDescription:
+            "Reduced, tenant-safe audit traceability is available for on-demand exports and metadata-only handoff preparation, with some institutional logging gaps still disclosed.",
+          evidenceCoverage: {
+            identityTimelineAvailable: true,
+            exportGeneratedOnDemand: true,
+            exportStoredByRentChain: false,
+            handoffDraftMetadataAvailable: true,
+            manualReleasePreparationAvailable: true,
+            observabilityCoverage: "draft_creation_only",
+            canonicalInstitutionEventsAvailable: false,
+          },
+          readinessGaps: [
+            "institutional_export_events_not_recorded",
+            "institutional_handoff_lifecycle_events_limited",
+            "access_audit_summary_not_available",
+          ],
+        },
       },
       extensions: {
         reserved: {},
@@ -1130,11 +1145,22 @@ describe("tenant workspace frontend shell", () => {
     expect(screen.getByText(/Institution-ready structure/i)).toBeInTheDocument();
     expect(screen.getByText(/Validation status/i)).toBeInTheDocument();
     expect(screen.getByText(/Compliance readiness/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Audit traceability/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Draft metadata trace/i)).toBeInTheDocument();
+    expect(screen.getByText(/Institution event coverage/i)).toBeInTheDocument();
+    expect(screen.getByText(/Draft creation only/i)).toBeInTheDocument();
     expect(screen.getByText(/Exports are generated on request and are not stored by RentChain/i)).toBeInTheDocument();
     expect(screen.getAllByText(/No data is sent automatically/i).length).toBeGreaterThan(0);
+    expect(
+      screen.getByText(/This audit traceability summary reflects reduced, tenant-safe evidence only/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Current gaps: export generation is not recorded as an institutional event stream/i)).toBeInTheDocument();
     expect(screen.queryByText(/SOC2/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/certification/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/guaranteed/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/send to bank/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/ready to send/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/delivered/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/drawnDataUrl/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/paymentMethod/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Lease activated/i)).not.toBeInTheDocument();

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
@@ -1257,6 +1257,51 @@ export default function TenantWorkspacePage() {
                       No data is sent automatically.
                     </div>
                   </div>
+
+                  <div style={{ display: "grid", gap: 6 }}>
+                    <div style={{ fontWeight: 700, color: textTokens.primary }}>Audit traceability</div>
+                    <TenantKeyValueGrid
+                      rows={[
+                        {
+                          label: "Audit traceability",
+                          value: institutionalPackage.complianceReadiness.auditTraceability.traceabilityLabel,
+                        },
+                        {
+                          label: "Draft metadata trace",
+                          value: institutionalPackage.complianceReadiness.auditTraceability.evidenceCoverage
+                            .handoffDraftMetadataAvailable
+                            ? "Available"
+                            : "Not available",
+                        },
+                        {
+                          label: "Institution event coverage",
+                          value:
+                            institutionalPackage.complianceReadiness.auditTraceability.evidenceCoverage
+                              .observabilityCoverage === "draft_creation_only"
+                              ? "Draft creation only"
+                              : "Not available",
+                        },
+                        {
+                          label: "Canonical institution events",
+                          value: institutionalPackage.complianceReadiness.auditTraceability.evidenceCoverage
+                            .canonicalInstitutionEventsAvailable
+                            ? "Available"
+                            : "Not available",
+                        },
+                      ]}
+                    />
+                    <div style={{ color: textTokens.secondary, lineHeight: 1.6 }}>
+                      {institutionalPackage.complianceReadiness.auditTraceability.traceabilityDescription}
+                    </div>
+                    <div style={{ color: textTokens.secondary, lineHeight: 1.6 }}>
+                      This audit traceability summary reflects reduced, tenant-safe evidence only. Institutional exports
+                      are generated on demand, are not stored by RentChain, and are not transmitted automatically.
+                    </div>
+                    <div style={{ color: textTokens.secondary, lineHeight: 1.6 }}>
+                      Current gaps: export generation is not recorded as an institutional event stream, institutional
+                      handoff lifecycle coverage is limited, and a broader access audit summary is not available.
+                    </div>
+                  </div>
                 </div>
               ) : null}
             </div>


### PR DESCRIPTION
This PR introduces Compliance / Audit Layer v3.

Includes:
- additive auditTraceability under schemaVersion 2.0 complianceReadiness
- tenant-safe traceability status, evidence coverage, and readiness gaps
- tenant workspace Audit traceability section
- focused backend/frontend test coverage

Guardrails preserved:
- no raw audit logs or event payloads
- no canonical event changes
- no observability recorder changes
- no tokens, document URLs, payment methods, internal IDs, or raw evidence exposed
- no real institution integration
- no outbound transmission
- no stored export payloads
- no credentials or delivery workflow
- no SOC2/certification/legal guarantee language