### PR TITLE
Prepare payment duplicate suppression decisions

### DIFF
--- a/docs/architecture/payment-execution-boundary-v1.md
+++ b/docs/architecture/payment-execution-boundary-v1.md
@@ -423,6 +423,52 @@ Deferred items:
 3. Provider-neutral `PaymentIntent` persistence.
 4. Trustly sandbox adapter.
 
+## Duplicate Suppression Readiness v1
+
+Status: duplicate-suppression decisions are derived for rent-payment webhook provider events, but suppression is not active.
+
+Decision helper behavior:
+
+- `processed` receipt: future suppress candidate with `shouldSuppress: true`.
+- `ignored_duplicate` receipt: future suppress candidate with `shouldSuppress: true`.
+- `processing` receipt: does not suppress; requires manual review before future enforcement.
+- `failed` receipt: does not suppress; requires manual review.
+- `manual_review_required` receipt: does not suppress; remains manual-review owned.
+- `received` receipt: does not suppress because processing has not completed.
+- Missing or unknown receipt state: does not suppress and fails closed.
+
+Where the decision is inserted:
+
+```text
+provider event
+  -> provider-event receipt persistence
+  -> duplicate-suppression decision derivation
+  -> payment.provider_signal_received canonical event
+  -> read-only reconciliation derivation
+  -> paymentReconciliationRecords upsert
+  -> existing rent-payment webhook status update
+```
+
+Why suppression is not active yet:
+
+The existing rent-payment webhook updater is already behavior-preserving and idempotent for current Stripe rent payments. This phase only proves the decision layer can classify receipt states deterministically. Active suppression requires explicit follow-up approval because it would change whether duplicate provider events execute the existing webhook update path.
+
+Behavior intentionally unchanged:
+
+- Existing webhook HTTP responses are unchanged.
+- Existing `rentPayments` status updates are unchanged.
+- Duplicate webhooks still execute the existing rent-payment update path.
+- Provider-event receipts and reconciliation records remain audit/readiness layers.
+- Screening checkout webhook behavior is untouched.
+- SaaS subscription webhook behavior is untouched.
+
+Deferred items:
+
+1. Active duplicate suppression after explicit approval.
+2. Reconciliation-driven status transitions.
+3. Provider-neutral `PaymentIntent` persistence.
+4. Trustly sandbox adapter.
+
 ## Intentional Non-Implementation
 
 This mission intentionally does not:

--- a/rentchain-api/src/lib/payments/__tests__/paymentDuplicateSuppression.test.ts
+++ b/rentchain-api/src/lib/payments/__tests__/paymentDuplicateSuppression.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { derivePaymentDuplicateSuppressionDecision } from "../paymentDuplicateSuppression";
+
+describe("derivePaymentDuplicateSuppressionDecision", () => {
+  it("marks processed receipts as future suppress candidates", () => {
+    expect(
+      derivePaymentDuplicateSuppressionDecision({
+        receipt: {
+          status: "processed",
+          duplicateCount: 2,
+        },
+      })
+    ).toEqual({
+      shouldSuppress: true,
+      reason: "provider_event_already_processed",
+      existingReceiptStatus: "processed",
+      duplicateCount: 2,
+      safeToAcknowledge: true,
+      requiresManualReview: false,
+    });
+  });
+
+  it("does not suppress failed receipts", () => {
+    expect(
+      derivePaymentDuplicateSuppressionDecision({
+        receipt: {
+          status: "failed",
+          duplicateCount: 1,
+        },
+      })
+    ).toEqual({
+      shouldSuppress: false,
+      reason: "provider_event_previous_processing_failed",
+      existingReceiptStatus: "failed",
+      duplicateCount: 1,
+      safeToAcknowledge: false,
+      requiresManualReview: true,
+    });
+  });
+
+  it("does not suppress manual review receipts", () => {
+    expect(
+      derivePaymentDuplicateSuppressionDecision({
+        receipt: {
+          status: "manual_review_required",
+          duplicateCount: 1,
+        },
+      })
+    ).toEqual({
+      shouldSuppress: false,
+      reason: "provider_event_manual_review_required",
+      existingReceiptStatus: "manual_review_required",
+      duplicateCount: 1,
+      safeToAcknowledge: true,
+      requiresManualReview: true,
+    });
+  });
+
+  it("does not suppress missing receipts", () => {
+    expect(derivePaymentDuplicateSuppressionDecision({ receipt: null })).toEqual({
+      shouldSuppress: false,
+      reason: "provider_event_receipt_missing",
+      existingReceiptStatus: null,
+      duplicateCount: 0,
+      safeToAcknowledge: false,
+      requiresManualReview: false,
+    });
+  });
+
+  it("fails closed for unknown receipt statuses", () => {
+    expect(
+      derivePaymentDuplicateSuppressionDecision({
+        receipt: {
+          status: "settled" as any,
+          duplicateCount: 3,
+        },
+      })
+    ).toEqual({
+      shouldSuppress: false,
+      reason: "provider_event_receipt_status_unknown",
+      existingReceiptStatus: "unknown",
+      duplicateCount: 3,
+      safeToAcknowledge: false,
+      requiresManualReview: true,
+    });
+  });
+});

--- a/rentchain-api/src/lib/payments/paymentDuplicateSuppression.ts
+++ b/rentchain-api/src/lib/payments/paymentDuplicateSuppression.ts
@@ -1,0 +1,117 @@
+import type {
+  PaymentProviderEventReceipt,
+  PaymentProviderEventReceiptStatus,
+} from "./paymentProviderEventReceipts";
+
+export type PaymentDuplicateSuppressionDecisionReason =
+  | "provider_event_receipt_missing"
+  | "provider_event_already_processed"
+  | "provider_event_duplicate_already_recorded"
+  | "provider_event_processing_in_progress"
+  | "provider_event_previous_processing_failed"
+  | "provider_event_manual_review_required"
+  | "provider_event_not_processed_yet"
+  | "provider_event_receipt_status_unknown";
+
+export type PaymentDuplicateSuppressionDecision = {
+  shouldSuppress: boolean;
+  reason: PaymentDuplicateSuppressionDecisionReason;
+  existingReceiptStatus: PaymentProviderEventReceiptStatus | "unknown" | null;
+  duplicateCount: number;
+  safeToAcknowledge: boolean;
+  requiresManualReview: boolean;
+};
+
+type DuplicateSuppressionDecisionInput = {
+  receipt?: Pick<PaymentProviderEventReceipt, "status" | "duplicateCount"> | null;
+};
+
+function normalizeDuplicateCount(value: unknown): number {
+  const next = Number(value);
+  if (!Number.isFinite(next) || next < 0) return 0;
+  return Math.floor(next);
+}
+
+export function derivePaymentDuplicateSuppressionDecision(
+  input: DuplicateSuppressionDecisionInput
+): PaymentDuplicateSuppressionDecision {
+  const receipt = input.receipt || null;
+  if (!receipt) {
+    return {
+      shouldSuppress: false,
+      reason: "provider_event_receipt_missing",
+      existingReceiptStatus: null,
+      duplicateCount: 0,
+      safeToAcknowledge: false,
+      requiresManualReview: false,
+    };
+  }
+
+  const duplicateCount = normalizeDuplicateCount(receipt.duplicateCount);
+
+  switch (receipt.status) {
+    case "processed":
+      return {
+        shouldSuppress: true,
+        reason: "provider_event_already_processed",
+        existingReceiptStatus: "processed",
+        duplicateCount,
+        safeToAcknowledge: true,
+        requiresManualReview: false,
+      };
+    case "ignored_duplicate":
+      return {
+        shouldSuppress: true,
+        reason: "provider_event_duplicate_already_recorded",
+        existingReceiptStatus: "ignored_duplicate",
+        duplicateCount,
+        safeToAcknowledge: true,
+        requiresManualReview: false,
+      };
+    case "processing":
+      return {
+        shouldSuppress: false,
+        reason: "provider_event_processing_in_progress",
+        existingReceiptStatus: "processing",
+        duplicateCount,
+        safeToAcknowledge: false,
+        requiresManualReview: true,
+      };
+    case "failed":
+      return {
+        shouldSuppress: false,
+        reason: "provider_event_previous_processing_failed",
+        existingReceiptStatus: "failed",
+        duplicateCount,
+        safeToAcknowledge: false,
+        requiresManualReview: true,
+      };
+    case "manual_review_required":
+      return {
+        shouldSuppress: false,
+        reason: "provider_event_manual_review_required",
+        existingReceiptStatus: "manual_review_required",
+        duplicateCount,
+        safeToAcknowledge: true,
+        requiresManualReview: true,
+      };
+    case "received":
+      return {
+        shouldSuppress: false,
+        reason: "provider_event_not_processed_yet",
+        existingReceiptStatus: "received",
+        duplicateCount,
+        safeToAcknowledge: false,
+        requiresManualReview: false,
+      };
+    default:
+      return {
+        shouldSuppress: false,
+        reason: "provider_event_receipt_status_unknown",
+        existingReceiptStatus: "unknown",
+        duplicateCount,
+        safeToAcknowledge: false,
+        requiresManualReview: true,
+      };
+  }
+}

--- a/rentchain-api/src/routes/__tests__/rentPaymentWebhook.test.ts
+++ b/rentchain-api/src/routes/__tests__/rentPaymentWebhook.test.ts
@@ -8,6 +8,7 @@ const {
   normalizeRentPaymentProviderEventMock,
   deriveRentPaymentReconciliationMock,
   buildProviderWebhookIdempotencyKeyMock,
+  derivePaymentDuplicateSuppressionDecisionMock,
 } = vi.hoisted(() => {
   const store = new Map<string, Map<string, any>>();
 
@@ -61,6 +62,17 @@ const {
     buildProviderWebhookIdempotencyKeyMock: vi.fn(
       (input: any) => `provider_event:${input.provider}:${input.providerEventId}`
     ),
+    derivePaymentDuplicateSuppressionDecisionMock: vi.fn((input: any) => ({
+      shouldSuppress: input.receipt?.status === "processed" || input.receipt?.status === "ignored_duplicate",
+      reason:
+        input.receipt?.status === "ignored_duplicate"
+          ? "provider_event_duplicate_already_recorded"
+          : "provider_event_not_processed_yet",
+      existingReceiptStatus: input.receipt?.status || null,
+      duplicateCount: input.receipt?.duplicateCount || 0,
+      safeToAcknowledge: input.receipt?.status === "ignored_duplicate",
+      requiresManualReview: false,
+    })),
   };
 });
 
@@ -152,6 +164,14 @@ vi.mock("../../lib/payments/paymentIdempotency", async (importOriginal) => {
   };
 });
 
+vi.mock("../../lib/payments/paymentDuplicateSuppression", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../lib/payments/paymentDuplicateSuppression")>();
+  return {
+    ...actual,
+    derivePaymentDuplicateSuppressionDecision: derivePaymentDuplicateSuppressionDecisionMock,
+  };
+});
+
 async function invokeWebhook(body: string) {
   const { stripeWebhookHandler } = await import("../stripeScreeningOrdersWebhookRoutes");
   return await new Promise<{ status: number; body: any; text?: string }>((resolve, reject) => {
@@ -187,6 +207,7 @@ describe("rent payment webhook reconciliation", () => {
     normalizeRentPaymentProviderEventMock.mockClear();
     deriveRentPaymentReconciliationMock.mockClear();
     buildProviderWebhookIdempotencyKeyMock.mockClear();
+    derivePaymentDuplicateSuppressionDecisionMock.mockClear();
     normalizeRentPaymentProviderEventMock.mockImplementation((input: any) => {
       const failed = String(input.rawEvent?.type || "").includes("failed");
       return {
@@ -281,6 +302,19 @@ describe("rent payment webhook reconciliation", () => {
       providerSignal: expect.objectContaining({
         provider: "stripe",
         providerEventId: "evt_rent_paid_1",
+      }),
+    });
+    expect(derivePaymentDuplicateSuppressionDecisionMock).toHaveBeenCalledTimes(2);
+    expect(derivePaymentDuplicateSuppressionDecisionMock).toHaveBeenNthCalledWith(1, {
+      receipt: expect.objectContaining({
+        status: "received",
+        duplicateCount: 0,
+      }),
+    });
+    expect(derivePaymentDuplicateSuppressionDecisionMock).toHaveBeenNthCalledWith(2, {
+      receipt: expect.objectContaining({
+        status: "ignored_duplicate",
+        duplicateCount: 1,
       }),
     });
 
@@ -475,6 +509,7 @@ describe("rent payment webhook reconciliation", () => {
     expect(normalizeRentPaymentProviderEventMock).not.toHaveBeenCalled();
     expect(buildProviderWebhookIdempotencyKeyMock).not.toHaveBeenCalled();
     expect(deriveRentPaymentReconciliationMock).not.toHaveBeenCalled();
+    expect(derivePaymentDuplicateSuppressionDecisionMock).not.toHaveBeenCalled();
     expect(Array.from(ensureCollection("paymentProviderEventReceipts").values())).toHaveLength(0);
     expect(Array.from(ensureCollection("paymentReconciliationRecords").values())).toHaveLength(0);
     expect(
@@ -510,6 +545,7 @@ describe("rent payment webhook reconciliation", () => {
     expect(normalizeRentPaymentProviderEventMock).not.toHaveBeenCalled();
     expect(buildProviderWebhookIdempotencyKeyMock).not.toHaveBeenCalled();
     expect(deriveRentPaymentReconciliationMock).not.toHaveBeenCalled();
+    expect(derivePaymentDuplicateSuppressionDecisionMock).not.toHaveBeenCalled();
     expect(Array.from(ensureCollection("paymentProviderEventReceipts").values())).toHaveLength(0);
     expect(Array.from(ensureCollection("paymentReconciliationRecords").values())).toHaveLength(0);
     expect(

--- a/rentchain-api/src/routes/stripeScreeningOrdersWebhookRoutes.ts
+++ b/rentchain-api/src/routes/stripeScreeningOrdersWebhookRoutes.ts
@@ -35,6 +35,7 @@ import {
   markProviderEventProcessing,
   markProviderEventReceived,
 } from "../lib/payments/paymentProviderEventReceipts";
+import { derivePaymentDuplicateSuppressionDecision } from "../lib/payments/paymentDuplicateSuppression";
 import { upsertPaymentReconciliationRecord } from "../lib/payments/paymentReconciliationRecords";
 
 interface StripeWebhookRequest extends Request {
@@ -312,6 +313,7 @@ async function prepareRentPaymentWebhookNormalizationContext(params: {
       rawStatus: normalizedProviderEvent.rawStatus,
       metadata: normalizedProviderEvent.metadata || null,
     });
+    const duplicateSuppressionDecision = derivePaymentDuplicateSuppressionDecision({ receipt: receipt.receipt });
     await writeCanonicalEvent({
       type: "payment.provider_signal_received",
       domain: "payment",
@@ -365,7 +367,7 @@ async function prepareRentPaymentWebhookNormalizationContext(params: {
 
     if (receipt.isDuplicate) {
       await markProviderEventIgnoredDuplicate({ receiptId: receipt.receiptId });
-      return { normalizedProviderEvent, idempotencyKey, reconciliation, receipt };
+      return { normalizedProviderEvent, idempotencyKey, reconciliation, receipt, duplicateSuppressionDecision };
     }
 
     await markProviderEventProcessing({ receiptId: receipt.receiptId });
@@ -377,7 +379,7 @@ async function prepareRentPaymentWebhookNormalizationContext(params: {
       });
     }
 
-    return { normalizedProviderEvent, idempotencyKey, reconciliation, receipt };
+    return { normalizedProviderEvent, idempotencyKey, reconciliation, receipt, duplicateSuppressionDecision };
   } catch (err: any) {
     console.warn("[stripe-webhook-rent-payment] normalization seam skipped", {
       eventId: event.id,


### PR DESCRIPTION
This PR prepares duplicate-suppression decisions for payment provider webhooks without activating suppression.

Includes:
- pure duplicate-suppression readiness helper for provider-event receipt state
- processed/ignored_duplicate receipts marked as future suppress candidates
- unknown receipt states fail closed with manual review required
- decision derivation inserted after rent webhook receipt persistence
- existing webhook HTTP responses and rentPayments updates preserved
- screening/subscription branches untouched

Guardrails preserved:
- duplicate suppression is not active
- backend/docs only
- no frontend changes
- no Trustly implementation
- no PaymentIntent persistence
- no dependency or lockfile changes
- no reconciliation-driven status transitions

Verification:
- git diff --check passed
- paymentDuplicateSuppression.test.ts passed: 5 tests
- rentPaymentWebhook.test.ts passed: 5 tests
- receipt/reconciliation tests passed: 15 tests
- payment boundary tests passed: 34 tests
- pnpm build passed under Node 20