### PR TITLE
fix: repair lease renewal ledger flow

### DIFF
--- a/rentchain-api/src/routes/__tests__/leaseDraftRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseDraftRoutes.test.ts
@@ -202,6 +202,37 @@ describe("lease draft routes", () => {
     expect(listRes.body?.tasks).toHaveLength(3);
   });
 
+  it("regenerates and lists automation tasks for a firestore-backed lease", async () => {
+    const router = (await import("../leaseRoutes")).default;
+    const app = express();
+    app.use(express.json());
+    app.use(router);
+
+    await fakeDb.collection("leases").doc("lease-firestore").set({
+      landlordId: "landlord-1",
+      tenantId: "tenant-3",
+      propertyId: "prop-3",
+      unitNumber: "3A",
+      startDate: "2026-01-01",
+      endDate: "2026-12-31",
+      automationEnabled: true,
+      renewalStatus: "offered",
+      status: "active",
+    });
+
+    const regenerateRes = await request(app)
+      .post("/lease-firestore/automation/tasks/regenerate")
+      .set(auth);
+    expect(regenerateRes.status).toBe(200);
+    expect(regenerateRes.body?.ok).toBe(true);
+    expect(Array.isArray(regenerateRes.body?.tasks)).toBe(true);
+
+    const listRes = await request(app).get("/lease-firestore/automation/tasks").set(auth);
+    expect(listRes.status).toBe(200);
+    expect(listRes.body?.ok).toBe(true);
+    expect(Array.isArray(listRes.body?.tasks)).toBe(true);
+  });
+
   it("activates lease from draft and tenant lease fetch includes it", async () => {
     const router = (await import("../leaseRoutes")).default;
     const app = express();

--- a/rentchain-api/src/routes/__tests__/leaseNoticeLandlordRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseNoticeLandlordRoutes.test.ts
@@ -343,6 +343,11 @@ describe("leaseNoticeLandlordRoutes policy integration", () => {
   it("returns only expiring workflow items when the expiring status filter is requested", async () => {
     if (!collections.has("leases")) collections.set("leases", new Map());
     if (!collections.has("leaseNotices")) collections.set("leaseNotices", new Map());
+    if (!collections.has("properties")) collections.set("properties", new Map());
+    collections.get("properties")?.set("property-1", {
+      landlordId: "landlord-1",
+      addressLine1: "123 Harbour St",
+    });
     collections.get("leases")?.set("lease-expiring", {
       landlordId: "landlord-1",
       propertyId: "property-1",
@@ -376,6 +381,7 @@ describe("leaseNoticeLandlordRoutes policy integration", () => {
     expect(res.body?.items[0]).toEqual(
       expect.objectContaining({
         id: "lease-expiring",
+        propertyAddress: "123 Harbour St",
         noticeBucket: "expiring",
         leaseLifecycleSummary: expect.objectContaining({
           lifecycleStatus: "expiring_soon",

--- a/rentchain-api/src/routes/leaseNoticeLandlordRoutes.ts
+++ b/rentchain-api/src/routes/leaseNoticeLandlordRoutes.ts
@@ -111,6 +111,29 @@ router.get("/expiring", async (req: any, res) => {
       db.collection("leases").where("landlordId", "==", landlordId).limit(400).get(),
       db.collection("leaseNotices").where("landlordId", "==", landlordId).limit(400).get(),
     ]);
+    const propertyIds = Array.from(
+      new Set(
+        leaseSnap.docs
+          .map((doc) => String((doc.data() as any)?.propertyId || "").trim())
+          .filter(Boolean)
+      )
+    );
+    const propertyEntries = await Promise.all(
+      propertyIds.map(async (id) => {
+        try {
+          const snap = await db.collection("properties").doc(id).get();
+          if (!snap.exists) return [id, null] as const;
+          const raw = snap.data() as any;
+          const address =
+            String(raw?.addressLine1 || raw?.address || "").trim() ||
+            null;
+          return [id, address] as const;
+        } catch {
+          return [id, null] as const;
+        }
+      })
+    );
+    const propertyAddressById = new Map<string, string | null>(propertyEntries);
     const latestNoticeByLeaseId = new Map<string, any>();
     const leaseNotices = noticeSnap.docs
       .map((doc) => ({ id: doc.id, ...(doc.data() as any) }))
@@ -133,9 +156,14 @@ router.get("/expiring", async (req: any, res) => {
           now,
           horizon,
         });
+        const propertyAddress =
+          (lease.propertyId ? propertyAddressById.get(lease.propertyId) : null) ||
+          lease.propertyAddress ||
+          null;
         return noticeBucket
           ? {
               ...lease,
+              propertyAddress,
               noticeBucket,
               leaseLifecycleSummary: deriveLeaseLifecycleSummary({
                 lease,

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -1171,11 +1171,13 @@ router.get("/snapshots/:id", requireLandlord, async (req: any, res: Response) =>
   }
 });
 
-router.post("/:id/automation/tasks/regenerate", requireLandlord, (req: any, res: Response) => {
-  const lease = leaseService.getById(String(req.params?.id || "").trim());
-  if (!lease) {
-    return res.status(404).json({ ok: false, error: "Lease not found" });
+router.post("/:id/automation/tasks/regenerate", requireLandlord, async (req: any, res: Response) => {
+  const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
+  const leaseResult = await getLeaseEntityForLandlord(String(req.params?.id || "").trim(), landlordId);
+  if (!leaseResult.ok) {
+    return res.status(leaseResult.status).json({ ok: false, error: leaseResult.error });
   }
+  const lease = leaseResult.lease as any;
   const tasks = regenerateLeaseAutomationTasks({
     id: lease.id,
     startDate: lease.startDate,
@@ -1186,11 +1188,13 @@ router.post("/:id/automation/tasks/regenerate", requireLandlord, (req: any, res:
   return res.status(200).json({ ok: true, tasks });
 });
 
-router.get("/:id/automation/tasks", requireLandlord, (req: any, res: Response) => {
-  const lease = leaseService.getById(String(req.params?.id || "").trim());
-  if (!lease) {
-    return res.status(404).json({ ok: false, error: "Lease not found" });
+router.get("/:id/automation/tasks", requireLandlord, async (req: any, res: Response) => {
+  const landlordId = String(req.user?.landlordId || req.user?.id || "").trim();
+  const leaseResult = await getLeaseEntityForLandlord(String(req.params?.id || "").trim(), landlordId);
+  if (!leaseResult.ok) {
+    return res.status(leaseResult.status).json({ ok: false, error: leaseResult.error });
   }
+  const lease = leaseResult.lease as any;
   const tasks = getLeaseAutomationTasks(lease.id);
   return res.status(200).json({ ok: true, tasks });
 });

--- a/rentchain-api/src/services/leaseNoticeWorkflowService.ts
+++ b/rentchain-api/src/services/leaseNoticeWorkflowService.ts
@@ -57,6 +57,7 @@ export type LeaseWorkflowLease = {
   tenantName: string | null;
   unitLabel: string | null;
   propertyLabel: string | null;
+  propertyAddress: string | null;
 };
 
 export type LeaseNoticePreviewInput = {
@@ -253,6 +254,7 @@ export function normalizeLeaseRecord(id: string, raw: any): LeaseWorkflowLease {
     tenantName: String(raw?.tenantName || raw?.residentName || "").trim() || null,
     unitLabel: String(raw?.unitLabel || raw?.unitNumber || raw?.unit || "").trim() || null,
     propertyLabel: String(raw?.propertyLabel || raw?.propertyName || "").trim() || null,
+    propertyAddress: String(raw?.propertyAddress || raw?.propertyAddressLine1 || raw?.addressLine1 || raw?.propertyAddress1 || raw?.address || "").trim() || null,
   };
 }
 

--- a/rentchain-frontend/src/api/landlordLeaseRenewalApi.ts
+++ b/rentchain-frontend/src/api/landlordLeaseRenewalApi.ts
@@ -14,6 +14,7 @@ export type LandlordLeaseRenewalLease = {
   id: string;
   tenantId: string;
   propertyId: string | null;
+  propertyAddress: string | null;
   unitId: string | null;
   status: string;
   leaseType: "fixed_term" | "year_to_year" | "month_to_month";

--- a/rentchain-frontend/src/components/tenants/TenantDetailPanel.test.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantDetailPanel.test.tsx
@@ -1,0 +1,206 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TenantDetailPanel } from "./TenantDetailPanel";
+
+const mocks = vi.hoisted(() => ({
+  useTenantDetail: vi.fn(),
+  fetchLedger: vi.fn(),
+  fetchLeaseLedger: vi.fn(),
+  getTenantSignals: vi.fn(),
+  showToast: vi.fn(),
+}));
+
+vi.mock("../../hooks/useTenantDetail", () => ({
+  useTenantDetail: mocks.useTenantDetail,
+}));
+
+vi.mock("@/api/ledgerApi", () => ({
+  fetchLedger: mocks.fetchLedger,
+}));
+
+vi.mock("@/api/leaseLedgerApi", () => ({
+  fetchLeaseLedger: mocks.fetchLeaseLedger,
+}));
+
+vi.mock("@/api/tenantSignals", () => ({
+  getTenantSignals: mocks.getTenantSignals,
+}));
+
+vi.mock("../ui/ToastProvider", () => ({
+  useToast: () => ({ showToast: mocks.showToast }),
+}));
+
+vi.mock("@/hooks/useEntitlements", () => ({
+  useEntitlements: () => ({
+    loading: false,
+    capabilities: { ledger: true },
+    canExportPdf: true,
+    hasMoveInReadiness: true,
+  }),
+}));
+
+vi.mock("@/context/UpgradeContext", () => ({
+  useUpgrade: () => ({ openUpgrade: vi.fn() }),
+}));
+
+vi.mock("@/context/useAuth", () => ({
+  useAuth: () => ({
+    user: { id: "landlord-1", role: "landlord", actorRole: "landlord", displayName: "Landlord" },
+  }),
+}));
+
+vi.mock("./CredibilityInsightsCard", () => ({
+  CredibilityInsightsCard: () => <div>Credibility insights</div>,
+}));
+
+vi.mock("./MoveInReadinessPanel", () => ({
+  MoveInReadinessPanel: () => <div>Move-in readiness</div>,
+}));
+
+vi.mock("./TenantActivityPanel", () => ({
+  TenantActivityPanel: () => <div>Tenant activity panel</div>,
+}));
+
+vi.mock("@/components/billing/FeatureGate", () => ({
+  FeatureGate: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/billing/LockedFeature", () => ({
+  LockedFeature: () => <div>Locked feature</div>,
+}));
+
+vi.mock("../ledger/VerifyLedgerButton", () => ({
+  VerifyLedgerButton: () => <button type="button">Verify ledger</button>,
+}));
+
+vi.mock("./RecordTenantEventModal", () => ({
+  RecordTenantEventModal: () => null,
+}));
+
+vi.mock("./CreateNoticeModal", () => ({
+  CreateNoticeModal: () => null,
+}));
+
+vi.mock("./LeasePackWizardModal", () => ({
+  LeasePackWizardModal: () => null,
+}));
+
+describe("TenantDetailPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getTenantSignals.mockResolvedValue({ signals: null });
+    mocks.fetchLedger.mockResolvedValue([]);
+    mocks.fetchLeaseLedger.mockResolvedValue({
+      ok: true,
+      leaseId: "lease-1",
+      entries: [
+        {
+          id: "entry-1",
+          leaseId: "lease-1",
+          entryType: "charge",
+          category: "rent",
+          amountCents: 185000,
+          effectiveDate: "2026-04-01",
+          method: null,
+          reference: null,
+          notes: "April rent",
+          createdAt: 1,
+          signedAmountCents: 185000,
+          balanceCents: 185000,
+        },
+      ],
+      totals: { chargesCents: 185000, paymentsCents: 0, balanceCents: 185000 },
+      monthlyTotals: {},
+    });
+  });
+
+  it("reads the current lease ledger source when a current lease id exists", async () => {
+    mocks.useTenantDetail.mockReturnValue({
+      loading: false,
+      error: null,
+      bundle: {
+        tenant: {
+          id: "tenant-1",
+          fullName: "Taylor Tenant",
+          currentLeaseId: "lease-1",
+          propertyName: "Harbour View",
+          unit: "101",
+        },
+        currentLease: {
+          id: "lease-1",
+          tenantId: "tenant-1",
+          propertyName: "Harbour View",
+          unit: "101",
+          leaseStart: "2026-01-01",
+          leaseEnd: "2026-12-31",
+          monthlyRent: 1850,
+          status: "active",
+        },
+        property: { id: "prop-1", name: "Harbour View", addressLine1: "123 Harbour St", city: "Halifax", province: "NS" },
+        unit: { id: "unit-1", unitNumber: "101" },
+        moveInReadiness: null,
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <TenantDetailPanel tenantId="tenant-1" />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Current lease ledger")).toBeInTheDocument();
+    expect(screen.getByText("Charges and payments from the current lease ledger.")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Record tenant activity" }).length).toBeGreaterThan(0);
+    expect(screen.queryByRole("button", { name: "Verify ledger" })).not.toBeInTheDocument();
+    expect(screen.getByText(/Charge · rent/i)).toBeInTheDocument();
+    expect(screen.getByText(/Balance .*1,850\.00/i)).toBeInTheDocument();
+    expect(screen.getByText("Tenant activity panel")).toBeInTheDocument();
+    await waitFor(() => expect(mocks.fetchLeaseLedger).toHaveBeenCalledWith("lease-1"));
+    expect(mocks.fetchLedger).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the existing tenant-level ledger source when no current lease is linked", async () => {
+    mocks.useTenantDetail.mockReturnValue({
+      loading: false,
+      error: null,
+      bundle: {
+        tenant: {
+          id: "tenant-1",
+          fullName: "Taylor Tenant",
+          propertyName: "Harbour View",
+          unit: "101",
+        },
+        currentLease: null,
+        property: { id: "prop-1", name: "Harbour View", addressLine1: "123 Harbour St", city: "Halifax", province: "NS" },
+        unit: { id: "unit-1", unitNumber: "101" },
+        moveInReadiness: null,
+      },
+    });
+    mocks.fetchLedger.mockResolvedValue([
+      {
+        id: "ledger-1",
+        landlordId: "landlord-1",
+        tenantId: "tenant-1",
+        type: "PAYMENT_RECORDED",
+        version: 1,
+        ts: 1700000000000,
+        seq: 1,
+        prevHash: null,
+        payload: { amountCents: 185000 },
+        payloadHash: "payload-hash",
+        hash: "hash",
+        integrity: { status: "verified" },
+      },
+    ]);
+
+    render(
+      <MemoryRouter>
+        <TenantDetailPanel tenantId="tenant-1" />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/No current lease is linked, so this view is showing the existing tenant-level ledger source\./i)).toBeInTheDocument();
+    await waitFor(() => expect(mocks.fetchLedger).toHaveBeenCalledWith({ tenantId: "tenant-1", limit: 50 }));
+  });
+});

--- a/rentchain-frontend/src/components/tenants/TenantDetailPanel.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantDetailPanel.tsx
@@ -6,6 +6,7 @@ import { downloadTenantReport } from "@/api/tenantsApi";
 import { updateTenantMoveInReadiness, type MoveInReadiness } from "@/api/tenantDetail";
 import { getTenantSignals, type TenantSignals } from "@/api/tenantSignals";
 import { fetchLedger } from "@/api/ledgerApi";
+import { fetchLeaseLedger, type LeaseLedgerEntry } from "@/api/leaseLedgerApi";
 import { LedgerTimeline } from "../ledger/LedgerTimeline";
 import { VerifyLedgerButton } from "../ledger/VerifyLedgerButton";
 import { RecordTenantEventModal } from "./RecordTenantEventModal";
@@ -111,6 +112,10 @@ interface LayoutProps {
   activityRefreshKey: number;
 }
 
+function formatCurrencyCents(value: number) {
+  return (value / 100).toLocaleString(undefined, { style: "currency", currency: "CAD" });
+}
+
 const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityRefreshKey }) => {
   const navigate = useNavigate();
   const { user } = useAuth();
@@ -131,6 +136,8 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
   const [readinessSaving, setReadinessSaving] = useState(false);
 
   const [ledgerItems, setLedgerItems] = useState<any[]>([]);
+  const [leaseLedgerItems, setLeaseLedgerItems] = useState<LeaseLedgerEntry[]>([]);
+  const [ledgerMode, setLedgerMode] = useState<"lease" | "tenant">("tenant");
   const [ledgerLoading, setLedgerLoading] = useState(false);
   const [ledgerError, setLedgerError] = useState<string | null>(null);
   const cancelledRef = useRef(false);
@@ -185,25 +192,41 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
   };
 
   const loadLedger = React.useCallback(async () => {
+    const currentLeaseId = String(lease?.id || tenant?.currentLeaseId || tenant?.leaseId || "").trim();
     if (!tenantId) {
       setLedgerItems([]);
+      setLeaseLedgerItems([]);
       return;
     }
     if (!ledgerEnabled) {
       setLedgerItems([]);
+      setLeaseLedgerItems([]);
       return;
     }
     setLedgerLoading(true);
     setLedgerError(null);
     try {
-      const items = await fetchLedger({ tenantId, limit: 50 });
-      if (!cancelledRef.current) setLedgerItems(items || []);
+      if (currentLeaseId) {
+        const ledger = await fetchLeaseLedger(currentLeaseId);
+        if (!cancelledRef.current) {
+          setLedgerMode("lease");
+          setLeaseLedgerItems(Array.isArray(ledger.entries) ? ledger.entries : []);
+          setLedgerItems([]);
+        }
+      } else {
+        const items = await fetchLedger({ tenantId, limit: 50 });
+        if (!cancelledRef.current) {
+          setLedgerMode("tenant");
+          setLedgerItems(items || []);
+          setLeaseLedgerItems([]);
+        }
+      }
     } catch (err: any) {
       if (!cancelledRef.current) setLedgerError(err?.message || "Failed to load ledger");
     } finally {
       if (!cancelledRef.current) setLedgerLoading(false);
     }
-  }, [tenantId, ledgerEnabled]);
+  }, [lease?.id, ledgerEnabled, tenant?.currentLeaseId, tenant?.leaseId, tenantId]);
 
   useEffect(() => {
     cancelledRef.current = false;
@@ -447,7 +470,7 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
                       boxShadow: shadows.sm,
                     }}
                   >
-                    <span>Record event</span>
+                    <span>Record tenant activity</span>
                   </button>
                 ) : null}
               </>
@@ -663,7 +686,17 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
             alignItems: "center",
           }}
         >
-          <span>Ledger timeline</span>
+          <div style={{ display: "grid", gap: 2 }}>
+            <span>Current lease ledger</span>
+            <span style={{ color: text.muted, fontSize: "0.75rem", fontWeight: 400 }}>
+              Charges and payments from the current lease ledger.
+            </span>
+            {ledgerMode === "tenant" ? (
+              <span style={{ color: text.muted, fontSize: "0.75rem", fontWeight: 400 }}>
+                No current lease is linked, so this view is showing the existing tenant-level ledger source.
+              </span>
+            ) : null}
+          </div>
           <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
             <button
               type="button"
@@ -678,9 +711,9 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
                 fontSize: "0.8rem",
               }}
             >
-              Record event
+              Record tenant activity
             </button>
-            <VerifyLedgerButton onVerified={() => void loadLedger()} />
+            {ledgerMode === "tenant" ? <VerifyLedgerButton onVerified={() => void loadLedger()} /> : null}
           </div>
         </div>
         {ledgerLoading ? (
@@ -688,7 +721,50 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
         ) : ledgerError ? (
           <div style={{ color: colors.danger, fontSize: "0.85rem" }}>{ledgerError}</div>
         ) : (
-          <LedgerTimeline items={ledgerItems || []} compact />
+          ledgerMode === "lease" ? (
+            leaseLedgerItems.length === 0 ? (
+              <div style={{ color: text.muted }}>No ledger entries for the current lease yet.</div>
+            ) : (
+              <div style={{ display: "grid", gap: 8 }}>
+                {leaseLedgerItems.slice(0, 6).map((entry) => (
+                  <div
+                    key={entry.id}
+                    style={{
+                      border: "1px solid rgba(148,163,184,0.35)",
+                      borderRadius: 10,
+                      padding: 12,
+                      background: "rgba(255,255,255,0.8)",
+                      display: "grid",
+                      gap: 4,
+                    }}
+                  >
+                    <div style={{ display: "flex", justifyContent: "space-between", gap: 8, alignItems: "center" }}>
+                      <div style={{ fontWeight: 800, fontSize: 14, color: text.primary }}>
+                        {entry.entryType === "payment" ? "Payment" : "Charge"} · {entry.category}
+                      </div>
+                      <div
+                        style={{
+                          fontWeight: 700,
+                          color: entry.entryType === "payment" ? "#047857" : text.primary,
+                        }}
+                      >
+                        {entry.entryType === "payment" ? "-" : "+"}
+                        {formatCurrencyCents(Math.abs(Number(entry.amountCents || 0)))}
+                      </div>
+                    </div>
+                    <div style={{ color: text.muted, fontSize: "0.8rem" }}>
+                      {formatDateLabel(entry.effectiveDate)} · Balance {formatCurrencyCents(Number(entry.balanceCents || 0))}
+                    </div>
+                    <div style={{ color: text.primary, fontSize: "0.82rem" }}>
+                      {[entry.method, entry.reference].filter(Boolean).join(" · ") || entry.notes || "No additional details"}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )
+          ) : (
+            <LedgerTimeline items={ledgerItems || []} compact />
+          )
         )}
       </div>
       <TenantActivityPanel tenantId={tenantId} refreshKey={activityRefreshKey} />

--- a/rentchain-frontend/src/components/tenants/TenantLeasePanel.test.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantLeasePanel.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TenantLeasePanel } from "./TenantLeasePanel";
+
+const mocks = vi.hoisted(() => ({
+  getLeasesForTenant: vi.fn(),
+  getLeaseAutomationTasks: vi.fn(),
+  regenerateLeaseAutomationTasks: vi.fn(),
+  updateLease: vi.fn(),
+  endLease: vi.fn(),
+  useCapabilities: vi.fn(),
+  openUpgrade: vi.fn(),
+}));
+
+vi.mock("../../api/leasesApi", () => ({
+  getLeasesForTenant: mocks.getLeasesForTenant,
+  getLeaseAutomationTasks: mocks.getLeaseAutomationTasks,
+  regenerateLeaseAutomationTasks: mocks.regenerateLeaseAutomationTasks,
+  updateLease: mocks.updateLease,
+  endLease: mocks.endLease,
+}));
+
+vi.mock("@/hooks/useCapabilities", () => ({
+  useCapabilities: mocks.useCapabilities,
+}));
+
+vi.mock("@/context/UpgradeContext", () => ({
+  useUpgrade: () => ({ openUpgrade: mocks.openUpgrade }),
+}));
+
+vi.mock("@/components/leases/LeaseRiskCard", () => ({
+  LeaseRiskCard: () => <div>Risk card</div>,
+}));
+
+describe("TenantLeasePanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.useCapabilities.mockReturnValue({
+      loading: false,
+      features: { leases: true },
+    });
+    mocks.getLeasesForTenant.mockResolvedValue({
+      leases: [
+        {
+          id: "lease-1",
+          propertyId: "prop-1",
+          unitNumber: "101",
+          monthlyRent: 1800,
+          startDate: "2026-01-01",
+          endDate: "2026-12-31",
+          status: "active",
+          automationEnabled: true,
+        },
+      ],
+    });
+  });
+
+  it("shows the graceful automation unavailable copy when task lookup returns 404", async () => {
+    mocks.getLeaseAutomationTasks.mockRejectedValue(new Error("Request failed (404)"));
+
+    render(<TenantLeasePanel tenantId="tenant-1" />);
+
+    expect(await screen.findByText("Automation tasks unavailable")).toBeInTheDocument();
+    expect(screen.getByText("We couldn’t load upcoming automation tasks for this lease right now.")).toBeInTheDocument();
+    expect(screen.getByText("You can still manage the current lease and ledger normally.")).toBeInTheDocument();
+    await waitFor(() => expect(mocks.getLeaseAutomationTasks).toHaveBeenCalledWith("lease-1"));
+  });
+});

--- a/rentchain-frontend/src/components/tenants/TenantLeasePanel.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantLeasePanel.tsx
@@ -61,8 +61,8 @@ function getAutomationErrorCopy(error: TaskErrorState) {
     case "tasks_unavailable":
       return {
         title: "Automation tasks unavailable",
-        body: "We couldn’t load upcoming automation tasks right now.",
-        hint: "This may be temporary. Please refresh or try again shortly.",
+        body: "We couldn’t load upcoming automation tasks for this lease right now.",
+        hint: "You can still manage the current lease and ledger normally.",
       };
     case "tasks_refresh_failed":
       return {
@@ -79,8 +79,8 @@ function getAutomationErrorCopy(error: TaskErrorState) {
     default:
       return {
         title: "Automation tasks unavailable",
-        body: "We couldn’t load upcoming automation tasks right now.",
-        hint: "Please refresh or try again shortly.",
+        body: "We couldn’t load upcoming automation tasks for this lease right now.",
+        hint: "You can still manage the current lease and ledger normally.",
       };
   }
 }

--- a/rentchain-frontend/src/index.css
+++ b/rentchain-frontend/src/index.css
@@ -417,6 +417,10 @@ button,
     display: block !important;
   }
 
+  body[data-print-mode="lease-renewals"] .print-only-lease-renewals {
+    display: block !important;
+  }
+
   body[data-print-mode="application"] .print-only-application {
     display: block !important;
   }

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
@@ -173,8 +173,8 @@ describe("LandlordActiveLeasesPage", () => {
     expect(screen.getByText(/Prepare renewal notice/i)).toBeInTheDocument();
     expect(screen.getAllByText(/Rent terms ready for future setup/i).length).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: /Enable rent collection/i })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "View" })).toHaveAttribute("href", "/leases/lease-1/ledger");
     expect(screen.getByRole("link", { name: "View lease" })).toHaveAttribute("href", "https://example.com/lease.pdf");
+    expect(screen.getByRole("link", { name: "Ledger" })).toHaveAttribute("href", "/leases/lease-1/ledger");
     expect(screen.getByRole("link", { name: "Email" })).toHaveAttribute(
       "href",
       expect.stringContaining("mailto:jane%40example.com")
@@ -344,7 +344,8 @@ describe("LandlordActiveLeasesPage", () => {
     );
 
     expect((await screen.findAllByText("Harbour View")).length).toBeGreaterThan(0);
-    expect(screen.queryByRole("link", { name: "View lease" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Lease document unavailable" })).toBeDisabled();
+    expect(screen.getByRole("link", { name: "Ledger" })).toHaveAttribute("href", "/leases/lease-1/ledger");
     expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
   });
 
@@ -561,8 +562,8 @@ describe("LandlordActiveLeasesPage", () => {
     );
 
     expect(await screen.findByTestId("lease-mobile-card")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "View" })).toHaveAttribute("href", "/leases/lease-1/ledger");
     expect(screen.getByRole("link", { name: "View lease" })).toHaveAttribute("href", "https://example.com/lease.pdf");
+    expect(screen.getByRole("link", { name: "Ledger" })).toHaveAttribute("href", "/leases/lease-1/ledger");
     expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Archive lease" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Enable rent collection/i })).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
@@ -367,9 +367,6 @@ export default function LandlordActiveLeasesPage() {
     const { ledgerPath, emailHref } = buildLeaseActionMeta(lease);
     return (
       <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-        <Link to={ledgerPath} style={{ padding: "6px 10px", borderRadius: 8, border: "1px solid #cbd5e1", textDecoration: "none", color: "#0f172a" }}>
-          View
-        </Link>
         {lease.documentUrl ? (
           <a
             href={lease.documentUrl}
@@ -379,7 +376,18 @@ export default function LandlordActiveLeasesPage() {
           >
             View lease
           </a>
-        ) : null}
+        ) : (
+          <button
+            type="button"
+            disabled
+            style={{ padding: "6px 10px", borderRadius: 8, border: "1px solid #e2e8f0", background: "#f8fafc", color: "#94a3b8" }}
+          >
+            Lease document unavailable
+          </button>
+        )}
+        <Link to={ledgerPath} style={{ padding: "6px 10px", borderRadius: 8, border: "1px solid #cbd5e1", textDecoration: "none", color: "#0f172a" }}>
+          Ledger
+        </Link>
         {emailHref ? (
           <a
             href={emailHref}

--- a/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.test.tsx
@@ -206,6 +206,7 @@ describe("PortfolioHealthSummaryPage", () => {
           id: "lease-1",
           tenantId: "tenant-1",
           propertyId: "prop-2",
+          propertyAddress: "123 Harbour St",
           unitId: "unit-2",
           status: "active",
           leaseType: "fixed_term",
@@ -246,17 +247,59 @@ describe("PortfolioHealthSummaryPage", () => {
     );
 
     expect(await screen.findByText(/Opened from decisions to review lease-renewal pressure/i)).toBeInTheDocument();
-    expect(await screen.findByText(/Expiring soon leases/i)).toBeInTheDocument();
-    expect(screen.getByText(/Showing leases approaching notice timing/i)).toBeInTheDocument();
-    expect(screen.getByText(/Taylor Tenant/i)).toBeInTheDocument();
-    expect(screen.getByText(/Lifecycle:/i)).toBeInTheDocument();
-    expect(screen.getByText(/Outcome:/i)).toBeInTheDocument();
-    expect(screen.getByText(/Next step:/i)).toBeInTheDocument();
-    expect(screen.getByText(/History:/i)).toBeInTheDocument();
+    expect((await screen.findAllByText(/Expiring soon leases/i)).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText(/Showing leases approaching notice timing/i)).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText(/Taylor Tenant/i)).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText("123 Harbour St • Unit 2")).length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: "Print / Save renewal view" })).toBeInTheDocument();
+    expect((await screen.findAllByText(/Lifecycle:/i)).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText(/Outcome:/i)).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText(/Next step:/i)).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText(/History:/i)).length).toBeGreaterThan(0);
     expect(fetchExpiringLeaseRenewals).toHaveBeenCalledWith({
       propertyId: "prop-2",
       status: "expiring",
     });
+  });
+
+  it("routes scoped renewal printing through the shared print helper", async () => {
+    await mockEntitlements();
+    const { fetchLandlordPortfolioHealth } = await import("../../api/landlordPortfolioHealthApi");
+    const { fetchExpiringLeaseRenewals } = await import("../../api/landlordLeaseRenewalApi");
+    vi.mocked(fetchLandlordPortfolioHealth).mockResolvedValue({
+      portfolioHealth: {
+        version: "v1",
+        portfolioId: "landlord-1",
+        generatedAt: "2026-04-16T12:00:00.000Z",
+        overall: {
+          status: "watch",
+          headline: "Your portfolio health is stable overall.",
+          summary: "Most portfolio activity is progressing normally.",
+        },
+        trend: { direction: "stable", summary: "Stable." },
+        dimensions: [],
+        nextFocus: [],
+        metadata: {
+          portfolioScoreGrade: null,
+          portfolioScoreAvailable: true,
+          trendAvailable: true,
+        },
+      },
+    } as { portfolioHealth: LandlordPortfolioHealthSummaryV1 });
+    vi.mocked(fetchExpiringLeaseRenewals).mockResolvedValue({
+      ok: true,
+      items: [],
+      data: [],
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/portfolio-health?entry=lease-renewals&status=expiring"]}>
+        <PortfolioHealthSummaryPage />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Print / Save renewal view" }));
+    expect(printSummaryDocumentMock).toHaveBeenCalledWith("lease-renewals");
   });
 
   it("saves lease renewal operator inputs from the decision-entry workflow surface", async () => {
@@ -293,6 +336,7 @@ describe("PortfolioHealthSummaryPage", () => {
           id: "lease-1",
           tenantId: "tenant-1",
           propertyId: "prop-1",
+          propertyAddress: "12 Main St",
           unitId: "unit-1",
           status: "active",
           leaseType: "fixed_term",
@@ -322,6 +366,7 @@ describe("PortfolioHealthSummaryPage", () => {
         id: "lease-1",
         tenantId: "tenant-1",
         propertyId: "prop-1",
+        propertyAddress: "12 Main St",
         unitId: "unit-1",
         status: "active",
         leaseType: "fixed_term",
@@ -358,7 +403,7 @@ describe("PortfolioHealthSummaryPage", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText(/Lease renewal operator inputs/i)).toBeInTheDocument();
+    expect((await screen.findAllByText(/Lease renewal operator inputs/i)).length).toBeGreaterThan(0);
     fireEvent.change(screen.getByLabelText(/Rent change mode/i), { target: { value: "no_change" } });
     fireEvent.change(screen.getByLabelText(/New term type/i), { target: { value: "fixed_term" } });
     fireEvent.change(screen.getByLabelText(/New lease start date/i), { target: { value: "2026-07-01" } });
@@ -380,6 +425,96 @@ describe("PortfolioHealthSummaryPage", () => {
     expect(showToast).toHaveBeenCalledWith(
       expect.objectContaining({
         message: "Lease renewal inputs saved",
+      })
+    );
+  });
+
+  it("clears and blocks proposed rent when rent change mode does not allow it", async () => {
+    await mockEntitlements();
+    const { fetchLandlordPortfolioHealth } = await import("../../api/landlordPortfolioHealthApi");
+    const { fetchExpiringLeaseRenewals, saveLeaseRenewalInputs } = await import("../../api/landlordLeaseRenewalApi");
+    vi.mocked(fetchLandlordPortfolioHealth).mockResolvedValue({
+      portfolioHealth: {
+        version: "v1",
+        portfolioId: "landlord-1",
+        generatedAt: "2026-04-16T12:00:00.000Z",
+        overall: {
+          status: "watch",
+          headline: "Your portfolio health is stable overall.",
+          summary: "Most portfolio activity is progressing normally.",
+        },
+        trend: { direction: "stable", summary: "Stable." },
+        dimensions: [],
+        nextFocus: [],
+        metadata: {
+          portfolioScoreGrade: null,
+          portfolioScoreAvailable: true,
+          trendAvailable: true,
+        },
+      },
+    } as { portfolioHealth: LandlordPortfolioHealthSummaryV1 });
+    vi.mocked(fetchExpiringLeaseRenewals).mockResolvedValue({
+      ok: true,
+      items: [
+        {
+          id: "lease-1",
+          tenantId: "tenant-1",
+          propertyId: "prop-1",
+          propertyAddress: "12 Main St",
+          unitId: "unit-1",
+          status: "active",
+          leaseType: "fixed_term",
+          province: "NS",
+          leaseStartDate: "2025-07-01",
+          leaseEndDate: "2026-06-30",
+          currentRent: 1800,
+          currency: "CAD",
+          nextNoticeDueAt: Date.UTC(2026, 3, 1, 0, 0, 0, 0),
+          latestNoticeId: null,
+          tenantName: "Taylor Tenant",
+          unitLabel: "Unit 1",
+          propertyLabel: "Alpha",
+          renewalRentChangeMode: null,
+          renewalOfferedRent: null,
+          renewalDecisionDeadlineAt: null,
+          renewalNewTermType: null,
+          renewalNewLeaseStartDate: null,
+          renewalNewLeaseEndDate: null,
+        },
+      ],
+      data: [],
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/portfolio-health?entry=lease-renewals&propertyId=prop-1"]}>
+        <PortfolioHealthSummaryPage />
+      </MemoryRouter>
+    );
+
+    expect((await screen.findAllByText(/Lease renewal operator inputs/i)).length).toBeGreaterThan(0);
+    const proposedRentInput = screen.getByLabelText(/Proposed rent/i) as HTMLInputElement;
+
+    expect(proposedRentInput).toBeDisabled();
+    fireEvent.change(screen.getByLabelText(/Rent change mode/i), { target: { value: "increase" } });
+    expect(proposedRentInput).not.toBeDisabled();
+    fireEvent.change(proposedRentInput, { target: { value: "2000" } });
+    fireEvent.change(screen.getByLabelText(/Rent change mode/i), { target: { value: "no_change" } });
+
+    expect(proposedRentInput.value).toBe("");
+    fireEvent.click(screen.getByRole("button", { name: /Save renewal inputs/i }));
+
+    await waitFor(() =>
+      expect(saveLeaseRenewalInputs).toHaveBeenCalledWith(
+        "lease-1",
+        expect.objectContaining({
+          rentChangeMode: "no_change",
+          proposedRent: null,
+        })
+      )
+    );
+    expect(showToast).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Review renewal inputs",
       })
     );
   });

--- a/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.tsx
@@ -27,6 +27,10 @@ type LeaseRenewalFormState = {
   responseDeadlineAt: string;
 };
 
+type LeaseRenewalValidationState = {
+  proposedRent?: string | null;
+};
+
 type LeaseRenewalStatusScope = "expiring" | "pending-response" | "no-response";
 
 function toDatetimeLocalInput(value: number | null) {
@@ -106,6 +110,36 @@ function formatRenewalOutcome(
   }
 }
 
+function canSetProposedRent(rentChangeMode: LeaseRenewalFormState["rentChangeMode"]) {
+  return rentChangeMode === "increase" || rentChangeMode === "decrease";
+}
+
+function formatLeaseRenewalLocation(lease: LandlordLeaseRenewalLease) {
+  const propertyLabel = lease.propertyAddress || lease.propertyLabel || "Property";
+  return lease.unitLabel ? `${propertyLabel} • ${lease.unitLabel}` : propertyLabel;
+}
+
+function mapRenewalValidationMessage(errorCode: string | null | undefined) {
+  switch (String(errorCode || "").trim()) {
+    case "RENT_CHANGE_MODE_REQUIRED_FOR_PROPOSED_RENT":
+      return "Choose Increase or Decrease before entering a proposed rent.";
+    case "PROPOSED_RENT_NOT_ALLOWED_FOR_RENT_CHANGE_MODE":
+      return "Proposed rent is only allowed when rent change mode is Increase or Decrease.";
+    case "INVALID_PROPOSED_RENT":
+      return "Enter a valid proposed rent amount.";
+    case "INVALID_NEW_TERM_TYPE":
+      return "Choose a valid renewal term type.";
+    case "INVALID_NEW_LEASE_START_DATE":
+      return "Enter a valid new lease start date.";
+    case "INVALID_NEW_LEASE_END_DATE":
+      return "Enter a valid new lease end date.";
+    case "INVALID_RESPONSE_DEADLINE":
+      return "Enter a valid response deadline.";
+    default:
+      return null;
+  }
+}
+
 export default function PortfolioHealthSummaryPage() {
   const location = useLocation();
   const { showToast } = useToast();
@@ -123,6 +157,7 @@ export default function PortfolioHealthSummaryPage() {
   const [renewalLoading, setRenewalLoading] = React.useState(false);
   const [renewalError, setRenewalError] = React.useState<string | null>(null);
   const [savingLeaseId, setSavingLeaseId] = React.useState<string | null>(null);
+  const [renewalValidation, setRenewalValidation] = React.useState<Record<string, LeaseRenewalValidationState>>({});
   const entryParams = React.useMemo(() => new URLSearchParams(location.search), [location.search]);
   const entry = entryParams.get("entry");
   const entryPropertyId = entryParams.get("propertyId");
@@ -204,6 +239,7 @@ export default function PortfolioHealthSummaryPage() {
             return acc;
           }, {})
         );
+        setRenewalValidation({});
       } catch (err: unknown) {
         if (!mounted) return;
         const message = err instanceof Error && err.message ? err.message : "Failed to load lease renewal inputs";
@@ -228,9 +264,8 @@ export default function PortfolioHealthSummaryPage() {
 
   const handleRenewalFieldChange = React.useCallback(
     (leaseId: string, field: keyof LeaseRenewalFormState, value: string) => {
-      setRenewalForms((current) => ({
-        ...current,
-        [leaseId]: {
+      setRenewalForms((current) => {
+        const next = {
           ...(current[leaseId] || {
             rentChangeMode: "",
             proposedRent: "",
@@ -240,6 +275,23 @@ export default function PortfolioHealthSummaryPage() {
             responseDeadlineAt: "",
           }),
           [field]: value,
+        };
+        if (field === "rentChangeMode" && !canSetProposedRent(value as LeaseRenewalFormState["rentChangeMode"])) {
+          next.proposedRent = "";
+        }
+        return {
+          ...current,
+          [leaseId]: next,
+        };
+      });
+      setRenewalValidation((current) => ({
+        ...current,
+        [leaseId]: {
+          ...current[leaseId],
+          proposedRent:
+            field === "rentChangeMode" && !canSetProposedRent(value as LeaseRenewalFormState["rentChangeMode"])
+              ? "Choose Increase or Decrease before entering a proposed rent."
+              : null,
         },
       }));
     },
@@ -250,9 +302,21 @@ export default function PortfolioHealthSummaryPage() {
     async (leaseId: string) => {
       const form = renewalForms[leaseId];
       if (!form) return;
+      const nextValidation: LeaseRenewalValidationState = {};
+      if (form.proposedRent.trim() && !canSetProposedRent(form.rentChangeMode)) {
+        nextValidation.proposedRent = "Choose Increase or Decrease before entering a proposed rent.";
+        setRenewalValidation((current) => ({ ...current, [leaseId]: nextValidation }));
+        showToast({
+          message: "Review renewal inputs",
+          description: nextValidation.proposedRent,
+          variant: "warning",
+        });
+        return;
+      }
 
       try {
         setSavingLeaseId(leaseId);
+        setRenewalValidation((current) => ({ ...current, [leaseId]: {} }));
         const response = await saveLeaseRenewalInputs(leaseId, {
           rentChangeMode: form.rentChangeMode || null,
           proposedRent: form.proposedRent.trim() ? Number(form.proposedRent) : null,
@@ -266,6 +330,7 @@ export default function PortfolioHealthSummaryPage() {
           ...current,
           [leaseId]: createLeaseRenewalFormState(response.lease),
         }));
+        setRenewalValidation((current) => ({ ...current, [leaseId]: {} }));
         showToast({
           message: "Lease renewal inputs saved",
           description: "Saved values will be picked up by lease notice readiness checks.",
@@ -273,9 +338,22 @@ export default function PortfolioHealthSummaryPage() {
         });
       } catch (err: unknown) {
         const message = err instanceof Error && err.message ? err.message : "Failed to save lease renewal inputs";
+        const friendlyMessage = mapRenewalValidationMessage(message) || mapRenewalValidationMessage((err as any)?.payload?.error) || message;
+        if (
+          friendlyMessage &&
+          (message.includes("PROPOSED_RENT") || message.includes("RENT_CHANGE_MODE_REQUIRED_FOR_PROPOSED_RENT"))
+        ) {
+          setRenewalValidation((current) => ({
+            ...current,
+            [leaseId]: {
+              ...current[leaseId],
+              proposedRent: friendlyMessage,
+            },
+          }));
+        }
         showToast({
           message: "Failed to save lease renewal inputs",
-          description: message,
+          description: friendlyMessage,
           variant: "error",
         });
       } finally {
@@ -354,6 +432,64 @@ export default function PortfolioHealthSummaryPage() {
               <div style={{ fontWeight: 700 }}>{scopedRenewalHeading}</div>
               <div style={{ color: "#475569" }}>{scopedRenewalHelper}</div>
             </div>
+            <div style={{ display: "flex", justifyContent: "flex-end" }}>
+              <button
+                type="button"
+                className="no-print"
+                onClick={() => void printSummaryDocument("lease-renewals")}
+                style={{ padding: "8px 10px", borderRadius: 12, border: "1px solid #E5E7EB", background: "#FFFFFF", fontWeight: 900, cursor: "pointer" }}
+              >
+                Print / Save renewal view
+              </button>
+            </div>
+
+            <div className="print-only print-only-lease-renewals">
+              <div className="printHeader">
+                <div className="printTitle">{scopedRenewalHeading}</div>
+                <div className="printMeta">
+                  <div>Scope: Lease renewals</div>
+                  <div>Visible leases: {renewalItems.length}</div>
+                </div>
+              </div>
+              <div>{scopedRenewalHelper}</div>
+              <table className="printTable">
+                <thead>
+                  <tr>
+                    <th>Property</th>
+                    <th>Tenant</th>
+                    <th>Lease end</th>
+                    <th>Lifecycle</th>
+                    <th>Outcome</th>
+                    <th>Next step</th>
+                    <th>Renewal inputs</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {renewalItems.map((lease) => {
+                    const form = renewalForms[lease.id] || createLeaseRenewalFormState(lease);
+                    const renewalSummary = [
+                      form.rentChangeMode ? `Mode: ${form.rentChangeMode.replace(/_/g, " ")}` : null,
+                      form.proposedRent.trim() ? `Proposed rent: ${form.proposedRent}` : null,
+                      form.newTermType ? `Term: ${form.newTermType.replace(/_/g, " ")}` : null,
+                      form.responseDeadlineAt ? `Deadline: ${form.responseDeadlineAt}` : null,
+                    ]
+                      .filter(Boolean)
+                      .join(" · ");
+                    return (
+                      <tr key={lease.id}>
+                        <td>{formatLeaseRenewalLocation(lease)}</td>
+                        <td>{lease.tenantName || "—"}</td>
+                        <td>{lease.leaseEndDate || "unknown"}</td>
+                        <td>{lease.leaseLifecycleSummary?.lifecycleLabel || "—"}</td>
+                        <td>{formatRenewalOutcome(lease.leaseLifecycleSummary?.renewalOutcome)}</td>
+                        <td>{formatLifecycleNextAction(lease.leaseLifecycleSummary?.requiredNextAction)}</td>
+                        <td>{renewalSummary || "No renewal inputs saved"}</td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
 
             {renewalLoading ? <div>Loading lease renewal inputs…</div> : null}
             {!renewalLoading && renewalError ? <div style={{ color: "#b91c1c" }}>{renewalError}</div> : null}
@@ -364,6 +500,8 @@ export default function PortfolioHealthSummaryPage() {
             {!renewalLoading && !renewalError
               ? renewalItems.map((lease) => {
                   const form = renewalForms[lease.id] || createLeaseRenewalFormState(lease);
+                  const validation = renewalValidation[lease.id] || {};
+                  const proposedRentAllowed = canSetProposedRent(form.rentChangeMode);
                   const isSaving = savingLeaseId === lease.id;
                   return (
                     <div
@@ -379,7 +517,7 @@ export default function PortfolioHealthSummaryPage() {
                     >
                       <div style={{ display: "grid", gap: 2 }}>
                         <div style={{ fontWeight: 700 }}>
-                          {lease.propertyLabel || "Property"} {lease.unitLabel ? `• ${lease.unitLabel}` : ""}
+                          {formatLeaseRenewalLocation(lease)}
                         </div>
                         <div style={{ color: "#475569", fontSize: 14 }}>
                           Lease ends {lease.leaseEndDate || "unknown"}{lease.tenantName ? ` • ${lease.tenantName}` : ""}
@@ -428,8 +566,12 @@ export default function PortfolioHealthSummaryPage() {
                             min="0"
                             step="0.01"
                             value={form.proposedRent}
+                            disabled={!proposedRentAllowed}
                             onChange={(event) => handleRenewalFieldChange(lease.id, "proposedRent", event.target.value)}
                           />
+                          <span style={{ color: validation.proposedRent ? "#b91c1c" : "#64748b", fontSize: 12 }}>
+                            {validation.proposedRent || "Choose Increase or Decrease before entering a proposed rent."}
+                          </span>
                         </label>
 
                         <label style={{ display: "grid", gap: 4 }}>

--- a/rentchain-frontend/src/utils/printSummary.ts
+++ b/rentchain-frontend/src/utils/printSummary.ts
@@ -1,4 +1,4 @@
-export async function printSummaryDocument(mode: "summary" = "summary"): Promise<void> {
+export async function printSummaryDocument(mode: "summary" | "lease-renewals" = "summary"): Promise<void> {
   if (typeof window === "undefined" || typeof document === "undefined") return;
 
   const body = document.body;


### PR DESCRIPTION
This PR repairs lease renewal and ledger integration flows.

Includes:
- scoped Print / Save renewal view for portfolio-health lease renewals
- property address and unit display on expiring lease renewal items
- friendly renewal validation for rent-change mode/proposed rent conflicts
- clear separation between View lease document and Ledger actions on /leases
- landlord-aware lease automation lookup alignment
- tenant profile ledger panel now reads current lease ledger when available
- tenant activity write behavior remains separate from lease ledger
- focused backend/frontend test coverage

Guardrails preserved:
- no legal notice automation expansion
- no automatic notice sending
- no payment/provider/Stripe changes
- no data migration
- no permission expansion
- no broad lease or tenant profile redesign
- no new PDF library
- no tenant activity to lease ledger write-path unification

PR note:
- Lease notice landlord route tests passed: 7 tests.
- Lease draft route tests passed: 8 tests; rerun outside sandbox due to local listener EPERM.
- Lease active route tests passed: 6 tests.
- Backend typecheck passed.
- PortfolioHealthSummaryPage tests passed: 9 tests.
- LandlordActiveLeasesPage tests passed: 10 tests.
- TenantDetailPanel tests passed: 2 tests.
- TenantLeasePanel tests passed: 1 test.
- Frontend build passed.
- Existing chunk-size warning remains unchanged and out of scope.
- Tenant activity ↔ lease ledger write-path unification, data migration between ledger sources, broader tenant profile/lease workflow redesign, legal notice automation expansion, and payment/provider changes were intentionally deferred.