### PR TITLE
Expose payment obligation ledger on lease ledger

### DIFF
--- a/rentchain-frontend/src/api/leaseLedgerApi.ts
+++ b/rentchain-frontend/src/api/leaseLedgerApi.ts
@@ -18,6 +18,49 @@ export type LeaseLedgerEntry = {
   balanceCents: number;
 };
 
+export type PaymentObligationStatus =
+  | "expected"
+  | "pending"
+  | "paid"
+  | "underpaid"
+  | "overpaid"
+  | "failed"
+  | "missing"
+  | "manual_review_required"
+  | "unknown";
+
+export type LeaseObligationLedgerRow = {
+  rowId: string;
+  leaseId: string;
+  paymentIntentId?: string | null;
+  rentPaymentId?: string | null;
+  propertyId?: string | null;
+  unitId?: string | null;
+  tenantId?: string | null;
+  periodStart?: string | null;
+  periodEnd?: string | null;
+  dueDate?: string | null;
+  expectedAmountCents: number;
+  paidAmountCents?: number;
+  currency: string;
+  obligationStatus: PaymentObligationStatus;
+  paymentIntentStatus?: string | null;
+  rentPaymentStatus?: string | null;
+  reconciliationStatus?: string | null;
+  evidenceStatus?: "none" | "provider_received" | "reconciled" | "manual_review_required" | "failed" | "pending" | null;
+  source: "lease_lifecycle" | "payment_intent" | "rent_payment" | "reconciliation";
+  reasons: string[];
+};
+
+export type LeaseObligationLedgerSummary = {
+  totalRows: number;
+  expectedAmountCents: number;
+  paidAmountCents: number;
+  outstandingAmountCents: number;
+  statusCounts: Record<PaymentObligationStatus, number>;
+  manualReviewCount: number;
+};
+
 export type LeaseLedgerResponse = {
   ok: boolean;
   leaseId: string;
@@ -35,6 +78,8 @@ export type LeaseLedgerResponse = {
       netCents: number;
     }
   >;
+  obligationRows?: LeaseObligationLedgerRow[];
+  obligationSummary?: LeaseObligationLedgerSummary;
 };
 
 export async function fetchLeaseLedger(

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
@@ -83,6 +83,134 @@ describe("LeaseLedgerPage", () => {
       monthlyTotals: {
         "2026-04": { chargesCents: 145000, paymentsCents: 10000, netCents: 135000 },
       },
+      obligationRows: [
+        {
+          rowId: "obligation-paid",
+          leaseId: "lease-1",
+          paymentIntentId: "pi-paid",
+          rentPaymentId: "rp-paid",
+          propertyId: "prop-1",
+          unitId: "unit-1",
+          tenantId: "tenant-1",
+          periodStart: "2026-04-01",
+          periodEnd: "2026-04-30",
+          dueDate: "2026-04-01",
+          expectedAmountCents: 145000,
+          paidAmountCents: 145000,
+          currency: "cad",
+          obligationStatus: "paid",
+          paymentIntentStatus: "confirmed",
+          rentPaymentStatus: "paid",
+          reconciliationStatus: "reconciled",
+          evidenceStatus: "reconciled",
+          source: "reconciliation",
+          reasons: ["paid_amount_matches_expected"],
+        },
+        {
+          rowId: "obligation-underpaid",
+          leaseId: "lease-1",
+          propertyId: "prop-1",
+          expectedAmountCents: 145000,
+          paidAmountCents: 10000,
+          currency: "cad",
+          obligationStatus: "underpaid",
+          evidenceStatus: "provider_received",
+          source: "rent_payment",
+          reasons: ["paid_amount_below_expected"],
+        },
+        {
+          rowId: "obligation-overpaid",
+          leaseId: "lease-1",
+          propertyId: "prop-1",
+          expectedAmountCents: 145000,
+          paidAmountCents: 150000,
+          currency: "cad",
+          obligationStatus: "overpaid",
+          evidenceStatus: "provider_received",
+          source: "rent_payment",
+          reasons: ["paid_amount_above_expected"],
+        },
+        {
+          rowId: "obligation-missing",
+          leaseId: "lease-1",
+          propertyId: "prop-1",
+          expectedAmountCents: 145000,
+          paidAmountCents: 0,
+          currency: "cad",
+          obligationStatus: "missing",
+          evidenceStatus: "none",
+          source: "lease_lifecycle",
+          reasons: ["expected_payment_missing"],
+        },
+        {
+          rowId: "obligation-pending",
+          leaseId: "lease-1",
+          propertyId: "prop-1",
+          expectedAmountCents: 145000,
+          paidAmountCents: 0,
+          currency: "cad",
+          obligationStatus: "pending",
+          paymentIntentStatus: "pending_settlement",
+          evidenceStatus: "pending",
+          source: "payment_intent",
+          reasons: ["payment_pending"],
+        },
+        {
+          rowId: "obligation-failed",
+          leaseId: "lease-1",
+          propertyId: "prop-1",
+          expectedAmountCents: 145000,
+          paidAmountCents: 0,
+          currency: "cad",
+          obligationStatus: "failed",
+          evidenceStatus: "failed",
+          source: "rent_payment",
+          reasons: ["rent_payment_failed"],
+        },
+        {
+          rowId: "obligation-manual-review",
+          leaseId: "lease-1",
+          propertyId: "prop-1",
+          expectedAmountCents: 145000,
+          paidAmountCents: 145000,
+          currency: "cad",
+          obligationStatus: "manual_review_required",
+          evidenceStatus: "manual_review_required",
+          reconciliationStatus: "mismatch",
+          source: "reconciliation",
+          reasons: ["amount_mismatch"],
+        },
+        {
+          rowId: "obligation-unknown",
+          leaseId: "lease-1",
+          propertyId: "prop-1",
+          expectedAmountCents: 0,
+          paidAmountCents: 0,
+          currency: "cad",
+          obligationStatus: "unknown",
+          evidenceStatus: "none",
+          source: "payment_intent",
+          reasons: ["missing_expected_amount"],
+        },
+      ],
+      obligationSummary: {
+        totalRows: 8,
+        expectedAmountCents: 1015000,
+        paidAmountCents: 595000,
+        outstandingAmountCents: 420000,
+        manualReviewCount: 1,
+        statusCounts: {
+          expected: 0,
+          pending: 1,
+          paid: 1,
+          underpaid: 1,
+          overpaid: 1,
+          failed: 1,
+          missing: 1,
+          manual_review_required: 1,
+          unknown: 1,
+        },
+      },
     });
     mocks.getLeaseById.mockResolvedValue({
       lease: {
@@ -151,6 +279,95 @@ describe("LeaseLedgerPage", () => {
     expect(screen.getByText("-$100.00")).toBeInTheDocument();
     expect(screen.queryByText("145000")).not.toBeInTheDocument();
     expect(screen.queryByText("10000")).not.toBeInTheDocument();
+  });
+
+  it("renders read-only obligation summary and rows with dollar amounts and status badges", async () => {
+    render(
+      <MemoryRouter initialEntries={["/leases/lease-1/ledger"]}>
+        <Routes>
+          <Route path="/leases/:leaseId/ledger" element={<LeaseLedgerPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Payment obligations")).toBeInTheDocument();
+    expect(screen.getByText("Read-only view of expected rent, execution records, and reconciliation evidence.")).toBeInTheDocument();
+    expect(screen.getAllByText("Expected").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Paid").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Outstanding").length).toBeGreaterThan(0);
+    expect(screen.getByText("Manual Review")).toBeInTheDocument();
+    expect(screen.getByText("$10,150.00")).toBeInTheDocument();
+    expect(screen.getByText("$5,950.00")).toBeInTheDocument();
+    expect(screen.getByText("$4,200.00")).toBeInTheDocument();
+    expect(screen.getAllByText("1").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("$1,350.00").length).toBeGreaterThan(0);
+    expect(screen.getByText("$1,500.00")).toBeInTheDocument();
+    expect(screen.queryByText("1015000")).not.toBeInTheDocument();
+    expect(screen.queryByText("595000")).not.toBeInTheDocument();
+    expect(screen.queryByText("420000")).not.toBeInTheDocument();
+    expect(screen.getAllByText("Paid").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Pending").length).toBeGreaterThan(0);
+    expect(screen.getByText("Underpaid")).toBeInTheDocument();
+    expect(screen.getByText("Overpaid")).toBeInTheDocument();
+    expect(screen.getByText("Missing")).toBeInTheDocument();
+    expect(screen.getAllByText("Failed").length).toBeGreaterThan(0);
+    expect(screen.getByText("Manual review")).toBeInTheDocument();
+    expect(screen.getByText("Unknown")).toBeInTheDocument();
+    expect(screen.getAllByText("Reconciled").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Manual Review Required").length).toBeGreaterThan(0);
+  });
+
+  it("renders an empty obligation state while preserving existing ledger entries", async () => {
+    mocks.fetchLeaseLedger.mockResolvedValueOnce({
+      ok: true,
+      leaseId: "lease-1",
+      entries: [
+        {
+          id: "entry-1",
+          leaseId: "lease-1",
+          entryType: "charge",
+          category: "rent",
+          amountCents: 145000,
+          effectiveDate: "2026-04-01",
+          createdAt: 1,
+          signedAmountCents: 145000,
+          balanceCents: 145000,
+        },
+      ],
+      totals: { chargesCents: 145000, paymentsCents: 0, balanceCents: 145000 },
+      monthlyTotals: {},
+      obligationRows: [],
+      obligationSummary: {
+        totalRows: 0,
+        expectedAmountCents: 0,
+        paidAmountCents: 0,
+        outstandingAmountCents: 0,
+        manualReviewCount: 0,
+        statusCounts: {
+          expected: 0,
+          pending: 0,
+          paid: 0,
+          underpaid: 0,
+          overpaid: 0,
+          failed: 0,
+          missing: 0,
+          manual_review_required: 0,
+          unknown: 0,
+        },
+      },
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/leases/lease-1/ledger"]}>
+        <Routes>
+          <Route path="/leases/:leaseId/ledger" element={<LeaseLedgerPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Obligation ledger is not available yet for this lease.")).toBeInTheDocument();
+    expect(screen.getByText("+$1,450.00")).toBeInTheDocument();
+    expect(screen.getAllByText("$1,450.00").length).toBeGreaterThan(0);
   });
 
   it("exports the lease ledger as a PDF download", async () => {

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
@@ -5,7 +5,10 @@ import {
   addLeasePayment,
   fetchLeaseLedger,
   leaseLedgerExportUrl,
+  type LeaseObligationLedgerRow,
+  type LeaseObligationLedgerSummary,
   type LeaseLedgerEntry,
+  type PaymentObligationStatus,
 } from "../api/leaseLedgerApi";
 import { getAuthToken } from "../lib/authToken";
 import { getFirebaseIdToken } from "../lib/firebaseAuthToken";
@@ -53,6 +56,59 @@ function formatDate(value: string | null | undefined) {
   const parsed = new Date(value);
   if (Number.isNaN(parsed.getTime())) return value;
   return parsed.toLocaleDateString();
+}
+
+function formatPeriod(row: LeaseObligationLedgerRow): string {
+  const start = formatDate(row.periodStart);
+  const end = formatDate(row.periodEnd);
+  if (start === "—" && end === "—") return "—";
+  if (start !== "—" && end !== "—") return `${start} - ${end}`;
+  return start !== "—" ? start : end;
+}
+
+function obligationOutstandingCents(row: LeaseObligationLedgerRow): number {
+  return Math.max(0, Number(row.expectedAmountCents || 0) - Number(row.paidAmountCents || 0));
+}
+
+const obligationStatusCopy: Record<PaymentObligationStatus, { label: string; bg: string; color: string; border: string }> = {
+  expected: { label: "Expected", bg: "#eff6ff", color: "#1d4ed8", border: "#bfdbfe" },
+  pending: { label: "Pending", bg: "#fef9c3", color: "#854d0e", border: "#fde68a" },
+  paid: { label: "Paid", bg: "#dcfce7", color: "#166534", border: "#bbf7d0" },
+  underpaid: { label: "Underpaid", bg: "#ffedd5", color: "#9a3412", border: "#fed7aa" },
+  overpaid: { label: "Overpaid", bg: "#e0f2fe", color: "#075985", border: "#bae6fd" },
+  failed: { label: "Failed", bg: "#fee2e2", color: "#991b1b", border: "#fecaca" },
+  missing: { label: "Missing", bg: "#fef3c7", color: "#92400e", border: "#fde68a" },
+  manual_review_required: { label: "Manual review", bg: "#fae8ff", color: "#86198f", border: "#f5d0fe" },
+  unknown: { label: "Unknown", bg: "#f1f5f9", color: "#334155", border: "#cbd5e1" },
+};
+
+function ObligationStatusBadge({ status }: { status: PaymentObligationStatus }) {
+  const copy = obligationStatusCopy[status] || obligationStatusCopy.unknown;
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        borderRadius: 999,
+        border: `1px solid ${copy.border}`,
+        background: copy.bg,
+        color: copy.color,
+        padding: "3px 8px",
+        fontSize: 12,
+        fontWeight: 800,
+        whiteSpace: "nowrap",
+      }}
+    >
+      {copy.label}
+    </span>
+  );
+}
+
+function prettyEvidenceStatus(row: LeaseObligationLedgerRow): string {
+  const evidence = String(row.evidenceStatus || "").trim();
+  if (evidence) return evidence.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+  const fallback = row.reconciliationStatus || row.rentPaymentStatus || row.paymentIntentStatus || row.source;
+  return String(fallback || "none").replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
 function executionNextActionLabel(value: string | null | undefined) {
@@ -103,6 +159,8 @@ export default function LeaseLedgerPage() {
   const [entries, setEntries] = useState<LeaseLedgerEntry[]>([]);
   const [totals, setTotals] = useState({ chargesCents: 0, paymentsCents: 0, balanceCents: 0 });
   const [monthlyTotals, setMonthlyTotals] = useState<Record<string, { chargesCents: number; paymentsCents: number; netCents: number }>>({});
+  const [obligationRows, setObligationRows] = useState<LeaseObligationLedgerRow[]>([]);
+  const [obligationSummary, setObligationSummary] = useState<LeaseObligationLedgerSummary | null>(null);
   const [showChargeModal, setShowChargeModal] = useState(false);
   const [showPaymentModal, setShowPaymentModal] = useState(false);
   const [showNoteModal, setShowNoteModal] = useState(false);
@@ -135,6 +193,8 @@ export default function LeaseLedgerPage() {
       setEntries(Array.isArray(res.entries) ? res.entries : []);
       setTotals(res.totals || { chargesCents: 0, paymentsCents: 0, balanceCents: 0 });
       setMonthlyTotals(res.monthlyTotals || {});
+      setObligationRows(Array.isArray(res.obligationRows) ? res.obligationRows : []);
+      setObligationSummary(res.obligationSummary || null);
     } catch (err: unknown) {
       setError(errorMessage(err, "Failed to load lease ledger"));
     } finally {
@@ -387,6 +447,65 @@ export default function LeaseLedgerPage() {
           </div>
         </div>
       ) : null}
+
+      <section style={{ display: "grid", gap: 10 }}>
+        <div>
+          <h2 style={{ margin: 0, fontSize: "1rem" }}>Payment obligations</h2>
+          <div style={{ color: "#64748b", fontSize: 13, marginTop: 3 }}>
+            Read-only view of expected rent, execution records, and reconciliation evidence.
+          </div>
+        </div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(170px, 1fr))", gap: 8 }}>
+          <div style={{ border: "1px solid #e2e8f0", borderRadius: 10, padding: 10 }}>
+            <div style={{ fontSize: 12, color: "#64748b" }}>Expected</div>
+            <strong>{formatCurrencyCents(obligationSummary?.expectedAmountCents || 0)}</strong>
+          </div>
+          <div style={{ border: "1px solid #e2e8f0", borderRadius: 10, padding: 10 }}>
+            <div style={{ fontSize: 12, color: "#64748b" }}>Paid</div>
+            <strong>{formatCurrencyCents(obligationSummary?.paidAmountCents || 0)}</strong>
+          </div>
+          <div style={{ border: "1px solid #e2e8f0", borderRadius: 10, padding: 10 }}>
+            <div style={{ fontSize: 12, color: "#64748b" }}>Outstanding</div>
+            <strong>{formatCurrencyCents(obligationSummary?.outstandingAmountCents || 0)}</strong>
+          </div>
+          <div style={{ border: "1px solid #e2e8f0", borderRadius: 10, padding: 10 }}>
+            <div style={{ fontSize: 12, color: "#64748b" }}>Manual Review</div>
+            <strong>{obligationSummary?.manualReviewCount || 0}</strong>
+          </div>
+        </div>
+        {obligationRows.length === 0 ? (
+          <div style={{ border: "1px solid #e2e8f0", borderRadius: 12, padding: 12, color: "#64748b", background: "#fff" }}>
+            Obligation ledger is not available yet for this lease.
+          </div>
+        ) : (
+          <div style={{ overflowX: "auto", border: "1px solid #e2e8f0", borderRadius: 12 }}>
+            <table style={{ width: "100%", borderCollapse: "collapse", minWidth: 920 }}>
+              <thead>
+                <tr style={{ background: "#f8fafc" }}>
+                  {["Period", "Due date", "Expected", "Paid", "Outstanding", "Status", "Evidence"].map((h) => (
+                    <th key={h} style={{ textAlign: "left", padding: 10, borderBottom: "1px solid #e2e8f0" }}>{h}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {obligationRows.map((row) => (
+                  <tr key={row.rowId}>
+                    <td style={{ padding: 10, borderBottom: "1px solid #f1f5f9" }}>{formatPeriod(row)}</td>
+                    <td style={{ padding: 10, borderBottom: "1px solid #f1f5f9" }}>{formatDate(row.dueDate)}</td>
+                    <td style={{ padding: 10, borderBottom: "1px solid #f1f5f9" }}>{formatCurrencyCents(row.expectedAmountCents)}</td>
+                    <td style={{ padding: 10, borderBottom: "1px solid #f1f5f9" }}>{formatCurrencyCents(row.paidAmountCents)}</td>
+                    <td style={{ padding: 10, borderBottom: "1px solid #f1f5f9" }}>{formatCurrencyCents(obligationOutstandingCents(row))}</td>
+                    <td style={{ padding: 10, borderBottom: "1px solid #f1f5f9" }}>
+                      <ObligationStatusBadge status={row.obligationStatus || "unknown"} />
+                    </td>
+                    <td style={{ padding: 10, borderBottom: "1px solid #f1f5f9", color: "#475569" }}>{prettyEvidenceStatus(row)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
 
       {error ? <div style={{ color: "#b91c1c" }}>{error}</div> : null}
 


### PR DESCRIPTION
## Summary
- Displays read-only obligation summary on the lease ledger page.
- Displays obligation rows with expected, paid, outstanding, status, and evidence fields.
- Adds clear status badges for paid, pending, missing, underpaid, overpaid, failed, unknown, and manual-review states.
- Uses cents-to-currency formatting and prevents raw cents display.
- Preserves existing ledger entries, totals, and monthlyTotals.
- Frontend-only; no backend, payment behavior, Stripe, webhook, Trustly, PaymentIntent enforcement, dependency, or lockfile changes.

## Verification
- `pnpm exec vitest run src/pages/LeaseLedgerPage.test.tsx` passed: 6 tests.
- `pnpm exec vitest run src/pages/admin/PortfolioScoreHistoryPage.test.tsx` passed: 4 tests.
- `pnpm build` passed with existing chunk-size warning.
- `git diff --check` passed.
- dependency/lockfile diff empty.
- backend diff empty.

Note: full `pnpm test` has an intermittent unrelated `PortfolioScoreHistoryPage.test.tsx` failure in suite mode; the isolated rerun passes and this branch does not patch that out-of-scope test.