### PR TITLE
Link payment intents to lease lifecycle

### DIFF
--- a/docs/architecture/payment-intent-system-v1.md
+++ b/docs/architecture/payment-intent-system-v1.md
@@ -161,6 +161,41 @@ Stripe remains the only live rent-payment execution provider in V1. PaymentInten
 
 Future Trustly work should consume PaymentIntent as the internal obligation, but this mission does not add a Trustly adapter, credentials, UI, or switching logic.
 
+## Payment To Lease Linking
+
+PaymentIntent V1 links the rent obligation chain without replacing existing records:
+
+```text
+lease lifecycle
+  -> PaymentIntent obligation
+    -> rentPayments checkout record
+      -> provider receipt
+        -> reconciliation record
+          -> lease ledger read model
+```
+
+The lease lifecycle remains the source of truth for whether an obligation should exist. PaymentIntent stores the obligation context additively:
+
+- `leaseId`
+- `propertyId`
+- `unitId`
+- `tenantId`
+- `landlordId`
+- `periodStart` and `periodEnd` when available
+- `rentPaymentId` when checkout creates an execution record
+
+`rentPayments` continues to exist as the compatibility and checkout-history layer. New checkout records store `paymentIntentId`, and repeated checkout attempts for the same deterministic rent obligation update the same PaymentIntent while preserving separate `rentPayments` records.
+
+Webhook processing resolves the internal PaymentIntent in this order:
+
+1. `paymentIntentId` from provider metadata
+2. PaymentIntent lookup by `rentPaymentId`
+3. Safe lease-context lookup where enough obligation fields exist
+
+Resolved IDs are attached to provider receipts and reconciliation records. Existing `rentPayments` status transitions still run exactly as before; PaymentIntent is not authoritative for webhook behavior in V1.
+
+Lease ledger reads may include optional `paymentIntentId` and `paymentIntentStatus` for payment rows when the matching rentPayment/PaymentIntent can be resolved. Ledger calculations remain based on existing ledger entries and are not rewritten by PaymentIntent.
+
 ## Deferred Future Steps
 
 1. PaymentIntent-driven rent ledger.
@@ -170,4 +205,3 @@ Future Trustly work should consume PaymentIntent as the internal obligation, but
 5. Landlord/tenant UI for PaymentIntent history.
 6. PaymentIntent review queue for incomplete obligations.
 7. PaymentIntent-driven retry and expiration workflow.
-

--- a/rentchain-api/src/lib/payments/__tests__/paymentIntentLinking.test.ts
+++ b/rentchain-api/src/lib/payments/__tests__/paymentIntentLinking.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { collections, dbMock } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, any>>();
+
+  function ensureCollection(name: string) {
+    if (!collections.has(name)) collections.set(name, new Map<string, any>());
+    return collections.get(name)!;
+  }
+
+  function docRef(name: string, id: string) {
+    return {
+      async get() {
+        const data = ensureCollection(name).get(id);
+        return {
+          exists: Boolean(data),
+          data: () => data,
+        };
+      },
+      async set(payload: Record<string, unknown>, options?: { merge?: boolean }) {
+        const existing = ensureCollection(name).get(id) || {};
+        ensureCollection(name).set(id, options?.merge ? { ...existing, ...payload } : payload);
+      },
+    };
+  }
+
+  return {
+    collections,
+    dbMock: {
+      collection: (name: string) => ({
+        doc: (id: string) => docRef(name, id),
+        where: (field: string, op: string, value: unknown) => ({
+          limit: (count: number) => ({
+            async get() {
+              const docs = Array.from(ensureCollection(name).entries())
+                .filter(([, data]) => (op === "==" ? data?.[field] === value : false))
+                .slice(0, count)
+                .map(([id, data]) => ({
+                  id,
+                  data: () => data,
+                }));
+              return { empty: docs.length === 0, docs };
+            },
+          }),
+        }),
+      }),
+    },
+  };
+});
+
+vi.mock("../../../config/firebase", () => ({
+  db: dbMock,
+}));
+
+import { PAYMENT_INTENTS_COLLECTION, upsertPaymentIntent } from "../paymentIntents";
+import {
+  resolvePaymentIntentByLeaseContext,
+  resolvePaymentIntentByMetadata,
+  resolvePaymentIntentByRentPaymentId,
+} from "../paymentIntentResolver";
+
+describe("payment intent lease linking", () => {
+  beforeEach(() => {
+    collections.clear();
+  });
+
+  it("creates PaymentIntent records with lease and rentPayment linkage", async () => {
+    const result = await upsertPaymentIntent({
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      propertyId: "property-1",
+      unitId: "unit-1",
+      leaseId: "lease-1",
+      rentPaymentId: "rp-1",
+      purpose: "rent",
+      amountCents: 180000,
+      currency: "cad",
+      source: "rent_payment_checkout",
+      now: "2026-05-05T12:00:00.000Z",
+    });
+
+    expect(result.paymentIntent).toEqual(
+      expect.objectContaining({
+        leaseId: "lease-1",
+        rentPaymentId: "rp-1",
+        propertyId: "property-1",
+        unitId: "unit-1",
+        tenantId: "tenant-1",
+      })
+    );
+  });
+
+  it("resolves PaymentIntent by metadata, rentPaymentId, and lease context", async () => {
+    const result = await upsertPaymentIntent({
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      propertyId: "property-1",
+      unitId: "unit-1",
+      leaseId: "lease-1",
+      rentPaymentId: "rp-1",
+      purpose: "rent",
+      amountCents: 180000,
+      currency: "cad",
+      source: "rent_payment_checkout",
+      now: "2026-05-05T12:00:00.000Z",
+    });
+
+    await upsertPaymentIntent({
+      landlordId: "landlord-1",
+      tenantId: "tenant-2",
+      propertyId: "property-1",
+      unitId: "unit-2",
+      leaseId: "lease-2",
+      rentPaymentId: "rp-2",
+      purpose: "rent",
+      amountCents: 190000,
+      currency: "cad",
+      source: "rent_payment_checkout",
+      now: "2026-05-05T12:01:00.000Z",
+    });
+
+    await expect(
+      resolvePaymentIntentByMetadata({
+        metadata: {
+          paymentIntentId: result.paymentIntent.paymentIntentId,
+        },
+      })
+    ).resolves.toEqual(expect.objectContaining({ paymentIntentId: result.paymentIntent.paymentIntentId }));
+    await expect(resolvePaymentIntentByRentPaymentId({ rentPaymentId: "rp-1" })).resolves.toEqual(
+      expect.objectContaining({ paymentIntentId: result.paymentIntent.paymentIntentId })
+    );
+    await expect(
+      resolvePaymentIntentByLeaseContext({
+        context: {
+          landlordId: "landlord-1",
+          tenantId: "tenant-1",
+          propertyId: "property-1",
+          unitId: "unit-1",
+          leaseId: "lease-1",
+          amountCents: 180000,
+          currency: "cad",
+        },
+      })
+    ).resolves.toEqual(expect.objectContaining({ paymentIntentId: result.paymentIntent.paymentIntentId }));
+  });
+
+  it("keeps duplicate checkout linkage on one deterministic PaymentIntent", async () => {
+    const first = await upsertPaymentIntent({
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      propertyId: "property-1",
+      unitId: "unit-1",
+      leaseId: "lease-1",
+      rentPaymentId: "rp-1",
+      purpose: "rent",
+      amountCents: 180000,
+      currency: "cad",
+      source: "rent_payment_checkout",
+    });
+    const second = await upsertPaymentIntent({
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      propertyId: "property-1",
+      unitId: "unit-1",
+      leaseId: "lease-1",
+      rentPaymentId: "rp-2",
+      purpose: "rent",
+      amountCents: 180000,
+      currency: "cad",
+      source: "rent_payment_checkout",
+    });
+
+    expect(second.paymentIntent.paymentIntentId).toBe(first.paymentIntent.paymentIntentId);
+    expect(second.paymentIntent.rentPaymentId).toBe("rp-2");
+    expect(collections.get(PAYMENT_INTENTS_COLLECTION)?.size).toBe(1);
+  });
+});
+

--- a/rentchain-api/src/lib/payments/paymentIntentResolver.ts
+++ b/rentchain-api/src/lib/payments/paymentIntentResolver.ts
@@ -1,0 +1,155 @@
+import { db } from "../../config/firebase";
+import {
+  buildPaymentIntentId,
+  findPaymentIntentByRentPaymentId,
+  getPaymentIntentById,
+  PAYMENT_INTENTS_COLLECTION,
+  type PaymentIntentRecord,
+  type PaymentIntentUpsertInput,
+} from "./paymentIntents";
+
+type FirestoreDocRef = {
+  get(): Promise<{ exists: boolean; data(): Record<string, unknown> | undefined }>;
+  set(payload: Record<string, unknown>, options?: { merge?: boolean }): Promise<void>;
+};
+
+type FirestoreCollectionRef = {
+  doc(id: string): FirestoreDocRef;
+  where?(
+    field: string,
+    op: string,
+    value: unknown
+  ): {
+    limit(count: number): { get(): Promise<{ empty: boolean; docs: Array<{ id: string; data(): Record<string, unknown> | undefined }> }> };
+    get?(): Promise<{ empty: boolean; docs: Array<{ id: string; data(): Record<string, unknown> | undefined }> }>;
+  };
+};
+
+type FirestoreLike = {
+  collection(name: string): FirestoreCollectionRef;
+};
+
+export type PaymentIntentLeaseContext = Partial<
+  Pick<PaymentIntentUpsertInput, "landlordId" | "tenantId" | "propertyId" | "unitId" | "leaseId" | "amountCents" | "currency" | "periodStart" | "periodEnd">
+>;
+
+function getFirestore(input?: { firestore?: FirestoreLike }): FirestoreLike {
+  return input?.firestore || (db as unknown as FirestoreLike);
+}
+
+function asString(value: unknown, max = 500): string | null {
+  const next = String(value ?? "").trim().slice(0, max);
+  return next || null;
+}
+
+function normalizeRecord(data: Record<string, unknown>, fallbackId: string): PaymentIntentRecord {
+  return {
+    paymentIntentId: asString(data.paymentIntentId, 240) || fallbackId,
+    landlordId: asString(data.landlordId, 240),
+    tenantId: asString(data.tenantId, 240),
+    propertyId: asString(data.propertyId, 240),
+    unitId: asString(data.unitId, 240),
+    leaseId: asString(data.leaseId, 240),
+    rentPaymentId: asString(data.rentPaymentId, 240),
+    purpose: "rent",
+    amountCents: Math.max(0, Math.round(Number(data.amountCents || 0))),
+    currency: String(data.currency || "cad").trim().toLowerCase() || "cad",
+    periodStart: asString(data.periodStart, 120),
+    periodEnd: asString(data.periodEnd, 120),
+    dueDate: asString(data.dueDate, 120),
+    status: (asString(data.status, 80) as PaymentIntentRecord["status"]) || "manual_review_required",
+    provider: (asString(data.provider, 50) as PaymentIntentRecord["provider"]) || null,
+    providerSessionId: asString(data.providerSessionId, 240),
+    providerPaymentId: asString(data.providerPaymentId, 240),
+    source: (asString(data.source, 80) as PaymentIntentRecord["source"]) || "system_derived",
+    lifecycleState: data.lifecycleState === "complete" ? "complete" : "requires_review",
+    requiresReview: data.requiresReview === true,
+    createdAt: asString(data.createdAt, 120) || new Date(0).toISOString(),
+    updatedAt: asString(data.updatedAt, 120) || new Date(0).toISOString(),
+    metadataSummary:
+      data.metadataSummary && typeof data.metadataSummary === "object"
+        ? (data.metadataSummary as Record<string, unknown>)
+        : null,
+  };
+}
+
+function metadataValue(metadata: unknown, key: string): string | null {
+  if (!metadata || typeof metadata !== "object") return null;
+  return asString((metadata as Record<string, unknown>)[key], 240);
+}
+
+function matchesContext(intent: PaymentIntentRecord, context: PaymentIntentLeaseContext): boolean {
+  const checks: Array<[unknown, unknown]> = [
+    [context.landlordId, intent.landlordId],
+    [context.tenantId, intent.tenantId],
+    [context.propertyId, intent.propertyId],
+    [context.unitId, intent.unitId],
+    [context.leaseId, intent.leaseId],
+  ];
+  for (const [expected, actual] of checks) {
+    const normalizedExpected = asString(expected, 240);
+    if (normalizedExpected && normalizedExpected !== asString(actual, 240)) return false;
+  }
+  if (typeof context.amountCents === "number" && Number.isFinite(context.amountCents)) {
+    if (Math.round(context.amountCents) !== intent.amountCents) return false;
+  }
+  return true;
+}
+
+export async function resolvePaymentIntentByMetadata(input: {
+  metadata?: unknown;
+  firestore?: FirestoreLike;
+}): Promise<PaymentIntentRecord | null> {
+  const paymentIntentId = metadataValue(input.metadata, "paymentIntentId");
+  if (paymentIntentId) {
+    const byId = await getPaymentIntentById({ paymentIntentId, firestore: input.firestore });
+    if (byId) return byId;
+  }
+
+  const rentPaymentId = metadataValue(input.metadata, "rentPaymentId");
+  if (rentPaymentId) {
+    return findPaymentIntentByRentPaymentId({ rentPaymentId, firestore: input.firestore });
+  }
+
+  return null;
+}
+
+export async function resolvePaymentIntentByRentPaymentId(input: {
+  rentPaymentId?: string | null;
+  firestore?: FirestoreLike;
+}): Promise<PaymentIntentRecord | null> {
+  const rentPaymentId = asString(input.rentPaymentId, 240);
+  if (!rentPaymentId) return null;
+  return findPaymentIntentByRentPaymentId({ rentPaymentId, firestore: input.firestore });
+}
+
+export async function resolvePaymentIntentByLeaseContext(input: {
+  context: PaymentIntentLeaseContext;
+  firestore?: FirestoreLike;
+}): Promise<PaymentIntentRecord | null> {
+  const context = input.context || {};
+  const leaseId = asString(context.leaseId, 240);
+  if (!leaseId) return null;
+
+  if (
+    asString(context.landlordId, 240) &&
+    asString(context.propertyId, 240) &&
+    asString(context.tenantId, 240) &&
+    typeof context.amountCents === "number"
+  ) {
+    const expectedId = buildPaymentIntentId({
+      ...context,
+      purpose: "rent",
+      source: "system_derived",
+    });
+    const exact = await getPaymentIntentById({ paymentIntentId: expectedId, firestore: input.firestore });
+    if (exact) return exact;
+  }
+
+  const collection = getFirestore(input).collection(PAYMENT_INTENTS_COLLECTION);
+  if (!collection.where) return null;
+  const snap = await collection.where("leaseId", "==", leaseId).limit(20).get();
+  if (snap.empty) return null;
+  const candidates = (snap.docs || []).map((doc) => normalizeRecord(doc.data() || {}, doc.id));
+  return candidates.find((intent) => matchesContext(intent, context)) || candidates[0] || null;
+}

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.integrity.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.integrity.test.ts
@@ -203,6 +203,66 @@ describe("leaseRoutes integrity repairs", () => {
     expect(res.body?.totals?.chargesCents).toBe(180000);
   });
 
+  it("enriches lease ledger payment rows with PaymentIntent linkage when available", async () => {
+    seedDoc("leases", "lease-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      unitId: "unit-1",
+      unitNumber: "101",
+      status: "active",
+    });
+    seedDoc("ledgerEntries", "entry-1", {
+      landlordId: "landlord-1",
+      leaseId: "lease-1",
+      entryType: "payment",
+      reference: "rp-1",
+      amountCents: 180000,
+      effectiveDate: "2026-04-05",
+      createdAt: 10,
+    });
+    seedDoc("rentPayments", "rp-1", {
+      landlordId: "landlord-1",
+      leaseId: "lease-1",
+      paymentIntentId: "pi_rent_1",
+      amountCents: 180000,
+      currency: "cad",
+      status: "paid",
+    });
+    seedDoc("paymentIntents", "pi_rent_1", {
+      paymentIntentId: "pi_rent_1",
+      rentPaymentId: "rp-1",
+      leaseId: "lease-1",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      purpose: "rent",
+      amountCents: 180000,
+      currency: "cad",
+      status: "confirmed",
+      source: "rent_payment_checkout",
+      lifecycleState: "complete",
+      requiresReview: false,
+      createdAt: "2026-04-27T10:00:00.000Z",
+      updatedAt: "2026-04-27T10:00:00.000Z",
+    });
+
+    const app = await makeApp();
+    const res = await request(app).get("/lease-1/ledger");
+
+    expect(res.status).toBe(200);
+    expect(res.body?.entries?.[0]).toEqual(
+      expect.objectContaining({
+        entryType: "payment",
+        rentPaymentId: "rp-1",
+        paymentIntentId: "pi_rent_1",
+        paymentIntentStatus: "confirmed",
+        signedAmountCents: -180000,
+      })
+    );
+  });
+
   it("exports lease ledger csv with property and unit labels instead of raw ids", async () => {
     seedDoc("properties", "prop-1", {
       landlordId: "landlord-1",

--- a/rentchain-api/src/routes/__tests__/rentPaymentWebhook.test.ts
+++ b/rentchain-api/src/routes/__tests__/rentPaymentWebhook.test.ts
@@ -241,6 +241,7 @@ describe("rent payment webhook reconciliation", () => {
       currency: "cad",
       status: "checkout_created",
       processor: "stripe",
+      paymentIntentId: "pi_rent_1",
       processorCheckoutSessionId: "cs_test_1",
       processorPaymentIntentId: "pi_test_1",
       createdAt: "2026-04-27T10:00:00.000Z",
@@ -344,6 +345,7 @@ describe("rent payment webhook reconciliation", () => {
     expect(stored).toEqual(
       expect.objectContaining({
         status: "paid",
+        paymentIntentId: "pi_rent_1",
         processorCheckoutSessionId: "cs_test_1",
         processorPaymentIntentId: "pi_test_1",
         paidAt: expect.any(String),
@@ -530,6 +532,7 @@ describe("rent payment webhook reconciliation", () => {
     expect(ensureCollection("rentPayments").get("rp-1")).toEqual(
       expect.objectContaining({
         status: "paid",
+        paymentIntentId: "pi_rent_1",
         processorCheckoutSessionId: "cs_test_1",
         processorPaymentIntentId: "pi_test_1",
       })
@@ -570,6 +573,7 @@ describe("rent payment webhook reconciliation", () => {
     expect(ensureCollection("rentPayments").get("rp-1")).toEqual(
       expect.objectContaining({
         status: "failed",
+        paymentIntentId: "pi_rent_1",
         processorCheckoutSessionId: "cs_test_1",
         processorPaymentIntentId: "pi_test_1",
       })
@@ -726,6 +730,7 @@ describe("rent payment webhook reconciliation", () => {
     expect(ensureCollection("rentPayments").get("rp-1")).toEqual(
       expect.objectContaining({
         status: "paid",
+        paymentIntentId: "pi_rent_1",
         processorCheckoutSessionId: "cs_test_1",
         processorPaymentIntentId: "pi_test_1",
       })

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -826,6 +826,7 @@ describe("tenantPortalRoutes foundation", () => {
         currency: "cad",
         status: "checkout_created",
         processor: "stripe",
+        paymentIntentId: expect.stringMatching(/^pi_rent_/),
         processorCheckoutSessionId: "cs_test_1",
         processorPaymentIntentId: "pi_test_1",
       })
@@ -1005,6 +1006,7 @@ describe("tenantPortalRoutes foundation", () => {
           amountCents: 180000,
           currency: "cad",
           status: "paid",
+          paymentIntentId: null,
           createdAt: "2026-04-27T10:05:00.000Z",
           updatedAt: "2026-04-27T10:06:00.000Z",
           paidAt: "2026-04-27T10:06:00.000Z",
@@ -1016,6 +1018,7 @@ describe("tenantPortalRoutes foundation", () => {
               amountCents: 180000,
               currency: "cad",
               status: "paid",
+              paymentIntentId: null,
               createdAt: "2026-04-27T10:05:00.000Z",
               updatedAt: "2026-04-27T10:06:00.000Z",
               paidAt: "2026-04-27T10:06:00.000Z",

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -30,6 +30,9 @@ import { dedupePropertyScopedLeasesByUnit, filterPropertyScopedLeases } from "..
 import { writeCanonicalEvent } from "../lib/events/buildEvent";
 import { getSignedDownloadUrl } from "../lib/gcsSignedUrl";
 import {
+  resolvePaymentIntentByRentPaymentId,
+} from "../lib/payments/paymentIntentResolver";
+import {
   isTargetedHiddenLeaseId,
   isTargetedHiddenTenantId,
 } from "../lib/testDataVisibilityTargets";
@@ -719,6 +722,64 @@ async function loadLedgerEntries(leaseId: string, landlordId: string, from?: str
       if (dateDiff !== 0) return dateDiff;
       return toMillis(a?.createdAt) - toMillis(b?.createdAt);
     });
+}
+
+type LeaseLedgerPaymentIntentLink = {
+  rentPaymentId: string;
+  paymentIntentId: string | null;
+  paymentIntentStatus: string | null;
+};
+
+function getLedgerRentPaymentId(entry: any): string | null {
+  const candidates = [entry?.rentPaymentId, entry?.reference, entry?.paymentId];
+  for (const candidate of candidates) {
+    const value = String(candidate || "").trim();
+    if (value) return value;
+  }
+  return null;
+}
+
+async function loadLeaseLedgerPaymentIntentLinks(
+  leaseId: string,
+  landlordId: string
+): Promise<Map<string, LeaseLedgerPaymentIntentLink>> {
+  const links = new Map<string, LeaseLedgerPaymentIntentLink>();
+  const snap = await db
+    .collection("rentPayments")
+    .where("leaseId", "==", leaseId)
+    .get()
+    .catch(() => null);
+  for (const doc of snap?.docs || []) {
+    const data = (doc.data() as any) || {};
+    if (String(data?.landlordId || "").trim() !== landlordId) continue;
+    const rentPaymentId = String(data?.id || data?.rentPaymentId || doc.id || "").trim();
+    if (!rentPaymentId) continue;
+    const resolved = await resolvePaymentIntentByRentPaymentId({ rentPaymentId }).catch(() => null);
+    links.set(rentPaymentId, {
+      rentPaymentId,
+      paymentIntentId:
+        String(data?.paymentIntentId || resolved?.paymentIntentId || "").trim() || null,
+      paymentIntentStatus: String(resolved?.status || "").trim() || null,
+    });
+  }
+  return links;
+}
+
+function enrichLeaseLedgerEntryWithPaymentIntent(
+  entry: any,
+  links: Map<string, LeaseLedgerPaymentIntentLink>
+) {
+  if (entry?.entryType !== "payment") return entry;
+  const rentPaymentId = getLedgerRentPaymentId(entry);
+  if (!rentPaymentId) return entry;
+  const link = links.get(rentPaymentId);
+  if (!link) return { ...entry, rentPaymentId };
+  return {
+    ...entry,
+    rentPaymentId,
+    paymentIntentId: link.paymentIntentId,
+    paymentIntentStatus: link.paymentIntentStatus,
+  };
 }
 
 async function resolveLeaseLedgerExportLabels(lease: any) {
@@ -2280,10 +2341,12 @@ router.get("/:leaseId/ledger", async (req: any, res: Response) => {
     const from = toIsoDate(req.query?.from) || null;
     const to = toIsoDate(req.query?.to) || null;
     const entries = await loadLedgerEntries(leaseId, landlordId, from, to);
+    const paymentIntentLinks = await loadLeaseLedgerPaymentIntentLinks(leaseId, landlordId);
 
     let runningBalanceCents = 0;
     const monthlyTotals: Record<string, { chargesCents: number; paymentsCents: number; netCents: number }> = {};
-    const rows = entries.map((entry: any) => {
+    const rows = entries.map((rawEntry: any) => {
+      const entry = enrichLeaseLedgerEntryWithPaymentIntent(rawEntry, paymentIntentLinks);
       const signedAmountCents =
         entry.entryType === "payment" ? -Math.abs(Number(entry.amountCents || 0)) : Math.abs(Number(entry.amountCents || 0));
       runningBalanceCents += signedAmountCents;

--- a/rentchain-api/src/routes/stripeScreeningOrdersWebhookRoutes.ts
+++ b/rentchain-api/src/routes/stripeScreeningOrdersWebhookRoutes.ts
@@ -29,6 +29,10 @@ import {
 import type { PaymentIntentReference } from "../lib/payments/paymentTypes";
 import { updatePaymentIntentFromProviderSignal } from "../lib/payments/paymentIntents";
 import {
+  resolvePaymentIntentByMetadata,
+  resolvePaymentIntentByRentPaymentId,
+} from "../lib/payments/paymentIntentResolver";
+import {
   markProviderEventFailed,
   markProviderEventIgnoredDuplicate,
   markProviderEventManualReviewRequired,
@@ -305,8 +309,14 @@ async function prepareRentPaymentWebhookNormalizationContext(params: {
       providerSessionId: rentPaymentEvent.checkoutSessionId,
       purpose: "rent",
     });
+    const resolvedPaymentIntent =
+      (await resolvePaymentIntentByMetadata({ metadata: normalizedProviderEvent.metadata })) ||
+      (await resolvePaymentIntentByRentPaymentId({ rentPaymentId: rentPaymentEvent.rentPaymentId }));
     const paymentIntent = await updatePaymentIntentFromProviderSignal({
-      paymentIntentId: getPaymentIntentIdFromProviderMetadata(normalizedProviderEvent.metadata),
+      paymentIntentId:
+        resolvedPaymentIntent?.paymentIntentId ||
+        rentPaymentEvent.internalPaymentIntentId ||
+        getPaymentIntentIdFromProviderMetadata(normalizedProviderEvent.metadata),
       rentPaymentId: rentPaymentEvent.rentPaymentId,
       provider: "stripe",
       providerSessionId: normalizedProviderEvent.providerSessionId || rentPaymentEvent.checkoutSessionId,
@@ -314,7 +324,10 @@ async function prepareRentPaymentWebhookNormalizationContext(params: {
       normalizedStatus: normalizedProviderEvent.normalizedStatus,
     });
     const paymentIntentId =
-      paymentIntent?.paymentIntentId || getPaymentIntentIdFromProviderMetadata(normalizedProviderEvent.metadata);
+      paymentIntent?.paymentIntentId ||
+      resolvedPaymentIntent?.paymentIntentId ||
+      rentPaymentEvent.internalPaymentIntentId ||
+      getPaymentIntentIdFromProviderMetadata(normalizedProviderEvent.metadata);
     const idempotencyKey = buildProviderWebhookIdempotencyKey({
       provider: "stripe",
       providerEventId: normalizedProviderEvent.providerEventId || event.id || "event_missing",
@@ -389,7 +402,7 @@ async function prepareRentPaymentWebhookNormalizationContext(params: {
 
     if (receipt.isDuplicate) {
       await markProviderEventIgnoredDuplicate({ receiptId: receipt.receiptId });
-      return { normalizedProviderEvent, idempotencyKey, reconciliation, receipt, duplicateSuppressionDecision };
+      return { normalizedProviderEvent, idempotencyKey, reconciliation, receipt, duplicateSuppressionDecision, paymentIntentId };
     }
 
     await markProviderEventProcessing({ receiptId: receipt.receiptId });
@@ -401,7 +414,7 @@ async function prepareRentPaymentWebhookNormalizationContext(params: {
       });
     }
 
-    return { normalizedProviderEvent, idempotencyKey, reconciliation, receipt, duplicateSuppressionDecision };
+    return { normalizedProviderEvent, idempotencyKey, reconciliation, receipt, duplicateSuppressionDecision, paymentIntentId };
   } catch (err: any) {
     console.warn("[stripe-webhook-rent-payment] normalization seam skipped", {
       eventId: event.id,
@@ -812,6 +825,7 @@ export const stripeWebhookHandler = async (req: StripeWebhookRequest, res: Respo
             nextStatus: rentPaymentEvent.nextStatus,
             processorCheckoutSessionId: rentPaymentEvent.checkoutSessionId,
             processorPaymentIntentId: rentPaymentEvent.paymentIntentId,
+            paymentIntentId: receiptContext?.paymentIntentId || rentPaymentEvent.internalPaymentIntentId,
             paidAt: rentPaymentEvent.paidAt,
             eventId: event.id,
           });
@@ -1011,6 +1025,7 @@ export const stripeWebhookHandler = async (req: StripeWebhookRequest, res: Respo
             nextStatus: rentPaymentEvent.nextStatus,
             processorCheckoutSessionId: rentPaymentEvent.checkoutSessionId,
             processorPaymentIntentId: rentPaymentEvent.paymentIntentId,
+            paymentIntentId: receiptContext?.paymentIntentId || rentPaymentEvent.internalPaymentIntentId,
             paidAt: rentPaymentEvent.paidAt,
             eventId: event.id,
           });

--- a/rentchain-api/src/services/rentPayments/rentPaymentService.ts
+++ b/rentchain-api/src/services/rentPayments/rentPaymentService.ts
@@ -30,6 +30,7 @@ export type RentPaymentRecord = {
   landlordId: string;
   propertyId?: string | null;
   unitId?: string | null;
+  paymentIntentId?: string | null;
   amountCents: number;
   currency: "cad";
   status: RentPaymentStatus;
@@ -56,6 +57,7 @@ export type RentPaymentSummary = {
     createdAt: string;
     updatedAt: string;
     paidAt: string | null;
+    paymentIntentId?: string | null;
   } | null;
   paymentExperience: {
     history: Array<{
@@ -66,6 +68,7 @@ export type RentPaymentSummary = {
       createdAt: string;
       updatedAt: string;
       paidAt: string | null;
+      paymentIntentId?: string | null;
     }>;
     latestStatus: "pending" | "paid" | "failed" | "canceled" | null;
     retryAvailable: boolean;
@@ -119,6 +122,7 @@ type UpdateRentPaymentFromWebhookInput = {
   nextStatus: RentPaymentStatus;
   processorCheckoutSessionId?: string | null;
   processorPaymentIntentId?: string | null;
+  paymentIntentId?: string | null;
   paidAt?: string | null;
   eventId: string;
 };
@@ -198,6 +202,7 @@ function summarizePayment(record: RentPaymentRecord | null): RentPaymentSummary[
     createdAt: record.createdAt,
     updatedAt: record.updatedAt,
     paidAt: record.paidAt || null,
+    paymentIntentId: asString(record.paymentIntentId),
   };
 }
 
@@ -633,6 +638,7 @@ export async function createRentPaymentCheckout(input: CreateRentPaymentCheckout
     landlordId,
     propertyId: asString(lease.propertyId),
     unitId: asString(lease.unitId) || asString(lease.unitNumber),
+    paymentIntentId: paymentIntentResult.paymentIntent.paymentIntentId,
     amountCents,
     currency: "cad",
     status: "checkout_created",
@@ -692,6 +698,7 @@ export async function updateRentPaymentFromWebhook(input: UpdateRentPaymentFromW
       input.processorCheckoutSessionId === undefined ? current.processorCheckoutSessionId || null : input.processorCheckoutSessionId,
     processorPaymentIntentId:
       input.processorPaymentIntentId === undefined ? current.processorPaymentIntentId || null : input.processorPaymentIntentId,
+    paymentIntentId: input.paymentIntentId === undefined ? current.paymentIntentId || null : input.paymentIntentId,
     paidAt: input.nextStatus === "paid" ? asString(input.paidAt) || updatedAt : current.paidAt || null,
   };
   await ref.set(next, { merge: true });
@@ -730,6 +737,7 @@ export function extractRentPaymentMetadata(event: Stripe.Event): {
   rentPaymentId: string | null;
   checkoutSessionId: string | null;
   paymentIntentId: string | null;
+  internalPaymentIntentId: string | null;
   nextStatus: RentPaymentStatus | null;
   paidAt: string | null;
 } {
@@ -739,6 +747,7 @@ export function extractRentPaymentMetadata(event: Stripe.Event): {
       rentPaymentId: asString(session.metadata?.rentPaymentId),
       checkoutSessionId: asString(session.id),
       paymentIntentId: typeof session.payment_intent === "string" ? session.payment_intent : null,
+      internalPaymentIntentId: asString(session.metadata?.paymentIntentId),
       nextStatus:
         event.type === "checkout.session.async_payment_succeeded"
           ? "paid"
@@ -754,6 +763,7 @@ export function extractRentPaymentMetadata(event: Stripe.Event): {
       rentPaymentId: asString(session.metadata?.rentPaymentId),
       checkoutSessionId: asString(session.id),
       paymentIntentId: typeof session.payment_intent === "string" ? session.payment_intent : null,
+      internalPaymentIntentId: asString(session.metadata?.paymentIntentId),
       nextStatus: "failed",
       paidAt: null,
     };
@@ -764,6 +774,7 @@ export function extractRentPaymentMetadata(event: Stripe.Event): {
       rentPaymentId: asString(paymentIntent.metadata?.rentPaymentId),
       checkoutSessionId: null,
       paymentIntentId: asString(paymentIntent.id),
+      internalPaymentIntentId: asString(paymentIntent.metadata?.paymentIntentId),
       nextStatus: event.type === "payment_intent.succeeded" ? "paid" : "failed",
       paidAt: typeof event.created === "number" ? new Date(event.created * 1000).toISOString() : null,
     };
@@ -774,6 +785,7 @@ export function extractRentPaymentMetadata(event: Stripe.Event): {
       rentPaymentId: asString(session.metadata?.rentPaymentId),
       checkoutSessionId: asString(session.id),
       paymentIntentId: typeof session.payment_intent === "string" ? session.payment_intent : null,
+      internalPaymentIntentId: asString(session.metadata?.paymentIntentId),
       nextStatus: "expired",
       paidAt: null,
     };
@@ -782,6 +794,7 @@ export function extractRentPaymentMetadata(event: Stripe.Event): {
     rentPaymentId: null,
     checkoutSessionId: null,
     paymentIntentId: null,
+    internalPaymentIntentId: null,
     nextStatus: null,
     paidAt: null,
   };


### PR DESCRIPTION
## Summary
- Links PaymentIntent to lease lifecycle and rentPayments.
- Stores paymentIntentId on rentPayments.
- Resolves PaymentIntent in webhook processing using metadata first, then rentPaymentId.
- Links provider receipts and reconciliation records to PaymentIntent.
- Adds resolver helpers for PaymentIntent lookup.
- Adds safe lease ledger read-model enrichment with rentPaymentId, paymentIntentId, and paymentIntentStatus.
- Preserves existing Stripe checkout and webhook behavior.
- Keeps PaymentIntent additive and non-authoritative.
- No Trustly, subscription, screening, payout, schema, migration, dependency, lockfile, frontend, or lease mutation changes.

## Verification
- paymentIntentLinking tests passed: 3 tests.
- rentPaymentService + rentPaymentWebhook tests passed: 10 tests.
- tenantPortalRoutes tests passed: 54 tests.
- leaseRoutes.integrity tests passed: 9 tests.
- rentchain-api build passed.
- git diff --check passed.
- dependency/lockfile diff empty.
- frontend diff empty.