### PR TITLE
feat: add ecosystem coordination console

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -116,6 +116,7 @@ import adminReleaseGovernanceRoutes from "./routes/adminReleaseGovernanceRoutes"
 import adminPublicExposureHardeningRoutes from "./routes/adminPublicExposureHardeningRoutes";
 import adminCommercialReadinessRoutes from "./routes/adminCommercialReadinessRoutes";
 import adminControlledIntegrationsRoutes from "./routes/adminControlledIntegrationsRoutes";
+import adminEcosystemCoordinationRoutes from "./routes/adminEcosystemCoordinationRoutes";
 import portfolioScoreRoutes from "./routes/portfolioScoreRoutes";
 import portfolioScoreHistoryRoutes from "./routes/portfolioScoreHistoryRoutes";
 import landlordPortfolioHealthRoutes from "./routes/landlordPortfolioHealthRoutes";
@@ -296,6 +297,8 @@ app.use("/api/admin", routeSource("adminCommercialReadinessRoutes.ts"), adminCom
 console.log("[route-mount] adminCommercialReadinessRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("adminControlledIntegrationsRoutes.ts"), adminControlledIntegrationsRoutes);
 console.log("[route-mount] adminControlledIntegrationsRoutes mounted at /api/admin");
+app.use("/api/admin", routeSource("adminEcosystemCoordinationRoutes.ts"), adminEcosystemCoordinationRoutes);
+console.log("[route-mount] adminEcosystemCoordinationRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("portfolioScoreRoutes.ts"), portfolioScoreRoutes);
 console.log("[route-mount] portfolioScoreRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("portfolioScoreHistoryRoutes.ts"), portfolioScoreHistoryRoutes);

--- a/rentchain-api/src/lib/ecosystemCoordination/__tests__/deriveEcosystemCoordinationSnapshot.test.ts
+++ b/rentchain-api/src/lib/ecosystemCoordination/__tests__/deriveEcosystemCoordinationSnapshot.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import { deriveEcosystemCoordinationSnapshot } from "../deriveEcosystemCoordinationSnapshot";
+
+const completeInput = {
+  generatedAt: "2026-05-07T00:00:00.000Z",
+  networkParticipants: [{ participantId: "participant-1", status: "verified" }],
+  trustRelationships: [{ trustRelationshipId: "trust-1", status: "verified" }],
+  onboardingReadiness: [{ onboardingReadinessId: "onboarding-1", status: "ready_for_review" }],
+  operationalRiskProfiles: [{ operationalRiskId: "risk-1", status: "stable" }],
+  interoperabilityAdapterReadiness: [{ adapterReadinessId: "adapter-1", status: "ready_for_review" }],
+  controlledIntegrationProfiles: [{ controlledIntegrationId: "controlled-1", status: "sandbox_ready" }],
+  settlementReadiness: [{ settlementReadinessId: "settlement-1", status: "ready_for_review" }],
+  regulatoryProfiles: [{ regulatoryProfileId: "regulatory-1", status: "ready_for_review" }],
+  observabilityReadiness: [{ observabilityIncidentReadinessId: "observability-1", status: "ready_for_review" }],
+  releaseGovernanceProfiles: [{ releaseGovernanceId: "release-1", status: "ready_for_review" }],
+  publicExposureHardeningProfiles: [{ publicExposureHardeningId: "public-exposure-1", status: "ready_for_review" }],
+  commercialReadinessProfiles: [{ commercialReadinessId: "commercial-1", status: "ready_for_review" }],
+  evidencePacks: [{ evidencePackId: "evidence-1", status: "ready_for_review" }],
+  operatorReviewSessions: [{ reviewSessionId: "review-1", status: "completed" }],
+  auditEvents: [{ eventId: "audit-1", eventType: "ecosystem_coordination_snapshot_derived" }],
+};
+
+describe("deriveEcosystemCoordinationSnapshot", () => {
+  it("derives a deterministic stable snapshot with execution flags pinned off", () => {
+    const snapshot = deriveEcosystemCoordinationSnapshot(completeInput);
+    const repeat = deriveEcosystemCoordinationSnapshot(completeInput);
+
+    expect(snapshot).toEqual(repeat);
+    expect(snapshot.status).toBe("stable");
+    expect(snapshot).toEqual(
+      expect.objectContaining({
+        manualReviewRequired: true,
+        autonomousCoordinationEnabled: false,
+        externalExecutionEnabled: false,
+      })
+    );
+    expect(snapshot.summary).toEqual(
+      expect.objectContaining({
+        totalReferences: 15,
+        verifiedReferences: 15,
+        restrictions: 0,
+      })
+    );
+  });
+
+  it("aggregates blocked operational, integration, and regulatory restrictions", () => {
+    const snapshot = deriveEcosystemCoordinationSnapshot({
+      ...completeInput,
+      operationalRiskProfiles: [{ operationalRiskId: "risk-1", status: "blocked" }],
+      controlledIntegrationProfiles: [{ controlledIntegrationId: "controlled-1", status: "blocked" }],
+      regulatoryProfiles: [{ regulatoryProfileId: "regulatory-1", status: "blocked" }],
+    });
+
+    expect(snapshot.status).toBe("blocked");
+    expect(snapshot.ecosystemRestrictions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ restrictionType: "risk", status: "blocked" }),
+        expect.objectContaining({ restrictionType: "integration", status: "blocked" }),
+        expect.objectContaining({ restrictionType: "regulatory", status: "blocked" }),
+      ])
+    );
+    expect(snapshot.blockedReasons).toEqual(
+      expect.arrayContaining([
+        "Unresolved operational risk blocks ecosystem coordination.",
+        "Controlled integration readiness is blocked.",
+        "Regulatory restriction blocks ecosystem coordination.",
+      ])
+    );
+  });
+
+  it("requires review when critical observability, governance, review, or evidence lineage is missing", () => {
+    const snapshot = deriveEcosystemCoordinationSnapshot({
+      ...completeInput,
+      observabilityReadiness: [],
+      releaseGovernanceProfiles: [],
+      publicExposureHardeningProfiles: [],
+      commercialReadinessProfiles: [],
+      evidencePacks: [],
+      operatorReviewSessions: [],
+    });
+
+    expect(snapshot.status).toBe("review_required");
+    expect(snapshot.ecosystemRestrictions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ restrictionType: "observability", status: "review_required" }),
+        expect.objectContaining({ restrictionType: "governance", status: "review_required" }),
+        expect.objectContaining({ restrictionType: "evidence", status: "review_required" }),
+        expect.objectContaining({ restrictionType: "review", status: "review_required" }),
+      ])
+    );
+  });
+
+  it("marks incomplete onboarding readiness as attention required", () => {
+    const snapshot = deriveEcosystemCoordinationSnapshot({
+      ...completeInput,
+      onboardingReadiness: [{ onboardingReadinessId: "onboarding-1", status: "partially_ready" }],
+    });
+
+    expect(snapshot.status).toBe("attention_required");
+    expect(snapshot.ecosystemRestrictions).toEqual(
+      expect.arrayContaining([expect.objectContaining({ restrictionType: "onboarding", status: "review_required" })])
+    );
+  });
+
+  it("returns unknown when there is insufficient source context", () => {
+    const snapshot = deriveEcosystemCoordinationSnapshot({});
+
+    expect(snapshot.status).toBe("unknown");
+    expect(snapshot.summary.unavailableReferences).toBeGreaterThan(0);
+    expect(snapshot.canonicalEvents.map((event) => event.eventType)).toEqual(
+      expect.arrayContaining(["ecosystem_coordination_snapshot_derived", "ecosystem_coordination_redaction_applied"])
+    );
+  });
+
+  it("generates canonical events for restriction, review-required, blocked, and redaction paths", () => {
+    const blocked = deriveEcosystemCoordinationSnapshot({
+      ...completeInput,
+      regulatoryProfiles: [{ regulatoryProfileId: "regulatory-1", status: "blocked" }],
+    });
+
+    expect(blocked.canonicalEvents.map((event) => event.eventType)).toEqual(
+      expect.arrayContaining([
+        "ecosystem_coordination_snapshot_derived",
+        "ecosystem_coordination_redaction_applied",
+        "ecosystem_coordination_restriction_detected",
+        "ecosystem_coordination_blocked",
+      ])
+    );
+  });
+});

--- a/rentchain-api/src/lib/ecosystemCoordination/deriveEcosystemCoordinationSnapshot.ts
+++ b/rentchain-api/src/lib/ecosystemCoordination/deriveEcosystemCoordinationSnapshot.ts
@@ -1,0 +1,436 @@
+import type {
+  DeriveEcosystemCoordinationSnapshotInput,
+  EcosystemCoordinationCanonicalEvent,
+  EcosystemCoordinationReference,
+  EcosystemCoordinationReferenceStatus,
+  EcosystemCoordinationReferenceType,
+  EcosystemCoordinationSnapshot,
+  EcosystemCoordinationStatus,
+} from "./ecosystemCoordinationTypes";
+import { ecosystemIdPart, ecosystemReference, ecosystemRestriction } from "./ecosystemRestrictionModels";
+
+const DEFAULT_COORDINATION_KEY = "institutional-ecosystem-coordination-v1";
+
+const REDACTIONS = [
+  "Sensitive tenant, screening, private document, raw government ID, payment, banking, and settlement execution payloads are excluded.",
+  "Unrestricted operational telemetry, provider payloads, deployment execution, onboarding execution, payment execution, and external execution controls are excluded.",
+  "Ecosystem coordination is visibility metadata only; no autonomous orchestration, public networking, or external synchronization is enabled.",
+  "Private review notes, unrestricted audit histories, provider credentials, webhook secrets, and tokens are excluded.",
+];
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function asArray<T>(value: T[] | null | undefined): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function generatedAt(value: unknown): string {
+  const raw = asString(value, 120);
+  const date = raw ? new Date(raw) : new Date(0);
+  return Number.isNaN(date.getTime()) ? new Date(0).toISOString() : date.toISOString();
+}
+
+function recordId(record: Record<string, any>, keys: string[]): string {
+  for (const key of keys) {
+    const value = asString(record?.[key], 240);
+    if (value) return value;
+  }
+  return asString(record?.id, 240);
+}
+
+function referenceStatus(record: Record<string, any>, verifiedStatuses: string[]): EcosystemCoordinationReferenceStatus {
+  const status = asString(record?.status || record?.state || record?.conclusion, 80).toLowerCase();
+  if (status === "blocked" || status === "elevated" || status === "failure" || status === "failed" || status === "error" || status === "cancelled") return "blocked";
+  if (verifiedStatuses.includes(status)) return "verified";
+  if (status === "missing" || status === "unknown" || status === "unavailable" || status === "pending") return "unavailable";
+  return "partially_verified";
+}
+
+function statusForType(referenceType: EcosystemCoordinationReferenceType, record: Record<string, any>): EcosystemCoordinationReferenceStatus {
+  if (referenceType === "participant" || referenceType === "trust") return referenceStatus(record, ["verified"]);
+  if (referenceType === "risk") return referenceStatus(record, ["stable"]);
+  if (referenceType === "integration") return referenceStatus(record, ["ready_for_review", "sandbox_ready", "verified"]);
+  if (referenceType === "review") return referenceStatus(record, ["ready_for_review", "completed", "verified"]);
+  if (referenceType === "audit" && asString(record?.eventType, 120)) return "verified";
+  return referenceStatus(record, ["ready_for_review", "verified"]);
+}
+
+function statusFromReferences(hasContext: boolean, references: EcosystemCoordinationReference[]): EcosystemCoordinationStatus {
+  if (!hasContext) return "unknown";
+  if (references.some((reference) => reference.status === "blocked")) return "blocked";
+  const missingCritical = references.some(
+    (reference) =>
+      reference.status === "unavailable" &&
+      (reference.referenceType === "observability" ||
+        reference.referenceType === "governance" ||
+        reference.referenceType === "review" ||
+        reference.referenceType === "evidence" ||
+        reference.referenceType === "risk")
+  );
+  if (missingCritical) return "review_required";
+  if (references.some((reference) => reference.status === "unavailable" || reference.status === "partially_verified")) return "attention_required";
+  return "stable";
+}
+
+function event(input: {
+  eventType: EcosystemCoordinationCanonicalEvent["eventType"];
+  status: EcosystemCoordinationStatus;
+  ecosystemCoordinationId: string;
+  summary: string;
+}): EcosystemCoordinationCanonicalEvent {
+  return {
+    eventType: input.eventType,
+    action: input.eventType.replace(/^ecosystem_coordination_/, "").replace(/_/g, "."),
+    status: input.status,
+    resourceType: "ecosystem_coordination_snapshot",
+    resourceId: input.ecosystemCoordinationId,
+    summary: input.summary,
+  };
+}
+
+function referencesFor(input: {
+  records: Record<string, any>[];
+  fallback: string;
+  referenceType: EcosystemCoordinationReferenceType;
+  idKeys: string[];
+  label: string;
+  description: string;
+  destination: string;
+  blockedReason: string;
+}): EcosystemCoordinationReference[] {
+  if (!input.records.length) {
+    return [
+      ecosystemReference({
+        idParts: [input.referenceType, "missing"],
+        referenceType: input.referenceType,
+        status: "unavailable",
+        label: input.label,
+        description: `${input.description} is unavailable for ecosystem coordination review.`,
+        destination: input.destination,
+      }),
+    ];
+  }
+  return input.records.map((record, index) => {
+    const id = recordId(record, input.idKeys) || `${input.fallback}-${index + 1}`;
+    const status = statusForType(input.referenceType, record);
+    return ecosystemReference({
+      idParts: [input.referenceType, id],
+      referenceType: input.referenceType,
+      status,
+      label: input.label,
+      description: `${input.description} is available for ecosystem coordination review.`,
+      lineageReferences: [id].filter(Boolean),
+      destination: input.destination,
+      redacted: Boolean(record.redacted),
+      redactionReason: record.redacted ? `${input.label} payload is redacted for ecosystem coordination safety.` : null,
+      blockedReason: status === "blocked" ? input.blockedReason : null,
+    });
+  });
+}
+
+export function deriveEcosystemCoordinationSnapshot(input: DeriveEcosystemCoordinationSnapshotInput): EcosystemCoordinationSnapshot {
+  const coordinationKey = asString(input.coordinationKey, 160) || DEFAULT_COORDINATION_KEY;
+  const ecosystemCoordinationId =
+    ecosystemIdPart(["ecosystem_coordination", coordinationKey].join(":")) || "ecosystem_coordination:unknown";
+
+  const networkParticipants = asArray(input.networkParticipants);
+  const trustRelationships = asArray(input.trustRelationships);
+  const onboardingReadiness = asArray(input.onboardingReadiness);
+  const operationalRiskProfiles = asArray(input.operationalRiskProfiles);
+  const interoperabilityAdapterReadiness = asArray(input.interoperabilityAdapterReadiness);
+  const controlledIntegrationProfiles = asArray(input.controlledIntegrationProfiles);
+  const settlementReadiness = asArray(input.settlementReadiness);
+  const regulatoryProfiles = asArray(input.regulatoryProfiles);
+  const observabilityReadiness = asArray(input.observabilityReadiness);
+  const releaseGovernanceProfiles = asArray(input.releaseGovernanceProfiles);
+  const publicExposureHardeningProfiles = asArray(input.publicExposureHardeningProfiles);
+  const commercialReadinessProfiles = asArray(input.commercialReadinessProfiles);
+  const evidencePacks = asArray(input.evidencePacks);
+  const reviews = asArray(input.operatorReviewSessions);
+  const auditEvents = asArray(input.auditEvents);
+
+  const participantReferences = referencesFor({
+    records: networkParticipants,
+    fallback: "participant",
+    referenceType: "participant",
+    idKeys: ["participantId", "id"],
+    label: "Network participant reference",
+    description: "Network participant profile metadata",
+    destination: "/network-participants",
+    blockedReason: "Network participant profile is blocked.",
+  });
+  const trustReferences = referencesFor({
+    records: trustRelationships,
+    fallback: "trust",
+    referenceType: "trust",
+    idKeys: ["trustRelationshipId", "id"],
+    label: "Cross-organization trust reference",
+    description: "Cross-organization trust metadata",
+    destination: "/cross-organization-trust",
+    blockedReason: "Cross-organization trust relationship is blocked.",
+  });
+  const onboardingReferences = referencesFor({
+    records: onboardingReadiness,
+    fallback: "onboarding",
+    referenceType: "onboarding",
+    idKeys: ["onboardingReadinessId", "id"],
+    label: "Institution onboarding readiness reference",
+    description: "Institution onboarding readiness metadata",
+    destination: "/institution-onboarding-readiness",
+    blockedReason: "Institution onboarding readiness is blocked.",
+  });
+  const riskReferences = referencesFor({
+    records: operationalRiskProfiles,
+    fallback: "risk",
+    referenceType: "risk",
+    idKeys: ["operationalRiskId", "id"],
+    label: "Operational risk reference",
+    description: "Operational risk metadata",
+    destination: "/operational-risk",
+    blockedReason: "Unresolved operational risk blocks ecosystem coordination.",
+  });
+  const integrationReferences = [
+    ...referencesFor({
+      records: interoperabilityAdapterReadiness,
+      fallback: "interoperability",
+      referenceType: "integration",
+      idKeys: ["adapterReadinessId", "id"],
+      label: "Interoperability readiness reference",
+      description: "Interoperability readiness metadata",
+      destination: "/interoperability-adapters",
+      blockedReason: "Interoperability readiness is blocked.",
+    }),
+    ...referencesFor({
+      records: controlledIntegrationProfiles,
+      fallback: "controlled-integration",
+      referenceType: "integration",
+      idKeys: ["controlledIntegrationId", "id"],
+      label: "Controlled integration readiness reference",
+      description: "Controlled integration readiness metadata",
+      destination: "/admin/controlled-integrations",
+      blockedReason: "Controlled integration readiness is blocked.",
+    }),
+  ];
+  const settlementReferences = referencesFor({
+    records: settlementReadiness,
+    fallback: "settlement",
+    referenceType: "settlement",
+    idKeys: ["settlementReadinessId", "id"],
+    label: "Settlement readiness reference",
+    description: "Settlement readiness metadata",
+    destination: "/settlement-readiness",
+    blockedReason: "Settlement readiness is blocked.",
+  });
+  const regulatoryReferences = referencesFor({
+    records: regulatoryProfiles,
+    fallback: "regulatory",
+    referenceType: "regulatory",
+    idKeys: ["regulatoryProfileId", "id"],
+    label: "Regulatory profile reference",
+    description: "Regulatory profile metadata",
+    destination: "/regulatory-profiles",
+    blockedReason: "Regulatory restriction blocks ecosystem coordination.",
+  });
+  const observabilityReferences = referencesFor({
+    records: observabilityReadiness,
+    fallback: "observability",
+    referenceType: "observability",
+    idKeys: ["observabilityIncidentReadinessId", "id"],
+    label: "Observability readiness reference",
+    description: "Observability and incident readiness metadata",
+    destination: "/admin/observability-incident-readiness",
+    blockedReason: "Observability readiness is blocked.",
+  });
+  const governanceReferences = [
+    ...referencesFor({
+      records: releaseGovernanceProfiles,
+      fallback: "release-governance",
+      referenceType: "governance",
+      idKeys: ["releaseGovernanceId", "releaseVersion", "id"],
+      label: "Release governance reference",
+      description: "Release governance metadata",
+      destination: "/admin/release-governance",
+      blockedReason: "Release governance is blocked.",
+    }),
+    ...referencesFor({
+      records: publicExposureHardeningProfiles,
+      fallback: "public-exposure",
+      referenceType: "governance",
+      idKeys: ["publicExposureHardeningId", "id"],
+      label: "Public exposure hardening reference",
+      description: "Public exposure hardening metadata",
+      destination: "/admin/public-exposure-hardening",
+      blockedReason: "Public exposure hardening is blocked.",
+    }),
+    ...referencesFor({
+      records: commercialReadinessProfiles,
+      fallback: "commercial-readiness",
+      referenceType: "governance",
+      idKeys: ["commercialReadinessId", "id"],
+      label: "Commercial readiness reference",
+      description: "Commercial readiness metadata",
+      destination: "/admin/commercial-readiness",
+      blockedReason: "Commercial readiness is blocked.",
+    }),
+  ];
+  const evidenceReferences = referencesFor({
+    records: evidencePacks,
+    fallback: "evidence",
+    referenceType: "evidence",
+    idKeys: ["evidencePackId", "id"],
+    label: "Evidence lineage reference",
+    description: "Evidence lineage metadata",
+    destination: "/evidence-packs",
+    blockedReason: "Evidence lineage is blocked.",
+  });
+  const reviewReferences = referencesFor({
+    records: reviews,
+    fallback: "review",
+    referenceType: "review",
+    idKeys: ["reviewSessionId", "id"],
+    label: "Review lineage reference",
+    description: "Operator review lineage metadata",
+    destination: "/review-timeline",
+    blockedReason: "Review lineage is blocked.",
+  });
+  const auditReferences = referencesFor({
+    records: auditEvents.slice(0, 20),
+    fallback: "audit",
+    referenceType: "audit",
+    idKeys: ["eventId", "id"],
+    label: "Audit lineage reference",
+    description: "Canonical audit event metadata",
+    destination: "/review-timeline",
+    blockedReason: "Audit lineage is blocked.",
+  });
+
+  const allReferences = [
+    ...participantReferences,
+    ...trustReferences,
+    ...onboardingReferences,
+    ...riskReferences,
+    ...integrationReferences,
+    ...settlementReferences,
+    ...regulatoryReferences,
+    ...observabilityReferences,
+    ...governanceReferences,
+    ...evidenceReferences,
+    ...reviewReferences,
+    ...auditReferences,
+  ];
+
+  const ecosystemRestrictions = allReferences
+    .filter((reference) => reference.status !== "verified")
+    .map((reference) =>
+      ecosystemRestriction({
+        idParts: [reference.referenceType, reference.referenceId],
+        restrictionType: reference.referenceType,
+        status: reference.status === "blocked" ? "blocked" : "review_required",
+        label: `${reference.label} restriction`,
+        description: `${reference.label} is incomplete or blocked for ecosystem coordination.`,
+        blockedReason: reference.blockedReason,
+      })
+    );
+
+  const hasContext = Boolean(
+    networkParticipants.length ||
+      trustRelationships.length ||
+      onboardingReadiness.length ||
+      operationalRiskProfiles.length ||
+      interoperabilityAdapterReadiness.length ||
+      controlledIntegrationProfiles.length ||
+      settlementReadiness.length ||
+      regulatoryProfiles.length ||
+      observabilityReadiness.length ||
+      releaseGovernanceProfiles.length ||
+      publicExposureHardeningProfiles.length ||
+      commercialReadinessProfiles.length ||
+      evidencePacks.length ||
+      reviews.length ||
+      auditEvents.length
+  );
+  const status = statusFromReferences(hasContext, allReferences);
+  const blockedReasons = [...allReferences.map((reference) => reference.blockedReason), ...ecosystemRestrictions.map((restriction) => restriction.blockedReason)].filter(Boolean) as string[];
+
+  const canonicalEvents: EcosystemCoordinationCanonicalEvent[] = [
+    event({
+      eventType: "ecosystem_coordination_snapshot_derived",
+      status,
+      ecosystemCoordinationId,
+      summary:
+        "Ecosystem coordination snapshot derived from participant, trust, onboarding, risk, integration, settlement, regulatory, observability, governance, evidence, review, and audit metadata.",
+    }),
+    event({
+      eventType: "ecosystem_coordination_redaction_applied",
+      status,
+      ecosystemCoordinationId,
+      summary:
+        "Sensitive tenant, raw government ID, payment, banking, unrestricted telemetry, deployment, onboarding, orchestration, and external execution payloads were excluded.",
+    }),
+  ];
+  if (ecosystemRestrictions.length) {
+    canonicalEvents.push(
+      event({
+        eventType: "ecosystem_coordination_restriction_detected",
+        status,
+        ecosystemCoordinationId,
+        summary: "Ecosystem restrictions are visible for manual governance review.",
+      })
+    );
+  }
+  if (status === "review_required" || status === "attention_required") {
+    canonicalEvents.push(
+      event({
+        eventType: "ecosystem_coordination_review_required",
+        status,
+        ecosystemCoordinationId,
+        summary: "Manual ecosystem coordination review is required.",
+      })
+    );
+  }
+  if (status === "blocked") {
+    canonicalEvents.push(
+      event({
+        eventType: "ecosystem_coordination_blocked",
+        status,
+        ecosystemCoordinationId,
+        summary: "Ecosystem coordination is blocked by unresolved restrictions.",
+      })
+    );
+  }
+
+  return {
+    ecosystemCoordinationId,
+    status,
+    manualReviewRequired: true,
+    autonomousCoordinationEnabled: false,
+    externalExecutionEnabled: false,
+    generatedAt: generatedAt(input.generatedAt),
+    summary: {
+      totalReferences: allReferences.length,
+      verifiedReferences: allReferences.filter((reference) => reference.status === "verified").length,
+      partiallyVerifiedReferences: allReferences.filter((reference) => reference.status === "partially_verified").length,
+      blockedReferences: allReferences.filter((reference) => reference.status === "blocked").length,
+      unavailableReferences: allReferences.filter((reference) => reference.status === "unavailable").length,
+      restrictions: ecosystemRestrictions.length,
+    },
+    participantReferences,
+    trustReferences,
+    onboardingReferences,
+    riskReferences,
+    integrationReferences,
+    settlementReferences,
+    regulatoryReferences,
+    observabilityReferences,
+    governanceReferences,
+    reviewReferences,
+    evidenceReferences,
+    auditReferences,
+    ecosystemRestrictions,
+    redactions: REDACTIONS,
+    blockedReasons,
+    canonicalEvents,
+  };
+}

--- a/rentchain-api/src/lib/ecosystemCoordination/ecosystemCoordinationTypes.ts
+++ b/rentchain-api/src/lib/ecosystemCoordination/ecosystemCoordinationTypes.ts
@@ -1,0 +1,109 @@
+export type EcosystemCoordinationStatus = "stable" | "attention_required" | "review_required" | "blocked" | "unknown";
+
+export type EcosystemCoordinationReferenceType =
+  | "participant"
+  | "trust"
+  | "onboarding"
+  | "risk"
+  | "integration"
+  | "settlement"
+  | "regulatory"
+  | "observability"
+  | "governance"
+  | "evidence"
+  | "review"
+  | "audit";
+
+export type EcosystemCoordinationReferenceStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+
+export type EcosystemCoordinationCanonicalEventType =
+  | "ecosystem_coordination_snapshot_derived"
+  | "ecosystem_coordination_review_required"
+  | "ecosystem_coordination_blocked"
+  | "ecosystem_coordination_restriction_detected"
+  | "ecosystem_coordination_redaction_applied";
+
+export type EcosystemCoordinationReference = {
+  referenceId: string;
+  referenceType: EcosystemCoordinationReferenceType;
+  status: EcosystemCoordinationReferenceStatus;
+  label: string;
+  description: string;
+  reviewRequired: true;
+  lineageReferences: string[];
+  destination: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type EcosystemRestriction = {
+  restrictionId: string;
+  restrictionType: EcosystemCoordinationReferenceType | "orchestration" | "external_execution" | "public_networking";
+  status: "visible" | "blocked" | "review_required";
+  label: string;
+  description: string;
+  blockedReason: string | null;
+};
+
+export type EcosystemCoordinationCanonicalEvent = {
+  eventType: EcosystemCoordinationCanonicalEventType;
+  action: string;
+  status: EcosystemCoordinationStatus;
+  resourceType: "ecosystem_coordination_snapshot";
+  resourceId: string;
+  summary: string;
+};
+
+export type EcosystemCoordinationSnapshot = {
+  ecosystemCoordinationId: string;
+  status: EcosystemCoordinationStatus;
+  manualReviewRequired: true;
+  autonomousCoordinationEnabled: false;
+  externalExecutionEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    partiallyVerifiedReferences: number;
+    blockedReferences: number;
+    unavailableReferences: number;
+    restrictions: number;
+  };
+  participantReferences: EcosystemCoordinationReference[];
+  trustReferences: EcosystemCoordinationReference[];
+  onboardingReferences: EcosystemCoordinationReference[];
+  riskReferences: EcosystemCoordinationReference[];
+  integrationReferences: EcosystemCoordinationReference[];
+  settlementReferences: EcosystemCoordinationReference[];
+  regulatoryReferences: EcosystemCoordinationReference[];
+  observabilityReferences: EcosystemCoordinationReference[];
+  governanceReferences: EcosystemCoordinationReference[];
+  reviewReferences: EcosystemCoordinationReference[];
+  evidenceReferences: EcosystemCoordinationReference[];
+  auditReferences: EcosystemCoordinationReference[];
+  ecosystemRestrictions: EcosystemRestriction[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: EcosystemCoordinationCanonicalEvent[];
+};
+
+export type DeriveEcosystemCoordinationSnapshotInput = {
+  coordinationKey?: unknown;
+  generatedAt?: unknown;
+  networkParticipants?: Array<Record<string, any>> | null;
+  trustRelationships?: Array<Record<string, any>> | null;
+  onboardingReadiness?: Array<Record<string, any>> | null;
+  operationalRiskProfiles?: Array<Record<string, any>> | null;
+  interoperabilityAdapterReadiness?: Array<Record<string, any>> | null;
+  controlledIntegrationProfiles?: Array<Record<string, any>> | null;
+  settlementReadiness?: Array<Record<string, any>> | null;
+  regulatoryProfiles?: Array<Record<string, any>> | null;
+  observabilityReadiness?: Array<Record<string, any>> | null;
+  releaseGovernanceProfiles?: Array<Record<string, any>> | null;
+  publicExposureHardeningProfiles?: Array<Record<string, any>> | null;
+  commercialReadinessProfiles?: Array<Record<string, any>> | null;
+  evidencePacks?: Array<Record<string, any>> | null;
+  operatorReviewSessions?: Array<Record<string, any>> | null;
+  auditEvents?: Array<Record<string, any>> | null;
+};

--- a/rentchain-api/src/lib/ecosystemCoordination/ecosystemRestrictionModels.ts
+++ b/rentchain-api/src/lib/ecosystemCoordination/ecosystemRestrictionModels.ts
@@ -1,0 +1,63 @@
+import type {
+  EcosystemCoordinationReference,
+  EcosystemCoordinationReferenceStatus,
+  EcosystemCoordinationReferenceType,
+  EcosystemRestriction,
+} from "./ecosystemCoordinationTypes";
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+export function ecosystemIdPart(value: unknown): string {
+  return asString(value, 500)
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+export function ecosystemReference(input: {
+  idParts: unknown[];
+  referenceType: EcosystemCoordinationReferenceType;
+  status: EcosystemCoordinationReferenceStatus;
+  label: string;
+  description: string;
+  lineageReferences?: string[];
+  destination?: string | null;
+  redacted?: boolean;
+  redactionReason?: string | null;
+  blockedReason?: string | null;
+}): EcosystemCoordinationReference {
+  return {
+    referenceId: ecosystemIdPart(input.idParts.join(":")) || "ecosystem_reference:unknown",
+    referenceType: input.referenceType,
+    status: input.status,
+    label: input.label,
+    description: input.description,
+    reviewRequired: true,
+    lineageReferences: Array.from(new Set(input.lineageReferences || [])).filter(Boolean),
+    destination: input.destination || null,
+    redacted: Boolean(input.redacted),
+    redactionReason: input.redactionReason || null,
+    blockedReason: input.blockedReason || null,
+  };
+}
+
+export function ecosystemRestriction(input: {
+  idParts: unknown[];
+  restrictionType: EcosystemRestriction["restrictionType"];
+  status: EcosystemRestriction["status"];
+  label: string;
+  description: string;
+  blockedReason?: string | null;
+}): EcosystemRestriction {
+  return {
+    restrictionId: ecosystemIdPart(input.idParts.join(":")) || "ecosystem_restriction:unknown",
+    restrictionType: input.restrictionType,
+    status: input.status,
+    label: input.label,
+    description: input.description,
+    blockedReason: input.blockedReason || null,
+  };
+}

--- a/rentchain-api/src/routes/__tests__/adminEcosystemCoordinationRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/adminEcosystemCoordinationRoutes.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+  return {
+    resetFakeDb: () => store.clear(),
+    seedDoc: (collection: string, id: string, data: any) => ensureCollection(collection).set(id, { id, data }),
+    fakeDb: {
+      collection: (name: string) => ({
+        get: async () => {
+          const docs = Array.from(ensureCollection(name).values()).map((doc) => ({ id: doc.id, exists: true, data: () => doc.data }));
+          return { docs, empty: docs.length === 0, size: docs.length };
+        },
+      }),
+    },
+  };
+});
+
+let mockUser: any;
+
+vi.mock("../../config/firebase", () => ({ db: fakeDb }));
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!mockUser) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    req.user = mockUser;
+    return next();
+  },
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; user?: Record<string, unknown> | null }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    mockUser = options.user ?? mockUser;
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: mockUser,
+      query: Object.fromEntries(new URLSearchParams(queryString || "").entries()),
+      params: {},
+      headers: {},
+    };
+    const match = path.match(/^\/ecosystem-coordination\/(.+)$/);
+    if (match) req.params = { ecosystemCoordinationId: decodeURIComponent(match[1]) };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => (error ? reject(error) : undefined));
+  });
+}
+
+describe("adminEcosystemCoordinationRoutes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    resetFakeDb();
+    mockUser = { id: "admin-1", role: "admin", permissions: ["system.admin"] };
+  });
+
+  function seedReadinessContext() {
+    seedDoc("networkParticipantProfiles", "participant-1", { participantId: "participant-1", status: "verified", rawGovernmentId: "hidden" });
+    seedDoc("crossOrganizationTrustRelationships", "trust-1", { trustRelationshipId: "trust-1", status: "verified", privateTrustNote: "hidden" });
+    seedDoc("institutionOnboardingReadiness", "onboarding-1", { onboardingReadinessId: "onboarding-1", status: "ready_for_review", privateTenantData: "hidden" });
+    seedDoc("operationalRiskProfiles", "risk-1", { operationalRiskId: "risk-1", status: "stable", rawTelemetry: "hidden" });
+    seedDoc("interoperabilityAdapterReadiness", "adapter-1", { adapterReadinessId: "adapter-1", status: "ready_for_review", providerSecret: "hidden" });
+    seedDoc("controlledIntegrationProfiles", "controlled-1", { controlledIntegrationId: "controlled-1", status: "sandbox_ready", webhookSecret: "hidden" });
+    seedDoc("settlementReadiness", "settlement-1", { settlementReadinessId: "settlement-1", status: "ready_for_review", bankingPayload: "hidden" });
+    seedDoc("regulatoryProfiles", "regulatory-1", { regulatoryProfileId: "regulatory-1", status: "ready_for_review", governmentId: "hidden" });
+    seedDoc("observabilityIncidentReadinessProfiles", "observability-1", { observabilityIncidentReadinessId: "observability-1", status: "ready_for_review", unrestrictedTelemetry: "hidden" });
+    seedDoc("releaseGovernanceProfiles", "release-1", { releaseGovernanceId: "release-1", status: "ready_for_review", deployToken: "hidden" });
+    seedDoc("publicExposureHardeningProfiles", "public-exposure-1", { publicExposureHardeningId: "public-exposure-1", status: "ready_for_review" });
+    seedDoc("commercialReadinessProfiles", "commercial-1", { commercialReadinessId: "commercial-1", status: "ready_for_review" });
+    seedDoc("evidencePacks", "evidence-1", { evidencePackId: "evidence-1", status: "ready_for_review", rawPaymentPayload: "hidden" });
+    seedDoc("operatorReviewSessions", "review-1", { reviewSessionId: "review-1", status: "completed", privateNote: "hidden" });
+    seedDoc("events", "event-1", { eventId: "event-1", eventType: "ecosystem_coordination_snapshot_derived", rawAuditPayload: "hidden" });
+  }
+
+  it("returns admin-gated ecosystem coordination snapshots without sensitive ecosystem payloads", async () => {
+    seedReadinessContext();
+    const router = (await import("../adminEcosystemCoordinationRoutes")).default;
+
+    const forbidden = await invokeRouter(router, {
+      method: "GET",
+      url: "/ecosystem-coordination",
+      user: { id: "landlord-1", role: "landlord", permissions: [] },
+    });
+    expect(forbidden.status).toBe(403);
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/ecosystem-coordination",
+      user: { id: "admin-1", role: "admin", permissions: ["system.admin"] },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.snapshots).toHaveLength(1);
+    expect(res.body.snapshots[0]).toEqual(
+      expect.objectContaining({
+        manualReviewRequired: true,
+        autonomousCoordinationEnabled: false,
+        externalExecutionEnabled: false,
+      })
+    );
+    expect(JSON.stringify(res.body)).not.toContain("rawGovernmentId");
+    expect(JSON.stringify(res.body)).not.toContain("privateTenantData");
+    expect(JSON.stringify(res.body)).not.toContain("rawTelemetry");
+    expect(JSON.stringify(res.body)).not.toContain("providerSecret");
+    expect(JSON.stringify(res.body)).not.toContain("webhookSecret");
+    expect(JSON.stringify(res.body)).not.toContain("bankingPayload");
+    expect(JSON.stringify(res.body)).not.toContain("rawPaymentPayload");
+    expect(JSON.stringify(res.body)).not.toContain("privateNote");
+  });
+
+  it("returns a single ecosystem coordination snapshot by id", async () => {
+    seedReadinessContext();
+    const router = (await import("../adminEcosystemCoordinationRoutes")).default;
+    const list = await invokeRouter(router, { method: "GET", url: "/ecosystem-coordination" });
+    const id = list.body.snapshots[0].ecosystemCoordinationId;
+
+    const res = await invokeRouter(router, { method: "GET", url: `/ecosystem-coordination/${encodeURIComponent(id)}` });
+
+    expect(res.status).toBe(200);
+    expect(res.body.snapshot.ecosystemCoordinationId).toBe(id);
+  });
+
+  it("filters by status", async () => {
+    seedReadinessContext();
+    const router = (await import("../adminEcosystemCoordinationRoutes")).default;
+
+    const filtered = await invokeRouter(router, { method: "GET", url: "/ecosystem-coordination?status=blocked" });
+
+    expect(filtered.status).toBe(200);
+    expect(filtered.body.snapshots).toEqual([]);
+  });
+});

--- a/rentchain-api/src/routes/adminEcosystemCoordinationRoutes.ts
+++ b/rentchain-api/src/routes/adminEcosystemCoordinationRoutes.ts
@@ -1,0 +1,150 @@
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { requireAuth } from "../middleware/requireAuth";
+import { requirePermission } from "../middleware/requireAuthz";
+import { deriveEcosystemCoordinationSnapshot } from "../lib/ecosystemCoordination/deriveEcosystemCoordinationSnapshot";
+import type { EcosystemCoordinationSnapshot, EcosystemCoordinationStatus } from "../lib/ecosystemCoordination/ecosystemCoordinationTypes";
+
+const router = Router();
+
+const COORDINATION_KEY = "institutional-ecosystem-coordination-v1";
+const STATUSES = new Set<EcosystemCoordinationStatus>(["stable", "attention_required", "review_required", "blocked", "unknown"]);
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+async function loadCollection(collectionName: string, limit = 25) {
+  const snap = await db.collection(collectionName).get().catch(() => null);
+  return (snap?.docs || []).slice(0, limit).map((doc) => sanitizeRecord({ id: doc.id, ...((doc.data() as any) || {}) }));
+}
+
+function sanitizeRecord(record: Record<string, any>) {
+  const safe: Record<string, any> = {};
+  for (const key of [
+    "id",
+    "status",
+    "state",
+    "conclusion",
+    "participantId",
+    "participantType",
+    "trustRelationshipId",
+    "relationshipType",
+    "onboardingReadinessId",
+    "institutionType",
+    "operationalRiskId",
+    "riskScope",
+    "adapterReadinessId",
+    "adapterType",
+    "controlledIntegrationId",
+    "integrationType",
+    "settlementReadinessId",
+    "regulatoryProfileId",
+    "observabilityIncidentReadinessId",
+    "releaseGovernanceId",
+    "releaseVersion",
+    "publicExposureHardeningId",
+    "commercialReadinessId",
+    "evidencePackId",
+    "reviewSessionId",
+    "eventId",
+    "eventType",
+    "resourceType",
+    "resourceId",
+    "createdAt",
+    "updatedAt",
+    "redacted",
+  ]) {
+    if (record[key] !== undefined) safe[key] = record[key];
+  }
+  return safe;
+}
+
+async function buildEcosystemCoordinationSnapshots(): Promise<EcosystemCoordinationSnapshot[]> {
+  const [
+    networkParticipants,
+    trustRelationships,
+    onboardingReadiness,
+    operationalRiskProfiles,
+    interoperabilityAdapterReadiness,
+    controlledIntegrationProfiles,
+    settlementReadiness,
+    regulatoryProfiles,
+    observabilityReadiness,
+    releaseGovernanceProfiles,
+    publicExposureHardeningProfiles,
+    commercialReadinessProfiles,
+    evidencePacks,
+    reviews,
+    auditEvents,
+  ] = await Promise.all([
+    loadCollection("networkParticipantProfiles"),
+    loadCollection("crossOrganizationTrustRelationships"),
+    loadCollection("institutionOnboardingReadiness"),
+    loadCollection("operationalRiskProfiles"),
+    loadCollection("interoperabilityAdapterReadiness"),
+    loadCollection("controlledIntegrationProfiles"),
+    loadCollection("settlementReadiness"),
+    loadCollection("regulatoryProfiles"),
+    loadCollection("observabilityIncidentReadinessProfiles"),
+    loadCollection("releaseGovernanceProfiles"),
+    loadCollection("publicExposureHardeningProfiles"),
+    loadCollection("commercialReadinessProfiles"),
+    loadCollection("evidencePacks"),
+    loadCollection("operatorReviewSessions"),
+    loadCollection("events"),
+  ]);
+
+  return [
+    deriveEcosystemCoordinationSnapshot({
+      coordinationKey: COORDINATION_KEY,
+      networkParticipants,
+      trustRelationships,
+      onboardingReadiness,
+      operationalRiskProfiles,
+      interoperabilityAdapterReadiness,
+      controlledIntegrationProfiles,
+      settlementReadiness,
+      regulatoryProfiles,
+      observabilityReadiness,
+      releaseGovernanceProfiles,
+      publicExposureHardeningProfiles,
+      commercialReadinessProfiles,
+      evidencePacks,
+      operatorReviewSessions: reviews,
+      auditEvents,
+    }),
+  ];
+}
+
+function snapshotMatches(snapshot: EcosystemCoordinationSnapshot, id: string) {
+  return snapshot.ecosystemCoordinationId === id;
+}
+
+router.get("/ecosystem-coordination", requireAuth, requirePermission("system.admin"), async (req: any, res) => {
+  try {
+    const status = asString(req.query?.status, 80) as EcosystemCoordinationStatus;
+    let snapshots = await buildEcosystemCoordinationSnapshots();
+    if (status && STATUSES.has(status)) snapshots = snapshots.filter((snapshot) => snapshot.status === status);
+    return res.json({ ok: true, snapshots });
+  } catch (err: any) {
+    console.error("[admin-ecosystem-coordination] list failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "ECOSYSTEM_COORDINATION_FAILED" });
+  }
+});
+
+router.get("/ecosystem-coordination/:ecosystemCoordinationId", requireAuth, requirePermission("system.admin"), async (req: any, res) => {
+  try {
+    const ecosystemCoordinationId = decodeURIComponent(asString(req.params?.ecosystemCoordinationId, 500));
+    if (!ecosystemCoordinationId) return res.status(400).json({ ok: false, error: "ECOSYSTEM_COORDINATION_ID_REQUIRED" });
+    const snapshots = await buildEcosystemCoordinationSnapshots();
+    const snapshot = snapshots.find((next) => snapshotMatches(next, ecosystemCoordinationId));
+    if (!snapshot) return res.status(404).json({ ok: false, error: "ECOSYSTEM_COORDINATION_NOT_FOUND" });
+    return res.json({ ok: true, snapshot });
+  } catch (err: any) {
+    console.error("[admin-ecosystem-coordination] get failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "ECOSYSTEM_COORDINATION_GET_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -116,6 +116,7 @@ const ReleaseGovernancePage = lazy(() => import("./pages/ReleaseGovernancePage")
 const PublicExposureHardeningPage = lazy(() => import("./pages/PublicExposureHardeningPage"));
 const CommercialReadinessPage = lazy(() => import("./pages/CommercialReadinessPage"));
 const ControlledIntegrationsPage = lazy(() => import("./pages/ControlledIntegrationsPage"));
+const EcosystemCoordinationPage = lazy(() => import("./pages/EcosystemCoordinationPage"));
 const PortfolioScorePage = lazy(() => import("./pages/admin/PortfolioScorePage"));
 const PortfolioScoreHistoryPage = lazy(() => import("./pages/admin/PortfolioScoreHistoryPage"));
 const PortfolioHealthSummaryPage = lazy(() => import("./pages/landlord/PortfolioHealthSummaryPage"));
@@ -1322,6 +1323,14 @@ function App() {
               element={
                 <RequireAdmin>
                   <ControlledIntegrationsPage />
+                </RequireAdmin>
+              }
+            />
+            <Route
+              path="/admin/ecosystem-coordination"
+              element={
+                <RequireAdmin>
+                  <EcosystemCoordinationPage />
                 </RequireAdmin>
               }
             />

--- a/rentchain-frontend/src/api/ecosystemCoordinationApi.ts
+++ b/rentchain-frontend/src/api/ecosystemCoordinationApi.ts
@@ -1,0 +1,90 @@
+import { apiFetch } from "./apiFetch";
+
+export type EcosystemCoordinationStatus = "stable" | "attention_required" | "review_required" | "blocked" | "unknown";
+export type EcosystemCoordinationReferenceType =
+  | "participant"
+  | "trust"
+  | "onboarding"
+  | "risk"
+  | "integration"
+  | "settlement"
+  | "regulatory"
+  | "observability"
+  | "governance"
+  | "evidence"
+  | "review"
+  | "audit";
+export type EcosystemCoordinationReferenceStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+
+export type EcosystemCoordinationReference = {
+  referenceId: string;
+  referenceType: EcosystemCoordinationReferenceType;
+  status: EcosystemCoordinationReferenceStatus;
+  label: string;
+  description: string;
+  reviewRequired: true;
+  lineageReferences: string[];
+  destination: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type EcosystemRestriction = {
+  restrictionId: string;
+  restrictionType: EcosystemCoordinationReferenceType | "orchestration" | "external_execution" | "public_networking";
+  status: "visible" | "blocked" | "review_required";
+  label: string;
+  description: string;
+  blockedReason: string | null;
+};
+
+export type EcosystemCoordinationSnapshot = {
+  ecosystemCoordinationId: string;
+  status: EcosystemCoordinationStatus;
+  manualReviewRequired: true;
+  autonomousCoordinationEnabled: false;
+  externalExecutionEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    partiallyVerifiedReferences: number;
+    blockedReferences: number;
+    unavailableReferences: number;
+    restrictions: number;
+  };
+  participantReferences: EcosystemCoordinationReference[];
+  trustReferences: EcosystemCoordinationReference[];
+  onboardingReferences: EcosystemCoordinationReference[];
+  riskReferences: EcosystemCoordinationReference[];
+  integrationReferences: EcosystemCoordinationReference[];
+  settlementReferences: EcosystemCoordinationReference[];
+  regulatoryReferences: EcosystemCoordinationReference[];
+  observabilityReferences: EcosystemCoordinationReference[];
+  governanceReferences: EcosystemCoordinationReference[];
+  reviewReferences: EcosystemCoordinationReference[];
+  evidenceReferences: EcosystemCoordinationReference[];
+  auditReferences: EcosystemCoordinationReference[];
+  ecosystemRestrictions: EcosystemRestriction[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: Array<{ eventType: string; action: string; status: EcosystemCoordinationStatus; resourceId: string; summary: string }>;
+};
+
+export async function fetchEcosystemCoordinationSnapshots(params?: {
+  status?: EcosystemCoordinationStatus | "";
+}): Promise<EcosystemCoordinationSnapshot[]> {
+  const search = new URLSearchParams();
+  if (params?.status) search.set("status", params.status);
+  const suffix = search.toString() ? `?${search.toString()}` : "";
+  const response = await apiFetch<{ ok: true; snapshots: EcosystemCoordinationSnapshot[] }>(`/admin/ecosystem-coordination${suffix}`);
+  return response.snapshots;
+}
+
+export async function fetchEcosystemCoordinationSnapshot(ecosystemCoordinationId: string): Promise<EcosystemCoordinationSnapshot> {
+  const response = await apiFetch<{ ok: true; snapshot: EcosystemCoordinationSnapshot }>(
+    `/admin/ecosystem-coordination/${encodeURIComponent(ecosystemCoordinationId)}`
+  );
+  return response.snapshot;
+}

--- a/rentchain-frontend/src/components/ecosystem/EcosystemCoordinationConsole.test.tsx
+++ b/rentchain-frontend/src/components/ecosystem/EcosystemCoordinationConsole.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import type { EcosystemCoordinationSnapshot } from "@/api/ecosystemCoordinationApi";
+import { EcosystemCoordinationConsole } from "./EcosystemCoordinationConsole";
+
+const snapshot: EcosystemCoordinationSnapshot = {
+  ecosystemCoordinationId: "ecosystem_coordination:institutional:v1",
+  status: "blocked",
+  manualReviewRequired: true,
+  autonomousCoordinationEnabled: false,
+  externalExecutionEnabled: false,
+  generatedAt: "2026-05-07T00:00:00.000Z",
+  summary: {
+    totalReferences: 2,
+    verifiedReferences: 1,
+    partiallyVerifiedReferences: 0,
+    blockedReferences: 1,
+    unavailableReferences: 0,
+    restrictions: 1,
+  },
+  participantReferences: [],
+  trustReferences: [],
+  onboardingReferences: [],
+  riskReferences: [
+    {
+      referenceId: "risk-1",
+      referenceType: "risk",
+      status: "blocked",
+      label: "Operational risk reference",
+      description: "Operational risk metadata is available.",
+      reviewRequired: true,
+      lineageReferences: ["risk-1"],
+      destination: "/operational-risk",
+      redacted: false,
+      redactionReason: null,
+      blockedReason: "Operational risk blocks ecosystem coordination.",
+    },
+  ],
+  integrationReferences: [
+    {
+      referenceId: "integration-1",
+      referenceType: "integration",
+      status: "verified",
+      label: "Controlled integration reference",
+      description: "Controlled integration metadata is available.",
+      reviewRequired: true,
+      lineageReferences: ["integration-1"],
+      destination: "/admin/controlled-integrations",
+      redacted: false,
+      redactionReason: null,
+      blockedReason: null,
+    },
+  ],
+  settlementReferences: [],
+  regulatoryReferences: [],
+  observabilityReferences: [],
+  governanceReferences: [],
+  evidenceReferences: [],
+  reviewReferences: [],
+  auditReferences: [],
+  ecosystemRestrictions: [
+    {
+      restrictionId: "restriction-1",
+      restrictionType: "risk",
+      status: "blocked",
+      label: "Operational risk reference restriction",
+      description: "Risk reference requires governance attention.",
+      blockedReason: "Operational risk blocks ecosystem coordination.",
+    },
+  ],
+  redactions: [
+    "Private tenant data, raw government IDs, payment payloads, banking payloads, and settlement execution payloads are excluded.",
+  ],
+  blockedReasons: ["Operational risk blocks ecosystem coordination."],
+  canonicalEvents: [],
+};
+
+describe("EcosystemCoordinationConsole", () => {
+  it("renders coordination readiness, restrictions, blocked reasons, and required safety copy", () => {
+    render(
+      <MemoryRouter>
+        <EcosystemCoordinationConsole snapshot={snapshot} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("View ecosystem coordination")).toBeInTheDocument();
+    expect(screen.getByText("View restrictions")).toBeInTheDocument();
+    expect(screen.getAllByText("View blocked reason: Operational risk blocks ecosystem coordination.").length).toBeGreaterThan(0);
+    expect(screen.getByText("Manual review required")).toBeInTheDocument();
+    expect(screen.getByText(/Ecosystem coordination is operationally scoped and review controlled/i)).toBeInTheDocument();
+    expect(screen.getByText(/No autonomous orchestration or external execution is enabled/i)).toBeInTheDocument();
+    expect(screen.getByText(/Manual review remains required/i)).toBeInTheDocument();
+  });
+
+  it("does not render forbidden ecosystem execution labels", () => {
+    render(
+      <MemoryRouter>
+        <EcosystemCoordinationConsole snapshot={snapshot} />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText("Auto-coordinate")).not.toBeInTheDocument();
+    expect(screen.queryByText("Autonomous orchestration")).not.toBeInTheDocument();
+    expect(screen.queryByText("Execute integrations")).not.toBeInTheDocument();
+    expect(screen.queryByText("Trigger deployment")).not.toBeInTheDocument();
+    expect(screen.queryByText("Trigger onboarding")).not.toBeInTheDocument();
+    expect(screen.queryByText("Execute ecosystem actions")).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/ecosystem/EcosystemCoordinationConsole.tsx
+++ b/rentchain-frontend/src/components/ecosystem/EcosystemCoordinationConsole.tsx
@@ -1,0 +1,148 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import type {
+  EcosystemCoordinationReference,
+  EcosystemCoordinationSnapshot,
+  EcosystemRestriction,
+} from "@/api/ecosystemCoordinationApi";
+import { Card, Section } from "@/components/ui/Ui";
+
+function label(value: string) {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function tone(status: string) {
+  if (status === "blocked") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
+  if (status === "review_required" || status === "attention_required" || status === "partially_verified" || status === "unavailable") {
+    return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
+  }
+  if (status === "stable" || status === "verified") return { color: "#166534", background: "#dcfce7", border: "#bbf7d0" };
+  return { color: "#475569", background: "#f8fafc", border: "#e2e8f0" };
+}
+
+function Badge({ children, status }: { children: React.ReactNode; status: string }) {
+  const next = tone(status);
+  return (
+    <span style={{ border: `1px solid ${next.border}`, borderRadius: 999, background: next.background, color: next.color, padding: "3px 9px", fontSize: 12, fontWeight: 900, whiteSpace: "nowrap" }}>
+      {children}
+    </span>
+  );
+}
+
+function ReferenceList({ title, references }: { title: string; references: EcosystemCoordinationReference[] }) {
+  return (
+    <Section style={{ display: "grid", gap: 10 }}>
+      <div style={{ fontWeight: 900 }}>{title}</div>
+      {references.length ? (
+        references.slice(0, 12).map((reference) => (
+          <Card key={reference.referenceId} style={{ borderRadius: 8, padding: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+              <div>
+                <strong>{reference.label}</strong>
+                <div style={{ color: "#64748b", fontSize: 13 }}>{label(reference.referenceType)}</div>
+              </div>
+              <Badge status={reference.status}>{label(reference.status)}</Badge>
+            </div>
+            <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>{reference.description}</div>
+            {reference.lineageReferences.length ? <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>Lineage references: {reference.lineageReferences.length}</div> : null}
+            {reference.blockedReason ? <div style={{ color: "#991b1b", fontSize: 13, marginTop: 8 }}>View blocked reason: {reference.blockedReason}</div> : null}
+            {reference.redacted ? <div style={{ color: "#92400e", fontSize: 13, marginTop: 8 }}>{reference.redactionReason || "Redacted ecosystem reference"}</div> : null}
+            {reference.destination?.startsWith("/") ? <Link to={reference.destination} style={{ color: "#2563eb", fontWeight: 800, fontSize: 13, marginTop: 8, display: "inline-block" }}>View context</Link> : null}
+          </Card>
+        ))
+      ) : (
+        <Card style={{ color: "#64748b" }}>Context unavailable</Card>
+      )}
+    </Section>
+  );
+}
+
+function RestrictionList({ restrictions }: { restrictions: EcosystemRestriction[] }) {
+  return (
+    <Section style={{ display: "grid", gap: 10 }}>
+      <div style={{ fontWeight: 900 }}>View restrictions</div>
+      {restrictions.length ? (
+        restrictions.map((restriction) => (
+          <Card key={restriction.restrictionId} style={{ borderRadius: 8, padding: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+              <div>
+                <strong>{restriction.label}</strong>
+                <div style={{ color: "#64748b", fontSize: 13 }}>{label(restriction.restrictionType)}</div>
+              </div>
+              <Badge status={restriction.status}>{label(restriction.status)}</Badge>
+            </div>
+            <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>{restriction.description}</div>
+            {restriction.blockedReason ? <div style={{ color: "#991b1b", fontSize: 13, marginTop: 8 }}>View blocked reason: {restriction.blockedReason}</div> : null}
+          </Card>
+        ))
+      ) : (
+        <Card style={{ color: "#64748b" }}>No ecosystem restrictions detected.</Card>
+      )}
+    </Section>
+  );
+}
+
+export function EcosystemCoordinationConsole({ snapshot }: { snapshot: EcosystemCoordinationSnapshot }) {
+  return (
+    <div style={{ display: "grid", gap: 16 }}>
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+          <div>
+            <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>View ecosystem coordination</div>
+            <h2 style={{ margin: "2px 0 0", fontSize: "1.15rem" }}>Ecosystem coordination</h2>
+          </div>
+          <Badge status={snapshot.status}>{label(snapshot.status)}</Badge>
+        </div>
+        <div style={{ color: "#475569", lineHeight: 1.55 }}>
+          Ecosystem coordination is operationally scoped and review controlled. No autonomous orchestration or external execution is enabled.
+          Manual review remains required.
+        </div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <Badge status="review_required">Manual review required</Badge>
+          <Badge status={snapshot.autonomousCoordinationEnabled ? "blocked" : "verified"}>Autonomous coordination disabled</Badge>
+          <Badge status={snapshot.externalExecutionEnabled ? "blocked" : "verified"}>External execution disabled</Badge>
+        </div>
+      </Section>
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Ecosystem summary</div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: 10 }}>
+          {[
+            ["References", snapshot.summary.totalReferences],
+            ["Verified", snapshot.summary.verifiedReferences],
+            ["Partial", snapshot.summary.partiallyVerifiedReferences],
+            ["Blocked", snapshot.summary.blockedReferences],
+            ["Unavailable", snapshot.summary.unavailableReferences],
+            ["Restrictions", snapshot.summary.restrictions],
+          ].map(([name, value]) => (
+            <Card key={String(name)} style={{ borderRadius: 8, padding: 12 }}>
+              <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>{name}</div>
+              <strong style={{ color: "#0f172a", fontSize: 22 }}>{String(value)}</strong>
+            </Card>
+          ))}
+        </div>
+      </Section>
+
+      <RestrictionList restrictions={snapshot.ecosystemRestrictions} />
+      <ReferenceList title="Participant visibility" references={snapshot.participantReferences} />
+      <ReferenceList title="Trust relationships" references={snapshot.trustReferences} />
+      <ReferenceList title="Onboarding readiness" references={snapshot.onboardingReferences} />
+      <ReferenceList title="View operational risk" references={snapshot.riskReferences} />
+      <ReferenceList title="Integration readiness" references={snapshot.integrationReferences} />
+      <ReferenceList title="Settlement readiness" references={snapshot.settlementReferences} />
+      <ReferenceList title="Regulatory visibility" references={snapshot.regulatoryReferences} />
+      <ReferenceList title="Observability readiness" references={snapshot.observabilityReferences} />
+      <ReferenceList title="Governance readiness" references={snapshot.governanceReferences} />
+      <ReferenceList title="View evidence lineage" references={snapshot.evidenceReferences} />
+      <ReferenceList title="View review lineage" references={snapshot.reviewReferences} />
+      <ReferenceList title="Audit references" references={snapshot.auditReferences} />
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Redactions</div>
+        {snapshot.redactions.map((redaction) => (
+          <Card key={redaction} style={{ borderRadius: 8, padding: 12, color: "#475569" }}>{redaction}</Card>
+        ))}
+      </Section>
+    </div>
+  );
+}

--- a/rentchain-frontend/src/pages/EcosystemCoordinationPage.test.tsx
+++ b/rentchain-frontend/src/pages/EcosystemCoordinationPage.test.tsx
@@ -1,0 +1,99 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import EcosystemCoordinationPage from "./EcosystemCoordinationPage";
+
+const mockFetchSnapshots = vi.fn();
+const mockShowToast = vi.fn();
+
+vi.mock("@/api/ecosystemCoordinationApi", () => ({
+  fetchEcosystemCoordinationSnapshots: (...args: any[]) => mockFetchSnapshots(...args),
+}));
+
+vi.mock("@/components/layout/MacShell", () => ({
+  MacShell: ({ children, title }: any) => <main aria-label={title}>{children}</main>,
+}));
+
+vi.mock("@/components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
+const snapshot = {
+  ecosystemCoordinationId: "ecosystem_coordination:institutional:v1",
+  status: "stable",
+  manualReviewRequired: true,
+  autonomousCoordinationEnabled: false,
+  externalExecutionEnabled: false,
+  generatedAt: "2026-05-07T00:00:00.000Z",
+  summary: {
+    totalReferences: 1,
+    verifiedReferences: 1,
+    partiallyVerifiedReferences: 0,
+    blockedReferences: 0,
+    unavailableReferences: 0,
+    restrictions: 0,
+  },
+  participantReferences: [],
+  trustReferences: [],
+  onboardingReferences: [],
+  riskReferences: [],
+  integrationReferences: [],
+  settlementReferences: [],
+  regulatoryReferences: [],
+  observabilityReferences: [],
+  governanceReferences: [],
+  evidenceReferences: [],
+  reviewReferences: [],
+  auditReferences: [],
+  ecosystemRestrictions: [],
+  redactions: ["Sensitive tenant, payment, telemetry, and execution payloads are excluded."],
+  blockedReasons: [],
+  canonicalEvents: [],
+};
+
+describe("EcosystemCoordinationPage", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    mockFetchSnapshots.mockResolvedValue([snapshot]);
+  });
+
+  it("loads and renders ecosystem coordination snapshots with required safety copy", async () => {
+    render(
+      <MemoryRouter>
+        <EcosystemCoordinationPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Loading ecosystem coordination...")).toBeInTheDocument();
+    expect(await screen.findByText("Ecosystem summary")).toBeInTheDocument();
+    expect(screen.getAllByText(/Ecosystem coordination is operationally scoped and review controlled/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Manual review remains required/i).length).toBeGreaterThan(0);
+    expect(mockFetchSnapshots).toHaveBeenCalledWith({ status: "" });
+  });
+
+  it("filters snapshots by status", async () => {
+    render(
+      <MemoryRouter>
+        <EcosystemCoordinationPage />
+      </MemoryRouter>
+    );
+
+    fireEvent.change((await screen.findAllByLabelText("Status"))[0], { target: { value: "blocked" } });
+    await waitFor(() => {
+      expect(mockFetchSnapshots).toHaveBeenLastCalledWith({ status: "blocked" });
+    });
+  });
+
+  it("renders the empty state", async () => {
+    mockFetchSnapshots.mockResolvedValue([]);
+
+    render(
+      <MemoryRouter>
+        <EcosystemCoordinationPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("No ecosystem coordination snapshots match these filters.")).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/EcosystemCoordinationPage.tsx
+++ b/rentchain-frontend/src/pages/EcosystemCoordinationPage.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { useSearchParams } from "react-router-dom";
+import {
+  fetchEcosystemCoordinationSnapshots,
+  type EcosystemCoordinationSnapshot,
+  type EcosystemCoordinationStatus,
+} from "@/api/ecosystemCoordinationApi";
+import { EcosystemCoordinationConsole } from "@/components/ecosystem/EcosystemCoordinationConsole";
+import { MacShell } from "@/components/layout/MacShell";
+import { Card, Section } from "@/components/ui/Ui";
+import { useToast } from "@/components/ui/ToastProvider";
+
+const statuses: Array<EcosystemCoordinationStatus | ""> = ["", "stable", "attention_required", "review_required", "blocked", "unknown"];
+
+function label(value: string) {
+  return value ? value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase()) : "All";
+}
+
+export default function EcosystemCoordinationPage() {
+  const { showToast } = useToast();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [snapshots, setSnapshots] = React.useState<EcosystemCoordinationSnapshot[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const status = String(searchParams.get("status") || "") as EcosystemCoordinationStatus | "";
+
+  React.useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const next = await fetchEcosystemCoordinationSnapshots({ status });
+        if (mounted) setSnapshots(next);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Failed to load ecosystem coordination";
+        if (mounted) {
+          setError(message);
+          showToast({ message: "Failed to load ecosystem coordination", description: message, variant: "error" });
+        }
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [status, showToast]);
+
+  function updateStatus(value: string) {
+    const params = new URLSearchParams(searchParams);
+    if (value && value.trim()) params.set("status", value.trim());
+    else params.delete("status");
+    setSearchParams(params);
+  }
+
+  return (
+    <MacShell title="Ecosystem coordination" showTopNav={false}>
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "grid", gap: 6 }}>
+            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Ecosystem coordination</h1>
+            <div style={{ color: "#475569", maxWidth: 900 }}>
+              Ecosystem coordination is operationally scoped and review controlled. No autonomous orchestration or external execution is enabled.
+              Manual review remains required.
+            </div>
+          </div>
+        </Section>
+
+        <Section style={{ display: "flex", gap: 10, flexWrap: "wrap", alignItems: "end" }}>
+          <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Status
+            <select value={status} onChange={(event) => updateStatus(event.target.value)} style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 180 }}>
+              {statuses.map((item) => <option key={item || "all"} value={item}>{label(item)}</option>)}
+            </select>
+          </label>
+        </Section>
+
+        {loading ? <Card>Loading ecosystem coordination...</Card> : null}
+        {!loading && error ? <Card style={{ color: "#b91c1c" }}>We couldn't load ecosystem coordination right now.</Card> : null}
+        {!loading && !error && !snapshots.length ? <Card style={{ color: "#64748b" }}>No ecosystem coordination snapshots match these filters.</Card> : null}
+        {!loading && !error && snapshots.length ? (
+          <div style={{ display: "grid", gap: 16 }}>{snapshots.map((snapshot) => <EcosystemCoordinationConsole key={snapshot.ecosystemCoordinationId} snapshot={snapshot} />)}</div>
+        ) : null}
+      </div>
+    </MacShell>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a deterministic, admin-scoped Ecosystem Coordination read model that aggregates participant, trust, onboarding, operational risk, integration, settlement, regulatory, observability, governance, evidence, review, and audit lineage.
- Adds read-only admin endpoints for ecosystem coordination snapshots.
- Adds an admin Ecosystem Coordination Console with required review-control safety copy and no execution controls.

## Guardrails
- Manual review remains required.
- Autonomous coordination remains disabled.
- External execution remains disabled.
- No deployment, onboarding, payment, settlement, integration execution, external synchronization, public networking, or hidden orchestration path was added.
- Backend route sanitizes source records through a whitelist projection before derivation.

## Verification
- Backend targeted tests: `npm test -- --run src/lib/ecosystemCoordination/__tests__/deriveEcosystemCoordinationSnapshot.test.ts src/routes/__tests__/adminEcosystemCoordinationRoutes.test.ts` (9/9 passed)
- Frontend targeted tests: `npm test -- --run src/components/ecosystem/EcosystemCoordinationConsole.test.tsx src/pages/EcosystemCoordinationPage.test.tsx` (5/5 passed)
- Backend build: `npm run build` passed
- Frontend build: `npm run build` passed; existing large App chunk warning remains non-regressive and the new page is emitted as a separate lazy chunk
- `git diff --check` passed
- `git diff --cached --check` passed
- Dependency/lockfile diff: empty
- Forbidden ecosystem execution-label scan: clean