### PR TITLE
feat: add interoperability adapter layer

### DIFF
--- a/docs/architecture/interoperability-adapter-layer-v1.md
+++ b/docs/architecture/interoperability-adapter-layer-v1.md
@@ -1,0 +1,68 @@
+# Interoperability Adapter Layer v1
+
+## Purpose
+
+The Interoperability Adapter Layer provides deterministic, read-only readiness metadata for future integration compatibility with lenders, insurers, regulators, registries, accounting systems, payment providers, and operational partners.
+
+This layer is interoperability preparation only. It does not create live integrations, webhooks, public APIs, data synchronization, external execution, or external-system connectivity.
+
+## Read Model
+
+Adapter readiness is derived from existing RentChain systems:
+
+- Operational Risk profiles
+- Institution Onboarding Readiness
+- Cross-Organization Trust
+- Institutional Sharing Rooms
+- Settlement Rail Readiness
+- Regulatory Profiles
+- Evidence Packs
+- Operator Review Sessions
+- Canonical audit events
+
+Required execution flags remain fixed:
+
+- `manualReviewRequired: true`
+- `liveIntegrationEnabled: false`
+- `externalSynchronizationEnabled: false`
+
+## Deterministic Rules
+
+Adapter status is derived from explicit reference states:
+
+- `ready_for_review`: required readiness lineage is present and verified
+- `partially_ready`: readiness lineage is incomplete
+- `review_required`: required review or evidence lineage is missing
+- `blocked`: unresolved settlement, regulatory, sharing, compatibility, or evidence restrictions exist
+- `unknown`: source context is unavailable
+
+No AI integration scoring, probabilistic ranking, or autonomous approval is used.
+
+## Canonical Event Descriptors
+
+The layer emits descriptor-only canonical event metadata:
+
+- `interoperability_adapter_readiness_derived`
+- `interoperability_adapter_review_required`
+- `interoperability_adapter_blocked`
+- `interoperability_adapter_restriction_detected`
+- `interoperability_adapter_redaction_applied`
+
+These descriptors are additive and do not trigger external synchronization or execution.
+
+## Guardrails
+
+The layer does not:
+
+- integrate with external systems
+- send data externally
+- pull data from external systems
+- create webhooks
+- synchronize with lenders, insurers, regulators, registries, accounting systems, or payment providers
+- create public APIs
+- store live integration credentials or webhook secrets
+- expose raw government identifiers, screening, credit bureau, payment account, private tenant, admin-only, or unrestricted audit payloads
+
+## Extension Guidance
+
+Future adapter work should extend this read model with deterministic compatibility references before any execution-capable integration is considered. Any future integration mission must preserve consent, permission, redaction, review, and audit boundaries and must be explicitly authorized as out of scope for this v1 layer.

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -135,6 +135,7 @@ import landlordNetworkParticipantRoutes from "./routes/landlordNetworkParticipan
 import landlordCrossOrganizationTrustRoutes from "./routes/landlordCrossOrganizationTrustRoutes";
 import landlordInstitutionOnboardingRoutes from "./routes/landlordInstitutionOnboardingRoutes";
 import landlordOperationalRiskRoutes from "./routes/landlordOperationalRiskRoutes";
+import landlordInteroperabilityAdapterRoutes from "./routes/landlordInteroperabilityAdapterRoutes";
 import publicPortfolioScoreRoutes from "./routes/publicPortfolioScoreRoutes";
 import publicTenantShareRoutes from "./routes/publicTenantShareRoutes";
 import landlordActionRecommendationRoutes from "./routes/landlordActionRecommendationRoutes";
@@ -328,6 +329,8 @@ app.use("/api/landlord", routeSource("landlordInstitutionOnboardingRoutes.ts"), 
 console.log("[route-mount] landlordInstitutionOnboardingRoutes mounted at /api/landlord");
 app.use("/api/landlord", routeSource("landlordOperationalRiskRoutes.ts"), landlordOperationalRiskRoutes);
 console.log("[route-mount] landlordOperationalRiskRoutes mounted at /api/landlord");
+app.use("/api/landlord", routeSource("landlordInteroperabilityAdapterRoutes.ts"), landlordInteroperabilityAdapterRoutes);
+console.log("[route-mount] landlordInteroperabilityAdapterRoutes mounted at /api/landlord");
 app.use("/api", routeSource("landlordActionRecommendationRoutes.ts"), landlordActionRecommendationRoutes);
 console.log("[route-mount] landlordActionRecommendationRoutes mounted at /api");
 app.use("/api", routeSource("tenantFeedbackRoutes.ts"), tenantFeedbackRoutes);

--- a/rentchain-api/src/lib/interoperabilityAdapters/__tests__/deriveInteroperabilityAdapterReadiness.test.ts
+++ b/rentchain-api/src/lib/interoperabilityAdapters/__tests__/deriveInteroperabilityAdapterReadiness.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { deriveInteroperabilityAdapterReadiness } from "../deriveInteroperabilityAdapterReadiness";
+
+describe("deriveInteroperabilityAdapterReadiness", () => {
+  it("derives deterministic adapter readiness with required disabled execution flags", () => {
+    const readiness = deriveInteroperabilityAdapterReadiness({
+      landlordId: "landlord-1",
+      adapterType: "lender",
+      generatedAt: "2026-01-01T00:00:00.000Z",
+      operationalRiskProfiles: [{ operationalRiskId: "risk-1", status: "stable", sensitiveTenantPayload: "raw-secret" }],
+      institutionOnboardingReadiness: [{ onboardingReadinessId: "onboarding-1", status: "ready_for_review" }],
+      trustRelationships: [{ trustRelationshipId: "trust-1", status: "verified" }],
+      sharingRooms: [{ sharingRoomId: "room-1", status: "active", publiclyAccessible: false, externalExecutionEnabled: false }],
+      settlementReadiness: { settlementReadinessId: "settlement-1", status: "ready_for_review" },
+      regulatoryProfiles: [{ regulatoryProfileId: "regulatory-1", status: "ready_for_review" }],
+      evidencePacks: [{ evidencePackId: "evidence-1", status: "ready_for_review" }],
+      operatorReviewSessions: [{ reviewSessionId: "review-1", status: "completed" }],
+      auditEvents: [{ eventId: "event-1", eventType: "operational_risk_profile_derived" }],
+    });
+
+    expect(readiness).toEqual(
+      expect.objectContaining({
+        adapterReadinessId: "interoperability_adapter_readiness:landlord-1:lender",
+        status: "ready_for_review",
+        manualReviewRequired: true,
+        liveIntegrationEnabled: false,
+        externalSynchronizationEnabled: false,
+      })
+    );
+    expect(readiness.canonicalEvents.map((event) => event.eventType)).toContain("interoperability_adapter_readiness_derived");
+    expect(JSON.stringify(readiness)).not.toContain("sensitiveTenantPayload");
+    expect(JSON.stringify(readiness)).not.toContain("raw-secret");
+  });
+
+  it("surfaces blocked restrictions without enabling synchronization", () => {
+    const readiness = deriveInteroperabilityAdapterReadiness({
+      landlordId: "landlord-1",
+      adapterType: "payment_provider",
+      operationalRiskProfiles: [{ operationalRiskId: "risk-1", status: "blocked" }],
+      institutionOnboardingReadiness: [{ onboardingReadinessId: "onboarding-1", status: "blocked" }],
+      sharingRooms: [{ sharingRoomId: "room-1", status: "blocked", publiclyAccessible: true, externalExecutionEnabled: true }],
+      settlementReadiness: { settlementReadinessId: "settlement-1", status: "blocked" },
+      regulatoryProfiles: [{ regulatoryProfileId: "regulatory-1", status: "blocked" }],
+      evidencePacks: [{ evidencePackId: "evidence-1", status: "blocked" }],
+      operatorReviewSessions: [{ reviewSessionId: "review-1", status: "open" }],
+    });
+
+    expect(readiness.status).toBe("blocked");
+    expect(readiness.adapterRestrictions.length).toBeGreaterThan(0);
+    expect(readiness.liveIntegrationEnabled).toBe(false);
+    expect(readiness.externalSynchronizationEnabled).toBe(false);
+    expect(readiness.canonicalEvents.map((event) => event.eventType)).toContain("interoperability_adapter_blocked");
+  });
+
+  it("returns unknown when source context is unavailable", () => {
+    const readiness = deriveInteroperabilityAdapterReadiness({ landlordId: "landlord-1", adapterType: "registry" });
+
+    expect(readiness.status).toBe("unknown");
+    expect(readiness.manualReviewRequired).toBe(true);
+    expect(readiness.liveIntegrationEnabled).toBe(false);
+    expect(readiness.externalSynchronizationEnabled).toBe(false);
+  });
+});

--- a/rentchain-api/src/lib/interoperabilityAdapters/adapterRestrictionModels.ts
+++ b/rentchain-api/src/lib/interoperabilityAdapters/adapterRestrictionModels.ts
@@ -1,0 +1,63 @@
+import type {
+  InteroperabilityAdapterReference,
+  InteroperabilityAdapterReferenceStatus,
+  InteroperabilityAdapterReferenceType,
+  InteroperabilityAdapterRestriction,
+} from "./interoperabilityAdapterTypes";
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+export function interoperabilityAdapterIdPart(value: unknown): string {
+  return asString(value, 500)
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+export function adapterReference(input: {
+  idParts: unknown[];
+  referenceType: InteroperabilityAdapterReferenceType;
+  status: InteroperabilityAdapterReferenceStatus;
+  label: string;
+  description: string;
+  lineageReferences?: string[];
+  destination?: string | null;
+  redacted?: boolean;
+  redactionReason?: string | null;
+  blockedReason?: string | null;
+}): InteroperabilityAdapterReference {
+  return {
+    referenceId: interoperabilityAdapterIdPart(input.idParts.join(":")) || "interoperability_adapter_reference:unknown",
+    referenceType: input.referenceType,
+    status: input.status,
+    label: input.label,
+    description: input.description,
+    reviewRequired: true,
+    lineageReferences: Array.from(new Set(input.lineageReferences || [])).filter(Boolean),
+    destination: input.destination || null,
+    redacted: Boolean(input.redacted),
+    redactionReason: input.redactionReason || null,
+    blockedReason: input.blockedReason || null,
+  };
+}
+
+export function adapterRestriction(input: {
+  idParts: unknown[];
+  restrictionType: InteroperabilityAdapterRestriction["restrictionType"];
+  status: InteroperabilityAdapterRestriction["status"];
+  label: string;
+  description: string;
+  blockedReason?: string | null;
+}): InteroperabilityAdapterRestriction {
+  return {
+    restrictionId: interoperabilityAdapterIdPart(input.idParts.join(":")) || "interoperability_adapter_restriction:unknown",
+    restrictionType: input.restrictionType,
+    status: input.status,
+    label: input.label,
+    description: input.description,
+    blockedReason: input.blockedReason || null,
+  };
+}

--- a/rentchain-api/src/lib/interoperabilityAdapters/deriveInteroperabilityAdapterReadiness.ts
+++ b/rentchain-api/src/lib/interoperabilityAdapters/deriveInteroperabilityAdapterReadiness.ts
@@ -1,0 +1,373 @@
+import type {
+  DeriveInteroperabilityAdapterReadinessInput,
+  InteroperabilityAdapterCanonicalEvent,
+  InteroperabilityAdapterReadiness,
+  InteroperabilityAdapterReference,
+  InteroperabilityAdapterStatus,
+  InteroperabilityAdapterType,
+} from "./interoperabilityAdapterTypes";
+import { adapterReference, adapterRestriction, interoperabilityAdapterIdPart } from "./adapterRestrictionModels";
+
+const ADAPTER_TYPES = new Set<InteroperabilityAdapterType>(["lender", "insurer", "regulator", "registry", "accounting", "payment_provider", "operational_partner"]);
+
+const REDACTIONS = [
+  "Live integration credentials, webhook secrets, and external API payloads are excluded.",
+  "Raw government identifiers, screening, credit bureau, payment account, and private tenant payloads are excluded.",
+  "Unrestricted external exports, unrestricted financial information, and unrestricted audit histories are excluded.",
+  "Interoperability adapters are readiness metadata only; no external synchronization or execution is enabled.",
+];
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function asArray<T>(value: T[] | null | undefined): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function generatedAt(value: unknown): string {
+  const raw = asString(value, 120);
+  const date = raw ? new Date(raw) : new Date(0);
+  return Number.isNaN(date.getTime()) ? new Date(0).toISOString() : date.toISOString();
+}
+
+function normalizeAdapterType(value: unknown): InteroperabilityAdapterType {
+  const raw = asString(value, 80) as InteroperabilityAdapterType;
+  return ADAPTER_TYPES.has(raw) ? raw : "operational_partner";
+}
+
+function referenceId(record: Record<string, any>, keys: string[]): string {
+  for (const key of keys) {
+    const value = asString(record?.[key], 240);
+    if (value) return value;
+  }
+  return asString(record?.id, 240);
+}
+
+function readinessStatus(hasContext: boolean, references: InteroperabilityAdapterReference[]): InteroperabilityAdapterStatus {
+  if (!hasContext) return "unknown";
+  if (references.some((reference) => reference.status === "blocked")) return "blocked";
+  if (references.some((reference) => reference.status === "unavailable")) return "review_required";
+  if (references.some((reference) => reference.status === "partially_verified")) return "partially_ready";
+  return "ready_for_review";
+}
+
+function event(input: {
+  eventType: InteroperabilityAdapterCanonicalEvent["eventType"];
+  status: InteroperabilityAdapterStatus;
+  adapterReadinessId: string;
+  summary: string;
+}): InteroperabilityAdapterCanonicalEvent {
+  return {
+    eventType: input.eventType,
+    action: input.eventType.replace(/^interoperability_adapter_/, "").replace(/_/g, "."),
+    status: input.status,
+    resourceType: "interoperability_adapter_readiness",
+    resourceId: input.adapterReadinessId,
+    summary: input.summary,
+  };
+}
+
+function statusFromReadyBlocked(record: Record<string, any>, readyStatuses: string[]): InteroperabilityAdapterReference["status"] {
+  const status = asString(record?.status, 80);
+  if (status === "blocked") return "blocked";
+  if (readyStatuses.includes(status)) return "verified";
+  if (status === "unknown") return "unavailable";
+  return "partially_verified";
+}
+
+export function deriveInteroperabilityAdapterReadiness(input: DeriveInteroperabilityAdapterReadinessInput): InteroperabilityAdapterReadiness {
+  const landlordId = asString(input.landlordId, 240);
+  const adapterType = normalizeAdapterType(input.adapterType);
+  const adapterReadinessId =
+    interoperabilityAdapterIdPart(["interoperability_adapter_readiness", landlordId || "unknown", adapterType].join(":")) ||
+    "interoperability_adapter_readiness:unknown";
+
+  const operationalRiskProfiles = asArray(input.operationalRiskProfiles);
+  const onboardingReadiness = asArray(input.institutionOnboardingReadiness);
+  const trustRelationships = asArray(input.trustRelationships);
+  const sharingRooms = asArray(input.sharingRooms);
+  const regulatoryProfiles = asArray(input.regulatoryProfiles);
+  const evidencePacks = asArray(input.evidencePacks);
+  const reviews = asArray(input.operatorReviewSessions);
+  const auditEvents = asArray(input.auditEvents);
+  const settlementReadiness = input.settlementReadiness || null;
+
+  const compatibilitySources = [...operationalRiskProfiles, ...onboardingReadiness, ...trustRelationships];
+  const compatibilityReferences = compatibilitySources.length
+    ? compatibilitySources.map((record, index) => {
+        const id = referenceId(record, ["operationalRiskId", "onboardingReadinessId", "trustRelationshipId", "id"]) || String(index);
+        const status = record.status === "stable" || record.status === "ready_for_review" || record.status === "verified" ? "verified" : record.status === "blocked" ? "blocked" : "partially_verified";
+        return adapterReference({
+          idParts: ["compatibility", id],
+          referenceType: "compatibility",
+          status,
+          label: "Compatibility readiness reference",
+          description: "Operational compatibility metadata is available for interoperability readiness review.",
+          lineageReferences: [id].filter(Boolean),
+          destination: record.operationalRiskId ? "/operational-risk" : record.onboardingReadinessId ? "/institution-onboarding-readiness" : "/cross-organization-trust",
+          blockedReason: status === "blocked" ? "Compatibility readiness is blocked by operational restrictions." : null,
+        });
+      })
+    : [
+        adapterReference({
+          idParts: ["compatibility", "missing"],
+          referenceType: "compatibility",
+          status: "unavailable",
+          label: "Compatibility readiness reference",
+          description: "Operational compatibility metadata is unavailable.",
+          destination: "/operational-risk",
+        }),
+      ];
+
+  const settlementReferences = settlementReadiness
+    ? [
+        adapterReference({
+          idParts: ["settlement", referenceId(settlementReadiness, ["settlementReadinessId", "id"]) || "unknown"],
+          referenceType: "settlement",
+          status: statusFromReadyBlocked(settlementReadiness, ["ready_for_review"]),
+          label: "Settlement interoperability dependency",
+          description: "Settlement readiness metadata is available for interoperability readiness review.",
+          lineageReferences: [referenceId(settlementReadiness, ["settlementReadinessId", "id"])].filter(Boolean),
+          destination: "/settlement-readiness",
+          blockedReason: settlementReadiness.status === "blocked" ? "Settlement readiness is blocked." : null,
+        }),
+      ]
+    : [
+        adapterReference({
+          idParts: ["settlement", "missing"],
+          referenceType: "settlement",
+          status: "unavailable",
+          label: "Settlement interoperability dependency",
+          description: "Settlement readiness metadata is unavailable.",
+          destination: "/settlement-readiness",
+        }),
+      ];
+
+  const regulatoryReferences = regulatoryProfiles.length
+    ? regulatoryProfiles.map((profile) =>
+        adapterReference({
+          idParts: ["regulatory", referenceId(profile, ["regulatoryProfileId", "id"]) || "unknown"],
+          referenceType: "regulatory",
+          status: statusFromReadyBlocked(profile, ["ready_for_review"]),
+          label: "Regulatory interoperability dependency",
+          description: "Regulatory readiness metadata is available for interoperability readiness review.",
+          lineageReferences: [referenceId(profile, ["regulatoryProfileId", "id"])].filter(Boolean),
+          destination: "/regulatory-profiles",
+          blockedReason: profile.status === "blocked" ? "Regulatory readiness is blocked." : null,
+        })
+      )
+    : [
+        adapterReference({
+          idParts: ["regulatory", "missing"],
+          referenceType: "regulatory",
+          status: "unavailable",
+          label: "Regulatory interoperability dependency",
+          description: "Regulatory readiness metadata is unavailable.",
+          destination: "/regulatory-profiles",
+        }),
+      ];
+
+  const evidenceReferences = evidencePacks.length
+    ? evidencePacks.map((pack) =>
+        adapterReference({
+          idParts: ["evidence", referenceId(pack, ["evidencePackId", "id"]) || "unknown"],
+          referenceType: "evidence",
+          status: pack.status === "blocked" ? "blocked" : pack.status === "ready_for_review" ? "verified" : "partially_verified",
+          label: "Evidence interoperability lineage",
+          description: "Evidence pack lineage is available for interoperability readiness review.",
+          lineageReferences: [referenceId(pack, ["evidencePackId", "id"])].filter(Boolean),
+          destination: "/evidence-packs",
+          blockedReason: pack.status === "blocked" ? "Evidence interoperability lineage is blocked." : null,
+        })
+      )
+    : [
+        adapterReference({
+          idParts: ["evidence", "missing"],
+          referenceType: "evidence",
+          status: "unavailable",
+          label: "Evidence interoperability lineage",
+          description: "Evidence pack lineage is unavailable.",
+          destination: "/evidence-packs",
+        }),
+      ];
+
+  const reviewReferences = reviews.length
+    ? reviews.map((review) =>
+        adapterReference({
+          idParts: ["review", referenceId(review, ["reviewSessionId", "id"]) || "unknown"],
+          referenceType: "review",
+          status: review.status === "completed" ? "verified" : review.status === "blocked" ? "blocked" : "partially_verified",
+          label: "Review interoperability lineage",
+          description: "Operator review lineage is available for interoperability readiness review.",
+          lineageReferences: [referenceId(review, ["reviewSessionId", "id"])].filter(Boolean),
+          destination: "/review-timeline",
+          blockedReason: review.status === "blocked" ? "Review interoperability lineage is blocked." : null,
+        })
+      )
+    : [
+        adapterReference({
+          idParts: ["review", "missing"],
+          referenceType: "review",
+          status: "unavailable",
+          label: "Review interoperability lineage",
+          description: "Operator review lineage is unavailable.",
+          destination: "/review-timeline",
+        }),
+      ];
+
+  const sharingReferences = sharingRooms.length
+    ? sharingRooms.map((room) =>
+        adapterReference({
+          idParts: ["sharing", referenceId(room, ["sharingRoomId", "id"]) || "unknown"],
+          referenceType: "sharing",
+          status: room.publiclyAccessible || room.externalExecutionEnabled || room.status === "blocked" ? "blocked" : room.status === "active" ? "verified" : "partially_verified",
+          label: "Sharing interoperability boundary",
+          description: "Institutional sharing metadata is available as a reviewable interoperability boundary.",
+          lineageReferences: [referenceId(room, ["sharingRoomId", "id"])].filter(Boolean),
+          destination: "/institutional-sharing-rooms",
+          blockedReason: room.publiclyAccessible || room.externalExecutionEnabled ? "Public access or external execution is not allowed for interoperability readiness." : null,
+        })
+      )
+    : [
+        adapterReference({
+          idParts: ["sharing", "missing"],
+          referenceType: "sharing",
+          status: "unavailable",
+          label: "Sharing interoperability boundary",
+          description: "Institutional sharing metadata is unavailable.",
+          destination: "/institutional-sharing-rooms",
+        }),
+      ];
+
+  const auditReferences = auditEvents.length
+    ? auditEvents.slice(0, 12).map((record) =>
+        adapterReference({
+          idParts: ["audit", referenceId(record, ["eventId", "id"]) || "unknown"],
+          referenceType: "audit",
+          status: record.redacted ? "partially_verified" : "verified",
+          label: "Audit interoperability lineage",
+          description: "Canonical audit event metadata is available for interoperability readiness review.",
+          lineageReferences: [referenceId(record, ["eventId", "id"])].filter(Boolean),
+          destination: "/review-timeline",
+          redacted: Boolean(record.redacted),
+          redactionReason: record.redacted ? "Audit payload is redacted for interoperability safety." : null,
+        })
+      )
+    : [
+        adapterReference({
+          idParts: ["audit", "missing"],
+          referenceType: "audit",
+          status: "unavailable",
+          label: "Audit interoperability lineage",
+          description: "Canonical audit event metadata is unavailable.",
+          destination: "/review-timeline",
+        }),
+      ];
+
+  const allReferences = [
+    ...compatibilityReferences,
+    ...settlementReferences,
+    ...regulatoryReferences,
+    ...evidenceReferences,
+    ...reviewReferences,
+    ...sharingReferences,
+    ...auditReferences,
+  ];
+
+  const adapterRestrictions = [
+    ...allReferences
+      .filter((reference) => reference.status !== "verified")
+      .map((reference) =>
+        adapterRestriction({
+          idParts: [reference.referenceType, reference.referenceId],
+          restrictionType: reference.referenceType === "compatibility" ? "compatibility" : reference.referenceType,
+          status: reference.status === "blocked" ? "blocked" : "review_required",
+          label: `${reference.label} restriction`,
+          description: `${reference.label} is incomplete or blocked for interoperability readiness.`,
+          blockedReason: reference.blockedReason,
+        })
+      ),
+  ];
+
+  const hasContext = Boolean(
+    landlordId &&
+      (compatibilitySources.length || settlementReadiness || regulatoryProfiles.length || evidencePacks.length || reviews.length || sharingRooms.length || auditEvents.length)
+  );
+  const status = readinessStatus(hasContext, allReferences);
+  const blockedReasons = [...allReferences.map((reference) => reference.blockedReason), ...adapterRestrictions.map((restriction) => restriction.blockedReason)].filter(Boolean) as string[];
+
+  const canonicalEvents: InteroperabilityAdapterCanonicalEvent[] = [
+    event({
+      eventType: "interoperability_adapter_readiness_derived",
+      status,
+      adapterReadinessId,
+      summary: "Interoperability adapter readiness derived from compatibility, settlement, regulatory, evidence, review, sharing, and audit metadata.",
+    }),
+    event({
+      eventType: "interoperability_adapter_redaction_applied",
+      status,
+      adapterReadinessId,
+      summary: "Integration credentials, webhook secrets, external payloads, sensitive identity, screening, credit, payment, and private tenant payloads were excluded.",
+    }),
+  ];
+  if (adapterRestrictions.length) {
+    canonicalEvents.push(
+      event({
+        eventType: "interoperability_adapter_restriction_detected",
+        status,
+        adapterReadinessId,
+        summary: "Interoperability adapter restrictions are visible for manual review.",
+      })
+    );
+  }
+  if (status === "review_required" || status === "partially_ready") {
+    canonicalEvents.push(
+      event({
+        eventType: "interoperability_adapter_review_required",
+        status,
+        adapterReadinessId,
+        summary: "Manual interoperability readiness review is required.",
+      })
+    );
+  }
+  if (status === "blocked") {
+    canonicalEvents.push(
+      event({
+        eventType: "interoperability_adapter_blocked",
+        status,
+        adapterReadinessId,
+        summary: "Interoperability readiness is blocked by unsafe or missing required lineage.",
+      })
+    );
+  }
+
+  return {
+    adapterReadinessId,
+    adapterType,
+    status,
+    manualReviewRequired: true,
+    liveIntegrationEnabled: false,
+    externalSynchronizationEnabled: false,
+    generatedAt: generatedAt(input.generatedAt),
+    summary: {
+      totalReferences: allReferences.length,
+      verifiedReferences: allReferences.filter((reference) => reference.status === "verified").length,
+      partiallyVerifiedReferences: allReferences.filter((reference) => reference.status === "partially_verified").length,
+      blockedReferences: allReferences.filter((reference) => reference.status === "blocked").length,
+      unavailableReferences: allReferences.filter((reference) => reference.status === "unavailable").length,
+      restrictions: adapterRestrictions.length,
+    },
+    compatibilityReferences,
+    settlementReferences,
+    regulatoryReferences,
+    evidenceReferences,
+    reviewReferences,
+    sharingReferences,
+    auditReferences,
+    adapterRestrictions,
+    redactions: REDACTIONS,
+    blockedReasons,
+    canonicalEvents,
+  };
+}

--- a/rentchain-api/src/lib/interoperabilityAdapters/interoperabilityAdapterTypes.ts
+++ b/rentchain-api/src/lib/interoperabilityAdapters/interoperabilityAdapterTypes.ts
@@ -1,0 +1,90 @@
+export type InteroperabilityAdapterType = "lender" | "insurer" | "regulator" | "registry" | "accounting" | "payment_provider" | "operational_partner";
+
+export type InteroperabilityAdapterStatus = "ready_for_review" | "partially_ready" | "review_required" | "blocked" | "unknown";
+
+export type InteroperabilityAdapterReferenceType = "compatibility" | "settlement" | "regulatory" | "evidence" | "review" | "sharing" | "audit";
+
+export type InteroperabilityAdapterReferenceStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+
+export type InteroperabilityAdapterCanonicalEventType =
+  | "interoperability_adapter_readiness_derived"
+  | "interoperability_adapter_review_required"
+  | "interoperability_adapter_blocked"
+  | "interoperability_adapter_restriction_detected"
+  | "interoperability_adapter_redaction_applied";
+
+export type InteroperabilityAdapterReference = {
+  referenceId: string;
+  referenceType: InteroperabilityAdapterReferenceType;
+  status: InteroperabilityAdapterReferenceStatus;
+  label: string;
+  description: string;
+  reviewRequired: true;
+  lineageReferences: string[];
+  destination: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type InteroperabilityAdapterRestriction = {
+  restrictionId: string;
+  restrictionType: "compatibility" | "settlement" | "regulatory" | "evidence" | "review" | "sharing" | "audit" | "risk";
+  status: "visible" | "blocked" | "review_required";
+  label: string;
+  description: string;
+  blockedReason: string | null;
+};
+
+export type InteroperabilityAdapterCanonicalEvent = {
+  eventType: InteroperabilityAdapterCanonicalEventType;
+  action: string;
+  status: InteroperabilityAdapterStatus;
+  resourceType: "interoperability_adapter_readiness";
+  resourceId: string;
+  summary: string;
+};
+
+export type InteroperabilityAdapterReadiness = {
+  adapterReadinessId: string;
+  adapterType: InteroperabilityAdapterType;
+  status: InteroperabilityAdapterStatus;
+  manualReviewRequired: true;
+  liveIntegrationEnabled: false;
+  externalSynchronizationEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    partiallyVerifiedReferences: number;
+    blockedReferences: number;
+    unavailableReferences: number;
+    restrictions: number;
+  };
+  compatibilityReferences: InteroperabilityAdapterReference[];
+  settlementReferences: InteroperabilityAdapterReference[];
+  regulatoryReferences: InteroperabilityAdapterReference[];
+  evidenceReferences: InteroperabilityAdapterReference[];
+  reviewReferences: InteroperabilityAdapterReference[];
+  sharingReferences: InteroperabilityAdapterReference[];
+  auditReferences: InteroperabilityAdapterReference[];
+  adapterRestrictions: InteroperabilityAdapterRestriction[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: InteroperabilityAdapterCanonicalEvent[];
+};
+
+export type DeriveInteroperabilityAdapterReadinessInput = {
+  landlordId?: unknown;
+  adapterType?: unknown;
+  generatedAt?: unknown;
+  operationalRiskProfiles?: Array<Record<string, any>> | null;
+  institutionOnboardingReadiness?: Array<Record<string, any>> | null;
+  trustRelationships?: Array<Record<string, any>> | null;
+  sharingRooms?: Array<Record<string, any>> | null;
+  settlementReadiness?: Record<string, any> | null;
+  regulatoryProfiles?: Array<Record<string, any>> | null;
+  evidencePacks?: Array<Record<string, any>> | null;
+  operatorReviewSessions?: Array<Record<string, any>> | null;
+  auditEvents?: Array<Record<string, any>> | null;
+};

--- a/rentchain-api/src/routes/__tests__/landlordInteroperabilityAdapterRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordInteroperabilityAdapterRoutes.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+  function matches(doc: any, filters: Array<{ field: string; op: string; value: any }>) {
+    return filters.every(({ field, op, value }) => (op === "==" ? doc?.data?.[field] === value : false));
+  }
+  function makeQuery(name: string, filters: Array<{ field: string; op: string; value: any }> = []) {
+    return {
+      where: (field: string, op: string, value: any) => makeQuery(name, [...filters, { field, op, value }]),
+      get: async () => {
+        const docs = Array.from(ensureCollection(name).values())
+          .filter((doc) => matches(doc, filters))
+          .map((doc) => ({ id: doc.id, exists: true, data: () => doc.data }));
+        return { docs, empty: docs.length === 0, size: docs.length };
+      },
+      doc: (id: string) => makeDoc(name, id),
+    };
+  }
+  function makeDoc(name: string, id: string) {
+    const col = ensureCollection(name);
+    return {
+      id,
+      get: async () => {
+        const entry = col.get(id);
+        return { id, exists: Boolean(entry), data: () => entry?.data };
+      },
+      set: async (data: any) => {
+        col.set(id, { id, data });
+      },
+    };
+  }
+  return {
+    resetFakeDb: () => store.clear(),
+    seedDoc: (collection: string, id: string, data: any) => ensureCollection(collection).set(id, { id, data }),
+    fakeDb: {
+      collection: (name: string) => ({
+        where: (field: string, op: string, value: any) => makeQuery(name, [{ field, op, value }]),
+        get: async () => makeQuery(name).get(),
+        doc: (id: string) => makeDoc(name, id),
+      }),
+    },
+  };
+});
+
+let mockUser: any;
+
+vi.mock("../../config/firebase", () => ({ db: fakeDb }));
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!mockUser) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    req.user = mockUser;
+    return next();
+  },
+}));
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: any, res: any, next: any) => {
+    const role = String(req.user?.role || "").trim().toLowerCase();
+    const landlordId = req.user?.landlordId || req.user?.id;
+    if (role !== "landlord" && role !== "admin") return res.status(403).json({ ok: false, error: "Forbidden" });
+    req.user.landlordId = landlordId;
+    return next();
+  },
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; user?: Record<string, unknown> | null }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    mockUser = options.user ?? mockUser;
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: mockUser,
+      query: Object.fromEntries(new URLSearchParams(queryString || "").entries()),
+      params: {},
+      body: {},
+      headers: {},
+    };
+    const match = path.match(/^\/interoperability-adapters\/(.+)$/);
+    if (match) req.params = { adapterReadinessId: decodeURIComponent(match[1]) };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => (error ? reject(error) : undefined));
+  });
+}
+
+describe("landlordInteroperabilityAdapterRoutes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    resetFakeDb();
+    mockUser = { id: "landlord-1", landlordId: "landlord-1", role: "landlord" };
+  });
+
+  function seedAdapterContext() {
+    seedDoc("properties", "property-1", { landlordId: "landlord-1", propertyId: "property-1", province: "NS", municipality: "Halifax" });
+    seedDoc("operatorReviewSessions", "review-1", { landlordId: "landlord-1", reviewSessionId: "review-1", status: "completed" });
+    seedDoc("evidencePacks", "evidence-1", { landlordId: "landlord-1", evidencePackId: "evidence-1", status: "ready_for_review", rawGovernmentId: "sensitive-id" });
+    seedDoc("institutionalSharingRooms", "room-1", {
+      landlordId: "landlord-1",
+      sharingRoomId: "room-1",
+      status: "active",
+      publiclyAccessible: false,
+      externalExecutionEnabled: false,
+      accessControls: { institutionType: "lender" },
+    });
+    seedDoc("events", "event-1", { landlordId: "landlord-1", eventId: "event-1", eventType: "operational_risk_profile_derived" });
+    seedDoc("consents", "consent-1", { landlordId: "landlord-1", consentScope: "interoperability" });
+  }
+
+  it("returns landlord-scoped adapter readiness without sensitive payloads", async () => {
+    seedAdapterContext();
+    const router = (await import("../landlordInteroperabilityAdapterRoutes")).default;
+
+    const res = await invokeRouter(router, { method: "GET", url: "/interoperability-adapters?adapterType=lender" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.readiness).toHaveLength(1);
+    expect(res.body.readiness[0]).toEqual(
+      expect.objectContaining({ manualReviewRequired: true, liveIntegrationEnabled: false, externalSynchronizationEnabled: false })
+    );
+    expect(JSON.stringify(res.body)).not.toContain("sensitive-id");
+  });
+
+  it("returns a single adapter readiness item by id", async () => {
+    seedAdapterContext();
+    const router = (await import("../landlordInteroperabilityAdapterRoutes")).default;
+    const list = await invokeRouter(router, { method: "GET", url: "/interoperability-adapters?adapterType=lender" });
+    const id = list.body.readiness[0].adapterReadinessId;
+
+    const res = await invokeRouter(router, { method: "GET", url: `/interoperability-adapters/${encodeURIComponent(id)}` });
+
+    expect(res.status).toBe(200);
+    expect(res.body.readiness.adapterReadinessId).toBe(id);
+  });
+
+  it("filters by status and blocks non-landlord users", async () => {
+    seedAdapterContext();
+    const router = (await import("../landlordInteroperabilityAdapterRoutes")).default;
+
+    const filtered = await invokeRouter(router, { method: "GET", url: "/interoperability-adapters?adapterType=lender&status=unknown" });
+    expect(filtered.status).toBe(200);
+    expect(filtered.body.readiness).toEqual([]);
+
+    const forbidden = await invokeRouter(router, { method: "GET", url: "/interoperability-adapters", user: { id: "tenant-1", role: "tenant" } });
+    expect(forbidden.status).toBe(403);
+  });
+});

--- a/rentchain-api/src/routes/landlordInteroperabilityAdapterRoutes.ts
+++ b/rentchain-api/src/routes/landlordInteroperabilityAdapterRoutes.ts
@@ -1,0 +1,245 @@
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { requireAuth } from "../middleware/requireAuth";
+import { requireLandlord } from "../middleware/requireLandlord";
+import { deriveAutomatedWorkflowTransitions } from "../lib/automatedWorkflows/deriveAutomatedWorkflowTransitions";
+import { deriveCrossOrganizationTrust } from "../lib/crossOrganizationTrust/deriveCrossOrganizationTrust";
+import { deriveIdentityProfile } from "../lib/identityLayer/deriveIdentityProfile";
+import { deriveInstitutionOnboardingReadiness } from "../lib/institutionOnboarding/deriveInstitutionOnboardingReadiness";
+import { deriveInteroperabilityAdapterReadiness } from "../lib/interoperabilityAdapters/deriveInteroperabilityAdapterReadiness";
+import { deriveNetworkParticipantProfile } from "../lib/networkParticipants/deriveNetworkParticipantProfile";
+import { deriveOperationalRiskProfile } from "../lib/operationalRisk/deriveOperationalRiskProfile";
+import { deriveDelinquencySignals } from "../lib/payments/delinquencySignals";
+import { buildPaymentObligationLedgerRows } from "../lib/payments/paymentObligationLedger";
+import { deriveRegulatoryProfile } from "../lib/regulatoryProfiles/deriveRegulatoryProfile";
+import { deriveSettlementReadiness } from "../lib/settlementReadiness/deriveSettlementReadiness";
+import type { CrossOrganizationTrustRelationshipType } from "../lib/crossOrganizationTrust/crossOrganizationTrustTypes";
+import type { InstitutionType } from "../lib/institutionOnboarding/institutionOnboardingTypes";
+import type { InteroperabilityAdapterReadiness, InteroperabilityAdapterStatus, InteroperabilityAdapterType } from "../lib/interoperabilityAdapters/interoperabilityAdapterTypes";
+import type { NetworkParticipantType } from "../lib/networkParticipants/networkParticipantTypes";
+import type { OperationalRiskScope } from "../lib/operationalRisk/operationalRiskTypes";
+
+const router = Router();
+
+const ADAPTER_TYPES = new Set<InteroperabilityAdapterType>(["lender", "insurer", "regulator", "registry", "accounting", "payment_provider", "operational_partner"]);
+const STATUSES = new Set<InteroperabilityAdapterStatus>(["ready_for_review", "partially_ready", "review_required", "blocked", "unknown"]);
+const INSTITUTION_TYPES: InstitutionType[] = ["lender", "insurer", "auditor", "regulator", "municipality", "institutional_landlord", "operational_partner"];
+const PARTICIPANT_TYPES: NetworkParticipantType[] = ["landlord", "operator", "lender", "insurer", "auditor", "regulator", "contractor", "institutional_partner", "review_actor"];
+const TRUST_TYPES: CrossOrganizationTrustRelationshipType[] = ["operational_trust", "evidence_trust", "review_trust", "settlement_trust", "regulatory_trust", "sharing_trust"];
+const RISK_SCOPES: OperationalRiskScope[] = ["property", "lease", "participant", "institution", "workflow", "onboarding", "settlement", "regulatory"];
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function landlordIdFromReq(req: any) {
+  return asString(req.user?.landlordId || req.user?.id || req.user?.sub, 240);
+}
+
+function normalizedAdapterType(value: unknown): InteroperabilityAdapterType | "" {
+  const raw = asString(value, 80) as InteroperabilityAdapterType;
+  return ADAPTER_TYPES.has(raw) ? raw : "";
+}
+
+async function loadLandlordCollection(collectionName: string, landlordId: string) {
+  const byId = new Map<string, any>();
+  async function collect(field: "landlordId" | "ownerId" | "userId" | "createdByLandlordId") {
+    const snap = await db.collection(collectionName).where(field, "==", landlordId).get().catch(() => null);
+    for (const doc of snap?.docs || []) byId.set(doc.id, { id: doc.id, ...((doc.data() as any) || {}) });
+  }
+  await Promise.all([collect("landlordId"), collect("ownerId"), collect("userId"), collect("createdByLandlordId")]);
+  return Array.from(byId.values()).filter((record) =>
+    [record?.landlordId, record?.ownerId, record?.userId, record?.createdByLandlordId].some((value) => asString(value, 240) === landlordId)
+  );
+}
+
+function readinessMatches(readiness: InteroperabilityAdapterReadiness, id: string) {
+  return readiness.adapterReadinessId === id;
+}
+
+function participantTypeForInstitution(type: InstitutionType): NetworkParticipantType {
+  if (type === "lender" || type === "insurer" || type === "auditor" || type === "regulator") return type;
+  if (type === "institutional_landlord") return "landlord";
+  return "institutional_partner";
+}
+
+async function buildAdapterReadiness(landlordId: string, adapterType: InteroperabilityAdapterType | "") {
+  const [properties, registryStatuses, screeningOrders, consents, sharingRooms, evidencePacks, reviews, events, leases, paymentIntents, rentPayments, reconciliationRecords, contractors, decisions] =
+    await Promise.all([
+      loadLandlordCollection("properties", landlordId),
+      loadLandlordCollection("propertyRegistryStatuses", landlordId),
+      loadLandlordCollection("screeningOrders", landlordId),
+      loadLandlordCollection("consents", landlordId),
+      loadLandlordCollection("institutionalSharingRooms", landlordId),
+      loadLandlordCollection("evidencePacks", landlordId),
+      loadLandlordCollection("operatorReviewSessions", landlordId),
+      loadLandlordCollection("events", landlordId),
+      loadLandlordCollection("leases", landlordId),
+      loadLandlordCollection("paymentIntents", landlordId),
+      loadLandlordCollection("rentPayments", landlordId),
+      loadLandlordCollection("paymentReconciliationRecords", landlordId),
+      loadLandlordCollection("contractorProfiles", landlordId),
+      loadLandlordCollection("decisionInboxItems", landlordId),
+    ]);
+
+  const obligationRows = buildPaymentObligationLedgerRows({ leases, paymentIntents, rentPayments, reconciliationRecords });
+  const delinquencySignals = deriveDelinquencySignals(obligationRows);
+  const automatedWorkflows = deriveAutomatedWorkflowTransitions({ decisions: decisions as any[] }).workflows;
+  const settlementReadiness = deriveSettlementReadiness({
+    landlordId,
+    obligationRows,
+    reconciliationRecords,
+    evidencePacks,
+    operatorReviewSessions: reviews,
+    auditEvents: events,
+    decisions: decisions as any[],
+  });
+  const regulatoryProfile = deriveRegulatoryProfile({
+    landlordId,
+    properties,
+    registryStatuses,
+    screeningOrders,
+    consentRecords: consents,
+    sharingRooms,
+    institutionExportPackages: [],
+    evidencePacks,
+    operatorReviewSessions: reviews,
+    auditEvents: events,
+    settlementReadiness,
+  });
+
+  const identityProfiles = PARTICIPANT_TYPES.map((participantType) =>
+    deriveIdentityProfile({
+      identityType: participantType === "operator" || participantType === "review_actor" ? participantType : "organization",
+      identityId: participantType,
+      organization: { id: participantType, organizationId: participantType },
+      operator: reviews[0] || null,
+      consentRecords: consents,
+      reviewSessions: reviews,
+      canonicalEvents: events,
+    })
+  );
+
+  const networkParticipants = PARTICIPANT_TYPES.map((participantType, index) =>
+    deriveNetworkParticipantProfile({
+      landlordId,
+      participantType,
+      participantId: participantType,
+      identityProfiles: [identityProfiles[index]],
+      sharingRooms:
+        participantType === "lender" || participantType === "insurer" || participantType === "auditor" || participantType === "regulator"
+          ? sharingRooms.filter((room) => asString(room.accessControls?.institutionType || room.institutionType, 80) === participantType)
+          : sharingRooms,
+      operatorReviewSessions: reviews,
+      evidencePacks,
+      settlementReadiness,
+      regulatoryProfiles: [regulatoryProfile],
+      canonicalEvents: events,
+      contractorProfiles: participantType === "contractor" ? contractors : [],
+    })
+  );
+
+  const trustRelationships = TRUST_TYPES.map((relationshipType) =>
+    deriveCrossOrganizationTrust({
+      landlordId,
+      relationshipType,
+      networkParticipants,
+      evidencePacks,
+      operatorReviewSessions: reviews,
+      settlementReadiness,
+      regulatoryProfiles: [regulatoryProfile],
+      sharingRooms,
+      auditEvents: events,
+      consentRecords: consents,
+    })
+  );
+
+  const institutionOnboardingReadiness = INSTITUTION_TYPES.map((type) => {
+    const participantType = participantTypeForInstitution(type);
+    return deriveInstitutionOnboardingReadiness({
+      landlordId,
+      institutionType: type,
+      networkParticipants: networkParticipants.filter((participant) => participant.participantType === participantType),
+      trustRelationships,
+      identityProfiles: identityProfiles.filter((profile) => profile.identityId === participantType || profile.identityId === type),
+      evidencePacks,
+      operatorReviewSessions: reviews,
+      settlementReadiness,
+      regulatoryProfiles: [regulatoryProfile],
+      sharingRooms:
+        type === "lender" || type === "insurer" || type === "auditor" || type === "regulator"
+          ? sharingRooms.filter((room) => asString(room.accessControls?.institutionType || room.institutionType, 80) === type)
+          : sharingRooms,
+      auditEvents: events,
+      consentRecords: consents,
+    });
+  });
+
+  const operationalRiskProfiles = RISK_SCOPES.map((riskScope) =>
+    deriveOperationalRiskProfile({
+      landlordId,
+      riskScope,
+      evidencePacks,
+      operatorReviewSessions: reviews,
+      settlementReadiness,
+      regulatoryProfiles: [regulatoryProfile],
+      institutionOnboardingReadiness,
+      trustRelationships,
+      automatedWorkflows,
+      delinquencySignals,
+      auditEvents: events,
+    })
+  );
+
+  const types = adapterType ? [adapterType] : Array.from(ADAPTER_TYPES);
+  return types.map((type) =>
+    deriveInteroperabilityAdapterReadiness({
+      landlordId,
+      adapterType: type,
+      operationalRiskProfiles,
+      institutionOnboardingReadiness,
+      trustRelationships,
+      sharingRooms:
+        type === "lender" || type === "insurer" || type === "regulator"
+          ? sharingRooms.filter((room) => asString(room.accessControls?.institutionType || room.institutionType, 80) === type)
+          : sharingRooms,
+      settlementReadiness,
+      regulatoryProfiles: [regulatoryProfile],
+      evidencePacks,
+      operatorReviewSessions: reviews,
+      auditEvents: events,
+    })
+  );
+}
+
+router.get("/interoperability-adapters", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = landlordIdFromReq(req);
+    if (!landlordId) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    const adapterType = normalizedAdapterType(req.query?.adapterType);
+    const status = asString(req.query?.status, 80) as InteroperabilityAdapterStatus;
+    let readiness = await buildAdapterReadiness(landlordId, adapterType);
+    if (status && STATUSES.has(status)) readiness = readiness.filter((item) => item.status === status);
+    return res.json({ ok: true, readiness });
+  } catch (err: any) {
+    console.error("[landlord-interoperability-adapters] list failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "INTEROPERABILITY_ADAPTER_READINESS_FAILED" });
+  }
+});
+
+router.get("/interoperability-adapters/:adapterReadinessId", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = landlordIdFromReq(req);
+    const adapterReadinessId = decodeURIComponent(asString(req.params?.adapterReadinessId, 500));
+    if (!landlordId || !adapterReadinessId) return res.status(400).json({ ok: false, error: "ADAPTER_READINESS_ID_REQUIRED" });
+    const readiness = await buildAdapterReadiness(landlordId, "");
+    const item = readiness.find((next) => readinessMatches(next, adapterReadinessId));
+    if (!item) return res.status(404).json({ ok: false, error: "ADAPTER_READINESS_NOT_FOUND" });
+    return res.json({ ok: true, readiness: item });
+  } catch (err: any) {
+    console.error("[landlord-interoperability-adapters] get failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "INTEROPERABILITY_ADAPTER_READINESS_GET_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -158,6 +158,10 @@ vi.mock("./pages/OperationalRiskPage", () => ({
   default: () => <h1>Operational Risk Page</h1>,
 }));
 
+vi.mock("./pages/InteroperabilityAdapterPage", () => ({
+  default: () => <h1>Interoperability Adapter Page</h1>,
+}));
+
 vi.mock("./pages/landlord/PortfolioScorePage", () => ({
   default: () => <h1>Landlord Portfolio Score</h1>,
 }));
@@ -503,6 +507,20 @@ describe("Routes: /operational-risk", () => {
     );
 
     expect(await screen.findByText(/Operational Risk Page/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Routes: /interoperability-adapters", () => {
+  it("renders the interoperability adapters route", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/interoperability-adapters?adapterType=lender"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Interoperability Adapter Page/i)).toBeInTheDocument();
     expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -132,6 +132,7 @@ const NetworkParticipantsPage = lazy(() => import("./pages/NetworkParticipantsPa
 const CrossOrganizationTrustPage = lazy(() => import("./pages/CrossOrganizationTrustPage"));
 const InstitutionOnboardingReadinessPage = lazy(() => import("./pages/InstitutionOnboardingReadinessPage"));
 const OperationalRiskPage = lazy(() => import("./pages/OperationalRiskPage"));
+const InteroperabilityAdapterPage = lazy(() => import("./pages/InteroperabilityAdapterPage"));
 const LandlordPortfolioScorePage = lazy(() => import("./pages/landlord/PortfolioScorePage"));
 const SharedPortfolioScorePage = lazy(() => import("./pages/public/SharedPortfolioScorePage"));
 const TenantSharePackagePage = lazy(() => import("./pages/public/TenantSharePackagePage"));
@@ -707,6 +708,18 @@ function App() {
               <LandlordNav>
                 <Suspense fallback={null}>
                   <OperationalRiskPage />
+                </Suspense>
+              </LandlordNav>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/interoperability-adapters"
+          element={
+            <RequireAuth>
+              <LandlordNav>
+                <Suspense fallback={null}>
+                  <InteroperabilityAdapterPage />
                 </Suspense>
               </LandlordNav>
             </RequireAuth>

--- a/rentchain-frontend/src/api/interoperabilityAdaptersApi.ts
+++ b/rentchain-frontend/src/api/interoperabilityAdaptersApi.ts
@@ -1,0 +1,77 @@
+import { apiFetch } from "./apiFetch";
+
+export type InteroperabilityAdapterType = "lender" | "insurer" | "regulator" | "registry" | "accounting" | "payment_provider" | "operational_partner";
+export type InteroperabilityAdapterStatus = "ready_for_review" | "partially_ready" | "review_required" | "blocked" | "unknown";
+export type InteroperabilityAdapterReferenceType = "compatibility" | "settlement" | "regulatory" | "evidence" | "review" | "sharing" | "audit";
+export type InteroperabilityAdapterReferenceStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+
+export type InteroperabilityAdapterReference = {
+  referenceId: string;
+  referenceType: InteroperabilityAdapterReferenceType;
+  status: InteroperabilityAdapterReferenceStatus;
+  label: string;
+  description: string;
+  reviewRequired: true;
+  lineageReferences: string[];
+  destination: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type InteroperabilityAdapterRestriction = {
+  restrictionId: string;
+  restrictionType: "compatibility" | "settlement" | "regulatory" | "evidence" | "review" | "sharing" | "audit" | "risk";
+  status: "visible" | "blocked" | "review_required";
+  label: string;
+  description: string;
+  blockedReason: string | null;
+};
+
+export type InteroperabilityAdapterReadiness = {
+  adapterReadinessId: string;
+  adapterType: InteroperabilityAdapterType;
+  status: InteroperabilityAdapterStatus;
+  manualReviewRequired: true;
+  liveIntegrationEnabled: false;
+  externalSynchronizationEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    partiallyVerifiedReferences: number;
+    blockedReferences: number;
+    unavailableReferences: number;
+    restrictions: number;
+  };
+  compatibilityReferences: InteroperabilityAdapterReference[];
+  settlementReferences: InteroperabilityAdapterReference[];
+  regulatoryReferences: InteroperabilityAdapterReference[];
+  evidenceReferences: InteroperabilityAdapterReference[];
+  reviewReferences: InteroperabilityAdapterReference[];
+  sharingReferences: InteroperabilityAdapterReference[];
+  auditReferences: InteroperabilityAdapterReference[];
+  adapterRestrictions: InteroperabilityAdapterRestriction[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: Array<{ eventType: string; action: string; status: InteroperabilityAdapterStatus; resourceId: string; summary: string }>;
+};
+
+export async function fetchInteroperabilityAdapterReadiness(params?: {
+  adapterType?: InteroperabilityAdapterType | "";
+  status?: InteroperabilityAdapterStatus | "";
+}): Promise<InteroperabilityAdapterReadiness[]> {
+  const search = new URLSearchParams();
+  if (params?.adapterType) search.set("adapterType", params.adapterType);
+  if (params?.status) search.set("status", params.status);
+  const suffix = search.toString() ? `?${search.toString()}` : "";
+  const response = await apiFetch<{ ok: true; readiness: InteroperabilityAdapterReadiness[] }>(`/landlord/interoperability-adapters${suffix}`);
+  return response.readiness;
+}
+
+export async function fetchInteroperabilityAdapterReadinessItem(adapterReadinessId: string): Promise<InteroperabilityAdapterReadiness> {
+  const response = await apiFetch<{ ok: true; readiness: InteroperabilityAdapterReadiness }>(
+    `/landlord/interoperability-adapters/${encodeURIComponent(adapterReadinessId)}`
+  );
+  return response.readiness;
+}

--- a/rentchain-frontend/src/components/interoperability/InteroperabilityAdapterPanel.test.tsx
+++ b/rentchain-frontend/src/components/interoperability/InteroperabilityAdapterPanel.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import type { InteroperabilityAdapterReadiness } from "@/api/interoperabilityAdaptersApi";
+import { InteroperabilityAdapterPanel } from "./InteroperabilityAdapterPanel";
+
+const readiness: InteroperabilityAdapterReadiness = {
+  adapterReadinessId: "interoperability_adapter_readiness:landlord-1:lender",
+  adapterType: "lender",
+  status: "partially_ready",
+  manualReviewRequired: true,
+  liveIntegrationEnabled: false,
+  externalSynchronizationEnabled: false,
+  generatedAt: "2026-01-01T00:00:00.000Z",
+  summary: {
+    totalReferences: 1,
+    verifiedReferences: 0,
+    partiallyVerifiedReferences: 1,
+    blockedReferences: 0,
+    unavailableReferences: 0,
+    restrictions: 1,
+  },
+  compatibilityReferences: [
+    {
+      referenceId: "compatibility-1",
+      referenceType: "compatibility",
+      status: "partially_verified",
+      label: "Compatibility readiness reference",
+      description: "Operational compatibility metadata is available.",
+      reviewRequired: true,
+      lineageReferences: ["risk-1"],
+      destination: "/operational-risk",
+      redacted: false,
+      redactionReason: null,
+      blockedReason: null,
+    },
+  ],
+  settlementReferences: [],
+  regulatoryReferences: [],
+  evidenceReferences: [],
+  reviewReferences: [],
+  sharingReferences: [],
+  auditReferences: [],
+  adapterRestrictions: [],
+  redactions: ["Live integration credentials, webhook secrets, and external API payloads are excluded."],
+  blockedReasons: [],
+  canonicalEvents: [],
+};
+
+describe("InteroperabilityAdapterPanel", () => {
+  it("renders required safety copy and compatibility references", () => {
+    render(
+      <MemoryRouter>
+        <InteroperabilityAdapterPanel readiness={readiness} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("View interoperability readiness")).toBeInTheDocument();
+    expect(screen.getByText(/No live integrations or autonomous synchronization is enabled/i)).toBeInTheDocument();
+    expect(screen.getByText("Manual review required")).toBeInTheDocument();
+    expect(screen.getByText("View compatibility references")).toBeInTheDocument();
+    expect(screen.getByText("Live integration credentials, webhook secrets, and external API payloads are excluded.")).toBeInTheDocument();
+  });
+
+  it("omits forbidden interoperability labels", () => {
+    render(
+      <MemoryRouter>
+        <InteroperabilityAdapterPanel readiness={readiness} />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText("Connect integration")).not.toBeInTheDocument();
+    expect(screen.queryByText("Enable sync")).not.toBeInTheDocument();
+    expect(screen.queryByText("Auto-sync")).not.toBeInTheDocument();
+    expect(screen.queryByText("Connect lender")).not.toBeInTheDocument();
+    expect(screen.queryByText("Connect regulator")).not.toBeInTheDocument();
+    expect(screen.queryByText("Connect payment provider")).not.toBeInTheDocument();
+    expect(screen.queryByText("Autonomous integration")).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/interoperability/InteroperabilityAdapterPanel.tsx
+++ b/rentchain-frontend/src/components/interoperability/InteroperabilityAdapterPanel.tsx
@@ -1,0 +1,137 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import type { InteroperabilityAdapterReadiness, InteroperabilityAdapterReference, InteroperabilityAdapterRestriction } from "@/api/interoperabilityAdaptersApi";
+import { Card, Section } from "@/components/ui/Ui";
+
+function label(value: string) {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function tone(status: string) {
+  if (status === "blocked") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
+  if (status === "review_required" || status === "partially_ready" || status === "partially_verified" || status === "unavailable") return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
+  if (status === "ready_for_review" || status === "verified") return { color: "#166534", background: "#dcfce7", border: "#bbf7d0" };
+  return { color: "#475569", background: "#f8fafc", border: "#e2e8f0" };
+}
+
+function Badge({ children, status }: { children: React.ReactNode; status: string }) {
+  const next = tone(status);
+  return (
+    <span style={{ border: `1px solid ${next.border}`, borderRadius: 999, background: next.background, color: next.color, padding: "3px 9px", fontSize: 12, fontWeight: 900, whiteSpace: "nowrap" }}>
+      {children}
+    </span>
+  );
+}
+
+function ReferenceList({ title, references }: { title: string; references: InteroperabilityAdapterReference[] }) {
+  return (
+    <Section style={{ display: "grid", gap: 10 }}>
+      <div style={{ fontWeight: 900 }}>{title}</div>
+      {references.length ? (
+        references.slice(0, 12).map((reference) => (
+          <Card key={reference.referenceId} style={{ borderRadius: 8, padding: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+              <div>
+                <strong>{reference.label}</strong>
+                <div style={{ color: "#64748b", fontSize: 13 }}>{label(reference.referenceType)}</div>
+              </div>
+              <Badge status={reference.status}>{label(reference.status)}</Badge>
+            </div>
+            <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>{reference.description}</div>
+            {reference.lineageReferences.length ? <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>Lineage references: {reference.lineageReferences.length}</div> : null}
+            {reference.blockedReason ? <div style={{ color: "#991b1b", fontSize: 13, marginTop: 8 }}>View blocked reason: {reference.blockedReason}</div> : null}
+            {reference.redacted ? <div style={{ color: "#92400e", fontSize: 13, marginTop: 8 }}>{reference.redactionReason || "Redacted interoperability reference"}</div> : null}
+            {reference.destination ? <Link to={reference.destination} style={{ color: "#2563eb", fontWeight: 800, fontSize: 13, marginTop: 8, display: "inline-block" }}>View context</Link> : null}
+          </Card>
+        ))
+      ) : (
+        <Card style={{ color: "#64748b" }}>Context unavailable</Card>
+      )}
+    </Section>
+  );
+}
+
+function RestrictionList({ restrictions }: { restrictions: InteroperabilityAdapterRestriction[] }) {
+  return (
+    <Section style={{ display: "grid", gap: 10 }}>
+      <div style={{ fontWeight: 900 }}>View restrictions</div>
+      {restrictions.length ? (
+        restrictions.map((restriction) => (
+          <Card key={restriction.restrictionId} style={{ borderRadius: 8, padding: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+              <div>
+                <strong>{restriction.label}</strong>
+                <div style={{ color: "#64748b", fontSize: 13 }}>{label(restriction.restrictionType)}</div>
+              </div>
+              <Badge status={restriction.status}>{label(restriction.status)}</Badge>
+            </div>
+            <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>{restriction.description}</div>
+            {restriction.blockedReason ? <div style={{ color: "#991b1b", fontSize: 13, marginTop: 8 }}>View blocked reason: {restriction.blockedReason}</div> : null}
+          </Card>
+        ))
+      ) : (
+        <Card style={{ color: "#64748b" }}>No interoperability restrictions detected.</Card>
+      )}
+    </Section>
+  );
+}
+
+export function InteroperabilityAdapterPanel({ readiness }: { readiness: InteroperabilityAdapterReadiness }) {
+  return (
+    <div style={{ display: "grid", gap: 16 }}>
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+          <div>
+            <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>View interoperability readiness</div>
+            <h2 style={{ margin: "2px 0 0", fontSize: "1.15rem" }}>{label(readiness.adapterType)}</h2>
+          </div>
+          <Badge status={readiness.status}>{label(readiness.status)}</Badge>
+        </div>
+        <div style={{ color: "#475569", lineHeight: 1.55 }}>
+          Interoperability adapters are operationally scoped and review controlled. No live integrations or autonomous synchronization is enabled.
+          Manual review remains required.
+        </div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <Badge status="review_required">Manual review required</Badge>
+          <Badge status={readiness.liveIntegrationEnabled ? "blocked" : "verified"}>Live integration disabled</Badge>
+          <Badge status={readiness.externalSynchronizationEnabled ? "blocked" : "verified"}>External synchronization disabled</Badge>
+        </div>
+      </Section>
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Interoperability summary</div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: 10 }}>
+          {[
+            ["References", readiness.summary.totalReferences],
+            ["Verified", readiness.summary.verifiedReferences],
+            ["Partial", readiness.summary.partiallyVerifiedReferences],
+            ["Blocked", readiness.summary.blockedReferences],
+            ["Unavailable", readiness.summary.unavailableReferences],
+            ["Restrictions", readiness.summary.restrictions],
+          ].map(([name, value]) => (
+            <Card key={String(name)} style={{ borderRadius: 8, padding: 12 }}>
+              <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>{name}</div>
+              <strong style={{ color: "#0f172a", fontSize: 22 }}>{String(value)}</strong>
+            </Card>
+          ))}
+        </div>
+      </Section>
+
+      <RestrictionList restrictions={readiness.adapterRestrictions} />
+      <ReferenceList title="View compatibility references" references={readiness.compatibilityReferences} />
+      <ReferenceList title="Settlement dependencies" references={readiness.settlementReferences} />
+      <ReferenceList title="Regulatory dependencies" references={readiness.regulatoryReferences} />
+      <ReferenceList title="View evidence lineage" references={readiness.evidenceReferences} />
+      <ReferenceList title="View review lineage" references={readiness.reviewReferences} />
+      <ReferenceList title="Sharing boundaries" references={readiness.sharingReferences} />
+      <ReferenceList title="Audit references" references={readiness.auditReferences} />
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Redactions</div>
+        {readiness.redactions.map((redaction) => (
+          <Card key={redaction} style={{ borderRadius: 8, padding: 12, color: "#475569" }}>{redaction}</Card>
+        ))}
+      </Section>
+    </div>
+  );
+}

--- a/rentchain-frontend/src/pages/InteroperabilityAdapterPage.test.tsx
+++ b/rentchain-frontend/src/pages/InteroperabilityAdapterPage.test.tsx
@@ -1,0 +1,109 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import InteroperabilityAdapterPage from "./InteroperabilityAdapterPage";
+
+const mockFetchInteroperabilityAdapterReadiness = vi.fn();
+const mockShowToast = vi.fn();
+
+vi.mock("@/api/interoperabilityAdaptersApi", () => ({
+  fetchInteroperabilityAdapterReadiness: (...args: any[]) => mockFetchInteroperabilityAdapterReadiness(...args),
+}));
+
+vi.mock("@/components/layout/MacShell", () => ({
+  MacShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
+const readiness = {
+  adapterReadinessId: "interoperability_adapter_readiness:landlord-1:lender",
+  adapterType: "lender",
+  status: "ready_for_review",
+  manualReviewRequired: true,
+  liveIntegrationEnabled: false,
+  externalSynchronizationEnabled: false,
+  generatedAt: "2026-01-01T00:00:00.000Z",
+  summary: {
+    totalReferences: 1,
+    verifiedReferences: 1,
+    partiallyVerifiedReferences: 0,
+    blockedReferences: 0,
+    unavailableReferences: 0,
+    restrictions: 0,
+  },
+  compatibilityReferences: [],
+  settlementReferences: [],
+  regulatoryReferences: [],
+  evidenceReferences: [],
+  reviewReferences: [],
+  sharingReferences: [],
+  auditReferences: [],
+  adapterRestrictions: [],
+  redactions: ["Interoperability adapters are readiness metadata only; no external synchronization or execution is enabled."],
+  blockedReasons: [],
+  canonicalEvents: [],
+};
+
+describe("InteroperabilityAdapterPage", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchInteroperabilityAdapterReadiness.mockResolvedValue([readiness]);
+  });
+
+  it("renders interoperability readiness and required safety copy", async () => {
+    render(
+      <MemoryRouter>
+        <InteroperabilityAdapterPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Interoperability adapters")).toBeInTheDocument();
+    expect(screen.getAllByText(/No live integrations or autonomous synchronization is enabled/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("Interoperability adapters are readiness metadata only; no external synchronization or execution is enabled.")).toBeInTheDocument();
+  });
+
+  it("updates deterministic adapter and status filters", async () => {
+    render(
+      <MemoryRouter>
+        <InteroperabilityAdapterPage />
+      </MemoryRouter>
+    );
+
+    await screen.findByText("Interoperability adapters");
+    fireEvent.change(screen.getByLabelText("Adapter type"), { target: { value: "registry" } });
+    fireEvent.change(screen.getByLabelText("Status"), { target: { value: "blocked" } });
+
+    await waitFor(() => {
+      expect(mockFetchInteroperabilityAdapterReadiness).toHaveBeenLastCalledWith({
+        adapterType: "registry",
+        status: "blocked",
+      });
+    });
+  });
+
+  it("shows empty state and omits forbidden labels", async () => {
+    mockFetchInteroperabilityAdapterReadiness.mockResolvedValue([]);
+    render(
+      <MemoryRouter>
+        <InteroperabilityAdapterPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("No interoperability adapter readiness items match these filters.")).toBeInTheDocument();
+    expect(screen.queryByText("Connect integration")).not.toBeInTheDocument();
+    expect(screen.queryByText("Enable sync")).not.toBeInTheDocument();
+    expect(screen.queryByText("Auto-sync")).not.toBeInTheDocument();
+    expect(screen.queryByText("Connect lender")).not.toBeInTheDocument();
+    expect(screen.queryByText("Connect regulator")).not.toBeInTheDocument();
+    expect(screen.queryByText("Connect payment provider")).not.toBeInTheDocument();
+    expect(screen.queryByText("Autonomous integration")).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/InteroperabilityAdapterPage.tsx
+++ b/rentchain-frontend/src/pages/InteroperabilityAdapterPage.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { useSearchParams } from "react-router-dom";
+import {
+  fetchInteroperabilityAdapterReadiness,
+  type InteroperabilityAdapterReadiness,
+  type InteroperabilityAdapterStatus,
+  type InteroperabilityAdapterType,
+} from "@/api/interoperabilityAdaptersApi";
+import { InteroperabilityAdapterPanel } from "@/components/interoperability/InteroperabilityAdapterPanel";
+import { MacShell } from "@/components/layout/MacShell";
+import { Card, Section } from "@/components/ui/Ui";
+import { useToast } from "@/components/ui/ToastProvider";
+
+const adapterTypes: Array<InteroperabilityAdapterType | ""> = ["", "lender", "insurer", "regulator", "registry", "accounting", "payment_provider", "operational_partner"];
+const statuses: Array<InteroperabilityAdapterStatus | ""> = ["", "ready_for_review", "partially_ready", "review_required", "blocked", "unknown"];
+
+function label(value: string) {
+  return value ? value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase()) : "All";
+}
+
+export default function InteroperabilityAdapterPage() {
+  const { showToast } = useToast();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [readiness, setReadiness] = React.useState<InteroperabilityAdapterReadiness[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const adapterType = String(searchParams.get("adapterType") || "") as InteroperabilityAdapterType | "";
+  const status = String(searchParams.get("status") || "") as InteroperabilityAdapterStatus | "";
+
+  React.useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const next = await fetchInteroperabilityAdapterReadiness({ adapterType, status });
+        if (mounted) setReadiness(next);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Failed to load interoperability readiness";
+        if (mounted) {
+          setError(message);
+          showToast({ message: "Failed to load interoperability readiness", description: message, variant: "error" });
+        }
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [adapterType, status, showToast]);
+
+  function updateParams(next: { adapterType?: string; status?: string }) {
+    const params = new URLSearchParams(searchParams);
+    for (const [key, value] of Object.entries(next)) {
+      if (value && value.trim()) params.set(key, value.trim());
+      else params.delete(key);
+    }
+    setSearchParams(params);
+  }
+
+  return (
+    <MacShell title="Interoperability adapters" showTopNav={false}>
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "grid", gap: 6 }}>
+            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Interoperability adapters</h1>
+            <div style={{ color: "#475569", maxWidth: 900 }}>
+              Interoperability adapters are operationally scoped and review controlled. No live integrations or autonomous synchronization is enabled.
+              Manual review remains required.
+            </div>
+          </div>
+        </Section>
+
+        <Section style={{ display: "flex", gap: 10, flexWrap: "wrap", alignItems: "end" }}>
+          <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Adapter type
+            <select value={adapterType} onChange={(event) => updateParams({ adapterType: event.target.value })} style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 210 }}>
+              {adapterTypes.map((type) => <option key={type || "all"} value={type}>{label(type)}</option>)}
+            </select>
+          </label>
+          <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Status
+            <select value={status} onChange={(event) => updateParams({ status: event.target.value })} style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 180 }}>
+              {statuses.map((item) => <option key={item || "all"} value={item}>{label(item)}</option>)}
+            </select>
+          </label>
+        </Section>
+
+        {loading ? <Card>Loading interoperability readiness...</Card> : null}
+        {!loading && error ? <Card style={{ color: "#b91c1c" }}>We couldn't load interoperability readiness right now.</Card> : null}
+        {!loading && !error && !readiness.length ? <Card style={{ color: "#64748b" }}>No interoperability adapter readiness items match these filters.</Card> : null}
+        {!loading && !error && readiness.length ? (
+          <div style={{ display: "grid", gap: 16 }}>{readiness.map((item) => <InteroperabilityAdapterPanel key={item.adapterReadinessId} readiness={item} />)}</div>
+        ) : null}
+      </div>
+    </MacShell>
+  );
+}

--- a/rentchain-frontend/src/pages/OperationalRiskPage.test.tsx
+++ b/rentchain-frontend/src/pages/OperationalRiskPage.test.tsx
@@ -72,6 +72,7 @@ describe("OperationalRiskPage", () => {
 
     expect(await screen.findByText("Operational risk")).toBeInTheDocument();
     expect(screen.getAllByText(/No underwriting, autonomous enforcement, or public risk exposure is enabled/i).length).toBeGreaterThan(0);
+    expect(screen.getByRole("link", { name: "View interoperability readiness" })).toHaveAttribute("href", "/interoperability-adapters");
     expect(screen.getByText("Public risk exposure and autonomous enforcement are not enabled.")).toBeInTheDocument();
   });
 

--- a/rentchain-frontend/src/pages/OperationalRiskPage.tsx
+++ b/rentchain-frontend/src/pages/OperationalRiskPage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useSearchParams } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import {
   fetchOperationalRiskProfiles,
   type OperationalRiskProfile,
@@ -66,12 +66,15 @@ export default function OperationalRiskPage() {
     <MacShell title="Operational risk" showTopNav={false}>
       <div style={{ display: "grid", gap: 16 }}>
         <Section>
-          <div style={{ display: "grid", gap: 6 }}>
-            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Operational risk</h1>
-            <div style={{ color: "#475569", maxWidth: 900 }}>
-              Operational risk visibility is operationally scoped and review controlled. No underwriting, autonomous enforcement, or public risk exposure is enabled.
-              Manual review remains required.
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "start" }}>
+            <div style={{ display: "grid", gap: 6 }}>
+              <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Operational risk</h1>
+              <div style={{ color: "#475569", maxWidth: 900 }}>
+                Operational risk visibility is operationally scoped and review controlled. No underwriting, autonomous enforcement, or public risk exposure is enabled.
+                Manual review remains required.
+              </div>
             </div>
+            <Link to="/interoperability-adapters" style={{ color: "#2563eb", fontWeight: 900 }}>View interoperability readiness</Link>
           </div>
         </Section>
 


### PR DESCRIPTION
## Summary
- Adds deterministic, landlord-scoped Interoperability Adapter Layer read model
- Adds endpoints:
  - `GET /api/landlord/interoperability-adapters`
  - `GET /api/landlord/interoperability-adapters/:adapterReadinessId`
- Adds adapter readiness references for compatibility, settlement, regulatory, evidence, review, sharing, and audit lineage
- Adds descriptor-only canonical events:
  - `interoperability_adapter_readiness_derived`
  - `interoperability_adapter_review_required`
  - `interoperability_adapter_blocked`
  - `interoperability_adapter_restriction_detected`
  - `interoperability_adapter_redaction_applied`
- Adds frontend `/interoperability-adapters` page, `InteroperabilityAdapterPanel`, filters, and a safe Operational Risk entry link
- Adds architecture documentation for Interoperability Adapter Layer v1

## Guardrails
- Confirms `manualReviewRequired` remains `true`
- Confirms `liveIntegrationEnabled` remains `false`
- Confirms `externalSynchronizationEnabled` remains `false`
- Confirms no live integrations, external synchronization, webhooks, public APIs, regulator/lender/accounting/payment-provider API execution, autonomous synchronization, external data sending, or external data pulling was added
- Confirms raw government IDs, screening/credit payloads, payment account details, private tenant data, integration credentials, webhook secrets, unrestricted exports, unrestricted audit histories, and admin-only landlord-route data are excluded

## Verification
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && pnpm exec vitest run src/lib/interoperabilityAdapters/__tests__/deriveInteroperabilityAdapterReadiness.test.ts src/routes/__tests__/landlordInteroperabilityAdapterRoutes.test.ts`
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 && pnpm exec vitest run src/components/interoperability/InteroperabilityAdapterPanel.test.tsx src/pages/InteroperabilityAdapterPage.test.tsx src/pages/OperationalRiskPage.test.tsx src/App.routes.test.tsx`
- `cd rentchain-api && source ~/.nvm/nvm.sh && nvm use 20 && pnpm build`
- `cd rentchain-frontend && source ~/.nvm/nvm.sh && nvm use 20 && pnpm build`
- `git diff --check`
- `git diff --cached --check`
- dependency/lockfile diff empty
- touched runtime forbidden-label scan clean

## Scope
- Interoperability adapter files
- Landlord route wiring
- Frontend route wiring
- Safe Operational Risk entry link
- Tests and architecture documentation