### PR TITLE
feat: add release governance layer

### DIFF
--- a/docs/architecture/release-governance-layer-v1.md
+++ b/docs/architecture/release-governance-layer-v1.md
@@ -1,0 +1,127 @@
+# Release Governance Layer v1
+
+## Purpose
+
+The Release Governance Layer provides deterministic, permissioned release-readiness visibility for RentChain. It formalizes release references, deployment readiness visibility, rollback readiness, QA verification, operational-risk dependencies, evidence lineage, review lineage, and audit lineage in one admin-scoped read model.
+
+This layer is an institutional governance surface. It is not deployment orchestration.
+
+## Scope
+
+The v1 layer adds:
+
+- deterministic release governance profile derivation
+- admin-scoped read-only endpoints
+- QA, rollback, deployment, operational-risk, evidence, review, and audit references
+- release restriction visibility
+- descriptor-only canonical release governance events
+- admin UI for manual release governance review
+
+## Guardrails
+
+The layer preserves these controls:
+
+- `manualApprovalRequired` is always `true`
+- `autonomousDeploymentEnabled` is always `false`
+- `autonomousRollbackEnabled` is always `false`
+- `publicLaunchEnabled` is always `false`
+
+The layer does not deploy infrastructure, trigger releases, perform rollback, mutate production infrastructure, expose secrets, replace CI/CD systems, or create release execution APIs.
+
+## Read Model
+
+Release governance profiles include:
+
+- release governance ID
+- release version
+- readiness status
+- release references
+- deployment readiness references
+- rollback references
+- QA references
+- operational-risk references
+- evidence references
+- review references
+- audit references
+- release restrictions
+- redaction summary
+- descriptor-only canonical events
+
+Readiness status is deterministic:
+
+- `ready_for_review`: release, QA, operational-risk, evidence, review, and audit lineage is available
+- `partially_ready`: lineage exists but is incomplete
+- `review_required`: critical lineage is unavailable
+- `blocked`: operational-risk, QA, deployment, evidence, or review restrictions are blocked
+- `unknown`: insufficient source context exists
+
+## Endpoints
+
+Admin-scoped endpoints:
+
+- `GET /api/admin/release-governance`
+- `GET /api/admin/release-governance/:releaseGovernanceId`
+
+Query parameters:
+
+- `releaseVersion`
+- `status`
+
+Both endpoints are read-only and require the existing `system.admin` permission.
+
+## Redaction Boundary
+
+Release governance explicitly excludes:
+
+- deployment credentials
+- tokens and secrets
+- environment values
+- unrestricted CI/CD logs
+- sensitive admin-only infrastructure telemetry
+- production mutation payloads
+- deployment execution payloads
+- rollback execution payloads
+- launch execution payloads
+
+## Canonical Events
+
+Descriptor-only event types:
+
+- `release_governance_profile_derived`
+- `release_governance_review_required`
+- `release_governance_blocked`
+- `release_governance_restriction_detected`
+- `release_governance_redaction_applied`
+
+These are deterministic event descriptors only. They do not trigger deployment, rollback, launch, CI/CD mutation, or infrastructure mutation.
+
+## UI Surface
+
+The admin UI at `/admin/release-governance` displays:
+
+- release readiness summaries
+- deployment and rollback readiness visibility
+- QA verification references
+- operational-risk dependencies
+- evidence and review lineage
+- release restrictions
+- redaction summaries
+
+Required safety copy is visible in the UI:
+
+- "Release governance is operationally scoped and review controlled."
+- "No autonomous deployment, rollback, or public launch execution is enabled."
+- "Manual approval remains required."
+
+## Non-Goals
+
+This layer does not add:
+
+- deployment orchestration
+- rollback execution
+- CI/CD mutation
+- production infrastructure control
+- secret management systems
+- autonomous release approval
+- public-launch automation
+- external release APIs

--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -111,6 +111,7 @@ import adminAlertingRoutes from "./routes/adminAlertingRoutes";
 import adminAssignmentRoutes from "./routes/adminAssignmentRoutes";
 import adminNotificationRoutes from "./routes/adminNotificationRoutes";
 import adminObservabilityRoutes from "./routes/adminObservabilityRoutes";
+import adminReleaseGovernanceRoutes from "./routes/adminReleaseGovernanceRoutes";
 import portfolioScoreRoutes from "./routes/portfolioScoreRoutes";
 import portfolioScoreHistoryRoutes from "./routes/portfolioScoreHistoryRoutes";
 import landlordPortfolioHealthRoutes from "./routes/landlordPortfolioHealthRoutes";
@@ -281,6 +282,8 @@ app.use("/api/admin", routeSource("adminNotificationRoutes.ts"), adminNotificati
 console.log("[route-mount] adminNotificationRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("adminObservabilityRoutes.ts"), adminObservabilityRoutes);
 console.log("[route-mount] adminObservabilityRoutes mounted at /api/admin");
+app.use("/api/admin", routeSource("adminReleaseGovernanceRoutes.ts"), adminReleaseGovernanceRoutes);
+console.log("[route-mount] adminReleaseGovernanceRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("portfolioScoreRoutes.ts"), portfolioScoreRoutes);
 console.log("[route-mount] portfolioScoreRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("portfolioScoreHistoryRoutes.ts"), portfolioScoreHistoryRoutes);

--- a/rentchain-api/src/lib/releaseGovernance/__tests__/deriveReleaseGovernanceProfile.test.ts
+++ b/rentchain-api/src/lib/releaseGovernance/__tests__/deriveReleaseGovernanceProfile.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { deriveReleaseGovernanceProfile } from "../deriveReleaseGovernanceProfile";
+
+describe("deriveReleaseGovernanceProfile", () => {
+  it("derives deterministic release governance with disabled execution flags", () => {
+    const profile = deriveReleaseGovernanceProfile({
+      releaseVersion: "v1.0.0",
+      generatedAt: "2026-01-01T00:00:00.000Z",
+      releaseArtifacts: [{ artifactId: "release-notes", status: "verified", path: "docs/releases/v1.0.0.md", secretToken: "raw-secret" }],
+      deploymentChecks: [{ checkId: "ci-backend", status: "success" }],
+      rollbackArtifacts: [{ artifactId: "rollback-plan", status: "verified" }],
+      qaRecords: [{ qaId: "qa-1", status: "passed" }],
+      operationalRiskProfiles: [{ operationalRiskId: "risk-1", status: "stable" }],
+      evidencePacks: [{ evidencePackId: "evidence-1", status: "ready_for_review" }],
+      operatorReviewSessions: [{ reviewSessionId: "review-1", status: "completed" }],
+      auditEvents: [{ eventId: "event-1", eventType: "release_governance_profile_derived" }],
+    });
+
+    expect(profile).toEqual(
+      expect.objectContaining({
+        releaseGovernanceId: "release_governance:v1.0.0",
+        releaseVersion: "v1.0.0",
+        status: "ready_for_review",
+        manualApprovalRequired: true,
+        autonomousDeploymentEnabled: false,
+        autonomousRollbackEnabled: false,
+        publicLaunchEnabled: false,
+      })
+    );
+    expect(profile.canonicalEvents.map((event) => event.eventType)).toContain("release_governance_profile_derived");
+    expect(JSON.stringify(profile)).not.toContain("secretToken");
+    expect(JSON.stringify(profile)).not.toContain("raw-secret");
+  });
+
+  it("surfaces blocked restrictions without enabling deployment or rollback", () => {
+    const profile = deriveReleaseGovernanceProfile({
+      releaseVersion: "v1.0.0",
+      releaseArtifacts: [{ artifactId: "release-notes", status: "verified" }],
+      deploymentChecks: [{ checkId: "ci-backend", status: "failure" }],
+      rollbackArtifacts: [{ artifactId: "rollback-plan", status: "verified" }],
+      qaRecords: [{ qaId: "qa-1", status: "failed" }],
+      operationalRiskProfiles: [{ operationalRiskId: "risk-1", status: "blocked" }],
+      evidencePacks: [{ evidencePackId: "evidence-1", status: "blocked" }],
+      operatorReviewSessions: [{ reviewSessionId: "review-1", status: "blocked" }],
+    });
+
+    expect(profile.status).toBe("blocked");
+    expect(profile.releaseRestrictions.length).toBeGreaterThan(0);
+    expect(profile.autonomousDeploymentEnabled).toBe(false);
+    expect(profile.autonomousRollbackEnabled).toBe(false);
+    expect(profile.publicLaunchEnabled).toBe(false);
+    expect(profile.canonicalEvents.map((event) => event.eventType)).toContain("release_governance_blocked");
+  });
+
+  it("returns unknown when release governance source context is unavailable", () => {
+    const profile = deriveReleaseGovernanceProfile({ releaseVersion: "v1.0.0" });
+
+    expect(profile.status).toBe("unknown");
+    expect(profile.manualApprovalRequired).toBe(true);
+    expect(profile.autonomousDeploymentEnabled).toBe(false);
+    expect(profile.autonomousRollbackEnabled).toBe(false);
+    expect(profile.publicLaunchEnabled).toBe(false);
+  });
+});

--- a/rentchain-api/src/lib/releaseGovernance/deriveReleaseGovernanceProfile.ts
+++ b/rentchain-api/src/lib/releaseGovernance/deriveReleaseGovernanceProfile.ts
@@ -1,0 +1,385 @@
+import type {
+  DeriveReleaseGovernanceProfileInput,
+  ReleaseGovernanceCanonicalEvent,
+  ReleaseGovernanceProfile,
+  ReleaseGovernanceStatus,
+  ReleaseReference,
+} from "./releaseGovernanceTypes";
+import { releaseGovernanceIdPart, releaseReference, releaseRestriction } from "./releaseRestrictionModels";
+
+const DEFAULT_RELEASE_VERSION = "v0.9.0-core-foundation";
+
+const REDACTIONS = [
+  "Deployment credentials, tokens, secrets, and environment values are excluded.",
+  "Sensitive admin-only infrastructure telemetry and unrestricted CI/CD logs are excluded.",
+  "Production mutation, deployment execution, rollback execution, and public launch payloads are excluded.",
+  "Release governance is readiness metadata only; no autonomous deployment, rollback, or launch execution is enabled.",
+];
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function asArray<T>(value: T[] | null | undefined): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function generatedAt(value: unknown): string {
+  const raw = asString(value, 120);
+  const date = raw ? new Date(raw) : new Date(0);
+  return Number.isNaN(date.getTime()) ? new Date(0).toISOString() : date.toISOString();
+}
+
+function referenceId(record: Record<string, any>, keys: string[]): string {
+  for (const key of keys) {
+    const value = asString(record?.[key], 240);
+    if (value) return value;
+  }
+  return asString(record?.id, 240);
+}
+
+function statusFromRecord(record: Record<string, any>, verifiedStatuses: string[]): ReleaseReference["status"] {
+  const status = asString(record?.status || record?.conclusion || record?.state, 80).toLowerCase();
+  if (status === "blocked" || status === "failure" || status === "failed" || status === "error" || status === "cancelled") return "blocked";
+  if (verifiedStatuses.includes(status)) return "verified";
+  if (status === "missing" || status === "unknown" || status === "unavailable" || status === "pending") return "unavailable";
+  return "partially_verified";
+}
+
+function readinessStatus(hasContext: boolean, references: ReleaseReference[]): ReleaseGovernanceStatus {
+  if (!hasContext) return "unknown";
+  if (references.some((reference) => reference.status === "blocked")) return "blocked";
+  if (references.some((reference) => reference.status === "unavailable")) return "review_required";
+  if (references.some((reference) => reference.status === "partially_verified")) return "partially_ready";
+  return "ready_for_review";
+}
+
+function event(input: {
+  eventType: ReleaseGovernanceCanonicalEvent["eventType"];
+  status: ReleaseGovernanceStatus;
+  releaseGovernanceId: string;
+  summary: string;
+}): ReleaseGovernanceCanonicalEvent {
+  return {
+    eventType: input.eventType,
+    action: input.eventType.replace(/^release_governance_/, "").replace(/_/g, "."),
+    status: input.status,
+    resourceType: "release_governance_profile",
+    resourceId: input.releaseGovernanceId,
+    summary: input.summary,
+  };
+}
+
+export function deriveReleaseGovernanceProfile(input: DeriveReleaseGovernanceProfileInput): ReleaseGovernanceProfile {
+  const releaseVersion = asString(input.releaseVersion, 160) || DEFAULT_RELEASE_VERSION;
+  const releaseGovernanceId =
+    releaseGovernanceIdPart(["release_governance", releaseVersion].join(":")) || "release_governance:unknown";
+
+  const releaseArtifacts = asArray(input.releaseArtifacts);
+  const deploymentChecks = asArray(input.deploymentChecks);
+  const rollbackArtifacts = asArray(input.rollbackArtifacts);
+  const qaRecords = asArray(input.qaRecords);
+  const operationalRiskProfiles = asArray(input.operationalRiskProfiles);
+  const evidencePacks = asArray(input.evidencePacks);
+  const reviews = asArray(input.operatorReviewSessions);
+  const auditEvents = asArray(input.auditEvents);
+
+  const releaseReferences = releaseArtifacts.length
+    ? releaseArtifacts.map((artifact) =>
+        releaseReference({
+          idParts: ["release", referenceId(artifact, ["artifactId", "path", "id"]) || "unknown"],
+          referenceType: "release",
+          status: statusFromRecord(artifact, ["verified", "complete", "ready_for_review"]),
+          label: "Release readiness reference",
+          description: "Release governance artifact is available for manual release readiness review.",
+          lineageReferences: [referenceId(artifact, ["artifactId", "path", "id"])].filter(Boolean),
+          destination: asString(artifact.path, 240) || null,
+          blockedReason: artifact.status === "blocked" ? "Release readiness artifact is blocked." : null,
+        })
+      )
+    : [
+        releaseReference({
+          idParts: ["release", "missing"],
+          referenceType: "release",
+          status: "unavailable",
+          label: "Release readiness reference",
+          description: "Release governance artifacts are unavailable.",
+        }),
+      ];
+
+  const deploymentReferences = deploymentChecks.length
+    ? deploymentChecks.map((check) =>
+        releaseReference({
+          idParts: ["deployment", referenceId(check, ["checkId", "name", "id"]) || "unknown"],
+          referenceType: "deployment",
+          status: statusFromRecord(check, ["success", "passed", "verified"]),
+          label: "Deployment readiness visibility",
+          description: "CI/CD readiness metadata is available as visibility only and cannot trigger deployment.",
+          lineageReferences: [referenceId(check, ["checkId", "name", "id"])].filter(Boolean),
+          blockedReason: statusFromRecord(check, ["success", "passed", "verified"]) === "blocked" ? "Deployment readiness check is blocked." : null,
+        })
+      )
+    : [
+        releaseReference({
+          idParts: ["deployment", "missing"],
+          referenceType: "deployment",
+          status: "unavailable",
+          label: "Deployment readiness visibility",
+          description: "CI/CD readiness metadata is unavailable.",
+        }),
+      ];
+
+  const rollbackReferences = rollbackArtifacts.length
+    ? rollbackArtifacts.map((artifact) =>
+        releaseReference({
+          idParts: ["rollback", referenceId(artifact, ["artifactId", "path", "id"]) || "unknown"],
+          referenceType: "rollback",
+          status: statusFromRecord(artifact, ["verified", "complete", "ready_for_review"]),
+          label: "Rollback readiness reference",
+          description: "Rollback governance artifact is available for manual rollback readiness review.",
+          lineageReferences: [referenceId(artifact, ["artifactId", "path", "id"])].filter(Boolean),
+          destination: asString(artifact.path, 240) || null,
+        })
+      )
+    : [
+        releaseReference({
+          idParts: ["rollback", "missing"],
+          referenceType: "rollback",
+          status: "unavailable",
+          label: "Rollback readiness reference",
+          description: "Rollback readiness metadata is unavailable.",
+        }),
+      ];
+
+  const qaReferences = qaRecords.length
+    ? qaRecords.map((record) =>
+        releaseReference({
+          idParts: ["qa", referenceId(record, ["qaId", "checkId", "id"]) || "unknown"],
+          referenceType: "qa",
+          status: statusFromRecord(record, ["verified", "passed", "success", "complete"]),
+          label: "QA verification reference",
+          description: "QA verification metadata is available for release governance review.",
+          lineageReferences: [referenceId(record, ["qaId", "checkId", "id"])].filter(Boolean),
+          blockedReason: statusFromRecord(record, ["verified", "passed", "success", "complete"]) === "blocked" ? "QA verification is blocked." : null,
+        })
+      )
+    : [
+        releaseReference({
+          idParts: ["qa", "missing"],
+          referenceType: "qa",
+          status: "unavailable",
+          label: "QA verification reference",
+          description: "QA verification metadata is unavailable.",
+        }),
+      ];
+
+  const operationalRiskReferences = operationalRiskProfiles.length
+    ? operationalRiskProfiles.map((profile) =>
+        releaseReference({
+          idParts: ["operational_risk", referenceId(profile, ["operationalRiskId", "id"]) || "unknown"],
+          referenceType: "operational_risk",
+          status: profile.status === "stable" ? "verified" : profile.status === "blocked" || profile.status === "elevated" ? "blocked" : "partially_verified",
+          label: "Operational risk release dependency",
+          description: "Operational risk metadata is available for release governance review.",
+          lineageReferences: [referenceId(profile, ["operationalRiskId", "id"])].filter(Boolean),
+          destination: "/operational-risk",
+          blockedReason: profile.status === "blocked" || profile.status === "elevated" ? "Operational risk exposure must be reviewed before release readiness." : null,
+        })
+      )
+    : [
+        releaseReference({
+          idParts: ["operational_risk", "missing"],
+          referenceType: "operational_risk",
+          status: "unavailable",
+          label: "Operational risk release dependency",
+          description: "Operational risk metadata is unavailable.",
+          destination: "/operational-risk",
+        }),
+      ];
+
+  const evidenceReferences = evidencePacks.length
+    ? evidencePacks.map((pack) =>
+        releaseReference({
+          idParts: ["evidence", referenceId(pack, ["evidencePackId", "id"]) || "unknown"],
+          referenceType: "evidence",
+          status: pack.status === "blocked" ? "blocked" : pack.status === "ready_for_review" ? "verified" : "partially_verified",
+          label: "Evidence lineage reference",
+          description: "Evidence lineage is available for release governance review.",
+          lineageReferences: [referenceId(pack, ["evidencePackId", "id"])].filter(Boolean),
+          destination: "/evidence-packs",
+          blockedReason: pack.status === "blocked" ? "Evidence lineage is blocked." : null,
+        })
+      )
+    : [
+        releaseReference({
+          idParts: ["evidence", "missing"],
+          referenceType: "evidence",
+          status: "unavailable",
+          label: "Evidence lineage reference",
+          description: "Evidence lineage is unavailable.",
+          destination: "/evidence-packs",
+        }),
+      ];
+
+  const reviewReferences = reviews.length
+    ? reviews.map((review) =>
+        releaseReference({
+          idParts: ["review", referenceId(review, ["reviewSessionId", "id"]) || "unknown"],
+          referenceType: "review",
+          status: review.status === "completed" ? "verified" : review.status === "blocked" ? "blocked" : "partially_verified",
+          label: "Review lineage reference",
+          description: "Operator review lineage is available for release governance review.",
+          lineageReferences: [referenceId(review, ["reviewSessionId", "id"])].filter(Boolean),
+          destination: "/review-timeline",
+          blockedReason: review.status === "blocked" ? "Operator review lineage is blocked." : null,
+        })
+      )
+    : [
+        releaseReference({
+          idParts: ["review", "missing"],
+          referenceType: "review",
+          status: "unavailable",
+          label: "Review lineage reference",
+          description: "Operator review lineage is unavailable.",
+          destination: "/review-timeline",
+        }),
+      ];
+
+  const auditReferences = auditEvents.length
+    ? auditEvents.slice(0, 20).map((record) =>
+        releaseReference({
+          idParts: ["audit", referenceId(record, ["eventId", "id"]) || "unknown"],
+          referenceType: "audit",
+          status: record.redacted ? "partially_verified" : "verified",
+          label: "Audit lineage reference",
+          description: "Canonical audit event metadata is available for release governance review.",
+          lineageReferences: [referenceId(record, ["eventId", "id"])].filter(Boolean),
+          destination: "/review-timeline",
+          redacted: Boolean(record.redacted),
+          redactionReason: record.redacted ? "Audit payload is redacted for release governance safety." : null,
+        })
+      )
+    : [
+        releaseReference({
+          idParts: ["audit", "missing"],
+          referenceType: "audit",
+          status: "unavailable",
+          label: "Audit lineage reference",
+          description: "Canonical audit event metadata is unavailable.",
+          destination: "/review-timeline",
+        }),
+      ];
+
+  const allReferences = [
+    ...releaseReferences,
+    ...deploymentReferences,
+    ...rollbackReferences,
+    ...qaReferences,
+    ...operationalRiskReferences,
+    ...evidenceReferences,
+    ...reviewReferences,
+    ...auditReferences,
+  ];
+
+  const releaseRestrictions = allReferences
+    .filter((reference) => reference.status !== "verified")
+    .map((reference) =>
+      releaseRestriction({
+        idParts: [reference.referenceType, reference.referenceId],
+        restrictionType: reference.referenceType,
+        status: reference.status === "blocked" ? "blocked" : "review_required",
+        label: `${reference.label} restriction`,
+        description: `${reference.label} is incomplete or blocked for release governance readiness.`,
+        blockedReason: reference.blockedReason,
+      })
+    );
+
+  const hasContext = Boolean(
+    releaseArtifacts.length ||
+      deploymentChecks.length ||
+      rollbackArtifacts.length ||
+      qaRecords.length ||
+      operationalRiskProfiles.length ||
+      evidencePacks.length ||
+      reviews.length ||
+      auditEvents.length
+  );
+  const status = readinessStatus(hasContext, allReferences);
+  const blockedReasons = [...allReferences.map((reference) => reference.blockedReason), ...releaseRestrictions.map((restriction) => restriction.blockedReason)].filter(Boolean) as string[];
+
+  const canonicalEvents: ReleaseGovernanceCanonicalEvent[] = [
+    event({
+      eventType: "release_governance_profile_derived",
+      status,
+      releaseGovernanceId,
+      summary: "Release governance profile derived from release, deployment, rollback, QA, operational risk, evidence, review, and audit metadata.",
+    }),
+    event({
+      eventType: "release_governance_redaction_applied",
+      status,
+      releaseGovernanceId,
+      summary: "Secrets, tokens, credentials, unrestricted infrastructure telemetry, deployment execution, rollback execution, and launch payloads were excluded.",
+    }),
+  ];
+  if (releaseRestrictions.length) {
+    canonicalEvents.push(
+      event({
+        eventType: "release_governance_restriction_detected",
+        status,
+        releaseGovernanceId,
+        summary: "Release governance restrictions are visible for manual approval review.",
+      })
+    );
+  }
+  if (status === "review_required" || status === "partially_ready") {
+    canonicalEvents.push(
+      event({
+        eventType: "release_governance_review_required",
+        status,
+        releaseGovernanceId,
+        summary: "Manual release governance review is required.",
+      })
+    );
+  }
+  if (status === "blocked") {
+    canonicalEvents.push(
+      event({
+        eventType: "release_governance_blocked",
+        status,
+        releaseGovernanceId,
+        summary: "Release governance readiness is blocked by unresolved readiness restrictions.",
+      })
+    );
+  }
+
+  return {
+    releaseGovernanceId,
+    releaseVersion,
+    status,
+    manualApprovalRequired: true,
+    autonomousDeploymentEnabled: false,
+    autonomousRollbackEnabled: false,
+    publicLaunchEnabled: false,
+    generatedAt: generatedAt(input.generatedAt),
+    summary: {
+      totalReferences: allReferences.length,
+      verifiedReferences: allReferences.filter((reference) => reference.status === "verified").length,
+      partiallyVerifiedReferences: allReferences.filter((reference) => reference.status === "partially_verified").length,
+      blockedReferences: allReferences.filter((reference) => reference.status === "blocked").length,
+      unavailableReferences: allReferences.filter((reference) => reference.status === "unavailable").length,
+      restrictions: releaseRestrictions.length,
+    },
+    releaseReferences,
+    deploymentReferences,
+    rollbackReferences,
+    qaReferences,
+    operationalRiskReferences,
+    reviewReferences,
+    evidenceReferences,
+    auditReferences,
+    releaseRestrictions,
+    redactions: REDACTIONS,
+    blockedReasons,
+    canonicalEvents,
+  };
+}

--- a/rentchain-api/src/lib/releaseGovernance/releaseGovernanceTypes.ts
+++ b/rentchain-api/src/lib/releaseGovernance/releaseGovernanceTypes.ts
@@ -1,0 +1,88 @@
+export type ReleaseGovernanceStatus = "ready_for_review" | "partially_ready" | "review_required" | "blocked" | "unknown";
+
+export type ReleaseReferenceType = "release" | "deployment" | "rollback" | "qa" | "operational_risk" | "evidence" | "review" | "audit";
+
+export type ReleaseReferenceStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+
+export type ReleaseGovernanceCanonicalEventType =
+  | "release_governance_profile_derived"
+  | "release_governance_review_required"
+  | "release_governance_blocked"
+  | "release_governance_restriction_detected"
+  | "release_governance_redaction_applied";
+
+export type ReleaseReference = {
+  referenceId: string;
+  referenceType: ReleaseReferenceType;
+  status: ReleaseReferenceStatus;
+  label: string;
+  description: string;
+  reviewRequired: true;
+  lineageReferences: string[];
+  destination: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type ReleaseRestriction = {
+  restrictionId: string;
+  restrictionType: ReleaseReferenceType | "public_exposure" | "security";
+  status: "visible" | "blocked" | "review_required";
+  label: string;
+  description: string;
+  blockedReason: string | null;
+};
+
+export type ReleaseGovernanceCanonicalEvent = {
+  eventType: ReleaseGovernanceCanonicalEventType;
+  action: string;
+  status: ReleaseGovernanceStatus;
+  resourceType: "release_governance_profile";
+  resourceId: string;
+  summary: string;
+};
+
+export type ReleaseGovernanceProfile = {
+  releaseGovernanceId: string;
+  releaseVersion: string;
+  status: ReleaseGovernanceStatus;
+  manualApprovalRequired: true;
+  autonomousDeploymentEnabled: false;
+  autonomousRollbackEnabled: false;
+  publicLaunchEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    partiallyVerifiedReferences: number;
+    blockedReferences: number;
+    unavailableReferences: number;
+    restrictions: number;
+  };
+  releaseReferences: ReleaseReference[];
+  deploymentReferences: ReleaseReference[];
+  rollbackReferences: ReleaseReference[];
+  qaReferences: ReleaseReference[];
+  operationalRiskReferences: ReleaseReference[];
+  reviewReferences: ReleaseReference[];
+  evidenceReferences: ReleaseReference[];
+  auditReferences: ReleaseReference[];
+  releaseRestrictions: ReleaseRestriction[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: ReleaseGovernanceCanonicalEvent[];
+};
+
+export type DeriveReleaseGovernanceProfileInput = {
+  releaseVersion?: unknown;
+  generatedAt?: unknown;
+  releaseArtifacts?: Array<Record<string, any>> | null;
+  deploymentChecks?: Array<Record<string, any>> | null;
+  rollbackArtifacts?: Array<Record<string, any>> | null;
+  qaRecords?: Array<Record<string, any>> | null;
+  operationalRiskProfiles?: Array<Record<string, any>> | null;
+  evidencePacks?: Array<Record<string, any>> | null;
+  operatorReviewSessions?: Array<Record<string, any>> | null;
+  auditEvents?: Array<Record<string, any>> | null;
+};

--- a/rentchain-api/src/lib/releaseGovernance/releaseRestrictionModels.ts
+++ b/rentchain-api/src/lib/releaseGovernance/releaseRestrictionModels.ts
@@ -1,0 +1,58 @@
+import type { ReleaseReference, ReleaseReferenceStatus, ReleaseReferenceType, ReleaseRestriction } from "./releaseGovernanceTypes";
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+export function releaseGovernanceIdPart(value: unknown): string {
+  return asString(value, 500)
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+export function releaseReference(input: {
+  idParts: unknown[];
+  referenceType: ReleaseReferenceType;
+  status: ReleaseReferenceStatus;
+  label: string;
+  description: string;
+  lineageReferences?: string[];
+  destination?: string | null;
+  redacted?: boolean;
+  redactionReason?: string | null;
+  blockedReason?: string | null;
+}): ReleaseReference {
+  return {
+    referenceId: releaseGovernanceIdPart(input.idParts.join(":")) || "release_governance_reference:unknown",
+    referenceType: input.referenceType,
+    status: input.status,
+    label: input.label,
+    description: input.description,
+    reviewRequired: true,
+    lineageReferences: Array.from(new Set(input.lineageReferences || [])).filter(Boolean),
+    destination: input.destination || null,
+    redacted: Boolean(input.redacted),
+    redactionReason: input.redactionReason || null,
+    blockedReason: input.blockedReason || null,
+  };
+}
+
+export function releaseRestriction(input: {
+  idParts: unknown[];
+  restrictionType: ReleaseRestriction["restrictionType"];
+  status: ReleaseRestriction["status"];
+  label: string;
+  description: string;
+  blockedReason?: string | null;
+}): ReleaseRestriction {
+  return {
+    restrictionId: releaseGovernanceIdPart(input.idParts.join(":")) || "release_governance_restriction:unknown",
+    restrictionType: input.restrictionType,
+    status: input.status,
+    label: input.label,
+    description: input.description,
+    blockedReason: input.blockedReason || null,
+  };
+}

--- a/rentchain-api/src/routes/__tests__/adminReleaseGovernanceRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/adminReleaseGovernanceRoutes.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+  return {
+    resetFakeDb: () => store.clear(),
+    seedDoc: (collection: string, id: string, data: any) => ensureCollection(collection).set(id, { id, data }),
+    fakeDb: {
+      collection: (name: string) => ({
+        get: async () => {
+          const docs = Array.from(ensureCollection(name).values()).map((doc) => ({ id: doc.id, exists: true, data: () => doc.data }));
+          return { docs, empty: docs.length === 0, size: docs.length };
+        },
+      }),
+    },
+  };
+});
+
+let mockUser: any;
+
+vi.mock("../../config/firebase", () => ({ db: fakeDb }));
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!mockUser) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    req.user = mockUser;
+    return next();
+  },
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; user?: Record<string, unknown> | null }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    mockUser = options.user ?? mockUser;
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: mockUser,
+      query: Object.fromEntries(new URLSearchParams(queryString || "").entries()),
+      params: {},
+      headers: {},
+    };
+    const match = path.match(/^\/release-governance\/(.+)$/);
+    if (match) req.params = { releaseGovernanceId: decodeURIComponent(match[1]) };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => (error ? reject(error) : undefined));
+  });
+}
+
+describe("adminReleaseGovernanceRoutes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    resetFakeDb();
+    mockUser = { id: "admin-1", role: "admin", permissions: ["system.admin"] };
+  });
+
+  function seedReleaseGovernanceContext() {
+    seedDoc("evidencePacks", "evidence-1", { evidencePackId: "evidence-1", status: "ready_for_review", deploymentSecret: "secret-value" });
+    seedDoc("operatorReviewSessions", "review-1", { reviewSessionId: "review-1", status: "completed" });
+    seedDoc("operationalRiskProfiles", "risk-1", { operationalRiskId: "risk-1", status: "stable" });
+    seedDoc("releaseQaRecords", "qa-1", { qaId: "qa-1", status: "passed" });
+    seedDoc("events", "event-1", { eventId: "event-1", eventType: "operational_risk_profile_derived" });
+  }
+
+  it("returns admin-gated release governance profiles without sensitive payloads", async () => {
+    seedReleaseGovernanceContext();
+    const router = (await import("../adminReleaseGovernanceRoutes")).default;
+
+    const forbidden = await invokeRouter(router, {
+      method: "GET",
+      url: "/release-governance",
+      user: { id: "landlord-1", role: "landlord", permissions: [] },
+    });
+    expect(forbidden.status).toBe(403);
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/release-governance?releaseVersion=v0.9.0-core-foundation",
+      user: { id: "admin-1", role: "admin", permissions: ["system.admin"] },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.profiles).toHaveLength(1);
+    expect(res.body.profiles[0]).toEqual(
+      expect.objectContaining({
+        manualApprovalRequired: true,
+        autonomousDeploymentEnabled: false,
+        autonomousRollbackEnabled: false,
+        publicLaunchEnabled: false,
+      })
+    );
+    expect(JSON.stringify(res.body)).not.toContain("deploymentSecret");
+    expect(JSON.stringify(res.body)).not.toContain("secret-value");
+  });
+
+  it("returns a single release governance profile by id", async () => {
+    seedReleaseGovernanceContext();
+    const router = (await import("../adminReleaseGovernanceRoutes")).default;
+    const list = await invokeRouter(router, { method: "GET", url: "/release-governance?releaseVersion=v0.9.0-core-foundation" });
+    const id = list.body.profiles[0].releaseGovernanceId;
+
+    const res = await invokeRouter(router, { method: "GET", url: `/release-governance/${encodeURIComponent(id)}` });
+
+    expect(res.status).toBe(200);
+    expect(res.body.profile.releaseGovernanceId).toBe(id);
+  });
+
+  it("filters by status", async () => {
+    seedReleaseGovernanceContext();
+    const router = (await import("../adminReleaseGovernanceRoutes")).default;
+
+    const filtered = await invokeRouter(router, { method: "GET", url: "/release-governance?status=unknown" });
+
+    expect(filtered.status).toBe(200);
+    expect(filtered.body.profiles).toEqual([]);
+  });
+});

--- a/rentchain-api/src/routes/adminReleaseGovernanceRoutes.ts
+++ b/rentchain-api/src/routes/adminReleaseGovernanceRoutes.ts
@@ -1,0 +1,118 @@
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { requireAuth } from "../middleware/requireAuth";
+import { requirePermission } from "../middleware/requireAuthz";
+import { deriveReleaseGovernanceProfile } from "../lib/releaseGovernance/deriveReleaseGovernanceProfile";
+import type { ReleaseGovernanceProfile, ReleaseGovernanceStatus } from "../lib/releaseGovernance/releaseGovernanceTypes";
+
+const router = Router();
+
+const DEFAULT_RELEASE_VERSION = "v0.9.0-core-foundation";
+const STATUSES = new Set<ReleaseGovernanceStatus>(["ready_for_review", "partially_ready", "review_required", "blocked", "unknown"]);
+
+const RELEASE_ARTIFACTS = [
+  { artifactId: "release-notes-v0.9.0-core-foundation", status: "verified", path: "docs/releases/v0.9.0-core-foundation.md" },
+  { artifactId: "release-governance-baseline", status: "verified", path: "docs/releases/release-governance-baseline.md" },
+  { artifactId: "public-exposure-readiness-checklist", status: "verified", path: "docs/releases/public-exposure-readiness-checklist.md" },
+  { artifactId: "platform-state-v0.9.0-core-foundation", status: "verified", path: "docs/architecture/platform-state-v0.9.0-core-foundation.md" },
+];
+
+const ROLLBACK_ARTIFACTS = [{ artifactId: "release-governance-rollback-checklist", status: "verified", path: "docs/releases/release-governance-baseline.md" }];
+
+const DEPLOYMENT_CHECKS = [
+  { checkId: "ci-backend", name: "ci/backend", status: "pending_review" },
+  { checkId: "ci-frontend", name: "ci/frontend", status: "pending_review" },
+  { checkId: "merge-gate", name: "merge-gate", status: "pending_review" },
+  { checkId: "codex-pr-review", name: "codex-pr-review", status: "pending_review" },
+  { checkId: "vercel", name: "Vercel", status: "pending_review" },
+  { checkId: "terraform", name: "Terraform", status: "pending_review" },
+];
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+async function loadCollection(collectionName: string, limit = 25) {
+  const snap = await db.collection(collectionName).get().catch(() => null);
+  return (snap?.docs || []).slice(0, limit).map((doc) => sanitizeRecord({ id: doc.id, ...((doc.data() as any) || {}) }));
+}
+
+function sanitizeRecord(record: Record<string, any>) {
+  const safe: Record<string, any> = {};
+  for (const key of [
+    "id",
+    "status",
+    "eventId",
+    "eventType",
+    "resourceType",
+    "resourceId",
+    "evidencePackId",
+    "reviewSessionId",
+    "operationalRiskId",
+    "generatedAt",
+    "createdAt",
+    "updatedAt",
+    "redacted",
+  ]) {
+    if (record[key] !== undefined) safe[key] = record[key];
+  }
+  return safe;
+}
+
+async function buildReleaseGovernanceProfiles(releaseVersion: string): Promise<ReleaseGovernanceProfile[]> {
+  const [evidencePacks, reviews, auditEvents, operationalRiskProfiles, qaRecords] = await Promise.all([
+    loadCollection("evidencePacks"),
+    loadCollection("operatorReviewSessions"),
+    loadCollection("events"),
+    loadCollection("operationalRiskProfiles"),
+    loadCollection("releaseQaRecords"),
+  ]);
+
+  return [
+    deriveReleaseGovernanceProfile({
+      releaseVersion,
+      releaseArtifacts: RELEASE_ARTIFACTS,
+      deploymentChecks: DEPLOYMENT_CHECKS,
+      rollbackArtifacts: ROLLBACK_ARTIFACTS,
+      qaRecords,
+      operationalRiskProfiles,
+      evidencePacks,
+      operatorReviewSessions: reviews,
+      auditEvents,
+    }),
+  ];
+}
+
+function profileMatches(profile: ReleaseGovernanceProfile, id: string) {
+  return profile.releaseGovernanceId === id;
+}
+
+router.get("/release-governance", requireAuth, requirePermission("system.admin"), async (req: any, res) => {
+  try {
+    const releaseVersion = asString(req.query?.releaseVersion, 160) || DEFAULT_RELEASE_VERSION;
+    const status = asString(req.query?.status, 80) as ReleaseGovernanceStatus;
+    let profiles = await buildReleaseGovernanceProfiles(releaseVersion);
+    if (status && STATUSES.has(status)) profiles = profiles.filter((profile) => profile.status === status);
+    return res.json({ ok: true, profiles });
+  } catch (err: any) {
+    console.error("[admin-release-governance] list failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "RELEASE_GOVERNANCE_FAILED" });
+  }
+});
+
+router.get("/release-governance/:releaseGovernanceId", requireAuth, requirePermission("system.admin"), async (req: any, res) => {
+  try {
+    const releaseVersion = asString(req.query?.releaseVersion, 160) || DEFAULT_RELEASE_VERSION;
+    const releaseGovernanceId = decodeURIComponent(asString(req.params?.releaseGovernanceId, 500));
+    if (!releaseGovernanceId) return res.status(400).json({ ok: false, error: "RELEASE_GOVERNANCE_ID_REQUIRED" });
+    const profiles = await buildReleaseGovernanceProfiles(releaseVersion);
+    const profile = profiles.find((next) => profileMatches(next, releaseGovernanceId));
+    if (!profile) return res.status(404).json({ ok: false, error: "RELEASE_GOVERNANCE_NOT_FOUND" });
+    return res.json({ ok: true, profile });
+  } catch (err: any) {
+    console.error("[admin-release-governance] get failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "RELEASE_GOVERNANCE_GET_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-frontend/src/App.routes.test.tsx
+++ b/rentchain-frontend/src/App.routes.test.tsx
@@ -78,6 +78,10 @@ vi.mock("./pages/admin/AdminNotificationsPage", () => ({
   default: () => <h1>Admin Notifications</h1>,
 }));
 
+vi.mock("./pages/ReleaseGovernancePage", () => ({
+  default: () => <h1>Release Governance Page</h1>,
+}));
+
 vi.mock("./pages/admin/PortfolioScorePage", () => ({
   default: () => <h1>Portfolio Score Foundation</h1>,
 }));
@@ -633,6 +637,20 @@ describe("Routes: /admin/notifications", () => {
     );
 
     expect(await screen.findByText(/Admin Notifications/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("Routes: /admin/release-governance", () => {
+  it("renders the admin release governance route", async () => {
+    const { default: App } = await import("./App");
+    render(
+      <MemoryRouter initialEntries={["/admin/release-governance?releaseVersion=v0.9.0-core-foundation"]}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Release Governance Page/i)).toBeInTheDocument();
     expect(screen.queryByText(/Page not found/i)).not.toBeInTheDocument();
   });
 });

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -111,6 +111,7 @@ const AdminLeaseLifecycleReviewPage = lazy(() => import("./pages/admin/AdminLeas
 const AdminAlertingPage = lazy(() => import("./pages/admin/AdminAlertingPage"));
 const AdminObservabilityPage = lazy(() => import("./pages/admin/AdminObservabilityPage"));
 const AdminNotificationsPage = lazy(() => import("./pages/admin/AdminNotificationsPage"));
+const ReleaseGovernancePage = lazy(() => import("./pages/ReleaseGovernancePage"));
 const PortfolioScorePage = lazy(() => import("./pages/admin/PortfolioScorePage"));
 const PortfolioScoreHistoryPage = lazy(() => import("./pages/admin/PortfolioScoreHistoryPage"));
 const PortfolioHealthSummaryPage = lazy(() => import("./pages/landlord/PortfolioHealthSummaryPage"));
@@ -1277,6 +1278,14 @@ function App() {
               element={
                 <RequireAdmin>
                   <AdminNotificationsPage />
+                </RequireAdmin>
+              }
+            />
+            <Route
+              path="/admin/release-governance"
+              element={
+                <RequireAdmin>
+                  <ReleaseGovernancePage />
                 </RequireAdmin>
               }
             />

--- a/rentchain-frontend/src/api/releaseGovernanceApi.ts
+++ b/rentchain-frontend/src/api/releaseGovernanceApi.ts
@@ -1,0 +1,81 @@
+import { apiFetch } from "./apiFetch";
+
+export type ReleaseGovernanceStatus = "ready_for_review" | "partially_ready" | "review_required" | "blocked" | "unknown";
+export type ReleaseReferenceType = "release" | "deployment" | "rollback" | "qa" | "operational_risk" | "evidence" | "review" | "audit";
+export type ReleaseReferenceStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+
+export type ReleaseReference = {
+  referenceId: string;
+  referenceType: ReleaseReferenceType;
+  status: ReleaseReferenceStatus;
+  label: string;
+  description: string;
+  reviewRequired: true;
+  lineageReferences: string[];
+  destination: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type ReleaseRestriction = {
+  restrictionId: string;
+  restrictionType: ReleaseReferenceType | "public_exposure" | "security";
+  status: "visible" | "blocked" | "review_required";
+  label: string;
+  description: string;
+  blockedReason: string | null;
+};
+
+export type ReleaseGovernanceProfile = {
+  releaseGovernanceId: string;
+  releaseVersion: string;
+  status: ReleaseGovernanceStatus;
+  manualApprovalRequired: true;
+  autonomousDeploymentEnabled: false;
+  autonomousRollbackEnabled: false;
+  publicLaunchEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    partiallyVerifiedReferences: number;
+    blockedReferences: number;
+    unavailableReferences: number;
+    restrictions: number;
+  };
+  releaseReferences: ReleaseReference[];
+  deploymentReferences: ReleaseReference[];
+  rollbackReferences: ReleaseReference[];
+  qaReferences: ReleaseReference[];
+  operationalRiskReferences: ReleaseReference[];
+  reviewReferences: ReleaseReference[];
+  evidenceReferences: ReleaseReference[];
+  auditReferences: ReleaseReference[];
+  releaseRestrictions: ReleaseRestriction[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: Array<{ eventType: string; action: string; status: ReleaseGovernanceStatus; resourceId: string; summary: string }>;
+};
+
+export async function fetchReleaseGovernanceProfiles(params?: {
+  releaseVersion?: string;
+  status?: ReleaseGovernanceStatus | "";
+}): Promise<ReleaseGovernanceProfile[]> {
+  const search = new URLSearchParams();
+  if (params?.releaseVersion) search.set("releaseVersion", params.releaseVersion);
+  if (params?.status) search.set("status", params.status);
+  const suffix = search.toString() ? `?${search.toString()}` : "";
+  const response = await apiFetch<{ ok: true; profiles: ReleaseGovernanceProfile[] }>(`/admin/release-governance${suffix}`);
+  return response.profiles;
+}
+
+export async function fetchReleaseGovernanceProfile(releaseGovernanceId: string, releaseVersion?: string): Promise<ReleaseGovernanceProfile> {
+  const search = new URLSearchParams();
+  if (releaseVersion) search.set("releaseVersion", releaseVersion);
+  const suffix = search.toString() ? `?${search.toString()}` : "";
+  const response = await apiFetch<{ ok: true; profile: ReleaseGovernanceProfile }>(
+    `/admin/release-governance/${encodeURIComponent(releaseGovernanceId)}${suffix}`
+  );
+  return response.profile;
+}

--- a/rentchain-frontend/src/components/releaseGovernance/ReleaseGovernancePanel.test.tsx
+++ b/rentchain-frontend/src/components/releaseGovernance/ReleaseGovernancePanel.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import type { ReleaseGovernanceProfile } from "@/api/releaseGovernanceApi";
+import { ReleaseGovernancePanel } from "./ReleaseGovernancePanel";
+
+const profile: ReleaseGovernanceProfile = {
+  releaseGovernanceId: "release_governance:v0.9.0-core-foundation",
+  releaseVersion: "v0.9.0-core-foundation",
+  status: "partially_ready",
+  manualApprovalRequired: true,
+  autonomousDeploymentEnabled: false,
+  autonomousRollbackEnabled: false,
+  publicLaunchEnabled: false,
+  generatedAt: "2026-01-01T00:00:00.000Z",
+  summary: {
+    totalReferences: 1,
+    verifiedReferences: 0,
+    partiallyVerifiedReferences: 1,
+    blockedReferences: 0,
+    unavailableReferences: 0,
+    restrictions: 1,
+  },
+  releaseReferences: [],
+  deploymentReferences: [],
+  rollbackReferences: [],
+  qaReferences: [
+    {
+      referenceId: "qa-1",
+      referenceType: "qa",
+      status: "partially_verified",
+      label: "QA verification reference",
+      description: "QA verification metadata is available.",
+      reviewRequired: true,
+      lineageReferences: ["qa-1"],
+      destination: null,
+      redacted: false,
+      redactionReason: null,
+      blockedReason: null,
+    },
+  ],
+  operationalRiskReferences: [],
+  evidenceReferences: [],
+  reviewReferences: [],
+  auditReferences: [],
+  releaseRestrictions: [],
+  redactions: ["Deployment credentials, tokens, secrets, and environment values are excluded."],
+  blockedReasons: [],
+  canonicalEvents: [],
+};
+
+describe("ReleaseGovernancePanel", () => {
+  it("renders required safety copy and release governance lineage", () => {
+    render(
+      <MemoryRouter>
+        <ReleaseGovernancePanel profile={profile} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("View release readiness")).toBeInTheDocument();
+    expect(screen.getByText(/No autonomous deployment, rollback, or public launch execution is enabled/i)).toBeInTheDocument();
+    expect(screen.getByText("Manual approval required")).toBeInTheDocument();
+    expect(screen.getByText("View QA verification")).toBeInTheDocument();
+    expect(screen.getByText("Deployment credentials, tokens, secrets, and environment values are excluded.")).toBeInTheDocument();
+  });
+
+  it("omits forbidden release execution labels", () => {
+    render(
+      <MemoryRouter>
+        <ReleaseGovernancePanel profile={profile} />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText("Deploy automatically")).not.toBeInTheDocument();
+    expect(screen.queryByText("Auto-rollback")).not.toBeInTheDocument();
+    expect(screen.queryByText("Public launch")).not.toBeInTheDocument();
+    expect(screen.queryByText("Autonomous deployment")).not.toBeInTheDocument();
+    expect(screen.queryByText("Auto-approve release")).not.toBeInTheDocument();
+    expect(screen.queryByText("Trigger production deploy")).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/releaseGovernance/ReleaseGovernancePanel.tsx
+++ b/rentchain-frontend/src/components/releaseGovernance/ReleaseGovernancePanel.tsx
@@ -1,0 +1,142 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import type { ReleaseGovernanceProfile, ReleaseReference, ReleaseRestriction } from "@/api/releaseGovernanceApi";
+import { Card, Section } from "@/components/ui/Ui";
+
+function label(value: string) {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function tone(status: string) {
+  if (status === "blocked") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
+  if (status === "review_required" || status === "partially_ready" || status === "partially_verified" || status === "unavailable") {
+    return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
+  }
+  if (status === "ready_for_review" || status === "verified") return { color: "#166534", background: "#dcfce7", border: "#bbf7d0" };
+  return { color: "#475569", background: "#f8fafc", border: "#e2e8f0" };
+}
+
+function Badge({ children, status }: { children: React.ReactNode; status: string }) {
+  const next = tone(status);
+  return (
+    <span style={{ border: `1px solid ${next.border}`, borderRadius: 999, background: next.background, color: next.color, padding: "3px 9px", fontSize: 12, fontWeight: 900, whiteSpace: "nowrap" }}>
+      {children}
+    </span>
+  );
+}
+
+function ReferenceList({ title, references }: { title: string; references: ReleaseReference[] }) {
+  return (
+    <Section style={{ display: "grid", gap: 10 }}>
+      <div style={{ fontWeight: 900 }}>{title}</div>
+      {references.length ? (
+        references.slice(0, 12).map((reference) => (
+          <Card key={reference.referenceId} style={{ borderRadius: 8, padding: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+              <div>
+                <strong>{reference.label}</strong>
+                <div style={{ color: "#64748b", fontSize: 13 }}>{label(reference.referenceType)}</div>
+              </div>
+              <Badge status={reference.status}>{label(reference.status)}</Badge>
+            </div>
+            <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>{reference.description}</div>
+            {reference.lineageReferences.length ? <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>Lineage references: {reference.lineageReferences.length}</div> : null}
+            {reference.blockedReason ? <div style={{ color: "#991b1b", fontSize: 13, marginTop: 8 }}>View blocked reason: {reference.blockedReason}</div> : null}
+            {reference.redacted ? <div style={{ color: "#92400e", fontSize: 13, marginTop: 8 }}>{reference.redactionReason || "Redacted release governance reference"}</div> : null}
+            {reference.destination?.startsWith("/") ? <Link to={reference.destination} style={{ color: "#2563eb", fontWeight: 800, fontSize: 13, marginTop: 8, display: "inline-block" }}>View context</Link> : null}
+            {reference.destination && !reference.destination.startsWith("/") ? <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>{reference.destination}</div> : null}
+          </Card>
+        ))
+      ) : (
+        <Card style={{ color: "#64748b" }}>Context unavailable</Card>
+      )}
+    </Section>
+  );
+}
+
+function RestrictionList({ restrictions }: { restrictions: ReleaseRestriction[] }) {
+  return (
+    <Section style={{ display: "grid", gap: 10 }}>
+      <div style={{ fontWeight: 900 }}>View restrictions</div>
+      {restrictions.length ? (
+        restrictions.map((restriction) => (
+          <Card key={restriction.restrictionId} style={{ borderRadius: 8, padding: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+              <div>
+                <strong>{restriction.label}</strong>
+                <div style={{ color: "#64748b", fontSize: 13 }}>{label(restriction.restrictionType)}</div>
+              </div>
+              <Badge status={restriction.status}>{label(restriction.status)}</Badge>
+            </div>
+            <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>{restriction.description}</div>
+            {restriction.blockedReason ? <div style={{ color: "#991b1b", fontSize: 13, marginTop: 8 }}>View blocked reason: {restriction.blockedReason}</div> : null}
+          </Card>
+        ))
+      ) : (
+        <Card style={{ color: "#64748b" }}>No release governance restrictions detected.</Card>
+      )}
+    </Section>
+  );
+}
+
+export function ReleaseGovernancePanel({ profile }: { profile: ReleaseGovernanceProfile }) {
+  return (
+    <div style={{ display: "grid", gap: 16 }}>
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+          <div>
+            <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>View release readiness</div>
+            <h2 style={{ margin: "2px 0 0", fontSize: "1.15rem" }}>{profile.releaseVersion}</h2>
+          </div>
+          <Badge status={profile.status}>{label(profile.status)}</Badge>
+        </div>
+        <div style={{ color: "#475569", lineHeight: 1.55 }}>
+          Release governance is operationally scoped and review controlled. No autonomous deployment, rollback, or public launch execution is enabled.
+          Manual approval remains required.
+        </div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <Badge status="review_required">Manual approval required</Badge>
+          <Badge status={profile.autonomousDeploymentEnabled ? "blocked" : "verified"}>Deployment automation disabled</Badge>
+          <Badge status={profile.autonomousRollbackEnabled ? "blocked" : "verified"}>Rollback automation disabled</Badge>
+          <Badge status={profile.publicLaunchEnabled ? "blocked" : "verified"}>External launch disabled</Badge>
+        </div>
+      </Section>
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Governance summary</div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: 10 }}>
+          {[
+            ["References", profile.summary.totalReferences],
+            ["Verified", profile.summary.verifiedReferences],
+            ["Partial", profile.summary.partiallyVerifiedReferences],
+            ["Blocked", profile.summary.blockedReferences],
+            ["Unavailable", profile.summary.unavailableReferences],
+            ["Restrictions", profile.summary.restrictions],
+          ].map(([name, value]) => (
+            <Card key={String(name)} style={{ borderRadius: 8, padding: 12 }}>
+              <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>{name}</div>
+              <strong style={{ color: "#0f172a", fontSize: 22 }}>{String(value)}</strong>
+            </Card>
+          ))}
+        </div>
+      </Section>
+
+      <RestrictionList restrictions={profile.releaseRestrictions} />
+      <ReferenceList title="Release references" references={profile.releaseReferences} />
+      <ReferenceList title="Deployment readiness" references={profile.deploymentReferences} />
+      <ReferenceList title="Rollback readiness" references={profile.rollbackReferences} />
+      <ReferenceList title="View QA verification" references={profile.qaReferences} />
+      <ReferenceList title="View operational risk" references={profile.operationalRiskReferences} />
+      <ReferenceList title="View evidence lineage" references={profile.evidenceReferences} />
+      <ReferenceList title="View review lineage" references={profile.reviewReferences} />
+      <ReferenceList title="Audit references" references={profile.auditReferences} />
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Redactions</div>
+        {profile.redactions.map((redaction) => (
+          <Card key={redaction} style={{ borderRadius: 8, padding: 12, color: "#475569" }}>{redaction}</Card>
+        ))}
+      </Section>
+    </div>
+  );
+}

--- a/rentchain-frontend/src/pages/ReleaseGovernancePage.test.tsx
+++ b/rentchain-frontend/src/pages/ReleaseGovernancePage.test.tsx
@@ -1,0 +1,110 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ReleaseGovernancePage from "./ReleaseGovernancePage";
+
+const mockFetchReleaseGovernanceProfiles = vi.fn();
+const mockShowToast = vi.fn();
+
+vi.mock("@/api/releaseGovernanceApi", () => ({
+  fetchReleaseGovernanceProfiles: (...args: any[]) => mockFetchReleaseGovernanceProfiles(...args),
+}));
+
+vi.mock("@/components/layout/MacShell", () => ({
+  MacShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
+const profile = {
+  releaseGovernanceId: "release_governance:v0.9.0-core-foundation",
+  releaseVersion: "v0.9.0-core-foundation",
+  status: "ready_for_review",
+  manualApprovalRequired: true,
+  autonomousDeploymentEnabled: false,
+  autonomousRollbackEnabled: false,
+  publicLaunchEnabled: false,
+  generatedAt: "2026-01-01T00:00:00.000Z",
+  summary: {
+    totalReferences: 1,
+    verifiedReferences: 1,
+    partiallyVerifiedReferences: 0,
+    blockedReferences: 0,
+    unavailableReferences: 0,
+    restrictions: 0,
+  },
+  releaseReferences: [],
+  deploymentReferences: [],
+  rollbackReferences: [],
+  qaReferences: [],
+  operationalRiskReferences: [],
+  evidenceReferences: [],
+  reviewReferences: [],
+  auditReferences: [],
+  releaseRestrictions: [],
+  redactions: ["Release governance is readiness metadata only; no autonomous deployment, rollback, or launch execution is enabled."],
+  blockedReasons: [],
+  canonicalEvents: [],
+};
+
+describe("ReleaseGovernancePage", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchReleaseGovernanceProfiles.mockResolvedValue([profile]);
+  });
+
+  it("renders release governance and required safety copy", async () => {
+    render(
+      <MemoryRouter>
+        <ReleaseGovernancePage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Release governance")).toBeInTheDocument();
+    expect(screen.getAllByText(/No autonomous deployment, rollback, or public launch execution is enabled/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("Release governance is readiness metadata only; no autonomous deployment, rollback, or launch execution is enabled.")).toBeInTheDocument();
+  });
+
+  it("updates deterministic release and status filters", async () => {
+    render(
+      <MemoryRouter>
+        <ReleaseGovernancePage />
+      </MemoryRouter>
+    );
+
+    await screen.findByText("Release governance");
+    fireEvent.change(screen.getByLabelText("Release version"), { target: { value: "v1.0.0" } });
+    fireEvent.change(screen.getByLabelText("Status"), { target: { value: "blocked" } });
+
+    await waitFor(() => {
+      expect(mockFetchReleaseGovernanceProfiles).toHaveBeenLastCalledWith({
+        releaseVersion: "v1.0.0",
+        status: "blocked",
+      });
+    });
+  });
+
+  it("shows empty state and omits forbidden labels", async () => {
+    mockFetchReleaseGovernanceProfiles.mockResolvedValue([]);
+    render(
+      <MemoryRouter>
+        <ReleaseGovernancePage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("No release governance profiles match these filters.")).toBeInTheDocument();
+    expect(screen.queryByText("Deploy automatically")).not.toBeInTheDocument();
+    expect(screen.queryByText("Auto-rollback")).not.toBeInTheDocument();
+    expect(screen.queryByText("Public launch")).not.toBeInTheDocument();
+    expect(screen.queryByText("Autonomous deployment")).not.toBeInTheDocument();
+    expect(screen.queryByText("Auto-approve release")).not.toBeInTheDocument();
+    expect(screen.queryByText("Trigger production deploy")).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/ReleaseGovernancePage.tsx
+++ b/rentchain-frontend/src/pages/ReleaseGovernancePage.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { useSearchParams } from "react-router-dom";
+import { fetchReleaseGovernanceProfiles, type ReleaseGovernanceProfile, type ReleaseGovernanceStatus } from "@/api/releaseGovernanceApi";
+import { ReleaseGovernancePanel } from "@/components/releaseGovernance/ReleaseGovernancePanel";
+import { MacShell } from "@/components/layout/MacShell";
+import { Card, Section } from "@/components/ui/Ui";
+import { useToast } from "@/components/ui/ToastProvider";
+
+const statuses: Array<ReleaseGovernanceStatus | ""> = ["", "ready_for_review", "partially_ready", "review_required", "blocked", "unknown"];
+
+function label(value: string) {
+  return value ? value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase()) : "All";
+}
+
+export default function ReleaseGovernancePage() {
+  const { showToast } = useToast();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [profiles, setProfiles] = React.useState<ReleaseGovernanceProfile[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const releaseVersion = String(searchParams.get("releaseVersion") || "v0.9.0-core-foundation");
+  const status = String(searchParams.get("status") || "") as ReleaseGovernanceStatus | "";
+
+  React.useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const next = await fetchReleaseGovernanceProfiles({ releaseVersion, status });
+        if (mounted) setProfiles(next);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Failed to load release governance";
+        if (mounted) {
+          setError(message);
+          showToast({ message: "Failed to load release governance", description: message, variant: "error" });
+        }
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [releaseVersion, status, showToast]);
+
+  function updateParams(next: { releaseVersion?: string; status?: string }) {
+    const params = new URLSearchParams(searchParams);
+    for (const [key, value] of Object.entries(next)) {
+      if (value && value.trim()) params.set(key, value.trim());
+      else params.delete(key);
+    }
+    setSearchParams(params);
+  }
+
+  return (
+    <MacShell title="Release governance" showTopNav={false}>
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "grid", gap: 6 }}>
+            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Release governance</h1>
+            <div style={{ color: "#475569", maxWidth: 900 }}>
+              Release governance is operationally scoped and review controlled. No autonomous deployment, rollback, or public launch execution is enabled.
+              Manual approval remains required.
+            </div>
+          </div>
+        </Section>
+
+        <Section style={{ display: "flex", gap: 10, flexWrap: "wrap", alignItems: "end" }}>
+          <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Release version
+            <input value={releaseVersion} onChange={(event) => updateParams({ releaseVersion: event.target.value })} style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 260 }} />
+          </label>
+          <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Status
+            <select value={status} onChange={(event) => updateParams({ status: event.target.value })} style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 180 }}>
+              {statuses.map((item) => <option key={item || "all"} value={item}>{label(item)}</option>)}
+            </select>
+          </label>
+        </Section>
+
+        {loading ? <Card>Loading release governance...</Card> : null}
+        {!loading && error ? <Card style={{ color: "#b91c1c" }}>We couldn't load release governance right now.</Card> : null}
+        {!loading && !error && !profiles.length ? <Card style={{ color: "#64748b" }}>No release governance profiles match these filters.</Card> : null}
+        {!loading && !error && profiles.length ? (
+          <div style={{ display: "grid", gap: 16 }}>{profiles.map((profile) => <ReleaseGovernancePanel key={profile.releaseGovernanceId} profile={profile} />)}</div>
+        ) : null}
+      </div>
+    </MacShell>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds deterministic, admin-scoped, read-only Release Governance Layer
- Adds endpoints:
  - `GET /api/admin/release-governance`
  - `GET /api/admin/release-governance/:releaseGovernanceId`
- Adds `/admin/release-governance` UI and `ReleaseGovernancePanel`
- Adds release readiness, deployment, rollback, QA, operational-risk, evidence, review, and audit references
- Adds descriptor-only canonical events:
  - `release_governance_profile_derived`
  - `release_governance_review_required`
  - `release_governance_blocked`
  - `release_governance_restriction_detected`
  - `release_governance_redaction_applied`
- Confirms:
  - `manualApprovalRequired: true`
  - `autonomousDeploymentEnabled: false`
  - `autonomousRollbackEnabled: false`
  - `publicLaunchEnabled: false`
- Confirms no autonomous deployment, rollback, public-launch execution, CI/CD mutation, infrastructure orchestration, secret exposure, or unintended admin-only leakage was added
- Confirms dependency/lockfile diff is empty and forbidden runtime-label scan is clean

## Verification
- Targeted backend tests passed
- Targeted frontend tests passed
- Backend build passed
- Frontend build passed with existing chunk-size warning
- `git diff --check` passed
- Dependency/lockfile diff empty
- Forbidden runtime-label scan clean