### PR TITLE
Add payment obligation ledger readiness

### DIFF
--- a/docs/architecture/payment-intent-system-v1.md
+++ b/docs/architecture/payment-intent-system-v1.md
@@ -196,6 +196,20 @@ Resolved IDs are attached to provider receipts and reconciliation records. Exist
 
 Lease ledger reads may include optional `paymentIntentId` and `paymentIntentStatus` for payment rows when the matching rentPayment/PaymentIntent can be resolved. Ledger calculations remain based on existing ledger entries and are not rewritten by PaymentIntent.
 
+## Payment Obligation Ledger Readiness
+
+Payment Obligation Ledger Readiness V1 adds a read-only derivation layer that combines:
+
+```text
+lease lifecycle + PaymentIntent + rentPayments + reconciliation records
+```
+
+The read model derives obligation rows and summary totals for expected, paid, outstanding, and review-required payment states. It supports `paid`, `underpaid`, `overpaid`, `failed`, `missing`, `pending`, `manual_review_required`, and `unknown`.
+
+Reconciliation evidence wins over otherwise successful-looking payment records when it indicates mismatch, duplicate risk, or manual review. Missing or contradictory payment context fails safely into `manual_review_required` or `unknown`.
+
+V1 keeps PaymentIntent additive and non-authoritative. It does not generate monthly obligations, enforce collections, replace `rentPayments`, mutate leases, or change Stripe checkout/webhook behavior.
+
 ## Deferred Future Steps
 
 1. PaymentIntent-driven rent ledger.

--- a/docs/architecture/payment-obligation-ledger-readiness-v1.md
+++ b/docs/architecture/payment-obligation-ledger-readiness-v1.md
@@ -1,0 +1,100 @@
+# Payment Obligation Ledger Readiness V1
+
+Status: read-only financial visibility layer
+
+## Purpose
+
+Payment Obligation Ledger Readiness V1 prepares a read-only view that combines lease truth, PaymentIntent obligations, rent payment execution records, and reconciliation evidence.
+
+It does not enforce collections, generate obligations automatically, replace `rentPayments`, mutate leases, change provider behavior, or make PaymentIntent authoritative.
+
+## Source Hierarchy
+
+```text
+Lease lifecycle = truth
+PaymentIntent = obligation
+rentPayments = execution
+provider receipts / reconciliation = evidence
+ledger = financial history
+```
+
+The read model is intentionally defensive. If signals conflict, the row becomes `manual_review_required` or `unknown`; it does not present false success.
+
+## Row Model
+
+Rows include:
+
+- lease, property, unit, and tenant IDs
+- optional PaymentIntent and rentPayment IDs
+- period and due-date context when available
+- expected and paid amounts in cents
+- PaymentIntent, rentPayment, reconciliation, and evidence statuses
+- derived obligation status
+- source and reasons
+
+V1 amount handling remains cents-only in backend read models. UI formatting remains a presentation concern.
+
+## Status Derivation
+
+Supported obligation statuses:
+
+- `expected`
+- `pending`
+- `paid`
+- `underpaid`
+- `overpaid`
+- `failed`
+- `missing`
+- `manual_review_required`
+- `unknown`
+
+Precedence:
+
+1. Manual-review reconciliation, mismatch, or duplicate-risk evidence wins.
+2. Missing expected amount becomes `unknown`.
+3. Failed, cancelled, or expired rentPayment/PaymentIntent evidence becomes `failed`.
+4. Paid amount equal to expected becomes `paid`.
+5. Paid amount below expected becomes `underpaid`.
+6. Paid amount above expected becomes `overpaid`.
+7. Open checkout/provider states become `pending`.
+8. Expected lease or PaymentIntent with no payment evidence becomes `missing`.
+9. Insufficient context becomes `unknown`.
+
+## Lease Lifecycle Relationship
+
+Lease lifecycle remains the source of truth for whether an obligation should exist. V1 may create a read-only row from an active, notice-period, or signed-future lease when no PaymentIntent or rentPayment exists yet.
+
+Expired, terminated, cancelled, and renewed leases are not used to create new lease-only obligation rows in this V1 read model.
+
+## PaymentIntent Relationship
+
+PaymentIntent remains additive and non-authoritative. The ledger readiness helper treats PaymentIntent as an obligation signal and links it to rentPayments by `paymentIntentId` or `rentPaymentId` where available.
+
+Confirmed PaymentIntent status without paid rentPayment evidence becomes review-required rather than paid, because execution evidence is not complete.
+
+## rentPayments Relationship
+
+`rentPayments` remain the execution and checkout-history compatibility layer. V1 does not replace them. Paid rentPayments contribute paid amount. Failed, cancelled, or expired rentPayments contribute failed state.
+
+## Reconciliation Relationship
+
+Reconciliation records are evidence. Manual-review, mismatch, and duplicate-risk reconciliation records take precedence over otherwise paid-looking execution records.
+
+## API Integration
+
+The existing lease ledger route can add read-only fields without changing existing response shape:
+
+- `obligationRows`
+- `obligationSummary`
+
+Existing `entries`, `totals`, and `monthlyTotals` remain unchanged.
+
+## Deferred Future Steps
+
+1. PaymentIntent-authoritative ledger.
+2. Automated monthly obligation generation.
+3. Delinquency decision engine.
+4. Landlord/tenant ledger UI upgrade.
+5. Trustly integration.
+6. Obligation review queue for missing or contradictory payment evidence.
+7. Scheduled reconciliation between lease lifecycle and expected obligations.

--- a/rentchain-api/src/lib/payments/__tests__/paymentObligationLedger.test.ts
+++ b/rentchain-api/src/lib/payments/__tests__/paymentObligationLedger.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPaymentObligationLedgerRows,
+  derivePaymentObligationStatus,
+  summarizePaymentObligationLedger,
+  type PaymentObligationLeaseInput,
+} from "../paymentObligationLedger";
+import type { PaymentIntentRecord } from "../paymentIntents";
+import type { RentPaymentRecord } from "../../../services/rentPayments/rentPaymentService";
+
+const lease: PaymentObligationLeaseInput = {
+  id: "lease-1",
+  landlordId: "landlord-1",
+  propertyId: "prop-1",
+  unitId: "unit-1",
+  tenantId: "tenant-1",
+  monthlyRent: 180000,
+  currency: "cad",
+  startDate: "2026-04-01",
+  endDate: "2027-03-31",
+  derivedLifecycleState: "active",
+};
+
+function intent(overrides: Partial<PaymentIntentRecord> = {}): PaymentIntentRecord {
+  return {
+    paymentIntentId: "pi-rent-1",
+    landlordId: "landlord-1",
+    tenantId: "tenant-1",
+    propertyId: "prop-1",
+    unitId: "unit-1",
+    leaseId: "lease-1",
+    rentPaymentId: "rp-1",
+    purpose: "rent",
+    amountCents: 180000,
+    currency: "cad",
+    periodStart: "2026-04-01",
+    periodEnd: "2026-04-30",
+    dueDate: "2026-04-01",
+    status: "ready",
+    provider: null,
+    providerSessionId: null,
+    providerPaymentId: null,
+    source: "rent_payment_checkout",
+    lifecycleState: "complete",
+    requiresReview: false,
+    createdAt: "2026-04-01T00:00:00.000Z",
+    updatedAt: "2026-04-01T00:00:00.000Z",
+    metadataSummary: null,
+    ...overrides,
+  };
+}
+
+function rentPayment(overrides: Partial<RentPaymentRecord> = {}): RentPaymentRecord {
+  return {
+    id: "rp-1",
+    leaseId: "lease-1",
+    tenantId: "tenant-1",
+    landlordId: "landlord-1",
+    propertyId: "prop-1",
+    unitId: "unit-1",
+    paymentIntentId: "pi-rent-1",
+    amountCents: 180000,
+    currency: "cad",
+    status: "paid",
+    processor: "stripe",
+    processorCheckoutSessionId: "cs-1",
+    processorPaymentIntentId: "stripe-pi-1",
+    createdAt: "2026-04-01T00:00:00.000Z",
+    updatedAt: "2026-04-01T00:01:00.000Z",
+    paidAt: "2026-04-01T00:01:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("paymentObligationLedger", () => {
+  it("derives missing when a lease obligation has no payment evidence", () => {
+    const rows = buildPaymentObligationLedgerRows({ leases: [lease] });
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        leaseId: "lease-1",
+        expectedAmountCents: 180000,
+        paidAmountCents: 0,
+        obligationStatus: "missing",
+        source: "lease_lifecycle",
+        reasons: ["expected_payment_missing"],
+      }),
+    ]);
+  });
+
+  it("derives paid when paid amount matches expected", () => {
+    const rows = buildPaymentObligationLedgerRows({
+      leases: [lease],
+      paymentIntents: [intent({ status: "confirmed" })],
+      rentPayments: [rentPayment()],
+      reconciliationRecords: [
+        {
+          reconciliationId: "rec-1",
+          paymentIntentId: "pi-rent-1",
+          rentPaymentId: "rp-1",
+          reconciliationStatus: "reconciled",
+          reasons: ["provider_confirmed_amount_currency_match"],
+        },
+      ],
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual(
+      expect.objectContaining({
+        paymentIntentId: "pi-rent-1",
+        rentPaymentId: "rp-1",
+        expectedAmountCents: 180000,
+        paidAmountCents: 180000,
+        obligationStatus: "paid",
+        reconciliationStatus: "reconciled",
+        evidenceStatus: "reconciled",
+      })
+    );
+  });
+
+  it("derives underpaid and overpaid by comparing paid amount to expected amount", () => {
+    expect(
+      derivePaymentObligationStatus({
+        expectedAmountCents: 180000,
+        paidAmountCents: 100000,
+        hasPaymentIntent: true,
+      }).obligationStatus
+    ).toBe("underpaid");
+
+    expect(
+      derivePaymentObligationStatus({
+        expectedAmountCents: 180000,
+        paidAmountCents: 200000,
+        hasPaymentIntent: true,
+      }).obligationStatus
+    ).toBe("overpaid");
+  });
+
+  it("derives failed from failed rentPayment or PaymentIntent state", () => {
+    expect(
+      buildPaymentObligationLedgerRows({
+        leases: [lease],
+        paymentIntents: [intent({ status: "failed" })],
+      })[0]?.obligationStatus
+    ).toBe("failed");
+
+    expect(
+      buildPaymentObligationLedgerRows({
+        leases: [lease],
+        rentPayments: [rentPayment({ paymentIntentId: null, status: "failed", paidAt: null })],
+      })[0]?.obligationStatus
+    ).toBe("failed");
+  });
+
+  it("lets manual-review reconciliation take precedence over otherwise paid evidence", () => {
+    const rows = buildPaymentObligationLedgerRows({
+      leases: [lease],
+      paymentIntents: [intent({ status: "confirmed" })],
+      rentPayments: [rentPayment()],
+      reconciliationRecords: [
+        {
+          reconciliationId: "rec-1",
+          paymentIntentId: "pi-rent-1",
+          reconciliationStatus: "mismatch",
+          requiresManualReview: true,
+          reasons: ["amount_mismatch"],
+        },
+      ],
+    });
+
+    expect(rows[0]).toEqual(
+      expect.objectContaining({
+        obligationStatus: "manual_review_required",
+        evidenceStatus: "manual_review_required",
+        reasons: expect.arrayContaining(["reconciliation_requires_manual_review", "amount_mismatch"]),
+      })
+    );
+  });
+
+  it("marks missing or contradictory critical data as unknown or manual review", () => {
+    expect(
+      derivePaymentObligationStatus({
+        expectedAmountCents: 0,
+        paidAmountCents: 0,
+        hasPaymentIntent: true,
+      })
+    ).toEqual(
+      expect.objectContaining({
+        obligationStatus: "unknown",
+        reasons: ["missing_expected_amount"],
+      })
+    );
+
+    expect(
+      buildPaymentObligationLedgerRows({
+        paymentIntents: [intent({ amountCents: 0, status: "manual_review_required", requiresReview: true })],
+      })[0]
+    ).toEqual(
+      expect.objectContaining({
+        obligationStatus: "manual_review_required",
+        evidenceStatus: "manual_review_required",
+      })
+    );
+  });
+
+  it("summarizes expected paid outstanding and status counts", () => {
+    const rows = buildPaymentObligationLedgerRows({
+      leases: [
+        lease,
+        { ...lease, id: "lease-2", leaseId: "lease-2", propertyId: "prop-2", unitId: "unit-2" },
+      ],
+      paymentIntents: [intent({ status: "confirmed" })],
+      rentPayments: [rentPayment()],
+    });
+
+    const summary = summarizePaymentObligationLedger(rows);
+
+    expect(summary).toEqual(
+      expect.objectContaining({
+        totalRows: 2,
+        expectedAmountCents: 360000,
+        paidAmountCents: 180000,
+        outstandingAmountCents: 180000,
+      })
+    );
+    expect(summary.statusCounts.paid).toBe(1);
+    expect(summary.statusCounts.missing).toBe(1);
+  });
+});

--- a/rentchain-api/src/lib/payments/paymentObligationLedger.ts
+++ b/rentchain-api/src/lib/payments/paymentObligationLedger.ts
@@ -1,0 +1,449 @@
+import type { LeaseLifecycleState } from "../leases/leaseLifecycle";
+import type { PaymentIntentRecord, PaymentIntentStatus } from "./paymentIntents";
+import type { PaymentReconciliationStatus } from "./paymentReconciliation";
+import type { RentPaymentRecord, RentPaymentStatus } from "../../services/rentPayments/rentPaymentService";
+
+export type PaymentObligationStatus =
+  | "expected"
+  | "pending"
+  | "paid"
+  | "underpaid"
+  | "overpaid"
+  | "failed"
+  | "missing"
+  | "manual_review_required"
+  | "unknown";
+
+export type PaymentObligationLedgerSource =
+  | "lease_lifecycle"
+  | "payment_intent"
+  | "rent_payment"
+  | "reconciliation";
+
+export type PaymentObligationLedgerRow = {
+  rowId: string;
+  leaseId: string;
+  paymentIntentId?: string | null;
+  rentPaymentId?: string | null;
+  propertyId: string | null;
+  unitId?: string | null;
+  tenantId?: string | null;
+  periodStart?: string | null;
+  periodEnd?: string | null;
+  dueDate?: string | null;
+  expectedAmountCents: number;
+  paidAmountCents?: number;
+  currency: string;
+  obligationStatus: PaymentObligationStatus;
+  paymentIntentStatus?: PaymentIntentStatus | null;
+  rentPaymentStatus?: RentPaymentStatus | null;
+  reconciliationStatus?: PaymentReconciliationStatus | null;
+  evidenceStatus?: "none" | "provider_received" | "reconciled" | "manual_review_required" | "failed" | "pending";
+  source: PaymentObligationLedgerSource;
+  reasons: string[];
+};
+
+export type PaymentObligationLedgerSummary = {
+  totalRows: number;
+  expectedAmountCents: number;
+  paidAmountCents: number;
+  outstandingAmountCents: number;
+  statusCounts: Record<PaymentObligationStatus, number>;
+  manualReviewCount: number;
+};
+
+export type PaymentObligationLeaseInput = {
+  id?: string | null;
+  leaseId?: string | null;
+  landlordId?: string | null;
+  propertyId?: string | null;
+  unitId?: string | null;
+  tenantId?: string | null;
+  primaryTenantId?: string | null;
+  monthlyRent?: number | null;
+  amountCents?: number | null;
+  currency?: string | null;
+  startDate?: string | null;
+  endDate?: string | null;
+  dueDate?: string | null;
+  derivedLifecycleState?: LeaseLifecycleState | null;
+  derivedLifecycleRequiresReview?: boolean | null;
+  status?: string | null;
+};
+
+export type PaymentObligationReconciliationInput = {
+  reconciliationId?: string | null;
+  paymentIntentId?: string | null;
+  rentPaymentId?: string | null;
+  subjectId?: string | null;
+  reconciliationStatus?: PaymentReconciliationStatus | string | null;
+  requiresManualReview?: boolean | null;
+  reasons?: string[] | null;
+};
+
+export type BuildPaymentObligationLedgerRowsInput = {
+  leases?: PaymentObligationLeaseInput[];
+  paymentIntents?: PaymentIntentRecord[];
+  rentPayments?: RentPaymentRecord[];
+  reconciliationRecords?: PaymentObligationReconciliationInput[];
+};
+
+type StatusInput = {
+  expectedAmountCents: number;
+  paidAmountCents: number;
+  paymentIntentStatus?: PaymentIntentStatus | null;
+  rentPaymentStatus?: RentPaymentStatus | null;
+  reconciliationStatus?: PaymentReconciliationStatus | string | null;
+  requiresManualReview?: boolean | null;
+  hasPaymentEvidence?: boolean;
+  hasPaymentIntent?: boolean;
+  hasRentPayment?: boolean;
+  hasLeaseObligation?: boolean;
+};
+
+const REVIEW_RECONCILIATION_STATUSES = new Set(["manual_review_required", "mismatch", "duplicate_risk"]);
+const PENDING_RECONCILIATION_STATUSES = new Set(["pending_provider_confirmation", "pending_settlement", "not_started"]);
+const FAILED_RECONCILIATION_STATUSES = new Set(["failed"]);
+const FAILED_RENT_PAYMENT_STATUSES = new Set<RentPaymentStatus>(["failed", "canceled", "expired"]);
+const PENDING_RENT_PAYMENT_STATUSES = new Set<RentPaymentStatus>(["setup_required", "checkout_created", "payment_pending"]);
+const FAILED_PAYMENT_INTENT_STATUSES = new Set<PaymentIntentStatus>(["failed", "cancelled", "expired"]);
+const PENDING_PAYMENT_INTENT_STATUSES = new Set<PaymentIntentStatus>([
+  "draft",
+  "ready",
+  "provider_session_created",
+  "pending_provider_confirmation",
+  "pending_settlement",
+]);
+const PAID_PAYMENT_INTENT_STATUSES = new Set<PaymentIntentStatus>(["confirmed", "reconciled"]);
+
+function asString(value: unknown, max = 500): string | null {
+  const next = String(value ?? "").trim().slice(0, max);
+  return next || null;
+}
+
+function normalizeCurrency(value: unknown): string {
+  return String(value || "cad").trim().toLowerCase() || "cad";
+}
+
+function normalizeAmountCents(value: unknown): number {
+  const next = Number(value);
+  if (!Number.isFinite(next) || next < 0) return 0;
+  return Math.round(next);
+}
+
+function normalizeDate(value: unknown): string | null {
+  const raw = asString(value, 120);
+  if (!raw) return null;
+  const parsed = Date.parse(raw);
+  if (!Number.isFinite(parsed)) return raw;
+  return new Date(parsed).toISOString();
+}
+
+function cleanIdPart(value: unknown): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function rowIdFor(parts: unknown[]): string {
+  return cleanIdPart(parts.filter((part) => asString(part, 240)).join(":")) || "obligation:unknown";
+}
+
+function leaseIdOf(lease: PaymentObligationLeaseInput | null | undefined): string | null {
+  return asString(lease?.leaseId || lease?.id, 240);
+}
+
+function leaseLifecycleAllowsObligation(lease: PaymentObligationLeaseInput): boolean {
+  const state = asString(lease.derivedLifecycleState || lease.status, 80);
+  if (!state) return true;
+  return state === "active" || state === "notice_period" || state === "signed_future";
+}
+
+function findReconciliation(
+  records: PaymentObligationReconciliationInput[],
+  paymentIntentId?: string | null,
+  rentPaymentId?: string | null
+): PaymentObligationReconciliationInput | null {
+  const normalizedPaymentIntentId = asString(paymentIntentId, 240);
+  const normalizedRentPaymentId = asString(rentPaymentId, 240);
+  return (
+    records.find((record) => {
+      const recordPaymentIntentId = asString(record.paymentIntentId, 240);
+      const recordRentPaymentId = asString(record.rentPaymentId || record.subjectId, 240);
+      return Boolean(
+        (normalizedPaymentIntentId && recordPaymentIntentId === normalizedPaymentIntentId) ||
+          (normalizedRentPaymentId && recordRentPaymentId === normalizedRentPaymentId)
+      );
+    }) || null
+  );
+}
+
+function evidenceStatusFor(input: StatusInput): PaymentObligationLedgerRow["evidenceStatus"] {
+  const reconciliationStatus = asString(input.reconciliationStatus, 80);
+  if (input.requiresManualReview || (reconciliationStatus && REVIEW_RECONCILIATION_STATUSES.has(reconciliationStatus))) {
+    return "manual_review_required";
+  }
+  if (reconciliationStatus === "reconciled") return "reconciled";
+  if (reconciliationStatus && FAILED_RECONCILIATION_STATUSES.has(reconciliationStatus)) return "failed";
+  if (reconciliationStatus && PENDING_RECONCILIATION_STATUSES.has(reconciliationStatus)) return "pending";
+  if (input.rentPaymentStatus && FAILED_RENT_PAYMENT_STATUSES.has(input.rentPaymentStatus)) return "failed";
+  if (input.rentPaymentStatus || input.paymentIntentStatus) return "provider_received";
+  return "none";
+}
+
+export function derivePaymentObligationStatus(input: StatusInput): {
+  obligationStatus: PaymentObligationStatus;
+  reasons: string[];
+  evidenceStatus: PaymentObligationLedgerRow["evidenceStatus"];
+} {
+  const reasons: string[] = [];
+  const expectedAmountCents = normalizeAmountCents(input.expectedAmountCents);
+  const paidAmountCents = normalizeAmountCents(input.paidAmountCents);
+  const reconciliationStatus = asString(input.reconciliationStatus, 80);
+  const evidenceStatus = evidenceStatusFor(input);
+
+  if (input.requiresManualReview || (reconciliationStatus && REVIEW_RECONCILIATION_STATUSES.has(reconciliationStatus))) {
+    reasons.push(input.requiresManualReview ? "reconciliation_requires_manual_review" : `reconciliation_${reconciliationStatus}`);
+    return { obligationStatus: "manual_review_required", reasons, evidenceStatus };
+  }
+
+  if (expectedAmountCents <= 0) {
+    reasons.push("missing_expected_amount");
+    return { obligationStatus: "unknown", reasons, evidenceStatus };
+  }
+
+  if (input.rentPaymentStatus && FAILED_RENT_PAYMENT_STATUSES.has(input.rentPaymentStatus)) {
+    reasons.push(`rent_payment_${input.rentPaymentStatus}`);
+    return { obligationStatus: "failed", reasons, evidenceStatus };
+  }
+
+  if (input.paymentIntentStatus && FAILED_PAYMENT_INTENT_STATUSES.has(input.paymentIntentStatus)) {
+    reasons.push(`payment_intent_${input.paymentIntentStatus}`);
+    return { obligationStatus: "failed", reasons, evidenceStatus };
+  }
+
+  if (paidAmountCents > 0) {
+    if (paidAmountCents === expectedAmountCents) {
+      reasons.push("paid_amount_matches_expected");
+      return { obligationStatus: "paid", reasons, evidenceStatus };
+    }
+    if (paidAmountCents < expectedAmountCents) {
+      reasons.push("paid_amount_below_expected");
+      return { obligationStatus: "underpaid", reasons, evidenceStatus };
+    }
+    reasons.push("paid_amount_above_expected");
+    return { obligationStatus: "overpaid", reasons, evidenceStatus };
+  }
+
+  if (input.rentPaymentStatus && PENDING_RENT_PAYMENT_STATUSES.has(input.rentPaymentStatus)) {
+    reasons.push(`rent_payment_${input.rentPaymentStatus}`);
+    return { obligationStatus: "pending", reasons, evidenceStatus };
+  }
+
+  if (input.paymentIntentStatus && PENDING_PAYMENT_INTENT_STATUSES.has(input.paymentIntentStatus)) {
+    reasons.push(`payment_intent_${input.paymentIntentStatus}`);
+    return { obligationStatus: "pending", reasons, evidenceStatus };
+  }
+
+  if (input.paymentIntentStatus && PAID_PAYMENT_INTENT_STATUSES.has(input.paymentIntentStatus)) {
+    reasons.push("payment_intent_confirmed_without_paid_rent_payment");
+    return { obligationStatus: "manual_review_required", reasons, evidenceStatus: "manual_review_required" };
+  }
+
+  if (input.hasPaymentIntent || input.hasLeaseObligation) {
+    reasons.push("expected_payment_missing");
+    return { obligationStatus: "missing", reasons, evidenceStatus };
+  }
+
+  reasons.push("insufficient_obligation_context");
+  return { obligationStatus: "unknown", reasons, evidenceStatus };
+}
+
+export function buildPaymentObligationLedgerRows(
+  input: BuildPaymentObligationLedgerRowsInput
+): PaymentObligationLedgerRow[] {
+  const leases = input.leases || [];
+  const leaseById = new Map(leases.map((lease) => [leaseIdOf(lease), lease]).filter(([id]) => Boolean(id)) as Array<[string, PaymentObligationLeaseInput]>);
+  const rentPayments = input.rentPayments || [];
+  const rentPaymentsByIntent = new Map<string, RentPaymentRecord[]>();
+  const rentPaymentById = new Map<string, RentPaymentRecord>();
+  const reconciliationRecords = input.reconciliationRecords || [];
+  const rows: PaymentObligationLedgerRow[] = [];
+  const seenLeaseIds = new Set<string>();
+  const seenRentPaymentIds = new Set<string>();
+
+  for (const rentPayment of rentPayments) {
+    const rentPaymentId = asString(rentPayment.id, 240);
+    if (rentPaymentId) rentPaymentById.set(rentPaymentId, rentPayment);
+    const paymentIntentId = asString(rentPayment.paymentIntentId, 240);
+    if (paymentIntentId) {
+      const group = rentPaymentsByIntent.get(paymentIntentId) || [];
+      group.push(rentPayment);
+      rentPaymentsByIntent.set(paymentIntentId, group);
+    }
+  }
+
+  for (const intent of input.paymentIntents || []) {
+    const lease = leaseById.get(asString(intent.leaseId, 240) || "") || null;
+    const linkedRentPayments = [
+      ...((intent.paymentIntentId && rentPaymentsByIntent.get(intent.paymentIntentId)) || []),
+      ...(intent.rentPaymentId && rentPaymentById.has(intent.rentPaymentId) ? [rentPaymentById.get(intent.rentPaymentId)!] : []),
+    ].filter((record, index, records) => records.findIndex((item) => item.id === record.id) === index);
+    for (const record of linkedRentPayments) seenRentPaymentIds.add(record.id);
+    if (intent.leaseId) seenLeaseIds.add(intent.leaseId);
+
+    const paidAmountCents = linkedRentPayments
+      .filter((record) => record.status === "paid")
+      .reduce((sum, record) => sum + normalizeAmountCents(record.amountCents), 0);
+    const latestRentPayment = linkedRentPayments[0] || (intent.rentPaymentId ? rentPaymentById.get(intent.rentPaymentId) || null : null);
+    const reconciliation = findReconciliation(reconciliationRecords, intent.paymentIntentId, latestRentPayment?.id || intent.rentPaymentId || null);
+    const status = derivePaymentObligationStatus({
+      expectedAmountCents: intent.amountCents,
+      paidAmountCents,
+      paymentIntentStatus: intent.status,
+      rentPaymentStatus: latestRentPayment?.status || null,
+      reconciliationStatus: reconciliation?.reconciliationStatus || null,
+      requiresManualReview: intent.requiresReview || reconciliation?.requiresManualReview,
+      hasPaymentEvidence: linkedRentPayments.length > 0,
+      hasPaymentIntent: true,
+      hasRentPayment: linkedRentPayments.length > 0,
+      hasLeaseObligation: Boolean(lease),
+    });
+
+    rows.push({
+      rowId: rowIdFor(["payment_intent", intent.paymentIntentId]),
+      leaseId: asString(intent.leaseId || leaseIdOf(lease), 240) || "unknown",
+      paymentIntentId: intent.paymentIntentId,
+      rentPaymentId: latestRentPayment?.id || intent.rentPaymentId || null,
+      propertyId: intent.propertyId || lease?.propertyId || null,
+      unitId: intent.unitId || lease?.unitId || null,
+      tenantId: intent.tenantId || lease?.tenantId || lease?.primaryTenantId || null,
+      periodStart: normalizeDate(intent.periodStart || lease?.startDate),
+      periodEnd: normalizeDate(intent.periodEnd || lease?.endDate),
+      dueDate: normalizeDate(intent.dueDate || lease?.dueDate),
+      expectedAmountCents: normalizeAmountCents(intent.amountCents),
+      paidAmountCents,
+      currency: normalizeCurrency(intent.currency || lease?.currency),
+      obligationStatus: status.obligationStatus,
+      paymentIntentStatus: intent.status,
+      rentPaymentStatus: latestRentPayment?.status || null,
+      reconciliationStatus: (asString(reconciliation?.reconciliationStatus, 80) as PaymentReconciliationStatus | null) || null,
+      evidenceStatus: status.evidenceStatus,
+      source: reconciliation ? "reconciliation" : "payment_intent",
+      reasons: [...status.reasons, ...(reconciliation?.reasons || [])].filter(Boolean),
+    });
+  }
+
+  for (const rentPayment of rentPayments) {
+    if (seenRentPaymentIds.has(rentPayment.id)) continue;
+    if (rentPayment.leaseId) seenLeaseIds.add(rentPayment.leaseId);
+    const lease = leaseById.get(rentPayment.leaseId) || null;
+    const reconciliation = findReconciliation(reconciliationRecords, rentPayment.paymentIntentId || null, rentPayment.id);
+    const paidAmountCents = rentPayment.status === "paid" ? normalizeAmountCents(rentPayment.amountCents) : 0;
+    const status = derivePaymentObligationStatus({
+      expectedAmountCents: rentPayment.amountCents,
+      paidAmountCents,
+      rentPaymentStatus: rentPayment.status,
+      reconciliationStatus: reconciliation?.reconciliationStatus || null,
+      requiresManualReview: reconciliation?.requiresManualReview,
+      hasPaymentEvidence: true,
+      hasRentPayment: true,
+      hasLeaseObligation: Boolean(lease),
+    });
+    rows.push({
+      rowId: rowIdFor(["rent_payment", rentPayment.id]),
+      leaseId: rentPayment.leaseId,
+      paymentIntentId: rentPayment.paymentIntentId || null,
+      rentPaymentId: rentPayment.id,
+      propertyId: rentPayment.propertyId || lease?.propertyId || null,
+      unitId: rentPayment.unitId || lease?.unitId || null,
+      tenantId: rentPayment.tenantId || lease?.tenantId || lease?.primaryTenantId || null,
+      periodStart: normalizeDate(lease?.startDate),
+      periodEnd: normalizeDate(lease?.endDate),
+      dueDate: normalizeDate(lease?.dueDate),
+      expectedAmountCents: normalizeAmountCents(rentPayment.amountCents),
+      paidAmountCents,
+      currency: normalizeCurrency(rentPayment.currency || lease?.currency),
+      obligationStatus: status.obligationStatus,
+      paymentIntentStatus: null,
+      rentPaymentStatus: rentPayment.status,
+      reconciliationStatus: (asString(reconciliation?.reconciliationStatus, 80) as PaymentReconciliationStatus | null) || null,
+      evidenceStatus: status.evidenceStatus,
+      source: reconciliation ? "reconciliation" : "rent_payment",
+      reasons: [...status.reasons, ...(reconciliation?.reasons || [])].filter(Boolean),
+    });
+  }
+
+  for (const lease of leases) {
+    const leaseId = leaseIdOf(lease);
+    if (!leaseId || seenLeaseIds.has(leaseId) || !leaseLifecycleAllowsObligation(lease)) continue;
+    const expectedAmountCents = normalizeAmountCents(lease.amountCents ?? lease.monthlyRent);
+    const status = derivePaymentObligationStatus({
+      expectedAmountCents,
+      paidAmountCents: 0,
+      hasLeaseObligation: true,
+    });
+    rows.push({
+      rowId: rowIdFor(["lease_lifecycle", leaseId]),
+      leaseId,
+      paymentIntentId: null,
+      rentPaymentId: null,
+      propertyId: lease.propertyId || null,
+      unitId: lease.unitId || null,
+      tenantId: lease.tenantId || lease.primaryTenantId || null,
+      periodStart: normalizeDate(lease.startDate),
+      periodEnd: normalizeDate(lease.endDate),
+      dueDate: normalizeDate(lease.dueDate),
+      expectedAmountCents,
+      paidAmountCents: 0,
+      currency: normalizeCurrency(lease.currency),
+      obligationStatus: status.obligationStatus,
+      paymentIntentStatus: null,
+      rentPaymentStatus: null,
+      reconciliationStatus: null,
+      evidenceStatus: status.evidenceStatus,
+      source: "lease_lifecycle",
+      reasons: status.reasons,
+    });
+  }
+
+  return rows.sort((a, b) => {
+    const dueDiff = String(a.dueDate || a.periodStart || "").localeCompare(String(b.dueDate || b.periodStart || ""));
+    if (dueDiff !== 0) return dueDiff;
+    return a.rowId.localeCompare(b.rowId);
+  });
+}
+
+export function summarizePaymentObligationLedger(rows: PaymentObligationLedgerRow[]): PaymentObligationLedgerSummary {
+  const statusCounts = {
+    expected: 0,
+    pending: 0,
+    paid: 0,
+    underpaid: 0,
+    overpaid: 0,
+    failed: 0,
+    missing: 0,
+    manual_review_required: 0,
+    unknown: 0,
+  } satisfies Record<PaymentObligationStatus, number>;
+
+  let expectedAmountCents = 0;
+  let paidAmountCents = 0;
+  for (const row of rows || []) {
+    statusCounts[row.obligationStatus] += 1;
+    expectedAmountCents += normalizeAmountCents(row.expectedAmountCents);
+    paidAmountCents += normalizeAmountCents(row.paidAmountCents);
+  }
+
+  return {
+    totalRows: rows.length,
+    expectedAmountCents,
+    paidAmountCents,
+    outstandingAmountCents: Math.max(0, expectedAmountCents - paidAmountCents),
+    statusCounts,
+    manualReviewCount: statusCounts.manual_review_required,
+  };
+}

--- a/rentchain-api/src/routes/__tests__/leaseRoutes.integrity.test.ts
+++ b/rentchain-api/src/routes/__tests__/leaseRoutes.integrity.test.ts
@@ -261,6 +261,89 @@ describe("leaseRoutes integrity repairs", () => {
         signedAmountCents: -180000,
       })
     );
+    expect(res.body?.obligationRows?.[0]).toEqual(
+      expect.objectContaining({
+        leaseId: "lease-1",
+        paymentIntentId: "pi_rent_1",
+        rentPaymentId: "rp-1",
+        expectedAmountCents: 180000,
+        paidAmountCents: 180000,
+        obligationStatus: "paid",
+        paymentIntentStatus: "confirmed",
+        rentPaymentStatus: "paid",
+      })
+    );
+    expect(res.body?.obligationSummary).toEqual(
+      expect.objectContaining({
+        totalRows: 1,
+        expectedAmountCents: 180000,
+        paidAmountCents: 180000,
+        outstandingAmountCents: 0,
+      })
+    );
+  });
+
+  it("adds read-only obligation rows without changing existing ledger rows when payment is missing", async () => {
+    seedDoc("leases", "lease-1", {
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      tenantId: "tenant-1",
+      unitId: "unit-1",
+      unitNumber: "101",
+      monthlyRent: 1800,
+      startDate: "2026-04-01",
+      endDate: "2027-03-31",
+      status: "active",
+    });
+    seedDoc("ledgerEntries", "entry-1", {
+      landlordId: "landlord-1",
+      leaseId: "lease-1",
+      entryType: "charge",
+      category: "rent",
+      amountCents: 180000,
+      effectiveDate: "2026-04-01",
+      createdAt: 10,
+    });
+
+    const app = await makeApp();
+    const res = await request(app).get("/lease-1/ledger");
+
+    expect(res.status).toBe(200);
+    expect(res.body?.entries).toEqual([
+      expect.objectContaining({
+        id: "entry-1",
+        entryType: "charge",
+        amountCents: 180000,
+        signedAmountCents: 180000,
+        balanceCents: 180000,
+      }),
+    ]);
+    expect(res.body?.totals).toEqual(
+      expect.objectContaining({
+        chargesCents: 180000,
+        paymentsCents: 0,
+        balanceCents: 180000,
+      })
+    );
+    expect(res.body?.obligationRows).toEqual([
+      expect.objectContaining({
+        leaseId: "lease-1",
+        paymentIntentId: null,
+        rentPaymentId: null,
+        expectedAmountCents: 180000,
+        paidAmountCents: 0,
+        obligationStatus: "missing",
+        source: "lease_lifecycle",
+      }),
+    ]);
+    expect(res.body?.obligationSummary).toEqual(
+      expect.objectContaining({
+        totalRows: 1,
+        expectedAmountCents: 180000,
+        paidAmountCents: 0,
+        outstandingAmountCents: 180000,
+      })
+    );
   });
 
   it("exports lease ledger csv with property and unit labels instead of raw ids", async () => {

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -33,11 +33,16 @@ import {
   resolvePaymentIntentByRentPaymentId,
 } from "../lib/payments/paymentIntentResolver";
 import {
+  buildPaymentObligationLedgerRows,
+  summarizePaymentObligationLedger,
+} from "../lib/payments/paymentObligationLedger";
+import {
   isTargetedHiddenLeaseId,
   isTargetedHiddenTenantId,
 } from "../lib/testDataVisibilityTargets";
 import {
   enableRentCollectionForLease,
+  type RentPaymentRecord,
 } from "../services/rentPayments/rentPaymentService";
 import { buildLeasePaymentProjection } from "../services/projections/buildLeasePaymentProjection";
 import { computeNoResponseState } from "../services/leaseNoticeWorkflowService";
@@ -763,6 +768,86 @@ async function loadLeaseLedgerPaymentIntentLinks(
     });
   }
   return links;
+}
+
+function normalizeLeaseRentAmountCents(value: unknown): number {
+  const amount = Number(value);
+  if (!Number.isFinite(amount) || amount <= 0) return 0;
+  return Math.round(amount * 100);
+}
+
+async function loadLeaseRentPaymentsForObligationLedger(
+  leaseId: string,
+  landlordId: string
+): Promise<RentPaymentRecord[]> {
+  const snap = await db
+    .collection("rentPayments")
+    .where("leaseId", "==", leaseId)
+    .get()
+    .catch(() => null);
+  return (snap?.docs || [])
+    .map((doc: any) => ({ id: doc.id, ...((doc.data() as any) || {}) }))
+    .filter((record: any) => String(record?.landlordId || "").trim() === landlordId)
+    .map((record: any) => ({
+      id: String(record?.id || record?.rentPaymentId || "").trim() || String(record?.id || "").trim(),
+      leaseId: String(record?.leaseId || "").trim(),
+      tenantId: String(record?.tenantId || "").trim(),
+      landlordId: String(record?.landlordId || "").trim(),
+      propertyId: String(record?.propertyId || "").trim() || null,
+      unitId: String(record?.unitId || "").trim() || null,
+      paymentIntentId: String(record?.paymentIntentId || "").trim() || null,
+      amountCents: Math.max(0, Math.round(Number(record?.amountCents || 0))),
+      currency: "cad" as const,
+      status: String(record?.status || "setup_required").trim() as RentPaymentRecord["status"],
+      processor: "stripe" as const,
+      processorCheckoutSessionId: String(record?.processorCheckoutSessionId || "").trim() || null,
+      processorPaymentIntentId: String(record?.processorPaymentIntentId || "").trim() || null,
+      createdAt: String(record?.createdAt || "").trim(),
+      updatedAt: String(record?.updatedAt || "").trim(),
+      paidAt: String(record?.paidAt || "").trim() || null,
+    }));
+}
+
+async function loadLeasePaymentIntentsForObligationLedger(leaseId: string, landlordId: string) {
+  const snap = await db
+    .collection("paymentIntents")
+    .where("leaseId", "==", leaseId)
+    .get()
+    .catch(() => null);
+  return (snap?.docs || [])
+    .map((doc: any) => ({ paymentIntentId: doc.id, ...((doc.data() as any) || {}) }))
+    .filter((record: any) => String(record?.landlordId || "").trim() === landlordId);
+}
+
+async function loadLeaseReconciliationRecordsForObligationLedger(params: {
+  leaseId: string;
+  paymentIntentIds: string[];
+  rentPaymentIds: string[];
+}) {
+  const records = new Map<string, any>();
+  async function collect(field: string, value: string) {
+    const normalizedValue = String(value || "").trim();
+    if (!normalizedValue) return;
+    const snap = await db
+      .collection("paymentReconciliationRecords")
+      .where(field, "==", normalizedValue)
+      .get()
+      .catch(() => null);
+    for (const doc of snap?.docs || []) {
+      records.set(doc.id, { reconciliationId: doc.id, ...((doc.data() as any) || {}) });
+    }
+  }
+
+  await collect("leaseId", params.leaseId);
+  await collect("subjectId", params.leaseId);
+  for (const paymentIntentId of params.paymentIntentIds) {
+    await collect("paymentIntentId", paymentIntentId);
+  }
+  for (const rentPaymentId of params.rentPaymentIds) {
+    await collect("rentPaymentId", rentPaymentId);
+    await collect("subjectId", rentPaymentId);
+  }
+  return Array.from(records.values());
 }
 
 function enrichLeaseLedgerEntryWithPaymentIntent(
@@ -2342,6 +2427,26 @@ router.get("/:leaseId/ledger", async (req: any, res: Response) => {
     const to = toIsoDate(req.query?.to) || null;
     const entries = await loadLedgerEntries(leaseId, landlordId, from, to);
     const paymentIntentLinks = await loadLeaseLedgerPaymentIntentLinks(leaseId, landlordId);
+    const obligationRentPayments = await loadLeaseRentPaymentsForObligationLedger(leaseId, landlordId);
+    const obligationPaymentIntents = await loadLeasePaymentIntentsForObligationLedger(leaseId, landlordId);
+    const obligationReconciliationRecords = await loadLeaseReconciliationRecordsForObligationLedger({
+      leaseId,
+      paymentIntentIds: obligationPaymentIntents.map((record: any) => String(record?.paymentIntentId || "").trim()),
+      rentPaymentIds: obligationRentPayments.map((record) => String(record?.id || "").trim()),
+    });
+    const obligationRows = buildPaymentObligationLedgerRows({
+      leases: [
+        {
+          id: leaseId,
+          ...(leaseCheck.lease as any),
+          amountCents: normalizeLeaseRentAmountCents((leaseCheck.lease as any)?.monthlyRent),
+          derivedLifecycleState: deriveLeaseLifecycleState({ id: leaseId, ...(leaseCheck.lease as any) }).state,
+        },
+      ],
+      paymentIntents: obligationPaymentIntents as any,
+      rentPayments: obligationRentPayments,
+      reconciliationRecords: obligationReconciliationRecords,
+    });
 
     let runningBalanceCents = 0;
     const monthlyTotals: Record<string, { chargesCents: number; paymentsCents: number; netCents: number }> = {};
@@ -2382,6 +2487,8 @@ router.get("/:leaseId/ledger", async (req: any, res: Response) => {
         balanceCents: runningBalanceCents,
       },
       monthlyTotals,
+      obligationRows,
+      obligationSummary: summarizePaymentObligationLedger(obligationRows),
     });
   } catch (err) {
     console.error("[GET /api/leases/:leaseId/ledger] error", err);


### PR DESCRIPTION
## Summary
- Adds read-only payment obligation ledger derivation.
- Combines lease lifecycle, PaymentIntent, rentPayments, and reconciliation records.
- Derives missing, pending, paid, underpaid, overpaid, failed, unknown, and manual-review states.
- Gives manual-review, mismatch, and duplicate-risk reconciliation precedence.
- Adds obligationRows and obligationSummary additively to GET /api/leases/:leaseId/ledger.
- Preserves existing entries, totals, and monthlyTotals response fields.
- Keeps PaymentIntent additive and non-authoritative.
- Preserves existing Stripe checkout/webhook/provider and rentPayment behavior.
- Backend/docs only; no frontend, Trustly, provider behavior, schema, dependency, or lockfile changes.

## Verification
- paymentObligationLedger tests passed: 7 tests.
- leaseRoutes.integrity tests passed: 10 tests.
- rentchain-api build passed.
- git diff --check passed.
- dependency/lockfile diff empty.
- frontend diff empty.