### PR TITLE
feat: add institutional sharing room layer

### DIFF
--- a/docs/architecture/institutional-sharing-room-v1.md
+++ b/docs/architecture/institutional-sharing-room-v1.md
@@ -1,0 +1,81 @@
+# Institutional Sharing Room v1
+
+## Purpose
+
+Institutional Sharing Room v1 introduces controlled, revocable operational review spaces for institutional actors such as lenders, insurers, auditors, regulators, and operational partners.
+
+The layer organizes safe references to existing RentChain evidence, export previews, review timelines, audit readiness, and identity lineage without creating public portals or external integrations.
+
+## Core Model
+
+Sharing rooms include:
+
+- room type
+- access-control state
+- expiration metadata
+- shared scope references
+- redaction metadata
+- audit references
+- evidence and timeline references
+
+Every room is landlord-scoped and manually governed.
+
+## Required Safety Flags
+
+Every room enforces:
+
+- `manualReviewRequired: true`
+- `publiclyAccessible: false`
+- `externalExecutionEnabled: false`
+- `tokenizationEnabled: false`
+
+Access controls enforce:
+
+- `accessType: view_only`
+- `publicAccess: false`
+- `downloadEnabled: false`
+- `externalSubmissionEnabled: false`
+- `manualApprovalRequired: true`
+
+## Redaction Rules
+
+Sharing rooms never include raw sensitive payloads. The read model excludes:
+
+- raw government identity numbers
+- raw screening, credit bureau, and provider payloads
+- payment account, card, bank, processor, and provider details
+- private tenant documents
+- unrestricted tenant communications
+
+Redaction metadata is visible so operators can explain what was excluded.
+
+## Lifecycle Events
+
+Sharing rooms use additive canonical event descriptors:
+
+- `institutional_sharing_room_created`
+- `institutional_sharing_room_review_required`
+- `institutional_sharing_room_access_granted`
+- `institutional_sharing_room_access_expired`
+- `institutional_sharing_room_access_revoked`
+- `institutional_sharing_room_redaction_applied`
+
+Events remain deterministic and traceable. They do not submit, share, or certify anything externally.
+
+## Non-Goals
+
+Institutional Sharing Room v1 does not add:
+
+- public links
+- anonymous access
+- unrestricted downloads
+- live lender, insurer, regulator, or government integrations
+- autonomous sharing
+- legal certification
+- blockchain or tokenized identity sharing
+- financial rails
+- external API submission
+
+## Future Work
+
+Future missions may introduce verified rental history ledgers, settlement rail readiness, regulatory profile layers, and controlled institutional sharing workflows. Those extensions should preserve this permissioned, redaction-aware room model.

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -126,6 +126,7 @@ import landlordOperatorReviewRoutes from "./routes/landlordOperatorReviewRoutes"
 import landlordEvidencePackRoutes from "./routes/landlordEvidencePackRoutes";
 import landlordReviewTimelineRoutes from "./routes/landlordReviewTimelineRoutes";
 import landlordIdentityLayerRoutes from "./routes/landlordIdentityLayerRoutes";
+import landlordSharingRoomRoutes from "./routes/landlordSharingRoomRoutes";
 import publicPortfolioScoreRoutes from "./routes/publicPortfolioScoreRoutes";
 import publicTenantShareRoutes from "./routes/publicTenantShareRoutes";
 import landlordActionRecommendationRoutes from "./routes/landlordActionRecommendationRoutes";
@@ -301,6 +302,8 @@ app.use("/api/landlord", routeSource("landlordReviewTimelineRoutes.ts"), landlor
 console.log("[route-mount] landlordReviewTimelineRoutes mounted at /api/landlord");
 app.use("/api/landlord", routeSource("landlordIdentityLayerRoutes.ts"), landlordIdentityLayerRoutes);
 console.log("[route-mount] landlordIdentityLayerRoutes mounted at /api/landlord");
+app.use("/api/landlord", routeSource("landlordSharingRoomRoutes.ts"), landlordSharingRoomRoutes);
+console.log("[route-mount] landlordSharingRoomRoutes mounted at /api/landlord");
 app.use("/api", routeSource("landlordActionRecommendationRoutes.ts"), landlordActionRecommendationRoutes);
 console.log("[route-mount] landlordActionRecommendationRoutes mounted at /api");
 app.use("/api", routeSource("tenantFeedbackRoutes.ts"), tenantFeedbackRoutes);

--- a/rentchain-api/src/lib/sharingRooms/__tests__/buildInstitutionalSharingRoom.test.ts
+++ b/rentchain-api/src/lib/sharingRooms/__tests__/buildInstitutionalSharingRoom.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildInstitutionalSharingRoom,
+  normalizeInstitutionalSharingRoom,
+  parseSharingRoomCreateRequest,
+  revokeInstitutionalSharingRoom,
+} from "../buildInstitutionalSharingRoom";
+
+const actor = { userId: "landlord-1", role: "landlord" as const, email: "landlord@example.com" };
+
+describe("buildInstitutionalSharingRoom", () => {
+  it("builds deterministic permissioned rooms with safe flags and redactions", () => {
+    const request = parseSharingRoomCreateRequest({
+      roomType: "lender_review",
+      institutionType: "lender",
+      redactionLevel: "strict",
+      sharedScopes: [
+        { scopeKey: "evidence_pack", scopeId: "decision-1", label: "Decision evidence" },
+        { scopeKey: "identity_lineage", scopeId: "tenant-1", label: "Tenant identity lineage" },
+      ],
+    });
+
+    expect(request).toBeTruthy();
+    const room = buildInstitutionalSharingRoom({
+      landlordId: "landlord-1",
+      request: request!,
+      actor,
+      now: "2026-05-06T00:00:00.000Z",
+    });
+
+    expect(room).toEqual(
+      expect.objectContaining({
+        roomType: "lender_review",
+        status: "review_required",
+        manualReviewRequired: true,
+        publiclyAccessible: false,
+        externalExecutionEnabled: false,
+        tokenizationEnabled: false,
+      })
+    );
+    expect(room.accessControls).toEqual(
+      expect.objectContaining({
+        accessType: "view_only",
+        publicAccess: false,
+        downloadEnabled: false,
+        externalSubmissionEnabled: false,
+        manualApprovalRequired: true,
+      })
+    );
+    expect(room.expiresAt).toBe("2026-05-20T00:00:00.000Z");
+    expect(room.redactions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ fieldCategory: "government_identity_numbers", state: "excluded" }),
+        expect.objectContaining({ fieldCategory: "payment_account_details", state: "excluded" }),
+      ])
+    );
+    expect(room.auditReferences.map((event) => event.eventType)).toEqual([
+      "institutional_sharing_room_created",
+      "institutional_sharing_room_review_required",
+      "institutional_sharing_room_redaction_applied",
+    ]);
+  });
+
+  it("marks expired rooms deterministically", () => {
+    const room = normalizeInstitutionalSharingRoom(
+      {
+        sharingRoomId: "room-1",
+        landlordId: "landlord-1",
+        roomType: "auditor_review",
+        createdAt: "2026-05-01T00:00:00.000Z",
+        expiresAt: "2026-05-02T00:00:00.000Z",
+        accessControls: { institutionType: "auditor", status: "active", redactionLevel: "strict" },
+        sharedScopes: [{ scopeKey: "audit_compliance", scopeId: "readiness-1", label: "Readiness" }],
+      },
+      "2026-05-06T00:00:00.000Z"
+    );
+
+    expect(room?.status).toBe("expired");
+  });
+
+  it("revokes access without deleting lineage", () => {
+    const request = parseSharingRoomCreateRequest({
+      roomType: "insurer_review",
+      institutionType: "insurer",
+      sharedScopes: [{ scopeKey: "institution_export", scopeId: "package-1" }],
+    })!;
+    const room = buildInstitutionalSharingRoom({
+      landlordId: "landlord-1",
+      request,
+      actor,
+      now: "2026-05-06T00:00:00.000Z",
+    });
+
+    const revoked = revokeInstitutionalSharingRoom({ room, now: "2026-05-07T00:00:00.000Z" });
+
+    expect(revoked.status).toBe("expired");
+    expect(revoked.accessControls.status).toBe("revoked");
+    expect(revoked.sharedScopes).toHaveLength(1);
+    expect(revoked.auditReferences).toEqual(
+      expect.arrayContaining([expect.objectContaining({ eventType: "institutional_sharing_room_access_revoked" })])
+    );
+  });
+
+  it("rejects invalid or empty create requests", () => {
+    expect(parseSharingRoomCreateRequest({ roomType: "public_room", institutionType: "lender", sharedScopes: [] })).toBeNull();
+    expect(parseSharingRoomCreateRequest({ roomType: "lender_review", institutionType: "lender", sharedScopes: [] })).toBeNull();
+  });
+
+  it("does not include sensitive raw payloads from request fields", () => {
+    const request = parseSharingRoomCreateRequest({
+      roomType: "lender_review",
+      institutionType: "lender",
+      sharedScopes: [{ scopeKey: "identity_lineage", scopeId: "tenant-1", rawGovernmentId: "sensitive-government-id" }],
+      rawCreditPayload: "sensitive-credit-payload",
+      paymentAccount: "sensitive-payment-account",
+    })!;
+    const room = buildInstitutionalSharingRoom({ landlordId: "landlord-1", request, actor });
+
+    const serialized = JSON.stringify(room);
+    expect(serialized).not.toContain("sensitive-government-id");
+    expect(serialized).not.toContain("sensitive-credit-payload");
+    expect(serialized).not.toContain("sensitive-payment-account");
+  });
+});

--- a/rentchain-api/src/lib/sharingRooms/buildInstitutionalSharingRoom.ts
+++ b/rentchain-api/src/lib/sharingRooms/buildInstitutionalSharingRoom.ts
@@ -1,0 +1,306 @@
+import crypto from "crypto";
+import { SHARING_ROOM_REDACTIONS, sharingRoomSafetyFlags } from "./sharingRoomPolicyGuards";
+import type {
+  InstitutionalSharingRoom,
+  SharingAccessControl,
+  SharingAccessStatus,
+  SharingInstitutionType,
+  SharingRoomCreateRequest,
+  SharingRoomEventType,
+  SharingRoomStatus,
+  SharingRoomType,
+  SharingScopeKind,
+  SharingScopeReference,
+} from "./sharingRoomTypes";
+
+const ROOM_TYPES = new Set<SharingRoomType>([
+  "lender_review",
+  "insurer_review",
+  "auditor_review",
+  "regulator_review",
+  "operational_partner_review",
+]);
+
+const INSTITUTION_TYPES = new Set<SharingInstitutionType>(["lender", "insurer", "auditor", "regulator", "partner"]);
+
+const SCOPE_KINDS = new Set<SharingScopeKind>([
+  "evidence_pack",
+  "institution_export",
+  "review_timeline",
+  "audit_compliance",
+  "identity_lineage",
+  "operator_review",
+  "workflow",
+]);
+
+function asString(value: unknown, max = 500) {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function cleanId(value: unknown) {
+  return asString(value, 500)
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function toIsoDate(value: unknown): string | null {
+  const raw = asString(value, 120);
+  if (!raw) return null;
+  const date = new Date(raw);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+function defaultExpiresAt(now: string) {
+  const date = new Date(now);
+  date.setUTCDate(date.getUTCDate() + 14);
+  return date.toISOString();
+}
+
+function scopeDestination(scopeKey: SharingScopeKind, scopeId: string): string | null {
+  const encoded = encodeURIComponent(scopeId);
+  if (scopeKey === "evidence_pack") return `/evidence-packs?scope=decision&scopeId=${encoded}`;
+  if (scopeKey === "institution_export") return "/institution-exports";
+  if (scopeKey === "review_timeline") return `/review-timeline?scope=decision&scopeId=${encoded}`;
+  if (scopeKey === "audit_compliance") return "/audit-compliance";
+  if (scopeKey === "identity_lineage") return `/identity-layer?identityId=${encoded}`;
+  if (scopeKey === "operator_review") return `/review-timeline?scope=operator_review&scopeId=${encoded}`;
+  if (scopeKey === "workflow") return "/decision-inbox";
+  return null;
+}
+
+function labelScope(scopeKey: SharingScopeKind, scopeId: string) {
+  return `${scopeKey.replace(/_/g, " ")} ${scopeId}`.trim();
+}
+
+export function parseSharingRoomCreateRequest(body: unknown): SharingRoomCreateRequest | null {
+  const data = (body || {}) as Record<string, any>;
+  const roomType = asString(data.roomType, 80) as SharingRoomType;
+  const institutionType = asString(data.institutionType, 80) as SharingInstitutionType;
+  const redactionLevel = asString(data.redactionLevel, 40) === "standard" ? "standard" : "strict";
+  if (!ROOM_TYPES.has(roomType) || !INSTITUTION_TYPES.has(institutionType)) return null;
+  const sharedScopes = Array.isArray(data.sharedScopes)
+    ? data.sharedScopes
+        .map((item: any) => {
+          const scopeKey = asString(item?.scopeKey, 80) as SharingScopeKind;
+          const scopeId = asString(item?.scopeId, 500);
+          if (!SCOPE_KINDS.has(scopeKey) || !scopeId) return null;
+          return {
+            scopeKey,
+            scopeId,
+            label: asString(item?.label, 160) || null,
+          };
+        })
+        .filter(Boolean)
+        .slice(0, 12)
+    : [];
+  if (!sharedScopes.length) return null;
+  return {
+    roomType,
+    institutionType,
+    redactionLevel,
+    expiresAt: toIsoDate(data.expiresAt),
+    sharedScopes: sharedScopes as SharingRoomCreateRequest["sharedScopes"],
+  };
+}
+
+export function buildSharingRoomId(input: { landlordId: string; roomType: SharingRoomType; createdAt: string; sharedScopes: unknown }) {
+  const hash = crypto
+    .createHash("sha256")
+    .update(JSON.stringify({ landlordId: input.landlordId, roomType: input.roomType, createdAt: input.createdAt, sharedScopes: input.sharedScopes }))
+    .digest("hex")
+    .slice(0, 16);
+  return cleanId(`institutional_sharing_room:${input.landlordId}:${input.roomType}:${hash}`);
+}
+
+function accessControl(input: {
+  sharingRoomId: string;
+  institutionType: SharingInstitutionType;
+  redactionLevel: "strict" | "standard";
+  allowedScopes: SharingScopeKind[];
+  expiresAt: string | null;
+  status?: SharingAccessStatus;
+}): SharingAccessControl {
+  return {
+    accessControlId: cleanId(`${input.sharingRoomId}:access:view_only`),
+    accessType: "view_only",
+    institutionType: input.institutionType,
+    status: input.status || "pending_review",
+    manualApprovalRequired: true,
+    publicAccess: false,
+    downloadEnabled: false,
+    externalSubmissionEnabled: false,
+    allowedScopes: Array.from(new Set(input.allowedScopes)),
+    redactionLevel: input.redactionLevel,
+    expiresAt: input.expiresAt,
+  };
+}
+
+function deriveStatus(input: {
+  status?: unknown;
+  accessStatus: SharingAccessStatus;
+  expiresAt: string | null;
+  now: string;
+  sharedScopes: SharingScopeReference[];
+}): SharingRoomStatus {
+  const existing = asString(input.status, 80) as SharingRoomStatus;
+  if (existing === "blocked") return "blocked";
+  if (!input.sharedScopes.length || input.sharedScopes.some((scope) => scope.status === "blocked")) return "blocked";
+  const expiresAt = input.expiresAt ? new Date(input.expiresAt).getTime() : null;
+  if (input.accessStatus === "revoked" || input.accessStatus === "expired") return "expired";
+  if (expiresAt && expiresAt <= new Date(input.now).getTime()) return "expired";
+  if (input.accessStatus === "active") return "active";
+  return "review_required";
+}
+
+function normalizeScopeReference(raw: unknown): SharingScopeReference | null {
+  const data = (raw || {}) as Record<string, unknown>;
+  const scopeKey = asString(data.scopeKey, 80) as SharingScopeKind;
+  const scopeId = asString(data.scopeId, 500);
+  if (!SCOPE_KINDS.has(scopeKey) || !scopeId) return null;
+  const destination = asString(data.destination, 500) || scopeDestination(scopeKey, scopeId);
+  return {
+    scopeKey,
+    scopeId,
+    label: asString(data.label, 160) || labelScope(scopeKey, scopeId),
+    status: asString(data.status, 80) === "blocked" ? "blocked" : asString(data.status, 80) === "missing" ? "missing" : "available",
+    destination,
+    blockedReason: asString(data.blockedReason, 500) || null,
+  };
+}
+
+export function buildInstitutionalSharingRoom(input: {
+  landlordId: string;
+  request: SharingRoomCreateRequest;
+  actor: InstitutionalSharingRoom["createdBy"];
+  now?: string;
+}): InstitutionalSharingRoom {
+  const createdAt = toIsoDate(input.now) || new Date().toISOString();
+  const expiresAt = input.request.expiresAt || defaultExpiresAt(createdAt);
+  const sharedScopes = input.request.sharedScopes
+    .map((scope) =>
+      normalizeScopeReference({
+        ...scope,
+        label: scope.label || labelScope(scope.scopeKey, scope.scopeId),
+      })
+    )
+    .filter(Boolean) as SharingScopeReference[];
+  const sharingRoomId = buildSharingRoomId({
+    landlordId: input.landlordId,
+    roomType: input.request.roomType,
+    createdAt,
+    sharedScopes,
+  });
+  const accessControls = accessControl({
+    sharingRoomId,
+    institutionType: input.request.institutionType,
+    redactionLevel: input.request.redactionLevel,
+    allowedScopes: sharedScopes.map((scope) => scope.scopeKey),
+    expiresAt,
+  });
+  const auditReferences = canonicalSharingRoomEvents({
+    eventTypes: ["institutional_sharing_room_created", "institutional_sharing_room_review_required", "institutional_sharing_room_redaction_applied"],
+    occurredAt: createdAt,
+  });
+  return {
+    sharingRoomId,
+    landlordId: input.landlordId,
+    roomType: input.request.roomType,
+    status: deriveStatus({ accessStatus: accessControls.status, expiresAt, now: createdAt, sharedScopes }),
+    ...sharingRoomSafetyFlags(),
+    createdAt,
+    updatedAt: createdAt,
+    expiresAt,
+    createdBy: input.actor,
+    accessControls,
+    sharedScopes,
+    redactions: SHARING_ROOM_REDACTIONS,
+    auditReferences,
+    timelineReferences: sharedScopes.filter((scope) => scope.scopeKey === "review_timeline" || scope.scopeKey === "operator_review"),
+    evidenceReferences: sharedScopes.filter((scope) => scope.scopeKey === "evidence_pack" || scope.scopeKey === "institution_export"),
+  };
+}
+
+export function normalizeInstitutionalSharingRoom(raw: unknown, now?: string): InstitutionalSharingRoom | null {
+  const data = (raw || {}) as Record<string, any>;
+  const sharingRoomId = asString(data.sharingRoomId || data.id, 500);
+  const landlordId = asString(data.landlordId, 240);
+  const roomType = asString(data.roomType, 80) as SharingRoomType;
+  const createdAt = toIsoDate(data.createdAt);
+  if (!sharingRoomId || !landlordId || !ROOM_TYPES.has(roomType) || !createdAt) return null;
+  const sharedScopes = Array.isArray(data.sharedScopes)
+    ? (data.sharedScopes.map(normalizeScopeReference).filter(Boolean) as SharingScopeReference[])
+    : [];
+  const accessData = data.accessControls || {};
+  const institutionType = INSTITUTION_TYPES.has(asString(accessData.institutionType, 80) as SharingInstitutionType)
+    ? (asString(accessData.institutionType, 80) as SharingInstitutionType)
+    : "lender";
+  const expiresAt = toIsoDate(data.expiresAt || accessData.expiresAt);
+  const accessStatusRaw = asString(accessData.status, 80) as SharingAccessStatus;
+  const accessControls = accessControl({
+    sharingRoomId,
+    institutionType,
+    redactionLevel: asString(accessData.redactionLevel, 40) === "standard" ? "standard" : "strict",
+    allowedScopes: sharedScopes.map((scope) => scope.scopeKey),
+    expiresAt,
+    status: ["pending_review", "active", "expired", "revoked"].includes(accessStatusRaw) ? accessStatusRaw : "pending_review",
+  });
+  const evaluatedAt = toIsoDate(now) || new Date().toISOString();
+  const status = deriveStatus({
+    status: data.status,
+    accessStatus: accessControls.status,
+    expiresAt,
+    now: evaluatedAt,
+    sharedScopes,
+  });
+  return {
+    sharingRoomId,
+    landlordId,
+    roomType,
+    status,
+    ...sharingRoomSafetyFlags(),
+    createdAt,
+    updatedAt: toIsoDate(data.updatedAt) || createdAt,
+    expiresAt,
+    createdBy: {
+      userId: asString(data.createdBy?.userId, 240) || null,
+      role: ["admin", "operator"].includes(asString(data.createdBy?.role, 80)) ? asString(data.createdBy?.role, 80) as any : "landlord",
+      email: asString(data.createdBy?.email, 320) || null,
+    },
+    accessControls,
+    sharedScopes,
+    redactions: Array.isArray(data.redactions) && data.redactions.length ? data.redactions : SHARING_ROOM_REDACTIONS,
+    auditReferences: Array.isArray(data.auditReferences) ? data.auditReferences : [],
+    timelineReferences: sharedScopes.filter((scope) => scope.scopeKey === "review_timeline" || scope.scopeKey === "operator_review"),
+    evidenceReferences: sharedScopes.filter((scope) => scope.scopeKey === "evidence_pack" || scope.scopeKey === "institution_export"),
+  };
+}
+
+export function revokeInstitutionalSharingRoom(input: { room: InstitutionalSharingRoom; now?: string }): InstitutionalSharingRoom {
+  const updatedAt = toIsoDate(input.now) || new Date().toISOString();
+  return {
+    ...input.room,
+    status: "expired",
+    updatedAt,
+    accessControls: {
+      ...input.room.accessControls,
+      status: "revoked",
+    },
+    auditReferences: [
+      ...input.room.auditReferences,
+      ...canonicalSharingRoomEvents({ eventTypes: ["institutional_sharing_room_access_revoked"], occurredAt: updatedAt }),
+    ],
+  };
+}
+
+export function canonicalSharingRoomEvents(input: {
+  eventTypes: SharingRoomEventType[];
+  occurredAt: string;
+}): InstitutionalSharingRoom["auditReferences"] {
+  return input.eventTypes.map((eventType) => ({
+    eventType,
+    occurredAt: input.occurredAt,
+    summary: eventType.replace(/_/g, " "),
+  }));
+}

--- a/rentchain-api/src/lib/sharingRooms/sharingRoomPolicyGuards.ts
+++ b/rentchain-api/src/lib/sharingRooms/sharingRoomPolicyGuards.ts
@@ -1,0 +1,38 @@
+import type { SharingRoomRedaction } from "./sharingRoomTypes";
+
+export const SHARING_ROOM_REDACTIONS: SharingRoomRedaction[] = [
+  {
+    fieldCategory: "government_identity_numbers",
+    state: "excluded",
+    reason: "Raw government identity numbers are excluded from institutional sharing rooms.",
+  },
+  {
+    fieldCategory: "screening_credit_payloads",
+    state: "excluded",
+    reason: "Raw screening, credit bureau, and provider payloads are excluded.",
+  },
+  {
+    fieldCategory: "payment_account_details",
+    state: "excluded",
+    reason: "Payment account, card, bank, processor, and provider account details are excluded.",
+  },
+  {
+    fieldCategory: "private_tenant_documents",
+    state: "excluded",
+    reason: "Private tenant documents and unrestricted document storage are excluded.",
+  },
+  {
+    fieldCategory: "tenant_communications",
+    state: "partially_redacted",
+    reason: "Unrestricted tenant communications are not shared; only safe operational summaries may be referenced.",
+  },
+];
+
+export function sharingRoomSafetyFlags() {
+  return {
+    manualReviewRequired: true as const,
+    publiclyAccessible: false as const,
+    externalExecutionEnabled: false as const,
+    tokenizationEnabled: false as const,
+  };
+}

--- a/rentchain-api/src/lib/sharingRooms/sharingRoomTypes.ts
+++ b/rentchain-api/src/lib/sharingRooms/sharingRoomTypes.ts
@@ -1,0 +1,105 @@
+export const INSTITUTIONAL_SHARING_ROOMS_COLLECTION = "institutionalSharingRooms";
+
+export type SharingRoomType =
+  | "lender_review"
+  | "insurer_review"
+  | "auditor_review"
+  | "regulator_review"
+  | "operational_partner_review";
+
+export type SharingRoomStatus = "draft" | "review_required" | "active" | "expired" | "blocked";
+
+export type SharingInstitutionType = "lender" | "insurer" | "auditor" | "regulator" | "partner";
+
+export type SharingAccessStatus = "pending_review" | "active" | "expired" | "revoked";
+
+export type SharingScopeKind =
+  | "evidence_pack"
+  | "institution_export"
+  | "review_timeline"
+  | "audit_compliance"
+  | "identity_lineage"
+  | "operator_review"
+  | "workflow";
+
+export type SharingRedactionState = "excluded" | "partially_redacted" | "fully_redacted" | "blocked";
+
+export type SharingRoomEventType =
+  | "institutional_sharing_room_created"
+  | "institutional_sharing_room_review_required"
+  | "institutional_sharing_room_access_granted"
+  | "institutional_sharing_room_access_expired"
+  | "institutional_sharing_room_access_revoked"
+  | "institutional_sharing_room_redaction_applied";
+
+export type SharingAccessControl = {
+  accessControlId: string;
+  accessType: "view_only";
+  institutionType: SharingInstitutionType;
+  status: SharingAccessStatus;
+  manualApprovalRequired: true;
+  publicAccess: false;
+  downloadEnabled: false;
+  externalSubmissionEnabled: false;
+  allowedScopes: SharingScopeKind[];
+  redactionLevel: "strict" | "standard";
+  expiresAt: string | null;
+};
+
+export type SharingScopeReference = {
+  scopeKey: SharingScopeKind;
+  scopeId: string;
+  label: string;
+  status: "available" | "blocked" | "missing";
+  destination: string | null;
+  blockedReason: string | null;
+};
+
+export type SharingRoomRedaction = {
+  fieldCategory: string;
+  state: SharingRedactionState;
+  reason: string;
+};
+
+export type SharingRoomAuditReference = {
+  eventType: SharingRoomEventType;
+  summary: string;
+  occurredAt: string;
+};
+
+export type InstitutionalSharingRoom = {
+  sharingRoomId: string;
+  landlordId: string;
+  roomType: SharingRoomType;
+  status: SharingRoomStatus;
+  manualReviewRequired: true;
+  publiclyAccessible: false;
+  externalExecutionEnabled: false;
+  tokenizationEnabled: false;
+  createdAt: string;
+  updatedAt: string;
+  expiresAt: string | null;
+  createdBy: {
+    userId: string | null;
+    role: "landlord" | "admin" | "operator";
+    email?: string | null;
+  };
+  accessControls: SharingAccessControl;
+  sharedScopes: SharingScopeReference[];
+  redactions: SharingRoomRedaction[];
+  auditReferences: SharingRoomAuditReference[];
+  timelineReferences: SharingScopeReference[];
+  evidenceReferences: SharingScopeReference[];
+};
+
+export type SharingRoomCreateRequest = {
+  roomType: SharingRoomType;
+  institutionType: SharingInstitutionType;
+  redactionLevel: "strict" | "standard";
+  expiresAt?: string | null;
+  sharedScopes: Array<{
+    scopeKey: SharingScopeKind;
+    scopeId: string;
+    label?: string | null;
+  }>;
+};

--- a/rentchain-api/src/routes/__tests__/landlordSharingRoomRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordSharingRoomRoutes.test.ts
@@ -1,0 +1,219 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fakeDb, resetFakeDb, listDocs } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+
+  function matches(doc: any, filters: Array<{ field: string; op: string; value: any }>) {
+    return filters.every(({ field, op, value }) => {
+      const actual = doc?.data?.[field];
+      if (op === "==") return actual === value;
+      return false;
+    });
+  }
+
+  function makeQuery(name: string, filters: Array<{ field: string; op: string; value: any }> = []) {
+    return {
+      where: (field: string, op: string, value: any) => makeQuery(name, [...filters, { field, op, value }]),
+      get: async () => {
+        const docs = Array.from(ensureCollection(name).values())
+          .filter((doc) => matches(doc, filters))
+          .map((doc) => ({ id: doc.id, exists: true, data: () => doc.data }));
+        return { docs, empty: docs.length === 0, size: docs.length };
+      },
+      doc: (id: string) => makeDoc(name, id),
+    };
+  }
+
+  function makeDoc(name: string, id: string) {
+    const col = ensureCollection(name);
+    return {
+      id,
+      get: async () => {
+        const entry = col.get(id);
+        return { id, exists: Boolean(entry), data: () => entry?.data };
+      },
+      set: async (data: any) => {
+        col.set(id, { id, data });
+      },
+    };
+  }
+
+  return {
+    resetFakeDb: () => store.clear(),
+    listDocs: (collection: string) => Array.from(ensureCollection(collection).values()).map((entry) => entry.data),
+    fakeDb: {
+      collection: (name: string) => ({
+        where: (field: string, op: string, value: any) => makeQuery(name, [{ field, op, value }]),
+        get: async () => makeQuery(name).get(),
+        doc: (id: string) => makeDoc(name, id),
+      }),
+    },
+  };
+});
+
+let mockUser: any;
+
+vi.mock("../../config/firebase", () => ({
+  db: fakeDb,
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!mockUser) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    req.user = mockUser;
+    return next();
+  },
+}));
+
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: any, res: any, next: any) => {
+    const role = String(req.user?.role || "").trim().toLowerCase();
+    const landlordId = req.user?.landlordId || req.user?.id;
+    if (role !== "landlord" && role !== "admin") return res.status(403).json({ ok: false, error: "Forbidden" });
+    if (!landlordId) return res.status(401).json({ ok: false, error: "Missing landlord context" });
+    req.user.landlordId = landlordId;
+    return next();
+  },
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; body?: any; user?: Record<string, unknown> | null }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    const query = new URLSearchParams(queryString || "");
+    mockUser = options.user ?? mockUser;
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: mockUser,
+      body: options.body || {},
+      query: Object.fromEntries(query.entries()),
+      params: {},
+      headers: {},
+    };
+    const match = path.match(/^\/sharing-rooms\/([^/]+)(?:\/(revoke))?$/);
+    if (match) req.params = { sharingRoomId: decodeURIComponent(match[1]) };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("landlordSharingRoomRoutes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    resetFakeDb();
+    mockUser = { id: "landlord-1", landlordId: "landlord-1", role: "landlord", email: "landlord@example.com" };
+  });
+
+  it("creates permissioned sharing rooms and writes additive events", async () => {
+    const router = (await import("../landlordSharingRoomRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/sharing-rooms",
+      body: {
+        roomType: "lender_review",
+        institutionType: "lender",
+        sharedScopes: [
+          { scopeKey: "evidence_pack", scopeId: "decision-1", label: "Decision evidence" },
+          { scopeKey: "identity_lineage", scopeId: "tenant-1", label: "Tenant identity lineage" },
+        ],
+      },
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body.room).toEqual(
+      expect.objectContaining({
+        landlordId: "landlord-1",
+        roomType: "lender_review",
+        status: "review_required",
+        manualReviewRequired: true,
+        publiclyAccessible: false,
+        externalExecutionEnabled: false,
+        tokenizationEnabled: false,
+      })
+    );
+    expect(res.body.room.accessControls).toEqual(
+      expect.objectContaining({
+        publicAccess: false,
+        downloadEnabled: false,
+        externalSubmissionEnabled: false,
+      })
+    );
+    expect(listDocs("institutionalSharingRooms")).toHaveLength(1);
+    expect(listDocs("canonicalEvents").map((event: any) => event.type)).toEqual([
+      "institutional_sharing_room_created",
+      "institutional_sharing_room_review_required",
+    ]);
+  });
+
+  it("lists only landlord-scoped rooms", async () => {
+    const router = (await import("../landlordSharingRoomRoutes")).default;
+    await invokeRouter(router, {
+      method: "POST",
+      url: "/sharing-rooms",
+      body: { roomType: "auditor_review", institutionType: "auditor", sharedScopes: [{ scopeKey: "audit_compliance", scopeId: "readiness-1" }] },
+    });
+    mockUser = { id: "landlord-2", landlordId: "landlord-2", role: "landlord", email: "other@example.com" };
+
+    const res = await invokeRouter(router, { method: "GET", url: "/sharing-rooms" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.rooms).toEqual([]);
+  });
+
+  it("revokes access without deleting room lineage", async () => {
+    const router = (await import("../landlordSharingRoomRoutes")).default;
+    const create = await invokeRouter(router, {
+      method: "POST",
+      url: "/sharing-rooms",
+      body: { roomType: "insurer_review", institutionType: "insurer", sharedScopes: [{ scopeKey: "institution_export", scopeId: "package-1" }] },
+    });
+    const sharingRoomId = create.body.room.sharingRoomId;
+
+    const revoke = await invokeRouter(router, {
+      method: "POST",
+      url: `/sharing-rooms/${encodeURIComponent(sharingRoomId)}/revoke`,
+    });
+
+    expect(revoke.status).toBe(200);
+    expect(revoke.body.room.status).toBe("expired");
+    expect(revoke.body.room.accessControls.status).toBe("revoked");
+    expect(revoke.body.room.sharedScopes).toHaveLength(1);
+    expect(listDocs("canonicalEvents").map((event: any) => event.type)).toContain("institutional_sharing_room_access_revoked");
+  });
+
+  it("blocks invalid requests and non-landlord users", async () => {
+    const router = (await import("../landlordSharingRoomRoutes")).default;
+    const invalid = await invokeRouter(router, {
+      method: "POST",
+      url: "/sharing-rooms",
+      body: { roomType: "lender_review", institutionType: "lender", sharedScopes: [] },
+    });
+    expect(invalid.status).toBe(400);
+
+    const forbidden = await invokeRouter(router, {
+      method: "GET",
+      url: "/sharing-rooms",
+      user: { id: "tenant-1", role: "tenant" },
+    });
+    expect(forbidden.status).toBe(403);
+  });
+});

--- a/rentchain-api/src/routes/landlordSharingRoomRoutes.ts
+++ b/rentchain-api/src/routes/landlordSharingRoomRoutes.ts
@@ -1,0 +1,174 @@
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { requireAuth } from "../middleware/requireAuth";
+import { requireLandlord } from "../middleware/requireLandlord";
+import { writeCanonicalEvent } from "../lib/events/buildEvent";
+import {
+  buildInstitutionalSharingRoom,
+  normalizeInstitutionalSharingRoom,
+  parseSharingRoomCreateRequest,
+  revokeInstitutionalSharingRoom,
+} from "../lib/sharingRooms/buildInstitutionalSharingRoom";
+import {
+  INSTITUTIONAL_SHARING_ROOMS_COLLECTION,
+  type InstitutionalSharingRoom,
+  type SharingRoomEventType,
+} from "../lib/sharingRooms/sharingRoomTypes";
+
+const router = Router();
+
+function asString(value: unknown, max = 1000) {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function landlordIdFromReq(req: any) {
+  return asString(req.user?.landlordId || req.user?.id || req.user?.sub, 240);
+}
+
+function actorFromReq(req: any): InstitutionalSharingRoom["createdBy"] {
+  const role = asString(req.user?.role || req.user?.actorRole, 80).toLowerCase();
+  return {
+    userId: asString(req.user?.uid || req.user?.id || req.user?.sub, 240) || null,
+    role: role === "admin" ? "admin" : role === "operator" ? "operator" : "landlord",
+    email: asString(req.user?.email, 320) || null,
+  };
+}
+
+function eventIdFor(input: { eventType: SharingRoomEventType; sharingRoomId: string; at: string }) {
+  return [input.eventType, input.sharingRoomId, input.at]
+    .join(":")
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+async function writeSharingRoomEvent(input: {
+  eventType: SharingRoomEventType;
+  room: InstitutionalSharingRoom;
+  actor: InstitutionalSharingRoom["createdBy"];
+  summary: string;
+}) {
+  const occurredAt = input.room.updatedAt || new Date().toISOString();
+  await writeCanonicalEvent({
+    id: eventIdFor({ eventType: input.eventType, sharingRoomId: input.room.sharingRoomId, at: occurredAt }),
+    type: input.eventType,
+    domain: "system",
+    action: input.eventType,
+    status: input.room.status,
+    actor: {
+      type: input.actor.role === "admin" ? "admin" : "landlord",
+      id: input.actor.userId,
+      role: input.actor.role,
+      displayName: input.actor.email || null,
+    },
+    resource: {
+      type: "institutional_sharing_room",
+      id: input.room.sharingRoomId,
+      parentType: "landlord",
+      parentId: input.room.landlordId,
+    },
+    occurredAt,
+    visibility: "landlord",
+    summary: input.summary,
+    metadata: {
+      landlordId: input.room.landlordId,
+      roomType: input.room.roomType,
+      manualReviewRequired: true,
+      publiclyAccessible: false,
+      externalExecutionEnabled: false,
+      tokenizationEnabled: false,
+    },
+    tags: ["institutional_sharing_room", input.room.roomType],
+  });
+}
+
+async function loadRoomForLandlord(sharingRoomId: string, landlordId: string) {
+  const snap = await db.collection(INSTITUTIONAL_SHARING_ROOMS_COLLECTION).doc(sharingRoomId).get();
+  if (!snap.exists) return null;
+  const room = normalizeInstitutionalSharingRoom({ id: snap.id, ...((snap.data() as any) || {}) });
+  if (!room || room.landlordId !== landlordId) return null;
+  return room;
+}
+
+router.get("/sharing-rooms", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = landlordIdFromReq(req);
+    if (!landlordId) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    const snap = await db.collection(INSTITUTIONAL_SHARING_ROOMS_COLLECTION).where("landlordId", "==", landlordId).get();
+    const rooms = (snap.docs || [])
+      .map((doc: any) => normalizeInstitutionalSharingRoom({ id: doc.id, ...((doc.data() as any) || {}) }))
+      .filter((room): room is InstitutionalSharingRoom => Boolean(room))
+      .sort((a: InstitutionalSharingRoom, b: InstitutionalSharingRoom) => b.updatedAt.localeCompare(a.updatedAt));
+    return res.json({ ok: true, rooms });
+  } catch (err: any) {
+    console.error("[landlordSharingRoomRoutes] list failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "SHARING_ROOM_LIST_FAILED" });
+  }
+});
+
+router.post("/sharing-rooms", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = landlordIdFromReq(req);
+    const request = parseSharingRoomCreateRequest(req.body);
+    if (!landlordId || !request) return res.status(400).json({ ok: false, error: "SHARING_ROOM_CREATE_INVALID" });
+    const actor = actorFromReq(req);
+    const room = buildInstitutionalSharingRoom({ landlordId, request, actor });
+    await db.collection(INSTITUTIONAL_SHARING_ROOMS_COLLECTION).doc(room.sharingRoomId).set(room, { merge: false });
+    await writeSharingRoomEvent({
+      eventType: "institutional_sharing_room_created",
+      room,
+      actor,
+      summary: `Institutional sharing room created for ${room.roomType}.`,
+    });
+    await writeSharingRoomEvent({
+      eventType: "institutional_sharing_room_review_required",
+      room,
+      actor,
+      summary: "Manual review is required before institutional access can be relied on.",
+    });
+    return res.status(201).json({ ok: true, room });
+  } catch (err: any) {
+    console.error("[landlordSharingRoomRoutes] create failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "SHARING_ROOM_CREATE_FAILED" });
+  }
+});
+
+router.get("/sharing-rooms/:sharingRoomId", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = landlordIdFromReq(req);
+    const sharingRoomId = decodeURIComponent(asString(req.params?.sharingRoomId, 500));
+    if (!landlordId || !sharingRoomId) return res.status(400).json({ ok: false, error: "SHARING_ROOM_ID_REQUIRED" });
+    const room = await loadRoomForLandlord(sharingRoomId, landlordId);
+    if (!room) return res.status(404).json({ ok: false, error: "SHARING_ROOM_NOT_FOUND" });
+    return res.json({ ok: true, room });
+  } catch (err: any) {
+    console.error("[landlordSharingRoomRoutes] get failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "SHARING_ROOM_GET_FAILED" });
+  }
+});
+
+router.post("/sharing-rooms/:sharingRoomId/revoke", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = landlordIdFromReq(req);
+    const sharingRoomId = decodeURIComponent(asString(req.params?.sharingRoomId, 500));
+    if (!landlordId || !sharingRoomId) return res.status(400).json({ ok: false, error: "SHARING_ROOM_ID_REQUIRED" });
+    const existing = await loadRoomForLandlord(sharingRoomId, landlordId);
+    if (!existing) return res.status(404).json({ ok: false, error: "SHARING_ROOM_NOT_FOUND" });
+    const actor = actorFromReq(req);
+    const room = revokeInstitutionalSharingRoom({ room: existing });
+    await db.collection(INSTITUTIONAL_SHARING_ROOMS_COLLECTION).doc(room.sharingRoomId).set(room, { merge: false });
+    await writeSharingRoomEvent({
+      eventType: "institutional_sharing_room_access_revoked",
+      room,
+      actor,
+      summary: "Institutional sharing room access revoked.",
+    });
+    return res.json({ ok: true, room });
+  } catch (err: any) {
+    console.error("[landlordSharingRoomRoutes] revoke failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "SHARING_ROOM_REVOKE_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -122,6 +122,10 @@ vi.mock("./pages/IdentityLayerPage", () => ({
   default: () => <h1>Identity Layer Page</h1>,
 }));
 
+vi.mock("./pages/InstitutionalSharingRoomPage", () => ({
+  default: () => <h1>Institutional Sharing Rooms Page</h1>,
+}));
+
 vi.mock("./pages/landlord/PortfolioScorePage", () => ({
   default: () => <h1>Landlord Portfolio Score</h1>,
 }));
@@ -341,6 +345,20 @@ describe("Routes: /identity-layer", () => {
     );
 
     expect(await screen.findByText(/Identity Layer Page/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Routes: /institutional-sharing-rooms", () => {
+  it("renders the institutional sharing room route", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/institutional-sharing-rooms"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Institutional Sharing Rooms Page/i)).toBeInTheDocument();
     expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -123,6 +123,7 @@ const AuditCompliancePage = lazy(() => import("./pages/AuditCompliancePage"));
 const EvidencePackPage = lazy(() => import("./pages/EvidencePackPage"));
 const ReviewTimelinePage = lazy(() => import("./pages/ReviewTimelinePage"));
 const IdentityLayerPage = lazy(() => import("./pages/IdentityLayerPage"));
+const InstitutionalSharingRoomPage = lazy(() => import("./pages/InstitutionalSharingRoomPage"));
 const LandlordPortfolioScorePage = lazy(() => import("./pages/landlord/PortfolioScorePage"));
 const SharedPortfolioScorePage = lazy(() => import("./pages/public/SharedPortfolioScorePage"));
 const TenantSharePackagePage = lazy(() => import("./pages/public/TenantSharePackagePage"));
@@ -590,6 +591,18 @@ function App() {
               <LandlordNav>
                 <Suspense fallback={null}>
                   <IdentityLayerPage />
+                </Suspense>
+              </LandlordNav>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/institutional-sharing-rooms"
+          element={
+            <RequireAuth>
+              <LandlordNav>
+                <Suspense fallback={null}>
+                  <InstitutionalSharingRoomPage />
                 </Suspense>
               </LandlordNav>
             </RequireAuth>

--- a/rentchain-frontend/src/api/sharingRoomsApi.ts
+++ b/rentchain-frontend/src/api/sharingRoomsApi.ts
@@ -1,0 +1,89 @@
+import { apiFetch } from "./apiFetch";
+
+export type SharingRoomType =
+  | "lender_review"
+  | "insurer_review"
+  | "auditor_review"
+  | "regulator_review"
+  | "operational_partner_review";
+
+export type SharingRoomStatus = "draft" | "review_required" | "active" | "expired" | "blocked";
+export type SharingInstitutionType = "lender" | "insurer" | "auditor" | "regulator" | "partner";
+export type SharingAccessStatus = "pending_review" | "active" | "expired" | "revoked";
+export type SharingScopeKind =
+  | "evidence_pack"
+  | "institution_export"
+  | "review_timeline"
+  | "audit_compliance"
+  | "identity_lineage"
+  | "operator_review"
+  | "workflow";
+
+export type SharingScopeReference = {
+  scopeKey: SharingScopeKind;
+  scopeId: string;
+  label: string;
+  status: "available" | "blocked" | "missing";
+  destination: string | null;
+  blockedReason: string | null;
+};
+
+export type InstitutionalSharingRoom = {
+  sharingRoomId: string;
+  roomType: SharingRoomType;
+  status: SharingRoomStatus;
+  manualReviewRequired: true;
+  publiclyAccessible: false;
+  externalExecutionEnabled: false;
+  tokenizationEnabled: false;
+  createdAt: string;
+  updatedAt: string;
+  expiresAt: string | null;
+  accessControls: {
+    accessControlId: string;
+    accessType: "view_only";
+    institutionType: SharingInstitutionType;
+    status: SharingAccessStatus;
+    manualApprovalRequired: true;
+    publicAccess: false;
+    downloadEnabled: false;
+    externalSubmissionEnabled: false;
+    allowedScopes: SharingScopeKind[];
+    redactionLevel: "strict" | "standard";
+    expiresAt: string | null;
+  };
+  sharedScopes: SharingScopeReference[];
+  redactions: Array<{ fieldCategory: string; state: string; reason: string }>;
+  auditReferences: Array<{ eventType: string; summary: string; occurredAt: string }>;
+  timelineReferences: SharingScopeReference[];
+  evidenceReferences: SharingScopeReference[];
+};
+
+export type SharingRoomCreateInput = {
+  roomType: SharingRoomType;
+  institutionType: SharingInstitutionType;
+  redactionLevel?: "strict" | "standard";
+  expiresAt?: string | null;
+  sharedScopes: Array<{ scopeKey: SharingScopeKind; scopeId: string; label?: string | null }>;
+};
+
+export async function fetchSharingRooms(): Promise<InstitutionalSharingRoom[]> {
+  const response = await apiFetch<{ ok: true; rooms: InstitutionalSharingRoom[] }>("/landlord/sharing-rooms");
+  return response.rooms;
+}
+
+export async function createSharingRoom(input: SharingRoomCreateInput): Promise<InstitutionalSharingRoom> {
+  const response = await apiFetch<{ ok: true; room: InstitutionalSharingRoom }>("/landlord/sharing-rooms", {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+  return response.room;
+}
+
+export async function revokeSharingRoom(sharingRoomId: string): Promise<InstitutionalSharingRoom> {
+  const response = await apiFetch<{ ok: true; room: InstitutionalSharingRoom }>(
+    `/landlord/sharing-rooms/${encodeURIComponent(sharingRoomId)}/revoke`,
+    { method: "POST" }
+  );
+  return response.room;
+}

--- a/rentchain-frontend/src/components/evidence/EvidencePackPanel.tsx
+++ b/rentchain-frontend/src/components/evidence/EvidencePackPanel.tsx
@@ -65,6 +65,9 @@ export function EvidencePackPanel({ evidencePack }: { evidencePack: EvidencePack
           >
             View timeline
           </Link>
+          <Link to="/institutional-sharing-rooms" style={{ color: "#2563eb", fontWeight: 800, fontSize: 13 }}>
+            View sharing room
+          </Link>
         </div>
       </Section>
 

--- a/rentchain-frontend/src/components/sharingRooms/InstitutionalSharingRoom.test.tsx
+++ b/rentchain-frontend/src/components/sharingRooms/InstitutionalSharingRoom.test.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { InstitutionalSharingRoom } from "./InstitutionalSharingRoom";
+import type { InstitutionalSharingRoom as SharingRoom } from "@/api/sharingRoomsApi";
+
+function room(overrides: Partial<SharingRoom> = {}): SharingRoom {
+  return {
+    sharingRoomId: "room-1",
+    roomType: "lender_review",
+    status: "review_required",
+    manualReviewRequired: true,
+    publiclyAccessible: false,
+    externalExecutionEnabled: false,
+    tokenizationEnabled: false,
+    createdAt: "2026-05-06T00:00:00.000Z",
+    updatedAt: "2026-05-06T00:00:00.000Z",
+    expiresAt: "2026-05-20T00:00:00.000Z",
+    accessControls: {
+      accessControlId: "access-1",
+      accessType: "view_only",
+      institutionType: "lender",
+      status: "pending_review",
+      manualApprovalRequired: true,
+      publicAccess: false,
+      downloadEnabled: false,
+      externalSubmissionEnabled: false,
+      allowedScopes: ["evidence_pack"],
+      redactionLevel: "strict",
+      expiresAt: "2026-05-20T00:00:00.000Z",
+    },
+    sharedScopes: [
+      {
+        scopeKey: "evidence_pack",
+        scopeId: "decision-1",
+        label: "Decision evidence",
+        status: "available",
+        destination: "/evidence-packs?scope=decision&scopeId=decision-1",
+        blockedReason: null,
+      },
+    ],
+    redactions: [
+      {
+        fieldCategory: "payment_account_details",
+        state: "excluded",
+        reason: "Payment account details are excluded.",
+      },
+    ],
+    auditReferences: [
+      {
+        eventType: "institutional_sharing_room_created",
+        summary: "created",
+        occurredAt: "2026-05-06T00:00:00.000Z",
+      },
+    ],
+    timelineReferences: [],
+    evidenceReferences: [],
+    ...overrides,
+  };
+}
+
+describe("InstitutionalSharingRoom", () => {
+  afterEach(() => cleanup());
+
+  it("renders access controls, redactions, audit lineage, and safety copy", () => {
+    const onRevoke = vi.fn();
+    render(
+      <MemoryRouter>
+        <InstitutionalSharingRoom room={room()} onRevoke={onRevoke} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("View sharing room")).toBeInTheDocument();
+    expect(screen.getByText("Lender Review")).toBeInTheDocument();
+    expect(screen.getByText(/Institutional sharing remains permissioned and review controlled/i)).toBeInTheDocument();
+    expect(screen.getByText(/Sensitive data may be excluded or redacted/i)).toBeInTheDocument();
+    expect(screen.getByText(/No public sharing or automated submission is enabled/i)).toBeInTheDocument();
+    expect(screen.getByText("View Only")).toBeInTheDocument();
+    expect(screen.getByText("Decision evidence")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "View evidence" })).toHaveAttribute(
+      "href",
+      "/evidence-packs?scope=decision&scopeId=decision-1"
+    );
+    expect(screen.getByText("Payment Account Details")).toBeInTheDocument();
+    expect(screen.getByText("Institutional Sharing Room Created")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Revoke access" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /publish publicly|make public|auto-submit|auto-share|export unrestricted|mint token|permanent public access/i })).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/sharingRooms/InstitutionalSharingRoom.tsx
+++ b/rentchain-frontend/src/components/sharingRooms/InstitutionalSharingRoom.tsx
@@ -1,0 +1,135 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import type { InstitutionalSharingRoom as SharingRoom } from "@/api/sharingRoomsApi";
+import { Button, Card, Section } from "@/components/ui/Ui";
+
+function label(value: string) {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function statusTone(status: string) {
+  if (status === "blocked" || status === "revoked" || status === "expired") {
+    return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
+  }
+  if (status === "review_required" || status === "pending_review") {
+    return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
+  }
+  if (status === "active" || status === "available") return { color: "#166534", background: "#dcfce7", border: "#bbf7d0" };
+  return { color: "#475569", background: "#f8fafc", border: "#e2e8f0" };
+}
+
+function Badge({ children, status }: { children: React.ReactNode; status: string }) {
+  const tone = statusTone(status);
+  return (
+    <span
+      style={{
+        border: `1px solid ${tone.border}`,
+        borderRadius: 999,
+        background: tone.background,
+        color: tone.color,
+        padding: "3px 9px",
+        fontSize: 12,
+        fontWeight: 900,
+        whiteSpace: "nowrap",
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+export function InstitutionalSharingRoom({
+  room,
+  onRevoke,
+  revoking,
+}: {
+  room: SharingRoom;
+  onRevoke?: (sharingRoomId: string) => void;
+  revoking?: boolean;
+}) {
+  return (
+    <Card style={{ borderRadius: 8, display: "grid", gap: 12 }}>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+        <div>
+          <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>View sharing room</div>
+          <h2 style={{ margin: "2px 0 0", fontSize: "1.1rem" }}>{label(room.roomType)}</h2>
+        </div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <Badge status={room.status}>{label(room.status)}</Badge>
+          <Badge status={room.accessControls.status}>{label(room.accessControls.status)}</Badge>
+        </div>
+      </div>
+
+      <div style={{ color: "#475569", lineHeight: 1.55 }}>
+        Institutional sharing remains permissioned and review controlled. Sensitive data may be excluded or redacted. No public
+        sharing or automated submission is enabled.
+      </div>
+
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 8 }}>
+        <Card style={{ borderRadius: 8, padding: 10 }}>
+          <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>Institution</div>
+          <strong>{label(room.accessControls.institutionType)}</strong>
+        </Card>
+        <Card style={{ borderRadius: 8, padding: 10 }}>
+          <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>Access</div>
+          <strong>{label(room.accessControls.accessType)}</strong>
+        </Card>
+        <Card style={{ borderRadius: 8, padding: 10 }}>
+          <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>Expires</div>
+          <strong>{room.expiresAt ? new Date(room.expiresAt).toLocaleDateString() : "Review required"}</strong>
+        </Card>
+        <Card style={{ borderRadius: 8, padding: 10 }}>
+          <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>Download</div>
+          <strong>{room.accessControls.downloadEnabled ? "Enabled" : "Disabled"}</strong>
+        </Card>
+      </div>
+
+      <Section style={{ display: "grid", gap: 8, padding: 0, boxShadow: "none", border: 0 }}>
+        <div style={{ fontWeight: 900 }}>Review access scope</div>
+        {room.sharedScopes.map((scope) => (
+          <div key={`${scope.scopeKey}:${scope.scopeId}`} style={{ border: "1px solid #e2e8f0", borderRadius: 8, padding: 10 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+              <strong>{scope.label}</strong>
+              <Badge status={scope.status}>{label(scope.status)}</Badge>
+            </div>
+            <div style={{ color: "#64748b", fontSize: 13 }}>{label(scope.scopeKey)}</div>
+            {scope.blockedReason ? <div style={{ color: "#991b1b", fontSize: 13 }}>{scope.blockedReason}</div> : null}
+            {scope.destination ? (
+              <Link to={scope.destination} style={{ color: "#2563eb", fontWeight: 800, fontSize: 13 }}>
+                View evidence
+              </Link>
+            ) : null}
+          </div>
+        ))}
+      </Section>
+
+      <Section style={{ display: "grid", gap: 8, padding: 0, boxShadow: "none", border: 0 }}>
+        <div style={{ fontWeight: 900 }}>Review redactions</div>
+        {room.redactions.map((redaction) => (
+          <div key={redaction.fieldCategory} style={{ border: "1px solid #e2e8f0", borderRadius: 8, padding: 10 }}>
+            <strong>{label(redaction.fieldCategory)}</strong>
+            <div style={{ color: "#64748b", fontSize: 13 }}>{label(redaction.state)}</div>
+            <div style={{ color: "#475569", fontSize: 13 }}>{redaction.reason}</div>
+          </div>
+        ))}
+      </Section>
+
+      <Section style={{ display: "grid", gap: 8, padding: 0, boxShadow: "none", border: 0 }}>
+        <div style={{ fontWeight: 900 }}>View audit lineage</div>
+        {room.auditReferences.map((event) => (
+          <div key={`${event.eventType}:${event.occurredAt}`} style={{ color: "#475569", fontSize: 13 }}>
+            {label(event.eventType)}
+          </div>
+        ))}
+      </Section>
+
+      {onRevoke && room.accessControls.status !== "revoked" ? (
+        <div>
+          <Button type="button" onClick={() => onRevoke(room.sharingRoomId)} disabled={revoking}>
+            Revoke access
+          </Button>
+        </div>
+      ) : null}
+    </Card>
+  );
+}

--- a/rentchain-frontend/src/pages/InstitutionExportsPage.tsx
+++ b/rentchain-frontend/src/pages/InstitutionExportsPage.tsx
@@ -147,6 +147,9 @@ export default function InstitutionExportsPage() {
             <Link to="/audit-compliance" style={{ color: "#2563eb", fontWeight: 800 }}>
               View readiness
             </Link>
+            <Link to="/institutional-sharing-rooms" style={{ color: "#2563eb", fontWeight: 800 }}>
+              View sharing room
+            </Link>
           </div>
         </Section>
 

--- a/rentchain-frontend/src/pages/InstitutionalSharingRoomPage.test.tsx
+++ b/rentchain-frontend/src/pages/InstitutionalSharingRoomPage.test.tsx
@@ -1,0 +1,120 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import InstitutionalSharingRoomPage from "./InstitutionalSharingRoomPage";
+
+const apiMocks = vi.hoisted(() => ({
+  fetchSharingRooms: vi.fn(),
+  createSharingRoom: vi.fn(),
+  revokeSharingRoom: vi.fn(),
+  showToast: vi.fn(),
+  macShellProps: vi.fn(),
+}));
+
+vi.mock("@/api/sharingRoomsApi", async () => {
+  const actual = await vi.importActual<any>("@/api/sharingRoomsApi");
+  return {
+    ...actual,
+    fetchSharingRooms: apiMocks.fetchSharingRooms,
+    createSharingRoom: apiMocks.createSharingRoom,
+    revokeSharingRoom: apiMocks.revokeSharingRoom,
+  };
+});
+
+vi.mock("@/components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast: apiMocks.showToast }),
+}));
+
+vi.mock("@/components/layout/MacShell", () => ({
+  MacShell: ({ children, ...props }: { children: React.ReactNode; showTopNav?: boolean }) => {
+    apiMocks.macShellProps(props);
+    return <div>{children}</div>;
+  },
+}));
+
+function room() {
+  return {
+    sharingRoomId: "room-1",
+    roomType: "lender_review",
+    status: "review_required",
+    manualReviewRequired: true,
+    publiclyAccessible: false,
+    externalExecutionEnabled: false,
+    tokenizationEnabled: false,
+    createdAt: "2026-05-06T00:00:00.000Z",
+    updatedAt: "2026-05-06T00:00:00.000Z",
+    expiresAt: "2026-05-20T00:00:00.000Z",
+    accessControls: {
+      accessControlId: "access-1",
+      accessType: "view_only",
+      institutionType: "lender",
+      status: "pending_review",
+      manualApprovalRequired: true,
+      publicAccess: false,
+      downloadEnabled: false,
+      externalSubmissionEnabled: false,
+      allowedScopes: ["evidence_pack"],
+      redactionLevel: "strict",
+      expiresAt: "2026-05-20T00:00:00.000Z",
+    },
+    sharedScopes: [{ scopeKey: "evidence_pack", scopeId: "decision-1", label: "Decision evidence", status: "available", destination: "/evidence-packs", blockedReason: null }],
+    redactions: [{ fieldCategory: "payment_account_details", state: "excluded", reason: "Payment account details are excluded." }],
+    auditReferences: [{ eventType: "institutional_sharing_room_created", summary: "created", occurredAt: "2026-05-06T00:00:00.000Z" }],
+    timelineReferences: [],
+    evidenceReferences: [],
+  };
+}
+
+describe("InstitutionalSharingRoomPage", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    apiMocks.fetchSharingRooms.mockResolvedValue([room()]);
+    apiMocks.createSharingRoom.mockResolvedValue(room());
+    apiMocks.revokeSharingRoom.mockResolvedValue({
+      ...room(),
+      status: "expired",
+      accessControls: { ...room().accessControls, status: "revoked" },
+    });
+  });
+
+  it("renders rooms, creation controls, access scope, and safety copy", async () => {
+    render(
+      <MemoryRouter>
+        <InstitutionalSharingRoomPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole("heading", { name: "Institutional sharing rooms" })).toBeInTheDocument();
+    expect(screen.getAllByText(/Institutional sharing remains permissioned and review controlled/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Sensitive data may be excluded or redacted/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/No public sharing or automated submission is enabled/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("Create controlled room")).toBeInTheDocument();
+    expect(screen.getByText("Decision evidence")).toBeInTheDocument();
+    expect(screen.getByText("Payment Account Details")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /publish publicly|make public|auto-submit|auto-share|export unrestricted|mint token|permanent public access/i })).not.toBeInTheDocument();
+    expect(apiMocks.macShellProps).toHaveBeenCalledWith(expect.objectContaining({ showTopNav: false }));
+  });
+
+  it("creates and revokes rooms through scoped API helpers", async () => {
+    render(
+      <MemoryRouter>
+        <InstitutionalSharingRoomPage />
+      </MemoryRouter>
+    );
+
+    await screen.findByText("Decision evidence");
+    fireEvent.click(screen.getByRole("button", { name: "Review access scope" }));
+    expect(apiMocks.createSharingRoom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        roomType: "lender_review",
+        institutionType: "lender",
+        redactionLevel: "strict",
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Revoke access" }));
+    await waitFor(() => expect(apiMocks.revokeSharingRoom).toHaveBeenCalledWith("room-1"));
+  });
+});

--- a/rentchain-frontend/src/pages/InstitutionalSharingRoomPage.tsx
+++ b/rentchain-frontend/src/pages/InstitutionalSharingRoomPage.tsx
@@ -1,0 +1,168 @@
+import React from "react";
+import {
+  createSharingRoom,
+  fetchSharingRooms,
+  revokeSharingRoom,
+  type InstitutionalSharingRoom as SharingRoom,
+  type SharingInstitutionType,
+  type SharingRoomType,
+  type SharingScopeKind,
+} from "@/api/sharingRoomsApi";
+import { MacShell } from "@/components/layout/MacShell";
+import { InstitutionalSharingRoom } from "@/components/sharingRooms/InstitutionalSharingRoom";
+import { Button, Card, Section } from "@/components/ui/Ui";
+import { useToast } from "@/components/ui/ToastProvider";
+
+const roomTypes: SharingRoomType[] = [
+  "lender_review",
+  "insurer_review",
+  "auditor_review",
+  "regulator_review",
+  "operational_partner_review",
+];
+const institutionTypes: SharingInstitutionType[] = ["lender", "insurer", "auditor", "regulator", "partner"];
+const scopeKinds: SharingScopeKind[] = [
+  "evidence_pack",
+  "institution_export",
+  "review_timeline",
+  "audit_compliance",
+  "identity_lineage",
+  "operator_review",
+  "workflow",
+];
+
+function label(value: string) {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function errorMessage(error: unknown) {
+  if (error instanceof Error && error.message) return error.message;
+  return "Failed to load institutional sharing rooms";
+}
+
+export default function InstitutionalSharingRoomPage() {
+  const { showToast } = useToast();
+  const [rooms, setRooms] = React.useState<SharingRoom[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [saving, setSaving] = React.useState(false);
+  const [revokingId, setRevokingId] = React.useState<string | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+  const [roomType, setRoomType] = React.useState<SharingRoomType>("lender_review");
+  const [institutionType, setInstitutionType] = React.useState<SharingInstitutionType>("lender");
+  const [scopeKey, setScopeKey] = React.useState<SharingScopeKind>("evidence_pack");
+  const [scopeId, setScopeId] = React.useState("decision-1");
+
+  const loadRooms = React.useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const next = await fetchSharingRooms();
+      setRooms(next);
+    } catch (err) {
+      const message = errorMessage(err);
+      setError(message);
+      showToast({ message: "Failed to load institutional sharing rooms", description: message, variant: "error" });
+    } finally {
+      setLoading(false);
+    }
+  }, [showToast]);
+
+  React.useEffect(() => {
+    void loadRooms();
+  }, [loadRooms]);
+
+  async function createRoom() {
+    if (!scopeId.trim()) return;
+    try {
+      setSaving(true);
+      const room = await createSharingRoom({
+        roomType,
+        institutionType,
+        redactionLevel: "strict",
+        sharedScopes: [{ scopeKey, scopeId: scopeId.trim(), label: label(scopeKey) }],
+      });
+      setRooms((current) => [room, ...current.filter((item) => item.sharingRoomId !== room.sharingRoomId)]);
+    } catch (err) {
+      const message = errorMessage(err);
+      showToast({ message: "Failed to create institutional sharing room", description: message, variant: "error" });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function revokeRoom(sharingRoomId: string) {
+    try {
+      setRevokingId(sharingRoomId);
+      const room = await revokeSharingRoom(sharingRoomId);
+      setRooms((current) => current.map((item) => (item.sharingRoomId === room.sharingRoomId ? room : item)));
+    } catch (err) {
+      const message = errorMessage(err);
+      showToast({ message: "Failed to revoke sharing room access", description: message, variant: "error" });
+    } finally {
+      setRevokingId(null);
+    }
+  }
+
+  return (
+    <MacShell title="Institutional sharing rooms" showTopNav={false}>
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "grid", gap: 6 }}>
+            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Institutional sharing rooms</h1>
+            <div style={{ color: "#475569", maxWidth: 900 }}>
+              Institutional sharing remains permissioned and review controlled. Sensitive data may be excluded or redacted.
+              No public sharing or automated submission is enabled.
+            </div>
+          </div>
+        </Section>
+
+        <Section style={{ display: "grid", gap: 12 }}>
+          <div style={{ fontWeight: 900 }}>Create controlled room</div>
+          <div style={{ display: "flex", gap: 10, flexWrap: "wrap", alignItems: "end" }}>
+            <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+              Room type
+              <select value={roomType} onChange={(event) => setRoomType(event.target.value as SharingRoomType)} style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px" }}>
+                {roomTypes.map((type) => <option key={type} value={type}>{label(type)}</option>)}
+              </select>
+            </label>
+            <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+              Institution
+              <select value={institutionType} onChange={(event) => setInstitutionType(event.target.value as SharingInstitutionType)} style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px" }}>
+                {institutionTypes.map((type) => <option key={type} value={type}>{label(type)}</option>)}
+              </select>
+            </label>
+            <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+              Scope
+              <select value={scopeKey} onChange={(event) => setScopeKey(event.target.value as SharingScopeKind)} style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px" }}>
+                {scopeKinds.map((kind) => <option key={kind} value={kind}>{label(kind)}</option>)}
+              </select>
+            </label>
+            <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+              Scope ID
+              <input value={scopeId} onChange={(event) => setScopeId(event.target.value)} style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 220 }} />
+            </label>
+            <Button type="button" onClick={createRoom} disabled={saving || !scopeId.trim()}>
+              Review access scope
+            </Button>
+          </div>
+        </Section>
+
+        {loading ? <Card>Loading institutional sharing rooms...</Card> : null}
+        {!loading && error ? <Card style={{ color: "#b91c1c" }}>We couldn't load institutional sharing rooms right now.</Card> : null}
+        {!loading && !error && !rooms.length ? <Card style={{ color: "#64748b" }}>No institutional sharing rooms have been created yet.</Card> : null}
+        {!loading && !error && rooms.length ? (
+          <div style={{ display: "grid", gap: 12 }}>
+            {rooms.map((room) => (
+              <InstitutionalSharingRoom
+                key={room.sharingRoomId}
+                room={room}
+                onRevoke={revokeRoom}
+                revoking={revokingId === room.sharingRoomId}
+              />
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </MacShell>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds deterministic, landlord-scoped Institutional Sharing Room layer.
- Adds controlled view-only access metadata with expiration and revocation visibility.
- Adds redaction-aware shared scopes and audit/canonical event descriptors.
- Adds endpoints:
  - `GET /api/landlord/sharing-rooms`
  - `POST /api/landlord/sharing-rooms`
  - `GET /api/landlord/sharing-rooms/:sharingRoomId`
  - `POST /api/landlord/sharing-rooms/:sharingRoomId/revoke`
- Adds frontend `/institutional-sharing-rooms` surface and safe links from Evidence Packs and Institution Exports.
- Confirms `manualReviewRequired` remains true.
- Confirms `publiclyAccessible`, `externalExecutionEnabled`, and `tokenizationEnabled` remain false.
- Confirms no public sharing, tokenization, external integrations, unrestricted downloads, anonymous access, automated submission, sensitive data exposure, or admin-only leakage was added.

## Verification
- Backend targeted sharing-room tests passed: 9 tests.
- Frontend targeted sharing-room/routes tests passed: 35 tests.
- Backend full suite passed: 278 files / 1243 tests.
- Frontend full suite passed: 198 files / 786 tests.
- Backend build passed.
- Frontend build passed with existing chunk-size warning.
- `git diff --check` passed.
- Dependency/lockfile diff empty.
- Forbidden sharing labels absent.

## Guardrails
- No public sharing links or anonymous access.
- No unrestricted downloads.
- No live institutional integrations.
- No tokenization/blockchain identity sharing.
- No automated submission.
- No sensitive tenant/payment/screening payload exposure.
- No admin-only landlord-route leakage.