### PR TITLE
feat: add consumer reporting governance layer

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -118,6 +118,7 @@ import adminCommercialReadinessRoutes from "./routes/adminCommercialReadinessRou
 import adminControlledIntegrationsRoutes from "./routes/adminControlledIntegrationsRoutes";
 import adminEcosystemCoordinationRoutes from "./routes/adminEcosystemCoordinationRoutes";
 import adminPlatformCredentialingRoutes from "./routes/adminPlatformCredentialingRoutes";
+import adminConsumerReportingGovernanceRoutes from "./routes/adminConsumerReportingGovernanceRoutes";
 import portfolioScoreRoutes from "./routes/portfolioScoreRoutes";
 import portfolioScoreHistoryRoutes from "./routes/portfolioScoreHistoryRoutes";
 import landlordPortfolioHealthRoutes from "./routes/landlordPortfolioHealthRoutes";
@@ -302,6 +303,8 @@ app.use("/api/admin", routeSource("adminEcosystemCoordinationRoutes.ts"), adminE
 console.log("[route-mount] adminEcosystemCoordinationRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("adminPlatformCredentialingRoutes.ts"), adminPlatformCredentialingRoutes);
 console.log("[route-mount] adminPlatformCredentialingRoutes mounted at /api/admin");
+app.use("/api/admin", routeSource("adminConsumerReportingGovernanceRoutes.ts"), adminConsumerReportingGovernanceRoutes);
+console.log("[route-mount] adminConsumerReportingGovernanceRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("portfolioScoreRoutes.ts"), portfolioScoreRoutes);
 console.log("[route-mount] portfolioScoreRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("portfolioScoreHistoryRoutes.ts"), portfolioScoreHistoryRoutes);

--- a/rentchain-api/src/lib/consumerReportingGovernance/__tests__/deriveConsumerReportingGovernanceProfile.test.ts
+++ b/rentchain-api/src/lib/consumerReportingGovernance/__tests__/deriveConsumerReportingGovernanceProfile.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { deriveConsumerReportingGovernanceProfile } from "../deriveConsumerReportingGovernanceProfile";
+
+const completeInput = {
+  generatedAt: "2026-05-07T00:00:00.000Z",
+  consentGovernance: [{ consentGovernanceId: "consent-1", status: "ready_for_review" }],
+  disputeGovernance: [{ disputeGovernanceId: "dispute-1", status: "ready_for_review" }],
+  adverseActionReadiness: [{ adverseActionReadinessId: "adverse-1", status: "ready_for_review" }],
+  credentialingReadiness: [{ platformCredentialingId: "credentialing-1", status: "ready_for_review" }],
+  operationalRiskProfiles: [{ operationalRiskId: "risk-1", status: "stable" }],
+  rentalHistoryLineage: [{ rentalHistoryLedgerId: "ledger-1", status: "verified" }],
+  evidencePacks: [{ evidencePackId: "evidence-1", status: "ready_for_review" }],
+  operatorReviewSessions: [{ reviewSessionId: "review-1", status: "completed" }],
+  auditEvents: [{ eventId: "audit-1", eventType: "consumer_reporting_governance_profile_derived" }],
+};
+
+describe("deriveConsumerReportingGovernanceProfile", () => {
+  it("derives a deterministic ready-for-review profile with execution flags pinned off", () => {
+    const profile = deriveConsumerReportingGovernanceProfile(completeInput);
+    const repeat = deriveConsumerReportingGovernanceProfile(completeInput);
+
+    expect(profile).toEqual(repeat);
+    expect(profile.status).toBe("ready_for_review");
+    expect(profile).toEqual(
+      expect.objectContaining({
+        manualApprovalRequired: true,
+        consumerReportingExecutionEnabled: false,
+        autonomousReportingEnabled: false,
+        publicReportingExposureEnabled: false,
+      })
+    );
+    expect(profile.summary).toEqual(
+      expect.objectContaining({
+        totalReferences: 9,
+        verifiedReferences: 9,
+        restrictions: 0,
+      })
+    );
+  });
+
+  it("blocks unresolved consent and dispute restrictions", () => {
+    const profile = deriveConsumerReportingGovernanceProfile({
+      ...completeInput,
+      consentGovernance: [{ consentGovernanceId: "consent-1", status: "blocked" }],
+      disputeGovernance: [{ disputeGovernanceId: "dispute-1", status: "blocked" }],
+    });
+
+    expect(profile.status).toBe("blocked");
+    expect(profile.reportingRestrictions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ restrictionType: "consent", status: "blocked" }),
+        expect.objectContaining({ restrictionType: "dispute", status: "blocked" }),
+      ])
+    );
+  });
+
+  it("requires review when critical consent, dispute, audit, evidence, or review lineage is missing", () => {
+    const profile = deriveConsumerReportingGovernanceProfile({
+      ...completeInput,
+      consentGovernance: [],
+      disputeGovernance: [],
+      evidencePacks: [],
+      operatorReviewSessions: [],
+      auditEvents: [],
+    });
+
+    expect(profile.status).toBe("review_required");
+    expect(profile.reportingRestrictions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ restrictionType: "consent", status: "review_required" }),
+        expect.objectContaining({ restrictionType: "dispute", status: "review_required" }),
+        expect.objectContaining({ restrictionType: "evidence", status: "review_required" }),
+        expect.objectContaining({ restrictionType: "review", status: "review_required" }),
+        expect.objectContaining({ restrictionType: "audit", status: "review_required" }),
+      ])
+    );
+  });
+
+  it("marks unresolved operational risk as partially ready without autonomous reporting", () => {
+    const profile = deriveConsumerReportingGovernanceProfile({
+      ...completeInput,
+      operationalRiskProfiles: [{ operationalRiskId: "risk-1", status: "elevated" }],
+    });
+
+    expect(profile.status).toBe("partially_ready");
+    expect(profile.reportingRestrictions).toEqual(
+      expect.arrayContaining([expect.objectContaining({ restrictionType: "credentialing", status: "blocked" })])
+    );
+    expect(profile.autonomousReportingEnabled).toBe(false);
+  });
+
+  it("returns unknown when there is insufficient source context", () => {
+    const profile = deriveConsumerReportingGovernanceProfile({});
+
+    expect(profile.status).toBe("unknown");
+    expect(profile.summary.unavailableReferences).toBeGreaterThan(0);
+    expect(profile.canonicalEvents.map((event) => event.eventType)).toEqual(
+      expect.arrayContaining(["consumer_reporting_governance_profile_derived", "consumer_reporting_redaction_applied"])
+    );
+  });
+
+  it("generates canonical events for restriction, review-required, blocked, and redaction paths", () => {
+    const blocked = deriveConsumerReportingGovernanceProfile({
+      ...completeInput,
+      consentGovernance: [{ consentGovernanceId: "consent-1", status: "blocked" }],
+    });
+
+    expect(blocked.canonicalEvents.map((event) => event.eventType)).toEqual(
+      expect.arrayContaining([
+        "consumer_reporting_governance_profile_derived",
+        "consumer_reporting_redaction_applied",
+        "consumer_reporting_restriction_detected",
+        "consumer_reporting_blocked",
+      ])
+    );
+  });
+});

--- a/rentchain-api/src/lib/consumerReportingGovernance/consumerReportingGovernanceTypes.ts
+++ b/rentchain-api/src/lib/consumerReportingGovernance/consumerReportingGovernanceTypes.ts
@@ -1,0 +1,94 @@
+export type ConsumerReportingGovernanceStatus = "ready_for_review" | "partially_ready" | "review_required" | "blocked" | "unknown";
+
+export type ReportingReferenceType =
+  | "consent"
+  | "dispute"
+  | "adverse_action"
+  | "credentialing"
+  | "review"
+  | "evidence"
+  | "audit";
+
+export type ReportingReferenceStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+
+export type ConsumerReportingCanonicalEventType =
+  | "consumer_reporting_governance_profile_derived"
+  | "consumer_reporting_review_required"
+  | "consumer_reporting_blocked"
+  | "consumer_reporting_restriction_detected"
+  | "consumer_reporting_redaction_applied";
+
+export type ReportingReference = {
+  referenceId: string;
+  referenceType: ReportingReferenceType;
+  status: ReportingReferenceStatus;
+  label: string;
+  description: string;
+  reviewRequired: true;
+  lineageReferences: string[];
+  destination: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type ReportingRestriction = {
+  restrictionId: string;
+  restrictionType: ReportingReferenceType | "bureau_execution" | "collections_execution" | "public_scoring";
+  status: "visible" | "blocked" | "review_required";
+  label: string;
+  description: string;
+  blockedReason: string | null;
+};
+
+export type ConsumerReportingCanonicalEvent = {
+  eventType: ConsumerReportingCanonicalEventType;
+  action: string;
+  status: ConsumerReportingGovernanceStatus;
+  resourceType: "consumer_reporting_governance_profile";
+  resourceId: string;
+  summary: string;
+};
+
+export type ConsumerReportingGovernanceProfile = {
+  consumerReportingGovernanceId: string;
+  status: ConsumerReportingGovernanceStatus;
+  manualApprovalRequired: true;
+  consumerReportingExecutionEnabled: false;
+  autonomousReportingEnabled: false;
+  publicReportingExposureEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    partiallyVerifiedReferences: number;
+    blockedReferences: number;
+    unavailableReferences: number;
+    restrictions: number;
+  };
+  consentReferences: ReportingReference[];
+  disputeReferences: ReportingReference[];
+  adverseActionReferences: ReportingReference[];
+  credentialingReferences: ReportingReference[];
+  reviewReferences: ReportingReference[];
+  evidenceReferences: ReportingReference[];
+  auditReferences: ReportingReference[];
+  reportingRestrictions: ReportingRestriction[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: ConsumerReportingCanonicalEvent[];
+};
+
+export type DeriveConsumerReportingGovernanceProfileInput = {
+  governanceKey?: unknown;
+  generatedAt?: unknown;
+  consentGovernance?: Array<Record<string, any>> | null;
+  disputeGovernance?: Array<Record<string, any>> | null;
+  adverseActionReadiness?: Array<Record<string, any>> | null;
+  credentialingReadiness?: Array<Record<string, any>> | null;
+  operationalRiskProfiles?: Array<Record<string, any>> | null;
+  rentalHistoryLineage?: Array<Record<string, any>> | null;
+  evidencePacks?: Array<Record<string, any>> | null;
+  operatorReviewSessions?: Array<Record<string, any>> | null;
+  auditEvents?: Array<Record<string, any>> | null;
+};

--- a/rentchain-api/src/lib/consumerReportingGovernance/deriveConsumerReportingGovernanceProfile.ts
+++ b/rentchain-api/src/lib/consumerReportingGovernance/deriveConsumerReportingGovernanceProfile.ts
@@ -1,0 +1,327 @@
+import type {
+  ConsumerReportingCanonicalEvent,
+  ConsumerReportingGovernanceProfile,
+  ConsumerReportingGovernanceStatus,
+  DeriveConsumerReportingGovernanceProfileInput,
+  ReportingReference,
+  ReportingReferenceStatus,
+  ReportingReferenceType,
+} from "./consumerReportingGovernanceTypes";
+import { reportingIdPart, reportingReference, reportingRestriction } from "./reportingRestrictionModels";
+
+const DEFAULT_GOVERNANCE_KEY = "institutional-consumer-reporting-governance-v1";
+
+const REDACTIONS = [
+  "CRA status claims, bureau approval claims, bureau credentials, and reporting execution payloads are excluded.",
+  "Raw screening, credit bureau, government ID, tenant private document, payment account, and banking payloads are excluded.",
+  "Consumer reporting governance is visibility metadata only; no bureau execution, collections execution, adverse-action execution, or autonomous reporting is enabled.",
+  "Public tenant scoring, public reporting marketplaces, and unrestricted consumer-reporting distribution are excluded.",
+];
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function asArray<T>(value: T[] | null | undefined): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function generatedAt(value: unknown): string {
+  const raw = asString(value, 120);
+  const date = raw ? new Date(raw) : new Date(0);
+  return Number.isNaN(date.getTime()) ? new Date(0).toISOString() : date.toISOString();
+}
+
+function recordId(record: Record<string, any>, keys: string[]): string {
+  for (const key of keys) {
+    const value = asString(record?.[key], 240);
+    if (value) return value;
+  }
+  return asString(record?.id, 240);
+}
+
+function referenceStatus(record: Record<string, any>, verifiedStatuses: string[]): ReportingReferenceStatus {
+  const status = asString(record?.status || record?.state || record?.conclusion, 80).toLowerCase();
+  if (status === "blocked" || status === "elevated" || status === "failure" || status === "failed" || status === "error" || status === "cancelled") return "blocked";
+  if (verifiedStatuses.includes(status)) return "verified";
+  if (status === "missing" || status === "unknown" || status === "unavailable" || status === "pending") return "unavailable";
+  return "partially_verified";
+}
+
+function statusForType(referenceType: ReportingReferenceType, record: Record<string, any>): ReportingReferenceStatus {
+  if (referenceType === "credentialing") return referenceStatus(record, ["ready_for_review", "verified", "stable"]);
+  if (referenceType === "review") return referenceStatus(record, ["ready_for_review", "completed", "verified"]);
+  if (referenceType === "audit" && asString(record?.eventType, 120)) return "verified";
+  return referenceStatus(record, ["ready_for_review", "verified", "stable", "available", "configured"]);
+}
+
+function governanceStatus(hasContext: boolean, references: ReportingReference[]): ConsumerReportingGovernanceStatus {
+  if (!hasContext) return "unknown";
+  if (references.some((reference) => reference.status === "blocked" && (reference.referenceType === "consent" || reference.referenceType === "dispute"))) return "blocked";
+  const criticalMissing = references.some(
+    (reference) =>
+      reference.status === "unavailable" &&
+      (reference.referenceType === "consent" ||
+        reference.referenceType === "dispute" ||
+        reference.referenceType === "audit" ||
+        reference.referenceType === "evidence" ||
+        reference.referenceType === "review")
+  );
+  if (criticalMissing) return "review_required";
+  if (references.some((reference) => reference.status === "blocked" || reference.status === "unavailable" || reference.status === "partially_verified")) return "partially_ready";
+  return "ready_for_review";
+}
+
+function event(input: {
+  eventType: ConsumerReportingCanonicalEvent["eventType"];
+  status: ConsumerReportingGovernanceStatus;
+  consumerReportingGovernanceId: string;
+  summary: string;
+}): ConsumerReportingCanonicalEvent {
+  return {
+    eventType: input.eventType,
+    action: input.eventType.replace(/^consumer_reporting_/, "").replace(/_/g, "."),
+    status: input.status,
+    resourceType: "consumer_reporting_governance_profile",
+    resourceId: input.consumerReportingGovernanceId,
+    summary: input.summary,
+  };
+}
+
+function referencesFor(input: {
+  records: Record<string, any>[];
+  fallback: string;
+  referenceType: ReportingReferenceType;
+  idKeys: string[];
+  label: string;
+  description: string;
+  destination: string;
+  blockedReason: string;
+}): ReportingReference[] {
+  if (!input.records.length) {
+    return [
+      reportingReference({
+        idParts: [input.referenceType, "missing"],
+        referenceType: input.referenceType,
+        status: "unavailable",
+        label: input.label,
+        description: `${input.description} is unavailable for consumer reporting governance review.`,
+        destination: input.destination,
+      }),
+    ];
+  }
+  return input.records.map((record, index) => {
+    const id = recordId(record, input.idKeys) || `${input.fallback}-${index + 1}`;
+    const status = statusForType(input.referenceType, record);
+    return reportingReference({
+      idParts: [input.referenceType, id],
+      referenceType: input.referenceType,
+      status,
+      label: input.label,
+      description: `${input.description} is available for consumer reporting governance review.`,
+      lineageReferences: [id].filter(Boolean),
+      destination: input.destination,
+      redacted: Boolean(record.redacted),
+      redactionReason: record.redacted ? `${input.label} payload is redacted for reporting governance safety.` : null,
+      blockedReason: status === "blocked" ? input.blockedReason : null,
+    });
+  });
+}
+
+export function deriveConsumerReportingGovernanceProfile(input: DeriveConsumerReportingGovernanceProfileInput): ConsumerReportingGovernanceProfile {
+  const governanceKey = asString(input.governanceKey, 160) || DEFAULT_GOVERNANCE_KEY;
+  const consumerReportingGovernanceId =
+    reportingIdPart(["consumer_reporting_governance", governanceKey].join(":")) || "consumer_reporting_governance:unknown";
+
+  const consentGovernance = asArray(input.consentGovernance);
+  const disputeGovernance = asArray(input.disputeGovernance);
+  const adverseActionReadiness = asArray(input.adverseActionReadiness);
+  const credentialingReadiness = asArray(input.credentialingReadiness);
+  const operationalRiskProfiles = asArray(input.operationalRiskProfiles);
+  const rentalHistoryLineage = asArray(input.rentalHistoryLineage);
+  const evidencePacks = asArray(input.evidencePacks);
+  const reviews = asArray(input.operatorReviewSessions);
+  const auditEvents = asArray(input.auditEvents);
+
+  const consentReferences = referencesFor({
+    records: consentGovernance,
+    fallback: "consent",
+    referenceType: "consent",
+    idKeys: ["consentGovernanceId", "consentId", "identityConsentId", "id"],
+    label: "Consent governance reference",
+    description: "Consent governance and access-control metadata",
+    destination: "/identity-layer",
+    blockedReason: "Consent lineage is missing or blocked.",
+  });
+  const disputeReferences = referencesFor({
+    records: disputeGovernance,
+    fallback: "dispute",
+    referenceType: "dispute",
+    idKeys: ["disputeGovernanceId", "disputeId", "caseId", "id"],
+    label: "Dispute governance reference",
+    description: "Dispute governance readiness metadata",
+    destination: "/review-timeline",
+    blockedReason: "Dispute governance readiness is blocked.",
+  });
+  const adverseActionReferences = referencesFor({
+    records: adverseActionReadiness,
+    fallback: "adverse-action",
+    referenceType: "adverse_action",
+    idKeys: ["adverseActionReadinessId", "adverseActionId", "id"],
+    label: "Adverse-action governance reference",
+    description: "Adverse-action governance readiness metadata",
+    destination: "/review-timeline",
+    blockedReason: "Adverse-action governance readiness is blocked.",
+  });
+  const credentialingReferences = referencesFor({
+    records: [...credentialingReadiness, ...operationalRiskProfiles, ...rentalHistoryLineage],
+    fallback: "credentialing",
+    referenceType: "credentialing",
+    idKeys: ["platformCredentialingId", "operationalRiskId", "rentalHistoryLedgerId", "id"],
+    label: "Credentialing and reporting readiness reference",
+    description: "Credentialing, operational-risk, and rental-history governance metadata",
+    destination: "/admin/platform-credentialing-readiness",
+    blockedReason: "Credentialing or reporting readiness is blocked.",
+  });
+  const reviewReferences = referencesFor({
+    records: reviews,
+    fallback: "review",
+    referenceType: "review",
+    idKeys: ["reviewSessionId", "id"],
+    label: "Reporting review lineage reference",
+    description: "Reporting review lineage metadata",
+    destination: "/review-timeline",
+    blockedReason: "Reporting review lineage is blocked.",
+  });
+  const evidenceReferences = referencesFor({
+    records: evidencePacks,
+    fallback: "evidence",
+    referenceType: "evidence",
+    idKeys: ["evidencePackId", "id"],
+    label: "Reporting evidence lineage reference",
+    description: "Reporting evidence lineage metadata",
+    destination: "/evidence-packs",
+    blockedReason: "Reporting evidence lineage is blocked.",
+  });
+  const auditReferences = referencesFor({
+    records: auditEvents.slice(0, 20),
+    fallback: "audit",
+    referenceType: "audit",
+    idKeys: ["eventId", "auditId", "id"],
+    label: "Reporting audit lineage reference",
+    description: "Reporting audit lineage metadata",
+    destination: "/review-timeline",
+    blockedReason: "Reporting audit lineage is blocked.",
+  });
+
+  const allReferences = [
+    ...consentReferences,
+    ...disputeReferences,
+    ...adverseActionReferences,
+    ...credentialingReferences,
+    ...reviewReferences,
+    ...evidenceReferences,
+    ...auditReferences,
+  ];
+  const hasContext = Boolean(
+    consentGovernance.length ||
+      disputeGovernance.length ||
+      adverseActionReadiness.length ||
+      credentialingReadiness.length ||
+      operationalRiskProfiles.length ||
+      rentalHistoryLineage.length ||
+      evidencePacks.length ||
+      reviews.length ||
+      auditEvents.length
+  );
+  const status = governanceStatus(hasContext, allReferences);
+  const reportingRestrictions = allReferences
+    .filter((reference) => reference.status !== "verified")
+    .map((reference) =>
+      reportingRestriction({
+        idParts: [reference.referenceType, reference.referenceId],
+        restrictionType: reference.referenceType,
+        status: reference.status === "blocked" ? "blocked" : "review_required",
+        label: `${reference.label} restriction`,
+        description: `${reference.label} is incomplete or blocked for consumer reporting governance.`,
+        blockedReason: reference.blockedReason,
+      })
+    );
+  const blockedReasons = [...allReferences.map((reference) => reference.blockedReason), ...reportingRestrictions.map((restriction) => restriction.blockedReason)].filter(Boolean) as string[];
+
+  const canonicalEvents: ConsumerReportingCanonicalEvent[] = [
+    event({
+      eventType: "consumer_reporting_governance_profile_derived",
+      status,
+      consumerReportingGovernanceId,
+      summary:
+        "Consumer reporting governance profile derived from consent, dispute, adverse-action, credentialing, review, evidence, and audit metadata.",
+    }),
+    event({
+      eventType: "consumer_reporting_redaction_applied",
+      status,
+      consumerReportingGovernanceId,
+      summary:
+        "CRA claims, bureau credentials, raw screening, bureau, government ID, payment, private tenant, collections, and public scoring payloads were excluded.",
+    }),
+  ];
+  if (reportingRestrictions.length) {
+    canonicalEvents.push(
+      event({
+        eventType: "consumer_reporting_restriction_detected",
+        status,
+        consumerReportingGovernanceId,
+        summary: "Consumer reporting governance restrictions are visible for manual review.",
+      })
+    );
+  }
+  if (status === "review_required" || status === "partially_ready") {
+    canonicalEvents.push(
+      event({
+        eventType: "consumer_reporting_review_required",
+        status,
+        consumerReportingGovernanceId,
+        summary: "Manual consumer reporting governance review is required.",
+      })
+    );
+  }
+  if (status === "blocked") {
+    canonicalEvents.push(
+      event({
+        eventType: "consumer_reporting_blocked",
+        status,
+        consumerReportingGovernanceId,
+        summary: "Consumer reporting governance is blocked by unresolved restrictions.",
+      })
+    );
+  }
+
+  return {
+    consumerReportingGovernanceId,
+    status,
+    manualApprovalRequired: true,
+    consumerReportingExecutionEnabled: false,
+    autonomousReportingEnabled: false,
+    publicReportingExposureEnabled: false,
+    generatedAt: generatedAt(input.generatedAt),
+    summary: {
+      totalReferences: allReferences.length,
+      verifiedReferences: allReferences.filter((reference) => reference.status === "verified").length,
+      partiallyVerifiedReferences: allReferences.filter((reference) => reference.status === "partially_verified").length,
+      blockedReferences: allReferences.filter((reference) => reference.status === "blocked").length,
+      unavailableReferences: allReferences.filter((reference) => reference.status === "unavailable").length,
+      restrictions: reportingRestrictions.length,
+    },
+    consentReferences,
+    disputeReferences,
+    adverseActionReferences,
+    credentialingReferences,
+    reviewReferences,
+    evidenceReferences,
+    auditReferences,
+    reportingRestrictions,
+    redactions: REDACTIONS,
+    blockedReasons,
+    canonicalEvents,
+  };
+}

--- a/rentchain-api/src/lib/consumerReportingGovernance/reportingRestrictionModels.ts
+++ b/rentchain-api/src/lib/consumerReportingGovernance/reportingRestrictionModels.ts
@@ -1,0 +1,63 @@
+import type {
+  ReportingReference,
+  ReportingReferenceStatus,
+  ReportingReferenceType,
+  ReportingRestriction,
+} from "./consumerReportingGovernanceTypes";
+
+export function reportingIdPart(value: unknown) {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 240);
+}
+
+export function reportingReference(input: {
+  idParts: unknown[];
+  referenceType: ReportingReferenceType;
+  status: ReportingReferenceStatus;
+  label: string;
+  description: string;
+  lineageReferences?: string[];
+  destination?: string | null;
+  redacted?: boolean;
+  redactionReason?: string | null;
+  blockedReason?: string | null;
+}): ReportingReference {
+  const referenceId = reportingIdPart(input.idParts.filter(Boolean).join(":")) || `${input.referenceType}:unknown`;
+  return {
+    referenceId,
+    referenceType: input.referenceType,
+    status: input.status,
+    label: input.label,
+    description: input.description,
+    reviewRequired: true,
+    lineageReferences: Array.from(new Set(input.lineageReferences || [])).filter(Boolean).slice(0, 20),
+    destination: input.destination || null,
+    redacted: Boolean(input.redacted),
+    redactionReason: input.redactionReason || null,
+    blockedReason: input.blockedReason || null,
+  };
+}
+
+export function reportingRestriction(input: {
+  idParts: unknown[];
+  restrictionType: ReportingRestriction["restrictionType"];
+  status: ReportingRestriction["status"];
+  label: string;
+  description: string;
+  blockedReason?: string | null;
+}): ReportingRestriction {
+  const restrictionId = reportingIdPart(["reporting_restriction", ...input.idParts].filter(Boolean).join(":"));
+  return {
+    restrictionId: restrictionId || "reporting_restriction:unknown",
+    restrictionType: input.restrictionType,
+    status: input.status,
+    label: input.label,
+    description: input.description,
+    blockedReason: input.blockedReason || null,
+  };
+}

--- a/rentchain-api/src/routes/__tests__/adminConsumerReportingGovernanceRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/adminConsumerReportingGovernanceRoutes.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+  return {
+    resetFakeDb: () => store.clear(),
+    seedDoc: (collection: string, id: string, data: any) => ensureCollection(collection).set(id, { id, data }),
+    fakeDb: {
+      collection: (name: string) => ({
+        get: async () => {
+          const docs = Array.from(ensureCollection(name).values()).map((doc) => ({ id: doc.id, exists: true, data: () => doc.data }));
+          return { docs, empty: docs.length === 0, size: docs.length };
+        },
+      }),
+    },
+  };
+});
+
+let mockUser: any;
+
+vi.mock("../../config/firebase", () => ({ db: fakeDb }));
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!mockUser) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    req.user = mockUser;
+    return next();
+  },
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; user?: Record<string, unknown> | null }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    mockUser = options.user ?? mockUser;
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: mockUser,
+      query: Object.fromEntries(new URLSearchParams(queryString || "").entries()),
+      params: {},
+      headers: {},
+    };
+    const match = path.match(/^\/consumer-reporting-governance\/(.+)$/);
+    if (match) req.params = { consumerReportingGovernanceId: decodeURIComponent(match[1]) };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => (error ? reject(error) : undefined));
+  });
+}
+
+describe("adminConsumerReportingGovernanceRoutes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    resetFakeDb();
+    mockUser = { id: "admin-1", role: "admin", permissions: ["system.admin"] };
+  });
+
+  function seedGovernanceContext() {
+    seedDoc("consentGovernance", "consent-1", { consentGovernanceId: "consent-1", status: "ready_for_review", rawGovernmentId: "hidden" });
+    seedDoc("consumerReportingDisputeGovernance", "dispute-1", { disputeGovernanceId: "dispute-1", status: "ready_for_review", privateTenantData: "hidden" });
+    seedDoc("adverseActionReadiness", "adverse-1", { adverseActionReadinessId: "adverse-1", status: "ready_for_review", rawAdversePayload: "hidden" });
+    seedDoc("platformCredentialingReadiness", "credentialing-1", { platformCredentialingId: "credentialing-1", status: "ready_for_review", bureauCredential: "hidden" });
+    seedDoc("operationalRiskProfiles", "risk-1", { operationalRiskId: "risk-1", status: "stable", unrestrictedTelemetry: "hidden" });
+    seedDoc("verifiedRentalHistoryLedgers", "ledger-1", { rentalHistoryLedgerId: "ledger-1", status: "verified", rawPaymentPayload: "hidden" });
+    seedDoc("evidencePacks", "evidence-1", { evidencePackId: "evidence-1", status: "ready_for_review", creditBureauPayload: "hidden" });
+    seedDoc("operatorReviewSessions", "review-1", { reviewSessionId: "review-1", status: "completed", privateNote: "hidden" });
+    seedDoc("events", "event-1", { eventId: "event-1", eventType: "consumer_reporting_governance_profile_derived", rawAuditPayload: "hidden" });
+  }
+
+  it("returns admin-gated consumer reporting governance profiles without sensitive reporting payloads", async () => {
+    seedGovernanceContext();
+    const router = (await import("../adminConsumerReportingGovernanceRoutes")).default;
+
+    const forbidden = await invokeRouter(router, {
+      method: "GET",
+      url: "/consumer-reporting-governance",
+      user: { id: "landlord-1", role: "landlord", permissions: [] },
+    });
+    expect(forbidden.status).toBe(403);
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/consumer-reporting-governance",
+      user: { id: "admin-1", role: "admin", permissions: ["system.admin"] },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.profiles).toHaveLength(1);
+    expect(res.body.profiles[0]).toEqual(
+      expect.objectContaining({
+        manualApprovalRequired: true,
+        consumerReportingExecutionEnabled: false,
+        autonomousReportingEnabled: false,
+        publicReportingExposureEnabled: false,
+      })
+    );
+    expect(JSON.stringify(res.body)).not.toContain("rawGovernmentId");
+    expect(JSON.stringify(res.body)).not.toContain("privateTenantData");
+    expect(JSON.stringify(res.body)).not.toContain("rawAdversePayload");
+    expect(JSON.stringify(res.body)).not.toContain("bureauCredential");
+    expect(JSON.stringify(res.body)).not.toContain("unrestrictedTelemetry");
+    expect(JSON.stringify(res.body)).not.toContain("rawPaymentPayload");
+    expect(JSON.stringify(res.body)).not.toContain("creditBureauPayload");
+    expect(JSON.stringify(res.body)).not.toContain("privateNote");
+    expect(JSON.stringify(res.body)).not.toContain("rawAuditPayload");
+  });
+
+  it("returns a single consumer reporting governance profile by id", async () => {
+    seedGovernanceContext();
+    const router = (await import("../adminConsumerReportingGovernanceRoutes")).default;
+    const list = await invokeRouter(router, { method: "GET", url: "/consumer-reporting-governance" });
+    const id = list.body.profiles[0].consumerReportingGovernanceId;
+
+    const res = await invokeRouter(router, { method: "GET", url: `/consumer-reporting-governance/${encodeURIComponent(id)}` });
+
+    expect(res.status).toBe(200);
+    expect(res.body.profile.consumerReportingGovernanceId).toBe(id);
+  });
+
+  it("filters by status", async () => {
+    seedGovernanceContext();
+    const router = (await import("../adminConsumerReportingGovernanceRoutes")).default;
+
+    const filtered = await invokeRouter(router, { method: "GET", url: "/consumer-reporting-governance?status=blocked" });
+
+    expect(filtered.status).toBe(200);
+    expect(filtered.body.profiles).toEqual([]);
+  });
+});

--- a/rentchain-api/src/routes/adminConsumerReportingGovernanceRoutes.ts
+++ b/rentchain-api/src/routes/adminConsumerReportingGovernanceRoutes.ts
@@ -1,0 +1,137 @@
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { requireAuth } from "../middleware/requireAuth";
+import { requirePermission } from "../middleware/requireAuthz";
+import { deriveConsumerReportingGovernanceProfile } from "../lib/consumerReportingGovernance/deriveConsumerReportingGovernanceProfile";
+import type {
+  ConsumerReportingGovernanceProfile,
+  ConsumerReportingGovernanceStatus,
+} from "../lib/consumerReportingGovernance/consumerReportingGovernanceTypes";
+
+const router = Router();
+
+const GOVERNANCE_KEY = "institutional-consumer-reporting-governance-v1";
+const STATUSES = new Set<ConsumerReportingGovernanceStatus>([
+  "ready_for_review",
+  "partially_ready",
+  "review_required",
+  "blocked",
+  "unknown",
+]);
+
+const CONSENT_BASELINE = [{ consentGovernanceId: "identity-consent-reporting-governance-baseline", status: "ready_for_review" }];
+const DISPUTE_BASELINE = [{ disputeGovernanceId: "manual-dispute-governance-baseline", status: "ready_for_review" }];
+const ADVERSE_ACTION_BASELINE = [{ adverseActionReadinessId: "manual-adverse-action-governance-baseline", status: "ready_for_review" }];
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+async function loadCollection(collectionName: string, limit = 25) {
+  const snap = await db.collection(collectionName).get().catch(() => null);
+  return (snap?.docs || []).slice(0, limit).map((doc) => sanitizeRecord({ id: doc.id, ...((doc.data() as any) || {}) }));
+}
+
+function sanitizeRecord(record: Record<string, any>) {
+  const safe: Record<string, any> = {};
+  for (const key of [
+    "id",
+    "status",
+    "state",
+    "conclusion",
+    "consentGovernanceId",
+    "consentId",
+    "identityConsentId",
+    "disputeGovernanceId",
+    "disputeId",
+    "caseId",
+    "adverseActionReadinessId",
+    "adverseActionId",
+    "platformCredentialingId",
+    "operationalRiskId",
+    "rentalHistoryLedgerId",
+    "evidencePackId",
+    "reviewSessionId",
+    "eventId",
+    "eventType",
+    "resourceType",
+    "resourceId",
+    "createdAt",
+    "updatedAt",
+    "redacted",
+  ]) {
+    if (record[key] !== undefined) safe[key] = record[key];
+  }
+  return safe;
+}
+
+async function buildConsumerReportingGovernanceProfiles(): Promise<ConsumerReportingGovernanceProfile[]> {
+  const [
+    consentGovernance,
+    disputeGovernance,
+    adverseActionReadiness,
+    credentialingReadiness,
+    operationalRiskProfiles,
+    rentalHistoryLineage,
+    evidencePacks,
+    reviews,
+    auditEvents,
+  ] = await Promise.all([
+    loadCollection("consentGovernance"),
+    loadCollection("consumerReportingDisputeGovernance"),
+    loadCollection("adverseActionReadiness"),
+    loadCollection("platformCredentialingReadiness"),
+    loadCollection("operationalRiskProfiles"),
+    loadCollection("verifiedRentalHistoryLedgers"),
+    loadCollection("evidencePacks"),
+    loadCollection("operatorReviewSessions"),
+    loadCollection("events"),
+  ]);
+
+  return [
+    deriveConsumerReportingGovernanceProfile({
+      governanceKey: GOVERNANCE_KEY,
+      consentGovernance: consentGovernance.length ? consentGovernance : CONSENT_BASELINE,
+      disputeGovernance: disputeGovernance.length ? disputeGovernance : DISPUTE_BASELINE,
+      adverseActionReadiness: adverseActionReadiness.length ? adverseActionReadiness : ADVERSE_ACTION_BASELINE,
+      credentialingReadiness,
+      operationalRiskProfiles,
+      rentalHistoryLineage,
+      evidencePacks,
+      operatorReviewSessions: reviews,
+      auditEvents,
+    }),
+  ];
+}
+
+function profileMatches(profile: ConsumerReportingGovernanceProfile, id: string) {
+  return profile.consumerReportingGovernanceId === id;
+}
+
+router.get("/consumer-reporting-governance", requireAuth, requirePermission("system.admin"), async (req: any, res) => {
+  try {
+    const status = asString(req.query?.status, 80) as ConsumerReportingGovernanceStatus;
+    let profiles = await buildConsumerReportingGovernanceProfiles();
+    if (status && STATUSES.has(status)) profiles = profiles.filter((profile) => profile.status === status);
+    return res.json({ ok: true, profiles });
+  } catch (err: any) {
+    console.error("[admin-consumer-reporting-governance] list failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "CONSUMER_REPORTING_GOVERNANCE_FAILED" });
+  }
+});
+
+router.get("/consumer-reporting-governance/:consumerReportingGovernanceId", requireAuth, requirePermission("system.admin"), async (req: any, res) => {
+  try {
+    const consumerReportingGovernanceId = decodeURIComponent(asString(req.params?.consumerReportingGovernanceId, 500));
+    if (!consumerReportingGovernanceId) return res.status(400).json({ ok: false, error: "CONSUMER_REPORTING_GOVERNANCE_ID_REQUIRED" });
+    const profiles = await buildConsumerReportingGovernanceProfiles();
+    const profile = profiles.find((next) => profileMatches(next, consumerReportingGovernanceId));
+    if (!profile) return res.status(404).json({ ok: false, error: "CONSUMER_REPORTING_GOVERNANCE_NOT_FOUND" });
+    return res.json({ ok: true, profile });
+  } catch (err: any) {
+    console.error("[admin-consumer-reporting-governance] get failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "CONSUMER_REPORTING_GOVERNANCE_GET_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -118,6 +118,7 @@ const CommercialReadinessPage = lazy(() => import("./pages/CommercialReadinessPa
 const ControlledIntegrationsPage = lazy(() => import("./pages/ControlledIntegrationsPage"));
 const EcosystemCoordinationPage = lazy(() => import("./pages/EcosystemCoordinationPage"));
 const PlatformCredentialingReadinessPage = lazy(() => import("./pages/PlatformCredentialingReadinessPage"));
+const ConsumerReportingGovernancePage = lazy(() => import("./pages/ConsumerReportingGovernancePage"));
 const PortfolioScorePage = lazy(() => import("./pages/admin/PortfolioScorePage"));
 const PortfolioScoreHistoryPage = lazy(() => import("./pages/admin/PortfolioScoreHistoryPage"));
 const PortfolioHealthSummaryPage = lazy(() => import("./pages/landlord/PortfolioHealthSummaryPage"));
@@ -1340,6 +1341,14 @@ function App() {
               element={
                 <RequireAdmin>
                   <PlatformCredentialingReadinessPage />
+                </RequireAdmin>
+              }
+            />
+            <Route
+              path="/admin/consumer-reporting-governance"
+              element={
+                <RequireAdmin>
+                  <ConsumerReportingGovernancePage />
                 </RequireAdmin>
               }
             />

--- a/rentchain-frontend/src/api/consumerReportingGovernanceApi.ts
+++ b/rentchain-frontend/src/api/consumerReportingGovernanceApi.ts
@@ -1,0 +1,74 @@
+import { apiFetch } from "./apiFetch";
+
+export type ConsumerReportingGovernanceStatus = "ready_for_review" | "partially_ready" | "review_required" | "blocked" | "unknown";
+export type ReportingReferenceType = "consent" | "dispute" | "adverse_action" | "credentialing" | "review" | "evidence" | "audit";
+export type ReportingReferenceStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+
+export type ReportingReference = {
+  referenceId: string;
+  referenceType: ReportingReferenceType;
+  status: ReportingReferenceStatus;
+  label: string;
+  description: string;
+  reviewRequired: true;
+  lineageReferences: string[];
+  destination: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type ReportingRestriction = {
+  restrictionId: string;
+  restrictionType: ReportingReferenceType | "bureau_execution" | "collections_execution" | "public_scoring";
+  status: "visible" | "blocked" | "review_required";
+  label: string;
+  description: string;
+  blockedReason: string | null;
+};
+
+export type ConsumerReportingGovernanceProfile = {
+  consumerReportingGovernanceId: string;
+  status: ConsumerReportingGovernanceStatus;
+  manualApprovalRequired: true;
+  consumerReportingExecutionEnabled: false;
+  autonomousReportingEnabled: false;
+  publicReportingExposureEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    partiallyVerifiedReferences: number;
+    blockedReferences: number;
+    unavailableReferences: number;
+    restrictions: number;
+  };
+  consentReferences: ReportingReference[];
+  disputeReferences: ReportingReference[];
+  adverseActionReferences: ReportingReference[];
+  credentialingReferences: ReportingReference[];
+  reviewReferences: ReportingReference[];
+  evidenceReferences: ReportingReference[];
+  auditReferences: ReportingReference[];
+  reportingRestrictions: ReportingRestriction[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: Array<{ eventType: string; action: string; status: ConsumerReportingGovernanceStatus; resourceId: string; summary: string }>;
+};
+
+export async function fetchConsumerReportingGovernanceProfiles(params?: {
+  status?: ConsumerReportingGovernanceStatus | "";
+}): Promise<ConsumerReportingGovernanceProfile[]> {
+  const search = new URLSearchParams();
+  if (params?.status) search.set("status", params.status);
+  const suffix = search.toString() ? `?${search.toString()}` : "";
+  const response = await apiFetch<{ ok: true; profiles: ConsumerReportingGovernanceProfile[] }>(`/admin/consumer-reporting-governance${suffix}`);
+  return response.profiles;
+}
+
+export async function fetchConsumerReportingGovernanceProfile(consumerReportingGovernanceId: string): Promise<ConsumerReportingGovernanceProfile> {
+  const response = await apiFetch<{ ok: true; profile: ConsumerReportingGovernanceProfile }>(
+    `/admin/consumer-reporting-governance/${encodeURIComponent(consumerReportingGovernanceId)}`
+  );
+  return response.profile;
+}

--- a/rentchain-frontend/src/components/reporting/ConsumerReportingGovernancePanel.test.tsx
+++ b/rentchain-frontend/src/components/reporting/ConsumerReportingGovernancePanel.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import type { ConsumerReportingGovernanceProfile } from "@/api/consumerReportingGovernanceApi";
+import { ConsumerReportingGovernancePanel } from "./ConsumerReportingGovernancePanel";
+
+const profile: ConsumerReportingGovernanceProfile = {
+  consumerReportingGovernanceId: "consumer_reporting_governance:institutional:v1",
+  status: "blocked",
+  manualApprovalRequired: true,
+  consumerReportingExecutionEnabled: false,
+  autonomousReportingEnabled: false,
+  publicReportingExposureEnabled: false,
+  generatedAt: "2026-05-07T00:00:00.000Z",
+  summary: {
+    totalReferences: 2,
+    verifiedReferences: 1,
+    partiallyVerifiedReferences: 0,
+    blockedReferences: 1,
+    unavailableReferences: 0,
+    restrictions: 1,
+  },
+  consentReferences: [
+    {
+      referenceId: "consent-1",
+      referenceType: "consent",
+      status: "blocked",
+      label: "Consent governance reference",
+      description: "Consent metadata is available.",
+      reviewRequired: true,
+      lineageReferences: ["consent-1"],
+      destination: "/identity-layer",
+      redacted: false,
+      redactionReason: null,
+      blockedReason: "Consent lineage is missing or blocked.",
+    },
+  ],
+  disputeReferences: [],
+  adverseActionReferences: [],
+  credentialingReferences: [],
+  reviewReferences: [],
+  evidenceReferences: [],
+  auditReferences: [],
+  reportingRestrictions: [
+    {
+      restrictionId: "restriction-1",
+      restrictionType: "consent",
+      status: "blocked",
+      label: "Consent governance reference restriction",
+      description: "Consent reference requires governance review.",
+      blockedReason: "Consent lineage is missing or blocked.",
+    },
+  ],
+  redactions: ["Raw screening, credit bureau, government ID, tenant private document, payment account, and banking payloads are excluded."],
+  blockedReasons: ["Consent lineage is missing or blocked."],
+  canonicalEvents: [],
+};
+
+describe("ConsumerReportingGovernancePanel", () => {
+  it("renders reporting governance readiness, restrictions, blocked reasons, and required safety copy", () => {
+    render(
+      <MemoryRouter>
+        <ConsumerReportingGovernancePanel profile={profile} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("View governance readiness")).toBeInTheDocument();
+    expect(screen.getByText("View restrictions")).toBeInTheDocument();
+    expect(screen.getAllByText("View blocked reason: Consent lineage is missing or blocked.").length).toBeGreaterThan(0);
+    expect(screen.getByText("Manual review required")).toBeInTheDocument();
+    expect(screen.getByText(/Consumer reporting governance is operationally scoped and review controlled/i)).toBeInTheDocument();
+    expect(screen.getByText(/No bureau execution or autonomous reporting is enabled/i)).toBeInTheDocument();
+    expect(screen.getByText(/Manual approval remains required/i)).toBeInTheDocument();
+  });
+
+  it("does not render forbidden reporting execution labels", () => {
+    render(
+      <MemoryRouter>
+        <ConsumerReportingGovernancePanel profile={profile} />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText("Report to bureau")).not.toBeInTheDocument();
+    expect(screen.queryByText("Auto-report")).not.toBeInTheDocument();
+    expect(screen.queryByText("Execute collections")).not.toBeInTheDocument();
+    expect(screen.queryByText("Autonomous reporting")).not.toBeInTheDocument();
+    expect(screen.queryByText("Publish tenant score")).not.toBeInTheDocument();
+    expect(screen.queryByText("Enable CRA operations")).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/reporting/ConsumerReportingGovernancePanel.tsx
+++ b/rentchain-frontend/src/components/reporting/ConsumerReportingGovernancePanel.tsx
@@ -1,0 +1,144 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import type {
+  ConsumerReportingGovernanceProfile,
+  ReportingReference,
+  ReportingRestriction,
+} from "@/api/consumerReportingGovernanceApi";
+import { Card, Section } from "@/components/ui/Ui";
+
+function label(value: string) {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function tone(status: string) {
+  if (status === "blocked") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
+  if (status === "review_required" || status === "partially_ready" || status === "partially_verified" || status === "unavailable") {
+    return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
+  }
+  if (status === "ready_for_review" || status === "verified") return { color: "#166534", background: "#dcfce7", border: "#bbf7d0" };
+  return { color: "#475569", background: "#f8fafc", border: "#e2e8f0" };
+}
+
+function Badge({ children, status }: { children: React.ReactNode; status: string }) {
+  const next = tone(status);
+  return (
+    <span style={{ border: `1px solid ${next.border}`, borderRadius: 999, background: next.background, color: next.color, padding: "3px 9px", fontSize: 12, fontWeight: 900, whiteSpace: "nowrap" }}>
+      {children}
+    </span>
+  );
+}
+
+function ReferenceList({ title, references }: { title: string; references: ReportingReference[] }) {
+  return (
+    <Section style={{ display: "grid", gap: 10 }}>
+      <div style={{ fontWeight: 900 }}>{title}</div>
+      {references.length ? (
+        references.slice(0, 12).map((reference) => (
+          <Card key={reference.referenceId} style={{ borderRadius: 8, padding: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+              <div>
+                <strong>{reference.label}</strong>
+                <div style={{ color: "#64748b", fontSize: 13 }}>{label(reference.referenceType)}</div>
+              </div>
+              <Badge status={reference.status}>{label(reference.status)}</Badge>
+            </div>
+            <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>{reference.description}</div>
+            {reference.lineageReferences.length ? <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>Lineage references: {reference.lineageReferences.length}</div> : null}
+            {reference.blockedReason ? <div style={{ color: "#991b1b", fontSize: 13, marginTop: 8 }}>View blocked reason: {reference.blockedReason}</div> : null}
+            {reference.redacted ? <div style={{ color: "#92400e", fontSize: 13, marginTop: 8 }}>{reference.redactionReason || "Redacted reporting governance reference"}</div> : null}
+            {reference.destination?.startsWith("/") ? <Link to={reference.destination} style={{ color: "#2563eb", fontWeight: 800, fontSize: 13, marginTop: 8, display: "inline-block" }}>View context</Link> : null}
+          </Card>
+        ))
+      ) : (
+        <Card style={{ color: "#64748b" }}>Context unavailable</Card>
+      )}
+    </Section>
+  );
+}
+
+function RestrictionList({ restrictions }: { restrictions: ReportingRestriction[] }) {
+  return (
+    <Section style={{ display: "grid", gap: 10 }}>
+      <div style={{ fontWeight: 900 }}>View restrictions</div>
+      {restrictions.length ? (
+        restrictions.map((restriction) => (
+          <Card key={restriction.restrictionId} style={{ borderRadius: 8, padding: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+              <div>
+                <strong>{restriction.label}</strong>
+                <div style={{ color: "#64748b", fontSize: 13 }}>{label(restriction.restrictionType)}</div>
+              </div>
+              <Badge status={restriction.status}>{label(restriction.status)}</Badge>
+            </div>
+            <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>{restriction.description}</div>
+            {restriction.blockedReason ? <div style={{ color: "#991b1b", fontSize: 13, marginTop: 8 }}>View blocked reason: {restriction.blockedReason}</div> : null}
+          </Card>
+        ))
+      ) : (
+        <Card style={{ color: "#64748b" }}>No reporting restrictions detected.</Card>
+      )}
+    </Section>
+  );
+}
+
+export function ConsumerReportingGovernancePanel({ profile }: { profile: ConsumerReportingGovernanceProfile }) {
+  return (
+    <div style={{ display: "grid", gap: 16 }}>
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+          <div>
+            <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>View governance readiness</div>
+            <h2 style={{ margin: "2px 0 0", fontSize: "1.15rem" }}>Consumer reporting governance</h2>
+          </div>
+          <Badge status={profile.status}>{label(profile.status)}</Badge>
+        </div>
+        <div style={{ color: "#475569", lineHeight: 1.55 }}>
+          Consumer reporting governance is operationally scoped and review controlled. No bureau execution or autonomous reporting is enabled.
+          Manual approval remains required.
+        </div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <Badge status="review_required">Manual review required</Badge>
+          <Badge status={profile.consumerReportingExecutionEnabled ? "blocked" : "verified"}>Consumer reporting execution disabled</Badge>
+          <Badge status={profile.autonomousReportingEnabled ? "blocked" : "verified"}>Reporting automation disabled</Badge>
+          <Badge status={profile.publicReportingExposureEnabled ? "blocked" : "verified"}>Public reporting exposure disabled</Badge>
+        </div>
+      </Section>
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Governance summary</div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: 10 }}>
+          {[
+            ["References", profile.summary.totalReferences],
+            ["Verified", profile.summary.verifiedReferences],
+            ["Partial", profile.summary.partiallyVerifiedReferences],
+            ["Blocked", profile.summary.blockedReferences],
+            ["Unavailable", profile.summary.unavailableReferences],
+            ["Restrictions", profile.summary.restrictions],
+          ].map(([name, value]) => (
+            <Card key={String(name)} style={{ borderRadius: 8, padding: 12 }}>
+              <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>{name}</div>
+              <strong style={{ color: "#0f172a", fontSize: 22 }}>{String(value)}</strong>
+            </Card>
+          ))}
+        </div>
+      </Section>
+
+      <RestrictionList restrictions={profile.reportingRestrictions} />
+      <ReferenceList title="View consent lineage" references={profile.consentReferences} />
+      <ReferenceList title="View dispute lineage" references={profile.disputeReferences} />
+      <ReferenceList title="Adverse-action readiness" references={profile.adverseActionReferences} />
+      <ReferenceList title="Credentialing governance" references={profile.credentialingReferences} />
+      <ReferenceList title="View review lineage" references={profile.reviewReferences} />
+      <ReferenceList title="Evidence lineage" references={profile.evidenceReferences} />
+      <ReferenceList title="View audit lineage" references={profile.auditReferences} />
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Redactions</div>
+        {profile.redactions.map((redaction) => (
+          <Card key={redaction} style={{ borderRadius: 8, padding: 12, color: "#475569" }}>{redaction}</Card>
+        ))}
+      </Section>
+    </div>
+  );
+}

--- a/rentchain-frontend/src/pages/ConsumerReportingGovernancePage.test.tsx
+++ b/rentchain-frontend/src/pages/ConsumerReportingGovernancePage.test.tsx
@@ -1,0 +1,95 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import ConsumerReportingGovernancePage from "./ConsumerReportingGovernancePage";
+
+const mockFetchProfiles = vi.fn();
+const mockShowToast = vi.fn();
+
+vi.mock("@/api/consumerReportingGovernanceApi", () => ({
+  fetchConsumerReportingGovernanceProfiles: (...args: any[]) => mockFetchProfiles(...args),
+}));
+
+vi.mock("@/components/layout/MacShell", () => ({
+  MacShell: ({ children, title }: any) => <main aria-label={title}>{children}</main>,
+}));
+
+vi.mock("@/components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
+const profile = {
+  consumerReportingGovernanceId: "consumer_reporting_governance:institutional:v1",
+  status: "ready_for_review",
+  manualApprovalRequired: true,
+  consumerReportingExecutionEnabled: false,
+  autonomousReportingEnabled: false,
+  publicReportingExposureEnabled: false,
+  generatedAt: "2026-05-07T00:00:00.000Z",
+  summary: {
+    totalReferences: 1,
+    verifiedReferences: 1,
+    partiallyVerifiedReferences: 0,
+    blockedReferences: 0,
+    unavailableReferences: 0,
+    restrictions: 0,
+  },
+  consentReferences: [],
+  disputeReferences: [],
+  adverseActionReferences: [],
+  credentialingReferences: [],
+  reviewReferences: [],
+  evidenceReferences: [],
+  auditReferences: [],
+  reportingRestrictions: [],
+  redactions: ["Sensitive reporting payloads are excluded."],
+  blockedReasons: [],
+  canonicalEvents: [],
+};
+
+describe("ConsumerReportingGovernancePage", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    mockFetchProfiles.mockResolvedValue([profile]);
+  });
+
+  it("loads and renders consumer reporting governance with required safety copy", async () => {
+    render(
+      <MemoryRouter>
+        <ConsumerReportingGovernancePage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Loading consumer reporting governance...")).toBeInTheDocument();
+    expect(await screen.findByText("Governance summary")).toBeInTheDocument();
+    expect(screen.getAllByText(/Consumer reporting governance is operationally scoped and review controlled/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Manual approval remains required/i).length).toBeGreaterThan(0);
+    expect(mockFetchProfiles).toHaveBeenCalledWith({ status: "" });
+  });
+
+  it("filters profiles by status", async () => {
+    render(
+      <MemoryRouter>
+        <ConsumerReportingGovernancePage />
+      </MemoryRouter>
+    );
+
+    fireEvent.change((await screen.findAllByLabelText("Status"))[0], { target: { value: "blocked" } });
+    await waitFor(() => {
+      expect(mockFetchProfiles).toHaveBeenLastCalledWith({ status: "blocked" });
+    });
+  });
+
+  it("renders the empty state", async () => {
+    mockFetchProfiles.mockResolvedValue([]);
+
+    render(
+      <MemoryRouter>
+        <ConsumerReportingGovernancePage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("No consumer reporting governance profiles match these filters.")).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/ConsumerReportingGovernancePage.tsx
+++ b/rentchain-frontend/src/pages/ConsumerReportingGovernancePage.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { useSearchParams } from "react-router-dom";
+import {
+  fetchConsumerReportingGovernanceProfiles,
+  type ConsumerReportingGovernanceProfile,
+  type ConsumerReportingGovernanceStatus,
+} from "@/api/consumerReportingGovernanceApi";
+import { ConsumerReportingGovernancePanel } from "@/components/reporting/ConsumerReportingGovernancePanel";
+import { MacShell } from "@/components/layout/MacShell";
+import { Card, Section } from "@/components/ui/Ui";
+import { useToast } from "@/components/ui/ToastProvider";
+
+const statuses: Array<ConsumerReportingGovernanceStatus | ""> = ["", "ready_for_review", "partially_ready", "review_required", "blocked", "unknown"];
+
+function label(value: string) {
+  return value ? value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase()) : "All";
+}
+
+export default function ConsumerReportingGovernancePage() {
+  const { showToast } = useToast();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [profiles, setProfiles] = React.useState<ConsumerReportingGovernanceProfile[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const status = String(searchParams.get("status") || "") as ConsumerReportingGovernanceStatus | "";
+
+  React.useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const next = await fetchConsumerReportingGovernanceProfiles({ status });
+        if (mounted) setProfiles(next);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Failed to load consumer reporting governance";
+        if (mounted) {
+          setError(message);
+          showToast({ message: "Failed to load consumer reporting governance", description: message, variant: "error" });
+        }
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [status, showToast]);
+
+  function updateStatus(value: string) {
+    const params = new URLSearchParams(searchParams);
+    if (value && value.trim()) params.set("status", value.trim());
+    else params.delete("status");
+    setSearchParams(params);
+  }
+
+  return (
+    <MacShell title="Consumer reporting governance" showTopNav={false}>
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "grid", gap: 6 }}>
+            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Consumer reporting governance</h1>
+            <div style={{ color: "#475569", maxWidth: 900 }}>
+              Consumer reporting governance is operationally scoped and review controlled. No bureau execution or autonomous reporting is enabled.
+              Manual approval remains required.
+            </div>
+          </div>
+        </Section>
+
+        <Section style={{ display: "flex", gap: 10, flexWrap: "wrap", alignItems: "end" }}>
+          <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Status
+            <select value={status} onChange={(event) => updateStatus(event.target.value)} style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 180 }}>
+              {statuses.map((item) => <option key={item || "all"} value={item}>{label(item)}</option>)}
+            </select>
+          </label>
+        </Section>
+
+        {loading ? <Card>Loading consumer reporting governance...</Card> : null}
+        {!loading && error ? <Card style={{ color: "#b91c1c" }}>We couldn't load consumer reporting governance right now.</Card> : null}
+        {!loading && !error && !profiles.length ? <Card style={{ color: "#64748b" }}>No consumer reporting governance profiles match these filters.</Card> : null}
+        {!loading && !error && profiles.length ? (
+          <div style={{ display: "grid", gap: 16 }}>{profiles.map((profile) => <ConsumerReportingGovernancePanel key={profile.consumerReportingGovernanceId} profile={profile} />)}</div>
+        ) : null}
+      </div>
+    </MacShell>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a deterministic, admin-scoped Consumer Reporting Governance read model for future reporting-governance readiness.
- Adds read-only admin endpoints for consumer reporting governance profiles.
- Adds an admin Consumer Reporting Governance UI surface with required review-control safety copy and no execution controls.

## Guardrails
- Manual approval remains required.
- Consumer-reporting execution remains disabled.
- Autonomous reporting remains disabled.
- Public reporting exposure remains disabled.
- No CRA status claims, bureau approval claims, bureau execution, collections execution, adverse-action execution, autonomous reporting, public tenant scoring, or hidden reporting execution path was added.
- Backend route sanitizes source records through a whitelist projection before derivation.

## Verification
- Backend targeted tests: `npm test -- --run src/lib/consumerReportingGovernance/__tests__/deriveConsumerReportingGovernanceProfile.test.ts src/routes/__tests__/adminConsumerReportingGovernanceRoutes.test.ts` (9/9 passed)
- Frontend targeted tests: `npm test -- --run src/components/reporting/ConsumerReportingGovernancePanel.test.tsx src/pages/ConsumerReportingGovernancePage.test.tsx` (5/5 passed)
- Backend build: `npm run build` passed
- Frontend build: `npm run build` passed; existing large App chunk warning remains non-regressive and the new page is emitted as a separate lazy chunk
- `git diff --check` passed
- `git diff --cached --check` passed
- Dependency/lockfile diff: empty
- Forbidden reporting execution-label scan: clean