### PR TITLE
Polish platform layout and visible UX states

### DIFF
--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -159,6 +159,20 @@ describe("Routes: /tenant", () => {
   });
 });
 
+describe("Routes: /register", () => {
+  it("renders the signup page instead of a not-found dead end", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/register"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Create your RentChain account/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+});
+
 describe("Routes: /tenant/dashboard", () => {
   it("renders the tenant dashboard route without falling into landlord surfaces", async () => {
     const { default: App } = await import("./App");

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -336,6 +336,7 @@ function App() {
         <Route path="/site" element={suspensePage(<LandingPage />)} />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/signup" element={<SignupPage />} />
+        <Route path="/register" element={<SignupPage />} />
         <Route path="/app/login" element={<LoginPage />} />
         <Route path="/invite" element={<InviteRedeemPage />} />
         <Route path="/invite/:token" element={<InviteRedeemPage />} />

--- a/rentchain-frontend/src/components/DebugPanel.test.tsx
+++ b/rentchain-frontend/src/components/DebugPanel.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DebugPanel } from "./DebugPanel";
+import { fetchAccountLimits } from "../api/accountApi";
+import { setAuthToken } from "../lib/authToken";
+
+vi.mock("../api/accountApi", () => ({
+  fetchAccountLimits: vi.fn(),
+}));
+
+describe("DebugPanel", () => {
+  beforeEach(() => {
+    vi.mocked(fetchAccountLimits).mockReset();
+    setAuthToken(null);
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      writable: true,
+      value: 1280,
+    });
+  });
+
+  it("stays hidden without an authenticated landlord token", () => {
+    render(<DebugPanel />);
+
+    expect(screen.queryByText("Debug (dev only)")).not.toBeInTheDocument();
+    expect(fetchAccountLimits).not.toHaveBeenCalled();
+  });
+
+  it("stays hidden on mobile so it cannot cover bottom navigation", async () => {
+    setAuthToken("demo-token");
+    window.innerWidth = 390;
+    render(<DebugPanel />);
+
+    await waitFor(() => expect(fetchAccountLimits).not.toHaveBeenCalled());
+    expect(screen.queryByText("Debug (dev only)")).not.toBeInTheDocument();
+  });
+
+  it("renders account limits on authenticated desktop dev sessions", async () => {
+    setAuthToken("demo-token");
+    vi.mocked(fetchAccountLimits).mockResolvedValue({
+      status: "ok",
+      plan: "elite",
+      capabilities: {
+        "ai.insights": true,
+        screening: true,
+        "team.invites": false,
+      },
+      usage: {
+        properties: 2,
+        units: 4,
+      },
+      integrity: {
+        ok: true,
+      },
+    });
+
+    render(<DebugPanel />);
+
+    expect(await screen.findByText("Debug (dev only)")).toBeInTheDocument();
+    expect(screen.getByText("Plan: elite")).toBeInTheDocument();
+    expect(screen.getByText("Properties: 2")).toBeInTheDocument();
+    expect(screen.getByText("Team Invites: no")).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/DebugPanel.tsx
+++ b/rentchain-frontend/src/components/DebugPanel.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { fetchAccountLimits, type AccountLimits } from "../api/accountApi";
+import { getAuthToken } from "../lib/authToken";
 
 const lastApiError: unknown = null;
 
@@ -12,15 +13,34 @@ function formatApiError(err: unknown) {
 
 export const DebugPanel: React.FC = () => {
   const [limits, setLimits] = useState<AccountLimits | null>(null);
+  const [hasAuthToken, setHasAuthToken] = useState(false);
+  const [isMobileViewport, setIsMobileViewport] = useState(false);
 
   useEffect(() => {
     if (typeof window === "undefined") {
       return;
     }
-    fetchAccountLimits().then(setLimits).catch(() => setLimits(null));
+    const updateDebugEligibility = () => {
+      setHasAuthToken(Boolean(getAuthToken()));
+      setIsMobileViewport(window.innerWidth < 821);
+    };
+    updateDebugEligibility();
+    window.addEventListener("resize", updateDebugEligibility);
+    window.addEventListener("storage", updateDebugEligibility);
+    return () => {
+      window.removeEventListener("resize", updateDebugEligibility);
+      window.removeEventListener("storage", updateDebugEligibility);
+    };
   }, []);
 
-  if (!import.meta.env.DEV) return null;
+  useEffect(() => {
+    if (!import.meta.env.DEV || !hasAuthToken || isMobileViewport) {
+      return;
+    }
+    fetchAccountLimits().then(setLimits).catch(() => setLimits(null));
+  }, [hasAuthToken, isMobileViewport]);
+
+  if (!import.meta.env.DEV || !hasAuthToken || isMobileViewport) return null;
 
   // Normalize data to avoid crashes when limits are missing/shape differs
   const limitsData = limits || null;

--- a/rentchain-frontend/src/lib/publicRoute.ts
+++ b/rentchain-frontend/src/lib/publicRoute.ts
@@ -4,6 +4,7 @@ const PUBLIC_PREFIXES = [
   "/login",
   "/app/login",
   "/signup",
+  "/register",
   "/auth",
   "/invite",
   "/request-access",

--- a/rentchain-frontend/src/pages/tenant/TenantPortalComingSoon.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantPortalComingSoon.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import TenantPortalComingSoon from "./TenantPortalComingSoon";
+
+describe("TenantPortalComingSoon", () => {
+  it("shows tenant-safe unavailable copy without exposing environment flags", () => {
+    render(<TenantPortalComingSoon />);
+
+    expect(screen.getByText("Tenant portal coming soon")).toBeInTheDocument();
+    expect(screen.getByText(/contact your landlord for details/i)).toBeInTheDocument();
+    expect(screen.queryByText(/VITE_TENANT_PORTAL_ENABLED/i)).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/tenant/TenantPortalComingSoon.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantPortalComingSoon.tsx
@@ -28,9 +28,6 @@ export default function TenantPortalComingSoon() {
         <div style={{ opacity: 0.75 }}>
           We're preparing the tenant experience. Please check back later or contact your landlord for details.
         </div>
-        <div style={{ opacity: 0.6, fontSize: 12, marginTop: 8 }}>
-          VITE_TENANT_PORTAL_ENABLED: {String(import.meta.env.VITE_TENANT_PORTAL_ENABLED)}
-        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
This PR polishes visible platform UX states after the recent mobile layout work.

Includes:
- Fixes dead /register route by rendering the existing signup page and treating it as public.
- Removes tenant portal disabled-state env/debug leakage.
- Prevents dev-only DebugPanel from rendering on unauthenticated/public pages and mobile, avoiding account-limit noise and bottom-nav interference.
- Frontend-only; no backend/API/schema changes.
- Tests updated for /register, DebugPanel visibility, and tenant portal env leakage.

Verification:
- git diff --check passed.
- Full pnpm test passed.
- pnpm build passed.
- No dependency or lockfile changes.
- Backend untouched.