### PR TITLE
Add rent webhook normalization seam

### DIFF
--- a/docs/architecture/payment-execution-boundary-v1.md
+++ b/docs/architecture/payment-execution-boundary-v1.md
@@ -217,6 +217,53 @@ Future migration path:
 4. Canonical payment event domain expansion and emission.
 5. Trustly sandbox adapter.
 
+## Rent Webhook Normalization Seam v1
+
+Status: Stripe rent-payment webhook interpretation now passes through the provider boundary in read-only mode.
+
+What changed:
+
+- The shared Stripe webhook route still verifies Stripe signatures and handles subscription, screening, and rent-payment events in the same order as before.
+- Only the existing rent-payment branch calls `paymentExecutionService.normalizeRentPaymentProviderEvent`.
+- `stripePaymentProvider.normalizeProviderEvent` now understands the Stripe webhook shapes used by rent payments:
+  - `checkout.session.completed`
+  - `checkout.session.async_payment_succeeded`
+  - `checkout.session.async_payment_failed`
+  - `checkout.session.expired`
+  - `payment_intent.succeeded`
+  - `payment_intent.payment_failed`
+- The seam derives the deterministic provider-event idempotency key:
+
+```text
+provider_event:stripe:{stripeEventId}
+```
+
+- The seam derives reconciliation with `deriveRentPaymentReconciliation` using the current rent payment record and normalized provider signal.
+
+Behavior intentionally unchanged:
+
+- Existing `rentPayments` status transitions remain owned by `updateRentPaymentFromWebhook`.
+- Existing Stripe webhook HTTP responses remain unchanged.
+- Existing rent-payment canonical events remain unchanged.
+- Reconciliation output is not persisted.
+- Provider-event receipt/idempotency state is not persisted.
+- No new canonical payment events are emitted.
+- Screening checkout webhook behavior is untouched.
+- SaaS subscription webhook behavior is untouched.
+
+Why reconciliation is read-only:
+
+The current rent-payment records do not yet have provider-neutral payment intent or provider-event receipt persistence. Running reconciliation read-only lets RentChain prove the normalized signal and expected intent can be compared without risking double writes, new status transitions, or webhook retry behavior changes.
+
+Deferred items:
+
+1. Persisted provider-event receipt collection.
+2. Active idempotency enforcement for provider webhooks.
+3. `payment.provider_signal_received` canonical event emission.
+4. Reconciliation state persistence.
+5. Provider-neutral rent-payment intent persistence.
+6. Trustly webhook adapter.
+
 ## Intentional Non-Implementation
 
 This mission intentionally does not:

--- a/rentchain-api/src/lib/payments/__tests__/paymentExecutionService.test.ts
+++ b/rentchain-api/src/lib/payments/__tests__/paymentExecutionService.test.ts
@@ -141,6 +141,53 @@ describe("paymentExecutionService", () => {
     expect(result.normalizedStatus).toBe("confirmed");
   });
 
+  it("routes Stripe rent webhook events without dropping provider event id", () => {
+    const adapter = buildStripeAdapter();
+    const service = createPaymentExecutionService({ stripe: adapter });
+
+    const rawEvent = {
+      id: "evt_rent_paid_1",
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_test_1",
+          payment_intent: "pi_test_1",
+          payment_status: "paid",
+          metadata: {
+            rentPaymentId: "rp-1",
+          },
+        },
+      },
+    };
+    const result = service.normalizeRentPaymentProviderEvent({
+      provider: "stripe",
+      rawEvent,
+      providerEventId: "evt_rent_paid_1",
+      rawStatus: "paid",
+    });
+
+    expect(adapter.normalizeProviderEvent).toHaveBeenCalledWith({
+      provider: "stripe",
+      rawEvent,
+      providerEventId: "evt_rent_paid_1",
+      rawStatus: "paid",
+    });
+    expect(result.providerEventId).toBe("evt_rent_paid_1");
+    expect(result.normalizedStatus).toBe("confirmed");
+  });
+
+  it("fails closed for unknown rent webhook provider", () => {
+    const service = createPaymentExecutionService({ stripe: buildStripeAdapter() });
+
+    expect(() =>
+      service.normalizeRentPaymentProviderEvent({
+        provider: "manual",
+        providerEventId: "evt_manual_1",
+        rawStatus: "recorded",
+      })
+    ).toThrow("payment_provider_unsupported");
+  });
+
   it("derives reconciliation without mutating payment intent or provider signal", () => {
     const service = createPaymentExecutionService({ stripe: buildStripeAdapter() });
     const intent = { ...rentIntent };

--- a/rentchain-api/src/lib/payments/__tests__/stripePaymentProvider.test.ts
+++ b/rentchain-api/src/lib/payments/__tests__/stripePaymentProvider.test.ts
@@ -51,6 +51,111 @@ describe("stripePaymentProvider", () => {
     });
   });
 
+  it("normalizes checkout session completed webhook events with metadata and amounts", () => {
+    expect(
+      stripePaymentProvider.normalizeProviderEvent({
+        provider: "stripe",
+        rawEvent: {
+          id: "evt_checkout_1",
+          type: "checkout.session.completed",
+          created: 1_714_213_200,
+          data: {
+            object: {
+              id: "cs_test_1",
+              payment_intent: "pi_test_1",
+              payment_status: "paid",
+              amount_total: 180000,
+              currency: "cad",
+              metadata: {
+                rentPaymentId: "rp-1",
+                leaseId: "lease-1",
+              },
+            },
+          },
+        },
+      })
+    ).toMatchObject({
+      provider: "stripe",
+      providerEventId: "evt_checkout_1",
+      providerSessionId: "cs_test_1",
+      providerPaymentId: "pi_test_1",
+      rawStatus: "paid",
+      normalizedStatus: "confirmed",
+      amount: 180000,
+      currency: "CAD",
+      occurredAt: "2024-04-27T10:20:00.000Z",
+      metadata: {
+        rentPaymentId: "rp-1",
+        leaseId: "lease-1",
+      },
+    });
+  });
+
+  it("normalizes payment intent succeeded webhook events with metadata and amounts", () => {
+    expect(
+      stripePaymentProvider.normalizeProviderEvent({
+        provider: "stripe",
+        rawEvent: {
+          id: "evt_pi_1",
+          type: "payment_intent.succeeded",
+          created: 1_714_213_200,
+          data: {
+            object: {
+              id: "pi_test_1",
+              amount_received: 180000,
+              currency: "cad",
+              metadata: {
+                rentPaymentId: "rp-1",
+              },
+            },
+          },
+        },
+      })
+    ).toMatchObject({
+      provider: "stripe",
+      providerEventId: "evt_pi_1",
+      providerPaymentId: "pi_test_1",
+      rawStatus: "succeeded",
+      normalizedStatus: "confirmed",
+      amount: 180000,
+      currency: "CAD",
+      metadata: {
+        rentPaymentId: "rp-1",
+      },
+    });
+  });
+
+  it("preserves unknown webhook status as manual review", () => {
+    expect(
+      stripePaymentProvider.normalizeProviderEvent({
+        provider: "stripe",
+        rawEvent: {
+          id: "evt_unknown_1",
+          type: "payment_intent.requires_capture",
+          data: {
+            object: {
+              id: "pi_test_1",
+              status: "requires_capture",
+              amount: 180000,
+              currency: "cad",
+              metadata: {
+                rentPaymentId: "rp-1",
+              },
+            },
+          },
+        },
+      })
+    ).toMatchObject({
+      providerEventId: "evt_unknown_1",
+      providerPaymentId: "pi_test_1",
+      rawStatus: "requires_capture",
+      normalizedStatus: "manual_review_required",
+      metadata: {
+        rentPaymentId: "rp-1",
+      },
+    });
+  });
+
   it("delegates session creation without changing rent payment metadata", async () => {
     const createCheckoutSession = vi.fn().mockResolvedValue({
       id: "cs_test_1",

--- a/rentchain-api/src/lib/payments/paymentProviderAdapter.ts
+++ b/rentchain-api/src/lib/payments/paymentProviderAdapter.ts
@@ -22,6 +22,7 @@ export type CreatePaymentSessionResult = {
 
 export type NormalizeProviderEventInput = {
   provider: PaymentProvider;
+  rawEvent?: unknown;
   providerEventId?: string | null;
   providerPaymentId?: string | null;
   providerSessionId?: string | null;
@@ -31,6 +32,7 @@ export type NormalizeProviderEventInput = {
   amount?: number | null;
   currency?: string | null;
   occurredAt?: string | null;
+  metadata?: Record<string, unknown> | null;
 };
 
 export type NormalizedProviderPaymentEvent = {
@@ -45,6 +47,7 @@ export type NormalizedProviderPaymentEvent = {
   amount?: number | null;
   currency?: string | null;
   occurredAt?: string | null;
+  metadata?: Record<string, unknown> | null;
 };
 
 export type PaymentProviderAdapter = {
@@ -117,7 +120,7 @@ export function mapProviderStatus(provider: PaymentProvider, rawStatus: unknown)
 
 export function normalizeProviderPaymentEvent(input: NormalizeProviderEventInput): NormalizedProviderPaymentEvent {
   const rawStatus = String(input.rawStatus || "").trim() || null;
-  return {
+  const normalized: NormalizedProviderPaymentEvent = {
     provider: input.provider,
     providerEventId: input.providerEventId || null,
     providerPaymentId: input.providerPaymentId || null,
@@ -130,4 +133,8 @@ export function normalizeProviderPaymentEvent(input: NormalizeProviderEventInput
     currency: String(input.currency || "").trim().toUpperCase() || null,
     occurredAt: input.occurredAt || null,
   };
+  if (input.metadata && typeof input.metadata === "object") {
+    normalized.metadata = input.metadata;
+  }
+  return normalized;
 }

--- a/rentchain-api/src/lib/payments/providers/stripePaymentProvider.ts
+++ b/rentchain-api/src/lib/payments/providers/stripePaymentProvider.ts
@@ -27,6 +27,106 @@ function normalizeStripeCurrency(value: unknown): string {
   return String(value || "cad").trim().toLowerCase() || "cad";
 }
 
+function normalizeOptionalString(value: unknown): string | null {
+  const next = String(value || "").trim();
+  return next || null;
+}
+
+function normalizeMetadata(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object") return null;
+  return value as Record<string, unknown>;
+}
+
+function normalizeStripeOccurredAt(value: unknown): string | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  return new Date(value * 1000).toISOString();
+}
+
+function getStripeObjectId(value: unknown): string | null {
+  if (typeof value === "string") return normalizeOptionalString(value);
+  if (value && typeof value === "object") {
+    return normalizeOptionalString((value as { id?: unknown }).id);
+  }
+  return null;
+}
+
+function deriveCheckoutSessionRawStatus(eventType: string, session: Record<string, unknown>): string | null {
+  if (eventType === "checkout.session.async_payment_succeeded") return "paid";
+  if (eventType === "checkout.session.async_payment_failed") return "failed";
+  if (eventType === "checkout.session.expired") return "expired";
+  return normalizeOptionalString(session.payment_status) || normalizeOptionalString(session.status) || eventType || null;
+}
+
+function derivePaymentIntentRawStatus(eventType: string, paymentIntent: Record<string, unknown>): string | null {
+  if (eventType === "payment_intent.succeeded") return "succeeded";
+  if (eventType === "payment_intent.payment_failed") return "failed";
+  return normalizeOptionalString(paymentIntent.status) || eventType || null;
+}
+
+function normalizeStripeRawEvent(input: NormalizeProviderEventInput): NormalizeProviderEventInput | null {
+  const event = input.rawEvent as
+    | {
+        id?: unknown;
+        type?: unknown;
+        created?: unknown;
+        data?: { object?: Record<string, unknown> };
+      }
+    | null
+    | undefined;
+  const eventObject = event?.data?.object;
+  if (!event || !eventObject || typeof eventObject !== "object") return null;
+
+  const eventType = String(event.type || "").trim();
+  const providerEventId = normalizeOptionalString(event.id) || input.providerEventId || null;
+  const occurredAt = normalizeStripeOccurredAt(event.created) || input.occurredAt || null;
+
+  if (eventType.startsWith("checkout.session.")) {
+    const paymentIntent = eventObject.payment_intent;
+    return {
+      ...input,
+      provider: "stripe",
+      providerEventId,
+      providerSessionId: normalizeOptionalString(eventObject.id) || input.providerSessionId || null,
+      providerPaymentId: getStripeObjectId(paymentIntent) || input.providerPaymentId || null,
+      providerCustomerId: getStripeObjectId(eventObject.customer) || input.providerCustomerId || null,
+      rawStatus: deriveCheckoutSessionRawStatus(eventType, eventObject) || input.rawStatus || null,
+      amount: typeof eventObject.amount_total === "number" ? eventObject.amount_total : input.amount ?? null,
+      currency: normalizeOptionalString(eventObject.currency) || input.currency || null,
+      occurredAt,
+      metadata: normalizeMetadata(eventObject.metadata) || input.metadata || null,
+    };
+  }
+
+  if (eventType.startsWith("payment_intent.")) {
+    const amount =
+      typeof eventObject.amount_received === "number"
+        ? eventObject.amount_received
+        : typeof eventObject.amount === "number"
+          ? eventObject.amount
+          : input.amount ?? null;
+    return {
+      ...input,
+      provider: "stripe",
+      providerEventId,
+      providerPaymentId: normalizeOptionalString(eventObject.id) || input.providerPaymentId || null,
+      providerCustomerId: getStripeObjectId(eventObject.customer) || input.providerCustomerId || null,
+      rawStatus: derivePaymentIntentRawStatus(eventType, eventObject) || input.rawStatus || null,
+      amount,
+      currency: normalizeOptionalString(eventObject.currency) || input.currency || null,
+      occurredAt,
+      metadata: normalizeMetadata(eventObject.metadata) || input.metadata || null,
+    };
+  }
+
+  return {
+    ...input,
+    provider: "stripe",
+    providerEventId,
+    rawStatus: input.rawStatus || eventType || null,
+    occurredAt,
+  };
+}
+
 function buildRentPaymentSessionParams(input: CreatePaymentSessionInput): Stripe.Checkout.SessionCreateParams {
   const intent = input.intent;
   const metadata = {
@@ -91,7 +191,7 @@ export function createStripePaymentProvider(options?: StripePaymentProviderOptio
       };
     },
     normalizeProviderEvent(input: NormalizeProviderEventInput) {
-      return normalizeProviderPaymentEvent({ ...input, provider: "stripe" });
+      return normalizeProviderPaymentEvent(normalizeStripeRawEvent(input) || { ...input, provider: "stripe" });
     },
     mapProviderStatus(rawStatus: unknown): PaymentExecutionStatus {
       return mapProviderExecutionStatus("stripe", rawStatus);

--- a/rentchain-api/src/routes/__tests__/rentPaymentWebhook.test.ts
+++ b/rentchain-api/src/routes/__tests__/rentPaymentWebhook.test.ts
@@ -1,6 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { store, ensureCollection, constructEventMock, docRef } = vi.hoisted(() => {
+const {
+  store,
+  ensureCollection,
+  constructEventMock,
+  docRef,
+  normalizeRentPaymentProviderEventMock,
+  deriveRentPaymentReconciliationMock,
+  buildProviderWebhookIdempotencyKeyMock,
+} = vi.hoisted(() => {
   const store = new Map<string, Map<string, any>>();
 
   function ensureCollection(name: string) {
@@ -29,6 +37,27 @@ const { store, ensureCollection, constructEventMock, docRef } = vi.hoisted(() =>
     ensureCollection,
     constructEventMock: vi.fn(),
     docRef,
+    normalizeRentPaymentProviderEventMock: vi.fn((input: any) => ({
+      provider: "stripe",
+      providerEventId: input.providerEventId || input.rawEvent?.id || null,
+      providerPaymentId: input.providerPaymentId || null,
+      providerSessionId: input.providerSessionId || null,
+      rawStatus: "paid",
+      normalizedStatus: "confirmed",
+      purpose: input.purpose || null,
+      amount: 180000,
+      currency: "CAD",
+      metadata: input.rawEvent?.data?.object?.metadata || null,
+    })),
+    deriveRentPaymentReconciliationMock: vi.fn(() => ({
+      reconciliationStatus: "reconciled",
+      reasons: ["provider_confirmed_amount_currency_match"],
+      automationEligible: true,
+      requiresManualReview: false,
+    })),
+    buildProviderWebhookIdempotencyKeyMock: vi.fn(
+      (input: any) => `provider_event:${input.provider}:${input.providerEventId}`
+    ),
   };
 });
 
@@ -103,6 +132,23 @@ vi.mock("../../services/screeningPaymentTransactionService", () => ({
   recordScreeningPaymentFailed: vi.fn(async () => undefined),
 }));
 
+vi.mock("../../lib/payments/paymentExecutionService", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../lib/payments/paymentExecutionService")>();
+  return {
+    ...actual,
+    normalizeRentPaymentProviderEvent: normalizeRentPaymentProviderEventMock,
+    deriveRentPaymentReconciliation: deriveRentPaymentReconciliationMock,
+  };
+});
+
+vi.mock("../../lib/payments/paymentIdempotency", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../lib/payments/paymentIdempotency")>();
+  return {
+    ...actual,
+    buildProviderWebhookIdempotencyKey: buildProviderWebhookIdempotencyKeyMock,
+  };
+});
+
 async function invokeWebhook(body: string) {
   const { stripeWebhookHandler } = await import("../stripeScreeningOrdersWebhookRoutes");
   return await new Promise<{ status: number; body: any; text?: string }>((resolve, reject) => {
@@ -135,6 +181,30 @@ describe("rent payment webhook reconciliation", () => {
   beforeEach(() => {
     store.clear();
     constructEventMock.mockReset();
+    normalizeRentPaymentProviderEventMock.mockClear();
+    deriveRentPaymentReconciliationMock.mockClear();
+    buildProviderWebhookIdempotencyKeyMock.mockClear();
+    normalizeRentPaymentProviderEventMock.mockImplementation((input: any) => ({
+      provider: "stripe",
+      providerEventId: input.providerEventId || input.rawEvent?.id || null,
+      providerPaymentId: input.providerPaymentId || null,
+      providerSessionId: input.providerSessionId || null,
+      rawStatus: "paid",
+      normalizedStatus: "confirmed",
+      purpose: input.purpose || null,
+      amount: 180000,
+      currency: "CAD",
+      metadata: input.rawEvent?.data?.object?.metadata || null,
+    }));
+    deriveRentPaymentReconciliationMock.mockReturnValue({
+      reconciliationStatus: "reconciled",
+      reasons: ["provider_confirmed_amount_currency_match"],
+      automationEligible: true,
+      requiresManualReview: false,
+    });
+    buildProviderWebhookIdempotencyKeyMock.mockImplementation(
+      (input: any) => `provider_event:${input.provider}:${input.providerEventId}`
+    );
     ensureCollection("rentPayments").set("rp-1", {
       id: "rp-1",
       leaseId: "lease-1",
@@ -178,6 +248,36 @@ describe("rent payment webhook reconciliation", () => {
     expect(first.status).toBe(200);
     expect(second.status).toBe(200);
 
+    expect(normalizeRentPaymentProviderEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "stripe",
+        providerEventId: "evt_rent_paid_1",
+        providerPaymentId: "pi_test_1",
+        providerSessionId: "cs_test_1",
+        purpose: "rent",
+      })
+    );
+    expect(buildProviderWebhookIdempotencyKeyMock).toHaveBeenCalledWith({
+      provider: "stripe",
+      providerEventId: "evt_rent_paid_1",
+    });
+    expect(deriveRentPaymentReconciliationMock).toHaveBeenCalledWith({
+      expectedIntent: expect.objectContaining({
+        paymentIntentId: "rp-1",
+        landlordId: "landlord-1",
+        tenantId: "tenant-1",
+        leaseId: "lease-1",
+        amount: 180000,
+        currency: "cad",
+        purpose: "rent",
+        provider: "stripe",
+      }),
+      providerSignal: expect.objectContaining({
+        provider: "stripe",
+        providerEventId: "evt_rent_paid_1",
+      }),
+    });
+
     const stored = ensureCollection("rentPayments").get("rp-1");
     expect(stored).toEqual(
       expect.objectContaining({
@@ -187,6 +287,8 @@ describe("rent payment webhook reconciliation", () => {
         paidAt: expect.any(String),
       })
     );
+    expect(stored).not.toHaveProperty("reconciliationStatus");
+    expect(stored).not.toHaveProperty("providerEventReceiptId");
 
     const canonicalEvents = Array.from(ensureCollection("canonicalEvents").values());
     expect(canonicalEvents.filter((event: any) => event.type === "rent_payment.paid")).toHaveLength(1);
@@ -217,6 +319,15 @@ describe("rent payment webhook reconciliation", () => {
     const res = await invokeWebhook('{"id":"evt_rent_failed_1","type":"checkout.session.async_payment_failed"}');
 
     expect(res.status).toBe(200);
+    expect(normalizeRentPaymentProviderEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "stripe",
+        providerEventId: "evt_rent_failed_1",
+        providerPaymentId: "pi_test_1",
+        providerSessionId: "cs_test_1",
+        purpose: "rent",
+      })
+    );
     expect(ensureCollection("rentPayments").get("rp-1")).toEqual(
       expect.objectContaining({
         status: "failed",
@@ -227,5 +338,68 @@ describe("rent payment webhook reconciliation", () => {
 
     const canonicalEvents = Array.from(ensureCollection("canonicalEvents").values());
     expect(canonicalEvents.some((event: any) => event.type === "rent_payment.failed")).toBe(true);
+  });
+
+  it("does not run rent normalization for screening checkout webhooks", async () => {
+    constructEventMock.mockReturnValue({
+      id: "evt_screening_paid_1",
+      created: 1_714_213_200,
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_screening_1",
+          payment_intent: "pi_screening_1",
+          payment_status: "paid",
+          client_reference_id: "order-1",
+          metadata: {
+            orderId: "order-1",
+            applicationId: "app-1",
+            landlordId: "landlord-1",
+          },
+        },
+      },
+    });
+
+    ensureCollection("rentalApplications").set("app-1", {
+      id: "app-1",
+      landlordId: "landlord-1",
+      screeningStatus: "pending_payment",
+      screeningSessionId: "",
+    });
+
+    const res = await invokeWebhook('{"id":"evt_screening_paid_1","type":"checkout.session.completed"}');
+
+    expect(res.status).toBe(200);
+    expect(normalizeRentPaymentProviderEventMock).not.toHaveBeenCalled();
+    expect(buildProviderWebhookIdempotencyKeyMock).not.toHaveBeenCalled();
+    expect(deriveRentPaymentReconciliationMock).not.toHaveBeenCalled();
+  });
+
+  it("does not run rent normalization for subscription webhooks", async () => {
+    constructEventMock.mockReturnValue({
+      id: "evt_subscription_1",
+      created: 1_714_213_200,
+      type: "customer.subscription.updated",
+      data: {
+        object: {
+          id: "sub_1",
+          customer: "cus_1",
+          status: "active",
+          metadata: {
+            landlordId: "landlord-1",
+          },
+          items: {
+            data: [],
+          },
+        },
+      },
+    });
+
+    const res = await invokeWebhook('{"id":"evt_subscription_1","type":"customer.subscription.updated"}');
+
+    expect(res.status).toBe(200);
+    expect(normalizeRentPaymentProviderEventMock).not.toHaveBeenCalled();
+    expect(buildProviderWebhookIdempotencyKeyMock).not.toHaveBeenCalled();
+    expect(deriveRentPaymentReconciliationMock).not.toHaveBeenCalled();
   });
 });

--- a/rentchain-api/src/routes/stripeScreeningOrdersWebhookRoutes.ts
+++ b/rentchain-api/src/routes/stripeScreeningOrdersWebhookRoutes.ts
@@ -21,6 +21,12 @@ import {
   deriveBillingTierFromSubscription,
   updateLandlordSubscriptionState,
 } from "../services/billingSubscriptionSyncService";
+import { buildProviderWebhookIdempotencyKey } from "../lib/payments/paymentIdempotency";
+import {
+  deriveRentPaymentReconciliation,
+  normalizeRentPaymentProviderEvent,
+} from "../lib/payments/paymentExecutionService";
+import type { PaymentIntentReference } from "../lib/payments/paymentTypes";
 
 interface StripeWebhookRequest extends Request {
   rawBody?: Buffer;
@@ -246,6 +252,67 @@ function normalizeFailureReason(value: unknown): { code?: string; message?: stri
     code: normalizeOptionalString(item.code, 120),
     message: normalizeOptionalString(item.message || item.reason, 500),
   };
+}
+
+function buildExpectedRentPaymentIntent(
+  rentPaymentId: string,
+  rentPayment: Record<string, unknown> | null | undefined
+): PaymentIntentReference | null {
+  if (!rentPayment) return null;
+  const amount = Number(rentPayment.amountCents);
+  return {
+    paymentIntentId: normalizeString(rentPaymentId, 120),
+    landlordId: normalizeString(rentPayment.landlordId, 120),
+    tenantId: normalizeOptionalString(rentPayment.tenantId, 120) || null,
+    propertyId: normalizeOptionalString(rentPayment.propertyId, 120) || null,
+    unitId: normalizeOptionalString(rentPayment.unitId, 120) || null,
+    leaseId: normalizeOptionalString(rentPayment.leaseId, 120) || null,
+    amount: Number.isFinite(amount) ? Math.round(amount) : 0,
+    currency: normalizeOptionalString(rentPayment.currency, 8) || "cad",
+    purpose: "rent",
+    provider: "stripe",
+  };
+}
+
+async function prepareRentPaymentWebhookNormalizationContext(params: {
+  event: Stripe.Event;
+  rentPaymentEvent: ReturnType<typeof extractRentPaymentMetadata>;
+}) {
+  const { event, rentPaymentEvent } = params;
+  try {
+    const normalizedProviderEvent = normalizeRentPaymentProviderEvent({
+      provider: "stripe",
+      rawEvent: event,
+      providerEventId: event.id,
+      providerPaymentId: rentPaymentEvent.paymentIntentId,
+      providerSessionId: rentPaymentEvent.checkoutSessionId,
+      purpose: "rent",
+    });
+    const idempotencyKey = buildProviderWebhookIdempotencyKey({
+      provider: "stripe",
+      providerEventId: normalizedProviderEvent.providerEventId || event.id || "event_missing",
+    });
+
+    const rentPaymentId = normalizeString(rentPaymentEvent.rentPaymentId, 120);
+    const snap = rentPaymentId ? await db.collection("rentPayments").doc(rentPaymentId).get() : null;
+    const expectedIntent = snap?.exists
+      ? buildExpectedRentPaymentIntent(rentPaymentId, (snap.data() as Record<string, unknown>) || null)
+      : null;
+    const reconciliation = deriveRentPaymentReconciliation({
+      expectedIntent,
+      providerSignal: normalizedProviderEvent,
+    });
+
+    return { normalizedProviderEvent, idempotencyKey, reconciliation };
+  } catch (err: any) {
+    console.warn("[stripe-webhook-rent-payment] normalization seam skipped", {
+      eventId: event.id,
+      eventType: event.type,
+      rentPaymentId: rentPaymentEvent.rentPaymentId || null,
+      message: err?.message || String(err),
+    });
+    return null;
+  }
 }
 
 async function resolveOrderRefFromStripePayment(params: {
@@ -594,6 +661,7 @@ export const stripeWebhookHandler = async (req: StripeWebhookRequest, res: Respo
     try {
       const rentPaymentEvent = extractRentPaymentMetadata(event);
       if (rentPaymentEvent.rentPaymentId && rentPaymentEvent.nextStatus) {
+        await prepareRentPaymentWebhookNormalizationContext({ event, rentPaymentEvent });
         await updateRentPaymentFromWebhook({
           rentPaymentId: rentPaymentEvent.rentPaymentId,
           nextStatus: rentPaymentEvent.nextStatus,
@@ -783,6 +851,7 @@ export const stripeWebhookHandler = async (req: StripeWebhookRequest, res: Respo
     try {
       const rentPaymentEvent = extractRentPaymentMetadata(event);
       if (rentPaymentEvent.rentPaymentId && rentPaymentEvent.nextStatus) {
+        await prepareRentPaymentWebhookNormalizationContext({ event, rentPaymentEvent });
         await updateRentPaymentFromWebhook({
           rentPaymentId: rentPaymentEvent.rentPaymentId,
           nextStatus: rentPaymentEvent.nextStatus,


### PR DESCRIPTION
This PR adds a behavior-preserving Stripe rent-payment webhook normalization seam.

Includes:
- routes detected rent-payment webhook events through paymentExecutionService normalization
- extends stripePaymentProvider normalization for Stripe checkout/session and payment-intent webhook shapes
- derives deterministic provider-event idempotency keys without persisting/enforcing them yet
- derives rent-payment reconciliation in read-only mode without changing persisted rentPayments state
- preserves existing rent webhook response behavior, status updates, metadata handling, and canonical events
- confirms screening and subscription webhook branches do not run rent normalization
- updates the payment execution boundary documentation

Guardrails preserved:
- backend/docs only
- no frontend changes
- no schema migration
- no dependency or lockfile changes
- no Trustly implementation
- no UI changes
- no subscription behavior changes
- no screening checkout/webhook behavior changes
- no payout/pricing/plan changes
- no persisted rentPayments shape changes
- no new production canonical payment event emission

Verification:
- git diff --check passed
- focused payment boundary, Stripe provider, rent webhook, and rent payment service tests passed: 41 tests
- backend build passed