### PR TITLE
fix: clean up export labels and financial presentation

### DIFF
--- a/rentchain-api/src/lib/exports/__tests__/exportResponse.test.ts
+++ b/rentchain-api/src/lib/exports/__tests__/exportResponse.test.ts
@@ -18,7 +18,7 @@ describe("exportResponse", () => {
 
   it("returns the expected export content types", () => {
     expect(getExportContentType("csv")).toBe("text/csv; charset=utf-8");
-    expect(getExportContentType("xlsx")).toBe("application/vnd.ms-excel; charset=utf-8");
+    expect(getExportContentType("xls")).toBe("application/vnd.ms-excel; charset=utf-8");
     expect(getExportContentType("pdf")).toBe("application/pdf");
   });
 

--- a/rentchain-api/src/lib/exports/exportResponse.ts
+++ b/rentchain-api/src/lib/exports/exportResponse.ts
@@ -1,4 +1,4 @@
-export type ExportFormat = "csv" | "xlsx" | "pdf";
+export type ExportFormat = "csv" | "xls" | "pdf";
 
 function isoDateStamp(date: Date): string {
   return date.toISOString().slice(0, 10);
@@ -17,7 +17,7 @@ export function getExportContentType(format: ExportFormat): string {
   switch (format) {
     case "csv":
       return "text/csv; charset=utf-8";
-    case "xlsx":
+    case "xls":
       return "application/vnd.ms-excel; charset=utf-8";
     case "pdf":
       return "application/pdf";

--- a/rentchain-api/src/routes/__tests__/expensesRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/expensesRoutes.test.ts
@@ -233,4 +233,37 @@ describe("expenses routes", () => {
     expect(res.text).toContain("Alpha Property");
     expect(res.text).toContain("125.00");
   });
+
+  it("exports spreadsheet xml with human property and unit labels", async () => {
+    setPlan("pro");
+    seedDoc("units", "unit-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitNumber: "12A",
+    });
+    seedDoc("expenses", "expense-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      category: "Repairs",
+      vendorName: "FixIt",
+      amountCents: 12500,
+      incurredAtMs: Date.parse("2026-03-01T00:00:00.000Z"),
+      notes: "Pipe repair",
+      status: "recorded",
+      source: "manual",
+    });
+    const app = await createApp();
+    const res = await request(app).get("/api/expenses/export.xlsx");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toContain("application/vnd.ms-excel");
+    expect(String(res.headers["content-disposition"] || "")).toMatch(
+      /^attachment; filename="rentchain-expenses-\d{4}-\d{2}-\d{2}\.xls"$/
+    );
+    expect(res.text).toContain("Alpha Property");
+    expect(res.text).toContain("12A");
+    expect(res.text).not.toContain("prop-1");
+    expect(res.text).not.toContain("unit-1");
+  });
 });

--- a/rentchain-api/src/routes/__tests__/paymentsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/paymentsRoutes.test.ts
@@ -172,7 +172,7 @@ describe("paymentsRoutes exports", () => {
     expect(res.status).toBe(200);
     expect(res.headers["content-type"]).toContain("application/vnd.ms-excel");
     expect(res.headers["content-disposition"]).toMatch(
-      /^attachment; filename="rentchain-payments-\d{4}-\d{2}-\d{2}\.xlsx"$/
+      /^attachment; filename="rentchain-payments-\d{4}-\d{2}-\d{2}\.xls"$/
     );
     expect(String(res.body)).toContain("Taylor Tenant");
     expect(String(res.body)).toContain("123 Main St");

--- a/rentchain-api/src/routes/__tests__/workOrdersRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/workOrdersRoutes.test.ts
@@ -213,6 +213,11 @@ describe("workOrdersRoutes execution completion", () => {
       landlordId: "landlord-1",
       name: "123 Main St",
     });
+    ensureCollection("units").set("unit-1", {
+      id: "unit-1",
+      propertyId: "prop-1",
+      unitNumber: "4B",
+    });
   });
 
   it("writes structured metadata when a landlord completes an in-house work order", async () => {
@@ -1241,5 +1246,37 @@ describe("workOrdersRoutes execution completion", () => {
     expect(String(res.body)).toContain("Landlord confirmed the service window.");
     expect(String(res.body)).not.toContain("https://example.com/photo.jpg");
     expect(String(res.body)).not.toContain("https://example.com/invoice.pdf");
+  });
+
+  it("exports spreadsheet xml with human property and unit labels", async () => {
+    const router = (await import("../workOrdersRoutes")).default;
+    ensureCollection("workOrders").set("wo-1", {
+      ...ensureCollection("workOrders").get("wo-1"),
+      unitId: "unit-1",
+      status: "completed",
+      completionSummary: "Heat restored and tested.",
+    });
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/work-orders/export.xlsx",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "landlord-1",
+          role: "landlord",
+          landlordId: "landlord-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toContain("application/vnd.ms-excel");
+    expect(String(res.headers["content-disposition"] || "")).toMatch(
+      /^attachment; filename="rentchain-work-orders-\d{4}-\d{2}-\d{2}\.xls"$/
+    );
+    expect(String(res.body)).toContain("123 Main St");
+    expect(String(res.body)).toContain("4B");
+    expect(String(res.body)).not.toContain("prop-1");
+    expect(String(res.body)).not.toContain("unit-1");
   });
 });

--- a/rentchain-api/src/routes/expensesRoutes.ts
+++ b/rentchain-api/src/routes/expensesRoutes.ts
@@ -117,6 +117,19 @@ function landlordIdFromReq(req: any): string {
   return String(req.user?.landlordId || req.user?.id || "").trim();
 }
 
+function resolvePropertyLabel(raw: any): string {
+  return (
+    String(raw?.name || raw?.addressLine1 || raw?.address || raw?.displayName || raw?.propertyName || "").trim() ||
+    "Property"
+  );
+}
+
+function resolveUnitLabel(raw: any): string {
+  return (
+    String(raw?.unitNumber || raw?.name || raw?.label || raw?.displayLabel || raw?.unitLabel || "").trim() || "Unit"
+  );
+}
+
 async function getExpenseEntitlements(req: any) {
   const userId = String(req.user?.id || "").trim();
   return getUserEntitlements(userId, {
@@ -610,11 +623,19 @@ async function listExpensesForRequest(req: any, options: ExpenseQueryOptions = {
   return { ok: true as const, items };
 }
 
-function buildExpenseExportRows(items: any[], propertyNames: Map<string, string>) {
+async function buildExpenseExportRows(items: any[], propertyNames: Map<string, string>) {
+  const unitIds = Array.from(new Set(items.map((item: any) => String(item.unitId || "").trim()).filter(Boolean)));
+  const unitSnaps = await Promise.all(unitIds.map((id) => db.collection("units").doc(id).get()));
+  const unitLabels = new Map<string, string>();
+  unitSnaps.forEach((snap) => {
+    if (!snap.exists) return;
+    unitLabels.set(snap.id, resolveUnitLabel(snap.data() as any));
+  });
+
   return items.map((item: any) => ({
     date: toIsoDateFromMs(Number(item.incurredAtMs || 0)),
-    property: propertyNames.get(String(item.propertyId || "")) || String(item.propertyId || ""),
-    unit: String(item.unitId || ""),
+    property: propertyNames.get(String(item.propertyId || "").trim()) || "Property",
+    unit: item.unitId ? unitLabels.get(String(item.unitId || "").trim()) || "Unit" : "",
     category: String(item.category || ""),
     vendor: String(item.vendorName || ""),
     description: String(item.notes || ""),
@@ -1419,9 +1440,9 @@ router.get("/expenses/export.csv", requireAuth, async (req: any, res) => {
     propertySnaps.forEach((snap) => {
       if (!snap.exists) return;
       const data = snap.data() as any;
-      propertyNames.set(snap.id, String(data?.name || data?.addressLine1 || data?.address || snap.id));
+      propertyNames.set(snap.id, resolvePropertyLabel(data));
     });
-    const rows = buildExpenseExportRows(result.items, propertyNames);
+    const rows = await buildExpenseExportRows(result.items, propertyNames);
     const csv = [
       ["date", "property", "unit", "category", "vendor", "description", "amount", "status", "source"].join(","),
       ...rows.map((row) =>
@@ -1460,15 +1481,15 @@ router.get("/expenses/export.xlsx", requireAuth, async (req: any, res) => {
     propertySnaps.forEach((snap) => {
       if (!snap.exists) return;
       const data = snap.data() as any;
-      propertyNames.set(snap.id, String(data?.name || data?.addressLine1 || data?.address || snap.id));
+      propertyNames.set(snap.id, resolvePropertyLabel(data));
     });
-    const rows = buildExpenseExportRows(result.items, propertyNames);
+    const rows = await buildExpenseExportRows(result.items, propertyNames);
     const totalAmountCents = result.items.reduce((sum: number, item: any) => sum + Number(item.amountCents || 0), 0);
     const xml = renderExpenseSpreadsheetXml(rows, totalAmountCents);
 
     setAttachmentExportHeaders(res, {
-      filename: buildDatedExportFilename({ prefix: "rentchain-expenses", format: "xlsx" }),
-      format: "xlsx",
+      filename: buildDatedExportFilename({ prefix: "rentchain-expenses", format: "xls" }),
+      format: "xls",
     });
     return res.status(200).send(xml);
   } catch (err: any) {
@@ -1495,9 +1516,9 @@ router.get("/expenses/export.pdf", requireAuth, async (req: any, res) => {
     propertySnaps.forEach((snap) => {
       if (!snap.exists) return;
       const data = snap.data() as any;
-      propertyNames.set(snap.id, String(data?.name || data?.addressLine1 || data?.address || snap.id));
+      propertyNames.set(snap.id, resolvePropertyLabel(data));
     });
-    const rows = buildExpenseExportRows(result.items, propertyNames);
+    const rows = await buildExpenseExportRows(result.items, propertyNames);
     const totalAmountCents = result.items.reduce((sum: number, item: any) => sum + Number(item.amountCents || 0), 0);
     const propertyLabel = String(req.query?.propertyId || "").trim();
     const subtitle = [

--- a/rentchain-api/src/routes/maintenanceRequestsRoutes.ts
+++ b/rentchain-api/src/routes/maintenanceRequestsRoutes.ts
@@ -128,6 +128,58 @@ function optionalString(value: unknown, max = 1000): string | null {
   return next || null;
 }
 
+function resolvePropertyLabel(raw: any): string {
+  return (
+    String(raw?.name || raw?.addressLine1 || raw?.address || raw?.displayName || raw?.propertyName || "").trim() ||
+    "Property"
+  );
+}
+
+function resolveUnitLabel(raw: any): string {
+  return (
+    String(raw?.unitNumber || raw?.name || raw?.label || raw?.displayLabel || raw?.unitLabel || "").trim() || "Unit"
+  );
+}
+
+async function normalizeLandlordMaintenanceLabels(items: any[]) {
+  const propertyIds = Array.from(new Set(items.map((item) => String(item?.propertyId || "").trim()).filter(Boolean)));
+  const unitIds = Array.from(new Set(items.map((item) => String(item?.unitId || "").trim()).filter(Boolean)));
+  const [propertySnaps, unitSnaps] = await Promise.all([
+    Promise.all(propertyIds.map((id) => db.collection("properties").doc(id).get())),
+    Promise.all(unitIds.map((id) => db.collection("units").doc(id).get())),
+  ]);
+
+  const propertyLabels = new Map<string, string>();
+  propertySnaps.forEach((snap) => {
+    if (!snap.exists) return;
+    propertyLabels.set(snap.id, resolvePropertyLabel(snap.data() as any));
+  });
+
+  const unitLabels = new Map<string, string>();
+  unitSnaps.forEach((snap) => {
+    if (!snap.exists) return;
+    unitLabels.set(snap.id, resolveUnitLabel(snap.data() as any));
+  });
+
+  return items.map((item) => {
+    const propertyId = String(item?.propertyId || "").trim();
+    const unitId = String(item?.unitId || "").trim();
+    const currentPropertyLabel = String(item?.propertyLabel || "").trim();
+    const currentUnitLabel = String(item?.unitLabel || "").trim();
+    return {
+      ...item,
+      propertyLabel:
+        (currentPropertyLabel && currentPropertyLabel !== propertyId ? currentPropertyLabel : "") ||
+        propertyLabels.get(propertyId) ||
+        "Property",
+      unitLabel:
+        (currentUnitLabel && currentUnitLabel !== unitId ? currentUnitLabel : "") ||
+        unitLabels.get(unitId) ||
+        (unitId ? "Unit" : ""),
+    };
+  });
+}
+
 function landlordIdOf(req: any): string | null {
   return String(req.user?.landlordId || req.user?.id || "").trim() || null;
 }
@@ -1486,6 +1538,7 @@ router.get("/landlord/maintenance", async (req: any, res) => {
     if (statusFilter) {
       items = items.filter((item) => normalizeWorkflowStatus(item.status) === statusFilter);
     }
+    items = await normalizeLandlordMaintenanceLabels(items);
     items.sort((a, b) => Number(b.updatedAt || 0) - Number(a.updatedAt || 0));
     return res.json({ ok: true, items, data: items });
   } catch (err: any) {

--- a/rentchain-api/src/routes/paymentsRoutes.ts
+++ b/rentchain-api/src/routes/paymentsRoutes.ts
@@ -31,6 +31,22 @@ const xmlEscape = (value: unknown) =>
 
 const roleForReq = (req: any) => String(req.user?.actorRole || req.user?.role || "").trim().toLowerCase();
 
+function resolveTenantLabel(raw: any): string {
+  return (
+    String(raw?.fullName || raw?.name || raw?.displayName || "").trim() ||
+    [String(raw?.firstName || "").trim(), String(raw?.lastName || "").trim()].filter(Boolean).join(" ") ||
+    String(raw?.email || "").trim() ||
+    "Tenant"
+  );
+}
+
+function resolvePropertyLabel(raw: any): string {
+  return (
+    String(raw?.name || raw?.addressLine1 || raw?.address || raw?.displayName || raw?.propertyName || "").trim() ||
+    "Property"
+  );
+}
+
 function toMillis(value: any): number | null {
   if (value == null) return null;
   if (typeof value === "number") return value;
@@ -110,19 +126,14 @@ async function buildPaymentLabelMaps(payments: Payment[]) {
   tenantSnaps.forEach((snap) => {
     if (!snap.exists) return;
     const data = snap.data() as any;
-    const label =
-      String(data?.fullName || data?.name || data?.displayName || "").trim()
-      || [String(data?.firstName || "").trim(), String(data?.lastName || "").trim()].filter(Boolean).join(" ")
-      || "Tenant";
-    tenantLabels.set(snap.id, label);
+    tenantLabels.set(snap.id, resolveTenantLabel(data));
   });
 
   const propertyLabels = new Map<string, string>();
   propertySnaps.forEach((snap) => {
     if (!snap.exists) return;
     const data = snap.data() as any;
-    const label = String(data?.name || data?.addressLine1 || data?.address || "").trim() || "Property";
-    propertyLabels.set(snap.id, label);
+    propertyLabels.set(snap.id, resolvePropertyLabel(data));
   });
 
   return { tenantLabels, propertyLabels };
@@ -223,8 +234,8 @@ router.get("/payments/export.xlsx", requireAuth, async (req: any, res: Response)
     const xml = renderPaymentSpreadsheetXml(rows);
 
     setAttachmentExportHeaders(res, {
-      filename: buildDatedExportFilename({ prefix: "rentchain-payments", format: "xlsx" }),
-      format: "xlsx",
+      filename: buildDatedExportFilename({ prefix: "rentchain-payments", format: "xls" }),
+      format: "xls",
     });
     return res.status(200).send(xml);
   } catch (err) {

--- a/rentchain-api/src/routes/workOrdersRoutes.ts
+++ b/rentchain-api/src/routes/workOrdersRoutes.ts
@@ -95,6 +95,16 @@ function asOptionalString(value: unknown, max = 2000): string | null {
   return v || null;
 }
 
+function resolvePropertyLabel(raw: any): string {
+  return (
+    asString(raw?.name || raw?.addressLine1 || raw?.address || raw?.displayName || raw?.propertyName, 200) || "Property"
+  );
+}
+
+function resolveUnitLabel(raw: any): string {
+  return asString(raw?.unitNumber || raw?.name || raw?.label || raw?.displayLabel || raw?.unitLabel, 120) || "Unit";
+}
+
 function isAutomationRequested(body: any) {
   return Boolean(body?.automationEnabled || body?.automation?.enabled);
 }
@@ -741,12 +751,19 @@ async function listLandlordWorkOrdersForExport(req: any) {
 
 async function buildWorkOrderExportRows(items: any[]) {
   const propertyIds = Array.from(new Set(items.map((item) => asString(item.propertyId, 120)).filter(Boolean)));
+  const unitIds = Array.from(new Set(items.map((item) => asString(item.unitId, 120)).filter(Boolean)));
   const propertySnaps = await Promise.all(propertyIds.map((id) => db.collection("properties").doc(id).get()));
+  const unitSnaps = await Promise.all(unitIds.map((id) => db.collection("units").doc(id).get()));
   const propertyLabels = new Map<string, string>();
   propertySnaps.forEach((snap) => {
     if (!snap.exists) return;
     const data = snap.data() as any;
-    propertyLabels.set(snap.id, asString(data?.name || data?.addressLine1 || data?.address, 200) || "Property");
+    propertyLabels.set(snap.id, resolvePropertyLabel(data));
+  });
+  const unitLabels = new Map<string, string>();
+  unitSnaps.forEach((snap) => {
+    if (!snap.exists) return;
+    unitLabels.set(snap.id, resolveUnitLabel(snap.data() as any));
   });
 
   const latestComments = new Map<string, string>();
@@ -764,8 +781,14 @@ async function buildWorkOrderExportRows(items: any[]) {
 
   return items.map((item) => ({
     title: asString(item.title, 200),
-    property: propertyLabels.get(asString(item.propertyId, 120)) || "Property",
-    unit: "",
+    property:
+      (asString(item.propertyLabel, 200) && asString(item.propertyLabel, 200) !== asString(item.propertyId, 120)
+        ? asString(item.propertyLabel, 200)
+        : "") || propertyLabels.get(asString(item.propertyId, 120)) || "Property",
+    unit:
+      (asString(item.unitLabel, 120) && asString(item.unitLabel, 120) !== asString(item.unitId, 120)
+        ? asString(item.unitLabel, 120)
+        : "") || unitLabels.get(asString(item.unitId, 120)) || (asString(item.unitId, 120) ? "Unit" : ""),
     category: asString(item.category, 120),
     priority: asString(item.priority, 40),
     status: asString(item.status, 40),
@@ -1545,8 +1568,8 @@ router.get("/work-orders/export.xlsx", requireAuth, async (req: any, res) => {
     const xml = renderWorkOrderSpreadsheetXml(rows);
 
     setAttachmentExportHeaders(res, {
-      filename: buildDatedExportFilename({ prefix: "rentchain-work-orders", format: "xlsx" }),
-      format: "xlsx",
+      filename: buildDatedExportFilename({ prefix: "rentchain-work-orders", format: "xls" }),
+      format: "xls",
     });
     return res.status(200).send(xml);
   } catch (err) {

--- a/rentchain-api/src/services/tenantReportService.ts
+++ b/rentchain-api/src/services/tenantReportService.ts
@@ -592,11 +592,11 @@ export async function generateTenantReportPdfBuffer(
       doc.fontSize(11).text("No financial activity is available for this tenant yet.").moveDown(0.5);
     } else {
       const columns = [
-        { label: "Date", x: PDF_LEFT, width: 70 },
-        { label: "Activity", x: 114, width: 162 },
-        { label: "Context", x: 282, width: 132 },
-        { label: "Amount", x: 420, width: 56 },
-        { label: "Source", x: 482, width: 62 },
+        { label: "Date", x: PDF_LEFT, width: 64 },
+        { label: "Activity", x: 110, width: 142 },
+        { label: "Context", x: 258, width: 162 },
+        { label: "Amount", x: 426, width: 52 },
+        { label: "Source", x: 484, width: 60 },
       ];
 
       projectionGroupOrder.forEach((groupKey) => {
@@ -638,7 +638,7 @@ export async function generateTenantReportPdfBuffer(
           }
 
           const rowY = doc.y;
-          doc.fontSize(10).fillColor("#000000");
+          doc.fontSize(9.5).fillColor("#000000");
           doc.text(rowValues.date, columns[0].x, rowY, { width: columns[0].width });
           doc.text(rowValues.activity, columns[1].x, rowY, { width: columns[1].width });
           doc.text(rowValues.context, columns[2].x, rowY, { width: columns[2].width });

--- a/rentchain-frontend/src/components/tenants/TenantDetailPanel.test.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantDetailPanel.test.tsx
@@ -173,8 +173,9 @@ describe("TenantDetailPanel", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText("Current lease ledger")).toBeInTheDocument();
-    expect(screen.getByText("Charges and payments from the current lease ledger.")).toBeInTheDocument();
+    expect(await screen.findByText("Recent current lease ledger entries")).toBeInTheDocument();
+    expect(screen.getByText("Showing the most recent charges and payments from the current lease ledger.")).toBeInTheDocument();
+    expect(screen.getByText("Showing the latest 10 entries here. Open current lease ledger for the full history.")).toBeInTheDocument();
     expect(
       screen.getByText(
         "Tenant activity is recorded separately and does not add charges or payments to the current lease ledger."

--- a/rentchain-frontend/src/components/tenants/TenantDetailPanel.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantDetailPanel.tsx
@@ -47,6 +47,8 @@ const riskBorderMap: Record<string, string> = {
   HIGH: "1px solid rgba(239,68,68,0.55)",
 };
 
+const RECENT_LEASE_LEDGER_ENTRY_LIMIT = 10;
+
 function formatDateLabel(value?: string | number | null) {
   if (!value) return "--";
   const parsed = new Date(typeof value === "number" ? value : String(value));
@@ -738,13 +740,18 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
           }}
         >
           <div style={{ display: "grid", gap: 2 }}>
-            <span>Current lease ledger</span>
+            <span>Recent current lease ledger entries</span>
             <span style={{ color: text.muted, fontSize: "0.75rem", fontWeight: 400 }}>
-              Charges and payments from the current lease ledger.
+              Showing the most recent charges and payments from the current lease ledger.
             </span>
             <span style={{ color: text.muted, fontSize: "0.75rem", fontWeight: 400 }}>
               Tenant activity is recorded separately and does not add charges or payments to the current lease ledger.
             </span>
+            {ledgerMode === "lease" ? (
+              <span style={{ color: text.muted, fontSize: "0.75rem", fontWeight: 400 }}>
+                Showing the latest {RECENT_LEASE_LEDGER_ENTRY_LIMIT} entries here. Open current lease ledger for the full history.
+              </span>
+            ) : null}
             {ledgerMode === "tenant" ? (
               <span style={{ color: text.muted, fontSize: "0.75rem", fontWeight: 400 }}>
                 No current lease is linked, so this view is showing the existing tenant-level ledger source.
@@ -780,7 +787,7 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
               <div style={{ color: text.muted }}>No ledger entries for the current lease yet.</div>
             ) : (
               <div style={{ display: "grid", gap: 8 }}>
-                {leaseLedgerItems.slice(0, 6).map((entry) => (
+                {leaseLedgerItems.slice(0, RECENT_LEASE_LEDGER_ENTRY_LIMIT).map((entry) => (
                   <div
                     key={entry.id}
                     style={{

--- a/rentchain-frontend/src/pages/MaintenanceRequestsPage.test.tsx
+++ b/rentchain-frontend/src/pages/MaintenanceRequestsPage.test.tsx
@@ -135,6 +135,44 @@ describe("landlord maintenance workspace", () => {
     expect(printSummaryDocumentMock).toHaveBeenCalledWith("summary");
   });
 
+  it("falls back to human property and unit labels when raw ids leak through", async () => {
+    maintenanceWorkflowApi.listLandlordMaintenance.mockResolvedValue({
+      items: [
+        {
+          id: "maint-1",
+          tenantId: "tenant-1",
+          landlordId: "landlord-1",
+          propertyId: "W5ELj880M1z2i6uAWgHA",
+          unitId: "unit-opaque-1",
+          tenantName: "Taylor Tenant",
+          propertyLabel: "W5ELj880M1z2i6uAWgHA",
+          unitLabel: "unit-opaque-1",
+          title: "Broken heater",
+          description: "Heat is not turning on.",
+          category: "HVAC",
+          priority: "urgent",
+          status: "submitted",
+          createdAt: 100,
+          updatedAt: 200,
+          statusHistory: [],
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/maintenance/maint-1"]}>
+        <Routes>
+          <Route path="/maintenance/:id" element={<MaintenanceRequestsPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findAllByText("Property")).not.toHaveLength(0);
+    expect(screen.getAllByText("Unit").length).toBeGreaterThan(0);
+    expect(screen.queryAllByText("W5ELj880M1z2i6uAWgHA")).toHaveLength(0);
+    expect(screen.queryAllByText("unit-opaque-1")).toHaveLength(0);
+  });
+
   it("shows pending verification and follow-up state in the landlord closure workspace", async () => {
     maintenanceWorkflowApi.listLandlordMaintenance.mockResolvedValue({
       items: [
@@ -600,7 +638,7 @@ describe("landlord maintenance workspace", () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findAllByText("Tenant • Property")).not.toHaveLength(0);
+    expect(await screen.findAllByText(/Tenant\s+•\s+Property(?:\s+•\s+Unit)?/)).not.toHaveLength(0);
     expect(screen.queryByText(/tenant-1/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/prop-1/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/unit-2/i)).not.toBeInTheDocument();

--- a/rentchain-frontend/src/pages/MaintenanceRequestsPage.tsx
+++ b/rentchain-frontend/src/pages/MaintenanceRequestsPage.tsx
@@ -99,12 +99,25 @@ function displayTenantLabel(item: Pick<MaintenanceWorkflowItem, "tenantName">) {
   return String(item.tenantName || "").trim() || "Tenant";
 }
 
-function displayPropertyLabel(item: Pick<MaintenanceWorkflowItem, "propertyLabel">) {
-  return String(item.propertyLabel || "").trim() || "Property";
+function displayPropertyLabel(item: Pick<MaintenanceWorkflowItem, "propertyLabel" | "propertyId">) {
+  const label = String(item.propertyLabel || "").trim();
+  const propertyId = String(item.propertyId || "").trim();
+  return label && label !== propertyId ? label : "Property";
 }
 
-function displayUnitLabel(item: Pick<MaintenanceWorkflowItem, "unitLabel">) {
-  return String(item.unitLabel || "").trim();
+function displayUnitLabel(item: Pick<MaintenanceWorkflowItem, "unitLabel" | "unitId">) {
+  const label = String(item.unitLabel || "").trim();
+  const unitId = String(item.unitId || "").trim();
+  if (!label && !unitId) return "";
+  return label && label !== unitId ? label : "Unit";
+}
+
+function normalizeMaintenanceLabels<T extends MaintenanceWorkflowItem>(item: T): T {
+  return {
+    ...item,
+    propertyLabel: displayPropertyLabel(item),
+    unitLabel: displayUnitLabel(item) || null,
+  };
 }
 
 function startOfCalendarMonth(value: Date) {
@@ -208,7 +221,7 @@ export default function MaintenanceRequestsPage() {
         (item, index, list): item is LandlordMaintenanceContractor =>
           Boolean(item?.id) && list.findIndex((entry) => entry?.id === item?.id) === index
       );
-      setItems(nextItems);
+      setItems(nextItems.map((item) => normalizeMaintenanceLabels(item)));
       setContractors(nextContractors);
     } catch (err: any) {
       setItems([]);
@@ -666,8 +679,8 @@ export default function MaintenanceRequestsPage() {
               <tr key={item.id}>
                 <td>{item.title}</td>
                 <td>{item.tenantName || "Tenant"}</td>
-                <td>{item.propertyLabel || "Property"}</td>
-                <td>{item.unitLabel || "-"}</td>
+                <td>{displayPropertyLabel(item)}</td>
+                <td>{displayUnitLabel(item)}</td>
                 <td>{item.priority || "-"}</td>
                 <td>{item.status || "-"}</td>
                 <td>{item.assignedContractorName || "-"}</td>
@@ -685,8 +698,8 @@ export default function MaintenanceRequestsPage() {
                 <tr><th>Title</th><td>{selected.title}</td></tr>
                 <tr><th>Category</th><td>{selected.category || "-"}</td></tr>
                 <tr><th>Tenant</th><td>{selected.tenantName || "Tenant"}</td></tr>
-                <tr><th>Property</th><td>{selected.propertyLabel || "Property"}</td></tr>
-                <tr><th>Unit</th><td>{selected.unitLabel || "-"}</td></tr>
+                <tr><th>Property</th><td>{displayPropertyLabel(selected)}</td></tr>
+                <tr><th>Unit</th><td>{displayUnitLabel(selected)}</td></tr>
                 <tr><th>Priority</th><td>{selected.priority || "-"}</td></tr>
                 <tr><th>Status</th><td>{selected.status || "-"}</td></tr>
                 <tr><th>Assigned contractor</th><td>{selected.assignedContractorName || "-"}</td></tr>

--- a/rentchain-frontend/src/pages/PaymentsPage.tsx
+++ b/rentchain-frontend/src/pages/PaymentsPage.tsx
@@ -9,6 +9,22 @@ import { fetchTenants } from "../api/tenantsApi";
 import { printSummaryDocument } from "../utils/printSummary";
 import { triggerBlobDownload } from "../utils/downloadBlob";
 
+function tenantLabelFromValue(value: any): string {
+  return (
+    String(value?.fullName || value?.name || value?.displayName || "").trim() ||
+    [String(value?.firstName || "").trim(), String(value?.lastName || "").trim()].filter(Boolean).join(" ") ||
+    String(value?.email || "").trim() ||
+    ""
+  );
+}
+
+function propertyLabelFromValue(value: any): string {
+  return (
+    String(value?.name || value?.addressLine1 || value?.address || value?.displayName || value?.propertyName || "").trim() ||
+    ""
+  );
+}
+
 const PaymentsPage: React.FC = () => {
   const { payments, loading, error } = usePayments();
   const [rows, setRows] = useState<PaymentRecord[]>([]);
@@ -40,13 +56,13 @@ const PaymentsPage: React.FC = () => {
           tenants: new Map(
             tenantList.map((tenant) => [
               String(tenant.id || ""),
-              String(tenant.fullName || tenant.name || tenant.unitLabel || "").trim(),
+              tenantLabelFromValue(tenant),
             ])
           ),
           properties: new Map(
             propertyItems.map((property: any) => [
               String(property?.id || ""),
-              String(property?.name || property?.addressLine1 || property?.address || "").trim(),
+              propertyLabelFromValue(property),
             ])
           ),
         });


### PR DESCRIPTION
This PR cleans up landlord-facing export labels and financial presentation.

Includes:
- safer tenant/property label resolution on /payments
- payments, expenses, and work-orders exports suppress raw IDs
- SpreadsheetML exports now use .xls attachment filenames
- maintenance labels normalized server-side and sanitized client-side
- Tenant Summary PDF financial activity table formatting improved
- tenant profile ledger block clarified as recent entries
- tenant profile ledger visible row count increased from 6 to 10
- focused backend/frontend test coverage

Guardrails preserved:
- no renewal eligibility changes
- no legal notice workflow changes
- no payment/provider changes
- no ledger/payment conversion changes
- no tenant activity write-path changes
- no data mutation
- no schema migration
- no source merging

PR note:
- Tenant report tests passed: 2 tests.
- Payments route tests passed: 4 tests.
- Expenses route tests passed: 5 tests.
- Work orders route tests passed: 20 tests.
- Export helper tests passed: 3 tests.
- Backend typecheck passed.
- PaymentsPage tests passed: 3 tests.
- TenantDetailPanel tests passed: 2 tests.
- MaintenanceRequestsPage tests passed: 11 tests.
- Frontend build passed.
- Existing chunk-size warning remains unchanged and out of scope.
- Renewal eligibility end-date visibility remains deferred to feat/renewal-eligibility-enddate-visibility-v2.