### PR TITLE
Expose decision engine in UI

### DIFF
--- a/rentchain-frontend/src/lib/decisions/decisionDisplay.ts
+++ b/rentchain-frontend/src/lib/decisions/decisionDisplay.ts
@@ -1,0 +1,210 @@
+import type { DelinquencySignalType, LeaseDelinquencySignal } from "@/api/leaseLedgerApi";
+
+export type DecisionType =
+  | "review_overdue_rent"
+  | "review_underpaid_rent"
+  | "review_missing_payment"
+  | "review_failed_payment"
+  | "review_manual_payment_issue"
+  | "review_expiring_lease"
+  | "review_occupancy_conflict";
+
+export type DecisionSeverity = "info" | "warning" | "critical";
+export type DecisionStatus = "detected" | "surfaced" | "reviewed" | "accepted" | "dismissed" | "resolved";
+
+export type DecisionItem = {
+  decisionId: string;
+  leaseId?: string | null;
+  paymentIntentId?: string | null;
+  rentPaymentId?: string | null;
+  propertyId?: string | null;
+  unitId?: string | null;
+  tenantId?: string | null;
+  decisionType: DecisionType;
+  severity: DecisionSeverity;
+  status?: DecisionStatus;
+  reason: string;
+  metadata?: Record<string, unknown>;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+};
+
+export type DecisionSummary = {
+  total: number;
+  critical: number;
+  warning: number;
+  info: number;
+  overdue: number;
+  underpaid: number;
+  missing: number;
+  failed: number;
+  manualReview: number;
+  expiring: number;
+};
+
+export const decisionDisplayCopy: Record<DecisionType, { label: string; badge: string }> = {
+  review_overdue_rent: { label: "Overdue Rent", badge: "Overdue" },
+  review_underpaid_rent: { label: "Underpaid Rent", badge: "Underpaid" },
+  review_missing_payment: { label: "Missing Payment", badge: "Missing" },
+  review_failed_payment: { label: "Failed Payment", badge: "Failed" },
+  review_manual_payment_issue: { label: "Manual Review", badge: "Manual Review" },
+  review_expiring_lease: { label: "Expiring Lease", badge: "Expiring" },
+  review_occupancy_conflict: { label: "Occupancy Conflict", badge: "Occupancy" },
+};
+
+export const decisionSeverityStyle: Record<DecisionSeverity, { bg: string; color: string; border: string }> = {
+  critical: { bg: "#fee2e2", color: "#991b1b", border: "#fecaca" },
+  warning: { bg: "#ffedd5", color: "#9a3412", border: "#fed7aa" },
+  info: { bg: "#f1f5f9", color: "#334155", border: "#cbd5e1" },
+};
+
+const delinquencyDecisionMap: Record<
+  DelinquencySignalType,
+  { decisionType: DecisionType; severity: DecisionSeverity; reason: string } | null
+> = {
+  rent_due: null,
+  overdue: { decisionType: "review_overdue_rent", severity: "critical", reason: "Rent past due date" },
+  partially_paid: { decisionType: "review_underpaid_rent", severity: "warning", reason: "Partial payment received" },
+  missing_payment: { decisionType: "review_missing_payment", severity: "critical", reason: "Expected rent payment is missing" },
+  failed_payment: { decisionType: "review_failed_payment", severity: "critical", reason: "Payment did not complete" },
+  manual_review_required: { decisionType: "review_manual_payment_issue", severity: "warning", reason: "Payment mismatch detected" },
+};
+
+function cleanIdPart(value: unknown): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function decisionIdFor(parts: unknown[]): string {
+  return cleanIdPart(["decision", ...parts].filter(Boolean).join(":")) || "decision:unknown";
+}
+
+export function normalizeDecisionItems(value: unknown): DecisionItem[] {
+  return (Array.isArray(value) ? value : [])
+    .map((raw) => raw as Partial<DecisionItem>)
+    .filter((item): item is DecisionItem => Boolean(item.decisionType && item.reason && item.severity))
+    .map((item) => ({
+      decisionId: item.decisionId || decisionIdFor([item.decisionType, item.leaseId, item.paymentIntentId, item.rentPaymentId]),
+      leaseId: item.leaseId || null,
+      paymentIntentId: item.paymentIntentId || null,
+      rentPaymentId: item.rentPaymentId || null,
+      propertyId: item.propertyId || null,
+      unitId: item.unitId || null,
+      tenantId: item.tenantId || null,
+      decisionType: item.decisionType,
+      severity: item.severity,
+      status: item.status || "detected",
+      reason: item.reason,
+      metadata: item.metadata || {},
+      createdAt: item.createdAt || null,
+      updatedAt: item.updatedAt || null,
+    }));
+}
+
+export function deriveDecisionItemsFromDelinquencySignals(signals: LeaseDelinquencySignal[] | null | undefined): DecisionItem[] {
+  return (signals || [])
+    .map((signal) => {
+      const mapping = delinquencyDecisionMap[signal.signalType];
+      if (!mapping) return null;
+      return {
+        decisionId: decisionIdFor([mapping.decisionType, signal.signalId]),
+        leaseId: signal.leaseId,
+        paymentIntentId: signal.paymentIntentId || null,
+        rentPaymentId: signal.rentPaymentId || null,
+        propertyId: signal.propertyId || null,
+        unitId: signal.unitId || null,
+        tenantId: signal.tenantId || null,
+        decisionType: mapping.decisionType,
+        severity: mapping.severity,
+        status: "detected" as const,
+        reason: mapping.reason,
+        metadata: {
+          source: "delinquency_signal",
+          signalId: signal.signalId,
+          signalType: signal.signalType,
+          signalReasons: signal.reasons || [],
+          outstandingAmountCents: signal.outstandingAmountCents,
+        },
+        createdAt: signal.detectedAt,
+        updatedAt: signal.detectedAt,
+      };
+    })
+    .filter(Boolean) as DecisionItem[];
+}
+
+export function decisionFromLifecycleReviewItem(item: {
+  id: string;
+  leaseId: string;
+  propertyId?: string | null;
+  unitId?: string | null;
+  tenantId?: string | null;
+  category: string;
+  severity: DecisionSeverity;
+  description: string;
+  derivedLifecycleReasons?: string[];
+  detectedAt?: string | null;
+}): DecisionItem | null {
+  if (item.category === "expired_occupancy_conflict") {
+    return {
+      decisionId: decisionIdFor(["review_occupancy_conflict", item.id]),
+      leaseId: item.leaseId,
+      propertyId: item.propertyId || null,
+      unitId: item.unitId || null,
+      tenantId: item.tenantId || null,
+      decisionType: "review_occupancy_conflict",
+      severity: item.severity === "critical" ? "critical" : "warning",
+      status: "detected",
+      reason: "Lease lifecycle indicates an occupancy conflict that needs review.",
+      metadata: {
+        source: "lease_lifecycle_review_queue",
+        reviewItemId: item.id,
+        reviewCategory: item.category,
+        lifecycleReasons: item.derivedLifecycleReasons || [],
+      },
+      createdAt: item.detectedAt || null,
+      updatedAt: item.detectedAt || null,
+    };
+  }
+  if (item.category === "notice_conflict" || item.category === "renewal_ambiguity") {
+    return {
+      decisionId: decisionIdFor(["review_expiring_lease", item.id]),
+      leaseId: item.leaseId,
+      propertyId: item.propertyId || null,
+      unitId: item.unitId || null,
+      tenantId: item.tenantId || null,
+      decisionType: "review_expiring_lease",
+      severity: item.severity,
+      status: "detected",
+      reason: "Lease lifecycle timing or renewal context needs review.",
+      metadata: {
+        source: "lease_lifecycle_review_queue",
+        reviewItemId: item.id,
+        reviewCategory: item.category,
+        lifecycleReasons: item.derivedLifecycleReasons || [],
+      },
+      createdAt: item.detectedAt || null,
+      updatedAt: item.detectedAt || null,
+    };
+  }
+  return null;
+}
+
+export function summarizeDecisionItems(decisions: DecisionItem[] | null | undefined): DecisionSummary {
+  const rows = decisions || [];
+  return {
+    total: rows.length,
+    critical: rows.filter((item) => item.severity === "critical").length,
+    warning: rows.filter((item) => item.severity === "warning").length,
+    info: rows.filter((item) => item.severity === "info").length,
+    overdue: rows.filter((item) => item.decisionType === "review_overdue_rent").length,
+    underpaid: rows.filter((item) => item.decisionType === "review_underpaid_rent").length,
+    missing: rows.filter((item) => item.decisionType === "review_missing_payment").length,
+    failed: rows.filter((item) => item.decisionType === "review_failed_payment").length,
+    manualReview: rows.filter((item) => item.decisionType === "review_manual_payment_issue").length,
+    expiring: rows.filter((item) => item.decisionType === "review_expiring_lease").length,
+  };
+}

--- a/rentchain-frontend/src/pages/DashboardPage.test.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.test.tsx
@@ -248,6 +248,41 @@ describe("DashboardPage", () => {
         missingCredibilityCount: 1,
         healthStatus: "watch",
       },
+      decisions: [
+        {
+          decisionId: "decision:review_overdue_rent:lease-1",
+          leaseId: "lease-1",
+          propertyId: "property-1",
+          unitId: "unit-1",
+          decisionType: "review_overdue_rent",
+          severity: "critical",
+          status: "detected",
+          reason: "Rent past due date",
+          metadata: {},
+        },
+        {
+          decisionId: "decision:review_underpaid_rent:lease-2",
+          leaseId: "lease-2",
+          propertyId: "property-2",
+          unitId: "unit-2",
+          decisionType: "review_underpaid_rent",
+          severity: "warning",
+          status: "detected",
+          reason: "Partial payment received",
+          metadata: {},
+        },
+        {
+          decisionId: "decision:review_manual_payment_issue:lease-3",
+          leaseId: "lease-3",
+          propertyId: "property-3",
+          unitId: "unit-3",
+          decisionType: "review_manual_payment_issue",
+          severity: "warning",
+          status: "detected",
+          reason: "Payment mismatch detected",
+          metadata: {},
+        },
+      ],
     });
 
     render(
@@ -263,6 +298,29 @@ describe("DashboardPage", () => {
     expect(screen.getByRole("link", { name: "Tenants" })).toHaveAttribute("href", "/tenants");
     expect(screen.getByRole("link", { name: "Delinquencies" })).toHaveAttribute("href", "/payments?filter=delinquent");
     expect(screen.getAllByRole("link", { name: "2" }).some((link) => link.getAttribute("href") === "/applications?status=review")).toBe(true);
+    expect(screen.getByText("Decision summary")).toBeInTheDocument();
+    expect(screen.getByText("Read-only decisions from detected rent and lease signals.")).toBeInTheDocument();
+    expect(screen.getByText("Overdue Rent")).toBeInTheDocument();
+    expect(screen.getByText("Rent past due date")).toBeInTheDocument();
+    expect(screen.getByText("Underpaid Rent")).toBeInTheDocument();
+    expect(screen.getByText("Partial payment received")).toBeInTheDocument();
+    expect(screen.getAllByText("Manual Review").length).toBeGreaterThan(0);
+    expect(screen.getByText("Payment mismatch detected")).toBeInTheDocument();
+  });
+
+  it("renders an empty dashboard decision state without adding actions", async () => {
+    render(
+      <ToastProvider>
+        <MemoryRouter>
+          <DashboardPage />
+        </MemoryRouter>
+      </ToastProvider>
+    );
+
+    expect(await screen.findByText("Decision summary")).toBeInTheDocument();
+    expect(screen.getByText("No issues detected. Everything is up to date.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /accept/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /dismiss/i })).not.toBeInTheDocument();
   });
 
   it("keeps dashboard recent activity ledger CTA label consistent when lease context is missing", async () => {

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -41,6 +41,13 @@ import {
 } from "@/api/landlordAnalyticsApi";
 import { LandlordActivationFlowCard } from "@/components/activation/LandlordActivationFlowCard";
 import { clearPostUpgradeState, getPostUpgradeContent, getPostUpgradeState } from "@/lib/postUpgrade";
+import {
+  decisionDisplayCopy,
+  decisionSeverityStyle,
+  normalizeDecisionItems,
+  summarizeDecisionItems,
+  type DecisionItem,
+} from "@/lib/decisions/decisionDisplay";
 
 const StarterOnboardingPanel = React.lazy(
   () => import("../components/dashboard/StarterOnboardingPanel")
@@ -106,6 +113,61 @@ function formatDate(ts: number | null): string {
   } catch {
     return new Date(ts).toISOString();
   }
+}
+
+function DashboardDecisionSummaryPanel({ decisions }: { decisions: DecisionItem[] }) {
+  const summary = summarizeDecisionItems(decisions);
+  const cells = [
+    { label: "Overdue", value: summary.overdue, severity: "critical" as const },
+    { label: "Underpaid", value: summary.underpaid, severity: "warning" as const },
+    { label: "Missing", value: summary.missing, severity: "critical" as const },
+    { label: "Failed", value: summary.failed, severity: "critical" as const },
+    { label: "Manual Review", value: summary.manualReview, severity: "warning" as const },
+  ];
+  return (
+    <Card style={{ padding: spacing.md, border: `1px solid ${colors.border}`, display: "grid", gap: spacing.sm }}>
+      <div>
+        <div style={{ fontWeight: 800 }}>Decision summary</div>
+        <div style={{ color: text.muted, fontSize: 13, marginTop: 3 }}>
+          Read-only decisions from detected rent and lease signals.
+        </div>
+      </div>
+      {summary.total === 0 ? (
+        <div style={{ color: "#166534", background: "#f0fdf4", border: "1px solid #bbf7d0", borderRadius: 10, padding: 10 }}>
+          No issues detected. Everything is up to date.
+        </div>
+      ) : (
+        <>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(130px, 1fr))", gap: spacing.sm }}>
+            {cells.map((cell) => {
+              const tone = decisionSeverityStyle[cell.severity];
+              return (
+                <div key={cell.label} style={{ border: `1px solid ${tone.border}`, background: tone.bg, borderRadius: 10, padding: 10 }}>
+                  <div style={{ color: tone.color, fontSize: 12, fontWeight: 700 }}>{cell.label}</div>
+                  <strong style={{ color: tone.color, fontSize: 20 }}>{cell.value}</strong>
+                </div>
+              );
+            })}
+          </div>
+          <div style={{ display: "grid", gap: 6 }}>
+            {decisions.slice(0, 3).map((decision) => {
+              const copy = decisionDisplayCopy[decision.decisionType];
+              const tone = decisionSeverityStyle[decision.severity];
+              return (
+                <div key={decision.decisionId} style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center", color: text.primary }}>
+                  <span style={{ border: `1px solid ${tone.border}`, background: tone.bg, color: tone.color, borderRadius: 999, padding: "2px 8px", fontSize: 12, fontWeight: 800 }}>
+                    {copy.badge}
+                  </span>
+                  <span>{copy.label}</span>
+                  <span style={{ color: text.muted }}>{decision.reason}</span>
+                </div>
+              );
+            })}
+          </div>
+        </>
+      )}
+    </Card>
+  );
 }
 
 const DashboardPage: React.FC = () => {
@@ -434,6 +496,7 @@ const DashboardPage: React.FC = () => {
         ? "No onboarding drop-off right now."
         : "No onboarding starts recorded yet.";
   const events = Array.isArray(data?.events) ? data.events : [];
+  const dashboardDecisions = React.useMemo(() => normalizeDecisionItems(data?.decisions), [data?.decisions]);
 
   React.useEffect(() => {
     if (location.hash !== "#open-actions") return;
@@ -661,6 +724,7 @@ const DashboardPage: React.FC = () => {
             }}
           />
         ) : null}
+        {dataReady ? <DashboardDecisionSummaryPanel decisions={dashboardDecisions} /> : null}
         {dataReady ? (
           <div style={{ marginTop: spacing.md }}>
             <PortfolioCredibilitySummaryCard

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
@@ -425,6 +425,29 @@ describe("LeaseLedgerPage", () => {
     expect(screen.getByText("Manual review required — Payment mismatch or incomplete evidence (obligation requires manual review)")).toBeInTheDocument();
   });
 
+  it("renders read-only lease decisions derived from delinquency signals", async () => {
+    render(
+      <MemoryRouter initialEntries={["/leases/lease-1/ledger"]}>
+        <Routes>
+          <Route path="/leases/:leaseId/ledger" element={<LeaseLedgerPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Decisions")).toBeInTheDocument();
+    expect(screen.getByText("Read-only decisions derived from detected lease and payment signals.")).toBeInTheDocument();
+    expect(screen.getByText("Overdue Rent")).toBeInTheDocument();
+    expect(screen.getByText("Rent past due date")).toBeInTheDocument();
+    expect(screen.getByText("Underpaid Rent")).toBeInTheDocument();
+    expect(screen.getByText("Partial payment received")).toBeInTheDocument();
+    expect(screen.getByText("Missing Payment")).toBeInTheDocument();
+    expect(screen.getByText("Expected rent payment is missing")).toBeInTheDocument();
+    expect(screen.getByText("Failed Payment")).toBeInTheDocument();
+    expect(screen.getByText("Payment did not complete")).toBeInTheDocument();
+    expect(screen.getAllByText("Manual Review").length).toBeGreaterThan(0);
+    expect(screen.getByText("Payment mismatch detected")).toBeInTheDocument();
+  });
+
   it("renders an empty obligation state while preserving existing ledger entries", async () => {
     mocks.fetchLeaseLedger.mockResolvedValueOnce({
       ok: true,
@@ -485,6 +508,7 @@ describe("LeaseLedgerPage", () => {
 
     expect(await screen.findByText("Obligation ledger is not available yet for this lease.")).toBeInTheDocument();
     expect(screen.getByText("All rent obligations are up to date.")).toBeInTheDocument();
+    expect(screen.getByText("No issues detected. Everything is up to date.")).toBeInTheDocument();
     expect(screen.getByText("+$1,450.00")).toBeInTheDocument();
     expect(screen.getAllByText("$1,450.00").length).toBeGreaterThan(0);
   });

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
@@ -24,6 +24,14 @@ import {
   type LandlordActiveLease,
   type LeaseNote,
 } from "@/api/leasesApi";
+import {
+  decisionDisplayCopy,
+  decisionSeverityStyle,
+  deriveDecisionItemsFromDelinquencySignals,
+  summarizeDecisionItems,
+  type DecisionItem,
+  type DecisionSeverity,
+} from "@/lib/decisions/decisionDisplay";
 
 type ChargeType = "rent" | "fee" | "adjustment";
 type PaymentMethod = "cash" | "etransfer" | "cheque" | "bank" | "card" | "other";
@@ -147,6 +155,46 @@ function DelinquencySignalBadge({ signalType }: { signalType: DelinquencySignalT
     >
       {copy.label}
     </span>
+  );
+}
+
+function DecisionBadge({ severity, label }: { severity: DecisionSeverity; label: string }) {
+  const style = decisionSeverityStyle[severity] || decisionSeverityStyle.info;
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        borderRadius: 999,
+        border: `1px solid ${style.border}`,
+        background: style.bg,
+        color: style.color,
+        padding: "3px 8px",
+        fontSize: 12,
+        fontWeight: 800,
+        whiteSpace: "nowrap",
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+
+function DecisionRow({ decision }: { decision: DecisionItem }) {
+  const copy = decisionDisplayCopy[decision.decisionType];
+  const context = [
+    decision.unitId ? `Unit ${decision.unitId}` : null,
+    decision.tenantId ? `Tenant ${decision.tenantId}` : null,
+  ].filter(Boolean);
+  return (
+    <div style={{ border: "1px solid #e2e8f0", borderRadius: 12, padding: 12, background: "#fff", display: "grid", gap: 6 }}>
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+        <DecisionBadge severity={decision.severity} label={copy.badge} />
+        <strong>{copy.label}</strong>
+      </div>
+      <div style={{ color: "#475569" }}>{decision.reason}</div>
+      {context.length ? <div style={{ color: "#64748b", fontSize: 12 }}>{context.join(" · ")}</div> : null}
+    </div>
   );
 }
 
@@ -288,6 +336,9 @@ export default function LeaseLedgerPage() {
   const [paymentAmount, setPaymentAmount] = useState("");
   const [paymentReference, setPaymentReference] = useState("");
   const [paymentNotes, setPaymentNotes] = useState("");
+
+  const decisions = useMemo(() => deriveDecisionItemsFromDelinquencySignals(delinquencySignals), [delinquencySignals]);
+  const decisionSummary = useMemo(() => summarizeDecisionItems(decisions), [decisions]);
 
   const monthlyRows = useMemo(() => {
     return Object.entries(monthlyTotals).sort((a, b) => (a[0] < b[0] ? 1 : -1));
@@ -558,6 +609,42 @@ export default function LeaseLedgerPage() {
           </div>
         </div>
       ) : null}
+
+      <section style={{ display: "grid", gap: 10 }}>
+        <div>
+          <h2 style={{ margin: 0, fontSize: "1rem" }}>Decisions</h2>
+          <div style={{ color: "#64748b", fontSize: 13, marginTop: 3 }}>
+            Read-only decisions derived from detected lease and payment signals.
+          </div>
+        </div>
+        {decisions.length === 0 ? (
+          <div style={{ border: "1px solid #bbf7d0", borderRadius: 12, padding: 12, color: "#166534", background: "#f0fdf4" }}>
+            No issues detected. Everything is up to date.
+          </div>
+        ) : (
+          <>
+            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))", gap: 8 }}>
+              <div style={{ border: "1px solid #fecaca", borderRadius: 10, padding: 10, background: "#fef2f2" }}>
+                <div style={{ fontSize: 12, color: "#991b1b" }}>Critical</div>
+                <strong>{decisionSummary.critical}</strong>
+              </div>
+              <div style={{ border: "1px solid #fed7aa", borderRadius: 10, padding: 10, background: "#fff7ed" }}>
+                <div style={{ fontSize: 12, color: "#9a3412" }}>Warning</div>
+                <strong>{decisionSummary.warning}</strong>
+              </div>
+              <div style={{ border: "1px solid #e2e8f0", borderRadius: 10, padding: 10 }}>
+                <div style={{ fontSize: 12, color: "#64748b" }}>Total</div>
+                <strong>{decisionSummary.total}</strong>
+              </div>
+            </div>
+            <div style={{ display: "grid", gap: 8 }}>
+              {decisions.map((decision) => (
+                <DecisionRow key={decision.decisionId} decision={decision} />
+              ))}
+            </div>
+          </>
+        )}
+      </section>
 
       <section style={{ display: "grid", gap: 10 }}>
         <div>

--- a/rentchain-frontend/src/pages/admin/AdminLeaseLifecycleReviewPage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminLeaseLifecycleReviewPage.test.tsx
@@ -127,9 +127,14 @@ describe("AdminLeaseLifecycleReviewPage", () => {
     expect(screen.getByText(/Reviewed by ops/i)).toBeInTheDocument();
     expect(screen.getByText(/admin@example.com/i)).toBeInTheDocument();
     expect(screen.getByText(/No history yet/i)).toBeInTheDocument();
+    expect(screen.getByText(/Related decision/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Occupancy/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Lease lifecycle indicates an occupancy conflict that needs review/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "lease-1" })).toHaveAttribute("href", "/admin/leases?q=lease-1");
     expect(screen.queryByRole("button", { name: /fix/i })).not.toBeInTheDocument();
     expect(screen.queryByText(/Fix automatically/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /accept/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /dismiss/i })).not.toBeInTheDocument();
   });
 
   it("updates acknowledgement state from row actions", async () => {

--- a/rentchain-frontend/src/pages/admin/AdminLeaseLifecycleReviewPage.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminLeaseLifecycleReviewPage.tsx
@@ -11,6 +11,11 @@ import {
   type AdminLeaseLifecycleReviewSummary,
   type LeaseLifecycleReviewSeverity,
 } from "../../api/adminLeaseLifecycleReviewApi";
+import {
+  decisionDisplayCopy,
+  decisionFromLifecycleReviewItem,
+  decisionSeverityStyle,
+} from "@/lib/decisions/decisionDisplay";
 
 const emptySummary: AdminLeaseLifecycleReviewSummary = {
   total: 0,
@@ -88,6 +93,7 @@ function QueueItemRow({
     payload: { status: "reviewed" | "snoozed" | "assigned"; assignedTo?: string | null; snoozedUntil?: string | null; note?: string | null }
   ) => void;
 }) {
+  const decision = decisionFromLifecycleReviewItem(item);
   return (
     <tr>
       <td style={{ padding: "12px 10px", verticalAlign: "top", borderBottom: "1px solid #e2e8f0" }}>
@@ -109,6 +115,25 @@ function QueueItemRow({
         <div style={{ fontWeight: 700, color: "#0f172a" }}>{item.title}</div>
         <div style={{ color: "#475569", marginTop: 4 }}>{item.description}</div>
         <div style={{ color: "#64748b", fontSize: "0.9rem", marginTop: 6 }}>{reasonText(item)}</div>
+        {decision ? (
+          <div style={{ marginTop: 8, display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+            <span style={{ color: "#64748b", fontSize: 12, fontWeight: 700 }}>Related decision</span>
+            <span
+              style={{
+                border: `1px solid ${decisionSeverityStyle[decision.severity].border}`,
+                background: decisionSeverityStyle[decision.severity].bg,
+                color: decisionSeverityStyle[decision.severity].color,
+                borderRadius: 999,
+                padding: "2px 8px",
+                fontSize: 12,
+                fontWeight: 800,
+              }}
+            >
+              {decisionDisplayCopy[decision.decisionType].badge}
+            </span>
+            <span style={{ color: "#475569", fontSize: 12 }}>{decision.reason}</span>
+          </div>
+        ) : null}
       </td>
       <td style={{ padding: "12px 10px", verticalAlign: "top", borderBottom: "1px solid #e2e8f0" }}>
         <span style={{ color: "#0f172a", fontWeight: 700 }}>{item.recommendedAction}</span>


### PR DESCRIPTION
## Summary
- Displays read-only decision summary on dashboard.
- Shows lease-level decisions on lease ledger pages.
- Adds severity-based badges and reason text.
- Integrates decision visibility into admin lifecycle review surfaces.
- Preserves existing UI behavior.
- No accept, dismiss, fix, mutation, or automation actions.
- Frontend-only; no backend, payment behavior, Stripe/webhook, Trustly, PaymentIntent enforcement, schema, dependency, or lockfile changes.

## Verification
- Focused decision UI tests passed: 22 tests.
- Full frontend suite passed: 181 files / 742 tests.
- Frontend build passed with existing chunk-size warning.
- git diff --check passed.
- backend diff empty.
- dependency/lockfile diff empty.