### PR TITLE
feat: add commercial readiness layer

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -114,6 +114,7 @@ import adminObservabilityRoutes from "./routes/adminObservabilityRoutes";
 import adminObservabilityIncidentReadinessRoutes from "./routes/adminObservabilityIncidentReadinessRoutes";
 import adminReleaseGovernanceRoutes from "./routes/adminReleaseGovernanceRoutes";
 import adminPublicExposureHardeningRoutes from "./routes/adminPublicExposureHardeningRoutes";
+import adminCommercialReadinessRoutes from "./routes/adminCommercialReadinessRoutes";
 import portfolioScoreRoutes from "./routes/portfolioScoreRoutes";
 import portfolioScoreHistoryRoutes from "./routes/portfolioScoreHistoryRoutes";
 import landlordPortfolioHealthRoutes from "./routes/landlordPortfolioHealthRoutes";
@@ -290,6 +291,8 @@ app.use("/api/admin", routeSource("adminReleaseGovernanceRoutes.ts"), adminRelea
 console.log("[route-mount] adminReleaseGovernanceRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("adminPublicExposureHardeningRoutes.ts"), adminPublicExposureHardeningRoutes);
 console.log("[route-mount] adminPublicExposureHardeningRoutes mounted at /api/admin");
+app.use("/api/admin", routeSource("adminCommercialReadinessRoutes.ts"), adminCommercialReadinessRoutes);
+console.log("[route-mount] adminCommercialReadinessRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("portfolioScoreRoutes.ts"), portfolioScoreRoutes);
 console.log("[route-mount] portfolioScoreRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("portfolioScoreHistoryRoutes.ts"), portfolioScoreHistoryRoutes);

--- a/rentchain-api/src/lib/commercialReadiness/__tests__/deriveCommercialReadinessProfile.test.ts
+++ b/rentchain-api/src/lib/commercialReadiness/__tests__/deriveCommercialReadinessProfile.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { deriveCommercialReadinessProfile } from "../deriveCommercialReadinessProfile";
+
+const completeInput = {
+  generatedAt: "2026-05-07T00:00:00.000Z",
+  pricingReadiness: [{ pricingReadinessId: "pricing-1", status: "ready_for_review" }],
+  billingReadiness: [{ billingReadinessId: "billing-1", status: "ready_for_review" }],
+  subscriptionReadiness: [{ subscriptionReadinessId: "subscription-1", status: "ready_for_review" }],
+  enterpriseOnboardingReadiness: [{ onboardingReadinessId: "onboarding-1", status: "ready_for_review" }],
+  supportReadiness: [{ supportReadinessId: "support-1", status: "ready_for_review" }],
+  operationalRiskProfiles: [{ operationalRiskId: "risk-1", status: "stable" }],
+  releaseGovernanceProfiles: [{ releaseGovernanceId: "release-1", status: "ready_for_review" }],
+  evidencePacks: [{ evidencePackId: "evidence-1", status: "ready_for_review" }],
+  operatorReviewSessions: [{ reviewSessionId: "review-1", status: "completed" }],
+  auditEvents: [{ eventId: "audit-1", eventType: "commercial_readiness_profile_derived" }],
+};
+
+describe("deriveCommercialReadinessProfile", () => {
+  it("derives a deterministic ready-for-review profile with manual governance flags pinned", () => {
+    const profile = deriveCommercialReadinessProfile(completeInput);
+    const repeat = deriveCommercialReadinessProfile(completeInput);
+
+    expect(profile).toEqual(repeat);
+    expect(profile.status).toBe("ready_for_review");
+    expect(profile).toEqual(
+      expect.objectContaining({
+        manualApprovalRequired: true,
+        autonomousBillingEnabled: false,
+        autonomousCommercializationEnabled: false,
+        publicSelfServiceEnabled: false,
+      })
+    );
+    expect(profile.summary).toEqual(
+      expect.objectContaining({
+        totalReferences: 10,
+        verifiedReferences: 10,
+        restrictions: 0,
+      })
+    );
+  });
+
+  it("aggregates blocked commercial restrictions from operational risk and billing governance", () => {
+    const profile = deriveCommercialReadinessProfile({
+      ...completeInput,
+      billingReadiness: [{ billingReadinessId: "billing-1", status: "blocked" }],
+      operationalRiskProfiles: [{ operationalRiskId: "risk-1", status: "blocked" }],
+    });
+
+    expect(profile.status).toBe("blocked");
+    expect(profile.commercialRestrictions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ restrictionType: "billing", status: "blocked" }),
+        expect.objectContaining({ restrictionType: "operational_risk", status: "blocked" }),
+      ])
+    );
+    expect(profile.blockedReasons).toEqual(
+      expect.arrayContaining([
+        "Billing governance restriction is unresolved.",
+        "Unresolved operational risk blocks commercial readiness.",
+      ])
+    );
+  });
+
+  it("requires review when critical evidence or onboarding lineage is missing", () => {
+    const profile = deriveCommercialReadinessProfile({
+      ...completeInput,
+      enterpriseOnboardingReadiness: [],
+      evidencePacks: [],
+    });
+
+    expect(profile.status).toBe("review_required");
+    expect(profile.commercialRestrictions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ restrictionType: "onboarding", status: "review_required" }),
+        expect.objectContaining({ restrictionType: "evidence", status: "review_required" }),
+      ])
+    );
+  });
+
+  it("marks incomplete support readiness as partially ready", () => {
+    const profile = deriveCommercialReadinessProfile({
+      ...completeInput,
+      supportReadiness: [{ supportReadinessId: "support-1", status: "needs_review" }],
+    });
+
+    expect(profile.status).toBe("partially_ready");
+    expect(profile.commercialRestrictions).toEqual(
+      expect.arrayContaining([expect.objectContaining({ restrictionType: "support", status: "review_required" })])
+    );
+  });
+
+  it("derives unknown when source context is unavailable", () => {
+    const profile = deriveCommercialReadinessProfile({});
+
+    expect(profile.status).toBe("unknown");
+    expect(profile.summary.unavailableReferences).toBe(10);
+    expect(profile.canonicalEvents.map((event) => event.eventType)).toEqual(
+      expect.arrayContaining(["commercial_readiness_profile_derived", "commercial_readiness_redaction_applied"])
+    );
+  });
+
+  it("generates canonical events for restrictions, review-required, blocked, and redaction paths", () => {
+    const profile = deriveCommercialReadinessProfile({
+      ...completeInput,
+      billingReadiness: [{ billingReadinessId: "billing-1", status: "blocked" }],
+    });
+
+    expect(profile.canonicalEvents.map((event) => event.eventType)).toEqual(
+      expect.arrayContaining([
+        "commercial_readiness_profile_derived",
+        "commercial_readiness_redaction_applied",
+        "commercial_readiness_restriction_detected",
+        "commercial_readiness_blocked",
+      ])
+    );
+  });
+});

--- a/rentchain-api/src/lib/commercialReadiness/commercialReadinessTypes.ts
+++ b/rentchain-api/src/lib/commercialReadiness/commercialReadinessTypes.ts
@@ -1,0 +1,101 @@
+export type CommercialReadinessStatus = "ready_for_review" | "partially_ready" | "review_required" | "blocked" | "unknown";
+
+export type CommercialReferenceType =
+  | "pricing"
+  | "billing"
+  | "subscription"
+  | "onboarding"
+  | "support"
+  | "operational_risk"
+  | "release"
+  | "evidence"
+  | "review"
+  | "audit";
+
+export type CommercialReferenceStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+
+export type CommercialCanonicalEventType =
+  | "commercial_readiness_profile_derived"
+  | "commercial_readiness_review_required"
+  | "commercial_readiness_blocked"
+  | "commercial_readiness_restriction_detected"
+  | "commercial_readiness_redaction_applied";
+
+export type CommercialReference = {
+  referenceId: string;
+  referenceType: CommercialReferenceType;
+  status: CommercialReferenceStatus;
+  label: string;
+  description: string;
+  reviewRequired: true;
+  lineageReferences: string[];
+  destination: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type CommercialRestriction = {
+  restrictionId: string;
+  restrictionType: CommercialReferenceType | "commercialization" | "billing_execution" | "public_self_service";
+  status: "visible" | "blocked" | "review_required";
+  label: string;
+  description: string;
+  blockedReason: string | null;
+};
+
+export type CommercialCanonicalEvent = {
+  eventType: CommercialCanonicalEventType;
+  action: string;
+  status: CommercialReadinessStatus;
+  resourceType: "commercial_readiness_profile";
+  resourceId: string;
+  summary: string;
+};
+
+export type CommercialReadinessProfile = {
+  commercialReadinessId: string;
+  status: CommercialReadinessStatus;
+  manualApprovalRequired: true;
+  autonomousBillingEnabled: false;
+  autonomousCommercializationEnabled: false;
+  publicSelfServiceEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    partiallyVerifiedReferences: number;
+    blockedReferences: number;
+    unavailableReferences: number;
+    restrictions: number;
+  };
+  pricingReferences: CommercialReference[];
+  billingReferences: CommercialReference[];
+  subscriptionReferences: CommercialReference[];
+  onboardingReferences: CommercialReference[];
+  supportReferences: CommercialReference[];
+  operationalRiskReferences: CommercialReference[];
+  releaseReferences: CommercialReference[];
+  reviewReferences: CommercialReference[];
+  evidenceReferences: CommercialReference[];
+  auditReferences: CommercialReference[];
+  commercialRestrictions: CommercialRestriction[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: CommercialCanonicalEvent[];
+};
+
+export type DeriveCommercialReadinessProfileInput = {
+  readinessKey?: unknown;
+  generatedAt?: unknown;
+  pricingReadiness?: Array<Record<string, any>> | null;
+  billingReadiness?: Array<Record<string, any>> | null;
+  subscriptionReadiness?: Array<Record<string, any>> | null;
+  enterpriseOnboardingReadiness?: Array<Record<string, any>> | null;
+  supportReadiness?: Array<Record<string, any>> | null;
+  operationalRiskProfiles?: Array<Record<string, any>> | null;
+  releaseGovernanceProfiles?: Array<Record<string, any>> | null;
+  operatorReviewSessions?: Array<Record<string, any>> | null;
+  evidencePacks?: Array<Record<string, any>> | null;
+  auditEvents?: Array<Record<string, any>> | null;
+};

--- a/rentchain-api/src/lib/commercialReadiness/commercialRestrictionModels.ts
+++ b/rentchain-api/src/lib/commercialReadiness/commercialRestrictionModels.ts
@@ -1,0 +1,63 @@
+import type {
+  CommercialReference,
+  CommercialReferenceStatus,
+  CommercialReferenceType,
+  CommercialRestriction,
+} from "./commercialReadinessTypes";
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+export function commercialIdPart(value: unknown): string {
+  return asString(value, 500)
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+export function commercialReference(input: {
+  idParts: unknown[];
+  referenceType: CommercialReferenceType;
+  status: CommercialReferenceStatus;
+  label: string;
+  description: string;
+  lineageReferences?: string[];
+  destination?: string | null;
+  redacted?: boolean;
+  redactionReason?: string | null;
+  blockedReason?: string | null;
+}): CommercialReference {
+  return {
+    referenceId: commercialIdPart(input.idParts.join(":")) || "commercial_reference:unknown",
+    referenceType: input.referenceType,
+    status: input.status,
+    label: input.label,
+    description: input.description,
+    reviewRequired: true,
+    lineageReferences: Array.from(new Set(input.lineageReferences || [])).filter(Boolean),
+    destination: input.destination || null,
+    redacted: Boolean(input.redacted),
+    redactionReason: input.redactionReason || null,
+    blockedReason: input.blockedReason || null,
+  };
+}
+
+export function commercialRestriction(input: {
+  idParts: unknown[];
+  restrictionType: CommercialRestriction["restrictionType"];
+  status: CommercialRestriction["status"];
+  label: string;
+  description: string;
+  blockedReason?: string | null;
+}): CommercialRestriction {
+  return {
+    restrictionId: commercialIdPart(input.idParts.join(":")) || "commercial_restriction:unknown",
+    restrictionType: input.restrictionType,
+    status: input.status,
+    label: input.label,
+    description: input.description,
+    blockedReason: input.blockedReason || null,
+  };
+}

--- a/rentchain-api/src/lib/commercialReadiness/deriveCommercialReadinessProfile.ts
+++ b/rentchain-api/src/lib/commercialReadiness/deriveCommercialReadinessProfile.ts
@@ -1,0 +1,492 @@
+import type {
+  CommercialCanonicalEvent,
+  CommercialReadinessProfile,
+  CommercialReadinessStatus,
+  CommercialReference,
+  DeriveCommercialReadinessProfileInput,
+} from "./commercialReadinessTypes";
+import { commercialIdPart, commercialReference, commercialRestriction } from "./commercialRestrictionModels";
+
+const DEFAULT_READINESS_KEY = "institutional-commercial-operations-readiness-v1";
+
+const REDACTIONS = [
+  "Payment credentials, subscription secrets, customer financial histories, and payment account details are excluded.",
+  "Commercial readiness is metadata only; no billing, charging, contract, messaging, onboarding, or commercialization execution is enabled.",
+  "Sensitive tenant, payment, screening, private document, customer financial, and admin-only commercial payloads are excluded.",
+  "Public self-service monetization controls, unrestricted commercial telemetry, and payment-provider execution payloads are excluded.",
+];
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function asArray<T>(value: T[] | null | undefined): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function generatedAt(value: unknown): string {
+  const raw = asString(value, 120);
+  const date = raw ? new Date(raw) : new Date(0);
+  return Number.isNaN(date.getTime()) ? new Date(0).toISOString() : date.toISOString();
+}
+
+function recordId(record: Record<string, any>, keys: string[]): string {
+  for (const key of keys) {
+    const value = asString(record?.[key], 240);
+    if (value) return value;
+  }
+  return asString(record?.id, 240);
+}
+
+function readinessStatus(hasContext: boolean, references: CommercialReference[]): CommercialReadinessStatus {
+  if (!hasContext) return "unknown";
+  if (references.some((reference) => reference.status === "blocked")) return "blocked";
+  const hasCriticalMissing = references.some(
+    (reference) =>
+      reference.status === "unavailable" &&
+      (reference.referenceType === "pricing" ||
+        reference.referenceType === "billing" ||
+        reference.referenceType === "onboarding" ||
+        reference.referenceType === "operational_risk" ||
+        reference.referenceType === "evidence" ||
+        reference.referenceType === "review")
+  );
+  if (hasCriticalMissing) return "review_required";
+  if (references.some((reference) => reference.status === "unavailable" || reference.status === "partially_verified")) return "partially_ready";
+  return "ready_for_review";
+}
+
+function event(input: {
+  eventType: CommercialCanonicalEvent["eventType"];
+  status: CommercialReadinessStatus;
+  commercialReadinessId: string;
+  summary: string;
+}): CommercialCanonicalEvent {
+  return {
+    eventType: input.eventType,
+    action: input.eventType.replace(/^commercial_/, "").replace(/_/g, "."),
+    status: input.status,
+    resourceType: "commercial_readiness_profile",
+    resourceId: input.commercialReadinessId,
+    summary: input.summary,
+  };
+}
+
+function statusFromRecord(record: Record<string, any>, verifiedStatuses: string[]): CommercialReference["status"] {
+  const status = asString(record?.status || record?.state || record?.conclusion, 80).toLowerCase();
+  if (status === "blocked" || status === "failure" || status === "failed" || status === "error" || status === "cancelled") return "blocked";
+  if (verifiedStatuses.includes(status)) return "verified";
+  if (status === "missing" || status === "unknown" || status === "unavailable" || status === "pending") return "unavailable";
+  return "partially_verified";
+}
+
+function readyBlockedStatus(record: Record<string, any>, readyStatuses: string[]): CommercialReference["status"] {
+  const status = asString(record?.status || record?.state || record?.conclusion, 80).toLowerCase();
+  if (status === "blocked" || status === "failed" || status === "failure") return "blocked";
+  if (readyStatuses.includes(status)) return "verified";
+  if (status === "unknown" || status === "unavailable" || status === "missing" || status === "pending") return "unavailable";
+  return "partially_verified";
+}
+
+function releaseStatus(profile: Record<string, any>): CommercialReference["status"] {
+  const status = asString(profile?.status, 80);
+  if (status === "blocked") return "blocked";
+  if (status === "ready_for_review") return "verified";
+  if (status === "unknown" || status === "review_required") return "unavailable";
+  return "partially_verified";
+}
+
+function operationalRiskStatus(profile: Record<string, any>): CommercialReference["status"] {
+  const status = asString(profile?.status, 80);
+  if (status === "blocked" || status === "elevated") return "blocked";
+  if (status === "stable") return "verified";
+  if (status === "unknown") return "unavailable";
+  return "partially_verified";
+}
+
+export function deriveCommercialReadinessProfile(input: DeriveCommercialReadinessProfileInput): CommercialReadinessProfile {
+  const readinessKey = asString(input.readinessKey, 160) || DEFAULT_READINESS_KEY;
+  const commercialReadinessId =
+    commercialIdPart(["commercial_readiness", readinessKey].join(":")) || "commercial_readiness:unknown";
+
+  const pricingReadiness = asArray(input.pricingReadiness);
+  const billingReadiness = asArray(input.billingReadiness);
+  const subscriptionReadiness = asArray(input.subscriptionReadiness);
+  const onboardingReadiness = asArray(input.enterpriseOnboardingReadiness);
+  const supportReadiness = asArray(input.supportReadiness);
+  const operationalRiskProfiles = asArray(input.operationalRiskProfiles);
+  const releaseGovernanceProfiles = asArray(input.releaseGovernanceProfiles);
+  const reviews = asArray(input.operatorReviewSessions);
+  const evidencePacks = asArray(input.evidencePacks);
+  const auditEvents = asArray(input.auditEvents);
+
+  const pricingReferences = pricingReadiness.length
+    ? pricingReadiness.map((pricing) => {
+        const status = readyBlockedStatus(pricing, ["verified", "ready_for_review", "configured", "available"]);
+        return commercialReference({
+          idParts: ["pricing", recordId(pricing, ["pricingReadinessId", "pricingId", "key", "id"]) || "unknown"],
+          referenceType: "pricing",
+          status,
+          label: "Pricing governance reference",
+          description: "Pricing governance metadata is available for commercial readiness review.",
+          lineageReferences: [recordId(pricing, ["pricingReadinessId", "pricingId", "key", "id"])].filter(Boolean),
+          destination: "/site/pricing",
+          blockedReason: status === "blocked" ? "Pricing governance readiness is blocked." : null,
+        });
+      })
+    : [
+        commercialReference({
+          idParts: ["pricing", "missing"],
+          referenceType: "pricing",
+          status: "unavailable",
+          label: "Pricing governance reference",
+          description: "Pricing governance metadata is unavailable for commercial readiness review.",
+          destination: "/site/pricing",
+        }),
+      ];
+
+  const billingReferences = billingReadiness.length
+    ? billingReadiness.map((billing) => {
+        const status = readyBlockedStatus(billing, ["verified", "ready_for_review", "configured"]);
+        return commercialReference({
+          idParts: ["billing", recordId(billing, ["billingReadinessId", "billingId", "key", "id"]) || "unknown"],
+          referenceType: "billing",
+          status,
+          label: "Billing readiness reference",
+          description: "Billing readiness metadata is available for commercial readiness review.",
+          lineageReferences: [recordId(billing, ["billingReadinessId", "billingId", "key", "id"])].filter(Boolean),
+          destination: "/billing",
+          blockedReason: status === "blocked" ? "Billing governance restriction is unresolved." : null,
+        });
+      })
+    : [
+        commercialReference({
+          idParts: ["billing", "missing"],
+          referenceType: "billing",
+          status: "unavailable",
+          label: "Billing readiness reference",
+          description: "Billing readiness metadata is unavailable for commercial readiness review.",
+          destination: "/billing",
+        }),
+      ];
+
+  const subscriptionReferences = subscriptionReadiness.length
+    ? subscriptionReadiness.map((subscription) => {
+        const status = statusFromRecord(subscription, ["verified", "ready_for_review", "active", "configured"]);
+        return commercialReference({
+          idParts: ["subscription", recordId(subscription, ["subscriptionReadinessId", "subscriptionId", "key", "id"]) || "unknown"],
+          referenceType: "subscription",
+          status,
+          label: "Subscription governance reference",
+          description: "Subscription governance metadata is available for commercial readiness review.",
+          lineageReferences: [recordId(subscription, ["subscriptionReadinessId", "subscriptionId", "key", "id"])].filter(Boolean),
+          destination: "/billing",
+          blockedReason: status === "blocked" ? "Subscription governance readiness is blocked." : null,
+        });
+      })
+    : [
+        commercialReference({
+          idParts: ["subscription", "missing"],
+          referenceType: "subscription",
+          status: "unavailable",
+          label: "Subscription governance reference",
+          description: "Subscription governance metadata is unavailable for commercial readiness review.",
+          destination: "/billing",
+        }),
+      ];
+
+  const onboardingReferences = onboardingReadiness.length
+    ? onboardingReadiness.map((readiness) => {
+        const status = readyBlockedStatus(readiness, ["ready_for_review", "verified"]);
+        return commercialReference({
+          idParts: ["onboarding", recordId(readiness, ["onboardingReadinessId", "institutionOnboardingId", "id"]) || "unknown"],
+          referenceType: "onboarding",
+          status,
+          label: "Enterprise onboarding readiness",
+          description: "Enterprise onboarding readiness is available for commercial readiness review.",
+          lineageReferences: [recordId(readiness, ["onboardingReadinessId", "institutionOnboardingId", "id"])].filter(Boolean),
+          destination: "/institution-onboarding-readiness",
+          blockedReason: status === "blocked" ? "Enterprise onboarding readiness is blocked." : null,
+        });
+      })
+    : [
+        commercialReference({
+          idParts: ["onboarding", "missing"],
+          referenceType: "onboarding",
+          status: "unavailable",
+          label: "Enterprise onboarding readiness",
+          description: "Enterprise onboarding readiness metadata is unavailable for commercial readiness review.",
+          destination: "/institution-onboarding-readiness",
+        }),
+      ];
+
+  const supportReferences = supportReadiness.length
+    ? supportReadiness.map((support) => {
+        const status = readyBlockedStatus(support, ["verified", "ready_for_review", "stable"]);
+        return commercialReference({
+          idParts: ["support", recordId(support, ["supportReadinessId", "supportId", "id"]) || "unknown"],
+          referenceType: "support",
+          status,
+          label: "Customer-operation support readiness",
+          description: "Customer-operation and support readiness metadata is available for commercial readiness review.",
+          lineageReferences: [recordId(support, ["supportReadinessId", "supportId", "id"])].filter(Boolean),
+          destination: "/admin/support-console",
+          blockedReason: status === "blocked" ? "Support readiness is blocked." : null,
+        });
+      })
+    : [
+        commercialReference({
+          idParts: ["support", "missing"],
+          referenceType: "support",
+          status: "unavailable",
+          label: "Customer-operation support readiness",
+          description: "Support readiness metadata is unavailable for commercial readiness review.",
+          destination: "/admin/support-console",
+        }),
+      ];
+
+  const operationalRiskReferences = operationalRiskProfiles.length
+    ? operationalRiskProfiles.map((profile) => {
+        const status = operationalRiskStatus(profile);
+        return commercialReference({
+          idParts: ["operational_risk", recordId(profile, ["operationalRiskId", "id"]) || "unknown"],
+          referenceType: "operational_risk",
+          status,
+          label: "Operational risk dependency",
+          description: "Operational risk readiness is available for commercial readiness review.",
+          lineageReferences: [recordId(profile, ["operationalRiskId", "id"])].filter(Boolean),
+          destination: "/operational-risk",
+          blockedReason: status === "blocked" ? "Unresolved operational risk blocks commercial readiness." : null,
+        });
+      })
+    : [
+        commercialReference({
+          idParts: ["operational_risk", "missing"],
+          referenceType: "operational_risk",
+          status: "unavailable",
+          label: "Operational risk dependency",
+          description: "Operational risk readiness is unavailable for commercial readiness review.",
+          destination: "/operational-risk",
+        }),
+      ];
+
+  const releaseReferences = releaseGovernanceProfiles.length
+    ? releaseGovernanceProfiles.map((profile) => {
+        const status = releaseStatus(profile);
+        return commercialReference({
+          idParts: ["release", recordId(profile, ["releaseGovernanceId", "releaseVersion", "id"]) || "unknown"],
+          referenceType: "release",
+          status,
+          label: "Release governance dependency",
+          description: "Release governance readiness is available for commercial readiness review.",
+          lineageReferences: [recordId(profile, ["releaseGovernanceId", "releaseVersion", "id"])].filter(Boolean),
+          destination: "/admin/release-governance",
+          blockedReason: status === "blocked" ? "Release governance readiness is blocked." : null,
+        });
+      })
+    : [
+        commercialReference({
+          idParts: ["release", "missing"],
+          referenceType: "release",
+          status: "unavailable",
+          label: "Release governance dependency",
+          description: "Release governance readiness is unavailable for commercial readiness review.",
+          destination: "/admin/release-governance",
+        }),
+      ];
+
+  const evidenceReferences = evidencePacks.length
+    ? evidencePacks.map((pack) => {
+        const status = readyBlockedStatus(pack, ["ready_for_review", "verified"]);
+        return commercialReference({
+          idParts: ["evidence", recordId(pack, ["evidencePackId", "id"]) || "unknown"],
+          referenceType: "evidence",
+          status,
+          label: "Evidence lineage reference",
+          description: "Evidence lineage is available for commercial readiness review.",
+          lineageReferences: [recordId(pack, ["evidencePackId", "id"])].filter(Boolean),
+          destination: "/evidence-packs",
+          blockedReason: status === "blocked" ? "Evidence lineage is blocked." : null,
+        });
+      })
+    : [
+        commercialReference({
+          idParts: ["evidence", "missing"],
+          referenceType: "evidence",
+          status: "unavailable",
+          label: "Evidence lineage reference",
+          description: "Evidence lineage is unavailable for commercial readiness review.",
+          destination: "/evidence-packs",
+        }),
+      ];
+
+  const reviewReferences = reviews.length
+    ? reviews.map((review) => {
+        const status = review.status === "completed" ? "verified" : review.status === "blocked" ? "blocked" : "partially_verified";
+        return commercialReference({
+          idParts: ["review", recordId(review, ["reviewSessionId", "id"]) || "unknown"],
+          referenceType: "review",
+          status,
+          label: "Review lineage reference",
+          description: "Operator review lineage is available for commercial readiness review.",
+          lineageReferences: [recordId(review, ["reviewSessionId", "id"])].filter(Boolean),
+          destination: "/review-timeline",
+          blockedReason: status === "blocked" ? "Operator review lineage is blocked." : null,
+        });
+      })
+    : [
+        commercialReference({
+          idParts: ["review", "missing"],
+          referenceType: "review",
+          status: "unavailable",
+          label: "Review lineage reference",
+          description: "Operator review lineage is unavailable for commercial readiness review.",
+          destination: "/review-timeline",
+        }),
+      ];
+
+  const auditReferences = auditEvents.length
+    ? auditEvents.slice(0, 20).map((record) =>
+        commercialReference({
+          idParts: ["audit", recordId(record, ["eventId", "id"]) || "unknown"],
+          referenceType: "audit",
+          status: record.redacted ? "partially_verified" : "verified",
+          label: "Audit lineage reference",
+          description: "Canonical audit event metadata is available for commercial readiness review.",
+          lineageReferences: [recordId(record, ["eventId", "id"])].filter(Boolean),
+          destination: "/review-timeline",
+          redacted: Boolean(record.redacted),
+          redactionReason: record.redacted ? "Audit payload is redacted for commercial readiness safety." : null,
+        })
+      )
+    : [
+        commercialReference({
+          idParts: ["audit", "missing"],
+          referenceType: "audit",
+          status: "unavailable",
+          label: "Audit lineage reference",
+          description: "Canonical audit event metadata is unavailable for commercial readiness review.",
+          destination: "/review-timeline",
+        }),
+      ];
+
+  const allReferences = [
+    ...pricingReferences,
+    ...billingReferences,
+    ...subscriptionReferences,
+    ...onboardingReferences,
+    ...supportReferences,
+    ...operationalRiskReferences,
+    ...releaseReferences,
+    ...evidenceReferences,
+    ...reviewReferences,
+    ...auditReferences,
+  ];
+
+  const commercialRestrictions = allReferences
+    .filter((reference) => reference.status !== "verified")
+    .map((reference) =>
+      commercialRestriction({
+        idParts: [reference.referenceType, reference.referenceId],
+        restrictionType: reference.referenceType,
+        status: reference.status === "blocked" ? "blocked" : "review_required",
+        label: `${reference.label} restriction`,
+        description: `${reference.label} is incomplete or blocked for commercial readiness.`,
+        blockedReason: reference.blockedReason,
+      })
+    );
+
+  const hasContext = Boolean(
+    pricingReadiness.length ||
+      billingReadiness.length ||
+      subscriptionReadiness.length ||
+      onboardingReadiness.length ||
+      supportReadiness.length ||
+      operationalRiskProfiles.length ||
+      releaseGovernanceProfiles.length ||
+      reviews.length ||
+      evidencePacks.length ||
+      auditEvents.length
+  );
+  const status = readinessStatus(hasContext, allReferences);
+  const blockedReasons = [...allReferences.map((reference) => reference.blockedReason), ...commercialRestrictions.map((restriction) => restriction.blockedReason)].filter(Boolean) as string[];
+
+  const canonicalEvents: CommercialCanonicalEvent[] = [
+    event({
+      eventType: "commercial_readiness_profile_derived",
+      status,
+      commercialReadinessId,
+      summary:
+        "Commercial readiness profile derived from pricing, billing, subscription, onboarding, support, operational risk, release, evidence, review, and audit metadata.",
+    }),
+    event({
+      eventType: "commercial_readiness_redaction_applied",
+      status,
+      commercialReadinessId,
+      summary:
+        "Payment credentials, subscription secrets, customer financial histories, billing execution payloads, contract execution payloads, and public monetization controls were excluded.",
+    }),
+  ];
+  if (commercialRestrictions.length) {
+    canonicalEvents.push(
+      event({
+        eventType: "commercial_readiness_restriction_detected",
+        status,
+        commercialReadinessId,
+        summary: "Commercialization restrictions are visible for manual approval review.",
+      })
+    );
+  }
+  if (status === "review_required" || status === "partially_ready") {
+    canonicalEvents.push(
+      event({
+        eventType: "commercial_readiness_review_required",
+        status,
+        commercialReadinessId,
+        summary: "Manual commercial readiness review is required.",
+      })
+    );
+  }
+  if (status === "blocked") {
+    canonicalEvents.push(
+      event({
+        eventType: "commercial_readiness_blocked",
+        status,
+        commercialReadinessId,
+        summary: "Commercial readiness is blocked by unresolved restrictions.",
+      })
+    );
+  }
+
+  return {
+    commercialReadinessId,
+    status,
+    manualApprovalRequired: true,
+    autonomousBillingEnabled: false,
+    autonomousCommercializationEnabled: false,
+    publicSelfServiceEnabled: false,
+    generatedAt: generatedAt(input.generatedAt),
+    summary: {
+      totalReferences: allReferences.length,
+      verifiedReferences: allReferences.filter((reference) => reference.status === "verified").length,
+      partiallyVerifiedReferences: allReferences.filter((reference) => reference.status === "partially_verified").length,
+      blockedReferences: allReferences.filter((reference) => reference.status === "blocked").length,
+      unavailableReferences: allReferences.filter((reference) => reference.status === "unavailable").length,
+      restrictions: commercialRestrictions.length,
+    },
+    pricingReferences,
+    billingReferences,
+    subscriptionReferences,
+    onboardingReferences,
+    supportReferences,
+    operationalRiskReferences,
+    releaseReferences,
+    reviewReferences,
+    evidenceReferences,
+    auditReferences,
+    commercialRestrictions,
+    redactions: REDACTIONS,
+    blockedReasons,
+    canonicalEvents,
+  };
+}

--- a/rentchain-api/src/routes/__tests__/adminCommercialReadinessRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/adminCommercialReadinessRoutes.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+  return {
+    resetFakeDb: () => store.clear(),
+    seedDoc: (collection: string, id: string, data: any) => ensureCollection(collection).set(id, { id, data }),
+    fakeDb: {
+      collection: (name: string) => ({
+        get: async () => {
+          const docs = Array.from(ensureCollection(name).values()).map((doc) => ({ id: doc.id, exists: true, data: () => doc.data }));
+          return { docs, empty: docs.length === 0, size: docs.length };
+        },
+      }),
+    },
+  };
+});
+
+let mockUser: any;
+
+vi.mock("../../config/firebase", () => ({ db: fakeDb }));
+vi.mock("../../config/planMatrix", () => ({
+  getPricingHealth: () => ({ ok: true, missing: [], invalid: [], env: "test" }),
+}));
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!mockUser) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    req.user = mockUser;
+    return next();
+  },
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; user?: Record<string, unknown> | null }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    mockUser = options.user ?? mockUser;
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: mockUser,
+      query: Object.fromEntries(new URLSearchParams(queryString || "").entries()),
+      params: {},
+      headers: {},
+    };
+    const match = path.match(/^\/commercial-readiness\/(.+)$/);
+    if (match) req.params = { commercialReadinessId: decodeURIComponent(match[1]) };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => (error ? reject(error) : undefined));
+  });
+}
+
+describe("adminCommercialReadinessRoutes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    resetFakeDb();
+    mockUser = { id: "admin-1", role: "admin", permissions: ["system.admin"] };
+  });
+
+  function seedReadinessContext() {
+    seedDoc("pricingReadiness", "pricing-1", { pricingReadinessId: "pricing-1", status: "ready_for_review", stripePriceId: "price_secret" });
+    seedDoc("billingReadiness", "billing-1", { billingReadinessId: "billing-1", status: "ready_for_review", paymentMethodId: "pm_secret" });
+    seedDoc("subscriptionReadiness", "subscription-1", { subscriptionReadinessId: "subscription-1", status: "ready_for_review", subscriptionToken: "sub_secret" });
+    seedDoc("institutionOnboardingReadiness", "onboarding-1", { onboardingReadinessId: "onboarding-1", status: "ready_for_review", contractSecret: "hidden" });
+    seedDoc("commercialSupportReadiness", "support-1", { supportReadinessId: "support-1", status: "ready_for_review", privateNote: "hidden" });
+    seedDoc("operationalRiskProfiles", "risk-1", { operationalRiskId: "risk-1", status: "stable", rawPayload: "sensitive-risk" });
+    seedDoc("releaseGovernanceProfiles", "release-1", { releaseGovernanceId: "release-1", status: "ready_for_review" });
+    seedDoc("evidencePacks", "evidence-1", { evidencePackId: "evidence-1", status: "ready_for_review", paymentAccount: "acct_secret" });
+    seedDoc("operatorReviewSessions", "operator-review-1", { reviewSessionId: "operator-review-1", status: "completed", privateNote: "hidden" });
+    seedDoc("events", "event-1", { eventId: "event-1", eventType: "commercial_readiness_profile_derived", rawFinancialHistory: "hidden" });
+  }
+
+  it("returns admin-gated commercial readiness profiles without sensitive commercial payloads", async () => {
+    seedReadinessContext();
+    const router = (await import("../adminCommercialReadinessRoutes")).default;
+
+    const forbidden = await invokeRouter(router, {
+      method: "GET",
+      url: "/commercial-readiness",
+      user: { id: "landlord-1", role: "landlord", permissions: [] },
+    });
+    expect(forbidden.status).toBe(403);
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/commercial-readiness",
+      user: { id: "admin-1", role: "admin", permissions: ["system.admin"] },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.profiles).toHaveLength(1);
+    expect(res.body.profiles[0]).toEqual(
+      expect.objectContaining({
+        manualApprovalRequired: true,
+        autonomousBillingEnabled: false,
+        autonomousCommercializationEnabled: false,
+        publicSelfServiceEnabled: false,
+      })
+    );
+    expect(JSON.stringify(res.body)).not.toContain("price_secret");
+    expect(JSON.stringify(res.body)).not.toContain("pm_secret");
+    expect(JSON.stringify(res.body)).not.toContain("sub_secret");
+    expect(JSON.stringify(res.body)).not.toContain("contractSecret");
+    expect(JSON.stringify(res.body)).not.toContain("paymentAccount");
+    expect(JSON.stringify(res.body)).not.toContain("rawFinancialHistory");
+    expect(JSON.stringify(res.body)).not.toContain("privateNote");
+  });
+
+  it("returns a single commercial readiness profile by id", async () => {
+    seedReadinessContext();
+    const router = (await import("../adminCommercialReadinessRoutes")).default;
+    const list = await invokeRouter(router, { method: "GET", url: "/commercial-readiness" });
+    const id = list.body.profiles[0].commercialReadinessId;
+
+    const res = await invokeRouter(router, { method: "GET", url: `/commercial-readiness/${encodeURIComponent(id)}` });
+
+    expect(res.status).toBe(200);
+    expect(res.body.profile.commercialReadinessId).toBe(id);
+  });
+
+  it("filters by status", async () => {
+    seedReadinessContext();
+    const router = (await import("../adminCommercialReadinessRoutes")).default;
+
+    const filtered = await invokeRouter(router, { method: "GET", url: "/commercial-readiness?status=unknown" });
+
+    expect(filtered.status).toBe(200);
+    expect(filtered.body.profiles).toEqual([]);
+  });
+});

--- a/rentchain-api/src/routes/adminCommercialReadinessRoutes.ts
+++ b/rentchain-api/src/routes/adminCommercialReadinessRoutes.ts
@@ -1,0 +1,160 @@
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { getPricingHealth } from "../config/planMatrix";
+import { requireAuth } from "../middleware/requireAuth";
+import { requirePermission } from "../middleware/requireAuthz";
+import { deriveCommercialReadinessProfile } from "../lib/commercialReadiness/deriveCommercialReadinessProfile";
+import type { CommercialReadinessProfile, CommercialReadinessStatus } from "../lib/commercialReadiness/commercialReadinessTypes";
+
+const router = Router();
+
+const READINESS_KEY = "institutional-commercial-operations-readiness-v1";
+const STATUSES = new Set<CommercialReadinessStatus>([
+  "ready_for_review",
+  "partially_ready",
+  "review_required",
+  "blocked",
+  "unknown",
+]);
+
+const BILLING_READINESS = [
+  { billingReadinessId: "manual-billing-governance-baseline", status: "ready_for_review" },
+];
+
+const SUBSCRIPTION_READINESS = [
+  { subscriptionReadinessId: "manual-subscription-governance-baseline", status: "ready_for_review" },
+];
+
+const SUPPORT_READINESS = [
+  { supportReadinessId: "manual-commercial-support-readiness-baseline", status: "ready_for_review" },
+];
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+async function loadCollection(collectionName: string, limit = 25) {
+  const snap = await db.collection(collectionName).get().catch(() => null);
+  return (snap?.docs || []).slice(0, limit).map((doc) => sanitizeRecord({ id: doc.id, ...((doc.data() as any) || {}) }));
+}
+
+function sanitizeRecord(record: Record<string, any>) {
+  const safe: Record<string, any> = {};
+  for (const key of [
+    "id",
+    "status",
+    "state",
+    "conclusion",
+    "key",
+    "pricingReadinessId",
+    "pricingId",
+    "billingReadinessId",
+    "billingId",
+    "subscriptionReadinessId",
+    "subscriptionId",
+    "onboardingReadinessId",
+    "institutionOnboardingId",
+    "supportReadinessId",
+    "supportId",
+    "operationalRiskId",
+    "releaseGovernanceId",
+    "releaseVersion",
+    "evidencePackId",
+    "reviewSessionId",
+    "eventId",
+    "eventType",
+    "resourceType",
+    "resourceId",
+    "createdAt",
+    "updatedAt",
+    "redacted",
+  ]) {
+    if (record[key] !== undefined) safe[key] = record[key];
+  }
+  return safe;
+}
+
+function pricingReadinessFromConfig() {
+  const pricingHealth = getPricingHealth();
+  return [
+    {
+      pricingReadinessId: "pricing-governance-config",
+      status: pricingHealth.ok ? "ready_for_review" : "blocked",
+      key: "pricing-governance-config",
+    },
+  ];
+}
+
+async function buildCommercialReadinessProfiles(): Promise<CommercialReadinessProfile[]> {
+  const [
+    pricingReadiness,
+    billingReadiness,
+    subscriptionReadiness,
+    onboardingReadiness,
+    supportReadiness,
+    operationalRiskProfiles,
+    releaseGovernanceProfiles,
+    evidencePacks,
+    reviews,
+    auditEvents,
+  ] = await Promise.all([
+    loadCollection("pricingReadiness"),
+    loadCollection("billingReadiness"),
+    loadCollection("subscriptionReadiness"),
+    loadCollection("institutionOnboardingReadiness"),
+    loadCollection("commercialSupportReadiness"),
+    loadCollection("operationalRiskProfiles"),
+    loadCollection("releaseGovernanceProfiles"),
+    loadCollection("evidencePacks"),
+    loadCollection("operatorReviewSessions"),
+    loadCollection("events"),
+  ]);
+
+  return [
+    deriveCommercialReadinessProfile({
+      readinessKey: READINESS_KEY,
+      pricingReadiness: pricingReadiness.length ? pricingReadiness : pricingReadinessFromConfig(),
+      billingReadiness: billingReadiness.length ? billingReadiness : BILLING_READINESS,
+      subscriptionReadiness: subscriptionReadiness.length ? subscriptionReadiness : SUBSCRIPTION_READINESS,
+      enterpriseOnboardingReadiness: onboardingReadiness,
+      supportReadiness: supportReadiness.length ? supportReadiness : SUPPORT_READINESS,
+      operationalRiskProfiles,
+      releaseGovernanceProfiles,
+      evidencePacks,
+      operatorReviewSessions: reviews,
+      auditEvents,
+    }),
+  ];
+}
+
+function profileMatches(profile: CommercialReadinessProfile, id: string) {
+  return profile.commercialReadinessId === id;
+}
+
+router.get("/commercial-readiness", requireAuth, requirePermission("system.admin"), async (req: any, res) => {
+  try {
+    const status = asString(req.query?.status, 80) as CommercialReadinessStatus;
+    let profiles = await buildCommercialReadinessProfiles();
+    if (status && STATUSES.has(status)) profiles = profiles.filter((profile) => profile.status === status);
+    return res.json({ ok: true, profiles });
+  } catch (err: any) {
+    console.error("[admin-commercial-readiness] list failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "COMMERCIAL_READINESS_FAILED" });
+  }
+});
+
+router.get("/commercial-readiness/:commercialReadinessId", requireAuth, requirePermission("system.admin"), async (req: any, res) => {
+  try {
+    const commercialReadinessId = decodeURIComponent(asString(req.params?.commercialReadinessId, 500));
+    if (!commercialReadinessId) return res.status(400).json({ ok: false, error: "COMMERCIAL_READINESS_ID_REQUIRED" });
+    const profiles = await buildCommercialReadinessProfiles();
+    const profile = profiles.find((next) => profileMatches(next, commercialReadinessId));
+    if (!profile) return res.status(404).json({ ok: false, error: "COMMERCIAL_READINESS_NOT_FOUND" });
+    return res.json({ ok: true, profile });
+  } catch (err: any) {
+    console.error("[admin-commercial-readiness] get failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "COMMERCIAL_READINESS_GET_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -114,6 +114,7 @@ const AdminNotificationsPage = lazy(() => import("./pages/admin/AdminNotificatio
 const ObservabilityIncidentReadinessPage = lazy(() => import("./pages/ObservabilityIncidentReadinessPage"));
 const ReleaseGovernancePage = lazy(() => import("./pages/ReleaseGovernancePage"));
 const PublicExposureHardeningPage = lazy(() => import("./pages/PublicExposureHardeningPage"));
+const CommercialReadinessPage = lazy(() => import("./pages/CommercialReadinessPage"));
 const PortfolioScorePage = lazy(() => import("./pages/admin/PortfolioScorePage"));
 const PortfolioScoreHistoryPage = lazy(() => import("./pages/admin/PortfolioScoreHistoryPage"));
 const PortfolioHealthSummaryPage = lazy(() => import("./pages/landlord/PortfolioHealthSummaryPage"));
@@ -1304,6 +1305,14 @@ function App() {
               element={
                 <RequireAdmin>
                   <PublicExposureHardeningPage />
+                </RequireAdmin>
+              }
+            />
+            <Route
+              path="/admin/commercial-readiness"
+              element={
+                <RequireAdmin>
+                  <CommercialReadinessPage />
                 </RequireAdmin>
               }
             />

--- a/rentchain-frontend/src/api/commercialReadinessApi.ts
+++ b/rentchain-frontend/src/api/commercialReadinessApi.ts
@@ -1,0 +1,87 @@
+import { apiFetch } from "./apiFetch";
+
+export type CommercialReadinessStatus = "ready_for_review" | "partially_ready" | "review_required" | "blocked" | "unknown";
+export type CommercialReferenceType =
+  | "pricing"
+  | "billing"
+  | "subscription"
+  | "onboarding"
+  | "support"
+  | "operational_risk"
+  | "release"
+  | "evidence"
+  | "review"
+  | "audit";
+export type CommercialReferenceStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+
+export type CommercialReference = {
+  referenceId: string;
+  referenceType: CommercialReferenceType;
+  status: CommercialReferenceStatus;
+  label: string;
+  description: string;
+  reviewRequired: true;
+  lineageReferences: string[];
+  destination: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type CommercialRestriction = {
+  restrictionId: string;
+  restrictionType: CommercialReferenceType | "commercialization" | "billing_execution" | "public_self_service";
+  status: "visible" | "blocked" | "review_required";
+  label: string;
+  description: string;
+  blockedReason: string | null;
+};
+
+export type CommercialReadinessProfile = {
+  commercialReadinessId: string;
+  status: CommercialReadinessStatus;
+  manualApprovalRequired: true;
+  autonomousBillingEnabled: false;
+  autonomousCommercializationEnabled: false;
+  publicSelfServiceEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    partiallyVerifiedReferences: number;
+    blockedReferences: number;
+    unavailableReferences: number;
+    restrictions: number;
+  };
+  pricingReferences: CommercialReference[];
+  billingReferences: CommercialReference[];
+  subscriptionReferences: CommercialReference[];
+  onboardingReferences: CommercialReference[];
+  supportReferences: CommercialReference[];
+  operationalRiskReferences: CommercialReference[];
+  releaseReferences: CommercialReference[];
+  reviewReferences: CommercialReference[];
+  evidenceReferences: CommercialReference[];
+  auditReferences: CommercialReference[];
+  commercialRestrictions: CommercialRestriction[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: Array<{ eventType: string; action: string; status: CommercialReadinessStatus; resourceId: string; summary: string }>;
+};
+
+export async function fetchCommercialReadinessProfiles(params?: {
+  status?: CommercialReadinessStatus | "";
+}): Promise<CommercialReadinessProfile[]> {
+  const search = new URLSearchParams();
+  if (params?.status) search.set("status", params.status);
+  const suffix = search.toString() ? `?${search.toString()}` : "";
+  const response = await apiFetch<{ ok: true; profiles: CommercialReadinessProfile[] }>(`/admin/commercial-readiness${suffix}`);
+  return response.profiles;
+}
+
+export async function fetchCommercialReadinessProfile(commercialReadinessId: string): Promise<CommercialReadinessProfile> {
+  const response = await apiFetch<{ ok: true; profile: CommercialReadinessProfile }>(
+    `/admin/commercial-readiness/${encodeURIComponent(commercialReadinessId)}`
+  );
+  return response.profile;
+}

--- a/rentchain-frontend/src/components/commercial/CommercialReadinessPanel.test.tsx
+++ b/rentchain-frontend/src/components/commercial/CommercialReadinessPanel.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import type { CommercialReadinessProfile } from "@/api/commercialReadinessApi";
+import { CommercialReadinessPanel } from "./CommercialReadinessPanel";
+
+const profile: CommercialReadinessProfile = {
+  commercialReadinessId: "commercial_readiness:test",
+  status: "blocked",
+  manualApprovalRequired: true,
+  autonomousBillingEnabled: false,
+  autonomousCommercializationEnabled: false,
+  publicSelfServiceEnabled: false,
+  generatedAt: "2026-05-07T00:00:00.000Z",
+  summary: {
+    totalReferences: 2,
+    verifiedReferences: 1,
+    partiallyVerifiedReferences: 0,
+    blockedReferences: 1,
+    unavailableReferences: 0,
+    restrictions: 1,
+  },
+  pricingReferences: [
+    {
+      referenceId: "pricing-1",
+      referenceType: "pricing",
+      status: "verified",
+      label: "Pricing governance reference",
+      description: "Pricing governance metadata is available.",
+      reviewRequired: true,
+      lineageReferences: ["pricing-1"],
+      destination: "/site/pricing",
+      redacted: false,
+      redactionReason: null,
+      blockedReason: null,
+    },
+  ],
+  billingReferences: [],
+  subscriptionReferences: [],
+  onboardingReferences: [],
+  supportReferences: [],
+  operationalRiskReferences: [
+    {
+      referenceId: "risk-1",
+      referenceType: "operational_risk",
+      status: "blocked",
+      label: "Operational risk dependency",
+      description: "Operational risk readiness is available.",
+      reviewRequired: true,
+      lineageReferences: ["risk-1"],
+      destination: "/operational-risk",
+      redacted: false,
+      redactionReason: null,
+      blockedReason: "Unresolved operational risk blocks commercial readiness.",
+    },
+  ],
+  releaseReferences: [],
+  reviewReferences: [],
+  evidenceReferences: [],
+  auditReferences: [],
+  commercialRestrictions: [
+    {
+      restrictionId: "restriction-1",
+      restrictionType: "operational_risk",
+      status: "blocked",
+      label: "Operational risk dependency restriction",
+      description: "Operational risk dependency is incomplete.",
+      blockedReason: "Unresolved operational risk blocks commercial readiness.",
+    },
+  ],
+  redactions: ["Payment credentials and subscription secrets are excluded."],
+  blockedReasons: ["Unresolved operational risk blocks commercial readiness."],
+  canonicalEvents: [],
+};
+
+describe("CommercialReadinessPanel", () => {
+  it("renders readiness, restrictions, blocked reasons, and required safety copy", () => {
+    render(
+      <MemoryRouter>
+        <CommercialReadinessPanel profile={profile} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Commercial readiness")).toBeInTheDocument();
+    expect(screen.getByText("View restrictions")).toBeInTheDocument();
+    expect(screen.getAllByText("View blocked reason: Unresolved operational risk blocks commercial readiness.").length).toBeGreaterThan(0);
+    expect(screen.getByText("Manual approval required")).toBeInTheDocument();
+    expect(screen.getByText(/Commercial readiness is operationally scoped and review controlled/i)).toBeInTheDocument();
+    expect(screen.getByText(/No autonomous billing, charging, or commercialization execution is enabled/i)).toBeInTheDocument();
+    expect(screen.getByText(/Manual approval remains required/i)).toBeInTheDocument();
+  });
+
+  it("does not render forbidden commercial execution labels", () => {
+    render(
+      <MemoryRouter>
+        <CommercialReadinessPanel profile={profile} />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText(/Charge automatically/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Auto-subscribe/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Enable monetization/i)).not.toBeInTheDocument();
+    expect(screen.queryByText("Autonomous billing")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Auto-approve customer/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Trigger commercial rollout/i)).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/commercial/CommercialReadinessPanel.tsx
+++ b/rentchain-frontend/src/components/commercial/CommercialReadinessPanel.tsx
@@ -1,0 +1,144 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import type { CommercialReadinessProfile, CommercialReference, CommercialRestriction } from "@/api/commercialReadinessApi";
+import { Card, Section } from "@/components/ui/Ui";
+
+function label(value: string) {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function tone(status: string) {
+  if (status === "blocked") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
+  if (status === "review_required" || status === "partially_ready" || status === "partially_verified" || status === "unavailable") {
+    return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
+  }
+  if (status === "ready_for_review" || status === "verified") return { color: "#166534", background: "#dcfce7", border: "#bbf7d0" };
+  return { color: "#475569", background: "#f8fafc", border: "#e2e8f0" };
+}
+
+function Badge({ children, status }: { children: React.ReactNode; status: string }) {
+  const next = tone(status);
+  return (
+    <span style={{ border: `1px solid ${next.border}`, borderRadius: 999, background: next.background, color: next.color, padding: "3px 9px", fontSize: 12, fontWeight: 900, whiteSpace: "nowrap" }}>
+      {children}
+    </span>
+  );
+}
+
+function ReferenceList({ title, references }: { title: string; references: CommercialReference[] }) {
+  return (
+    <Section style={{ display: "grid", gap: 10 }}>
+      <div style={{ fontWeight: 900 }}>{title}</div>
+      {references.length ? (
+        references.slice(0, 12).map((reference) => (
+          <Card key={reference.referenceId} style={{ borderRadius: 8, padding: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+              <div>
+                <strong>{reference.label}</strong>
+                <div style={{ color: "#64748b", fontSize: 13 }}>{label(reference.referenceType)}</div>
+              </div>
+              <Badge status={reference.status}>{label(reference.status)}</Badge>
+            </div>
+            <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>{reference.description}</div>
+            {reference.lineageReferences.length ? <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>Lineage references: {reference.lineageReferences.length}</div> : null}
+            {reference.blockedReason ? <div style={{ color: "#991b1b", fontSize: 13, marginTop: 8 }}>View blocked reason: {reference.blockedReason}</div> : null}
+            {reference.redacted ? <div style={{ color: "#92400e", fontSize: 13, marginTop: 8 }}>{reference.redactionReason || "Redacted commercial readiness reference"}</div> : null}
+            {reference.destination?.startsWith("/") ? <Link to={reference.destination} style={{ color: "#2563eb", fontWeight: 800, fontSize: 13, marginTop: 8, display: "inline-block" }}>View context</Link> : null}
+            {reference.destination && !reference.destination.startsWith("/") ? <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>{reference.destination}</div> : null}
+          </Card>
+        ))
+      ) : (
+        <Card style={{ color: "#64748b" }}>Context unavailable</Card>
+      )}
+    </Section>
+  );
+}
+
+function RestrictionList({ restrictions }: { restrictions: CommercialRestriction[] }) {
+  return (
+    <Section style={{ display: "grid", gap: 10 }}>
+      <div style={{ fontWeight: 900 }}>View restrictions</div>
+      {restrictions.length ? (
+        restrictions.map((restriction) => (
+          <Card key={restriction.restrictionId} style={{ borderRadius: 8, padding: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+              <div>
+                <strong>{restriction.label}</strong>
+                <div style={{ color: "#64748b", fontSize: 13 }}>{label(restriction.restrictionType)}</div>
+              </div>
+              <Badge status={restriction.status}>{label(restriction.status)}</Badge>
+            </div>
+            <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>{restriction.description}</div>
+            {restriction.blockedReason ? <div style={{ color: "#991b1b", fontSize: 13, marginTop: 8 }}>View blocked reason: {restriction.blockedReason}</div> : null}
+          </Card>
+        ))
+      ) : (
+        <Card style={{ color: "#64748b" }}>No commercialization restrictions detected.</Card>
+      )}
+    </Section>
+  );
+}
+
+export function CommercialReadinessPanel({ profile }: { profile: CommercialReadinessProfile }) {
+  return (
+    <div style={{ display: "grid", gap: 16 }}>
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+          <div>
+            <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>View commercial readiness</div>
+            <h2 style={{ margin: "2px 0 0", fontSize: "1.15rem" }}>Commercial readiness</h2>
+          </div>
+          <Badge status={profile.status}>{label(profile.status)}</Badge>
+        </div>
+        <div style={{ color: "#475569", lineHeight: 1.55 }}>
+          Commercial readiness is operationally scoped and review controlled. No autonomous billing, charging, or commercialization execution is enabled.
+          Manual approval remains required.
+        </div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <Badge status="review_required">Manual approval required</Badge>
+          <Badge status={profile.autonomousBillingEnabled ? "blocked" : "verified"}>Billing execution disabled</Badge>
+          <Badge status={profile.autonomousCommercializationEnabled ? "blocked" : "verified"}>Commercialization execution disabled</Badge>
+          <Badge status={profile.publicSelfServiceEnabled ? "blocked" : "verified"}>Public self service disabled</Badge>
+        </div>
+      </Section>
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Commercial summary</div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: 10 }}>
+          {[
+            ["References", profile.summary.totalReferences],
+            ["Verified", profile.summary.verifiedReferences],
+            ["Partial", profile.summary.partiallyVerifiedReferences],
+            ["Blocked", profile.summary.blockedReferences],
+            ["Unavailable", profile.summary.unavailableReferences],
+            ["Restrictions", profile.summary.restrictions],
+          ].map(([name, value]) => (
+            <Card key={String(name)} style={{ borderRadius: 8, padding: 12 }}>
+              <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>{name}</div>
+              <strong style={{ color: "#0f172a", fontSize: 22 }}>{String(value)}</strong>
+            </Card>
+          ))}
+        </div>
+      </Section>
+
+      <RestrictionList restrictions={profile.commercialRestrictions} />
+      <ReferenceList title="View pricing readiness" references={profile.pricingReferences} />
+      <ReferenceList title="View billing readiness" references={profile.billingReferences} />
+      <ReferenceList title="View subscription readiness" references={profile.subscriptionReferences} />
+      <ReferenceList title="View onboarding readiness" references={profile.onboardingReferences} />
+      <ReferenceList title="View support readiness" references={profile.supportReferences} />
+      <ReferenceList title="View operational risk" references={profile.operationalRiskReferences} />
+      <ReferenceList title="View release readiness" references={profile.releaseReferences} />
+      <ReferenceList title="View evidence lineage" references={profile.evidenceReferences} />
+      <ReferenceList title="View review lineage" references={profile.reviewReferences} />
+      <ReferenceList title="Audit references" references={profile.auditReferences} />
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Redactions</div>
+        {profile.redactions.map((redaction) => (
+          <Card key={redaction} style={{ borderRadius: 8, padding: 12, color: "#475569" }}>{redaction}</Card>
+        ))}
+      </Section>
+    </div>
+  );
+}

--- a/rentchain-frontend/src/pages/CommercialReadinessPage.test.tsx
+++ b/rentchain-frontend/src/pages/CommercialReadinessPage.test.tsx
@@ -1,0 +1,99 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import CommercialReadinessPage from "./CommercialReadinessPage";
+
+const mockFetchProfiles = vi.fn();
+const mockShowToast = vi.fn();
+
+vi.mock("@/api/commercialReadinessApi", () => ({
+  fetchCommercialReadinessProfiles: (...args: any[]) => mockFetchProfiles(...args),
+}));
+
+vi.mock("@/components/layout/MacShell", () => ({
+  MacShell: ({ children, title }: any) => <main aria-label={title}>{children}</main>,
+}));
+
+vi.mock("@/components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
+const profile = {
+  commercialReadinessId: "commercial_readiness:test",
+  status: "ready_for_review",
+  manualApprovalRequired: true,
+  autonomousBillingEnabled: false,
+  autonomousCommercializationEnabled: false,
+  publicSelfServiceEnabled: false,
+  generatedAt: "2026-05-07T00:00:00.000Z",
+  summary: {
+    totalReferences: 1,
+    verifiedReferences: 1,
+    partiallyVerifiedReferences: 0,
+    blockedReferences: 0,
+    unavailableReferences: 0,
+    restrictions: 0,
+  },
+  pricingReferences: [],
+  billingReferences: [],
+  subscriptionReferences: [],
+  onboardingReferences: [],
+  supportReferences: [],
+  operationalRiskReferences: [],
+  releaseReferences: [],
+  reviewReferences: [],
+  evidenceReferences: [],
+  auditReferences: [],
+  commercialRestrictions: [],
+  redactions: ["Payment credentials and subscription secrets are excluded."],
+  blockedReasons: [],
+  canonicalEvents: [],
+};
+
+describe("CommercialReadinessPage", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    mockFetchProfiles.mockResolvedValue([profile]);
+  });
+
+  it("loads and renders commercial readiness profiles with required safety copy", async () => {
+    render(
+      <MemoryRouter>
+        <CommercialReadinessPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Loading commercial readiness...")).toBeInTheDocument();
+    expect(await screen.findByText("Commercial summary")).toBeInTheDocument();
+    expect(screen.getAllByText(/Commercial readiness is operationally scoped and review controlled/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Manual approval remains required/i).length).toBeGreaterThan(0);
+    expect(mockFetchProfiles).toHaveBeenCalledWith({ status: "" });
+  });
+
+  it("filters readiness profiles by status", async () => {
+    render(
+      <MemoryRouter>
+        <CommercialReadinessPage />
+      </MemoryRouter>
+    );
+
+    fireEvent.change((await screen.findAllByLabelText("Status"))[0], { target: { value: "blocked" } });
+
+    await waitFor(() => {
+      expect(mockFetchProfiles).toHaveBeenLastCalledWith({ status: "blocked" });
+    });
+  });
+
+  it("renders the empty state", async () => {
+    mockFetchProfiles.mockResolvedValue([]);
+
+    render(
+      <MemoryRouter>
+        <CommercialReadinessPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("No commercial readiness profiles match these filters.")).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/CommercialReadinessPage.tsx
+++ b/rentchain-frontend/src/pages/CommercialReadinessPage.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { useSearchParams } from "react-router-dom";
+import {
+  fetchCommercialReadinessProfiles,
+  type CommercialReadinessProfile,
+  type CommercialReadinessStatus,
+} from "@/api/commercialReadinessApi";
+import { CommercialReadinessPanel } from "@/components/commercial/CommercialReadinessPanel";
+import { MacShell } from "@/components/layout/MacShell";
+import { Card, Section } from "@/components/ui/Ui";
+import { useToast } from "@/components/ui/ToastProvider";
+
+const statuses: Array<CommercialReadinessStatus | ""> = ["", "ready_for_review", "partially_ready", "review_required", "blocked", "unknown"];
+
+function label(value: string) {
+  return value ? value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase()) : "All";
+}
+
+export default function CommercialReadinessPage() {
+  const { showToast } = useToast();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [profiles, setProfiles] = React.useState<CommercialReadinessProfile[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const status = String(searchParams.get("status") || "") as CommercialReadinessStatus | "";
+
+  React.useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const next = await fetchCommercialReadinessProfiles({ status });
+        if (mounted) setProfiles(next);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Failed to load commercial readiness";
+        if (mounted) {
+          setError(message);
+          showToast({ message: "Failed to load commercial readiness", description: message, variant: "error" });
+        }
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [status, showToast]);
+
+  function updateStatus(value: string) {
+    const params = new URLSearchParams(searchParams);
+    if (value && value.trim()) params.set("status", value.trim());
+    else params.delete("status");
+    setSearchParams(params);
+  }
+
+  return (
+    <MacShell title="Commercial readiness" showTopNav={false}>
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "grid", gap: 6 }}>
+            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Commercial readiness</h1>
+            <div style={{ color: "#475569", maxWidth: 900 }}>
+              Commercial readiness is operationally scoped and review controlled. No autonomous billing, charging, or commercialization execution is enabled.
+              Manual approval remains required.
+            </div>
+          </div>
+        </Section>
+
+        <Section style={{ display: "flex", gap: 10, flexWrap: "wrap", alignItems: "end" }}>
+          <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Status
+            <select value={status} onChange={(event) => updateStatus(event.target.value)} style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 180 }}>
+              {statuses.map((item) => <option key={item || "all"} value={item}>{label(item)}</option>)}
+            </select>
+          </label>
+        </Section>
+
+        {loading ? <Card>Loading commercial readiness...</Card> : null}
+        {!loading && error ? <Card style={{ color: "#b91c1c" }}>We couldn't load commercial readiness right now.</Card> : null}
+        {!loading && !error && !profiles.length ? <Card style={{ color: "#64748b" }}>No commercial readiness profiles match these filters.</Card> : null}
+        {!loading && !error && profiles.length ? (
+          <div style={{ display: "grid", gap: 16 }}>{profiles.map((profile) => <CommercialReadinessPanel key={profile.commercialReadinessId} profile={profile} />)}</div>
+        ) : null}
+      </div>
+    </MacShell>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a deterministic commercial readiness read model for pricing, billing, subscription, onboarding, support, operational risk, release, evidence, review, and audit lineage.
- Adds admin-only read endpoints for commercial readiness profiles.
- Adds an admin UI surface for commercial readiness, commercialization restrictions, redactions, and review/evidence lineage.

## Guardrails
- Manual approval remains required.
- Autonomous billing, autonomous commercialization, and public self-service monetization are not enabled.
- No billing execution, customer charging, contract execution, customer billing messaging, onboarding execution, public monetization flow, or payment-provider execution path was added.
- Admin route responses use whitelist projections and exclude payment credentials, subscription secrets, customer financial histories, payment account details, private notes, and sensitive commercial payloads.

## Verification
- Backend targeted tests passed: `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm test -- --run src/lib/commercialReadiness/__tests__/deriveCommercialReadinessProfile.test.ts src/routes/__tests__/adminCommercialReadinessRoutes.test.ts`
- Frontend targeted tests passed: `npm test -- --run src/components/commercial/CommercialReadinessPanel.test.tsx src/pages/CommercialReadinessPage.test.tsx`
- Backend build passed: `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm run build`
- Frontend build passed with existing large chunk warning; new page is lazy-loaded as a small chunk: `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm run build`
- Diff whitespace check passed: `git diff --cached --check`
- Dependency/lockfile diff remained empty.