### PR TITLE
fix: repair tenant lease safety and labels

### DIFF
--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -68,6 +68,41 @@ const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
       }),
     },
   };
+  it("reconciles the affected property unit to vacant when ending a lease", async () => {
+    seedDoc("properties", "prop-1", {
+      landlordId: "landlord-1",
+      name: "Harbour View",
+      units: [
+        { id: "unit-1", unitNumber: "101", status: "occupied" },
+        { id: "unit-2", unitNumber: "102", status: "occupied" },
+      ],
+    });
+    seedDoc("leases", "lease-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      tenantIds: ["tenant-1"],
+      primaryTenantId: "tenant-1",
+      unitId: "unit-1",
+      unitNumber: "101",
+      monthlyRent: 1850,
+      startDate: "2026-01-01",
+      endDate: null,
+      status: "active",
+      createdAt: 1,
+      updatedAt: 2,
+    });
+
+    const router = (await import("../leaseRoutes")).default;
+    const res = await invokeRouter(router, { method: "POST", url: "/lease-1/end", body: {} });
+
+    expect(res.status).toBe(200);
+    const propertySnap = await fakeDb.collection("properties").doc("prop-1").get();
+    expect(propertySnap.data()?.units).toEqual([
+      expect.objectContaining({ id: "unit-1", unitNumber: "101", status: "vacant" }),
+      expect.objectContaining({ id: "unit-2", unitNumber: "102", status: "occupied" }),
+    ]);
+  });
 });
 
 vi.mock("../../config/firebase", () => ({

--- a/rentchain-api/src/routes/__tests__/tenantsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantsRoutes.test.ts
@@ -3,12 +3,39 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const setMock = vi.fn(async () => undefined);
 const getTenantDetailBundleMock = vi.fn();
 const getTenantsListMock = vi.fn();
+const leaseDocs = new Map<string, any>();
+const propertyDocs = new Map<string, any>();
 
 vi.mock("../../config/firebase", () => ({
   db: {
-    collection: () => ({
-      doc: () => ({
+    collection: (name: string) => ({
+      doc: (id?: string) => ({
         set: setMock,
+        get: async () => {
+          if (name === "properties" && id) {
+            return {
+              id,
+              exists: propertyDocs.has(id),
+              data: () => propertyDocs.get(id),
+            };
+          }
+          return { id, exists: false, data: () => undefined };
+        },
+      }),
+      where: (field: string, op: string, value: any) => ({
+        get: async () => {
+          if (name !== "leases") return { docs: [] };
+          const docs = Array.from(leaseDocs.entries())
+            .filter(([, data]) => {
+              if (field === "tenantId" && op === "==" ) return data?.tenantId === value;
+              if (field === "tenantIds" && op === "array-contains") {
+                return Array.isArray(data?.tenantIds) && data.tenantIds.includes(value);
+              }
+              return false;
+            })
+            .map(([id, data]) => ({ id, data: () => data }));
+          return { docs };
+        },
       }),
     }),
   },
@@ -92,6 +119,8 @@ describe("tenantsRoutes", () => {
     setMock.mockClear();
     getTenantDetailBundleMock.mockReset();
     getTenantsListMock.mockReset();
+    leaseDocs.clear();
+    propertyDocs.clear();
   });
 
   it("filters hidden tenants from the landlord list route", async () => {
@@ -145,5 +174,38 @@ describe("tenantsRoutes", () => {
       { merge: true }
     );
     expect(result.body?.tenant?.fullName).toBe("Taylor Tenant");
+  });
+
+  it("returns landlord-safe lease labels for tenant lease history", async () => {
+    leaseDocs.set("lease-1", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      propertyId: "prop-raw-1",
+      unitNumber: "101",
+      monthlyRent: 1850,
+      startDate: "2026-01-01",
+      endDate: null,
+      status: "active",
+    });
+    propertyDocs.set("prop-raw-1", {
+      name: "Harbour View",
+      addressLine1: "123 Harbour St",
+    });
+
+    const router = (await import("../leaseRoutes")).default;
+    const result = await invokeRouter(router, {
+      method: "GET",
+      url: "/tenant/tenant-1",
+      body: {},
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.body?.leases?.[0]).toEqual(
+      expect.objectContaining({
+        propertyAddress: "123 Harbour St",
+        propertyName: "Harbour View",
+        propertyLabel: "Harbour View",
+      })
+    );
   });
 });

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -219,6 +219,63 @@ function propertyUnitKeyByNumber(propertyId: string, unitNumber: string) {
   return `${propertyId}::num::${unitNumber}`;
 }
 
+function normalizeUnitReference(value: any): string {
+  return String(value || "").trim().toLowerCase();
+}
+
+async function reconcilePropertyUnitVacancyForLeaseEnd(lease: any) {
+  const propertyId = String(lease?.propertyId || "").trim();
+  const unitId = String(lease?.unitId || "").trim();
+  const unitNumber = String(lease?.unitNumber || lease?.unit || "").trim();
+  if (!propertyId) {
+    const error = new Error("lease_end_missing_property");
+    (error as any).code = "lease_end_missing_property";
+    throw error;
+  }
+
+  const propertyRef = db.collection("properties").doc(propertyId);
+  const propertySnap = await propertyRef.get();
+  if (!propertySnap.exists) {
+    const error = new Error("lease_end_property_not_found");
+    (error as any).code = "lease_end_property_not_found";
+    throw error;
+  }
+
+  const propertyData = (propertySnap.data() || {}) as any;
+  const units = Array.isArray(propertyData?.units) ? propertyData.units : [];
+  if (!units.length) {
+    const error = new Error("lease_end_unit_not_found");
+    (error as any).code = "lease_end_unit_not_found";
+    throw error;
+  }
+
+  const normalizedUnitId = normalizeUnitReference(unitId);
+  const normalizedUnitNumber = normalizeUnitReference(unitNumber);
+  const unitIndex = units.findIndex((unit: any) => {
+    const candidateUnitId = normalizeUnitReference(unit?.id || unit?.unitId);
+    if (normalizedUnitId && candidateUnitId === normalizedUnitId) return true;
+    const candidateUnitNumber = normalizeUnitReference(unit?.unitNumber || unit?.label || unit?.unit);
+    return Boolean(normalizedUnitNumber) && candidateUnitNumber === normalizedUnitNumber;
+  });
+
+  if (unitIndex < 0) {
+    const error = new Error("lease_end_unit_not_found");
+    (error as any).code = "lease_end_unit_not_found";
+    throw error;
+  }
+
+  const nextUnits = units.map((unit: any, index: number) =>
+    index === unitIndex ? { ...unit, status: "vacant" } : unit
+  );
+  await propertyRef.set(
+    {
+      units: nextUnits,
+      updatedAt: new Date().toISOString(),
+    },
+    { merge: true }
+  );
+}
+
 async function loadLeaseDocumentUrlForLease(raw: any): Promise<string | null> {
   const directUrl =
     String(raw?.documentUrl || raw?.approvedDocumentUrl || raw?.documentRef || "").trim() || null;
@@ -1451,10 +1508,58 @@ router.get("/tenant/:tenantId", requireLandlord, async (req: any, res: Response)
       collectionRef.where("tenantIds", "array-contains", tenantId).get().catch(() => ({ docs: [] })),
     ]);
     const firestoreLeases = [...(directSnap.docs || []), ...(arraySnap.docs || [])]
-      .map((doc: any) => normalizeLeaseRow(doc.id, doc.data() as any))
+      .map((doc: any) => {
+        const raw = doc.data() as any;
+        const lease = normalizeLeaseRow(doc.id, raw);
+        return {
+          ...lease,
+          _rawPropertyAddress:
+            [raw?.propertyAddress, raw?.propertyAddressLine1, raw?.propertyAddressLabel]
+              .map((value: any) => String(value || "").trim())
+              .find(Boolean) || null,
+          _rawPropertyName:
+            [raw?.propertyName, raw?.propertyLabel]
+              .map((value: any) => String(value || "").trim())
+              .find(Boolean) || null,
+        };
+      })
       .filter((lease: any) => !landlordId || String(lease.landlordId || "").trim() === landlordId)
       .map(({ landlordId: _landlordId, ...lease }: any) => lease);
-    return res.status(200).json({ ok: true, leases: mergeLeaseRows([...memoryLeases, ...firestoreLeases]) });
+    const propertyIds = Array.from(
+      new Set(
+        firestoreLeases.map((lease: any) => String(lease.propertyId || "").trim()).filter(Boolean)
+      )
+    );
+    const propertyEntries = await Promise.all(
+      propertyIds.map(async (propertyId) => {
+        const snap = await db.collection("properties").doc(propertyId).get().catch(() => null);
+        if (!snap?.exists) return [propertyId, null] as const;
+        const data = snap.data() as any;
+        return [
+          propertyId,
+          {
+            propertyName: String(data?.name || data?.addressLine1 || "").trim() || null,
+            propertyAddress: String(data?.addressLine1 || data?.address || "").trim() || null,
+          },
+        ] as const;
+      })
+    );
+    const propertyMap = new Map<string, { propertyName: string | null; propertyAddress: string | null } | null>(
+      propertyEntries
+    );
+    const displayLeases = firestoreLeases.map((lease: any) => {
+      const propertyData = propertyMap.get(String(lease.propertyId || "").trim()) || null;
+      const propertyName = lease._rawPropertyName || propertyData?.propertyName || null;
+      const propertyAddress = lease._rawPropertyAddress || propertyData?.propertyAddress || null;
+      const { _rawPropertyName, _rawPropertyAddress, ...rest } = lease;
+      return {
+        ...rest,
+        propertyName,
+        propertyAddress,
+        propertyLabel: propertyName,
+      };
+    });
+    return res.status(200).json({ ok: true, leases: mergeLeaseRows([...memoryLeases, ...displayLeases]) });
   } catch {
     return res.status(200).json({ ok: true, leases: memoryLeases });
   }
@@ -1695,6 +1800,20 @@ router.post("/:id/end", async (req: any, res: Response) => {
         },
         { merge: true }
       );
+      try {
+        await reconcilePropertyUnitVacancyForLeaseEnd({ id: String(req.params?.id || "").trim(), ...(leaseResult.lease as any) });
+      } catch (reconcileErr: any) {
+        console.error("[POST /api/leases/:id/end] occupancy reconciliation failed", {
+          leaseId: String(req.params?.id || "").trim(),
+          landlordId,
+          error: reconcileErr?.message || String(reconcileErr),
+          code: reconcileErr?.code || null,
+        });
+        return res.status(409).json({
+          ok: false,
+          error: "lease_end_occupancy_reconciliation_failed",
+        });
+      }
       const refreshed = await getLeaseEntityForLandlord(String(req.params?.id || "").trim(), landlordId);
       if (!refreshed.ok) return res.status(refreshed.status).json({ error: refreshed.error });
       return res.json({ lease: await enrichLeaseRow({ id: String(req.params?.id || "").trim(), ...(refreshed.lease as any) }) });

--- a/rentchain-frontend/src/api/leasesApi.ts
+++ b/rentchain-frontend/src/api/leasesApi.ts
@@ -28,6 +28,9 @@ export interface Lease {
   tenantIds?: string[];
   primaryTenantId?: string | null;
   propertyId: string;
+  propertyAddress?: string | null;
+  propertyName?: string | null;
+  propertyLabel?: string | null;
   unitId?: string | null;
   unitNumber: string;
   monthlyRent: number;

--- a/rentchain-frontend/src/components/tenants/TenantDetailPanel.test.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantDetailPanel.test.tsx
@@ -151,6 +151,11 @@ describe("TenantDetailPanel", () => {
 
     expect(await screen.findByText("Current lease ledger")).toBeInTheDocument();
     expect(screen.getByText("Charges and payments from the current lease ledger.")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Tenant activity is recorded separately and does not add charges or payments to the current lease ledger."
+      )
+    ).toBeInTheDocument();
     expect(screen.getAllByRole("button", { name: "Record tenant activity" }).length).toBeGreaterThan(0);
     expect(screen.queryByRole("button", { name: "Verify ledger" })).not.toBeInTheDocument();
     expect(screen.getByText(/Charge · rent/i)).toBeInTheDocument();

--- a/rentchain-frontend/src/components/tenants/TenantDetailPanel.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantDetailPanel.tsx
@@ -691,6 +691,9 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
             <span style={{ color: text.muted, fontSize: "0.75rem", fontWeight: 400 }}>
               Charges and payments from the current lease ledger.
             </span>
+            <span style={{ color: text.muted, fontSize: "0.75rem", fontWeight: 400 }}>
+              Tenant activity is recorded separately and does not add charges or payments to the current lease ledger.
+            </span>
             {ledgerMode === "tenant" ? (
               <span style={{ color: text.muted, fontSize: "0.75rem", fontWeight: 400 }}>
                 No current lease is linked, so this view is showing the existing tenant-level ledger source.

--- a/rentchain-frontend/src/components/tenants/TenantLeasePanel.test.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantLeasePanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TenantLeasePanel } from "./TenantLeasePanel";
 
@@ -44,6 +44,8 @@ describe("TenantLeasePanel", () => {
         {
           id: "lease-1",
           propertyId: "prop-1",
+          propertyAddress: "123 Harbour St",
+          propertyName: "Harbour View",
           unitNumber: "101",
           monthlyRent: 1800,
           startDate: "2026-01-01",
@@ -64,5 +66,66 @@ describe("TenantLeasePanel", () => {
     expect(screen.getByText("We couldn’t load upcoming automation tasks for this lease right now.")).toBeInTheDocument();
     expect(screen.getByText("You can still manage the current lease and ledger normally.")).toBeInTheDocument();
     await waitFor(() => expect(mocks.getLeaseAutomationTasks).toHaveBeenCalledWith("lease-1"));
+  });
+
+  it("requires explicit confirmation before ending a lease", async () => {
+    mocks.getLeaseAutomationTasks.mockResolvedValue({ tasks: [] });
+
+    render(<TenantLeasePanel tenantId="tenant-1" />);
+
+    expect(await screen.findByText("Property: 123 Harbour St - Unit 101")).toBeInTheDocument();
+    fireEvent.click(screen.getAllByRole("button", { name: "End lease" })[0]);
+
+    expect(mocks.endLease).not.toHaveBeenCalled();
+    expect(screen.getByText("End this lease?")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "This will mark the current lease as ended and update the unit’s occupancy status. This action should only be used when the tenant is no longer occupying the unit."
+      )
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(screen.queryByText("End this lease?")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByRole("button", { name: "End lease" })[0]);
+    fireEvent.click(screen.getByRole("button", { name: "Confirm end lease" }));
+
+    await waitFor(() => expect(mocks.endLease).toHaveBeenCalledWith("lease-1", expect.any(String)));
+  });
+
+  it("does not render raw property ids in lease labels", async () => {
+    mocks.getLeaseAutomationTasks.mockResolvedValue({ tasks: [] });
+    mocks.getLeasesForTenant.mockResolvedValue({
+      leases: [
+        {
+          id: "lease-1",
+          propertyId: "prop-raw-1",
+          propertyName: "Harbour View",
+          unitNumber: "101",
+          monthlyRent: 1800,
+          startDate: "2026-01-01",
+          endDate: null,
+          status: "active",
+          automationEnabled: true,
+        },
+        {
+          id: "lease-2",
+          propertyId: "prop-raw-2",
+          propertyLabel: "Property",
+          unitNumber: "202",
+          monthlyRent: 1600,
+          startDate: "2025-01-01",
+          endDate: "2025-12-31",
+          status: "ended",
+        },
+      ],
+    });
+
+    render(<TenantLeasePanel tenantId="tenant-1" />);
+
+    expect(await screen.findByText("Property: Harbour View - Unit 101")).toBeInTheDocument();
+    expect(screen.getByText("Property - Unit 202")).toBeInTheDocument();
+    expect(screen.queryByText(/prop-raw-1/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/prop-raw-2/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/components/tenants/TenantLeasePanel.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantLeasePanel.tsx
@@ -110,6 +110,7 @@ export const TenantLeasePanel: React.FC<TenantLeasePanelProps> = ({ tenantId }) 
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [endingLeaseId, setEndingLeaseId] = useState<string | null>(null);
+  const [confirmingLeaseId, setConfirmingLeaseId] = useState<string | null>(null);
   const [automationSaving, setAutomationSaving] = useState(false);
   const [tasksLoading, setTasksLoading] = useState(false);
   const [taskError, setTaskError] = useState<TaskErrorState | null>(null);
@@ -213,11 +214,22 @@ export const TenantLeasePanel: React.FC<TenantLeasePanelProps> = ({ tenantId }) 
       maximumFractionDigits: 0,
     })}`;
 
+  const formatLeaseLabel = (lease: Lease) => {
+    const propertyLabel =
+      String(lease.propertyAddress || "").trim() ||
+      String(lease.propertyName || "").trim() ||
+      String(lease.propertyLabel || "").trim() ||
+      "Property";
+    const unitLabel = String(lease.unitNumber || "").trim();
+    return unitLabel ? `${propertyLabel} - Unit ${unitLabel}` : propertyLabel;
+  };
+
   const handleEndLease = async (leaseId: string) => {
     try {
       setEndingLeaseId(leaseId);
       await endLease(leaseId, new Date().toISOString());
       await loadLeases();
+      setConfirmingLeaseId(null);
     } catch (err) {
       console.error("[TenantLeasePanel] Failed to end lease", err);
     } finally {
@@ -341,7 +353,7 @@ export const TenantLeasePanel: React.FC<TenantLeasePanelProps> = ({ tenantId }) 
               Current Lease
             </div>
             <div style={{ color: "#0f172a", fontWeight: 700 }}>
-              Property: {activeLease.propertyId} - Unit {activeLease.unitNumber}
+              Property: {formatLeaseLabel(activeLease)}
             </div>
             <div style={{ color: "#334155", fontSize: 13, marginTop: 4, fontWeight: 600 }}>
               Rent: {formatCurrency(activeLease.monthlyRent)} / month
@@ -456,24 +468,85 @@ export const TenantLeasePanel: React.FC<TenantLeasePanelProps> = ({ tenantId }) 
                 </div>
               ) : null}
             </div>
-            <button
-              type="button"
-              onClick={() => handleEndLease(activeLease.id)}
-              disabled={endingLeaseId === activeLease.id}
-              style={{
-                marginTop: 8,
-                padding: "6px 10px",
-                borderRadius: 10,
-                border: "1px solid rgba(148,163,184,0.4)",
-                background: "transparent",
-                color: "#e5e7eb",
-                cursor: endingLeaseId === activeLease.id ? "default" : "pointer",
-                opacity: endingLeaseId === activeLease.id ? 0.7 : 1,
-                fontSize: 12,
-              }}
-            >
-              {endingLeaseId === activeLease.id ? "Ending..." : "End lease"}
-            </button>
+            <div style={{ marginTop: 8, display: "grid", gap: 8 }}>
+              {confirmingLeaseId === activeLease.id ? (
+                <div
+                  style={{
+                    borderRadius: 12,
+                    border: "1px solid rgba(185,28,28,0.28)",
+                    background: "rgba(254,242,242,0.98)",
+                    padding: 12,
+                    display: "grid",
+                    gap: 8,
+                  }}
+                >
+                  <div style={{ color: "#7f1d1d", fontWeight: 800 }}>End this lease?</div>
+                  <div style={{ color: "#991b1b", fontSize: 13, lineHeight: 1.5 }}>
+                    This will mark the current lease as ended and update the unit’s occupancy
+                    status. This action should only be used when the tenant is no longer
+                    occupying the unit.
+                  </div>
+                  <div style={{ display: "flex", justifyContent: "flex-end", gap: 8, flexWrap: "wrap" }}>
+                    <button
+                      type="button"
+                      onClick={() => setConfirmingLeaseId(null)}
+                      disabled={endingLeaseId === activeLease.id}
+                      style={{
+                        padding: "6px 10px",
+                        borderRadius: 10,
+                        border: "1px solid rgba(148,163,184,0.35)",
+                        background: "#fff",
+                        color: "#334155",
+                        fontWeight: 700,
+                        cursor: endingLeaseId === activeLease.id ? "default" : "pointer",
+                        opacity: endingLeaseId === activeLease.id ? 0.7 : 1,
+                        fontSize: 12,
+                      }}
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleEndLease(activeLease.id)}
+                      disabled={endingLeaseId === activeLease.id}
+                      style={{
+                        padding: "6px 10px",
+                        borderRadius: 10,
+                        border: "1px solid rgba(153,27,27,0.6)",
+                        background: "#b91c1c",
+                        color: "#fff",
+                        fontWeight: 800,
+                        cursor: endingLeaseId === activeLease.id ? "default" : "pointer",
+                        opacity: endingLeaseId === activeLease.id ? 0.7 : 1,
+                        fontSize: 12,
+                      }}
+                    >
+                      {endingLeaseId === activeLease.id ? "Ending..." : "Confirm end lease"}
+                    </button>
+                  </div>
+                </div>
+              ) : null}
+              <div style={{ display: "flex", justifyContent: "flex-end" }}>
+                <button
+                  type="button"
+                  onClick={() => setConfirmingLeaseId(activeLease.id)}
+                  disabled={endingLeaseId === activeLease.id}
+                  style={{
+                    padding: "6px 10px",
+                    borderRadius: 10,
+                    border: "1px solid rgba(185,28,28,0.45)",
+                    background: "rgba(254,226,226,0.98)",
+                    color: "#991b1b",
+                    cursor: endingLeaseId === activeLease.id ? "default" : "pointer",
+                    opacity: endingLeaseId === activeLease.id ? 0.7 : 1,
+                    fontSize: 12,
+                    fontWeight: 800,
+                  }}
+                >
+                  End lease
+                </button>
+              </div>
+            </div>
           </div>
         )}
 
@@ -506,7 +579,7 @@ export const TenantLeasePanel: React.FC<TenantLeasePanelProps> = ({ tenantId }) 
                 >
                   <div>
                     <div style={{ fontWeight: 600 }}>
-                      {lease.propertyId} - Unit {lease.unitNumber}
+                      {formatLeaseLabel(lease)}
                     </div>
                     <div style={{ color: "#475569", fontSize: 12 }}>
                       {formatDate(lease.startDate)} → {formatDate(lease.endDate)}

--- a/rentchain-frontend/src/pages/MessagesPage.test.tsx
+++ b/rentchain-frontend/src/pages/MessagesPage.test.tsx
@@ -41,6 +41,7 @@ vi.mock("@/components/layout/ResponsiveMasterDetail", () => ({
 
 describe("MessagesPage", () => {
   beforeEach(() => {
+    vi.useRealTimers();
     mocks.useCapabilitiesMock.mockReturnValue({
       features: { messaging: true },
       loading: false,

--- a/rentchain-frontend/src/pages/MessagesPage.tsx
+++ b/rentchain-frontend/src/pages/MessagesPage.tsx
@@ -70,12 +70,21 @@ export default function MessagesPage() {
   const messagingEnabled = features?.messaging !== false;
   const conversationPollTimeoutRef = useRef<number | null>(null);
   const conversationPollFailureRef = useRef(0);
+  const hasLoadedConversationsRef = useRef(false);
+  const hasLoadedThreadRef = useRef(false);
 
-  const loadConversations = useCallback(async (preferredId?: string | null): Promise<boolean> => {
+  const loadConversations = useCallback(async (
+    preferredId?: string | null,
+    options?: { background?: boolean }
+  ): Promise<boolean> => {
+    const background = options?.background === true;
     try {
-      setLoadingList(true);
+      if (!background || !hasLoadedConversationsRef.current) {
+        setLoadingList(true);
+      }
       const data = await fetchLandlordConversations();
       setConversations(data);
+      hasLoadedConversationsRef.current = true;
       if (preferredId) {
         setSelectedId(preferredId);
       } else if (!selectedId && data.length > 0) {
@@ -86,20 +95,32 @@ export default function MessagesPage() {
       setError(err?.message || "Failed to load conversations");
       return false;
     } finally {
-      setLoadingList(false);
+      if (!background || !hasLoadedConversationsRef.current) {
+        setLoadingList(false);
+      } else {
+        setLoadingList(false);
+      }
     }
   }, [selectedId]);
 
-  const loadThread = async (id: string) => {
+  const loadThread = async (id: string, options?: { background?: boolean }) => {
+    const background = options?.background === true;
     try {
-      setLoadingThread(true);
+      if (!background || !hasLoadedThreadRef.current) {
+        setLoadingThread(true);
+      }
       const res = await fetchLandlordConversationMessages(id);
       setMessages(res.messages || []);
+      hasLoadedThreadRef.current = true;
       await markLandlordConversationRead(id);
     } catch (err: any) {
       setError(err?.message || "Failed to load messages");
     } finally {
-      setLoadingThread(false);
+      if (!background || !hasLoadedThreadRef.current) {
+        setLoadingThread(false);
+      } else {
+        setLoadingThread(false);
+      }
     }
   };
 
@@ -136,7 +157,7 @@ export default function MessagesPage() {
     const tick = async () => {
       if (cancelled) return;
       try {
-        const ok = await loadConversations(selectedId);
+        const ok = await loadConversations(selectedId, { background: true });
         conversationPollFailureRef.current = ok
           ? 0
           : Math.min(conversationPollFailureRef.current + 1, 6);
@@ -160,8 +181,9 @@ export default function MessagesPage() {
   useEffect(() => {
     if (!selectedId) return;
     if (!messagingEnabled) return;
+    hasLoadedThreadRef.current = false;
     void loadThread(selectedId);
-    const t = window.setInterval(() => void loadThread(selectedId), POLL_THREAD_MS);
+    const t = window.setInterval(() => void loadThread(selectedId, { background: true }), POLL_THREAD_MS);
     return () => window.clearInterval(t);
   }, [selectedId, messagingEnabled]);
 


### PR DESCRIPTION
This PR repairs urgent post-QA tenant/lease safety and data consistency issues.

Includes:
- two-step destructive End lease confirmation
- unit occupancy reconciliation when a lease is ended
- controlled reconciliation failure handling
- messages page background polling flicker reduction
- tenant lease labels no longer fall back to raw property IDs
- landlord-safe property labels added where available
- clearer tenant activity vs lease ledger copy
- focused backend/frontend test coverage

Guardrails preserved:
- no tenant activity to lease ledger write-path unification
- no data migration
- no permission expansion
- no websocket/realtime rewrite
- no legal notice automation expansion
- no payment/provider/Stripe changes
- existing ledger and tenant activity data preserved

PR note:
- Lease active route tests passed: 6 tests.
- Messages route tests passed: 3 tests.
- Tenants route tests passed: 3 tests.
- Backend typecheck passed.
- TenantLeasePanel tests passed: 3 tests.
- TenantDetailPanel tests passed: 2 tests.
- MessagesPage tests passed: 3 tests.
- PropertiesPage tests passed: 5 tests.
- Frontend build passed.
- Existing chunk-size warning remains unchanged and out of scope.
- Dashboard lease notice count/list repair, portfolio-health renewal PDF blank-page fix, renewal save refresh, tenant activity ↔ lease ledger write-path unification, broad tenant/dashboard redesign, websocket/realtime rewrite, legal notice automation expansion, payment/provider changes, data migration, and permission expansion were intentionally deferred.