### PR TITLE
feat: add operational risk layer

### DIFF
--- a/docs/architecture/operational-risk-layer-v1.md
+++ b/docs/architecture/operational-risk-layer-v1.md
@@ -1,0 +1,69 @@
+# Operational Risk Layer v1
+
+## Purpose
+
+The Operational Risk Layer provides deterministic, read-only visibility into operational readiness and exposure across review, evidence, settlement, regulatory, onboarding, trust, workflow, delinquency, and audit systems.
+
+This layer is an operational review surface only. It is not an underwriting system, credit score, legal adjudication engine, financial adjudication engine, enforcement system, or public risk product.
+
+## Read Model
+
+Operational risk profiles are derived from existing RentChain systems:
+
+- Evidence Packs
+- Operator Review Sessions
+- Settlement Rail Readiness
+- Regulatory Profiles
+- Institution Onboarding Readiness
+- Cross-Organization Trust
+- Automated Workflow previews
+- Delinquency signals
+- Canonical audit events
+
+The v1 model keeps required safety flags fixed:
+
+- `manualReviewRequired: true`
+- `autonomousRiskActionsEnabled: false`
+- `publicRiskExposureEnabled: false`
+
+## Deterministic Rules
+
+Risk status is derived from explicit reference states:
+
+- `stable`: required lineage is present and verified
+- `attention_required`: partial or unavailable operational references exist
+- `elevated`: multiple unresolved or elevated restrictions exist
+- `blocked`: critical blocked operational lineage exists
+- `unknown`: source context is unavailable
+
+No AI scoring, probabilistic ranking, credit scoring, underwriting logic, legal conclusion, or financial adjudication is used.
+
+## Canonical Event Descriptors
+
+The layer emits descriptor-only canonical event metadata:
+
+- `operational_risk_profile_derived`
+- `operational_risk_restriction_detected`
+- `operational_risk_review_required`
+- `operational_risk_blocked`
+- `operational_risk_redaction_applied`
+
+These are additive review descriptors only and do not trigger workflow execution.
+
+## Guardrails
+
+The layer does not:
+
+- perform underwriting
+- create credit scores
+- adjudicate legal or financial outcomes
+- perform autonomous enforcement
+- trigger penalties
+- expose public risk scores
+- integrate with institutions
+- mutate source records
+- expose raw identity, screening, credit, payment account, private document, admin-only, or unrestricted audit payloads
+
+## Extension Guidance
+
+Future missions should extend this layer by adding deterministic references to existing review/evidence/readiness systems. New sources must preserve permission checks, redaction boundaries, manual review requirements, and read-only behavior.

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -134,6 +134,7 @@ import landlordAssetTokenizationReadinessRoutes from "./routes/landlordAssetToke
 import landlordNetworkParticipantRoutes from "./routes/landlordNetworkParticipantRoutes";
 import landlordCrossOrganizationTrustRoutes from "./routes/landlordCrossOrganizationTrustRoutes";
 import landlordInstitutionOnboardingRoutes from "./routes/landlordInstitutionOnboardingRoutes";
+import landlordOperationalRiskRoutes from "./routes/landlordOperationalRiskRoutes";
 import publicPortfolioScoreRoutes from "./routes/publicPortfolioScoreRoutes";
 import publicTenantShareRoutes from "./routes/publicTenantShareRoutes";
 import landlordActionRecommendationRoutes from "./routes/landlordActionRecommendationRoutes";
@@ -325,6 +326,8 @@ app.use("/api/landlord", routeSource("landlordCrossOrganizationTrustRoutes.ts"),
 console.log("[route-mount] landlordCrossOrganizationTrustRoutes mounted at /api/landlord");
 app.use("/api/landlord", routeSource("landlordInstitutionOnboardingRoutes.ts"), landlordInstitutionOnboardingRoutes);
 console.log("[route-mount] landlordInstitutionOnboardingRoutes mounted at /api/landlord");
+app.use("/api/landlord", routeSource("landlordOperationalRiskRoutes.ts"), landlordOperationalRiskRoutes);
+console.log("[route-mount] landlordOperationalRiskRoutes mounted at /api/landlord");
 app.use("/api", routeSource("landlordActionRecommendationRoutes.ts"), landlordActionRecommendationRoutes);
 console.log("[route-mount] landlordActionRecommendationRoutes mounted at /api");
 app.use("/api", routeSource("tenantFeedbackRoutes.ts"), tenantFeedbackRoutes);

--- a/rentchain-api/src/lib/operationalRisk/__tests__/deriveOperationalRiskProfile.test.ts
+++ b/rentchain-api/src/lib/operationalRisk/__tests__/deriveOperationalRiskProfile.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { deriveOperationalRiskProfile } from "../deriveOperationalRiskProfile";
+
+describe("deriveOperationalRiskProfile", () => {
+  it("derives deterministic operational risk with required safety flags", () => {
+    const profile = deriveOperationalRiskProfile({
+      landlordId: "landlord-1",
+      riskScope: "institution",
+      generatedAt: "2026-01-01T00:00:00.000Z",
+      evidencePacks: [{ evidencePackId: "evidence-1", status: "ready_for_review", sensitiveTenantPayload: "private" }],
+      operatorReviewSessions: [{ reviewSessionId: "review-1", status: "completed" }],
+      settlementReadiness: { settlementReadinessId: "settlement-1", status: "ready_for_review" },
+      regulatoryProfiles: [{ regulatoryProfileId: "regulatory-1", status: "ready_for_review" }],
+      institutionOnboardingReadiness: [{ onboardingReadinessId: "onboarding-1", status: "ready_for_review" }],
+      trustRelationships: [{ trustRelationshipId: "trust-1", status: "verified" }],
+      automatedWorkflows: [{ automationId: "workflow-1", decisionId: "decision-1", status: "derived" }],
+      auditEvents: [{ eventId: "event-1", eventType: "operator_review_session_closed" }],
+    });
+
+    expect(profile).toEqual(
+      expect.objectContaining({
+        operationalRiskId: "operational_risk:landlord-1:institution",
+        status: "stable",
+        manualReviewRequired: true,
+        autonomousRiskActionsEnabled: false,
+        publicRiskExposureEnabled: false,
+      })
+    );
+    expect(profile.canonicalEvents.map((event) => event.eventType)).toContain("operational_risk_profile_derived");
+    expect(JSON.stringify(profile)).not.toContain("sensitiveTenantPayload");
+    expect(JSON.stringify(profile)).not.toContain("sensitive-id");
+  });
+
+  it("surfaces blocked and elevated risk references without scoring or enforcement", () => {
+    const profile = deriveOperationalRiskProfile({
+      landlordId: "landlord-1",
+      riskScope: "settlement",
+      evidencePacks: [{ evidencePackId: "evidence-1", status: "blocked" }],
+      operatorReviewSessions: [{ reviewSessionId: "review-1", status: "open" }],
+      settlementReadiness: { settlementReadinessId: "settlement-1", status: "blocked" },
+      regulatoryProfiles: [{ regulatoryProfileId: "regulatory-1", status: "partially_ready" }],
+      institutionOnboardingReadiness: [{ onboardingReadinessId: "onboarding-1", status: "blocked" }],
+      trustRelationships: [{ trustRelationshipId: "trust-1", status: "blocked" }],
+      automatedWorkflows: [{ automationId: "workflow-1", decisionId: "decision-1", status: "blocked", blockedReasons: ["missing_review"] }],
+      delinquencySignals: [{ signalId: "signal-1", severity: "critical" }],
+    });
+
+    expect(profile.status).toBe("blocked");
+    expect(profile.summary.criticalSeverityReferences).toBeGreaterThan(0);
+    expect(profile.blockedReasons.length).toBeGreaterThan(0);
+    expect(profile.canonicalEvents.map((event) => event.eventType)).toContain("operational_risk_blocked");
+    expect(profile).toEqual(expect.objectContaining({ autonomousRiskActionsEnabled: false, publicRiskExposureEnabled: false }));
+  });
+
+  it("returns unknown when source context is unavailable", () => {
+    const profile = deriveOperationalRiskProfile({ landlordId: "landlord-1", riskScope: "workflow" });
+
+    expect(profile.status).toBe("unknown");
+    expect(profile.manualReviewRequired).toBe(true);
+    expect(profile.autonomousRiskActionsEnabled).toBe(false);
+    expect(profile.publicRiskExposureEnabled).toBe(false);
+  });
+});

--- a/rentchain-api/src/lib/operationalRisk/deriveOperationalRiskProfile.ts
+++ b/rentchain-api/src/lib/operationalRisk/deriveOperationalRiskProfile.ts
@@ -1,0 +1,446 @@
+import type {
+  DeriveOperationalRiskProfileInput,
+  OperationalRiskCanonicalEvent,
+  OperationalRiskProfile,
+  OperationalRiskReference,
+  OperationalRiskScope,
+  OperationalRiskSeverity,
+  OperationalRiskStatus,
+} from "./operationalRiskTypes";
+import { operationalRiskIdPart, riskReference } from "./riskRestrictionModels";
+
+const RISK_SCOPES = new Set<OperationalRiskScope>(["property", "lease", "participant", "institution", "workflow", "onboarding", "settlement", "regulatory"]);
+
+const REDACTIONS = [
+  "Sensitive tenant identity, screening, credit, payment account, and private document payloads are excluded.",
+  "Operational risk references are deterministic metadata, not underwriting, credit, legal, or financial adjudication.",
+  "Public risk exposure and autonomous enforcement are not enabled.",
+  "Admin-only records and unrestricted audit histories are not included in landlord operational risk views.",
+];
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function asArray<T>(value: T[] | null | undefined): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function generatedAt(value: unknown): string {
+  const raw = asString(value, 120);
+  const date = raw ? new Date(raw) : new Date(0);
+  return Number.isNaN(date.getTime()) ? new Date(0).toISOString() : date.toISOString();
+}
+
+function normalizeRiskScope(value: unknown): OperationalRiskScope {
+  const raw = asString(value, 80) as OperationalRiskScope;
+  return RISK_SCOPES.has(raw) ? raw : "institution";
+}
+
+function recordId(record: Record<string, any>, keys: string[]): string {
+  for (const key of keys) {
+    const value = asString(record?.[key], 240);
+    if (value) return value;
+  }
+  return asString(record?.id, 240);
+}
+
+function severityRank(severity: OperationalRiskSeverity): number {
+  if (severity === "critical") return 4;
+  if (severity === "elevated") return 3;
+  if (severity === "moderate") return 2;
+  return 1;
+}
+
+function statusFromReferences(hasContext: boolean, references: OperationalRiskReference[]): OperationalRiskStatus {
+  if (!hasContext) return "unknown";
+  if (references.some((reference) => reference.status === "blocked" && reference.severity === "critical")) return "blocked";
+  const elevatedCount = references.filter((reference) => reference.status !== "verified" && severityRank(reference.severity) >= 3).length;
+  const moderateCount = references.filter((reference) => reference.status !== "verified" && severityRank(reference.severity) >= 2).length;
+  if (elevatedCount >= 2 || references.some((reference) => reference.status === "blocked")) return "elevated";
+  if (moderateCount > 0 || references.some((reference) => reference.status === "unavailable" || reference.status === "partially_verified")) return "attention_required";
+  return "stable";
+}
+
+function event(input: {
+  eventType: OperationalRiskCanonicalEvent["eventType"];
+  status: OperationalRiskStatus;
+  operationalRiskId: string;
+  summary: string;
+}): OperationalRiskCanonicalEvent {
+  return {
+    eventType: input.eventType,
+    action: input.eventType.replace(/^operational_risk_/, "").replace(/_/g, "."),
+    status: input.status,
+    resourceType: "operational_risk",
+    resourceId: input.operationalRiskId,
+    summary: input.summary,
+  };
+}
+
+function readyBlockedStatus(record: Record<string, any>, readyStatuses: string[]): OperationalRiskReference["status"] {
+  const status = asString(record?.status, 80);
+  if (status === "blocked") return "blocked";
+  if (readyStatuses.includes(status)) return "verified";
+  if (status === "unknown") return "unavailable";
+  return "partially_verified";
+}
+
+function severityForStatus(status: OperationalRiskReference["status"], fallback: OperationalRiskSeverity): OperationalRiskSeverity {
+  if (status === "blocked") return "critical";
+  if (status === "unavailable") return fallback === "critical" ? "elevated" : fallback;
+  return fallback;
+}
+
+export function deriveOperationalRiskProfile(input: DeriveOperationalRiskProfileInput): OperationalRiskProfile {
+  const landlordId = asString(input.landlordId, 240);
+  const riskScope = normalizeRiskScope(input.riskScope);
+  const operationalRiskId =
+    operationalRiskIdPart(["operational_risk", landlordId || "unknown", riskScope].join(":")) || "operational_risk:unknown";
+
+  const evidencePacks = asArray(input.evidencePacks);
+  const reviews = asArray(input.operatorReviewSessions);
+  const regulatoryProfiles = asArray(input.regulatoryProfiles);
+  const onboardingReadiness = asArray(input.institutionOnboardingReadiness);
+  const trustRelationships = asArray(input.trustRelationships);
+  const automatedWorkflows = asArray(input.automatedWorkflows);
+  const delinquencySignals = asArray(input.delinquencySignals);
+  const auditEvents = asArray(input.auditEvents);
+  const settlementReadiness = input.settlementReadiness || null;
+
+  const evidenceReferences = evidencePacks.length
+    ? evidencePacks.map((pack) => {
+        const status = readyBlockedStatus(pack, ["ready_for_review"]);
+        return riskReference({
+          idParts: ["evidence", recordId(pack, ["evidencePackId", "id"]) || "unknown"],
+          riskType: "evidence_gap",
+          status,
+          severity: severityForStatus(status, "moderate"),
+          label: "Evidence gap visibility",
+          description: "Evidence pack lineage is available for operational risk review.",
+          lineageReferences: [recordId(pack, ["evidencePackId", "id"])].filter(Boolean),
+          destination: "/evidence-packs",
+          blockedReason: status === "blocked" ? "Evidence lineage is blocked." : null,
+        });
+      })
+    : [
+        riskReference({
+          idParts: ["evidence", "missing"],
+          riskType: "evidence_gap",
+          status: "unavailable",
+          severity: "moderate",
+          label: "Evidence gap visibility",
+          description: "Evidence pack lineage is unavailable for operational risk review.",
+          destination: "/evidence-packs",
+        }),
+      ];
+
+  const reviewReferences = reviews.length
+    ? reviews.map((review) => {
+        const status = review.status === "completed" ? "verified" : review.status === "blocked" ? "blocked" : "partially_verified";
+        return riskReference({
+          idParts: ["review", recordId(review, ["reviewSessionId", "id"]) || "unknown"],
+          riskType: "review_gap",
+          status,
+          severity: severityForStatus(status, "moderate"),
+          label: "Review gap visibility",
+          description: "Operator review lineage is available for operational risk review.",
+          lineageReferences: [recordId(review, ["reviewSessionId", "id"])].filter(Boolean),
+          destination: "/review-timeline",
+          blockedReason: status === "blocked" ? "Operator review lineage is blocked." : null,
+        });
+      })
+    : [
+        riskReference({
+          idParts: ["review", "missing"],
+          riskType: "review_gap",
+          status: "unavailable",
+          severity: "moderate",
+          label: "Review gap visibility",
+          description: "Operator review lineage is unavailable for operational risk review.",
+          destination: "/review-timeline",
+        }),
+      ];
+
+  const settlementReferences = settlementReadiness
+    ? [
+        riskReference({
+          idParts: ["settlement", recordId(settlementReadiness, ["settlementReadinessId", "id"]) || "unknown"],
+          riskType: "settlement_inconsistency",
+          status: readyBlockedStatus(settlementReadiness, ["ready_for_review"]),
+          severity: severityForStatus(readyBlockedStatus(settlementReadiness, ["ready_for_review"]), "elevated"),
+          label: "Settlement inconsistency visibility",
+          description: "Settlement readiness lineage is available for operational risk review.",
+          lineageReferences: [recordId(settlementReadiness, ["settlementReadinessId", "id"])].filter(Boolean),
+          destination: "/settlement-readiness",
+          blockedReason: settlementReadiness.status === "blocked" ? "Settlement readiness is blocked." : null,
+        }),
+      ]
+    : [
+        riskReference({
+          idParts: ["settlement", "missing"],
+          riskType: "settlement_inconsistency",
+          status: "unavailable",
+          severity: "elevated",
+          label: "Settlement inconsistency visibility",
+          description: "Settlement readiness lineage is unavailable for operational risk review.",
+          destination: "/settlement-readiness",
+        }),
+      ];
+
+  const regulatoryReferences = regulatoryProfiles.length
+    ? regulatoryProfiles.map((profile) => {
+        const status = readyBlockedStatus(profile, ["ready_for_review"]);
+        return riskReference({
+          idParts: ["regulatory", recordId(profile, ["regulatoryProfileId", "id"]) || "unknown"],
+          riskType: "regulatory_restriction",
+          status,
+          severity: severityForStatus(status, "elevated"),
+          label: "Regulatory restriction visibility",
+          description: "Regulatory readiness lineage is available for operational risk review.",
+          lineageReferences: [recordId(profile, ["regulatoryProfileId", "id"])].filter(Boolean),
+          destination: "/regulatory-profiles",
+          blockedReason: status === "blocked" ? "Regulatory readiness is blocked." : null,
+        });
+      })
+    : [
+        riskReference({
+          idParts: ["regulatory", "missing"],
+          riskType: "regulatory_restriction",
+          status: "unavailable",
+          severity: "elevated",
+          label: "Regulatory restriction visibility",
+          description: "Regulatory readiness lineage is unavailable for operational risk review.",
+          destination: "/regulatory-profiles",
+        }),
+      ];
+
+  const onboardingReferences = onboardingReadiness.length
+    ? onboardingReadiness.map((readiness) => {
+        const status = readiness.status === "ready_for_review" ? "verified" : readiness.status === "blocked" ? "blocked" : "partially_verified";
+        return riskReference({
+          idParts: ["onboarding", recordId(readiness, ["onboardingReadinessId", "id"]) || "unknown"],
+          riskType: "onboarding_blocker",
+          status,
+          severity: severityForStatus(status, "elevated"),
+          label: "Onboarding blocker visibility",
+          description: "Institution onboarding readiness is available for operational risk review.",
+          lineageReferences: [recordId(readiness, ["onboardingReadinessId", "id"])].filter(Boolean),
+          destination: "/institution-onboarding-readiness",
+          blockedReason: status === "blocked" ? "Institution onboarding readiness is blocked." : null,
+        });
+      })
+    : [
+        riskReference({
+          idParts: ["onboarding", "missing"],
+          riskType: "onboarding_blocker",
+          status: "unavailable",
+          severity: "elevated",
+          label: "Onboarding blocker visibility",
+          description: "Institution onboarding readiness is unavailable for operational risk review.",
+          destination: "/institution-onboarding-readiness",
+        }),
+      ];
+
+  const trustReferences = trustRelationships.length
+    ? trustRelationships.map((trust) => {
+        const status = trust.status === "verified" ? "verified" : trust.status === "blocked" ? "blocked" : "partially_verified";
+        return riskReference({
+          idParts: ["trust", recordId(trust, ["trustRelationshipId", "id"]) || "unknown"],
+          riskType: "trust_restriction",
+          status,
+          severity: severityForStatus(status, "elevated"),
+          label: "Trust restriction visibility",
+          description: "Cross-organization trust lineage is available for operational risk review.",
+          lineageReferences: [recordId(trust, ["trustRelationshipId", "id"])].filter(Boolean),
+          destination: "/cross-organization-trust",
+          blockedReason: status === "blocked" ? "Cross-organization trust is blocked." : null,
+        });
+      })
+    : [
+        riskReference({
+          idParts: ["trust", "missing"],
+          riskType: "trust_restriction",
+          status: "unavailable",
+          severity: "elevated",
+          label: "Trust restriction visibility",
+          description: "Cross-organization trust lineage is unavailable for operational risk review.",
+          destination: "/cross-organization-trust",
+        }),
+      ];
+
+  const workflowReferences = automatedWorkflows.length
+    ? automatedWorkflows.map((workflow) => {
+        const status = workflow.status === "completed" || workflow.status === "derived" ? "verified" : workflow.status === "blocked" ? "blocked" : "partially_verified";
+        return riskReference({
+          idParts: ["workflow", recordId(workflow, ["automationId", "decisionId", "id"]) || "unknown"],
+          riskType: "workflow_instability",
+          status,
+          severity: status === "blocked" ? "critical" : workflow.escalationLevel === "critical" ? "elevated" : "moderate",
+          label: "Workflow instability visibility",
+          description: "Workflow orchestration preview metadata is available for operational risk review.",
+          lineageReferences: [recordId(workflow, ["automationId", "decisionId", "id"])].filter(Boolean),
+          destination: "/decision-inbox",
+          blockedReason: status === "blocked" ? asArray(workflow.blockedReasons).join("; ") || "Workflow preview is blocked." : null,
+        });
+      })
+    : [
+        riskReference({
+          idParts: ["workflow", "missing"],
+          riskType: "workflow_instability",
+          status: "unavailable",
+          severity: "moderate",
+          label: "Workflow instability visibility",
+          description: "Workflow orchestration preview metadata is unavailable for operational risk review.",
+          destination: "/decision-inbox",
+        }),
+      ];
+
+  const delinquencyReferences = delinquencySignals.length
+    ? delinquencySignals.slice(0, 12).map((signal) =>
+        riskReference({
+          idParts: ["delinquency", recordId(signal, ["signalId", "id"]) || "unknown"],
+          riskType: "delinquency_exposure",
+          status: "partially_verified",
+          severity: signal.severity === "critical" ? "elevated" : signal.severity === "warning" ? "moderate" : "low",
+          label: "Delinquency exposure visibility",
+          description: "Delinquency signal metadata is available for operational risk review without enforcement behavior.",
+          lineageReferences: [recordId(signal, ["signalId", "leaseId", "id"])].filter(Boolean),
+          destination: "/decision-inbox?queue=delinquency_review",
+          blockedReason: null,
+        })
+      )
+    : [];
+
+  const auditReferences = auditEvents.length
+    ? auditEvents.slice(0, 12).map((record) =>
+        riskReference({
+          idParts: ["audit", recordId(record, ["eventId", "id"]) || "unknown"],
+          riskType: "audit_gap",
+          status: record.redacted ? "partially_verified" : "verified",
+          severity: record.redacted ? "low" : "low",
+          label: "Audit gap visibility",
+          description: "Canonical audit event metadata is available for operational risk review.",
+          lineageReferences: [recordId(record, ["eventId", "id"])].filter(Boolean),
+          destination: "/review-timeline",
+          redacted: Boolean(record.redacted),
+          redactionReason: record.redacted ? "Audit payload is redacted for operational risk safety." : null,
+        })
+      )
+    : [
+        riskReference({
+          idParts: ["audit", "missing"],
+          riskType: "audit_gap",
+          status: "unavailable",
+          severity: "moderate",
+          label: "Audit gap visibility",
+          description: "Canonical audit event lineage is unavailable for operational risk review.",
+          destination: "/review-timeline",
+        }),
+      ];
+
+  const allReferences = [
+    ...evidenceReferences,
+    ...reviewReferences,
+    ...settlementReferences,
+    ...regulatoryReferences,
+    ...onboardingReferences,
+    ...trustReferences,
+    ...workflowReferences,
+    ...delinquencyReferences,
+    ...auditReferences,
+  ];
+  const hasContext = Boolean(
+    landlordId &&
+      (evidencePacks.length ||
+        reviews.length ||
+        settlementReadiness ||
+        regulatoryProfiles.length ||
+        onboardingReadiness.length ||
+        trustRelationships.length ||
+        automatedWorkflows.length ||
+        delinquencySignals.length ||
+        auditEvents.length)
+  );
+  const status = statusFromReferences(hasContext, allReferences);
+  const blockedReasons = allReferences.map((reference) => reference.blockedReason).filter(Boolean) as string[];
+
+  const canonicalEvents: OperationalRiskCanonicalEvent[] = [
+    event({
+      eventType: "operational_risk_profile_derived",
+      status,
+      operationalRiskId,
+      summary: "Operational risk profile derived from review, evidence, settlement, regulatory, onboarding, trust, workflow, delinquency, and audit metadata.",
+    }),
+    event({
+      eventType: "operational_risk_redaction_applied",
+      status,
+      operationalRiskId,
+      summary: "Sensitive identity, screening, credit, payment, private document, admin-only, and unrestricted audit payloads were excluded.",
+    }),
+  ];
+  if (allReferences.some((reference) => reference.status !== "verified")) {
+    canonicalEvents.push(
+      event({
+        eventType: "operational_risk_restriction_detected",
+        status,
+        operationalRiskId,
+        summary: "Operational risk restrictions are visible for manual review.",
+      })
+    );
+  }
+  if (status === "attention_required" || status === "elevated") {
+    canonicalEvents.push(
+      event({
+        eventType: "operational_risk_review_required",
+        status,
+        operationalRiskId,
+        summary: "Manual operational risk review is required.",
+      })
+    );
+  }
+  if (status === "blocked") {
+    canonicalEvents.push(
+      event({
+        eventType: "operational_risk_blocked",
+        status,
+        operationalRiskId,
+        summary: "Operational risk visibility is blocked by critical readiness or lineage restrictions.",
+      })
+    );
+  }
+
+  return {
+    operationalRiskId,
+    riskScope,
+    status,
+    manualReviewRequired: true,
+    autonomousRiskActionsEnabled: false,
+    publicRiskExposureEnabled: false,
+    generatedAt: generatedAt(input.generatedAt),
+    summary: {
+      totalReferences: allReferences.length,
+      verifiedReferences: allReferences.filter((reference) => reference.status === "verified").length,
+      partiallyVerifiedReferences: allReferences.filter((reference) => reference.status === "partially_verified").length,
+      blockedReferences: allReferences.filter((reference) => reference.status === "blocked").length,
+      unavailableReferences: allReferences.filter((reference) => reference.status === "unavailable").length,
+      lowSeverityReferences: allReferences.filter((reference) => reference.severity === "low").length,
+      moderateSeverityReferences: allReferences.filter((reference) => reference.severity === "moderate").length,
+      elevatedSeverityReferences: allReferences.filter((reference) => reference.severity === "elevated").length,
+      criticalSeverityReferences: allReferences.filter((reference) => reference.severity === "critical").length,
+    },
+    riskReferences: allReferences,
+    evidenceReferences,
+    reviewReferences,
+    settlementReferences,
+    regulatoryReferences,
+    onboardingReferences,
+    trustReferences,
+    workflowReferences,
+    delinquencyReferences,
+    auditReferences,
+    redactions: REDACTIONS,
+    blockedReasons,
+    canonicalEvents,
+  };
+}

--- a/rentchain-api/src/lib/operationalRisk/operationalRiskTypes.ts
+++ b/rentchain-api/src/lib/operationalRisk/operationalRiskTypes.ts
@@ -1,0 +1,98 @@
+export type OperationalRiskScope = "property" | "lease" | "participant" | "institution" | "workflow" | "onboarding" | "settlement" | "regulatory";
+
+export type OperationalRiskStatus = "stable" | "attention_required" | "elevated" | "blocked" | "unknown";
+
+export type OperationalRiskType =
+  | "review_gap"
+  | "evidence_gap"
+  | "settlement_inconsistency"
+  | "workflow_instability"
+  | "delinquency_exposure"
+  | "onboarding_blocker"
+  | "regulatory_restriction"
+  | "audit_gap"
+  | "trust_restriction";
+
+export type OperationalRiskReferenceStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+
+export type OperationalRiskSeverity = "low" | "moderate" | "elevated" | "critical";
+
+export type OperationalRiskCanonicalEventType =
+  | "operational_risk_profile_derived"
+  | "operational_risk_restriction_detected"
+  | "operational_risk_review_required"
+  | "operational_risk_blocked"
+  | "operational_risk_redaction_applied";
+
+export type OperationalRiskReference = {
+  riskReferenceId: string;
+  riskType: OperationalRiskType;
+  status: OperationalRiskReferenceStatus;
+  severity: OperationalRiskSeverity;
+  label: string;
+  description: string;
+  reviewRequired: true;
+  lineageReferences: string[];
+  destination: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type OperationalRiskCanonicalEvent = {
+  eventType: OperationalRiskCanonicalEventType;
+  action: string;
+  status: OperationalRiskStatus;
+  resourceType: "operational_risk";
+  resourceId: string;
+  summary: string;
+};
+
+export type OperationalRiskProfile = {
+  operationalRiskId: string;
+  riskScope: OperationalRiskScope;
+  status: OperationalRiskStatus;
+  manualReviewRequired: true;
+  autonomousRiskActionsEnabled: false;
+  publicRiskExposureEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    partiallyVerifiedReferences: number;
+    blockedReferences: number;
+    unavailableReferences: number;
+    lowSeverityReferences: number;
+    moderateSeverityReferences: number;
+    elevatedSeverityReferences: number;
+    criticalSeverityReferences: number;
+  };
+  riskReferences: OperationalRiskReference[];
+  evidenceReferences: OperationalRiskReference[];
+  reviewReferences: OperationalRiskReference[];
+  settlementReferences: OperationalRiskReference[];
+  regulatoryReferences: OperationalRiskReference[];
+  onboardingReferences: OperationalRiskReference[];
+  trustReferences: OperationalRiskReference[];
+  workflowReferences: OperationalRiskReference[];
+  delinquencyReferences: OperationalRiskReference[];
+  auditReferences: OperationalRiskReference[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: OperationalRiskCanonicalEvent[];
+};
+
+export type DeriveOperationalRiskProfileInput = {
+  landlordId?: unknown;
+  riskScope?: unknown;
+  generatedAt?: unknown;
+  evidencePacks?: Array<Record<string, any>> | null;
+  operatorReviewSessions?: Array<Record<string, any>> | null;
+  settlementReadiness?: Record<string, any> | null;
+  regulatoryProfiles?: Array<Record<string, any>> | null;
+  institutionOnboardingReadiness?: Array<Record<string, any>> | null;
+  trustRelationships?: Array<Record<string, any>> | null;
+  automatedWorkflows?: Array<Record<string, any>> | null;
+  delinquencySignals?: Array<Record<string, any>> | null;
+  auditEvents?: Array<Record<string, any>> | null;
+};

--- a/rentchain-api/src/lib/operationalRisk/riskRestrictionModels.ts
+++ b/rentchain-api/src/lib/operationalRisk/riskRestrictionModels.ts
@@ -1,0 +1,47 @@
+import type {
+  OperationalRiskReference,
+  OperationalRiskReferenceStatus,
+  OperationalRiskSeverity,
+  OperationalRiskType,
+} from "./operationalRiskTypes";
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+export function operationalRiskIdPart(value: unknown): string {
+  return asString(value, 500)
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+export function riskReference(input: {
+  idParts: unknown[];
+  riskType: OperationalRiskType;
+  status: OperationalRiskReferenceStatus;
+  severity: OperationalRiskSeverity;
+  label: string;
+  description: string;
+  lineageReferences?: string[];
+  destination?: string | null;
+  redacted?: boolean;
+  redactionReason?: string | null;
+  blockedReason?: string | null;
+}): OperationalRiskReference {
+  return {
+    riskReferenceId: operationalRiskIdPart(input.idParts.join(":")) || "operational_risk_reference:unknown",
+    riskType: input.riskType,
+    status: input.status,
+    severity: input.severity,
+    label: input.label,
+    description: input.description,
+    reviewRequired: true,
+    lineageReferences: Array.from(new Set(input.lineageReferences || [])).filter(Boolean),
+    destination: input.destination || null,
+    redacted: Boolean(input.redacted),
+    redactionReason: input.redactionReason || null,
+    blockedReason: input.blockedReason || null,
+  };
+}

--- a/rentchain-api/src/routes/__tests__/landlordOperationalRiskRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordOperationalRiskRoutes.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+  function matches(doc: any, filters: Array<{ field: string; op: string; value: any }>) {
+    return filters.every(({ field, op, value }) => (op === "==" ? doc?.data?.[field] === value : false));
+  }
+  function makeQuery(name: string, filters: Array<{ field: string; op: string; value: any }> = []) {
+    return {
+      where: (field: string, op: string, value: any) => makeQuery(name, [...filters, { field, op, value }]),
+      get: async () => {
+        const docs = Array.from(ensureCollection(name).values())
+          .filter((doc) => matches(doc, filters))
+          .map((doc) => ({ id: doc.id, exists: true, data: () => doc.data }));
+        return { docs, empty: docs.length === 0, size: docs.length };
+      },
+      doc: (id: string) => makeDoc(name, id),
+    };
+  }
+  function makeDoc(name: string, id: string) {
+    const col = ensureCollection(name);
+    return {
+      id,
+      get: async () => {
+        const entry = col.get(id);
+        return { id, exists: Boolean(entry), data: () => entry?.data };
+      },
+      set: async (data: any) => {
+        col.set(id, { id, data });
+      },
+    };
+  }
+  return {
+    resetFakeDb: () => store.clear(),
+    seedDoc: (collection: string, id: string, data: any) => ensureCollection(collection).set(id, { id, data }),
+    fakeDb: {
+      collection: (name: string) => ({
+        where: (field: string, op: string, value: any) => makeQuery(name, [{ field, op, value }]),
+        get: async () => makeQuery(name).get(),
+        doc: (id: string) => makeDoc(name, id),
+      }),
+    },
+  };
+});
+
+let mockUser: any;
+
+vi.mock("../../config/firebase", () => ({ db: fakeDb }));
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!mockUser) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    req.user = mockUser;
+    return next();
+  },
+}));
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: any, res: any, next: any) => {
+    const role = String(req.user?.role || "").trim().toLowerCase();
+    const landlordId = req.user?.landlordId || req.user?.id;
+    if (role !== "landlord" && role !== "admin") return res.status(403).json({ ok: false, error: "Forbidden" });
+    req.user.landlordId = landlordId;
+    return next();
+  },
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; user?: Record<string, unknown> | null }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    mockUser = options.user ?? mockUser;
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: mockUser,
+      query: Object.fromEntries(new URLSearchParams(queryString || "").entries()),
+      params: {},
+      body: {},
+      headers: {},
+    };
+    const match = path.match(/^\/operational-risk\/(.+)$/);
+    if (match) req.params = { operationalRiskId: decodeURIComponent(match[1]) };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => (error ? reject(error) : undefined));
+  });
+}
+
+describe("landlordOperationalRiskRoutes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    resetFakeDb();
+    mockUser = { id: "landlord-1", landlordId: "landlord-1", role: "landlord" };
+  });
+
+  function seedRiskContext() {
+    seedDoc("properties", "property-1", { landlordId: "landlord-1", propertyId: "property-1", province: "NS", municipality: "Halifax" });
+    seedDoc("operatorReviewSessions", "review-1", { landlordId: "landlord-1", reviewSessionId: "review-1", status: "completed" });
+    seedDoc("evidencePacks", "evidence-1", { landlordId: "landlord-1", evidencePackId: "evidence-1", status: "ready_for_review", rawGovernmentId: "sensitive-id" });
+    seedDoc("institutionalSharingRooms", "room-1", {
+      landlordId: "landlord-1",
+      sharingRoomId: "room-1",
+      status: "active",
+      publiclyAccessible: false,
+      externalExecutionEnabled: false,
+      accessControls: { institutionType: "lender" },
+    });
+    seedDoc("events", "event-1", { landlordId: "landlord-1", eventId: "event-1", eventType: "operator_review_session_closed" });
+    seedDoc("consents", "consent-1", { landlordId: "landlord-1", consentScope: "operational_risk" });
+    seedDoc("decisionInboxItems", "decision-1", {
+      landlordId: "landlord-1",
+      id: "decision-1",
+      title: "Review delinquency context",
+      description: "Manual review",
+      severity: "medium",
+      workflow: { queue: "delinquency_review", workflowState: "new", escalationLevel: "none", reviewPriority: "standard", manualOnly: true },
+    });
+  }
+
+  it("returns landlord-scoped operational risk without sensitive payloads", async () => {
+    seedRiskContext();
+    const router = (await import("../landlordOperationalRiskRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/operational-risk?riskScope=institution" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.profiles).toHaveLength(1);
+    expect(res.body.profiles[0]).toEqual(
+      expect.objectContaining({ manualReviewRequired: true, autonomousRiskActionsEnabled: false, publicRiskExposureEnabled: false })
+    );
+    const serialized = JSON.stringify(res.body);
+    expect(serialized).not.toContain("sensitive-id");
+  });
+
+  it("returns a single operational risk profile by id", async () => {
+    seedRiskContext();
+    const router = (await import("../landlordOperationalRiskRoutes")).default;
+    const list = await invokeRouter(router, { method: "GET", url: "/operational-risk?riskScope=institution" });
+    const id = list.body.profiles[0].operationalRiskId;
+
+    const res = await invokeRouter(router, { method: "GET", url: `/operational-risk/${encodeURIComponent(id)}` });
+
+    expect(res.status).toBe(200);
+    expect(res.body.profile.operationalRiskId).toBe(id);
+  });
+
+  it("filters by status and blocks non-landlord users", async () => {
+    seedRiskContext();
+    const router = (await import("../landlordOperationalRiskRoutes")).default;
+
+    const filtered = await invokeRouter(router, { method: "GET", url: "/operational-risk?riskScope=institution&status=unknown" });
+    expect(filtered.status).toBe(200);
+    expect(filtered.body.profiles).toEqual([]);
+
+    const forbidden = await invokeRouter(router, { method: "GET", url: "/operational-risk", user: { id: "tenant-1", role: "tenant" } });
+    expect(forbidden.status).toBe(403);
+  });
+});

--- a/rentchain-api/src/routes/landlordOperationalRiskRoutes.ts
+++ b/rentchain-api/src/routes/landlordOperationalRiskRoutes.ts
@@ -1,0 +1,224 @@
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { requireAuth } from "../middleware/requireAuth";
+import { requireLandlord } from "../middleware/requireLandlord";
+import { deriveAutomatedWorkflowTransitions } from "../lib/automatedWorkflows/deriveAutomatedWorkflowTransitions";
+import { deriveCrossOrganizationTrust } from "../lib/crossOrganizationTrust/deriveCrossOrganizationTrust";
+import { deriveDelinquencySignals } from "../lib/payments/delinquencySignals";
+import { buildPaymentObligationLedgerRows } from "../lib/payments/paymentObligationLedger";
+import { deriveIdentityProfile } from "../lib/identityLayer/deriveIdentityProfile";
+import { deriveInstitutionOnboardingReadiness } from "../lib/institutionOnboarding/deriveInstitutionOnboardingReadiness";
+import { deriveNetworkParticipantProfile } from "../lib/networkParticipants/deriveNetworkParticipantProfile";
+import { deriveOperationalRiskProfile } from "../lib/operationalRisk/deriveOperationalRiskProfile";
+import { deriveRegulatoryProfile } from "../lib/regulatoryProfiles/deriveRegulatoryProfile";
+import { deriveSettlementReadiness } from "../lib/settlementReadiness/deriveSettlementReadiness";
+import type { CrossOrganizationTrustRelationshipType } from "../lib/crossOrganizationTrust/crossOrganizationTrustTypes";
+import type { InstitutionType } from "../lib/institutionOnboarding/institutionOnboardingTypes";
+import type { NetworkParticipantType } from "../lib/networkParticipants/networkParticipantTypes";
+import type { OperationalRiskScope, OperationalRiskSeverity, OperationalRiskStatus } from "../lib/operationalRisk/operationalRiskTypes";
+
+const router = Router();
+
+const RISK_SCOPES = new Set<OperationalRiskScope>(["property", "lease", "participant", "institution", "workflow", "onboarding", "settlement", "regulatory"]);
+const STATUSES = new Set<OperationalRiskStatus>(["stable", "attention_required", "elevated", "blocked", "unknown"]);
+const SEVERITIES = new Set<OperationalRiskSeverity>(["low", "moderate", "elevated", "critical"]);
+const INSTITUTION_TYPES: InstitutionType[] = ["lender", "insurer", "auditor", "regulator", "municipality", "institutional_landlord", "operational_partner"];
+const PARTICIPANT_TYPES: NetworkParticipantType[] = ["landlord", "operator", "lender", "insurer", "auditor", "regulator", "contractor", "institutional_partner", "review_actor"];
+const TRUST_TYPES: CrossOrganizationTrustRelationshipType[] = ["operational_trust", "evidence_trust", "review_trust", "settlement_trust", "regulatory_trust", "sharing_trust"];
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function landlordIdFromReq(req: any) {
+  return asString(req.user?.landlordId || req.user?.id || req.user?.sub, 240);
+}
+
+function normalizedRiskScope(value: unknown): OperationalRiskScope | "" {
+  const raw = asString(value, 80) as OperationalRiskScope;
+  return RISK_SCOPES.has(raw) ? raw : "";
+}
+
+function participantTypeForInstitution(type: InstitutionType): NetworkParticipantType {
+  if (type === "lender" || type === "insurer" || type === "auditor" || type === "regulator") return type;
+  if (type === "institutional_landlord") return "landlord";
+  return "institutional_partner";
+}
+
+async function loadLandlordCollection(collectionName: string, landlordId: string) {
+  const byId = new Map<string, any>();
+  async function collect(field: "landlordId" | "ownerId" | "userId" | "createdByLandlordId") {
+    const snap = await db.collection(collectionName).where(field, "==", landlordId).get().catch(() => null);
+    for (const doc of snap?.docs || []) byId.set(doc.id, { id: doc.id, ...((doc.data() as any) || {}) });
+  }
+  await Promise.all([collect("landlordId"), collect("ownerId"), collect("userId"), collect("createdByLandlordId")]);
+  return Array.from(byId.values()).filter((record) =>
+    [record?.landlordId, record?.ownerId, record?.userId, record?.createdByLandlordId].some((value) => asString(value, 240) === landlordId)
+  );
+}
+
+async function buildOperationalRiskProfiles(landlordId: string, riskScope: OperationalRiskScope | "") {
+  const [properties, registryStatuses, screeningOrders, consents, sharingRooms, evidencePacks, reviews, events, leases, paymentIntents, rentPayments, reconciliationRecords, contractors, decisions] =
+    await Promise.all([
+      loadLandlordCollection("properties", landlordId),
+      loadLandlordCollection("propertyRegistryStatuses", landlordId),
+      loadLandlordCollection("screeningOrders", landlordId),
+      loadLandlordCollection("consents", landlordId),
+      loadLandlordCollection("institutionalSharingRooms", landlordId),
+      loadLandlordCollection("evidencePacks", landlordId),
+      loadLandlordCollection("operatorReviewSessions", landlordId),
+      loadLandlordCollection("events", landlordId),
+      loadLandlordCollection("leases", landlordId),
+      loadLandlordCollection("paymentIntents", landlordId),
+      loadLandlordCollection("rentPayments", landlordId),
+      loadLandlordCollection("paymentReconciliationRecords", landlordId),
+      loadLandlordCollection("contractorProfiles", landlordId),
+      loadLandlordCollection("decisionInboxItems", landlordId),
+    ]);
+
+  const obligationRows = buildPaymentObligationLedgerRows({ leases, paymentIntents, rentPayments, reconciliationRecords });
+  const delinquencySignals = deriveDelinquencySignals(obligationRows);
+  const automatedWorkflows = deriveAutomatedWorkflowTransitions({ decisions: decisions as any[] }).workflows;
+  const settlementReadiness = deriveSettlementReadiness({
+    landlordId,
+    obligationRows,
+    reconciliationRecords,
+    evidencePacks,
+    operatorReviewSessions: reviews,
+    auditEvents: events,
+    decisions: decisions as any[],
+  });
+  const regulatoryProfile = deriveRegulatoryProfile({
+    landlordId,
+    properties,
+    registryStatuses,
+    screeningOrders,
+    consentRecords: consents,
+    sharingRooms,
+    institutionExportPackages: [],
+    evidencePacks,
+    operatorReviewSessions: reviews,
+    auditEvents: events,
+    settlementReadiness,
+  });
+
+  const identityProfiles = PARTICIPANT_TYPES.map((participantType) =>
+    deriveIdentityProfile({
+      identityType: participantType === "operator" || participantType === "review_actor" ? participantType : "organization",
+      identityId: participantType,
+      organization: { id: participantType, organizationId: participantType },
+      operator: reviews[0] || null,
+      consentRecords: consents,
+      reviewSessions: reviews,
+      canonicalEvents: events,
+    })
+  );
+
+  const networkParticipants = PARTICIPANT_TYPES.map((participantType, index) =>
+    deriveNetworkParticipantProfile({
+      landlordId,
+      participantType,
+      participantId: participantType,
+      identityProfiles: [identityProfiles[index]],
+      sharingRooms:
+        participantType === "lender" || participantType === "insurer" || participantType === "auditor" || participantType === "regulator"
+          ? sharingRooms.filter((room) => asString(room.accessControls?.institutionType || room.institutionType, 80) === participantType)
+          : sharingRooms,
+      operatorReviewSessions: reviews,
+      evidencePacks,
+      settlementReadiness,
+      regulatoryProfiles: [regulatoryProfile],
+      canonicalEvents: events,
+      contractorProfiles: participantType === "contractor" ? contractors : [],
+    })
+  );
+
+  const trustRelationships = TRUST_TYPES.map((relationshipType) =>
+    deriveCrossOrganizationTrust({
+      landlordId,
+      relationshipType,
+      networkParticipants,
+      evidencePacks,
+      operatorReviewSessions: reviews,
+      settlementReadiness,
+      regulatoryProfiles: [regulatoryProfile],
+      sharingRooms,
+      auditEvents: events,
+      consentRecords: consents,
+    })
+  );
+
+  const onboardingReadiness = INSTITUTION_TYPES.map((type) => {
+    const participantType = participantTypeForInstitution(type);
+    return deriveInstitutionOnboardingReadiness({
+      landlordId,
+      institutionType: type,
+      networkParticipants: networkParticipants.filter((participant) => participant.participantType === participantType),
+      trustRelationships,
+      identityProfiles: identityProfiles.filter((profile) => profile.identityId === participantType || profile.identityId === type),
+      evidencePacks,
+      operatorReviewSessions: reviews,
+      settlementReadiness,
+      regulatoryProfiles: [regulatoryProfile],
+      sharingRooms:
+        type === "lender" || type === "insurer" || type === "auditor" || type === "regulator"
+          ? sharingRooms.filter((room) => asString(room.accessControls?.institutionType || room.institutionType, 80) === type)
+          : sharingRooms,
+      auditEvents: events,
+      consentRecords: consents,
+    });
+  });
+
+  const scopes = riskScope ? [riskScope] : Array.from(RISK_SCOPES);
+  return scopes.map((scope) =>
+    deriveOperationalRiskProfile({
+      landlordId,
+      riskScope: scope,
+      evidencePacks,
+      operatorReviewSessions: reviews,
+      settlementReadiness,
+      regulatoryProfiles: [regulatoryProfile],
+      institutionOnboardingReadiness: onboardingReadiness,
+      trustRelationships,
+      automatedWorkflows,
+      delinquencySignals,
+      auditEvents: events,
+    })
+  );
+}
+
+router.get("/operational-risk", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = landlordIdFromReq(req);
+    if (!landlordId) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    const riskScope = normalizedRiskScope(req.query?.riskScope);
+    const status = asString(req.query?.status, 80) as OperationalRiskStatus;
+    const severity = asString(req.query?.severity, 80) as OperationalRiskSeverity;
+    let profiles = await buildOperationalRiskProfiles(landlordId, riskScope);
+    if (status && STATUSES.has(status)) profiles = profiles.filter((profile) => profile.status === status);
+    if (severity && SEVERITIES.has(severity)) {
+      profiles = profiles.filter((profile) => profile.riskReferences.some((reference) => reference.severity === severity));
+    }
+    return res.json({ ok: true, profiles });
+  } catch (err: any) {
+    console.error("[landlord-operational-risk] list failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "OPERATIONAL_RISK_FAILED" });
+  }
+});
+
+router.get("/operational-risk/:operationalRiskId", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = landlordIdFromReq(req);
+    const operationalRiskId = decodeURIComponent(asString(req.params?.operationalRiskId, 500));
+    if (!landlordId || !operationalRiskId) return res.status(400).json({ ok: false, error: "OPERATIONAL_RISK_ID_REQUIRED" });
+    const profiles = await buildOperationalRiskProfiles(landlordId, "");
+    const profile = profiles.find((next) => next.operationalRiskId === operationalRiskId);
+    if (!profile) return res.status(404).json({ ok: false, error: "OPERATIONAL_RISK_NOT_FOUND" });
+    return res.json({ ok: true, profile });
+  } catch (err: any) {
+    console.error("[landlord-operational-risk] get failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "OPERATIONAL_RISK_GET_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -154,6 +154,10 @@ vi.mock("./pages/InstitutionOnboardingReadinessPage", () => ({
   default: () => <h1>Institution Onboarding Readiness Page</h1>,
 }));
 
+vi.mock("./pages/OperationalRiskPage", () => ({
+  default: () => <h1>Operational Risk Page</h1>,
+}));
+
 vi.mock("./pages/landlord/PortfolioScorePage", () => ({
   default: () => <h1>Landlord Portfolio Score</h1>,
 }));
@@ -485,6 +489,20 @@ describe("Routes: /institution-onboarding-readiness", () => {
     );
 
     expect(await screen.findByText(/Institution Onboarding Readiness Page/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Routes: /operational-risk", () => {
+  it("renders the operational risk route", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/operational-risk?riskScope=institution"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Operational Risk Page/i)).toBeInTheDocument();
     expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -131,6 +131,7 @@ const AssetTokenizationReadinessPage = lazy(() => import("./pages/AssetTokenizat
 const NetworkParticipantsPage = lazy(() => import("./pages/NetworkParticipantsPage"));
 const CrossOrganizationTrustPage = lazy(() => import("./pages/CrossOrganizationTrustPage"));
 const InstitutionOnboardingReadinessPage = lazy(() => import("./pages/InstitutionOnboardingReadinessPage"));
+const OperationalRiskPage = lazy(() => import("./pages/OperationalRiskPage"));
 const LandlordPortfolioScorePage = lazy(() => import("./pages/landlord/PortfolioScorePage"));
 const SharedPortfolioScorePage = lazy(() => import("./pages/public/SharedPortfolioScorePage"));
 const TenantSharePackagePage = lazy(() => import("./pages/public/TenantSharePackagePage"));
@@ -694,6 +695,18 @@ function App() {
               <LandlordNav>
                 <Suspense fallback={null}>
                   <InstitutionOnboardingReadinessPage />
+                </Suspense>
+              </LandlordNav>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/operational-risk"
+          element={
+            <RequireAuth>
+              <LandlordNav>
+                <Suspense fallback={null}>
+                  <OperationalRiskPage />
                 </Suspense>
               </LandlordNav>
             </RequireAuth>

--- a/rentchain-frontend/src/api/operationalRiskApi.ts
+++ b/rentchain-frontend/src/api/operationalRiskApi.ts
@@ -1,0 +1,84 @@
+import { apiFetch } from "./apiFetch";
+
+export type OperationalRiskScope = "property" | "lease" | "participant" | "institution" | "workflow" | "onboarding" | "settlement" | "regulatory";
+export type OperationalRiskStatus = "stable" | "attention_required" | "elevated" | "blocked" | "unknown";
+export type OperationalRiskType =
+  | "review_gap"
+  | "evidence_gap"
+  | "settlement_inconsistency"
+  | "workflow_instability"
+  | "delinquency_exposure"
+  | "onboarding_blocker"
+  | "regulatory_restriction"
+  | "audit_gap"
+  | "trust_restriction";
+export type OperationalRiskReferenceStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+export type OperationalRiskSeverity = "low" | "moderate" | "elevated" | "critical";
+
+export type OperationalRiskReference = {
+  riskReferenceId: string;
+  riskType: OperationalRiskType;
+  status: OperationalRiskReferenceStatus;
+  severity: OperationalRiskSeverity;
+  label: string;
+  description: string;
+  reviewRequired: true;
+  lineageReferences: string[];
+  destination: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type OperationalRiskProfile = {
+  operationalRiskId: string;
+  riskScope: OperationalRiskScope;
+  status: OperationalRiskStatus;
+  manualReviewRequired: true;
+  autonomousRiskActionsEnabled: false;
+  publicRiskExposureEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    partiallyVerifiedReferences: number;
+    blockedReferences: number;
+    unavailableReferences: number;
+    lowSeverityReferences: number;
+    moderateSeverityReferences: number;
+    elevatedSeverityReferences: number;
+    criticalSeverityReferences: number;
+  };
+  riskReferences: OperationalRiskReference[];
+  evidenceReferences: OperationalRiskReference[];
+  reviewReferences: OperationalRiskReference[];
+  settlementReferences: OperationalRiskReference[];
+  regulatoryReferences: OperationalRiskReference[];
+  onboardingReferences: OperationalRiskReference[];
+  trustReferences: OperationalRiskReference[];
+  workflowReferences: OperationalRiskReference[];
+  delinquencyReferences: OperationalRiskReference[];
+  auditReferences: OperationalRiskReference[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: Array<{ eventType: string; action: string; status: OperationalRiskStatus; resourceId: string; summary: string }>;
+};
+
+export async function fetchOperationalRiskProfiles(params?: {
+  riskScope?: OperationalRiskScope | "";
+  status?: OperationalRiskStatus | "";
+  severity?: OperationalRiskSeverity | "";
+}): Promise<OperationalRiskProfile[]> {
+  const search = new URLSearchParams();
+  if (params?.riskScope) search.set("riskScope", params.riskScope);
+  if (params?.status) search.set("status", params.status);
+  if (params?.severity) search.set("severity", params.severity);
+  const suffix = search.toString() ? `?${search.toString()}` : "";
+  const response = await apiFetch<{ ok: true; profiles: OperationalRiskProfile[] }>(`/landlord/operational-risk${suffix}`);
+  return response.profiles;
+}
+
+export async function fetchOperationalRiskProfile(operationalRiskId: string): Promise<OperationalRiskProfile> {
+  const response = await apiFetch<{ ok: true; profile: OperationalRiskProfile }>(`/landlord/operational-risk/${encodeURIComponent(operationalRiskId)}`);
+  return response.profile;
+}

--- a/rentchain-frontend/src/components/risk/OperationalRiskPanel.test.tsx
+++ b/rentchain-frontend/src/components/risk/OperationalRiskPanel.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { OperationalRiskPanel } from "./OperationalRiskPanel";
+import type { OperationalRiskProfile } from "@/api/operationalRiskApi";
+
+const profile: OperationalRiskProfile = {
+  operationalRiskId: "operational_risk:landlord-1:institution",
+  riskScope: "institution",
+  status: "attention_required",
+  manualReviewRequired: true,
+  autonomousRiskActionsEnabled: false,
+  publicRiskExposureEnabled: false,
+  generatedAt: "2026-01-01T00:00:00.000Z",
+  summary: {
+    totalReferences: 2,
+    verifiedReferences: 1,
+    partiallyVerifiedReferences: 1,
+    blockedReferences: 0,
+    unavailableReferences: 0,
+    lowSeverityReferences: 0,
+    moderateSeverityReferences: 1,
+    elevatedSeverityReferences: 1,
+    criticalSeverityReferences: 0,
+  },
+  riskReferences: [],
+  evidenceReferences: [
+    {
+      riskReferenceId: "evidence-1",
+      riskType: "evidence_gap",
+      status: "partially_verified",
+      severity: "moderate",
+      label: "Evidence gap visibility",
+      description: "Evidence lineage is available.",
+      reviewRequired: true,
+      lineageReferences: ["evidence-1"],
+      destination: "/evidence-packs",
+      redacted: false,
+      redactionReason: null,
+      blockedReason: null,
+    },
+  ],
+  reviewReferences: [],
+  settlementReferences: [],
+  regulatoryReferences: [],
+  onboardingReferences: [],
+  trustReferences: [],
+  workflowReferences: [],
+  delinquencyReferences: [],
+  auditReferences: [],
+  redactions: ["Sensitive tenant identity, screening, credit, payment account, and private document payloads are excluded."],
+  blockedReasons: [],
+  canonicalEvents: [],
+};
+
+describe("OperationalRiskPanel", () => {
+  it("renders safety copy, lineage, and status details", () => {
+    render(
+      <MemoryRouter>
+        <OperationalRiskPanel profile={profile} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("View operational risk")).toBeInTheDocument();
+    expect(screen.getByText(/No underwriting, autonomous enforcement, or public risk exposure is enabled/i)).toBeInTheDocument();
+    expect(screen.getByText("Manual review required")).toBeInTheDocument();
+    expect(screen.getByText("View evidence lineage")).toBeInTheDocument();
+    expect(screen.getByText("Sensitive tenant identity, screening, credit, payment account, and private document payloads are excluded.")).toBeInTheDocument();
+  });
+
+  it("omits forbidden operational risk labels", () => {
+    render(
+      <MemoryRouter>
+        <OperationalRiskPanel profile={profile} />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText("Auto-enforce")).not.toBeInTheDocument();
+    expect(screen.queryByText("Underwrite automatically")).not.toBeInTheDocument();
+    expect(screen.queryByText("Public risk score")).not.toBeInTheDocument();
+    expect(screen.queryByText("Autonomous action")).not.toBeInTheDocument();
+    expect(screen.queryByText("Approve risk automatically")).not.toBeInTheDocument();
+    expect(screen.queryByText("Public exposure")).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/risk/OperationalRiskPanel.tsx
+++ b/rentchain-frontend/src/components/risk/OperationalRiskPanel.tsx
@@ -1,0 +1,119 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import type { OperationalRiskProfile, OperationalRiskReference } from "@/api/operationalRiskApi";
+import { Card, Section } from "@/components/ui/Ui";
+
+function label(value: string) {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function tone(status: string) {
+  if (status === "blocked" || status === "critical") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
+  if (status === "elevated" || status === "attention_required" || status === "partially_verified" || status === "unavailable" || status === "moderate") {
+    return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
+  }
+  if (status === "stable" || status === "verified" || status === "low") return { color: "#166534", background: "#dcfce7", border: "#bbf7d0" };
+  return { color: "#475569", background: "#f8fafc", border: "#e2e8f0" };
+}
+
+function Badge({ children, status }: { children: React.ReactNode; status: string }) {
+  const next = tone(status);
+  return (
+    <span style={{ border: `1px solid ${next.border}`, borderRadius: 999, background: next.background, color: next.color, padding: "3px 9px", fontSize: 12, fontWeight: 900, whiteSpace: "nowrap" }}>
+      {children}
+    </span>
+  );
+}
+
+function ReferenceList({ title, references }: { title: string; references: OperationalRiskReference[] }) {
+  return (
+    <Section style={{ display: "grid", gap: 10 }}>
+      <div style={{ fontWeight: 900 }}>{title}</div>
+      {references.length ? (
+        references.slice(0, 12).map((reference) => (
+          <Card key={reference.riskReferenceId} style={{ borderRadius: 8, padding: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+              <div>
+                <strong>{reference.label}</strong>
+                <div style={{ color: "#64748b", fontSize: 13 }}>{label(reference.riskType)}</div>
+              </div>
+              <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                <Badge status={reference.status}>{label(reference.status)}</Badge>
+                <Badge status={reference.severity}>{label(reference.severity)}</Badge>
+              </div>
+            </div>
+            <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>{reference.description}</div>
+            {reference.lineageReferences.length ? <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>Lineage references: {reference.lineageReferences.length}</div> : null}
+            {reference.blockedReason ? <div style={{ color: "#991b1b", fontSize: 13, marginTop: 8 }}>View blocked reason: {reference.blockedReason}</div> : null}
+            {reference.redacted ? <div style={{ color: "#92400e", fontSize: 13, marginTop: 8 }}>{reference.redactionReason || "Redacted operational risk reference"}</div> : null}
+            {reference.destination ? <Link to={reference.destination} style={{ color: "#2563eb", fontWeight: 800, fontSize: 13, marginTop: 8, display: "inline-block" }}>View context</Link> : null}
+          </Card>
+        ))
+      ) : (
+        <Card style={{ color: "#64748b" }}>Context unavailable</Card>
+      )}
+    </Section>
+  );
+}
+
+export function OperationalRiskPanel({ profile }: { profile: OperationalRiskProfile }) {
+  return (
+    <div style={{ display: "grid", gap: 16 }}>
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+          <div>
+            <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>View operational risk</div>
+            <h2 style={{ margin: "2px 0 0", fontSize: "1.15rem" }}>{label(profile.riskScope)}</h2>
+          </div>
+          <Badge status={profile.status}>{label(profile.status)}</Badge>
+        </div>
+        <div style={{ color: "#475569", lineHeight: 1.55 }}>
+          Operational risk visibility is operationally scoped and review controlled. No underwriting, autonomous enforcement, or public risk exposure is enabled.
+          Manual review remains required.
+        </div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <Badge status="attention_required">Manual review required</Badge>
+          <Badge status={profile.autonomousRiskActionsEnabled ? "blocked" : "verified"}>Risk actions disabled</Badge>
+          <Badge status={profile.publicRiskExposureEnabled ? "blocked" : "verified"}>Public risk visibility disabled</Badge>
+        </div>
+      </Section>
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Risk summary</div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: 10 }}>
+          {[
+            ["References", profile.summary.totalReferences],
+            ["Verified", profile.summary.verifiedReferences],
+            ["Partial", profile.summary.partiallyVerifiedReferences],
+            ["Blocked", profile.summary.blockedReferences],
+            ["Unavailable", profile.summary.unavailableReferences],
+            ["Critical", profile.summary.criticalSeverityReferences],
+          ].map(([name, value]) => (
+            <Card key={String(name)} style={{ borderRadius: 8, padding: 12 }}>
+              <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>{name}</div>
+              <strong style={{ color: "#0f172a", fontSize: 22 }}>{String(value)}</strong>
+            </Card>
+          ))}
+        </div>
+      </Section>
+
+      <ReferenceList title="View restrictions" references={profile.riskReferences.filter((reference) => reference.status !== "verified")} />
+      <ReferenceList title="View evidence lineage" references={profile.evidenceReferences} />
+      <ReferenceList title="View review lineage" references={profile.reviewReferences} />
+      <ReferenceList title="Settlement restrictions" references={profile.settlementReferences} />
+      <ReferenceList title="Regulatory restrictions" references={profile.regulatoryReferences} />
+      <ReferenceList title="Onboarding restrictions" references={profile.onboardingReferences} />
+      <ReferenceList title="Trust restrictions" references={profile.trustReferences} />
+      <ReferenceList title="Workflow instability" references={profile.workflowReferences} />
+      <ReferenceList title="Delinquency exposure" references={profile.delinquencyReferences} />
+      <ReferenceList title="Audit references" references={profile.auditReferences} />
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Redactions</div>
+        {profile.redactions.map((redaction) => (
+          <Card key={redaction} style={{ borderRadius: 8, padding: 12, color: "#475569" }}>{redaction}</Card>
+        ))}
+      </Section>
+    </div>
+  );
+}

--- a/rentchain-frontend/src/pages/InstitutionOnboardingReadinessPage.test.tsx
+++ b/rentchain-frontend/src/pages/InstitutionOnboardingReadinessPage.test.tsx
@@ -69,6 +69,7 @@ describe("InstitutionOnboardingReadinessPage", () => {
 
     expect(await screen.findByText("Institution onboarding readiness")).toBeInTheDocument();
     expect(screen.getAllByText(/No live institution integration or autonomous onboarding is enabled/i).length).toBeGreaterThan(0);
+    expect(screen.getByRole("link", { name: "View operational risk" })).toHaveAttribute("href", "/operational-risk");
     expect(screen.getByText("Public onboarding portals and unrestricted institutional directory data are not included.")).toBeInTheDocument();
   });
 

--- a/rentchain-frontend/src/pages/InstitutionOnboardingReadinessPage.tsx
+++ b/rentchain-frontend/src/pages/InstitutionOnboardingReadinessPage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useSearchParams } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import {
   fetchInstitutionOnboardingReadiness,
   type InstitutionOnboardingReadiness,
@@ -63,12 +63,15 @@ export default function InstitutionOnboardingReadinessPage() {
     <MacShell title="Institution onboarding readiness" showTopNav={false}>
       <div style={{ display: "grid", gap: 16 }}>
         <Section>
-          <div style={{ display: "grid", gap: 6 }}>
-            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Institution onboarding readiness</h1>
-            <div style={{ color: "#475569", maxWidth: 900 }}>
-              Institution onboarding readiness is operationally scoped and review controlled. No live institution integration or autonomous onboarding is enabled.
-              Manual review remains required.
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "start" }}>
+            <div style={{ display: "grid", gap: 6 }}>
+              <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Institution onboarding readiness</h1>
+              <div style={{ color: "#475569", maxWidth: 900 }}>
+                Institution onboarding readiness is operationally scoped and review controlled. No live institution integration or autonomous onboarding is enabled.
+                Manual review remains required.
+              </div>
             </div>
+            <Link to="/operational-risk" style={{ color: "#2563eb", fontWeight: 900 }}>View operational risk</Link>
           </div>
         </Section>
 

--- a/rentchain-frontend/src/pages/OperationalRiskPage.test.tsx
+++ b/rentchain-frontend/src/pages/OperationalRiskPage.test.tsx
@@ -1,0 +1,115 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import OperationalRiskPage from "./OperationalRiskPage";
+
+const mockFetchOperationalRiskProfiles = vi.fn();
+const mockShowToast = vi.fn();
+
+vi.mock("@/api/operationalRiskApi", () => ({
+  fetchOperationalRiskProfiles: (...args: any[]) => mockFetchOperationalRiskProfiles(...args),
+}));
+
+vi.mock("@/components/layout/MacShell", () => ({
+  MacShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
+const profile = {
+  operationalRiskId: "operational_risk:landlord-1:institution",
+  riskScope: "institution",
+  status: "attention_required",
+  manualReviewRequired: true,
+  autonomousRiskActionsEnabled: false,
+  publicRiskExposureEnabled: false,
+  generatedAt: "2026-01-01T00:00:00.000Z",
+  summary: {
+    totalReferences: 1,
+    verifiedReferences: 0,
+    partiallyVerifiedReferences: 1,
+    blockedReferences: 0,
+    unavailableReferences: 0,
+    lowSeverityReferences: 0,
+    moderateSeverityReferences: 1,
+    elevatedSeverityReferences: 0,
+    criticalSeverityReferences: 0,
+  },
+  riskReferences: [],
+  evidenceReferences: [],
+  reviewReferences: [],
+  settlementReferences: [],
+  regulatoryReferences: [],
+  onboardingReferences: [],
+  trustReferences: [],
+  workflowReferences: [],
+  delinquencyReferences: [],
+  auditReferences: [],
+  redactions: ["Public risk exposure and autonomous enforcement are not enabled."],
+  blockedReasons: [],
+  canonicalEvents: [],
+};
+
+describe("OperationalRiskPage", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchOperationalRiskProfiles.mockResolvedValue([profile]);
+  });
+
+  it("renders operational risk and required safety copy", async () => {
+    render(
+      <MemoryRouter>
+        <OperationalRiskPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Operational risk")).toBeInTheDocument();
+    expect(screen.getAllByText(/No underwriting, autonomous enforcement, or public risk exposure is enabled/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("Public risk exposure and autonomous enforcement are not enabled.")).toBeInTheDocument();
+  });
+
+  it("updates deterministic scope, status, and severity filters", async () => {
+    render(
+      <MemoryRouter>
+        <OperationalRiskPage />
+      </MemoryRouter>
+    );
+
+    await screen.findByText("Operational risk");
+    fireEvent.change(screen.getByLabelText("Risk scope"), { target: { value: "settlement" } });
+    fireEvent.change(screen.getByLabelText("Status"), { target: { value: "blocked" } });
+    fireEvent.change(screen.getByLabelText("Severity"), { target: { value: "critical" } });
+
+    await waitFor(() => {
+      expect(mockFetchOperationalRiskProfiles).toHaveBeenLastCalledWith({
+        riskScope: "settlement",
+        status: "blocked",
+        severity: "critical",
+      });
+    });
+  });
+
+  it("shows empty state and omits forbidden labels", async () => {
+    mockFetchOperationalRiskProfiles.mockResolvedValue([]);
+    render(
+      <MemoryRouter>
+        <OperationalRiskPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("No operational risk profiles match these filters.")).toBeInTheDocument();
+    expect(screen.queryByText("Auto-enforce")).not.toBeInTheDocument();
+    expect(screen.queryByText("Underwrite automatically")).not.toBeInTheDocument();
+    expect(screen.queryByText("Public risk score")).not.toBeInTheDocument();
+    expect(screen.queryByText("Autonomous action")).not.toBeInTheDocument();
+    expect(screen.queryByText("Approve risk automatically")).not.toBeInTheDocument();
+    expect(screen.queryByText("Public exposure")).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/OperationalRiskPage.tsx
+++ b/rentchain-frontend/src/pages/OperationalRiskPage.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { useSearchParams } from "react-router-dom";
+import {
+  fetchOperationalRiskProfiles,
+  type OperationalRiskProfile,
+  type OperationalRiskScope,
+  type OperationalRiskSeverity,
+  type OperationalRiskStatus,
+} from "@/api/operationalRiskApi";
+import { MacShell } from "@/components/layout/MacShell";
+import { OperationalRiskPanel } from "@/components/risk/OperationalRiskPanel";
+import { Card, Section } from "@/components/ui/Ui";
+import { useToast } from "@/components/ui/ToastProvider";
+
+const riskScopes: Array<OperationalRiskScope | ""> = ["", "property", "lease", "participant", "institution", "workflow", "onboarding", "settlement", "regulatory"];
+const statuses: Array<OperationalRiskStatus | ""> = ["", "stable", "attention_required", "elevated", "blocked", "unknown"];
+const severities: Array<OperationalRiskSeverity | ""> = ["", "low", "moderate", "elevated", "critical"];
+
+function label(value: string) {
+  return value ? value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase()) : "All";
+}
+
+export default function OperationalRiskPage() {
+  const { showToast } = useToast();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [profiles, setProfiles] = React.useState<OperationalRiskProfile[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const riskScope = String(searchParams.get("riskScope") || "") as OperationalRiskScope | "";
+  const status = String(searchParams.get("status") || "") as OperationalRiskStatus | "";
+  const severity = String(searchParams.get("severity") || "") as OperationalRiskSeverity | "";
+
+  React.useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const next = await fetchOperationalRiskProfiles({ riskScope, status, severity });
+        if (mounted) setProfiles(next);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Failed to load operational risk";
+        if (mounted) {
+          setError(message);
+          showToast({ message: "Failed to load operational risk", description: message, variant: "error" });
+        }
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [riskScope, status, severity, showToast]);
+
+  function updateParams(next: { riskScope?: string; status?: string; severity?: string }) {
+    const params = new URLSearchParams(searchParams);
+    for (const [key, value] of Object.entries(next)) {
+      if (value && value.trim()) params.set(key, value.trim());
+      else params.delete(key);
+    }
+    setSearchParams(params);
+  }
+
+  return (
+    <MacShell title="Operational risk" showTopNav={false}>
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "grid", gap: 6 }}>
+            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Operational risk</h1>
+            <div style={{ color: "#475569", maxWidth: 900 }}>
+              Operational risk visibility is operationally scoped and review controlled. No underwriting, autonomous enforcement, or public risk exposure is enabled.
+              Manual review remains required.
+            </div>
+          </div>
+        </Section>
+
+        <Section style={{ display: "flex", gap: 10, flexWrap: "wrap", alignItems: "end" }}>
+          <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Risk scope
+            <select value={riskScope} onChange={(event) => updateParams({ riskScope: event.target.value })} style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 180 }}>
+              {riskScopes.map((scope) => <option key={scope || "all"} value={scope}>{label(scope)}</option>)}
+            </select>
+          </label>
+          <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Status
+            <select value={status} onChange={(event) => updateParams({ status: event.target.value })} style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 180 }}>
+              {statuses.map((item) => <option key={item || "all"} value={item}>{label(item)}</option>)}
+            </select>
+          </label>
+          <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Severity
+            <select value={severity} onChange={(event) => updateParams({ severity: event.target.value })} style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 180 }}>
+              {severities.map((item) => <option key={item || "all"} value={item}>{label(item)}</option>)}
+            </select>
+          </label>
+        </Section>
+
+        {loading ? <Card>Loading operational risk...</Card> : null}
+        {!loading && error ? <Card style={{ color: "#b91c1c" }}>We couldn't load operational risk right now.</Card> : null}
+        {!loading && !error && !profiles.length ? <Card style={{ color: "#64748b" }}>No operational risk profiles match these filters.</Card> : null}
+        {!loading && !error && profiles.length ? (
+          <div style={{ display: "grid", gap: 16 }}>{profiles.map((profile) => <OperationalRiskPanel key={profile.operationalRiskId} profile={profile} />)}</div>
+        ) : null}
+      </div>
+    </MacShell>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds deterministic, landlord-scoped Operational Risk Layer read model
- Adds endpoints:
  - `GET /api/landlord/operational-risk`
  - `GET /api/landlord/operational-risk/:operationalRiskId`
- Adds operational risk references for review gaps, evidence gaps, settlement inconsistencies, workflow instability, delinquency exposure, onboarding blockers, regulatory restrictions, audit gaps, and trust restrictions
- Adds descriptor-only canonical events:
  - `operational_risk_profile_derived`
  - `operational_risk_restriction_detected`
  - `operational_risk_review_required`
  - `operational_risk_blocked`
  - `operational_risk_redaction_applied`
- Adds frontend `/operational-risk` page, `OperationalRiskPanel`, filters, and a safe Institution Onboarding entry link
- Adds architecture documentation for Operational Risk Layer v1

## Guardrails
- Confirms `manualReviewRequired` remains `true`
- Confirms `autonomousRiskActionsEnabled` remains `false`
- Confirms `publicRiskExposureEnabled` remains `false`
- Confirms no AI/probabilistic risk scoring, credit scoring, underwriting, legal adjudication, financial adjudication, autonomous enforcement, automated penalties, public risk exposure, institution integrations, or execution behavior was added
- Confirms raw government IDs, screening/credit payloads, payment account details, private tenant data, unrestricted audit histories, and admin-only landlord-route data are excluded

## Verification
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && pnpm exec vitest run src/lib/operationalRisk/__tests__/deriveOperationalRiskProfile.test.ts src/routes/__tests__/landlordOperationalRiskRoutes.test.ts`
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 && pnpm exec vitest run src/components/risk/OperationalRiskPanel.test.tsx src/pages/OperationalRiskPage.test.tsx src/pages/InstitutionOnboardingReadinessPage.test.tsx src/App.routes.test.tsx`
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && pnpm build`
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 && pnpm build`
- `git diff --check`
- `git diff --cached --check`
- dependency/lockfile diff empty
- touched runtime forbidden-label scan clean

## Scope
- Operational risk files
- Landlord route wiring
- Frontend route wiring
- Safe Institution Onboarding entry link
- Tests and architecture documentation