### PR TITLE
feat: add regulatory profile layer

### DIFF
--- a/docs/architecture/regulatory-profile-layer-v1.md
+++ b/docs/architecture/regulatory-profile-layer-v1.md
@@ -1,0 +1,83 @@
+# Regulatory Profile Layer v1
+
+## Purpose
+
+The Regulatory Profile Layer is a deterministic, landlord-scoped read model for jurisdiction-aware operational readiness. It normalizes registry, screening, privacy, institutional-sharing, settlement, export, audit, review, and evidence references into one profile per jurisdiction.
+
+This layer is operational readiness only. It does not provide legal advice, legal certification, regulator filing, external submission, autonomous compliance approval, or live government integration.
+
+## Model
+
+Regulatory profiles include:
+
+- jurisdiction: country, province, and municipality
+- status: `ready_for_review`, `partially_ready`, `blocked`, or `unknown`
+- required safety flags:
+  - `manualReviewRequired: true`
+  - `legalCertificationEnabled: false`
+  - `externalRegulatorSubmissionEnabled: false`
+- registry references
+- screening readiness summaries
+- privacy and consent readiness summaries
+- institutional-sharing restrictions
+- settlement-readiness restrictions
+- export/shareability restrictions
+- audit, review, and evidence lineage
+- redaction notes and blocked reasons
+
+## Deterministic Status Rules
+
+- `unknown`: insufficient landlord-scoped source context exists.
+- `blocked`: at least one required regulatory reference is blocked.
+- `partially_ready`: at least one reference is partially verified or unavailable, with no blocked reference.
+- `ready_for_review`: all available references are verified and no blocked reference exists.
+
+No AI scoring, probabilistic compliance scoring, legal conclusions, or jurisdiction ranking is used.
+
+## Restriction Rules
+
+Regulatory restrictions are derived from existing landlord-scoped read models:
+
+- missing consent lineage makes privacy readiness blocked
+- blocked settlement readiness creates a settlement restriction
+- blocked audit readiness creates an audit restriction
+- blocked export preview creates an export/shareability restriction
+- sharing room metadata that indicates public access, external execution, or blocked state creates a sharing restriction
+- missing registry verification creates a registry readiness restriction
+
+All restrictions include explicit reasons and preserve review/evidence lineage where safely available.
+
+## Redaction Rules
+
+Regulatory profiles expose summary references only. They exclude:
+
+- legal opinions and legal advice
+- government filing payloads
+- raw screening and credit bureau payloads
+- sensitive tenant and payment data
+- unrestricted regulatory export payloads
+
+## Canonical Event Descriptors
+
+The layer emits descriptor-only canonical event metadata:
+
+- `regulatory_profile_derived`
+- `regulatory_restriction_detected`
+- `regulatory_review_required`
+- `regulatory_profile_blocked`
+- `regulatory_redaction_applied`
+
+These descriptors are additive, deterministic, explainable, and traceable. They do not mutate source records or submit anything externally.
+
+## Non-Goals
+
+This layer does not add:
+
+- regulator integrations
+- legal filing
+- automated compliance certification
+- legal advice generation
+- government API submission
+- PSP/MSB execution
+- public compliance publishing
+- hidden compliance side effects

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -129,6 +129,7 @@ import landlordIdentityLayerRoutes from "./routes/landlordIdentityLayerRoutes";
 import landlordSharingRoomRoutes from "./routes/landlordSharingRoomRoutes";
 import landlordRentalHistoryLedgerRoutes from "./routes/landlordRentalHistoryLedgerRoutes";
 import landlordSettlementReadinessRoutes from "./routes/landlordSettlementReadinessRoutes";
+import landlordRegulatoryProfileRoutes from "./routes/landlordRegulatoryProfileRoutes";
 import publicPortfolioScoreRoutes from "./routes/publicPortfolioScoreRoutes";
 import publicTenantShareRoutes from "./routes/publicTenantShareRoutes";
 import landlordActionRecommendationRoutes from "./routes/landlordActionRecommendationRoutes";
@@ -310,6 +311,8 @@ app.use("/api/landlord", routeSource("landlordRentalHistoryLedgerRoutes.ts"), la
 console.log("[route-mount] landlordRentalHistoryLedgerRoutes mounted at /api/landlord");
 app.use("/api/landlord", routeSource("landlordSettlementReadinessRoutes.ts"), landlordSettlementReadinessRoutes);
 console.log("[route-mount] landlordSettlementReadinessRoutes mounted at /api/landlord");
+app.use("/api/landlord", routeSource("landlordRegulatoryProfileRoutes.ts"), landlordRegulatoryProfileRoutes);
+console.log("[route-mount] landlordRegulatoryProfileRoutes mounted at /api/landlord");
 app.use("/api", routeSource("landlordActionRecommendationRoutes.ts"), landlordActionRecommendationRoutes);
 console.log("[route-mount] landlordActionRecommendationRoutes mounted at /api");
 app.use("/api", routeSource("tenantFeedbackRoutes.ts"), tenantFeedbackRoutes);

--- a/rentchain-api/src/lib/regulatoryProfiles/__tests__/deriveRegulatoryProfile.test.ts
+++ b/rentchain-api/src/lib/regulatoryProfiles/__tests__/deriveRegulatoryProfile.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { deriveRegulatoryProfile } from "../deriveRegulatoryProfile";
+
+describe("deriveRegulatoryProfile", () => {
+  it("derives deterministic regulatory readiness with required safety flags", () => {
+    const profile = deriveRegulatoryProfile({
+      landlordId: "landlord-1",
+      province: "NS",
+      municipality: "Halifax",
+      properties: [{ id: "property-1", province: "NS", municipality: "Halifax" }],
+      registryStatuses: [{ propertyId: "property-1", status: "verified" }],
+      consentRecords: [{ id: "consent-1", tenantId: "tenant-1" }],
+      evidencePacks: [{ evidencePackId: "evidence-1" }],
+      operatorReviewSessions: [{ reviewSessionId: "review-1", status: "completed" }],
+      settlementReadiness: { status: "ready_for_review", settlementReadinessId: "settlement-1", reviewReferences: [], evidenceReferences: [], blockedReasons: [] } as any,
+      auditComplianceReadiness: { status: "ready_for_review", readinessId: "audit-1", checks: [] } as any,
+    });
+
+    expect(profile).toEqual(
+      expect.objectContaining({
+        manualReviewRequired: true,
+        legalCertificationEnabled: false,
+        externalRegulatorSubmissionEnabled: false,
+      })
+    );
+    expect(profile.jurisdiction).toEqual({ country: "CA", province: "NS", municipality: "Halifax" });
+    expect(profile.canonicalEvents.map((event) => event.eventType)).toEqual(
+      expect.arrayContaining(["regulatory_profile_derived", "regulatory_redaction_applied"])
+    );
+  });
+
+  it("blocks when consent lineage is missing", () => {
+    const profile = deriveRegulatoryProfile({
+      landlordId: "landlord-1",
+      properties: [{ id: "property-1" }],
+      registryStatuses: [{ propertyId: "property-1", status: "verified" }],
+    });
+
+    expect(profile.status).toBe("blocked");
+    expect(profile.blockedReasons.join(" ")).toMatch(/Consent/i);
+  });
+
+  it("returns unknown when source context is unavailable", () => {
+    const profile = deriveRegulatoryProfile({ landlordId: "landlord-1" });
+
+    expect(profile.status).toBe("unknown");
+  });
+
+  it("excludes legal, screening, tenant, and payment payloads", () => {
+    const profile = deriveRegulatoryProfile({
+      landlordId: "landlord-1",
+      properties: [{ id: "property-1", legalOpinion: "sensitive-legal" }],
+      screeningOrders: [{ id: "screening-1", rawBureauPayload: "sensitive-bureau" }],
+      consentRecords: [{ id: "consent-1" }],
+    });
+
+    const serialized = JSON.stringify(profile);
+    expect(serialized).not.toContain("sensitive-legal");
+    expect(serialized).not.toContain("sensitive-bureau");
+    expect(profile.redactions).toEqual(expect.arrayContaining(["Legal opinions and legal advice are excluded."]));
+  });
+});

--- a/rentchain-api/src/lib/regulatoryProfiles/deriveRegulatoryProfile.ts
+++ b/rentchain-api/src/lib/regulatoryProfiles/deriveRegulatoryProfile.ts
@@ -1,0 +1,327 @@
+import type {
+  DeriveRegulatoryProfileInput,
+  RegulatoryCanonicalEvent,
+  RegulatoryJurisdiction,
+  RegulatoryProfile,
+  RegulatoryProfileStatus,
+  RegulatoryReference,
+} from "./regulatoryProfileTypes";
+import { regulatoryIdPart, regulatoryReference } from "./regulatoryRestrictionModels";
+
+const REDACTIONS = [
+  "Legal opinions and legal advice are excluded.",
+  "Government filing payloads are excluded.",
+  "Raw screening and credit bureau payloads are excluded.",
+  "Sensitive tenant and payment data are excluded.",
+  "Regulatory references are operational readiness summaries only.",
+];
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function asArray<T>(value: T[] | null | undefined): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function generatedAt(value: unknown): string {
+  const raw = asString(value, 120);
+  const date = raw ? new Date(raw) : new Date(0);
+  return Number.isNaN(date.getTime()) ? new Date(0).toISOString() : date.toISOString();
+}
+
+function jurisdictionFrom(input: DeriveRegulatoryProfileInput): RegulatoryJurisdiction {
+  const property = asArray(input.properties)[0] || {};
+  return {
+    country: "CA",
+    province: asString(input.province || property.province || property.provinceState || property.state, 40).toUpperCase() || "UNKNOWN",
+    municipality: asString(input.municipality || property.municipality || property.city, 120) || "Unknown municipality",
+  };
+}
+
+function event(input: {
+  eventType: RegulatoryCanonicalEvent["eventType"];
+  status: RegulatoryProfileStatus;
+  regulatoryProfileId: string;
+  summary: string;
+}): RegulatoryCanonicalEvent {
+  return {
+    eventType: input.eventType,
+    action: input.eventType.replace(/^regulatory_/, "").replace(/_/g, "."),
+    status: input.status,
+    resourceType: "regulatory_profile",
+    resourceId: input.regulatoryProfileId,
+    summary: input.summary,
+  };
+}
+
+function profileStatus(hasContext: boolean, references: RegulatoryReference[]): RegulatoryProfileStatus {
+  if (!hasContext) return "unknown";
+  if (references.some((reference) => reference.status === "blocked")) return "blocked";
+  if (references.some((reference) => reference.status === "partially_verified" || reference.status === "unavailable")) return "partially_ready";
+  return "ready_for_review";
+}
+
+export function deriveRegulatoryProfile(input: DeriveRegulatoryProfileInput): RegulatoryProfile {
+  const landlordId = asString(input.landlordId, 240);
+  const jurisdiction = jurisdictionFrom(input);
+  const regulatoryProfileId =
+    regulatoryIdPart(["regulatory_profile", landlordId || "unknown", jurisdiction.country, jurisdiction.province, jurisdiction.municipality].join(":")) ||
+    "regulatory_profile:unknown";
+  const properties = asArray(input.properties);
+  const registryStatuses = asArray(input.registryStatuses);
+  const screeningOrders = asArray(input.screeningOrders);
+  const consentRecords = asArray(input.consentRecords);
+  const sharingRooms = asArray(input.sharingRooms);
+  const exports = asArray(input.institutionExportPackages);
+  const evidencePacks = asArray(input.evidencePacks);
+  const reviews = asArray(input.operatorReviewSessions);
+  const auditEvents = asArray(input.auditEvents);
+  const settlementReadiness = input.settlementReadiness || null;
+  const auditReadiness = input.auditComplianceReadiness || null;
+
+  const registryReferences = (registryStatuses.length ? registryStatuses : properties).map((record, index) => {
+    const propertyId = asString(record.propertyId || record.id, 240);
+    const verified = ["verified", "matched", "ready", "active"].includes(asString(record.status || record.registryStatus, 80));
+    return regulatoryReference({
+      idParts: ["registry", propertyId || index],
+      referenceType: "registry",
+      status: propertyId && verified ? "verified" : propertyId ? "partially_verified" : "unavailable",
+      label: "Registry readiness reference",
+      description: "Property registry metadata is available for jurisdiction-aware review.",
+      jurisdiction,
+      restricted: !verified,
+      reasons: verified ? [] : ["Registry verification is incomplete or unavailable."],
+      evidenceLineage: evidencePacks.map((pack) => asString(pack.evidencePackId || pack.id, 240)).filter(Boolean),
+      destination: propertyId ? `/properties?propertyId=${encodeURIComponent(propertyId)}` : null,
+    });
+  });
+
+  const screeningReadiness = [
+    regulatoryReference({
+      idParts: ["screening", screeningOrders.length || "none"],
+      referenceType: "screening",
+      status: screeningOrders.length ? "partially_verified" : "unavailable",
+      label: "Screening readiness",
+      description: screeningOrders.length
+        ? `${screeningOrders.length} screening references are available as summary metadata.`
+        : "No landlord-scoped screening readiness references were available.",
+      jurisdiction,
+      restricted: !screeningOrders.length,
+      reasons: screeningOrders.length ? [] : ["Screening readiness lineage is unavailable."],
+      reviewLineage: reviews.map((review) => asString(review.reviewSessionId || review.id, 240)).filter(Boolean),
+    }),
+  ];
+
+  const privacyReadiness = [
+    regulatoryReference({
+      idParts: ["privacy", consentRecords.length || "none"],
+      referenceType: "privacy",
+      status: consentRecords.length ? "verified" : "blocked",
+      label: "Privacy and consent readiness",
+      description: consentRecords.length
+        ? `${consentRecords.length} consent references are available for operational review.`
+        : "Consent lineage is required before regulated sharing review.",
+      jurisdiction,
+      restricted: !consentRecords.length,
+      reasons: consentRecords.length ? [] : ["Consent lineage is missing."],
+      blockedReason: consentRecords.length ? null : "Consent/access lineage is required for regulatory profile readiness.",
+    }),
+  ];
+
+  const sharingRestrictions = sharingRooms.map((room) => {
+    const blocked = room.publiclyAccessible === true || room.externalExecutionEnabled === true || room.status === "blocked";
+    return regulatoryReference({
+      idParts: ["sharing", room.sharingRoomId || room.id || "unknown"],
+      referenceType: "sharing",
+      status: blocked ? "blocked" : "verified",
+      label: "Institutional sharing restriction",
+      description: "Institutional sharing metadata is available for regulatory review.",
+      jurisdiction,
+      restricted: blocked,
+      reasons: blocked ? ["Sharing room metadata indicates public access, external execution, or blocked review state."] : [],
+      reviewLineage: reviews.map((review) => asString(review.reviewSessionId || review.id, 240)).filter(Boolean),
+      evidenceLineage: evidencePacks.map((pack) => asString(pack.evidencePackId || pack.id, 240)).filter(Boolean),
+      destination: "/institutional-sharing-rooms",
+      blockedReason: blocked ? "Sharing restriction requires manual review." : null,
+    });
+  });
+
+  const settlementRestrictions = settlementReadiness
+    ? [
+        regulatoryReference({
+          idParts: ["settlement", settlementReadiness.settlementReadinessId],
+          referenceType: "settlement",
+          status: settlementReadiness.status === "blocked" ? "blocked" : settlementReadiness.status === "ready_for_review" ? "verified" : "partially_verified",
+          label: "Settlement readiness restriction",
+          description: "Settlement readiness metadata is available for jurisdiction-aware review.",
+          jurisdiction,
+          restricted: settlementReadiness.status !== "ready_for_review",
+          reasons: settlementReadiness.blockedReasons || [],
+          reviewLineage: settlementReadiness.reviewReferences.map((reference) => reference.settlementReferenceId),
+          evidenceLineage: settlementReadiness.evidenceReferences.map((reference) => reference.settlementReferenceId),
+          destination: "/settlement-readiness",
+          blockedReason: settlementReadiness.status === "blocked" ? "Settlement readiness is blocked." : null,
+        }),
+      ]
+    : [
+        regulatoryReference({
+          idParts: ["settlement", "missing"],
+          referenceType: "settlement",
+          status: "unavailable",
+          label: "Settlement readiness restriction",
+          description: "Settlement readiness metadata is unavailable.",
+          jurisdiction,
+          restricted: true,
+          reasons: ["Settlement readiness context is unavailable."],
+          destination: "/settlement-readiness",
+        }),
+      ];
+
+  const exportRestrictions = exports.map((pkg) => {
+    const blocked = pkg.externalSubmissionEnabled === true || pkg.status === "blocked";
+    return regulatoryReference({
+      idParts: ["export", pkg.packageId || pkg.id || "unknown"],
+      referenceType: "export",
+      status: blocked ? "blocked" : "verified",
+      label: "Export/shareability restriction",
+      description: "Institution export preview metadata is available.",
+      jurisdiction,
+      restricted: blocked,
+      reasons: blocked ? ["Export preview is blocked or external submission is enabled."] : [],
+      destination: "/institution-exports",
+      blockedReason: blocked ? "Export restriction requires manual review." : null,
+    });
+  });
+
+  const auditReferences = auditReadiness
+    ? [
+        regulatoryReference({
+          idParts: ["audit", auditReadiness.readinessId],
+          referenceType: "audit",
+          status: auditReadiness.status === "blocked" ? "blocked" : auditReadiness.status === "ready_for_review" ? "verified" : "partially_verified",
+          label: "Audit/compliance readiness",
+          description: "Audit/compliance readiness is available as operational review metadata.",
+          jurisdiction,
+          restricted: auditReadiness.status !== "ready_for_review",
+          reasons: auditReadiness.checks.flatMap((check) => check.blockedReasons || []).slice(0, 8),
+          destination: "/audit-compliance",
+          blockedReason: auditReadiness.status === "blocked" ? "Audit readiness is blocked." : null,
+        }),
+      ]
+    : [];
+
+  const reviewReferences = reviews.map((review) =>
+    regulatoryReference({
+      idParts: ["review", review.reviewSessionId || review.id || "unknown"],
+      referenceType: "review",
+      status: review.status === "completed" ? "verified" : "partially_verified",
+      label: "Review lineage",
+      description: "Operator review lineage is available for regulatory review.",
+      jurisdiction,
+      reviewLineage: [asString(review.reviewSessionId || review.id, 240)].filter(Boolean),
+      destination: "/review-timeline",
+    })
+  );
+
+  const evidenceReferences = evidencePacks.map((pack) =>
+    regulatoryReference({
+      idParts: ["evidence", pack.evidencePackId || pack.id || "unknown"],
+      referenceType: "audit",
+      status: pack.status === "blocked" ? "blocked" : "verified",
+      label: "Evidence lineage",
+      description: "Evidence pack metadata is available for regulatory review.",
+      jurisdiction,
+      evidenceLineage: [asString(pack.evidencePackId || pack.id, 240)].filter(Boolean),
+      destination: "/evidence-packs",
+      blockedReason: pack.status === "blocked" ? "Evidence pack is blocked." : null,
+    })
+  );
+
+  const allReferences = [
+    ...registryReferences,
+    ...screeningReadiness,
+    ...privacyReadiness,
+    ...sharingRestrictions,
+    ...settlementRestrictions,
+    ...exportRestrictions,
+    ...auditReferences,
+    ...reviewReferences,
+    ...evidenceReferences,
+  ];
+  const hasContext = Boolean(landlordId && (properties.length || registryStatuses.length || auditEvents.length || settlementReadiness || auditReadiness));
+  const status = profileStatus(hasContext, allReferences);
+  const blockedReasons = allReferences.map((reference) => reference.blockedReason).filter(Boolean) as string[];
+  const restrictions = allReferences.filter((reference) => reference.restrictionSummary.restricted).length;
+
+  return {
+    regulatoryProfileId,
+    jurisdiction,
+    status,
+    manualReviewRequired: true,
+    legalCertificationEnabled: false,
+    externalRegulatorSubmissionEnabled: false,
+    generatedAt: generatedAt(input.generatedAt),
+    summary: {
+      totalReferences: allReferences.length,
+      verifiedReferences: allReferences.filter((reference) => reference.status === "verified").length,
+      partiallyReadyReferences: allReferences.filter((reference) => reference.status === "partially_verified").length,
+      blockedReferences: allReferences.filter((reference) => reference.status === "blocked").length,
+      unavailableReferences: allReferences.filter((reference) => reference.status === "unavailable").length,
+      restrictions,
+    },
+    registryReferences,
+    screeningReadiness,
+    privacyReadiness,
+    sharingRestrictions,
+    settlementRestrictions: [...settlementRestrictions, ...exportRestrictions, ...auditReferences],
+    reviewReferences,
+    evidenceReferences,
+    redactions: REDACTIONS,
+    blockedReasons,
+    canonicalEvents: [
+      event({
+        eventType: "regulatory_profile_derived",
+        status,
+        regulatoryProfileId,
+        summary: "Regulatory profile was derived from jurisdiction, readiness, review, and evidence metadata.",
+      }),
+      ...(restrictions
+        ? [
+            event({
+              eventType: "regulatory_restriction_detected",
+              status,
+              regulatoryProfileId,
+              summary: "Operational regulatory restrictions were detected for manual review.",
+            }),
+          ]
+        : []),
+      ...(status === "blocked"
+        ? [
+            event({
+              eventType: "regulatory_profile_blocked",
+              status,
+              regulatoryProfileId,
+              summary: "Regulatory profile readiness is blocked by missing or unsafe references.",
+            }),
+          ]
+        : []),
+      event({
+        eventType: "regulatory_redaction_applied",
+        status,
+        regulatoryProfileId,
+        summary: "Sensitive legal, screening, tenant, and payment data were excluded.",
+      }),
+      ...(status === "partially_ready"
+        ? [
+            event({
+              eventType: "regulatory_review_required",
+              status,
+              regulatoryProfileId,
+              summary: "Manual regulatory profile review is required.",
+            }),
+          ]
+        : []),
+    ],
+  };
+}

--- a/rentchain-api/src/lib/regulatoryProfiles/regulatoryProfileTypes.ts
+++ b/rentchain-api/src/lib/regulatoryProfiles/regulatoryProfileTypes.ts
@@ -1,0 +1,93 @@
+import type { AuditComplianceReadiness } from "../auditCompliance/auditComplianceTypes";
+import type { SettlementReadiness } from "../settlementReadiness/settlementReadinessTypes";
+
+export type RegulatoryProfileStatus = "ready_for_review" | "partially_ready" | "blocked" | "unknown";
+export type RegulatoryReferenceStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+export type RegulatoryReferenceType = "registry" | "screening" | "privacy" | "settlement" | "export" | "sharing" | "audit" | "review";
+export type RegulatoryEventType =
+  | "regulatory_profile_derived"
+  | "regulatory_restriction_detected"
+  | "regulatory_review_required"
+  | "regulatory_profile_blocked"
+  | "regulatory_redaction_applied";
+
+export type RegulatoryJurisdiction = {
+  country: "CA";
+  province: string;
+  municipality: string;
+};
+
+export type RegulatoryReference = {
+  referenceId: string;
+  referenceType: RegulatoryReferenceType;
+  status: RegulatoryReferenceStatus;
+  label: string;
+  description: string;
+  jurisdictionScope: RegulatoryJurisdiction;
+  restrictionSummary: {
+    restricted: boolean;
+    reasons: string[];
+  };
+  reviewLineage: string[];
+  evidenceLineage: string[];
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+  destination: string | null;
+};
+
+export type RegulatoryCanonicalEvent = {
+  eventType: RegulatoryEventType;
+  action: string;
+  status: RegulatoryProfileStatus;
+  resourceType: "regulatory_profile";
+  resourceId: string;
+  summary: string;
+};
+
+export type RegulatoryProfile = {
+  regulatoryProfileId: string;
+  jurisdiction: RegulatoryJurisdiction;
+  status: RegulatoryProfileStatus;
+  manualReviewRequired: true;
+  legalCertificationEnabled: false;
+  externalRegulatorSubmissionEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    partiallyReadyReferences: number;
+    blockedReferences: number;
+    unavailableReferences: number;
+    restrictions: number;
+  };
+  registryReferences: RegulatoryReference[];
+  screeningReadiness: RegulatoryReference[];
+  privacyReadiness: RegulatoryReference[];
+  sharingRestrictions: RegulatoryReference[];
+  settlementRestrictions: RegulatoryReference[];
+  reviewReferences: RegulatoryReference[];
+  evidenceReferences: RegulatoryReference[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: RegulatoryCanonicalEvent[];
+};
+
+export type DeriveRegulatoryProfileInput = {
+  landlordId?: unknown;
+  country?: unknown;
+  province?: unknown;
+  municipality?: unknown;
+  generatedAt?: unknown;
+  properties?: Record<string, unknown>[] | null;
+  registryStatuses?: Record<string, unknown>[] | null;
+  screeningOrders?: Record<string, unknown>[] | null;
+  consentRecords?: Record<string, unknown>[] | null;
+  sharingRooms?: Record<string, unknown>[] | null;
+  institutionExportPackages?: Record<string, unknown>[] | null;
+  evidencePacks?: Record<string, unknown>[] | null;
+  operatorReviewSessions?: Record<string, unknown>[] | null;
+  auditEvents?: Record<string, unknown>[] | null;
+  auditComplianceReadiness?: AuditComplianceReadiness | null;
+  settlementReadiness?: SettlementReadiness | null;
+};

--- a/rentchain-api/src/lib/regulatoryProfiles/regulatoryRestrictionModels.ts
+++ b/rentchain-api/src/lib/regulatoryProfiles/regulatoryRestrictionModels.ts
@@ -1,0 +1,49 @@
+import type { RegulatoryJurisdiction, RegulatoryReference, RegulatoryReferenceStatus, RegulatoryReferenceType } from "./regulatoryProfileTypes";
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+export function regulatoryIdPart(value: unknown): string {
+  return asString(value, 500)
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+export function regulatoryReference(input: {
+  idParts: unknown[];
+  referenceType: RegulatoryReferenceType;
+  status: RegulatoryReferenceStatus;
+  label: string;
+  description: string;
+  jurisdiction: RegulatoryJurisdiction;
+  restricted?: boolean;
+  reasons?: string[];
+  reviewLineage?: string[];
+  evidenceLineage?: string[];
+  redacted?: boolean;
+  redactionReason?: string | null;
+  blockedReason?: string | null;
+  destination?: string | null;
+}): RegulatoryReference {
+  return {
+    referenceId: regulatoryIdPart(["regulatory", input.referenceType, ...input.idParts].filter(Boolean).join(":")) || "regulatory:unknown",
+    referenceType: input.referenceType,
+    status: input.status,
+    label: input.label,
+    description: input.description,
+    jurisdictionScope: input.jurisdiction,
+    restrictionSummary: {
+      restricted: input.restricted === true,
+      reasons: (input.reasons || []).filter(Boolean).slice(0, 8),
+    },
+    reviewLineage: (input.reviewLineage || []).filter(Boolean).slice(0, 8),
+    evidenceLineage: (input.evidenceLineage || []).filter(Boolean).slice(0, 8),
+    redacted: input.redacted === true,
+    redactionReason: input.redactionReason || null,
+    blockedReason: input.blockedReason || null,
+    destination: input.destination || null,
+  };
+}

--- a/rentchain-api/src/routes/__tests__/landlordRegulatoryProfileRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordRegulatoryProfileRoutes.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+  function matches(doc: any, filters: Array<{ field: string; op: string; value: any }>) {
+    return filters.every(({ field, op, value }) => (op === "==" ? doc?.data?.[field] === value : false));
+  }
+  function makeQuery(name: string, filters: Array<{ field: string; op: string; value: any }> = []) {
+    return {
+      where: (field: string, op: string, value: any) => makeQuery(name, [...filters, { field, op, value }]),
+      get: async () => {
+        const docs = Array.from(ensureCollection(name).values())
+          .filter((doc) => matches(doc, filters))
+          .map((doc) => ({ id: doc.id, exists: true, data: () => doc.data }));
+        return { docs, empty: docs.length === 0, size: docs.length };
+      },
+      doc: (id: string) => makeDoc(name, id),
+    };
+  }
+  function makeDoc(name: string, id: string) {
+    const col = ensureCollection(name);
+    return {
+      id,
+      get: async () => {
+        const entry = col.get(id);
+        return { id, exists: Boolean(entry), data: () => entry?.data };
+      },
+      set: async (data: any) => {
+        col.set(id, { id, data });
+      },
+    };
+  }
+  return {
+    resetFakeDb: () => store.clear(),
+    seedDoc: (collection: string, id: string, data: any) => ensureCollection(collection).set(id, { id, data }),
+    fakeDb: {
+      collection: (name: string) => ({
+        where: (field: string, op: string, value: any) => makeQuery(name, [{ field, op, value }]),
+        get: async () => makeQuery(name).get(),
+        doc: (id: string) => makeDoc(name, id),
+      }),
+    },
+  };
+});
+
+let mockUser: any;
+
+vi.mock("../../config/firebase", () => ({ db: fakeDb }));
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!mockUser) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    req.user = mockUser;
+    return next();
+  },
+}));
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: any, res: any, next: any) => {
+    const role = String(req.user?.role || "").trim().toLowerCase();
+    const landlordId = req.user?.landlordId || req.user?.id;
+    if (role !== "landlord" && role !== "admin") return res.status(403).json({ ok: false, error: "Forbidden" });
+    req.user.landlordId = landlordId;
+    return next();
+  },
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; user?: Record<string, unknown> | null }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    mockUser = options.user ?? mockUser;
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: mockUser,
+      query: Object.fromEntries(new URLSearchParams(queryString || "").entries()),
+      params: {},
+      body: {},
+      headers: {},
+    };
+    const match = path.match(/^\/regulatory-profiles\/(.+)$/);
+    if (match) req.params = { regulatoryProfileId: decodeURIComponent(match[1]) };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => (error ? reject(error) : undefined));
+  });
+}
+
+describe("landlordRegulatoryProfileRoutes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    resetFakeDb();
+    mockUser = { id: "landlord-1", landlordId: "landlord-1", role: "landlord" };
+  });
+
+  function seedRegulatory() {
+    seedDoc("properties", "property-1", { landlordId: "landlord-1", province: "NS", municipality: "Halifax", legalOpinion: "sensitive-legal" });
+    seedDoc("propertyRegistryStatuses", "registry-1", { landlordId: "landlord-1", propertyId: "property-1", status: "verified" });
+    seedDoc("screeningOrders", "screening-1", { landlordId: "landlord-1", rawBureauPayload: "sensitive-bureau" });
+    seedDoc("consents", "consent-1", { landlordId: "landlord-1", tenantId: "tenant-1" });
+    seedDoc("institutionalSharingRooms", "room-1", { landlordId: "landlord-1", sharingRoomId: "room-1", publiclyAccessible: false, externalExecutionEnabled: false });
+    seedDoc("evidencePacks", "evidence-1", { landlordId: "landlord-1", evidencePackId: "evidence-1" });
+    seedDoc("operatorReviewSessions", "review-1", { landlordId: "landlord-1", reviewSessionId: "review-1", status: "completed" });
+    seedDoc("events", "event-1", { landlordId: "landlord-1", type: "registry.reviewed" });
+  }
+
+  it("returns landlord-scoped regulatory profiles without sensitive payloads", async () => {
+    seedRegulatory();
+    const router = (await import("../landlordRegulatoryProfileRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/regulatory-profiles?province=NS&municipality=Halifax" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.profiles).toHaveLength(1);
+    expect(res.body.profiles[0]).toEqual(
+      expect.objectContaining({ manualReviewRequired: true, legalCertificationEnabled: false, externalRegulatorSubmissionEnabled: false })
+    );
+    const serialized = JSON.stringify(res.body);
+    expect(serialized).not.toContain("sensitive-legal");
+    expect(serialized).not.toContain("sensitive-bureau");
+  });
+
+  it("returns a single profile by id", async () => {
+    seedRegulatory();
+    const router = (await import("../landlordRegulatoryProfileRoutes")).default;
+    const list = await invokeRouter(router, { method: "GET", url: "/regulatory-profiles" });
+    const id = list.body.profiles[0].regulatoryProfileId;
+
+    const res = await invokeRouter(router, { method: "GET", url: `/regulatory-profiles/${encodeURIComponent(id)}` });
+
+    expect(res.status).toBe(200);
+    expect(res.body.profile.regulatoryProfileId).toBe(id);
+  });
+
+  it("filters by status and blocks non-landlord users", async () => {
+    seedRegulatory();
+    const router = (await import("../landlordRegulatoryProfileRoutes")).default;
+
+    const filtered = await invokeRouter(router, { method: "GET", url: "/regulatory-profiles?status=unknown" });
+    expect(filtered.status).toBe(200);
+    expect(filtered.body.profiles).toEqual([]);
+
+    const forbidden = await invokeRouter(router, { method: "GET", url: "/regulatory-profiles", user: { id: "tenant-1", role: "tenant" } });
+    expect(forbidden.status).toBe(403);
+  });
+});

--- a/rentchain-api/src/routes/landlordRegulatoryProfileRoutes.ts
+++ b/rentchain-api/src/routes/landlordRegulatoryProfileRoutes.ts
@@ -1,0 +1,153 @@
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { requireAuth } from "../middleware/requireAuth";
+import { requireLandlord } from "../middleware/requireLandlord";
+import { deriveAuditComplianceReadiness } from "../lib/auditCompliance/deriveAuditComplianceReadiness";
+import { deriveInstitutionExportPackage } from "../lib/institutionExports/deriveInstitutionExportPackage";
+import { deriveRegulatoryProfile } from "../lib/regulatoryProfiles/deriveRegulatoryProfile";
+import { deriveSettlementReadiness } from "../lib/settlementReadiness/deriveSettlementReadiness";
+import { buildPaymentObligationLedgerRows } from "../lib/payments/paymentObligationLedger";
+import type { RegulatoryProfile, RegulatoryProfileStatus } from "../lib/regulatoryProfiles/regulatoryProfileTypes";
+
+const router = Router();
+const STATUSES = new Set<RegulatoryProfileStatus>(["ready_for_review", "partially_ready", "blocked", "unknown"]);
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function landlordIdFromReq(req: any) {
+  return asString(req.user?.landlordId || req.user?.id || req.user?.sub, 240);
+}
+
+async function loadLandlordCollection(collectionName: string, landlordId: string) {
+  const byId = new Map<string, any>();
+  async function collect(field: "landlordId" | "ownerId" | "userId") {
+    const snap = await db.collection(collectionName).where(field, "==", landlordId).get().catch(() => null);
+    for (const doc of snap?.docs || []) byId.set(doc.id, { id: doc.id, ...((doc.data() as any) || {}) });
+  }
+  await Promise.all([collect("landlordId"), collect("ownerId"), collect("userId")]);
+  return Array.from(byId.values()).filter((record) =>
+    [record?.landlordId, record?.ownerId, record?.userId].some((value) => asString(value, 240) === landlordId)
+  );
+}
+
+function filterJurisdiction(records: any[], filters: { province: string; municipality: string }) {
+  return records.filter((record) => {
+    if (filters.province) {
+      const province = asString(record?.province || record?.provinceState || record?.state, 80).toUpperCase();
+      if (province !== filters.province.toUpperCase()) return false;
+    }
+    if (filters.municipality) {
+      const municipality = asString(record?.municipality || record?.city, 160).toLowerCase();
+      if (municipality !== filters.municipality.toLowerCase()) return false;
+    }
+    return true;
+  });
+}
+
+function profileMatches(profile: RegulatoryProfile, id: string) {
+  return profile.regulatoryProfileId === id;
+}
+
+async function buildProfiles(landlordId: string, filters: { country: string; province: string; municipality: string }) {
+  const [propertiesRaw, registryStatuses, screeningOrders, consents, sharingRooms, evidencePacks, reviews, events, leases, paymentIntents, rentPayments, reconciliationRecords] =
+    await Promise.all([
+      loadLandlordCollection("properties", landlordId),
+      loadLandlordCollection("propertyRegistryStatuses", landlordId),
+      loadLandlordCollection("screeningOrders", landlordId),
+      loadLandlordCollection("consents", landlordId),
+      loadLandlordCollection("institutionalSharingRooms", landlordId),
+      loadLandlordCollection("evidencePacks", landlordId),
+      loadLandlordCollection("operatorReviewSessions", landlordId),
+      loadLandlordCollection("events", landlordId),
+      loadLandlordCollection("leases", landlordId),
+      loadLandlordCollection("paymentIntents", landlordId),
+      loadLandlordCollection("rentPayments", landlordId),
+      loadLandlordCollection("paymentReconciliationRecords", landlordId),
+    ]);
+  const properties = filterJurisdiction(propertiesRaw, filters);
+  const obligationRows = buildPaymentObligationLedgerRows({ leases, paymentIntents, rentPayments, reconciliationRecords });
+  const settlementReadiness = deriveSettlementReadiness({
+    landlordId,
+    obligationRows,
+    reconciliationRecords,
+    evidencePacks,
+    operatorReviewSessions: reviews,
+    auditEvents: events,
+  });
+  const institutionExportPackage = deriveInstitutionExportPackage({
+    packageType: "lender_due_diligence",
+    landlordId,
+    properties,
+    leases,
+    maintenanceRequests: [],
+    auditEvents: events,
+    decisionItems: [],
+  });
+  const auditComplianceReadiness = deriveAuditComplianceReadiness({
+    scope: "landlord_portfolio",
+    landlordId,
+    properties,
+    leases,
+    rentPayments,
+    decisions: [],
+    auditEvents: events,
+    policyEvents: events.filter((event) => asString(event.domain, 80) === "policy"),
+    institutionExportPackage,
+  });
+  const profile = deriveRegulatoryProfile({
+    landlordId,
+    country: filters.country || "CA",
+    province: filters.province,
+    municipality: filters.municipality,
+    properties,
+    registryStatuses,
+    screeningOrders,
+    consentRecords: consents,
+    sharingRooms,
+    institutionExportPackages: [institutionExportPackage],
+    evidencePacks,
+    operatorReviewSessions: reviews,
+    auditEvents: events,
+    auditComplianceReadiness,
+    settlementReadiness,
+  });
+  return [profile];
+}
+
+router.get("/regulatory-profiles", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = landlordIdFromReq(req);
+    if (!landlordId) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    const filters = {
+      country: asString(req.query?.country, 20) || "CA",
+      province: asString(req.query?.province, 80),
+      municipality: asString(req.query?.municipality, 160),
+    };
+    const status = asString(req.query?.status, 80) as RegulatoryProfileStatus;
+    let profiles = await buildProfiles(landlordId, filters);
+    if (status && STATUSES.has(status)) profiles = profiles.filter((profile) => profile.status === status);
+    return res.json({ ok: true, profiles });
+  } catch (err: any) {
+    console.error("[landlord-regulatory-profiles] list failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "REGULATORY_PROFILES_FAILED" });
+  }
+});
+
+router.get("/regulatory-profiles/:regulatoryProfileId", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = landlordIdFromReq(req);
+    const regulatoryProfileId = decodeURIComponent(asString(req.params?.regulatoryProfileId, 500));
+    if (!landlordId || !regulatoryProfileId) return res.status(400).json({ ok: false, error: "REGULATORY_PROFILE_ID_REQUIRED" });
+    const profiles = await buildProfiles(landlordId, { country: "CA", province: "", municipality: "" });
+    const profile = profiles.find((item) => profileMatches(item, regulatoryProfileId));
+    if (!profile) return res.status(404).json({ ok: false, error: "REGULATORY_PROFILE_NOT_FOUND" });
+    return res.json({ ok: true, profile });
+  } catch (err: any) {
+    console.error("[landlord-regulatory-profiles] get failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "REGULATORY_PROFILE_GET_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -134,6 +134,10 @@ vi.mock("./pages/SettlementReadinessPage", () => ({
   default: () => <h1>Settlement Readiness Page</h1>,
 }));
 
+vi.mock("./pages/RegulatoryProfilePage", () => ({
+  default: () => <h1>Regulatory Profiles Page</h1>,
+}));
+
 vi.mock("./pages/landlord/PortfolioScorePage", () => ({
   default: () => <h1>Landlord Portfolio Score</h1>,
 }));
@@ -395,6 +399,20 @@ describe("Routes: /settlement-readiness", () => {
     );
 
     expect(await screen.findByText(/Settlement Readiness Page/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Routes: /regulatory-profiles", () => {
+  it("renders the regulatory profiles route", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/regulatory-profiles?province=NS&municipality=Halifax"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Regulatory Profiles Page/i)).toBeInTheDocument();
     expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -126,6 +126,7 @@ const IdentityLayerPage = lazy(() => import("./pages/IdentityLayerPage"));
 const InstitutionalSharingRoomPage = lazy(() => import("./pages/InstitutionalSharingRoomPage"));
 const VerifiedRentalHistoryPage = lazy(() => import("./pages/VerifiedRentalHistoryPage"));
 const SettlementReadinessPage = lazy(() => import("./pages/SettlementReadinessPage"));
+const RegulatoryProfilePage = lazy(() => import("./pages/RegulatoryProfilePage"));
 const LandlordPortfolioScorePage = lazy(() => import("./pages/landlord/PortfolioScorePage"));
 const SharedPortfolioScorePage = lazy(() => import("./pages/public/SharedPortfolioScorePage"));
 const TenantSharePackagePage = lazy(() => import("./pages/public/TenantSharePackagePage"));
@@ -629,6 +630,18 @@ function App() {
               <LandlordNav>
                 <Suspense fallback={null}>
                   <SettlementReadinessPage />
+                </Suspense>
+              </LandlordNav>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/regulatory-profiles"
+          element={
+            <RequireAuth>
+              <LandlordNav>
+                <Suspense fallback={null}>
+                  <RegulatoryProfilePage />
                 </Suspense>
               </LandlordNav>
             </RequireAuth>

--- a/rentchain-frontend/src/api/regulatoryProfileApi.ts
+++ b/rentchain-frontend/src/api/regulatoryProfileApi.ts
@@ -1,0 +1,74 @@
+import { apiFetch } from "./apiFetch";
+
+export type RegulatoryProfileStatus = "ready_for_review" | "partially_ready" | "blocked" | "unknown";
+export type RegulatoryReferenceStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+export type RegulatoryReferenceType = "registry" | "screening" | "privacy" | "settlement" | "export" | "sharing" | "audit" | "review";
+
+export type RegulatoryJurisdiction = { country: "CA"; province: string; municipality: string };
+
+export type RegulatoryReference = {
+  referenceId: string;
+  referenceType: RegulatoryReferenceType;
+  status: RegulatoryReferenceStatus;
+  label: string;
+  description: string;
+  jurisdictionScope: RegulatoryJurisdiction;
+  restrictionSummary: { restricted: boolean; reasons: string[] };
+  reviewLineage: string[];
+  evidenceLineage: string[];
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+  destination: string | null;
+};
+
+export type RegulatoryProfile = {
+  regulatoryProfileId: string;
+  jurisdiction: RegulatoryJurisdiction;
+  status: RegulatoryProfileStatus;
+  manualReviewRequired: true;
+  legalCertificationEnabled: false;
+  externalRegulatorSubmissionEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    partiallyReadyReferences: number;
+    blockedReferences: number;
+    unavailableReferences: number;
+    restrictions: number;
+  };
+  registryReferences: RegulatoryReference[];
+  screeningReadiness: RegulatoryReference[];
+  privacyReadiness: RegulatoryReference[];
+  sharingRestrictions: RegulatoryReference[];
+  settlementRestrictions: RegulatoryReference[];
+  reviewReferences: RegulatoryReference[];
+  evidenceReferences: RegulatoryReference[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: Array<{ eventType: string; action: string; status: RegulatoryProfileStatus; resourceId: string; summary: string }>;
+};
+
+export async function fetchRegulatoryProfiles(params?: {
+  country?: string;
+  province?: string;
+  municipality?: string;
+  status?: RegulatoryProfileStatus | "";
+}): Promise<RegulatoryProfile[]> {
+  const search = new URLSearchParams();
+  if (params?.country) search.set("country", params.country);
+  if (params?.province) search.set("province", params.province);
+  if (params?.municipality) search.set("municipality", params.municipality);
+  if (params?.status) search.set("status", params.status);
+  const suffix = search.toString() ? `?${search.toString()}` : "";
+  const response = await apiFetch<{ ok: true; profiles: RegulatoryProfile[] }>(`/landlord/regulatory-profiles${suffix}`);
+  return response.profiles;
+}
+
+export async function fetchRegulatoryProfile(regulatoryProfileId: string): Promise<RegulatoryProfile> {
+  const response = await apiFetch<{ ok: true; profile: RegulatoryProfile }>(
+    `/landlord/regulatory-profiles/${encodeURIComponent(regulatoryProfileId)}`
+  );
+  return response.profile;
+}

--- a/rentchain-frontend/src/components/regulatory/RegulatoryProfilePanel.test.tsx
+++ b/rentchain-frontend/src/components/regulatory/RegulatoryProfilePanel.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { RegulatoryProfilePanel } from "./RegulatoryProfilePanel";
+
+const profile = {
+  regulatoryProfileId: "regulatory_profile:landlord-1:ca:ns:halifax",
+  jurisdiction: { country: "CA", province: "NS", municipality: "Halifax" },
+  status: "partially_ready",
+  manualReviewRequired: true,
+  legalCertificationEnabled: false,
+  externalRegulatorSubmissionEnabled: false,
+  generatedAt: "2026-01-01T00:00:00.000Z",
+  summary: {
+    totalReferences: 3,
+    verifiedReferences: 1,
+    partiallyReadyReferences: 1,
+    blockedReferences: 1,
+    unavailableReferences: 0,
+    restrictions: 2,
+  },
+  registryReferences: [
+    {
+      referenceId: "regulatory:registry:property-1",
+      referenceType: "registry",
+      status: "partially_verified",
+      label: "Registry readiness reference",
+      description: "Property registry metadata is available for jurisdiction-aware review.",
+      jurisdictionScope: { country: "CA", province: "NS", municipality: "Halifax" },
+      restrictionSummary: { restricted: true, reasons: ["Registry verification is incomplete or unavailable."] },
+      reviewLineage: [],
+      evidenceLineage: ["evidence-1"],
+      destination: "/properties?propertyId=property-1",
+      redacted: false,
+      redactionReason: null,
+      blockedReason: null,
+    },
+  ],
+  screeningReadiness: [],
+  privacyReadiness: [
+    {
+      referenceId: "regulatory:privacy:none",
+      referenceType: "privacy",
+      status: "blocked",
+      label: "Privacy and consent readiness",
+      description: "Consent lineage is required before regulated sharing review.",
+      jurisdictionScope: { country: "CA", province: "NS", municipality: "Halifax" },
+      restrictionSummary: { restricted: true, reasons: ["Consent lineage is missing."] },
+      reviewLineage: [],
+      evidenceLineage: [],
+      destination: null,
+      redacted: false,
+      redactionReason: null,
+      blockedReason: "Consent/access lineage is required for regulatory profile readiness.",
+    },
+  ],
+  sharingRestrictions: [],
+  settlementRestrictions: [],
+  exportRestrictions: [],
+  auditReferences: [],
+  reviewReferences: [],
+  evidenceReferences: [],
+  redactions: ["Government filing payloads are excluded."],
+  blockedReasons: ["Consent/access lineage is required for regulatory profile readiness."],
+  canonicalEvents: [],
+} as const;
+
+describe("RegulatoryProfilePanel", () => {
+  it("renders regulatory readiness, restrictions, lineage, and required safety copy", () => {
+    render(
+      <MemoryRouter>
+        <RegulatoryProfilePanel profile={profile as any} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("View regulatory profile")).toBeInTheDocument();
+    expect(screen.getAllByText(/No legal certification or regulator submission is enabled/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("View restrictions: Registry verification is incomplete or unavailable.")).toBeInTheDocument();
+    expect(screen.getByText("View blocked reason: Consent/access lineage is required for regulatory profile readiness.")).toBeInTheDocument();
+    expect(screen.getByText("Government filing payloads are excluded.")).toBeInTheDocument();
+  });
+
+  it("does not render forbidden regulatory action labels", () => {
+    render(
+      <MemoryRouter>
+        <RegulatoryProfilePanel profile={profile as any} />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText("Certify compliance")).not.toBeInTheDocument();
+    expect(screen.queryByText("Submit to regulator")).not.toBeInTheDocument();
+    expect(screen.queryByText("Auto-file")).not.toBeInTheDocument();
+    expect(screen.queryByText("Legal approval")).not.toBeInTheDocument();
+    expect(screen.queryByText("Autonomous compliance")).not.toBeInTheDocument();
+    expect(screen.queryByText("Publish compliance")).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/regulatory/RegulatoryProfilePanel.tsx
+++ b/rentchain-frontend/src/components/regulatory/RegulatoryProfilePanel.tsx
@@ -1,0 +1,109 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import type { RegulatoryProfile, RegulatoryReference } from "@/api/regulatoryProfileApi";
+import { Card, Section } from "@/components/ui/Ui";
+
+function label(value: string) {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function tone(status: string) {
+  if (status === "blocked") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
+  if (status === "partially_ready" || status === "partially_verified" || status === "unavailable") return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
+  if (status === "ready_for_review" || status === "verified") return { color: "#166534", background: "#dcfce7", border: "#bbf7d0" };
+  return { color: "#475569", background: "#f8fafc", border: "#e2e8f0" };
+}
+
+function Badge({ children, status }: { children: React.ReactNode; status: string }) {
+  const next = tone(status);
+  return (
+    <span style={{ border: `1px solid ${next.border}`, borderRadius: 999, background: next.background, color: next.color, padding: "3px 9px", fontSize: 12, fontWeight: 900, whiteSpace: "nowrap" }}>
+      {children}
+    </span>
+  );
+}
+
+function ReferenceList({ title, references }: { title: string; references: RegulatoryReference[] }) {
+  return (
+    <Section style={{ display: "grid", gap: 10 }}>
+      <div style={{ fontWeight: 900 }}>{title}</div>
+      {references.length ? (
+        references.slice(0, 10).map((reference) => (
+          <Card key={reference.referenceId} style={{ borderRadius: 8, padding: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+              <div>
+                <strong>{reference.label}</strong>
+                <div style={{ color: "#64748b", fontSize: 13 }}>{label(reference.referenceType)}</div>
+              </div>
+              <Badge status={reference.status}>{label(reference.status)}</Badge>
+            </div>
+            <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>{reference.description}</div>
+            {reference.restrictionSummary.restricted ? (
+              <div style={{ color: "#92400e", fontSize: 13, marginTop: 8 }}>View restrictions: {reference.restrictionSummary.reasons.join("; ") || "Manual review required."}</div>
+            ) : null}
+            {reference.blockedReason ? <div style={{ color: "#991b1b", fontSize: 13, marginTop: 8 }}>View blocked reason: {reference.blockedReason}</div> : null}
+            {reference.destination ? <Link to={reference.destination} style={{ color: "#2563eb", fontWeight: 800, fontSize: 13, marginTop: 8, display: "inline-block" }}>View context</Link> : null}
+          </Card>
+        ))
+      ) : (
+        <Card style={{ color: "#64748b" }}>Context unavailable</Card>
+      )}
+    </Section>
+  );
+}
+
+export function RegulatoryProfilePanel({ profile }: { profile: RegulatoryProfile }) {
+  return (
+    <div style={{ display: "grid", gap: 16 }}>
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+          <div>
+            <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>View regulatory profile</div>
+            <h2 style={{ margin: "2px 0 0", fontSize: "1.15rem" }}>{profile.jurisdiction.country} / {profile.jurisdiction.province} / {profile.jurisdiction.municipality}</h2>
+          </div>
+          <Badge status={profile.status}>{label(profile.status)}</Badge>
+        </div>
+        <div style={{ color: "#475569", lineHeight: 1.55 }}>
+          Regulatory profiles are operational readiness references only. No legal certification or regulator submission is enabled. Manual review remains required.
+        </div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <Badge status="partially_ready">Manual review required</Badge>
+          <Badge status={profile.legalCertificationEnabled ? "blocked" : "verified"}>Legal certification disabled</Badge>
+          <Badge status={profile.externalRegulatorSubmissionEnabled ? "blocked" : "verified"}>Regulator submission disabled</Badge>
+        </div>
+      </Section>
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Regulatory summary</div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: 10 }}>
+          {[
+            ["References", profile.summary.totalReferences],
+            ["Verified", profile.summary.verifiedReferences],
+            ["Partial", profile.summary.partiallyReadyReferences],
+            ["Blocked", profile.summary.blockedReferences],
+            ["Unavailable", profile.summary.unavailableReferences],
+            ["Restrictions", profile.summary.restrictions],
+          ].map(([name, value]) => (
+            <Card key={String(name)} style={{ borderRadius: 8, padding: 12 }}>
+              <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>{name}</div>
+              <strong style={{ color: "#0f172a", fontSize: 22 }}>{String(value)}</strong>
+            </Card>
+          ))}
+        </div>
+      </Section>
+
+      <ReferenceList title="Registry references" references={profile.registryReferences} />
+      <ReferenceList title="Screening and privacy readiness" references={[...profile.screeningReadiness, ...profile.privacyReadiness]} />
+      <ReferenceList title="View restrictions" references={[...profile.sharingRestrictions, ...profile.settlementRestrictions]} />
+      <ReferenceList title="View evidence lineage" references={profile.evidenceReferences} />
+      <ReferenceList title="View review lineage" references={profile.reviewReferences} />
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Redactions</div>
+        {profile.redactions.map((redaction) => (
+          <Card key={redaction} style={{ borderRadius: 8, padding: 12, color: "#475569" }}>{redaction}</Card>
+        ))}
+      </Section>
+    </div>
+  );
+}

--- a/rentchain-frontend/src/pages/RegulatoryProfilePage.test.tsx
+++ b/rentchain-frontend/src/pages/RegulatoryProfilePage.test.tsx
@@ -1,0 +1,112 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import RegulatoryProfilePage from "./RegulatoryProfilePage";
+
+const mockFetchRegulatoryProfiles = vi.fn();
+const mockShowToast = vi.fn();
+
+vi.mock("@/api/regulatoryProfileApi", () => ({
+  fetchRegulatoryProfiles: (...args: any[]) => mockFetchRegulatoryProfiles(...args),
+}));
+
+vi.mock("@/components/layout/MacShell", () => ({
+  MacShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
+const profile = {
+  regulatoryProfileId: "regulatory_profile:landlord-1:ca:ns:halifax",
+  jurisdiction: { country: "CA", province: "NS", municipality: "Halifax" },
+  status: "partially_ready",
+  manualReviewRequired: true,
+  legalCertificationEnabled: false,
+  externalRegulatorSubmissionEnabled: false,
+  generatedAt: "2026-01-01T00:00:00.000Z",
+  summary: {
+    totalReferences: 1,
+    verifiedReferences: 0,
+    partiallyReadyReferences: 1,
+    blockedReferences: 0,
+    unavailableReferences: 0,
+    restrictions: 1,
+  },
+  registryReferences: [],
+  screeningReadiness: [],
+  privacyReadiness: [],
+  sharingRestrictions: [],
+  settlementRestrictions: [],
+  exportRestrictions: [],
+  auditReferences: [],
+  reviewReferences: [],
+  evidenceReferences: [],
+  redactions: ["Raw screening and credit bureau payloads are excluded."],
+  blockedReasons: [],
+  canonicalEvents: [],
+};
+
+describe("RegulatoryProfilePage", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchRegulatoryProfiles.mockResolvedValue([profile]);
+  });
+
+  it("renders regulatory profiles and required safety copy", async () => {
+    render(
+      <MemoryRouter>
+        <RegulatoryProfilePage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Regulatory profiles")).toBeInTheDocument();
+    expect(screen.getAllByText(/No legal certification or regulator submission is enabled/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("Raw screening and credit bureau payloads are excluded.")).toBeInTheDocument();
+  });
+
+  it("updates deterministic jurisdiction and status filters", async () => {
+    render(
+      <MemoryRouter>
+        <RegulatoryProfilePage />
+      </MemoryRouter>
+    );
+
+    await screen.findByText("Regulatory profiles");
+    fireEvent.change(screen.getByLabelText("Province"), { target: { value: "NS" } });
+    fireEvent.change(screen.getByLabelText("Municipality"), { target: { value: "Halifax" } });
+    fireEvent.change(screen.getByLabelText("Status"), { target: { value: "blocked" } });
+
+    await waitFor(() => {
+      expect(mockFetchRegulatoryProfiles).toHaveBeenLastCalledWith({
+        country: "CA",
+        province: "NS",
+        municipality: "Halifax",
+        status: "blocked",
+      });
+    });
+  });
+
+  it("shows empty state and omits forbidden labels", async () => {
+    mockFetchRegulatoryProfiles.mockResolvedValue([]);
+    render(
+      <MemoryRouter>
+        <RegulatoryProfilePage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("No regulatory profiles match these filters.")).toBeInTheDocument();
+    expect(screen.queryByText("Certify compliance")).not.toBeInTheDocument();
+    expect(screen.queryByText("Submit to regulator")).not.toBeInTheDocument();
+    expect(screen.queryByText("Auto-file")).not.toBeInTheDocument();
+    expect(screen.queryByText("Legal approval")).not.toBeInTheDocument();
+    expect(screen.queryByText("Autonomous compliance")).not.toBeInTheDocument();
+    expect(screen.queryByText("Publish compliance")).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/RegulatoryProfilePage.tsx
+++ b/rentchain-frontend/src/pages/RegulatoryProfilePage.tsx
@@ -1,0 +1,94 @@
+import React from "react";
+import { useSearchParams } from "react-router-dom";
+import { fetchRegulatoryProfiles, type RegulatoryProfile, type RegulatoryProfileStatus } from "@/api/regulatoryProfileApi";
+import { MacShell } from "@/components/layout/MacShell";
+import { RegulatoryProfilePanel } from "@/components/regulatory/RegulatoryProfilePanel";
+import { Card, Section } from "@/components/ui/Ui";
+import { useToast } from "@/components/ui/ToastProvider";
+
+const statuses: Array<RegulatoryProfileStatus | ""> = ["", "ready_for_review", "partially_ready", "blocked", "unknown"];
+
+function label(value: string) {
+  return value ? value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase()) : "All";
+}
+
+export default function RegulatoryProfilePage() {
+  const { showToast } = useToast();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [profiles, setProfiles] = React.useState<RegulatoryProfile[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const province = String(searchParams.get("province") || "").trim();
+  const municipality = String(searchParams.get("municipality") || "").trim();
+  const status = String(searchParams.get("status") || "") as RegulatoryProfileStatus | "";
+
+  React.useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const next = await fetchRegulatoryProfiles({ country: "CA", province: province || undefined, municipality: municipality || undefined, status });
+        if (mounted) setProfiles(next);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Failed to load regulatory profiles";
+        if (mounted) {
+          setError(message);
+          showToast({ message: "Failed to load regulatory profiles", description: message, variant: "error" });
+        }
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [province, municipality, status, showToast]);
+
+  function updateParams(next: { province?: string; municipality?: string; status?: string }) {
+    const params = new URLSearchParams(searchParams);
+    for (const [key, value] of Object.entries(next)) {
+      if (value && value.trim()) params.set(key, value.trim());
+      else params.delete(key);
+    }
+    setSearchParams(params);
+  }
+
+  return (
+    <MacShell title="Regulatory profiles" showTopNav={false}>
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "grid", gap: 6 }}>
+            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Regulatory profiles</h1>
+            <div style={{ color: "#475569", maxWidth: 900 }}>
+              Regulatory profiles are operational readiness references only. No legal certification or regulator submission is enabled.
+              Manual review remains required.
+            </div>
+          </div>
+        </Section>
+
+        <Section style={{ display: "flex", gap: 10, flexWrap: "wrap", alignItems: "end" }}>
+          <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Province
+            <input value={province} onChange={(event) => updateParams({ province: event.target.value })} placeholder="NS" style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 160 }} />
+          </label>
+          <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Municipality
+            <input value={municipality} onChange={(event) => updateParams({ municipality: event.target.value })} placeholder="Halifax" style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 180 }} />
+          </label>
+          <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Status
+            <select value={status} onChange={(event) => updateParams({ status: event.target.value })} style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 180 }}>
+              {statuses.map((item) => <option key={item || "all"} value={item}>{label(item)}</option>)}
+            </select>
+          </label>
+        </Section>
+
+        {loading ? <Card>Loading regulatory profiles...</Card> : null}
+        {!loading && error ? <Card style={{ color: "#b91c1c" }}>We couldn't load regulatory profiles right now.</Card> : null}
+        {!loading && !error && !profiles.length ? <Card style={{ color: "#64748b" }}>No regulatory profiles match these filters.</Card> : null}
+        {!loading && !error && profiles.length ? <div style={{ display: "grid", gap: 16 }}>{profiles.map((profile) => <RegulatoryProfilePanel key={profile.regulatoryProfileId} profile={profile} />)}</div> : null}
+      </div>
+    </MacShell>
+  );
+}

--- a/rentchain-frontend/src/pages/SettlementReadinessPage.tsx
+++ b/rentchain-frontend/src/pages/SettlementReadinessPage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useSearchParams } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import {
   fetchSettlementReadiness,
   type SettlementReadiness,
@@ -85,6 +85,9 @@ export default function SettlementReadinessPage() {
               Settlement readiness references are operational and review scoped. No payment execution or banking integration is enabled.
               Manual review remains required.
             </div>
+            <Link to="/regulatory-profiles" style={{ color: "#2563eb", fontWeight: 800, width: "fit-content" }}>
+              View regulatory profile
+            </Link>
           </div>
         </Section>
 


### PR DESCRIPTION
## Summary
- Adds deterministic, landlord-scoped Regulatory Profile Layer v1.
- Adds endpoints:
  - `GET /api/landlord/regulatory-profiles`
  - `GET /api/landlord/regulatory-profiles/:regulatoryProfileId`
- Adds frontend `/regulatory-profiles` page and `RegulatoryProfilePanel`.
- Adds a safe link from Settlement Readiness to Regulatory Profiles.
- Adds jurisdiction-aware registry, screening, privacy/consent, sharing, settlement, export, audit, review, and evidence readiness references.
- Adds descriptor-only canonical events for regulatory profile derivation, restriction detection, review-required, blocked, and redaction states.
- Documents Regulatory Profile Layer v1 architecture.

## Guardrails
- `manualReviewRequired` remains `true`.
- `legalCertificationEnabled` remains `false`.
- `externalRegulatorSubmissionEnabled` remains `false`.
- No legal advice, legal certification, regulator filing, government API integration, autonomous compliance approval, external submission, PSP/MSB execution, or hidden compliance side effects were added.
- Sensitive tenant/payment/screening payloads and admin-only data are excluded from landlord regulatory-profile responses.

## Verification
- Backend targeted tests passed: `pnpm exec vitest run src/lib/regulatoryProfiles/__tests__/deriveRegulatoryProfile.test.ts src/routes/__tests__/landlordRegulatoryProfileRoutes.test.ts` (2 files / 7 tests).
- Frontend targeted tests passed: `pnpm exec vitest run src/components/regulatory/RegulatoryProfilePanel.test.tsx src/pages/RegulatoryProfilePage.test.tsx src/pages/SettlementReadinessPage.test.tsx src/App.routes.test.tsx` (4 files / 43 tests).
- Backend build passed: `pnpm build`.
- Frontend build passed: `pnpm build` with existing chunk-size warning.
- Full frontend suite passed: 204 files / 804 tests.
- Full backend suite passed outside sandbox after sandbox Supertest `listen EPERM`: 284 files / 1265 tests.
- `git diff --check` passed.
- Dependency/lockfile diff empty.
- Forbidden runtime-label scan clean.