### PR TITLE
feat: add guarded delinquency action scaffolding

### DIFF
--- a/docs/architecture/decision-engine-v1.md
+++ b/docs/architecture/decision-engine-v1.md
@@ -166,6 +166,33 @@ This layer does not add:
 - notification sending
 - payment or lease enforcement
 
+## Delinquency Actions V1
+
+Delinquency Actions V1 adds guarded manual action descriptors to Decision Inbox items routed to `delinquency_review`.
+
+The descriptors are scaffolding only:
+
+- `review_context`
+- `view_ledger`
+- `prepare_reminder`
+- `prepare_notice`
+
+Every descriptor is `manualOnly: true` and `policyGuarded: true`. Available descriptors only navigate to existing context, such as the lease ledger. Blocked descriptors explain why no draft or execution path is available.
+
+The inbox copy explicitly states that no automated notice or payment action will be taken. Notice-related copy is draft-only and tells operators to review local legal requirements before use.
+
+This layer does not add:
+
+- tenant email or SMS sending
+- notice sending
+- payment collection
+- Stripe, Trustly, or PaymentIntent behavior
+- lease financial mutations
+- delinquency status mutation
+- eviction filing
+- notification infrastructure
+- background workers
+
 ## Deferred
 
 1. Decision timeline page.

--- a/rentchain-api/src/lib/decisions/__tests__/deriveDecisionInbox.test.ts
+++ b/rentchain-api/src/lib/decisions/__tests__/deriveDecisionInbox.test.ts
@@ -91,6 +91,11 @@ describe("deriveDecisionInbox", () => {
             escalationLevel: "critical",
             manualOnly: true,
           }),
+          delinquencyActions: expect.arrayContaining([
+            expect.objectContaining({ actionKey: "view_ledger", status: "available", manualOnly: true }),
+            expect.objectContaining({ actionKey: "prepare_reminder", status: "blocked", manualOnly: true }),
+            expect.objectContaining({ actionKey: "prepare_notice", status: "blocked", manualOnly: true }),
+          ]),
         }),
         expect.objectContaining({
           id: "approve_maintenance_cost:wo-1",
@@ -109,6 +114,7 @@ describe("deriveDecisionInbox", () => {
         }),
       ])
     );
+    expect(result.items.find((item) => item.id === "approve_maintenance_cost:wo-1")?.delinquencyActions).toBeUndefined();
   });
 
   it("filters by severity, status, type, and workflow routing deterministically", () => {

--- a/rentchain-api/src/lib/decisions/decisionInboxTypes.ts
+++ b/rentchain-api/src/lib/decisions/decisionInboxTypes.ts
@@ -54,6 +54,22 @@ export type DecisionWorkflowRouting = {
   manualOnly: true;
 };
 
+export type DelinquencyActionKey = "review_context" | "prepare_reminder" | "prepare_notice" | "view_ledger";
+
+export type DelinquencyActionStatus = "available" | "blocked" | "unavailable";
+
+export type DelinquencyActionDescriptor = {
+  actionKey: DelinquencyActionKey;
+  label: string;
+  description: string;
+  manualOnly: true;
+  requiresConfirmation: boolean;
+  policyGuarded: true;
+  destination: string | null;
+  status: DelinquencyActionStatus;
+  blockedReason: string | null;
+};
+
 export type DecisionInboxItem = {
   id: string;
   title: string;
@@ -66,6 +82,7 @@ export type DecisionInboxItem = {
   destination: string | null;
   automationEligible: false;
   workflow: DecisionWorkflowRouting;
+  delinquencyActions?: DelinquencyActionDescriptor[];
   createdAt: string | null;
   updatedAt: string | null;
 };

--- a/rentchain-api/src/lib/decisions/deriveDecisionInbox.ts
+++ b/rentchain-api/src/lib/decisions/deriveDecisionInbox.ts
@@ -12,6 +12,7 @@ import type {
   DecisionWorkflowState,
 } from "./decisionInboxTypes";
 import { deriveDecisionWorkflowRouting } from "./deriveDecisionWorkflowRouting";
+import { deriveDelinquencyActions } from "../delinquency/deriveDelinquencyActions";
 
 type SourceDecision = Decision & { latestAction?: unknown };
 
@@ -198,10 +199,12 @@ export function decisionInboxItemFromLeaseDecision(decision: SourceDecision): De
     createdAt: normalizeDate(decision.createdAt),
     updatedAt: normalizeDate(decision.updatedAt),
   };
-  return {
+  const item = {
     ...base,
     workflow: deriveDecisionWorkflowRouting({ ...base, decisionType: decision.decisionType }),
   };
+  const delinquencyActions = deriveDelinquencyActions(item);
+  return delinquencyActions.length ? { ...item, delinquencyActions } : item;
 }
 
 export function decisionInboxItemFromAnalyticsDecision(decision: LandlordAgentDecision): DecisionInboxItem {
@@ -219,7 +222,7 @@ export function decisionInboxItemFromAnalyticsDecision(decision: LandlordAgentDe
     createdAt: null,
     updatedAt: normalizeDate(decision.reviewedAt || decision.executedAt || decision.executionOutcomeAt),
   };
-  return {
+  const item = {
     ...base,
     workflow: deriveDecisionWorkflowRouting({
       ...base,
@@ -227,6 +230,8 @@ export function decisionInboxItemFromAnalyticsDecision(decision: LandlordAgentDe
       workflowCategory: decision.workflowCategory,
     }),
   };
+  const delinquencyActions = deriveDelinquencyActions(item);
+  return delinquencyActions.length ? { ...item, delinquencyActions } : item;
 }
 
 function filterValue<T extends string>(value: unknown, known: Set<T>): T | null {

--- a/rentchain-api/src/lib/delinquency/__tests__/deriveDelinquencyActions.test.ts
+++ b/rentchain-api/src/lib/delinquency/__tests__/deriveDelinquencyActions.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { deriveDelinquencyActions } from "../deriveDelinquencyActions";
+import type { DecisionInboxItem } from "../../decisions/decisionInboxTypes";
+
+function item(overrides: Partial<DecisionInboxItem> = {}): DecisionInboxItem {
+  return {
+    id: "decision:review_missing_payment:lease-1",
+    title: "Review Missing Payment",
+    description: "Expected rent payment is missing.",
+    severity: "critical",
+    status: "open",
+    type: "billing",
+    source: "lease_ledger",
+    relatedEntity: { kind: "lease", id: "lease-1", label: "Lease lease-1" },
+    destination: "/leases/lease-1/ledger",
+    automationEligible: false,
+    workflow: {
+      queue: "delinquency_review",
+      workflowState: "escalated",
+      ownershipType: "landlord",
+      reviewPriority: "critical",
+      escalationLevel: "critical",
+      manualOnly: true,
+    },
+    createdAt: "2026-05-05T12:00:00.000Z",
+    updatedAt: "2026-05-05T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("deriveDelinquencyActions", () => {
+  it("derives guarded manual-only action descriptors for delinquency decisions", () => {
+    const actions = deriveDelinquencyActions(item());
+
+    expect(actions).toEqual([
+      expect.objectContaining({
+        actionKey: "review_context",
+        status: "available",
+        destination: "/leases/lease-1/ledger",
+        manualOnly: true,
+        policyGuarded: true,
+      }),
+      expect.objectContaining({
+        actionKey: "view_ledger",
+        status: "available",
+        destination: "/leases/lease-1/ledger",
+        manualOnly: true,
+      }),
+      expect.objectContaining({
+        actionKey: "prepare_reminder",
+        status: "blocked",
+        requiresConfirmation: true,
+        blockedReason: expect.stringMatching(/no tenant communication will be sent/i),
+      }),
+      expect.objectContaining({
+        actionKey: "prepare_notice",
+        status: "blocked",
+        requiresConfirmation: true,
+        blockedReason: expect.stringMatching(/no legal notice will be generated or sent/i),
+      }),
+    ]);
+  });
+
+  it("does not derive actions for non-delinquency decisions", () => {
+    expect(
+      deriveDelinquencyActions(
+        item({
+          id: "approve_maintenance_cost:wo-1",
+          type: "maintenance",
+          workflow: {
+            queue: "maintenance_review",
+            workflowState: "new",
+            ownershipType: "landlord",
+            reviewPriority: "high",
+            escalationLevel: "urgent",
+            manualOnly: true,
+          },
+        })
+      )
+    ).toEqual([]);
+  });
+
+  it("uses deterministic blocked reasons when context is missing", () => {
+    const actions = deriveDelinquencyActions(item({ destination: null }));
+
+    expect(actions.find((entry) => entry.actionKey === "review_context")).toEqual(
+      expect.objectContaining({
+        status: "blocked",
+        destination: null,
+        blockedReason: "Lease or ledger context is unavailable for this decision.",
+      })
+    );
+    expect(actions.find((entry) => entry.actionKey === "view_ledger")).toEqual(
+      expect.objectContaining({
+        status: "blocked",
+        destination: null,
+        blockedReason: "A lease ledger destination is unavailable for this decision.",
+      })
+    );
+  });
+});

--- a/rentchain-api/src/lib/delinquency/delinquencyActionTypes.ts
+++ b/rentchain-api/src/lib/delinquency/delinquencyActionTypes.ts
@@ -1,0 +1,3 @@
+import type { DelinquencyActionDescriptor, DelinquencyActionKey, DelinquencyActionStatus } from "../decisions/decisionInboxTypes";
+
+export type { DelinquencyActionDescriptor, DelinquencyActionKey, DelinquencyActionStatus };

--- a/rentchain-api/src/lib/delinquency/deriveDelinquencyActions.ts
+++ b/rentchain-api/src/lib/delinquency/deriveDelinquencyActions.ts
@@ -1,0 +1,76 @@
+import type { DecisionInboxItem } from "../decisions/decisionInboxTypes";
+import type { DelinquencyActionDescriptor } from "./delinquencyActionTypes";
+
+function action(input: {
+  actionKey: DelinquencyActionDescriptor["actionKey"];
+  label: string;
+  description: string;
+  requiresConfirmation: boolean;
+  destination?: string | null;
+  status: DelinquencyActionDescriptor["status"];
+  blockedReason?: string | null;
+}): DelinquencyActionDescriptor {
+  return {
+    actionKey: input.actionKey,
+    label: input.label,
+    description: input.description,
+    manualOnly: true,
+    requiresConfirmation: input.requiresConfirmation,
+    policyGuarded: true,
+    destination: input.destination || null,
+    status: input.status,
+    blockedReason: input.blockedReason || null,
+  };
+}
+
+function hasLedgerDestination(item: Pick<DecisionInboxItem, "destination">): boolean {
+  return Boolean(item.destination && /\/leases\/[^/]+\/ledger(?:$|[?#])/.test(item.destination));
+}
+
+export function deriveDelinquencyActions(item: DecisionInboxItem): DelinquencyActionDescriptor[] {
+  if (item.workflow.queue !== "delinquency_review") return [];
+
+  const ledgerAvailable = hasLedgerDestination(item);
+  const contextDestination = item.destination || null;
+  const contextReason = contextDestination ? null : "Lease or ledger context is unavailable for this decision.";
+  const ledgerReason = ledgerAvailable ? null : "A lease ledger destination is unavailable for this decision.";
+
+  return [
+    action({
+      actionKey: "review_context",
+      label: "Review context",
+      description: "Review lease and payment context before taking any manual follow-up.",
+      requiresConfirmation: false,
+      destination: contextDestination,
+      status: contextDestination ? "available" : "blocked",
+      blockedReason: contextReason,
+    }),
+    action({
+      actionKey: "view_ledger",
+      label: "View ledger",
+      description: "Open the existing lease ledger to compare expected rent, payments, and reconciliation evidence.",
+      requiresConfirmation: false,
+      destination: ledgerAvailable ? item.destination : null,
+      status: ledgerAvailable ? "available" : "blocked",
+      blockedReason: ledgerReason,
+    }),
+    action({
+      actionKey: "prepare_reminder",
+      label: "Prepare reminder",
+      description: "Scaffold a manual reminder review. No tenant message is generated or sent from this inbox.",
+      requiresConfirmation: true,
+      destination: contextDestination,
+      status: "blocked",
+      blockedReason: "Reminder draft preview is not enabled in this scaffold; no tenant communication will be sent.",
+    }),
+    action({
+      actionKey: "prepare_notice",
+      label: "Prepare notice",
+      description: "Scaffold a manual notice review. Draft only. Review local legal requirements before use.",
+      requiresConfirmation: true,
+      destination: contextDestination,
+      status: "blocked",
+      blockedReason: "Notice draft preview is not enabled in this scaffold; no legal notice will be generated or sent.",
+    }),
+  ];
+}

--- a/rentchain-api/src/routes/__tests__/landlordDecisionInboxRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordDecisionInboxRoutes.test.ts
@@ -200,6 +200,10 @@ describe("landlordDecisionInboxRoutes", () => {
             escalationLevel: "critical",
             manualOnly: true,
           }),
+          delinquencyActions: expect.arrayContaining([
+            expect.objectContaining({ actionKey: "view_ledger", status: "available", manualOnly: true }),
+            expect.objectContaining({ actionKey: "prepare_notice", status: "blocked", manualOnly: true }),
+          ]),
         }),
       ])
     );

--- a/rentchain-frontend/src/api/decisionInboxApi.ts
+++ b/rentchain-frontend/src/api/decisionInboxApi.ts
@@ -37,6 +37,17 @@ export type DecisionWorkflowRouting = {
   escalationLevel: DecisionWorkflowEscalationLevel;
   manualOnly: true;
 };
+export type DelinquencyActionDescriptor = {
+  actionKey: "review_context" | "prepare_reminder" | "prepare_notice" | "view_ledger";
+  label: string;
+  description: string;
+  manualOnly: true;
+  requiresConfirmation: boolean;
+  policyGuarded: true;
+  destination: string | null;
+  status: "available" | "blocked" | "unavailable";
+  blockedReason: string | null;
+};
 
 export type DecisionInboxItem = {
   id: string;
@@ -54,6 +65,7 @@ export type DecisionInboxItem = {
   destination: string | null;
   automationEligible: false;
   workflow: DecisionWorkflowRouting;
+  delinquencyActions?: DelinquencyActionDescriptor[];
   createdAt: string | null;
   updatedAt: string | null;
 };

--- a/rentchain-frontend/src/pages/DecisionInboxPage.test.tsx
+++ b/rentchain-frontend/src/pages/DecisionInboxPage.test.tsx
@@ -53,6 +53,52 @@ function inboxResponse(overrides: Record<string, unknown> = {}) {
           escalationLevel: "critical",
           manualOnly: true,
         },
+        delinquencyActions: [
+          {
+            actionKey: "review_context",
+            label: "Review context",
+            description: "Review lease and payment context before taking any manual follow-up.",
+            manualOnly: true,
+            requiresConfirmation: false,
+            policyGuarded: true,
+            destination: "/leases/lease-1/ledger",
+            status: "available",
+            blockedReason: null,
+          },
+          {
+            actionKey: "view_ledger",
+            label: "View ledger",
+            description: "Open the existing lease ledger to compare expected rent, payments, and reconciliation evidence.",
+            manualOnly: true,
+            requiresConfirmation: false,
+            policyGuarded: true,
+            destination: "/leases/lease-1/ledger",
+            status: "available",
+            blockedReason: null,
+          },
+          {
+            actionKey: "prepare_reminder",
+            label: "Prepare reminder",
+            description: "Scaffold a manual reminder review. No tenant message is generated or sent from this inbox.",
+            manualOnly: true,
+            requiresConfirmation: true,
+            policyGuarded: true,
+            destination: "/leases/lease-1/ledger",
+            status: "blocked",
+            blockedReason: "Reminder draft preview is not enabled in this scaffold; no tenant communication will be sent.",
+          },
+          {
+            actionKey: "prepare_notice",
+            label: "Prepare notice",
+            description: "Scaffold a manual notice review. Draft only. Review local legal requirements before use.",
+            manualOnly: true,
+            requiresConfirmation: true,
+            policyGuarded: true,
+            destination: "/leases/lease-1/ledger",
+            status: "blocked",
+            blockedReason: "Notice draft preview is not enabled in this scaffold; no legal notice will be generated or sent.",
+          },
+        ],
         createdAt: "2026-05-05T12:00:00.000Z",
         updatedAt: "2026-05-05T12:00:00.000Z",
       },
@@ -134,12 +180,20 @@ describe("DecisionInboxPage", () => {
     expect(screen.getAllByText("Delinquency Review").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Maintenance Review").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Urgent").length).toBeGreaterThan(0);
+    expect(screen.getByText("Manual review required")).toBeInTheDocument();
+    expect(screen.getByText("No automated notice or payment action will be taken.")).toBeInTheDocument();
+    expect(screen.getByText("Review context")).toBeInTheDocument();
+    expect(screen.getByText("Prepare reminder")).toBeInTheDocument();
+    expect(screen.getByText("Prepare notice")).toBeInTheDocument();
+    expect(screen.getByText("Draft only. Review local legal requirements before use.")).toBeInTheDocument();
+    expect(screen.getByText(/no tenant communication will be sent/i)).toBeInTheDocument();
     expect(screen.getByText("Source: Lease Ledger")).toBeInTheDocument();
     expect(screen.getByText("Related: Lease lease-1")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "View context" })).toHaveAttribute("href", "/leases/lease-1/ledger");
     expect(screen.getByText("Open cost approval")).toBeInTheDocument();
     expect(screen.getByText("No context link available")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /resolve|dismiss|snooze|approve|retry|execute/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/send notice|charge tenant|start eviction|auto-send|auto-charge/i)).not.toBeInTheDocument();
     expect(apiMocks.macShellProps).toHaveBeenCalledWith(expect.objectContaining({ showTopNav: false }));
   });
 

--- a/rentchain-frontend/src/pages/DecisionInboxPage.tsx
+++ b/rentchain-frontend/src/pages/DecisionInboxPage.tsx
@@ -134,6 +134,7 @@ function Badge({ children, tone }: { children: React.ReactNode; tone: { color: s
 }
 
 function DecisionInboxCard({ item }: { item: DecisionInboxItem }) {
+  const delinquencyActions = item.delinquencyActions || [];
   return (
     <Card style={{ display: "grid", gap: 12, borderRadius: 8 }}>
       <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
@@ -163,6 +164,61 @@ function DecisionInboxCard({ item }: { item: DecisionInboxItem }) {
           <span style={{ color: "#64748b", fontSize: 13 }}>No context link available</span>
         )}
       </div>
+      {delinquencyActions.length ? (
+        <div
+          style={{
+            border: "1px solid #fed7aa",
+            background: "#fff7ed",
+            borderRadius: 8,
+            padding: 12,
+            display: "grid",
+            gap: 10,
+          }}
+        >
+          <div style={{ display: "grid", gap: 4 }}>
+            <div style={{ color: "#9a3412", fontWeight: 900 }}>Manual review required</div>
+            <div style={{ color: "#7c2d12", fontSize: 13 }}>
+              No automated notice or payment action will be taken.
+            </div>
+          </div>
+          <div style={{ display: "grid", gap: 8 }}>
+            {delinquencyActions.map((action) => (
+              <div
+                key={action.actionKey}
+                style={{
+                  display: "grid",
+                  gap: 4,
+                  border: "1px solid #fed7aa",
+                  borderRadius: 8,
+                  padding: 10,
+                  background: "#fff",
+                }}
+              >
+                <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+                  <strong style={{ color: "#0f172a" }}>{action.label}</strong>
+                  <span style={{ color: action.status === "available" ? "#166534" : "#92400e", fontSize: 12, fontWeight: 900 }}>
+                    {label(action.status)}
+                  </span>
+                </div>
+                <div style={{ color: "#475569", fontSize: 13 }}>{action.description}</div>
+                {action.actionKey === "prepare_notice" ? (
+                  <div style={{ color: "#7c2d12", fontSize: 12 }}>
+                    Draft only. Review local legal requirements before use.
+                  </div>
+                ) : null}
+                {action.blockedReason ? (
+                  <div style={{ color: "#92400e", fontSize: 12 }}>{action.blockedReason}</div>
+                ) : null}
+                {action.status === "available" && action.destination ? (
+                  <Link to={action.destination} style={{ color: "#2563eb", fontWeight: 800, fontSize: 13 }}>
+                    Open manual context
+                  </Link>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
     </Card>
   );
 }


### PR DESCRIPTION
## Summary
- Adds manual-only delinquency action descriptors for Decision Inbox items routed to `delinquency_review`.
- Adds `review_context`, `view_ledger`, `prepare_reminder`, and `prepare_notice` descriptors.
- Keeps reminder and notice preparation blocked with explicit reasons.
- Extends Decision Inbox API and UI to display guarded manual delinquency actions.
- Adds UI safety copy confirming no automated notice or payment action will be taken.
- Documents the decision engine architecture update.

## Guardrails
- No payment, notice, enforcement, communication execution, background worker, notification infrastructure, Stripe/webhook, Trustly, PaymentIntent, or lease/payment mutation was added.
- Landlord endpoint remains landlord-scoped with no admin-only data exposure.
- Forbidden UI actions were not added: Send notice, Charge tenant, Start eviction, Execute, Auto-send, Auto-charge.

## Verification
- Backend targeted tests passed: 10 tests.
- Frontend DecisionInboxPage test passed: 3 tests.
- Backend build passed.
- Full frontend suite passed: 184 files / 755 tests.
- Frontend build passed with existing chunk-size warning.
- `git diff --check` passed.
- Dependency/lockfile diff empty.