### PR TITLE
fix: clarify tenant activity ledger separation

### DIFF
--- a/rentchain-frontend/src/components/tenants/RecordTenantEventModal.test.tsx
+++ b/rentchain-frontend/src/components/tenants/RecordTenantEventModal.test.tsx
@@ -1,0 +1,64 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RecordTenantEventModal } from "./RecordTenantEventModal";
+
+const mocks = vi.hoisted(() => ({
+  createTenantEvent: vi.fn(),
+  showToast: vi.fn(),
+}));
+
+vi.mock("../../api/tenantEventsWriteApi", () => ({
+  createTenantEvent: mocks.createTenantEvent,
+}));
+
+vi.mock("../ui/ToastProvider", () => ({
+  useToast: () => ({ showToast: mocks.showToast }),
+}));
+
+describe("RecordTenantEventModal", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("explains that tenant activity records timeline notes only", () => {
+    render(
+      <RecordTenantEventModal
+        open
+        tenantId="tenant-1"
+        tenantName="Taylor Tenant"
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByText(
+        /Tenant activity records notes on the tenant timeline only\. To add charges or payments to the lease ledger, use the current lease ledger\./
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("labels finance-looking activity types as timeline notes", () => {
+    render(
+      <RecordTenantEventModal
+        open
+        tenantId="tenant-1"
+        tenantName="Taylor Tenant"
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByText("Timeline note only — does not update the lease ledger or payments register.")
+    ).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/Event type/i), { target: { value: "CHARGE_ADDED" } });
+
+    expect(
+      screen.getByText("Timeline note only — does not update the lease ledger or payments register.")
+    ).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/tenants/RecordTenantEventModal.tsx
+++ b/rentchain-frontend/src/components/tenants/RecordTenantEventModal.tsx
@@ -15,12 +15,15 @@ type Props = {
 };
 
 const TYPES: { type: TenantEventType; label: string; hint: string }[] = [
-  { type: "PAYMENT_RECORDED", label: "Payment recorded", hint: "Payment received" },
-  { type: "CHARGE_ADDED", label: "Charge added", hint: "Rent or fee added" },
+  { type: "PAYMENT_RECORDED", label: "Payment recorded", hint: "Payment received as a tenant timeline note" },
+  { type: "CHARGE_ADDED", label: "Charge added", hint: "Rent or fee noted on the tenant timeline" },
   { type: "ADJUSTMENT_RECORDED", label: "Adjustment recorded", hint: "Credit or adjustment" },
   { type: "NOTICE_SERVED", label: "Notice served", hint: "Formal notice delivered" },
   { type: "LEASE_STARTED", label: "Lease started", hint: "Start of tenancy" },
 ];
+
+const TIMELINE_ONLY_FINANCE_TYPES: TenantEventType[] = ["PAYMENT_RECORDED", "CHARGE_ADDED"];
+const timelineOnlyFinanceCopy = "Timeline note only — does not update the lease ledger or payments register.";
 
 const isoToday = () => {
   const d = new Date();
@@ -62,6 +65,7 @@ export const RecordTenantEventModal: React.FC<Props> = ({
 
   const financeTypes: TenantEventType[] = ["PAYMENT_RECORDED", "CHARGE_ADDED", "ADJUSTMENT_RECORDED"];
   const showAmount = financeTypes.includes(type);
+  const isTimelineOnlyFinanceType = TIMELINE_ONLY_FINANCE_TYPES.includes(type);
   const showDaysLate = false;
   const showNotice = type === "NOTICE_SERVED";
 
@@ -216,7 +220,8 @@ export const RecordTenantEventModal: React.FC<Props> = ({
           <div>
             <div style={{ fontSize: 16, fontWeight: 700 }}>Record tenant event</div>
             <div style={{ fontSize: 12, color: text.muted }}>
-              This becomes part of the tenant's permanent rental history.
+              Tenant activity records notes on the tenant timeline only. To add charges or payments to the lease ledger,
+              use the current lease ledger.
             </div>
           </div>
           <button
@@ -259,6 +264,11 @@ export const RecordTenantEventModal: React.FC<Props> = ({
               ))}
             </select>
             <div style={{ fontSize: 12, color: text.muted }}>{typeMeta?.hint}</div>
+            {isTimelineOnlyFinanceType ? (
+              <div style={{ fontSize: 12, color: text.muted, fontWeight: 600 }}>
+                {timelineOnlyFinanceCopy}
+              </div>
+            ) : null}
         </label>
 
           <label style={{ display: "grid", gap: 6 }}>

--- a/rentchain-frontend/src/components/tenants/TenantActivityPanel.test.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantActivityPanel.test.tsx
@@ -96,6 +96,33 @@ describe("TenantActivityPanel", () => {
 
     const expected = new Date("2026-04-20T09:00:00.000Z").toLocaleString();
     expect(await screen.findByText("Payment recorded")).toBeInTheDocument();
+    expect(screen.getByText("Timeline note")).toBeInTheDocument();
     expect(screen.getByText(expected)).toBeInTheDocument();
+  });
+
+  it("marks charge activity entries as timeline notes without implying ledger changes", async () => {
+    mocks.listTenantEvents.mockResolvedValue({
+      ok: true,
+      items: [
+        {
+          id: "event-4",
+          tenantId: "tenant-1",
+          landlordId: "landlord-1",
+          type: "CHARGE_ADDED",
+          title: "Charge added",
+          description: "Manual charge note",
+          amountCents: 12500,
+          currency: "CAD",
+          createdAt: "2026-04-23T11:00:00.000Z",
+        },
+      ],
+      nextCursor: null,
+    });
+
+    render(<TenantActivityPanel tenantId="tenant-1" />);
+
+    expect(await screen.findByText("Charge added")).toBeInTheDocument();
+    expect(screen.getByText("Timeline note")).toBeInTheDocument();
+    expect(screen.getByText(/CHARGE_ADDED/)).toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/components/tenants/TenantActivityPanel.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantActivityPanel.tsx
@@ -24,6 +24,10 @@ function getErrorMessage(error: unknown) {
   return "Failed to load tenant activity";
 }
 
+function isTimelineOnlyFinanceType(type?: string | null) {
+  return type === "PAYMENT_RECORDED" || type === "CHARGE_ADDED";
+}
+
 export const TenantActivityPanel: React.FC<Props> = ({ tenantId, refreshKey = 0 }) => {
   const [items, setItems] = useState<TenantEvent[]>([]);
   const [nextCursor, setNextCursor] = useState<string | number | null>(null);
@@ -142,6 +146,7 @@ export const TenantActivityPanel: React.FC<Props> = ({ tenantId, refreshKey = 0 
             const occurred = toMillis(evt.occurredAt);
             const created = toMillis(evt.createdAt);
             const when = occurred || created ? new Date(occurred || created || 0).toLocaleString() : "";
+            const showTimelineNote = isTimelineOnlyFinanceType(evt.type);
 
             return (
               <div
@@ -183,7 +188,23 @@ export const TenantActivityPanel: React.FC<Props> = ({ tenantId, refreshKey = 0 
                         marginBottom: 2,
                       }}
                     >
-                      {evt.title || evt.type}
+                      <span>{evt.title || evt.type}</span>
+                      {showTimelineNote ? (
+                        <span
+                          style={{
+                            marginLeft: 6,
+                            padding: "2px 6px",
+                            borderRadius: "999px",
+                            border: `1px solid ${colors.border}`,
+                            color: text.muted,
+                            fontSize: 10,
+                            fontWeight: 700,
+                            whiteSpace: "nowrap",
+                          }}
+                        >
+                          Timeline note
+                        </span>
+                      ) : null}
                     </div>
                     {evt.description ? (
                       <div style={{ color: text.muted }}>{evt.description}</div>

--- a/rentchain-frontend/src/components/tenants/TenantDetailPanel.test.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantDetailPanel.test.tsx
@@ -175,6 +175,7 @@ describe("TenantDetailPanel", () => {
 
     expect(await screen.findByText("Recent current lease ledger entries")).toBeInTheDocument();
     expect(screen.getByText("Showing the most recent charges and payments from the current lease ledger.")).toBeInTheDocument();
+    expect(screen.getByText("Use the current lease ledger to record charges and payments.")).toBeInTheDocument();
     expect(screen.getByText("Showing the latest 10 entries here. Open current lease ledger for the full history.")).toBeInTheDocument();
     expect(
       screen.getByText(

--- a/rentchain-frontend/src/components/tenants/TenantDetailPanel.tsx
+++ b/rentchain-frontend/src/components/tenants/TenantDetailPanel.tsx
@@ -663,11 +663,15 @@ const TenantDetailLayout: React.FC<LayoutProps> = ({ bundle, tenantId, activityR
             style={{
               marginTop: "0.5rem",
               display: "flex",
-              justifyContent: "flex-end",
+              justifyContent: "space-between",
+              alignItems: "center",
               gap: 8,
               flexWrap: "wrap",
             }}
           >
+            <div style={{ color: text.muted, fontSize: "0.8rem" }}>
+              Use the current lease ledger to record charges and payments.
+            </div>
             <button
               type="button"
               onClick={handleViewInLedger}


### PR DESCRIPTION
This PR completes Phase 1 of Tenant Activity / Ledger Unification.

Includes:
- clearer tenant activity timeline-only copy
- finance-looking tenant events remain selectable but are marked as timeline notes
- Tenant Activity rows show Timeline note badge for PAYMENT_RECORDED and CHARGE_ADDED
- Tenant detail guides landlords to the current lease ledger for real charges/payments
- focused frontend test coverage

Guardrails preserved:
- frontend-only
- no backend changes
- no ledger write behavior changes
- no payments behavior changes
- no financial projection changes
- no data mutation
- no source merging

PR note:
- Tenant activity/modal/detail tests passed: 8 tests.
- Frontend build passed.
- git diff --check passed.
- Existing large chunk warning remains unchanged and out of scope.
- Phase 2 route ownership cleanup and Phase 3 explicit conversion workflow remain deferred.