### PR TITLE
Enforce rent payment duplicate suppression

### DIFF
--- a/docs/architecture/payment-execution-boundary-v1.md
+++ b/docs/architecture/payment-execution-boundary-v1.md
@@ -469,6 +469,63 @@ Deferred items:
 3. Provider-neutral `PaymentIntent` persistence.
 4. Trustly sandbox adapter.
 
+## Duplicate Suppression Enforcement v1
+
+Status: already-processed rent-payment provider events are suppressed before the existing rent-payment update call.
+
+What is suppressed:
+
+- Duplicate provider events whose previous receipt state was `processed`.
+- Duplicate provider events whose previous receipt state was `ignored_duplicate`.
+
+What is not suppressed:
+
+- First-time provider events.
+- Duplicate provider events whose previous receipt state was `failed`.
+- Duplicate provider events whose previous receipt state was `manual_review_required`.
+- Duplicate provider events whose previous receipt state was `processing`, `received`, missing, or unknown.
+
+Stripe acknowledgment semantics:
+
+Suppressed rent-payment duplicates still return the same Stripe-safe success acknowledgment:
+
+```json
+{ "received": true }
+```
+
+The webhook does not throw for suppressed duplicate events. Stripe retry semantics remain stable because RentChain acknowledges events it has already safely processed.
+
+Ordering:
+
+```text
+provider event
+  -> provider-event receipt persistence
+  -> duplicate-suppression decision derivation from previous receipt state
+  -> payment.provider_signal_received canonical event
+  -> read-only reconciliation derivation
+  -> paymentReconciliationRecords upsert
+  -> suppress only if previous receipt was processed/ignored_duplicate
+  -> otherwise continue existing rent-payment webhook status update
+```
+
+Why enforcement is narrow:
+
+Only receipt states that prove the provider event has already passed the existing webhook path are suppressible. Failed, manual-review, in-progress, missing, and unknown states continue through the existing path so RentChain does not accidentally hide a payment update that still needs processing.
+
+Behavior intentionally unchanged:
+
+- First-time rent-payment webhook behavior is unchanged.
+- Existing webhook HTTP response shape is unchanged.
+- Existing `rentPayments` status transition logic is unchanged for non-suppressed events.
+- Screening checkout webhook behavior is untouched.
+- SaaS subscription webhook behavior is untouched.
+
+Deferred items:
+
+1. Provider-neutral `PaymentIntent` persistence.
+2. Reconciliation-driven status transitions.
+3. Trustly sandbox adapter.
+
 ## Intentional Non-Implementation
 
 This mission intentionally does not:

--- a/rentchain-api/src/lib/payments/__tests__/paymentProviderEventReceipts.test.ts
+++ b/rentchain-api/src/lib/payments/__tests__/paymentProviderEventReceipts.test.ts
@@ -102,6 +102,11 @@ describe("paymentProviderEventReceipts", () => {
     });
 
     expect(duplicate.isDuplicate).toBe(true);
+    expect(duplicate.previousReceipt).toMatchObject({
+      status: "received",
+      duplicateCount: 0,
+      lastSeenAt: "2026-05-03T12:00:00.000Z",
+    });
     expect(duplicate.receipt).toMatchObject({
       status: "ignored_duplicate",
       duplicateCount: 1,

--- a/rentchain-api/src/lib/payments/paymentProviderEventReceipts.ts
+++ b/rentchain-api/src/lib/payments/paymentProviderEventReceipts.ts
@@ -70,6 +70,7 @@ export type ProviderEventReceiptWriteResult = {
   receiptId: string;
   isDuplicate: boolean;
   receipt: PaymentProviderEventReceipt;
+  previousReceipt?: PaymentProviderEventReceipt | null;
 };
 
 function nowIso(value?: string | null): string {
@@ -181,7 +182,7 @@ export async function markProviderEventReceived(input: ReceiptWriteInput): Promi
       metadataSummary: metadataSummary || existing.metadataSummary || null,
     };
     await ref.set(next, { merge: true });
-    return { receiptId, isDuplicate: true, receipt: next };
+    return { receiptId, isDuplicate: true, receipt: next, previousReceipt: existing };
   }
 
   const receipt: PaymentProviderEventReceipt = {
@@ -204,7 +205,7 @@ export async function markProviderEventReceived(input: ReceiptWriteInput): Promi
     metadataSummary,
   };
   await ref.set(receipt, { merge: true });
-  return { receiptId, isDuplicate: false, receipt };
+  return { receiptId, isDuplicate: false, receipt, previousReceipt: null };
 }
 
 async function markProviderEventStatus(

--- a/rentchain-api/src/routes/__tests__/rentPaymentWebhook.test.ts
+++ b/rentchain-api/src/routes/__tests__/rentPaymentWebhook.test.ts
@@ -70,7 +70,7 @@ const {
           : "provider_event_not_processed_yet",
       existingReceiptStatus: input.receipt?.status || null,
       duplicateCount: input.receipt?.duplicateCount || 0,
-      safeToAcknowledge: input.receipt?.status === "ignored_duplicate",
+      safeToAcknowledge: input.receipt?.status === "processed" || input.receipt?.status === "ignored_duplicate",
       requiresManualReview: false,
     })),
   };
@@ -313,8 +313,8 @@ describe("rent payment webhook reconciliation", () => {
     });
     expect(derivePaymentDuplicateSuppressionDecisionMock).toHaveBeenNthCalledWith(2, {
       receipt: expect.objectContaining({
-        status: "ignored_duplicate",
-        duplicateCount: 1,
+        status: "processed",
+        duplicateCount: 0,
       }),
     });
 
@@ -399,6 +399,109 @@ describe("rent payment webhook reconciliation", () => {
     expect(JSON.stringify(rentPaidEvent || {})).not.toContain("card");
     expect(JSON.stringify(rentPaidEvent || {})).not.toContain("receipt");
     expect(JSON.stringify(rentPaidEvent || {})).not.toContain("@");
+  });
+
+  it("acknowledges already-processed duplicate rent webhooks without rerunning the rent payment update", async () => {
+    constructEventMock.mockReturnValue({
+      id: "evt_rent_paid_1",
+      created: 1_714_213_200,
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_test_1",
+          payment_intent: "pi_test_1",
+          payment_status: "paid",
+          metadata: {
+            rentPaymentId: "rp-1",
+            leaseId: "lease-1",
+            tenantId: "tenant-1",
+            landlordId: "landlord-1",
+          },
+        },
+      },
+    });
+
+    const first = await invokeWebhook('{"id":"evt_rent_paid_1","type":"checkout.session.completed"}');
+    ensureCollection("rentPayments").set("rp-1", {
+      ...ensureCollection("rentPayments").get("rp-1"),
+      status: "checkout_created",
+      updatedAt: "2026-04-27T10:00:00.000Z",
+      paidAt: null,
+    });
+    const duplicate = await invokeWebhook('{"id":"evt_rent_paid_1","type":"checkout.session.completed"}');
+
+    expect(first.status).toBe(200);
+    expect(duplicate.status).toBe(200);
+    expect(ensureCollection("rentPayments").get("rp-1")).toEqual(
+      expect.objectContaining({
+        status: "checkout_created",
+        updatedAt: "2026-04-27T10:00:00.000Z",
+        paidAt: null,
+      })
+    );
+    expect(ensureCollection("paymentProviderEventReceipts").get("provider_event:stripe:evt_rent_paid_1")).toEqual(
+      expect.objectContaining({
+        status: "ignored_duplicate",
+        duplicateCount: 1,
+      })
+    );
+    expect(derivePaymentDuplicateSuppressionDecisionMock).toHaveBeenNthCalledWith(2, {
+      receipt: expect.objectContaining({
+        status: "processed",
+        duplicateCount: 0,
+      }),
+    });
+    expect(Array.from(ensureCollection("canonicalEvents").values()).filter((event: any) => event.type === "rent_payment.paid")).toHaveLength(1);
+  });
+
+  it("does not suppress duplicate rent webhooks when the previous receipt failed", async () => {
+    ensureCollection("paymentProviderEventReceipts").set("provider_event:stripe:evt_rent_paid_failed_receipt", {
+      receiptId: "provider_event:stripe:evt_rent_paid_failed_receipt",
+      idempotencyKey: "provider_event:stripe:evt_rent_paid_failed_receipt",
+      provider: "stripe",
+      providerEventId: "evt_rent_paid_failed_receipt",
+      purpose: "rent",
+      subjectType: "rent_payment",
+      subjectId: "rp-1",
+      status: "failed",
+      firstReceivedAt: "2026-04-27T10:00:00.000Z",
+      lastSeenAt: "2026-04-27T10:00:00.000Z",
+      duplicateCount: 0,
+      normalizedStatus: "confirmed",
+      rawStatus: "paid",
+    });
+    constructEventMock.mockReturnValue({
+      id: "evt_rent_paid_failed_receipt",
+      created: 1_714_213_200,
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_test_1",
+          payment_intent: "pi_test_1",
+          payment_status: "paid",
+          metadata: {
+            rentPaymentId: "rp-1",
+          },
+        },
+      },
+    });
+
+    const res = await invokeWebhook('{"id":"evt_rent_paid_failed_receipt","type":"checkout.session.completed"}');
+
+    expect(res.status).toBe(200);
+    expect(derivePaymentDuplicateSuppressionDecisionMock).toHaveBeenCalledWith({
+      receipt: expect.objectContaining({
+        status: "failed",
+        duplicateCount: 0,
+      }),
+    });
+    expect(ensureCollection("rentPayments").get("rp-1")).toEqual(
+      expect.objectContaining({
+        status: "paid",
+        processorCheckoutSessionId: "cs_test_1",
+        processorPaymentIntentId: "pi_test_1",
+      })
+    );
   });
 
   it("updates a rent payment to failed from async payment failure metadata", async () => {

--- a/rentchain-api/src/routes/stripeScreeningOrdersWebhookRoutes.ts
+++ b/rentchain-api/src/routes/stripeScreeningOrdersWebhookRoutes.ts
@@ -313,7 +313,9 @@ async function prepareRentPaymentWebhookNormalizationContext(params: {
       rawStatus: normalizedProviderEvent.rawStatus,
       metadata: normalizedProviderEvent.metadata || null,
     });
-    const duplicateSuppressionDecision = derivePaymentDuplicateSuppressionDecision({ receipt: receipt.receipt });
+    const duplicateSuppressionDecision = derivePaymentDuplicateSuppressionDecision({
+      receipt: receipt.isDuplicate ? receipt.previousReceipt || receipt.receipt : receipt.receipt,
+    });
     await writeCanonicalEvent({
       type: "payment.provider_signal_received",
       domain: "payment",
@@ -422,6 +424,16 @@ async function markRentPaymentWebhookReceiptFailed(
       message: markerErr?.message || String(markerErr),
     });
   }
+}
+
+function shouldSuppressRentPaymentWebhookUpdate(
+  context: Awaited<ReturnType<typeof prepareRentPaymentWebhookNormalizationContext>>
+): boolean {
+  return Boolean(
+    context?.receipt?.isDuplicate &&
+      context.duplicateSuppressionDecision?.shouldSuppress &&
+      context.duplicateSuppressionDecision.safeToAcknowledge
+  );
 }
 
 async function resolveOrderRefFromStripePayment(params: {
@@ -771,6 +783,9 @@ export const stripeWebhookHandler = async (req: StripeWebhookRequest, res: Respo
       const rentPaymentEvent = extractRentPaymentMetadata(event);
       if (rentPaymentEvent.rentPaymentId && rentPaymentEvent.nextStatus) {
         const receiptContext = await prepareRentPaymentWebhookNormalizationContext({ event, rentPaymentEvent });
+        if (shouldSuppressRentPaymentWebhookUpdate(receiptContext)) {
+          return res.status(200).json({ received: true });
+        }
         try {
           await updateRentPaymentFromWebhook({
             rentPaymentId: rentPaymentEvent.rentPaymentId,
@@ -967,6 +982,9 @@ export const stripeWebhookHandler = async (req: StripeWebhookRequest, res: Respo
       const rentPaymentEvent = extractRentPaymentMetadata(event);
       if (rentPaymentEvent.rentPaymentId && rentPaymentEvent.nextStatus) {
         const receiptContext = await prepareRentPaymentWebhookNormalizationContext({ event, rentPaymentEvent });
+        if (shouldSuppressRentPaymentWebhookUpdate(receiptContext)) {
+          return res.status(200).json({ received: true });
+        }
         try {
           await updateRentPaymentFromWebhook({
             rentPaymentId: rentPaymentEvent.rentPaymentId,


### PR DESCRIPTION
This PR activates duplicate suppression for rent-payment provider webhooks only.

Includes:
- suppresses repeat processing only when the previous receipt state was processed or ignored_duplicate
- preserves Stripe-safe 200 acknowledgment with `{ received: true }` for suppressed duplicates
- keeps first-time rentPayment status transitions unchanged
- does not suppress failed, manual-review, in-progress, missing, or unknown receipt states
- leaves screening/subscription branches untouched

Guardrails preserved:
- backend/docs only
- no frontend changes
- no dependency or lockfile changes
- no Trustly implementation
- no PaymentIntent persistence
- no payout, pricing, or subscription changes

Verification:
- git diff --check passed
- paymentDuplicateSuppression.test.ts passed: 5 tests
- rentPaymentWebhook.test.ts passed: 7 tests
- paymentProviderEventReceipts + reconciliation record tests passed: 10 tests
- payment boundary tests passed: 34 tests
- pnpm build passed under Node 20