### PR TITLE
fix: clean up print rendering

### DIFF
--- a/rentchain-frontend/src/index.css
+++ b/rentchain-frontend/src/index.css
@@ -321,26 +321,64 @@ button,
 }
 
 @media print {
-  body * {
-    visibility: hidden !important;
+  @page {
+    margin: 12mm;
   }
 
-  .print-only,
-  .print-only * {
+  body[data-print-root-active="true"] > * {
+    display: none !important;
+  }
+
+  body[data-print-root-active="true"] > [data-print-root="true"] {
+    display: block !important;
+    padding: 24px !important;
+    background: #fff !important;
+  }
+
+  body[data-print-root-active="true"] > [data-print-root="true"],
+  body[data-print-root-active="true"] > [data-print-root="true"] * {
     visibility: visible !important;
   }
 
   .print-only {
-    display: block !important;
-    position: absolute;
-    left: 0;
-    top: 0;
-    width: 100%;
-    padding: 24px;
+    display: none !important;
   }
 
-  @page {
-    margin: 12mm;
+  body[data-print-root-active="true"] .print-only {
+    display: block !important;
+  }
+
+  body:not([data-print-root-active="true"]) * {
+    visibility: hidden !important;
+  }
+
+  body:not([data-print-root-active="true"]) .print-only-summary,
+  body:not([data-print-root-active="true"]) .print-only-lease-renewals,
+  body:not([data-print-root-active="true"]) .print-only-application {
+    display: block !important;
+    visibility: visible !important;
+    position: absolute !important;
+    left: 0 !important;
+    top: 0 !important;
+    width: 100% !important;
+    padding: 24px !important;
+    background: #fff !important;
+    box-sizing: border-box !important;
+  }
+
+  body:not([data-print-root-active="true"]) .print-only-summary *,
+  body:not([data-print-root-active="true"]) .print-only-lease-renewals *,
+  body:not([data-print-root-active="true"]) .print-only-application * {
+    visibility: visible !important;
+  }
+
+  body[data-print-mode="summary"]:not([data-print-root-active="true"]) .print-only-lease-renewals,
+  body[data-print-mode="summary"]:not([data-print-root-active="true"]) .print-only-application,
+  body[data-print-mode="lease-renewals"]:not([data-print-root-active="true"]) .print-only-summary,
+  body[data-print-mode="lease-renewals"]:not([data-print-root-active="true"]) .print-only-application,
+  body[data-print-mode="application"]:not([data-print-root-active="true"]) .print-only-summary,
+  body[data-print-mode="application"]:not([data-print-root-active="true"]) .print-only-lease-renewals {
+    display: none !important;
   }
 }
 
@@ -405,40 +443,4 @@ button,
 
 .printFooter {
   margin-top: 14px;
-}
-
-/* Print mode selection for applications */
-@media print {
-  .print-only {
-    display: none !important;
-  }
-
-  body[data-print-mode="summary"] .print-only-summary {
-    display: block !important;
-  }
-
-  body[data-print-mode="lease-renewals"] .print-only-lease-renewals {
-    display: block !important;
-  }
-
-  body[data-print-mode="application"] .print-only-application {
-    display: block !important;
-  }
-
-  body * {
-    visibility: hidden !important;
-  }
-
-  .print-only,
-  .print-only * {
-    visibility: visible !important;
-  }
-
-  .print-only {
-    position: absolute;
-    left: 0;
-    top: 0;
-    width: 100%;
-    padding: 24px;
-  }
 }

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   convertUnitReferenceToLease: vi.fn(),
   archiveLeaseRecord: vi.fn(),
   restoreLeaseRecord: vi.fn(),
+  printSummaryDocument: vi.fn(),
 }));
 
 vi.mock("@/api/leasesApi", () => ({
@@ -23,12 +24,17 @@ vi.mock("@/api/leasesApi", () => ({
   restoreLeaseRecord: mocks.restoreLeaseRecord,
 }));
 
+vi.mock("@/utils/printSummary", () => ({
+  printSummaryDocument: (...args: unknown[]) => mocks.printSummaryDocument(...args),
+}));
+
 describe("LandlordActiveLeasesPage", () => {
   afterEach(() => {
     cleanup();
   });
 
   beforeEach(() => {
+    mocks.printSummaryDocument.mockReset();
     Object.defineProperty(window, "matchMedia", {
       writable: true,
       value: vi.fn().mockImplementation((query: string) => ({
@@ -184,6 +190,8 @@ describe("LandlordActiveLeasesPage", () => {
     await waitFor(() => expect(mocks.enableLeasePaymentRail).toHaveBeenCalledWith("lease-1"));
     fireEvent.click(screen.getByRole("button", { name: "Archive lease" }));
     await waitFor(() => expect(mocks.archiveLeaseRecord).toHaveBeenCalledWith("lease-1"));
+    fireEvent.click(screen.getByRole("button", { name: "Print / Save PDF" }));
+    expect(mocks.printSummaryDocument).toHaveBeenCalledWith("summary");
   });
 
   it("shows landlord-safe payment visibility without retry or receipt actions", async () => {

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
@@ -17,6 +17,7 @@ import {
   prettyRentPaymentStatus,
 } from "@/lib/payments/paymentStatusGuidance";
 import { isTargetedHiddenLeaseId } from "@/lib/testDataVisibilityTargets";
+import { printSummaryDocument } from "@/utils/printSummary";
 
 function formatCurrency(value: number | null | undefined) {
   const amount = typeof value === "number" ? value : 0;
@@ -470,7 +471,7 @@ export default function LandlordActiveLeasesPage() {
         <button
           type="button"
           className="no-print"
-          onClick={() => window.print()}
+          onClick={() => void printSummaryDocument("summary")}
           style={{ padding: "8px 10px", borderRadius: 12, border: "1px solid #E5E7EB", background: "#FFFFFF", fontWeight: 900, cursor: "pointer" }}
         >
           Print / Save PDF

--- a/rentchain-frontend/src/utils/printSummary.ts
+++ b/rentchain-frontend/src/utils/printSummary.ts
@@ -1,19 +1,54 @@
-export async function printSummaryDocument(mode: "summary" | "lease-renewals" = "summary"): Promise<void> {
+type PrintSummaryMode = "summary" | "lease-renewals" | "application";
+
+const PRINT_SELECTOR_BY_MODE: Record<PrintSummaryMode, string> = {
+  summary: ".print-only-summary",
+  "lease-renewals": ".print-only-lease-renewals",
+  application: ".print-only-application",
+};
+
+export async function printSummaryDocument(mode: PrintSummaryMode = "summary"): Promise<void> {
   if (typeof window === "undefined" || typeof document === "undefined") return;
 
   const body = document.body;
   const previousMode = body.getAttribute("data-print-mode");
-  body.setAttribute("data-print-mode", mode);
+  const selector = PRINT_SELECTOR_BY_MODE[mode];
+  const printableSource = document.querySelector<HTMLElement>(selector);
+  const printableRoot = document.createElement("div");
+  let cleanedUp = false;
+
+  printableRoot.setAttribute("data-print-root", "true");
+
+  if (printableSource) {
+    printableRoot.appendChild(printableSource.cloneNode(true));
+  }
+
+  const cleanup = () => {
+    if (cleanedUp) return;
+    cleanedUp = true;
+    window.removeEventListener("afterprint", cleanup);
+    printableRoot.remove();
+    body.removeAttribute("data-print-root-active");
+    if (previousMode) {
+      body.setAttribute("data-print-mode", previousMode);
+    } else {
+      body.removeAttribute("data-print-mode");
+    }
+  };
 
   try {
+    body.setAttribute("data-print-mode", mode);
+    body.setAttribute("data-print-root-active", "true");
+    body.appendChild(printableRoot);
+
+    window.addEventListener("afterprint", cleanup, { once: true });
+    await new Promise<void>((resolve) => {
+      window.requestAnimationFrame(() => {
+        resolve();
+      });
+    });
+
     window.print();
   } finally {
-    window.setTimeout(() => {
-      if (previousMode) {
-        body.setAttribute("data-print-mode", previousMode);
-      } else {
-        body.removeAttribute("data-print-mode");
-      }
-    }, 0);
+    window.setTimeout(cleanup, 250);
   }
 }


### PR DESCRIPTION
This PR repairs print/PDF rendering cleanup.

Includes:
- consolidated duplicated print CSS into one authoritative print block
- /leases print now uses printSummaryDocument("summary")
- helper-driven print flows now isolate a single temporary print root
- selected print sections are cloned before printing to avoid surrounding layout and phantom pages
- print mode is set before printing and cleared after print
- focused frontend test coverage

Guardrails preserved:
- frontend-only
- no backend/API/export data changes
- no new PDF library
- no route changes
- no payment/provider changes
- no analytics changes
- no tenant summary backend PDF changes

PR note:
- LandlordActiveLeasesPage tests passed: 10 tests.
- PortfolioHealthSummaryPage tests passed: 9 tests.
- Frontend build passed.
- Existing chunk-size warning remains unchanged and out of scope.
- Manual browser/PDF QA remains required after merge for /leases and portfolio-health renewal print flows.
- Tenant summary backend PDF layout/content issues and other raw window.print pages remain deferred.