### PR TITLE
fix: repair lease restore unit matching

### DIFF
--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -567,6 +567,22 @@ describe("leaseRoutes GET /active", () => {
         { id: "unit-2", unitNumber: "102", status: "vacant" },
       ],
     });
+    seedDoc("units", "unit-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitNumber: "101",
+      label: "Unit 101",
+      status: "vacant",
+      occupancyStatus: "vacant",
+    });
+    seedDoc("units", "unit-2", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitNumber: "102",
+      label: "Unit 102",
+      status: "vacant",
+      occupancyStatus: "vacant",
+    });
     seedDoc("leases", "lease-1", {
       landlordId: "landlord-1",
       propertyId: "prop-1",
@@ -610,6 +626,15 @@ describe("leaseRoutes GET /active", () => {
       expect.objectContaining({ id: "unit-1", unitNumber: "101", status: "occupied" }),
       expect.objectContaining({ id: "unit-2", unitNumber: "102", status: "vacant" }),
     ]);
+
+    const unitSnap = await fakeDb.collection("units").doc("unit-1").get();
+    expect(unitSnap.data()).toEqual(
+      expect.objectContaining({
+        status: "occupied",
+        occupancyStatus: "occupied",
+        updatedAt: expect.any(String),
+      })
+    );
   });
 
   it("fails to restore a lease unless it is currently ended", async () => {
@@ -617,6 +642,13 @@ describe("leaseRoutes GET /active", () => {
       landlordId: "landlord-1",
       name: "Harbour View",
       units: [{ id: "unit-1", unitNumber: "101", status: "occupied" }],
+    });
+    seedDoc("units", "unit-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitNumber: "101",
+      status: "occupied",
+      occupancyStatus: "occupied",
     });
     seedDoc("leases", "lease-1", {
       landlordId: "landlord-1",
@@ -644,6 +676,13 @@ describe("leaseRoutes GET /active", () => {
       landlordId: "landlord-1",
       name: "Harbour View",
       units: [{ id: "unit-1", unitNumber: "101", status: "vacant" }],
+    });
+    seedDoc("units", "unit-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitNumber: "101",
+      status: "vacant",
+      occupancyStatus: "vacant",
     });
     seedDoc("leases", "lease-ended", {
       landlordId: "landlord-1",
@@ -688,11 +727,19 @@ describe("leaseRoutes GET /active", () => {
     ]);
   });
 
-  it("fails to restore when the matching property unit cannot be found", async () => {
+  it("fails to restore when no canonical unit match exists", async () => {
     seedDoc("properties", "prop-1", {
       landlordId: "landlord-1",
       name: "Harbour View",
       units: [{ id: "unit-2", unitNumber: "102", status: "vacant" }],
+    });
+    seedDoc("units", "unit-2", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitNumber: "102",
+      label: "Unit 102",
+      status: "vacant",
+      occupancyStatus: "vacant",
     });
     seedDoc("leases", "lease-1", {
       landlordId: "landlord-1",
@@ -724,5 +771,190 @@ describe("leaseRoutes GET /active", () => {
         endDate: "2026-04-01",
       })
     );
+  });
+
+  it("restores by canonical unitId even when embedded property units do not match", async () => {
+    seedDoc("properties", "prop-1", {
+      landlordId: "landlord-1",
+      name: "Harbour View",
+      units: [{ id: "unit-x", unitNumber: "999", status: "vacant" }],
+    });
+    seedDoc("units", "unit-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitNumber: "101",
+      label: "Unit 101",
+      status: "vacant",
+      occupancyStatus: "vacant",
+    });
+    seedDoc("leases", "lease-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      tenantIds: ["tenant-1"],
+      primaryTenantId: "tenant-1",
+      unitId: "unit-1",
+      unitNumber: "101",
+      monthlyRent: 1850,
+      startDate: "2026-01-01",
+      endDate: "2026-04-01",
+      status: "ended",
+    });
+
+    const router = (await import("../leaseRoutes")).default;
+    const res = await invokeRouter(router, { method: "POST", url: "/lease-1/restore-active", body: {} });
+
+    expect(res.status).toBe(200);
+
+    const propertySnap = await fakeDb.collection("properties").doc("prop-1").get();
+    expect(propertySnap.data()?.units).toEqual([
+      expect.objectContaining({ id: "unit-x", unitNumber: "999", status: "vacant" }),
+    ]);
+    const unitSnap = await fakeDb.collection("units").doc("unit-1").get();
+    expect(unitSnap.data()).toEqual(
+      expect.objectContaining({
+        status: "occupied",
+        occupancyStatus: "occupied",
+      })
+    );
+  });
+
+  it("restores by unique normalized unit label when unitId is missing", async () => {
+    seedDoc("properties", "prop-1", {
+      landlordId: "landlord-1",
+      name: "Harbour View",
+      units: [{ unitNumber: "3", label: "Unit 3", status: "vacant" }],
+    });
+    seedDoc("units", "unit-3", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitNumber: "3",
+      label: "Unit 3",
+      status: "vacant",
+      occupancyStatus: "vacant",
+    });
+    seedDoc("leases", "lease-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      tenantIds: ["tenant-1"],
+      primaryTenantId: "tenant-1",
+      unitId: "",
+      unitNumber: "Unit 3",
+      monthlyRent: 1850,
+      startDate: "2026-01-01",
+      endDate: "2026-04-01",
+      status: "ended",
+    });
+
+    const router = (await import("../leaseRoutes")).default;
+    const res = await invokeRouter(router, { method: "POST", url: "/lease-1/restore-active", body: {} });
+
+    expect(res.status).toBe(200);
+    const unitSnap = await fakeDb.collection("units").doc("unit-3").get();
+    expect(unitSnap.data()).toEqual(
+      expect.objectContaining({
+        status: "occupied",
+        occupancyStatus: "occupied",
+      })
+    );
+    const propertySnap = await fakeDb.collection("properties").doc("prop-1").get();
+    expect(propertySnap.data()?.units).toEqual([
+      expect.objectContaining({ unitNumber: "3", label: "Unit 3", status: "occupied" }),
+    ]);
+  });
+
+  it("fails to restore when canonical fallback matching is ambiguous", async () => {
+    seedDoc("properties", "prop-1", {
+      landlordId: "landlord-1",
+      name: "Harbour View",
+      units: [],
+    });
+    seedDoc("units", "unit-3a", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitNumber: "3",
+      label: "Unit 3",
+      status: "vacant",
+      occupancyStatus: "vacant",
+    });
+    seedDoc("units", "unit-3b", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitNumber: "Unit 3",
+      label: "3",
+      status: "vacant",
+      occupancyStatus: "vacant",
+    });
+    seedDoc("leases", "lease-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      tenantIds: ["tenant-1"],
+      primaryTenantId: "tenant-1",
+      unitId: "",
+      unitNumber: "3",
+      monthlyRent: 1850,
+      startDate: "2026-01-01",
+      endDate: "2026-04-01",
+      status: "ended",
+    });
+
+    const router = (await import("../leaseRoutes")).default;
+    const res = await invokeRouter(router, { method: "POST", url: "/lease-1/restore-active", body: {} });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual({ ok: false, error: "lease_restore_unit_reconciliation_failed" });
+
+    const leaseSnap = await fakeDb.collection("leases").doc("lease-1").get();
+    expect(leaseSnap.data()).toEqual(expect.objectContaining({ status: "ended" }));
+    expect((await fakeDb.collection("units").doc("unit-3a").get()).data()).toEqual(
+      expect.objectContaining({ status: "vacant", occupancyStatus: "vacant" })
+    );
+    expect((await fakeDb.collection("units").doc("unit-3b").get()).data()).toEqual(
+      expect.objectContaining({ status: "vacant", occupancyStatus: "vacant" })
+    );
+  });
+
+  it("patches embedded property units only when a single exact embedded match exists", async () => {
+    seedDoc("properties", "prop-1", {
+      landlordId: "landlord-1",
+      name: "Harbour View",
+      units: [
+        { id: "unit-1", unitNumber: "101", status: "vacant" },
+        { id: "unit-dup", unitNumber: "102", status: "vacant" },
+      ],
+    });
+    seedDoc("units", "unit-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitNumber: "101",
+      label: "Unit 101",
+      status: "vacant",
+      occupancyStatus: "vacant",
+    });
+    seedDoc("leases", "lease-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      tenantIds: ["tenant-1"],
+      primaryTenantId: "tenant-1",
+      unitId: "unit-1",
+      unitNumber: "101",
+      monthlyRent: 1850,
+      startDate: "2026-01-01",
+      endDate: "2026-04-01",
+      status: "ended",
+    });
+
+    const router = (await import("../leaseRoutes")).default;
+    const res = await invokeRouter(router, { method: "POST", url: "/lease-1/restore-active", body: {} });
+
+    expect(res.status).toBe(200);
+    const propertySnap = await fakeDb.collection("properties").doc("prop-1").get();
+    expect(propertySnap.data()?.units).toEqual([
+      expect.objectContaining({ id: "unit-1", unitNumber: "101", status: "occupied" }),
+      expect.objectContaining({ id: "unit-dup", unitNumber: "102", status: "vacant" }),
+    ]);
   });
 });

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -223,6 +223,12 @@ function normalizeUnitReference(value: any): string {
   return String(value || "").trim().toLowerCase();
 }
 
+function normalizeUnitMatchToken(value: any): string {
+  const raw = String(value || "").trim().toLowerCase();
+  if (!raw) return "";
+  return raw.replace(/^unit\b/, "").replace(/[\s_-]+/g, "");
+}
+
 async function resolvePropertyUnitForLease(lease: any, errorPrefix: string) {
   const propertyId = String(lease?.propertyId || "").trim();
   const unitId = String(lease?.unitId || "").trim();
@@ -286,17 +292,138 @@ async function reconcilePropertyUnitVacancyForLeaseEnd(lease: any) {
 }
 
 async function reconcilePropertyUnitOccupancyForLeaseRestore(lease: any) {
-  const { propertyRef, units, unitIndex } = await resolvePropertyUnitForLease(lease, "lease_restore");
-  const nextUnits = units.map((unit: any, index: number) =>
-    index === unitIndex ? { ...unit, status: "occupied" } : unit
-  );
-  await propertyRef.set(
+  const targets = await resolveRestoreUnitTargetsForLease(lease, "lease_restore");
+  const nowIso = new Date().toISOString();
+
+  await db.collection("units").doc(targets.unitDocId).set(
     {
-      units: nextUnits,
-      updatedAt: new Date().toISOString(),
+      status: "occupied",
+      occupancyStatus: "occupied",
+      updatedAt: nowIso,
     },
     { merge: true }
   );
+
+  const propertyPatch: Record<string, unknown> = {
+    updatedAt: nowIso,
+  };
+  if (targets.propertyUnitIndex >= 0) {
+    propertyPatch.units = targets.propertyUnits.map((unit: any, index: number) =>
+      index === targets.propertyUnitIndex ? { ...unit, status: "occupied" } : unit
+    );
+  }
+  await targets.propertyRef.set(propertyPatch, { merge: true });
+}
+
+async function resolveRestoreUnitTargetsForLease(lease: any, errorPrefix: string) {
+  const propertyId = String(lease?.propertyId || "").trim();
+  const landlordId = String(lease?.landlordId || "").trim();
+  const leaseUnitId = String(lease?.unitId || "").trim();
+  const leaseUnitNumber = String(lease?.unitNumber || lease?.unit || "").trim();
+  if (!propertyId) {
+    const error = new Error(`${errorPrefix}_property_not_found`);
+    (error as any).code = `${errorPrefix}_property_not_found`;
+    throw error;
+  }
+
+  const propertyRef = db.collection("properties").doc(propertyId);
+  const propertySnap = await propertyRef.get();
+  if (!propertySnap.exists) {
+    const error = new Error(`${errorPrefix}_property_not_found`);
+    (error as any).code = `${errorPrefix}_property_not_found`;
+    throw error;
+  }
+
+  const propertyData = (propertySnap.data() || {}) as any;
+  const propertyUnits = Array.isArray(propertyData?.units) ? propertyData.units : [];
+  const canonicalUnits = await loadUnitsForProperty(db as any, propertyId, landlordId || null);
+
+  const normalizedLeaseUnitId = normalizeUnitReference(leaseUnitId);
+  const canonicalIdMatches = normalizedLeaseUnitId
+    ? canonicalUnits.filter((unit) => normalizeUnitReference(unit.id) === normalizedLeaseUnitId)
+    : [];
+  if (canonicalIdMatches.length > 1) {
+    const error = new Error(`${errorPrefix}_unit_ambiguous`);
+    (error as any).code = `${errorPrefix}_unit_ambiguous`;
+    throw error;
+  }
+
+  const fallbackTarget = normalizeUnitMatchToken(leaseUnitNumber);
+  const canonicalFallbackMatches =
+    canonicalIdMatches.length === 1 || !fallbackTarget
+      ? []
+      : canonicalUnits.filter((unit) => {
+          const tokens = [
+            normalizeUnitMatchToken(unit.unitNumber),
+            normalizeUnitMatchToken(unit.label),
+            normalizeUnitMatchToken((unit.raw as any)?.unit),
+            normalizeUnitMatchToken((unit.raw as any)?.name),
+          ].filter(Boolean);
+          return tokens.includes(fallbackTarget);
+        });
+  if (!canonicalIdMatches.length && canonicalFallbackMatches.length > 1) {
+    const error = new Error(`${errorPrefix}_unit_ambiguous`);
+    (error as any).code = `${errorPrefix}_unit_ambiguous`;
+    throw error;
+  }
+
+  const matchedUnit = canonicalIdMatches[0] || canonicalFallbackMatches[0] || null;
+  if (!matchedUnit) {
+    const error = new Error(`${errorPrefix}_unit_not_found`);
+    (error as any).code = `${errorPrefix}_unit_not_found`;
+    throw error;
+  }
+
+  let propertyUnitIndex = -1;
+  if (propertyUnits.length) {
+    const embeddedIdMatches = leaseUnitId
+      ? propertyUnits
+          .map((unit: any, index: number) => ({ unit, index }))
+          .filter(
+            ({ unit }: { unit: any; index: number }) =>
+              normalizeUnitReference(unit?.id || unit?.unitId) === normalizedLeaseUnitId
+          )
+      : [];
+    if (embeddedIdMatches.length > 1) {
+      const error = new Error(`${errorPrefix}_unit_ambiguous`);
+      (error as any).code = `${errorPrefix}_unit_ambiguous`;
+      throw error;
+    }
+
+    if (embeddedIdMatches.length === 1) {
+      propertyUnitIndex = embeddedIdMatches[0].index;
+    } else {
+      const embeddedTarget = normalizeUnitMatchToken(
+        matchedUnit.unitNumber || matchedUnit.label || leaseUnitNumber
+      );
+      if (embeddedTarget) {
+        const embeddedLabelMatches = propertyUnits
+          .map((unit: any, index: number) => ({ unit, index }))
+          .filter(({ unit }: { unit: any; index: number }) => {
+            const tokens = [
+              normalizeUnitMatchToken(unit?.unitNumber),
+              normalizeUnitMatchToken(unit?.label),
+              normalizeUnitMatchToken(unit?.unit),
+              normalizeUnitMatchToken(unit?.name),
+            ].filter(Boolean);
+            return tokens.includes(embeddedTarget);
+          });
+        if (embeddedLabelMatches.length > 1) {
+          const error = new Error(`${errorPrefix}_unit_ambiguous`);
+          (error as any).code = `${errorPrefix}_unit_ambiguous`;
+          throw error;
+        }
+        propertyUnitIndex = embeddedLabelMatches[0]?.index ?? -1;
+      }
+    }
+  }
+
+  return {
+    propertyRef,
+    propertyUnits,
+    propertyUnitIndex,
+    unitDocId: matchedUnit.id,
+  };
 }
 
 async function loadLeaseDocumentUrlForLease(raw: any): Promise<string | null> {
@@ -1950,7 +2077,7 @@ router.post("/:id/restore-active", requireLandlord, async (req: any, res: Respon
     }
 
     try {
-      await resolvePropertyUnitForLease(existingLease, "lease_restore");
+      await resolveRestoreUnitTargetsForLease(existingLease, "lease_restore");
     } catch (resolveErr: any) {
       console.error("[POST /api/leases/:id/restore-active] property unit resolution failed", {
         leaseId,


### PR DESCRIPTION
This PR repairs lease restore unit matching.

Includes:
- canonical units collection lookup for lease restore
- unitId-first restore matching
- deterministic normalized unit label/number fallback
- canonical unit occupancy restore
- safe embedded property units patch only when uniquely matched
- ambiguity/no-match fail-closed behavior
- focused backend test coverage

Guardrails preserved:
- backend-only
- no direct Firestore edits
- no migration
- no frontend changes
- no lease ledger, payment, or tenant activity changes
- no unrelated unit mutation

PR note:
- Lease active route tests passed: 15 tests.
- Backend typecheck passed.
- Production restore retest required after merge/deploy:
  POST /api/leases/0bf298d0-ce52-44a7-8628-16c023983fac/restore-active