### PR TITLE
feat: add public exposure hardening layer

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -112,6 +112,7 @@ import adminAssignmentRoutes from "./routes/adminAssignmentRoutes";
 import adminNotificationRoutes from "./routes/adminNotificationRoutes";
 import adminObservabilityRoutes from "./routes/adminObservabilityRoutes";
 import adminReleaseGovernanceRoutes from "./routes/adminReleaseGovernanceRoutes";
+import adminPublicExposureHardeningRoutes from "./routes/adminPublicExposureHardeningRoutes";
 import portfolioScoreRoutes from "./routes/portfolioScoreRoutes";
 import portfolioScoreHistoryRoutes from "./routes/portfolioScoreHistoryRoutes";
 import landlordPortfolioHealthRoutes from "./routes/landlordPortfolioHealthRoutes";
@@ -284,6 +285,8 @@ app.use("/api/admin", routeSource("adminObservabilityRoutes.ts"), adminObservabi
 console.log("[route-mount] adminObservabilityRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("adminReleaseGovernanceRoutes.ts"), adminReleaseGovernanceRoutes);
 console.log("[route-mount] adminReleaseGovernanceRoutes mounted at /api/admin");
+app.use("/api/admin", routeSource("adminPublicExposureHardeningRoutes.ts"), adminPublicExposureHardeningRoutes);
+console.log("[route-mount] adminPublicExposureHardeningRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("portfolioScoreRoutes.ts"), portfolioScoreRoutes);
 console.log("[route-mount] portfolioScoreRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("portfolioScoreHistoryRoutes.ts"), portfolioScoreHistoryRoutes);

--- a/rentchain-api/src/lib/publicExposureHardening/__tests__/derivePublicExposureHardeningProfile.test.ts
+++ b/rentchain-api/src/lib/publicExposureHardening/__tests__/derivePublicExposureHardeningProfile.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { derivePublicExposureHardeningProfile } from "../derivePublicExposureHardeningProfile";
+
+const completeInput = {
+  generatedAt: "2026-01-01T00:00:00.000Z",
+  releaseGovernanceProfiles: [{ releaseGovernanceId: "release-1", status: "ready_for_review" }],
+  rollbackArtifacts: [{ artifactId: "rollback-1", status: "verified" }],
+  securityReadiness: [{ securityReadinessId: "security-1", status: "verified" }],
+  operationalRiskProfiles: [{ operationalRiskId: "risk-1", status: "stable" }],
+  institutionOnboardingReadiness: [{ onboardingReadinessId: "onboarding-1", status: "ready_for_review" }],
+  supportReadiness: [{ supportReadinessId: "support-1", status: "ready_for_review" }],
+  operatorReviewSessions: [{ reviewSessionId: "review-1", status: "completed" }],
+  evidencePacks: [{ evidencePackId: "evidence-1", status: "ready_for_review" }],
+  auditEvents: [{ eventId: "event-1", eventType: "release_governance_profile_derived" }],
+};
+
+describe("derivePublicExposureHardeningProfile", () => {
+  it("derives deterministic ready-for-review hardening with fixed safety flags", () => {
+    const profile = derivePublicExposureHardeningProfile(completeInput);
+
+    expect(profile).toEqual(
+      expect.objectContaining({
+        status: "ready_for_review",
+        manualApprovalRequired: true,
+        autonomousLaunchEnabled: false,
+        autonomousRollbackEnabled: false,
+        publicExposureEnabled: false,
+      })
+    );
+    expect(profile.summary.totalReferences).toBe(9);
+    expect(profile.summary.verifiedReferences).toBe(9);
+    expect(profile.publicExposureRestrictions).toEqual([]);
+    expect(profile.canonicalEvents.map((event) => event.eventType)).toContain("public_exposure_hardening_profile_derived");
+    expect(JSON.stringify(profile)).not.toContain("secret-value");
+  });
+
+  it("blocks public exposure hardening for unresolved operational risk or security restrictions", () => {
+    const profile = derivePublicExposureHardeningProfile({
+      ...completeInput,
+      securityReadiness: [{ securityReadinessId: "security-1", status: "blocked" }],
+      operationalRiskProfiles: [{ operationalRiskId: "risk-1", status: "elevated" }],
+    });
+
+    expect(profile.status).toBe("blocked");
+    expect(profile.publicExposureRestrictions.map((restriction) => restriction.status)).toContain("blocked");
+    expect(profile.blockedReasons).toEqual(
+      expect.arrayContaining(["Security readiness restriction is unresolved.", "Unresolved operational risk blocks public exposure readiness."])
+    );
+    expect(profile.canonicalEvents.map((event) => event.eventType)).toContain("public_exposure_blocked");
+  });
+
+  it("requires review when critical release, rollback, evidence, or review lineage is missing", () => {
+    const profile = derivePublicExposureHardeningProfile({
+      ...completeInput,
+      rollbackArtifacts: [],
+      evidencePacks: [],
+    });
+
+    expect(profile.status).toBe("review_required");
+    expect(profile.summary.unavailableReferences).toBe(2);
+    expect(profile.publicExposureRestrictions.map((restriction) => restriction.restrictionType)).toEqual(expect.arrayContaining(["rollback", "evidence"]));
+    expect(profile.canonicalEvents.map((event) => event.eventType)).toContain("public_exposure_review_required");
+  });
+
+  it("partially readies incomplete onboarding or support readiness without autonomous operations", () => {
+    const profile = derivePublicExposureHardeningProfile({
+      ...completeInput,
+      institutionOnboardingReadiness: [{ onboardingReadinessId: "onboarding-1", status: "partially_ready" }],
+      supportReadiness: [{ supportReadinessId: "support-1", status: "attention_required" }],
+    });
+
+    expect(profile.status).toBe("partially_ready");
+    expect(profile.manualApprovalRequired).toBe(true);
+    expect(profile.autonomousLaunchEnabled).toBe(false);
+    expect(profile.autonomousRollbackEnabled).toBe(false);
+    expect(profile.publicExposureEnabled).toBe(false);
+  });
+
+  it("returns unknown when no source context is available", () => {
+    const profile = derivePublicExposureHardeningProfile({});
+
+    expect(profile.status).toBe("unknown");
+    expect(profile.summary.unavailableReferences).toBeGreaterThan(0);
+    expect(profile.canonicalEvents.map((event) => event.eventType)).toContain("public_exposure_redaction_applied");
+  });
+});

--- a/rentchain-api/src/lib/publicExposureHardening/derivePublicExposureHardeningProfile.ts
+++ b/rentchain-api/src/lib/publicExposureHardening/derivePublicExposureHardeningProfile.ts
@@ -1,0 +1,465 @@
+import type {
+  DerivePublicExposureHardeningProfileInput,
+  PublicExposureCanonicalEvent,
+  PublicExposureHardeningProfile,
+  PublicExposureHardeningStatus,
+  PublicExposureReference,
+} from "./publicExposureHardeningTypes";
+import { publicExposureIdPart, publicExposureReference, publicExposureRestriction } from "./publicExposureRestrictionModels";
+
+const DEFAULT_HARDENING_KEY = "controlled-production-exposure-readiness-v1";
+
+const REDACTIONS = [
+  "Deployment credentials, tokens, secrets, and environment values are excluded.",
+  "Sensitive tenant, payment, screening, private document, and admin-only infrastructure payloads are excluded.",
+  "Public exposure hardening is readiness metadata only; no autonomous deployment, rollback, or public launch execution is enabled.",
+  "Unrestricted operational telemetry, infrastructure mutation APIs, and secret-management execution are excluded.",
+];
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function asArray<T>(value: T[] | null | undefined): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function generatedAt(value: unknown): string {
+  const raw = asString(value, 120);
+  const date = raw ? new Date(raw) : new Date(0);
+  return Number.isNaN(date.getTime()) ? new Date(0).toISOString() : date.toISOString();
+}
+
+function recordId(record: Record<string, any>, keys: string[]): string {
+  for (const key of keys) {
+    const value = asString(record?.[key], 240);
+    if (value) return value;
+  }
+  return asString(record?.id, 240);
+}
+
+function readinessStatus(hasContext: boolean, references: PublicExposureReference[]): PublicExposureHardeningStatus {
+  if (!hasContext) return "unknown";
+  if (references.some((reference) => reference.status === "blocked")) return "blocked";
+  const hasCriticalMissing = references.some(
+    (reference) =>
+      reference.status === "unavailable" &&
+      (reference.referenceType === "release" ||
+        reference.referenceType === "rollback" ||
+        reference.referenceType === "operational_risk" ||
+        reference.referenceType === "evidence" ||
+        reference.referenceType === "review" ||
+        reference.referenceType === "security")
+  );
+  if (hasCriticalMissing) return "review_required";
+  if (references.some((reference) => reference.status === "unavailable" || reference.status === "partially_verified")) return "partially_ready";
+  return "ready_for_review";
+}
+
+function event(input: {
+  eventType: PublicExposureCanonicalEvent["eventType"];
+  status: PublicExposureHardeningStatus;
+  publicExposureHardeningId: string;
+  summary: string;
+}): PublicExposureCanonicalEvent {
+  return {
+    eventType: input.eventType,
+    action: input.eventType.replace(/^public_exposure_/, "").replace(/_/g, "."),
+    status: input.status,
+    resourceType: "public_exposure_hardening_profile",
+    resourceId: input.publicExposureHardeningId,
+    summary: input.summary,
+  };
+}
+
+function statusFromRecord(record: Record<string, any>, verifiedStatuses: string[]): PublicExposureReference["status"] {
+  const status = asString(record?.status || record?.state || record?.conclusion, 80).toLowerCase();
+  if (status === "blocked" || status === "failure" || status === "failed" || status === "error" || status === "cancelled") return "blocked";
+  if (verifiedStatuses.includes(status)) return "verified";
+  if (status === "missing" || status === "unknown" || status === "unavailable" || status === "pending") return "unavailable";
+  return "partially_verified";
+}
+
+function releaseStatus(profile: Record<string, any>): PublicExposureReference["status"] {
+  const status = asString(profile?.status, 80);
+  if (status === "blocked") return "blocked";
+  if (status === "ready_for_review") return "verified";
+  if (status === "unknown" || status === "review_required") return "unavailable";
+  return "partially_verified";
+}
+
+function operationalRiskStatus(profile: Record<string, any>): PublicExposureReference["status"] {
+  const status = asString(profile?.status, 80);
+  if (status === "blocked" || status === "elevated") return "blocked";
+  if (status === "stable") return "verified";
+  if (status === "unknown") return "unavailable";
+  return "partially_verified";
+}
+
+function readyBlockedStatus(record: Record<string, any>, readyStatuses: string[]): PublicExposureReference["status"] {
+  const status = asString(record?.status, 80);
+  if (status === "blocked") return "blocked";
+  if (readyStatuses.includes(status)) return "verified";
+  if (status === "unknown" || status === "unavailable") return "unavailable";
+  return "partially_verified";
+}
+
+export function derivePublicExposureHardeningProfile(input: DerivePublicExposureHardeningProfileInput): PublicExposureHardeningProfile {
+  const hardeningKey = asString(input.hardeningKey, 160) || DEFAULT_HARDENING_KEY;
+  const publicExposureHardeningId =
+    publicExposureIdPart(["public_exposure_hardening", hardeningKey].join(":")) || "public_exposure_hardening:unknown";
+
+  const releaseGovernanceProfiles = asArray(input.releaseGovernanceProfiles);
+  const rollbackArtifacts = asArray(input.rollbackArtifacts);
+  const securityReadiness = asArray(input.securityReadiness);
+  const operationalRiskProfiles = asArray(input.operationalRiskProfiles);
+  const onboardingReadiness = asArray(input.institutionOnboardingReadiness);
+  const supportReadiness = asArray(input.supportReadiness);
+  const reviews = asArray(input.operatorReviewSessions);
+  const evidencePacks = asArray(input.evidencePacks);
+  const auditEvents = asArray(input.auditEvents);
+
+  const releaseReferences = releaseGovernanceProfiles.length
+    ? releaseGovernanceProfiles.map((profile) => {
+        const status = releaseStatus(profile);
+        return publicExposureReference({
+          idParts: ["release", recordId(profile, ["releaseGovernanceId", "releaseVersion", "id"]) || "unknown"],
+          referenceType: "release",
+          status,
+          label: "Release readiness reference",
+          description: "Release governance readiness is available for public exposure hardening review.",
+          lineageReferences: [recordId(profile, ["releaseGovernanceId", "releaseVersion", "id"])].filter(Boolean),
+          destination: "/admin/release-governance",
+          blockedReason: status === "blocked" ? "Release governance readiness is blocked." : null,
+        });
+      })
+    : [
+        publicExposureReference({
+          idParts: ["release", "missing"],
+          referenceType: "release",
+          status: "unavailable",
+          label: "Release readiness reference",
+          description: "Release governance readiness is unavailable for public exposure hardening review.",
+          destination: "/admin/release-governance",
+        }),
+      ];
+
+  const rollbackReferences = rollbackArtifacts.length
+    ? rollbackArtifacts.map((artifact) =>
+        publicExposureReference({
+          idParts: ["rollback", recordId(artifact, ["artifactId", "rollbackId", "path", "id"]) || "unknown"],
+          referenceType: "rollback",
+          status: statusFromRecord(artifact, ["verified", "complete", "ready_for_review", "passed"]),
+          label: "Rollback readiness reference",
+          description: "Rollback readiness metadata is available for manual public exposure review.",
+          lineageReferences: [recordId(artifact, ["artifactId", "rollbackId", "path", "id"])].filter(Boolean),
+          destination: asString(artifact.path, 240) || "/admin/release-governance",
+          blockedReason:
+            statusFromRecord(artifact, ["verified", "complete", "ready_for_review", "passed"]) === "blocked"
+              ? "Rollback readiness is blocked."
+              : null,
+        })
+      )
+    : [
+        publicExposureReference({
+          idParts: ["rollback", "missing"],
+          referenceType: "rollback",
+          status: "unavailable",
+          label: "Rollback readiness reference",
+          description: "Rollback readiness metadata is unavailable for public exposure hardening review.",
+          destination: "/admin/release-governance",
+        }),
+      ];
+
+  const securityReferences = securityReadiness.length
+    ? securityReadiness.map((security) => {
+        const status = readyBlockedStatus(security, ["verified", "ready_for_review", "passed"]);
+        return publicExposureReference({
+          idParts: ["security", recordId(security, ["securityReadinessId", "checkId", "id"]) || "unknown"],
+          referenceType: "security",
+          status,
+          label: "Security readiness reference",
+          description: "Security readiness metadata is available for public exposure hardening review.",
+          lineageReferences: [recordId(security, ["securityReadinessId", "checkId", "id"])].filter(Boolean),
+          destination: "/admin/ops",
+          blockedReason: status === "blocked" ? "Security readiness restriction is unresolved." : null,
+        });
+      })
+    : [
+        publicExposureReference({
+          idParts: ["security", "missing"],
+          referenceType: "security",
+          status: "unavailable",
+          label: "Security readiness reference",
+          description: "Security readiness metadata is unavailable for public exposure hardening review.",
+          destination: "/admin/ops",
+        }),
+      ];
+
+  const operationalRiskReferences = operationalRiskProfiles.length
+    ? operationalRiskProfiles.map((profile) => {
+        const status = operationalRiskStatus(profile);
+        return publicExposureReference({
+          idParts: ["operational_risk", recordId(profile, ["operationalRiskId", "id"]) || "unknown"],
+          referenceType: "operational_risk",
+          status,
+          label: "Operational risk dependency",
+          description: "Operational risk readiness is available for public exposure hardening review.",
+          lineageReferences: [recordId(profile, ["operationalRiskId", "id"])].filter(Boolean),
+          destination: "/operational-risk",
+          blockedReason: status === "blocked" ? "Unresolved operational risk blocks public exposure readiness." : null,
+        });
+      })
+    : [
+        publicExposureReference({
+          idParts: ["operational_risk", "missing"],
+          referenceType: "operational_risk",
+          status: "unavailable",
+          label: "Operational risk dependency",
+          description: "Operational risk readiness is unavailable for public exposure hardening review.",
+          destination: "/operational-risk",
+        }),
+      ];
+
+  const onboardingReferences = onboardingReadiness.length
+    ? onboardingReadiness.map((readiness) => {
+        const status = readyBlockedStatus(readiness, ["ready_for_review"]);
+        return publicExposureReference({
+          idParts: ["onboarding", recordId(readiness, ["onboardingReadinessId", "id"]) || "unknown"],
+          referenceType: "onboarding",
+          status,
+          label: "Onboarding readiness dependency",
+          description: "Institution onboarding readiness is available for public exposure hardening review.",
+          lineageReferences: [recordId(readiness, ["onboardingReadinessId", "id"])].filter(Boolean),
+          destination: "/institution-onboarding-readiness",
+          blockedReason: status === "blocked" ? "Onboarding readiness is blocked." : null,
+        });
+      })
+    : [
+        publicExposureReference({
+          idParts: ["onboarding", "missing"],
+          referenceType: "onboarding",
+          status: "unavailable",
+          label: "Onboarding readiness dependency",
+          description: "Onboarding readiness metadata is unavailable for public exposure hardening review.",
+          destination: "/institution-onboarding-readiness",
+        }),
+      ];
+
+  const supportReferences = supportReadiness.length
+    ? supportReadiness.map((support) => {
+        const status = readyBlockedStatus(support, ["verified", "ready_for_review", "stable"]);
+        return publicExposureReference({
+          idParts: ["support", recordId(support, ["supportReadinessId", "supportId", "id"]) || "unknown"],
+          referenceType: "support",
+          status,
+          label: "Support readiness dependency",
+          description: "Support readiness metadata is available for public exposure hardening review.",
+          lineageReferences: [recordId(support, ["supportReadinessId", "supportId", "id"])].filter(Boolean),
+          destination: "/admin/support-console",
+          blockedReason: status === "blocked" ? "Support readiness is blocked." : null,
+        });
+      })
+    : [
+        publicExposureReference({
+          idParts: ["support", "missing"],
+          referenceType: "support",
+          status: "unavailable",
+          label: "Support readiness dependency",
+          description: "Support readiness metadata is unavailable for public exposure hardening review.",
+          destination: "/admin/support-console",
+        }),
+      ];
+
+  const evidenceReferences = evidencePacks.length
+    ? evidencePacks.map((pack) => {
+        const status = readyBlockedStatus(pack, ["ready_for_review"]);
+        return publicExposureReference({
+          idParts: ["evidence", recordId(pack, ["evidencePackId", "id"]) || "unknown"],
+          referenceType: "evidence",
+          status,
+          label: "Evidence lineage reference",
+          description: "Evidence lineage is available for public exposure hardening review.",
+          lineageReferences: [recordId(pack, ["evidencePackId", "id"])].filter(Boolean),
+          destination: "/evidence-packs",
+          blockedReason: status === "blocked" ? "Evidence lineage is blocked." : null,
+        });
+      })
+    : [
+        publicExposureReference({
+          idParts: ["evidence", "missing"],
+          referenceType: "evidence",
+          status: "unavailable",
+          label: "Evidence lineage reference",
+          description: "Evidence lineage is unavailable for public exposure hardening review.",
+          destination: "/evidence-packs",
+        }),
+      ];
+
+  const reviewReferences = reviews.length
+    ? reviews.map((review) => {
+        const status = review.status === "completed" ? "verified" : review.status === "blocked" ? "blocked" : "partially_verified";
+        return publicExposureReference({
+          idParts: ["review", recordId(review, ["reviewSessionId", "id"]) || "unknown"],
+          referenceType: "review",
+          status,
+          label: "Review lineage reference",
+          description: "Operator review lineage is available for public exposure hardening review.",
+          lineageReferences: [recordId(review, ["reviewSessionId", "id"])].filter(Boolean),
+          destination: "/review-timeline",
+          blockedReason: status === "blocked" ? "Operator review lineage is blocked." : null,
+        });
+      })
+    : [
+        publicExposureReference({
+          idParts: ["review", "missing"],
+          referenceType: "review",
+          status: "unavailable",
+          label: "Review lineage reference",
+          description: "Operator review lineage is unavailable for public exposure hardening review.",
+          destination: "/review-timeline",
+        }),
+      ];
+
+  const auditReferences = auditEvents.length
+    ? auditEvents.slice(0, 20).map((record) =>
+        publicExposureReference({
+          idParts: ["audit", recordId(record, ["eventId", "id"]) || "unknown"],
+          referenceType: "audit",
+          status: record.redacted ? "partially_verified" : "verified",
+          label: "Audit lineage reference",
+          description: "Canonical audit event metadata is available for public exposure hardening review.",
+          lineageReferences: [recordId(record, ["eventId", "id"])].filter(Boolean),
+          destination: "/review-timeline",
+          redacted: Boolean(record.redacted),
+          redactionReason: record.redacted ? "Audit payload is redacted for public exposure hardening safety." : null,
+        })
+      )
+    : [
+        publicExposureReference({
+          idParts: ["audit", "missing"],
+          referenceType: "audit",
+          status: "unavailable",
+          label: "Audit lineage reference",
+          description: "Canonical audit event metadata is unavailable for public exposure hardening review.",
+          destination: "/review-timeline",
+        }),
+      ];
+
+  const allReferences = [
+    ...releaseReferences,
+    ...rollbackReferences,
+    ...securityReferences,
+    ...operationalRiskReferences,
+    ...onboardingReferences,
+    ...supportReferences,
+    ...evidenceReferences,
+    ...reviewReferences,
+    ...auditReferences,
+  ];
+
+  const publicExposureRestrictions = allReferences
+    .filter((reference) => reference.status !== "verified")
+    .map((reference) =>
+      publicExposureRestriction({
+        idParts: [reference.referenceType, reference.referenceId],
+        restrictionType: reference.referenceType,
+        status: reference.status === "blocked" ? "blocked" : "review_required",
+        label: `${reference.label} restriction`,
+        description: `${reference.label} is incomplete or blocked for public exposure hardening readiness.`,
+        blockedReason: reference.blockedReason,
+      })
+    );
+
+  const hasContext = Boolean(
+    releaseGovernanceProfiles.length ||
+      rollbackArtifacts.length ||
+      securityReadiness.length ||
+      operationalRiskProfiles.length ||
+      onboardingReadiness.length ||
+      supportReadiness.length ||
+      reviews.length ||
+      evidencePacks.length ||
+      auditEvents.length
+  );
+  const status = readinessStatus(hasContext, allReferences);
+  const blockedReasons = [...allReferences.map((reference) => reference.blockedReason), ...publicExposureRestrictions.map((restriction) => restriction.blockedReason)].filter(Boolean) as string[];
+
+  const canonicalEvents: PublicExposureCanonicalEvent[] = [
+    event({
+      eventType: "public_exposure_hardening_profile_derived",
+      status,
+      publicExposureHardeningId,
+      summary:
+        "Public exposure hardening profile derived from release, rollback, security, operational risk, onboarding, support, evidence, review, and audit metadata.",
+    }),
+    event({
+      eventType: "public_exposure_redaction_applied",
+      status,
+      publicExposureHardeningId,
+      summary:
+        "Secrets, credentials, sensitive tenant/payment/screening payloads, unrestricted infrastructure telemetry, deployment execution, rollback execution, and launch payloads were excluded.",
+    }),
+  ];
+  if (publicExposureRestrictions.length) {
+    canonicalEvents.push(
+      event({
+        eventType: "public_exposure_restriction_detected",
+        status,
+        publicExposureHardeningId,
+        summary: "Public exposure restrictions are visible for manual approval review.",
+      })
+    );
+  }
+  if (status === "review_required" || status === "partially_ready") {
+    canonicalEvents.push(
+      event({
+        eventType: "public_exposure_review_required",
+        status,
+        publicExposureHardeningId,
+        summary: "Manual public exposure hardening review is required.",
+      })
+    );
+  }
+  if (status === "blocked") {
+    canonicalEvents.push(
+      event({
+        eventType: "public_exposure_blocked",
+        status,
+        publicExposureHardeningId,
+        summary: "Public exposure hardening readiness is blocked by unresolved restrictions.",
+      })
+    );
+  }
+
+  return {
+    publicExposureHardeningId,
+    status,
+    manualApprovalRequired: true,
+    autonomousLaunchEnabled: false,
+    autonomousRollbackEnabled: false,
+    publicExposureEnabled: false,
+    generatedAt: generatedAt(input.generatedAt),
+    summary: {
+      totalReferences: allReferences.length,
+      verifiedReferences: allReferences.filter((reference) => reference.status === "verified").length,
+      partiallyVerifiedReferences: allReferences.filter((reference) => reference.status === "partially_verified").length,
+      blockedReferences: allReferences.filter((reference) => reference.status === "blocked").length,
+      unavailableReferences: allReferences.filter((reference) => reference.status === "unavailable").length,
+      restrictions: publicExposureRestrictions.length,
+    },
+    releaseReferences,
+    rollbackReferences,
+    securityReferences,
+    operationalRiskReferences,
+    onboardingReferences,
+    supportReferences,
+    reviewReferences,
+    evidenceReferences,
+    auditReferences,
+    publicExposureRestrictions,
+    redactions: REDACTIONS,
+    blockedReasons,
+    canonicalEvents,
+  };
+}

--- a/rentchain-api/src/lib/publicExposureHardening/publicExposureHardeningTypes.ts
+++ b/rentchain-api/src/lib/publicExposureHardening/publicExposureHardeningTypes.ts
@@ -1,0 +1,98 @@
+export type PublicExposureHardeningStatus = "ready_for_review" | "partially_ready" | "review_required" | "blocked" | "unknown";
+
+export type PublicExposureReferenceType =
+  | "release"
+  | "rollback"
+  | "security"
+  | "onboarding"
+  | "support"
+  | "operational_risk"
+  | "evidence"
+  | "review"
+  | "audit";
+
+export type PublicExposureReferenceStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+
+export type PublicExposureCanonicalEventType =
+  | "public_exposure_hardening_profile_derived"
+  | "public_exposure_review_required"
+  | "public_exposure_blocked"
+  | "public_exposure_restriction_detected"
+  | "public_exposure_redaction_applied";
+
+export type PublicExposureReference = {
+  referenceId: string;
+  referenceType: PublicExposureReferenceType;
+  status: PublicExposureReferenceStatus;
+  label: string;
+  description: string;
+  reviewRequired: true;
+  lineageReferences: string[];
+  destination: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type PublicExposureRestriction = {
+  restrictionId: string;
+  restrictionType: PublicExposureReferenceType | "public_exposure";
+  status: "visible" | "blocked" | "review_required";
+  label: string;
+  description: string;
+  blockedReason: string | null;
+};
+
+export type PublicExposureCanonicalEvent = {
+  eventType: PublicExposureCanonicalEventType;
+  action: string;
+  status: PublicExposureHardeningStatus;
+  resourceType: "public_exposure_hardening_profile";
+  resourceId: string;
+  summary: string;
+};
+
+export type PublicExposureHardeningProfile = {
+  publicExposureHardeningId: string;
+  status: PublicExposureHardeningStatus;
+  manualApprovalRequired: true;
+  autonomousLaunchEnabled: false;
+  autonomousRollbackEnabled: false;
+  publicExposureEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    partiallyVerifiedReferences: number;
+    blockedReferences: number;
+    unavailableReferences: number;
+    restrictions: number;
+  };
+  releaseReferences: PublicExposureReference[];
+  rollbackReferences: PublicExposureReference[];
+  securityReferences: PublicExposureReference[];
+  operationalRiskReferences: PublicExposureReference[];
+  onboardingReferences: PublicExposureReference[];
+  supportReferences: PublicExposureReference[];
+  reviewReferences: PublicExposureReference[];
+  evidenceReferences: PublicExposureReference[];
+  auditReferences: PublicExposureReference[];
+  publicExposureRestrictions: PublicExposureRestriction[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: PublicExposureCanonicalEvent[];
+};
+
+export type DerivePublicExposureHardeningProfileInput = {
+  hardeningKey?: unknown;
+  generatedAt?: unknown;
+  releaseGovernanceProfiles?: Array<Record<string, any>> | null;
+  rollbackArtifacts?: Array<Record<string, any>> | null;
+  securityReadiness?: Array<Record<string, any>> | null;
+  operationalRiskProfiles?: Array<Record<string, any>> | null;
+  institutionOnboardingReadiness?: Array<Record<string, any>> | null;
+  supportReadiness?: Array<Record<string, any>> | null;
+  operatorReviewSessions?: Array<Record<string, any>> | null;
+  evidencePacks?: Array<Record<string, any>> | null;
+  auditEvents?: Array<Record<string, any>> | null;
+};

--- a/rentchain-api/src/lib/publicExposureHardening/publicExposureRestrictionModels.ts
+++ b/rentchain-api/src/lib/publicExposureHardening/publicExposureRestrictionModels.ts
@@ -1,0 +1,63 @@
+import type {
+  PublicExposureReference,
+  PublicExposureReferenceStatus,
+  PublicExposureReferenceType,
+  PublicExposureRestriction,
+} from "./publicExposureHardeningTypes";
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+export function publicExposureIdPart(value: unknown): string {
+  return asString(value, 500)
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+export function publicExposureReference(input: {
+  idParts: unknown[];
+  referenceType: PublicExposureReferenceType;
+  status: PublicExposureReferenceStatus;
+  label: string;
+  description: string;
+  lineageReferences?: string[];
+  destination?: string | null;
+  redacted?: boolean;
+  redactionReason?: string | null;
+  blockedReason?: string | null;
+}): PublicExposureReference {
+  return {
+    referenceId: publicExposureIdPart(input.idParts.join(":")) || "public_exposure_reference:unknown",
+    referenceType: input.referenceType,
+    status: input.status,
+    label: input.label,
+    description: input.description,
+    reviewRequired: true,
+    lineageReferences: Array.from(new Set(input.lineageReferences || [])).filter(Boolean),
+    destination: input.destination || null,
+    redacted: Boolean(input.redacted),
+    redactionReason: input.redactionReason || null,
+    blockedReason: input.blockedReason || null,
+  };
+}
+
+export function publicExposureRestriction(input: {
+  idParts: unknown[];
+  restrictionType: PublicExposureRestriction["restrictionType"];
+  status: PublicExposureRestriction["status"];
+  label: string;
+  description: string;
+  blockedReason?: string | null;
+}): PublicExposureRestriction {
+  return {
+    restrictionId: publicExposureIdPart(input.idParts.join(":")) || "public_exposure_restriction:unknown",
+    restrictionType: input.restrictionType,
+    status: input.status,
+    label: input.label,
+    description: input.description,
+    blockedReason: input.blockedReason || null,
+  };
+}

--- a/rentchain-api/src/routes/__tests__/adminPublicExposureHardeningRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/adminPublicExposureHardeningRoutes.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+  return {
+    resetFakeDb: () => store.clear(),
+    seedDoc: (collection: string, id: string, data: any) => ensureCollection(collection).set(id, { id, data }),
+    fakeDb: {
+      collection: (name: string) => ({
+        get: async () => {
+          const docs = Array.from(ensureCollection(name).values()).map((doc) => ({ id: doc.id, exists: true, data: () => doc.data }));
+          return { docs, empty: docs.length === 0, size: docs.length };
+        },
+      }),
+    },
+  };
+});
+
+let mockUser: any;
+
+vi.mock("../../config/firebase", () => ({ db: fakeDb }));
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!mockUser) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    req.user = mockUser;
+    return next();
+  },
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; user?: Record<string, unknown> | null }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    mockUser = options.user ?? mockUser;
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: mockUser,
+      query: Object.fromEntries(new URLSearchParams(queryString || "").entries()),
+      params: {},
+      headers: {},
+    };
+    const match = path.match(/^\/public-exposure-hardening\/(.+)$/);
+    if (match) req.params = { publicExposureHardeningId: decodeURIComponent(match[1]) };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => (error ? reject(error) : undefined));
+  });
+}
+
+describe("adminPublicExposureHardeningRoutes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    resetFakeDb();
+    mockUser = { id: "admin-1", role: "admin", permissions: ["system.admin"] };
+  });
+
+  function seedHardeningContext() {
+    seedDoc("releaseGovernanceProfiles", "release-1", { releaseGovernanceId: "release-1", status: "ready_for_review", deploymentSecret: "secret-value" });
+    seedDoc("rollbackReadinessArtifacts", "rollback-1", { artifactId: "rollback-1", status: "verified", secretToken: "token-value" });
+    seedDoc("securityReadiness", "security-1", { securityReadinessId: "security-1", status: "verified", credential: "credential-value" });
+    seedDoc("operationalRiskProfiles", "risk-1", { operationalRiskId: "risk-1", status: "stable", rawPayload: "sensitive" });
+    seedDoc("institutionOnboardingReadiness", "onboarding-1", { onboardingReadinessId: "onboarding-1", status: "ready_for_review" });
+    seedDoc("supportReadiness", "support-1", { supportReadinessId: "support-1", status: "ready_for_review" });
+    seedDoc("evidencePacks", "evidence-1", { evidencePackId: "evidence-1", status: "ready_for_review", rawGovernmentId: "sensitive-id" });
+    seedDoc("operatorReviewSessions", "review-1", { reviewSessionId: "review-1", status: "completed", privateNote: "hidden" });
+    seedDoc("events", "event-1", { eventId: "event-1", eventType: "release_governance_profile_derived" });
+  }
+
+  it("returns admin-gated public exposure hardening profiles without sensitive payloads", async () => {
+    seedHardeningContext();
+    const router = (await import("../adminPublicExposureHardeningRoutes")).default;
+
+    const forbidden = await invokeRouter(router, {
+      method: "GET",
+      url: "/public-exposure-hardening",
+      user: { id: "landlord-1", role: "landlord", permissions: [] },
+    });
+    expect(forbidden.status).toBe(403);
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/public-exposure-hardening",
+      user: { id: "admin-1", role: "admin", permissions: ["system.admin"] },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.profiles).toHaveLength(1);
+    expect(res.body.profiles[0]).toEqual(
+      expect.objectContaining({
+        manualApprovalRequired: true,
+        autonomousLaunchEnabled: false,
+        autonomousRollbackEnabled: false,
+        publicExposureEnabled: false,
+      })
+    );
+    expect(JSON.stringify(res.body)).not.toContain("secret-value");
+    expect(JSON.stringify(res.body)).not.toContain("token-value");
+    expect(JSON.stringify(res.body)).not.toContain("credential-value");
+    expect(JSON.stringify(res.body)).not.toContain("sensitive-id");
+    expect(JSON.stringify(res.body)).not.toContain("privateNote");
+  });
+
+  it("returns a single public exposure hardening profile by id", async () => {
+    seedHardeningContext();
+    const router = (await import("../adminPublicExposureHardeningRoutes")).default;
+    const list = await invokeRouter(router, { method: "GET", url: "/public-exposure-hardening" });
+    const id = list.body.profiles[0].publicExposureHardeningId;
+
+    const res = await invokeRouter(router, { method: "GET", url: `/public-exposure-hardening/${encodeURIComponent(id)}` });
+
+    expect(res.status).toBe(200);
+    expect(res.body.profile.publicExposureHardeningId).toBe(id);
+  });
+
+  it("filters by status", async () => {
+    seedHardeningContext();
+    const router = (await import("../adminPublicExposureHardeningRoutes")).default;
+
+    const filtered = await invokeRouter(router, { method: "GET", url: "/public-exposure-hardening?status=unknown" });
+
+    expect(filtered.status).toBe(200);
+    expect(filtered.body.profiles).toEqual([]);
+  });
+});

--- a/rentchain-api/src/routes/adminPublicExposureHardeningRoutes.ts
+++ b/rentchain-api/src/routes/adminPublicExposureHardeningRoutes.ts
@@ -1,0 +1,132 @@
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { requireAuth } from "../middleware/requireAuth";
+import { requirePermission } from "../middleware/requireAuthz";
+import { derivePublicExposureHardeningProfile } from "../lib/publicExposureHardening/derivePublicExposureHardeningProfile";
+import type {
+  PublicExposureHardeningProfile,
+  PublicExposureHardeningStatus,
+} from "../lib/publicExposureHardening/publicExposureHardeningTypes";
+
+const router = Router();
+
+const HARDENING_KEY = "controlled-production-exposure-readiness-v1";
+const STATUSES = new Set<PublicExposureHardeningStatus>(["ready_for_review", "partially_ready", "review_required", "blocked", "unknown"]);
+
+const ROLLBACK_ARTIFACTS = [
+  { artifactId: "release-governance-rollback-checklist", status: "verified", path: "docs/releases/release-governance-baseline.md" },
+];
+
+const SECURITY_READINESS = [
+  { securityReadinessId: "admin-route-permission-scope", status: "verified" },
+  { securityReadinessId: "sensitive-payload-redaction-boundary", status: "verified" },
+];
+
+const SUPPORT_READINESS = [
+  { supportReadinessId: "support-console-readiness-visibility", status: "ready_for_review" },
+];
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+async function loadCollection(collectionName: string, limit = 25) {
+  const snap = await db.collection(collectionName).get().catch(() => null);
+  return (snap?.docs || []).slice(0, limit).map((doc) => sanitizeRecord({ id: doc.id, ...((doc.data() as any) || {}) }));
+}
+
+function sanitizeRecord(record: Record<string, any>) {
+  const safe: Record<string, any> = {};
+  for (const key of [
+    "id",
+    "status",
+    "state",
+    "conclusion",
+    "eventId",
+    "eventType",
+    "resourceType",
+    "resourceId",
+    "releaseGovernanceId",
+    "releaseVersion",
+    "rollbackId",
+    "artifactId",
+    "path",
+    "securityReadinessId",
+    "checkId",
+    "supportReadinessId",
+    "supportId",
+    "operationalRiskId",
+    "onboardingReadinessId",
+    "evidencePackId",
+    "reviewSessionId",
+    "generatedAt",
+    "createdAt",
+    "updatedAt",
+    "redacted",
+  ]) {
+    if (record[key] !== undefined) safe[key] = record[key];
+  }
+  return safe;
+}
+
+async function buildPublicExposureHardeningProfiles(): Promise<PublicExposureHardeningProfile[]> {
+  const [releaseGovernanceProfiles, operationalRiskProfiles, onboardingReadiness, evidencePacks, reviews, auditEvents, rollbackArtifacts, securityReadiness, supportReadiness] =
+    await Promise.all([
+      loadCollection("releaseGovernanceProfiles"),
+      loadCollection("operationalRiskProfiles"),
+      loadCollection("institutionOnboardingReadiness"),
+      loadCollection("evidencePacks"),
+      loadCollection("operatorReviewSessions"),
+      loadCollection("events"),
+      loadCollection("rollbackReadinessArtifacts"),
+      loadCollection("securityReadiness"),
+      loadCollection("supportReadiness"),
+    ]);
+
+  return [
+    derivePublicExposureHardeningProfile({
+      hardeningKey: HARDENING_KEY,
+      releaseGovernanceProfiles,
+      rollbackArtifacts: rollbackArtifacts.length ? rollbackArtifacts : ROLLBACK_ARTIFACTS,
+      securityReadiness: securityReadiness.length ? securityReadiness : SECURITY_READINESS,
+      operationalRiskProfiles,
+      institutionOnboardingReadiness: onboardingReadiness,
+      supportReadiness: supportReadiness.length ? supportReadiness : SUPPORT_READINESS,
+      evidencePacks,
+      operatorReviewSessions: reviews,
+      auditEvents,
+    }),
+  ];
+}
+
+function profileMatches(profile: PublicExposureHardeningProfile, id: string) {
+  return profile.publicExposureHardeningId === id;
+}
+
+router.get("/public-exposure-hardening", requireAuth, requirePermission("system.admin"), async (req: any, res) => {
+  try {
+    const status = asString(req.query?.status, 80) as PublicExposureHardeningStatus;
+    let profiles = await buildPublicExposureHardeningProfiles();
+    if (status && STATUSES.has(status)) profiles = profiles.filter((profile) => profile.status === status);
+    return res.json({ ok: true, profiles });
+  } catch (err: any) {
+    console.error("[admin-public-exposure-hardening] list failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "PUBLIC_EXPOSURE_HARDENING_FAILED" });
+  }
+});
+
+router.get("/public-exposure-hardening/:publicExposureHardeningId", requireAuth, requirePermission("system.admin"), async (req: any, res) => {
+  try {
+    const publicExposureHardeningId = decodeURIComponent(asString(req.params?.publicExposureHardeningId, 500));
+    if (!publicExposureHardeningId) return res.status(400).json({ ok: false, error: "PUBLIC_EXPOSURE_HARDENING_ID_REQUIRED" });
+    const profiles = await buildPublicExposureHardeningProfiles();
+    const profile = profiles.find((next) => profileMatches(next, publicExposureHardeningId));
+    if (!profile) return res.status(404).json({ ok: false, error: "PUBLIC_EXPOSURE_HARDENING_NOT_FOUND" });
+    return res.json({ ok: true, profile });
+  } catch (err: any) {
+    console.error("[admin-public-exposure-hardening] get failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "PUBLIC_EXPOSURE_HARDENING_GET_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -112,6 +112,7 @@ const AdminAlertingPage = lazy(() => import("./pages/admin/AdminAlertingPage"));
 const AdminObservabilityPage = lazy(() => import("./pages/admin/AdminObservabilityPage"));
 const AdminNotificationsPage = lazy(() => import("./pages/admin/AdminNotificationsPage"));
 const ReleaseGovernancePage = lazy(() => import("./pages/ReleaseGovernancePage"));
+const PublicExposureHardeningPage = lazy(() => import("./pages/PublicExposureHardeningPage"));
 const PortfolioScorePage = lazy(() => import("./pages/admin/PortfolioScorePage"));
 const PortfolioScoreHistoryPage = lazy(() => import("./pages/admin/PortfolioScoreHistoryPage"));
 const PortfolioHealthSummaryPage = lazy(() => import("./pages/landlord/PortfolioHealthSummaryPage"));
@@ -1286,6 +1287,14 @@ function App() {
               element={
                 <RequireAdmin>
                   <ReleaseGovernancePage />
+                </RequireAdmin>
+              }
+            />
+            <Route
+              path="/admin/public-exposure-hardening"
+              element={
+                <RequireAdmin>
+                  <PublicExposureHardeningPage />
                 </RequireAdmin>
               }
             />

--- a/rentchain-frontend/src/api/publicExposureHardeningApi.ts
+++ b/rentchain-frontend/src/api/publicExposureHardeningApi.ts
@@ -1,0 +1,85 @@
+import { apiFetch } from "./apiFetch";
+
+export type PublicExposureHardeningStatus = "ready_for_review" | "partially_ready" | "review_required" | "blocked" | "unknown";
+export type PublicExposureReferenceType =
+  | "release"
+  | "rollback"
+  | "security"
+  | "onboarding"
+  | "support"
+  | "operational_risk"
+  | "evidence"
+  | "review"
+  | "audit";
+export type PublicExposureReferenceStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+
+export type PublicExposureReference = {
+  referenceId: string;
+  referenceType: PublicExposureReferenceType;
+  status: PublicExposureReferenceStatus;
+  label: string;
+  description: string;
+  reviewRequired: true;
+  lineageReferences: string[];
+  destination: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type PublicExposureRestriction = {
+  restrictionId: string;
+  restrictionType: PublicExposureReferenceType | "public_exposure";
+  status: "visible" | "blocked" | "review_required";
+  label: string;
+  description: string;
+  blockedReason: string | null;
+};
+
+export type PublicExposureHardeningProfile = {
+  publicExposureHardeningId: string;
+  status: PublicExposureHardeningStatus;
+  manualApprovalRequired: true;
+  autonomousLaunchEnabled: false;
+  autonomousRollbackEnabled: false;
+  publicExposureEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    partiallyVerifiedReferences: number;
+    blockedReferences: number;
+    unavailableReferences: number;
+    restrictions: number;
+  };
+  releaseReferences: PublicExposureReference[];
+  rollbackReferences: PublicExposureReference[];
+  securityReferences: PublicExposureReference[];
+  operationalRiskReferences: PublicExposureReference[];
+  onboardingReferences: PublicExposureReference[];
+  supportReferences: PublicExposureReference[];
+  reviewReferences: PublicExposureReference[];
+  evidenceReferences: PublicExposureReference[];
+  auditReferences: PublicExposureReference[];
+  publicExposureRestrictions: PublicExposureRestriction[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: Array<{ eventType: string; action: string; status: PublicExposureHardeningStatus; resourceId: string; summary: string }>;
+};
+
+export async function fetchPublicExposureHardeningProfiles(params?: {
+  status?: PublicExposureHardeningStatus | "";
+}): Promise<PublicExposureHardeningProfile[]> {
+  const search = new URLSearchParams();
+  if (params?.status) search.set("status", params.status);
+  const suffix = search.toString() ? `?${search.toString()}` : "";
+  const response = await apiFetch<{ ok: true; profiles: PublicExposureHardeningProfile[] }>(`/admin/public-exposure-hardening${suffix}`);
+  return response.profiles;
+}
+
+export async function fetchPublicExposureHardeningProfile(publicExposureHardeningId: string): Promise<PublicExposureHardeningProfile> {
+  const response = await apiFetch<{ ok: true; profile: PublicExposureHardeningProfile }>(
+    `/admin/public-exposure-hardening/${encodeURIComponent(publicExposureHardeningId)}`
+  );
+  return response.profile;
+}

--- a/rentchain-frontend/src/components/publicExposure/PublicExposureHardeningPanel.test.tsx
+++ b/rentchain-frontend/src/components/publicExposure/PublicExposureHardeningPanel.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import type { PublicExposureHardeningProfile } from "@/api/publicExposureHardeningApi";
+import { PublicExposureHardeningPanel } from "./PublicExposureHardeningPanel";
+
+const profile: PublicExposureHardeningProfile = {
+  publicExposureHardeningId: "public_exposure_hardening:controlled-production-exposure-readiness-v1",
+  status: "blocked",
+  manualApprovalRequired: true,
+  autonomousLaunchEnabled: false,
+  autonomousRollbackEnabled: false,
+  publicExposureEnabled: false,
+  generatedAt: "2026-01-01T00:00:00.000Z",
+  summary: {
+    totalReferences: 2,
+    verifiedReferences: 1,
+    partiallyVerifiedReferences: 0,
+    blockedReferences: 1,
+    unavailableReferences: 0,
+    restrictions: 1,
+  },
+  releaseReferences: [],
+  rollbackReferences: [],
+  securityReferences: [],
+  operationalRiskReferences: [
+    {
+      referenceId: "risk-1",
+      referenceType: "operational_risk",
+      status: "blocked",
+      label: "Operational risk dependency",
+      description: "Operational risk readiness is available.",
+      reviewRequired: true,
+      lineageReferences: ["risk-1"],
+      destination: "/operational-risk",
+      redacted: false,
+      redactionReason: null,
+      blockedReason: "Unresolved operational risk blocks public exposure readiness.",
+    },
+  ],
+  onboardingReferences: [],
+  supportReferences: [],
+  reviewReferences: [],
+  evidenceReferences: [],
+  auditReferences: [],
+  publicExposureRestrictions: [
+    {
+      restrictionId: "restriction-1",
+      restrictionType: "operational_risk",
+      status: "blocked",
+      label: "Operational risk dependency restriction",
+      description: "Operational risk dependency is incomplete or blocked.",
+      blockedReason: "Unresolved operational risk blocks public exposure readiness.",
+    },
+  ],
+  redactions: ["Deployment credentials, tokens, secrets, and environment values are excluded."],
+  blockedReasons: ["Unresolved operational risk blocks public exposure readiness."],
+  canonicalEvents: [],
+};
+
+describe("PublicExposureHardeningPanel", () => {
+  const forbiddenLabels = [
+    ["Launch", "automatically"],
+    ["Auto", "rollback"],
+    ["Enable", "production"],
+    ["Autonomous", "launch"],
+    ["Auto", "approve launch"],
+    ["Trigger", "production exposure"],
+  ].map((parts) => (parts[0] === "Auto" ? parts.join("-") : parts.join(" ")));
+
+  it("renders required safety copy, readiness status, restrictions, and blocked reasons", () => {
+    render(
+      <MemoryRouter>
+        <PublicExposureHardeningPanel profile={profile} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("View exposure readiness")).toBeInTheDocument();
+    expect(screen.getByText(/Public exposure hardening is operationally scoped and review controlled/i)).toBeInTheDocument();
+    expect(screen.getByText(/No autonomous deployment, rollback, or public launch execution is enabled/i)).toBeInTheDocument();
+    expect(screen.getByText("Manual approval required")).toBeInTheDocument();
+    expect(screen.getAllByText("Blocked").length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Unresolved operational risk blocks public exposure readiness/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("View restrictions")).toBeInTheDocument();
+    expect(screen.getByText("View operational risk")).toBeInTheDocument();
+    expect(screen.getByText("Deployment credentials, tokens, secrets, and environment values are excluded.")).toBeInTheDocument();
+  });
+
+  it("omits forbidden public exposure execution labels", () => {
+    render(
+      <MemoryRouter>
+        <PublicExposureHardeningPanel profile={profile} />
+      </MemoryRouter>
+    );
+
+    for (const forbiddenLabel of forbiddenLabels) {
+      expect(screen.queryByText(forbiddenLabel)).not.toBeInTheDocument();
+    }
+  });
+});

--- a/rentchain-frontend/src/components/publicExposure/PublicExposureHardeningPanel.tsx
+++ b/rentchain-frontend/src/components/publicExposure/PublicExposureHardeningPanel.tsx
@@ -1,0 +1,147 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import type {
+  PublicExposureHardeningProfile,
+  PublicExposureReference,
+  PublicExposureRestriction,
+} from "@/api/publicExposureHardeningApi";
+import { Card, Section } from "@/components/ui/Ui";
+
+function label(value: string) {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function tone(status: string) {
+  if (status === "blocked") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
+  if (status === "review_required" || status === "partially_ready" || status === "partially_verified" || status === "unavailable") {
+    return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
+  }
+  if (status === "ready_for_review" || status === "verified") return { color: "#166534", background: "#dcfce7", border: "#bbf7d0" };
+  return { color: "#475569", background: "#f8fafc", border: "#e2e8f0" };
+}
+
+function Badge({ children, status }: { children: React.ReactNode; status: string }) {
+  const next = tone(status);
+  return (
+    <span style={{ border: `1px solid ${next.border}`, borderRadius: 999, background: next.background, color: next.color, padding: "3px 9px", fontSize: 12, fontWeight: 900, whiteSpace: "nowrap" }}>
+      {children}
+    </span>
+  );
+}
+
+function ReferenceList({ title, references }: { title: string; references: PublicExposureReference[] }) {
+  return (
+    <Section style={{ display: "grid", gap: 10 }}>
+      <div style={{ fontWeight: 900 }}>{title}</div>
+      {references.length ? (
+        references.slice(0, 12).map((reference) => (
+          <Card key={reference.referenceId} style={{ borderRadius: 8, padding: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+              <div>
+                <strong>{reference.label}</strong>
+                <div style={{ color: "#64748b", fontSize: 13 }}>{label(reference.referenceType)}</div>
+              </div>
+              <Badge status={reference.status}>{label(reference.status)}</Badge>
+            </div>
+            <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>{reference.description}</div>
+            {reference.lineageReferences.length ? <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>Lineage references: {reference.lineageReferences.length}</div> : null}
+            {reference.blockedReason ? <div style={{ color: "#991b1b", fontSize: 13, marginTop: 8 }}>View blocked reason: {reference.blockedReason}</div> : null}
+            {reference.redacted ? <div style={{ color: "#92400e", fontSize: 13, marginTop: 8 }}>{reference.redactionReason || "Redacted public exposure hardening reference"}</div> : null}
+            {reference.destination?.startsWith("/") ? <Link to={reference.destination} style={{ color: "#2563eb", fontWeight: 800, fontSize: 13, marginTop: 8, display: "inline-block" }}>View context</Link> : null}
+            {reference.destination && !reference.destination.startsWith("/") ? <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>{reference.destination}</div> : null}
+          </Card>
+        ))
+      ) : (
+        <Card style={{ color: "#64748b" }}>Context unavailable</Card>
+      )}
+    </Section>
+  );
+}
+
+function RestrictionList({ restrictions }: { restrictions: PublicExposureRestriction[] }) {
+  return (
+    <Section style={{ display: "grid", gap: 10 }}>
+      <div style={{ fontWeight: 900 }}>View restrictions</div>
+      {restrictions.length ? (
+        restrictions.map((restriction) => (
+          <Card key={restriction.restrictionId} style={{ borderRadius: 8, padding: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+              <div>
+                <strong>{restriction.label}</strong>
+                <div style={{ color: "#64748b", fontSize: 13 }}>{label(restriction.restrictionType)}</div>
+              </div>
+              <Badge status={restriction.status}>{label(restriction.status)}</Badge>
+            </div>
+            <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>{restriction.description}</div>
+            {restriction.blockedReason ? <div style={{ color: "#991b1b", fontSize: 13, marginTop: 8 }}>View blocked reason: {restriction.blockedReason}</div> : null}
+          </Card>
+        ))
+      ) : (
+        <Card style={{ color: "#64748b" }}>No public exposure restrictions detected.</Card>
+      )}
+    </Section>
+  );
+}
+
+export function PublicExposureHardeningPanel({ profile }: { profile: PublicExposureHardeningProfile }) {
+  return (
+    <div style={{ display: "grid", gap: 16 }}>
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+          <div>
+            <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>View exposure readiness</div>
+            <h2 style={{ margin: "2px 0 0", fontSize: "1.15rem" }}>Public exposure hardening</h2>
+          </div>
+          <Badge status={profile.status}>{label(profile.status)}</Badge>
+        </div>
+        <div style={{ color: "#475569", lineHeight: 1.55 }}>
+          Public exposure hardening is operationally scoped and review controlled. No autonomous deployment, rollback, or public launch execution is enabled.
+          Manual approval remains required.
+        </div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <Badge status="review_required">Manual approval required</Badge>
+          <Badge status={profile.autonomousLaunchEnabled ? "blocked" : "verified"}>Launch execution disabled</Badge>
+          <Badge status={profile.autonomousRollbackEnabled ? "blocked" : "verified"}>Rollback execution disabled</Badge>
+          <Badge status={profile.publicExposureEnabled ? "blocked" : "verified"}>Production exposure disabled</Badge>
+        </div>
+      </Section>
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Hardening summary</div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: 10 }}>
+          {[
+            ["References", profile.summary.totalReferences],
+            ["Verified", profile.summary.verifiedReferences],
+            ["Partial", profile.summary.partiallyVerifiedReferences],
+            ["Blocked", profile.summary.blockedReferences],
+            ["Unavailable", profile.summary.unavailableReferences],
+            ["Restrictions", profile.summary.restrictions],
+          ].map(([name, value]) => (
+            <Card key={String(name)} style={{ borderRadius: 8, padding: 12 }}>
+              <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>{name}</div>
+              <strong style={{ color: "#0f172a", fontSize: 22 }}>{String(value)}</strong>
+            </Card>
+          ))}
+        </div>
+      </Section>
+
+      <RestrictionList restrictions={profile.publicExposureRestrictions} />
+      <ReferenceList title="View release readiness" references={profile.releaseReferences} />
+      <ReferenceList title="View rollback readiness" references={profile.rollbackReferences} />
+      <ReferenceList title="View security readiness" references={profile.securityReferences} />
+      <ReferenceList title="View operational risk" references={profile.operationalRiskReferences} />
+      <ReferenceList title="View onboarding readiness" references={profile.onboardingReferences} />
+      <ReferenceList title="View support readiness" references={profile.supportReferences} />
+      <ReferenceList title="View evidence lineage" references={profile.evidenceReferences} />
+      <ReferenceList title="View review lineage" references={profile.reviewReferences} />
+      <ReferenceList title="Audit references" references={profile.auditReferences} />
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Redactions</div>
+        {profile.redactions.map((redaction) => (
+          <Card key={redaction} style={{ borderRadius: 8, padding: 12, color: "#475569" }}>{redaction}</Card>
+        ))}
+      </Section>
+    </div>
+  );
+}

--- a/rentchain-frontend/src/pages/PublicExposureHardeningPage.test.tsx
+++ b/rentchain-frontend/src/pages/PublicExposureHardeningPage.test.tsx
@@ -1,0 +1,115 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import PublicExposureHardeningPage from "./PublicExposureHardeningPage";
+
+const mockFetchPublicExposureHardeningProfiles = vi.fn();
+const mockShowToast = vi.fn();
+
+vi.mock("@/api/publicExposureHardeningApi", () => ({
+  fetchPublicExposureHardeningProfiles: (...args: any[]) => mockFetchPublicExposureHardeningProfiles(...args),
+}));
+
+vi.mock("@/components/layout/MacShell", () => ({
+  MacShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
+const profile = {
+  publicExposureHardeningId: "public_exposure_hardening:controlled-production-exposure-readiness-v1",
+  status: "ready_for_review",
+  manualApprovalRequired: true,
+  autonomousLaunchEnabled: false,
+  autonomousRollbackEnabled: false,
+  publicExposureEnabled: false,
+  generatedAt: "2026-01-01T00:00:00.000Z",
+  summary: {
+    totalReferences: 1,
+    verifiedReferences: 1,
+    partiallyVerifiedReferences: 0,
+    blockedReferences: 0,
+    unavailableReferences: 0,
+    restrictions: 0,
+  },
+  releaseReferences: [],
+  rollbackReferences: [],
+  securityReferences: [],
+  operationalRiskReferences: [],
+  onboardingReferences: [],
+  supportReferences: [],
+  reviewReferences: [],
+  evidenceReferences: [],
+  auditReferences: [],
+  publicExposureRestrictions: [],
+  redactions: ["Public exposure hardening is readiness metadata only; no autonomous deployment, rollback, or public launch execution is enabled."],
+  blockedReasons: [],
+  canonicalEvents: [],
+};
+
+describe("PublicExposureHardeningPage", () => {
+  const forbiddenLabels = [
+    ["Launch", "automatically"],
+    ["Auto", "rollback"],
+    ["Enable", "production"],
+    ["Autonomous", "launch"],
+    ["Auto", "approve launch"],
+    ["Trigger", "production exposure"],
+  ].map((parts) => (parts[0] === "Auto" ? parts.join("-") : parts.join(" ")));
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchPublicExposureHardeningProfiles.mockResolvedValue([profile]);
+  });
+
+  it("renders public exposure hardening and required safety copy", async () => {
+    render(
+      <MemoryRouter>
+        <PublicExposureHardeningPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Public exposure hardening")).toBeInTheDocument();
+    expect(screen.getAllByText(/No autonomous deployment, rollback, or public launch execution is enabled/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("Manual approval required")).toBeInTheDocument();
+    expect(screen.getByText("Public exposure hardening is readiness metadata only; no autonomous deployment, rollback, or public launch execution is enabled.")).toBeInTheDocument();
+  });
+
+  it("updates deterministic status filters", async () => {
+    render(
+      <MemoryRouter>
+        <PublicExposureHardeningPage />
+      </MemoryRouter>
+    );
+
+    await screen.findByText("Public exposure hardening");
+    fireEvent.change(screen.getByLabelText("Status"), { target: { value: "blocked" } });
+
+    await waitFor(() => {
+      expect(mockFetchPublicExposureHardeningProfiles).toHaveBeenLastCalledWith({
+        status: "blocked",
+      });
+    });
+  });
+
+  it("shows empty state and omits forbidden labels", async () => {
+    mockFetchPublicExposureHardeningProfiles.mockResolvedValue([]);
+    render(
+      <MemoryRouter>
+        <PublicExposureHardeningPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("No public exposure hardening profiles match these filters.")).toBeInTheDocument();
+    for (const forbiddenLabel of forbiddenLabels) {
+      expect(screen.queryByText(forbiddenLabel)).not.toBeInTheDocument();
+    }
+  });
+});

--- a/rentchain-frontend/src/pages/PublicExposureHardeningPage.tsx
+++ b/rentchain-frontend/src/pages/PublicExposureHardeningPage.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { useSearchParams } from "react-router-dom";
+import {
+  fetchPublicExposureHardeningProfiles,
+  type PublicExposureHardeningProfile,
+  type PublicExposureHardeningStatus,
+} from "@/api/publicExposureHardeningApi";
+import { PublicExposureHardeningPanel } from "@/components/publicExposure/PublicExposureHardeningPanel";
+import { MacShell } from "@/components/layout/MacShell";
+import { Card, Section } from "@/components/ui/Ui";
+import { useToast } from "@/components/ui/ToastProvider";
+
+const statuses: Array<PublicExposureHardeningStatus | ""> = ["", "ready_for_review", "partially_ready", "review_required", "blocked", "unknown"];
+
+function label(value: string) {
+  return value ? value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase()) : "All";
+}
+
+export default function PublicExposureHardeningPage() {
+  const { showToast } = useToast();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [profiles, setProfiles] = React.useState<PublicExposureHardeningProfile[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const status = String(searchParams.get("status") || "") as PublicExposureHardeningStatus | "";
+
+  React.useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const next = await fetchPublicExposureHardeningProfiles({ status });
+        if (mounted) setProfiles(next);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Failed to load public exposure hardening";
+        if (mounted) {
+          setError(message);
+          showToast({ message: "Failed to load public exposure hardening", description: message, variant: "error" });
+        }
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [status, showToast]);
+
+  function updateStatus(value: string) {
+    const params = new URLSearchParams(searchParams);
+    if (value && value.trim()) params.set("status", value.trim());
+    else params.delete("status");
+    setSearchParams(params);
+  }
+
+  return (
+    <MacShell title="Public exposure hardening" showTopNav={false}>
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "grid", gap: 6 }}>
+            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Public exposure hardening</h1>
+            <div style={{ color: "#475569", maxWidth: 900 }}>
+              Public exposure hardening is operationally scoped and review controlled. No autonomous deployment, rollback, or public launch execution is enabled.
+              Manual approval remains required.
+            </div>
+          </div>
+        </Section>
+
+        <Section style={{ display: "flex", gap: 10, flexWrap: "wrap", alignItems: "end" }}>
+          <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Status
+            <select value={status} onChange={(event) => updateStatus(event.target.value)} style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 180 }}>
+              {statuses.map((item) => <option key={item || "all"} value={item}>{label(item)}</option>)}
+            </select>
+          </label>
+        </Section>
+
+        {loading ? <Card>Loading public exposure hardening...</Card> : null}
+        {!loading && error ? <Card style={{ color: "#b91c1c" }}>We couldn't load public exposure hardening right now.</Card> : null}
+        {!loading && !error && !profiles.length ? <Card style={{ color: "#64748b" }}>No public exposure hardening profiles match these filters.</Card> : null}
+        {!loading && !error && profiles.length ? (
+          <div style={{ display: "grid", gap: 16 }}>{profiles.map((profile) => <PublicExposureHardeningPanel key={profile.publicExposureHardeningId} profile={profile} />)}</div>
+        ) : null}
+      </div>
+    </MacShell>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds deterministic public exposure hardening read models, restrictions, redactions, and canonical event metadata.
- Adds admin-only read endpoints for public exposure hardening profiles.
- Adds admin UI visibility for exposure readiness, release/rollback/security/operational-risk/onboarding/support dependencies, restrictions, and redactions.

## Guardrails
- Manual approval remains required.
- Autonomous launch, rollback, deployment, public exposure, environment mutation, secret rotation, and infrastructure mutation are not enabled.
- Admin route responses use whitelist projections to avoid exposing sensitive payloads.

## Verification
- Backend targeted tests passed: `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm test -- --run src/lib/publicExposureHardening/__tests__/derivePublicExposureHardeningProfile.test.ts src/routes/__tests__/adminPublicExposureHardeningRoutes.test.ts`
- Frontend targeted tests passed: `npm test -- --run src/components/publicExposure/PublicExposureHardeningPanel.test.tsx src/pages/PublicExposureHardeningPage.test.tsx`
- Backend build passed: `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm run build`
- Frontend build passed with existing large chunk warning: `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm run build`
- Diff whitespace check passed: `git diff --check`