### PR TITLE
Add canonical lease state machine

### DIFF
--- a/docs/architecture/lease-state-machine-v1.md
+++ b/docs/architecture/lease-state-machine-v1.md
@@ -1,0 +1,61 @@
+# Lease State Machine V1
+
+RentChain lease lifecycle state is derived from lease facts first and stored legacy status second. The V1 rollout is additive: it introduces deterministic lifecycle interpretation without migrating stored `lease.status`, rewriting leases, or enforcing workflow transitions.
+
+## Canonical States
+
+- `draft`: lease exists but has not been sent, signed, or activated.
+- `pending_signature`: lease has been sent or prepared, but tenant and landlord signatures are not complete.
+- `signed_future`: lease is fully signed and starts in the future.
+- `active`: lease is fully signed/current and today is inside the lease term.
+- `notice_period`: lease is current, but notice, move-out, or termination intent exists.
+- `expired`: lease end date has passed and no signed renewal or successor supersedes it.
+- `renewed`: lease has been superseded by a signed renewal or successor lease.
+- `terminated`: lease ended early through termination, notice, or agreement.
+- `cancelled`: lease was abandoned or cancelled before activation.
+- `unknown`: lease data is missing or contradictory enough to require review.
+
+## Derivation Precedence
+
+1. Cancellation facts (`cancelledAt`, cancelled/void status) win first.
+2. Effective termination facts (`terminatedAt`, `terminationDate`, terminated status) win before active checks.
+3. Signed successor or renewal facts produce `renewed`.
+4. Draft-like leases without term dates remain `draft`.
+5. Sent but not fully signed leases are `pending_signature`.
+6. Fully signed future leases are `signed_future`.
+7. Current leases with notice or move-out signals are `notice_period`.
+8. Current signed leases are `active`.
+9. Past end dates without successor facts are `expired`.
+10. Invalid ranges or unsafe contradictions produce `unknown` with `requiresReview`.
+
+Stored `lease.status` remains supported as a legacy hint, but it does not override cancellation, termination, renewal, or end-date facts.
+
+## Occupancy Mapping
+
+- `active` -> `occupied`
+- `notice_period` -> `notice_period`
+- `signed_future` -> `upcoming`
+- `expired`, `terminated`, `cancelled`, `renewed`, draft/no lease -> `vacant`
+- `unknown` or review-required lifecycle -> `review_required`
+
+V1 does not mutate `unit.status`; occupancy output is derived for display and analytics only.
+
+## Expiring Soon
+
+`isLeaseExpiringSoon` only returns true for `active` and `notice_period` leases whose effective end date is inside the threshold window. Expired, renewed, terminated, cancelled, draft, pending-signature, and signed-future leases are excluded.
+
+## Rollout
+
+Phase 1 adds the backend canonical helper and unit tests.
+Phase 2 exposes additive derived lifecycle fields in lease view models.
+Phase 3 aligns frontend helper semantics and prefers backend-derived lifecycle fields when present.
+Phase 4 uses the derived lifecycle in safe display contexts such as lease badges, unit occupancy, and portfolio health/expiring-soon summaries.
+
+## Deferred Future Steps
+
+1. Stored lifecycle transition events.
+2. Scheduled lease lifecycle reconciliation job.
+3. Admin review queue for contradictory leases.
+4. Lease renewal workflow enforcement.
+5. Payment obligation generation from active lease lifecycle.
+6. Institution-ready lease export schema.

--- a/rentchain-api/src/lib/analytics/__tests__/deriveAdminAnalyticsSnapshot.test.ts
+++ b/rentchain-api/src/lib/analytics/__tests__/deriveAdminAnalyticsSnapshot.test.ts
@@ -215,4 +215,59 @@ describe("deriveAdminAnalyticsSnapshot", () => {
       activeActors: 0,
     });
   });
+
+  it("counts expiring soon leases only when canonical lifecycle is active or notice-period", () => {
+    const now = Date.UTC(2026, 4, 5, 12, 0, 0, 0);
+    const result = deriveAdminAnalyticsSnapshot({
+      now,
+      from: now - 30 * 24 * 60 * 60 * 1000,
+      to: now,
+      period: "30d",
+      granularity: "daily",
+      applications: [],
+      screeningReconciliations: [],
+      financialTransactions: [],
+      workOrders: [],
+      properties: [],
+      units: [],
+      leases: [
+        {
+          id: "lease-active",
+          status: "active",
+          signedAt: "2026-01-01",
+          startDate: "2026-01-01",
+          endDate: "2026-06-01",
+        },
+        {
+          id: "lease-expired-stale-active",
+          status: "active",
+          signedAt: "2025-01-01",
+          startDate: "2025-01-01",
+          endDate: "2026-04-30",
+        },
+        {
+          id: "lease-renewed",
+          status: "renewed",
+          signedAt: "2025-01-01",
+          startDate: "2025-01-01",
+          endDate: "2026-06-01",
+          successorLeaseId: "lease-next",
+          hasSignedSuccessorLease: true,
+        },
+        {
+          id: "lease-future",
+          status: "active",
+          signedAt: "2026-05-01",
+          startDate: "2026-06-01",
+          endDate: "2026-06-30",
+        },
+      ],
+      events: [],
+      canonicalEvents: [],
+    });
+
+    expect(result.portfolio.leasesEndingIn30Days).toBe(1);
+    expect(result.portfolio.leasesEndingIn60Days).toBe(1);
+    expect(result.portfolio.leasesEndingIn90Days).toBe(1);
+  });
 });

--- a/rentchain-api/src/lib/analytics/deriveAdminAnalyticsSnapshot.ts
+++ b/rentchain-api/src/lib/analytics/deriveAdminAnalyticsSnapshot.ts
@@ -8,6 +8,7 @@ import type {
   AdminActivityAnalytics,
 } from "./analyticsTypes";
 import type { ScreeningReconciliationStatus } from "../reconciliation/reconciliationTypes";
+import { isLeaseExpiringSoon } from "../leases/leaseLifecycle";
 
 const SCREENING_STATUS_KEYS: ScreeningReconciliationStatus[] = [
   "not_started",
@@ -304,10 +305,9 @@ function derivePortfolioAnalytics(
       toMillis(lease?.leaseEnd) ||
       toMillis(lease?.moveOutDate);
     if (endAt != null) {
-      const deltaDays = Math.floor((endAt - now) / (24 * 60 * 60 * 1000));
-      if (deltaDays >= 0 && deltaDays <= 30) leasesEndingIn30Days += 1;
-      if (deltaDays >= 0 && deltaDays <= 60) leasesEndingIn60Days += 1;
-      if (deltaDays >= 0 && deltaDays <= 90) leasesEndingIn90Days += 1;
+      if (isLeaseExpiringSoon(lease, now, 30)) leasesEndingIn30Days += 1;
+      if (isLeaseExpiringSoon(lease, now, 60)) leasesEndingIn60Days += 1;
+      if (isLeaseExpiringSoon(lease, now, 90)) leasesEndingIn90Days += 1;
       if (endAt >= from && endAt <= to) turnoverCount += 1;
     }
   }

--- a/rentchain-api/src/lib/analytics/deriveLandlordAnalyticsSnapshot.ts
+++ b/rentchain-api/src/lib/analytics/deriveLandlordAnalyticsSnapshot.ts
@@ -12,21 +12,10 @@ import type {
   LandlordPropertyAnalytics,
   LandlordAnalyticsSnapshot,
 } from "./analyticsTypes";
+import { deriveLeaseLifecycleState } from "../leases/leaseLifecycle";
 
 function asString(value: unknown, max = 240) {
   return String(value || "").trim().slice(0, max);
-}
-
-function toMillis(value: unknown): number | null {
-  if (value == null || value === "") return null;
-  if (typeof value === "number" && Number.isFinite(value)) return value;
-  if (typeof value === "string") {
-    const parsed = Date.parse(value);
-    return Number.isFinite(parsed) ? parsed : null;
-  }
-  if (typeof (value as any)?.toMillis === "function") return (value as any).toMillis();
-  if (typeof (value as any)?.seconds === "number") return (value as any).seconds * 1000;
-  return null;
 }
 
 function isOccupiedUnit(unit: any) {
@@ -34,17 +23,6 @@ function isOccupiedUnit(unit: any) {
   if (status === "occupied" || status === "leased") return true;
   if (status === "vacant" || status === "available") return false;
   return Boolean(asString(unit?.tenantName, 120) || asString(unit?.tenantId, 120));
-}
-
-function isActiveLease(lease: any, now: number) {
-  const status = asString(lease?.status, 80).toLowerCase();
-  if (status === "active" || status === "current") return true;
-  const startAt = toMillis(lease?.leaseStartDate) || toMillis(lease?.startDate) || toMillis(lease?.leaseStart);
-  const endAt =
-    toMillis(lease?.leaseEndDate) || toMillis(lease?.endDate) || toMillis(lease?.leaseEnd) || toMillis(lease?.moveOutDate);
-  if (startAt != null && startAt > now) return false;
-  if (endAt != null && endAt < now) return false;
-  return startAt != null || endAt != null;
 }
 
 function numberOrNull(...values: unknown[]) {
@@ -71,7 +49,7 @@ function deriveEstimatedRent(leases: any[], now: number) {
   let occupiedUnitsWithRent = 0;
 
   for (const lease of leases || []) {
-    if (!isActiveLease(lease, now)) continue;
+    if (!deriveLeaseLifecycleState(lease, now).isOccupancyActive) continue;
     const rentCents = monthlyRentCentsFromLease(lease);
     if (rentCents == null || rentCents <= 0) continue;
     estimatedScheduledRentCents += rentCents;

--- a/rentchain-api/src/lib/leases/__tests__/leaseLifecycle.test.ts
+++ b/rentchain-api/src/lib/leases/__tests__/leaseLifecycle.test.ts
@@ -1,0 +1,309 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveLeaseLifecycleState,
+  deriveUnitOccupancyFromLeaseLifecycle,
+  isLeaseExpiringSoon,
+} from "../leaseLifecycle";
+
+const today = "2026-05-05";
+
+describe("leaseLifecycle", () => {
+  it("derives draft leases", () => {
+    const result = deriveLeaseLifecycleState({ status: "draft" }, today);
+
+    expect(result).toMatchObject({
+      state: "draft",
+      isCurrent: false,
+      isTerminal: false,
+      isOccupancyActive: false,
+      requiresReview: false,
+    });
+    expect(result.reasons).toContain("draft_without_term_dates");
+  });
+
+  it("derives pending_signature when sent but not fully signed", () => {
+    const result = deriveLeaseLifecycleState(
+      {
+        status: "sent",
+        sentAt: "2026-05-01",
+        tenantSignedAt: "2026-05-02",
+        startDate: "2026-06-01",
+        endDate: "2027-05-31",
+      },
+      today
+    );
+
+    expect(result.state).toBe("pending_signature");
+    expect(result.reasons).toContain("sent_not_fully_signed");
+  });
+
+  it("derives signed_future for fully signed leases before start date", () => {
+    const result = deriveLeaseLifecycleState(
+      {
+        status: "active",
+        tenantSignedAt: "2026-05-01",
+        landlordSignedAt: "2026-05-02",
+        startDate: "2026-06-01",
+        endDate: "2027-05-31",
+      },
+      today
+    );
+
+    expect(result.state).toBe("signed_future");
+    expect(result.isOccupancyActive).toBe(false);
+  });
+
+  it("derives active for signed current leases", () => {
+    const result = deriveLeaseLifecycleState(
+      {
+        status: "active",
+        signedAt: "2026-01-01",
+        startDate: "2026-01-01",
+        endDate: "2026-12-31",
+      },
+      today
+    );
+
+    expect(result).toMatchObject({
+      state: "active",
+      isCurrent: true,
+      isOccupancyActive: true,
+      isTerminal: false,
+    });
+  });
+
+  it("derives notice_period when a current lease has notice data", () => {
+    const result = deriveLeaseLifecycleState(
+      {
+        status: "active",
+        signedAt: "2026-01-01",
+        startDate: "2026-01-01",
+        endDate: "2026-12-31",
+        noticeGivenAt: "2026-05-01",
+      },
+      today
+    );
+
+    expect(result.state).toBe("notice_period");
+    expect(result.isOccupancyActive).toBe(true);
+  });
+
+  it("derives expired for ended leases with no successor", () => {
+    const result = deriveLeaseLifecycleState(
+      {
+        status: "active",
+        signedAt: "2025-01-01",
+        startDate: "2025-01-01",
+        endDate: "2026-04-30",
+      },
+      today
+    );
+
+    expect(result).toMatchObject({
+      state: "expired",
+      isCurrent: false,
+      isTerminal: true,
+      isOccupancyActive: false,
+    });
+  });
+
+  it("derives renewed for ended leases with signed successor hints", () => {
+    const result = deriveLeaseLifecycleState(
+      {
+        status: "active",
+        signedAt: "2025-01-01",
+        startDate: "2025-01-01",
+        endDate: "2026-04-30",
+        successorLeaseId: "lease-next",
+        hasSignedSuccessorLease: true,
+      },
+      today
+    );
+
+    expect(result).toMatchObject({
+      state: "renewed",
+      isTerminal: true,
+      isRenewalProtected: true,
+    });
+  });
+
+  it("derives terminated for effective termination dates", () => {
+    const result = deriveLeaseLifecycleState(
+      {
+        status: "active",
+        signedAt: "2026-01-01",
+        startDate: "2026-01-01",
+        endDate: "2026-12-31",
+        terminationDate: "2026-05-01",
+      },
+      today
+    );
+
+    expect(result).toMatchObject({
+      state: "terminated",
+      isTerminal: true,
+      isOccupancyActive: false,
+    });
+  });
+
+  it("derives cancelled before activation", () => {
+    const result = deriveLeaseLifecycleState(
+      {
+        status: "cancelled",
+        sentAt: "2026-04-01",
+        startDate: "2026-06-01",
+        endDate: "2027-05-31",
+      },
+      today
+    );
+
+    expect(result).toMatchObject({
+      state: "cancelled",
+      isTerminal: true,
+      requiresReview: false,
+    });
+  });
+
+  it("flags contradictory date ranges as unknown and review-required", () => {
+    const result = deriveLeaseLifecycleState(
+      {
+        status: "active",
+        signedAt: "2026-01-01",
+        startDate: "2026-12-31",
+        endDate: "2026-01-01",
+      },
+      today
+    );
+
+    expect(result).toMatchObject({
+      state: "unknown",
+      requiresReview: true,
+      isOccupancyActive: false,
+    });
+    expect(result.reasons).toContain("date_range_invalid");
+  });
+
+  it("maps active lifecycle to occupied unit occupancy", () => {
+    const lifecycle = deriveLeaseLifecycleState(
+      { status: "active", signedAt: "2026-01-01", startDate: "2026-01-01", endDate: "2026-12-31" },
+      today
+    );
+
+    expect(deriveUnitOccupancyFromLeaseLifecycle(lifecycle)).toMatchObject({
+      state: "occupied",
+      leaseLifecycleState: "active",
+    });
+  });
+
+  it("maps notice_period lifecycle to notice_period occupancy", () => {
+    const lifecycle = deriveLeaseLifecycleState(
+      {
+        status: "move_out_pending",
+        signedAt: "2026-01-01",
+        startDate: "2026-01-01",
+        endDate: "2026-12-31",
+      },
+      today
+    );
+
+    expect(deriveUnitOccupancyFromLeaseLifecycle(lifecycle)).toMatchObject({
+      state: "notice_period",
+      leaseLifecycleState: "notice_period",
+    });
+  });
+
+  it("maps signed_future lifecycle to upcoming occupancy", () => {
+    const lifecycle = deriveLeaseLifecycleState(
+      {
+        status: "active",
+        signedAt: "2026-05-01",
+        startDate: "2026-06-01",
+        endDate: "2027-05-31",
+      },
+      today
+    );
+
+    expect(deriveUnitOccupancyFromLeaseLifecycle(lifecycle)).toMatchObject({
+      state: "upcoming",
+      leaseLifecycleState: "signed_future",
+    });
+  });
+
+  it("maps expired, terminated, and cancelled lifecycles to vacant occupancy", () => {
+    const expired = deriveLeaseLifecycleState(
+      { status: "active", signedAt: "2025-01-01", startDate: "2025-01-01", endDate: "2026-04-30" },
+      today
+    );
+    const terminated = deriveLeaseLifecycleState(
+      { status: "terminated", startDate: "2026-01-01", endDate: "2026-12-31" },
+      today
+    );
+    const cancelled = deriveLeaseLifecycleState({ status: "cancelled" }, today);
+
+    expect(deriveUnitOccupancyFromLeaseLifecycle(expired).state).toBe("vacant");
+    expect(deriveUnitOccupancyFromLeaseLifecycle(terminated).state).toBe("vacant");
+    expect(deriveUnitOccupancyFromLeaseLifecycle(cancelled).state).toBe("vacant");
+  });
+
+  it("treats unknown lifecycle as review-required occupancy", () => {
+    const unknown = deriveLeaseLifecycleState(
+      { status: "active", startDate: "2026-12-31", endDate: "2026-01-01" },
+      today
+    );
+
+    expect(deriveUnitOccupancyFromLeaseLifecycle(unknown)).toMatchObject({
+      state: "review_required",
+      leaseLifecycleState: "unknown",
+    });
+  });
+
+  it("only flags active and notice-period leases as expiring soon", () => {
+    expect(
+      isLeaseExpiringSoon(
+        { status: "active", signedAt: "2026-01-01", startDate: "2026-01-01", endDate: "2026-06-01" },
+        today,
+        60
+      )
+    ).toBe(true);
+    expect(
+      isLeaseExpiringSoon(
+        {
+          status: "move_out_pending",
+          signedAt: "2026-01-01",
+          startDate: "2026-01-01",
+          endDate: "2026-06-01",
+        },
+        today,
+        60
+      )
+    ).toBe(true);
+    expect(
+      isLeaseExpiringSoon(
+        { status: "active", signedAt: "2025-01-01", startDate: "2025-01-01", endDate: "2026-04-30" },
+        today,
+        60
+      )
+    ).toBe(false);
+    expect(
+      isLeaseExpiringSoon(
+        { status: "active", signedAt: "2026-05-01", startDate: "2026-06-01", endDate: "2026-06-30" },
+        today,
+        60
+      )
+    ).toBe(false);
+    expect(
+      isLeaseExpiringSoon(
+        {
+          status: "renewed",
+          signedAt: "2025-01-01",
+          startDate: "2025-01-01",
+          endDate: "2026-06-01",
+          successorLeaseId: "lease-next",
+          hasSignedSuccessorLease: true,
+        },
+        today,
+        60
+      )
+    ).toBe(false);
+  });
+});

--- a/rentchain-api/src/lib/leases/leaseLifecycle.ts
+++ b/rentchain-api/src/lib/leases/leaseLifecycle.ts
@@ -1,0 +1,453 @@
+export type LeaseLifecycleState =
+  | "draft"
+  | "pending_signature"
+  | "signed_future"
+  | "active"
+  | "notice_period"
+  | "expired"
+  | "renewed"
+  | "terminated"
+  | "cancelled"
+  | "unknown";
+
+export type UnitOccupancyState = "occupied" | "notice_period" | "upcoming" | "vacant" | "review_required";
+
+export interface LeaseLifecycleInput {
+  leaseId?: string | null;
+  id?: string | null;
+  status?: string | null;
+  startDate?: unknown;
+  leaseStartDate?: unknown;
+  leaseStart?: unknown;
+  endDate?: unknown;
+  leaseEndDate?: unknown;
+  leaseEnd?: unknown;
+  signedAt?: unknown;
+  sentAt?: unknown;
+  activatedAt?: unknown;
+  cancelledAt?: unknown;
+  terminatedAt?: unknown;
+  terminationDate?: unknown;
+  moveOutDate?: unknown;
+  noticeGivenAt?: unknown;
+  noticeEffectiveDate?: unknown;
+  noticeDate?: unknown;
+  noticeAt?: unknown;
+  renewalLeaseId?: string | null;
+  renewedByLeaseId?: string | null;
+  successorLeaseId?: string | null;
+  replacedByLeaseId?: string | null;
+  isRenewal?: boolean | null;
+  tenantSignedAt?: unknown;
+  landlordSignedAt?: unknown;
+  signatureStatus?: string | null;
+  leaseExecution?: {
+    executionStatus?: string | null;
+    completedAt?: unknown;
+  } | null;
+  leaseLifecycleSummary?: {
+    lifecycleStatus?: string | null;
+    renewalOutcome?: string | null;
+  } | null;
+  hasSignedSuccessorLease?: boolean | null;
+  hasActiveSuccessorLease?: boolean | null;
+  hasRenewalLease?: boolean | null;
+}
+
+export interface LeaseLifecycleResult {
+  state: LeaseLifecycleState;
+  reasons: string[];
+  effectiveStartDate?: string;
+  effectiveEndDate?: string;
+  isCurrent: boolean;
+  isTerminal: boolean;
+  isOccupancyActive: boolean;
+  isRenewalProtected: boolean;
+  requiresReview: boolean;
+}
+
+export interface UnitOccupancyLifecycleResult {
+  state: UnitOccupancyState;
+  reasons: string[];
+  leaseLifecycleState?: LeaseLifecycleState;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const DRAFT_STATUSES = new Set(["draft", "created"]);
+const PENDING_SIGNATURE_STATUSES = new Set([
+  "pending_signature",
+  "sent",
+  "prepared",
+  "ready_for_tenant_signature",
+  "tenant_signed",
+  "ready_for_landlord_signature",
+  "landlord_signed",
+]);
+const SIGNED_STATUSES = new Set([
+  "signed",
+  "active",
+  "current",
+  "renewal_pending",
+  "renewal_accepted",
+  "notice_pending",
+  "move_out_pending",
+  "ending",
+]);
+const NOTICE_STATUSES = new Set(["notice_period", "notice_pending", "move_out_pending", "ending"]);
+const EXPIRED_STATUSES = new Set(["expired", "ended", "archived"]);
+const TERMINATED_STATUSES = new Set(["terminated", "ended_early"]);
+const CANCELLED_STATUSES = new Set(["cancelled", "canceled", "void", "abandoned"]);
+const RENEWED_STATUSES = new Set(["renewed", "superseded"]);
+
+function normalize(value: unknown): string {
+  return String(value || "").trim().toLowerCase();
+}
+
+function firstValue(...values: unknown[]): unknown {
+  return values.find((value) => value != null && value !== "");
+}
+
+function toDate(value: unknown): Date | null {
+  if (value == null || value === "") return null;
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+  if (typeof (value as any)?.toDate === "function") {
+    try {
+      const date = (value as any).toDate();
+      return date instanceof Date && !Number.isNaN(date.getTime()) ? date : null;
+    } catch {
+      return null;
+    }
+  }
+  if (typeof (value as any)?.toMillis === "function") {
+    try {
+      const date = new Date((value as any).toMillis());
+      return Number.isNaN(date.getTime()) ? null : date;
+    } catch {
+      return null;
+    }
+  }
+  if (typeof (value as any)?.seconds === "number") {
+    const date = new Date((value as any).seconds * 1000);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+  const parsed = new Date(String(value));
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function toDay(value: unknown): number | null {
+  const date = toDate(value);
+  if (!date) return null;
+  return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+}
+
+function toIsoDay(value: unknown): string | undefined {
+  const day = toDay(value);
+  return day == null ? undefined : new Date(day).toISOString().slice(0, 10);
+}
+
+function todayDay(today: unknown): number {
+  return toDay(today) ?? toDay(new Date()) ?? Date.now();
+}
+
+function hasAnyDate(...values: unknown[]): boolean {
+  return values.some((value) => toDay(value) != null);
+}
+
+function hasRenewalLink(input: LeaseLifecycleInput): boolean {
+  return Boolean(
+    input.renewalLeaseId ||
+      input.renewedByLeaseId ||
+      input.successorLeaseId ||
+      input.replacedByLeaseId ||
+      input.hasRenewalLease ||
+      input.hasSignedSuccessorLease ||
+      input.hasActiveSuccessorLease
+  );
+}
+
+function hasSignedSuccessor(input: LeaseLifecycleInput): boolean {
+  return Boolean(
+    input.hasSignedSuccessorLease ||
+      input.hasActiveSuccessorLease ||
+      ((input.renewalLeaseId || input.renewedByLeaseId || input.successorLeaseId || input.replacedByLeaseId) &&
+        input.hasRenewalLease)
+  );
+}
+
+function hasNoticeSignal(input: LeaseLifecycleInput, status: string, lifecycleStatus: string): boolean {
+  const renewalOutcome = normalize(input.leaseLifecycleSummary?.renewalOutcome);
+  return (
+    NOTICE_STATUSES.has(status) ||
+    NOTICE_STATUSES.has(lifecycleStatus) ||
+    renewalOutcome === "tenant_quitting" ||
+    hasAnyDate(input.noticeGivenAt, input.noticeEffectiveDate, input.noticeDate, input.noticeAt, input.moveOutDate)
+  );
+}
+
+function hasSentSignal(input: LeaseLifecycleInput, status: string, executionStatus: string): boolean {
+  return Boolean(
+    hasAnyDate(input.sentAt) ||
+      PENDING_SIGNATURE_STATUSES.has(status) ||
+      PENDING_SIGNATURE_STATUSES.has(executionStatus)
+  );
+}
+
+function hasFullySignedSignal(input: LeaseLifecycleInput, status: string, executionStatus: string): boolean {
+  const signatureStatus = normalize(input.signatureStatus);
+  return Boolean(
+    hasAnyDate(input.signedAt, input.activatedAt, input.leaseExecution?.completedAt) ||
+      (hasAnyDate(input.tenantSignedAt) && hasAnyDate(input.landlordSignedAt)) ||
+      signatureStatus === "signed" ||
+      executionStatus === "fully_executed" ||
+      SIGNED_STATUSES.has(status)
+  );
+}
+
+function result(
+  state: LeaseLifecycleState,
+  reasons: string[],
+  options: {
+    input: LeaseLifecycleInput;
+    startValue: unknown;
+    endValue: unknown;
+    renewalProtected?: boolean;
+    requiresReview?: boolean;
+  }
+): LeaseLifecycleResult {
+  const isCurrent = state === "active" || state === "notice_period";
+  const isTerminal = state === "expired" || state === "renewed" || state === "terminated" || state === "cancelled";
+  return {
+    state,
+    reasons,
+    effectiveStartDate: toIsoDay(options.startValue),
+    effectiveEndDate: toIsoDay(options.endValue),
+    isCurrent,
+    isTerminal,
+    isOccupancyActive: isCurrent,
+    isRenewalProtected: Boolean(options.renewalProtected || hasRenewalLink(options.input) || state === "renewed"),
+    requiresReview: Boolean(options.requiresReview || state === "unknown"),
+  };
+}
+
+export function deriveLeaseLifecycleState(
+  input: LeaseLifecycleInput | null | undefined,
+  today: unknown = new Date()
+): LeaseLifecycleResult {
+  if (!input) {
+    return result("unknown", ["lease_missing"], {
+      input: {},
+      startValue: null,
+      endValue: null,
+      requiresReview: true,
+    });
+  }
+
+  const status = normalize(input.status);
+  const lifecycleStatus = normalize(input.leaseLifecycleSummary?.lifecycleStatus);
+  const executionStatus = normalize(input.leaseExecution?.executionStatus);
+  const currentDay = todayDay(today);
+  const startValue = firstValue(input.startDate, input.leaseStartDate, input.leaseStart);
+  const endValue = firstValue(input.endDate, input.leaseEndDate, input.leaseEnd);
+  const startDay = toDay(startValue);
+  const endDay = toDay(endValue);
+  const terminationDay = toDay(firstValue(input.terminatedAt, input.terminationDate));
+  const cancelledDay = toDay(input.cancelledAt);
+  const hasSigned = hasFullySignedSignal(input, status, executionStatus);
+  const hasSent = hasSentSignal(input, status, executionStatus);
+  const hasNotice = hasNoticeSignal(input, status, lifecycleStatus);
+  const renewalProtected = hasRenewalLink(input);
+
+  if (startDay != null && endDay != null && startDay > endDay) {
+    return result("unknown", ["date_range_invalid"], {
+      input,
+      startValue,
+      endValue,
+      renewalProtected,
+      requiresReview: true,
+    });
+  }
+
+  if (cancelledDay != null || CANCELLED_STATUSES.has(status)) {
+    return result("cancelled", [cancelledDay != null ? "cancelled_at_present" : "status_cancelled"], {
+      input,
+      startValue,
+      endValue,
+      renewalProtected,
+    });
+  }
+
+  if (terminationDay != null && terminationDay <= currentDay) {
+    return result("terminated", ["termination_effective"], {
+      input,
+      startValue,
+      endValue: firstValue(input.terminationDate, input.terminatedAt, endValue),
+      renewalProtected,
+    });
+  }
+
+  if (TERMINATED_STATUSES.has(status)) {
+    return result("terminated", ["status_terminated"], {
+      input,
+      startValue,
+      endValue: firstValue(input.terminationDate, input.terminatedAt, endValue),
+      renewalProtected,
+    });
+  }
+
+  if (hasSignedSuccessor(input) || (RENEWED_STATUSES.has(status) && renewalProtected)) {
+    return result("renewed", ["signed_successor_present"], {
+      input,
+      startValue,
+      endValue,
+      renewalProtected: true,
+    });
+  }
+
+  if (!startDay && !endDay && (DRAFT_STATUSES.has(status) || executionStatus === "draft" || !status)) {
+    return result("draft", ["draft_without_term_dates"], {
+      input,
+      startValue,
+      endValue,
+      renewalProtected,
+    });
+  }
+
+  if (hasSent && !hasSigned) {
+    return result("pending_signature", ["sent_not_fully_signed"], {
+      input,
+      startValue,
+      endValue,
+      renewalProtected,
+    });
+  }
+
+  if (hasSigned && startDay != null && startDay > currentDay) {
+    return result("signed_future", ["signed_before_start_date"], {
+      input,
+      startValue,
+      endValue,
+      renewalProtected,
+    });
+  }
+
+  const isWithinTerm =
+    hasSigned &&
+    (startDay == null || startDay <= currentDay) &&
+    (endDay == null || endDay >= currentDay) &&
+    (startDay != null || endDay != null || status === "active" || status === "current");
+
+  if (isWithinTerm && hasNotice) {
+    return result("notice_period", ["active_notice_signal"], {
+      input,
+      startValue,
+      endValue: firstValue(input.noticeEffectiveDate, input.moveOutDate, endValue),
+      renewalProtected,
+    });
+  }
+
+  if (isWithinTerm) {
+    return result("active", ["signed_current_term"], {
+      input,
+      startValue,
+      endValue,
+      renewalProtected,
+    });
+  }
+
+  if (endDay != null && endDay < currentDay) {
+    if (renewalProtected || RENEWED_STATUSES.has(status) || lifecycleStatus === "renewed") {
+      return result("renewed", ["ended_with_successor_or_renewal"], {
+        input,
+        startValue,
+        endValue,
+        renewalProtected: true,
+      });
+    }
+    return result("expired", ["end_date_past"], {
+      input,
+      startValue,
+      endValue,
+      renewalProtected,
+    });
+  }
+
+  if (EXPIRED_STATUSES.has(status) || lifecycleStatus === "expired") {
+    return result("expired", ["status_expired"], {
+      input,
+      startValue,
+      endValue,
+      renewalProtected,
+    });
+  }
+
+  if (DRAFT_STATUSES.has(status) || executionStatus === "draft") {
+    return result("draft", ["status_draft"], {
+      input,
+      startValue,
+      endValue,
+      renewalProtected,
+    });
+  }
+
+  return result("unknown", ["insufficient_or_contradictory_lifecycle_data"], {
+    input,
+    startValue,
+    endValue,
+    renewalProtected,
+    requiresReview: true,
+  });
+}
+
+export function deriveUnitOccupancyFromLeaseLifecycle(
+  input: LeaseLifecycleResult | LeaseLifecycleInput | Array<LeaseLifecycleResult | LeaseLifecycleInput> | null | undefined,
+  today: unknown = new Date()
+): UnitOccupancyLifecycleResult {
+  const items = Array.isArray(input) ? input : input ? [input] : [];
+  if (!items.length) return { state: "vacant", reasons: ["no_lease"] };
+
+  const lifecycles = items.map((item) =>
+    typeof (item as LeaseLifecycleResult).state === "string"
+      ? (item as LeaseLifecycleResult)
+      : deriveLeaseLifecycleState(item as LeaseLifecycleInput, today)
+  );
+
+  const review = lifecycles.find((entry) => entry.state === "unknown" || entry.requiresReview);
+  if (review) {
+    return { state: "review_required", reasons: review.reasons, leaseLifecycleState: review.state };
+  }
+
+  const notice = lifecycles.find((entry) => entry.state === "notice_period");
+  if (notice) return { state: "notice_period", reasons: notice.reasons, leaseLifecycleState: notice.state };
+
+  const active = lifecycles.find((entry) => entry.state === "active");
+  if (active) return { state: "occupied", reasons: active.reasons, leaseLifecycleState: active.state };
+
+  const future = lifecycles.find((entry) => entry.state === "signed_future");
+  if (future) return { state: "upcoming", reasons: future.reasons, leaseLifecycleState: future.state };
+
+  return { state: "vacant", reasons: ["no_current_or_upcoming_lease"] };
+}
+
+export function isLeaseExpiringSoon(
+  resultOrLease: LeaseLifecycleResult | LeaseLifecycleInput | null | undefined,
+  today: unknown = new Date(),
+  thresholdDays = 60
+): boolean {
+  if (!resultOrLease) return false;
+  const lifecycle =
+    typeof (resultOrLease as LeaseLifecycleResult).state === "string"
+      ? (resultOrLease as LeaseLifecycleResult)
+      : deriveLeaseLifecycleState(resultOrLease as LeaseLifecycleInput, today);
+  if (lifecycle.state !== "active" && lifecycle.state !== "notice_period") return false;
+  if (!lifecycle.effectiveEndDate) return false;
+  const currentDay = todayDay(today);
+  const endDay = toDay(lifecycle.effectiveEndDate);
+  if (endDay == null || endDay < currentDay) return false;
+  const daysUntilEnd = Math.floor((endDay - currentDay) / DAY_MS);
+  return daysUntilEnd <= thresholdDays;
+}

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.active.test.ts
@@ -170,7 +170,7 @@ describe("leaseRoutes GET /active", () => {
       monthlyRent: 1850,
       dueDay: 1,
       startDate: "2026-01-01",
-      endDate: "2026-12-31",
+      endDate: "2099-12-31",
       status: "active",
       tenantSignature: {
         signedAt: "2026-01-05T12:00:00.000Z",
@@ -254,6 +254,11 @@ describe("leaseRoutes GET /active", () => {
           lifecycleLabel: "Active",
           requiredNextAction: "none",
         }),
+        derivedLifecycleState: "active",
+        derivedLifecycleReasons: ["signed_current_term"],
+        derivedLifecycleRequiresReview: false,
+        derivedLifecycleIsCurrent: true,
+        derivedLifecycleIsOccupancyActive: true,
       })
     );
     expect(res.body?.leases?.[0]?.tenantSignature?.drawnDataUrl).toBeUndefined();

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -39,6 +39,7 @@ import {
 import { buildLeasePaymentProjection } from "../services/projections/buildLeasePaymentProjection";
 import { computeNoResponseState } from "../services/leaseNoticeWorkflowService";
 import { deriveLeaseLifecycleSummary } from "../services/leaseLifecycle/deriveLeaseLifecycleSummary";
+import { deriveLeaseLifecycleState } from "../lib/leases/leaseLifecycle";
 
 const router = Router();
 const LEDGER_COLLECTION = "ledgerEntries";
@@ -132,6 +133,7 @@ function toMillis(value: any): number {
 
 function normalizeLeaseRow(id: string, raw: any) {
   const risk = raw?.risk && typeof raw?.risk === "object" ? raw.risk : null;
+  const lifecycle = deriveLeaseLifecycleState({ id, ...raw });
   return {
     id,
     landlordId: String(raw?.landlordId || "").trim() || null,
@@ -174,6 +176,11 @@ function normalizeLeaseRow(id: string, raw: any) {
     cleanupBatch: String(raw?.cleanupBatch || "").trim() || null,
     createdAt: raw?.createdAt || null,
     updatedAt: raw?.updatedAt || null,
+    derivedLifecycleState: lifecycle.state,
+    derivedLifecycleReasons: lifecycle.reasons,
+    derivedLifecycleRequiresReview: lifecycle.requiresReview,
+    derivedLifecycleIsCurrent: lifecycle.isCurrent,
+    derivedLifecycleIsOccupancyActive: lifecycle.isOccupancyActive,
   };
 }
 

--- a/rentchain-frontend/src/components/properties/PropertyDetailPanel.test.tsx
+++ b/rentchain-frontend/src/components/properties/PropertyDetailPanel.test.tsx
@@ -277,6 +277,61 @@ describe("PropertyDetailPanel", () => {
     expect(screen.queryByText("Jane Tenant")).not.toBeInTheDocument();
   });
 
+  it("shows manually occupied units when manual occupancy has a current lease end date", async () => {
+    mocks.fetchUnitsForProperty.mockResolvedValue([
+      {
+        id: "unit-1",
+        unitNumber: "101",
+        status: "occupied",
+        occupantName: "Leen Bakri-Kasbah and Patricia Emeline Krisinta",
+        leaseEndDate: "2027-04-30",
+        rent: 1800,
+      },
+    ]);
+    mocks.getLeasesForProperty.mockResolvedValue({
+      leases: [
+        {
+          id: "lease-expired",
+          tenantId: "tenant-1",
+          propertyId: "prop-1",
+          unitId: "unit-1",
+          unitNumber: "101",
+          monthlyRent: 1800,
+          startDate: "2025-01-01",
+          endDate: "2026-04-30",
+          status: "active",
+          createdAt: "2025-01-01T00:00:00.000Z",
+          updatedAt: "2025-01-01T00:00:00.000Z",
+        },
+      ],
+      credibilitySummary: null,
+    });
+
+    render(
+      <MemoryRouter>
+        <PropertyDetailPanel
+          property={{
+            id: "prop-1",
+            name: "Harbour View",
+            addressLine1: "12 Wharf Street",
+            city: "Halifax",
+            province: "NS",
+            postalCode: "B3H 1A1",
+            country: "Canada",
+            totalUnits: 1,
+            amenities: [],
+            units: [],
+            createdAt: new Date().toISOString(),
+          }}
+          onRefresh={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    expect((await screen.findAllByText("Occupied")).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("100%").length).toBeGreaterThan(0);
+  });
+
   it("renders safely when lease-backed occupancy falls back from active leases", async () => {
     mocks.fetchUnitsForProperty.mockResolvedValue([
       {

--- a/rentchain-frontend/src/lib/leases/leaseLifecycle.test.ts
+++ b/rentchain-frontend/src/lib/leases/leaseLifecycle.test.ts
@@ -10,6 +10,21 @@ import {
 const today = "2026-05-04";
 
 describe("leaseLifecycle", () => {
+  it("prefers backend derived lifecycle state when present", () => {
+    const lease = {
+      id: "lease-derived",
+      unitId: "unit-1",
+      status: "active",
+      startDate: "2026-01-01",
+      endDate: "2026-12-31",
+      derivedLifecycleState: "expired",
+      derivedLifecycleReasons: ["end_date_past"],
+    };
+
+    expect(deriveLeaseLifecycleStatus(lease, today)).toBe("expired");
+    expect(isLeaseCurrentlyActive(lease, today)).toBe(false);
+  });
+
   it("treats expired leases as expired instead of active", () => {
     const lease = {
       id: "lease-expired",
@@ -91,6 +106,30 @@ describe("leaseLifecycle", () => {
     ).toMatchObject({ status: "vacant", label: "Vacant" });
   });
 
+  it("respects valid manual unit occupancy when only expired leases exist", () => {
+    expect(
+      deriveUnitOccupancyFromLeases(
+        {
+          id: "unit-manual",
+          unitNumber: "105",
+          status: "occupied",
+          occupantName: "Leen Bakri-Kasbah and Patricia Emeline Krisinta",
+          leaseEndDate: "2027-04-30",
+        },
+        [
+          {
+            id: "lease-expired",
+            unitId: "unit-manual",
+            status: "active",
+            startDate: "2025-01-01",
+            endDate: "2026-04-30",
+          },
+        ],
+        today
+      )
+    ).toMatchObject({ status: "occupied", label: "Occupied", lease: null });
+  });
+
   it("returns only currently active leases ending inside the threshold", () => {
     const leases = [
       {
@@ -125,5 +164,23 @@ describe("leaseLifecycle", () => {
     ];
 
     expect(getExpiringSoonLeases(leases, today, 60).map((lease) => lease.id)).toEqual(["lease-29", "lease-60"]);
+  });
+
+  it("maps backend unknown lifecycle to review-required occupancy", () => {
+    expect(
+      deriveUnitOccupancyFromLeases(
+        { id: "unit-review", unitNumber: "105" },
+        [
+          {
+            id: "lease-review",
+            unitId: "unit-review",
+            status: "active",
+            derivedLifecycleState: "unknown",
+            derivedLifecycleRequiresReview: true,
+          },
+        ],
+        today
+      )
+    ).toMatchObject({ status: "review_required", label: "Review required" });
   });
 });

--- a/rentchain-frontend/src/lib/leases/leaseLifecycle.ts
+++ b/rentchain-frontend/src/lib/leases/leaseLifecycle.ts
@@ -7,13 +7,14 @@ export type LeaseLifecycleStatus =
   | "expired"
   | "renewed"
   | "terminated"
-  | "cancelled";
+  | "cancelled"
+  | "unknown";
 
-export type UnitOccupancyStatus = "vacant" | "occupied" | "notice_period" | "upcoming";
+export type UnitOccupancyStatus = "vacant" | "occupied" | "notice_period" | "upcoming" | "review_required";
 
 export type UnitOccupancy = {
   status: UnitOccupancyStatus;
-  label: "Vacant" | "Occupied" | "Notice period" | "Upcoming";
+  label: "Vacant" | "Occupied" | "Notice period" | "Upcoming" | "Review required";
   lease: LeaseLike | null;
 };
 
@@ -43,6 +44,9 @@ export type LeaseLike = {
     lifecycleStatus?: string | null;
     renewalOutcome?: string | null;
   } | null;
+  derivedLifecycleState?: string | null;
+  derivedLifecycleReasons?: string[] | null;
+  derivedLifecycleRequiresReview?: boolean | null;
 };
 
 type UnitLike = {
@@ -51,6 +55,13 @@ type UnitLike = {
   unitNumber?: string | null;
   label?: string | null;
   name?: string | null;
+  status?: string | null;
+  occupancyStatus?: string | null;
+  occupantName?: string | null;
+  tenantName?: string | null;
+  occupants?: string[] | null;
+  leaseEndDate?: string | number | Date | null;
+  leaseEnd?: string | number | Date | null;
 };
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -67,6 +78,19 @@ const PENDING_SIGNATURE_STATUSES = new Set([
   "tenant_signed",
   "ready_for_landlord_signature",
   "landlord_signed",
+]);
+
+const CANONICAL_LIFECYCLE_STATUSES = new Set<LeaseLifecycleStatus>([
+  "draft",
+  "pending_signature",
+  "signed_future",
+  "active",
+  "notice_period",
+  "expired",
+  "renewed",
+  "terminated",
+  "cancelled",
+  "unknown",
 ]);
 
 function normalize(value: unknown): string {
@@ -129,11 +153,20 @@ function hasRenewalReplacement(lease: LeaseLike): boolean {
   );
 }
 
+function backendDerivedLifecycleStatus(lease: LeaseLike): LeaseLifecycleStatus | null {
+  const derived = normalize(lease.derivedLifecycleState);
+  return CANONICAL_LIFECYCLE_STATUSES.has(derived as LeaseLifecycleStatus)
+    ? (derived as LeaseLifecycleStatus)
+    : null;
+}
+
 export function deriveLeaseLifecycleStatus(
   lease: LeaseLike | null | undefined,
   today: string | number | Date = new Date()
 ): LeaseLifecycleStatus {
   if (!lease) return "draft";
+  const derived = backendDerivedLifecycleStatus(lease);
+  if (derived) return derived;
 
   const status = normalize(lease.status);
   const lifecycleStatus = normalize(lease.leaseLifecycleSummary?.lifecycleStatus);
@@ -193,6 +226,24 @@ function leaseIdentifiers(lease: LeaseLike): string[] {
   );
 }
 
+function hasManualOccupant(unit: UnitLike): boolean {
+  return Boolean(
+    String(unit.occupantName || unit.tenantName || "").trim() ||
+      (Array.isArray(unit.occupants) && unit.occupants.some((value) => String(value || "").trim()))
+  );
+}
+
+function hasCurrentManualLeaseEnd(unit: UnitLike, today: string | number | Date): boolean {
+  const endDay = toDay(unit.leaseEndDate ?? unit.leaseEnd);
+  if (endDay == null) return false;
+  return endDay >= todayDay(today);
+}
+
+function hasManualCurrentOccupancy(unit: UnitLike, today: string | number | Date): boolean {
+  const status = normalize(unit.occupancyStatus || unit.status);
+  return status === "occupied" && hasManualOccupant(unit) && hasCurrentManualLeaseEnd(unit, today);
+}
+
 export function leasesForUnit(unit: UnitLike, leases: LeaseLike[]): LeaseLike[] {
   const ids = new Set(unitIdentifiers(unit));
   if (!ids.size) return [];
@@ -212,6 +263,9 @@ export function deriveUnitOccupancyFromLeases(
     status: deriveLeaseLifecycleStatus(lease, today),
   }));
 
+  const review = withLifecycle.find((item) => item.status === "unknown" || item.lease.derivedLifecycleRequiresReview === true);
+  if (review) return { status: "review_required", label: "Review required", lease: review.lease };
+
   const notice = withLifecycle.find((item) => item.status === "notice_period");
   if (notice) return { status: "notice_period", label: "Notice period", lease: notice.lease };
 
@@ -220,6 +274,10 @@ export function deriveUnitOccupancyFromLeases(
 
   const upcoming = withLifecycle.find((item) => item.status === "signed_future");
   if (upcoming) return { status: "upcoming", label: "Upcoming", lease: upcoming.lease };
+
+  if (hasManualCurrentOccupancy(unit, today)) {
+    return { status: "occupied", label: "Occupied", lease: null };
+  }
 
   return { status: "vacant", label: "Vacant", lease: null };
 }

--- a/rentchain-frontend/src/lib/propertySummaryMetrics.test.ts
+++ b/rentchain-frontend/src/lib/propertySummaryMetrics.test.ts
@@ -76,4 +76,109 @@ describe("buildPropertySummaryMetrics", () => {
     expect(metrics.activeLeaseRentTotal).toBe(0);
     expect(metrics.currentOccupiedRentTotal).toBe(0);
   });
+
+  it("counts valid manual occupancy when expired leases are the only lease records", () => {
+    const metrics = buildPropertySummaryMetrics(
+      [
+        {
+          id: "unit-1",
+          unitNumber: "101",
+          status: "occupied",
+          occupantName: "Leen Bakri-Kasbah and Patricia Emeline Krisinta",
+          leaseEndDate: "2027-04-30",
+          rent: 1800,
+        },
+      ],
+      [
+        {
+          id: "lease-expired",
+          tenantId: "tenant-1",
+          propertyId: "prop-1",
+          unitId: "unit-1",
+          unitNumber: "101",
+          monthlyRent: 1800,
+          startDate: "2025-01-01",
+          endDate: "2026-04-30",
+          status: "active",
+          createdAt: "2025-01-01T00:00:00.000Z",
+          updatedAt: "2025-01-01T00:00:00.000Z",
+        },
+      ],
+      1,
+      "2026-05-04"
+    );
+
+    expect(metrics.leasedUnits).toHaveLength(1);
+    expect(metrics.occupancyRate).toBe(100);
+    expect(metrics.activeLeaseRentTotal).toBe(0);
+    expect(metrics.currentOccupiedRentTotal).toBe(1800);
+  });
+
+  it("keeps signed future leases as upcoming instead of manual occupied", () => {
+    const metrics = buildPropertySummaryMetrics(
+      [
+        {
+          id: "unit-1",
+          unitNumber: "101",
+          status: "occupied",
+          occupantName: "Future Tenant",
+          leaseEndDate: "2027-04-30",
+          rent: 1800,
+        },
+      ],
+      [
+        {
+          id: "lease-future",
+          tenantId: "tenant-1",
+          propertyId: "prop-1",
+          unitId: "unit-1",
+          unitNumber: "101",
+          monthlyRent: 1800,
+          startDate: "2026-06-01",
+          endDate: "2027-05-31",
+          status: "active",
+          signatureStatus: "signed",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+      1,
+      "2026-05-04"
+    );
+
+    expect(metrics.leasedUnits).toHaveLength(0);
+    expect(metrics.occupancyRate).toBe(0);
+    expect(metrics.currentOccupiedRentTotal).toBe(0);
+  });
+
+  it("uses backend derived lifecycle state for occupancy when present", () => {
+    const metrics = buildPropertySummaryMetrics(
+      [
+        {
+          id: "unit-1",
+          unitNumber: "101",
+          status: "vacant",
+          rent: 1800,
+        },
+      ],
+      [
+        {
+          id: "lease-derived",
+          tenantId: "tenant-1",
+          propertyId: "prop-1",
+          unitId: "unit-1",
+          unitNumber: "101",
+          monthlyRent: 1800,
+          status: "active",
+          derivedLifecycleState: "signed_future",
+        },
+      ],
+      1,
+      "2026-05-04"
+    );
+
+    expect(metrics.leasedUnits).toHaveLength(0);
+    expect(metrics.occupancyRate).toBe(0);
+    expect(metrics.currentOccupiedRentTotal).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary
- Adds backend canonical lease lifecycle derivation for draft, pending_signature, signed_future, active, notice_period, expired, renewed, terminated, cancelled, and unknown.
- Treats stored lease.status as a compatibility hint rather than a blind source of truth.
- Adds deterministic occupancy mapping for occupied, notice_period, upcoming, vacant, and review_required.
- Adds expiring-soon logic that only includes active and notice_period leases.
- Adds additive derived lifecycle fields to lease rows.
- Updates admin/landlord analytics to use canonical lifecycle logic.
- Aligns frontend lifecycle helper to prefer backend derivedLifecycleState when present.
- Preserves manual unit occupancy override when unit.status is occupied, occupant data exists, and leaseEndDate is current/future.
- Preserves expired-lease-alone behavior as Vacant.
- Adds architecture documentation.
- No schema migration, stored status rewrite, Trustly, PaymentIntent, payment architecture, dependency, or lockfile changes.

## Verification
- Backend lease lifecycle/route tests passed: 31 tests.
- Backend build passed.
- Frontend focused tests passed: 18 tests.
- Full frontend suite passed on rerun: 180 files / 733 tests.
- Frontend build passed with existing chunk-size warning.
- git diff --check passed.
- dependency/lockfile diff empty.

## Notes
- One frontend full-suite run had a transient unrelated failure in `PortfolioScoreHistoryPage.test.tsx`; rerunning `pnpm test` immediately after passed cleanly with 180 files / 733 tests.