### PR TITLE
fix: clarify recorded payments surface

### DIFF
--- a/rentchain-frontend/src/components/tenants/TenantPaymentsPanel.test.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantPaymentsPanel.test.tsx
@@ -45,7 +45,7 @@ describe("TenantPaymentsPanel", () => {
 
     expect(
       screen.getByText(
-        "Only recorded rent payments appear here. Lease ledger charges and credits are shown in the current lease ledger section."
+        "Only recorded rent payments appear here. Lease charges, credits, and unmatched ledger entries appear in Financial activity and the current lease ledger."
       )
     ).toBeInTheDocument();
 

--- a/rentchain-frontend/src/components/tenants/TenantPaymentsPanel.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantPaymentsPanel.tsx
@@ -151,7 +151,7 @@ export function TenantPaymentsPanel({ tenantId }: Props) {
             Last payment: {lastPayment ? formatDate((lastPayment as any).paidAt) : "--"}
           </div>
           <div style={{ fontSize: 12, opacity: 0.78, marginTop: 4 }}>
-            Only recorded rent payments appear here. Lease ledger charges and credits are shown in the current lease ledger section.
+            Only recorded rent payments appear here. Lease charges, credits, and unmatched ledger entries appear in Financial activity and the current lease ledger.
           </div>
         </div>
 

--- a/rentchain-frontend/src/pages/PaymentsPage.test.tsx
+++ b/rentchain-frontend/src/pages/PaymentsPage.test.tsx
@@ -58,14 +58,29 @@ describe("PaymentsPage", () => {
     });
   });
 
-  it("renders export controls and payment labels", async () => {
+  it("renders the recorded-payments framing, explainer, and export controls", async () => {
     render(<PaymentsPage />);
 
+    expect(screen.getByText("Payments (recorded)")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "This page shows recorded rent payments only. Lease charges, credits, and unmatched ledger entries appear in tenant Financial activity and lease ledger views."
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText("Financial Activity")).toBeInTheDocument();
+    expect(screen.getByText("Recorded payments track money entered in the payments system.")).toBeInTheDocument();
+    expect(
+      screen.getByText("Lease ledger activity tracks charges, credits, and unmatched ledger entries separately.")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("These views are intentionally separate to avoid double counting and preserve audit integrity.")
+    ).toBeInTheDocument();
     expect(await screen.findByRole("button", { name: "Export CSV" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Export Spreadsheet" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Export PDF" })).toBeInTheDocument();
     expect((await screen.findAllByText("Taylor Tenant")).length).toBeGreaterThan(0);
     expect(screen.getAllByText("123 Main St").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("e-transfer").length).toBeGreaterThan(0);
   });
 
   it("routes PDF export through the shared print helper", async () => {

--- a/rentchain-frontend/src/pages/PaymentsPage.tsx
+++ b/rentchain-frontend/src/pages/PaymentsPage.tsx
@@ -146,7 +146,7 @@ const PaymentsPage: React.FC = () => {
       <Card elevated>
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: spacing.md }}>
           <div>
-            <h1 style={{ fontSize: "1.4rem", fontWeight: 700, margin: 0, color: text.primary }}>Payments</h1>
+            <h1 style={{ fontSize: "1.4rem", fontWeight: 700, margin: 0, color: text.primary }}>Payments (recorded)</h1>
             <div
               style={{
                 marginTop: "0.1rem",
@@ -154,7 +154,7 @@ const PaymentsPage: React.FC = () => {
                 color: text.muted,
               }}
             >
-              All recorded payments across tenants and properties.
+              This page shows recorded rent payments only. Lease charges, credits, and unmatched ledger entries appear in tenant Financial activity and lease ledger views.
             </div>
           </div>
           <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap", justifyContent: "flex-end" }}>
@@ -165,6 +165,21 @@ const PaymentsPage: React.FC = () => {
               {exporting === "xlsx" ? "Exporting..." : "Export Spreadsheet"}
             </Button>
             <Button variant="secondary" onClick={() => void printSummaryDocument("summary")}>Export PDF</Button>
+          </div>
+        </div>
+      </Card>
+
+      <Card>
+        <div style={{ display: "grid", gap: spacing.xs }}>
+          <div style={{ fontSize: "1rem", fontWeight: 700, color: text.primary }}>Financial Activity</div>
+          <div style={{ fontSize: "0.92rem", color: text.primary }}>
+            Recorded payments track money entered in the payments system.
+          </div>
+          <div style={{ fontSize: "0.92rem", color: text.primary }}>
+            Lease ledger activity tracks charges, credits, and unmatched ledger entries separately.
+          </div>
+          <div style={{ fontSize: "0.92rem", color: text.muted }}>
+            These views are intentionally separate to avoid double counting and preserve audit integrity.
           </div>
         </div>
       </Card>


### PR DESCRIPTION
This PR clarifies the recorded payments surface.

Includes:
- /payments title updated to Payments (recorded)
- copy explaining recorded payments vs lease ledger activity
- Financial Activity explainer on /payments
- Tenant Payments panel copy clarified
- focused frontend test coverage

Guardrails preserved:
- frontend-only
- no backend/API changes
- no /api/payments source changes
- no projection rows injected into payments surfaces
- no ledger route changes
- no tenant activity changes
- no data mutation
- no source merging
- no payment/provider changes

PR note:
- PaymentsPage tests passed: 3 tests.
- TenantPaymentsPanel tests passed: 2 tests.
- Frontend build passed.
- Existing chunk-size warning remains unchanged and out of scope.
- Deferred: /payments financial-activity tab, Tenant Summary PDF projection consumption, ledger/payment conversions, tenant activity write-path unification, and 2026 ledger-only payment backfill.