### PR TITLE
Add lease lifecycle review history

### DIFF
--- a/docs/architecture/lease-state-machine-v1.md
+++ b/docs/architecture/lease-state-machine-v1.md
@@ -93,15 +93,37 @@ Important boundaries:
 - Acknowledgements do not auto-correct lifecycle derivation.
 - Acknowledgements do not create payment obligations or trigger renewal enforcement.
 
+## Lease Lifecycle Review History V1
+
+Review history adds an audit timeline for acknowledgement changes without changing lease records. History events are stored separately in `leaseLifecycleReviewHistory` and are keyed to the deterministic review item ID plus a generated history ID.
+
+Tracked actions include:
+
+- `reviewed`: an operator marked a review item reviewed.
+- `snoozed`: an operator deferred a review item until a future timestamp.
+- `assigned`: an operator assigned a review item to an owner or team.
+- `reopened`: an operator returned a review item to open status.
+- `note_updated`: an operator updated acknowledgement context without changing the acknowledgement status.
+
+History events include the review item ID, lease/property/unit references, previous and next acknowledgement status, optional assignee, optional snooze timestamp, optional note, actor ID/email, and event timestamp. The admin review queue returns a small recent-history timeline per item for audit visibility.
+
+Important boundaries:
+
+- History writes never mutate lease records.
+- History writes never rewrite `lease.status`.
+- History is not a lifecycle correction workflow.
+- History is admin/operator audit metadata only.
+
 ## Deferred Future Steps
 
 1. Stored lifecycle transition events.
 2. Scheduled lease lifecycle reconciliation job.
 3. Assignment notifications.
-4. Review history timeline.
-5. Auto-created admin triage queue items.
-6. Landlord-safe warning surfacing.
-7. Lifecycle correction workflow.
-8. Lease renewal workflow enforcement.
-9. Payment obligation generation from active lease lifecycle.
-10. Institution-ready lease export schema.
+4. Auto-created admin triage queue items.
+5. Landlord-safe warning surfacing.
+6. Lifecycle correction workflow.
+7. Assignment notifications from review history events.
+8. Review history retention/export policy.
+9. Lease renewal workflow enforcement.
+10. Payment obligation generation from active lease lifecycle.
+11. Institution-ready lease export schema.

--- a/rentchain-api/src/lib/leases/leaseLifecycleReviewHistory.ts
+++ b/rentchain-api/src/lib/leases/leaseLifecycleReviewHistory.ts
@@ -1,0 +1,137 @@
+import crypto from "crypto";
+import type { LeaseLifecycleReviewItemWithAcknowledgement } from "./leaseLifecycleReviewAcknowledgements";
+import type {
+  LeaseLifecycleReviewAcknowledgement,
+  LeaseLifecycleReviewAcknowledgementPatch,
+  LeaseLifecycleReviewAcknowledgementStatus,
+} from "./leaseLifecycleReviewAcknowledgements";
+
+export const LEASE_LIFECYCLE_REVIEW_HISTORY_COLLECTION = "leaseLifecycleReviewHistory";
+
+export type LeaseLifecycleReviewHistoryAction = "reviewed" | "snoozed" | "assigned" | "reopened" | "note_updated";
+
+export type LeaseLifecycleReviewHistoryEvent = {
+  historyId: string;
+  reviewItemId: string;
+  leaseId: string;
+  landlordId: string | null;
+  propertyId: string | null;
+  unitId: string | null;
+  action: LeaseLifecycleReviewHistoryAction;
+  previousStatus?: LeaseLifecycleReviewAcknowledgementStatus | null;
+  nextStatus: LeaseLifecycleReviewAcknowledgementStatus;
+  assignedTo?: string | null;
+  snoozedUntil?: string | null;
+  note?: string | null;
+  actorId: string | null;
+  actorEmail?: string | null;
+  createdAt: string;
+};
+
+function asString(value: unknown, max = 1000): string {
+  return String(value || "").trim().slice(0, max);
+}
+
+function toIsoDate(value: unknown): string | null {
+  const raw = asString(value, 120);
+  if (!raw) return null;
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toISOString();
+}
+
+function actionForPatch(input: {
+  patch: LeaseLifecycleReviewAcknowledgementPatch;
+  existing?: LeaseLifecycleReviewAcknowledgement | null;
+}): LeaseLifecycleReviewHistoryAction {
+  if (input.patch.status === "open") return "reopened";
+  if (input.existing?.status === input.patch.status && asString(input.patch.note) !== asString(input.existing?.note)) {
+    return "note_updated";
+  }
+  return input.patch.status;
+}
+
+export function buildLeaseLifecycleReviewHistoryEvent(input: {
+  item: LeaseLifecycleReviewItemWithAcknowledgement;
+  acknowledgement: LeaseLifecycleReviewAcknowledgement;
+  patch: LeaseLifecycleReviewAcknowledgementPatch;
+  existing?: LeaseLifecycleReviewAcknowledgement | null;
+  actorId?: string | null;
+  actorEmail?: string | null;
+  now?: string;
+}): LeaseLifecycleReviewHistoryEvent {
+  const createdAt = toIsoDate(input.now) || new Date().toISOString();
+  const action = actionForPatch({ patch: input.patch, existing: input.existing });
+  const historySeed = `${input.item.id}:${createdAt}:${input.acknowledgement.status}:${crypto.randomUUID()}`;
+  return {
+    historyId: crypto.createHash("sha256").update(historySeed).digest("hex"),
+    reviewItemId: input.item.id,
+    leaseId: input.item.leaseId,
+    landlordId: input.item.landlordId,
+    propertyId: input.item.propertyId,
+    unitId: input.item.unitId,
+    action,
+    previousStatus: input.existing?.status || null,
+    nextStatus: input.acknowledgement.status,
+    assignedTo: input.acknowledgement.assignedTo || null,
+    snoozedUntil: input.acknowledgement.snoozedUntil || null,
+    note: input.acknowledgement.note || null,
+    actorId: asString(input.actorId, 240) || null,
+    actorEmail: asString(input.actorEmail, 320) || null,
+    createdAt,
+  };
+}
+
+export function normalizeLeaseLifecycleReviewHistoryEvent(raw: unknown): LeaseLifecycleReviewHistoryEvent | null {
+  const data = (raw || {}) as Record<string, unknown>;
+  const historyId = asString(data.historyId || data.id, 240);
+  const reviewItemId = asString(data.reviewItemId, 4000);
+  const leaseId = asString(data.leaseId, 240);
+  const action = asString(data.action, 40) as LeaseLifecycleReviewHistoryAction;
+  const nextStatus = asString(data.nextStatus, 40) as LeaseLifecycleReviewAcknowledgementStatus;
+  const createdAt = toIsoDate(data.createdAt);
+  if (!historyId || !reviewItemId || !leaseId || !createdAt) return null;
+  if (!["reviewed", "snoozed", "assigned", "reopened", "note_updated"].includes(action)) return null;
+  if (!["open", "reviewed", "snoozed", "assigned"].includes(nextStatus)) return null;
+  return {
+    historyId,
+    reviewItemId,
+    leaseId,
+    landlordId: asString(data.landlordId, 240) || null,
+    propertyId: asString(data.propertyId, 240) || null,
+    unitId: asString(data.unitId, 240) || null,
+    action,
+    previousStatus: (asString(data.previousStatus, 40) as LeaseLifecycleReviewAcknowledgementStatus) || null,
+    nextStatus,
+    assignedTo: asString(data.assignedTo, 240) || null,
+    snoozedUntil: toIsoDate(data.snoozedUntil),
+    note: asString(data.note, 1000) || null,
+    actorId: asString(data.actorId, 240) || null,
+    actorEmail: asString(data.actorEmail, 320) || null,
+    createdAt,
+  };
+}
+
+export function mergeLeaseLifecycleReviewHistory<T extends LeaseLifecycleReviewItemWithAcknowledgement>(
+  items: T[],
+  history: unknown[],
+  limitPerItem = 3
+): Array<T & { recentHistory: LeaseLifecycleReviewHistoryEvent[] }> {
+  const byReviewItemId = new Map<string, LeaseLifecycleReviewHistoryEvent[]>();
+  for (const raw of Array.isArray(history) ? history : []) {
+    const event = normalizeLeaseLifecycleReviewHistoryEvent(raw);
+    if (!event) continue;
+    const list = byReviewItemId.get(event.reviewItemId) || [];
+    list.push(event);
+    byReviewItemId.set(event.reviewItemId, list);
+  }
+
+  for (const list of byReviewItemId.values()) {
+    list.sort((a, b) => String(b.createdAt).localeCompare(String(a.createdAt)));
+  }
+
+  return items.map((item) => ({
+    ...item,
+    recentHistory: (byReviewItemId.get(item.id) || []).slice(0, limitPerItem),
+  }));
+}

--- a/rentchain-api/src/routes/__tests__/adminLeaseLifecycleReviewQueueRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/adminLeaseLifecycleReviewQueueRoutes.test.ts
@@ -113,6 +113,7 @@ async function invokeRouter(
 
 const adminUser = {
   id: "admin-1",
+  email: "admin@example.com",
   role: "admin",
   permissions: [],
   revokedPermissions: [],
@@ -241,6 +242,21 @@ describe("admin lease lifecycle review queue route", () => {
       acknowledgedAt: "2026-05-05T12:00:00.000Z",
       updatedAt: "2026-05-05T12:00:00.000Z",
     });
+    seedDoc("leaseLifecycleReviewHistory", "history-1", {
+      historyId: "history-1",
+      reviewItemId: "lease_lifecycle:lease-unknown:unknown_lifecycle",
+      leaseId: "lease-unknown",
+      landlordId: "landlord-1",
+      propertyId: "property-1",
+      unitId: "unit-2",
+      action: "reviewed",
+      previousStatus: null,
+      nextStatus: "reviewed",
+      note: "Reviewed by ops",
+      actorId: "admin-1",
+      actorEmail: "admin@example.com",
+      createdAt: "2026-05-05T12:00:00.000Z",
+    });
 
     const router = (await import("../adminLeasesRoutes")).default;
     const response = await invokeRouter(router, {
@@ -259,6 +275,16 @@ describe("admin lease lifecycle review queue route", () => {
           note: "Reviewed by ops",
           acknowledgedBy: "admin-1",
         }),
+        recentHistory: [
+          expect.objectContaining({
+            historyId: "history-1",
+            action: "reviewed",
+            nextStatus: "reviewed",
+            note: "Reviewed by ops",
+            actorId: "admin-1",
+            actorEmail: "admin@example.com",
+          }),
+        ],
       })
     );
   });
@@ -295,18 +321,38 @@ describe("admin lease lifecycle review queue route", () => {
         acknowledgedBy: "admin-1",
       })
     );
+    expect(response.body.historyEvent).toEqual(
+      expect.objectContaining({
+        reviewItemId: "lease_lifecycle:lease-unknown:unknown_lifecycle",
+        leaseId: "lease-unknown",
+        action: "reviewed",
+        previousStatus: null,
+        nextStatus: "reviewed",
+        note: "Dates reviewed",
+        actorId: "admin-1",
+        actorEmail: "admin@example.com",
+      })
+    );
+    expect(Array.from(collections.get("leaseLifecycleReviewHistory")?.values() || [])).toEqual([
+      expect.objectContaining({
+        action: "reviewed",
+        nextStatus: "reviewed",
+        leaseId: "lease-unknown",
+      }),
+    ]);
     expect(collections.get("leases")?.get("lease-unknown")).toEqual({ id: "lease-unknown", ...originalLease });
   });
 
   it("allows admins to snooze and assign review items", async () => {
-    seedDoc("leases", "lease-unknown", {
+    const originalLease = {
       status: "active",
       propertyId: "property-1",
       unitId: "unit-2",
       landlordId: "landlord-1",
       startDate: "2026-12-31",
       endDate: "2026-01-01",
-    });
+    };
+    seedDoc("leases", "lease-unknown", originalLease);
 
     const router = (await import("../adminLeasesRoutes")).default;
     const snoozed = await invokeRouter(router, {
@@ -322,6 +368,13 @@ describe("admin lease lifecycle review queue route", () => {
     expect(snoozed.body.acknowledgement).toEqual(
       expect.objectContaining({
         status: "snoozed",
+        snoozedUntil: "2026-05-12T12:00:00.000Z",
+      })
+    );
+    expect(snoozed.body.historyEvent).toEqual(
+      expect.objectContaining({
+        action: "snoozed",
+        nextStatus: "snoozed",
         snoozedUntil: "2026-05-12T12:00:00.000Z",
       })
     );
@@ -342,6 +395,21 @@ describe("admin lease lifecycle review queue route", () => {
         assignedTo: "ops-admin-2",
       })
     );
+    expect(assigned.body.historyEvent).toEqual(
+      expect.objectContaining({
+        action: "assigned",
+        previousStatus: "snoozed",
+        nextStatus: "assigned",
+        assignedTo: "ops-admin-2",
+      })
+    );
+    expect(Array.from(collections.get("leaseLifecycleReviewHistory")?.values() || [])).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ action: "snoozed", leaseId: "lease-unknown" }),
+        expect.objectContaining({ action: "assigned", leaseId: "lease-unknown" }),
+      ])
+    );
+    expect(collections.get("leases")?.get("lease-unknown")).toEqual({ id: "lease-unknown", ...originalLease });
   });
 
   it("blocks non-admin acknowledgement mutations", async () => {

--- a/rentchain-api/src/routes/adminLeasesRoutes.ts
+++ b/rentchain-api/src/routes/adminLeasesRoutes.ts
@@ -15,6 +15,11 @@ import {
   type LeaseLifecycleReviewAcknowledgementPatch,
   type LeaseLifecycleReviewAcknowledgementStatus,
 } from "../lib/leases/leaseLifecycleReviewAcknowledgements";
+import {
+  buildLeaseLifecycleReviewHistoryEvent,
+  LEASE_LIFECYCLE_REVIEW_HISTORY_COLLECTION,
+  mergeLeaseLifecycleReviewHistory,
+} from "../lib/leases/leaseLifecycleReviewHistory";
 
 const router = Router();
 
@@ -37,6 +42,10 @@ function actorIdFromReq(req: any) {
   return asString(req.user?.uid || req.user?.id || req.user?.sub, 240) || null;
 }
 
+function actorEmailFromReq(req: any) {
+  return asString(req.user?.email, 320) || null;
+}
+
 function parseAcknowledgementPatch(body: any): LeaseLifecycleReviewAcknowledgementPatch | null {
   const status = asString(body?.status, 40) as LeaseLifecycleReviewAcknowledgementStatus;
   if (!["open", "reviewed", "snoozed", "assigned"].includes(status)) return null;
@@ -56,17 +65,22 @@ function parseAcknowledgementPatch(body: any): LeaseLifecycleReviewAcknowledgeme
 }
 
 async function deriveReviewQueueWithAcknowledgements(today: unknown) {
-  const [leases, units, acknowledgements] = await Promise.all([
+  const [leases, units, acknowledgements, history] = await Promise.all([
     loadCollection("leases"),
     loadCollection("units"),
     loadCollection(LEASE_LIFECYCLE_REVIEW_ACKNOWLEDGEMENTS_COLLECTION),
+    loadCollection(LEASE_LIFECYCLE_REVIEW_HISTORY_COLLECTION),
   ]);
   const queue = deriveLeaseLifecycleReviewQueue({
     leases,
     units,
     today: today || new Date(),
   });
-  return mergeLeaseLifecycleReviewAcknowledgements(queue, acknowledgements);
+  const withAcknowledgements = mergeLeaseLifecycleReviewAcknowledgements(queue, acknowledgements);
+  return {
+    ...withAcknowledgements,
+    items: mergeLeaseLifecycleReviewHistory(withAcknowledgements.items, history),
+  };
 }
 
 router.get(
@@ -131,6 +145,15 @@ router.patch(
         existing,
       });
       await ref.set(acknowledgement, { merge: false });
+      const historyEvent = buildLeaseLifecycleReviewHistoryEvent({
+        item,
+        acknowledgement,
+        patch,
+        existing,
+        actorId: actorIdFromReq(req),
+        actorEmail: actorEmailFromReq(req),
+      });
+      await db.collection(LEASE_LIFECYCLE_REVIEW_HISTORY_COLLECTION).doc(historyEvent.historyId).set(historyEvent, { merge: false });
 
       console.info("[leases.lifecycleReviewQueue.acknowledgement]", {
         route: "/api/admin/lease-lifecycle-review-queue/:reviewItemId/acknowledgement",
@@ -141,7 +164,7 @@ router.patch(
         status: acknowledgement.status,
       });
 
-      return res.json({ ok: true, acknowledgement });
+      return res.json({ ok: true, acknowledgement, historyEvent });
     } catch (err: any) {
       console.error("[adminLeasesRoutes] lifecycle review acknowledgement failed", err?.message || err);
       return res.status(500).json({ ok: false, error: "admin_lease_lifecycle_acknowledgement_failed" });

--- a/rentchain-frontend/src/api/adminLeaseLifecycleReviewApi.ts
+++ b/rentchain-frontend/src/api/adminLeaseLifecycleReviewApi.ts
@@ -28,6 +28,7 @@ export type AdminLeaseLifecycleReviewItem = {
   createdFrom: "lease_lifecycle_review_queue_v1";
   detectedAt: string;
   acknowledgement: AdminLeaseLifecycleReviewAcknowledgement | null;
+  recentHistory: AdminLeaseLifecycleReviewHistoryEvent[];
 };
 
 export type AdminLeaseLifecycleReviewAcknowledgementStatus = "open" | "reviewed" | "snoozed" | "assigned";
@@ -46,6 +47,26 @@ export type AdminLeaseLifecycleReviewAcknowledgement = {
   acknowledgedBy: string | null;
   acknowledgedAt: string;
   updatedAt: string;
+};
+
+export type AdminLeaseLifecycleReviewHistoryAction = "reviewed" | "snoozed" | "assigned" | "reopened" | "note_updated";
+
+export type AdminLeaseLifecycleReviewHistoryEvent = {
+  historyId: string;
+  reviewItemId: string;
+  leaseId: string;
+  landlordId: string | null;
+  propertyId: string | null;
+  unitId: string | null;
+  action: AdminLeaseLifecycleReviewHistoryAction;
+  previousStatus?: AdminLeaseLifecycleReviewAcknowledgementStatus | null;
+  nextStatus: AdminLeaseLifecycleReviewAcknowledgementStatus;
+  assignedTo?: string | null;
+  snoozedUntil?: string | null;
+  note?: string | null;
+  actorId: string | null;
+  actorEmail?: string | null;
+  createdAt: string;
 };
 
 export type AdminLeaseLifecycleReviewSummary = {
@@ -80,8 +101,12 @@ export async function updateAdminLeaseLifecycleReviewAcknowledgement(
     snoozedUntil?: string | null;
     note?: string | null;
   }
-): Promise<{ ok: true; acknowledgement: AdminLeaseLifecycleReviewAcknowledgement }> {
-  return await apiFetch<{ ok: true; acknowledgement: AdminLeaseLifecycleReviewAcknowledgement }>(
+): Promise<{ ok: true; acknowledgement: AdminLeaseLifecycleReviewAcknowledgement; historyEvent: AdminLeaseLifecycleReviewHistoryEvent }> {
+  return await apiFetch<{
+    ok: true;
+    acknowledgement: AdminLeaseLifecycleReviewAcknowledgement;
+    historyEvent: AdminLeaseLifecycleReviewHistoryEvent;
+  }>(
     `/admin/lease-lifecycle-review-queue/${encodeURIComponent(reviewItemId)}/acknowledgement`,
     {
       method: "PATCH",

--- a/rentchain-frontend/src/pages/admin/AdminLeaseLifecycleReviewPage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminLeaseLifecycleReviewPage.test.tsx
@@ -68,6 +68,23 @@ describe("AdminLeaseLifecycleReviewPage", () => {
             acknowledgedAt: "2026-05-05T12:00:00.000Z",
             updatedAt: "2026-05-05T12:00:00.000Z",
           },
+          recentHistory: [
+            {
+              historyId: "history-1",
+              reviewItemId: "lease_lifecycle:lease-1:unknown_lifecycle",
+              leaseId: "lease-1",
+              landlordId: "landlord-1",
+              propertyId: "property-1",
+              unitId: "unit-1",
+              action: "reviewed",
+              previousStatus: null,
+              nextStatus: "reviewed",
+              note: "Reviewed by ops",
+              actorId: "admin-1",
+              actorEmail: "admin@example.com",
+              createdAt: "2026-05-05T12:00:00.000Z",
+            },
+          ],
         },
         {
           id: "lease_lifecycle:lease-2:expired_occupancy_conflict",
@@ -85,6 +102,7 @@ describe("AdminLeaseLifecycleReviewPage", () => {
           createdFrom: "lease_lifecycle_review_queue_v1",
           detectedAt: "2026-05-05T12:00:00.000Z",
           acknowledgement: null,
+          recentHistory: [],
         },
       ],
     });
@@ -105,6 +123,10 @@ describe("AdminLeaseLifecycleReviewPage", () => {
     expect(screen.getAllByRole("button", { name: /Mark reviewed/i }).length).toBeGreaterThan(0);
     expect(screen.getAllByRole("button", { name: /Snooze/i }).length).toBeGreaterThan(0);
     expect(screen.getAllByRole("button", { name: /Assign/i }).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Recent history/i).length).toBe(2);
+    expect(screen.getByText(/Reviewed by ops/i)).toBeInTheDocument();
+    expect(screen.getByText(/admin@example.com/i)).toBeInTheDocument();
+    expect(screen.getByText(/No history yet/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "lease-1" })).toHaveAttribute("href", "/admin/leases?q=lease-1");
     expect(screen.queryByRole("button", { name: /fix/i })).not.toBeInTheDocument();
     expect(screen.queryByText(/Fix automatically/i)).not.toBeInTheDocument();
@@ -140,6 +162,7 @@ describe("AdminLeaseLifecycleReviewPage", () => {
           createdFrom: "lease_lifecycle_review_queue_v1",
           detectedAt: "2026-05-05T12:00:00.000Z",
           acknowledgement: null,
+          recentHistory: [],
         },
       ],
     });
@@ -156,6 +179,21 @@ describe("AdminLeaseLifecycleReviewPage", () => {
         acknowledgedBy: "admin-1",
         acknowledgedAt: "2026-05-05T12:00:00.000Z",
         updatedAt: "2026-05-05T12:00:00.000Z",
+      },
+      historyEvent: {
+        historyId: "history-1",
+        reviewItemId: "lease_lifecycle:lease-1:unknown_lifecycle",
+        leaseId: "lease-1",
+        landlordId: "landlord-1",
+        propertyId: "property-1",
+        unitId: "unit-1",
+        action: "reviewed",
+        previousStatus: null,
+        nextStatus: "reviewed",
+        note: "Reviewed from lease lifecycle queue",
+        actorId: "admin-1",
+        actorEmail: "admin@example.com",
+        createdAt: "2026-05-05T12:00:00.000Z",
       },
     });
 
@@ -174,6 +212,8 @@ describe("AdminLeaseLifecycleReviewPage", () => {
       })
     );
     expect((await screen.findAllByText(/reviewed/i)).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Reviewed from lease lifecycle queue/i)).toBeInTheDocument();
+    expect(screen.getByText(/admin@example.com/i)).toBeInTheDocument();
   });
 
   it("renders empty and error states", async () => {

--- a/rentchain-frontend/src/pages/admin/AdminLeaseLifecycleReviewPage.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminLeaseLifecycleReviewPage.tsx
@@ -6,6 +6,7 @@ import {
   fetchAdminLeaseLifecycleReviewQueue,
   updateAdminLeaseLifecycleReviewAcknowledgement,
   type AdminLeaseLifecycleReviewAcknowledgement,
+  type AdminLeaseLifecycleReviewHistoryEvent,
   type AdminLeaseLifecycleReviewItem,
   type AdminLeaseLifecycleReviewSummary,
   type LeaseLifecycleReviewSeverity,
@@ -41,6 +42,29 @@ function acknowledgementLabel(acknowledgement: AdminLeaseLifecycleReviewAcknowle
     return `assigned to ${acknowledgement.assignedTo}`;
   }
   return acknowledgement.status;
+}
+
+function formatHistoryTimestamp(value: string) {
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return value || "Unknown time";
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(parsed));
+}
+
+function historyActor(event: AdminLeaseLifecycleReviewHistoryEvent) {
+  return event.actorEmail || event.actorId || "Unknown admin";
+}
+
+function historyLine(event: AdminLeaseLifecycleReviewHistoryEvent) {
+  const details = [
+    event.assignedTo ? `assigned to ${event.assignedTo}` : null,
+    event.snoozedUntil ? `snoozed until ${new Date(event.snoozedUntil).toLocaleDateString()}` : null,
+  ].filter(Boolean);
+  return details.length ? `${event.action.replace(/_/g, " ")} - ${details.join(", ")}` : event.action.replace(/_/g, " ");
 }
 
 function SummaryCard({ label, value }: { label: string; value: number }) {
@@ -121,6 +145,22 @@ function QueueItemRow({
               Assign
             </Button>
           </div>
+          <div style={{ display: "grid", gap: 6 }}>
+            <div style={{ color: "#64748b", fontSize: 12, fontWeight: 700 }}>Recent history</div>
+            {item.recentHistory?.length ? (
+              item.recentHistory.map((event) => (
+                <div key={event.historyId} style={{ color: "#475569", fontSize: 12, lineHeight: 1.35 }}>
+                  <strong style={{ color: "#0f172a" }}>{historyLine(event)}</strong>
+                  <div>
+                    {historyActor(event)} · {formatHistoryTimestamp(event.createdAt)}
+                  </div>
+                  {event.note ? <div>{event.note}</div> : null}
+                </div>
+              ))
+            ) : (
+              <div style={{ color: "#64748b", fontSize: 12 }}>No history yet.</div>
+            )}
+          </div>
         </div>
       </td>
     </tr>
@@ -163,7 +203,13 @@ export default function AdminLeaseLifecycleReviewPage() {
         const response = await updateAdminLeaseLifecycleReviewAcknowledgement(item.id, payload);
         setItems((current) =>
           current.map((candidate) =>
-            candidate.id === item.id ? { ...candidate, acknowledgement: response.acknowledgement } : candidate
+            candidate.id === item.id
+              ? {
+                  ...candidate,
+                  acknowledgement: response.acknowledgement,
+                  recentHistory: [response.historyEvent, ...(candidate.recentHistory || [])].slice(0, 3),
+                }
+              : candidate
           )
         );
       } catch (err: any) {


### PR DESCRIPTION
## Summary
- Adds separate `leaseLifecycleReviewHistory` records for admin review queue acknowledgement changes.
- Writes history events after acknowledgement state is saved.
- Embeds recent history into the existing admin-only lease lifecycle review queue response.
- Shows a compact Recent history timeline in the admin review page.
- Preserves existing acknowledgement actions and avoids adding auto-fix controls.
- No lease mutations, stored status rewrites, schema migration, payment, Trustly, PaymentIntent, dependency, or lockfile changes.

## Verification
- Backend admin review queue route tests passed: 7 tests.
- Backend build passed.
- Frontend admin page tests passed: 3 tests.
- Frontend full suite passed on rerun: 181 files / 737 tests.
- Frontend build passed with existing chunk-size warning.
- `git diff --check` passed.
- Dependency/lockfile diff empty.