### PR TITLE
fix: add action routing deeplinks

### DIFF
--- a/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.test.tsx
@@ -550,6 +550,65 @@ describe("ApplicationsPage", () => {
     expect(screen.getByText("40%")).toBeInTheDocument();
   });
 
+  it("hydrates analytics application-funnel query params into valid filters", async () => {
+    render(
+      <MemoryRouter initialEntries={["/applications?entry=application-funnel&status=SUBMITTED&propertyId=prop-1"]}>
+        <ApplicationsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Application funnel review")).toBeInTheDocument();
+    expect(screen.getByText(/Status filter: SUBMITTED/i)).toBeInTheDocument();
+    expect(screen.getByText(/Property: Harbour View/i)).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(mocks.fetchRentalApplications).toHaveBeenCalledWith(
+        expect.objectContaining({
+          propertyId: "prop-1",
+          status: "SUBMITTED",
+        })
+      );
+    });
+    await waitFor(() => {
+      expect(mocks.fetchLandlordApplicationFunnel).toHaveBeenCalledWith({ propertyId: "prop-1" });
+    });
+  });
+
+  it("ignores invalid application status query params without changing default loading", async () => {
+    render(
+      <MemoryRouter initialEntries={["/applications?status=review"]}>
+        <ApplicationsPage />
+      </MemoryRouter>
+    );
+
+    await screen.findByText("Jamie Stone");
+
+    await waitFor(() => {
+      expect(mocks.fetchRentalApplications).toHaveBeenCalledWith({
+        propertyId: undefined,
+        status: undefined,
+      });
+    });
+    expect(mocks.fetchRentalApplications).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "review",
+      })
+    );
+  });
+
+  it("preserves screening-checkout applicationId selection from query params", async () => {
+    render(
+      <MemoryRouter initialEntries={["/applications?entry=screening-checkout&applicationId=app-1"]}>
+        <ApplicationsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Screening checkout review")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mocks.fetchRentalApplication).toHaveBeenCalledWith("app-1");
+    });
+  });
+
   it("renders the application funnel card with counts and a simple drop-off hint", async () => {
     render(
       <MemoryRouter>

--- a/rentchain-frontend/src/pages/ApplicationsPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationsPage.tsx
@@ -118,6 +118,28 @@ const statusOptions: RentalApplicationStatus[] = [
   "CONDITIONAL_DEPOSIT",
 ];
 
+const supportedAnalyticsApplicationEntries = ["application-funnel", "screening-checkout"] as const;
+type AnalyticsApplicationEntry = (typeof supportedAnalyticsApplicationEntries)[number];
+
+const isAnalyticsApplicationEntry = (value: string | null): value is AnalyticsApplicationEntry =>
+  supportedAnalyticsApplicationEntries.includes(value as AnalyticsApplicationEntry);
+
+const normalizeApplicationStatusParam = (value: string | null): RentalApplicationStatus | null => {
+  const normalized = String(value || "").trim().toUpperCase();
+  return statusOptions.includes(normalized as RentalApplicationStatus) ? (normalized as RentalApplicationStatus) : null;
+};
+
+const analyticsApplicationEntryCopy: Record<AnalyticsApplicationEntry, { title: string; body: string }> = {
+  "application-funnel": {
+    title: "Application funnel review",
+    body: "Opened from analytics to review submitted application follow-through.",
+  },
+  "screening-checkout": {
+    title: "Screening checkout review",
+    body: "Opened from analytics to continue the selected application screening workflow.",
+  },
+};
+
 type PropertyOption = { id: string; name: string };
 
 const AI_FLAG_LABELS: Record<string, string> = {
@@ -297,7 +319,7 @@ const ApplicationsPage: React.FC = () => {
   const [loadingDetail, setLoadingDetail] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
-  const [statusFilter, setStatusFilter] = useState<string>("");
+  const [statusFilter, setStatusFilter] = useState<string>(() => normalizeApplicationStatusParam(upgradeParams.get("status")) || "");
   const [propertyFilter, setPropertyFilter] = useState<string>("");
   const [properties, setProperties] = useState<PropertyOption[]>([]);
   const [propertyRecords, setPropertyRecords] = useState<any[]>([]);
@@ -490,6 +512,15 @@ const ApplicationsPage: React.FC = () => {
     currentPlan === "elite";
   const upgradeConfirmed = upgradeParams.get("upgradeConfirmed") === "1";
   const upgradeHighlight = upgradeParams.get("highlight");
+  const analyticsEntryParam = upgradeParams.get("entry");
+  const analyticsEntry = isAnalyticsApplicationEntry(analyticsEntryParam) ? analyticsEntryParam : null;
+  const analyticsStatusFilter = normalizeApplicationStatusParam(upgradeParams.get("status"));
+  const analyticsPropertyId = String(upgradeParams.get("propertyId") || "").trim();
+  const analyticsEntryContext = analyticsEntry ? analyticsApplicationEntryCopy[analyticsEntry] : null;
+  const analyticsEntryPropertyName =
+    analyticsPropertyId && propertiesLoaded
+      ? properties.find((property) => property.id === analyticsPropertyId)?.name || null
+      : null;
   const canViewScreeningHistory = entitlements.canViewScreeningHistory;
   const canExportPdf = entitlements.canExportPdf;
   const canViewReviewSummary = entitlements.canViewReviewSummary;
@@ -1019,6 +1050,24 @@ const ApplicationsPage: React.FC = () => {
       alive = false;
     };
   }, [propertyFilter]);
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const nextStatus = normalizeApplicationStatusParam(params.get("status"));
+    if (nextStatus && nextStatus !== statusFilter) {
+      setStatusFilter(nextStatus);
+    }
+  }, [location.search, statusFilter]);
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const nextPropertyId = String(params.get("propertyId") || "").trim();
+    if (!nextPropertyId || !propertiesLoaded || propertiesError) return;
+    const propertyExists = properties.some((property) => property.id === nextPropertyId);
+    if (propertyExists && nextPropertyId !== propertyFilter) {
+      setPropertyFilter(nextPropertyId);
+    }
+  }, [location.search, properties, propertiesError, propertiesLoaded, propertyFilter]);
 
   useEffect(() => {
     const params = new URLSearchParams(location.search);
@@ -2056,6 +2105,28 @@ const ApplicationsPage: React.FC = () => {
             {upgradeHighlight === "screening"
               ? "Upgrade confirmed. Screening workflows are now active on this page."
               : "Upgrade confirmed. Secure application links are now active on this page."}
+          </div>
+        ) : null}
+        {analyticsEntryContext ? (
+          <div
+            style={{
+              marginTop: 12,
+              padding: "10px 12px",
+              borderRadius: 12,
+              border: "1px solid rgba(14,165,233,0.28)",
+              background: "rgba(14,165,233,0.08)",
+              color: text.primary,
+              fontSize: 13,
+              display: "grid",
+              gap: 4,
+            }}
+          >
+            <div style={{ fontWeight: 700 }}>{analyticsEntryContext.title}</div>
+            <div style={{ color: text.muted }}>
+              {analyticsEntryContext.body}
+              {analyticsStatusFilter ? ` Status filter: ${analyticsStatusFilter}.` : ""}
+              {analyticsEntryPropertyName ? ` Property: ${analyticsEntryPropertyName}.` : ""}
+            </div>
           </div>
         ) : null}
       </Card>

--- a/rentchain-frontend/src/pages/landlord/WorkOrdersPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/WorkOrdersPage.test.tsx
@@ -108,6 +108,51 @@ vi.mock("@/components/billing/FeatureTeaser", () => ({
   ),
 }));
 
+const makeWorkOrder = (overrides: Record<string, unknown> = {}) => ({
+  id: "wo-1",
+  landlordId: "landlord-1",
+  propertyId: "prop-1",
+  unitId: "unit-1",
+  title: "Broken heater",
+  description: "Restore heat in unit 3A",
+  category: "HVAC",
+  priority: "urgent",
+  status: "completed",
+  visibility: "private",
+  budgetMinCents: null,
+  budgetMaxCents: null,
+  assignedContractorId: "contractor-1",
+  invitedContractorIds: [],
+  acceptedAtMs: 10,
+  startedAtMs: 20,
+  completedAtMs: 30,
+  scheduledFor: 15,
+  serviceStartedAt: 20,
+  serviceCompletedAt: 30,
+  completionSummary: "Replaced igniter and restored heat.",
+  completionOutcome: "completed",
+  completedByActorRole: "contractor",
+  notifications: {
+    landlord: {
+      requiresReview: true,
+      requiresReschedule: false,
+      lastNotifiedAt: 39,
+    },
+  },
+  completionConfirmedByLandlordAt: null,
+  completionConfirmedByLandlordBy: null,
+  reopenedAt: null,
+  reopenedByActorId: null,
+  reopenedByActorRole: null,
+  reopenReason: null,
+  executionBlockedReason: null,
+  notesInternal: "",
+  linkedExpenseId: null,
+  createdAtMs: 1,
+  updatedAtMs: 35,
+  ...overrides,
+});
+
 describe("WorkOrdersPage", () => {
   beforeEach(() => {
     cleanup();
@@ -168,6 +213,70 @@ describe("WorkOrdersPage", () => {
     });
 
     expect(mocks.listWorkOrders).not.toHaveBeenCalled();
+  });
+
+  it("preserves default no-query work-order loading", async () => {
+    mocks.canUseWorkOrders = true;
+    mocks.listWorkOrders.mockResolvedValue([makeWorkOrder()]);
+
+    render(
+      <MemoryRouter>
+        <WorkOrdersPage />
+      </MemoryRouter>
+    );
+
+    expect((await screen.findAllByText("Broken heater")).length).toBeGreaterThan(0);
+    expect(screen.queryByText("Maintenance backlog review")).not.toBeInTheDocument();
+    expect(mocks.listWorkOrders).toHaveBeenCalledWith();
+  });
+
+  it("hydrates maintenance-backlog query params into a property-scoped visible list", async () => {
+    mocks.canUseWorkOrders = true;
+    mocks.fetchProperties.mockResolvedValue({
+      items: [
+        { id: "prop-1", name: "Harbour View" },
+        { id: "prop-2", name: "North Point" },
+      ],
+    });
+    mocks.listWorkOrders.mockResolvedValue([
+      makeWorkOrder({ id: "wo-1", propertyId: "prop-1", title: "Broken heater" }),
+      makeWorkOrder({ id: "wo-2", propertyId: "prop-2", title: "Lobby paint" }),
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={["/work-orders?entry=maintenance-backlog&propertyId=prop-1"]}>
+        <WorkOrdersPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Maintenance backlog review")).toBeInTheDocument();
+    expect((await screen.findAllByText("Broken heater")).length).toBeGreaterThan(0);
+    expect(screen.queryByText("Lobby paint")).not.toBeInTheDocument();
+    expect(await screen.findByText(/Property: Harbour View/i)).toBeInTheDocument();
+  });
+
+  it("hydrates maintenance-cost-approval query params and selects the matching work order", async () => {
+    mocks.canUseWorkOrders = true;
+    mocks.fetchProperties.mockResolvedValue({ items: [{ id: "prop-1", name: "Harbour View" }] });
+    mocks.listWorkOrders.mockResolvedValue([
+      makeWorkOrder({ id: "wo-1", propertyId: "prop-1", title: "Broken heater", cost: { reviewStatus: "pending_review" } }),
+      makeWorkOrder({ id: "wo-2", propertyId: "prop-1", title: "Leaky faucet" }),
+    ]);
+    mocks.listWorkOrderUpdates.mockResolvedValue([]);
+
+    render(
+      <MemoryRouter initialEntries={["/work-orders?entry=maintenance-cost-approval&propertyId=prop-1&workOrderId=wo-1"]}>
+        <WorkOrdersPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Maintenance cost approval")).toBeInTheDocument();
+    expect(await screen.findByText("Timeline: Broken heater")).toBeInTheDocument();
+    expect(await screen.findByText(/Matching work order selected when available/i)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mocks.listWorkOrderUpdates).toHaveBeenCalledWith("wo-1");
+    });
+    expect(mocks.reviewWorkOrderCost).not.toHaveBeenCalled();
   });
 
   it("shows execution details and lets the landlord confirm and reopen completion", async () => {

--- a/rentchain-frontend/src/pages/landlord/WorkOrdersPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/WorkOrdersPage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { Button, Card } from "../../components/ui/Ui";
 import { AddExpenseModal } from "../../components/expenses/AddExpenseModal";
 import ContractorAssignmentPanel from "../../components/marketplace/ContractorAssignmentPanel";
@@ -222,7 +222,25 @@ function expenseLinkStatusLabel(item: WorkOrderRecord | null) {
   return "Not linked";
 }
 
+const supportedWorkOrderEntries = ["maintenance-backlog", "maintenance-cost-approval"] as const;
+type WorkOrderEntry = (typeof supportedWorkOrderEntries)[number];
+
+const isWorkOrderEntry = (value: string | null): value is WorkOrderEntry =>
+  supportedWorkOrderEntries.includes(value as WorkOrderEntry);
+
+const workOrderEntryCopy: Record<WorkOrderEntry, { title: string; body: string }> = {
+  "maintenance-backlog": {
+    title: "Maintenance backlog review",
+    body: "Opened from analytics to review maintenance items that need landlord follow-through.",
+  },
+  "maintenance-cost-approval": {
+    title: "Maintenance cost approval",
+    body: "Opened from analytics to review the selected work order cost before any manual approval.",
+  },
+};
+
 export default function WorkOrdersPage() {
+  const location = useLocation();
   const entitlements = useEntitlements();
   const [items, setItems] = React.useState<WorkOrderRecord[]>([]);
   const [loading, setLoading] = React.useState(true);
@@ -270,6 +288,16 @@ export default function WorkOrdersPage() {
   const marketplaceDirectoryPlanLabel = resolveRequiredPlanLabel("marketplace_directory") || "Pro";
   const marketplaceAssignmentPlanLabel =
     resolveRequiredPlanLabel("marketplace_contractor_assignment") || "Elite";
+  const queryParams = React.useMemo(() => new URLSearchParams(location.search), [location.search]);
+  const entryParam = queryParams.get("entry");
+  const workOrderEntry = isWorkOrderEntry(entryParam) ? entryParam : null;
+  const workOrderEntryContext = workOrderEntry ? workOrderEntryCopy[workOrderEntry] : null;
+  const propertyIdParam = String(queryParams.get("propertyId") || "").trim();
+  const workOrderIdParam = String(queryParams.get("workOrderId") || "").trim();
+  const deepLinkPropertyName =
+    propertyIdParam && properties.length
+      ? properties.find((property) => property.id === propertyIdParam)?.name || null
+      : null;
 
   const normalizeCategory = React.useCallback((input: string): ExpenseCategory => {
     const raw = String(input || "").trim().toLowerCase();
@@ -344,6 +372,11 @@ export default function WorkOrdersPage() {
       (String(item.assignedContractorId || "").trim() ? "Assigned" : "-")
     );
   }, []);
+
+  const visibleWorkOrders = React.useMemo(() => {
+    if (!propertyIdParam) return items;
+    return items.filter((item) => item.propertyId === propertyIdParam);
+  }, [items, propertyIdParam]);
 
   const triggerExport = React.useCallback(async (format: "csv" | "xls") => {
     try {
@@ -893,6 +926,14 @@ export default function WorkOrdersPage() {
     void run();
   }, [canUseMarketplaceContractorAssignment, canUseWorkOrders, selected, selectedServiceArea]);
 
+  React.useEffect(() => {
+    if (!canUseWorkOrders || !workOrderIdParam || loading) return;
+    const nextSelected = items.find((item) => item.id === workOrderIdParam);
+    if (!nextSelected || selected?.id === nextSelected.id) return;
+    setSelected(nextSelected);
+    void loadUpdates(nextSelected.id);
+  }, [canUseWorkOrders, items, loadUpdates, loading, selected?.id, workOrderIdParam]);
+
   if (!canUseWorkOrders) {
     return (
       <LockedFeature
@@ -935,12 +976,31 @@ export default function WorkOrdersPage() {
         <Card style={{ borderColor: "#ef4444", color: "#991b1b" }}>{error}</Card>
       ) : null}
 
+      {workOrderEntryContext ? (
+        <Card
+          style={{
+            borderColor: "#bae6fd",
+            background: "#f0f9ff",
+            color: "#0f172a",
+            display: "grid",
+            gap: 4,
+          }}
+        >
+          <div style={{ fontWeight: 700 }}>{workOrderEntryContext.title}</div>
+          <div style={{ color: "#475569", fontSize: 13 }}>
+            {workOrderEntryContext.body}
+            {deepLinkPropertyName ? ` Property: ${deepLinkPropertyName}.` : propertyIdParam ? " Property filter applied." : ""}
+            {workOrderIdParam ? " Matching work order selected when available." : ""}
+          </div>
+        </Card>
+      ) : null}
+
       <div className="print-only print-only-summary">
         <div className="printHeader">
           <div className="printTitle">Work orders summary</div>
           <div className="printMeta">
             <div>Generated: {new Date().toLocaleString()}</div>
-            <div>Rows: {items.length}</div>
+            <div>Rows: {visibleWorkOrders.length}</div>
           </div>
         </div>
         <div className="printH3">Work orders</div>
@@ -960,7 +1020,7 @@ export default function WorkOrdersPage() {
             </tr>
           </thead>
           <tbody>
-            {items.map((item) => (
+            {visibleWorkOrders.map((item) => (
               <tr key={item.id}>
                 <td>{item.title}</td>
                 <td>{getPropertyLabel(item)}</td>
@@ -1027,11 +1087,11 @@ export default function WorkOrdersPage() {
         <Card>
           {loading ? (
             <div>Loading work orders...</div>
-          ) : items.length === 0 ? (
+          ) : visibleWorkOrders.length === 0 ? (
             <div style={{ color: "#64748b" }}>No work orders yet.</div>
           ) : isMobile ? (
             <div style={{ display: "grid", gap: 12 }}>
-              {items.map((item) => (
+              {visibleWorkOrders.map((item) => (
                 <div
                   key={item.id}
                   style={{
@@ -1124,7 +1184,7 @@ export default function WorkOrdersPage() {
                 </tr>
               </thead>
               <tbody>
-                {items.map((item) => (
+                {visibleWorkOrders.map((item) => (
                   <tr key={item.id} style={{ borderBottom: "1px solid #f1f5f9" }}>
                     <td style={{ padding: 8, fontWeight: 600 }}>{item.title}</td>
                     <td style={{ padding: 8 }}>{item.category || "-"}</td>


### PR DESCRIPTION
This PR adds action-routing deeplink support.

Includes:
- /applications query-param hydration for application-funnel and screening-checkout entries
- property/status filter hydration with invalid status safely ignored
- existing applicationId/modal/screening/upgrade behavior preserved
- /work-orders query-param hydration for maintenance backlog and cost approval entries
- work-order property filtering and workOrderId selection without executing actions
- contextual entry cards on supported routed entries
- focused frontend test coverage

Guardrails preserved:
- frontend-only
- no backend/API changes
- no workflow state changes
- no automatic execution behavior
- no permission changes
- no analytics calculation changes
- no broad page redesign

PR note:
- ApplicationsPage tests passed: 23 tests.
- WorkOrdersPage tests passed: 15 tests.
- Frontend build passed.
- git diff --check passed.
- Existing large chunk warning remains unchanged and out of scope.
- Backend action metadata changes, API filtering contracts, new workflow states/routes, dashboard status taxonomy changes, and automatic execution remain deferred.