### PR TITLE
fix: add lease document fallback view

### DIFF
--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -124,6 +124,7 @@ const MessagesPage = lazy(() => import("./pages/MessagesPage"));
 const MaintenanceRequestsPage = lazy(() => import("./pages/MaintenanceRequestsPage"));
 const LeaseLedgerPage = lazy(() => import("./pages/LeaseLedgerPage"));
 const LandlordActiveLeasesPage = lazy(() => import("./pages/LandlordActiveLeasesPage"));
+const LandlordLeaseSummaryPage = lazy(() => import("./pages/LandlordLeaseSummaryPage"));
 const ApplicationReviewSummaryPage = lazy(() => import("./pages/ApplicationReviewSummaryPage"));
 const ReferralsPage = lazy(() => import("./pages/ReferralsPage"));
 const AccountPage = lazy(() => import("./pages/AccountPage"));
@@ -1085,6 +1086,18 @@ function App() {
               <LandlordNav>
                 <Suspense fallback={null}>
                   <LandlordActiveLeasesPage />
+                </Suspense>
+              </LandlordNav>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/leases/:leaseId/summary"
+          element={
+            <RequireAuth>
+              <LandlordNav>
+                <Suspense fallback={null}>
+                  <LandlordLeaseSummaryPage />
                 </Suspense>
               </LandlordNav>
             </RequireAuth>

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
@@ -352,7 +352,7 @@ describe("LandlordActiveLeasesPage", () => {
     );
 
     expect((await screen.findAllByText("Harbour View")).length).toBeGreaterThan(0);
-    expect(screen.getByRole("button", { name: "Lease document unavailable" })).toBeDisabled();
+    expect(screen.getByRole("link", { name: "View lease" })).toHaveAttribute("href", "/leases/lease-1/summary");
     expect(screen.getByRole("link", { name: "Ledger" })).toHaveAttribute("href", "/leases/lease-1/ledger");
     expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
   });

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
@@ -338,6 +338,7 @@ export default function LandlordActiveLeasesPage() {
 
   function buildLeaseActionMeta(lease: LandlordActiveLease) {
     const ledgerPath = `/leases/${encodeURIComponent(lease.id)}/ledger`;
+    const summaryPath = `/leases/${encodeURIComponent(lease.id)}/summary`;
     const ledgerUrl =
       typeof window !== "undefined"
         ? `${window.location.origin}${ledgerPath}`
@@ -358,6 +359,7 @@ export default function LandlordActiveLeasesPage() {
     );
     return {
       ledgerPath,
+      summaryPath,
       emailHref: lease.tenantEmail
         ? `mailto:${encodeURIComponent(lease.tenantEmail)}?subject=${emailSubject}&body=${emailBody}`
         : null,
@@ -365,7 +367,7 @@ export default function LandlordActiveLeasesPage() {
   }
 
   function renderLeaseActions(lease: LandlordActiveLease) {
-    const { ledgerPath, emailHref } = buildLeaseActionMeta(lease);
+    const { ledgerPath, summaryPath, emailHref } = buildLeaseActionMeta(lease);
     return (
       <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
         {lease.documentUrl ? (
@@ -378,13 +380,12 @@ export default function LandlordActiveLeasesPage() {
             View lease
           </a>
         ) : (
-          <button
-            type="button"
-            disabled
-            style={{ padding: "6px 10px", borderRadius: 8, border: "1px solid #e2e8f0", background: "#f8fafc", color: "#94a3b8" }}
+          <Link
+            to={summaryPath}
+            style={{ padding: "6px 10px", borderRadius: 8, border: "1px solid #cbd5e1", background: "#fff", color: "#0f172a", textDecoration: "none" }}
           >
-            Lease document unavailable
-          </button>
+            View lease
+          </Link>
         )}
         <Link to={ledgerPath} style={{ padding: "6px 10px", borderRadius: 8, border: "1px solid #cbd5e1", textDecoration: "none", color: "#0f172a" }}>
           Ledger

--- a/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.test.tsx
@@ -1,0 +1,105 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import LandlordLeaseSummaryPage from "./LandlordLeaseSummaryPage";
+
+const mocks = vi.hoisted(() => ({
+  getLeaseById: vi.fn(),
+}));
+
+vi.mock("@/api/leasesApi", () => ({
+  getLeaseById: mocks.getLeaseById,
+}));
+
+describe("LandlordLeaseSummaryPage", () => {
+  beforeEach(() => {
+    mocks.getLeaseById.mockReset();
+    mocks.getLeaseById.mockResolvedValue({
+      lease: {
+        id: "lease-1",
+        propertyId: "prop-1",
+        propertyName: "Coburg Rd",
+        unitNumber: "3",
+        monthlyRent: 2100,
+        startDate: "2026-01-01",
+        endDate: "2026-12-31",
+        status: "active",
+        tenantName: "Tony Wenpeng",
+        tenantEmail: "tony@example.com",
+        documentUrl: null,
+        paymentReadiness: {
+          readinessStatus: "ready_to_configure",
+          readinessLabel: "Rent terms ready for future setup",
+          readinessDescription: "The current lease shows the rent terms needed for a future setup workflow.",
+          requiredNextAction: "confirm_payment_setup_later",
+          rentTerms: {
+            rentAmountAvailable: true,
+            dueDateAvailable: true,
+            leaseDatesAvailable: true,
+            tenantLinked: true,
+            leaseExecuted: false,
+          },
+          paymentSetup: {
+            processorConnected: false,
+            moneyMovementEnabled: false,
+            storedPaymentMethod: false,
+          },
+        },
+        leaseLifecycleSummary: {
+          lifecycleStatus: "expiring_soon",
+          lifecycleLabel: "Expiring soon",
+          lifecycleDescription: "This lease is approaching notice timing.",
+          requiredNextAction: "prepare_renewal_notice",
+          renewalOutcome: "not_started",
+          history: [],
+        },
+      },
+    });
+
+    global.URL.createObjectURL = vi.fn(() => "blob:lease-summary");
+    global.URL.revokeObjectURL = vi.fn();
+    HTMLAnchorElement.prototype.click = vi.fn();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders landlord-safe lease details without exposing storage paths", async () => {
+    render(
+      <MemoryRouter initialEntries={["/leases/lease-1/summary"]}>
+        <Routes>
+          <Route path="/leases/:leaseId/summary" element={<LandlordLeaseSummaryPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Lease summary")).toBeInTheDocument();
+    expect(mocks.getLeaseById).toHaveBeenCalledWith("lease-1");
+    expect(screen.getByText("Coburg Rd")).toBeInTheDocument();
+    expect(screen.getByText("Tony Wenpeng")).toBeInTheDocument();
+    expect(screen.getByText("Not attached")).toBeInTheDocument();
+    expect(screen.queryByText(/gs:\/\//i)).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Open ledger" })).toHaveAttribute("href", "/leases/lease-1/ledger");
+    expect(screen.getByRole("link", { name: "Back to leases" })).toHaveAttribute("href", "/leases");
+  });
+
+  it("keeps save lease summary available for missing-document leases", async () => {
+    render(
+      <MemoryRouter initialEntries={["/leases/lease-1/summary"]}>
+        <Routes>
+          <Route path="/leases/:leaseId/summary" element={<LandlordLeaseSummaryPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Save lease summary" }));
+
+    await waitFor(() => {
+      expect(global.URL.createObjectURL).toHaveBeenCalledTimes(1);
+      expect(HTMLAnchorElement.prototype.click).toHaveBeenCalledTimes(1);
+      expect(global.URL.revokeObjectURL).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.tsx
@@ -1,0 +1,206 @@
+import React from "react";
+import { Link, useParams } from "react-router-dom";
+import { getLeaseById, type LandlordActiveLease } from "@/api/leasesApi";
+
+function errorMessage(error: unknown, fallback: string) {
+  if (error instanceof Error && error.message) return error.message;
+  return fallback;
+}
+
+function formatCurrency(value: number | null | undefined) {
+  const amount = typeof value === "number" ? value : 0;
+  return amount.toLocaleString(undefined, { style: "currency", currency: "CAD" });
+}
+
+function formatDate(value: string | null | undefined) {
+  if (!value) return "—";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return parsed.toLocaleDateString();
+}
+
+function prettyLeaseStatus(value: string | null | undefined) {
+  const normalized = String(value || "").trim().toLowerCase();
+  if (!normalized) return "Unknown";
+  if (normalized === "notice_pending") return "Renew letter needed";
+  if (normalized === "renewal_pending") return "Renewal pending";
+  if (normalized === "renewal_accepted") return "Renewing";
+  if (normalized === "move_out_pending") return "Quitting";
+  return normalized.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function downloadLeaseSummary(lease: LandlordActiveLease) {
+  const text = [
+    `Property: ${lease.propertyName || "Property"}`,
+    `Unit: ${lease.unitNumber || "—"}`,
+    `Tenant: ${lease.tenantName || "—"}`,
+    `Tenant email: ${lease.tenantEmail || "—"}`,
+    `Monthly rent: ${formatCurrency(lease.monthlyRent)}`,
+    `Start date: ${lease.startDate || "—"}`,
+    `End date: ${lease.endDate || "—"}`,
+    `Status: ${prettyLeaseStatus(lease.status)}`,
+    `Lease document: ${lease.documentUrl ? "Available" : "Not available"}`,
+  ].join("\n");
+
+  const blob = new Blob([text], { type: "text/plain;charset=utf-8" });
+  const url = window.URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = `lease-${lease.unitNumber || lease.id}.txt`;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  window.URL.revokeObjectURL(url);
+}
+
+function DetailRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div style={{ display: "grid", gap: 4 }}>
+      <div style={{ fontSize: 12, fontWeight: 700, color: "#64748b", textTransform: "uppercase", letterSpacing: 0.3 }}>{label}</div>
+      <div style={{ color: "#0f172a" }}>{value}</div>
+    </div>
+  );
+}
+
+export default function LandlordLeaseSummaryPage() {
+  const { leaseId = "" } = useParams();
+  const [lease, setLease] = React.useState<LandlordActiveLease | null>(null);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    let active = true;
+
+    async function load() {
+      if (!leaseId) {
+        setError("Missing lease id.");
+        setLoading(false);
+        return;
+      }
+
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await getLeaseById(leaseId);
+        if (!active) return;
+        setLease(response.lease || null);
+      } catch (err: unknown) {
+        if (!active) return;
+        setError(errorMessage(err, "Failed to load lease summary."));
+        setLease(null);
+      } finally {
+        if (active) setLoading(false);
+      }
+    }
+
+    void load();
+    return () => {
+      active = false;
+    };
+  }, [leaseId]);
+
+  const ledgerPath = lease ? `/leases/${encodeURIComponent(lease.id)}/ledger` : `/leases/${encodeURIComponent(leaseId)}/ledger`;
+
+  return (
+    <div style={{ display: "grid", gap: 16 }}>
+      <div style={{ display: "grid", gap: 6 }}>
+        <div style={{ fontSize: 24, fontWeight: 800 }}>Lease summary</div>
+        <div style={{ color: "#475569", fontSize: 14 }}>
+          Review the current landlord-visible lease details when a separate lease document is not attached.
+        </div>
+      </div>
+
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+        <Link
+          to={ledgerPath}
+          style={{ padding: "8px 10px", borderRadius: 10, border: "1px solid #cbd5e1", textDecoration: "none", color: "#0f172a" }}
+        >
+          Open ledger
+        </Link>
+        <button
+          type="button"
+          onClick={() => {
+            if (lease) downloadLeaseSummary(lease);
+          }}
+          disabled={!lease}
+          style={{ padding: "8px 10px", borderRadius: 10, border: "1px solid #cbd5e1", background: "#fff", color: "#0f172a" }}
+        >
+          Save lease summary
+        </button>
+        <Link
+          to="/leases"
+          style={{ padding: "8px 10px", borderRadius: 10, border: "1px solid #cbd5e1", textDecoration: "none", color: "#0f172a" }}
+        >
+          Back to leases
+        </Link>
+      </div>
+
+      {loading ? <div>Loading lease summary…</div> : null}
+      {error ? <div style={{ color: "#b91c1c" }}>{error}</div> : null}
+
+      {lease ? (
+        <>
+          <div
+            style={{
+              display: "grid",
+              gap: 16,
+              gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+              padding: 16,
+              borderRadius: 16,
+              border: "1px solid #e2e8f0",
+              background: "#fff",
+            }}
+          >
+            <DetailRow label="Property" value={lease.propertyName || "Property"} />
+            <DetailRow label="Unit" value={lease.unitNumber || "—"} />
+            <DetailRow label="Tenant" value={lease.tenantName || "—"} />
+            <DetailRow label="Monthly rent" value={formatCurrency(lease.monthlyRent)} />
+            <DetailRow label="Start date" value={formatDate(lease.startDate)} />
+            <DetailRow label="End date" value={formatDate(lease.endDate)} />
+            <DetailRow label="Status" value={prettyLeaseStatus(lease.status)} />
+            <DetailRow label="Lease document" value={lease.documentUrl ? "Available" : "Not attached"} />
+          </div>
+
+          {lease.leaseExecution || lease.paymentReadiness || lease.leaseLifecycleSummary ? (
+            <div
+              style={{
+                display: "grid",
+                gap: 16,
+                padding: 16,
+                borderRadius: 16,
+                border: "1px solid #e2e8f0",
+                background: "#fff",
+              }}
+            >
+              <div style={{ fontSize: 16, fontWeight: 700, color: "#0f172a" }}>Current lease signals</div>
+
+              {lease.leaseExecution ? (
+                <div style={{ display: "grid", gap: 6 }}>
+                  <div style={{ fontWeight: 700, color: "#0f172a" }}>Execution</div>
+                  <div>{lease.leaseExecution.executionLabel}</div>
+                  <div style={{ color: "#64748b", fontSize: 14 }}>{lease.leaseExecution.executionDescription}</div>
+                </div>
+              ) : null}
+
+              {lease.paymentReadiness ? (
+                <div style={{ display: "grid", gap: 6 }}>
+                  <div style={{ fontWeight: 700, color: "#0f172a" }}>Payment readiness</div>
+                  <div>{lease.paymentReadiness.readinessLabel}</div>
+                  <div style={{ color: "#64748b", fontSize: 14 }}>{lease.paymentReadiness.readinessDescription}</div>
+                </div>
+              ) : null}
+
+              {lease.leaseLifecycleSummary ? (
+                <div style={{ display: "grid", gap: 6 }}>
+                  <div style={{ fontWeight: 700, color: "#0f172a" }}>Lifecycle</div>
+                  <div>{lease.leaseLifecycleSummary.lifecycleLabel}</div>
+                  <div style={{ color: "#64748b", fontSize: 14 }}>{lease.leaseLifecycleSummary.lifecycleDescription}</div>
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+        </>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
This PR fixes lease document availability for landlord leases.

Includes:
- fallback lease summary page for leases without documentUrl
- new route: /leases/:leaseId/summary
- View lease now routes to summary when document is unavailable
- removal of disabled 'Lease document unavailable' action
- preserved Ledger and Save behaviors
- landlord-safe lease detail rendering
- focused frontend test coverage

Guardrails preserved:
- frontend-only
- no backend/API changes
- no storage or document generation changes
- no raw storage path exposure
- no e-sign/provider integration
- no lease-pack coupling
- no data migration

PR note:
- LandlordActiveLeasesPage tests passed: 10 tests.
- LandlordLeaseSummaryPage tests passed: 2 tests.
- Frontend build passed.
- Existing chunk-size warning remains unchanged and out of scope.
- Lease pack integration intentionally deferred.