### PR TITLE
feat: add institution onboarding readiness layer

### DIFF
--- a/docs/architecture/institution-onboarding-readiness-v1.md
+++ b/docs/architecture/institution-onboarding-readiness-v1.md
@@ -1,0 +1,94 @@
+# Institution Onboarding Readiness v1
+
+## Purpose
+
+The Institution Onboarding Readiness Layer provides deterministic, permissioned, read-only readiness references for future operational coordination with lenders, insurers, auditors, municipalities, regulators, institutional landlords, and ecosystem partners.
+
+This layer is an internal operational readiness surface. It does not create live integrations, external onboarding submission, public onboarding portals, autonomous approvals, legal certification, or institution credential exchange.
+
+## Model
+
+The v1 read model derives `InstitutionOnboardingReadiness` records for:
+
+- `lender`
+- `insurer`
+- `auditor`
+- `regulator`
+- `municipality`
+- `institutional_landlord`
+- `operational_partner`
+
+Every readiness record includes:
+
+- `manualReviewRequired: true`
+- `externalOnboardingEnabled: false`
+- `autonomousApprovalEnabled: false`
+- deterministic status and summary counts
+- participant, trust, identity, evidence, review, settlement, regulatory, sharing, and audit references
+- onboarding restrictions
+- redaction metadata
+- descriptor-only canonical events
+
+## Status Rules
+
+Readiness derivation is deterministic:
+
+- `ready_for_review`: required references are present and no selected references are blocked or unavailable
+- `partially_ready`: lineage exists but at least one selected reference is incomplete
+- `review_required`: required lineage is unavailable and no selected reference is blocked
+- `blocked`: selected references or restrictions indicate unsafe or conflicting onboarding context
+- `unknown`: insufficient source context exists
+
+No AI scoring, probabilistic ranking, or external onboarding decisioning is used.
+
+## Restrictions
+
+Onboarding restrictions are surfaced when source relationships are incomplete or unsafe:
+
+- missing consent or access lineage blocks onboarding readiness
+- incomplete trust relationship readiness creates trust restrictions
+- incomplete settlement readiness creates settlement restrictions
+- incomplete regulatory readiness creates regulatory restrictions
+- missing evidence, review, or audit lineage creates manual review requirements
+
+Restrictions are visibility-only. They do not approve, reject, submit, communicate, integrate, or execute.
+
+## Canonical Events
+
+The layer emits descriptor-only event metadata for audit traceability:
+
+- `institution_onboarding_readiness_derived`
+- `institution_onboarding_review_required`
+- `institution_onboarding_blocked`
+- `institution_onboarding_restriction_detected`
+- `institution_onboarding_redaction_applied`
+
+These are additive descriptors in the derived read model. They do not mutate source records or create external side effects.
+
+## Redaction Model
+
+The derived model excludes:
+
+- raw government identifiers
+- screening and credit bureau payloads
+- payment account details
+- unrestricted financial information
+- private tenant documents
+- tenant communications
+- external onboarding payloads
+- public portal and unrestricted directory data
+
+Landlord routes remain scoped to landlord-accessible operational metadata.
+
+## Non-Goals
+
+This layer does not provide:
+
+- lender, insurer, or regulator integrations
+- onboarding submission
+- public onboarding portals
+- autonomous onboarding approvals
+- public institutional directories
+- legal certification
+- institution credential exchange
+- AI onboarding scoring

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -133,6 +133,7 @@ import landlordRegulatoryProfileRoutes from "./routes/landlordRegulatoryProfileR
 import landlordAssetTokenizationReadinessRoutes from "./routes/landlordAssetTokenizationReadinessRoutes";
 import landlordNetworkParticipantRoutes from "./routes/landlordNetworkParticipantRoutes";
 import landlordCrossOrganizationTrustRoutes from "./routes/landlordCrossOrganizationTrustRoutes";
+import landlordInstitutionOnboardingRoutes from "./routes/landlordInstitutionOnboardingRoutes";
 import publicPortfolioScoreRoutes from "./routes/publicPortfolioScoreRoutes";
 import publicTenantShareRoutes from "./routes/publicTenantShareRoutes";
 import landlordActionRecommendationRoutes from "./routes/landlordActionRecommendationRoutes";
@@ -322,6 +323,8 @@ app.use("/api/landlord", routeSource("landlordNetworkParticipantRoutes.ts"), lan
 console.log("[route-mount] landlordNetworkParticipantRoutes mounted at /api/landlord");
 app.use("/api/landlord", routeSource("landlordCrossOrganizationTrustRoutes.ts"), landlordCrossOrganizationTrustRoutes);
 console.log("[route-mount] landlordCrossOrganizationTrustRoutes mounted at /api/landlord");
+app.use("/api/landlord", routeSource("landlordInstitutionOnboardingRoutes.ts"), landlordInstitutionOnboardingRoutes);
+console.log("[route-mount] landlordInstitutionOnboardingRoutes mounted at /api/landlord");
 app.use("/api", routeSource("landlordActionRecommendationRoutes.ts"), landlordActionRecommendationRoutes);
 console.log("[route-mount] landlordActionRecommendationRoutes mounted at /api");
 app.use("/api", routeSource("tenantFeedbackRoutes.ts"), tenantFeedbackRoutes);

--- a/rentchain-api/src/lib/institutionOnboarding/__tests__/deriveInstitutionOnboardingReadiness.test.ts
+++ b/rentchain-api/src/lib/institutionOnboarding/__tests__/deriveInstitutionOnboardingReadiness.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { deriveInstitutionOnboardingReadiness } from "../deriveInstitutionOnboardingReadiness";
+
+describe("deriveInstitutionOnboardingReadiness", () => {
+  it("derives deterministic guarded onboarding readiness from operational lineage", () => {
+    const readiness = deriveInstitutionOnboardingReadiness({
+      landlordId: "landlord-1",
+      institutionType: "lender",
+      networkParticipants: [{ participantId: "participant-1", status: "verified" }],
+      trustRelationships: [{ trustRelationshipId: "trust-1", status: "verified" }],
+      identityProfiles: [{ identityId: "organization:lender-1", status: "verified" }],
+      evidencePacks: [{ evidencePackId: "evidence-1", status: "ready_for_review" }],
+      operatorReviewSessions: [{ reviewSessionId: "review-1", status: "completed" }],
+      settlementReadiness: { settlementReadinessId: "settlement-1", status: "ready_for_review" },
+      regulatoryProfiles: [{ regulatoryProfileId: "regulatory-1", status: "ready_for_review" }],
+      sharingRooms: [{ sharingRoomId: "room-1", status: "active", publiclyAccessible: false, externalExecutionEnabled: false }],
+      auditEvents: [{ eventId: "event-1" }],
+      consentRecords: [{ consentId: "consent-1" }],
+    });
+
+    expect(readiness.institutionType).toBe("lender");
+    expect(readiness.status).toBe("ready_for_review");
+    expect(readiness.manualReviewRequired).toBe(true);
+    expect(readiness.externalOnboardingEnabled).toBe(false);
+    expect(readiness.autonomousApprovalEnabled).toBe(false);
+    expect(readiness.canonicalEvents.map((event) => event.eventType)).toContain("institution_onboarding_readiness_derived");
+    expect(readiness.canonicalEvents.map((event) => event.eventType)).toContain("institution_onboarding_redaction_applied");
+  });
+
+  it("blocks onboarding when sharing and consent lineage are missing", () => {
+    const readiness = deriveInstitutionOnboardingReadiness({
+      landlordId: "landlord-1",
+      institutionType: "auditor",
+      networkParticipants: [{ participantId: "participant-1", status: "verified" }],
+      trustRelationships: [{ trustRelationshipId: "trust-1", status: "verified" }],
+      identityProfiles: [{ identityId: "organization:auditor-1", status: "verified" }],
+      evidencePacks: [{ evidencePackId: "evidence-1", status: "ready_for_review" }],
+      operatorReviewSessions: [{ reviewSessionId: "review-1", status: "completed" }],
+      settlementReadiness: { settlementReadinessId: "settlement-1", status: "ready_for_review" },
+      regulatoryProfiles: [{ regulatoryProfileId: "regulatory-1", status: "ready_for_review" }],
+      sharingRooms: [],
+      auditEvents: [{ eventId: "event-1" }],
+      consentRecords: [],
+    });
+
+    expect(readiness.status).toBe("blocked");
+    expect(readiness.blockedReasons).toContain("Consent/access lineage is missing for institution onboarding.");
+    expect(readiness.onboardingRestrictions.map((restriction) => restriction.restrictionType)).toContain("consent");
+    expect(readiness.canonicalEvents.map((event) => event.eventType)).toContain("institution_onboarding_blocked");
+  });
+
+  it("keeps missing evidence review-required and excludes sensitive payloads", () => {
+    const readiness = deriveInstitutionOnboardingReadiness({
+      landlordId: "landlord-1",
+      institutionType: "regulator",
+      networkParticipants: [{ participantId: "participant-1", status: "verified", rawGovernmentId: "sensitive-id" }],
+      trustRelationships: [{ trustRelationshipId: "trust-1", status: "verified" }],
+      identityProfiles: [{ identityId: "organization:regulator-1", status: "verified" }],
+      evidencePacks: [],
+      operatorReviewSessions: [{ reviewSessionId: "review-1", status: "completed" }],
+      settlementReadiness: { settlementReadinessId: "settlement-1", status: "ready_for_review" },
+      regulatoryProfiles: [{ regulatoryProfileId: "regulatory-1", status: "ready_for_review" }],
+      sharingRooms: [{ sharingRoomId: "room-1", status: "active", publiclyAccessible: false, externalExecutionEnabled: false }],
+      auditEvents: [{ eventId: "event-1" }],
+      consentRecords: [{ consentId: "consent-1" }],
+    });
+
+    expect(readiness.status).toBe("review_required");
+    expect(readiness.evidenceReferences[0]).toEqual(expect.objectContaining({ status: "unavailable" }));
+    expect(JSON.stringify(readiness)).not.toContain("sensitive-id");
+    expect(readiness.redactions).toEqual(
+      expect.arrayContaining(["Raw government identifiers, screening, and credit bureau payloads are excluded."])
+    );
+  });
+});

--- a/rentchain-api/src/lib/institutionOnboarding/deriveInstitutionOnboardingReadiness.ts
+++ b/rentchain-api/src/lib/institutionOnboarding/deriveInstitutionOnboardingReadiness.ts
@@ -1,0 +1,459 @@
+import type {
+  DeriveInstitutionOnboardingReadinessInput,
+  InstitutionOnboardingCanonicalEvent,
+  InstitutionOnboardingReadiness,
+  InstitutionOnboardingReference,
+  InstitutionOnboardingStatus,
+  InstitutionType,
+} from "./institutionOnboardingTypes";
+import { institutionOnboardingIdPart, onboardingReference, onboardingRestriction } from "./onboardingRestrictionModels";
+
+const INSTITUTION_TYPES = new Set<InstitutionType>(["lender", "insurer", "auditor", "regulator", "municipality", "institutional_landlord", "operational_partner"]);
+
+const REDACTIONS = [
+  "Raw government identifiers, screening, and credit bureau payloads are excluded.",
+  "Payment account details and unrestricted financial information are excluded.",
+  "Private tenant documents and tenant communications are excluded.",
+  "Institution onboarding references are operational metadata, not external onboarding payloads.",
+  "Public onboarding portals and unrestricted institutional directory data are not included.",
+];
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function asArray<T>(value: T[] | null | undefined): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function generatedAt(value: unknown): string {
+  const raw = asString(value, 120);
+  const date = raw ? new Date(raw) : new Date(0);
+  return Number.isNaN(date.getTime()) ? new Date(0).toISOString() : date.toISOString();
+}
+
+function normalizeInstitutionType(value: unknown): InstitutionType {
+  const raw = asString(value, 80) as InstitutionType;
+  return INSTITUTION_TYPES.has(raw) ? raw : "operational_partner";
+}
+
+function referenceId(record: Record<string, any>, keys: string[]): string {
+  for (const key of keys) {
+    const value = asString(record?.[key], 240);
+    if (value) return value;
+  }
+  return asString(record?.id, 240);
+}
+
+function statusFromReferences(hasContext: boolean, references: InstitutionOnboardingReference[]): InstitutionOnboardingStatus {
+  if (!hasContext) return "unknown";
+  if (references.some((reference) => reference.status === "blocked")) return "blocked";
+  if (references.some((reference) => reference.status === "unavailable")) return "review_required";
+  if (references.some((reference) => reference.status === "partially_verified")) return "partially_ready";
+  return "ready_for_review";
+}
+
+function event(input: {
+  eventType: InstitutionOnboardingCanonicalEvent["eventType"];
+  status: InstitutionOnboardingStatus;
+  onboardingReadinessId: string;
+  summary: string;
+}): InstitutionOnboardingCanonicalEvent {
+  return {
+    eventType: input.eventType,
+    action: input.eventType.replace(/^institution_onboarding_/, "").replace(/_/g, "."),
+    status: input.status,
+    resourceType: "institution_onboarding_readiness",
+    resourceId: input.onboardingReadinessId,
+    summary: input.summary,
+  };
+}
+
+function statusFromReadyBlocked(record: Record<string, any>, readyStatuses: string[]): InstitutionOnboardingReference["status"] {
+  const status = asString(record?.status, 80);
+  if (status === "blocked") return "blocked";
+  if (readyStatuses.includes(status)) return "verified";
+  return "partially_verified";
+}
+
+export function deriveInstitutionOnboardingReadiness(input: DeriveInstitutionOnboardingReadinessInput): InstitutionOnboardingReadiness {
+  const landlordId = asString(input.landlordId, 240);
+  const institutionType = normalizeInstitutionType(input.institutionType);
+  const onboardingReadinessId =
+    institutionOnboardingIdPart(["institution_onboarding_readiness", landlordId || "unknown", institutionType].join(":")) || "institution_onboarding_readiness:unknown";
+
+  const participants = asArray(input.networkParticipants);
+  const trustRelationships = asArray(input.trustRelationships);
+  const identityProfiles = asArray(input.identityProfiles);
+  const evidencePacks = asArray(input.evidencePacks);
+  const reviews = asArray(input.operatorReviewSessions);
+  const regulatoryProfiles = asArray(input.regulatoryProfiles);
+  const sharingRooms = asArray(input.sharingRooms);
+  const auditEvents = asArray(input.auditEvents);
+  const consentRecords = asArray(input.consentRecords);
+  const settlementReadiness = input.settlementReadiness || null;
+
+  const participantReferences = participants.length
+    ? participants.map((participant) =>
+        onboardingReference({
+          idParts: ["participant", referenceId(participant, ["participantId", "id", "participantType"]) || institutionType],
+          referenceType: "identity",
+          status: participant.status === "verified" ? "verified" : participant.status === "blocked" ? "blocked" : "partially_verified",
+          label: "Institution participant reference",
+          description: "Network participant metadata is available for onboarding readiness review.",
+          lineageReferences: [referenceId(participant, ["participantId", "id"])].filter(Boolean),
+          destination: "/network-participants",
+          blockedReason: participant.status === "blocked" ? "Institution participant relationship is blocked." : null,
+        })
+      )
+    : [
+        onboardingReference({
+          idParts: ["participant", "missing"],
+          referenceType: "identity",
+          status: "unavailable",
+          label: "Institution participant reference",
+          description: "Institution participant metadata is unavailable.",
+          destination: "/network-participants",
+        }),
+      ];
+
+  const trustReferences = trustRelationships.length
+    ? trustRelationships.map((trust) =>
+        onboardingReference({
+          idParts: ["trust", referenceId(trust, ["trustRelationshipId", "id", "relationshipType"]) || institutionType],
+          referenceType: "trust",
+          status: trust.status === "verified" ? "verified" : trust.status === "blocked" ? "blocked" : "partially_verified",
+          label: "Trust relationship readiness",
+          description: "Cross-organization trust lineage is available for onboarding readiness review.",
+          lineageReferences: [referenceId(trust, ["trustRelationshipId", "id"])].filter(Boolean),
+          destination: "/cross-organization-trust",
+          blockedReason: trust.status === "blocked" ? "Cross-organization trust is blocked." : null,
+        })
+      )
+    : [
+        onboardingReference({
+          idParts: ["trust", "missing"],
+          referenceType: "trust",
+          status: "unavailable",
+          label: "Trust relationship readiness",
+          description: "Cross-organization trust lineage is missing for onboarding readiness.",
+          destination: "/cross-organization-trust",
+        }),
+      ];
+
+  const identityReferences = identityProfiles.length
+    ? identityProfiles.map((profile) =>
+        onboardingReference({
+          idParts: ["identity", referenceId(profile, ["identityId", "id"]) || institutionType],
+          referenceType: "identity",
+          status: profile.status === "verified" ? "verified" : profile.status === "blocked" ? "blocked" : "partially_verified",
+          label: "Institution identity lineage",
+          description: "Identity lineage is available for institution onboarding readiness.",
+          lineageReferences: [referenceId(profile, ["identityId", "id"])].filter(Boolean),
+          destination: "/identity-layer",
+          blockedReason: profile.status === "blocked" ? "Identity lineage is blocked." : null,
+        })
+      )
+    : [
+        onboardingReference({
+          idParts: ["identity", "missing"],
+          referenceType: "identity",
+          status: "unavailable",
+          label: "Institution identity lineage",
+          description: "Identity lineage is missing for institution onboarding readiness.",
+          destination: "/identity-layer",
+        }),
+      ];
+
+  const evidenceReferences = evidencePacks.length
+    ? evidencePacks.map((pack) =>
+        onboardingReference({
+          idParts: ["evidence", referenceId(pack, ["evidencePackId", "id"]) || "unknown"],
+          referenceType: "evidence",
+          status: pack.status === "blocked" ? "blocked" : pack.status === "ready_for_review" ? "verified" : "partially_verified",
+          label: "Evidence readiness lineage",
+          description: "Evidence pack lineage is available for institution onboarding readiness.",
+          lineageReferences: [referenceId(pack, ["evidencePackId", "id"])].filter(Boolean),
+          destination: "/evidence-packs",
+          blockedReason: pack.status === "blocked" ? "Evidence onboarding lineage is blocked." : null,
+        })
+      )
+    : [
+        onboardingReference({
+          idParts: ["evidence", "missing"],
+          referenceType: "evidence",
+          status: "unavailable",
+          label: "Evidence readiness lineage",
+          description: "Evidence lineage is missing for institution onboarding readiness.",
+          destination: "/evidence-packs",
+        }),
+      ];
+
+  const reviewReferences = reviews.length
+    ? reviews.map((review) =>
+        onboardingReference({
+          idParts: ["review", referenceId(review, ["reviewSessionId", "id"]) || "unknown"],
+          referenceType: "review",
+          status: review.status === "completed" ? "verified" : review.status === "blocked" ? "blocked" : "partially_verified",
+          label: "Review readiness lineage",
+          description: "Operator review lineage is available for institution onboarding readiness.",
+          lineageReferences: [referenceId(review, ["reviewSessionId", "id"])].filter(Boolean),
+          destination: "/review-timeline",
+          blockedReason: review.status === "blocked" ? "Review onboarding lineage is blocked." : null,
+        })
+      )
+    : [
+        onboardingReference({
+          idParts: ["review", "missing"],
+          referenceType: "review",
+          status: "unavailable",
+          label: "Review readiness lineage",
+          description: "Review lineage is missing for institution onboarding readiness.",
+          destination: "/review-timeline",
+        }),
+      ];
+
+  const settlementReferences = settlementReadiness
+    ? [
+        onboardingReference({
+          idParts: ["settlement", referenceId(settlementReadiness, ["settlementReadinessId", "id"]) || "unknown"],
+          referenceType: "settlement",
+          status: statusFromReadyBlocked(settlementReadiness, ["ready_for_review"]),
+          label: "Settlement onboarding dependency",
+          description: "Settlement readiness metadata is available for institution onboarding readiness.",
+          lineageReferences: [referenceId(settlementReadiness, ["settlementReadinessId", "id"])].filter(Boolean),
+          destination: "/settlement-readiness",
+          blockedReason: settlementReadiness.status === "blocked" ? "Settlement readiness is blocked." : null,
+        }),
+      ]
+    : [
+        onboardingReference({
+          idParts: ["settlement", "missing"],
+          referenceType: "settlement",
+          status: "unavailable",
+          label: "Settlement onboarding dependency",
+          description: "Settlement readiness context is unavailable.",
+          destination: "/settlement-readiness",
+        }),
+      ];
+
+  const regulatoryReferences = regulatoryProfiles.length
+    ? regulatoryProfiles.map((profile) =>
+        onboardingReference({
+          idParts: ["regulatory", referenceId(profile, ["regulatoryProfileId", "id"]) || "unknown"],
+          referenceType: "regulatory",
+          status: statusFromReadyBlocked(profile, ["ready_for_review"]),
+          label: "Regulatory onboarding dependency",
+          description: "Regulatory readiness metadata is available for institution onboarding readiness.",
+          lineageReferences: [referenceId(profile, ["regulatoryProfileId", "id"])].filter(Boolean),
+          destination: "/regulatory-profiles",
+          blockedReason: profile.status === "blocked" ? "Regulatory readiness is blocked." : null,
+        })
+      )
+    : [
+        onboardingReference({
+          idParts: ["regulatory", "missing"],
+          referenceType: "regulatory",
+          status: "unavailable",
+          label: "Regulatory onboarding dependency",
+          description: "Regulatory readiness context is unavailable.",
+          destination: "/regulatory-profiles",
+        }),
+      ];
+
+  const sharingReferences = sharingRooms.length
+    ? sharingRooms.map((room) =>
+        onboardingReference({
+          idParts: ["sharing", referenceId(room, ["sharingRoomId", "id"]) || "unknown"],
+          referenceType: "sharing",
+          status: room.publiclyAccessible || room.externalExecutionEnabled || room.status === "blocked" ? "blocked" : room.status === "active" ? "verified" : "partially_verified",
+          label: "Institutional sharing onboarding dependency",
+          description: "Permissioned sharing-room metadata is available for onboarding readiness.",
+          lineageReferences: [referenceId(room, ["sharingRoomId", "id"])].filter(Boolean),
+          destination: "/institutional-sharing-rooms",
+          blockedReason: room.publiclyAccessible || room.externalExecutionEnabled ? "Public access or external execution is not allowed for institution onboarding." : null,
+        })
+      )
+    : [
+        onboardingReference({
+          idParts: ["sharing", "missing"],
+          referenceType: "sharing",
+          status: consentRecords.length ? "partially_verified" : "blocked",
+          label: "Institutional sharing onboarding dependency",
+          description: "Institutional onboarding requires permissioned sharing or consent/access lineage.",
+          destination: "/institutional-sharing-rooms",
+          blockedReason: consentRecords.length ? null : "Consent/access lineage is missing for institution onboarding.",
+        }),
+      ];
+
+  const auditReferences = auditEvents.length
+    ? auditEvents.slice(0, 12).map((record) =>
+        onboardingReference({
+          idParts: ["audit", referenceId(record, ["eventId", "id"]) || "unknown"],
+          referenceType: "audit",
+          status: record.redacted ? "partially_verified" : "verified",
+          label: "Audit onboarding lineage",
+          description: "Canonical audit event metadata is available for institution onboarding readiness.",
+          lineageReferences: [referenceId(record, ["eventId", "id"])].filter(Boolean),
+          destination: "/review-timeline",
+          redacted: Boolean(record.redacted),
+          redactionReason: record.redacted ? "Audit payload is redacted for onboarding safety." : null,
+        })
+      )
+    : [
+        onboardingReference({
+          idParts: ["audit", "missing"],
+          referenceType: "audit",
+          status: "unavailable",
+          label: "Audit onboarding lineage",
+          description: "Audit lineage is missing for institution onboarding readiness.",
+          destination: "/review-timeline",
+        }),
+      ];
+
+  const allReferences = [
+    ...participantReferences,
+    ...trustReferences,
+    ...identityReferences,
+    ...evidenceReferences,
+    ...reviewReferences,
+    ...settlementReferences,
+    ...regulatoryReferences,
+    ...sharingReferences,
+    ...auditReferences,
+  ];
+
+  const onboardingRestrictions = [
+    ...(consentRecords.length
+      ? []
+      : [
+          onboardingRestriction({
+            idParts: ["consent", "missing"],
+            restrictionType: "consent",
+            status: "blocked",
+            label: "Consent/access lineage missing",
+            description: "Institution onboarding readiness requires consent or access lineage before operational reliance.",
+            blockedReason: "Consent/access lineage is missing.",
+          }),
+        ]),
+    ...trustReferences
+      .filter((reference) => reference.status !== "verified")
+      .map((reference) =>
+        onboardingRestriction({
+          idParts: ["trust", reference.referenceId],
+          restrictionType: "trust",
+          status: reference.status === "blocked" ? "blocked" : "review_required",
+          label: "Trust onboarding restriction",
+          description: "Trust relationship readiness is incomplete or blocked.",
+          blockedReason: reference.blockedReason,
+        })
+      ),
+    ...settlementReferences
+      .filter((reference) => reference.status !== "verified")
+      .map((reference) =>
+        onboardingRestriction({
+          idParts: ["settlement", reference.referenceId],
+          restrictionType: "settlement",
+          status: reference.status === "blocked" ? "blocked" : "review_required",
+          label: "Settlement onboarding restriction",
+          description: "Settlement readiness is incomplete or blocked.",
+          blockedReason: reference.blockedReason,
+        })
+      ),
+    ...regulatoryReferences
+      .filter((reference) => reference.status !== "verified")
+      .map((reference) =>
+        onboardingRestriction({
+          idParts: ["regulatory", reference.referenceId],
+          restrictionType: "regulatory",
+          status: reference.status === "blocked" ? "blocked" : "review_required",
+          label: "Regulatory onboarding restriction",
+          description: "Regulatory readiness is incomplete or blocked.",
+          blockedReason: reference.blockedReason,
+        })
+      ),
+  ];
+
+  const hasContext = Boolean(
+    landlordId &&
+      (participants.length || trustRelationships.length || identityProfiles.length || evidencePacks.length || reviews.length || settlementReadiness || regulatoryProfiles.length || sharingRooms.length || auditEvents.length)
+  );
+  const status = statusFromReferences(hasContext, allReferences);
+  const blockedReasons = [...allReferences.map((reference) => reference.blockedReason), ...onboardingRestrictions.map((restriction) => restriction.blockedReason)].filter(Boolean) as string[];
+
+  const canonicalEvents: InstitutionOnboardingCanonicalEvent[] = [
+    event({
+      eventType: "institution_onboarding_readiness_derived",
+      status,
+      onboardingReadinessId,
+      summary: "Institution onboarding readiness derived from participant, trust, identity, review, evidence, settlement, regulatory, sharing, and audit metadata.",
+    }),
+    event({
+      eventType: "institution_onboarding_redaction_applied",
+      status,
+      onboardingReadinessId,
+      summary: "Sensitive identity, screening, payment, private document, tenant communication, and external onboarding payloads were excluded.",
+    }),
+  ];
+  if (onboardingRestrictions.length) {
+    canonicalEvents.push(
+      event({
+        eventType: "institution_onboarding_restriction_detected",
+        status,
+        onboardingReadinessId,
+        summary: "Institution onboarding restrictions are visible for manual review.",
+      })
+    );
+  }
+  if (status === "review_required" || status === "partially_ready") {
+    canonicalEvents.push(
+      event({
+        eventType: "institution_onboarding_review_required",
+        status,
+        onboardingReadinessId,
+        summary: "Manual institution onboarding readiness review is required.",
+      })
+    );
+  }
+  if (status === "blocked") {
+    canonicalEvents.push(
+      event({
+        eventType: "institution_onboarding_blocked",
+        status,
+        onboardingReadinessId,
+        summary: "Institution onboarding readiness is blocked by unsafe or missing required lineage.",
+      })
+    );
+  }
+
+  return {
+    onboardingReadinessId,
+    institutionType,
+    status,
+    manualReviewRequired: true,
+    externalOnboardingEnabled: false,
+    autonomousApprovalEnabled: false,
+    generatedAt: generatedAt(input.generatedAt),
+    summary: {
+      totalReferences: allReferences.length,
+      verifiedReferences: allReferences.filter((reference) => reference.status === "verified").length,
+      partiallyVerifiedReferences: allReferences.filter((reference) => reference.status === "partially_verified").length,
+      blockedReferences: allReferences.filter((reference) => reference.status === "blocked").length,
+      unavailableReferences: allReferences.filter((reference) => reference.status === "unavailable").length,
+      restrictions: onboardingRestrictions.length,
+    },
+    participantReferences,
+    trustReferences,
+    identityReferences,
+    evidenceReferences,
+    reviewReferences,
+    settlementReferences,
+    regulatoryReferences,
+    sharingReferences,
+    auditReferences,
+    onboardingRestrictions,
+    redactions: REDACTIONS,
+    blockedReasons,
+    canonicalEvents,
+  };
+}

--- a/rentchain-api/src/lib/institutionOnboarding/institutionOnboardingTypes.ts
+++ b/rentchain-api/src/lib/institutionOnboarding/institutionOnboardingTypes.ts
@@ -1,0 +1,93 @@
+export type InstitutionType = "lender" | "insurer" | "auditor" | "regulator" | "municipality" | "institutional_landlord" | "operational_partner";
+
+export type InstitutionOnboardingStatus = "ready_for_review" | "partially_ready" | "review_required" | "blocked" | "unknown";
+
+export type InstitutionOnboardingReferenceType = "identity" | "trust" | "evidence" | "review" | "settlement" | "regulatory" | "sharing" | "audit";
+
+export type InstitutionOnboardingReferenceStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+
+export type InstitutionOnboardingCanonicalEventType =
+  | "institution_onboarding_readiness_derived"
+  | "institution_onboarding_review_required"
+  | "institution_onboarding_blocked"
+  | "institution_onboarding_restriction_detected"
+  | "institution_onboarding_redaction_applied";
+
+export type InstitutionOnboardingReference = {
+  referenceId: string;
+  referenceType: InstitutionOnboardingReferenceType;
+  status: InstitutionOnboardingReferenceStatus;
+  label: string;
+  description: string;
+  reviewRequired: true;
+  lineageReferences: string[];
+  destination: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type InstitutionOnboardingRestriction = {
+  restrictionId: string;
+  restrictionType: "consent" | "settlement" | "regulatory" | "sharing" | "evidence" | "review" | "trust";
+  status: "visible" | "blocked" | "review_required";
+  label: string;
+  description: string;
+  blockedReason: string | null;
+};
+
+export type InstitutionOnboardingCanonicalEvent = {
+  eventType: InstitutionOnboardingCanonicalEventType;
+  action: string;
+  status: InstitutionOnboardingStatus;
+  resourceType: "institution_onboarding_readiness";
+  resourceId: string;
+  summary: string;
+};
+
+export type InstitutionOnboardingReadiness = {
+  onboardingReadinessId: string;
+  institutionType: InstitutionType;
+  status: InstitutionOnboardingStatus;
+  manualReviewRequired: true;
+  externalOnboardingEnabled: false;
+  autonomousApprovalEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    partiallyVerifiedReferences: number;
+    blockedReferences: number;
+    unavailableReferences: number;
+    restrictions: number;
+  };
+  participantReferences: InstitutionOnboardingReference[];
+  trustReferences: InstitutionOnboardingReference[];
+  identityReferences: InstitutionOnboardingReference[];
+  evidenceReferences: InstitutionOnboardingReference[];
+  reviewReferences: InstitutionOnboardingReference[];
+  settlementReferences: InstitutionOnboardingReference[];
+  regulatoryReferences: InstitutionOnboardingReference[];
+  sharingReferences: InstitutionOnboardingReference[];
+  auditReferences: InstitutionOnboardingReference[];
+  onboardingRestrictions: InstitutionOnboardingRestriction[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: InstitutionOnboardingCanonicalEvent[];
+};
+
+export type DeriveInstitutionOnboardingReadinessInput = {
+  landlordId?: unknown;
+  institutionType?: unknown;
+  generatedAt?: unknown;
+  networkParticipants?: Array<Record<string, any>> | null;
+  trustRelationships?: Array<Record<string, any>> | null;
+  identityProfiles?: Array<Record<string, any>> | null;
+  evidencePacks?: Array<Record<string, any>> | null;
+  operatorReviewSessions?: Array<Record<string, any>> | null;
+  settlementReadiness?: Record<string, any> | null;
+  regulatoryProfiles?: Array<Record<string, any>> | null;
+  sharingRooms?: Array<Record<string, any>> | null;
+  auditEvents?: Array<Record<string, any>> | null;
+  consentRecords?: Array<Record<string, any>> | null;
+};

--- a/rentchain-api/src/lib/institutionOnboarding/onboardingRestrictionModels.ts
+++ b/rentchain-api/src/lib/institutionOnboarding/onboardingRestrictionModels.ts
@@ -1,0 +1,63 @@
+import type {
+  InstitutionOnboardingReference,
+  InstitutionOnboardingReferenceStatus,
+  InstitutionOnboardingReferenceType,
+  InstitutionOnboardingRestriction,
+} from "./institutionOnboardingTypes";
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+export function institutionOnboardingIdPart(value: unknown): string {
+  return asString(value, 500)
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+export function onboardingReference(input: {
+  idParts: unknown[];
+  referenceType: InstitutionOnboardingReferenceType;
+  status: InstitutionOnboardingReferenceStatus;
+  label: string;
+  description: string;
+  lineageReferences?: string[];
+  destination?: string | null;
+  redacted?: boolean;
+  redactionReason?: string | null;
+  blockedReason?: string | null;
+}): InstitutionOnboardingReference {
+  return {
+    referenceId: institutionOnboardingIdPart(input.idParts.join(":")) || "institution_onboarding_reference:unknown",
+    referenceType: input.referenceType,
+    status: input.status,
+    label: input.label,
+    description: input.description,
+    reviewRequired: true,
+    lineageReferences: Array.from(new Set(input.lineageReferences || [])).filter(Boolean),
+    destination: input.destination || null,
+    redacted: Boolean(input.redacted),
+    redactionReason: input.redactionReason || null,
+    blockedReason: input.blockedReason || null,
+  };
+}
+
+export function onboardingRestriction(input: {
+  idParts: unknown[];
+  restrictionType: InstitutionOnboardingRestriction["restrictionType"];
+  status: InstitutionOnboardingRestriction["status"];
+  label: string;
+  description: string;
+  blockedReason?: string | null;
+}): InstitutionOnboardingRestriction {
+  return {
+    restrictionId: institutionOnboardingIdPart(input.idParts.join(":")) || "institution_onboarding_restriction:unknown",
+    restrictionType: input.restrictionType,
+    status: input.status,
+    label: input.label,
+    description: input.description,
+    blockedReason: input.blockedReason || null,
+  };
+}

--- a/rentchain-api/src/routes/__tests__/landlordInstitutionOnboardingRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordInstitutionOnboardingRoutes.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+  function matches(doc: any, filters: Array<{ field: string; op: string; value: any }>) {
+    return filters.every(({ field, op, value }) => (op === "==" ? doc?.data?.[field] === value : false));
+  }
+  function makeQuery(name: string, filters: Array<{ field: string; op: string; value: any }> = []) {
+    return {
+      where: (field: string, op: string, value: any) => makeQuery(name, [...filters, { field, op, value }]),
+      get: async () => {
+        const docs = Array.from(ensureCollection(name).values())
+          .filter((doc) => matches(doc, filters))
+          .map((doc) => ({ id: doc.id, exists: true, data: () => doc.data }));
+        return { docs, empty: docs.length === 0, size: docs.length };
+      },
+      doc: (id: string) => makeDoc(name, id),
+    };
+  }
+  function makeDoc(name: string, id: string) {
+    const col = ensureCollection(name);
+    return {
+      id,
+      get: async () => {
+        const entry = col.get(id);
+        return { id, exists: Boolean(entry), data: () => entry?.data };
+      },
+      set: async (data: any) => {
+        col.set(id, { id, data });
+      },
+    };
+  }
+  return {
+    resetFakeDb: () => store.clear(),
+    seedDoc: (collection: string, id: string, data: any) => ensureCollection(collection).set(id, { id, data }),
+    fakeDb: {
+      collection: (name: string) => ({
+        where: (field: string, op: string, value: any) => makeQuery(name, [{ field, op, value }]),
+        get: async () => makeQuery(name).get(),
+        doc: (id: string) => makeDoc(name, id),
+      }),
+    },
+  };
+});
+
+let mockUser: any;
+
+vi.mock("../../config/firebase", () => ({ db: fakeDb }));
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!mockUser) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    req.user = mockUser;
+    return next();
+  },
+}));
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: any, res: any, next: any) => {
+    const role = String(req.user?.role || "").trim().toLowerCase();
+    const landlordId = req.user?.landlordId || req.user?.id;
+    if (role !== "landlord" && role !== "admin") return res.status(403).json({ ok: false, error: "Forbidden" });
+    req.user.landlordId = landlordId;
+    return next();
+  },
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; user?: Record<string, unknown> | null }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    mockUser = options.user ?? mockUser;
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: mockUser,
+      query: Object.fromEntries(new URLSearchParams(queryString || "").entries()),
+      params: {},
+      body: {},
+      headers: {},
+    };
+    const match = path.match(/^\/institution-onboarding-readiness\/(.+)$/);
+    if (match) req.params = { onboardingReadinessId: decodeURIComponent(match[1]) };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => (error ? reject(error) : undefined));
+  });
+}
+
+describe("landlordInstitutionOnboardingRoutes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    resetFakeDb();
+    mockUser = { id: "landlord-1", landlordId: "landlord-1", role: "landlord" };
+  });
+
+  function seedOnboardingContext() {
+    seedDoc("properties", "property-1", { landlordId: "landlord-1", propertyId: "property-1", province: "NS", municipality: "Halifax" });
+    seedDoc("operatorReviewSessions", "review-1", { landlordId: "landlord-1", reviewSessionId: "review-1", status: "completed" });
+    seedDoc("evidencePacks", "evidence-1", { landlordId: "landlord-1", evidencePackId: "evidence-1", status: "ready_for_review" });
+    seedDoc("institutionalSharingRooms", "room-1", {
+      landlordId: "landlord-1",
+      sharingRoomId: "room-1",
+      status: "active",
+      publiclyAccessible: false,
+      externalExecutionEnabled: false,
+      accessControls: { institutionType: "lender" },
+    });
+    seedDoc("events", "event-1", { landlordId: "landlord-1", eventId: "event-1", eventType: "operator_review_session_closed" });
+    seedDoc("consents", "consent-1", { landlordId: "landlord-1", consentScope: "institution_onboarding", rawGovernmentId: "sensitive-id" });
+  }
+
+  it("returns landlord-scoped onboarding readiness without sensitive payloads", async () => {
+    seedOnboardingContext();
+    const router = (await import("../landlordInstitutionOnboardingRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/institution-onboarding-readiness?institutionType=lender" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.readiness).toHaveLength(1);
+    expect(res.body.readiness[0]).toEqual(
+      expect.objectContaining({ manualReviewRequired: true, externalOnboardingEnabled: false, autonomousApprovalEnabled: false })
+    );
+    const serialized = JSON.stringify(res.body);
+    expect(serialized).not.toContain("sensitive-id");
+  });
+
+  it("returns a single onboarding readiness item by id", async () => {
+    seedOnboardingContext();
+    const router = (await import("../landlordInstitutionOnboardingRoutes")).default;
+    const list = await invokeRouter(router, { method: "GET", url: "/institution-onboarding-readiness?institutionType=lender" });
+    const id = list.body.readiness[0].onboardingReadinessId;
+
+    const res = await invokeRouter(router, { method: "GET", url: `/institution-onboarding-readiness/${encodeURIComponent(id)}` });
+
+    expect(res.status).toBe(200);
+    expect(res.body.readiness.onboardingReadinessId).toBe(id);
+  });
+
+  it("filters by status and blocks non-landlord users", async () => {
+    seedOnboardingContext();
+    const router = (await import("../landlordInstitutionOnboardingRoutes")).default;
+
+    const filtered = await invokeRouter(router, { method: "GET", url: "/institution-onboarding-readiness?institutionType=lender&status=unknown" });
+    expect(filtered.status).toBe(200);
+    expect(filtered.body.readiness).toEqual([]);
+
+    const forbidden = await invokeRouter(router, { method: "GET", url: "/institution-onboarding-readiness", user: { id: "tenant-1", role: "tenant" } });
+    expect(forbidden.status).toBe(403);
+  });
+});

--- a/rentchain-api/src/routes/landlordInstitutionOnboardingRoutes.ts
+++ b/rentchain-api/src/routes/landlordInstitutionOnboardingRoutes.ts
@@ -1,0 +1,197 @@
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { requireAuth } from "../middleware/requireAuth";
+import { requireLandlord } from "../middleware/requireLandlord";
+import { deriveCrossOrganizationTrust } from "../lib/crossOrganizationTrust/deriveCrossOrganizationTrust";
+import { deriveIdentityProfile } from "../lib/identityLayer/deriveIdentityProfile";
+import { deriveInstitutionOnboardingReadiness } from "../lib/institutionOnboarding/deriveInstitutionOnboardingReadiness";
+import { deriveNetworkParticipantProfile } from "../lib/networkParticipants/deriveNetworkParticipantProfile";
+import { deriveRegulatoryProfile } from "../lib/regulatoryProfiles/deriveRegulatoryProfile";
+import { deriveSettlementReadiness } from "../lib/settlementReadiness/deriveSettlementReadiness";
+import { buildPaymentObligationLedgerRows } from "../lib/payments/paymentObligationLedger";
+import type { CrossOrganizationTrustRelationshipType } from "../lib/crossOrganizationTrust/crossOrganizationTrustTypes";
+import type { InstitutionOnboardingReadiness, InstitutionOnboardingStatus, InstitutionType } from "../lib/institutionOnboarding/institutionOnboardingTypes";
+import type { NetworkParticipantType } from "../lib/networkParticipants/networkParticipantTypes";
+
+const router = Router();
+const INSTITUTION_TYPES = new Set<InstitutionType>(["lender", "insurer", "auditor", "regulator", "municipality", "institutional_landlord", "operational_partner"]);
+const STATUSES = new Set<InstitutionOnboardingStatus>(["ready_for_review", "partially_ready", "review_required", "blocked", "unknown"]);
+const PARTICIPANT_TYPES: NetworkParticipantType[] = ["landlord", "operator", "lender", "insurer", "auditor", "regulator", "contractor", "institutional_partner", "review_actor"];
+const TRUST_TYPES: CrossOrganizationTrustRelationshipType[] = ["operational_trust", "evidence_trust", "review_trust", "settlement_trust", "regulatory_trust", "sharing_trust"];
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function landlordIdFromReq(req: any) {
+  return asString(req.user?.landlordId || req.user?.id || req.user?.sub, 240);
+}
+
+function normalizedInstitutionType(value: unknown): InstitutionType | "" {
+  const raw = asString(value, 80) as InstitutionType;
+  return INSTITUTION_TYPES.has(raw) ? raw : "";
+}
+
+async function loadLandlordCollection(collectionName: string, landlordId: string) {
+  const byId = new Map<string, any>();
+  async function collect(field: "landlordId" | "ownerId" | "userId" | "createdByLandlordId") {
+    const snap = await db.collection(collectionName).where(field, "==", landlordId).get().catch(() => null);
+    for (const doc of snap?.docs || []) byId.set(doc.id, { id: doc.id, ...((doc.data() as any) || {}) });
+  }
+  await Promise.all([collect("landlordId"), collect("ownerId"), collect("userId"), collect("createdByLandlordId")]);
+  return Array.from(byId.values()).filter((record) =>
+    [record?.landlordId, record?.ownerId, record?.userId, record?.createdByLandlordId].some((value) => asString(value, 240) === landlordId)
+  );
+}
+
+function readinessMatches(readiness: InstitutionOnboardingReadiness, id: string) {
+  return readiness.onboardingReadinessId === id;
+}
+
+function participantTypeForInstitution(type: InstitutionType): NetworkParticipantType {
+  if (type === "lender" || type === "insurer" || type === "auditor" || type === "regulator") return type;
+  if (type === "institutional_landlord") return "landlord";
+  return "institutional_partner";
+}
+
+async function buildReadiness(landlordId: string, institutionType: InstitutionType | "") {
+  const [properties, registryStatuses, screeningOrders, consents, sharingRooms, evidencePacks, reviews, events, leases, paymentIntents, rentPayments, reconciliationRecords, contractors] =
+    await Promise.all([
+      loadLandlordCollection("properties", landlordId),
+      loadLandlordCollection("propertyRegistryStatuses", landlordId),
+      loadLandlordCollection("screeningOrders", landlordId),
+      loadLandlordCollection("consents", landlordId),
+      loadLandlordCollection("institutionalSharingRooms", landlordId),
+      loadLandlordCollection("evidencePacks", landlordId),
+      loadLandlordCollection("operatorReviewSessions", landlordId),
+      loadLandlordCollection("events", landlordId),
+      loadLandlordCollection("leases", landlordId),
+      loadLandlordCollection("paymentIntents", landlordId),
+      loadLandlordCollection("rentPayments", landlordId),
+      loadLandlordCollection("paymentReconciliationRecords", landlordId),
+      loadLandlordCollection("contractorProfiles", landlordId),
+    ]);
+
+  const obligationRows = buildPaymentObligationLedgerRows({ leases, paymentIntents, rentPayments, reconciliationRecords });
+  const settlementReadiness = deriveSettlementReadiness({
+    landlordId,
+    obligationRows,
+    reconciliationRecords,
+    evidencePacks,
+    operatorReviewSessions: reviews,
+    auditEvents: events,
+  });
+  const regulatoryProfile = deriveRegulatoryProfile({
+    landlordId,
+    properties,
+    registryStatuses,
+    screeningOrders,
+    consentRecords: consents,
+    sharingRooms,
+    institutionExportPackages: [],
+    evidencePacks,
+    operatorReviewSessions: reviews,
+    auditEvents: events,
+    settlementReadiness,
+  });
+
+  const identityProfiles = PARTICIPANT_TYPES.map((participantType) =>
+    deriveIdentityProfile({
+      identityType: participantType === "operator" || participantType === "review_actor" ? participantType : "organization",
+      identityId: participantType,
+      organization: { id: participantType, organizationId: participantType },
+      operator: reviews[0] || null,
+      consentRecords: consents,
+      reviewSessions: reviews,
+      canonicalEvents: events,
+    })
+  );
+
+  const networkParticipants = PARTICIPANT_TYPES.map((participantType, index) =>
+    deriveNetworkParticipantProfile({
+      landlordId,
+      participantType,
+      participantId: participantType,
+      identityProfiles: [identityProfiles[index]],
+      sharingRooms:
+        participantType === "lender" || participantType === "insurer" || participantType === "auditor" || participantType === "regulator"
+          ? sharingRooms.filter((room) => asString(room.accessControls?.institutionType || room.institutionType, 80) === participantType)
+          : sharingRooms,
+      operatorReviewSessions: reviews,
+      evidencePacks,
+      settlementReadiness,
+      regulatoryProfiles: [regulatoryProfile],
+      canonicalEvents: events,
+      contractorProfiles: participantType === "contractor" ? contractors : [],
+    })
+  );
+
+  const trustRelationships = TRUST_TYPES.map((relationshipType) =>
+    deriveCrossOrganizationTrust({
+      landlordId,
+      relationshipType,
+      networkParticipants,
+      evidencePacks,
+      operatorReviewSessions: reviews,
+      settlementReadiness,
+      regulatoryProfiles: [regulatoryProfile],
+      sharingRooms,
+      auditEvents: events,
+      consentRecords: consents,
+    })
+  );
+
+  const types = institutionType ? [institutionType] : Array.from(INSTITUTION_TYPES);
+  return types.map((type) => {
+    const participantType = participantTypeForInstitution(type);
+    return deriveInstitutionOnboardingReadiness({
+      landlordId,
+      institutionType: type,
+      networkParticipants: networkParticipants.filter((participant) => participant.participantType === participantType),
+      trustRelationships,
+      identityProfiles: identityProfiles.filter((profile) => profile.identityId === participantType || profile.identityId === type),
+      evidencePacks,
+      operatorReviewSessions: reviews,
+      settlementReadiness,
+      regulatoryProfiles: [regulatoryProfile],
+      sharingRooms:
+        type === "lender" || type === "insurer" || type === "auditor" || type === "regulator"
+          ? sharingRooms.filter((room) => asString(room.accessControls?.institutionType || room.institutionType, 80) === type)
+          : sharingRooms,
+      auditEvents: events,
+      consentRecords: consents,
+    });
+  });
+}
+
+router.get("/institution-onboarding-readiness", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = landlordIdFromReq(req);
+    if (!landlordId) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    const institutionType = normalizedInstitutionType(req.query?.institutionType);
+    const status = asString(req.query?.status, 80) as InstitutionOnboardingStatus;
+    let readiness = await buildReadiness(landlordId, institutionType);
+    if (status && STATUSES.has(status)) readiness = readiness.filter((item) => item.status === status);
+    return res.json({ ok: true, readiness });
+  } catch (err: any) {
+    console.error("[landlord-institution-onboarding-readiness] list failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "INSTITUTION_ONBOARDING_READINESS_FAILED" });
+  }
+});
+
+router.get("/institution-onboarding-readiness/:onboardingReadinessId", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = landlordIdFromReq(req);
+    const onboardingReadinessId = decodeURIComponent(asString(req.params?.onboardingReadinessId, 500));
+    if (!landlordId || !onboardingReadinessId) return res.status(400).json({ ok: false, error: "ONBOARDING_READINESS_ID_REQUIRED" });
+    const readiness = await buildReadiness(landlordId, "");
+    const item = readiness.find((next) => readinessMatches(next, onboardingReadinessId));
+    if (!item) return res.status(404).json({ ok: false, error: "ONBOARDING_READINESS_NOT_FOUND" });
+    return res.json({ ok: true, readiness: item });
+  } catch (err: any) {
+    console.error("[landlord-institution-onboarding-readiness] get failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "INSTITUTION_ONBOARDING_READINESS_GET_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -150,6 +150,10 @@ vi.mock("./pages/CrossOrganizationTrustPage", () => ({
   default: () => <h1>Cross Organization Trust Page</h1>,
 }));
 
+vi.mock("./pages/InstitutionOnboardingReadinessPage", () => ({
+  default: () => <h1>Institution Onboarding Readiness Page</h1>,
+}));
+
 vi.mock("./pages/landlord/PortfolioScorePage", () => ({
   default: () => <h1>Landlord Portfolio Score</h1>,
 }));
@@ -467,6 +471,20 @@ describe("Routes: /cross-organization-trust", () => {
     );
 
     expect(await screen.findByText(/Cross Organization Trust Page/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Routes: /institution-onboarding-readiness", () => {
+  it("renders the institution onboarding readiness route", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/institution-onboarding-readiness?institutionType=lender"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Institution Onboarding Readiness Page/i)).toBeInTheDocument();
     expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -130,6 +130,7 @@ const RegulatoryProfilePage = lazy(() => import("./pages/RegulatoryProfilePage")
 const AssetTokenizationReadinessPage = lazy(() => import("./pages/AssetTokenizationReadinessPage"));
 const NetworkParticipantsPage = lazy(() => import("./pages/NetworkParticipantsPage"));
 const CrossOrganizationTrustPage = lazy(() => import("./pages/CrossOrganizationTrustPage"));
+const InstitutionOnboardingReadinessPage = lazy(() => import("./pages/InstitutionOnboardingReadinessPage"));
 const LandlordPortfolioScorePage = lazy(() => import("./pages/landlord/PortfolioScorePage"));
 const SharedPortfolioScorePage = lazy(() => import("./pages/public/SharedPortfolioScorePage"));
 const TenantSharePackagePage = lazy(() => import("./pages/public/TenantSharePackagePage"));
@@ -681,6 +682,18 @@ function App() {
               <LandlordNav>
                 <Suspense fallback={null}>
                   <CrossOrganizationTrustPage />
+                </Suspense>
+              </LandlordNav>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/institution-onboarding-readiness"
+          element={
+            <RequireAuth>
+              <LandlordNav>
+                <Suspense fallback={null}>
+                  <InstitutionOnboardingReadinessPage />
                 </Suspense>
               </LandlordNav>
             </RequireAuth>

--- a/rentchain-frontend/src/api/institutionOnboardingApi.ts
+++ b/rentchain-frontend/src/api/institutionOnboardingApi.ts
@@ -1,0 +1,79 @@
+import { apiFetch } from "./apiFetch";
+
+export type InstitutionType = "lender" | "insurer" | "auditor" | "regulator" | "municipality" | "institutional_landlord" | "operational_partner";
+export type InstitutionOnboardingStatus = "ready_for_review" | "partially_ready" | "review_required" | "blocked" | "unknown";
+export type InstitutionOnboardingReferenceStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+export type InstitutionOnboardingReferenceType = "identity" | "trust" | "evidence" | "review" | "settlement" | "regulatory" | "sharing" | "audit";
+
+export type InstitutionOnboardingReference = {
+  referenceId: string;
+  referenceType: InstitutionOnboardingReferenceType;
+  status: InstitutionOnboardingReferenceStatus;
+  label: string;
+  description: string;
+  reviewRequired: true;
+  lineageReferences: string[];
+  destination: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type InstitutionOnboardingRestriction = {
+  restrictionId: string;
+  restrictionType: "consent" | "settlement" | "regulatory" | "sharing" | "evidence" | "review" | "trust";
+  status: "visible" | "blocked" | "review_required";
+  label: string;
+  description: string;
+  blockedReason: string | null;
+};
+
+export type InstitutionOnboardingReadiness = {
+  onboardingReadinessId: string;
+  institutionType: InstitutionType;
+  status: InstitutionOnboardingStatus;
+  manualReviewRequired: true;
+  externalOnboardingEnabled: false;
+  autonomousApprovalEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    partiallyVerifiedReferences: number;
+    blockedReferences: number;
+    unavailableReferences: number;
+    restrictions: number;
+  };
+  participantReferences: InstitutionOnboardingReference[];
+  trustReferences: InstitutionOnboardingReference[];
+  identityReferences: InstitutionOnboardingReference[];
+  evidenceReferences: InstitutionOnboardingReference[];
+  reviewReferences: InstitutionOnboardingReference[];
+  settlementReferences: InstitutionOnboardingReference[];
+  regulatoryReferences: InstitutionOnboardingReference[];
+  sharingReferences: InstitutionOnboardingReference[];
+  auditReferences: InstitutionOnboardingReference[];
+  onboardingRestrictions: InstitutionOnboardingRestriction[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: Array<{ eventType: string; action: string; status: InstitutionOnboardingStatus; resourceId: string; summary: string }>;
+};
+
+export async function fetchInstitutionOnboardingReadiness(params?: {
+  institutionType?: InstitutionType | "";
+  status?: InstitutionOnboardingStatus | "";
+}): Promise<InstitutionOnboardingReadiness[]> {
+  const search = new URLSearchParams();
+  if (params?.institutionType) search.set("institutionType", params.institutionType);
+  if (params?.status) search.set("status", params.status);
+  const suffix = search.toString() ? `?${search.toString()}` : "";
+  const response = await apiFetch<{ ok: true; readiness: InstitutionOnboardingReadiness[] }>(`/landlord/institution-onboarding-readiness${suffix}`);
+  return response.readiness;
+}
+
+export async function fetchInstitutionOnboardingReadinessItem(onboardingReadinessId: string): Promise<InstitutionOnboardingReadiness> {
+  const response = await apiFetch<{ ok: true; readiness: InstitutionOnboardingReadiness }>(
+    `/landlord/institution-onboarding-readiness/${encodeURIComponent(onboardingReadinessId)}`
+  );
+  return response.readiness;
+}

--- a/rentchain-frontend/src/components/onboarding/InstitutionOnboardingPanel.test.tsx
+++ b/rentchain-frontend/src/components/onboarding/InstitutionOnboardingPanel.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { InstitutionOnboardingPanel } from "./InstitutionOnboardingPanel";
+
+const reference = {
+  referenceId: "onboarding:evidence:evidence-1",
+  referenceType: "evidence",
+  status: "verified",
+  label: "Evidence readiness lineage",
+  description: "Evidence pack lineage is available for institution onboarding readiness.",
+  reviewRequired: true,
+  lineageReferences: ["evidence-1"],
+  destination: "/evidence-packs",
+  redacted: false,
+  redactionReason: null,
+  blockedReason: null,
+};
+
+const readiness = {
+  onboardingReadinessId: "institution_onboarding_readiness:landlord-1:lender",
+  institutionType: "lender",
+  status: "review_required",
+  manualReviewRequired: true,
+  externalOnboardingEnabled: false,
+  autonomousApprovalEnabled: false,
+  generatedAt: "2026-01-01T00:00:00.000Z",
+  summary: {
+    totalReferences: 2,
+    verifiedReferences: 1,
+    partiallyVerifiedReferences: 0,
+    blockedReferences: 1,
+    unavailableReferences: 0,
+    restrictions: 1,
+  },
+  participantReferences: [],
+  trustReferences: [],
+  identityReferences: [],
+  evidenceReferences: [reference],
+  reviewReferences: [{ ...reference, referenceId: "onboarding:review:review-1", referenceType: "review", label: "Review readiness lineage" }],
+  settlementReferences: [],
+  regulatoryReferences: [],
+  sharingReferences: [],
+  auditReferences: [],
+  onboardingRestrictions: [
+    {
+      restrictionId: "onboarding:consent:missing",
+      restrictionType: "consent",
+      status: "blocked",
+      label: "Consent/access lineage missing",
+      description: "Institution onboarding readiness requires consent or access lineage before operational reliance.",
+      blockedReason: "Consent/access lineage is missing.",
+    },
+  ],
+  redactions: ["Raw government identifiers, screening, and credit bureau payloads are excluded."],
+  blockedReasons: ["Consent/access lineage is missing."],
+  canonicalEvents: [],
+} as const;
+
+describe("InstitutionOnboardingPanel", () => {
+  it("renders onboarding lineage, restrictions, redactions, and required safety copy", () => {
+    render(
+      <MemoryRouter>
+        <InstitutionOnboardingPanel readiness={readiness as any} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("View onboarding readiness")).toBeInTheDocument();
+    expect(screen.getAllByText(/No live institution integration or autonomous onboarding is enabled/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("View blocked reason: Consent/access lineage is missing.")).toBeInTheDocument();
+    expect(screen.getByText("Raw government identifiers, screening, and credit bureau payloads are excluded.")).toBeInTheDocument();
+  });
+
+  it("does not render forbidden onboarding action labels", () => {
+    render(
+      <MemoryRouter>
+        <InstitutionOnboardingPanel readiness={readiness as any} />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText("Connect lender")).not.toBeInTheDocument();
+    expect(screen.queryByText("Connect regulator")).not.toBeInTheDocument();
+    expect(screen.queryByText("Auto-onboard")).not.toBeInTheDocument();
+    expect(screen.queryByText("Submit onboarding")).not.toBeInTheDocument();
+    expect(screen.queryByText("Autonomous approval")).not.toBeInTheDocument();
+    expect(screen.queryByText("Publish onboarding")).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/onboarding/InstitutionOnboardingPanel.tsx
+++ b/rentchain-frontend/src/components/onboarding/InstitutionOnboardingPanel.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import type { CrossOrganizationTrustReference, CrossOrganizationTrustRelationship, CrossOrganizationTrustRestriction } from "@/api/crossOrganizationTrustApi";
+import type { InstitutionOnboardingReadiness, InstitutionOnboardingReference, InstitutionOnboardingRestriction } from "@/api/institutionOnboardingApi";
 import { Card, Section } from "@/components/ui/Ui";
 
 function label(value: string) {
@@ -9,8 +9,8 @@ function label(value: string) {
 
 function tone(status: string) {
   if (status === "blocked") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
-  if (status === "review_required" || status === "partially_verified" || status === "unavailable") return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
-  if (status === "verified") return { color: "#166534", background: "#dcfce7", border: "#bbf7d0" };
+  if (status === "review_required" || status === "partially_ready" || status === "partially_verified" || status === "unavailable") return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
+  if (status === "ready_for_review" || status === "verified") return { color: "#166534", background: "#dcfce7", border: "#bbf7d0" };
   return { color: "#475569", background: "#f8fafc", border: "#e2e8f0" };
 }
 
@@ -23,13 +23,13 @@ function Badge({ children, status }: { children: React.ReactNode; status: string
   );
 }
 
-function ReferenceList({ title, references }: { title: string; references: CrossOrganizationTrustReference[] }) {
+function ReferenceList({ title, references }: { title: string; references: InstitutionOnboardingReference[] }) {
   return (
     <Section style={{ display: "grid", gap: 10 }}>
       <div style={{ fontWeight: 900 }}>{title}</div>
       {references.length ? (
         references.slice(0, 12).map((reference) => (
-          <Card key={reference.trustReferenceId} style={{ borderRadius: 8, padding: 12 }}>
+          <Card key={reference.referenceId} style={{ borderRadius: 8, padding: 12 }}>
             <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
               <div>
                 <strong>{reference.label}</strong>
@@ -40,7 +40,7 @@ function ReferenceList({ title, references }: { title: string; references: Cross
             <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>{reference.description}</div>
             {reference.lineageReferences.length ? <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>Lineage references: {reference.lineageReferences.length}</div> : null}
             {reference.blockedReason ? <div style={{ color: "#991b1b", fontSize: 13, marginTop: 8 }}>View blocked reason: {reference.blockedReason}</div> : null}
-            {reference.redacted ? <div style={{ color: "#92400e", fontSize: 13, marginTop: 8 }}>{reference.redactionReason || "Redacted trust reference"}</div> : null}
+            {reference.redacted ? <div style={{ color: "#92400e", fontSize: 13, marginTop: 8 }}>{reference.redactionReason || "Redacted onboarding reference"}</div> : null}
             {reference.destination ? <Link to={reference.destination} style={{ color: "#2563eb", fontWeight: 800, fontSize: 13, marginTop: 8, display: "inline-block" }}>View context</Link> : null}
           </Card>
         ))
@@ -51,7 +51,7 @@ function ReferenceList({ title, references }: { title: string; references: Cross
   );
 }
 
-function RestrictionList({ restrictions }: { restrictions: CrossOrganizationTrustRestriction[] }) {
+function RestrictionList({ restrictions }: { restrictions: InstitutionOnboardingRestriction[] }) {
   return (
     <Section style={{ display: "grid", gap: 10 }}>
       <div style={{ fontWeight: 900 }}>View restrictions</div>
@@ -70,44 +70,44 @@ function RestrictionList({ restrictions }: { restrictions: CrossOrganizationTrus
           </Card>
         ))
       ) : (
-        <Card style={{ color: "#64748b" }}>No trust restrictions detected.</Card>
+        <Card style={{ color: "#64748b" }}>No onboarding restrictions detected.</Card>
       )}
     </Section>
   );
 }
 
-export function CrossOrganizationTrustPanel({ trustRelationship }: { trustRelationship: CrossOrganizationTrustRelationship }) {
+export function InstitutionOnboardingPanel({ readiness }: { readiness: InstitutionOnboardingReadiness }) {
   return (
     <div style={{ display: "grid", gap: 16 }}>
       <Section style={{ display: "grid", gap: 10 }}>
         <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
           <div>
-            <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>View trust relationship</div>
-            <h2 style={{ margin: "2px 0 0", fontSize: "1.15rem" }}>{label(trustRelationship.relationshipType)}</h2>
+            <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>View onboarding readiness</div>
+            <h2 style={{ margin: "2px 0 0", fontSize: "1.15rem" }}>{label(readiness.institutionType)}</h2>
           </div>
-          <Badge status={trustRelationship.status}>{label(trustRelationship.status)}</Badge>
+          <Badge status={readiness.status}>{label(readiness.status)}</Badge>
         </div>
         <div style={{ color: "#475569", lineHeight: 1.55 }}>
-          Trust relationships are operationally scoped and review controlled. No public trust exposure or autonomous trust approval is enabled.
+          Institution onboarding readiness is operationally scoped and review controlled. No live institution integration or autonomous onboarding is enabled.
           Manual review remains required.
         </div>
         <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
           <Badge status="review_required">Manual review required</Badge>
-          <Badge status={trustRelationship.publicTrustExposureEnabled ? "blocked" : "verified"}>Public exposure disabled</Badge>
-          <Badge status={trustRelationship.autonomousTrustApprovalEnabled ? "blocked" : "verified"}>Approval automation disabled</Badge>
+          <Badge status={readiness.externalOnboardingEnabled ? "blocked" : "verified"}>External onboarding disabled</Badge>
+          <Badge status={readiness.autonomousApprovalEnabled ? "blocked" : "verified"}>Approval automation disabled</Badge>
         </div>
       </Section>
 
       <Section style={{ display: "grid", gap: 10 }}>
-        <div style={{ fontWeight: 900 }}>Trust summary</div>
+        <div style={{ fontWeight: 900 }}>Onboarding summary</div>
         <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: 10 }}>
           {[
-            ["References", trustRelationship.summary.totalReferences],
-            ["Verified", trustRelationship.summary.verifiedReferences],
-            ["Partial", trustRelationship.summary.partiallyVerifiedReferences],
-            ["Blocked", trustRelationship.summary.blockedReferences],
-            ["Unavailable", trustRelationship.summary.unavailableReferences],
-            ["Restrictions", trustRelationship.summary.restrictions],
+            ["References", readiness.summary.totalReferences],
+            ["Verified", readiness.summary.verifiedReferences],
+            ["Partial", readiness.summary.partiallyVerifiedReferences],
+            ["Blocked", readiness.summary.blockedReferences],
+            ["Unavailable", readiness.summary.unavailableReferences],
+            ["Restrictions", readiness.summary.restrictions],
           ].map(([name, value]) => (
             <Card key={String(name)} style={{ borderRadius: 8, padding: 12 }}>
               <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>{name}</div>
@@ -117,18 +117,20 @@ export function CrossOrganizationTrustPanel({ trustRelationship }: { trustRelati
         </div>
       </Section>
 
-      <RestrictionList restrictions={trustRelationship.trustRestrictions} />
-      <ReferenceList title="View evidence lineage" references={trustRelationship.evidenceReferences} />
-      <ReferenceList title="View review lineage" references={trustRelationship.reviewReferences} />
-      <ReferenceList title="Settlement references" references={trustRelationship.settlementReferences} />
-      <ReferenceList title="Regulatory references" references={trustRelationship.regulatoryReferences} />
-      <ReferenceList title="Sharing references" references={trustRelationship.sharingReferences} />
-      <ReferenceList title="Audit references" references={trustRelationship.auditReferences} />
-      <ReferenceList title="Operational references" references={trustRelationship.operationalReferences} />
+      <RestrictionList restrictions={readiness.onboardingRestrictions} />
+      <ReferenceList title="Participant references" references={readiness.participantReferences} />
+      <ReferenceList title="Trust references" references={readiness.trustReferences} />
+      <ReferenceList title="Identity references" references={readiness.identityReferences} />
+      <ReferenceList title="View evidence lineage" references={readiness.evidenceReferences} />
+      <ReferenceList title="View review lineage" references={readiness.reviewReferences} />
+      <ReferenceList title="Settlement dependencies" references={readiness.settlementReferences} />
+      <ReferenceList title="Regulatory dependencies" references={readiness.regulatoryReferences} />
+      <ReferenceList title="Sharing dependencies" references={readiness.sharingReferences} />
+      <ReferenceList title="Audit references" references={readiness.auditReferences} />
 
       <Section style={{ display: "grid", gap: 10 }}>
         <div style={{ fontWeight: 900 }}>Redactions</div>
-        {trustRelationship.redactions.map((redaction) => (
+        {readiness.redactions.map((redaction) => (
           <Card key={redaction} style={{ borderRadius: 8, padding: 12, color: "#475569" }}>{redaction}</Card>
         ))}
       </Section>

--- a/rentchain-frontend/src/pages/CrossOrganizationTrustPage.tsx
+++ b/rentchain-frontend/src/pages/CrossOrganizationTrustPage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useSearchParams } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import {
   fetchCrossOrganizationTrustRelationships,
   type CrossOrganizationTrustRelationship,
@@ -71,12 +71,15 @@ export default function CrossOrganizationTrustPage() {
     <MacShell title="Cross-organization trust" showTopNav={false}>
       <div style={{ display: "grid", gap: 16 }}>
         <Section>
-          <div style={{ display: "grid", gap: 6 }}>
-            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Cross-organization trust</h1>
-            <div style={{ color: "#475569", maxWidth: 900 }}>
-              Trust relationships are operationally scoped and review controlled. No public trust exposure or autonomous trust approval is enabled.
-              Manual review remains required.
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "start" }}>
+            <div style={{ display: "grid", gap: 6 }}>
+              <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Cross-organization trust</h1>
+              <div style={{ color: "#475569", maxWidth: 900 }}>
+                Trust relationships are operationally scoped and review controlled. No public trust exposure or autonomous trust approval is enabled.
+                Manual review remains required.
+              </div>
             </div>
+            <Link to="/institution-onboarding-readiness" style={{ color: "#2563eb", fontWeight: 900 }}>View onboarding readiness</Link>
           </div>
         </Section>
 

--- a/rentchain-frontend/src/pages/InstitutionOnboardingReadinessPage.test.tsx
+++ b/rentchain-frontend/src/pages/InstitutionOnboardingReadinessPage.test.tsx
@@ -1,0 +1,110 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import InstitutionOnboardingReadinessPage from "./InstitutionOnboardingReadinessPage";
+
+const mockFetchInstitutionOnboardingReadiness = vi.fn();
+const mockShowToast = vi.fn();
+
+vi.mock("@/api/institutionOnboardingApi", () => ({
+  fetchInstitutionOnboardingReadiness: (...args: any[]) => mockFetchInstitutionOnboardingReadiness(...args),
+}));
+
+vi.mock("@/components/layout/MacShell", () => ({
+  MacShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
+const readiness = {
+  onboardingReadinessId: "institution_onboarding_readiness:landlord-1:lender",
+  institutionType: "lender",
+  status: "ready_for_review",
+  manualReviewRequired: true,
+  externalOnboardingEnabled: false,
+  autonomousApprovalEnabled: false,
+  generatedAt: "2026-01-01T00:00:00.000Z",
+  summary: {
+    totalReferences: 1,
+    verifiedReferences: 1,
+    partiallyVerifiedReferences: 0,
+    blockedReferences: 0,
+    unavailableReferences: 0,
+    restrictions: 0,
+  },
+  participantReferences: [],
+  trustReferences: [],
+  identityReferences: [],
+  evidenceReferences: [],
+  reviewReferences: [],
+  settlementReferences: [],
+  regulatoryReferences: [],
+  sharingReferences: [],
+  auditReferences: [],
+  onboardingRestrictions: [],
+  redactions: ["Public onboarding portals and unrestricted institutional directory data are not included."],
+  blockedReasons: [],
+  canonicalEvents: [],
+};
+
+describe("InstitutionOnboardingReadinessPage", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchInstitutionOnboardingReadiness.mockResolvedValue([readiness]);
+  });
+
+  it("renders onboarding readiness and required safety copy", async () => {
+    render(
+      <MemoryRouter>
+        <InstitutionOnboardingReadinessPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Institution onboarding readiness")).toBeInTheDocument();
+    expect(screen.getAllByText(/No live institution integration or autonomous onboarding is enabled/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("Public onboarding portals and unrestricted institutional directory data are not included.")).toBeInTheDocument();
+  });
+
+  it("updates deterministic institution and status filters", async () => {
+    render(
+      <MemoryRouter>
+        <InstitutionOnboardingReadinessPage />
+      </MemoryRouter>
+    );
+
+    await screen.findByText("Institution onboarding readiness");
+    fireEvent.change(screen.getByLabelText("Institution type"), { target: { value: "auditor" } });
+    fireEvent.change(screen.getByLabelText("Status"), { target: { value: "blocked" } });
+
+    await waitFor(() => {
+      expect(mockFetchInstitutionOnboardingReadiness).toHaveBeenLastCalledWith({
+        institutionType: "auditor",
+        status: "blocked",
+      });
+    });
+  });
+
+  it("shows empty state and omits forbidden labels", async () => {
+    mockFetchInstitutionOnboardingReadiness.mockResolvedValue([]);
+    render(
+      <MemoryRouter>
+        <InstitutionOnboardingReadinessPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("No institution onboarding readiness items match these filters.")).toBeInTheDocument();
+    expect(screen.queryByText("Connect lender")).not.toBeInTheDocument();
+    expect(screen.queryByText("Connect regulator")).not.toBeInTheDocument();
+    expect(screen.queryByText("Auto-onboard")).not.toBeInTheDocument();
+    expect(screen.queryByText("Submit onboarding")).not.toBeInTheDocument();
+    expect(screen.queryByText("Autonomous approval")).not.toBeInTheDocument();
+    expect(screen.queryByText("Publish onboarding")).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/InstitutionOnboardingReadinessPage.tsx
+++ b/rentchain-frontend/src/pages/InstitutionOnboardingReadinessPage.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { useSearchParams } from "react-router-dom";
+import {
+  fetchInstitutionOnboardingReadiness,
+  type InstitutionOnboardingReadiness,
+  type InstitutionOnboardingStatus,
+  type InstitutionType,
+} from "@/api/institutionOnboardingApi";
+import { MacShell } from "@/components/layout/MacShell";
+import { InstitutionOnboardingPanel } from "@/components/onboarding/InstitutionOnboardingPanel";
+import { Card, Section } from "@/components/ui/Ui";
+import { useToast } from "@/components/ui/ToastProvider";
+
+const institutionTypes: Array<InstitutionType | ""> = ["", "lender", "insurer", "auditor", "regulator", "municipality", "institutional_landlord", "operational_partner"];
+const statuses: Array<InstitutionOnboardingStatus | ""> = ["", "ready_for_review", "partially_ready", "review_required", "blocked", "unknown"];
+
+function label(value: string) {
+  return value ? value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase()) : "All";
+}
+
+export default function InstitutionOnboardingReadinessPage() {
+  const { showToast } = useToast();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [readiness, setReadiness] = React.useState<InstitutionOnboardingReadiness[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const institutionType = String(searchParams.get("institutionType") || "") as InstitutionType | "";
+  const status = String(searchParams.get("status") || "") as InstitutionOnboardingStatus | "";
+
+  React.useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const next = await fetchInstitutionOnboardingReadiness({ institutionType, status });
+        if (mounted) setReadiness(next);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Failed to load institution onboarding readiness";
+        if (mounted) {
+          setError(message);
+          showToast({ message: "Failed to load institution onboarding readiness", description: message, variant: "error" });
+        }
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [institutionType, status, showToast]);
+
+  function updateParams(next: { institutionType?: string; status?: string }) {
+    const params = new URLSearchParams(searchParams);
+    for (const [key, value] of Object.entries(next)) {
+      if (value && value.trim()) params.set(key, value.trim());
+      else params.delete(key);
+    }
+    setSearchParams(params);
+  }
+
+  return (
+    <MacShell title="Institution onboarding readiness" showTopNav={false}>
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "grid", gap: 6 }}>
+            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Institution onboarding readiness</h1>
+            <div style={{ color: "#475569", maxWidth: 900 }}>
+              Institution onboarding readiness is operationally scoped and review controlled. No live institution integration or autonomous onboarding is enabled.
+              Manual review remains required.
+            </div>
+          </div>
+        </Section>
+
+        <Section style={{ display: "flex", gap: 10, flexWrap: "wrap", alignItems: "end" }}>
+          <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Institution type
+            <select value={institutionType} onChange={(event) => updateParams({ institutionType: event.target.value })} style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 210 }}>
+              {institutionTypes.map((type) => <option key={type || "all"} value={type}>{label(type)}</option>)}
+            </select>
+          </label>
+          <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Status
+            <select value={status} onChange={(event) => updateParams({ status: event.target.value })} style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 180 }}>
+              {statuses.map((item) => <option key={item || "all"} value={item}>{label(item)}</option>)}
+            </select>
+          </label>
+        </Section>
+
+        {loading ? <Card>Loading institution onboarding readiness...</Card> : null}
+        {!loading && error ? <Card style={{ color: "#b91c1c" }}>We couldn't load institution onboarding readiness right now.</Card> : null}
+        {!loading && !error && !readiness.length ? <Card style={{ color: "#64748b" }}>No institution onboarding readiness items match these filters.</Card> : null}
+        {!loading && !error && readiness.length ? (
+          <div style={{ display: "grid", gap: 16 }}>{readiness.map((item) => <InstitutionOnboardingPanel key={item.onboardingReadinessId} readiness={item} />)}</div>
+        ) : null}
+      </div>
+    </MacShell>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds deterministic, landlord-scoped Institution Onboarding Readiness Layer
- Adds endpoints:
  - `GET /api/landlord/institution-onboarding-readiness`
  - `GET /api/landlord/institution-onboarding-readiness/:onboardingReadinessId`
- Adds frontend `/institution-onboarding-readiness` page and `InstitutionOnboardingPanel`
- Adds safe Cross-Organization Trust entry link to onboarding readiness
- Adds onboarding readiness references for participant, trust, identity, evidence, review, settlement, regulatory, sharing, and audit lineage
- Adds deterministic onboarding restrictions for missing consent/access lineage, incomplete trust readiness, incomplete settlement readiness, and incomplete regulatory readiness
- Adds descriptor-only canonical events for onboarding derivation, review-required, blocked, restriction-detected, and redaction states
- Adds architecture documentation for Institution Onboarding Readiness v1

## Guardrails
- Confirms `manualReviewRequired: true`
- Confirms `externalOnboardingEnabled: false`
- Confirms `autonomousApprovalEnabled: false`
- Confirms no live institution integrations, regulator/lender/insurer APIs, onboarding submission, autonomous onboarding, public onboarding portal, public institutional directory, legal certification, or external execution was added
- Confirms raw government IDs, screening/credit payloads, payment account details, private tenant documents, tenant communications, external onboarding payloads, and admin-only data are excluded from landlord onboarding responses

## Verification
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && pnpm exec vitest run src/lib/institutionOnboarding/__tests__/deriveInstitutionOnboardingReadiness.test.ts src/routes/__tests__/landlordInstitutionOnboardingRoutes.test.ts`
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 && pnpm exec vitest run src/components/onboarding/InstitutionOnboardingPanel.test.tsx src/components/trust/CrossOrganizationTrustPanel.test.tsx src/pages/InstitutionOnboardingReadinessPage.test.tsx src/pages/CrossOrganizationTrustPage.test.tsx src/App.routes.test.tsx`
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && pnpm build`
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 && pnpm build`
- `git diff --check`
- `git diff --cached --check`
- dependency/lockfile diff: empty
- forbidden runtime-label scan: clean