### PR TITLE
feat: add agent supervision console

### DIFF
--- a/docs/architecture/agent-supervision-console-v1.md
+++ b/docs/architecture/agent-supervision-console-v1.md
@@ -1,0 +1,78 @@
+# Agent Supervision Console v1
+
+## Purpose
+
+Agent Supervision Console v1 adds a deterministic, landlord-scoped supervision surface for RentChain's controlled agentic infrastructure.
+
+The console centralizes visibility into:
+
+- automated workflow previews
+- policy-gated agent suggestions
+- blocked policy guards
+- escalation indicators
+- workflow synchronization issues
+- review, evidence, timeline, and readiness references
+
+## Read-Only Scope
+
+This layer is read-only and supervision-oriented. It does not execute actions, communicate externally, submit exports, certify compliance, trigger payment movement, or mutate source-of-truth records.
+
+Required flags remain:
+
+- `manualReviewRequired: true`
+- `policyGuarded: true`
+- `requiresHumanApproval: true`
+- `externalExecutionEnabled: false`
+- `autonomousExecutionEnabled: false`
+
+## Derivation
+
+The backend derives an `AgentSupervisionSnapshot` from the existing Decision Inbox read model. It reuses:
+
+- decision workflow routing
+- automated workflow previews
+- policy-gated agent action suggestions
+- escalation metadata
+- existing evidence and timeline routes
+
+No new decision engine, workflow engine, queue infrastructure, worker, or autonomous agent is introduced.
+
+## Endpoint
+
+`GET /api/landlord/agent-supervision/snapshot`
+
+The endpoint is landlord-scoped through existing authentication and landlord middleware. It returns a deterministic snapshot with summary counts and grouped supervision items.
+
+## Canonical Events
+
+V1 exposes additive event descriptors only:
+
+- `agent_supervision_snapshot_generated`
+- `agent_supervision_escalation_visible`
+- `agent_supervision_review_required`
+- `agent_supervision_policy_guard_visible`
+- `agent_supervision_acknowledgement_visible`
+
+These are traceability descriptors in the snapshot. V1 does not persist or execute event side effects.
+
+## UI
+
+The frontend adds `/agent-supervision`, a read-only console showing:
+
+- supervision summary cards
+- suggested action visibility
+- workflow synchronization visibility
+- blocked policy guards
+- escalation indicators
+- review, evidence, and timeline references
+
+The UI intentionally contains no execution, approval, communication, payment, legal, export, certification, or autonomous-mode controls.
+
+## Deferred
+
+- acknowledgement persistence
+- centralized agent supervision inbox filters
+- admin-only supervision surfaces
+- agent supervision audit timeline persistence
+- policy-gated agent action execution
+- supervised automation controls

--- a/rentchain-api/src/lib/agentSupervision/__tests__/deriveAgentSupervisionSnapshot.test.ts
+++ b/rentchain-api/src/lib/agentSupervision/__tests__/deriveAgentSupervisionSnapshot.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+import { deriveAgentSupervisionSnapshot } from "../deriveAgentSupervisionSnapshot";
+
+function decision(overrides: Record<string, any> = {}) {
+  return {
+    id: "decision-1",
+    title: "Review Missing Payment",
+    description: "Expected rent payment is missing.",
+    severity: "critical",
+    destination: "/leases/lease-1/ledger",
+    workflow: {
+      queue: "delinquency_review",
+      workflowState: "escalated",
+      escalationLevel: "critical",
+      reviewPriority: "critical",
+      manualOnly: true,
+    },
+    automatedWorkflow: {
+      automationId: "automated-workflow-1",
+      status: "pending",
+      transition: { fromState: "escalated", toState: "escalated" },
+      blockedReasons: [],
+      reasons: ["Decision is routed to delinquency review."],
+      canonicalEvents: [
+        {
+          eventType: "automated_workflow_review_required",
+          action: "review_required",
+          status: "pending",
+          resourceType: "decision",
+          resourceId: "decision-1",
+          summary: "Human acknowledgement remains required.",
+        },
+      ],
+      generatedAt: "2026-05-06T12:00:00.000Z",
+    },
+    agentActions: [
+      {
+        agentActionId: "agent-action-1",
+        actionType: "suggest_escalation",
+        status: "suggested",
+        manualReviewRequired: true,
+        policyGuarded: true,
+        externalExecutionEnabled: false,
+        requiresHumanApproval: true,
+        explanation: {
+          summary: "Escalation review is recommended.",
+          reasons: ["Escalation metadata indicates elevated priority."],
+          blockedReasons: [],
+        },
+        relatedScope: { scope: "decision", scopeId: "decision-1" },
+        canonicalEvents: [
+          {
+            eventType: "policy_gated_agent_action_suggested",
+            action: "suggest_escalation",
+            status: "suggested",
+            resourceType: "decision",
+            resourceId: "decision-1",
+            summary: "Suggestion is available.",
+          },
+        ],
+        generatedAt: "2026-05-06T12:00:00.000Z",
+      },
+    ],
+    createdAt: "2026-05-06T12:00:00.000Z",
+    updatedAt: "2026-05-06T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("deriveAgentSupervisionSnapshot", () => {
+  it("derives deterministic supervision visibility from existing workflow and agent action metadata", () => {
+    const snapshot = deriveAgentSupervisionSnapshot({
+      generatedAt: "2026-05-06T12:00:00.000Z",
+      decisions: [decision()],
+    });
+
+    expect(snapshot).toEqual(
+      expect.objectContaining({
+        manualReviewRequired: true,
+        externalExecutionEnabled: false,
+        autonomousExecutionEnabled: false,
+      })
+    );
+    expect(snapshot.summary).toEqual(
+      expect.objectContaining({
+        suggestedActions: 1,
+        blockedActions: 0,
+        escalations: 1,
+        workflowSyncIssues: 0,
+      })
+    );
+    expect(snapshot.agentActions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          itemType: "agent_action",
+          status: "suggested",
+          policyGuarded: true,
+          manualReviewRequired: true,
+          requiresHumanApproval: true,
+          destination: "/leases/lease-1/ledger",
+        }),
+      ])
+    );
+    expect(snapshot.workflowStates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          itemType: "workflow_transition",
+          status: "pending_review",
+          relatedScope: { scope: "workflow", scopeId: "decision-1" },
+        }),
+      ])
+    );
+    expect(snapshot.escalations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          itemType: "escalation",
+          severity: "critical",
+          status: "pending_review",
+        }),
+      ])
+    );
+    expect(snapshot.canonicalEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ eventType: "agent_supervision_snapshot_generated" }),
+        expect.objectContaining({ eventType: "agent_supervision_escalation_visible" }),
+      ])
+    );
+    expect(JSON.stringify(snapshot)).not.toMatch(/externalExecutionEnabled":true|autonomousExecutionEnabled":true|executed":true/i);
+  });
+
+  it("surfaces blocked policy guards and workflow synchronization issues", () => {
+    const snapshot = deriveAgentSupervisionSnapshot({
+      generatedAt: "2026-05-06T12:00:00.000Z",
+      decisions: [
+        decision({
+          severity: "high",
+          workflow: {
+            queue: "maintenance_review",
+            workflowState: "waiting_context",
+            escalationLevel: "urgent",
+            reviewPriority: "high",
+            manualOnly: true,
+          },
+          automatedWorkflow: {
+            automationId: "automated-workflow-2",
+            status: "blocked",
+            transition: { fromState: "waiting_context", toState: "waiting_context" },
+            blockedReasons: ["Required workflow context is missing or incomplete."],
+            reasons: ["Decision is waiting for context."],
+            canonicalEvents: [],
+            generatedAt: "2026-05-06T12:00:00.000Z",
+          },
+          agentActions: [
+            {
+              agentActionId: "agent-action-2",
+              actionType: "request_evidence",
+              status: "blocked",
+              manualReviewRequired: true,
+              policyGuarded: true,
+              externalExecutionEnabled: false,
+              requiresHumanApproval: true,
+              explanation: {
+                summary: "Request additional evidence.",
+                reasons: ["Workflow context is blocked."],
+                blockedReasons: ["Required workflow context is missing or incomplete."],
+              },
+              relatedScope: { scope: "evidence_pack", scopeId: "decision-1" },
+              canonicalEvents: [],
+              generatedAt: "2026-05-06T12:00:00.000Z",
+            },
+          ],
+        }),
+      ],
+    });
+
+    expect(snapshot.summary).toEqual(
+      expect.objectContaining({
+        blockedActions: 1,
+        escalations: 1,
+        workflowSyncIssues: 1,
+      })
+    );
+    expect(snapshot.policyGuardResults).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          status: "blocked",
+          blockedReasons: ["Required workflow context is missing or incomplete."],
+        }),
+      ])
+    );
+    expect(snapshot.workflowStates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          itemType: "synchronization_issue",
+          status: "blocked",
+          blockedReasons: ["Required workflow context is missing or incomplete."],
+        }),
+      ])
+    );
+  });
+});

--- a/rentchain-api/src/lib/agentSupervision/agentSupervisionPolicyGuards.ts
+++ b/rentchain-api/src/lib/agentSupervision/agentSupervisionPolicyGuards.ts
@@ -1,0 +1,12 @@
+import type { AgentSupervisionItem } from "./agentSupervisionTypes";
+
+export function enforceAgentSupervisionPolicyFlags<T extends Omit<AgentSupervisionItem, "policyGuarded" | "manualReviewRequired" | "requiresHumanApproval">>(
+  item: T
+): T & Pick<AgentSupervisionItem, "policyGuarded" | "manualReviewRequired" | "requiresHumanApproval"> {
+  return {
+    ...item,
+    policyGuarded: true,
+    manualReviewRequired: true,
+    requiresHumanApproval: true,
+  };
+}

--- a/rentchain-api/src/lib/agentSupervision/agentSupervisionTypes.ts
+++ b/rentchain-api/src/lib/agentSupervision/agentSupervisionTypes.ts
@@ -1,0 +1,131 @@
+import type { PolicyGatedAgentActionEvent } from "../agentActions/agentActionTypes";
+import type { AutomatedWorkflowCanonicalEvent } from "../automatedWorkflows/automatedWorkflowTypes";
+
+export type AgentSupervisionItemType =
+  | "agent_action"
+  | "workflow_transition"
+  | "escalation"
+  | "review_requirement"
+  | "policy_guard"
+  | "synchronization_issue";
+
+export type AgentSupervisionStatus =
+  | "suggested"
+  | "blocked"
+  | "pending_review"
+  | "acknowledged"
+  | "synchronized"
+  | "unresolved";
+
+export type AgentSupervisionSeverity = "critical" | "high" | "medium" | "low" | "info";
+
+export type AgentSupervisionScope = "decision" | "workflow" | "review" | "evidence_pack" | "export" | "audit_compliance";
+
+export type AgentSupervisionCanonicalEventType =
+  | "agent_supervision_snapshot_generated"
+  | "agent_supervision_escalation_visible"
+  | "agent_supervision_review_required"
+  | "agent_supervision_policy_guard_visible"
+  | "agent_supervision_acknowledgement_visible";
+
+export type AgentSupervisionCanonicalEvent = {
+  eventType: AgentSupervisionCanonicalEventType;
+  action: string;
+  status: AgentSupervisionStatus;
+  resourceType: AgentSupervisionScope;
+  resourceId: string;
+  summary: string;
+};
+
+export type AgentSupervisionRelatedScope = {
+  scope: AgentSupervisionScope;
+  scopeId: string;
+};
+
+export type AgentSupervisionItem = {
+  supervisionItemId: string;
+  itemType: AgentSupervisionItemType;
+  status: AgentSupervisionStatus;
+  severity: AgentSupervisionSeverity;
+  label: string;
+  description: string;
+  policyGuarded: true;
+  manualReviewRequired: true;
+  requiresHumanApproval: true;
+  blockedReasons: string[];
+  relatedScope: AgentSupervisionRelatedScope;
+  destination: string | null;
+  timestamp: string;
+  canonicalEvents: AgentSupervisionCanonicalEvent[];
+};
+
+export type AgentSupervisionSnapshotSummary = {
+  suggestedActions: number;
+  blockedActions: number;
+  pendingReviews: number;
+  escalations: number;
+  workflowSyncIssues: number;
+};
+
+export type AgentSupervisionSnapshot = {
+  supervisionSnapshotId: string;
+  generatedAt: string;
+  manualReviewRequired: true;
+  externalExecutionEnabled: false;
+  autonomousExecutionEnabled: false;
+  summary: AgentSupervisionSnapshotSummary;
+  agentActions: AgentSupervisionItem[];
+  workflowStates: AgentSupervisionItem[];
+  policyGuardResults: AgentSupervisionItem[];
+  escalations: AgentSupervisionItem[];
+  reviewReferences: AgentSupervisionItem[];
+  evidenceReferences: AgentSupervisionItem[];
+  timelineReferences: AgentSupervisionItem[];
+  canonicalEvents: Array<AgentSupervisionCanonicalEvent | PolicyGatedAgentActionEvent | AutomatedWorkflowCanonicalEvent>;
+};
+
+export type DeriveAgentSupervisionSnapshotInput = {
+  decisions?: Array<{
+    id: string;
+    title: string;
+    description: string;
+    severity: string;
+    destination: string | null;
+    workflow: {
+      queue: string;
+      workflowState: string;
+      escalationLevel: string;
+      reviewPriority: string;
+      manualOnly: true;
+    };
+    automatedWorkflow?: {
+      automationId: string;
+      status: string;
+      transition: { fromState: string; toState: string };
+      blockedReasons: string[];
+      reasons: string[];
+      canonicalEvents: AutomatedWorkflowCanonicalEvent[];
+      generatedAt: string;
+    };
+    agentActions?: Array<{
+      agentActionId: string;
+      actionType: string;
+      status: string;
+      policyGuarded: true;
+      manualReviewRequired: true;
+      externalExecutionEnabled: false;
+      requiresHumanApproval: true;
+      explanation: {
+        summary: string;
+        reasons: string[];
+        blockedReasons: string[];
+      };
+      relatedScope: { scope: string; scopeId: string };
+      canonicalEvents: PolicyGatedAgentActionEvent[];
+      generatedAt: string;
+    }>;
+    createdAt?: string | null;
+    updatedAt?: string | null;
+  }> | null;
+  generatedAt?: string | Date | null;
+};

--- a/rentchain-api/src/lib/agentSupervision/deriveAgentSupervisionSnapshot.ts
+++ b/rentchain-api/src/lib/agentSupervision/deriveAgentSupervisionSnapshot.ts
@@ -1,0 +1,261 @@
+import { enforceAgentSupervisionPolicyFlags } from "./agentSupervisionPolicyGuards";
+import type {
+  AgentSupervisionCanonicalEvent,
+  AgentSupervisionItem,
+  AgentSupervisionSeverity,
+  AgentSupervisionSnapshot,
+  AgentSupervisionStatus,
+  DeriveAgentSupervisionSnapshotInput,
+} from "./agentSupervisionTypes";
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function cleanId(value: unknown): string {
+  return asString(value, 800)
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function generatedAt(value: unknown): string {
+  const raw = asString(value, 120);
+  const parsed = raw ? new Date(raw) : new Date();
+  return Number.isNaN(parsed.getTime()) ? new Date().toISOString() : parsed.toISOString();
+}
+
+function severityFromDecision(value: unknown): AgentSupervisionSeverity {
+  const severity = asString(value, 40);
+  if (severity === "critical") return "critical";
+  if (severity === "high") return "high";
+  if (severity === "medium") return "medium";
+  if (severity === "low") return "low";
+  return "info";
+}
+
+function severityFromEscalation(value: unknown, fallback: AgentSupervisionSeverity): AgentSupervisionSeverity {
+  const escalation = asString(value, 40);
+  if (escalation === "critical") return "critical";
+  if (escalation === "urgent") return "high";
+  if (escalation === "attention") return fallback === "info" ? "medium" : fallback;
+  return fallback;
+}
+
+function actionStatus(value: unknown): AgentSupervisionStatus {
+  const status = asString(value, 40);
+  if (status === "blocked") return "blocked";
+  if (status === "acknowledged") return "acknowledged";
+  if (status === "suggested") return "suggested";
+  return "unresolved";
+}
+
+function workflowStatus(value: unknown): AgentSupervisionStatus {
+  const status = asString(value, 40);
+  if (status === "blocked") return "blocked";
+  if (status === "completed" || status === "derived") return "synchronized";
+  if (status === "pending") return "pending_review";
+  return "unresolved";
+}
+
+function supervisionEvent(input: {
+  eventType: AgentSupervisionCanonicalEvent["eventType"];
+  action: string;
+  status: AgentSupervisionStatus;
+  resourceType: AgentSupervisionCanonicalEvent["resourceType"];
+  resourceId: string;
+  summary: string;
+}): AgentSupervisionCanonicalEvent {
+  return input;
+}
+
+function agentActionItem(decision: NonNullable<DeriveAgentSupervisionSnapshotInput["decisions"]>[number], action: NonNullable<NonNullable<DeriveAgentSupervisionSnapshotInput["decisions"]>[number]["agentActions"]>[number], generated: string): AgentSupervisionItem {
+  const blockedReasons = action.explanation?.blockedReasons || [];
+  const status = actionStatus(action.status);
+  return enforceAgentSupervisionPolicyFlags({
+    supervisionItemId: cleanId(`agent_supervision:agent_action:${action.agentActionId}`) || "agent_supervision:agent_action:unknown",
+    itemType: "agent_action",
+    status,
+    severity: severityFromEscalation(decision.workflow.escalationLevel, severityFromDecision(decision.severity)),
+    label: action.actionType.replace(/_/g, " "),
+    description: action.explanation?.summary || "Policy-gated agent suggestion is available for review.",
+    blockedReasons,
+    relatedScope: { scope: "decision", scopeId: decision.id },
+    destination: decision.destination,
+    timestamp: action.generatedAt || generated,
+    canonicalEvents: [
+      supervisionEvent({
+        eventType: status === "blocked" ? "agent_supervision_policy_guard_visible" : "agent_supervision_review_required",
+        action: action.actionType,
+        status,
+        resourceType: "decision",
+        resourceId: decision.id,
+        summary: status === "blocked"
+          ? "Policy guard block is visible in the agent supervision console."
+          : "Agent suggestion remains visible for manual review.",
+      }),
+    ],
+  });
+}
+
+function workflowItem(decision: NonNullable<DeriveAgentSupervisionSnapshotInput["decisions"]>[number], generated: string): AgentSupervisionItem | null {
+  const workflow = decision.automatedWorkflow;
+  if (!workflow) return null;
+  const status = workflowStatus(workflow.status);
+  return enforceAgentSupervisionPolicyFlags({
+    supervisionItemId: cleanId(`agent_supervision:workflow:${workflow.automationId}`) || "agent_supervision:workflow:unknown",
+    itemType: workflow.status === "blocked" ? "synchronization_issue" : "workflow_transition",
+    status,
+    severity: severityFromEscalation(decision.workflow.escalationLevel, severityFromDecision(decision.severity)),
+    label: `Workflow ${workflow.transition.fromState} to ${workflow.transition.toState}`.replace(/_/g, " "),
+    description: workflow.reasons?.[0] || "Deterministic workflow state is visible for supervision.",
+    blockedReasons: workflow.blockedReasons || [],
+    relatedScope: { scope: "workflow", scopeId: decision.id },
+    destination: decision.destination,
+    timestamp: workflow.generatedAt || generated,
+    canonicalEvents: [
+      supervisionEvent({
+        eventType: workflow.status === "blocked" ? "agent_supervision_policy_guard_visible" : "agent_supervision_snapshot_generated",
+        action: workflow.status === "blocked" ? "workflow_block_visible" : "workflow_state_visible",
+        status,
+        resourceType: "workflow",
+        resourceId: decision.id,
+        summary: workflow.status === "blocked"
+          ? "Workflow synchronization issue is visible for manual review."
+          : "Workflow state is visible in the supervision snapshot.",
+      }),
+    ],
+  });
+}
+
+function escalationItem(decision: NonNullable<DeriveAgentSupervisionSnapshotInput["decisions"]>[number], generated: string): AgentSupervisionItem | null {
+  if (decision.workflow.escalationLevel !== "critical" && decision.workflow.escalationLevel !== "urgent") return null;
+  return enforceAgentSupervisionPolicyFlags({
+    supervisionItemId: cleanId(`agent_supervision:escalation:${decision.id}:${decision.workflow.escalationLevel}`) || "agent_supervision:escalation:unknown",
+    itemType: "escalation",
+    status: "pending_review",
+    severity: decision.workflow.escalationLevel === "critical" ? "critical" : "high",
+    label: `${decision.workflow.escalationLevel} escalation`.replace(/_/g, " "),
+    description: `${decision.title} requires elevated manual review visibility.`,
+    blockedReasons: [],
+    relatedScope: { scope: "decision", scopeId: decision.id },
+    destination: decision.destination,
+    timestamp: decision.updatedAt || decision.createdAt || generated,
+    canonicalEvents: [
+      supervisionEvent({
+        eventType: "agent_supervision_escalation_visible",
+        action: "escalation_visible",
+        status: "pending_review",
+        resourceType: "decision",
+        resourceId: decision.id,
+        summary: "Escalation is visible for supervised manual review.",
+      }),
+    ],
+  });
+}
+
+function referenceItem(input: {
+  decisionId: string;
+  title: string;
+  kind: "review" | "evidence_pack" | "audit_compliance";
+  destination: string | null;
+  timestamp: string;
+}): AgentSupervisionItem {
+  return enforceAgentSupervisionPolicyFlags({
+    supervisionItemId: cleanId(`agent_supervision:${input.kind}:${input.decisionId}`) || `agent_supervision:${input.kind}:unknown`,
+    itemType: "review_requirement",
+    status: "pending_review",
+    severity: "info",
+    label: input.kind.replace(/_/g, " "),
+    description: `${input.title} has related ${input.kind.replace(/_/g, " ")} context available for supervision.`,
+    blockedReasons: [],
+    relatedScope: { scope: input.kind, scopeId: input.decisionId },
+    destination: input.destination,
+    timestamp: input.timestamp,
+    canonicalEvents: [
+      supervisionEvent({
+        eventType: "agent_supervision_review_required",
+        action: `${input.kind}_visible`,
+        status: "pending_review",
+        resourceType: input.kind,
+        resourceId: input.decisionId,
+        summary: "Related review context is visible in the supervision snapshot.",
+      }),
+    ],
+  });
+}
+
+export function deriveAgentSupervisionSnapshot(input: DeriveAgentSupervisionSnapshotInput): AgentSupervisionSnapshot {
+  const generated = generatedAt(input.generatedAt);
+  const decisions = input.decisions || [];
+  const agentActions = decisions.flatMap((decision) =>
+    (decision.agentActions || []).map((action) => agentActionItem(decision, action, generated))
+  );
+  const workflowStates = decisions.map((decision) => workflowItem(decision, generated)).filter(Boolean) as AgentSupervisionItem[];
+  const escalations = decisions.map((decision) => escalationItem(decision, generated)).filter(Boolean) as AgentSupervisionItem[];
+  const reviewReferences = decisions.map((decision) =>
+    referenceItem({
+      decisionId: decision.id,
+      title: decision.title,
+      kind: "review",
+      destination: `/review-timeline?scope=decision&scopeId=${encodeURIComponent(decision.id)}`,
+      timestamp: decision.updatedAt || decision.createdAt || generated,
+    })
+  );
+  const evidenceReferences = decisions.map((decision) =>
+    referenceItem({
+      decisionId: decision.id,
+      title: decision.title,
+      kind: "evidence_pack",
+      destination: `/evidence-packs?scope=decision&scopeId=${encodeURIComponent(decision.id)}`,
+      timestamp: decision.updatedAt || decision.createdAt || generated,
+    })
+  );
+  const timelineReferences = decisions.map((decision) =>
+    referenceItem({
+      decisionId: decision.id,
+      title: decision.title,
+      kind: "audit_compliance",
+      destination: "/audit-compliance",
+      timestamp: decision.updatedAt || decision.createdAt || generated,
+    })
+  );
+  const policyGuardResults = agentActions.filter((item) => item.status === "blocked");
+  const canonicalEvents = [
+    supervisionEvent({
+      eventType: "agent_supervision_snapshot_generated",
+      action: "snapshot_generated",
+      status: "synchronized",
+      resourceType: "workflow",
+      resourceId: "agent_supervision",
+      summary: "Agent supervision snapshot generated for read-only manual review.",
+    }),
+    ...agentActions.flatMap((item) => item.canonicalEvents),
+    ...workflowStates.flatMap((item) => item.canonicalEvents),
+    ...escalations.flatMap((item) => item.canonicalEvents),
+  ];
+
+  return {
+    supervisionSnapshotId: cleanId(`agent_supervision_snapshot:${generated}`) || "agent_supervision_snapshot",
+    generatedAt: generated,
+    manualReviewRequired: true,
+    externalExecutionEnabled: false,
+    autonomousExecutionEnabled: false,
+    summary: {
+      suggestedActions: agentActions.filter((item) => item.status === "suggested").length,
+      blockedActions: agentActions.filter((item) => item.status === "blocked").length,
+      pendingReviews: [...agentActions, ...workflowStates, ...reviewReferences].filter((item) => item.status === "pending_review" || item.status === "suggested").length,
+      escalations: escalations.length,
+      workflowSyncIssues: workflowStates.filter((item) => item.itemType === "synchronization_issue" || item.status === "blocked").length,
+    },
+    agentActions,
+    workflowStates,
+    policyGuardResults,
+    escalations,
+    reviewReferences,
+    evidenceReferences,
+    timelineReferences,
+    canonicalEvents,
+  };
+}

--- a/rentchain-api/src/routes/__tests__/landlordDecisionInboxRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordDecisionInboxRoutes.test.ts
@@ -353,6 +353,55 @@ describe("landlordDecisionInboxRoutes", () => {
     expect(JSON.stringify(res.body)).not.toMatch(/externalExecutionEnabled":true|executed":true|charge tenant|file eviction/i);
   });
 
+  it("returns a read-only agent supervision snapshot without execution behavior", async () => {
+    seedLease();
+    const router = (await import("../landlordDecisionInboxRoutes")).default;
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/agent-supervision/snapshot?queue=delinquency_review&escalationLevel=critical",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.manualReviewRequired).toBe(true);
+    expect(res.body.externalExecutionEnabled).toBe(false);
+    expect(res.body.autonomousExecutionEnabled).toBe(false);
+    expect(res.body.summary).toEqual(
+      expect.objectContaining({
+        suggestedActions: 2,
+        blockedActions: 0,
+        escalations: 2,
+      })
+    );
+    expect(res.body.agentActions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          itemType: "agent_action",
+          status: "suggested",
+          policyGuarded: true,
+          manualReviewRequired: true,
+          requiresHumanApproval: true,
+        }),
+      ])
+    );
+    expect(res.body.workflowStates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          status: "pending_review",
+          relatedScope: expect.objectContaining({ scope: "workflow" }),
+        }),
+      ])
+    );
+    expect(res.body.canonicalEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ eventType: "agent_supervision_snapshot_generated" }),
+        expect.objectContaining({ eventType: "agent_supervision_escalation_visible" }),
+      ])
+    );
+    expect(JSON.stringify(res.body)).not.toMatch(/externalExecutionEnabled":true|autonomousExecutionEnabled":true|executed":true|charge tenant|file eviction/i);
+  });
+
   it("blocks non-landlord users", async () => {
     const router = (await import("../landlordDecisionInboxRoutes")).default;
 

--- a/rentchain-api/src/routes/landlordDecisionInboxRoutes.ts
+++ b/rentchain-api/src/routes/landlordDecisionInboxRoutes.ts
@@ -6,6 +6,7 @@ import { loadLandlordAnalyticsSnapshot } from "../services/landlord/landlordAnal
 import { deriveDecisionInbox } from "../lib/decisions/deriveDecisionInbox";
 import { deriveAutomatedWorkflowTransitions } from "../lib/automatedWorkflows/deriveAutomatedWorkflowTransitions";
 import { derivePolicyGatedAgentActions } from "../lib/agentActions/derivePolicyGatedAgentActions";
+import { deriveAgentSupervisionSnapshot } from "../lib/agentSupervision/deriveAgentSupervisionSnapshot";
 import { deriveDecisions, type Decision } from "../lib/decisions/decisionEngine";
 import { applyDecisionActions, DECISION_ACTIONS_COLLECTION } from "../lib/decisions/decisionActions";
 import { deriveLeaseLifecycleState } from "../lib/leases/leaseLifecycle";
@@ -289,6 +290,46 @@ router.get("/agent-actions/suggestions", requireAuth, requireLandlord, async (re
   } catch (err: any) {
     console.error("[landlord-agent-actions] suggestions failed", err?.message || err);
     return res.status(500).json({ ok: false, error: "AGENT_ACTION_SUGGESTIONS_FAILED" });
+  }
+});
+
+router.get("/agent-supervision/snapshot", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = asString(req.user?.landlordId || req.user?.id, 240);
+    if (!landlordId) {
+      return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    }
+
+    const [snapshot, leaseDecisions] = await Promise.all([
+      loadLandlordAnalyticsSnapshot({
+        landlordId,
+        period: req.query?.period,
+        propertyId: req.query?.propertyId,
+      }),
+      deriveLeaseDecisionsForInbox(landlordId),
+    ]);
+
+    const inbox = deriveDecisionInbox({
+      analyticsDecisions: Array.isArray(snapshot?.decisions?.items) ? snapshot.decisions.items : [],
+      leaseDecisions,
+      filters: {
+        severity: req.query?.severity,
+        status: req.query?.decisionStatus,
+        type: req.query?.type,
+        queue: req.query?.queue,
+        workflowState: req.query?.workflowState,
+        escalationLevel: req.query?.escalationLevel,
+      },
+    });
+    const supervision = deriveAgentSupervisionSnapshot({ decisions: inbox.items });
+
+    return res.json({
+      ok: true,
+      ...supervision,
+    });
+  } catch (err: any) {
+    console.error("[landlord-agent-supervision] snapshot failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "AGENT_SUPERVISION_SNAPSHOT_FAILED" });
   }
 });
 

--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -98,6 +98,10 @@ vi.mock("./pages/DecisionInboxPage", () => ({
   default: () => <h1>Decision Inbox Page</h1>,
 }));
 
+vi.mock("./pages/AgentSupervisionPage", () => ({
+  default: () => <h1>Agent Supervision Page</h1>,
+}));
+
 vi.mock("./pages/InstitutionExportsPage", () => ({
   default: () => <h1>Institution Export Preview Page</h1>,
 }));
@@ -249,6 +253,20 @@ describe("Routes: /decision-inbox", () => {
     );
 
     expect(await screen.findByText(/Decision Inbox Page/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Routes: /agent-supervision", () => {
+  it("renders the read-only agent supervision route", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/agent-supervision"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Agent Supervision Page/i)).toBeInTheDocument();
     expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -117,6 +117,7 @@ const PortfolioHealthSummaryPage = lazy(() => import("./pages/landlord/Portfolio
 const LandlordAnalyticsPage = lazy(() => import("./pages/landlord/LandlordAnalyticsPage"));
 const LandlordInboxPage = lazy(() => import("./pages/landlord/LandlordInboxPage"));
 const DecisionInboxPage = lazy(() => import("./pages/DecisionInboxPage"));
+const AgentSupervisionPage = lazy(() => import("./pages/AgentSupervisionPage"));
 const InstitutionExportsPage = lazy(() => import("./pages/InstitutionExportsPage"));
 const AuditCompliancePage = lazy(() => import("./pages/AuditCompliancePage"));
 const EvidencePackPage = lazy(() => import("./pages/EvidencePackPage"));
@@ -516,6 +517,18 @@ function App() {
               <LandlordNav>
                 <Suspense fallback={null}>
                   <DecisionInboxPage />
+                </Suspense>
+              </LandlordNav>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/agent-supervision"
+          element={
+            <RequireAuth>
+              <LandlordNav>
+                <Suspense fallback={null}>
+                  <AgentSupervisionPage />
                 </Suspense>
               </LandlordNav>
             </RequireAuth>

--- a/rentchain-frontend/src/api/agentSupervisionApi.ts
+++ b/rentchain-frontend/src/api/agentSupervisionApi.ts
@@ -1,0 +1,87 @@
+import { apiFetch } from "./apiFetch";
+
+export type AgentSupervisionItemType =
+  | "agent_action"
+  | "workflow_transition"
+  | "escalation"
+  | "review_requirement"
+  | "policy_guard"
+  | "synchronization_issue";
+
+export type AgentSupervisionStatus =
+  | "suggested"
+  | "blocked"
+  | "pending_review"
+  | "acknowledged"
+  | "synchronized"
+  | "unresolved";
+
+export type AgentSupervisionSeverity = "critical" | "high" | "medium" | "low" | "info";
+
+export type AgentSupervisionScope = "decision" | "workflow" | "review" | "evidence_pack" | "export" | "audit_compliance";
+
+export type AgentSupervisionItem = {
+  supervisionItemId: string;
+  itemType: AgentSupervisionItemType;
+  status: AgentSupervisionStatus;
+  severity: AgentSupervisionSeverity;
+  label: string;
+  description: string;
+  policyGuarded: true;
+  manualReviewRequired: true;
+  requiresHumanApproval: true;
+  blockedReasons: string[];
+  relatedScope: {
+    scope: AgentSupervisionScope;
+    scopeId: string;
+  };
+  destination: string | null;
+  timestamp: string;
+};
+
+export type AgentSupervisionSnapshot = {
+  supervisionSnapshotId: string;
+  generatedAt: string;
+  manualReviewRequired: true;
+  externalExecutionEnabled: false;
+  autonomousExecutionEnabled: false;
+  summary: {
+    suggestedActions: number;
+    blockedActions: number;
+    pendingReviews: number;
+    escalations: number;
+    workflowSyncIssues: number;
+  };
+  agentActions: AgentSupervisionItem[];
+  workflowStates: AgentSupervisionItem[];
+  policyGuardResults: AgentSupervisionItem[];
+  escalations: AgentSupervisionItem[];
+  reviewReferences: AgentSupervisionItem[];
+  evidenceReferences: AgentSupervisionItem[];
+  timelineReferences: AgentSupervisionItem[];
+};
+
+export async function fetchAgentSupervisionSnapshot(): Promise<AgentSupervisionSnapshot> {
+  const response = await apiFetch<{ ok: true } & AgentSupervisionSnapshot>("/landlord/agent-supervision/snapshot");
+  return {
+    supervisionSnapshotId: response.supervisionSnapshotId || "agent_supervision_snapshot",
+    generatedAt: response.generatedAt || new Date(0).toISOString(),
+    manualReviewRequired: true,
+    externalExecutionEnabled: false,
+    autonomousExecutionEnabled: false,
+    summary: response.summary || {
+      suggestedActions: 0,
+      blockedActions: 0,
+      pendingReviews: 0,
+      escalations: 0,
+      workflowSyncIssues: 0,
+    },
+    agentActions: response.agentActions || [],
+    workflowStates: response.workflowStates || [],
+    policyGuardResults: response.policyGuardResults || [],
+    escalations: response.escalations || [],
+    reviewReferences: response.reviewReferences || [],
+    evidenceReferences: response.evidenceReferences || [],
+    timelineReferences: response.timelineReferences || [],
+  };
+}

--- a/rentchain-frontend/src/components/agentSupervision/AgentSupervisionConsole.test.tsx
+++ b/rentchain-frontend/src/components/agentSupervision/AgentSupervisionConsole.test.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { AgentSupervisionConsole } from "./AgentSupervisionConsole";
+import type { AgentSupervisionSnapshot } from "@/api/agentSupervisionApi";
+
+function snapshot(): AgentSupervisionSnapshot {
+  const item = {
+    supervisionItemId: "agent-supervision-item-1",
+    itemType: "agent_action" as const,
+    status: "blocked" as const,
+    severity: "critical" as const,
+    label: "request evidence",
+    description: "Additional evidence is required before progressing this workflow.",
+    policyGuarded: true as const,
+    manualReviewRequired: true as const,
+    requiresHumanApproval: true as const,
+    blockedReasons: ["Required workflow context is missing or incomplete."],
+    relatedScope: { scope: "decision" as const, scopeId: "decision-1" },
+    destination: "/decision-inbox",
+    timestamp: "2026-05-06T12:00:00.000Z",
+  };
+  return {
+    supervisionSnapshotId: "snapshot-1",
+    generatedAt: "2026-05-06T12:00:00.000Z",
+    manualReviewRequired: true,
+    externalExecutionEnabled: false,
+    autonomousExecutionEnabled: false,
+    summary: {
+      suggestedActions: 2,
+      blockedActions: 1,
+      pendingReviews: 3,
+      escalations: 1,
+      workflowSyncIssues: 1,
+    },
+    agentActions: [item],
+    workflowStates: [{ ...item, supervisionItemId: "workflow-1", itemType: "synchronization_issue", label: "workflow sync issue" }],
+    policyGuardResults: [{ ...item, supervisionItemId: "policy-1", itemType: "policy_guard", label: "policy guard" }],
+    escalations: [{ ...item, supervisionItemId: "escalation-1", itemType: "escalation", label: "critical escalation" }],
+    reviewReferences: [{ ...item, supervisionItemId: "review-1", itemType: "review_requirement", label: "review lineage" }],
+    evidenceReferences: [{ ...item, supervisionItemId: "evidence-1", itemType: "review_requirement", label: "evidence pack" }],
+    timelineReferences: [{ ...item, supervisionItemId: "timeline-1", itemType: "review_requirement", label: "timeline" }],
+  };
+}
+
+describe("AgentSupervisionConsole", () => {
+  it("renders summary, blocked reasons, links, and required safety copy without mutation controls", () => {
+    render(
+      <MemoryRouter>
+        <AgentSupervisionConsole snapshot={snapshot()} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Supervised operational intelligence only.")).toBeInTheDocument();
+    expect(screen.getByText(/Manual review and approval remain required/i)).toBeInTheDocument();
+    expect(screen.getByText(/No tenant communication, payment action, legal enforcement, or external submission is automated/i)).toBeInTheDocument();
+    expect(screen.getAllByText("Suggested actions").length).toBeGreaterThan(0);
+    expect(screen.getByText("Blocked actions")).toBeInTheDocument();
+    expect(screen.getByText("Pending reviews")).toBeInTheDocument();
+    expect(screen.getAllByText("Escalations").length).toBeGreaterThan(0);
+    expect(screen.getByText("Workflow sync issues")).toBeInTheDocument();
+    expect(screen.getByText("Blocked policy guards")).toBeInTheDocument();
+    expect(screen.getByText("Review lineage")).toBeInTheDocument();
+    expect(screen.getByText("Evidence references")).toBeInTheDocument();
+    expect(screen.getByText("Timeline references")).toBeInTheDocument();
+    expect(screen.getAllByText("Required workflow context is missing or incomplete.").length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("link", { name: "View supervision item" }).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Manual review required").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Policy guarded").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Human approval required").length).toBeGreaterThan(0);
+    expect(screen.queryByRole("button", { name: /execute|auto|approve|submit/i })).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/agentSupervision/AgentSupervisionConsole.tsx
+++ b/rentchain-frontend/src/components/agentSupervision/AgentSupervisionConsole.tsx
@@ -1,0 +1,147 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import type {
+  AgentSupervisionItem,
+  AgentSupervisionSeverity,
+  AgentSupervisionSnapshot,
+  AgentSupervisionStatus,
+} from "@/api/agentSupervisionApi";
+import { Card, Section } from "@/components/ui/Ui";
+
+function label(value: string) {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function severityTone(severity: AgentSupervisionSeverity) {
+  if (severity === "critical") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
+  if (severity === "high") return { color: "#9f1239", background: "#ffe4e6", border: "#fecdd3" };
+  if (severity === "medium") return { color: "#9a3412", background: "#ffedd5", border: "#fed7aa" };
+  if (severity === "low") return { color: "#075985", background: "#e0f2fe", border: "#bae6fd" };
+  return { color: "#334155", background: "#f1f5f9", border: "#cbd5e1" };
+}
+
+function statusTone(status: AgentSupervisionStatus) {
+  if (status === "blocked") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
+  if (status === "pending_review" || status === "suggested") return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
+  if (status === "acknowledged" || status === "synchronized") return { color: "#166534", background: "#dcfce7", border: "#bbf7d0" };
+  return { color: "#475569", background: "#f8fafc", border: "#e2e8f0" };
+}
+
+function Badge({ children, tone }: { children: React.ReactNode; tone: { color: string; background: string; border: string } }) {
+  return (
+    <span
+      style={{
+        border: `1px solid ${tone.border}`,
+        borderRadius: 999,
+        background: tone.background,
+        color: tone.color,
+        padding: "3px 9px",
+        fontSize: 12,
+        fontWeight: 800,
+        whiteSpace: "nowrap",
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+function SupervisionItemCard({ item }: { item: AgentSupervisionItem }) {
+  return (
+    <Card style={{ borderRadius: 8, padding: 12, display: "grid", gap: 8 }}>
+      <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+        <Badge tone={severityTone(item.severity)}>{label(item.severity)}</Badge>
+        <Badge tone={statusTone(item.status)}>{label(item.status)}</Badge>
+        <span style={{ color: "#475569", fontSize: 13, fontWeight: 800 }}>{label(item.itemType)}</span>
+        <span style={{ color: "#64748b", fontSize: 13 }}>
+          Scope: {label(item.relatedScope.scope)} {item.relatedScope.scopeId}
+        </span>
+      </div>
+      <div style={{ display: "grid", gap: 4 }}>
+        <strong style={{ color: "#0f172a" }}>{label(item.label)}</strong>
+        <span style={{ color: "#475569", lineHeight: 1.5 }}>{item.description}</span>
+      </div>
+      {item.blockedReasons.length ? (
+        <div style={{ display: "grid", gap: 4 }}>
+          <strong style={{ color: "#991b1b", fontSize: 13 }}>View blocked reason</strong>
+          {item.blockedReasons.map((reason) => (
+            <span key={reason} style={{ color: "#991b1b", fontSize: 13, fontWeight: 700 }}>
+              {reason}
+            </span>
+          ))}
+        </div>
+      ) : null}
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", color: "#475569", fontSize: 12, fontWeight: 800 }}>
+        <span>Manual review required</span>
+        <span>Policy guarded</span>
+        <span>Human approval required</span>
+      </div>
+      {item.destination ? (
+        <Link to={item.destination} style={{ color: "#2563eb", fontWeight: 800 }}>
+          View supervision item
+        </Link>
+      ) : null}
+    </Card>
+  );
+}
+
+function ItemSection({ title, items }: { title: string; items: AgentSupervisionItem[] }) {
+  if (!items.length) return null;
+  return (
+    <Section style={{ display: "grid", gap: 10 }}>
+      <div style={{ fontWeight: 900, color: "#0f172a" }}>{title}</div>
+      <div style={{ display: "grid", gap: 10 }}>
+        {items.map((item) => (
+          <SupervisionItemCard key={item.supervisionItemId} item={item} />
+        ))}
+      </div>
+    </Section>
+  );
+}
+
+export function AgentSupervisionConsole({ snapshot }: { snapshot: AgentSupervisionSnapshot }) {
+  return (
+    <div style={{ display: "grid", gap: 16 }}>
+      <Section style={{ display: "grid", gap: 8 }}>
+        <div style={{ display: "grid", gap: 4 }}>
+          <strong style={{ color: "#0f172a" }}>Supervised operational intelligence only.</strong>
+          <span style={{ color: "#475569" }}>
+            Manual review and approval remain required. No tenant communication, payment action, legal enforcement, or
+            external submission is automated.
+          </span>
+        </div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap", color: "#475569", fontSize: 12, fontWeight: 900 }}>
+          <span>External execution disabled</span>
+          <span>Autonomous execution disabled</span>
+          <span>Manual review required</span>
+        </div>
+      </Section>
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Supervision summary</div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(145px, 1fr))", gap: 10 }}>
+          {[
+            ["Suggested actions", snapshot.summary.suggestedActions],
+            ["Blocked actions", snapshot.summary.blockedActions],
+            ["Pending reviews", snapshot.summary.pendingReviews],
+            ["Escalations", snapshot.summary.escalations],
+            ["Workflow sync issues", snapshot.summary.workflowSyncIssues],
+          ].map(([name, value]) => (
+            <Card key={String(name)} style={{ borderRadius: 8, padding: 12 }}>
+              <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>{name}</div>
+              <strong style={{ color: "#0f172a", fontSize: 22 }}>{value}</strong>
+            </Card>
+          ))}
+        </div>
+      </Section>
+
+      <ItemSection title="Suggested actions" items={snapshot.agentActions} />
+      <ItemSection title="Workflow synchronization" items={snapshot.workflowStates} />
+      <ItemSection title="Blocked policy guards" items={snapshot.policyGuardResults} />
+      <ItemSection title="Escalations" items={snapshot.escalations} />
+      <ItemSection title="Review lineage" items={snapshot.reviewReferences} />
+      <ItemSection title="Evidence references" items={snapshot.evidenceReferences} />
+      <ItemSection title="Timeline references" items={snapshot.timelineReferences} />
+    </div>
+  );
+}

--- a/rentchain-frontend/src/pages/AgentSupervisionPage.test.tsx
+++ b/rentchain-frontend/src/pages/AgentSupervisionPage.test.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import AgentSupervisionPage from "./AgentSupervisionPage";
+
+const apiMocks = vi.hoisted(() => ({
+  fetchAgentSupervisionSnapshot: vi.fn(),
+  showToast: vi.fn(),
+  macShellProps: vi.fn(),
+}));
+
+vi.mock("@/api/agentSupervisionApi", async () => {
+  const actual = await vi.importActual<any>("@/api/agentSupervisionApi");
+  return {
+    ...actual,
+    fetchAgentSupervisionSnapshot: apiMocks.fetchAgentSupervisionSnapshot,
+  };
+});
+
+vi.mock("@/components/ui/ToastProvider", () => ({
+  useToast: () => ({
+    showToast: apiMocks.showToast,
+  }),
+}));
+
+vi.mock("@/components/layout/MacShell", () => ({
+  MacShell: ({ children, ...props }: { children: React.ReactNode; showTopNav?: boolean }) => {
+    apiMocks.macShellProps(props);
+    return <div>{children}</div>;
+  },
+}));
+
+function snapshot() {
+  const item = {
+    supervisionItemId: "agent-supervision-item-1",
+    itemType: "agent_action",
+    status: "suggested",
+    severity: "critical",
+    label: "suggest escalation",
+    description: "Escalation review is recommended.",
+    policyGuarded: true,
+    manualReviewRequired: true,
+    requiresHumanApproval: true,
+    blockedReasons: [],
+    relatedScope: { scope: "decision", scopeId: "decision-1" },
+    destination: "/review-timeline?scope=decision&scopeId=decision-1",
+    timestamp: "2026-05-06T12:00:00.000Z",
+  };
+  return {
+    supervisionSnapshotId: "snapshot-1",
+    generatedAt: "2026-05-06T12:00:00.000Z",
+    manualReviewRequired: true,
+    externalExecutionEnabled: false,
+    autonomousExecutionEnabled: false,
+    summary: {
+      suggestedActions: 1,
+      blockedActions: 0,
+      pendingReviews: 2,
+      escalations: 1,
+      workflowSyncIssues: 0,
+    },
+    agentActions: [item],
+    workflowStates: [],
+    policyGuardResults: [],
+    escalations: [{ ...item, supervisionItemId: "escalation-1", itemType: "escalation", label: "critical escalation" }],
+    reviewReferences: [],
+    evidenceReferences: [],
+    timelineReferences: [],
+  };
+}
+
+describe("AgentSupervisionPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiMocks.fetchAgentSupervisionSnapshot.mockResolvedValue(snapshot());
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("loads and renders the read-only agent supervision console", async () => {
+    render(
+      <MemoryRouter>
+        <AgentSupervisionPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole("heading", { name: "Agent supervision" })).toBeInTheDocument();
+    expect(apiMocks.fetchAgentSupervisionSnapshot).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("link", { name: "Decision inbox" })).toHaveAttribute("href", "/decision-inbox");
+    expect(screen.getByText("Supervised operational intelligence only.")).toBeInTheDocument();
+    expect(screen.getAllByText("Suggested actions").length).toBeGreaterThan(0);
+    expect(screen.getByText("Critical Escalation")).toBeInTheDocument();
+    expect(screen.getByText(/No tenant communication, payment action, legal enforcement, or external submission is automated/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /execute|auto|approve|submit/i })).not.toBeInTheDocument();
+    expect(apiMocks.macShellProps).toHaveBeenCalledWith(expect.objectContaining({ showTopNav: false }));
+  });
+});

--- a/rentchain-frontend/src/pages/AgentSupervisionPage.tsx
+++ b/rentchain-frontend/src/pages/AgentSupervisionPage.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { fetchAgentSupervisionSnapshot, type AgentSupervisionSnapshot } from "@/api/agentSupervisionApi";
+import { AgentSupervisionConsole } from "@/components/agentSupervision/AgentSupervisionConsole";
+import { MacShell } from "@/components/layout/MacShell";
+import { Card, Section } from "@/components/ui/Ui";
+import { useToast } from "@/components/ui/ToastProvider";
+
+function errorMessage(error: unknown) {
+  if (error instanceof Error && error.message) return error.message;
+  return "Failed to load agent supervision snapshot";
+}
+
+export default function AgentSupervisionPage() {
+  const { showToast } = useToast();
+  const [data, setData] = React.useState<AgentSupervisionSnapshot | null>(null);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const snapshot = await fetchAgentSupervisionSnapshot();
+        if (mounted) setData(snapshot);
+      } catch (err) {
+        if (!mounted) return;
+        const message = errorMessage(err);
+        setError(message);
+        showToast({ message: "Failed to load agent supervision", description: message, variant: "error" });
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [showToast]);
+
+  return (
+    <MacShell title="Agent supervision" showTopNav={false}>
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "start" }}>
+            <div style={{ display: "grid", gap: 6 }}>
+              <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Agent supervision</h1>
+              <div style={{ color: "#475569", maxWidth: 900 }}>
+                A read-only control tower for workflow previews, policy-gated suggestions, blocked states, escalation
+                visibility, and review lineage.
+              </div>
+            </div>
+            <Link to="/decision-inbox" style={{ color: "#2563eb", fontWeight: 800 }}>
+              Decision inbox
+            </Link>
+          </div>
+        </Section>
+
+        {loading ? <Card>Loading agent supervision...</Card> : null}
+        {!loading && error ? <Card style={{ color: "#b91c1c" }}>{error}</Card> : null}
+        {!loading && !error && data ? <AgentSupervisionConsole snapshot={data} /> : null}
+      </div>
+    </MacShell>
+  );
+}

--- a/rentchain-frontend/src/pages/DecisionInboxPage.test.tsx
+++ b/rentchain-frontend/src/pages/DecisionInboxPage.test.tsx
@@ -328,6 +328,7 @@ describe("DecisionInboxPage", () => {
       "href",
       "/institution-exports"
     );
+    expect(screen.getByRole("link", { name: "Agent supervision" })).toHaveAttribute("href", "/agent-supervision");
     expect(screen.getByText("Summary")).toBeInTheDocument();
     expect(screen.getAllByText("Critical").length).toBeGreaterThan(0);
     expect(screen.getAllByText("High").length).toBeGreaterThan(0);

--- a/rentchain-frontend/src/pages/DecisionInboxPage.tsx
+++ b/rentchain-frontend/src/pages/DecisionInboxPage.tsx
@@ -412,6 +412,9 @@ export default function DecisionInboxPage() {
             <Link to="/institution-exports" style={{ color: "#2563eb", fontWeight: 800 }}>
               Institution export preview
             </Link>
+            <Link to="/agent-supervision" style={{ color: "#2563eb", fontWeight: 800 }}>
+              Agent supervision
+            </Link>
           </div>
         </Section>
 


### PR DESCRIPTION
## Summary
- Adds deterministic, landlord-scoped Agent Supervision Snapshot derivation.
- Adds backend endpoint: `GET /api/landlord/agent-supervision/snapshot`.
- Adds frontend API helper, reusable `AgentSupervisionConsole`, and `/agent-supervision` page.
- Links Decision Inbox to the Agent Supervision Console.
- Adds architecture documentation for Agent Supervision Console v1.

## Supervision scope
- Centralizes visibility into automated workflow previews, policy-gated agent suggestions, blocked policy guards, escalation indicators, workflow sync issues, review lineage, evidence references, and timeline/readiness references.
- Required safety flags remain enforced: `manualReviewRequired: true`, `policyGuarded: true`, `requiresHumanApproval: true`, `externalExecutionEnabled: false`, and `autonomousExecutionEnabled: false`.
- Canonical supervision events are additive descriptors only.

## Guardrails
- No execution endpoints or controls were added.
- No communication, payment, legal, export, certification, notification, worker/queue, autonomous agent, or source-record mutation behavior was added.
- No sensitive tenant/payment/screening payload exposure or admin-only landlord-route leakage was introduced.
- Forbidden UI labels/buttons are absent from touched UI.

## Verification
- Backend focused tests passed: `pnpm exec vitest run src/lib/agentSupervision/__tests__/deriveAgentSupervisionSnapshot.test.ts src/routes/__tests__/landlordDecisionInboxRoutes.test.ts` (9 tests).
- Frontend focused tests passed: `pnpm exec vitest run src/components/agentSupervision/AgentSupervisionConsole.test.tsx src/pages/AgentSupervisionPage.test.tsx src/pages/DecisionInboxPage.test.tsx src/App.routes.test.tsx` (35 tests).
- Backend build passed.
- Frontend build passed with existing chunk-size warning.
- `git diff --check` passed.
- Dependency/lockfile diff empty.
- Forbidden UI label scan over touched UI files returned no matches.