### PR TITLE
feat: expose financial projection endpoint

### DIFF
--- a/rentchain-api/src/routes/__tests__/tenantsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantsRoutes.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const setMock = vi.fn(async () => undefined);
 const getTenantDetailBundleMock = vi.fn();
 const getTenantsListMock = vi.fn();
+const deriveFinancialProjectionRowsMock = vi.fn();
 const leaseDocs = new Map<string, any>();
 const propertyDocs = new Map<string, any>();
 
@@ -54,6 +55,10 @@ vi.mock("../../middleware/requireLandlord", () => ({
 vi.mock("../../services/tenantDetailsService", () => ({
   getTenantDetailBundle: getTenantDetailBundleMock,
   getTenantsList: getTenantsListMock,
+}));
+
+vi.mock("../../services/financialProjectionService", () => ({
+  deriveFinancialProjectionRows: deriveFinancialProjectionRowsMock,
 }));
 
 vi.mock("../../services/tenantLedgerService", () => ({
@@ -119,6 +124,7 @@ describe("tenantsRoutes", () => {
     setMock.mockClear();
     getTenantDetailBundleMock.mockReset();
     getTenantsListMock.mockReset();
+    deriveFinancialProjectionRowsMock.mockReset();
     leaseDocs.clear();
     propertyDocs.clear();
   });
@@ -207,5 +213,102 @@ describe("tenantsRoutes", () => {
         propertyLabel: "Harbour View",
       })
     );
+  });
+
+  it("returns sorted financial projection rows for a landlord-owned tenant", async () => {
+    getTenantDetailBundleMock.mockResolvedValue({
+      tenant: { id: "tenant-1", landlordId: "landlord-1" },
+    });
+    deriveFinancialProjectionRowsMock.mockResolvedValue({
+      rows: [
+        {
+          id: "lease_charge:entry-1",
+          sourceType: "lease_charge",
+          sourceId: "entry-1",
+          leaseId: "lease-1",
+          tenantId: "tenant-1",
+          propertyId: "property-1",
+          unitId: "unit-1",
+          propertyLabel: "Harbour View",
+          unitLabel: "101",
+          amount: 1850,
+          direction: "debit",
+          occurredAt: "2026-04-01",
+          displayLabel: "Rent charge",
+          sourceBadge: "Lease charge",
+        },
+        {
+          id: "recorded_payment:payment-1",
+          sourceType: "recorded_payment",
+          sourceId: "payment-1",
+          leaseId: null,
+          tenantId: "tenant-1",
+          propertyId: "property-1",
+          unitId: null,
+          propertyLabel: "Harbour View",
+          unitLabel: null,
+          amount: 1850,
+          direction: "credit",
+          occurredAt: "2026-04-03",
+          displayLabel: "Recorded payment (e-transfer)",
+          sourceBadge: "Recorded payment",
+        },
+      ],
+      counts: {
+        recorded_payment: 1,
+        lease_charge: 1,
+        lease_credit: 0,
+        ledger_payment_unmatched: 0,
+      },
+    });
+
+    const router = (await import("../tenantsRoutes")).default;
+    const result = await invokeRouter(router, {
+      method: "GET",
+      url: "/tenant-1/financial-activity",
+    });
+
+    expect(result.status).toBe(200);
+    expect(getTenantDetailBundleMock).toHaveBeenCalledWith("tenant-1", { landlordId: "landlord-1" });
+    expect(deriveFinancialProjectionRowsMock).toHaveBeenCalledWith({
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+    });
+    expect(result.body).toEqual({
+      ok: true,
+      data: {
+        rows: [
+          expect.objectContaining({
+            sourceType: "recorded_payment",
+            sourceBadge: "Recorded payment",
+            propertyLabel: "Harbour View",
+            unitLabel: null,
+          }),
+          expect.objectContaining({
+            sourceType: "lease_charge",
+            sourceBadge: "Lease charge",
+            propertyLabel: "Harbour View",
+            unitLabel: "101",
+          }),
+        ],
+      },
+    });
+    expect(result.body.data.rows[0].occurredAt).toBe("2026-04-03");
+    expect(result.body.data.rows[0].propertyLabel).not.toBe(result.body.data.rows[0].propertyId);
+  });
+
+  it("rejects financial projection access when the tenant is outside landlord scope", async () => {
+    getTenantDetailBundleMock.mockResolvedValue({ tenant: null });
+    const router = (await import("../tenantsRoutes")).default;
+
+    const result = await invokeRouter(router, {
+      method: "GET",
+      url: "/tenant-1/financial-activity",
+    });
+
+    expect(result.status).toBe(404);
+    expect(result.body).toEqual({ ok: false, error: "Tenant not found" });
+    expect(deriveFinancialProjectionRowsMock).not.toHaveBeenCalled();
+    expect(setMock).not.toHaveBeenCalled();
   });
 });

--- a/rentchain-api/src/routes/tenantsRoutes.ts
+++ b/rentchain-api/src/routes/tenantsRoutes.ts
@@ -7,6 +7,10 @@ import {
 } from "../services/tenantDetailsService";
 import { getTenantLedger } from "../services/tenantLedgerService";
 import { generateTenantReportPdfBuffer } from "../services/tenantReportService";
+import {
+  deriveFinancialProjectionRows,
+  type FinancialProjectionRow,
+} from "../services/financialProjectionService";
 import { listTenanciesByTenantId } from "../services/tenanciesService";
 import {
   updateMoveInReadinessItems,
@@ -19,6 +23,14 @@ function getLandlordId(req: any): string | null {
   const role = String(req.user?.role || "").toLowerCase();
   if (role === "admin") return null;
   return req.user?.landlordId || req.user?.id || null;
+}
+
+function compareFinancialProjectionRows(a: FinancialProjectionRow, b: FinancialProjectionRow) {
+  const dateDiff = String(b?.occurredAt || "").localeCompare(String(a?.occurredAt || ""));
+  if (dateDiff !== 0) return dateDiff;
+  const typeDiff = String(a?.sourceType || "").localeCompare(String(b?.sourceType || ""));
+  if (typeDiff !== 0) return typeDiff;
+  return String(a?.sourceId || "").localeCompare(String(b?.sourceId || ""));
 }
 
 router.use(requireLandlord);
@@ -151,6 +163,34 @@ router.get("/:tenantId/payments", async (req: any, res) => {
   } catch (err: any) {
     console.error("[GET /api/tenants/:tenantId/payments] error", err);
     return res.status(500).json({ ok: false, error: "Failed to load tenant payments" });
+  }
+});
+
+router.get("/:tenantId/financial-activity", async (req: any, res) => {
+  const landlordId = getLandlordId(req);
+  const tenantId = String(req.params?.tenantId || "").trim();
+  if (!tenantId) return res.status(400).json({ ok: false, error: "tenantId is required" });
+  if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
+
+  try {
+    const bundle = await getTenantDetailBundle(tenantId, { landlordId });
+    if (!bundle?.tenant) return res.status(404).json({ ok: false, error: "Tenant not found" });
+
+    const projection = await deriveFinancialProjectionRows({ landlordId, tenantId });
+    const rows = Array.isArray(projection?.rows)
+      ? projection.rows.slice().sort(compareFinancialProjectionRows)
+      : [];
+
+    return res.status(200).json({
+      ok: true,
+      data: { rows },
+    });
+  } catch (err: any) {
+    console.error("[GET /api/tenants/:tenantId/financial-activity] error", err);
+    return res.status(500).json({
+      ok: false,
+      error: err?.message ?? "Failed to load tenant financial activity",
+    });
   }
 });
 


### PR DESCRIPTION
This PR introduces a read-only tenant financial activity projection endpoint.

Includes:
- GET /api/tenants/:tenantId/financial-activity
- landlord-scoped tenant authorization
- projection rows derived from existing financial projection service
- source-badged read-only rows for recorded payments, lease charges, lease credits, and unmatched ledger payments
- deterministic sorting by occurredAt desc with stable tie-breakers
- focused backend test coverage

Guardrails preserved:
- backend-only
- read-only endpoint
- no frontend changes
- no /api/payments changes
- no lease ledger route changes
- no tenant activity route changes
- no data mutation
- no source merging
- no schema migration
- no payment/provider changes