### PR TITLE
feat: add tenant participation layer

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -35,6 +35,7 @@ import tenantSignalsRoutes from "./routes/tenantSignalsRoutes";
 import reportingRoutes from "./routes/reportingRoutes";
 import tenantInvitesRoutes from "./routes/tenantInvitesRoutes";
 import tenantPortalRoutes from "./routes/tenantPortalRoutes";
+import tenantParticipationRoutes from "./routes/tenantParticipationRoutes";
 import tenantInviteAliasesRoutes from "./routes/tenantInviteAliasesRoutes";
 import landlordInvitesAdminRoutes from "./routes/landlordInvitesAdminRoutes";
 import landlordInvitesPublicRoutes from "./routes/landlordInvitesPublicRoutes";
@@ -409,6 +410,7 @@ app.use(
 );
 app.use("/api/tenant-invites", tenantInvitesRoutes);
 app.use("/api/tenant", tenantPortalRoutes);
+app.use("/api/tenant", tenantParticipationRoutes);
 app.use("/api", routeSource("tenantInviteAliasesRoutes"), tenantInviteAliasesRoutes);
 app.use("/api", routeSource("tenantEventsRoutes"), tenantEventsRoutes);
 app.use("/api", routeSource("tenantEventsWriteRoutes"), tenantEventsWriteRoutes);

--- a/rentchain-api/src/lib/tenantParticipation/__tests__/deriveTenantParticipationProfile.test.ts
+++ b/rentchain-api/src/lib/tenantParticipation/__tests__/deriveTenantParticipationProfile.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { deriveTenantParticipationProfile } from "../deriveTenantParticipationProfile";
+
+const completeInput = {
+  tenantId: "tenant-1",
+  generatedAt: "2026-05-07T00:00:00.000Z",
+  onboardingRecords: [{ onboardingId: "onboarding-1", tenantId: "tenant-1", status: "completed" }],
+  paymentConsistencyRecords: [{ paymentConsistencyId: "payment-1", tenantId: "tenant-1", status: "verified" }],
+  occupancyRecords: [{ rentalHistoryLedgerId: "ledger-1", tenantId: "tenant-1", status: "verified" }],
+  maintenanceRecords: [{ maintenanceRequestId: "maintenance-1", tenantId: "tenant-1", status: "completed" }],
+  reviewRecords: [{ reviewSessionId: "review-1", tenantId: "tenant-1", status: "completed" }],
+  disputeRecords: [{ disputeResolutionId: "dispute-1", tenantId: "tenant-1", status: "ready_for_review" }],
+  communicationRecords: [{ communicationId: "message-1", tenantId: "tenant-1", status: "available" }],
+  evidencePacks: [{ evidencePackId: "evidence-1", tenantId: "tenant-1", status: "ready_for_review" }],
+  auditEvents: [{ eventId: "audit-1", resourceId: "tenant-1", eventType: "tenant_participation_profile_derived" }],
+};
+
+describe("deriveTenantParticipationProfile", () => {
+  it("derives a deterministic verified profile with incentive flags pinned off", () => {
+    const profile = deriveTenantParticipationProfile(completeInput);
+    const repeat = deriveTenantParticipationProfile(completeInput);
+
+    expect(profile).toEqual(repeat);
+    expect(profile.status).toBe("verified");
+    expect(profile).toEqual(
+      expect.objectContaining({
+        manualReviewRequired: true,
+        publicParticipationExposureEnabled: false,
+        autonomousRewardExecutionEnabled: false,
+      })
+    );
+    expect(profile.summary).toEqual(
+      expect.objectContaining({
+        totalReferences: 9,
+        verifiedReferences: 9,
+        restrictions: 0,
+      })
+    );
+  });
+
+  it("blocks unresolved onboarding or dispute restrictions", () => {
+    const profile = deriveTenantParticipationProfile({
+      ...completeInput,
+      onboardingRecords: [{ onboardingId: "onboarding-1", tenantId: "tenant-1", status: "blocked" }],
+      disputeRecords: [{ disputeResolutionId: "dispute-1", tenantId: "tenant-1", status: "blocked" }],
+    });
+
+    expect(profile.status).toBe("blocked");
+    expect(profile.participationRestrictions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ restrictionType: "onboarding", status: "blocked" }),
+        expect.objectContaining({ restrictionType: "dispute_resolution", status: "blocked" }),
+      ])
+    );
+  });
+
+  it("requires review when critical review, evidence, or audit lineage is missing", () => {
+    const profile = deriveTenantParticipationProfile({
+      ...completeInput,
+      reviewRecords: [],
+      evidencePacks: [],
+      auditEvents: [],
+    });
+
+    expect(profile.status).toBe("review_required");
+    expect(profile.participationRestrictions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ restrictionType: "review", status: "review_required" }),
+        expect.objectContaining({ restrictionType: "evidence", status: "review_required" }),
+        expect.objectContaining({ restrictionType: "audit", status: "review_required" }),
+      ])
+    );
+  });
+
+  it("marks incomplete participation lineage as partially verified without autonomous incentives", () => {
+    const profile = deriveTenantParticipationProfile({
+      ...completeInput,
+      maintenanceRecords: [{ maintenanceRequestId: "maintenance-1", tenantId: "tenant-1", status: "pending" }],
+    });
+
+    expect(profile.status).toBe("partially_verified");
+    expect(profile.autonomousRewardExecutionEnabled).toBe(false);
+  });
+
+  it("returns unknown when there is insufficient source context", () => {
+    const profile = deriveTenantParticipationProfile({ tenantId: "tenant-1" });
+
+    expect(profile.status).toBe("unknown");
+    expect(profile.summary.unavailableReferences).toBeGreaterThan(0);
+    expect(profile.canonicalEvents.map((event) => event.eventType)).toEqual(
+      expect.arrayContaining(["tenant_participation_profile_derived", "tenant_participation_redaction_applied"])
+    );
+  });
+
+  it("generates canonical events for restriction, review-required, blocked, and redaction paths", () => {
+    const blocked = deriveTenantParticipationProfile({
+      ...completeInput,
+      disputeRecords: [{ disputeResolutionId: "dispute-1", tenantId: "tenant-1", status: "blocked" }],
+    });
+
+    expect(blocked.canonicalEvents.map((event) => event.eventType)).toEqual(
+      expect.arrayContaining([
+        "tenant_participation_profile_derived",
+        "tenant_participation_redaction_applied",
+        "tenant_participation_restriction_detected",
+        "tenant_participation_blocked",
+      ])
+    );
+  });
+});

--- a/rentchain-api/src/lib/tenantParticipation/deriveTenantParticipationProfile.ts
+++ b/rentchain-api/src/lib/tenantParticipation/deriveTenantParticipationProfile.ts
@@ -1,0 +1,346 @@
+import type {
+  DeriveTenantParticipationProfileInput,
+  ParticipationReference,
+  ParticipationReferenceStatus,
+  ParticipationReferenceType,
+  TenantParticipationCanonicalEvent,
+  TenantParticipationProfile,
+  TenantParticipationStatus,
+} from "./tenantParticipationTypes";
+import { participationIdPart, participationReference, participationRestriction } from "./participationRestrictionModels";
+
+const REDACTIONS = [
+  "Public-facing tenant scoring outputs, ranking outputs, social-credit indicators, and public reputation marketplace payloads are excluded.",
+  "Raw payment account details, raw screening or credit bureau payloads, private tenant documents, and unrestricted audit histories are excluded.",
+  "Tenant participation is visibility metadata only; no autonomous rewards, penalties, public profiles, or hidden behavioral scoring are enabled.",
+  "Participation references are consent-aware, permission scoped, and manually reviewed before any portable use.",
+];
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function asArray<T>(value: T[] | null | undefined): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function generatedAt(value: unknown): string {
+  const raw = asString(value, 120);
+  const date = raw ? new Date(raw) : new Date(0);
+  return Number.isNaN(date.getTime()) ? new Date(0).toISOString() : date.toISOString();
+}
+
+function recordId(record: Record<string, any>, keys: string[]): string {
+  for (const key of keys) {
+    const value = asString(record?.[key], 240);
+    if (value) return value;
+  }
+  return asString(record?.id, 240);
+}
+
+function referenceStatus(record: Record<string, any>, verifiedStatuses: string[]): ParticipationReferenceStatus {
+  const status = asString(record?.status || record?.state || record?.conclusion, 80).toLowerCase();
+  if (status === "blocked" || status === "elevated" || status === "failure" || status === "failed" || status === "error" || status === "cancelled") return "blocked";
+  if (verifiedStatuses.includes(status)) return "verified";
+  if (status === "missing" || status === "unknown" || status === "unavailable" || status === "pending") return "unavailable";
+  return "partially_verified";
+}
+
+function statusForType(referenceType: ParticipationReferenceType, record: Record<string, any>): ParticipationReferenceStatus {
+  if (referenceType === "review") return referenceStatus(record, ["ready_for_review", "completed", "verified"]);
+  if (referenceType === "audit" && asString(record?.eventType, 120)) return "verified";
+  return referenceStatus(record, ["ready_for_review", "verified", "available", "completed", "stable", "active"]);
+}
+
+function profileStatus(hasContext: boolean, references: ParticipationReference[]): TenantParticipationStatus {
+  if (!hasContext) return "unknown";
+  if (references.some((reference) => reference.status === "blocked" && (reference.referenceType === "onboarding" || reference.referenceType === "dispute_resolution"))) return "blocked";
+  const criticalMissing = references.some(
+    (reference) =>
+      reference.status === "unavailable" &&
+      (reference.referenceType === "onboarding" ||
+        reference.referenceType === "review" ||
+        reference.referenceType === "evidence" ||
+        reference.referenceType === "audit")
+  );
+  if (criticalMissing) return "review_required";
+  if (references.some((reference) => reference.status === "blocked" || reference.status === "unavailable" || reference.status === "partially_verified")) return "partially_verified";
+  return "verified";
+}
+
+function event(input: {
+  eventType: TenantParticipationCanonicalEvent["eventType"];
+  status: TenantParticipationStatus;
+  tenantParticipationId: string;
+  summary: string;
+}): TenantParticipationCanonicalEvent {
+  return {
+    eventType: input.eventType,
+    action: input.eventType.replace(/^tenant_participation_/, "").replace(/_/g, "."),
+    status: input.status,
+    resourceType: "tenant_participation_profile",
+    resourceId: input.tenantParticipationId,
+    summary: input.summary,
+  };
+}
+
+function referencesFor(input: {
+  records: Record<string, any>[];
+  fallback: string;
+  referenceType: ParticipationReferenceType;
+  idKeys: string[];
+  label: string;
+  description: string;
+  destination: string;
+  blockedReason: string;
+}): ParticipationReference[] {
+  if (!input.records.length) {
+    return [
+      participationReference({
+        idParts: [input.referenceType, "missing"],
+        referenceType: input.referenceType,
+        status: "unavailable",
+        label: input.label,
+        description: `${input.description} is unavailable for participation review.`,
+        destination: input.destination,
+      }),
+    ];
+  }
+  return input.records.map((record, index) => {
+    const id = recordId(record, input.idKeys) || `${input.fallback}-${index + 1}`;
+    const status = statusForType(input.referenceType, record);
+    return participationReference({
+      idParts: [input.referenceType, id],
+      referenceType: input.referenceType,
+      status,
+      label: input.label,
+      description: `${input.description} is available for participation review.`,
+      lineageReferences: [id].filter(Boolean),
+      destination: input.destination,
+      redacted: Boolean(record.redacted),
+      redactionReason: record.redacted ? `${input.label} payload is redacted for tenant participation safety.` : null,
+      blockedReason: status === "blocked" ? input.blockedReason : null,
+    });
+  });
+}
+
+export function deriveTenantParticipationProfile(input: DeriveTenantParticipationProfileInput): TenantParticipationProfile {
+  const tenantId = asString(input.tenantId, 240) || "unknown";
+  const tenantParticipationId = participationIdPart(["tenant_participation", tenantId].join(":")) || "tenant_participation:unknown";
+
+  const onboardingRecords = asArray(input.onboardingRecords);
+  const paymentConsistencyRecords = asArray(input.paymentConsistencyRecords);
+  const occupancyRecords = asArray(input.occupancyRecords);
+  const maintenanceRecords = asArray(input.maintenanceRecords);
+  const reviewRecords = asArray(input.reviewRecords);
+  const disputeRecords = asArray(input.disputeRecords);
+  const communicationRecords = asArray(input.communicationRecords);
+  const evidencePacks = asArray(input.evidencePacks);
+  const auditEvents = asArray(input.auditEvents);
+
+  const onboardingReferences = referencesFor({
+    records: onboardingRecords,
+    fallback: "onboarding",
+    referenceType: "onboarding",
+    idKeys: ["onboardingId", "applicationId", "tenantId", "id"],
+    label: "Onboarding participation reference",
+    description: "Tenant onboarding participation metadata",
+    destination: "/tenant/application",
+    blockedReason: "Onboarding participation is blocked.",
+  });
+  const paymentConsistencyReferences = referencesFor({
+    records: paymentConsistencyRecords,
+    fallback: "payment",
+    referenceType: "payment_consistency",
+    idKeys: ["paymentConsistencyId", "ledgerEventId", "paymentId", "id"],
+    label: "Payment-consistency reference",
+    description: "Verified payment-consistency metadata",
+    destination: "/tenant/ledger",
+    blockedReason: "Payment-consistency reference is blocked.",
+  });
+  const occupancyReferences = referencesFor({
+    records: occupancyRecords,
+    fallback: "occupancy",
+    referenceType: "occupancy",
+    idKeys: ["rentalHistoryLedgerId", "leaseId", "occupancyId", "id"],
+    label: "Occupancy-consistency reference",
+    description: "Verified occupancy-consistency metadata",
+    destination: "/tenant/lease",
+    blockedReason: "Occupancy-consistency reference is blocked.",
+  });
+  const maintenanceParticipationReferences = referencesFor({
+    records: maintenanceRecords,
+    fallback: "maintenance",
+    referenceType: "maintenance",
+    idKeys: ["maintenanceRequestId", "workOrderId", "id"],
+    label: "Maintenance participation reference",
+    description: "Maintenance participation metadata",
+    destination: "/tenant/maintenance",
+    blockedReason: "Maintenance participation reference is blocked.",
+  });
+  const reviewParticipationReferences = referencesFor({
+    records: reviewRecords,
+    fallback: "review",
+    referenceType: "review",
+    idKeys: ["reviewSessionId", "operatorReviewId", "id"],
+    label: "Review participation reference",
+    description: "Manual review participation metadata",
+    destination: "/review-timeline",
+    blockedReason: "Review participation reference is blocked.",
+  });
+  const disputeParticipationReferences = referencesFor({
+    records: disputeRecords,
+    fallback: "dispute",
+    referenceType: "dispute_resolution",
+    idKeys: ["disputeResolutionId", "disputeId", "caseId", "id"],
+    label: "Dispute-resolution participation reference",
+    description: "Dispute-resolution participation metadata",
+    destination: "/tenant/activity",
+    blockedReason: "Dispute-resolution participation is blocked.",
+  });
+  const communicationParticipationReferences = referencesFor({
+    records: communicationRecords,
+    fallback: "communication",
+    referenceType: "communication",
+    idKeys: ["communicationId", "messageId", "noticeId", "id"],
+    label: "Communication responsiveness reference",
+    description: "Communication responsiveness metadata",
+    destination: "/tenant/messages",
+    blockedReason: "Communication responsiveness reference is blocked.",
+  });
+  const evidenceReferences = referencesFor({
+    records: evidencePacks,
+    fallback: "evidence",
+    referenceType: "evidence",
+    idKeys: ["evidencePackId", "id"],
+    label: "Participation evidence lineage reference",
+    description: "Participation evidence lineage metadata",
+    destination: "/evidence-packs",
+    blockedReason: "Participation evidence lineage is blocked.",
+  });
+  const auditReferences = referencesFor({
+    records: auditEvents.slice(0, 20),
+    fallback: "audit",
+    referenceType: "audit",
+    idKeys: ["eventId", "auditId", "id"],
+    label: "Participation audit lineage reference",
+    description: "Participation audit lineage metadata",
+    destination: "/tenant/activity",
+    blockedReason: "Participation audit lineage is blocked.",
+  });
+
+  const allReferences = [
+    ...onboardingReferences,
+    ...paymentConsistencyReferences,
+    ...occupancyReferences,
+    ...maintenanceParticipationReferences,
+    ...reviewParticipationReferences,
+    ...disputeParticipationReferences,
+    ...communicationParticipationReferences,
+    ...evidenceReferences,
+    ...auditReferences,
+  ];
+  const hasContext = Boolean(
+    onboardingRecords.length ||
+      paymentConsistencyRecords.length ||
+      occupancyRecords.length ||
+      maintenanceRecords.length ||
+      reviewRecords.length ||
+      disputeRecords.length ||
+      communicationRecords.length ||
+      evidencePacks.length ||
+      auditEvents.length
+  );
+  const status = profileStatus(hasContext, allReferences);
+  const participationRestrictions = allReferences
+    .filter((reference) => reference.status !== "verified")
+    .map((reference) =>
+      participationRestriction({
+        idParts: [reference.referenceType, reference.referenceId],
+        restrictionType: reference.referenceType,
+        status: reference.status === "blocked" ? "blocked" : "review_required",
+        label: `${reference.label} restriction`,
+        description: `${reference.label} is incomplete or blocked for tenant participation review.`,
+        blockedReason: reference.blockedReason,
+      })
+    );
+  const blockedReasons = [...allReferences.map((reference) => reference.blockedReason), ...participationRestrictions.map((restriction) => restriction.blockedReason)].filter(Boolean) as string[];
+
+  const canonicalEvents: TenantParticipationCanonicalEvent[] = [
+    event({
+      eventType: "tenant_participation_profile_derived",
+      status,
+      tenantParticipationId,
+      summary:
+        "Tenant participation profile derived from onboarding, payment, occupancy, maintenance, review, dispute, communication, evidence, and audit metadata.",
+    }),
+    event({
+      eventType: "tenant_participation_redaction_applied",
+      status,
+      tenantParticipationId,
+      summary:
+        "Public scoring, public ranking, raw payment, raw screening, private tenant document, and unrestricted audit payloads were excluded.",
+    }),
+  ];
+  if (participationRestrictions.length) {
+    canonicalEvents.push(
+      event({
+        eventType: "tenant_participation_restriction_detected",
+        status,
+        tenantParticipationId,
+        summary: "Tenant participation restrictions are visible for manual review.",
+      })
+    );
+  }
+  if (status === "review_required" || status === "partially_verified") {
+    canonicalEvents.push(
+      event({
+        eventType: "tenant_participation_review_required",
+        status,
+        tenantParticipationId,
+        summary: "Manual tenant participation review is required.",
+      })
+    );
+  }
+  if (status === "blocked") {
+    canonicalEvents.push(
+      event({
+        eventType: "tenant_participation_blocked",
+        status,
+        tenantParticipationId,
+        summary: "Tenant participation profile is blocked by unresolved restrictions.",
+      })
+    );
+  }
+
+  return {
+    tenantParticipationId,
+    status,
+    tenantId,
+    manualReviewRequired: true,
+    publicParticipationExposureEnabled: false,
+    autonomousRewardExecutionEnabled: false,
+    generatedAt: generatedAt(input.generatedAt),
+    summary: {
+      totalReferences: allReferences.length,
+      verifiedReferences: allReferences.filter((reference) => reference.status === "verified").length,
+      partiallyVerifiedReferences: allReferences.filter((reference) => reference.status === "partially_verified").length,
+      blockedReferences: allReferences.filter((reference) => reference.status === "blocked").length,
+      unavailableReferences: allReferences.filter((reference) => reference.status === "unavailable").length,
+      restrictions: participationRestrictions.length,
+    },
+    onboardingReferences,
+    paymentConsistencyReferences,
+    occupancyReferences,
+    maintenanceParticipationReferences,
+    reviewParticipationReferences,
+    disputeParticipationReferences,
+    communicationParticipationReferences,
+    evidenceReferences,
+    auditReferences,
+    participationRestrictions,
+    redactions: REDACTIONS,
+    blockedReasons,
+    canonicalEvents,
+  };
+}

--- a/rentchain-api/src/lib/tenantParticipation/participationRestrictionModels.ts
+++ b/rentchain-api/src/lib/tenantParticipation/participationRestrictionModels.ts
@@ -1,0 +1,63 @@
+import type {
+  ParticipationReference,
+  ParticipationReferenceStatus,
+  ParticipationReferenceType,
+  ParticipationRestriction,
+} from "./tenantParticipationTypes";
+
+export function participationIdPart(value: unknown) {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 240);
+}
+
+export function participationReference(input: {
+  idParts: unknown[];
+  referenceType: ParticipationReferenceType;
+  status: ParticipationReferenceStatus;
+  label: string;
+  description: string;
+  lineageReferences?: string[];
+  destination?: string | null;
+  redacted?: boolean;
+  redactionReason?: string | null;
+  blockedReason?: string | null;
+}): ParticipationReference {
+  const referenceId = participationIdPart(input.idParts.filter(Boolean).join(":")) || `${input.referenceType}:unknown`;
+  return {
+    referenceId,
+    referenceType: input.referenceType,
+    status: input.status,
+    label: input.label,
+    description: input.description,
+    reviewRequired: true,
+    lineageReferences: Array.from(new Set(input.lineageReferences || [])).filter(Boolean).slice(0, 20),
+    destination: input.destination || null,
+    redacted: Boolean(input.redacted),
+    redactionReason: input.redactionReason || null,
+    blockedReason: input.blockedReason || null,
+  };
+}
+
+export function participationRestriction(input: {
+  idParts: unknown[];
+  restrictionType: ParticipationRestriction["restrictionType"];
+  status: ParticipationRestriction["status"];
+  label: string;
+  description: string;
+  blockedReason?: string | null;
+}): ParticipationRestriction {
+  const restrictionId = participationIdPart(["participation_restriction", ...input.idParts].filter(Boolean).join(":"));
+  return {
+    restrictionId: restrictionId || "participation_restriction:unknown",
+    restrictionType: input.restrictionType,
+    status: input.status,
+    label: input.label,
+    description: input.description,
+    blockedReason: input.blockedReason || null,
+  };
+}

--- a/rentchain-api/src/lib/tenantParticipation/tenantParticipationTypes.ts
+++ b/rentchain-api/src/lib/tenantParticipation/tenantParticipationTypes.ts
@@ -1,0 +1,98 @@
+export type TenantParticipationStatus = "verified" | "partially_verified" | "review_required" | "blocked" | "unknown";
+
+export type ParticipationReferenceType =
+  | "onboarding"
+  | "payment_consistency"
+  | "occupancy"
+  | "maintenance"
+  | "review"
+  | "dispute_resolution"
+  | "communication"
+  | "evidence"
+  | "audit";
+
+export type ParticipationReferenceStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+
+export type TenantParticipationCanonicalEventType =
+  | "tenant_participation_profile_derived"
+  | "tenant_participation_review_required"
+  | "tenant_participation_blocked"
+  | "tenant_participation_restriction_detected"
+  | "tenant_participation_redaction_applied";
+
+export type ParticipationReference = {
+  referenceId: string;
+  referenceType: ParticipationReferenceType;
+  status: ParticipationReferenceStatus;
+  label: string;
+  description: string;
+  reviewRequired: true;
+  lineageReferences: string[];
+  destination: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type ParticipationRestriction = {
+  restrictionId: string;
+  restrictionType: ParticipationReferenceType | "public_scoring" | "autonomous_incentive" | "public_profile";
+  status: "visible" | "blocked" | "review_required";
+  label: string;
+  description: string;
+  blockedReason: string | null;
+};
+
+export type TenantParticipationCanonicalEvent = {
+  eventType: TenantParticipationCanonicalEventType;
+  action: string;
+  status: TenantParticipationStatus;
+  resourceType: "tenant_participation_profile";
+  resourceId: string;
+  summary: string;
+};
+
+export type TenantParticipationProfile = {
+  tenantParticipationId: string;
+  status: TenantParticipationStatus;
+  tenantId: string;
+  manualReviewRequired: true;
+  publicParticipationExposureEnabled: false;
+  autonomousRewardExecutionEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    partiallyVerifiedReferences: number;
+    blockedReferences: number;
+    unavailableReferences: number;
+    restrictions: number;
+  };
+  onboardingReferences: ParticipationReference[];
+  paymentConsistencyReferences: ParticipationReference[];
+  occupancyReferences: ParticipationReference[];
+  maintenanceParticipationReferences: ParticipationReference[];
+  reviewParticipationReferences: ParticipationReference[];
+  disputeParticipationReferences: ParticipationReference[];
+  communicationParticipationReferences: ParticipationReference[];
+  evidenceReferences: ParticipationReference[];
+  auditReferences: ParticipationReference[];
+  participationRestrictions: ParticipationRestriction[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: TenantParticipationCanonicalEvent[];
+};
+
+export type DeriveTenantParticipationProfileInput = {
+  tenantId?: unknown;
+  generatedAt?: unknown;
+  onboardingRecords?: Array<Record<string, any>> | null;
+  paymentConsistencyRecords?: Array<Record<string, any>> | null;
+  occupancyRecords?: Array<Record<string, any>> | null;
+  maintenanceRecords?: Array<Record<string, any>> | null;
+  reviewRecords?: Array<Record<string, any>> | null;
+  disputeRecords?: Array<Record<string, any>> | null;
+  communicationRecords?: Array<Record<string, any>> | null;
+  evidencePacks?: Array<Record<string, any>> | null;
+  auditEvents?: Array<Record<string, any>> | null;
+};

--- a/rentchain-api/src/routes/__tests__/tenantParticipationRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantParticipationRoutes.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+  return {
+    resetFakeDb: () => store.clear(),
+    seedDoc: (collection: string, id: string, data: any) => ensureCollection(collection).set(id, { id, data }),
+    fakeDb: {
+      collection: (name: string) => ({
+        get: async () => {
+          const docs = Array.from(ensureCollection(name).values()).map((doc) => ({ id: doc.id, exists: true, data: () => doc.data }));
+          return { docs, empty: docs.length === 0, size: docs.length };
+        },
+      }),
+    },
+  };
+});
+
+let mockUser: any;
+
+vi.mock("../../config/firebase", () => ({ db: fakeDb }));
+vi.mock("../../middleware/authMiddleware", () => ({
+  authenticateJwt: (req: any, res: any, next: any) => {
+    if (!mockUser) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    req.user = mockUser;
+    return next();
+  },
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; user?: Record<string, unknown> | null }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    mockUser = options.user ?? mockUser;
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: mockUser,
+      query: Object.fromEntries(new URLSearchParams(queryString || "").entries()),
+      params: {},
+      headers: {},
+    };
+    const match = path.match(/^\/participation-profile\/(.+)$/);
+    if (match) req.params = { tenantParticipationId: decodeURIComponent(match[1]) };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => (error ? reject(error) : undefined));
+  });
+}
+
+describe("tenantParticipationRoutes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    resetFakeDb();
+    mockUser = { id: "tenant-user-1", role: "tenant", tenantId: "tenant-1" };
+  });
+
+  function seedParticipationContext() {
+    seedDoc("rentalApplications", "application-1", { applicationId: "application-1", tenantId: "tenant-1", status: "completed", rawGovernmentId: "hidden" });
+    seedDoc("ledgerEvents", "payment-1", { ledgerEventId: "payment-1", tenantId: "tenant-1", status: "verified", paymentAccount: "hidden" });
+    seedDoc("verifiedRentalHistoryLedgers", "ledger-1", { rentalHistoryLedgerId: "ledger-1", tenantId: "tenant-1", status: "verified", rawPaymentPayload: "hidden" });
+    seedDoc("maintenanceRequests", "maintenance-1", { maintenanceRequestId: "maintenance-1", tenantId: "tenant-1", status: "completed", privateTenantData: "hidden" });
+    seedDoc("operatorReviewSessions", "review-1", { reviewSessionId: "review-1", tenantId: "tenant-1", status: "completed", privateNote: "hidden" });
+    seedDoc("disputeResolutionReadiness", "dispute-1", { disputeResolutionId: "dispute-1", tenantId: "tenant-1", status: "ready_for_review", rawDisputePayload: "hidden" });
+    seedDoc("tenantMessages", "message-1", { communicationId: "message-1", tenantId: "tenant-1", status: "available", messageBody: "hidden" });
+    seedDoc("evidencePacks", "evidence-1", { evidencePackId: "evidence-1", tenantId: "tenant-1", status: "ready_for_review", creditBureauPayload: "hidden" });
+    seedDoc("events", "event-1", { eventId: "event-1", resourceId: "tenant-1", eventType: "tenant_participation_profile_derived", unrestrictedAuditHistory: "hidden" });
+    seedDoc("ledgerEvents", "other-payment", { ledgerEventId: "other-payment", tenantId: "tenant-2", status: "verified" });
+  }
+
+  it("returns tenant-scoped participation profiles without sensitive payloads", async () => {
+    seedParticipationContext();
+    const router = (await import("../tenantParticipationRoutes")).default;
+
+    const forbidden = await invokeRouter(router, {
+      method: "GET",
+      url: "/participation-profile",
+      user: { id: "landlord-1", role: "landlord", tenantId: "tenant-1" },
+    });
+    expect(forbidden.status).toBe(401);
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/participation-profile",
+      user: { id: "tenant-user-1", role: "tenant", tenantId: "tenant-1" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.profiles).toHaveLength(1);
+    expect(res.body.profiles[0]).toEqual(
+      expect.objectContaining({
+        tenantId: "tenant-1",
+        manualReviewRequired: true,
+        publicParticipationExposureEnabled: false,
+        autonomousRewardExecutionEnabled: false,
+      })
+    );
+    expect(JSON.stringify(res.body)).not.toContain("tenant-2");
+    expect(JSON.stringify(res.body)).not.toContain("rawGovernmentId");
+    expect(JSON.stringify(res.body)).not.toContain("paymentAccount");
+    expect(JSON.stringify(res.body)).not.toContain("rawPaymentPayload");
+    expect(JSON.stringify(res.body)).not.toContain("privateTenantData");
+    expect(JSON.stringify(res.body)).not.toContain("privateNote");
+    expect(JSON.stringify(res.body)).not.toContain("rawDisputePayload");
+    expect(JSON.stringify(res.body)).not.toContain("messageBody");
+    expect(JSON.stringify(res.body)).not.toContain("creditBureauPayload");
+    expect(JSON.stringify(res.body)).not.toContain("unrestrictedAuditHistory");
+  });
+
+  it("returns a single tenant participation profile by id", async () => {
+    seedParticipationContext();
+    const router = (await import("../tenantParticipationRoutes")).default;
+    const list = await invokeRouter(router, { method: "GET", url: "/participation-profile" });
+    const id = list.body.profiles[0].tenantParticipationId;
+
+    const res = await invokeRouter(router, { method: "GET", url: `/participation-profile/${encodeURIComponent(id)}` });
+
+    expect(res.status).toBe(200);
+    expect(res.body.profile.tenantParticipationId).toBe(id);
+  });
+
+  it("filters by status", async () => {
+    seedParticipationContext();
+    const router = (await import("../tenantParticipationRoutes")).default;
+
+    const filtered = await invokeRouter(router, { method: "GET", url: "/participation-profile?status=blocked" });
+
+    expect(filtered.status).toBe(200);
+    expect(filtered.body.profiles).toEqual([]);
+  });
+});

--- a/rentchain-api/src/routes/tenantParticipationRoutes.ts
+++ b/rentchain-api/src/routes/tenantParticipationRoutes.ts
@@ -1,0 +1,152 @@
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { authenticateJwt } from "../middleware/authMiddleware";
+import { deriveTenantParticipationProfile } from "../lib/tenantParticipation/deriveTenantParticipationProfile";
+import type { TenantParticipationProfile, TenantParticipationStatus } from "../lib/tenantParticipation/tenantParticipationTypes";
+
+const router = Router();
+router.use(authenticateJwt);
+
+const STATUSES = new Set<TenantParticipationStatus>(["verified", "partially_verified", "review_required", "blocked", "unknown"]);
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function requireTenant(req: any, res: any, next: any) {
+  const user = req.user;
+  const role = asString(user?.role, 80).toLowerCase();
+  const tenantId = asString(user?.tenantId, 240);
+  if (!user || role !== "tenant" || !tenantId) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+  return next();
+}
+
+function belongsToTenant(record: Record<string, any>, tenantId: string) {
+  const tenantIds = Array.isArray(record.tenantIds) ? record.tenantIds.map((item) => asString(item, 240)) : [];
+  return [record.tenantId, record.primaryTenantId, record.applicantTenantId, record.identityId, record.resourceId, record.id]
+    .map((value) => asString(value, 240))
+    .concat(tenantIds)
+    .includes(tenantId);
+}
+
+async function loadTenantCollection(collectionName: string, tenantId: string, limit = 25) {
+  const snap = await db.collection(collectionName).get().catch(() => null);
+  return (snap?.docs || [])
+    .slice(0, 200)
+    .map((doc) => sanitizeRecord({ id: doc.id, ...((doc.data() as any) || {}) }))
+    .filter((record) => belongsToTenant(record, tenantId))
+    .slice(0, limit);
+}
+
+function sanitizeRecord(record: Record<string, any>) {
+  const safe: Record<string, any> = {};
+  for (const key of [
+    "id",
+    "status",
+    "state",
+    "conclusion",
+    "tenantId",
+    "tenantIds",
+    "primaryTenantId",
+    "applicantTenantId",
+    "identityId",
+    "resourceId",
+    "applicationId",
+    "onboardingId",
+    "paymentConsistencyId",
+    "ledgerEventId",
+    "paymentId",
+    "rentalHistoryLedgerId",
+    "leaseId",
+    "occupancyId",
+    "maintenanceRequestId",
+    "workOrderId",
+    "reviewSessionId",
+    "operatorReviewId",
+    "disputeResolutionId",
+    "disputeId",
+    "caseId",
+    "communicationId",
+    "messageId",
+    "noticeId",
+    "evidencePackId",
+    "eventId",
+    "eventType",
+    "createdAt",
+    "updatedAt",
+    "occurredAt",
+    "redacted",
+  ]) {
+    if (record[key] !== undefined) safe[key] = record[key];
+  }
+  return safe;
+}
+
+async function buildTenantParticipationProfiles(tenantId: string): Promise<TenantParticipationProfile[]> {
+  const [
+    onboardingRecords,
+    paymentConsistencyRecords,
+    occupancyRecords,
+    maintenanceRecords,
+    reviewRecords,
+    disputeRecords,
+    communicationRecords,
+    evidencePacks,
+    auditEvents,
+  ] = await Promise.all([
+    loadTenantCollection("rentalApplications", tenantId),
+    loadTenantCollection("ledgerEvents", tenantId),
+    loadTenantCollection("verifiedRentalHistoryLedgers", tenantId),
+    loadTenantCollection("maintenanceRequests", tenantId),
+    loadTenantCollection("operatorReviewSessions", tenantId),
+    loadTenantCollection("disputeResolutionReadiness", tenantId),
+    Promise.all([loadTenantCollection("tenantMessages", tenantId), loadTenantCollection("tenantNotices", tenantId)]).then((groups) => groups.flat()),
+    loadTenantCollection("evidencePacks", tenantId),
+    loadTenantCollection("events", tenantId),
+  ]);
+
+  return [
+    deriveTenantParticipationProfile({
+      tenantId,
+      onboardingRecords,
+      paymentConsistencyRecords,
+      occupancyRecords,
+      maintenanceRecords,
+      reviewRecords,
+      disputeRecords,
+      communicationRecords,
+      evidencePacks,
+      auditEvents,
+    }),
+  ];
+}
+
+router.get("/participation-profile", requireTenant, async (req: any, res) => {
+  try {
+    const tenantId = asString(req.user?.tenantId, 240);
+    const status = asString(req.query?.status, 80) as TenantParticipationStatus;
+    let profiles = await buildTenantParticipationProfiles(tenantId);
+    if (status && STATUSES.has(status)) profiles = profiles.filter((profile) => profile.status === status);
+    return res.json({ ok: true, profiles });
+  } catch (err: any) {
+    console.error("[tenant-participation] list failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "TENANT_PARTICIPATION_FAILED" });
+  }
+});
+
+router.get("/participation-profile/:tenantParticipationId", requireTenant, async (req: any, res) => {
+  try {
+    const tenantId = asString(req.user?.tenantId, 240);
+    const tenantParticipationId = decodeURIComponent(asString(req.params?.tenantParticipationId, 500));
+    if (!tenantParticipationId) return res.status(400).json({ ok: false, error: "TENANT_PARTICIPATION_ID_REQUIRED" });
+    const profiles = await buildTenantParticipationProfiles(tenantId);
+    const profile = profiles.find((next) => next.tenantParticipationId === tenantParticipationId);
+    if (!profile) return res.status(404).json({ ok: false, error: "TENANT_PARTICIPATION_NOT_FOUND" });
+    return res.json({ ok: true, profile });
+  } catch (err: any) {
+    console.error("[tenant-participation] get failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "TENANT_PARTICIPATION_GET_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -185,6 +185,7 @@ const TenantApplicationStatusPage = lazy(() => import("./pages/tenant/TenantAppl
 const TenantLeasePage = lazy(() => import("./pages/tenant/TenantLeasePage"));
 const TenantLedgerPage = lazy(() => import("./pages/tenant/TenantLedgerPage"));
 const TenantActivityPage = lazy(() => import("./pages/tenant/TenantActivityPage"));
+const TenantParticipationPage = lazy(() => import("./pages/TenantParticipationPage"));
 const TenantAttachmentsPage = lazy(() => import("./pages/tenant/TenantAttachmentsPage"));
 const TenantNoticesCenterPage = lazy(() => import("./pages/tenant/TenantNoticesCenterPage"));
 const TenantProfilePage = lazy(() => import("./pages/tenant/TenantProfilePage"));
@@ -1526,6 +1527,10 @@ function App() {
         <Route
           path="/tenant/ledger"
           element={renderTenantShell(suspensePage(<TenantLedgerPage />))}
+        />
+        <Route
+          path="/tenant/participation"
+          element={renderTenantShell(suspensePage(<TenantParticipationPage />))}
         />
         <Route
           path="/tenant/attachments"

--- a/rentchain-frontend/src/api/tenantParticipationApi.ts
+++ b/rentchain-frontend/src/api/tenantParticipationApi.ts
@@ -1,0 +1,91 @@
+import { tenantApiFetch } from "./tenantApiFetch";
+
+export type TenantParticipationStatus = "verified" | "partially_verified" | "review_required" | "blocked" | "unknown";
+export type ParticipationReferenceType =
+  | "onboarding"
+  | "payment_consistency"
+  | "occupancy"
+  | "maintenance"
+  | "review"
+  | "dispute_resolution"
+  | "communication"
+  | "evidence"
+  | "audit";
+export type ParticipationReferenceStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+
+export type ParticipationReference = {
+  referenceId: string;
+  referenceType: ParticipationReferenceType;
+  status: ParticipationReferenceStatus;
+  label: string;
+  description: string;
+  reviewRequired: true;
+  lineageReferences: string[];
+  destination: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type ParticipationRestriction = {
+  restrictionId: string;
+  restrictionType: ParticipationReferenceType | "public_scoring" | "autonomous_incentive" | "public_profile";
+  status: "visible" | "blocked" | "review_required";
+  label: string;
+  description: string;
+  blockedReason: string | null;
+};
+
+export type TenantParticipationProfile = {
+  tenantParticipationId: string;
+  status: TenantParticipationStatus;
+  tenantId: string;
+  manualReviewRequired: true;
+  publicParticipationExposureEnabled: false;
+  autonomousRewardExecutionEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    partiallyVerifiedReferences: number;
+    blockedReferences: number;
+    unavailableReferences: number;
+    restrictions: number;
+  };
+  onboardingReferences: ParticipationReference[];
+  paymentConsistencyReferences: ParticipationReference[];
+  occupancyReferences: ParticipationReference[];
+  maintenanceParticipationReferences: ParticipationReference[];
+  reviewParticipationReferences: ParticipationReference[];
+  disputeParticipationReferences: ParticipationReference[];
+  communicationParticipationReferences: ParticipationReference[];
+  evidenceReferences: ParticipationReference[];
+  auditReferences: ParticipationReference[];
+  participationRestrictions: ParticipationRestriction[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: Array<{
+    eventType: string;
+    action: string;
+    status: TenantParticipationStatus;
+    resourceId: string;
+    summary: string;
+  }>;
+};
+
+export async function fetchTenantParticipationProfiles(params?: {
+  status?: TenantParticipationStatus | "";
+}): Promise<TenantParticipationProfile[]> {
+  const search = new URLSearchParams();
+  if (params?.status) search.set("status", params.status);
+  const suffix = search.toString() ? `?${search.toString()}` : "";
+  const response = await tenantApiFetch<{ ok: true; profiles: TenantParticipationProfile[] }>(`/tenant/participation-profile${suffix}`);
+  return response.profiles;
+}
+
+export async function fetchTenantParticipationProfile(tenantParticipationId: string): Promise<TenantParticipationProfile> {
+  const response = await tenantApiFetch<{ ok: true; profile: TenantParticipationProfile }>(
+    `/tenant/participation-profile/${encodeURIComponent(tenantParticipationId)}`
+  );
+  return response.profile;
+}

--- a/rentchain-frontend/src/components/participation/TenantParticipationPanel.test.tsx
+++ b/rentchain-frontend/src/components/participation/TenantParticipationPanel.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import type { TenantParticipationProfile } from "@/api/tenantParticipationApi";
+import { TenantParticipationPanel } from "./TenantParticipationPanel";
+
+const profile: TenantParticipationProfile = {
+  tenantParticipationId: "tenant_participation:tenant-1",
+  status: "blocked",
+  tenantId: "tenant-1",
+  manualReviewRequired: true,
+  publicParticipationExposureEnabled: false,
+  autonomousRewardExecutionEnabled: false,
+  generatedAt: "2026-05-07T00:00:00.000Z",
+  summary: {
+    totalReferences: 2,
+    verifiedReferences: 1,
+    partiallyVerifiedReferences: 0,
+    blockedReferences: 1,
+    unavailableReferences: 0,
+    restrictions: 1,
+  },
+  onboardingReferences: [
+    {
+      referenceId: "onboarding-1",
+      referenceType: "onboarding",
+      status: "blocked",
+      label: "Onboarding participation reference",
+      description: "Tenant onboarding participation metadata is available for participation review.",
+      reviewRequired: true,
+      lineageReferences: ["application-1"],
+      destination: "/tenant/application",
+      redacted: false,
+      redactionReason: null,
+      blockedReason: "Onboarding participation is blocked.",
+    },
+  ],
+  paymentConsistencyReferences: [],
+  occupancyReferences: [],
+  maintenanceParticipationReferences: [],
+  reviewParticipationReferences: [],
+  disputeParticipationReferences: [],
+  communicationParticipationReferences: [],
+  evidenceReferences: [],
+  auditReferences: [],
+  participationRestrictions: [
+    {
+      restrictionId: "restriction-1",
+      restrictionType: "onboarding",
+      status: "blocked",
+      label: "Onboarding participation reference restriction",
+      description: "Onboarding participation reference is incomplete or blocked for tenant participation review.",
+      blockedReason: "Onboarding participation is blocked.",
+    },
+  ],
+  redactions: ["Raw payment account details, raw screening or credit bureau payloads, private tenant documents, and unrestricted audit histories are excluded."],
+  blockedReasons: ["Onboarding participation is blocked."],
+  canonicalEvents: [],
+};
+
+describe("TenantParticipationPanel", () => {
+  it("renders participation readiness, restrictions, blocked reasons, and required safety copy", () => {
+    render(
+      <MemoryRouter>
+        <TenantParticipationPanel profile={profile} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("View participation profile")).toBeInTheDocument();
+    expect(screen.getByText("View participation lineage")).toBeInTheDocument();
+    expect(screen.getByText("View restrictions")).toBeInTheDocument();
+    expect(screen.getAllByText("View blocked reason: Onboarding participation is blocked.").length).toBeGreaterThan(0);
+    expect(screen.getByText("Manual review required")).toBeInTheDocument();
+    expect(screen.getByText(/Participation references are operationally scoped and review controlled/i)).toBeInTheDocument();
+    expect(screen.getByText(/No public tenant scoring or autonomous incentives are enabled/i)).toBeInTheDocument();
+    expect(screen.getByText(/Manual review remains required/i)).toBeInTheDocument();
+  });
+
+  it("does not render forbidden participation labels", () => {
+    render(
+      <MemoryRouter>
+        <TenantParticipationPanel profile={profile} />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText("Public tenant score")).not.toBeInTheDocument();
+    expect(screen.queryByText("Auto-reward")).not.toBeInTheDocument();
+    expect(screen.queryByText("Auto-penalize")).not.toBeInTheDocument();
+    expect(screen.queryByText("Public ranking")).not.toBeInTheDocument();
+    expect(screen.queryByText("Autonomous incentive")).not.toBeInTheDocument();
+    expect(screen.queryByText("Publish participation score")).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/participation/TenantParticipationPanel.tsx
+++ b/rentchain-frontend/src/components/participation/TenantParticipationPanel.tsx
@@ -1,0 +1,172 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import type {
+  ParticipationReference,
+  ParticipationRestriction,
+  TenantParticipationProfile,
+} from "@/api/tenantParticipationApi";
+import { Card, Section } from "@/components/ui/Ui";
+
+function label(value: string) {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function tone(status: string) {
+  if (status === "blocked") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
+  if (status === "review_required" || status === "partially_verified" || status === "unavailable") {
+    return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
+  }
+  if (status === "verified") return { color: "#166534", background: "#dcfce7", border: "#bbf7d0" };
+  return { color: "#475569", background: "#f8fafc", border: "#e2e8f0" };
+}
+
+function Badge({ children, status }: { children: React.ReactNode; status: string }) {
+  const next = tone(status);
+  return (
+    <span
+      style={{
+        border: `1px solid ${next.border}`,
+        borderRadius: 999,
+        background: next.background,
+        color: next.color,
+        padding: "3px 9px",
+        fontSize: 12,
+        fontWeight: 900,
+        whiteSpace: "nowrap",
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+function ReferenceList({ title, references }: { title: string; references: ParticipationReference[] }) {
+  return (
+    <Section style={{ display: "grid", gap: 10 }}>
+      <div style={{ fontWeight: 900 }}>{title}</div>
+      {references.length ? (
+        references.slice(0, 12).map((reference) => (
+          <Card key={reference.referenceId} style={{ borderRadius: 8, padding: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+              <div>
+                <strong>{reference.label}</strong>
+                <div style={{ color: "#64748b", fontSize: 13 }}>{label(reference.referenceType)}</div>
+              </div>
+              <Badge status={reference.status}>{label(reference.status)}</Badge>
+            </div>
+            <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>{reference.description}</div>
+            {reference.lineageReferences.length ? (
+              <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>Lineage references: {reference.lineageReferences.length}</div>
+            ) : null}
+            {reference.blockedReason ? (
+              <div style={{ color: "#991b1b", fontSize: 13, marginTop: 8 }}>View blocked reason: {reference.blockedReason}</div>
+            ) : null}
+            {reference.redacted ? (
+              <div style={{ color: "#92400e", fontSize: 13, marginTop: 8 }}>
+                {reference.redactionReason || "Redacted tenant participation reference"}
+              </div>
+            ) : null}
+            {reference.destination?.startsWith("/") ? (
+              <Link to={reference.destination} style={{ color: "#2563eb", fontWeight: 800, fontSize: 13, marginTop: 8, display: "inline-block" }}>
+                View context
+              </Link>
+            ) : null}
+          </Card>
+        ))
+      ) : (
+        <Card style={{ color: "#64748b" }}>Context unavailable</Card>
+      )}
+    </Section>
+  );
+}
+
+function RestrictionList({ restrictions }: { restrictions: ParticipationRestriction[] }) {
+  return (
+    <Section style={{ display: "grid", gap: 10 }}>
+      <div style={{ fontWeight: 900 }}>View restrictions</div>
+      {restrictions.length ? (
+        restrictions.map((restriction) => (
+          <Card key={restriction.restrictionId} style={{ borderRadius: 8, padding: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+              <div>
+                <strong>{restriction.label}</strong>
+                <div style={{ color: "#64748b", fontSize: 13 }}>{label(restriction.restrictionType)}</div>
+              </div>
+              <Badge status={restriction.status}>{label(restriction.status)}</Badge>
+            </div>
+            <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>{restriction.description}</div>
+            {restriction.blockedReason ? (
+              <div style={{ color: "#991b1b", fontSize: 13, marginTop: 8 }}>View blocked reason: {restriction.blockedReason}</div>
+            ) : null}
+          </Card>
+        ))
+      ) : (
+        <Card style={{ color: "#64748b" }}>No tenant participation restrictions detected.</Card>
+      )}
+    </Section>
+  );
+}
+
+export function TenantParticipationPanel({ profile }: { profile: TenantParticipationProfile }) {
+  return (
+    <div style={{ display: "grid", gap: 16 }}>
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+          <div>
+            <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>View participation profile</div>
+            <h2 style={{ margin: "2px 0 0", fontSize: "1.15rem" }}>Tenant participation</h2>
+          </div>
+          <Badge status={profile.status}>{label(profile.status)}</Badge>
+        </div>
+        <div style={{ color: "#475569", lineHeight: 1.55 }}>
+          Participation references are operationally scoped and review controlled. No public tenant scoring or autonomous incentives are enabled.
+          Manual review remains required.
+        </div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <Badge status="review_required">Manual review required</Badge>
+          <Badge status={profile.publicParticipationExposureEnabled ? "blocked" : "verified"}>Public exposure disabled</Badge>
+          <Badge status={profile.autonomousRewardExecutionEnabled ? "blocked" : "verified"}>Reward automation disabled</Badge>
+        </div>
+      </Section>
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Participation summary</div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: 10 }}>
+          {[
+            ["References", profile.summary.totalReferences],
+            ["Verified", profile.summary.verifiedReferences],
+            ["Partial", profile.summary.partiallyVerifiedReferences],
+            ["Blocked", profile.summary.blockedReferences],
+            ["Unavailable", profile.summary.unavailableReferences],
+            ["Restrictions", profile.summary.restrictions],
+          ].map(([name, value]) => (
+            <Card key={String(name)} style={{ borderRadius: 8, padding: 12 }}>
+              <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>{name}</div>
+              <strong style={{ color: "#0f172a", fontSize: 22 }}>{String(value)}</strong>
+            </Card>
+          ))}
+        </div>
+      </Section>
+
+      <RestrictionList restrictions={profile.participationRestrictions} />
+      <ReferenceList title="View participation lineage" references={profile.onboardingReferences} />
+      <ReferenceList title="Payment consistency" references={profile.paymentConsistencyReferences} />
+      <ReferenceList title="Occupancy consistency" references={profile.occupancyReferences} />
+      <ReferenceList title="Maintenance participation" references={profile.maintenanceParticipationReferences} />
+      <ReferenceList title="View review lineage" references={profile.reviewParticipationReferences} />
+      <ReferenceList title="Dispute-resolution participation" references={profile.disputeParticipationReferences} />
+      <ReferenceList title="Communication responsiveness" references={profile.communicationParticipationReferences} />
+      <ReferenceList title="View evidence lineage" references={profile.evidenceReferences} />
+      <ReferenceList title="Audit lineage" references={profile.auditReferences} />
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Redactions</div>
+        {profile.redactions.map((redaction) => (
+          <Card key={redaction} style={{ borderRadius: 8, padding: 12, color: "#475569" }}>
+            {redaction}
+          </Card>
+        ))}
+      </Section>
+    </div>
+  );
+}

--- a/rentchain-frontend/src/pages/TenantParticipationPage.test.tsx
+++ b/rentchain-frontend/src/pages/TenantParticipationPage.test.tsx
@@ -1,0 +1,97 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import TenantParticipationPage from "./TenantParticipationPage";
+
+const mockFetchProfiles = vi.fn();
+const mockShowToast = vi.fn();
+
+vi.mock("@/api/tenantParticipationApi", () => ({
+  fetchTenantParticipationProfiles: (...args: any[]) => mockFetchProfiles(...args),
+}));
+
+vi.mock("@/components/layout/MacShell", () => ({
+  MacShell: ({ children, title }: any) => <main aria-label={title}>{children}</main>,
+}));
+
+vi.mock("@/components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
+const profile = {
+  tenantParticipationId: "tenant_participation:tenant-1",
+  status: "verified",
+  tenantId: "tenant-1",
+  manualReviewRequired: true,
+  publicParticipationExposureEnabled: false,
+  autonomousRewardExecutionEnabled: false,
+  generatedAt: "2026-05-07T00:00:00.000Z",
+  summary: {
+    totalReferences: 1,
+    verifiedReferences: 1,
+    partiallyVerifiedReferences: 0,
+    blockedReferences: 0,
+    unavailableReferences: 0,
+    restrictions: 0,
+  },
+  onboardingReferences: [],
+  paymentConsistencyReferences: [],
+  occupancyReferences: [],
+  maintenanceParticipationReferences: [],
+  reviewParticipationReferences: [],
+  disputeParticipationReferences: [],
+  communicationParticipationReferences: [],
+  evidenceReferences: [],
+  auditReferences: [],
+  participationRestrictions: [],
+  redactions: ["Sensitive participation payloads are excluded."],
+  blockedReasons: [],
+  canonicalEvents: [],
+};
+
+describe("TenantParticipationPage", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    mockFetchProfiles.mockResolvedValue([profile]);
+  });
+
+  it("loads and renders tenant participation with required safety copy", async () => {
+    render(
+      <MemoryRouter>
+        <TenantParticipationPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Loading tenant participation...")).toBeInTheDocument();
+    expect(await screen.findByText("Participation summary")).toBeInTheDocument();
+    expect(screen.getAllByText(/Participation references are operationally scoped and review controlled/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Manual review remains required/i).length).toBeGreaterThan(0);
+    expect(mockFetchProfiles).toHaveBeenCalledWith({ status: "" });
+  });
+
+  it("filters profiles by status", async () => {
+    render(
+      <MemoryRouter>
+        <TenantParticipationPage />
+      </MemoryRouter>
+    );
+
+    fireEvent.change((await screen.findAllByLabelText("Status"))[0], { target: { value: "blocked" } });
+    await waitFor(() => {
+      expect(mockFetchProfiles).toHaveBeenLastCalledWith({ status: "blocked" });
+    });
+  });
+
+  it("renders the empty state", async () => {
+    mockFetchProfiles.mockResolvedValue([]);
+
+    render(
+      <MemoryRouter>
+        <TenantParticipationPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("No tenant participation profiles match these filters.")).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/TenantParticipationPage.tsx
+++ b/rentchain-frontend/src/pages/TenantParticipationPage.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+import { useSearchParams } from "react-router-dom";
+import {
+  fetchTenantParticipationProfiles,
+  type TenantParticipationProfile,
+  type TenantParticipationStatus,
+} from "@/api/tenantParticipationApi";
+import { MacShell } from "@/components/layout/MacShell";
+import { TenantParticipationPanel } from "@/components/participation/TenantParticipationPanel";
+import { Card, Section } from "@/components/ui/Ui";
+import { useToast } from "@/components/ui/ToastProvider";
+
+const statuses: Array<TenantParticipationStatus | ""> = ["", "verified", "partially_verified", "review_required", "blocked", "unknown"];
+
+function label(value: string) {
+  return value ? value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase()) : "All";
+}
+
+export default function TenantParticipationPage() {
+  const { showToast } = useToast();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [profiles, setProfiles] = React.useState<TenantParticipationProfile[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const status = String(searchParams.get("status") || "") as TenantParticipationStatus | "";
+
+  React.useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const next = await fetchTenantParticipationProfiles({ status });
+        if (mounted) setProfiles(next);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Failed to load tenant participation";
+        if (mounted) {
+          setError(message);
+          showToast({ message: "Failed to load tenant participation", description: message, variant: "error" });
+        }
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [status, showToast]);
+
+  function updateStatus(value: string) {
+    const params = new URLSearchParams(searchParams);
+    if (value && value.trim()) params.set("status", value.trim());
+    else params.delete("status");
+    setSearchParams(params);
+  }
+
+  return (
+    <MacShell title="Tenant participation" showTopNav={false}>
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "grid", gap: 6 }}>
+            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Tenant participation</h1>
+            <div style={{ color: "#475569", maxWidth: 900 }}>
+              Participation references are operationally scoped and review controlled. No public tenant scoring or autonomous incentives are enabled.
+              Manual review remains required.
+            </div>
+          </div>
+        </Section>
+
+        <Section style={{ display: "flex", gap: 10, flexWrap: "wrap", alignItems: "end" }}>
+          <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Status
+            <select value={status} onChange={(event) => updateStatus(event.target.value)} style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 180 }}>
+              {statuses.map((item) => (
+                <option key={item || "all"} value={item}>
+                  {label(item)}
+                </option>
+              ))}
+            </select>
+          </label>
+        </Section>
+
+        {loading ? <Card>Loading tenant participation...</Card> : null}
+        {!loading && error ? <Card style={{ color: "#b91c1c" }}>We couldn't load tenant participation right now.</Card> : null}
+        {!loading && !error && !profiles.length ? <Card style={{ color: "#64748b" }}>No tenant participation profiles match these filters.</Card> : null}
+        {!loading && !error && profiles.length ? (
+          <div style={{ display: "grid", gap: 16 }}>{profiles.map((profile) => <TenantParticipationPanel key={profile.tenantParticipationId} profile={profile} />)}</div>
+        ) : null}
+      </div>
+    </MacShell>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a deterministic tenant participation read model with onboarding, payment-consistency, occupancy, maintenance, review, dispute, communication, evidence, and audit lineage references.
- Adds tenant-scoped read-only endpoints under `/api/tenant/participation-profile`.
- Adds a tenant-facing participation profile page/panel with required guardrail copy, restrictions, redactions, and status visibility.

## Guardrails
- `manualReviewRequired` remains `true`.
- `publicParticipationExposureEnabled` remains `false`.
- `autonomousRewardExecutionEnabled` remains `false`.
- No public tenant scoring, public reputation marketplace, autonomous reward/penalty execution, bureau execution, or hidden behavioral scoring path was added.
- Route payloads use whitelist sanitization and tenant-authenticated server-side scoping.

## Verification
- Backend targeted tests: `9/9` passed.
- Frontend targeted tests: `5/5` passed.
- Backend build: passed.
- Frontend build: passed; existing chunk-size warning remains non-regressive.
- `git diff --cached --check`: passed.
- Dependency/lockfile diff: empty.
- Forbidden label scan: clean for prohibited UI labels/buttons.