### PR TITLE
chore: add Codex governance discovery bootstrap

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,5 +1,7 @@
 # RentChain Architecture & Deployment Quick Guide
 
+For implementation workflow, mission execution, and repository discovery rules, follow `codex.md` and `PROCESS.md` when present.
+
 ## 1) What runs where
 - **Vercel**: `rentchain-frontend` only (static build + client-side app + serverless functions under `rentchain-frontend/api/*` for lightweight proxies/waitlist).
 - **Cloud Run**: `rentchain-api` (Express app). All core API routes live here.

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -12,6 +12,14 @@ Do not skip steps.
 
 Mission execution follows the Mission Promotion Pipeline: only the active mission is executed; future roadmap remains private.
 
+## Repository Discovery
+
+All missions inherit the repository discovery and governance-resolution rules from `codex.md` when `codex.md` exists.
+
+Mission prompts should not repeat generic repository bootstrap instructions unless the mission has specialized audit requirements.
+
+If `codex.md` is absent, Codex should follow the nearest available process/governance document and document assumptions.
+
 ---
 
 ## 1. Explore

--- a/codex.md
+++ b/codex.md
@@ -85,6 +85,43 @@ gcloud run deploy
 * `.codex/docs/auth.md`
 * `.codex/docs/pipeline.md`
 
+## Repository Discovery & Governance Resolution
+
+Before planning or implementing any mission, Codex must:
+
+1. Audit the repository structure.
+2. Identify the actual governance, workflow, architecture, and execution files present in the current branch.
+3. Follow discovered repository conventions.
+4. Avoid introducing duplicate systems, duplicate execution layers, or conflicting abstractions.
+5. Never assume files exist unless they are present.
+
+Expected inspection locations include:
+
+- repository root
+- `docs/`
+- `.github/`
+- `.codex/`
+- execution or mission folders
+- architecture or planning folders
+
+Possible governance files may include, when present:
+
+- `AGENTS.md`
+- `PROCESS.md`
+- `codex.md`
+- `specifications.md`
+- `ARCHITECTURE.md`
+- `CONTRIBUTING.md`
+- `docs/missions/_template.md`
+- `docs/execution/CURRENT_MISSION.md`
+
+If expected governance files are missing, Codex must:
+
+- proceed using nearby implementation patterns and existing repository conventions
+- document assumptions in the PR summary
+- avoid fabricating missing framework files
+- avoid adding mission-local bootstrap text unless the mission specifically requires specialized discovery behavior
+
 ## Strict Rule
 
 Only read sub-docs when specifically prompted for that domain.

--- a/docs/missions/_template.md
+++ b/docs/missions/_template.md
@@ -2,6 +2,8 @@
 
 MISSION: <Mission title>
 
+Codex must follow the repository discovery and governance-resolution rules defined in `codex.md` before implementation begins. If `codex.md` is unavailable, Codex must discover and follow the nearest available governance/process documents and document assumptions.
+
 # Branch
 
 BRANCH:


### PR DESCRIPTION
## Summary
- Adds canonical repository discovery and governance-resolution rules to codex.md.
- Cross-references the rule from PROCESS.md, docs/missions/_template.md, and ARCHITECTURE.md.
- Ensures future missions do not need repeated generic bootstrap instructions.
- Handles missing governance files gracefully.
- Confirms no product/runtime files were changed.

## Governance audit
Found:
- codex.md
- PROCESS.md
- AGENTS.md
- ARCHITECTURE.md
- docs/missions/_template.md
- docs/execution/CURRENT_MISSION.md
- .codex/
- .github/

Absent:
- specifications.md
- CONTRIBUTING.md

## Verification
- git diff --check passed.
- PR diff only includes documentation/governance files.
- rentchain-api diff empty.
- rentchain-frontend diff empty.
- No product/runtime files changed.