### PR TITLE
Fix mobile landlord gutters and bottom nav drawer

### DIFF
--- a/rentchain-frontend/src/components/layout/LandlordNav.css
+++ b/rentchain-frontend/src/components/layout/LandlordNav.css
@@ -195,7 +195,7 @@
   margin-left: 4px;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 820px) {
   .rc-landlord-topnav {
     display: none;
   }
@@ -210,10 +210,56 @@
   }
 
   .rc-landlord-content {
-    padding-bottom: 96px;
+    padding: 12px max(16px, env(safe-area-inset-left)) 96px max(16px, env(safe-area-inset-right));
+  }
+
+  .rc-landlord-content--mobile-flush {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  .rc-mac-shell-main {
+    padding-left: 0 !important;
+    padding-right: 0 !important;
   }
 
   .rc-mobile-tabbar {
     display: grid;
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+
+  .rc-landlord-backdrop {
+    z-index: 55;
+  }
+
+  .rc-landlord-drawer {
+    top: auto;
+    left: max(12px, env(safe-area-inset-left));
+    right: max(12px, env(safe-area-inset-right));
+    bottom: calc(74px + env(safe-area-inset-bottom));
+    width: auto;
+    max-height: min(68dvh, 560px);
+    border-radius: 20px;
+    box-shadow: 0 -18px 40px rgba(15, 23, 42, 0.18);
+    transform: translateY(calc(100% + 24px));
+    padding: 16px 14px;
+  }
+
+  .rc-landlord-drawer.is-open {
+    transform: translateY(0);
+  }
+
+  .rc-landlord-drawer-header {
+    padding-bottom: 10px;
+  }
+
+  .rc-landlord-drawer-links {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .rc-landlord-drawer-links button {
+    min-height: 48px;
+    text-align: center;
+    padding: 10px 8px;
   }
 }

--- a/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { LandlordNav } from "./LandlordNav";
+
+const mocks = vi.hoisted(() => ({
+  logout: vi.fn(),
+  fetchLandlordConversations: vi.fn(),
+  useCapabilities: vi.fn(),
+}));
+
+vi.mock("../../context/useAuth", () => ({
+  useAuth: () => ({
+    user: { id: "landlord-1", role: "landlord", actorRole: "landlord", email: "owner@example.com" },
+    logout: mocks.logout,
+    ready: true,
+    isLoading: false,
+    authStatus: "authed",
+  }),
+}));
+
+vi.mock("@/hooks/useCapabilities", () => ({
+  useCapabilities: mocks.useCapabilities,
+}));
+
+vi.mock("../../api/messagesApi", () => ({
+  fetchLandlordConversations: mocks.fetchLandlordConversations,
+}));
+
+vi.mock("./TopNav", () => ({
+  default: () => <div>Top nav</div>,
+}));
+
+vi.mock("@/features/upgradeNudges/UpgradeNudgeHost", () => ({
+  UpgradeNudgeHost: () => null,
+}));
+
+function renderLandlordNav(initialPath = "/dashboard") {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route
+          path="*"
+          element={
+            <LandlordNav>
+              <div data-testid="page-content">Page content</div>
+            </LandlordNav>
+          }
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe("LandlordNav mobile drawer", () => {
+  afterEach(() => {
+    cleanup();
+    document.body.style.overflow = "";
+  });
+
+  beforeEach(() => {
+    mocks.logout.mockReset();
+    mocks.fetchLandlordConversations.mockResolvedValue([]);
+    mocks.useCapabilities.mockReturnValue({
+      features: {
+        messaging: true,
+        maintenance: true,
+        portfolio_health_summary: true,
+      },
+      loading: false,
+    });
+  });
+
+  it("opens a bottom-nav drawer with expected workspace options", async () => {
+    renderLandlordNav();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open workspace pages" }));
+
+    const drawer = screen.getByRole("dialog", { name: "Navigation menu" });
+    expect(drawer).toHaveClass("is-open");
+    expect(within(drawer).getByRole("button", { name: "Dashboard" })).toBeInTheDocument();
+    expect(within(drawer).getByRole("button", { name: "Payments" })).toBeInTheDocument();
+    expect(within(drawer).getByRole("button", { name: "Work Orders" })).toBeInTheDocument();
+  });
+
+  it("closes the drawer on option select and route change", async () => {
+    renderLandlordNav();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open workspace pages" }));
+    fireEvent.click(within(screen.getByRole("dialog", { name: "Navigation menu" })).getByRole("button", { name: "Payments" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog", { name: "Navigation menu" })).not.toHaveClass("is-open");
+    });
+  });
+
+  it("closes the drawer on Escape", async () => {
+    renderLandlordNav();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open workspace pages" }));
+    expect(screen.getByRole("dialog", { name: "Navigation menu" })).toHaveClass("is-open");
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog", { name: "Navigation menu" })).not.toHaveClass("is-open");
+    });
+  });
+
+  it("keeps messages flush so its own mobile spacing remains authoritative", () => {
+    renderLandlordNav("/messages");
+
+    expect(document.querySelector(".rc-landlord-content")).toHaveClass("rc-landlord-content--mobile-flush");
+  });
+
+  it("keeps ordinary landlord pages inside the shared mobile spacing wrapper", () => {
+    renderLandlordNav("/leases");
+
+    expect(document.querySelector(".rc-landlord-content")).not.toHaveClass("rc-landlord-content--mobile-flush");
+  });
+});

--- a/rentchain-frontend/src/components/layout/LandlordNav.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
+import { Menu, X } from "lucide-react";
 import { Navigate, useLocation, useNavigate } from "react-router-dom";
 import TopNav from "./TopNav";
 import { useAuth } from "../../context/useAuth";
@@ -53,6 +54,15 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
     [primaryDrawerItems]
   );
   const tabItems = visibleItems.filter((item) => item.showInTabs);
+  const contentClassName = [
+    "rc-landlord-content",
+    loc.pathname.startsWith("/messages") ? "rc-landlord-content--mobile-flush" : "",
+  ].filter(Boolean).join(" ");
+
+  const handleDrawerNavigation = (path: string) => {
+    setDrawerOpen(false);
+    nav(path);
+  };
 
   useEffect(() => {
     let mounted = true;
@@ -203,7 +213,7 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
                 <button
                   key={to}
                   type="button"
-                  onClick={() => nav(to)}
+                  onClick={() => handleDrawerNavigation(to)}
                   className={loc.pathname.startsWith(to) ? "active" : ""}
                 >
                   {label}
@@ -224,7 +234,7 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
                 <button
                   key={to}
                   type="button"
-                  onClick={() => nav(to)}
+                  onClick={() => handleDrawerNavigation(to)}
                   className={loc.pathname.startsWith(to) ? "active" : ""}
                 >
                   {label}
@@ -236,7 +246,7 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
       </aside>
 
       <UpgradeNudgeHost />
-      <div className="rc-landlord-content">{children}</div>
+      <div className={contentClassName}>{children}</div>
 
       <nav className="rc-mobile-tabbar" aria-label="Bottom navigation">
         {(navLoading ? [] : tabItems).map(({ to, label, icon: Icon }) => {
@@ -259,6 +269,20 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
             </button>
           );
         })}
+        <button
+          type="button"
+          onClick={(event) => {
+            lastFocusedRef.current = event.currentTarget;
+            setDrawerOpen(true);
+          }}
+          className={drawerOpen ? "active" : ""}
+          aria-label="Open workspace pages"
+          aria-expanded={drawerOpen}
+          aria-controls="rc-landlord-drawer"
+        >
+          {drawerOpen ? <X size={20} strokeWidth={2.2} /> : <Menu size={20} strokeWidth={2.2} />}
+          <span className="rc-mobile-tabbar-label">More</span>
+        </button>
       </nav>
     </div>
   );

--- a/rentchain-frontend/src/components/layout/MacShell.test.tsx
+++ b/rentchain-frontend/src/components/layout/MacShell.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MacShell } from "./MacShell";
+
+vi.mock("./TopNav", () => ({
+  default: () => <div>Top nav</div>,
+}));
+
+describe("MacShell", () => {
+  it("keeps its desktop page padding while exposing a mobile-safe shell class", () => {
+    render(
+      <MacShell showTopNav={false}>
+        <div>Shell content</div>
+      </MacShell>
+    );
+
+    const main = screen.getByText("Shell content").closest("main");
+    expect(main).toHaveClass("rc-mac-shell-main");
+    expect(main).toHaveStyle({ margin: "0 auto" });
+  });
+});

--- a/rentchain-frontend/src/components/layout/MacShell.tsx
+++ b/rentchain-frontend/src/components/layout/MacShell.tsx
@@ -38,6 +38,7 @@ export const MacShell: React.FC<MacShellProps> = ({
         </div>
       ) : null}
       <main
+        className="rc-mac-shell-main"
         style={{
           maxWidth: layout.maxWidth,
           margin: "0 auto",

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.test.tsx
@@ -173,6 +173,7 @@ describe("LandlordActiveLeasesPage", () => {
     );
 
     expect((await screen.findAllByText("Harbour View")).length).toBeGreaterThan(0);
+    expect(document.querySelector(".rc-leases-page")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Print / Save PDF" })).toBeInTheDocument();
     expect(screen.getAllByText("Lease fully executed").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Expiring soon").length).toBeGreaterThan(0);

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
@@ -461,7 +461,7 @@ export default function LandlordActiveLeasesPage() {
   }
 
   return (
-    <div style={{ display: "grid", gap: 16 }}>
+    <div className="rc-leases-page" style={{ display: "grid", gap: 16 }}>
       <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "flex-start" }}>
         <div style={{ display: "grid", gap: 6 }}>
           <div style={{ fontSize: 24, fontWeight: 800 }}>Lease operations</div>


### PR DESCRIPTION
This PR fixes mobile landlord spacing and improves the bottom navigation drawer UX.

Includes:
- Adds shared mobile gutters to landlord content shell.
- Preserves /messages benchmark spacing with a flush class.
- Fixes /leases mobile edge bleed with page-level class ownership.
- Adds mobile bottom-nav More drawer as a bottom sheet using existing nav definitions.
- Drawer closes on route selection, outside tap, Escape, and route change.
- No backend/API/schema changes.

Tests:
- Focused Vitest passed.
- Full pnpm test passed.
- pnpm build passed.
- git diff --check passed.