### PR TITLE
feat: add operator review session layer

### DIFF
--- a/docs/architecture/operator-review-session-v1.md
+++ b/docs/architecture/operator-review-session-v1.md
@@ -1,0 +1,74 @@
+# Operator Review Session v1
+
+Operator Review Session v1 adds a deterministic, permissioned review envelope for human review of decisions, workflows, delinquency context, institution export previews, and audit/compliance readiness.
+
+## Purpose
+
+A review session is an auditable operational review envelope. It captures who opened a review, what scope was reviewed, which safe evidence references were attached, any bounded notes, and the final manual outcome.
+
+## Scope
+
+Supported review scopes:
+
+- `decision`
+- `workflow`
+- `delinquency`
+- `institution_export`
+- `audit_compliance`
+
+Supported outcomes:
+
+- `reviewed`
+- `needs_follow_up`
+- `escalated`
+- `blocked`
+- `unresolved`
+
+## Persistence
+
+Review sessions are stored separately in `operatorReviewSessions`.
+
+Review sessions do not mutate:
+
+- leases
+- payments
+- tenants
+- properties
+- screening records
+- institution export previews
+- audit/compliance readiness records
+- decision derivation source records
+
+## Audit Events
+
+Review session changes create additive canonical events:
+
+- `operator_review_session_opened`
+- `operator_review_note_added`
+- `operator_review_outcome_recorded`
+- `operator_review_session_closed`
+
+These events are audit visibility only. They do not trigger automation or workflow execution.
+
+## Safety
+
+V1 remains manual only:
+
+- `manualOnly: true`
+- `systemGenerated: false`
+- no autonomous review
+- no auto-resolution
+- no legal certification
+- no external filing
+- no notification sending
+- no background jobs or queues
+
+Notes are length-limited and sanitized before persistence.
+
+## Deferred
+
+- Evidence pack generation
+- Canonical review timeline views
+- Supervised automation
+- Policy-gated agent actions
+- Agent supervision console

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -122,6 +122,7 @@ import landlordPortfolioScoreSharingRoutes from "./routes/landlordPortfolioScore
 import landlordDecisionInboxRoutes from "./routes/landlordDecisionInboxRoutes";
 import landlordInstitutionExportsRoutes from "./routes/landlordInstitutionExportsRoutes";
 import landlordAuditComplianceRoutes from "./routes/landlordAuditComplianceRoutes";
+import landlordOperatorReviewRoutes from "./routes/landlordOperatorReviewRoutes";
 import publicPortfolioScoreRoutes from "./routes/publicPortfolioScoreRoutes";
 import publicTenantShareRoutes from "./routes/publicTenantShareRoutes";
 import landlordActionRecommendationRoutes from "./routes/landlordActionRecommendationRoutes";
@@ -289,6 +290,8 @@ app.use("/api/landlord", routeSource("landlordInstitutionExportsRoutes.ts"), lan
 console.log("[route-mount] landlordInstitutionExportsRoutes mounted at /api/landlord");
 app.use("/api/landlord", routeSource("landlordAuditComplianceRoutes.ts"), landlordAuditComplianceRoutes);
 console.log("[route-mount] landlordAuditComplianceRoutes mounted at /api/landlord");
+app.use("/api/landlord", routeSource("landlordOperatorReviewRoutes.ts"), landlordOperatorReviewRoutes);
+console.log("[route-mount] landlordOperatorReviewRoutes mounted at /api/landlord");
 app.use("/api", routeSource("landlordActionRecommendationRoutes.ts"), landlordActionRecommendationRoutes);
 console.log("[route-mount] landlordActionRecommendationRoutes mounted at /api");
 app.use("/api", routeSource("tenantFeedbackRoutes.ts"), tenantFeedbackRoutes);

--- a/rentchain-api/src/lib/operatorReviews/__tests__/buildOperatorReviewSession.test.ts
+++ b/rentchain-api/src/lib/operatorReviews/__tests__/buildOperatorReviewSession.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import {
+  addOperatorReviewNote,
+  buildOperatorReviewSession,
+  closeOperatorReviewSession,
+  normalizeOperatorReviewSession,
+  parseOperatorReviewCloseRequest,
+  parseOperatorReviewOpenRequest,
+  sanitizeOperatorReviewNote,
+} from "../buildOperatorReviewSession";
+
+const actor = { userId: "landlord-1", role: "landlord" as const, email: "landlord@example.com" };
+
+describe("buildOperatorReviewSession", () => {
+  it("builds deterministic manual review sessions for a scope", () => {
+    const request = parseOperatorReviewOpenRequest({
+      scope: "decision",
+      scopeId: "decision-1",
+      linkedEvidence: [{ evidenceId: "decision-1", label: "Decision", kind: "decision", destination: "/decision-inbox" }],
+      note: "Initial review",
+    });
+    expect(request).toBeTruthy();
+
+    const session = buildOperatorReviewSession({
+      landlordId: "landlord-1",
+      request: request!,
+      actor,
+      now: "2026-05-05T12:00:00.000Z",
+    });
+    const duplicate = buildOperatorReviewSession({
+      landlordId: "landlord-1",
+      request: request!,
+      actor,
+      now: "2026-05-05T12:00:00.000Z",
+    });
+
+    expect(session.reviewSessionId).toBe(duplicate.reviewSessionId);
+    expect(session).toEqual(
+      expect.objectContaining({
+        scope: "decision",
+        scopeId: "decision-1",
+        status: "open",
+        manualOnly: true,
+        systemGenerated: false,
+      })
+    );
+    expect(session.notes[0]).toEqual(expect.objectContaining({ text: "Initial review", actor }));
+  });
+
+  it("sanitizes notes and preserves note history", () => {
+    const session = buildOperatorReviewSession({
+      landlordId: "landlord-1",
+      request: { scope: "audit_compliance", scopeId: "readiness-1", linkedEvidence: [], note: null },
+      actor,
+      now: "2026-05-05T12:00:00.000Z",
+    });
+    const updated = addOperatorReviewNote({
+      session,
+      note: " <script>Review</script>   evidence ",
+      actor,
+      now: "2026-05-05T12:01:00.000Z",
+    });
+
+    expect(sanitizeOperatorReviewNote(" <b>Needs review</b> ")).toBe("bNeeds review/b");
+    expect(updated.notes).toHaveLength(1);
+    expect(updated.notes[0].text).toBe("scriptReview/script evidence");
+    expect(session.notes).toHaveLength(0);
+  });
+
+  it("closes sessions with deterministic outcomes without mutating the source object", () => {
+    const session = buildOperatorReviewSession({
+      landlordId: "landlord-1",
+      request: { scope: "institution_export", scopeId: "package-1", linkedEvidence: [], note: null },
+      actor,
+      now: "2026-05-05T12:00:00.000Z",
+    });
+    const request = parseOperatorReviewCloseRequest({
+      result: "needs_follow_up",
+      summary: "Needs source context follow-up",
+    });
+
+    const closed = closeOperatorReviewSession({
+      session,
+      request: request!,
+      actor,
+      now: "2026-05-05T12:02:00.000Z",
+    });
+
+    expect(session.status).toBe("open");
+    expect(closed.status).toBe("completed");
+    expect(closed.outcome).toEqual(
+      expect.objectContaining({
+        result: "needs_follow_up",
+        summary: "Needs source context follow-up",
+        recordedBy: actor,
+      })
+    );
+  });
+
+  it("normalizes stored sessions defensively", () => {
+    const normalized = normalizeOperatorReviewSession({
+      reviewSessionId: "session-1",
+      landlordId: "landlord-1",
+      scope: "workflow",
+      scopeId: "workflow-1",
+      status: "completed",
+      openedAt: "2026-05-05T12:00:00.000Z",
+      closedAt: "2026-05-05T12:02:00.000Z",
+      openedBy: actor,
+      outcome: {
+        result: "reviewed",
+        summary: "Reviewed",
+        recordedAt: "2026-05-05T12:02:00.000Z",
+        recordedBy: actor,
+      },
+      notes: [],
+      linkedEvidence: [],
+      updatedAt: "2026-05-05T12:02:00.000Z",
+    });
+
+    expect(normalized).toEqual(expect.objectContaining({ reviewSessionId: "session-1", manualOnly: true }));
+    expect(normalizeOperatorReviewSession({ reviewSessionId: "missing" })).toBeNull();
+  });
+});

--- a/rentchain-api/src/lib/operatorReviews/buildOperatorReviewSession.ts
+++ b/rentchain-api/src/lib/operatorReviews/buildOperatorReviewSession.ts
@@ -1,0 +1,298 @@
+import crypto from "crypto";
+import type {
+  OperatorReviewActor,
+  OperatorReviewCloseRequest,
+  OperatorReviewEvidenceReference,
+  OperatorReviewNote,
+  OperatorReviewNoteRequest,
+  OperatorReviewOpenRequest,
+  OperatorReviewOutcome,
+  OperatorReviewOutcomeResult,
+  OperatorReviewScope,
+  OperatorReviewSession,
+  OperatorReviewStatus,
+} from "./operatorReviewTypes";
+
+const VALID_SCOPES = new Set<OperatorReviewScope>([
+  "decision",
+  "workflow",
+  "delinquency",
+  "institution_export",
+  "audit_compliance",
+]);
+const VALID_OUTCOMES = new Set<OperatorReviewOutcomeResult>([
+  "reviewed",
+  "needs_follow_up",
+  "escalated",
+  "blocked",
+  "unresolved",
+]);
+const VALID_CLOSE_STATUSES = new Set<OperatorReviewStatus>(["completed", "escalated", "abandoned"]);
+
+function asString(value: unknown, max = 1000): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function cleanIdPart(value: unknown): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function toIsoDate(value: unknown): string | null {
+  const raw = asString(value, 120);
+  if (!raw) return null;
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toISOString();
+}
+
+export function sanitizeOperatorReviewNote(value: unknown): string {
+  return asString(value, 1200).replace(/[<>]/g, "").replace(/\s+/g, " ").trim();
+}
+
+export function operatorReviewSessionId(input: {
+  landlordId: string;
+  scope: OperatorReviewScope;
+  scopeId: string;
+}): string {
+  const clean = cleanIdPart(["operator_review", input.landlordId, input.scope, input.scopeId].join(":"));
+  return clean || crypto.createHash("sha256").update(JSON.stringify(input)).digest("hex");
+}
+
+export function operatorReviewNoteId(input: {
+  reviewSessionId: string;
+  createdAt: string;
+  actorId?: string | null;
+  note: string;
+}): string {
+  return crypto
+    .createHash("sha256")
+    .update([input.reviewSessionId, input.createdAt, input.actorId || "", input.note].join(":"))
+    .digest("hex");
+}
+
+export function normalizeOperatorReviewActor(raw: unknown): OperatorReviewActor {
+  const data = (raw || {}) as Record<string, unknown>;
+  const role = asString(data.role, 40).toLowerCase();
+  return {
+    userId: asString(data.userId, 240) || null,
+    role: role === "admin" || role === "operator" ? role : "landlord",
+    email: asString(data.email, 320) || null,
+  };
+}
+
+export function normalizeEvidenceReferences(raw: unknown): OperatorReviewEvidenceReference[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((item) => {
+      const data = (item || {}) as Record<string, unknown>;
+      const evidenceId = asString(data.evidenceId || data.id, 240);
+      const label = asString(data.label, 160);
+      const kind = asString(data.kind, 80) as OperatorReviewEvidenceReference["kind"];
+      if (!evidenceId || !label) return null;
+      return {
+        evidenceId,
+        label,
+        kind: ["decision", "workflow", "ledger", "export_package", "audit_readiness"].includes(kind)
+          ? kind
+          : "unknown",
+        destination: asString(data.destination, 500) || null,
+      };
+    })
+    .filter(Boolean)
+    .slice(0, 12) as OperatorReviewEvidenceReference[];
+}
+
+export function normalizeOperatorReviewSession(raw: unknown): OperatorReviewSession | null {
+  const data = (raw || {}) as Record<string, unknown>;
+  const reviewSessionId = asString(data.reviewSessionId || data.id, 240);
+  const landlordId = asString(data.landlordId, 240);
+  const scope = asString(data.scope, 80) as OperatorReviewScope;
+  const scopeId = asString(data.scopeId, 500);
+  const status = asString(data.status, 40) as OperatorReviewStatus;
+  const openedAt = toIsoDate(data.openedAt);
+  const updatedAt = toIsoDate(data.updatedAt) || openedAt;
+  if (!reviewSessionId || !landlordId || !VALID_SCOPES.has(scope) || !scopeId || !openedAt || !updatedAt) {
+    return null;
+  }
+  const notes = Array.isArray(data.notes)
+    ? data.notes
+        .map((rawNote) => {
+          const note = (rawNote || {}) as Record<string, unknown>;
+          const text = sanitizeOperatorReviewNote(note.text);
+          const createdAt = toIsoDate(note.createdAt);
+          const noteId = asString(note.noteId, 240);
+          if (!noteId || !text || !createdAt) return null;
+          return {
+            noteId,
+            text,
+            createdAt,
+            actor: normalizeOperatorReviewActor(note.actor),
+          };
+        })
+        .filter(Boolean)
+    : [];
+  const rawOutcome = (data.outcome || null) as Record<string, unknown> | null;
+  const outcome =
+    rawOutcome && VALID_OUTCOMES.has(asString(rawOutcome.result, 80) as OperatorReviewOutcomeResult)
+      ? {
+          result: asString(rawOutcome.result, 80) as OperatorReviewOutcomeResult,
+          summary: sanitizeOperatorReviewNote(rawOutcome.summary),
+          recordedAt: toIsoDate(rawOutcome.recordedAt) || updatedAt,
+          recordedBy: normalizeOperatorReviewActor(rawOutcome.recordedBy),
+        }
+      : null;
+  return {
+    reviewSessionId,
+    landlordId,
+    scope,
+    scopeId,
+    status: status === "completed" || status === "escalated" || status === "abandoned" ? status : "open",
+    openedAt,
+    closedAt: toIsoDate(data.closedAt),
+    openedBy: normalizeOperatorReviewActor(data.openedBy),
+    outcome,
+    notes: notes as OperatorReviewNote[],
+    linkedEvidence: normalizeEvidenceReferences(data.linkedEvidence),
+    manualOnly: true,
+    systemGenerated: false,
+    updatedAt,
+  };
+}
+
+export function parseOperatorReviewOpenRequest(body: unknown): OperatorReviewOpenRequest | null {
+  const data = (body || {}) as Record<string, unknown>;
+  const scope = asString(data.scope, 80) as OperatorReviewScope;
+  const scopeId = asString(data.scopeId, 500);
+  if (!VALID_SCOPES.has(scope) || !scopeId) return null;
+  return {
+    scope,
+    scopeId,
+    linkedEvidence: normalizeEvidenceReferences(data.linkedEvidence),
+    note: sanitizeOperatorReviewNote(data.note) || null,
+  };
+}
+
+export function parseOperatorReviewNoteRequest(body: unknown): OperatorReviewNoteRequest | null {
+  const note = sanitizeOperatorReviewNote((body as Record<string, unknown> | null)?.note);
+  return note ? { note } : null;
+}
+
+export function parseOperatorReviewCloseRequest(body: unknown): OperatorReviewCloseRequest | null {
+  const data = (body || {}) as Record<string, unknown>;
+  const result = asString(data.result, 80) as OperatorReviewOutcomeResult;
+  const summary = sanitizeOperatorReviewNote(data.summary);
+  const status = asString(data.status, 80) as OperatorReviewStatus;
+  if (!VALID_OUTCOMES.has(result) || !summary) return null;
+  return {
+    result,
+    summary,
+    status: VALID_CLOSE_STATUSES.has(status) ? status : result === "escalated" ? "escalated" : "completed",
+  };
+}
+
+export function buildOperatorReviewSession(input: {
+  landlordId: string;
+  request: OperatorReviewOpenRequest;
+  actor: OperatorReviewActor;
+  now?: string;
+}): OperatorReviewSession {
+  const openedAt = toIsoDate(input.now) || new Date().toISOString();
+  const reviewSessionId = operatorReviewSessionId({
+    landlordId: input.landlordId,
+    scope: input.request.scope,
+    scopeId: input.request.scopeId,
+  });
+  const notes = input.request.note
+    ? [
+        buildOperatorReviewNote({
+          reviewSessionId,
+          note: input.request.note,
+          actor: input.actor,
+          now: openedAt,
+        }),
+      ]
+    : [];
+  return {
+    reviewSessionId,
+    landlordId: input.landlordId,
+    scope: input.request.scope,
+    scopeId: input.request.scopeId,
+    status: "open",
+    openedAt,
+    closedAt: null,
+    openedBy: input.actor,
+    outcome: null,
+    notes,
+    linkedEvidence: input.request.linkedEvidence || [],
+    manualOnly: true,
+    systemGenerated: false,
+    updatedAt: openedAt,
+  };
+}
+
+export function buildOperatorReviewNote(input: {
+  reviewSessionId: string;
+  note: string;
+  actor: OperatorReviewActor;
+  now?: string;
+}): OperatorReviewNote {
+  const createdAt = toIsoDate(input.now) || new Date().toISOString();
+  const text = sanitizeOperatorReviewNote(input.note);
+  return {
+    noteId: operatorReviewNoteId({
+      reviewSessionId: input.reviewSessionId,
+      createdAt,
+      actorId: input.actor.userId,
+      note: text,
+    }),
+    text,
+    createdAt,
+    actor: input.actor,
+  };
+}
+
+export function addOperatorReviewNote(input: {
+  session: OperatorReviewSession;
+  note: string;
+  actor: OperatorReviewActor;
+  now?: string;
+}): OperatorReviewSession {
+  const note = buildOperatorReviewNote({
+    reviewSessionId: input.session.reviewSessionId,
+    note: input.note,
+    actor: input.actor,
+    now: input.now,
+  });
+  return {
+    ...input.session,
+    notes: [...input.session.notes, note],
+    updatedAt: note.createdAt,
+  };
+}
+
+export function closeOperatorReviewSession(input: {
+  session: OperatorReviewSession;
+  request: OperatorReviewCloseRequest;
+  actor: OperatorReviewActor;
+  now?: string;
+}): OperatorReviewSession {
+  const closedAt = toIsoDate(input.now) || new Date().toISOString();
+  const outcome: OperatorReviewOutcome = {
+    result: input.request.result,
+    summary: sanitizeOperatorReviewNote(input.request.summary),
+    recordedAt: closedAt,
+    recordedBy: input.actor,
+  };
+  return {
+    ...input.session,
+    status: input.request.status || (input.request.result === "escalated" ? "escalated" : "completed"),
+    closedAt,
+    outcome,
+    updatedAt: closedAt,
+  };
+}

--- a/rentchain-api/src/lib/operatorReviews/operatorReviewTypes.ts
+++ b/rentchain-api/src/lib/operatorReviews/operatorReviewTypes.ts
@@ -1,0 +1,86 @@
+export const OPERATOR_REVIEW_SESSIONS_COLLECTION = "operatorReviewSessions";
+
+export type OperatorReviewScope =
+  | "decision"
+  | "workflow"
+  | "delinquency"
+  | "institution_export"
+  | "audit_compliance";
+
+export type OperatorReviewStatus = "open" | "completed" | "escalated" | "abandoned";
+
+export type OperatorReviewOutcomeResult =
+  | "reviewed"
+  | "needs_follow_up"
+  | "escalated"
+  | "blocked"
+  | "unresolved";
+
+export type OperatorReviewActorRole = "landlord" | "admin" | "operator";
+
+export type OperatorReviewActor = {
+  userId: string | null;
+  role: OperatorReviewActorRole;
+  email?: string | null;
+};
+
+export type OperatorReviewNote = {
+  noteId: string;
+  text: string;
+  createdAt: string;
+  actor: OperatorReviewActor;
+};
+
+export type OperatorReviewEvidenceReference = {
+  evidenceId: string;
+  label: string;
+  kind: "decision" | "workflow" | "ledger" | "export_package" | "audit_readiness" | "unknown";
+  destination?: string | null;
+};
+
+export type OperatorReviewOutcome = {
+  result: OperatorReviewOutcomeResult;
+  summary: string;
+  recordedAt: string;
+  recordedBy: OperatorReviewActor;
+};
+
+export type OperatorReviewSession = {
+  reviewSessionId: string;
+  landlordId: string;
+  scope: OperatorReviewScope;
+  scopeId: string;
+  status: OperatorReviewStatus;
+  openedAt: string;
+  closedAt: string | null;
+  openedBy: OperatorReviewActor;
+  outcome: OperatorReviewOutcome | null;
+  notes: OperatorReviewNote[];
+  linkedEvidence: OperatorReviewEvidenceReference[];
+  manualOnly: true;
+  systemGenerated: false;
+  updatedAt: string;
+};
+
+export type OperatorReviewOpenRequest = {
+  scope: OperatorReviewScope;
+  scopeId: string;
+  linkedEvidence?: OperatorReviewEvidenceReference[];
+  note?: string | null;
+};
+
+export type OperatorReviewNoteRequest = {
+  note: string;
+};
+
+export type OperatorReviewCloseRequest = {
+  result: OperatorReviewOutcomeResult;
+  summary: string;
+  status?: OperatorReviewStatus | null;
+};
+
+export type OperatorReviewEventType =
+  | "operator_review_session_opened"
+  | "operator_review_note_added"
+  | "operator_review_outcome_recorded"
+  | "operator_review_session_closed";

--- a/rentchain-api/src/routes/__tests__/landlordOperatorReviewRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordOperatorReviewRoutes.test.ts
@@ -1,0 +1,222 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fakeDb, resetFakeDb, listDocs } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+
+  function matches(doc: any, filters: Array<{ field: string; op: string; value: any }>) {
+    return filters.every(({ field, op, value }) => {
+      const actual = doc?.data?.[field];
+      if (op === "==") return actual === value;
+      return false;
+    });
+  }
+
+  function makeQuery(name: string, filters: Array<{ field: string; op: string; value: any }> = []) {
+    return {
+      where: (field: string, op: string, value: any) => makeQuery(name, [...filters, { field, op, value }]),
+      get: async () => {
+        const docs = Array.from(ensureCollection(name).values())
+          .filter((doc) => matches(doc, filters))
+          .map((doc) => ({ id: doc.id, exists: true, data: () => doc.data }));
+        return { docs, empty: docs.length === 0, size: docs.length };
+      },
+      doc: (id: string) => makeDoc(name, id),
+    };
+  }
+
+  function makeDoc(name: string, id: string) {
+    const col = ensureCollection(name);
+    return {
+      id,
+      get: async () => {
+        const entry = col.get(id);
+        return { id, exists: Boolean(entry), data: () => entry?.data };
+      },
+      set: async (data: any) => {
+        col.set(id, { id, data });
+      },
+    };
+  }
+
+  return {
+    resetFakeDb: () => store.clear(),
+    listDocs: (collection: string) => Array.from(ensureCollection(collection).values()).map((entry) => entry.data),
+    fakeDb: {
+      collection: (name: string) => ({
+        where: (field: string, op: string, value: any) => makeQuery(name, [{ field, op, value }]),
+        get: async () => makeQuery(name).get(),
+        doc: (id: string) => makeDoc(name, id),
+      }),
+    },
+  };
+});
+
+let mockUser: any;
+
+vi.mock("../../config/firebase", () => ({
+  db: fakeDb,
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!mockUser) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    req.user = mockUser;
+    return next();
+  },
+}));
+
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: any, res: any, next: any) => {
+    const role = String(req.user?.role || "").trim().toLowerCase();
+    const landlordId = req.user?.landlordId || req.user?.id;
+    if (role !== "landlord" && role !== "admin") return res.status(403).json({ ok: false, error: "Forbidden" });
+    if (!landlordId) return res.status(401).json({ ok: false, error: "Missing landlord context" });
+    req.user.landlordId = landlordId;
+    return next();
+  },
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; body?: any; user?: Record<string, unknown> | null }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    const query = new URLSearchParams(queryString || "");
+    mockUser = options.user ?? mockUser;
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: mockUser,
+      body: options.body || {},
+      query: Object.fromEntries(query.entries()),
+      params: {},
+      headers: {},
+    };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("landlordOperatorReviewRoutes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    resetFakeDb();
+    mockUser = { id: "landlord-1", landlordId: "landlord-1", role: "landlord", email: "landlord@example.com" };
+  });
+
+  it("opens landlord-scoped review sessions and writes canonical events", async () => {
+    const router = (await import("../landlordOperatorReviewRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/operator-reviews",
+      body: {
+        scope: "decision",
+        scopeId: "decision-1",
+        note: "Review this decision",
+        linkedEvidence: [{ evidenceId: "decision-1", label: "Decision", kind: "decision" }],
+      },
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body.session).toEqual(
+      expect.objectContaining({
+        landlordId: "landlord-1",
+        scope: "decision",
+        scopeId: "decision-1",
+        status: "open",
+        manualOnly: true,
+        systemGenerated: false,
+      })
+    );
+    expect(listDocs("operatorReviewSessions")).toHaveLength(1);
+    expect(listDocs("canonicalEvents")).toEqual([
+      expect.objectContaining({
+        type: "operator_review_session_opened",
+        domain: "system",
+        visibility: "landlord",
+      }),
+    ]);
+  });
+
+  it("adds sanitized notes and closes sessions with outcome events", async () => {
+    const router = (await import("../landlordOperatorReviewRoutes")).default;
+    const open = await invokeRouter(router, {
+      method: "POST",
+      url: "/operator-reviews",
+      body: { scope: "audit_compliance", scopeId: "readiness-1" },
+    });
+    const reviewSessionId = open.body.session.reviewSessionId;
+
+    const note = await invokeRouter(router, {
+      method: "POST",
+      url: `/operator-reviews/${encodeURIComponent(reviewSessionId)}/notes`,
+      body: { note: " <b>Needs follow-up</b> " },
+    });
+    expect(note.status).toBe(200);
+    expect(note.body.note.text).toBe("bNeeds follow-up/b");
+
+    const close = await invokeRouter(router, {
+      method: "POST",
+      url: `/operator-reviews/${encodeURIComponent(reviewSessionId)}/close`,
+      body: { result: "needs_follow_up", summary: "Needs supporting evidence" },
+    });
+    expect(close.status).toBe(200);
+    expect(close.body.session).toEqual(
+      expect.objectContaining({
+        status: "completed",
+        outcome: expect.objectContaining({ result: "needs_follow_up" }),
+      })
+    );
+    expect(listDocs("canonicalEvents").map((event: any) => event.type)).toEqual([
+      "operator_review_session_opened",
+      "operator_review_note_added",
+      "operator_review_outcome_recorded",
+      "operator_review_session_closed",
+    ]);
+  });
+
+  it("lists only sessions for the authenticated landlord", async () => {
+    const router = (await import("../landlordOperatorReviewRoutes")).default;
+    await invokeRouter(router, {
+      method: "POST",
+      url: "/operator-reviews",
+      body: { scope: "decision", scopeId: "decision-1" },
+    });
+    mockUser = { id: "landlord-2", landlordId: "landlord-2", role: "landlord", email: "other@example.com" };
+
+    const res = await invokeRouter(router, { method: "GET", url: "/operator-reviews?scope=decision" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.sessions).toEqual([]);
+  });
+
+  it("blocks non-landlord users", async () => {
+    mockUser = { id: "tenant-1", role: "tenant" };
+    const router = (await import("../landlordOperatorReviewRoutes")).default;
+
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/operator-reviews",
+      body: { scope: "decision", scopeId: "decision-1" },
+    });
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/rentchain-api/src/routes/landlordOperatorReviewRoutes.ts
+++ b/rentchain-api/src/routes/landlordOperatorReviewRoutes.ts
@@ -1,0 +1,222 @@
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { requireAuth } from "../middleware/requireAuth";
+import { requireLandlord } from "../middleware/requireLandlord";
+import { writeCanonicalEvent } from "../lib/events/buildEvent";
+import {
+  addOperatorReviewNote,
+  buildOperatorReviewSession,
+  closeOperatorReviewSession,
+  normalizeOperatorReviewActor,
+  normalizeOperatorReviewSession,
+  parseOperatorReviewCloseRequest,
+  parseOperatorReviewNoteRequest,
+  parseOperatorReviewOpenRequest,
+} from "../lib/operatorReviews/buildOperatorReviewSession";
+import {
+  OPERATOR_REVIEW_SESSIONS_COLLECTION,
+  type OperatorReviewEventType,
+  type OperatorReviewScope,
+  type OperatorReviewSession,
+} from "../lib/operatorReviews/operatorReviewTypes";
+
+const router = Router();
+
+function asString(value: unknown, max = 1000) {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function landlordIdFromReq(req: any) {
+  return asString(req.user?.landlordId || req.user?.id || req.user?.sub, 240);
+}
+
+function actorFromReq(req: any) {
+  const role = asString(req.user?.role || req.user?.actorRole, 80).toLowerCase();
+  return normalizeOperatorReviewActor({
+    userId: asString(req.user?.uid || req.user?.id || req.user?.sub, 240) || null,
+    role: role === "admin" ? "admin" : role === "operator" ? "operator" : "landlord",
+    email: asString(req.user?.email, 320) || null,
+  });
+}
+
+function eventIdFor(input: { eventType: OperatorReviewEventType; reviewSessionId: string; at: string }) {
+  return [input.eventType, input.reviewSessionId, input.at]
+    .join(":")
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+async function writeReviewEvent(input: {
+  eventType: OperatorReviewEventType;
+  session: OperatorReviewSession;
+  actor: ReturnType<typeof actorFromReq>;
+  summary: string;
+}) {
+  const occurredAt = input.session.updatedAt || new Date().toISOString();
+  await writeCanonicalEvent({
+    id: eventIdFor({
+      eventType: input.eventType,
+      reviewSessionId: input.session.reviewSessionId,
+      at: occurredAt,
+    }),
+    type: input.eventType,
+    domain: "system",
+    action: input.eventType,
+    status: input.session.status,
+    actor: {
+      type: input.actor.role === "admin" ? "admin" : "landlord",
+      id: input.actor.userId,
+      role: input.actor.role,
+      displayName: input.actor.email || null,
+    },
+    resource: {
+      type: "operator_review_session",
+      id: input.session.reviewSessionId,
+      parentType: input.session.scope,
+      parentId: input.session.scopeId,
+    },
+    occurredAt,
+    visibility: "landlord",
+    summary: input.summary,
+    metadata: {
+      landlordId: input.session.landlordId,
+      scope: input.session.scope,
+      scopeId: input.session.scopeId,
+      manualOnly: true,
+      systemGenerated: false,
+    },
+    tags: ["operator_review", input.session.scope],
+  });
+}
+
+async function loadSessionForLandlord(reviewSessionId: string, landlordId: string) {
+  const snap = await db.collection(OPERATOR_REVIEW_SESSIONS_COLLECTION).doc(reviewSessionId).get();
+  if (!snap.exists) return null;
+  const session = normalizeOperatorReviewSession({ id: snap.id, ...((snap.data() as any) || {}) });
+  if (!session || session.landlordId !== landlordId) return null;
+  return session;
+}
+
+router.get("/operator-reviews", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = landlordIdFromReq(req);
+    if (!landlordId) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    const scope = asString(req.query?.scope, 80) as OperatorReviewScope;
+    const scopeId = asString(req.query?.scopeId, 500);
+    let query: any = db.collection(OPERATOR_REVIEW_SESSIONS_COLLECTION).where("landlordId", "==", landlordId);
+    if (scope) query = query.where("scope", "==", scope);
+    if (scopeId) query = query.where("scopeId", "==", scopeId);
+    const snap = await query.get();
+    const sessions = (snap.docs || [])
+      .map((doc: any) => normalizeOperatorReviewSession({ id: doc.id, ...((doc.data() as any) || {}) }))
+      .filter(Boolean)
+      .sort((a: OperatorReviewSession, b: OperatorReviewSession) => b.updatedAt.localeCompare(a.updatedAt));
+    return res.json({ ok: true, sessions });
+  } catch (err: any) {
+    console.error("[landlordOperatorReviewRoutes] list failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "OPERATOR_REVIEW_LIST_FAILED" });
+  }
+});
+
+router.post("/operator-reviews", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = landlordIdFromReq(req);
+    const request = parseOperatorReviewOpenRequest(req.body);
+    if (!landlordId || !request) return res.status(400).json({ ok: false, error: "OPERATOR_REVIEW_OPEN_INVALID" });
+    const actor = actorFromReq(req);
+    const session = buildOperatorReviewSession({ landlordId, request, actor });
+    const existing = await loadSessionForLandlord(session.reviewSessionId, landlordId);
+    if (existing && existing.status === "open") {
+      return res.json({ ok: true, session: existing, existing: true });
+    }
+    await db.collection(OPERATOR_REVIEW_SESSIONS_COLLECTION).doc(session.reviewSessionId).set(session, { merge: false });
+    await writeReviewEvent({
+      eventType: "operator_review_session_opened",
+      session,
+      actor,
+      summary: `Operator review opened for ${session.scope}.`,
+    });
+    return res.status(201).json({ ok: true, session, existing: false });
+  } catch (err: any) {
+    console.error("[landlordOperatorReviewRoutes] open failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "OPERATOR_REVIEW_OPEN_FAILED" });
+  }
+});
+
+router.get("/operator-reviews/:reviewSessionId", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = landlordIdFromReq(req);
+    const reviewSessionId = decodeURIComponent(asString(req.params?.reviewSessionId, 500));
+    if (!landlordId || !reviewSessionId) return res.status(400).json({ ok: false, error: "OPERATOR_REVIEW_ID_REQUIRED" });
+    const session = await loadSessionForLandlord(reviewSessionId, landlordId);
+    if (!session) return res.status(404).json({ ok: false, error: "OPERATOR_REVIEW_NOT_FOUND" });
+    return res.json({ ok: true, session });
+  } catch (err: any) {
+    console.error("[landlordOperatorReviewRoutes] get failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "OPERATOR_REVIEW_GET_FAILED" });
+  }
+});
+
+router.post("/operator-reviews/:reviewSessionId/notes", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = landlordIdFromReq(req);
+    const reviewSessionId = decodeURIComponent(asString(req.params?.reviewSessionId, 500));
+    const request = parseOperatorReviewNoteRequest(req.body);
+    if (!landlordId || !reviewSessionId || !request) {
+      return res.status(400).json({ ok: false, error: "OPERATOR_REVIEW_NOTE_INVALID" });
+    }
+    const existing = await loadSessionForLandlord(reviewSessionId, landlordId);
+    if (!existing) return res.status(404).json({ ok: false, error: "OPERATOR_REVIEW_NOT_FOUND" });
+    if (existing.status !== "open") return res.status(409).json({ ok: false, error: "OPERATOR_REVIEW_CLOSED" });
+    const actor = actorFromReq(req);
+    const session = addOperatorReviewNote({ session: existing, note: request.note, actor });
+    await db.collection(OPERATOR_REVIEW_SESSIONS_COLLECTION).doc(session.reviewSessionId).set(session, { merge: false });
+    await writeReviewEvent({
+      eventType: "operator_review_note_added",
+      session,
+      actor,
+      summary: "Operator review note added.",
+    });
+    return res.json({ ok: true, session, note: session.notes[session.notes.length - 1] });
+  } catch (err: any) {
+    console.error("[landlordOperatorReviewRoutes] note failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "OPERATOR_REVIEW_NOTE_FAILED" });
+  }
+});
+
+router.post("/operator-reviews/:reviewSessionId/close", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = landlordIdFromReq(req);
+    const reviewSessionId = decodeURIComponent(asString(req.params?.reviewSessionId, 500));
+    const request = parseOperatorReviewCloseRequest(req.body);
+    if (!landlordId || !reviewSessionId || !request) {
+      return res.status(400).json({ ok: false, error: "OPERATOR_REVIEW_CLOSE_INVALID" });
+    }
+    const existing = await loadSessionForLandlord(reviewSessionId, landlordId);
+    if (!existing) return res.status(404).json({ ok: false, error: "OPERATOR_REVIEW_NOT_FOUND" });
+    if (existing.status !== "open") return res.status(409).json({ ok: false, error: "OPERATOR_REVIEW_ALREADY_CLOSED" });
+    const actor = actorFromReq(req);
+    const session = closeOperatorReviewSession({ session: existing, request, actor });
+    await db.collection(OPERATOR_REVIEW_SESSIONS_COLLECTION).doc(session.reviewSessionId).set(session, { merge: false });
+    await writeReviewEvent({
+      eventType: "operator_review_outcome_recorded",
+      session,
+      actor,
+      summary: `Operator review outcome recorded: ${session.outcome?.result || "unresolved"}.`,
+    });
+    await writeReviewEvent({
+      eventType: "operator_review_session_closed",
+      session,
+      actor,
+      summary: `Operator review closed with ${session.status} status.`,
+    });
+    return res.json({ ok: true, session });
+  } catch (err: any) {
+    console.error("[landlordOperatorReviewRoutes] close failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "OPERATOR_REVIEW_CLOSE_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-frontend/src/api/operatorReviewApi.ts
+++ b/rentchain-frontend/src/api/operatorReviewApi.ts
@@ -1,0 +1,121 @@
+import { apiFetch } from "./apiFetch";
+
+export type OperatorReviewScope =
+  | "decision"
+  | "workflow"
+  | "delinquency"
+  | "institution_export"
+  | "audit_compliance";
+
+export type OperatorReviewStatus = "open" | "completed" | "escalated" | "abandoned";
+
+export type OperatorReviewOutcomeResult =
+  | "reviewed"
+  | "needs_follow_up"
+  | "escalated"
+  | "blocked"
+  | "unresolved";
+
+export type OperatorReviewActor = {
+  userId: string | null;
+  role: "landlord" | "admin" | "operator";
+  email?: string | null;
+};
+
+export type OperatorReviewEvidenceReference = {
+  evidenceId: string;
+  label: string;
+  kind: "decision" | "workflow" | "ledger" | "export_package" | "audit_readiness" | "unknown";
+  destination?: string | null;
+};
+
+export type OperatorReviewNote = {
+  noteId: string;
+  text: string;
+  createdAt: string;
+  actor: OperatorReviewActor;
+};
+
+export type OperatorReviewSession = {
+  reviewSessionId: string;
+  landlordId: string;
+  scope: OperatorReviewScope;
+  scopeId: string;
+  status: OperatorReviewStatus;
+  openedAt: string;
+  closedAt: string | null;
+  openedBy: OperatorReviewActor;
+  outcome: {
+    result: OperatorReviewOutcomeResult;
+    summary: string;
+    recordedAt: string;
+    recordedBy: OperatorReviewActor;
+  } | null;
+  notes: OperatorReviewNote[];
+  linkedEvidence: OperatorReviewEvidenceReference[];
+  manualOnly: true;
+  systemGenerated: false;
+  updatedAt: string;
+};
+
+export type OpenOperatorReviewSessionInput = {
+  scope: OperatorReviewScope;
+  scopeId: string;
+  linkedEvidence?: OperatorReviewEvidenceReference[];
+  note?: string | null;
+};
+
+export type CloseOperatorReviewSessionInput = {
+  result: OperatorReviewOutcomeResult;
+  summary: string;
+  status?: OperatorReviewStatus;
+};
+
+export async function fetchOperatorReviewSessions(params: {
+  scope: OperatorReviewScope;
+  scopeId: string;
+}): Promise<OperatorReviewSession[]> {
+  const search = new URLSearchParams({ scope: params.scope, scopeId: params.scopeId });
+  const response = await apiFetch<{ ok: true; sessions: OperatorReviewSession[] }>(
+    `/landlord/operator-reviews?${search.toString()}`
+  );
+  return response.sessions || [];
+}
+
+export async function openOperatorReviewSession(
+  input: OpenOperatorReviewSessionInput
+): Promise<OperatorReviewSession> {
+  const response = await apiFetch<{ ok: true; session: OperatorReviewSession }>("/landlord/operator-reviews", {
+    method: "POST",
+    body: input,
+  });
+  return response.session;
+}
+
+export async function addOperatorReviewNote(
+  reviewSessionId: string,
+  note: string
+): Promise<OperatorReviewSession> {
+  const response = await apiFetch<{ ok: true; session: OperatorReviewSession }>(
+    `/landlord/operator-reviews/${encodeURIComponent(reviewSessionId)}/notes`,
+    {
+      method: "POST",
+      body: { note },
+    }
+  );
+  return response.session;
+}
+
+export async function closeOperatorReviewSession(
+  reviewSessionId: string,
+  input: CloseOperatorReviewSessionInput
+): Promise<OperatorReviewSession> {
+  const response = await apiFetch<{ ok: true; session: OperatorReviewSession }>(
+    `/landlord/operator-reviews/${encodeURIComponent(reviewSessionId)}/close`,
+    {
+      method: "POST",
+      body: input,
+    }
+  );
+  return response.session;
+}

--- a/rentchain-frontend/src/components/operatorReviews/OperatorReviewSessionPanel.test.tsx
+++ b/rentchain-frontend/src/components/operatorReviews/OperatorReviewSessionPanel.test.tsx
@@ -1,0 +1,136 @@
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { OperatorReviewSessionPanel } from "./OperatorReviewSessionPanel";
+
+const apiMocks = vi.hoisted(() => ({
+  fetchOperatorReviewSessions: vi.fn(),
+  openOperatorReviewSession: vi.fn(),
+  addOperatorReviewNote: vi.fn(),
+  closeOperatorReviewSession: vi.fn(),
+  showToast: vi.fn(),
+}));
+
+vi.mock("@/api/operatorReviewApi", async () => {
+  const actual = await vi.importActual<any>("@/api/operatorReviewApi");
+  return {
+    ...actual,
+    fetchOperatorReviewSessions: apiMocks.fetchOperatorReviewSessions,
+    openOperatorReviewSession: apiMocks.openOperatorReviewSession,
+    addOperatorReviewNote: apiMocks.addOperatorReviewNote,
+    closeOperatorReviewSession: apiMocks.closeOperatorReviewSession,
+  };
+});
+
+vi.mock("@/components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast: apiMocks.showToast }),
+}));
+
+function session(overrides: Record<string, any> = {}) {
+  return {
+    reviewSessionId: "operator_review:landlord-1:decision:decision-1",
+    landlordId: "landlord-1",
+    scope: "decision",
+    scopeId: "decision-1",
+    status: "open",
+    openedAt: "2026-05-05T12:00:00.000Z",
+    closedAt: null,
+    openedBy: { userId: "landlord-1", role: "landlord", email: "landlord@example.com" },
+    outcome: null,
+    notes: [],
+    linkedEvidence: [{ evidenceId: "decision-1", label: "Decision evidence", kind: "decision", destination: "/decision-inbox" }],
+    manualOnly: true,
+    systemGenerated: false,
+    updatedAt: "2026-05-05T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("OperatorReviewSessionPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiMocks.fetchOperatorReviewSessions.mockResolvedValue([]);
+    apiMocks.openOperatorReviewSession.mockResolvedValue(session());
+    apiMocks.addOperatorReviewNote.mockResolvedValue(session({
+      notes: [{ noteId: "note-1", text: "Reviewed evidence", createdAt: "2026-05-05T12:01:00.000Z", actor: { userId: "landlord-1", role: "landlord" } }],
+      updatedAt: "2026-05-05T12:01:00.000Z",
+    }));
+    apiMocks.closeOperatorReviewSession.mockResolvedValue(session({
+      status: "completed",
+      closedAt: "2026-05-05T12:02:00.000Z",
+      outcome: {
+        result: "reviewed",
+        summary: "Reviewed by operator",
+        recordedAt: "2026-05-05T12:02:00.000Z",
+        recordedBy: { userId: "landlord-1", role: "landlord" },
+      },
+      updatedAt: "2026-05-05T12:02:00.000Z",
+    }));
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("opens a review session and shows required safety copy", async () => {
+    render(
+      <MemoryRouter>
+        <OperatorReviewSessionPanel scope="decision" scopeId="decision-1" linkedEvidence={[]} />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Operator review session")).toBeInTheDocument();
+    expect(screen.getByText(/Manual operator review/i)).toBeInTheDocument();
+    expect(screen.getByText(/Review sessions are audit logged/i)).toBeInTheDocument();
+    expect(screen.getByText(/No automated approval or certification occurs/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open review" }));
+
+    await waitFor(() => {
+      expect(apiMocks.openOperatorReviewSession).toHaveBeenCalledWith({
+        scope: "decision",
+        scopeId: "decision-1",
+        linkedEvidence: [],
+      });
+    });
+    expect(await screen.findByRole("button", { name: "Record outcome" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /approve|certify|auto-resolve|file|submit to regulator|legal approval/i })).not.toBeInTheDocument();
+  });
+
+  it("adds notes and records outcomes for active sessions", async () => {
+    apiMocks.fetchOperatorReviewSessions.mockResolvedValue([session()]);
+
+    render(
+      <MemoryRouter>
+        <OperatorReviewSessionPanel
+          scope="decision"
+          scopeId="decision-1"
+          linkedEvidence={[{ evidenceId: "decision-1", label: "Decision evidence", kind: "decision", destination: "/decision-inbox" }]}
+        />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole("button", { name: "Add note" })).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Review note"), { target: { value: "Reviewed evidence" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add note" }));
+
+    await waitFor(() => {
+      expect(apiMocks.addOperatorReviewNote).toHaveBeenCalledWith(
+        "operator_review:landlord-1:decision:decision-1",
+        "Reviewed evidence"
+      );
+    });
+
+    fireEvent.change(screen.getByLabelText("Outcome"), { target: { value: "reviewed" } });
+    fireEvent.change(screen.getByLabelText("Outcome summary"), { target: { value: "Reviewed by operator" } });
+    fireEvent.click(screen.getByRole("button", { name: "Record outcome" }));
+
+    await waitFor(() => {
+      expect(apiMocks.closeOperatorReviewSession).toHaveBeenCalledWith(
+        "operator_review:landlord-1:decision:decision-1",
+        expect.objectContaining({ result: "reviewed", summary: "Reviewed by operator" })
+      );
+    });
+  });
+});

--- a/rentchain-frontend/src/components/operatorReviews/OperatorReviewSessionPanel.tsx
+++ b/rentchain-frontend/src/components/operatorReviews/OperatorReviewSessionPanel.tsx
@@ -1,0 +1,257 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import {
+  addOperatorReviewNote,
+  closeOperatorReviewSession,
+  fetchOperatorReviewSessions,
+  openOperatorReviewSession,
+  type OperatorReviewEvidenceReference,
+  type OperatorReviewOutcomeResult,
+  type OperatorReviewScope,
+  type OperatorReviewSession,
+} from "@/api/operatorReviewApi";
+import { Button, Card } from "@/components/ui/Ui";
+import { useToast } from "@/components/ui/ToastProvider";
+
+const outcomeOptions: Array<{ value: OperatorReviewOutcomeResult; label: string }> = [
+  { value: "reviewed", label: "Reviewed" },
+  { value: "needs_follow_up", label: "Needs follow-up" },
+  { value: "escalated", label: "Escalated" },
+  { value: "blocked", label: "Blocked" },
+  { value: "unresolved", label: "Unresolved" },
+];
+
+function label(value: string) {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function statusTone(status: string) {
+  if (status === "escalated" || status === "blocked") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
+  if (status === "open" || status === "needs_follow_up") return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
+  if (status === "completed" || status === "reviewed") return { color: "#166534", background: "#dcfce7", border: "#bbf7d0" };
+  return { color: "#475569", background: "#f8fafc", border: "#e2e8f0" };
+}
+
+function Badge({ children, status }: { children: React.ReactNode; status: string }) {
+  const tone = statusTone(status);
+  return (
+    <span
+      style={{
+        border: `1px solid ${tone.border}`,
+        borderRadius: 999,
+        background: tone.background,
+        color: tone.color,
+        padding: "3px 9px",
+        fontSize: 12,
+        fontWeight: 900,
+        whiteSpace: "nowrap",
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+function errorMessage(error: unknown) {
+  if (error instanceof Error && error.message) return error.message;
+  return "Review session request failed";
+}
+
+export function OperatorReviewSessionPanel({
+  scope,
+  scopeId,
+  linkedEvidence = [],
+}: {
+  scope: OperatorReviewScope;
+  scopeId: string;
+  linkedEvidence?: OperatorReviewEvidenceReference[];
+}) {
+  const { showToast } = useToast();
+  const [sessions, setSessions] = React.useState<OperatorReviewSession[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [working, setWorking] = React.useState(false);
+  const [note, setNote] = React.useState("");
+  const [outcome, setOutcome] = React.useState<OperatorReviewOutcomeResult>("reviewed");
+  const [summary, setSummary] = React.useState("Reviewed by operator");
+
+  const loadSessions = React.useCallback(async () => {
+    try {
+      setLoading(true);
+      const next = await fetchOperatorReviewSessions({ scope, scopeId });
+      setSessions(next);
+    } catch (error) {
+      showToast({ message: "Failed to load review sessions", description: errorMessage(error), variant: "error" });
+    } finally {
+      setLoading(false);
+    }
+  }, [scope, scopeId, showToast]);
+
+  React.useEffect(() => {
+    void loadSessions();
+  }, [loadSessions]);
+
+  const activeSession = sessions.find((session) => session.status === "open") || null;
+  const latestSession = sessions[0] || null;
+
+  async function handleOpenReview() {
+    try {
+      setWorking(true);
+      const session = await openOperatorReviewSession({ scope, scopeId, linkedEvidence });
+      setSessions((current) => [session, ...current.filter((item) => item.reviewSessionId !== session.reviewSessionId)]);
+      showToast({ message: "Review session opened", variant: "success" });
+    } catch (error) {
+      showToast({ message: "Failed to open review session", description: errorMessage(error), variant: "error" });
+    } finally {
+      setWorking(false);
+    }
+  }
+
+  async function handleAddNote() {
+    if (!activeSession || !note.trim()) return;
+    try {
+      setWorking(true);
+      const session = await addOperatorReviewNote(activeSession.reviewSessionId, note);
+      setSessions((current) => [session, ...current.filter((item) => item.reviewSessionId !== session.reviewSessionId)]);
+      setNote("");
+      showToast({ message: "Review note added", variant: "success" });
+    } catch (error) {
+      showToast({ message: "Failed to add review note", description: errorMessage(error), variant: "error" });
+    } finally {
+      setWorking(false);
+    }
+  }
+
+  async function handleCloseReview() {
+    if (!activeSession || !summary.trim()) return;
+    try {
+      setWorking(true);
+      const session = await closeOperatorReviewSession(activeSession.reviewSessionId, {
+        result: outcome,
+        summary,
+        status: outcome === "escalated" ? "escalated" : "completed",
+      });
+      setSessions((current) => [session, ...current.filter((item) => item.reviewSessionId !== session.reviewSessionId)]);
+      showToast({ message: "Review outcome recorded", variant: "success" });
+    } catch (error) {
+      showToast({ message: "Failed to close review session", description: errorMessage(error), variant: "error" });
+    } finally {
+      setWorking(false);
+    }
+  }
+
+  return (
+    <Card style={{ borderRadius: 8, display: "grid", gap: 12, background: "#f8fafc" }}>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap", alignItems: "start" }}>
+        <div style={{ display: "grid", gap: 4 }}>
+          <strong style={{ color: "#0f172a" }}>Operator review session</strong>
+          <div style={{ color: "#475569", fontSize: 13 }}>
+            Manual operator review. Review sessions are audit logged. No automated approval or certification occurs.
+          </div>
+        </div>
+        {latestSession ? <Badge status={latestSession.status}>{label(latestSession.status)}</Badge> : null}
+      </div>
+
+      {loading ? <div style={{ color: "#64748b", fontSize: 13 }}>Loading review history...</div> : null}
+
+      {!loading && !activeSession ? (
+        <Button type="button" variant="secondary" onClick={handleOpenReview} disabled={working}>
+          Open review
+        </Button>
+      ) : null}
+
+      {activeSession ? (
+        <div style={{ display: "grid", gap: 10 }}>
+          <div style={{ color: "#64748b", fontSize: 13 }}>Opened {new Date(activeSession.openedAt).toLocaleString()}</div>
+          <label style={{ display: "grid", gap: 5, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Review note
+            <textarea
+              value={note}
+              onChange={(event) => setNote(event.target.value)}
+              maxLength={1200}
+              rows={3}
+              style={{
+                border: "1px solid #cbd5e1",
+                borderRadius: 8,
+                padding: 10,
+                resize: "vertical",
+                color: "#0f172a",
+              }}
+            />
+          </label>
+          <Button type="button" variant="ghost" onClick={handleAddNote} disabled={working || !note.trim()}>
+            Add note
+          </Button>
+          <div style={{ display: "grid", gridTemplateColumns: "minmax(150px, 220px) 1fr", gap: 8 }}>
+            <label style={{ display: "grid", gap: 5, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+              Outcome
+              <select
+                value={outcome}
+                onChange={(event) => setOutcome(event.target.value as OperatorReviewOutcomeResult)}
+                style={{
+                  border: "1px solid #cbd5e1",
+                  borderRadius: 8,
+                  padding: "8px 10px",
+                  color: "#0f172a",
+                  background: "#fff",
+                }}
+              >
+                {outcomeOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label style={{ display: "grid", gap: 5, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+              Outcome summary
+              <input
+                value={summary}
+                onChange={(event) => setSummary(event.target.value)}
+                maxLength={500}
+                style={{
+                  border: "1px solid #cbd5e1",
+                  borderRadius: 8,
+                  padding: "8px 10px",
+                  color: "#0f172a",
+                }}
+              />
+            </label>
+          </div>
+          <Button type="button" onClick={handleCloseReview} disabled={working || !summary.trim()}>
+            Record outcome
+          </Button>
+        </div>
+      ) : null}
+
+      {latestSession?.linkedEvidence.length ? (
+        <div style={{ display: "grid", gap: 6 }}>
+          <strong style={{ color: "#0f172a", fontSize: 13 }}>Evidence references</strong>
+          {latestSession.linkedEvidence.map((evidence) =>
+            evidence.destination ? (
+              <Link key={evidence.evidenceId} to={evidence.destination} style={{ color: "#2563eb", fontWeight: 800, fontSize: 13 }}>
+                {evidence.label}
+              </Link>
+            ) : (
+              <span key={evidence.evidenceId} style={{ color: "#475569", fontSize: 13 }}>
+                {evidence.label}
+              </span>
+            )
+          )}
+        </div>
+      ) : null}
+
+      {sessions.length ? (
+        <div style={{ display: "grid", gap: 6 }}>
+          <strong style={{ color: "#0f172a", fontSize: 13 }}>View review history</strong>
+          {sessions.slice(0, 3).map((session) => (
+            <div key={session.reviewSessionId} style={{ color: "#475569", fontSize: 13 }}>
+              {label(session.status)} - {new Date(session.updatedAt).toLocaleString()}
+              {session.outcome ? ` - ${label(session.outcome.result)}: ${session.outcome.summary}` : ""}
+              {session.notes.length ? ` - ${session.notes.length} note${session.notes.length === 1 ? "" : "s"}` : ""}
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </Card>
+  );
+}

--- a/rentchain-frontend/src/pages/AuditCompliancePage.test.tsx
+++ b/rentchain-frontend/src/pages/AuditCompliancePage.test.tsx
@@ -5,6 +5,10 @@ import AuditCompliancePage from "./AuditCompliancePage";
 
 const apiMocks = vi.hoisted(() => ({
   fetchAuditComplianceReadiness: vi.fn(),
+  fetchOperatorReviewSessions: vi.fn(),
+  openOperatorReviewSession: vi.fn(),
+  addOperatorReviewNote: vi.fn(),
+  closeOperatorReviewSession: vi.fn(),
   showToast: vi.fn(),
   macShellProps: vi.fn(),
 }));
@@ -14,6 +18,17 @@ vi.mock("@/api/auditComplianceApi", async () => {
   return {
     ...actual,
     fetchAuditComplianceReadiness: apiMocks.fetchAuditComplianceReadiness,
+  };
+});
+
+vi.mock("@/api/operatorReviewApi", async () => {
+  const actual = await vi.importActual<any>("@/api/operatorReviewApi");
+  return {
+    ...actual,
+    fetchOperatorReviewSessions: apiMocks.fetchOperatorReviewSessions,
+    openOperatorReviewSession: apiMocks.openOperatorReviewSession,
+    addOperatorReviewNote: apiMocks.addOperatorReviewNote,
+    closeOperatorReviewSession: apiMocks.closeOperatorReviewSession,
   };
 });
 
@@ -99,6 +114,7 @@ describe("AuditCompliancePage", () => {
     cleanup();
     vi.clearAllMocks();
     apiMocks.fetchAuditComplianceReadiness.mockResolvedValue(readiness());
+    apiMocks.fetchOperatorReviewSessions.mockResolvedValue([]);
   });
 
   it("renders readiness summary, checks, redactions, and required safety copy", async () => {
@@ -115,6 +131,8 @@ describe("AuditCompliancePage", () => {
     expect(screen.getByText(/Missing evidence: No landlord-scoped audit or canonical event records/i)).toBeInTheDocument();
     expect(screen.getByText(/Blocked: Redaction metadata is required/i)).toBeInTheDocument();
     expect(screen.getByText("Tenant Contact Details")).toBeInTheDocument();
+    expect(screen.getByText("Operator review session")).toBeInTheDocument();
+    expect(screen.getByText(/Review sessions are audit logged/i)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /certify|submit|file|send|auto-report|approve compliance/i })).not.toBeInTheDocument();
     expect(screen.queryByText(/approved compliant|legal compliance confirmed/i)).not.toBeInTheDocument();
     expect(apiMocks.macShellProps).toHaveBeenCalledWith(expect.objectContaining({ showTopNav: false }));

--- a/rentchain-frontend/src/pages/AuditCompliancePage.tsx
+++ b/rentchain-frontend/src/pages/AuditCompliancePage.tsx
@@ -5,6 +5,7 @@ import {
   type AuditComplianceReadiness,
 } from "@/api/auditComplianceApi";
 import { MacShell } from "@/components/layout/MacShell";
+import { OperatorReviewSessionPanel } from "@/components/operatorReviews/OperatorReviewSessionPanel";
 import { Card, Section } from "@/components/ui/Ui";
 import { useToast } from "@/components/ui/ToastProvider";
 
@@ -184,6 +185,21 @@ export default function AuditCompliancePage() {
                   {disclaimer}
                 </div>
               ))}
+            </Section>
+
+            <Section>
+              <OperatorReviewSessionPanel
+                scope="audit_compliance"
+                scopeId={data.readinessId}
+                linkedEvidence={[
+                  {
+                    evidenceId: data.readinessId,
+                    label: "Audit and compliance readiness",
+                    kind: "audit_readiness",
+                    destination: "/audit-compliance",
+                  },
+                ]}
+              />
             </Section>
           </>
         ) : null}

--- a/rentchain-frontend/src/pages/DecisionInboxPage.test.tsx
+++ b/rentchain-frontend/src/pages/DecisionInboxPage.test.tsx
@@ -6,6 +6,10 @@ import DecisionInboxPage from "./DecisionInboxPage";
 
 const apiMocks = vi.hoisted(() => ({
   fetchDecisionInbox: vi.fn(),
+  fetchOperatorReviewSessions: vi.fn(),
+  openOperatorReviewSession: vi.fn(),
+  addOperatorReviewNote: vi.fn(),
+  closeOperatorReviewSession: vi.fn(),
   showToast: vi.fn(),
   macShellProps: vi.fn(),
 }));
@@ -15,6 +19,17 @@ vi.mock("@/api/decisionInboxApi", async () => {
   return {
     ...actual,
     fetchDecisionInbox: apiMocks.fetchDecisionInbox,
+  };
+});
+
+vi.mock("@/api/operatorReviewApi", async () => {
+  const actual = await vi.importActual<any>("@/api/operatorReviewApi");
+  return {
+    ...actual,
+    fetchOperatorReviewSessions: apiMocks.fetchOperatorReviewSessions,
+    openOperatorReviewSession: apiMocks.openOperatorReviewSession,
+    addOperatorReviewNote: apiMocks.addOperatorReviewNote,
+    closeOperatorReviewSession: apiMocks.closeOperatorReviewSession,
   };
 });
 
@@ -154,6 +169,7 @@ describe("DecisionInboxPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     apiMocks.fetchDecisionInbox.mockResolvedValue(inboxResponse());
+    apiMocks.fetchOperatorReviewSessions.mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -196,6 +212,8 @@ describe("DecisionInboxPage", () => {
     expect(screen.getByRole("link", { name: "View context" })).toHaveAttribute("href", "/leases/lease-1/ledger");
     expect(screen.getByText("Open cost approval")).toBeInTheDocument();
     expect(screen.getByText("No context link available")).toBeInTheDocument();
+    expect(screen.getAllByText("Operator review session").length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/No automated approval or certification occurs/i).length).toBeGreaterThan(0);
     expect(screen.queryByRole("button", { name: /resolve|dismiss|snooze|approve|retry|execute/i })).not.toBeInTheDocument();
     expect(screen.queryByText(/send notice|charge tenant|start eviction|auto-send|auto-charge/i)).not.toBeInTheDocument();
     expect(apiMocks.macShellProps).toHaveBeenCalledWith(expect.objectContaining({ showTopNav: false }));

--- a/rentchain-frontend/src/pages/DecisionInboxPage.tsx
+++ b/rentchain-frontend/src/pages/DecisionInboxPage.tsx
@@ -11,7 +11,9 @@ import {
   type DecisionWorkflowQueue,
   type DecisionWorkflowState,
 } from "@/api/decisionInboxApi";
+import type { OperatorReviewEvidenceReference, OperatorReviewScope } from "@/api/operatorReviewApi";
 import { MacShell } from "@/components/layout/MacShell";
+import { OperatorReviewSessionPanel } from "@/components/operatorReviews/OperatorReviewSessionPanel";
 import { Card, Section } from "@/components/ui/Ui";
 import { useToast } from "@/components/ui/ToastProvider";
 
@@ -135,6 +137,23 @@ function Badge({ children, tone }: { children: React.ReactNode; tone: { color: s
 
 function DecisionInboxCard({ item }: { item: DecisionInboxItem }) {
   const delinquencyActions = item.delinquencyActions || [];
+  const reviewScope: OperatorReviewScope = item.workflow.queue === "delinquency_review" ? "delinquency" : "decision";
+  const evidence: OperatorReviewEvidenceReference[] = [
+    {
+      evidenceId: item.id,
+      label: item.title,
+      kind: "decision",
+      destination: item.destination,
+    },
+  ];
+  if (item.destination) {
+    evidence.push({
+      evidenceId: `${item.id}:context`,
+      label: "Decision context",
+      kind: item.workflow.queue === "delinquency_review" ? "ledger" : "workflow",
+      destination: item.destination,
+    });
+  }
   return (
     <Card style={{ display: "grid", gap: 12, borderRadius: 8 }}>
       <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
@@ -219,6 +238,11 @@ function DecisionInboxCard({ item }: { item: DecisionInboxItem }) {
           </div>
         </div>
       ) : null}
+      <OperatorReviewSessionPanel
+        scope={reviewScope}
+        scopeId={item.id}
+        linkedEvidence={evidence}
+      />
     </Card>
   );
 }

--- a/rentchain-frontend/src/pages/InstitutionExportsPage.test.tsx
+++ b/rentchain-frontend/src/pages/InstitutionExportsPage.test.tsx
@@ -6,6 +6,10 @@ import InstitutionExportsPage from "./InstitutionExportsPage";
 
 const apiMocks = vi.hoisted(() => ({
   fetchInstitutionExportPreview: vi.fn(),
+  fetchOperatorReviewSessions: vi.fn(),
+  openOperatorReviewSession: vi.fn(),
+  addOperatorReviewNote: vi.fn(),
+  closeOperatorReviewSession: vi.fn(),
   showToast: vi.fn(),
   macShellProps: vi.fn(),
 }));
@@ -15,6 +19,17 @@ vi.mock("@/api/institutionExportsApi", async () => {
   return {
     ...actual,
     fetchInstitutionExportPreview: apiMocks.fetchInstitutionExportPreview,
+  };
+});
+
+vi.mock("@/api/operatorReviewApi", async () => {
+  const actual = await vi.importActual<any>("@/api/operatorReviewApi");
+  return {
+    ...actual,
+    fetchOperatorReviewSessions: apiMocks.fetchOperatorReviewSessions,
+    openOperatorReviewSession: apiMocks.openOperatorReviewSession,
+    addOperatorReviewNote: apiMocks.addOperatorReviewNote,
+    closeOperatorReviewSession: apiMocks.closeOperatorReviewSession,
   };
 });
 
@@ -83,6 +98,7 @@ describe("InstitutionExportsPage", () => {
     cleanup();
     vi.clearAllMocks();
     apiMocks.fetchInstitutionExportPreview.mockResolvedValue(previewPackage());
+    apiMocks.fetchOperatorReviewSessions.mockResolvedValue([]);
   });
 
   it("renders read-only preview status, sections, redactions, and safety copy", async () => {
@@ -107,6 +123,8 @@ describe("InstitutionExportsPage", () => {
     expect(screen.getByText("Payment Account Details")).toBeInTheDocument();
     expect(screen.getByText("Preview payload summary")).toBeInTheDocument();
     expect(screen.getByText("75%")).toBeInTheDocument();
+    expect(screen.getByText("Operator review session")).toBeInTheDocument();
+    expect(screen.getByText(/No automated approval or certification occurs/i)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /submit|send|upload|auto-report|schedule|file now/i })).not.toBeInTheDocument();
     expect(screen.queryByText(/send to lender|send to institution/i)).not.toBeInTheDocument();
     expect(apiMocks.macShellProps).toHaveBeenCalledWith(expect.objectContaining({ showTopNav: false }));

--- a/rentchain-frontend/src/pages/InstitutionExportsPage.tsx
+++ b/rentchain-frontend/src/pages/InstitutionExportsPage.tsx
@@ -7,6 +7,7 @@ import {
   type InstitutionExportSection,
 } from "@/api/institutionExportsApi";
 import { MacShell } from "@/components/layout/MacShell";
+import { OperatorReviewSessionPanel } from "@/components/operatorReviews/OperatorReviewSessionPanel";
 import { Button, Card, Section } from "@/components/ui/Ui";
 import { useToast } from "@/components/ui/ToastProvider";
 
@@ -220,6 +221,21 @@ export default function InstitutionExportsPage() {
             </Section>
 
             <PreviewSummary data={data} />
+
+            <Section>
+              <OperatorReviewSessionPanel
+                scope="institution_export"
+                scopeId={data.packageId}
+                linkedEvidence={[
+                  {
+                    evidenceId: data.packageId,
+                    label: `${label(data.packageType)} preview`,
+                    kind: "export_package",
+                    destination: "/institution-exports",
+                  },
+                ]}
+              />
+            </Section>
           </>
         ) : null}
       </div>


### PR DESCRIPTION
## Summary
- Adds deterministic, landlord-scoped operator review sessions for decisions, workflows, delinquency context, institution export previews, and audit/compliance readiness
- Adds review session endpoints for create/read/note/close flows
- Adds canonical review events:
  - `operator_review_session_opened`
  - `operator_review_note_added`
  - `operator_review_outcome_recorded`
  - `operator_review_session_closed`
- Adds operator review UI panels integrated into Decision Inbox, Institution Exports, and Audit Compliance surfaces
- Adds audit-logged manual review history and outcome recording
- Confirms review sessions remain manual, permissioned, deterministic, and audit logged
- Confirms no autonomous review, legal certification, external filing, scheduled reporting, notification system, worker/queue infrastructure, or source-record mutation was added
- Confirms no sensitive tenant/payment/screening payload exposure or admin-only data leakage was introduced

## Verification
- Backend operator review helper/route tests passed: 8 tests
- Backend build passed on Node 20
- Frontend operator review focused tests passed: 10 tests
- Full frontend suite passed: 187 files / 764 tests
- Frontend build passed with existing chunk-size warning
- `git diff --check` passed
- Dependency and lockfile diff empty
- Forbidden labels absent from touched UI: Approve, Certify, Auto-resolve, File, Submit to regulator, Legal approval

## Merge Discipline
Before merge, verify CI/backend, CI/frontend, merge-gate, codex-pr-review, Vercel, and Terraform pass; PR diff remains scoped to operator review session files; dependency and lockfile diff remain empty; canonical review events are additive audit events only; review sessions stay separate from lease/payment/property source-of-truth records; notes remain sanitized and permission scoped; and no hidden workflow side effects were introduced.