### PR TITLE
Emit rent payment provider signal events

### DIFF
--- a/docs/architecture/payment-execution-boundary-v1.md
+++ b/docs/architecture/payment-execution-boundary-v1.md
@@ -317,10 +317,55 @@ Behavior intentionally unchanged:
 Deferred items:
 
 1. Active duplicate suppression after receipt confidence is proven.
-2. `payment.provider_signal_received` canonical event emission.
-3. Persisted reconciliation state.
-4. Provider-neutral `PaymentIntent` persistence.
-5. Trustly sandbox adapter.
+2. Persisted reconciliation state.
+3. Provider-neutral `PaymentIntent` persistence.
+4. Trustly sandbox adapter.
+
+## Provider Signal Canonical Events v1
+
+Status: rent-payment webhook provider signals emit a canonical audit event after receipt persistence succeeds.
+
+What is emitted:
+
+- Type: `payment.provider_signal_received`
+- Domain: `payment`
+- Action: `provider_signal_received`
+- Resource: provider-event receipt
+- Parent resource: rent payment
+- Visibility: `internal`
+
+Safe metadata only:
+
+- `provider`
+- `providerEventId`
+- `idempotencyKey`
+- `receiptId`
+- `purpose`
+- `normalizedStatus`
+- `rawStatus`
+- `subjectType`
+- `subjectId`
+
+Why emission happens after receipt persistence:
+
+The provider receipt is the stable audit anchor for provider webhook evidence. Emitting after the receipt write means the canonical event can reference the receipt id and idempotency key without storing raw provider payloads or depending on later rent-payment status updates.
+
+Behavior intentionally unchanged:
+
+- Existing webhook HTTP responses are unchanged.
+- Existing `rentPayments` status updates are unchanged.
+- Duplicate provider events are still not actively suppressed.
+- Reconciliation remains read-only.
+- Screening checkout webhook behavior is untouched.
+- SaaS subscription webhook behavior is untouched.
+- No Trustly adapter or Trustly events are implemented.
+
+Deferred items:
+
+1. Active duplicate suppression.
+2. Persisted reconciliation state.
+3. Provider-neutral `PaymentIntent` persistence.
+4. Trustly sandbox adapter.
 
 ## Intentional Non-Implementation
 

--- a/rentchain-api/src/lib/events/buildEvent.ts
+++ b/rentchain-api/src/lib/events/buildEvent.ts
@@ -18,6 +18,7 @@ const ALLOWED_DOMAINS = new Set<CanonicalEventDomain>([
   "expense",
   "tenant",
   "billing",
+  "payment",
   "policy",
   "system",
 ]);

--- a/rentchain-api/src/lib/events/eventTypes.ts
+++ b/rentchain-api/src/lib/events/eventTypes.ts
@@ -6,6 +6,7 @@ export type CanonicalEventDomain =
   | "expense"
   | "tenant"
   | "billing"
+  | "payment"
   | "policy"
   | "system";
 

--- a/rentchain-api/src/routes/__tests__/rentPaymentWebhook.test.ts
+++ b/rentchain-api/src/routes/__tests__/rentPaymentWebhook.test.ts
@@ -314,10 +314,37 @@ describe("rent payment webhook reconciliation", () => {
     );
 
     const canonicalEvents = Array.from(ensureCollection("canonicalEvents").values());
+    const providerSignalEvents = canonicalEvents.filter((event: any) => event.type === "payment.provider_signal_received");
+    expect(providerSignalEvents).toHaveLength(2);
+    expect(providerSignalEvents[0]).toEqual(
+      expect.objectContaining({
+        domain: "payment",
+        action: "provider_signal_received",
+        status: "confirmed",
+        resource: expect.objectContaining({
+          type: "provider_event_receipt",
+          id: "provider_event:stripe:evt_rent_paid_1",
+          parentType: "rent_payment",
+          parentId: "rp-1",
+        }),
+        metadata: expect.objectContaining({
+          provider: "stripe",
+          providerEventId: "evt_rent_paid_1",
+          idempotencyKey: "provider_event:stripe:evt_rent_paid_1",
+          receiptId: "provider_event:stripe:evt_rent_paid_1",
+          purpose: "rent",
+          normalizedStatus: "confirmed",
+          rawStatus: "paid",
+          subjectType: "rent_payment",
+          subjectId: "rp-1",
+        }),
+      })
+    );
     expect(canonicalEvents.filter((event: any) => event.type === "rent_payment.paid")).toHaveLength(1);
-    expect(JSON.stringify(canonicalEvents[0] || {})).not.toContain("card");
-    expect(JSON.stringify(canonicalEvents[0] || {})).not.toContain("receipt");
-    expect(JSON.stringify(canonicalEvents[0] || {})).not.toContain("@");
+    const rentPaidEvent = canonicalEvents.find((event: any) => event.type === "rent_payment.paid");
+    expect(JSON.stringify(rentPaidEvent || {})).not.toContain("card");
+    expect(JSON.stringify(rentPaidEvent || {})).not.toContain("receipt");
+    expect(JSON.stringify(rentPaidEvent || {})).not.toContain("@");
   });
 
   it("updates a rent payment to failed from async payment failure metadata", async () => {
@@ -371,6 +398,18 @@ describe("rent payment webhook reconciliation", () => {
     );
 
     const canonicalEvents = Array.from(ensureCollection("canonicalEvents").values());
+    const providerSignalEvent = canonicalEvents.find((event: any) => event.type === "payment.provider_signal_received");
+    expect(providerSignalEvent).toEqual(
+      expect.objectContaining({
+        status: "failed",
+        metadata: expect.objectContaining({
+          providerEventId: "evt_rent_failed_1",
+          receiptId: "provider_event:stripe:evt_rent_failed_1",
+          normalizedStatus: "failed",
+          rawStatus: "failed",
+        }),
+      })
+    );
     expect(canonicalEvents.some((event: any) => event.type === "rent_payment.failed")).toBe(true);
   });
 
@@ -408,6 +447,11 @@ describe("rent payment webhook reconciliation", () => {
     expect(buildProviderWebhookIdempotencyKeyMock).not.toHaveBeenCalled();
     expect(deriveRentPaymentReconciliationMock).not.toHaveBeenCalled();
     expect(Array.from(ensureCollection("paymentProviderEventReceipts").values())).toHaveLength(0);
+    expect(
+      Array.from(ensureCollection("canonicalEvents").values()).some(
+        (event: any) => event.type === "payment.provider_signal_received"
+      )
+    ).toBe(false);
   });
 
   it("does not run rent normalization for subscription webhooks", async () => {
@@ -437,5 +481,10 @@ describe("rent payment webhook reconciliation", () => {
     expect(buildProviderWebhookIdempotencyKeyMock).not.toHaveBeenCalled();
     expect(deriveRentPaymentReconciliationMock).not.toHaveBeenCalled();
     expect(Array.from(ensureCollection("paymentProviderEventReceipts").values())).toHaveLength(0);
+    expect(
+      Array.from(ensureCollection("canonicalEvents").values()).some(
+        (event: any) => event.type === "payment.provider_signal_received"
+      )
+    ).toBe(false);
   });
 });

--- a/rentchain-api/src/routes/stripeScreeningOrdersWebhookRoutes.ts
+++ b/rentchain-api/src/routes/stripeScreeningOrdersWebhookRoutes.ts
@@ -311,6 +311,37 @@ async function prepareRentPaymentWebhookNormalizationContext(params: {
       rawStatus: normalizedProviderEvent.rawStatus,
       metadata: normalizedProviderEvent.metadata || null,
     });
+    await writeCanonicalEvent({
+      type: "payment.provider_signal_received",
+      domain: "payment",
+      action: "provider_signal_received",
+      status: normalizedProviderEvent.normalizedStatus,
+      actor: {
+        type: "system",
+        role: "system",
+        id: null,
+      },
+      resource: {
+        type: "provider_event_receipt",
+        id: receipt.receiptId,
+        parentType: "rent_payment",
+        parentId: rentPaymentEvent.rentPaymentId,
+      },
+      occurredAt: typeof event.created === "number" ? event.created * 1000 : new Date().toISOString(),
+      visibility: "internal",
+      summary: "Payment provider signal received",
+      metadata: {
+        provider: "stripe",
+        providerEventId: normalizedProviderEvent.providerEventId || event.id || "event_missing",
+        idempotencyKey,
+        receiptId: receipt.receiptId,
+        purpose: "rent",
+        normalizedStatus: normalizedProviderEvent.normalizedStatus,
+        rawStatus: normalizedProviderEvent.rawStatus,
+        subjectType: "rent_payment",
+        subjectId: rentPaymentEvent.rentPaymentId,
+      },
+    });
 
     if (receipt.isDuplicate) {
       await markProviderEventIgnoredDuplicate({ receiptId: receipt.receiptId });


### PR DESCRIPTION
This PR emits canonical provider-signal events for rent-payment webhook provider signals.

Includes:
- emits canonical `payment.provider_signal_received` events for rent-payment webhook provider signals
- ensures provider receipt persistence happens before canonical event emission
- references persisted `receiptId` and deterministic `idempotencyKey`
- limits event metadata to safe provider/status/subject summary fields
- preserves existing webhook HTTP responses and rentPayment status updates
- keeps duplicate suppression deferred
- keeps reconciliation read-only
- leaves screening/subscription branches untouched
- enables the `payment` canonical event domain
- updates payment execution boundary documentation

Guardrails preserved:
- backend/docs only
- no Trustly implementation
- no UI changes
- no frontend changes
- no dependency or lockfile changes
- no duplicate suppression
- no persisted reconciliation state
- no PaymentIntent persistence
- no screening/subscription/payout/pricing behavior changes

Verification:
- git diff --check passed
- paymentProviderEventReceipts.test.ts passed: 7 tests
- rentPaymentWebhook.test.ts passed: 4 tests
- focused payment boundary tests passed: 34 tests
- rentchain-api pnpm build passed