### PR TITLE
feat: add read-only decision inbox

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -119,6 +119,7 @@ import landlordAnalyticsAlertsRoutes from "./routes/landlordAnalyticsAlertsRoute
 import landlordAnalyticsBenchmarkingRoutes from "./routes/landlordAnalyticsBenchmarkingRoutes";
 import landlordPortfolioScoreRoutes from "./routes/landlordPortfolioScoreRoutes";
 import landlordPortfolioScoreSharingRoutes from "./routes/landlordPortfolioScoreSharingRoutes";
+import landlordDecisionInboxRoutes from "./routes/landlordDecisionInboxRoutes";
 import publicPortfolioScoreRoutes from "./routes/publicPortfolioScoreRoutes";
 import publicTenantShareRoutes from "./routes/publicTenantShareRoutes";
 import landlordActionRecommendationRoutes from "./routes/landlordActionRecommendationRoutes";
@@ -280,6 +281,8 @@ app.use("/api", routeSource("landlordPortfolioScoreRoutes.ts"), landlordPortfoli
 console.log("[route-mount] landlordPortfolioScoreRoutes mounted at /api");
 app.use("/api", routeSource("landlordPortfolioScoreSharingRoutes.ts"), landlordPortfolioScoreSharingRoutes);
 console.log("[route-mount] landlordPortfolioScoreSharingRoutes mounted at /api");
+app.use("/api/landlord", routeSource("landlordDecisionInboxRoutes.ts"), landlordDecisionInboxRoutes);
+console.log("[route-mount] landlordDecisionInboxRoutes mounted at /api/landlord");
 app.use("/api", routeSource("landlordActionRecommendationRoutes.ts"), landlordActionRecommendationRoutes);
 console.log("[route-mount] landlordActionRecommendationRoutes mounted at /api");
 app.use("/api", routeSource("tenantFeedbackRoutes.ts"), tenantFeedbackRoutes);

--- a/rentchain-api/src/lib/decisions/__tests__/deriveDecisionInbox.test.ts
+++ b/rentchain-api/src/lib/decisions/__tests__/deriveDecisionInbox.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import { deriveDecisionInbox } from "../deriveDecisionInbox";
+import type { Decision } from "../decisionEngine";
+import type { LandlordAgentDecision } from "../../analytics/analyticsTypes";
+
+function leaseDecision(overrides: Partial<Decision> = {}): Decision {
+  return {
+    decisionId: "decision:review_missing_payment:lease-1",
+    leaseId: "lease-1",
+    paymentIntentId: "pi-1",
+    rentPaymentId: null,
+    propertyId: "prop-1",
+    unitId: "unit-1",
+    tenantId: "tenant-1",
+    decisionType: "review_missing_payment",
+    severity: "critical",
+    status: "detected",
+    reason: "Expected rent payment is missing.",
+    metadata: { source: "delinquency_signal" },
+    createdAt: "2026-05-05T12:00:00.000Z",
+    updatedAt: "2026-05-05T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function analyticsDecision(overrides: Partial<LandlordAgentDecision> = {}): LandlordAgentDecision {
+  return {
+    id: "approve_maintenance_cost:wo-1",
+    decisionType: "approve_maintenance_cost",
+    priority: "high",
+    explanation: "A maintenance cost needs review.",
+    supportingSignals: [],
+    recommendedAction: "Open cost approval",
+    state: "pending",
+    actionKey: "open_maintenance_cost_approval_flow",
+    actionLabel: "Open cost approval",
+    destination: "/work-orders?workOrderId=wo-1",
+    workflowCategory: "maintenance_cost_approval",
+    automationEligible: true,
+    automationState: "ready",
+    automationReason: "Execution is available elsewhere but not from the inbox.",
+    executionMappingState: "mapped",
+    executionMapping: {
+      action: "maintenance.auto_approve_cost",
+      resourceType: "work_order",
+      resourceId: "wo-1",
+      prerequisitesMet: true,
+      prerequisiteReason: null,
+    },
+    executionInputState: "complete",
+    executionInputReason: null,
+    executionInputMissingFields: [],
+    executionInput: null,
+    executionState: "executable",
+    blockedReason: null,
+    executionGuardKey: "maintenance.auto_approve_cost:work_order:wo-1",
+    duplicateGuardActive: false,
+    executionSummary: {
+      lastExecutedAt: null,
+      executionCount: 0,
+      lastExecutionOutcome: "none",
+      lastExecutionOutcomeAt: null,
+    },
+    executionOutcomeStatus: "none",
+    executionOutcomeAt: null,
+    executionOutcomeReason: null,
+    ...overrides,
+  };
+}
+
+describe("deriveDecisionInbox", () => {
+  it("normalizes existing lease and analytics decisions into a read-only inbox", () => {
+    const result = deriveDecisionInbox({
+      leaseDecisions: [leaseDecision()],
+      analyticsDecisions: [analyticsDecision()],
+    });
+
+    expect(result.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "decision:review_missing_payment:lease-1",
+          severity: "critical",
+          status: "open",
+          type: "billing",
+          source: "lease_ledger",
+          destination: "/leases/lease-1/ledger",
+          automationEligible: false,
+        }),
+        expect.objectContaining({
+          id: "approve_maintenance_cost:wo-1",
+          severity: "high",
+          status: "open",
+          type: "maintenance",
+          source: "analytics",
+          destination: "/work-orders?workOrderId=wo-1",
+          automationEligible: false,
+        }),
+      ])
+    );
+  });
+
+  it("filters by severity, status, and type deterministically", () => {
+    const result = deriveDecisionInbox({
+      leaseDecisions: [
+        leaseDecision(),
+        leaseDecision({
+          decisionId: "decision:review_underpaid_rent:lease-2",
+          leaseId: "lease-2",
+          decisionType: "review_underpaid_rent",
+          severity: "warning",
+          status: "reviewed",
+        }),
+      ],
+      analyticsDecisions: [analyticsDecision()],
+      filters: { severity: "medium", status: "pending", type: "billing" },
+    });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toEqual(
+      expect.objectContaining({
+        id: "decision:review_underpaid_rent:lease-2",
+        severity: "medium",
+        status: "pending",
+        type: "billing",
+      })
+    );
+  });
+
+  it("returns summary counts for the filtered result", () => {
+    const result = deriveDecisionInbox({
+      leaseDecisions: [leaseDecision(), leaseDecision({ decisionId: "decision:resolved", status: "resolved" })],
+      analyticsDecisions: [analyticsDecision({ id: "blocked-decision", executionState: "blocked" })],
+    });
+
+    expect(result.summary).toEqual({
+      total: 3,
+      critical: 2,
+      high: 1,
+      open: 1,
+      blocked: 1,
+    });
+  });
+});

--- a/rentchain-api/src/lib/decisions/decisionInboxTypes.ts
+++ b/rentchain-api/src/lib/decisions/decisionInboxTypes.ts
@@ -1,0 +1,57 @@
+export type DecisionInboxSeverity = "critical" | "high" | "medium" | "low" | "info" | "unknown";
+
+export type DecisionInboxStatus = "open" | "pending" | "blocked" | "resolved" | "dismissed" | "unknown";
+
+export type DecisionInboxType =
+  | "lease"
+  | "screening"
+  | "maintenance"
+  | "compliance"
+  | "admin"
+  | "property"
+  | "tenant"
+  | "billing"
+  | "unknown";
+
+export type DecisionInboxSource = "dashboard" | "lease_ledger" | "admin_review" | "analytics" | "unknown";
+
+export type DecisionInboxRelatedEntity = {
+  kind: "lease" | "application" | "tenant" | "property" | "unit" | "maintenance_request" | "unknown";
+  id: string;
+  label: string;
+};
+
+export type DecisionInboxItem = {
+  id: string;
+  title: string;
+  description: string;
+  severity: DecisionInboxSeverity;
+  status: DecisionInboxStatus;
+  type: DecisionInboxType;
+  source: DecisionInboxSource;
+  relatedEntity: DecisionInboxRelatedEntity | null;
+  destination: string | null;
+  automationEligible: false;
+  createdAt: string | null;
+  updatedAt: string | null;
+};
+
+export type DecisionInboxFilters = {
+  severity: DecisionInboxSeverity[];
+  status: DecisionInboxStatus[];
+  type: DecisionInboxType[];
+};
+
+export type DecisionInboxSummary = {
+  total: number;
+  critical: number;
+  high: number;
+  open: number;
+  blocked: number;
+};
+
+export type DecisionInboxResult = {
+  items: DecisionInboxItem[];
+  filters: DecisionInboxFilters;
+  summary: DecisionInboxSummary;
+};

--- a/rentchain-api/src/lib/decisions/deriveDecisionInbox.ts
+++ b/rentchain-api/src/lib/decisions/deriveDecisionInbox.ts
@@ -1,0 +1,254 @@
+import type { LandlordAgentDecision } from "../analytics/analyticsTypes";
+import type { Decision } from "./decisionEngine";
+import type {
+  DecisionInboxItem,
+  DecisionInboxResult,
+  DecisionInboxSeverity,
+  DecisionInboxSource,
+  DecisionInboxStatus,
+  DecisionInboxType,
+} from "./decisionInboxTypes";
+
+type SourceDecision = Decision & { latestAction?: unknown };
+
+export type DeriveDecisionInboxInput = {
+  leaseDecisions?: SourceDecision[] | null;
+  analyticsDecisions?: LandlordAgentDecision[] | null;
+  filters?: {
+    severity?: unknown;
+    status?: unknown;
+    type?: unknown;
+  } | null;
+};
+
+const KNOWN_SEVERITIES = new Set<DecisionInboxSeverity>(["critical", "high", "medium", "low", "info", "unknown"]);
+const KNOWN_STATUSES = new Set<DecisionInboxStatus>(["open", "pending", "blocked", "resolved", "dismissed", "unknown"]);
+const KNOWN_TYPES = new Set<DecisionInboxType>([
+  "lease",
+  "screening",
+  "maintenance",
+  "compliance",
+  "admin",
+  "property",
+  "tenant",
+  "billing",
+  "unknown",
+]);
+
+function asString(value: unknown, max = 500): string | null {
+  const next = String(value ?? "").trim().slice(0, max);
+  return next || null;
+}
+
+function normalizeDate(value: unknown): string | null {
+  const raw = asString(value, 120);
+  if (!raw) return null;
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toISOString();
+}
+
+function titleCase(value: unknown): string {
+  const text = asString(value, 120);
+  if (!text) return "Decision";
+  return text.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function cleanId(value: unknown): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function fallbackId(source: DecisionInboxSource, rawId: unknown, type: unknown) {
+  return cleanId(["decision_inbox", source, rawId || type || "unknown"].join(":")) || "decision_inbox:unknown";
+}
+
+function decisionEngineSeverity(value: unknown): DecisionInboxSeverity {
+  const severity = asString(value, 40);
+  if (severity === "critical") return "critical";
+  if (severity === "warning") return "medium";
+  if (severity === "info") return "info";
+  return "unknown";
+}
+
+function analyticsSeverity(value: unknown): DecisionInboxSeverity {
+  const priority = asString(value, 40);
+  if (priority === "high") return "high";
+  if (priority === "medium") return "medium";
+  if (priority === "low") return "low";
+  return "unknown";
+}
+
+function decisionStatus(value: unknown): DecisionInboxStatus {
+  const status = asString(value, 40);
+  if (status === "dismissed") return "dismissed";
+  if (status === "resolved" || status === "accepted") return "resolved";
+  if (status === "reviewed" || status === "snoozed" || status === "assigned" || status === "surfaced") return "pending";
+  if (status === "detected" || !status) return "open";
+  return "unknown";
+}
+
+function analyticsStatus(decision: LandlordAgentDecision): DecisionInboxStatus {
+  if (decision.executionState === "blocked" || decision.executionState === "unsafe_duplicate") return "blocked";
+  if (decision.state === "dismissed") return "dismissed";
+  if (decision.state === "executed") return "resolved";
+  if (decision.state === "reviewed" || decision.state === "snoozed") return "pending";
+  if (decision.state === "pending") return "open";
+  return "unknown";
+}
+
+function typeFromDecisionType(value: unknown): DecisionInboxType {
+  const type = asString(value, 120);
+  if (!type) return "unknown";
+  if (type.includes("rent") || type.includes("payment") || type.includes("revenue")) return "billing";
+  if (type.includes("lease") || type.includes("occupancy") || type.includes("renewal") || type.includes("vacancy")) return "lease";
+  if (type.includes("screening") || type.includes("application_conversion") || type.includes("application")) return "screening";
+  if (type.includes("maintenance")) return "maintenance";
+  if (type.includes("property")) return "property";
+  return "unknown";
+}
+
+function destinationForLeaseDecision(decision: SourceDecision): string | null {
+  const leaseId = asString(decision.leaseId, 240);
+  if (!leaseId) return null;
+  const type = asString(decision.decisionType, 120) || "";
+  if (type.includes("rent") || type.includes("payment")) return `/leases/${encodeURIComponent(leaseId)}/ledger`;
+  return `/leases/${encodeURIComponent(leaseId)}/summary`;
+}
+
+function relatedEntityForLeaseDecision(decision: SourceDecision): DecisionInboxItem["relatedEntity"] {
+  const leaseId = asString(decision.leaseId, 240);
+  if (leaseId) {
+    return { kind: "lease", id: leaseId, label: `Lease ${leaseId}` };
+  }
+  const propertyId = asString(decision.propertyId, 240);
+  if (propertyId) {
+    return { kind: "property", id: propertyId, label: `Property ${propertyId}` };
+  }
+  return null;
+}
+
+function relatedEntityForAnalyticsDecision(decision: LandlordAgentDecision): DecisionInboxItem["relatedEntity"] {
+  const resourceType = asString(decision.executionMapping?.resourceType, 120);
+  const resourceId = asString(decision.executionMapping?.resourceId, 240);
+  if (resourceType && resourceId) {
+    if (resourceType === "rental_application") {
+      return { kind: "application", id: resourceId, label: `Application ${resourceId}` };
+    }
+    if (resourceType === "work_order") {
+      return { kind: "maintenance_request", id: resourceId, label: `Work order ${resourceId}` };
+    }
+    if (resourceType === "lease") {
+      return { kind: "lease", id: resourceId, label: `Lease ${resourceId}` };
+    }
+  }
+  const propertyId = decision.supportingSignals?.map((signal) => asString(signal.propertyId, 240)).find(Boolean);
+  if (propertyId) return { kind: "property", id: propertyId, label: `Property ${propertyId}` };
+  return null;
+}
+
+export function decisionInboxItemFromLeaseDecision(decision: SourceDecision): DecisionInboxItem {
+  const type = typeFromDecisionType(decision.decisionType);
+  return {
+    id: asString(decision.decisionId, 600) || fallbackId("lease_ledger", decision.decisionId, decision.decisionType),
+    title: titleCase(decision.decisionType),
+    description: asString(decision.reason, 1000) || "Decision context is available for review.",
+    severity: decisionEngineSeverity(decision.severity),
+    status: decisionStatus(decision.status),
+    type,
+    source: "lease_ledger",
+    relatedEntity: relatedEntityForLeaseDecision(decision),
+    destination: destinationForLeaseDecision(decision),
+    automationEligible: false,
+    createdAt: normalizeDate(decision.createdAt),
+    updatedAt: normalizeDate(decision.updatedAt),
+  };
+}
+
+export function decisionInboxItemFromAnalyticsDecision(decision: LandlordAgentDecision): DecisionInboxItem {
+  return {
+    id: asString(decision.id, 600) || fallbackId("analytics", decision.id, decision.decisionType),
+    title: asString(decision.actionLabel || decision.recommendedAction, 240) || titleCase(decision.decisionType),
+    description: asString(decision.explanation || decision.recommendedAction, 1000) || "Analytics decision context is available for review.",
+    severity: analyticsSeverity(decision.priority),
+    status: analyticsStatus(decision),
+    type: typeFromDecisionType(decision.decisionType),
+    source: "analytics",
+    relatedEntity: relatedEntityForAnalyticsDecision(decision),
+    destination: asString(decision.destination || decision.href, 500),
+    automationEligible: false,
+    createdAt: null,
+    updatedAt: normalizeDate(decision.reviewedAt || decision.executedAt || decision.executionOutcomeAt),
+  };
+}
+
+function filterValue<T extends string>(value: unknown, known: Set<T>): T | null {
+  const raw = asString(value, 80)?.toLowerCase();
+  if (!raw || raw === "all") return null;
+  return known.has(raw as T) ? (raw as T) : null;
+}
+
+function uniqueSorted<T extends string>(values: T[], known: readonly T[]): T[] {
+  const present = new Set(values);
+  return known.filter((value) => present.has(value));
+}
+
+export function deriveDecisionInbox(input: DeriveDecisionInboxInput): DecisionInboxResult {
+  const allItems = [
+    ...(input.analyticsDecisions || []).map(decisionInboxItemFromAnalyticsDecision),
+    ...(input.leaseDecisions || []).map(decisionInboxItemFromLeaseDecision),
+  ].sort((a, b) => {
+    const severityOrder: Record<DecisionInboxSeverity, number> = {
+      critical: 0,
+      high: 1,
+      medium: 2,
+      low: 3,
+      info: 4,
+      unknown: 5,
+    };
+    return (
+      severityOrder[a.severity] - severityOrder[b.severity] ||
+      (b.updatedAt || b.createdAt || "").localeCompare(a.updatedAt || a.createdAt || "") ||
+      a.id.localeCompare(b.id)
+    );
+  });
+
+  const severity = filterValue(input.filters?.severity, KNOWN_SEVERITIES);
+  const status = filterValue(input.filters?.status, KNOWN_STATUSES);
+  const type = filterValue(input.filters?.type, KNOWN_TYPES);
+  const items = allItems.filter((item) => {
+    if (severity && item.severity !== severity) return false;
+    if (status && item.status !== status) return false;
+    if (type && item.type !== type) return false;
+    return true;
+  });
+
+  return {
+    items,
+    filters: {
+      severity: uniqueSorted(
+        allItems.map((item) => item.severity),
+        ["critical", "high", "medium", "low", "info", "unknown"]
+      ),
+      status: uniqueSorted(
+        allItems.map((item) => item.status),
+        ["open", "pending", "blocked", "resolved", "dismissed", "unknown"]
+      ),
+      type: uniqueSorted(
+        allItems.map((item) => item.type),
+        ["lease", "screening", "maintenance", "compliance", "admin", "property", "tenant", "billing", "unknown"]
+      ),
+    },
+    summary: {
+      total: items.length,
+      critical: items.filter((item) => item.severity === "critical").length,
+      high: items.filter((item) => item.severity === "high").length,
+      open: items.filter((item) => item.status === "open").length,
+      blocked: items.filter((item) => item.status === "blocked").length,
+    },
+  };
+}

--- a/rentchain-api/src/routes/__tests__/landlordDecisionInboxRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordDecisionInboxRoutes.test.ts
@@ -1,0 +1,238 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+
+  function matches(doc: any, filters: Array<{ field: string; op: string; value: any }>) {
+    return filters.every(({ field, op, value }) => {
+      const actual = doc?.data?.[field];
+      if (op === "==") return actual === value;
+      return false;
+    });
+  }
+
+  function makeQuery(name: string, filters: Array<{ field: string; op: string; value: any }> = []) {
+    return {
+      where: (field: string, op: string, value: any) => makeQuery(name, [...filters, { field, op, value }]),
+      get: async () => {
+        const docs = Array.from(ensureCollection(name).values())
+          .filter((doc) => matches(doc, filters))
+          .map((doc) => ({ id: doc.id, exists: true, data: () => doc.data }));
+        return { docs, empty: docs.length === 0, size: docs.length };
+      },
+      doc: (id: string) => makeDoc(name, id),
+    };
+  }
+
+  function makeDoc(name: string, id: string) {
+    const col = ensureCollection(name);
+    return {
+      id,
+      get: async () => {
+        const entry = col.get(id);
+        return { id, exists: Boolean(entry), data: () => entry?.data };
+      },
+      set: async (data: any) => {
+        col.set(id, { id, data });
+      },
+    };
+  }
+
+  return {
+    resetFakeDb: () => store.clear(),
+    seedDoc: (collection: string, id: string, data: any) => ensureCollection(collection).set(id, { id, data }),
+    fakeDb: {
+      collection: (name: string) => ({
+        where: (field: string, op: string, value: any) => makeQuery(name, [{ field, op, value }]),
+        get: async () => makeQuery(name).get(),
+        doc: (id: string) => makeDoc(name, id),
+      }),
+    },
+  };
+});
+
+const loadLandlordAnalyticsSnapshot = vi.fn();
+let mockUser: any;
+
+vi.mock("../../config/firebase", () => ({
+  db: fakeDb,
+}));
+
+vi.mock("../../services/landlord/landlordAnalyticsSnapshot", () => ({
+  loadLandlordAnalyticsSnapshot,
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!mockUser) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    req.user = mockUser;
+    return next();
+  },
+}));
+
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: any, res: any, next: any) => {
+    const role = String(req.user?.role || "").trim().toLowerCase();
+    const landlordId = req.user?.landlordId || req.user?.id;
+    if (role !== "landlord" && role !== "admin") return res.status(403).json({ ok: false, error: "Forbidden" });
+    if (!landlordId) return res.status(401).json({ ok: false, error: "Missing landlord context" });
+    req.user.landlordId = landlordId;
+    return next();
+  },
+}));
+
+function analyticsDecision(overrides: Record<string, any> = {}) {
+  return {
+    id: "approve_maintenance_cost:wo-1",
+    decisionType: "approve_maintenance_cost",
+    priority: "high",
+    explanation: "A maintenance cost needs review.",
+    supportingSignals: [],
+    recommendedAction: "Open cost approval",
+    state: "pending",
+    actionLabel: "Open cost approval",
+    destination: "/work-orders?workOrderId=wo-1",
+    automationEligible: true,
+    executionState: "executable",
+    executionMapping: {
+      resourceType: "work_order",
+      resourceId: "wo-1",
+    },
+    ...overrides,
+  };
+}
+
+function seedLease(overrides: Record<string, any> = {}) {
+  seedDoc("leases", overrides.id || "lease-1", {
+    landlordId: "landlord-1",
+    propertyId: "prop-1",
+    unitId: "unit-1",
+    tenantId: "tenant-1",
+    monthlyRent: 1800,
+    startDate: "2026-04-01",
+    endDate: "2027-03-31",
+    dueDate: "2026-04-01",
+    signedAt: "2026-04-01T00:00:00.000Z",
+    status: "active",
+    ...overrides,
+  });
+}
+
+async function invokeRouter(router: any, options: { method: string; url: string; user?: Record<string, unknown> | null }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    const query = new URLSearchParams(queryString || "");
+    mockUser = options.user ?? mockUser;
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: mockUser,
+      body: {},
+      query: Object.fromEntries(query.entries()),
+      params: {},
+      headers: {},
+    };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("landlordDecisionInboxRoutes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    resetFakeDb();
+    mockUser = { id: "landlord-1", landlordId: "landlord-1", role: "landlord", email: "landlord@example.com" };
+    loadLandlordAnalyticsSnapshot.mockResolvedValue({ decisions: { items: [analyticsDecision()] } });
+  });
+
+  it("returns read-only normalized decision inbox items and summary counts", async () => {
+    seedLease();
+    const router = (await import("../landlordDecisionInboxRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/decision-inbox" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "approve_maintenance_cost:wo-1",
+          source: "analytics",
+          type: "maintenance",
+          severity: "high",
+          automationEligible: false,
+        }),
+        expect.objectContaining({
+          source: "lease_ledger",
+          type: "billing",
+          severity: "critical",
+          destination: "/leases/lease-1/ledger",
+          automationEligible: false,
+        }),
+      ])
+    );
+    expect(res.body.summary).toEqual(expect.objectContaining({ total: 3, critical: 2, high: 1, open: 3 }));
+  });
+
+  it("filters inbox items by severity, status, and type", async () => {
+    seedLease();
+    const router = (await import("../landlordDecisionInboxRoutes")).default;
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/decision-inbox?severity=critical&status=open&type=billing",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(2);
+    expect(res.body.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ source: "lease_ledger", type: "billing" }),
+      ])
+    );
+  });
+
+  it("does not expose another landlord's lease decisions", async () => {
+    seedLease({ id: "lease-other", landlordId: "landlord-2" });
+    loadLandlordAnalyticsSnapshot.mockResolvedValue({ decisions: { items: [] } });
+    const router = (await import("../landlordDecisionInboxRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/decision-inbox" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.items).toEqual([]);
+    expect(res.body.summary.total).toBe(0);
+  });
+
+  it("blocks non-landlord users", async () => {
+    const router = (await import("../landlordDecisionInboxRoutes")).default;
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/decision-inbox",
+      user: { id: "tenant-1", role: "tenant" },
+    });
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/rentchain-api/src/routes/landlordDecisionInboxRoutes.ts
+++ b/rentchain-api/src/routes/landlordDecisionInboxRoutes.ts
@@ -1,0 +1,187 @@
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { requireAuth } from "../middleware/requireAuth";
+import { requireLandlord } from "../middleware/requireLandlord";
+import { loadLandlordAnalyticsSnapshot } from "../services/landlord/landlordAnalyticsSnapshot";
+import { deriveDecisionInbox } from "../lib/decisions/deriveDecisionInbox";
+import { deriveDecisions, type Decision } from "../lib/decisions/decisionEngine";
+import { applyDecisionActions, DECISION_ACTIONS_COLLECTION } from "../lib/decisions/decisionActions";
+import { deriveLeaseLifecycleState } from "../lib/leases/leaseLifecycle";
+import { buildPaymentObligationLedgerRows } from "../lib/payments/paymentObligationLedger";
+import { deriveDelinquencySignals } from "../lib/payments/delinquencySignals";
+import type { RentPaymentRecord } from "../services/rentPayments/rentPaymentService";
+
+const router = Router();
+
+function asString(value: unknown, max = 1000) {
+  const next = String(value ?? "").trim().slice(0, max);
+  return next || "";
+}
+
+function normalizeLeaseRentAmountCents(value: unknown): number {
+  const amount = Number(value);
+  if (!Number.isFinite(amount) || amount <= 0) return 0;
+  return Math.round(amount * 100);
+}
+
+async function loadLandlordLeases(landlordId: string) {
+  const byId = new Map<string, any>();
+  async function collect(field: "landlordId" | "ownerId" | "userId") {
+    const snap = await db.collection("leases").where(field, "==", landlordId).get().catch(() => null);
+    for (const doc of snap?.docs || []) {
+      byId.set(doc.id, { id: doc.id, ...((doc.data() as any) || {}) });
+    }
+  }
+  await Promise.all([collect("landlordId"), collect("ownerId"), collect("userId")]);
+  return Array.from(byId.values()).filter((lease) => {
+    return [lease?.landlordId, lease?.ownerId, lease?.userId].some((value) => asString(value, 240) === landlordId);
+  });
+}
+
+async function loadLeaseRentPayments(leaseId: string, landlordId: string): Promise<RentPaymentRecord[]> {
+  const snap = await db.collection("rentPayments").where("leaseId", "==", leaseId).get().catch(() => null);
+  return (snap?.docs || [])
+    .map((doc: any) => ({ id: doc.id, ...((doc.data() as any) || {}) }))
+    .filter((record: any) => asString(record?.landlordId, 240) === landlordId)
+    .map((record: any) => ({
+      id: asString(record?.id || record?.rentPaymentId || record?.paymentId || docId(record), 240),
+      leaseId: asString(record?.leaseId, 240),
+      tenantId: asString(record?.tenantId, 240),
+      landlordId: asString(record?.landlordId, 240),
+      propertyId: asString(record?.propertyId, 240) || null,
+      unitId: asString(record?.unitId, 240) || null,
+      paymentIntentId: asString(record?.paymentIntentId, 240) || null,
+      amountCents: Math.max(0, Math.round(Number(record?.amountCents || 0))),
+      currency: "cad" as const,
+      status: asString(record?.status || "setup_required", 80) as RentPaymentRecord["status"],
+      processor: "stripe" as const,
+      processorCheckoutSessionId: asString(record?.processorCheckoutSessionId, 240) || null,
+      processorPaymentIntentId: asString(record?.processorPaymentIntentId, 240) || null,
+      createdAt: asString(record?.createdAt, 120),
+      updatedAt: asString(record?.updatedAt, 120),
+      paidAt: asString(record?.paidAt, 120) || null,
+    }));
+}
+
+function docId(record: any) {
+  return asString(record?.id, 240);
+}
+
+async function loadLeasePaymentIntents(leaseId: string, landlordId: string) {
+  const snap = await db.collection("paymentIntents").where("leaseId", "==", leaseId).get().catch(() => null);
+  return (snap?.docs || [])
+    .map((doc: any) => ({ paymentIntentId: doc.id, ...((doc.data() as any) || {}) }))
+    .filter((record: any) => asString(record?.landlordId, 240) === landlordId);
+}
+
+async function loadLeaseReconciliationRecords(params: {
+  leaseId: string;
+  paymentIntentIds: string[];
+  rentPaymentIds: string[];
+}) {
+  const records = new Map<string, any>();
+  async function collect(field: string, value: string) {
+    const normalized = asString(value, 240);
+    if (!normalized) return;
+    const snap = await db.collection("paymentReconciliationRecords").where(field, "==", normalized).get().catch(() => null);
+    for (const doc of snap?.docs || []) {
+      records.set(doc.id, { reconciliationId: doc.id, ...((doc.data() as any) || {}) });
+    }
+  }
+  await collect("leaseId", params.leaseId);
+  await collect("subjectId", params.leaseId);
+  for (const paymentIntentId of params.paymentIntentIds) await collect("paymentIntentId", paymentIntentId);
+  for (const rentPaymentId of params.rentPaymentIds) {
+    await collect("rentPaymentId", rentPaymentId);
+    await collect("subjectId", rentPaymentId);
+  }
+  return Array.from(records.values());
+}
+
+async function loadDecisionActionsForLease(leaseId: string) {
+  const snap = await db.collection(DECISION_ACTIONS_COLLECTION).where("leaseId", "==", leaseId).get().catch(() => null);
+  return (snap?.docs || []).map((doc: any) => ({ id: doc.id, ...((doc.data() as any) || {}) }));
+}
+
+async function deriveLeaseDecisionsForInbox(landlordId: string): Promise<Decision[]> {
+  const leases = await loadLandlordLeases(landlordId);
+  const nested = await Promise.all(
+    leases.map(async (lease) => {
+      const leaseId = asString(lease?.id, 240);
+      if (!leaseId) return [];
+      const [rentPayments, paymentIntents, actions] = await Promise.all([
+        loadLeaseRentPayments(leaseId, landlordId),
+        loadLeasePaymentIntents(leaseId, landlordId),
+        loadDecisionActionsForLease(leaseId),
+      ]);
+      const reconciliationRecords = await loadLeaseReconciliationRecords({
+        leaseId,
+        paymentIntentIds: paymentIntents.map((record: any) => asString(record?.paymentIntentId, 240)).filter(Boolean),
+        rentPaymentIds: rentPayments.map((record) => asString(record?.id, 240)).filter(Boolean),
+      });
+      const lifecycle = deriveLeaseLifecycleState({ id: leaseId, ...lease });
+      const obligationRows = buildPaymentObligationLedgerRows({
+        leases: [
+          {
+            ...lease,
+            id: leaseId,
+            amountCents: normalizeLeaseRentAmountCents(lease?.monthlyRent),
+            derivedLifecycleState: lifecycle.state,
+          },
+        ],
+        paymentIntents,
+        rentPayments,
+        reconciliationRecords,
+      });
+      const delinquencySignals = deriveDelinquencySignals(obligationRows);
+      const decisions = deriveDecisions({
+        delinquencySignals,
+        leaseLifecycle: {
+          ...lifecycle,
+          leaseId,
+          propertyId: asString(lease?.propertyId, 240) || null,
+          unitId: asString(lease?.unitId, 240) || null,
+          tenantId: asString(lease?.tenantId || lease?.primaryTenantId, 240) || null,
+        },
+        obligationRows,
+      });
+      return applyDecisionActions(decisions, actions);
+    })
+  );
+  return nested.flat();
+}
+
+router.get("/decision-inbox", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = asString(req.user?.landlordId || req.user?.id, 240);
+    if (!landlordId) {
+      return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    }
+
+    const [snapshot, leaseDecisions] = await Promise.all([
+      loadLandlordAnalyticsSnapshot({
+        landlordId,
+        period: req.query?.period,
+        propertyId: req.query?.propertyId,
+      }),
+      deriveLeaseDecisionsForInbox(landlordId),
+    ]);
+
+    const inbox = deriveDecisionInbox({
+      analyticsDecisions: Array.isArray(snapshot?.decisions?.items) ? snapshot.decisions.items : [],
+      leaseDecisions,
+      filters: {
+        severity: req.query?.severity,
+        status: req.query?.status,
+        type: req.query?.type,
+      },
+    });
+
+    return res.json({ ok: true, ...inbox });
+  } catch (err: any) {
+    console.error("[landlord-decision-inbox] failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "DECISION_INBOX_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -94,6 +94,10 @@ vi.mock("./pages/landlord/LandlordAnalyticsPage", () => ({
   default: () => <h1>Landlord Analytics Dashboard</h1>,
 }));
 
+vi.mock("./pages/DecisionInboxPage", () => ({
+  default: () => <h1>Decision Inbox Page</h1>,
+}));
+
 vi.mock("./pages/landlord/PortfolioScorePage", () => ({
   default: () => <h1>Landlord Portfolio Score</h1>,
 }));
@@ -215,6 +219,20 @@ describe("Routes: /automation/timeline", () => {
     );
 
     expect(await screen.findByText(/Automation Timeline/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Routes: /decision-inbox", () => {
+  it("renders the read-only decision inbox route", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/decision-inbox"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Decision Inbox Page/i)).toBeInTheDocument();
     expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -116,6 +116,7 @@ const PortfolioScoreHistoryPage = lazy(() => import("./pages/admin/PortfolioScor
 const PortfolioHealthSummaryPage = lazy(() => import("./pages/landlord/PortfolioHealthSummaryPage"));
 const LandlordAnalyticsPage = lazy(() => import("./pages/landlord/LandlordAnalyticsPage"));
 const LandlordInboxPage = lazy(() => import("./pages/landlord/LandlordInboxPage"));
+const DecisionInboxPage = lazy(() => import("./pages/DecisionInboxPage"));
 const LandlordPortfolioScorePage = lazy(() => import("./pages/landlord/PortfolioScorePage"));
 const SharedPortfolioScorePage = lazy(() => import("./pages/public/SharedPortfolioScorePage"));
 const TenantSharePackagePage = lazy(() => import("./pages/public/TenantSharePackagePage"));
@@ -499,6 +500,18 @@ function App() {
               <LandlordNav>
                 <Suspense fallback={null}>
                   <LandlordInboxPage />
+                </Suspense>
+              </LandlordNav>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/decision-inbox"
+          element={
+            <RequireAuth>
+              <LandlordNav>
+                <Suspense fallback={null}>
+                  <DecisionInboxPage />
                 </Suspense>
               </LandlordNav>
             </RequireAuth>

--- a/rentchain-frontend/src/api/decisionInboxApi.ts
+++ b/rentchain-frontend/src/api/decisionInboxApi.ts
@@ -1,0 +1,69 @@
+import { apiFetch } from "./apiFetch";
+
+export type DecisionInboxSeverity = "critical" | "high" | "medium" | "low" | "info" | "unknown";
+export type DecisionInboxStatus = "open" | "pending" | "blocked" | "resolved" | "dismissed" | "unknown";
+export type DecisionInboxType =
+  | "lease"
+  | "screening"
+  | "maintenance"
+  | "compliance"
+  | "admin"
+  | "property"
+  | "tenant"
+  | "billing"
+  | "unknown";
+
+export type DecisionInboxItem = {
+  id: string;
+  title: string;
+  description: string;
+  severity: DecisionInboxSeverity;
+  status: DecisionInboxStatus;
+  type: DecisionInboxType;
+  source: "dashboard" | "lease_ledger" | "admin_review" | "analytics" | "unknown";
+  relatedEntity: {
+    kind: "lease" | "application" | "tenant" | "property" | "unit" | "maintenance_request" | "unknown";
+    id: string;
+    label: string;
+  } | null;
+  destination: string | null;
+  automationEligible: false;
+  createdAt: string | null;
+  updatedAt: string | null;
+};
+
+export type DecisionInboxResponse = {
+  items: DecisionInboxItem[];
+  filters: {
+    severity: DecisionInboxSeverity[];
+    status: DecisionInboxStatus[];
+    type: DecisionInboxType[];
+  };
+  summary: {
+    total: number;
+    critical: number;
+    high: number;
+    open: number;
+    blocked: number;
+  };
+};
+
+export type DecisionInboxQuery = {
+  severity?: DecisionInboxSeverity | "all";
+  status?: DecisionInboxStatus | "all";
+  type?: DecisionInboxType | "all";
+};
+
+export async function fetchDecisionInbox(params?: DecisionInboxQuery): Promise<DecisionInboxResponse> {
+  const search = new URLSearchParams();
+  if (params?.severity && params.severity !== "all") search.set("severity", params.severity);
+  if (params?.status && params.status !== "all") search.set("status", params.status);
+  if (params?.type && params.type !== "all") search.set("type", params.type);
+  const suffix = search.toString() ? `?${search.toString()}` : "";
+  const response = await apiFetch<{ ok: true } & DecisionInboxResponse>(`/landlord/decision-inbox${suffix}`);
+  return {
+    items: response.items || [],
+    filters: response.filters || { severity: [], status: [], type: [] },
+    summary: response.summary || { total: 0, critical: 0, high: 0, open: 0, blocked: 0 },
+  };
+}

--- a/rentchain-frontend/src/components/layout/navConfig.ts
+++ b/rentchain-frontend/src/components/layout/navConfig.ts
@@ -71,6 +71,14 @@ export const NAV_ITEMS: NavItem[] = [
     requiresLandlordOrAdmin: true,
   },
   {
+    id: "decision-inbox",
+    label: "Decisions",
+    to: "/decision-inbox",
+    icon: Inbox,
+    showInDrawer: true,
+    requiresLandlordOrAdmin: true,
+  },
+  {
     id: "analytics",
     label: "Analytics",
     to: "/analytics",

--- a/rentchain-frontend/src/pages/DashboardPage.tsx
+++ b/rentchain-frontend/src/pages/DashboardPage.tsx
@@ -157,6 +157,9 @@ function DashboardDecisionSummaryPanel({
         <div style={{ color: text.muted, fontSize: 13, marginTop: 3 }}>
           Read-only decisions from detected rent and lease signals.
         </div>
+        <Link to="/decision-inbox" style={{ display: "inline-block", marginTop: 6, color: "#2563eb", fontWeight: 800 }}>
+          Open decision inbox
+        </Link>
       </div>
       {summary.total === 0 ? (
         <div style={{ color: "#166534", background: "#f0fdf4", border: "1px solid #bbf7d0", borderRadius: 10, padding: 10 }}>

--- a/rentchain-frontend/src/pages/DecisionInboxPage.test.tsx
+++ b/rentchain-frontend/src/pages/DecisionInboxPage.test.tsx
@@ -1,0 +1,158 @@
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import DecisionInboxPage from "./DecisionInboxPage";
+
+const apiMocks = vi.hoisted(() => ({
+  fetchDecisionInbox: vi.fn(),
+  showToast: vi.fn(),
+  macShellProps: vi.fn(),
+}));
+
+vi.mock("@/api/decisionInboxApi", async () => {
+  const actual = await vi.importActual<any>("@/api/decisionInboxApi");
+  return {
+    ...actual,
+    fetchDecisionInbox: apiMocks.fetchDecisionInbox,
+  };
+});
+
+vi.mock("@/components/ui/ToastProvider", () => ({
+  useToast: () => ({
+    showToast: apiMocks.showToast,
+  }),
+}));
+
+vi.mock("@/components/layout/MacShell", () => ({
+  MacShell: ({ children, ...props }: { children: React.ReactNode; showTopNav?: boolean }) => {
+    apiMocks.macShellProps(props);
+    return <div>{children}</div>;
+  },
+}));
+
+function inboxResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    items: [
+      {
+        id: "decision:review_missing_payment:lease-1",
+        title: "Review Missing Payment",
+        description: "Expected rent payment is missing.",
+        severity: "critical",
+        status: "open",
+        type: "billing",
+        source: "lease_ledger",
+        relatedEntity: { kind: "lease", id: "lease-1", label: "Lease lease-1" },
+        destination: "/leases/lease-1/ledger",
+        automationEligible: false,
+        createdAt: "2026-05-05T12:00:00.000Z",
+        updatedAt: "2026-05-05T12:00:00.000Z",
+      },
+      {
+        id: "approve_maintenance_cost:wo-1",
+        title: "Open cost approval",
+        description: "A maintenance cost needs review.",
+        severity: "high",
+        status: "blocked",
+        type: "maintenance",
+        source: "analytics",
+        relatedEntity: { kind: "maintenance_request", id: "wo-1", label: "Work order wo-1" },
+        destination: null,
+        automationEligible: false,
+        createdAt: null,
+        updatedAt: null,
+      },
+    ],
+    filters: {
+      severity: ["critical", "high"],
+      status: ["open", "blocked"],
+      type: ["billing", "maintenance"],
+    },
+    summary: {
+      total: 2,
+      critical: 1,
+      high: 1,
+      open: 1,
+      blocked: 1,
+    },
+    ...overrides,
+  };
+}
+
+describe("DecisionInboxPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiMocks.fetchDecisionInbox.mockResolvedValue(inboxResponse());
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders summary counts, badges, and safe context links", async () => {
+    render(
+      <MemoryRouter>
+        <DecisionInboxPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole("heading", { name: "Decision inbox" })).toBeInTheDocument();
+    expect(screen.getByText("Summary")).toBeInTheDocument();
+    expect(screen.getAllByText("Critical").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("High").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Open").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Blocked").length).toBeGreaterThan(0);
+    expect(screen.getByText("Review Missing Payment")).toBeInTheDocument();
+    expect(screen.getByText("Expected rent payment is missing.")).toBeInTheDocument();
+    expect(screen.getByText("Source: Lease Ledger")).toBeInTheDocument();
+    expect(screen.getByText("Related: Lease lease-1")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "View context" })).toHaveAttribute("href", "/leases/lease-1/ledger");
+    expect(screen.getByText("Open cost approval")).toBeInTheDocument();
+    expect(screen.getByText("No context link available")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /resolve|dismiss|snooze|approve|retry|execute/i })).not.toBeInTheDocument();
+    expect(apiMocks.macShellProps).toHaveBeenCalledWith(expect.objectContaining({ showTopNav: false }));
+  });
+
+  it("updates visible decisions through deterministic filters", async () => {
+    apiMocks.fetchDecisionInbox
+      .mockResolvedValueOnce(inboxResponse())
+      .mockResolvedValueOnce(
+        inboxResponse({
+          items: [inboxResponse().items[0]],
+          summary: { total: 1, critical: 1, high: 0, open: 1, blocked: 0 },
+        })
+      );
+
+    render(
+      <MemoryRouter>
+        <DecisionInboxPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Review Missing Payment")).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Severity"), { target: { value: "critical" } });
+
+    await waitFor(() => {
+      expect(apiMocks.fetchDecisionInbox).toHaveBeenLastCalledWith(
+        expect.objectContaining({ severity: "critical", status: "all", type: "all" })
+      );
+    });
+  });
+
+  it("renders an empty state when no decisions match filters", async () => {
+    apiMocks.fetchDecisionInbox.mockResolvedValue(
+      inboxResponse({
+        items: [],
+        summary: { total: 0, critical: 0, high: 0, open: 0, blocked: 0 },
+      })
+    );
+
+    render(
+      <MemoryRouter>
+        <DecisionInboxPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("No decisions match the current filters.")).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/DecisionInboxPage.tsx
+++ b/rentchain-frontend/src/pages/DecisionInboxPage.tsx
@@ -1,0 +1,246 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import {
+  fetchDecisionInbox,
+  type DecisionInboxItem,
+  type DecisionInboxResponse,
+  type DecisionInboxSeverity,
+  type DecisionInboxStatus,
+  type DecisionInboxType,
+} from "@/api/decisionInboxApi";
+import { MacShell } from "@/components/layout/MacShell";
+import { Card, Section } from "@/components/ui/Ui";
+import { useToast } from "@/components/ui/ToastProvider";
+
+type FilterValue<T extends string> = T | "all";
+
+const severityOptions: Array<FilterValue<DecisionInboxSeverity>> = [
+  "all",
+  "critical",
+  "high",
+  "medium",
+  "low",
+  "info",
+  "unknown",
+];
+const statusOptions: Array<FilterValue<DecisionInboxStatus>> = [
+  "all",
+  "open",
+  "pending",
+  "blocked",
+  "resolved",
+  "dismissed",
+  "unknown",
+];
+const typeOptions: Array<FilterValue<DecisionInboxType>> = [
+  "all",
+  "lease",
+  "screening",
+  "maintenance",
+  "compliance",
+  "admin",
+  "property",
+  "tenant",
+  "billing",
+  "unknown",
+];
+
+function label(value: string) {
+  if (value === "all") return "All";
+  return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function severityTone(severity: DecisionInboxSeverity) {
+  if (severity === "critical") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
+  if (severity === "high") return { color: "#9f1239", background: "#ffe4e6", border: "#fecdd3" };
+  if (severity === "medium") return { color: "#9a3412", background: "#ffedd5", border: "#fed7aa" };
+  if (severity === "low") return { color: "#075985", background: "#e0f2fe", border: "#bae6fd" };
+  if (severity === "info") return { color: "#334155", background: "#f1f5f9", border: "#cbd5e1" };
+  return { color: "#475569", background: "#f8fafc", border: "#e2e8f0" };
+}
+
+function statusTone(status: DecisionInboxStatus) {
+  if (status === "blocked") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
+  if (status === "open") return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
+  if (status === "pending") return { color: "#1d4ed8", background: "#dbeafe", border: "#bfdbfe" };
+  if (status === "resolved") return { color: "#166534", background: "#dcfce7", border: "#bbf7d0" };
+  if (status === "dismissed") return { color: "#475569", background: "#f1f5f9", border: "#cbd5e1" };
+  return { color: "#475569", background: "#f8fafc", border: "#e2e8f0" };
+}
+
+function Badge({ children, tone }: { children: React.ReactNode; tone: { color: string; background: string; border: string } }) {
+  return (
+    <span
+      style={{
+        border: `1px solid ${tone.border}`,
+        borderRadius: 999,
+        background: tone.background,
+        color: tone.color,
+        padding: "3px 9px",
+        fontSize: 12,
+        fontWeight: 800,
+        whiteSpace: "nowrap",
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+function DecisionInboxCard({ item }: { item: DecisionInboxItem }) {
+  return (
+    <Card style={{ display: "grid", gap: 12, borderRadius: 8 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+        <Badge tone={severityTone(item.severity)}>{label(item.severity)}</Badge>
+        <Badge tone={statusTone(item.status)}>{label(item.status)}</Badge>
+        <span style={{ color: "#475569", fontSize: 13, fontWeight: 700 }}>{label(item.type)}</span>
+        <span style={{ color: "#64748b", fontSize: 13 }}>Source: {label(item.source)}</span>
+      </div>
+      <div style={{ display: "grid", gap: 5 }}>
+        <div style={{ color: "#0f172a", fontSize: 17, fontWeight: 800 }}>{item.title}</div>
+        <div style={{ color: "#475569", lineHeight: 1.55 }}>{item.description}</div>
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
+        <span style={{ color: "#64748b", fontSize: 13 }}>
+          Related: {item.relatedEntity?.label || "Context unavailable"}
+        </span>
+        {item.destination ? (
+          <Link to={item.destination} style={{ color: "#2563eb", fontWeight: 800 }}>
+            View context
+          </Link>
+        ) : (
+          <span style={{ color: "#64748b", fontSize: 13 }}>No context link available</span>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+function FilterSelect<T extends string>({
+  labelText,
+  value,
+  options,
+  onChange,
+}: {
+  labelText: string;
+  value: FilterValue<T>;
+  options: Array<FilterValue<T>>;
+  onChange: (value: FilterValue<T>) => void;
+}) {
+  return (
+    <label style={{ display: "grid", gap: 5, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+      {labelText}
+      <select
+        value={value}
+        onChange={(event) => onChange(event.target.value as FilterValue<T>)}
+        style={{
+          border: "1px solid #cbd5e1",
+          borderRadius: 8,
+          padding: "8px 10px",
+          color: "#0f172a",
+          background: "#fff",
+          minWidth: 150,
+        }}
+      >
+        {options.map((option) => (
+          <option key={option} value={option}>
+            {label(option)}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+function errorMessage(error: unknown) {
+  if (error instanceof Error && error.message) return error.message;
+  return "Failed to load decision inbox";
+}
+
+export default function DecisionInboxPage() {
+  const { showToast } = useToast();
+  const [severity, setSeverity] = React.useState<FilterValue<DecisionInboxSeverity>>("all");
+  const [status, setStatus] = React.useState<FilterValue<DecisionInboxStatus>>("all");
+  const [type, setType] = React.useState<FilterValue<DecisionInboxType>>("all");
+  const [data, setData] = React.useState<DecisionInboxResponse | null>(null);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const response = await fetchDecisionInbox({ severity, status, type });
+        if (!mounted) return;
+        setData(response);
+      } catch (err) {
+        if (!mounted) return;
+        const message = errorMessage(err);
+        setError(message);
+        showToast({ message: "Failed to load decision inbox", description: message, variant: "error" });
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [severity, status, type, showToast]);
+
+  return (
+    <MacShell title="Decision inbox" showTopNav={false}>
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "grid", gap: 6 }}>
+            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Decision inbox</h1>
+            <div style={{ color: "#475569", maxWidth: 900 }}>
+              A read-only view of detected decisions across analytics and lease ledger surfaces. Review context here without
+              triggering workflow actions.
+            </div>
+          </div>
+        </Section>
+
+        {data ? (
+          <Section style={{ display: "grid", gap: 10 }}>
+            <div style={{ fontWeight: 800 }}>Summary</div>
+            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(130px, 1fr))", gap: 10 }}>
+              {[
+                ["Total", data.summary.total],
+                ["Critical", data.summary.critical],
+                ["High", data.summary.high],
+                ["Open", data.summary.open],
+                ["Blocked", data.summary.blocked],
+              ].map(([name, value]) => (
+                <Card key={String(name)} style={{ borderRadius: 8, padding: 12 }}>
+                  <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>{name}</div>
+                  <strong style={{ color: "#0f172a", fontSize: 22 }}>{value}</strong>
+                </Card>
+              ))}
+            </div>
+          </Section>
+        ) : null}
+
+        <Section style={{ display: "flex", gap: 12, flexWrap: "wrap", alignItems: "end" }}>
+          <FilterSelect labelText="Severity" value={severity} options={severityOptions} onChange={setSeverity} />
+          <FilterSelect labelText="Status" value={status} options={statusOptions} onChange={setStatus} />
+          <FilterSelect labelText="Type" value={type} options={typeOptions} onChange={setType} />
+        </Section>
+
+        {loading ? <Card>Loading decision inbox…</Card> : null}
+        {!loading && error ? <Card style={{ color: "#b91c1c" }}>We couldn't load the decision inbox right now.</Card> : null}
+        {!loading && !error && data?.items.length === 0 ? (
+          <Card style={{ color: "#64748b" }}>No decisions match the current filters.</Card>
+        ) : null}
+        {!loading && !error && data?.items.length ? (
+          <div style={{ display: "grid", gap: 12 }}>
+            {data.items.map((item) => (
+              <DecisionInboxCard key={item.id} item={item} />
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </MacShell>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds centralized landlord-scoped Decision Inbox aggregation.
- Normalizes analytics/dashboard and lease-ledger decisions into one read-only surface.
- Adds severity, status, and type filters.
- Adds backend endpoint: `GET /api/landlord/decision-inbox`.
- Adds frontend page: `/decision-inbox`.
- Adds dashboard navigation into the inbox.
- Excludes admin lifecycle review decisions from the landlord endpoint to prevent admin-only data exposure.
- Confirms no automated actions, mutations, workflow routing, execution behavior, payment changes, or admin-only data exposure were added.

## Verification
- Backend decision inbox focused tests passed: 7 tests.
- Backend build passed.
- Frontend focused decision inbox/routing/dashboard tests passed: 40 tests.
- Full frontend suite passed: 184 files / 755 tests.
- Frontend build passed with existing chunk-size warning.
- `git diff --check origin/main...HEAD` passed.
- Dependency and lockfile diff empty.