### PR TITLE
Link decisions to context and evidence

### DIFF
--- a/docs/architecture/decision-engine-v1.md
+++ b/docs/architecture/decision-engine-v1.md
@@ -89,11 +89,44 @@ Decision Engine V1 does not:
 
 It prepares an auditable layer for later review and workflow surfaces.
 
+## Decision Context Linking V1
+
+Decision Context Linking V1 makes each visible decision an entry point into the records and evidence that explain it.
+
+The context layer is frontend-readable and non-mutating:
+
+- lease context links to `/leases/:leaseId/summary`
+- ledger context links to `/leases/:leaseId/ledger`
+- property and unit context links to `/properties` with query parameters where available
+- tenant context links to `/tenants` with query parameters where available
+- admin lifecycle context links to `/admin/lease-lifecycle-review`
+
+Evidence summaries are derived from existing decision metadata, obligation rows, delinquency signals, and the latest decision action overlay. They can include:
+
+- decision reason
+- severity
+- related delinquency signal and signal reason
+- obligation status
+- outstanding amount
+- lease lifecycle state and lifecycle reason
+- PaymentIntent and rentPayment references
+- current status and last action
+
+Missing context is shown as unavailable instead of rendering empty identifiers. Raw internal IDs remain secondary technical references, not the primary display label.
+
+This layer does not add:
+
+- automated actions
+- notices
+- payment retries
+- lease or payment mutations
+- decision execution workflows
+
 ## Deferred
 
-1. Decision persistence and history.
-2. Admin and landlord decision review surfaces.
-3. Decision acknowledgements and assignments.
-4. Notification and notice workflows.
-5. Auto-resolution after source evidence changes.
-6. Decision-to-action execution policies.
+1. Full decision inbox.
+2. Decision timeline page.
+3. Decision-to-action execution workflows.
+4. Automated notices.
+5. Institution export of decision packets.
+6. Compliance rollup for decision context and evidence.

--- a/rentchain-frontend/src/components/decisions/DecisionContextPanel.test.tsx
+++ b/rentchain-frontend/src/components/decisions/DecisionContextPanel.test.tsx
@@ -1,0 +1,69 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it } from "vitest";
+import { DecisionContextPanel } from "./DecisionContextPanel";
+import type { DecisionItem } from "@/lib/decisions/decisionDisplay";
+
+const baseDecision: DecisionItem = {
+  decisionId: "decision-1",
+  leaseId: "lease-1",
+  propertyId: "property-1",
+  unitId: "unit-1",
+  tenantId: "tenant-1",
+  paymentIntentId: "pi-1",
+  rentPaymentId: "rp-1",
+  decisionType: "review_overdue_rent",
+  severity: "critical",
+  status: "reviewed",
+  reason: "Rent past due date",
+  metadata: {
+    signalType: "overdue",
+    outstandingAmountCents: 145000,
+    obligationStatus: "missing",
+  },
+  latestAction: {
+    actionId: "action-1",
+    decisionId: "decision-1",
+    actionType: "reviewed",
+    nextStatus: "reviewed",
+    actorEmail: "admin@example.com",
+    createdAt: "2026-05-05T12:00:00.000Z",
+  },
+};
+
+describe("DecisionContextPanel", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders context links, evidence, and review trail", () => {
+    render(
+      <MemoryRouter>
+        <DecisionContextPanel decision={baseDecision} includeAdminReviewLink />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("link", { name: "Lease summary" })).toHaveAttribute("href", "/leases/lease-1/summary");
+    expect(screen.getByRole("link", { name: "Lease ledger" })).toHaveAttribute("href", "/leases/lease-1/ledger");
+    expect(screen.getByRole("link", { name: "Property / unit" })).toHaveAttribute("href", "/properties?propertyId=property-1&unitId=unit-1");
+    expect(screen.getByRole("link", { name: "Tenant" })).toHaveAttribute("href", "/tenants?tenantId=tenant-1");
+    expect(screen.getByRole("link", { name: "Lifecycle review" })).toHaveAttribute("href", "/admin/lease-lifecycle-review");
+    expect(screen.getByText("Decision reason")).toBeInTheDocument();
+    expect(screen.getByText("Rent past due date")).toBeInTheDocument();
+    expect(screen.getByText("$1,450.00")).toBeInTheDocument();
+    expect(screen.getByText(/Current status:/)).toBeInTheDocument();
+    expect(screen.getByText(/Last action:/)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /fix/i })).not.toBeInTheDocument();
+  });
+
+  it("renders graceful fallback when no context identifiers exist", () => {
+    render(
+      <MemoryRouter>
+        <DecisionContextPanel decision={{ ...baseDecision, leaseId: null, propertyId: null, unitId: null, tenantId: null }} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Context unavailable")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Lease ledger" })).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/decisions/DecisionContextPanel.tsx
+++ b/rentchain-frontend/src/components/decisions/DecisionContextPanel.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import type { LeaseDelinquencySignal, LeaseObligationLedgerRow } from "@/api/leaseLedgerApi";
+import { decisionStatusCopy, type DecisionItem } from "@/lib/decisions/decisionDisplay";
+import { buildDecisionContextLinks, buildDecisionEvidenceItems } from "@/lib/decisions/decisionContext";
+
+export function DecisionContextPanel({
+  decision,
+  obligationRows,
+  delinquencySignals,
+  includeAdminReviewLink = false,
+  compact = false,
+}: {
+  decision: DecisionItem;
+  obligationRows?: LeaseObligationLedgerRow[] | null;
+  delinquencySignals?: LeaseDelinquencySignal[] | null;
+  includeAdminReviewLink?: boolean;
+  compact?: boolean;
+}) {
+  const links = buildDecisionContextLinks(decision, { includeAdminReviewLink });
+  const evidenceItems = buildDecisionEvidenceItems(decision, { obligationRows, delinquencySignals });
+  const latestAction = decision.latestAction;
+
+  return (
+    <div
+      data-testid="decision-context-panel"
+      style={{
+        border: "1px solid #e2e8f0",
+        borderRadius: 10,
+        padding: compact ? 10 : 12,
+        background: "#f8fafc",
+        display: "grid",
+        gap: compact ? 8 : 10,
+      }}
+    >
+      <div style={{ display: "grid", gap: 6 }}>
+        <div style={{ color: "#334155", fontSize: 12, fontWeight: 800, textTransform: "uppercase" }}>Context</div>
+        {links.length ? (
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+            {links.map((link) => (
+              <Link
+                key={`${link.key}-${link.href}`}
+                to={link.href}
+                style={{
+                  border: "1px solid #cbd5e1",
+                  borderRadius: 999,
+                  padding: "4px 9px",
+                  background: "#fff",
+                  color: "#0f172a",
+                  fontSize: 12,
+                  fontWeight: 800,
+                  textDecoration: "none",
+                }}
+                title={link.helperText}
+              >
+                {link.label}
+              </Link>
+            ))}
+          </div>
+        ) : (
+          <div style={{ color: "#64748b", fontSize: 12 }}>Context unavailable</div>
+        )}
+      </div>
+
+      <div style={{ display: "grid", gap: 6 }}>
+        <div style={{ color: "#334155", fontSize: 12, fontWeight: 800, textTransform: "uppercase" }}>Evidence</div>
+        <dl style={{ display: "grid", gridTemplateColumns: compact ? "1fr" : "repeat(auto-fit, minmax(170px, 1fr))", gap: 8, margin: 0 }}>
+          {evidenceItems.map((item) => (
+            <div key={`${item.label}-${item.value}`} style={{ display: "grid", gap: 2 }}>
+              <dt style={{ color: "#64748b", fontSize: 12 }}>{item.label}</dt>
+              <dd style={{ color: "#0f172a", fontSize: 13, fontWeight: 700, margin: 0, overflowWrap: "anywhere" }}>{item.value}</dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+
+      <div style={{ display: "grid", gap: 4 }}>
+        <div style={{ color: "#334155", fontSize: 12, fontWeight: 800, textTransform: "uppercase" }}>Review trail</div>
+        <div style={{ color: "#475569", fontSize: 12 }}>
+          Current status: <strong>{decisionStatusCopy[decision.status || "detected"]}</strong>
+        </div>
+        {latestAction ? (
+          <div style={{ color: "#475569", fontSize: 12 }}>
+            Last action: <strong>{decisionStatusCopy[latestAction.nextStatus]}</strong>
+            {latestAction.actorEmail ? ` by ${latestAction.actorEmail}` : ""}
+          </div>
+        ) : (
+          <div style={{ color: "#64748b", fontSize: 12 }}>No decision action history yet.</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default DecisionContextPanel;
+

--- a/rentchain-frontend/src/lib/decisions/decisionContext.test.ts
+++ b/rentchain-frontend/src/lib/decisions/decisionContext.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDecisionContextLinks,
+  buildDecisionEvidenceItems,
+  findRelatedDelinquencySignal,
+  findRelatedObligationRow,
+} from "./decisionContext";
+import type { DecisionItem } from "./decisionDisplay";
+
+const decision: DecisionItem = {
+  decisionId: "decision-1",
+  leaseId: "lease-1",
+  propertyId: "property-1",
+  unitId: "unit-1",
+  tenantId: "tenant-1",
+  paymentIntentId: "pi-1",
+  rentPaymentId: "rp-1",
+  decisionType: "review_overdue_rent",
+  severity: "critical",
+  status: "assigned",
+  reason: "Rent past due date",
+  metadata: {
+    signalId: "signal-1",
+    signalType: "overdue",
+    obligationStatus: "missing",
+    outstandingAmountCents: 145000,
+  },
+  latestAction: {
+    actionId: "action-1",
+    decisionId: "decision-1",
+    actionType: "assigned",
+    nextStatus: "assigned",
+    actorEmail: "ops@example.com",
+    createdAt: "2026-05-05T12:00:00.000Z",
+  },
+};
+
+describe("decisionContext", () => {
+  it("builds deterministic context links from available identifiers", () => {
+    expect(buildDecisionContextLinks(decision, { includeAdminReviewLink: true })).toEqual([
+      expect.objectContaining({ key: "lease", label: "Lease summary", href: "/leases/lease-1/summary" }),
+      expect.objectContaining({ key: "ledger", label: "Lease ledger", href: "/leases/lease-1/ledger" }),
+      expect.objectContaining({ key: "property", label: "Property / unit", href: "/properties?propertyId=property-1&unitId=unit-1" }),
+      expect.objectContaining({ key: "tenant", label: "Tenant", href: "/tenants?tenantId=tenant-1" }),
+      expect.objectContaining({ key: "admin_review", label: "Lifecycle review", href: "/admin/lease-lifecycle-review" }),
+    ]);
+  });
+
+  it("returns no links when context identifiers are unavailable", () => {
+    expect(buildDecisionContextLinks({ ...decision, leaseId: null, propertyId: null, unitId: null, tenantId: null })).toEqual([]);
+  });
+
+  it("matches obligation rows and delinquency signals by stable references", () => {
+    const row = {
+      rowId: "row-1",
+      leaseId: "lease-1",
+      paymentIntentId: "pi-1",
+      rentPaymentId: "rp-1",
+      propertyId: "property-1",
+      unitId: "unit-1",
+      expectedAmountCents: 145000,
+      paidAmountCents: 0,
+      currency: "cad",
+      obligationStatus: "missing" as const,
+      evidenceStatus: "none" as const,
+      source: "payment_intent" as const,
+      reasons: ["expected_payment_missing"],
+    };
+    const signal = {
+      signalId: "signal-1",
+      leaseId: "lease-1",
+      paymentIntentId: "pi-1",
+      propertyId: "property-1",
+      expectedAmountCents: 145000,
+      paidAmountCents: 0,
+      outstandingAmountCents: 145000,
+      signalType: "overdue" as const,
+      severity: "critical" as const,
+      detectedAt: "2026-05-05T12:00:00.000Z",
+      reasons: ["obligation_missing_after_due_date"],
+    };
+
+    expect(findRelatedObligationRow(decision, [row])).toBe(row);
+    expect(findRelatedDelinquencySignal(decision, [signal])).toBe(signal);
+  });
+
+  it("builds evidence without leaking undefined values", () => {
+    const items = buildDecisionEvidenceItems(decision);
+
+    expect(items).toEqual(
+      expect.arrayContaining([
+        { label: "Decision reason", value: "Rent past due date" },
+        { label: "Severity", value: "Critical" },
+        { label: "Related delinquency signal", value: "Overdue" },
+        { label: "Outstanding amount", value: "$1,450.00" },
+        { label: "Payment intent reference", value: "pi-1" },
+        { label: "Rent payment reference", value: "rp-1" },
+        { label: "Last action", value: "Assigned by ops@example.com" },
+      ])
+    );
+    expect(items.map((item) => item.value)).not.toContain("undefined");
+  });
+});
+

--- a/rentchain-frontend/src/lib/decisions/decisionContext.ts
+++ b/rentchain-frontend/src/lib/decisions/decisionContext.ts
@@ -1,0 +1,199 @@
+import type { LeaseDelinquencySignal, LeaseObligationLedgerRow } from "@/api/leaseLedgerApi";
+import type { DecisionItem } from "./decisionDisplay";
+
+export type DecisionContextLink = {
+  key: "lease" | "ledger" | "property" | "tenant" | "admin_review";
+  label: string;
+  href: string;
+  helperText?: string;
+};
+
+export type DecisionEvidenceItem = {
+  label: string;
+  value: string;
+};
+
+export type DecisionRelatedData = {
+  obligationRows?: LeaseObligationLedgerRow[] | null;
+  delinquencySignals?: LeaseDelinquencySignal[] | null;
+  includeAdminReviewLink?: boolean;
+};
+
+function cleanString(value: unknown): string | null {
+  const next = String(value ?? "").trim();
+  return next || null;
+}
+
+function metadataString(decision: DecisionItem, key: string): string | null {
+  return cleanString(decision.metadata?.[key]);
+}
+
+function metadataNumber(decision: DecisionItem, key: string): number | null {
+  const value = Number(decision.metadata?.[key]);
+  return Number.isFinite(value) ? value : null;
+}
+
+function formatCurrencyCents(value: unknown): string {
+  const cents = Number(value || 0);
+  const amount = Math.abs(cents) / 100;
+  return `${cents < 0 ? "-" : ""}$${amount.toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+function titleCase(value: unknown): string {
+  const text = cleanString(value);
+  if (!text) return "Context unavailable";
+  return text.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function datesMatch(a: unknown, b: unknown): boolean {
+  const left = cleanString(a);
+  const right = cleanString(b);
+  if (!left || !right) return false;
+  const leftParsed = Date.parse(left);
+  const rightParsed = Date.parse(right);
+  if (!Number.isFinite(leftParsed) || !Number.isFinite(rightParsed)) return left === right;
+  return new Date(leftParsed).toISOString().slice(0, 10) === new Date(rightParsed).toISOString().slice(0, 10);
+}
+
+export function findRelatedObligationRow(
+  decision: DecisionItem,
+  rows: LeaseObligationLedgerRow[] | null | undefined
+): LeaseObligationLedgerRow | null {
+  const obligationRows = rows || [];
+  const obligationRowId = metadataString(decision, "obligationRowId");
+  const expectedAmountCents = metadataNumber(decision, "expectedAmountCents");
+  const dueDate = metadataString(decision, "dueDate");
+
+  return (
+    obligationRows.find((row) => {
+      if (obligationRowId && row.rowId === obligationRowId) return true;
+      if (decision.paymentIntentId && row.paymentIntentId === decision.paymentIntentId) return true;
+      if (decision.rentPaymentId && row.rentPaymentId === decision.rentPaymentId) return true;
+      return Boolean(
+        decision.leaseId &&
+          row.leaseId === decision.leaseId &&
+          expectedAmountCents != null &&
+          Number(row.expectedAmountCents || 0) === expectedAmountCents &&
+          (!dueDate || datesMatch(dueDate, row.dueDate))
+      );
+    }) || null
+  );
+}
+
+export function findRelatedDelinquencySignal(
+  decision: DecisionItem,
+  signals: LeaseDelinquencySignal[] | null | undefined
+): LeaseDelinquencySignal | null {
+  const delinquencySignals = signals || [];
+  const signalId = metadataString(decision, "signalId");
+  return (
+    delinquencySignals.find((signal) => {
+      if (signalId && signal.signalId === signalId) return true;
+      if (decision.paymentIntentId && signal.paymentIntentId === decision.paymentIntentId) return true;
+      if (decision.rentPaymentId && signal.rentPaymentId === decision.rentPaymentId) return true;
+      return Boolean(decision.leaseId && signal.leaseId === decision.leaseId && signal.signalType === decision.metadata?.signalType);
+    }) || null
+  );
+}
+
+export function buildDecisionContextLinks(
+  decision: DecisionItem,
+  options?: { includeAdminReviewLink?: boolean }
+): DecisionContextLink[] {
+  const links: DecisionContextLink[] = [];
+  if (decision.leaseId) {
+    links.push({
+      key: "lease",
+      label: "Lease summary",
+      href: `/leases/${encodeURIComponent(decision.leaseId)}/summary`,
+      helperText: "Open lease record",
+    });
+    links.push({
+      key: "ledger",
+      label: "Lease ledger",
+      href: `/leases/${encodeURIComponent(decision.leaseId)}/ledger`,
+      helperText: "Review obligations and payments",
+    });
+  }
+  if (decision.propertyId) {
+    const search = new URLSearchParams({ propertyId: decision.propertyId });
+    if (decision.unitId) search.set("unitId", decision.unitId);
+    links.push({
+      key: "property",
+      label: decision.unitId ? "Property / unit" : "Property",
+      href: `/properties?${search.toString()}`,
+      helperText: decision.unitId ? "Open property and unit context" : "Open property context",
+    });
+  }
+  if (decision.tenantId) {
+    links.push({
+      key: "tenant",
+      label: "Tenant",
+      href: `/tenants?tenantId=${encodeURIComponent(decision.tenantId)}`,
+      helperText: "Open tenant context",
+    });
+  }
+  if (options?.includeAdminReviewLink) {
+    links.push({
+      key: "admin_review",
+      label: "Lifecycle review",
+      href: "/admin/lease-lifecycle-review",
+      helperText: "Open operator review queue",
+    });
+  }
+  return links;
+}
+
+export function buildDecisionEvidenceItems(
+  decision: DecisionItem,
+  relatedData?: DecisionRelatedData
+): DecisionEvidenceItem[] {
+  const relatedRow = findRelatedObligationRow(decision, relatedData?.obligationRows);
+  const relatedSignal = findRelatedDelinquencySignal(decision, relatedData?.delinquencySignals);
+  const outstandingAmountCents =
+    relatedSignal?.outstandingAmountCents ??
+    metadataNumber(decision, "outstandingAmountCents") ??
+    (relatedRow
+      ? Math.max(0, Number(relatedRow.expectedAmountCents || 0) - Number(relatedRow.paidAmountCents || 0))
+      : null);
+  const signalType = relatedSignal?.signalType || metadataString(decision, "signalType");
+  const signalReasons = relatedSignal?.reasons?.length
+    ? relatedSignal.reasons.join(", ")
+    : Array.isArray(decision.metadata?.signalReasons)
+    ? (decision.metadata.signalReasons as unknown[]).map((reason) => String(reason)).join(", ")
+    : null;
+  const lifecycleState = metadataString(decision, "lifecycleState");
+  const lifecycleReasons = Array.isArray(decision.metadata?.lifecycleReasons)
+    ? (decision.metadata.lifecycleReasons as unknown[]).map((reason) => String(reason)).join(", ")
+    : null;
+
+  const items: DecisionEvidenceItem[] = [
+    { label: "Decision reason", value: decision.reason || "Context unavailable" },
+    { label: "Severity", value: titleCase(decision.severity) },
+  ];
+
+  if (signalType) items.push({ label: "Related delinquency signal", value: titleCase(signalType) });
+  if (signalReasons) items.push({ label: "Signal reason", value: signalReasons });
+  if (relatedRow?.obligationStatus || decision.metadata?.obligationStatus) {
+    items.push({ label: "Obligation status", value: titleCase(relatedRow?.obligationStatus || decision.metadata?.obligationStatus) });
+  }
+  if (outstandingAmountCents != null) {
+    items.push({ label: "Outstanding amount", value: formatCurrencyCents(outstandingAmountCents) });
+  }
+  if (lifecycleState) items.push({ label: "Lease lifecycle state", value: titleCase(lifecycleState) });
+  if (lifecycleReasons) items.push({ label: "Lifecycle reason", value: lifecycleReasons });
+  if (decision.paymentIntentId) items.push({ label: "Payment intent reference", value: decision.paymentIntentId });
+  if (decision.rentPaymentId) items.push({ label: "Rent payment reference", value: decision.rentPaymentId });
+  if (decision.latestAction) {
+    items.push({
+      label: "Last action",
+      value: `${titleCase(decision.latestAction.nextStatus)}${decision.latestAction.actorEmail ? ` by ${decision.latestAction.actorEmail}` : ""}`,
+    });
+  }
+
+  return items;
+}
+

--- a/rentchain-frontend/src/pages/DashboardPage.test.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.test.tsx
@@ -320,11 +320,13 @@ describe("DashboardPage", () => {
     expect(screen.getByText("Decision summary")).toBeInTheDocument();
     expect(screen.getByText("Read-only decisions from detected rent and lease signals.")).toBeInTheDocument();
     expect(screen.getByText("Overdue Rent")).toBeInTheDocument();
-    expect(screen.getByText("Rent past due date")).toBeInTheDocument();
+    expect(screen.getAllByText("Rent past due date").length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("link", { name: "Lease ledger" }).some((link) => link.getAttribute("href") === "/leases/lease-1/ledger")).toBe(true);
+    expect(screen.getAllByRole("link", { name: "Property / unit" }).some((link) => link.getAttribute("href") === "/properties?propertyId=property-1&unitId=unit-1")).toBe(true);
     expect(screen.getByText("Underpaid Rent")).toBeInTheDocument();
-    expect(screen.getByText("Partial payment received")).toBeInTheDocument();
+    expect(screen.getAllByText("Partial payment received").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Manual Review").length).toBeGreaterThan(0);
-    expect(screen.getByText("Payment mismatch detected")).toBeInTheDocument();
+    expect(screen.getAllByText("Payment mismatch detected").length).toBeGreaterThan(0);
   });
 
   it("updates dashboard decision status from human actions", async () => {
@@ -361,7 +363,7 @@ describe("DashboardPage", () => {
         expect.objectContaining({ actionType: "reviewed", leaseId: "lease-1" })
       )
     );
-    expect(screen.getByText("Reviewed")).toBeInTheDocument();
+    expect(screen.getAllByText("Reviewed").length).toBeGreaterThan(0);
   });
 
   it("renders an empty dashboard decision state without adding actions", async () => {

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -51,6 +51,7 @@ import {
   type DecisionItem,
 } from "@/lib/decisions/decisionDisplay";
 import { patchDecisionAction } from "@/api/decisionApi";
+import { DecisionContextPanel } from "@/components/decisions/DecisionContextPanel";
 
 const StarterOnboardingPanel = React.lazy(
   () => import("../components/dashboard/StarterOnboardingPanel")
@@ -190,6 +191,7 @@ function DashboardDecisionSummaryPanel({
                   <span>{copy.label}</span>
                   <span style={{ color: text.muted }}>{decision.reason}</span>
                   </div>
+                  <DecisionContextPanel decision={decision} compact />
                   <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
                     {(["reviewed", "snoozed", "assigned", "dismissed", "resolved"] as DecisionActionType[]).map((actionType) => (
                       <button

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
@@ -306,11 +306,17 @@ describe("LeaseLedgerPage", () => {
           propertyId: "prop-1",
           unitId: "unit-1",
           tenantId: "tenant-1",
+          paymentIntentId: "pi-missing",
           decisionType: "review_overdue_rent",
           severity: "critical",
           status: "detected",
           reason: "Rent past due date",
-          metadata: {},
+          metadata: {
+            signalId: "delinquency:overdue:pi-missing",
+            signalType: "overdue",
+            outstandingAmountCents: 145000,
+            obligationStatus: "missing",
+          },
           createdAt: "2026-05-05T00:00:00.000Z",
           updatedAt: "2026-05-05T00:00:00.000Z",
         },
@@ -520,15 +526,20 @@ describe("LeaseLedgerPage", () => {
     expect(await screen.findByText("Decisions")).toBeInTheDocument();
     expect(screen.getByText("Read-only decisions derived from detected lease and payment signals.")).toBeInTheDocument();
     expect(screen.getByText("Overdue Rent")).toBeInTheDocument();
-    expect(screen.getByText("Rent past due date")).toBeInTheDocument();
+    expect(screen.getAllByText("Rent past due date").length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("link", { name: "Lease ledger" }).some((link) => link.getAttribute("href") === "/leases/lease-1/ledger")).toBe(true);
+    expect(screen.getAllByRole("link", { name: "Property / unit" }).some((link) => link.getAttribute("href") === "/properties?propertyId=prop-1&unitId=unit-1")).toBe(true);
+    expect(screen.getByRole("link", { name: "Tenant" })).toHaveAttribute("href", "/tenants?tenantId=tenant-1");
+    expect(screen.getAllByText("Outstanding amount").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("$1,450.00").length).toBeGreaterThan(0);
     expect(screen.getByText("Underpaid Rent")).toBeInTheDocument();
-    expect(screen.getByText("Partial payment received")).toBeInTheDocument();
+    expect(screen.getAllByText("Partial payment received").length).toBeGreaterThan(0);
     expect(screen.getByText("Missing Payment")).toBeInTheDocument();
-    expect(screen.getByText("Expected rent payment is missing")).toBeInTheDocument();
+    expect(screen.getAllByText("Expected rent payment is missing").length).toBeGreaterThan(0);
     expect(screen.getByText("Failed Payment")).toBeInTheDocument();
-    expect(screen.getByText("Payment did not complete")).toBeInTheDocument();
+    expect(screen.getAllByText("Payment did not complete").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Manual Review").length).toBeGreaterThan(0);
-    expect(screen.getByText("Payment mismatch detected")).toBeInTheDocument();
+    expect(screen.getAllByText("Payment mismatch detected").length).toBeGreaterThan(0);
   });
 
   it("updates lease decision status from human actions", async () => {

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
@@ -34,6 +34,7 @@ import {
   type DecisionItem,
   type DecisionSeverity,
 } from "@/lib/decisions/decisionDisplay";
+import { DecisionContextPanel } from "@/components/decisions/DecisionContextPanel";
 
 type ChargeType = "rent" | "fee" | "adjustment";
 type PaymentMethod = "cash" | "etransfer" | "cheque" | "bank" | "card" | "other";
@@ -242,10 +243,14 @@ function DecisionActionControls({
 
 function DecisionRow({
   decision,
+  obligationRows,
+  delinquencySignals,
   pending,
   onAction,
 }: {
   decision: DecisionItem;
+  obligationRows: LeaseObligationLedgerRow[];
+  delinquencySignals: LeaseDelinquencySignal[];
   pending: boolean;
   onAction: (decision: DecisionItem, actionType: DecisionActionType) => void;
 }) {
@@ -268,6 +273,7 @@ function DecisionRow({
       {decision.latestAction ? (
         <div style={{ color: "#64748b", fontSize: 12 }}>Last action: {decisionStatusCopy[decision.latestAction.nextStatus]}</div>
       ) : null}
+      <DecisionContextPanel decision={decision} obligationRows={obligationRows} delinquencySignals={delinquencySignals} />
       <DecisionActionControls decision={decision} pending={pending} onAction={onAction} />
     </div>
   );
@@ -740,6 +746,8 @@ export default function LeaseLedgerPage() {
                 <DecisionRow
                   key={decision.decisionId}
                   decision={decision}
+                  obligationRows={obligationRows}
+                  delinquencySignals={delinquencySignals}
                   pending={decisionActionPendingId === decision.decisionId}
                   onAction={handleDecisionAction}
                 />

--- a/rentchain-frontend/src/pages/admin/AdminLeaseLifecycleReviewPage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminLeaseLifecycleReviewPage.test.tsx
@@ -132,8 +132,13 @@ describe("AdminLeaseLifecycleReviewPage", () => {
     expect(screen.getByText(/admin@example.com/i)).toBeInTheDocument();
     expect(screen.getByText(/No history yet/i)).toBeInTheDocument();
     expect(screen.getByText(/Related decision/i)).toBeInTheDocument();
+    expect(screen.getAllByRole("link", { name: "Lease summary" }).some((link) => link.getAttribute("href") === "/leases/lease-2/summary")).toBe(true);
+    expect(screen.getAllByRole("link", { name: "Lease ledger" }).some((link) => link.getAttribute("href") === "/leases/lease-2/ledger")).toBe(true);
+    expect(screen.getAllByRole("link", { name: "Property / unit" }).some((link) => link.getAttribute("href") === "/properties?propertyId=property-2&unitId=unit-2")).toBe(true);
+    expect(screen.getAllByRole("link", { name: "Lifecycle review" }).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Evidence").length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Occupancy/i).length).toBeGreaterThan(0);
-    expect(screen.getByText(/Lease lifecycle indicates an occupancy conflict that needs review/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Lease lifecycle indicates an occupancy conflict that needs review/i).length).toBeGreaterThan(0);
     expect(screen.getByRole("link", { name: "lease-1" })).toHaveAttribute("href", "/admin/leases?q=lease-1");
     expect(screen.queryByRole("button", { name: /fix/i })).not.toBeInTheDocument();
     expect(screen.queryByText(/Fix automatically/i)).not.toBeInTheDocument();
@@ -195,7 +200,8 @@ describe("AdminLeaseLifecycleReviewPage", () => {
       expect.stringContaining("review_occupancy_conflict"),
       expect.objectContaining({ actionType: "resolved", leaseId: "lease-2" })
     );
-    expect(await screen.findByText("Resolved")).toBeInTheDocument();
+    await screen.findAllByText("Resolved");
+    expect(screen.getAllByText("Resolved").length).toBeGreaterThan(0);
   });
 
   it("updates acknowledgement state from row actions", async () => {

--- a/rentchain-frontend/src/pages/admin/AdminLeaseLifecycleReviewPage.tsx
+++ b/rentchain-frontend/src/pages/admin/AdminLeaseLifecycleReviewPage.tsx
@@ -20,6 +20,7 @@ import {
   type DecisionItem,
 } from "@/lib/decisions/decisionDisplay";
 import { patchDecisionAction } from "@/api/decisionApi";
+import { DecisionContextPanel } from "@/components/decisions/DecisionContextPanel";
 
 const emptySummary: AdminLeaseLifecycleReviewSummary = {
   total: 0,
@@ -144,6 +145,9 @@ function QueueItemRow({
               {decisionStatusCopy[decision.status || "detected"]}
             </span>
             <span style={{ color: "#475569", fontSize: 12 }}>{decision.reason}</span>
+            <div style={{ width: "100%" }}>
+              <DecisionContextPanel decision={decision} includeAdminReviewLink compact />
+            </div>
             <div style={{ display: "flex", gap: 6, flexWrap: "wrap", width: "100%" }}>
               {(["reviewed", "snoozed", "assigned", "dismissed", "resolved"] as DecisionActionType[]).map((actionType) => (
                 <Button


### PR DESCRIPTION
## Summary
- Adds deterministic decision context link helpers.
- Adds reusable DecisionContextPanel with Context, Evidence, and Review trail sections.
- Links decisions to related lease, ledger, property/unit, tenant, and admin review context.
- Shows evidence summaries for decision reason, severity, delinquency signal, obligation status, outstanding amount, lifecycle state/reasons, payment references, and last action.
- Integrates context visibility into dashboard, lease ledger, and admin lifecycle review surfaces.
- Preserves existing decision lifecycle actions.
- Frontend/docs only; no backend, automation, lease/payment mutation, Stripe/webhook changes, Trustly, PaymentIntent enforcement, dependency, or lockfile changes.

## Verification
- decisionContext and DecisionContextPanel tests passed: 6 tests.
- focused dashboard/lease ledger/admin page tests passed: 25 tests.
- full frontend suite passed: 183 files / 751 tests.
- frontend build passed with existing chunk-size warning.
- git diff --check passed.
- backend diff empty.
- dependency/lockfile diff empty.