### PR TITLE
Add lease lifecycle review queue

### DIFF
--- a/docs/architecture/lease-state-machine-v1.md
+++ b/docs/architecture/lease-state-machine-v1.md
@@ -51,11 +51,37 @@ Phase 2 exposes additive derived lifecycle fields in lease view models.
 Phase 3 aligns frontend helper semantics and prefers backend-derived lifecycle fields when present.
 Phase 4 uses the derived lifecycle in safe display contexts such as lease badges, unit occupancy, and portfolio health/expiring-soon summaries.
 
+## Lease Lifecycle Review Queue V1
+
+The review queue surfaces lifecycle records that need operator attention without mutating leases, unit records, or stored statuses. It is an admin/operator visibility layer, not an automation or correction workflow.
+
+Review criteria include:
+
+- `derivedLifecycleState === "unknown"`
+- `derivedLifecycleRequiresReview === true`
+- contradictory or incomplete lifecycle derivation reasons
+- missing critical start or end dates on current/signed leases
+- stored active/current status with a past end date
+- expired lease plus current manual occupied unit data
+- ambiguous renewal or successor links
+- termination or notice fields that conflict with lifecycle interpretation
+
+Queue items use read-only severity and category metadata:
+
+- Severities: `critical`, `warning`, `info`
+- Categories: `unknown_lifecycle`, `missing_dates`, `contradictory_status`, `expired_occupancy_conflict`, `renewal_ambiguity`, `termination_conflict`, `notice_conflict`
+
+Recommended actions are non-mutating prompts such as reviewing lease dates, reviewing renewal links, reviewing termination notice, confirming occupancy manually, opening a property/unit record, or opening a lease record.
+
 ## Deferred Future Steps
 
 1. Stored lifecycle transition events.
 2. Scheduled lease lifecycle reconciliation job.
-3. Admin review queue for contradictory leases.
-4. Lease renewal workflow enforcement.
-5. Payment obligation generation from active lease lifecycle.
-6. Institution-ready lease export schema.
+3. Operator acknowledgement state.
+4. Review assignment/owner.
+5. Auto-created admin triage queue items.
+6. Landlord-safe warning surfacing.
+7. Lifecycle correction workflow.
+8. Lease renewal workflow enforcement.
+9. Payment obligation generation from active lease lifecycle.
+10. Institution-ready lease export schema.

--- a/rentchain-api/src/lib/leases/__tests__/leaseLifecycleReviewQueue.test.ts
+++ b/rentchain-api/src/lib/leases/__tests__/leaseLifecycleReviewQueue.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveLeaseLifecycleReviewItem,
+  deriveLeaseLifecycleReviewQueue,
+} from "../leaseLifecycleReviewQueue";
+
+const today = "2026-05-05";
+const detectedAt = "2026-05-05T12:00:00.000Z";
+
+describe("leaseLifecycleReviewQueue", () => {
+  it("creates a critical item for unknown lifecycle", () => {
+    const item = deriveLeaseLifecycleReviewItem({
+      lease: {
+        id: "lease-unknown",
+        landlordId: "landlord-1",
+        propertyId: "property-1",
+        unitId: "unit-1",
+        status: "active",
+        startDate: "2026-12-31",
+        endDate: "2026-01-01",
+      },
+      today,
+      detectedAt,
+    });
+
+    expect(item).toMatchObject({
+      id: "lease_lifecycle:lease-unknown:unknown_lifecycle",
+      leaseId: "lease-unknown",
+      landlordId: "landlord-1",
+      propertyId: "property-1",
+      unitId: "unit-1",
+      derivedLifecycleState: "unknown",
+      severity: "critical",
+      category: "unknown_lifecycle",
+      recommendedAction: "Open lease record",
+      createdFrom: "lease_lifecycle_review_queue_v1",
+      detectedAt,
+    });
+    expect(item?.derivedLifecycleReasons).toContain("date_range_invalid");
+  });
+
+  it("creates an item when canonical lifecycle requires review", () => {
+    const item = deriveLeaseLifecycleReviewItem({
+      lease: {
+        id: "lease-review",
+        status: "unexpected_status",
+        startDate: "2026-01-01",
+        endDate: "2026-12-31",
+      },
+      today,
+      detectedAt,
+    });
+
+    expect(item).toMatchObject({
+      leaseId: "lease-review",
+      derivedLifecycleState: "unknown",
+      severity: "critical",
+      category: "unknown_lifecycle",
+    });
+  });
+
+  it("does not flag a valid active lease", () => {
+    const item = deriveLeaseLifecycleReviewItem({
+      lease: {
+        id: "lease-active",
+        status: "active",
+        signedAt: "2026-01-01",
+        startDate: "2026-01-01",
+        endDate: "2026-12-31",
+      },
+      today,
+      detectedAt,
+    });
+
+    expect(item).toBeNull();
+  });
+
+  it("flags expired occupancy conflicts when manual unit occupancy is current", () => {
+    const item = deriveLeaseLifecycleReviewItem({
+      lease: {
+        id: "lease-expired",
+        status: "active",
+        signedAt: "2025-01-01",
+        startDate: "2025-01-01",
+        endDate: "2026-04-30",
+        unitId: "unit-1",
+      },
+      unit: {
+        id: "unit-1",
+        status: "occupied",
+        occupantName: "Leen Bakri-Kasbah",
+        leaseEndDate: "2027-04-30",
+      },
+      today,
+      detectedAt,
+    });
+
+    expect(item).toMatchObject({
+      leaseId: "lease-expired",
+      derivedLifecycleState: "expired",
+      severity: "warning",
+      category: "expired_occupancy_conflict",
+      recommendedAction: "Confirm occupancy manually",
+    });
+  });
+
+  it("flags missing dates for active-like leases", () => {
+    const item = deriveLeaseLifecycleReviewItem({
+      lease: {
+        id: "lease-missing-dates",
+        status: "active",
+        signedAt: "2026-01-01",
+        startDate: "2026-01-01",
+      },
+      today,
+      detectedAt,
+    });
+
+    expect(item).toMatchObject({
+      leaseId: "lease-missing-dates",
+      severity: "critical",
+      category: "missing_dates",
+      recommendedAction: "Review lease dates",
+    });
+  });
+
+  it("flags termination conflicts", () => {
+    const item = deriveLeaseLifecycleReviewItem({
+      lease: {
+        id: "lease-termination",
+        status: "active",
+        signedAt: "2026-01-01",
+        startDate: "2026-01-01",
+        endDate: "2026-12-31",
+        terminationDate: "2026-08-01",
+      },
+      today,
+      detectedAt,
+    });
+
+    expect(item).toMatchObject({
+      leaseId: "lease-termination",
+      severity: "warning",
+      category: "termination_conflict",
+      recommendedAction: "Review termination notice",
+    });
+  });
+
+  it("flags renewal ambiguity", () => {
+    const item = deriveLeaseLifecycleReviewItem({
+      lease: {
+        id: "lease-renewal",
+        status: "expired",
+        startDate: "2025-01-01",
+        endDate: "2026-04-30",
+        renewalLeaseId: "lease-next-1",
+        successorLeaseId: "lease-next-2",
+      },
+      today,
+      detectedAt,
+    });
+
+    expect(item).toMatchObject({
+      leaseId: "lease-renewal",
+      severity: "warning",
+      category: "renewal_ambiguity",
+      recommendedAction: "Review renewal link",
+    });
+  });
+
+  it("counts queue severities and sorts critical items first", () => {
+    const queue = deriveLeaseLifecycleReviewQueue({
+      leases: [
+        {
+          id: "lease-valid",
+          status: "active",
+          signedAt: "2026-01-01",
+          startDate: "2026-01-01",
+          endDate: "2026-12-31",
+        },
+        {
+          id: "lease-warning",
+          status: "active",
+          signedAt: "2025-01-01",
+          startDate: "2025-01-01",
+          endDate: "2026-04-30",
+          unitId: "unit-1",
+        },
+        {
+          id: "lease-critical",
+          status: "active",
+          startDate: "2026-12-31",
+          endDate: "2026-01-01",
+        },
+      ],
+      units: [
+        {
+          id: "unit-1",
+          status: "occupied",
+          occupantName: "Manual Occupant",
+          leaseEndDate: "2027-04-30",
+        },
+      ],
+      today,
+      detectedAt,
+    });
+
+    expect(queue.summary).toEqual({
+      total: 2,
+      critical: 1,
+      warning: 1,
+      info: 0,
+    });
+    expect(queue.items.map((item) => item.leaseId)).toEqual(["lease-critical", "lease-warning"]);
+  });
+});

--- a/rentchain-api/src/lib/leases/leaseLifecycleReviewQueue.ts
+++ b/rentchain-api/src/lib/leases/leaseLifecycleReviewQueue.ts
@@ -1,0 +1,368 @@
+import { deriveLeaseLifecycleState, type LeaseLifecycleResult, type LeaseLifecycleState } from "./leaseLifecycle";
+
+export type LeaseLifecycleReviewSeverity = "info" | "warning" | "critical";
+
+export type LeaseLifecycleReviewCategory =
+  | "unknown_lifecycle"
+  | "missing_dates"
+  | "contradictory_status"
+  | "expired_occupancy_conflict"
+  | "renewal_ambiguity"
+  | "termination_conflict"
+  | "notice_conflict";
+
+export type LeaseLifecycleReviewItem = {
+  id: string;
+  leaseId: string;
+  propertyId: string | null;
+  unitId: string | null;
+  landlordId: string | null;
+  tenantId?: string | null;
+  derivedLifecycleState: LeaseLifecycleState;
+  derivedLifecycleReasons: string[];
+  severity: LeaseLifecycleReviewSeverity;
+  category: LeaseLifecycleReviewCategory;
+  title: string;
+  description: string;
+  recommendedAction: string;
+  createdFrom: "lease_lifecycle_review_queue_v1";
+  detectedAt: string;
+};
+
+export type LeaseLifecycleReviewQueueResult = {
+  items: LeaseLifecycleReviewItem[];
+  summary: {
+    total: number;
+    critical: number;
+    warning: number;
+    info: number;
+  };
+};
+
+export type LeaseLifecycleReviewQueueInput = {
+  leases: unknown[];
+  units?: unknown[];
+  today?: unknown;
+  detectedAt?: string;
+};
+
+const SEVERITY_RANK: Record<LeaseLifecycleReviewSeverity, number> = {
+  critical: 0,
+  warning: 1,
+  info: 2,
+};
+
+function asString(value: unknown, max = 240): string {
+  return String(value || "").trim().slice(0, max);
+}
+
+function normalize(value: unknown): string {
+  return asString(value).toLowerCase();
+}
+
+function firstValue(...values: unknown[]): unknown {
+  return values.find((value) => value != null && value !== "");
+}
+
+function toDate(value: unknown): Date | null {
+  if (value == null || value === "") return null;
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+  if (typeof (value as any)?.toDate === "function") {
+    try {
+      const date = (value as any).toDate();
+      return date instanceof Date && !Number.isNaN(date.getTime()) ? date : null;
+    } catch {
+      return null;
+    }
+  }
+  if (typeof (value as any)?.toMillis === "function") {
+    try {
+      const date = new Date((value as any).toMillis());
+      return Number.isNaN(date.getTime()) ? null : date;
+    } catch {
+      return null;
+    }
+  }
+  if (typeof (value as any)?.seconds === "number") {
+    const date = new Date((value as any).seconds * 1000);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+  const date = new Date(String(value));
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function toDay(value: unknown): number | null {
+  const date = toDate(value);
+  if (!date) return null;
+  return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+}
+
+function todayDay(today: unknown): number {
+  return toDay(today) ?? toDay(new Date()) ?? Date.now();
+}
+
+function hasAnyDate(...values: unknown[]): boolean {
+  return values.some((value) => toDay(value) != null);
+}
+
+function hasValue(value: unknown): boolean {
+  return asString(value).length > 0;
+}
+
+function tenantId(raw: Record<string, unknown>): string | null {
+  const fromArray = Array.isArray(raw.tenantIds) ? asString(raw.tenantIds[0]) : "";
+  return asString(raw.tenantId || raw.primaryTenantId || fromArray) || null;
+}
+
+function criticalDateValues(raw: Record<string, unknown>) {
+  return {
+    startValue: firstValue(raw.startDate, raw.leaseStartDate, raw.leaseStart),
+    endValue: firstValue(raw.endDate, raw.leaseEndDate, raw.leaseEnd),
+    terminationValue: firstValue(raw.terminatedAt, raw.terminationDate),
+    noticeValue: firstValue(raw.noticeGivenAt, raw.noticeEffectiveDate, raw.noticeDate, raw.noticeAt),
+  };
+}
+
+function buildUnitLookup(units: unknown[] | undefined) {
+  const out = new Map<string, Record<string, unknown>>();
+  for (const unit of Array.isArray(units) ? units : []) {
+    const raw = (unit || {}) as Record<string, unknown>;
+    const keys = [
+      raw.id,
+      raw.unitId,
+      raw.uid,
+      raw.unitNumber,
+      raw.label,
+      raw.name,
+      raw.unit,
+    ]
+      .map((value) => normalize(value))
+      .filter(Boolean);
+    for (const key of keys) out.set(key, raw);
+  }
+  return out;
+}
+
+function unitForLease(lease: Record<string, unknown>, unitsByKey: Map<string, Record<string, unknown>>) {
+  const keys = [lease.unitId, lease.unitNumber, lease.unitLabel, lease.unit]
+    .map((value) => normalize(value))
+    .filter(Boolean);
+  for (const key of keys) {
+    const unit = unitsByKey.get(key);
+    if (unit) return unit;
+  }
+  return null;
+}
+
+function hasManualOccupant(unit: Record<string, unknown> | null): boolean {
+  if (!unit) return false;
+  if (hasValue(unit.occupantName) || hasValue(unit.tenantName)) return true;
+  return Array.isArray(unit.occupants) && unit.occupants.some((value) => hasValue(value));
+}
+
+function hasCurrentManualOccupancy(unit: Record<string, unknown> | null, today: unknown): boolean {
+  if (!unit) return false;
+  const status = normalize(unit.occupancyStatus || unit.status);
+  if (status !== "occupied") return false;
+  if (!hasManualOccupant(unit)) return false;
+  const endDay = toDay(firstValue(unit.leaseEndDate, unit.leaseEnd));
+  return endDay != null && endDay >= todayDay(today);
+}
+
+function hasRenewalAmbiguity(raw: Record<string, unknown>) {
+  const links = [raw.renewalLeaseId, raw.renewedByLeaseId, raw.successorLeaseId, raw.replacedByLeaseId]
+    .map((value) => asString(value))
+    .filter(Boolean);
+  if (links.length > 1 && new Set(links).size > 1) return true;
+  return Boolean((raw.renewalLeaseId || raw.successorLeaseId || raw.replacedByLeaseId) && raw.hasRenewalLease === false);
+}
+
+function hasTerminationConflict(raw: Record<string, unknown>, lifecycle: LeaseLifecycleResult, today: unknown) {
+  const status = normalize(raw.status);
+  const terminationDate = toDay(firstValue(raw.terminatedAt, raw.terminationDate));
+  if (terminationDate != null && (lifecycle.state === "active" || lifecycle.state === "notice_period")) return true;
+  return (status === "active" || status === "current") && terminationDate != null && terminationDate > todayDay(today);
+}
+
+function hasNoticeConflict(raw: Record<string, unknown>, lifecycle: LeaseLifecycleResult) {
+  const status = normalize(raw.status);
+  const noticeExists = hasAnyDate(raw.noticeGivenAt, raw.noticeEffectiveDate, raw.noticeDate, raw.noticeAt, raw.moveOutDate);
+  if (!noticeExists) return false;
+  if (lifecycle.state === "terminated" || lifecycle.state === "cancelled" || lifecycle.state === "renewed") return true;
+  return status === "expired";
+}
+
+function hasMissingDates(raw: Record<string, unknown>, lifecycle: LeaseLifecycleResult) {
+  const { startValue, endValue } = criticalDateValues(raw);
+  const status = normalize(raw.status);
+  const needsDates =
+    lifecycle.state === "active" ||
+    lifecycle.state === "notice_period" ||
+    lifecycle.state === "signed_future" ||
+    status === "active" ||
+    status === "current";
+  return needsDates && (!toDay(startValue) || !toDay(endValue));
+}
+
+function classifyReviewItem(params: {
+  raw: Record<string, unknown>;
+  lifecycle: LeaseLifecycleResult;
+  unit: Record<string, unknown> | null;
+  today: unknown;
+}): Omit<LeaseLifecycleReviewItem, "id" | "leaseId" | "propertyId" | "unitId" | "landlordId" | "tenantId" | "derivedLifecycleState" | "derivedLifecycleReasons" | "createdFrom" | "detectedAt"> | null {
+  const { raw, lifecycle, unit, today } = params;
+  const status = normalize(raw.status);
+  const { startValue, endValue, terminationValue, noticeValue } = criticalDateValues(raw);
+
+  if (lifecycle.state === "unknown" || lifecycle.requiresReview) {
+    return {
+      severity: "critical",
+      category: "unknown_lifecycle",
+      title: "Lease lifecycle needs review",
+      description: "Canonical lifecycle derivation could not safely classify this lease.",
+      recommendedAction: "Open lease record",
+    };
+  }
+
+  if (toDay(startValue) != null && toDay(endValue) != null && toDay(startValue)! > toDay(endValue)!) {
+    return {
+      severity: "critical",
+      category: "contradictory_status",
+      title: "Lease date range is invalid",
+      description: "The lease start date is after the lease end date.",
+      recommendedAction: "Review lease dates",
+    };
+  }
+
+  if (hasMissingDates(raw, lifecycle)) {
+    return {
+      severity: "critical",
+      category: "missing_dates",
+      title: "Lease is missing critical dates",
+      description: "The lease appears current or signed but is missing a usable start or end date.",
+      recommendedAction: "Review lease dates",
+    };
+  }
+
+  if ((status === "active" || status === "current") && lifecycle.state === "expired") {
+    if (hasCurrentManualOccupancy(unit, today)) {
+      return {
+        severity: "warning",
+        category: "expired_occupancy_conflict",
+        title: "Expired lease conflicts with manual occupancy",
+        description: "The lease is expired, but the unit has current manual occupied data.",
+        recommendedAction: "Confirm occupancy manually",
+      };
+    }
+    return {
+      severity: "warning",
+      category: "contradictory_status",
+      title: "Stored lease status conflicts with end date",
+      description: "Stored status appears active, but the canonical lifecycle is expired.",
+      recommendedAction: "Review lease dates",
+    };
+  }
+
+  if (hasRenewalAmbiguity(raw)) {
+    return {
+      severity: "warning",
+      category: "renewal_ambiguity",
+      title: "Renewal or successor link is ambiguous",
+      description: "The lease has multiple or incomplete renewal/successor signals.",
+      recommendedAction: "Review renewal link",
+    };
+  }
+
+  if (hasTerminationConflict(raw, lifecycle, today) || (toDay(terminationValue) != null && toDay(noticeValue) != null && lifecycle.state === "active")) {
+    return {
+      severity: "warning",
+      category: "termination_conflict",
+      title: "Termination data needs review",
+      description: "Termination fields conflict with the current lifecycle interpretation.",
+      recommendedAction: "Review termination notice",
+    };
+  }
+
+  if (hasNoticeConflict(raw, lifecycle)) {
+    return {
+      severity: "info",
+      category: "notice_conflict",
+      title: "Notice data needs review",
+      description: "Notice or move-out fields conflict with the current lifecycle interpretation.",
+      recommendedAction: "Review termination notice",
+    };
+  }
+
+  return null;
+}
+
+export function deriveLeaseLifecycleReviewItem(input: {
+  lease: unknown;
+  unit?: unknown;
+  today?: unknown;
+  detectedAt?: string;
+}): LeaseLifecycleReviewItem | null {
+  const raw = (input.lease || {}) as Record<string, unknown>;
+  const leaseId = asString(raw.id || raw.leaseId);
+  if (!leaseId) return null;
+  const today = input.today ?? new Date();
+  const lifecycle = deriveLeaseLifecycleState({ id: leaseId, ...(raw as any) }, today);
+  const classification = classifyReviewItem({
+    raw,
+    lifecycle,
+    unit: input.unit ? ((input.unit || {}) as Record<string, unknown>) : null,
+    today,
+  });
+  if (!classification) return null;
+
+  return {
+    id: `lease_lifecycle:${leaseId}:${classification.category}`,
+    leaseId,
+    propertyId: asString(raw.propertyId) || null,
+    unitId: asString(raw.unitId) || null,
+    landlordId: asString(raw.landlordId) || null,
+    tenantId: tenantId(raw),
+    derivedLifecycleState: lifecycle.state,
+    derivedLifecycleReasons: lifecycle.reasons,
+    ...classification,
+    createdFrom: "lease_lifecycle_review_queue_v1",
+    detectedAt: input.detectedAt || new Date().toISOString(),
+  };
+}
+
+export function deriveLeaseLifecycleReviewQueue(input: LeaseLifecycleReviewQueueInput): LeaseLifecycleReviewQueueResult {
+  const unitsByKey = buildUnitLookup(input.units);
+  const items = (Array.isArray(input.leases) ? input.leases : [])
+    .map((lease) => {
+      const raw = (lease || {}) as Record<string, unknown>;
+      return deriveLeaseLifecycleReviewItem({
+        lease,
+        unit: unitForLease(raw, unitsByKey) || undefined,
+        today: input.today,
+        detectedAt: input.detectedAt,
+      });
+    })
+    .filter(Boolean) as LeaseLifecycleReviewItem[];
+
+  items.sort((a, b) => {
+    const severityDiff = SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity];
+    if (severityDiff !== 0) return severityDiff;
+    const dateDiff = String(b.detectedAt).localeCompare(String(a.detectedAt));
+    if (dateDiff !== 0) return dateDiff;
+    return a.id.localeCompare(b.id);
+  });
+
+  return {
+    items,
+    summary: {
+      total: items.length,
+      critical: items.filter((item) => item.severity === "critical").length,
+      warning: items.filter((item) => item.severity === "warning").length,
+      info: items.filter((item) => item.severity === "info").length,
+    },
+  };
+}

--- a/rentchain-api/src/routes/__tests__/adminLeaseLifecycleReviewQueueRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/adminLeaseLifecycleReviewQueueRoutes.test.ts
@@ -1,0 +1,234 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { collections, dbMock } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, any>>();
+
+  function ensureCollection(name: string) {
+    if (!collections.has(name)) {
+      collections.set(name, new Map<string, any>());
+    }
+    return collections.get(name)!;
+  }
+
+  return {
+    collections,
+    dbMock: {
+      collection: (name: string) => ({
+        async get() {
+          const docs = Array.from(ensureCollection(name).entries()).map(([id, data]) => ({
+            id,
+            data: () => data,
+          }));
+          return { docs, empty: docs.length === 0, size: docs.length };
+        },
+      }),
+    },
+  };
+});
+
+vi.mock("../../config/firebase", () => ({
+  db: dbMock,
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!req.user) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    return next();
+  },
+}));
+
+function seedDoc(collectionName: string, id: string, data: any) {
+  if (!collections.has(collectionName)) {
+    collections.set(collectionName, new Map<string, any>());
+  }
+  collections.get(collectionName)!.set(id, { id, ...data });
+}
+
+async function invokeRouter(
+  router: any,
+  options: { method: string; url: string; user?: Record<string, unknown> | null }
+) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    const query = new URLSearchParams(queryString || "");
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: options.user ?? null,
+      query: Object.fromEntries(query.entries()),
+      params: {},
+      headers: {},
+      get(name: string) {
+        return this.headers[String(name).toLowerCase()];
+      },
+      header(name: string) {
+        return this.get(name);
+      },
+    };
+    const res: any = {
+      statusCode: 200,
+      headers: {} as Record<string, string>,
+      setHeader(name: string, value: string) {
+        this.headers[name.toLowerCase()] = value;
+      },
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+      send(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+const adminUser = {
+  id: "admin-1",
+  role: "admin",
+  permissions: [],
+  revokedPermissions: [],
+};
+
+describe("admin lease lifecycle review queue route", () => {
+  beforeEach(() => {
+    collections.clear();
+  });
+
+  it("requires admin permission", async () => {
+    const router = (await import("../adminLeasesRoutes")).default;
+
+    const unauthenticated = await invokeRouter(router, {
+      method: "GET",
+      url: "/lease-lifecycle-review-queue",
+    });
+    expect(unauthenticated.status).toBe(401);
+
+    const forbidden = await invokeRouter(router, {
+      method: "GET",
+      url: "/lease-lifecycle-review-queue",
+      user: { id: "landlord-1", role: "landlord", permissions: [], revokedPermissions: [] },
+    });
+    expect(forbidden.status).toBe(403);
+  });
+
+  it("returns stable queue summary and redacted review items for admin users", async () => {
+    seedDoc("leases", "lease-active", {
+      status: "active",
+      propertyId: "property-1",
+      unitId: "unit-1",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      startDate: "2026-01-01",
+      endDate: "2026-12-31",
+      tenantSignedAt: "2025-12-15T12:00:00.000Z",
+      landlordSignedAt: "2025-12-16T12:00:00.000Z",
+    });
+    seedDoc("leases", "lease-unknown", {
+      status: "active",
+      propertyId: "property-1",
+      unitId: "unit-2",
+      landlordId: "landlord-1",
+      startDate: "2026-12-31",
+      endDate: "2026-01-01",
+      tenantSignedAt: "2025-12-15T12:00:00.000Z",
+      landlordSignedAt: "2025-12-16T12:00:00.000Z",
+    });
+    seedDoc("leases", "lease-conflict", {
+      status: "active",
+      propertyId: "property-2",
+      unitId: "unit-3",
+      landlordId: "landlord-2",
+      startDate: "2025-01-01",
+      endDate: "2025-12-31",
+      tenantSignedAt: "2024-12-15T12:00:00.000Z",
+      landlordSignedAt: "2024-12-16T12:00:00.000Z",
+    });
+    seedDoc("units", "unit-3", {
+      status: "occupied",
+      occupantName: "Manual Occupant",
+      leaseEndDate: "2027-04-30",
+    });
+
+    const router = (await import("../adminLeasesRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/lease-lifecycle-review-queue?today=2026-05-05&limit=10",
+      user: adminUser,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        ok: true,
+        summary: {
+          total: 2,
+          critical: 1,
+          warning: 1,
+          info: 0,
+        },
+      })
+    );
+    expect(response.body.items).toHaveLength(2);
+    expect(response.body.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          leaseId: "lease-unknown",
+          category: "unknown_lifecycle",
+          severity: "critical",
+          recommendedAction: "Open lease record",
+          createdFrom: "lease_lifecycle_review_queue_v1",
+        }),
+        expect.objectContaining({
+          leaseId: "lease-conflict",
+          category: "expired_occupancy_conflict",
+          severity: "warning",
+          recommendedAction: "Confirm occupancy manually",
+        }),
+      ])
+    );
+    expect(response.body.items[0]).not.toHaveProperty("raw");
+    expect(response.body.items[0]).not.toHaveProperty("payload");
+  });
+
+  it("returns an empty queue for valid leases", async () => {
+    seedDoc("leases", "lease-active", {
+      status: "active",
+      propertyId: "property-1",
+      unitId: "unit-1",
+      landlordId: "landlord-1",
+      startDate: "2026-01-01",
+      endDate: "2026-12-31",
+      tenantSignedAt: "2025-12-15T12:00:00.000Z",
+      landlordSignedAt: "2025-12-16T12:00:00.000Z",
+    });
+
+    const router = (await import("../adminLeasesRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/lease-lifecycle-review-queue?today=2026-05-05",
+      user: adminUser,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      ok: true,
+      items: [],
+      summary: {
+        total: 0,
+        critical: 0,
+        warning: 0,
+        info: 0,
+      },
+    });
+  });
+});

--- a/rentchain-api/src/routes/adminLeasesRoutes.ts
+++ b/rentchain-api/src/routes/adminLeasesRoutes.ts
@@ -1,11 +1,60 @@
 import { Router } from "express";
+import { db } from "../config/firebase";
 import { requireAuth } from "../middleware/requireAuth";
 import { requirePermission } from "../middleware/requireAuthz";
 import { listAdminLeases } from "../services/admin/adminLeaseView";
 import { buildAdminLeasesCsv } from "../services/admin/adminCsvExport";
 import { recordAdminAuditEvent } from "../services/admin/adminAuditEvents";
+import { deriveLeaseLifecycleReviewQueue } from "../lib/leases/leaseLifecycleReviewQueue";
 
 const router = Router();
+
+function parseReviewQueueLimit(value: unknown) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return 100;
+  return Math.max(1, Math.min(250, Math.floor(parsed)));
+}
+
+async function loadCollection(name: string) {
+  const snap = await db.collection(name).get();
+  return (snap.docs || []).map((doc: any) => ({ id: doc.id, ...(doc.data() || {}) }));
+}
+
+router.get(
+  "/lease-lifecycle-review-queue",
+  requireAuth,
+  requirePermission("system.admin"),
+  async (req: any, res) => {
+    try {
+      const limit = parseReviewQueueLimit(req.query?.limit);
+      const [leases, units] = await Promise.all([loadCollection("leases"), loadCollection("units")]);
+      const queue = deriveLeaseLifecycleReviewQueue({
+        leases,
+        units,
+        today: req.query?.today || new Date(),
+      });
+      const items = queue.items.slice(0, limit);
+
+      console.info("[leases.lifecycleReviewQueue]", {
+        route: "/api/admin/lease-lifecycle-review-queue",
+        userId: String(req.user?.id || req.user?.sub || "").trim() || null,
+        role: String(req.user?.role || "").toLowerCase(),
+        adminAccessResolved: true,
+        resultCount: items.length,
+        total: queue.summary.total,
+      });
+
+      return res.json({
+        ok: true,
+        items,
+        summary: queue.summary,
+      });
+    } catch (err: any) {
+      console.error("[adminLeasesRoutes] lifecycle review queue failed", err?.message || err);
+      return res.status(500).json({ ok: false, error: "admin_lease_lifecycle_review_queue_failed" });
+    }
+  }
+);
 
 router.get(
   "/leases/export.csv",

--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -66,6 +66,10 @@ vi.mock("./pages/admin/AdminTriageQueuePage", () => ({
   default: () => <h1>Admin Triage Queue</h1>,
 }));
 
+vi.mock("./pages/admin/AdminLeaseLifecycleReviewPage", () => ({
+  default: () => <h1>Lease Lifecycle Review</h1>,
+}));
+
 vi.mock("./pages/admin/AdminAlertingPage", () => ({
   default: () => <h1>Admin Alerts</h1>,
 }));
@@ -281,6 +285,20 @@ describe("Routes: /admin/triage", () => {
     );
 
     expect(await screen.findByText(/Admin Triage Queue/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Routes: /admin/lease-lifecycle-review", () => {
+  it("renders the admin lease lifecycle review route", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/admin/lease-lifecycle-review"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Lease Lifecycle Review/i)).toBeInTheDocument();
     expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -107,6 +107,7 @@ const AutomationTimelineV1Page = lazy(() => import("./pages/admin/AutomationTime
 const SupportDebugConsolePage = lazy(() => import("./pages/admin/SupportDebugConsolePage"));
 const SecurityReliabilityConsolePage = lazy(() => import("./pages/admin/SecurityReliabilityConsolePage"));
 const AdminTriageQueuePage = lazy(() => import("./pages/admin/AdminTriageQueuePage"));
+const AdminLeaseLifecycleReviewPage = lazy(() => import("./pages/admin/AdminLeaseLifecycleReviewPage"));
 const AdminAlertingPage = lazy(() => import("./pages/admin/AdminAlertingPage"));
 const AdminObservabilityPage = lazy(() => import("./pages/admin/AdminObservabilityPage"));
 const AdminNotificationsPage = lazy(() => import("./pages/admin/AdminNotificationsPage"));
@@ -1020,6 +1021,16 @@ function App() {
             <RequireAdmin>
               <Suspense fallback={null}>
                 <AdminTriageQueuePage />
+              </Suspense>
+            </RequireAdmin>
+          }
+        />
+        <Route
+          path="/admin/lease-lifecycle-review"
+          element={
+            <RequireAdmin>
+              <Suspense fallback={null}>
+                <AdminLeaseLifecycleReviewPage />
               </Suspense>
             </RequireAdmin>
           }

--- a/rentchain-frontend/src/api/adminLeaseLifecycleReviewApi.ts
+++ b/rentchain-frontend/src/api/adminLeaseLifecycleReviewApi.ts
@@ -1,0 +1,54 @@
+import { apiFetch } from "./apiFetch";
+
+export type LeaseLifecycleReviewSeverity = "info" | "warning" | "critical";
+
+export type LeaseLifecycleReviewCategory =
+  | "unknown_lifecycle"
+  | "missing_dates"
+  | "contradictory_status"
+  | "expired_occupancy_conflict"
+  | "renewal_ambiguity"
+  | "termination_conflict"
+  | "notice_conflict";
+
+export type AdminLeaseLifecycleReviewItem = {
+  id: string;
+  leaseId: string;
+  propertyId: string | null;
+  unitId: string | null;
+  landlordId: string | null;
+  tenantId?: string | null;
+  derivedLifecycleState: string;
+  derivedLifecycleReasons: string[];
+  severity: LeaseLifecycleReviewSeverity;
+  category: LeaseLifecycleReviewCategory;
+  title: string;
+  description: string;
+  recommendedAction: string;
+  createdFrom: "lease_lifecycle_review_queue_v1";
+  detectedAt: string;
+};
+
+export type AdminLeaseLifecycleReviewSummary = {
+  total: number;
+  critical: number;
+  warning: number;
+  info: number;
+};
+
+export type AdminLeaseLifecycleReviewResponse = {
+  ok: true;
+  items: AdminLeaseLifecycleReviewItem[];
+  summary: AdminLeaseLifecycleReviewSummary;
+};
+
+export async function fetchAdminLeaseLifecycleReviewQueue(params?: {
+  limit?: number | null;
+}): Promise<AdminLeaseLifecycleReviewResponse> {
+  const search = new URLSearchParams();
+  if (typeof params?.limit === "number") search.set("limit", String(params.limit));
+  const query = search.toString();
+  return await apiFetch<AdminLeaseLifecycleReviewResponse>(
+    `/admin/lease-lifecycle-review-queue${query ? `?${query}` : ""}`
+  );
+}

--- a/rentchain-frontend/src/pages/admin/AdminLeaseLifecycleReviewPage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminLeaseLifecycleReviewPage.test.tsx
@@ -1,0 +1,116 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import AdminLeaseLifecycleReviewPage from "./AdminLeaseLifecycleReviewPage";
+
+vi.mock("../../api/adminLeaseLifecycleReviewApi", () => ({
+  fetchAdminLeaseLifecycleReviewQueue: vi.fn(),
+}));
+
+vi.mock("../../components/layout/MacShell", () => ({
+  MacShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("../../components/ui/Ui", () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  Pill: ({ children, ...props }: any) => <span {...props}>{children}</span>,
+  Section: ({ children }: any) => <section>{children}</section>,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("AdminLeaseLifecycleReviewPage", () => {
+  it("renders summary counts and read-only review items", async () => {
+    const { fetchAdminLeaseLifecycleReviewQueue } = await import("../../api/adminLeaseLifecycleReviewApi");
+    vi.mocked(fetchAdminLeaseLifecycleReviewQueue).mockResolvedValue({
+      ok: true,
+      summary: {
+        total: 2,
+        critical: 1,
+        warning: 1,
+        info: 0,
+      },
+      items: [
+        {
+          id: "lease_lifecycle:lease-1:unknown_lifecycle",
+          leaseId: "lease-1",
+          propertyId: "property-1",
+          unitId: "unit-1",
+          landlordId: "landlord-1",
+          tenantId: "tenant-1",
+          derivedLifecycleState: "unknown",
+          derivedLifecycleReasons: ["date_range_invalid"],
+          severity: "critical",
+          category: "unknown_lifecycle",
+          title: "Lease lifecycle needs review",
+          description: "Canonical lifecycle derivation could not safely classify this lease.",
+          recommendedAction: "Open lease record",
+          createdFrom: "lease_lifecycle_review_queue_v1",
+          detectedAt: "2026-05-05T12:00:00.000Z",
+        },
+        {
+          id: "lease_lifecycle:lease-2:expired_occupancy_conflict",
+          leaseId: "lease-2",
+          propertyId: "property-2",
+          unitId: "unit-2",
+          landlordId: "landlord-2",
+          derivedLifecycleState: "expired",
+          derivedLifecycleReasons: ["end_date_past"],
+          severity: "warning",
+          category: "expired_occupancy_conflict",
+          title: "Expired lease conflicts with manual occupancy",
+          description: "The lease is expired, but the unit has current manual occupied data.",
+          recommendedAction: "Confirm occupancy manually",
+          createdFrom: "lease_lifecycle_review_queue_v1",
+          detectedAt: "2026-05-05T12:00:00.000Z",
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter>
+        <AdminLeaseLifecycleReviewPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Lease lifecycle needs review/i)).toBeInTheDocument();
+    expect(screen.getByText(/Expired lease conflicts with manual occupancy/i)).toBeInTheDocument();
+    expect(screen.getByText(/unknown lifecycle/i)).toBeInTheDocument();
+    expect(screen.getByText(/expired occupancy conflict/i)).toBeInTheDocument();
+    expect(screen.getByText(/Open lease record/i)).toBeInTheDocument();
+    expect(screen.getByText(/Confirm occupancy manually/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "lease-1" })).toHaveAttribute("href", "/admin/leases?q=lease-1");
+    expect(screen.queryByRole("button", { name: /fix/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/Fix automatically/i)).not.toBeInTheDocument();
+  });
+
+  it("renders empty and error states", async () => {
+    const { fetchAdminLeaseLifecycleReviewQueue } = await import("../../api/adminLeaseLifecycleReviewApi");
+    vi.mocked(fetchAdminLeaseLifecycleReviewQueue)
+      .mockResolvedValueOnce({
+        ok: true,
+        summary: { total: 0, critical: 0, warning: 0, info: 0 },
+        items: [],
+      })
+      .mockRejectedValueOnce(new Error("Boom"));
+
+    render(
+      <MemoryRouter>
+        <AdminLeaseLifecycleReviewPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/No lease lifecycle review items need attention right now/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Refresh/i }));
+    expect(await screen.findByText(/Failed to load lease lifecycle review queue: Boom/i)).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/admin/AdminLeaseLifecycleReviewPage.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminLeaseLifecycleReviewPage.tsx
@@ -1,0 +1,151 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { MacShell } from "../../components/layout/MacShell";
+import { Button, Card, Pill, Section } from "../../components/ui/Ui";
+import {
+  fetchAdminLeaseLifecycleReviewQueue,
+  type AdminLeaseLifecycleReviewItem,
+  type AdminLeaseLifecycleReviewSummary,
+  type LeaseLifecycleReviewSeverity,
+} from "../../api/adminLeaseLifecycleReviewApi";
+
+const emptySummary: AdminLeaseLifecycleReviewSummary = {
+  total: 0,
+  critical: 0,
+  warning: 0,
+  info: 0,
+};
+
+const severityTone: Record<LeaseLifecycleReviewSeverity, React.CSSProperties> = {
+  critical: { background: "#fee2e2", color: "#991b1b", borderColor: "#fecaca" },
+  warning: { background: "#fef3c7", color: "#92400e", borderColor: "#fde68a" },
+  info: { background: "#e0f2fe", color: "#075985", borderColor: "#bae6fd" },
+};
+
+function formatLabel(value: string) {
+  return value.replace(/_/g, " ");
+}
+
+function reasonText(item: AdminLeaseLifecycleReviewItem) {
+  return item.derivedLifecycleReasons?.length ? item.derivedLifecycleReasons.join(", ") : item.description;
+}
+
+function SummaryCard({ label, value }: { label: string; value: number }) {
+  return (
+    <Card style={{ padding: 14 }}>
+      <div style={{ color: "#64748b", fontSize: "0.85rem", fontWeight: 700 }}>{label}</div>
+      <div style={{ color: "#0f172a", fontSize: "1.45rem", fontWeight: 800 }}>{value}</div>
+    </Card>
+  );
+}
+
+function QueueItemRow({ item }: { item: AdminLeaseLifecycleReviewItem }) {
+  return (
+    <tr>
+      <td style={{ padding: "12px 10px", verticalAlign: "top", borderBottom: "1px solid #e2e8f0" }}>
+        <Pill style={severityTone[item.severity]}>{item.severity}</Pill>
+      </td>
+      <td style={{ padding: "12px 10px", verticalAlign: "top", borderBottom: "1px solid #e2e8f0" }}>
+        <div style={{ fontWeight: 700, color: "#0f172a" }}>{formatLabel(item.category)}</div>
+        <div style={{ color: "#64748b", fontSize: "0.9rem" }}>{formatLabel(item.derivedLifecycleState)}</div>
+      </td>
+      <td style={{ padding: "12px 10px", verticalAlign: "top", borderBottom: "1px solid #e2e8f0" }}>
+        <div style={{ display: "grid", gap: 4 }}>
+          <Link to={`/admin/leases?q=${encodeURIComponent(item.leaseId)}`}>{item.leaseId}</Link>
+          <span style={{ color: "#64748b", fontSize: "0.9rem" }}>
+            Property {item.propertyId || "-"} - Unit {item.unitId || "-"}
+          </span>
+        </div>
+      </td>
+      <td style={{ padding: "12px 10px", verticalAlign: "top", borderBottom: "1px solid #e2e8f0" }}>
+        <div style={{ fontWeight: 700, color: "#0f172a" }}>{item.title}</div>
+        <div style={{ color: "#475569", marginTop: 4 }}>{item.description}</div>
+        <div style={{ color: "#64748b", fontSize: "0.9rem", marginTop: 6 }}>{reasonText(item)}</div>
+      </td>
+      <td style={{ padding: "12px 10px", verticalAlign: "top", borderBottom: "1px solid #e2e8f0" }}>
+        <span style={{ color: "#0f172a", fontWeight: 700 }}>{item.recommendedAction}</span>
+      </td>
+    </tr>
+  );
+}
+
+export default function AdminLeaseLifecycleReviewPage() {
+  const [items, setItems] = React.useState<AdminLeaseLifecycleReviewItem[]>([]);
+  const [summary, setSummary] = React.useState<AdminLeaseLifecycleReviewSummary>(emptySummary);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const load = React.useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const response = await fetchAdminLeaseLifecycleReviewQueue({ limit: 100 });
+      setItems(response.items || []);
+      setSummary(response.summary || emptySummary);
+    } catch (err: any) {
+      setError(err?.message || "Failed to load lease lifecycle review queue");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  React.useEffect(() => {
+    void load();
+  }, [load]);
+
+  return (
+    <MacShell title="Admin - Lease Lifecycle Review">
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 16, alignItems: "flex-start", flexWrap: "wrap" }}>
+            <div style={{ display: "grid", gap: 6 }}>
+              <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+                <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Lease Lifecycle Review</h1>
+                <Pill tone="accent">Read only</Pill>
+              </div>
+              <div style={{ color: "#475569", maxWidth: 820 }}>
+                Operator queue for leases whose canonical lifecycle derivation needs review. This page does not mutate lease records or rewrite stored statuses.
+              </div>
+            </div>
+            <Button variant="secondary" onClick={() => void load()} disabled={loading}>
+              Refresh
+            </Button>
+          </div>
+        </Section>
+
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))", gap: 12 }}>
+          <SummaryCard label="Total" value={summary.total} />
+          <SummaryCard label="Critical" value={summary.critical} />
+          <SummaryCard label="Warning" value={summary.warning} />
+          <SummaryCard label="Info" value={summary.info} />
+        </div>
+
+        {loading ? <Card>Loading lease lifecycle review queue...</Card> : null}
+        {!loading && error ? <Card style={{ color: "#b91c1c" }}>Failed to load lease lifecycle review queue: {error}</Card> : null}
+        {!loading && !error && items.length === 0 ? (
+          <Card>No lease lifecycle review items need attention right now.</Card>
+        ) : null}
+        {!loading && !error && items.length > 0 ? (
+          <Card style={{ overflowX: "auto" }}>
+            <table style={{ width: "100%", borderCollapse: "collapse", minWidth: 900 }}>
+              <thead>
+                <tr style={{ textAlign: "left", color: "#475569", fontSize: "0.85rem" }}>
+                  <th style={{ padding: "0 10px 10px" }}>Severity</th>
+                  <th style={{ padding: "0 10px 10px" }}>Category</th>
+                  <th style={{ padding: "0 10px 10px" }}>Lease</th>
+                  <th style={{ padding: "0 10px 10px" }}>Reason</th>
+                  <th style={{ padding: "0 10px 10px" }}>Recommended action</th>
+                </tr>
+              </thead>
+              <tbody>
+                {items.map((item) => (
+                  <QueueItemRow key={item.id} item={item} />
+                ))}
+              </tbody>
+            </table>
+          </Card>
+        ) : null}
+      </div>
+    </MacShell>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds read-only lease lifecycle review queue derivation.
- Surfaces unknown, contradictory, incomplete, or review-required lease lifecycle records.
- Adds severity/category/recommended-action metadata for operator review.
- Adds admin-only read endpoint: `GET /api/admin/lease-lifecycle-review-queue`.
- Adds minimal admin UI at `/admin/lease-lifecycle-review`.
- Preserves lease records without mutation or stored status rewrite.
- No schema migration, payment, Trustly, PaymentIntent, dependency, or lockfile changes.

## Verification
- Backend focused tests passed: 27 tests.
- Backend build passed.
- Frontend focused route/page tests passed: 26 tests.
- Frontend full suite passed: 181 files / 736 tests.
- Frontend build passed with existing chunk-size warning.
- `git diff --check` passed.
- dependency/lockfile diff empty.

## PR discipline
Before merge, confirm:
- CI is green
- diff remains scoped to lease review queue/admin UI/docs
- no dependency/lockfile changes
- no schema migration
- no lease mutations
- no stored status rewrites
- no payment/Trustly/PaymentIntent work