### PR TITLE
feat: add evidence pack preview layer

### DIFF
--- a/docs/architecture/evidence-pack-layer-v1.md
+++ b/docs/architecture/evidence-pack-layer-v1.md
@@ -1,0 +1,140 @@
+# Evidence Pack Layer V1
+
+## Purpose
+
+Evidence Pack Layer V1 introduces deterministic, read-only evidence previews for landlord-scoped operational review. An evidence pack is a review envelope that summarizes which supporting records, events, decisions, review sessions, export readiness checks, and audit/compliance readiness checks are available for a given scope.
+
+Evidence packs are for internal review and context discovery only. They do not share data externally, issue certification, file reports, send communications, or mutate source records.
+
+## Scope
+
+Supported preview scopes:
+
+- `decision`
+- `workflow`
+- `delinquency`
+- `institution_export`
+- `audit_compliance`
+- `lease`
+- `property`
+- `tenant`
+- `maintenance`
+- `admin_review`
+
+The V1 landlord endpoint is permission-scoped and must not expose admin-only evidence through landlord routes.
+
+## Model
+
+Each evidence pack includes:
+
+- deterministic `evidencePackId`
+- `scope` and `scopeId`
+- readiness `status`
+- `manualReviewRequired: true`
+- `externalSharingEnabled: false`
+- `certificationIssued: false`
+- summary counts
+- evidence sections
+- redaction metadata
+- blocked reasons
+- disclaimers
+
+The pack is a derived read model. It is not persisted as a new source of truth.
+
+## Sections
+
+V1 derives these sections when source data is available:
+
+- Decision lineage
+- Workflow routing
+- Operator review sessions
+- Audit events
+- Export readiness
+- Audit and compliance readiness
+- Lease context
+- Property context
+- Maintenance context
+- Delinquency context
+- Redaction summary
+
+Sections may be marked `included`, `incomplete`, `blocked`, or `unavailable`.
+
+## Status Rules
+
+Evidence pack status is deterministic:
+
+- `ready_for_review`: required context is present, no blocked sections, and redaction metadata is available.
+- `incomplete`: one or more non-critical sections are missing or unavailable.
+- `blocked`: a required or safety-sensitive section is blocked.
+- `unavailable`: scope, scope identifier, or landlord context is missing.
+
+No AI scoring, probabilistic ranking, legal conclusion, or compliance certification is produced.
+
+## Redactions
+
+Evidence packs must exclude or redact sensitive payloads, including:
+
+- tenant contact details when not required for the review summary
+- private tenant documents
+- identity documents
+- screening or credit payloads
+- payment provider details
+- private message contents
+
+Redaction metadata is shown as review context. Missing redaction metadata blocks review-ready status.
+
+## Endpoint
+
+Landlord-scoped preview endpoint:
+
+```text
+GET /api/landlord/evidence-packs/preview?scope=...&scopeId=...
+```
+
+Allowed behavior:
+
+- read-only derivation
+- safe internal context links
+- redaction metadata
+- missing evidence and blocked reason reporting
+
+Not allowed:
+
+- external sharing
+- public links
+- file generation for external use
+- certification
+- scheduled generation
+- background workers
+- external API calls
+- mutation of leases, tenants, properties, payments, applications, screening, maintenance, decisions, exports, audit readiness, or operator reviews
+
+## UI
+
+The frontend exposes an internal evidence pack preview surface at:
+
+```text
+/evidence-packs
+```
+
+Supported entry points may link from Decision Inbox, operator review sessions, institution export previews, and audit/compliance readiness surfaces.
+
+Required safety copy:
+
+- “Preview only. Evidence is not shared externally.”
+- “Manual review is required before relying on or sharing this evidence.”
+- “Sensitive data may be excluded or redacted.”
+
+## Deferred
+
+- External sharing rooms
+- Public evidence package links
+- Lender, insurer, government, or auditor submission
+- Report/email sending
+- Legal certification
+- Audit signing
+- Evidence notarization
+- Tenant document export
+- Raw credit/bureau export
+- Payment account export
+- Live integrations

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -123,6 +123,7 @@ import landlordDecisionInboxRoutes from "./routes/landlordDecisionInboxRoutes";
 import landlordInstitutionExportsRoutes from "./routes/landlordInstitutionExportsRoutes";
 import landlordAuditComplianceRoutes from "./routes/landlordAuditComplianceRoutes";
 import landlordOperatorReviewRoutes from "./routes/landlordOperatorReviewRoutes";
+import landlordEvidencePackRoutes from "./routes/landlordEvidencePackRoutes";
 import publicPortfolioScoreRoutes from "./routes/publicPortfolioScoreRoutes";
 import publicTenantShareRoutes from "./routes/publicTenantShareRoutes";
 import landlordActionRecommendationRoutes from "./routes/landlordActionRecommendationRoutes";
@@ -292,6 +293,8 @@ app.use("/api/landlord", routeSource("landlordAuditComplianceRoutes.ts"), landlo
 console.log("[route-mount] landlordAuditComplianceRoutes mounted at /api/landlord");
 app.use("/api/landlord", routeSource("landlordOperatorReviewRoutes.ts"), landlordOperatorReviewRoutes);
 console.log("[route-mount] landlordOperatorReviewRoutes mounted at /api/landlord");
+app.use("/api/landlord", routeSource("landlordEvidencePackRoutes.ts"), landlordEvidencePackRoutes);
+console.log("[route-mount] landlordEvidencePackRoutes mounted at /api/landlord");
 app.use("/api", routeSource("landlordActionRecommendationRoutes.ts"), landlordActionRecommendationRoutes);
 console.log("[route-mount] landlordActionRecommendationRoutes mounted at /api");
 app.use("/api", routeSource("tenantFeedbackRoutes.ts"), tenantFeedbackRoutes);

--- a/rentchain-api/src/lib/evidencePacks/__tests__/deriveEvidencePack.test.ts
+++ b/rentchain-api/src/lib/evidencePacks/__tests__/deriveEvidencePack.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import { deriveEvidencePack } from "../deriveEvidencePack";
+
+const decision: any = {
+  id: "decision-1",
+  title: "Review missing payment",
+  description: "Expected rent payment is missing.",
+  severity: "critical",
+  status: "open",
+  type: "billing",
+  source: "lease_ledger",
+  destination: "/leases/lease-1/ledger",
+  workflow: {
+    queue: "delinquency_review",
+    workflowState: "escalated",
+    ownershipType: "landlord",
+    reviewPriority: "critical",
+    escalationLevel: "critical",
+    manualOnly: true,
+  },
+  createdAt: "2026-05-05T12:00:00.000Z",
+  updatedAt: "2026-05-05T12:00:00.000Z",
+};
+
+const exportPackage: any = {
+  packageId: "institution_export:lender_due_diligence:landlord-1",
+  packageType: "lender_due_diligence",
+  audience: "lender",
+  status: "preview_ready",
+  generatedAt: "2026-05-05T12:00:00.000Z",
+  manualOnly: true,
+  externalSubmissionEnabled: false,
+  sections: [{ sectionKey: "decision_summary", label: "Decision summary", status: "included", recordsCount: 1, blockedReasons: [] }],
+  blockedReasons: [],
+  redactions: [{ fieldCategory: "payment_account_details", reason: "Payment account details are excluded." }],
+  payloadPreview: {},
+};
+
+const readiness: any = {
+  readinessId: "audit_compliance:landlord_portfolio:landlord-1:portfolio",
+  scope: "landlord_portfolio",
+  status: "needs_attention",
+  manualOnly: true,
+  certificationIssued: false,
+  externalFilingEnabled: false,
+  automatedReportingEnabled: false,
+  generatedAt: "2026-05-05T12:00:00.000Z",
+  summary: { totalChecks: 1, passed: 1, needsAttention: 0, blocked: 0, unavailable: 0 },
+  checks: [{ checkKey: "sensitive_data_redacted", label: "Sensitive data redacted", status: "passed", severity: "critical", evidence: ["Redactions present."], missingEvidence: [], blockedReasons: [], manualReviewRequired: true }],
+  redactions: [{ fieldCategory: "screening_payloads", reason: "Screening payloads are excluded." }],
+  disclaimers: [],
+};
+
+describe("deriveEvidencePack", () => {
+  it("derives deterministic read-only evidence packs with redactions", () => {
+    const pack = deriveEvidencePack({
+      scope: "decision",
+      scopeId: "decision-1",
+      landlordId: "landlord-1",
+      generatedAt: "2026-05-05T12:00:00.000Z",
+      decisions: [decision],
+      operatorReviewSessions: [{
+        reviewSessionId: "review-1",
+        landlordId: "landlord-1",
+        scope: "decision",
+        scopeId: "decision-1",
+        status: "completed",
+        openedAt: "2026-05-05T12:01:00.000Z",
+        closedAt: "2026-05-05T12:02:00.000Z",
+        openedBy: { userId: "landlord-1", role: "landlord" },
+        outcome: { result: "reviewed", summary: "Reviewed", recordedAt: "2026-05-05T12:02:00.000Z", recordedBy: { userId: "landlord-1", role: "landlord" } },
+        notes: [],
+        linkedEvidence: [],
+        manualOnly: true,
+        systemGenerated: false,
+        updatedAt: "2026-05-05T12:02:00.000Z",
+      } as any],
+      institutionExportPackage: exportPackage,
+      auditComplianceReadiness: readiness,
+      canonicalEvents: [{ id: "event-1", type: "operator_review_session_closed", summary: "Review closed", resource: { id: "decision-1" }, occurredAt: "2026-05-05T12:02:00.000Z" }],
+      leases: [{ id: "lease-1", leaseId: "lease-1", propertyId: "prop-1", unitId: "unit-1" }],
+      properties: [{ id: "prop-1", name: "Main property" }],
+      maintenanceRequests: [],
+    });
+
+    expect(pack).toEqual(expect.objectContaining({
+      evidencePackId: "evidence_pack:decision:landlord-1:decision-1",
+      manualReviewRequired: true,
+      externalSharingEnabled: false,
+      certificationIssued: false,
+    }));
+    expect(pack.sections.map((section) => section.sectionKey)).toEqual(expect.arrayContaining([
+      "decision_lineage",
+      "workflow_routing",
+      "operator_review_sessions",
+      "audit_events",
+      "redaction_summary",
+    ]));
+    expect(pack.redactions).toEqual(expect.arrayContaining([
+      expect.objectContaining({ fieldCategory: "payment_account_details" }),
+      expect.objectContaining({ fieldCategory: "screening_payloads" }),
+    ]));
+    expect(pack.summary.redactedItems).toBeGreaterThan(0);
+    expect(JSON.stringify(pack)).not.toMatch(/accountNumber|creditReport|bureauPayload|privateDocument/i);
+  });
+
+  it("blocks readiness when redaction metadata is missing", () => {
+    const pack = deriveEvidencePack({
+      scope: "decision",
+      scopeId: "decision-1",
+      landlordId: "landlord-1",
+      decisions: [decision],
+      institutionExportPackage: { ...exportPackage, redactions: [] },
+      auditComplianceReadiness: { ...readiness, redactions: [] },
+    });
+
+    expect(pack.status).toBe("blocked");
+    expect(pack.blockedReasons).toEqual(expect.arrayContaining([
+      "Redaction metadata is required before evidence can be review-ready.",
+    ]));
+  });
+
+  it("marks missing scope context unavailable", () => {
+    const pack = deriveEvidencePack({
+      scope: "decision",
+      scopeId: "",
+      landlordId: "landlord-1",
+      decisions: [],
+    });
+
+    expect(pack.status).toBe("unavailable");
+    expect(pack.manualReviewRequired).toBe(true);
+  });
+});

--- a/rentchain-api/src/lib/evidencePacks/deriveEvidencePack.ts
+++ b/rentchain-api/src/lib/evidencePacks/deriveEvidencePack.ts
@@ -1,0 +1,457 @@
+import type {
+  DeriveEvidencePackInput,
+  EvidenceItem,
+  EvidenceItemSource,
+  EvidenceItemStatus,
+  EvidenceItemType,
+  EvidencePack,
+  EvidencePackRedaction,
+  EvidencePackScope,
+  EvidencePackSection,
+  EvidencePackSectionKey,
+  EvidenceSectionStatus,
+} from "./evidencePackTypes";
+
+const DEFAULT_DISCLAIMERS = [
+  "Preview only. Evidence is not shared externally.",
+  "Manual review is required before relying on or sharing this evidence.",
+  "Sensitive data may be excluded or redacted.",
+];
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function arrayOf<T>(value: T[] | null | undefined): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function cleanId(value: unknown): string {
+  return asString(value, 500)
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function normalizeGeneratedAt(value: unknown): string {
+  const raw = asString(value, 120);
+  const date = raw ? new Date(raw) : new Date();
+  if (Number.isNaN(date.getTime())) return new Date().toISOString();
+  return date.toISOString();
+}
+
+function normalizeTimestamp(value: unknown): string | null {
+  const raw = asString(value, 120);
+  if (!raw) return null;
+  const date = new Date(raw);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+function evidenceItem(input: {
+  itemType: EvidenceItemType;
+  label: string;
+  description: string;
+  status?: EvidenceItemStatus;
+  source: EvidenceItemSource;
+  sourceId?: string | null;
+  destination?: string | null;
+  timestamp?: string | null;
+  redacted?: boolean;
+  redactionReason?: string | null;
+  blockedReason?: string | null;
+}): EvidenceItem {
+  const sourceId = asString(input.sourceId, 500) || null;
+  return {
+    evidenceItemId:
+      cleanId(["evidence_item", input.source, input.itemType, sourceId || input.label].join(":")) ||
+      "evidence_item:unknown",
+    itemType: input.itemType,
+    label: asString(input.label, 160) || "Evidence item",
+    description: asString(input.description, 1000) || "Evidence is available for manual review.",
+    status: input.status || "included",
+    source: input.source,
+    sourceId,
+    destination: asString(input.destination, 500) || null,
+    timestamp: normalizeTimestamp(input.timestamp),
+    redacted: input.redacted === true,
+    redactionReason: asString(input.redactionReason, 500) || null,
+    blockedReason: asString(input.blockedReason, 500) || null,
+  };
+}
+
+function section(input: {
+  sectionKey: EvidencePackSectionKey;
+  label: string;
+  items?: EvidenceItem[];
+  missingEvidence?: string[];
+  blockedReasons?: string[];
+  fallbackStatus?: EvidenceSectionStatus;
+}): EvidencePackSection {
+  const items = input.items || [];
+  const blockedReasons = (input.blockedReasons || []).filter(Boolean);
+  const missingEvidence = (input.missingEvidence || []).filter(Boolean);
+  const status: EvidenceSectionStatus = blockedReasons.length
+    ? "blocked"
+    : items.some((item) => item.status === "blocked")
+      ? "blocked"
+      : missingEvidence.length
+        ? "incomplete"
+        : items.length
+          ? "included"
+          : input.fallbackStatus || "unavailable";
+  return {
+    sectionKey: input.sectionKey,
+    label: input.label,
+    status,
+    itemsCount: items.length,
+    items,
+    missingEvidence,
+    blockedReasons,
+  };
+}
+
+function isRelatedToScope(record: Record<string, any>, scope: EvidencePackScope, scopeId: string): boolean {
+  const id = asString(scopeId, 500);
+  if (!id) return false;
+  if (scope === "decision" || scope === "workflow" || scope === "delinquency") {
+    return [record.id, record.decisionId, record.scopeId, record.resource?.id, record.resource?.parentId]
+      .map((value) => asString(value, 500))
+      .includes(id);
+  }
+  if (scope === "institution_export") {
+    return [record.packageId, record.scopeId, record.resource?.id, record.resource?.parentId]
+      .map((value) => asString(value, 500))
+      .includes(id);
+  }
+  if (scope === "audit_compliance") {
+    return [record.readinessId, record.scopeId, record.resource?.id, record.resource?.parentId]
+      .map((value) => asString(value, 500))
+      .includes(id);
+  }
+  if (scope === "lease") return asString(record.leaseId || record.id || record.resource?.id, 500) === id;
+  if (scope === "property") return asString(record.propertyId || record.id || record.resource?.id, 500) === id;
+  if (scope === "maintenance") return asString(record.id || record.maintenanceRequestId || record.workOrderId, 500) === id;
+  return false;
+}
+
+function decisionSections(input: DeriveEvidencePackInput): EvidencePackSection[] {
+  const scopeId = asString(input.scopeId, 500);
+  const decisions = arrayOf(input.decisions);
+  const scopedDecisions = decisions.filter((decision: any) => {
+    if (["decision", "workflow", "delinquency"].includes(input.scope)) {
+      return asString(decision.id, 500) === scopeId || asString(decision.workflow?.queue, 120) === scopeId;
+    }
+    return isRelatedToScope(decision as any, input.scope, scopeId);
+  });
+  const target = scopedDecisions.length ? scopedDecisions : decisions.slice(0, 5);
+
+  const decisionItems = target.map((decision) =>
+    evidenceItem({
+      itemType: "decision",
+      label: decision.title,
+      description: decision.description,
+      source: "decision_inbox",
+      sourceId: decision.id,
+      destination: decision.destination,
+      timestamp: decision.updatedAt || decision.createdAt,
+    })
+  );
+
+  const workflowItems = target.map((decision) =>
+    evidenceItem({
+      itemType: "workflow",
+      label: "Workflow routing",
+      description: `Queue ${decision.workflow.queue}; state ${decision.workflow.workflowState}; escalation ${decision.workflow.escalationLevel}.`,
+      source: "workflow_routing",
+      sourceId: decision.id,
+      destination: decision.destination,
+      timestamp: decision.updatedAt || decision.createdAt,
+    })
+  );
+
+  return [
+    section({
+      sectionKey: "decision_lineage",
+      label: "Decision lineage",
+      items: decisionItems,
+      missingEvidence: decisionItems.length ? [] : ["No landlord-safe decision evidence was available for this scope."],
+    }),
+    section({
+      sectionKey: "workflow_routing",
+      label: "Workflow routing",
+      items: workflowItems,
+      missingEvidence: workflowItems.length ? [] : ["No workflow routing metadata was available for this scope."],
+    }),
+  ];
+}
+
+function operatorReviewSection(input: DeriveEvidencePackInput): EvidencePackSection {
+  const sessions = arrayOf(input.operatorReviewSessions).filter((session) =>
+    isRelatedToScope(session as any, input.scope, input.scopeId)
+  );
+  return section({
+    sectionKey: "operator_review_sessions",
+    label: "Operator review sessions",
+    items: sessions.map((session) =>
+      evidenceItem({
+        itemType: "operator_review",
+        label: `Review session ${session.status}`,
+        description: session.outcome?.summary || `Manual review session for ${session.scope}.`,
+        source: "operator_review",
+        sourceId: session.reviewSessionId,
+        timestamp: session.updatedAt,
+      })
+    ),
+    missingEvidence: sessions.length ? [] : ["No operator review sessions were available for this scope."],
+  });
+}
+
+function canonicalEventsSection(input: DeriveEvidencePackInput): EvidencePackSection {
+  const events = arrayOf(input.canonicalEvents)
+    .filter((event) => isRelatedToScope(event, input.scope, input.scopeId))
+    .slice(0, 20);
+  return section({
+    sectionKey: "audit_events",
+    label: "Audit events",
+    items: events.map((event) =>
+      evidenceItem({
+        itemType: "canonical_event",
+        label: asString(event.type || event.action, 160) || "Canonical event",
+        description: asString(event.summary, 1000) || "Canonical event is available.",
+        source: "canonical_events",
+        sourceId: event.id,
+        timestamp: event.occurredAt || event.recordedAt,
+      })
+    ),
+    missingEvidence: events.length ? [] : ["No landlord-scoped canonical events were available for this scope."],
+  });
+}
+
+function exportSection(input: DeriveEvidencePackInput): EvidencePackSection {
+  const exportPackage = input.institutionExportPackage;
+  const items =
+    exportPackage?.sections.map((item) =>
+      evidenceItem({
+        itemType: "export_section",
+        label: item.label,
+        description: `${item.recordsCount} aggregate records; status ${item.status}.`,
+        status: item.status === "blocked" ? "blocked" : item.status === "included" ? "included" : "unavailable",
+        source: "institution_exports",
+        sourceId: `${exportPackage.packageId}:${item.sectionKey}`,
+        timestamp: exportPackage.generatedAt,
+        blockedReason: item.blockedReasons.join(" ") || null,
+      })
+    ) || [];
+  return section({
+    sectionKey: "export_readiness",
+    label: "Export readiness",
+    items,
+    missingEvidence: items.length ? [] : ["No institution export preview was available for this evidence pack."],
+  });
+}
+
+function readinessSection(input: DeriveEvidencePackInput): EvidencePackSection {
+  const readiness = input.auditComplianceReadiness;
+  const items =
+    readiness?.checks.map((check) =>
+      evidenceItem({
+        itemType: "readiness_check",
+        label: check.label,
+        description:
+          check.evidence.join(" ") ||
+          check.missingEvidence.join(" ") ||
+          check.blockedReasons.join(" ") ||
+          `Readiness check status ${check.status}.`,
+        status: check.status === "blocked" ? "blocked" : check.status === "passed" ? "included" : "unavailable",
+        source: "audit_compliance",
+        sourceId: `${readiness.readinessId}:${check.checkKey}`,
+        timestamp: readiness.generatedAt,
+        blockedReason: check.blockedReasons.join(" ") || null,
+      })
+    ) || [];
+  return section({
+    sectionKey: "audit_compliance_readiness",
+    label: "Audit and compliance readiness",
+    items,
+    missingEvidence: items.length ? [] : ["No audit/compliance readiness checks were available for this scope."],
+  });
+}
+
+function contextSections(input: DeriveEvidencePackInput): EvidencePackSection[] {
+  const leaseItems = arrayOf(input.leases)
+    .filter((lease) => input.scope !== "lease" || asString(lease.id || lease.leaseId, 240) === input.scopeId)
+    .slice(0, 8)
+    .map((lease) =>
+      evidenceItem({
+        itemType: "lease_summary",
+        label: `Lease ${asString(lease.id || lease.leaseId, 120) || "summary"}`,
+        description: `Lease context includes property and unit linkage without private tenant documents.`,
+        source: "lease_ledger",
+        sourceId: asString(lease.id || lease.leaseId, 240) || null,
+        destination: asString(lease.id || lease.leaseId, 240) ? `/leases/${encodeURIComponent(asString(lease.id || lease.leaseId, 240))}/ledger` : null,
+        timestamp: lease.updatedAt || lease.createdAt,
+      })
+    );
+  const propertyItems = arrayOf(input.properties)
+    .filter((property) => input.scope !== "property" || asString(property.id || property.propertyId, 240) === input.scopeId)
+    .slice(0, 8)
+    .map((property) =>
+      evidenceItem({
+        itemType: "property_summary",
+        label: asString(property.name || property.address || property.id || "Property summary", 160),
+        description: "Landlord-scoped property context is available.",
+        source: "registry",
+        sourceId: asString(property.id || property.propertyId, 240) || null,
+        destination: "/properties",
+        timestamp: property.updatedAt || property.createdAt,
+      })
+    );
+  const maintenanceItems = arrayOf(input.maintenanceRequests)
+    .filter((record) => input.scope !== "maintenance" || asString(record.id || record.maintenanceRequestId, 240) === input.scopeId)
+    .slice(0, 8)
+    .map((record) =>
+      evidenceItem({
+        itemType: "maintenance_summary",
+        label: asString(record.title || record.category || record.id || "Maintenance record", 160),
+        description: "Maintenance summary is included without private message contents.",
+        source: "maintenance",
+        sourceId: asString(record.id || record.maintenanceRequestId, 240) || null,
+        destination: "/maintenance",
+        timestamp: record.updatedAt || record.createdAt,
+      })
+    );
+
+  return [
+    section({
+      sectionKey: "lease_context",
+      label: "Lease context",
+      items: leaseItems,
+      missingEvidence: leaseItems.length ? [] : ["No landlord-scoped lease context was available."],
+    }),
+    section({
+      sectionKey: "property_context",
+      label: "Property context",
+      items: propertyItems,
+      missingEvidence: propertyItems.length ? [] : ["No landlord-scoped property context was available."],
+    }),
+    section({
+      sectionKey: "maintenance_context",
+      label: "Maintenance context",
+      items: maintenanceItems,
+      missingEvidence: maintenanceItems.length ? [] : ["No landlord-scoped maintenance context was available."],
+    }),
+  ];
+}
+
+function delinquencySection(input: DeriveEvidencePackInput): EvidencePackSection {
+  const delinquency = arrayOf(input.decisions).filter((decision) => {
+    return decision.workflow.queue === "delinquency_review" || decision.type === "billing";
+  });
+  return section({
+    sectionKey: "delinquency_context",
+    label: "Delinquency context",
+    items: delinquency.slice(0, 8).map((decision) =>
+      evidenceItem({
+        itemType: "ledger_summary",
+        label: decision.title,
+        description: decision.description,
+        source: "lease_ledger",
+        sourceId: decision.id,
+        destination: decision.destination,
+        timestamp: decision.updatedAt || decision.createdAt,
+      })
+    ),
+    missingEvidence: delinquency.length ? [] : ["No landlord-safe delinquency context was available."],
+  });
+}
+
+function redactionSection(input: DeriveEvidencePackInput): { section: EvidencePackSection; redactions: EvidencePackRedaction[] } {
+  const redactions = [
+    ...(input.institutionExportPackage?.redactions || []),
+    ...(input.auditComplianceReadiness?.redactions || []),
+  ];
+  const byCategory = new Map<string, EvidencePackRedaction>();
+  for (const redaction of redactions) {
+    const fieldCategory = asString(redaction.fieldCategory, 160);
+    const reason = asString(redaction.reason, 500);
+    if (fieldCategory && reason) byCategory.set(fieldCategory, { fieldCategory, reason });
+  }
+  const normalized = Array.from(byCategory.values());
+  return {
+    redactions: normalized,
+    section: section({
+      sectionKey: "redaction_summary",
+      label: "Redaction summary",
+      items: normalized.map((redaction) =>
+        evidenceItem({
+          itemType: "redaction_note",
+          label: redaction.fieldCategory,
+          description: redaction.reason,
+          status: "redacted",
+          source: "institution_exports",
+          sourceId: redaction.fieldCategory,
+          redacted: true,
+          redactionReason: redaction.reason,
+        })
+      ),
+      blockedReasons: normalized.length ? [] : ["Redaction metadata is required before evidence can be review-ready."],
+    }),
+  };
+}
+
+function derivePackStatus(sections: EvidencePackSection[], hasScope: boolean): EvidencePack["status"] {
+  if (!hasScope) return "unavailable";
+  if (sections.some((item) => item.status === "blocked" && ["redaction_summary", "audit_compliance_readiness"].includes(item.sectionKey))) {
+    return "blocked";
+  }
+  if (sections.some((item) => item.status === "blocked")) return "blocked";
+  if (sections.some((item) => item.status === "incomplete" || item.status === "unavailable")) return "incomplete";
+  return "ready_for_review";
+}
+
+export function deriveEvidencePack(input: DeriveEvidencePackInput): EvidencePack {
+  const scope = input.scope;
+  const scopeId = asString(input.scopeId, 500);
+  const generatedAt = normalizeGeneratedAt(input.generatedAt);
+  const decisionRelatedSections = decisionSections(input);
+  const redactions = redactionSection(input);
+  const sections = [
+    ...decisionRelatedSections,
+    operatorReviewSection(input),
+    canonicalEventsSection(input),
+    exportSection(input),
+    readinessSection(input),
+    ...contextSections(input),
+    delinquencySection(input),
+    redactions.section,
+  ];
+  const allItems = sections.flatMap((item) => item.items);
+  const blockedReasons = sections.flatMap((item) => item.blockedReasons);
+  const missingItems = sections.reduce((sum, item) => sum + item.missingEvidence.length, 0);
+  const hasScope = Boolean(scope && scopeId && input.landlordId);
+
+  return {
+    evidencePackId:
+      cleanId(`evidence_pack:${scope}:${input.landlordId || "missing_landlord"}:${scopeId || "missing_scope"}`) ||
+      "evidence_pack:unknown",
+    scope,
+    scopeId,
+    status: derivePackStatus(sections, hasScope),
+    manualReviewRequired: true,
+    externalSharingEnabled: false,
+    certificationIssued: false,
+    generatedAt,
+    summary: {
+      totalItems: allItems.length,
+      includedItems: allItems.filter((item) => item.status === "included").length,
+      redactedItems: allItems.filter((item) => item.redacted || item.status === "redacted").length,
+      blockedItems: allItems.filter((item) => item.status === "blocked").length,
+      missingItems,
+    },
+    sections,
+    redactions: redactions.redactions,
+    blockedReasons,
+    disclaimers: DEFAULT_DISCLAIMERS,
+  };
+}

--- a/rentchain-api/src/lib/evidencePacks/evidencePackTypes.ts
+++ b/rentchain-api/src/lib/evidencePacks/evidencePackTypes.ts
@@ -1,0 +1,127 @@
+import type { AuditComplianceReadiness } from "../auditCompliance/auditComplianceTypes";
+import type { DecisionInboxItem } from "../decisions/decisionInboxTypes";
+import type { InstitutionExportPackage } from "../institutionExports/institutionExportTypes";
+import type { OperatorReviewSession } from "../operatorReviews/operatorReviewTypes";
+
+export type EvidencePackScope =
+  | "decision"
+  | "workflow"
+  | "delinquency"
+  | "institution_export"
+  | "audit_compliance"
+  | "lease"
+  | "property"
+  | "tenant"
+  | "maintenance"
+  | "admin_review";
+
+export type EvidencePackStatus = "ready_for_review" | "incomplete" | "blocked" | "unavailable";
+
+export type EvidenceSectionStatus = "included" | "incomplete" | "blocked" | "unavailable";
+
+export type EvidenceItemStatus = "included" | "redacted" | "blocked" | "unavailable";
+
+export type EvidenceItemType =
+  | "decision"
+  | "workflow"
+  | "operator_review"
+  | "canonical_event"
+  | "export_section"
+  | "readiness_check"
+  | "lease_summary"
+  | "property_summary"
+  | "ledger_summary"
+  | "maintenance_summary"
+  | "redaction_note";
+
+export type EvidenceItemSource =
+  | "decision_inbox"
+  | "workflow_routing"
+  | "operator_review"
+  | "canonical_events"
+  | "institution_exports"
+  | "audit_compliance"
+  | "lease_ledger"
+  | "maintenance"
+  | "registry"
+  | "unknown";
+
+export type EvidenceItem = {
+  evidenceItemId: string;
+  itemType: EvidenceItemType;
+  label: string;
+  description: string;
+  status: EvidenceItemStatus;
+  source: EvidenceItemSource;
+  sourceId: string | null;
+  destination: string | null;
+  timestamp: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type EvidencePackSectionKey =
+  | "decision_lineage"
+  | "workflow_routing"
+  | "operator_review_sessions"
+  | "audit_events"
+  | "export_readiness"
+  | "audit_compliance_readiness"
+  | "lease_context"
+  | "property_context"
+  | "delinquency_context"
+  | "maintenance_context"
+  | "redaction_summary";
+
+export type EvidencePackSection = {
+  sectionKey: EvidencePackSectionKey;
+  label: string;
+  status: EvidenceSectionStatus;
+  itemsCount: number;
+  items: EvidenceItem[];
+  missingEvidence: string[];
+  blockedReasons: string[];
+};
+
+export type EvidencePackRedaction = {
+  fieldCategory: string;
+  reason: string;
+};
+
+export type EvidencePack = {
+  evidencePackId: string;
+  scope: EvidencePackScope;
+  scopeId: string;
+  status: EvidencePackStatus;
+  manualReviewRequired: true;
+  externalSharingEnabled: false;
+  certificationIssued: false;
+  generatedAt: string;
+  summary: {
+    totalItems: number;
+    includedItems: number;
+    redactedItems: number;
+    blockedItems: number;
+    missingItems: number;
+  };
+  sections: EvidencePackSection[];
+  redactions: EvidencePackRedaction[];
+  blockedReasons: string[];
+  disclaimers: string[];
+};
+
+export type DeriveEvidencePackInput = {
+  scope: EvidencePackScope;
+  scopeId: string;
+  landlordId?: string | null;
+  generatedAt?: string | Date | null;
+  decisions?: DecisionInboxItem[] | null;
+  operatorReviewSessions?: OperatorReviewSession[] | null;
+  institutionExportPackage?: InstitutionExportPackage | null;
+  auditComplianceReadiness?: AuditComplianceReadiness | null;
+  canonicalEvents?: Array<Record<string, any>> | null;
+  leases?: Array<Record<string, any>> | null;
+  properties?: Array<Record<string, any>> | null;
+  maintenanceRequests?: Array<Record<string, any>> | null;
+};

--- a/rentchain-api/src/routes/__tests__/landlordEvidencePackRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordEvidencePackRoutes.test.ts
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+
+  function matches(doc: any, filters: Array<{ field: string; op: string; value: any }>) {
+    return filters.every(({ field, op, value }) => {
+      const actual = doc?.data?.[field];
+      if (op === "==") return actual === value;
+      return false;
+    });
+  }
+
+  function makeQuery(name: string, filters: Array<{ field: string; op: string; value: any }> = []) {
+    return {
+      where: (field: string, op: string, value: any) => makeQuery(name, [...filters, { field, op, value }]),
+      get: async () => {
+        const docs = Array.from(ensureCollection(name).values())
+          .filter((doc) => matches(doc, filters))
+          .map((doc) => ({ id: doc.id, exists: true, data: () => doc.data }));
+        return { docs, empty: docs.length === 0, size: docs.length };
+      },
+      doc: (id: string) => makeDoc(name, id),
+    };
+  }
+
+  function makeDoc(name: string, id: string) {
+    const col = ensureCollection(name);
+    return {
+      id,
+      get: async () => {
+        const entry = col.get(id);
+        return { id, exists: Boolean(entry), data: () => entry?.data };
+      },
+      set: async (data: any) => {
+        col.set(id, { id, data });
+      },
+    };
+  }
+
+  return {
+    resetFakeDb: () => store.clear(),
+    seedDoc: (collection: string, id: string, data: any) => ensureCollection(collection).set(id, { id, data }),
+    fakeDb: {
+      collection: (name: string) => ({
+        where: (field: string, op: string, value: any) => makeQuery(name, [{ field, op, value }]),
+        get: async () => makeQuery(name).get(),
+        doc: (id: string) => makeDoc(name, id),
+      }),
+    },
+  };
+});
+
+let mockUser: any;
+
+vi.mock("../../config/firebase", () => ({
+  db: fakeDb,
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!mockUser) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    req.user = mockUser;
+    return next();
+  },
+}));
+
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: any, res: any, next: any) => {
+    const role = String(req.user?.role || "").trim().toLowerCase();
+    const landlordId = req.user?.landlordId || req.user?.id;
+    if (role !== "landlord" && role !== "admin") return res.status(403).json({ ok: false, error: "Forbidden" });
+    if (!landlordId) return res.status(401).json({ ok: false, error: "Missing landlord context" });
+    req.user.landlordId = landlordId;
+    return next();
+  },
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; user?: Record<string, unknown> | null }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    const query = new URLSearchParams(queryString || "");
+    mockUser = options.user ?? mockUser;
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: mockUser,
+      body: {},
+      query: Object.fromEntries(query.entries()),
+      params: {},
+      headers: {},
+    };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+function seedLandlordData() {
+  seedDoc("properties", "prop-1", { landlordId: "landlord-1", name: "Main property", unitsCount: 1 });
+  seedDoc("leases", "lease-1", { landlordId: "landlord-1", propertyId: "prop-1", unitId: "unit-1", status: "active" });
+  seedDoc("events", "event-1", {
+    landlordId: "landlord-1",
+    id: "event-1",
+    type: "operator_review_session_closed",
+    summary: "Review closed",
+    resource: { id: "decision-1", parentId: "decision-1" },
+    occurredAt: "2026-05-05T12:00:00.000Z",
+  });
+  seedDoc("operatorReviewSessions", "review-1", {
+    reviewSessionId: "review-1",
+    landlordId: "landlord-1",
+    scope: "decision",
+    scopeId: "decision-1",
+    status: "completed",
+    openedAt: "2026-05-05T12:00:00.000Z",
+    closedAt: "2026-05-05T12:01:00.000Z",
+    openedBy: { userId: "landlord-1", role: "landlord" },
+    outcome: { result: "reviewed", summary: "Reviewed", recordedAt: "2026-05-05T12:01:00.000Z", recordedBy: { userId: "landlord-1", role: "landlord" } },
+    notes: [],
+    linkedEvidence: [],
+    manualOnly: true,
+    systemGenerated: false,
+    updatedAt: "2026-05-05T12:01:00.000Z",
+  });
+  seedDoc("landlordAnalyticsSnapshots", "snapshot-1", {
+    landlordId: "landlord-1",
+    decisions: {
+      items: [{
+        id: "decision-1",
+        decisionType: "rent_payment_missing",
+        priority: "high",
+        explanation: "Expected rent payment is missing.",
+        recommendedAction: "Review missing payment",
+        state: "pending",
+        destination: "/leases/lease-1/ledger",
+      }],
+    },
+  });
+}
+
+describe("landlordEvidencePackRoutes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    resetFakeDb();
+    mockUser = { id: "landlord-1", landlordId: "landlord-1", role: "landlord", email: "landlord@example.com" };
+  });
+
+  it("returns landlord-scoped read-only evidence pack previews", async () => {
+    seedLandlordData();
+    const router = (await import("../landlordEvidencePackRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/evidence-packs/preview?scope=decision&scopeId=decision-1" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.evidencePack).toEqual(expect.objectContaining({
+      scope: "decision",
+      scopeId: "decision-1",
+      manualReviewRequired: true,
+      externalSharingEnabled: false,
+      certificationIssued: false,
+    }));
+    expect(res.body.evidencePack.sections.map((section: any) => section.sectionKey)).toEqual(expect.arrayContaining([
+      "decision_lineage",
+      "operator_review_sessions",
+      "audit_events",
+      "redaction_summary",
+    ]));
+    expect(JSON.stringify(res.body.evidencePack)).not.toMatch(/accountNumber|creditReport|bureauPayload|privateDocument/i);
+  });
+
+  it("requires landlord scope and valid evidence pack query", async () => {
+    const router = (await import("../landlordEvidencePackRoutes")).default;
+
+    const badQuery = await invokeRouter(router, { method: "GET", url: "/evidence-packs/preview?scope=decision" });
+    expect(badQuery.status).toBe(400);
+
+    const forbidden = await invokeRouter(router, {
+      method: "GET",
+      url: "/evidence-packs/preview?scope=decision&scopeId=decision-1",
+      user: { id: "tenant-1", role: "tenant" },
+    });
+    expect(forbidden.status).toBe(403);
+  });
+
+  it("does not expose another landlord's source context", async () => {
+    seedLandlordData();
+    seedDoc("properties", "prop-2", { landlordId: "landlord-2", name: "Other property" });
+    mockUser = { id: "landlord-2", landlordId: "landlord-2", role: "landlord", email: "other@example.com" };
+    const router = (await import("../landlordEvidencePackRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/evidence-packs/preview?scope=decision&scopeId=decision-1" });
+
+    expect(res.status).toBe(200);
+    expect(JSON.stringify(res.body.evidencePack)).not.toContain("Main property");
+  });
+});

--- a/rentchain-api/src/routes/landlordEvidencePackRoutes.ts
+++ b/rentchain-api/src/routes/landlordEvidencePackRoutes.ts
@@ -1,0 +1,157 @@
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { requireAuth } from "../middleware/requireAuth";
+import { requireLandlord } from "../middleware/requireLandlord";
+import { deriveAuditComplianceReadiness } from "../lib/auditCompliance/deriveAuditComplianceReadiness";
+import { deriveDecisionInbox } from "../lib/decisions/deriveDecisionInbox";
+import { deriveEvidencePack } from "../lib/evidencePacks/deriveEvidencePack";
+import type { EvidencePackScope } from "../lib/evidencePacks/evidencePackTypes";
+import { deriveInstitutionExportPackage } from "../lib/institutionExports/deriveInstitutionExportPackage";
+import type { InstitutionExportPackageType } from "../lib/institutionExports/institutionExportTypes";
+import { normalizeOperatorReviewSession } from "../lib/operatorReviews/buildOperatorReviewSession";
+import { OPERATOR_REVIEW_SESSIONS_COLLECTION } from "../lib/operatorReviews/operatorReviewTypes";
+
+const router = Router();
+
+const SCOPES = new Set<EvidencePackScope>([
+  "decision",
+  "workflow",
+  "delinquency",
+  "institution_export",
+  "audit_compliance",
+  "lease",
+  "property",
+  "tenant",
+  "maintenance",
+  "admin_review",
+]);
+const PACKAGE_TYPES = new Set<InstitutionExportPackageType>([
+  "lender_due_diligence",
+  "insurance_review",
+  "government_program_review",
+  "auditor_review",
+  "internal_admin_review",
+]);
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function requestedScope(value: unknown): EvidencePackScope | null {
+  const raw = asString(value, 120) as EvidencePackScope;
+  return SCOPES.has(raw) ? raw : null;
+}
+
+function requestedPackageType(value: unknown): InstitutionExportPackageType {
+  const raw = asString(value, 120) as InstitutionExportPackageType;
+  return PACKAGE_TYPES.has(raw) ? raw : "lender_due_diligence";
+}
+
+async function loadLandlordCollection(collectionName: string, landlordId: string) {
+  const byId = new Map<string, any>();
+  async function collect(field: "landlordId" | "ownerId" | "userId") {
+    const snap = await db.collection(collectionName).where(field, "==", landlordId).get().catch(() => null);
+    for (const doc of snap?.docs || []) {
+      byId.set(doc.id, { id: doc.id, ...((doc.data() as any) || {}) });
+    }
+  }
+  await Promise.all([collect("landlordId"), collect("ownerId"), collect("userId")]);
+  return Array.from(byId.values()).filter((record) =>
+    [record?.landlordId, record?.ownerId, record?.userId].some((value) => asString(value, 240) === landlordId)
+  );
+}
+
+async function loadLandlordDecisionItems(landlordId: string) {
+  const analyticsDecisions = new Map<string, any>();
+  async function collectAnalytics(collectionName: string) {
+    const records = await loadLandlordCollection(collectionName, landlordId).catch(() => []);
+    for (const record of records) {
+      const decisions = Array.isArray(record?.decisions?.items)
+        ? record.decisions.items
+        : Array.isArray(record?.decisions)
+          ? record.decisions
+          : [];
+      for (const decision of decisions) {
+        const id = asString(decision?.id || decision?.decisionId, 600);
+        if (id) analyticsDecisions.set(id, decision);
+      }
+    }
+  }
+  await Promise.all([collectAnalytics("landlordAnalyticsSnapshots"), collectAnalytics("analyticsSnapshots")]);
+  return deriveDecisionInbox({ analyticsDecisions: Array.from(analyticsDecisions.values()) }).items;
+}
+
+async function loadOperatorReviewSessions(landlordId: string) {
+  const snap = await db.collection(OPERATOR_REVIEW_SESSIONS_COLLECTION).where("landlordId", "==", landlordId).get().catch(() => null);
+  return (snap?.docs || [])
+    .map((doc: any) => normalizeOperatorReviewSession({ id: doc.id, ...((doc.data() as any) || {}) }))
+    .filter(Boolean);
+}
+
+router.get("/evidence-packs/preview", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = asString(req.user?.landlordId || req.user?.id, 240);
+    const scope = requestedScope(req.query?.scope);
+    const scopeId = asString(req.query?.scopeId, 500);
+    if (!landlordId) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    if (!scope || !scopeId) return res.status(400).json({ ok: false, error: "EVIDENCE_PACK_SCOPE_REQUIRED" });
+
+    const packageType = requestedPackageType(req.query?.packageType);
+    const [properties, leases, units, maintenanceRequests, rentPayments, events, decisions, operatorReviewSessions] =
+      await Promise.all([
+        loadLandlordCollection("properties", landlordId),
+        loadLandlordCollection("leases", landlordId),
+        loadLandlordCollection("units", landlordId),
+        loadLandlordCollection("maintenanceRequests", landlordId),
+        loadLandlordCollection("rentPayments", landlordId),
+        loadLandlordCollection("events", landlordId),
+        loadLandlordDecisionItems(landlordId),
+        loadOperatorReviewSessions(landlordId),
+      ]);
+
+    const institutionExportPackage = deriveInstitutionExportPackage({
+      packageType,
+      landlordId,
+      properties,
+      leases,
+      units,
+      maintenanceRequests,
+      auditEvents: events,
+      decisionItems: decisions,
+    });
+    const auditComplianceReadiness = deriveAuditComplianceReadiness({
+      scope: scope === "audit_compliance" ? "landlord_portfolio" : scope === "lease" ? "lease" : scope === "property" ? "property" : "landlord_portfolio",
+      landlordId,
+      propertyId: scope === "property" ? scopeId : undefined,
+      leaseId: scope === "lease" ? scopeId : undefined,
+      properties,
+      leases,
+      rentPayments,
+      decisions,
+      auditEvents: events,
+      policyEvents: events.filter((event) => asString(event?.domain, 80) === "policy" || asString(event?.type, 120).startsWith("policy.")),
+      institutionExportPackage,
+    });
+
+    const evidencePack = deriveEvidencePack({
+      scope,
+      scopeId,
+      landlordId,
+      decisions,
+      operatorReviewSessions: operatorReviewSessions as any,
+      institutionExportPackage,
+      auditComplianceReadiness,
+      canonicalEvents: events,
+      leases,
+      properties,
+      maintenanceRequests,
+    });
+
+    return res.json({ ok: true, evidencePack });
+  } catch (err: any) {
+    console.error("[landlord-evidence-packs] preview failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "EVIDENCE_PACK_PREVIEW_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -106,6 +106,10 @@ vi.mock("./pages/AuditCompliancePage", () => ({
   default: () => <h1>Audit Compliance Readiness Page</h1>,
 }));
 
+vi.mock("./pages/EvidencePackPage", () => ({
+  default: () => <h1>Evidence Pack Preview Page</h1>,
+}));
+
 vi.mock("./pages/landlord/PortfolioScorePage", () => ({
   default: () => <h1>Landlord Portfolio Score</h1>,
 }));
@@ -269,6 +273,20 @@ describe("Routes: /audit-compliance", () => {
     );
 
     expect(await screen.findByText(/Audit Compliance Readiness Page/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Routes: /evidence-packs", () => {
+  it("renders the read-only evidence pack preview route", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/evidence-packs?scope=decision&scopeId=decision-1"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Evidence Pack Preview Page/i)).toBeInTheDocument();
     expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -119,6 +119,7 @@ const LandlordInboxPage = lazy(() => import("./pages/landlord/LandlordInboxPage"
 const DecisionInboxPage = lazy(() => import("./pages/DecisionInboxPage"));
 const InstitutionExportsPage = lazy(() => import("./pages/InstitutionExportsPage"));
 const AuditCompliancePage = lazy(() => import("./pages/AuditCompliancePage"));
+const EvidencePackPage = lazy(() => import("./pages/EvidencePackPage"));
 const LandlordPortfolioScorePage = lazy(() => import("./pages/landlord/PortfolioScorePage"));
 const SharedPortfolioScorePage = lazy(() => import("./pages/public/SharedPortfolioScorePage"));
 const TenantSharePackagePage = lazy(() => import("./pages/public/TenantSharePackagePage"));
@@ -538,6 +539,18 @@ function App() {
               <LandlordNav>
                 <Suspense fallback={null}>
                   <AuditCompliancePage />
+                </Suspense>
+              </LandlordNav>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/evidence-packs"
+          element={
+            <RequireAuth>
+              <LandlordNav>
+                <Suspense fallback={null}>
+                  <EvidencePackPage />
                 </Suspense>
               </LandlordNav>
             </RequireAuth>

--- a/rentchain-frontend/src/api/evidencePackApi.ts
+++ b/rentchain-frontend/src/api/evidencePackApi.ts
@@ -1,0 +1,122 @@
+import { apiFetch } from "./apiFetch";
+
+export type EvidencePackScope =
+  | "decision"
+  | "workflow"
+  | "delinquency"
+  | "institution_export"
+  | "audit_compliance"
+  | "lease"
+  | "property"
+  | "tenant"
+  | "maintenance"
+  | "admin_review";
+
+export type EvidencePackStatus = "ready_for_review" | "incomplete" | "blocked" | "unavailable";
+export type EvidenceSectionStatus = "included" | "incomplete" | "blocked" | "unavailable";
+export type EvidenceItemStatus = "included" | "redacted" | "blocked" | "unavailable";
+
+export type EvidenceItem = {
+  evidenceItemId: string;
+  itemType:
+    | "decision"
+    | "workflow"
+    | "operator_review"
+    | "canonical_event"
+    | "export_section"
+    | "readiness_check"
+    | "lease_summary"
+    | "property_summary"
+    | "ledger_summary"
+    | "maintenance_summary"
+    | "redaction_note";
+  label: string;
+  description: string;
+  status: EvidenceItemStatus;
+  source:
+    | "decision_inbox"
+    | "workflow_routing"
+    | "operator_review"
+    | "canonical_events"
+    | "institution_exports"
+    | "audit_compliance"
+    | "lease_ledger"
+    | "maintenance"
+    | "registry"
+    | "unknown";
+  sourceId: string | null;
+  destination: string | null;
+  timestamp: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type EvidencePackSection = {
+  sectionKey:
+    | "decision_lineage"
+    | "workflow_routing"
+    | "operator_review_sessions"
+    | "audit_events"
+    | "export_readiness"
+    | "audit_compliance_readiness"
+    | "lease_context"
+    | "property_context"
+    | "delinquency_context"
+    | "maintenance_context"
+    | "redaction_summary";
+  label: string;
+  status: EvidenceSectionStatus;
+  itemsCount: number;
+  items: EvidenceItem[];
+  missingEvidence: string[];
+  blockedReasons: string[];
+};
+
+export type EvidencePack = {
+  evidencePackId: string;
+  scope: EvidencePackScope;
+  scopeId: string;
+  status: EvidencePackStatus;
+  manualReviewRequired: true;
+  externalSharingEnabled: false;
+  certificationIssued: false;
+  generatedAt: string;
+  summary: {
+    totalItems: number;
+    includedItems: number;
+    redactedItems: number;
+    blockedItems: number;
+    missingItems: number;
+  };
+  sections: EvidencePackSection[];
+  redactions: Array<{ fieldCategory: string; reason: string }>;
+  blockedReasons: string[];
+  disclaimers: string[];
+};
+
+export type EvidencePackQuery = {
+  scope: EvidencePackScope;
+  scopeId: string;
+  packageType?:
+    | "lender_due_diligence"
+    | "insurance_review"
+    | "government_program_review"
+    | "auditor_review"
+    | "internal_admin_review";
+};
+
+export function evidencePackPath(params: EvidencePackQuery) {
+  const search = new URLSearchParams({ scope: params.scope, scopeId: params.scopeId });
+  if (params.packageType) search.set("packageType", params.packageType);
+  return `/evidence-packs?${search.toString()}`;
+}
+
+export async function fetchEvidencePackPreview(params: EvidencePackQuery): Promise<EvidencePack> {
+  const search = new URLSearchParams({ scope: params.scope, scopeId: params.scopeId });
+  if (params.packageType) search.set("packageType", params.packageType);
+  const response = await apiFetch<{ ok: true; evidencePack: EvidencePack }>(
+    `/landlord/evidence-packs/preview?${search.toString()}`
+  );
+  return response.evidencePack;
+}

--- a/rentchain-frontend/src/components/evidence/EvidencePackPanel.test.tsx
+++ b/rentchain-frontend/src/components/evidence/EvidencePackPanel.test.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { EvidencePackPanel } from "./EvidencePackPanel";
+
+function evidencePack(overrides: Record<string, any> = {}) {
+  return {
+    evidencePackId: "evidence_pack:decision:landlord-1:decision-1",
+    scope: "decision",
+    scopeId: "decision-1",
+    status: "incomplete",
+    manualReviewRequired: true,
+    externalSharingEnabled: false,
+    certificationIssued: false,
+    generatedAt: "2026-05-05T12:00:00.000Z",
+    summary: { totalItems: 2, includedItems: 1, redactedItems: 1, blockedItems: 0, missingItems: 1 },
+    sections: [
+      {
+        sectionKey: "decision_lineage",
+        label: "Decision lineage",
+        status: "included",
+        itemsCount: 1,
+        items: [{
+          evidenceItemId: "item-1",
+          itemType: "decision",
+          label: "Review missing payment",
+          description: "Expected rent payment is missing.",
+          status: "included",
+          source: "decision_inbox",
+          sourceId: "decision-1",
+          destination: "/leases/lease-1/ledger",
+          timestamp: "2026-05-05T12:00:00.000Z",
+          redacted: false,
+          redactionReason: null,
+          blockedReason: null,
+        }],
+        missingEvidence: [],
+        blockedReasons: [],
+      },
+      {
+        sectionKey: "audit_events",
+        label: "Audit events",
+        status: "incomplete",
+        itemsCount: 0,
+        items: [],
+        missingEvidence: ["No landlord-scoped canonical events were available for this scope."],
+        blockedReasons: [],
+      },
+    ],
+    redactions: [{ fieldCategory: "payment_account_details", reason: "Payment account details are excluded." }],
+    blockedReasons: [],
+    disclaimers: [
+      "Preview only. Evidence is not shared externally.",
+      "Manual review is required before relying on or sharing this evidence.",
+      "Sensitive data may be excluded or redacted.",
+    ],
+    ...overrides,
+  };
+}
+
+describe("EvidencePackPanel", () => {
+  afterEach(() => cleanup());
+
+  it("renders status, sections, redactions, missing evidence, and safe links", () => {
+    render(
+      <MemoryRouter>
+        <EvidencePackPanel evidencePack={evidencePack() as any} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Evidence details")).toBeInTheDocument();
+    expect(screen.getAllByText(/Preview only\. Evidence is not shared externally\./i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Manual review is required before relying on or sharing this evidence\./i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Sensitive data may be excluded or redacted\./i).length).toBeGreaterThan(0);
+    expect(screen.getByText("Total items")).toBeInTheDocument();
+    expect(screen.getByText("Decision lineage")).toBeInTheDocument();
+    expect(screen.getByText("Review missing payment")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "View context" })).toHaveAttribute("href", "/leases/lease-1/ledger");
+    expect(screen.getByText(/Missing evidence: No landlord-scoped canonical events/i)).toBeInTheDocument();
+    expect(screen.getByText("Payment Account Details")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /submit|send|share externally|certify|file|upload|auto-report|legal approval/i })).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/evidence/EvidencePackPanel.tsx
+++ b/rentchain-frontend/src/components/evidence/EvidencePackPanel.tsx
@@ -1,0 +1,143 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { type EvidencePack } from "@/api/evidencePackApi";
+import { Card, Section } from "@/components/ui/Ui";
+
+function label(value: string) {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function statusTone(status: string) {
+  if (status === "blocked") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
+  if (status === "incomplete" || status === "unavailable") return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
+  if (status === "included" || status === "ready_for_review") return { color: "#166534", background: "#dcfce7", border: "#bbf7d0" };
+  if (status === "redacted") return { color: "#1d4ed8", background: "#dbeafe", border: "#bfdbfe" };
+  return { color: "#475569", background: "#f8fafc", border: "#e2e8f0" };
+}
+
+function Badge({ children, status }: { children: React.ReactNode; status: string }) {
+  const tone = statusTone(status);
+  return (
+    <span
+      style={{
+        border: `1px solid ${tone.border}`,
+        borderRadius: 999,
+        background: tone.background,
+        color: tone.color,
+        padding: "3px 9px",
+        fontSize: 12,
+        fontWeight: 900,
+        whiteSpace: "nowrap",
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+export function EvidencePackPanel({ evidencePack }: { evidencePack: EvidencePack }) {
+  return (
+    <div style={{ display: "grid", gap: 12 }}>
+      <Section>
+        <div style={{ display: "grid", gap: 6 }}>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+            <div>
+              <h2 style={{ margin: 0, fontSize: "1.1rem" }}>Evidence details</h2>
+              <div style={{ color: "#64748b", fontSize: 13 }}>
+                {label(evidencePack.scope)} · {evidencePack.scopeId}
+              </div>
+            </div>
+            <Badge status={evidencePack.status}>{label(evidencePack.status)}</Badge>
+          </div>
+          <div style={{ color: "#475569", lineHeight: 1.55 }}>
+            Preview only. Evidence is not shared externally. Manual review is required before relying on or sharing this
+            evidence. Sensitive data may be excluded or redacted.
+          </div>
+          <div style={{ color: "#475569", fontSize: 13 }}>
+            Manual review required: {evidencePack.manualReviewRequired ? "Yes" : "No"}. External sharing enabled:{" "}
+            {evidencePack.externalSharingEnabled ? "Yes" : "No"}. Certification issued:{" "}
+            {evidencePack.certificationIssued ? "Yes" : "No"}.
+          </div>
+        </div>
+      </Section>
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Summary</div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(130px, 1fr))", gap: 10 }}>
+          {[
+            ["Total items", evidencePack.summary.totalItems],
+            ["Included", evidencePack.summary.includedItems],
+            ["Redacted", evidencePack.summary.redactedItems],
+            ["Blocked", evidencePack.summary.blockedItems],
+            ["Missing", evidencePack.summary.missingItems],
+          ].map(([name, value]) => (
+            <Card key={String(name)} style={{ borderRadius: 8, padding: 12 }}>
+              <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>{name}</div>
+              <strong style={{ color: "#0f172a", fontSize: 22 }}>{String(value)}</strong>
+            </Card>
+          ))}
+        </div>
+      </Section>
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Evidence sections</div>
+        {evidencePack.sections.map((section) => (
+          <Card key={section.sectionKey} style={{ borderRadius: 8, display: "grid", gap: 8 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+              <div>
+                <strong>{section.label}</strong>
+                <div style={{ color: "#64748b", fontSize: 13 }}>{section.itemsCount} evidence items</div>
+              </div>
+              <Badge status={section.status}>{label(section.status)}</Badge>
+            </div>
+            {section.items.slice(0, 5).map((item) => (
+              <div key={item.evidenceItemId} style={{ borderTop: "1px solid #e2e8f0", paddingTop: 8, display: "grid", gap: 4 }}>
+                <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+                  <strong style={{ color: "#0f172a", fontSize: 13 }}>{item.label}</strong>
+                  <Badge status={item.status}>{label(item.status)}</Badge>
+                </div>
+                <div style={{ color: "#475569", fontSize: 13 }}>{item.description}</div>
+                {item.redactionReason ? <div style={{ color: "#1d4ed8", fontSize: 12 }}>{item.redactionReason}</div> : null}
+                {item.blockedReason ? <div style={{ color: "#991b1b", fontSize: 12 }}>{item.blockedReason}</div> : null}
+                {item.destination ? (
+                  <Link to={item.destination} style={{ color: "#2563eb", fontWeight: 800, fontSize: 13 }}>
+                    View context
+                  </Link>
+                ) : null}
+              </div>
+            ))}
+            {section.missingEvidence.length ? (
+              <div style={{ color: "#92400e", fontSize: 13 }}>Missing evidence: {section.missingEvidence.join(" ")}</div>
+            ) : null}
+            {section.blockedReasons.length ? (
+              <div style={{ color: "#991b1b", fontSize: 13 }}>Blocked: {section.blockedReasons.join(" ")}</div>
+            ) : null}
+          </Card>
+        ))}
+      </Section>
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Redactions</div>
+        {evidencePack.redactions.length ? (
+          evidencePack.redactions.map((redaction) => (
+            <Card key={redaction.fieldCategory} style={{ borderRadius: 8, padding: 12 }}>
+              <strong>{label(redaction.fieldCategory)}</strong>
+              <div style={{ color: "#475569", fontSize: 13, marginTop: 4 }}>{redaction.reason}</div>
+            </Card>
+          ))
+        ) : (
+          <Card style={{ color: "#92400e" }}>Review missing evidence: redaction metadata is unavailable.</Card>
+        )}
+      </Section>
+
+      <Section style={{ display: "grid", gap: 8 }}>
+        <div style={{ fontWeight: 900 }}>Disclaimers</div>
+        {evidencePack.disclaimers.map((disclaimer) => (
+          <div key={disclaimer} style={{ color: "#475569", lineHeight: 1.55 }}>
+            {disclaimer}
+          </div>
+        ))}
+      </Section>
+    </div>
+  );
+}

--- a/rentchain-frontend/src/components/operatorReviews/OperatorReviewSessionPanel.test.tsx
+++ b/rentchain-frontend/src/components/operatorReviews/OperatorReviewSessionPanel.test.tsx
@@ -81,6 +81,10 @@ describe("OperatorReviewSessionPanel", () => {
     );
 
     expect(await screen.findByText("Operator review session")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "View evidence pack" })).toHaveAttribute(
+      "href",
+      "/evidence-packs?scope=decision&scopeId=decision-1"
+    );
     expect(screen.getByText(/Manual operator review/i)).toBeInTheDocument();
     expect(screen.getByText(/Review sessions are audit logged/i)).toBeInTheDocument();
     expect(screen.getByText(/No automated approval or certification occurs/i)).toBeInTheDocument();

--- a/rentchain-frontend/src/components/operatorReviews/OperatorReviewSessionPanel.tsx
+++ b/rentchain-frontend/src/components/operatorReviews/OperatorReviewSessionPanel.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Link } from "react-router-dom";
+import { evidencePackPath } from "@/api/evidencePackApi";
 import {
   addOperatorReviewNote,
   closeOperatorReviewSession,
@@ -150,6 +151,9 @@ export function OperatorReviewSessionPanel({
         </div>
         {latestSession ? <Badge status={latestSession.status}>{label(latestSession.status)}</Badge> : null}
       </div>
+      <Link to={evidencePackPath({ scope, scopeId })} style={{ color: "#2563eb", fontWeight: 800, fontSize: 13 }}>
+        View evidence pack
+      </Link>
 
       {loading ? <div style={{ color: "#64748b", fontSize: 13 }}>Loading review history...</div> : null}
 

--- a/rentchain-frontend/src/pages/AuditCompliancePage.test.tsx
+++ b/rentchain-frontend/src/pages/AuditCompliancePage.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import AuditCompliancePage from "./AuditCompliancePage";
 
@@ -118,7 +119,11 @@ describe("AuditCompliancePage", () => {
   });
 
   it("renders readiness summary, checks, redactions, and required safety copy", async () => {
-    render(<AuditCompliancePage />);
+    render(
+      <MemoryRouter>
+        <AuditCompliancePage />
+      </MemoryRouter>
+    );
 
     expect(await screen.findByRole("heading", { name: "Audit and compliance readiness" })).toBeInTheDocument();
     expect(screen.getAllByText(/Readiness only\. This is not legal certification\./i).length).toBeGreaterThan(0);
@@ -141,7 +146,11 @@ describe("AuditCompliancePage", () => {
   it("renders an empty redaction state safely", async () => {
     apiMocks.fetchAuditComplianceReadiness.mockResolvedValue(readiness({ redactions: [] }));
 
-    render(<AuditCompliancePage />);
+    render(
+      <MemoryRouter>
+        <AuditCompliancePage />
+      </MemoryRouter>
+    );
 
     expect(await screen.findByText("No redaction metadata is available yet.")).toBeInTheDocument();
   });

--- a/rentchain-frontend/src/pages/AuditCompliancePage.tsx
+++ b/rentchain-frontend/src/pages/AuditCompliancePage.tsx
@@ -1,9 +1,11 @@
 import React from "react";
+import { Link } from "react-router-dom";
 import {
   fetchAuditComplianceReadiness,
   type AuditComplianceCheck,
   type AuditComplianceReadiness,
 } from "@/api/auditComplianceApi";
+import { evidencePackPath } from "@/api/evidencePackApi";
 import { MacShell } from "@/components/layout/MacShell";
 import { OperatorReviewSessionPanel } from "@/components/operatorReviews/OperatorReviewSessionPanel";
 import { Card, Section } from "@/components/ui/Ui";
@@ -185,6 +187,15 @@ export default function AuditCompliancePage() {
                   {disclaimer}
                 </div>
               ))}
+            </Section>
+
+            <Section>
+              <Link
+                to={evidencePackPath({ scope: "audit_compliance", scopeId: data.readinessId })}
+                style={{ color: "#2563eb", fontWeight: 800 }}
+              >
+                Preview evidence
+              </Link>
             </Section>
 
             <Section>

--- a/rentchain-frontend/src/pages/DecisionInboxPage.tsx
+++ b/rentchain-frontend/src/pages/DecisionInboxPage.tsx
@@ -12,6 +12,7 @@ import {
   type DecisionWorkflowState,
 } from "@/api/decisionInboxApi";
 import type { OperatorReviewEvidenceReference, OperatorReviewScope } from "@/api/operatorReviewApi";
+import { evidencePackPath } from "@/api/evidencePackApi";
 import { MacShell } from "@/components/layout/MacShell";
 import { OperatorReviewSessionPanel } from "@/components/operatorReviews/OperatorReviewSessionPanel";
 import { Card, Section } from "@/components/ui/Ui";
@@ -182,6 +183,12 @@ function DecisionInboxCard({ item }: { item: DecisionInboxItem }) {
         ) : (
           <span style={{ color: "#64748b", fontSize: 13 }}>No context link available</span>
         )}
+        <Link
+          to={evidencePackPath({ scope: reviewScope, scopeId: item.id })}
+          style={{ color: "#2563eb", fontWeight: 800 }}
+        >
+          Preview evidence
+        </Link>
       </div>
       {delinquencyActions.length ? (
         <div

--- a/rentchain-frontend/src/pages/EvidencePackPage.test.tsx
+++ b/rentchain-frontend/src/pages/EvidencePackPage.test.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import EvidencePackPage from "./EvidencePackPage";
+
+const apiMocks = vi.hoisted(() => ({
+  fetchEvidencePackPreview: vi.fn(),
+  showToast: vi.fn(),
+  macShellProps: vi.fn(),
+}));
+
+vi.mock("@/api/evidencePackApi", async () => {
+  const actual = await vi.importActual<any>("@/api/evidencePackApi");
+  return {
+    ...actual,
+    fetchEvidencePackPreview: apiMocks.fetchEvidencePackPreview,
+  };
+});
+
+vi.mock("@/components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast: apiMocks.showToast }),
+}));
+
+vi.mock("@/components/layout/MacShell", () => ({
+  MacShell: ({ children, ...props }: { children: React.ReactNode; showTopNav?: boolean }) => {
+    apiMocks.macShellProps(props);
+    return <div>{children}</div>;
+  },
+}));
+
+function evidencePack() {
+  return {
+    evidencePackId: "evidence_pack:decision:landlord-1:decision-1",
+    scope: "decision",
+    scopeId: "decision-1",
+    status: "ready_for_review",
+    manualReviewRequired: true,
+    externalSharingEnabled: false,
+    certificationIssued: false,
+    generatedAt: "2026-05-05T12:00:00.000Z",
+    summary: { totalItems: 1, includedItems: 1, redactedItems: 0, blockedItems: 0, missingItems: 0 },
+    sections: [],
+    redactions: [{ fieldCategory: "tenant_contact_details", reason: "Tenant contact details are excluded." }],
+    blockedReasons: [],
+    disclaimers: [
+      "Preview only. Evidence is not shared externally.",
+      "Manual review is required before relying on or sharing this evidence.",
+      "Sensitive data may be excluded or redacted.",
+    ],
+  };
+}
+
+describe("EvidencePackPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiMocks.fetchEvidencePackPreview.mockResolvedValue(evidencePack());
+  });
+
+  afterEach(() => cleanup());
+
+  it("renders evidence pack preview from query params", async () => {
+    render(
+      <MemoryRouter initialEntries={["/evidence-packs?scope=decision&scopeId=decision-1"]}>
+        <EvidencePackPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole("heading", { name: "Evidence pack preview" })).toBeInTheDocument();
+    expect(apiMocks.fetchEvidencePackPreview).toHaveBeenCalledWith({ scope: "decision", scopeId: "decision-1" });
+    expect(screen.getByText("Ready For Review")).toBeInTheDocument();
+    expect(screen.getByText("Tenant Contact Details")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /submit|send|share externally|certify|file|upload|auto-report|legal approval/i })).not.toBeInTheDocument();
+    expect(apiMocks.macShellProps).toHaveBeenCalledWith(expect.objectContaining({ showTopNav: false }));
+  });
+
+  it("loads a preview after manual scope input", async () => {
+    render(
+      <MemoryRouter initialEntries={["/evidence-packs"]}>
+        <EvidencePackPage />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByLabelText("Scope ID"), { target: { value: "lease-1" } });
+    fireEvent.change(screen.getByLabelText("Scope"), { target: { value: "lease" } });
+    fireEvent.click(screen.getByRole("button", { name: "Preview evidence" }));
+
+    await waitFor(() => {
+      expect(apiMocks.fetchEvidencePackPreview).toHaveBeenCalledWith({ scope: "lease", scopeId: "lease-1" });
+    });
+  });
+});

--- a/rentchain-frontend/src/pages/EvidencePackPage.tsx
+++ b/rentchain-frontend/src/pages/EvidencePackPage.tsx
@@ -1,0 +1,127 @@
+import React from "react";
+import { useSearchParams } from "react-router-dom";
+import {
+  fetchEvidencePackPreview,
+  type EvidencePack,
+  type EvidencePackScope,
+} from "@/api/evidencePackApi";
+import { EvidencePackPanel } from "@/components/evidence/EvidencePackPanel";
+import { MacShell } from "@/components/layout/MacShell";
+import { Card, Section } from "@/components/ui/Ui";
+import { useToast } from "@/components/ui/ToastProvider";
+
+const scopeOptions: EvidencePackScope[] = [
+  "decision",
+  "workflow",
+  "delinquency",
+  "institution_export",
+  "audit_compliance",
+  "lease",
+  "property",
+  "tenant",
+  "maintenance",
+  "admin_review",
+];
+
+function isScope(value: string | null): value is EvidencePackScope {
+  return Boolean(value && scopeOptions.includes(value as EvidencePackScope));
+}
+
+function label(value: string) {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function errorMessage(error: unknown) {
+  if (error instanceof Error && error.message) return error.message;
+  return "Failed to load evidence pack preview";
+}
+
+export default function EvidencePackPage() {
+  const [params, setParams] = useSearchParams();
+  const { showToast } = useToast();
+  const initialScope = params.get("scope");
+  const [scope, setScope] = React.useState<EvidencePackScope>(isScope(initialScope) ? initialScope : "decision");
+  const [scopeId, setScopeId] = React.useState(params.get("scopeId") || "");
+  const [data, setData] = React.useState<EvidencePack | null>(null);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const loadPreview = React.useCallback(async () => {
+    if (!scopeId.trim()) {
+      setError("Scope ID is required for evidence preview.");
+      setData(null);
+      return;
+    }
+    try {
+      setLoading(true);
+      setError(null);
+      const evidencePack = await fetchEvidencePackPreview({ scope, scopeId: scopeId.trim() });
+      setData(evidencePack);
+      setParams({ scope, scopeId: scopeId.trim() });
+    } catch (err) {
+      const message = errorMessage(err);
+      setError(message);
+      showToast({ message: "Failed to load evidence pack preview", description: message, variant: "error" });
+    } finally {
+      setLoading(false);
+    }
+  }, [scope, scopeId, setParams, showToast]);
+
+  React.useEffect(() => {
+    if (params.get("scopeId")) void loadPreview();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <MacShell title="Evidence pack preview" showTopNav={false}>
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "grid", gap: 6 }}>
+            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Evidence pack preview</h1>
+            <div style={{ color: "#475569", maxWidth: 900 }}>
+              Preview only. Evidence is not shared externally. Manual review is required before relying on or sharing this
+              evidence. Sensitive data may be excluded or redacted.
+            </div>
+          </div>
+        </Section>
+
+        <Section style={{ display: "flex", gap: 12, alignItems: "end", flexWrap: "wrap" }}>
+          <label style={{ display: "grid", gap: 5, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Scope
+            <select
+              value={scope}
+              onChange={(event) => setScope(event.target.value as EvidencePackScope)}
+              style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 200 }}
+            >
+              {scopeOptions.map((option) => (
+                <option key={option} value={option}>
+                  {label(option)}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label style={{ display: "grid", gap: 5, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Scope ID
+            <input
+              value={scopeId}
+              onChange={(event) => setScopeId(event.target.value)}
+              style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 260 }}
+            />
+          </label>
+          <button
+            type="button"
+            onClick={loadPreview}
+            disabled={loading || !scopeId.trim()}
+            style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "9px 12px", fontWeight: 900, background: "#fff" }}
+          >
+            Preview evidence
+          </button>
+        </Section>
+
+        {loading ? <Card>Loading evidence pack preview...</Card> : null}
+        {!loading && error ? <Card style={{ color: "#b91c1c" }}>{error}</Card> : null}
+        {!loading && !error && data ? <EvidencePackPanel evidencePack={data} /> : null}
+      </div>
+    </MacShell>
+  );
+}

--- a/rentchain-frontend/src/pages/InstitutionExportsPage.tsx
+++ b/rentchain-frontend/src/pages/InstitutionExportsPage.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Link } from "react-router-dom";
+import { evidencePackPath } from "@/api/evidencePackApi";
 import {
   fetchInstitutionExportPreview,
   type InstitutionExportPackage,
@@ -221,6 +222,14 @@ export default function InstitutionExportsPage() {
             </Section>
 
             <PreviewSummary data={data} />
+            <Section>
+              <Link
+                to={evidencePackPath({ scope: "institution_export", scopeId: data.packageId })}
+                style={{ color: "#2563eb", fontWeight: 800 }}
+              >
+                Preview evidence
+              </Link>
+            </Section>
 
             <Section>
               <OperatorReviewSessionPanel


### PR DESCRIPTION
## Summary
- Adds deterministic, landlord-scoped Evidence Pack preview scaffolding.
- Adds backend endpoint: `GET /api/landlord/evidence-packs/preview?scope=...&scopeId=...`.
- Adds frontend Evidence Pack preview page and reusable `EvidencePackPanel`.
- Adds evidence sections for decision lineage, workflow routing, operator review sessions, audit events, export readiness, audit/compliance readiness, lease context, property context, maintenance context, delinquency context, and redaction summary.
- Adds safe preview entry links from Decision Inbox, Operator Review Sessions, Institution Exports, and Audit Compliance.
- Adds explicit redaction metadata, missing evidence visibility, and blocked reasons.
- Confirms `manualReviewRequired: true`, `externalSharingEnabled: false`, and `certificationIssued: false`.
- Confirms no external sharing, submission, certification, notification, background job, live integration, or source-record mutation was added.
- Confirms no sensitive tenant/payment/screening payload exposure or admin-only landlord-route leakage was introduced.

## Verification
- Backend evidence pack tests passed: 6 tests.
- Frontend focused evidence/entry tests passed: 41 tests.
- Backend build passed.
- Frontend build passed with existing chunk-size warning.
- Full frontend suite passed: 189 files / 768 tests.
- `git diff --check` passed.
- Dependency/lockfile diff empty.
- Forbidden evidence-sharing UI label scan clean.

## Pre-merge checklist
- CI/backend passes.
- CI/frontend passes.
- merge-gate passes.
- codex-pr-review passes.
- Vercel passes.
- Terraform passes.
- PR diff remains scoped to evidence pack files.
- Dependency and lockfile diff remain empty.
- Forbidden labels remain absent: Submit, Send, Share externally, Certify, File, Upload to lender, Upload to institution, Auto-report, Legal approval.
- Evidence packs remain preview-only/read-only.
- Safe internal deep links only.
- Redaction metadata remains deterministic.
- Missing evidence and blocked reasons remain explicit.
- No persistence or external-share side effects were introduced.