### PR TITLE
Add payment intent system

### DIFF
--- a/docs/architecture/payment-execution-boundary-v1.md
+++ b/docs/architecture/payment-execution-boundary-v1.md
@@ -526,6 +526,48 @@ Deferred items:
 2. Reconciliation-driven status transitions.
 3. Trustly sandbox adapter.
 
+## PaymentIntent System v1
+
+Status: provider-neutral rent-payment obligations are persisted passively.
+
+What changed:
+
+- Collection: `paymentIntents`
+- Rent checkout now creates or upserts a deterministic PaymentIntent before Stripe session creation.
+- Stripe Checkout metadata now includes the internal `paymentIntentId` in addition to the existing `rentPaymentId`.
+- Provider session references are linked back to the PaymentIntent after Stripe session creation.
+- Rent webhook provider receipts and reconciliation records can include `paymentIntentId` when metadata or the `rentPaymentId` mapping resolves it.
+- PaymentIntent status updates from provider signals are passive and do not drive existing webhook behavior.
+
+Behavior intentionally unchanged:
+
+- Existing Stripe rent checkout response shape is unchanged.
+- Existing `rentPayments` records remain the active checkout/history records.
+- Existing rent-payment webhook status transitions remain unchanged.
+- Existing duplicate suppression behavior remains unchanged.
+- Screening checkout, subscriptions, payouts, pricing, and plans are untouched.
+- No Trustly implementation is included.
+
+Ordering:
+
+```text
+rent checkout request
+  -> validate existing rent-payment eligibility
+  -> upsert PaymentIntent
+  -> create existing Stripe Checkout Session
+  -> link provider session refs to PaymentIntent
+  -> write existing rentPayments record
+  -> return existing tenant checkout response
+```
+
+Deferred items:
+
+1. PaymentIntent-driven rent ledger.
+2. PaymentIntent monthly generation from active leases.
+3. PaymentIntent reconciliation-driven status enforcement.
+4. Trustly sandbox adapter using PaymentIntent.
+5. Landlord/tenant UI for PaymentIntent history.
+
 ## Intentional Non-Implementation
 
 This mission intentionally does not:

--- a/docs/architecture/payment-intent-system-v1.md
+++ b/docs/architecture/payment-intent-system-v1.md
@@ -1,0 +1,173 @@
+# Payment Intent System V1
+
+Status: passive rent-payment obligation layer
+
+## Purpose
+
+PaymentIntent represents RentChain's internal obligation or request to collect money before provider execution happens.
+
+The V1 scope is rent payments only. It does not implement Trustly, change provider selection, alter Stripe checkout behavior, change webhook status transitions, migrate historical records, or replace `rentPayments`.
+
+## Source Of Truth Hierarchy
+
+```text
+Lease System = Truth
+PaymentIntent = Obligation
+Payment Provider = Execution
+Reconciliation = Evidence review
+Ledger = Financial history
+```
+
+Lease lifecycle remains the product truth for whether rent should exist. PaymentIntent records are additive financial obligations derived at checkout time in V1, not a new lease automation engine.
+
+## Model
+
+Collection: `paymentIntents`
+
+Core fields:
+
+- `paymentIntentId`
+- `landlordId`
+- `tenantId`
+- `propertyId`
+- `unitId`
+- `leaseId`
+- `rentPaymentId`
+- `purpose: rent`
+- `amountCents`
+- `currency`
+- `periodStart`
+- `periodEnd`
+- `dueDate`
+- `status`
+- `provider`
+- `providerSessionId`
+- `providerPaymentId`
+- `source`
+- `lifecycleState`
+- `requiresReview`
+- `createdAt`
+- `updatedAt`
+- `metadataSummary`
+
+Statuses:
+
+- `draft`
+- `ready`
+- `provider_session_created`
+- `pending_provider_confirmation`
+- `pending_settlement`
+- `confirmed`
+- `failed`
+- `cancelled`
+- `expired`
+- `manual_review_required`
+- `reconciled`
+
+Sources:
+
+- `rent_payment_checkout`
+- `manual_admin`
+- `system_derived`
+- `migration_placeholder`
+
+V1 stores amount in cents and stores provider IDs as secondary references. It does not store raw provider payloads.
+
+## Deterministic ID Strategy
+
+Rent checkout PaymentIntent IDs are deterministic from the stable rent obligation fields when available:
+
+```text
+landlordId + propertyId + unitId + leaseId + tenantId + purpose + periodStart + periodEnd + amountCents + currency
+```
+
+The generated document ID uses a safe hash:
+
+```text
+pi_rent:{hash}
+```
+
+If critical obligation fields are missing, the helper falls back to available internal subject data such as `rentPaymentId`, then marks the PaymentIntent as:
+
+```text
+status = manual_review_required
+lifecycleState = requires_review
+requiresReview = true
+```
+
+This prevents duplicate PaymentIntent records for repeated checkout attempts against the same rent obligation, while still preserving separate `rentPayments` records for the existing checkout history.
+
+## Checkout Integration
+
+Existing Stripe rent checkout remains the execution path:
+
+```text
+tenant route
+  -> rentPaymentService.createRentPaymentCheckout
+    -> upsert PaymentIntent
+    -> create existing Stripe Checkout session
+    -> link provider session refs to PaymentIntent
+    -> write existing rentPayments record
+    -> return existing checkout response shape
+```
+
+Behavior intentionally preserved:
+
+- Stripe Checkout mode remains `payment`.
+- Stripe payment method behavior is unchanged.
+- `rentPayments` remains the existing tenant checkout record.
+- Tenant response remains `{ rentPaymentId, status, redirectUrl }`.
+- Existing rent-payment blocked states remain unchanged.
+- Existing Stripe metadata still includes `rentPaymentId`, `leaseId`, `tenantId`, and `landlordId`.
+
+Additive metadata:
+
+- `paymentIntentId` is included in Stripe Checkout Session metadata and PaymentIntent metadata where safe.
+
+## Webhook Linking
+
+The rent-payment webhook branch remains responsible for current `rentPayments` status transitions.
+
+V1 passively links provider evidence back to PaymentIntent by:
+
+1. resolving `paymentIntentId` from provider metadata when present
+2. falling back to the `rentPaymentId` mapping when safe
+3. updating provider session/payment references on the PaymentIntent
+4. adding `paymentIntentId` to provider-event receipts and reconciliation records
+
+Safe status updates are passive and do not drive webhook behavior:
+
+- pending provider signals -> pending states
+- confirmed provider signal -> `confirmed`
+- failed provider signal -> `failed`
+- cancelled/expired provider signal -> matching terminal state
+- mismatch/unknown/manual-review signal -> `manual_review_required`
+
+Existing `rentPayments` status update logic remains unchanged.
+
+## Canonical Events
+
+PaymentIntent V1 adds taxonomy for:
+
+- `payment.intent_created`
+- `payment.intent_updated`
+- `payment.intent_provider_linked`
+
+V1 emits intent-created and provider-linked events only from the rent-payment checkout flow, and only with safe IDs and summary metadata. These events are additive and do not replace provider signal events or rent payment events.
+
+## Relationship To Stripe And Future Trustly
+
+Stripe remains the only live rent-payment execution provider in V1. PaymentIntent is provider-neutral and keeps Stripe IDs as attributes.
+
+Future Trustly work should consume PaymentIntent as the internal obligation, but this mission does not add a Trustly adapter, credentials, UI, or switching logic.
+
+## Deferred Future Steps
+
+1. PaymentIntent-driven rent ledger.
+2. Monthly PaymentIntent generation from active leases.
+3. Reconciliation-driven PaymentIntent status enforcement.
+4. Trustly sandbox adapter using PaymentIntent.
+5. Landlord/tenant UI for PaymentIntent history.
+6. PaymentIntent review queue for incomplete obligations.
+7. PaymentIntent-driven retry and expiration workflow.
+

--- a/rentchain-api/src/lib/payments/__tests__/paymentIntents.test.ts
+++ b/rentchain-api/src/lib/payments/__tests__/paymentIntents.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { collections, dbMock } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, any>>();
+
+  function ensureCollection(name: string) {
+    if (!collections.has(name)) collections.set(name, new Map<string, any>());
+    return collections.get(name)!;
+  }
+
+  function docRef(name: string, id: string) {
+    return {
+      async get() {
+        const data = ensureCollection(name).get(id);
+        return {
+          exists: Boolean(data),
+          data: () => data,
+        };
+      },
+      async set(payload: Record<string, unknown>, options?: { merge?: boolean }) {
+        const existing = ensureCollection(name).get(id) || {};
+        ensureCollection(name).set(id, options?.merge ? { ...existing, ...payload } : payload);
+      },
+    };
+  }
+
+  return {
+    collections,
+    dbMock: {
+      collection: (name: string) => ({
+        doc: (id: string) => docRef(name, id),
+        where: (field: string, op: string, value: unknown) => ({
+          limit: (count: number) => ({
+            async get() {
+              const docs = Array.from(ensureCollection(name).entries())
+                .filter(([, data]) => (op === "==" ? data?.[field] === value : false))
+                .slice(0, count)
+                .map(([id, data]) => ({
+                  id,
+                  data: () => data,
+                }));
+              return { empty: docs.length === 0, docs };
+            },
+          }),
+        }),
+      }),
+    },
+  };
+});
+
+vi.mock("../../../config/firebase", () => ({
+  db: dbMock,
+}));
+
+import {
+  buildPaymentIntentId,
+  findPaymentIntentByRentPaymentId,
+  linkPaymentIntentProviderReference,
+  PAYMENT_INTENTS_COLLECTION,
+  updatePaymentIntentFromProviderSignal,
+  upsertPaymentIntent,
+} from "../paymentIntents";
+
+const baseIntentInput = {
+  landlordId: "landlord-1",
+  tenantId: "tenant-1",
+  propertyId: "property-1",
+  unitId: "unit-1",
+  leaseId: "lease-1",
+  rentPaymentId: "rp-1",
+  purpose: "rent" as const,
+  amountCents: 180000,
+  currency: "cad",
+  source: "rent_payment_checkout" as const,
+  now: "2026-05-05T12:00:00.000Z",
+};
+
+describe("paymentIntents", () => {
+  beforeEach(() => {
+    collections.clear();
+  });
+
+  it("builds deterministic rent PaymentIntent IDs from obligation fields", () => {
+    const first = buildPaymentIntentId(baseIntentInput);
+    const second = buildPaymentIntentId({
+      ...baseIntentInput,
+      rentPaymentId: "rp-retry",
+    });
+
+    expect(first).toMatch(/^pi_rent_[a-f0-9]{32}$/);
+    expect(second).toBe(first);
+  });
+
+  it("creates and upserts duplicate rent PaymentIntents without duplicate records", async () => {
+    const first = await upsertPaymentIntent(baseIntentInput);
+    const duplicate = await upsertPaymentIntent({
+      ...baseIntentInput,
+      rentPaymentId: "rp-2",
+      now: "2026-05-05T12:05:00.000Z",
+    });
+
+    expect(first.created).toBe(true);
+    expect(duplicate.created).toBe(false);
+    expect(duplicate.paymentIntent.paymentIntentId).toBe(first.paymentIntent.paymentIntentId);
+    expect(duplicate.paymentIntent.rentPaymentId).toBe("rp-2");
+    expect(duplicate.paymentIntent.amountCents).toBe(180000);
+    expect(duplicate.paymentIntent.currency).toBe("cad");
+    expect(duplicate.paymentIntent.status).toBe("ready");
+    expect(duplicate.paymentIntent.lifecycleState).toBe("complete");
+    expect(collections.get(PAYMENT_INTENTS_COLLECTION)?.size).toBe(1);
+  });
+
+  it("links provider session references without storing raw provider payloads", async () => {
+    const created = await upsertPaymentIntent(baseIntentInput);
+    const linked = await linkPaymentIntentProviderReference({
+      paymentIntentId: created.paymentIntent.paymentIntentId,
+      provider: "stripe",
+      providerSessionId: "cs_test_1",
+      providerPaymentId: "pi_test_1",
+      now: "2026-05-05T12:01:00.000Z",
+    });
+
+    expect(linked).toEqual(
+      expect.objectContaining({
+        paymentIntentId: created.paymentIntent.paymentIntentId,
+        provider: "stripe",
+        providerSessionId: "cs_test_1",
+        providerPaymentId: "pi_test_1",
+        status: "provider_session_created",
+      })
+    );
+    expect(JSON.stringify(linked)).not.toContain("checkout.session");
+    expect(JSON.stringify(linked)).not.toContain("card");
+  });
+
+  it("marks incomplete rent PaymentIntent data for review", async () => {
+    const result = await upsertPaymentIntent({
+      purpose: "rent",
+      rentPaymentId: "rp-review",
+      amountCents: 180000,
+      source: "rent_payment_checkout",
+      now: "2026-05-05T12:00:00.000Z",
+    });
+
+    expect(result.paymentIntent).toEqual(
+      expect.objectContaining({
+        status: "manual_review_required",
+        lifecycleState: "requires_review",
+        requiresReview: true,
+      })
+    );
+  });
+
+  it("finds intents by rentPaymentId and updates provider signal status", async () => {
+    const created = await upsertPaymentIntent(baseIntentInput);
+    const found = await findPaymentIntentByRentPaymentId({ rentPaymentId: "rp-1" });
+    const updated = await updatePaymentIntentFromProviderSignal({
+      rentPaymentId: "rp-1",
+      provider: "stripe",
+      providerSessionId: "cs_test_1",
+      providerPaymentId: "pi_test_1",
+      normalizedStatus: "confirmed",
+      now: "2026-05-05T12:02:00.000Z",
+    });
+
+    expect(found?.paymentIntentId).toBe(created.paymentIntent.paymentIntentId);
+    expect(updated).toEqual(
+      expect.objectContaining({
+        paymentIntentId: created.paymentIntent.paymentIntentId,
+        status: "confirmed",
+        providerSessionId: "cs_test_1",
+        providerPaymentId: "pi_test_1",
+      })
+    );
+  });
+});

--- a/rentchain-api/src/lib/payments/__tests__/paymentProviderEventReceipts.test.ts
+++ b/rentchain-api/src/lib/payments/__tests__/paymentProviderEventReceipts.test.ts
@@ -201,6 +201,7 @@ describe("paymentProviderEventReceipts", () => {
       purpose: null,
       subjectType: null,
       subjectId: null,
+      paymentIntentId: null,
       status: "received",
       duplicateCount: 0,
       normalizedStatus: "confirmed",

--- a/rentchain-api/src/lib/payments/__tests__/paymentReconciliationRecords.test.ts
+++ b/rentchain-api/src/lib/payments/__tests__/paymentReconciliationRecords.test.ts
@@ -54,6 +54,7 @@ describe("paymentReconciliationRecords", () => {
       receiptId: "provider_event:stripe:evt_1",
       subjectType: "rent_payment",
       subjectId: "rp-1",
+      paymentIntentId: null,
       purpose: "rent",
       providerSignal,
       reconciliation: {
@@ -73,6 +74,7 @@ describe("paymentReconciliationRecords", () => {
       receiptId: "provider_event:stripe:evt_1",
       subjectType: "rent_payment",
       subjectId: "rp-1",
+      paymentIntentId: null,
       purpose: "rent",
       normalizedStatus: "confirmed",
       rawStatus: "paid",

--- a/rentchain-api/src/lib/payments/paymentCanonicalEvents.ts
+++ b/rentchain-api/src/lib/payments/paymentCanonicalEvents.ts
@@ -1,5 +1,7 @@
 export const PAYMENT_CANONICAL_EVENTS = [
   "payment.intent_created",
+  "payment.intent_updated",
+  "payment.intent_provider_linked",
   "payment.provider_selected",
   "payment.provider_session_created",
   "payment.provider_signal_received",

--- a/rentchain-api/src/lib/payments/paymentIntents.ts
+++ b/rentchain-api/src/lib/payments/paymentIntents.ts
@@ -1,0 +1,368 @@
+import crypto from "crypto";
+import { db } from "../../config/firebase";
+import type { PaymentExecutionStatus, PaymentProvider, PaymentPurpose } from "./paymentTypes";
+
+export const PAYMENT_INTENTS_COLLECTION = "paymentIntents";
+
+export const PAYMENT_INTENT_STATUSES = [
+  "draft",
+  "ready",
+  "provider_session_created",
+  "pending_provider_confirmation",
+  "pending_settlement",
+  "confirmed",
+  "failed",
+  "cancelled",
+  "expired",
+  "manual_review_required",
+  "reconciled",
+] as const;
+export type PaymentIntentStatus = (typeof PAYMENT_INTENT_STATUSES)[number];
+
+export const PAYMENT_INTENT_SOURCES = [
+  "rent_payment_checkout",
+  "manual_admin",
+  "system_derived",
+  "migration_placeholder",
+] as const;
+export type PaymentIntentSource = (typeof PAYMENT_INTENT_SOURCES)[number];
+
+export type PaymentIntentRecord = {
+  paymentIntentId: string;
+  landlordId: string | null;
+  tenantId?: string | null;
+  propertyId: string | null;
+  unitId?: string | null;
+  leaseId?: string | null;
+  rentPaymentId?: string | null;
+  purpose: Extract<PaymentPurpose, "rent">;
+  amountCents: number;
+  currency: string;
+  periodStart?: string | null;
+  periodEnd?: string | null;
+  dueDate?: string | null;
+  status: PaymentIntentStatus;
+  provider?: PaymentProvider | null;
+  providerSessionId?: string | null;
+  providerPaymentId?: string | null;
+  source: PaymentIntentSource;
+  lifecycleState: "complete" | "requires_review";
+  requiresReview: boolean;
+  createdAt: string;
+  updatedAt: string;
+  metadataSummary?: Record<string, unknown> | null;
+};
+
+export type PaymentIntentUpsertInput = {
+  landlordId?: string | null;
+  tenantId?: string | null;
+  propertyId?: string | null;
+  unitId?: string | null;
+  leaseId?: string | null;
+  rentPaymentId?: string | null;
+  purpose: Extract<PaymentPurpose, "rent">;
+  amountCents: number;
+  currency?: string | null;
+  periodStart?: string | null;
+  periodEnd?: string | null;
+  dueDate?: string | null;
+  source: PaymentIntentSource;
+  provider?: PaymentProvider | null;
+  providerSessionId?: string | null;
+  providerPaymentId?: string | null;
+  metadataSummary?: Record<string, unknown> | null;
+  now?: string | null;
+  firestore?: FirestoreLike;
+};
+
+type FirestoreDocRef = {
+  get(): Promise<{ exists: boolean; data(): Record<string, unknown> | undefined }>;
+  set(payload: Record<string, unknown>, options?: { merge?: boolean }): Promise<void>;
+};
+
+type FirestoreCollectionRef = {
+  doc(id: string): FirestoreDocRef;
+  where?(
+    field: string,
+    op: string,
+    value: unknown
+  ): {
+    limit(count: number): { get(): Promise<{ empty: boolean; docs: Array<{ id: string; data(): Record<string, unknown> | undefined }> }> };
+    get?(): Promise<{ empty: boolean; docs: Array<{ id: string; data(): Record<string, unknown> | undefined }> }>;
+  };
+};
+
+type FirestoreLike = {
+  collection(name: string): FirestoreCollectionRef;
+};
+
+function getFirestore(input?: { firestore?: FirestoreLike }): FirestoreLike {
+  return input?.firestore || (db as unknown as FirestoreLike);
+}
+
+function asString(value: unknown, max = 500): string | null {
+  const next = String(value ?? "").trim().slice(0, max);
+  return next || null;
+}
+
+function normalizeCurrency(value: unknown): string {
+  return String(value || "cad").trim().toLowerCase() || "cad";
+}
+
+function normalizeAmountCents(value: unknown): number {
+  const next = Number(value);
+  if (!Number.isFinite(next) || next < 0) return 0;
+  return Math.round(next);
+}
+
+function toIsoDate(value: unknown): string | null {
+  const raw = asString(value, 120);
+  if (!raw) return null;
+  const parsed = Date.parse(raw);
+  if (!Number.isFinite(parsed)) return null;
+  return new Date(parsed).toISOString();
+}
+
+function nowIso(value?: string | null): string {
+  return toIsoDate(value) || new Date().toISOString();
+}
+
+function cleanPart(value: unknown): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function stableHash(value: string): string {
+  return crypto.createHash("sha256").update(value).digest("hex").slice(0, 32);
+}
+
+function normalizeMetadataSummary(value: Record<string, unknown> | null | undefined): Record<string, unknown> | null {
+  if (!value || typeof value !== "object") return null;
+  const safe: Record<string, unknown> = {};
+  for (const [key, rawValue] of Object.entries(value).slice(0, 20)) {
+    const safeKey = asString(key, 80);
+    if (!safeKey) continue;
+    if (rawValue == null || ["string", "number", "boolean"].includes(typeof rawValue)) {
+      safe[safeKey] = rawValue;
+    }
+  }
+  return Object.keys(safe).length ? safe : null;
+}
+
+function normalizeStatus(value: unknown): PaymentIntentStatus | null {
+  const next = asString(value, 80) as PaymentIntentStatus | null;
+  return next && (PAYMENT_INTENT_STATUSES as readonly string[]).includes(next) ? next : null;
+}
+
+function normalizeRecord(data: Record<string, unknown>, fallbackId: string): PaymentIntentRecord {
+  const amountCents = normalizeAmountCents(data.amountCents);
+  const status = normalizeStatus(data.status) || "manual_review_required";
+  const requiresReview = data.requiresReview === true || status === "manual_review_required";
+  return {
+    paymentIntentId: asString(data.paymentIntentId, 240) || fallbackId,
+    landlordId: asString(data.landlordId, 240),
+    tenantId: asString(data.tenantId, 240),
+    propertyId: asString(data.propertyId, 240),
+    unitId: asString(data.unitId, 240),
+    leaseId: asString(data.leaseId, 240),
+    rentPaymentId: asString(data.rentPaymentId, 240),
+    purpose: "rent",
+    amountCents,
+    currency: normalizeCurrency(data.currency),
+    periodStart: toIsoDate(data.periodStart),
+    periodEnd: toIsoDate(data.periodEnd),
+    dueDate: toIsoDate(data.dueDate),
+    status,
+    provider: (asString(data.provider, 50) as PaymentProvider | null) || null,
+    providerSessionId: asString(data.providerSessionId, 240),
+    providerPaymentId: asString(data.providerPaymentId, 240),
+    source: ((asString(data.source, 80) as PaymentIntentSource | null) || "system_derived") as PaymentIntentSource,
+    lifecycleState: requiresReview ? "requires_review" : "complete",
+    requiresReview,
+    createdAt: toIsoDate(data.createdAt) || nowIso(),
+    updatedAt: toIsoDate(data.updatedAt) || nowIso(),
+    metadataSummary:
+      data.metadataSummary && typeof data.metadataSummary === "object"
+        ? normalizeMetadataSummary(data.metadataSummary as Record<string, unknown>)
+        : null,
+  };
+}
+
+function hasCompleteRentObligationKey(input: PaymentIntentUpsertInput): boolean {
+  return Boolean(
+    asString(input.landlordId, 240) &&
+      asString(input.propertyId, 240) &&
+      asString(input.leaseId, 240) &&
+      asString(input.tenantId, 240) &&
+      normalizeAmountCents(input.amountCents) > 0 &&
+      normalizeCurrency(input.currency)
+  );
+}
+
+export function buildPaymentIntentId(input: Partial<PaymentIntentUpsertInput>): string {
+  const amountCents = normalizeAmountCents(input.amountCents);
+  const currency = normalizeCurrency(input.currency);
+  const purpose = asString(input.purpose, 40) || "rent";
+  const keyParts = hasCompleteRentObligationKey({
+    ...(input as PaymentIntentUpsertInput),
+    purpose: "rent",
+    source: input.source || "system_derived",
+    amountCents,
+    currency,
+  })
+    ? [
+        "rent_obligation",
+        input.landlordId,
+        input.propertyId,
+        input.unitId,
+        input.leaseId,
+        input.tenantId,
+        purpose,
+        toIsoDate(input.periodStart) || "",
+        toIsoDate(input.periodEnd) || "",
+        amountCents,
+        currency,
+      ]
+    : ["rent_payment", input.rentPaymentId || input.leaseId || input.tenantId || "review_required", purpose, amountCents, currency];
+
+  const seed = keyParts.map((part) => cleanPart(part)).join(":");
+  return `pi_rent_${stableHash(seed)}`;
+}
+
+export async function getPaymentIntentById(input: {
+  paymentIntentId: string;
+  firestore?: FirestoreLike;
+}): Promise<PaymentIntentRecord | null> {
+  const paymentIntentId = asString(input.paymentIntentId, 240);
+  if (!paymentIntentId) return null;
+  const snap = await getFirestore(input).collection(PAYMENT_INTENTS_COLLECTION).doc(paymentIntentId).get();
+  if (!snap.exists) return null;
+  return normalizeRecord(snap.data() || {}, paymentIntentId);
+}
+
+export async function findPaymentIntentByRentPaymentId(input: {
+  rentPaymentId: string;
+  firestore?: FirestoreLike;
+}): Promise<PaymentIntentRecord | null> {
+  const rentPaymentId = asString(input.rentPaymentId, 240);
+  if (!rentPaymentId) return null;
+  const collection = getFirestore(input).collection(PAYMENT_INTENTS_COLLECTION);
+  if (!collection.where) return null;
+  const snap = await collection.where("rentPaymentId", "==", rentPaymentId).limit(1).get();
+  if (snap.empty || !snap.docs?.[0]) return null;
+  return normalizeRecord(snap.docs[0].data() || {}, snap.docs[0].id);
+}
+
+export async function upsertPaymentIntent(input: PaymentIntentUpsertInput): Promise<{
+  paymentIntent: PaymentIntentRecord;
+  created: boolean;
+}> {
+  const at = nowIso(input.now);
+  const paymentIntentId = buildPaymentIntentId(input);
+  const ref = getFirestore(input).collection(PAYMENT_INTENTS_COLLECTION).doc(paymentIntentId);
+  const snap = await ref.get();
+  const existing = snap.exists ? normalizeRecord(snap.data() || {}, paymentIntentId) : null;
+  const requiresReview = !hasCompleteRentObligationKey(input);
+  const status: PaymentIntentStatus = requiresReview ? "manual_review_required" : existing?.status || "ready";
+  const next: PaymentIntentRecord = {
+    paymentIntentId,
+    landlordId: asString(input.landlordId, 240),
+    tenantId: asString(input.tenantId, 240),
+    propertyId: asString(input.propertyId, 240),
+    unitId: asString(input.unitId, 240),
+    leaseId: asString(input.leaseId, 240),
+    rentPaymentId: asString(input.rentPaymentId, 240) || existing?.rentPaymentId || null,
+    purpose: "rent",
+    amountCents: normalizeAmountCents(input.amountCents),
+    currency: normalizeCurrency(input.currency),
+    periodStart: toIsoDate(input.periodStart),
+    periodEnd: toIsoDate(input.periodEnd),
+    dueDate: toIsoDate(input.dueDate),
+    status,
+    provider: input.provider || existing?.provider || null,
+    providerSessionId: asString(input.providerSessionId, 240) || existing?.providerSessionId || null,
+    providerPaymentId: asString(input.providerPaymentId, 240) || existing?.providerPaymentId || null,
+    source: input.source,
+    lifecycleState: requiresReview ? "requires_review" : "complete",
+    requiresReview,
+    createdAt: existing?.createdAt || at,
+    updatedAt: at,
+    metadataSummary: normalizeMetadataSummary(input.metadataSummary) || existing?.metadataSummary || null,
+  };
+  await ref.set(next, { merge: true });
+  return { paymentIntent: next, created: !existing };
+}
+
+export async function linkPaymentIntentProviderReference(input: {
+  paymentIntentId: string;
+  provider: PaymentProvider;
+  providerSessionId?: string | null;
+  providerPaymentId?: string | null;
+  status?: PaymentIntentStatus;
+  now?: string | null;
+  firestore?: FirestoreLike;
+}): Promise<PaymentIntentRecord | null> {
+  const paymentIntentId = asString(input.paymentIntentId, 240);
+  if (!paymentIntentId) return null;
+  const existing = await getPaymentIntentById({ paymentIntentId, firestore: input.firestore });
+  if (!existing) return null;
+  const at = nowIso(input.now);
+  const patch = {
+    provider: input.provider,
+    providerSessionId: asString(input.providerSessionId, 240) || existing.providerSessionId || null,
+    providerPaymentId: asString(input.providerPaymentId, 240) || existing.providerPaymentId || null,
+    status: input.status || "provider_session_created",
+    updatedAt: at,
+  };
+  await getFirestore(input).collection(PAYMENT_INTENTS_COLLECTION).doc(paymentIntentId).set(patch, { merge: true });
+  return normalizeRecord({ ...existing, ...patch }, paymentIntentId);
+}
+
+export function mapProviderSignalToPaymentIntentStatus(status: PaymentExecutionStatus | null | undefined): PaymentIntentStatus {
+  if (status === "provider_session_created") return "provider_session_created";
+  if (status === "pending_provider_confirmation") return "pending_provider_confirmation";
+  if (status === "pending_settlement" || status === "initiated") return "pending_settlement";
+  if (status === "confirmed" || status === "reconciled") return "confirmed";
+  if (status === "failed") return "failed";
+  if (status === "cancelled") return "cancelled";
+  if (status === "expired") return "expired";
+  if (status === "mismatch" || status === "duplicate_risk" || status === "manual_review_required") {
+    return "manual_review_required";
+  }
+  return "manual_review_required";
+}
+
+export async function updatePaymentIntentFromProviderSignal(input: {
+  paymentIntentId?: string | null;
+  rentPaymentId?: string | null;
+  provider: PaymentProvider;
+  providerSessionId?: string | null;
+  providerPaymentId?: string | null;
+  normalizedStatus?: PaymentExecutionStatus | null;
+  now?: string | null;
+  firestore?: FirestoreLike;
+}): Promise<PaymentIntentRecord | null> {
+  const fromId = input.paymentIntentId
+    ? await getPaymentIntentById({ paymentIntentId: input.paymentIntentId, firestore: input.firestore })
+    : null;
+  const intent =
+    fromId ||
+    (input.rentPaymentId
+      ? await findPaymentIntentByRentPaymentId({ rentPaymentId: input.rentPaymentId, firestore: input.firestore })
+      : null);
+  if (!intent) return null;
+  return linkPaymentIntentProviderReference({
+    paymentIntentId: intent.paymentIntentId,
+    provider: input.provider,
+    providerSessionId: input.providerSessionId,
+    providerPaymentId: input.providerPaymentId,
+    status: mapProviderSignalToPaymentIntentStatus(input.normalizedStatus),
+    now: input.now,
+    firestore: input.firestore,
+  });
+}
+

--- a/rentchain-api/src/lib/payments/paymentProviderEventReceipts.ts
+++ b/rentchain-api/src/lib/payments/paymentProviderEventReceipts.ts
@@ -22,6 +22,7 @@ export type PaymentProviderEventReceipt = {
   purpose?: PaymentPurpose | null;
   subjectType?: string | null;
   subjectId?: string | null;
+  paymentIntentId?: string | null;
   status: PaymentProviderEventReceiptStatus;
   firstReceivedAt: string;
   lastSeenAt: string;
@@ -52,6 +53,7 @@ type ReceiptWriteInput = {
   purpose?: PaymentPurpose | null;
   subjectType?: string | null;
   subjectId?: string | null;
+  paymentIntentId?: string | null;
   normalizedStatus?: PaymentExecutionStatus | null;
   rawStatus?: string | null;
   metadata?: Record<string, unknown> | null;
@@ -126,6 +128,7 @@ function normalizeReceipt(data: Record<string, unknown>, fallback: { receiptId: 
     purpose: (normalizeOptionalString(data.purpose, 50) as PaymentPurpose | null) || null,
     subjectType: normalizeOptionalString(data.subjectType, 80),
     subjectId: normalizeOptionalString(data.subjectId, 300),
+    paymentIntentId: normalizeOptionalString(data.paymentIntentId, 300),
     status: (normalizeOptionalString(data.status, 80) || "received") as PaymentProviderEventReceiptStatus,
     firstReceivedAt: normalizeOptionalString(data.firstReceivedAt, 80) || nowIso(),
     lastSeenAt: normalizeOptionalString(data.lastSeenAt, 80) || nowIso(),
@@ -155,6 +158,7 @@ export function serializeProviderEventReceiptSummary(receipt: PaymentProviderEve
     purpose: receipt.purpose || null,
     subjectType: receipt.subjectType || null,
     subjectId: receipt.subjectId || null,
+    paymentIntentId: receipt.paymentIntentId || null,
     status: receipt.status,
     duplicateCount: receipt.duplicateCount,
     normalizedStatus: receipt.normalizedStatus || null,
@@ -180,6 +184,7 @@ export async function markProviderEventReceived(input: ReceiptWriteInput): Promi
       normalizedStatus: input.normalizedStatus || existing.normalizedStatus || null,
       rawStatus: input.rawStatus || existing.rawStatus || null,
       metadataSummary: metadataSummary || existing.metadataSummary || null,
+      paymentIntentId: normalizeOptionalString(input.paymentIntentId, 300) || existing.paymentIntentId || null,
     };
     await ref.set(next, { merge: true });
     return { receiptId, isDuplicate: true, receipt: next, previousReceipt: existing };
@@ -193,6 +198,7 @@ export async function markProviderEventReceived(input: ReceiptWriteInput): Promi
     purpose: input.purpose || null,
     subjectType: normalizeOptionalString(input.subjectType, 80),
     subjectId: normalizeOptionalString(input.subjectId, 300),
+    paymentIntentId: normalizeOptionalString(input.paymentIntentId, 300),
     status: "received",
     firstReceivedAt: at,
     lastSeenAt: at,

--- a/rentchain-api/src/lib/payments/paymentReconciliationRecords.ts
+++ b/rentchain-api/src/lib/payments/paymentReconciliationRecords.ts
@@ -13,6 +13,7 @@ export type PaymentReconciliationRecord = {
   receiptId: string;
   subjectType?: string | null;
   subjectId?: string | null;
+  paymentIntentId?: string | null;
   purpose?: PaymentPurpose | null;
   normalizedStatus?: PaymentExecutionStatus | null;
   rawStatus?: string | null;
@@ -40,6 +41,7 @@ type UpsertPaymentReconciliationRecordInput = {
   receiptId: string;
   subjectType?: string | null;
   subjectId?: string | null;
+  paymentIntentId?: string | null;
   purpose?: PaymentPurpose | null;
   providerSignal: NormalizedProviderPaymentEvent;
   reconciliation: PaymentReconciliationResult;
@@ -92,6 +94,7 @@ function normalizeRecord(
     receiptId: normalizeOptionalString(data.receiptId, 300) || fallback.receiptId,
     subjectType: normalizeOptionalString(data.subjectType, 80),
     subjectId: normalizeOptionalString(data.subjectId, 300),
+    paymentIntentId: normalizeOptionalString(data.paymentIntentId, 300),
     purpose: (normalizeOptionalString(data.purpose, 50) as PaymentPurpose | null) || null,
     normalizedStatus: (normalizeOptionalString(data.normalizedStatus, 80) as PaymentExecutionStatus | null) || null,
     rawStatus: normalizeOptionalString(data.rawStatus, 200),
@@ -133,6 +136,7 @@ export async function upsertPaymentReconciliationRecord(
     receiptId: input.receiptId,
     subjectType: normalizeOptionalString(input.subjectType, 80),
     subjectId: normalizeOptionalString(input.subjectId, 300),
+    paymentIntentId: normalizeOptionalString(input.paymentIntentId, 300),
     purpose: input.purpose || input.providerSignal.purpose || null,
     normalizedStatus: input.providerSignal.normalizedStatus || null,
     rawStatus: input.providerSignal.rawStatus || null,

--- a/rentchain-api/src/routes/__tests__/rentPaymentWebhook.test.ts
+++ b/rentchain-api/src/routes/__tests__/rentPaymentWebhook.test.ts
@@ -247,6 +247,27 @@ describe("rent payment webhook reconciliation", () => {
       updatedAt: "2026-04-27T10:00:00.000Z",
       paidAt: null,
     });
+    ensureCollection("paymentIntents").set("pi_rent_1", {
+      paymentIntentId: "pi_rent_1",
+      rentPaymentId: "rp-1",
+      leaseId: "lease-1",
+      tenantId: "tenant-1",
+      landlordId: "landlord-1",
+      propertyId: null,
+      unitId: null,
+      purpose: "rent",
+      amountCents: 180000,
+      currency: "cad",
+      status: "provider_session_created",
+      provider: "stripe",
+      providerSessionId: "cs_test_1",
+      providerPaymentId: "pi_test_1",
+      source: "rent_payment_checkout",
+      lifecycleState: "complete",
+      requiresReview: false,
+      createdAt: "2026-04-27T10:00:00.000Z",
+      updatedAt: "2026-04-27T10:00:00.000Z",
+    });
   });
 
   it("marks a rent payment paid idempotently from checkout completion metadata", async () => {
@@ -261,6 +282,7 @@ describe("rent payment webhook reconciliation", () => {
           payment_status: "paid",
           metadata: {
             rentPaymentId: "rp-1",
+            paymentIntentId: "pi_rent_1",
             leaseId: "lease-1",
             tenantId: "tenant-1",
             landlordId: "landlord-1",
@@ -290,7 +312,7 @@ describe("rent payment webhook reconciliation", () => {
     });
     expect(deriveRentPaymentReconciliationMock).toHaveBeenCalledWith({
       expectedIntent: expect.objectContaining({
-        paymentIntentId: "rp-1",
+        paymentIntentId: "pi_rent_1",
         landlordId: "landlord-1",
         tenantId: "tenant-1",
         leaseId: "lease-1",
@@ -340,6 +362,7 @@ describe("rent payment webhook reconciliation", () => {
         purpose: "rent",
         subjectType: "rent_payment",
         subjectId: "rp-1",
+        paymentIntentId: "pi_rent_1",
         status: "ignored_duplicate",
         duplicateCount: 1,
         normalizedStatus: "confirmed",
@@ -356,6 +379,7 @@ describe("rent payment webhook reconciliation", () => {
         receiptId: "provider_event:stripe:evt_rent_paid_1",
         subjectType: "rent_payment",
         subjectId: "rp-1",
+        paymentIntentId: "pi_rent_1",
         purpose: "rent",
         normalizedStatus: "confirmed",
         rawStatus: "paid",
@@ -391,7 +415,15 @@ describe("rent payment webhook reconciliation", () => {
           rawStatus: "paid",
           subjectType: "rent_payment",
           subjectId: "rp-1",
+          paymentIntentId: "pi_rent_1",
         }),
+      })
+    );
+    expect(ensureCollection("paymentIntents").get("pi_rent_1")).toEqual(
+      expect.objectContaining({
+        status: "confirmed",
+        providerSessionId: "cs_test_1",
+        providerPaymentId: "pi_test_1",
       })
     );
     expect(canonicalEvents.filter((event: any) => event.type === "rent_payment.paid")).toHaveLength(1);
@@ -540,6 +572,13 @@ describe("rent payment webhook reconciliation", () => {
         status: "failed",
         processorCheckoutSessionId: "cs_test_1",
         processorPaymentIntentId: "pi_test_1",
+      })
+    );
+    expect(ensureCollection("paymentIntents").get("pi_rent_1")).toEqual(
+      expect.objectContaining({
+        status: "failed",
+        providerSessionId: "cs_test_1",
+        providerPaymentId: "pi_test_1",
       })
     );
     expect(ensureCollection("paymentProviderEventReceipts").get("provider_event:stripe:evt_rent_failed_1")).toEqual(

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -801,6 +801,7 @@ describe("tenantPortalRoutes foundation", () => {
           tenantId: "tenant-1",
           landlordId: "landlord-1",
           rentPaymentId: expect.any(String),
+          paymentIntentId: expect.stringMatching(/^pi_rent_/),
         }),
         payment_intent_data: expect.objectContaining({
           metadata: expect.objectContaining({
@@ -808,6 +809,7 @@ describe("tenantPortalRoutes foundation", () => {
             tenantId: "tenant-1",
             landlordId: "landlord-1",
             rentPaymentId: expect.any(String),
+            paymentIntentId: expect.stringMatching(/^pi_rent_/),
           }),
         }),
       })
@@ -826,6 +828,26 @@ describe("tenantPortalRoutes foundation", () => {
         processor: "stripe",
         processorCheckoutSessionId: "cs_test_1",
         processorPaymentIntentId: "pi_test_1",
+      })
+    );
+    const storedPaymentIntents = Array.from(ensureCollection("paymentIntents").values());
+    expect(storedPaymentIntents).toHaveLength(1);
+    expect(storedPaymentIntents[0]).toEqual(
+      expect.objectContaining({
+        paymentIntentId: expect.stringMatching(/^pi_rent_/),
+        rentPaymentId: res.body.data.rentPaymentId,
+        leaseId: "lease-1",
+        tenantId: "tenant-1",
+        landlordId: "landlord-1",
+        propertyId: "prop-1",
+        amountCents: 180000,
+        currency: "cad",
+        purpose: "rent",
+        source: "rent_payment_checkout",
+        provider: "stripe",
+        providerSessionId: "cs_test_1",
+        providerPaymentId: "pi_test_1",
+        status: "provider_session_created",
       })
     );
     expect(JSON.stringify(storedPayments[0])).not.toContain("card");
@@ -875,6 +897,61 @@ describe("tenantPortalRoutes foundation", () => {
       detail: "payment_already_pending",
     });
     expect(stripeCheckoutCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("reuses the same PaymentIntent for repeated checkout attempts on the same rent obligation", async () => {
+    ensureCollection("leases").set("lease-1", {
+      ...(ensureCollection("leases").get("lease-1") || {}),
+      landlordId: "landlord-1",
+      paymentRailEnabled: true,
+      paymentRailEnabledAt: "2026-04-27T10:00:00.000Z",
+      paymentRailProcessor: "stripe",
+    });
+
+    const router = (await import("../tenantPortalRoutes")).default;
+    const first = await invokeRouter(router, {
+      method: "POST",
+      url: "/leases/lease-1/payments/checkout",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+    const firstPaymentId = first.body.data.rentPaymentId;
+    ensureCollection("rentPayments").set(firstPaymentId, {
+      ...ensureCollection("rentPayments").get(firstPaymentId),
+      status: "failed",
+      updatedAt: "2026-04-27T10:05:00.000Z",
+    });
+
+    const second = await invokeRouter(router, {
+      method: "POST",
+      url: "/leases/lease-1/payments/checkout",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(second.body.data.rentPaymentId).not.toBe(firstPaymentId);
+    expect(ensureCollection("rentPayments").size).toBe(2);
+    expect(ensureCollection("paymentIntents").size).toBe(1);
+    expect(Array.from(ensureCollection("paymentIntents").values())[0]).toEqual(
+      expect.objectContaining({
+        rentPaymentId: second.body.data.rentPaymentId,
+        paymentIntentId: stripeCheckoutCreateMock.mock.calls[1][0].metadata.paymentIntentId,
+      })
+    );
   });
 
   it("returns tenant-safe rent payment status for the current lease", async () => {

--- a/rentchain-api/src/routes/stripeScreeningOrdersWebhookRoutes.ts
+++ b/rentchain-api/src/routes/stripeScreeningOrdersWebhookRoutes.ts
@@ -27,6 +27,7 @@ import {
   normalizeRentPaymentProviderEvent,
 } from "../lib/payments/paymentExecutionService";
 import type { PaymentIntentReference } from "../lib/payments/paymentTypes";
+import { updatePaymentIntentFromProviderSignal } from "../lib/payments/paymentIntents";
 import {
   markProviderEventFailed,
   markProviderEventIgnoredDuplicate,
@@ -266,12 +267,13 @@ function normalizeFailureReason(value: unknown): { code?: string; message?: stri
 
 function buildExpectedRentPaymentIntent(
   rentPaymentId: string,
-  rentPayment: Record<string, unknown> | null | undefined
+  rentPayment: Record<string, unknown> | null | undefined,
+  paymentIntentId?: string | null
 ): PaymentIntentReference | null {
   if (!rentPayment) return null;
   const amount = Number(rentPayment.amountCents);
   return {
-    paymentIntentId: normalizeString(rentPaymentId, 120),
+    paymentIntentId: normalizeOptionalString(paymentIntentId, 240) || normalizeString(rentPaymentId, 120),
     landlordId: normalizeString(rentPayment.landlordId, 120),
     tenantId: normalizeOptionalString(rentPayment.tenantId, 120) || null,
     propertyId: normalizeOptionalString(rentPayment.propertyId, 120) || null,
@@ -282,6 +284,11 @@ function buildExpectedRentPaymentIntent(
     purpose: "rent",
     provider: "stripe",
   };
+}
+
+function getPaymentIntentIdFromProviderMetadata(metadata: unknown): string | null {
+  if (!metadata || typeof metadata !== "object") return null;
+  return normalizeOptionalString((metadata as Record<string, unknown>).paymentIntentId, 240) || null;
 }
 
 async function prepareRentPaymentWebhookNormalizationContext(params: {
@@ -298,6 +305,16 @@ async function prepareRentPaymentWebhookNormalizationContext(params: {
       providerSessionId: rentPaymentEvent.checkoutSessionId,
       purpose: "rent",
     });
+    const paymentIntent = await updatePaymentIntentFromProviderSignal({
+      paymentIntentId: getPaymentIntentIdFromProviderMetadata(normalizedProviderEvent.metadata),
+      rentPaymentId: rentPaymentEvent.rentPaymentId,
+      provider: "stripe",
+      providerSessionId: normalizedProviderEvent.providerSessionId || rentPaymentEvent.checkoutSessionId,
+      providerPaymentId: normalizedProviderEvent.providerPaymentId || rentPaymentEvent.paymentIntentId,
+      normalizedStatus: normalizedProviderEvent.normalizedStatus,
+    });
+    const paymentIntentId =
+      paymentIntent?.paymentIntentId || getPaymentIntentIdFromProviderMetadata(normalizedProviderEvent.metadata);
     const idempotencyKey = buildProviderWebhookIdempotencyKey({
       provider: "stripe",
       providerEventId: normalizedProviderEvent.providerEventId || event.id || "event_missing",
@@ -309,6 +326,7 @@ async function prepareRentPaymentWebhookNormalizationContext(params: {
       purpose: "rent",
       subjectType: "rent_payment",
       subjectId: rentPaymentEvent.rentPaymentId,
+      paymentIntentId,
       normalizedStatus: normalizedProviderEvent.normalizedStatus,
       rawStatus: normalizedProviderEvent.rawStatus,
       metadata: normalizedProviderEvent.metadata || null,
@@ -345,13 +363,14 @@ async function prepareRentPaymentWebhookNormalizationContext(params: {
         rawStatus: normalizedProviderEvent.rawStatus,
         subjectType: "rent_payment",
         subjectId: rentPaymentEvent.rentPaymentId,
+        paymentIntentId: paymentIntentId || null,
       },
     });
 
     const rentPaymentId = normalizeString(rentPaymentEvent.rentPaymentId, 120);
     const snap = rentPaymentId ? await db.collection("rentPayments").doc(rentPaymentId).get() : null;
     const expectedIntent = snap?.exists
-      ? buildExpectedRentPaymentIntent(rentPaymentId, (snap.data() as Record<string, unknown>) || null)
+      ? buildExpectedRentPaymentIntent(rentPaymentId, (snap.data() as Record<string, unknown>) || null, paymentIntentId)
       : null;
     const reconciliation = deriveRentPaymentReconciliation({
       expectedIntent,
@@ -362,6 +381,7 @@ async function prepareRentPaymentWebhookNormalizationContext(params: {
       receiptId: receipt.receiptId,
       subjectType: "rent_payment",
       subjectId: rentPaymentEvent.rentPaymentId,
+      paymentIntentId,
       purpose: "rent",
       providerSignal: normalizedProviderEvent,
       reconciliation,

--- a/rentchain-api/src/services/rentPayments/rentPaymentService.ts
+++ b/rentchain-api/src/services/rentPayments/rentPaymentService.ts
@@ -4,6 +4,11 @@ import { db } from "../../config/firebase";
 import { FRONTEND_URL } from "../../config/screeningConfig";
 import { writeCanonicalEvent } from "../../lib/events/buildEvent";
 import { createRentPaymentSession } from "../../lib/payments/paymentExecutionService";
+import {
+  linkPaymentIntentProviderReference,
+  upsertPaymentIntent,
+  type PaymentIntentRecord,
+} from "../../lib/payments/paymentIntents";
 import type { PaymentReadiness } from "../paymentReadiness/derivePaymentReadiness";
 import { recordSystemObservabilityEvent } from "../observability/recordSystemObservabilityEvent";
 
@@ -291,6 +296,59 @@ async function writeRentPaymentEvent(params: {
   });
 }
 
+async function writePaymentIntentEvent(params: {
+  type: "payment.intent_created" | "payment.intent_provider_linked";
+  paymentIntent: PaymentIntentRecord;
+  rentPaymentId: string;
+  occurredAt?: string;
+}) {
+  try {
+    await writeCanonicalEvent({
+      type: params.type,
+      domain: "payment",
+      action: params.type.replace(/^payment\./, ""),
+      status: params.paymentIntent.status,
+      actor: {
+        type: "system",
+        id: null,
+        role: "system",
+      },
+      resource: {
+        type: "payment_intent",
+        id: params.paymentIntent.paymentIntentId,
+        parentType: "rent_payment",
+        parentId: params.rentPaymentId,
+      },
+      occurredAt: params.occurredAt || new Date().toISOString(),
+      visibility: "internal",
+      summary:
+        params.type === "payment.intent_created"
+          ? "Rent PaymentIntent created"
+          : "Rent PaymentIntent linked to provider session",
+      metadata: {
+        paymentIntentId: params.paymentIntent.paymentIntentId,
+        rentPaymentId: params.rentPaymentId,
+        leaseId: params.paymentIntent.leaseId || null,
+        landlordId: params.paymentIntent.landlordId || null,
+        tenantId: params.paymentIntent.tenantId || null,
+        propertyId: params.paymentIntent.propertyId || null,
+        unitId: params.paymentIntent.unitId || null,
+        purpose: params.paymentIntent.purpose,
+        provider: params.paymentIntent.provider || null,
+        providerSessionId: params.paymentIntent.providerSessionId || null,
+        providerPaymentId: params.paymentIntent.providerPaymentId || null,
+      },
+    });
+  } catch (err: any) {
+    console.warn("[rentPaymentService] payment intent canonical event skipped", {
+      type: params.type,
+      paymentIntentId: params.paymentIntent.paymentIntentId,
+      rentPaymentId: params.rentPaymentId,
+      message: err?.message || String(err),
+    });
+  }
+}
+
 async function recordRentPaymentObservabilityEvent(params: {
   rentPaymentId: string;
   status: RentPaymentStatus;
@@ -502,10 +560,37 @@ export async function createRentPaymentCheckout(input: CreateRentPaymentCheckout
   const cancelUrl = `${frontendBase}${sanitizeRelativePath(input.cancelPath, "/tenant/lease")}`;
   const stripeSuccessUrl = `${successUrl}${successUrl.includes("?") ? "&" : "?"}rentPaymentStatus=success`;
   const stripeCancelUrl = `${cancelUrl}${cancelUrl.includes("?") ? "&" : "?"}rentPaymentStatus=canceled`;
+  const paymentIntentResult = await upsertPaymentIntent({
+    landlordId,
+    tenantId,
+    propertyId: asString(lease.propertyId),
+    unitId: asString(lease.unitId) || asString(lease.unitNumber),
+    leaseId,
+    rentPaymentId,
+    purpose: "rent",
+    amountCents,
+    currency: "cad",
+    source: "rent_payment_checkout",
+    provider: "stripe",
+    metadataSummary: {
+      leaseId,
+      rentPaymentId,
+      source: "rent_payment_checkout",
+    },
+    now: createdAt,
+  });
+  if (paymentIntentResult.created) {
+    await writePaymentIntentEvent({
+      type: "payment.intent_created",
+      paymentIntent: paymentIntentResult.paymentIntent,
+      rentPaymentId,
+      occurredAt: createdAt,
+    });
+  }
 
   const session = await createRentPaymentSession({
     intent: {
-      paymentIntentId: rentPaymentId,
+      paymentIntentId: paymentIntentResult.paymentIntent.paymentIntentId,
       landlordId,
       tenantId,
       propertyId: asString(lease.propertyId),
@@ -521,10 +606,25 @@ export async function createRentPaymentCheckout(input: CreateRentPaymentCheckout
       tenantId,
       landlordId,
       rentPaymentId,
+      paymentIntentId: paymentIntentResult.paymentIntent.paymentIntentId,
     },
     successUrl: stripeSuccessUrl,
     cancelUrl: stripeCancelUrl,
   });
+  const linkedPaymentIntent = await linkPaymentIntentProviderReference({
+    paymentIntentId: paymentIntentResult.paymentIntent.paymentIntentId,
+    provider: "stripe",
+    providerSessionId: session.reference.providerSessionId,
+    providerPaymentId: session.reference.providerPaymentId,
+    status: "provider_session_created",
+  });
+  if (linkedPaymentIntent) {
+    await writePaymentIntentEvent({
+      type: "payment.intent_provider_linked",
+      paymentIntent: linkedPaymentIntent,
+      rentPaymentId,
+    });
+  }
 
   const record: RentPaymentRecord = {
     id: rentPaymentId,


### PR DESCRIPTION
## Summary
- Adds provider-neutral PaymentIntent persistence for rent-payment obligations.
- Introduces deterministic PaymentIntent IDs to avoid duplicate intent creation.
- Passively creates/updates PaymentIntents during existing Stripe rent-payment checkout.
- Adds additive paymentIntentId metadata to Stripe rent checkout sessions.
- Links provider/session references, provider receipts, and reconciliation records back to PaymentIntent where safe.
- Adds safe PaymentIntent canonical event constants/emission for created/linked events.
- Preserves existing Stripe checkout and webhook behavior.
- Adds PaymentIntent architecture documentation.
- No Trustly, subscription billing, screening checkout, payout, schema migration, frontend, dependency, or lockfile changes.

## Verification
- Payment intent/receipt/reconciliation tests passed: 15 tests.
- Rent payment service/webhook tests passed: 10 tests.
- Tenant portal focused tests passed: 54 tests.
- rentchain-api build passed.
- `git diff --check` passed.
- Dependency/lockfile diff empty.