### PR TITLE
feat: add tenant financial activity panel

### DIFF
--- a/rentchain-frontend/src/api/tenantDetail.ts
+++ b/rentchain-frontend/src/api/tenantDetail.ts
@@ -83,6 +83,31 @@ export interface TenantInsight {
   [key: string]: any;
 }
 
+export type FinancialProjectionSourceType =
+  | "recorded_payment"
+  | "lease_charge"
+  | "lease_credit"
+  | "ledger_payment_unmatched";
+
+export type FinancialProjectionDirection = "credit" | "debit";
+
+export interface FinancialProjectionRow {
+  id: string;
+  sourceType: FinancialProjectionSourceType;
+  sourceId: string;
+  leaseId: string | null;
+  tenantId: string | null;
+  propertyId: string | null;
+  unitId: string | null;
+  propertyLabel: string | null;
+  unitLabel: string | null;
+  amount: number;
+  direction: FinancialProjectionDirection;
+  occurredAt: string;
+  displayLabel: string;
+  sourceBadge: string;
+}
+
 export type MoveInRequirementsStatus = "not-started" | "in-progress" | "complete" | "unknown";
 export type MoveInRequirementState = "complete" | "pending" | "not-required" | "unknown";
 export type MoveInRequirementKey =
@@ -224,6 +249,17 @@ export async function fetchTenantDetail(tenantId: string): Promise<TenantDetailB
 
   const res = await apiFetch<TenantDetailBundle>(`/tenants/${encodeURIComponent(tenantId)}`);
   return res;
+}
+
+export async function fetchTenantFinancialActivity(tenantId: string): Promise<FinancialProjectionRow[]> {
+  if (!tenantId) {
+    throw new Error("tenantId is required");
+  }
+
+  const res = await apiFetch<{ ok: true; data: { rows: FinancialProjectionRow[] } }>(
+    `/tenants/${encodeURIComponent(tenantId)}/financial-activity`
+  );
+  return Array.isArray(res?.data?.rows) ? res.data.rows : [];
 }
 
 export async function updateTenantMoveInReadiness(

--- a/rentchain-frontend/src/components/tenants/FinancialActivityPanel.test.tsx
+++ b/rentchain-frontend/src/components/tenants/FinancialActivityPanel.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { FinancialActivityPanel } from "./FinancialActivityPanel";
+import type { FinancialProjectionRow } from "@/api/tenantDetail";
+
+const rows: FinancialProjectionRow[] = [
+  {
+    id: "row-1",
+    sourceType: "recorded_payment",
+    sourceId: "payment-1",
+    leaseId: "lease-1",
+    tenantId: "tenant-1",
+    propertyId: "property-1",
+    unitId: "unit-1",
+    propertyLabel: "Harbour View",
+    unitLabel: "101",
+    amount: 1850,
+    direction: "credit",
+    occurredAt: "2026-04-03T10:00:00.000Z",
+    displayLabel: "Recorded payment (e-transfer)",
+    sourceBadge: "Recorded payment",
+  },
+  {
+    id: "row-2",
+    sourceType: "ledger_payment_unmatched",
+    sourceId: "ledger-2",
+    leaseId: "lease-1",
+    tenantId: "tenant-1",
+    propertyId: null,
+    unitId: null,
+    propertyLabel: null,
+    unitLabel: null,
+    amount: 1850,
+    direction: "credit",
+    occurredAt: "2026-04-02T10:00:00.000Z",
+    displayLabel: "Lease ledger payment (cash)",
+    sourceBadge: "Lease ledger payment",
+  },
+  {
+    id: "row-3",
+    sourceType: "lease_charge",
+    sourceId: "ledger-1",
+    leaseId: "lease-1",
+    tenantId: "tenant-1",
+    propertyId: "property-1",
+    unitId: "unit-1",
+    propertyLabel: "Harbour View",
+    unitLabel: "101",
+    amount: 1850,
+    direction: "debit",
+    occurredAt: "2026-04-01T10:00:00.000Z",
+    displayLabel: "Rent charge",
+    sourceBadge: "Lease charge",
+  },
+  {
+    id: "row-4",
+    sourceType: "lease_credit",
+    sourceId: "ledger-3",
+    leaseId: "lease-1",
+    tenantId: "tenant-1",
+    propertyId: "property-1",
+    unitId: "unit-1",
+    propertyLabel: "Harbour View",
+    unitLabel: "101",
+    amount: 50,
+    direction: "credit",
+    occurredAt: "2026-03-31T10:00:00.000Z",
+    displayLabel: "Lease credit",
+    sourceBadge: "Lease credit",
+  },
+];
+
+describe("FinancialActivityPanel", () => {
+  it("groups rows by source type with clear badge labels", () => {
+    render(<FinancialActivityPanel rows={rows} loading={false} error={null} />);
+
+    expect(screen.getByText("Financial activity")).toBeInTheDocument();
+    expect(screen.getByText("Recorded Payments")).toBeInTheDocument();
+    expect(screen.getByText("Lease Charges")).toBeInTheDocument();
+    expect(screen.getByText("Lease Credits")).toBeInTheDocument();
+    expect(screen.getByText("Unmatched Ledger Payments")).toBeInTheDocument();
+    expect(screen.getByText("Payment")).toBeInTheDocument();
+    expect(screen.getByText("Lease Charge")).toBeInTheDocument();
+    expect(screen.getByText("Credit")).toBeInTheDocument();
+    expect(screen.getByText("Unmatched Ledger Entry")).toBeInTheDocument();
+    expect(screen.getAllByText("Harbour View • Unit 101").length).toBeGreaterThan(0);
+  });
+
+  it("renders loading, error, and empty states without raw ids", () => {
+    const { rerender } = render(<FinancialActivityPanel rows={[]} loading={true} error={null} />);
+    expect(screen.getByText("Loading financial activity...")).toBeInTheDocument();
+
+    rerender(<FinancialActivityPanel rows={[]} loading={false} error={"boom"} />);
+    expect(screen.getByText("Could not load financial activity.")).toBeInTheDocument();
+
+    rerender(<FinancialActivityPanel rows={[]} loading={false} error={null} />);
+    expect(screen.getByText("No financial activity is available for this tenant yet.")).toBeInTheDocument();
+    expect(screen.queryByText("property-1")).not.toBeInTheDocument();
+    expect(screen.queryByText("unit-1")).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/tenants/FinancialActivityPanel.tsx
+++ b/rentchain-frontend/src/components/tenants/FinancialActivityPanel.tsx
@@ -1,0 +1,177 @@
+import React from "react";
+import { colors, radius, spacing, text } from "../../styles/tokens";
+import type { FinancialProjectionRow, FinancialProjectionSourceType } from "@/api/tenantDetail";
+
+type FinancialActivityPanelProps = {
+  rows: FinancialProjectionRow[];
+  loading: boolean;
+  error: string | null;
+};
+
+type FinancialActivityGroupKey = FinancialProjectionSourceType;
+
+const groupOrder: FinancialActivityGroupKey[] = [
+  "recorded_payment",
+  "lease_charge",
+  "lease_credit",
+  "ledger_payment_unmatched",
+];
+
+const groupLabels: Record<FinancialActivityGroupKey, string> = {
+  recorded_payment: "Recorded Payments",
+  lease_charge: "Lease Charges",
+  lease_credit: "Lease Credits",
+  ledger_payment_unmatched: "Unmatched Ledger Payments",
+};
+
+const badgeLabels: Record<FinancialActivityGroupKey, string> = {
+  recorded_payment: "Payment",
+  lease_charge: "Lease Charge",
+  lease_credit: "Credit",
+  ledger_payment_unmatched: "Unmatched Ledger Entry",
+};
+
+function toMillis(value: string): number {
+  const parsed = Date.parse(String(value || ""));
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function formatDateLabel(value: string) {
+  const parsed = new Date(String(value || ""));
+  if (Number.isNaN(parsed.getTime())) return "Unknown date";
+  return parsed.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function formatMoney(value: number, direction: "credit" | "debit") {
+  const magnitude = Math.abs(Number(value || 0));
+  const prefix = direction === "debit" ? "-" : "+";
+  return `${prefix}$${magnitude.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+function buildContextLabel(row: FinancialProjectionRow) {
+  const parts = [row.propertyLabel, row.unitLabel ? `Unit ${row.unitLabel}` : null].filter(Boolean);
+  return parts.length ? parts.join(" • ") : null;
+}
+
+export const FinancialActivityPanel: React.FC<FinancialActivityPanelProps> = ({
+  rows,
+  loading,
+  error,
+}) => {
+  const sortedRows = React.useMemo(
+    () =>
+      [...rows].sort((left, right) => {
+        const timeDiff = toMillis(right.occurredAt) - toMillis(left.occurredAt);
+        if (timeDiff !== 0) return timeDiff;
+        const typeDiff = groupOrder.indexOf(left.sourceType) - groupOrder.indexOf(right.sourceType);
+        if (typeDiff !== 0) return typeDiff;
+        return String(left.sourceId || left.id).localeCompare(String(right.sourceId || right.id));
+      }),
+    [rows]
+  );
+
+  const groupedRows = React.useMemo(() => {
+    const next = new Map<FinancialActivityGroupKey, FinancialProjectionRow[]>();
+    groupOrder.forEach((key) => next.set(key, []));
+    sortedRows.forEach((row) => {
+      next.get(row.sourceType)?.push(row);
+    });
+    return next;
+  }, [sortedRows]);
+
+  return (
+    <div
+      style={{
+        padding: spacing.md,
+        borderRadius: radius.md,
+        border: `1px solid ${colors.border}`,
+        background: colors.panel,
+        display: "grid",
+        gap: spacing.md,
+      }}
+    >
+      <div style={{ display: "grid", gap: 4 }}>
+        <div style={{ fontWeight: 700 }}>Financial activity</div>
+        <div style={{ color: text.muted, fontSize: "0.8rem" }}>
+          Read-only activity across recorded payments and current lease ledger items. Underlying records remain
+          separate.
+        </div>
+      </div>
+
+      {loading ? <div style={{ color: text.muted }}>Loading financial activity...</div> : null}
+      {!loading && error ? <div style={{ color: colors.danger, fontSize: "0.85rem" }}>Could not load financial activity.</div> : null}
+      {!loading && !error && sortedRows.length === 0 ? (
+        <div style={{ color: text.muted }}>No financial activity is available for this tenant yet.</div>
+      ) : null}
+
+      {!loading && !error && sortedRows.length > 0 ? (
+        <div style={{ display: "grid", gap: spacing.md }}>
+          {groupOrder.map((groupKey) => {
+            const items = groupedRows.get(groupKey) || [];
+            if (items.length === 0) return null;
+            return (
+              <section key={groupKey} style={{ display: "grid", gap: 8 }}>
+                <div style={{ fontWeight: 700, fontSize: "0.9rem" }}>{groupLabels[groupKey]}</div>
+                <div style={{ display: "grid", gap: 8 }}>
+                  {items.map((row) => {
+                    const contextLabel = buildContextLabel(row);
+                    return (
+                      <div
+                        key={row.id}
+                        style={{
+                          border: "1px solid rgba(148,163,184,0.35)",
+                          borderRadius: 10,
+                          padding: 12,
+                          background: "rgba(255,255,255,0.8)",
+                          display: "grid",
+                          gap: 6,
+                        }}
+                      >
+                        <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "start" }}>
+                          <div style={{ display: "grid", gap: 4 }}>
+                            <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+                              <div style={{ fontWeight: 700, fontSize: "0.88rem" }}>{row.displayLabel}</div>
+                              <span
+                                style={{
+                                  display: "inline-flex",
+                                  alignItems: "center",
+                                  padding: "2px 8px",
+                                  borderRadius: radius.pill,
+                                  border: `1px solid ${colors.border}`,
+                                  background: colors.card,
+                                  color: text.primary,
+                                  fontSize: "0.72rem",
+                                  fontWeight: 700,
+                                }}
+                              >
+                                {badgeLabels[groupKey]}
+                              </span>
+                            </div>
+                            {contextLabel ? <div style={{ color: text.muted, fontSize: "0.8rem" }}>{contextLabel}</div> : null}
+                          </div>
+                          <div style={{ display: "grid", gap: 4, justifyItems: "end", textAlign: "right" }}>
+                            <div style={{ fontWeight: 700, color: row.direction === "debit" ? text.primary : "#047857" }}>
+                              {formatMoney(row.amount, row.direction)}
+                            </div>
+                            <div style={{ color: text.muted, fontSize: "0.8rem" }}>{formatDateLabel(row.occurredAt)}</div>
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </section>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+};

--- a/rentchain-frontend/src/components/tenants/TenantDetailPanel.test.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantDetailPanel.test.tsx
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   useTenantDetail: vi.fn(),
   fetchLedger: vi.fn(),
   fetchLeaseLedger: vi.fn(),
+  fetchTenantFinancialActivity: vi.fn(),
   getTenantSignals: vi.fn(),
   showToast: vi.fn(),
 }));
@@ -21,6 +22,11 @@ vi.mock("@/api/ledgerApi", () => ({
 
 vi.mock("@/api/leaseLedgerApi", () => ({
   fetchLeaseLedger: mocks.fetchLeaseLedger,
+}));
+
+vi.mock("@/api/tenantDetail", () => ({
+  fetchTenantFinancialActivity: mocks.fetchTenantFinancialActivity,
+  updateTenantMoveInReadiness: vi.fn(),
 }));
 
 vi.mock("@/api/tenantSignals", () => ({
@@ -90,6 +96,24 @@ describe("TenantDetailPanel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.getTenantSignals.mockResolvedValue({ signals: null });
+    mocks.fetchTenantFinancialActivity.mockResolvedValue([
+      {
+        id: "row-1",
+        sourceType: "recorded_payment",
+        sourceId: "payment-1",
+        leaseId: "lease-1",
+        tenantId: "tenant-1",
+        propertyId: "property-1",
+        unitId: "unit-1",
+        propertyLabel: "Harbour View",
+        unitLabel: "101",
+        amount: 1850,
+        direction: "credit",
+        occurredAt: "2026-04-03T10:00:00.000Z",
+        displayLabel: "Recorded payment (e-transfer)",
+        sourceBadge: "Recorded payment",
+      },
+    ]);
     mocks.fetchLedger.mockResolvedValue([]);
     mocks.fetchLeaseLedger.mockResolvedValue({
       ok: true,
@@ -160,8 +184,12 @@ describe("TenantDetailPanel", () => {
     expect(screen.queryByRole("button", { name: "Verify ledger" })).not.toBeInTheDocument();
     expect(screen.getByText(/Charge · rent/i)).toBeInTheDocument();
     expect(screen.getByText(/Balance .*1,850\.00/i)).toBeInTheDocument();
+    expect(await screen.findByText("Financial activity")).toBeInTheDocument();
+    expect(screen.getByText("Recorded Payments")).toBeInTheDocument();
+    expect(screen.getByText("Recorded payment (e-transfer)")).toBeInTheDocument();
     expect(screen.getByText("Tenant activity panel")).toBeInTheDocument();
     await waitFor(() => expect(mocks.fetchLeaseLedger).toHaveBeenCalledWith("lease-1"));
+    await waitFor(() => expect(mocks.fetchTenantFinancialActivity).toHaveBeenCalledWith("tenant-1"));
     expect(mocks.fetchLedger).not.toHaveBeenCalled();
   });
 
@@ -207,5 +235,6 @@ describe("TenantDetailPanel", () => {
 
     expect(await screen.findByText(/No current lease is linked, so this view is showing the existing tenant-level ledger source\./i)).toBeInTheDocument();
     await waitFor(() => expect(mocks.fetchLedger).toHaveBeenCalledWith({ tenantId: "tenant-1", limit: 50 }));
+    await waitFor(() => expect(mocks.fetchTenantFinancialActivity).toHaveBeenCalledWith("tenant-1"));
   });
 });

--- a/rentchain-frontend/src/components/tenants/TenantDetailPanel.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantDetailPanel.tsx
@@ -3,7 +3,12 @@ import React, { useEffect, useState, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { useTenantDetail } from "../../hooks/useTenantDetail";
 import { downloadTenantReport } from "@/api/tenantsApi";
-import { updateTenantMoveInReadiness, type MoveInReadiness } from "@/api/tenantDetail";
+import {
+  fetchTenantFinancialActivity,
+  updateTenantMoveInReadiness,
+  type FinancialProjectionRow,
+  type MoveInReadiness,
+} from "@/api/tenantDetail";
 import { getTenantSignals, type TenantSignals } from "@/api/tenantSignals";
 import { fetchLedger } from "@/api/ledgerApi";
 import { fetchLeaseLedger, type LeaseLedgerEntry } from "@/api/leaseLedgerApi";
@@ -21,6 +26,7 @@ import { useAuth } from "@/context/useAuth";
 import { CredibilityInsightsCard } from "./CredibilityInsightsCard";
 import { MoveInReadinessPanel } from "./MoveInReadinessPanel";
 import { TenantActivityPanel } from "./TenantActivityPanel";
+import { FinancialActivityPanel } from "./FinancialActivityPanel";
 import { FeatureGate } from "@/components/billing/FeatureGate";
 import { LockedFeature } from "@/components/billing/LockedFeature";
 
@@ -140,6 +146,9 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
   const [ledgerMode, setLedgerMode] = useState<"lease" | "tenant">("tenant");
   const [ledgerLoading, setLedgerLoading] = useState(false);
   const [ledgerError, setLedgerError] = useState<string | null>(null);
+  const [financialActivityRows, setFinancialActivityRows] = useState<FinancialProjectionRow[]>([]);
+  const [financialActivityLoading, setFinancialActivityLoading] = useState(false);
+  const [financialActivityError, setFinancialActivityError] = useState<string | null>(null);
   const cancelledRef = useRef(false);
 
   const [signals, setSignals] = useState<TenantSignals | null>(null);
@@ -235,6 +244,42 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
       cancelledRef.current = true;
     };
   }, [loadLedger]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadFinancialActivity() {
+      if (!tenantId) {
+        setFinancialActivityRows([]);
+        setFinancialActivityLoading(false);
+        setFinancialActivityError(null);
+        return;
+      }
+
+      try {
+        setFinancialActivityLoading(true);
+        setFinancialActivityError(null);
+        const rows = await fetchTenantFinancialActivity(tenantId);
+        if (!cancelled) {
+          setFinancialActivityRows(Array.isArray(rows) ? rows : []);
+        }
+      } catch (err: any) {
+        if (!cancelled) {
+          setFinancialActivityRows([]);
+          setFinancialActivityError(err?.message || "Failed to load financial activity");
+        }
+      } finally {
+        if (!cancelled) {
+          setFinancialActivityLoading(false);
+        }
+      }
+    }
+
+    void loadFinancialActivity();
+    return () => {
+      cancelled = true;
+    };
+  }, [tenantId]);
 
   const handleDownloadReport = async () => {
     if (!canExportPdf) {
@@ -665,6 +710,12 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
           <div style={{ opacity: 0.75 }}>No signals yet.</div>
         )}
       </div>
+
+      <FinancialActivityPanel
+        rows={financialActivityRows}
+        loading={financialActivityLoading}
+        error={financialActivityError}
+      />
 
       {/* Ledger timeline */}
       <div


### PR DESCRIPTION
This PR adds landlord-facing financial activity visibility to tenant profiles.

Includes:
- frontend financial activity API helper
- new read-only Financial Activity panel
- grouped projected rows for recorded payments, lease charges, lease credits, and unmatched ledger payments
- clear source badges
- property/unit label display
- loading, error, and empty states
- focused frontend test coverage

Guardrails preserved:
- frontend-only
- no backend/API changes
- no /api/payments changes
- no lease ledger route changes
- no tenant activity changes
- no data mutation
- no source merging
- no payment/provider changes

PR note:
- FinancialActivityPanel tests passed: 2 tests.
- TenantDetailPanel tests passed: 2 tests.
- Frontend build passed.
- Existing chunk-size warning remains unchanged and out of scope.
- /payments page alignment, Tenant Summary PDF projection consumption, backend/API changes, ledger/payment conversions, tenant activity write-path unification, and 2026 ledger-only payment backfill remain deferred.