### PR TITLE
feat: add policy-gated agent action suggestions

### DIFF
--- a/docs/architecture/policy-gated-agent-actions-v1.md
+++ b/docs/architecture/policy-gated-agent-actions-v1.md
@@ -1,0 +1,110 @@
+# Policy-Gated Agent Actions v1
+
+Policy-Gated Agent Actions v1 adds deterministic, operator-visible action suggestions on top of Decision Inbox, workflow routing, automated workflow previews, operator reviews, evidence packs, and review timelines.
+
+This layer is not autonomous agent execution. It is a supervised recommendation surface for human operators.
+
+## Scope
+
+V1 supports:
+
+- suggested actions
+- suggested next steps
+- suggested workflow transitions
+- suggested evidence requests
+- suggested review escalation
+- suggested follow-up review
+- canonical agent-action event descriptors
+
+V1 does not:
+
+- execute actions automatically
+- contact tenants, landlords, vendors, lenders, insurers, regulators, or institutions
+- send email, SMS, push notifications, reports, or notices
+- trigger payment collection or financial movement
+- generate legal notices or eviction actions
+- approve workflows or certify compliance
+- submit exports externally
+- add background workers, queues, cron, Pub/Sub, schedulers, or autonomous agents
+- mutate lease, property, tenant, payment, screening, decision, export, evidence, or audit readiness records
+
+## Model
+
+Each suggestion contains:
+
+- `agentActionId`
+- `actionType`
+- `status`
+- `manualReviewRequired: true`
+- `policyGuarded: true`
+- `externalExecutionEnabled: false`
+- `requiresHumanApproval: true`
+- `explanation`
+- `relatedScope`
+- `queue`
+- `escalationLevel`
+- `canonicalEvents`
+- `generatedAt`
+
+## Action Types
+
+Supported V1 action types:
+
+- `request_evidence`
+- `recommend_review`
+- `suggest_escalation`
+- `suggest_follow_up`
+- `suggest_workflow_transition`
+- `suggest_export_review`
+
+These are recommendations only. They never execute operational changes.
+
+## Policy Guards
+
+Suggestions require:
+
+- manual workflow routing
+- non-executable Decision Inbox items
+- external workflow execution disabled
+- landlord-safe ownership metadata
+
+Admin-owned decisions are blocked from landlord action suggestions. Blocked suggestions include deterministic blocked reasons.
+
+## Canonical Event Descriptors
+
+V1 emits deterministic event descriptors:
+
+- `policy_gated_agent_action_suggested`
+- `policy_gated_agent_action_blocked`
+- `policy_gated_agent_action_acknowledged`
+- `policy_gated_agent_action_review_required`
+
+These descriptors support audit and timeline context. They do not write events or trigger side effects in V1.
+
+## API
+
+The landlord-scoped suggestion endpoint is:
+
+```text
+GET /api/landlord/agent-actions/suggestions
+```
+
+Supported filters:
+
+- `actionType`
+- `status`
+- `queue`
+- `escalationLevel`
+
+Decision Inbox responses include `agentActions` per item and `agentActionSummary`.
+
+## Deferred
+
+- acknowledgement persistence
+- full agent supervision console
+- policy-gated execution requests
+- operator assignment workflows
+- notification delivery
+- external submissions
+- payment actions
+- legal notice workflows

--- a/rentchain-api/src/lib/agentActions/__tests__/derivePolicyGatedAgentActions.test.ts
+++ b/rentchain-api/src/lib/agentActions/__tests__/derivePolicyGatedAgentActions.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+import { derivePolicyGatedAgentActions } from "../derivePolicyGatedAgentActions";
+import type { DecisionInboxItem } from "../../decisions/decisionInboxTypes";
+
+function decision(overrides: Partial<DecisionInboxItem> = {}): DecisionInboxItem {
+  return {
+    id: "decision-1",
+    title: "Review Missing Payment",
+    description: "Expected rent payment is missing.",
+    severity: "critical",
+    status: "open",
+    type: "billing",
+    source: "lease_ledger",
+    relatedEntity: { kind: "lease", id: "lease-1", label: "Lease lease-1" },
+    destination: "/leases/lease-1/ledger",
+    automationEligible: false,
+    workflow: {
+      queue: "delinquency_review",
+      workflowState: "escalated",
+      ownershipType: "landlord",
+      reviewPriority: "critical",
+      escalationLevel: "critical",
+      manualOnly: true,
+    },
+    automatedWorkflow: {
+      automationId: "automated_workflow:decision-1:delinquency_review",
+      decisionId: "decision-1",
+      workflowType: "delinquency",
+      status: "pending",
+      queue: "delinquency_review",
+      escalationLevel: "critical",
+      manualReviewRequired: true,
+      policyGuarded: true,
+      externalExecutionEnabled: false,
+      requiresHumanAcknowledgement: true,
+      transition: { fromState: "escalated", toState: "escalated" },
+      reasons: ["Manual review remains required."],
+      blockedReasons: [],
+      canonicalEvents: [],
+      generatedAt: "2026-05-06T00:00:00.000Z",
+    },
+    createdAt: "2026-05-05T12:00:00.000Z",
+    updatedAt: "2026-05-05T12:00:00.000Z",
+    ...overrides,
+    workflow: {
+      queue: "delinquency_review",
+      workflowState: "escalated",
+      ownershipType: "landlord",
+      reviewPriority: "critical",
+      escalationLevel: "critical",
+      manualOnly: true,
+      ...overrides.workflow,
+    },
+  };
+}
+
+describe("derivePolicyGatedAgentActions", () => {
+  it("derives deterministic escalation suggestions with required safety flags", () => {
+    const result = derivePolicyGatedAgentActions({
+      generatedAt: "2026-05-06T00:00:00.000Z",
+      decisions: [decision()],
+    });
+
+    expect(result.actions).toHaveLength(1);
+    expect(result.actions[0]).toEqual(expect.objectContaining({
+      agentActionId: "policy_gated_agent_action:decision-1:suggest_escalation",
+      actionType: "suggest_escalation",
+      status: "suggested",
+      manualReviewRequired: true,
+      policyGuarded: true,
+      externalExecutionEnabled: false,
+      requiresHumanApproval: true,
+      relatedScope: { scope: "decision", scopeId: "decision-1" },
+      generatedAt: "2026-05-06T00:00:00.000Z",
+    }));
+    expect(result.actions[0].explanation.reasons).toEqual(expect.arrayContaining([
+      "Workflow escalation metadata indicates elevated review priority.",
+      "Operator review and human approval remain required.",
+    ]));
+    expect(result.actions[0].canonicalEvents).toEqual(expect.arrayContaining([
+      expect.objectContaining({ eventType: "policy_gated_agent_action_suggested" }),
+      expect.objectContaining({ eventType: "policy_gated_agent_action_review_required" }),
+    ]));
+    expect(result.summary).toEqual(expect.objectContaining({ total: 1, suggested: 1, reviewRequired: 1, escalationSuggested: 1 }));
+  });
+
+  it("derives request-evidence suggestions when workflow context is blocked", () => {
+    const result = derivePolicyGatedAgentActions({
+      decisions: [
+        decision({
+          id: "decision-2",
+          type: "maintenance",
+          severity: "high",
+          workflow: {
+            queue: "maintenance_review",
+            workflowState: "waiting_context",
+            ownershipType: "landlord",
+            reviewPriority: "high",
+            escalationLevel: "urgent",
+            manualOnly: true,
+          },
+          automatedWorkflow: {
+            ...decision().automatedWorkflow!,
+            decisionId: "decision-2",
+            status: "blocked",
+            queue: "maintenance_review",
+            workflowType: "maintenance",
+            blockedReasons: ["Required workflow context is missing or incomplete."],
+          },
+        }),
+      ],
+    });
+
+    expect(result.actions[0]).toEqual(expect.objectContaining({
+      actionType: "request_evidence",
+      status: "blocked",
+      relatedScope: { scope: "evidence_pack", scopeId: "decision-2" },
+    }));
+    expect(result.actions[0].explanation.blockedReasons).toContain("Required workflow context is missing or incomplete.");
+    expect(result.actions[0].canonicalEvents).toEqual(expect.arrayContaining([
+      expect.objectContaining({ eventType: "policy_gated_agent_action_blocked" }),
+    ]));
+  });
+
+  it("blocks admin-owned suggestions from landlord-safe output", () => {
+    const result = derivePolicyGatedAgentActions({
+      decisions: [
+        decision({
+          id: "admin-decision",
+          workflow: {
+            queue: "admin_review",
+            workflowState: "new",
+            ownershipType: "admin",
+            reviewPriority: "high",
+            escalationLevel: "urgent",
+            manualOnly: true,
+          },
+        }),
+      ],
+    });
+
+    expect(result.actions[0].status).toBe("blocked");
+    expect(result.actions[0].explanation.blockedReasons).toContain(
+      "Admin-owned decisions are not exposed through landlord agent-action suggestions."
+    );
+  });
+
+  it("filters suggestions by type, status, queue, and escalation", () => {
+    const result = derivePolicyGatedAgentActions({
+      decisions: [
+        decision(),
+        decision({
+          id: "decision-2",
+          type: "maintenance",
+          severity: "high",
+          workflow: {
+            queue: "maintenance_review",
+            workflowState: "waiting_context",
+            ownershipType: "landlord",
+            reviewPriority: "high",
+            escalationLevel: "urgent",
+            manualOnly: true,
+          },
+          automatedWorkflow: {
+            ...decision().automatedWorkflow!,
+            decisionId: "decision-2",
+            status: "blocked",
+            queue: "maintenance_review",
+            workflowType: "maintenance",
+            blockedReasons: ["Required workflow context is missing or incomplete."],
+          },
+        }),
+      ],
+      filters: {
+        actionType: "request_evidence",
+        status: "blocked",
+        queue: "maintenance_review",
+        escalationLevel: "urgent",
+      },
+    });
+
+    expect(result.actions).toHaveLength(1);
+    expect(result.actions[0].agentActionId).toBe("policy_gated_agent_action:decision-2:request_evidence");
+  });
+
+  it("does not mutate source decisions", () => {
+    const source = decision();
+    const before = structuredClone(source);
+
+    derivePolicyGatedAgentActions({ decisions: [source] });
+
+    expect(source).toEqual(before);
+  });
+});

--- a/rentchain-api/src/lib/agentActions/agentActionPolicyGuards.ts
+++ b/rentchain-api/src/lib/agentActions/agentActionPolicyGuards.ts
@@ -1,0 +1,36 @@
+import type { DecisionInboxItem } from "../decisions/decisionInboxTypes";
+
+export type AgentActionPolicyGuardResult = {
+  allowed: boolean;
+  manualReviewRequired: true;
+  policyGuarded: true;
+  externalExecutionEnabled: false;
+  requiresHumanApproval: true;
+  blockedReasons: string[];
+};
+
+export function evaluateAgentActionPolicyGuards(decision: DecisionInboxItem): AgentActionPolicyGuardResult {
+  const blockedReasons: string[] = [];
+
+  if (decision.automationEligible !== false) {
+    blockedReasons.push("Agent suggestions cannot be derived from executable automation items.");
+  }
+  if (decision.workflow.manualOnly !== true) {
+    blockedReasons.push("Workflow routing must remain manual-only before agent suggestions can be surfaced.");
+  }
+  if (decision.workflow.ownershipType === "admin") {
+    blockedReasons.push("Admin-owned decisions are not exposed through landlord agent-action suggestions.");
+  }
+  if (decision.automatedWorkflow?.externalExecutionEnabled !== false) {
+    blockedReasons.push("External workflow execution must be disabled before agent suggestions can be surfaced.");
+  }
+
+  return {
+    allowed: blockedReasons.length === 0,
+    manualReviewRequired: true,
+    policyGuarded: true,
+    externalExecutionEnabled: false,
+    requiresHumanApproval: true,
+    blockedReasons,
+  };
+}

--- a/rentchain-api/src/lib/agentActions/agentActionTypes.ts
+++ b/rentchain-api/src/lib/agentActions/agentActionTypes.ts
@@ -1,0 +1,81 @@
+import type {
+  DecisionInboxItem,
+  DecisionWorkflowEscalationLevel,
+  DecisionWorkflowQueue,
+} from "../decisions/decisionInboxTypes";
+
+export type AgentActionType =
+  | "request_evidence"
+  | "recommend_review"
+  | "suggest_escalation"
+  | "suggest_follow_up"
+  | "suggest_workflow_transition"
+  | "suggest_export_review";
+
+export type AgentActionStatus = "suggested" | "blocked" | "unavailable" | "acknowledged";
+
+export type AgentActionScope = "decision" | "workflow" | "evidence_pack" | "operator_review" | "export" | "audit_compliance";
+
+export type PolicyGatedAgentActionEventType =
+  | "policy_gated_agent_action_suggested"
+  | "policy_gated_agent_action_blocked"
+  | "policy_gated_agent_action_acknowledged"
+  | "policy_gated_agent_action_review_required";
+
+export type PolicyGatedAgentActionEvent = {
+  eventType: PolicyGatedAgentActionEventType;
+  action: string;
+  status: AgentActionStatus;
+  resourceType: AgentActionScope;
+  resourceId: string;
+  summary: string;
+};
+
+export type PolicyGatedAgentAction = {
+  agentActionId: string;
+  actionType: AgentActionType;
+  status: AgentActionStatus;
+  manualReviewRequired: true;
+  policyGuarded: true;
+  externalExecutionEnabled: false;
+  requiresHumanApproval: true;
+  explanation: {
+    summary: string;
+    reasons: string[];
+    blockedReasons: string[];
+  };
+  relatedScope: {
+    scope: AgentActionScope;
+    scopeId: string;
+  };
+  queue: DecisionWorkflowQueue;
+  escalationLevel: DecisionWorkflowEscalationLevel;
+  canonicalEvents: PolicyGatedAgentActionEvent[];
+  generatedAt: string;
+};
+
+export type PolicyGatedAgentActionSummary = {
+  total: number;
+  suggested: number;
+  blocked: number;
+  unavailable: number;
+  acknowledged: number;
+  reviewRequired: number;
+  escalationSuggested: number;
+};
+
+export type PolicyGatedAgentActionResult = {
+  actions: PolicyGatedAgentAction[];
+  summary: PolicyGatedAgentActionSummary;
+};
+
+export type DerivePolicyGatedAgentActionsInput = {
+  decisions?: DecisionInboxItem[] | null;
+  generatedAt?: string | Date | null;
+  filters?: {
+    actionType?: unknown;
+    status?: unknown;
+    queue?: unknown;
+    escalationLevel?: unknown;
+  } | null;
+};

--- a/rentchain-api/src/lib/agentActions/derivePolicyGatedAgentActions.ts
+++ b/rentchain-api/src/lib/agentActions/derivePolicyGatedAgentActions.ts
@@ -1,0 +1,191 @@
+import type {
+  DecisionInboxItem,
+  DecisionWorkflowEscalationLevel,
+  DecisionWorkflowQueue,
+} from "../decisions/decisionInboxTypes";
+import { evaluateAgentActionPolicyGuards } from "./agentActionPolicyGuards";
+import type {
+  AgentActionStatus,
+  AgentActionType,
+  DerivePolicyGatedAgentActionsInput,
+  PolicyGatedAgentAction,
+  PolicyGatedAgentActionEvent,
+  PolicyGatedAgentActionResult,
+} from "./agentActionTypes";
+
+const ACTION_TYPES: AgentActionType[] = [
+  "request_evidence",
+  "recommend_review",
+  "suggest_escalation",
+  "suggest_follow_up",
+  "suggest_workflow_transition",
+  "suggest_export_review",
+];
+const STATUSES: AgentActionStatus[] = ["suggested", "blocked", "unavailable", "acknowledged"];
+const QUEUES: DecisionWorkflowQueue[] = [
+  "lease_review",
+  "delinquency_review",
+  "screening_review",
+  "maintenance_review",
+  "compliance_review",
+  "admin_review",
+  "general_review",
+];
+const ESCALATIONS: DecisionWorkflowEscalationLevel[] = ["none", "attention", "urgent", "critical"];
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function cleanId(value: unknown): string {
+  return asString(value, 800)
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function generatedAt(value: unknown): string {
+  const raw = asString(value, 120);
+  const parsed = raw ? new Date(raw) : new Date();
+  return Number.isNaN(parsed.getTime()) ? new Date().toISOString() : parsed.toISOString();
+}
+
+function actionTypeForDecision(decision: DecisionInboxItem): AgentActionType {
+  if (decision.workflow.workflowState === "waiting_context" || decision.automatedWorkflow?.status === "blocked") {
+    return "request_evidence";
+  }
+  if (decision.workflow.escalationLevel === "critical" || decision.workflow.escalationLevel === "urgent") {
+    return "suggest_escalation";
+  }
+  if (decision.workflow.queue === "compliance_review") return "suggest_export_review";
+  if (decision.workflow.workflowState === "new" || decision.workflow.workflowState === "triaged") {
+    return "suggest_workflow_transition";
+  }
+  if (decision.workflow.workflowState === "under_review" || decision.status === "pending") return "suggest_follow_up";
+  return "recommend_review";
+}
+
+function summaryForAction(actionType: AgentActionType, decision: DecisionInboxItem): string {
+  if (actionType === "request_evidence") return "Request additional evidence before progressing this workflow.";
+  if (actionType === "suggest_escalation") return "Escalation review is recommended based on workflow severity.";
+  if (actionType === "suggest_follow_up") return "Follow-up review is recommended for this open workflow.";
+  if (actionType === "suggest_workflow_transition") return "Workflow transition review is recommended.";
+  if (actionType === "suggest_export_review") return "Review export or readiness context before use.";
+  return `Review ${decision.title} before taking any manual operational step.`;
+}
+
+function reasonsForAction(actionType: AgentActionType, decision: DecisionInboxItem): string[] {
+  const reasons = [
+    `Decision ${decision.id} is routed to ${decision.workflow.queue}.`,
+    `Workflow state is ${decision.workflow.workflowState}.`,
+    `Escalation level is ${decision.workflow.escalationLevel}.`,
+    "Operator review and human approval remain required.",
+  ];
+  if (actionType === "request_evidence") {
+    reasons.push("Workflow context is blocked or waiting for additional evidence.");
+  }
+  if (actionType === "suggest_escalation") {
+    reasons.push("Workflow escalation metadata indicates elevated review priority.");
+  }
+  if (decision.automatedWorkflow) {
+    reasons.push(`Automated workflow preview status is ${decision.automatedWorkflow.status}.`);
+  }
+  return reasons;
+}
+
+function eventsForAction(input: {
+  actionType: AgentActionType;
+  status: AgentActionStatus;
+  decision: DecisionInboxItem;
+  blockedReasons: string[];
+}): PolicyGatedAgentActionEvent[] {
+  const events: PolicyGatedAgentActionEvent[] = [];
+  events.push({
+    eventType: input.blockedReasons.length ? "policy_gated_agent_action_blocked" : "policy_gated_agent_action_suggested",
+    action: input.actionType,
+    status: input.status,
+    resourceType: "decision",
+    resourceId: input.decision.id,
+    summary: input.blockedReasons.length
+      ? "Policy-gated agent suggestion is blocked pending manual review."
+      : "Policy-gated agent suggestion is available for operator review.",
+  });
+  events.push({
+    eventType: "policy_gated_agent_action_review_required",
+    action: "review_required",
+    status: input.status === "acknowledged" ? "acknowledged" : "suggested",
+    resourceType: "workflow",
+    resourceId: input.decision.id,
+    summary: "Human approval remains required; no agent action will execute automatically.",
+  });
+  return events;
+}
+
+export function agentActionFromDecision(decision: DecisionInboxItem, generated: string): PolicyGatedAgentAction {
+  const guard = evaluateAgentActionPolicyGuards(decision);
+  const actionType = actionTypeForDecision(decision);
+  const blockedReasons = [
+    ...guard.blockedReasons,
+    ...(decision.automatedWorkflow?.blockedReasons || []),
+  ];
+  const status: AgentActionStatus = blockedReasons.length ? "blocked" : "suggested";
+
+  return {
+    agentActionId: cleanId(`policy_gated_agent_action:${decision.id}:${actionType}`) || "policy_gated_agent_action:unknown",
+    actionType,
+    status,
+    manualReviewRequired: true,
+    policyGuarded: true,
+    externalExecutionEnabled: false,
+    requiresHumanApproval: true,
+    explanation: {
+      summary: summaryForAction(actionType, decision),
+      reasons: reasonsForAction(actionType, decision),
+      blockedReasons,
+    },
+    relatedScope: {
+      scope: actionType === "suggest_export_review" ? "export" : actionType === "request_evidence" ? "evidence_pack" : "decision",
+      scopeId: decision.id,
+    },
+    queue: decision.workflow.queue,
+    escalationLevel: decision.workflow.escalationLevel,
+    canonicalEvents: eventsForAction({ actionType, status, decision, blockedReasons }),
+    generatedAt: generated,
+  };
+}
+
+function filterValue<T extends string>(value: unknown, known: readonly T[]): T | null {
+  const raw = asString(value, 80).toLowerCase();
+  if (!raw || raw === "all") return null;
+  return known.includes(raw as T) ? (raw as T) : null;
+}
+
+export function derivePolicyGatedAgentActions(input: DerivePolicyGatedAgentActionsInput): PolicyGatedAgentActionResult {
+  const generated = generatedAt(input.generatedAt);
+  const allActions = (input.decisions || []).map((decision) => agentActionFromDecision(decision, generated));
+  const actionType = filterValue(input.filters?.actionType, ACTION_TYPES);
+  const status = filterValue(input.filters?.status, STATUSES);
+  const queue = filterValue(input.filters?.queue, QUEUES);
+  const escalationLevel = filterValue(input.filters?.escalationLevel, ESCALATIONS);
+  const actions = allActions.filter((action) => {
+    if (actionType && action.actionType !== actionType) return false;
+    if (status && action.status !== status) return false;
+    if (queue && action.queue !== queue) return false;
+    if (escalationLevel && action.escalationLevel !== escalationLevel) return false;
+    return true;
+  });
+
+  return {
+    actions,
+    summary: {
+      total: actions.length,
+      suggested: actions.filter((action) => action.status === "suggested").length,
+      blocked: actions.filter((action) => action.status === "blocked").length,
+      unavailable: actions.filter((action) => action.status === "unavailable").length,
+      acknowledged: actions.filter((action) => action.status === "acknowledged").length,
+      reviewRequired: actions.filter((action) => action.manualReviewRequired).length,
+      escalationSuggested: actions.filter((action) => action.actionType === "suggest_escalation").length,
+    },
+  };
+}

--- a/rentchain-api/src/lib/decisions/decisionInboxTypes.ts
+++ b/rentchain-api/src/lib/decisions/decisionInboxTypes.ts
@@ -1,4 +1,5 @@
 import type { AutomatedWorkflowPreview, AutomatedWorkflowSummary } from "../automatedWorkflows/automatedWorkflowTypes";
+import type { PolicyGatedAgentAction, PolicyGatedAgentActionSummary } from "../agentActions/agentActionTypes";
 
 export type DecisionInboxSeverity = "critical" | "high" | "medium" | "low" | "info" | "unknown";
 
@@ -85,6 +86,7 @@ export type DecisionInboxItem = {
   automationEligible: false;
   workflow: DecisionWorkflowRouting;
   automatedWorkflow?: AutomatedWorkflowPreview;
+  agentActions?: PolicyGatedAgentAction[];
   delinquencyActions?: DelinquencyActionDescriptor[];
   createdAt: string | null;
   updatedAt: string | null;
@@ -120,4 +122,5 @@ export type DecisionInboxResult = {
   summary: DecisionInboxSummary;
   workflowSummary: DecisionInboxWorkflowSummary;
   automationSummary: AutomatedWorkflowSummary;
+  agentActionSummary: PolicyGatedAgentActionSummary;
 };

--- a/rentchain-api/src/lib/decisions/deriveDecisionInbox.ts
+++ b/rentchain-api/src/lib/decisions/deriveDecisionInbox.ts
@@ -14,6 +14,7 @@ import type {
 import { deriveDecisionWorkflowRouting } from "./deriveDecisionWorkflowRouting";
 import { deriveDelinquencyActions } from "../delinquency/deriveDelinquencyActions";
 import { deriveAutomatedWorkflowTransitions } from "../automatedWorkflows/deriveAutomatedWorkflowTransitions";
+import { derivePolicyGatedAgentActions } from "../agentActions/derivePolicyGatedAgentActions";
 
 type SourceDecision = Decision & { latestAction?: unknown };
 
@@ -254,10 +255,23 @@ export function deriveDecisionInbox(input: DeriveDecisionInboxInput): DecisionIn
   const automationByDecisionId = new Map(
     deriveAutomatedWorkflowTransitions({ decisions: baseItems }).workflows.map((workflow) => [workflow.decisionId, workflow])
   );
-  const allItems = baseItems.map((item) => ({
+  const itemsWithAutomation = baseItems.map((item) => ({
     ...item,
     automatedWorkflow: automationByDecisionId.get(item.id),
-  })).sort((a, b) => {
+  }));
+  const agentActionsByDecisionId = new Map(
+    derivePolicyGatedAgentActions({ decisions: itemsWithAutomation }).actions.map((action) => [
+      action.relatedScope.scopeId,
+      action,
+    ])
+  );
+  const allItems = itemsWithAutomation.map((item) => {
+    const action = agentActionsByDecisionId.get(item.id);
+    return {
+      ...item,
+      agentActions: action ? [action] : [],
+    };
+  }).sort((a, b) => {
     const severityOrder: Record<DecisionInboxSeverity, number> = {
       critical: 0,
       high: 1,
@@ -339,5 +353,6 @@ export function deriveDecisionInbox(input: DeriveDecisionInboxInput): DecisionIn
       critical: items.filter((item) => item.workflow.escalationLevel === "critical").length,
     },
     automationSummary: deriveAutomatedWorkflowTransitions({ decisions: items }).summary,
+    agentActionSummary: derivePolicyGatedAgentActions({ decisions: items }).summary,
   };
 }

--- a/rentchain-api/src/routes/__tests__/landlordDecisionInboxRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordDecisionInboxRoutes.test.ts
@@ -188,6 +188,16 @@ describe("landlordDecisionInboxRoutes", () => {
             externalExecutionEnabled: false,
             policyGuarded: true,
           }),
+          agentActions: expect.arrayContaining([
+            expect.objectContaining({
+              actionType: "suggest_escalation",
+              status: "suggested",
+              manualReviewRequired: true,
+              policyGuarded: true,
+              externalExecutionEnabled: false,
+              requiresHumanApproval: true,
+            }),
+          ]),
           workflow: expect.objectContaining({
             queue: "maintenance_review",
             workflowState: "escalated",
@@ -211,6 +221,15 @@ describe("landlordDecisionInboxRoutes", () => {
               expect.objectContaining({ eventType: "automated_workflow_review_required" }),
             ]),
           }),
+          agentActions: expect.arrayContaining([
+            expect.objectContaining({
+              actionType: "suggest_escalation",
+              status: "suggested",
+              canonicalEvents: expect.arrayContaining([
+                expect.objectContaining({ eventType: "policy_gated_agent_action_review_required" }),
+              ]),
+            }),
+          ]),
           workflow: expect.objectContaining({
             queue: "delinquency_review",
             workflowState: "escalated",
@@ -231,6 +250,12 @@ describe("landlordDecisionInboxRoutes", () => {
       pending: 3,
       escalationFlagged: 3,
       reviewRequired: 3,
+    }));
+    expect(res.body.agentActionSummary).toEqual(expect.objectContaining({
+      total: 3,
+      suggested: 3,
+      reviewRequired: 3,
+      escalationSuggested: 3,
     }));
   });
 
@@ -288,6 +313,39 @@ describe("landlordDecisionInboxRoutes", () => {
           requiresHumanAcknowledgement: true,
           canonicalEvents: expect.arrayContaining([
             expect.objectContaining({ eventType: "automated_workflow_review_required" }),
+          ]),
+        }),
+      ])
+    );
+    expect(JSON.stringify(res.body)).not.toMatch(/externalExecutionEnabled":true|executed":true|charge tenant|file eviction/i);
+  });
+
+  it("returns read-only policy-gated agent action suggestions", async () => {
+    seedLease();
+    const router = (await import("../landlordDecisionInboxRoutes")).default;
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/agent-actions/suggestions?actionType=suggest_escalation&status=suggested&queue=delinquency_review",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.manualReviewRequired).toBe(true);
+    expect(res.body.externalExecutionEnabled).toBe(false);
+    expect(res.body.requiresHumanApproval).toBe(true);
+    expect(res.body.actions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          actionType: "suggest_escalation",
+          status: "suggested",
+          manualReviewRequired: true,
+          policyGuarded: true,
+          externalExecutionEnabled: false,
+          requiresHumanApproval: true,
+          canonicalEvents: expect.arrayContaining([
+            expect.objectContaining({ eventType: "policy_gated_agent_action_suggested" }),
+            expect.objectContaining({ eventType: "policy_gated_agent_action_review_required" }),
           ]),
         }),
       ])

--- a/rentchain-api/src/routes/landlordDecisionInboxRoutes.ts
+++ b/rentchain-api/src/routes/landlordDecisionInboxRoutes.ts
@@ -5,6 +5,7 @@ import { requireLandlord } from "../middleware/requireLandlord";
 import { loadLandlordAnalyticsSnapshot } from "../services/landlord/landlordAnalyticsSnapshot";
 import { deriveDecisionInbox } from "../lib/decisions/deriveDecisionInbox";
 import { deriveAutomatedWorkflowTransitions } from "../lib/automatedWorkflows/deriveAutomatedWorkflowTransitions";
+import { derivePolicyGatedAgentActions } from "../lib/agentActions/derivePolicyGatedAgentActions";
 import { deriveDecisions, type Decision } from "../lib/decisions/decisionEngine";
 import { applyDecisionActions, DECISION_ACTIONS_COLLECTION } from "../lib/decisions/decisionActions";
 import { deriveLeaseLifecycleState } from "../lib/leases/leaseLifecycle";
@@ -236,6 +237,58 @@ router.get("/automated-workflows/preview", requireAuth, requireLandlord, async (
   } catch (err: any) {
     console.error("[landlord-automated-workflows] preview failed", err?.message || err);
     return res.status(500).json({ ok: false, error: "AUTOMATED_WORKFLOW_PREVIEW_FAILED" });
+  }
+});
+
+router.get("/agent-actions/suggestions", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = asString(req.user?.landlordId || req.user?.id, 240);
+    if (!landlordId) {
+      return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    }
+
+    const [snapshot, leaseDecisions] = await Promise.all([
+      loadLandlordAnalyticsSnapshot({
+        landlordId,
+        period: req.query?.period,
+        propertyId: req.query?.propertyId,
+      }),
+      deriveLeaseDecisionsForInbox(landlordId),
+    ]);
+
+    const inbox = deriveDecisionInbox({
+      analyticsDecisions: Array.isArray(snapshot?.decisions?.items) ? snapshot.decisions.items : [],
+      leaseDecisions,
+      filters: {
+        severity: req.query?.severity,
+        status: req.query?.decisionStatus,
+        type: req.query?.type,
+        queue: req.query?.queue,
+        workflowState: req.query?.workflowState,
+        escalationLevel: req.query?.escalationLevel,
+      },
+    });
+    const suggestions = derivePolicyGatedAgentActions({
+      decisions: inbox.items,
+      filters: {
+        actionType: req.query?.actionType,
+        status: req.query?.status,
+        queue: req.query?.queue,
+        escalationLevel: req.query?.escalationLevel,
+      },
+    });
+
+    return res.json({
+      ok: true,
+      actions: suggestions.actions,
+      summary: suggestions.summary,
+      manualReviewRequired: true,
+      externalExecutionEnabled: false,
+      requiresHumanApproval: true,
+    });
+  } catch (err: any) {
+    console.error("[landlord-agent-actions] suggestions failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "AGENT_ACTION_SUGGESTIONS_FAILED" });
   }
 });
 

--- a/rentchain-frontend/src/api/decisionInboxApi.ts
+++ b/rentchain-frontend/src/api/decisionInboxApi.ts
@@ -37,6 +37,20 @@ export type AutomatedWorkflowEventType =
   | "automated_workflow_escalation_flagged"
   | "automated_workflow_review_required"
   | "automated_workflow_sync_completed";
+export type AgentActionType =
+  | "request_evidence"
+  | "recommend_review"
+  | "suggest_escalation"
+  | "suggest_follow_up"
+  | "suggest_workflow_transition"
+  | "suggest_export_review";
+export type AgentActionStatus = "suggested" | "blocked" | "unavailable" | "acknowledged";
+export type AgentActionScope = "decision" | "workflow" | "evidence_pack" | "operator_review" | "export" | "audit_compliance";
+export type PolicyGatedAgentActionEventType =
+  | "policy_gated_agent_action_suggested"
+  | "policy_gated_agent_action_blocked"
+  | "policy_gated_agent_action_acknowledged"
+  | "policy_gated_agent_action_review_required";
 export type DecisionWorkflowRouting = {
   queue: DecisionWorkflowQueue;
   workflowState: DecisionWorkflowState;
@@ -81,6 +95,44 @@ export type AutomatedWorkflowSummary = {
   escalationFlagged: number;
   reviewRequired: number;
 };
+export type PolicyGatedAgentAction = {
+  agentActionId: string;
+  actionType: AgentActionType;
+  status: AgentActionStatus;
+  manualReviewRequired: true;
+  policyGuarded: true;
+  externalExecutionEnabled: false;
+  requiresHumanApproval: true;
+  explanation: {
+    summary: string;
+    reasons: string[];
+    blockedReasons: string[];
+  };
+  relatedScope: {
+    scope: AgentActionScope;
+    scopeId: string;
+  };
+  queue: DecisionWorkflowQueue;
+  escalationLevel: DecisionWorkflowEscalationLevel;
+  canonicalEvents: Array<{
+    eventType: PolicyGatedAgentActionEventType;
+    action: string;
+    status: AgentActionStatus;
+    resourceType: AgentActionScope;
+    resourceId: string;
+    summary: string;
+  }>;
+  generatedAt: string;
+};
+export type PolicyGatedAgentActionSummary = {
+  total: number;
+  suggested: number;
+  blocked: number;
+  unavailable: number;
+  acknowledged: number;
+  reviewRequired: number;
+  escalationSuggested: number;
+};
 export type DelinquencyActionDescriptor = {
   actionKey: "review_context" | "prepare_reminder" | "prepare_notice" | "view_ledger";
   label: string;
@@ -110,6 +162,7 @@ export type DecisionInboxItem = {
   automationEligible: false;
   workflow: DecisionWorkflowRouting;
   automatedWorkflow?: AutomatedWorkflowPreview;
+  agentActions?: PolicyGatedAgentAction[];
   delinquencyActions?: DelinquencyActionDescriptor[];
   createdAt: string | null;
   updatedAt: string | null;
@@ -139,6 +192,7 @@ export type DecisionInboxResponse = {
     critical: number;
   };
   automationSummary: AutomatedWorkflowSummary;
+  agentActionSummary: PolicyGatedAgentActionSummary;
 };
 
 export type DecisionInboxQuery = {
@@ -180,6 +234,15 @@ export async function fetchDecisionInbox(params?: DecisionInboxQuery): Promise<D
       completed: 0,
       escalationFlagged: 0,
       reviewRequired: 0,
+    },
+    agentActionSummary: response.agentActionSummary || {
+      total: 0,
+      suggested: 0,
+      blocked: 0,
+      unavailable: 0,
+      acknowledged: 0,
+      reviewRequired: 0,
+      escalationSuggested: 0,
     },
   };
 }

--- a/rentchain-frontend/src/components/agentActions/AgentActionPanel.test.tsx
+++ b/rentchain-frontend/src/components/agentActions/AgentActionPanel.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { AgentActionPanel } from "./AgentActionPanel";
+import type { PolicyGatedAgentAction } from "@/api/decisionInboxApi";
+
+function action(overrides: Partial<PolicyGatedAgentAction> = {}): PolicyGatedAgentAction {
+  return {
+    agentActionId: "policy_gated_agent_action:decision-1:suggest_escalation",
+    actionType: "suggest_escalation",
+    status: "suggested",
+    manualReviewRequired: true,
+    policyGuarded: true,
+    externalExecutionEnabled: false,
+    requiresHumanApproval: true,
+    explanation: {
+      summary: "Escalation review is recommended based on workflow severity.",
+      reasons: ["Workflow escalation metadata indicates elevated review priority."],
+      blockedReasons: [],
+    },
+    relatedScope: { scope: "decision", scopeId: "decision-1" },
+    queue: "delinquency_review",
+    escalationLevel: "critical",
+    canonicalEvents: [],
+    generatedAt: "2026-05-06T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("AgentActionPanel", () => {
+  it("renders suggested actions with safety copy and no forbidden controls", () => {
+    render(<AgentActionPanel actions={[action()]} />);
+
+    expect(screen.getByText("Suggested actions only.")).toBeInTheDocument();
+    expect(screen.getByText(/Manual approval is required/i)).toBeInTheDocument();
+    expect(screen.getByText("Suggest Escalation")).toBeInTheDocument();
+    expect(screen.getByText("Review explanation")).toBeInTheDocument();
+    expect(screen.getByText("External execution disabled")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /execute|auto|approve|submit/i })).not.toBeInTheDocument();
+  });
+
+  it("renders blocked reasons", () => {
+    render(
+      <AgentActionPanel
+        actions={[
+          action({
+            actionType: "request_evidence",
+            status: "blocked",
+            explanation: {
+              summary: "Request additional evidence before progressing this workflow.",
+              reasons: ["Workflow context is blocked."],
+              blockedReasons: ["Required workflow context is missing or incomplete."],
+            },
+          }),
+        ]}
+      />
+    );
+
+    expect(screen.getByText("Request Evidence")).toBeInTheDocument();
+    expect(screen.getByText("Blocked")).toBeInTheDocument();
+    expect(screen.getByText("Required workflow context is missing or incomplete.")).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/agentActions/AgentActionPanel.tsx
+++ b/rentchain-frontend/src/components/agentActions/AgentActionPanel.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import type { AgentActionStatus, PolicyGatedAgentAction } from "@/api/decisionInboxApi";
+
+function label(value: string) {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function statusTone(status: AgentActionStatus) {
+  if (status === "blocked") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
+  if (status === "suggested") return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
+  if (status === "acknowledged") return { color: "#166534", background: "#dcfce7", border: "#bbf7d0" };
+  return { color: "#475569", background: "#f8fafc", border: "#e2e8f0" };
+}
+
+function Badge({ status }: { status: AgentActionStatus }) {
+  const tone = statusTone(status);
+  return (
+    <span
+      style={{
+        border: `1px solid ${tone.border}`,
+        borderRadius: 999,
+        background: tone.background,
+        color: tone.color,
+        padding: "3px 9px",
+        fontSize: 12,
+        fontWeight: 800,
+        whiteSpace: "nowrap",
+      }}
+    >
+      {label(status)}
+    </span>
+  );
+}
+
+export function AgentActionPanel({ actions }: { actions?: PolicyGatedAgentAction[] | null }) {
+  const rows = actions || [];
+  if (!rows.length) return null;
+
+  return (
+    <div
+      style={{
+        border: "1px solid #c7d2fe",
+        background: "#eef2ff",
+        borderRadius: 8,
+        padding: 12,
+        display: "grid",
+        gap: 10,
+      }}
+    >
+      <div style={{ display: "grid", gap: 4 }}>
+        <strong style={{ color: "#312e81" }}>Suggested actions only.</strong>
+        <span style={{ color: "#3730a3", fontSize: 13 }}>
+          Manual approval is required. No tenant communication, payment action, legal enforcement, or external submission is automated.
+        </span>
+      </div>
+      {rows.map((action) => (
+        <div
+          key={action.agentActionId}
+          style={{
+            display: "grid",
+            gap: 8,
+            border: "1px solid #c7d2fe",
+            background: "#fff",
+            borderRadius: 8,
+            padding: 10,
+          }}
+        >
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+            <strong style={{ color: "#0f172a" }}>{label(action.actionType)}</strong>
+            <Badge status={action.status} />
+          </div>
+          <div style={{ color: "#334155", fontSize: 13 }}>{action.explanation.summary}</div>
+          <div style={{ display: "grid", gap: 4 }}>
+            <strong style={{ color: "#312e81", fontSize: 13 }}>Review explanation</strong>
+            {action.explanation.reasons.slice(0, 4).map((reason) => (
+              <span key={reason} style={{ color: "#475569", fontSize: 13 }}>
+                {reason}
+              </span>
+            ))}
+            {action.explanation.blockedReasons.map((reason) => (
+              <span key={reason} style={{ color: "#991b1b", fontSize: 13, fontWeight: 700 }}>
+                {reason}
+              </span>
+            ))}
+          </div>
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap", color: "#475569", fontSize: 12, fontWeight: 800 }}>
+            <span>Manual review required</span>
+            <span>Policy guarded</span>
+            <span>Human approval required</span>
+            <span>External execution disabled</span>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/rentchain-frontend/src/pages/DecisionInboxPage.test.tsx
+++ b/rentchain-frontend/src/pages/DecisionInboxPage.test.tsx
@@ -90,6 +90,39 @@ function inboxResponse(overrides: Record<string, unknown> = {}) {
           ],
           generatedAt: "2026-05-05T12:00:00.000Z",
         },
+        agentActions: [
+          {
+            agentActionId: "policy_gated_agent_action:decision_review_missing_payment_lease-1:suggest_escalation",
+            actionType: "suggest_escalation",
+            status: "suggested",
+            manualReviewRequired: true,
+            policyGuarded: true,
+            externalExecutionEnabled: false,
+            requiresHumanApproval: true,
+            explanation: {
+              summary: "Escalation review is recommended based on workflow severity.",
+              reasons: [
+                "Workflow escalation metadata indicates elevated review priority.",
+                "Operator review and human approval remain required.",
+              ],
+              blockedReasons: [],
+            },
+            relatedScope: { scope: "decision", scopeId: "decision:review_missing_payment:lease-1" },
+            queue: "delinquency_review",
+            escalationLevel: "critical",
+            canonicalEvents: [
+              {
+                eventType: "policy_gated_agent_action_review_required",
+                action: "review_required",
+                status: "suggested",
+                resourceType: "workflow",
+                resourceId: "decision:review_missing_payment:lease-1",
+                summary: "Human approval remains required; no agent action will execute automatically.",
+              },
+            ],
+            generatedAt: "2026-05-05T12:00:00.000Z",
+          },
+        ],
         workflow: {
           queue: "delinquency_review",
           workflowState: "escalated",
@@ -187,6 +220,36 @@ function inboxResponse(overrides: Record<string, unknown> = {}) {
           ],
           generatedAt: "2026-05-05T12:00:00.000Z",
         },
+        agentActions: [
+          {
+            agentActionId: "policy_gated_agent_action:approve_maintenance_cost_wo-1:request_evidence",
+            actionType: "request_evidence",
+            status: "blocked",
+            manualReviewRequired: true,
+            policyGuarded: true,
+            externalExecutionEnabled: false,
+            requiresHumanApproval: true,
+            explanation: {
+              summary: "Request additional evidence before progressing this workflow.",
+              reasons: ["Workflow context is blocked or waiting for additional evidence."],
+              blockedReasons: ["Required workflow context is missing or incomplete."],
+            },
+            relatedScope: { scope: "evidence_pack", scopeId: "approve_maintenance_cost:wo-1" },
+            queue: "maintenance_review",
+            escalationLevel: "urgent",
+            canonicalEvents: [
+              {
+                eventType: "policy_gated_agent_action_blocked",
+                action: "request_evidence",
+                status: "blocked",
+                resourceType: "decision",
+                resourceId: "approve_maintenance_cost:wo-1",
+                summary: "Policy-gated agent suggestion is blocked pending manual review.",
+              },
+            ],
+            generatedAt: "2026-05-05T12:00:00.000Z",
+          },
+        ],
         workflow: {
           queue: "maintenance_review",
           workflowState: "waiting_context",
@@ -229,6 +292,15 @@ function inboxResponse(overrides: Record<string, unknown> = {}) {
       escalationFlagged: 2,
       reviewRequired: 2,
     },
+    agentActionSummary: {
+      total: 2,
+      suggested: 1,
+      blocked: 1,
+      unavailable: 0,
+      acknowledged: 0,
+      reviewRequired: 2,
+      escalationSuggested: 1,
+    },
     ...overrides,
   };
 }
@@ -267,19 +339,29 @@ describe("DecisionInboxPage", () => {
     expect(screen.getByText("Review required")).toBeInTheDocument();
     expect(screen.getByText("Escalation flags")).toBeInTheDocument();
     expect(screen.getByText("Blocked orchestration")).toBeInTheDocument();
+    expect(screen.getByText("Agent suggestions")).toBeInTheDocument();
+    expect(screen.getByText("Suggested actions")).toBeInTheDocument();
+    expect(screen.getByText("Blocked suggestions")).toBeInTheDocument();
+    expect(screen.getByText("Suggestion review required")).toBeInTheDocument();
     expect(screen.getByText("Review Missing Payment")).toBeInTheDocument();
     expect(screen.getByText("Expected rent payment is missing.")).toBeInTheDocument();
     expect(screen.getAllByText("Delinquency Review").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Maintenance Review").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Urgent").length).toBeGreaterThan(0);
-    expect(screen.getByText("Manual review required")).toBeInTheDocument();
+    expect(screen.getAllByText("Manual review required").length).toBeGreaterThan(0);
     expect(screen.getByText("No automated notice or payment action will be taken.")).toBeInTheDocument();
     expect(screen.getAllByText("Deterministic workflow orchestration only.").length).toBeGreaterThan(0);
     expect(screen.getAllByText(/No tenant communication, payment action, or legal enforcement is automated/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText("Review automation reasoning").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Workflow type:").length).toBeGreaterThan(0);
     expect(screen.getAllByText(/External execution:/).length).toBeGreaterThan(0);
-    expect(screen.getByText("Required workflow context is missing or incomplete.")).toBeInTheDocument();
+    expect(screen.getAllByText("Required workflow context is missing or incomplete.").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Suggested actions only.").length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Manual approval is required/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("Suggest Escalation")).toBeInTheDocument();
+    expect(screen.getByText("Request Evidence")).toBeInTheDocument();
+    expect(screen.getAllByText("Review explanation").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Human approval required").length).toBeGreaterThan(0);
     expect(screen.getByText("Review context")).toBeInTheDocument();
     expect(screen.getByText("Prepare reminder")).toBeInTheDocument();
     expect(screen.getByText("Prepare notice")).toBeInTheDocument();
@@ -320,6 +402,7 @@ describe("DecisionInboxPage", () => {
           summary: { total: 1, critical: 1, high: 0, open: 1, blocked: 0 },
           workflowSummary: { new: 0, underReview: 0, escalated: 1, critical: 1 },
           automationSummary: { total: 1, pending: 1, derived: 0, blocked: 0, completed: 0, escalationFlagged: 1, reviewRequired: 1 },
+          agentActionSummary: { total: 1, suggested: 1, blocked: 0, unavailable: 0, acknowledged: 0, reviewRequired: 1, escalationSuggested: 1 },
         })
       );
 
@@ -351,6 +434,7 @@ describe("DecisionInboxPage", () => {
         summary: { total: 1, critical: 0, high: 1, open: 0, blocked: 1 },
         workflowSummary: { new: 0, underReview: 0, escalated: 0, critical: 0 },
         automationSummary: { total: 1, pending: 0, derived: 0, blocked: 1, completed: 0, escalationFlagged: 1, reviewRequired: 1 },
+        agentActionSummary: { total: 1, suggested: 0, blocked: 1, unavailable: 0, acknowledged: 0, reviewRequired: 1, escalationSuggested: 0 },
       })
     );
     fireEvent.change(screen.getByLabelText("Queue"), { target: { value: "maintenance_review" } });
@@ -369,6 +453,7 @@ describe("DecisionInboxPage", () => {
         summary: { total: 0, critical: 0, high: 0, open: 0, blocked: 0 },
         workflowSummary: { new: 0, underReview: 0, escalated: 0, critical: 0 },
         automationSummary: { total: 0, pending: 0, derived: 0, blocked: 0, completed: 0, escalationFlagged: 0, reviewRequired: 0 },
+        agentActionSummary: { total: 0, suggested: 0, blocked: 0, unavailable: 0, acknowledged: 0, reviewRequired: 0, escalationSuggested: 0 },
       })
     );
 

--- a/rentchain-frontend/src/pages/DecisionInboxPage.tsx
+++ b/rentchain-frontend/src/pages/DecisionInboxPage.tsx
@@ -16,6 +16,7 @@ import type { OperatorReviewEvidenceReference, OperatorReviewScope } from "@/api
 import { evidencePackPath } from "@/api/evidencePackApi";
 import { reviewTimelinePath } from "@/api/reviewTimelineApi";
 import { MacShell } from "@/components/layout/MacShell";
+import { AgentActionPanel } from "@/components/agentActions/AgentActionPanel";
 import { OperatorReviewSessionPanel } from "@/components/operatorReviews/OperatorReviewSessionPanel";
 import { Card, Section } from "@/components/ui/Ui";
 import { useToast } from "@/components/ui/ToastProvider";
@@ -310,6 +311,7 @@ function DecisionInboxCard({ item }: { item: DecisionInboxItem }) {
           </div>
         </div>
       ) : null}
+      <AgentActionPanel actions={item.agentActions} />
       <OperatorReviewSessionPanel
         scope={reviewScope}
         scopeId={item.id}
@@ -431,6 +433,10 @@ export default function DecisionInboxPage() {
                 ["Review required", data.automationSummary.reviewRequired],
                 ["Escalation flags", data.automationSummary.escalationFlagged],
                 ["Blocked orchestration", data.automationSummary.blocked],
+                ["Agent suggestions", data.agentActionSummary.total],
+                ["Suggested actions", data.agentActionSummary.suggested],
+                ["Blocked suggestions", data.agentActionSummary.blocked],
+                ["Suggestion review required", data.agentActionSummary.reviewRequired],
               ].map(([name, value]) => (
                 <Card key={String(name)} style={{ borderRadius: 8, padding: 12 }}>
                   <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>{name}</div>


### PR DESCRIPTION
## Summary
- Adds deterministic, policy-gated agent action suggestion scaffolding.
- Adds backend agent action models, policy guards, derivation helpers, and a landlord-scoped suggestions endpoint: `GET /api/landlord/agent-actions/suggestions`.
- Additively includes `agentActions` and `agentActionSummary` in the landlord Decision Inbox read model.
- Adds Decision Inbox UI panels for suggested actions, blocked reasons, policy-guard badges, and manual-review visibility.
- Adds architecture documentation for policy-gated agent actions.

## Guardrails
- Suggestions remain operator-visible recommendations only.
- `manualReviewRequired` and `requiresHumanApproval` remain true.
- `policyGuarded` remains true.
- `externalExecutionEnabled` remains false.
- No communication, payment, legal, export, certification, notification, worker/queue, autonomous agent, or source-record mutation behavior was added.
- No sensitive tenant/payment/screening payload exposure or admin-only landlord-route leakage was introduced.

## Verification
- Backend targeted tests passed: `pnpm exec vitest run src/lib/agentActions/__tests__/derivePolicyGatedAgentActions.test.ts src/routes/__tests__/landlordDecisionInboxRoutes.test.ts` (11 tests).
- Frontend targeted tests passed: `pnpm exec vitest run src/components/agentActions/AgentActionPanel.test.tsx src/pages/DecisionInboxPage.test.tsx` (5 tests).
- Backend build passed.
- Frontend build passed with existing chunk-size warning.
- `git diff --check` passed.
- Dependency/lockfile diff empty.
- Forbidden UI label scan over touched UI files returned no matches.