### PR TITLE
Expose delinquency detection on lease ledger

### DIFF
--- a/rentchain-frontend/src/api/leaseLedgerApi.ts
+++ b/rentchain-frontend/src/api/leaseLedgerApi.ts
@@ -61,6 +61,46 @@ export type LeaseObligationLedgerSummary = {
   manualReviewCount: number;
 };
 
+export type DelinquencySignalType =
+  | "rent_due"
+  | "overdue"
+  | "partially_paid"
+  | "failed_payment"
+  | "missing_payment"
+  | "manual_review_required";
+
+export type DelinquencySeverity = "info" | "warning" | "critical";
+
+export type LeaseDelinquencySignal = {
+  signalId: string;
+  leaseId: string;
+  paymentIntentId?: string | null;
+  rentPaymentId?: string | null;
+  propertyId?: string | null;
+  unitId?: string | null;
+  tenantId?: string | null;
+  periodStart?: string | null;
+  periodEnd?: string | null;
+  dueDate?: string | null;
+  expectedAmountCents: number;
+  paidAmountCents: number;
+  outstandingAmountCents: number;
+  signalType: DelinquencySignalType;
+  severity: DelinquencySeverity;
+  detectedAt: string;
+  reasons: string[];
+};
+
+export type LeaseDelinquencySummary = {
+  totalSignals: number;
+  overdueCount: number;
+  partiallyPaidCount: number;
+  failedCount: number;
+  missingCount: number;
+  manualReviewCount: number;
+  totalOutstandingCents: number;
+};
+
 export type LeaseLedgerResponse = {
   ok: boolean;
   leaseId: string;
@@ -80,6 +120,8 @@ export type LeaseLedgerResponse = {
   >;
   obligationRows?: LeaseObligationLedgerRow[];
   obligationSummary?: LeaseObligationLedgerSummary;
+  delinquencySignals?: LeaseDelinquencySignal[];
+  delinquencySummary?: LeaseDelinquencySummary;
 };
 
 export async function fetchLeaseLedger(

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
@@ -109,6 +109,7 @@ describe("LeaseLedgerPage", () => {
         {
           rowId: "obligation-underpaid",
           leaseId: "lease-1",
+          paymentIntentId: "pi-underpaid",
           propertyId: "prop-1",
           expectedAmountCents: 145000,
           paidAmountCents: 10000,
@@ -133,6 +134,7 @@ describe("LeaseLedgerPage", () => {
         {
           rowId: "obligation-missing",
           leaseId: "lease-1",
+          paymentIntentId: "pi-missing",
           propertyId: "prop-1",
           expectedAmountCents: 145000,
           paidAmountCents: 0,
@@ -145,6 +147,7 @@ describe("LeaseLedgerPage", () => {
         {
           rowId: "obligation-pending",
           leaseId: "lease-1",
+          paymentIntentId: "pi-pending",
           propertyId: "prop-1",
           expectedAmountCents: 145000,
           paidAmountCents: 0,
@@ -158,6 +161,7 @@ describe("LeaseLedgerPage", () => {
         {
           rowId: "obligation-failed",
           leaseId: "lease-1",
+          paymentIntentId: "pi-failed",
           propertyId: "prop-1",
           expectedAmountCents: 145000,
           paidAmountCents: 0,
@@ -170,6 +174,7 @@ describe("LeaseLedgerPage", () => {
         {
           rowId: "obligation-manual-review",
           leaseId: "lease-1",
+          paymentIntentId: "pi-manual-review",
           propertyId: "prop-1",
           expectedAmountCents: 145000,
           paidAmountCents: 145000,
@@ -210,6 +215,84 @@ describe("LeaseLedgerPage", () => {
           manual_review_required: 1,
           unknown: 1,
         },
+      },
+      delinquencySignals: [
+        {
+          signalId: "delinquency:overdue:pi-missing",
+          leaseId: "lease-1",
+          paymentIntentId: "pi-missing",
+          propertyId: "prop-1",
+          dueDate: "2026-04-01T00:00:00.000Z",
+          expectedAmountCents: 145000,
+          paidAmountCents: 0,
+          outstandingAmountCents: 145000,
+          signalType: "overdue",
+          severity: "critical",
+          detectedAt: "2026-05-05T00:00:00.000Z",
+          reasons: ["obligation_missing_after_due_date"],
+        },
+        {
+          signalId: "delinquency:missing_payment:pi-missing",
+          leaseId: "lease-1",
+          paymentIntentId: "pi-missing",
+          propertyId: "prop-1",
+          dueDate: "2026-04-01T00:00:00.000Z",
+          expectedAmountCents: 145000,
+          paidAmountCents: 0,
+          outstandingAmountCents: 145000,
+          signalType: "missing_payment",
+          severity: "warning",
+          detectedAt: "2026-05-05T00:00:00.000Z",
+          reasons: ["missing_rent_payment_after_due_date"],
+        },
+        {
+          signalId: "delinquency:partially_paid:pi-underpaid",
+          leaseId: "lease-1",
+          paymentIntentId: "pi-underpaid",
+          propertyId: "prop-1",
+          expectedAmountCents: 145000,
+          paidAmountCents: 10000,
+          outstandingAmountCents: 135000,
+          signalType: "partially_paid",
+          severity: "warning",
+          detectedAt: "2026-05-05T00:00:00.000Z",
+          reasons: ["obligation_partially_paid"],
+        },
+        {
+          signalId: "delinquency:failed_payment:pi-failed",
+          leaseId: "lease-1",
+          paymentIntentId: "pi-failed",
+          propertyId: "prop-1",
+          expectedAmountCents: 145000,
+          paidAmountCents: 0,
+          outstandingAmountCents: 145000,
+          signalType: "failed_payment",
+          severity: "critical",
+          detectedAt: "2026-05-05T00:00:00.000Z",
+          reasons: ["obligation_payment_failed"],
+        },
+        {
+          signalId: "delinquency:manual_review_required:pi-manual-review",
+          leaseId: "lease-1",
+          paymentIntentId: "pi-manual-review",
+          propertyId: "prop-1",
+          expectedAmountCents: 145000,
+          paidAmountCents: 145000,
+          outstandingAmountCents: 0,
+          signalType: "manual_review_required",
+          severity: "warning",
+          detectedAt: "2026-05-05T00:00:00.000Z",
+          reasons: ["obligation_requires_manual_review"],
+        },
+      ],
+      delinquencySummary: {
+        totalSignals: 5,
+        overdueCount: 1,
+        partiallyPaidCount: 1,
+        failedCount: 1,
+        missingCount: 1,
+        manualReviewCount: 1,
+        totalOutstandingCents: 425000,
       },
     });
     mocks.getLeaseById.mockResolvedValue({
@@ -295,7 +378,7 @@ describe("LeaseLedgerPage", () => {
     expect(screen.getAllByText("Expected").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Paid").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Outstanding").length).toBeGreaterThan(0);
-    expect(screen.getByText("Manual Review")).toBeInTheDocument();
+    expect(screen.getAllByText("Manual Review").length).toBeGreaterThan(0);
     expect(screen.getByText("$10,150.00")).toBeInTheDocument();
     expect(screen.getByText("$5,950.00")).toBeInTheDocument();
     expect(screen.getByText("$4,200.00")).toBeInTheDocument();
@@ -307,14 +390,39 @@ describe("LeaseLedgerPage", () => {
     expect(screen.queryByText("420000")).not.toBeInTheDocument();
     expect(screen.getAllByText("Paid").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Pending").length).toBeGreaterThan(0);
-    expect(screen.getByText("Underpaid")).toBeInTheDocument();
-    expect(screen.getByText("Overpaid")).toBeInTheDocument();
-    expect(screen.getByText("Missing")).toBeInTheDocument();
+    expect(screen.getAllByText("Underpaid").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Overpaid").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Missing").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Failed").length).toBeGreaterThan(0);
     expect(screen.getByText("Manual review")).toBeInTheDocument();
-    expect(screen.getByText("Unknown")).toBeInTheDocument();
+    expect(screen.getAllByText("Unknown").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Reconciled").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Manual Review Required").length).toBeGreaterThan(0);
+  });
+
+  it("renders delinquency summary cards and row-level signal reasons", async () => {
+    render(
+      <MemoryRouter initialEntries={["/leases/lease-1/ledger"]}>
+        <Routes>
+          <Route path="/leases/:leaseId/ledger" element={<LeaseLedgerPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Delinquency overview")).toBeInTheDocument();
+    expect(screen.getByText("Read-only detection based on obligation ledger signals.")).toBeInTheDocument();
+    expect(screen.getAllByText("Overdue").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Outstanding").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Underpaid").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Manual Review").length).toBeGreaterThan(0);
+    expect(screen.getByText("$4,250.00")).toBeInTheDocument();
+    expect(screen.queryByText("425000")).not.toBeInTheDocument();
+
+    expect(screen.getByText("Overdue — Rent past due date (obligation missing after due date)")).toBeInTheDocument();
+    expect(screen.getByText("Missing — No rent payment found after due date (missing rent payment after due date)")).toBeInTheDocument();
+    expect(screen.getByText("Underpaid — Partial payment received (obligation partially paid)")).toBeInTheDocument();
+    expect(screen.getByText("Failed — Payment did not complete (obligation payment failed)")).toBeInTheDocument();
+    expect(screen.getByText("Manual review required — Payment mismatch or incomplete evidence (obligation requires manual review)")).toBeInTheDocument();
   });
 
   it("renders an empty obligation state while preserving existing ledger entries", async () => {
@@ -355,6 +463,16 @@ describe("LeaseLedgerPage", () => {
           unknown: 0,
         },
       },
+      delinquencySignals: [],
+      delinquencySummary: {
+        totalSignals: 0,
+        overdueCount: 0,
+        partiallyPaidCount: 0,
+        failedCount: 0,
+        missingCount: 0,
+        manualReviewCount: 0,
+        totalOutstandingCents: 0,
+      },
     });
 
     render(
@@ -366,6 +484,7 @@ describe("LeaseLedgerPage", () => {
     );
 
     expect(await screen.findByText("Obligation ledger is not available yet for this lease.")).toBeInTheDocument();
+    expect(screen.getByText("All rent obligations are up to date.")).toBeInTheDocument();
     expect(screen.getByText("+$1,450.00")).toBeInTheDocument();
     expect(screen.getAllByText("$1,450.00").length).toBeGreaterThan(0);
   });

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
@@ -5,8 +5,11 @@ import {
   addLeasePayment,
   fetchLeaseLedger,
   leaseLedgerExportUrl,
+  type DelinquencySignalType,
   type LeaseObligationLedgerRow,
   type LeaseObligationLedgerSummary,
+  type LeaseDelinquencySignal,
+  type LeaseDelinquencySummary,
   type LeaseLedgerEntry,
   type PaymentObligationStatus,
 } from "../api/leaseLedgerApi";
@@ -82,6 +85,27 @@ const obligationStatusCopy: Record<PaymentObligationStatus, { label: string; bg:
   unknown: { label: "Unknown", bg: "#f1f5f9", color: "#334155", border: "#cbd5e1" },
 };
 
+const delinquencySignalCopy: Record<DelinquencySignalType, { label: string; reason: string; bg: string; color: string; border: string }> = {
+  rent_due: { label: "Rent due", reason: "Rent is due by the due date", bg: "#eff6ff", color: "#1d4ed8", border: "#bfdbfe" },
+  overdue: { label: "Overdue", reason: "Rent past due date", bg: "#fee2e2", color: "#991b1b", border: "#fecaca" },
+  partially_paid: { label: "Underpaid", reason: "Partial payment received", bg: "#ffedd5", color: "#9a3412", border: "#fed7aa" },
+  failed_payment: { label: "Failed", reason: "Payment did not complete", bg: "#fee2e2", color: "#991b1b", border: "#fecaca" },
+  missing_payment: { label: "Missing", reason: "No rent payment found after due date", bg: "#fef3c7", color: "#92400e", border: "#fde68a" },
+  manual_review_required: { label: "Manual review required", reason: "Payment mismatch or incomplete evidence", bg: "#fae8ff", color: "#86198f", border: "#f5d0fe" },
+};
+
+const obligationFallbackReason: Record<PaymentObligationStatus, string> = {
+  expected: "Expected rent obligation",
+  pending: "Payment pending",
+  paid: "Obligation satisfied",
+  underpaid: "Partial payment received",
+  overpaid: "Payment exceeds expected amount",
+  failed: "Payment did not complete",
+  missing: "Expected payment is missing",
+  manual_review_required: "Payment mismatch or incomplete evidence",
+  unknown: "Obligation state needs review",
+};
+
 function ObligationStatusBadge({ status }: { status: PaymentObligationStatus }) {
   const copy = obligationStatusCopy[status] || obligationStatusCopy.unknown;
   return (
@@ -101,6 +125,89 @@ function ObligationStatusBadge({ status }: { status: PaymentObligationStatus }) 
     >
       {copy.label}
     </span>
+  );
+}
+
+function DelinquencySignalBadge({ signalType }: { signalType: DelinquencySignalType }) {
+  const copy = delinquencySignalCopy[signalType];
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        borderRadius: 999,
+        border: `1px solid ${copy.border}`,
+        background: copy.bg,
+        color: copy.color,
+        padding: "3px 8px",
+        fontSize: 12,
+        fontWeight: 800,
+        whiteSpace: "nowrap",
+      }}
+    >
+      {copy.label}
+    </span>
+  );
+}
+
+function reasonTextFromSignal(signal: LeaseDelinquencySignal): string {
+  const copy = delinquencySignalCopy[signal.signalType];
+  const reason = (signal.reasons || [])[0]?.replace(/_/g, " ");
+  return `${copy.label} — ${copy.reason}${reason ? ` (${reason})` : ""}`;
+}
+
+function comparableDate(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return parsed.toISOString().slice(0, 10);
+}
+
+function signalMatchesRow(signal: LeaseDelinquencySignal, row: LeaseObligationLedgerRow): boolean {
+  if (signal.paymentIntentId && row.paymentIntentId && signal.paymentIntentId === row.paymentIntentId) return true;
+  if (signal.rentPaymentId && row.rentPaymentId && signal.rentPaymentId === row.rentPaymentId) return true;
+  if (signal.paymentIntentId || signal.rentPaymentId) return false;
+  const sameLease = signal.leaseId === row.leaseId;
+  const sameExpected = Number(signal.expectedAmountCents || 0) === Number(row.expectedAmountCents || 0);
+  const hasDateAnchor = Boolean(signal.periodStart || signal.periodEnd || signal.dueDate);
+  const samePeriod =
+    (!signal.periodStart || comparableDate(signal.periodStart) === comparableDate(row.periodStart)) &&
+    (!signal.periodEnd || comparableDate(signal.periodEnd) === comparableDate(row.periodEnd)) &&
+    (!signal.dueDate || comparableDate(signal.dueDate) === comparableDate(row.dueDate));
+  return sameLease && sameExpected && hasDateAnchor && samePeriod;
+}
+
+function DelinquencyIndicators({
+  row,
+  signals,
+}: {
+  row: LeaseObligationLedgerRow;
+  signals: LeaseDelinquencySignal[];
+}) {
+  const matchingSignals = signals.filter((signal) => signalMatchesRow(signal, row));
+  if (matchingSignals.length === 0) {
+    const status = row.obligationStatus || "unknown";
+    const copy = obligationStatusCopy[status] || obligationStatusCopy.unknown;
+    return (
+      <div style={{ display: "grid", gap: 4 }}>
+        <span style={{ color: copy.color, fontWeight: 800 }}>{copy.label}</span>
+        <span style={{ color: "#64748b", fontSize: 12 }}>{obligationFallbackReason[status] || obligationFallbackReason.unknown}</span>
+      </div>
+    );
+  }
+  return (
+    <div style={{ display: "grid", gap: 6 }}>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+        {matchingSignals.map((signal) => (
+          <DelinquencySignalBadge key={signal.signalId} signalType={signal.signalType} />
+        ))}
+      </div>
+      {matchingSignals.map((signal) => (
+        <span key={`${signal.signalId}-reason`} style={{ color: "#475569", fontSize: 12 }}>
+          {reasonTextFromSignal(signal)}
+        </span>
+      ))}
+    </div>
   );
 }
 
@@ -161,6 +268,8 @@ export default function LeaseLedgerPage() {
   const [monthlyTotals, setMonthlyTotals] = useState<Record<string, { chargesCents: number; paymentsCents: number; netCents: number }>>({});
   const [obligationRows, setObligationRows] = useState<LeaseObligationLedgerRow[]>([]);
   const [obligationSummary, setObligationSummary] = useState<LeaseObligationLedgerSummary | null>(null);
+  const [delinquencySignals, setDelinquencySignals] = useState<LeaseDelinquencySignal[]>([]);
+  const [delinquencySummary, setDelinquencySummary] = useState<LeaseDelinquencySummary | null>(null);
   const [showChargeModal, setShowChargeModal] = useState(false);
   const [showPaymentModal, setShowPaymentModal] = useState(false);
   const [showNoteModal, setShowNoteModal] = useState(false);
@@ -195,6 +304,8 @@ export default function LeaseLedgerPage() {
       setMonthlyTotals(res.monthlyTotals || {});
       setObligationRows(Array.isArray(res.obligationRows) ? res.obligationRows : []);
       setObligationSummary(res.obligationSummary || null);
+      setDelinquencySignals(Array.isArray(res.delinquencySignals) ? res.delinquencySignals : []);
+      setDelinquencySummary(res.delinquencySummary || null);
     } catch (err: unknown) {
       setError(errorMessage(err, "Failed to load lease ledger"));
     } finally {
@@ -450,6 +561,38 @@ export default function LeaseLedgerPage() {
 
       <section style={{ display: "grid", gap: 10 }}>
         <div>
+          <h2 style={{ margin: 0, fontSize: "1rem" }}>Delinquency overview</h2>
+          <div style={{ color: "#64748b", fontSize: 13, marginTop: 3 }}>
+            Read-only detection based on obligation ledger signals.
+          </div>
+        </div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(170px, 1fr))", gap: 8 }}>
+          <div style={{ border: "1px solid #fecaca", borderRadius: 10, padding: 10, background: "#fef2f2" }}>
+            <div style={{ fontSize: 12, color: "#991b1b" }}>Overdue</div>
+            <strong>{delinquencySummary?.overdueCount || 0}</strong>
+          </div>
+          <div style={{ border: "1px solid #fde68a", borderRadius: 10, padding: 10, background: "#fffbeb" }}>
+            <div style={{ fontSize: 12, color: "#92400e" }}>Outstanding</div>
+            <strong>{formatCurrencyCents(delinquencySummary?.totalOutstandingCents || 0)}</strong>
+          </div>
+          <div style={{ border: "1px solid #fed7aa", borderRadius: 10, padding: 10, background: "#fff7ed" }}>
+            <div style={{ fontSize: 12, color: "#9a3412" }}>Underpaid</div>
+            <strong>{delinquencySummary?.partiallyPaidCount || 0}</strong>
+          </div>
+          <div style={{ border: "1px solid #f5d0fe", borderRadius: 10, padding: 10, background: "#fdf4ff" }}>
+            <div style={{ fontSize: 12, color: "#86198f" }}>Manual Review</div>
+            <strong>{delinquencySummary?.manualReviewCount || 0}</strong>
+          </div>
+        </div>
+        {delinquencySignals.length === 0 ? (
+          <div style={{ border: "1px solid #bbf7d0", borderRadius: 12, padding: 12, color: "#166534", background: "#f0fdf4" }}>
+            All rent obligations are up to date.
+          </div>
+        ) : null}
+      </section>
+
+      <section style={{ display: "grid", gap: 10 }}>
+        <div>
           <h2 style={{ margin: 0, fontSize: "1rem" }}>Payment obligations</h2>
           <div style={{ color: "#64748b", fontSize: 13, marginTop: 3 }}>
             Read-only view of expected rent, execution records, and reconciliation evidence.
@@ -479,10 +622,10 @@ export default function LeaseLedgerPage() {
           </div>
         ) : (
           <div style={{ overflowX: "auto", border: "1px solid #e2e8f0", borderRadius: 12 }}>
-            <table style={{ width: "100%", borderCollapse: "collapse", minWidth: 920 }}>
+            <table style={{ width: "100%", borderCollapse: "collapse", minWidth: 1080 }}>
               <thead>
                 <tr style={{ background: "#f8fafc" }}>
-                  {["Period", "Due date", "Expected", "Paid", "Outstanding", "Status", "Evidence"].map((h) => (
+                  {["Period", "Due date", "Expected", "Paid", "Outstanding", "Status", "Delinquency", "Evidence"].map((h) => (
                     <th key={h} style={{ textAlign: "left", padding: 10, borderBottom: "1px solid #e2e8f0" }}>{h}</th>
                   ))}
                 </tr>
@@ -497,6 +640,9 @@ export default function LeaseLedgerPage() {
                     <td style={{ padding: 10, borderBottom: "1px solid #f1f5f9" }}>{formatCurrencyCents(obligationOutstandingCents(row))}</td>
                     <td style={{ padding: 10, borderBottom: "1px solid #f1f5f9" }}>
                       <ObligationStatusBadge status={row.obligationStatus || "unknown"} />
+                    </td>
+                    <td style={{ padding: 10, borderBottom: "1px solid #f1f5f9", minWidth: 220 }}>
+                      <DelinquencyIndicators row={row} signals={delinquencySignals} />
                     </td>
                     <td style={{ padding: 10, borderBottom: "1px solid #f1f5f9", color: "#475569" }}>{prettyEvidenceStatus(row)}</td>
                   </tr>


### PR DESCRIPTION
## Summary
- Displays read-only delinquency summary on lease ledger UI.
- Shows overdue, underpaid, missing, failed, and manual-review states.
- Adds row-level delinquency indicators and reason text.
- Uses existing obligation ledger and delinquency signals.
- Preserves existing obligation rows, ledger entries, totals, and monthly totals.
- Frontend-only; no backend, payment behavior, Stripe, webhook, Trustly, PaymentIntent enforcement, schema, dependency, or lockfile changes.

## Verification
- LeaseLedgerPage focused test passed: 7 tests.
- Full frontend suite passed: 181 files / 740 tests.
- pnpm build passed with existing chunk-size warning.
- git diff --check passed.
- backend diff empty.
- dependency/lockfile diff empty.