### PR TITLE
docs: add v0.9.0 core foundation release checkpoint

### DIFF
--- a/docs/architecture/architectural-drift-freeze-v0.9.0.md
+++ b/docs/architecture/architectural-drift-freeze-v0.9.0.md
@@ -1,0 +1,100 @@
+# Architectural Drift Freeze Guidance — v0.9.0-core-foundation
+
+## Purpose
+
+This guidance protects the stable foundation established by `v0.9.0-core-foundation`. Future missions should extend the existing foundation instead of creating parallel systems or bypassing safety controls.
+
+This is internal architecture guidance, not public launch certification, legal compliance certification, or institutional approval.
+
+## Stable Foundation Systems
+
+Protect and extend these systems:
+
+- decision inbox
+- workflow routing
+- delinquency action scaffolding
+- institution export preview
+- audit/compliance readiness
+- operator review sessions
+- evidence packs
+- canonical review timeline
+- automated workflow previews
+- policy-gated agent actions
+- agent supervision console
+
+## Extension Rules
+
+- Extend existing systems before creating new systems.
+- Keep deterministic derivation logic centralized.
+- Preserve landlord/admin permission boundaries.
+- Preserve manual review requirements.
+- Preserve policy guard checks.
+- Preserve audit and review lineage.
+- Preserve redaction-aware evidence and export behavior.
+- Keep external execution disabled unless a mission explicitly authorizes controlled execution.
+
+## What Must Not Be Duplicated
+
+- Do not create a parallel decision inbox.
+- Do not create a parallel workflow routing layer.
+- Do not create a parallel evidence pack system.
+- Do not create a parallel review timeline.
+- Do not create a parallel agent-action system.
+- Do not create a parallel supervision console.
+- Do not create separate severity, status, queue, or action vocabularies without migration guidance.
+
+## Future Mission Guidance
+
+Every future mission should audit the stable systems before implementation and answer:
+
+1. Which existing layer owns this concept?
+2. Can this be represented as an extension of an existing read model, route, or UI surface?
+3. Does the mission require mutation or execution, or can it remain preview/read-only?
+4. Which permission boundary applies?
+5. Which sensitive payloads must be excluded or redacted?
+6. Which canonical event or timeline relationship already exists?
+
+## Required Audit Before New Feature Work
+
+Before adding feature work, inspect the relevant existing layers:
+
+- decision and workflow models
+- decision inbox aggregation
+- operator review sessions
+- evidence pack derivation
+- canonical review timeline derivation
+- institution export preview derivation
+- audit/compliance readiness derivation
+- automated workflow previews
+- policy-gated agent suggestions
+- agent supervision snapshot
+
+## When New Systems Are Allowed
+
+New systems are allowed only when:
+
+- no existing stable layer owns the concept;
+- extending an existing layer would create ambiguity or unsafe coupling;
+- the new system has explicit permission, scope, and guardrail definitions;
+- the new system does not duplicate existing decision, workflow, evidence, timeline, or agent infrastructure;
+- the PR documents why a new system is necessary.
+
+## Drift Warning Signs
+
+- A new route or helper recreates decision/workflow/evidence/timeline concepts.
+- A UI surface introduces action controls that bypass policy guards.
+- A model adds a new status/severity vocabulary that overlaps existing types.
+- A feature hides automation behind read-only wording.
+- A landlord route exposes admin-only context.
+- A preview endpoint starts persisting or submitting data externally.
+- A feature claims public launch readiness without readiness review.
+- A feature claims legal/compliance certification.
+
+## Non-Negotiable Rules
+
+- Do not bypass policy guards.
+- Do not add hidden automation.
+- Do not widen permissions casually.
+- Do not introduce public launch claims without readiness review.
+- Do not claim legal/compliance certification without a separate approved process.
+- Do not add autonomous execution, payment automation, legal notice automation, external filing, or live institutional submission without an explicit execution mission.

--- a/docs/architecture/platform-state-v0.9.0-core-foundation.md
+++ b/docs/architecture/platform-state-v0.9.0-core-foundation.md
@@ -1,0 +1,108 @@
+# Platform State Snapshot — v0.9.0-core-foundation
+
+## Purpose
+
+This snapshot documents the internal platform state at `v0.9.0-core-foundation`, the RentChain Core Foundation Release. It describes the operational layers now present and the guardrails that remain in force.
+
+This snapshot is not a public launch declaration, legal/compliance certification, or external institutional approval.
+
+## Current System Layers
+
+RentChain now has four internal foundation layers:
+
+1. Operational system of record.
+2. Human accountability layer.
+3. Institutional evidence infrastructure.
+4. Controlled agentic infrastructure.
+
+## Layer 1: Operational System Of Record
+
+Layer 1 provides deterministic operational visibility and routing:
+
+- canonical events
+- derived decisions
+- workflow routing
+- decision inbox
+
+This layer makes operational state visible and reviewable without replacing lease, payment, screening, maintenance, or property source-of-truth records.
+
+## Layer 2: Human Accountability Layer
+
+Layer 2 provides human review and accountability:
+
+- operator review sessions
+- audit/compliance readiness
+- review outcomes
+- manual accountability
+
+Review sessions are permissioned, deterministic, and audit-oriented. Audit/compliance readiness summarizes evidence and blocking conditions but does not certify legal compliance.
+
+## Layer 3: Institutional Evidence Infrastructure
+
+Layer 3 organizes evidence for internal and future institutional review:
+
+- evidence packs
+- canonical review timeline
+- institution export previews
+- redaction-aware evidence summaries
+
+Evidence and export surfaces are preview-only. Sensitive tenant, screening, payment, identity, private document, and message payloads are excluded or redacted where applicable.
+
+## Layer 4: Controlled Agentic Infrastructure
+
+Layer 4 introduces supervised operational intelligence without autonomous execution:
+
+- automated workflow previews
+- policy-gated agent suggestions
+- agent supervision console
+
+Automated workflows are deterministic previews of internal review state. Agent suggestions are operator-visible recommendations only. The Agent Supervision Console centralizes visibility into workflow previews, suggestions, blocked states, escalations, review lineage, evidence references, and timeline references.
+
+## Current Guardrail Model
+
+- Manual review remains required.
+- Policy guards remain explicit.
+- Human approval remains required for suggested actions.
+- External execution remains disabled.
+- Autonomous execution remains disabled.
+- Landlord routes remain landlord-scoped.
+- Admin-only data must not leak into landlord surfaces.
+- Sensitive tenant/payment/screening/private document payloads must not be exposed.
+
+No autonomous execution, payment automation, legal notice automation, external filing, or live institutional submission exists in this release.
+
+## Current Non-Goals
+
+- Public launch readiness.
+- Legal compliance certification.
+- Regulatory filing.
+- External lender, insurer, government, auditor, or institutional submission.
+- Tenant communication automation.
+- Payment collection automation.
+- Legal notice or eviction workflow automation.
+- Autonomous agent execution.
+- Background workers, cron, queues, Pub/Sub, or scheduled reporting.
+
+## Phase 3 Identity Roadmap
+
+Phase 3 should focus on identity and trust infrastructure, including:
+
+- canonical identity layer
+- actor identity and attribution strengthening
+- tenant/landlord/entity verification surfaces
+- permissioned identity references for evidence and review surfaces
+- identity-safe redaction and disclosure rules
+
+These additions should extend existing review, evidence, timeline, policy, and supervision layers rather than creating parallel identity workflows.
+
+## Phase 4 Institutional/Financial Rails Roadmap
+
+Phase 4 should prepare institution and financial rails without bypassing the foundation guardrails:
+
+- institutional sharing room
+- verified rental history ledger
+- settlement rail readiness
+- regulatory profile layer
+- policy-gated institutional submission review
+
+Future rails must remain permissioned, auditable, redaction-aware, and operator-controlled until explicit execution missions authorize controlled actions.

--- a/docs/releases/public-exposure-readiness-checklist.md
+++ b/docs/releases/public-exposure-readiness-checklist.md
@@ -1,0 +1,99 @@
+# Public Exposure Readiness Checklist
+
+## Purpose
+
+This checklist is for future public exposure readiness review. It does not certify launch readiness, legal compliance, institutional approval, or production safety by itself.
+
+Status values:
+
+- Not started
+- In progress
+- Ready for review
+- Blocked
+- Complete
+
+## Product Readiness
+
+- [ ] Core user workflows reviewed. Status: Not started.
+- [ ] Public-facing copy reviewed. Status: Not started.
+- [ ] Feature flags and disabled states reviewed. Status: Not started.
+- [ ] Known limitations documented. Status: Not started.
+- [ ] Product support handoff complete. Status: Not started.
+
+## Security Readiness
+
+- [ ] Authentication and authorization reviewed. Status: Not started.
+- [ ] Landlord/admin permission boundaries reviewed. Status: Not started.
+- [ ] Tenant-facing whitelist projections reviewed. Status: Not started.
+- [ ] Sensitive payload exposure audit complete. Status: Not started.
+- [ ] Public route review complete. Status: Not started.
+
+## Privacy/Legal Readiness
+
+- [ ] Privacy policy reviewed. Status: Not started.
+- [ ] Terms reviewed. Status: Not started.
+- [ ] Tenant consent flows reviewed. Status: Not started.
+- [ ] Screening data handling reviewed. Status: Not started.
+- [ ] Legal disclaimers reviewed. Status: Not started.
+
+## Operational Readiness
+
+- [ ] Incident response runbook ready. Status: Not started.
+- [ ] Rollback process verified. Status: Not started.
+- [ ] On-call or owner assignment confirmed. Status: Not started.
+- [ ] Deployment process reviewed. Status: Not started.
+- [ ] Release communication plan ready. Status: Not started.
+
+## Support Readiness
+
+- [ ] Support intake process ready. Status: Not started.
+- [ ] Known issue templates ready. Status: Not started.
+- [ ] Escalation path defined. Status: Not started.
+- [ ] Help content reviewed. Status: Not started.
+- [ ] Customer-facing support language reviewed. Status: Not started.
+
+## Billing/Payment Readiness
+
+- [ ] Billing flows reviewed. Status: Not started.
+- [ ] Payment execution boundaries reviewed. Status: Not started.
+- [ ] Refund/support process reviewed. Status: Not started.
+- [ ] Provider webhook behavior reviewed. Status: Not started.
+- [ ] Payment failure states reviewed. Status: Not started.
+
+## Screening Readiness
+
+- [ ] Screening consent reviewed. Status: Not started.
+- [ ] Screening provider adapter boundaries reviewed. Status: Not started.
+- [ ] Sensitive screening payload exposure audit complete. Status: Not started.
+- [ ] Applicant/tenant experience reviewed. Status: Not started.
+- [ ] Adverse or decision-related language reviewed. Status: Not started.
+
+## Tenant Experience Readiness
+
+- [ ] Tenant onboarding reviewed. Status: Not started.
+- [ ] Tenant document flows reviewed. Status: Not started.
+- [ ] Tenant messaging/notification boundaries reviewed. Status: Not started.
+- [ ] Tenant data visibility reviewed. Status: Not started.
+- [ ] Accessibility review complete. Status: Not started.
+
+## Landlord Experience Readiness
+
+- [ ] Landlord onboarding reviewed. Status: Not started.
+- [ ] Landlord dashboard and review surfaces reviewed. Status: Not started.
+- [ ] Decision Inbox and supervision surfaces reviewed. Status: Not started.
+- [ ] Evidence/export/audit readiness copy reviewed. Status: Not started.
+- [ ] Landlord support path reviewed. Status: Not started.
+
+## Monitoring/Incident Readiness
+
+- [ ] Frontend monitoring reviewed. Status: Not started.
+- [ ] Backend monitoring reviewed. Status: Not started.
+- [ ] Error alerting reviewed. Status: Not started.
+- [ ] Deployment health checks reviewed. Status: Not started.
+- [ ] Incident review process ready. Status: Not started.
+
+## Launch Decision Status
+
+Current launch decision status: Not started.
+
+This checklist must be completed and reviewed before any public exposure claim. Completion of `v0.9.0-core-foundation` does not certify launch readiness.

--- a/docs/releases/release-governance-baseline.md
+++ b/docs/releases/release-governance-baseline.md
@@ -1,0 +1,87 @@
+# Release Governance Baseline
+
+## Purpose
+
+This baseline defines the repeatable release governance checks RentChain should use for release checkpoints. It is a process guide, not a product feature, public launch certification, legal certification, or institutional approval.
+
+## Release Checklist
+
+- [ ] Confirm branch scope.
+- [ ] Confirm `ci/backend` passed.
+- [ ] Confirm `ci/frontend` passed.
+- [ ] Confirm `merge-gate` passed.
+- [ ] Confirm `codex-pr-review` passed.
+- [ ] Confirm Vercel passed.
+- [ ] Confirm Terraform passed.
+- [ ] Confirm dependency/lockfile diff is empty unless intended.
+- [ ] Confirm docs updated.
+- [ ] Confirm release notes updated.
+- [ ] Confirm release tag created when applicable.
+- [ ] Confirm product/runtime/infrastructure changes are in scope.
+- [ ] Confirm PR summary includes guardrails, limitations, and verification.
+
+## QA Checklist
+
+- [ ] Confirm targeted tests for touched areas passed.
+- [ ] Confirm broader tests were run when practical.
+- [ ] Confirm builds passed.
+- [ ] Confirm known warnings are documented and non-regressive.
+- [ ] Confirm user-visible behavior matches the mission acceptance criteria.
+- [ ] Confirm no hidden automation or side effects were introduced.
+
+## Migration Checklist
+
+- [ ] Confirm whether migrations are required.
+- [ ] Confirm no schema-breaking change exists unless explicitly approved.
+- [ ] Confirm Firestore collection/index impacts.
+- [ ] Confirm migration rollback approach.
+- [ ] Confirm data backfill plan if applicable.
+- [ ] Confirm migration verification steps.
+
+## Rollback Checklist
+
+- [ ] Identify merge commit.
+- [ ] Identify release tag.
+- [ ] Identify affected files.
+- [ ] Confirm rollback approach.
+- [ ] Confirm database/infrastructure impact.
+- [ ] Confirm communication plan.
+- [ ] Confirm post-rollback verification.
+- [ ] Confirm whether rollback requires follow-up remediation PR.
+
+## Monitoring Checklist
+
+- [ ] Confirm deployment health checks.
+- [ ] Confirm application logs are monitored.
+- [ ] Confirm error rates are monitored.
+- [ ] Confirm frontend deployment status.
+- [ ] Confirm backend deployment status.
+- [ ] Confirm alerts are in place for known risk surfaces.
+
+## Security Review Checklist
+
+- [ ] Confirm authorization boundaries remain unchanged or intentionally reviewed.
+- [ ] Confirm no landlord/admin permission widening.
+- [ ] Confirm sensitive tenant/payment/screening/private document payloads are excluded from new surfaces.
+- [ ] Confirm no raw sensitive payloads are logged.
+- [ ] Confirm public routes were not widened.
+- [ ] Confirm external API calls were not added unless explicitly approved.
+
+## Documentation Checklist
+
+- [ ] Confirm architecture docs updated.
+- [ ] Confirm release notes updated.
+- [ ] Confirm runbook or governance docs updated when needed.
+- [ ] Confirm PR summary documents assumptions and limitations.
+- [ ] Confirm release checkpoint language does not claim public launch readiness unless approved.
+- [ ] Confirm release checkpoint language does not claim legal/compliance certification.
+
+## Post-Release Review Checklist
+
+- [ ] Confirm release tag exists.
+- [ ] Confirm main is synced.
+- [ ] Confirm merged branch is cleaned up.
+- [ ] Confirm final working tree is clean.
+- [ ] Confirm follow-up missions are documented.
+- [ ] Confirm any deferred risks are tracked.
+- [ ] Confirm release notes reflect the final merged scope.

--- a/docs/releases/v0.9.0-core-foundation.md
+++ b/docs/releases/v0.9.0-core-foundation.md
@@ -1,0 +1,118 @@
+# RentChain Core Foundation Release
+
+Version: v0.9.0-core-foundation
+
+Release name: RentChain Core Foundation Release
+
+Release meaning: Institutional operational foundation complete.
+
+This release is an internal foundation checkpoint, not a public launch declaration.
+
+## Release Purpose
+
+The purpose of `v0.9.0-core-foundation` is to mark completion of RentChain's institutional operational foundation. The release establishes the core read models, review envelopes, evidence surfaces, and supervised operational visibility needed before identity, institutional sharing, verified history, settlement readiness, and regulatory profile layers are added.
+
+## Completed Phases
+
+Phase 1 — Institutional Operational Core:
+
+- `feat/decision-inbox-v1`
+- `feat/decision-workflow-routing-v1`
+- `feat/delinquency-actions-v1`
+- `feat/institution-export-layer-v1`
+- `feat/audit-compliance-layer-v1`
+- `feat/operator-review-session-v1`
+- `feat/evidence-pack-layer-v1`
+- `feat/canonical-review-timeline-v1`
+
+Phase 2 — Controlled Workflow Orchestration:
+
+- `feat/automated-workflows-v1`
+- `feat/policy-gated-agent-actions-v1`
+- `feat/agent-supervision-console-v1`
+
+## Completed Merged Missions
+
+The completed merged missions created a deterministic path from detected operational signals to structured decisions, workflow routing, review sessions, evidence organization, timeline visibility, export preview scaffolding, audit/compliance readiness, and supervised agentic visibility.
+
+These missions are baseline infrastructure only. They do not declare public launch readiness, legal compliance certification, or institutional approval.
+
+## Architecture Layers Completed
+
+- Decision and workflow visibility through the Decision Inbox.
+- Workflow routing metadata and review-state organization.
+- Manual delinquency action scaffolding with blocked notice/reminder preparation.
+- Institution export preview scaffolding with aggregate-only and redaction-aware sections.
+- Audit/compliance readiness visibility without certification.
+- Operator review sessions with audit-oriented review history.
+- Evidence Pack preview scaffolding with missing evidence and redaction visibility.
+- Canonical Review Timeline visibility for review lineage.
+- Automated workflow preview derivation for internal orchestration state only.
+- Policy-gated agent action suggestions with human approval required.
+- Agent Supervision Console for centralized read-only supervision.
+
+## What This Release Includes
+
+- Landlord-scoped operational read models.
+- Deterministic decision aggregation.
+- Deterministic workflow routing and automated workflow previews.
+- Manual-only delinquency action descriptors.
+- Institution export preview packages.
+- Audit/compliance readiness checks.
+- Operator review session envelopes.
+- Evidence Pack preview summaries.
+- Canonical Review Timeline aggregation.
+- Policy-gated agent suggestion descriptors.
+- Agent Supervision Console visibility.
+- Documentation and governance baselines for future release reviews.
+
+## What This Release Does Not Include
+
+- Public launch certification.
+- Legal compliance certification.
+- External institutional approval.
+- External data submission.
+- Tenant, landlord, lender, insurer, regulator, or vendor communication.
+- Payment collection or financial movement automation.
+- Legal notice generation or eviction workflow execution.
+- Autonomous agent execution.
+- Background workers, queues, cron, Pub/Sub, or scheduled reporting.
+- Live integrations with lenders, insurers, government programs, auditors, or institutions.
+
+## Safety Guardrails Preserved
+
+- Manual review remains required.
+- Policy guards remain explicit.
+- External execution remains disabled.
+- Autonomous execution remains disabled.
+- Sensitive tenant, payment, screening, private document, and admin-only payloads are excluded from landlord-scoped institutional surfaces.
+- No source-of-truth lease, tenant, property, screening, payment, decision, export, audit readiness, evidence, or review records are mutated by read-only preview layers.
+- No automated tenant communication, payment action, legal enforcement, external filing, export submission, or compliance certification exists.
+
+## Known Limitations
+
+- Evidence packs and institution exports are preview-only and not shareable externally.
+- Audit/compliance readiness is an internal readiness model and is not a legal conclusion.
+- Agent actions are suggestions only and cannot execute.
+- Automated workflows are internal preview/orchestration visibility only.
+- Public launch readiness still requires a separate product, security, privacy, operational, support, billing, screening, tenant experience, landlord experience, and incident-readiness review.
+
+## Next Planned Phase
+
+The next planned phase is identity and institutional trust infrastructure, beginning with `feat/identity-layer-v1`, followed by institutional sharing, verified rental history, settlement rail readiness, and regulatory profile layers.
+
+## Release Tag Reference
+
+Release tag: `v0.9.0-core-foundation`
+
+The tag marks the internal foundation checkpoint after the Phase 1 and Phase 2 missions listed above.
+
+## Merge Checkpoint Summary
+
+At this checkpoint:
+
+- Institutional operational foundation is complete.
+- Core review and evidence surfaces are in place.
+- Controlled workflow orchestration visibility is in place.
+- Agent supervision is visible and non-executing.
+- No autonomous execution, payment automation, legal notice automation, external filing, or live institutional submission exists in this release.


### PR DESCRIPTION
## Summary
- Adds release notes for `v0.9.0-core-foundation` / RentChain Core Foundation Release.
- Adds platform state architecture snapshot for the internal foundation checkpoint.
- Adds release governance baseline checklist.
- Adds public exposure readiness checklist for future readiness review.
- Adds architectural drift freeze guidance for v0.9.0 foundation systems.

## Scope
- Documentation only.
- No product code, backend runtime code, frontend runtime code, infrastructure, dependency, or lockfile changes.
- No public launch readiness claim.
- No legal/compliance certification claim.
- No external institutional approval claim.

## Audit notes
- `docs/releases/` did not exist, so it was created because this mission explicitly required release files there.
- No `docs/releases/README.md` existed, so no release index was updated.
- No `docs/architecture/README.md` existed, so no architecture index was updated.

## Verification
- `git diff --cached --check` passed before commit.
- Changed files are docs-only.
- Dependency/lockfile diff empty.
- Search for `v0.9.0-core-foundation` passed.
- Search for `not a public launch` passed.
- Search for `No autonomous execution` passed.