### PR TITLE
Repair lease lifecycle display issues

### DIFF
--- a/rentchain-frontend/src/api/landlordLeaseRenewalApi.ts
+++ b/rentchain-frontend/src/api/landlordLeaseRenewalApi.ts
@@ -34,6 +34,8 @@ export type LandlordLeaseRenewalLease = {
   renewalNewTermType: "fixed_term" | "year_to_year" | "month_to_month" | null;
   renewalNewLeaseStartDate: string | null;
   renewalNewLeaseEndDate: string | null;
+  renewalUpdatedAt?: string | number | null;
+  updatedAt?: string | number | null;
   noticeBucket?: "expiring" | "pending-response" | "no-response";
   leaseLifecycleSummary?: LeaseLifecycleSummary;
 };

--- a/rentchain-frontend/src/components/DebugPanel.test.tsx
+++ b/rentchain-frontend/src/components/DebugPanel.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DebugPanel } from "./DebugPanel";
 import { fetchAccountLimits } from "../api/accountApi";
@@ -7,6 +8,14 @@ import { setAuthToken } from "../lib/authToken";
 vi.mock("../api/accountApi", () => ({
   fetchAccountLimits: vi.fn(),
 }));
+
+function renderDebugPanel(path = "/dashboard") {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <DebugPanel />
+    </MemoryRouter>
+  );
+}
 
 describe("DebugPanel", () => {
   beforeEach(() => {
@@ -20,7 +29,7 @@ describe("DebugPanel", () => {
   });
 
   it("stays hidden without an authenticated landlord token", () => {
-    render(<DebugPanel />);
+    renderDebugPanel();
 
     expect(screen.queryByText("Debug (dev only)")).not.toBeInTheDocument();
     expect(fetchAccountLimits).not.toHaveBeenCalled();
@@ -29,7 +38,15 @@ describe("DebugPanel", () => {
   it("stays hidden on mobile so it cannot cover bottom navigation", async () => {
     setAuthToken("demo-token");
     window.innerWidth = 390;
-    render(<DebugPanel />);
+    renderDebugPanel();
+
+    await waitFor(() => expect(fetchAccountLimits).not.toHaveBeenCalled());
+    expect(screen.queryByText("Debug (dev only)")).not.toBeInTheDocument();
+  });
+
+  it("stays hidden on public routes even when a token is present", async () => {
+    setAuthToken("demo-token");
+    renderDebugPanel("/login");
 
     await waitFor(() => expect(fetchAccountLimits).not.toHaveBeenCalled());
     expect(screen.queryByText("Debug (dev only)")).not.toBeInTheDocument();
@@ -54,7 +71,7 @@ describe("DebugPanel", () => {
       },
     });
 
-    render(<DebugPanel />);
+    renderDebugPanel();
 
     expect(await screen.findByText("Debug (dev only)")).toBeInTheDocument();
     expect(screen.getByText("Plan: elite")).toBeInTheDocument();

--- a/rentchain-frontend/src/components/DebugPanel.tsx
+++ b/rentchain-frontend/src/components/DebugPanel.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
 import { fetchAccountLimits, type AccountLimits } from "../api/accountApi";
 import { getAuthToken } from "../lib/authToken";
+import { isPublicRoutePath } from "../lib/publicRoute";
 
 const lastApiError: unknown = null;
 
@@ -12,9 +14,11 @@ function formatApiError(err: unknown) {
 }
 
 export const DebugPanel: React.FC = () => {
+  const location = useLocation();
   const [limits, setLimits] = useState<AccountLimits | null>(null);
   const [hasAuthToken, setHasAuthToken] = useState(false);
   const [isMobileViewport, setIsMobileViewport] = useState(false);
+  const isPublicRoute = isPublicRoutePath(location.pathname);
 
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -34,13 +38,13 @@ export const DebugPanel: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    if (!import.meta.env.DEV || !hasAuthToken || isMobileViewport) {
+    if (!import.meta.env.DEV || !hasAuthToken || isMobileViewport || isPublicRoute) {
       return;
     }
     fetchAccountLimits().then(setLimits).catch(() => setLimits(null));
-  }, [hasAuthToken, isMobileViewport]);
+  }, [hasAuthToken, isMobileViewport, isPublicRoute]);
 
-  if (!import.meta.env.DEV || !hasAuthToken || isMobileViewport) return null;
+  if (!import.meta.env.DEV || !hasAuthToken || isMobileViewport || isPublicRoute) return null;
 
   // Normalize data to avoid crashes when limits are missing/shape differs
   const limitsData = limits || null;

--- a/rentchain-frontend/src/components/dashboard/KpiStrip.test.tsx
+++ b/rentchain-frontend/src/components/dashboard/KpiStrip.test.tsx
@@ -36,7 +36,7 @@ describe("KpiStrip", () => {
     );
 
     const grid = container.firstElementChild as HTMLElement;
-    expect(grid).toHaveStyle({ gridTemplateColumns: "1fr", gap: "12px" });
+    expect(grid).toHaveStyle({ gridTemplateColumns: "1fr", gap: "16px" });
     expect(screen.getByText("Properties")).toBeInTheDocument();
     expect(screen.getByText("Units")).toBeInTheDocument();
   });

--- a/rentchain-frontend/src/components/dashboard/KpiStrip.test.tsx
+++ b/rentchain-frontend/src/components/dashboard/KpiStrip.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { KpiStrip } from "./KpiStrip";
+
+describe("KpiStrip", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: query === "(max-width: 767px)",
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  });
+
+  it("stacks top dashboard KPI cards with mobile spacing", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <KpiStrip
+          kpis={{
+            propertiesCount: 2,
+            unitsCount: 4,
+            tenantsCount: 3,
+            openActionsCount: 1,
+            delinquentCount: 0,
+          }}
+        />
+      </MemoryRouter>
+    );
+
+    const grid = container.firstElementChild as HTMLElement;
+    expect(grid).toHaveStyle({ gridTemplateColumns: "1fr", gap: "12px" });
+    expect(screen.getByText("Properties")).toBeInTheDocument();
+    expect(screen.getByText("Units")).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/dashboard/KpiStrip.tsx
+++ b/rentchain-frontend/src/components/dashboard/KpiStrip.tsx
@@ -43,7 +43,7 @@ export function KpiStrip({ kpis, loading, links }: Props) {
       style={{
         display: "grid",
         gridTemplateColumns: isMobile ? "1fr" : "repeat(auto-fit, minmax(140px, 1fr))",
-        gap: isMobile ? 12 : spacing.sm,
+        gap: isMobile ? 16 : spacing.sm,
         alignItems: "stretch",
       }}
     >
@@ -53,7 +53,7 @@ export function KpiStrip({ kpis, loading, links }: Props) {
           <Card
             key={item.key}
             style={{
-              padding: isMobile ? spacing.sm : spacing.md,
+              padding: isMobile ? spacing.md : spacing.md,
               border: `1px solid ${colors.border}`,
               minHeight: isMobile ? 0 : 80,
               height: "100%",

--- a/rentchain-frontend/src/components/dashboard/KpiStrip.tsx
+++ b/rentchain-frontend/src/components/dashboard/KpiStrip.tsx
@@ -42,10 +42,8 @@ export function KpiStrip({ kpis, loading, links }: Props) {
     <div
       style={{
         display: "grid",
-        gridTemplateColumns: isMobile
-          ? "repeat(2, minmax(0, 1fr))"
-          : "repeat(auto-fit, minmax(140px, 1fr))",
-        gap: spacing.sm,
+        gridTemplateColumns: isMobile ? "1fr" : "repeat(auto-fit, minmax(140px, 1fr))",
+        gap: isMobile ? 12 : spacing.sm,
         alignItems: "stretch",
       }}
     >

--- a/rentchain-frontend/src/components/layout/LandlordNav.css
+++ b/rentchain-frontend/src/components/layout/LandlordNav.css
@@ -1,6 +1,10 @@
 .rc-landlord-shell {
   min-height: 100vh;
   position: relative;
+  --rc-mobile-bottom-nav-height: 74px;
+  --rc-mobile-bottom-nav-safe-offset: calc(
+    var(--rc-mobile-bottom-nav-height) + env(safe-area-inset-bottom)
+  );
 }
 
 .rc-landlord-topnav {
@@ -226,19 +230,22 @@
   .rc-mobile-tabbar {
     display: grid;
     grid-template-columns: repeat(6, minmax(0, 1fr));
+    z-index: 70;
   }
 
   .rc-landlord-backdrop {
     z-index: 55;
+    bottom: var(--rc-mobile-bottom-nav-safe-offset);
   }
 
   .rc-landlord-drawer {
     top: auto;
     left: max(12px, env(safe-area-inset-left));
     right: max(12px, env(safe-area-inset-right));
-    bottom: calc(74px + env(safe-area-inset-bottom));
+    bottom: var(--rc-mobile-bottom-nav-safe-offset);
     width: auto;
-    max-height: min(68dvh, 560px);
+    max-height: min(calc(100vh - var(--rc-mobile-bottom-nav-safe-offset) - 24px), 560px);
+    max-height: min(calc(100dvh - var(--rc-mobile-bottom-nav-safe-offset) - 24px), 560px);
     border-radius: 20px;
     box-shadow: 0 -18px 40px rgba(15, 23, 42, 0.18);
     transform: translateY(calc(100% + 24px));

--- a/rentchain-frontend/src/components/layout/LandlordNav.css
+++ b/rentchain-frontend/src/components/layout/LandlordNav.css
@@ -1,9 +1,9 @@
 .rc-landlord-shell {
   min-height: 100vh;
   position: relative;
-  --rc-mobile-bottom-nav-height: 74px;
-  --rc-mobile-bottom-nav-safe-offset: calc(
-    var(--rc-mobile-bottom-nav-height) + env(safe-area-inset-bottom)
+  --rc-mobile-bottom-nav-height: 104px;
+  --rc-mobile-drawer-bottom-offset: calc(
+    var(--rc-mobile-bottom-nav-height) + env(safe-area-inset-bottom, 0px)
   );
 }
 
@@ -162,7 +162,7 @@
   right: 0;
   border-top: 1px solid rgba(0, 0, 0, 0.08);
   background: #ffffff;
-  padding: 8px 10px calc(8px + env(safe-area-inset-bottom));
+  padding: 8px 10px calc(8px + env(safe-area-inset-bottom, 0px));
   grid-template-columns: repeat(5, 1fr);
   z-index: 20;
 }
@@ -214,7 +214,7 @@
   }
 
   .rc-landlord-content {
-    padding: 12px max(16px, env(safe-area-inset-left)) 96px max(16px, env(safe-area-inset-right));
+    padding: 12px max(16px, env(safe-area-inset-left, 0px)) 118px max(16px, env(safe-area-inset-right, 0px));
   }
 
   .rc-landlord-content--mobile-flush {
@@ -235,17 +235,17 @@
 
   .rc-landlord-backdrop {
     z-index: 55;
-    bottom: var(--rc-mobile-bottom-nav-safe-offset);
+    bottom: var(--rc-mobile-drawer-bottom-offset);
   }
 
   .rc-landlord-drawer {
     top: auto;
-    left: max(12px, env(safe-area-inset-left));
-    right: max(12px, env(safe-area-inset-right));
-    bottom: var(--rc-mobile-bottom-nav-safe-offset);
+    left: max(12px, env(safe-area-inset-left, 0px));
+    right: max(12px, env(safe-area-inset-right, 0px));
+    bottom: var(--rc-mobile-drawer-bottom-offset);
     width: auto;
-    max-height: min(calc(100vh - var(--rc-mobile-bottom-nav-safe-offset) - 24px), 560px);
-    max-height: min(calc(100dvh - var(--rc-mobile-bottom-nav-safe-offset) - 24px), 560px);
+    max-height: min(calc(100vh - var(--rc-mobile-drawer-bottom-offset) - 16px), 560px);
+    max-height: min(calc(100dvh - var(--rc-mobile-drawer-bottom-offset) - 16px), 560px);
     border-radius: 20px;
     box-shadow: 0 -18px 40px rgba(15, 23, 42, 0.18);
     transform: translateY(calc(100% + 24px));

--- a/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
@@ -83,6 +83,20 @@ describe("LandlordNav mobile drawer", () => {
     expect(within(drawer).getByRole("button", { name: "Work Orders" })).toBeInTheDocument();
   });
 
+  it("keeps the mobile tab bar and close control available while the drawer is open", () => {
+    renderLandlordNav();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open workspace pages" }));
+
+    expect(screen.getByRole("navigation", { name: "Bottom navigation" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Open workspace pages" })).toHaveClass("active");
+    expect(
+      within(screen.getByRole("dialog", { name: "Navigation menu" })).getByRole("button", {
+        name: "Close menu",
+      })
+    ).toBeInTheDocument();
+  });
+
   it("closes the drawer on option select and route change", async () => {
     renderLandlordNav();
 

--- a/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.test.tsx
@@ -97,6 +97,16 @@ describe("LandlordNav mobile drawer", () => {
     ).toBeInTheDocument();
   });
 
+  it("uses a safe-area drawer offset so the sheet and backdrop stop above the mobile nav", () => {
+    renderLandlordNav();
+
+    const drawer = document.querySelector(".rc-landlord-drawer");
+    const backdrop = document.querySelector(".rc-landlord-backdrop");
+
+    expect(drawer).toHaveClass("rc-landlord-drawer--nav-safe");
+    expect(backdrop).toHaveClass("rc-landlord-backdrop--nav-safe");
+  });
+
   it("closes the drawer on option select and route change", async () => {
     renderLandlordNav();
 

--- a/rentchain-frontend/src/components/layout/LandlordNav.tsx
+++ b/rentchain-frontend/src/components/layout/LandlordNav.tsx
@@ -182,14 +182,14 @@ export const LandlordNav: React.FC<Props> = ({ children, unreadMessages }) => {
       </button>
 
       <div
-        className={`rc-landlord-backdrop ${drawerOpen ? "is-open" : ""}`}
+        className={`rc-landlord-backdrop rc-landlord-backdrop--nav-safe ${drawerOpen ? "is-open" : ""}`}
         onClick={() => setDrawerOpen(false)}
         aria-hidden={!drawerOpen}
       />
 
       <aside
         id="rc-landlord-drawer"
-        className={`rc-landlord-drawer ${drawerOpen ? "is-open" : ""}`}
+        className={`rc-landlord-drawer rc-landlord-drawer--nav-safe ${drawerOpen ? "is-open" : ""}`}
         role="dialog"
         aria-modal="true"
         aria-label="Navigation menu"

--- a/rentchain-frontend/src/components/leases/LeaseDocumentView.tsx
+++ b/rentchain-frontend/src/components/leases/LeaseDocumentView.tsx
@@ -1,0 +1,131 @@
+import React from "react";
+import type { LandlordActiveLease } from "@/api/leasesApi";
+
+function formatCurrency(value: number | null | undefined) {
+  const amount = typeof value === "number" ? value : 0;
+  return amount.toLocaleString(undefined, { style: "currency", currency: "CAD" });
+}
+
+function formatDate(value: string | null | undefined) {
+  if (!value) return "—";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return parsed.toLocaleDateString();
+}
+
+function prettyLeaseStatus(value: string | null | undefined) {
+  const normalized = String(value || "").trim().toLowerCase();
+  if (!normalized) return "Unknown";
+  return normalized.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function Section({ title, children }: React.PropsWithChildren<{ title: string }>) {
+  return (
+    <section style={{ display: "grid", gap: 10, paddingTop: 18, borderTop: "1px solid #e2e8f0" }}>
+      <h2 style={{ margin: 0, fontSize: 16, letterSpacing: 0, color: "#0f172a" }}>{title}</h2>
+      <div style={{ display: "grid", gap: 8 }}>{children}</div>
+    </section>
+  );
+}
+
+function Field({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div style={{ display: "grid", gap: 3 }}>
+      <div style={{ fontSize: 12, fontWeight: 700, color: "#64748b", textTransform: "uppercase", letterSpacing: 0 }}>
+        {label}
+      </div>
+      <div style={{ color: "#0f172a" }}>{value}</div>
+    </div>
+  );
+}
+
+export function LeaseDocumentView({ lease }: { lease: LandlordActiveLease }) {
+  return (
+    <article
+      data-testid="lease-document-view"
+      style={{
+        width: "min(100%, 860px)",
+        margin: "0 auto",
+        padding: "32px min(6vw, 52px)",
+        border: "1px solid #dbe4ee",
+        borderRadius: 6,
+        background: "#fff",
+        boxShadow: "0 14px 32px rgba(15,23,42,0.08)",
+        display: "grid",
+        gap: 22,
+      }}
+    >
+      <header style={{ display: "grid", gap: 8, textAlign: "center" }}>
+        <div style={{ fontSize: 12, fontWeight: 800, color: "#64748b", textTransform: "uppercase", letterSpacing: 0 }}>
+          RentChain lease record
+        </div>
+        <h1 style={{ margin: 0, fontSize: 26, letterSpacing: 0, color: "#0f172a" }}>Residential Lease Pack</h1>
+        <div style={{ color: "#475569" }}>
+          Document-style summary generated from the current landlord lease record.
+        </div>
+      </header>
+
+      <Section title="Property and Unit">
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 14 }}>
+          <Field label="Property" value={lease.propertyName || lease.propertyLabel || lease.propertyAddress || "Property"} />
+          <Field label="Unit" value={lease.unitNumber || "—"} />
+          <Field label="Lease reference" value={lease.id} />
+        </div>
+      </Section>
+
+      <Section title="Landlord and Tenant">
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 14 }}>
+          <Field label="Tenant" value={lease.tenantName || "Tenant not linked"} />
+          <Field label="Tenant email" value={lease.tenantEmail || "No email on file"} />
+          <Field label="Landlord record" value="Current RentChain landlord account" />
+        </div>
+      </Section>
+
+      <Section title="Lease Term">
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 14 }}>
+          <Field label="Start date" value={formatDate(lease.startDate)} />
+          <Field label="End date" value={formatDate(lease.endDate)} />
+          <Field label="Current status" value={prettyLeaseStatus(lease.status)} />
+        </div>
+      </Section>
+
+      <Section title="Rent and Payment Terms">
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 14 }}>
+          <Field label="Monthly rent" value={formatCurrency(lease.monthlyRent)} />
+          <Field label="Payment readiness" value={lease.paymentReadiness?.readinessLabel || "Payment readiness unavailable"} />
+          <Field
+            label="Rent collection"
+            value={lease.rentPaymentSummary?.paymentRail.enabled ? "Enabled" : "Not enabled"}
+          />
+        </div>
+        {lease.paymentReadiness?.readinessDescription ? (
+          <div style={{ color: "#475569", lineHeight: 1.5 }}>{lease.paymentReadiness.readinessDescription}</div>
+        ) : null}
+      </Section>
+
+      <Section title="Clauses and Additional Terms">
+        <div style={{ color: "#475569", lineHeight: 1.6 }}>
+          Full legal clauses remain in the attached lease document when one is available. This fallback view summarizes the
+          landlord-visible lease record so the lease is still reviewable when no separate file is attached.
+        </div>
+      </Section>
+
+      {lease.leaseExecution || lease.leaseLifecycleSummary ? (
+        <Section title="Audit and Events">
+          {lease.leaseExecution ? (
+            <div style={{ display: "grid", gap: 4 }}>
+              <strong>{lease.leaseExecution.executionLabel}</strong>
+              <span style={{ color: "#475569" }}>{lease.leaseExecution.executionDescription}</span>
+            </div>
+          ) : null}
+          {lease.leaseLifecycleSummary ? (
+            <div style={{ display: "grid", gap: 4 }}>
+              <strong>{lease.leaseLifecycleSummary.lifecycleLabel}</strong>
+              <span style={{ color: "#475569" }}>{lease.leaseLifecycleSummary.lifecycleDescription}</span>
+            </div>
+          ) : null}
+        </Section>
+      ) : null}
+    </article>
+  );
+}

--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.test.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.test.tsx
@@ -234,7 +234,7 @@ describe("PropertyDetailPanel", () => {
     );
   });
 
-  it("derives occupancy and occupied rent from canonical unit state when no active lease exists yet", async () => {
+  it("treats units without active lease records as vacant even when unit flags are stale", async () => {
     mocks.fetchUnitsForProperty.mockResolvedValue([
       {
         id: "unit-1",
@@ -272,9 +272,9 @@ describe("PropertyDetailPanel", () => {
       </MemoryRouter>
     );
 
-    expect((await screen.findAllByText("Occupied")).length).toBeGreaterThan(0);
-    expect(screen.getByText("50%")).toBeInTheDocument();
-    expect(screen.getAllByText("$1,800").length).toBeGreaterThan(0);
+    expect((await screen.findAllByText("Vacant")).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("0%").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Jane Tenant")).not.toBeInTheDocument();
   });
 
   it("renders safely when lease-backed occupancy falls back from active leases", async () => {
@@ -326,6 +326,78 @@ describe("PropertyDetailPanel", () => {
     );
 
     expect((await screen.findAllByText("Occupied")).length).toBeGreaterThan(0);
+  });
+
+  it("shows upcoming and notice-period occupancy from lease lifecycle", async () => {
+    mocks.fetchUnitsForProperty.mockResolvedValue([
+      {
+        id: "unit-future",
+        unitNumber: "201",
+        rent: 1800,
+      },
+      {
+        id: "unit-notice",
+        unitNumber: "202",
+        rent: 1900,
+      },
+    ]);
+    mocks.getLeasesForProperty.mockResolvedValue({
+      leases: [
+        {
+          id: "lease-future",
+          tenantId: "tenant-1",
+          propertyId: "prop-1",
+          unitId: "unit-future",
+          unitNumber: "201",
+          monthlyRent: 1800,
+          startDate: "2026-06-01",
+          endDate: "2027-05-31",
+          status: "active",
+          signatureStatus: "signed",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+        {
+          id: "lease-notice",
+          tenantId: "tenant-2",
+          propertyId: "prop-1",
+          unitId: "unit-notice",
+          unitNumber: "202",
+          monthlyRent: 1900,
+          startDate: "2026-01-01",
+          endDate: "2026-12-31",
+          status: "move_out_pending",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+      credibilitySummary: null,
+    });
+
+    render(
+      <MemoryRouter>
+        <PropertyDetailPanel
+          property={{
+            id: "prop-1",
+            name: "Harbour View",
+            addressLine1: "12 Wharf Street",
+            city: "Halifax",
+            province: "NS",
+            postalCode: "B3H 1A1",
+            country: "Canada",
+            totalUnits: 2,
+            amenities: [],
+            units: [],
+            createdAt: new Date().toISOString(),
+          }}
+          onRefresh={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    expect((await screen.findAllByText("Upcoming")).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Notice period").length).toBeGreaterThan(0);
+    expect(screen.getByText("50%")).toBeInTheDocument();
   });
 
   it("uses the updated archive confirmation copy before archiving", async () => {

--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.tsx
@@ -37,6 +37,10 @@ import { HalifaxRegistrySubmissionAssistant } from "@/components/properties/Hali
 import type { PropertyCredibilitySummary } from "@/types/credibilitySummary";
 import { calculateConfiguredUnitRentTotal, resolveConfiguredUnitRent } from "@/lib/propertyRentSummary";
 import { buildPropertySummaryMetrics } from "@/lib/propertySummaryMetrics";
+import {
+  deriveUnitOccupancyFromLeases,
+  type UnitOccupancyStatus,
+} from "@/lib/leases/leaseLifecycle";
 import { getUnitsNeedingOccupancySetup } from "./occupancyPrompt";
 
 interface PropertyDetailPanelProps {
@@ -53,6 +57,19 @@ interface PropertyDetailPanelProps {
 import { safeLocaleNumber } from "@/utils/format";
 
 const formatCurrency = (value: number): string => `$${safeLocaleNumber(value)}`;
+
+function unitOccupancyTone(status: UnitOccupancyStatus) {
+  if (status === "occupied") {
+    return { background: "rgba(34,197,94,0.1)", color: "#166534", dot: "#22c55e" };
+  }
+  if (status === "notice_period") {
+    return { background: "rgba(245,158,11,0.12)", color: "#92400e", dot: "#f59e0b" };
+  }
+  if (status === "upcoming") {
+    return { background: "rgba(59,130,246,0.1)", color: "#1d4ed8", dot: "#3b82f6" };
+  }
+  return { background: "rgba(248,113,113,0.08)", color: "#b91c1c", dot: "#f87171" };
+}
 
 const formatDate = (iso: string): string => {
   const d = new Date(iso);
@@ -586,23 +603,11 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
     activeLeaseRentTotal,
     currentOccupiedRentTotal,
   } = useMemo(() => buildPropertySummaryMetrics(displayedUnits, leases, unitCount), [displayedUnits, leases, unitCount]);
-  const leasedUnitIds = useMemo(
-    () => new Set(activeLeases.map((lease) => String(lease.unitId || "").trim()).filter(Boolean)),
-    [activeLeases]
-  );
-  const leasedUnitNumbers = useMemo(
-    () => new Set(activeLeases.map((lease) => String(lease.unitNumber || "").trim()).filter(Boolean)),
-    [activeLeases]
-  );
   const collectionRate =
     currentOccupiedRentTotal > 0 ? totalCollectedThisMonth / currentOccupiedRentTotal : 0;
-  const isLeaseBackedUnit = useCallback(
-    (unit: any) => {
-      const unitId = String(unit?.id || unit?.unitId || "").trim();
-      const unitNumber = String(unit?.unitNumber || unit?.label || "").trim();
-      return (unitId && leasedUnitIds.has(unitId)) || (unitNumber && leasedUnitNumbers.has(unitNumber));
-    },
-    [leasedUnitIds, leasedUnitNumbers]
+  const getUnitOccupancy = useCallback(
+    (unit: any) => deriveUnitOccupancyFromLeases(unit, leases),
+    [leases]
   );
 
   const unitsNeedingOccupancySetup = useMemo(
@@ -1105,7 +1110,7 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
             {unitCount === 0 ? "--" : `${occupancyRate.toFixed(0)}%`}
           </div>
           <div className="rc-kpi-subtext" style={{ color: "#4b5563", fontSize: "0.75rem", marginTop: 2 }}>
-            Based on units marked occupied in the unit table.
+            Based on active and notice-period lease records.
           </div>
         </div>
         <div
@@ -1164,7 +1169,7 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
             {formatCurrency(currentOccupiedRentTotal)}
           </div>
           <div className="rc-kpi-subtext" style={{ color: "#4b5563", fontSize: "0.75rem", marginTop: 2 }}>
-            Uses active lease rent when present and otherwise falls back to occupied unit rent.
+            Uses active and notice-period lease rent when present.
           </div>
         </div>
 
@@ -1446,8 +1451,22 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
                     (u as any).baths ?? (u as any).bathrooms ?? (u as any).bathroomsCount ?? null;
                   const rentVal = resolveConfiguredUnitRent(u);
                   const sqftVal = (u as any).sqft ?? null;
-                  const statusVal = (u as any).status || (isLeaseBackedUnit(u) ? "occupied" : "vacant");
-                  const isLeased = String(statusVal || "").toLowerCase() === "occupied";
+                  const occupancy = getUnitOccupancy(u);
+                  const occupancyTone = unitOccupancyTone(occupancy.status);
+                  const isLeased = occupancy.status === "occupied" || occupancy.status === "notice_period";
+                  const occupantName =
+                    isLeased || occupancy.status === "upcoming"
+                      ? String((u as any).occupantName || (occupancy.lease as any)?.tenantName || "").trim()
+                      : "";
+                  const leaseEndDate =
+                    isLeased || occupancy.status === "upcoming"
+                      ? String(
+                          (occupancy.lease as any)?.endDate ||
+                            (occupancy.lease as any)?.leaseEndDate ||
+                            (u as any).leaseEndDate ||
+                            ""
+                        ).trim()
+                      : "";
                   const rentDisplay =
                     rentVal !== null && rentVal !== undefined
                       ? formatCurrency(Number(rentVal) || 0)
@@ -1510,10 +1529,8 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
                               padding: "4px 10px",
                               borderRadius: 999,
                               border: "1px solid rgba(148,163,184,0.35)",
-                              background: isLeased
-                                ? "rgba(34,197,94,0.1)"
-                                : "rgba(248,113,113,0.08)",
-                              color: isLeased ? "#166534" : "#f87171",
+                              background: occupancyTone.background,
+                              color: occupancyTone.color,
                               fontSize: "0.8rem",
                             }}
                           >
@@ -1522,17 +1539,15 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
                                 width: 8,
                                 height: 8,
                                 borderRadius: "999px",
-                                backgroundColor: isLeased ? "#22c55e" : "#f87171",
+                                backgroundColor: occupancyTone.dot,
                               }}
                             />
-                            {isLeased ? "Occupied" : "Vacant"}
+                            {occupancy.label}
                           </span>
-                          {(u as any).occupantName ? (
+                          {occupantName ? (
                             <div style={{ fontSize: "0.8rem", color: "#475569" }}>
-                              {String((u as any).occupantName)}
-                              {(u as any).leaseEndDate
-                                ? ` · Ends ${formatDate(String((u as any).leaseEndDate))}`
-                                : ""}
+                              {occupantName}
+                              {leaseEndDate ? ` · Ends ${formatDate(leaseEndDate)}` : ""}
                             </div>
                           ) : null}
                           {(u as any).leaseDocument?.fileName ? (
@@ -1615,8 +1630,21 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
               (u as any).baths ?? (u as any).bathrooms ?? (u as any).bathroomsCount ?? null;
             const rentVal = resolveConfiguredUnitRent(u);
             const sqftVal = (u as any).sqft ?? null;
-            const statusVal = (u as any).status || (isLeaseBackedUnit(u) ? "occupied" : "vacant");
-            const isLeased = String(statusVal || "").toLowerCase() === "occupied";
+            const occupancy = getUnitOccupancy(u);
+            const isLeased = occupancy.status === "occupied" || occupancy.status === "notice_period";
+            const occupantName =
+              isLeased || occupancy.status === "upcoming"
+                ? String((u as any).occupantName || (occupancy.lease as any)?.tenantName || "").trim()
+                : "";
+            const leaseEndDate =
+              isLeased || occupancy.status === "upcoming"
+                ? String(
+                    (occupancy.lease as any)?.endDate ||
+                      (occupancy.lease as any)?.leaseEndDate ||
+                      (u as any).leaseEndDate ||
+                      ""
+                  ).trim()
+                : "";
             const rentDisplay =
               rentVal !== null && rentVal !== undefined
                 ? formatCurrency(Number(rentVal) || 0)
@@ -1654,13 +1682,11 @@ export const PropertyDetailPanel: React.FC<PropertyDetailPanelProps> = ({
                   </div>
                   <div>
                     <div className="rc-unit-label">Status</div>
-                    <div className="rc-unit-value">{isLeased ? "Occupied" : "Vacant"}</div>
-                    {(u as any).occupantName ? (
+                    <div className="rc-unit-value">{occupancy.label}</div>
+                    {occupantName ? (
                       <div style={{ fontSize: "0.8rem", color: "#475569", marginTop: 4 }}>
-                        {String((u as any).occupantName)}
-                        {(u as any).leaseEndDate
-                          ? ` · Ends ${formatDate(String((u as any).leaseEndDate))}`
-                          : ""}
+                        {occupantName}
+                        {leaseEndDate ? ` · Ends ${formatDate(leaseEndDate)}` : ""}
                       </div>
                     ) : null}
                     {(u as any).leaseDocument?.fileName ? (

--- a/rentchain-frontend/src/lib/leases/leaseLifecycle.test.ts
+++ b/rentchain-frontend/src/lib/leases/leaseLifecycle.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveLeaseLifecycleStatus,
+  deriveUnitOccupancyFromLeases,
+  getExpiringSoonLeases,
+  isLeaseCurrentlyActive,
+  isLeaseExpired,
+} from "./leaseLifecycle";
+
+const today = "2026-05-04";
+
+describe("leaseLifecycle", () => {
+  it("treats expired leases as expired instead of active", () => {
+    const lease = {
+      id: "lease-expired",
+      unitId: "unit-1",
+      status: "active",
+      startDate: "2025-05-01",
+      endDate: "2026-04-30",
+    };
+
+    expect(deriveLeaseLifecycleStatus(lease, today)).toBe("expired");
+    expect(isLeaseExpired(lease, today)).toBe(true);
+    expect(isLeaseCurrentlyActive(lease, today)).toBe(false);
+  });
+
+  it("derives active, notice-period, future, and vacant unit occupancy from leases", () => {
+    expect(
+      deriveUnitOccupancyFromLeases(
+        { id: "unit-active", unitNumber: "101", status: "vacant" },
+        [
+          {
+            id: "lease-active",
+            unitId: "unit-active",
+            status: "active",
+            startDate: "2026-01-01",
+            endDate: "2026-12-31",
+          },
+        ],
+        today
+      )
+    ).toMatchObject({ status: "occupied", label: "Occupied" });
+
+    expect(
+      deriveUnitOccupancyFromLeases(
+        { id: "unit-notice", unitNumber: "102" },
+        [
+          {
+            id: "lease-notice",
+            unitId: "unit-notice",
+            status: "move_out_pending",
+            startDate: "2026-01-01",
+            endDate: "2026-12-31",
+          },
+        ],
+        today
+      )
+    ).toMatchObject({ status: "notice_period", label: "Notice period" });
+
+    expect(
+      deriveUnitOccupancyFromLeases(
+        { id: "unit-future", unitNumber: "103" },
+        [
+          {
+            id: "lease-future",
+            unitId: "unit-future",
+            status: "active",
+            signatureStatus: "signed",
+            startDate: "2026-06-01",
+            endDate: "2027-05-31",
+          },
+        ],
+        today
+      )
+    ).toMatchObject({ status: "upcoming", label: "Upcoming" });
+
+    expect(
+      deriveUnitOccupancyFromLeases(
+        { id: "unit-stale", unitNumber: "104", status: "occupied" },
+        [
+          {
+            id: "lease-stale",
+            unitId: "unit-stale",
+            status: "active",
+            startDate: "2025-01-01",
+            endDate: "2026-04-01",
+          },
+        ],
+        today
+      )
+    ).toMatchObject({ status: "vacant", label: "Vacant" });
+  });
+
+  it("returns only currently active leases ending inside the threshold", () => {
+    const leases = [
+      {
+        id: "lease-29",
+        unitId: "unit-1",
+        status: "active",
+        startDate: "2026-01-01",
+        endDate: "2026-06-02",
+      },
+      {
+        id: "lease-60",
+        unitId: "unit-2",
+        status: "active",
+        startDate: "2026-01-01",
+        endDate: "2026-07-03",
+      },
+      {
+        id: "lease-future",
+        unitId: "unit-3",
+        status: "active",
+        signatureStatus: "signed",
+        startDate: "2026-06-01",
+        endDate: "2026-07-01",
+      },
+      {
+        id: "lease-expired",
+        unitId: "unit-4",
+        status: "active",
+        startDate: "2025-01-01",
+        endDate: "2026-05-01",
+      },
+    ];
+
+    expect(getExpiringSoonLeases(leases, today, 60).map((lease) => lease.id)).toEqual(["lease-29", "lease-60"]);
+  });
+});

--- a/rentchain-frontend/src/lib/leases/leaseLifecycle.ts
+++ b/rentchain-frontend/src/lib/leases/leaseLifecycle.ts
@@ -1,0 +1,241 @@
+export type LeaseLifecycleStatus =
+  | "draft"
+  | "pending_signature"
+  | "signed_future"
+  | "active"
+  | "notice_period"
+  | "expired"
+  | "renewed"
+  | "terminated"
+  | "cancelled";
+
+export type UnitOccupancyStatus = "vacant" | "occupied" | "notice_period" | "upcoming";
+
+export type UnitOccupancy = {
+  status: UnitOccupancyStatus;
+  label: "Vacant" | "Occupied" | "Notice period" | "Upcoming";
+  lease: LeaseLike | null;
+};
+
+export type LeaseLike = {
+  id?: string | null;
+  unitId?: string | null;
+  unitNumber?: string | null;
+  status?: string | null;
+  monthlyRent?: number | null;
+  startDate?: string | number | null;
+  leaseStartDate?: string | number | null;
+  endDate?: string | number | null;
+  leaseEndDate?: string | number | null;
+  moveOutDate?: string | number | null;
+  terminationDate?: string | number | null;
+  noticeDate?: string | number | null;
+  noticeAt?: string | number | null;
+  renewedByLeaseId?: string | null;
+  renewalLeaseId?: string | null;
+  replacedByLeaseId?: string | null;
+  signatureStatus?: string | null;
+  leaseExecution?: {
+    executionStatus?: string | null;
+    completedAt?: string | number | null;
+  } | null;
+  leaseLifecycleSummary?: {
+    lifecycleStatus?: string | null;
+    renewalOutcome?: string | null;
+  } | null;
+};
+
+type UnitLike = {
+  id?: string | null;
+  unitId?: string | null;
+  unitNumber?: string | null;
+  label?: string | null;
+  name?: string | null;
+};
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const ACTIVE_STATUSES = new Set(["active", "renewal_pending", "renewal_accepted"]);
+const NOTICE_STATUSES = new Set(["notice_pending", "move_out_pending", "ending"]);
+const EXPIRED_STATUSES = new Set(["expired", "ended", "archived"]);
+const TERMINATED_STATUSES = new Set(["terminated", "ended_early"]);
+const CANCELLED_STATUSES = new Set(["cancelled", "canceled", "void", "abandoned"]);
+const DRAFT_STATUSES = new Set(["draft"]);
+const PENDING_SIGNATURE_STATUSES = new Set([
+  "pending_signature",
+  "ready_for_tenant_signature",
+  "tenant_signed",
+  "ready_for_landlord_signature",
+  "landlord_signed",
+]);
+
+function normalize(value: unknown): string {
+  return String(value || "").trim().toLowerCase();
+}
+
+function toDay(value: string | number | Date | null | undefined): number | null {
+  if (value == null || value === "") return null;
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+}
+
+function todayDay(today: string | number | Date = new Date()): number {
+  return toDay(today) ?? toDay(new Date()) ?? Date.now();
+}
+
+function leaseStartDay(lease: LeaseLike): number | null {
+  return toDay(lease.startDate ?? lease.leaseStartDate);
+}
+
+function leaseEndDay(lease: LeaseLike): number | null {
+  return toDay(lease.endDate ?? lease.leaseEndDate);
+}
+
+function hasNoticeSignal(lease: LeaseLike): boolean {
+  const status = normalize(lease.status);
+  const lifecycleStatus = normalize(lease.leaseLifecycleSummary?.lifecycleStatus);
+  const renewalOutcome = normalize(lease.leaseLifecycleSummary?.renewalOutcome);
+  return (
+    NOTICE_STATUSES.has(status) ||
+    NOTICE_STATUSES.has(lifecycleStatus) ||
+    renewalOutcome === "tenant_quitting" ||
+    Boolean(lease.noticeDate || lease.noticeAt || lease.moveOutDate)
+  );
+}
+
+function hasSignedSignal(lease: LeaseLike): boolean {
+  const status = normalize(lease.status);
+  const executionStatus = normalize(lease.leaseExecution?.executionStatus);
+  const signatureStatus = normalize(lease.signatureStatus);
+  return (
+    ACTIVE_STATUSES.has(status) ||
+    NOTICE_STATUSES.has(status) ||
+    signatureStatus === "signed" ||
+    executionStatus === "fully_executed" ||
+    Boolean(lease.leaseExecution?.completedAt)
+  );
+}
+
+function hasRenewalReplacement(lease: LeaseLike): boolean {
+  const status = normalize(lease.status);
+  const lifecycleStatus = normalize(lease.leaseLifecycleSummary?.lifecycleStatus);
+  const renewalOutcome = normalize(lease.leaseLifecycleSummary?.renewalOutcome);
+  return (
+    Boolean(lease.renewedByLeaseId || lease.renewalLeaseId || lease.replacedByLeaseId) ||
+    lifecycleStatus === "renewed" ||
+    renewalOutcome === "renewed" ||
+    status === "renewed"
+  );
+}
+
+export function deriveLeaseLifecycleStatus(
+  lease: LeaseLike | null | undefined,
+  today: string | number | Date = new Date()
+): LeaseLifecycleStatus {
+  if (!lease) return "draft";
+
+  const status = normalize(lease.status);
+  const lifecycleStatus = normalize(lease.leaseLifecycleSummary?.lifecycleStatus);
+  const executionStatus = normalize(lease.leaseExecution?.executionStatus);
+  const currentDay = todayDay(today);
+  const startDay = leaseStartDay(lease);
+  const endDay = leaseEndDay(lease);
+
+  if (CANCELLED_STATUSES.has(status)) return "cancelled";
+  if (TERMINATED_STATUSES.has(status) || (lease.terminationDate && (toDay(lease.terminationDate) ?? Infinity) <= currentDay)) {
+    return "terminated";
+  }
+
+  const withinTerm = (startDay == null || startDay <= currentDay) && (endDay == null || endDay >= currentDay);
+  if (withinTerm && hasNoticeSignal(lease)) return "notice_period";
+  if (withinTerm && (ACTIVE_STATUSES.has(status) || hasSignedSignal(lease))) return "active";
+
+  if (startDay != null && startDay > currentDay && hasSignedSignal(lease)) return "signed_future";
+  if (endDay != null && endDay < currentDay) {
+    return hasRenewalReplacement(lease) ? "renewed" : "expired";
+  }
+  if (hasRenewalReplacement(lease) && !withinTerm) return "renewed";
+  if (EXPIRED_STATUSES.has(status) || lifecycleStatus === "expired") return "expired";
+  if (DRAFT_STATUSES.has(status) || executionStatus === "draft") return "draft";
+  if (PENDING_SIGNATURE_STATUSES.has(status) || PENDING_SIGNATURE_STATUSES.has(executionStatus)) return "pending_signature";
+  if (hasSignedSignal(lease)) return startDay != null && startDay > currentDay ? "signed_future" : "active";
+
+  return "draft";
+}
+
+export function isLeaseCurrentlyActive(lease: LeaseLike | null | undefined, today: string | number | Date = new Date()) {
+  const status = deriveLeaseLifecycleStatus(lease, today);
+  return status === "active" || status === "notice_period";
+}
+
+export function isLeaseExpired(lease: LeaseLike | null | undefined, today: string | number | Date = new Date()) {
+  return deriveLeaseLifecycleStatus(lease, today) === "expired";
+}
+
+function unitIdentifiers(unit: UnitLike): string[] {
+  return Array.from(
+    new Set(
+      [unit.id, unit.unitId, unit.unitNumber, unit.label, unit.name]
+        .map((value) => String(value || "").trim().toLowerCase())
+        .filter(Boolean)
+    )
+  );
+}
+
+function leaseIdentifiers(lease: LeaseLike): string[] {
+  return Array.from(
+    new Set(
+      [lease.unitId, lease.unitNumber]
+        .map((value) => String(value || "").trim().toLowerCase())
+        .filter(Boolean)
+    )
+  );
+}
+
+export function leasesForUnit(unit: UnitLike, leases: LeaseLike[]): LeaseLike[] {
+  const ids = new Set(unitIdentifiers(unit));
+  if (!ids.size) return [];
+  return (Array.isArray(leases) ? leases : []).filter((lease) =>
+    leaseIdentifiers(lease).some((identifier) => ids.has(identifier))
+  );
+}
+
+export function deriveUnitOccupancyFromLeases(
+  unit: UnitLike,
+  leases: LeaseLike[],
+  today: string | number | Date = new Date()
+): UnitOccupancy {
+  const matchedLeases = leasesForUnit(unit, leases);
+  const withLifecycle = matchedLeases.map((lease) => ({
+    lease,
+    status: deriveLeaseLifecycleStatus(lease, today),
+  }));
+
+  const notice = withLifecycle.find((item) => item.status === "notice_period");
+  if (notice) return { status: "notice_period", label: "Notice period", lease: notice.lease };
+
+  const active = withLifecycle.find((item) => item.status === "active");
+  if (active) return { status: "occupied", label: "Occupied", lease: active.lease };
+
+  const upcoming = withLifecycle.find((item) => item.status === "signed_future");
+  if (upcoming) return { status: "upcoming", label: "Upcoming", lease: upcoming.lease };
+
+  return { status: "vacant", label: "Vacant", lease: null };
+}
+
+export function getExpiringSoonLeases(
+  leases: LeaseLike[],
+  today: string | number | Date = new Date(),
+  thresholdDays = 60
+): LeaseLike[] {
+  const currentDay = todayDay(today);
+  return (Array.isArray(leases) ? leases : []).filter((lease) => {
+    const lifecycle = deriveLeaseLifecycleStatus(lease, today);
+    if (lifecycle !== "active" && lifecycle !== "notice_period") return false;
+    const endDay = leaseEndDay(lease);
+    if (endDay == null || endDay < currentDay) return false;
+    const daysUntilEnd = Math.floor((endDay - currentDay) / DAY_MS);
+    return daysUntilEnd <= thresholdDays;
+  });
+}

--- a/rentchain-frontend/src/lib/propertySummaryMetrics.test.ts
+++ b/rentchain-frontend/src/lib/propertySummaryMetrics.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { buildPropertySummaryMetrics } from "./propertySummaryMetrics";
 
 describe("buildPropertySummaryMetrics", () => {
-  it("keeps leased units lease-based while occupancy stays unit-based", () => {
+  it("derives occupancy and rent from active lease lifecycle instead of stale unit status", () => {
     const metrics = buildPropertySummaryMetrics(
       [
         {
@@ -32,12 +32,48 @@ describe("buildPropertySummaryMetrics", () => {
           updatedAt: "2026-01-01T00:00:00.000Z",
         },
       ],
-      2
+      2,
+      "2026-05-04"
     );
 
     expect(metrics.leasedUnits).toHaveLength(1);
     expect(metrics.occupancyRate).toBe(50);
     expect(metrics.activeLeaseRentTotal).toBe(1900);
-    expect(metrics.currentOccupiedRentTotal).toBe(1800);
+    expect(metrics.currentOccupiedRentTotal).toBe(1900);
+  });
+
+  it("does not count expired leases or stale occupied flags as occupied", () => {
+    const metrics = buildPropertySummaryMetrics(
+      [
+        {
+          id: "unit-1",
+          unitNumber: "101",
+          status: "occupied",
+          rent: 1800,
+        },
+      ],
+      [
+        {
+          id: "lease-expired",
+          tenantId: "tenant-1",
+          propertyId: "prop-1",
+          unitId: "unit-1",
+          unitNumber: "101",
+          monthlyRent: 1800,
+          startDate: "2025-01-01",
+          endDate: "2025-12-31",
+          status: "active",
+          createdAt: "2025-01-01T00:00:00.000Z",
+          updatedAt: "2025-01-01T00:00:00.000Z",
+        },
+      ],
+      1,
+      "2026-05-04"
+    );
+
+    expect(metrics.leasedUnits).toHaveLength(0);
+    expect(metrics.occupancyRate).toBe(0);
+    expect(metrics.activeLeaseRentTotal).toBe(0);
+    expect(metrics.currentOccupiedRentTotal).toBe(0);
   });
 });

--- a/rentchain-frontend/src/lib/propertySummaryMetrics.ts
+++ b/rentchain-frontend/src/lib/propertySummaryMetrics.ts
@@ -1,49 +1,11 @@
 import type { Lease } from "@/api/leasesApi";
+import {
+  deriveUnitOccupancyFromLeases,
+  isLeaseCurrentlyActive,
+} from "@/lib/leases/leaseLifecycle";
 import { resolveConfiguredUnitRent } from "@/lib/propertyRentSummary";
 
-const ACTIVE_LEASE_STATUSES = new Set([
-  "active",
-  "notice_pending",
-  "renewal_pending",
-  "renewal_accepted",
-  "move_out_pending",
-]);
-
 type UnitLike = Record<string, unknown>;
-
-function normalizeString(value: unknown): string {
-  return String(value || "").trim();
-}
-
-function unitIdentifiers(unit: UnitLike): string[] {
-  const values = [
-    normalizeString(unit.id),
-    normalizeString(unit.unitId),
-    normalizeString(unit.unitNumber),
-    normalizeString(unit.label),
-  ].filter(Boolean);
-  return Array.from(new Set(values));
-}
-
-function leaseIdentifiers(lease: Lease): string[] {
-  const values = [normalizeString(lease.unitId), normalizeString(lease.unitNumber)].filter(Boolean);
-  return Array.from(new Set(values));
-}
-
-function isOccupiedUnit(unit: UnitLike): boolean {
-  const status = normalizeString(unit.occupancyStatus || unit.status).toLowerCase();
-  return status === "occupied";
-}
-
-function isActiveLease(lease: Lease): boolean {
-  return ACTIVE_LEASE_STATUSES.has(normalizeString(lease.status).toLowerCase());
-}
-
-function getMatchingActiveLeases(unit: UnitLike, activeLeases: Lease[]): Lease[] {
-  const ids = new Set(unitIdentifiers(unit));
-  if (!ids.size) return [];
-  return activeLeases.filter((lease) => leaseIdentifiers(lease).some((identifier) => ids.has(identifier)));
-}
 
 export type PropertySummaryMetrics = {
   activeLeases: Lease[];
@@ -54,28 +16,34 @@ export type PropertySummaryMetrics = {
   currentOccupiedRentTotal: number;
 };
 
-export function buildPropertySummaryMetrics(units: UnitLike[], leases: Lease[], unitCount: number): PropertySummaryMetrics {
+export function buildPropertySummaryMetrics(
+  units: UnitLike[],
+  leases: Lease[],
+  unitCount: number,
+  today: string | number | Date = new Date()
+): PropertySummaryMetrics {
   const displayedUnits = Array.isArray(units) ? units : [];
-  const activeLeases = (Array.isArray(leases) ? leases : []).filter(isActiveLease);
-  const occupiedUnits = displayedUnits.filter(isOccupiedUnit);
-  const leasedUnits = displayedUnits.filter((unit) => getMatchingActiveLeases(unit, activeLeases).length > 0);
+  const activeLeases = (Array.isArray(leases) ? leases : []).filter((lease) => isLeaseCurrentlyActive(lease, today));
+  const occupancyByUnit = displayedUnits.map((unit) => ({
+    unit,
+    occupancy: deriveUnitOccupancyFromLeases(unit, leases, today),
+  }));
+  const occupiedUnits = occupancyByUnit
+    .filter((item) => item.occupancy.status === "occupied" || item.occupancy.status === "notice_period")
+    .map((item) => item.unit);
+  const leasedUnits = occupiedUnits;
   const occupancyRate = unitCount > 0 ? (occupiedUnits.length / unitCount) * 100 : 0;
   const activeLeaseRentTotal = activeLeases.reduce(
     (sum, lease) => sum + (typeof lease.monthlyRent === "number" ? lease.monthlyRent : 0),
     0
   );
-  const currentOccupiedRentTotal = occupiedUnits.reduce((sum, unit) => {
-    const matchingLeases = getMatchingActiveLeases(unit, activeLeases);
-    if (matchingLeases.length > 0) {
-      return (
-        sum +
-        matchingLeases.reduce(
-          (leaseSum, lease) => leaseSum + (typeof lease.monthlyRent === "number" ? lease.monthlyRent : 0),
-          0
-        )
-      );
-    }
-    return sum + (resolveConfiguredUnitRent(unit) ?? 0);
+  const currentOccupiedRentTotal = occupancyByUnit.reduce((sum, item) => {
+    if (item.occupancy.status !== "occupied" && item.occupancy.status !== "notice_period") return sum;
+    const rentFromLease =
+      typeof item.occupancy.lease?.monthlyRent === "number"
+        ? item.occupancy.lease.monthlyRent
+        : null;
+    return sum + (rentFromLease ?? resolveConfiguredUnitRent(item.unit) ?? 0);
   }, 0);
 
   return {

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.test.tsx
@@ -1,6 +1,6 @@
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import ApplicationReviewSummaryPage from "./ApplicationReviewSummaryPage";
 
 vi.mock("@/hooks/useEntitlements", () => ({
@@ -25,6 +25,11 @@ vi.mock("../components/ui/ToastProvider", () => ({
 vi.mock("@/components/billing/LockedFeature", () => ({
   LockedFeature: ({ title }: { title: string }) => <div>{title}</div>,
 }));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
 
 function renderPage() {
   return render(
@@ -155,9 +160,8 @@ describe("ApplicationReviewSummaryPage", () => {
     renderPage();
 
     expect(await screen.findByText("Application Review Summary")).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Overview" })).toHaveAttribute("aria-selected", "true");
     expect(await screen.findByText("Intake Summary")).toBeInTheDocument();
-    expect(await screen.findByText("Follow-up resolution")).toBeInTheDocument();
-    expect((await screen.findAllByText("Decision workspace")).length).toBeGreaterThan(0);
     expect(await screen.findByText("Shared package categories")).toBeInTheDocument();
     expect(await screen.findByText("Recent activity")).toBeInTheDocument();
     expect(screen.getAllByText("Profile details").length).toBeGreaterThan(0);
@@ -165,13 +169,34 @@ describe("ApplicationReviewSummaryPage", () => {
     expect(screen.getAllByText("Documents & records").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Consent / identity status").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Application readiness").length).toBeGreaterThan(0);
-    expect((await screen.findAllByText("Partly addressed")).length).toBeGreaterThan(0);
     expect(await screen.findByText("Application readiness updated")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Activity" }));
+    expect(screen.getByRole("tab", { name: "Activity" })).toHaveAttribute("aria-selected", "true");
+    expect(await screen.findByText("Follow-up resolution")).toBeInTheDocument();
+    expect((await screen.findAllByText("Partly addressed")).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("Next steps")).length).toBeGreaterThan(0);
     expect(await screen.findByText("Structured follow-up loop")).toBeInTheDocument();
     expect(screen.getAllByText(/Review the addressed categories now visible/i).length).toBeGreaterThan(0);
     expect(await screen.findByText("Still needs follow-up")).toBeInTheDocument();
     expect(await screen.findByText("Now appears addressed")).toBeInTheDocument();
+    expect(await screen.findByText("Recent updates")).toBeInTheDocument();
+    expect(await screen.findByText(/Tenant updated follow-up items/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Follow-up stays organized by aligned package categories/i)).toBeInTheDocument();
+    expect(await screen.findByText("Portability summary")).toBeInTheDocument();
+    expect(await screen.findByText("Network reuse")).toBeInTheDocument();
+    expect(await screen.findByText("Ready to reuse")).toBeInTheDocument();
+    expect(await screen.findByText("Tenant-approved reusable application path is available")).toBeInTheDocument();
+    expect(await screen.findByText("RentChain application")).toBeInTheDocument();
+    expect(await screen.findByText("Identity and reusable application context are already in scope for this review path.")).toBeInTheDocument();
+    expect(await screen.findByText("Identity and application summaries approved")).toBeInTheDocument();
+    expect(await screen.findByText("Additional approval may unlock more")).toBeInTheDocument();
+    expect(await screen.findByText("No")).toBeInTheDocument();
+    expect(await screen.findByText("Use this as review context only. It does not expand landlord access or permissions.")).toBeInTheDocument();
+    expect(await screen.findByText("Reusable across applications")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Decision" }));
+    expect(await screen.findByText("Decision workspace")).toBeInTheDocument();
     expect(await screen.findByText("Decision status")).toBeInTheDocument();
     expect(await screen.findByText("What is still missing")).toBeInTheDocument();
     expect(await screen.findByText(/This application is not ready for a landlord next-step decision yet/i)).toBeInTheDocument();
@@ -199,28 +224,14 @@ describe("ApplicationReviewSummaryPage", () => {
     expect((await screen.findAllByText("Next actor")).length).toBeGreaterThan(0);
     expect(await screen.findByText("Deposit / first payment")).toBeInTheDocument();
     expect(await screen.findByText("Payment status")).toBeInTheDocument();
-    expect(await screen.findByText("Recent updates")).toBeInTheDocument();
-    expect(await screen.findByText(/Tenant updated follow-up items/i)).toBeInTheDocument();
-    expect(await screen.findByText(/Follow-up stays organized by aligned package categories/i)).toBeInTheDocument();
-    expect(await screen.findByText("Shared with tenant permission and current server-authorized review access.")).toBeInTheDocument();
-    expect(await screen.findByText("Jane Applicant")).toBeInTheDocument();
     expect(await screen.findByText("Landlord Decision Panel")).toBeInTheDocument();
     expect(await screen.findByText("Identity verification completed")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Screening" }));
     expect(await screen.findByText("Trust guidance")).toBeInTheDocument();
     expect(await screen.findByText("Credibility summary")).toBeInTheDocument();
-    expect(await screen.findByText("Portability summary")).toBeInTheDocument();
-    expect(await screen.findByText("Network reuse")).toBeInTheDocument();
     expect(await screen.findByText("Credibility established")).toBeInTheDocument();
     expect(await screen.findByText("Most credibility signals are available in the current record.")).toBeInTheDocument();
-    expect(await screen.findByText("Ready to reuse")).toBeInTheDocument();
-    expect(await screen.findByText("Tenant-approved reusable application path is available")).toBeInTheDocument();
-    expect(await screen.findByText("RentChain application")).toBeInTheDocument();
-    expect(await screen.findByText("Identity and reusable application context are already in scope for this review path.")).toBeInTheDocument();
-    expect(await screen.findByText("Identity and application summaries approved")).toBeInTheDocument();
-    expect(await screen.findByText("Additional approval may unlock more")).toBeInTheDocument();
-    expect(await screen.findByText("No")).toBeInTheDocument();
-    expect(await screen.findByText("Use this as review context only. It does not expand landlord access or permissions.")).toBeInTheDocument();
-    expect(await screen.findByText("Reusable across applications")).toBeInTheDocument();
     expect((await screen.findAllByText("Ready for review")).length).toBeGreaterThan(0);
     expect(await screen.findByText("Application information is mostly complete.")).toBeInTheDocument();
     expect(await screen.findByText("Employment or income details are still incomplete.")).toBeInTheDocument();
@@ -296,6 +307,7 @@ describe("ApplicationReviewSummaryPage", () => {
 
     renderPage();
 
+    fireEvent.click(await screen.findByRole("tab", { name: "Decision" }));
     expect((await screen.findAllByText("Decision workspace")).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("Ready for decision")).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("Ready for next step")).length).toBeGreaterThan(0);
@@ -381,6 +393,7 @@ describe("ApplicationReviewSummaryPage", () => {
 
     renderPage();
 
+    fireEvent.click(await screen.findByRole("tab", { name: "Decision" }));
     expect((await screen.findAllByText("Decision workspace")).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("Hold for later")).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("Not ready for lease step")).length).toBeGreaterThan(0);

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
@@ -36,6 +36,15 @@ import { buildLandlordStructuredNotificationTriggers } from "./structuredNotific
 import { resolveRequiredPlanLabel } from "@/lib/upgradePrompt";
 import { buildLandlordNetworkReuseCopy } from "../lib/reuse/landlordNetworkReuseCopy";
 
+type ReviewSummaryTab = "overview" | "screening" | "decision" | "activity";
+
+const reviewSummaryTabs: Array<{ id: ReviewSummaryTab; label: string }> = [
+  { id: "overview", label: "Overview" },
+  { id: "screening", label: "Screening" },
+  { id: "decision", label: "Decision" },
+  { id: "activity", label: "Activity" },
+];
+
 function money(cents: number | null): string {
   if (cents == null || !Number.isFinite(cents)) return "Not provided";
   return (cents / 100).toLocaleString(undefined, { style: "currency", currency: "CAD" });
@@ -321,6 +330,7 @@ function ApplicationReviewSummaryPageBody() {
   const [summary, setSummary] = useState<ApplicationReviewSummary | null>(null);
   const [evaluatingRisk, setEvaluatingRisk] = useState(false);
   const [savingDecision, setSavingDecision] = useState(false);
+  const [activeReviewTab, setActiveReviewTab] = useState<ReviewSummaryTab>("overview");
 
   const loadSummary = React.useCallback(async () => {
     if (!entitlements.canViewReviewSummary) {
@@ -618,6 +628,53 @@ function ApplicationReviewSummaryPageBody() {
 
       {!loading && !error && summary ? (
         <>
+          <div
+            role="tablist"
+            aria-label="Review summary sections"
+            style={{
+              display: "flex",
+              gap: 8,
+              flexWrap: "wrap",
+              padding: 6,
+              border: `1px solid ${colors.border}`,
+              borderRadius: 12,
+              background: "#f8fafc",
+            }}
+          >
+            {reviewSummaryTabs.map((tab) => {
+              const selected = activeReviewTab === tab.id;
+              return (
+                <button
+                  key={tab.id}
+                  type="button"
+                  role="tab"
+                  aria-selected={selected}
+                  aria-controls={`review-summary-panel-${tab.id}`}
+                  id={`review-summary-tab-${tab.id}`}
+                  onClick={() => setActiveReviewTab(tab.id)}
+                  style={{
+                    border: `1px solid ${selected ? "rgba(37,99,235,0.45)" : "transparent"}`,
+                    borderRadius: 10,
+                    background: selected ? "#ffffff" : "transparent",
+                    color: selected ? text.main : text.subtle,
+                    fontWeight: 800,
+                    padding: "8px 12px",
+                    cursor: "pointer",
+                  }}
+                >
+                  {tab.label}
+                </button>
+              );
+            })}
+          </div>
+
+          {activeReviewTab === "overview" ? (
+            <div
+              role="tabpanel"
+              id="review-summary-panel-overview"
+              aria-labelledby="review-summary-tab-overview"
+              style={{ display: "grid", gap: 12 }}
+            >
           {intakeView ? (
             <Card style={{ display: "grid", gap: 12 }}>
               <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
@@ -782,6 +839,59 @@ function ApplicationReviewSummaryPageBody() {
             </Card>
           ) : null}
 
+          <Card style={{ display: "grid", gap: 8 }}>
+            <div style={{ fontWeight: 700 }}>Applicant Overview</div>
+            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 8 }}>
+              {kv("Name", summary.applicant.name || "Not provided")}
+              {kv("Email", summary.applicant.email || "Not provided")}
+              {kv(
+                "Address",
+                [
+                  summary.applicant.currentAddressLine,
+                  summary.applicant.city,
+                  summary.applicant.provinceState,
+                  summary.applicant.postalCode,
+                  summary.applicant.country,
+                ]
+                  .filter(Boolean)
+                  .join(", ") || "Not provided"
+              )}
+              {kv(
+                "Time at current address",
+                summary.applicant.timeAtCurrentAddressMonths != null
+                  ? `${summary.applicant.timeAtCurrentAddressMonths} months`
+                  : "Not provided"
+              )}
+              {kv("Current rent", money(summary.applicant.currentRentAmountCents))}
+            </div>
+          </Card>
+
+          <Card style={{ display: "grid", gap: 8 }}>
+            <div style={{ fontWeight: 700 }}>Employment & Income</div>
+            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 8 }}>
+              {kv("Employer", summary.employment.employerName || "Not provided")}
+              {kv("Job title", summary.employment.jobTitle || "Not provided")}
+              {kv("Income", money(summary.employment.incomeAmountCents))}
+              {kv("Income frequency", summary.employment.incomeFrequency || "Not provided")}
+              {kv("Income monthly (derived)", money(summary.employment.incomeMonthlyCents))}
+              {kv(
+                "Months at current job",
+                summary.employment.monthsAtJob != null ? String(summary.employment.monthsAtJob) : "Not provided"
+              )}
+              {kv("Work reference name", summary.reference.name || "Not provided")}
+              {kv("Work reference phone", summary.reference.phone || "Not provided")}
+            </div>
+          </Card>
+            </div>
+          ) : null}
+
+          {activeReviewTab === "activity" ? (
+            <div
+              role="tabpanel"
+              id="review-summary-panel-activity"
+              aria-labelledby="review-summary-tab-activity"
+              style={{ display: "grid", gap: 12 }}
+            >
           {guidanceView && interactionLoop && resolutionView ? (
             <Card style={{ display: "grid", gap: 10 }}>
               <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
@@ -886,6 +996,74 @@ function ApplicationReviewSummaryPageBody() {
             </Card>
           ) : null}
 
+          {structuredNotifications.length ? (
+            <Card style={{ display: "grid", gap: 8 }}>
+              <StructuredNotificationList
+                heading="Recent updates"
+                emptyLabel="Recent workflow-triggered review updates will appear here as the package changes."
+                items={structuredNotifications}
+              />
+            </Card>
+          ) : null}
+
+          {summary.portableIdentitySummary ? (
+            <Card style={{ display: "grid", gap: 8 }}>
+              <div style={{ fontWeight: 700 }}>Portability summary</div>
+              <div style={{ fontSize: 13, color: text.subtle }}>
+                {summary.portableIdentitySummary.portabilityDescription}
+              </div>
+              <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 8 }}>
+                {kv("Status", summary.portableIdentitySummary.portabilityLabel)}
+                {kv(
+                  "Reusable across applications",
+                  summary.portableIdentitySummary.reusableAcrossApplications ? "Yes" : "Not yet"
+                )}
+              </div>
+            </Card>
+          ) : null}
+
+          {summary.networkReuseSummary ? (
+            <Card style={{ display: "grid", gap: 8 }}>
+              {(() => {
+                const networkReuseCopy = buildLandlordNetworkReuseCopy(summary.networkReuseSummary);
+                return (
+                  <>
+              <div style={{ fontWeight: 700 }}>Network reuse</div>
+              <div style={{ fontSize: 13, color: text.subtle }}>
+                {networkReuseCopy.description}
+              </div>
+              <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 8 }}>
+                {kv("Status", networkReuseCopy.headline)}
+                {kv("Source", networkReuseCopy.sourceLabel)}
+                {kv("Consent required", summary.networkReuseSummary.consentRequired ? "Yes" : "No")}
+                {kv(
+                  "Approved reuse support",
+                  networkReusePathSupportLabel(
+                    summary.networkReuseSummary.identitySummaryApproved,
+                    summary.networkReuseSummary.applicationSummaryApproved
+                  )
+                )}
+                {kv(
+                  "Additional approval may unlock more",
+                  summary.networkReuseSummary.additionalConsentMayUnlock ? "Yes" : "No"
+                )}
+              </div>
+              <div style={{ fontSize: 12, color: text.subtle }}>{networkReuseCopy.guardrailCopy}</div>
+                  </>
+                );
+              })()}
+            </Card>
+          ) : null}
+            </div>
+          ) : null}
+
+          {activeReviewTab === "decision" ? (
+            <div
+              role="tabpanel"
+              id="review-summary-panel-decision"
+              aria-labelledby="review-summary-tab-decision"
+              style={{ display: "grid", gap: 12 }}
+            >
           {decisionWorkspace ? (
             <Card style={{ display: "grid", gap: 10 }}>
               <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
@@ -1616,13 +1794,75 @@ function ApplicationReviewSummaryPageBody() {
             </Card>
           ) : null}
 
-          {structuredNotifications.length ? (
+          <ApplicationDecisionSummaryCard
+            summary={summary.decisionSummary || null}
+            onEvaluateRisk={handleEvaluateRisk}
+            evaluatingRisk={evaluatingRisk}
+            onDecision={handleDecision}
+            submittingDecision={savingDecision}
+          />
+
+          <Card style={{ display: "grid", gap: 6 }}>
+            <div style={{ fontWeight: 700 }}>Insights</div>
+            {summary.insights.length ? (
+              <ul style={{ margin: 0, paddingLeft: 20, color: text.main }}>
+                {summary.insights.map((line) => (
+                  <li key={line}>{line}</li>
+                ))}
+              </ul>
+            ) : (
+              <div style={{ color: text.subtle }}>No insights available.</div>
+            )}
+            <div style={{ fontSize: 12, color: text.subtle }}>
+              This summary is descriptive and does not provide approval/denial recommendations.
+            </div>
+          </Card>
+            </div>
+          ) : null}
+
+          {activeReviewTab === "screening" ? (
+            <div
+              role="tabpanel"
+              id="review-summary-panel-screening"
+              aria-labelledby="review-summary-tab-screening"
+              style={{ display: "grid", gap: 12 }}
+            >
+          <Card style={{ display: "grid", gap: 8 }}>
+            <div style={{ fontWeight: 700 }}>Screening & Compliance</div>
+            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 8 }}>
+              {kv("Screening status", summary.screening.status || "not_run")}
+              {kv("Screening provider", summary.screening.provider || "Not provided")}
+              {kv("Reference ID", summary.screening.referenceId || "Not provided")}
+              {kv(
+                "Completeness",
+                `${summary.derived.completeness.label} (${Math.round(summary.derived.completeness.score * 100)}%)`
+              )}
+              {kv("Income-to-rent ratio", ratio(summary.derived.incomeToRentRatio))}
+              {kv("Consent version", summary.compliance.applicationConsentVersion || "Not provided")}
+              {kv("Consent accepted at", dateOr(summary.compliance.applicationConsentAcceptedAt))}
+              {kv("Signature type", summary.compliance.signatureType || "Not provided")}
+              {kv("Signed at", dateOr(summary.compliance.signedAt))}
+            </div>
+            {summary.derived.flags.length ? (
+              <div style={{ fontSize: 13, color: text.subtle }}>
+                Flags: {summary.derived.flags.join(", ")}
+              </div>
+            ) : (
+              <div style={{ fontSize: 13, color: text.subtle }}>Flags: none</div>
+            )}
+          </Card>
+
+          {summary.tenantCredibilitySummary ? (
             <Card style={{ display: "grid", gap: 8 }}>
-              <StructuredNotificationList
-                heading="Recent updates"
-                emptyLabel="Recent workflow-triggered review updates will appear here as the package changes."
-                items={structuredNotifications}
-              />
+              <div style={{ fontWeight: 700 }}>Credibility summary</div>
+              <div style={{ fontSize: 13, color: text.subtle }}>
+                {summary.tenantCredibilitySummary.summaryDescription}
+              </div>
+              <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 8 }}>
+                {kv("Summary", summary.tenantCredibilitySummary.summaryLabel)}
+                {kv("Completeness level", summary.tenantCredibilitySummary.completenessLevel)}
+                {kv("Verification level", summary.tenantCredibilitySummary.verificationLevel)}
+              </div>
             </Card>
           ) : null}
 
@@ -1718,162 +1958,8 @@ function ApplicationReviewSummaryPageBody() {
               </div>
             </Card>
           ) : null}
-
-          {summary.tenantCredibilitySummary ? (
-            <Card style={{ display: "grid", gap: 8 }}>
-              <div style={{ fontWeight: 700 }}>Credibility summary</div>
-              <div style={{ fontSize: 13, color: text.subtle }}>
-                {summary.tenantCredibilitySummary.summaryDescription}
-              </div>
-              <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 8 }}>
-                {kv("Summary", summary.tenantCredibilitySummary.summaryLabel)}
-                {kv("Completeness level", summary.tenantCredibilitySummary.completenessLevel)}
-                {kv("Verification level", summary.tenantCredibilitySummary.verificationLevel)}
-              </div>
-            </Card>
+            </div>
           ) : null}
-
-          {summary.portableIdentitySummary ? (
-            <Card style={{ display: "grid", gap: 8 }}>
-              <div style={{ fontWeight: 700 }}>Portability summary</div>
-              <div style={{ fontSize: 13, color: text.subtle }}>
-                {summary.portableIdentitySummary.portabilityDescription}
-              </div>
-              <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 8 }}>
-                {kv("Status", summary.portableIdentitySummary.portabilityLabel)}
-                {kv(
-                  "Reusable across applications",
-                  summary.portableIdentitySummary.reusableAcrossApplications ? "Yes" : "Not yet"
-                )}
-              </div>
-            </Card>
-          ) : null}
-
-          {summary.networkReuseSummary ? (
-            <Card style={{ display: "grid", gap: 8 }}>
-              {(() => {
-                const networkReuseCopy = buildLandlordNetworkReuseCopy(summary.networkReuseSummary);
-                return (
-                  <>
-              <div style={{ fontWeight: 700 }}>Network reuse</div>
-              <div style={{ fontSize: 13, color: text.subtle }}>
-                {networkReuseCopy.description}
-              </div>
-              <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 8 }}>
-                {kv("Status", networkReuseCopy.headline)}
-                {kv("Source", networkReuseCopy.sourceLabel)}
-                {kv("Consent required", summary.networkReuseSummary.consentRequired ? "Yes" : "No")}
-                {kv(
-                  "Approved reuse support",
-                  networkReusePathSupportLabel(
-                    summary.networkReuseSummary.identitySummaryApproved,
-                    summary.networkReuseSummary.applicationSummaryApproved
-                  )
-                )}
-                {kv(
-                  "Additional approval may unlock more",
-                  summary.networkReuseSummary.additionalConsentMayUnlock ? "Yes" : "No"
-                )}
-              </div>
-              <div style={{ fontSize: 12, color: text.subtle }}>{networkReuseCopy.guardrailCopy}</div>
-                  </>
-                );
-              })()}
-            </Card>
-          ) : null}
-
-          <Card style={{ display: "grid", gap: 8 }}>
-            <div style={{ fontWeight: 700 }}>Applicant Overview</div>
-            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 8 }}>
-              {kv("Name", summary.applicant.name || "Not provided")}
-              {kv("Email", summary.applicant.email || "Not provided")}
-              {kv(
-                "Address",
-                [
-                  summary.applicant.currentAddressLine,
-                  summary.applicant.city,
-                  summary.applicant.provinceState,
-                  summary.applicant.postalCode,
-                  summary.applicant.country,
-                ]
-                  .filter(Boolean)
-                  .join(", ") || "Not provided"
-              )}
-              {kv(
-                "Time at current address",
-                summary.applicant.timeAtCurrentAddressMonths != null
-                  ? `${summary.applicant.timeAtCurrentAddressMonths} months`
-                  : "Not provided"
-              )}
-              {kv("Current rent", money(summary.applicant.currentRentAmountCents))}
-            </div>
-          </Card>
-
-          <Card style={{ display: "grid", gap: 8 }}>
-            <div style={{ fontWeight: 700 }}>Employment & Income</div>
-            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 8 }}>
-              {kv("Employer", summary.employment.employerName || "Not provided")}
-              {kv("Job title", summary.employment.jobTitle || "Not provided")}
-              {kv("Income", money(summary.employment.incomeAmountCents))}
-              {kv("Income frequency", summary.employment.incomeFrequency || "Not provided")}
-              {kv("Income monthly (derived)", money(summary.employment.incomeMonthlyCents))}
-              {kv(
-                "Months at current job",
-                summary.employment.monthsAtJob != null ? String(summary.employment.monthsAtJob) : "Not provided"
-              )}
-              {kv("Work reference name", summary.reference.name || "Not provided")}
-              {kv("Work reference phone", summary.reference.phone || "Not provided")}
-            </div>
-          </Card>
-
-          <Card style={{ display: "grid", gap: 8 }}>
-            <div style={{ fontWeight: 700 }}>Screening & Compliance</div>
-            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 8 }}>
-              {kv("Screening status", summary.screening.status || "not_run")}
-              {kv("Screening provider", summary.screening.provider || "Not provided")}
-              {kv("Reference ID", summary.screening.referenceId || "Not provided")}
-              {kv(
-                "Completeness",
-                `${summary.derived.completeness.label} (${Math.round(summary.derived.completeness.score * 100)}%)`
-              )}
-              {kv("Income-to-rent ratio", ratio(summary.derived.incomeToRentRatio))}
-              {kv("Consent version", summary.compliance.applicationConsentVersion || "Not provided")}
-              {kv("Consent accepted at", dateOr(summary.compliance.applicationConsentAcceptedAt))}
-              {kv("Signature type", summary.compliance.signatureType || "Not provided")}
-              {kv("Signed at", dateOr(summary.compliance.signedAt))}
-            </div>
-            {summary.derived.flags.length ? (
-              <div style={{ fontSize: 13, color: text.subtle }}>
-                Flags: {summary.derived.flags.join(", ")}
-              </div>
-            ) : (
-              <div style={{ fontSize: 13, color: text.subtle }}>Flags: none</div>
-            )}
-          </Card>
-
-          <ApplicationDecisionSummaryCard
-            summary={summary.decisionSummary || null}
-            onEvaluateRisk={handleEvaluateRisk}
-            evaluatingRisk={evaluatingRisk}
-            onDecision={handleDecision}
-            submittingDecision={savingDecision}
-          />
-
-          <Card style={{ display: "grid", gap: 6 }}>
-            <div style={{ fontWeight: 700 }}>Insights</div>
-            {summary.insights.length ? (
-              <ul style={{ margin: 0, paddingLeft: 20, color: text.main }}>
-                {summary.insights.map((line) => (
-                  <li key={line}>{line}</li>
-                ))}
-              </ul>
-            ) : (
-              <div style={{ color: text.subtle }}>No insights available.</div>
-            )}
-            <div style={{ fontSize: 12, color: text.subtle }}>
-              This summary is descriptive and does not provide approval/denial recommendations.
-            </div>
-          </Card>
         </>
       ) : null}
         </>

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.css
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.css
@@ -1,0 +1,13 @@
+.rc-leases-page {
+  box-sizing: border-box;
+  width: min(100%, 1180px);
+  margin: 0 auto;
+  padding: 0 16px;
+}
+
+@media (max-width: 768px) {
+  .rc-leases-page {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.css
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.css
@@ -2,12 +2,15 @@
   box-sizing: border-box;
   width: min(100%, 1180px);
   margin: 0 auto;
-  padding: 0 16px;
+  padding: 20px;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  background: #f8fafc;
 }
 
 @media (max-width: 768px) {
   .rc-leases-page {
-    padding-left: 0;
-    padding-right: 0;
+    padding: 14px;
+    border-radius: 12px;
   }
 }

--- a/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordActiveLeasesPage.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/lib/payments/paymentStatusGuidance";
 import { isTargetedHiddenLeaseId } from "@/lib/testDataVisibilityTargets";
 import { printSummaryDocument } from "@/utils/printSummary";
+import "./LandlordActiveLeasesPage.css";
 
 function formatCurrency(value: number | null | undefined) {
   const amount = typeof value === "number" ? value : 0;

--- a/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.test.tsx
@@ -76,10 +76,17 @@ describe("LandlordLeaseSummaryPage", () => {
     );
 
     expect(await screen.findByText("Lease summary")).toBeInTheDocument();
+    expect(screen.getByTestId("lease-document-view")).toBeInTheDocument();
+    expect(screen.getByText("Residential Lease Pack")).toBeInTheDocument();
+    expect(screen.getByText("Property and Unit")).toBeInTheDocument();
+    expect(screen.getByText("Landlord and Tenant")).toBeInTheDocument();
+    expect(screen.getByText("Lease Term")).toBeInTheDocument();
+    expect(screen.getByText("Rent and Payment Terms")).toBeInTheDocument();
+    expect(screen.getByText("Clauses and Additional Terms")).toBeInTheDocument();
+    expect(screen.getByText("Audit and Events")).toBeInTheDocument();
     expect(mocks.getLeaseById).toHaveBeenCalledWith("lease-1");
     expect(screen.getByText("Coburg Rd")).toBeInTheDocument();
     expect(screen.getByText("Tony Wenpeng")).toBeInTheDocument();
-    expect(screen.getByText("Not attached")).toBeInTheDocument();
     expect(screen.queryByText(/gs:\/\//i)).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Open ledger" })).toHaveAttribute("href", "/leases/lease-1/ledger");
     expect(screen.getByRole("link", { name: "Back to leases" })).toHaveAttribute("href", "/leases");

--- a/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Link, useParams } from "react-router-dom";
 import { getLeaseById, type LandlordActiveLease } from "@/api/leasesApi";
+import { LeaseDocumentView } from "@/components/leases/LeaseDocumentView";
 
 function errorMessage(error: unknown, fallback: string) {
   if (error instanceof Error && error.message) return error.message;
@@ -51,15 +52,6 @@ function downloadLeaseSummary(lease: LandlordActiveLease) {
   anchor.click();
   anchor.remove();
   window.URL.revokeObjectURL(url);
-}
-
-function DetailRow({ label, value }: { label: string; value: React.ReactNode }) {
-  return (
-    <div style={{ display: "grid", gap: 4 }}>
-      <div style={{ fontSize: 12, fontWeight: 700, color: "#64748b", textTransform: "uppercase", letterSpacing: 0.3 }}>{label}</div>
-      <div style={{ color: "#0f172a" }}>{value}</div>
-    </div>
-  );
 }
 
 export default function LandlordLeaseSummaryPage() {
@@ -138,69 +130,7 @@ export default function LandlordLeaseSummaryPage() {
       {loading ? <div>Loading lease summary…</div> : null}
       {error ? <div style={{ color: "#b91c1c" }}>{error}</div> : null}
 
-      {lease ? (
-        <>
-          <div
-            style={{
-              display: "grid",
-              gap: 16,
-              gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
-              padding: 16,
-              borderRadius: 16,
-              border: "1px solid #e2e8f0",
-              background: "#fff",
-            }}
-          >
-            <DetailRow label="Property" value={lease.propertyName || "Property"} />
-            <DetailRow label="Unit" value={lease.unitNumber || "—"} />
-            <DetailRow label="Tenant" value={lease.tenantName || "—"} />
-            <DetailRow label="Monthly rent" value={formatCurrency(lease.monthlyRent)} />
-            <DetailRow label="Start date" value={formatDate(lease.startDate)} />
-            <DetailRow label="End date" value={formatDate(lease.endDate)} />
-            <DetailRow label="Status" value={prettyLeaseStatus(lease.status)} />
-            <DetailRow label="Lease document" value={lease.documentUrl ? "Available" : "Not attached"} />
-          </div>
-
-          {lease.leaseExecution || lease.paymentReadiness || lease.leaseLifecycleSummary ? (
-            <div
-              style={{
-                display: "grid",
-                gap: 16,
-                padding: 16,
-                borderRadius: 16,
-                border: "1px solid #e2e8f0",
-                background: "#fff",
-              }}
-            >
-              <div style={{ fontSize: 16, fontWeight: 700, color: "#0f172a" }}>Current lease signals</div>
-
-              {lease.leaseExecution ? (
-                <div style={{ display: "grid", gap: 6 }}>
-                  <div style={{ fontWeight: 700, color: "#0f172a" }}>Execution</div>
-                  <div>{lease.leaseExecution.executionLabel}</div>
-                  <div style={{ color: "#64748b", fontSize: 14 }}>{lease.leaseExecution.executionDescription}</div>
-                </div>
-              ) : null}
-
-              {lease.paymentReadiness ? (
-                <div style={{ display: "grid", gap: 6 }}>
-                  <div style={{ fontWeight: 700, color: "#0f172a" }}>Payment readiness</div>
-                  <div>{lease.paymentReadiness.readinessLabel}</div>
-                  <div style={{ color: "#64748b", fontSize: 14 }}>{lease.paymentReadiness.readinessDescription}</div>
-                </div>
-              ) : null}
-
-              {lease.leaseLifecycleSummary ? (
-                <div style={{ display: "grid", gap: 6 }}>
-                  <div style={{ fontWeight: 700, color: "#0f172a" }}>Lifecycle</div>
-                  <div>{lease.leaseLifecycleSummary.lifecycleLabel}</div>
-                  <div style={{ color: "#64748b", fontSize: 14 }}>{lease.leaseLifecycleSummary.lifecycleDescription}</div>
-                </div>
-              ) : null}
-            </div>
-          ) : null}
-        </>
-      ) : null}
+      {lease ? <LeaseDocumentView lease={lease} /> : null}
     </div>
   );
 }

--- a/rentchain-frontend/src/pages/MessagesPage.test.tsx
+++ b/rentchain-frontend/src/pages/MessagesPage.test.tsx
@@ -156,12 +156,52 @@ describe("MessagesPage", () => {
 
     await flushAsync();
     expect(screen.getAllByText("Taylor Tenant")[0]).toBeInTheDocument();
-    expect(screen.getByText("Tenant conversation • Unit unavailable")).toBeInTheDocument();
-    expect(screen.queryByText("Tenant • Tenant conversation")).not.toBeInTheDocument();
+    expect(screen.getAllByText("Taylor Tenant • Conversation").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Tenant conversation • Unit unavailable")).not.toBeInTheDocument();
     expect(screen.getAllByText("TT")[0]).toBeInTheDocument();
     expect(screen.queryByText(/tenant-raw-1/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/prop-raw-1/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/unit-raw-1/i)).not.toBeInTheDocument();
+  });
+
+  it("keeps message labels useful when property or unit context is incomplete", async () => {
+    mocks.fetchLandlordConversationsMock.mockResolvedValue([
+      {
+        id: "conv-2",
+        tenantDisplayName: "Jordan Tenant",
+        unitDisplayLabel: "4B",
+      },
+      {
+        id: "conv-3",
+        tenantDisplayName: "Morgan Tenant",
+        propertyDisplayLabel: "Harbour View",
+      },
+      {
+        id: "conv-4",
+        propertyDisplayLabel: "North Point",
+        unitDisplayLabel: "Unit 8",
+      },
+    ]);
+    mocks.fetchLandlordConversationMessagesMock.mockResolvedValue({
+      conversation: {
+        id: "conv-2",
+        tenantDisplayName: "Jordan Tenant",
+        unitDisplayLabel: "4B",
+      },
+      messages: [],
+    });
+
+    render(
+      <MemoryRouter>
+        <MessagesPage />
+      </MemoryRouter>
+    );
+
+    await flushAsync();
+    expect(screen.getAllByText("Jordan Tenant • Unit 4B").length).toBeGreaterThan(0);
+    expect(screen.getByText("Morgan Tenant • Property unavailable")).toBeInTheDocument();
+    expect(screen.getByText("Tenant • North Point / Unit 8")).toBeInTheDocument();
+    expect(screen.queryByText("Tenant conversation • Unit unavailable")).not.toBeInTheDocument();
   });
 
   it("preserves the selected conversation across background refresh without blanking the thread", async () => {

--- a/rentchain-frontend/src/pages/MessagesPage.test.tsx
+++ b/rentchain-frontend/src/pages/MessagesPage.test.tsx
@@ -156,7 +156,8 @@ describe("MessagesPage", () => {
 
     await flushAsync();
     expect(screen.getAllByText("Taylor Tenant")[0]).toBeInTheDocument();
-    expect(screen.getByText("Tenant conversation")).toBeInTheDocument();
+    expect(screen.getByText("Tenant conversation • Unit unavailable")).toBeInTheDocument();
+    expect(screen.queryByText("Tenant • Tenant conversation")).not.toBeInTheDocument();
     expect(screen.getAllByText("TT")[0]).toBeInTheDocument();
     expect(screen.queryByText(/tenant-raw-1/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/prop-raw-1/i)).not.toBeInTheDocument();

--- a/rentchain-frontend/src/pages/MessagesPage.tsx
+++ b/rentchain-frontend/src/pages/MessagesPage.tsx
@@ -54,10 +54,21 @@ function displayTenantName(conversation: Conversation | null) {
   return tenantName || "Tenant";
 }
 
+function hasTenantDisplayName(conversation: Conversation | null) {
+  return Boolean(String(conversation?.tenantDisplayName || "").trim());
+}
+
+function displayUnitContext(conversation: Conversation | null) {
+  const unitLabel = String(conversation?.unitDisplayLabel || "").trim();
+  if (!unitLabel) return "Unit unavailable";
+  return /^unit\b/i.test(unitLabel) ? unitLabel : `Unit ${unitLabel}`;
+}
+
 function displayConversationContext(conversation: Conversation | null) {
   const propertyLabel = String(conversation?.propertyDisplayLabel || "").trim();
-  const unitLabel = String(conversation?.unitDisplayLabel || "").trim();
-  return [propertyLabel, unitLabel].filter(Boolean).join(" / ") || "Tenant conversation";
+  const unitLabel = displayUnitContext(conversation);
+  if (propertyLabel) return `${propertyLabel} / ${unitLabel}`;
+  return `Tenant conversation • ${unitLabel}`;
 }
 
 function buildTenantInitials(conversation: Conversation | null) {
@@ -75,6 +86,7 @@ function buildConversationTitle(conversation: Conversation | null) {
   if (!conversation) return "Conversation";
   const tenantName = displayTenantName(conversation);
   const locationLabel = displayConversationContext(conversation);
+  if (!hasTenantDisplayName(conversation)) return locationLabel;
   if (tenantName && locationLabel) return `${tenantName} • ${locationLabel}`;
   if (tenantName) return tenantName;
   if (locationLabel) return locationLabel;

--- a/rentchain-frontend/src/pages/MessagesPage.tsx
+++ b/rentchain-frontend/src/pages/MessagesPage.tsx
@@ -60,15 +60,17 @@ function hasTenantDisplayName(conversation: Conversation | null) {
 
 function displayUnitContext(conversation: Conversation | null) {
   const unitLabel = String(conversation?.unitDisplayLabel || "").trim();
-  if (!unitLabel) return "Unit unavailable";
+  if (!unitLabel) return "";
   return /^unit\b/i.test(unitLabel) ? unitLabel : `Unit ${unitLabel}`;
 }
 
 function displayConversationContext(conversation: Conversation | null) {
   const propertyLabel = String(conversation?.propertyDisplayLabel || "").trim();
   const unitLabel = displayUnitContext(conversation);
-  if (propertyLabel) return `${propertyLabel} / ${unitLabel}`;
-  return `Tenant conversation • ${unitLabel}`;
+  if (propertyLabel && unitLabel) return `${propertyLabel} / ${unitLabel}`;
+  if (unitLabel) return unitLabel;
+  if (propertyLabel) return "Property unavailable";
+  return "Conversation";
 }
 
 function buildTenantInitials(conversation: Conversation | null) {
@@ -86,7 +88,7 @@ function buildConversationTitle(conversation: Conversation | null) {
   if (!conversation) return "Conversation";
   const tenantName = displayTenantName(conversation);
   const locationLabel = displayConversationContext(conversation);
-  if (!hasTenantDisplayName(conversation)) return locationLabel;
+  if (!hasTenantDisplayName(conversation)) return `Tenant • ${locationLabel}`;
   if (tenantName && locationLabel) return `${tenantName} • ${locationLabel}`;
   if (tenantName) return tenantName;
   if (locationLabel) return locationLabel;

--- a/rentchain-frontend/src/pages/PropertiesPage.tsx
+++ b/rentchain-frontend/src/pages/PropertiesPage.tsx
@@ -33,6 +33,7 @@ import "./PropertiesPage.css";
 import { track } from "../lib/analytics";
 import { resolveReturnToParam } from "../lib/propertyGate";
 import { useCapabilities } from "../hooks/useCapabilities";
+import { deriveUnitOccupancyFromLeases } from "../lib/leases/leaseLifecycle";
 
 const PropertiesPage: React.FC = () => {
   const [properties, setProperties] = useState<Property[]>([]);
@@ -894,12 +895,16 @@ const PropertiesPage: React.FC = () => {
                         </tr>
                       </thead>
                       <tbody>
-                        {(Array.isArray((selectedProperty as any)?.units) ? (selectedProperty as any).units : []).map((unit: any, index: number) => (
-                          <tr key={String(unit?.id || unit?.unitId || unit?.uid || index)}>
-                            <td>{String(unit?.unitNumber || unit?.label || unit?.name || "—")}</td>
-                            <td>{String(unit?.status || unit?.occupancyStatus || "unknown")}</td>
-                          </tr>
-                        ))}
+                        {(Array.isArray((selectedProperty as any)?.units) ? (selectedProperty as any).units : []).map((unit: any, index: number) => {
+                          const leases = Array.isArray((selectedProperty as any)?.leases) ? (selectedProperty as any).leases : [];
+                          const occupancy = deriveUnitOccupancyFromLeases(unit, leases);
+                          return (
+                            <tr key={String(unit?.id || unit?.unitId || unit?.uid || index)}>
+                              <td>{String(unit?.unitNumber || unit?.label || unit?.name || "—")}</td>
+                              <td>{occupancy.label}</td>
+                            </tr>
+                          );
+                        })}
                       </tbody>
                     </table>
                   </div>

--- a/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.test.tsx
@@ -251,6 +251,7 @@ describe("PortfolioHealthSummaryPage", () => {
     expect((await screen.findAllByText(/Showing leases approaching notice timing/i)).length).toBeGreaterThan(0);
     expect((await screen.findAllByText(/Taylor Tenant/i)).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("123 Harbour St • Unit 2")).length).toBeGreaterThan(0);
+    expect(screen.getByText("Expires 2026-06-30")).toBeInTheDocument();
     expect(screen.getByText("Visible leases: 1")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Print / Save renewal view" })).toBeInTheDocument();
     expect((await screen.findAllByText(/Lifecycle:/i)).length).toBeGreaterThan(0);

--- a/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.test.tsx
@@ -252,6 +252,7 @@ describe("PortfolioHealthSummaryPage", () => {
     expect((await screen.findAllByText(/Taylor Tenant/i)).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("123 Harbour St • Unit 2")).length).toBeGreaterThan(0);
     expect(screen.getByText("Expires 2026-06-30")).toBeInTheDocument();
+    expect(screen.queryByText(/^Updated/)).not.toBeInTheDocument();
     expect(screen.getByText("Visible leases: 1")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Print / Save renewal view" })).toBeInTheDocument();
     expect((await screen.findAllByText(/Lifecycle:/i)).length).toBeGreaterThan(0);
@@ -388,6 +389,7 @@ describe("PortfolioHealthSummaryPage", () => {
         renewalNewTermType: "fixed_term",
         renewalNewLeaseStartDate: "2026-07-01",
         renewalNewLeaseEndDate: "2027-06-30",
+        renewalUpdatedAt: "2026-05-04T12:00:00.000Z",
       },
       renewalInputs: {
         rentChangeMode: "no_change",
@@ -429,6 +431,7 @@ describe("PortfolioHealthSummaryPage", () => {
         message: "Lease renewal inputs saved",
       })
     );
+    expect(await screen.findByText("Updated • May 4")).toBeInTheDocument();
   });
 
   it("clears and blocks proposed rent when rent change mode does not allow it", async () => {

--- a/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.test.tsx
@@ -251,6 +251,7 @@ describe("PortfolioHealthSummaryPage", () => {
     expect((await screen.findAllByText(/Showing leases approaching notice timing/i)).length).toBeGreaterThan(0);
     expect((await screen.findAllByText(/Taylor Tenant/i)).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("123 Harbour St • Unit 2")).length).toBeGreaterThan(0);
+    expect(screen.getByText("Visible leases: 1")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Print / Save renewal view" })).toBeInTheDocument();
     expect((await screen.findAllByText(/Lifecycle:/i)).length).toBeGreaterThan(0);
     expect((await screen.findAllByText(/Outcome:/i)).length).toBeGreaterThan(0);

--- a/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.tsx
@@ -119,6 +119,10 @@ function formatLeaseRenewalLocation(lease: LandlordLeaseRenewalLease) {
   return lease.unitLabel ? `${propertyLabel} • ${lease.unitLabel}` : propertyLabel;
 }
 
+function formatLeaseExpiryBadge(lease: LandlordLeaseRenewalLease) {
+  return lease.leaseEndDate ? `Expires ${lease.leaseEndDate}` : "Expiry date unavailable";
+}
+
 function mapRenewalValidationMessage(errorCode: string | null | undefined) {
   switch (String(errorCode || "").trim()) {
     case "RENT_CHANGE_MODE_REQUIRED_FOR_PROPOSED_RENT":
@@ -516,12 +520,28 @@ export default function PortfolioHealthSummaryPage() {
                         background: "#fff",
                       }}
                     >
-                      <div style={{ display: "grid", gap: 2 }}>
-                        <div style={{ fontWeight: 700 }}>
-                          {formatLeaseRenewalLocation(lease)}
+                      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 12, flexWrap: "wrap" }}>
+                        <div style={{ display: "grid", gap: 2 }}>
+                          <div style={{ fontWeight: 700 }}>
+                            {formatLeaseRenewalLocation(lease)}
+                          </div>
+                          <div style={{ color: "#475569", fontSize: 14 }}>
+                            Lease ends {lease.leaseEndDate || "unknown"}{lease.tenantName ? ` • ${lease.tenantName}` : ""}
+                          </div>
                         </div>
-                        <div style={{ color: "#475569", fontSize: 14 }}>
-                          Lease ends {lease.leaseEndDate || "unknown"}{lease.tenantName ? ` • ${lease.tenantName}` : ""}
+                        <div
+                          style={{
+                            padding: "5px 10px",
+                            borderRadius: 999,
+                            border: "1px solid rgba(245,158,11,0.35)",
+                            background: "rgba(245,158,11,0.14)",
+                            color: "#92400e",
+                            fontSize: 12,
+                            fontWeight: 800,
+                            whiteSpace: "nowrap",
+                          }}
+                        >
+                          {formatLeaseExpiryBadge(lease)}
                         </div>
                       </div>
 

--- a/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.tsx
@@ -188,6 +188,7 @@ export default function PortfolioHealthSummaryPage() {
       : entryStatus === "no-response"
       ? "Showing leases where the tenant response window has elapsed without a reply."
       : "Save renewal term and deadline choices on the lease record so readiness checks can observe them canonically.";
+  const renewalDisplayItems = React.useMemo(() => renewalItems, [renewalItems]);
 
   React.useEffect(() => {
     if (entitlementLoading || !canViewPortfolioHealthSummary) return;
@@ -448,7 +449,7 @@ export default function PortfolioHealthSummaryPage() {
                 <div className="printTitle">{scopedRenewalHeading}</div>
                 <div className="printMeta">
                   <div>Scope: Lease renewals</div>
-                  <div>Visible leases: {renewalItems.length}</div>
+                  <div>Visible leases: {renewalDisplayItems.length}</div>
                 </div>
               </div>
               <div>{scopedRenewalHelper}</div>
@@ -465,7 +466,7 @@ export default function PortfolioHealthSummaryPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {renewalItems.map((lease) => {
+                  {renewalDisplayItems.map((lease) => {
                     const form = renewalForms[lease.id] || createLeaseRenewalFormState(lease);
                     const renewalSummary = [
                       form.rentChangeMode ? `Mode: ${form.rentChangeMode.replace(/_/g, " ")}` : null,
@@ -493,12 +494,12 @@ export default function PortfolioHealthSummaryPage() {
 
             {renewalLoading ? <div>Loading lease renewal inputs…</div> : null}
             {!renewalLoading && renewalError ? <div style={{ color: "#b91c1c" }}>{renewalError}</div> : null}
-            {!renewalLoading && !renewalError && renewalItems.length === 0 ? (
+            {!renewalLoading && !renewalError && renewalDisplayItems.length === 0 ? (
               <div style={{ color: "#475569" }}>No expiring leases are currently visible for this scope.</div>
             ) : null}
 
             {!renewalLoading && !renewalError
-              ? renewalItems.map((lease) => {
+              ? renewalDisplayItems.map((lease) => {
                   const form = renewalForms[lease.id] || createLeaseRenewalFormState(lease);
                   const validation = renewalValidation[lease.id] || {};
                   const proposedRentAllowed = canSetProposedRent(form.rentChangeMode);

--- a/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/landlord/PortfolioHealthSummaryPage.tsx
@@ -123,6 +123,30 @@ function formatLeaseExpiryBadge(lease: LandlordLeaseRenewalLease) {
   return lease.leaseEndDate ? `Expires ${lease.leaseEndDate}` : "Expiry date unavailable";
 }
 
+function hasSavedRenewalInputs(lease: LandlordLeaseRenewalLease) {
+  return Boolean(
+    lease.renewalRentChangeMode ||
+      lease.renewalOfferedRent != null ||
+      lease.renewalDecisionDeadlineAt ||
+      lease.renewalNewTermType ||
+      lease.renewalNewLeaseStartDate ||
+      lease.renewalNewLeaseEndDate
+  );
+}
+
+function formatShortUpdateDate(value: string | number | null | undefined) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+function formatRenewalUpdatedBadge(lease: LandlordLeaseRenewalLease) {
+  if (!hasSavedRenewalInputs(lease)) return null;
+  const updatedAt = formatShortUpdateDate(lease.renewalUpdatedAt || lease.updatedAt);
+  return updatedAt ? `Updated • ${updatedAt}` : "Updated";
+}
+
 function mapRenewalValidationMessage(errorCode: string | null | undefined) {
   switch (String(errorCode || "").trim()) {
     case "RENT_CHANGE_MODE_REQUIRED_FOR_PROPOSED_RENT":
@@ -508,6 +532,7 @@ export default function PortfolioHealthSummaryPage() {
                   const validation = renewalValidation[lease.id] || {};
                   const proposedRentAllowed = canSetProposedRent(form.rentChangeMode);
                   const isSaving = savingLeaseId === lease.id;
+                  const updatedBadge = formatRenewalUpdatedBadge(lease);
                   return (
                     <div
                       key={lease.id}
@@ -529,19 +554,37 @@ export default function PortfolioHealthSummaryPage() {
                             Lease ends {lease.leaseEndDate || "unknown"}{lease.tenantName ? ` • ${lease.tenantName}` : ""}
                           </div>
                         </div>
-                        <div
-                          style={{
-                            padding: "5px 10px",
-                            borderRadius: 999,
-                            border: "1px solid rgba(245,158,11,0.35)",
-                            background: "rgba(245,158,11,0.14)",
-                            color: "#92400e",
-                            fontSize: 12,
-                            fontWeight: 800,
-                            whiteSpace: "nowrap",
-                          }}
-                        >
-                          {formatLeaseExpiryBadge(lease)}
+                        <div style={{ display: "flex", gap: 8, flexWrap: "wrap", justifyContent: "flex-end" }}>
+                          {updatedBadge ? (
+                            <div
+                              style={{
+                                padding: "5px 10px",
+                                borderRadius: 999,
+                                border: "1px solid rgba(22,101,52,0.28)",
+                                background: "rgba(22,101,52,0.10)",
+                                color: "#166534",
+                                fontSize: 12,
+                                fontWeight: 800,
+                                whiteSpace: "nowrap",
+                              }}
+                            >
+                              {updatedBadge}
+                            </div>
+                          ) : null}
+                          <div
+                            style={{
+                              padding: "5px 10px",
+                              borderRadius: 999,
+                              border: "1px solid rgba(245,158,11,0.35)",
+                              background: "rgba(245,158,11,0.14)",
+                              color: "#92400e",
+                              fontSize: 12,
+                              fontWeight: 800,
+                              whiteSpace: "nowrap",
+                            }}
+                          >
+                            {formatLeaseExpiryBadge(lease)}
+                          </div>
                         </div>
                       </div>
 


### PR DESCRIPTION
This PR repairs core lease lifecycle display issues discovered during landlord-account testing.

Includes:
- shared frontend lease lifecycle helpers
- unit occupancy derived from lease lifecycle instead of stale unit.status
- expired, terminated, cancelled, and no-lease units display as Vacant
- Occupied, Notice period, Upcoming, and Vacant display states
- proper /leases page gutters/container
- document-style Residential Lease Pack fallback for View Lease
- aligned portfolio renewal UI/PDF display source
- preserved DebugPanel public/mobile visibility repair

Guardrails preserved:
- frontend-only
- no backend changes
- no Trustly work
- no PaymentIntent work
- no payment architecture changes
- no dependency or lockfile changes

Verification:
- git diff --check passed
- lease lifecycle/property summary tests passed: 5 tests
- focused component/page tests passed: 17 tests
- full frontend suite passed: 177 files / 705 tests
- pnpm build passed under Node 20
- no backend diff
- no dependency/lockfile diff

Manual QA note:
- Real landlord-account browser QA was not available from this environment and remains pending before merge.
- Portfolio health core dimensions/next-focus still depend on backend summary data and should be audited in a follow-up if real-account QA shows stale or contradictory health insights.