### PR TITLE
feat: improve analytics insight clarity

### DIFF
--- a/rentchain-frontend/src/components/analytics/InsightCardsPanel.test.tsx
+++ b/rentchain-frontend/src/components/analytics/InsightCardsPanel.test.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import InsightCardsPanel from "./InsightCardsPanel";
+
+describe("InsightCardsPanel", () => {
+  it("suppresses duplicate operational insights already covered by alerts", () => {
+    render(
+      <InsightCardsPanel
+        insights={[
+          { type: "lease_expiry", severity: "medium", message: "1 lease ends within 30 days." },
+          { type: "vacancy_leader", severity: "low", message: "Alpha currently has the lowest vacancy rate in your portfolio." },
+        ]}
+        alerts={[
+          {
+            id: "alert-1",
+            type: "lease_expiry",
+            severity: "medium",
+            status: "active",
+            title: "Leases ending soon",
+            message: "1 lease ends within 30 days.",
+            detectedAt: "2026-04-20T00:00:00.000Z",
+            lastEvaluatedAt: "2026-04-20T00:00:00.000Z",
+            notification: { inAppEligible: true, emailEligible: true, automationEligible: false },
+          },
+        ]}
+        decisions={[]}
+      />
+    );
+
+    expect(screen.getByText(/Alpha currently has the lowest vacancy rate/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^1 lease ends within 30 days\.$/i)).not.toBeInTheDocument();
+  });
+
+  it("renders an updated intro and empty state when only duplicates were filtered away", () => {
+    render(
+      <InsightCardsPanel
+        insights={[{ type: "lease_expiry", severity: "medium", message: "1 lease ends within 30 days." }]}
+        alerts={[
+          {
+            id: "alert-1",
+            type: "lease_expiry",
+            severity: "medium",
+            status: "active",
+            title: "Leases ending soon",
+            message: "1 lease ends within 30 days.",
+            detectedAt: "2026-04-20T00:00:00.000Z",
+            lastEvaluatedAt: "2026-04-20T00:00:00.000Z",
+            notification: { inAppEligible: true, emailEligible: true, automationEligible: false },
+          },
+        ]}
+        decisions={[]}
+      />
+    );
+
+    expect(screen.getAllByText(/Distinct portfolio patterns worth reviewing after alerts and next actions/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/No standout analytics signals in this view right now/i)).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/analytics/InsightCardsPanel.tsx
+++ b/rentchain-frontend/src/components/analytics/InsightCardsPanel.tsx
@@ -1,6 +1,12 @@
 import React from "react";
 import { Card } from "../ui/Ui";
+import type { AnalyticsAlert } from "@/api/landlordAnalyticsAlertsApi";
+import type { LandlordAgentDecision } from "@/api/landlordAnalyticsApi";
 import type { LandlordAnalyticsInsight } from "@/api/landlordAnalyticsApi";
+import {
+  analyticsInsightIntroCopy,
+  shouldRenderInsightCard,
+} from "@/lib/analytics/analyticsInsightCopy";
 
 const severityColor: Record<LandlordAnalyticsInsight["severity"], string> = {
   low: "#0369a1",
@@ -10,24 +16,34 @@ const severityColor: Record<LandlordAnalyticsInsight["severity"], string> = {
 
 type Props = {
   insights: LandlordAnalyticsInsight[];
+  alerts?: AnalyticsAlert[];
+  decisions?: LandlordAgentDecision[];
 };
 
-export function InsightCardsPanel({ insights }: Props) {
+export function InsightCardsPanel({ insights, alerts = [], decisions = [] }: Props) {
+  const visibleInsights = insights.filter((insight) =>
+    shouldRenderInsightCard({
+      insight,
+      alerts,
+      decisions,
+    })
+  );
+
   return (
     <Card>
       <div style={{ display: "grid", gap: 12 }}>
         <div style={{ display: "grid", gap: 4 }}>
           <h2 style={{ margin: 0, fontSize: "1.05rem" }}>Attention-worthy insights</h2>
           <div style={{ color: "#475569" }}>
-            A small set of explainable analytics signals worth reviewing first.
+            {analyticsInsightIntroCopy()}
           </div>
         </div>
 
-        {insights.length === 0 ? (
+        {visibleInsights.length === 0 ? (
           <div style={{ color: "#64748b" }}>No standout analytics signals in this view right now.</div>
         ) : (
           <div style={{ display: "grid", gap: 10 }}>
-            {insights.map((insight, index) => (
+            {visibleInsights.map((insight, index) => (
               <div
                 key={`${insight.type}-${index}`}
                 style={{

--- a/rentchain-frontend/src/components/analytics/PredictiveMetricsPanel.test.tsx
+++ b/rentchain-frontend/src/components/analytics/PredictiveMetricsPanel.test.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import PredictiveMetricsPanel from "./PredictiveMetricsPanel";
+
+describe("PredictiveMetricsPanel", () => {
+  it("renders landlord-readable support lines and hides raw support keys", () => {
+    render(
+      <PredictiveMetricsPanel
+        metrics={[
+          {
+            key: "projected_vacancy_risk",
+            label: "Projected vacancy risk",
+            riskLevel: "medium",
+            status: "supported",
+            explanation: "Vacancy pressure is present in the current view, but it is not yet at the highest-risk threshold.",
+            supportingValues: {
+              vacancyRate: 0.2,
+              topPropertyId: "prop-2",
+              vacantUnits: 1,
+            },
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByText(/Current vacancy: 20%/i)).toBeInTheDocument();
+    expect(screen.getByText(/Vacant units: 1/i)).toBeInTheDocument();
+    expect(screen.queryByText(/topPropertyId/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/prop-2/i)).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/analytics/PredictiveMetricsPanel.tsx
+++ b/rentchain-frontend/src/components/analytics/PredictiveMetricsPanel.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Card } from "../ui/Ui";
 import type { LandlordPredictiveMetric } from "@/api/landlordAnalyticsApi";
+import { formatPredictiveSupportingValues } from "@/lib/analytics/analyticsInsightCopy";
 
 const riskTone: Record<"low" | "medium" | "high", { bg: string; text: string }> = {
   low: { bg: "rgba(14, 165, 233, 0.12)", text: "#075985" },
@@ -11,17 +12,6 @@ const riskTone: Record<"low" | "medium" | "high", { bg: string; text: string }> 
 type Props = {
   metrics: LandlordPredictiveMetric[];
 };
-
-function supportingLine(metric: LandlordPredictiveMetric) {
-  if (!metric.supportingValues) return null;
-
-  const parts = Object.entries(metric.supportingValues)
-    .filter(([, value]) => value != null && value !== "")
-    .slice(0, 3)
-    .map(([key, value]) => `${key}: ${String(value)}`);
-
-  return parts.length ? parts.join(" • ") : null;
-}
 
 export function PredictiveMetricsPanel({ metrics }: Props) {
   return (
@@ -39,7 +29,7 @@ export function PredictiveMetricsPanel({ metrics }: Props) {
         ) : (
           <div style={{ display: "grid", gap: 10 }}>
             {metrics.map((metric) => {
-              const support = supportingLine(metric);
+              const support = formatPredictiveSupportingValues(metric);
               return (
                 <div
                   key={metric.key}

--- a/rentchain-frontend/src/lib/analytics/analyticsInsightCopy.test.ts
+++ b/rentchain-frontend/src/lib/analytics/analyticsInsightCopy.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import type { AnalyticsAlert } from "@/api/landlordAnalyticsAlertsApi";
+import type {
+  LandlordAgentDecision,
+  LandlordAnalyticsInsight,
+  LandlordPredictiveMetric,
+} from "@/api/landlordAnalyticsApi";
+import {
+  deriveAlertTheme,
+  deriveDecisionTheme,
+  deriveInsightTheme,
+  formatPredictiveSupportingValues,
+  shouldRenderInsightCard,
+} from "./analyticsInsightCopy";
+
+function buildMetric(overrides?: Partial<LandlordPredictiveMetric>): LandlordPredictiveMetric {
+  return {
+    key: "projected_vacancy_risk",
+    label: "Projected vacancy risk",
+    riskLevel: "medium",
+    status: "supported",
+    explanation: "Vacancy pressure is present in the current view.",
+    supportingValues: {
+      vacancyRate: 0.2,
+      topPropertyId: "prop-2",
+      vacantUnits: 1,
+    },
+    ...overrides,
+  };
+}
+
+function buildAlert(overrides?: Partial<AnalyticsAlert>): AnalyticsAlert {
+  return {
+    id: "alert-1",
+    type: "lease_expiry",
+    severity: "medium",
+    status: "active",
+    title: "Leases ending soon",
+    message: "1 lease ends within 30 days.",
+    detectedAt: "2026-04-20T00:00:00.000Z",
+    lastEvaluatedAt: "2026-04-20T00:00:00.000Z",
+    notification: { inAppEligible: true, emailEligible: true, automationEligible: false },
+    ...overrides,
+  };
+}
+
+function buildDecision(overrides?: Partial<LandlordAgentDecision>): LandlordAgentDecision {
+  return {
+    id: "review_lease_renewals",
+    decisionType: "review_lease_renewals",
+    priority: "medium",
+    explanation: "Several leases are approaching renewal windows and need attention.",
+    supportingSignals: [],
+    recommendedAction: "Review renewals",
+    actionKey: "open_lease_renewals_flow",
+    actionLabel: "Open renewals focus",
+    destination: "/portfolio-health",
+    automationEligible: false,
+    automationState: "manual_only",
+    automationReason: null,
+    executionMappingState: "none",
+    executionMapping: null,
+    executionInputState: "none",
+    executionInputReason: null,
+    executionInputMissingFields: [],
+    executionInput: null,
+    executionOutcomeStatus: "none",
+    executionOutcomeAt: null,
+    executionOutcomeReason: null,
+    state: "pending",
+    ...overrides,
+  };
+}
+
+describe("analyticsInsightCopy", () => {
+  it("formats predictive supporting values into landlord-readable lines and hides raw IDs", () => {
+    const result = formatPredictiveSupportingValues(buildMetric());
+
+    expect(result).toContain("Current vacancy: 20%");
+    expect(result).toContain("Vacant units: 1");
+    expect(result).not.toContain("topPropertyId");
+    expect(result).not.toContain("prop-2");
+  });
+
+  it("limits predictive support output to two readable lines", () => {
+    const result = formatPredictiveSupportingValues(
+      buildMetric({
+        supportingValues: {
+          submittedCurrent: 1,
+          submittedPrior: 4,
+          conversionCurrent: 0.2,
+          conversionPrior: 0.5,
+        },
+        key: "projected_application_slowdown_risk",
+      })
+    );
+
+    expect(result).toBe("Current submitted applications: 1 • Prior submitted applications: 4");
+  });
+
+  it("suppresses low-value duplicate operational insights when alerts or decisions already cover the same theme", () => {
+    const insight: LandlordAnalyticsInsight = {
+      type: "lease_expiry",
+      severity: "medium",
+      message: "1 lease ends within 30 days.",
+    };
+
+    expect(
+      shouldRenderInsightCard({
+        insight,
+        alerts: [buildAlert()],
+        decisions: [buildDecision()],
+      })
+    ).toBe(false);
+  });
+
+  it("preserves comparative leader insights even when other signals exist", () => {
+    const insight: LandlordAnalyticsInsight = {
+      type: "vacancy_leader",
+      severity: "low",
+      message: "Alpha currently has the lowest vacancy rate in your portfolio.",
+    };
+
+    expect(
+      shouldRenderInsightCard({
+        insight,
+        alerts: [buildAlert({ type: "high_vacancy" })],
+        decisions: [buildDecision({ decisionType: "reduce_vacancy_risk" })],
+      })
+    ).toBe(true);
+  });
+
+  it("classifies alert, decision, and insight themes deterministically", () => {
+    expect(deriveAlertTheme(buildAlert({ type: "maintenance_cost_spike" }))).toBe("maintenance");
+    expect(deriveDecisionTheme(buildDecision({ decisionType: "review_revenue_pressure" }))).toBe("revenue");
+    expect(
+      deriveInsightTheme({
+        type: "applications_drop",
+        severity: "low",
+        message: "Applications dropped compared with the previous period.",
+      })
+    ).toBe("applications");
+  });
+});

--- a/rentchain-frontend/src/lib/analytics/analyticsInsightCopy.ts
+++ b/rentchain-frontend/src/lib/analytics/analyticsInsightCopy.ts
@@ -1,0 +1,256 @@
+import type { AnalyticsAlert } from "@/api/landlordAnalyticsAlertsApi";
+import type {
+  LandlordAgentDecision,
+  LandlordAnalyticsInsight,
+  LandlordPredictiveMetric,
+} from "@/api/landlordAnalyticsApi";
+
+export type AnalyticsTheme =
+  | "vacancy"
+  | "lease_expiry"
+  | "applications"
+  | "maintenance"
+  | "revenue"
+  | "property_focus"
+  | "other";
+
+function formatPercent(value: number | null | undefined) {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  return `${Math.round(value * 100)}%`;
+}
+
+function formatCurrency(cents: number | null | undefined) {
+  if (typeof cents !== "number" || !Number.isFinite(cents)) return null;
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(cents / 100);
+}
+
+function formatCount(value: number | string | null | undefined) {
+  if (typeof value === "number" && Number.isFinite(value)) return String(Math.round(value));
+  if (typeof value === "string" && value.trim()) return value.trim();
+  return null;
+}
+
+function isHiddenSupportKey(key: string) {
+  return key === "propertyId" || key === "topPropertyId" || key.endsWith("Id");
+}
+
+function hasDisplayValue(value: unknown) {
+  if (value == null) return false;
+  if (typeof value === "string") return value.trim().length > 0;
+  if (typeof value === "number") return Number.isFinite(value);
+  return false;
+}
+
+function mappedSupportLine(metric: LandlordPredictiveMetric, key: string, value: unknown): string | null {
+  if (isHiddenSupportKey(key) || !hasDisplayValue(value)) return null;
+
+  switch (key) {
+    case "vacancyRate": {
+      const formatted = formatPercent(typeof value === "number" ? value : null);
+      return formatted ? `Current vacancy: ${formatted}` : null;
+    }
+    case "worseningVsPrior": {
+      const numeric = typeof value === "number" ? value : null;
+      if (numeric == null) return null;
+      if (metric.key === "projected_vacancy_risk") {
+        const formatted = formatPercent(numeric);
+        return formatted ? `Vacancy change vs prior period: ${formatted}` : null;
+      }
+      if (metric.key === "projected_application_slowdown_risk") {
+        return `Applications down vs prior period: ${Math.round(numeric)}`;
+      }
+      return null;
+    }
+    case "vacantUnits": {
+      const formatted = formatCount(value as number | string | null | undefined);
+      return formatted ? `Vacant units: ${formatted}` : null;
+    }
+    case "leasesEndingSoon": {
+      const formatted = formatCount(value as number | string | null | undefined);
+      return formatted ? `Leases ending soon: ${formatted}` : null;
+    }
+    case "topPropertyVacancyRate": {
+      const formatted = formatPercent(typeof value === "number" ? value : null);
+      return formatted ? `Highest property vacancy: ${formatted}` : null;
+    }
+    case "topPropertyLeaseExpiries": {
+      const formatted = formatCount(value as number | string | null | undefined);
+      return formatted ? `Most lease expiries at one property: ${formatted}` : null;
+    }
+    case "topPropertyShare":
+    case "topPropertyMaintenanceShare": {
+      const formatted = formatPercent(typeof value === "number" ? value : null);
+      return formatted ? `Share concentrated in one property: ${formatted}` : null;
+    }
+    case "openWorkOrders": {
+      const formatted = formatCount(value as number | string | null | undefined);
+      return formatted ? `Open work orders: ${formatted}` : null;
+    }
+    case "maintenanceCostCents": {
+      const formatted = formatCurrency(typeof value === "number" ? value : null);
+      return formatted ? `Maintenance cost in view: ${formatted}` : null;
+    }
+    case "worseningVsPriorCents": {
+      const formatted = formatCurrency(typeof value === "number" ? value : null);
+      return formatted ? `Cost change vs prior period: ${formatted}` : null;
+    }
+    case "submittedCurrent": {
+      const formatted = formatCount(value as number | string | null | undefined);
+      return formatted ? `Current submitted applications: ${formatted}` : null;
+    }
+    case "submittedPrior": {
+      const formatted = formatCount(value as number | string | null | undefined);
+      return formatted ? `Prior submitted applications: ${formatted}` : null;
+    }
+    case "conversionCurrent": {
+      const formatted = formatPercent(typeof value === "number" ? value : null);
+      return formatted ? `Current conversion rate: ${formatted}` : null;
+    }
+    case "conversionPrior": {
+      const formatted = formatPercent(typeof value === "number" ? value : null);
+      return formatted ? `Prior conversion rate: ${formatted}` : null;
+    }
+    case "estimatedScheduledRentCents": {
+      const formatted = formatCurrency(typeof value === "number" ? value : null);
+      return formatted ? `Scheduled rent: ${formatted}` : null;
+    }
+    case "priorEstimatedScheduledRentCents": {
+      const formatted = formatCurrency(typeof value === "number" ? value : null);
+      return formatted ? `Prior scheduled rent: ${formatted}` : null;
+    }
+    case "relativeDelta": {
+      const formatted = formatPercent(typeof value === "number" ? value : null);
+      return formatted ? `Relative change: ${formatted}` : null;
+    }
+    case "applicationVolume": {
+      const formatted = formatCount(value as number | string | null | undefined);
+      return formatted ? `Applications in view: ${formatted}` : null;
+    }
+    default:
+      return null;
+  }
+}
+
+export function formatPredictiveSupportingValues(metric: LandlordPredictiveMetric): string | null {
+  const supportingValues = metric.supportingValues;
+  if (!supportingValues) return null;
+
+  const lines = Object.entries(supportingValues)
+    .map(([key, value]) => mappedSupportLine(metric, key, value))
+    .filter((line): line is string => Boolean(line))
+    .slice(0, 2);
+
+  return lines.length ? lines.join(" • ") : null;
+}
+
+export function derivePredictiveMetricTheme(metric: LandlordPredictiveMetric): AnalyticsTheme {
+  switch (metric.key) {
+    case "projected_vacancy_risk":
+      return "vacancy";
+    case "projected_lease_expiry_concentration":
+      return "lease_expiry";
+    case "projected_maintenance_burden_risk":
+      return "maintenance";
+    case "projected_application_slowdown_risk":
+      return "applications";
+    case "projected_revenue_pressure_signal":
+      return "revenue";
+    default:
+      return "other";
+  }
+}
+
+export function deriveAlertTheme(alert: AnalyticsAlert): AnalyticsTheme {
+  switch (alert.type) {
+    case "high_vacancy":
+    case "vacancy_increase":
+      return "vacancy";
+    case "lease_expiry":
+      return "lease_expiry";
+    case "application_drop":
+    case "application_conversion_drop":
+    case "low_application_activity":
+      return "applications";
+    case "maintenance_cost_spike":
+    case "work_order_concentration":
+      return "maintenance";
+    default:
+      return "other";
+  }
+}
+
+export function deriveDecisionTheme(decision: LandlordAgentDecision): AnalyticsTheme {
+  switch (decision.decisionType) {
+    case "reduce_vacancy_risk":
+      return "vacancy";
+    case "review_lease_renewals":
+      return "lease_expiry";
+    case "improve_application_conversion":
+      return "applications";
+    case "address_maintenance_backlog":
+    case "approve_maintenance_cost":
+      return "maintenance";
+    case "review_revenue_pressure":
+      return "revenue";
+    case "focus_highest_risk_property":
+      return "property_focus";
+    default:
+      return "other";
+  }
+}
+
+export function deriveInsightTheme(insight: LandlordAnalyticsInsight): AnalyticsTheme {
+  switch (insight.type) {
+    case "vacancy_concentration":
+    case "vacancy_risk":
+      return "vacancy";
+    case "lease_expiry":
+    case "lease_expiry_concentration":
+      return "lease_expiry";
+    case "applications_drop":
+      return "applications";
+    case "maintenance_cost_increase":
+    case "maintenance_concentration":
+    case "work_order_concentration":
+      return "maintenance";
+    case "vacancy_leader":
+    case "application_conversion_leader":
+    case "rent_leader":
+      return "other";
+    default:
+      return "other";
+  }
+}
+
+function isComparativeLeaderInsight(insight: LandlordAnalyticsInsight) {
+  return (
+    insight.type === "vacancy_leader" ||
+    insight.type === "application_conversion_leader" ||
+    insight.type === "rent_leader"
+  );
+}
+
+export function shouldRenderInsightCard(params: {
+  insight: LandlordAnalyticsInsight;
+  alerts: AnalyticsAlert[];
+  decisions: LandlordAgentDecision[];
+}): boolean {
+  const { insight, alerts, decisions } = params;
+  if (isComparativeLeaderInsight(insight)) return true;
+
+  const theme = deriveInsightTheme(insight);
+  if (theme === "other") return true;
+
+  const coveredByAlert = alerts.some((alert) => alert.status === "active" && deriveAlertTheme(alert) === theme);
+  const coveredByDecision = decisions.some((decision) => deriveDecisionTheme(decision) === theme);
+
+  return !(coveredByAlert || coveredByDecision);
+}
+
+export function analyticsInsightIntroCopy() {
+  return "Distinct portfolio patterns worth reviewing after alerts and next actions.";
+}

--- a/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.test.tsx
@@ -535,7 +535,13 @@ describe("LandlordAnalyticsPage", () => {
     fireEvent.click(screen.getByRole("tab", { name: "Predictive metrics" }));
     expect(screen.getByRole("heading", { name: /Predictive metrics/i })).toBeInTheDocument();
     expect(screen.getByText(/Vacancy pressure is present in the current view/i)).toBeInTheDocument();
+    expect(screen.getByText(/Current vacancy: 20% • Vacant units: 1/i)).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: /Recommended next actions/i })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Attention-worthy insights" }));
+    expect(screen.getByRole("heading", { name: /Attention-worthy insights/i })).toBeInTheDocument();
+    expect(screen.getByText(/Distinct portfolio patterns worth reviewing after alerts and next actions/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^1 lease ends within 30 days\.$/i)).not.toBeInTheDocument();
 
     expect(screen.getByRole("heading", { name: /Applications/i })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /Revenue signal/i })).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.tsx
@@ -596,7 +596,11 @@ export default function LandlordAnalyticsPage() {
               ) : null}
 
               {activeTab === "attention-worthy-insights" && canViewPortfolioScore && canViewAdvancedAnalytics ? (
-                <InsightCardsPanel insights={snapshot.insights} />
+                <InsightCardsPanel
+                  insights={snapshot.insights}
+                  alerts={alerts?.alerts || []}
+                  decisions={prioritizedDecisions}
+                />
               ) : null}
 
               {activeTab !== "analytics-alerts" && !canViewPortfolioScore ? (


### PR DESCRIPTION
This PR introduces Analytics Intelligence v2.

Includes:
- shared analytics insight copy helper
- readable predictive metric support lines
- hidden raw/internal support keys
- support output capped at 2 mapped lines per metric
- deterministic insight theme derivation
- render-time suppression of duplicate low-value insight cards already covered by alerts or visible decisions
- preserved leader/comparative insight cards
- focused frontend test coverage

Guardrails preserved:
- frontend-only
- no backend/API changes
- no analytics calculation changes
- no tab/filter/route/layout changes
- no decision priority or execution logic changes
- no alert threshold changes
- no sensitive/internal IDs rendered