### PR TITLE
fix: align renewal notice counts

### DIFF
--- a/rentchain-api/src/routes/__tests__/dashboardRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/dashboardRoutes.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const computePortfolioCredibilitySummaryMock = vi.fn();
 const resolveLandlordAndTierMock = vi.fn();
+const deriveLandlordVisibleExpiringLeasesMock = vi.fn();
 
 const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
   const store = new Map<string, Map<string, any>>();
@@ -68,6 +69,7 @@ vi.mock("../../lib/landlordResolver", () => ({
 
 vi.mock("../../services/leaseNoticeWorkflowService", () => ({
   computeNoResponseState: vi.fn(() => false),
+  deriveLandlordVisibleExpiringLeases: deriveLandlordVisibleExpiringLeasesMock,
   normalizeLeaseRecord: vi.fn((id: string, raw: any) => ({ id, ...raw })),
 }));
 
@@ -80,7 +82,9 @@ describe("dashboardRoutes GET /summary", () => {
     resetFakeDb();
     computePortfolioCredibilitySummaryMock.mockReset();
     resolveLandlordAndTierMock.mockReset();
+    deriveLandlordVisibleExpiringLeasesMock.mockReset();
     resolveLandlordAndTierMock.mockResolvedValue({ tier: "pro" });
+    deriveLandlordVisibleExpiringLeasesMock.mockResolvedValue([]);
     computePortfolioCredibilitySummaryMock.mockImplementation(({ leases }: any) => ({
       propertyCount: 1,
       activeLeaseCount: Array.isArray(leases) ? leases.length : 0,
@@ -216,6 +220,43 @@ describe("dashboardRoutes GET /summary", () => {
           href: "/applications?openTransUnionAccess=1",
         }),
       ])
+    );
+  });
+
+  it("derives expiring, pending, and no-response counts from the shared renewal dataset", async () => {
+    seedDoc("properties", "prop-active", {
+      landlordId: "landlord-1",
+      portfolioStatus: "active",
+      units: [{ id: "unit-1" }],
+    });
+    seedDoc("leases", "lease-visible", {
+      landlordId: "landlord-1",
+      propertyId: "prop-active",
+      tenantId: "tenant-active",
+      status: "active",
+    });
+    deriveLandlordVisibleExpiringLeasesMock.mockResolvedValue([
+      { id: "lease-expiring", noticeBucket: "expiring" },
+      { id: "lease-pending", noticeBucket: "pending-response" },
+      { id: "lease-no-response", noticeBucket: "no-response" },
+    ]);
+
+    const app = await makeApp();
+    const response = await invokeSummary(app);
+
+    expect(response.status).toBe(200);
+    expect(response.body?.data?.leaseNoticeSummary).toEqual(
+      expect.objectContaining({
+        expiringSoon: 1,
+        pendingResponse: 1,
+        noResponse: 1,
+      })
+    );
+    expect(deriveLandlordVisibleExpiringLeasesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        landlordId: "landlord-1",
+        withinDays: 120,
+      })
     );
   });
 });

--- a/rentchain-api/src/routes/__tests__/leaseNoticeLandlordRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseNoticeLandlordRoutes.test.ts
@@ -84,6 +84,7 @@ vi.mock("../../config/leaseNoticeRules", () => ({
 const appendLeaseWorkflowEvent = vi.fn(async () => undefined);
 const buildPreview = vi.fn(async () => undefined);
 const computeNoResponseStateMock = vi.fn(() => false);
+const deriveLandlordVisibleExpiringLeasesMock = vi.fn(async () => []);
 const deriveLeaseRenewalOperatorInputRecord = vi.fn((lease: any) => ({
   rentChangeMode: lease?.renewalRentChangeMode ?? null,
   proposedRent: lease?.renewalOfferedRent ?? null,
@@ -129,6 +130,7 @@ vi.mock("../../services/leaseNoticeWorkflowService", () => ({
   appendLeaseWorkflowEvent,
   buildPreview,
   computeNoResponseState: computeNoResponseStateMock,
+  deriveLandlordVisibleExpiringLeases: deriveLandlordVisibleExpiringLeasesMock,
   deriveLeaseRenewalOperatorInputRecord,
   getLeaseForLandlordWorkflow,
   getLeaseNoticeByLeaseId: vi.fn(),
@@ -181,6 +183,7 @@ describe("leaseNoticeLandlordRoutes policy integration", () => {
     collections.clear();
     vi.clearAllMocks();
     computeNoResponseStateMock.mockReturnValue(false);
+    deriveLandlordVisibleExpiringLeasesMock.mockResolvedValue([]);
     normalizeLeaseRecord.mockImplementation((id: string, raw: any) => ({ id, ...(raw || {}) }));
     sanitizeLeaseRenewalOperatorInput.mockImplementation((body: any) => ({
       ok: true,
@@ -341,34 +344,22 @@ describe("leaseNoticeLandlordRoutes policy integration", () => {
   });
 
   it("returns only expiring workflow items when the expiring status filter is requested", async () => {
-    if (!collections.has("leases")) collections.set("leases", new Map());
-    if (!collections.has("leaseNotices")) collections.set("leaseNotices", new Map());
-    if (!collections.has("properties")) collections.set("properties", new Map());
-    collections.get("properties")?.set("property-1", {
-      landlordId: "landlord-1",
-      addressLine1: "123 Harbour St",
-    });
-    collections.get("leases")?.set("lease-expiring", {
-      landlordId: "landlord-1",
-      propertyId: "property-1",
-      unitId: "unit-1",
-      status: "active",
-      nextNoticeDueAt: Date.now() + 5 * 24 * 60 * 60 * 1000,
-    });
-    collections.get("leases")?.set("lease-pending", {
-      landlordId: "landlord-1",
-      propertyId: "property-1",
-      unitId: "unit-2",
-      status: "renewal_pending",
-      nextNoticeDueAt: Date.now() + 5 * 24 * 60 * 60 * 1000,
-    });
-    collections.get("leaseNotices")?.set("notice-pending", {
-      landlordId: "landlord-1",
-      leaseId: "lease-pending",
-      tenantResponse: "pending",
-      createdAt: Date.now(),
-      updatedAt: Date.now(),
-    });
+    deriveLandlordVisibleExpiringLeasesMock.mockResolvedValue([
+      {
+        id: "lease-expiring",
+        propertyAddress: "123 Harbour St",
+        noticeBucket: "expiring",
+        nextNoticeDueAt: Date.now() + 5 * 24 * 60 * 60 * 1000,
+        latestNotice: null,
+      },
+      {
+        id: "lease-pending",
+        propertyAddress: "123 Harbour St",
+        noticeBucket: "pending-response",
+        nextNoticeDueAt: Date.now() + 5 * 24 * 60 * 60 * 1000,
+        latestNotice: { tenantResponse: "pending" },
+      },
+    ]);
 
     const router = (await import("../leaseNoticeLandlordRoutes")).default;
     const res = await invokeRouter(router, {
@@ -392,29 +383,20 @@ describe("leaseNoticeLandlordRoutes policy integration", () => {
   });
 
   it("returns only pending-response workflow items when that status filter is requested", async () => {
-    if (!collections.has("leases")) collections.set("leases", new Map());
-    if (!collections.has("leaseNotices")) collections.set("leaseNotices", new Map());
-    collections.get("leases")?.set("lease-expiring", {
-      landlordId: "landlord-1",
-      propertyId: "property-1",
-      unitId: "unit-1",
-      status: "active",
-      nextNoticeDueAt: Date.now() + 5 * 24 * 60 * 60 * 1000,
-    });
-    collections.get("leases")?.set("lease-pending", {
-      landlordId: "landlord-1",
-      propertyId: "property-1",
-      unitId: "unit-2",
-      status: "renewal_pending",
-      nextNoticeDueAt: Date.now() + 5 * 24 * 60 * 60 * 1000,
-    });
-    collections.get("leaseNotices")?.set("notice-pending", {
-      landlordId: "landlord-1",
-      leaseId: "lease-pending",
-      tenantResponse: "pending",
-      createdAt: Date.now(),
-      updatedAt: Date.now(),
-    });
+    deriveLandlordVisibleExpiringLeasesMock.mockResolvedValue([
+      {
+        id: "lease-expiring",
+        noticeBucket: "expiring",
+        nextNoticeDueAt: Date.now() + 5 * 24 * 60 * 60 * 1000,
+        latestNotice: null,
+      },
+      {
+        id: "lease-pending",
+        noticeBucket: "pending-response",
+        nextNoticeDueAt: Date.now() + 5 * 24 * 60 * 60 * 1000,
+        latestNotice: { tenantResponse: "pending" },
+      },
+    ]);
 
     const router = (await import("../leaseNoticeLandlordRoutes")).default;
     const res = await invokeRouter(router, {
@@ -436,23 +418,15 @@ describe("leaseNoticeLandlordRoutes policy integration", () => {
   });
 
   it("returns only no-response workflow items when that status filter is requested", async () => {
-    computeNoResponseStateMock.mockImplementation((notice: any) => String(notice?.leaseId || "").trim() === "lease-no-response");
-    if (!collections.has("leases")) collections.set("leases", new Map());
-    if (!collections.has("leaseNotices")) collections.set("leaseNotices", new Map());
-    collections.get("leases")?.set("lease-no-response", {
-      landlordId: "landlord-1",
-      propertyId: "property-1",
-      unitId: "unit-3",
-      status: "renewal_pending",
-      nextNoticeDueAt: Date.now() + 5 * 24 * 60 * 60 * 1000,
-    });
-    collections.get("leaseNotices")?.set("notice-no-response", {
-      landlordId: "landlord-1",
-      leaseId: "lease-no-response",
-      tenantResponse: "pending",
-      createdAt: Date.now(),
-      updatedAt: Date.now(),
-    });
+    computeNoResponseStateMock.mockReturnValue(true);
+    deriveLandlordVisibleExpiringLeasesMock.mockResolvedValue([
+      {
+        id: "lease-no-response",
+        noticeBucket: "no-response",
+        nextNoticeDueAt: Date.now() + 5 * 24 * 60 * 60 * 1000,
+        latestNotice: { tenantResponse: "pending" },
+      },
+    ]);
 
     const router = (await import("../leaseNoticeLandlordRoutes")).default;
     const res = await invokeRouter(router, {

--- a/rentchain-api/src/routes/dashboardRoutes.ts
+++ b/rentchain-api/src/routes/dashboardRoutes.ts
@@ -3,7 +3,11 @@ import { authenticateJwt } from "../middleware/authMiddleware";
 import { requireAuth } from "../middleware/requireAuth";
 import { db } from "../config/firebase";
 import { resolveLandlordAndTier } from "../lib/landlordResolver";
-import { computeNoResponseState, normalizeLeaseRecord } from "../services/leaseNoticeWorkflowService";
+import {
+  computeNoResponseState,
+  deriveLandlordVisibleExpiringLeases,
+  normalizeLeaseRecord,
+} from "../services/leaseNoticeWorkflowService";
 import { computePortfolioCredibilitySummary } from "../services/risk/portfolioCredibilitySummary";
 import {
   isTargetedHiddenLeaseId,
@@ -279,7 +283,14 @@ router.get("/summary", requireAuth, async (req: any, res) => {
     if (!leaseId || latestNoticeByLeaseId.has(leaseId)) continue;
     latestNoticeByLeaseId.set(leaseId, notice);
   }
-  const soonWindowMs = 120 * 24 * 60 * 60 * 1000;
+  const sharedRenewalItems = await deriveLandlordVisibleExpiringLeases({
+    landlordId,
+    withinDays: 120,
+    now,
+    leaseDocs: leasesSnap.docs as any,
+    noticeDocs: leaseNoticesSnap.docs as any,
+    propertyRecords: properties,
+  });
   const portfolioCredibilitySummary = computePortfolioCredibilitySummary({
     leases: visibleLeases.map((lease) => ({
       id: lease.id,
@@ -304,28 +315,18 @@ router.get("/summary", requireAuth, async (req: any, res) => {
   });
 
   const leaseNoticeSummary = {
-    expiringSoon: visibleLeases.filter((lease) => {
-      const dueAt = Number(lease.nextNoticeDueAt || 0);
-      return dueAt > 0 && dueAt <= now + soonWindowMs;
-    }).length,
-    pendingResponse: 0,
+    expiringSoon: sharedRenewalItems.filter((lease) => lease.noticeBucket === "expiring").length,
+    pendingResponse: sharedRenewalItems.filter((lease) => lease.noticeBucket === "pending-response").length,
     renewed: 0,
     quitting: 0,
-    noResponse: 0,
+    noResponse: sharedRenewalItems.filter((lease) => lease.noticeBucket === "no-response").length,
   };
   latestNoticeByLeaseId.forEach((notice, leaseId) => {
     const response = String(notice?.tenantResponse || "pending").trim().toLowerCase();
     const lease = visibleLeases.find((row) => row.id === leaseId) || null;
     if (!lease) return;
     const noResponse = computeNoResponseState(notice);
-    if (noResponse) {
-      leaseNoticeSummary.noResponse += 1;
-      return;
-    }
-    if (response === "pending") {
-      leaseNoticeSummary.pendingResponse += 1;
-      return;
-    }
+    if (noResponse || response === "pending") return;
     if (response === "renew" || String(lease?.status || "") === "renewal_accepted") {
       leaseNoticeSummary.renewed += 1;
       return;

--- a/rentchain-api/src/routes/leaseNoticeLandlordRoutes.ts
+++ b/rentchain-api/src/routes/leaseNoticeLandlordRoutes.ts
@@ -11,6 +11,7 @@ import {
   buildLeaseNoticePreviewInputFromLease,
   buildPreview,
   computeNoResponseState,
+  deriveLandlordVisibleExpiringLeases,
   deriveLeaseRenewalOperatorInputRecord,
   getLeaseForLandlordWorkflow,
   getLeaseNoticeByLeaseId,
@@ -55,22 +56,6 @@ function asLeaseRenewalWorkflowBucket(value: unknown): LeaseRenewalWorkflowBucke
   return null;
 }
 
-function deriveLeaseRenewalWorkflowBucket(params: {
-  lease: any;
-  latestNotice: any | null;
-  now: number;
-  horizon: number;
-}): LeaseRenewalWorkflowBucket | null {
-  const { lease, latestNotice, now, horizon } = params;
-  const noResponse = latestNotice ? computeNoResponseState(latestNotice) : false;
-  if (noResponse) return "no-response";
-  const response = String(latestNotice?.tenantResponse || "pending").trim().toLowerCase();
-  if (latestNotice && response === "pending") return "pending-response";
-  const dueAt = Number(lease?.nextNoticeDueAt || 0);
-  if (dueAt > 0 && dueAt >= now && dueAt <= horizon) return "expiring";
-  return null;
-}
-
 async function performLeaseNoticeSend(params: {
   leaseId: string;
   landlordId: string;
@@ -106,84 +91,29 @@ router.get("/expiring", async (req: any, res) => {
     const propertyId = String(req.query?.propertyId || "").trim();
     const statusFilter = asLeaseRenewalWorkflowBucket(req.query?.status);
     const now = Date.now();
-    const horizon = now + withinDays * 24 * 60 * 60 * 1000;
     const [leaseSnap, noticeSnap] = await Promise.all([
       db.collection("leases").where("landlordId", "==", landlordId).limit(400).get(),
       db.collection("leaseNotices").where("landlordId", "==", landlordId).limit(400).get(),
     ]);
-    const propertyIds = Array.from(
-      new Set(
-        leaseSnap.docs
-          .map((doc) => String((doc.data() as any)?.propertyId || "").trim())
-          .filter(Boolean)
-      )
-    );
-    const propertyEntries = await Promise.all(
-      propertyIds.map(async (id) => {
-        try {
-          const snap = await db.collection("properties").doc(id).get();
-          if (!snap.exists) return [id, null] as const;
-          const raw = snap.data() as any;
-          const address =
-            String(raw?.addressLine1 || raw?.address || "").trim() ||
-            null;
-          return [id, address] as const;
-        } catch {
-          return [id, null] as const;
-        }
-      })
-    );
-    const propertyAddressById = new Map<string, string | null>(propertyEntries);
-    const latestNoticeByLeaseId = new Map<string, any>();
-    const leaseNotices = noticeSnap.docs
-      .map((doc) => ({ id: doc.id, ...(doc.data() as any) }))
-      .sort((a, b) => Number(b.updatedAt || b.createdAt || 0) - Number(a.updatedAt || a.createdAt || 0));
-    for (const notice of leaseNotices) {
-      const leaseId = String(notice?.leaseId || "").trim();
-      if (!leaseId || latestNoticeByLeaseId.has(leaseId)) continue;
-      latestNoticeByLeaseId.set(leaseId, notice);
-    }
-
-    const items = leaseSnap.docs
-      .map((doc) => normalizeLeaseRecord(doc.id, doc.data() as any))
-      .filter((lease) => !propertyId || lease.propertyId === propertyId)
-      .filter((lease) => lease.status === "active" || lease.status === "notice_pending" || lease.status === "renewal_pending")
-      .map((lease) => {
-        const latestNotice = latestNoticeByLeaseId.get(lease.id) || null;
-        const noticeBucket = deriveLeaseRenewalWorkflowBucket({
-          lease,
-          latestNotice,
-          now,
-          horizon,
-        });
-        const propertyAddress =
-          (lease.propertyId ? propertyAddressById.get(lease.propertyId) : null) ||
-          lease.propertyAddress ||
-          null;
-        return noticeBucket
-          ? {
-              ...lease,
-              propertyAddress,
-              noticeBucket,
-              leaseLifecycleSummary: deriveLeaseLifecycleSummary({
-                lease,
-                latestNotice,
-                noResponse: latestNotice ? computeNoResponseState(latestNotice) : false,
-                now,
-                expiringWindowMs: withinDays * 24 * 60 * 60 * 1000,
-              }),
-            }
-          : null;
-      })
-      .filter(
-        (
-          lease
-        ): lease is ReturnType<typeof normalizeLeaseRecord> & {
-          noticeBucket: LeaseRenewalWorkflowBucket;
-          leaseLifecycleSummary: ReturnType<typeof deriveLeaseLifecycleSummary>;
-        } => Boolean(lease)
-      )
+    const items = (await deriveLandlordVisibleExpiringLeases({
+      landlordId,
+      withinDays,
+      propertyId,
+      now,
+      leaseDocs: leaseSnap.docs as any,
+      noticeDocs: noticeSnap.docs as any,
+    }))
       .filter((lease: any) => !statusFilter || lease.noticeBucket === statusFilter)
+      .map((lease) => ({
+        ...lease,
+        leaseLifecycleSummary: deriveLeaseLifecycleSummary({
+          lease,
+          latestNotice: lease.latestNotice,
+          noResponse: lease.latestNotice ? computeNoResponseState(lease.latestNotice) : false,
+          now,
+          expiringWindowMs: withinDays * 24 * 60 * 60 * 1000,
+        }),
+      }))
       .sort((a, b) => Number(a.nextNoticeDueAt || 0) - Number(b.nextNoticeDueAt || 0));
 
     console.info("[lease-notice] expiring-list", {

--- a/rentchain-api/src/services/__tests__/leaseNoticeWorkflowService.test.ts
+++ b/rentchain-api/src/services/__tests__/leaseNoticeWorkflowService.test.ts
@@ -1,11 +1,62 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { collections, dbMock } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, any>>();
+
+  function ensureCollection(name: string) {
+    if (!collections.has(name)) collections.set(name, new Map<string, any>());
+    return collections.get(name)!;
+  }
+
+  function makeQuery(name: string, filters: Array<{ field: string; value: any }> = []) {
+    return {
+      where: (field: string, _op: string, value: any) => makeQuery(name, [...filters, { field, value }]),
+      limit: (_count: number) => makeQuery(name, filters),
+      get: async () => {
+        const docs = Array.from(ensureCollection(name).entries())
+          .filter(([, data]) => filters.every((filter) => data?.[filter.field] === filter.value))
+          .map(([id, data]) => ({ id, data: () => data }));
+        return { docs, empty: docs.length === 0, size: docs.length };
+      },
+    };
+  }
+
+  return {
+    collections,
+    dbMock: {
+      collection: (name: string) => ({
+        where: (field: string, op: string, value: any) => makeQuery(name, [{ field, value }]),
+        limit: (_count: number) => makeQuery(name),
+        get: async () => makeQuery(name).get(),
+        doc: (id: string) => ({
+          id,
+          get: async () => ({
+            id,
+            exists: ensureCollection(name).has(id),
+            data: () => ensureCollection(name).get(id),
+          }),
+        }),
+      }),
+    },
+  };
+});
+
+vi.mock("../../config/firebase", () => ({
+  db: dbMock,
+}));
+
 import {
+  deriveLandlordVisibleExpiringLeases,
   deriveLeaseNoticeExecutionInputSnapshot,
   normalizeLeaseRecord,
   sanitizeLeaseRenewalOperatorInput,
 } from "../leaseNoticeWorkflowService";
 
 describe("leaseNoticeWorkflowService renewal operator inputs", () => {
+  beforeEach(() => {
+    collections.clear();
+  });
+
   it("keeps readiness partial when term fields are still unset", () => {
     const lease = normalizeLeaseRecord("lease-1", {
       landlordId: "landlord-1",
@@ -75,5 +126,59 @@ describe("leaseNoticeWorkflowService renewal operator inputs", () => {
       ok: false,
       error: "PROPOSED_RENT_NOT_ALLOWED_FOR_RENT_CHANGE_MODE",
     });
+  });
+
+  it("builds one landlord-visible renewal dataset and excludes hidden, archived, vacant, ended, and past-due leases", async () => {
+    collections.set(
+      "properties",
+      new Map([
+        ["prop-active", { landlordId: "landlord-1", name: "Active Property", addressLine1: "123 Main St", portfolioStatus: "active" }],
+        ["prop-archived", { landlordId: "landlord-1", name: "Archived Property", portfolioStatus: "archived" }],
+      ])
+    );
+    collections.set(
+      "units",
+      new Map([
+        ["unit-1", { landlordId: "landlord-1", propertyId: "prop-active", unitNumber: "1", label: "Unit 1", status: "occupied" }],
+        ["unit-2", { landlordId: "landlord-1", propertyId: "prop-active", unitNumber: "2", label: "Unit 2", status: "occupied" }],
+        ["unit-3", { landlordId: "landlord-1", propertyId: "prop-active", unitNumber: "3", label: "Unit 3", status: "occupied" }],
+        ["unit-4", { landlordId: "landlord-1", propertyId: "prop-active", unitNumber: "4", label: "Unit 4", status: "vacant" }],
+        ["unit-5", { landlordId: "landlord-1", propertyId: "prop-archived", unitNumber: "5", label: "Unit 5", status: "occupied" }],
+      ])
+    );
+    collections.set(
+      "leases",
+      new Map([
+        ["lease-expiring", { landlordId: "landlord-1", propertyId: "prop-active", unitId: "unit-1", status: "active", nextNoticeDueAt: Date.now() + 5 * 24 * 60 * 60 * 1000 }],
+        ["lease-pending", { landlordId: "landlord-1", propertyId: "prop-active", unitId: "unit-2", status: "renewal_pending", nextNoticeDueAt: Date.now() + 5 * 24 * 60 * 60 * 1000 }],
+        ["lease-no-response", { landlordId: "landlord-1", propertyId: "prop-active", unitId: "unit-3", status: "notice_pending", nextNoticeDueAt: Date.now() + 5 * 24 * 60 * 60 * 1000 }],
+        ["lease-vacant", { landlordId: "landlord-1", propertyId: "prop-active", unitId: "unit-4", status: "active", nextNoticeDueAt: Date.now() + 5 * 24 * 60 * 60 * 1000 }],
+        ["lease-archived-property", { landlordId: "landlord-1", propertyId: "prop-archived", unitId: "unit-5", status: "active", nextNoticeDueAt: Date.now() + 5 * 24 * 60 * 60 * 1000 }],
+        ["lease-ended", { landlordId: "landlord-1", propertyId: "prop-active", unitId: "unit-1", status: "ended", nextNoticeDueAt: Date.now() + 5 * 24 * 60 * 60 * 1000 }],
+        ["lease-renewed", { landlordId: "landlord-1", propertyId: "prop-active", unitId: "unit-1", status: "renewal_accepted", nextNoticeDueAt: Date.now() + 5 * 24 * 60 * 60 * 1000 }],
+        ["lease-move-out", { landlordId: "landlord-1", propertyId: "prop-active", unitId: "unit-1", status: "move_out_pending", nextNoticeDueAt: Date.now() + 5 * 24 * 60 * 60 * 1000 }],
+        ["lease-past-due", { landlordId: "landlord-1", propertyId: "prop-active", unitId: "unit-1", status: "active", nextNoticeDueAt: Date.now() - 5 * 24 * 60 * 60 * 1000 }],
+        ["lease-hidden", { landlordId: "landlord-1", propertyId: "prop-active", unitId: "unit-1", status: "active", nextNoticeDueAt: Date.now() + 5 * 24 * 60 * 60 * 1000, hiddenFromActiveLists: true }],
+      ])
+    );
+    collections.set(
+      "leaseNotices",
+      new Map([
+        ["notice-pending", { landlordId: "landlord-1", leaseId: "lease-pending", tenantResponse: "pending", createdAt: Date.now(), updatedAt: Date.now() }],
+        ["notice-no-response", { landlordId: "landlord-1", leaseId: "lease-no-response", tenantResponse: "pending", responseDeadlineAt: Date.now() - 1000, createdAt: Date.now(), updatedAt: Date.now() }],
+      ])
+    );
+
+    const items = await deriveLandlordVisibleExpiringLeases({
+      landlordId: "landlord-1",
+      withinDays: 120,
+      now: Date.now(),
+    });
+
+    expect(items.map((item) => ({ id: item.id, bucket: item.noticeBucket }))).toEqual([
+      { id: "lease-expiring", bucket: "expiring" },
+      { id: "lease-pending", bucket: "pending-response" },
+      { id: "lease-no-response", bucket: "no-response" },
+    ]);
   });
 });

--- a/rentchain-api/src/services/leaseNoticeWorkflowService.ts
+++ b/rentchain-api/src/services/leaseNoticeWorkflowService.ts
@@ -9,6 +9,8 @@ import {
   resolveLeaseNoticeRule,
 } from "../config/leaseNoticeRules";
 import { toAutopilotPolicySummary } from "../lib/policy/policyEvaluator";
+import { loadUnitsForProperty, resolveUnitReference } from "./leaseCanonicalizationService";
+import { isTargetedHiddenLeaseId } from "../lib/testDataVisibilityTargets";
 
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -111,6 +113,24 @@ export type LeaseNoticeExecutionInputSnapshot = {
   responseDeadlineAt: number | null;
 };
 
+export type LeaseRenewalWorkflowBucket = "expiring" | "pending-response" | "no-response";
+
+export type LandlordVisibleExpiringLeaseItem = LeaseWorkflowLease & {
+  noticeBucket: LeaseRenewalWorkflowBucket;
+  latestNotice: any | null;
+};
+
+type FirestoreLikeDoc = {
+  id: string;
+  data(): any;
+};
+
+type NormalizedLeaseCandidate = {
+  id: string;
+  raw: any;
+  lease: LeaseWorkflowLease;
+};
+
 export type LeaseRenewalOperatorInputRecord = {
   rentChangeMode: RentChangeMode | null;
   proposedRent: number | null;
@@ -155,6 +175,26 @@ function minusDays(dateOnly: string, days: number): number | null {
 function asCurrency(value: unknown): string {
   const raw = String(value || "CAD").trim().toUpperCase();
   return raw || "CAD";
+}
+
+function normalizePortfolioStatus(value: unknown): "active" | "archived" {
+  return String(value || "").trim().toLowerCase() === "archived" ? "archived" : "active";
+}
+
+function normalizeStatus(value: unknown): string {
+  return String(value || "").trim().toLowerCase();
+}
+
+function resolveUnitOccupancyStatus(unit: Record<string, unknown> | null | undefined): "occupied" | "vacant" | null {
+  const explicitStatus = normalizeStatus(unit?.status);
+  if (explicitStatus === "occupied" || explicitStatus === "vacant") {
+    return explicitStatus;
+  }
+  const occupancyStatus = normalizeStatus(unit?.occupancyStatus);
+  if (occupancyStatus === "occupied" || occupancyStatus === "vacant") {
+    return occupancyStatus;
+  }
+  return null;
 }
 
 function asLeaseType(value: unknown): LeaseType {
@@ -256,6 +296,141 @@ export function normalizeLeaseRecord(id: string, raw: any): LeaseWorkflowLease {
     propertyLabel: String(raw?.propertyLabel || raw?.propertyName || "").trim() || null,
     propertyAddress: String(raw?.propertyAddress || raw?.propertyAddressLine1 || raw?.addressLine1 || raw?.propertyAddress1 || raw?.address || "").trim() || null,
   };
+}
+
+function isLeaseRenewalWorkflowStatus(status: unknown) {
+  const normalized = String(status || "").trim().toLowerCase();
+  return normalized === "active" || normalized === "notice_pending" || normalized === "renewal_pending";
+}
+
+function deriveLeaseRenewalWorkflowBucket(params: {
+  lease: LeaseWorkflowLease;
+  latestNotice: any | null;
+  now: number;
+  horizon: number;
+}): LeaseRenewalWorkflowBucket | null {
+  const { lease, latestNotice, now, horizon } = params;
+  const dueAt = Number(lease?.nextNoticeDueAt || 0);
+  if (!(dueAt > 0 && dueAt >= now && dueAt <= horizon)) return null;
+  const noResponse = latestNotice ? computeNoResponseState(latestNotice) : false;
+  if (noResponse) return "no-response";
+  const response = String(latestNotice?.tenantResponse || "").trim().toLowerCase();
+  if (latestNotice && response === "pending") return "pending-response";
+  return "expiring";
+}
+
+export async function deriveLandlordVisibleExpiringLeases(params: {
+  landlordId: string;
+  withinDays?: number;
+  propertyId?: string | null;
+  now?: number;
+  leaseDocs?: FirestoreLikeDoc[];
+  noticeDocs?: FirestoreLikeDoc[];
+  propertyRecords?: Array<{ id: string; [key: string]: any }>;
+}): Promise<LandlordVisibleExpiringLeaseItem[]> {
+  const landlordId = String(params.landlordId || "").trim();
+  if (!landlordId) return [];
+
+  const now = typeof params.now === "number" ? params.now : nowMs();
+  const withinDays = Math.max(1, Number(params.withinDays || 120));
+  const horizon = now + withinDays * 24 * 60 * 60 * 1000;
+  const propertyIdFilter = String(params.propertyId || "").trim() || null;
+
+  const [leaseDocs, noticeDocs] = await Promise.all([
+    params.leaseDocs
+      ? Promise.resolve(params.leaseDocs)
+      : db.collection("leases").where("landlordId", "==", landlordId).limit(400).get().then((snap) => snap.docs as any),
+    params.noticeDocs
+      ? Promise.resolve(params.noticeDocs)
+      : db.collection("leaseNotices").where("landlordId", "==", landlordId).limit(400).get().then((snap) => snap.docs as any),
+  ]);
+
+  const normalizedLeases: NormalizedLeaseCandidate[] = leaseDocs
+    .map((doc: any) => {
+      const raw = doc.data() as any;
+      return { id: doc.id, raw, lease: normalizeLeaseRecord(doc.id, raw) };
+    })
+    .filter(({ id, raw, lease }: NormalizedLeaseCandidate) => {
+      if (raw?.hiddenFromActiveLists === true || isTargetedHiddenLeaseId(id)) return false;
+      if (!isLeaseRenewalWorkflowStatus(lease.status)) return false;
+      if (propertyIdFilter && lease.propertyId !== propertyIdFilter) return false;
+      return true;
+    });
+
+  const propertyIds = Array.from(
+    new Set(
+      normalizedLeases
+        .map(({ lease }: NormalizedLeaseCandidate) => String(lease.propertyId || "").trim())
+        .filter(Boolean)
+    )
+  );
+
+  const propertyRecords = params.propertyRecords
+    ? params.propertyRecords
+    : await Promise.all(
+        (propertyIds as string[]).map(async (id) => {
+          const snap = await db.collection("properties").doc(id).get();
+          return snap.exists ? { id: snap.id, ...(snap.data() as any) } : null;
+        })
+      ).then((items) => items.filter(Boolean) as Array<{ id: string; [key: string]: any }>);
+
+  const propertyById = new Map<string, any>(
+    propertyRecords.map((property) => [String(property?.id || "").trim(), property])
+  );
+
+  const unitsByPropertyId = new Map<string, Awaited<ReturnType<typeof loadUnitsForProperty>>>();
+  for (const propertyId of propertyIds as string[]) {
+    unitsByPropertyId.set(propertyId, await loadUnitsForProperty(db as any, propertyId, landlordId));
+  }
+
+  const latestNoticeByLeaseId = new Map<string, any>();
+  const notices = noticeDocs
+    .map((doc: any) => ({ id: doc.id, ...(doc.data() as any) }))
+    .sort((a: any, b: any) => Number(b.updatedAt || b.createdAt || 0) - Number(a.updatedAt || a.createdAt || 0));
+  for (const notice of notices) {
+    const leaseId = String(notice?.leaseId || "").trim();
+    if (!leaseId || latestNoticeByLeaseId.has(leaseId)) continue;
+    latestNoticeByLeaseId.set(leaseId, notice);
+  }
+
+  const items: LandlordVisibleExpiringLeaseItem[] = [];
+  for (const { lease, raw } of normalizedLeases) {
+    const propertyId = String(lease.propertyId || "").trim();
+    if (!propertyId) continue;
+    const property = propertyById.get(propertyId);
+    if (!property) continue;
+    if (property?.hiddenFromActiveLists === true) continue;
+    if (Boolean(property?.archivedAt) || normalizePortfolioStatus(property?.portfolioStatus) === "archived") continue;
+
+    const units = unitsByPropertyId.get(propertyId) || [];
+    const resolution = resolveUnitReference(units, lease.unitId || lease.unitLabel || raw?.unitNumber || raw?.unit || null);
+    if (!resolution.unit || resolution.ambiguous) continue;
+    if (resolution.unit.raw?.hiddenFromActiveLists === true) continue;
+    if (resolveUnitOccupancyStatus(resolution.unit.raw) !== "occupied") continue;
+
+    const latestNotice = latestNoticeByLeaseId.get(lease.id) || null;
+    const noticeBucket = deriveLeaseRenewalWorkflowBucket({
+      lease,
+      latestNotice,
+      now,
+      horizon,
+    });
+    if (!noticeBucket) continue;
+
+    items.push({
+      ...lease,
+      propertyLabel:
+        String(property?.name || property?.addressLine1 || property?.address || "").trim() ||
+        lease.propertyLabel,
+      propertyAddress:
+        String(property?.addressLine1 || property?.address || "").trim() || lease.propertyAddress,
+      unitLabel: resolution.unit.label || resolution.unit.unitNumber || lease.unitLabel,
+      latestNotice,
+      noticeBucket,
+    });
+  }
+
+  return items.sort((a, b) => Number(a.nextNoticeDueAt || 0) - Number(b.nextNoticeDueAt || 0));
 }
 
 export function deriveLeaseRenewalOperatorInputRecord(lease: LeaseWorkflowLease): LeaseRenewalOperatorInputRecord {


### PR DESCRIPTION
This PR aligns dashboard lease notice counts with the portfolio-health renewal list.

Includes:
- shared deriveLandlordVisibleExpiringLeases helper
- dashboard expiring/pending/no-response counts sourced from the shared dataset
- /landlord/leases/expiring sourced from the same shared eligibility rule
- consistent exclusion of ended, accepted, move-out, vacant, hidden, archived, unresolved, and past-due leases
- focused backend test coverage

Guardrails preserved:
- backend-only
- no frontend production logic changes
- no legal notice automation changes
- no automatic notice sending
- no payment/provider changes
- no data migration
- no broad dashboard or portfolio-health redesign

PR note:
- Lease notice workflow, dashboard route, and lease notice landlord route tests passed: 14 tests.
- Backend typecheck passed.
- No frontend tests required because links/UI behavior stayed unchanged.
- PDF/print cleanup remains deferred to feat/pdf-rendering-cleanup-v1.