### PR TITLE
feat: add deterministic decision workflow routing

### DIFF
--- a/docs/architecture/decision-engine-v1.md
+++ b/docs/architecture/decision-engine-v1.md
@@ -122,11 +122,55 @@ This layer does not add:
 - lease or payment mutations
 - decision execution workflows
 
+## Decision Workflow Routing V1
+
+Decision Workflow Routing V1 adds read-only organization metadata to Decision Inbox items. It does not create queues, workers, assignments, notifications, or execution behavior.
+
+Routing is derived deterministically from the normalized decision inbox item and existing analytics workflow category when present. Each item receives:
+
+- `queue`
+- `workflowState`
+- `ownershipType`
+- `reviewPriority`
+- `escalationLevel`
+- `manualOnly: true`
+
+Supported queues are:
+
+- `lease_review`
+- `delinquency_review`
+- `screening_review`
+- `maintenance_review`
+- `compliance_review`
+- `admin_review`
+- `general_review`
+
+Supported workflow states are:
+
+- `new`
+- `triaged`
+- `under_review`
+- `waiting_context`
+- `escalated`
+- `resolved`
+- `archived`
+
+The landlord Decision Inbox can filter by queue, workflow state, and escalation level. Landlord routes expose only landlord-safe routing metadata and continue to exclude admin-only review data.
+
+This layer does not add:
+
+- workflow-triggered mutations
+- autonomous routing
+- assignment persistence
+- background queue infrastructure
+- notification sending
+- payment or lease enforcement
+
 ## Deferred
 
-1. Full decision inbox.
-2. Decision timeline page.
-3. Decision-to-action execution workflows.
-4. Automated notices.
-5. Institution export of decision packets.
-6. Compliance rollup for decision context and evidence.
+1. Decision timeline page.
+2. Decision-to-action execution workflows.
+3. Automated notices.
+4. Institution export of decision packets.
+5. Compliance rollup for decision context and evidence.
+6. Operator assignment persistence after access and audit boundaries are finalized.

--- a/rentchain-api/src/lib/decisions/__tests__/deriveDecisionInbox.test.ts
+++ b/rentchain-api/src/lib/decisions/__tests__/deriveDecisionInbox.test.ts
@@ -85,6 +85,12 @@ describe("deriveDecisionInbox", () => {
           source: "lease_ledger",
           destination: "/leases/lease-1/ledger",
           automationEligible: false,
+          workflow: expect.objectContaining({
+            queue: "delinquency_review",
+            workflowState: "escalated",
+            escalationLevel: "critical",
+            manualOnly: true,
+          }),
         }),
         expect.objectContaining({
           id: "approve_maintenance_cost:wo-1",
@@ -94,12 +100,18 @@ describe("deriveDecisionInbox", () => {
           source: "analytics",
           destination: "/work-orders?workOrderId=wo-1",
           automationEligible: false,
+          workflow: expect.objectContaining({
+            queue: "maintenance_review",
+            workflowState: "escalated",
+            escalationLevel: "urgent",
+            manualOnly: true,
+          }),
         }),
       ])
     );
   });
 
-  it("filters by severity, status, and type deterministically", () => {
+  it("filters by severity, status, type, and workflow routing deterministically", () => {
     const result = deriveDecisionInbox({
       leaseDecisions: [
         leaseDecision(),
@@ -112,7 +124,14 @@ describe("deriveDecisionInbox", () => {
         }),
       ],
       analyticsDecisions: [analyticsDecision()],
-      filters: { severity: "medium", status: "pending", type: "billing" },
+      filters: {
+        severity: "medium",
+        status: "pending",
+        type: "billing",
+        queue: "delinquency_review",
+        workflowState: "under_review",
+        escalationLevel: "attention",
+      },
     });
 
     expect(result.items).toHaveLength(1);
@@ -122,6 +141,11 @@ describe("deriveDecisionInbox", () => {
         severity: "medium",
         status: "pending",
         type: "billing",
+        workflow: expect.objectContaining({
+          queue: "delinquency_review",
+          workflowState: "under_review",
+          escalationLevel: "attention",
+        }),
       })
     );
   });
@@ -139,5 +163,18 @@ describe("deriveDecisionInbox", () => {
       open: 1,
       blocked: 1,
     });
+    expect(result.workflowSummary).toEqual({
+      new: 0,
+      underReview: 0,
+      escalated: 1,
+      critical: 1,
+    });
+    expect(result.filters).toEqual(
+      expect.objectContaining({
+        queue: expect.arrayContaining(["delinquency_review", "maintenance_review"]),
+        workflowState: expect.arrayContaining(["escalated", "waiting_context"]),
+        escalationLevel: expect.arrayContaining(["critical", "urgent"]),
+      })
+    );
   });
 });

--- a/rentchain-api/src/lib/decisions/__tests__/deriveDecisionWorkflowRouting.test.ts
+++ b/rentchain-api/src/lib/decisions/__tests__/deriveDecisionWorkflowRouting.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { deriveDecisionWorkflowRouting } from "../deriveDecisionWorkflowRouting";
+
+const baseInput = {
+  id: "decision:review_missing_payment:lease-1",
+  title: "Review Missing Payment",
+  description: "Expected rent payment is missing.",
+  severity: "critical" as const,
+  status: "open" as const,
+  type: "billing" as const,
+  source: "lease_ledger" as const,
+  decisionType: "review_missing_payment",
+};
+
+describe("deriveDecisionWorkflowRouting", () => {
+  it("routes delinquency decisions to the delinquency review queue", () => {
+    expect(deriveDecisionWorkflowRouting(baseInput)).toEqual({
+      queue: "delinquency_review",
+      workflowState: "escalated",
+      ownershipType: "landlord",
+      reviewPriority: "critical",
+      escalationLevel: "critical",
+      manualOnly: true,
+    });
+  });
+
+  it("routes analytics workflow categories deterministically", () => {
+    expect(
+      deriveDecisionWorkflowRouting({
+        ...baseInput,
+        id: "approve_maintenance_cost:wo-1",
+        title: "Open cost approval",
+        description: "A maintenance cost needs review.",
+        severity: "high",
+        status: "open",
+        type: "maintenance",
+        source: "analytics",
+        decisionType: "approve_maintenance_cost",
+        workflowCategory: "maintenance_cost_approval",
+      })
+    ).toEqual(
+      expect.objectContaining({
+        queue: "maintenance_review",
+        ownershipType: "landlord",
+        reviewPriority: "high",
+        escalationLevel: "urgent",
+        workflowState: "escalated",
+        manualOnly: true,
+      })
+    );
+  });
+
+  it("normalizes pending, resolved, and blocked workflow states without execution behavior", () => {
+    expect(deriveDecisionWorkflowRouting({ ...baseInput, status: "pending", severity: "medium" }).workflowState).toBe(
+      "under_review"
+    );
+    expect(deriveDecisionWorkflowRouting({ ...baseInput, status: "resolved" }).workflowState).toBe("resolved");
+    expect(deriveDecisionWorkflowRouting({ ...baseInput, status: "blocked", severity: "low" })).toEqual(
+      expect.objectContaining({ workflowState: "waiting_context", escalationLevel: "attention" })
+    );
+  });
+
+  it("classifies compliance and admin decisions without leaking execution intent", () => {
+    expect(deriveDecisionWorkflowRouting({ ...baseInput, type: "compliance" })).toEqual(
+      expect.objectContaining({ queue: "compliance_review", ownershipType: "compliance", manualOnly: true })
+    );
+    expect(deriveDecisionWorkflowRouting({ ...baseInput, source: "admin_review", type: "admin" })).toEqual(
+      expect.objectContaining({ queue: "admin_review", ownershipType: "admin", manualOnly: true })
+    );
+  });
+});

--- a/rentchain-api/src/lib/decisions/decisionInboxTypes.ts
+++ b/rentchain-api/src/lib/decisions/decisionInboxTypes.ts
@@ -21,6 +21,39 @@ export type DecisionInboxRelatedEntity = {
   label: string;
 };
 
+export type DecisionWorkflowQueue =
+  | "lease_review"
+  | "delinquency_review"
+  | "screening_review"
+  | "maintenance_review"
+  | "compliance_review"
+  | "admin_review"
+  | "general_review";
+
+export type DecisionWorkflowState =
+  | "new"
+  | "triaged"
+  | "under_review"
+  | "waiting_context"
+  | "escalated"
+  | "resolved"
+  | "archived";
+
+export type DecisionWorkflowOwnershipType = "landlord" | "admin" | "compliance" | "operations" | "system";
+
+export type DecisionWorkflowReviewPriority = "critical" | "high" | "medium" | "low";
+
+export type DecisionWorkflowEscalationLevel = "none" | "attention" | "urgent" | "critical";
+
+export type DecisionWorkflowRouting = {
+  queue: DecisionWorkflowQueue;
+  workflowState: DecisionWorkflowState;
+  ownershipType: DecisionWorkflowOwnershipType;
+  reviewPriority: DecisionWorkflowReviewPriority;
+  escalationLevel: DecisionWorkflowEscalationLevel;
+  manualOnly: true;
+};
+
 export type DecisionInboxItem = {
   id: string;
   title: string;
@@ -32,6 +65,7 @@ export type DecisionInboxItem = {
   relatedEntity: DecisionInboxRelatedEntity | null;
   destination: string | null;
   automationEligible: false;
+  workflow: DecisionWorkflowRouting;
   createdAt: string | null;
   updatedAt: string | null;
 };
@@ -40,6 +74,9 @@ export type DecisionInboxFilters = {
   severity: DecisionInboxSeverity[];
   status: DecisionInboxStatus[];
   type: DecisionInboxType[];
+  queue: DecisionWorkflowQueue[];
+  workflowState: DecisionWorkflowState[];
+  escalationLevel: DecisionWorkflowEscalationLevel[];
 };
 
 export type DecisionInboxSummary = {
@@ -50,8 +87,16 @@ export type DecisionInboxSummary = {
   blocked: number;
 };
 
+export type DecisionInboxWorkflowSummary = {
+  new: number;
+  underReview: number;
+  escalated: number;
+  critical: number;
+};
+
 export type DecisionInboxResult = {
   items: DecisionInboxItem[];
   filters: DecisionInboxFilters;
   summary: DecisionInboxSummary;
+  workflowSummary: DecisionInboxWorkflowSummary;
 };

--- a/rentchain-api/src/lib/decisions/decisionWorkflowTypes.ts
+++ b/rentchain-api/src/lib/decisions/decisionWorkflowTypes.ts
@@ -1,0 +1,8 @@
+export type {
+  DecisionWorkflowEscalationLevel,
+  DecisionWorkflowOwnershipType,
+  DecisionWorkflowQueue,
+  DecisionWorkflowReviewPriority,
+  DecisionWorkflowRouting,
+  DecisionWorkflowState,
+} from "./decisionInboxTypes";

--- a/rentchain-api/src/lib/decisions/deriveDecisionInbox.ts
+++ b/rentchain-api/src/lib/decisions/deriveDecisionInbox.ts
@@ -7,7 +7,11 @@ import type {
   DecisionInboxSource,
   DecisionInboxStatus,
   DecisionInboxType,
+  DecisionWorkflowEscalationLevel,
+  DecisionWorkflowQueue,
+  DecisionWorkflowState,
 } from "./decisionInboxTypes";
+import { deriveDecisionWorkflowRouting } from "./deriveDecisionWorkflowRouting";
 
 type SourceDecision = Decision & { latestAction?: unknown };
 
@@ -18,6 +22,9 @@ export type DeriveDecisionInboxInput = {
     severity?: unknown;
     status?: unknown;
     type?: unknown;
+    queue?: unknown;
+    workflowState?: unknown;
+    escalationLevel?: unknown;
   } | null;
 };
 
@@ -33,6 +40,30 @@ const KNOWN_TYPES = new Set<DecisionInboxType>([
   "tenant",
   "billing",
   "unknown",
+]);
+const KNOWN_QUEUES = new Set<DecisionWorkflowQueue>([
+  "lease_review",
+  "delinquency_review",
+  "screening_review",
+  "maintenance_review",
+  "compliance_review",
+  "admin_review",
+  "general_review",
+]);
+const KNOWN_WORKFLOW_STATES = new Set<DecisionWorkflowState>([
+  "new",
+  "triaged",
+  "under_review",
+  "waiting_context",
+  "escalated",
+  "resolved",
+  "archived",
+]);
+const KNOWN_ESCALATION_LEVELS = new Set<DecisionWorkflowEscalationLevel>([
+  "none",
+  "attention",
+  "urgent",
+  "critical",
 ]);
 
 function asString(value: unknown, max = 500): string | null {
@@ -153,7 +184,7 @@ function relatedEntityForAnalyticsDecision(decision: LandlordAgentDecision): Dec
 
 export function decisionInboxItemFromLeaseDecision(decision: SourceDecision): DecisionInboxItem {
   const type = typeFromDecisionType(decision.decisionType);
-  return {
+  const base: Omit<DecisionInboxItem, "workflow"> = {
     id: asString(decision.decisionId, 600) || fallbackId("lease_ledger", decision.decisionId, decision.decisionType),
     title: titleCase(decision.decisionType),
     description: asString(decision.reason, 1000) || "Decision context is available for review.",
@@ -167,10 +198,14 @@ export function decisionInboxItemFromLeaseDecision(decision: SourceDecision): De
     createdAt: normalizeDate(decision.createdAt),
     updatedAt: normalizeDate(decision.updatedAt),
   };
+  return {
+    ...base,
+    workflow: deriveDecisionWorkflowRouting({ ...base, decisionType: decision.decisionType }),
+  };
 }
 
 export function decisionInboxItemFromAnalyticsDecision(decision: LandlordAgentDecision): DecisionInboxItem {
-  return {
+  const base: Omit<DecisionInboxItem, "workflow"> = {
     id: asString(decision.id, 600) || fallbackId("analytics", decision.id, decision.decisionType),
     title: asString(decision.actionLabel || decision.recommendedAction, 240) || titleCase(decision.decisionType),
     description: asString(decision.explanation || decision.recommendedAction, 1000) || "Analytics decision context is available for review.",
@@ -183,6 +218,14 @@ export function decisionInboxItemFromAnalyticsDecision(decision: LandlordAgentDe
     automationEligible: false,
     createdAt: null,
     updatedAt: normalizeDate(decision.reviewedAt || decision.executedAt || decision.executionOutcomeAt),
+  };
+  return {
+    ...base,
+    workflow: deriveDecisionWorkflowRouting({
+      ...base,
+      decisionType: decision.decisionType,
+      workflowCategory: decision.workflowCategory,
+    }),
   };
 }
 
@@ -220,10 +263,16 @@ export function deriveDecisionInbox(input: DeriveDecisionInboxInput): DecisionIn
   const severity = filterValue(input.filters?.severity, KNOWN_SEVERITIES);
   const status = filterValue(input.filters?.status, KNOWN_STATUSES);
   const type = filterValue(input.filters?.type, KNOWN_TYPES);
+  const queue = filterValue(input.filters?.queue, KNOWN_QUEUES);
+  const workflowState = filterValue(input.filters?.workflowState, KNOWN_WORKFLOW_STATES);
+  const escalationLevel = filterValue(input.filters?.escalationLevel, KNOWN_ESCALATION_LEVELS);
   const items = allItems.filter((item) => {
     if (severity && item.severity !== severity) return false;
     if (status && item.status !== status) return false;
     if (type && item.type !== type) return false;
+    if (queue && item.workflow.queue !== queue) return false;
+    if (workflowState && item.workflow.workflowState !== workflowState) return false;
+    if (escalationLevel && item.workflow.escalationLevel !== escalationLevel) return false;
     return true;
   });
 
@@ -242,6 +291,26 @@ export function deriveDecisionInbox(input: DeriveDecisionInboxInput): DecisionIn
         allItems.map((item) => item.type),
         ["lease", "screening", "maintenance", "compliance", "admin", "property", "tenant", "billing", "unknown"]
       ),
+      queue: uniqueSorted(
+        allItems.map((item) => item.workflow.queue),
+        [
+          "lease_review",
+          "delinquency_review",
+          "screening_review",
+          "maintenance_review",
+          "compliance_review",
+          "admin_review",
+          "general_review",
+        ]
+      ),
+      workflowState: uniqueSorted(
+        allItems.map((item) => item.workflow.workflowState),
+        ["new", "triaged", "under_review", "waiting_context", "escalated", "resolved", "archived"]
+      ),
+      escalationLevel: uniqueSorted(
+        allItems.map((item) => item.workflow.escalationLevel),
+        ["none", "attention", "urgent", "critical"]
+      ),
     },
     summary: {
       total: items.length,
@@ -249,6 +318,12 @@ export function deriveDecisionInbox(input: DeriveDecisionInboxInput): DecisionIn
       high: items.filter((item) => item.severity === "high").length,
       open: items.filter((item) => item.status === "open").length,
       blocked: items.filter((item) => item.status === "blocked").length,
+    },
+    workflowSummary: {
+      new: items.filter((item) => item.workflow.workflowState === "new").length,
+      underReview: items.filter((item) => item.workflow.workflowState === "under_review").length,
+      escalated: items.filter((item) => item.workflow.workflowState === "escalated").length,
+      critical: items.filter((item) => item.workflow.escalationLevel === "critical").length,
     },
   };
 }

--- a/rentchain-api/src/lib/decisions/deriveDecisionWorkflowRouting.ts
+++ b/rentchain-api/src/lib/decisions/deriveDecisionWorkflowRouting.ts
@@ -1,0 +1,109 @@
+import type {
+  DecisionInboxItem,
+  DecisionInboxSeverity,
+  DecisionInboxStatus,
+  DecisionInboxType,
+  DecisionWorkflowEscalationLevel,
+  DecisionWorkflowOwnershipType,
+  DecisionWorkflowQueue,
+  DecisionWorkflowReviewPriority,
+  DecisionWorkflowRouting,
+  DecisionWorkflowState,
+} from "./decisionInboxTypes";
+
+export type DecisionWorkflowRoutingInput = Pick<
+  DecisionInboxItem,
+  "id" | "title" | "description" | "severity" | "status" | "type" | "source"
+> & {
+  decisionType?: string | null;
+  workflowCategory?: string | null;
+};
+
+function lower(value: unknown): string {
+  return String(value ?? "").trim().toLowerCase();
+}
+
+function reviewPriorityFromSeverity(severity: DecisionInboxSeverity): DecisionWorkflowReviewPriority {
+  if (severity === "critical") return "critical";
+  if (severity === "high") return "high";
+  if (severity === "medium") return "medium";
+  return "low";
+}
+
+function escalationFromStatusAndSeverity(
+  status: DecisionInboxStatus,
+  severity: DecisionInboxSeverity
+): DecisionWorkflowEscalationLevel {
+  if (status === "resolved" || status === "dismissed") return "none";
+  if (status === "blocked") return severity === "critical" || severity === "high" ? "urgent" : "attention";
+  if (severity === "critical") return "critical";
+  if (severity === "high") return "urgent";
+  if (severity === "medium") return "attention";
+  return "none";
+}
+
+function workflowStateFromStatus(
+  status: DecisionInboxStatus,
+  escalationLevel: DecisionWorkflowEscalationLevel
+): DecisionWorkflowState {
+  if (status === "resolved") return "resolved";
+  if (status === "dismissed") return "archived";
+  if (status === "blocked") return "waiting_context";
+  if (status === "pending") return "under_review";
+  if (status === "open" && (escalationLevel === "critical" || escalationLevel === "urgent")) return "escalated";
+  if (status === "open") return "new";
+  return "triaged";
+}
+
+function queueFromInput(input: DecisionWorkflowRoutingInput): DecisionWorkflowQueue {
+  const haystack = [input.decisionType, input.workflowCategory, input.type, input.title, input.description, input.id]
+    .map(lower)
+    .join(" ");
+
+  if (input.source === "admin_review" || input.type === "admin") return "admin_review";
+  if (haystack.includes("compliance") || input.type === "compliance") return "compliance_review";
+  if (
+    haystack.includes("rent") ||
+    haystack.includes("payment") ||
+    haystack.includes("revenue") ||
+    input.type === "billing"
+  ) {
+    return "delinquency_review";
+  }
+  if (
+    haystack.includes("lease") ||
+    haystack.includes("renewal") ||
+    haystack.includes("vacancy") ||
+    haystack.includes("occupancy") ||
+    input.type === "lease"
+  ) {
+    return "lease_review";
+  }
+  if (haystack.includes("screening") || haystack.includes("application") || input.type === "screening") {
+    return "screening_review";
+  }
+  if (haystack.includes("maintenance") || haystack.includes("work_order") || input.type === "maintenance") {
+    return "maintenance_review";
+  }
+  return "general_review";
+}
+
+function ownershipForQueue(queue: DecisionWorkflowQueue): DecisionWorkflowOwnershipType {
+  if (queue === "admin_review") return "admin";
+  if (queue === "compliance_review") return "compliance";
+  if (queue === "general_review") return "operations";
+  return "landlord";
+}
+
+export function deriveDecisionWorkflowRouting(input: DecisionWorkflowRoutingInput): DecisionWorkflowRouting {
+  const queue = queueFromInput(input);
+  const escalationLevel = escalationFromStatusAndSeverity(input.status, input.severity);
+  return {
+    queue,
+    workflowState: workflowStateFromStatus(input.status, escalationLevel),
+    ownershipType: ownershipForQueue(queue),
+    reviewPriority: reviewPriorityFromSeverity(input.severity),
+    escalationLevel,
+    manualOnly: true,
+  };
+}

--- a/rentchain-api/src/routes/__tests__/landlordDecisionInboxRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordDecisionInboxRoutes.test.ts
@@ -181,6 +181,12 @@ describe("landlordDecisionInboxRoutes", () => {
           type: "maintenance",
           severity: "high",
           automationEligible: false,
+          workflow: expect.objectContaining({
+            queue: "maintenance_review",
+            workflowState: "escalated",
+            escalationLevel: "urgent",
+            manualOnly: true,
+          }),
         }),
         expect.objectContaining({
           source: "lease_ledger",
@@ -188,19 +194,26 @@ describe("landlordDecisionInboxRoutes", () => {
           severity: "critical",
           destination: "/leases/lease-1/ledger",
           automationEligible: false,
+          workflow: expect.objectContaining({
+            queue: "delinquency_review",
+            workflowState: "escalated",
+            escalationLevel: "critical",
+            manualOnly: true,
+          }),
         }),
       ])
     );
     expect(res.body.summary).toEqual(expect.objectContaining({ total: 3, critical: 2, high: 1, open: 3 }));
+    expect(res.body.workflowSummary).toEqual(expect.objectContaining({ escalated: 3, critical: 2 }));
   });
 
-  it("filters inbox items by severity, status, and type", async () => {
+  it("filters inbox items by severity, status, type, and workflow routing", async () => {
     seedLease();
     const router = (await import("../landlordDecisionInboxRoutes")).default;
 
     const res = await invokeRouter(router, {
       method: "GET",
-      url: "/decision-inbox?severity=critical&status=open&type=billing",
+      url: "/decision-inbox?severity=critical&status=open&type=billing&queue=delinquency_review&workflowState=escalated&escalationLevel=critical",
     });
 
     expect(res.status).toBe(200);

--- a/rentchain-api/src/routes/landlordDecisionInboxRoutes.ts
+++ b/rentchain-api/src/routes/landlordDecisionInboxRoutes.ts
@@ -174,6 +174,9 @@ router.get("/decision-inbox", requireAuth, requireLandlord, async (req: any, res
         severity: req.query?.severity,
         status: req.query?.status,
         type: req.query?.type,
+        queue: req.query?.queue,
+        workflowState: req.query?.workflowState,
+        escalationLevel: req.query?.escalationLevel,
       },
     });
 

--- a/rentchain-frontend/src/api/decisionInboxApi.ts
+++ b/rentchain-frontend/src/api/decisionInboxApi.ts
@@ -12,6 +12,31 @@ export type DecisionInboxType =
   | "tenant"
   | "billing"
   | "unknown";
+export type DecisionWorkflowQueue =
+  | "lease_review"
+  | "delinquency_review"
+  | "screening_review"
+  | "maintenance_review"
+  | "compliance_review"
+  | "admin_review"
+  | "general_review";
+export type DecisionWorkflowState =
+  | "new"
+  | "triaged"
+  | "under_review"
+  | "waiting_context"
+  | "escalated"
+  | "resolved"
+  | "archived";
+export type DecisionWorkflowEscalationLevel = "none" | "attention" | "urgent" | "critical";
+export type DecisionWorkflowRouting = {
+  queue: DecisionWorkflowQueue;
+  workflowState: DecisionWorkflowState;
+  ownershipType: "landlord" | "admin" | "compliance" | "operations" | "system";
+  reviewPriority: "critical" | "high" | "medium" | "low";
+  escalationLevel: DecisionWorkflowEscalationLevel;
+  manualOnly: true;
+};
 
 export type DecisionInboxItem = {
   id: string;
@@ -28,6 +53,7 @@ export type DecisionInboxItem = {
   } | null;
   destination: string | null;
   automationEligible: false;
+  workflow: DecisionWorkflowRouting;
   createdAt: string | null;
   updatedAt: string | null;
 };
@@ -38,6 +64,9 @@ export type DecisionInboxResponse = {
     severity: DecisionInboxSeverity[];
     status: DecisionInboxStatus[];
     type: DecisionInboxType[];
+    queue: DecisionWorkflowQueue[];
+    workflowState: DecisionWorkflowState[];
+    escalationLevel: DecisionWorkflowEscalationLevel[];
   };
   summary: {
     total: number;
@@ -46,12 +75,21 @@ export type DecisionInboxResponse = {
     open: number;
     blocked: number;
   };
+  workflowSummary: {
+    new: number;
+    underReview: number;
+    escalated: number;
+    critical: number;
+  };
 };
 
 export type DecisionInboxQuery = {
   severity?: DecisionInboxSeverity | "all";
   status?: DecisionInboxStatus | "all";
   type?: DecisionInboxType | "all";
+  queue?: DecisionWorkflowQueue | "all";
+  workflowState?: DecisionWorkflowState | "all";
+  escalationLevel?: DecisionWorkflowEscalationLevel | "all";
 };
 
 export async function fetchDecisionInbox(params?: DecisionInboxQuery): Promise<DecisionInboxResponse> {
@@ -59,11 +97,22 @@ export async function fetchDecisionInbox(params?: DecisionInboxQuery): Promise<D
   if (params?.severity && params.severity !== "all") search.set("severity", params.severity);
   if (params?.status && params.status !== "all") search.set("status", params.status);
   if (params?.type && params.type !== "all") search.set("type", params.type);
+  if (params?.queue && params.queue !== "all") search.set("queue", params.queue);
+  if (params?.workflowState && params.workflowState !== "all") search.set("workflowState", params.workflowState);
+  if (params?.escalationLevel && params.escalationLevel !== "all") search.set("escalationLevel", params.escalationLevel);
   const suffix = search.toString() ? `?${search.toString()}` : "";
   const response = await apiFetch<{ ok: true } & DecisionInboxResponse>(`/landlord/decision-inbox${suffix}`);
   return {
     items: response.items || [],
-    filters: response.filters || { severity: [], status: [], type: [] },
+    filters: response.filters || {
+      severity: [],
+      status: [],
+      type: [],
+      queue: [],
+      workflowState: [],
+      escalationLevel: [],
+    },
     summary: response.summary || { total: 0, critical: 0, high: 0, open: 0, blocked: 0 },
+    workflowSummary: response.workflowSummary || { new: 0, underReview: 0, escalated: 0, critical: 0 },
   };
 }

--- a/rentchain-frontend/src/pages/DecisionInboxPage.test.tsx
+++ b/rentchain-frontend/src/pages/DecisionInboxPage.test.tsx
@@ -45,6 +45,14 @@ function inboxResponse(overrides: Record<string, unknown> = {}) {
         relatedEntity: { kind: "lease", id: "lease-1", label: "Lease lease-1" },
         destination: "/leases/lease-1/ledger",
         automationEligible: false,
+        workflow: {
+          queue: "delinquency_review",
+          workflowState: "escalated",
+          ownershipType: "landlord",
+          reviewPriority: "critical",
+          escalationLevel: "critical",
+          manualOnly: true,
+        },
         createdAt: "2026-05-05T12:00:00.000Z",
         updatedAt: "2026-05-05T12:00:00.000Z",
       },
@@ -59,6 +67,14 @@ function inboxResponse(overrides: Record<string, unknown> = {}) {
         relatedEntity: { kind: "maintenance_request", id: "wo-1", label: "Work order wo-1" },
         destination: null,
         automationEligible: false,
+        workflow: {
+          queue: "maintenance_review",
+          workflowState: "waiting_context",
+          ownershipType: "landlord",
+          reviewPriority: "high",
+          escalationLevel: "urgent",
+          manualOnly: true,
+        },
         createdAt: null,
         updatedAt: null,
       },
@@ -67,6 +83,9 @@ function inboxResponse(overrides: Record<string, unknown> = {}) {
       severity: ["critical", "high"],
       status: ["open", "blocked"],
       type: ["billing", "maintenance"],
+      queue: ["delinquency_review", "maintenance_review"],
+      workflowState: ["escalated", "waiting_context"],
+      escalationLevel: ["critical", "urgent"],
     },
     summary: {
       total: 2,
@@ -74,6 +93,12 @@ function inboxResponse(overrides: Record<string, unknown> = {}) {
       high: 1,
       open: 1,
       blocked: 1,
+    },
+    workflowSummary: {
+      new: 0,
+      underReview: 0,
+      escalated: 1,
+      critical: 1,
     },
     ...overrides,
   };
@@ -102,8 +127,13 @@ describe("DecisionInboxPage", () => {
     expect(screen.getAllByText("High").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Open").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Blocked").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Escalated").length).toBeGreaterThan(0);
+    expect(screen.getByText("Critical workflow")).toBeInTheDocument();
     expect(screen.getByText("Review Missing Payment")).toBeInTheDocument();
     expect(screen.getByText("Expected rent payment is missing.")).toBeInTheDocument();
+    expect(screen.getAllByText("Delinquency Review").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Maintenance Review").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Urgent").length).toBeGreaterThan(0);
     expect(screen.getByText("Source: Lease Ledger")).toBeInTheDocument();
     expect(screen.getByText("Related: Lease lease-1")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "View context" })).toHaveAttribute("href", "/leases/lease-1/ledger");
@@ -120,6 +150,7 @@ describe("DecisionInboxPage", () => {
         inboxResponse({
           items: [inboxResponse().items[0]],
           summary: { total: 1, critical: 1, high: 0, open: 1, blocked: 0 },
+          workflowSummary: { new: 0, underReview: 0, escalated: 1, critical: 1 },
         })
       );
 
@@ -134,7 +165,29 @@ describe("DecisionInboxPage", () => {
 
     await waitFor(() => {
       expect(apiMocks.fetchDecisionInbox).toHaveBeenLastCalledWith(
-        expect.objectContaining({ severity: "critical", status: "all", type: "all" })
+        expect.objectContaining({
+          severity: "critical",
+          status: "all",
+          type: "all",
+          queue: "all",
+          workflowState: "all",
+          escalationLevel: "all",
+        })
+      );
+    });
+
+    apiMocks.fetchDecisionInbox.mockResolvedValueOnce(
+      inboxResponse({
+        items: [inboxResponse().items[1]],
+        summary: { total: 1, critical: 0, high: 1, open: 0, blocked: 1 },
+        workflowSummary: { new: 0, underReview: 0, escalated: 0, critical: 0 },
+      })
+    );
+    fireEvent.change(screen.getByLabelText("Queue"), { target: { value: "maintenance_review" } });
+
+    await waitFor(() => {
+      expect(apiMocks.fetchDecisionInbox).toHaveBeenLastCalledWith(
+        expect.objectContaining({ severity: "critical", queue: "maintenance_review" })
       );
     });
   });
@@ -144,6 +197,7 @@ describe("DecisionInboxPage", () => {
       inboxResponse({
         items: [],
         summary: { total: 0, critical: 0, high: 0, open: 0, blocked: 0 },
+        workflowSummary: { new: 0, underReview: 0, escalated: 0, critical: 0 },
       })
     );
 

--- a/rentchain-frontend/src/pages/DecisionInboxPage.tsx
+++ b/rentchain-frontend/src/pages/DecisionInboxPage.tsx
@@ -7,6 +7,9 @@ import {
   type DecisionInboxSeverity,
   type DecisionInboxStatus,
   type DecisionInboxType,
+  type DecisionWorkflowEscalationLevel,
+  type DecisionWorkflowQueue,
+  type DecisionWorkflowState,
 } from "@/api/decisionInboxApi";
 import { MacShell } from "@/components/layout/MacShell";
 import { Card, Section } from "@/components/ui/Ui";
@@ -44,6 +47,33 @@ const typeOptions: Array<FilterValue<DecisionInboxType>> = [
   "billing",
   "unknown",
 ];
+const queueOptions: Array<FilterValue<DecisionWorkflowQueue>> = [
+  "all",
+  "lease_review",
+  "delinquency_review",
+  "screening_review",
+  "maintenance_review",
+  "compliance_review",
+  "admin_review",
+  "general_review",
+];
+const workflowStateOptions: Array<FilterValue<DecisionWorkflowState>> = [
+  "all",
+  "new",
+  "triaged",
+  "under_review",
+  "waiting_context",
+  "escalated",
+  "resolved",
+  "archived",
+];
+const escalationOptions: Array<FilterValue<DecisionWorkflowEscalationLevel>> = [
+  "all",
+  "none",
+  "attention",
+  "urgent",
+  "critical",
+];
 
 function label(value: string) {
   if (value === "all") return "All";
@@ -65,6 +95,22 @@ function statusTone(status: DecisionInboxStatus) {
   if (status === "pending") return { color: "#1d4ed8", background: "#dbeafe", border: "#bfdbfe" };
   if (status === "resolved") return { color: "#166534", background: "#dcfce7", border: "#bbf7d0" };
   if (status === "dismissed") return { color: "#475569", background: "#f1f5f9", border: "#cbd5e1" };
+  return { color: "#475569", background: "#f8fafc", border: "#e2e8f0" };
+}
+
+function workflowStateTone(state: DecisionWorkflowState) {
+  if (state === "escalated") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
+  if (state === "waiting_context") return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
+  if (state === "under_review") return { color: "#1d4ed8", background: "#dbeafe", border: "#bfdbfe" };
+  if (state === "resolved") return { color: "#166534", background: "#dcfce7", border: "#bbf7d0" };
+  if (state === "archived") return { color: "#475569", background: "#f1f5f9", border: "#cbd5e1" };
+  return { color: "#334155", background: "#f8fafc", border: "#e2e8f0" };
+}
+
+function escalationTone(level: DecisionWorkflowEscalationLevel) {
+  if (level === "critical") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
+  if (level === "urgent") return { color: "#9f1239", background: "#ffe4e6", border: "#fecdd3" };
+  if (level === "attention") return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
   return { color: "#475569", background: "#f8fafc", border: "#e2e8f0" };
 }
 
@@ -93,7 +139,12 @@ function DecisionInboxCard({ item }: { item: DecisionInboxItem }) {
       <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
         <Badge tone={severityTone(item.severity)}>{label(item.severity)}</Badge>
         <Badge tone={statusTone(item.status)}>{label(item.status)}</Badge>
+        <Badge tone={workflowStateTone(item.workflow.workflowState)}>{label(item.workflow.workflowState)}</Badge>
+        <Badge tone={escalationTone(item.workflow.escalationLevel)}>
+          {item.workflow.escalationLevel === "none" ? "No escalation" : label(item.workflow.escalationLevel)}
+        </Badge>
         <span style={{ color: "#475569", fontSize: 13, fontWeight: 700 }}>{label(item.type)}</span>
+        <span style={{ color: "#475569", fontSize: 13, fontWeight: 700 }}>{label(item.workflow.queue)}</span>
         <span style={{ color: "#64748b", fontSize: 13 }}>Source: {label(item.source)}</span>
       </div>
       <div style={{ display: "grid", gap: 5 }}>
@@ -162,6 +213,9 @@ export default function DecisionInboxPage() {
   const [severity, setSeverity] = React.useState<FilterValue<DecisionInboxSeverity>>("all");
   const [status, setStatus] = React.useState<FilterValue<DecisionInboxStatus>>("all");
   const [type, setType] = React.useState<FilterValue<DecisionInboxType>>("all");
+  const [queue, setQueue] = React.useState<FilterValue<DecisionWorkflowQueue>>("all");
+  const [workflowState, setWorkflowState] = React.useState<FilterValue<DecisionWorkflowState>>("all");
+  const [escalationLevel, setEscalationLevel] = React.useState<FilterValue<DecisionWorkflowEscalationLevel>>("all");
   const [data, setData] = React.useState<DecisionInboxResponse | null>(null);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
@@ -172,7 +226,7 @@ export default function DecisionInboxPage() {
       try {
         setLoading(true);
         setError(null);
-        const response = await fetchDecisionInbox({ severity, status, type });
+        const response = await fetchDecisionInbox({ severity, status, type, queue, workflowState, escalationLevel });
         if (!mounted) return;
         setData(response);
       } catch (err) {
@@ -187,7 +241,7 @@ export default function DecisionInboxPage() {
     return () => {
       mounted = false;
     };
-  }, [severity, status, type, showToast]);
+  }, [severity, status, type, queue, workflowState, escalationLevel, showToast]);
 
   return (
     <MacShell title="Decision inbox" showTopNav={false}>
@@ -212,6 +266,10 @@ export default function DecisionInboxPage() {
                 ["High", data.summary.high],
                 ["Open", data.summary.open],
                 ["Blocked", data.summary.blocked],
+                ["New", data.workflowSummary.new],
+                ["Under review", data.workflowSummary.underReview],
+                ["Escalated", data.workflowSummary.escalated],
+                ["Critical workflow", data.workflowSummary.critical],
               ].map(([name, value]) => (
                 <Card key={String(name)} style={{ borderRadius: 8, padding: 12 }}>
                   <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>{name}</div>
@@ -226,6 +284,19 @@ export default function DecisionInboxPage() {
           <FilterSelect labelText="Severity" value={severity} options={severityOptions} onChange={setSeverity} />
           <FilterSelect labelText="Status" value={status} options={statusOptions} onChange={setStatus} />
           <FilterSelect labelText="Type" value={type} options={typeOptions} onChange={setType} />
+          <FilterSelect labelText="Queue" value={queue} options={queueOptions} onChange={setQueue} />
+          <FilterSelect
+            labelText="Workflow state"
+            value={workflowState}
+            options={workflowStateOptions}
+            onChange={setWorkflowState}
+          />
+          <FilterSelect
+            labelText="Escalation"
+            value={escalationLevel}
+            options={escalationOptions}
+            onChange={setEscalationLevel}
+          />
         </Section>
 
         {loading ? <Card>Loading decision inbox…</Card> : null}


### PR DESCRIPTION
## Summary
- Adds deterministic read-only workflow metadata to Decision Inbox items.
- Introduces queues, workflow states, ownership type, review priority, escalation level, and `manualOnly` routing metadata.
- Adds filters for `queue`, `workflowState`, and `escalationLevel`.
- Extends backend Decision Inbox aggregation and landlord route safely.
- Extends frontend Decision Inbox UI with routing badges and filters.
- Documents decision workflow routing architecture.

## Guardrails
- No automated actions, mutations, queue infrastructure, notifications, lease/payment changes, Stripe/webhook changes, or admin-only data exposure were added.
- No execution or mutation controls were introduced in the UI.
- Dependency and lockfile diff remained empty.

## Verification
- Backend targeted tests passed: 11 tests.
- Frontend DecisionInboxPage test passed: 3 tests.
- Full frontend suite passed: 184 files / 755 tests.
- Backend build passed.
- Frontend build passed with existing chunk-size warning.
- `git diff --check` passed.
- Dependency/lockfile diff empty.