### PR TITLE
fix: repair exports and demo login

### DIFF
--- a/rentchain-api/src/routes/__tests__/expensesRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/expensesRoutes.test.ts
@@ -234,7 +234,7 @@ describe("expenses routes", () => {
     expect(res.text).toContain("125.00");
   });
 
-  it("exports spreadsheet xml with human property and unit labels", async () => {
+  it("exports spreadsheet table with human property and unit labels", async () => {
     setPlan("pro");
     seedDoc("units", "unit-1", {
       landlordId: "landlord-1",
@@ -263,6 +263,10 @@ describe("expenses routes", () => {
     );
     expect(res.text).toContain("Alpha Property");
     expect(res.text).toContain("12A");
+    expect(res.text).toContain("<table>");
+    expect(res.text).toContain("<th>Date</th>");
+    expect(res.text).not.toContain("<?xml");
+    expect(res.text).not.toContain("<Workbook");
     expect(res.text).not.toContain("prop-1");
     expect(res.text).not.toContain("unit-1");
   });

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.integrity.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.integrity.test.ts
@@ -203,6 +203,46 @@ describe("leaseRoutes integrity repairs", () => {
     expect(res.body?.totals?.chargesCents).toBe(180000);
   });
 
+  it("exports lease ledger csv with property and unit labels instead of raw ids", async () => {
+    seedDoc("properties", "prop-1", {
+      landlordId: "landlord-1",
+      propertyAddress: "123 Main St",
+      name: "Harbour View",
+    });
+    seedDoc("leases", "lease-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      unitId: "unit-1",
+      unitNumber: "101",
+      status: "active",
+    });
+    seedDoc("ledgerEntries", "entry-1", {
+      landlordId: "landlord-1",
+      leaseId: "lease-1",
+      entryType: "charge",
+      category: "rent",
+      amountCents: 180000,
+      effectiveDate: "2026-04-01",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      createdAt: 10,
+    });
+
+    const app = await makeApp();
+    const res = await request(app).get("/lease-1/ledger/export.csv");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toContain("text/csv");
+    expect(res.text).toContain("property,unit");
+    expect(res.text).toContain("123 Main St");
+    expect(res.text).toContain("101");
+    expect(res.text).not.toContain("propertyId");
+    expect(res.text).not.toContain("unitId");
+    expect(res.text).not.toContain("prop-1");
+    expect(res.text).not.toContain("unit-1");
+  });
+
   it("converts an occupied unit reference into a canonical lease and tenant", async () => {
     seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Harbour View" });
     seedDoc("units", "unit-1", {

--- a/rentchain-api/src/routes/__tests__/paymentsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/paymentsRoutes.test.ts
@@ -165,7 +165,7 @@ describe("paymentsRoutes exports", () => {
     expect(String(res.body)).not.toContain("prop-1");
   });
 
-  it("exports spreadsheet xml from the primary .xls route with safe labels", async () => {
+  it("exports spreadsheet table from the primary .xls route with safe labels", async () => {
     const router = (await import("../paymentsRoutes")).default;
     const res = await invokeRouter(router, { method: "GET", url: "/payments/export.xls" });
 
@@ -176,6 +176,10 @@ describe("paymentsRoutes exports", () => {
     );
     expect(String(res.body)).toContain("Taylor Tenant");
     expect(String(res.body)).toContain("123 Main St");
+    expect(String(res.body)).toContain("<table>");
+    expect(String(res.body)).toContain("<th>Paid Date</th>");
+    expect(String(res.body)).not.toContain("<?xml");
+    expect(String(res.body)).not.toContain("<Workbook");
   });
 
   it("keeps the legacy .xlsx spreadsheet route as a compatibility alias", async () => {

--- a/rentchain-api/src/routes/__tests__/workOrdersRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/workOrdersRoutes.test.ts
@@ -1248,7 +1248,7 @@ describe("workOrdersRoutes execution completion", () => {
     expect(String(res.body)).not.toContain("https://example.com/invoice.pdf");
   });
 
-  it("exports spreadsheet xml with human property and unit labels", async () => {
+  it("exports spreadsheet table with human property and unit labels", async () => {
     const router = (await import("../workOrdersRoutes")).default;
     ensureCollection("workOrders").set("wo-1", {
       ...ensureCollection("workOrders").get("wo-1"),
@@ -1276,6 +1276,10 @@ describe("workOrdersRoutes execution completion", () => {
     );
     expect(String(res.body)).toContain("123 Main St");
     expect(String(res.body)).toContain("4B");
+    expect(String(res.body)).toContain("<table>");
+    expect(String(res.body)).toContain("<th>Title</th>");
+    expect(String(res.body)).not.toContain("<?xml");
+    expect(String(res.body)).not.toContain("<Workbook");
     expect(String(res.body)).not.toContain("prop-1");
     expect(String(res.body)).not.toContain("unit-1");
   });

--- a/rentchain-api/src/routes/expensesRoutes.ts
+++ b/rentchain-api/src/routes/expensesRoutes.ts
@@ -645,15 +645,18 @@ async function buildExpenseExportRows(items: any[], propertyNames: Map<string, s
   }));
 }
 
-function renderExpenseSpreadsheetXml(rows: Array<Record<string, string>>, totalAmountCents: number) {
-  const headers = ["Date", "Property", "Unit", "Category", "Vendor", "Description", "Amount", "Status", "Source"];
-  const xmlEscape = (value: unknown) =>
-    String(value ?? "")
-      .replace(/&/g, "&amp;")
-      .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;");
+function htmlEscape(value: unknown) {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
 
-  const rowXml = rows
+function renderExpensesSpreadsheetTable(rows: Array<Record<string, string>>, totalAmountCents: number) {
+  const headers = ["Date", "Property", "Unit", "Category", "Vendor", "Description", "Amount", "Status", "Source"];
+
+  const rowHtml = rows
     .map((row) => {
       const cells = [
         row.date,
@@ -666,34 +669,30 @@ function renderExpenseSpreadsheetXml(rows: Array<Record<string, string>>, totalA
         row.status,
         row.source,
       ]
-        .map(
-          (value) =>
-            `<Cell><Data ss:Type="String">${xmlEscape(value)}</Data></Cell>`
-        )
+        .map((value) => `<td>${htmlEscape(value)}</td>`)
         .join("");
-      return `<Row>${cells}</Row>`;
+      return `<tr>${cells}</tr>`;
     })
     .join("");
 
-  return `<?xml version="1.0"?>
-<?mso-application progid="Excel.Sheet"?>
-<Workbook xmlns="urn:schemas-microsoft-com:office:spreadsheet"
- xmlns:o="urn:schemas-microsoft-com:office:office"
- xmlns:x="urn:schemas-microsoft-com:office:excel"
- xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet">
-  <Worksheet ss:Name="Expenses">
-    <Table>
-      <Row>${headers.map((header) => `<Cell><Data ss:Type="String">${xmlEscape(header)}</Data></Cell>`).join("")}</Row>
-      ${rowXml}
-      <Row>
-        <Cell><Data ss:Type="String">Total</Data></Cell>
-        <Cell/><Cell/><Cell/><Cell/><Cell/>
-        <Cell><Data ss:Type="String">${(totalAmountCents / 100).toFixed(2)}</Data></Cell>
-        <Cell/><Cell/>
-      </Row>
-    </Table>
-  </Worksheet>
-</Workbook>`;
+  return `<!doctype html>
+<html>
+  <head><meta charset="utf-8"><title>RentChain Expenses Export</title></head>
+  <body>
+    <table>
+      <thead><tr>${headers.map((header) => `<th>${htmlEscape(header)}</th>`).join("")}</tr></thead>
+      <tbody>
+        ${rowHtml}
+        <tr>
+          <td>Total</td>
+          <td></td><td></td><td></td><td></td><td></td>
+          <td>${htmlEscape((totalAmountCents / 100).toFixed(2))}</td>
+          <td></td><td></td>
+        </tr>
+      </tbody>
+    </table>
+  </body>
+</html>`;
 }
 
 async function renderExpensePdf(params: {
@@ -1485,13 +1484,13 @@ async function handleExpenseSpreadsheetExport(req: any, res: any) {
     });
     const rows = await buildExpenseExportRows(result.items, propertyNames);
     const totalAmountCents = result.items.reduce((sum: number, item: any) => sum + Number(item.amountCents || 0), 0);
-    const xml = renderExpenseSpreadsheetXml(rows, totalAmountCents);
+    const table = renderExpensesSpreadsheetTable(rows, totalAmountCents);
 
     setAttachmentExportHeaders(res, {
       filename: buildDatedExportFilename({ prefix: "rentchain-expenses", format: "xls" }),
       format: "xls",
     });
-    return res.status(200).send(xml);
+    return res.status(200).send(table);
   } catch (err: any) {
     console.error("[expenses] xls export failed", err?.message || err);
     return res.status(500).json({ ok: false, error: "EXPENSE_EXPORT_FAILED" });

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -713,6 +713,24 @@ async function loadLedgerEntries(leaseId: string, landlordId: string, from?: str
     });
 }
 
+async function resolveLeaseLedgerExportLabels(lease: any) {
+  const propertyId = String(lease?.propertyId || "").trim();
+  const propertySnap = propertyId
+    ? await db.collection("properties").doc(propertyId).get().catch(() => null)
+    : null;
+  const propertyData = propertySnap?.exists ? (propertySnap.data() as any) : null;
+  const property =
+    String(propertyData?.propertyAddress || lease?.propertyAddress || "").trim() ||
+    String(propertyData?.addressLine1 || propertyData?.address || lease?.addressLine1 || lease?.address || "").trim() ||
+    String(propertyData?.propertyName || lease?.propertyName || "").trim() ||
+    String(propertyData?.name || lease?.name || "").trim() ||
+    "Property";
+  const unit =
+    String(lease?.unitLabel || lease?.unitNumber || lease?.unit || "").trim() ||
+    "Unit";
+  return { property, unit };
+}
+
 async function enforceLeaseCapability(req: any, res: Response): Promise<boolean> {
   const landlordId = req.user?.landlordId || req.user?.id;
   if (!landlordId) {
@@ -2292,6 +2310,7 @@ router.get("/:leaseId/ledger/export.csv", async (req: any, res: Response) => {
     const from = toIsoDate(req.query?.from) || null;
     const to = toIsoDate(req.query?.to) || null;
     const entries = await loadLedgerEntries(leaseId, landlordId, from, to);
+    const labels = await resolveLeaseLedgerExportLabels(leaseCheck.lease);
     let runningBalance = 0;
     const header = [
       "date",
@@ -2303,8 +2322,8 @@ router.get("/:leaseId/ledger/export.csv", async (req: any, res: Response) => {
       "method",
       "reference",
       "notes",
-      "propertyId",
-      "unitId",
+      "property",
+      "unit",
       "createdAt",
     ];
     const rows = entries.map((entry: any) => {
@@ -2320,8 +2339,8 @@ router.get("/:leaseId/ledger/export.csv", async (req: any, res: Response) => {
         entry.method || "",
         entry.reference || "",
         entry.notes || "",
-        entry.propertyId || "",
-        entry.unitId || "",
+        labels.property,
+        labels.unit,
         entry.createdAt || "",
       ]
         .map(escapeCsvCell)

--- a/rentchain-api/src/routes/paymentsRoutes.ts
+++ b/rentchain-api/src/routes/paymentsRoutes.ts
@@ -23,12 +23,6 @@ const csvEscape = (value: unknown) => {
   return text;
 };
 
-const xmlEscape = (value: unknown) =>
-  String(value ?? "")
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
-
 const roleForReq = (req: any) => String(req.user?.actorRole || req.user?.role || "").trim().toLowerCase();
 
 function resolveTenantLabel(raw: any): string {
@@ -151,30 +145,35 @@ async function buildPaymentExportRows(payments: Payment[]) {
   }));
 }
 
-function renderPaymentSpreadsheetXml(rows: Array<Record<string, string>>) {
+function htmlEscape(value: unknown) {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function renderPaymentsSpreadsheetTable(rows: Array<Record<string, string>>) {
   const headers = ["Paid Date", "Tenant", "Property", "Amount", "Method", "Notes"];
-  const rowXml = rows
+  const rowHtml = rows
     .map((row) => {
       const cells = [row.paidDate, row.tenant, row.property, row.amount, row.method, row.notes]
-        .map((value) => `<Cell><Data ss:Type="String">${xmlEscape(value)}</Data></Cell>`)
+        .map((value) => `<td>${htmlEscape(value)}</td>`)
         .join("");
-      return `<Row>${cells}</Row>`;
+      return `<tr>${cells}</tr>`;
     })
     .join("");
 
-  return `<?xml version="1.0"?>
-<?mso-application progid="Excel.Sheet"?>
-<Workbook xmlns="urn:schemas-microsoft-com:office:spreadsheet"
- xmlns:o="urn:schemas-microsoft-com:office:office"
- xmlns:x="urn:schemas-microsoft-com:office:excel"
- xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet">
-  <Worksheet ss:Name="Payments">
-    <Table>
-      <Row>${headers.map((header) => `<Cell><Data ss:Type="String">${xmlEscape(header)}</Data></Cell>`).join("")}</Row>
-      ${rowXml}
-    </Table>
-  </Worksheet>
-</Workbook>`;
+  return `<!doctype html>
+<html>
+  <head><meta charset="utf-8"><title>RentChain Payments Export</title></head>
+  <body>
+    <table>
+      <thead><tr>${headers.map((header) => `<th>${htmlEscape(header)}</th>`).join("")}</tr></thead>
+      <tbody>${rowHtml}</tbody>
+    </table>
+  </body>
+</html>`;
 }
 
 const parseYearMonth = (req: Request): { year: number; month: number } | null => {
@@ -231,13 +230,13 @@ async function handlePaymentSpreadsheetExport(req: any, res: Response) {
     }
 
     const rows = await buildPaymentExportRows(await listPersistedPayments());
-    const xml = renderPaymentSpreadsheetXml(rows);
+    const table = renderPaymentsSpreadsheetTable(rows);
 
     setAttachmentExportHeaders(res, {
       filename: buildDatedExportFilename({ prefix: "rentchain-payments", format: "xls" }),
       format: "xls",
     });
-    return res.status(200).send(xml);
+    return res.status(200).send(table);
   } catch (err) {
     console.error("[paymentsRoutes] xls export failed", err);
     return res.status(500).json({ ok: false, error: "PAYMENTS_EXPORT_FAILED" });

--- a/rentchain-api/src/routes/workOrdersRoutes.ts
+++ b/rentchain-api/src/routes/workOrdersRoutes.ts
@@ -729,11 +729,12 @@ function exportCsvEscape(value: unknown): string {
   return text;
 }
 
-function exportXmlEscape(value: unknown) {
+function exportHtmlEscape(value: unknown) {
   return String(value ?? "")
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
 }
 
 function exportDateTime(value: unknown) {
@@ -809,7 +810,7 @@ async function buildWorkOrderExportRows(items: any[]) {
   }));
 }
 
-function renderWorkOrderSpreadsheetXml(rows: Array<Record<string, string>>) {
+function renderWorkOrdersSpreadsheetTable(rows: Array<Record<string, string>>) {
   const headers = [
     "Title",
     "Property",
@@ -830,7 +831,7 @@ function renderWorkOrderSpreadsheetXml(rows: Array<Record<string, string>>) {
     "Linked Expense Status",
     "Latest Comment",
   ];
-  const rowXml = rows
+  const rowHtml = rows
     .map((row) => {
       const values = [
         row.title,
@@ -852,25 +853,20 @@ function renderWorkOrderSpreadsheetXml(rows: Array<Record<string, string>>) {
         row.linkedExpenseStatus,
         row.latestComment,
       ];
-      return `<Row>${values
-        .map((value) => `<Cell><Data ss:Type="String">${exportXmlEscape(value)}</Data></Cell>`)
-        .join("")}</Row>`;
+      return `<tr>${values.map((value) => `<td>${exportHtmlEscape(value)}</td>`).join("")}</tr>`;
     })
     .join("");
 
-  return `<?xml version="1.0"?>
-<?mso-application progid="Excel.Sheet"?>
-<Workbook xmlns="urn:schemas-microsoft-com:office:spreadsheet"
- xmlns:o="urn:schemas-microsoft-com:office:office"
- xmlns:x="urn:schemas-microsoft-com:office:excel"
- xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet">
-  <Worksheet ss:Name="Work Orders">
-    <Table>
-      <Row>${headers.map((header) => `<Cell><Data ss:Type="String">${exportXmlEscape(header)}</Data></Cell>`).join("")}</Row>
-      ${rowXml}
-    </Table>
-  </Worksheet>
-</Workbook>`;
+  return `<!doctype html>
+<html>
+  <head><meta charset="utf-8"><title>RentChain Work Orders Export</title></head>
+  <body>
+    <table>
+      <thead><tr>${headers.map((header) => `<th>${exportHtmlEscape(header)}</th>`).join("")}</tr></thead>
+      <tbody>${rowHtml}</tbody>
+    </table>
+  </body>
+</html>`;
 }
 router.post("/contractor/profile", requireAuth, async (req: any, res) => {
   try {
@@ -1565,13 +1561,13 @@ async function handleWorkOrderSpreadsheetExport(req: any, res: any) {
   try {
     if (!isLandlord(req)) return res.status(403).json({ ok: false, error: "FORBIDDEN" });
     const rows = await buildWorkOrderExportRows(await listLandlordWorkOrdersForExport(req));
-    const xml = renderWorkOrderSpreadsheetXml(rows);
+    const table = renderWorkOrdersSpreadsheetTable(rows);
 
     setAttachmentExportHeaders(res, {
       filename: buildDatedExportFilename({ prefix: "rentchain-work-orders", format: "xls" }),
       format: "xls",
     });
-    return res.status(200).send(xml);
+    return res.status(200).send(table);
   } catch (err) {
     console.error("[work-orders] xls export failed", err);
     return res.status(500).json({ ok: false, error: "WORK_ORDER_EXPORT_FAILED" });

--- a/rentchain-frontend/src/api/authApi.ts
+++ b/rentchain-frontend/src/api/authApi.ts
@@ -108,10 +108,14 @@ export async function signup(
 }
 
 export async function loginDemo(plan: string = "core"): Promise<LoginResponse> {
-  const demoEmail = import.meta.env.DEV ? "demo@rentchain.dev" : "";
-  return login(demoEmail, "demo", {
+  const response = await apiJson<LoginResponse>("/api/auth/login/demo", {
+    method: "POST",
     headers: { "x-rentchain-plan": plan },
   });
+  const token = (response as any)?.token;
+  if (!token) throw new Error("Token missing from demo login response");
+  setAuthToken(token);
+  return response;
 }
 
 export async function verifyTwoFactorCode(

--- a/rentchain-frontend/src/context/AuthContext.tsx
+++ b/rentchain-frontend/src/context/AuthContext.tsx
@@ -444,9 +444,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     try {
       clearAuthStateBeforeNewSession();
       const demoEmail = import.meta.env.DEV ? "demo@rentchain.dev" : "";
-      const response = await apiLogin(demoEmail, "demo", {
-        headers: { "x-rentchain-plan": plan },
-      });
+      const response = await apiLoginDemo(plan);
 
       if (response.requires2fa) {
         setTwoFactorPendingToken(response.pendingToken ?? null);

--- a/rentchain-frontend/src/context/__tests__/AuthContext.test.ts
+++ b/rentchain-frontend/src/context/__tests__/AuthContext.test.ts
@@ -1,0 +1,88 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthProvider, useAuth } from "../AuthContext";
+import { TOKEN_KEY } from "../../lib/authToken";
+
+vi.mock("../../api/baseUrl", () => ({
+  getApiBaseUrl: () => "https://rentchain.test",
+}));
+
+vi.mock("../../lib/firebaseAuthToken", () => ({
+  getFirebaseIdToken: vi.fn(async () => null),
+  warnIfFirebaseDomainMismatch: vi.fn(),
+}));
+
+const demoUser = {
+  id: "demo-landlord",
+  email: "demo@rentchain.dev",
+  role: "landlord",
+  landlordId: "demo-landlord",
+  plan: "elite",
+};
+
+function DemoLoginHarness() {
+  const auth = useAuth();
+  return React.createElement(
+    "div",
+    null,
+    React.createElement("button", { onClick: () => void auth.loginDemo("elite") }, "Login demo"),
+    React.createElement("div", { "data-testid": "token" }, auth.token || ""),
+    React.createElement("div", { "data-testid": "email" }, auth.user?.email || "")
+  );
+}
+
+describe("AuthContext demo login", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  it("calls the demo login endpoint without a password and stores the returned token", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "https://rentchain.test/api/auth/login/demo") {
+        expect(init?.method).toBe("POST");
+        expect(init?.body).toBeUndefined();
+        expect(new Headers(init?.headers).get("x-rentchain-plan")).toBe("elite");
+        return new Response(JSON.stringify({ token: "demo.token.value", user: demoUser }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+
+      if (url === "https://rentchain.test/api/me") {
+        expect(new Headers(init?.headers).get("authorization")).toBe("Bearer demo.token.value");
+        return new Response(JSON.stringify({ user: demoUser }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    global.fetch = fetchMock as any;
+
+    render(
+      React.createElement(
+        AuthProvider,
+        null,
+        React.createElement(DemoLoginHarness)
+      )
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Login demo" }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith("https://rentchain.test/api/auth/login/demo", expect.any(Object)));
+    await waitFor(() => expect(screen.getByTestId("email")).toHaveTextContent("demo@rentchain.dev"));
+
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      "https://rentchain.test/api/auth/login",
+      expect.objectContaining({ body: expect.stringContaining("demo") })
+    );
+    expect(window.localStorage.getItem(TOKEN_KEY)).toBe("demo.token.value");
+    expect(window.sessionStorage.getItem(TOKEN_KEY)).toBe("demo.token.value");
+    expect(screen.getByTestId("token")).toHaveTextContent("demo.token.value");
+  });
+});


### PR DESCRIPTION
This PR repairs export download formatting, lease ledger export labels, and demo login.

Includes:
- payments, expenses, and work-orders spreadsheet exports now return clean HTML table .xls output instead of SpreadsheetML XML shown as code
- lease ledger CSV exports now use landlord-readable property/unit labels instead of raw propertyId/unitId columns
- demo login now calls POST /api/auth/login/demo without password fallback
- existing auth token storage/hydration behavior preserved
- focused backend/frontend test coverage

Guardrails preserved:
- no new spreadsheet library
- no XLSX conversion
- no export data-source changes
- no payment/provider changes
- no schema migration
- no auth model weakening
- no backend permission changes
- no UI redesign

PR note:
- Backend focused tests passed: 39 tests.
- Frontend focused tests passed: 3 tests.
- API build passed using Node 20 path.
- Frontend build passed.
- git diff --check passed.
- Existing frontend large chunk warning remains unchanged and out of scope.