### PR TITLE
fix: stabilize message identity display

### DIFF
--- a/rentchain-api/src/routes/__tests__/messagesRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/messagesRoutes.test.ts
@@ -214,6 +214,40 @@ describe("messagesRoutes notifications", () => {
     );
   });
 
+  it("enriches older conversations from tenant-linked property and unit context when available", async () => {
+    ensureCollection("conversations").set("conv-2", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      propertyId: null,
+      unitId: null,
+    });
+    ensureCollection("tenants").set("tenant-1", {
+      email: "tenant@example.com",
+      fullName: "Taylor Tenant",
+      propertyId: "prop-1",
+      unit: "2A",
+    });
+
+    const router = await createRouter();
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/landlord/messages/conversations",
+      headers: { "x-test-user": JSON.stringify({ id: "landlord-1", landlordId: "landlord-1", role: "landlord" }) },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.conversations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "conv-2",
+          tenantDisplayName: "Taylor Tenant",
+          propertyDisplayLabel: "Harbour View",
+          unitDisplayLabel: "Unit 2A",
+        }),
+      ])
+    );
+  });
+
   it("stores deterministic property context when tenant conversation is created", async () => {
     const router = await createRouter();
     const res = await invokeRouter(router, {
@@ -228,6 +262,31 @@ describe("messagesRoutes notifications", () => {
         tenantId: "tenant-1",
         propertyId: "prop-1",
         unitId: "unit-1",
+      })
+    );
+  });
+
+  it("returns enriched tenant conversation detail without raw ids in labels", async () => {
+    const router = await createRouter();
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/tenant/messages/conversation/conv-1",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "tenant-user-1",
+          tenantId: "tenant-1",
+          landlordId: "landlord-1",
+          role: "tenant",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.conversation).toEqual(
+      expect.objectContaining({
+        tenantDisplayName: "Taylor Tenant",
+        propertyDisplayLabel: "Harbour View",
+        unitDisplayLabel: "Unit 2A",
       })
     );
   });

--- a/rentchain-api/src/routes/messagesRoutes.ts
+++ b/rentchain-api/src/routes/messagesRoutes.ts
@@ -80,7 +80,17 @@ async function enrichConversationDisplay<T extends ReturnType<typeof normalizeCo
     Promise.all(
       tenantIds.map(async (tenantId) => {
         const snap = await db.collection("tenants").doc(tenantId).get();
-        return [tenantId, snap.exists ? buildTenantLabel(snap.data() as any) : null] as const;
+        const raw = snap.exists ? (snap.data() as any) : null;
+        return [
+          tenantId,
+          {
+            raw,
+            label: raw ? buildTenantLabel(raw) : null,
+            unitLabel: raw ? normalizeUnitLabel(raw?.unitLabel || raw?.unit) : null,
+            unitId: raw ? stringOrNull(raw?.unitId) : null,
+            propertyId: raw ? stringOrNull(raw?.propertyId) : null,
+          },
+        ] as const;
       })
     ),
     Promise.all(
@@ -98,7 +108,10 @@ async function enrichConversationDisplay<T extends ReturnType<typeof normalizeCo
     ),
   ]);
 
-  const tenantNameById = new Map<string, string | null>(tenants);
+  const tenantById = new Map<
+    string,
+    { raw: any; label: string | null; unitLabel: string | null; unitId: string | null; propertyId: string | null }
+  >(tenants);
   const unitById = new Map<string, { raw: any; label: string | null }>(units);
   const propertyIds = Array.from(
     new Set(
@@ -107,7 +120,9 @@ async function enrichConversationDisplay<T extends ReturnType<typeof normalizeCo
           const direct = stringOrNull((conversation as any).propertyId);
           if (direct) return direct;
           const unitId = stringOrNull(conversation.unitId);
-          return unitId ? stringOrNull(unitById.get(unitId)?.raw?.propertyId) : null;
+          if (unitId) return stringOrNull(unitById.get(unitId)?.raw?.propertyId);
+          const tenantId = stringOrNull(conversation.tenantId);
+          return tenantId ? stringOrNull(tenantById.get(tenantId)?.propertyId) : null;
         })
         .filter(Boolean)
     )
@@ -122,24 +137,30 @@ async function enrichConversationDisplay<T extends ReturnType<typeof normalizeCo
 
   return conversations.map((conversation) => {
     const unitId = stringOrNull(conversation.unitId);
+    const tenantId = stringOrNull(conversation.tenantId);
+    const resolvedTenant = tenantId ? tenantById.get(tenantId) : null;
     const resolvedUnit = unitId ? unitById.get(unitId) : null;
     const propertyId =
       stringOrNull((conversation as any).propertyId) ||
-      stringOrNull(resolvedUnit?.raw?.propertyId);
+      stringOrNull(resolvedUnit?.raw?.propertyId) ||
+      stringOrNull(resolvedTenant?.propertyId);
     const property = propertyId ? propertyById.get(propertyId) : null;
     const fallbackUnitFromProperty = Array.isArray(property?.units)
       ? property.units.find((unit: any) => {
           const candidateId = stringOrNull(unit?.id) || stringOrNull(unit?.unitId) || stringOrNull(unit?.uid);
-          return candidateId && unitId && candidateId === unitId;
+          if (candidateId && unitId && candidateId === unitId) return true;
+          const candidateLabel = normalizeUnitLabel(unit?.unitNumber || unit?.label || unit?.name);
+          return Boolean(candidateLabel && resolvedTenant?.unitLabel && candidateLabel === resolvedTenant.unitLabel);
         })
       : null;
 
     return {
       ...conversation,
-      tenantDisplayName: tenantNameById.get(String(conversation.tenantId || "").trim()) || null,
+      tenantDisplayName: resolvedTenant?.label || null,
       propertyDisplayLabel: buildPropertyLabel(property),
       unitDisplayLabel:
         resolvedUnit?.label ||
+        resolvedTenant?.unitLabel ||
         normalizeUnitLabel(
           fallbackUnitFromProperty?.unitNumber ||
             fallbackUnitFromProperty?.label ||
@@ -447,9 +468,11 @@ router.get("/tenant/messages/conversation", requireTenant, async (req: any, res)
         lastReadAtTenant: null,
       });
       const created = await ref.get();
-      return res.json({ ok: true, conversation: normalizeConversation(created) });
+      const enriched = (await enrichConversationDisplay([normalizeConversation(created)]))[0];
+      return res.json({ ok: true, conversation: enriched });
     }
-    return res.json({ ok: true, conversation: normalizeConversation(snap) });
+    const enriched = (await enrichConversationDisplay([normalizeConversation(snap)]))[0];
+    return res.json({ ok: true, conversation: enriched });
   } catch (err: any) {
     console.error("[messages] tenant get/create conversation error", err);
     return res.status(500).json({ ok: false, error: "Failed to load conversation" });
@@ -468,7 +491,7 @@ router.get("/tenant/messages/conversation/:id", requireTenant, async (req: any, 
   try {
     const convoSnap = await db.collection("conversations").doc(id).get();
     if (!convoSnap.exists) return res.status(404).json({ ok: false, error: "Conversation not found" });
-    const convo = normalizeConversation(convoSnap);
+    const convo = (await enrichConversationDisplay([normalizeConversation(convoSnap)]))[0];
     if (convo.tenantId !== ctx.tenantId || convo.landlordId !== ctx.landlordId) {
       return res.status(403).json({ ok: false, error: "Forbidden" });
     }

--- a/rentchain-frontend/src/pages/MessagesPage.test.tsx
+++ b/rentchain-frontend/src/pages/MessagesPage.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import MessagesPage from "./MessagesPage";
 
 const mocks = vi.hoisted(() => ({
@@ -40,8 +40,18 @@ vi.mock("@/components/layout/ResponsiveMasterDetail", () => ({
 }));
 
 describe("MessagesPage", () => {
-  beforeEach(() => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllTimers();
     vi.useRealTimers();
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mocks.fetchLandlordConversationsMock.mockReset();
+    mocks.fetchLandlordConversationMessagesMock.mockReset();
+    mocks.markLandlordConversationReadMock.mockReset();
+    mocks.sendLandlordMessageMock.mockReset();
     mocks.useCapabilitiesMock.mockReturnValue({
       features: { messaging: true },
       loading: false,
@@ -67,6 +77,20 @@ describe("MessagesPage", () => {
     mocks.sendLandlordMessageMock.mockResolvedValue(undefined);
   });
 
+  async function flushTimers(ms: number) {
+    await act(async () => {
+      vi.advanceTimersByTime(ms);
+      await Promise.resolve();
+    });
+  }
+
+  async function flushAsync() {
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
   it("prefers tenant and property/unit labels over raw ids", async () => {
     render(
       <MemoryRouter>
@@ -74,15 +98,14 @@ describe("MessagesPage", () => {
       </MemoryRouter>
     );
 
-    await waitFor(() => {
-      expect(screen.getByText("Taylor Tenant")).toBeInTheDocument();
-      expect(screen.getByText("Harbour View / Unit 2A")).toBeInTheDocument();
-      expect(screen.getByText("TT")).toBeInTheDocument();
-    });
+    await flushAsync();
+    expect(screen.getByText("Taylor Tenant")).toBeInTheDocument();
+    expect(screen.getByText("Harbour View / Unit 2A")).toBeInTheDocument();
+    expect(screen.getByText("TT")).toBeInTheDocument();
     expect(screen.queryByText(/Tenant tenant-/i)).not.toBeInTheDocument();
   });
 
-  it("shows unread state from existing conversation data", async () => {
+  it("marks an unread selected conversation read without exposing raw ids", async () => {
     mocks.fetchLandlordConversationsMock.mockResolvedValue([
       {
         id: "conv-1",
@@ -99,9 +122,9 @@ describe("MessagesPage", () => {
       </MemoryRouter>
     );
 
-    await waitFor(() => {
-      expect(container.querySelector(".rc-messages-unread-dot")).not.toBeNull();
-    });
+    await flushAsync();
+    expect(container.querySelector(".rc-messages-list-item-title")?.textContent).toContain("Taylor Tenant");
+    expect(mocks.markLandlordConversationReadMock).toHaveBeenCalledTimes(1);
   });
 
   it("uses safe context fallbacks and deterministic initials for Taylor Tenant", async () => {
@@ -131,13 +154,87 @@ describe("MessagesPage", () => {
       </MemoryRouter>
     );
 
-    await waitFor(() => {
-      expect(screen.getAllByText("Taylor Tenant")[0]).toBeInTheDocument();
-      expect(screen.getByText("Tenant conversation")).toBeInTheDocument();
-    });
+    await flushAsync();
+    expect(screen.getAllByText("Taylor Tenant")[0]).toBeInTheDocument();
+    expect(screen.getByText("Tenant conversation")).toBeInTheDocument();
     expect(screen.getAllByText("TT")[0]).toBeInTheDocument();
     expect(screen.queryByText(/tenant-raw-1/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/prop-raw-1/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/unit-raw-1/i)).not.toBeInTheDocument();
+  });
+
+  it("preserves the selected conversation across background refresh without blanking the thread", async () => {
+    mocks.fetchLandlordConversationMessagesMock.mockResolvedValue({
+      conversation: {
+        id: "conv-1",
+        tenantDisplayName: "Taylor Tenant",
+        propertyDisplayLabel: "Harbour View",
+        unitDisplayLabel: "Unit 2A",
+      },
+      messages: [
+        {
+          id: "msg-1",
+          conversationId: "conv-1",
+          senderRole: "tenant",
+          body: "Hello there",
+          createdAtMs: 1,
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter>
+        <MessagesPage />
+      </MemoryRouter>
+    );
+
+    await flushAsync();
+    expect(screen.getByText("Hello there")).toBeInTheDocument();
+    expect(screen.getAllByText("Taylor Tenant • Harbour View / Unit 2A").length).toBeGreaterThan(0);
+
+    await flushTimers(15000);
+    await flushTimers(12000);
+
+    expect(screen.getByText("Hello there")).toBeInTheDocument();
+    expect(screen.queryByText("Loading messages…")).not.toBeInTheDocument();
+    expect(screen.getAllByText("Taylor Tenant • Harbour View / Unit 2A").length).toBeGreaterThan(0);
+  });
+
+  it("does not repeatedly fire read for a stable selected conversation after background refresh", async () => {
+    mocks.fetchLandlordConversationsMock.mockResolvedValue([
+      {
+        id: "conv-1",
+        tenantDisplayName: "Taylor Tenant",
+        propertyDisplayLabel: "Harbour View",
+        unitDisplayLabel: "Unit 2A",
+        hasUnread: true,
+        lastMessageAt: 123,
+      },
+    ]);
+    mocks.fetchLandlordConversationMessagesMock.mockResolvedValue({
+      conversation: {
+        id: "conv-1",
+        tenantDisplayName: "Taylor Tenant",
+        propertyDisplayLabel: "Harbour View",
+        unitDisplayLabel: "Unit 2A",
+        hasUnread: true,
+        lastMessageAt: 123,
+      },
+      messages: [],
+    });
+
+    render(
+      <MemoryRouter>
+        <MessagesPage />
+      </MemoryRouter>
+    );
+
+    await flushAsync();
+    expect(mocks.markLandlordConversationReadMock).toHaveBeenCalledTimes(1);
+
+    await flushTimers(15000);
+    await flushTimers(12000);
+
+    expect(mocks.markLandlordConversationReadMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/rentchain-frontend/src/pages/MessagesPage.tsx
+++ b/rentchain-frontend/src/pages/MessagesPage.tsx
@@ -19,6 +19,36 @@ const POLL_CONVERSATIONS_MS = 15000;
 const POLL_THREAD_MS = 12000;
 const MAX_CONVERSATIONS_BACKOFF_MS = 120000;
 
+function areConversationsEquivalent(current: Conversation[], next: Conversation[]) {
+  if (current === next) return true;
+  if (current.length !== next.length) return false;
+  return current.every((item, index) => {
+    const candidate = next[index];
+    return (
+      item.id === candidate?.id &&
+      item.tenantDisplayName === candidate?.tenantDisplayName &&
+      item.propertyDisplayLabel === candidate?.propertyDisplayLabel &&
+      item.unitDisplayLabel === candidate?.unitDisplayLabel &&
+      item.lastMessageAt === candidate?.lastMessageAt &&
+      item.hasUnread === candidate?.hasUnread
+    );
+  });
+}
+
+function areMessagesEquivalent(current: Message[], next: Message[]) {
+  if (current === next) return true;
+  if (current.length !== next.length) return false;
+  return current.every((item, index) => {
+    const candidate = next[index];
+    return (
+      item.id === candidate?.id &&
+      item.body === candidate?.body &&
+      item.senderRole === candidate?.senderRole &&
+      item.createdAtMs === candidate?.createdAtMs
+    );
+  });
+}
+
 function displayTenantName(conversation: Conversation | null) {
   const tenantName = String(conversation?.tenantDisplayName || "").trim();
   return tenantName || "Tenant";
@@ -72,6 +102,12 @@ export default function MessagesPage() {
   const conversationPollFailureRef = useRef(0);
   const hasLoadedConversationsRef = useRef(false);
   const hasLoadedThreadRef = useRef(false);
+  const selectedIdRef = useRef<string | null>(null);
+  const lastMarkedReadRef = useRef<Record<string, number>>({});
+
+  useEffect(() => {
+    selectedIdRef.current = selectedId;
+  }, [selectedId]);
 
   const loadConversations = useCallback(async (
     preferredId?: string | null,
@@ -83,46 +119,63 @@ export default function MessagesPage() {
         setLoadingList(true);
       }
       const data = await fetchLandlordConversations();
-      setConversations(data);
+      setConversations((prev) => (areConversationsEquivalent(prev, data) ? prev : data));
       hasLoadedConversationsRef.current = true;
-      if (preferredId) {
-        setSelectedId(preferredId);
-      } else if (!selectedId && data.length > 0) {
-        setSelectedId(data[0].id);
+
+      const currentSelectedId = selectedIdRef.current;
+      const preferredSelectedId =
+        preferredId && data.some((conversation) => conversation.id === preferredId)
+          ? preferredId
+          : null;
+      const existingSelectedId =
+        currentSelectedId && data.some((conversation) => conversation.id === currentSelectedId)
+          ? currentSelectedId
+          : null;
+      const nextSelectedId =
+        preferredSelectedId || existingSelectedId || data[0]?.id || null;
+
+      if (nextSelectedId !== currentSelectedId) {
+        selectedIdRef.current = nextSelectedId;
+        setSelectedId(nextSelectedId);
       }
+      setError(null);
       return true;
     } catch (err: any) {
       setError(err?.message || "Failed to load conversations");
       return false;
     } finally {
-      if (!background || !hasLoadedConversationsRef.current) {
-        setLoadingList(false);
-      } else {
+      if (!background) {
         setLoadingList(false);
       }
     }
-  }, [selectedId]);
+  }, []);
 
-  const loadThread = async (id: string, options?: { background?: boolean }) => {
+  const loadThread = useCallback(async (id: string, options?: { background?: boolean }) => {
     const background = options?.background === true;
     try {
       if (!background || !hasLoadedThreadRef.current) {
         setLoadingThread(true);
       }
       const res = await fetchLandlordConversationMessages(id);
-      setMessages(res.messages || []);
+      const nextMessages = Array.isArray(res.messages) ? res.messages : [];
+      setMessages((prev) => (areMessagesEquivalent(prev, nextMessages) ? prev : nextMessages));
+      if (res.conversation) {
+        setConversations((prev) =>
+          prev.map((conversation) =>
+            conversation.id === res.conversation?.id ? { ...conversation, ...res.conversation } : conversation
+          )
+        );
+      }
       hasLoadedThreadRef.current = true;
-      await markLandlordConversationRead(id);
+      setError(null);
     } catch (err: any) {
       setError(err?.message || "Failed to load messages");
     } finally {
-      if (!background || !hasLoadedThreadRef.current) {
-        setLoadingThread(false);
-      } else {
+      if (!background) {
         setLoadingThread(false);
       }
     }
-  };
+  }, []);
 
   useEffect(() => {
     const params = new URLSearchParams(location.search);
@@ -130,9 +183,6 @@ export default function MessagesPage() {
     void (async () => {
       if (!messagingEnabled) return;
       await loadConversations(deepLinkId);
-      if (deepLinkId) {
-        await loadThread(deepLinkId);
-      }
     })();
   }, [location.search, messagingEnabled, loadConversations]);
 
@@ -157,7 +207,7 @@ export default function MessagesPage() {
     const tick = async () => {
       if (cancelled) return;
       try {
-        const ok = await loadConversations(selectedId, { background: true });
+        const ok = await loadConversations(selectedIdRef.current, { background: true });
         conversationPollFailureRef.current = ok
           ? 0
           : Math.min(conversationPollFailureRef.current + 1, 6);
@@ -168,7 +218,7 @@ export default function MessagesPage() {
       }
     };
 
-    void tick();
+    scheduleNext();
     return () => {
       cancelled = true;
       if (conversationPollTimeoutRef.current) {
@@ -176,7 +226,7 @@ export default function MessagesPage() {
         conversationPollTimeoutRef.current = null;
       }
     };
-  }, [messagingEnabled, loadConversations, selectedId]);
+  }, [messagingEnabled, loadConversations]);
 
   useEffect(() => {
     if (!selectedId) return;
@@ -185,7 +235,51 @@ export default function MessagesPage() {
     void loadThread(selectedId);
     const t = window.setInterval(() => void loadThread(selectedId, { background: true }), POLL_THREAD_MS);
     return () => window.clearInterval(t);
-  }, [selectedId, messagingEnabled]);
+  }, [selectedId, messagingEnabled, loadThread]);
+
+  const selectedConversation = useMemo(
+    () => conversations.find((c) => c.id === selectedId) || null,
+    [conversations, selectedId]
+  );
+
+  useEffect(() => {
+    if (!messagingEnabled || !selectedConversation?.id || selectedConversation.hasUnread !== true) return;
+    const marker = Number(selectedConversation.lastMessageAt || 0);
+    if (lastMarkedReadRef.current[selectedConversation.id] === marker) return;
+
+    let cancelled = false;
+    void (async () => {
+      lastMarkedReadRef.current[selectedConversation.id] = marker;
+      try {
+        await markLandlordConversationRead(selectedConversation.id);
+        if (cancelled) return;
+        setConversations((prev) =>
+          prev.map((conversation) =>
+            conversation.id === selectedConversation.id
+              ? {
+                  ...conversation,
+                  hasUnread: false,
+                }
+              : conversation
+          )
+        );
+      } catch (err: any) {
+        delete lastMarkedReadRef.current[selectedConversation.id];
+        if (!cancelled) {
+          setError(err?.message || "Failed to mark conversation read");
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    messagingEnabled,
+    selectedConversation?.id,
+    selectedConversation?.hasUnread,
+    selectedConversation?.lastMessageAt,
+  ]);
 
 
   const handleSend = async () => {
@@ -194,13 +288,8 @@ export default function MessagesPage() {
     setComposer("");
     await sendLandlordMessage(selectedId, body);
     await loadThread(selectedId);
-    await loadConversations();
+    await loadConversations(selectedId, { background: true });
   };
-
-  const selectedConversation = useMemo(
-    () => conversations.find((c) => c.id === selectedId) || null,
-    [conversations, selectedId]
-  );
   const selectedConversationTitle = buildConversationTitle(selectedConversation);
 
   return (


### PR DESCRIPTION
This PR repairs landlord messages stability and identity display.

Includes:
- deterministic conversation identity enrichment
- tenant/property/unit labels on conversation list and detail responses
- selected conversation preserved across background refresh
- background polling no longer blanks visible UI
- read acknowledgement guarded to prevent read/refetch loops
- message labels avoid raw tenant/property/unit IDs
- focused backend/frontend test coverage

Guardrails preserved:
- no websocket/realtime rewrite
- no new notification system
- no permission changes
- no message content changes
- no broad messages redesign
- existing send/read behavior preserved

PR note:
- Messages route tests passed: 6 tests.
- Backend typecheck passed.
- MessagesPage tests passed: 5 tests.
- Frontend build passed.
- Existing chunk-size warning remains unchanged and out of scope.
- Tenant reporting/payments consistency, renewal eligibility unification, print/PDF cleanup, and tenant activity ↔ lease ledger write-path unification remain deferred.