### PR TITLE
feat: add platform credentialing readiness

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -117,6 +117,7 @@ import adminPublicExposureHardeningRoutes from "./routes/adminPublicExposureHard
 import adminCommercialReadinessRoutes from "./routes/adminCommercialReadinessRoutes";
 import adminControlledIntegrationsRoutes from "./routes/adminControlledIntegrationsRoutes";
 import adminEcosystemCoordinationRoutes from "./routes/adminEcosystemCoordinationRoutes";
+import adminPlatformCredentialingRoutes from "./routes/adminPlatformCredentialingRoutes";
 import portfolioScoreRoutes from "./routes/portfolioScoreRoutes";
 import portfolioScoreHistoryRoutes from "./routes/portfolioScoreHistoryRoutes";
 import landlordPortfolioHealthRoutes from "./routes/landlordPortfolioHealthRoutes";
@@ -299,6 +300,8 @@ app.use("/api/admin", routeSource("adminControlledIntegrationsRoutes.ts"), admin
 console.log("[route-mount] adminControlledIntegrationsRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("adminEcosystemCoordinationRoutes.ts"), adminEcosystemCoordinationRoutes);
 console.log("[route-mount] adminEcosystemCoordinationRoutes mounted at /api/admin");
+app.use("/api/admin", routeSource("adminPlatformCredentialingRoutes.ts"), adminPlatformCredentialingRoutes);
+console.log("[route-mount] adminPlatformCredentialingRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("portfolioScoreRoutes.ts"), portfolioScoreRoutes);
 console.log("[route-mount] portfolioScoreRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("portfolioScoreHistoryRoutes.ts"), portfolioScoreHistoryRoutes);

--- a/rentchain-api/src/lib/platformCredentialing/__tests__/derivePlatformCredentialingReadiness.test.ts
+++ b/rentchain-api/src/lib/platformCredentialing/__tests__/derivePlatformCredentialingReadiness.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { derivePlatformCredentialingReadiness } from "../derivePlatformCredentialingReadiness";
+
+const completeInput = {
+  generatedAt: "2026-05-07T00:00:00.000Z",
+  governanceReadiness: [{ governanceReadinessId: "governance-1", status: "ready_for_review" }],
+  privacyReadiness: [{ privacyReadinessId: "privacy-1", status: "ready_for_review" }],
+  consentGovernance: [{ consentGovernanceId: "consent-1", status: "ready_for_review" }],
+  auditLineage: [{ eventId: "audit-1", eventType: "platform_credentialing_readiness_derived" }],
+  verificationReadiness: [{ verificationReadinessId: "verification-1", status: "ready_for_review" }],
+  interoperabilityReadiness: [{ adapterReadinessId: "adapter-1", status: "ready_for_review" }],
+  institutionOnboardingReadiness: [{ onboardingReadinessId: "onboarding-1", status: "ready_for_review" }],
+  operationalRiskProfiles: [{ operationalRiskId: "risk-1", status: "stable" }],
+  evidencePacks: [{ evidencePackId: "evidence-1", status: "ready_for_review" }],
+  operatorReviewSessions: [{ reviewSessionId: "review-1", status: "completed" }],
+};
+
+describe("derivePlatformCredentialingReadiness", () => {
+  it("derives a deterministic ready-for-review profile with execution flags pinned off", () => {
+    const readiness = derivePlatformCredentialingReadiness(completeInput);
+    const repeat = derivePlatformCredentialingReadiness(completeInput);
+
+    expect(readiness).toEqual(repeat);
+    expect(readiness.status).toBe("ready_for_review");
+    expect(readiness).toEqual(
+      expect.objectContaining({
+        manualApprovalRequired: true,
+        consumerReportingExecutionEnabled: false,
+        autonomousCredentialApprovalEnabled: false,
+        publicCredentialExposureEnabled: false,
+      })
+    );
+    expect(readiness.summary).toEqual(
+      expect.objectContaining({
+        totalReferences: 10,
+        verifiedReferences: 10,
+        restrictions: 0,
+      })
+    );
+  });
+
+  it("blocks unresolved governance, privacy, and consent restrictions", () => {
+    const readiness = derivePlatformCredentialingReadiness({
+      ...completeInput,
+      governanceReadiness: [{ governanceReadinessId: "governance-1", status: "blocked" }],
+      privacyReadiness: [{ privacyReadinessId: "privacy-1", status: "blocked" }],
+      consentGovernance: [{ consentGovernanceId: "consent-1", status: "blocked" }],
+    });
+
+    expect(readiness.status).toBe("blocked");
+    expect(readiness.credentialingRestrictions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ restrictionType: "governance", status: "blocked" }),
+        expect.objectContaining({ restrictionType: "privacy", status: "blocked" }),
+        expect.objectContaining({ restrictionType: "consent", status: "blocked" }),
+      ])
+    );
+  });
+
+  it("requires review when critical consent, audit, evidence, or review lineage is missing", () => {
+    const readiness = derivePlatformCredentialingReadiness({
+      ...completeInput,
+      consentGovernance: [],
+      auditLineage: [],
+      evidencePacks: [],
+      operatorReviewSessions: [],
+    });
+
+    expect(readiness.status).toBe("review_required");
+    expect(readiness.credentialingRestrictions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ restrictionType: "consent", status: "review_required" }),
+        expect.objectContaining({ restrictionType: "audit", status: "review_required" }),
+        expect.objectContaining({ restrictionType: "evidence", status: "review_required" }),
+        expect.objectContaining({ restrictionType: "review", status: "review_required" }),
+      ])
+    );
+  });
+
+  it("marks unresolved operational risk as partially ready without autonomous approval", () => {
+    const readiness = derivePlatformCredentialingReadiness({
+      ...completeInput,
+      operationalRiskProfiles: [{ operationalRiskId: "risk-1", status: "elevated" }],
+    });
+
+    expect(readiness.status).toBe("partially_ready");
+    expect(readiness.credentialingRestrictions).toEqual(
+      expect.arrayContaining([expect.objectContaining({ restrictionType: "verification", status: "blocked" })])
+    );
+    expect(readiness.autonomousCredentialApprovalEnabled).toBe(false);
+  });
+
+  it("returns unknown when there is insufficient source context", () => {
+    const readiness = derivePlatformCredentialingReadiness({});
+
+    expect(readiness.status).toBe("unknown");
+    expect(readiness.summary.unavailableReferences).toBeGreaterThan(0);
+    expect(readiness.canonicalEvents.map((event) => event.eventType)).toEqual(
+      expect.arrayContaining(["platform_credentialing_readiness_derived", "platform_credentialing_redaction_applied"])
+    );
+  });
+
+  it("generates canonical events for restriction, review-required, blocked, and redaction paths", () => {
+    const blocked = derivePlatformCredentialingReadiness({
+      ...completeInput,
+      privacyReadiness: [{ privacyReadinessId: "privacy-1", status: "blocked" }],
+    });
+
+    expect(blocked.canonicalEvents.map((event) => event.eventType)).toEqual(
+      expect.arrayContaining([
+        "platform_credentialing_readiness_derived",
+        "platform_credentialing_redaction_applied",
+        "platform_credentialing_restriction_detected",
+        "platform_credentialing_blocked",
+      ])
+    );
+  });
+});

--- a/rentchain-api/src/lib/platformCredentialing/credentialingRestrictionModels.ts
+++ b/rentchain-api/src/lib/platformCredentialing/credentialingRestrictionModels.ts
@@ -1,0 +1,63 @@
+import type {
+  CredentialingReference,
+  CredentialingReferenceStatus,
+  CredentialingReferenceType,
+  CredentialingRestriction,
+} from "./platformCredentialingTypes";
+
+export function credentialingIdPart(value: unknown) {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 240);
+}
+
+export function credentialingReference(input: {
+  idParts: unknown[];
+  referenceType: CredentialingReferenceType;
+  status: CredentialingReferenceStatus;
+  label: string;
+  description: string;
+  lineageReferences?: string[];
+  destination?: string | null;
+  redacted?: boolean;
+  redactionReason?: string | null;
+  blockedReason?: string | null;
+}): CredentialingReference {
+  const referenceId = credentialingIdPart(input.idParts.filter(Boolean).join(":")) || `${input.referenceType}:unknown`;
+  return {
+    referenceId,
+    referenceType: input.referenceType,
+    status: input.status,
+    label: input.label,
+    description: input.description,
+    reviewRequired: true,
+    lineageReferences: Array.from(new Set(input.lineageReferences || [])).filter(Boolean).slice(0, 20),
+    destination: input.destination || null,
+    redacted: Boolean(input.redacted),
+    redactionReason: input.redactionReason || null,
+    blockedReason: input.blockedReason || null,
+  };
+}
+
+export function credentialingRestriction(input: {
+  idParts: unknown[];
+  restrictionType: CredentialingRestriction["restrictionType"];
+  status: CredentialingRestriction["status"];
+  label: string;
+  description: string;
+  blockedReason?: string | null;
+}): CredentialingRestriction {
+  const restrictionId = credentialingIdPart(["credentialing_restriction", ...input.idParts].filter(Boolean).join(":"));
+  return {
+    restrictionId: restrictionId || "credentialing_restriction:unknown",
+    restrictionType: input.restrictionType,
+    status: input.status,
+    label: input.label,
+    description: input.description,
+    blockedReason: input.blockedReason || null,
+  };
+}

--- a/rentchain-api/src/lib/platformCredentialing/derivePlatformCredentialingReadiness.ts
+++ b/rentchain-api/src/lib/platformCredentialing/derivePlatformCredentialingReadiness.ts
@@ -1,0 +1,357 @@
+import type {
+  CredentialingReference,
+  CredentialingReferenceStatus,
+  CredentialingReferenceType,
+  DerivePlatformCredentialingReadinessInput,
+  PlatformCredentialingCanonicalEvent,
+  PlatformCredentialingReadiness,
+  PlatformCredentialingStatus,
+} from "./platformCredentialingTypes";
+import { credentialingIdPart, credentialingReference, credentialingRestriction } from "./credentialingRestrictionModels";
+
+const DEFAULT_READINESS_KEY = "institutional-platform-credentialing-readiness-v1";
+
+const REDACTIONS = [
+  "CRA registration claims, bureau approval claims, bureau credentials, and provider credentials are excluded.",
+  "Raw screening, credit bureau, government ID, tenant private document, payment account, and banking payloads are excluded.",
+  "Platform credentialing readiness is visibility metadata only; no consumer-reporting execution or autonomous credential approval is enabled.",
+  "Public credential marketplaces, unrestricted credential delegation, and live institutional onboarding execution are excluded.",
+];
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function asArray<T>(value: T[] | null | undefined): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function generatedAt(value: unknown): string {
+  const raw = asString(value, 120);
+  const date = raw ? new Date(raw) : new Date(0);
+  return Number.isNaN(date.getTime()) ? new Date(0).toISOString() : date.toISOString();
+}
+
+function recordId(record: Record<string, any>, keys: string[]): string {
+  for (const key of keys) {
+    const value = asString(record?.[key], 240);
+    if (value) return value;
+  }
+  return asString(record?.id, 240);
+}
+
+function referenceStatus(record: Record<string, any>, verifiedStatuses: string[]): CredentialingReferenceStatus {
+  const status = asString(record?.status || record?.state || record?.conclusion, 80).toLowerCase();
+  if (status === "blocked" || status === "elevated" || status === "failure" || status === "failed" || status === "error" || status === "cancelled") return "blocked";
+  if (verifiedStatuses.includes(status)) return "verified";
+  if (status === "missing" || status === "unknown" || status === "unavailable" || status === "pending") return "unavailable";
+  return "partially_verified";
+}
+
+function statusForType(referenceType: CredentialingReferenceType, record: Record<string, any>): CredentialingReferenceStatus {
+  if (referenceType === "verification") return referenceStatus(record, ["ready_for_review", "verified", "partially_verified", "stable"]);
+  if (referenceType === "interoperability") return referenceStatus(record, ["ready_for_review", "sandbox_ready", "verified"]);
+  if (referenceType === "review") return referenceStatus(record, ["ready_for_review", "completed", "verified"]);
+  if (referenceType === "audit" && asString(record?.eventType, 120)) return "verified";
+  return referenceStatus(record, ["ready_for_review", "verified", "stable", "available", "configured"]);
+}
+
+function readinessStatus(hasContext: boolean, references: CredentialingReference[]): PlatformCredentialingStatus {
+  if (!hasContext) return "unknown";
+  if (references.some((reference) => reference.status === "blocked" && (reference.referenceType === "governance" || reference.referenceType === "privacy" || reference.referenceType === "consent"))) {
+    return "blocked";
+  }
+  const criticalMissing = references.some(
+    (reference) =>
+      reference.status === "unavailable" &&
+      (reference.referenceType === "governance" ||
+        reference.referenceType === "consent" ||
+        reference.referenceType === "audit" ||
+        reference.referenceType === "evidence" ||
+        reference.referenceType === "review")
+  );
+  if (criticalMissing) return "review_required";
+  if (references.some((reference) => reference.status === "blocked" || reference.status === "unavailable" || reference.status === "partially_verified")) return "partially_ready";
+  return "ready_for_review";
+}
+
+function event(input: {
+  eventType: PlatformCredentialingCanonicalEvent["eventType"];
+  status: PlatformCredentialingStatus;
+  platformCredentialingId: string;
+  summary: string;
+}): PlatformCredentialingCanonicalEvent {
+  return {
+    eventType: input.eventType,
+    action: input.eventType.replace(/^platform_credentialing_/, "").replace(/_/g, "."),
+    status: input.status,
+    resourceType: "platform_credentialing_readiness",
+    resourceId: input.platformCredentialingId,
+    summary: input.summary,
+  };
+}
+
+function referencesFor(input: {
+  records: Record<string, any>[];
+  fallback: string;
+  referenceType: CredentialingReferenceType;
+  idKeys: string[];
+  label: string;
+  description: string;
+  destination: string;
+  blockedReason: string;
+}): CredentialingReference[] {
+  if (!input.records.length) {
+    return [
+      credentialingReference({
+        idParts: [input.referenceType, "missing"],
+        referenceType: input.referenceType,
+        status: "unavailable",
+        label: input.label,
+        description: `${input.description} is unavailable for platform credentialing review.`,
+        destination: input.destination,
+      }),
+    ];
+  }
+  return input.records.map((record, index) => {
+    const id = recordId(record, input.idKeys) || `${input.fallback}-${index + 1}`;
+    const status = statusForType(input.referenceType, record);
+    return credentialingReference({
+      idParts: [input.referenceType, id],
+      referenceType: input.referenceType,
+      status,
+      label: input.label,
+      description: `${input.description} is available for platform credentialing review.`,
+      lineageReferences: [id].filter(Boolean),
+      destination: input.destination,
+      redacted: Boolean(record.redacted),
+      redactionReason: record.redacted ? `${input.label} payload is redacted for credentialing safety.` : null,
+      blockedReason: status === "blocked" ? input.blockedReason : null,
+    });
+  });
+}
+
+export function derivePlatformCredentialingReadiness(input: DerivePlatformCredentialingReadinessInput): PlatformCredentialingReadiness {
+  const readinessKey = asString(input.readinessKey, 160) || DEFAULT_READINESS_KEY;
+  const platformCredentialingId =
+    credentialingIdPart(["platform_credentialing", readinessKey].join(":")) || "platform_credentialing:unknown";
+
+  const governanceReadiness = asArray(input.governanceReadiness);
+  const privacyReadiness = asArray(input.privacyReadiness);
+  const consentGovernance = asArray(input.consentGovernance);
+  const auditLineage = asArray(input.auditLineage);
+  const verificationReadiness = asArray(input.verificationReadiness);
+  const interoperabilityReadiness = asArray(input.interoperabilityReadiness);
+  const institutionOnboardingReadiness = asArray(input.institutionOnboardingReadiness);
+  const operationalRiskProfiles = asArray(input.operationalRiskProfiles);
+  const evidencePacks = asArray(input.evidencePacks);
+  const reviews = asArray(input.operatorReviewSessions);
+
+  const governanceReferences = [
+    ...referencesFor({
+      records: governanceReadiness,
+      fallback: "governance",
+      referenceType: "governance",
+      idKeys: ["governanceReadinessId", "releaseGovernanceId", "publicExposureHardeningId", "commercialReadinessId", "ecosystemCoordinationId", "id"],
+      label: "Platform governance reference",
+      description: "Platform governance readiness metadata",
+      destination: "/admin/ecosystem-coordination",
+      blockedReason: "Platform governance readiness is blocked.",
+    }),
+    ...referencesFor({
+      records: institutionOnboardingReadiness,
+      fallback: "institution-onboarding",
+      referenceType: "governance",
+      idKeys: ["onboardingReadinessId", "institutionOnboardingId", "id"],
+      label: "Institutional onboarding governance reference",
+      description: "Institutional onboarding readiness metadata",
+      destination: "/institution-onboarding-readiness",
+      blockedReason: "Institutional onboarding governance is blocked.",
+    }),
+  ];
+
+  const privacyReferences = referencesFor({
+    records: privacyReadiness,
+    fallback: "privacy",
+    referenceType: "privacy",
+    idKeys: ["privacyReadinessId", "policyId", "identityLayerId", "id"],
+    label: "Privacy and compliance posture reference",
+    description: "Privacy and compliance posture metadata",
+    destination: "/identity-layer",
+    blockedReason: "Privacy or compliance posture is blocked.",
+  });
+  const consentReferences = referencesFor({
+    records: consentGovernance,
+    fallback: "consent",
+    referenceType: "consent",
+    idKeys: ["consentGovernanceId", "consentId", "identityConsentId", "id"],
+    label: "Consent governance reference",
+    description: "Consent governance and access-control metadata",
+    destination: "/identity-layer",
+    blockedReason: "Consent governance is missing or blocked.",
+  });
+  const auditReferences = referencesFor({
+    records: auditLineage.slice(0, 20),
+    fallback: "audit",
+    referenceType: "audit",
+    idKeys: ["eventId", "auditId", "id"],
+    label: "Audit lineage reference",
+    description: "Audit lineage metadata",
+    destination: "/review-timeline",
+    blockedReason: "Audit lineage is blocked.",
+  });
+  const verificationReferences = referencesFor({
+    records: [...verificationReadiness, ...operationalRiskProfiles],
+    fallback: "verification",
+    referenceType: "verification",
+    idKeys: ["verificationReadinessId", "identityProfileId", "participantId", "operationalRiskId", "id"],
+    label: "Landlord and platform verification support reference",
+    description: "Operational verification support metadata",
+    destination: "/network-participants",
+    blockedReason: "Verification support readiness is blocked.",
+  });
+  const interoperabilityReferences = referencesFor({
+    records: interoperabilityReadiness,
+    fallback: "interoperability",
+    referenceType: "interoperability",
+    idKeys: ["adapterReadinessId", "controlledIntegrationId", "id"],
+    label: "Interoperability governance reference",
+    description: "Interoperability governance metadata",
+    destination: "/interoperability-adapters",
+    blockedReason: "Interoperability governance is blocked.",
+  });
+  const evidenceReferences = referencesFor({
+    records: evidencePacks,
+    fallback: "evidence",
+    referenceType: "evidence",
+    idKeys: ["evidencePackId", "id"],
+    label: "Evidence credentialing lineage reference",
+    description: "Evidence lineage metadata",
+    destination: "/evidence-packs",
+    blockedReason: "Evidence lineage is blocked.",
+  });
+  const reviewReferences = referencesFor({
+    records: reviews,
+    fallback: "review",
+    referenceType: "review",
+    idKeys: ["reviewSessionId", "id"],
+    label: "Review credentialing lineage reference",
+    description: "Operator review lineage metadata",
+    destination: "/review-timeline",
+    blockedReason: "Review lineage is blocked.",
+  });
+
+  const allReferences = [
+    ...governanceReferences,
+    ...privacyReferences,
+    ...consentReferences,
+    ...auditReferences,
+    ...verificationReferences,
+    ...interoperabilityReferences,
+    ...reviewReferences,
+    ...evidenceReferences,
+  ];
+  const hasContext = Boolean(
+    governanceReadiness.length ||
+      privacyReadiness.length ||
+      consentGovernance.length ||
+      auditLineage.length ||
+      verificationReadiness.length ||
+      interoperabilityReadiness.length ||
+      institutionOnboardingReadiness.length ||
+      operationalRiskProfiles.length ||
+      evidencePacks.length ||
+      reviews.length
+  );
+  const status = readinessStatus(hasContext, allReferences);
+  const credentialingRestrictions = allReferences
+    .filter((reference) => reference.status !== "verified")
+    .map((reference) =>
+      credentialingRestriction({
+        idParts: [reference.referenceType, reference.referenceId],
+        restrictionType: reference.referenceType,
+        status: reference.status === "blocked" ? "blocked" : "review_required",
+        label: `${reference.label} restriction`,
+        description: `${reference.label} is incomplete or blocked for platform credentialing readiness.`,
+        blockedReason: reference.blockedReason,
+      })
+    );
+  const blockedReasons = [...allReferences.map((reference) => reference.blockedReason), ...credentialingRestrictions.map((restriction) => restriction.blockedReason)].filter(Boolean) as string[];
+
+  const canonicalEvents: PlatformCredentialingCanonicalEvent[] = [
+    event({
+      eventType: "platform_credentialing_readiness_derived",
+      status,
+      platformCredentialingId,
+      summary:
+        "Platform credentialing readiness derived from governance, privacy, consent, audit, verification, interoperability, review, and evidence metadata.",
+    }),
+    event({
+      eventType: "platform_credentialing_redaction_applied",
+      status,
+      platformCredentialingId,
+      summary:
+        "CRA claims, bureau credentials, raw screening, bureau, government ID, payment, private tenant, and credential marketplace payloads were excluded.",
+    }),
+  ];
+  if (credentialingRestrictions.length) {
+    canonicalEvents.push(
+      event({
+        eventType: "platform_credentialing_restriction_detected",
+        status,
+        platformCredentialingId,
+        summary: "Platform credentialing restrictions are visible for manual governance review.",
+      })
+    );
+  }
+  if (status === "review_required" || status === "partially_ready") {
+    canonicalEvents.push(
+      event({
+        eventType: "platform_credentialing_review_required",
+        status,
+        platformCredentialingId,
+        summary: "Manual platform credentialing review is required.",
+      })
+    );
+  }
+  if (status === "blocked") {
+    canonicalEvents.push(
+      event({
+        eventType: "platform_credentialing_blocked",
+        status,
+        platformCredentialingId,
+        summary: "Platform credentialing readiness is blocked by unresolved restrictions.",
+      })
+    );
+  }
+
+  return {
+    platformCredentialingId,
+    status,
+    manualApprovalRequired: true,
+    consumerReportingExecutionEnabled: false,
+    autonomousCredentialApprovalEnabled: false,
+    publicCredentialExposureEnabled: false,
+    generatedAt: generatedAt(input.generatedAt),
+    summary: {
+      totalReferences: allReferences.length,
+      verifiedReferences: allReferences.filter((reference) => reference.status === "verified").length,
+      partiallyVerifiedReferences: allReferences.filter((reference) => reference.status === "partially_verified").length,
+      blockedReferences: allReferences.filter((reference) => reference.status === "blocked").length,
+      unavailableReferences: allReferences.filter((reference) => reference.status === "unavailable").length,
+      restrictions: credentialingRestrictions.length,
+    },
+    governanceReferences,
+    privacyReferences,
+    consentReferences,
+    auditReferences,
+    verificationReferences,
+    interoperabilityReferences,
+    reviewReferences,
+    evidenceReferences,
+    credentialingRestrictions,
+    redactions: REDACTIONS,
+    blockedReasons,
+    canonicalEvents,
+  };
+}

--- a/rentchain-api/src/lib/platformCredentialing/platformCredentialingTypes.ts
+++ b/rentchain-api/src/lib/platformCredentialing/platformCredentialingTypes.ts
@@ -1,0 +1,97 @@
+export type PlatformCredentialingStatus = "ready_for_review" | "partially_ready" | "review_required" | "blocked" | "unknown";
+
+export type CredentialingReferenceType =
+  | "governance"
+  | "privacy"
+  | "consent"
+  | "audit"
+  | "verification"
+  | "interoperability"
+  | "evidence"
+  | "review";
+
+export type CredentialingReferenceStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+
+export type PlatformCredentialingCanonicalEventType =
+  | "platform_credentialing_readiness_derived"
+  | "platform_credentialing_review_required"
+  | "platform_credentialing_blocked"
+  | "platform_credentialing_restriction_detected"
+  | "platform_credentialing_redaction_applied";
+
+export type CredentialingReference = {
+  referenceId: string;
+  referenceType: CredentialingReferenceType;
+  status: CredentialingReferenceStatus;
+  label: string;
+  description: string;
+  reviewRequired: true;
+  lineageReferences: string[];
+  destination: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type CredentialingRestriction = {
+  restrictionId: string;
+  restrictionType: CredentialingReferenceType | "consumer_reporting" | "bureau_execution" | "credential_marketplace";
+  status: "visible" | "blocked" | "review_required";
+  label: string;
+  description: string;
+  blockedReason: string | null;
+};
+
+export type PlatformCredentialingCanonicalEvent = {
+  eventType: PlatformCredentialingCanonicalEventType;
+  action: string;
+  status: PlatformCredentialingStatus;
+  resourceType: "platform_credentialing_readiness";
+  resourceId: string;
+  summary: string;
+};
+
+export type PlatformCredentialingReadiness = {
+  platformCredentialingId: string;
+  status: PlatformCredentialingStatus;
+  manualApprovalRequired: true;
+  consumerReportingExecutionEnabled: false;
+  autonomousCredentialApprovalEnabled: false;
+  publicCredentialExposureEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    partiallyVerifiedReferences: number;
+    blockedReferences: number;
+    unavailableReferences: number;
+    restrictions: number;
+  };
+  governanceReferences: CredentialingReference[];
+  privacyReferences: CredentialingReference[];
+  consentReferences: CredentialingReference[];
+  auditReferences: CredentialingReference[];
+  verificationReferences: CredentialingReference[];
+  interoperabilityReferences: CredentialingReference[];
+  reviewReferences: CredentialingReference[];
+  evidenceReferences: CredentialingReference[];
+  credentialingRestrictions: CredentialingRestriction[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: PlatformCredentialingCanonicalEvent[];
+};
+
+export type DerivePlatformCredentialingReadinessInput = {
+  readinessKey?: unknown;
+  generatedAt?: unknown;
+  governanceReadiness?: Array<Record<string, any>> | null;
+  privacyReadiness?: Array<Record<string, any>> | null;
+  consentGovernance?: Array<Record<string, any>> | null;
+  auditLineage?: Array<Record<string, any>> | null;
+  verificationReadiness?: Array<Record<string, any>> | null;
+  interoperabilityReadiness?: Array<Record<string, any>> | null;
+  institutionOnboardingReadiness?: Array<Record<string, any>> | null;
+  operationalRiskProfiles?: Array<Record<string, any>> | null;
+  evidencePacks?: Array<Record<string, any>> | null;
+  operatorReviewSessions?: Array<Record<string, any>> | null;
+};

--- a/rentchain-api/src/routes/__tests__/adminPlatformCredentialingRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/adminPlatformCredentialingRoutes.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+  return {
+    resetFakeDb: () => store.clear(),
+    seedDoc: (collection: string, id: string, data: any) => ensureCollection(collection).set(id, { id, data }),
+    fakeDb: {
+      collection: (name: string) => ({
+        get: async () => {
+          const docs = Array.from(ensureCollection(name).values()).map((doc) => ({ id: doc.id, exists: true, data: () => doc.data }));
+          return { docs, empty: docs.length === 0, size: docs.length };
+        },
+      }),
+    },
+  };
+});
+
+let mockUser: any;
+
+vi.mock("../../config/firebase", () => ({ db: fakeDb }));
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!mockUser) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    req.user = mockUser;
+    return next();
+  },
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; user?: Record<string, unknown> | null }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    mockUser = options.user ?? mockUser;
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: mockUser,
+      query: Object.fromEntries(new URLSearchParams(queryString || "").entries()),
+      params: {},
+      headers: {},
+    };
+    const match = path.match(/^\/platform-credentialing-readiness\/(.+)$/);
+    if (match) req.params = { platformCredentialingId: decodeURIComponent(match[1]) };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => (error ? reject(error) : undefined));
+  });
+}
+
+describe("adminPlatformCredentialingRoutes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    resetFakeDb();
+    mockUser = { id: "admin-1", role: "admin", permissions: ["system.admin"] };
+  });
+
+  function seedReadinessContext() {
+    seedDoc("releaseGovernanceProfiles", "release-1", { releaseGovernanceId: "release-1", status: "ready_for_review", deployToken: "hidden" });
+    seedDoc("publicExposureHardeningProfiles", "public-exposure-1", { publicExposureHardeningId: "public-exposure-1", status: "ready_for_review" });
+    seedDoc("commercialReadinessProfiles", "commercial-1", { commercialReadinessId: "commercial-1", status: "ready_for_review", paymentAccount: "hidden" });
+    seedDoc("privacyReadiness", "privacy-1", { privacyReadinessId: "privacy-1", status: "ready_for_review", rawGovernmentId: "hidden" });
+    seedDoc("consentGovernance", "consent-1", { consentGovernanceId: "consent-1", status: "ready_for_review", consentSecret: "hidden" });
+    seedDoc("events", "event-1", { eventId: "event-1", eventType: "platform_credentialing_readiness_derived", rawAuditPayload: "hidden" });
+    seedDoc("identityProfiles", "identity-1", { identityProfileId: "identity-1", status: "ready_for_review", rawScreeningPayload: "hidden" });
+    seedDoc("networkParticipantProfiles", "participant-1", { participantId: "participant-1", status: "verified", rawGovernmentId: "hidden" });
+    seedDoc("interoperabilityAdapterReadiness", "adapter-1", { adapterReadinessId: "adapter-1", status: "ready_for_review", providerCredential: "hidden" });
+    seedDoc("controlledIntegrationProfiles", "controlled-1", { controlledIntegrationId: "controlled-1", status: "sandbox_ready", webhookSecret: "hidden" });
+    seedDoc("institutionOnboardingReadiness", "onboarding-1", { onboardingReadinessId: "onboarding-1", status: "ready_for_review", privateTenantData: "hidden" });
+    seedDoc("operationalRiskProfiles", "risk-1", { operationalRiskId: "risk-1", status: "stable", unrestrictedTelemetry: "hidden" });
+    seedDoc("evidencePacks", "evidence-1", { evidencePackId: "evidence-1", status: "ready_for_review", creditBureauPayload: "hidden" });
+    seedDoc("operatorReviewSessions", "review-1", { reviewSessionId: "review-1", status: "completed", privateNote: "hidden" });
+  }
+
+  it("returns admin-gated platform credentialing readiness without sensitive credentialing payloads", async () => {
+    seedReadinessContext();
+    const router = (await import("../adminPlatformCredentialingRoutes")).default;
+
+    const forbidden = await invokeRouter(router, {
+      method: "GET",
+      url: "/platform-credentialing-readiness",
+      user: { id: "landlord-1", role: "landlord", permissions: [] },
+    });
+    expect(forbidden.status).toBe(403);
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/platform-credentialing-readiness",
+      user: { id: "admin-1", role: "admin", permissions: ["system.admin"] },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.readiness).toHaveLength(1);
+    expect(res.body.readiness[0]).toEqual(
+      expect.objectContaining({
+        manualApprovalRequired: true,
+        consumerReportingExecutionEnabled: false,
+        autonomousCredentialApprovalEnabled: false,
+        publicCredentialExposureEnabled: false,
+      })
+    );
+    expect(JSON.stringify(res.body)).not.toContain("deployToken");
+    expect(JSON.stringify(res.body)).not.toContain("paymentAccount");
+    expect(JSON.stringify(res.body)).not.toContain("rawGovernmentId");
+    expect(JSON.stringify(res.body)).not.toContain("consentSecret");
+    expect(JSON.stringify(res.body)).not.toContain("rawAuditPayload");
+    expect(JSON.stringify(res.body)).not.toContain("rawScreeningPayload");
+    expect(JSON.stringify(res.body)).not.toContain("providerCredential");
+    expect(JSON.stringify(res.body)).not.toContain("webhookSecret");
+    expect(JSON.stringify(res.body)).not.toContain("privateTenantData");
+    expect(JSON.stringify(res.body)).not.toContain("creditBureauPayload");
+    expect(JSON.stringify(res.body)).not.toContain("privateNote");
+  });
+
+  it("returns a single platform credentialing readiness profile by id", async () => {
+    seedReadinessContext();
+    const router = (await import("../adminPlatformCredentialingRoutes")).default;
+    const list = await invokeRouter(router, { method: "GET", url: "/platform-credentialing-readiness" });
+    const id = list.body.readiness[0].platformCredentialingId;
+
+    const res = await invokeRouter(router, { method: "GET", url: `/platform-credentialing-readiness/${encodeURIComponent(id)}` });
+
+    expect(res.status).toBe(200);
+    expect(res.body.readiness.platformCredentialingId).toBe(id);
+  });
+
+  it("filters by status", async () => {
+    seedReadinessContext();
+    const router = (await import("../adminPlatformCredentialingRoutes")).default;
+
+    const filtered = await invokeRouter(router, { method: "GET", url: "/platform-credentialing-readiness?status=blocked" });
+
+    expect(filtered.status).toBe(200);
+    expect(filtered.body.readiness).toEqual([]);
+  });
+});

--- a/rentchain-api/src/routes/adminPlatformCredentialingRoutes.ts
+++ b/rentchain-api/src/routes/adminPlatformCredentialingRoutes.ts
@@ -1,0 +1,158 @@
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { requireAuth } from "../middleware/requireAuth";
+import { requirePermission } from "../middleware/requireAuthz";
+import { derivePlatformCredentialingReadiness } from "../lib/platformCredentialing/derivePlatformCredentialingReadiness";
+import type {
+  PlatformCredentialingReadiness,
+  PlatformCredentialingStatus,
+} from "../lib/platformCredentialing/platformCredentialingTypes";
+
+const router = Router();
+
+const READINESS_KEY = "institutional-platform-credentialing-readiness-v1";
+const STATUSES = new Set<PlatformCredentialingStatus>([
+  "ready_for_review",
+  "partially_ready",
+  "review_required",
+  "blocked",
+  "unknown",
+]);
+
+const PRIVACY_READINESS = [
+  { privacyReadinessId: "privacy-compliance-governance-baseline", status: "ready_for_review" },
+];
+
+const CONSENT_GOVERNANCE = [
+  { consentGovernanceId: "identity-consent-governance-baseline", status: "ready_for_review" },
+];
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+async function loadCollection(collectionName: string, limit = 25) {
+  const snap = await db.collection(collectionName).get().catch(() => null);
+  return (snap?.docs || []).slice(0, limit).map((doc) => sanitizeRecord({ id: doc.id, ...((doc.data() as any) || {}) }));
+}
+
+function sanitizeRecord(record: Record<string, any>) {
+  const safe: Record<string, any> = {};
+  for (const key of [
+    "id",
+    "status",
+    "state",
+    "conclusion",
+    "governanceReadinessId",
+    "privacyReadinessId",
+    "policyId",
+    "consentGovernanceId",
+    "consentId",
+    "identityConsentId",
+    "verificationReadinessId",
+    "identityProfileId",
+    "participantId",
+    "adapterReadinessId",
+    "controlledIntegrationId",
+    "onboardingReadinessId",
+    "institutionOnboardingId",
+    "operationalRiskId",
+    "releaseGovernanceId",
+    "publicExposureHardeningId",
+    "commercialReadinessId",
+    "ecosystemCoordinationId",
+    "evidencePackId",
+    "reviewSessionId",
+    "eventId",
+    "eventType",
+    "resourceType",
+    "resourceId",
+    "createdAt",
+    "updatedAt",
+    "redacted",
+  ]) {
+    if (record[key] !== undefined) safe[key] = record[key];
+  }
+  return safe;
+}
+
+async function buildPlatformCredentialingReadiness(): Promise<PlatformCredentialingReadiness[]> {
+  const [
+    governanceReadiness,
+    privacyReadiness,
+    consentGovernance,
+    auditLineage,
+    verificationReadiness,
+    interoperabilityReadiness,
+    controlledIntegrations,
+    onboardingReadiness,
+    operationalRiskProfiles,
+    evidencePacks,
+    reviews,
+  ] = await Promise.all([
+    Promise.all([
+      loadCollection("releaseGovernanceProfiles"),
+      loadCollection("publicExposureHardeningProfiles"),
+      loadCollection("commercialReadinessProfiles"),
+      loadCollection("ecosystemCoordinationSnapshots"),
+    ]).then((groups) => groups.flat()),
+    loadCollection("privacyReadiness"),
+    loadCollection("consentGovernance"),
+    loadCollection("events"),
+    Promise.all([loadCollection("identityProfiles"), loadCollection("networkParticipantProfiles")]).then((groups) => groups.flat()),
+    loadCollection("interoperabilityAdapterReadiness"),
+    loadCollection("controlledIntegrationProfiles"),
+    loadCollection("institutionOnboardingReadiness"),
+    loadCollection("operationalRiskProfiles"),
+    loadCollection("evidencePacks"),
+    loadCollection("operatorReviewSessions"),
+  ]);
+
+  return [
+    derivePlatformCredentialingReadiness({
+      readinessKey: READINESS_KEY,
+      governanceReadiness,
+      privacyReadiness: privacyReadiness.length ? privacyReadiness : PRIVACY_READINESS,
+      consentGovernance: consentGovernance.length ? consentGovernance : CONSENT_GOVERNANCE,
+      auditLineage,
+      verificationReadiness,
+      interoperabilityReadiness: [...interoperabilityReadiness, ...controlledIntegrations],
+      institutionOnboardingReadiness: onboardingReadiness,
+      operationalRiskProfiles,
+      evidencePacks,
+      operatorReviewSessions: reviews,
+    }),
+  ];
+}
+
+function readinessMatches(readiness: PlatformCredentialingReadiness, id: string) {
+  return readiness.platformCredentialingId === id;
+}
+
+router.get("/platform-credentialing-readiness", requireAuth, requirePermission("system.admin"), async (req: any, res) => {
+  try {
+    const status = asString(req.query?.status, 80) as PlatformCredentialingStatus;
+    let readiness = await buildPlatformCredentialingReadiness();
+    if (status && STATUSES.has(status)) readiness = readiness.filter((profile) => profile.status === status);
+    return res.json({ ok: true, readiness });
+  } catch (err: any) {
+    console.error("[admin-platform-credentialing] list failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "PLATFORM_CREDENTIALING_READINESS_FAILED" });
+  }
+});
+
+router.get("/platform-credentialing-readiness/:platformCredentialingId", requireAuth, requirePermission("system.admin"), async (req: any, res) => {
+  try {
+    const platformCredentialingId = decodeURIComponent(asString(req.params?.platformCredentialingId, 500));
+    if (!platformCredentialingId) return res.status(400).json({ ok: false, error: "PLATFORM_CREDENTIALING_ID_REQUIRED" });
+    const readiness = await buildPlatformCredentialingReadiness();
+    const profile = readiness.find((next) => readinessMatches(next, platformCredentialingId));
+    if (!profile) return res.status(404).json({ ok: false, error: "PLATFORM_CREDENTIALING_NOT_FOUND" });
+    return res.json({ ok: true, readiness: profile });
+  } catch (err: any) {
+    console.error("[admin-platform-credentialing] get failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "PLATFORM_CREDENTIALING_GET_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -117,6 +117,7 @@ const PublicExposureHardeningPage = lazy(() => import("./pages/PublicExposureHar
 const CommercialReadinessPage = lazy(() => import("./pages/CommercialReadinessPage"));
 const ControlledIntegrationsPage = lazy(() => import("./pages/ControlledIntegrationsPage"));
 const EcosystemCoordinationPage = lazy(() => import("./pages/EcosystemCoordinationPage"));
+const PlatformCredentialingReadinessPage = lazy(() => import("./pages/PlatformCredentialingReadinessPage"));
 const PortfolioScorePage = lazy(() => import("./pages/admin/PortfolioScorePage"));
 const PortfolioScoreHistoryPage = lazy(() => import("./pages/admin/PortfolioScoreHistoryPage"));
 const PortfolioHealthSummaryPage = lazy(() => import("./pages/landlord/PortfolioHealthSummaryPage"));
@@ -1331,6 +1332,14 @@ function App() {
               element={
                 <RequireAdmin>
                   <EcosystemCoordinationPage />
+                </RequireAdmin>
+              }
+            />
+            <Route
+              path="/admin/platform-credentialing-readiness"
+              element={
+                <RequireAdmin>
+                  <PlatformCredentialingReadinessPage />
                 </RequireAdmin>
               }
             />

--- a/rentchain-frontend/src/api/platformCredentialingApi.ts
+++ b/rentchain-frontend/src/api/platformCredentialingApi.ts
@@ -1,0 +1,83 @@
+import { apiFetch } from "./apiFetch";
+
+export type PlatformCredentialingStatus = "ready_for_review" | "partially_ready" | "review_required" | "blocked" | "unknown";
+export type CredentialingReferenceType =
+  | "governance"
+  | "privacy"
+  | "consent"
+  | "audit"
+  | "verification"
+  | "interoperability"
+  | "evidence"
+  | "review";
+export type CredentialingReferenceStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+
+export type CredentialingReference = {
+  referenceId: string;
+  referenceType: CredentialingReferenceType;
+  status: CredentialingReferenceStatus;
+  label: string;
+  description: string;
+  reviewRequired: true;
+  lineageReferences: string[];
+  destination: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type CredentialingRestriction = {
+  restrictionId: string;
+  restrictionType: CredentialingReferenceType | "consumer_reporting" | "bureau_execution" | "credential_marketplace";
+  status: "visible" | "blocked" | "review_required";
+  label: string;
+  description: string;
+  blockedReason: string | null;
+};
+
+export type PlatformCredentialingReadiness = {
+  platformCredentialingId: string;
+  status: PlatformCredentialingStatus;
+  manualApprovalRequired: true;
+  consumerReportingExecutionEnabled: false;
+  autonomousCredentialApprovalEnabled: false;
+  publicCredentialExposureEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    partiallyVerifiedReferences: number;
+    blockedReferences: number;
+    unavailableReferences: number;
+    restrictions: number;
+  };
+  governanceReferences: CredentialingReference[];
+  privacyReferences: CredentialingReference[];
+  consentReferences: CredentialingReference[];
+  auditReferences: CredentialingReference[];
+  verificationReferences: CredentialingReference[];
+  interoperabilityReferences: CredentialingReference[];
+  reviewReferences: CredentialingReference[];
+  evidenceReferences: CredentialingReference[];
+  credentialingRestrictions: CredentialingRestriction[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: Array<{ eventType: string; action: string; status: PlatformCredentialingStatus; resourceId: string; summary: string }>;
+};
+
+export async function fetchPlatformCredentialingReadiness(params?: {
+  status?: PlatformCredentialingStatus | "";
+}): Promise<PlatformCredentialingReadiness[]> {
+  const search = new URLSearchParams();
+  if (params?.status) search.set("status", params.status);
+  const suffix = search.toString() ? `?${search.toString()}` : "";
+  const response = await apiFetch<{ ok: true; readiness: PlatformCredentialingReadiness[] }>(`/admin/platform-credentialing-readiness${suffix}`);
+  return response.readiness;
+}
+
+export async function fetchPlatformCredentialingReadinessById(platformCredentialingId: string): Promise<PlatformCredentialingReadiness> {
+  const response = await apiFetch<{ ok: true; readiness: PlatformCredentialingReadiness }>(
+    `/admin/platform-credentialing-readiness/${encodeURIComponent(platformCredentialingId)}`
+  );
+  return response.readiness;
+}

--- a/rentchain-frontend/src/components/credentialing/PlatformCredentialingPanel.test.tsx
+++ b/rentchain-frontend/src/components/credentialing/PlatformCredentialingPanel.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import type { PlatformCredentialingReadiness } from "@/api/platformCredentialingApi";
+import { PlatformCredentialingPanel } from "./PlatformCredentialingPanel";
+
+const readiness: PlatformCredentialingReadiness = {
+  platformCredentialingId: "platform_credentialing:institutional:v1",
+  status: "blocked",
+  manualApprovalRequired: true,
+  consumerReportingExecutionEnabled: false,
+  autonomousCredentialApprovalEnabled: false,
+  publicCredentialExposureEnabled: false,
+  generatedAt: "2026-05-07T00:00:00.000Z",
+  summary: {
+    totalReferences: 2,
+    verifiedReferences: 1,
+    partiallyVerifiedReferences: 0,
+    blockedReferences: 1,
+    unavailableReferences: 0,
+    restrictions: 1,
+  },
+  governanceReferences: [],
+  privacyReferences: [
+    {
+      referenceId: "privacy-1",
+      referenceType: "privacy",
+      status: "blocked",
+      label: "Privacy posture reference",
+      description: "Privacy posture metadata is available.",
+      reviewRequired: true,
+      lineageReferences: ["privacy-1"],
+      destination: "/identity-layer",
+      redacted: false,
+      redactionReason: null,
+      blockedReason: "Privacy or compliance posture is blocked.",
+    },
+  ],
+  consentReferences: [],
+  auditReferences: [],
+  verificationReferences: [],
+  interoperabilityReferences: [],
+  reviewReferences: [],
+  evidenceReferences: [],
+  credentialingRestrictions: [
+    {
+      restrictionId: "restriction-1",
+      restrictionType: "privacy",
+      status: "blocked",
+      label: "Privacy posture reference restriction",
+      description: "Privacy reference requires review.",
+      blockedReason: "Privacy or compliance posture is blocked.",
+    },
+  ],
+  redactions: ["Raw screening, credit bureau, government ID, tenant private document, payment account, and banking payloads are excluded."],
+  blockedReasons: ["Privacy or compliance posture is blocked."],
+  canonicalEvents: [],
+};
+
+describe("PlatformCredentialingPanel", () => {
+  it("renders credentialing readiness, restrictions, blocked reasons, and required safety copy", () => {
+    render(
+      <MemoryRouter>
+        <PlatformCredentialingPanel readiness={readiness} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("View credentialing readiness")).toBeInTheDocument();
+    expect(screen.getByText("View restrictions")).toBeInTheDocument();
+    expect(screen.getAllByText("View blocked reason: Privacy or compliance posture is blocked.").length).toBeGreaterThan(0);
+    expect(screen.getByText("Manual review required")).toBeInTheDocument();
+    expect(screen.getByText(/Platform credentialing readiness is operationally scoped and review controlled/i)).toBeInTheDocument();
+    expect(screen.getByText(/No consumer-reporting execution or autonomous credential approval is enabled/i)).toBeInTheDocument();
+    expect(screen.getByText(/Manual review remains required/i)).toBeInTheDocument();
+  });
+
+  it("does not render forbidden credentialing execution labels", () => {
+    render(
+      <MemoryRouter>
+        <PlatformCredentialingPanel readiness={readiness} />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText("Approve CRA access")).not.toBeInTheDocument();
+    expect(screen.queryByText("Enable bureau execution")).not.toBeInTheDocument();
+    expect(screen.queryByText("Autonomous onboarding")).not.toBeInTheDocument();
+    expect(screen.queryByText("Public credential listing")).not.toBeInTheDocument();
+    expect(screen.queryByText("Auto-approve credentials")).not.toBeInTheDocument();
+    expect(screen.queryByText("Enable consumer reporting")).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/credentialing/PlatformCredentialingPanel.tsx
+++ b/rentchain-frontend/src/components/credentialing/PlatformCredentialingPanel.tsx
@@ -1,0 +1,145 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import type {
+  CredentialingReference,
+  CredentialingRestriction,
+  PlatformCredentialingReadiness,
+} from "@/api/platformCredentialingApi";
+import { Card, Section } from "@/components/ui/Ui";
+
+function label(value: string) {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function tone(status: string) {
+  if (status === "blocked") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
+  if (status === "review_required" || status === "partially_ready" || status === "partially_verified" || status === "unavailable") {
+    return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
+  }
+  if (status === "ready_for_review" || status === "verified") return { color: "#166534", background: "#dcfce7", border: "#bbf7d0" };
+  return { color: "#475569", background: "#f8fafc", border: "#e2e8f0" };
+}
+
+function Badge({ children, status }: { children: React.ReactNode; status: string }) {
+  const next = tone(status);
+  return (
+    <span style={{ border: `1px solid ${next.border}`, borderRadius: 999, background: next.background, color: next.color, padding: "3px 9px", fontSize: 12, fontWeight: 900, whiteSpace: "nowrap" }}>
+      {children}
+    </span>
+  );
+}
+
+function ReferenceList({ title, references }: { title: string; references: CredentialingReference[] }) {
+  return (
+    <Section style={{ display: "grid", gap: 10 }}>
+      <div style={{ fontWeight: 900 }}>{title}</div>
+      {references.length ? (
+        references.slice(0, 12).map((reference) => (
+          <Card key={reference.referenceId} style={{ borderRadius: 8, padding: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+              <div>
+                <strong>{reference.label}</strong>
+                <div style={{ color: "#64748b", fontSize: 13 }}>{label(reference.referenceType)}</div>
+              </div>
+              <Badge status={reference.status}>{label(reference.status)}</Badge>
+            </div>
+            <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>{reference.description}</div>
+            {reference.lineageReferences.length ? <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>Lineage references: {reference.lineageReferences.length}</div> : null}
+            {reference.blockedReason ? <div style={{ color: "#991b1b", fontSize: 13, marginTop: 8 }}>View blocked reason: {reference.blockedReason}</div> : null}
+            {reference.redacted ? <div style={{ color: "#92400e", fontSize: 13, marginTop: 8 }}>{reference.redactionReason || "Redacted credentialing readiness reference"}</div> : null}
+            {reference.destination?.startsWith("/") ? <Link to={reference.destination} style={{ color: "#2563eb", fontWeight: 800, fontSize: 13, marginTop: 8, display: "inline-block" }}>View context</Link> : null}
+          </Card>
+        ))
+      ) : (
+        <Card style={{ color: "#64748b" }}>Context unavailable</Card>
+      )}
+    </Section>
+  );
+}
+
+function RestrictionList({ restrictions }: { restrictions: CredentialingRestriction[] }) {
+  return (
+    <Section style={{ display: "grid", gap: 10 }}>
+      <div style={{ fontWeight: 900 }}>View restrictions</div>
+      {restrictions.length ? (
+        restrictions.map((restriction) => (
+          <Card key={restriction.restrictionId} style={{ borderRadius: 8, padding: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+              <div>
+                <strong>{restriction.label}</strong>
+                <div style={{ color: "#64748b", fontSize: 13 }}>{label(restriction.restrictionType)}</div>
+              </div>
+              <Badge status={restriction.status}>{label(restriction.status)}</Badge>
+            </div>
+            <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>{restriction.description}</div>
+            {restriction.blockedReason ? <div style={{ color: "#991b1b", fontSize: 13, marginTop: 8 }}>View blocked reason: {restriction.blockedReason}</div> : null}
+          </Card>
+        ))
+      ) : (
+        <Card style={{ color: "#64748b" }}>No credentialing restrictions detected.</Card>
+      )}
+    </Section>
+  );
+}
+
+export function PlatformCredentialingPanel({ readiness }: { readiness: PlatformCredentialingReadiness }) {
+  return (
+    <div style={{ display: "grid", gap: 16 }}>
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+          <div>
+            <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>View credentialing readiness</div>
+            <h2 style={{ margin: "2px 0 0", fontSize: "1.15rem" }}>Platform credentialing readiness</h2>
+          </div>
+          <Badge status={readiness.status}>{label(readiness.status)}</Badge>
+        </div>
+        <div style={{ color: "#475569", lineHeight: 1.55 }}>
+          Platform credentialing readiness is operationally scoped and review controlled. No consumer-reporting execution or autonomous credential approval is enabled.
+          Manual review remains required.
+        </div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <Badge status="review_required">Manual review required</Badge>
+          <Badge status={readiness.consumerReportingExecutionEnabled ? "blocked" : "verified"}>Consumer-reporting execution disabled</Badge>
+          <Badge status={readiness.autonomousCredentialApprovalEnabled ? "blocked" : "verified"}>Credential approval disabled</Badge>
+          <Badge status={readiness.publicCredentialExposureEnabled ? "blocked" : "verified"}>Public credential exposure disabled</Badge>
+        </div>
+      </Section>
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Credentialing summary</div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: 10 }}>
+          {[
+            ["References", readiness.summary.totalReferences],
+            ["Verified", readiness.summary.verifiedReferences],
+            ["Partial", readiness.summary.partiallyVerifiedReferences],
+            ["Blocked", readiness.summary.blockedReferences],
+            ["Unavailable", readiness.summary.unavailableReferences],
+            ["Restrictions", readiness.summary.restrictions],
+          ].map(([name, value]) => (
+            <Card key={String(name)} style={{ borderRadius: 8, padding: 12 }}>
+              <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>{name}</div>
+              <strong style={{ color: "#0f172a", fontSize: 22 }}>{String(value)}</strong>
+            </Card>
+          ))}
+        </div>
+      </Section>
+
+      <RestrictionList restrictions={readiness.credentialingRestrictions} />
+      <ReferenceList title="View governance references" references={readiness.governanceReferences} />
+      <ReferenceList title="Privacy readiness" references={readiness.privacyReferences} />
+      <ReferenceList title="View consent lineage" references={readiness.consentReferences} />
+      <ReferenceList title="View audit lineage" references={readiness.auditReferences} />
+      <ReferenceList title="Verification support" references={readiness.verificationReferences} />
+      <ReferenceList title="Interoperability governance" references={readiness.interoperabilityReferences} />
+      <ReferenceList title="View evidence lineage" references={readiness.evidenceReferences} />
+      <ReferenceList title="Review lineage" references={readiness.reviewReferences} />
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Redactions</div>
+        {readiness.redactions.map((redaction) => (
+          <Card key={redaction} style={{ borderRadius: 8, padding: 12, color: "#475569" }}>{redaction}</Card>
+        ))}
+      </Section>
+    </div>
+  );
+}

--- a/rentchain-frontend/src/pages/PlatformCredentialingReadinessPage.test.tsx
+++ b/rentchain-frontend/src/pages/PlatformCredentialingReadinessPage.test.tsx
@@ -1,0 +1,96 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import PlatformCredentialingReadinessPage from "./PlatformCredentialingReadinessPage";
+
+const mockFetchReadiness = vi.fn();
+const mockShowToast = vi.fn();
+
+vi.mock("@/api/platformCredentialingApi", () => ({
+  fetchPlatformCredentialingReadiness: (...args: any[]) => mockFetchReadiness(...args),
+}));
+
+vi.mock("@/components/layout/MacShell", () => ({
+  MacShell: ({ children, title }: any) => <main aria-label={title}>{children}</main>,
+}));
+
+vi.mock("@/components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
+const readiness = {
+  platformCredentialingId: "platform_credentialing:institutional:v1",
+  status: "ready_for_review",
+  manualApprovalRequired: true,
+  consumerReportingExecutionEnabled: false,
+  autonomousCredentialApprovalEnabled: false,
+  publicCredentialExposureEnabled: false,
+  generatedAt: "2026-05-07T00:00:00.000Z",
+  summary: {
+    totalReferences: 1,
+    verifiedReferences: 1,
+    partiallyVerifiedReferences: 0,
+    blockedReferences: 0,
+    unavailableReferences: 0,
+    restrictions: 0,
+  },
+  governanceReferences: [],
+  privacyReferences: [],
+  consentReferences: [],
+  auditReferences: [],
+  verificationReferences: [],
+  interoperabilityReferences: [],
+  reviewReferences: [],
+  evidenceReferences: [],
+  credentialingRestrictions: [],
+  redactions: ["Sensitive credentialing payloads are excluded."],
+  blockedReasons: [],
+  canonicalEvents: [],
+};
+
+describe("PlatformCredentialingReadinessPage", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    mockFetchReadiness.mockResolvedValue([readiness]);
+  });
+
+  it("loads and renders platform credentialing readiness with required safety copy", async () => {
+    render(
+      <MemoryRouter>
+        <PlatformCredentialingReadinessPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Loading platform credentialing readiness...")).toBeInTheDocument();
+    expect(await screen.findByText("Credentialing summary")).toBeInTheDocument();
+    expect(screen.getAllByText(/Platform credentialing readiness is operationally scoped and review controlled/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Manual review remains required/i).length).toBeGreaterThan(0);
+    expect(mockFetchReadiness).toHaveBeenCalledWith({ status: "" });
+  });
+
+  it("filters readiness by status", async () => {
+    render(
+      <MemoryRouter>
+        <PlatformCredentialingReadinessPage />
+      </MemoryRouter>
+    );
+
+    fireEvent.change((await screen.findAllByLabelText("Status"))[0], { target: { value: "blocked" } });
+    await waitFor(() => {
+      expect(mockFetchReadiness).toHaveBeenLastCalledWith({ status: "blocked" });
+    });
+  });
+
+  it("renders the empty state", async () => {
+    mockFetchReadiness.mockResolvedValue([]);
+
+    render(
+      <MemoryRouter>
+        <PlatformCredentialingReadinessPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("No platform credentialing readiness profiles match these filters.")).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/PlatformCredentialingReadinessPage.tsx
+++ b/rentchain-frontend/src/pages/PlatformCredentialingReadinessPage.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { useSearchParams } from "react-router-dom";
+import {
+  fetchPlatformCredentialingReadiness,
+  type PlatformCredentialingReadiness,
+  type PlatformCredentialingStatus,
+} from "@/api/platformCredentialingApi";
+import { PlatformCredentialingPanel } from "@/components/credentialing/PlatformCredentialingPanel";
+import { MacShell } from "@/components/layout/MacShell";
+import { Card, Section } from "@/components/ui/Ui";
+import { useToast } from "@/components/ui/ToastProvider";
+
+const statuses: Array<PlatformCredentialingStatus | ""> = ["", "ready_for_review", "partially_ready", "review_required", "blocked", "unknown"];
+
+function label(value: string) {
+  return value ? value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase()) : "All";
+}
+
+export default function PlatformCredentialingReadinessPage() {
+  const { showToast } = useToast();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [readiness, setReadiness] = React.useState<PlatformCredentialingReadiness[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const status = String(searchParams.get("status") || "") as PlatformCredentialingStatus | "";
+
+  React.useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const next = await fetchPlatformCredentialingReadiness({ status });
+        if (mounted) setReadiness(next);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Failed to load platform credentialing readiness";
+        if (mounted) {
+          setError(message);
+          showToast({ message: "Failed to load platform credentialing readiness", description: message, variant: "error" });
+        }
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [status, showToast]);
+
+  function updateStatus(value: string) {
+    const params = new URLSearchParams(searchParams);
+    if (value && value.trim()) params.set("status", value.trim());
+    else params.delete("status");
+    setSearchParams(params);
+  }
+
+  return (
+    <MacShell title="Platform credentialing readiness" showTopNav={false}>
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "grid", gap: 6 }}>
+            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Platform credentialing readiness</h1>
+            <div style={{ color: "#475569", maxWidth: 900 }}>
+              Platform credentialing readiness is operationally scoped and review controlled. No consumer-reporting execution or autonomous credential approval is enabled.
+              Manual review remains required.
+            </div>
+          </div>
+        </Section>
+
+        <Section style={{ display: "flex", gap: 10, flexWrap: "wrap", alignItems: "end" }}>
+          <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Status
+            <select value={status} onChange={(event) => updateStatus(event.target.value)} style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 180 }}>
+              {statuses.map((item) => <option key={item || "all"} value={item}>{label(item)}</option>)}
+            </select>
+          </label>
+        </Section>
+
+        {loading ? <Card>Loading platform credentialing readiness...</Card> : null}
+        {!loading && error ? <Card style={{ color: "#b91c1c" }}>We couldn't load platform credentialing readiness right now.</Card> : null}
+        {!loading && !error && !readiness.length ? <Card style={{ color: "#64748b" }}>No platform credentialing readiness profiles match these filters.</Card> : null}
+        {!loading && !error && readiness.length ? (
+          <div style={{ display: "grid", gap: 16 }}>{readiness.map((profile) => <PlatformCredentialingPanel key={profile.platformCredentialingId} readiness={profile} />)}</div>
+        ) : null}
+      </div>
+    </MacShell>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a deterministic, admin-scoped Platform Credentialing Readiness read model for institutional/platform onboarding preparedness.
- Adds read-only admin endpoints for platform credentialing readiness.
- Adds an admin Platform Credentialing Readiness UI surface with required review-control safety copy and no execution controls.

## Guardrails
- Manual approval remains required.
- Consumer-reporting execution remains disabled.
- Autonomous credential approval remains disabled.
- Public credential exposure remains disabled.
- No CRA status claims, bureau integrations, consumer-reporting execution, autonomous onboarding, public credential marketplace, or hidden credential execution path was added.
- Backend route sanitizes source records through a whitelist projection before derivation.

## Verification
- Backend targeted tests: `npm test -- --run src/lib/platformCredentialing/__tests__/derivePlatformCredentialingReadiness.test.ts src/routes/__tests__/adminPlatformCredentialingRoutes.test.ts` (9/9 passed)
- Frontend targeted tests: `npm test -- --run src/components/credentialing/PlatformCredentialingPanel.test.tsx src/pages/PlatformCredentialingReadinessPage.test.tsx` (5/5 passed)
- Backend build: `npm run build` passed
- Frontend build: `npm run build` passed; existing large App chunk warning remains non-regressive and the new page is emitted as a separate lazy chunk
- `git diff --check` passed
- `git diff --cached --check` passed
- Dependency/lockfile diff: empty
- Forbidden credentialing execution-label scan: clean