### PR TITLE
Add Stripe rent payment adapter seam

### DIFF
--- a/docs/architecture/payment-execution-boundary-v1.md
+++ b/docs/architecture/payment-execution-boundary-v1.md
@@ -1,0 +1,179 @@
+# Payment Execution Boundary v1
+
+Status: implemented as passive backend boundary helpers
+
+Branch: `feat/payment-execution-boundary-v1`
+
+## Purpose
+
+Create the first provider-neutral payment execution boundary for RentChain so Stripe, future Trustly work, manual payments, rent collection, screening checkout, subscriptions, and payouts do not become tangled.
+
+This mission does not implement Trustly, change live Stripe behavior, change UI, migrate schema, or emit new canonical events globally.
+
+## Source Of Truth Hierarchy
+
+1. RentChain payment intent is the expected internal obligation.
+2. Provider event or provider signal is external evidence.
+3. Reconciliation engine is the business interpretation.
+4. Canonical event stream is the permanent audit history.
+
+Provider-specific IDs and statuses are evidence. They are not RentChain product truth by themselves.
+
+## Current Flow Audit
+
+| Flow | Current behavior | Boundary finding |
+| --- | --- | --- |
+| SaaS subscriptions | `billingRoutes.ts` creates Stripe subscription checkout and portal sessions; subscription state derives from Stripe customer/session/subscription data. | Keep separate from rent and screening payment execution. Plan, pricing, and entitlement semantics are subscription-specific. |
+| Rent payments | `rentPaymentService.ts` creates Stripe Checkout sessions, stores `processor: "stripe"`, and maps webhooks into rent payment status. | Future providers need a provider-neutral intent/session boundary before any Trustly work. |
+| Screening checkout | `screeningCheckoutExecutionService.ts` and Stripe webhook routes use Stripe sessions/payment intents to mark screening orders paid or failed. | Payment collection should be separable from screening fulfillment. |
+| Manual payments | `paymentsRoutes.ts` records persisted/manual payments and ledger events. | Manual remains source attribution only; it has no provider webhook or settlement lifecycle. |
+| Financial transactions | `financialTransactionService.ts` stores narrow transaction records; screening callers currently write Stripe-shaped metadata. | Good base for later provider metadata, payout, reversal, and reconciliation events. |
+| Canonical events | `buildEvent.ts` writes append-only canonical events, currently without dedicated `payment` or `payout` domains. | This mission defines taxonomy constants but does not globally emit them. |
+| Reconciliation | Screening has dedicated reconciliation helpers; rent/provider payment reconciliation is not centralized. | A pure payment reconciliation helper now defines the fail-closed rules. |
+
+## Boundary Modules Added
+
+- `rentchain-api/src/lib/payments/paymentTypes.ts`
+  - provider-neutral types for providers, purposes, execution statuses, actor types, provider references, and payment intent references.
+- `rentchain-api/src/lib/payments/paymentProviderAdapter.ts`
+  - adapter contract plus provider-status normalization helpers.
+- `rentchain-api/src/lib/payments/paymentIdempotency.ts`
+  - deterministic idempotency key helpers for provider webhooks, session creation, and manual payments.
+- `rentchain-api/src/lib/payments/paymentReconciliation.ts`
+  - pure reconciliation derivation from expected intent plus normalized provider signal.
+- `rentchain-api/src/lib/payments/paymentCanonicalEvents.ts`
+  - canonical payment, payout, and affordability event taxonomy constants.
+
+## Provider Evidence Contract
+
+Provider adapters must normalize provider-specific state into `PaymentExecutionStatus` before product services interpret it.
+
+Unknown provider statuses map to `manual_review_required`. This is intentional fail-closed behavior.
+
+Provider adapters must not directly mutate:
+
+- leases
+- ledger entries
+- tenant activity
+- persisted payments
+- screening fulfillment
+- landlord/tenant read models
+
+Adapters return evidence. Product services and reconciliation decide what the evidence means.
+
+## Reconciliation Authority
+
+`derivePaymentReconciliation` is pure. It accepts:
+
+- expected internal payment intent
+- normalized provider signal
+- existing reconciliation state
+
+It returns:
+
+- `reconciliationStatus`
+- `reasons[]`
+- `automationEligible`
+- `requiresManualReview`
+
+Rules:
+
+- Missing internal subject reference requires manual review.
+- Missing provider signal requires manual review.
+- Duplicate provider event becomes `duplicate_risk`.
+- Amount mismatch becomes `mismatch` and requires manual review.
+- Currency mismatch becomes `mismatch` and requires manual review.
+- Confirmed matching provider evidence becomes `reconciled`.
+- Pending evidence remains pending and is not automation-eligible.
+- Failed, cancelled, or expired evidence becomes failed.
+- Unknown status requires manual review.
+
+## Idempotency Strategy
+
+Provider webhook key:
+
+```text
+provider_event:{provider}:{providerEventId}
+```
+
+Session creation key:
+
+```text
+payment_session:{provider}:{purpose}:{subjectId}:{amount}:{currency}
+```
+
+Manual payment key:
+
+```text
+manual_payment:manual:{landlordId}:{subjectId}:{amount}:{receivedAt}
+```
+
+These helpers are deterministic and side-effect free. This mission does not wire them into live flows.
+
+## Canonical Event Taxonomy
+
+Defined constants:
+
+- `payment.intent_created`
+- `payment.provider_selected`
+- `payment.provider_session_created`
+- `payment.provider_signal_received`
+- `payment.initiated`
+- `payment.pending`
+- `payment.confirmed`
+- `payment.failed`
+- `payment.cancelled`
+- `payment.expired`
+- `payment.mismatch_detected`
+- `payment.duplicate_detected`
+- `payment.manual_review_required`
+- `payment.reconciled`
+- `payment.reconciliation_failed`
+- `payout.initiated`
+- `payout.completed`
+- `payout.failed`
+- `affordability.verification_started`
+- `affordability.verification_completed`
+- `affordability.verification_failed`
+
+This mission defines taxonomy only. Future missions must deliberately expand canonical event domains and event writing before global emission.
+
+## Failure-First Cases
+
+| Case | Boundary behavior |
+| --- | --- |
+| Duplicate webhook | Deterministic provider event key plus reconciliation `duplicate_risk`. |
+| Delayed webhook | Provider signal remains external evidence until reconciled against current intent. |
+| Webhook never arrives | Missing provider signal requires manual review or timeout workflow. |
+| Provider status unknown | `manual_review_required`. |
+| Amount mismatch | `mismatch`, manual review, not automation eligible. |
+| Currency mismatch | `mismatch`, manual review, not automation eligible. |
+| Payment confirmed but subject missing | Manual review because internal obligation cannot be identified. |
+| Payout initiated but not settled | Pending payout state; do not mark landlord paid out. |
+| Bank connection revoked | Provider signal should normalize to failed/manual review depending on provider evidence. |
+| Manual payment duplicate risk | Deterministic manual payment key gives future workflows a repeatable comparison key. |
+
+## Future Trustly Path
+
+Trustly can be evaluated later by implementing a Trustly adapter that satisfies the provider contract and maps Trustly statuses into provider-neutral execution statuses. That adapter should remain sandbox-only until:
+
+- webhook verification and idempotency are implemented
+- consent language is approved
+- Canadian rail/product availability is confirmed
+- payment and payout reconciliation states are supported
+- Stripe behavior remains covered by regression tests
+
+## Intentional Non-Implementation
+
+This mission intentionally does not:
+
+- implement Trustly
+- create Trustly credentials
+- change Stripe checkout
+- change screening checkout behavior
+- change SaaS billing behavior
+- change manual payment behavior
+- add UI
+- migrate schema
+- emit new payment canonical events globally
+- alter pricing, plans, subscriptions, or screening business rules

--- a/docs/architecture/payment-execution-boundary-v1.md
+++ b/docs/architecture/payment-execution-boundary-v1.md
@@ -163,6 +163,60 @@ Trustly can be evaluated later by implementing a Trustly adapter that satisfies 
 - payment and payout reconciliation states are supported
 - Stripe behavior remains covered by regression tests
 
+## Stripe Rent-Payment Adapter Seam v1
+
+Status: Stripe rent-payment session creation is now routed through the provider boundary.
+
+What changed:
+
+- `rentPaymentService.ts` still owns RentChain rent-payment record creation, validation, canonical event writes, observability writes, and response shaping.
+- Stripe Checkout session creation for rent payments now flows through `paymentExecutionService.createRentPaymentSession`.
+- `paymentExecutionService` supports only Stripe for live rent-payment sessions in this phase and fails closed for unknown providers.
+- `stripePaymentProvider` is a thin wrapper around the existing Stripe SDK helper pattern and creates the same Checkout Session shape used before.
+
+Why this contains Stripe:
+
+```text
+tenant route
+  -> rentPaymentService
+    -> paymentExecutionService
+      -> stripePaymentProvider
+        -> existing Stripe SDK helper
+```
+
+Behavior intentionally unchanged:
+
+- Stripe Checkout mode remains `payment`.
+- Payment method remains card checkout.
+- Product label remains `Monthly rent payment`.
+- Stripe metadata still includes `leaseId`, `tenantId`, `landlordId`, and `rentPaymentId`.
+- PaymentIntent metadata remains the same.
+- Success and cancel URLs still append `rentPaymentStatus=success` or `rentPaymentStatus=canceled`.
+- `rentPayments` records still use `processor: "stripe"`, `processorCheckoutSessionId`, and `processorPaymentIntentId`.
+- Existing rent payment canonical events remain under the existing event behavior.
+- Tenant route response shape remains `{ rentPaymentId, status, redirectUrl }`.
+
+Webhook seam decision:
+
+The Stripe webhook route currently handles rent payments, screening payments, and subscription events in one file. This mission leaves webhook persistence behavior unchanged to avoid touching screening or subscriptions. Future work should add a rent-only provider-event normalization seam before any persisted webhook behavior changes.
+
+Out of scope:
+
+- Screening checkout adapter changes.
+- SaaS subscription billing changes.
+- Payout behavior.
+- Provider switching UI.
+- Trustly implementation.
+- New canonical payment event emission.
+
+Future migration path:
+
+1. Rent payment session creation seam.
+2. Rent webhook normalization seam.
+3. Provider-neutral persisted rent payment fields.
+4. Canonical payment event domain expansion and emission.
+5. Trustly sandbox adapter.
+
 ## Intentional Non-Implementation
 
 This mission intentionally does not:

--- a/rentchain-api/src/lib/payments/__tests__/paymentExecutionService.test.ts
+++ b/rentchain-api/src/lib/payments/__tests__/paymentExecutionService.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it, vi } from "vitest";
+import { createPaymentExecutionService } from "../paymentExecutionService";
+import type { PaymentProviderAdapter } from "../paymentProviderAdapter";
+import type { PaymentIntentReference } from "../paymentTypes";
+
+const rentIntent: PaymentIntentReference = {
+  paymentIntentId: "rent-payment-1",
+  landlordId: "landlord-1",
+  tenantId: "tenant-1",
+  leaseId: "lease-1",
+  propertyId: "prop-1",
+  unitId: "unit-1",
+  amount: 125000,
+  currency: "cad",
+  purpose: "rent",
+  provider: "stripe",
+};
+
+function buildStripeAdapter(): PaymentProviderAdapter {
+  return {
+    provider: "stripe",
+    createPaymentSession: vi.fn().mockResolvedValue({
+      provider: "stripe",
+      status: "provider_session_created",
+      redirectUrl: "https://checkout.stripe.test/session/cs_1",
+      reference: {
+        provider: "stripe",
+        providerSessionId: "cs_1",
+        providerPaymentId: "pi_1",
+      },
+    }),
+    normalizeProviderEvent: vi.fn((input) => ({
+      provider: "stripe",
+      providerEventId: input.providerEventId || null,
+      providerPaymentId: input.providerPaymentId || null,
+      providerSessionId: input.providerSessionId || null,
+      providerCustomerId: input.providerCustomerId || null,
+      rawStatus: input.rawStatus || null,
+      normalizedStatus: input.rawStatus === "paid" ? "confirmed" : "manual_review_required",
+      purpose: input.purpose || null,
+      amount: input.amount || null,
+      currency: input.currency || null,
+      occurredAt: input.occurredAt || null,
+    })),
+    mapProviderStatus: vi.fn((rawStatus) => (rawStatus === "paid" ? "confirmed" : "manual_review_required")),
+  };
+}
+
+describe("paymentExecutionService", () => {
+  it("rejects unknown provider for rent payment sessions", async () => {
+    const service = createPaymentExecutionService({ stripe: buildStripeAdapter() });
+
+    await expect(
+      service.createRentPaymentSession({
+        intent: { ...rentIntent, provider: "trustly" },
+        successUrl: "https://app.test/success",
+        cancelUrl: "https://app.test/cancel",
+      })
+    ).rejects.toThrow("payment_provider_unsupported");
+  });
+
+  it("routes Stripe rent payment sessions to the Stripe adapter", async () => {
+    const adapter = buildStripeAdapter();
+    const service = createPaymentExecutionService({ stripe: adapter });
+
+    await service.createRentPaymentSession({
+      intent: rentIntent,
+      successUrl: "https://app.test/success",
+      cancelUrl: "https://app.test/cancel",
+    });
+
+    expect(adapter.createPaymentSession).toHaveBeenCalledWith({
+      intent: rentIntent,
+      successUrl: "https://app.test/success",
+      cancelUrl: "https://app.test/cancel",
+    });
+  });
+
+  it("preserves amount, currency, purpose, and subject metadata", async () => {
+    const adapter = buildStripeAdapter();
+    const service = createPaymentExecutionService({ stripe: adapter });
+
+    await service.createRentPaymentSession({
+      intent: rentIntent,
+      metadata: {
+        leaseId: "lease-1",
+        tenantId: "tenant-1",
+        landlordId: "landlord-1",
+        rentPaymentId: "rent-payment-1",
+      },
+      successUrl: "https://app.test/success",
+      cancelUrl: "https://app.test/cancel",
+    });
+
+    expect(adapter.createPaymentSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        intent: expect.objectContaining({
+          amount: 125000,
+          currency: "cad",
+          purpose: "rent",
+          leaseId: "lease-1",
+          tenantId: "tenant-1",
+          landlordId: "landlord-1",
+        }),
+        metadata: {
+          leaseId: "lease-1",
+          tenantId: "tenant-1",
+          landlordId: "landlord-1",
+          rentPaymentId: "rent-payment-1",
+        },
+      })
+    );
+  });
+
+  it("rejects unknown provider for rent payment provider event normalization", () => {
+    const service = createPaymentExecutionService({ stripe: buildStripeAdapter() });
+
+    expect(() =>
+      service.normalizeRentPaymentProviderEvent({
+        provider: "trustly",
+        rawStatus: "paid",
+      })
+    ).toThrow("payment_provider_unsupported");
+  });
+
+  it("routes Stripe provider event normalization to the Stripe adapter", () => {
+    const adapter = buildStripeAdapter();
+    const service = createPaymentExecutionService({ stripe: adapter });
+
+    const result = service.normalizeRentPaymentProviderEvent({
+      provider: "stripe",
+      providerEventId: "evt_1",
+      rawStatus: "paid",
+    });
+
+    expect(adapter.normalizeProviderEvent).toHaveBeenCalledWith({
+      provider: "stripe",
+      providerEventId: "evt_1",
+      rawStatus: "paid",
+    });
+    expect(result.normalizedStatus).toBe("confirmed");
+  });
+
+  it("derives reconciliation without mutating payment intent or provider signal", () => {
+    const service = createPaymentExecutionService({ stripe: buildStripeAdapter() });
+    const intent = { ...rentIntent };
+    const signal = {
+      provider: "stripe" as const,
+      providerEventId: "evt_1",
+      rawStatus: "paid",
+      normalizedStatus: "confirmed" as const,
+      amount: 125000,
+      currency: "CAD",
+    };
+
+    const result = service.deriveRentPaymentReconciliation({
+      expectedIntent: intent,
+      providerSignal: signal,
+    });
+
+    expect(result.reconciliationStatus).toBe("reconciled");
+    expect(intent).toEqual(rentIntent);
+    expect(signal).toEqual({
+      provider: "stripe",
+      providerEventId: "evt_1",
+      rawStatus: "paid",
+      normalizedStatus: "confirmed",
+      amount: 125000,
+      currency: "CAD",
+    });
+  });
+});

--- a/rentchain-api/src/lib/payments/__tests__/paymentIdempotency.test.ts
+++ b/rentchain-api/src/lib/payments/__tests__/paymentIdempotency.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildManualPaymentIdempotencyKey,
+  buildProviderWebhookIdempotencyKey,
+  buildSessionCreationIdempotencyKey,
+} from "../paymentIdempotency";
+
+describe("paymentIdempotency", () => {
+  it("builds deterministic provider webhook keys from provider and event id", () => {
+    expect(
+      buildProviderWebhookIdempotencyKey({
+        provider: "stripe",
+        providerEventId: " evt_123 ",
+      })
+    ).toBe("provider_event:stripe:evt_123");
+  });
+
+  it("builds deterministic session creation keys from internal subject and amount", () => {
+    expect(
+      buildSessionCreationIdempotencyKey({
+        provider: "trustly",
+        purpose: "rent",
+        subjectId: " lease/123 ",
+        amount: 125000.4,
+        currency: "CAD",
+      })
+    ).toBe("payment_session:trustly:rent:lease_123:125000:cad");
+  });
+
+  it("builds deterministic manual payment keys with normalized received date", () => {
+    expect(
+      buildManualPaymentIdempotencyKey({
+        landlordId: "landlord-1",
+        subjectId: "lease-1",
+        amount: 50000,
+        receivedAt: "2026-05-01T10:00:00.000Z",
+      })
+    ).toBe("manual_payment:manual:landlord-1:lease-1:50000:2026-05-01t10:00:00.000z");
+  });
+
+  it("keeps missing fields explicit instead of creating blank key parts", () => {
+    expect(
+      buildManualPaymentIdempotencyKey({
+        landlordId: "",
+        subjectId: "",
+        amount: Number.NaN,
+      })
+    ).toBe("manual_payment:manual:landlord_missing:subject_missing:amount_invalid:received_at_missing");
+  });
+});

--- a/rentchain-api/src/lib/payments/__tests__/paymentProviderAdapter.test.ts
+++ b/rentchain-api/src/lib/payments/__tests__/paymentProviderAdapter.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { mapProviderStatus, normalizeProviderPaymentEvent } from "../paymentProviderAdapter";
+
+describe("paymentProviderAdapter", () => {
+  it("maps Stripe statuses into provider-neutral execution statuses", () => {
+    expect(mapProviderStatus("stripe", "open")).toBe("provider_session_created");
+    expect(mapProviderStatus("stripe", "processing")).toBe("pending_provider_confirmation");
+    expect(mapProviderStatus("stripe", "paid")).toBe("confirmed");
+    expect(mapProviderStatus("stripe", "canceled")).toBe("cancelled");
+    expect(mapProviderStatus("stripe", "expired")).toBe("expired");
+  });
+
+  it("maps Trustly statuses without implementing a Trustly provider", () => {
+    expect(mapProviderStatus("trustly", "authorized")).toBe("pending_settlement");
+    expect(mapProviderStatus("trustly", "settled")).toBe("confirmed");
+    expect(mapProviderStatus("trustly", "denied")).toBe("failed");
+  });
+
+  it("fails closed for unknown provider statuses", () => {
+    expect(mapProviderStatus("stripe", "surprise_status")).toBe("manual_review_required");
+    expect(mapProviderStatus("trustly", "")).toBe("manual_review_required");
+    expect(mapProviderStatus("manual", null)).toBe("manual_review_required");
+  });
+
+  it("normalizes provider events with safe amount and currency fields", () => {
+    expect(
+      normalizeProviderPaymentEvent({
+        provider: "stripe",
+        providerEventId: "evt_1",
+        providerPaymentId: "pi_1",
+        rawStatus: "paid",
+        amount: 125000,
+        currency: "cad",
+        purpose: "rent",
+      })
+    ).toEqual({
+      provider: "stripe",
+      providerEventId: "evt_1",
+      providerPaymentId: "pi_1",
+      providerSessionId: null,
+      providerCustomerId: null,
+      rawStatus: "paid",
+      normalizedStatus: "confirmed",
+      purpose: "rent",
+      amount: 125000,
+      currency: "CAD",
+      occurredAt: null,
+    });
+  });
+});

--- a/rentchain-api/src/lib/payments/__tests__/paymentReconciliation.test.ts
+++ b/rentchain-api/src/lib/payments/__tests__/paymentReconciliation.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vitest";
+import { normalizeProviderPaymentEvent } from "../paymentProviderAdapter";
+import { derivePaymentReconciliation } from "../paymentReconciliation";
+import type { PaymentIntentReference } from "../paymentTypes";
+
+const rentIntent: PaymentIntentReference = {
+  paymentIntentId: "rent-payment-1",
+  landlordId: "landlord-1",
+  tenantId: "tenant-1",
+  leaseId: "lease-1",
+  amount: 125000,
+  currency: "CAD",
+  purpose: "rent",
+  provider: "stripe",
+};
+
+describe("paymentReconciliation", () => {
+  it("reconciles confirmed provider evidence when amount and currency match", () => {
+    const signal = normalizeProviderPaymentEvent({
+      provider: "stripe",
+      providerEventId: "evt_1",
+      rawStatus: "paid",
+      amount: 125000,
+      currency: "cad",
+      purpose: "rent",
+    });
+
+    expect(
+      derivePaymentReconciliation({
+        expectedIntent: rentIntent,
+        providerSignal: signal,
+      })
+    ).toEqual({
+      reconciliationStatus: "reconciled",
+      reasons: ["provider_confirmed_amount_currency_match"],
+      automationEligible: true,
+      requiresManualReview: false,
+    });
+  });
+
+  it("requires manual review for amount mismatch", () => {
+    const signal = normalizeProviderPaymentEvent({
+      provider: "stripe",
+      providerEventId: "evt_1",
+      rawStatus: "paid",
+      amount: 120000,
+      currency: "CAD",
+    });
+
+    expect(
+      derivePaymentReconciliation({
+        expectedIntent: rentIntent,
+        providerSignal: signal,
+      })
+    ).toMatchObject({
+      reconciliationStatus: "mismatch",
+      reasons: ["amount_mismatch"],
+      automationEligible: false,
+      requiresManualReview: true,
+    });
+  });
+
+  it("requires manual review for currency mismatch", () => {
+    const signal = normalizeProviderPaymentEvent({
+      provider: "stripe",
+      providerEventId: "evt_1",
+      rawStatus: "paid",
+      amount: 125000,
+      currency: "USD",
+    });
+
+    expect(
+      derivePaymentReconciliation({
+        expectedIntent: rentIntent,
+        providerSignal: signal,
+      })
+    ).toMatchObject({
+      reconciliationStatus: "mismatch",
+      reasons: ["currency_mismatch"],
+      requiresManualReview: true,
+    });
+  });
+
+  it("marks duplicate provider events as duplicate risk", () => {
+    const signal = normalizeProviderPaymentEvent({
+      provider: "stripe",
+      providerEventId: "evt_1",
+      rawStatus: "paid",
+      amount: 125000,
+      currency: "CAD",
+    });
+
+    expect(
+      derivePaymentReconciliation({
+        expectedIntent: rentIntent,
+        providerSignal: signal,
+        existingState: { seenProviderEventIds: ["evt_1"] },
+      })
+    ).toEqual({
+      reconciliationStatus: "duplicate_risk",
+      reasons: ["duplicate_provider_event"],
+      automationEligible: false,
+      requiresManualReview: true,
+    });
+  });
+
+  it("keeps pending provider evidence out of automation", () => {
+    const signal = normalizeProviderPaymentEvent({
+      provider: "trustly",
+      providerEventId: "evt_1",
+      rawStatus: "authorized",
+      amount: 125000,
+      currency: "CAD",
+    });
+
+    expect(
+      derivePaymentReconciliation({
+        expectedIntent: rentIntent,
+        providerSignal: signal,
+      })
+    ).toEqual({
+      reconciliationStatus: "pending_settlement",
+      reasons: ["provider_signal_pending_settlement"],
+      automationEligible: false,
+      requiresManualReview: false,
+    });
+  });
+
+  it("maps failed provider evidence to failed reconciliation", () => {
+    const signal = normalizeProviderPaymentEvent({
+      provider: "stripe",
+      providerEventId: "evt_1",
+      rawStatus: "failed",
+      amount: 125000,
+      currency: "CAD",
+    });
+
+    expect(
+      derivePaymentReconciliation({
+        expectedIntent: rentIntent,
+        providerSignal: signal,
+      })
+    ).toMatchObject({
+      reconciliationStatus: "failed",
+      reasons: ["provider_signal_failed"],
+      requiresManualReview: false,
+    });
+  });
+
+  it("fails closed for unknown provider status", () => {
+    const signal = normalizeProviderPaymentEvent({
+      provider: "stripe",
+      providerEventId: "evt_1",
+      rawStatus: "unexpected",
+      amount: 125000,
+      currency: "CAD",
+    });
+
+    expect(
+      derivePaymentReconciliation({
+        expectedIntent: rentIntent,
+        providerSignal: signal,
+      })
+    ).toEqual({
+      reconciliationStatus: "manual_review_required",
+      reasons: ["provider_status_unknown_or_manual_review"],
+      automationEligible: false,
+      requiresManualReview: true,
+    });
+  });
+
+  it("requires manual review when internal subject reference is missing", () => {
+    expect(
+      derivePaymentReconciliation({
+        expectedIntent: {
+          ...rentIntent,
+          leaseId: null,
+          tenantId: null,
+        },
+        providerSignal: normalizeProviderPaymentEvent({
+          provider: "stripe",
+          providerEventId: "evt_1",
+          rawStatus: "paid",
+          amount: 125000,
+          currency: "CAD",
+        }),
+      })
+    ).toEqual({
+      reconciliationStatus: "manual_review_required",
+      reasons: ["missing_internal_subject_reference"],
+      automationEligible: false,
+      requiresManualReview: true,
+    });
+  });
+
+  it("requires manual review when provider signal is missing", () => {
+    expect(
+      derivePaymentReconciliation({
+        expectedIntent: rentIntent,
+        providerSignal: null,
+      })
+    ).toEqual({
+      reconciliationStatus: "manual_review_required",
+      reasons: ["missing_provider_signal"],
+      automationEligible: false,
+      requiresManualReview: true,
+    });
+  });
+});

--- a/rentchain-api/src/lib/payments/__tests__/stripePaymentProvider.test.ts
+++ b/rentchain-api/src/lib/payments/__tests__/stripePaymentProvider.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from "vitest";
+import { createStripePaymentProvider, stripePaymentProvider } from "../providers/stripePaymentProvider";
+
+describe("stripePaymentProvider", () => {
+  it("uses stripe as its provider key", () => {
+    expect(stripePaymentProvider.provider).toBe("stripe");
+  });
+
+  it("maps known Stripe statuses to provider-neutral statuses", () => {
+    expect(stripePaymentProvider.mapProviderStatus("open")).toBe("provider_session_created");
+    expect(stripePaymentProvider.mapProviderStatus("processing")).toBe("pending_provider_confirmation");
+    expect(stripePaymentProvider.mapProviderStatus("paid")).toBe("confirmed");
+    expect(stripePaymentProvider.mapProviderStatus("canceled")).toBe("cancelled");
+    expect(stripePaymentProvider.mapProviderStatus("expired")).toBe("expired");
+  });
+
+  it("maps unknown Stripe status to manual review", () => {
+    expect(stripePaymentProvider.mapProviderStatus("not_a_real_status")).toBe("manual_review_required");
+  });
+
+  it("normalizes provider events without dropping event id or raw status", () => {
+    expect(
+      stripePaymentProvider.normalizeProviderEvent({
+        provider: "stripe",
+        providerEventId: "evt_123",
+        providerSessionId: "cs_123",
+        rawStatus: "paid",
+        amount: 125000,
+        currency: "cad",
+      })
+    ).toMatchObject({
+      provider: "stripe",
+      providerEventId: "evt_123",
+      providerSessionId: "cs_123",
+      rawStatus: "paid",
+      normalizedStatus: "confirmed",
+      amount: 125000,
+      currency: "CAD",
+    });
+  });
+
+  it("normalizes a minimal safe mocked event shape", () => {
+    expect(
+      stripePaymentProvider.normalizeProviderEvent({
+        provider: "stripe",
+      })
+    ).toMatchObject({
+      provider: "stripe",
+      rawStatus: null,
+      normalizedStatus: "manual_review_required",
+    });
+  });
+
+  it("delegates session creation without changing rent payment metadata", async () => {
+    const createCheckoutSession = vi.fn().mockResolvedValue({
+      id: "cs_test_1",
+      url: "https://checkout.stripe.test/session/cs_test_1",
+      payment_intent: "pi_test_1",
+    });
+    const provider = createStripePaymentProvider({ createCheckoutSession });
+
+    const result = await provider.createPaymentSession({
+      intent: {
+        paymentIntentId: "rent-payment-1",
+        landlordId: "landlord-1",
+        tenantId: "tenant-1",
+        leaseId: "lease-1",
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        amount: 125000,
+        currency: "cad",
+        purpose: "rent",
+        provider: "stripe",
+      },
+      metadata: {
+        leaseId: "lease-1",
+        tenantId: "tenant-1",
+        landlordId: "landlord-1",
+        rentPaymentId: "rent-payment-1",
+      },
+      successUrl: "https://app.test/tenant/lease?rentPaymentStatus=success",
+      cancelUrl: "https://app.test/tenant/lease?rentPaymentStatus=canceled",
+    });
+
+    expect(createCheckoutSession).toHaveBeenCalledWith({
+      mode: "payment",
+      payment_method_types: ["card"],
+      line_items: [
+        {
+          price_data: {
+            currency: "cad",
+            product_data: {
+              name: "Monthly rent payment",
+            },
+            unit_amount: 125000,
+          },
+          quantity: 1,
+        },
+      ],
+      metadata: {
+        leaseId: "lease-1",
+        tenantId: "tenant-1",
+        landlordId: "landlord-1",
+        rentPaymentId: "rent-payment-1",
+      },
+      payment_intent_data: {
+        metadata: {
+          leaseId: "lease-1",
+          tenantId: "tenant-1",
+          landlordId: "landlord-1",
+          rentPaymentId: "rent-payment-1",
+        },
+      },
+      success_url: "https://app.test/tenant/lease?rentPaymentStatus=success",
+      cancel_url: "https://app.test/tenant/lease?rentPaymentStatus=canceled",
+    });
+    expect(result).toEqual({
+      provider: "stripe",
+      status: "provider_session_created",
+      redirectUrl: "https://checkout.stripe.test/session/cs_test_1",
+      reference: {
+        provider: "stripe",
+        providerSessionId: "cs_test_1",
+        providerPaymentId: "pi_test_1",
+        rawStatus: "open",
+        normalizedStatus: "provider_session_created",
+      },
+    });
+  });
+});

--- a/rentchain-api/src/lib/payments/paymentCanonicalEvents.ts
+++ b/rentchain-api/src/lib/payments/paymentCanonicalEvents.ts
@@ -1,0 +1,29 @@
+export const PAYMENT_CANONICAL_EVENTS = [
+  "payment.intent_created",
+  "payment.provider_selected",
+  "payment.provider_session_created",
+  "payment.provider_signal_received",
+  "payment.initiated",
+  "payment.pending",
+  "payment.confirmed",
+  "payment.failed",
+  "payment.cancelled",
+  "payment.expired",
+  "payment.mismatch_detected",
+  "payment.duplicate_detected",
+  "payment.manual_review_required",
+  "payment.reconciled",
+  "payment.reconciliation_failed",
+  "payout.initiated",
+  "payout.completed",
+  "payout.failed",
+  "affordability.verification_started",
+  "affordability.verification_completed",
+  "affordability.verification_failed",
+] as const;
+
+export type PaymentCanonicalEventName = (typeof PAYMENT_CANONICAL_EVENTS)[number];
+
+export function isPaymentCanonicalEventName(value: unknown): value is PaymentCanonicalEventName {
+  return (PAYMENT_CANONICAL_EVENTS as readonly string[]).includes(String(value || "").trim());
+}

--- a/rentchain-api/src/lib/payments/paymentExecutionService.ts
+++ b/rentchain-api/src/lib/payments/paymentExecutionService.ts
@@ -1,0 +1,52 @@
+import { derivePaymentReconciliation } from "./paymentReconciliation";
+import type { NormalizedProviderPaymentEvent, NormalizeProviderEventInput, PaymentProviderAdapter } from "./paymentProviderAdapter";
+import { stripePaymentProvider } from "./providers/stripePaymentProvider";
+import type { PaymentIntentReference, PaymentProvider } from "./paymentTypes";
+
+type PaymentExecutionAdapters = Partial<Record<PaymentProvider, PaymentProviderAdapter>>;
+
+export type RentPaymentSessionInput = {
+  intent: PaymentIntentReference;
+  successUrl: string;
+  cancelUrl: string;
+  metadata?: Record<string, string | number | boolean | null>;
+};
+
+export function createPaymentExecutionService(adapters: PaymentExecutionAdapters = { stripe: stripePaymentProvider }) {
+  function getAdapter(provider: PaymentProvider): PaymentProviderAdapter {
+    const adapter = adapters[provider];
+    if (!adapter || provider !== "stripe") {
+      throw new Error("payment_provider_unsupported");
+    }
+    return adapter;
+  }
+
+  return {
+    async createRentPaymentSession(input: RentPaymentSessionInput) {
+      if (input.intent.provider !== "stripe") {
+        throw new Error("payment_provider_unsupported");
+      }
+      if (input.intent.purpose !== "rent") {
+        throw new Error("payment_purpose_unsupported");
+      }
+      return getAdapter(input.intent.provider).createPaymentSession(input);
+    },
+
+    normalizeRentPaymentProviderEvent(input: NormalizeProviderEventInput): NormalizedProviderPaymentEvent {
+      if (input.provider !== "stripe") {
+        throw new Error("payment_provider_unsupported");
+      }
+      return getAdapter(input.provider).normalizeProviderEvent(input);
+    },
+
+    deriveRentPaymentReconciliation(input: Parameters<typeof derivePaymentReconciliation>[0]) {
+      return derivePaymentReconciliation(input);
+    },
+  };
+}
+
+export const paymentExecutionService = createPaymentExecutionService();
+
+export const createRentPaymentSession = paymentExecutionService.createRentPaymentSession;
+export const normalizeRentPaymentProviderEvent = paymentExecutionService.normalizeRentPaymentProviderEvent;
+export const deriveRentPaymentReconciliation = paymentExecutionService.deriveRentPaymentReconciliation;

--- a/rentchain-api/src/lib/payments/paymentIdempotency.ts
+++ b/rentchain-api/src/lib/payments/paymentIdempotency.ts
@@ -1,0 +1,70 @@
+import type { PaymentProvider, PaymentPurpose } from "./paymentTypes";
+
+type ProviderWebhookIdempotencyInput = {
+  provider: PaymentProvider;
+  providerEventId: string;
+};
+
+type SessionCreationIdempotencyInput = {
+  provider: PaymentProvider;
+  purpose: PaymentPurpose;
+  subjectId: string;
+  amount: number;
+  currency: string;
+};
+
+type ManualPaymentIdempotencyInput = {
+  landlordId: string;
+  subjectId: string;
+  amount: number;
+  receivedAt?: string | number | Date | null;
+};
+
+function cleanPart(value: unknown): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function normalizeAmount(amount: unknown): string {
+  const next = typeof amount === "number" ? amount : Number(amount);
+  if (!Number.isFinite(next)) return "amount_invalid";
+  return String(Math.round(next));
+}
+
+function normalizeReceivedAt(value: ManualPaymentIdempotencyInput["receivedAt"]): string {
+  if (value instanceof Date && Number.isFinite(value.getTime())) return value.toISOString();
+  if (typeof value === "number" && Number.isFinite(value)) return new Date(value).toISOString();
+  const raw = String(value || "").trim();
+  if (!raw) return "received_at_missing";
+  const parsed = Date.parse(raw);
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : raw;
+}
+
+export function buildProviderWebhookIdempotencyKey(input: ProviderWebhookIdempotencyInput): string {
+  return ["provider_event", cleanPart(input.provider), cleanPart(input.providerEventId || "event_missing")].join(":");
+}
+
+export function buildSessionCreationIdempotencyKey(input: SessionCreationIdempotencyInput): string {
+  return [
+    "payment_session",
+    cleanPart(input.provider),
+    cleanPart(input.purpose),
+    cleanPart(input.subjectId || "subject_missing"),
+    normalizeAmount(input.amount),
+    cleanPart(input.currency || "currency_missing"),
+  ].join(":");
+}
+
+export function buildManualPaymentIdempotencyKey(input: ManualPaymentIdempotencyInput): string {
+  return [
+    "manual_payment",
+    "manual",
+    cleanPart(input.landlordId || "landlord_missing"),
+    cleanPart(input.subjectId || "subject_missing"),
+    normalizeAmount(input.amount),
+    cleanPart(normalizeReceivedAt(input.receivedAt)),
+  ].join(":");
+}

--- a/rentchain-api/src/lib/payments/paymentProviderAdapter.ts
+++ b/rentchain-api/src/lib/payments/paymentProviderAdapter.ts
@@ -1,0 +1,133 @@
+import type {
+  PaymentExecutionStatus,
+  PaymentIntentReference,
+  PaymentProvider,
+  PaymentPurpose,
+  ProviderPaymentReference,
+} from "./paymentTypes";
+
+export type CreatePaymentSessionInput = {
+  intent: PaymentIntentReference;
+  successUrl?: string | null;
+  cancelUrl?: string | null;
+  metadata?: Record<string, string | number | boolean | null>;
+};
+
+export type CreatePaymentSessionResult = {
+  provider: PaymentProvider;
+  status: PaymentExecutionStatus;
+  redirectUrl?: string | null;
+  reference: ProviderPaymentReference;
+};
+
+export type NormalizeProviderEventInput = {
+  provider: PaymentProvider;
+  providerEventId?: string | null;
+  providerPaymentId?: string | null;
+  providerSessionId?: string | null;
+  providerCustomerId?: string | null;
+  rawStatus?: string | null;
+  purpose?: PaymentPurpose | null;
+  amount?: number | null;
+  currency?: string | null;
+  occurredAt?: string | null;
+};
+
+export type NormalizedProviderPaymentEvent = {
+  provider: PaymentProvider;
+  providerEventId?: string | null;
+  providerPaymentId?: string | null;
+  providerSessionId?: string | null;
+  providerCustomerId?: string | null;
+  rawStatus: string | null;
+  normalizedStatus: PaymentExecutionStatus;
+  purpose?: PaymentPurpose | null;
+  amount?: number | null;
+  currency?: string | null;
+  occurredAt?: string | null;
+};
+
+export type PaymentProviderAdapter = {
+  provider: PaymentProvider;
+  createPaymentSession(input: CreatePaymentSessionInput): Promise<CreatePaymentSessionResult>;
+  normalizeProviderEvent(input: NormalizeProviderEventInput): NormalizedProviderPaymentEvent;
+  mapProviderStatus(rawStatus: unknown): PaymentExecutionStatus;
+};
+
+const STRIPE_STATUS_MAP: Record<string, PaymentExecutionStatus> = {
+  open: "provider_session_created",
+  complete: "confirmed",
+  completed: "confirmed",
+  paid: "confirmed",
+  succeeded: "confirmed",
+  processing: "pending_provider_confirmation",
+  requires_payment_method: "pending_provider_confirmation",
+  requires_confirmation: "initiated",
+  requires_action: "pending_provider_confirmation",
+  canceled: "cancelled",
+  cancelled: "cancelled",
+  expired: "expired",
+  failed: "failed",
+};
+
+const TRUSTLY_STATUS_MAP: Record<string, PaymentExecutionStatus> = {
+  created: "provider_session_created",
+  initiated: "initiated",
+  pending: "pending_provider_confirmation",
+  processing: "pending_provider_confirmation",
+  authorized: "pending_settlement",
+  settled: "confirmed",
+  completed: "confirmed",
+  confirmed: "confirmed",
+  failed: "failed",
+  denied: "failed",
+  cancelled: "cancelled",
+  canceled: "cancelled",
+  expired: "expired",
+};
+
+const MANUAL_STATUS_MAP: Record<string, PaymentExecutionStatus> = {
+  recorded: "confirmed",
+  received: "confirmed",
+  reconciled: "reconciled",
+  pending: "manual_review_required",
+  duplicate: "duplicate_risk",
+  void: "cancelled",
+  voided: "cancelled",
+  failed: "failed",
+};
+
+function normalizeRawStatus(rawStatus: unknown): string {
+  return String(rawStatus || "")
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "_");
+}
+
+export function mapProviderStatus(provider: PaymentProvider, rawStatus: unknown): PaymentExecutionStatus {
+  const status = normalizeRawStatus(rawStatus);
+  if (!status) return "manual_review_required";
+  const maps: Record<PaymentProvider, Record<string, PaymentExecutionStatus>> = {
+    stripe: STRIPE_STATUS_MAP,
+    trustly: TRUSTLY_STATUS_MAP,
+    manual: MANUAL_STATUS_MAP,
+  };
+  return maps[provider][status] || "manual_review_required";
+}
+
+export function normalizeProviderPaymentEvent(input: NormalizeProviderEventInput): NormalizedProviderPaymentEvent {
+  const rawStatus = String(input.rawStatus || "").trim() || null;
+  return {
+    provider: input.provider,
+    providerEventId: input.providerEventId || null,
+    providerPaymentId: input.providerPaymentId || null,
+    providerSessionId: input.providerSessionId || null,
+    providerCustomerId: input.providerCustomerId || null,
+    rawStatus,
+    normalizedStatus: mapProviderStatus(input.provider, rawStatus),
+    purpose: input.purpose || null,
+    amount: typeof input.amount === "number" && Number.isFinite(input.amount) ? input.amount : null,
+    currency: String(input.currency || "").trim().toUpperCase() || null,
+    occurredAt: input.occurredAt || null,
+  };
+}

--- a/rentchain-api/src/lib/payments/paymentReconciliation.ts
+++ b/rentchain-api/src/lib/payments/paymentReconciliation.ts
@@ -80,6 +80,7 @@ export function derivePaymentReconciliation(params: {
       requiresManualReview: true,
     });
   }
+  const checkedExpected = expected as PaymentIntentReference;
 
   if (!signal) {
     return result("manual_review_required", ["missing_provider_signal"], {
@@ -93,11 +94,11 @@ export function derivePaymentReconciliation(params: {
     });
   }
 
-  if (typeof signal.amount === "number" && Number.isFinite(signal.amount) && signal.amount !== expected.amount) {
+  if (typeof signal.amount === "number" && Number.isFinite(signal.amount) && signal.amount !== checkedExpected.amount) {
     reasons.push("amount_mismatch");
   }
 
-  if (normalizeCurrency(signal.currency) && normalizeCurrency(signal.currency) !== normalizeCurrency(expected.currency)) {
+  if (normalizeCurrency(signal.currency) && normalizeCurrency(signal.currency) !== normalizeCurrency(checkedExpected.currency)) {
     reasons.push("currency_mismatch");
   }
 

--- a/rentchain-api/src/lib/payments/paymentReconciliation.ts
+++ b/rentchain-api/src/lib/payments/paymentReconciliation.ts
@@ -1,0 +1,138 @@
+import type { NormalizedProviderPaymentEvent } from "./paymentProviderAdapter";
+import type { PaymentExecutionStatus, PaymentIntentReference } from "./paymentTypes";
+
+export type PaymentReconciliationStatus =
+  | "not_started"
+  | "pending_provider_confirmation"
+  | "pending_settlement"
+  | "confirmed"
+  | "failed"
+  | "mismatch"
+  | "duplicate_risk"
+  | "manual_review_required"
+  | "reconciled";
+
+export type ExistingPaymentReconciliationState = {
+  seenProviderEventIds?: string[];
+  status?: PaymentReconciliationStatus | null;
+};
+
+export type PaymentReconciliationResult = {
+  reconciliationStatus: PaymentReconciliationStatus;
+  reasons: string[];
+  automationEligible: boolean;
+  requiresManualReview: boolean;
+};
+
+function normalizeCurrency(value: unknown): string {
+  return String(value || "").trim().toUpperCase();
+}
+
+function isMissingSubjectReference(intent: PaymentIntentReference | null | undefined): boolean {
+  if (!intent) return true;
+  if (!String(intent.paymentIntentId || "").trim()) return true;
+  if (!String(intent.landlordId || "").trim()) return true;
+  if (intent.purpose === "rent" || intent.purpose === "deposit") {
+    return !String(intent.leaseId || "").trim() && !String(intent.tenantId || "").trim();
+  }
+  if (intent.purpose === "screening") {
+    return !String(intent.screeningOrderId || "").trim();
+  }
+  if (intent.purpose === "subscription") {
+    return !String(intent.subscriptionId || "").trim();
+  }
+  return false;
+}
+
+function result(
+  reconciliationStatus: PaymentReconciliationStatus,
+  reasons: string[],
+  options?: { automationEligible?: boolean; requiresManualReview?: boolean }
+): PaymentReconciliationResult {
+  return {
+    reconciliationStatus,
+    reasons,
+    automationEligible: options?.automationEligible === true,
+    requiresManualReview: options?.requiresManualReview === true,
+  };
+}
+
+function isDuplicateProviderEvent(
+  signal: NormalizedProviderPaymentEvent | null | undefined,
+  existing: ExistingPaymentReconciliationState | null | undefined
+): boolean {
+  const eventId = String(signal?.providerEventId || "").trim();
+  if (!eventId) return false;
+  return Boolean(existing?.seenProviderEventIds?.includes(eventId));
+}
+
+export function derivePaymentReconciliation(params: {
+  expectedIntent?: PaymentIntentReference | null;
+  providerSignal?: NormalizedProviderPaymentEvent | null;
+  existingState?: ExistingPaymentReconciliationState | null;
+}): PaymentReconciliationResult {
+  const expected = params.expectedIntent || null;
+  const signal = params.providerSignal || null;
+  const reasons: string[] = [];
+
+  if (isMissingSubjectReference(expected)) {
+    return result("manual_review_required", ["missing_internal_subject_reference"], {
+      requiresManualReview: true,
+    });
+  }
+
+  if (!signal) {
+    return result("manual_review_required", ["missing_provider_signal"], {
+      requiresManualReview: true,
+    });
+  }
+
+  if (isDuplicateProviderEvent(signal, params.existingState)) {
+    return result("duplicate_risk", ["duplicate_provider_event"], {
+      requiresManualReview: true,
+    });
+  }
+
+  if (typeof signal.amount === "number" && Number.isFinite(signal.amount) && signal.amount !== expected.amount) {
+    reasons.push("amount_mismatch");
+  }
+
+  if (normalizeCurrency(signal.currency) && normalizeCurrency(signal.currency) !== normalizeCurrency(expected.currency)) {
+    reasons.push("currency_mismatch");
+  }
+
+  if (reasons.length > 0) {
+    return result("mismatch", reasons, { requiresManualReview: true });
+  }
+
+  const status: PaymentExecutionStatus = signal.normalizedStatus;
+  if (status === "confirmed" || status === "reconciled") {
+    return result("reconciled", ["provider_confirmed_amount_currency_match"], {
+      automationEligible: true,
+      requiresManualReview: false,
+    });
+  }
+  if (status === "pending_settlement") {
+    return result("pending_settlement", ["provider_signal_pending_settlement"]);
+  }
+  if (
+    status === "initiated" ||
+    status === "provider_session_created" ||
+    status === "pending_provider_confirmation"
+  ) {
+    return result("pending_provider_confirmation", ["provider_signal_pending_confirmation"]);
+  }
+  if (status === "failed" || status === "cancelled" || status === "expired") {
+    return result("failed", [`provider_signal_${status}`]);
+  }
+  if (status === "duplicate_risk") {
+    return result("duplicate_risk", ["provider_signal_duplicate_risk"], { requiresManualReview: true });
+  }
+  if (status === "mismatch") {
+    return result("mismatch", ["provider_signal_mismatch"], { requiresManualReview: true });
+  }
+
+  return result("manual_review_required", ["provider_status_unknown_or_manual_review"], {
+    requiresManualReview: true,
+  });
+}

--- a/rentchain-api/src/lib/payments/paymentTypes.ts
+++ b/rentchain-api/src/lib/payments/paymentTypes.ts
@@ -1,0 +1,74 @@
+export const PAYMENT_PROVIDERS = ["stripe", "trustly", "manual"] as const;
+export type PaymentProvider = (typeof PAYMENT_PROVIDERS)[number];
+
+export const PAYMENT_PURPOSES = ["rent", "screening", "subscription", "deposit", "maintenance", "payout"] as const;
+export type PaymentPurpose = (typeof PAYMENT_PURPOSES)[number];
+
+export const PAYMENT_EXECUTION_STATUSES = [
+  "not_started",
+  "provider_session_created",
+  "initiated",
+  "pending_provider_confirmation",
+  "pending_settlement",
+  "confirmed",
+  "failed",
+  "cancelled",
+  "expired",
+  "mismatch",
+  "duplicate_risk",
+  "manual_review_required",
+  "reconciled",
+] as const;
+export type PaymentExecutionStatus = (typeof PAYMENT_EXECUTION_STATUSES)[number];
+
+export const PAYMENT_ACTOR_TYPES = ["tenant", "landlord", "admin", "system", "provider"] as const;
+export type PaymentActorType = (typeof PAYMENT_ACTOR_TYPES)[number];
+
+export type ProviderPaymentReference = {
+  provider: PaymentProvider;
+  providerPaymentId?: string | null;
+  providerSessionId?: string | null;
+  providerCustomerId?: string | null;
+  providerEventId?: string | null;
+  rawStatus?: string | null;
+  normalizedStatus?: PaymentExecutionStatus | null;
+};
+
+export type PaymentIntentReference = {
+  paymentIntentId: string;
+  landlordId: string;
+  tenantId?: string | null;
+  propertyId?: string | null;
+  unitId?: string | null;
+  leaseId?: string | null;
+  screeningOrderId?: string | null;
+  subscriptionId?: string | null;
+  amount: number;
+  currency: string;
+  purpose: PaymentPurpose;
+  provider: PaymentProvider;
+};
+
+export type PaymentSubjectReference = {
+  paymentIntentId?: string | null;
+  landlordId?: string | null;
+  tenantId?: string | null;
+  propertyId?: string | null;
+  unitId?: string | null;
+  leaseId?: string | null;
+  screeningOrderId?: string | null;
+  subscriptionId?: string | null;
+  payoutId?: string | null;
+};
+
+export function isPaymentProvider(value: unknown): value is PaymentProvider {
+  return (PAYMENT_PROVIDERS as readonly string[]).includes(String(value || "").trim());
+}
+
+export function isPaymentPurpose(value: unknown): value is PaymentPurpose {
+  return (PAYMENT_PURPOSES as readonly string[]).includes(String(value || "").trim());
+}
+
+export function isPaymentExecutionStatus(value: unknown): value is PaymentExecutionStatus {
+  return (PAYMENT_EXECUTION_STATUSES as readonly string[]).includes(String(value || "").trim());
+}

--- a/rentchain-api/src/lib/payments/providers/stripePaymentProvider.ts
+++ b/rentchain-api/src/lib/payments/providers/stripePaymentProvider.ts
@@ -1,0 +1,102 @@
+import type Stripe from "stripe";
+import { getStripeClient } from "../../../services/stripeService";
+import {
+  mapProviderStatus as mapProviderExecutionStatus,
+  normalizeProviderPaymentEvent,
+  type CreatePaymentSessionInput,
+  type CreatePaymentSessionResult,
+  type NormalizeProviderEventInput,
+  type PaymentProviderAdapter,
+} from "../paymentProviderAdapter";
+import type { PaymentExecutionStatus } from "../paymentTypes";
+
+type StripeCheckoutSessionCreator = (
+  params: Stripe.Checkout.SessionCreateParams
+) => Promise<Pick<Stripe.Checkout.Session, "id" | "url" | "payment_intent">>;
+
+type StripePaymentProviderOptions = {
+  createCheckoutSession?: StripeCheckoutSessionCreator;
+};
+
+function resolveCheckoutSessionCreator(options?: StripePaymentProviderOptions): StripeCheckoutSessionCreator {
+  if (options?.createCheckoutSession) return options.createCheckoutSession;
+  return (params) => getStripeClient().checkout.sessions.create(params);
+}
+
+function normalizeStripeCurrency(value: unknown): string {
+  return String(value || "cad").trim().toLowerCase() || "cad";
+}
+
+function buildRentPaymentSessionParams(input: CreatePaymentSessionInput): Stripe.Checkout.SessionCreateParams {
+  const intent = input.intent;
+  const metadata = {
+    leaseId: intent.leaseId || "",
+    tenantId: intent.tenantId || "",
+    landlordId: intent.landlordId,
+    rentPaymentId: intent.paymentIntentId,
+    ...(input.metadata || {}),
+  };
+
+  return {
+    mode: "payment",
+    payment_method_types: ["card"],
+    line_items: [
+      {
+        price_data: {
+          currency: normalizeStripeCurrency(intent.currency),
+          product_data: {
+            name: "Monthly rent payment",
+          },
+          unit_amount: intent.amount,
+        },
+        quantity: 1,
+      },
+    ],
+    metadata,
+    payment_intent_data: {
+      metadata,
+    },
+    success_url: input.successUrl || "",
+    cancel_url: input.cancelUrl || "",
+  };
+}
+
+export function createStripePaymentProvider(options?: StripePaymentProviderOptions): PaymentProviderAdapter {
+  const createCheckoutSession = resolveCheckoutSessionCreator(options);
+
+  return {
+    provider: "stripe",
+    async createPaymentSession(input: CreatePaymentSessionInput): Promise<CreatePaymentSessionResult> {
+      if (input.intent.provider !== "stripe") {
+        throw new Error("stripe_payment_provider_invalid_provider");
+      }
+      if (input.intent.purpose !== "rent") {
+        throw new Error("stripe_payment_provider_unsupported_purpose");
+      }
+
+      const session = await createCheckoutSession(buildRentPaymentSessionParams(input));
+      const providerPaymentId = typeof session.payment_intent === "string" ? session.payment_intent : null;
+
+      return {
+        provider: "stripe",
+        status: "provider_session_created",
+        redirectUrl: String(session.url || "").trim(),
+        reference: {
+          provider: "stripe",
+          providerSessionId: session.id,
+          providerPaymentId,
+          rawStatus: "open",
+          normalizedStatus: "provider_session_created",
+        },
+      };
+    },
+    normalizeProviderEvent(input: NormalizeProviderEventInput) {
+      return normalizeProviderPaymentEvent({ ...input, provider: "stripe" });
+    },
+    mapProviderStatus(rawStatus: unknown): PaymentExecutionStatus {
+      return mapProviderExecutionStatus("stripe", rawStatus);
+    },
+  };
+}
+
+export const stripePaymentProvider = createStripePaymentProvider();

--- a/rentchain-api/src/services/rentPayments/rentPaymentService.ts
+++ b/rentchain-api/src/services/rentPayments/rentPaymentService.ts
@@ -2,8 +2,8 @@ import crypto from "crypto";
 import Stripe from "stripe";
 import { db } from "../../config/firebase";
 import { FRONTEND_URL } from "../../config/screeningConfig";
-import { getStripeClient } from "../stripeService";
 import { writeCanonicalEvent } from "../../lib/events/buildEvent";
+import { createRentPaymentSession } from "../../lib/payments/paymentExecutionService";
 import type { PaymentReadiness } from "../paymentReadiness/derivePaymentReadiness";
 import { recordSystemObservabilityEvent } from "../observability/recordSystemObservabilityEvent";
 
@@ -497,42 +497,33 @@ export async function createRentPaymentCheckout(input: CreateRentPaymentCheckout
   const rentPaymentId = crypto.randomUUID();
   const createdAt = new Date().toISOString();
   const checkoutRef = db.collection(RENT_PAYMENTS_COLLECTION).doc(rentPaymentId);
-  const stripe = getStripeClient();
   const frontendBase = resolveFrontendBase();
   const successUrl = `${frontendBase}${sanitizeRelativePath(input.successPath, "/tenant/lease")}`;
   const cancelUrl = `${frontendBase}${sanitizeRelativePath(input.cancelPath, "/tenant/lease")}`;
+  const stripeSuccessUrl = `${successUrl}${successUrl.includes("?") ? "&" : "?"}rentPaymentStatus=success`;
+  const stripeCancelUrl = `${cancelUrl}${cancelUrl.includes("?") ? "&" : "?"}rentPaymentStatus=canceled`;
 
-  const session = await stripe.checkout.sessions.create({
-    mode: "payment",
-    payment_method_types: ["card"],
-    line_items: [
-      {
-        price_data: {
-          currency: "cad",
-          product_data: {
-            name: "Monthly rent payment",
-          },
-          unit_amount: amountCents,
-        },
-        quantity: 1,
-      },
-    ],
+  const session = await createRentPaymentSession({
+    intent: {
+      paymentIntentId: rentPaymentId,
+      landlordId,
+      tenantId,
+      propertyId: asString(lease.propertyId),
+      unitId: asString(lease.unitId) || asString(lease.unitNumber),
+      leaseId,
+      amount: amountCents,
+      currency: "cad",
+      purpose: "rent",
+      provider: "stripe",
+    },
     metadata: {
       leaseId,
       tenantId,
       landlordId,
       rentPaymentId,
     },
-    payment_intent_data: {
-      metadata: {
-        leaseId,
-        tenantId,
-        landlordId,
-        rentPaymentId,
-      },
-    },
-    success_url: `${successUrl}${successUrl.includes("?") ? "&" : "?"}rentPaymentStatus=success`,
-    cancel_url: `${cancelUrl}${cancelUrl.includes("?") ? "&" : "?"}rentPaymentStatus=canceled`,
+    successUrl: stripeSuccessUrl,
+    cancelUrl: stripeCancelUrl,
   });
 
   const record: RentPaymentRecord = {
@@ -546,8 +537,8 @@ export async function createRentPaymentCheckout(input: CreateRentPaymentCheckout
     currency: "cad",
     status: "checkout_created",
     processor: "stripe",
-    processorCheckoutSessionId: session.id,
-    processorPaymentIntentId: typeof session.payment_intent === "string" ? session.payment_intent : null,
+    processorCheckoutSessionId: session.reference.providerSessionId,
+    processorPaymentIntentId: session.reference.providerPaymentId,
     createdAt,
     updatedAt: createdAt,
     paidAt: null,
@@ -577,7 +568,7 @@ export async function createRentPaymentCheckout(input: CreateRentPaymentCheckout
     ok: true as const,
     rentPaymentId,
     status: "checkout_created" as const,
-    redirectUrl: String(session.url || "").trim(),
+    redirectUrl: String(session.redirectUrl || "").trim(),
   };
 }
 


### PR DESCRIPTION
This PR adds a behavior-preserving Stripe rent-payment adapter seam.

Includes:
- Routes existing Stripe rent-payment checkout through paymentExecutionService
- Adds stripePaymentProvider as a thin adapter around existing Stripe SDK helper behavior
- Preserves existing tenant checkout response, rentPayments Firestore shape, Stripe metadata, and webhook behavior
- Keeps reconciliation pure and non-mutating
- Fails closed for unsupported providers
- Defers webhook normalization because the current webhook handler is shared with rent payments, screening, and subscriptions

Guardrails preserved:
- Backend/docs only
- No frontend changes
- No schema changes
- No dependency or lockfile changes
- No Trustly implementation
- No screening, subscription, payout, pricing, or plan changes
- No webhook behavior changes

Verification:
- git diff --check passed
- payment boundary focused tests passed
- Stripe adapter/service tests passed
- rent-payment regression tests passed
- pnpm build passed