### PR TITLE
feat: add deterministic identity layer

### DIFF
--- a/docs/architecture/identity-layer-v1.md
+++ b/docs/architecture/identity-layer-v1.md
@@ -1,0 +1,78 @@
+# Identity Layer v1
+
+## Purpose
+
+Identity Layer v1 introduces deterministic, permissioned operational identity references for RentChain. It centralizes safe identity lineage for tenants, properties, organizations, operators, and review actors without creating public identity profiles or external identity execution.
+
+## Scope
+
+This layer is read-only and landlord-scoped. It derives identity profiles from existing operational references:
+
+- tenant profile references
+- property registry references
+- organization/operator attribution references
+- consent references
+- verification references
+- operator review references
+- canonical event references
+
+## Required Safety Flags
+
+Every derived identity profile includes:
+
+- `manualReviewRequired: true`
+- `publiclyShareable: false`
+- `externalInstitutionSharingEnabled: false`
+- `tokenizationEnabled: false`
+
+## Status Rules
+
+Identity status is deterministic:
+
+- `verified`: required verification and consent references are present
+- `partially_verified`: at least one verification reference exists, but other lineage is missing
+- `review_required`: source context exists but required verification or consent lineage is missing
+- `blocked`: conflicting or unsafe identity references require manual review
+- `unknown`: source context is unavailable
+
+No probabilistic trust scoring, AI adjudication, or hidden identity ranking is used.
+
+## Redaction Model
+
+The identity profile is a safe read model. It excludes:
+
+- government identity numbers
+- raw screening or credit bureau payloads
+- payment account details
+- private tenant documents
+
+Redaction metadata is shown so operators understand what categories are intentionally excluded.
+
+## Canonical Event Descriptors
+
+Identity Layer v1 emits deterministic event descriptors for audit lineage:
+
+- `identity_profile_derived`
+- `identity_verification_reference_attached`
+- `identity_consent_reference_attached`
+- `identity_review_required`
+- `identity_blocked`
+
+These are additive descriptors only. They do not mutate source records.
+
+## Non-Goals
+
+Identity Layer v1 does not add:
+
+- public identity sharing
+- tokenization or blockchain identity
+- decentralized wallets
+- live institution integrations
+- autonomous verification
+- legal identity certification
+- payment or financial identity rails
+- source-of-truth tenant, lease, property, or payment mutations
+
+## Future Work
+
+Future missions may add institutional sharing rooms, verified rental history ledgers, settlement rail readiness, and regulatory profile layers. Those extensions should build on this permissioned identity reference model rather than creating a parallel identity system.

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -125,6 +125,7 @@ import landlordAuditComplianceRoutes from "./routes/landlordAuditComplianceRoute
 import landlordOperatorReviewRoutes from "./routes/landlordOperatorReviewRoutes";
 import landlordEvidencePackRoutes from "./routes/landlordEvidencePackRoutes";
 import landlordReviewTimelineRoutes from "./routes/landlordReviewTimelineRoutes";
+import landlordIdentityLayerRoutes from "./routes/landlordIdentityLayerRoutes";
 import publicPortfolioScoreRoutes from "./routes/publicPortfolioScoreRoutes";
 import publicTenantShareRoutes from "./routes/publicTenantShareRoutes";
 import landlordActionRecommendationRoutes from "./routes/landlordActionRecommendationRoutes";
@@ -298,6 +299,8 @@ app.use("/api/landlord", routeSource("landlordEvidencePackRoutes.ts"), landlordE
 console.log("[route-mount] landlordEvidencePackRoutes mounted at /api/landlord");
 app.use("/api/landlord", routeSource("landlordReviewTimelineRoutes.ts"), landlordReviewTimelineRoutes);
 console.log("[route-mount] landlordReviewTimelineRoutes mounted at /api/landlord");
+app.use("/api/landlord", routeSource("landlordIdentityLayerRoutes.ts"), landlordIdentityLayerRoutes);
+console.log("[route-mount] landlordIdentityLayerRoutes mounted at /api/landlord");
 app.use("/api", routeSource("landlordActionRecommendationRoutes.ts"), landlordActionRecommendationRoutes);
 console.log("[route-mount] landlordActionRecommendationRoutes mounted at /api");
 app.use("/api", routeSource("tenantFeedbackRoutes.ts"), tenantFeedbackRoutes);

--- a/rentchain-api/src/lib/identityLayer/__tests__/deriveIdentityProfile.test.ts
+++ b/rentchain-api/src/lib/identityLayer/__tests__/deriveIdentityProfile.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { deriveIdentityProfile } from "../deriveIdentityProfile";
+
+describe("deriveIdentityProfile", () => {
+  it("derives a verified tenant profile from verification and consent lineage", () => {
+    const profile = deriveIdentityProfile({
+      identityType: "tenant",
+      identityId: "tenant-1",
+      generatedAt: "2026-01-01T00:00:00.000Z",
+      tenant: { id: "tenant-1", screeningId: "screening-1", createdAt: "2025-12-01T00:00:00.000Z" },
+      consentRecords: [{ id: "consent-1", scope: "screening consent", signedAt: "2025-12-01T00:00:00.000Z" }],
+      reviewSessions: [{ id: "review-1", openedAt: "2025-12-02T00:00:00.000Z" }],
+    });
+
+    expect(profile).toEqual(
+      expect.objectContaining({
+        identityId: "tenant:tenant-1",
+        identityType: "tenant",
+        status: "verified",
+        manualReviewRequired: true,
+        publiclyShareable: false,
+        externalInstitutionSharingEnabled: false,
+        tokenizationEnabled: false,
+      })
+    );
+    expect(profile.verificationSummary.verifiedReferences).toBeGreaterThan(0);
+    expect(profile.consentSummary.consentAvailable).toBe(true);
+    expect(profile.reviewReferences).toHaveLength(1);
+    expect(profile.canonicalEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ eventType: "identity_profile_derived" }),
+        expect.objectContaining({ eventType: "identity_verification_reference_attached" }),
+        expect.objectContaining({ eventType: "identity_consent_reference_attached" }),
+      ])
+    );
+  });
+
+  it("requires review when tenant consent lineage is missing", () => {
+    const profile = deriveIdentityProfile({
+      identityType: "tenant",
+      identityId: "tenant-2",
+      tenant: { id: "tenant-2", screeningId: "screening-2" },
+    });
+
+    expect(profile.status).toBe("partially_verified");
+    expect(profile.consentSummary.missingConsentReasons).toContain("Consent lineage reference is missing.");
+    expect(profile.portabilitySummary.portabilityStatus).toBe("limited");
+  });
+
+  it("derives verified property identity from registry linkage", () => {
+    const profile = deriveIdentityProfile({
+      identityType: "property",
+      identityId: "property-1",
+      property: { id: "property-1", createdAt: "2025-01-01T00:00:00.000Z" },
+      registryStatus: { id: "registry-1", status: "verified", verifiedAt: "2025-01-02T00:00:00.000Z" },
+      consentRecords: [{ id: "consent-1", scope: "portfolio operations consent" }],
+    });
+
+    expect(profile.status).toBe("verified");
+    expect(profile.verificationReferences).toEqual(
+      expect.arrayContaining([expect.objectContaining({ label: "Registry verification reference", status: "available" })])
+    );
+  });
+
+  it("blocks conflicting identity references deterministically", () => {
+    const profile = deriveIdentityProfile({
+      identityType: "tenant",
+      identityId: "tenant-3",
+      tenant: { id: "tenant-3", screeningId: "screening-3", identityConflict: true },
+      consentRecords: [{ id: "consent-3", scope: "screening consent" }],
+    });
+
+    expect(profile.status).toBe("blocked");
+    expect(profile.blockedReasons).toContain("Conflicting identity reference requires manual review.");
+    expect(profile.canonicalEvents).toEqual(expect.arrayContaining([expect.objectContaining({ eventType: "identity_blocked" })]));
+  });
+
+  it("returns unknown when source context is unavailable", () => {
+    const profile = deriveIdentityProfile({ identityType: "operator", identityId: "operator-1" });
+
+    expect(profile.status).toBe("unknown");
+    expect(profile.verificationSummary.missingReferences).toBeGreaterThan(0);
+  });
+
+  it("excludes sensitive raw identity payloads from the read model", () => {
+    const profile = deriveIdentityProfile({
+      identityType: "tenant",
+      identityId: "tenant-sensitive",
+      tenant: {
+        id: "tenant-sensitive",
+        screeningId: "screening-sensitive",
+        governmentIdRaw: "sensitive-government-id-value",
+        creditPayload: "sensitive-credit-payload",
+        paymentAccount: "sensitive-payment-account",
+      },
+      consentRecords: [{ id: "consent-sensitive", scope: "screening consent" }],
+    });
+
+    const serialized = JSON.stringify(profile);
+    expect(serialized).not.toContain("sensitive-government-id-value");
+    expect(serialized).not.toContain("sensitive-credit-payload");
+    expect(serialized).not.toContain("sensitive-payment-account");
+    expect(profile.redactions).toEqual(expect.arrayContaining(["Raw screening and credit bureau payloads are excluded."]));
+  });
+});

--- a/rentchain-api/src/lib/identityLayer/deriveIdentityProfile.ts
+++ b/rentchain-api/src/lib/identityLayer/deriveIdentityProfile.ts
@@ -1,0 +1,333 @@
+import type {
+  DeriveIdentityProfileInput,
+  IdentityLayerCanonicalEvent,
+  IdentityLayerProfile,
+  IdentityLayerReference,
+  IdentityLayerStatus,
+  IdentityLayerType,
+} from "./identityLayerTypes";
+import { consentReference } from "./identityConsentModels";
+import { identityReference, isVerifiedReference } from "./identityVerificationModels";
+
+const IDENTITY_TYPES = new Set<IdentityLayerType>(["tenant", "property", "organization", "operator", "review_actor"]);
+
+const REDACTIONS = [
+  "Government identity numbers are excluded.",
+  "Raw screening and credit bureau payloads are excluded.",
+  "Payment account details are excluded.",
+  "Private tenant documents are excluded.",
+];
+
+function asString(value: unknown, max = 240): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function requestedIdentityType(value: unknown): IdentityLayerType {
+  const raw = asString(value, 80) as IdentityLayerType;
+  return IDENTITY_TYPES.has(raw) ? raw : "tenant";
+}
+
+function safeIdentityId(type: IdentityLayerType, value: unknown) {
+  const raw = asString(value, 400);
+  return raw ? `${type}:${raw}` : `${type}:unknown`;
+}
+
+function hasValue(record: Record<string, unknown> | null | undefined, keys: string[]) {
+  return keys.some((key) => asString(record?.[key], 400));
+}
+
+function statusFromReferences(params: {
+  sourceAvailable: boolean;
+  verificationReferences: IdentityLayerReference[];
+  consentReferences: IdentityLayerReference[];
+  blockedReasons: string[];
+}): IdentityLayerStatus {
+  if (!params.sourceAvailable) return "unknown";
+  if (params.blockedReasons.length) return "blocked";
+
+  const verifiedCount = params.verificationReferences.filter(isVerifiedReference).length;
+  const missingVerification = params.verificationReferences.some((reference) => reference.status === "missing");
+  const missingConsent = params.consentReferences.length === 0;
+
+  if (verifiedCount > 0 && !missingVerification && !missingConsent) return "verified";
+  if (verifiedCount > 0) return "partially_verified";
+  return "review_required";
+}
+
+function canonicalEvent(params: {
+  eventType: IdentityLayerCanonicalEvent["eventType"];
+  status: IdentityLayerStatus;
+  resourceType: IdentityLayerType;
+  resourceId: string;
+  summary: string;
+}): IdentityLayerCanonicalEvent {
+  return {
+    eventType: params.eventType,
+    action: params.eventType.replace(/^identity_/, "").replace(/_/g, "."),
+    status: params.status,
+    resourceType: params.resourceType,
+    resourceId: params.resourceId,
+    summary: params.summary,
+  };
+}
+
+function tenantReferences(input: DeriveIdentityProfileInput) {
+  const tenant = input.tenant || null;
+  const references: IdentityLayerReference[] = [];
+  if (tenant) {
+    references.push(
+      identityReference({
+        referenceId: tenant.id || tenant.tenantId || input.identityId,
+        referenceType: "tenant_profile",
+        label: "Tenant profile reference",
+        destination: "/tenants",
+        occurredAt: tenant.updatedAt || tenant.createdAt,
+      })
+    );
+  } else {
+    references.push(
+      identityReference({
+        referenceId: "tenant_profile:missing",
+        referenceType: "tenant_profile",
+        label: "Tenant profile reference",
+        status: "missing",
+        blockedReason: "Tenant profile context is unavailable.",
+      })
+    );
+  }
+
+  const screeningPresent = hasValue(tenant, ["screeningId", "screeningReportId", "verificationId", "identityVerificationId"]);
+  references.push(
+    identityReference({
+      referenceId: screeningPresent ? tenant?.screeningId || tenant?.screeningReportId || tenant?.verificationId : "screening:missing",
+      referenceType: "screening",
+      label: "Screening verification reference",
+      status: screeningPresent ? "available" : "missing",
+      blockedReason: screeningPresent ? null : "Screening verification reference is missing.",
+    })
+  );
+
+  return references;
+}
+
+function propertyReferences(input: DeriveIdentityProfileInput) {
+  const property = input.property || null;
+  const registry = input.registryStatus || null;
+  const references: IdentityLayerReference[] = [];
+  if (property) {
+    references.push(
+      identityReference({
+        referenceId: property.id || property.propertyId || input.identityId,
+        referenceType: "property_registry",
+        label: "Property identity reference",
+        destination: "/properties",
+        occurredAt: property.updatedAt || property.createdAt,
+      })
+    );
+  } else {
+    references.push(
+      identityReference({
+        referenceId: "property:missing",
+        referenceType: "property_registry",
+        label: "Property identity reference",
+        status: "missing",
+        blockedReason: "Property context is unavailable.",
+      })
+    );
+  }
+
+  const verified = ["verified", "matched", "canonical"].includes(asString(registry?.status || registry?.reviewStatus, 80));
+  references.push(
+    identityReference({
+      referenceId: registry?.id || registry?.propertyId || property?.id || "registry:missing",
+      referenceType: "property_registry",
+      label: "Registry verification reference",
+      status: verified ? "available" : "missing",
+      occurredAt: registry?.updatedAt || registry?.verifiedAt,
+      blockedReason: verified ? null : "Verified registry linkage is missing.",
+    })
+  );
+
+  return references;
+}
+
+function organizationReferences(input: DeriveIdentityProfileInput) {
+  const organization = input.organization || null;
+  return [
+    identityReference({
+      referenceId: organization?.id || organization?.organizationId || input.identityId || "organization:missing",
+      referenceType: "organization",
+      label: "Organization identity reference",
+      status: organization ? "available" : "missing",
+      blockedReason: organization ? null : "Organization context is unavailable.",
+    }),
+  ];
+}
+
+function operatorReferences(input: DeriveIdentityProfileInput) {
+  const operator = input.operator || null;
+  return [
+    identityReference({
+      referenceId: operator?.id || operator?.userId || input.identityId || "operator:missing",
+      referenceType: "operator_review",
+      label: "Operator attribution reference",
+      status: operator ? "available" : "missing",
+      blockedReason: operator ? null : "Operator attribution context is unavailable.",
+    }),
+  ];
+}
+
+export function deriveIdentityProfile(input: DeriveIdentityProfileInput): IdentityLayerProfile {
+  const identityType = requestedIdentityType(input.identityType);
+  const identityId = safeIdentityId(identityType, input.identityId);
+  const sourceRecord =
+    identityType === "tenant"
+      ? input.tenant
+      : identityType === "property"
+        ? input.property
+        : identityType === "organization"
+          ? input.organization
+          : input.operator;
+
+  const verificationReferences =
+    identityType === "tenant"
+      ? tenantReferences(input)
+      : identityType === "property"
+        ? propertyReferences(input)
+        : identityType === "organization"
+          ? organizationReferences(input)
+          : operatorReferences(input);
+
+  const consentReferences = (input.consentRecords || []).map((record) => consentReference(record));
+  const reviewReferences = (input.reviewSessions || []).map((review) =>
+    identityReference({
+      referenceId: review.id || review.reviewSessionId,
+      referenceType: "operator_review",
+      label: "Operator review session",
+      destination: "/review-timeline",
+      occurredAt: review.closedAt || review.openedAt || review.createdAt,
+    })
+  );
+  const eventReferences = (input.canonicalEvents || []).map((event) =>
+    identityReference({
+      referenceId: event.id || event.eventId,
+      referenceType: "canonical_event",
+      label: asString(event.type || event.eventType, 120) || "Canonical event",
+      destination: "/review-timeline",
+      occurredAt: event.timestamp || event.createdAt || event.occurredAt,
+      redacted: Boolean(event.redacted),
+      status: event.redacted ? "redacted" : "available",
+      blockedReason: event.redacted ? "Event payload is redacted for identity safety." : null,
+    })
+  );
+
+  const blockedReasons: string[] = [];
+  if (hasValue(sourceRecord, ["identityConflict", "blockedReason"])) {
+    blockedReasons.push("Conflicting identity reference requires manual review.");
+  }
+
+  const status = statusFromReferences({
+    sourceAvailable: Boolean(sourceRecord),
+    verificationReferences,
+    consentReferences,
+    blockedReasons,
+  });
+
+  const verifiedReferences = verificationReferences.filter(isVerifiedReference).length;
+  const missingReferences = verificationReferences.filter((reference) => reference.status === "missing").length;
+  const blockedReferences = verificationReferences.filter((reference) => reference.status === "blocked").length;
+  const missingConsentReasons = consentReferences.length ? [] : ["Consent lineage reference is missing."];
+  const portabilityStatus = status === "verified" ? "ready" : verifiedReferences > 0 ? "limited" : "not_ready";
+  const generatedAt = asString(input.generatedAt, 120) || new Date(0).toISOString();
+  const lineageReferences = [...verificationReferences, ...consentReferences, ...reviewReferences, ...eventReferences];
+
+  const canonicalEvents: IdentityLayerCanonicalEvent[] = [
+    canonicalEvent({
+      eventType: "identity_profile_derived",
+      status,
+      resourceType: identityType,
+      resourceId: identityId,
+      summary: "Identity profile derived from permission-scoped operational references.",
+    }),
+  ];
+
+  if (verifiedReferences > 0) {
+    canonicalEvents.push(
+      canonicalEvent({
+        eventType: "identity_verification_reference_attached",
+        status,
+        resourceType: identityType,
+        resourceId: identityId,
+        summary: "Verification lineage references are attached.",
+      })
+    );
+  }
+  if (consentReferences.length > 0) {
+    canonicalEvents.push(
+      canonicalEvent({
+        eventType: "identity_consent_reference_attached",
+        status,
+        resourceType: identityType,
+        resourceId: identityId,
+        summary: "Consent lineage references are attached.",
+      })
+    );
+  }
+  if (status === "review_required") {
+    canonicalEvents.push(
+      canonicalEvent({
+        eventType: "identity_review_required",
+        status,
+        resourceType: identityType,
+        resourceId: identityId,
+        summary: "Manual identity review is required before relying on this profile.",
+      })
+    );
+  }
+  if (status === "blocked") {
+    canonicalEvents.push(
+      canonicalEvent({
+        eventType: "identity_blocked",
+        status,
+        resourceType: identityType,
+        resourceId: identityId,
+        summary: "Identity profile is blocked by conflicting or unsafe references.",
+      })
+    );
+  }
+
+  return {
+    identityId,
+    identityType,
+    status,
+    manualReviewRequired: true,
+    publiclyShareable: false,
+    externalInstitutionSharingEnabled: false,
+    tokenizationEnabled: false,
+    verificationSummary: {
+      totalReferences: verificationReferences.length,
+      verifiedReferences,
+      missingReferences,
+      blockedReferences,
+    },
+    consentSummary: {
+      consentAvailable: consentReferences.length > 0,
+      consentScope: consentReferences.map((reference) => reference.label),
+      consentReferences: consentReferences.length,
+      missingConsentReasons,
+    },
+    portabilitySummary: {
+      portableReferenceAvailable: status === "verified" || status === "partially_verified",
+      portabilityStatus,
+      blockedReasons: portabilityStatus === "not_ready" ? ["Identity portability requires verified references."] : [],
+    },
+    lineageReferences,
+    verificationReferences,
+    consentReferences,
+    reviewReferences,
+    redactions: REDACTIONS,
+    blockedReasons,
+    canonicalEvents,
+    generatedAt,
+  };
+}

--- a/rentchain-api/src/lib/identityLayer/identityConsentModels.ts
+++ b/rentchain-api/src/lib/identityLayer/identityConsentModels.ts
@@ -1,0 +1,18 @@
+import type { IdentityLayerReference } from "./identityLayerTypes";
+import { identityReference } from "./identityVerificationModels";
+
+function asString(value: unknown, max = 240): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+export function consentReference(record: Record<string, unknown>): IdentityLayerReference {
+  const id = asString(record.id || record.consentId || record.applicationId || record.leaseId, 400);
+  const scope = asString(record.scope || record.consentScope || record.type, 120) || "operational consent";
+  return identityReference({
+    referenceId: id ? `consent:${id}` : "consent:unknown",
+    referenceType: "consent",
+    label: scope,
+    status: "available",
+    occurredAt: record.createdAt || record.updatedAt || record.signedAt || record.consentAt,
+  });
+}

--- a/rentchain-api/src/lib/identityLayer/identityLayerTypes.ts
+++ b/rentchain-api/src/lib/identityLayer/identityLayerTypes.ts
@@ -1,0 +1,88 @@
+export type IdentityLayerType = "tenant" | "property" | "organization" | "operator" | "review_actor";
+
+export type IdentityLayerStatus = "verified" | "partially_verified" | "review_required" | "blocked" | "unknown";
+
+export type IdentityLayerEventType =
+  | "identity_profile_derived"
+  | "identity_verification_reference_attached"
+  | "identity_consent_reference_attached"
+  | "identity_review_required"
+  | "identity_blocked";
+
+export type IdentityLayerReference = {
+  referenceId: string;
+  referenceType:
+    | "tenant_profile"
+    | "property_registry"
+    | "organization"
+    | "operator_review"
+    | "canonical_event"
+    | "screening"
+    | "consent"
+    | "evidence"
+    | "unknown";
+  label: string;
+  status: "available" | "missing" | "blocked" | "redacted";
+  destination: string | null;
+  occurredAt: string | null;
+  redacted: boolean;
+  blockedReason: string | null;
+};
+
+export type IdentityLayerCanonicalEvent = {
+  eventType: IdentityLayerEventType;
+  action: string;
+  status: IdentityLayerStatus;
+  resourceType: IdentityLayerType;
+  resourceId: string;
+  summary: string;
+};
+
+export type IdentityLayerProfile = {
+  identityId: string;
+  identityType: IdentityLayerType;
+  status: IdentityLayerStatus;
+  manualReviewRequired: true;
+  publiclyShareable: false;
+  externalInstitutionSharingEnabled: false;
+  tokenizationEnabled: false;
+  verificationSummary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    missingReferences: number;
+    blockedReferences: number;
+  };
+  consentSummary: {
+    consentAvailable: boolean;
+    consentScope: string[];
+    consentReferences: number;
+    missingConsentReasons: string[];
+  };
+  portabilitySummary: {
+    portableReferenceAvailable: boolean;
+    portabilityStatus: "ready" | "limited" | "not_ready";
+    blockedReasons: string[];
+  };
+  lineageReferences: IdentityLayerReference[];
+  verificationReferences: IdentityLayerReference[];
+  consentReferences: IdentityLayerReference[];
+  reviewReferences: IdentityLayerReference[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: IdentityLayerCanonicalEvent[];
+  generatedAt: string;
+};
+
+export type DeriveIdentityProfileInput = {
+  identityType?: unknown;
+  identityId?: unknown;
+  generatedAt?: unknown;
+  tenant?: Record<string, unknown> | null;
+  property?: Record<string, unknown> | null;
+  organization?: Record<string, unknown> | null;
+  operator?: Record<string, unknown> | null;
+  registryStatus?: Record<string, unknown> | null;
+  reviewSessions?: Array<Record<string, unknown>> | null;
+  canonicalEvents?: Array<Record<string, unknown>> | null;
+  consentRecords?: Array<Record<string, unknown>> | null;
+};

--- a/rentchain-api/src/lib/identityLayer/identityVerificationModels.ts
+++ b/rentchain-api/src/lib/identityLayer/identityVerificationModels.ts
@@ -1,0 +1,31 @@
+import type { IdentityLayerReference } from "./identityLayerTypes";
+
+function asString(value: unknown, max = 240): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+export function identityReference(params: {
+  referenceId: unknown;
+  referenceType: IdentityLayerReference["referenceType"];
+  label: string;
+  status?: IdentityLayerReference["status"];
+  destination?: string | null;
+  occurredAt?: unknown;
+  redacted?: boolean;
+  blockedReason?: string | null;
+}): IdentityLayerReference {
+  return {
+    referenceId: asString(params.referenceId, 400) || "identity_reference:unknown",
+    referenceType: params.referenceType,
+    label: params.label,
+    status: params.status || "available",
+    destination: params.destination || null,
+    occurredAt: asString(params.occurredAt, 120) || null,
+    redacted: Boolean(params.redacted),
+    blockedReason: params.blockedReason || null,
+  };
+}
+
+export function isVerifiedReference(reference: IdentityLayerReference) {
+  return reference.status === "available" && !reference.redacted;
+}

--- a/rentchain-api/src/routes/__tests__/landlordIdentityLayerRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordIdentityLayerRoutes.test.ts
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+
+  function matches(doc: any, filters: Array<{ field: string; op: string; value: any }>) {
+    return filters.every(({ field, op, value }) => {
+      const actual = doc?.data?.[field];
+      if (op === "==") return actual === value;
+      return false;
+    });
+  }
+
+  function makeQuery(name: string, filters: Array<{ field: string; op: string; value: any }> = []) {
+    return {
+      where: (field: string, op: string, value: any) => makeQuery(name, [...filters, { field, op, value }]),
+      get: async () => {
+        const docs = Array.from(ensureCollection(name).values())
+          .filter((doc) => matches(doc, filters))
+          .map((doc) => ({ id: doc.id, exists: true, data: () => doc.data }));
+        return { docs, empty: docs.length === 0, size: docs.length };
+      },
+      doc: (id: string) => makeDoc(name, id),
+    };
+  }
+
+  function makeDoc(name: string, id: string) {
+    const col = ensureCollection(name);
+    return {
+      id,
+      get: async () => {
+        const entry = col.get(id);
+        return { id, exists: Boolean(entry), data: () => entry?.data };
+      },
+      set: async (data: any) => {
+        col.set(id, { id, data });
+      },
+    };
+  }
+
+  return {
+    resetFakeDb: () => store.clear(),
+    seedDoc: (collection: string, id: string, data: any) => ensureCollection(collection).set(id, { id, data }),
+    fakeDb: {
+      collection: (name: string) => ({
+        where: (field: string, op: string, value: any) => makeQuery(name, [{ field, op, value }]),
+        get: async () => makeQuery(name).get(),
+        doc: (id: string) => makeDoc(name, id),
+      }),
+    },
+  };
+});
+
+let mockUser: any;
+
+vi.mock("../../config/firebase", () => ({
+  db: fakeDb,
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!mockUser) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    req.user = mockUser;
+    return next();
+  },
+}));
+
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: any, res: any, next: any) => {
+    const role = String(req.user?.role || "").trim().toLowerCase();
+    const landlordId = req.user?.landlordId || req.user?.id;
+    if (role !== "landlord" && role !== "admin") return res.status(403).json({ ok: false, error: "Forbidden" });
+    if (!landlordId) return res.status(401).json({ ok: false, error: "Missing landlord context" });
+    req.user.landlordId = landlordId;
+    return next();
+  },
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; user?: Record<string, unknown> | null }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    const query = new URLSearchParams(queryString || "");
+    mockUser = options.user ?? mockUser;
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: mockUser,
+      body: {},
+      query: Object.fromEntries(query.entries()),
+      params: {},
+      headers: {},
+    };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("landlordIdentityLayerRoutes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    resetFakeDb();
+    mockUser = { id: "landlord-1", landlordId: "landlord-1", role: "landlord", email: "landlord@example.com" };
+  });
+
+  it("returns landlord-scoped tenant identity without sensitive raw payloads", async () => {
+    seedDoc("tenants", "tenant-1", {
+      landlordId: "landlord-1",
+      screeningId: "screening-1",
+      governmentIdRaw: "sensitive-government-id-value",
+      paymentAccount: "sensitive-payment-account",
+    });
+    seedDoc("tenants", "tenant-other", { landlordId: "landlord-2", screeningId: "screening-other" });
+    seedDoc("consents", "consent-1", { landlordId: "landlord-1", tenantId: "tenant-1", scope: "screening consent" });
+    const router = (await import("../landlordIdentityLayerRoutes")).default;
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/identity-layer/profile?identityType=tenant&identityId=tenant-1",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.profile).toEqual(
+      expect.objectContaining({
+        identityId: "tenant:tenant-1",
+        identityType: "tenant",
+        manualReviewRequired: true,
+        publiclyShareable: false,
+        externalInstitutionSharingEnabled: false,
+        tokenizationEnabled: false,
+      })
+    );
+    const serialized = JSON.stringify(res.body.profile);
+    expect(serialized).not.toContain("sensitive-government-id-value");
+    expect(serialized).not.toContain("sensitive-payment-account");
+    expect(serialized).not.toContain("tenant-other");
+  });
+
+  it("returns property identity status with registry lineage", async () => {
+    seedDoc("properties", "property-1", { landlordId: "landlord-1", propertyId: "property-1" });
+    seedDoc("propertyRegistryStatuses", "registry-1", { landlordId: "landlord-1", propertyId: "property-1", status: "verified" });
+    seedDoc("consents", "consent-1", { landlordId: "landlord-1", propertyId: "property-1", scope: "portfolio operations consent" });
+    const router = (await import("../landlordIdentityLayerRoutes")).default;
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/identity-layer/status?identityType=property&identityId=property-1",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toEqual(
+      expect.objectContaining({
+        identityId: "property:property-1",
+        identityType: "property",
+        status: "verified",
+        publiclyShareable: false,
+        tokenizationEnabled: false,
+      })
+    );
+  });
+
+  it("blocks non-landlord users", async () => {
+    const router = (await import("../landlordIdentityLayerRoutes")).default;
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/identity-layer/profile",
+      user: { id: "tenant-1", role: "tenant" },
+    });
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/rentchain-api/src/routes/landlordIdentityLayerRoutes.ts
+++ b/rentchain-api/src/routes/landlordIdentityLayerRoutes.ts
@@ -1,0 +1,129 @@
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { requireAuth } from "../middleware/requireAuth";
+import { requireLandlord } from "../middleware/requireLandlord";
+import { deriveIdentityProfile } from "../lib/identityLayer/deriveIdentityProfile";
+import type { IdentityLayerType } from "../lib/identityLayer/identityLayerTypes";
+
+const router = Router();
+
+const IDENTITY_TYPES = new Set<IdentityLayerType>(["tenant", "property", "organization", "operator", "review_actor"]);
+
+function asString(value: unknown, max = 240): string {
+  const next = String(value ?? "").trim().slice(0, max);
+  return next || "";
+}
+
+function requestedIdentityType(value: unknown): IdentityLayerType {
+  const raw = asString(value, 80) as IdentityLayerType;
+  return IDENTITY_TYPES.has(raw) ? raw : "tenant";
+}
+
+async function loadLandlordCollection(collectionName: string, landlordId: string) {
+  const byId = new Map<string, any>();
+  async function collect(field: "landlordId" | "ownerId" | "userId") {
+    const snap = await db.collection(collectionName).where(field, "==", landlordId).get().catch(() => null);
+    for (const doc of snap?.docs || []) {
+      byId.set(doc.id, { id: doc.id, ...((doc.data() as any) || {}) });
+    }
+  }
+
+  await Promise.all([collect("landlordId"), collect("ownerId"), collect("userId")]);
+
+  return Array.from(byId.values()).filter((record) =>
+    [record?.landlordId, record?.ownerId, record?.userId].some((value) => asString(value, 240) === landlordId)
+  );
+}
+
+function selectRecord(records: any[], identityId: string, fields: string[]) {
+  if (!records.length) return null;
+  if (!identityId) return records[0];
+  return (
+    records.find((record) => {
+      return [record?.id, ...fields.map((field) => record?.[field])].some((value) => asString(value, 400) === identityId);
+    }) || null
+  );
+}
+
+function relatedRecords(records: any[], identityId: string, fields: string[]) {
+  if (!identityId) return records;
+  return records.filter((record) => {
+    return fields.some((field) => asString(record?.[field], 400) === identityId) || asString(record?.id, 400) === identityId;
+  });
+}
+
+async function buildProfile(req: any) {
+  const landlordId = asString(req.user?.landlordId || req.user?.id, 240);
+  if (!landlordId) return null;
+
+  const identityType = requestedIdentityType(req.query?.identityType);
+  const identityId = asString(req.query?.identityId, 400);
+
+  const [tenants, properties, organizations, reviews, events, consents, registryStatuses] = await Promise.all([
+    loadLandlordCollection("tenants", landlordId),
+    loadLandlordCollection("properties", landlordId),
+    loadLandlordCollection("organizations", landlordId),
+    loadLandlordCollection("operatorReviewSessions", landlordId),
+    loadLandlordCollection("events", landlordId),
+    loadLandlordCollection("consents", landlordId),
+    loadLandlordCollection("propertyRegistryStatuses", landlordId),
+  ]);
+
+  const tenant = selectRecord(tenants, identityId, ["tenantId", "profileId"]);
+  const property = selectRecord(properties, identityId, ["propertyId"]);
+  const organization = selectRecord(organizations, identityId, ["organizationId"]);
+  const operator = selectRecord(reviews, identityId, ["actorId", "openedById", "userId"]);
+  const propertyId = asString(property?.id || property?.propertyId || identityId, 400);
+  const registryStatus = selectRecord(registryStatuses, propertyId, ["propertyId"]);
+  const consentRecords = relatedRecords(consents, identityId, ["identityId", "tenantId", "propertyId", "userId"]);
+  const reviewSessions = relatedRecords(reviews, identityId, ["scopeId", "tenantId", "propertyId", "actorId", "openedById"]);
+  const canonicalEvents = relatedRecords(events, identityId, ["resourceId", "tenantId", "propertyId", "actorId"]);
+
+  return deriveIdentityProfile({
+    identityType,
+    identityId,
+    tenant: identityType === "tenant" ? tenant : null,
+    property: identityType === "property" ? property : null,
+    organization: identityType === "organization" ? organization : null,
+    operator: identityType === "operator" || identityType === "review_actor" ? operator : null,
+    registryStatus: identityType === "property" ? registryStatus : null,
+    consentRecords,
+    reviewSessions,
+    canonicalEvents,
+  });
+}
+
+router.get("/identity-layer/profile", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const profile = await buildProfile(req);
+    if (!profile) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    return res.json({ ok: true, profile });
+  } catch (err: any) {
+    console.error("[landlord-identity-layer] profile failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "IDENTITY_PROFILE_FAILED" });
+  }
+});
+
+router.get("/identity-layer/status", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const profile = await buildProfile(req);
+    if (!profile) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    return res.json({
+      ok: true,
+      status: {
+        identityId: profile.identityId,
+        identityType: profile.identityType,
+        status: profile.status,
+        manualReviewRequired: profile.manualReviewRequired,
+        publiclyShareable: profile.publiclyShareable,
+        externalInstitutionSharingEnabled: profile.externalInstitutionSharingEnabled,
+        tokenizationEnabled: profile.tokenizationEnabled,
+      },
+    });
+  } catch (err: any) {
+    console.error("[landlord-identity-layer] status failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "IDENTITY_STATUS_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -118,6 +118,10 @@ vi.mock("./pages/ReviewTimelinePage", () => ({
   default: () => <h1>Canonical Review Timeline Page</h1>,
 }));
 
+vi.mock("./pages/IdentityLayerPage", () => ({
+  default: () => <h1>Identity Layer Page</h1>,
+}));
+
 vi.mock("./pages/landlord/PortfolioScorePage", () => ({
   default: () => <h1>Landlord Portfolio Score</h1>,
 }));
@@ -323,6 +327,20 @@ describe("Routes: /review-timeline", () => {
     );
 
     expect(await screen.findByText(/Canonical Review Timeline Page/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Routes: /identity-layer", () => {
+  it("renders the permissioned identity layer route", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/identity-layer?identityType=tenant&identityId=tenant-1"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Identity Layer Page/i)).toBeInTheDocument();
     expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -122,6 +122,7 @@ const InstitutionExportsPage = lazy(() => import("./pages/InstitutionExportsPage
 const AuditCompliancePage = lazy(() => import("./pages/AuditCompliancePage"));
 const EvidencePackPage = lazy(() => import("./pages/EvidencePackPage"));
 const ReviewTimelinePage = lazy(() => import("./pages/ReviewTimelinePage"));
+const IdentityLayerPage = lazy(() => import("./pages/IdentityLayerPage"));
 const LandlordPortfolioScorePage = lazy(() => import("./pages/landlord/PortfolioScorePage"));
 const SharedPortfolioScorePage = lazy(() => import("./pages/public/SharedPortfolioScorePage"));
 const TenantSharePackagePage = lazy(() => import("./pages/public/TenantSharePackagePage"));
@@ -577,6 +578,18 @@ function App() {
               <LandlordNav>
                 <Suspense fallback={null}>
                   <ReviewTimelinePage />
+                </Suspense>
+              </LandlordNav>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/identity-layer"
+          element={
+            <RequireAuth>
+              <LandlordNav>
+                <Suspense fallback={null}>
+                  <IdentityLayerPage />
                 </Suspense>
               </LandlordNav>
             </RequireAuth>

--- a/rentchain-frontend/src/api/identityLayerApi.ts
+++ b/rentchain-frontend/src/api/identityLayerApi.ts
@@ -1,0 +1,80 @@
+import { apiFetch } from "./apiFetch";
+
+export type IdentityLayerType = "tenant" | "property" | "organization" | "operator" | "review_actor";
+export type IdentityLayerStatus = "verified" | "partially_verified" | "review_required" | "blocked" | "unknown";
+
+export type IdentityLayerReference = {
+  referenceId: string;
+  referenceType:
+    | "tenant_profile"
+    | "property_registry"
+    | "organization"
+    | "operator_review"
+    | "canonical_event"
+    | "screening"
+    | "consent"
+    | "evidence"
+    | "unknown";
+  label: string;
+  status: "available" | "missing" | "blocked" | "redacted";
+  destination: string | null;
+  occurredAt: string | null;
+  redacted: boolean;
+  blockedReason: string | null;
+};
+
+export type IdentityLayerProfile = {
+  identityId: string;
+  identityType: IdentityLayerType;
+  status: IdentityLayerStatus;
+  manualReviewRequired: true;
+  publiclyShareable: false;
+  externalInstitutionSharingEnabled: false;
+  tokenizationEnabled: false;
+  verificationSummary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    missingReferences: number;
+    blockedReferences: number;
+  };
+  consentSummary: {
+    consentAvailable: boolean;
+    consentScope: string[];
+    consentReferences: number;
+    missingConsentReasons: string[];
+  };
+  portabilitySummary: {
+    portableReferenceAvailable: boolean;
+    portabilityStatus: "ready" | "limited" | "not_ready";
+    blockedReasons: string[];
+  };
+  lineageReferences: IdentityLayerReference[];
+  verificationReferences: IdentityLayerReference[];
+  consentReferences: IdentityLayerReference[];
+  reviewReferences: IdentityLayerReference[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: Array<{
+    eventType: string;
+    action: string;
+    status: IdentityLayerStatus;
+    resourceType: IdentityLayerType;
+    resourceId: string;
+    summary: string;
+  }>;
+  generatedAt: string;
+};
+
+export type IdentityLayerProfileQuery = {
+  identityType?: IdentityLayerType;
+  identityId?: string;
+};
+
+export async function fetchIdentityLayerProfile(params?: IdentityLayerProfileQuery): Promise<IdentityLayerProfile> {
+  const search = new URLSearchParams();
+  if (params?.identityType) search.set("identityType", params.identityType);
+  if (params?.identityId) search.set("identityId", params.identityId);
+  const suffix = search.toString() ? `?${search.toString()}` : "";
+  const response = await apiFetch<{ ok: true; profile: IdentityLayerProfile }>(`/landlord/identity-layer/profile${suffix}`);
+  return response.profile;
+}

--- a/rentchain-frontend/src/components/identity/IdentityProfilePanel.test.tsx
+++ b/rentchain-frontend/src/components/identity/IdentityProfilePanel.test.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { IdentityProfilePanel } from "./IdentityProfilePanel";
+import type { IdentityLayerProfile } from "@/api/identityLayerApi";
+
+function profile(overrides: Partial<IdentityLayerProfile> = {}): IdentityLayerProfile {
+  return {
+    identityId: "tenant:tenant-1",
+    identityType: "tenant",
+    status: "verified",
+    manualReviewRequired: true,
+    publiclyShareable: false,
+    externalInstitutionSharingEnabled: false,
+    tokenizationEnabled: false,
+    verificationSummary: {
+      totalReferences: 2,
+      verifiedReferences: 2,
+      missingReferences: 0,
+      blockedReferences: 0,
+    },
+    consentSummary: {
+      consentAvailable: true,
+      consentScope: ["screening consent"],
+      consentReferences: 1,
+      missingConsentReasons: [],
+    },
+    portabilitySummary: {
+      portableReferenceAvailable: true,
+      portabilityStatus: "ready",
+      blockedReasons: [],
+    },
+    lineageReferences: [],
+    verificationReferences: [
+      {
+        referenceId: "tenant-1",
+        referenceType: "tenant_profile",
+        label: "Tenant profile reference",
+        status: "available",
+        destination: "/tenants",
+        occurredAt: null,
+        redacted: false,
+        blockedReason: null,
+      },
+    ],
+    consentReferences: [
+      {
+        referenceId: "consent-1",
+        referenceType: "consent",
+        label: "screening consent",
+        status: "available",
+        destination: null,
+        occurredAt: null,
+        redacted: false,
+        blockedReason: null,
+      },
+    ],
+    reviewReferences: [],
+    redactions: ["Raw screening and credit bureau payloads are excluded."],
+    blockedReasons: [],
+    canonicalEvents: [],
+    generatedAt: "2026-05-06T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("IdentityProfilePanel", () => {
+  afterEach(() => cleanup());
+
+  it("renders identity status, lineage, redactions, and required safety copy", () => {
+    render(
+      <MemoryRouter>
+        <IdentityProfilePanel profile={profile()} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("View identity profile")).toBeInTheDocument();
+    expect(screen.getAllByText("Verified").length).toBeGreaterThan(0);
+    expect(screen.getByText(/Identity references are permissioned and operationally scoped/i)).toBeInTheDocument();
+    expect(screen.getByText(/Manual review remains required/i)).toBeInTheDocument();
+    expect(screen.getByText(/No public identity sharing or tokenization is enabled/i)).toBeInTheDocument();
+    expect(screen.getByText("View verification lineage")).toBeInTheDocument();
+    expect(screen.getByText("Tenant profile reference")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "View context" })).toHaveAttribute("href", "/tenants");
+    expect(screen.getByText("View consent lineage")).toBeInTheDocument();
+    expect(screen.getByText("screening consent")).toBeInTheDocument();
+    expect(screen.getByText("Raw screening and credit bureau payloads are excluded.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /publish identity|share publicly|mint token|export identity publicly|autonomous verification|approve identity automatically/i })).not.toBeInTheDocument();
+  });
+
+  it("renders graceful missing context and blocked reasons", () => {
+    render(
+      <MemoryRouter>
+        <IdentityProfilePanel
+          profile={profile({
+            status: "review_required",
+            consentReferences: [],
+            reviewReferences: [],
+            portabilitySummary: {
+              portableReferenceAvailable: false,
+              portabilityStatus: "not_ready",
+              blockedReasons: ["Identity portability requires verified references."],
+            },
+          })}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getAllByText("Context unavailable").length).toBeGreaterThan(0);
+    expect(screen.getByText(/View blocked reason: Identity portability requires verified references\./i)).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/identity/IdentityProfilePanel.tsx
+++ b/rentchain-frontend/src/components/identity/IdentityProfilePanel.tsx
@@ -1,0 +1,144 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import type { IdentityLayerProfile, IdentityLayerReference } from "@/api/identityLayerApi";
+import { Card, Section } from "@/components/ui/Ui";
+
+function label(value: string) {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function statusTone(status: string) {
+  if (status === "blocked") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
+  if (status === "review_required" || status === "missing") return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
+  if (status === "verified" || status === "available" || status === "ready") {
+    return { color: "#166534", background: "#dcfce7", border: "#bbf7d0" };
+  }
+  if (status === "partially_verified" || status === "limited") {
+    return { color: "#9a3412", background: "#ffedd5", border: "#fed7aa" };
+  }
+  return { color: "#475569", background: "#f8fafc", border: "#e2e8f0" };
+}
+
+function Badge({ children, status }: { children: React.ReactNode; status: string }) {
+  const tone = statusTone(status);
+  return (
+    <span
+      style={{
+        border: `1px solid ${tone.border}`,
+        borderRadius: 999,
+        background: tone.background,
+        color: tone.color,
+        padding: "3px 9px",
+        fontSize: 12,
+        fontWeight: 900,
+        whiteSpace: "nowrap",
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+function ReferenceList({ title, references }: { title: string; references: IdentityLayerReference[] }) {
+  return (
+    <Section style={{ display: "grid", gap: 10 }}>
+      <div style={{ fontWeight: 900 }}>{title}</div>
+      {references.length ? (
+        references.map((reference) => (
+          <Card key={`${reference.referenceType}:${reference.referenceId}`} style={{ borderRadius: 8, padding: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+              <div>
+                <strong style={{ color: "#0f172a" }}>{reference.label || "Context unavailable"}</strong>
+                <div style={{ color: "#64748b", fontSize: 13 }}>{label(reference.referenceType)}</div>
+              </div>
+              <Badge status={reference.status}>{label(reference.status)}</Badge>
+            </div>
+            {reference.blockedReason ? (
+              <div style={{ color: "#991b1b", fontSize: 13, marginTop: 8 }}>Blocked reason: {reference.blockedReason}</div>
+            ) : null}
+            {reference.redacted ? (
+              <div style={{ color: "#92400e", fontSize: 13, marginTop: 8 }}>Redacted identity reference</div>
+            ) : null}
+            {reference.destination ? (
+              <Link to={reference.destination} style={{ color: "#2563eb", fontWeight: 800, fontSize: 13, marginTop: 8, display: "inline-block" }}>
+                View context
+              </Link>
+            ) : null}
+          </Card>
+        ))
+      ) : (
+        <Card style={{ color: "#64748b" }}>Context unavailable</Card>
+      )}
+    </Section>
+  );
+}
+
+export function IdentityProfilePanel({ profile }: { profile: IdentityLayerProfile }) {
+  return (
+    <div style={{ display: "grid", gap: 16 }}>
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
+          <div>
+            <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>View identity profile</div>
+            <h2 style={{ margin: "2px 0 0", fontSize: "1.15rem" }}>{label(profile.identityType)}</h2>
+          </div>
+          <Badge status={profile.status}>{label(profile.status)}</Badge>
+        </div>
+        <div style={{ color: "#475569", lineHeight: 1.55 }}>
+          Identity references are permissioned and operationally scoped. Manual review remains required. No public identity sharing or
+          tokenization is enabled.
+        </div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <Badge status={profile.manualReviewRequired ? "review_required" : "unknown"}>Manual review required</Badge>
+          <Badge status={profile.publiclyShareable ? "blocked" : "available"}>Permission scoped</Badge>
+          <Badge status={profile.tokenizationEnabled ? "blocked" : "available"}>Tokenization disabled</Badge>
+        </div>
+      </Section>
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Verification summary</div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: 10 }}>
+          {[
+            ["Total references", profile.verificationSummary.totalReferences],
+            ["Verified", profile.verificationSummary.verifiedReferences],
+            ["Missing", profile.verificationSummary.missingReferences],
+            ["Blocked", profile.verificationSummary.blockedReferences],
+          ].map(([name, value]) => (
+            <Card key={String(name)} style={{ borderRadius: 8, padding: 12 }}>
+              <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>{name}</div>
+              <strong style={{ color: "#0f172a", fontSize: 22 }}>{String(value)}</strong>
+            </Card>
+          ))}
+        </div>
+      </Section>
+
+      <ReferenceList title="View verification lineage" references={profile.verificationReferences} />
+      <ReferenceList title="View consent lineage" references={profile.consentReferences} />
+      <ReferenceList title="View review lineage" references={profile.reviewReferences} />
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Portability readiness</div>
+        <Card style={{ borderRadius: 8, padding: 12 }}>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+            <strong>{profile.portabilitySummary.portableReferenceAvailable ? "Portable reference available" : "Portable reference limited"}</strong>
+            <Badge status={profile.portabilitySummary.portabilityStatus}>{label(profile.portabilitySummary.portabilityStatus)}</Badge>
+          </div>
+          {profile.portabilitySummary.blockedReasons.map((reason) => (
+            <div key={reason} style={{ color: "#991b1b", fontSize: 13, marginTop: 8 }}>
+              View blocked reason: {reason}
+            </div>
+          ))}
+        </Card>
+      </Section>
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Redactions</div>
+        {profile.redactions.map((redaction) => (
+          <Card key={redaction} style={{ borderRadius: 8, padding: 12, color: "#475569" }}>
+            {redaction}
+          </Card>
+        ))}
+      </Section>
+    </div>
+  );
+}

--- a/rentchain-frontend/src/pages/DecisionInboxPage.tsx
+++ b/rentchain-frontend/src/pages/DecisionInboxPage.tsx
@@ -415,6 +415,9 @@ export default function DecisionInboxPage() {
             <Link to="/agent-supervision" style={{ color: "#2563eb", fontWeight: 800 }}>
               Agent supervision
             </Link>
+            <Link to="/identity-layer" style={{ color: "#2563eb", fontWeight: 800 }}>
+              Identity layer
+            </Link>
           </div>
         </Section>
 

--- a/rentchain-frontend/src/pages/IdentityLayerPage.test.tsx
+++ b/rentchain-frontend/src/pages/IdentityLayerPage.test.tsx
@@ -1,0 +1,121 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import IdentityLayerPage from "./IdentityLayerPage";
+
+const apiMocks = vi.hoisted(() => ({
+  fetchIdentityLayerProfile: vi.fn(),
+  showToast: vi.fn(),
+  macShellProps: vi.fn(),
+}));
+
+vi.mock("@/api/identityLayerApi", async () => {
+  const actual = await vi.importActual<any>("@/api/identityLayerApi");
+  return {
+    ...actual,
+    fetchIdentityLayerProfile: apiMocks.fetchIdentityLayerProfile,
+  };
+});
+
+vi.mock("@/components/ui/ToastProvider", () => ({
+  useToast: () => ({
+    showToast: apiMocks.showToast,
+  }),
+}));
+
+vi.mock("@/components/layout/MacShell", () => ({
+  MacShell: ({ children, ...props }: { children: React.ReactNode; showTopNav?: boolean }) => {
+    apiMocks.macShellProps(props);
+    return <div>{children}</div>;
+  },
+}));
+
+function profile() {
+  return {
+    identityId: "tenant:tenant-1",
+    identityType: "tenant",
+    status: "partially_verified",
+    manualReviewRequired: true,
+    publiclyShareable: false,
+    externalInstitutionSharingEnabled: false,
+    tokenizationEnabled: false,
+    verificationSummary: {
+      totalReferences: 2,
+      verifiedReferences: 1,
+      missingReferences: 1,
+      blockedReferences: 0,
+    },
+    consentSummary: {
+      consentAvailable: false,
+      consentScope: [],
+      consentReferences: 0,
+      missingConsentReasons: ["Consent lineage reference is missing."],
+    },
+    portabilitySummary: {
+      portableReferenceAvailable: true,
+      portabilityStatus: "limited",
+      blockedReasons: [],
+    },
+    lineageReferences: [],
+    verificationReferences: [
+      {
+        referenceId: "tenant-1",
+        referenceType: "tenant_profile",
+        label: "Tenant profile reference",
+        status: "available",
+        destination: "/tenants",
+        occurredAt: null,
+        redacted: false,
+        blockedReason: null,
+      },
+    ],
+    consentReferences: [],
+    reviewReferences: [],
+    redactions: ["Payment account details are excluded."],
+    blockedReasons: [],
+    canonicalEvents: [],
+    generatedAt: "2026-05-06T00:00:00.000Z",
+  };
+}
+
+describe("IdentityLayerPage", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    apiMocks.fetchIdentityLayerProfile.mockResolvedValue(profile());
+  });
+
+  it("renders identity profile, filters, and required safety copy", async () => {
+    render(
+      <MemoryRouter initialEntries={["/identity-layer?identityType=tenant&identityId=tenant-1"]}>
+        <IdentityLayerPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole("heading", { name: "Identity layer" })).toBeInTheDocument();
+    expect(screen.getAllByText(/Identity references are permissioned and operationally scoped/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Manual review remains required/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/No public identity sharing or tokenization is enabled/i).length).toBeGreaterThan(0);
+    expect(screen.getByDisplayValue("tenant")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("tenant-1")).toBeInTheDocument();
+    expect(screen.getByText("View verification lineage")).toBeInTheDocument();
+    expect(screen.getByText("Payment account details are excluded.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /publish identity|share publicly|mint token|export identity publicly|autonomous verification|approve identity automatically/i })).not.toBeInTheDocument();
+    expect(apiMocks.fetchIdentityLayerProfile).toHaveBeenCalledWith({ identityType: "tenant", identityId: "tenant-1" });
+    expect(apiMocks.macShellProps).toHaveBeenCalledWith(expect.objectContaining({ showTopNav: false }));
+  });
+
+  it("renders load errors safely", async () => {
+    apiMocks.fetchIdentityLayerProfile.mockRejectedValue(new Error("network unavailable"));
+
+    render(
+      <MemoryRouter>
+        <IdentityLayerPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/We couldn't load identity layer profile right now\./i)).toBeInTheDocument();
+    expect(apiMocks.showToast).toHaveBeenCalledWith(expect.objectContaining({ variant: "error" }));
+  });
+});

--- a/rentchain-frontend/src/pages/IdentityLayerPage.tsx
+++ b/rentchain-frontend/src/pages/IdentityLayerPage.tsx
@@ -1,0 +1,116 @@
+import React from "react";
+import { Link, useSearchParams } from "react-router-dom";
+import {
+  fetchIdentityLayerProfile,
+  type IdentityLayerProfile,
+  type IdentityLayerType,
+} from "@/api/identityLayerApi";
+import { IdentityProfilePanel } from "@/components/identity/IdentityProfilePanel";
+import { MacShell } from "@/components/layout/MacShell";
+import { Card, Section } from "@/components/ui/Ui";
+import { useToast } from "@/components/ui/ToastProvider";
+
+const IDENTITY_TYPES: IdentityLayerType[] = ["tenant", "property", "organization", "operator", "review_actor"];
+
+function errorMessage(error: unknown) {
+  if (error instanceof Error && error.message) return error.message;
+  return "Failed to load identity layer profile";
+}
+
+function requestedType(value: string | null): IdentityLayerType {
+  return IDENTITY_TYPES.includes(value as IdentityLayerType) ? (value as IdentityLayerType) : "tenant";
+}
+
+export default function IdentityLayerPage() {
+  const { showToast } = useToast();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [profile, setProfile] = React.useState<IdentityLayerProfile | null>(null);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const identityType = requestedType(searchParams.get("identityType"));
+  const identityId = String(searchParams.get("identityId") || "").trim();
+
+  React.useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const next = await fetchIdentityLayerProfile({ identityType, identityId: identityId || undefined });
+        if (!mounted) return;
+        setProfile(next);
+      } catch (err) {
+        if (!mounted) return;
+        const message = errorMessage(err);
+        setError(message);
+        showToast({ message: "Failed to load identity layer profile", description: message, variant: "error" });
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [identityType, identityId, showToast]);
+
+  function updateParams(next: { identityType?: IdentityLayerType; identityId?: string }) {
+    const params = new URLSearchParams(searchParams);
+    if (next.identityType) params.set("identityType", next.identityType);
+    if (next.identityId !== undefined) {
+      if (next.identityId.trim()) params.set("identityId", next.identityId.trim());
+      else params.delete("identityId");
+    }
+    setSearchParams(params);
+  }
+
+  return (
+    <MacShell title="Identity layer" showTopNav={false}>
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "grid", gap: 6 }}>
+            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Identity layer</h1>
+            <div style={{ color: "#475569", maxWidth: 900 }}>
+              Identity references are permissioned and operationally scoped. Manual review remains required. No public identity sharing or
+              tokenization is enabled.
+            </div>
+          </div>
+        </Section>
+
+        <Section style={{ display: "grid", gap: 12 }}>
+          <div style={{ display: "flex", gap: 10, flexWrap: "wrap", alignItems: "end" }}>
+            <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+              Identity type
+              <select
+                value={identityType}
+                onChange={(event) => updateParams({ identityType: event.target.value as IdentityLayerType })}
+                style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 180 }}
+              >
+                {IDENTITY_TYPES.map((type) => (
+                  <option key={type} value={type}>
+                    {type.replace(/_/g, " ")}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+              Identity reference
+              <input
+                value={identityId}
+                onChange={(event) => updateParams({ identityId: event.target.value })}
+                placeholder="Optional internal reference"
+                style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 240 }}
+              />
+            </label>
+            <Link to="/review-timeline" style={{ color: "#2563eb", fontWeight: 800, paddingBottom: 9 }}>
+              View review lineage
+            </Link>
+          </div>
+        </Section>
+
+        {loading ? <Card>Loading identity layer profile...</Card> : null}
+        {!loading && error ? <Card style={{ color: "#b91c1c" }}>We couldn't load identity layer profile right now.</Card> : null}
+        {!loading && !error && profile ? <IdentityProfilePanel profile={profile} /> : null}
+      </div>
+    </MacShell>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds deterministic, permissioned Identity Layer v1 for tenant, property, organization, operator, and review-actor identity references.
- Adds landlord-scoped endpoints:
  - `GET /api/landlord/identity-layer/profile`
  - `GET /api/landlord/identity-layer/status`
- Adds identity profile model with verification, consent, review, portability, redaction, and lineage references.
- Adds frontend `/identity-layer` page, `IdentityProfilePanel`, and Decision Inbox link.
- Adds architecture documentation for Identity Layer v1.

## Guardrails
- `manualReviewRequired` remains `true`.
- `publiclyShareable`, `externalInstitutionSharingEnabled`, and `tokenizationEnabled` remain `false`.
- No public identity sharing, tokenization, external identity execution, autonomous verification, or AI trust scoring was added.
- Raw government IDs, screening/credit payloads, payment account details, private documents, and admin-only data are excluded.

## Verification
- Backend targeted identity tests passed: 9 tests.
- Frontend targeted identity/routes tests passed: 35 tests.
- Backend full suite passed: 276 files / 1234 tests.
- Frontend full suite passed: 196 files / 782 tests.
- Backend build passed.
- Frontend build passed with existing chunk-size warning.
- `git diff --check` passed.
- Dependency/lockfile diff empty.
- Forbidden identity action labels absent:
  - Publish identity
  - Share publicly
  - Mint token
  - Export identity publicly
  - Autonomous verification
  - Approve identity automatically