### PR TITLE
feat: add observability incident readiness layer

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -111,6 +111,7 @@ import adminAlertingRoutes from "./routes/adminAlertingRoutes";
 import adminAssignmentRoutes from "./routes/adminAssignmentRoutes";
 import adminNotificationRoutes from "./routes/adminNotificationRoutes";
 import adminObservabilityRoutes from "./routes/adminObservabilityRoutes";
+import adminObservabilityIncidentReadinessRoutes from "./routes/adminObservabilityIncidentReadinessRoutes";
 import adminReleaseGovernanceRoutes from "./routes/adminReleaseGovernanceRoutes";
 import adminPublicExposureHardeningRoutes from "./routes/adminPublicExposureHardeningRoutes";
 import portfolioScoreRoutes from "./routes/portfolioScoreRoutes";
@@ -283,6 +284,8 @@ app.use("/api/admin", routeSource("adminNotificationRoutes.ts"), adminNotificati
 console.log("[route-mount] adminNotificationRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("adminObservabilityRoutes.ts"), adminObservabilityRoutes);
 console.log("[route-mount] adminObservabilityRoutes mounted at /api/admin");
+app.use("/api/admin", routeSource("adminObservabilityIncidentReadinessRoutes.ts"), adminObservabilityIncidentReadinessRoutes);
+console.log("[route-mount] adminObservabilityIncidentReadinessRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("adminReleaseGovernanceRoutes.ts"), adminReleaseGovernanceRoutes);
 console.log("[route-mount] adminReleaseGovernanceRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("adminPublicExposureHardeningRoutes.ts"), adminPublicExposureHardeningRoutes);

--- a/rentchain-api/src/lib/observabilityIncidentReadiness/__tests__/deriveObservabilityIncidentReadinessProfile.test.ts
+++ b/rentchain-api/src/lib/observabilityIncidentReadiness/__tests__/deriveObservabilityIncidentReadinessProfile.test.ts
@@ -27,6 +27,7 @@ describe("deriveObservabilityIncidentReadinessProfile", () => {
         manualReviewRequired: true,
         externalMonitoringIntegrationEnabled: false,
         autonomousRemediationEnabled: false,
+        alertExecutionEnabled: false,
         alertSendingEnabled: false,
         productionMutationEnabled: false,
         sensitiveTelemetryExposed: false,
@@ -85,6 +86,7 @@ describe("deriveObservabilityIncidentReadinessProfile", () => {
     expect(profile.status).toBe("partially_ready");
     expect(profile.manualReviewRequired).toBe(true);
     expect(profile.autonomousRemediationEnabled).toBe(false);
+    expect(profile.alertExecutionEnabled).toBe(false);
     expect(profile.alertSendingEnabled).toBe(false);
     expect(profile.productionMutationEnabled).toBe(false);
   });

--- a/rentchain-api/src/lib/observabilityIncidentReadiness/__tests__/deriveObservabilityIncidentReadinessProfile.test.ts
+++ b/rentchain-api/src/lib/observabilityIncidentReadiness/__tests__/deriveObservabilityIncidentReadinessProfile.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { deriveObservabilityIncidentReadinessProfile } from "../deriveObservabilityIncidentReadinessProfile";
+
+const completeInput = {
+  generatedAt: "2026-01-01T00:00:00.000Z",
+  observabilityEvents: [{ id: "obs-1", eventType: "workflow_completed", workflow: "payment", severity: "info", status: "resolved" }],
+  statusIncidents: [{ id: "incident-1", status: "resolved", severity: "minor" }],
+  recoveryReadiness: [{ recoveryReadinessId: "recovery-1", status: "ready_for_review" }],
+  escalationReadiness: [{ escalationReadinessId: "escalation-1", status: "ready_for_review" }],
+  postIncidentReviews: [{ postIncidentReviewId: "post-incident-1", status: "ready_for_review" }],
+  slaEvaluations: [{ slaId: "sla-1", status: "verified", stage: "fresh" }],
+  adminAlerts: [{ alertId: "alert-1", severity: "low", status: "verified" }],
+  releaseGovernanceProfiles: [{ releaseGovernanceId: "release-1", status: "ready_for_review" }],
+  publicExposureHardeningProfiles: [{ publicExposureHardeningId: "public-exposure-1", status: "ready_for_review" }],
+  evidencePacks: [{ evidencePackId: "evidence-1", status: "ready_for_review" }],
+  operatorReviewSessions: [{ reviewSessionId: "review-1", status: "completed" }],
+  auditEvents: [{ eventId: "event-1", eventType: "public_exposure_hardening_profile_derived" }],
+};
+
+describe("deriveObservabilityIncidentReadinessProfile", () => {
+  it("derives deterministic ready-for-review readiness with fixed non-execution flags", () => {
+    const profile = deriveObservabilityIncidentReadinessProfile(completeInput);
+
+    expect(profile).toEqual(
+      expect.objectContaining({
+        status: "ready_for_review",
+        manualReviewRequired: true,
+        externalMonitoringIntegrationEnabled: false,
+        autonomousRemediationEnabled: false,
+        alertSendingEnabled: false,
+        productionMutationEnabled: false,
+        sensitiveTelemetryExposed: false,
+      })
+    );
+    expect(profile.summary.totalReferences).toBe(13);
+    expect(profile.summary.verifiedReferences).toBe(13);
+    expect(profile.observabilityIncidentRestrictions).toEqual([]);
+    expect(profile.canonicalEvents.map((event) => event.eventType)).toContain("observability_incident_readiness_profile_derived");
+  });
+
+  it("blocks readiness for open critical observability, incident, or alert restrictions", () => {
+    const profile = deriveObservabilityIncidentReadinessProfile({
+      ...completeInput,
+      observabilityEvents: [{ id: "obs-1", eventType: "action_failed", workflow: "payment", severity: "critical", status: "open" }],
+      statusIncidents: [{ id: "incident-1", status: "investigating", severity: "critical" }],
+      adminAlerts: [{ alertId: "alert-1", severity: "critical", status: "open" }],
+    });
+
+    expect(profile.status).toBe("blocked");
+    expect(profile.observabilityIncidentRestrictions.map((restriction) => restriction.status)).toContain("blocked");
+    expect(profile.blockedReasons).toEqual(
+      expect.arrayContaining([
+        "Open critical observability event requires incident readiness review.",
+        "Active major or critical incident blocks readiness.",
+        "Unresolved outage lineage blocks incident readiness.",
+        "Critical admin alert requires manual incident readiness review.",
+      ])
+    );
+    expect(profile.canonicalEvents.map((event) => event.eventType)).toContain("observability_incident_blocked");
+  });
+
+  it("requires review when critical readiness lineage is missing", () => {
+    const profile = deriveObservabilityIncidentReadinessProfile({
+      ...completeInput,
+      observabilityEvents: [],
+      slaEvaluations: [],
+      auditEvents: [],
+    });
+
+    expect(profile.status).toBe("review_required");
+    expect(profile.summary.unavailableReferences).toBe(3);
+    expect(profile.observabilityIncidentRestrictions.map((restriction) => restriction.restrictionType)).toEqual(
+      expect.arrayContaining(["observability", "sla", "audit"])
+    );
+    expect(profile.canonicalEvents.map((event) => event.eventType)).toContain("observability_incident_review_required");
+  });
+
+  it("keeps partial readiness for overdue SLA or high alert visibility without executing remediation", () => {
+    const profile = deriveObservabilityIncidentReadinessProfile({
+      ...completeInput,
+      slaEvaluations: [{ slaId: "sla-1", stage: "overdue" }],
+      adminAlerts: [{ alertId: "alert-1", severity: "high" }],
+    });
+
+    expect(profile.status).toBe("partially_ready");
+    expect(profile.manualReviewRequired).toBe(true);
+    expect(profile.autonomousRemediationEnabled).toBe(false);
+    expect(profile.alertSendingEnabled).toBe(false);
+    expect(profile.productionMutationEnabled).toBe(false);
+  });
+
+  it("returns unknown when no source context is available", () => {
+    const profile = deriveObservabilityIncidentReadinessProfile({});
+
+    expect(profile.status).toBe("unknown");
+    expect(profile.summary.unavailableReferences).toBeGreaterThan(0);
+    expect(profile.canonicalEvents.map((event) => event.eventType)).toContain("observability_incident_redaction_applied");
+  });
+});

--- a/rentchain-api/src/lib/observabilityIncidentReadiness/deriveObservabilityIncidentReadinessProfile.ts
+++ b/rentchain-api/src/lib/observabilityIncidentReadiness/deriveObservabilityIncidentReadinessProfile.ts
@@ -571,6 +571,7 @@ export function deriveObservabilityIncidentReadinessProfile(
     manualReviewRequired: true,
     externalMonitoringIntegrationEnabled: false,
     autonomousRemediationEnabled: false,
+    alertExecutionEnabled: false,
     alertSendingEnabled: false,
     productionMutationEnabled: false,
     sensitiveTelemetryExposed: false,

--- a/rentchain-api/src/lib/observabilityIncidentReadiness/deriveObservabilityIncidentReadinessProfile.ts
+++ b/rentchain-api/src/lib/observabilityIncidentReadiness/deriveObservabilityIncidentReadinessProfile.ts
@@ -1,0 +1,604 @@
+import type {
+  DeriveObservabilityIncidentReadinessProfileInput,
+  ObservabilityIncidentCanonicalEvent,
+  ObservabilityIncidentReadinessProfile,
+  ObservabilityIncidentReadinessStatus,
+  ObservabilityIncidentReference,
+} from "./observabilityIncidentReadinessTypes";
+import {
+  observabilityIncidentIdPart,
+  observabilityIncidentReference,
+  observabilityIncidentRestriction,
+} from "./observabilityIncidentRestrictionModels";
+
+const DEFAULT_READINESS_KEY = "operational-observability-incident-readiness-v1";
+
+const REDACTIONS = [
+  "Sensitive telemetry payloads, stack traces, request bodies, tenant/payment/screening data, and credentials are excluded.",
+  "External monitoring integrations, alert sending, autonomous remediation, and production mutation are not enabled.",
+  "Incident readiness is review metadata only; no outage declaration, remediation, recovery, or public-status mutation is executed.",
+  "Admin-only source records are projected through deterministic readiness references.",
+];
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function asArray<T>(value: T[] | null | undefined): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function generatedAt(value: unknown): string {
+  const raw = asString(value, 120);
+  const date = raw ? new Date(raw) : new Date(0);
+  return Number.isNaN(date.getTime()) ? new Date(0).toISOString() : date.toISOString();
+}
+
+function recordId(record: Record<string, any>, keys: string[]): string {
+  for (const key of keys) {
+    const value = asString(record?.[key], 240);
+    if (value) return value;
+  }
+  return asString(record?.id, 240);
+}
+
+function event(input: {
+  eventType: ObservabilityIncidentCanonicalEvent["eventType"];
+  status: ObservabilityIncidentReadinessStatus;
+  observabilityIncidentReadinessId: string;
+  summary: string;
+}): ObservabilityIncidentCanonicalEvent {
+  return {
+    eventType: input.eventType,
+    action: input.eventType.replace(/^observability_incident_/, "").replace(/_/g, "."),
+    status: input.status,
+    resourceType: "observability_incident_readiness_profile",
+    resourceId: input.observabilityIncidentReadinessId,
+    summary: input.summary,
+  };
+}
+
+function statusFromReadiness(record: Record<string, any>, verifiedStatuses: string[]): ObservabilityIncidentReference["status"] {
+  const status = asString(record?.status || record?.state || record?.conclusion, 80).toLowerCase();
+  if (status === "blocked" || status === "critical" || status === "major_outage" || status === "failed" || status === "failure") return "blocked";
+  if (verifiedStatuses.includes(status)) return "verified";
+  if (status === "unknown" || status === "missing" || status === "unavailable" || status === "pending") return "unavailable";
+  return "partially_verified";
+}
+
+function observabilityEventStatus(record: Record<string, any>): ObservabilityIncidentReference["status"] {
+  const status = asString(record?.status, 80).toLowerCase();
+  const severity = asString(record?.severity, 80).toLowerCase();
+  if (status === "open" && severity === "critical") return "blocked";
+  if (status === "open" && severity === "warning") return "partially_verified";
+  if (status === "resolved" || record.eventType === "workflow_completed") return "verified";
+  return "partially_verified";
+}
+
+function incidentStatus(record: Record<string, any>): ObservabilityIncidentReference["status"] {
+  const status = asString(record?.status, 80).toLowerCase();
+  const severity = asString(record?.severity, 80).toLowerCase();
+  if (status === "resolved") return "verified";
+  if (severity === "critical" || severity === "major") return "blocked";
+  if (status === "investigating" || status === "identified" || status === "monitoring") return "partially_verified";
+  return "unavailable";
+}
+
+function releaseStatus(record: Record<string, any>): ObservabilityIncidentReference["status"] {
+  const status = asString(record?.status, 80).toLowerCase();
+  if (status === "blocked") return "blocked";
+  if (status === "ready_for_review") return "verified";
+  if (status === "unknown" || status === "review_required") return "unavailable";
+  return "partially_verified";
+}
+
+function publicExposureStatus(record: Record<string, any>): ObservabilityIncidentReference["status"] {
+  const status = asString(record?.status, 80).toLowerCase();
+  if (status === "blocked") return "blocked";
+  if (status === "ready_for_review") return "verified";
+  if (status === "unknown" || status === "review_required") return "unavailable";
+  return "partially_verified";
+}
+
+function readinessStatus(hasContext: boolean, references: ObservabilityIncidentReference[]): ObservabilityIncidentReadinessStatus {
+  if (!hasContext) return "unknown";
+  if (references.some((reference) => reference.status === "blocked")) return "blocked";
+  const missingCritical = references.some(
+    (reference) =>
+      reference.status === "unavailable" &&
+      (reference.referenceType === "observability" ||
+        reference.referenceType === "incident" ||
+        reference.referenceType === "recovery" ||
+        reference.referenceType === "escalation" ||
+        reference.referenceType === "post_incident_review" ||
+        reference.referenceType === "sla" ||
+        reference.referenceType === "alert" ||
+        reference.referenceType === "audit")
+  );
+  if (missingCritical) return "review_required";
+  if (references.some((reference) => reference.status === "unavailable" || reference.status === "partially_verified")) return "partially_ready";
+  return "ready_for_review";
+}
+
+export function deriveObservabilityIncidentReadinessProfile(
+  input: DeriveObservabilityIncidentReadinessProfileInput
+): ObservabilityIncidentReadinessProfile {
+  const readinessKey = asString(input.readinessKey, 160) || DEFAULT_READINESS_KEY;
+  const observabilityIncidentReadinessId =
+    observabilityIncidentIdPart(["observability_incident_readiness", readinessKey].join(":")) ||
+    "observability_incident_readiness:unknown";
+
+  const observabilityEvents = asArray(input.observabilityEvents);
+  const statusIncidents = asArray(input.statusIncidents);
+  const recoveryReadiness = asArray(input.recoveryReadiness);
+  const escalationReadiness = asArray(input.escalationReadiness);
+  const postIncidentReviews = asArray(input.postIncidentReviews);
+  const slaEvaluations = asArray(input.slaEvaluations);
+  const adminAlerts = asArray(input.adminAlerts);
+  const releaseGovernanceProfiles = asArray(input.releaseGovernanceProfiles);
+  const publicExposureHardeningProfiles = asArray(input.publicExposureHardeningProfiles);
+  const evidencePacks = asArray(input.evidencePacks);
+  const reviews = asArray(input.operatorReviewSessions);
+  const auditEvents = asArray(input.auditEvents);
+
+  const observabilityReferences = observabilityEvents.length
+    ? observabilityEvents.slice(0, 20).map((record) => {
+        const status = observabilityEventStatus(record);
+        return observabilityIncidentReference({
+          idParts: ["observability", recordId(record, ["eventId", "observabilityEventId", "id"]) || "unknown"],
+          referenceType: "observability",
+          status,
+          label: "Observability health reference",
+          description: "Internal observability metadata is available for incident readiness review.",
+          lineageReferences: [recordId(record, ["eventId", "observabilityEventId", "id"])].filter(Boolean),
+          destination: "/admin/observability",
+          blockedReason: status === "blocked" ? "Open critical observability event requires incident readiness review." : null,
+        });
+      })
+    : [
+        observabilityIncidentReference({
+          idParts: ["observability", "missing"],
+          referenceType: "observability",
+          status: "unavailable",
+          label: "Observability health reference",
+          description: "Internal observability metadata is unavailable for incident readiness review.",
+          destination: "/admin/observability",
+        }),
+      ];
+
+  const incidentReferences = statusIncidents.length
+    ? statusIncidents.slice(0, 20).map((record) => {
+        const status = incidentStatus(record);
+        return observabilityIncidentReference({
+          idParts: ["incident", recordId(record, ["incidentId", "id"]) || "unknown"],
+          referenceType: "incident",
+          status,
+          label: "Incident visibility reference",
+          description: "Incident metadata is available for manual incident readiness review.",
+          lineageReferences: [recordId(record, ["incidentId", "id"])].filter(Boolean),
+          destination: "/status",
+          blockedReason: status === "blocked" ? "Active major or critical incident blocks readiness." : null,
+        });
+      })
+    : [
+        observabilityIncidentReference({
+          idParts: ["incident", "none-active"],
+          referenceType: "incident",
+          status: "verified",
+          label: "Incident visibility reference",
+          description: "No active incident metadata requires escalation in this readiness snapshot.",
+          destination: "/status",
+        }),
+      ];
+
+  const outageReferences = statusIncidents.filter((record) => ["major", "critical"].includes(asString(record.severity, 80).toLowerCase())).length
+    ? statusIncidents
+        .filter((record) => ["major", "critical"].includes(asString(record.severity, 80).toLowerCase()))
+        .slice(0, 12)
+        .map((record) =>
+          observabilityIncidentReference({
+            idParts: ["outage", recordId(record, ["incidentId", "id"]) || "unknown"],
+            referenceType: "outage",
+            status: incidentStatus(record),
+            label: "Outage lineage reference",
+            description: "Outage lineage metadata is available for manual review.",
+            lineageReferences: [recordId(record, ["incidentId", "id"])].filter(Boolean),
+            destination: "/status",
+            blockedReason: incidentStatus(record) === "blocked" ? "Unresolved outage lineage blocks incident readiness." : null,
+          })
+        )
+    : [
+        observabilityIncidentReference({
+          idParts: ["outage", "none-active"],
+          referenceType: "outage",
+          status: "verified",
+          label: "Outage lineage reference",
+          description: "No active major or critical outage lineage is present in this readiness snapshot.",
+          destination: "/status",
+        }),
+      ];
+
+  const recoveryReferences = recoveryReadiness.length
+    ? recoveryReadiness.map((record) => {
+        const status = statusFromReadiness(record, ["verified", "ready_for_review", "complete", "resolved"]);
+        return observabilityIncidentReference({
+          idParts: ["recovery", recordId(record, ["recoveryReadinessId", "recoveryId", "id"]) || "unknown"],
+          referenceType: "recovery",
+          status,
+          label: "Recovery readiness reference",
+          description: "Recovery readiness metadata is available for manual incident readiness review.",
+          lineageReferences: [recordId(record, ["recoveryReadinessId", "recoveryId", "id"])].filter(Boolean),
+          destination: "/admin/observability",
+          blockedReason: status === "blocked" ? "Recovery readiness is blocked." : null,
+        });
+      })
+    : [
+        observabilityIncidentReference({
+          idParts: ["recovery", "baseline"],
+          referenceType: "recovery",
+          status: "verified",
+          label: "Recovery readiness reference",
+          description: "Manual recovery review remains the baseline; no autonomous recovery execution is enabled.",
+          destination: "/admin/observability",
+        }),
+      ];
+
+  const escalationReferences = escalationReadiness.length
+    ? escalationReadiness.map((record) => {
+        const status = statusFromReadiness(record, ["verified", "ready_for_review", "complete"]);
+        return observabilityIncidentReference({
+          idParts: ["escalation", recordId(record, ["escalationReadinessId", "escalationId", "id"]) || "unknown"],
+          referenceType: "escalation",
+          status,
+          label: "Escalation readiness reference",
+          description: "Escalation readiness metadata is available for incident readiness review.",
+          lineageReferences: [recordId(record, ["escalationReadinessId", "escalationId", "id"])].filter(Boolean),
+          destination: "/admin/alerts",
+          blockedReason: status === "blocked" ? "Escalation readiness is blocked." : null,
+        });
+      })
+    : [
+        observabilityIncidentReference({
+          idParts: ["escalation", "baseline"],
+          referenceType: "escalation",
+          status: "verified",
+          label: "Escalation readiness reference",
+          description: "Manual escalation review remains the baseline; no alert sending or automated escalation is enabled.",
+          destination: "/admin/alerts",
+        }),
+      ];
+
+  const postIncidentReviewReferences = postIncidentReviews.length
+    ? postIncidentReviews.map((record) => {
+        const status = statusFromReadiness(record, ["verified", "ready_for_review", "complete", "completed"]);
+        return observabilityIncidentReference({
+          idParts: ["post_incident_review", recordId(record, ["postIncidentReviewId", "reviewId", "id"]) || "unknown"],
+          referenceType: "post_incident_review",
+          status,
+          label: "Post-incident review reference",
+          description: "Post-incident review metadata is available for manual readiness review.",
+          lineageReferences: [recordId(record, ["postIncidentReviewId", "reviewId", "id"])].filter(Boolean),
+          destination: "/review-timeline",
+          blockedReason: status === "blocked" ? "Post-incident review is blocked." : null,
+        });
+      })
+    : [
+        observabilityIncidentReference({
+          idParts: ["post_incident_review", "baseline"],
+          referenceType: "post_incident_review",
+          status: "verified",
+          label: "Post-incident review reference",
+          description: "Post-incident review remains manual and review-controlled.",
+          destination: "/review-timeline",
+        }),
+      ];
+
+  const slaReferences = slaEvaluations.length
+    ? slaEvaluations.slice(0, 20).map((record) => {
+        const stage = asString(record?.stage || record?.sla?.stage, 80).toLowerCase();
+        const status = stage === "escalated" || stage === "overdue" ? "partially_verified" : "verified";
+        return observabilityIncidentReference({
+          idParts: ["sla", recordId(record, ["slaId", "id", "resourceId"]) || "unknown"],
+          referenceType: "sla",
+          status,
+          label: "SLA readiness reference",
+          description: "SLA metadata is available for escalation readiness review.",
+          lineageReferences: [recordId(record, ["slaId", "id", "resourceId"])].filter(Boolean),
+          destination: "/admin/sla",
+        });
+      })
+    : [
+        observabilityIncidentReference({
+          idParts: ["sla", "missing"],
+          referenceType: "sla",
+          status: "unavailable",
+          label: "SLA readiness reference",
+          description: "SLA readiness metadata is unavailable for incident readiness review.",
+          destination: "/admin/sla",
+        }),
+      ];
+
+  const alertReferences = adminAlerts.length
+    ? adminAlerts.slice(0, 20).map((record) => {
+        const severity = asString(record.severity, 80).toLowerCase();
+        const status = severity === "critical" ? "blocked" : severity === "high" ? "partially_verified" : "verified";
+        return observabilityIncidentReference({
+          idParts: ["alert", recordId(record, ["alertId", "id"]) || "unknown"],
+          referenceType: "alert",
+          status,
+          label: "Alert visibility reference",
+          description: "Admin alert metadata is available for incident readiness review without sending alerts.",
+          lineageReferences: [recordId(record, ["alertId", "id"])].filter(Boolean),
+          destination: "/admin/alerts",
+          blockedReason: status === "blocked" ? "Critical admin alert requires manual incident readiness review." : null,
+        });
+      })
+    : [
+        observabilityIncidentReference({
+          idParts: ["alert", "baseline"],
+          referenceType: "alert",
+          status: "verified",
+          label: "Alert visibility reference",
+          description: "No active admin alert metadata requires incident readiness escalation in this snapshot.",
+          destination: "/admin/alerts",
+        }),
+      ];
+
+  const releaseReferences = releaseGovernanceProfiles.length
+    ? releaseGovernanceProfiles.map((record) => {
+        const status = releaseStatus(record);
+        return observabilityIncidentReference({
+          idParts: ["release", recordId(record, ["releaseGovernanceId", "releaseVersion", "id"]) || "unknown"],
+          referenceType: "release",
+          status,
+          label: "Release governance reference",
+          description: "Release governance metadata is available for incident readiness review.",
+          lineageReferences: [recordId(record, ["releaseGovernanceId", "releaseVersion", "id"])].filter(Boolean),
+          destination: "/admin/release-governance",
+          blockedReason: status === "blocked" ? "Release governance readiness is blocked." : null,
+        });
+      })
+    : [
+        observabilityIncidentReference({
+          idParts: ["release", "missing"],
+          referenceType: "release",
+          status: "unavailable",
+          label: "Release governance reference",
+          description: "Release governance metadata is unavailable for incident readiness review.",
+          destination: "/admin/release-governance",
+        }),
+      ];
+
+  const publicExposureReferences = publicExposureHardeningProfiles.length
+    ? publicExposureHardeningProfiles.map((record) => {
+        const status = publicExposureStatus(record);
+        return observabilityIncidentReference({
+          idParts: ["public_exposure", recordId(record, ["publicExposureHardeningId", "id"]) || "unknown"],
+          referenceType: "public_exposure",
+          status,
+          label: "Public exposure hardening reference",
+          description: "Public exposure hardening metadata is available for incident readiness review.",
+          lineageReferences: [recordId(record, ["publicExposureHardeningId", "id"])].filter(Boolean),
+          destination: "/admin/public-exposure-hardening",
+          blockedReason: status === "blocked" ? "Public exposure hardening readiness is blocked." : null,
+        });
+      })
+    : [
+        observabilityIncidentReference({
+          idParts: ["public_exposure", "missing"],
+          referenceType: "public_exposure",
+          status: "unavailable",
+          label: "Public exposure hardening reference",
+          description: "Public exposure hardening metadata is unavailable for incident readiness review.",
+          destination: "/admin/public-exposure-hardening",
+        }),
+      ];
+
+  const evidenceReferences = evidencePacks.length
+    ? evidencePacks.map((record) => {
+        const status = statusFromReadiness(record, ["ready_for_review"]);
+        return observabilityIncidentReference({
+          idParts: ["evidence", recordId(record, ["evidencePackId", "id"]) || "unknown"],
+          referenceType: "evidence",
+          status,
+          label: "Evidence lineage reference",
+          description: "Evidence lineage is available for incident readiness review.",
+          lineageReferences: [recordId(record, ["evidencePackId", "id"])].filter(Boolean),
+          destination: "/evidence-packs",
+          blockedReason: status === "blocked" ? "Evidence lineage is blocked." : null,
+        });
+      })
+    : [
+        observabilityIncidentReference({
+          idParts: ["evidence", "missing"],
+          referenceType: "evidence",
+          status: "unavailable",
+          label: "Evidence lineage reference",
+          description: "Evidence lineage is unavailable for incident readiness review.",
+          destination: "/evidence-packs",
+        }),
+      ];
+
+  const reviewReferences = reviews.length
+    ? reviews.map((record) => {
+        const status = record.status === "completed" ? "verified" : record.status === "blocked" ? "blocked" : "partially_verified";
+        return observabilityIncidentReference({
+          idParts: ["review", recordId(record, ["reviewSessionId", "id"]) || "unknown"],
+          referenceType: "review",
+          status,
+          label: "Review lineage reference",
+          description: "Operator review lineage is available for incident readiness review.",
+          lineageReferences: [recordId(record, ["reviewSessionId", "id"])].filter(Boolean),
+          destination: "/review-timeline",
+          blockedReason: status === "blocked" ? "Operator review lineage is blocked." : null,
+        });
+      })
+    : [
+        observabilityIncidentReference({
+          idParts: ["review", "missing"],
+          referenceType: "review",
+          status: "unavailable",
+          label: "Review lineage reference",
+          description: "Operator review lineage is unavailable for incident readiness review.",
+          destination: "/review-timeline",
+        }),
+      ];
+
+  const auditReferences = auditEvents.length
+    ? auditEvents.slice(0, 20).map((record) =>
+        observabilityIncidentReference({
+          idParts: ["audit", recordId(record, ["eventId", "id"]) || "unknown"],
+          referenceType: "audit",
+          status: record.redacted ? "partially_verified" : "verified",
+          label: "Audit lineage reference",
+          description: "Canonical audit event metadata is available for incident readiness review.",
+          lineageReferences: [recordId(record, ["eventId", "id"])].filter(Boolean),
+          destination: "/review-timeline",
+          redacted: Boolean(record.redacted),
+          redactionReason: record.redacted ? "Audit payload is redacted for incident readiness safety." : null,
+        })
+      )
+    : [
+        observabilityIncidentReference({
+          idParts: ["audit", "missing"],
+          referenceType: "audit",
+          status: "unavailable",
+          label: "Audit lineage reference",
+          description: "Canonical audit event metadata is unavailable for incident readiness review.",
+          destination: "/review-timeline",
+        }),
+      ];
+
+  const allReferences = [
+    ...observabilityReferences,
+    ...incidentReferences,
+    ...outageReferences,
+    ...recoveryReferences,
+    ...escalationReferences,
+    ...postIncidentReviewReferences,
+    ...slaReferences,
+    ...alertReferences,
+    ...releaseReferences,
+    ...publicExposureReferences,
+    ...evidenceReferences,
+    ...reviewReferences,
+    ...auditReferences,
+  ];
+
+  const observabilityIncidentRestrictions = allReferences
+    .filter((reference) => reference.status !== "verified")
+    .map((reference) =>
+      observabilityIncidentRestriction({
+        idParts: [reference.referenceType, reference.referenceId],
+        restrictionType: reference.referenceType,
+        status: reference.status === "blocked" ? "blocked" : "review_required",
+        label: `${reference.label} restriction`,
+        description: `${reference.label} is incomplete or blocked for observability and incident readiness.`,
+        blockedReason: reference.blockedReason,
+      })
+    );
+
+  const hasContext = Boolean(
+    observabilityEvents.length ||
+      statusIncidents.length ||
+      recoveryReadiness.length ||
+      escalationReadiness.length ||
+      postIncidentReviews.length ||
+      slaEvaluations.length ||
+      adminAlerts.length ||
+      releaseGovernanceProfiles.length ||
+      publicExposureHardeningProfiles.length ||
+      evidencePacks.length ||
+      reviews.length ||
+      auditEvents.length
+  );
+  const status = readinessStatus(hasContext, allReferences);
+  const blockedReasons = [
+    ...allReferences.map((reference) => reference.blockedReason),
+    ...observabilityIncidentRestrictions.map((restriction) => restriction.blockedReason),
+  ].filter(Boolean) as string[];
+
+  const canonicalEvents: ObservabilityIncidentCanonicalEvent[] = [
+    event({
+      eventType: "observability_incident_readiness_profile_derived",
+      status,
+      observabilityIncidentReadinessId,
+      summary:
+        "Observability and incident readiness profile derived from observability, incident, outage, recovery, escalation, SLA, alert, release, public exposure, evidence, review, and audit metadata.",
+    }),
+    event({
+      eventType: "observability_incident_redaction_applied",
+      status,
+      observabilityIncidentReadinessId,
+      summary:
+        "Sensitive telemetry, stack traces, request bodies, credentials, tenant/payment/screening payloads, external monitoring integration, alert sending, remediation, recovery execution, and production mutation payloads were excluded.",
+    }),
+  ];
+  if (observabilityIncidentRestrictions.length) {
+    canonicalEvents.push(
+      event({
+        eventType: "observability_incident_restriction_detected",
+        status,
+        observabilityIncidentReadinessId,
+        summary: "Observability and incident readiness restrictions are visible for manual review.",
+      })
+    );
+  }
+  if (status === "review_required" || status === "partially_ready") {
+    canonicalEvents.push(
+      event({
+        eventType: "observability_incident_review_required",
+        status,
+        observabilityIncidentReadinessId,
+        summary: "Manual observability and incident readiness review is required.",
+      })
+    );
+  }
+  if (status === "blocked") {
+    canonicalEvents.push(
+      event({
+        eventType: "observability_incident_blocked",
+        status,
+        observabilityIncidentReadinessId,
+        summary: "Observability and incident readiness is blocked by unresolved restrictions.",
+      })
+    );
+  }
+
+  return {
+    observabilityIncidentReadinessId,
+    status,
+    manualReviewRequired: true,
+    externalMonitoringIntegrationEnabled: false,
+    autonomousRemediationEnabled: false,
+    alertSendingEnabled: false,
+    productionMutationEnabled: false,
+    sensitiveTelemetryExposed: false,
+    generatedAt: generatedAt(input.generatedAt),
+    summary: {
+      totalReferences: allReferences.length,
+      verifiedReferences: allReferences.filter((reference) => reference.status === "verified").length,
+      partiallyVerifiedReferences: allReferences.filter((reference) => reference.status === "partially_verified").length,
+      blockedReferences: allReferences.filter((reference) => reference.status === "blocked").length,
+      unavailableReferences: allReferences.filter((reference) => reference.status === "unavailable").length,
+      restrictions: observabilityIncidentRestrictions.length,
+    },
+    observabilityReferences,
+    incidentReferences,
+    outageReferences,
+    recoveryReferences,
+    escalationReferences,
+    postIncidentReviewReferences,
+    slaReferences,
+    alertReferences,
+    releaseReferences,
+    publicExposureReferences,
+    evidenceReferences,
+    reviewReferences,
+    auditReferences,
+    observabilityIncidentRestrictions,
+    redactions: REDACTIONS,
+    blockedReasons,
+    canonicalEvents,
+  };
+}

--- a/rentchain-api/src/lib/observabilityIncidentReadiness/observabilityIncidentReadinessTypes.ts
+++ b/rentchain-api/src/lib/observabilityIncidentReadiness/observabilityIncidentReadinessTypes.ts
@@ -1,0 +1,120 @@
+export type ObservabilityIncidentReadinessStatus =
+  | "ready_for_review"
+  | "partially_ready"
+  | "review_required"
+  | "blocked"
+  | "unknown";
+
+export type ObservabilityIncidentReferenceType =
+  | "observability"
+  | "incident"
+  | "outage"
+  | "recovery"
+  | "escalation"
+  | "post_incident_review"
+  | "sla"
+  | "alert"
+  | "release"
+  | "public_exposure"
+  | "evidence"
+  | "review"
+  | "audit";
+
+export type ObservabilityIncidentReferenceStatus =
+  | "verified"
+  | "partially_verified"
+  | "blocked"
+  | "unavailable";
+
+export type ObservabilityIncidentCanonicalEventType =
+  | "observability_incident_readiness_profile_derived"
+  | "observability_incident_review_required"
+  | "observability_incident_blocked"
+  | "observability_incident_restriction_detected"
+  | "observability_incident_redaction_applied";
+
+export type ObservabilityIncidentReference = {
+  referenceId: string;
+  referenceType: ObservabilityIncidentReferenceType;
+  status: ObservabilityIncidentReferenceStatus;
+  label: string;
+  description: string;
+  reviewRequired: true;
+  lineageReferences: string[];
+  destination: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type ObservabilityIncidentRestriction = {
+  restrictionId: string;
+  restrictionType: ObservabilityIncidentReferenceType | "external_monitoring" | "autonomous_remediation";
+  status: "visible" | "blocked" | "review_required";
+  label: string;
+  description: string;
+  blockedReason: string | null;
+};
+
+export type ObservabilityIncidentCanonicalEvent = {
+  eventType: ObservabilityIncidentCanonicalEventType;
+  action: string;
+  status: ObservabilityIncidentReadinessStatus;
+  resourceType: "observability_incident_readiness_profile";
+  resourceId: string;
+  summary: string;
+};
+
+export type ObservabilityIncidentReadinessProfile = {
+  observabilityIncidentReadinessId: string;
+  status: ObservabilityIncidentReadinessStatus;
+  manualReviewRequired: true;
+  externalMonitoringIntegrationEnabled: false;
+  autonomousRemediationEnabled: false;
+  alertSendingEnabled: false;
+  productionMutationEnabled: false;
+  sensitiveTelemetryExposed: false;
+  generatedAt: string;
+  summary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    partiallyVerifiedReferences: number;
+    blockedReferences: number;
+    unavailableReferences: number;
+    restrictions: number;
+  };
+  observabilityReferences: ObservabilityIncidentReference[];
+  incidentReferences: ObservabilityIncidentReference[];
+  outageReferences: ObservabilityIncidentReference[];
+  recoveryReferences: ObservabilityIncidentReference[];
+  escalationReferences: ObservabilityIncidentReference[];
+  postIncidentReviewReferences: ObservabilityIncidentReference[];
+  slaReferences: ObservabilityIncidentReference[];
+  alertReferences: ObservabilityIncidentReference[];
+  releaseReferences: ObservabilityIncidentReference[];
+  publicExposureReferences: ObservabilityIncidentReference[];
+  evidenceReferences: ObservabilityIncidentReference[];
+  reviewReferences: ObservabilityIncidentReference[];
+  auditReferences: ObservabilityIncidentReference[];
+  observabilityIncidentRestrictions: ObservabilityIncidentRestriction[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: ObservabilityIncidentCanonicalEvent[];
+};
+
+export type DeriveObservabilityIncidentReadinessProfileInput = {
+  readinessKey?: unknown;
+  generatedAt?: unknown;
+  observabilityEvents?: Array<Record<string, any>> | null;
+  statusIncidents?: Array<Record<string, any>> | null;
+  recoveryReadiness?: Array<Record<string, any>> | null;
+  escalationReadiness?: Array<Record<string, any>> | null;
+  postIncidentReviews?: Array<Record<string, any>> | null;
+  slaEvaluations?: Array<Record<string, any>> | null;
+  adminAlerts?: Array<Record<string, any>> | null;
+  releaseGovernanceProfiles?: Array<Record<string, any>> | null;
+  publicExposureHardeningProfiles?: Array<Record<string, any>> | null;
+  evidencePacks?: Array<Record<string, any>> | null;
+  operatorReviewSessions?: Array<Record<string, any>> | null;
+  auditEvents?: Array<Record<string, any>> | null;
+};

--- a/rentchain-api/src/lib/observabilityIncidentReadiness/observabilityIncidentReadinessTypes.ts
+++ b/rentchain-api/src/lib/observabilityIncidentReadiness/observabilityIncidentReadinessTypes.ts
@@ -71,6 +71,7 @@ export type ObservabilityIncidentReadinessProfile = {
   manualReviewRequired: true;
   externalMonitoringIntegrationEnabled: false;
   autonomousRemediationEnabled: false;
+  alertExecutionEnabled: false;
   alertSendingEnabled: false;
   productionMutationEnabled: false;
   sensitiveTelemetryExposed: false;

--- a/rentchain-api/src/lib/observabilityIncidentReadiness/observabilityIncidentRestrictionModels.ts
+++ b/rentchain-api/src/lib/observabilityIncidentReadiness/observabilityIncidentRestrictionModels.ts
@@ -1,0 +1,63 @@
+import type {
+  ObservabilityIncidentReference,
+  ObservabilityIncidentReferenceStatus,
+  ObservabilityIncidentReferenceType,
+  ObservabilityIncidentRestriction,
+} from "./observabilityIncidentReadinessTypes";
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+export function observabilityIncidentIdPart(value: unknown): string {
+  return asString(value, 500)
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+export function observabilityIncidentReference(input: {
+  idParts: unknown[];
+  referenceType: ObservabilityIncidentReferenceType;
+  status: ObservabilityIncidentReferenceStatus;
+  label: string;
+  description: string;
+  lineageReferences?: string[];
+  destination?: string | null;
+  redacted?: boolean;
+  redactionReason?: string | null;
+  blockedReason?: string | null;
+}): ObservabilityIncidentReference {
+  return {
+    referenceId: observabilityIncidentIdPart(input.idParts.join(":")) || "observability_incident_reference:unknown",
+    referenceType: input.referenceType,
+    status: input.status,
+    label: input.label,
+    description: input.description,
+    reviewRequired: true,
+    lineageReferences: Array.from(new Set(input.lineageReferences || [])).filter(Boolean),
+    destination: input.destination || null,
+    redacted: Boolean(input.redacted),
+    redactionReason: input.redactionReason || null,
+    blockedReason: input.blockedReason || null,
+  };
+}
+
+export function observabilityIncidentRestriction(input: {
+  idParts: unknown[];
+  restrictionType: ObservabilityIncidentRestriction["restrictionType"];
+  status: ObservabilityIncidentRestriction["status"];
+  label: string;
+  description: string;
+  blockedReason?: string | null;
+}): ObservabilityIncidentRestriction {
+  return {
+    restrictionId: observabilityIncidentIdPart(input.idParts.join(":")) || "observability_incident_restriction:unknown",
+    restrictionType: input.restrictionType,
+    status: input.status,
+    label: input.label,
+    description: input.description,
+    blockedReason: input.blockedReason || null,
+  };
+}

--- a/rentchain-api/src/routes/__tests__/adminObservabilityIncidentReadinessRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/adminObservabilityIncidentReadinessRoutes.test.ts
@@ -115,6 +115,7 @@ describe("adminObservabilityIncidentReadinessRoutes", () => {
         manualReviewRequired: true,
         externalMonitoringIntegrationEnabled: false,
         autonomousRemediationEnabled: false,
+        alertExecutionEnabled: false,
         alertSendingEnabled: false,
         productionMutationEnabled: false,
         sensitiveTelemetryExposed: false,

--- a/rentchain-api/src/routes/__tests__/adminObservabilityIncidentReadinessRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/adminObservabilityIncidentReadinessRoutes.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+  return {
+    resetFakeDb: () => store.clear(),
+    seedDoc: (collection: string, id: string, data: any) => ensureCollection(collection).set(id, { id, data }),
+    fakeDb: {
+      collection: (name: string) => ({
+        get: async () => {
+          const docs = Array.from(ensureCollection(name).values()).map((doc) => ({ id: doc.id, exists: true, data: () => doc.data }));
+          return { docs, empty: docs.length === 0, size: docs.length };
+        },
+      }),
+    },
+  };
+});
+
+let mockUser: any;
+
+vi.mock("../../config/firebase", () => ({ db: fakeDb }));
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!mockUser) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    req.user = mockUser;
+    return next();
+  },
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; user?: Record<string, unknown> | null }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    mockUser = options.user ?? mockUser;
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: mockUser,
+      query: Object.fromEntries(new URLSearchParams(queryString || "").entries()),
+      params: {},
+      headers: {},
+    };
+    const match = path.match(/^\/observability-incident-readiness\/(.+)$/);
+    if (match) req.params = { observabilityIncidentReadinessId: decodeURIComponent(match[1]) };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => (error ? reject(error) : undefined));
+  });
+}
+
+describe("adminObservabilityIncidentReadinessRoutes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    resetFakeDb();
+    mockUser = { id: "admin-1", role: "admin", permissions: ["system.admin"] };
+  });
+
+  function seedReadinessContext() {
+    seedDoc("systemObservabilityEvents", "obs-1", {
+      eventType: "workflow_completed",
+      status: "resolved",
+      severity: "info",
+      requestBody: "sensitive-payload",
+      stackTrace: "stack-value",
+    });
+    seedDoc("statusIncidents", "incident-1", { status: "resolved", severity: "minor", privateTelemetry: "hidden" });
+    seedDoc("incidentRecoveryReadiness", "recovery-1", { recoveryReadinessId: "recovery-1", status: "ready_for_review", credentials: "secret-value" });
+    seedDoc("incidentEscalationReadiness", "escalation-1", { escalationReadinessId: "escalation-1", status: "ready_for_review" });
+    seedDoc("postIncidentReviews", "review-1", { postIncidentReviewId: "post-incident-1", status: "ready_for_review" });
+    seedDoc("slaEvaluations", "sla-1", { slaId: "sla-1", stage: "fresh" });
+    seedDoc("adminAlerts", "alert-1", { alertId: "alert-1", severity: "low", webhookUrl: "https://example.test/hook" });
+    seedDoc("releaseGovernanceProfiles", "release-1", { releaseGovernanceId: "release-1", status: "ready_for_review" });
+    seedDoc("publicExposureHardeningProfiles", "public-exposure-1", { publicExposureHardeningId: "public-exposure-1", status: "ready_for_review" });
+    seedDoc("evidencePacks", "evidence-1", { evidencePackId: "evidence-1", status: "ready_for_review", rawGovernmentId: "sensitive-id" });
+    seedDoc("operatorReviewSessions", "operator-review-1", { reviewSessionId: "operator-review-1", status: "completed", privateNote: "hidden" });
+    seedDoc("events", "event-1", { eventId: "event-1", eventType: "observability_incident_readiness_profile_derived" });
+  }
+
+  it("returns admin-gated readiness profiles without sensitive telemetry payloads", async () => {
+    seedReadinessContext();
+    const router = (await import("../adminObservabilityIncidentReadinessRoutes")).default;
+
+    const forbidden = await invokeRouter(router, {
+      method: "GET",
+      url: "/observability-incident-readiness",
+      user: { id: "landlord-1", role: "landlord", permissions: [] },
+    });
+    expect(forbidden.status).toBe(403);
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/observability-incident-readiness",
+      user: { id: "admin-1", role: "admin", permissions: ["system.admin"] },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.profiles).toHaveLength(1);
+    expect(res.body.profiles[0]).toEqual(
+      expect.objectContaining({
+        manualReviewRequired: true,
+        externalMonitoringIntegrationEnabled: false,
+        autonomousRemediationEnabled: false,
+        alertSendingEnabled: false,
+        productionMutationEnabled: false,
+        sensitiveTelemetryExposed: false,
+      })
+    );
+    expect(JSON.stringify(res.body)).not.toContain("sensitive-payload");
+    expect(JSON.stringify(res.body)).not.toContain("stack-value");
+    expect(JSON.stringify(res.body)).not.toContain("secret-value");
+    expect(JSON.stringify(res.body)).not.toContain("webhook");
+    expect(JSON.stringify(res.body)).not.toContain("sensitive-id");
+    expect(JSON.stringify(res.body)).not.toContain("privateNote");
+  });
+
+  it("returns a single readiness profile by id", async () => {
+    seedReadinessContext();
+    const router = (await import("../adminObservabilityIncidentReadinessRoutes")).default;
+    const list = await invokeRouter(router, { method: "GET", url: "/observability-incident-readiness" });
+    const id = list.body.profiles[0].observabilityIncidentReadinessId;
+
+    const res = await invokeRouter(router, { method: "GET", url: `/observability-incident-readiness/${encodeURIComponent(id)}` });
+
+    expect(res.status).toBe(200);
+    expect(res.body.profile.observabilityIncidentReadinessId).toBe(id);
+  });
+
+  it("filters by status", async () => {
+    seedReadinessContext();
+    const router = (await import("../adminObservabilityIncidentReadinessRoutes")).default;
+
+    const filtered = await invokeRouter(router, { method: "GET", url: "/observability-incident-readiness?status=unknown" });
+
+    expect(filtered.status).toBe(200);
+    expect(filtered.body.profiles).toEqual([]);
+  });
+});

--- a/rentchain-api/src/routes/adminObservabilityIncidentReadinessRoutes.ts
+++ b/rentchain-api/src/routes/adminObservabilityIncidentReadinessRoutes.ts
@@ -1,0 +1,173 @@
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { requireAuth } from "../middleware/requireAuth";
+import { requirePermission } from "../middleware/requireAuthz";
+import { deriveObservabilityIncidentReadinessProfile } from "../lib/observabilityIncidentReadiness/deriveObservabilityIncidentReadinessProfile";
+import type {
+  ObservabilityIncidentReadinessProfile,
+  ObservabilityIncidentReadinessStatus,
+} from "../lib/observabilityIncidentReadiness/observabilityIncidentReadinessTypes";
+import { SYSTEM_OBSERVABILITY_EVENTS_COLLECTION } from "../services/observability/observabilityTypes";
+
+const router = Router();
+
+const READINESS_KEY = "operational-observability-incident-readiness-v1";
+const STATUSES = new Set<ObservabilityIncidentReadinessStatus>([
+  "ready_for_review",
+  "partially_ready",
+  "review_required",
+  "blocked",
+  "unknown",
+]);
+
+const RECOVERY_READINESS = [
+  { recoveryReadinessId: "manual-recovery-readiness-baseline", status: "ready_for_review" },
+];
+
+const ESCALATION_READINESS = [
+  { escalationReadinessId: "manual-escalation-readiness-baseline", status: "ready_for_review" },
+];
+
+const POST_INCIDENT_REVIEWS = [
+  { postIncidentReviewId: "manual-post-incident-review-baseline", status: "ready_for_review" },
+];
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+async function loadCollection(collectionName: string, limit = 25) {
+  const snap = await db.collection(collectionName).get().catch(() => null);
+  return (snap?.docs || []).slice(0, limit).map((doc) => sanitizeRecord({ id: doc.id, ...((doc.data() as any) || {}) }));
+}
+
+function sanitizeRecord(record: Record<string, any>) {
+  const safe: Record<string, any> = {};
+  for (const key of [
+    "id",
+    "status",
+    "state",
+    "conclusion",
+    "eventId",
+    "eventType",
+    "observabilityEventId",
+    "workflow",
+    "severity",
+    "title",
+    "occurredAt",
+    "resolvedAt",
+    "incidentId",
+    "createdAt",
+    "updatedAt",
+    "resolvedAtMs",
+    "recoveryReadinessId",
+    "recoveryId",
+    "escalationReadinessId",
+    "escalationId",
+    "postIncidentReviewId",
+    "reviewId",
+    "slaId",
+    "stage",
+    "resourceId",
+    "alertId",
+    "releaseGovernanceId",
+    "releaseVersion",
+    "publicExposureHardeningId",
+    "evidencePackId",
+    "reviewSessionId",
+    "resourceType",
+    "resourceId",
+    "redacted",
+  ]) {
+    if (record[key] !== undefined) safe[key] = record[key];
+  }
+  if (record.sla && typeof record.sla === "object") {
+    safe.sla = { stage: asString(record.sla.stage, 80) || null };
+  }
+  return safe;
+}
+
+async function buildObservabilityIncidentReadinessProfiles(): Promise<ObservabilityIncidentReadinessProfile[]> {
+  const [
+    observabilityEvents,
+    statusIncidents,
+    recoveryReadiness,
+    escalationReadiness,
+    postIncidentReviews,
+    slaEvaluations,
+    adminAlerts,
+    releaseGovernanceProfiles,
+    publicExposureHardeningProfiles,
+    evidencePacks,
+    reviews,
+    auditEvents,
+  ] = await Promise.all([
+    loadCollection(SYSTEM_OBSERVABILITY_EVENTS_COLLECTION),
+    loadCollection("statusIncidents"),
+    loadCollection("incidentRecoveryReadiness"),
+    loadCollection("incidentEscalationReadiness"),
+    loadCollection("postIncidentReviews"),
+    loadCollection("slaEvaluations"),
+    loadCollection("adminAlerts"),
+    loadCollection("releaseGovernanceProfiles"),
+    loadCollection("publicExposureHardeningProfiles"),
+    loadCollection("evidencePacks"),
+    loadCollection("operatorReviewSessions"),
+    loadCollection("events"),
+  ]);
+
+  return [
+    deriveObservabilityIncidentReadinessProfile({
+      readinessKey: READINESS_KEY,
+      observabilityEvents,
+      statusIncidents,
+      recoveryReadiness: recoveryReadiness.length ? recoveryReadiness : RECOVERY_READINESS,
+      escalationReadiness: escalationReadiness.length ? escalationReadiness : ESCALATION_READINESS,
+      postIncidentReviews: postIncidentReviews.length ? postIncidentReviews : POST_INCIDENT_REVIEWS,
+      slaEvaluations,
+      adminAlerts,
+      releaseGovernanceProfiles,
+      publicExposureHardeningProfiles,
+      evidencePacks,
+      operatorReviewSessions: reviews,
+      auditEvents,
+    }),
+  ];
+}
+
+function profileMatches(profile: ObservabilityIncidentReadinessProfile, id: string) {
+  return profile.observabilityIncidentReadinessId === id;
+}
+
+router.get("/observability-incident-readiness", requireAuth, requirePermission("system.admin"), async (req: any, res) => {
+  try {
+    const status = asString(req.query?.status, 80) as ObservabilityIncidentReadinessStatus;
+    let profiles = await buildObservabilityIncidentReadinessProfiles();
+    if (status && STATUSES.has(status)) profiles = profiles.filter((profile) => profile.status === status);
+    return res.json({ ok: true, profiles });
+  } catch (err: any) {
+    console.error("[admin-observability-incident-readiness] list failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "OBSERVABILITY_INCIDENT_READINESS_FAILED" });
+  }
+});
+
+router.get(
+  "/observability-incident-readiness/:observabilityIncidentReadinessId",
+  requireAuth,
+  requirePermission("system.admin"),
+  async (req: any, res) => {
+    try {
+      const observabilityIncidentReadinessId = decodeURIComponent(asString(req.params?.observabilityIncidentReadinessId, 500));
+      if (!observabilityIncidentReadinessId) return res.status(400).json({ ok: false, error: "OBSERVABILITY_INCIDENT_READINESS_ID_REQUIRED" });
+      const profiles = await buildObservabilityIncidentReadinessProfiles();
+      const profile = profiles.find((next) => profileMatches(next, observabilityIncidentReadinessId));
+      if (!profile) return res.status(404).json({ ok: false, error: "OBSERVABILITY_INCIDENT_READINESS_NOT_FOUND" });
+      return res.json({ ok: true, profile });
+    } catch (err: any) {
+      console.error("[admin-observability-incident-readiness] get failed", err?.message || err);
+      return res.status(500).json({ ok: false, error: "OBSERVABILITY_INCIDENT_READINESS_GET_FAILED" });
+    }
+  }
+);
+
+export default router;

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -111,6 +111,7 @@ const AdminLeaseLifecycleReviewPage = lazy(() => import("./pages/admin/AdminLeas
 const AdminAlertingPage = lazy(() => import("./pages/admin/AdminAlertingPage"));
 const AdminObservabilityPage = lazy(() => import("./pages/admin/AdminObservabilityPage"));
 const AdminNotificationsPage = lazy(() => import("./pages/admin/AdminNotificationsPage"));
+const ObservabilityIncidentReadinessPage = lazy(() => import("./pages/ObservabilityIncidentReadinessPage"));
 const ReleaseGovernancePage = lazy(() => import("./pages/ReleaseGovernancePage"));
 const PublicExposureHardeningPage = lazy(() => import("./pages/PublicExposureHardeningPage"));
 const PortfolioScorePage = lazy(() => import("./pages/admin/PortfolioScorePage"));
@@ -1271,6 +1272,14 @@ function App() {
               element={
                 <RequireAdmin>
                   <AdminObservabilityPage />
+                </RequireAdmin>
+              }
+            />
+            <Route
+              path="/admin/observability-incident-readiness"
+              element={
+                <RequireAdmin>
+                  <ObservabilityIncidentReadinessPage />
                 </RequireAdmin>
               }
             />

--- a/rentchain-frontend/src/api/observabilityIncidentReadinessApi.ts
+++ b/rentchain-frontend/src/api/observabilityIncidentReadinessApi.ts
@@ -53,6 +53,7 @@ export type ObservabilityIncidentReadinessProfile = {
   manualReviewRequired: true;
   externalMonitoringIntegrationEnabled: false;
   autonomousRemediationEnabled: false;
+  alertExecutionEnabled: false;
   alertSendingEnabled: false;
   productionMutationEnabled: false;
   sensitiveTelemetryExposed: false;

--- a/rentchain-frontend/src/api/observabilityIncidentReadinessApi.ts
+++ b/rentchain-frontend/src/api/observabilityIncidentReadinessApi.ts
@@ -1,0 +1,106 @@
+import { apiFetch } from "./apiFetch";
+
+export type ObservabilityIncidentReadinessStatus =
+  | "ready_for_review"
+  | "partially_ready"
+  | "review_required"
+  | "blocked"
+  | "unknown";
+
+export type ObservabilityIncidentReferenceType =
+  | "observability"
+  | "incident"
+  | "outage"
+  | "recovery"
+  | "escalation"
+  | "post_incident_review"
+  | "sla"
+  | "alert"
+  | "release"
+  | "public_exposure"
+  | "evidence"
+  | "review"
+  | "audit";
+
+export type ObservabilityIncidentReferenceStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+
+export type ObservabilityIncidentReference = {
+  referenceId: string;
+  referenceType: ObservabilityIncidentReferenceType;
+  status: ObservabilityIncidentReferenceStatus;
+  label: string;
+  description: string;
+  reviewRequired: true;
+  lineageReferences: string[];
+  destination: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type ObservabilityIncidentRestriction = {
+  restrictionId: string;
+  restrictionType: ObservabilityIncidentReferenceType | "external_monitoring" | "autonomous_remediation";
+  status: "visible" | "blocked" | "review_required";
+  label: string;
+  description: string;
+  blockedReason: string | null;
+};
+
+export type ObservabilityIncidentReadinessProfile = {
+  observabilityIncidentReadinessId: string;
+  status: ObservabilityIncidentReadinessStatus;
+  manualReviewRequired: true;
+  externalMonitoringIntegrationEnabled: false;
+  autonomousRemediationEnabled: false;
+  alertSendingEnabled: false;
+  productionMutationEnabled: false;
+  sensitiveTelemetryExposed: false;
+  generatedAt: string;
+  summary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    partiallyVerifiedReferences: number;
+    blockedReferences: number;
+    unavailableReferences: number;
+    restrictions: number;
+  };
+  observabilityReferences: ObservabilityIncidentReference[];
+  incidentReferences: ObservabilityIncidentReference[];
+  outageReferences: ObservabilityIncidentReference[];
+  recoveryReferences: ObservabilityIncidentReference[];
+  escalationReferences: ObservabilityIncidentReference[];
+  postIncidentReviewReferences: ObservabilityIncidentReference[];
+  slaReferences: ObservabilityIncidentReference[];
+  alertReferences: ObservabilityIncidentReference[];
+  releaseReferences: ObservabilityIncidentReference[];
+  publicExposureReferences: ObservabilityIncidentReference[];
+  evidenceReferences: ObservabilityIncidentReference[];
+  reviewReferences: ObservabilityIncidentReference[];
+  auditReferences: ObservabilityIncidentReference[];
+  observabilityIncidentRestrictions: ObservabilityIncidentRestriction[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: Array<{ eventType: string; action: string; status: ObservabilityIncidentReadinessStatus; resourceId: string; summary: string }>;
+};
+
+export async function fetchObservabilityIncidentReadinessProfiles(params?: {
+  status?: ObservabilityIncidentReadinessStatus | "";
+}): Promise<ObservabilityIncidentReadinessProfile[]> {
+  const search = new URLSearchParams();
+  if (params?.status) search.set("status", params.status);
+  const suffix = search.toString() ? `?${search.toString()}` : "";
+  const response = await apiFetch<{ ok: true; profiles: ObservabilityIncidentReadinessProfile[] }>(
+    `/admin/observability-incident-readiness${suffix}`
+  );
+  return response.profiles;
+}
+
+export async function fetchObservabilityIncidentReadinessProfile(
+  observabilityIncidentReadinessId: string
+): Promise<ObservabilityIncidentReadinessProfile> {
+  const response = await apiFetch<{ ok: true; profile: ObservabilityIncidentReadinessProfile }>(
+    `/admin/observability-incident-readiness/${encodeURIComponent(observabilityIncidentReadinessId)}`
+  );
+  return response.profile;
+}

--- a/rentchain-frontend/src/components/observabilityIncident/ObservabilityIncidentReadinessPanel.test.tsx
+++ b/rentchain-frontend/src/components/observabilityIncident/ObservabilityIncidentReadinessPanel.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import type { ObservabilityIncidentReadinessProfile } from "@/api/observabilityIncidentReadinessApi";
+import { ObservabilityIncidentReadinessPanel } from "./ObservabilityIncidentReadinessPanel";
+
+const profile: ObservabilityIncidentReadinessProfile = {
+  observabilityIncidentReadinessId: "observability_incident_readiness:operational-observability-incident-readiness-v1",
+  status: "blocked",
+  manualReviewRequired: true,
+  externalMonitoringIntegrationEnabled: false,
+  autonomousRemediationEnabled: false,
+  alertSendingEnabled: false,
+  productionMutationEnabled: false,
+  sensitiveTelemetryExposed: false,
+  generatedAt: "2026-01-01T00:00:00.000Z",
+  summary: {
+    totalReferences: 2,
+    verifiedReferences: 1,
+    partiallyVerifiedReferences: 0,
+    blockedReferences: 1,
+    unavailableReferences: 0,
+    restrictions: 1,
+  },
+  observabilityReferences: [
+    {
+      referenceId: "obs-1",
+      referenceType: "observability",
+      status: "blocked",
+      label: "Observability health reference",
+      description: "Internal observability metadata is available.",
+      reviewRequired: true,
+      lineageReferences: ["obs-1"],
+      destination: "/admin/observability",
+      redacted: false,
+      redactionReason: null,
+      blockedReason: "Open critical observability event requires incident readiness review.",
+    },
+  ],
+  incidentReferences: [],
+  outageReferences: [],
+  recoveryReferences: [],
+  escalationReferences: [],
+  postIncidentReviewReferences: [],
+  slaReferences: [],
+  alertReferences: [],
+  releaseReferences: [],
+  publicExposureReferences: [],
+  evidenceReferences: [],
+  reviewReferences: [],
+  auditReferences: [],
+  observabilityIncidentRestrictions: [
+    {
+      restrictionId: "restriction-1",
+      restrictionType: "observability",
+      status: "blocked",
+      label: "Observability health reference restriction",
+      description: "Observability health reference is incomplete or blocked.",
+      blockedReason: "Open critical observability event requires incident readiness review.",
+    },
+  ],
+  redactions: ["Sensitive telemetry payloads, stack traces, request bodies, tenant/payment/screening data, and credentials are excluded."],
+  blockedReasons: ["Open critical observability event requires incident readiness review."],
+  canonicalEvents: [],
+};
+
+describe("ObservabilityIncidentReadinessPanel", () => {
+  const forbiddenLabels = [
+    ["Connect", "monitoring"],
+    ["Send", "alert"],
+    ["Auto", "remediate"],
+    ["Execute", "recovery"],
+    ["Mutate", "production"],
+    ["Expose", "telemetry"],
+  ].map((parts) => (parts[0] === "Auto" ? parts.join("-") : parts.join(" ")));
+
+  it("renders safety copy, readiness status, restrictions, and blocked reasons", () => {
+    render(
+      <MemoryRouter>
+        <ObservabilityIncidentReadinessPanel profile={profile} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("View incident readiness")).toBeInTheDocument();
+    expect(screen.getByText(/Observability and incident readiness is operationally scoped and review controlled/i)).toBeInTheDocument();
+    expect(screen.getByText(/No external monitoring integration, alert sending, autonomous remediation, recovery execution, or production mutation is enabled/i)).toBeInTheDocument();
+    expect(screen.getByText("Manual review required")).toBeInTheDocument();
+    expect(screen.getAllByText("Blocked").length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Open critical observability event requires incident readiness review/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("View readiness restrictions")).toBeInTheDocument();
+    expect(screen.getByText("View observability health")).toBeInTheDocument();
+    expect(screen.getByText("Sensitive telemetry payloads, stack traces, request bodies, tenant/payment/screening data, and credentials are excluded.")).toBeInTheDocument();
+  });
+
+  it("omits forbidden execution labels", () => {
+    render(
+      <MemoryRouter>
+        <ObservabilityIncidentReadinessPanel profile={profile} />
+      </MemoryRouter>
+    );
+
+    for (const forbiddenLabel of forbiddenLabels) {
+      expect(screen.queryByText(forbiddenLabel)).not.toBeInTheDocument();
+    }
+  });
+});

--- a/rentchain-frontend/src/components/observabilityIncident/ObservabilityIncidentReadinessPanel.test.tsx
+++ b/rentchain-frontend/src/components/observabilityIncident/ObservabilityIncidentReadinessPanel.test.tsx
@@ -11,6 +11,7 @@ const profile: ObservabilityIncidentReadinessProfile = {
   manualReviewRequired: true,
   externalMonitoringIntegrationEnabled: false,
   autonomousRemediationEnabled: false,
+  alertExecutionEnabled: false,
   alertSendingEnabled: false,
   productionMutationEnabled: false,
   sensitiveTelemetryExposed: false,

--- a/rentchain-frontend/src/components/observabilityIncident/ObservabilityIncidentReadinessPanel.tsx
+++ b/rentchain-frontend/src/components/observabilityIncident/ObservabilityIncidentReadinessPanel.tsx
@@ -1,0 +1,152 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import type {
+  ObservabilityIncidentReadinessProfile,
+  ObservabilityIncidentReference,
+  ObservabilityIncidentRestriction,
+} from "@/api/observabilityIncidentReadinessApi";
+import { Card, Section } from "@/components/ui/Ui";
+
+function label(value: string) {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function tone(status: string) {
+  if (status === "blocked") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
+  if (status === "review_required" || status === "partially_ready" || status === "partially_verified" || status === "unavailable") {
+    return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
+  }
+  if (status === "ready_for_review" || status === "verified") return { color: "#166534", background: "#dcfce7", border: "#bbf7d0" };
+  return { color: "#475569", background: "#f8fafc", border: "#e2e8f0" };
+}
+
+function Badge({ children, status }: { children: React.ReactNode; status: string }) {
+  const next = tone(status);
+  return (
+    <span style={{ border: `1px solid ${next.border}`, borderRadius: 999, background: next.background, color: next.color, padding: "3px 9px", fontSize: 12, fontWeight: 900, whiteSpace: "nowrap" }}>
+      {children}
+    </span>
+  );
+}
+
+function ReferenceList({ title, references }: { title: string; references: ObservabilityIncidentReference[] }) {
+  return (
+    <Section style={{ display: "grid", gap: 10 }}>
+      <div style={{ fontWeight: 900 }}>{title}</div>
+      {references.length ? (
+        references.slice(0, 12).map((reference) => (
+          <Card key={reference.referenceId} style={{ borderRadius: 8, padding: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+              <div>
+                <strong>{reference.label}</strong>
+                <div style={{ color: "#64748b", fontSize: 13 }}>{label(reference.referenceType)}</div>
+              </div>
+              <Badge status={reference.status}>{label(reference.status)}</Badge>
+            </div>
+            <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>{reference.description}</div>
+            {reference.lineageReferences.length ? <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>Lineage references: {reference.lineageReferences.length}</div> : null}
+            {reference.blockedReason ? <div style={{ color: "#991b1b", fontSize: 13, marginTop: 8 }}>View blocked reason: {reference.blockedReason}</div> : null}
+            {reference.redacted ? <div style={{ color: "#92400e", fontSize: 13, marginTop: 8 }}>{reference.redactionReason || "Redacted observability incident reference"}</div> : null}
+            {reference.destination?.startsWith("/") ? <Link to={reference.destination} style={{ color: "#2563eb", fontWeight: 800, fontSize: 13, marginTop: 8, display: "inline-block" }}>View context</Link> : null}
+          </Card>
+        ))
+      ) : (
+        <Card style={{ color: "#64748b" }}>Context unavailable</Card>
+      )}
+    </Section>
+  );
+}
+
+function RestrictionList({ restrictions }: { restrictions: ObservabilityIncidentRestriction[] }) {
+  return (
+    <Section style={{ display: "grid", gap: 10 }}>
+      <div style={{ fontWeight: 900 }}>View readiness restrictions</div>
+      {restrictions.length ? (
+        restrictions.map((restriction) => (
+          <Card key={restriction.restrictionId} style={{ borderRadius: 8, padding: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+              <div>
+                <strong>{restriction.label}</strong>
+                <div style={{ color: "#64748b", fontSize: 13 }}>{label(restriction.restrictionType)}</div>
+              </div>
+              <Badge status={restriction.status}>{label(restriction.status)}</Badge>
+            </div>
+            <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>{restriction.description}</div>
+            {restriction.blockedReason ? <div style={{ color: "#991b1b", fontSize: 13, marginTop: 8 }}>View blocked reason: {restriction.blockedReason}</div> : null}
+          </Card>
+        ))
+      ) : (
+        <Card style={{ color: "#64748b" }}>No observability incident readiness restrictions detected.</Card>
+      )}
+    </Section>
+  );
+}
+
+export function ObservabilityIncidentReadinessPanel({ profile }: { profile: ObservabilityIncidentReadinessProfile }) {
+  return (
+    <div style={{ display: "grid", gap: 16 }}>
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+          <div>
+            <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>View incident readiness</div>
+            <h2 style={{ margin: "2px 0 0", fontSize: "1.15rem" }}>Observability and incident readiness</h2>
+          </div>
+          <Badge status={profile.status}>{label(profile.status)}</Badge>
+        </div>
+        <div style={{ color: "#475569", lineHeight: 1.55 }}>
+          Observability and incident readiness is operationally scoped and review controlled. No external monitoring integration, alert sending, autonomous remediation, recovery execution, or production mutation is enabled.
+          Manual review remains required.
+        </div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <Badge status="review_required">Manual review required</Badge>
+          <Badge status={profile.externalMonitoringIntegrationEnabled ? "blocked" : "verified"}>External monitoring disabled</Badge>
+          <Badge status={profile.autonomousRemediationEnabled ? "blocked" : "verified"}>Autonomous remediation disabled</Badge>
+          <Badge status={profile.alertSendingEnabled ? "blocked" : "verified"}>Alert sending disabled</Badge>
+          <Badge status={profile.productionMutationEnabled ? "blocked" : "verified"}>Production mutation disabled</Badge>
+          <Badge status={profile.sensitiveTelemetryExposed ? "blocked" : "verified"}>Sensitive telemetry excluded</Badge>
+        </div>
+      </Section>
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Readiness summary</div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: 10 }}>
+          {[
+            ["References", profile.summary.totalReferences],
+            ["Verified", profile.summary.verifiedReferences],
+            ["Partial", profile.summary.partiallyVerifiedReferences],
+            ["Blocked", profile.summary.blockedReferences],
+            ["Unavailable", profile.summary.unavailableReferences],
+            ["Restrictions", profile.summary.restrictions],
+          ].map(([name, value]) => (
+            <Card key={String(name)} style={{ borderRadius: 8, padding: 12 }}>
+              <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>{name}</div>
+              <strong style={{ color: "#0f172a", fontSize: 22 }}>{String(value)}</strong>
+            </Card>
+          ))}
+        </div>
+      </Section>
+
+      <RestrictionList restrictions={profile.observabilityIncidentRestrictions} />
+      <ReferenceList title="View observability health" references={profile.observabilityReferences} />
+      <ReferenceList title="View incident visibility" references={profile.incidentReferences} />
+      <ReferenceList title="View outage lineage" references={profile.outageReferences} />
+      <ReferenceList title="View recovery readiness" references={profile.recoveryReferences} />
+      <ReferenceList title="View escalation readiness" references={profile.escalationReferences} />
+      <ReferenceList title="View post-incident review" references={profile.postIncidentReviewReferences} />
+      <ReferenceList title="View SLA readiness" references={profile.slaReferences} />
+      <ReferenceList title="View alert visibility" references={profile.alertReferences} />
+      <ReferenceList title="View release readiness" references={profile.releaseReferences} />
+      <ReferenceList title="View public exposure readiness" references={profile.publicExposureReferences} />
+      <ReferenceList title="View evidence lineage" references={profile.evidenceReferences} />
+      <ReferenceList title="View review lineage" references={profile.reviewReferences} />
+      <ReferenceList title="Audit references" references={profile.auditReferences} />
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Redactions</div>
+        {profile.redactions.map((redaction) => (
+          <Card key={redaction} style={{ borderRadius: 8, padding: 12, color: "#475569" }}>{redaction}</Card>
+        ))}
+      </Section>
+    </div>
+  );
+}

--- a/rentchain-frontend/src/components/observabilityIncident/ObservabilityIncidentReadinessPanel.tsx
+++ b/rentchain-frontend/src/components/observabilityIncident/ObservabilityIncidentReadinessPanel.tsx
@@ -101,6 +101,7 @@ export function ObservabilityIncidentReadinessPanel({ profile }: { profile: Obse
           <Badge status="review_required">Manual review required</Badge>
           <Badge status={profile.externalMonitoringIntegrationEnabled ? "blocked" : "verified"}>External monitoring disabled</Badge>
           <Badge status={profile.autonomousRemediationEnabled ? "blocked" : "verified"}>Autonomous remediation disabled</Badge>
+          <Badge status={profile.alertExecutionEnabled ? "blocked" : "verified"}>Alert execution disabled</Badge>
           <Badge status={profile.alertSendingEnabled ? "blocked" : "verified"}>Alert sending disabled</Badge>
           <Badge status={profile.productionMutationEnabled ? "blocked" : "verified"}>Production mutation disabled</Badge>
           <Badge status={profile.sensitiveTelemetryExposed ? "blocked" : "verified"}>Sensitive telemetry excluded</Badge>

--- a/rentchain-frontend/src/pages/ObservabilityIncidentReadinessPage.test.tsx
+++ b/rentchain-frontend/src/pages/ObservabilityIncidentReadinessPage.test.tsx
@@ -25,6 +25,7 @@ const profile = {
   manualReviewRequired: true,
   externalMonitoringIntegrationEnabled: false,
   autonomousRemediationEnabled: false,
+  alertExecutionEnabled: false,
   alertSendingEnabled: false,
   productionMutationEnabled: false,
   sensitiveTelemetryExposed: false,

--- a/rentchain-frontend/src/pages/ObservabilityIncidentReadinessPage.test.tsx
+++ b/rentchain-frontend/src/pages/ObservabilityIncidentReadinessPage.test.tsx
@@ -1,0 +1,121 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ObservabilityIncidentReadinessPage from "./ObservabilityIncidentReadinessPage";
+
+const mockFetchProfiles = vi.fn();
+const mockShowToast = vi.fn();
+
+vi.mock("@/api/observabilityIncidentReadinessApi", () => ({
+  fetchObservabilityIncidentReadinessProfiles: (...args: any[]) => mockFetchProfiles(...args),
+}));
+
+vi.mock("@/components/layout/MacShell", () => ({
+  MacShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
+const profile = {
+  observabilityIncidentReadinessId: "observability_incident_readiness:operational-observability-incident-readiness-v1",
+  status: "ready_for_review",
+  manualReviewRequired: true,
+  externalMonitoringIntegrationEnabled: false,
+  autonomousRemediationEnabled: false,
+  alertSendingEnabled: false,
+  productionMutationEnabled: false,
+  sensitiveTelemetryExposed: false,
+  generatedAt: "2026-01-01T00:00:00.000Z",
+  summary: {
+    totalReferences: 1,
+    verifiedReferences: 1,
+    partiallyVerifiedReferences: 0,
+    blockedReferences: 0,
+    unavailableReferences: 0,
+    restrictions: 0,
+  },
+  observabilityReferences: [],
+  incidentReferences: [],
+  outageReferences: [],
+  recoveryReferences: [],
+  escalationReferences: [],
+  postIncidentReviewReferences: [],
+  slaReferences: [],
+  alertReferences: [],
+  releaseReferences: [],
+  publicExposureReferences: [],
+  evidenceReferences: [],
+  reviewReferences: [],
+  auditReferences: [],
+  observabilityIncidentRestrictions: [],
+  redactions: ["External monitoring integrations, alert sending, autonomous remediation, and production mutation are not enabled."],
+  blockedReasons: [],
+  canonicalEvents: [],
+};
+
+describe("ObservabilityIncidentReadinessPage", () => {
+  const forbiddenLabels = [
+    ["Connect", "monitoring"],
+    ["Send", "alert"],
+    ["Auto", "remediate"],
+    ["Execute", "recovery"],
+    ["Mutate", "production"],
+    ["Expose", "telemetry"],
+  ].map((parts) => (parts[0] === "Auto" ? parts.join("-") : parts.join(" ")));
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchProfiles.mockResolvedValue([profile]);
+  });
+
+  it("renders observability incident readiness and required safety copy", async () => {
+    render(
+      <MemoryRouter>
+        <ObservabilityIncidentReadinessPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Observability and incident readiness")).toBeInTheDocument();
+    expect(screen.getAllByText(/No external monitoring integration, alert sending, autonomous remediation, recovery execution, or production mutation is enabled/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("Manual review required")).toBeInTheDocument();
+    expect(screen.getByText("External monitoring integrations, alert sending, autonomous remediation, and production mutation are not enabled.")).toBeInTheDocument();
+  });
+
+  it("updates deterministic status filters", async () => {
+    render(
+      <MemoryRouter>
+        <ObservabilityIncidentReadinessPage />
+      </MemoryRouter>
+    );
+
+    await screen.findByText("Observability and incident readiness");
+    fireEvent.change(screen.getByLabelText("Status"), { target: { value: "blocked" } });
+
+    await waitFor(() => {
+      expect(mockFetchProfiles).toHaveBeenLastCalledWith({
+        status: "blocked",
+      });
+    });
+  });
+
+  it("shows empty state and omits forbidden labels", async () => {
+    mockFetchProfiles.mockResolvedValue([]);
+    render(
+      <MemoryRouter>
+        <ObservabilityIncidentReadinessPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("No observability incident readiness profiles match these filters.")).toBeInTheDocument();
+    for (const forbiddenLabel of forbiddenLabels) {
+      expect(screen.queryByText(forbiddenLabel)).not.toBeInTheDocument();
+    }
+  });
+});

--- a/rentchain-frontend/src/pages/ObservabilityIncidentReadinessPage.tsx
+++ b/rentchain-frontend/src/pages/ObservabilityIncidentReadinessPage.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { useSearchParams } from "react-router-dom";
+import {
+  fetchObservabilityIncidentReadinessProfiles,
+  type ObservabilityIncidentReadinessProfile,
+  type ObservabilityIncidentReadinessStatus,
+} from "@/api/observabilityIncidentReadinessApi";
+import { ObservabilityIncidentReadinessPanel } from "@/components/observabilityIncident/ObservabilityIncidentReadinessPanel";
+import { MacShell } from "@/components/layout/MacShell";
+import { Card, Section } from "@/components/ui/Ui";
+import { useToast } from "@/components/ui/ToastProvider";
+
+const statuses: Array<ObservabilityIncidentReadinessStatus | ""> = ["", "ready_for_review", "partially_ready", "review_required", "blocked", "unknown"];
+
+function label(value: string) {
+  return value ? value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase()) : "All";
+}
+
+export default function ObservabilityIncidentReadinessPage() {
+  const { showToast } = useToast();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [profiles, setProfiles] = React.useState<ObservabilityIncidentReadinessProfile[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const status = String(searchParams.get("status") || "") as ObservabilityIncidentReadinessStatus | "";
+
+  React.useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const next = await fetchObservabilityIncidentReadinessProfiles({ status });
+        if (mounted) setProfiles(next);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Failed to load observability incident readiness";
+        if (mounted) {
+          setError(message);
+          showToast({ message: "Failed to load observability incident readiness", description: message, variant: "error" });
+        }
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [status, showToast]);
+
+  function updateStatus(value: string) {
+    const params = new URLSearchParams(searchParams);
+    if (value && value.trim()) params.set("status", value.trim());
+    else params.delete("status");
+    setSearchParams(params);
+  }
+
+  return (
+    <MacShell title="Observability and incident readiness" showTopNav={false}>
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "grid", gap: 6 }}>
+            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Observability and incident readiness</h1>
+            <div style={{ color: "#475569", maxWidth: 900 }}>
+              Observability and incident readiness is operationally scoped and review controlled. No external monitoring integration, alert sending, autonomous remediation, recovery execution, or production mutation is enabled.
+              Manual review remains required.
+            </div>
+          </div>
+        </Section>
+
+        <Section style={{ display: "flex", gap: 10, flexWrap: "wrap", alignItems: "end" }}>
+          <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Status
+            <select value={status} onChange={(event) => updateStatus(event.target.value)} style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 180 }}>
+              {statuses.map((item) => <option key={item || "all"} value={item}>{label(item)}</option>)}
+            </select>
+          </label>
+        </Section>
+
+        {loading ? <Card>Loading observability incident readiness...</Card> : null}
+        {!loading && error ? <Card style={{ color: "#b91c1c" }}>We couldn't load observability incident readiness right now.</Card> : null}
+        {!loading && !error && !profiles.length ? <Card style={{ color: "#64748b" }}>No observability incident readiness profiles match these filters.</Card> : null}
+        {!loading && !error && profiles.length ? (
+          <div style={{ display: "grid", gap: 16 }}>{profiles.map((profile) => <ObservabilityIncidentReadinessPanel key={profile.observabilityIncidentReadinessId} profile={profile} />)}</div>
+        ) : null}
+      </div>
+    </MacShell>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a deterministic observability and incident readiness read model with references, restrictions, redactions, and canonical event metadata.
- Adds admin-only read endpoints for observability incident readiness profiles.
- Adds an admin UI surface for operational health, incident visibility, outage lineage, recovery readiness, escalation readiness, post-incident review, SLA, alert, release, public exposure, evidence, review, and audit references.

## Guardrails
- Manual review remains required.
- External monitoring integration, alert sending, autonomous remediation, recovery execution, production mutation, and sensitive telemetry exposure are not enabled.
- Admin route responses use whitelist projections to avoid exposing sensitive telemetry, credentials, request bodies, stack traces, tenant/payment/screening payloads, or private review notes.

## Verification
- Backend targeted tests passed: `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm test -- --run src/lib/observabilityIncidentReadiness/__tests__/deriveObservabilityIncidentReadinessProfile.test.ts src/routes/__tests__/adminObservabilityIncidentReadinessRoutes.test.ts`
- Frontend targeted tests passed: `npm test -- --run src/components/observabilityIncident/ObservabilityIncidentReadinessPanel.test.tsx src/pages/ObservabilityIncidentReadinessPage.test.tsx`
- Backend build passed: `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm run build`
- Frontend build passed with existing large chunk warning; new page is lazy-loaded as a small chunk: `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm run build`
- Diff whitespace check passed: `git diff --check`