### PR TITLE
Persist payment reconciliation records

### DIFF
--- a/docs/architecture/payment-execution-boundary-v1.md
+++ b/docs/architecture/payment-execution-boundary-v1.md
@@ -363,7 +363,63 @@ Behavior intentionally unchanged:
 Deferred items:
 
 1. Active duplicate suppression.
-2. Persisted reconciliation state.
+2. Provider-neutral `PaymentIntent` persistence.
+3. Trustly sandbox adapter.
+
+## Payment Reconciliation Persistence v1
+
+Status: rent-payment webhook reconciliation results are persisted as read-only audit records.
+
+What is persisted:
+
+- Collection: `paymentReconciliationRecords`
+- Document id: deterministic id derived from the provider webhook idempotency key.
+- Core fields:
+  - `reconciliationId`
+  - `provider`
+  - `providerEventId`
+  - `idempotencyKey`
+  - `receiptId`
+  - `subjectType`
+  - `subjectId`
+  - `purpose`
+  - `normalizedStatus`
+  - `rawStatus`
+  - `reconciliationStatus`
+  - `reasons`
+  - `requiresManualReview`
+  - `automationEligible`
+  - `createdAt`
+  - `updatedAt`
+
+Ordering:
+
+```text
+provider event
+  -> provider-event receipt persistence
+  -> payment.provider_signal_received canonical event
+  -> read-only reconciliation derivation
+  -> paymentReconciliationRecords upsert
+  -> existing rent-payment webhook status update
+```
+
+Why this is read-only:
+
+The reconciliation record captures RentChain's interpretation of provider evidence for audit visibility and future operations. It does not currently drive live `rentPayments` status transitions because the existing webhook updater remains the source of current production behavior.
+
+Behavior intentionally unchanged:
+
+- Existing webhook HTTP responses are unchanged.
+- Existing `rentPayments` status updates are unchanged.
+- Duplicate provider events upsert the same reconciliation record but do not suppress webhook execution.
+- Screening checkout webhook behavior is untouched.
+- SaaS subscription webhook behavior is untouched.
+- No reconciliation canonical events are emitted in this phase.
+
+Deferred items:
+
+1. Active duplicate suppression.
+2. Reconciliation-driven status transitions.
 3. Provider-neutral `PaymentIntent` persistence.
 4. Trustly sandbox adapter.
 

--- a/rentchain-api/src/lib/payments/__tests__/paymentReconciliationRecords.test.ts
+++ b/rentchain-api/src/lib/payments/__tests__/paymentReconciliationRecords.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPaymentReconciliationRecordId,
+  upsertPaymentReconciliationRecord,
+} from "../paymentReconciliationRecords";
+
+function buildFirestore() {
+  const store = new Map<string, Map<string, any>>();
+
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+
+  return {
+    store,
+    firestore: {
+      collection: (name: string) => ({
+        doc: (id: string) => ({
+          get: async () => ({
+            exists: ensureCollection(name).has(id),
+            data: () => ensureCollection(name).get(id),
+          }),
+          set: async (payload: Record<string, unknown>, options?: { merge?: boolean }) => {
+            const col = ensureCollection(name);
+            const existing = col.get(id) || {};
+            col.set(id, options?.merge ? { ...existing, ...payload } : payload);
+          },
+        }),
+      }),
+    },
+  };
+}
+
+const providerSignal = {
+  provider: "stripe" as const,
+  providerEventId: "evt_1",
+  rawStatus: "paid",
+  normalizedStatus: "confirmed" as const,
+  purpose: "rent" as const,
+};
+
+describe("paymentReconciliationRecords", () => {
+  it("builds deterministic record ids from idempotency keys", () => {
+    expect(buildPaymentReconciliationRecordId("provider_event:stripe:evt_1")).toBe("provider_event:stripe:evt_1");
+    expect(buildPaymentReconciliationRecordId("provider/event stripe evt 1")).toBe("provider_event_stripe_evt_1");
+  });
+
+  it("creates a reconciliation record with safe summary fields", async () => {
+    const { firestore, store } = buildFirestore();
+    const record = await upsertPaymentReconciliationRecord({
+      firestore,
+      idempotencyKey: "provider_event:stripe:evt_1",
+      receiptId: "provider_event:stripe:evt_1",
+      subjectType: "rent_payment",
+      subjectId: "rp-1",
+      purpose: "rent",
+      providerSignal,
+      reconciliation: {
+        reconciliationStatus: "reconciled",
+        reasons: ["provider_confirmed_amount_currency_match"],
+        requiresManualReview: false,
+        automationEligible: true,
+      },
+      now: "2026-05-03T12:00:00.000Z",
+    });
+
+    expect(record).toEqual({
+      reconciliationId: "provider_event:stripe:evt_1",
+      provider: "stripe",
+      providerEventId: "evt_1",
+      idempotencyKey: "provider_event:stripe:evt_1",
+      receiptId: "provider_event:stripe:evt_1",
+      subjectType: "rent_payment",
+      subjectId: "rp-1",
+      purpose: "rent",
+      normalizedStatus: "confirmed",
+      rawStatus: "paid",
+      reconciliationStatus: "reconciled",
+      reasons: ["provider_confirmed_amount_currency_match"],
+      requiresManualReview: false,
+      automationEligible: true,
+      createdAt: "2026-05-03T12:00:00.000Z",
+      updatedAt: "2026-05-03T12:00:00.000Z",
+    });
+  });
+
+  it("upserts the same reconciliation record for duplicate provider events", async () => {
+    const { firestore, store } = buildFirestore();
+    await upsertPaymentReconciliationRecord({
+      firestore,
+      idempotencyKey: "provider_event:stripe:evt_1",
+      receiptId: "provider_event:stripe:evt_1",
+      providerSignal,
+      reconciliation: {
+        reconciliationStatus: "reconciled",
+        reasons: ["provider_confirmed_amount_currency_match"],
+        requiresManualReview: false,
+        automationEligible: true,
+      },
+      now: "2026-05-03T12:00:00.000Z",
+    });
+
+    const updated = await upsertPaymentReconciliationRecord({
+      firestore,
+      idempotencyKey: "provider_event:stripe:evt_1",
+      receiptId: "provider_event:stripe:evt_1",
+      providerSignal,
+      reconciliation: {
+        reconciliationStatus: "duplicate_risk",
+        reasons: ["duplicate_provider_event"],
+        requiresManualReview: true,
+        automationEligible: false,
+      },
+      now: "2026-05-03T12:01:00.000Z",
+    });
+
+    expect(updated).toMatchObject({
+      reconciliationId: "provider_event:stripe:evt_1",
+      reconciliationStatus: "duplicate_risk",
+      reasons: ["duplicate_provider_event"],
+      requiresManualReview: true,
+      automationEligible: false,
+      createdAt: "2026-05-03T12:00:00.000Z",
+      updatedAt: "2026-05-03T12:01:00.000Z",
+    });
+    expect(store.get("paymentReconciliationRecords")?.size).toBe(1);
+  });
+});

--- a/rentchain-api/src/lib/payments/paymentReconciliationRecords.ts
+++ b/rentchain-api/src/lib/payments/paymentReconciliationRecords.ts
@@ -1,0 +1,149 @@
+import { db } from "../../config/firebase";
+import type { NormalizedProviderPaymentEvent } from "./paymentProviderAdapter";
+import type { PaymentReconciliationResult } from "./paymentReconciliation";
+import type { PaymentExecutionStatus, PaymentProvider, PaymentPurpose } from "./paymentTypes";
+
+export const PAYMENT_RECONCILIATION_RECORDS_COLLECTION = "paymentReconciliationRecords";
+
+export type PaymentReconciliationRecord = {
+  reconciliationId: string;
+  provider: PaymentProvider;
+  providerEventId: string;
+  idempotencyKey: string;
+  receiptId: string;
+  subjectType?: string | null;
+  subjectId?: string | null;
+  purpose?: PaymentPurpose | null;
+  normalizedStatus?: PaymentExecutionStatus | null;
+  rawStatus?: string | null;
+  reconciliationStatus: PaymentReconciliationResult["reconciliationStatus"];
+  reasons: string[];
+  requiresManualReview: boolean;
+  automationEligible: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type FirestoreDocRef = {
+  get(): Promise<{ exists: boolean; data(): Record<string, unknown> | undefined }>;
+  set(payload: Record<string, unknown>, options?: { merge?: boolean }): Promise<void>;
+};
+
+type FirestoreLike = {
+  collection(name: string): {
+    doc(id: string): FirestoreDocRef;
+  };
+};
+
+type UpsertPaymentReconciliationRecordInput = {
+  idempotencyKey: string;
+  receiptId: string;
+  subjectType?: string | null;
+  subjectId?: string | null;
+  purpose?: PaymentPurpose | null;
+  providerSignal: NormalizedProviderPaymentEvent;
+  reconciliation: PaymentReconciliationResult;
+  now?: string | null;
+  firestore?: FirestoreLike;
+};
+
+function nowIso(value?: string | null): string {
+  const raw = String(value || "").trim();
+  if (raw) return raw;
+  return new Date().toISOString();
+}
+
+function cleanRecordPart(value: unknown): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function normalizeOptionalString(value: unknown, max = 500): string | null {
+  const next = String(value || "").trim().slice(0, max);
+  return next || null;
+}
+
+function getFirestore(input?: { firestore?: FirestoreLike }): FirestoreLike {
+  return input?.firestore || (db as unknown as FirestoreLike);
+}
+
+function recordRef(reconciliationId: string, firestore?: FirestoreLike): FirestoreDocRef {
+  return getFirestore({ firestore }).collection(PAYMENT_RECONCILIATION_RECORDS_COLLECTION).doc(reconciliationId);
+}
+
+function normalizeReasons(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((item) => String(item || "").trim()).filter(Boolean).slice(0, 20);
+}
+
+function normalizeRecord(
+  data: Record<string, unknown>,
+  fallback: { reconciliationId: string; idempotencyKey: string; receiptId: string }
+): PaymentReconciliationRecord {
+  return {
+    reconciliationId: normalizeOptionalString(data.reconciliationId, 300) || fallback.reconciliationId,
+    provider: (normalizeOptionalString(data.provider, 50) || "stripe") as PaymentProvider,
+    providerEventId: normalizeOptionalString(data.providerEventId, 300) || "event_missing",
+    idempotencyKey: normalizeOptionalString(data.idempotencyKey, 500) || fallback.idempotencyKey,
+    receiptId: normalizeOptionalString(data.receiptId, 300) || fallback.receiptId,
+    subjectType: normalizeOptionalString(data.subjectType, 80),
+    subjectId: normalizeOptionalString(data.subjectId, 300),
+    purpose: (normalizeOptionalString(data.purpose, 50) as PaymentPurpose | null) || null,
+    normalizedStatus: (normalizeOptionalString(data.normalizedStatus, 80) as PaymentExecutionStatus | null) || null,
+    rawStatus: normalizeOptionalString(data.rawStatus, 200),
+    reconciliationStatus:
+      (normalizeOptionalString(data.reconciliationStatus, 80) as PaymentReconciliationResult["reconciliationStatus"]) ||
+      "manual_review_required",
+    reasons: normalizeReasons(data.reasons),
+    requiresManualReview: data.requiresManualReview === true,
+    automationEligible: data.automationEligible === true,
+    createdAt: normalizeOptionalString(data.createdAt, 80) || nowIso(),
+    updatedAt: normalizeOptionalString(data.updatedAt, 80) || nowIso(),
+  };
+}
+
+export function buildPaymentReconciliationRecordId(idempotencyKey: string): string {
+  return cleanRecordPart(idempotencyKey || "provider_event:event_missing") || "provider_event:event_missing";
+}
+
+export async function upsertPaymentReconciliationRecord(
+  input: UpsertPaymentReconciliationRecordInput
+): Promise<PaymentReconciliationRecord> {
+  const at = nowIso(input.now);
+  const reconciliationId = buildPaymentReconciliationRecordId(input.idempotencyKey || input.receiptId);
+  const ref = recordRef(reconciliationId, input.firestore);
+  const snap = await ref.get();
+  const existing = snap.exists
+    ? normalizeRecord(snap.data() || {}, {
+        reconciliationId,
+        idempotencyKey: input.idempotencyKey,
+        receiptId: input.receiptId,
+      })
+    : null;
+
+  const record: PaymentReconciliationRecord = {
+    reconciliationId,
+    provider: input.providerSignal.provider,
+    providerEventId: input.providerSignal.providerEventId || "event_missing",
+    idempotencyKey: input.idempotencyKey,
+    receiptId: input.receiptId,
+    subjectType: normalizeOptionalString(input.subjectType, 80),
+    subjectId: normalizeOptionalString(input.subjectId, 300),
+    purpose: input.purpose || input.providerSignal.purpose || null,
+    normalizedStatus: input.providerSignal.normalizedStatus || null,
+    rawStatus: input.providerSignal.rawStatus || null,
+    reconciliationStatus: input.reconciliation.reconciliationStatus,
+    reasons: normalizeReasons(input.reconciliation.reasons),
+    requiresManualReview: input.reconciliation.requiresManualReview === true,
+    automationEligible: input.reconciliation.automationEligible === true,
+    createdAt: existing?.createdAt || at,
+    updatedAt: at,
+  };
+
+  await ref.set(record, { merge: true });
+  return record;
+}

--- a/rentchain-api/src/routes/__tests__/rentPaymentWebhook.test.ts
+++ b/rentchain-api/src/routes/__tests__/rentPaymentWebhook.test.ts
@@ -312,6 +312,26 @@ describe("rent payment webhook reconciliation", () => {
         rawStatus: "paid",
       })
     );
+    const reconciliationRecord = ensureCollection("paymentReconciliationRecords").get("provider_event:stripe:evt_rent_paid_1");
+    expect(reconciliationRecord).toEqual(
+      expect.objectContaining({
+        reconciliationId: "provider_event:stripe:evt_rent_paid_1",
+        provider: "stripe",
+        providerEventId: "evt_rent_paid_1",
+        idempotencyKey: "provider_event:stripe:evt_rent_paid_1",
+        receiptId: "provider_event:stripe:evt_rent_paid_1",
+        subjectType: "rent_payment",
+        subjectId: "rp-1",
+        purpose: "rent",
+        normalizedStatus: "confirmed",
+        rawStatus: "paid",
+        reconciliationStatus: "reconciled",
+        reasons: ["provider_confirmed_amount_currency_match"],
+        requiresManualReview: false,
+        automationEligible: true,
+      })
+    );
+    expect(ensureCollection("paymentReconciliationRecords").size).toBe(1);
 
     const canonicalEvents = Array.from(ensureCollection("canonicalEvents").values());
     const providerSignalEvents = canonicalEvents.filter((event: any) => event.type === "payment.provider_signal_received");
@@ -396,6 +416,15 @@ describe("rent payment webhook reconciliation", () => {
         rawStatus: "failed",
       })
     );
+    expect(ensureCollection("paymentReconciliationRecords").get("provider_event:stripe:evt_rent_failed_1")).toEqual(
+      expect.objectContaining({
+        reconciliationId: "provider_event:stripe:evt_rent_failed_1",
+        providerEventId: "evt_rent_failed_1",
+        receiptId: "provider_event:stripe:evt_rent_failed_1",
+        reconciliationStatus: "reconciled",
+        reasons: ["provider_confirmed_amount_currency_match"],
+      })
+    );
 
     const canonicalEvents = Array.from(ensureCollection("canonicalEvents").values());
     const providerSignalEvent = canonicalEvents.find((event: any) => event.type === "payment.provider_signal_received");
@@ -447,6 +476,7 @@ describe("rent payment webhook reconciliation", () => {
     expect(buildProviderWebhookIdempotencyKeyMock).not.toHaveBeenCalled();
     expect(deriveRentPaymentReconciliationMock).not.toHaveBeenCalled();
     expect(Array.from(ensureCollection("paymentProviderEventReceipts").values())).toHaveLength(0);
+    expect(Array.from(ensureCollection("paymentReconciliationRecords").values())).toHaveLength(0);
     expect(
       Array.from(ensureCollection("canonicalEvents").values()).some(
         (event: any) => event.type === "payment.provider_signal_received"
@@ -481,10 +511,62 @@ describe("rent payment webhook reconciliation", () => {
     expect(buildProviderWebhookIdempotencyKeyMock).not.toHaveBeenCalled();
     expect(deriveRentPaymentReconciliationMock).not.toHaveBeenCalled();
     expect(Array.from(ensureCollection("paymentProviderEventReceipts").values())).toHaveLength(0);
+    expect(Array.from(ensureCollection("paymentReconciliationRecords").values())).toHaveLength(0);
     expect(
       Array.from(ensureCollection("canonicalEvents").values()).some(
         (event: any) => event.type === "payment.provider_signal_received"
       )
     ).toBe(false);
+  });
+
+  it("persists manual review reconciliation without changing webhook response or rent payment update", async () => {
+    deriveRentPaymentReconciliationMock.mockReturnValueOnce({
+      reconciliationStatus: "manual_review_required",
+      reasons: ["missing_internal_subject_reference"],
+      automationEligible: false,
+      requiresManualReview: true,
+    });
+    constructEventMock.mockReturnValue({
+      id: "evt_rent_manual_review_1",
+      created: 1_714_213_200,
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_test_1",
+          payment_intent: "pi_test_1",
+          payment_status: "paid",
+          metadata: {
+            rentPaymentId: "rp-1",
+          },
+        },
+      },
+    });
+
+    const res = await invokeWebhook('{"id":"evt_rent_manual_review_1","type":"checkout.session.completed"}');
+
+    expect(res.status).toBe(200);
+    expect(ensureCollection("rentPayments").get("rp-1")).toEqual(
+      expect.objectContaining({
+        status: "paid",
+        processorCheckoutSessionId: "cs_test_1",
+        processorPaymentIntentId: "pi_test_1",
+      })
+    );
+    expect(ensureCollection("paymentReconciliationRecords").get("provider_event:stripe:evt_rent_manual_review_1")).toEqual(
+      expect.objectContaining({
+        reconciliationStatus: "manual_review_required",
+        reasons: ["missing_internal_subject_reference"],
+        requiresManualReview: true,
+        automationEligible: false,
+        receiptId: "provider_event:stripe:evt_rent_manual_review_1",
+        idempotencyKey: "provider_event:stripe:evt_rent_manual_review_1",
+      })
+    );
+    expect(ensureCollection("paymentProviderEventReceipts").get("provider_event:stripe:evt_rent_manual_review_1")).toEqual(
+      expect.objectContaining({
+        status: "manual_review_required",
+        failureReason: "missing_internal_subject_reference",
+      })
+    );
   });
 });

--- a/rentchain-api/src/routes/stripeScreeningOrdersWebhookRoutes.ts
+++ b/rentchain-api/src/routes/stripeScreeningOrdersWebhookRoutes.ts
@@ -35,6 +35,7 @@ import {
   markProviderEventProcessing,
   markProviderEventReceived,
 } from "../lib/payments/paymentProviderEventReceipts";
+import { upsertPaymentReconciliationRecord } from "../lib/payments/paymentReconciliationRecords";
 
 interface StripeWebhookRequest extends Request {
   rawBody?: Buffer;
@@ -343,13 +344,6 @@ async function prepareRentPaymentWebhookNormalizationContext(params: {
       },
     });
 
-    if (receipt.isDuplicate) {
-      await markProviderEventIgnoredDuplicate({ receiptId: receipt.receiptId });
-      return { normalizedProviderEvent, idempotencyKey, reconciliation: null, receipt };
-    }
-
-    await markProviderEventProcessing({ receiptId: receipt.receiptId });
-
     const rentPaymentId = normalizeString(rentPaymentEvent.rentPaymentId, 120);
     const snap = rentPaymentId ? await db.collection("rentPayments").doc(rentPaymentId).get() : null;
     const expectedIntent = snap?.exists
@@ -359,6 +353,23 @@ async function prepareRentPaymentWebhookNormalizationContext(params: {
       expectedIntent,
       providerSignal: normalizedProviderEvent,
     });
+    await upsertPaymentReconciliationRecord({
+      idempotencyKey,
+      receiptId: receipt.receiptId,
+      subjectType: "rent_payment",
+      subjectId: rentPaymentEvent.rentPaymentId,
+      purpose: "rent",
+      providerSignal: normalizedProviderEvent,
+      reconciliation,
+    });
+
+    if (receipt.isDuplicate) {
+      await markProviderEventIgnoredDuplicate({ receiptId: receipt.receiptId });
+      return { normalizedProviderEvent, idempotencyKey, reconciliation, receipt };
+    }
+
+    await markProviderEventProcessing({ receiptId: receipt.receiptId });
+
     if (reconciliation.requiresManualReview) {
       await markProviderEventManualReviewRequired({
         receiptId: receipt.receiptId,


### PR DESCRIPTION
This PR persists read-only reconciliation records for rent-payment provider signals.

Includes:
- adds provider-neutral paymentReconciliationRecords helper
- persists safe read-only reconciliation summaries for rent-payment provider signals
- uses deterministic reconciliation IDs derived from provider webhook idempotency keys
- upserts duplicate webhooks into the same reconciliation record
- persists receiptId, idempotencyKey, provider signal status, reconciliation status, reasons, manual-review flag, and automation eligibility
- preserves existing webhook HTTP responses and rentPayments status updates
- keeps duplicate suppression deferred
- keeps PaymentIntent persistence deferred
- leaves screening/subscription branches untouched
- updates payment execution boundary documentation

Guardrails preserved:
- backend/docs only
- no Trustly implementation
- no UI changes
- no frontend changes
- no dependency or lockfile changes
- no duplicate suppression
- no PaymentIntent persistence
- no reconciliation-driven status transitions
- no screening/subscription/payout/pricing behavior changes

Verification:
- git diff --check passed
- paymentReconciliationRecords.test.ts passed: 3 tests
- rentPaymentWebhook.test.ts passed: 5 tests
- focused payment helper tests passed: 41 tests
- rentchain-api pnpm build passed