### PR TITLE
feat: add network participant layer

### DIFF
--- a/docs/architecture/network-participant-layer-v1.md
+++ b/docs/architecture/network-participant-layer-v1.md
@@ -1,0 +1,93 @@
+# Network Participant Layer v1
+
+## Purpose
+
+The Network Participant Layer normalizes permissioned operational ecosystem actors into deterministic read models for review, evidence, sharing, settlement, regulatory, and audit visibility.
+
+This layer is institutional ecosystem relationship infrastructure. It is not public networking, public discovery, reputation scoring, messaging, or external institution integration.
+
+## Participants
+
+Supported participant types:
+
+- landlord
+- operator
+- lender
+- insurer
+- auditor
+- regulator
+- contractor
+- institutional_partner
+- review_actor
+
+Each participant profile is derived from existing landlord-scoped operational references and includes:
+
+- identity references
+- relationship references
+- review references
+- evidence references
+- permission references
+- redactions
+- blocked reasons
+- descriptor-only canonical events
+
+## Required Safety Flags
+
+Every profile returns:
+
+- `manualReviewRequired: true`
+- `publiclyDiscoverable: false`
+- `externalRelationshipExecutionEnabled: false`
+
+These flags are invariant in v1.
+
+## Relationship Rules
+
+Relationships are deterministic and derived from existing references:
+
+- identity lineage present -> verification relationship can be verified
+- sharing-room metadata present -> sharing relationship is visible
+- review sessions present -> review relationship is visible
+- evidence packs present -> evidence relationship is visible
+- settlement/regulatory restrictions -> operational relationship can be blocked
+- public access or external execution metadata -> relationship blocked
+- missing institutional identity lineage -> review required or unavailable
+
+No AI trust scoring, probabilistic ranking, public reputation, autonomous trust, or public discovery is introduced.
+
+## Canonical Event Descriptors
+
+The layer emits descriptor-only event references:
+
+- `network_participant_profile_derived`
+- `network_relationship_verified`
+- `network_relationship_review_required`
+- `network_relationship_blocked`
+- `network_relationship_redaction_applied`
+
+These are additive, deterministic, explainable, and traceable. They do not mutate source records or create external relationships.
+
+## Redaction Model
+
+The layer excludes:
+
+- private identity details and raw government identifiers
+- raw screening and credit bureau payloads
+- payment account details and unrestricted financial information
+- unrestricted audit histories and private tenant communications
+- public profile or reputation metadata
+
+## Non-Goals
+
+This release does not add:
+
+- public participant profiles
+- public participant search or discovery
+- social-network features
+- messaging systems
+- public reputation systems
+- AI trust scoring
+- autonomous relationship execution
+- external institution integrations
+- financial execution
+- legal certification

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -131,6 +131,7 @@ import landlordRentalHistoryLedgerRoutes from "./routes/landlordRentalHistoryLed
 import landlordSettlementReadinessRoutes from "./routes/landlordSettlementReadinessRoutes";
 import landlordRegulatoryProfileRoutes from "./routes/landlordRegulatoryProfileRoutes";
 import landlordAssetTokenizationReadinessRoutes from "./routes/landlordAssetTokenizationReadinessRoutes";
+import landlordNetworkParticipantRoutes from "./routes/landlordNetworkParticipantRoutes";
 import publicPortfolioScoreRoutes from "./routes/publicPortfolioScoreRoutes";
 import publicTenantShareRoutes from "./routes/publicTenantShareRoutes";
 import landlordActionRecommendationRoutes from "./routes/landlordActionRecommendationRoutes";
@@ -316,6 +317,8 @@ app.use("/api/landlord", routeSource("landlordRegulatoryProfileRoutes.ts"), land
 console.log("[route-mount] landlordRegulatoryProfileRoutes mounted at /api/landlord");
 app.use("/api/landlord", routeSource("landlordAssetTokenizationReadinessRoutes.ts"), landlordAssetTokenizationReadinessRoutes);
 console.log("[route-mount] landlordAssetTokenizationReadinessRoutes mounted at /api/landlord");
+app.use("/api/landlord", routeSource("landlordNetworkParticipantRoutes.ts"), landlordNetworkParticipantRoutes);
+console.log("[route-mount] landlordNetworkParticipantRoutes mounted at /api/landlord");
 app.use("/api", routeSource("landlordActionRecommendationRoutes.ts"), landlordActionRecommendationRoutes);
 console.log("[route-mount] landlordActionRecommendationRoutes mounted at /api");
 app.use("/api", routeSource("tenantFeedbackRoutes.ts"), tenantFeedbackRoutes);

--- a/rentchain-api/src/lib/networkParticipants/__tests__/deriveNetworkParticipantProfile.test.ts
+++ b/rentchain-api/src/lib/networkParticipants/__tests__/deriveNetworkParticipantProfile.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { deriveNetworkParticipantProfile } from "../deriveNetworkParticipantProfile";
+
+describe("deriveNetworkParticipantProfile", () => {
+  it("derives deterministic guarded network participant profile", () => {
+    const profile = deriveNetworkParticipantProfile({
+      landlordId: "landlord-1",
+      participantType: "lender",
+      participantId: "lender-1",
+      identityProfiles: [{ identityId: "organization:lender-1", identityType: "organization", status: "verified" }],
+      sharingRooms: [
+        {
+          sharingRoomId: "room-1",
+          status: "active",
+          publiclyAccessible: false,
+          externalExecutionEnabled: false,
+          accessControls: { institutionType: "lender" },
+        },
+      ],
+      operatorReviewSessions: [{ reviewSessionId: "review-1", status: "completed" }],
+      evidencePacks: [{ evidencePackId: "evidence-1", status: "ready_for_review" }],
+    });
+
+    expect(profile.participantType).toBe("lender");
+    expect(profile.status).toBe("verified");
+    expect(profile.manualReviewRequired).toBe(true);
+    expect(profile.publiclyDiscoverable).toBe(false);
+    expect(profile.externalRelationshipExecutionEnabled).toBe(false);
+    expect(profile.relationshipReferences.some((relationship) => relationship.relationshipType === "sharing_relationship")).toBe(true);
+    expect(profile.canonicalEvents.map((event) => event.eventType)).toContain("network_participant_profile_derived");
+    expect(profile.canonicalEvents.map((event) => event.eventType)).toContain("network_relationship_verified");
+  });
+
+  it("blocks unsafe public or external sharing relationships", () => {
+    const profile = deriveNetworkParticipantProfile({
+      landlordId: "landlord-1",
+      participantType: "auditor",
+      participantId: "auditor-1",
+      identityProfiles: [{ identityId: "organization:auditor-1", identityType: "organization", status: "verified" }],
+      sharingRooms: [
+        {
+          sharingRoomId: "room-unsafe",
+          status: "active",
+          publiclyAccessible: true,
+          externalExecutionEnabled: false,
+          accessControls: { institutionType: "auditor" },
+        },
+      ],
+    });
+
+    expect(profile.status).toBe("blocked");
+    expect(profile.blockedReasons).toContain("Public access or external execution is not allowed for network participants.");
+    expect(profile.canonicalEvents.map((event) => event.eventType)).toContain("network_relationship_blocked");
+  });
+
+  it("keeps missing institutional identity review-required and redacted", () => {
+    const profile = deriveNetworkParticipantProfile({
+      landlordId: "landlord-1",
+      participantType: "regulator",
+      participantId: "regulator-1",
+      identityProfiles: [],
+      sharingRooms: [],
+    });
+
+    expect(profile.status).toBe("review_required");
+    expect(profile.identityReferences[0]).toEqual(expect.objectContaining({ status: "missing" }));
+    expect(JSON.stringify(profile)).not.toContain("rawGovernmentId");
+    expect(profile.redactions).toEqual(expect.arrayContaining(["Private identity details and raw government identifiers are excluded."]));
+  });
+});

--- a/rentchain-api/src/lib/networkParticipants/deriveNetworkParticipantProfile.ts
+++ b/rentchain-api/src/lib/networkParticipants/deriveNetworkParticipantProfile.ts
@@ -1,0 +1,361 @@
+import type {
+  DeriveNetworkParticipantProfileInput,
+  NetworkParticipantCanonicalEvent,
+  NetworkParticipantProfile,
+  NetworkParticipantStatus,
+  NetworkParticipantType,
+  NetworkRelationshipReference,
+} from "./networkParticipantTypes";
+import { networkParticipantIdPart, participantReference, relationshipReference } from "./networkRelationshipModels";
+
+const PARTICIPANT_TYPES = new Set<NetworkParticipantType>([
+  "landlord",
+  "operator",
+  "lender",
+  "insurer",
+  "auditor",
+  "regulator",
+  "contractor",
+  "institutional_partner",
+  "review_actor",
+]);
+
+const REDACTIONS = [
+  "Private identity details and raw government identifiers are excluded.",
+  "Raw screening and credit bureau payloads are excluded.",
+  "Payment account details and unrestricted financial information are excluded.",
+  "Unrestricted audit histories and private tenant communications are excluded.",
+  "Network participants are permissioned operational actors, not public profiles.",
+];
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function asArray<T>(value: T[] | null | undefined): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function generatedAt(value: unknown): string {
+  const raw = asString(value, 120);
+  const date = raw ? new Date(raw) : new Date(0);
+  return Number.isNaN(date.getTime()) ? new Date(0).toISOString() : date.toISOString();
+}
+
+function normalizeType(value: unknown): NetworkParticipantType {
+  const raw = asString(value, 80) as NetworkParticipantType;
+  return PARTICIPANT_TYPES.has(raw) ? raw : "landlord";
+}
+
+function event(input: {
+  eventType: NetworkParticipantCanonicalEvent["eventType"];
+  status: NetworkParticipantStatus;
+  participantId: string;
+  summary: string;
+}): NetworkParticipantCanonicalEvent {
+  return {
+    eventType: input.eventType,
+    action: input.eventType.replace(/^network_/, "").replace(/_/g, "."),
+    status: input.status,
+    resourceType: "network_participant",
+    resourceId: input.participantId,
+    summary: input.summary,
+  };
+}
+
+function statusFromRelationships(hasContext: boolean, relationships: NetworkRelationshipReference[]): NetworkParticipantStatus {
+  if (!hasContext) return "unknown";
+  if (relationships.some((relationship) => relationship.status === "blocked")) return "blocked";
+  if (relationships.some((relationship) => relationship.status === "unavailable")) return "review_required";
+  if (relationships.some((relationship) => relationship.status === "partially_verified")) return "partially_verified";
+  return "verified";
+}
+
+function participantMatches(record: Record<string, any>, participantType: NetworkParticipantType, participantId: string) {
+  if (!participantId) return true;
+  const values = [
+    record.id,
+    record.participantId,
+    record.identityId,
+    record.userId,
+    record.actorId,
+    record.openedById,
+    record.reviewActorId,
+    record.contractorId,
+    record.institutionId,
+    record.sharingRoomId,
+    record.type,
+    record.participantType,
+  ].map((value) => asString(value, 500));
+  if (values.includes(participantId)) return true;
+  if (participantType === "lender" || participantType === "insurer" || participantType === "auditor" || participantType === "regulator") {
+    return asString(record.accessControls?.institutionType || record.institutionType, 80) === participantType;
+  }
+  return false;
+}
+
+export function deriveNetworkParticipantProfile(input: DeriveNetworkParticipantProfileInput): NetworkParticipantProfile {
+  const landlordId = asString(input.landlordId, 240);
+  const participantType = normalizeType(input.participantType);
+  const requestedId = asString(input.participantId, 500);
+  const participantId =
+    networkParticipantIdPart(["network_participant", landlordId || "unknown", participantType, requestedId || "portfolio"].join(":")) ||
+    "network_participant:unknown";
+
+  const identityProfiles = asArray(input.identityProfiles);
+  const sharingRooms = asArray(input.sharingRooms).filter((room) => participantMatches(room, participantType, requestedId));
+  const reviews = asArray(input.operatorReviewSessions).filter((review) => participantMatches(review, participantType, requestedId));
+  const evidencePacks = asArray(input.evidencePacks);
+  const regulatoryProfiles = asArray(input.regulatoryProfiles);
+  const events = asArray(input.canonicalEvents);
+  const contractors = asArray(input.contractorProfiles).filter((contractor) => participantMatches(contractor, participantType, requestedId));
+  const settlementReadiness = input.settlementReadiness || null;
+
+  const identityReferences = identityProfiles.length
+    ? identityProfiles.map((profile) =>
+        participantReference({
+          idParts: ["identity", profile.identityId || profile.id || participantType],
+          referenceType: "identity",
+          label: "Identity lineage reference",
+          status: profile.status === "blocked" ? "blocked" : "available",
+          destination: `/identity-layer?identityType=${encodeURIComponent(asString(profile.identityType || "organization", 80))}&identityId=${encodeURIComponent(
+            asString(profile.identityId || profile.id, 500)
+          )}`,
+          blockedReason: profile.status === "blocked" ? "Identity lineage is blocked." : null,
+        })
+      )
+    : [
+        participantReference({
+          idParts: ["identity", "missing", participantType],
+          referenceType: "identity",
+          label: "Identity lineage reference",
+          status: participantType === "landlord" ? "available" : "missing",
+          blockedReason: participantType === "landlord" ? null : "Identity lineage is missing for this participant type.",
+        }),
+      ];
+
+  const reviewReferences = reviews.map((review) =>
+    participantReference({
+      idParts: ["review", review.reviewSessionId || review.id || "unknown"],
+      referenceType: "review",
+      label: "Operator review lineage",
+      status: review.status === "completed" ? "available" : "missing",
+      destination: "/review-timeline",
+      occurredAt: review.closedAt || review.openedAt || review.createdAt,
+      blockedReason: review.status === "blocked" ? "Operator review is blocked." : null,
+    })
+  );
+
+  const evidenceReferences = evidencePacks.map((pack) =>
+    participantReference({
+      idParts: ["evidence", pack.evidencePackId || pack.id || "unknown"],
+      referenceType: "evidence",
+      label: "Evidence lineage",
+      status: pack.status === "blocked" ? "blocked" : "available",
+      destination: "/evidence-packs",
+      occurredAt: pack.generatedAt || pack.createdAt,
+      blockedReason: pack.status === "blocked" ? "Evidence pack is blocked." : null,
+    })
+  );
+
+  const permissionReferences = sharingRooms.map((room) =>
+    participantReference({
+      idParts: ["permission", room.sharingRoomId || room.id || "unknown"],
+      referenceType: "permission",
+      label: "Permissioned sharing boundary",
+      status: room.publiclyAccessible || room.externalExecutionEnabled ? "blocked" : "available",
+      destination: "/institutional-sharing-rooms",
+      occurredAt: room.updatedAt || room.createdAt,
+      blockedReason: room.publiclyAccessible || room.externalExecutionEnabled ? "Sharing room indicates public access or external execution." : null,
+    })
+  );
+
+  const relationshipReferences: NetworkRelationshipReference[] = [];
+  relationshipReferences.push(
+    relationshipReference({
+      idParts: ["verification", participantId],
+      relationshipType: "verification_relationship",
+      status: identityReferences.some((reference) => reference.status === "blocked")
+        ? "blocked"
+        : identityReferences.some((reference) => reference.status === "missing")
+          ? "unavailable"
+          : "verified",
+      label: "Identity verification relationship",
+      description: "Identity lineage is available as permission-scoped participant metadata.",
+      participantReferences: identityReferences.map((reference) => reference.referenceId),
+      reviewLineage: reviewReferences.map((reference) => reference.referenceId),
+      destination: "/identity-layer",
+      blockedReason: identityReferences.some((reference) => reference.status === "blocked") ? "Identity relationship requires manual review." : null,
+    })
+  );
+
+  if (sharingRooms.length) {
+    for (const room of sharingRooms) {
+      relationshipReferences.push(
+        relationshipReference({
+          idParts: ["sharing", room.sharingRoomId || room.id || "unknown"],
+          relationshipType: "sharing_relationship",
+          status: room.publiclyAccessible || room.externalExecutionEnabled || room.status === "blocked" ? "blocked" : room.status === "active" ? "verified" : "partially_verified",
+          label: "Institutional sharing relationship",
+          description: "Sharing-room metadata is available as a controlled relationship reference.",
+          participantReferences: [asString(room.sharingRoomId || room.id, 240)].filter(Boolean),
+          permissionReferences: permissionReferences.map((reference) => reference.referenceId),
+          evidenceLineage: evidenceReferences.map((reference) => reference.referenceId),
+          reviewLineage: reviewReferences.map((reference) => reference.referenceId),
+          destination: "/institutional-sharing-rooms",
+          blockedReason: room.publiclyAccessible || room.externalExecutionEnabled ? "Public access or external execution is not allowed for network participants." : null,
+        })
+      );
+    }
+  } else {
+    relationshipReferences.push(
+      relationshipReference({
+        idParts: ["sharing", "missing", participantType],
+        relationshipType: "sharing_relationship",
+        status: participantType === "landlord" || participantType === "operator" || participantType === "review_actor" ? "partially_verified" : "unavailable",
+        label: "Institutional sharing relationship",
+        description: "No institutional sharing relationship is currently available for this participant.",
+        blockedReason: null,
+      })
+    );
+  }
+
+  if (reviews.length) {
+    relationshipReferences.push(
+      relationshipReference({
+        idParts: ["review", participantId],
+        relationshipType: "review_relationship",
+        status: reviews.some((review) => review.status === "completed") ? "verified" : "partially_verified",
+        label: "Review relationship",
+        description: "Operator review lineage is available for this participant.",
+        reviewLineage: reviewReferences.map((reference) => reference.referenceId),
+        destination: "/review-timeline",
+      })
+    );
+  }
+
+  if (evidencePacks.length) {
+    relationshipReferences.push(
+      relationshipReference({
+        idParts: ["evidence", participantId],
+        relationshipType: "evidence_relationship",
+        status: evidencePacks.some((pack) => pack.status === "blocked") ? "blocked" : "verified",
+        label: "Evidence relationship",
+        description: "Evidence pack lineage is available for participant review.",
+        evidenceLineage: evidenceReferences.map((reference) => reference.referenceId),
+        destination: "/evidence-packs",
+        blockedReason: evidencePacks.some((pack) => pack.status === "blocked") ? "Evidence relationship is blocked." : null,
+      })
+    );
+  }
+
+  if (settlementReadiness || regulatoryProfiles.length || contractors.length) {
+    relationshipReferences.push(
+      relationshipReference({
+        idParts: ["operational", participantId],
+        relationshipType: "operational_relationship",
+        status:
+          settlementReadiness?.status === "blocked" || regulatoryProfiles.some((profile) => profile.status === "blocked")
+            ? "blocked"
+            : "partially_verified",
+        label: "Operational relationship",
+        description: "Settlement, regulatory, or contractor metadata is available as operational ecosystem context.",
+        participantReferences: contractors.map((contractor) => asString(contractor.contractorId || contractor.id, 240)).filter(Boolean),
+        evidenceLineage: evidenceReferences.map((reference) => reference.referenceId),
+        reviewLineage: reviewReferences.map((reference) => reference.referenceId),
+        destination: settlementReadiness ? "/settlement-readiness" : regulatoryProfiles.length ? "/regulatory-profiles" : null,
+        blockedReason:
+          settlementReadiness?.status === "blocked" || regulatoryProfiles.some((profile) => profile.status === "blocked")
+            ? "Settlement or regulatory relationship is blocked."
+            : null,
+      })
+    );
+  }
+
+  const hasContext = Boolean(
+    landlordId &&
+      (participantType === "landlord" ||
+        identityProfiles.length ||
+        requestedId ||
+        sharingRooms.length ||
+        reviews.length ||
+        contractors.length ||
+        events.length ||
+        settlementReadiness ||
+        regulatoryProfiles.length)
+  );
+  const status = statusFromRelationships(hasContext, relationshipReferences);
+  const blockedReasons = relationshipReferences.map((relationship) => relationship.blockedReason).filter(Boolean) as string[];
+  const canonicalEvents: NetworkParticipantCanonicalEvent[] = [
+    event({
+      eventType: "network_participant_profile_derived",
+      status,
+      participantId,
+      summary: "Network participant profile derived from permission-scoped operational references.",
+    }),
+    event({
+      eventType: "network_relationship_redaction_applied",
+      status,
+      participantId,
+      summary: "Private identity, screening, payment, audit, and contact payloads were excluded from participant references.",
+    }),
+  ];
+  if (relationshipReferences.some((relationship) => relationship.status === "verified")) {
+    canonicalEvents.push(
+      event({
+        eventType: "network_relationship_verified",
+        status,
+        participantId,
+        summary: "At least one permission-scoped network relationship is verified.",
+      })
+    );
+  }
+  if (status === "review_required" || status === "partially_verified") {
+    canonicalEvents.push(
+      event({
+        eventType: "network_relationship_review_required",
+        status,
+        participantId,
+        summary: "Manual relationship review is required before relying on this participant profile.",
+      })
+    );
+  }
+  if (status === "blocked") {
+    canonicalEvents.push(
+      event({
+        eventType: "network_relationship_blocked",
+        status,
+        participantId,
+        summary: "Network relationship is blocked by unsafe or conflicting references.",
+      })
+    );
+  }
+
+  return {
+    participantId,
+    participantType,
+    status,
+    manualReviewRequired: true,
+    publiclyDiscoverable: false,
+    externalRelationshipExecutionEnabled: false,
+    generatedAt: generatedAt(input.generatedAt),
+    summary: {
+      totalRelationships: relationshipReferences.length,
+      verifiedRelationships: relationshipReferences.filter((relationship) => relationship.status === "verified").length,
+      partiallyVerifiedRelationships: relationshipReferences.filter((relationship) => relationship.status === "partially_verified").length,
+      blockedRelationships: relationshipReferences.filter((relationship) => relationship.status === "blocked").length,
+      unavailableRelationships: relationshipReferences.filter((relationship) => relationship.status === "unavailable").length,
+      evidenceReferences: evidenceReferences.length,
+      reviewReferences: reviewReferences.length,
+      permissionReferences: permissionReferences.length,
+    },
+    identityReferences,
+    relationshipReferences,
+    reviewReferences,
+    evidenceReferences,
+    permissionReferences,
+    redactions: REDACTIONS,
+    blockedReasons,
+    canonicalEvents,
+  };
+}

--- a/rentchain-api/src/lib/networkParticipants/networkParticipantTypes.ts
+++ b/rentchain-api/src/lib/networkParticipants/networkParticipantTypes.ts
@@ -1,0 +1,117 @@
+export type NetworkParticipantType =
+  | "landlord"
+  | "operator"
+  | "lender"
+  | "insurer"
+  | "auditor"
+  | "regulator"
+  | "contractor"
+  | "institutional_partner"
+  | "review_actor";
+
+export type NetworkParticipantStatus = "verified" | "partially_verified" | "review_required" | "blocked" | "unknown";
+
+export type NetworkRelationshipType =
+  | "review_relationship"
+  | "sharing_relationship"
+  | "operational_relationship"
+  | "verification_relationship"
+  | "evidence_relationship";
+
+export type NetworkRelationshipStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+
+export type NetworkParticipantCanonicalEventType =
+  | "network_participant_profile_derived"
+  | "network_relationship_verified"
+  | "network_relationship_review_required"
+  | "network_relationship_blocked"
+  | "network_relationship_redaction_applied";
+
+export type NetworkRelationshipReference = {
+  relationshipId: string;
+  relationshipType: NetworkRelationshipType;
+  status: NetworkRelationshipStatus;
+  label: string;
+  description: string;
+  reviewRequired: true;
+  participantReferences: string[];
+  evidenceLineage: string[];
+  reviewLineage: string[];
+  permissionReferences: string[];
+  destination: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type NetworkParticipantReference = {
+  referenceId: string;
+  referenceType:
+    | "identity"
+    | "relationship"
+    | "review"
+    | "evidence"
+    | "permission"
+    | "sharing_room"
+    | "settlement"
+    | "regulatory"
+    | "canonical_event";
+  label: string;
+  status: "available" | "missing" | "blocked" | "redacted";
+  destination: string | null;
+  occurredAt: string | null;
+  redacted: boolean;
+  blockedReason: string | null;
+};
+
+export type NetworkParticipantCanonicalEvent = {
+  eventType: NetworkParticipantCanonicalEventType;
+  action: string;
+  status: NetworkParticipantStatus;
+  resourceType: "network_participant";
+  resourceId: string;
+  summary: string;
+};
+
+export type NetworkParticipantProfile = {
+  participantId: string;
+  participantType: NetworkParticipantType;
+  status: NetworkParticipantStatus;
+  manualReviewRequired: true;
+  publiclyDiscoverable: false;
+  externalRelationshipExecutionEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalRelationships: number;
+    verifiedRelationships: number;
+    partiallyVerifiedRelationships: number;
+    blockedRelationships: number;
+    unavailableRelationships: number;
+    evidenceReferences: number;
+    reviewReferences: number;
+    permissionReferences: number;
+  };
+  identityReferences: NetworkParticipantReference[];
+  relationshipReferences: NetworkRelationshipReference[];
+  reviewReferences: NetworkParticipantReference[];
+  evidenceReferences: NetworkParticipantReference[];
+  permissionReferences: NetworkParticipantReference[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: NetworkParticipantCanonicalEvent[];
+};
+
+export type DeriveNetworkParticipantProfileInput = {
+  landlordId?: unknown;
+  participantType?: unknown;
+  participantId?: unknown;
+  generatedAt?: unknown;
+  identityProfiles?: Array<Record<string, any>> | null;
+  sharingRooms?: Array<Record<string, any>> | null;
+  operatorReviewSessions?: Array<Record<string, any>> | null;
+  evidencePacks?: Array<Record<string, any>> | null;
+  settlementReadiness?: Record<string, any> | null;
+  regulatoryProfiles?: Array<Record<string, any>> | null;
+  canonicalEvents?: Array<Record<string, any>> | null;
+  contractorProfiles?: Array<Record<string, any>> | null;
+};

--- a/rentchain-api/src/lib/networkParticipants/networkRelationshipModels.ts
+++ b/rentchain-api/src/lib/networkParticipants/networkRelationshipModels.ts
@@ -1,0 +1,74 @@
+import type {
+  NetworkParticipantReference,
+  NetworkRelationshipReference,
+  NetworkRelationshipStatus,
+  NetworkRelationshipType,
+} from "./networkParticipantTypes";
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+export function networkParticipantIdPart(value: unknown): string {
+  return asString(value, 500)
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+export function participantReference(input: {
+  idParts: unknown[];
+  referenceType: NetworkParticipantReference["referenceType"];
+  label: string;
+  status?: NetworkParticipantReference["status"];
+  destination?: string | null;
+  occurredAt?: unknown;
+  redacted?: boolean;
+  blockedReason?: string | null;
+}): NetworkParticipantReference {
+  const redacted = Boolean(input.redacted);
+  return {
+    referenceId: networkParticipantIdPart(input.idParts.join(":")) || "network_reference:unknown",
+    referenceType: input.referenceType,
+    label: input.label,
+    status: input.status || (redacted ? "redacted" : "available"),
+    destination: input.destination || null,
+    occurredAt: asString(input.occurredAt, 120) || null,
+    redacted,
+    blockedReason: input.blockedReason || null,
+  };
+}
+
+export function relationshipReference(input: {
+  idParts: unknown[];
+  relationshipType: NetworkRelationshipType;
+  status: NetworkRelationshipStatus;
+  label: string;
+  description: string;
+  participantReferences?: string[];
+  evidenceLineage?: string[];
+  reviewLineage?: string[];
+  permissionReferences?: string[];
+  destination?: string | null;
+  redacted?: boolean;
+  redactionReason?: string | null;
+  blockedReason?: string | null;
+}): NetworkRelationshipReference {
+  return {
+    relationshipId: networkParticipantIdPart(input.idParts.join(":")) || "network_relationship:unknown",
+    relationshipType: input.relationshipType,
+    status: input.status,
+    label: input.label,
+    description: input.description,
+    reviewRequired: true,
+    participantReferences: Array.from(new Set(input.participantReferences || [])).filter(Boolean),
+    evidenceLineage: Array.from(new Set(input.evidenceLineage || [])).filter(Boolean),
+    reviewLineage: Array.from(new Set(input.reviewLineage || [])).filter(Boolean),
+    permissionReferences: Array.from(new Set(input.permissionReferences || [])).filter(Boolean),
+    destination: input.destination || null,
+    redacted: Boolean(input.redacted),
+    redactionReason: input.redactionReason || null,
+    blockedReason: input.blockedReason || null,
+  };
+}

--- a/rentchain-api/src/routes/__tests__/landlordNetworkParticipantRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordNetworkParticipantRoutes.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+  function matches(doc: any, filters: Array<{ field: string; op: string; value: any }>) {
+    return filters.every(({ field, op, value }) => (op === "==" ? doc?.data?.[field] === value : false));
+  }
+  function makeQuery(name: string, filters: Array<{ field: string; op: string; value: any }> = []) {
+    return {
+      where: (field: string, op: string, value: any) => makeQuery(name, [...filters, { field, op, value }]),
+      get: async () => {
+        const docs = Array.from(ensureCollection(name).values())
+          .filter((doc) => matches(doc, filters))
+          .map((doc) => ({ id: doc.id, exists: true, data: () => doc.data }));
+        return { docs, empty: docs.length === 0, size: docs.length };
+      },
+      doc: (id: string) => makeDoc(name, id),
+    };
+  }
+  function makeDoc(name: string, id: string) {
+    const col = ensureCollection(name);
+    return {
+      id,
+      get: async () => {
+        const entry = col.get(id);
+        return { id, exists: Boolean(entry), data: () => entry?.data };
+      },
+      set: async (data: any) => {
+        col.set(id, { id, data });
+      },
+    };
+  }
+  return {
+    resetFakeDb: () => store.clear(),
+    seedDoc: (collection: string, id: string, data: any) => ensureCollection(collection).set(id, { id, data }),
+    fakeDb: {
+      collection: (name: string) => ({
+        where: (field: string, op: string, value: any) => makeQuery(name, [{ field, op, value }]),
+        get: async () => makeQuery(name).get(),
+        doc: (id: string) => makeDoc(name, id),
+      }),
+    },
+  };
+});
+
+let mockUser: any;
+
+vi.mock("../../config/firebase", () => ({ db: fakeDb }));
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!mockUser) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    req.user = mockUser;
+    return next();
+  },
+}));
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: any, res: any, next: any) => {
+    const role = String(req.user?.role || "").trim().toLowerCase();
+    const landlordId = req.user?.landlordId || req.user?.id;
+    if (role !== "landlord" && role !== "admin") return res.status(403).json({ ok: false, error: "Forbidden" });
+    req.user.landlordId = landlordId;
+    return next();
+  },
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; user?: Record<string, unknown> | null }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    mockUser = options.user ?? mockUser;
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: mockUser,
+      query: Object.fromEntries(new URLSearchParams(queryString || "").entries()),
+      params: {},
+      body: {},
+      headers: {},
+    };
+    const match = path.match(/^\/network-participants\/(.+)$/);
+    if (match) req.params = { participantId: decodeURIComponent(match[1]) };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => (error ? reject(error) : undefined));
+  });
+}
+
+describe("landlordNetworkParticipantRoutes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    resetFakeDb();
+    mockUser = { id: "landlord-1", landlordId: "landlord-1", role: "landlord" };
+  });
+
+  function seedNetwork() {
+    seedDoc("operatorReviewSessions", "review-1", { landlordId: "landlord-1", reviewSessionId: "review-1", status: "completed" });
+    seedDoc("evidencePacks", "evidence-1", { landlordId: "landlord-1", evidencePackId: "evidence-1", status: "ready_for_review" });
+    seedDoc("institutionalSharingRooms", "room-1", {
+      landlordId: "landlord-1",
+      sharingRoomId: "room-1",
+      status: "active",
+      publiclyAccessible: false,
+      externalExecutionEnabled: false,
+      accessControls: { institutionType: "lender" },
+    });
+    seedDoc("consents", "consent-1", { landlordId: "landlord-1", consentScope: "network_review", rawGovernmentId: "sensitive-id" });
+  }
+
+  it("returns landlord-scoped participants without sensitive payloads", async () => {
+    seedNetwork();
+    const router = (await import("../landlordNetworkParticipantRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/network-participants?participantType=lender" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.participants).toHaveLength(1);
+    expect(res.body.participants[0]).toEqual(
+      expect.objectContaining({ manualReviewRequired: true, publiclyDiscoverable: false, externalRelationshipExecutionEnabled: false })
+    );
+    const serialized = JSON.stringify(res.body);
+    expect(serialized).not.toContain("sensitive-id");
+  });
+
+  it("returns a single participant by id", async () => {
+    seedNetwork();
+    const router = (await import("../landlordNetworkParticipantRoutes")).default;
+    const list = await invokeRouter(router, { method: "GET", url: "/network-participants?participantType=lender" });
+    const id = list.body.participants[0].participantId;
+
+    const res = await invokeRouter(router, { method: "GET", url: `/network-participants/${encodeURIComponent(id)}` });
+
+    expect(res.status).toBe(200);
+    expect(res.body.participant.participantId).toBe(id);
+  });
+
+  it("filters by status and blocks non-landlord users", async () => {
+    seedNetwork();
+    const router = (await import("../landlordNetworkParticipantRoutes")).default;
+
+    const filtered = await invokeRouter(router, { method: "GET", url: "/network-participants?participantType=lender&status=unknown" });
+    expect(filtered.status).toBe(200);
+    expect(filtered.body.participants).toEqual([]);
+
+    const forbidden = await invokeRouter(router, { method: "GET", url: "/network-participants", user: { id: "tenant-1", role: "tenant" } });
+    expect(forbidden.status).toBe(403);
+  });
+});

--- a/rentchain-api/src/routes/landlordNetworkParticipantRoutes.ts
+++ b/rentchain-api/src/routes/landlordNetworkParticipantRoutes.ts
@@ -1,0 +1,211 @@
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { requireAuth } from "../middleware/requireAuth";
+import { requireLandlord } from "../middleware/requireLandlord";
+import { deriveIdentityProfile } from "../lib/identityLayer/deriveIdentityProfile";
+import { deriveNetworkParticipantProfile } from "../lib/networkParticipants/deriveNetworkParticipantProfile";
+import type {
+  NetworkParticipantProfile,
+  NetworkParticipantStatus,
+  NetworkParticipantType,
+} from "../lib/networkParticipants/networkParticipantTypes";
+
+const router = Router();
+const PARTICIPANT_TYPES = new Set<NetworkParticipantType>([
+  "landlord",
+  "operator",
+  "lender",
+  "insurer",
+  "auditor",
+  "regulator",
+  "contractor",
+  "institutional_partner",
+  "review_actor",
+]);
+const STATUSES = new Set<NetworkParticipantStatus>(["verified", "partially_verified", "review_required", "blocked", "unknown"]);
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function landlordIdFromReq(req: any) {
+  return asString(req.user?.landlordId || req.user?.id || req.user?.sub, 240);
+}
+
+async function loadLandlordCollection(collectionName: string, landlordId: string) {
+  const byId = new Map<string, any>();
+  async function collect(field: "landlordId" | "ownerId" | "userId" | "createdByLandlordId") {
+    const snap = await db.collection(collectionName).where(field, "==", landlordId).get().catch(() => null);
+    for (const doc of snap?.docs || []) byId.set(doc.id, { id: doc.id, ...((doc.data() as any) || {}) });
+  }
+  await Promise.all([collect("landlordId"), collect("ownerId"), collect("userId"), collect("createdByLandlordId")]);
+  return Array.from(byId.values()).filter((record) =>
+    [record?.landlordId, record?.ownerId, record?.userId, record?.createdByLandlordId].some((value) => asString(value, 240) === landlordId)
+  );
+}
+
+function normalizedParticipantType(value: unknown): NetworkParticipantType | "" {
+  const raw = asString(value, 80) as NetworkParticipantType;
+  return PARTICIPANT_TYPES.has(raw) ? raw : "";
+}
+
+function profileMatches(profile: NetworkParticipantProfile, id: string) {
+  return profile.participantId === id;
+}
+
+function identityProfiles(input: {
+  participantType: NetworkParticipantType;
+  participantId: string;
+  tenants: any[];
+  properties: any[];
+  organizations: any[];
+  reviews: any[];
+  consents: any[];
+  events: any[];
+  registryStatuses: any[];
+}) {
+  const profiles = [];
+  if (input.participantType === "landlord") {
+    profiles.push(
+      deriveIdentityProfile({
+        identityType: "organization",
+        identityId: input.participantId || "landlord",
+        organization: { id: input.participantId || "landlord", organizationId: input.participantId || "landlord" },
+        consentRecords: input.consents,
+        reviewSessions: input.reviews,
+        canonicalEvents: input.events,
+      })
+    );
+  }
+  if (input.participantType === "operator" || input.participantType === "review_actor") {
+    profiles.push(
+      deriveIdentityProfile({
+        identityType: input.participantType === "operator" ? "operator" : "review_actor",
+        identityId: input.participantId,
+        operator: input.reviews[0] || null,
+        consentRecords: input.consents,
+        reviewSessions: input.reviews,
+        canonicalEvents: input.events,
+      })
+    );
+  }
+  if (input.participantType === "contractor") {
+    profiles.push(
+      deriveIdentityProfile({
+        identityType: "organization",
+        identityId: input.participantId || "contractor",
+        organization: { id: input.participantId || "contractor", organizationId: input.participantId || "contractor" },
+        consentRecords: input.consents,
+        reviewSessions: input.reviews,
+        canonicalEvents: input.events,
+      })
+    );
+  }
+  if (["lender", "insurer", "auditor", "regulator", "institutional_partner"].includes(input.participantType)) {
+    profiles.push(
+      deriveIdentityProfile({
+        identityType: "organization",
+        identityId: input.participantId || input.participantType,
+        organization: { id: input.participantId || input.participantType, organizationId: input.participantId || input.participantType },
+        consentRecords: input.consents,
+        reviewSessions: input.reviews,
+        canonicalEvents: input.events,
+      })
+    );
+  }
+  return profiles;
+}
+
+async function buildProfiles(landlordId: string, filters: { participantType: NetworkParticipantType | ""; participantId: string }) {
+  const [tenants, properties, organizations, reviews, evidencePacks, sharingRooms, consents, events, registryStatuses, contractors, settlementRecords, regulatoryRecords] =
+    await Promise.all([
+      loadLandlordCollection("tenants", landlordId),
+      loadLandlordCollection("properties", landlordId),
+      loadLandlordCollection("organizations", landlordId),
+      loadLandlordCollection("operatorReviewSessions", landlordId),
+      loadLandlordCollection("evidencePacks", landlordId),
+      loadLandlordCollection("institutionalSharingRooms", landlordId),
+      loadLandlordCollection("consents", landlordId),
+      loadLandlordCollection("events", landlordId),
+      loadLandlordCollection("propertyRegistryStatuses", landlordId),
+      loadLandlordCollection("contractorProfiles", landlordId),
+      loadLandlordCollection("settlementReadiness", landlordId),
+      loadLandlordCollection("regulatoryProfiles", landlordId),
+    ]);
+
+  const types: NetworkParticipantType[] = filters.participantType
+    ? [filters.participantType]
+    : ["landlord", "operator", "lender", "insurer", "auditor", "regulator", "contractor", "institutional_partner", "review_actor"];
+
+  return types.map((participantType) => {
+    const scopedSharingRooms =
+      participantType === "lender" || participantType === "insurer" || participantType === "auditor" || participantType === "regulator"
+        ? sharingRooms.filter((room) => asString(room.accessControls?.institutionType || room.institutionType, 80) === participantType)
+        : sharingRooms;
+    const scopedReviews =
+      participantType === "operator" || participantType === "review_actor"
+        ? reviews.filter((review) => !filters.participantId || [review.id, review.actorId, review.openedById, review.userId].map((value) => asString(value, 500)).includes(filters.participantId))
+        : reviews;
+    const scopedContractors =
+      participantType === "contractor"
+        ? contractors.filter((contractor) => !filters.participantId || [contractor.id, contractor.contractorId].map((value) => asString(value, 500)).includes(filters.participantId))
+        : [];
+
+    return deriveNetworkParticipantProfile({
+      landlordId,
+      participantType,
+      participantId: filters.participantId,
+      identityProfiles: identityProfiles({
+        participantType,
+        participantId: filters.participantId,
+        tenants,
+        properties,
+        organizations,
+        reviews: scopedReviews,
+        consents,
+        events,
+        registryStatuses,
+      }),
+      sharingRooms: scopedSharingRooms,
+      operatorReviewSessions: scopedReviews,
+      evidencePacks,
+      settlementReadiness: settlementRecords[0] || null,
+      regulatoryProfiles: regulatoryRecords,
+      canonicalEvents: events,
+      contractorProfiles: scopedContractors,
+    });
+  });
+}
+
+router.get("/network-participants", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = landlordIdFromReq(req);
+    if (!landlordId) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    const participantType = normalizedParticipantType(req.query?.participantType);
+    const participantId = asString(req.query?.participantId, 500);
+    const status = asString(req.query?.status, 80) as NetworkParticipantStatus;
+    let participants = await buildProfiles(landlordId, { participantType, participantId });
+    if (status && STATUSES.has(status)) participants = participants.filter((profile) => profile.status === status);
+    return res.json({ ok: true, participants });
+  } catch (err: any) {
+    console.error("[landlord-network-participants] list failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "NETWORK_PARTICIPANTS_FAILED" });
+  }
+});
+
+router.get("/network-participants/:participantId", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = landlordIdFromReq(req);
+    const participantId = decodeURIComponent(asString(req.params?.participantId, 500));
+    if (!landlordId || !participantId) return res.status(400).json({ ok: false, error: "NETWORK_PARTICIPANT_ID_REQUIRED" });
+    const participants = await buildProfiles(landlordId, { participantType: "", participantId: "" });
+    const profile = participants.find((participant) => profileMatches(participant, participantId));
+    if (!profile) return res.status(404).json({ ok: false, error: "NETWORK_PARTICIPANT_NOT_FOUND" });
+    return res.json({ ok: true, participant: profile });
+  } catch (err: any) {
+    console.error("[landlord-network-participants] get failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "NETWORK_PARTICIPANT_GET_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -142,6 +142,10 @@ vi.mock("./pages/AssetTokenizationReadinessPage", () => ({
   default: () => <h1>Asset Tokenization Readiness Page</h1>,
 }));
 
+vi.mock("./pages/NetworkParticipantsPage", () => ({
+  default: () => <h1>Network Participants Page</h1>,
+}));
+
 vi.mock("./pages/landlord/PortfolioScorePage", () => ({
   default: () => <h1>Landlord Portfolio Score</h1>,
 }));
@@ -431,6 +435,20 @@ describe("Routes: /asset-tokenization-readiness", () => {
     );
 
     expect(await screen.findByText(/Asset Tokenization Readiness Page/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Routes: /network-participants", () => {
+  it("renders the network participants route", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/network-participants?participantType=lender"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Network Participants Page/i)).toBeInTheDocument();
     expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -128,6 +128,7 @@ const VerifiedRentalHistoryPage = lazy(() => import("./pages/VerifiedRentalHisto
 const SettlementReadinessPage = lazy(() => import("./pages/SettlementReadinessPage"));
 const RegulatoryProfilePage = lazy(() => import("./pages/RegulatoryProfilePage"));
 const AssetTokenizationReadinessPage = lazy(() => import("./pages/AssetTokenizationReadinessPage"));
+const NetworkParticipantsPage = lazy(() => import("./pages/NetworkParticipantsPage"));
 const LandlordPortfolioScorePage = lazy(() => import("./pages/landlord/PortfolioScorePage"));
 const SharedPortfolioScorePage = lazy(() => import("./pages/public/SharedPortfolioScorePage"));
 const TenantSharePackagePage = lazy(() => import("./pages/public/TenantSharePackagePage"));
@@ -655,6 +656,18 @@ function App() {
               <LandlordNav>
                 <Suspense fallback={null}>
                   <AssetTokenizationReadinessPage />
+                </Suspense>
+              </LandlordNav>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/network-participants"
+          element={
+            <RequireAuth>
+              <LandlordNav>
+                <Suspense fallback={null}>
+                  <NetworkParticipantsPage />
                 </Suspense>
               </LandlordNav>
             </RequireAuth>

--- a/rentchain-frontend/src/api/networkParticipantsApi.ts
+++ b/rentchain-frontend/src/api/networkParticipantsApi.ts
@@ -1,0 +1,98 @@
+import { apiFetch } from "./apiFetch";
+
+export type NetworkParticipantType =
+  | "landlord"
+  | "operator"
+  | "lender"
+  | "insurer"
+  | "auditor"
+  | "regulator"
+  | "contractor"
+  | "institutional_partner"
+  | "review_actor";
+
+export type NetworkParticipantStatus = "verified" | "partially_verified" | "review_required" | "blocked" | "unknown";
+export type NetworkRelationshipStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+export type NetworkRelationshipType =
+  | "review_relationship"
+  | "sharing_relationship"
+  | "operational_relationship"
+  | "verification_relationship"
+  | "evidence_relationship";
+
+export type NetworkParticipantReference = {
+  referenceId: string;
+  referenceType: "identity" | "relationship" | "review" | "evidence" | "permission" | "sharing_room" | "settlement" | "regulatory" | "canonical_event";
+  label: string;
+  status: "available" | "missing" | "blocked" | "redacted";
+  destination: string | null;
+  occurredAt: string | null;
+  redacted: boolean;
+  blockedReason: string | null;
+};
+
+export type NetworkRelationshipReference = {
+  relationshipId: string;
+  relationshipType: NetworkRelationshipType;
+  status: NetworkRelationshipStatus;
+  label: string;
+  description: string;
+  reviewRequired: true;
+  participantReferences: string[];
+  evidenceLineage: string[];
+  reviewLineage: string[];
+  permissionReferences: string[];
+  destination: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type NetworkParticipantProfile = {
+  participantId: string;
+  participantType: NetworkParticipantType;
+  status: NetworkParticipantStatus;
+  manualReviewRequired: true;
+  publiclyDiscoverable: false;
+  externalRelationshipExecutionEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalRelationships: number;
+    verifiedRelationships: number;
+    partiallyVerifiedRelationships: number;
+    blockedRelationships: number;
+    unavailableRelationships: number;
+    evidenceReferences: number;
+    reviewReferences: number;
+    permissionReferences: number;
+  };
+  identityReferences: NetworkParticipantReference[];
+  relationshipReferences: NetworkRelationshipReference[];
+  reviewReferences: NetworkParticipantReference[];
+  evidenceReferences: NetworkParticipantReference[];
+  permissionReferences: NetworkParticipantReference[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: Array<{ eventType: string; action: string; status: NetworkParticipantStatus; resourceId: string; summary: string }>;
+};
+
+export async function fetchNetworkParticipants(params?: {
+  participantType?: NetworkParticipantType | "";
+  participantId?: string;
+  status?: NetworkParticipantStatus | "";
+}): Promise<NetworkParticipantProfile[]> {
+  const search = new URLSearchParams();
+  if (params?.participantType) search.set("participantType", params.participantType);
+  if (params?.participantId) search.set("participantId", params.participantId);
+  if (params?.status) search.set("status", params.status);
+  const suffix = search.toString() ? `?${search.toString()}` : "";
+  const response = await apiFetch<{ ok: true; participants: NetworkParticipantProfile[] }>(`/landlord/network-participants${suffix}`);
+  return response.participants;
+}
+
+export async function fetchNetworkParticipant(participantId: string): Promise<NetworkParticipantProfile> {
+  const response = await apiFetch<{ ok: true; participant: NetworkParticipantProfile }>(
+    `/landlord/network-participants/${encodeURIComponent(participantId)}`
+  );
+  return response.participant;
+}

--- a/rentchain-frontend/src/components/network/NetworkParticipantPanel.test.tsx
+++ b/rentchain-frontend/src/components/network/NetworkParticipantPanel.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { NetworkParticipantPanel } from "./NetworkParticipantPanel";
+
+const participant = {
+  participantId: "network_participant:landlord-1:lender:lender-1",
+  participantType: "lender",
+  status: "partially_verified",
+  manualReviewRequired: true,
+  publiclyDiscoverable: false,
+  externalRelationshipExecutionEnabled: false,
+  generatedAt: "2026-01-01T00:00:00.000Z",
+  summary: {
+    totalRelationships: 2,
+    verifiedRelationships: 1,
+    partiallyVerifiedRelationships: 1,
+    blockedRelationships: 0,
+    unavailableRelationships: 0,
+    evidenceReferences: 1,
+    reviewReferences: 1,
+    permissionReferences: 1,
+  },
+  identityReferences: [
+    {
+      referenceId: "identity:lender-1",
+      referenceType: "identity",
+      label: "Identity lineage reference",
+      status: "available",
+      destination: "/identity-layer",
+      occurredAt: null,
+      redacted: false,
+      blockedReason: null,
+    },
+  ],
+  relationshipReferences: [
+    {
+      relationshipId: "sharing:room-1",
+      relationshipType: "sharing_relationship",
+      status: "partially_verified",
+      label: "Institutional sharing relationship",
+      description: "Sharing-room metadata is available as a controlled relationship reference.",
+      reviewRequired: true,
+      participantReferences: ["room-1"],
+      evidenceLineage: ["evidence-1"],
+      reviewLineage: ["review-1"],
+      permissionReferences: ["permission-1"],
+      destination: "/institutional-sharing-rooms",
+      redacted: false,
+      redactionReason: null,
+      blockedReason: "Manual relationship review remains required.",
+    },
+  ],
+  reviewReferences: [],
+  evidenceReferences: [],
+  permissionReferences: [],
+  redactions: ["Payment account details and unrestricted financial information are excluded."],
+  blockedReasons: ["Manual relationship review remains required."],
+  canonicalEvents: [],
+} as const;
+
+describe("NetworkParticipantPanel", () => {
+  it("renders participant relationships, lineage, blocked reasons, and safety copy", () => {
+    render(
+      <MemoryRouter>
+        <NetworkParticipantPanel participant={participant as any} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("View participant")).toBeInTheDocument();
+    expect(screen.getByText(/Network participants are permissioned operational actors/i)).toBeInTheDocument();
+    expect(screen.getByText("View relationships")).toBeInTheDocument();
+    expect(screen.getByText("View evidence lineage: 1")).toBeInTheDocument();
+    expect(screen.getByText("View review lineage: 1")).toBeInTheDocument();
+    expect(screen.getByText("View blocked reason: Manual relationship review remains required.")).toBeInTheDocument();
+    expect(screen.getByText("Payment account details and unrestricted financial information are excluded.")).toBeInTheDocument();
+  });
+
+  it("does not render forbidden public-network labels", () => {
+    render(
+      <MemoryRouter>
+        <NetworkParticipantPanel participant={participant as any} />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText("Public profile")).not.toBeInTheDocument();
+    expect(screen.queryByText("Publish participant")).not.toBeInTheDocument();
+    expect(screen.queryByText("Public directory")).not.toBeInTheDocument();
+    expect(screen.queryByText("Autonomous trust")).not.toBeInTheDocument();
+    expect(screen.queryByText("Auto-connect")).not.toBeInTheDocument();
+    expect(screen.queryByText("Public reputation")).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/network/NetworkParticipantPanel.tsx
+++ b/rentchain-frontend/src/components/network/NetworkParticipantPanel.tsx
@@ -1,0 +1,137 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import type { NetworkParticipantProfile, NetworkParticipantReference, NetworkRelationshipReference } from "@/api/networkParticipantsApi";
+import { Card, Section } from "@/components/ui/Ui";
+
+function label(value: string) {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function tone(status: string) {
+  if (status === "blocked") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
+  if (status === "review_required" || status === "partially_verified" || status === "missing" || status === "unavailable") {
+    return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
+  }
+  if (status === "verified" || status === "available") return { color: "#166534", background: "#dcfce7", border: "#bbf7d0" };
+  return { color: "#475569", background: "#f8fafc", border: "#e2e8f0" };
+}
+
+function Badge({ children, status }: { children: React.ReactNode; status: string }) {
+  const next = tone(status);
+  return (
+    <span style={{ border: `1px solid ${next.border}`, borderRadius: 999, background: next.background, color: next.color, padding: "3px 9px", fontSize: 12, fontWeight: 900, whiteSpace: "nowrap" }}>
+      {children}
+    </span>
+  );
+}
+
+function RelationshipList({ relationships }: { relationships: NetworkRelationshipReference[] }) {
+  return (
+    <Section style={{ display: "grid", gap: 10 }}>
+      <div style={{ fontWeight: 900 }}>View relationships</div>
+      {relationships.length ? (
+        relationships.map((relationship) => (
+          <Card key={relationship.relationshipId} style={{ borderRadius: 8, padding: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+              <div>
+                <strong>{relationship.label}</strong>
+                <div style={{ color: "#64748b", fontSize: 13 }}>{label(relationship.relationshipType)}</div>
+              </div>
+              <Badge status={relationship.status}>{label(relationship.status)}</Badge>
+            </div>
+            <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>{relationship.description}</div>
+            {relationship.reviewLineage.length ? <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>View review lineage: {relationship.reviewLineage.length}</div> : null}
+            {relationship.evidenceLineage.length ? <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>View evidence lineage: {relationship.evidenceLineage.length}</div> : null}
+            {relationship.blockedReason ? <div style={{ color: "#991b1b", fontSize: 13, marginTop: 8 }}>View blocked reason: {relationship.blockedReason}</div> : null}
+            {relationship.destination ? <Link to={relationship.destination} style={{ color: "#2563eb", fontWeight: 800, fontSize: 13, marginTop: 8, display: "inline-block" }}>View participant context</Link> : null}
+          </Card>
+        ))
+      ) : (
+        <Card style={{ color: "#64748b" }}>Context unavailable</Card>
+      )}
+    </Section>
+  );
+}
+
+function ReferenceList({ title, references }: { title: string; references: NetworkParticipantReference[] }) {
+  return (
+    <Section style={{ display: "grid", gap: 10 }}>
+      <div style={{ fontWeight: 900 }}>{title}</div>
+      {references.length ? (
+        references.map((reference) => (
+          <Card key={reference.referenceId} style={{ borderRadius: 8, padding: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+              <div>
+                <strong>{reference.label}</strong>
+                <div style={{ color: "#64748b", fontSize: 13 }}>{label(reference.referenceType)}</div>
+              </div>
+              <Badge status={reference.status}>{label(reference.status)}</Badge>
+            </div>
+            {reference.blockedReason ? <div style={{ color: "#991b1b", fontSize: 13, marginTop: 8 }}>View blocked reason: {reference.blockedReason}</div> : null}
+            {reference.redacted ? <div style={{ color: "#92400e", fontSize: 13, marginTop: 8 }}>Redacted participant reference</div> : null}
+            {reference.destination ? <Link to={reference.destination} style={{ color: "#2563eb", fontWeight: 800, fontSize: 13, marginTop: 8, display: "inline-block" }}>View context</Link> : null}
+          </Card>
+        ))
+      ) : (
+        <Card style={{ color: "#64748b" }}>Context unavailable</Card>
+      )}
+    </Section>
+  );
+}
+
+export function NetworkParticipantPanel({ participant }: { participant: NetworkParticipantProfile }) {
+  return (
+    <div style={{ display: "grid", gap: 16 }}>
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+          <div>
+            <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>View participant</div>
+            <h2 style={{ margin: "2px 0 0", fontSize: "1.15rem" }}>{label(participant.participantType)}</h2>
+          </div>
+          <Badge status={participant.status}>{label(participant.status)}</Badge>
+        </div>
+        <div style={{ color: "#475569", lineHeight: 1.55 }}>
+          Network participants are permissioned operational actors. No public discovery or autonomous relationship execution is enabled.
+          Manual review remains required.
+        </div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <Badge status="review_required">Manual review required</Badge>
+          <Badge status={participant.publiclyDiscoverable ? "blocked" : "verified"}>Discovery disabled</Badge>
+          <Badge status={participant.externalRelationshipExecutionEnabled ? "blocked" : "verified"}>Relationship execution disabled</Badge>
+        </div>
+      </Section>
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Participant summary</div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: 10 }}>
+          {[
+            ["Relationships", participant.summary.totalRelationships],
+            ["Verified", participant.summary.verifiedRelationships],
+            ["Partial", participant.summary.partiallyVerifiedRelationships],
+            ["Blocked", participant.summary.blockedRelationships],
+            ["Evidence", participant.summary.evidenceReferences],
+            ["Reviews", participant.summary.reviewReferences],
+          ].map(([name, value]) => (
+            <Card key={String(name)} style={{ borderRadius: 8, padding: 12 }}>
+              <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>{name}</div>
+              <strong style={{ color: "#0f172a", fontSize: 22 }}>{String(value)}</strong>
+            </Card>
+          ))}
+        </div>
+      </Section>
+
+      <RelationshipList relationships={participant.relationshipReferences} />
+      <ReferenceList title="Identity references" references={participant.identityReferences} />
+      <ReferenceList title="View review lineage" references={participant.reviewReferences} />
+      <ReferenceList title="View evidence lineage" references={participant.evidenceReferences} />
+      <ReferenceList title="Permission references" references={participant.permissionReferences} />
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Redactions</div>
+        {participant.redactions.map((redaction) => (
+          <Card key={redaction} style={{ borderRadius: 8, padding: 12, color: "#475569" }}>{redaction}</Card>
+        ))}
+      </Section>
+    </div>
+  );
+}

--- a/rentchain-frontend/src/pages/IdentityLayerPage.tsx
+++ b/rentchain-frontend/src/pages/IdentityLayerPage.tsx
@@ -110,6 +110,12 @@ export default function IdentityLayerPage() {
             >
               View rental history
             </Link>
+            <Link
+              to={`/network-participants${identityId ? `?participantId=${encodeURIComponent(identityId)}` : ""}`}
+              style={{ color: "#2563eb", fontWeight: 800, paddingBottom: 9 }}
+            >
+              View network participants
+            </Link>
           </div>
         </Section>
 

--- a/rentchain-frontend/src/pages/NetworkParticipantsPage.test.tsx
+++ b/rentchain-frontend/src/pages/NetworkParticipantsPage.test.tsx
@@ -1,0 +1,109 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import NetworkParticipantsPage from "./NetworkParticipantsPage";
+
+const mockFetchNetworkParticipants = vi.fn();
+const mockShowToast = vi.fn();
+
+vi.mock("@/api/networkParticipantsApi", () => ({
+  fetchNetworkParticipants: (...args: any[]) => mockFetchNetworkParticipants(...args),
+}));
+
+vi.mock("@/components/layout/MacShell", () => ({
+  MacShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
+const participant = {
+  participantId: "network_participant:landlord-1:lender:lender-1",
+  participantType: "lender",
+  status: "verified",
+  manualReviewRequired: true,
+  publiclyDiscoverable: false,
+  externalRelationshipExecutionEnabled: false,
+  generatedAt: "2026-01-01T00:00:00.000Z",
+  summary: {
+    totalRelationships: 1,
+    verifiedRelationships: 1,
+    partiallyVerifiedRelationships: 0,
+    blockedRelationships: 0,
+    unavailableRelationships: 0,
+    evidenceReferences: 0,
+    reviewReferences: 0,
+    permissionReferences: 0,
+  },
+  identityReferences: [],
+  relationshipReferences: [],
+  reviewReferences: [],
+  evidenceReferences: [],
+  permissionReferences: [],
+  redactions: ["Raw screening and credit bureau payloads are excluded."],
+  blockedReasons: [],
+  canonicalEvents: [],
+};
+
+describe("NetworkParticipantsPage", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchNetworkParticipants.mockResolvedValue([participant]);
+  });
+
+  it("renders network participants and required safety copy", async () => {
+    render(
+      <MemoryRouter>
+        <NetworkParticipantsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Network participants")).toBeInTheDocument();
+    expect(screen.getAllByText(/No public discovery or autonomous relationship execution is enabled/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("Raw screening and credit bureau payloads are excluded.")).toBeInTheDocument();
+  });
+
+  it("updates participant filters deterministically", async () => {
+    render(
+      <MemoryRouter>
+        <NetworkParticipantsPage />
+      </MemoryRouter>
+    );
+
+    await screen.findByText("Network participants");
+    fireEvent.change(screen.getByLabelText("Participant type"), { target: { value: "auditor" } });
+    fireEvent.change(screen.getByLabelText("Participant reference"), { target: { value: "auditor-1" } });
+    fireEvent.change(screen.getByLabelText("Status"), { target: { value: "blocked" } });
+
+    await waitFor(() => {
+      expect(mockFetchNetworkParticipants).toHaveBeenLastCalledWith({
+        participantType: "auditor",
+        participantId: "auditor-1",
+        status: "blocked",
+      });
+    });
+  });
+
+  it("shows empty state and omits forbidden labels", async () => {
+    mockFetchNetworkParticipants.mockResolvedValue([]);
+    render(
+      <MemoryRouter>
+        <NetworkParticipantsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("No network participants match these filters.")).toBeInTheDocument();
+    expect(screen.queryByText("Public profile")).not.toBeInTheDocument();
+    expect(screen.queryByText("Publish participant")).not.toBeInTheDocument();
+    expect(screen.queryByText("Public directory")).not.toBeInTheDocument();
+    expect(screen.queryByText("Autonomous trust")).not.toBeInTheDocument();
+    expect(screen.queryByText("Auto-connect")).not.toBeInTheDocument();
+    expect(screen.queryByText("Public reputation")).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/NetworkParticipantsPage.tsx
+++ b/rentchain-frontend/src/pages/NetworkParticipantsPage.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import { useSearchParams } from "react-router-dom";
+import {
+  fetchNetworkParticipants,
+  type NetworkParticipantProfile,
+  type NetworkParticipantStatus,
+  type NetworkParticipantType,
+} from "@/api/networkParticipantsApi";
+import { MacShell } from "@/components/layout/MacShell";
+import { NetworkParticipantPanel } from "@/components/network/NetworkParticipantPanel";
+import { Card, Section } from "@/components/ui/Ui";
+import { useToast } from "@/components/ui/ToastProvider";
+
+const participantTypes: Array<NetworkParticipantType | ""> = [
+  "",
+  "landlord",
+  "operator",
+  "lender",
+  "insurer",
+  "auditor",
+  "regulator",
+  "contractor",
+  "institutional_partner",
+  "review_actor",
+];
+const statuses: Array<NetworkParticipantStatus | ""> = ["", "verified", "partially_verified", "review_required", "blocked", "unknown"];
+
+function label(value: string) {
+  return value ? value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase()) : "All";
+}
+
+export default function NetworkParticipantsPage() {
+  const { showToast } = useToast();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [participants, setParticipants] = React.useState<NetworkParticipantProfile[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const participantType = String(searchParams.get("participantType") || "") as NetworkParticipantType | "";
+  const participantId = String(searchParams.get("participantId") || "").trim();
+  const status = String(searchParams.get("status") || "") as NetworkParticipantStatus | "";
+
+  React.useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const next = await fetchNetworkParticipants({ participantType, participantId: participantId || undefined, status });
+        if (mounted) setParticipants(next);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Failed to load network participants";
+        if (mounted) {
+          setError(message);
+          showToast({ message: "Failed to load network participants", description: message, variant: "error" });
+        }
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [participantType, participantId, status, showToast]);
+
+  function updateParams(next: { participantType?: string; participantId?: string; status?: string }) {
+    const params = new URLSearchParams(searchParams);
+    for (const [key, value] of Object.entries(next)) {
+      if (value && value.trim()) params.set(key, value.trim());
+      else params.delete(key);
+    }
+    setSearchParams(params);
+  }
+
+  return (
+    <MacShell title="Network participants" showTopNav={false}>
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "grid", gap: 6 }}>
+            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Network participants</h1>
+            <div style={{ color: "#475569", maxWidth: 900 }}>
+              Network participants are permissioned operational actors. No public discovery or autonomous relationship execution is enabled.
+              Manual review remains required.
+            </div>
+          </div>
+        </Section>
+
+        <Section style={{ display: "flex", gap: 10, flexWrap: "wrap", alignItems: "end" }}>
+          <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Participant type
+            <select value={participantType} onChange={(event) => updateParams({ participantType: event.target.value })} style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 190 }}>
+              {participantTypes.map((type) => <option key={type || "all"} value={type}>{label(type)}</option>)}
+            </select>
+          </label>
+          <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Participant reference
+            <input value={participantId} onChange={(event) => updateParams({ participantId: event.target.value })} placeholder="Optional internal reference" style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 230 }} />
+          </label>
+          <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Status
+            <select value={status} onChange={(event) => updateParams({ status: event.target.value })} style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 180 }}>
+              {statuses.map((item) => <option key={item || "all"} value={item}>{label(item)}</option>)}
+            </select>
+          </label>
+        </Section>
+
+        {loading ? <Card>Loading network participants...</Card> : null}
+        {!loading && error ? <Card style={{ color: "#b91c1c" }}>We couldn't load network participants right now.</Card> : null}
+        {!loading && !error && !participants.length ? <Card style={{ color: "#64748b" }}>No network participants match these filters.</Card> : null}
+        {!loading && !error && participants.length ? <div style={{ display: "grid", gap: 16 }}>{participants.map((participant) => <NetworkParticipantPanel key={participant.participantId} participant={participant} />)}</div> : null}
+      </div>
+    </MacShell>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds deterministic, landlord-scoped Network Participant Layer
- Adds endpoints:
  - `GET /api/landlord/network-participants`
  - `GET /api/landlord/network-participants/:participantId`
- Adds participant profiles for landlord, operator, lender, insurer, auditor, regulator, contractor, institutional partner, and review actor references
- Adds relationship references for verification, sharing, operational, review, and evidence relationships
- Adds review/evidence/permission lineage, blocked reasons, redactions, and descriptor-only canonical events
- Adds frontend `/network-participants` page and `NetworkParticipantPanel`
- Adds safe entry link from Identity Layer
- Adds architecture documentation for Network Participant Layer v1
- Confirms `manualReviewRequired` true
- Confirms `publiclyDiscoverable` and `externalRelationshipExecutionEnabled` false
- Confirms no public networking, public participant discovery, public reputation scoring, social features, autonomous trust, external institution integrations, sensitive payload exposure, or admin-only leakage was added

## Verification
- Backend targeted tests passed: `pnpm exec vitest run src/lib/networkParticipants/__tests__/deriveNetworkParticipantProfile.test.ts src/routes/__tests__/landlordNetworkParticipantRoutes.test.ts`
- Frontend targeted tests passed: `pnpm exec vitest run src/components/network/NetworkParticipantPanel.test.tsx src/pages/NetworkParticipantsPage.test.tsx src/pages/IdentityLayerPage.test.tsx src/App.routes.test.tsx`
- Backend build passed: `pnpm build`
- Frontend build passed: `pnpm build` with existing non-regressive chunk-size warning
- Full backend suite passed outside sandbox: `pnpm test`
- Full frontend suite passed on rerun: `pnpm test`
- Failed frontend full-suite attempt reproduced transient existing jsdom navigation/timeouts; rerunning the failed files passed, and the full suite passed on rerun
- `git diff --check` passed
- Dependency/lockfile diff empty
- Forbidden runtime-label scan clean

## Guardrails
- Read-only, deterministic, permissioned, audit-oriented participant aggregation only
- No public profiles, public directory/search, messaging, public reputation, AI trust scoring, autonomous relationship execution, institution integrations, financial execution, or legal certification
- Sensitive identity, screening/credit, payment, private audit, and tenant communication payloads are excluded/redacted