### PR TITLE
Add decision lifecycle actions

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -129,6 +129,7 @@ import viewingRoutes from "./routes/viewingRoutes";
 import screeningOpsRoutes from "./routes/screeningOpsRoutes";
 import leaseOverlapCleanupRoutes from "./routes/leaseOverlapCleanupRoutes";
 import riskAgentRoutes from "./routes/riskAgentRoutes";
+import decisionRoutes from "./routes/decisionRoutes";
 
 process.on("unhandledRejection", (reason) => {
   console.error("[FATAL] unhandledRejection", reason);
@@ -309,6 +310,7 @@ app.get("/api/me", async (req: any, res: any, next: any) => {
 
 // Core prefixed APIs must mount before broad /api routers.
 app.use("/api/compliance", routeSource("complianceRoutes.ts"), complianceRoutes);
+app.use("/api/decisions", routeSource("decisionRoutes.ts"), decisionRoutes);
 app.use("/api/leases", routeSource("leaseRoutes.ts"), leaseRoutes);
 app.use("/api/tenants", routeSource("tenantsRoutes.ts"), tenantsRoutes);
 app.use("/api", routeSource("tenanciesRoutes.ts"), tenanciesRoutes);

--- a/rentchain-api/src/lib/decisions/__tests__/decisionActions.test.ts
+++ b/rentchain-api/src/lib/decisions/__tests__/decisionActions.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import type { Decision } from "../decisionEngine";
+import {
+  applyDecisionActions,
+  buildDecisionAction,
+  normalizeDecisionAction,
+  parseDecisionActionPatch,
+} from "../decisionActions";
+
+function decision(overrides: Partial<Decision> = {}): Decision {
+  return {
+    decisionId: "decision:review_overdue_rent:sig-1",
+    leaseId: "lease-1",
+    paymentIntentId: "pi-1",
+    rentPaymentId: "rp-1",
+    propertyId: "prop-1",
+    unitId: "unit-1",
+    tenantId: "tenant-1",
+    decisionType: "review_overdue_rent",
+    severity: "critical",
+    status: "detected",
+    reason: "Rent obligation is overdue.",
+    metadata: {},
+    createdAt: "2026-05-01T10:00:00.000Z",
+    updatedAt: "2026-05-01T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("decisionActions", () => {
+  it("parses valid action patches and rejects incomplete action payloads", () => {
+    expect(parseDecisionActionPatch({ actionType: "reviewed", note: "Checked" })).toEqual({
+      actionType: "reviewed",
+      note: "Checked",
+    });
+    expect(parseDecisionActionPatch({ actionType: "assigned" })).toBeNull();
+    expect(parseDecisionActionPatch({ actionType: "snoozed", snoozedUntil: "not-a-date" })).toBeNull();
+    expect(parseDecisionActionPatch({ actionType: "fixed" })).toBeNull();
+  });
+
+  it("creates action records without mutating the source decision", () => {
+    const source = decision();
+    const action = buildDecisionAction({
+      decision: source,
+      patch: { actionType: "reviewed", note: "Reviewed by ops" },
+      landlordId: "landlord-1",
+      actorId: "admin-1",
+      actorEmail: "admin@example.com",
+      now: "2026-05-05T12:00:00.000Z",
+    });
+
+    expect(action).toEqual(
+      expect.objectContaining({
+        decisionId: source.decisionId,
+        leaseId: "lease-1",
+        landlordId: "landlord-1",
+        actionType: "reviewed",
+        previousStatus: "detected",
+        nextStatus: "reviewed",
+        note: "Reviewed by ops",
+        actorId: "admin-1",
+        actorEmail: "admin@example.com",
+        createdAt: "2026-05-05T12:00:00.000Z",
+      })
+    );
+    expect(source.status).toBe("detected");
+  });
+
+  it("applies the latest action as a status overlay", () => {
+    const source = decision();
+    const reviewed = buildDecisionAction({
+      decision: source,
+      patch: { actionType: "reviewed" },
+      now: "2026-05-05T12:00:00.000Z",
+    });
+    const dismissed = buildDecisionAction({
+      decision: source,
+      patch: { actionType: "dismissed" },
+      existingActions: [reviewed],
+      now: "2026-05-05T13:00:00.000Z",
+    });
+
+    const merged = applyDecisionActions([source], [dismissed, reviewed]);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toEqual(
+      expect.objectContaining({
+        decisionId: source.decisionId,
+        status: "dismissed",
+        updatedAt: "2026-05-05T13:00:00.000Z",
+        latestAction: expect.objectContaining({ actionType: "dismissed" }),
+      })
+    );
+    expect(source.status).toBe("detected");
+  });
+
+  it("supports snoozed and assigned lifecycle statuses", () => {
+    const source = decision();
+    const snoozed = buildDecisionAction({
+      decision: source,
+      patch: { actionType: "snoozed", snoozedUntil: "2026-05-12" },
+      now: "2026-05-05T12:00:00.000Z",
+    });
+    const assigned = buildDecisionAction({
+      decision: source,
+      patch: { actionType: "assigned", assignedTo: "ops@example.com" },
+      existingActions: [snoozed],
+      now: "2026-05-05T13:00:00.000Z",
+    });
+
+    expect(snoozed.nextStatus).toBe("snoozed");
+    expect(snoozed.snoozedUntil).toBe("2026-05-12T00:00:00.000Z");
+    expect(assigned.nextStatus).toBe("assigned");
+    expect(assigned.assignedTo).toBe("ops@example.com");
+    expect(assigned.previousStatus).toBe("snoozed");
+  });
+
+  it("normalizes persisted action records defensively", () => {
+    expect(
+      normalizeDecisionAction({
+        actionId: "action-1",
+        decisionId: "decision-1",
+        leaseId: "lease-1",
+        actionType: "resolved",
+        previousStatus: "reviewed",
+        nextStatus: "resolved",
+        createdAt: "2026-05-05T12:00:00.000Z",
+      })
+    ).toEqual(expect.objectContaining({ actionType: "resolved", nextStatus: "resolved" }));
+    expect(normalizeDecisionAction({ decisionId: "decision-1", actionType: "resolved" })).toBeNull();
+  });
+});

--- a/rentchain-api/src/lib/decisions/decisionActions.ts
+++ b/rentchain-api/src/lib/decisions/decisionActions.ts
@@ -1,0 +1,181 @@
+import crypto from "crypto";
+import type { Decision, DecisionStatus } from "./decisionEngine";
+
+export const DECISION_ACTIONS_COLLECTION = "decisionActions";
+
+export type DecisionActionType = "reviewed" | "snoozed" | "assigned" | "dismissed" | "resolved";
+
+export type DecisionAction = {
+  actionId: string;
+  decisionId: string;
+  leaseId: string;
+  propertyId: string | null;
+  unitId: string | null;
+  landlordId: string | null;
+  actorId: string | null;
+  actorEmail?: string | null;
+  actionType: DecisionActionType;
+  previousStatus: DecisionStatus;
+  nextStatus: DecisionStatus;
+  note?: string | null;
+  assignedTo?: string | null;
+  snoozedUntil?: string | null;
+  createdAt: string;
+};
+
+export type DecisionActionPatch = {
+  actionType: DecisionActionType;
+  note?: string | null;
+  assignedTo?: string | null;
+  snoozedUntil?: string | null;
+};
+
+export type DecisionWithActions = Decision & {
+  latestAction: DecisionAction | null;
+};
+
+const VALID_ACTIONS = new Set<DecisionActionType>(["reviewed", "snoozed", "assigned", "dismissed", "resolved"]);
+
+function asString(value: unknown, max = 1000): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function toIsoDate(value: unknown): string | null {
+  const raw = asString(value, 120);
+  if (!raw) return null;
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toISOString();
+}
+
+function cleanIdPart(value: unknown): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function nextStatusForAction(actionType: DecisionActionType): DecisionStatus {
+  if (actionType === "reviewed") return "reviewed";
+  if (actionType === "snoozed") return "snoozed";
+  if (actionType === "assigned") return "assigned";
+  if (actionType === "dismissed") return "dismissed";
+  return "resolved";
+}
+
+export function normalizeDecisionAction(raw: unknown): DecisionAction | null {
+  const data = (raw || {}) as Record<string, unknown>;
+  const actionId = asString(data.actionId || data.id, 240);
+  const decisionId = asString(data.decisionId, 500);
+  const leaseId = asString(data.leaseId, 240);
+  const actionType = asString(data.actionType, 40) as DecisionActionType;
+  const previousStatus = asString(data.previousStatus, 40) as DecisionStatus;
+  const nextStatus = asString(data.nextStatus, 40) as DecisionStatus;
+  const createdAt = toIsoDate(data.createdAt);
+  if (!actionId || !decisionId || !leaseId || !createdAt || !VALID_ACTIONS.has(actionType)) return null;
+  if (!nextStatus) return null;
+  return {
+    actionId,
+    decisionId,
+    leaseId,
+    propertyId: asString(data.propertyId, 240) || null,
+    unitId: asString(data.unitId, 240) || null,
+    landlordId: asString(data.landlordId, 240) || null,
+    actorId: asString(data.actorId, 240) || null,
+    actorEmail: asString(data.actorEmail, 320) || null,
+    actionType,
+    previousStatus: previousStatus || "detected",
+    nextStatus,
+    note: asString(data.note, 1000) || null,
+    assignedTo: asString(data.assignedTo, 240) || null,
+    snoozedUntil: toIsoDate(data.snoozedUntil),
+    createdAt,
+  };
+}
+
+export function parseDecisionActionPatch(body: unknown): DecisionActionPatch | null {
+  const data = (body || {}) as Record<string, unknown>;
+  const actionType = asString(data.actionType, 40) as DecisionActionType;
+  if (!VALID_ACTIONS.has(actionType)) return null;
+  const patch: DecisionActionPatch = {
+    actionType,
+    note: asString(data.note, 1000) || null,
+  };
+  if (actionType === "assigned") {
+    patch.assignedTo = asString(data.assignedTo, 240) || null;
+    if (!patch.assignedTo) return null;
+  }
+  if (actionType === "snoozed") {
+    patch.snoozedUntil = toIsoDate(data.snoozedUntil);
+    if (!patch.snoozedUntil) return null;
+  }
+  return patch;
+}
+
+export function buildDecisionAction(input: {
+  decision: Decision;
+  patch: DecisionActionPatch;
+  existingActions?: DecisionAction[] | null;
+  landlordId?: string | null;
+  actorId?: string | null;
+  actorEmail?: string | null;
+  now?: string;
+}): DecisionAction {
+  const createdAt = toIsoDate(input.now) || new Date().toISOString();
+  const current = applyDecisionActions([input.decision], input.existingActions || [])[0];
+  const nextStatus = nextStatusForAction(input.patch.actionType);
+  const seed = [
+    input.decision.decisionId,
+    input.patch.actionType,
+    createdAt,
+    crypto.randomUUID(),
+  ].join(":");
+  return {
+    actionId: crypto.createHash("sha256").update(seed).digest("hex"),
+    decisionId: input.decision.decisionId,
+    leaseId: input.decision.leaseId,
+    propertyId: input.decision.propertyId || null,
+    unitId: input.decision.unitId || null,
+    landlordId: asString(input.landlordId, 240) || null,
+    actorId: asString(input.actorId, 240) || null,
+    actorEmail: asString(input.actorEmail, 320) || null,
+    actionType: input.patch.actionType,
+    previousStatus: current.status || "detected",
+    nextStatus,
+    note: asString(input.patch.note, 1000) || null,
+    assignedTo: input.patch.actionType === "assigned" ? asString(input.patch.assignedTo, 240) || null : null,
+    snoozedUntil: input.patch.actionType === "snoozed" ? toIsoDate(input.patch.snoozedUntil) : null,
+    createdAt,
+  };
+}
+
+export function applyDecisionActions(decisions: Decision[], rawActions: unknown[]): DecisionWithActions[] {
+  const latestByDecisionId = new Map<string, DecisionAction>();
+  for (const raw of Array.isArray(rawActions) ? rawActions : []) {
+    const action = normalizeDecisionAction(raw);
+    if (!action) continue;
+    const current = latestByDecisionId.get(action.decisionId);
+    if (!current || action.createdAt.localeCompare(current.createdAt) >= 0) {
+      latestByDecisionId.set(action.decisionId, action);
+    }
+  }
+
+  return (decisions || []).map((decision) => {
+    const latestAction = latestByDecisionId.get(decision.decisionId) || null;
+    if (!latestAction) {
+      return { ...decision, status: decision.status || "detected", latestAction: null };
+    }
+    return {
+      ...decision,
+      status: latestAction.nextStatus,
+      updatedAt: latestAction.createdAt,
+      latestAction,
+    };
+  });
+}
+
+export function decisionActionRecordId(action: DecisionAction): string {
+  return cleanIdPart(["decision_action", action.decisionId, action.actionId].join(":")) || action.actionId;
+}

--- a/rentchain-api/src/lib/decisions/decisionEngine.ts
+++ b/rentchain-api/src/lib/decisions/decisionEngine.ts
@@ -13,7 +13,15 @@ export type DecisionType =
 
 export type DecisionSeverity = "info" | "warning" | "critical";
 
-export type DecisionStatus = "detected" | "surfaced" | "reviewed" | "accepted" | "dismissed" | "resolved";
+export type DecisionStatus =
+  | "detected"
+  | "surfaced"
+  | "reviewed"
+  | "snoozed"
+  | "assigned"
+  | "accepted"
+  | "dismissed"
+  | "resolved";
 
 export type Decision = {
   decisionId: string;

--- a/rentchain-api/src/routes/__tests__/decisionRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/decisionRoutes.test.ts
@@ -1,0 +1,179 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fakeDb, resetFakeDb, seedDoc, listDocs } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+
+  function matches(doc: any, filters: Array<{ field: string; op: string; value: any }>) {
+    return filters.every(({ field, op, value }) => {
+      const actual = doc?.data?.[field];
+      if (op === "==") return actual === value;
+      return false;
+    });
+  }
+
+  function makeQuery(name: string, filters: Array<{ field: string; op: string; value: any }> = []) {
+    return {
+      where: (field: string, op: string, value: any) => makeQuery(name, [...filters, { field, op, value }]),
+      get: async () => {
+        const docs = Array.from(ensureCollection(name).values())
+          .filter((doc) => matches(doc, filters))
+          .map((doc) => ({ id: doc.id, exists: true, data: () => doc.data }));
+        return { docs, empty: docs.length === 0, size: docs.length };
+      },
+      doc: (id: string) => makeDoc(name, id),
+    };
+  }
+
+  function makeDoc(name: string, id: string) {
+    const col = ensureCollection(name);
+    return {
+      id,
+      get: async () => {
+        const entry = col.get(id);
+        return { id, exists: Boolean(entry), data: () => entry?.data };
+      },
+      set: async (data: any) => {
+        col.set(id, { id, data });
+      },
+    };
+  }
+
+  return {
+    resetFakeDb: () => store.clear(),
+    seedDoc: (collection: string, id: string, data: any) => ensureCollection(collection).set(id, { id, data }),
+    listDocs: (collection: string) => Array.from(ensureCollection(collection).values()).map((entry) => entry.data),
+    fakeDb: {
+      collection: (name: string) => ({
+        where: (field: string, op: string, value: any) => makeQuery(name, [{ field, op, value }]),
+        get: async () => makeQuery(name).get(),
+        doc: (id: string) => makeDoc(name, id),
+      }),
+    },
+  };
+});
+
+vi.mock("../../config/firebase", () => ({
+  db: fakeDb,
+}));
+
+let mockUser: any;
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, _res: any, next: any) => {
+    if (!mockUser) {
+      return _res.status(401).json({ ok: false, error: "unauthenticated" });
+    }
+    req.user = mockUser;
+    return next();
+  },
+}));
+
+function seedLease(overrides: Record<string, any> = {}) {
+  seedDoc("leases", "lease-1", {
+    landlordId: "landlord-1",
+    propertyId: "prop-1",
+    unitId: "unit-1",
+    tenantId: "tenant-1",
+    monthlyRent: 1800,
+    startDate: "2026-04-01",
+    endDate: "2027-03-31",
+    dueDate: "2026-04-01",
+    signedAt: "2026-04-01T00:00:00.000Z",
+    status: "active",
+    ...overrides,
+  });
+}
+
+async function makeApp() {
+  const router = (await import("../decisionRoutes")).default;
+  const app = express();
+  app.use(express.json());
+  app.use("/api/decisions", router);
+  return app;
+}
+
+describe("decisionRoutes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    resetFakeDb();
+    mockUser = { id: "landlord-1", landlordId: "landlord-1", role: "landlord", email: "landlord@example.com" };
+  });
+
+  it("returns lease-scoped derived decisions with action overlays", async () => {
+    seedLease();
+    seedDoc("decisionActions", "action-1", {
+      actionId: "action-1",
+      decisionId: "decision:review_missing_payment:decision:missing_payment:obligation:lease-1",
+      leaseId: "lease-1",
+      landlordId: "landlord-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      actionType: "reviewed",
+      previousStatus: "detected",
+      nextStatus: "reviewed",
+      actorId: "landlord-1",
+      createdAt: "2026-05-05T12:00:00.000Z",
+    });
+
+    const app = await makeApp();
+    const res = await request(app).get("/api/decisions?leaseId=lease-1");
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.decisions.length).toBeGreaterThan(0);
+    expect(res.body.decisions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          decisionType: "review_missing_payment",
+        }),
+      ])
+    );
+  });
+
+  it("persists decision action records without mutating lease documents", async () => {
+    seedLease();
+    const app = await makeApp();
+
+    const listRes = await request(app).get("/api/decisions?leaseId=lease-1");
+    const decision = listRes.body.decisions.find((row: any) => row.decisionType === "review_missing_payment");
+    expect(decision).toBeTruthy();
+
+    const res = await request(app)
+      .patch(`/api/decisions/${encodeURIComponent(decision.decisionId)}/action`)
+      .send({ leaseId: "lease-1", actionType: "reviewed", note: "Reviewed by operator" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.action).toEqual(
+      expect.objectContaining({
+        decisionId: decision.decisionId,
+        leaseId: "lease-1",
+        actionType: "reviewed",
+        nextStatus: "reviewed",
+        note: "Reviewed by operator",
+      })
+    );
+    expect(listDocs("decisionActions")).toHaveLength(1);
+    expect(listDocs("leases")).toEqual([
+      expect.objectContaining({
+        landlordId: "landlord-1",
+        status: "active",
+      }),
+    ]);
+  });
+
+  it("blocks landlord access to leases outside their scope", async () => {
+    seedLease({ landlordId: "landlord-2" });
+    const app = await makeApp();
+
+    const res = await request(app).get("/api/decisions?leaseId=lease-1");
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/rentchain-api/src/routes/decisionRoutes.ts
+++ b/rentchain-api/src/routes/decisionRoutes.ts
@@ -1,0 +1,259 @@
+import { Router, Response } from "express";
+import { db } from "../config/firebase";
+import { requireAuth } from "../middleware/requireAuth";
+import { deriveDecisions, type Decision } from "../lib/decisions/decisionEngine";
+import {
+  applyDecisionActions,
+  buildDecisionAction,
+  DECISION_ACTIONS_COLLECTION,
+  decisionActionRecordId,
+  parseDecisionActionPatch,
+} from "../lib/decisions/decisionActions";
+import { deriveLeaseLifecycleState } from "../lib/leases/leaseLifecycle";
+import {
+  buildPaymentObligationLedgerRows,
+  summarizePaymentObligationLedger,
+} from "../lib/payments/paymentObligationLedger";
+import {
+  deriveDelinquencySignals,
+  summarizeDelinquencySignals,
+} from "../lib/payments/delinquencySignals";
+import type { RentPaymentRecord } from "../services/rentPayments/rentPaymentService";
+
+const router = Router();
+
+function asString(value: unknown, max = 1000) {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function isAdmin(req: any) {
+  const role = asString(req.user?.role, 80).toLowerCase();
+  return role === "admin" || role === "system.admin";
+}
+
+function landlordIdFromReq(req: any) {
+  return asString(req.user?.landlordId || req.user?.id || req.user?.sub, 240) || null;
+}
+
+function actorIdFromReq(req: any) {
+  return asString(req.user?.uid || req.user?.id || req.user?.sub, 240) || null;
+}
+
+function actorEmailFromReq(req: any) {
+  return asString(req.user?.email, 320) || null;
+}
+
+async function loadLeaseForDecisionAccess(req: any, leaseId: string) {
+  const snap = await db.collection("leases").doc(leaseId).get();
+  if (!snap.exists) return { ok: false as const, status: 404, error: "decision_lease_not_found" };
+  const lease = { id: snap.id, ...((snap.data() as any) || {}) };
+  const leaseLandlordId = asString((lease as any).landlordId, 240);
+  if (!isAdmin(req) && leaseLandlordId !== landlordIdFromReq(req)) {
+    return { ok: false as const, status: 403, error: "decision_forbidden" };
+  }
+  return { ok: true as const, lease, landlordId: leaseLandlordId || landlordIdFromReq(req) };
+}
+
+function normalizeLeaseRentAmountCents(value: unknown): number {
+  const amount = Number(value);
+  if (!Number.isFinite(amount) || amount <= 0) return 0;
+  return Math.round(amount * 100);
+}
+
+async function loadLeaseRentPayments(leaseId: string, landlordId: string | null): Promise<RentPaymentRecord[]> {
+  const snap = await db.collection("rentPayments").where("leaseId", "==", leaseId).get().catch(() => null);
+  return (snap?.docs || [])
+    .map((doc: any) => ({ id: doc.id, ...((doc.data() as any) || {}) }))
+    .filter((record: any) => !landlordId || asString(record?.landlordId, 240) === landlordId)
+    .map((record: any) => ({
+      id: asString(record?.id || record?.rentPaymentId || record?.paymentId || "", 240) || asString(record?.id, 240),
+      leaseId: asString(record?.leaseId, 240),
+      tenantId: asString(record?.tenantId, 240),
+      landlordId: asString(record?.landlordId, 240),
+      propertyId: asString(record?.propertyId, 240) || null,
+      unitId: asString(record?.unitId, 240) || null,
+      paymentIntentId: asString(record?.paymentIntentId, 240) || null,
+      amountCents: Math.max(0, Math.round(Number(record?.amountCents || 0))),
+      currency: "cad" as const,
+      status: asString(record?.status || "setup_required", 80) as RentPaymentRecord["status"],
+      processor: "stripe" as const,
+      processorCheckoutSessionId: asString(record?.processorCheckoutSessionId, 240) || null,
+      processorPaymentIntentId: asString(record?.processorPaymentIntentId, 240) || null,
+      createdAt: asString(record?.createdAt, 120),
+      updatedAt: asString(record?.updatedAt, 120),
+      paidAt: asString(record?.paidAt, 120) || null,
+    }));
+}
+
+async function loadLeasePaymentIntents(leaseId: string, landlordId: string | null) {
+  const snap = await db.collection("paymentIntents").where("leaseId", "==", leaseId).get().catch(() => null);
+  return (snap?.docs || [])
+    .map((doc: any) => ({ paymentIntentId: doc.id, ...((doc.data() as any) || {}) }))
+    .filter((record: any) => !landlordId || asString(record?.landlordId, 240) === landlordId);
+}
+
+async function loadLeaseReconciliationRecords(params: {
+  leaseId: string;
+  paymentIntentIds: string[];
+  rentPaymentIds: string[];
+}) {
+  const records = new Map<string, any>();
+  async function collect(field: string, value: string) {
+    const normalized = asString(value, 240);
+    if (!normalized) return;
+    const snap = await db.collection("paymentReconciliationRecords").where(field, "==", normalized).get().catch(() => null);
+    for (const doc of snap?.docs || []) {
+      records.set(doc.id, { reconciliationId: doc.id, ...((doc.data() as any) || {}) });
+    }
+  }
+  await collect("leaseId", params.leaseId);
+  await collect("subjectId", params.leaseId);
+  for (const paymentIntentId of params.paymentIntentIds) await collect("paymentIntentId", paymentIntentId);
+  for (const rentPaymentId of params.rentPaymentIds) {
+    await collect("rentPaymentId", rentPaymentId);
+    await collect("subjectId", rentPaymentId);
+  }
+  return Array.from(records.values());
+}
+
+async function loadDecisionActionsForLease(leaseId: string) {
+  const snap = await db.collection(DECISION_ACTIONS_COLLECTION).where("leaseId", "==", leaseId).get().catch(() => null);
+  return (snap?.docs || []).map((doc: any) => ({ id: doc.id, ...((doc.data() as any) || {}) }));
+}
+
+async function deriveLeaseDecisionReadModel(req: any, leaseId: string) {
+  const access = await loadLeaseForDecisionAccess(req, leaseId);
+  if (!access.ok) return access;
+  const { lease, landlordId } = access;
+  const [rentPayments, paymentIntents] = await Promise.all([
+    loadLeaseRentPayments(leaseId, landlordId),
+    loadLeasePaymentIntents(leaseId, landlordId),
+  ]);
+  const reconciliationRecords = await loadLeaseReconciliationRecords({
+    leaseId,
+    paymentIntentIds: paymentIntents.map((record: any) => asString(record?.paymentIntentId, 240)).filter(Boolean),
+    rentPaymentIds: rentPayments.map((record) => asString(record?.id, 240)).filter(Boolean),
+  });
+  const lifecycle = deriveLeaseLifecycleState({ id: leaseId, ...lease });
+  const obligationRows = buildPaymentObligationLedgerRows({
+    leases: [
+      {
+        ...lease,
+        id: leaseId,
+        amountCents: normalizeLeaseRentAmountCents((lease as any)?.monthlyRent),
+        derivedLifecycleState: lifecycle.state,
+      },
+    ],
+    paymentIntents,
+    rentPayments,
+    reconciliationRecords,
+  });
+  const delinquencySignals = deriveDelinquencySignals(obligationRows);
+  const decisions = deriveDecisions({
+    delinquencySignals,
+    leaseLifecycle: {
+      ...lifecycle,
+      leaseId,
+      propertyId: asString((lease as any).propertyId, 240) || null,
+      unitId: asString((lease as any).unitId, 240) || null,
+      tenantId: asString((lease as any).tenantId || (lease as any).primaryTenantId, 240) || null,
+    },
+    obligationRows,
+  });
+  const actions = await loadDecisionActionsForLease(leaseId);
+  return {
+    ok: true as const,
+    lease,
+    landlordId,
+    decisions: applyDecisionActions(decisions, actions),
+    actions,
+    obligationRows,
+    obligationSummary: summarizePaymentObligationLedger(obligationRows),
+    delinquencySignals,
+    delinquencySummary: summarizeDelinquencySignals(delinquencySignals),
+  };
+}
+
+function fallbackDecisionFromBody(body: any, decisionId: string, lease: any): Decision | null {
+  const raw = body?.decision || {};
+  const decisionType = asString(raw.decisionType, 80) as Decision["decisionType"];
+  const severity = asString(raw.severity, 40) as Decision["severity"];
+  const reason = asString(raw.reason, 1000);
+  if (!decisionType || !severity || !reason) return null;
+  return {
+    decisionId,
+    leaseId: asString(raw.leaseId || lease.id, 240),
+    paymentIntentId: asString(raw.paymentIntentId, 240) || null,
+    rentPaymentId: asString(raw.rentPaymentId, 240) || null,
+    propertyId: asString(raw.propertyId || lease.propertyId, 240) || null,
+    unitId: asString(raw.unitId || lease.unitId, 240) || null,
+    tenantId: asString(raw.tenantId || lease.tenantId || lease.primaryTenantId, 240) || null,
+    decisionType,
+    severity,
+    status: "detected",
+    reason,
+    metadata: typeof raw.metadata === "object" && raw.metadata ? raw.metadata : { source: "decision_action_request" },
+    createdAt: asString(raw.createdAt, 120) || new Date().toISOString(),
+    updatedAt: asString(raw.updatedAt, 120) || new Date().toISOString(),
+  };
+}
+
+router.get("/", requireAuth, async (req: any, res: Response) => {
+  try {
+    const leaseId = asString(req.query?.leaseId, 240);
+    if (!leaseId) return res.status(400).json({ ok: false, error: "decision_lease_id_required" });
+    const model = await deriveLeaseDecisionReadModel(req, leaseId);
+    if (!model.ok) return res.status(model.status).json({ ok: false, error: model.error });
+    return res.json({
+      ok: true,
+      decisions: model.decisions,
+      actions: model.actions,
+      summary: {
+        total: model.decisions.length,
+        critical: model.decisions.filter((decision) => decision.severity === "critical").length,
+        warning: model.decisions.filter((decision) => decision.severity === "warning").length,
+        info: model.decisions.filter((decision) => decision.severity === "info").length,
+      },
+    });
+  } catch (err: any) {
+    console.error("[decisionRoutes] GET /api/decisions failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "decision_list_failed" });
+  }
+});
+
+router.patch("/:decisionId/action", requireAuth, async (req: any, res: Response) => {
+  try {
+    const decisionId = decodeURIComponent(asString(req.params?.decisionId, 600));
+    const leaseId = asString(req.body?.leaseId || req.body?.decision?.leaseId, 240);
+    const patch = parseDecisionActionPatch(req.body);
+    if (!decisionId || !leaseId || !patch) {
+      return res.status(400).json({ ok: false, error: "decision_action_invalid" });
+    }
+
+    const model = await deriveLeaseDecisionReadModel(req, leaseId);
+    if (!model.ok) return res.status(model.status).json({ ok: false, error: model.error });
+    const existingActions = model.actions;
+    const decision =
+      model.decisions.find((candidate) => candidate.decisionId === decisionId) ||
+      fallbackDecisionFromBody(req.body, decisionId, model.lease);
+    if (!decision) return res.status(404).json({ ok: false, error: "decision_not_found" });
+
+    const action = buildDecisionAction({
+      decision,
+      patch,
+      existingActions,
+      landlordId: model.landlordId,
+      actorId: actorIdFromReq(req),
+      actorEmail: actorEmailFromReq(req),
+    });
+    await db.collection(DECISION_ACTIONS_COLLECTION).doc(decisionActionRecordId(action)).set(action, { merge: false });
+    const merged = applyDecisionActions([decision], [...existingActions, action])[0];
+
+    return res.json({ ok: true, action, decision: merged });
+  } catch (err: any) {
+    console.error("[decisionRoutes] PATCH /api/decisions/:decisionId/action failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "decision_action_failed" });
+  }
+});
+
+export default router;

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -40,6 +40,11 @@ import {
   deriveDelinquencySignals,
   summarizeDelinquencySignals,
 } from "../lib/payments/delinquencySignals";
+import { deriveDecisions } from "../lib/decisions/decisionEngine";
+import {
+  applyDecisionActions,
+  DECISION_ACTIONS_COLLECTION,
+} from "../lib/decisions/decisionActions";
 import {
   isTargetedHiddenLeaseId,
   isTargetedHiddenTenantId,
@@ -852,6 +857,11 @@ async function loadLeaseReconciliationRecordsForObligationLedger(params: {
     await collect("subjectId", rentPaymentId);
   }
   return Array.from(records.values());
+}
+
+async function loadLeaseDecisionActions(leaseId: string) {
+  const snap = await db.collection(DECISION_ACTIONS_COLLECTION).where("leaseId", "==", leaseId).get().catch(() => null);
+  return (snap?.docs || []).map((doc: any) => ({ id: doc.id, ...((doc.data() as any) || {}) }));
 }
 
 function enrichLeaseLedgerEntryWithPaymentIntent(
@@ -2452,6 +2462,22 @@ router.get("/:leaseId/ledger", async (req: any, res: Response) => {
       reconciliationRecords: obligationReconciliationRecords,
     });
     const delinquencySignals = deriveDelinquencySignals(obligationRows);
+    const decisionActions = await loadLeaseDecisionActions(leaseId);
+    const leaseLifecycle = deriveLeaseLifecycleState({ id: leaseId, ...(leaseCheck.lease as any) });
+    const decisions = applyDecisionActions(
+      deriveDecisions({
+        delinquencySignals,
+        leaseLifecycle: {
+          ...leaseLifecycle,
+          leaseId,
+          propertyId: String((leaseCheck.lease as any)?.propertyId || "").trim() || null,
+          unitId: String((leaseCheck.lease as any)?.unitId || "").trim() || null,
+          tenantId: String((leaseCheck.lease as any)?.tenantId || (leaseCheck.lease as any)?.primaryTenantId || "").trim() || null,
+        },
+        obligationRows,
+      }),
+      decisionActions
+    );
 
     let runningBalanceCents = 0;
     const monthlyTotals: Record<string, { chargesCents: number; paymentsCents: number; netCents: number }> = {};
@@ -2496,6 +2522,7 @@ router.get("/:leaseId/ledger", async (req: any, res: Response) => {
       obligationSummary: summarizePaymentObligationLedger(obligationRows),
       delinquencySignals,
       delinquencySummary: summarizeDelinquencySignals(delinquencySignals),
+      decisions,
     });
   } catch (err) {
     console.error("[GET /api/leases/:leaseId/ledger] error", err);

--- a/rentchain-frontend/src/api/decisionApi.ts
+++ b/rentchain-frontend/src/api/decisionApi.ts
@@ -1,0 +1,24 @@
+import { apiFetch } from "./apiFetch";
+import type { DecisionActionType, DecisionItem } from "@/lib/decisions/decisionDisplay";
+
+export type DecisionActionPayload = {
+  leaseId: string;
+  actionType: DecisionActionType;
+  note?: string | null;
+  assignedTo?: string | null;
+  snoozedUntil?: string | null;
+  decision?: DecisionItem;
+};
+
+export async function patchDecisionAction(decisionId: string, payload: DecisionActionPayload) {
+  return apiFetch(`/decisions/${encodeURIComponent(decisionId)}/action`, {
+    method: "PATCH",
+    body: payload,
+  });
+}
+
+export async function getLeaseDecisions(leaseId: string) {
+  return apiFetch(`/decisions?leaseId=${encodeURIComponent(leaseId)}`, {
+    method: "GET",
+  });
+}

--- a/rentchain-frontend/src/api/leaseLedgerApi.ts
+++ b/rentchain-frontend/src/api/leaseLedgerApi.ts
@@ -1,5 +1,6 @@
 import { apiFetch } from "./apiFetch";
 import { API_BASE_URL } from "./config";
+import type { DecisionItem } from "@/lib/decisions/decisionDisplay";
 
 export type LeaseLedgerEntry = {
   id: string;
@@ -122,6 +123,7 @@ export type LeaseLedgerResponse = {
   obligationSummary?: LeaseObligationLedgerSummary;
   delinquencySignals?: LeaseDelinquencySignal[];
   delinquencySummary?: LeaseDelinquencySummary;
+  decisions?: DecisionItem[];
 };
 
 export async function fetchLeaseLedger(

--- a/rentchain-frontend/src/lib/decisions/decisionDisplay.ts
+++ b/rentchain-frontend/src/lib/decisions/decisionDisplay.ts
@@ -10,7 +10,30 @@ export type DecisionType =
   | "review_occupancy_conflict";
 
 export type DecisionSeverity = "info" | "warning" | "critical";
-export type DecisionStatus = "detected" | "surfaced" | "reviewed" | "accepted" | "dismissed" | "resolved";
+export type DecisionActionType = "reviewed" | "snoozed" | "assigned" | "dismissed" | "resolved";
+export type DecisionStatus =
+  | "detected"
+  | "surfaced"
+  | "reviewed"
+  | "snoozed"
+  | "assigned"
+  | "accepted"
+  | "dismissed"
+  | "resolved";
+
+export type DecisionAction = {
+  actionId: string;
+  decisionId: string;
+  actionType: DecisionActionType;
+  previousStatus?: DecisionStatus;
+  nextStatus: DecisionStatus;
+  note?: string | null;
+  assignedTo?: string | null;
+  snoozedUntil?: string | null;
+  actorId?: string | null;
+  actorEmail?: string | null;
+  createdAt: string;
+};
 
 export type DecisionItem = {
   decisionId: string;
@@ -27,6 +50,7 @@ export type DecisionItem = {
   metadata?: Record<string, unknown>;
   createdAt?: string | null;
   updatedAt?: string | null;
+  latestAction?: DecisionAction | null;
 };
 
 export type DecisionSummary = {
@@ -56,6 +80,17 @@ export const decisionSeverityStyle: Record<DecisionSeverity, { bg: string; color
   critical: { bg: "#fee2e2", color: "#991b1b", border: "#fecaca" },
   warning: { bg: "#ffedd5", color: "#9a3412", border: "#fed7aa" },
   info: { bg: "#f1f5f9", color: "#334155", border: "#cbd5e1" },
+};
+
+export const decisionStatusCopy: Record<DecisionStatus, string> = {
+  detected: "Detected",
+  surfaced: "Surfaced",
+  reviewed: "Reviewed",
+  snoozed: "Snoozed",
+  assigned: "Assigned",
+  accepted: "Accepted",
+  dismissed: "Dismissed",
+  resolved: "Resolved",
 };
 
 const delinquencyDecisionMap: Record<
@@ -102,6 +137,7 @@ export function normalizeDecisionItems(value: unknown): DecisionItem[] {
       metadata: item.metadata || {},
       createdAt: item.createdAt || null,
       updatedAt: item.updatedAt || null,
+      latestAction: item.latestAction || null,
     }));
 }
 

--- a/rentchain-frontend/src/pages/DashboardPage.test.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import { ToastProvider } from "../components/ui/ToastProvider";
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   useOnboardingStateMock: vi.fn(),
   useUpgradeMock: vi.fn(),
   navigateMock: vi.fn(),
+  patchDecisionActionMock: vi.fn(),
 }));
 
 vi.mock("react-router-dom", async () => {
@@ -82,6 +83,10 @@ vi.mock("../config/screening", () => ({
   screeningComingSoonLabel: () => "Credit screening - coming soon.",
 }));
 
+vi.mock("@/api/decisionApi", () => ({
+  patchDecisionAction: mocks.patchDecisionActionMock,
+}));
+
 afterEach(() => {
   cleanup();
 });
@@ -117,6 +122,20 @@ describe("DashboardPage", () => {
       loading: false,
     });
     mocks.fetchDashboardSummaryMock.mockResolvedValue({});
+    mocks.patchDecisionActionMock.mockImplementation(async (_decisionId: string, payload: any) => ({
+      ok: true,
+      decision: {
+        ...payload.decision,
+        status: payload.actionType === "reviewed" ? "reviewed" : payload.actionType,
+        latestAction: {
+          actionId: "action-1",
+          decisionId: payload.decision.decisionId,
+          actionType: payload.actionType,
+          nextStatus: payload.actionType === "reviewed" ? "reviewed" : payload.actionType,
+          createdAt: "2026-05-05T12:00:00.000Z",
+        },
+      },
+    }));
     mocks.useApplicationsMock.mockReturnValue({
       applications: [],
       loading: false,
@@ -306,6 +325,43 @@ describe("DashboardPage", () => {
     expect(screen.getByText("Partial payment received")).toBeInTheDocument();
     expect(screen.getAllByText("Manual Review").length).toBeGreaterThan(0);
     expect(screen.getByText("Payment mismatch detected")).toBeInTheDocument();
+  });
+
+  it("updates dashboard decision status from human actions", async () => {
+    mocks.fetchDashboardSummaryMock.mockResolvedValue({
+      decisions: [
+        {
+          decisionId: "decision:review_overdue_rent:lease-1",
+          leaseId: "lease-1",
+          propertyId: "property-1",
+          unitId: "unit-1",
+          decisionType: "review_overdue_rent",
+          severity: "critical",
+          status: "detected",
+          reason: "Rent past due date",
+          metadata: {},
+        },
+      ],
+    });
+
+    render(
+      <ToastProvider>
+        <MemoryRouter>
+          <DashboardPage />
+        </MemoryRouter>
+      </ToastProvider>
+    );
+
+    expect(await screen.findByText("Overdue Rent")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Mark reviewed" }));
+
+    await waitFor(() =>
+      expect(mocks.patchDecisionActionMock).toHaveBeenCalledWith(
+        "decision:review_overdue_rent:lease-1",
+        expect.objectContaining({ actionType: "reviewed", leaseId: "lease-1" })
+      )
+    );
+    expect(screen.getByText("Reviewed")).toBeInTheDocument();
   });
 
   it("renders an empty dashboard decision state without adding actions", async () => {

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -44,10 +44,13 @@ import { clearPostUpgradeState, getPostUpgradeContent, getPostUpgradeState } fro
 import {
   decisionDisplayCopy,
   decisionSeverityStyle,
+  decisionStatusCopy,
   normalizeDecisionItems,
   summarizeDecisionItems,
+  type DecisionActionType,
   type DecisionItem,
 } from "@/lib/decisions/decisionDisplay";
+import { patchDecisionAction } from "@/api/decisionApi";
 
 const StarterOnboardingPanel = React.lazy(
   () => import("../components/dashboard/StarterOnboardingPanel")
@@ -115,7 +118,29 @@ function formatDate(ts: number | null): string {
   }
 }
 
-function DashboardDecisionSummaryPanel({ decisions }: { decisions: DecisionItem[] }) {
+function localDecisionStatus(decision: DecisionItem, actionType: DecisionActionType): DecisionItem {
+  const status =
+    actionType === "reviewed"
+      ? "reviewed"
+      : actionType === "snoozed"
+      ? "snoozed"
+      : actionType === "assigned"
+      ? "assigned"
+      : actionType === "dismissed"
+      ? "dismissed"
+      : "resolved";
+  return { ...decision, status };
+}
+
+function DashboardDecisionSummaryPanel({
+  decisions,
+  pendingId,
+  onAction,
+}: {
+  decisions: DecisionItem[];
+  pendingId: string | null;
+  onAction: (decision: DecisionItem, actionType: DecisionActionType) => void;
+}) {
   const summary = summarizeDecisionItems(decisions);
   const cells = [
     { label: "Overdue", value: summary.overdue, severity: "critical" as const },
@@ -154,12 +179,40 @@ function DashboardDecisionSummaryPanel({ decisions }: { decisions: DecisionItem[
               const copy = decisionDisplayCopy[decision.decisionType];
               const tone = decisionSeverityStyle[decision.severity];
               return (
-                <div key={decision.decisionId} style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center", color: text.primary }}>
+                <div key={decision.decisionId} style={{ display: "grid", gap: 6, color: text.primary, borderTop: `1px solid ${colors.border}`, paddingTop: 8 }}>
+                  <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
                   <span style={{ border: `1px solid ${tone.border}`, background: tone.bg, color: tone.color, borderRadius: 999, padding: "2px 8px", fontSize: 12, fontWeight: 800 }}>
                     {copy.badge}
                   </span>
+                    <span style={{ border: "1px solid #cbd5e1", borderRadius: 999, padding: "2px 8px", fontSize: 12, fontWeight: 800 }}>
+                      {decisionStatusCopy[decision.status || "detected"]}
+                    </span>
                   <span>{copy.label}</span>
                   <span style={{ color: text.muted }}>{decision.reason}</span>
+                  </div>
+                  <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+                    {(["reviewed", "snoozed", "assigned", "dismissed", "resolved"] as DecisionActionType[]).map((actionType) => (
+                      <button
+                        key={actionType}
+                        type="button"
+                        disabled={pendingId === decision.decisionId || !decision.leaseId}
+                        onClick={() => onAction(decision, actionType)}
+                        style={{ border: "1px solid #cbd5e1", background: "#fff", borderRadius: 8, padding: "5px 8px", fontWeight: 700 }}
+                      >
+                        {pendingId === decision.decisionId
+                          ? "Saving..."
+                          : actionType === "reviewed"
+                          ? "Mark reviewed"
+                          : actionType === "snoozed"
+                          ? "Snooze"
+                          : actionType === "assigned"
+                          ? "Assign"
+                          : actionType === "dismissed"
+                          ? "Dismiss"
+                          : "Resolve"}
+                      </button>
+                    ))}
+                  </div>
                 </div>
               );
             })}
@@ -173,6 +226,8 @@ function DashboardDecisionSummaryPanel({ decisions }: { decisions: DecisionItem[
 const DashboardPage: React.FC = () => {
   // Guardrail: declare derived values used in hook deps above the hooks that depend on them.
   const [data, setData] = React.useState<any | null>(null);
+  const [decisionRows, setDecisionRows] = React.useState<DecisionItem[]>([]);
+  const [decisionActionPendingId, setDecisionActionPendingId] = React.useState<string | null>(null);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
   const [lastUpdatedAt, setLastUpdatedAt] = React.useState<number | null>(null);
@@ -236,6 +291,7 @@ const DashboardPage: React.FC = () => {
     try {
       const summary = await fetchDashboardSummary();
       setData(summary);
+      setDecisionRows(normalizeDecisionItems((summary as any)?.decisions));
       setLastUpdatedAt(Date.now());
     } catch (err: any) {
       setError(err?.message || "Failed to load dashboard");
@@ -496,7 +552,27 @@ const DashboardPage: React.FC = () => {
         ? "No onboarding drop-off right now."
         : "No onboarding starts recorded yet.";
   const events = Array.isArray(data?.events) ? data.events : [];
-  const dashboardDecisions = React.useMemo(() => normalizeDecisionItems(data?.decisions), [data?.decisions]);
+  const dashboardDecisions = decisionRows;
+
+  const handleDashboardDecisionAction = async (decision: DecisionItem, actionType: DecisionActionType) => {
+    if (!decision.leaseId) return;
+    setDecisionActionPendingId(decision.decisionId);
+    try {
+      const result = await patchDecisionAction(decision.decisionId, {
+        leaseId: decision.leaseId,
+        actionType,
+        decision,
+        assignedTo: actionType === "assigned" ? "operations" : undefined,
+        snoozedUntil: actionType === "snoozed" ? new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString() : undefined,
+      });
+      const nextDecision = result?.decision || localDecisionStatus(decision, actionType);
+      setDecisionRows((current) => current.map((item) => (item.decisionId === decision.decisionId ? nextDecision : item)));
+    } catch (err) {
+      showToast("Unable to update decision right now.", "error");
+    } finally {
+      setDecisionActionPendingId(null);
+    }
+  };
 
   React.useEffect(() => {
     if (location.hash !== "#open-actions") return;
@@ -724,7 +800,13 @@ const DashboardPage: React.FC = () => {
             }}
           />
         ) : null}
-        {dataReady ? <DashboardDecisionSummaryPanel decisions={dashboardDecisions} /> : null}
+        {dataReady ? (
+          <DashboardDecisionSummaryPanel
+            decisions={dashboardDecisions}
+            pendingId={decisionActionPendingId}
+            onAction={handleDashboardDecisionAction}
+          />
+        ) : null}
         {dataReady ? (
           <div style={{ marginTop: spacing.md }}>
             <PortfolioCredibilitySummaryCard

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   createLeaseNote: vi.fn(),
   archiveLeaseRecord: vi.fn(),
   restoreLeaseRecord: vi.fn(),
+  patchDecisionAction: vi.fn(),
 }));
 
 vi.mock("../api/leaseLedgerApi", () => ({
@@ -28,6 +29,10 @@ vi.mock("@/api/leasesApi", () => ({
   createLeaseNote: mocks.createLeaseNote,
   archiveLeaseRecord: mocks.archiveLeaseRecord,
   restoreLeaseRecord: mocks.restoreLeaseRecord,
+}));
+
+vi.mock("@/api/decisionApi", () => ({
+  patchDecisionAction: mocks.patchDecisionAction,
 }));
 
 vi.mock("../lib/authToken", () => ({
@@ -294,6 +299,70 @@ describe("LeaseLedgerPage", () => {
         manualReviewCount: 1,
         totalOutstandingCents: 425000,
       },
+      decisions: [
+        {
+          decisionId: "decision-overdue",
+          leaseId: "lease-1",
+          propertyId: "prop-1",
+          unitId: "unit-1",
+          tenantId: "tenant-1",
+          decisionType: "review_overdue_rent",
+          severity: "critical",
+          status: "detected",
+          reason: "Rent past due date",
+          metadata: {},
+          createdAt: "2026-05-05T00:00:00.000Z",
+          updatedAt: "2026-05-05T00:00:00.000Z",
+        },
+        {
+          decisionId: "decision-underpaid",
+          leaseId: "lease-1",
+          propertyId: "prop-1",
+          decisionType: "review_underpaid_rent",
+          severity: "warning",
+          status: "detected",
+          reason: "Partial payment received",
+          metadata: {},
+          createdAt: "2026-05-05T00:00:00.000Z",
+          updatedAt: "2026-05-05T00:00:00.000Z",
+        },
+        {
+          decisionId: "decision-missing",
+          leaseId: "lease-1",
+          propertyId: "prop-1",
+          decisionType: "review_missing_payment",
+          severity: "critical",
+          status: "detected",
+          reason: "Expected rent payment is missing",
+          metadata: {},
+          createdAt: "2026-05-05T00:00:00.000Z",
+          updatedAt: "2026-05-05T00:00:00.000Z",
+        },
+        {
+          decisionId: "decision-failed",
+          leaseId: "lease-1",
+          propertyId: "prop-1",
+          decisionType: "review_failed_payment",
+          severity: "critical",
+          status: "detected",
+          reason: "Payment did not complete",
+          metadata: {},
+          createdAt: "2026-05-05T00:00:00.000Z",
+          updatedAt: "2026-05-05T00:00:00.000Z",
+        },
+        {
+          decisionId: "decision-manual",
+          leaseId: "lease-1",
+          propertyId: "prop-1",
+          decisionType: "review_manual_payment_issue",
+          severity: "warning",
+          status: "detected",
+          reason: "Payment mismatch detected",
+          metadata: {},
+          createdAt: "2026-05-05T00:00:00.000Z",
+          updatedAt: "2026-05-05T00:00:00.000Z",
+        },
+      ],
     });
     mocks.getLeaseById.mockResolvedValue({
       lease: {
@@ -324,6 +393,20 @@ describe("LeaseLedgerPage", () => {
     });
     mocks.archiveLeaseRecord.mockResolvedValue({ ok: true, lease: { id: "lease-1", archivedAt: "2026-04-01T00:00:00.000Z" } });
     mocks.restoreLeaseRecord.mockResolvedValue({ ok: true, lease: { id: "lease-1", archivedAt: null } });
+    mocks.patchDecisionAction.mockImplementation(async (_decisionId: string, payload: any) => ({
+      ok: true,
+      decision: {
+        ...payload.decision,
+        status: payload.actionType === "reviewed" ? "reviewed" : payload.actionType,
+        latestAction: {
+          actionId: "action-1",
+          decisionId: payload.decision.decisionId,
+          actionType: payload.actionType,
+          nextStatus: payload.actionType === "reviewed" ? "reviewed" : payload.actionType,
+          createdAt: "2026-05-05T12:00:00.000Z",
+        },
+      },
+    }));
     vi.spyOn(window, "confirm").mockReturnValue(true);
   });
 
@@ -446,6 +529,22 @@ describe("LeaseLedgerPage", () => {
     expect(screen.getByText("Payment did not complete")).toBeInTheDocument();
     expect(screen.getAllByText("Manual Review").length).toBeGreaterThan(0);
     expect(screen.getByText("Payment mismatch detected")).toBeInTheDocument();
+  });
+
+  it("updates lease decision status from human actions", async () => {
+    render(
+      <MemoryRouter initialEntries={["/leases/lease-1/ledger"]}>
+        <Routes>
+          <Route path="/leases/:leaseId/ledger" element={<LeaseLedgerPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Overdue Rent")).toBeInTheDocument();
+    fireEvent.click(screen.getAllByRole("button", { name: "Mark reviewed" })[0]);
+
+    await waitFor(() => expect(mocks.patchDecisionAction).toHaveBeenCalledWith("decision-overdue", expect.objectContaining({ actionType: "reviewed" })));
+    expect(screen.getAllByText("Reviewed").length).toBeGreaterThan(0);
   });
 
   it("renders an empty obligation state while preserving existing ledger entries", async () => {

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
@@ -13,6 +13,7 @@ import {
   type LeaseLedgerEntry,
   type PaymentObligationStatus,
 } from "../api/leaseLedgerApi";
+import { patchDecisionAction } from "@/api/decisionApi";
 import { getAuthToken } from "../lib/authToken";
 import { getFirebaseIdToken } from "../lib/firebaseAuthToken";
 import {
@@ -27,8 +28,9 @@ import {
 import {
   decisionDisplayCopy,
   decisionSeverityStyle,
-  deriveDecisionItemsFromDelinquencySignals,
+  decisionStatusCopy,
   summarizeDecisionItems,
+  type DecisionActionType,
   type DecisionItem,
   type DecisionSeverity,
 } from "@/lib/decisions/decisionDisplay";
@@ -180,7 +182,73 @@ function DecisionBadge({ severity, label }: { severity: DecisionSeverity; label:
   );
 }
 
-function DecisionRow({ decision }: { decision: DecisionItem }) {
+function decisionWithStatus(decision: DecisionItem, actionType: DecisionActionType): DecisionItem {
+  const nextStatus =
+    actionType === "reviewed"
+      ? "reviewed"
+      : actionType === "snoozed"
+      ? "snoozed"
+      : actionType === "assigned"
+      ? "assigned"
+      : actionType === "dismissed"
+      ? "dismissed"
+      : "resolved";
+  return {
+    ...decision,
+    status: nextStatus,
+    latestAction: {
+      actionId: `local-${decision.decisionId}-${actionType}`,
+      decisionId: decision.decisionId,
+      actionType,
+      previousStatus: decision.status || "detected",
+      nextStatus,
+      createdAt: new Date().toISOString(),
+    },
+  };
+}
+
+function DecisionActionControls({
+  decision,
+  pending,
+  onAction,
+}: {
+  decision: DecisionItem;
+  pending: boolean;
+  onAction: (decision: DecisionItem, actionType: DecisionActionType) => void;
+}) {
+  const actions: Array<{ actionType: DecisionActionType; label: string }> = [
+    { actionType: "reviewed", label: "Mark reviewed" },
+    { actionType: "snoozed", label: "Snooze" },
+    { actionType: "assigned", label: "Assign" },
+    { actionType: "dismissed", label: "Dismiss" },
+    { actionType: "resolved", label: "Resolve" },
+  ];
+  return (
+    <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+      {actions.map((action) => (
+        <button
+          key={action.actionType}
+          type="button"
+          disabled={pending}
+          onClick={() => onAction(decision, action.actionType)}
+          style={{ border: "1px solid #cbd5e1", background: "#fff", borderRadius: 8, padding: "6px 9px", fontWeight: 700 }}
+        >
+          {pending ? "Saving..." : action.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function DecisionRow({
+  decision,
+  pending,
+  onAction,
+}: {
+  decision: DecisionItem;
+  pending: boolean;
+  onAction: (decision: DecisionItem, actionType: DecisionActionType) => void;
+}) {
   const copy = decisionDisplayCopy[decision.decisionType];
   const context = [
     decision.unitId ? `Unit ${decision.unitId}` : null,
@@ -190,10 +258,17 @@ function DecisionRow({ decision }: { decision: DecisionItem }) {
     <div style={{ border: "1px solid #e2e8f0", borderRadius: 12, padding: 12, background: "#fff", display: "grid", gap: 6 }}>
       <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
         <DecisionBadge severity={decision.severity} label={copy.badge} />
+        <span style={{ border: "1px solid #cbd5e1", borderRadius: 999, padding: "3px 8px", fontSize: 12, fontWeight: 800 }}>
+          {decisionStatusCopy[decision.status || "detected"]}
+        </span>
         <strong>{copy.label}</strong>
       </div>
       <div style={{ color: "#475569" }}>{decision.reason}</div>
       {context.length ? <div style={{ color: "#64748b", fontSize: 12 }}>{context.join(" · ")}</div> : null}
+      {decision.latestAction ? (
+        <div style={{ color: "#64748b", fontSize: 12 }}>Last action: {decisionStatusCopy[decision.latestAction.nextStatus]}</div>
+      ) : null}
+      <DecisionActionControls decision={decision} pending={pending} onAction={onAction} />
     </div>
   );
 }
@@ -318,6 +393,8 @@ export default function LeaseLedgerPage() {
   const [obligationSummary, setObligationSummary] = useState<LeaseObligationLedgerSummary | null>(null);
   const [delinquencySignals, setDelinquencySignals] = useState<LeaseDelinquencySignal[]>([]);
   const [delinquencySummary, setDelinquencySummary] = useState<LeaseDelinquencySummary | null>(null);
+  const [decisions, setDecisions] = useState<DecisionItem[]>([]);
+  const [decisionActionPendingId, setDecisionActionPendingId] = useState<string | null>(null);
   const [showChargeModal, setShowChargeModal] = useState(false);
   const [showPaymentModal, setShowPaymentModal] = useState(false);
   const [showNoteModal, setShowNoteModal] = useState(false);
@@ -337,7 +414,6 @@ export default function LeaseLedgerPage() {
   const [paymentReference, setPaymentReference] = useState("");
   const [paymentNotes, setPaymentNotes] = useState("");
 
-  const decisions = useMemo(() => deriveDecisionItemsFromDelinquencySignals(delinquencySignals), [delinquencySignals]);
   const decisionSummary = useMemo(() => summarizeDecisionItems(decisions), [decisions]);
 
   const monthlyRows = useMemo(() => {
@@ -357,10 +433,32 @@ export default function LeaseLedgerPage() {
       setObligationSummary(res.obligationSummary || null);
       setDelinquencySignals(Array.isArray(res.delinquencySignals) ? res.delinquencySignals : []);
       setDelinquencySummary(res.delinquencySummary || null);
+      setDecisions(Array.isArray(res.decisions) ? res.decisions : []);
     } catch (err: unknown) {
       setError(errorMessage(err, "Failed to load lease ledger"));
     } finally {
       setLoading(false);
+    }
+  };
+
+  const handleDecisionAction = async (decision: DecisionItem, actionType: DecisionActionType) => {
+    if (!leaseId) return;
+    setDecisionActionPendingId(decision.decisionId);
+    const snoozedUntil = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+    try {
+      const result = await patchDecisionAction(decision.decisionId, {
+        leaseId,
+        actionType,
+        decision,
+        assignedTo: actionType === "assigned" ? "operations" : undefined,
+        snoozedUntil: actionType === "snoozed" ? snoozedUntil : undefined,
+      });
+      const nextDecision = result?.decision || decisionWithStatus(decision, actionType);
+      setDecisions((current) => current.map((item) => (item.decisionId === decision.decisionId ? nextDecision : item)));
+    } catch (err: unknown) {
+      setError(errorMessage(err, "Failed to update decision"));
+    } finally {
+      setDecisionActionPendingId(null);
     }
   };
 
@@ -639,7 +737,12 @@ export default function LeaseLedgerPage() {
             </div>
             <div style={{ display: "grid", gap: 8 }}>
               {decisions.map((decision) => (
-                <DecisionRow key={decision.decisionId} decision={decision} />
+                <DecisionRow
+                  key={decision.decisionId}
+                  decision={decision}
+                  pending={decisionActionPendingId === decision.decisionId}
+                  onAction={handleDecisionAction}
+                />
               ))}
             </div>
           </>

--- a/rentchain-frontend/src/pages/admin/AdminLeaseLifecycleReviewPage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminLeaseLifecycleReviewPage.test.tsx
@@ -9,6 +9,10 @@ vi.mock("../../api/adminLeaseLifecycleReviewApi", () => ({
   updateAdminLeaseLifecycleReviewAcknowledgement: vi.fn(),
 }));
 
+vi.mock("@/api/decisionApi", () => ({
+  patchDecisionAction: vi.fn(),
+}));
+
 vi.mock("../../components/layout/MacShell", () => ({
   MacShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }));
@@ -134,7 +138,64 @@ describe("AdminLeaseLifecycleReviewPage", () => {
     expect(screen.queryByRole("button", { name: /fix/i })).not.toBeInTheDocument();
     expect(screen.queryByText(/Fix automatically/i)).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /accept/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /dismiss/i })).not.toBeInTheDocument();
+  });
+
+  it("updates related decision lifecycle state from row actions", async () => {
+    const { fetchAdminLeaseLifecycleReviewQueue } = await import("../../api/adminLeaseLifecycleReviewApi");
+    const { patchDecisionAction } = await import("@/api/decisionApi");
+    vi.mocked(fetchAdminLeaseLifecycleReviewQueue).mockResolvedValue({
+      ok: true,
+      summary: { total: 1, critical: 0, warning: 1, info: 0 },
+      items: [
+        {
+          id: "lease_lifecycle:lease-2:expired_occupancy_conflict",
+          leaseId: "lease-2",
+          propertyId: "property-2",
+          unitId: "unit-2",
+          landlordId: "landlord-2",
+          derivedLifecycleState: "expired",
+          derivedLifecycleReasons: ["end_date_past"],
+          severity: "warning",
+          category: "expired_occupancy_conflict",
+          title: "Expired lease conflicts with manual occupancy",
+          description: "The lease is expired, but the unit has current manual occupied data.",
+          recommendedAction: "Confirm occupancy manually",
+          createdFrom: "lease_lifecycle_review_queue_v1",
+          detectedAt: "2026-05-05T12:00:00.000Z",
+          acknowledgement: null,
+          recentHistory: [],
+        },
+      ],
+    });
+    vi.mocked(patchDecisionAction).mockResolvedValue({
+      ok: true,
+      decision: {
+        decisionId: "decision:review_occupancy_conflict:lease_lifecycle:lease-2:expired_occupancy_conflict",
+        leaseId: "lease-2",
+        propertyId: "property-2",
+        unitId: "unit-2",
+        decisionType: "review_occupancy_conflict",
+        severity: "warning",
+        status: "resolved",
+        reason: "Lease lifecycle indicates an occupancy conflict that needs review.",
+        metadata: {},
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <AdminLeaseLifecycleReviewPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Related decision/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Resolve" }));
+
+    expect(vi.mocked(patchDecisionAction)).toHaveBeenCalledWith(
+      expect.stringContaining("review_occupancy_conflict"),
+      expect.objectContaining({ actionType: "resolved", leaseId: "lease-2" })
+    );
+    expect(await screen.findByText("Resolved")).toBeInTheDocument();
   });
 
   it("updates acknowledgement state from row actions", async () => {

--- a/rentchain-frontend/src/pages/admin/AdminLeaseLifecycleReviewPage.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminLeaseLifecycleReviewPage.tsx
@@ -15,7 +15,11 @@ import {
   decisionDisplayCopy,
   decisionFromLifecycleReviewItem,
   decisionSeverityStyle,
+  decisionStatusCopy,
+  type DecisionActionType,
+  type DecisionItem,
 } from "@/lib/decisions/decisionDisplay";
+import { patchDecisionAction } from "@/api/decisionApi";
 
 const emptySummary: AdminLeaseLifecycleReviewSummary = {
   total: 0,
@@ -84,16 +88,21 @@ function SummaryCard({ label, value }: { label: string; value: number }) {
 function QueueItemRow({
   item,
   busy,
+  decisionStatusById,
   onAcknowledge,
+  onDecisionAction,
 }: {
   item: AdminLeaseLifecycleReviewItem;
   busy: boolean;
+  decisionStatusById: Record<string, DecisionItem>;
   onAcknowledge: (
     item: AdminLeaseLifecycleReviewItem,
     payload: { status: "reviewed" | "snoozed" | "assigned"; assignedTo?: string | null; snoozedUntil?: string | null; note?: string | null }
   ) => void;
+  onDecisionAction: (decision: DecisionItem, actionType: DecisionActionType) => void;
 }) {
-  const decision = decisionFromLifecycleReviewItem(item);
+  const baseDecision = decisionFromLifecycleReviewItem(item);
+  const decision = baseDecision ? decisionStatusById[baseDecision.decisionId] || baseDecision : null;
   return (
     <tr>
       <td style={{ padding: "12px 10px", verticalAlign: "top", borderBottom: "1px solid #e2e8f0" }}>
@@ -131,7 +140,30 @@ function QueueItemRow({
             >
               {decisionDisplayCopy[decision.decisionType].badge}
             </span>
+            <span style={{ border: "1px solid #cbd5e1", borderRadius: 999, padding: "2px 8px", fontSize: 12, fontWeight: 800 }}>
+              {decisionStatusCopy[decision.status || "detected"]}
+            </span>
             <span style={{ color: "#475569", fontSize: 12 }}>{decision.reason}</span>
+            <div style={{ display: "flex", gap: 6, flexWrap: "wrap", width: "100%" }}>
+              {(["reviewed", "snoozed", "assigned", "dismissed", "resolved"] as DecisionActionType[]).map((actionType) => (
+                <Button
+                  key={actionType}
+                  variant="ghost"
+                  disabled={busy}
+                  onClick={() => onDecisionAction(decision, actionType)}
+                >
+                  {actionType === "reviewed"
+                    ? "Mark reviewed"
+                    : actionType === "snoozed"
+                    ? "Snooze"
+                    : actionType === "assigned"
+                    ? "Assign"
+                    : actionType === "dismissed"
+                    ? "Dismiss"
+                    : "Resolve"}
+                </Button>
+              ))}
+            </div>
           </div>
         ) : null}
       </td>
@@ -198,6 +230,7 @@ export default function AdminLeaseLifecycleReviewPage() {
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
   const [busyItemId, setBusyItemId] = React.useState<string | null>(null);
+  const [decisionStatusById, setDecisionStatusById] = React.useState<Record<string, DecisionItem>>({});
 
   const load = React.useCallback(async () => {
     try {
@@ -246,6 +279,28 @@ export default function AdminLeaseLifecycleReviewPage() {
     []
   );
 
+  const handleDecisionAction = React.useCallback(async (decision: DecisionItem, actionType: DecisionActionType) => {
+    try {
+      setBusyItemId(decision.decisionId);
+      setError(null);
+      const response = await patchDecisionAction(decision.decisionId, {
+        leaseId: decision.leaseId || "",
+        actionType,
+        decision,
+        assignedTo: actionType === "assigned" ? "operations" : undefined,
+        snoozedUntil: actionType === "snoozed" ? new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString() : undefined,
+      });
+      setDecisionStatusById((current) => ({
+        ...current,
+        [decision.decisionId]: response?.decision || { ...decision, status: actionType === "reviewed" ? "reviewed" : actionType },
+      }));
+    } catch (err: any) {
+      setError(err?.message || "Failed to update decision action");
+    } finally {
+      setBusyItemId(null);
+    }
+  }, []);
+
   return (
     <MacShell title="Admin - Lease Lifecycle Review">
       <div style={{ display: "grid", gap: 16 }}>
@@ -293,7 +348,14 @@ export default function AdminLeaseLifecycleReviewPage() {
               </thead>
               <tbody>
                 {items.map((item) => (
-                  <QueueItemRow key={item.id} item={item} busy={busyItemId === item.id} onAcknowledge={handleAcknowledge} />
+                  <QueueItemRow
+                    key={item.id}
+                    item={item}
+                    busy={busyItemId === item.id || busyItemId === decisionFromLifecycleReviewItem(item)?.decisionId}
+                    decisionStatusById={decisionStatusById}
+                    onAcknowledge={handleAcknowledge}
+                    onDecisionAction={handleDecisionAction}
+                  />
                 ))}
               </tbody>
             </table>


### PR DESCRIPTION
## Summary
- Adds human-controlled decision lifecycle actions for reviewed, snoozed, assigned, dismissed, and resolved.
- Stores decision actions separately from derived decisions.
- Applies latest action as an overlay without mutating source decisions.
- Adds admin decision action endpoints.
- Additively includes overlaid decisions in the lease ledger response.
- Adds action controls to dashboard, lease ledger, and admin lifecycle review surfaces.
- No lease mutations, payment mutations, automation, Stripe/webhook changes, Trustly, PaymentIntent enforcement, schema changes, dependency changes, or lockfile changes.

## Verification
- Backend decision action/route tests passed: 8 tests.
- Lease route integrity tests passed: 10 tests.
- Decision engine tests passed: 9 tests.
- Backend build passed.
- Frontend focused tests passed: 25 tests.
- Full frontend suite passed: 181 files / 745 tests.
- Frontend build passed with existing chunk-size warning.
- git diff --check passed.
- dependency/lockfile diff empty.