### PR TITLE
fix: improve analytics workspace layout

### DIFF
--- a/rentchain-frontend/src/components/analytics/AnalyticsFiltersBar.tsx
+++ b/rentchain-frontend/src/components/analytics/AnalyticsFiltersBar.tsx
@@ -7,6 +7,7 @@ type Props = {
   propertyId: string;
   properties: Array<{ id: string; name: string }>;
   disabled?: boolean;
+  embedded?: boolean;
   onPeriodChange: (period: AnalyticsPeriod) => void;
   onPropertyChange: (propertyId: string) => void;
 };
@@ -16,55 +17,58 @@ export function AnalyticsFiltersBar({
   propertyId,
   properties,
   disabled = false,
+  embedded = false,
   onPeriodChange,
   onPropertyChange,
 }: Props) {
-  return (
-    <Card>
-      <div
-        style={{
-          display: "grid",
-          gap: 12,
-          gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
-          alignItems: "end",
-        }}
-      >
-        <label style={{ display: "grid", gap: 6 }}>
-          <span style={{ color: "#475569", fontSize: "0.88rem", fontWeight: 600 }}>Period</span>
-          <select
-            aria-label="Analytics period"
-            disabled={disabled}
-            value={period}
-            onChange={(event) => onPeriodChange(event.target.value as AnalyticsPeriod)}
-            style={{ padding: "10px 12px", borderRadius: 10, border: "1px solid #cbd5e1", background: "#fff" }}
-          >
-            <option value="30d">Last 30 days</option>
-            <option value="90d">Last 90 days</option>
-            <option value="365d">Last 365 days</option>
-            <option value="month_to_date">Month to date</option>
-          </select>
-        </label>
+  const content = (
+    <div
+      style={{
+        display: "grid",
+        gap: 12,
+        gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+        alignItems: "end",
+      }}
+    >
+      <label style={{ display: "grid", gap: 6 }}>
+        <span style={{ color: "#475569", fontSize: "0.88rem", fontWeight: 600 }}>Period</span>
+        <select
+          aria-label="Analytics period"
+          disabled={disabled}
+          value={period}
+          onChange={(event) => onPeriodChange(event.target.value as AnalyticsPeriod)}
+          style={{ padding: "10px 12px", borderRadius: 10, border: "1px solid #cbd5e1", background: "#fff" }}
+        >
+          <option value="30d">Last 30 days</option>
+          <option value="90d">Last 90 days</option>
+          <option value="365d">Last 365 days</option>
+          <option value="month_to_date">Month to date</option>
+        </select>
+      </label>
 
-        <label style={{ display: "grid", gap: 6 }}>
-          <span style={{ color: "#475569", fontSize: "0.88rem", fontWeight: 600 }}>Property</span>
-          <select
-            aria-label="Analytics property"
-            disabled={disabled}
-            value={propertyId}
-            onChange={(event) => onPropertyChange(event.target.value)}
-            style={{ padding: "10px 12px", borderRadius: 10, border: "1px solid #cbd5e1", background: "#fff" }}
-          >
-            <option value="">All properties</option>
-            {properties.map((property) => (
-              <option key={property.id} value={property.id}>
-                {property.name}
-              </option>
-            ))}
-          </select>
-        </label>
-      </div>
-    </Card>
+      <label style={{ display: "grid", gap: 6 }}>
+        <span style={{ color: "#475569", fontSize: "0.88rem", fontWeight: 600 }}>Property</span>
+        <select
+          aria-label="Analytics property"
+          disabled={disabled}
+          value={propertyId}
+          onChange={(event) => onPropertyChange(event.target.value)}
+          style={{ padding: "10px 12px", borderRadius: 10, border: "1px solid #cbd5e1", background: "#fff" }}
+        >
+          <option value="">All properties</option>
+          {properties.map((property) => (
+            <option key={property.id} value={property.id}>
+              {property.name}
+            </option>
+          ))}
+        </select>
+      </label>
+    </div>
   );
+
+  if (embedded) return content;
+
+  return <Card>{content}</Card>;
 }
 
 export default AnalyticsFiltersBar;

--- a/rentchain-frontend/src/components/analytics/AnalyticsWorkspaceHeader.tsx
+++ b/rentchain-frontend/src/components/analytics/AnalyticsWorkspaceHeader.tsx
@@ -1,0 +1,114 @@
+import React from "react";
+import type { AnalyticsPeriod } from "@/api/landlordAnalyticsApi";
+import { Button, Card } from "../ui/Ui";
+import AnalyticsFiltersBar from "./AnalyticsFiltersBar";
+
+type AnalyticsWorkspaceTabId =
+  | "analytics-alerts"
+  | "portfolio-benchmarking"
+  | "decision-outcomes"
+  | "operator-queue"
+  | "recommended-next-actions"
+  | "actions-to-review"
+  | "predictive-metrics"
+  | "attention-worthy-insights"
+  | "portfolio-execution-summary";
+
+type AnalyticsWorkspaceTab = {
+  id: AnalyticsWorkspaceTabId;
+  label: string;
+};
+
+type Props = {
+  title: string;
+  description: string;
+  focusLabel: string | null;
+  activeTab: AnalyticsWorkspaceTabId;
+  tabs: AnalyticsWorkspaceTab[];
+  period: AnalyticsPeriod;
+  propertyId: string;
+  properties: Array<{ id: string; name: string }>;
+  disabled?: boolean;
+  onTabChange: (tab: AnalyticsWorkspaceTabId) => void;
+  onPeriodChange: (period: AnalyticsPeriod) => void;
+  onPropertyChange: (propertyId: string) => void;
+  onPrint: () => void;
+};
+
+export default function AnalyticsWorkspaceHeader({
+  title,
+  description,
+  focusLabel,
+  activeTab,
+  tabs,
+  period,
+  propertyId,
+  properties,
+  disabled = false,
+  onTabChange,
+  onPeriodChange,
+  onPropertyChange,
+  onPrint,
+}: Props) {
+  return (
+    <Card className="analytics-workspace-header" elevated>
+      <div className="analytics-workspace-header__top">
+        <div style={{ display: "grid", gap: 6 }}>
+          <h1 style={{ margin: 0, fontSize: "1.5rem" }}>{title}</h1>
+          <div style={{ color: "#475569", maxWidth: 840 }}>{description}</div>
+          {focusLabel ? (
+            <div style={{ color: "#0f766e", fontWeight: 600, fontSize: "0.92rem" }}>
+              Focused from decisions: {focusLabel}
+            </div>
+          ) : null}
+        </div>
+        <Button
+          type="button"
+          className="no-print"
+          variant="ghost"
+          onClick={onPrint}
+          style={{ fontWeight: 800, justifySelf: "start", whiteSpace: "nowrap" }}
+        >
+          Print / Save PDF
+        </Button>
+      </div>
+
+      <div className="analytics-workspace-header__controls" aria-label="Analytics control area">
+        <div
+          role="tablist"
+          aria-label="Analytics workspace sections"
+          className="analytics-workspace-tabs"
+        >
+          {tabs.map((tab) => {
+            const selected = activeTab === tab.id;
+            return (
+              <button
+                key={tab.id}
+                id={`analytics-tab-${tab.id}`}
+                type="button"
+                role="tab"
+                aria-selected={selected}
+                aria-controls={`analytics-panel-${tab.id}`}
+                onClick={() => onTabChange(tab.id)}
+                className="analytics-workspace-tab"
+                data-active={selected ? "true" : "false"}
+              >
+                {tab.label}
+              </button>
+            );
+          })}
+        </div>
+
+        <AnalyticsFiltersBar
+          embedded
+          period={period}
+          propertyId={propertyId}
+          properties={properties}
+          disabled={disabled}
+          onPeriodChange={onPeriodChange}
+          onPropertyChange={onPropertyChange}
+        />
+      </div>
+    </Card>
+  );
+}

--- a/rentchain-frontend/src/index.css
+++ b/rentchain-frontend/src/index.css
@@ -444,3 +444,96 @@ button,
 .printFooter {
   margin-top: 14px;
 }
+
+.analytics-workspace-page {
+  display: grid;
+  gap: 16px;
+  padding: 16px;
+  border-radius: 24px;
+  background: #f8fafc;
+}
+
+.analytics-workspace-header {
+  position: sticky;
+  top: 12px;
+  z-index: 6;
+}
+
+.analytics-workspace-header__top {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  margin-bottom: 14px;
+}
+
+.analytics-workspace-header__controls {
+  display: grid;
+  gap: 14px;
+}
+
+.analytics-workspace-tabs {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  padding-bottom: 4px;
+  scrollbar-width: thin;
+}
+
+.analytics-workspace-tab {
+  border-radius: 999px;
+  border: 1px solid #cbd5e1;
+  background: #fff;
+  color: #334155;
+  font-weight: 700;
+  padding: 8px 12px;
+  cursor: pointer;
+  white-space: nowrap;
+  flex: 0 0 auto;
+}
+
+.analytics-workspace-tab[data-active="true"] {
+  border-color: #0f172a;
+  background: #0f172a;
+  color: #fff;
+}
+
+.analytics-print-summary .printKpis {
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.analytics-print-summary__intro {
+  color: #334155;
+  margin-bottom: 8px;
+}
+
+@media (max-width: 720px) {
+  .analytics-workspace-page {
+    padding: 12px;
+  }
+
+  .analytics-workspace-header {
+    top: 8px;
+  }
+
+  .analytics-workspace-header__top {
+    margin-bottom: 12px;
+  }
+}
+
+@media print {
+  .analytics-workspace-page {
+    padding: 0 !important;
+    background: #fff !important;
+  }
+
+  .analytics-workspace-header,
+  .analytics-workspace-summary-grid {
+    position: static !important;
+  }
+
+  .analytics-print-summary .printKpis {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}

--- a/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import type { LandlordAnalyticsSnapshot } from "../../api/landlordAnalyticsApi";
 import type { LandlordAnalyticsAlertsResponse } from "../../api/landlordAnalyticsAlertsApi";
 import type { LandlordAnalyticsBenchmarkingResponse } from "../../api/landlordAnalyticsBenchmarkingApi";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import LandlordAnalyticsPage from "./LandlordAnalyticsPage";
@@ -51,8 +51,11 @@ vi.mock("../../components/layout/MacShell", () => ({
 }));
 
 vi.mock("../../components/ui/Ui", () => ({
-  Card: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => <div {...props}>{children}</div>,
+  Card: ({ children, elevated: _elevated, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+    <div {...props}>{children}</div>
+  ),
   Section: ({ children }: React.PropsWithChildren) => <section>{children}</section>,
+  Button: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => <button {...props}>{children}</button>,
 }));
 
 vi.mock("@/components/billing/FeatureTeaser", () => ({
@@ -498,14 +501,20 @@ describe("LandlordAnalyticsPage", () => {
     await mockEntitlements();
     await mockApiResolved();
 
-    render(
+    const { container } = render(
       <MemoryRouter>
         <LandlordAnalyticsPage />
       </MemoryRouter>
     );
 
     expect(await screen.findByText(/Analytics alerts/i)).toBeInTheDocument();
-    expect(screen.getByRole("tablist", { name: /Analytics workspace sections/i })).toBeInTheDocument();
+    const workspacePage = container.querySelector(".analytics-workspace-page");
+    expect(workspacePage).toBeTruthy();
+
+    const controlArea = screen.getByLabelText(/Analytics control area/i);
+    expect(within(controlArea).getByRole("tablist", { name: /Analytics workspace sections/i })).toBeInTheDocument();
+    expect(within(controlArea).getByLabelText(/Analytics period/i)).toBeInTheDocument();
+    expect(within(controlArea).getByLabelText(/Analytics property/i)).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Analytics alerts" })).toHaveAttribute("aria-selected", "true");
     expect(screen.getByRole("tab", { name: "Portfolio benchmarking" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Decision outcomes" })).toBeInTheDocument();
@@ -534,14 +543,18 @@ describe("LandlordAnalyticsPage", () => {
 
     fireEvent.click(screen.getByRole("tab", { name: "Predictive metrics" }));
     expect(screen.getByRole("heading", { name: /Predictive metrics/i })).toBeInTheDocument();
-    expect(screen.getByText(/Vacancy pressure is present in the current view/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Vacancy pressure is present in the current view/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Current vacancy: 20% • Vacant units: 1/i)).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: /Recommended next actions/i })).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("tab", { name: "Attention-worthy insights" }));
     expect(screen.getByRole("heading", { name: /Attention-worthy insights/i })).toBeInTheDocument();
     expect(screen.getByText(/Distinct portfolio patterns worth reviewing after alerts and next actions/i)).toBeInTheDocument();
-    expect(screen.queryByText(/^1 lease ends within 30 days\.$/i)).not.toBeInTheDocument();
+    expect(
+      within(screen.getByRole("tabpanel", { name: "Attention-worthy insights" })).queryByText(
+        /^1 lease ends within 30 days\.$/i
+      )
+    ).not.toBeInTheDocument();
 
     expect(screen.getByRole("heading", { name: /Applications/i })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /Revenue signal/i })).toBeInTheDocument();
@@ -569,7 +582,7 @@ describe("LandlordAnalyticsPage", () => {
     expect(screen.queryByText(/Beta carries the strongest vacancy pressure/i)).not.toBeInTheDocument();
   });
 
-  it("routes print/save pdf through the shared print helper", async () => {
+  it("routes print/save pdf through the selected analytics workspace summary", async () => {
     await mockEntitlements();
     await mockApiResolved();
 
@@ -578,6 +591,12 @@ describe("LandlordAnalyticsPage", () => {
         <LandlordAnalyticsPage />
       </MemoryRouter>
     );
+
+    fireEvent.click(await screen.findByRole("tab", { name: "Predictive metrics" }));
+    const printSummary = screen.getByTestId("analytics-print-summary");
+    expect(printSummary).toHaveAttribute("data-active-workspace", "predictive-metrics");
+    expect(within(printSummary).getByText("Predictive metrics")).toBeInTheDocument();
+    expect(within(printSummary).queryByText("Decision queue")).not.toBeInTheDocument();
 
     fireEvent.click(await screen.findByRole("button", { name: "Print / Save PDF" }));
     expect(printSummaryDocument).toHaveBeenCalledWith("summary");

--- a/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/LandlordAnalyticsPage.tsx
@@ -16,9 +16,9 @@ import { useEntitlements } from "@/hooks/useEntitlements";
 import { FeatureTeaser } from "@/components/billing/FeatureTeaser";
 import AnalyticsAlertsPanel from "../../components/analytics/AnalyticsAlertsPanel";
 import AgentDecisionPanel from "../../components/analytics/AgentDecisionPanel";
-import AnalyticsFiltersBar from "../../components/analytics/AnalyticsFiltersBar";
 import AnalyticsKpiGrid from "../../components/analytics/AnalyticsKpiGrid";
 import AnalyticsSectionPanel from "../../components/analytics/AnalyticsSectionPanel";
+import AnalyticsWorkspaceHeader from "../../components/analytics/AnalyticsWorkspaceHeader";
 import DecisionQueueSummary from "../../components/analytics/DecisionQueueSummary";
 import DecisionOutcomeAnalyticsPanel from "../../components/analytics/DecisionOutcomeAnalyticsPanel";
 import InsightCardsPanel from "../../components/analytics/InsightCardsPanel";
@@ -102,6 +102,50 @@ function workspaceTabIntro(tab: AnalyticsWorkspaceTabId) {
     return "This view summarizes how decisions are distributed across execution states so you can see what is ready, blocked, or already handled.";
   }
   return null;
+}
+
+function formatPrintDate(value: string | null | undefined) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", year: "numeric" }).format(date);
+}
+
+function resolvePropertyFilterLabel(
+  propertyId: string,
+  properties: Array<{ id: string; name: string }>
+) {
+  if (!propertyId) return "All properties";
+  return properties.find((property) => property.id === propertyId)?.name || "Filtered property";
+}
+
+function renderPrintTable(
+  headers: string[],
+  rows: Array<Array<React.ReactNode>>,
+  emptyMessage: string
+) {
+  if (!rows.length) return <div style={{ color: "#64748b" }}>{emptyMessage}</div>;
+
+  return (
+    <table className="printTable">
+      <thead>
+        <tr>
+          {headers.map((header) => (
+            <th key={header}>{header}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row, rowIndex) => (
+          <tr key={rowIndex}>
+            {row.map((cell, cellIndex) => (
+              <td key={cellIndex}>{cell}</td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
 }
 
 function useAnalyticsState(enabled: boolean, includeBenchmarking: boolean, period: AnalyticsPeriod, propertyId: string) {
@@ -219,6 +263,7 @@ export default function LandlordAnalyticsPage() {
   const activeTabLabel = ANALYTICS_WORKSPACE_TABS.find((tab) => tab.id === activeTab)?.label || "Analytics alerts";
   const showPortfolioScoreTeaser = canViewPortfolioScore === false;
   const showAdvancedAnalyticsTeaser = canViewPortfolioScore && !canViewAdvancedAnalytics;
+  const propertyFilterLabel = resolvePropertyFilterLabel(propertyId, snapshot?.properties || []);
 
   const summaryItems = snapshot
     ? [
@@ -267,128 +312,161 @@ export default function LandlordAnalyticsPage() {
       ]
     : [];
 
+  const printWorkspaceContent = React.useMemo(() => {
+    if (!snapshot) return null;
+
+    if (activeTab === "analytics-alerts") {
+      const alertRows =
+        alerts?.alerts.map((alert) => [
+          alert.title,
+          alert.severity,
+          alert.status,
+          formatPrintDate(alert.detectedAt),
+        ]) || [];
+      return renderPrintTable(
+        ["Alert", "Severity", "Status", "Detected"],
+        alertRows,
+        "No analytics alerts are active for this view."
+      );
+    }
+
+    if (activeTab === "portfolio-benchmarking") {
+      const comparisonRows =
+        benchmarking?.comparisons.map((comparison) => [
+          comparison.propertyName,
+          formatPercent(comparison.metrics.occupancyRate),
+          formatPercent(comparison.metrics.vacancyRate),
+          String(comparison.metrics.openWorkOrders),
+        ]) || [];
+      return renderPrintTable(
+        ["Property", "Occupancy", "Vacancy", "Open work orders"],
+        comparisonRows,
+        "Benchmarking is not available for this view yet."
+      );
+    }
+
+    if (activeTab === "decision-outcomes") {
+      const analytics = snapshot.decisionOutcomeAnalytics;
+      const rows = analytics
+        ? [
+            ["Appeared", String(analytics.appearedCount)],
+            ["Reviewed", String(analytics.reviewedCount)],
+            ["Executed", String(analytics.executedCount)],
+            ["Failed", String(analytics.failedExecutionCount)],
+            ["Resolved", String(analytics.resolvedCount)],
+            ["Resolution rate", formatPercent(analytics.resolutionRate)],
+          ]
+        : [];
+      return renderPrintTable(["Metric", "Value"], rows, "Decision outcomes are not available for this view yet.");
+    }
+
+    if (activeTab === "operator-queue" || activeTab === "portfolio-execution-summary") {
+      const queueRows = decisions.slice(0, 12).map((decision) => [
+        decision.title,
+        decision.priority,
+        decision.executionState,
+        decision.automationState,
+      ]);
+      return renderPrintTable(
+        ["Decision", "Priority", "Execution state", "Automation"],
+        queueRows,
+        "No operator queue decisions are available in this view."
+      );
+    }
+
+    if (activeTab === "recommended-next-actions" || activeTab === "actions-to-review") {
+      const actionRows = prioritizedDecisions.slice(0, 12).map((decision) => [
+        decision.title,
+        decision.priority,
+        decision.recommendedAction,
+        decision.automationState,
+      ]);
+      return renderPrintTable(
+        ["Decision", "Priority", "Recommended action", "Automation"],
+        actionRows,
+        "No recommended actions are available in this view."
+      );
+    }
+
+    if (activeTab === "predictive-metrics") {
+      const rows =
+        snapshot.predictive?.metrics.map((metric) => [
+          metric.label,
+          metric.riskLevel || metric.status,
+          metric.explanation,
+        ]) || [];
+      return renderPrintTable(["Metric", "Signal", "Explanation"], rows, "No predictive metrics are available.");
+    }
+
+    if (activeTab === "attention-worthy-insights") {
+      const rows = snapshot.insights.map((insight) => [insight.severity, insight.message]);
+      return renderPrintTable(["Severity", "Insight"], rows, "No standout analytics insights are available.");
+    }
+
+    return null;
+  }, [activeTab, alerts?.alerts, benchmarking?.comparisons, decisions, prioritizedDecisions, snapshot]);
+
   return (
     <MacShell title="Analytics" showTopNav={false}>
-      <div style={{ display: "grid", gap: 16 }}>
-        <Section>
-          <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "flex-start" }}>
+      <div className="analytics-workspace-page">
+        {analyticsEnabled ? (
+          <AnalyticsWorkspaceHeader
+            title="Analytics"
+            description="A calm view of portfolio health, application activity, leasing pressure, maintenance burden, and rent signals."
+            focusLabel={routedEntryLabel}
+            activeTab={activeTab}
+            tabs={ANALYTICS_WORKSPACE_TABS}
+            period={period}
+            propertyId={propertyId}
+            properties={snapshot?.properties || []}
+            disabled={loading}
+            onTabChange={setActiveTab}
+            onPeriodChange={setPeriod}
+            onPropertyChange={setPropertyId}
+            onPrint={() => void printSummaryDocument("summary")}
+          />
+        ) : (
+          <Section>
             <div style={{ display: "grid", gap: 6 }}>
               <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Analytics</h1>
               <div style={{ color: "#475569", maxWidth: 840 }}>
                 A calm view of portfolio health, application activity, leasing pressure, maintenance burden, and rent signals.
               </div>
-              {routedEntryLabel ? (
-                <div style={{ color: "#0f766e", fontWeight: 600, fontSize: "0.92rem" }}>
-                  Focused from decisions: {routedEntryLabel}
-                </div>
-              ) : null}
             </div>
-            <button
-              type="button"
-              className="no-print"
-              onClick={() => void printSummaryDocument("summary")}
-              style={{ padding: "8px 10px", borderRadius: 12, border: "1px solid #E5E7EB", background: "#FFFFFF", fontWeight: 900, cursor: "pointer" }}
-            >
-              Print / Save PDF
-            </button>
-          </div>
-        </Section>
+          </Section>
+        )}
 
         {snapshot ? (
-          <div className="print-only print-only-summary">
+          <div
+            className="print-only print-only-summary analytics-print-summary"
+            data-testid="analytics-print-summary"
+            data-active-workspace={activeTab}
+          >
             <div className="printHeader">
-              <div className="printTitle">Analytics summary</div>
+              <div className="printTitle">Analytics workspace</div>
               <div className="printMeta">
+                <div>Workspace: {activeTabLabel}</div>
                 <div>Period: {periodLabel(period)}</div>
-                <div>Property filter: {propertyId || "All properties"}</div>
+                <div>Property filter: {propertyFilterLabel}</div>
               </div>
             </div>
             <div className="printKpis">
-              {summaryItems.slice(0, 4).map((item) => (
+              {summaryItems.slice(0, 6).map((item) => (
                 <div key={item.label} className="printKpi">
                   <div className="printKpiLabel">{item.label}</div>
                   <div className="printKpiValue">{item.value}</div>
                 </div>
               ))}
             </div>
-            <div className="printH3">Decision queue</div>
-            <table className="printTable">
-              <thead>
-                <tr>
-                  <th>Title</th>
-                  <th>Priority</th>
-                  <th>Status</th>
-                </tr>
-              </thead>
-              <tbody>
-                {prioritizedDecisions.slice(0, 10).map((decision) => (
-                  <tr key={decision.id}>
-                    <td>{decision.title}</td>
-                    <td>{decision.priority}</td>
-                    <td>{decision.executionState}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+            <div className="printH3">{activeTabLabel}</div>
+            {activeTabIntro ? <div className="analytics-print-summary__intro">{activeTabIntro}</div> : null}
+            {printWorkspaceContent}
           </div>
         ) : null}
 
         {entitlementLoading ? <Card>Loading analytics access…</Card> : null}
         {!entitlementLoading && !canViewPortfolioHealthSummary ? (
           <Card style={{ color: "#b91c1c" }}>Analytics is currently unavailable for this account.</Card>
-        ) : null}
-
-        {analyticsEnabled ? (
-          <div
-            role="tablist"
-            aria-label="Analytics workspace sections"
-            style={{
-              display: "flex",
-              gap: 8,
-              overflowX: "auto",
-              paddingBottom: 4,
-              scrollbarWidth: "thin",
-            }}
-          >
-            {ANALYTICS_WORKSPACE_TABS.map((tab) => {
-              const selected = activeTab === tab.id;
-              return (
-                <button
-                  key={tab.id}
-                  id={`analytics-tab-${tab.id}`}
-                  type="button"
-                  role="tab"
-                  aria-selected={selected}
-                  aria-controls={`analytics-panel-${tab.id}`}
-                  onClick={() => setActiveTab(tab.id)}
-                  style={{
-                    borderRadius: 999,
-                    border: selected ? "1px solid #0f172a" : "1px solid #cbd5e1",
-                    background: selected ? "#0f172a" : "#fff",
-                    color: selected ? "#fff" : "#334155",
-                    fontWeight: 700,
-                    padding: "8px 12px",
-                    cursor: "pointer",
-                    whiteSpace: "nowrap",
-                    flex: "0 0 auto",
-                  }}
-                >
-                  {tab.label}
-                </button>
-              );
-            })}
-          </div>
-        ) : null}
-
-        {analyticsEnabled ? (
-          <AnalyticsFiltersBar
-            period={period}
-            propertyId={propertyId}
-            properties={snapshot?.properties || []}
-            disabled={loading}
-            onPeriodChange={setPeriod}
-            onPropertyChange={setPropertyId}
-          />
         ) : null}
 
         {analyticsEnabled && loading ? <Card>Loading analytics…</Card> : null}
@@ -402,9 +480,10 @@ export default function LandlordAnalyticsPage() {
 
             {canViewPortfolioScore ? (
               <div
+                className="analytics-workspace-summary-grid"
                 style={{
                   display: "grid",
-                  gap: 16,
+                  gap: 12,
                   gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
                 }}
               >
@@ -553,7 +632,7 @@ export default function LandlordAnalyticsPage() {
               role="tabpanel"
               aria-labelledby={`analytics-tab-${activeTab}`}
               aria-label={activeTabLabel}
-              style={{ display: "grid", gap: 12 }}
+              style={{ display: "grid", gap: 12, alignContent: "start" }}
             >
               {activeTabIntro ? (
                 <Card style={{ color: "#475569" }}>{activeTabIntro}</Card>


### PR DESCRIPTION
This PR improves the landlord analytics workspace UX.

Includes:
- sticky analytics workspace header
- title, tabs, filters, and Print / Save PDF combined into one control area
- preserved accessible tab behavior
- mobile-safe horizontal tab scrolling
- selected-workspace print/PDF output
- compact KPI summary and active filters in print output
- analytics-scoped neutral background fix for visual artifact
- focused frontend test coverage

Guardrails preserved:
- frontend-only
- no backend/API changes
- no analytics calculation changes
- no new analytics metrics
- no scoring/ranking/underwriting changes
- no permission changes
- no new charting or PDF library