### PR TITLE
fix: repair spreadsheet export format

### DIFF
--- a/rentchain-api/src/lib/exports/__tests__/exportResponse.test.ts
+++ b/rentchain-api/src/lib/exports/__tests__/exportResponse.test.ts
@@ -18,7 +18,7 @@ describe("exportResponse", () => {
 
   it("returns the expected export content types", () => {
     expect(getExportContentType("csv")).toBe("text/csv; charset=utf-8");
-    expect(getExportContentType("xls")).toBe("application/vnd.ms-excel; charset=utf-8");
+    expect(getExportContentType("xls")).toBe("application/vnd.ms-excel");
     expect(getExportContentType("pdf")).toBe("application/pdf");
   });
 

--- a/rentchain-api/src/lib/exports/exportResponse.ts
+++ b/rentchain-api/src/lib/exports/exportResponse.ts
@@ -18,7 +18,7 @@ export function getExportContentType(format: ExportFormat): string {
     case "csv":
       return "text/csv; charset=utf-8";
     case "xls":
-      return "application/vnd.ms-excel; charset=utf-8";
+      return "application/vnd.ms-excel";
     case "pdf":
       return "application/pdf";
     default:

--- a/rentchain-api/src/routes/__tests__/expensesRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/expensesRoutes.test.ts
@@ -254,7 +254,7 @@ describe("expenses routes", () => {
       source: "manual",
     });
     const app = await createApp();
-    const res = await request(app).get("/api/expenses/export.xlsx");
+    const res = await request(app).get("/api/expenses/export.xls");
 
     expect(res.status).toBe(200);
     expect(res.headers["content-type"]).toContain("application/vnd.ms-excel");
@@ -265,5 +265,17 @@ describe("expenses routes", () => {
     expect(res.text).toContain("12A");
     expect(res.text).not.toContain("prop-1");
     expect(res.text).not.toContain("unit-1");
+  });
+
+  it("keeps the legacy .xlsx expense export route as a compatibility alias", async () => {
+    setPlan("pro");
+    const app = await createApp();
+    const res = await request(app).get("/api/expenses/export.xlsx");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toContain("application/vnd.ms-excel");
+    expect(String(res.headers["content-disposition"] || "")).toMatch(
+      /^attachment; filename="rentchain-expenses-\d{4}-\d{2}-\d{2}\.xls"$/
+    );
   });
 });

--- a/rentchain-api/src/routes/__tests__/paymentsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/paymentsRoutes.test.ts
@@ -165,9 +165,9 @@ describe("paymentsRoutes exports", () => {
     expect(String(res.body)).not.toContain("prop-1");
   });
 
-  it("exports spreadsheet xml with safe labels", async () => {
+  it("exports spreadsheet xml from the primary .xls route with safe labels", async () => {
     const router = (await import("../paymentsRoutes")).default;
-    const res = await invokeRouter(router, { method: "GET", url: "/payments/export.xlsx" });
+    const res = await invokeRouter(router, { method: "GET", url: "/payments/export.xls" });
 
     expect(res.status).toBe(200);
     expect(res.headers["content-type"]).toContain("application/vnd.ms-excel");
@@ -176,6 +176,17 @@ describe("paymentsRoutes exports", () => {
     );
     expect(String(res.body)).toContain("Taylor Tenant");
     expect(String(res.body)).toContain("123 Main St");
+  });
+
+  it("keeps the legacy .xlsx spreadsheet route as a compatibility alias", async () => {
+    const router = (await import("../paymentsRoutes")).default;
+    const res = await invokeRouter(router, { method: "GET", url: "/payments/export.xlsx" });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toContain("application/vnd.ms-excel");
+    expect(res.headers["content-disposition"]).toMatch(
+      /^attachment; filename="rentchain-payments-\d{4}-\d{2}-\d{2}\.xls"$/
+    );
   });
 
   it("lists persisted Firestore payments for a tenant", async () => {

--- a/rentchain-api/src/routes/__tests__/workOrdersRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/workOrdersRoutes.test.ts
@@ -1259,7 +1259,7 @@ describe("workOrdersRoutes execution completion", () => {
 
     const res = await invokeRouter(router, {
       method: "GET",
-      url: "/work-orders/export.xlsx",
+      url: "/work-orders/export.xls",
       headers: {
         "x-test-user": JSON.stringify({
           id: "landlord-1",
@@ -1278,5 +1278,27 @@ describe("workOrdersRoutes execution completion", () => {
     expect(String(res.body)).toContain("4B");
     expect(String(res.body)).not.toContain("prop-1");
     expect(String(res.body)).not.toContain("unit-1");
+  });
+
+  it("keeps the legacy .xlsx work-order export route as a compatibility alias", async () => {
+    const router = (await import("../workOrdersRoutes")).default;
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/work-orders/export.xlsx",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "landlord-1",
+          role: "landlord",
+          landlordId: "landlord-1",
+        }),
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toContain("application/vnd.ms-excel");
+    expect(String(res.headers["content-disposition"] || "")).toMatch(
+      /^attachment; filename="rentchain-work-orders-\d{4}-\d{2}-\d{2}\.xls"$/
+    );
   });
 });

--- a/rentchain-api/src/routes/expensesRoutes.ts
+++ b/rentchain-api/src/routes/expensesRoutes.ts
@@ -1463,7 +1463,7 @@ router.get("/expenses/export.csv", requireAuth, async (req: any, res) => {
   }
 });
 
-router.get("/expenses/export.xlsx", requireAuth, async (req: any, res) => {
+async function handleExpenseSpreadsheetExport(req: any, res: any) {
   try {
     const role = normalizeRole(req);
     if (role !== "landlord" && role !== "admin") {
@@ -1493,10 +1493,13 @@ router.get("/expenses/export.xlsx", requireAuth, async (req: any, res) => {
     });
     return res.status(200).send(xml);
   } catch (err: any) {
-    console.error("[expenses] xlsx export failed", err?.message || err);
+    console.error("[expenses] xls export failed", err?.message || err);
     return res.status(500).json({ ok: false, error: "EXPENSE_EXPORT_FAILED" });
   }
-});
+}
+
+router.get("/expenses/export.xls", requireAuth, handleExpenseSpreadsheetExport);
+router.get("/expenses/export.xlsx", requireAuth, handleExpenseSpreadsheetExport);
 
 router.get("/expenses/export.pdf", requireAuth, async (req: any, res) => {
   try {

--- a/rentchain-api/src/routes/paymentsRoutes.ts
+++ b/rentchain-api/src/routes/paymentsRoutes.ts
@@ -223,7 +223,7 @@ router.get("/payments/export.csv", requireAuth, async (req: any, res: Response) 
   }
 });
 
-router.get("/payments/export.xlsx", requireAuth, async (req: any, res: Response) => {
+async function handlePaymentSpreadsheetExport(req: any, res: Response) {
   try {
     const role = roleForReq(req);
     if (role !== "landlord" && role !== "admin") {
@@ -239,10 +239,13 @@ router.get("/payments/export.xlsx", requireAuth, async (req: any, res: Response)
     });
     return res.status(200).send(xml);
   } catch (err) {
-    console.error("[paymentsRoutes] xlsx export failed", err);
+    console.error("[paymentsRoutes] xls export failed", err);
     return res.status(500).json({ ok: false, error: "PAYMENTS_EXPORT_FAILED" });
   }
-});
+}
+
+router.get("/payments/export.xls", requireAuth, handlePaymentSpreadsheetExport);
+router.get("/payments/export.xlsx", requireAuth, handlePaymentSpreadsheetExport);
 
 // POST /api/payments
 router.post(

--- a/rentchain-api/src/routes/workOrdersRoutes.ts
+++ b/rentchain-api/src/routes/workOrdersRoutes.ts
@@ -1561,7 +1561,7 @@ router.get("/work-orders/export.csv", requireAuth, async (req: any, res) => {
   }
 });
 
-router.get("/work-orders/export.xlsx", requireAuth, async (req: any, res) => {
+async function handleWorkOrderSpreadsheetExport(req: any, res: any) {
   try {
     if (!isLandlord(req)) return res.status(403).json({ ok: false, error: "FORBIDDEN" });
     const rows = await buildWorkOrderExportRows(await listLandlordWorkOrdersForExport(req));
@@ -1573,10 +1573,13 @@ router.get("/work-orders/export.xlsx", requireAuth, async (req: any, res) => {
     });
     return res.status(200).send(xml);
   } catch (err) {
-    console.error("[work-orders] xlsx export failed", err);
+    console.error("[work-orders] xls export failed", err);
     return res.status(500).json({ ok: false, error: "WORK_ORDER_EXPORT_FAILED" });
   }
-});
+}
+
+router.get("/work-orders/export.xls", requireAuth, handleWorkOrderSpreadsheetExport);
+router.get("/work-orders/export.xlsx", requireAuth, handleWorkOrderSpreadsheetExport);
 
 router.get("/work-orders/:id", requireAuth, async (req: any, res) => {
   try {

--- a/rentchain-api/src/services/tenantReportService.ts
+++ b/rentchain-api/src/services/tenantReportService.ts
@@ -209,10 +209,10 @@ const projectionGroupLabels: Record<FinancialProjectionSourceType, string> = {
 };
 
 const projectionSourceLabels: Record<FinancialProjectionSourceType, string> = {
-  recorded_payment: "Payment",
+  recorded_payment: "Recorded Payment",
   lease_charge: "Lease Charge",
   lease_credit: "Credit",
-  ledger_payment_unmatched: "Unmatched Ledger Entry",
+  ledger_payment_unmatched: "Ledger Payment",
 };
 
 function drawProjectionTableHeader(doc: any, columns: Array<{ label: string; x: number; width: number }>) {
@@ -223,15 +223,15 @@ function drawProjectionTableHeader(doc: any, columns: Array<{ label: string; x: 
       align: column.label === "Amount" ? "right" : "left",
     });
   });
-  doc.moveDown(0.2);
-  const lineY = doc.y + 2;
+  doc.moveDown(0.1);
+  const lineY = doc.y + 1;
   doc
     .strokeColor("#d4d4d8")
     .lineWidth(0.75)
     .moveTo(PDF_LEFT, lineY)
     .lineTo(PDF_RIGHT, lineY)
     .stroke();
-  doc.y = lineY + 8;
+  doc.y = lineY + 6;
 }
 
 function formatProjectionDate(value: string | null | undefined) {
@@ -593,10 +593,10 @@ export async function generateTenantReportPdfBuffer(
     } else {
       const columns = [
         { label: "Date", x: PDF_LEFT, width: 64 },
-        { label: "Activity", x: 110, width: 142 },
-        { label: "Context", x: 258, width: 162 },
-        { label: "Amount", x: 426, width: 52 },
-        { label: "Source", x: 484, width: 60 },
+        { label: "Activity", x: 110, width: 134 },
+        { label: "Context", x: 250, width: 158 },
+        { label: "Amount", x: 414, width: 56 },
+        { label: "Source", x: 476, width: 72 },
       ];
 
       projectionGroupOrder.forEach((groupKey) => {
@@ -638,7 +638,7 @@ export async function generateTenantReportPdfBuffer(
           }
 
           const rowY = doc.y;
-          doc.fontSize(9.5).fillColor("#000000");
+          doc.fontSize(9).fillColor("#000000");
           doc.text(rowValues.date, columns[0].x, rowY, { width: columns[0].width });
           doc.text(rowValues.activity, columns[1].x, rowY, { width: columns[1].width });
           doc.text(rowValues.context, columns[2].x, rowY, { width: columns[2].width });

--- a/rentchain-frontend/src/api/expensesApi.ts
+++ b/rentchain-frontend/src/api/expensesApi.ts
@@ -145,7 +145,7 @@ async function downloadExpenseExport(path: string) {
   });
 }
 
-export async function exportExpenses(format: "csv" | "xlsx" | "pdf", filters?: ListExpensesFilters) {
+export async function exportExpenses(format: "csv" | "xls" | "pdf", filters?: ListExpensesFilters) {
   const params = new URLSearchParams();
   if (filters?.propertyId) params.set("propertyId", filters.propertyId);
   if (filters?.unitId) params.set("unitId", filters.unitId);

--- a/rentchain-frontend/src/api/exportDownload.test.ts
+++ b/rentchain-frontend/src/api/exportDownload.test.ts
@@ -26,8 +26,8 @@ describe("exportDownload", () => {
       "admin-leases-2026-04-01.csv"
     );
     expect(
-      parseContentDispositionFilename("attachment; filename*=UTF-8''rentchain%20expenses.xlsx", "fallback.xlsx")
-    ).toBe("rentchain expenses.xlsx");
+      parseContentDispositionFilename("attachment; filename*=UTF-8''rentchain%20expenses.xls", "fallback.xls")
+    ).toBe("rentchain expenses.xls");
     expect(parseContentDispositionFilename(null, "fallback.csv")).toBe("fallback.csv");
   });
 

--- a/rentchain-frontend/src/api/paymentsApi.ts
+++ b/rentchain-frontend/src/api/paymentsApi.ts
@@ -100,7 +100,7 @@ export async function getPropertyMonthlyPayments(
   return data;
 }
 
-export async function exportPayments(format: "csv" | "xlsx") {
+export async function exportPayments(format: "csv" | "xls") {
   return downloadAuthenticatedExport({
     path: `/payments/export.${format}`,
     fallbackFilename: "rentchain-payments-export",

--- a/rentchain-frontend/src/api/workOrdersApi.ts
+++ b/rentchain-frontend/src/api/workOrdersApi.ts
@@ -267,7 +267,7 @@ async function downloadWorkOrderExport(path: string) {
   });
 }
 
-export async function exportWorkOrders(format: "csv" | "xlsx") {
+export async function exportWorkOrders(format: "csv" | "xls") {
   return downloadWorkOrderExport(`/work-orders/export.${format}`);
 }
 

--- a/rentchain-frontend/src/pages/ExpensesPage.test.tsx
+++ b/rentchain-frontend/src/pages/ExpensesPage.test.tsx
@@ -70,7 +70,7 @@ describe("ExpensesPage", () => {
 
     expect(await screen.findByText("Upgrade to Pro to import receipts, PDFs, CSVs, and spreadsheets with AI-assisted review.")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Export CSV" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Export Spreadsheet" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Export Spreadsheet (.xls)" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Export PDF" })).not.toBeInTheDocument();
     expect(screen.getAllByText("Alpha Property").length).toBeGreaterThan(0);
   });
@@ -87,7 +87,7 @@ describe("ExpensesPage", () => {
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Export CSV" })).toBeInTheDocument();
     });
-    expect(screen.getByRole("button", { name: "Export Spreadsheet" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Export Spreadsheet (.xls)" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Export PDF" })).toBeInTheDocument();
   });
 
@@ -108,8 +108,8 @@ describe("ExpensesPage", () => {
     fireEvent.click((await screen.findAllByRole("button", { name: "Export CSV" }))[0]);
     await waitFor(() => expect(mocks.exportExpensesMock).toHaveBeenCalledWith("csv", expect.any(Object)));
 
-    fireEvent.click(screen.getAllByRole("button", { name: "Export Spreadsheet" })[0]);
-    await waitFor(() => expect(mocks.exportExpensesMock).toHaveBeenCalledWith("xlsx", expect.any(Object)));
+    fireEvent.click(screen.getAllByRole("button", { name: "Export Spreadsheet (.xls)" })[0]);
+    await waitFor(() => expect(mocks.exportExpensesMock).toHaveBeenCalledWith("xls", expect.any(Object)));
 
     fireEvent.click(screen.getAllByRole("button", { name: "Export PDF" })[0]);
     await waitFor(() => expect(mocks.exportExpensesMock).toHaveBeenCalledWith("pdf", expect.any(Object)));

--- a/rentchain-frontend/src/pages/ExpensesPage.tsx
+++ b/rentchain-frontend/src/pages/ExpensesPage.tsx
@@ -106,7 +106,7 @@ const ExpensesPage: React.FC = () => {
   const [dateFrom, setDateFrom] = React.useState("");
   const [dateTo, setDateTo] = React.useState("");
   const [importing, setImporting] = React.useState(false);
-  const [exporting, setExporting] = React.useState<null | "csv" | "xlsx" | "pdf">(null);
+  const [exporting, setExporting] = React.useState<null | "csv" | "xls" | "pdf">(null);
   const [importFiles, setImportFiles] = React.useState<File[]>([]);
   const [previewRows, setPreviewRows] = React.useState<ExpenseImportPreviewRow[]>([]);
   const [previewSummary, setPreviewSummary] = React.useState<null | {
@@ -195,7 +195,7 @@ const ExpensesPage: React.FC = () => {
     [items]
   );
 
-  const triggerDownload = async (format: "csv" | "xlsx" | "pdf") => {
+  const triggerDownload = async (format: "csv" | "xls" | "pdf") => {
     try {
       setExporting(format);
       const { blob, filename } = await exportExpenses(format, {
@@ -307,8 +307,8 @@ const ExpensesPage: React.FC = () => {
               <Button variant="secondary" onClick={() => void triggerDownload("csv")} disabled={exporting !== null}>
                 {exporting === "csv" ? "Exporting..." : "Export CSV"}
               </Button>
-              <Button variant="secondary" onClick={() => void triggerDownload("xlsx")} disabled={exporting !== null}>
-                {exporting === "xlsx" ? "Exporting..." : "Export Spreadsheet"}
+              <Button variant="secondary" onClick={() => void triggerDownload("xls")} disabled={exporting !== null}>
+                {exporting === "xls" ? "Exporting..." : "Export Spreadsheet (.xls)"}
               </Button>
               <Button variant="secondary" onClick={() => void triggerDownload("pdf")} disabled={exporting !== null}>
                 {exporting === "pdf" ? "Exporting..." : "Export PDF"}

--- a/rentchain-frontend/src/pages/PaymentsPage.test.tsx
+++ b/rentchain-frontend/src/pages/PaymentsPage.test.tsx
@@ -76,7 +76,7 @@ describe("PaymentsPage", () => {
       screen.getByText("These views are intentionally separate to avoid double counting and preserve audit integrity.")
     ).toBeInTheDocument();
     expect(await screen.findByRole("button", { name: "Export CSV" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Export Spreadsheet" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Export Spreadsheet (.xls)" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Export PDF" })).toBeInTheDocument();
     expect((await screen.findAllByText("Taylor Tenant")).length).toBeGreaterThan(0);
     expect(screen.getAllByText("123 Main St").length).toBeGreaterThan(0);
@@ -108,8 +108,8 @@ describe("PaymentsPage", () => {
     fireEvent.click((await screen.findAllByRole("button", { name: "Export CSV" }))[0]);
     await waitFor(() => expect(mocks.exportPayments).toHaveBeenCalledWith("csv"));
 
-    fireEvent.click(screen.getAllByRole("button", { name: "Export Spreadsheet" })[0]);
-    await waitFor(() => expect(mocks.exportPayments).toHaveBeenCalledWith("xlsx"));
+    fireEvent.click(screen.getAllByRole("button", { name: "Export Spreadsheet (.xls)" })[0]);
+    await waitFor(() => expect(mocks.exportPayments).toHaveBeenCalledWith("xls"));
 
     createElementSpy.mockRestore();
     click.mockRestore();

--- a/rentchain-frontend/src/pages/PaymentsPage.tsx
+++ b/rentchain-frontend/src/pages/PaymentsPage.tsx
@@ -28,7 +28,7 @@ function propertyLabelFromValue(value: any): string {
 const PaymentsPage: React.FC = () => {
   const { payments, loading, error } = usePayments();
   const [rows, setRows] = useState<PaymentRecord[]>([]);
-  const [exporting, setExporting] = useState<null | "csv" | "xlsx">(null);
+  const [exporting, setExporting] = useState<null | "csv" | "xls">(null);
   const [labelMap, setLabelMap] = useState<{ tenants: Map<string, string>; properties: Map<string, string> }>({
     tenants: new Map(),
     properties: new Map(),
@@ -84,7 +84,7 @@ const PaymentsPage: React.FC = () => {
   const getPropertyLabel = (payment: PaymentRecord) =>
     labelMap.properties.get(String(payment.propertyId || "").trim()) || "Property";
 
-  const triggerExport = async (format: "csv" | "xlsx") => {
+  const triggerExport = async (format: "csv" | "xls") => {
     try {
       setExporting(format);
       const { blob, filename } = await exportPayments(format);
@@ -177,8 +177,8 @@ const PaymentsPage: React.FC = () => {
             <Button variant="secondary" onClick={() => void triggerExport("csv")} disabled={exporting !== null}>
               {exporting === "csv" ? "Exporting..." : "Export CSV"}
             </Button>
-            <Button variant="secondary" onClick={() => void triggerExport("xlsx")} disabled={exporting !== null}>
-              {exporting === "xlsx" ? "Exporting..." : "Export Spreadsheet"}
+            <Button variant="secondary" onClick={() => void triggerExport("xls")} disabled={exporting !== null}>
+              {exporting === "xls" ? "Exporting..." : "Export Spreadsheet (.xls)"}
             </Button>
             <Button variant="secondary" onClick={() => void printSummaryDocument("summary")}>Export PDF</Button>
           </div>

--- a/rentchain-frontend/src/pages/landlord/WorkOrdersPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/WorkOrdersPage.test.tsx
@@ -365,7 +365,7 @@ describe("WorkOrdersPage", () => {
     );
 
     expect(await screen.findByRole("button", { name: "Export CSV" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Export Spreadsheet" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Export Spreadsheet (.xls)" })).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Export PDF" }));
     expect(mocks.printSummaryDocument).toHaveBeenCalledWith("summary");
   });

--- a/rentchain-frontend/src/pages/landlord/WorkOrdersPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/WorkOrdersPage.tsx
@@ -254,7 +254,7 @@ export default function WorkOrdersPage() {
   const [convertTarget, setConvertTarget] = React.useState<WorkOrderRecord | null>(null);
   const [convertVendor, setConvertVendor] = React.useState("");
   const [isMobile, setIsMobile] = React.useState(false);
-  const [exporting, setExporting] = React.useState<null | "csv" | "xlsx">(null);
+  const [exporting, setExporting] = React.useState<null | "csv" | "xls">(null);
   const [evidenceFile, setEvidenceFile] = React.useState<File | null>(null);
   const [evidenceType, setEvidenceType] = React.useState<WorkOrderEvidenceType>("inspection");
   const [evidenceCaption, setEvidenceCaption] = React.useState("");
@@ -345,7 +345,7 @@ export default function WorkOrdersPage() {
     );
   }, []);
 
-  const triggerExport = React.useCallback(async (format: "csv" | "xlsx") => {
+  const triggerExport = React.useCallback(async (format: "csv" | "xls") => {
     try {
       setExporting(format);
       const { blob, filename } = await exportWorkOrders(format);
@@ -916,8 +916,8 @@ export default function WorkOrdersPage() {
           <Button variant="secondary" onClick={() => void triggerExport("csv")} disabled={exporting !== null}>
             {exporting === "csv" ? "Exporting..." : "Export CSV"}
           </Button>
-          <Button variant="secondary" onClick={() => void triggerExport("xlsx")} disabled={exporting !== null}>
-            {exporting === "xlsx" ? "Exporting..." : "Export Spreadsheet"}
+          <Button variant="secondary" onClick={() => void triggerExport("xls")} disabled={exporting !== null}>
+            {exporting === "xls" ? "Exporting..." : "Export Spreadsheet (.xls)"}
           </Button>
           <Button variant="secondary" onClick={() => void printSummaryDocument("summary")}>
             Export PDF


### PR DESCRIPTION
This PR repairs SpreadsheetML export handling and improves Tenant Summary PDF financial table formatting.

Includes:
- new .xls export routes for payments, expenses, and work orders
- existing .xlsx routes retained as compatibility aliases
- SpreadsheetML exports now return application/vnd.ms-excel
- Content-Disposition filenames now use .xls
- frontend export helpers now request .xls routes
- export button copy updated to Export Spreadsheet (.xls)
- Tenant Summary PDF financial activity table layout improved
- focused backend/frontend test coverage

Guardrails preserved:
- no real .xlsx generation
- no new spreadsheet library
- no export data-source changes
- no payment/provider changes
- no renewal eligibility changes
- no broad PDF redesign