### PR TITLE
feat: add cross-organization trust layer

### DIFF
--- a/docs/architecture/cross-organization-trust-layer-v1.md
+++ b/docs/architecture/cross-organization-trust-layer-v1.md
@@ -1,0 +1,92 @@
+# Cross-Organization Trust Layer v1
+
+## Purpose
+
+The Cross-Organization Trust Layer provides deterministic, permissioned, read-only operational trust relationship references across network participants. It connects participant metadata with evidence lineage, review lineage, settlement readiness, regulatory readiness, institutional sharing controls, and audit lineage.
+
+This layer is an internal operational readiness surface. It does not create public reputation exposure, autonomous approvals, financial execution, legal certification, public discovery, or institutional integrations.
+
+## Model
+
+The v1 read model derives `CrossOrganizationTrustRelationship` records for:
+
+- `operational_trust`
+- `evidence_trust`
+- `review_trust`
+- `settlement_trust`
+- `regulatory_trust`
+- `sharing_trust`
+
+Every relationship includes:
+
+- `manualReviewRequired: true`
+- `publicTrustExposureEnabled: false`
+- `autonomousTrustApprovalEnabled: false`
+- deterministic status and summary counts
+- participant, review, evidence, settlement, regulatory, sharing, audit, and operational references
+- trust restrictions
+- redaction metadata
+- descriptor-only canonical events
+
+## Status Rules
+
+Status derivation is deterministic:
+
+- `verified`: required references are present and no selected references are blocked or unavailable
+- `partially_verified`: lineage exists but at least one selected reference is incomplete
+- `review_required`: required lineage is unavailable and no selected reference is blocked
+- `blocked`: selected references or restrictions indicate unsafe or conflicting operational trust context
+- `unknown`: insufficient source context exists
+
+No AI scoring, probabilistic ranking, or public trust calculation is used.
+
+## Restrictions
+
+Trust restrictions are surfaced when source relationships are incomplete or unsafe:
+
+- missing consent or access lineage blocks sharing trust
+- incomplete settlement readiness creates settlement restrictions
+- incomplete regulatory readiness creates regulatory restrictions
+- missing evidence, review, or audit lineage creates manual review requirements
+
+Restrictions are visibility-only. They do not approve, reject, execute, share, file, or communicate.
+
+## Canonical Events
+
+The layer emits descriptor-only event metadata for audit traceability:
+
+- `cross_organization_trust_derived`
+- `cross_organization_trust_verified`
+- `cross_organization_trust_review_required`
+- `cross_organization_trust_blocked`
+- `cross_organization_trust_redaction_applied`
+
+These are additive descriptors in the derived read model. They do not mutate source records or create external side effects.
+
+## Redaction Model
+
+The derived model excludes:
+
+- raw government identifiers
+- screening and credit bureau payloads
+- payment account details
+- unrestricted financial information
+- unrestricted audit histories
+- private tenant communications
+- public reputation and participant ranking data
+
+Landlord routes remain scoped to landlord-accessible operational metadata.
+
+## Non-Goals
+
+This layer does not provide:
+
+- public trust exposure
+- public participant ranking
+- reputation marketplaces
+- autonomous trust approvals
+- institution integrations
+- social networking
+- public discovery
+- financial execution
+- legal certification

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -132,6 +132,7 @@ import landlordSettlementReadinessRoutes from "./routes/landlordSettlementReadin
 import landlordRegulatoryProfileRoutes from "./routes/landlordRegulatoryProfileRoutes";
 import landlordAssetTokenizationReadinessRoutes from "./routes/landlordAssetTokenizationReadinessRoutes";
 import landlordNetworkParticipantRoutes from "./routes/landlordNetworkParticipantRoutes";
+import landlordCrossOrganizationTrustRoutes from "./routes/landlordCrossOrganizationTrustRoutes";
 import publicPortfolioScoreRoutes from "./routes/publicPortfolioScoreRoutes";
 import publicTenantShareRoutes from "./routes/publicTenantShareRoutes";
 import landlordActionRecommendationRoutes from "./routes/landlordActionRecommendationRoutes";
@@ -319,6 +320,8 @@ app.use("/api/landlord", routeSource("landlordAssetTokenizationReadinessRoutes.t
 console.log("[route-mount] landlordAssetTokenizationReadinessRoutes mounted at /api/landlord");
 app.use("/api/landlord", routeSource("landlordNetworkParticipantRoutes.ts"), landlordNetworkParticipantRoutes);
 console.log("[route-mount] landlordNetworkParticipantRoutes mounted at /api/landlord");
+app.use("/api/landlord", routeSource("landlordCrossOrganizationTrustRoutes.ts"), landlordCrossOrganizationTrustRoutes);
+console.log("[route-mount] landlordCrossOrganizationTrustRoutes mounted at /api/landlord");
 app.use("/api", routeSource("landlordActionRecommendationRoutes.ts"), landlordActionRecommendationRoutes);
 console.log("[route-mount] landlordActionRecommendationRoutes mounted at /api");
 app.use("/api", routeSource("tenantFeedbackRoutes.ts"), tenantFeedbackRoutes);

--- a/rentchain-api/src/lib/crossOrganizationTrust/__tests__/deriveCrossOrganizationTrust.test.ts
+++ b/rentchain-api/src/lib/crossOrganizationTrust/__tests__/deriveCrossOrganizationTrust.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { deriveCrossOrganizationTrust } from "../deriveCrossOrganizationTrust";
+
+describe("deriveCrossOrganizationTrust", () => {
+  it("derives deterministic guarded trust relationships from operational lineage", () => {
+    const trust = deriveCrossOrganizationTrust({
+      landlordId: "landlord-1",
+      relationshipType: "operational_trust",
+      networkParticipants: [{ participantId: "participant-1", status: "verified" }],
+      evidencePacks: [{ evidencePackId: "evidence-1", status: "ready_for_review" }],
+      operatorReviewSessions: [{ reviewSessionId: "review-1", status: "completed" }],
+      settlementReadiness: { settlementReadinessId: "settlement-1", status: "ready_for_review" },
+      regulatoryProfiles: [{ regulatoryProfileId: "regulatory-1", status: "ready_for_review" }],
+      sharingRooms: [{ sharingRoomId: "room-1", status: "active", publiclyAccessible: false, externalExecutionEnabled: false }],
+      auditEvents: [{ eventId: "event-1" }],
+      consentRecords: [{ consentId: "consent-1" }],
+    });
+
+    expect(trust.status).toBe("verified");
+    expect(trust.manualReviewRequired).toBe(true);
+    expect(trust.publicTrustExposureEnabled).toBe(false);
+    expect(trust.autonomousTrustApprovalEnabled).toBe(false);
+    expect(trust.summary.totalReferences).toBeGreaterThan(0);
+    expect(trust.canonicalEvents.map((event) => event.eventType)).toContain("cross_organization_trust_derived");
+    expect(trust.canonicalEvents.map((event) => event.eventType)).toContain("cross_organization_trust_verified");
+  });
+
+  it("blocks sharing trust when consent lineage is missing", () => {
+    const trust = deriveCrossOrganizationTrust({
+      landlordId: "landlord-1",
+      relationshipType: "sharing_trust",
+      networkParticipants: [{ participantId: "participant-1", status: "verified" }],
+      evidencePacks: [{ evidencePackId: "evidence-1", status: "ready_for_review" }],
+      operatorReviewSessions: [{ reviewSessionId: "review-1", status: "completed" }],
+      settlementReadiness: { settlementReadinessId: "settlement-1", status: "ready_for_review" },
+      regulatoryProfiles: [{ regulatoryProfileId: "regulatory-1", status: "ready_for_review" }],
+      sharingRooms: [],
+      auditEvents: [{ eventId: "event-1" }],
+      consentRecords: [],
+    });
+
+    expect(trust.status).toBe("blocked");
+    expect(trust.blockedReasons).toContain("Consent/access lineage is missing for sharing trust.");
+    expect(trust.trustRestrictions.map((restriction) => restriction.restrictionType)).toContain("consent");
+    expect(trust.canonicalEvents.map((event) => event.eventType)).toContain("cross_organization_trust_blocked");
+  });
+
+  it("keeps missing lineage review-required and excludes sensitive payloads", () => {
+    const trust = deriveCrossOrganizationTrust({
+      landlordId: "landlord-1",
+      relationshipType: "evidence_trust",
+      networkParticipants: [{ participantId: "participant-1", status: "verified", rawGovernmentId: "sensitive-id" }],
+      evidencePacks: [],
+      operatorReviewSessions: [],
+      settlementReadiness: null,
+      regulatoryProfiles: [],
+      sharingRooms: [],
+      auditEvents: [],
+      consentRecords: [{ consentId: "consent-1" }],
+    });
+
+    expect(trust.status).toBe("review_required");
+    expect(trust.evidenceReferences[0]).toEqual(expect.objectContaining({ status: "unavailable" }));
+    expect(JSON.stringify(trust)).not.toContain("sensitive-id");
+    expect(trust.redactions).toEqual(
+      expect.arrayContaining(["Raw government identifiers, screening, and credit bureau payloads are excluded."])
+    );
+  });
+});

--- a/rentchain-api/src/lib/crossOrganizationTrust/crossOrganizationTrustTypes.ts
+++ b/rentchain-api/src/lib/crossOrganizationTrust/crossOrganizationTrustTypes.ts
@@ -1,0 +1,96 @@
+export type CrossOrganizationTrustRelationshipType =
+  | "operational_trust"
+  | "evidence_trust"
+  | "review_trust"
+  | "settlement_trust"
+  | "regulatory_trust"
+  | "sharing_trust";
+
+export type CrossOrganizationTrustStatus = "verified" | "partially_verified" | "review_required" | "blocked" | "unknown";
+
+export type CrossOrganizationTrustReferenceType = "evidence" | "review" | "settlement" | "regulatory" | "sharing" | "audit" | "operational";
+
+export type CrossOrganizationTrustReferenceStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+
+export type CrossOrganizationTrustCanonicalEventType =
+  | "cross_organization_trust_derived"
+  | "cross_organization_trust_verified"
+  | "cross_organization_trust_review_required"
+  | "cross_organization_trust_blocked"
+  | "cross_organization_trust_redaction_applied";
+
+export type CrossOrganizationTrustReference = {
+  trustReferenceId: string;
+  referenceType: CrossOrganizationTrustReferenceType;
+  status: CrossOrganizationTrustReferenceStatus;
+  label: string;
+  description: string;
+  reviewRequired: true;
+  lineageReferences: string[];
+  destination: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type CrossOrganizationTrustRestriction = {
+  restrictionId: string;
+  restrictionType: "consent" | "settlement" | "regulatory" | "sharing" | "audit" | "evidence" | "review";
+  status: "visible" | "blocked" | "review_required";
+  label: string;
+  description: string;
+  blockedReason: string | null;
+};
+
+export type CrossOrganizationTrustCanonicalEvent = {
+  eventType: CrossOrganizationTrustCanonicalEventType;
+  action: string;
+  status: CrossOrganizationTrustStatus;
+  resourceType: "cross_organization_trust";
+  resourceId: string;
+  summary: string;
+};
+
+export type CrossOrganizationTrustRelationship = {
+  trustRelationshipId: string;
+  relationshipType: CrossOrganizationTrustRelationshipType;
+  status: CrossOrganizationTrustStatus;
+  manualReviewRequired: true;
+  publicTrustExposureEnabled: false;
+  autonomousTrustApprovalEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    partiallyVerifiedReferences: number;
+    blockedReferences: number;
+    unavailableReferences: number;
+    restrictions: number;
+  };
+  participantReferences: string[];
+  reviewReferences: CrossOrganizationTrustReference[];
+  evidenceReferences: CrossOrganizationTrustReference[];
+  settlementReferences: CrossOrganizationTrustReference[];
+  regulatoryReferences: CrossOrganizationTrustReference[];
+  sharingReferences: CrossOrganizationTrustReference[];
+  auditReferences: CrossOrganizationTrustReference[];
+  operationalReferences: CrossOrganizationTrustReference[];
+  trustRestrictions: CrossOrganizationTrustRestriction[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: CrossOrganizationTrustCanonicalEvent[];
+};
+
+export type DeriveCrossOrganizationTrustInput = {
+  landlordId?: unknown;
+  relationshipType?: unknown;
+  generatedAt?: unknown;
+  networkParticipants?: Array<Record<string, any>> | null;
+  evidencePacks?: Array<Record<string, any>> | null;
+  operatorReviewSessions?: Array<Record<string, any>> | null;
+  settlementReadiness?: Record<string, any> | null;
+  regulatoryProfiles?: Array<Record<string, any>> | null;
+  sharingRooms?: Array<Record<string, any>> | null;
+  auditEvents?: Array<Record<string, any>> | null;
+  consentRecords?: Array<Record<string, any>> | null;
+};

--- a/rentchain-api/src/lib/crossOrganizationTrust/deriveCrossOrganizationTrust.ts
+++ b/rentchain-api/src/lib/crossOrganizationTrust/deriveCrossOrganizationTrust.ts
@@ -1,0 +1,397 @@
+import type {
+  CrossOrganizationTrustCanonicalEvent,
+  CrossOrganizationTrustReference,
+  CrossOrganizationTrustRelationship,
+  CrossOrganizationTrustRelationshipType,
+  CrossOrganizationTrustStatus,
+  DeriveCrossOrganizationTrustInput,
+} from "./crossOrganizationTrustTypes";
+import { crossOrganizationTrustIdPart, trustReference, trustRestriction } from "./trustRestrictionModels";
+
+const RELATIONSHIP_TYPES = new Set<CrossOrganizationTrustRelationshipType>([
+  "operational_trust",
+  "evidence_trust",
+  "review_trust",
+  "settlement_trust",
+  "regulatory_trust",
+  "sharing_trust",
+]);
+
+const REDACTIONS = [
+  "Public reputation scores and participant rankings are excluded.",
+  "Raw government identifiers, screening, and credit bureau payloads are excluded.",
+  "Payment account details and unrestricted financial information are excluded.",
+  "Unrestricted audit histories and private tenant communications are excluded.",
+  "Trust relationships are operational references, not public trust exposure.",
+];
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function asArray<T>(value: T[] | null | undefined): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function generatedAt(value: unknown): string {
+  const raw = asString(value, 120);
+  const date = raw ? new Date(raw) : new Date(0);
+  return Number.isNaN(date.getTime()) ? new Date(0).toISOString() : date.toISOString();
+}
+
+function normalizeRelationshipType(value: unknown): CrossOrganizationTrustRelationshipType {
+  const raw = asString(value, 80) as CrossOrganizationTrustRelationshipType;
+  return RELATIONSHIP_TYPES.has(raw) ? raw : "operational_trust";
+}
+
+function statusFromReferences(hasContext: boolean, references: CrossOrganizationTrustReference[]): CrossOrganizationTrustStatus {
+  if (!hasContext) return "unknown";
+  if (references.some((reference) => reference.status === "blocked")) return "blocked";
+  if (references.some((reference) => reference.status === "unavailable")) return "review_required";
+  if (references.some((reference) => reference.status === "partially_verified")) return "partially_verified";
+  return "verified";
+}
+
+function event(input: {
+  eventType: CrossOrganizationTrustCanonicalEvent["eventType"];
+  status: CrossOrganizationTrustStatus;
+  trustRelationshipId: string;
+  summary: string;
+}): CrossOrganizationTrustCanonicalEvent {
+  return {
+    eventType: input.eventType,
+    action: input.eventType.replace(/^cross_organization_/, "").replace(/_/g, "."),
+    status: input.status,
+    resourceType: "cross_organization_trust",
+    resourceId: input.trustRelationshipId,
+    summary: input.summary,
+  };
+}
+
+export function deriveCrossOrganizationTrust(input: DeriveCrossOrganizationTrustInput): CrossOrganizationTrustRelationship {
+  const landlordId = asString(input.landlordId, 240);
+  const relationshipType = normalizeRelationshipType(input.relationshipType);
+  const trustRelationshipId =
+    crossOrganizationTrustIdPart(["cross_organization_trust", landlordId || "unknown", relationshipType].join(":")) || "cross_organization_trust:unknown";
+
+  const participants = asArray(input.networkParticipants);
+  const evidencePacks = asArray(input.evidencePacks);
+  const reviews = asArray(input.operatorReviewSessions);
+  const regulatoryProfiles = asArray(input.regulatoryProfiles);
+  const sharingRooms = asArray(input.sharingRooms);
+  const auditEvents = asArray(input.auditEvents);
+  const consentRecords = asArray(input.consentRecords);
+  const settlementReadiness = input.settlementReadiness || null;
+
+  const participantReferences = participants.map((participant) => asString(participant.participantId || participant.id, 240)).filter(Boolean);
+
+  const evidenceReferences = evidencePacks.length
+    ? evidencePacks.map((pack) =>
+        trustReference({
+          idParts: ["evidence", pack.evidencePackId || pack.id || "unknown"],
+          referenceType: "evidence",
+          status: pack.status === "blocked" ? "blocked" : "verified",
+          label: "Evidence trust lineage",
+          description: "Evidence pack lineage is available for operational trust review.",
+          lineageReferences: [asString(pack.evidencePackId || pack.id, 240)].filter(Boolean),
+          destination: "/evidence-packs",
+          blockedReason: pack.status === "blocked" ? "Evidence trust lineage is blocked." : null,
+        })
+      )
+    : [
+        trustReference({
+          idParts: ["evidence", "missing"],
+          referenceType: "evidence",
+          status: "unavailable",
+          label: "Evidence trust lineage",
+          description: "Evidence lineage is missing for this trust relationship.",
+          destination: "/evidence-packs",
+        }),
+      ];
+
+  const reviewReferences = reviews.length
+    ? reviews.map((review) =>
+        trustReference({
+          idParts: ["review", review.reviewSessionId || review.id || "unknown"],
+          referenceType: "review",
+          status: review.status === "completed" ? "verified" : review.status === "blocked" ? "blocked" : "partially_verified",
+          label: "Review trust lineage",
+          description: "Operator review lineage is available for operational trust review.",
+          lineageReferences: [asString(review.reviewSessionId || review.id, 240)].filter(Boolean),
+          destination: "/review-timeline",
+          blockedReason: review.status === "blocked" ? "Review trust lineage is blocked." : null,
+        })
+      )
+    : [
+        trustReference({
+          idParts: ["review", "missing"],
+          referenceType: "review",
+          status: "unavailable",
+          label: "Review trust lineage",
+          description: "Review lineage is missing for this trust relationship.",
+          destination: "/review-timeline",
+        }),
+      ];
+
+  const settlementReferences = settlementReadiness
+    ? [
+        trustReference({
+          idParts: ["settlement", settlementReadiness.settlementReadinessId || "unknown"],
+          referenceType: "settlement",
+          status: settlementReadiness.status === "ready_for_review" ? "verified" : settlementReadiness.status === "blocked" ? "blocked" : "partially_verified",
+          label: "Settlement trust reference",
+          description: "Settlement readiness metadata is available for operational trust review.",
+          lineageReferences: [asString(settlementReadiness.settlementReadinessId, 240)].filter(Boolean),
+          destination: "/settlement-readiness",
+          blockedReason: settlementReadiness.status === "blocked" ? "Settlement readiness is blocked." : null,
+        }),
+      ]
+    : [
+        trustReference({
+          idParts: ["settlement", "missing"],
+          referenceType: "settlement",
+          status: "unavailable",
+          label: "Settlement trust reference",
+          description: "Settlement readiness context is unavailable.",
+          destination: "/settlement-readiness",
+        }),
+      ];
+
+  const regulatoryReferences = regulatoryProfiles.length
+    ? regulatoryProfiles.map((profile) =>
+        trustReference({
+          idParts: ["regulatory", profile.regulatoryProfileId || profile.id || "unknown"],
+          referenceType: "regulatory",
+          status: profile.status === "ready_for_review" ? "verified" : profile.status === "blocked" ? "blocked" : "partially_verified",
+          label: "Regulatory trust reference",
+          description: "Regulatory readiness metadata is available for operational trust review.",
+          lineageReferences: [asString(profile.regulatoryProfileId || profile.id, 240)].filter(Boolean),
+          destination: "/regulatory-profiles",
+          blockedReason: profile.status === "blocked" ? "Regulatory readiness is blocked." : null,
+        })
+      )
+    : [
+        trustReference({
+          idParts: ["regulatory", "missing"],
+          referenceType: "regulatory",
+          status: "unavailable",
+          label: "Regulatory trust reference",
+          description: "Regulatory readiness context is unavailable.",
+          destination: "/regulatory-profiles",
+        }),
+      ];
+
+  const sharingReferences = sharingRooms.length
+    ? sharingRooms.map((room) =>
+        trustReference({
+          idParts: ["sharing", room.sharingRoomId || room.id || "unknown"],
+          referenceType: "sharing",
+          status: room.publiclyAccessible || room.externalExecutionEnabled || room.status === "blocked" ? "blocked" : room.status === "active" ? "verified" : "partially_verified",
+          label: "Institutional sharing trust reference",
+          description: "Permissioned sharing-room metadata is available for trust review.",
+          lineageReferences: [asString(room.sharingRoomId || room.id, 240)].filter(Boolean),
+          destination: "/institutional-sharing-rooms",
+          blockedReason: room.publiclyAccessible || room.externalExecutionEnabled ? "Public access or external execution is not allowed for trust relationships." : null,
+        })
+      )
+    : [
+        trustReference({
+          idParts: ["sharing", "missing"],
+          referenceType: "sharing",
+          status: consentRecords.length ? "partially_verified" : "blocked",
+          label: "Institutional sharing trust reference",
+          description: "Institutional sharing trust requires consent/access lineage.",
+          destination: "/institutional-sharing-rooms",
+          blockedReason: consentRecords.length ? null : "Consent/access lineage is missing for sharing trust.",
+        }),
+      ];
+
+  const auditReferences = auditEvents.length
+    ? auditEvents.slice(0, 12).map((record) =>
+        trustReference({
+          idParts: ["audit", record.eventId || record.id || "unknown"],
+          referenceType: "audit",
+          status: record.redacted ? "partially_verified" : "verified",
+          label: "Audit trust lineage",
+          description: "Canonical audit event metadata is available for trust review.",
+          lineageReferences: [asString(record.eventId || record.id, 240)].filter(Boolean),
+          destination: "/review-timeline",
+          redacted: Boolean(record.redacted),
+          redactionReason: record.redacted ? "Audit payload is redacted for trust safety." : null,
+        })
+      )
+    : [
+        trustReference({
+          idParts: ["audit", "missing"],
+          referenceType: "audit",
+          status: "unavailable",
+          label: "Audit trust lineage",
+          description: "Audit lineage is missing for this trust relationship.",
+          destination: "/review-timeline",
+        }),
+      ];
+
+  const operationalReferences = participants.length
+    ? participants.map((participant) =>
+        trustReference({
+          idParts: ["operational", participant.participantId || participant.id || participant.participantType || "unknown"],
+          referenceType: "operational",
+          status: participant.status === "blocked" ? "blocked" : participant.status === "verified" ? "verified" : "partially_verified",
+          label: "Operational participant trust boundary",
+          description: "Network participant metadata is available as operational trust context.",
+          lineageReferences: [asString(participant.participantId || participant.id, 240)].filter(Boolean),
+          destination: "/network-participants",
+          blockedReason: participant.status === "blocked" ? "Network participant relationship is blocked." : null,
+        })
+      )
+    : [
+        trustReference({
+          idParts: ["operational", "missing"],
+          referenceType: "operational",
+          status: "unavailable",
+          label: "Operational participant trust boundary",
+          description: "Network participant context is unavailable.",
+          destination: "/network-participants",
+        }),
+      ];
+
+  const allReferences = [
+    ...evidenceReferences,
+    ...reviewReferences,
+    ...settlementReferences,
+    ...regulatoryReferences,
+    ...sharingReferences,
+    ...auditReferences,
+    ...operationalReferences,
+  ];
+
+  const trustRestrictions = [
+    ...(consentRecords.length
+      ? []
+      : [
+          trustRestriction({
+            idParts: ["consent", "missing"],
+            restrictionType: "consent",
+            status: "blocked",
+            label: "Consent/access lineage missing",
+            description: "Permissioned trust requires consent or access lineage before relying on the relationship.",
+            blockedReason: "Consent/access lineage is missing.",
+          }),
+        ]),
+    ...settlementReferences
+      .filter((reference) => reference.status !== "verified")
+      .map((reference) =>
+        trustRestriction({
+          idParts: ["settlement", reference.trustReferenceId],
+          restrictionType: "settlement",
+          status: reference.status === "blocked" ? "blocked" : "review_required",
+          label: "Settlement trust restriction",
+          description: "Settlement readiness is incomplete or blocked.",
+          blockedReason: reference.blockedReason,
+        })
+      ),
+    ...regulatoryReferences
+      .filter((reference) => reference.status !== "verified")
+      .map((reference) =>
+        trustRestriction({
+          idParts: ["regulatory", reference.trustReferenceId],
+          restrictionType: "regulatory",
+          status: reference.status === "blocked" ? "blocked" : "review_required",
+          label: "Regulatory trust restriction",
+          description: "Regulatory readiness is incomplete or blocked.",
+          blockedReason: reference.blockedReason,
+        })
+      ),
+  ];
+
+  const relationshipReferences =
+    relationshipType === "evidence_trust"
+      ? evidenceReferences
+      : relationshipType === "review_trust"
+        ? reviewReferences
+        : relationshipType === "settlement_trust"
+          ? settlementReferences
+          : relationshipType === "regulatory_trust"
+            ? regulatoryReferences
+            : relationshipType === "sharing_trust"
+              ? sharingReferences
+              : allReferences;
+  const hasContext = Boolean(landlordId && (participants.length || evidencePacks.length || reviews.length || settlementReadiness || regulatoryProfiles.length || sharingRooms.length || auditEvents.length));
+  const status = statusFromReferences(hasContext, relationshipReferences);
+  const blockedReasons = [...relationshipReferences.map((reference) => reference.blockedReason), ...trustRestrictions.map((restriction) => restriction.blockedReason)].filter(Boolean) as string[];
+
+  const canonicalEvents: CrossOrganizationTrustCanonicalEvent[] = [
+    event({
+      eventType: "cross_organization_trust_derived",
+      status,
+      trustRelationshipId,
+      summary: "Cross-organization trust relationship derived from participant, review, evidence, settlement, regulatory, sharing, and audit metadata.",
+    }),
+    event({
+      eventType: "cross_organization_trust_redaction_applied",
+      status,
+      trustRelationshipId,
+      summary: "Public reputation, raw identity, screening, payment, audit, and tenant communication payloads were excluded.",
+    }),
+  ];
+  if (status === "verified") {
+    canonicalEvents.push(
+      event({
+        eventType: "cross_organization_trust_verified",
+        status,
+        trustRelationshipId,
+        summary: "Trust relationship has verified operational lineage references.",
+      })
+    );
+  }
+  if (status === "review_required" || status === "partially_verified") {
+    canonicalEvents.push(
+      event({
+        eventType: "cross_organization_trust_review_required",
+        status,
+        trustRelationshipId,
+        summary: "Manual trust relationship review is required.",
+      })
+    );
+  }
+  if (status === "blocked") {
+    canonicalEvents.push(
+      event({
+        eventType: "cross_organization_trust_blocked",
+        status,
+        trustRelationshipId,
+        summary: "Cross-organization trust relationship is blocked by unsafe or missing required lineage.",
+      })
+    );
+  }
+
+  return {
+    trustRelationshipId,
+    relationshipType,
+    status,
+    manualReviewRequired: true,
+    publicTrustExposureEnabled: false,
+    autonomousTrustApprovalEnabled: false,
+    generatedAt: generatedAt(input.generatedAt),
+    summary: {
+      totalReferences: relationshipReferences.length,
+      verifiedReferences: relationshipReferences.filter((reference) => reference.status === "verified").length,
+      partiallyVerifiedReferences: relationshipReferences.filter((reference) => reference.status === "partially_verified").length,
+      blockedReferences: relationshipReferences.filter((reference) => reference.status === "blocked").length,
+      unavailableReferences: relationshipReferences.filter((reference) => reference.status === "unavailable").length,
+      restrictions: trustRestrictions.length,
+    },
+    participantReferences,
+    reviewReferences,
+    evidenceReferences,
+    settlementReferences,
+    regulatoryReferences,
+    sharingReferences,
+    auditReferences,
+    operationalReferences,
+    trustRestrictions,
+    redactions: REDACTIONS,
+    blockedReasons,
+    canonicalEvents,
+  };
+}

--- a/rentchain-api/src/lib/crossOrganizationTrust/trustRestrictionModels.ts
+++ b/rentchain-api/src/lib/crossOrganizationTrust/trustRestrictionModels.ts
@@ -1,0 +1,63 @@
+import type {
+  CrossOrganizationTrustReference,
+  CrossOrganizationTrustReferenceStatus,
+  CrossOrganizationTrustReferenceType,
+  CrossOrganizationTrustRestriction,
+} from "./crossOrganizationTrustTypes";
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+export function crossOrganizationTrustIdPart(value: unknown): string {
+  return asString(value, 500)
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+export function trustReference(input: {
+  idParts: unknown[];
+  referenceType: CrossOrganizationTrustReferenceType;
+  status: CrossOrganizationTrustReferenceStatus;
+  label: string;
+  description: string;
+  lineageReferences?: string[];
+  destination?: string | null;
+  redacted?: boolean;
+  redactionReason?: string | null;
+  blockedReason?: string | null;
+}): CrossOrganizationTrustReference {
+  return {
+    trustReferenceId: crossOrganizationTrustIdPart(input.idParts.join(":")) || "trust_reference:unknown",
+    referenceType: input.referenceType,
+    status: input.status,
+    label: input.label,
+    description: input.description,
+    reviewRequired: true,
+    lineageReferences: Array.from(new Set(input.lineageReferences || [])).filter(Boolean),
+    destination: input.destination || null,
+    redacted: Boolean(input.redacted),
+    redactionReason: input.redactionReason || null,
+    blockedReason: input.blockedReason || null,
+  };
+}
+
+export function trustRestriction(input: {
+  idParts: unknown[];
+  restrictionType: CrossOrganizationTrustRestriction["restrictionType"];
+  status: CrossOrganizationTrustRestriction["status"];
+  label: string;
+  description: string;
+  blockedReason?: string | null;
+}): CrossOrganizationTrustRestriction {
+  return {
+    restrictionId: crossOrganizationTrustIdPart(input.idParts.join(":")) || "trust_restriction:unknown",
+    restrictionType: input.restrictionType,
+    status: input.status,
+    label: input.label,
+    description: input.description,
+    blockedReason: input.blockedReason || null,
+  };
+}

--- a/rentchain-api/src/routes/__tests__/landlordCrossOrganizationTrustRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordCrossOrganizationTrustRoutes.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+  function matches(doc: any, filters: Array<{ field: string; op: string; value: any }>) {
+    return filters.every(({ field, op, value }) => (op === "==" ? doc?.data?.[field] === value : false));
+  }
+  function makeQuery(name: string, filters: Array<{ field: string; op: string; value: any }> = []) {
+    return {
+      where: (field: string, op: string, value: any) => makeQuery(name, [...filters, { field, op, value }]),
+      get: async () => {
+        const docs = Array.from(ensureCollection(name).values())
+          .filter((doc) => matches(doc, filters))
+          .map((doc) => ({ id: doc.id, exists: true, data: () => doc.data }));
+        return { docs, empty: docs.length === 0, size: docs.length };
+      },
+      doc: (id: string) => makeDoc(name, id),
+    };
+  }
+  function makeDoc(name: string, id: string) {
+    const col = ensureCollection(name);
+    return {
+      id,
+      get: async () => {
+        const entry = col.get(id);
+        return { id, exists: Boolean(entry), data: () => entry?.data };
+      },
+      set: async (data: any) => {
+        col.set(id, { id, data });
+      },
+    };
+  }
+  return {
+    resetFakeDb: () => store.clear(),
+    seedDoc: (collection: string, id: string, data: any) => ensureCollection(collection).set(id, { id, data }),
+    fakeDb: {
+      collection: (name: string) => ({
+        where: (field: string, op: string, value: any) => makeQuery(name, [{ field, op, value }]),
+        get: async () => makeQuery(name).get(),
+        doc: (id: string) => makeDoc(name, id),
+      }),
+    },
+  };
+});
+
+let mockUser: any;
+
+vi.mock("../../config/firebase", () => ({ db: fakeDb }));
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!mockUser) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    req.user = mockUser;
+    return next();
+  },
+}));
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: any, res: any, next: any) => {
+    const role = String(req.user?.role || "").trim().toLowerCase();
+    const landlordId = req.user?.landlordId || req.user?.id;
+    if (role !== "landlord" && role !== "admin") return res.status(403).json({ ok: false, error: "Forbidden" });
+    req.user.landlordId = landlordId;
+    return next();
+  },
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; user?: Record<string, unknown> | null }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    mockUser = options.user ?? mockUser;
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: mockUser,
+      query: Object.fromEntries(new URLSearchParams(queryString || "").entries()),
+      params: {},
+      body: {},
+      headers: {},
+    };
+    const match = path.match(/^\/cross-organization-trust\/(.+)$/);
+    if (match) req.params = { trustRelationshipId: decodeURIComponent(match[1]) };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => (error ? reject(error) : undefined));
+  });
+}
+
+describe("landlordCrossOrganizationTrustRoutes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    resetFakeDb();
+    mockUser = { id: "landlord-1", landlordId: "landlord-1", role: "landlord" };
+  });
+
+  function seedTrustContext() {
+    seedDoc("properties", "property-1", { landlordId: "landlord-1", propertyId: "property-1", province: "NS", municipality: "Halifax" });
+    seedDoc("operatorReviewSessions", "review-1", { landlordId: "landlord-1", reviewSessionId: "review-1", status: "completed" });
+    seedDoc("evidencePacks", "evidence-1", { landlordId: "landlord-1", evidencePackId: "evidence-1", status: "ready_for_review" });
+    seedDoc("institutionalSharingRooms", "room-1", {
+      landlordId: "landlord-1",
+      sharingRoomId: "room-1",
+      status: "active",
+      publiclyAccessible: false,
+      externalExecutionEnabled: false,
+      accessControls: { institutionType: "lender" },
+    });
+    seedDoc("events", "event-1", { landlordId: "landlord-1", eventId: "event-1", eventType: "operator_review_session_closed" });
+    seedDoc("consents", "consent-1", { landlordId: "landlord-1", consentScope: "trust_review", rawGovernmentId: "sensitive-id" });
+  }
+
+  it("returns landlord-scoped trust relationships without sensitive payloads", async () => {
+    seedTrustContext();
+    const router = (await import("../landlordCrossOrganizationTrustRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/cross-organization-trust?relationshipType=operational_trust" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.trustRelationships).toHaveLength(1);
+    expect(res.body.trustRelationships[0]).toEqual(
+      expect.objectContaining({ manualReviewRequired: true, publicTrustExposureEnabled: false, autonomousTrustApprovalEnabled: false })
+    );
+    const serialized = JSON.stringify(res.body);
+    expect(serialized).not.toContain("sensitive-id");
+  });
+
+  it("returns a single trust relationship by id", async () => {
+    seedTrustContext();
+    const router = (await import("../landlordCrossOrganizationTrustRoutes")).default;
+    const list = await invokeRouter(router, { method: "GET", url: "/cross-organization-trust?relationshipType=sharing_trust" });
+    const id = list.body.trustRelationships[0].trustRelationshipId;
+
+    const res = await invokeRouter(router, { method: "GET", url: `/cross-organization-trust/${encodeURIComponent(id)}` });
+
+    expect(res.status).toBe(200);
+    expect(res.body.trustRelationship.trustRelationshipId).toBe(id);
+  });
+
+  it("filters by status and blocks non-landlord users", async () => {
+    seedTrustContext();
+    const router = (await import("../landlordCrossOrganizationTrustRoutes")).default;
+
+    const filtered = await invokeRouter(router, { method: "GET", url: "/cross-organization-trust?relationshipType=operational_trust&status=unknown" });
+    expect(filtered.status).toBe(200);
+    expect(filtered.body.trustRelationships).toEqual([]);
+
+    const forbidden = await invokeRouter(router, { method: "GET", url: "/cross-organization-trust", user: { id: "tenant-1", role: "tenant" } });
+    expect(forbidden.status).toBe(403);
+  });
+});

--- a/rentchain-api/src/routes/landlordCrossOrganizationTrustRoutes.ts
+++ b/rentchain-api/src/routes/landlordCrossOrganizationTrustRoutes.ts
@@ -1,0 +1,179 @@
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { requireAuth } from "../middleware/requireAuth";
+import { requireLandlord } from "../middleware/requireLandlord";
+import { deriveCrossOrganizationTrust } from "../lib/crossOrganizationTrust/deriveCrossOrganizationTrust";
+import { deriveIdentityProfile } from "../lib/identityLayer/deriveIdentityProfile";
+import { deriveNetworkParticipantProfile } from "../lib/networkParticipants/deriveNetworkParticipantProfile";
+import { deriveRegulatoryProfile } from "../lib/regulatoryProfiles/deriveRegulatoryProfile";
+import { deriveSettlementReadiness } from "../lib/settlementReadiness/deriveSettlementReadiness";
+import { buildPaymentObligationLedgerRows } from "../lib/payments/paymentObligationLedger";
+import type {
+  CrossOrganizationTrustRelationship,
+  CrossOrganizationTrustRelationshipType,
+  CrossOrganizationTrustStatus,
+} from "../lib/crossOrganizationTrust/crossOrganizationTrustTypes";
+import type { NetworkParticipantType } from "../lib/networkParticipants/networkParticipantTypes";
+
+const router = Router();
+const RELATIONSHIP_TYPES = new Set<CrossOrganizationTrustRelationshipType>([
+  "operational_trust",
+  "evidence_trust",
+  "review_trust",
+  "settlement_trust",
+  "regulatory_trust",
+  "sharing_trust",
+]);
+const STATUSES = new Set<CrossOrganizationTrustStatus>(["verified", "partially_verified", "review_required", "blocked", "unknown"]);
+const PARTICIPANT_TYPES: NetworkParticipantType[] = [
+  "landlord",
+  "operator",
+  "lender",
+  "insurer",
+  "auditor",
+  "regulator",
+  "contractor",
+  "institutional_partner",
+  "review_actor",
+];
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function landlordIdFromReq(req: any) {
+  return asString(req.user?.landlordId || req.user?.id || req.user?.sub, 240);
+}
+
+async function loadLandlordCollection(collectionName: string, landlordId: string) {
+  const byId = new Map<string, any>();
+  async function collect(field: "landlordId" | "ownerId" | "userId" | "createdByLandlordId") {
+    const snap = await db.collection(collectionName).where(field, "==", landlordId).get().catch(() => null);
+    for (const doc of snap?.docs || []) byId.set(doc.id, { id: doc.id, ...((doc.data() as any) || {}) });
+  }
+  await Promise.all([collect("landlordId"), collect("ownerId"), collect("userId"), collect("createdByLandlordId")]);
+  return Array.from(byId.values()).filter((record) =>
+    [record?.landlordId, record?.ownerId, record?.userId, record?.createdByLandlordId].some((value) => asString(value, 240) === landlordId)
+  );
+}
+
+function trustMatches(trust: CrossOrganizationTrustRelationship, id: string) {
+  return trust.trustRelationshipId === id;
+}
+
+async function buildTrustRelationships(landlordId: string, relationshipType: CrossOrganizationTrustRelationshipType | "") {
+  const [properties, registryStatuses, screeningOrders, consents, sharingRooms, evidencePacks, reviews, events, leases, paymentIntents, rentPayments, reconciliationRecords, contractors] =
+    await Promise.all([
+      loadLandlordCollection("properties", landlordId),
+      loadLandlordCollection("propertyRegistryStatuses", landlordId),
+      loadLandlordCollection("screeningOrders", landlordId),
+      loadLandlordCollection("consents", landlordId),
+      loadLandlordCollection("institutionalSharingRooms", landlordId),
+      loadLandlordCollection("evidencePacks", landlordId),
+      loadLandlordCollection("operatorReviewSessions", landlordId),
+      loadLandlordCollection("events", landlordId),
+      loadLandlordCollection("leases", landlordId),
+      loadLandlordCollection("paymentIntents", landlordId),
+      loadLandlordCollection("rentPayments", landlordId),
+      loadLandlordCollection("paymentReconciliationRecords", landlordId),
+      loadLandlordCollection("contractorProfiles", landlordId),
+    ]);
+
+  const obligationRows = buildPaymentObligationLedgerRows({ leases, paymentIntents, rentPayments, reconciliationRecords });
+  const settlementReadiness = deriveSettlementReadiness({
+    landlordId,
+    obligationRows,
+    reconciliationRecords,
+    evidencePacks,
+    operatorReviewSessions: reviews,
+    auditEvents: events,
+  });
+  const regulatoryProfile = deriveRegulatoryProfile({
+    landlordId,
+    properties,
+    registryStatuses,
+    screeningOrders,
+    consentRecords: consents,
+    sharingRooms,
+    institutionExportPackages: [],
+    evidencePacks,
+    operatorReviewSessions: reviews,
+    auditEvents: events,
+    settlementReadiness,
+  });
+  const networkParticipants = PARTICIPANT_TYPES.map((participantType) => {
+    const identityProfile = deriveIdentityProfile({
+      identityType: participantType === "operator" || participantType === "review_actor" ? participantType : "organization",
+      identityId: participantType,
+      organization: { id: participantType, organizationId: participantType },
+      operator: reviews[0] || null,
+      consentRecords: consents,
+      reviewSessions: reviews,
+      canonicalEvents: events,
+    });
+    return deriveNetworkParticipantProfile({
+      landlordId,
+      participantType,
+      participantId: participantType,
+      identityProfiles: [identityProfile],
+      sharingRooms:
+        participantType === "lender" || participantType === "insurer" || participantType === "auditor" || participantType === "regulator"
+          ? sharingRooms.filter((room) => asString(room.accessControls?.institutionType || room.institutionType, 80) === participantType)
+          : sharingRooms,
+      operatorReviewSessions: reviews,
+      evidencePacks,
+      settlementReadiness,
+      regulatoryProfiles: [regulatoryProfile],
+      canonicalEvents: events,
+      contractorProfiles: participantType === "contractor" ? contractors : [],
+    });
+  });
+
+  const types = relationshipType ? [relationshipType] : Array.from(RELATIONSHIP_TYPES);
+  return types.map((type) =>
+    deriveCrossOrganizationTrust({
+      landlordId,
+      relationshipType: type,
+      networkParticipants,
+      evidencePacks,
+      operatorReviewSessions: reviews,
+      settlementReadiness,
+      regulatoryProfiles: [regulatoryProfile],
+      sharingRooms,
+      auditEvents: events,
+      consentRecords: consents,
+    })
+  );
+}
+
+router.get("/cross-organization-trust", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = landlordIdFromReq(req);
+    if (!landlordId) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    const relationshipType = asString(req.query?.relationshipType, 80) as CrossOrganizationTrustRelationshipType | "";
+    const status = asString(req.query?.status, 80) as CrossOrganizationTrustStatus;
+    let trustRelationships = await buildTrustRelationships(landlordId, RELATIONSHIP_TYPES.has(relationshipType as any) ? relationshipType : "");
+    if (status && STATUSES.has(status)) trustRelationships = trustRelationships.filter((trust) => trust.status === status);
+    return res.json({ ok: true, trustRelationships });
+  } catch (err: any) {
+    console.error("[landlord-cross-organization-trust] list failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "CROSS_ORGANIZATION_TRUST_FAILED" });
+  }
+});
+
+router.get("/cross-organization-trust/:trustRelationshipId", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = landlordIdFromReq(req);
+    const trustRelationshipId = decodeURIComponent(asString(req.params?.trustRelationshipId, 500));
+    if (!landlordId || !trustRelationshipId) return res.status(400).json({ ok: false, error: "TRUST_RELATIONSHIP_ID_REQUIRED" });
+    const trustRelationships = await buildTrustRelationships(landlordId, "");
+    const trustRelationship = trustRelationships.find((trust) => trustMatches(trust, trustRelationshipId));
+    if (!trustRelationship) return res.status(404).json({ ok: false, error: "TRUST_RELATIONSHIP_NOT_FOUND" });
+    return res.json({ ok: true, trustRelationship });
+  } catch (err: any) {
+    console.error("[landlord-cross-organization-trust] get failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "CROSS_ORGANIZATION_TRUST_GET_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -146,6 +146,10 @@ vi.mock("./pages/NetworkParticipantsPage", () => ({
   default: () => <h1>Network Participants Page</h1>,
 }));
 
+vi.mock("./pages/CrossOrganizationTrustPage", () => ({
+  default: () => <h1>Cross Organization Trust Page</h1>,
+}));
+
 vi.mock("./pages/landlord/PortfolioScorePage", () => ({
   default: () => <h1>Landlord Portfolio Score</h1>,
 }));
@@ -449,6 +453,20 @@ describe("Routes: /network-participants", () => {
     );
 
     expect(await screen.findByText(/Network Participants Page/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Routes: /cross-organization-trust", () => {
+  it("renders the cross-organization trust route", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/cross-organization-trust?relationshipType=operational_trust"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Cross Organization Trust Page/i)).toBeInTheDocument();
     expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -129,6 +129,7 @@ const SettlementReadinessPage = lazy(() => import("./pages/SettlementReadinessPa
 const RegulatoryProfilePage = lazy(() => import("./pages/RegulatoryProfilePage"));
 const AssetTokenizationReadinessPage = lazy(() => import("./pages/AssetTokenizationReadinessPage"));
 const NetworkParticipantsPage = lazy(() => import("./pages/NetworkParticipantsPage"));
+const CrossOrganizationTrustPage = lazy(() => import("./pages/CrossOrganizationTrustPage"));
 const LandlordPortfolioScorePage = lazy(() => import("./pages/landlord/PortfolioScorePage"));
 const SharedPortfolioScorePage = lazy(() => import("./pages/public/SharedPortfolioScorePage"));
 const TenantSharePackagePage = lazy(() => import("./pages/public/TenantSharePackagePage"));
@@ -668,6 +669,18 @@ function App() {
               <LandlordNav>
                 <Suspense fallback={null}>
                   <NetworkParticipantsPage />
+                </Suspense>
+              </LandlordNav>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/cross-organization-trust"
+          element={
+            <RequireAuth>
+              <LandlordNav>
+                <Suspense fallback={null}>
+                  <CrossOrganizationTrustPage />
                 </Suspense>
               </LandlordNav>
             </RequireAuth>

--- a/rentchain-frontend/src/api/crossOrganizationTrustApi.ts
+++ b/rentchain-frontend/src/api/crossOrganizationTrustApi.ts
@@ -1,0 +1,85 @@
+import { apiFetch } from "./apiFetch";
+
+export type CrossOrganizationTrustRelationshipType =
+  | "operational_trust"
+  | "evidence_trust"
+  | "review_trust"
+  | "settlement_trust"
+  | "regulatory_trust"
+  | "sharing_trust";
+
+export type CrossOrganizationTrustStatus = "verified" | "partially_verified" | "review_required" | "blocked" | "unknown";
+export type CrossOrganizationTrustReferenceStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+export type CrossOrganizationTrustReferenceType = "evidence" | "review" | "settlement" | "regulatory" | "sharing" | "audit" | "operational";
+
+export type CrossOrganizationTrustReference = {
+  trustReferenceId: string;
+  referenceType: CrossOrganizationTrustReferenceType;
+  status: CrossOrganizationTrustReferenceStatus;
+  label: string;
+  description: string;
+  reviewRequired: true;
+  lineageReferences: string[];
+  destination: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type CrossOrganizationTrustRestriction = {
+  restrictionId: string;
+  restrictionType: "consent" | "settlement" | "regulatory" | "sharing" | "audit" | "evidence" | "review";
+  status: "visible" | "blocked" | "review_required";
+  label: string;
+  description: string;
+  blockedReason: string | null;
+};
+
+export type CrossOrganizationTrustRelationship = {
+  trustRelationshipId: string;
+  relationshipType: CrossOrganizationTrustRelationshipType;
+  status: CrossOrganizationTrustStatus;
+  manualReviewRequired: true;
+  publicTrustExposureEnabled: false;
+  autonomousTrustApprovalEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    partiallyVerifiedReferences: number;
+    blockedReferences: number;
+    unavailableReferences: number;
+    restrictions: number;
+  };
+  participantReferences: string[];
+  reviewReferences: CrossOrganizationTrustReference[];
+  evidenceReferences: CrossOrganizationTrustReference[];
+  settlementReferences: CrossOrganizationTrustReference[];
+  regulatoryReferences: CrossOrganizationTrustReference[];
+  sharingReferences: CrossOrganizationTrustReference[];
+  auditReferences: CrossOrganizationTrustReference[];
+  operationalReferences: CrossOrganizationTrustReference[];
+  trustRestrictions: CrossOrganizationTrustRestriction[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: Array<{ eventType: string; action: string; status: CrossOrganizationTrustStatus; resourceId: string; summary: string }>;
+};
+
+export async function fetchCrossOrganizationTrustRelationships(params?: {
+  relationshipType?: CrossOrganizationTrustRelationshipType | "";
+  status?: CrossOrganizationTrustStatus | "";
+}): Promise<CrossOrganizationTrustRelationship[]> {
+  const search = new URLSearchParams();
+  if (params?.relationshipType) search.set("relationshipType", params.relationshipType);
+  if (params?.status) search.set("status", params.status);
+  const suffix = search.toString() ? `?${search.toString()}` : "";
+  const response = await apiFetch<{ ok: true; trustRelationships: CrossOrganizationTrustRelationship[] }>(`/landlord/cross-organization-trust${suffix}`);
+  return response.trustRelationships;
+}
+
+export async function fetchCrossOrganizationTrustRelationship(trustRelationshipId: string): Promise<CrossOrganizationTrustRelationship> {
+  const response = await apiFetch<{ ok: true; trustRelationship: CrossOrganizationTrustRelationship }>(
+    `/landlord/cross-organization-trust/${encodeURIComponent(trustRelationshipId)}`
+  );
+  return response.trustRelationship;
+}

--- a/rentchain-frontend/src/components/trust/CrossOrganizationTrustPanel.test.tsx
+++ b/rentchain-frontend/src/components/trust/CrossOrganizationTrustPanel.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { CrossOrganizationTrustPanel } from "./CrossOrganizationTrustPanel";
+
+const reference = {
+  trustReferenceId: "trust:evidence:evidence-1",
+  referenceType: "evidence",
+  status: "verified",
+  label: "Evidence trust lineage",
+  description: "Evidence pack lineage is available for operational trust review.",
+  reviewRequired: true,
+  lineageReferences: ["evidence-1"],
+  destination: "/evidence-packs",
+  redacted: false,
+  redactionReason: null,
+  blockedReason: null,
+};
+
+const trustRelationship = {
+  trustRelationshipId: "cross_organization_trust:landlord-1:operational_trust",
+  relationshipType: "operational_trust",
+  status: "review_required",
+  manualReviewRequired: true,
+  publicTrustExposureEnabled: false,
+  autonomousTrustApprovalEnabled: false,
+  generatedAt: "2026-01-01T00:00:00.000Z",
+  summary: {
+    totalReferences: 2,
+    verifiedReferences: 1,
+    partiallyVerifiedReferences: 0,
+    blockedReferences: 1,
+    unavailableReferences: 0,
+    restrictions: 1,
+  },
+  participantReferences: ["participant-1"],
+  reviewReferences: [{ ...reference, trustReferenceId: "trust:review:review-1", referenceType: "review", label: "Review trust lineage" }],
+  evidenceReferences: [reference],
+  settlementReferences: [],
+  regulatoryReferences: [],
+  sharingReferences: [],
+  auditReferences: [],
+  operationalReferences: [],
+  trustRestrictions: [
+    {
+      restrictionId: "trust:consent:missing",
+      restrictionType: "consent",
+      status: "blocked",
+      label: "Consent/access lineage missing",
+      description: "Permissioned trust requires consent or access lineage before relying on the relationship.",
+      blockedReason: "Consent/access lineage is missing.",
+    },
+  ],
+  redactions: ["Raw government identifiers, screening, and credit bureau payloads are excluded."],
+  blockedReasons: ["Consent/access lineage is missing."],
+  canonicalEvents: [],
+} as const;
+
+describe("CrossOrganizationTrustPanel", () => {
+  it("renders trust lineage, restrictions, redactions, and required safety copy", () => {
+    render(
+      <MemoryRouter>
+        <CrossOrganizationTrustPanel trustRelationship={trustRelationship as any} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("View trust relationship")).toBeInTheDocument();
+    expect(screen.getAllByText(/No public trust exposure or autonomous trust approval is enabled/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("View blocked reason: Consent/access lineage is missing.")).toBeInTheDocument();
+    expect(screen.getByText("Raw government identifiers, screening, and credit bureau payloads are excluded.")).toBeInTheDocument();
+  });
+
+  it("does not render forbidden trust action labels", () => {
+    render(
+      <MemoryRouter>
+        <CrossOrganizationTrustPanel trustRelationship={trustRelationship as any} />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText("Public trust score")).not.toBeInTheDocument();
+    expect(screen.queryByText("Publish trust")).not.toBeInTheDocument();
+    expect(screen.queryByText("Auto-approve trust")).not.toBeInTheDocument();
+    expect(screen.queryByText("Autonomous trust")).not.toBeInTheDocument();
+    expect(screen.queryByText("Public ranking")).not.toBeInTheDocument();
+    expect(screen.queryByText("Reputation marketplace")).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/trust/CrossOrganizationTrustPanel.tsx
+++ b/rentchain-frontend/src/components/trust/CrossOrganizationTrustPanel.tsx
@@ -1,0 +1,137 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import type { CrossOrganizationTrustReference, CrossOrganizationTrustRelationship, CrossOrganizationTrustRestriction } from "@/api/crossOrganizationTrustApi";
+import { Card, Section } from "@/components/ui/Ui";
+
+function label(value: string) {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function tone(status: string) {
+  if (status === "blocked") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
+  if (status === "review_required" || status === "partially_verified" || status === "unavailable") return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
+  if (status === "verified") return { color: "#166534", background: "#dcfce7", border: "#bbf7d0" };
+  return { color: "#475569", background: "#f8fafc", border: "#e2e8f0" };
+}
+
+function Badge({ children, status }: { children: React.ReactNode; status: string }) {
+  const next = tone(status);
+  return (
+    <span style={{ border: `1px solid ${next.border}`, borderRadius: 999, background: next.background, color: next.color, padding: "3px 9px", fontSize: 12, fontWeight: 900, whiteSpace: "nowrap" }}>
+      {children}
+    </span>
+  );
+}
+
+function ReferenceList({ title, references }: { title: string; references: CrossOrganizationTrustReference[] }) {
+  return (
+    <Section style={{ display: "grid", gap: 10 }}>
+      <div style={{ fontWeight: 900 }}>{title}</div>
+      {references.length ? (
+        references.slice(0, 12).map((reference) => (
+          <Card key={reference.trustReferenceId} style={{ borderRadius: 8, padding: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+              <div>
+                <strong>{reference.label}</strong>
+                <div style={{ color: "#64748b", fontSize: 13 }}>{label(reference.referenceType)}</div>
+              </div>
+              <Badge status={reference.status}>{label(reference.status)}</Badge>
+            </div>
+            <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>{reference.description}</div>
+            {reference.lineageReferences.length ? <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>Lineage references: {reference.lineageReferences.length}</div> : null}
+            {reference.blockedReason ? <div style={{ color: "#991b1b", fontSize: 13, marginTop: 8 }}>View blocked reason: {reference.blockedReason}</div> : null}
+            {reference.redacted ? <div style={{ color: "#92400e", fontSize: 13, marginTop: 8 }}>{reference.redactionReason || "Redacted trust reference"}</div> : null}
+            {reference.destination ? <Link to={reference.destination} style={{ color: "#2563eb", fontWeight: 800, fontSize: 13, marginTop: 8, display: "inline-block" }}>View context</Link> : null}
+          </Card>
+        ))
+      ) : (
+        <Card style={{ color: "#64748b" }}>Context unavailable</Card>
+      )}
+    </Section>
+  );
+}
+
+function RestrictionList({ restrictions }: { restrictions: CrossOrganizationTrustRestriction[] }) {
+  return (
+    <Section style={{ display: "grid", gap: 10 }}>
+      <div style={{ fontWeight: 900 }}>View restrictions</div>
+      {restrictions.length ? (
+        restrictions.map((restriction) => (
+          <Card key={restriction.restrictionId} style={{ borderRadius: 8, padding: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+              <div>
+                <strong>{restriction.label}</strong>
+                <div style={{ color: "#64748b", fontSize: 13 }}>{label(restriction.restrictionType)}</div>
+              </div>
+              <Badge status={restriction.status}>{label(restriction.status)}</Badge>
+            </div>
+            <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>{restriction.description}</div>
+            {restriction.blockedReason ? <div style={{ color: "#991b1b", fontSize: 13, marginTop: 8 }}>View blocked reason: {restriction.blockedReason}</div> : null}
+          </Card>
+        ))
+      ) : (
+        <Card style={{ color: "#64748b" }}>No trust restrictions detected.</Card>
+      )}
+    </Section>
+  );
+}
+
+export function CrossOrganizationTrustPanel({ trustRelationship }: { trustRelationship: CrossOrganizationTrustRelationship }) {
+  return (
+    <div style={{ display: "grid", gap: 16 }}>
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+          <div>
+            <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>View trust relationship</div>
+            <h2 style={{ margin: "2px 0 0", fontSize: "1.15rem" }}>{label(trustRelationship.relationshipType)}</h2>
+          </div>
+          <Badge status={trustRelationship.status}>{label(trustRelationship.status)}</Badge>
+        </div>
+        <div style={{ color: "#475569", lineHeight: 1.55 }}>
+          Trust relationships are operationally scoped and review controlled. No public trust exposure or autonomous trust approval is enabled.
+          Manual review remains required.
+        </div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <Badge status="review_required">Manual review required</Badge>
+          <Badge status={trustRelationship.publicTrustExposureEnabled ? "blocked" : "verified"}>Public exposure disabled</Badge>
+          <Badge status={trustRelationship.autonomousTrustApprovalEnabled ? "blocked" : "verified"}>Autonomous approval disabled</Badge>
+        </div>
+      </Section>
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Trust summary</div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: 10 }}>
+          {[
+            ["References", trustRelationship.summary.totalReferences],
+            ["Verified", trustRelationship.summary.verifiedReferences],
+            ["Partial", trustRelationship.summary.partiallyVerifiedReferences],
+            ["Blocked", trustRelationship.summary.blockedReferences],
+            ["Unavailable", trustRelationship.summary.unavailableReferences],
+            ["Restrictions", trustRelationship.summary.restrictions],
+          ].map(([name, value]) => (
+            <Card key={String(name)} style={{ borderRadius: 8, padding: 12 }}>
+              <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>{name}</div>
+              <strong style={{ color: "#0f172a", fontSize: 22 }}>{String(value)}</strong>
+            </Card>
+          ))}
+        </div>
+      </Section>
+
+      <RestrictionList restrictions={trustRelationship.trustRestrictions} />
+      <ReferenceList title="View evidence lineage" references={trustRelationship.evidenceReferences} />
+      <ReferenceList title="View review lineage" references={trustRelationship.reviewReferences} />
+      <ReferenceList title="Settlement references" references={trustRelationship.settlementReferences} />
+      <ReferenceList title="Regulatory references" references={trustRelationship.regulatoryReferences} />
+      <ReferenceList title="Sharing references" references={trustRelationship.sharingReferences} />
+      <ReferenceList title="Audit references" references={trustRelationship.auditReferences} />
+      <ReferenceList title="Operational references" references={trustRelationship.operationalReferences} />
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Redactions</div>
+        {trustRelationship.redactions.map((redaction) => (
+          <Card key={redaction} style={{ borderRadius: 8, padding: 12, color: "#475569" }}>{redaction}</Card>
+        ))}
+      </Section>
+    </div>
+  );
+}

--- a/rentchain-frontend/src/pages/CrossOrganizationTrustPage.test.tsx
+++ b/rentchain-frontend/src/pages/CrossOrganizationTrustPage.test.tsx
@@ -1,0 +1,109 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import CrossOrganizationTrustPage from "./CrossOrganizationTrustPage";
+
+const mockFetchCrossOrganizationTrustRelationships = vi.fn();
+const mockShowToast = vi.fn();
+
+vi.mock("@/api/crossOrganizationTrustApi", () => ({
+  fetchCrossOrganizationTrustRelationships: (...args: any[]) => mockFetchCrossOrganizationTrustRelationships(...args),
+}));
+
+vi.mock("@/components/layout/MacShell", () => ({
+  MacShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
+const trustRelationship = {
+  trustRelationshipId: "cross_organization_trust:landlord-1:operational_trust",
+  relationshipType: "operational_trust",
+  status: "verified",
+  manualReviewRequired: true,
+  publicTrustExposureEnabled: false,
+  autonomousTrustApprovalEnabled: false,
+  generatedAt: "2026-01-01T00:00:00.000Z",
+  summary: {
+    totalReferences: 1,
+    verifiedReferences: 1,
+    partiallyVerifiedReferences: 0,
+    blockedReferences: 0,
+    unavailableReferences: 0,
+    restrictions: 0,
+  },
+  participantReferences: [],
+  reviewReferences: [],
+  evidenceReferences: [],
+  settlementReferences: [],
+  regulatoryReferences: [],
+  sharingReferences: [],
+  auditReferences: [],
+  operationalReferences: [],
+  trustRestrictions: [],
+  redactions: ["Public reputation scores and participant rankings are excluded."],
+  blockedReasons: [],
+  canonicalEvents: [],
+};
+
+describe("CrossOrganizationTrustPage", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchCrossOrganizationTrustRelationships.mockResolvedValue([trustRelationship]);
+  });
+
+  it("renders trust relationships and required safety copy", async () => {
+    render(
+      <MemoryRouter>
+        <CrossOrganizationTrustPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Cross-organization trust")).toBeInTheDocument();
+    expect(screen.getAllByText(/No public trust exposure or autonomous trust approval is enabled/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("Public reputation scores and participant rankings are excluded.")).toBeInTheDocument();
+  });
+
+  it("updates deterministic relationship and status filters", async () => {
+    render(
+      <MemoryRouter>
+        <CrossOrganizationTrustPage />
+      </MemoryRouter>
+    );
+
+    await screen.findByText("Cross-organization trust");
+    fireEvent.change(screen.getByLabelText("Relationship type"), { target: { value: "settlement_trust" } });
+    fireEvent.change(screen.getByLabelText("Status"), { target: { value: "blocked" } });
+
+    await waitFor(() => {
+      expect(mockFetchCrossOrganizationTrustRelationships).toHaveBeenLastCalledWith({
+        relationshipType: "settlement_trust",
+        status: "blocked",
+      });
+    });
+  });
+
+  it("shows empty state and omits forbidden labels", async () => {
+    mockFetchCrossOrganizationTrustRelationships.mockResolvedValue([]);
+    render(
+      <MemoryRouter>
+        <CrossOrganizationTrustPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("No cross-organization trust relationships match these filters.")).toBeInTheDocument();
+    expect(screen.queryByText("Public trust score")).not.toBeInTheDocument();
+    expect(screen.queryByText("Publish trust")).not.toBeInTheDocument();
+    expect(screen.queryByText("Auto-approve trust")).not.toBeInTheDocument();
+    expect(screen.queryByText("Autonomous trust")).not.toBeInTheDocument();
+    expect(screen.queryByText("Public ranking")).not.toBeInTheDocument();
+    expect(screen.queryByText("Reputation marketplace")).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/CrossOrganizationTrustPage.tsx
+++ b/rentchain-frontend/src/pages/CrossOrganizationTrustPage.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+import { useSearchParams } from "react-router-dom";
+import {
+  fetchCrossOrganizationTrustRelationships,
+  type CrossOrganizationTrustRelationship,
+  type CrossOrganizationTrustRelationshipType,
+  type CrossOrganizationTrustStatus,
+} from "@/api/crossOrganizationTrustApi";
+import { MacShell } from "@/components/layout/MacShell";
+import { CrossOrganizationTrustPanel } from "@/components/trust/CrossOrganizationTrustPanel";
+import { Card, Section } from "@/components/ui/Ui";
+import { useToast } from "@/components/ui/ToastProvider";
+
+const relationshipTypes: Array<CrossOrganizationTrustRelationshipType | ""> = [
+  "",
+  "operational_trust",
+  "evidence_trust",
+  "review_trust",
+  "settlement_trust",
+  "regulatory_trust",
+  "sharing_trust",
+];
+const statuses: Array<CrossOrganizationTrustStatus | ""> = ["", "verified", "partially_verified", "review_required", "blocked", "unknown"];
+
+function label(value: string) {
+  return value ? value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase()) : "All";
+}
+
+export default function CrossOrganizationTrustPage() {
+  const { showToast } = useToast();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [trustRelationships, setTrustRelationships] = React.useState<CrossOrganizationTrustRelationship[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const relationshipType = String(searchParams.get("relationshipType") || "") as CrossOrganizationTrustRelationshipType | "";
+  const status = String(searchParams.get("status") || "") as CrossOrganizationTrustStatus | "";
+
+  React.useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const next = await fetchCrossOrganizationTrustRelationships({ relationshipType, status });
+        if (mounted) setTrustRelationships(next);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Failed to load cross-organization trust";
+        if (mounted) {
+          setError(message);
+          showToast({ message: "Failed to load cross-organization trust", description: message, variant: "error" });
+        }
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [relationshipType, status, showToast]);
+
+  function updateParams(next: { relationshipType?: string; status?: string }) {
+    const params = new URLSearchParams(searchParams);
+    for (const [key, value] of Object.entries(next)) {
+      if (value && value.trim()) params.set(key, value.trim());
+      else params.delete(key);
+    }
+    setSearchParams(params);
+  }
+
+  return (
+    <MacShell title="Cross-organization trust" showTopNav={false}>
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "grid", gap: 6 }}>
+            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Cross-organization trust</h1>
+            <div style={{ color: "#475569", maxWidth: 900 }}>
+              Trust relationships are operationally scoped and review controlled. No public trust exposure or autonomous trust approval is enabled.
+              Manual review remains required.
+            </div>
+          </div>
+        </Section>
+
+        <Section style={{ display: "flex", gap: 10, flexWrap: "wrap", alignItems: "end" }}>
+          <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Relationship type
+            <select value={relationshipType} onChange={(event) => updateParams({ relationshipType: event.target.value })} style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 190 }}>
+              {relationshipTypes.map((type) => <option key={type || "all"} value={type}>{label(type)}</option>)}
+            </select>
+          </label>
+          <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Status
+            <select value={status} onChange={(event) => updateParams({ status: event.target.value })} style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 180 }}>
+              {statuses.map((item) => <option key={item || "all"} value={item}>{label(item)}</option>)}
+            </select>
+          </label>
+        </Section>
+
+        {loading ? <Card>Loading cross-organization trust...</Card> : null}
+        {!loading && error ? <Card style={{ color: "#b91c1c" }}>We couldn't load cross-organization trust right now.</Card> : null}
+        {!loading && !error && !trustRelationships.length ? <Card style={{ color: "#64748b" }}>No cross-organization trust relationships match these filters.</Card> : null}
+        {!loading && !error && trustRelationships.length ? (
+          <div style={{ display: "grid", gap: 16 }}>{trustRelationships.map((trustRelationship) => <CrossOrganizationTrustPanel key={trustRelationship.trustRelationshipId} trustRelationship={trustRelationship} />)}</div>
+        ) : null}
+      </div>
+    </MacShell>
+  );
+}

--- a/rentchain-frontend/src/pages/NetworkParticipantsPage.tsx
+++ b/rentchain-frontend/src/pages/NetworkParticipantsPage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useSearchParams } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import {
   fetchNetworkParticipants,
   type NetworkParticipantProfile,
@@ -75,12 +75,15 @@ export default function NetworkParticipantsPage() {
     <MacShell title="Network participants" showTopNav={false}>
       <div style={{ display: "grid", gap: 16 }}>
         <Section>
-          <div style={{ display: "grid", gap: 6 }}>
-            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Network participants</h1>
-            <div style={{ color: "#475569", maxWidth: 900 }}>
-              Network participants are permissioned operational actors. No public discovery or autonomous relationship execution is enabled.
-              Manual review remains required.
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "start" }}>
+            <div style={{ display: "grid", gap: 6 }}>
+              <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Network participants</h1>
+              <div style={{ color: "#475569", maxWidth: 900 }}>
+                Network participants are permissioned operational actors. No public discovery or autonomous relationship execution is enabled.
+                Manual review remains required.
+              </div>
             </div>
+            <Link to="/cross-organization-trust" style={{ color: "#2563eb", fontWeight: 900 }}>View trust relationship</Link>
           </div>
         </Section>
 


### PR DESCRIPTION
## Summary
- Adds deterministic, landlord-scoped Cross-Organization Trust Layer read model
- Adds endpoints:
  - `GET /api/landlord/cross-organization-trust`
  - `GET /api/landlord/cross-organization-trust/:trustRelationshipId`
- Adds frontend `/cross-organization-trust` page and `CrossOrganizationTrustPanel`
- Adds safe Network Participants entry link to cross-organization trust
- Adds evidence, review, settlement, regulatory, sharing, audit, and operational trust references
- Adds deterministic trust restrictions for missing consent/access lineage, incomplete settlement readiness, and incomplete regulatory readiness
- Adds descriptor-only canonical events for trust derivation, verification, review-required, blocked, and redaction states
- Adds architecture documentation for Cross-Organization Trust Layer v1

## Guardrails
- Confirms `manualReviewRequired: true`
- Confirms `publicTrustExposureEnabled: false`
- Confirms `autonomousTrustApprovalEnabled: false`
- Confirms no public trust scores, public reputation, participant ranking, social-network behavior, autonomous trust approval, financial execution, legal certification, or external institution integration was added
- Confirms raw government IDs, screening/credit payloads, payment account details, unrestricted audit histories, private tenant communications, and admin-only data are excluded from landlord trust responses

## Verification
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && pnpm exec vitest run src/lib/crossOrganizationTrust/__tests__/deriveCrossOrganizationTrust.test.ts src/routes/__tests__/landlordCrossOrganizationTrustRoutes.test.ts`
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 && pnpm exec vitest run src/components/trust/CrossOrganizationTrustPanel.test.tsx src/pages/CrossOrganizationTrustPage.test.tsx src/pages/NetworkParticipantsPage.test.tsx src/App.routes.test.tsx`
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && pnpm build`
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 && pnpm build`
- `git diff --check`
- `git diff --cached --check`
- dependency/lockfile diff: empty
- forbidden runtime-label scan: clean