### PR TITLE
fix: align tenant reporting payment sources

### DIFF
--- a/rentchain-api/src/services/__tests__/tenantReportService.test.ts
+++ b/rentchain-api/src/services/__tests__/tenantReportService.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const collections = new Map<string, Map<string, any>>();
+const getTenantDetailBundleMock = vi.fn();
+const getTenantLedgerMock = vi.fn();
+
+function ensureCollection(name: string) {
+  if (!collections.has(name)) collections.set(name, new Map());
+  return collections.get(name)!;
+}
+
+vi.mock("../../config/firebase", () => ({
+  db: {
+    collection: (name: string) => ({
+      where: (field: string, _op: string, value: any) => {
+        const applyFilter = (rows: Array<[string, any]>) =>
+          rows.filter(([, data]) => data?.[field] === value);
+        return {
+          where: (field2: string, _op2: string, value2: any) => ({
+            get: async () => {
+              const docs = applyFilter(Array.from(ensureCollection(name).entries()))
+                .filter(([, data]) => data?.[field2] === value2)
+                .map(([id, data]) => ({
+                  id,
+                  data: () => data,
+                }));
+              return { docs };
+            },
+          }),
+          orderBy: (_orderField: string, _direction?: string) => ({
+            limit: (_count: number) => ({
+              get: async () => {
+                const docs = applyFilter(Array.from(ensureCollection(name).entries()))
+                  .sort((a, b) => String(b[1]?.paidAt || "").localeCompare(String(a[1]?.paidAt || "")))
+                  .map(([id, data]) => ({
+                    id,
+                    data: () => data,
+                  }));
+                return { docs };
+              },
+            }),
+          }),
+          get: async () => {
+            const docs = applyFilter(Array.from(ensureCollection(name).entries())).map(([id, data]) => ({
+              id,
+              data: () => data,
+            }));
+            return { docs };
+          },
+        };
+      },
+    }),
+  },
+}));
+
+vi.mock("../tenantDetailsService", () => ({
+  getTenantDetailBundle: getTenantDetailBundleMock,
+}));
+
+vi.mock("../tenantLedgerService", () => ({
+  getTenantLedger: getTenantLedgerMock,
+}));
+
+describe("tenantReportService", () => {
+  beforeEach(() => {
+    collections.clear();
+    vi.clearAllMocks();
+    getTenantLedgerMock.mockResolvedValue([]);
+  });
+
+  it("uses persisted payments for metrics and current lease ledger for the ledger section", async () => {
+    getTenantDetailBundleMock.mockResolvedValue({
+      tenant: {
+        id: "tenant-1",
+        fullName: "Taylor Tenant",
+        landlordId: "landlord-1",
+        propertyName: "Harbour View",
+        unit: "101",
+        currentLeaseId: "lease-1",
+      },
+      currentLease: {
+        id: "lease-1",
+        propertyName: "Harbour View",
+        unit: "101",
+      },
+    });
+
+    ensureCollection("payments").set("payment-1", {
+      tenantId: "tenant-1",
+      amount: 1850,
+      paidAt: "2026-04-03",
+      dueDate: "2026-04-01",
+      method: "e-transfer",
+      status: "Recorded",
+    });
+    ensureCollection("ledgerEntries").set("entry-1", {
+      landlordId: "landlord-1",
+      leaseId: "lease-1",
+      entryType: "charge",
+      category: "rent",
+      amountCents: 185000,
+      effectiveDate: "2026-04-01",
+      createdAt: 1,
+    });
+    ensureCollection("ledgerEntries").set("entry-2", {
+      landlordId: "landlord-1",
+      leaseId: "lease-1",
+      entryType: "payment",
+      category: "payment",
+      amountCents: 185000,
+      effectiveDate: "2026-04-03",
+      method: "etransfer",
+      createdAt: 2,
+    });
+
+    const { buildTenantReportData } = await import("../tenantReportService");
+    const result = await buildTenantReportData("tenant-1");
+
+    expect(result.behavior.totalPayments).toBe(1);
+    expect(result.behavior.lastPaymentDate).toBe("2026-04-03");
+    expect(result.ledgerEntries).toEqual([
+      expect.objectContaining({
+        type: "payment",
+        amount: 1850,
+        runningBalance: 0,
+      }),
+      expect.objectContaining({
+        type: "charge",
+        amount: 1850,
+        runningBalance: 1850,
+      }),
+    ]);
+    expect(result.ledgerSummary).toEqual({
+      currentBalance: 0,
+      totalCharges: 1850,
+      totalPayments: 1850,
+      netLifetime: 3700,
+    });
+    expect(getTenantLedgerMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the tenant ledger service only when no current lease exists", async () => {
+    getTenantDetailBundleMock.mockResolvedValue({
+      tenant: {
+        id: "tenant-1",
+        fullName: "Taylor Tenant",
+        landlordId: "landlord-1",
+      },
+      currentLease: null,
+    });
+    ensureCollection("payments").set("payment-1", {
+      tenantId: "tenant-1",
+      amount: 1850,
+      paidAt: "2026-04-03",
+      dueDate: "2026-04-01",
+      status: "Recorded",
+    });
+    getTenantLedgerMock.mockResolvedValue([
+      {
+        id: "legacy-1",
+        tenantId: "tenant-1",
+        date: "2026-04-01",
+        type: "payment",
+        amount: 1850,
+        runningBalance: -1850,
+      },
+    ]);
+
+    const { buildTenantReportData } = await import("../tenantReportService");
+    const result = await buildTenantReportData("tenant-1");
+
+    expect(getTenantLedgerMock).toHaveBeenCalledWith("tenant-1");
+    expect(result.ledgerEntries).toEqual([
+      expect.objectContaining({
+        id: "legacy-1",
+        amount: 1850,
+      }),
+    ]);
+    expect(result.behavior.totalPayments).toBe(1);
+  });
+});

--- a/rentchain-api/src/services/tenantReportService.ts
+++ b/rentchain-api/src/services/tenantReportService.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
+import { db } from "../config/firebase";
 import { getTenantLedger } from "./tenantLedgerService";
-import { getPaymentsForTenant } from "./paymentsService";
 import { getTenantDetailBundle } from "./tenantDetailsService";
 
 export type TenantPaymentBehaviorSummary = {
@@ -53,12 +53,124 @@ const parseDate = (value: any): Date | null => {
   return Number.isNaN(d.getTime()) ? null : d;
 };
 
+const toMillis = (value: any): number => {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value?.toMillis === "function") {
+    try {
+      return Number(value.toMillis()) || 0;
+    } catch {
+      return 0;
+    }
+  }
+  if (typeof value?.seconds === "number") return Number(value.seconds) * 1000;
+  const parsed = Date.parse(String(value || ""));
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+async function loadPersistedPaymentsForTenant(tenantId: string) {
+  const snap = await db
+    .collection("payments")
+    .where("tenantId", "==", tenantId)
+    .orderBy("paidAt", "desc")
+    .limit(200)
+    .get();
+
+  return snap.docs.map((doc: any) => {
+    const raw = doc.data() as any;
+    return {
+      id: doc.id,
+      tenantId: String(raw?.tenantId || "").trim() || tenantId,
+      propertyId: String(raw?.propertyId || "").trim() || null,
+      amount: Number(raw?.amount ?? 0),
+      paidAt: String(raw?.paidAt || "").trim(),
+      dueDate: raw?.dueDate ?? null,
+      method: raw?.method ?? null,
+      notes: raw?.notes ?? null,
+      status: String(raw?.status || "").trim() || "Recorded",
+    };
+  });
+}
+
+function buildLedgerEntryLabel(entry: any) {
+  const category = String(entry?.category || "").trim();
+  const reference = String(entry?.reference || "").trim();
+  const notes = String(entry?.notes || "").trim();
+
+  if (entry?.entryType === "payment") {
+    if (reference) return `Payment${entry?.method ? ` (${entry.method})` : ""} · ${reference}`;
+    if (entry?.method) return `Payment (${entry.method})`;
+    return "Payment";
+  }
+
+  if (category === "rent") return "Charge · rent";
+  if (category === "fee") return "Charge · fee";
+  if (category === "adjustment") return "Charge · adjustment";
+  if (notes) return notes;
+  return "Charge";
+}
+
+async function loadCurrentLeaseLedgerEntries(leaseId: string, landlordId?: string | null) {
+  const snap = await db
+    .collection("ledgerEntries")
+    .where("leaseId", "==", leaseId)
+    .get();
+
+  const rawEntries = snap.docs
+    .map((doc: any) => ({ id: doc.id, ...(doc.data() as any) }))
+    .filter((entry: any) => {
+      if (!landlordId) return true;
+      return String(entry?.landlordId || "").trim() === String(landlordId).trim();
+    })
+    .sort((a: any, b: any) => {
+      const dateDiff = String(a?.effectiveDate || "").localeCompare(String(b?.effectiveDate || ""));
+      if (dateDiff !== 0) return dateDiff;
+      return toMillis(a?.createdAt) - toMillis(b?.createdAt);
+    });
+
+  let runningBalanceCents = 0;
+  const mappedAsc = rawEntries.map((entry: any) => {
+    const amountCents = Math.abs(Number(entry?.amountCents || 0));
+    const signedAmountCents =
+      String(entry?.entryType || "").trim().toLowerCase() === "payment"
+        ? -amountCents
+        : amountCents;
+    runningBalanceCents += signedAmountCents;
+    return {
+      id: entry.id,
+      tenantId: null,
+      date: String(entry?.effectiveDate || "").trim() || null,
+      type: String(entry?.entryType || "").trim().toLowerCase() || "entry",
+      amount: amountCents / 100,
+      direction:
+        String(entry?.entryType || "").trim().toLowerCase() === "payment"
+          ? "credit"
+          : "debit",
+      method: entry?.method ?? null,
+      label: buildLedgerEntryLabel(entry),
+      notes: entry?.notes ?? null,
+      referenceId: entry?.reference ?? null,
+      runningBalance: runningBalanceCents / 100,
+    };
+  });
+
+  return mappedAsc.reverse();
+}
+
 export async function buildTenantReportData(
   tenantId: string
 ): Promise<TenantReportData> {
   const bundle = await getTenantDetailBundle(tenantId);
-  const payments = await getPaymentsForTenant(tenantId);
-  const ledgerEntries = await getTenantLedger(tenantId);
+  const currentLeaseId = String(
+    bundle?.currentLease?.id ||
+      bundle?.lease?.id ||
+      bundle?.tenant?.currentLeaseId ||
+      ""
+  ).trim();
+  const landlordId = String(bundle?.tenant?.landlordId || "").trim() || null;
+  const payments = await loadPersistedPaymentsForTenant(tenantId);
+  const ledgerEntries = currentLeaseId
+    ? await loadCurrentLeaseLedgerEntries(currentLeaseId, landlordId)
+    : await getTenantLedger(tenantId);
 
   const behavior: TenantPaymentBehaviorSummary = {
     onTimeRate: null,
@@ -166,8 +278,16 @@ export async function buildTenantReportData(
       bundle?.tenant?.fullName ||
       bundle?.tenant?.name ||
       "Unknown tenant",
-    propertyName: bundle?.tenant?.propertyName ?? null,
-    unitLabel: (bundle?.tenant as any)?.unit ?? null,
+    propertyName:
+      bundle?.currentLease?.propertyName ??
+      bundle?.lease?.propertyName ??
+      bundle?.tenant?.propertyName ??
+      null,
+    unitLabel:
+      bundle?.currentLease?.unit ??
+      bundle?.lease?.unit ??
+      (bundle?.tenant as any)?.unit ??
+      null,
     createdAt: (bundle?.tenant as any)?.createdAt ?? null,
     behavior,
     ledgerSummary,

--- a/rentchain-frontend/src/components/tenants/TenantPaymentsPanel.test.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantPaymentsPanel.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TenantPaymentsPanel } from "./TenantPaymentsPanel";
+
+const mocks = vi.hoisted(() => ({
+  fetchPayments: vi.fn(),
+  getTenantMonthlyPayments: vi.fn(),
+  updatePayment: vi.fn(),
+}));
+
+vi.mock("@/api/paymentsApi", () => ({
+  fetchPayments: mocks.fetchPayments,
+  getTenantMonthlyPayments: mocks.getTenantMonthlyPayments,
+  updatePayment: mocks.updatePayment,
+}));
+
+describe("TenantPaymentsPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.fetchPayments.mockResolvedValue([
+      {
+        id: "payment-1",
+        tenantId: "tenant-1",
+        amount: 1850,
+        paidAt: "2026-04-03",
+        status: "Recorded",
+      },
+    ]);
+    mocks.getTenantMonthlyPayments.mockResolvedValue({
+      payments: [
+        {
+          id: "payment-1",
+          tenantId: "tenant-1",
+          amount: 1850,
+          paidAt: "2026-04-03",
+          status: "Recorded",
+        },
+      ],
+      total: 1850,
+    });
+  });
+
+  it("keeps reading the payments api and renders the approved clarity copy", async () => {
+    render(<TenantPaymentsPanel tenantId="tenant-1" />);
+
+    expect(
+      screen.getByText(
+        "Only recorded rent payments appear here. Charges and credits are shown in the lease ledger."
+      )
+    ).toBeInTheDocument();
+
+    await waitFor(() => expect(mocks.fetchPayments).toHaveBeenCalledWith("tenant-1"));
+    expect(mocks.getTenantMonthlyPayments).toHaveBeenCalled();
+    expect(await screen.findByText("Recorded")).toBeInTheDocument();
+    expect(
+      screen.getByText((content) => content.includes("Total:") && content.includes("1,850.00"))
+    ).toBeInTheDocument();
+  });
+
+  it("shows the existing empty state when the payments api returns no payments", async () => {
+    mocks.fetchPayments.mockResolvedValue([]);
+    mocks.getTenantMonthlyPayments.mockResolvedValue({ payments: [], total: 0 });
+
+    render(<TenantPaymentsPanel tenantId="tenant-1" />);
+
+    expect(await screen.findByText("No payments yet.")).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/tenants/TenantPaymentsPanel.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantPaymentsPanel.tsx
@@ -150,6 +150,9 @@ export function TenantPaymentsPanel({ tenantId }: Props) {
           <div style={{ fontSize: 12, opacity: 0.8 }}>
             Last payment: {lastPayment ? formatDate((lastPayment as any).paidAt) : "--"}
           </div>
+          <div style={{ fontSize: 12, opacity: 0.78, marginTop: 4 }}>
+            Only recorded rent payments appear here. Charges and credits are shown in the lease ledger.
+          </div>
         </div>
 
         <div className="rc-tenant-payments-controls">


### PR DESCRIPTION
This PR repairs tenant reporting/payment source consistency.

Includes:
- Tenant Summary reports use Firestore payments for payment behavior metrics
- Tenant Summary reports use current lease ledgerEntries for the lease ledger section
- legacy tenant ledger fallback only when no current lease exists
- Tenant Payments panel remains aligned to /api/payments only
- clearer payments-panel copy explaining payments vs lease ledger
- focused backend/frontend test coverage

Guardrails preserved:
- no /api/payments source or response shape change
- no client-side source merging
- no lease ledger to payments conversion
- no tenant activity to ledger/payments unification
- no data mutation
- no schema changes
- no payment/provider/Stripe changes

PR note:
- Tenant report/payment/tenant route tests passed: 9 tests.
- Backend typecheck passed.
- TenantPaymentsPanel and TenantDetailPanel tests passed: 4 tests.
- Frontend build passed.
- Existing chunk-size warning remains unchanged and out of scope.
- Ledger–Payments Unification v2 remains deferred if future product direction requires payment reporting to reflect lease-ledger payment entries.