### PR TITLE
Add payment provider event receipts

### DIFF
--- a/docs/architecture/payment-execution-boundary-v1.md
+++ b/docs/architecture/payment-execution-boundary-v1.md
@@ -264,6 +264,64 @@ Deferred items:
 5. Provider-neutral rent-payment intent persistence.
 6. Trustly webhook adapter.
 
+## Provider Event Receipts v1
+
+Status: provider-event receipts are persisted for rent-payment webhook events only.
+
+What is persisted:
+
+- Collection: `paymentProviderEventReceipts`
+- Document id: deterministic receipt id derived from the provider webhook idempotency key.
+- Core fields:
+  - `receiptId`
+  - `idempotencyKey`
+  - `provider`
+  - `providerEventId`
+  - `purpose`
+  - `subjectType`
+  - `subjectId`
+  - `status`
+  - `firstReceivedAt`
+  - `lastSeenAt`
+  - `processedAt`
+  - `failedAt`
+  - `failureReason`
+  - `duplicateCount`
+  - `normalizedStatus`
+  - `rawStatus`
+  - `metadataSummary`
+
+Receipt statuses:
+
+- `received`
+- `processing`
+- `processed`
+- `ignored_duplicate`
+- `failed`
+- `manual_review_required`
+
+Why this comes before active idempotency enforcement:
+
+The existing Stripe webhook behavior is intentionally preserved. Stripe may retry events, and RentChain's current rent-payment updater is already idempotent for the persisted rent payment status. Persisting receipts first gives support and future reconciliation jobs an audit trail of what arrived, when it arrived again, and how it was interpreted before RentChain starts suppressing duplicate execution paths.
+
+Behavior intentionally unchanged:
+
+- Rent-payment webhook HTTP responses are unchanged.
+- Existing `rentPayments` updates are unchanged.
+- Existing rent-payment canonical events are unchanged.
+- Duplicate provider events are recorded as `ignored_duplicate`, but they do not suppress the existing webhook code path yet.
+- Screening checkout webhook behavior is untouched.
+- SaaS subscription webhook behavior is untouched.
+- Reconciliation remains read-only.
+
+Deferred items:
+
+1. Active duplicate suppression after receipt confidence is proven.
+2. `payment.provider_signal_received` canonical event emission.
+3. Persisted reconciliation state.
+4. Provider-neutral `PaymentIntent` persistence.
+5. Trustly sandbox adapter.
+
 ## Intentional Non-Implementation
 
 This mission intentionally does not:

--- a/rentchain-api/src/lib/payments/__tests__/paymentProviderEventReceipts.test.ts
+++ b/rentchain-api/src/lib/payments/__tests__/paymentProviderEventReceipts.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildProviderEventReceiptId,
+  markProviderEventFailed,
+  markProviderEventManualReviewRequired,
+  markProviderEventProcessed,
+  markProviderEventReceived,
+  serializeProviderEventReceiptSummary,
+} from "../paymentProviderEventReceipts";
+
+function buildFirestore() {
+  const store = new Map<string, Map<string, any>>();
+
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+
+  return {
+    store,
+    firestore: {
+      collection: (name: string) => ({
+        doc: (id: string) => ({
+          get: async () => ({
+            exists: ensureCollection(name).has(id),
+            data: () => ensureCollection(name).get(id),
+          }),
+          set: async (payload: Record<string, unknown>, options?: { merge?: boolean }) => {
+            const col = ensureCollection(name);
+            const existing = col.get(id) || {};
+            col.set(id, options?.merge ? { ...existing, ...payload } : payload);
+          },
+        }),
+      }),
+    },
+  };
+}
+
+describe("paymentProviderEventReceipts", () => {
+  it("builds deterministic receipt ids from idempotency keys", () => {
+    expect(buildProviderEventReceiptId("provider_event:stripe:evt_123")).toBe("provider_event:stripe:evt_123");
+    expect(buildProviderEventReceiptId("provider/event stripe evt 123")).toBe("provider_event_stripe_evt_123");
+  });
+
+  it("creates a first receipt with safe metadata summary", async () => {
+    const { firestore } = buildFirestore();
+    const result = await markProviderEventReceived({
+      firestore,
+      idempotencyKey: "provider_event:stripe:evt_1",
+      provider: "stripe",
+      providerEventId: "evt_1",
+      purpose: "rent",
+      subjectType: "rent_payment",
+      subjectId: "rp-1",
+      normalizedStatus: "confirmed",
+      rawStatus: "paid",
+      metadata: {
+        rentPaymentId: "rp-1",
+        leaseId: "lease-1",
+      },
+      now: "2026-05-03T12:00:00.000Z",
+    });
+
+    expect(result.isDuplicate).toBe(false);
+    expect(result.receipt).toMatchObject({
+      receiptId: "provider_event:stripe:evt_1",
+      idempotencyKey: "provider_event:stripe:evt_1",
+      provider: "stripe",
+      providerEventId: "evt_1",
+      purpose: "rent",
+      subjectType: "rent_payment",
+      subjectId: "rp-1",
+      status: "received",
+      firstReceivedAt: "2026-05-03T12:00:00.000Z",
+      lastSeenAt: "2026-05-03T12:00:00.000Z",
+      duplicateCount: 0,
+      normalizedStatus: "confirmed",
+      rawStatus: "paid",
+      metadataSummary: {
+        keys: ["leaseId", "rentPaymentId"],
+      },
+    });
+  });
+
+  it("marks duplicate receipt without suppressing caller behavior", async () => {
+    const { firestore } = buildFirestore();
+    await markProviderEventReceived({
+      firestore,
+      idempotencyKey: "provider_event:stripe:evt_1",
+      provider: "stripe",
+      providerEventId: "evt_1",
+      purpose: "rent",
+      now: "2026-05-03T12:00:00.000Z",
+    });
+    const duplicate = await markProviderEventReceived({
+      firestore,
+      idempotencyKey: "provider_event:stripe:evt_1",
+      provider: "stripe",
+      providerEventId: "evt_1",
+      purpose: "rent",
+      now: "2026-05-03T12:01:00.000Z",
+    });
+
+    expect(duplicate.isDuplicate).toBe(true);
+    expect(duplicate.receipt).toMatchObject({
+      status: "ignored_duplicate",
+      duplicateCount: 1,
+      firstReceivedAt: "2026-05-03T12:00:00.000Z",
+      lastSeenAt: "2026-05-03T12:01:00.000Z",
+    });
+  });
+
+  it("marks processed receipts", async () => {
+    const { firestore } = buildFirestore();
+    const received = await markProviderEventReceived({
+      firestore,
+      idempotencyKey: "provider_event:stripe:evt_1",
+      provider: "stripe",
+      providerEventId: "evt_1",
+      now: "2026-05-03T12:00:00.000Z",
+    });
+
+    const processed = await markProviderEventProcessed({
+      firestore,
+      receiptId: received.receiptId,
+      now: "2026-05-03T12:02:00.000Z",
+    });
+
+    expect(processed).toMatchObject({
+      status: "processed",
+      processedAt: "2026-05-03T12:02:00.000Z",
+      failureReason: null,
+    });
+  });
+
+  it("marks failed receipts", async () => {
+    const { firestore } = buildFirestore();
+    const received = await markProviderEventReceived({
+      firestore,
+      idempotencyKey: "provider_event:stripe:evt_1",
+      provider: "stripe",
+      providerEventId: "evt_1",
+    });
+
+    const failed = await markProviderEventFailed({
+      firestore,
+      receiptId: received.receiptId,
+      failureReason: "rent_payment_update_failed",
+      now: "2026-05-03T12:03:00.000Z",
+    });
+
+    expect(failed).toMatchObject({
+      status: "failed",
+      failedAt: "2026-05-03T12:03:00.000Z",
+      failureReason: "rent_payment_update_failed",
+    });
+  });
+
+  it("marks manual review receipts", async () => {
+    const { firestore } = buildFirestore();
+    const received = await markProviderEventReceived({
+      firestore,
+      idempotencyKey: "provider_event:stripe:evt_1",
+      provider: "stripe",
+      providerEventId: "evt_1",
+    });
+
+    const manualReview = await markProviderEventManualReviewRequired({
+      firestore,
+      receiptId: received.receiptId,
+      failureReason: "amount_mismatch",
+    });
+
+    expect(manualReview).toMatchObject({
+      status: "manual_review_required",
+      failureReason: "amount_mismatch",
+    });
+  });
+
+  it("serializes a safe receipt summary", async () => {
+    const { firestore } = buildFirestore();
+    const received = await markProviderEventReceived({
+      firestore,
+      idempotencyKey: "provider_event:stripe:evt_1",
+      provider: "stripe",
+      providerEventId: "evt_1",
+      normalizedStatus: "confirmed",
+      rawStatus: "paid",
+    });
+
+    expect(serializeProviderEventReceiptSummary(received.receipt)).toEqual({
+      receiptId: "provider_event:stripe:evt_1",
+      idempotencyKey: "provider_event:stripe:evt_1",
+      provider: "stripe",
+      providerEventId: "evt_1",
+      purpose: null,
+      subjectType: null,
+      subjectId: null,
+      status: "received",
+      duplicateCount: 0,
+      normalizedStatus: "confirmed",
+      rawStatus: "paid",
+    });
+  });
+});

--- a/rentchain-api/src/lib/payments/paymentProviderEventReceipts.ts
+++ b/rentchain-api/src/lib/payments/paymentProviderEventReceipts.ts
@@ -1,0 +1,257 @@
+import { db } from "../../config/firebase";
+import type { PaymentExecutionStatus, PaymentProvider, PaymentPurpose } from "./paymentTypes";
+
+export const PAYMENT_PROVIDER_EVENT_RECEIPTS_COLLECTION = "paymentProviderEventReceipts";
+
+export const PAYMENT_PROVIDER_EVENT_RECEIPT_STATUSES = [
+  "received",
+  "processing",
+  "processed",
+  "ignored_duplicate",
+  "failed",
+  "manual_review_required",
+] as const;
+
+export type PaymentProviderEventReceiptStatus = (typeof PAYMENT_PROVIDER_EVENT_RECEIPT_STATUSES)[number];
+
+export type PaymentProviderEventReceipt = {
+  receiptId: string;
+  idempotencyKey: string;
+  provider: PaymentProvider;
+  providerEventId: string;
+  purpose?: PaymentPurpose | null;
+  subjectType?: string | null;
+  subjectId?: string | null;
+  status: PaymentProviderEventReceiptStatus;
+  firstReceivedAt: string;
+  lastSeenAt: string;
+  processedAt?: string | null;
+  failedAt?: string | null;
+  failureReason?: string | null;
+  duplicateCount: number;
+  normalizedStatus?: PaymentExecutionStatus | null;
+  rawStatus?: string | null;
+  metadataSummary?: Record<string, unknown> | null;
+};
+
+type FirestoreDocRef = {
+  get(): Promise<{ exists: boolean; data(): Record<string, unknown> | undefined }>;
+  set(payload: Record<string, unknown>, options?: { merge?: boolean }): Promise<void>;
+};
+
+type FirestoreLike = {
+  collection(name: string): {
+    doc(id: string): FirestoreDocRef;
+  };
+};
+
+type ReceiptWriteInput = {
+  idempotencyKey: string;
+  provider: PaymentProvider;
+  providerEventId: string;
+  purpose?: PaymentPurpose | null;
+  subjectType?: string | null;
+  subjectId?: string | null;
+  normalizedStatus?: PaymentExecutionStatus | null;
+  rawStatus?: string | null;
+  metadata?: Record<string, unknown> | null;
+  now?: string | null;
+  firestore?: FirestoreLike;
+};
+
+type ReceiptStatusInput = {
+  receiptId: string;
+  now?: string | null;
+  failureReason?: string | null;
+  firestore?: FirestoreLike;
+};
+
+export type ProviderEventReceiptWriteResult = {
+  receiptId: string;
+  isDuplicate: boolean;
+  receipt: PaymentProviderEventReceipt;
+};
+
+function nowIso(value?: string | null): string {
+  const raw = String(value || "").trim();
+  if (raw) return raw;
+  return new Date().toISOString();
+}
+
+function cleanReceiptPart(value: unknown): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function asPositiveInteger(value: unknown): number {
+  const next = Number(value);
+  if (!Number.isFinite(next) || next < 0) return 0;
+  return Math.floor(next);
+}
+
+function normalizeOptionalString(value: unknown, max = 500): string | null {
+  const next = String(value || "").trim().slice(0, max);
+  return next || null;
+}
+
+function getFirestore(input?: { firestore?: FirestoreLike }): FirestoreLike {
+  return input?.firestore || (db as unknown as FirestoreLike);
+}
+
+function receiptRef(receiptId: string, firestore?: FirestoreLike): FirestoreDocRef {
+  return getFirestore({ firestore }).collection(PAYMENT_PROVIDER_EVENT_RECEIPTS_COLLECTION).doc(receiptId);
+}
+
+function normalizeMetadataSummary(metadata: Record<string, unknown> | null | undefined): Record<string, unknown> | null {
+  if (!metadata || typeof metadata !== "object") return null;
+  const keys = Object.keys(metadata)
+    .map((key) => String(key || "").trim())
+    .filter(Boolean)
+    .sort();
+  if (keys.length === 0) return null;
+  return { keys };
+}
+
+function normalizeReceipt(data: Record<string, unknown>, fallback: { receiptId: string; idempotencyKey: string }): PaymentProviderEventReceipt {
+  return {
+    receiptId: normalizeOptionalString(data.receiptId, 300) || fallback.receiptId,
+    idempotencyKey: normalizeOptionalString(data.idempotencyKey, 500) || fallback.idempotencyKey,
+    provider: (normalizeOptionalString(data.provider, 50) || "stripe") as PaymentProvider,
+    providerEventId: normalizeOptionalString(data.providerEventId, 300) || "event_missing",
+    purpose: (normalizeOptionalString(data.purpose, 50) as PaymentPurpose | null) || null,
+    subjectType: normalizeOptionalString(data.subjectType, 80),
+    subjectId: normalizeOptionalString(data.subjectId, 300),
+    status: (normalizeOptionalString(data.status, 80) || "received") as PaymentProviderEventReceiptStatus,
+    firstReceivedAt: normalizeOptionalString(data.firstReceivedAt, 80) || nowIso(),
+    lastSeenAt: normalizeOptionalString(data.lastSeenAt, 80) || nowIso(),
+    processedAt: normalizeOptionalString(data.processedAt, 80),
+    failedAt: normalizeOptionalString(data.failedAt, 80),
+    failureReason: normalizeOptionalString(data.failureReason, 500),
+    duplicateCount: asPositiveInteger(data.duplicateCount),
+    normalizedStatus: (normalizeOptionalString(data.normalizedStatus, 80) as PaymentExecutionStatus | null) || null,
+    rawStatus: normalizeOptionalString(data.rawStatus, 200),
+    metadataSummary:
+      data.metadataSummary && typeof data.metadataSummary === "object"
+        ? (data.metadataSummary as Record<string, unknown>)
+        : null,
+  };
+}
+
+export function buildProviderEventReceiptId(idempotencyKey: string): string {
+  return cleanReceiptPart(idempotencyKey || "provider_event:event_missing") || "provider_event:event_missing";
+}
+
+export function serializeProviderEventReceiptSummary(receipt: PaymentProviderEventReceipt): Record<string, unknown> {
+  return {
+    receiptId: receipt.receiptId,
+    idempotencyKey: receipt.idempotencyKey,
+    provider: receipt.provider,
+    providerEventId: receipt.providerEventId,
+    purpose: receipt.purpose || null,
+    subjectType: receipt.subjectType || null,
+    subjectId: receipt.subjectId || null,
+    status: receipt.status,
+    duplicateCount: receipt.duplicateCount,
+    normalizedStatus: receipt.normalizedStatus || null,
+    rawStatus: receipt.rawStatus || null,
+  };
+}
+
+export async function markProviderEventReceived(input: ReceiptWriteInput): Promise<ProviderEventReceiptWriteResult> {
+  const at = nowIso(input.now);
+  const receiptId = buildProviderEventReceiptId(input.idempotencyKey);
+  const ref = receiptRef(receiptId, input.firestore);
+  const snap = await ref.get();
+  const metadataSummary = normalizeMetadataSummary(input.metadata);
+
+  if (snap.exists) {
+    const existing = normalizeReceipt(snap.data() || {}, { receiptId, idempotencyKey: input.idempotencyKey });
+    const duplicateCount = existing.duplicateCount + 1;
+    const next: PaymentProviderEventReceipt = {
+      ...existing,
+      status: "ignored_duplicate",
+      lastSeenAt: at,
+      duplicateCount,
+      normalizedStatus: input.normalizedStatus || existing.normalizedStatus || null,
+      rawStatus: input.rawStatus || existing.rawStatus || null,
+      metadataSummary: metadataSummary || existing.metadataSummary || null,
+    };
+    await ref.set(next, { merge: true });
+    return { receiptId, isDuplicate: true, receipt: next };
+  }
+
+  const receipt: PaymentProviderEventReceipt = {
+    receiptId,
+    idempotencyKey: input.idempotencyKey,
+    provider: input.provider,
+    providerEventId: input.providerEventId || "event_missing",
+    purpose: input.purpose || null,
+    subjectType: normalizeOptionalString(input.subjectType, 80),
+    subjectId: normalizeOptionalString(input.subjectId, 300),
+    status: "received",
+    firstReceivedAt: at,
+    lastSeenAt: at,
+    processedAt: null,
+    failedAt: null,
+    failureReason: null,
+    duplicateCount: 0,
+    normalizedStatus: input.normalizedStatus || null,
+    rawStatus: input.rawStatus || null,
+    metadataSummary,
+  };
+  await ref.set(receipt, { merge: true });
+  return { receiptId, isDuplicate: false, receipt };
+}
+
+async function markProviderEventStatus(
+  input: ReceiptStatusInput & { status: PaymentProviderEventReceiptStatus }
+): Promise<PaymentProviderEventReceipt> {
+  const at = nowIso(input.now);
+  const ref = receiptRef(input.receiptId, input.firestore);
+  const snap = await ref.get();
+  const existing = normalizeReceipt(snap.data() || {}, {
+    receiptId: input.receiptId,
+    idempotencyKey: input.receiptId,
+  });
+  const patch: Record<string, unknown> = {
+    status: input.status,
+    lastSeenAt: at,
+  };
+  if (input.status === "processed") {
+    patch.processedAt = at;
+    patch.failureReason = null;
+  }
+  if (input.status === "failed") {
+    patch.failedAt = at;
+    patch.failureReason = normalizeOptionalString(input.failureReason, 500) || "provider_event_processing_failed";
+  }
+  if (input.status === "manual_review_required") {
+    patch.failureReason = normalizeOptionalString(input.failureReason, 500) || "manual_review_required";
+  }
+  await ref.set(patch, { merge: true });
+  return normalizeReceipt({ ...existing, ...patch }, { receiptId: input.receiptId, idempotencyKey: existing.idempotencyKey });
+}
+
+export function markProviderEventProcessing(input: ReceiptStatusInput): Promise<PaymentProviderEventReceipt> {
+  return markProviderEventStatus({ ...input, status: "processing" });
+}
+
+export function markProviderEventProcessed(input: ReceiptStatusInput): Promise<PaymentProviderEventReceipt> {
+  return markProviderEventStatus({ ...input, status: "processed" });
+}
+
+export function markProviderEventIgnoredDuplicate(input: ReceiptStatusInput): Promise<PaymentProviderEventReceipt> {
+  return markProviderEventStatus({ ...input, status: "ignored_duplicate" });
+}
+
+export function markProviderEventFailed(input: ReceiptStatusInput): Promise<PaymentProviderEventReceipt> {
+  return markProviderEventStatus({ ...input, status: "failed" });
+}
+
+export function markProviderEventManualReviewRequired(input: ReceiptStatusInput): Promise<PaymentProviderEventReceipt> {
+  return markProviderEventStatus({ ...input, status: "manual_review_required" });
+}

--- a/rentchain-api/src/routes/__tests__/rentPaymentWebhook.test.ts
+++ b/rentchain-api/src/routes/__tests__/rentPaymentWebhook.test.ts
@@ -37,18 +37,21 @@ const {
     ensureCollection,
     constructEventMock: vi.fn(),
     docRef,
-    normalizeRentPaymentProviderEventMock: vi.fn((input: any) => ({
-      provider: "stripe",
-      providerEventId: input.providerEventId || input.rawEvent?.id || null,
-      providerPaymentId: input.providerPaymentId || null,
-      providerSessionId: input.providerSessionId || null,
-      rawStatus: "paid",
-      normalizedStatus: "confirmed",
-      purpose: input.purpose || null,
-      amount: 180000,
-      currency: "CAD",
-      metadata: input.rawEvent?.data?.object?.metadata || null,
-    })),
+    normalizeRentPaymentProviderEventMock: vi.fn((input: any) => {
+      const failed = String(input.rawEvent?.type || "").includes("failed");
+      return {
+        provider: "stripe",
+        providerEventId: input.providerEventId || input.rawEvent?.id || null,
+        providerPaymentId: input.providerPaymentId || null,
+        providerSessionId: input.providerSessionId || null,
+        rawStatus: failed ? "failed" : "paid",
+        normalizedStatus: failed ? "failed" : "confirmed",
+        purpose: input.purpose || null,
+        amount: 180000,
+        currency: "CAD",
+        metadata: input.rawEvent?.data?.object?.metadata || null,
+      };
+    }),
     deriveRentPaymentReconciliationMock: vi.fn(() => ({
       reconciliationStatus: "reconciled",
       reasons: ["provider_confirmed_amount_currency_match"],
@@ -184,18 +187,21 @@ describe("rent payment webhook reconciliation", () => {
     normalizeRentPaymentProviderEventMock.mockClear();
     deriveRentPaymentReconciliationMock.mockClear();
     buildProviderWebhookIdempotencyKeyMock.mockClear();
-    normalizeRentPaymentProviderEventMock.mockImplementation((input: any) => ({
-      provider: "stripe",
-      providerEventId: input.providerEventId || input.rawEvent?.id || null,
-      providerPaymentId: input.providerPaymentId || null,
-      providerSessionId: input.providerSessionId || null,
-      rawStatus: "paid",
-      normalizedStatus: "confirmed",
-      purpose: input.purpose || null,
-      amount: 180000,
-      currency: "CAD",
-      metadata: input.rawEvent?.data?.object?.metadata || null,
-    }));
+    normalizeRentPaymentProviderEventMock.mockImplementation((input: any) => {
+      const failed = String(input.rawEvent?.type || "").includes("failed");
+      return {
+        provider: "stripe",
+        providerEventId: input.providerEventId || input.rawEvent?.id || null,
+        providerPaymentId: input.providerPaymentId || null,
+        providerSessionId: input.providerSessionId || null,
+        rawStatus: failed ? "failed" : "paid",
+        normalizedStatus: failed ? "failed" : "confirmed",
+        purpose: input.purpose || null,
+        amount: 180000,
+        currency: "CAD",
+        metadata: input.rawEvent?.data?.object?.metadata || null,
+      };
+    });
     deriveRentPaymentReconciliationMock.mockReturnValue({
       reconciliationStatus: "reconciled",
       reasons: ["provider_confirmed_amount_currency_match"],
@@ -290,6 +296,23 @@ describe("rent payment webhook reconciliation", () => {
     expect(stored).not.toHaveProperty("reconciliationStatus");
     expect(stored).not.toHaveProperty("providerEventReceiptId");
 
+    const receipt = ensureCollection("paymentProviderEventReceipts").get("provider_event:stripe:evt_rent_paid_1");
+    expect(receipt).toEqual(
+      expect.objectContaining({
+        receiptId: "provider_event:stripe:evt_rent_paid_1",
+        idempotencyKey: "provider_event:stripe:evt_rent_paid_1",
+        provider: "stripe",
+        providerEventId: "evt_rent_paid_1",
+        purpose: "rent",
+        subjectType: "rent_payment",
+        subjectId: "rp-1",
+        status: "ignored_duplicate",
+        duplicateCount: 1,
+        normalizedStatus: "confirmed",
+        rawStatus: "paid",
+      })
+    );
+
     const canonicalEvents = Array.from(ensureCollection("canonicalEvents").values());
     expect(canonicalEvents.filter((event: any) => event.type === "rent_payment.paid")).toHaveLength(1);
     expect(JSON.stringify(canonicalEvents[0] || {})).not.toContain("card");
@@ -335,6 +358,17 @@ describe("rent payment webhook reconciliation", () => {
         processorPaymentIntentId: "pi_test_1",
       })
     );
+    expect(ensureCollection("paymentProviderEventReceipts").get("provider_event:stripe:evt_rent_failed_1")).toEqual(
+      expect.objectContaining({
+        provider: "stripe",
+        providerEventId: "evt_rent_failed_1",
+        purpose: "rent",
+        status: "processed",
+        duplicateCount: 0,
+        normalizedStatus: "failed",
+        rawStatus: "failed",
+      })
+    );
 
     const canonicalEvents = Array.from(ensureCollection("canonicalEvents").values());
     expect(canonicalEvents.some((event: any) => event.type === "rent_payment.failed")).toBe(true);
@@ -373,6 +407,7 @@ describe("rent payment webhook reconciliation", () => {
     expect(normalizeRentPaymentProviderEventMock).not.toHaveBeenCalled();
     expect(buildProviderWebhookIdempotencyKeyMock).not.toHaveBeenCalled();
     expect(deriveRentPaymentReconciliationMock).not.toHaveBeenCalled();
+    expect(Array.from(ensureCollection("paymentProviderEventReceipts").values())).toHaveLength(0);
   });
 
   it("does not run rent normalization for subscription webhooks", async () => {
@@ -401,5 +436,6 @@ describe("rent payment webhook reconciliation", () => {
     expect(normalizeRentPaymentProviderEventMock).not.toHaveBeenCalled();
     expect(buildProviderWebhookIdempotencyKeyMock).not.toHaveBeenCalled();
     expect(deriveRentPaymentReconciliationMock).not.toHaveBeenCalled();
+    expect(Array.from(ensureCollection("paymentProviderEventReceipts").values())).toHaveLength(0);
   });
 });

--- a/rentchain-api/src/routes/stripeScreeningOrdersWebhookRoutes.ts
+++ b/rentchain-api/src/routes/stripeScreeningOrdersWebhookRoutes.ts
@@ -27,6 +27,14 @@ import {
   normalizeRentPaymentProviderEvent,
 } from "../lib/payments/paymentExecutionService";
 import type { PaymentIntentReference } from "../lib/payments/paymentTypes";
+import {
+  markProviderEventFailed,
+  markProviderEventIgnoredDuplicate,
+  markProviderEventManualReviewRequired,
+  markProviderEventProcessed,
+  markProviderEventProcessing,
+  markProviderEventReceived,
+} from "../lib/payments/paymentProviderEventReceipts";
 
 interface StripeWebhookRequest extends Request {
   rawBody?: Buffer;
@@ -292,6 +300,24 @@ async function prepareRentPaymentWebhookNormalizationContext(params: {
       provider: "stripe",
       providerEventId: normalizedProviderEvent.providerEventId || event.id || "event_missing",
     });
+    const receipt = await markProviderEventReceived({
+      idempotencyKey,
+      provider: "stripe",
+      providerEventId: normalizedProviderEvent.providerEventId || event.id || "event_missing",
+      purpose: "rent",
+      subjectType: "rent_payment",
+      subjectId: rentPaymentEvent.rentPaymentId,
+      normalizedStatus: normalizedProviderEvent.normalizedStatus,
+      rawStatus: normalizedProviderEvent.rawStatus,
+      metadata: normalizedProviderEvent.metadata || null,
+    });
+
+    if (receipt.isDuplicate) {
+      await markProviderEventIgnoredDuplicate({ receiptId: receipt.receiptId });
+      return { normalizedProviderEvent, idempotencyKey, reconciliation: null, receipt };
+    }
+
+    await markProviderEventProcessing({ receiptId: receipt.receiptId });
 
     const rentPaymentId = normalizeString(rentPaymentEvent.rentPaymentId, 120);
     const snap = rentPaymentId ? await db.collection("rentPayments").doc(rentPaymentId).get() : null;
@@ -302,8 +328,14 @@ async function prepareRentPaymentWebhookNormalizationContext(params: {
       expectedIntent,
       providerSignal: normalizedProviderEvent,
     });
+    if (reconciliation.requiresManualReview) {
+      await markProviderEventManualReviewRequired({
+        receiptId: receipt.receiptId,
+        failureReason: reconciliation.reasons.join(",") || "manual_review_required",
+      });
+    }
 
-    return { normalizedProviderEvent, idempotencyKey, reconciliation };
+    return { normalizedProviderEvent, idempotencyKey, reconciliation, receipt };
   } catch (err: any) {
     console.warn("[stripe-webhook-rent-payment] normalization seam skipped", {
       eventId: event.id,
@@ -312,6 +344,39 @@ async function prepareRentPaymentWebhookNormalizationContext(params: {
       message: err?.message || String(err),
     });
     return null;
+  }
+}
+
+async function markRentPaymentWebhookReceiptProcessed(
+  context: Awaited<ReturnType<typeof prepareRentPaymentWebhookNormalizationContext>>
+) {
+  if (!context?.receipt || context.receipt.isDuplicate) return;
+  if (context.reconciliation?.requiresManualReview) return;
+  try {
+    await markProviderEventProcessed({ receiptId: context.receipt.receiptId });
+  } catch (err: any) {
+    console.warn("[stripe-webhook-rent-payment] receipt processed marker skipped", {
+      receiptId: context.receipt.receiptId,
+      message: err?.message || String(err),
+    });
+  }
+}
+
+async function markRentPaymentWebhookReceiptFailed(
+  context: Awaited<ReturnType<typeof prepareRentPaymentWebhookNormalizationContext>>,
+  err: unknown
+) {
+  if (!context?.receipt || context.receipt.isDuplicate) return;
+  try {
+    await markProviderEventFailed({
+      receiptId: context.receipt.receiptId,
+      failureReason: (err as any)?.message || String(err || "rent_payment_webhook_failed"),
+    });
+  } catch (markerErr: any) {
+    console.warn("[stripe-webhook-rent-payment] receipt failed marker skipped", {
+      receiptId: context.receipt.receiptId,
+      message: markerErr?.message || String(markerErr),
+    });
   }
 }
 
@@ -661,15 +726,21 @@ export const stripeWebhookHandler = async (req: StripeWebhookRequest, res: Respo
     try {
       const rentPaymentEvent = extractRentPaymentMetadata(event);
       if (rentPaymentEvent.rentPaymentId && rentPaymentEvent.nextStatus) {
-        await prepareRentPaymentWebhookNormalizationContext({ event, rentPaymentEvent });
-        await updateRentPaymentFromWebhook({
-          rentPaymentId: rentPaymentEvent.rentPaymentId,
-          nextStatus: rentPaymentEvent.nextStatus,
-          processorCheckoutSessionId: rentPaymentEvent.checkoutSessionId,
-          processorPaymentIntentId: rentPaymentEvent.paymentIntentId,
-          paidAt: rentPaymentEvent.paidAt,
-          eventId: event.id,
-        });
+        const receiptContext = await prepareRentPaymentWebhookNormalizationContext({ event, rentPaymentEvent });
+        try {
+          await updateRentPaymentFromWebhook({
+            rentPaymentId: rentPaymentEvent.rentPaymentId,
+            nextStatus: rentPaymentEvent.nextStatus,
+            processorCheckoutSessionId: rentPaymentEvent.checkoutSessionId,
+            processorPaymentIntentId: rentPaymentEvent.paymentIntentId,
+            paidAt: rentPaymentEvent.paidAt,
+            eventId: event.id,
+          });
+          await markRentPaymentWebhookReceiptProcessed(receiptContext);
+        } catch (err) {
+          await markRentPaymentWebhookReceiptFailed(receiptContext, err);
+          throw err;
+        }
         return res.status(200).json({ received: true });
       }
 
@@ -851,15 +922,21 @@ export const stripeWebhookHandler = async (req: StripeWebhookRequest, res: Respo
     try {
       const rentPaymentEvent = extractRentPaymentMetadata(event);
       if (rentPaymentEvent.rentPaymentId && rentPaymentEvent.nextStatus) {
-        await prepareRentPaymentWebhookNormalizationContext({ event, rentPaymentEvent });
-        await updateRentPaymentFromWebhook({
-          rentPaymentId: rentPaymentEvent.rentPaymentId,
-          nextStatus: rentPaymentEvent.nextStatus,
-          processorCheckoutSessionId: rentPaymentEvent.checkoutSessionId,
-          processorPaymentIntentId: rentPaymentEvent.paymentIntentId,
-          paidAt: rentPaymentEvent.paidAt,
-          eventId: event.id,
-        });
+        const receiptContext = await prepareRentPaymentWebhookNormalizationContext({ event, rentPaymentEvent });
+        try {
+          await updateRentPaymentFromWebhook({
+            rentPaymentId: rentPaymentEvent.rentPaymentId,
+            nextStatus: rentPaymentEvent.nextStatus,
+            processorCheckoutSessionId: rentPaymentEvent.checkoutSessionId,
+            processorPaymentIntentId: rentPaymentEvent.paymentIntentId,
+            paidAt: rentPaymentEvent.paidAt,
+            eventId: event.id,
+          });
+          await markRentPaymentWebhookReceiptProcessed(receiptContext);
+        } catch (err) {
+          await markRentPaymentWebhookReceiptFailed(receiptContext, err);
+          throw err;
+        }
         return res.status(200).json({ received: true });
       }
 


### PR DESCRIPTION
This PR adds provider-neutral provider-event receipt persistence for webhook/idempotency tracking.

Includes:
- adds paymentProviderEventReceipts persistence helper
- records received, processing, processed, ignored_duplicate, failed, and manual_review_required receipt states
- uses deterministic receipt IDs derived from provider webhook idempotency keys
- tracks duplicate webhook sightings with duplicateCount and lastSeenAt
- inserts receipt tracking into the rent-payment webhook branch only
- preserves existing webhook HTTP responses and rentPayment status updates
- leaves screening/subscription/payout/pricing behavior unchanged
- updates payment execution boundary documentation

Guardrails preserved:
- backend/docs only
- no Trustly implementation
- no UI changes
- no frontend changes
- no schema-breaking changes
- no dependency or lockfile changes
- no active duplicate suppression
- no canonical payment.provider_signal_received production emission
- no persisted reconciliation state
- no PaymentIntent persistence

Verification:
- git diff --check passed
- paymentProviderEventReceipts tests passed: 7 tests
- focused payment boundary tests passed: 34 tests
- rent webhook and rent payment service tests passed: 7 tests
- rentchain-api pnpm build passed

Note:
- No separate rentPaymentWebhookNormalization.test.ts file exists in the repo; existing rentPaymentWebhook.test.ts covers the normalization and receipt regression path.