### PR TITLE
feat: add asset tokenization readiness infrastructure

### DIFF
--- a/docs/architecture/asset-tokenization-readiness-infrastructure-v1.md
+++ b/docs/architecture/asset-tokenization-readiness-infrastructure-v1.md
@@ -1,0 +1,87 @@
+# Asset Tokenization Readiness Infrastructure v1
+
+## Purpose
+
+Asset Tokenization Readiness Infrastructure is a deterministic, landlord-scoped read model for institutional real-world asset readiness review. It aggregates canonical asset references, lease cashflow summaries, occupancy lineage, maintenance/performance lineage, settlement readiness, regulatory profiles, review lineage, evidence lineage, and redaction metadata.
+
+This layer is infrastructure readiness only. It does not mint tokens, deploy smart contracts, integrate with blockchains, create wallets, onboard investors, create securities offerings, move money, or operate a public marketplace.
+
+## Model
+
+Asset readiness records include:
+
+- `assetReadinessId`
+- `assetType`: `property`, `lease_cashflow`, or `operational_asset`
+- status: `eligible_for_review`, `partially_ready`, `blocked`, or `unknown`
+- required safety flags:
+  - `manualReviewRequired: true`
+  - `tokenIssuanceEnabled: false`
+  - `blockchainIntegrationEnabled: false`
+  - `publicMarketplaceEnabled: false`
+- asset identity references
+- lease cashflow references
+- occupancy references
+- maintenance/performance references
+- settlement-readiness references
+- regulatory-profile references
+- review and evidence lineage
+- redactions and blocked reasons
+
+## Deterministic Eligibility Rules
+
+- `unknown`: insufficient landlord-scoped source context exists.
+- `blocked`: required settlement or regulatory lineage is missing/blocked, unresolved delinquency review metadata is visible, or a referenced source is blocked.
+- `partially_ready`: source lineage exists but one or more references remain partial or unavailable.
+- `eligible_for_review`: required settlement, regulatory, review, and evidence lineage are present and no blocked or partial references remain.
+
+No AI tokenization scoring, probabilistic eligibility ranking, public reputation score, or autonomous approval is used.
+
+## Restriction Rules
+
+The layer derives blocked-tokenization reasons from existing read models only:
+
+- missing settlement readiness blocks tokenization readiness
+- missing regulatory profile blocks tokenization readiness
+- blocked settlement readiness blocks tokenization readiness
+- blocked regulatory readiness blocks tokenization readiness
+- blocked evidence pack blocks tokenization readiness
+- unresolved delinquency review metadata blocks tokenization readiness
+- incomplete cashflow, occupancy, review, or evidence lineage keeps readiness partial
+
+## Redaction Rules
+
+Asset readiness records expose summary references only. They exclude:
+
+- token issuance payloads
+- blockchain addresses, wallets, and custody metadata
+- investor data and securities-offering materials
+- raw financial account data and unrestricted financial exports
+- sensitive tenant, screening, and private audit payloads
+
+## Canonical Event Descriptors
+
+The layer emits descriptor-only canonical event metadata:
+
+- `asset_tokenization_readiness_derived`
+- `asset_tokenization_review_required`
+- `asset_tokenization_blocked`
+- `asset_tokenization_restriction_detected`
+- `asset_tokenization_redaction_applied`
+
+These descriptors are additive, deterministic, explainable, and traceable. They do not persist source-record mutations or perform external execution.
+
+## Non-Goals
+
+This layer does not add:
+
+- token issuance
+- smart contract deployment
+- blockchain integration
+- wallet or custody systems
+- investor onboarding
+- securities offerings
+- crypto settlement
+- public marketplaces
+- DeFi, staking, or yield behavior
+- autonomous tokenization
+- live institutional financial integrations

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -130,6 +130,7 @@ import landlordSharingRoomRoutes from "./routes/landlordSharingRoomRoutes";
 import landlordRentalHistoryLedgerRoutes from "./routes/landlordRentalHistoryLedgerRoutes";
 import landlordSettlementReadinessRoutes from "./routes/landlordSettlementReadinessRoutes";
 import landlordRegulatoryProfileRoutes from "./routes/landlordRegulatoryProfileRoutes";
+import landlordAssetTokenizationReadinessRoutes from "./routes/landlordAssetTokenizationReadinessRoutes";
 import publicPortfolioScoreRoutes from "./routes/publicPortfolioScoreRoutes";
 import publicTenantShareRoutes from "./routes/publicTenantShareRoutes";
 import landlordActionRecommendationRoutes from "./routes/landlordActionRecommendationRoutes";
@@ -313,6 +314,8 @@ app.use("/api/landlord", routeSource("landlordSettlementReadinessRoutes.ts"), la
 console.log("[route-mount] landlordSettlementReadinessRoutes mounted at /api/landlord");
 app.use("/api/landlord", routeSource("landlordRegulatoryProfileRoutes.ts"), landlordRegulatoryProfileRoutes);
 console.log("[route-mount] landlordRegulatoryProfileRoutes mounted at /api/landlord");
+app.use("/api/landlord", routeSource("landlordAssetTokenizationReadinessRoutes.ts"), landlordAssetTokenizationReadinessRoutes);
+console.log("[route-mount] landlordAssetTokenizationReadinessRoutes mounted at /api/landlord");
 app.use("/api", routeSource("landlordActionRecommendationRoutes.ts"), landlordActionRecommendationRoutes);
 console.log("[route-mount] landlordActionRecommendationRoutes mounted at /api");
 app.use("/api", routeSource("tenantFeedbackRoutes.ts"), tenantFeedbackRoutes);

--- a/rentchain-api/src/lib/assetTokenizationReadiness/__tests__/deriveAssetTokenizationReadiness.test.ts
+++ b/rentchain-api/src/lib/assetTokenizationReadiness/__tests__/deriveAssetTokenizationReadiness.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { deriveAssetTokenizationReadiness } from "../deriveAssetTokenizationReadiness";
+
+describe("deriveAssetTokenizationReadiness", () => {
+  it("derives deterministic readiness with required disabled execution flags", () => {
+    const readiness = deriveAssetTokenizationReadiness({
+      landlordId: "landlord-1",
+      propertyId: "property-1",
+      properties: [{ id: "property-1" }],
+      leases: [{ id: "lease-1", propertyId: "property-1", startDate: "2026-01-01" }],
+      obligationRows: [{ rowId: "row-1", leaseId: "lease-1", obligationStatus: "paid" }],
+      evidencePacks: [{ evidencePackId: "evidence-1", status: "ready_for_review" }],
+      operatorReviewSessions: [{ reviewSessionId: "review-1", status: "completed" }],
+      settlementReadiness: {
+        settlementReadinessId: "settlement-1",
+        status: "ready_for_review",
+        reviewReferences: [],
+        evidenceReferences: [],
+      } as any,
+      regulatoryProfiles: [{ regulatoryProfileId: "regulatory-1", status: "ready_for_review" } as any],
+    });
+
+    expect(readiness.assetReadinessId).toBe("asset_tokenization_readiness:landlord-1:property:property-1");
+    expect(readiness.manualReviewRequired).toBe(true);
+    expect(readiness.tokenIssuanceEnabled).toBe(false);
+    expect(readiness.blockchainIntegrationEnabled).toBe(false);
+    expect(readiness.publicMarketplaceEnabled).toBe(false);
+    expect(readiness.status).toBe("partially_ready");
+    expect(readiness.canonicalEvents.map((event) => event.eventType)).toContain("asset_tokenization_readiness_derived");
+    expect(readiness.canonicalEvents.map((event) => event.eventType)).toContain("asset_tokenization_redaction_applied");
+  });
+
+  it("blocks when settlement or regulatory lineage is missing", () => {
+    const readiness = deriveAssetTokenizationReadiness({
+      landlordId: "landlord-1",
+      properties: [{ id: "property-1" }],
+      leases: [{ id: "lease-1", propertyId: "property-1" }],
+      obligationRows: [{ rowId: "row-1", leaseId: "lease-1", obligationStatus: "paid" }],
+    });
+
+    expect(readiness.status).toBe("blocked");
+    expect(readiness.blockedReasons).toContain("Settlement readiness lineage is missing.");
+    expect(readiness.blockedReasons).toContain("Regulatory profile lineage is missing.");
+    expect(readiness.canonicalEvents.map((event) => event.eventType)).toContain("asset_tokenization_blocked");
+    expect(readiness.canonicalEvents.map((event) => event.eventType)).toContain("asset_tokenization_restriction_detected");
+  });
+
+  it("returns unknown when source context is unavailable", () => {
+    const readiness = deriveAssetTokenizationReadiness({ landlordId: "landlord-1" });
+
+    expect(readiness.status).toBe("unknown");
+    expect(readiness.summary.unavailableReferences).toBeGreaterThan(0);
+  });
+
+  it("keeps sensitive token, blockchain, investor, and financial payloads out of the read model", () => {
+    const readiness = deriveAssetTokenizationReadiness({
+      landlordId: "landlord-1",
+      properties: [{ id: "property-1", walletAddress: "0xabc", bankAccountNumber: "123" }],
+      settlementReadiness: { settlementReadinessId: "settlement-1", status: "blocked", reviewReferences: [], evidenceReferences: [] } as any,
+      regulatoryProfiles: [{ regulatoryProfileId: "regulatory-1", status: "blocked" } as any],
+    });
+    const serialized = JSON.stringify(readiness);
+
+    expect(serialized).not.toContain("0xabc");
+    expect(serialized).not.toContain("123");
+    expect(readiness.redactions.join(" ")).toContain("Blockchain addresses");
+    expect(readiness.redactions.join(" ")).toContain("Investor data");
+  });
+});

--- a/rentchain-api/src/lib/assetTokenizationReadiness/assetEligibilityModels.ts
+++ b/rentchain-api/src/lib/assetTokenizationReadiness/assetEligibilityModels.ts
@@ -1,0 +1,42 @@
+import type {
+  AssetTokenizationReference,
+  AssetTokenizationReferenceStatus,
+  AssetTokenizationReferenceType,
+} from "./assetTokenizationReadinessTypes";
+
+export function assetTokenizationIdPart(value: unknown): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+export function assetReference(input: {
+  idParts: unknown[];
+  referenceType: AssetTokenizationReferenceType;
+  status: AssetTokenizationReferenceStatus;
+  label: string;
+  description: string;
+  sourceId?: unknown;
+  destination?: string | null;
+  redacted?: boolean;
+  redactionReason?: string | null;
+  blockedReason?: string | null;
+}): AssetTokenizationReference {
+  return {
+    assetReferenceId: assetTokenizationIdPart(["asset_tokenization", ...input.idParts].join(":")) || "asset_tokenization:unknown",
+    referenceType: input.referenceType,
+    status: input.status,
+    label: input.label,
+    description: input.description,
+    reviewRequired: true,
+    tokenizationEligible: false,
+    sourceId: String(input.sourceId ?? "").trim() || null,
+    destination: input.destination || null,
+    redacted: Boolean(input.redacted),
+    redactionReason: input.redactionReason || null,
+    blockedReason: input.blockedReason || null,
+  };
+}

--- a/rentchain-api/src/lib/assetTokenizationReadiness/assetTokenizationReadinessTypes.ts
+++ b/rentchain-api/src/lib/assetTokenizationReadiness/assetTokenizationReadinessTypes.ts
@@ -1,0 +1,92 @@
+import type { RegulatoryProfile } from "../regulatoryProfiles/regulatoryProfileTypes";
+import type { SettlementReadiness } from "../settlementReadiness/settlementReadinessTypes";
+
+export type AssetTokenizationReadinessStatus = "eligible_for_review" | "partially_ready" | "blocked" | "unknown";
+export type AssetTokenizationAssetType = "property" | "lease_cashflow" | "operational_asset";
+export type AssetTokenizationReferenceStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+export type AssetTokenizationReferenceType =
+  | "property_identity"
+  | "lease_cashflow"
+  | "occupancy"
+  | "maintenance_performance"
+  | "settlement_readiness"
+  | "regulatory_profile"
+  | "review_lineage"
+  | "evidence_lineage";
+
+export type AssetTokenizationEventType =
+  | "asset_tokenization_readiness_derived"
+  | "asset_tokenization_review_required"
+  | "asset_tokenization_blocked"
+  | "asset_tokenization_restriction_detected"
+  | "asset_tokenization_redaction_applied";
+
+export type AssetTokenizationReference = {
+  assetReferenceId: string;
+  referenceType: AssetTokenizationReferenceType;
+  status: AssetTokenizationReferenceStatus;
+  label: string;
+  description: string;
+  reviewRequired: true;
+  tokenizationEligible: false;
+  sourceId: string | null;
+  destination: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type AssetTokenizationCanonicalEvent = {
+  eventType: AssetTokenizationEventType;
+  action: string;
+  status: AssetTokenizationReadinessStatus;
+  resourceType: "asset_tokenization_readiness";
+  resourceId: string;
+  summary: string;
+};
+
+export type AssetTokenizationReadiness = {
+  assetReadinessId: string;
+  assetType: AssetTokenizationAssetType;
+  status: AssetTokenizationReadinessStatus;
+  manualReviewRequired: true;
+  tokenIssuanceEnabled: false;
+  blockchainIntegrationEnabled: false;
+  publicMarketplaceEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    partiallyVerifiedReferences: number;
+    blockedReferences: number;
+    unavailableReferences: number;
+    tokenizationEligibleReferences: number;
+  };
+  assetReferences: AssetTokenizationReference[];
+  cashflowReferences: AssetTokenizationReference[];
+  occupancyReferences: AssetTokenizationReference[];
+  maintenancePerformanceReferences: AssetTokenizationReference[];
+  settlementReadinessReferences: AssetTokenizationReference[];
+  regulatoryProfileReferences: AssetTokenizationReference[];
+  reviewReferences: AssetTokenizationReference[];
+  evidenceReferences: AssetTokenizationReference[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: AssetTokenizationCanonicalEvent[];
+};
+
+export type DeriveAssetTokenizationReadinessInput = {
+  landlordId?: unknown;
+  propertyId?: unknown;
+  assetType?: unknown;
+  generatedAt?: unknown;
+  properties?: Record<string, unknown>[] | null;
+  leases?: Record<string, unknown>[] | null;
+  obligationRows?: Record<string, unknown>[] | null;
+  maintenanceRequests?: Record<string, unknown>[] | null;
+  evidencePacks?: Record<string, unknown>[] | null;
+  operatorReviewSessions?: Record<string, unknown>[] | null;
+  auditEvents?: Record<string, unknown>[] | null;
+  settlementReadiness?: SettlementReadiness | null;
+  regulatoryProfiles?: RegulatoryProfile[] | null;
+};

--- a/rentchain-api/src/lib/assetTokenizationReadiness/deriveAssetTokenizationReadiness.ts
+++ b/rentchain-api/src/lib/assetTokenizationReadiness/deriveAssetTokenizationReadiness.ts
@@ -1,0 +1,352 @@
+import type {
+  AssetTokenizationAssetType,
+  AssetTokenizationCanonicalEvent,
+  AssetTokenizationReadiness,
+  AssetTokenizationReadinessStatus,
+  AssetTokenizationReference,
+  DeriveAssetTokenizationReadinessInput,
+} from "./assetTokenizationReadinessTypes";
+import { assetReference, assetTokenizationIdPart } from "./assetEligibilityModels";
+
+const REDACTIONS = [
+  "Token issuance payloads are excluded.",
+  "Blockchain addresses, wallets, and custody metadata are excluded.",
+  "Investor data and securities-offering materials are excluded.",
+  "Raw financial account data and unrestricted financial exports are excluded.",
+  "Sensitive tenant, screening, and private audit payloads are excluded.",
+];
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function asArray<T>(value: T[] | null | undefined): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function generatedAt(value: unknown): string {
+  const raw = asString(value, 120);
+  const date = raw ? new Date(raw) : new Date(0);
+  return Number.isNaN(date.getTime()) ? new Date(0).toISOString() : date.toISOString();
+}
+
+function normalizeAssetType(value: unknown): AssetTokenizationAssetType {
+  const raw = asString(value, 80);
+  if (raw === "lease_cashflow" || raw === "operational_asset") return raw;
+  return "property";
+}
+
+function idMatches(record: Record<string, unknown>, ids: string[], keys: string[]) {
+  const safeIds = ids.map((id) => asString(id, 500)).filter(Boolean);
+  if (!safeIds.length) return false;
+  return keys.some((key) => safeIds.includes(asString(record[key], 500)));
+}
+
+function event(input: {
+  eventType: AssetTokenizationCanonicalEvent["eventType"];
+  status: AssetTokenizationReadinessStatus;
+  assetReadinessId: string;
+  summary: string;
+}): AssetTokenizationCanonicalEvent {
+  return {
+    eventType: input.eventType,
+    action: input.eventType.replace(/^asset_tokenization_/, "").replace(/_/g, "."),
+    status: input.status,
+    resourceType: "asset_tokenization_readiness",
+    resourceId: input.assetReadinessId,
+    summary: input.summary,
+  };
+}
+
+function readinessStatus(hasContext: boolean, references: AssetTokenizationReference[]): AssetTokenizationReadinessStatus {
+  if (!hasContext) return "unknown";
+  if (references.some((reference) => reference.status === "blocked")) return "blocked";
+  if (references.some((reference) => reference.status === "partially_verified" || reference.status === "unavailable")) return "partially_ready";
+  return "eligible_for_review";
+}
+
+export function deriveAssetTokenizationReadiness(input: DeriveAssetTokenizationReadinessInput): AssetTokenizationReadiness {
+  const landlordId = asString(input.landlordId, 240);
+  const propertyId = asString(input.propertyId, 240);
+  const assetType = normalizeAssetType(input.assetType);
+  const assetReadinessId =
+    assetTokenizationIdPart(["asset_tokenization_readiness", landlordId || "unknown", assetType, propertyId || "portfolio"].join(":")) ||
+    "asset_tokenization_readiness:unknown";
+  const properties = asArray(input.properties);
+  const leases = asArray(input.leases);
+  const obligationRows = asArray(input.obligationRows);
+  const maintenanceRequests = asArray(input.maintenanceRequests);
+  const evidencePacks = asArray(input.evidencePacks);
+  const reviews = asArray(input.operatorReviewSessions);
+  const auditEvents = asArray(input.auditEvents);
+  const settlementReadiness = input.settlementReadiness || null;
+  const regulatoryProfiles = asArray(input.regulatoryProfiles);
+
+  const assetReferences = properties.length
+    ? properties.map((property, index) => {
+        const id = asString(property.propertyId || property.id || property.pid || index, 240);
+        const status = id ? "verified" : "unavailable";
+        return assetReference({
+          idParts: ["property_identity", id || index],
+          referenceType: "property_identity",
+          status,
+          label: "Canonical asset reference",
+          description: "Property identity metadata is available as a canonical operational asset reference.",
+          sourceId: id,
+          destination: id ? `/properties?propertyId=${encodeURIComponent(id)}` : null,
+        });
+      })
+    : [
+        assetReference({
+          idParts: ["property_identity", "missing"],
+          referenceType: "property_identity",
+          status: "unavailable",
+          label: "Canonical asset reference",
+          description: "No landlord-scoped property identity reference was available.",
+          blockedReason: null,
+        }),
+      ];
+
+  const cashflowReferences = obligationRows.length
+    ? obligationRows.map((row) => {
+        const rowId = asString(row.rowId || row.leaseId || "unknown", 240);
+        const status = ["paid", "expected", "pending"].includes(asString(row.obligationStatus, 80)) ? "partially_verified" : "blocked";
+        return assetReference({
+          idParts: ["lease_cashflow", rowId],
+          referenceType: "lease_cashflow",
+          status,
+          label: "Lease cashflow reference",
+          description: "Lease cashflow is available as summarized obligation ledger metadata.",
+          sourceId: rowId,
+          destination: row.leaseId ? `/leases/${encodeURIComponent(asString(row.leaseId, 240))}/ledger` : null,
+          blockedReason: status === "blocked" ? "Lease cashflow requires manual review before tokenization-readiness review." : null,
+        });
+      })
+    : [
+        assetReference({
+          idParts: ["lease_cashflow", "missing"],
+          referenceType: "lease_cashflow",
+          status: "unavailable",
+          label: "Lease cashflow reference",
+          description: "Lease cashflow lineage is unavailable.",
+        }),
+      ];
+
+  const occupancyReferences = leases.length
+    ? leases.map((lease) => {
+        const leaseId = asString(lease.leaseId || lease.id, 240);
+        const hasOccupancyDates = Boolean(asString(lease.startDate, 120) || asString(lease.endDate, 120));
+        return assetReference({
+          idParts: ["occupancy", leaseId || "unknown"],
+          referenceType: "occupancy",
+          status: hasOccupancyDates ? "partially_verified" : "unavailable",
+          label: "Occupancy reference",
+          description: "Lease participation and occupancy timing are available as summary metadata.",
+          sourceId: leaseId,
+          destination: leaseId ? `/leases/${encodeURIComponent(leaseId)}` : null,
+          blockedReason: null,
+        });
+      })
+    : [];
+
+  const maintenancePerformanceReferences = maintenanceRequests.map((request) => {
+    const maintenanceId = asString(request.maintenanceRequestId || request.id, 240);
+    return assetReference({
+      idParts: ["maintenance_performance", maintenanceId || "unknown"],
+      referenceType: "maintenance_performance",
+      status: maintenanceId ? "partially_verified" : "unavailable",
+      label: "Maintenance/performance reference",
+      description: "Maintenance participation metadata is available as operational performance lineage.",
+      sourceId: maintenanceId,
+      destination: "/maintenance",
+    });
+  });
+
+  const settlementReadinessReferences = settlementReadiness
+    ? [
+        assetReference({
+          idParts: ["settlement_readiness", settlementReadiness.settlementReadinessId],
+          referenceType: "settlement_readiness",
+          status:
+            settlementReadiness.status === "ready_for_review"
+              ? "verified"
+              : settlementReadiness.status === "blocked"
+                ? "blocked"
+                : "partially_verified",
+          label: "Settlement readiness linkage",
+          description: "Settlement readiness metadata is available for asset-tokenization readiness review.",
+          sourceId: settlementReadiness.settlementReadinessId,
+          destination: "/settlement-readiness",
+          blockedReason: settlementReadiness.status === "blocked" ? "Settlement readiness is blocked." : null,
+        }),
+      ]
+    : [
+        assetReference({
+          idParts: ["settlement_readiness", "missing"],
+          referenceType: "settlement_readiness",
+          status: "blocked",
+          label: "Settlement readiness linkage",
+          description: "Settlement readiness is required before asset-tokenization readiness review.",
+          destination: "/settlement-readiness",
+          blockedReason: "Settlement readiness lineage is missing.",
+        }),
+      ];
+
+  const regulatoryProfileReferences = regulatoryProfiles.length
+    ? regulatoryProfiles.map((profile) =>
+        assetReference({
+          idParts: ["regulatory_profile", profile.regulatoryProfileId],
+          referenceType: "regulatory_profile",
+          status: profile.status === "ready_for_review" ? "verified" : profile.status === "blocked" ? "blocked" : "partially_verified",
+          label: "Regulatory profile linkage",
+          description: "Regulatory profile metadata is available for asset-tokenization readiness review.",
+          sourceId: profile.regulatoryProfileId,
+          destination: "/regulatory-profiles",
+          blockedReason: profile.status === "blocked" ? "Regulatory profile readiness is blocked." : null,
+        })
+      )
+    : [
+        assetReference({
+          idParts: ["regulatory_profile", "missing"],
+          referenceType: "regulatory_profile",
+          status: "blocked",
+          label: "Regulatory profile linkage",
+          description: "Regulatory profile lineage is required before asset-tokenization readiness review.",
+          destination: "/regulatory-profiles",
+          blockedReason: "Regulatory profile lineage is missing.",
+        }),
+      ];
+
+  const reviewReferences = reviews.map((review) => {
+    const reviewId = asString(review.reviewSessionId || review.id, 240);
+    return assetReference({
+      idParts: ["review_lineage", reviewId || "unknown"],
+      referenceType: "review_lineage",
+      status: review.status === "completed" ? "verified" : "partially_verified",
+      label: "Review lineage",
+      description: "Operator review lineage is available for manual tokenization-readiness review.",
+      sourceId: reviewId,
+      destination: "/review-timeline",
+    });
+  });
+
+  const evidenceReferences = evidencePacks.map((pack) => {
+    const evidenceId = asString(pack.evidencePackId || pack.id, 240);
+    return assetReference({
+      idParts: ["evidence_lineage", evidenceId || "unknown"],
+      referenceType: "evidence_lineage",
+      status: pack.status === "blocked" ? "blocked" : "verified",
+      label: "Evidence lineage",
+      description: "Evidence pack lineage is available for asset-tokenization readiness review.",
+      sourceId: evidenceId,
+      destination: "/evidence-packs",
+      blockedReason: pack.status === "blocked" ? "Evidence pack is blocked." : null,
+    });
+  });
+
+  const unresolvedDelinquency = auditEvents.some((record) => {
+    const text = `${asString(record.type || record.eventType || record.action, 200)} ${asString(record.status, 80)}`.toLowerCase();
+    return text.includes("delinquency") && !text.includes("resolved") && !text.includes("closed");
+  });
+  const delinquencyReference = unresolvedDelinquency
+    ? [
+        assetReference({
+          idParts: ["review_lineage", "unresolved_delinquency"],
+          referenceType: "review_lineage",
+          status: "blocked",
+          label: "Delinquency review restriction",
+          description: "Unresolved delinquency review metadata is visible as a tokenization-readiness restriction.",
+          destination: "/review-timeline",
+          blockedReason: "Unresolved delinquency review requires manual review before tokenization-readiness review.",
+        }),
+      ]
+    : [];
+
+  const allReferences = [
+    ...assetReferences,
+    ...cashflowReferences,
+    ...occupancyReferences,
+    ...maintenancePerformanceReferences,
+    ...settlementReadinessReferences,
+    ...regulatoryProfileReferences,
+    ...reviewReferences,
+    ...evidenceReferences,
+    ...delinquencyReference,
+  ];
+  const hasContext = Boolean(landlordId && (properties.length || leases.length || obligationRows.length || settlementReadiness || regulatoryProfiles.length));
+  const status = readinessStatus(hasContext, allReferences);
+  const blockedReasons = allReferences.map((reference) => reference.blockedReason).filter(Boolean) as string[];
+
+  return {
+    assetReadinessId,
+    assetType,
+    status,
+    manualReviewRequired: true,
+    tokenIssuanceEnabled: false,
+    blockchainIntegrationEnabled: false,
+    publicMarketplaceEnabled: false,
+    generatedAt: generatedAt(input.generatedAt),
+    summary: {
+      totalReferences: allReferences.length,
+      verifiedReferences: allReferences.filter((reference) => reference.status === "verified").length,
+      partiallyVerifiedReferences: allReferences.filter((reference) => reference.status === "partially_verified").length,
+      blockedReferences: allReferences.filter((reference) => reference.status === "blocked").length,
+      unavailableReferences: allReferences.filter((reference) => reference.status === "unavailable").length,
+      tokenizationEligibleReferences: 0,
+    },
+    assetReferences,
+    cashflowReferences,
+    occupancyReferences,
+    maintenancePerformanceReferences,
+    settlementReadinessReferences,
+    regulatoryProfileReferences,
+    reviewReferences: [...reviewReferences, ...delinquencyReference],
+    evidenceReferences,
+    redactions: REDACTIONS,
+    blockedReasons,
+    canonicalEvents: [
+      event({
+        eventType: "asset_tokenization_readiness_derived",
+        status,
+        assetReadinessId,
+        summary: "Asset tokenization readiness was derived from asset, cashflow, settlement, regulatory, review, and evidence metadata.",
+      }),
+      ...(status === "blocked"
+        ? [
+            event({
+              eventType: "asset_tokenization_blocked",
+              status,
+              assetReadinessId,
+              summary: "Asset tokenization readiness is blocked by missing or unsafe required lineage.",
+            }),
+          ]
+        : []),
+      ...(status === "partially_ready"
+        ? [
+            event({
+              eventType: "asset_tokenization_review_required",
+              status,
+              assetReadinessId,
+              summary: "Manual asset tokenization readiness review is required.",
+            }),
+          ]
+        : []),
+      ...(blockedReasons.length
+        ? [
+            event({
+              eventType: "asset_tokenization_restriction_detected",
+              status,
+              assetReadinessId,
+              summary: "Asset-tokenization restrictions were detected for manual review.",
+            }),
+          ]
+        : []),
+      event({
+        eventType: "asset_tokenization_redaction_applied",
+        status,
+        assetReadinessId,
+        summary: "Token, blockchain, investor, financial-account, tenant, screening, and private audit payloads were excluded.",
+      }),
+    ],
+  };
+}

--- a/rentchain-api/src/routes/__tests__/landlordAssetTokenizationReadinessRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordAssetTokenizationReadinessRoutes.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+  function matches(doc: any, filters: Array<{ field: string; op: string; value: any }>) {
+    return filters.every(({ field, op, value }) => (op === "==" ? doc?.data?.[field] === value : false));
+  }
+  function makeQuery(name: string, filters: Array<{ field: string; op: string; value: any }> = []) {
+    return {
+      where: (field: string, op: string, value: any) => makeQuery(name, [...filters, { field, op, value }]),
+      get: async () => {
+        const docs = Array.from(ensureCollection(name).values())
+          .filter((doc) => matches(doc, filters))
+          .map((doc) => ({ id: doc.id, exists: true, data: () => doc.data }));
+        return { docs, empty: docs.length === 0, size: docs.length };
+      },
+      doc: (id: string) => makeDoc(name, id),
+    };
+  }
+  function makeDoc(name: string, id: string) {
+    const col = ensureCollection(name);
+    return {
+      id,
+      get: async () => {
+        const entry = col.get(id);
+        return { id, exists: Boolean(entry), data: () => entry?.data };
+      },
+      set: async (data: any) => {
+        col.set(id, { id, data });
+      },
+    };
+  }
+  return {
+    resetFakeDb: () => store.clear(),
+    seedDoc: (collection: string, id: string, data: any) => ensureCollection(collection).set(id, { id, data }),
+    fakeDb: {
+      collection: (name: string) => ({
+        where: (field: string, op: string, value: any) => makeQuery(name, [{ field, op, value }]),
+        get: async () => makeQuery(name).get(),
+        doc: (id: string) => makeDoc(name, id),
+      }),
+    },
+  };
+});
+
+let mockUser: any;
+
+vi.mock("../../config/firebase", () => ({ db: fakeDb }));
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!mockUser) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    req.user = mockUser;
+    return next();
+  },
+}));
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: any, res: any, next: any) => {
+    const role = String(req.user?.role || "").trim().toLowerCase();
+    const landlordId = req.user?.landlordId || req.user?.id;
+    if (role !== "landlord" && role !== "admin") return res.status(403).json({ ok: false, error: "Forbidden" });
+    req.user.landlordId = landlordId;
+    return next();
+  },
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; user?: Record<string, unknown> | null }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    mockUser = options.user ?? mockUser;
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: mockUser,
+      query: Object.fromEntries(new URLSearchParams(queryString || "").entries()),
+      params: {},
+      body: {},
+      headers: {},
+    };
+    const match = path.match(/^\/asset-tokenization-readiness\/(.+)$/);
+    if (match) req.params = { assetReadinessId: decodeURIComponent(match[1]) };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => (error ? reject(error) : undefined));
+  });
+}
+
+describe("landlordAssetTokenizationReadinessRoutes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    resetFakeDb();
+    mockUser = { id: "landlord-1", landlordId: "landlord-1", role: "landlord" };
+  });
+
+  function seedAssetReadiness() {
+    seedDoc("properties", "property-1", { landlordId: "landlord-1", province: "NS", municipality: "Halifax", walletAddress: "0xabc" });
+    seedDoc("leases", "lease-1", { landlordId: "landlord-1", leaseId: "lease-1", propertyId: "property-1", monthlyRent: 2000, startDate: "2026-01-01", status: "active" });
+    seedDoc("propertyRegistryStatuses", "registry-1", { landlordId: "landlord-1", propertyId: "property-1", status: "verified" });
+    seedDoc("consents", "consent-1", { landlordId: "landlord-1", tenantId: "tenant-1" });
+    seedDoc("evidencePacks", "evidence-1", { landlordId: "landlord-1", propertyId: "property-1", evidencePackId: "evidence-1" });
+    seedDoc("operatorReviewSessions", "review-1", { landlordId: "landlord-1", propertyId: "property-1", reviewSessionId: "review-1", status: "completed" });
+    seedDoc("events", "event-1", { landlordId: "landlord-1", propertyId: "property-1", type: "asset.reviewed" });
+  }
+
+  it("returns landlord-scoped asset readiness without token or blockchain payloads", async () => {
+    seedAssetReadiness();
+    const router = (await import("../landlordAssetTokenizationReadinessRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/asset-tokenization-readiness?propertyId=property-1" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.readiness).toHaveLength(1);
+    expect(res.body.readiness[0]).toEqual(
+      expect.objectContaining({
+        manualReviewRequired: true,
+        tokenIssuanceEnabled: false,
+        blockchainIntegrationEnabled: false,
+        publicMarketplaceEnabled: false,
+      })
+    );
+    const serialized = JSON.stringify(res.body);
+    expect(serialized).not.toContain("0xabc");
+  });
+
+  it("returns a single readiness record by id", async () => {
+    seedAssetReadiness();
+    const router = (await import("../landlordAssetTokenizationReadinessRoutes")).default;
+    const list = await invokeRouter(router, { method: "GET", url: "/asset-tokenization-readiness" });
+    const id = list.body.readiness[0].assetReadinessId;
+
+    const res = await invokeRouter(router, { method: "GET", url: `/asset-tokenization-readiness/${encodeURIComponent(id)}` });
+
+    expect(res.status).toBe(200);
+    expect(res.body.readiness.assetReadinessId).toBe(id);
+  });
+
+  it("filters by status and blocks non-landlord users", async () => {
+    seedAssetReadiness();
+    const router = (await import("../landlordAssetTokenizationReadinessRoutes")).default;
+
+    const filtered = await invokeRouter(router, { method: "GET", url: "/asset-tokenization-readiness?status=unknown" });
+    expect(filtered.status).toBe(200);
+    expect(filtered.body.readiness).toEqual([]);
+
+    const forbidden = await invokeRouter(router, { method: "GET", url: "/asset-tokenization-readiness", user: { id: "tenant-1", role: "tenant" } });
+    expect(forbidden.status).toBe(403);
+  });
+});

--- a/rentchain-api/src/routes/landlordAssetTokenizationReadinessRoutes.ts
+++ b/rentchain-api/src/routes/landlordAssetTokenizationReadinessRoutes.ts
@@ -1,0 +1,193 @@
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { requireAuth } from "../middleware/requireAuth";
+import { requireLandlord } from "../middleware/requireLandlord";
+import { deriveAssetTokenizationReadiness } from "../lib/assetTokenizationReadiness/deriveAssetTokenizationReadiness";
+import { deriveAuditComplianceReadiness } from "../lib/auditCompliance/deriveAuditComplianceReadiness";
+import { deriveInstitutionExportPackage } from "../lib/institutionExports/deriveInstitutionExportPackage";
+import { deriveRegulatoryProfile } from "../lib/regulatoryProfiles/deriveRegulatoryProfile";
+import { deriveSettlementReadiness } from "../lib/settlementReadiness/deriveSettlementReadiness";
+import { buildPaymentObligationLedgerRows } from "../lib/payments/paymentObligationLedger";
+import type {
+  AssetTokenizationAssetType,
+  AssetTokenizationReadiness,
+  AssetTokenizationReadinessStatus,
+} from "../lib/assetTokenizationReadiness/assetTokenizationReadinessTypes";
+
+const router = Router();
+const STATUSES = new Set<AssetTokenizationReadinessStatus>(["eligible_for_review", "partially_ready", "blocked", "unknown"]);
+const ASSET_TYPES = new Set<AssetTokenizationAssetType>(["property", "lease_cashflow", "operational_asset"]);
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function landlordIdFromReq(req: any) {
+  return asString(req.user?.landlordId || req.user?.id || req.user?.sub, 240);
+}
+
+async function loadLandlordCollection(collectionName: string, landlordId: string) {
+  const byId = new Map<string, any>();
+  async function collect(field: "landlordId" | "ownerId" | "userId") {
+    const snap = await db.collection(collectionName).where(field, "==", landlordId).get().catch(() => null);
+    for (const doc of snap?.docs || []) byId.set(doc.id, { id: doc.id, ...((doc.data() as any) || {}) });
+  }
+  await Promise.all([collect("landlordId"), collect("ownerId"), collect("userId")]);
+  return Array.from(byId.values()).filter((record) =>
+    [record?.landlordId, record?.ownerId, record?.userId].some((value) => asString(value, 240) === landlordId)
+  );
+}
+
+function filterContext(records: any[], propertyId: string) {
+  if (!propertyId) return records;
+  return records.filter((record) => {
+    return (
+      asString(record?.propertyId || record?.id, 240) === propertyId ||
+      asString(record?.scopeId, 240) === propertyId
+    );
+  });
+}
+
+function itemMatches(item: AssetTokenizationReadiness, id: string) {
+  return item.assetReadinessId === id;
+}
+
+async function buildReadinessItems(landlordId: string, filters: { propertyId: string; assetType: AssetTokenizationAssetType | "" }) {
+  const [
+    propertiesRaw,
+    leasesRaw,
+    paymentIntentsRaw,
+    rentPaymentsRaw,
+    reconciliationRaw,
+    maintenanceRaw,
+    registryStatuses,
+    screeningOrders,
+    consents,
+    sharingRooms,
+    evidencePacksRaw,
+    reviewsRaw,
+    eventsRaw,
+  ] = await Promise.all([
+    loadLandlordCollection("properties", landlordId),
+    loadLandlordCollection("leases", landlordId),
+    loadLandlordCollection("paymentIntents", landlordId),
+    loadLandlordCollection("rentPayments", landlordId),
+    loadLandlordCollection("paymentReconciliationRecords", landlordId),
+    loadLandlordCollection("maintenanceRequests", landlordId),
+    loadLandlordCollection("propertyRegistryStatuses", landlordId),
+    loadLandlordCollection("screeningOrders", landlordId),
+    loadLandlordCollection("consents", landlordId),
+    loadLandlordCollection("institutionalSharingRooms", landlordId),
+    loadLandlordCollection("evidencePacks", landlordId),
+    loadLandlordCollection("operatorReviewSessions", landlordId),
+    loadLandlordCollection("events", landlordId),
+  ]);
+
+  const properties = filterContext(propertiesRaw, filters.propertyId);
+  const leases = filterContext(leasesRaw, filters.propertyId);
+  const propertyIds = new Set(properties.map((property) => asString(property.propertyId || property.id, 240)).filter(Boolean));
+  const scopedPaymentIntents = filterContext(paymentIntentsRaw, filters.propertyId);
+  const scopedRentPayments = filterContext(rentPaymentsRaw, filters.propertyId);
+  const scopedReconciliation = filterContext(reconciliationRaw, filters.propertyId);
+  const scopedMaintenance = filterContext(maintenanceRaw, filters.propertyId);
+  const scopedEvidence = filterContext(evidencePacksRaw, filters.propertyId);
+  const scopedReviews = filterContext(reviewsRaw, filters.propertyId);
+  const scopedEvents = filterContext(eventsRaw, filters.propertyId);
+  const obligationRows = buildPaymentObligationLedgerRows({
+    leases,
+    paymentIntents: scopedPaymentIntents,
+    rentPayments: scopedRentPayments,
+    reconciliationRecords: scopedReconciliation,
+  });
+  const settlementReadiness = deriveSettlementReadiness({
+    landlordId,
+    propertyId: filters.propertyId,
+    obligationRows,
+    reconciliationRecords: scopedReconciliation,
+    evidencePacks: scopedEvidence,
+    operatorReviewSessions: scopedReviews,
+    auditEvents: scopedEvents,
+  });
+  const institutionExportPackage = deriveInstitutionExportPackage({
+    packageType: "lender_due_diligence",
+    landlordId,
+    properties,
+    leases,
+    maintenanceRequests: scopedMaintenance,
+    auditEvents: scopedEvents,
+    decisionItems: [],
+  });
+  const auditComplianceReadiness = deriveAuditComplianceReadiness({
+    scope: filters.propertyId ? "property" : "landlord_portfolio",
+    landlordId,
+    properties,
+    leases,
+    rentPayments: scopedRentPayments,
+    decisions: [],
+    auditEvents: scopedEvents,
+    policyEvents: scopedEvents.filter((event) => asString(event.domain, 80) === "policy"),
+    institutionExportPackage,
+  });
+  const regulatoryProfile = deriveRegulatoryProfile({
+    landlordId,
+    properties,
+    registryStatuses: registryStatuses.filter((record) => !propertyIds.size || propertyIds.has(asString(record.propertyId || record.id, 240))),
+    screeningOrders,
+    consentRecords: consents,
+    sharingRooms,
+    institutionExportPackages: [institutionExportPackage],
+    evidencePacks: scopedEvidence,
+    operatorReviewSessions: scopedReviews,
+    auditEvents: scopedEvents,
+    auditComplianceReadiness,
+    settlementReadiness,
+  });
+  const readiness = deriveAssetTokenizationReadiness({
+    landlordId,
+    propertyId: filters.propertyId,
+    assetType: filters.assetType || "property",
+    properties,
+    leases,
+    obligationRows,
+    maintenanceRequests: scopedMaintenance,
+    evidencePacks: scopedEvidence,
+    operatorReviewSessions: scopedReviews,
+    auditEvents: scopedEvents,
+    settlementReadiness,
+    regulatoryProfiles: [regulatoryProfile],
+  });
+  return [readiness];
+}
+
+router.get("/asset-tokenization-readiness", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = landlordIdFromReq(req);
+    if (!landlordId) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    const propertyId = asString(req.query?.propertyId, 240);
+    const assetType = asString(req.query?.assetType, 80) as AssetTokenizationAssetType | "";
+    const status = asString(req.query?.status, 80) as AssetTokenizationReadinessStatus;
+    let readiness = await buildReadinessItems(landlordId, { propertyId, assetType: ASSET_TYPES.has(assetType as any) ? assetType : "" });
+    if (status && STATUSES.has(status)) readiness = readiness.filter((item) => item.status === status);
+    return res.json({ ok: true, readiness });
+  } catch (err: any) {
+    console.error("[landlord-asset-tokenization-readiness] list failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "ASSET_TOKENIZATION_READINESS_FAILED" });
+  }
+});
+
+router.get("/asset-tokenization-readiness/:assetReadinessId", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = landlordIdFromReq(req);
+    const assetReadinessId = decodeURIComponent(asString(req.params?.assetReadinessId, 500));
+    if (!landlordId || !assetReadinessId) return res.status(400).json({ ok: false, error: "ASSET_READINESS_ID_REQUIRED" });
+    const readiness = await buildReadinessItems(landlordId, { propertyId: "", assetType: "" });
+    const item = readiness.find((next) => itemMatches(next, assetReadinessId));
+    if (!item) return res.status(404).json({ ok: false, error: "ASSET_READINESS_NOT_FOUND" });
+    return res.json({ ok: true, readiness: item });
+  } catch (err: any) {
+    console.error("[landlord-asset-tokenization-readiness] get failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "ASSET_TOKENIZATION_READINESS_GET_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -138,6 +138,10 @@ vi.mock("./pages/RegulatoryProfilePage", () => ({
   default: () => <h1>Regulatory Profiles Page</h1>,
 }));
 
+vi.mock("./pages/AssetTokenizationReadinessPage", () => ({
+  default: () => <h1>Asset Tokenization Readiness Page</h1>,
+}));
+
 vi.mock("./pages/landlord/PortfolioScorePage", () => ({
   default: () => <h1>Landlord Portfolio Score</h1>,
 }));
@@ -413,6 +417,20 @@ describe("Routes: /regulatory-profiles", () => {
     );
 
     expect(await screen.findByText(/Regulatory Profiles Page/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Routes: /asset-tokenization-readiness", () => {
+  it("renders the asset tokenization readiness route", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/asset-tokenization-readiness?propertyId=property-1"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Asset Tokenization Readiness Page/i)).toBeInTheDocument();
     expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -127,6 +127,7 @@ const InstitutionalSharingRoomPage = lazy(() => import("./pages/InstitutionalSha
 const VerifiedRentalHistoryPage = lazy(() => import("./pages/VerifiedRentalHistoryPage"));
 const SettlementReadinessPage = lazy(() => import("./pages/SettlementReadinessPage"));
 const RegulatoryProfilePage = lazy(() => import("./pages/RegulatoryProfilePage"));
+const AssetTokenizationReadinessPage = lazy(() => import("./pages/AssetTokenizationReadinessPage"));
 const LandlordPortfolioScorePage = lazy(() => import("./pages/landlord/PortfolioScorePage"));
 const SharedPortfolioScorePage = lazy(() => import("./pages/public/SharedPortfolioScorePage"));
 const TenantSharePackagePage = lazy(() => import("./pages/public/TenantSharePackagePage"));
@@ -642,6 +643,18 @@ function App() {
               <LandlordNav>
                 <Suspense fallback={null}>
                   <RegulatoryProfilePage />
+                </Suspense>
+              </LandlordNav>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/asset-tokenization-readiness"
+          element={
+            <RequireAuth>
+              <LandlordNav>
+                <Suspense fallback={null}>
+                  <AssetTokenizationReadinessPage />
                 </Suspense>
               </LandlordNav>
             </RequireAuth>

--- a/rentchain-frontend/src/api/assetTokenizationReadinessApi.ts
+++ b/rentchain-frontend/src/api/assetTokenizationReadinessApi.ts
@@ -1,0 +1,80 @@
+import { apiFetch } from "./apiFetch";
+
+export type AssetTokenizationReadinessStatus = "eligible_for_review" | "partially_ready" | "blocked" | "unknown";
+export type AssetTokenizationAssetType = "property" | "lease_cashflow" | "operational_asset";
+export type AssetTokenizationReferenceStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+export type AssetTokenizationReferenceType =
+  | "property_identity"
+  | "lease_cashflow"
+  | "occupancy"
+  | "maintenance_performance"
+  | "settlement_readiness"
+  | "regulatory_profile"
+  | "review_lineage"
+  | "evidence_lineage";
+
+export type AssetTokenizationReference = {
+  assetReferenceId: string;
+  referenceType: AssetTokenizationReferenceType;
+  status: AssetTokenizationReferenceStatus;
+  label: string;
+  description: string;
+  reviewRequired: true;
+  tokenizationEligible: false;
+  sourceId: string | null;
+  destination: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type AssetTokenizationReadiness = {
+  assetReadinessId: string;
+  assetType: AssetTokenizationAssetType;
+  status: AssetTokenizationReadinessStatus;
+  manualReviewRequired: true;
+  tokenIssuanceEnabled: false;
+  blockchainIntegrationEnabled: false;
+  publicMarketplaceEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    partiallyVerifiedReferences: number;
+    blockedReferences: number;
+    unavailableReferences: number;
+    tokenizationEligibleReferences: number;
+  };
+  assetReferences: AssetTokenizationReference[];
+  cashflowReferences: AssetTokenizationReference[];
+  occupancyReferences: AssetTokenizationReference[];
+  maintenancePerformanceReferences: AssetTokenizationReference[];
+  settlementReadinessReferences: AssetTokenizationReference[];
+  regulatoryProfileReferences: AssetTokenizationReference[];
+  reviewReferences: AssetTokenizationReference[];
+  evidenceReferences: AssetTokenizationReference[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: Array<{ eventType: string; action: string; status: AssetTokenizationReadinessStatus; resourceId: string; summary: string }>;
+};
+
+export async function fetchAssetTokenizationReadiness(params?: {
+  propertyId?: string;
+  assetType?: AssetTokenizationAssetType | "";
+  status?: AssetTokenizationReadinessStatus | "";
+}): Promise<AssetTokenizationReadiness[]> {
+  const search = new URLSearchParams();
+  if (params?.propertyId) search.set("propertyId", params.propertyId);
+  if (params?.assetType) search.set("assetType", params.assetType);
+  if (params?.status) search.set("status", params.status);
+  const suffix = search.toString() ? `?${search.toString()}` : "";
+  const response = await apiFetch<{ ok: true; readiness: AssetTokenizationReadiness[] }>(`/landlord/asset-tokenization-readiness${suffix}`);
+  return response.readiness;
+}
+
+export async function fetchAssetTokenizationReadinessItem(assetReadinessId: string): Promise<AssetTokenizationReadiness> {
+  const response = await apiFetch<{ ok: true; readiness: AssetTokenizationReadiness }>(
+    `/landlord/asset-tokenization-readiness/${encodeURIComponent(assetReadinessId)}`
+  );
+  return response.readiness;
+}

--- a/rentchain-frontend/src/components/tokenization/AssetTokenizationReadinessPanel.test.tsx
+++ b/rentchain-frontend/src/components/tokenization/AssetTokenizationReadinessPanel.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { AssetTokenizationReadinessPanel } from "./AssetTokenizationReadinessPanel";
+
+const readiness = {
+  assetReadinessId: "asset_tokenization_readiness:landlord-1:property:property-1",
+  assetType: "property",
+  status: "blocked",
+  manualReviewRequired: true,
+  tokenIssuanceEnabled: false,
+  blockchainIntegrationEnabled: false,
+  publicMarketplaceEnabled: false,
+  generatedAt: "2026-01-01T00:00:00.000Z",
+  summary: {
+    totalReferences: 2,
+    verifiedReferences: 1,
+    partiallyVerifiedReferences: 0,
+    blockedReferences: 1,
+    unavailableReferences: 0,
+    tokenizationEligibleReferences: 0,
+  },
+  assetReferences: [
+    {
+      assetReferenceId: "asset_tokenization:property_identity:property-1",
+      referenceType: "property_identity",
+      status: "verified",
+      label: "Canonical asset reference",
+      description: "Property identity metadata is available.",
+      reviewRequired: true,
+      tokenizationEligible: false,
+      sourceId: "property-1",
+      destination: "/properties?propertyId=property-1",
+      redacted: false,
+      redactionReason: null,
+      blockedReason: null,
+    },
+  ],
+  cashflowReferences: [],
+  occupancyReferences: [],
+  maintenancePerformanceReferences: [],
+  settlementReadinessReferences: [
+    {
+      assetReferenceId: "asset_tokenization:settlement_readiness:settlement-1",
+      referenceType: "settlement_readiness",
+      status: "blocked",
+      label: "Settlement readiness linkage",
+      description: "Settlement readiness metadata is available.",
+      reviewRequired: true,
+      tokenizationEligible: false,
+      sourceId: "settlement-1",
+      destination: "/settlement-readiness",
+      redacted: false,
+      redactionReason: null,
+      blockedReason: "Settlement readiness is blocked.",
+    },
+  ],
+  regulatoryProfileReferences: [],
+  reviewReferences: [],
+  evidenceReferences: [],
+  redactions: ["Blockchain addresses, wallets, and custody metadata are excluded."],
+  blockedReasons: ["Settlement readiness is blocked."],
+  canonicalEvents: [],
+} as const;
+
+describe("AssetTokenizationReadinessPanel", () => {
+  it("renders readiness, lineage, blocked reasons, and required safety copy", () => {
+    render(
+      <MemoryRouter>
+        <AssetTokenizationReadinessPanel readiness={readiness as any} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("View readiness")).toBeInTheDocument();
+    expect(screen.getAllByText(/No token issuance, blockchain integration, or public marketplace is enabled/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("View settlement lineage")).toBeInTheDocument();
+    expect(screen.getByText("View blocked reason: Settlement readiness is blocked.")).toBeInTheDocument();
+    expect(screen.getByText("Blockchain addresses, wallets, and custody metadata are excluded.")).toBeInTheDocument();
+  });
+
+  it("does not render forbidden tokenization action labels", () => {
+    render(
+      <MemoryRouter>
+        <AssetTokenizationReadinessPanel readiness={readiness as any} />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText("Mint token")).not.toBeInTheDocument();
+    expect(screen.queryByText("Deploy contract")).not.toBeInTheDocument();
+    expect(screen.queryByText("Connect blockchain")).not.toBeInTheDocument();
+    expect(screen.queryByText("Public marketplace")).not.toBeInTheDocument();
+    expect(screen.queryByText("Issue asset")).not.toBeInTheDocument();
+    expect(screen.queryByText("Autonomous tokenization")).not.toBeInTheDocument();
+    expect(screen.queryByText("Investor onboarding")).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/tokenization/AssetTokenizationReadinessPanel.tsx
+++ b/rentchain-frontend/src/components/tokenization/AssetTokenizationReadinessPanel.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import type { AssetTokenizationReadiness, AssetTokenizationReference } from "@/api/assetTokenizationReadinessApi";
+import { Card, Section } from "@/components/ui/Ui";
+
+function label(value: string) {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function tone(status: string) {
+  if (status === "blocked") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
+  if (status === "partially_ready" || status === "partially_verified" || status === "unavailable") return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
+  if (status === "eligible_for_review" || status === "verified") return { color: "#166534", background: "#dcfce7", border: "#bbf7d0" };
+  return { color: "#475569", background: "#f8fafc", border: "#e2e8f0" };
+}
+
+function Badge({ children, status }: { children: React.ReactNode; status: string }) {
+  const next = tone(status);
+  return (
+    <span style={{ border: `1px solid ${next.border}`, borderRadius: 999, background: next.background, color: next.color, padding: "3px 9px", fontSize: 12, fontWeight: 900, whiteSpace: "nowrap" }}>
+      {children}
+    </span>
+  );
+}
+
+function ReferenceList({ title, references }: { title: string; references: AssetTokenizationReference[] }) {
+  return (
+    <Section style={{ display: "grid", gap: 10 }}>
+      <div style={{ fontWeight: 900 }}>{title}</div>
+      {references.length ? (
+        references.slice(0, 10).map((reference) => (
+          <Card key={reference.assetReferenceId} style={{ borderRadius: 8, padding: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+              <div>
+                <strong>{reference.label}</strong>
+                <div style={{ color: "#64748b", fontSize: 13 }}>{label(reference.referenceType)}</div>
+              </div>
+              <Badge status={reference.status}>{label(reference.status)}</Badge>
+            </div>
+            <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>{reference.description}</div>
+            {reference.blockedReason ? <div style={{ color: "#991b1b", fontSize: 13, marginTop: 8 }}>View blocked reason: {reference.blockedReason}</div> : null}
+            {reference.redactionReason ? <div style={{ color: "#92400e", fontSize: 13, marginTop: 8 }}>{reference.redactionReason}</div> : null}
+            {reference.destination ? <Link to={reference.destination} style={{ color: "#2563eb", fontWeight: 800, fontSize: 13, marginTop: 8, display: "inline-block" }}>View context</Link> : null}
+          </Card>
+        ))
+      ) : (
+        <Card style={{ color: "#64748b" }}>Context unavailable</Card>
+      )}
+    </Section>
+  );
+}
+
+export function AssetTokenizationReadinessPanel({ readiness }: { readiness: AssetTokenizationReadiness }) {
+  return (
+    <div style={{ display: "grid", gap: 16 }}>
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+          <div>
+            <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>View readiness</div>
+            <h2 style={{ margin: "2px 0 0", fontSize: "1.15rem" }}>{label(readiness.assetType)}</h2>
+          </div>
+          <Badge status={readiness.status}>{label(readiness.status)}</Badge>
+        </div>
+        <div style={{ color: "#475569", lineHeight: 1.55 }}>
+          Asset tokenization readiness is operational and review scoped. No token issuance, blockchain integration, or public marketplace is enabled.
+          Manual review remains required.
+        </div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <Badge status="partially_ready">Manual review required</Badge>
+          <Badge status={readiness.tokenIssuanceEnabled ? "blocked" : "verified"}>Token issuance disabled</Badge>
+          <Badge status={readiness.blockchainIntegrationEnabled ? "blocked" : "verified"}>Blockchain integration disabled</Badge>
+          <Badge status={readiness.publicMarketplaceEnabled ? "blocked" : "verified"}>Marketplace disabled</Badge>
+        </div>
+      </Section>
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Readiness summary</div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: 10 }}>
+          {[
+            ["References", readiness.summary.totalReferences],
+            ["Verified", readiness.summary.verifiedReferences],
+            ["Partial", readiness.summary.partiallyVerifiedReferences],
+            ["Blocked", readiness.summary.blockedReferences],
+            ["Unavailable", readiness.summary.unavailableReferences],
+            ["Eligible", readiness.summary.tokenizationEligibleReferences],
+          ].map(([name, value]) => (
+            <Card key={String(name)} style={{ borderRadius: 8, padding: 12 }}>
+              <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>{name}</div>
+              <strong style={{ color: "#0f172a", fontSize: 22 }}>{String(value)}</strong>
+            </Card>
+          ))}
+        </div>
+      </Section>
+
+      <ReferenceList title="Canonical asset references" references={readiness.assetReferences} />
+      <ReferenceList title="Lease cashflow and occupancy" references={[...readiness.cashflowReferences, ...readiness.occupancyReferences]} />
+      <ReferenceList title="Maintenance and performance" references={readiness.maintenancePerformanceReferences} />
+      <ReferenceList title="View settlement lineage" references={readiness.settlementReadinessReferences} />
+      <ReferenceList title="View regulatory lineage" references={readiness.regulatoryProfileReferences} />
+      <ReferenceList title="View evidence lineage" references={readiness.evidenceReferences} />
+      <ReferenceList title="Review lineage" references={readiness.reviewReferences} />
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Redactions</div>
+        {readiness.redactions.map((redaction) => (
+          <Card key={redaction} style={{ borderRadius: 8, padding: 12, color: "#475569" }}>{redaction}</Card>
+        ))}
+      </Section>
+    </div>
+  );
+}

--- a/rentchain-frontend/src/pages/AssetTokenizationReadinessPage.test.tsx
+++ b/rentchain-frontend/src/pages/AssetTokenizationReadinessPage.test.tsx
@@ -1,0 +1,112 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import AssetTokenizationReadinessPage from "./AssetTokenizationReadinessPage";
+
+const mockFetchAssetTokenizationReadiness = vi.fn();
+const mockShowToast = vi.fn();
+
+vi.mock("@/api/assetTokenizationReadinessApi", () => ({
+  fetchAssetTokenizationReadiness: (...args: any[]) => mockFetchAssetTokenizationReadiness(...args),
+}));
+
+vi.mock("@/components/layout/MacShell", () => ({
+  MacShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
+const readiness = {
+  assetReadinessId: "asset_tokenization_readiness:landlord-1:property:property-1",
+  assetType: "property",
+  status: "partially_ready",
+  manualReviewRequired: true,
+  tokenIssuanceEnabled: false,
+  blockchainIntegrationEnabled: false,
+  publicMarketplaceEnabled: false,
+  generatedAt: "2026-01-01T00:00:00.000Z",
+  summary: {
+    totalReferences: 1,
+    verifiedReferences: 0,
+    partiallyVerifiedReferences: 1,
+    blockedReferences: 0,
+    unavailableReferences: 0,
+    tokenizationEligibleReferences: 0,
+  },
+  assetReferences: [],
+  cashflowReferences: [],
+  occupancyReferences: [],
+  maintenancePerformanceReferences: [],
+  settlementReadinessReferences: [],
+  regulatoryProfileReferences: [],
+  reviewReferences: [],
+  evidenceReferences: [],
+  redactions: ["Investor data and securities-offering materials are excluded."],
+  blockedReasons: [],
+  canonicalEvents: [],
+};
+
+describe("AssetTokenizationReadinessPage", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchAssetTokenizationReadiness.mockResolvedValue([readiness]);
+  });
+
+  it("renders asset tokenization readiness and required safety copy", async () => {
+    render(
+      <MemoryRouter>
+        <AssetTokenizationReadinessPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Asset tokenization readiness")).toBeInTheDocument();
+    expect(screen.getAllByText(/No token issuance, blockchain integration, or public marketplace is enabled/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("Investor data and securities-offering materials are excluded.")).toBeInTheDocument();
+  });
+
+  it("updates deterministic property, asset type, and status filters", async () => {
+    render(
+      <MemoryRouter>
+        <AssetTokenizationReadinessPage />
+      </MemoryRouter>
+    );
+
+    await screen.findByText("Asset tokenization readiness");
+    fireEvent.change(screen.getAllByLabelText("Property reference")[0], { target: { value: "property-2" } });
+    fireEvent.change(screen.getAllByLabelText("Asset type")[0], { target: { value: "lease_cashflow" } });
+    fireEvent.change(screen.getAllByLabelText("Status")[0], { target: { value: "blocked" } });
+
+    await waitFor(() => {
+      expect(mockFetchAssetTokenizationReadiness).toHaveBeenLastCalledWith({
+        propertyId: "property-2",
+        assetType: "lease_cashflow",
+        status: "blocked",
+      });
+    });
+  });
+
+  it("shows empty state and omits forbidden labels", async () => {
+    mockFetchAssetTokenizationReadiness.mockResolvedValue([]);
+    render(
+      <MemoryRouter>
+        <AssetTokenizationReadinessPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("No asset-tokenization readiness references match these filters.")).toBeInTheDocument();
+    expect(screen.queryByText("Mint token")).not.toBeInTheDocument();
+    expect(screen.queryByText("Deploy contract")).not.toBeInTheDocument();
+    expect(screen.queryByText("Connect blockchain")).not.toBeInTheDocument();
+    expect(screen.queryByText("Public marketplace")).not.toBeInTheDocument();
+    expect(screen.queryByText("Issue asset")).not.toBeInTheDocument();
+    expect(screen.queryByText("Autonomous tokenization")).not.toBeInTheDocument();
+    expect(screen.queryByText("Investor onboarding")).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/AssetTokenizationReadinessPage.tsx
+++ b/rentchain-frontend/src/pages/AssetTokenizationReadinessPage.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { useSearchParams } from "react-router-dom";
+import {
+  fetchAssetTokenizationReadiness,
+  type AssetTokenizationAssetType,
+  type AssetTokenizationReadiness,
+  type AssetTokenizationReadinessStatus,
+} from "@/api/assetTokenizationReadinessApi";
+import { MacShell } from "@/components/layout/MacShell";
+import { AssetTokenizationReadinessPanel } from "@/components/tokenization/AssetTokenizationReadinessPanel";
+import { Card, Section } from "@/components/ui/Ui";
+import { useToast } from "@/components/ui/ToastProvider";
+
+const statuses: Array<AssetTokenizationReadinessStatus | ""> = ["", "eligible_for_review", "partially_ready", "blocked", "unknown"];
+const assetTypes: Array<AssetTokenizationAssetType | ""> = ["", "property", "lease_cashflow", "operational_asset"];
+
+function label(value: string) {
+  return value ? value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase()) : "All";
+}
+
+export default function AssetTokenizationReadinessPage() {
+  const { showToast } = useToast();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [readiness, setReadiness] = React.useState<AssetTokenizationReadiness[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const propertyId = String(searchParams.get("propertyId") || "").trim();
+  const assetType = String(searchParams.get("assetType") || "") as AssetTokenizationAssetType | "";
+  const status = String(searchParams.get("status") || "") as AssetTokenizationReadinessStatus | "";
+
+  React.useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const next = await fetchAssetTokenizationReadiness({
+          propertyId: propertyId || undefined,
+          assetType,
+          status,
+        });
+        if (mounted) setReadiness(next);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Failed to load asset tokenization readiness";
+        if (mounted) {
+          setError(message);
+          showToast({ message: "Failed to load asset tokenization readiness", description: message, variant: "error" });
+        }
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [propertyId, assetType, status, showToast]);
+
+  function updateParams(next: { propertyId?: string; assetType?: string; status?: string }) {
+    const params = new URLSearchParams(searchParams);
+    for (const [key, value] of Object.entries(next)) {
+      if (value && value.trim()) params.set(key, value.trim());
+      else params.delete(key);
+    }
+    setSearchParams(params);
+  }
+
+  return (
+    <MacShell title="Asset tokenization readiness" showTopNav={false}>
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "grid", gap: 6 }}>
+            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Asset tokenization readiness</h1>
+            <div style={{ color: "#475569", maxWidth: 900 }}>
+              Asset tokenization readiness is operational and review scoped. No token issuance, blockchain integration, or public marketplace is enabled.
+              Manual review remains required.
+            </div>
+          </div>
+        </Section>
+
+        <Section style={{ display: "flex", gap: 10, flexWrap: "wrap", alignItems: "end" }}>
+          <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Property reference
+            <input value={propertyId} onChange={(event) => updateParams({ propertyId: event.target.value })} placeholder="Optional property reference" style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 220 }} />
+          </label>
+          <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Asset type
+            <select value={assetType} onChange={(event) => updateParams({ assetType: event.target.value })} style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 180 }}>
+              {assetTypes.map((item) => <option key={item || "all"} value={item}>{label(item)}</option>)}
+            </select>
+          </label>
+          <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Status
+            <select value={status} onChange={(event) => updateParams({ status: event.target.value })} style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 180 }}>
+              {statuses.map((item) => <option key={item || "all"} value={item}>{label(item)}</option>)}
+            </select>
+          </label>
+        </Section>
+
+        {loading ? <Card>Loading asset tokenization readiness...</Card> : null}
+        {!loading && error ? <Card style={{ color: "#b91c1c" }}>We couldn't load asset tokenization readiness right now.</Card> : null}
+        {!loading && !error && !readiness.length ? <Card style={{ color: "#64748b" }}>No asset-tokenization readiness references match these filters.</Card> : null}
+        {!loading && !error && readiness.length ? (
+          <div style={{ display: "grid", gap: 16 }}>{readiness.map((item) => <AssetTokenizationReadinessPanel key={item.assetReadinessId} readiness={item} />)}</div>
+        ) : null}
+      </div>
+    </MacShell>
+  );
+}

--- a/rentchain-frontend/src/pages/RegulatoryProfilePage.tsx
+++ b/rentchain-frontend/src/pages/RegulatoryProfilePage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useSearchParams } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import { fetchRegulatoryProfiles, type RegulatoryProfile, type RegulatoryProfileStatus } from "@/api/regulatoryProfileApi";
 import { MacShell } from "@/components/layout/MacShell";
 import { RegulatoryProfilePanel } from "@/components/regulatory/RegulatoryProfilePanel";
@@ -64,6 +64,9 @@ export default function RegulatoryProfilePage() {
               Regulatory profiles are operational readiness references only. No legal certification or regulator submission is enabled.
               Manual review remains required.
             </div>
+            <Link to="/asset-tokenization-readiness" style={{ color: "#2563eb", fontWeight: 800, width: "fit-content" }}>
+              View asset tokenization readiness
+            </Link>
           </div>
         </Section>
 


### PR DESCRIPTION
## Summary
- Adds deterministic, landlord-scoped Asset Tokenization Readiness Infrastructure
- Adds endpoints:
  - `GET /api/landlord/asset-tokenization-readiness`
  - `GET /api/landlord/asset-tokenization-readiness/:assetReadinessId`
- Adds frontend `/asset-tokenization-readiness` page and `AssetTokenizationReadinessPanel`
- Adds safe link from Regulatory Profiles
- Adds canonical asset, lease cashflow, occupancy, maintenance/performance, settlement-readiness, regulatory-profile, review, evidence, redaction, and audit-event references
- Adds descriptor-only canonical events for asset-tokenization readiness/review/restriction/redaction states
- Confirms `manualReviewRequired` true
- Confirms `tokenIssuanceEnabled`, `blockchainIntegrationEnabled`, and `publicMarketplaceEnabled` false
- Confirms no token issuance, smart contracts, blockchain integration, wallets, securities offering, investor onboarding, public marketplace execution, external financial execution, sensitive payload exposure, or admin-only leakage was added

## Verification
- Backend targeted tests passed: `pnpm exec vitest run src/lib/assetTokenizationReadiness/__tests__/deriveAssetTokenizationReadiness.test.ts src/routes/__tests__/landlordAssetTokenizationReadinessRoutes.test.ts`
- Frontend targeted tests passed: `pnpm exec vitest run src/components/tokenization/AssetTokenizationReadinessPanel.test.tsx src/pages/AssetTokenizationReadinessPage.test.tsx src/pages/RegulatoryProfilePage.test.tsx src/App.routes.test.tsx`
- Frontend targeted retest passed after label cleanup
- Full backend suite passed: `pnpm test`
- Full frontend suite passed: `pnpm test`
- Backend build passed: `pnpm build`
- Frontend build passed: `pnpm build` with existing non-regressive chunk-size warning
- `git diff --check` passed
- Dependency/lockfile diff empty
- Forbidden runtime-label scan clean

## Guardrails
- No token issuance, blockchain deployment, smart contracts, wallets, exchanges, DeFi, staking, securities offering, investor onboarding, crypto custody, or real-money movement added
- No sensitive tenant/payment/screening/private audit payload exposure added
- No landlord/admin permission widening added
- Read-only, deterministic, permissioned, review-oriented infrastructure only