### PR TITLE
Add decision engine v1

### DIFF
--- a/docs/architecture/decision-engine-v1.md
+++ b/docs/architecture/decision-engine-v1.md
@@ -1,0 +1,99 @@
+# Decision Engine V1
+
+## Purpose
+
+Decision Engine V1 turns deterministic RentChain signals into structured, auditable decisions.
+
+The layer is read-only in V1:
+
+- no payment behavior changes
+- no Stripe or webhook changes
+- no Trustly implementation
+- no PaymentIntent enforcement
+- no lease or payment record mutation
+- no automated notices, renewals, collections, or correction workflows
+
+## Source Hierarchy
+
+RentChain keeps the current foundation boundaries intact:
+
+1. Lease lifecycle is the source of truth for whether a lease is current, expiring, expired, terminated, renewed, or in review.
+2. PaymentIntent represents the internal obligation.
+3. Obligation ledger compares expected rent against execution and reconciliation evidence.
+4. Delinquency detection identifies read-only payment problems.
+5. Decision Engine maps those signals into reviewable decisions.
+
+## Decision Model
+
+Each decision is deterministic and contains:
+
+- `decisionId`
+- lease, property, unit, tenant, PaymentIntent, and rentPayment identifiers where available
+- `decisionType`
+- `severity`
+- `status`
+- human-readable `reason`
+- `metadata`
+- `createdAt`
+- `updatedAt`
+
+Decision statuses are:
+
+- `detected`
+- `surfaced`
+- `reviewed`
+- `accepted`
+- `dismissed`
+- `resolved`
+
+V1 only emits `detected`. Later workflow surfaces can advance the status without mutating source lease or payment records.
+
+## Signal To Decision Mapping
+
+Delinquency signals map as follows:
+
+| Signal | Decision | Severity |
+| --- | --- | --- |
+| `overdue` | `review_overdue_rent` | `critical` |
+| `partially_paid` | `review_underpaid_rent` | `warning` |
+| `missing_payment` | `review_missing_payment` | `critical` |
+| `failed_payment` | `review_failed_payment` | `critical` |
+| `manual_review_required` | `review_manual_payment_issue` | `warning` |
+
+Informational `rent_due` signals do not produce decisions in V1 because they are not problems by themselves.
+
+Lease lifecycle signals map as follows:
+
+| Lifecycle condition | Decision |
+| --- | --- |
+| `notice_period` and nearing `effectiveEndDate` | `review_expiring_lease` |
+| lifecycle reasons include occupancy conflict data | `review_occupancy_conflict` |
+
+## Auditability
+
+Decision IDs are built deterministically from the decision type and source signal or lifecycle context. Running derivation against the same inputs produces the same decision IDs.
+
+The source signal IDs, lifecycle reasons, obligation row IDs, amounts, and due dates remain in metadata so operators can trace why each decision exists.
+
+## No Enforcement Yet
+
+Decision Engine V1 does not:
+
+- send notices
+- collect or retry payments
+- alter ledger rows
+- update lease lifecycle status
+- update PaymentIntent status
+- create landlord or tenant tasks
+- resolve decisions automatically
+
+It prepares an auditable layer for later review and workflow surfaces.
+
+## Deferred
+
+1. Decision persistence and history.
+2. Admin and landlord decision review surfaces.
+3. Decision acknowledgements and assignments.
+4. Notification and notice workflows.
+5. Auto-resolution after source evidence changes.
+6. Decision-to-action execution policies.

--- a/rentchain-api/src/lib/decisions/__tests__/decisionEngine.test.ts
+++ b/rentchain-api/src/lib/decisions/__tests__/decisionEngine.test.ts
@@ -1,0 +1,285 @@
+import { describe, expect, it } from "vitest";
+import { deriveDecisions, type DecisionLeaseLifecycleInput } from "../decisionEngine";
+import type { DelinquencySignal } from "../../payments/delinquencySignals";
+import type { PaymentObligationLedgerRow } from "../../payments/paymentObligationLedger";
+
+function signal(overrides: Partial<DelinquencySignal> = {}): DelinquencySignal {
+  return {
+    signalId: "delinquency:overdue:pi-1",
+    leaseId: "lease-1",
+    paymentIntentId: "pi-1",
+    rentPaymentId: "rp-1",
+    propertyId: "prop-1",
+    unitId: "unit-1",
+    tenantId: "tenant-1",
+    periodStart: "2026-04-01T00:00:00.000Z",
+    periodEnd: "2026-04-30T00:00:00.000Z",
+    dueDate: "2026-04-10T00:00:00.000Z",
+    expectedAmountCents: 180000,
+    paidAmountCents: 0,
+    outstandingAmountCents: 180000,
+    signalType: "overdue",
+    severity: "critical",
+    detectedAt: "2026-04-15T00:00:00.000Z",
+    reasons: ["obligation_pending_after_due_date"],
+    ...overrides,
+  };
+}
+
+function row(overrides: Partial<PaymentObligationLedgerRow> = {}): PaymentObligationLedgerRow {
+  return {
+    rowId: "obligation:pi-1",
+    leaseId: "lease-1",
+    paymentIntentId: "pi-1",
+    rentPaymentId: "rp-1",
+    propertyId: "prop-1",
+    unitId: "unit-1",
+    tenantId: "tenant-1",
+    periodStart: "2026-04-01T00:00:00.000Z",
+    periodEnd: "2026-04-30T00:00:00.000Z",
+    dueDate: "2026-04-10T00:00:00.000Z",
+    expectedAmountCents: 180000,
+    paidAmountCents: 0,
+    currency: "cad",
+    obligationStatus: "pending",
+    paymentIntentStatus: "pending_settlement",
+    rentPaymentStatus: "payment_pending",
+    reconciliationStatus: null,
+    evidenceStatus: "pending",
+    source: "payment_intent",
+    reasons: ["payment_intent_pending_settlement"],
+    ...overrides,
+  };
+}
+
+function lifecycle(overrides: Partial<NonNullable<DecisionLeaseLifecycleInput>> = {}): NonNullable<DecisionLeaseLifecycleInput> {
+  return {
+    leaseId: "lease-1",
+    propertyId: "prop-1",
+    unitId: "unit-1",
+    tenantId: "tenant-1",
+    state: "notice_period",
+    reasons: ["active_notice_signal"],
+    effectiveStartDate: "2026-04-01",
+    effectiveEndDate: "2026-05-01",
+    isCurrent: true,
+    isTerminal: false,
+    isOccupancyActive: true,
+    isRenewalProtected: false,
+    requiresReview: false,
+    ...overrides,
+  };
+}
+
+describe("decisionEngine", () => {
+  it("maps overdue delinquency signal to a critical rent review decision", () => {
+    const decisions = deriveDecisions({
+      delinquencySignals: [signal()],
+      obligationRows: [row()],
+      today: "2026-04-15T00:00:00.000Z",
+    });
+
+    expect(decisions).toEqual([
+      expect.objectContaining({
+        decisionId: "decision:review_overdue_rent:delinquency:overdue:pi-1",
+        leaseId: "lease-1",
+        paymentIntentId: "pi-1",
+        rentPaymentId: "rp-1",
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        tenantId: "tenant-1",
+        decisionType: "review_overdue_rent",
+        severity: "critical",
+        status: "detected",
+        reason: "Rent obligation is overdue.",
+        createdAt: "2026-04-15T00:00:00.000Z",
+        updatedAt: "2026-04-15T00:00:00.000Z",
+      }),
+    ]);
+    expect(decisions[0].metadata).toEqual(
+      expect.objectContaining({
+        source: "delinquency_signal",
+        signalId: "delinquency:overdue:pi-1",
+        obligationRowId: "obligation:pi-1",
+        outstandingAmountCents: 180000,
+      })
+    );
+  });
+
+  it("maps underpaid delinquency signal to a warning decision", () => {
+    const decisions = deriveDecisions({
+      delinquencySignals: [
+        signal({
+          signalId: "delinquency:partially_paid:pi-1",
+          signalType: "partially_paid",
+          severity: "warning",
+          paidAmountCents: 100000,
+          outstandingAmountCents: 80000,
+          reasons: ["obligation_partially_paid"],
+        }),
+      ],
+      obligationRows: [row({ obligationStatus: "underpaid", paidAmountCents: 100000 })],
+      today: "2026-04-15T00:00:00.000Z",
+    });
+
+    expect(decisions[0]).toEqual(
+      expect.objectContaining({
+        decisionId: "decision:review_underpaid_rent:delinquency:partially_paid:pi-1",
+        decisionType: "review_underpaid_rent",
+        severity: "warning",
+        reason: "Rent obligation is partially paid.",
+      })
+    );
+  });
+
+  it("maps missing payment signal to a critical decision", () => {
+    const decisions = deriveDecisions({
+      delinquencySignals: [
+        signal({
+          signalId: "delinquency:missing_payment:lease-1",
+          paymentIntentId: null,
+          rentPaymentId: null,
+          signalType: "missing_payment",
+          severity: "warning",
+          reasons: ["missing_rent_payment_after_due_date"],
+        }),
+      ],
+      obligationRows: [row({ paymentIntentId: null, rentPaymentId: null, obligationStatus: "missing" })],
+      today: "2026-04-15T00:00:00.000Z",
+    });
+
+    expect(decisions[0]).toEqual(
+      expect.objectContaining({
+        decisionId: "decision:review_missing_payment:delinquency:missing_payment:lease-1",
+        decisionType: "review_missing_payment",
+        severity: "critical",
+        reason: "Expected rent payment is missing.",
+      })
+    );
+  });
+
+  it("maps failed payment signal to a critical decision", () => {
+    const decisions = deriveDecisions({
+      delinquencySignals: [
+        signal({
+          signalId: "delinquency:failed_payment:rp-1",
+          signalType: "failed_payment",
+          reasons: ["obligation_payment_failed"],
+        }),
+      ],
+      obligationRows: [row({ obligationStatus: "failed", rentPaymentStatus: "failed", evidenceStatus: "failed" })],
+      today: "2026-04-15T00:00:00.000Z",
+    });
+
+    expect(decisions[0]).toEqual(
+      expect.objectContaining({
+        decisionType: "review_failed_payment",
+        severity: "critical",
+        reason: "Rent payment did not complete.",
+      })
+    );
+  });
+
+  it("maps manual payment review signal to a warning decision", () => {
+    const decisions = deriveDecisions({
+      delinquencySignals: [
+        signal({
+          signalId: "delinquency:manual_review_required:pi-1",
+          signalType: "manual_review_required",
+          severity: "warning",
+          paidAmountCents: 180000,
+          outstandingAmountCents: 0,
+          reasons: ["obligation_requires_manual_review"],
+        }),
+      ],
+      obligationRows: [row({ obligationStatus: "manual_review_required", paidAmountCents: 180000 })],
+      today: "2026-04-15T00:00:00.000Z",
+    });
+
+    expect(decisions[0]).toEqual(
+      expect.objectContaining({
+        decisionType: "review_manual_payment_issue",
+        severity: "warning",
+        reason: "Payment evidence requires manual review.",
+      })
+    );
+  });
+
+  it("does not create decisions for informational rent_due signals", () => {
+    const decisions = deriveDecisions({
+      delinquencySignals: [
+        signal({
+          signalId: "delinquency:rent_due:pi-1",
+          signalType: "rent_due",
+          severity: "info",
+          reasons: ["obligation_expected_not_past_due"],
+        }),
+      ],
+      obligationRows: [row({ obligationStatus: "expected" })],
+      today: "2026-04-09T00:00:00.000Z",
+    });
+
+    expect(decisions).toEqual([]);
+  });
+
+  it("derives expiring lease decision from notice-period lifecycle nearing end", () => {
+    const decisions = deriveDecisions({
+      leaseLifecycle: lifecycle(),
+      today: "2026-04-15T00:00:00.000Z",
+      expiringSoonThresholdDays: 30,
+    });
+
+    expect(decisions).toEqual([
+      expect.objectContaining({
+        decisionId: "decision:review_expiring_lease:lease-1:2026-05-01",
+        decisionType: "review_expiring_lease",
+        severity: "warning",
+        status: "detected",
+        reason: "Lease is in notice period and nearing the end of term.",
+      }),
+    ]);
+    expect(decisions[0].metadata).toEqual(
+      expect.objectContaining({
+        source: "lease_lifecycle",
+        lifecycleState: "notice_period",
+        daysUntilEnd: 16,
+        thresholdDays: 30,
+      })
+    );
+  });
+
+  it("derives occupancy conflict decision from lifecycle occupancy reasons", () => {
+    const decisions = deriveDecisions({
+      leaseLifecycle: lifecycle({
+        state: "unknown",
+        reasons: ["expired_occupancy_conflict"],
+        requiresReview: true,
+      }),
+      today: "2026-04-15T00:00:00.000Z",
+    });
+
+    expect(decisions[0]).toEqual(
+      expect.objectContaining({
+        decisionType: "review_occupancy_conflict",
+        severity: "critical",
+        reason: "Lease lifecycle indicates an occupancy conflict that needs review.",
+      })
+    );
+  });
+
+  it("does not mutate source signals, lifecycle, or obligation rows", () => {
+    const sourceSignal = signal();
+    const sourceRow = row();
+    const sourceLifecycle = lifecycle();
+    const before = JSON.stringify({ sourceSignal, sourceRow, sourceLifecycle });
+
+    deriveDecisions({
+      delinquencySignals: [sourceSignal],
+      obligationRows: [sourceRow],
+      leaseLifecycle: sourceLifecycle,
+      today: "2026-04-15T00:00:00.000Z",
+    });
+
+    expect(JSON.stringify({ sourceSignal, sourceRow, sourceLifecycle })).toBe(before);
+  });
+});

--- a/rentchain-api/src/lib/decisions/decisionEngine.ts
+++ b/rentchain-api/src/lib/decisions/decisionEngine.ts
@@ -1,0 +1,272 @@
+import type { LeaseLifecycleResult } from "../leases/leaseLifecycle";
+import type { DelinquencySignal, DelinquencySignalType } from "../payments/delinquencySignals";
+import type { PaymentObligationLedgerRow } from "../payments/paymentObligationLedger";
+
+export type DecisionType =
+  | "review_overdue_rent"
+  | "review_underpaid_rent"
+  | "review_missing_payment"
+  | "review_failed_payment"
+  | "review_manual_payment_issue"
+  | "review_expiring_lease"
+  | "review_occupancy_conflict";
+
+export type DecisionSeverity = "info" | "warning" | "critical";
+
+export type DecisionStatus = "detected" | "surfaced" | "reviewed" | "accepted" | "dismissed" | "resolved";
+
+export type Decision = {
+  decisionId: string;
+  leaseId: string;
+  paymentIntentId?: string | null;
+  rentPaymentId?: string | null;
+  propertyId: string | null;
+  unitId: string | null;
+  tenantId?: string | null;
+  decisionType: DecisionType;
+  severity: DecisionSeverity;
+  status: DecisionStatus;
+  reason: string;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type DecisionLeaseLifecycleInput =
+  | (LeaseLifecycleResult & {
+      leaseId?: string | null;
+      propertyId?: string | null;
+      unitId?: string | null;
+      tenantId?: string | null;
+    })
+  | null
+  | undefined;
+
+export type DeriveDecisionsInput = {
+  delinquencySignals?: DelinquencySignal[] | null;
+  leaseLifecycle?: DecisionLeaseLifecycleInput;
+  obligationRows?: PaymentObligationLedgerRow[] | null;
+  today?: unknown;
+  expiringSoonThresholdDays?: number;
+};
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const DELINQUENCY_DECISION_MAP: Record<
+  DelinquencySignalType,
+  { decisionType: DecisionType; severity: DecisionSeverity; reason: string } | null
+> = {
+  rent_due: null,
+  overdue: {
+    decisionType: "review_overdue_rent",
+    severity: "critical",
+    reason: "Rent obligation is overdue.",
+  },
+  partially_paid: {
+    decisionType: "review_underpaid_rent",
+    severity: "warning",
+    reason: "Rent obligation is partially paid.",
+  },
+  missing_payment: {
+    decisionType: "review_missing_payment",
+    severity: "critical",
+    reason: "Expected rent payment is missing.",
+  },
+  failed_payment: {
+    decisionType: "review_failed_payment",
+    severity: "critical",
+    reason: "Rent payment did not complete.",
+  },
+  manual_review_required: {
+    decisionType: "review_manual_payment_issue",
+    severity: "warning",
+    reason: "Payment evidence requires manual review.",
+  },
+};
+
+function asString(value: unknown, max = 500): string | null {
+  const next = String(value ?? "").trim().slice(0, max);
+  return next || null;
+}
+
+function normalizeDate(value: unknown): string | null {
+  const raw = asString(value, 120);
+  if (!raw) return null;
+  const parsed = Date.parse(raw);
+  if (!Number.isFinite(parsed)) return null;
+  return new Date(parsed).toISOString();
+}
+
+function todayIso(value: unknown): string {
+  return normalizeDate(value) || new Date().toISOString();
+}
+
+function toDay(value: unknown): number | null {
+  const normalized = normalizeDate(value);
+  if (!normalized) return null;
+  const parsed = new Date(normalized);
+  return Date.UTC(parsed.getUTCFullYear(), parsed.getUTCMonth(), parsed.getUTCDate());
+}
+
+function daysBetween(start: unknown, end: unknown): number | null {
+  const startDay = toDay(start);
+  const endDay = toDay(end);
+  if (startDay == null || endDay == null) return null;
+  return Math.floor((endDay - startDay) / DAY_MS);
+}
+
+function cleanIdPart(value: unknown): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function decisionIdFor(parts: unknown[]): string {
+  return cleanIdPart(["decision", ...parts].filter((part) => asString(part, 240)).join(":")) || "decision:unknown";
+}
+
+function matchingObligationRow(
+  signal: DelinquencySignal,
+  obligationRows: PaymentObligationLedgerRow[]
+): PaymentObligationLedgerRow | null {
+  return (
+    obligationRows.find((row) => {
+      return Boolean(
+        (signal.paymentIntentId && row.paymentIntentId === signal.paymentIntentId) ||
+          (signal.rentPaymentId && row.rentPaymentId === signal.rentPaymentId) ||
+          (signal.leaseId === row.leaseId &&
+            signal.expectedAmountCents === row.expectedAmountCents &&
+            (!signal.dueDate || normalizeDate(signal.dueDate) === normalizeDate(row.dueDate)))
+      );
+    }) || null
+  );
+}
+
+function decisionFromDelinquencySignal(
+  signal: DelinquencySignal,
+  obligationRows: PaymentObligationLedgerRow[],
+  fallbackDetectedAt: string
+): Decision | null {
+  const mapping = DELINQUENCY_DECISION_MAP[signal.signalType];
+  if (!mapping) return null;
+  const row = matchingObligationRow(signal, obligationRows);
+  const timestamp = normalizeDate(signal.detectedAt) || fallbackDetectedAt;
+  return {
+    decisionId: decisionIdFor([mapping.decisionType, signal.signalId]),
+    leaseId: asString(signal.leaseId, 240) || row?.leaseId || "unknown",
+    paymentIntentId: signal.paymentIntentId || row?.paymentIntentId || null,
+    rentPaymentId: signal.rentPaymentId || row?.rentPaymentId || null,
+    propertyId: signal.propertyId || row?.propertyId || null,
+    unitId: signal.unitId || row?.unitId || null,
+    tenantId: signal.tenantId || row?.tenantId || null,
+    decisionType: mapping.decisionType,
+    severity: mapping.severity,
+    status: "detected",
+    reason: mapping.reason,
+    metadata: {
+      source: "delinquency_signal",
+      signalId: signal.signalId,
+      signalType: signal.signalType,
+      signalReasons: signal.reasons || [],
+      expectedAmountCents: signal.expectedAmountCents,
+      paidAmountCents: signal.paidAmountCents,
+      outstandingAmountCents: signal.outstandingAmountCents,
+      dueDate: signal.dueDate || null,
+      obligationRowId: row?.rowId || null,
+      obligationStatus: row?.obligationStatus || null,
+    },
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+}
+
+function hasOccupancyConflictReason(lifecycle: DecisionLeaseLifecycleInput): boolean {
+  return Boolean(
+    lifecycle?.reasons?.some((reason) => {
+      const normalized = String(reason || "").toLowerCase();
+      return normalized.includes("occupancy") || normalized.includes("occupant");
+    })
+  );
+}
+
+function lifecycleBaseFields(lifecycle: NonNullable<DecisionLeaseLifecycleInput>) {
+  return {
+    leaseId: asString(lifecycle.leaseId, 240) || "unknown",
+    propertyId: asString(lifecycle.propertyId, 240),
+    unitId: asString(lifecycle.unitId, 240),
+    tenantId: asString(lifecycle.tenantId, 240),
+  };
+}
+
+function decisionsFromLeaseLifecycle(
+  lifecycle: DecisionLeaseLifecycleInput,
+  today: unknown,
+  thresholdDays: number,
+  timestamp: string
+): Decision[] {
+  if (!lifecycle) return [];
+  const base = lifecycleBaseFields(lifecycle);
+  const decisions: Decision[] = [];
+  const daysUntilEnd = daysBetween(today, lifecycle.effectiveEndDate);
+
+  if (lifecycle.state === "notice_period" && daysUntilEnd != null && daysUntilEnd >= 0 && daysUntilEnd <= thresholdDays) {
+    decisions.push({
+      decisionId: decisionIdFor(["review_expiring_lease", base.leaseId, lifecycle.effectiveEndDate || "no_end_date"]),
+      ...base,
+      decisionType: "review_expiring_lease",
+      severity: daysUntilEnd <= 14 ? "critical" : "warning",
+      status: "detected",
+      reason: "Lease is in notice period and nearing the end of term.",
+      metadata: {
+        source: "lease_lifecycle",
+        lifecycleState: lifecycle.state,
+        lifecycleReasons: lifecycle.reasons || [],
+        effectiveEndDate: lifecycle.effectiveEndDate || null,
+        daysUntilEnd,
+        thresholdDays,
+      },
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+  }
+
+  if (hasOccupancyConflictReason(lifecycle)) {
+    decisions.push({
+      decisionId: decisionIdFor(["review_occupancy_conflict", base.leaseId, (lifecycle.reasons || []).join("_")]),
+      ...base,
+      decisionType: "review_occupancy_conflict",
+      severity: lifecycle.requiresReview ? "critical" : "warning",
+      status: "detected",
+      reason: "Lease lifecycle indicates an occupancy conflict that needs review.",
+      metadata: {
+        source: "lease_lifecycle",
+        lifecycleState: lifecycle.state,
+        lifecycleReasons: lifecycle.reasons || [],
+        requiresReview: lifecycle.requiresReview,
+      },
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+  }
+
+  return decisions;
+}
+
+export function deriveDecisions(input: DeriveDecisionsInput): Decision[] {
+  const timestamp = todayIso(input.today);
+  const obligationRows = input.obligationRows || [];
+  const delinquencyDecisions = (input.delinquencySignals || [])
+    .map((signal) => decisionFromDelinquencySignal(signal, obligationRows, timestamp))
+    .filter(Boolean) as Decision[];
+  const lifecycleDecisions = decisionsFromLeaseLifecycle(
+    input.leaseLifecycle,
+    input.today || new Date(),
+    input.expiringSoonThresholdDays ?? 60,
+    timestamp
+  );
+
+  return [...delinquencyDecisions, ...lifecycleDecisions].sort((a, b) => a.decisionId.localeCompare(b.decisionId));
+}


### PR DESCRIPTION
## Summary
- Adds read-only decision engine for RentChain signals.
- Maps delinquency and lease lifecycle signals into structured decisions.
- Adds deterministic decision IDs, severity, status, reason, metadata, and audit timestamps.
- Emits detected decisions only in V1.
- Keeps decisions deterministic and auditable.
- Defers API/UI integration to a later mission.
- No enforcement, automation, payment behavior, Stripe/webhook, Trustly, PaymentIntent enforcement, lease mutation, schema, dependency, or lockfile changes.

## Verification
- decisionEngine tests passed: 9 tests.
- rentchain-api build passed.
- git diff --check passed.
- dependency/lockfile diff empty.