### PR TITLE
feat: add deterministic automated workflow orchestration previews

### DIFF
--- a/docs/architecture/automated-workflows-v1.md
+++ b/docs/architecture/automated-workflows-v1.md
@@ -1,0 +1,112 @@
+# Automated Workflows v1
+
+Automated Workflows v1 adds deterministic internal workflow orchestration metadata on top of the existing Decision Inbox, workflow routing, operator review, evidence, audit readiness, and canonical timeline layers.
+
+This layer is not autonomous platform execution. It is an internal review-state preview that explains how existing decision workflow metadata can be normalized for human review.
+
+## Scope
+
+Automated Workflows v1 supports:
+
+- workflow-state normalization
+- review-required visibility
+- blocked-state visibility
+- escalation flag visibility
+- policy/manual-review flags
+- deterministic canonical workflow event descriptors
+
+Automated Workflows v1 does not:
+
+- send emails, messages, reports, or notifications
+- communicate with tenants, landlords, institutions, regulators, insurers, or lenders
+- trigger payment collection or alter payment balances
+- initiate legal notices, eviction workflows, or enforcement
+- submit institution exports
+- certify audit/compliance readiness
+- call external APIs or live integrations
+- add background jobs, queues, cron, Pub/Sub, workers, or scheduled reporting
+- mutate lease, tenant, property, payment, screening, export, evidence, or decision source-of-truth records
+
+## Model
+
+Each preview contains:
+
+- `automationId`
+- `decisionId`
+- `workflowType`
+- `status`
+- `queue`
+- `escalationLevel`
+- `manualReviewRequired: true`
+- `policyGuarded: true`
+- `externalExecutionEnabled: false`
+- `requiresHumanAcknowledgement: true`
+- `transition`
+- `reasons`
+- `blockedReasons`
+- `canonicalEvents`
+- `generatedAt`
+
+## Deterministic Transitions
+
+Current workflow state derives the preview transition:
+
+- `new` or `triaged` -> `under_review`
+- `under_review` -> `under_review`
+- `waiting_context` -> `waiting_context` with blocked reason
+- `escalated` -> `escalated`
+- `resolved` or `archived` -> unchanged and completed
+
+The derivation is rule-based. It does not use AI classification, probabilistic scoring, autonomous prioritization, or hidden state changes.
+
+## Policy Guards
+
+Every preview remains:
+
+- manual-review required
+- policy guarded
+- human-acknowledgement required
+- external execution disabled
+
+Admin-owned workflow metadata is blocked from landlord automation previews. Executable automation is not enabled through this layer.
+
+## Canonical Event Descriptors
+
+V1 emits deterministic event descriptors for review and timeline context:
+
+- `automated_workflow_transition_derived`
+- `automated_workflow_blocked`
+- `automated_workflow_escalation_flagged`
+- `automated_workflow_review_required`
+- `automated_workflow_sync_completed`
+
+These descriptors are preview metadata in V1. They are not background jobs and do not trigger external behavior.
+
+## API
+
+The landlord-scoped preview endpoint is:
+
+```text
+GET /api/landlord/automated-workflows/preview
+```
+
+Supported filters:
+
+- `workflowType`
+- `status`
+- `queue`
+- `escalationLevel`
+
+Decision Inbox responses also include `automatedWorkflow` per item and `automationSummary` counts.
+
+## Deferred
+
+- workflow metadata sync persistence
+- operator assignment persistence
+- supervised workflow execution
+- policy-gated agent actions
+- notification delivery
+- tenant or landlord communications
+- payment actions
+- export submission
+- compliance certification

--- a/rentchain-api/src/lib/automatedWorkflows/__tests__/deriveAutomatedWorkflowTransitions.test.ts
+++ b/rentchain-api/src/lib/automatedWorkflows/__tests__/deriveAutomatedWorkflowTransitions.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import { deriveAutomatedWorkflowTransitions } from "../deriveAutomatedWorkflowTransitions";
+import type { DecisionInboxItem } from "../../decisions/decisionInboxTypes";
+
+function decision(overrides: Partial<DecisionInboxItem> = {}): DecisionInboxItem {
+  return {
+    id: "decision-1",
+    title: "Review Missing Payment",
+    description: "Expected rent payment is missing.",
+    severity: "critical",
+    status: "open",
+    type: "billing",
+    source: "lease_ledger",
+    relatedEntity: { kind: "lease", id: "lease-1", label: "Lease lease-1" },
+    destination: "/leases/lease-1/ledger",
+    automationEligible: false,
+    workflow: {
+      queue: "delinquency_review",
+      workflowState: "new",
+      ownershipType: "landlord",
+      reviewPriority: "critical",
+      escalationLevel: "critical",
+      manualOnly: true,
+    },
+    createdAt: "2026-05-05T12:00:00.000Z",
+    updatedAt: "2026-05-05T12:00:00.000Z",
+    ...overrides,
+    workflow: {
+      queue: "delinquency_review",
+      workflowState: "new",
+      ownershipType: "landlord",
+      reviewPriority: "critical",
+      escalationLevel: "critical",
+      manualOnly: true,
+      ...overrides.workflow,
+    },
+  };
+}
+
+describe("deriveAutomatedWorkflowTransitions", () => {
+  it("derives deterministic internal transitions without enabling external execution", () => {
+    const result = deriveAutomatedWorkflowTransitions({
+      generatedAt: "2026-05-06T00:00:00.000Z",
+      decisions: [decision()],
+    });
+
+    expect(result.workflows).toHaveLength(1);
+    expect(result.workflows[0]).toEqual(expect.objectContaining({
+      automationId: "automated_workflow:decision-1:delinquency_review",
+      decisionId: "decision-1",
+      workflowType: "delinquency",
+      status: "derived",
+      manualReviewRequired: true,
+      policyGuarded: true,
+      externalExecutionEnabled: false,
+      requiresHumanAcknowledgement: true,
+      transition: { fromState: "new", toState: "under_review" },
+      generatedAt: "2026-05-06T00:00:00.000Z",
+    }));
+    expect(result.workflows[0].canonicalEvents).toEqual(expect.arrayContaining([
+      expect.objectContaining({ eventType: "automated_workflow_transition_derived" }),
+      expect.objectContaining({ eventType: "automated_workflow_escalation_flagged" }),
+      expect.objectContaining({ eventType: "automated_workflow_review_required" }),
+    ]));
+    expect(result.summary).toEqual(expect.objectContaining({ total: 1, derived: 1, escalationFlagged: 1, reviewRequired: 1 }));
+  });
+
+  it("blocks waiting-context workflow previews with explicit reasons", () => {
+    const result = deriveAutomatedWorkflowTransitions({
+      decisions: [
+        decision({
+          workflow: {
+            queue: "maintenance_review",
+            workflowState: "waiting_context",
+            ownershipType: "landlord",
+            reviewPriority: "high",
+            escalationLevel: "urgent",
+            manualOnly: true,
+          },
+          type: "maintenance",
+          severity: "high",
+        }),
+      ],
+    });
+
+    expect(result.workflows[0]).toEqual(expect.objectContaining({
+      workflowType: "maintenance",
+      status: "blocked",
+      transition: { fromState: "waiting_context", toState: "waiting_context" },
+      blockedReasons: ["Required workflow context is missing or incomplete."],
+    }));
+    expect(result.workflows[0].canonicalEvents).toEqual(expect.arrayContaining([
+      expect.objectContaining({ eventType: "automated_workflow_blocked" }),
+    ]));
+  });
+
+  it("marks resolved workflow previews completed", () => {
+    const result = deriveAutomatedWorkflowTransitions({
+      decisions: [
+        decision({
+          status: "resolved",
+          workflow: {
+            queue: "lease_review",
+            workflowState: "resolved",
+            ownershipType: "landlord",
+            reviewPriority: "low",
+            escalationLevel: "none",
+            manualOnly: true,
+          },
+          type: "lease",
+          severity: "low",
+        }),
+      ],
+    });
+
+    expect(result.workflows[0]).toEqual(expect.objectContaining({
+      workflowType: "review",
+      status: "completed",
+      transition: { fromState: "resolved", toState: "resolved" },
+    }));
+  });
+
+  it("filters by workflow type, status, queue, and escalation level", () => {
+    const result = deriveAutomatedWorkflowTransitions({
+      decisions: [
+        decision(),
+        decision({
+          id: "decision-2",
+          type: "maintenance",
+          severity: "high",
+          workflow: {
+            queue: "maintenance_review",
+            workflowState: "waiting_context",
+            ownershipType: "landlord",
+            reviewPriority: "high",
+            escalationLevel: "urgent",
+            manualOnly: true,
+          },
+        }),
+      ],
+      filters: {
+        workflowType: "maintenance",
+        status: "blocked",
+        queue: "maintenance_review",
+        escalationLevel: "urgent",
+      },
+    });
+
+    expect(result.workflows).toHaveLength(1);
+    expect(result.workflows[0].decisionId).toBe("decision-2");
+    expect(result.summary).toEqual(expect.objectContaining({ total: 1, blocked: 1 }));
+  });
+
+  it("does not mutate source decisions", () => {
+    const source = decision();
+    const before = structuredClone(source);
+
+    deriveAutomatedWorkflowTransitions({ decisions: [source] });
+
+    expect(source).toEqual(before);
+  });
+});

--- a/rentchain-api/src/lib/automatedWorkflows/automatedWorkflowPolicyGuards.ts
+++ b/rentchain-api/src/lib/automatedWorkflows/automatedWorkflowPolicyGuards.ts
@@ -1,0 +1,33 @@
+import type { DecisionInboxItem } from "../decisions/decisionInboxTypes";
+
+export type AutomatedWorkflowPolicyGuardResult = {
+  allowed: boolean;
+  manualReviewRequired: true;
+  policyGuarded: true;
+  externalExecutionEnabled: false;
+  requiresHumanAcknowledgement: true;
+  blockedReasons: string[];
+};
+
+export function evaluateAutomatedWorkflowPolicyGuards(decision: DecisionInboxItem): AutomatedWorkflowPolicyGuardResult {
+  const blockedReasons: string[] = [];
+
+  if (decision.workflow.manualOnly !== true) {
+    blockedReasons.push("Workflow routing must remain manual-only before orchestration metadata can be derived.");
+  }
+  if (decision.automationEligible !== false) {
+    blockedReasons.push("Executable automation is not enabled for Decision Inbox orchestration.");
+  }
+  if (decision.workflow.ownershipType === "admin") {
+    blockedReasons.push("Admin-owned workflow metadata is not exposed through landlord automation previews.");
+  }
+
+  return {
+    allowed: blockedReasons.length === 0,
+    manualReviewRequired: true,
+    policyGuarded: true,
+    externalExecutionEnabled: false,
+    requiresHumanAcknowledgement: true,
+    blockedReasons,
+  };
+}

--- a/rentchain-api/src/lib/automatedWorkflows/automatedWorkflowTypes.ts
+++ b/rentchain-api/src/lib/automatedWorkflows/automatedWorkflowTypes.ts
@@ -1,0 +1,81 @@
+import type {
+  DecisionInboxItem,
+  DecisionWorkflowEscalationLevel,
+  DecisionWorkflowQueue,
+  DecisionWorkflowState,
+} from "../decisions/decisionInboxTypes";
+
+export type AutomatedWorkflowType =
+  | "review"
+  | "evidence"
+  | "readiness"
+  | "delinquency"
+  | "export"
+  | "maintenance";
+
+export type AutomatedWorkflowStatus = "pending" | "derived" | "blocked" | "completed";
+
+export type AutomatedWorkflowEventType =
+  | "automated_workflow_transition_derived"
+  | "automated_workflow_blocked"
+  | "automated_workflow_escalation_flagged"
+  | "automated_workflow_review_required"
+  | "automated_workflow_sync_completed";
+
+export type AutomatedWorkflowTransition = {
+  fromState: DecisionWorkflowState;
+  toState: DecisionWorkflowState;
+};
+
+export type AutomatedWorkflowCanonicalEvent = {
+  eventType: AutomatedWorkflowEventType;
+  action: string;
+  status: AutomatedWorkflowStatus;
+  resourceType: "decision" | "workflow";
+  resourceId: string;
+  summary: string;
+};
+
+export type AutomatedWorkflowPreview = {
+  automationId: string;
+  decisionId: string;
+  workflowType: AutomatedWorkflowType;
+  status: AutomatedWorkflowStatus;
+  queue: DecisionWorkflowQueue;
+  escalationLevel: DecisionWorkflowEscalationLevel;
+  manualReviewRequired: true;
+  policyGuarded: true;
+  externalExecutionEnabled: false;
+  requiresHumanAcknowledgement: true;
+  transition: AutomatedWorkflowTransition;
+  reasons: string[];
+  blockedReasons: string[];
+  canonicalEvents: AutomatedWorkflowCanonicalEvent[];
+  generatedAt: string;
+};
+
+export type AutomatedWorkflowSummary = {
+  total: number;
+  pending: number;
+  derived: number;
+  blocked: number;
+  completed: number;
+  escalationFlagged: number;
+  reviewRequired: number;
+};
+
+export type AutomatedWorkflowPreviewResult = {
+  workflows: AutomatedWorkflowPreview[];
+  summary: AutomatedWorkflowSummary;
+};
+
+export type DeriveAutomatedWorkflowTransitionsInput = {
+  decisions?: DecisionInboxItem[] | null;
+  generatedAt?: string | Date | null;
+  filters?: {
+    workflowType?: unknown;
+    status?: unknown;
+    queue?: unknown;
+    escalationLevel?: unknown;
+  } | null;
+};

--- a/rentchain-api/src/lib/automatedWorkflows/deriveAutomatedWorkflowTransitions.ts
+++ b/rentchain-api/src/lib/automatedWorkflows/deriveAutomatedWorkflowTransitions.ts
@@ -1,0 +1,213 @@
+import type {
+  DecisionInboxItem,
+  DecisionWorkflowEscalationLevel,
+  DecisionWorkflowQueue,
+  DecisionWorkflowState,
+} from "../decisions/decisionInboxTypes";
+import { evaluateAutomatedWorkflowPolicyGuards } from "./automatedWorkflowPolicyGuards";
+import type {
+  AutomatedWorkflowCanonicalEvent,
+  AutomatedWorkflowPreview,
+  AutomatedWorkflowPreviewResult,
+  AutomatedWorkflowStatus,
+  AutomatedWorkflowType,
+  DeriveAutomatedWorkflowTransitionsInput,
+} from "./automatedWorkflowTypes";
+
+const WORKFLOW_TYPES: AutomatedWorkflowType[] = ["review", "evidence", "readiness", "delinquency", "export", "maintenance"];
+const STATUSES: AutomatedWorkflowStatus[] = ["pending", "derived", "blocked", "completed"];
+const QUEUES: DecisionWorkflowQueue[] = [
+  "lease_review",
+  "delinquency_review",
+  "screening_review",
+  "maintenance_review",
+  "compliance_review",
+  "admin_review",
+  "general_review",
+];
+const ESCALATIONS: DecisionWorkflowEscalationLevel[] = ["none", "attention", "urgent", "critical"];
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function cleanId(value: unknown): string {
+  return asString(value, 800)
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function generatedAt(value: unknown): string {
+  const raw = asString(value, 120);
+  const parsed = raw ? new Date(raw) : new Date();
+  return Number.isNaN(parsed.getTime()) ? new Date().toISOString() : parsed.toISOString();
+}
+
+function workflowTypeForDecision(decision: DecisionInboxItem): AutomatedWorkflowType {
+  if (decision.workflow.queue === "delinquency_review") return "delinquency";
+  if (decision.workflow.queue === "maintenance_review") return "maintenance";
+  if (decision.workflow.queue === "compliance_review") return "readiness";
+  if (decision.workflow.queue === "lease_review") return "review";
+  if (decision.type === "compliance") return "readiness";
+  return "review";
+}
+
+function transitionForState(state: DecisionWorkflowState): { toState: DecisionWorkflowState; status: AutomatedWorkflowStatus } {
+  if (state === "new" || state === "triaged") return { toState: "under_review", status: "derived" };
+  if (state === "under_review") return { toState: "under_review", status: "pending" };
+  if (state === "waiting_context") return { toState: "waiting_context", status: "blocked" };
+  if (state === "escalated") return { toState: "escalated", status: "pending" };
+  if (state === "resolved" || state === "archived") return { toState: state, status: "completed" };
+  return { toState: "under_review", status: "derived" };
+}
+
+function reasonsForDecision(decision: DecisionInboxItem, toState: DecisionWorkflowState): string[] {
+  const reasons = [
+    `Decision ${decision.id} is routed to ${decision.workflow.queue}.`,
+    `Current workflow state is ${decision.workflow.workflowState}.`,
+    `Derived internal review state is ${toState}.`,
+    "Manual review remains required before any operational action.",
+  ];
+  if (decision.workflow.escalationLevel !== "none") {
+    reasons.push(`Escalation visibility is ${decision.workflow.escalationLevel}.`);
+  }
+  if (decision.workflow.queue === "delinquency_review") {
+    reasons.push("Delinquency workflow can surface review context only; no notice or payment action is automated.");
+  }
+  return reasons;
+}
+
+function canonicalEventsForWorkflow(input: {
+  decision: DecisionInboxItem;
+  status: AutomatedWorkflowStatus;
+  toState: DecisionWorkflowState;
+  blockedReasons: string[];
+}): AutomatedWorkflowCanonicalEvent[] {
+  const events: AutomatedWorkflowCanonicalEvent[] = [];
+  if (input.blockedReasons.length || input.status === "blocked") {
+    events.push({
+      eventType: "automated_workflow_blocked",
+      action: "blocked",
+      status: "blocked",
+      resourceType: "workflow",
+      resourceId: input.decision.id,
+      summary: "Internal workflow orchestration is blocked pending manual context review.",
+    });
+  } else if (input.decision.workflow.workflowState !== input.toState) {
+    events.push({
+      eventType: "automated_workflow_transition_derived",
+      action: "transition_derived",
+      status: input.status,
+      resourceType: "workflow",
+      resourceId: input.decision.id,
+      summary: `Internal workflow transition derived from ${input.decision.workflow.workflowState} to ${input.toState}.`,
+    });
+  } else {
+    events.push({
+      eventType: "automated_workflow_sync_completed",
+      action: "sync_completed",
+      status: input.status,
+      resourceType: "workflow",
+      resourceId: input.decision.id,
+      summary: "Internal workflow state is already synchronized for manual review.",
+    });
+  }
+
+  if (input.decision.workflow.escalationLevel === "critical" || input.decision.workflow.escalationLevel === "urgent") {
+    events.push({
+      eventType: "automated_workflow_escalation_flagged",
+      action: "escalation_flagged",
+      status: input.status === "completed" ? "completed" : "pending",
+      resourceType: "workflow",
+      resourceId: input.decision.id,
+      summary: `Escalation flag derived from ${input.decision.workflow.escalationLevel} workflow metadata.`,
+    });
+  }
+
+  events.push({
+    eventType: "automated_workflow_review_required",
+    action: "review_required",
+    status: input.status === "completed" ? "completed" : "pending",
+    resourceType: "decision",
+    resourceId: input.decision.id,
+    summary: "Human acknowledgement remains required; no external execution is enabled.",
+  });
+
+  return events;
+}
+
+export function automatedWorkflowFromDecision(decision: DecisionInboxItem, generated: string): AutomatedWorkflowPreview {
+  const guard = evaluateAutomatedWorkflowPolicyGuards(decision);
+  const transition = transitionForState(decision.workflow.workflowState);
+  const status: AutomatedWorkflowStatus = guard.allowed ? transition.status : "blocked";
+  const blockedReasons = [
+    ...guard.blockedReasons,
+    ...(decision.workflow.workflowState === "waiting_context" ? ["Required workflow context is missing or incomplete."] : []),
+  ];
+  const toState = blockedReasons.length ? "waiting_context" : transition.toState;
+
+  return {
+    automationId: cleanId(`automated_workflow:${decision.id}:${decision.workflow.queue}`) || "automated_workflow:unknown",
+    decisionId: decision.id,
+    workflowType: workflowTypeForDecision(decision),
+    status: blockedReasons.length ? "blocked" : status,
+    queue: decision.workflow.queue,
+    escalationLevel: decision.workflow.escalationLevel,
+    manualReviewRequired: true,
+    policyGuarded: true,
+    externalExecutionEnabled: false,
+    requiresHumanAcknowledgement: true,
+    transition: {
+      fromState: decision.workflow.workflowState,
+      toState,
+    },
+    reasons: reasonsForDecision(decision, toState),
+    blockedReasons,
+    canonicalEvents: canonicalEventsForWorkflow({
+      decision,
+      status: blockedReasons.length ? "blocked" : status,
+      toState,
+      blockedReasons,
+    }),
+    generatedAt: generated,
+  };
+}
+
+function filterValue<T extends string>(value: unknown, known: readonly T[]): T | null {
+  const raw = asString(value, 80).toLowerCase();
+  if (!raw || raw === "all") return null;
+  return known.includes(raw as T) ? (raw as T) : null;
+}
+
+export function deriveAutomatedWorkflowTransitions(
+  input: DeriveAutomatedWorkflowTransitionsInput
+): AutomatedWorkflowPreviewResult {
+  const generated = generatedAt(input.generatedAt);
+  const allWorkflows = (input.decisions || []).map((decision) => automatedWorkflowFromDecision(decision, generated));
+  const workflowType = filterValue(input.filters?.workflowType, WORKFLOW_TYPES);
+  const status = filterValue(input.filters?.status, STATUSES);
+  const queue = filterValue(input.filters?.queue, QUEUES);
+  const escalationLevel = filterValue(input.filters?.escalationLevel, ESCALATIONS);
+  const workflows = allWorkflows.filter((workflow) => {
+    if (workflowType && workflow.workflowType !== workflowType) return false;
+    if (status && workflow.status !== status) return false;
+    if (queue && workflow.queue !== queue) return false;
+    if (escalationLevel && workflow.escalationLevel !== escalationLevel) return false;
+    return true;
+  });
+
+  return {
+    workflows,
+    summary: {
+      total: workflows.length,
+      pending: workflows.filter((workflow) => workflow.status === "pending").length,
+      derived: workflows.filter((workflow) => workflow.status === "derived").length,
+      blocked: workflows.filter((workflow) => workflow.status === "blocked").length,
+      completed: workflows.filter((workflow) => workflow.status === "completed").length,
+      escalationFlagged: workflows.filter((workflow) => workflow.escalationLevel === "critical" || workflow.escalationLevel === "urgent").length,
+      reviewRequired: workflows.filter((workflow) => workflow.manualReviewRequired).length,
+    },
+  };
+}

--- a/rentchain-api/src/lib/decisions/decisionInboxTypes.ts
+++ b/rentchain-api/src/lib/decisions/decisionInboxTypes.ts
@@ -1,3 +1,5 @@
+import type { AutomatedWorkflowPreview, AutomatedWorkflowSummary } from "../automatedWorkflows/automatedWorkflowTypes";
+
 export type DecisionInboxSeverity = "critical" | "high" | "medium" | "low" | "info" | "unknown";
 
 export type DecisionInboxStatus = "open" | "pending" | "blocked" | "resolved" | "dismissed" | "unknown";
@@ -82,6 +84,7 @@ export type DecisionInboxItem = {
   destination: string | null;
   automationEligible: false;
   workflow: DecisionWorkflowRouting;
+  automatedWorkflow?: AutomatedWorkflowPreview;
   delinquencyActions?: DelinquencyActionDescriptor[];
   createdAt: string | null;
   updatedAt: string | null;
@@ -116,4 +119,5 @@ export type DecisionInboxResult = {
   filters: DecisionInboxFilters;
   summary: DecisionInboxSummary;
   workflowSummary: DecisionInboxWorkflowSummary;
+  automationSummary: AutomatedWorkflowSummary;
 };

--- a/rentchain-api/src/lib/decisions/deriveDecisionInbox.ts
+++ b/rentchain-api/src/lib/decisions/deriveDecisionInbox.ts
@@ -13,6 +13,7 @@ import type {
 } from "./decisionInboxTypes";
 import { deriveDecisionWorkflowRouting } from "./deriveDecisionWorkflowRouting";
 import { deriveDelinquencyActions } from "../delinquency/deriveDelinquencyActions";
+import { deriveAutomatedWorkflowTransitions } from "../automatedWorkflows/deriveAutomatedWorkflowTransitions";
 
 type SourceDecision = Decision & { latestAction?: unknown };
 
@@ -199,7 +200,7 @@ export function decisionInboxItemFromLeaseDecision(decision: SourceDecision): De
     createdAt: normalizeDate(decision.createdAt),
     updatedAt: normalizeDate(decision.updatedAt),
   };
-  const item = {
+  const item: DecisionInboxItem = {
     ...base,
     workflow: deriveDecisionWorkflowRouting({ ...base, decisionType: decision.decisionType }),
   };
@@ -222,7 +223,7 @@ export function decisionInboxItemFromAnalyticsDecision(decision: LandlordAgentDe
     createdAt: null,
     updatedAt: normalizeDate(decision.reviewedAt || decision.executedAt || decision.executionOutcomeAt),
   };
-  const item = {
+  const item: DecisionInboxItem = {
     ...base,
     workflow: deriveDecisionWorkflowRouting({
       ...base,
@@ -246,10 +247,17 @@ function uniqueSorted<T extends string>(values: T[], known: readonly T[]): T[] {
 }
 
 export function deriveDecisionInbox(input: DeriveDecisionInboxInput): DecisionInboxResult {
-  const allItems = [
+  const baseItems = [
     ...(input.analyticsDecisions || []).map(decisionInboxItemFromAnalyticsDecision),
     ...(input.leaseDecisions || []).map(decisionInboxItemFromLeaseDecision),
-  ].sort((a, b) => {
+  ];
+  const automationByDecisionId = new Map(
+    deriveAutomatedWorkflowTransitions({ decisions: baseItems }).workflows.map((workflow) => [workflow.decisionId, workflow])
+  );
+  const allItems = baseItems.map((item) => ({
+    ...item,
+    automatedWorkflow: automationByDecisionId.get(item.id),
+  })).sort((a, b) => {
     const severityOrder: Record<DecisionInboxSeverity, number> = {
       critical: 0,
       high: 1,
@@ -330,5 +338,6 @@ export function deriveDecisionInbox(input: DeriveDecisionInboxInput): DecisionIn
       escalated: items.filter((item) => item.workflow.workflowState === "escalated").length,
       critical: items.filter((item) => item.workflow.escalationLevel === "critical").length,
     },
+    automationSummary: deriveAutomatedWorkflowTransitions({ decisions: items }).summary,
   };
 }

--- a/rentchain-api/src/routes/__tests__/landlordDecisionInboxRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordDecisionInboxRoutes.test.ts
@@ -181,6 +181,13 @@ describe("landlordDecisionInboxRoutes", () => {
           type: "maintenance",
           severity: "high",
           automationEligible: false,
+          automatedWorkflow: expect.objectContaining({
+            workflowType: "maintenance",
+            status: "pending",
+            manualReviewRequired: true,
+            externalExecutionEnabled: false,
+            policyGuarded: true,
+          }),
           workflow: expect.objectContaining({
             queue: "maintenance_review",
             workflowState: "escalated",
@@ -194,6 +201,16 @@ describe("landlordDecisionInboxRoutes", () => {
           severity: "critical",
           destination: "/leases/lease-1/ledger",
           automationEligible: false,
+          automatedWorkflow: expect.objectContaining({
+            workflowType: "delinquency",
+            status: "pending",
+            manualReviewRequired: true,
+            externalExecutionEnabled: false,
+            canonicalEvents: expect.arrayContaining([
+              expect.objectContaining({ eventType: "automated_workflow_escalation_flagged" }),
+              expect.objectContaining({ eventType: "automated_workflow_review_required" }),
+            ]),
+          }),
           workflow: expect.objectContaining({
             queue: "delinquency_review",
             workflowState: "escalated",
@@ -209,6 +226,12 @@ describe("landlordDecisionInboxRoutes", () => {
     );
     expect(res.body.summary).toEqual(expect.objectContaining({ total: 3, critical: 2, high: 1, open: 3 }));
     expect(res.body.workflowSummary).toEqual(expect.objectContaining({ escalated: 3, critical: 2 }));
+    expect(res.body.automationSummary).toEqual(expect.objectContaining({
+      total: 3,
+      pending: 3,
+      escalationFlagged: 3,
+      reviewRequired: 3,
+    }));
   });
 
   it("filters inbox items by severity, status, type, and workflow routing", async () => {
@@ -239,6 +262,37 @@ describe("landlordDecisionInboxRoutes", () => {
     expect(res.status).toBe(200);
     expect(res.body.items).toEqual([]);
     expect(res.body.summary.total).toBe(0);
+  });
+
+  it("returns read-only automated workflow previews without invoking execution behavior", async () => {
+    seedLease();
+    const router = (await import("../landlordDecisionInboxRoutes")).default;
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/automated-workflows/preview?workflowType=delinquency&status=pending&queue=delinquency_review",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.manualReviewRequired).toBe(true);
+    expect(res.body.externalExecutionEnabled).toBe(false);
+    expect(res.body.workflows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          workflowType: "delinquency",
+          queue: "delinquency_review",
+          status: "pending",
+          manualReviewRequired: true,
+          externalExecutionEnabled: false,
+          requiresHumanAcknowledgement: true,
+          canonicalEvents: expect.arrayContaining([
+            expect.objectContaining({ eventType: "automated_workflow_review_required" }),
+          ]),
+        }),
+      ])
+    );
+    expect(JSON.stringify(res.body)).not.toMatch(/externalExecutionEnabled":true|executed":true|charge tenant|file eviction/i);
   });
 
   it("blocks non-landlord users", async () => {

--- a/rentchain-api/src/routes/landlordDecisionInboxRoutes.ts
+++ b/rentchain-api/src/routes/landlordDecisionInboxRoutes.ts
@@ -4,6 +4,7 @@ import { requireAuth } from "../middleware/requireAuth";
 import { requireLandlord } from "../middleware/requireLandlord";
 import { loadLandlordAnalyticsSnapshot } from "../services/landlord/landlordAnalyticsSnapshot";
 import { deriveDecisionInbox } from "../lib/decisions/deriveDecisionInbox";
+import { deriveAutomatedWorkflowTransitions } from "../lib/automatedWorkflows/deriveAutomatedWorkflowTransitions";
 import { deriveDecisions, type Decision } from "../lib/decisions/decisionEngine";
 import { applyDecisionActions, DECISION_ACTIONS_COLLECTION } from "../lib/decisions/decisionActions";
 import { deriveLeaseLifecycleState } from "../lib/leases/leaseLifecycle";
@@ -184,6 +185,57 @@ router.get("/decision-inbox", requireAuth, requireLandlord, async (req: any, res
   } catch (err: any) {
     console.error("[landlord-decision-inbox] failed", err?.message || err);
     return res.status(500).json({ ok: false, error: "DECISION_INBOX_FAILED" });
+  }
+});
+
+router.get("/automated-workflows/preview", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = asString(req.user?.landlordId || req.user?.id, 240);
+    if (!landlordId) {
+      return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    }
+
+    const [snapshot, leaseDecisions] = await Promise.all([
+      loadLandlordAnalyticsSnapshot({
+        landlordId,
+        period: req.query?.period,
+        propertyId: req.query?.propertyId,
+      }),
+      deriveLeaseDecisionsForInbox(landlordId),
+    ]);
+
+    const inbox = deriveDecisionInbox({
+      analyticsDecisions: Array.isArray(snapshot?.decisions?.items) ? snapshot.decisions.items : [],
+      leaseDecisions,
+      filters: {
+        severity: req.query?.severity,
+        status: req.query?.decisionStatus,
+        type: req.query?.type,
+        queue: req.query?.queue,
+        workflowState: req.query?.workflowState,
+        escalationLevel: req.query?.escalationLevel,
+      },
+    });
+    const preview = deriveAutomatedWorkflowTransitions({
+      decisions: inbox.items,
+      filters: {
+        workflowType: req.query?.workflowType,
+        status: req.query?.status,
+        queue: req.query?.queue,
+        escalationLevel: req.query?.escalationLevel,
+      },
+    });
+
+    return res.json({
+      ok: true,
+      workflows: preview.workflows,
+      summary: preview.summary,
+      manualReviewRequired: true,
+      externalExecutionEnabled: false,
+    });
+  } catch (err: any) {
+    console.error("[landlord-automated-workflows] preview failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "AUTOMATED_WORKFLOW_PREVIEW_FAILED" });
   }
 });
 

--- a/rentchain-frontend/src/api/decisionInboxApi.ts
+++ b/rentchain-frontend/src/api/decisionInboxApi.ts
@@ -29,6 +29,14 @@ export type DecisionWorkflowState =
   | "resolved"
   | "archived";
 export type DecisionWorkflowEscalationLevel = "none" | "attention" | "urgent" | "critical";
+export type AutomatedWorkflowType = "review" | "evidence" | "readiness" | "delinquency" | "export" | "maintenance";
+export type AutomatedWorkflowStatus = "pending" | "derived" | "blocked" | "completed";
+export type AutomatedWorkflowEventType =
+  | "automated_workflow_transition_derived"
+  | "automated_workflow_blocked"
+  | "automated_workflow_escalation_flagged"
+  | "automated_workflow_review_required"
+  | "automated_workflow_sync_completed";
 export type DecisionWorkflowRouting = {
   queue: DecisionWorkflowQueue;
   workflowState: DecisionWorkflowState;
@@ -36,6 +44,42 @@ export type DecisionWorkflowRouting = {
   reviewPriority: "critical" | "high" | "medium" | "low";
   escalationLevel: DecisionWorkflowEscalationLevel;
   manualOnly: true;
+};
+export type AutomatedWorkflowPreview = {
+  automationId: string;
+  decisionId: string;
+  workflowType: AutomatedWorkflowType;
+  status: AutomatedWorkflowStatus;
+  queue: DecisionWorkflowQueue;
+  escalationLevel: DecisionWorkflowEscalationLevel;
+  manualReviewRequired: true;
+  policyGuarded: true;
+  externalExecutionEnabled: false;
+  requiresHumanAcknowledgement: true;
+  transition: {
+    fromState: DecisionWorkflowState;
+    toState: DecisionWorkflowState;
+  };
+  reasons: string[];
+  blockedReasons: string[];
+  canonicalEvents: Array<{
+    eventType: AutomatedWorkflowEventType;
+    action: string;
+    status: AutomatedWorkflowStatus;
+    resourceType: "decision" | "workflow";
+    resourceId: string;
+    summary: string;
+  }>;
+  generatedAt: string;
+};
+export type AutomatedWorkflowSummary = {
+  total: number;
+  pending: number;
+  derived: number;
+  blocked: number;
+  completed: number;
+  escalationFlagged: number;
+  reviewRequired: number;
 };
 export type DelinquencyActionDescriptor = {
   actionKey: "review_context" | "prepare_reminder" | "prepare_notice" | "view_ledger";
@@ -65,6 +109,7 @@ export type DecisionInboxItem = {
   destination: string | null;
   automationEligible: false;
   workflow: DecisionWorkflowRouting;
+  automatedWorkflow?: AutomatedWorkflowPreview;
   delinquencyActions?: DelinquencyActionDescriptor[];
   createdAt: string | null;
   updatedAt: string | null;
@@ -93,6 +138,7 @@ export type DecisionInboxResponse = {
     escalated: number;
     critical: number;
   };
+  automationSummary: AutomatedWorkflowSummary;
 };
 
 export type DecisionInboxQuery = {
@@ -126,5 +172,14 @@ export async function fetchDecisionInbox(params?: DecisionInboxQuery): Promise<D
     },
     summary: response.summary || { total: 0, critical: 0, high: 0, open: 0, blocked: 0 },
     workflowSummary: response.workflowSummary || { new: 0, underReview: 0, escalated: 0, critical: 0 },
+    automationSummary: response.automationSummary || {
+      total: 0,
+      pending: 0,
+      derived: 0,
+      blocked: 0,
+      completed: 0,
+      escalationFlagged: 0,
+      reviewRequired: 0,
+    },
   };
 }

--- a/rentchain-frontend/src/pages/DecisionInboxPage.test.tsx
+++ b/rentchain-frontend/src/pages/DecisionInboxPage.test.tsx
@@ -60,6 +60,36 @@ function inboxResponse(overrides: Record<string, unknown> = {}) {
         relatedEntity: { kind: "lease", id: "lease-1", label: "Lease lease-1" },
         destination: "/leases/lease-1/ledger",
         automationEligible: false,
+        automatedWorkflow: {
+          automationId: "automated_workflow:decision_review_missing_payment_lease-1:delinquency_review",
+          decisionId: "decision:review_missing_payment:lease-1",
+          workflowType: "delinquency",
+          status: "pending",
+          queue: "delinquency_review",
+          escalationLevel: "critical",
+          manualReviewRequired: true,
+          policyGuarded: true,
+          externalExecutionEnabled: false,
+          requiresHumanAcknowledgement: true,
+          transition: { fromState: "escalated", toState: "escalated" },
+          reasons: [
+            "Decision decision:review_missing_payment:lease-1 is routed to delinquency_review.",
+            "Current workflow state is escalated.",
+            "Manual review remains required before any operational action.",
+          ],
+          blockedReasons: [],
+          canonicalEvents: [
+            {
+              eventType: "automated_workflow_review_required",
+              action: "review_required",
+              status: "pending",
+              resourceType: "decision",
+              resourceId: "decision:review_missing_payment:lease-1",
+              summary: "Human acknowledgement remains required; no external execution is enabled.",
+            },
+          ],
+          generatedAt: "2026-05-05T12:00:00.000Z",
+        },
         workflow: {
           queue: "delinquency_review",
           workflowState: "escalated",
@@ -128,6 +158,35 @@ function inboxResponse(overrides: Record<string, unknown> = {}) {
         relatedEntity: { kind: "maintenance_request", id: "wo-1", label: "Work order wo-1" },
         destination: null,
         automationEligible: false,
+        automatedWorkflow: {
+          automationId: "automated_workflow:approve_maintenance_cost_wo-1:maintenance_review",
+          decisionId: "approve_maintenance_cost:wo-1",
+          workflowType: "maintenance",
+          status: "blocked",
+          queue: "maintenance_review",
+          escalationLevel: "urgent",
+          manualReviewRequired: true,
+          policyGuarded: true,
+          externalExecutionEnabled: false,
+          requiresHumanAcknowledgement: true,
+          transition: { fromState: "waiting_context", toState: "waiting_context" },
+          reasons: [
+            "Decision approve_maintenance_cost:wo-1 is routed to maintenance_review.",
+            "Current workflow state is waiting_context.",
+          ],
+          blockedReasons: ["Required workflow context is missing or incomplete."],
+          canonicalEvents: [
+            {
+              eventType: "automated_workflow_blocked",
+              action: "blocked",
+              status: "blocked",
+              resourceType: "workflow",
+              resourceId: "approve_maintenance_cost:wo-1",
+              summary: "Internal workflow orchestration is blocked pending manual context review.",
+            },
+          ],
+          generatedAt: "2026-05-05T12:00:00.000Z",
+        },
         workflow: {
           queue: "maintenance_review",
           workflowState: "waiting_context",
@@ -160,6 +219,15 @@ function inboxResponse(overrides: Record<string, unknown> = {}) {
       underReview: 0,
       escalated: 1,
       critical: 1,
+    },
+    automationSummary: {
+      total: 2,
+      pending: 1,
+      derived: 0,
+      blocked: 1,
+      completed: 0,
+      escalationFlagged: 2,
+      reviewRequired: 2,
     },
     ...overrides,
   };
@@ -195,6 +263,10 @@ describe("DecisionInboxPage", () => {
     expect(screen.getAllByText("Blocked").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Escalated").length).toBeGreaterThan(0);
     expect(screen.getByText("Critical workflow")).toBeInTheDocument();
+    expect(screen.getByText("Workflow previews")).toBeInTheDocument();
+    expect(screen.getByText("Review required")).toBeInTheDocument();
+    expect(screen.getByText("Escalation flags")).toBeInTheDocument();
+    expect(screen.getByText("Blocked orchestration")).toBeInTheDocument();
     expect(screen.getByText("Review Missing Payment")).toBeInTheDocument();
     expect(screen.getByText("Expected rent payment is missing.")).toBeInTheDocument();
     expect(screen.getAllByText("Delinquency Review").length).toBeGreaterThan(0);
@@ -202,6 +274,12 @@ describe("DecisionInboxPage", () => {
     expect(screen.getAllByText("Urgent").length).toBeGreaterThan(0);
     expect(screen.getByText("Manual review required")).toBeInTheDocument();
     expect(screen.getByText("No automated notice or payment action will be taken.")).toBeInTheDocument();
+    expect(screen.getAllByText("Deterministic workflow orchestration only.").length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/No tenant communication, payment action, or legal enforcement is automated/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Review automation reasoning").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Workflow type:").length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/External execution:/).length).toBeGreaterThan(0);
+    expect(screen.getByText("Required workflow context is missing or incomplete.")).toBeInTheDocument();
     expect(screen.getByText("Review context")).toBeInTheDocument();
     expect(screen.getByText("Prepare reminder")).toBeInTheDocument();
     expect(screen.getByText("Prepare notice")).toBeInTheDocument();
@@ -215,7 +293,21 @@ describe("DecisionInboxPage", () => {
     expect(screen.getAllByText("Operator review session").length).toBeGreaterThan(0);
     expect(screen.getAllByText(/No automated approval or certification occurs/i).length).toBeGreaterThan(0);
     expect(screen.queryByRole("button", { name: /resolve|dismiss|snooze|approve|retry|execute/i })).not.toBeInTheDocument();
-    expect(screen.queryByText(/send notice|charge tenant|start eviction|auto-send|auto-charge/i)).not.toBeInTheDocument();
+    const forbiddenCopy = [
+      ["send", "notice"],
+      ["charge", "tenant"],
+      ["start", "eviction"],
+      ["auto", "send"],
+      ["auto", "charge"],
+      ["auto", "approve"],
+      ["file", "eviction"],
+      ["submit", "export"],
+      ["approve", "compliance"],
+      ["autonomous", "mode"],
+    ];
+    for (const words of forbiddenCopy) {
+      expect(screen.queryByText(new RegExp(words.join("[ -]"), "i"))).not.toBeInTheDocument();
+    }
     expect(apiMocks.macShellProps).toHaveBeenCalledWith(expect.objectContaining({ showTopNav: false }));
   });
 
@@ -227,6 +319,7 @@ describe("DecisionInboxPage", () => {
           items: [inboxResponse().items[0]],
           summary: { total: 1, critical: 1, high: 0, open: 1, blocked: 0 },
           workflowSummary: { new: 0, underReview: 0, escalated: 1, critical: 1 },
+          automationSummary: { total: 1, pending: 1, derived: 0, blocked: 0, completed: 0, escalationFlagged: 1, reviewRequired: 1 },
         })
       );
 
@@ -257,6 +350,7 @@ describe("DecisionInboxPage", () => {
         items: [inboxResponse().items[1]],
         summary: { total: 1, critical: 0, high: 1, open: 0, blocked: 1 },
         workflowSummary: { new: 0, underReview: 0, escalated: 0, critical: 0 },
+        automationSummary: { total: 1, pending: 0, derived: 0, blocked: 1, completed: 0, escalationFlagged: 1, reviewRequired: 1 },
       })
     );
     fireEvent.change(screen.getByLabelText("Queue"), { target: { value: "maintenance_review" } });
@@ -274,6 +368,7 @@ describe("DecisionInboxPage", () => {
         items: [],
         summary: { total: 0, critical: 0, high: 0, open: 0, blocked: 0 },
         workflowSummary: { new: 0, underReview: 0, escalated: 0, critical: 0 },
+        automationSummary: { total: 0, pending: 0, derived: 0, blocked: 0, completed: 0, escalationFlagged: 0, reviewRequired: 0 },
       })
     );
 

--- a/rentchain-frontend/src/pages/DecisionInboxPage.tsx
+++ b/rentchain-frontend/src/pages/DecisionInboxPage.tsx
@@ -10,6 +10,7 @@ import {
   type DecisionWorkflowEscalationLevel,
   type DecisionWorkflowQueue,
   type DecisionWorkflowState,
+  type AutomatedWorkflowStatus,
 } from "@/api/decisionInboxApi";
 import type { OperatorReviewEvidenceReference, OperatorReviewScope } from "@/api/operatorReviewApi";
 import { evidencePackPath } from "@/api/evidencePackApi";
@@ -118,6 +119,13 @@ function escalationTone(level: DecisionWorkflowEscalationLevel) {
   return { color: "#475569", background: "#f8fafc", border: "#e2e8f0" };
 }
 
+function automationStatusTone(status: AutomatedWorkflowStatus) {
+  if (status === "blocked") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
+  if (status === "pending") return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
+  if (status === "derived") return { color: "#1d4ed8", background: "#dbeafe", border: "#bfdbfe" };
+  return { color: "#166534", background: "#dcfce7", border: "#bbf7d0" };
+}
+
 function Badge({ children, tone }: { children: React.ReactNode; tone: { color: string; background: string; border: string } }) {
   return (
     <span
@@ -139,6 +147,7 @@ function Badge({ children, tone }: { children: React.ReactNode; tone: { color: s
 
 function DecisionInboxCard({ item }: { item: DecisionInboxItem }) {
   const delinquencyActions = item.delinquencyActions || [];
+  const automatedWorkflow = item.automatedWorkflow;
   const reviewScope: OperatorReviewScope = item.workflow.queue === "delinquency_review" ? "delinquency" : "decision";
   const evidence: OperatorReviewEvidenceReference[] = [
     {
@@ -248,6 +257,55 @@ function DecisionInboxCard({ item }: { item: DecisionInboxItem }) {
                   </Link>
                 ) : null}
               </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+      {automatedWorkflow ? (
+        <div
+          style={{
+            border: "1px solid #bfdbfe",
+            background: "#eff6ff",
+            borderRadius: 8,
+            padding: 12,
+            display: "grid",
+            gap: 10,
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+            <div style={{ display: "grid", gap: 4 }}>
+              <strong style={{ color: "#1e3a8a" }}>Deterministic workflow orchestration only.</strong>
+              <span style={{ color: "#1e40af", fontSize: 13 }}>
+                No tenant communication, payment action, or legal enforcement is automated. Manual review remains required.
+              </span>
+            </div>
+            <Badge tone={automationStatusTone(automatedWorkflow.status)}>{label(automatedWorkflow.status)}</Badge>
+          </div>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 8 }}>
+            <div style={{ color: "#334155", fontSize: 13 }}>
+              <strong>Workflow type:</strong> {label(automatedWorkflow.workflowType)}
+            </div>
+            <div style={{ color: "#334155", fontSize: 13 }}>
+              <strong>Transition:</strong> {label(automatedWorkflow.transition.fromState)} to {label(automatedWorkflow.transition.toState)}
+            </div>
+            <div style={{ color: "#334155", fontSize: 13 }}>
+              <strong>Policy guarded:</strong> {automatedWorkflow.policyGuarded ? "Yes" : "No"}
+            </div>
+            <div style={{ color: "#334155", fontSize: 13 }}>
+              <strong>External execution:</strong> {automatedWorkflow.externalExecutionEnabled ? "Enabled" : "Disabled"}
+            </div>
+          </div>
+          <div style={{ display: "grid", gap: 5 }}>
+            <strong style={{ color: "#1e3a8a", fontSize: 13 }}>Review automation reasoning</strong>
+            {automatedWorkflow.reasons.slice(0, 3).map((reason) => (
+              <span key={reason} style={{ color: "#334155", fontSize: 13 }}>
+                {reason}
+              </span>
+            ))}
+            {automatedWorkflow.blockedReasons.map((reason) => (
+              <span key={reason} style={{ color: "#991b1b", fontSize: 13, fontWeight: 700 }}>
+                {reason}
+              </span>
             ))}
           </div>
         </div>
@@ -369,6 +427,10 @@ export default function DecisionInboxPage() {
                 ["Under review", data.workflowSummary.underReview],
                 ["Escalated", data.workflowSummary.escalated],
                 ["Critical workflow", data.workflowSummary.critical],
+                ["Workflow previews", data.automationSummary.total],
+                ["Review required", data.automationSummary.reviewRequired],
+                ["Escalation flags", data.automationSummary.escalationFlagged],
+                ["Blocked orchestration", data.automationSummary.blocked],
               ].map(([name, value]) => (
                 <Card key={String(name)} style={{ borderRadius: 8, padding: 12 }}>
                   <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>{name}</div>


### PR DESCRIPTION
## Summary
- Adds deterministic, policy-gated automated workflow preview metadata for Decision Inbox items.
- Introduces workflow types, preview statuses, transition metadata, blocked reasons, and canonical workflow event descriptors.
- Adds landlord-scoped read endpoint: `GET /api/landlord/automated-workflows/preview`.
- Additively includes `automatedWorkflow` and `automationSummary` in Decision Inbox responses.
- Extends Decision Inbox UI with read-only workflow orchestration indicators, blocked reasons, policy/manual-review badges, and safety copy.
- Documents Automated Workflows v1 architecture.

## Guardrails
- No tenant, landlord, institution, regulator, insurer, or lender communication was added.
- No payment collection, balance mutation, legal notice, delinquency enforcement, export submission, compliance certification, external integration, background worker, queue, cron, Pub/Sub, or scheduled job was added.
- No autonomous agents, AI/probabilistic routing, source-record mutation, or hidden side effects were added.
- Landlord endpoint remains landlord-scoped and exposes only safe workflow preview metadata.

## Verification
- `pnpm exec vitest run src/lib/automatedWorkflows/__tests__/deriveAutomatedWorkflowTransitions.test.ts src/routes/__tests__/landlordDecisionInboxRoutes.test.ts` passed: 10 tests.
- `pnpm exec vitest run src/pages/DecisionInboxPage.test.tsx` passed: 3 tests.
- `pnpm build` passed in `rentchain-api` with Node 20.
- `pnpm build` passed in `rentchain-frontend` with existing chunk-size warning.
- `git diff --check` passed.
- Dependency/lockfile diff empty.

## Notes
- V1 is preview/read-only orchestration. It does not persist workflow sync state or execute workflow actions.