### PR TITLE
feat: add institution export preview layer

### DIFF
--- a/docs/architecture/institution-export-layer-v1.md
+++ b/docs/architecture/institution-export-layer-v1.md
@@ -1,0 +1,125 @@
+# Institution Export Layer v1
+
+## Purpose
+
+Institution Export Layer v1 prepares read-only preview packages for future institutional review workflows. It is scaffolding for lenders, insurers, government programs, auditors, and internal administrative review without submitting data externally.
+
+The layer exists to answer:
+
+- which landlord-scoped sections are available
+- which sections are blocked or unavailable
+- which sensitive data categories are excluded or redacted
+- whether the preview is ready for manual review
+
+## Scope
+
+V1 is preview-only and deterministic.
+
+Allowed:
+
+- landlord-scoped preview JSON
+- aggregate section summaries
+- deterministic readiness and blocking reasons
+- redaction metadata
+- manual review safety copy
+
+Not allowed:
+
+- external submission
+- live lender, insurer, government, or auditor integrations
+- scheduled report generation
+- background workers, queues, cron, or Pub/Sub
+- emails, uploads, or institution sharing
+- legal, financial, or compliance certification
+- mutation of lease, tenant, property, screening, payment, delinquency, maintenance, or decision records
+
+## Package Types
+
+Supported package types:
+
+- `lender_due_diligence`
+- `insurance_review`
+- `government_program_review`
+- `auditor_review`
+- `internal_admin_review`
+
+Supported audiences:
+
+- `lender`
+- `insurer`
+- `government`
+- `auditor`
+- `internal`
+
+Every package includes:
+
+- `manualOnly: true`
+- `externalSubmissionEnabled: false`
+
+## Sections
+
+Initial sections:
+
+- `property_summary`
+- `lease_summary`
+- `occupancy_summary`
+- `decision_summary`
+- `delinquency_summary`
+- `maintenance_summary`
+- `audit_event_summary`
+
+Each section is marked as:
+
+- `included`
+- `blocked`
+- `unavailable`
+
+Blocking and unavailable reasons are explicit and deterministic.
+
+## Redactions
+
+V1 preview payloads exclude sensitive or high-risk categories:
+
+- tenant contact details
+- identity documents
+- raw screening, credit bureau, and provider payloads
+- bank account, card, payment account, and processor details
+- unrestricted private message contents
+
+Preview payloads are aggregate summaries only. They do not include tenant private documents, raw screening internals, unredacted identity documents, full bank/payment account details, or unrestricted message bodies.
+
+## Endpoint
+
+Landlord-scoped preview endpoint:
+
+`GET /api/landlord/institution-exports/preview?packageType=lender_due_diligence`
+
+The endpoint uses existing authentication and landlord scoping. It returns preview JSON only and does not persist generated packages.
+
+## UI
+
+The frontend preview page is available at:
+
+`/institution-exports`
+
+It displays:
+
+- package type selector
+- readiness status
+- included, blocked, and unavailable sections
+- blocked reasons
+- redaction notes
+- aggregate preview payload summary
+
+Required safety copy makes clear that no data is submitted externally and that manual review is required before sharing with any institution.
+
+## Deferred
+
+Future missions may add:
+
+1. Export file generation after explicit review.
+2. Admin-only institutional package review.
+3. Audit/compliance layer checks.
+4. Institution-specific schemas.
+5. Signed audit packets.
+6. External submission workflows, only after explicit permission and compliance review.

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -120,6 +120,7 @@ import landlordAnalyticsBenchmarkingRoutes from "./routes/landlordAnalyticsBench
 import landlordPortfolioScoreRoutes from "./routes/landlordPortfolioScoreRoutes";
 import landlordPortfolioScoreSharingRoutes from "./routes/landlordPortfolioScoreSharingRoutes";
 import landlordDecisionInboxRoutes from "./routes/landlordDecisionInboxRoutes";
+import landlordInstitutionExportsRoutes from "./routes/landlordInstitutionExportsRoutes";
 import publicPortfolioScoreRoutes from "./routes/publicPortfolioScoreRoutes";
 import publicTenantShareRoutes from "./routes/publicTenantShareRoutes";
 import landlordActionRecommendationRoutes from "./routes/landlordActionRecommendationRoutes";
@@ -283,6 +284,8 @@ app.use("/api", routeSource("landlordPortfolioScoreSharingRoutes.ts"), landlordP
 console.log("[route-mount] landlordPortfolioScoreSharingRoutes mounted at /api");
 app.use("/api/landlord", routeSource("landlordDecisionInboxRoutes.ts"), landlordDecisionInboxRoutes);
 console.log("[route-mount] landlordDecisionInboxRoutes mounted at /api/landlord");
+app.use("/api/landlord", routeSource("landlordInstitutionExportsRoutes.ts"), landlordInstitutionExportsRoutes);
+console.log("[route-mount] landlordInstitutionExportsRoutes mounted at /api/landlord");
 app.use("/api", routeSource("landlordActionRecommendationRoutes.ts"), landlordActionRecommendationRoutes);
 console.log("[route-mount] landlordActionRecommendationRoutes mounted at /api");
 app.use("/api", routeSource("tenantFeedbackRoutes.ts"), tenantFeedbackRoutes);

--- a/rentchain-api/src/lib/institutionExports/__tests__/deriveInstitutionExportPackage.test.ts
+++ b/rentchain-api/src/lib/institutionExports/__tests__/deriveInstitutionExportPackage.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { deriveInstitutionExportPackage } from "../deriveInstitutionExportPackage";
+
+describe("deriveInstitutionExportPackage", () => {
+  it("derives a deterministic preview package with manual-only safeguards", () => {
+    const pkg = deriveInstitutionExportPackage({
+      packageType: "lender_due_diligence",
+      landlordId: "landlord-1",
+      generatedAt: "2026-05-05T12:00:00.000Z",
+      properties: [{ id: "prop-1", status: "active", unitsCount: 4 }],
+      leases: [{ id: "lease-1", status: "active", unitId: "unit-1" }],
+      maintenanceRequests: [{ id: "maint-1", status: "open" }],
+      decisionItems: [
+        {
+          id: "decision-1",
+          severity: "critical",
+          type: "billing",
+          workflow: { queue: "delinquency_review" },
+        },
+      ],
+      auditEvents: [{ id: "event-1" }],
+    });
+
+    expect(pkg.packageId).toBe("institution_export:lender_due_diligence:landlord-1");
+    expect(pkg.audience).toBe("lender");
+    expect(pkg.status).toBe("preview_ready");
+    expect(pkg.manualOnly).toBe(true);
+    expect(pkg.externalSubmissionEnabled).toBe(false);
+    expect(pkg.sections).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ sectionKey: "property_summary", status: "included", recordsCount: 1 }),
+        expect.objectContaining({ sectionKey: "lease_summary", status: "included", recordsCount: 1 }),
+        expect.objectContaining({ sectionKey: "delinquency_summary", status: "included", recordsCount: 1 }),
+      ])
+    );
+    expect(pkg.payloadPreview).toEqual(
+      expect.objectContaining({
+        propertySummary: expect.objectContaining({ propertyCount: 1, unitCount: 4 }),
+        delinquencySummary: expect.objectContaining({ decisionsCount: 1, criticalCount: 1 }),
+      })
+    );
+  });
+
+  it("blocks previews when landlord or property context is missing", () => {
+    const pkg = deriveInstitutionExportPackage({
+      packageType: "auditor_review",
+      generatedAt: "2026-05-05T12:00:00.000Z",
+      properties: [],
+      leases: [],
+    });
+
+    expect(pkg.status).toBe("blocked");
+    expect(pkg.packageId).toBe("institution_export:auditor_review:missing_landlord");
+    expect(pkg.blockedReasons).toEqual(
+      expect.arrayContaining([
+        "Landlord context is required before an institution export preview can be prepared.",
+        "At least one landlord-scoped property is required for institution export preview.",
+      ])
+    );
+    expect(pkg.sections).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ sectionKey: "property_summary", status: "blocked" }),
+        expect.objectContaining({ sectionKey: "lease_summary", status: "unavailable" }),
+      ])
+    );
+  });
+
+  it("lists redactions and excludes sensitive raw payload categories from the preview", () => {
+    const pkg = deriveInstitutionExportPackage({
+      packageType: "government_program_review",
+      landlordId: "landlord-1",
+      generatedAt: "2026-05-05T12:00:00.000Z",
+      properties: [{ id: "prop-1" }],
+      leases: [
+        {
+          id: "lease-1",
+          tenantId: "tenant-1",
+          ssn: "123-45-6789",
+          creditReport: { score: 700 },
+          bankAccountNumber: "000123",
+        } as any,
+      ],
+    });
+
+    expect(pkg.redactions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ fieldCategory: "tenant_contact_details" }),
+        expect.objectContaining({ fieldCategory: "screening_payloads" }),
+        expect.objectContaining({ fieldCategory: "payment_account_details" }),
+      ])
+    );
+    expect(JSON.stringify(pkg.payloadPreview)).not.toMatch(/123-45-6789|creditReport|000123|tenant-1/);
+  });
+});

--- a/rentchain-api/src/lib/institutionExports/deriveInstitutionExportPackage.ts
+++ b/rentchain-api/src/lib/institutionExports/deriveInstitutionExportPackage.ts
@@ -1,0 +1,290 @@
+import type {
+  DeriveInstitutionExportPackageInput,
+  InstitutionExportAudience,
+  InstitutionExportPackage,
+  InstitutionExportPackageType,
+  InstitutionExportRedaction,
+  InstitutionExportSection,
+  InstitutionExportSectionKey,
+  InstitutionExportSectionStatus,
+} from "./institutionExportTypes";
+
+const PACKAGE_AUDIENCE: Record<InstitutionExportPackageType, InstitutionExportAudience> = {
+  lender_due_diligence: "lender",
+  insurance_review: "insurer",
+  government_program_review: "government",
+  auditor_review: "auditor",
+  internal_admin_review: "internal",
+};
+
+const DEFAULT_REDACTIONS: InstitutionExportRedaction[] = [
+  {
+    fieldCategory: "tenant_contact_details",
+    reason: "Tenant email, phone, and private contact details are excluded from V1 previews.",
+  },
+  {
+    fieldCategory: "identity_documents",
+    reason: "Identity documents and document images are excluded from institution export previews.",
+  },
+  {
+    fieldCategory: "screening_payloads",
+    reason: "Raw bureau, credit, and screening provider payloads are excluded.",
+  },
+  {
+    fieldCategory: "payment_account_details",
+    reason: "Bank account, card, processor payload, and provider account details are excluded.",
+  },
+  {
+    fieldCategory: "private_message_contents",
+    reason: "Unrestricted tenant, landlord, and support message bodies are excluded.",
+  },
+];
+
+function asString(value: unknown, max = 240): string {
+  const next = String(value ?? "").trim().slice(0, max);
+  return next || "";
+}
+
+function asCount(value: unknown): number {
+  const count = Number(value);
+  if (!Number.isFinite(count) || count < 0) return 0;
+  return Math.floor(count);
+}
+
+function arrayOf<T>(value: T[] | null | undefined): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function cleanId(value: unknown): string {
+  return asString(value, 240)
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function normalizeGeneratedAt(value: unknown): string {
+  const raw = asString(value, 120);
+  const date = raw ? new Date(raw) : new Date();
+  if (Number.isNaN(date.getTime())) return new Date().toISOString();
+  return date.toISOString();
+}
+
+function section(
+  sectionKey: InstitutionExportSectionKey,
+  label: string,
+  status: InstitutionExportSectionStatus,
+  recordsCount: number,
+  blockedReasons: string[] = []
+): InstitutionExportSection {
+  return {
+    sectionKey,
+    label,
+    status,
+    recordsCount: Math.max(0, Math.floor(recordsCount)),
+    blockedReasons,
+  };
+}
+
+function statusOf(value: unknown): string {
+  return asString(value, 80).toLowerCase();
+}
+
+function countActiveProperties(properties: Array<Record<string, unknown>>) {
+  return properties.filter((property) => {
+    const status = statusOf(property.status);
+    return !status || ["active", "available", "occupied", "listed"].includes(status);
+  }).length;
+}
+
+function countActiveLeases(leases: Array<Record<string, unknown>>) {
+  return leases.filter((lease) => {
+    const status = statusOf(lease.status || lease.lifecycleState || lease.derivedLifecycleState);
+    return ["active", "occupied", "signed", "current"].includes(status);
+  }).length;
+}
+
+function countOccupiedUnits(input: {
+  units: Array<Record<string, unknown>>;
+  leases: Array<Record<string, unknown>>;
+}) {
+  const occupiedFromUnits = input.units.filter((unit) => {
+    const status = statusOf(unit.occupancyStatus || unit.status);
+    return status === "occupied" || Boolean(asString(unit.leaseId, 240));
+  }).length;
+  if (input.units.length) return occupiedFromUnits;
+
+  const occupiedUnitIds = new Set(
+    input.leases
+      .filter((lease) => countActiveLeases([lease]) > 0)
+      .map((lease) => asString(lease.unitId, 240))
+      .filter(Boolean)
+  );
+  return occupiedUnitIds.size;
+}
+
+function countTotalUnits(input: {
+  units: Array<Record<string, unknown>>;
+  properties: Array<Record<string, unknown>>;
+  leases: Array<Record<string, unknown>>;
+}) {
+  if (input.units.length) return input.units.length;
+  const declared = input.properties.reduce((sum, property) => {
+    return sum + asCount(property.unitsCount ?? property.unitCount);
+  }, 0);
+  if (declared > 0) return declared;
+  return new Set(input.leases.map((lease) => asString(lease.unitId, 240)).filter(Boolean)).size;
+}
+
+function summarizeDecisions(decisions: Array<Record<string, any>>) {
+  const delinquency = decisions.filter((decision) => {
+    return (
+      statusOf(decision.workflow?.queue) === "delinquency_review" ||
+      statusOf(decision.type) === "billing" ||
+      statusOf(decision.id).includes("rent") ||
+      statusOf(decision.id).includes("payment")
+    );
+  });
+  return {
+    total: decisions.length,
+    critical: decisions.filter((decision) => statusOf(decision.severity) === "critical").length,
+    high: decisions.filter((decision) => statusOf(decision.severity) === "high").length,
+    delinquency: delinquency.length,
+  };
+}
+
+function summarizeMaintenance(records: Array<Record<string, unknown>>) {
+  return {
+    total: records.length,
+    open: records.filter((record) => {
+      const status = statusOf(record.status || record.state);
+      return !status || ["open", "new", "pending", "assigned", "in_progress"].includes(status);
+    }).length,
+    completed: records.filter((record) => {
+      const status = statusOf(record.status || record.state);
+      return ["completed", "closed", "resolved", "done"].includes(status);
+    }).length,
+  };
+}
+
+export function deriveInstitutionExportPackage(input: DeriveInstitutionExportPackageInput): InstitutionExportPackage {
+  const packageType = input.packageType;
+  const audience = PACKAGE_AUDIENCE[packageType];
+  const landlordId = asString(input.landlordId, 240);
+  const generatedAt = normalizeGeneratedAt(input.generatedAt);
+  const properties = arrayOf(input.properties) as Array<Record<string, unknown>>;
+  const leases = arrayOf(input.leases) as Array<Record<string, unknown>>;
+  const units = arrayOf(input.units) as Array<Record<string, unknown>>;
+  const maintenanceRequests = arrayOf(input.maintenanceRequests) as Array<Record<string, unknown>>;
+  const decisionItems = arrayOf(input.decisionItems) as Array<Record<string, any>>;
+  const auditEvents = arrayOf(input.auditEvents);
+
+  const blockedReasons: string[] = [];
+  if (!landlordId) blockedReasons.push("Landlord context is required before an institution export preview can be prepared.");
+  if (!properties.length) blockedReasons.push("At least one landlord-scoped property is required for institution export preview.");
+
+  const totalUnits = countTotalUnits({ units, properties, leases });
+  const occupiedUnits = countOccupiedUnits({ units, leases });
+  const activeProperties = countActiveProperties(properties);
+  const activeLeases = countActiveLeases(leases);
+  const decisionSummary = summarizeDecisions(decisionItems);
+  const maintenanceSummary = summarizeMaintenance(maintenanceRequests);
+  const occupancyRate = totalUnits > 0 ? Math.round((occupiedUnits / totalUnits) * 1000) / 10 : null;
+
+  const sections: InstitutionExportSection[] = [
+    section(
+      "property_summary",
+      "Property summary",
+      properties.length ? "included" : "blocked",
+      properties.length,
+      properties.length ? [] : ["No landlord-scoped property records were available."]
+    ),
+    section(
+      "lease_summary",
+      "Lease summary",
+      leases.length ? "included" : "unavailable",
+      leases.length,
+      leases.length ? [] : ["No lease records were available for this landlord preview."]
+    ),
+    section(
+      "occupancy_summary",
+      "Occupancy summary",
+      totalUnits > 0 || leases.length ? "included" : "unavailable",
+      totalUnits || leases.length,
+      totalUnits > 0 || leases.length ? [] : ["No unit or lease occupancy context was available."]
+    ),
+    section(
+      "decision_summary",
+      "Decision summary",
+      decisionItems.length ? "included" : "unavailable",
+      decisionItems.length,
+      decisionItems.length ? [] : ["No landlord-safe decision inbox items were available."]
+    ),
+    section(
+      "delinquency_summary",
+      "Delinquency summary",
+      decisionSummary.delinquency ? "included" : "unavailable",
+      decisionSummary.delinquency,
+      decisionSummary.delinquency ? [] : ["No landlord-safe delinquency decisions were available."]
+    ),
+    section(
+      "maintenance_summary",
+      "Maintenance summary",
+      maintenanceRequests.length ? "included" : "unavailable",
+      maintenanceRequests.length,
+      maintenanceRequests.length ? [] : ["No maintenance records were available for this landlord preview."]
+    ),
+    section(
+      "audit_event_summary",
+      "Audit event summary",
+      auditEvents.length ? "included" : "unavailable",
+      auditEvents.length,
+      auditEvents.length ? [] : ["No landlord-scoped audit events were available for this preview."]
+    ),
+  ];
+
+  return {
+    packageId: cleanId(`institution_export:${packageType}:${landlordId || "missing_landlord"}`),
+    packageType,
+    audience,
+    status: blockedReasons.length ? "blocked" : "preview_ready",
+    generatedAt,
+    manualOnly: true,
+    externalSubmissionEnabled: false,
+    sections,
+    blockedReasons,
+    redactions: DEFAULT_REDACTIONS,
+    payloadPreview: {
+      packageType,
+      audience,
+      landlordContextAvailable: Boolean(landlordId),
+      propertySummary: {
+        propertyCount: properties.length,
+        activePropertyCount: activeProperties,
+        unitCount: totalUnits,
+      },
+      leaseSummary: {
+        leaseCount: leases.length,
+        activeLeaseCount: activeLeases,
+      },
+      occupancySummary: {
+        occupiedUnits,
+        totalUnits,
+        occupancyRate,
+      },
+      decisionSummary,
+      delinquencySummary: {
+        decisionsCount: decisionSummary.delinquency,
+        criticalCount: decisionItems.filter(
+          (decision) =>
+            statusOf(decision.severity) === "critical" &&
+            (statusOf(decision.workflow?.queue) === "delinquency_review" || statusOf(decision.type) === "billing")
+        ).length,
+      },
+      maintenanceSummary,
+      auditEventSummary: {
+        total: auditEvents.length,
+      },
+    },
+  };
+}

--- a/rentchain-api/src/lib/institutionExports/institutionExportTypes.ts
+++ b/rentchain-api/src/lib/institutionExports/institutionExportTypes.ts
@@ -1,0 +1,103 @@
+export type InstitutionExportPackageType =
+  | "lender_due_diligence"
+  | "insurance_review"
+  | "government_program_review"
+  | "auditor_review"
+  | "internal_admin_review";
+
+export type InstitutionExportAudience = "lender" | "insurer" | "government" | "auditor" | "internal";
+
+export type InstitutionExportStatus = "preview_ready" | "blocked" | "unavailable";
+
+export type InstitutionExportSectionStatus = "included" | "blocked" | "unavailable";
+
+export type InstitutionExportSectionKey =
+  | "property_summary"
+  | "lease_summary"
+  | "occupancy_summary"
+  | "decision_summary"
+  | "delinquency_summary"
+  | "maintenance_summary"
+  | "audit_event_summary";
+
+export type InstitutionExportSection = {
+  sectionKey: InstitutionExportSectionKey;
+  label: string;
+  status: InstitutionExportSectionStatus;
+  recordsCount: number;
+  blockedReasons: string[];
+};
+
+export type InstitutionExportRedaction = {
+  fieldCategory: string;
+  reason: string;
+};
+
+export type InstitutionExportPackage = {
+  packageId: string;
+  packageType: InstitutionExportPackageType;
+  audience: InstitutionExportAudience;
+  status: InstitutionExportStatus;
+  generatedAt: string;
+  manualOnly: true;
+  externalSubmissionEnabled: false;
+  sections: InstitutionExportSection[];
+  blockedReasons: string[];
+  redactions: InstitutionExportRedaction[];
+  payloadPreview: Record<string, unknown>;
+};
+
+export type InstitutionExportPropertyInput = {
+  id?: unknown;
+  propertyId?: unknown;
+  status?: unknown;
+  unitsCount?: unknown;
+  unitCount?: unknown;
+};
+
+export type InstitutionExportLeaseInput = {
+  id?: unknown;
+  leaseId?: unknown;
+  status?: unknown;
+  lifecycleState?: unknown;
+  derivedLifecycleState?: unknown;
+  unitId?: unknown;
+  tenantId?: unknown;
+  primaryTenantId?: unknown;
+};
+
+export type InstitutionExportUnitInput = {
+  id?: unknown;
+  unitId?: unknown;
+  status?: unknown;
+  occupancyStatus?: unknown;
+  leaseId?: unknown;
+};
+
+export type InstitutionExportMaintenanceInput = {
+  id?: unknown;
+  status?: unknown;
+  state?: unknown;
+};
+
+export type InstitutionExportDecisionInput = {
+  id?: unknown;
+  severity?: unknown;
+  type?: unknown;
+  status?: unknown;
+  workflow?: {
+    queue?: unknown;
+  } | null;
+};
+
+export type DeriveInstitutionExportPackageInput = {
+  packageType: InstitutionExportPackageType;
+  landlordId?: unknown;
+  generatedAt?: unknown;
+  properties?: InstitutionExportPropertyInput[] | null;
+  leases?: InstitutionExportLeaseInput[] | null;
+  units?: InstitutionExportUnitInput[] | null;
+  maintenanceRequests?: InstitutionExportMaintenanceInput[] | null;
+  decisionItems?: InstitutionExportDecisionInput[] | null;
+  auditEvents?: unknown[] | null;
+};

--- a/rentchain-api/src/routes/__tests__/landlordInstitutionExportsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordInstitutionExportsRoutes.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+
+  function matches(doc: any, filters: Array<{ field: string; op: string; value: any }>) {
+    return filters.every(({ field, op, value }) => {
+      const actual = doc?.data?.[field];
+      if (op === "==") return actual === value;
+      return false;
+    });
+  }
+
+  function makeQuery(name: string, filters: Array<{ field: string; op: string; value: any }> = []) {
+    return {
+      where: (field: string, op: string, value: any) => makeQuery(name, [...filters, { field, op, value }]),
+      get: async () => {
+        const docs = Array.from(ensureCollection(name).values())
+          .filter((doc) => matches(doc, filters))
+          .map((doc) => ({ id: doc.id, exists: true, data: () => doc.data }));
+        return { docs, empty: docs.length === 0, size: docs.length };
+      },
+      doc: (id: string) => makeDoc(name, id),
+    };
+  }
+
+  function makeDoc(name: string, id: string) {
+    const col = ensureCollection(name);
+    return {
+      id,
+      get: async () => {
+        const entry = col.get(id);
+        return { id, exists: Boolean(entry), data: () => entry?.data };
+      },
+      set: async (data: any) => {
+        col.set(id, { id, data });
+      },
+    };
+  }
+
+  return {
+    resetFakeDb: () => store.clear(),
+    seedDoc: (collection: string, id: string, data: any) => ensureCollection(collection).set(id, { id, data }),
+    fakeDb: {
+      collection: (name: string) => ({
+        where: (field: string, op: string, value: any) => makeQuery(name, [{ field, op, value }]),
+        get: async () => makeQuery(name).get(),
+        doc: (id: string) => makeDoc(name, id),
+      }),
+    },
+  };
+});
+
+let mockUser: any;
+
+vi.mock("../../config/firebase", () => ({
+  db: fakeDb,
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!mockUser) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    req.user = mockUser;
+    return next();
+  },
+}));
+
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: any, res: any, next: any) => {
+    const role = String(req.user?.role || "").trim().toLowerCase();
+    const landlordId = req.user?.landlordId || req.user?.id;
+    if (role !== "landlord" && role !== "admin") return res.status(403).json({ ok: false, error: "Forbidden" });
+    if (!landlordId) return res.status(401).json({ ok: false, error: "Missing landlord context" });
+    req.user.landlordId = landlordId;
+    return next();
+  },
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; user?: Record<string, unknown> | null }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    const query = new URLSearchParams(queryString || "");
+    mockUser = options.user ?? mockUser;
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: mockUser,
+      body: {},
+      query: Object.fromEntries(query.entries()),
+      params: {},
+      headers: {},
+    };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("landlordInstitutionExportsRoutes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    resetFakeDb();
+    mockUser = { id: "landlord-1", landlordId: "landlord-1", role: "landlord", email: "landlord@example.com" };
+  });
+
+  it("returns a landlord-scoped read-only institution export preview", async () => {
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", status: "active", unitsCount: 2 });
+    seedDoc("properties", "prop-other", { landlordId: "landlord-2", status: "active", unitsCount: 99 });
+    seedDoc("leases", "lease-1", { landlordId: "landlord-1", propertyId: "prop-1", unitId: "unit-1", status: "active" });
+    seedDoc("maintenanceRequests", "maint-1", { landlordId: "landlord-1", status: "open" });
+    seedDoc("events", "event-1", { landlordId: "landlord-1", type: "audit" });
+    const router = (await import("../landlordInstitutionExportsRoutes")).default;
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/institution-exports/preview?packageType=lender_due_diligence",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.package).toEqual(
+      expect.objectContaining({
+        packageType: "lender_due_diligence",
+        audience: "lender",
+        status: "preview_ready",
+        manualOnly: true,
+        externalSubmissionEnabled: false,
+      })
+    );
+    expect(res.body.package.sections).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ sectionKey: "property_summary", status: "included", recordsCount: 1 }),
+        expect.objectContaining({ sectionKey: "maintenance_summary", status: "included", recordsCount: 1 }),
+      ])
+    );
+    expect(res.body.package.payloadPreview.propertySummary.propertyCount).toBe(1);
+    expect(JSON.stringify(res.body.package.payloadPreview)).not.toContain("prop-other");
+  });
+
+  it("returns deterministic blocked state when required context is unavailable", async () => {
+    const router = (await import("../landlordInstitutionExportsRoutes")).default;
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/institution-exports/preview?packageType=auditor_review",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.package.status).toBe("blocked");
+    expect(res.body.package.blockedReasons).toContain(
+      "At least one landlord-scoped property is required for institution export preview."
+    );
+    expect(res.body.package.sections).toEqual(
+      expect.arrayContaining([expect.objectContaining({ sectionKey: "property_summary", status: "blocked" })])
+    );
+  });
+
+  it("blocks non-landlord users", async () => {
+    const router = (await import("../landlordInstitutionExportsRoutes")).default;
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/institution-exports/preview",
+      user: { id: "tenant-1", role: "tenant" },
+    });
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/rentchain-api/src/routes/landlordInstitutionExportsRoutes.ts
+++ b/rentchain-api/src/routes/landlordInstitutionExportsRoutes.ts
@@ -1,0 +1,105 @@
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { requireAuth } from "../middleware/requireAuth";
+import { requireLandlord } from "../middleware/requireLandlord";
+import { deriveDecisionInbox } from "../lib/decisions/deriveDecisionInbox";
+import { deriveInstitutionExportPackage } from "../lib/institutionExports/deriveInstitutionExportPackage";
+import type { InstitutionExportPackageType } from "../lib/institutionExports/institutionExportTypes";
+
+const router = Router();
+
+const PACKAGE_TYPES = new Set<InstitutionExportPackageType>([
+  "lender_due_diligence",
+  "insurance_review",
+  "government_program_review",
+  "auditor_review",
+  "internal_admin_review",
+]);
+
+function asString(value: unknown, max = 240): string {
+  const next = String(value ?? "").trim().slice(0, max);
+  return next || "";
+}
+
+function requestedPackageType(value: unknown): InstitutionExportPackageType {
+  const raw = asString(value, 120) as InstitutionExportPackageType;
+  return PACKAGE_TYPES.has(raw) ? raw : "lender_due_diligence";
+}
+
+async function loadLandlordCollection(collectionName: string, landlordId: string) {
+  const byId = new Map<string, any>();
+  async function collect(field: "landlordId" | "ownerId" | "userId") {
+    const snap = await db.collection(collectionName).where(field, "==", landlordId).get().catch(() => null);
+    for (const doc of snap?.docs || []) {
+      byId.set(doc.id, { id: doc.id, ...((doc.data() as any) || {}) });
+    }
+  }
+
+  await Promise.all([collect("landlordId"), collect("ownerId"), collect("userId")]);
+
+  return Array.from(byId.values()).filter((record) =>
+    [record?.landlordId, record?.ownerId, record?.userId].some((value) => asString(value, 240) === landlordId)
+  );
+}
+
+async function loadLandlordDecisionItems(landlordId: string) {
+  const analyticsDecisions = new Map<string, any>();
+
+  async function collectAnalytics(collectionName: string) {
+    const records = await loadLandlordCollection(collectionName, landlordId).catch(() => []);
+    for (const record of records) {
+      const decisions = Array.isArray(record?.decisions?.items)
+        ? record.decisions.items
+        : Array.isArray(record?.decisions)
+          ? record.decisions
+          : [];
+      for (const decision of decisions) {
+        const id = asString(decision?.id || decision?.decisionId, 600);
+        if (id) analyticsDecisions.set(id, decision);
+      }
+    }
+  }
+
+  await Promise.all([collectAnalytics("landlordAnalyticsSnapshots"), collectAnalytics("analyticsSnapshots")]);
+
+  return deriveDecisionInbox({
+    analyticsDecisions: Array.from(analyticsDecisions.values()),
+  }).items;
+}
+
+router.get("/institution-exports/preview", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = asString(req.user?.landlordId || req.user?.id, 240);
+    if (!landlordId) {
+      return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    }
+
+    const packageType = requestedPackageType(req.query?.packageType);
+    const [properties, leases, units, maintenanceRequests, auditEvents, decisionItems] = await Promise.all([
+      loadLandlordCollection("properties", landlordId),
+      loadLandlordCollection("leases", landlordId),
+      loadLandlordCollection("units", landlordId),
+      loadLandlordCollection("maintenanceRequests", landlordId),
+      loadLandlordCollection("events", landlordId),
+      loadLandlordDecisionItems(landlordId),
+    ]);
+
+    const exportPackage = deriveInstitutionExportPackage({
+      packageType,
+      landlordId,
+      properties,
+      leases,
+      units,
+      maintenanceRequests,
+      auditEvents,
+      decisionItems,
+    });
+
+    return res.json({ ok: true, package: exportPackage });
+  } catch (err: any) {
+    console.error("[landlord-institution-exports] preview failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "INSTITUTION_EXPORT_PREVIEW_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -98,6 +98,10 @@ vi.mock("./pages/DecisionInboxPage", () => ({
   default: () => <h1>Decision Inbox Page</h1>,
 }));
 
+vi.mock("./pages/InstitutionExportsPage", () => ({
+  default: () => <h1>Institution Export Preview Page</h1>,
+}));
+
 vi.mock("./pages/landlord/PortfolioScorePage", () => ({
   default: () => <h1>Landlord Portfolio Score</h1>,
 }));
@@ -233,6 +237,20 @@ describe("Routes: /decision-inbox", () => {
     );
 
     expect(await screen.findByText(/Decision Inbox Page/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Routes: /institution-exports", () => {
+  it("renders the read-only institution export preview route", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/institution-exports"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Institution Export Preview Page/i)).toBeInTheDocument();
     expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -117,6 +117,7 @@ const PortfolioHealthSummaryPage = lazy(() => import("./pages/landlord/Portfolio
 const LandlordAnalyticsPage = lazy(() => import("./pages/landlord/LandlordAnalyticsPage"));
 const LandlordInboxPage = lazy(() => import("./pages/landlord/LandlordInboxPage"));
 const DecisionInboxPage = lazy(() => import("./pages/DecisionInboxPage"));
+const InstitutionExportsPage = lazy(() => import("./pages/InstitutionExportsPage"));
 const LandlordPortfolioScorePage = lazy(() => import("./pages/landlord/PortfolioScorePage"));
 const SharedPortfolioScorePage = lazy(() => import("./pages/public/SharedPortfolioScorePage"));
 const TenantSharePackagePage = lazy(() => import("./pages/public/TenantSharePackagePage"));
@@ -512,6 +513,18 @@ function App() {
               <LandlordNav>
                 <Suspense fallback={null}>
                   <DecisionInboxPage />
+                </Suspense>
+              </LandlordNav>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/institution-exports"
+          element={
+            <RequireAuth>
+              <LandlordNav>
+                <Suspense fallback={null}>
+                  <InstitutionExportsPage />
                 </Suspense>
               </LandlordNav>
             </RequireAuth>

--- a/rentchain-frontend/src/api/institutionExportsApi.ts
+++ b/rentchain-frontend/src/api/institutionExportsApi.ts
@@ -1,0 +1,52 @@
+import { apiFetch } from "./apiFetch";
+
+export type InstitutionExportPackageType =
+  | "lender_due_diligence"
+  | "insurance_review"
+  | "government_program_review"
+  | "auditor_review"
+  | "internal_admin_review";
+
+export type InstitutionExportSection = {
+  sectionKey:
+    | "property_summary"
+    | "lease_summary"
+    | "occupancy_summary"
+    | "decision_summary"
+    | "delinquency_summary"
+    | "maintenance_summary"
+    | "audit_event_summary";
+  label: string;
+  status: "included" | "blocked" | "unavailable";
+  recordsCount: number;
+  blockedReasons: string[];
+};
+
+export type InstitutionExportRedaction = {
+  fieldCategory: string;
+  reason: string;
+};
+
+export type InstitutionExportPackage = {
+  packageId: string;
+  packageType: InstitutionExportPackageType;
+  audience: "lender" | "insurer" | "government" | "auditor" | "internal";
+  status: "preview_ready" | "blocked" | "unavailable";
+  generatedAt: string;
+  manualOnly: true;
+  externalSubmissionEnabled: false;
+  sections: InstitutionExportSection[];
+  blockedReasons: string[];
+  redactions: InstitutionExportRedaction[];
+  payloadPreview: Record<string, any>;
+};
+
+export async function fetchInstitutionExportPreview(
+  packageType: InstitutionExportPackageType
+): Promise<InstitutionExportPackage> {
+  const search = new URLSearchParams({ packageType });
+  const response = await apiFetch<{ ok: true; package: InstitutionExportPackage }>(
+    `/landlord/institution-exports/preview?${search.toString()}`
+  );
+  return response.package;
+}

--- a/rentchain-frontend/src/pages/DecisionInboxPage.test.tsx
+++ b/rentchain-frontend/src/pages/DecisionInboxPage.test.tsx
@@ -168,6 +168,10 @@ describe("DecisionInboxPage", () => {
     );
 
     expect(await screen.findByRole("heading", { name: "Decision inbox" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Institution export preview" })).toHaveAttribute(
+      "href",
+      "/institution-exports"
+    );
     expect(screen.getByText("Summary")).toBeInTheDocument();
     expect(screen.getAllByText("Critical").length).toBeGreaterThan(0);
     expect(screen.getAllByText("High").length).toBeGreaterThan(0);

--- a/rentchain-frontend/src/pages/DecisionInboxPage.tsx
+++ b/rentchain-frontend/src/pages/DecisionInboxPage.tsx
@@ -303,12 +303,17 @@ export default function DecisionInboxPage() {
     <MacShell title="Decision inbox" showTopNav={false}>
       <div style={{ display: "grid", gap: 16 }}>
         <Section>
-          <div style={{ display: "grid", gap: 6 }}>
-            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Decision inbox</h1>
-            <div style={{ color: "#475569", maxWidth: 900 }}>
-              A read-only view of detected decisions across analytics and lease ledger surfaces. Review context here without
-              triggering workflow actions.
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "start" }}>
+            <div style={{ display: "grid", gap: 6 }}>
+              <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Decision inbox</h1>
+              <div style={{ color: "#475569", maxWidth: 900 }}>
+                A read-only view of detected decisions across analytics and lease ledger surfaces. Review context here without
+                triggering workflow actions.
+              </div>
             </div>
+            <Link to="/institution-exports" style={{ color: "#2563eb", fontWeight: 800 }}>
+              Institution export preview
+            </Link>
           </div>
         </Section>
 

--- a/rentchain-frontend/src/pages/InstitutionExportsPage.test.tsx
+++ b/rentchain-frontend/src/pages/InstitutionExportsPage.test.tsx
@@ -1,0 +1,138 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import InstitutionExportsPage from "./InstitutionExportsPage";
+
+const apiMocks = vi.hoisted(() => ({
+  fetchInstitutionExportPreview: vi.fn(),
+  showToast: vi.fn(),
+  macShellProps: vi.fn(),
+}));
+
+vi.mock("@/api/institutionExportsApi", async () => {
+  const actual = await vi.importActual<any>("@/api/institutionExportsApi");
+  return {
+    ...actual,
+    fetchInstitutionExportPreview: apiMocks.fetchInstitutionExportPreview,
+  };
+});
+
+vi.mock("@/components/ui/ToastProvider", () => ({
+  useToast: () => ({
+    showToast: apiMocks.showToast,
+  }),
+}));
+
+vi.mock("@/components/layout/MacShell", () => ({
+  MacShell: ({ children, ...props }: { children: React.ReactNode; showTopNav?: boolean }) => {
+    apiMocks.macShellProps(props);
+    return <div>{children}</div>;
+  },
+}));
+
+function previewPackage(overrides: Record<string, unknown> = {}) {
+  return {
+    packageId: "institution_export:lender_due_diligence:landlord-1",
+    packageType: "lender_due_diligence",
+    audience: "lender",
+    status: "preview_ready",
+    generatedAt: "2026-05-05T12:00:00.000Z",
+    manualOnly: true,
+    externalSubmissionEnabled: false,
+    sections: [
+      {
+        sectionKey: "property_summary",
+        label: "Property summary",
+        status: "included",
+        recordsCount: 2,
+        blockedReasons: [],
+      },
+      {
+        sectionKey: "audit_event_summary",
+        label: "Audit event summary",
+        status: "unavailable",
+        recordsCount: 0,
+        blockedReasons: ["No landlord-scoped audit events were available for this preview."],
+      },
+    ],
+    blockedReasons: [],
+    redactions: [
+      {
+        fieldCategory: "tenant_contact_details",
+        reason: "Tenant email, phone, and private contact details are excluded from V1 previews.",
+      },
+      {
+        fieldCategory: "payment_account_details",
+        reason: "Bank account, card, processor payload, and provider account details are excluded.",
+      },
+    ],
+    payloadPreview: {
+      propertySummary: { propertyCount: 2, unitCount: 8 },
+      leaseSummary: { activeLeaseCount: 6 },
+      occupancySummary: { occupancyRate: 75 },
+      decisionSummary: { total: 3, critical: 1 },
+      maintenanceSummary: { total: 4 },
+    },
+    ...overrides,
+  };
+}
+
+describe("InstitutionExportsPage", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    apiMocks.fetchInstitutionExportPreview.mockResolvedValue(previewPackage());
+  });
+
+  it("renders read-only preview status, sections, redactions, and safety copy", async () => {
+    render(<InstitutionExportsPage />);
+
+    expect(await screen.findByRole("heading", { name: "Institution export preview" })).toBeInTheDocument();
+    expect(screen.getByText(/Preview only\. No data is submitted externally\./i)).toBeInTheDocument();
+    expect(screen.getByText(/Manual review required before sharing with any institution\./i)).toBeInTheDocument();
+    expect(screen.getByText(/Sensitive tenant data may be excluded or redacted\./i)).toBeInTheDocument();
+    expect(screen.getByText("Lender Due Diligence")).toBeInTheDocument();
+    expect(screen.getByText("Preview Ready")).toBeInTheDocument();
+    expect(screen.getByText("Property summary")).toBeInTheDocument();
+    expect(screen.getByText("2 records")).toBeInTheDocument();
+    expect(screen.getByText("Audit event summary")).toBeInTheDocument();
+    expect(screen.getByText(/No landlord-scoped audit events/i)).toBeInTheDocument();
+    expect(screen.getByText("Tenant Contact Details")).toBeInTheDocument();
+    expect(screen.getByText("Payment Account Details")).toBeInTheDocument();
+    expect(screen.getByText("Preview payload summary")).toBeInTheDocument();
+    expect(screen.getByText("75%")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /submit|send|upload|auto-report|schedule|file now/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/send to lender|send to institution/i)).not.toBeInTheDocument();
+    expect(apiMocks.macShellProps).toHaveBeenCalledWith(expect.objectContaining({ showTopNav: false }));
+  });
+
+  it("reloads a deterministic preview when package type changes", async () => {
+    apiMocks.fetchInstitutionExportPreview
+      .mockResolvedValueOnce(previewPackage())
+      .mockResolvedValueOnce(previewPackage({ packageType: "auditor_review", audience: "auditor" }));
+
+    render(<InstitutionExportsPage />);
+
+    expect(await screen.findByText("Lender Due Diligence")).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Package type"), { target: { value: "auditor_review" } });
+
+    await waitFor(() => {
+      expect(apiMocks.fetchInstitutionExportPreview).toHaveBeenLastCalledWith("auditor_review");
+    });
+    expect(await screen.findByText("Auditor Review")).toBeInTheDocument();
+  });
+
+  it("renders blocked readiness and blocked reasons", async () => {
+    apiMocks.fetchInstitutionExportPreview.mockResolvedValue(
+      previewPackage({
+        status: "blocked",
+        blockedReasons: ["At least one landlord-scoped property is required for institution export preview."],
+      })
+    );
+
+    render(<InstitutionExportsPage />);
+
+    expect(await screen.findByText("Blocked")).toBeInTheDocument();
+    expect(screen.getByText(/At least one landlord-scoped property is required/i)).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/InstitutionExportsPage.tsx
+++ b/rentchain-frontend/src/pages/InstitutionExportsPage.tsx
@@ -1,0 +1,224 @@
+import React from "react";
+import {
+  fetchInstitutionExportPreview,
+  type InstitutionExportPackage,
+  type InstitutionExportPackageType,
+  type InstitutionExportSection,
+} from "@/api/institutionExportsApi";
+import { MacShell } from "@/components/layout/MacShell";
+import { Button, Card, Section } from "@/components/ui/Ui";
+import { useToast } from "@/components/ui/ToastProvider";
+
+const PACKAGE_OPTIONS: Array<{ value: InstitutionExportPackageType; label: string }> = [
+  { value: "lender_due_diligence", label: "Lender due diligence" },
+  { value: "insurance_review", label: "Insurance review" },
+  { value: "government_program_review", label: "Government program review" },
+  { value: "auditor_review", label: "Auditor review" },
+  { value: "internal_admin_review", label: "Internal admin review" },
+];
+
+function label(value: string) {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function statusTone(status: string) {
+  if (status === "blocked") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
+  if (status === "included" || status === "preview_ready") {
+    return { color: "#166534", background: "#dcfce7", border: "#bbf7d0" };
+  }
+  return { color: "#475569", background: "#f8fafc", border: "#e2e8f0" };
+}
+
+function Badge({ children, status }: { children: React.ReactNode; status: string }) {
+  const tone = statusTone(status);
+  return (
+    <span
+      style={{
+        border: `1px solid ${tone.border}`,
+        borderRadius: 999,
+        background: tone.background,
+        color: tone.color,
+        padding: "3px 9px",
+        fontSize: 12,
+        fontWeight: 900,
+        whiteSpace: "nowrap",
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+function errorMessage(error: unknown) {
+  if (error instanceof Error && error.message) return error.message;
+  return "Failed to load institution export preview";
+}
+
+function SectionRow({ section }: { section: InstitutionExportSection }) {
+  return (
+    <Card style={{ borderRadius: 8, padding: 12, display: "grid", gap: 8 }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+        <div>
+          <strong style={{ color: "#0f172a" }}>{section.label}</strong>
+          <div style={{ color: "#64748b", fontSize: 13 }}>{section.recordsCount} records</div>
+        </div>
+        <Badge status={section.status}>{label(section.status)}</Badge>
+      </div>
+      {section.blockedReasons.length ? (
+        <div style={{ color: "#92400e", fontSize: 13 }}>{section.blockedReasons.join(" ")}</div>
+      ) : null}
+    </Card>
+  );
+}
+
+function PreviewSummary({ data }: { data: InstitutionExportPackage }) {
+  const preview = data.payloadPreview || {};
+  const propertySummary = preview.propertySummary || {};
+  const leaseSummary = preview.leaseSummary || {};
+  const occupancySummary = preview.occupancySummary || {};
+  const decisionSummary = preview.decisionSummary || {};
+  const maintenanceSummary = preview.maintenanceSummary || {};
+
+  const rows = [
+    ["Properties", propertySummary.propertyCount],
+    ["Units", propertySummary.unitCount],
+    ["Active leases", leaseSummary.activeLeaseCount],
+    ["Occupancy rate", occupancySummary.occupancyRate == null ? "Unavailable" : `${occupancySummary.occupancyRate}%`],
+    ["Decisions", decisionSummary.total],
+    ["Critical decisions", decisionSummary.critical],
+    ["Maintenance records", maintenanceSummary.total],
+  ];
+
+  return (
+    <Card style={{ borderRadius: 8, display: "grid", gap: 10 }}>
+      <div style={{ fontWeight: 900 }}>Preview payload summary</div>
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))", gap: 8 }}>
+        {rows.map(([name, value]) => (
+          <div key={String(name)} style={{ border: "1px solid #e2e8f0", borderRadius: 8, padding: 10 }}>
+            <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>{name}</div>
+            <strong style={{ color: "#0f172a", fontSize: 18 }}>{String(value ?? 0)}</strong>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}
+
+export default function InstitutionExportsPage() {
+  const { showToast } = useToast();
+  const [packageType, setPackageType] = React.useState<InstitutionExportPackageType>("lender_due_diligence");
+  const [data, setData] = React.useState<InstitutionExportPackage | null>(null);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const loadPreview = React.useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const preview = await fetchInstitutionExportPreview(packageType);
+      setData(preview);
+    } catch (err) {
+      const message = errorMessage(err);
+      setError(message);
+      showToast({ message: "Failed to load institution export preview", description: message, variant: "error" });
+    } finally {
+      setLoading(false);
+    }
+  }, [packageType, showToast]);
+
+  React.useEffect(() => {
+    void loadPreview();
+  }, [loadPreview]);
+
+  return (
+    <MacShell title="Institution export preview" showTopNav={false}>
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "grid", gap: 6 }}>
+            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Institution export preview</h1>
+            <div style={{ color: "#475569", maxWidth: 900 }}>
+              Preview only. No data is submitted externally. Manual review required before sharing with any institution.
+              Sensitive tenant data may be excluded or redacted.
+            </div>
+          </div>
+        </Section>
+
+        <Section style={{ display: "flex", alignItems: "end", gap: 12, flexWrap: "wrap" }}>
+          <label style={{ display: "grid", gap: 5, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Package type
+            <select
+              value={packageType}
+              onChange={(event) => setPackageType(event.target.value as InstitutionExportPackageType)}
+              style={{
+                border: "1px solid #cbd5e1",
+                borderRadius: 8,
+                padding: "8px 10px",
+                color: "#0f172a",
+                background: "#fff",
+                minWidth: 240,
+              }}
+            >
+              {PACKAGE_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <Button type="button" onClick={loadPreview} disabled={loading}>
+            Preview package
+          </Button>
+        </Section>
+
+        {loading ? <Card>Loading institution export preview...</Card> : null}
+        {!loading && error ? (
+          <Card style={{ color: "#b91c1c" }}>We couldn't load the institution export preview right now.</Card>
+        ) : null}
+
+        {!loading && !error && data ? (
+          <>
+            <Section style={{ display: "grid", gap: 12 }}>
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+                <div>
+                  <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>Readiness</div>
+                  <h2 style={{ margin: "2px 0 0", fontSize: "1.1rem" }}>{label(data.packageType)}</h2>
+                </div>
+                <Badge status={data.status}>{label(data.status)}</Badge>
+              </div>
+              <div style={{ color: "#475569", lineHeight: 1.55 }}>
+                Audience: {label(data.audience)}. Manual only: {data.manualOnly ? "Yes" : "No"}. External submission enabled:{" "}
+                {data.externalSubmissionEnabled ? "Yes" : "No"}.
+              </div>
+              {data.blockedReasons.length ? (
+                <Card style={{ borderRadius: 8, color: "#92400e", background: "#fffbeb" }}>
+                  {data.blockedReasons.join(" ")}
+                </Card>
+              ) : null}
+            </Section>
+
+            <Section style={{ display: "grid", gap: 10 }}>
+              <div style={{ fontWeight: 900 }}>Included sections</div>
+              <div style={{ display: "grid", gap: 10 }}>
+                {data.sections.map((section) => (
+                  <SectionRow key={section.sectionKey} section={section} />
+                ))}
+              </div>
+            </Section>
+
+            <Section style={{ display: "grid", gap: 10 }}>
+              <div style={{ fontWeight: 900 }}>Redactions</div>
+              {data.redactions.map((redaction) => (
+                <Card key={redaction.fieldCategory} style={{ borderRadius: 8, padding: 12 }}>
+                  <strong style={{ color: "#0f172a" }}>{label(redaction.fieldCategory)}</strong>
+                  <div style={{ color: "#475569", fontSize: 13, marginTop: 4 }}>{redaction.reason}</div>
+                </Card>
+              ))}
+            </Section>
+
+            <PreviewSummary data={data} />
+          </>
+        ) : null}
+      </div>
+    </MacShell>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds read-only, landlord-scoped institution export preview scaffolding
- Adds deterministic package types for lender, insurance, government, auditor, and internal review
- Adds aggregate-only export preview sections for property, lease, occupancy, decision, delinquency, maintenance, and audit summaries
- Adds redaction metadata excluding tenant contact details, identity documents, screening/credit payloads, payment provider details, and private message contents
- Adds backend endpoint: `GET /api/landlord/institution-exports/preview`
- Adds frontend page: `/institution-exports`
- Adds safety copy confirming preview-only/manual review behavior
- Confirms no external submission, live integration, automated reporting, email, background job, payment action, notice action, communication execution, or source-record mutation was added
- Confirms landlord endpoint remains landlord-scoped and aggregate-only

## Verification
- Backend institution export tests passed: 6 tests
- Backend build passed
- Frontend targeted institution export/decision inbox/route tests passed: 32 tests
- Full frontend suite passed: 185 files / 759 tests
- Frontend build passed with existing chunk-size warning
- `git diff --check` passed
- Dependency and lockfile diff empty

## Merge Discipline
Before merge, verify CI, merge-gate, codex-pr-review, Vercel, and Terraform pass; PR diff remains scoped to institution export preview files; no forbidden UI actions appear; and preview payload remains aggregate-only without sensitive tenant/payment/screening payloads.