### PR TITLE
feat: add audit compliance readiness layer

### DIFF
--- a/docs/architecture/audit-compliance-layer-v1.md
+++ b/docs/architecture/audit-compliance-layer-v1.md
@@ -1,0 +1,127 @@
+# Audit Compliance Layer v1
+
+## Purpose
+
+Audit Compliance Layer v1 summarizes whether landlord-scoped records are complete, traceable, and ready for manual review. It sits on top of the Decision Inbox, workflow routing, delinquency action scaffolding, and institution export preview.
+
+This layer is readiness visibility only.
+
+## Guardrails
+
+V1 does not provide legal compliance certification. It does not file, submit, send, schedule, or report anything externally.
+
+Every readiness response includes:
+
+- `manualOnly: true`
+- `certificationIssued: false`
+- `externalFilingEnabled: false`
+- `automatedReportingEnabled: false`
+
+Allowed wording:
+
+- readiness
+- review-ready
+- manual review required
+- evidence available
+- missing evidence
+- blocked reason
+
+Avoided wording:
+
+- certified compliant
+- legally compliant
+- approved
+- filed
+- submitted
+
+## Readiness Checks
+
+Initial deterministic checks:
+
+- `property_identity_present`
+- `lease_traceability`
+- `occupancy_summary_available`
+- `payment_summary_available`
+- `decision_workflow_reviewable`
+- `delinquency_actions_manual_only`
+- `institution_export_preview_only`
+- `audit_event_coverage`
+- `policy_evaluation_available`
+- `sensitive_data_redacted`
+- `external_submission_disabled`
+- `automated_reporting_disabled`
+
+Each check includes:
+
+- status
+- severity
+- evidence
+- missing evidence
+- blocked reasons
+- `manualReviewRequired: true`
+
+## Status Rules
+
+Overall readiness status is deterministic:
+
+- `blocked`: at least one critical check is blocked
+- `needs_attention`: at least one check needs attention and no critical check is blocked
+- `ready_for_review`: no blocked critical checks and no needs-attention checks
+- `unavailable`: insufficient source context exists for a meaningful readiness summary
+
+No AI scoring or probabilistic judgment is used.
+
+## Endpoint
+
+Landlord-scoped readiness endpoint:
+
+`GET /api/landlord/audit-compliance/readiness`
+
+Optional query parameters:
+
+- `scope`
+- `propertyId`
+- `leaseId`
+- `packageType`
+
+The endpoint uses existing authentication and landlord scoping. It returns readiness JSON only and does not persist generated readiness records.
+
+## UI
+
+Frontend readiness page:
+
+`/audit-compliance`
+
+The page displays:
+
+- readiness status
+- summary counts
+- checks
+- evidence
+- missing evidence
+- blocked reasons
+- redaction metadata
+- disclaimers
+
+Required copy makes clear that readiness is not legal certification, no external filing or automated reporting is performed, and manual review is required before relying on the package.
+
+## Sensitive Data
+
+The readiness layer relies on institution export redaction metadata and does not expose:
+
+- raw bureau or credit reports
+- private tenant documents
+- identity documents
+- payment account data
+- private message contents
+- admin-only records through landlord routes
+
+## Deferred
+
+Future missions may add:
+
+1. Audit packet review workflows.
+2. Admin-only readiness views.
+3. Institution-specific readiness schemas.
+4. Signed audit packets.
+5. External filings or reports only after explicit legal/compliance review and mission approval.

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -121,6 +121,7 @@ import landlordPortfolioScoreRoutes from "./routes/landlordPortfolioScoreRoutes"
 import landlordPortfolioScoreSharingRoutes from "./routes/landlordPortfolioScoreSharingRoutes";
 import landlordDecisionInboxRoutes from "./routes/landlordDecisionInboxRoutes";
 import landlordInstitutionExportsRoutes from "./routes/landlordInstitutionExportsRoutes";
+import landlordAuditComplianceRoutes from "./routes/landlordAuditComplianceRoutes";
 import publicPortfolioScoreRoutes from "./routes/publicPortfolioScoreRoutes";
 import publicTenantShareRoutes from "./routes/publicTenantShareRoutes";
 import landlordActionRecommendationRoutes from "./routes/landlordActionRecommendationRoutes";
@@ -286,6 +287,8 @@ app.use("/api/landlord", routeSource("landlordDecisionInboxRoutes.ts"), landlord
 console.log("[route-mount] landlordDecisionInboxRoutes mounted at /api/landlord");
 app.use("/api/landlord", routeSource("landlordInstitutionExportsRoutes.ts"), landlordInstitutionExportsRoutes);
 console.log("[route-mount] landlordInstitutionExportsRoutes mounted at /api/landlord");
+app.use("/api/landlord", routeSource("landlordAuditComplianceRoutes.ts"), landlordAuditComplianceRoutes);
+console.log("[route-mount] landlordAuditComplianceRoutes mounted at /api/landlord");
 app.use("/api", routeSource("landlordActionRecommendationRoutes.ts"), landlordActionRecommendationRoutes);
 console.log("[route-mount] landlordActionRecommendationRoutes mounted at /api");
 app.use("/api", routeSource("tenantFeedbackRoutes.ts"), tenantFeedbackRoutes);

--- a/rentchain-api/src/lib/auditCompliance/__tests__/deriveAuditComplianceReadiness.test.ts
+++ b/rentchain-api/src/lib/auditCompliance/__tests__/deriveAuditComplianceReadiness.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import { deriveAuditComplianceReadiness } from "../deriveAuditComplianceReadiness";
+import type { DecisionInboxItem } from "../../decisions/decisionInboxTypes";
+
+function exportPackage(overrides: Record<string, unknown> = {}) {
+  return {
+    packageId: "institution_export:lender_due_diligence:landlord-1",
+    packageType: "lender_due_diligence",
+    audience: "lender",
+    status: "preview_ready",
+    generatedAt: "2026-05-05T12:00:00.000Z",
+    manualOnly: true,
+    externalSubmissionEnabled: false,
+    sections: [
+      {
+        sectionKey: "property_summary",
+        label: "Property summary",
+        status: "included",
+        recordsCount: 1,
+        blockedReasons: [],
+      },
+      {
+        sectionKey: "occupancy_summary",
+        label: "Occupancy summary",
+        status: "included",
+        recordsCount: 1,
+        blockedReasons: [],
+      },
+    ],
+    blockedReasons: [],
+    redactions: [
+      {
+        fieldCategory: "tenant_contact_details",
+        reason: "Tenant contact details are excluded.",
+      },
+      {
+        fieldCategory: "payment_account_details",
+        reason: "Payment account details are excluded.",
+      },
+    ],
+    payloadPreview: {},
+    ...overrides,
+  } as any;
+}
+
+function decision(overrides: Partial<DecisionInboxItem> = {}): DecisionInboxItem {
+  return {
+    id: "decision-1",
+    title: "Review missing payment",
+    description: "Expected rent payment is missing.",
+    severity: "critical",
+    status: "open",
+    type: "billing",
+    source: "lease_ledger",
+    relatedEntity: { kind: "lease", id: "lease-1", label: "Lease lease-1" },
+    destination: "/leases/lease-1/ledger",
+    automationEligible: false,
+    workflow: {
+      queue: "delinquency_review",
+      workflowState: "escalated",
+      ownershipType: "landlord",
+      reviewPriority: "critical",
+      escalationLevel: "critical",
+      manualOnly: true,
+    },
+    delinquencyActions: [
+      {
+        actionKey: "view_ledger",
+        label: "View ledger",
+        description: "Open the ledger.",
+        manualOnly: true,
+        requiresConfirmation: false,
+        policyGuarded: true,
+        destination: "/leases/lease-1/ledger",
+        status: "available",
+        blockedReason: null,
+      },
+    ],
+    createdAt: null,
+    updatedAt: null,
+    ...overrides,
+  };
+}
+
+describe("deriveAuditComplianceReadiness", () => {
+  it("derives deterministic readiness with non-certification safeguards", () => {
+    const readiness = deriveAuditComplianceReadiness({
+      landlordId: "landlord-1",
+      generatedAt: "2026-05-05T12:00:00.000Z",
+      properties: [{ id: "prop-1", address: "123 Main" }],
+      leases: [{ id: "lease-1", propertyId: "prop-1", unitId: "unit-1" }],
+      rentPayments: [{ id: "rent-1", leaseId: "lease-1" }],
+      decisions: [decision()],
+      auditEvents: [{ id: "event-1", domain: "lease" }],
+      policyEvents: [{ id: "policy-1", type: "policy.evaluated" }],
+      institutionExportPackage: exportPackage(),
+    });
+
+    expect(readiness.readinessId).toBe("audit_compliance:landlord_portfolio:landlord-1:portfolio");
+    expect(readiness.status).toBe("ready_for_review");
+    expect(readiness.manualOnly).toBe(true);
+    expect(readiness.certificationIssued).toBe(false);
+    expect(readiness.externalFilingEnabled).toBe(false);
+    expect(readiness.automatedReportingEnabled).toBe(false);
+    expect(readiness.summary).toEqual({ totalChecks: 12, passed: 12, needsAttention: 0, blocked: 0, unavailable: 0 });
+    expect(readiness.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ checkKey: "property_identity_present", status: "passed" }),
+        expect.objectContaining({ checkKey: "sensitive_data_redacted", status: "passed" }),
+        expect.objectContaining({ checkKey: "external_submission_disabled", status: "passed" }),
+      ])
+    );
+    expect(readiness.disclaimers).toContain("Readiness only. This is not legal certification.");
+  });
+
+  it("marks missing critical property context as blocked", () => {
+    const readiness = deriveAuditComplianceReadiness({
+      landlordId: "landlord-1",
+      generatedAt: "2026-05-05T12:00:00.000Z",
+      properties: [],
+      leases: [{ id: "lease-1", propertyId: "prop-1", unitId: "unit-1" }],
+      institutionExportPackage: exportPackage(),
+    });
+
+    expect(readiness.status).toBe("blocked");
+    expect(readiness.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkKey: "property_identity_present",
+          status: "blocked",
+          severity: "critical",
+        }),
+      ])
+    );
+  });
+
+  it("uses needs_attention for missing non-critical evidence", () => {
+    const readiness = deriveAuditComplianceReadiness({
+      landlordId: "landlord-1",
+      generatedAt: "2026-05-05T12:00:00.000Z",
+      properties: [{ id: "prop-1" }],
+      leases: [{ id: "lease-1", propertyId: "prop-1", unitId: "unit-1" }],
+      rentPayments: [],
+      decisions: [],
+      auditEvents: [],
+      institutionExportPackage: exportPackage(),
+    });
+
+    expect(readiness.status).toBe("needs_attention");
+    expect(readiness.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ checkKey: "payment_summary_available", status: "needs_attention" }),
+        expect.objectContaining({ checkKey: "decision_workflow_reviewable", status: "needs_attention" }),
+        expect.objectContaining({ checkKey: "audit_event_coverage", status: "needs_attention" }),
+      ])
+    );
+  });
+
+  it("excludes sensitive raw payloads from readiness output", () => {
+    const readiness = deriveAuditComplianceReadiness({
+      landlordId: "landlord-1",
+      generatedAt: "2026-05-05T12:00:00.000Z",
+      properties: [{ id: "prop-1", ownerSsn: "123-45-6789" } as any],
+      leases: [{ id: "lease-1", propertyId: "prop-1", unitId: "unit-1", tenantId: "tenant-1" }],
+      rentPayments: [{ id: "rent-1", bankAccountNumber: "000123" } as any],
+      decisions: [decision()],
+      institutionExportPackage: exportPackage(),
+    });
+
+    expect(JSON.stringify(readiness)).not.toMatch(/123-45-6789|000123|tenant-1/);
+  });
+});

--- a/rentchain-api/src/lib/auditCompliance/auditComplianceTypes.ts
+++ b/rentchain-api/src/lib/auditCompliance/auditComplianceTypes.ts
@@ -1,0 +1,114 @@
+import type { InstitutionExportPackage, InstitutionExportRedaction } from "../institutionExports/institutionExportTypes";
+import type { DecisionInboxItem } from "../decisions/decisionInboxTypes";
+
+export type AuditComplianceScope =
+  | "landlord_portfolio"
+  | "property"
+  | "lease"
+  | "export_package"
+  | "admin_review";
+
+export type AuditComplianceReadinessStatus =
+  | "ready_for_review"
+  | "needs_attention"
+  | "blocked"
+  | "unavailable";
+
+export type AuditComplianceCheckStatus = "passed" | "needs_attention" | "blocked" | "unavailable";
+
+export type AuditComplianceSeverity = "critical" | "high" | "medium" | "low" | "info";
+
+export type AuditComplianceCheckKey =
+  | "property_identity_present"
+  | "lease_traceability"
+  | "occupancy_summary_available"
+  | "payment_summary_available"
+  | "decision_workflow_reviewable"
+  | "delinquency_actions_manual_only"
+  | "institution_export_preview_only"
+  | "audit_event_coverage"
+  | "policy_evaluation_available"
+  | "sensitive_data_redacted"
+  | "external_submission_disabled"
+  | "automated_reporting_disabled";
+
+export type AuditComplianceCheck = {
+  checkKey: AuditComplianceCheckKey;
+  label: string;
+  status: AuditComplianceCheckStatus;
+  severity: AuditComplianceSeverity;
+  evidence: string[];
+  missingEvidence: string[];
+  blockedReasons: string[];
+  manualReviewRequired: true;
+};
+
+export type AuditComplianceSummary = {
+  totalChecks: number;
+  passed: number;
+  needsAttention: number;
+  blocked: number;
+  unavailable: number;
+};
+
+export type AuditComplianceReadiness = {
+  readinessId: string;
+  scope: AuditComplianceScope;
+  status: AuditComplianceReadinessStatus;
+  manualOnly: true;
+  certificationIssued: false;
+  externalFilingEnabled: false;
+  automatedReportingEnabled: false;
+  generatedAt: string;
+  summary: AuditComplianceSummary;
+  checks: AuditComplianceCheck[];
+  redactions: InstitutionExportRedaction[];
+  disclaimers: string[];
+};
+
+export type AuditCompliancePropertyInput = {
+  id?: unknown;
+  propertyId?: unknown;
+  address?: unknown;
+  status?: unknown;
+};
+
+export type AuditComplianceLeaseInput = {
+  id?: unknown;
+  leaseId?: unknown;
+  propertyId?: unknown;
+  unitId?: unknown;
+  tenantId?: unknown;
+  primaryTenantId?: unknown;
+  status?: unknown;
+};
+
+export type AuditCompliancePaymentInput = {
+  id?: unknown;
+  paymentId?: unknown;
+  rentPaymentId?: unknown;
+  leaseId?: unknown;
+  status?: unknown;
+};
+
+export type AuditComplianceEventInput = {
+  id?: unknown;
+  type?: unknown;
+  domain?: unknown;
+  action?: unknown;
+};
+
+export type DeriveAuditComplianceReadinessInput = {
+  scope?: AuditComplianceScope;
+  landlordId?: unknown;
+  propertyId?: unknown;
+  leaseId?: unknown;
+  generatedAt?: unknown;
+  properties?: AuditCompliancePropertyInput[] | null;
+  leases?: AuditComplianceLeaseInput[] | null;
+  rentPayments?: AuditCompliancePaymentInput[] | null;
+  decisions?: DecisionInboxItem[] | null;
+  auditEvents?: AuditComplianceEventInput[] | null;
+  policyEvents?: AuditComplianceEventInput[] | null;
+  institutionExportPackage?: InstitutionExportPackage | null;
+};

--- a/rentchain-api/src/lib/auditCompliance/deriveAuditComplianceReadiness.ts
+++ b/rentchain-api/src/lib/auditCompliance/deriveAuditComplianceReadiness.ts
@@ -1,0 +1,285 @@
+import type {
+  AuditComplianceCheck,
+  AuditComplianceCheckKey,
+  AuditComplianceCheckStatus,
+  AuditComplianceReadiness,
+  AuditComplianceScope,
+  AuditComplianceSeverity,
+  DeriveAuditComplianceReadinessInput,
+} from "./auditComplianceTypes";
+
+const DEFAULT_DISCLAIMERS = [
+  "Readiness only. This is not legal certification.",
+  "No external filing or automated reporting is performed.",
+  "Manual review is required before sharing or relying on this package.",
+];
+
+function asString(value: unknown, max = 240): string {
+  const next = String(value ?? "").trim().slice(0, max);
+  return next || "";
+}
+
+function arrayOf<T>(value: T[] | null | undefined): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function normalizeGeneratedAt(value: unknown): string {
+  const raw = asString(value, 120);
+  const date = raw ? new Date(raw) : new Date();
+  if (Number.isNaN(date.getTime())) return new Date().toISOString();
+  return date.toISOString();
+}
+
+function cleanId(value: unknown): string {
+  return asString(value, 240)
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function check(
+  checkKey: AuditComplianceCheckKey,
+  label: string,
+  status: AuditComplianceCheckStatus,
+  severity: AuditComplianceSeverity,
+  evidence: string[] = [],
+  missingEvidence: string[] = [],
+  blockedReasons: string[] = []
+): AuditComplianceCheck {
+  return {
+    checkKey,
+    label,
+    status,
+    severity,
+    evidence,
+    missingEvidence,
+    blockedReasons,
+    manualReviewRequired: true,
+  };
+}
+
+function countByStatus(checks: AuditComplianceCheck[]) {
+  return {
+    totalChecks: checks.length,
+    passed: checks.filter((item) => item.status === "passed").length,
+    needsAttention: checks.filter((item) => item.status === "needs_attention").length,
+    blocked: checks.filter((item) => item.status === "blocked").length,
+    unavailable: checks.filter((item) => item.status === "unavailable").length,
+  };
+}
+
+function deriveOverallStatus(checks: AuditComplianceCheck[], hasSourceContext: boolean): AuditComplianceReadiness["status"] {
+  if (!hasSourceContext) return "unavailable";
+  if (checks.some((item) => item.status === "blocked" && item.severity === "critical")) return "blocked";
+  if (checks.some((item) => item.status === "needs_attention")) return "needs_attention";
+  return "ready_for_review";
+}
+
+function leaseTraceability(input: DeriveAuditComplianceReadinessInput) {
+  const leases = arrayOf(input.leases);
+  if (!leases.length) {
+    return check(
+      "lease_traceability",
+      "Lease traceability",
+      "needs_attention",
+      "high",
+      [],
+      ["No landlord-scoped lease records were available for readiness review."]
+    );
+  }
+  const incomplete = leases.filter((lease) => {
+    return !asString(lease.id || lease.leaseId, 240) || !asString(lease.propertyId, 240) || !asString(lease.unitId, 240);
+  }).length;
+  if (incomplete) {
+    return check(
+      "lease_traceability",
+      "Lease traceability",
+      "needs_attention",
+      "high",
+      [`${leases.length - incomplete} lease records have property and unit linkage.`],
+      [`${incomplete} lease records are missing lease, property, or unit traceability fields.`]
+    );
+  }
+  return check("lease_traceability", "Lease traceability", "passed", "high", [
+    `${leases.length} lease records include lease, property, and unit traceability.`,
+  ]);
+}
+
+function delinquencyActionsManualOnly(decisions: NonNullable<DeriveAuditComplianceReadinessInput["decisions"]>) {
+  const delinquencyActions = decisions.flatMap((decision) => decision.delinquencyActions || []);
+  if (!delinquencyActions.length) {
+    return check(
+      "delinquency_actions_manual_only",
+      "Delinquency actions manual only",
+      "unavailable",
+      "medium",
+      [],
+      ["No delinquency action descriptors were present in the landlord-safe decision context."]
+    );
+  }
+  const nonManual = delinquencyActions.filter((action) => action.manualOnly !== true).length;
+  if (nonManual) {
+    return check(
+      "delinquency_actions_manual_only",
+      "Delinquency actions manual only",
+      "blocked",
+      "critical",
+      [],
+      [],
+      [`${nonManual} delinquency action descriptors are not marked manual-only.`]
+    );
+  }
+  return check("delinquency_actions_manual_only", "Delinquency actions manual only", "passed", "medium", [
+    `${delinquencyActions.length} delinquency action descriptors are manual-only.`,
+  ]);
+}
+
+export function deriveAuditComplianceReadiness(
+  input: DeriveAuditComplianceReadinessInput
+): AuditComplianceReadiness {
+  const scope: AuditComplianceScope = input.scope || "landlord_portfolio";
+  const landlordId = asString(input.landlordId, 240);
+  const propertyId = asString(input.propertyId, 240);
+  const leaseId = asString(input.leaseId, 240);
+  const generatedAt = normalizeGeneratedAt(input.generatedAt);
+  const properties = arrayOf(input.properties);
+  const leases = arrayOf(input.leases);
+  const rentPayments = arrayOf(input.rentPayments);
+  const decisions = arrayOf(input.decisions);
+  const auditEvents = arrayOf(input.auditEvents);
+  const policyEvents = arrayOf(input.policyEvents);
+  const exportPackage = input.institutionExportPackage || null;
+  const exportSections = exportPackage?.sections || [];
+  const exportRedactions = exportPackage?.redactions || [];
+  const hasSourceContext = Boolean(landlordId && (properties.length || leases.length || exportPackage));
+
+  const checks: AuditComplianceCheck[] = [
+    properties.length
+      ? check("property_identity_present", "Property identity present", "passed", "critical", [
+          `${properties.length} landlord-scoped property records are available.`,
+        ])
+      : check(
+          "property_identity_present",
+          "Property identity present",
+          "blocked",
+          "critical",
+          [],
+          [],
+          ["At least one landlord-scoped property record is required for readiness review."]
+        ),
+    leaseTraceability(input),
+    exportSections.some((section) => section.sectionKey === "occupancy_summary" && section.status === "included")
+      ? check("occupancy_summary_available", "Occupancy summary available", "passed", "medium", [
+          "Institution export preview includes occupancy summary metadata.",
+        ])
+      : check(
+          "occupancy_summary_available",
+          "Occupancy summary available",
+          "needs_attention",
+          "medium",
+          [],
+          ["Occupancy summary metadata is unavailable or incomplete."]
+        ),
+    rentPayments.length
+      ? check("payment_summary_available", "Payment summary available", "passed", "high", [
+          `${rentPayments.length} landlord-scoped rent payment records are available for summary review.`,
+        ])
+      : check(
+          "payment_summary_available",
+          "Payment summary available",
+          leases.length ? "needs_attention" : "unavailable",
+          "high",
+          [],
+          leases.length
+            ? ["No landlord-scoped rent payment records were available for readiness review."]
+            : ["Payment summary requires lease or rent payment context."]
+        ),
+    decisions.length
+      ? check("decision_workflow_reviewable", "Decision workflow reviewable", "passed", "medium", [
+          `${decisions.length} landlord-safe decision inbox items are available.`,
+        ])
+      : check(
+          "decision_workflow_reviewable",
+          "Decision workflow reviewable",
+          "needs_attention",
+          "medium",
+          [],
+          ["No landlord-safe decision workflow items were available."]
+        ),
+    delinquencyActionsManualOnly(decisions),
+    exportPackage?.manualOnly === true && exportPackage?.externalSubmissionEnabled === false
+      ? check("institution_export_preview_only", "Institution export preview only", "passed", "critical", [
+          "Institution export package is manual-only with external submission disabled.",
+        ])
+      : check(
+          "institution_export_preview_only",
+          "Institution export preview only",
+          "blocked",
+          "critical",
+          [],
+          [],
+          ["Institution export preview metadata was unavailable or did not confirm preview-only behavior."]
+        ),
+    auditEvents.length
+      ? check("audit_event_coverage", "Audit event coverage", "passed", "medium", [
+          `${auditEvents.length} landlord-scoped audit or canonical event records are available.`,
+        ])
+      : check(
+          "audit_event_coverage",
+          "Audit event coverage",
+          "needs_attention",
+          "medium",
+          [],
+          ["No landlord-scoped audit or canonical event records were available."]
+        ),
+    policyEvents.length
+      ? check("policy_evaluation_available", "Policy evaluation available", "passed", "low", [
+          `${policyEvents.length} policy evaluation events are available.`,
+        ])
+      : check(
+          "policy_evaluation_available",
+          "Policy evaluation available",
+          "unavailable",
+          "low",
+          [],
+          ["No policy evaluation events were available in the landlord-scoped event set."]
+        ),
+    exportRedactions.length
+      ? check("sensitive_data_redacted", "Sensitive data redacted", "passed", "critical", [
+          `${exportRedactions.length} sensitive data categories are excluded or redacted.`,
+        ])
+      : check(
+          "sensitive_data_redacted",
+          "Sensitive data redacted",
+          "blocked",
+          "critical",
+          [],
+          [],
+          ["Redaction metadata is required before readiness review."]
+        ),
+    check("external_submission_disabled", "External submission disabled", "passed", "critical", [
+      "External filing is disabled for audit/compliance readiness.",
+    ]),
+    check("automated_reporting_disabled", "Automated reporting disabled", "passed", "critical", [
+      "Automated reporting is disabled for audit/compliance readiness.",
+    ]),
+  ];
+
+  return {
+    readinessId:
+      cleanId(`audit_compliance:${scope}:${landlordId || "missing_landlord"}:${propertyId || leaseId || "portfolio"}`) ||
+      "audit_compliance:unknown",
+    scope,
+    status: deriveOverallStatus(checks, hasSourceContext),
+    manualOnly: true,
+    certificationIssued: false,
+    externalFilingEnabled: false,
+    automatedReportingEnabled: false,
+    generatedAt,
+    summary: countByStatus(checks),
+    checks,
+    redactions: exportRedactions,
+    disclaimers: DEFAULT_DISCLAIMERS,
+  };
+}

--- a/rentchain-api/src/routes/__tests__/landlordAuditComplianceRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordAuditComplianceRoutes.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+
+  function matches(doc: any, filters: Array<{ field: string; op: string; value: any }>) {
+    return filters.every(({ field, op, value }) => {
+      const actual = doc?.data?.[field];
+      if (op === "==") return actual === value;
+      return false;
+    });
+  }
+
+  function makeQuery(name: string, filters: Array<{ field: string; op: string; value: any }> = []) {
+    return {
+      where: (field: string, op: string, value: any) => makeQuery(name, [...filters, { field, op, value }]),
+      get: async () => {
+        const docs = Array.from(ensureCollection(name).values())
+          .filter((doc) => matches(doc, filters))
+          .map((doc) => ({ id: doc.id, exists: true, data: () => doc.data }));
+        return { docs, empty: docs.length === 0, size: docs.length };
+      },
+      doc: (id: string) => makeDoc(name, id),
+    };
+  }
+
+  function makeDoc(name: string, id: string) {
+    const col = ensureCollection(name);
+    return {
+      id,
+      get: async () => {
+        const entry = col.get(id);
+        return { id, exists: Boolean(entry), data: () => entry?.data };
+      },
+      set: async (data: any) => {
+        col.set(id, { id, data });
+      },
+    };
+  }
+
+  return {
+    resetFakeDb: () => store.clear(),
+    seedDoc: (collection: string, id: string, data: any) => ensureCollection(collection).set(id, { id, data }),
+    fakeDb: {
+      collection: (name: string) => ({
+        where: (field: string, op: string, value: any) => makeQuery(name, [{ field, op, value }]),
+        get: async () => makeQuery(name).get(),
+        doc: (id: string) => makeDoc(name, id),
+      }),
+    },
+  };
+});
+
+let mockUser: any;
+
+vi.mock("../../config/firebase", () => ({
+  db: fakeDb,
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!mockUser) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    req.user = mockUser;
+    return next();
+  },
+}));
+
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: any, res: any, next: any) => {
+    const role = String(req.user?.role || "").trim().toLowerCase();
+    const landlordId = req.user?.landlordId || req.user?.id;
+    if (role !== "landlord" && role !== "admin") return res.status(403).json({ ok: false, error: "Forbidden" });
+    if (!landlordId) return res.status(401).json({ ok: false, error: "Missing landlord context" });
+    req.user.landlordId = landlordId;
+    return next();
+  },
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; user?: Record<string, unknown> | null }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    const query = new URLSearchParams(queryString || "");
+    mockUser = options.user ?? mockUser;
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: mockUser,
+      body: {},
+      query: Object.fromEntries(query.entries()),
+      params: {},
+      headers: {},
+    };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("landlordAuditComplianceRoutes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    resetFakeDb();
+    mockUser = { id: "landlord-1", landlordId: "landlord-1", role: "landlord", email: "landlord@example.com" };
+  });
+
+  it("returns landlord-scoped readiness without certification or filing flags", async () => {
+    seedDoc("properties", "prop-1", { landlordId: "landlord-1", status: "active", unitsCount: 1 });
+    seedDoc("properties", "prop-other", { landlordId: "landlord-2", status: "active", unitsCount: 99 });
+    seedDoc("leases", "lease-1", { landlordId: "landlord-1", propertyId: "prop-1", unitId: "unit-1", status: "active" });
+    seedDoc("rentPayments", "rent-1", { landlordId: "landlord-1", leaseId: "lease-1", status: "paid" });
+    seedDoc("events", "event-1", { landlordId: "landlord-1", domain: "lease", type: "lease.updated" });
+    seedDoc("events", "policy-1", { landlordId: "landlord-1", domain: "policy", type: "policy.evaluated" });
+    const router = (await import("../landlordAuditComplianceRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/audit-compliance/readiness" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.readiness).toEqual(
+      expect.objectContaining({
+        manualOnly: true,
+        certificationIssued: false,
+        externalFilingEnabled: false,
+        automatedReportingEnabled: false,
+      })
+    );
+    expect(res.body.readiness.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ checkKey: "property_identity_present", status: "passed" }),
+        expect.objectContaining({ checkKey: "external_submission_disabled", status: "passed" }),
+        expect.objectContaining({ checkKey: "automated_reporting_disabled", status: "passed" }),
+      ])
+    );
+    expect(JSON.stringify(res.body.readiness)).not.toContain("prop-other");
+  });
+
+  it("returns deterministic blocked readiness when property context is missing", async () => {
+    const router = (await import("../landlordAuditComplianceRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/audit-compliance/readiness" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.readiness.status).toBe("blocked");
+    expect(res.body.readiness.checks).toEqual(
+      expect.arrayContaining([expect.objectContaining({ checkKey: "property_identity_present", status: "blocked" })])
+    );
+  });
+
+  it("blocks non-landlord users", async () => {
+    const router = (await import("../landlordAuditComplianceRoutes")).default;
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/audit-compliance/readiness",
+      user: { id: "tenant-1", role: "tenant" },
+    });
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/rentchain-api/src/routes/landlordAuditComplianceRoutes.ts
+++ b/rentchain-api/src/routes/landlordAuditComplianceRoutes.ts
@@ -1,0 +1,157 @@
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { requireAuth } from "../middleware/requireAuth";
+import { requireLandlord } from "../middleware/requireLandlord";
+import { deriveDecisionInbox } from "../lib/decisions/deriveDecisionInbox";
+import { deriveInstitutionExportPackage } from "../lib/institutionExports/deriveInstitutionExportPackage";
+import { deriveAuditComplianceReadiness } from "../lib/auditCompliance/deriveAuditComplianceReadiness";
+import type { AuditComplianceScope } from "../lib/auditCompliance/auditComplianceTypes";
+import type { InstitutionExportPackageType } from "../lib/institutionExports/institutionExportTypes";
+
+const router = Router();
+
+const PACKAGE_TYPES = new Set<InstitutionExportPackageType>([
+  "lender_due_diligence",
+  "insurance_review",
+  "government_program_review",
+  "auditor_review",
+  "internal_admin_review",
+]);
+
+const SCOPES = new Set<AuditComplianceScope>([
+  "landlord_portfolio",
+  "property",
+  "lease",
+  "export_package",
+  "admin_review",
+]);
+
+function asString(value: unknown, max = 240): string {
+  const next = String(value ?? "").trim().slice(0, max);
+  return next || "";
+}
+
+function requestedPackageType(value: unknown): InstitutionExportPackageType {
+  const raw = asString(value, 120) as InstitutionExportPackageType;
+  return PACKAGE_TYPES.has(raw) ? raw : "lender_due_diligence";
+}
+
+function requestedScope(value: unknown): AuditComplianceScope {
+  const raw = asString(value, 120) as AuditComplianceScope;
+  return SCOPES.has(raw) ? raw : "landlord_portfolio";
+}
+
+async function loadLandlordCollection(collectionName: string, landlordId: string) {
+  const byId = new Map<string, any>();
+  async function collect(field: "landlordId" | "ownerId" | "userId") {
+    const snap = await db.collection(collectionName).where(field, "==", landlordId).get().catch(() => null);
+    for (const doc of snap?.docs || []) {
+      byId.set(doc.id, { id: doc.id, ...((doc.data() as any) || {}) });
+    }
+  }
+
+  await Promise.all([collect("landlordId"), collect("ownerId"), collect("userId")]);
+
+  return Array.from(byId.values()).filter((record) =>
+    [record?.landlordId, record?.ownerId, record?.userId].some((value) => asString(value, 240) === landlordId)
+  );
+}
+
+function filterContext(records: any[], filters: { propertyId: string; leaseId: string }) {
+  return records.filter((record) => {
+    if (filters.leaseId) {
+      return asString(record?.id || record?.leaseId || record?.leaseID, 240) === filters.leaseId || asString(record?.leaseId, 240) === filters.leaseId;
+    }
+    if (filters.propertyId) return asString(record?.propertyId || record?.id, 240) === filters.propertyId;
+    return true;
+  });
+}
+
+async function loadLandlordDecisionItems(landlordId: string) {
+  const analyticsDecisions = new Map<string, any>();
+
+  async function collectAnalytics(collectionName: string) {
+    const records = await loadLandlordCollection(collectionName, landlordId).catch(() => []);
+    for (const record of records) {
+      const decisions = Array.isArray(record?.decisions?.items)
+        ? record.decisions.items
+        : Array.isArray(record?.decisions)
+          ? record.decisions
+          : [];
+      for (const decision of decisions) {
+        const id = asString(decision?.id || decision?.decisionId, 600);
+        if (id) analyticsDecisions.set(id, decision);
+      }
+    }
+  }
+
+  await Promise.all([collectAnalytics("landlordAnalyticsSnapshots"), collectAnalytics("analyticsSnapshots")]);
+
+  return deriveDecisionInbox({
+    analyticsDecisions: Array.from(analyticsDecisions.values()),
+  }).items;
+}
+
+router.get("/audit-compliance/readiness", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = asString(req.user?.landlordId || req.user?.id, 240);
+    if (!landlordId) {
+      return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    }
+
+    const scope = requestedScope(req.query?.scope);
+    const packageType = requestedPackageType(req.query?.packageType);
+    const propertyId = asString(req.query?.propertyId, 240);
+    const leaseId = asString(req.query?.leaseId, 240);
+    const [allProperties, allLeases, units, maintenanceRequests, auditEventsRaw, rentPayments, decisions] = await Promise.all([
+      loadLandlordCollection("properties", landlordId),
+      loadLandlordCollection("leases", landlordId),
+      loadLandlordCollection("units", landlordId),
+      loadLandlordCollection("maintenanceRequests", landlordId),
+      loadLandlordCollection("events", landlordId),
+      loadLandlordCollection("rentPayments", landlordId),
+      loadLandlordDecisionItems(landlordId),
+    ]);
+
+    const filters = { propertyId, leaseId };
+    const properties = filterContext(allProperties, filters);
+    const leases = filterContext(allLeases, filters);
+    const paymentsForContext = filterContext(rentPayments, filters);
+    const eventsForContext = filterContext(auditEventsRaw, filters);
+    const policyEvents = eventsForContext.filter((event) => {
+      return asString(event?.domain, 80) === "policy" || asString(event?.type, 120).startsWith("policy.");
+    });
+
+    const institutionExportPackage = deriveInstitutionExportPackage({
+      packageType,
+      landlordId,
+      properties,
+      leases,
+      units: filterContext(units, filters),
+      maintenanceRequests: filterContext(maintenanceRequests, filters),
+      auditEvents: eventsForContext,
+      decisionItems: decisions,
+    });
+
+    const readiness = deriveAuditComplianceReadiness({
+      scope,
+      landlordId,
+      propertyId,
+      leaseId,
+      properties,
+      leases,
+      rentPayments: paymentsForContext,
+      decisions,
+      auditEvents: eventsForContext,
+      policyEvents,
+      institutionExportPackage,
+    });
+
+    return res.json({ ok: true, readiness });
+  } catch (err: any) {
+    console.error("[landlord-audit-compliance] readiness failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "AUDIT_COMPLIANCE_READINESS_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -102,6 +102,10 @@ vi.mock("./pages/InstitutionExportsPage", () => ({
   default: () => <h1>Institution Export Preview Page</h1>,
 }));
 
+vi.mock("./pages/AuditCompliancePage", () => ({
+  default: () => <h1>Audit Compliance Readiness Page</h1>,
+}));
+
 vi.mock("./pages/landlord/PortfolioScorePage", () => ({
   default: () => <h1>Landlord Portfolio Score</h1>,
 }));
@@ -251,6 +255,20 @@ describe("Routes: /institution-exports", () => {
     );
 
     expect(await screen.findByText(/Institution Export Preview Page/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Routes: /audit-compliance", () => {
+  it("renders the read-only audit compliance readiness route", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/audit-compliance"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Audit Compliance Readiness Page/i)).toBeInTheDocument();
     expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -118,6 +118,7 @@ const LandlordAnalyticsPage = lazy(() => import("./pages/landlord/LandlordAnalyt
 const LandlordInboxPage = lazy(() => import("./pages/landlord/LandlordInboxPage"));
 const DecisionInboxPage = lazy(() => import("./pages/DecisionInboxPage"));
 const InstitutionExportsPage = lazy(() => import("./pages/InstitutionExportsPage"));
+const AuditCompliancePage = lazy(() => import("./pages/AuditCompliancePage"));
 const LandlordPortfolioScorePage = lazy(() => import("./pages/landlord/PortfolioScorePage"));
 const SharedPortfolioScorePage = lazy(() => import("./pages/public/SharedPortfolioScorePage"));
 const TenantSharePackagePage = lazy(() => import("./pages/public/TenantSharePackagePage"));
@@ -525,6 +526,18 @@ function App() {
               <LandlordNav>
                 <Suspense fallback={null}>
                   <InstitutionExportsPage />
+                </Suspense>
+              </LandlordNav>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/audit-compliance"
+          element={
+            <RequireAuth>
+              <LandlordNav>
+                <Suspense fallback={null}>
+                  <AuditCompliancePage />
                 </Suspense>
               </LandlordNav>
             </RequireAuth>

--- a/rentchain-frontend/src/api/auditComplianceApi.ts
+++ b/rentchain-frontend/src/api/auditComplianceApi.ts
@@ -1,0 +1,74 @@
+import { apiFetch } from "./apiFetch";
+import type { InstitutionExportRedaction } from "./institutionExportsApi";
+
+export type AuditComplianceScope =
+  | "landlord_portfolio"
+  | "property"
+  | "lease"
+  | "export_package"
+  | "admin_review";
+
+export type AuditComplianceReadinessStatus =
+  | "ready_for_review"
+  | "needs_attention"
+  | "blocked"
+  | "unavailable";
+
+export type AuditComplianceCheck = {
+  checkKey: string;
+  label: string;
+  status: "passed" | "needs_attention" | "blocked" | "unavailable";
+  severity: "critical" | "high" | "medium" | "low" | "info";
+  evidence: string[];
+  missingEvidence: string[];
+  blockedReasons: string[];
+  manualReviewRequired: true;
+};
+
+export type AuditComplianceReadiness = {
+  readinessId: string;
+  scope: AuditComplianceScope;
+  status: AuditComplianceReadinessStatus;
+  manualOnly: true;
+  certificationIssued: false;
+  externalFilingEnabled: false;
+  automatedReportingEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalChecks: number;
+    passed: number;
+    needsAttention: number;
+    blocked: number;
+    unavailable: number;
+  };
+  checks: AuditComplianceCheck[];
+  redactions: InstitutionExportRedaction[];
+  disclaimers: string[];
+};
+
+export type AuditComplianceReadinessQuery = {
+  scope?: AuditComplianceScope;
+  propertyId?: string;
+  leaseId?: string;
+  packageType?:
+    | "lender_due_diligence"
+    | "insurance_review"
+    | "government_program_review"
+    | "auditor_review"
+    | "internal_admin_review";
+};
+
+export async function fetchAuditComplianceReadiness(
+  params?: AuditComplianceReadinessQuery
+): Promise<AuditComplianceReadiness> {
+  const search = new URLSearchParams();
+  if (params?.scope) search.set("scope", params.scope);
+  if (params?.propertyId) search.set("propertyId", params.propertyId);
+  if (params?.leaseId) search.set("leaseId", params.leaseId);
+  if (params?.packageType) search.set("packageType", params.packageType);
+  const suffix = search.toString() ? `?${search.toString()}` : "";
+  const response = await apiFetch<{ ok: true; readiness: AuditComplianceReadiness }>(
+    `/landlord/audit-compliance/readiness${suffix}`
+  );
+  return response.readiness;
+}

--- a/rentchain-frontend/src/pages/AuditCompliancePage.test.tsx
+++ b/rentchain-frontend/src/pages/AuditCompliancePage.test.tsx
@@ -1,0 +1,130 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import AuditCompliancePage from "./AuditCompliancePage";
+
+const apiMocks = vi.hoisted(() => ({
+  fetchAuditComplianceReadiness: vi.fn(),
+  showToast: vi.fn(),
+  macShellProps: vi.fn(),
+}));
+
+vi.mock("@/api/auditComplianceApi", async () => {
+  const actual = await vi.importActual<any>("@/api/auditComplianceApi");
+  return {
+    ...actual,
+    fetchAuditComplianceReadiness: apiMocks.fetchAuditComplianceReadiness,
+  };
+});
+
+vi.mock("@/components/ui/ToastProvider", () => ({
+  useToast: () => ({
+    showToast: apiMocks.showToast,
+  }),
+}));
+
+vi.mock("@/components/layout/MacShell", () => ({
+  MacShell: ({ children, ...props }: { children: React.ReactNode; showTopNav?: boolean }) => {
+    apiMocks.macShellProps(props);
+    return <div>{children}</div>;
+  },
+}));
+
+function readiness(overrides: Record<string, unknown> = {}) {
+  return {
+    readinessId: "audit_compliance:landlord_portfolio:landlord-1:portfolio",
+    scope: "landlord_portfolio",
+    status: "needs_attention",
+    manualOnly: true,
+    certificationIssued: false,
+    externalFilingEnabled: false,
+    automatedReportingEnabled: false,
+    generatedAt: "2026-05-05T12:00:00.000Z",
+    summary: {
+      totalChecks: 3,
+      passed: 1,
+      needsAttention: 1,
+      blocked: 1,
+      unavailable: 0,
+    },
+    checks: [
+      {
+        checkKey: "property_identity_present",
+        label: "Property identity present",
+        status: "passed",
+        severity: "critical",
+        evidence: ["1 landlord-scoped property record is available."],
+        missingEvidence: [],
+        blockedReasons: [],
+        manualReviewRequired: true,
+      },
+      {
+        checkKey: "audit_event_coverage",
+        label: "Audit event coverage",
+        status: "needs_attention",
+        severity: "medium",
+        evidence: [],
+        missingEvidence: ["No landlord-scoped audit or canonical event records were available."],
+        blockedReasons: [],
+        manualReviewRequired: true,
+      },
+      {
+        checkKey: "sensitive_data_redacted",
+        label: "Sensitive data redacted",
+        status: "blocked",
+        severity: "critical",
+        evidence: [],
+        missingEvidence: [],
+        blockedReasons: ["Redaction metadata is required before readiness review."],
+        manualReviewRequired: true,
+      },
+    ],
+    redactions: [
+      {
+        fieldCategory: "tenant_contact_details",
+        reason: "Tenant contact details are excluded.",
+      },
+    ],
+    disclaimers: [
+      "Readiness only. This is not legal certification.",
+      "No external filing or automated reporting is performed.",
+      "Manual review is required before sharing or relying on this package.",
+    ],
+    ...overrides,
+  };
+}
+
+describe("AuditCompliancePage", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    apiMocks.fetchAuditComplianceReadiness.mockResolvedValue(readiness());
+  });
+
+  it("renders readiness summary, checks, redactions, and required safety copy", async () => {
+    render(<AuditCompliancePage />);
+
+    expect(await screen.findByRole("heading", { name: "Audit and compliance readiness" })).toBeInTheDocument();
+    expect(screen.getAllByText(/Readiness only\. This is not legal certification\./i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/No external filing or automated reporting is performed\./i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Manual review is required before sharing or relying on this package\./i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Needs Attention").length).toBeGreaterThan(0);
+    expect(screen.getByText("Total checks")).toBeInTheDocument();
+    expect(screen.getByText("Property identity present")).toBeInTheDocument();
+    expect(screen.getByText("Audit event coverage")).toBeInTheDocument();
+    expect(screen.getByText(/Missing evidence: No landlord-scoped audit or canonical event records/i)).toBeInTheDocument();
+    expect(screen.getByText(/Blocked: Redaction metadata is required/i)).toBeInTheDocument();
+    expect(screen.getByText("Tenant Contact Details")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /certify|submit|file|send|auto-report|approve compliance/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/approved compliant|legal compliance confirmed/i)).not.toBeInTheDocument();
+    expect(apiMocks.macShellProps).toHaveBeenCalledWith(expect.objectContaining({ showTopNav: false }));
+  });
+
+  it("renders an empty redaction state safely", async () => {
+    apiMocks.fetchAuditComplianceReadiness.mockResolvedValue(readiness({ redactions: [] }));
+
+    render(<AuditCompliancePage />);
+
+    expect(await screen.findByText("No redaction metadata is available yet.")).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/AuditCompliancePage.tsx
+++ b/rentchain-frontend/src/pages/AuditCompliancePage.tsx
@@ -1,0 +1,193 @@
+import React from "react";
+import {
+  fetchAuditComplianceReadiness,
+  type AuditComplianceCheck,
+  type AuditComplianceReadiness,
+} from "@/api/auditComplianceApi";
+import { MacShell } from "@/components/layout/MacShell";
+import { Card, Section } from "@/components/ui/Ui";
+import { useToast } from "@/components/ui/ToastProvider";
+
+function label(value: string) {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function statusTone(status: string) {
+  if (status === "blocked") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
+  if (status === "needs_attention") return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
+  if (status === "passed" || status === "ready_for_review") {
+    return { color: "#166534", background: "#dcfce7", border: "#bbf7d0" };
+  }
+  return { color: "#475569", background: "#f8fafc", border: "#e2e8f0" };
+}
+
+function Badge({ children, status }: { children: React.ReactNode; status: string }) {
+  const tone = statusTone(status);
+  return (
+    <span
+      style={{
+        border: `1px solid ${tone.border}`,
+        borderRadius: 999,
+        background: tone.background,
+        color: tone.color,
+        padding: "3px 9px",
+        fontSize: 12,
+        fontWeight: 900,
+        whiteSpace: "nowrap",
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+function errorMessage(error: unknown) {
+  if (error instanceof Error && error.message) return error.message;
+  return "Failed to load audit and compliance readiness";
+}
+
+function CheckCard({ check }: { check: AuditComplianceCheck }) {
+  return (
+    <Card style={{ borderRadius: 8, display: "grid", gap: 8 }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+        <div>
+          <strong style={{ color: "#0f172a" }}>{check.label}</strong>
+          <div style={{ color: "#64748b", fontSize: 13 }}>Severity: {label(check.severity)}</div>
+        </div>
+        <Badge status={check.status}>{label(check.status)}</Badge>
+      </div>
+      {check.evidence.length ? (
+        <div style={{ color: "#166534", fontSize: 13 }}>Evidence: {check.evidence.join(" ")}</div>
+      ) : null}
+      {check.missingEvidence.length ? (
+        <div style={{ color: "#92400e", fontSize: 13 }}>Missing evidence: {check.missingEvidence.join(" ")}</div>
+      ) : null}
+      {check.blockedReasons.length ? (
+        <div style={{ color: "#991b1b", fontSize: 13 }}>Blocked: {check.blockedReasons.join(" ")}</div>
+      ) : null}
+      {check.manualReviewRequired ? (
+        <div style={{ color: "#475569", fontSize: 12 }}>Manual review required</div>
+      ) : null}
+    </Card>
+  );
+}
+
+export default function AuditCompliancePage() {
+  const { showToast } = useToast();
+  const [data, setData] = React.useState<AuditComplianceReadiness | null>(null);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const readiness = await fetchAuditComplianceReadiness();
+        if (!mounted) return;
+        setData(readiness);
+      } catch (err) {
+        if (!mounted) return;
+        const message = errorMessage(err);
+        setError(message);
+        showToast({ message: "Failed to load audit and compliance readiness", description: message, variant: "error" });
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [showToast]);
+
+  return (
+    <MacShell title="Audit and compliance readiness" showTopNav={false}>
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "grid", gap: 6 }}>
+            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Audit and compliance readiness</h1>
+            <div style={{ color: "#475569", maxWidth: 900 }}>
+              Readiness only. This is not legal certification. No external filing or automated reporting is performed.
+              Manual review is required before sharing or relying on this package.
+            </div>
+          </div>
+        </Section>
+
+        {loading ? <Card>Loading audit and compliance readiness...</Card> : null}
+        {!loading && error ? (
+          <Card style={{ color: "#b91c1c" }}>We couldn't load audit and compliance readiness right now.</Card>
+        ) : null}
+
+        {!loading && !error && data ? (
+          <>
+            <Section style={{ display: "grid", gap: 12 }}>
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
+                <div>
+                  <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>Readiness status</div>
+                  <h2 style={{ margin: "2px 0 0", fontSize: "1.1rem" }}>{label(data.scope)}</h2>
+                </div>
+                <Badge status={data.status}>{label(data.status)}</Badge>
+              </div>
+              <div style={{ color: "#475569", lineHeight: 1.55 }}>
+                Manual only: {data.manualOnly ? "Yes" : "No"}. Certification issued: {data.certificationIssued ? "Yes" : "No"}.
+                External filing enabled: {data.externalFilingEnabled ? "Yes" : "No"}. Automated reporting enabled:{" "}
+                {data.automatedReportingEnabled ? "Yes" : "No"}.
+              </div>
+            </Section>
+
+            <Section style={{ display: "grid", gap: 10 }}>
+              <div style={{ fontWeight: 900 }}>Summary</div>
+              <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(130px, 1fr))", gap: 10 }}>
+                {[
+                  ["Total checks", data.summary.totalChecks],
+                  ["Passed", data.summary.passed],
+                  ["Needs attention", data.summary.needsAttention],
+                  ["Blocked", data.summary.blocked],
+                  ["Unavailable", data.summary.unavailable],
+                ].map(([name, value]) => (
+                  <Card key={String(name)} style={{ borderRadius: 8, padding: 12 }}>
+                    <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>{name}</div>
+                    <strong style={{ color: "#0f172a", fontSize: 22 }}>{String(value)}</strong>
+                  </Card>
+                ))}
+              </div>
+            </Section>
+
+            <Section style={{ display: "grid", gap: 10 }}>
+              <div style={{ fontWeight: 900 }}>Review checks</div>
+              <div style={{ display: "grid", gap: 10 }}>
+                {data.checks.map((check) => (
+                  <CheckCard key={check.checkKey} check={check} />
+                ))}
+              </div>
+            </Section>
+
+            <Section style={{ display: "grid", gap: 10 }}>
+              <div style={{ fontWeight: 900 }}>Redactions</div>
+              {data.redactions.length ? (
+                data.redactions.map((redaction) => (
+                  <Card key={redaction.fieldCategory} style={{ borderRadius: 8, padding: 12 }}>
+                    <strong style={{ color: "#0f172a" }}>{label(redaction.fieldCategory)}</strong>
+                    <div style={{ color: "#475569", fontSize: 13, marginTop: 4 }}>{redaction.reason}</div>
+                  </Card>
+                ))
+              ) : (
+                <Card style={{ color: "#64748b" }}>No redaction metadata is available yet.</Card>
+              )}
+            </Section>
+
+            <Section style={{ display: "grid", gap: 8 }}>
+              <div style={{ fontWeight: 900 }}>Disclaimers</div>
+              {data.disclaimers.map((disclaimer) => (
+                <div key={disclaimer} style={{ color: "#475569", lineHeight: 1.55 }}>
+                  {disclaimer}
+                </div>
+              ))}
+            </Section>
+          </>
+        ) : null}
+      </div>
+    </MacShell>
+  );
+}

--- a/rentchain-frontend/src/pages/InstitutionExportsPage.test.tsx
+++ b/rentchain-frontend/src/pages/InstitutionExportsPage.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import InstitutionExportsPage from "./InstitutionExportsPage";
 
@@ -85,12 +86,17 @@ describe("InstitutionExportsPage", () => {
   });
 
   it("renders read-only preview status, sections, redactions, and safety copy", async () => {
-    render(<InstitutionExportsPage />);
+    render(
+      <MemoryRouter>
+        <InstitutionExportsPage />
+      </MemoryRouter>
+    );
 
     expect(await screen.findByRole("heading", { name: "Institution export preview" })).toBeInTheDocument();
     expect(screen.getByText(/Preview only\. No data is submitted externally\./i)).toBeInTheDocument();
     expect(screen.getByText(/Manual review required before sharing with any institution\./i)).toBeInTheDocument();
     expect(screen.getByText(/Sensitive tenant data may be excluded or redacted\./i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "View readiness" })).toHaveAttribute("href", "/audit-compliance");
     expect(screen.getByText("Lender Due Diligence")).toBeInTheDocument();
     expect(screen.getByText("Preview Ready")).toBeInTheDocument();
     expect(screen.getByText("Property summary")).toBeInTheDocument();
@@ -111,7 +117,11 @@ describe("InstitutionExportsPage", () => {
       .mockResolvedValueOnce(previewPackage())
       .mockResolvedValueOnce(previewPackage({ packageType: "auditor_review", audience: "auditor" }));
 
-    render(<InstitutionExportsPage />);
+    render(
+      <MemoryRouter>
+        <InstitutionExportsPage />
+      </MemoryRouter>
+    );
 
     expect(await screen.findByText("Lender Due Diligence")).toBeInTheDocument();
     fireEvent.change(screen.getByLabelText("Package type"), { target: { value: "auditor_review" } });
@@ -130,7 +140,11 @@ describe("InstitutionExportsPage", () => {
       })
     );
 
-    render(<InstitutionExportsPage />);
+    render(
+      <MemoryRouter>
+        <InstitutionExportsPage />
+      </MemoryRouter>
+    );
 
     expect(await screen.findByText("Blocked")).toBeInTheDocument();
     expect(screen.getByText(/At least one landlord-scoped property is required/i)).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/InstitutionExportsPage.tsx
+++ b/rentchain-frontend/src/pages/InstitutionExportsPage.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Link } from "react-router-dom";
 import {
   fetchInstitutionExportPreview,
   type InstitutionExportPackage,
@@ -140,6 +141,9 @@ export default function InstitutionExportsPage() {
               Preview only. No data is submitted externally. Manual review required before sharing with any institution.
               Sensitive tenant data may be excluded or redacted.
             </div>
+            <Link to="/audit-compliance" style={{ color: "#2563eb", fontWeight: 800 }}>
+              View readiness
+            </Link>
           </div>
         </Section>
 


### PR DESCRIPTION
## Summary
- Adds deterministic, read-only audit/compliance readiness scaffolding
- Adds landlord-scoped endpoint: `GET /api/landlord/audit-compliance/readiness`
- Adds frontend page: `/audit-compliance`
- Adds readiness checks for property identity, lease traceability, occupancy, payment, workflow, delinquency, export preview, audit events, policy evaluation, redactions, external submission disabled, and automated reporting disabled
- Adds required safety copy confirming readiness-only/manual-review behavior
- Confirms no legal certification, external filing, automated reporting, notification, email, worker, queue, scheduled job, or source-record mutation was added
- Confirms sensitive tenant/payment/screening payloads and admin-only data are not exposed

## Verification
- Backend audit compliance tests passed: 7 tests
- Backend build passed
- Frontend targeted audit compliance/institution export/route tests passed: 32 tests
- Full frontend suite passed: 186 files / 762 tests
- Frontend build passed with existing chunk-size warning
- `git diff --check` passed
- Dependency and lockfile diff empty

## Merge Discipline
Before merge, verify CI, merge-gate, codex-pr-review, Vercel, and Terraform pass; PR diff remains scoped to audit/compliance readiness files; dependency and lockfile diff remain empty; and no forbidden UI labels appear: Certify, Submit, File, Send, Auto-report, Approved compliant, Legal compliance confirmed.