### PR TITLE
feat: add rental debt accountability layer

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -137,6 +137,7 @@ import landlordReviewTimelineRoutes from "./routes/landlordReviewTimelineRoutes"
 import landlordIdentityLayerRoutes from "./routes/landlordIdentityLayerRoutes";
 import landlordSharingRoomRoutes from "./routes/landlordSharingRoomRoutes";
 import landlordRentalHistoryLedgerRoutes from "./routes/landlordRentalHistoryLedgerRoutes";
+import landlordRentalDebtRoutes from "./routes/landlordRentalDebtRoutes";
 import landlordSettlementReadinessRoutes from "./routes/landlordSettlementReadinessRoutes";
 import landlordRegulatoryProfileRoutes from "./routes/landlordRegulatoryProfileRoutes";
 import landlordAssetTokenizationReadinessRoutes from "./routes/landlordAssetTokenizationReadinessRoutes";
@@ -340,6 +341,8 @@ app.use("/api/landlord", routeSource("landlordSharingRoomRoutes.ts"), landlordSh
 console.log("[route-mount] landlordSharingRoomRoutes mounted at /api/landlord");
 app.use("/api/landlord", routeSource("landlordRentalHistoryLedgerRoutes.ts"), landlordRentalHistoryLedgerRoutes);
 console.log("[route-mount] landlordRentalHistoryLedgerRoutes mounted at /api/landlord");
+app.use("/api/landlord", routeSource("landlordRentalDebtRoutes.ts"), landlordRentalDebtRoutes);
+console.log("[route-mount] landlordRentalDebtRoutes mounted at /api/landlord");
 app.use("/api/landlord", routeSource("landlordSettlementReadinessRoutes.ts"), landlordSettlementReadinessRoutes);
 console.log("[route-mount] landlordSettlementReadinessRoutes mounted at /api/landlord");
 app.use("/api/landlord", routeSource("landlordRegulatoryProfileRoutes.ts"), landlordRegulatoryProfileRoutes);

--- a/rentchain-api/src/lib/rentalDebt/__tests__/deriveRentalDebtProfile.test.ts
+++ b/rentchain-api/src/lib/rentalDebt/__tests__/deriveRentalDebtProfile.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { deriveRentalDebtProfile } from "../deriveRentalDebtProfile";
+
+describe("deriveRentalDebtProfile", () => {
+  const completeInput = {
+    landlordId: "landlord-1",
+    tenantId: "tenant-1",
+    generatedAt: "2026-05-07T00:00:00.000Z",
+    paymentDefaultRecords: [{ paymentDefaultId: "default-1", status: "verified" }],
+    delinquencyRecords: [{ delinquencyId: "delinquency-1", status: "verified" }],
+    disputeRecords: [{ disputeId: "dispute-1", status: "verified" }],
+    consentRecords: [{ consentId: "consent-1", status: "verified" }],
+    reviewRecords: [{ reviewSessionId: "review-1", status: "completed" }],
+    evidencePacks: [{ evidencePackId: "evidence-1", status: "verified" }],
+    auditEvents: [{ eventId: "event-1", eventType: "rental_debt_profile_derived" }],
+  };
+
+  it("derives a deterministic verified profile with execution flags pinned off", () => {
+    const profile = deriveRentalDebtProfile(completeInput);
+    const again = deriveRentalDebtProfile(completeInput);
+
+    expect(profile).toEqual(again);
+    expect(profile).toEqual(
+      expect.objectContaining({
+        rentalDebtId: "rental_debt:landlord-1:tenant-1",
+        status: "verified",
+        manualReviewRequired: true,
+        collectionsExecutionEnabled: false,
+        bureauReportingEnabled: false,
+        publicDebtExposureEnabled: false,
+      })
+    );
+    expect(profile.summary.totalReferences).toBe(7);
+    expect(profile.summary.verifiedReferences).toBe(7);
+    expect(profile.debtRestrictions).toEqual([]);
+  });
+
+  it("blocks unresolved consent or dispute restrictions", () => {
+    const profile = deriveRentalDebtProfile({
+      ...completeInput,
+      consentRecords: [{ consentId: "consent-1", status: "blocked" }],
+    });
+
+    expect(profile.status).toBe("blocked");
+    expect(profile.debtRestrictions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          restrictionType: "consent",
+          status: "blocked",
+        }),
+      ])
+    );
+    expect(profile.canonicalEvents.map((event) => event.eventType)).toContain("rental_debt_blocked");
+  });
+
+  it("requires review when critical evidence, review, consent, or audit lineage is missing", () => {
+    const profile = deriveRentalDebtProfile({
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      paymentDefaultRecords: [{ paymentDefaultId: "default-1", status: "verified" }],
+      delinquencyRecords: [{ delinquencyId: "delinquency-1", status: "verified" }],
+      disputeRecords: [{ disputeId: "dispute-1", status: "verified" }],
+    });
+
+    expect(profile.status).toBe("review_required");
+    expect(profile.debtRestrictions.some((restriction) => restriction.restrictionType === "consent")).toBe(true);
+    expect(profile.debtRestrictions.some((restriction) => restriction.restrictionType === "review")).toBe(true);
+    expect(profile.debtRestrictions.some((restriction) => restriction.restrictionType === "evidence")).toBe(true);
+    expect(profile.debtRestrictions.some((restriction) => restriction.restrictionType === "audit")).toBe(true);
+  });
+
+  it("uses partial verification for incomplete operational debt lineage without enabling enforcement", () => {
+    const profile = deriveRentalDebtProfile({
+      ...completeInput,
+      delinquencyRecords: [{ delinquencyId: "delinquency-1", status: "under_review" }],
+    });
+
+    expect(profile.status).toBe("partially_verified");
+    expect(profile.collectionsExecutionEnabled).toBe(false);
+    expect(profile.bureauReportingEnabled).toBe(false);
+    expect(profile.publicDebtExposureEnabled).toBe(false);
+    expect(profile.canonicalEvents.map((event) => event.eventType)).toContain("rental_debt_review_required");
+  });
+
+  it("returns unknown when source context is unavailable", () => {
+    const profile = deriveRentalDebtProfile({ landlordId: "landlord-1", tenantId: "tenant-1" });
+
+    expect(profile.status).toBe("unknown");
+    expect(profile.summary.unavailableReferences).toBe(7);
+  });
+
+  it("generates additive canonical events for redaction and restrictions", () => {
+    const profile = deriveRentalDebtProfile({
+      ...completeInput,
+      evidencePacks: [{ evidencePackId: "evidence-1", status: "blocked", redacted: true }],
+    });
+
+    expect(profile.canonicalEvents.map((event) => event.eventType)).toEqual(
+      expect.arrayContaining(["rental_debt_profile_derived", "rental_debt_redaction_applied", "rental_debt_restriction_detected"])
+    );
+    expect(profile.evidenceReferences[0]).toEqual(
+      expect.objectContaining({
+        redacted: true,
+        redactionReason: "Debt evidence lineage reference payload is redacted for debt accountability safety.",
+      })
+    );
+  });
+});

--- a/rentchain-api/src/lib/rentalDebt/debtRestrictionModels.ts
+++ b/rentchain-api/src/lib/rentalDebt/debtRestrictionModels.ts
@@ -1,0 +1,63 @@
+import type {
+  DebtReference,
+  DebtReferenceStatus,
+  DebtReferenceType,
+  DebtRestriction,
+} from "./rentalDebtTypes";
+
+export function debtIdPart(value: unknown) {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 240);
+}
+
+export function debtReference(input: {
+  idParts: unknown[];
+  referenceType: DebtReferenceType;
+  status: DebtReferenceStatus;
+  label: string;
+  description: string;
+  lineageReferences?: string[];
+  destination?: string | null;
+  redacted?: boolean;
+  redactionReason?: string | null;
+  blockedReason?: string | null;
+}): DebtReference {
+  const referenceId = debtIdPart(input.idParts.filter(Boolean).join(":")) || `${input.referenceType}:unknown`;
+  return {
+    referenceId,
+    referenceType: input.referenceType,
+    status: input.status,
+    label: input.label,
+    description: input.description,
+    reviewRequired: true,
+    lineageReferences: Array.from(new Set(input.lineageReferences || [])).filter(Boolean).slice(0, 20),
+    destination: input.destination || null,
+    redacted: Boolean(input.redacted),
+    redactionReason: input.redactionReason || null,
+    blockedReason: input.blockedReason || null,
+  };
+}
+
+export function debtRestriction(input: {
+  idParts: unknown[];
+  restrictionType: DebtRestriction["restrictionType"];
+  status: DebtRestriction["status"];
+  label: string;
+  description: string;
+  blockedReason?: string | null;
+}): DebtRestriction {
+  const restrictionId = debtIdPart(["debt_restriction", ...input.idParts].filter(Boolean).join(":"));
+  return {
+    restrictionId: restrictionId || "debt_restriction:unknown",
+    restrictionType: input.restrictionType,
+    status: input.status,
+    label: input.label,
+    description: input.description,
+    blockedReason: input.blockedReason || null,
+  };
+}

--- a/rentchain-api/src/lib/rentalDebt/deriveRentalDebtProfile.ts
+++ b/rentchain-api/src/lib/rentalDebt/deriveRentalDebtProfile.ts
@@ -1,0 +1,323 @@
+import type {
+  DebtReference,
+  DebtReferenceStatus,
+  DebtReferenceType,
+  DeriveRentalDebtProfileInput,
+  RentalDebtCanonicalEvent,
+  RentalDebtProfile,
+  RentalDebtStatus,
+} from "./rentalDebtTypes";
+import { debtIdPart, debtReference, debtRestriction } from "./debtRestrictionModels";
+
+const REDACTIONS = [
+  "Collections execution payloads, bureau reporting payloads, public debt lists, and public accountability marketplace payloads are excluded.",
+  "Raw payment account details, private tenant data, unrestricted delinquency histories, and raw screening or credit bureau payloads are excluded.",
+  "Rental debt accountability is visibility metadata only; no autonomous enforcement, collections execution, bureau reporting, or public debt exposure is enabled.",
+  "Debt references are consent-aware, permission scoped, and manually reviewed before any accountability use.",
+];
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function asArray<T>(value: T[] | null | undefined): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function generatedAt(value: unknown): string {
+  const raw = asString(value, 120);
+  const date = raw ? new Date(raw) : new Date(0);
+  return Number.isNaN(date.getTime()) ? new Date(0).toISOString() : date.toISOString();
+}
+
+function recordId(record: Record<string, any>, keys: string[]): string {
+  for (const key of keys) {
+    const value = asString(record?.[key], 240);
+    if (value) return value;
+  }
+  return asString(record?.id, 240);
+}
+
+function referenceStatus(record: Record<string, any>, verifiedStatuses: string[]): DebtReferenceStatus {
+  const status = asString(record?.status || record?.state || record?.conclusion || record?.paymentStatus, 80).toLowerCase();
+  if (status === "blocked" || status === "disputed" || status === "elevated" || status === "failure" || status === "failed" || status === "error" || status === "cancelled") {
+    return "blocked";
+  }
+  if (verifiedStatuses.includes(status)) return "verified";
+  if (status === "missing" || status === "unknown" || status === "unavailable" || status === "pending") return "unavailable";
+  return "partially_verified";
+}
+
+function statusForType(referenceType: DebtReferenceType, record: Record<string, any>): DebtReferenceStatus {
+  if (referenceType === "review") return referenceStatus(record, ["ready_for_review", "completed", "verified", "reviewed"]);
+  if (referenceType === "audit" && asString(record?.eventType || record?.type, 120)) return "verified";
+  if (referenceType === "payment_default") return referenceStatus(record, ["verified", "available", "reviewed", "confirmed", "past_due", "overdue", "defaulted"]);
+  if (referenceType === "delinquency") return referenceStatus(record, ["verified", "available", "reviewed", "confirmed", "past_due", "overdue", "delinquent"]);
+  return referenceStatus(record, ["ready_for_review", "verified", "available", "completed", "stable", "active", "configured"]);
+}
+
+function profileStatus(hasContext: boolean, references: DebtReference[]): RentalDebtStatus {
+  if (!hasContext) return "unknown";
+  if (references.some((reference) => reference.status === "blocked" && (reference.referenceType === "consent" || reference.referenceType === "dispute"))) return "blocked";
+  const criticalMissing = references.some(
+    (reference) =>
+      reference.status === "unavailable" &&
+      (reference.referenceType === "consent" ||
+        reference.referenceType === "review" ||
+        reference.referenceType === "evidence" ||
+        reference.referenceType === "audit")
+  );
+  if (criticalMissing) return "review_required";
+  if (references.some((reference) => reference.status === "blocked" || reference.status === "unavailable" || reference.status === "partially_verified")) return "partially_verified";
+  return "verified";
+}
+
+function event(input: {
+  eventType: RentalDebtCanonicalEvent["eventType"];
+  status: RentalDebtStatus;
+  rentalDebtId: string;
+  summary: string;
+}): RentalDebtCanonicalEvent {
+  return {
+    eventType: input.eventType,
+    action: input.eventType.replace(/^rental_debt_/, "").replace(/_/g, "."),
+    status: input.status,
+    resourceType: "rental_debt_profile",
+    resourceId: input.rentalDebtId,
+    summary: input.summary,
+  };
+}
+
+function referencesFor(input: {
+  records: Record<string, any>[];
+  fallback: string;
+  referenceType: DebtReferenceType;
+  idKeys: string[];
+  label: string;
+  description: string;
+  destination: string;
+  blockedReason: string;
+}): DebtReference[] {
+  if (!input.records.length) {
+    return [
+      debtReference({
+        idParts: [input.referenceType, "missing"],
+        referenceType: input.referenceType,
+        status: "unavailable",
+        label: input.label,
+        description: `${input.description} is unavailable for rental debt accountability review.`,
+        destination: input.destination,
+      }),
+    ];
+  }
+  return input.records.map((record, index) => {
+    const id = recordId(record, input.idKeys) || `${input.fallback}-${index + 1}`;
+    const status = statusForType(input.referenceType, record);
+    return debtReference({
+      idParts: [input.referenceType, id],
+      referenceType: input.referenceType,
+      status,
+      label: input.label,
+      description: `${input.description} is available for rental debt accountability review.`,
+      lineageReferences: [id].filter(Boolean),
+      destination: input.destination,
+      redacted: Boolean(record.redacted),
+      redactionReason: record.redacted ? `${input.label} payload is redacted for debt accountability safety.` : null,
+      blockedReason: status === "blocked" ? input.blockedReason : null,
+    });
+  });
+}
+
+export function deriveRentalDebtProfile(input: DeriveRentalDebtProfileInput): RentalDebtProfile {
+  const landlordId = asString(input.landlordId, 240) || "unknown";
+  const tenantId = asString(input.tenantId, 240) || "unknown";
+  const rentalDebtId = debtIdPart(["rental_debt", landlordId, tenantId].join(":")) || "rental_debt:unknown";
+
+  const paymentDefaultRecords = asArray(input.paymentDefaultRecords);
+  const delinquencyRecords = asArray(input.delinquencyRecords);
+  const disputeRecords = asArray(input.disputeRecords);
+  const consentRecords = asArray(input.consentRecords);
+  const reviewRecords = asArray(input.reviewRecords);
+  const evidencePacks = asArray(input.evidencePacks);
+  const auditEvents = asArray(input.auditEvents);
+
+  const paymentDefaultReferences = referencesFor({
+    records: paymentDefaultRecords,
+    fallback: "payment-default",
+    referenceType: "payment_default",
+    idKeys: ["paymentDefaultId", "ledgerEventId", "paymentId", "rentPaymentId", "id"],
+    label: "Payment-default reference",
+    description: "Payment-default and missed-payment metadata",
+    destination: "/ledger",
+    blockedReason: "Payment-default reference is blocked.",
+  });
+  const delinquencyReferences = referencesFor({
+    records: delinquencyRecords,
+    fallback: "delinquency",
+    referenceType: "delinquency",
+    idKeys: ["delinquencyId", "ledgerEventId", "rentPaymentId", "paymentId", "id"],
+    label: "Delinquency evidence reference",
+    description: "Delinquency evidence lineage metadata",
+    destination: "/verified-rental-history",
+    blockedReason: "Delinquency evidence lineage is blocked.",
+  });
+  const disputeReferences = referencesFor({
+    records: disputeRecords,
+    fallback: "dispute",
+    referenceType: "dispute",
+    idKeys: ["disputeId", "disputeGovernanceId", "caseId", "id"],
+    label: "Dispute linkage reference",
+    description: "Dispute linkage and dispute-governance metadata",
+    destination: "/review-timeline",
+    blockedReason: "Dispute linkage is blocked.",
+  });
+  const consentReferences = referencesFor({
+    records: consentRecords,
+    fallback: "consent",
+    referenceType: "consent",
+    idKeys: ["consentId", "consentGovernanceId", "identityConsentId", "id"],
+    label: "Consent governance reference",
+    description: "Consent governance and access-control metadata",
+    destination: "/identity-layer",
+    blockedReason: "Consent governance lineage is missing or blocked.",
+  });
+  const reviewReferences = referencesFor({
+    records: reviewRecords,
+    fallback: "review",
+    referenceType: "review",
+    idKeys: ["reviewSessionId", "operatorReviewId", "id"],
+    label: "Debt review lineage reference",
+    description: "Manual debt review lineage metadata",
+    destination: "/review-timeline",
+    blockedReason: "Debt review lineage is blocked.",
+  });
+  const evidenceReferences = referencesFor({
+    records: evidencePacks,
+    fallback: "evidence",
+    referenceType: "evidence",
+    idKeys: ["evidencePackId", "id"],
+    label: "Debt evidence lineage reference",
+    description: "Debt evidence lineage metadata",
+    destination: "/evidence-packs",
+    blockedReason: "Debt evidence lineage is blocked.",
+  });
+  const auditReferences = referencesFor({
+    records: auditEvents.slice(0, 20),
+    fallback: "audit",
+    referenceType: "audit",
+    idKeys: ["eventId", "auditId", "id"],
+    label: "Debt audit lineage reference",
+    description: "Debt audit lineage metadata",
+    destination: "/review-timeline",
+    blockedReason: "Debt audit lineage is blocked.",
+  });
+
+  const allReferences = [
+    ...paymentDefaultReferences,
+    ...delinquencyReferences,
+    ...disputeReferences,
+    ...consentReferences,
+    ...reviewReferences,
+    ...evidenceReferences,
+    ...auditReferences,
+  ];
+  const hasContext = Boolean(
+    paymentDefaultRecords.length ||
+      delinquencyRecords.length ||
+      disputeRecords.length ||
+      consentRecords.length ||
+      reviewRecords.length ||
+      evidencePacks.length ||
+      auditEvents.length
+  );
+  const status = profileStatus(hasContext, allReferences);
+  const debtRestrictions = allReferences
+    .filter((reference) => reference.status !== "verified")
+    .map((reference) =>
+      debtRestriction({
+        idParts: [reference.referenceType, reference.referenceId],
+        restrictionType: reference.referenceType,
+        status: reference.status === "blocked" ? "blocked" : "review_required",
+        label: `${reference.label} restriction`,
+        description: `${reference.label} is incomplete or blocked for rental debt accountability review.`,
+        blockedReason: reference.blockedReason,
+      })
+    );
+  const blockedReasons = [...allReferences.map((reference) => reference.blockedReason), ...debtRestrictions.map((restriction) => restriction.blockedReason)].filter(Boolean) as string[];
+
+  const canonicalEvents: RentalDebtCanonicalEvent[] = [
+    event({
+      eventType: "rental_debt_profile_derived",
+      status,
+      rentalDebtId,
+      summary: "Rental debt profile derived from payment-default, delinquency, dispute, consent, review, evidence, and audit metadata.",
+    }),
+    event({
+      eventType: "rental_debt_redaction_applied",
+      status,
+      rentalDebtId,
+      summary: "Collections, bureau reporting, public debt exposure, raw payment, private tenant, and unrestricted delinquency payloads were excluded.",
+    }),
+  ];
+  if (debtRestrictions.length) {
+    canonicalEvents.push(
+      event({
+        eventType: "rental_debt_restriction_detected",
+        status,
+        rentalDebtId,
+        summary: "Rental debt accountability restrictions are visible for manual review.",
+      })
+    );
+  }
+  if (status === "review_required" || status === "partially_verified") {
+    canonicalEvents.push(
+      event({
+        eventType: "rental_debt_review_required",
+        status,
+        rentalDebtId,
+        summary: "Manual rental debt accountability review is required.",
+      })
+    );
+  }
+  if (status === "blocked") {
+    canonicalEvents.push(
+      event({
+        eventType: "rental_debt_blocked",
+        status,
+        rentalDebtId,
+        summary: "Rental debt accountability profile is blocked by unresolved restrictions.",
+      })
+    );
+  }
+
+  return {
+    rentalDebtId,
+    status,
+    landlordId,
+    tenantId,
+    manualReviewRequired: true,
+    collectionsExecutionEnabled: false,
+    bureauReportingEnabled: false,
+    publicDebtExposureEnabled: false,
+    generatedAt: generatedAt(input.generatedAt),
+    summary: {
+      totalReferences: allReferences.length,
+      verifiedReferences: allReferences.filter((reference) => reference.status === "verified").length,
+      partiallyVerifiedReferences: allReferences.filter((reference) => reference.status === "partially_verified").length,
+      blockedReferences: allReferences.filter((reference) => reference.status === "blocked").length,
+      unavailableReferences: allReferences.filter((reference) => reference.status === "unavailable").length,
+      restrictions: debtRestrictions.length,
+    },
+    paymentDefaultReferences,
+    delinquencyReferences,
+    disputeReferences,
+    consentReferences,
+    reviewReferences,
+    evidenceReferences,
+    auditReferences,
+    debtRestrictions,
+    redactions: REDACTIONS,
+    blockedReasons,
+    canonicalEvents,
+  };
+}

--- a/rentchain-api/src/lib/rentalDebt/rentalDebtTypes.ts
+++ b/rentchain-api/src/lib/rentalDebt/rentalDebtTypes.ts
@@ -1,0 +1,87 @@
+export type RentalDebtStatus = "verified" | "partially_verified" | "review_required" | "blocked" | "unknown";
+
+export type DebtReferenceType = "payment_default" | "delinquency" | "dispute" | "consent" | "review" | "evidence" | "audit";
+export type DebtReferenceStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+
+export type RentalDebtCanonicalEventType =
+  | "rental_debt_profile_derived"
+  | "rental_debt_review_required"
+  | "rental_debt_blocked"
+  | "rental_debt_restriction_detected"
+  | "rental_debt_redaction_applied";
+
+export type DebtReference = {
+  referenceId: string;
+  referenceType: DebtReferenceType;
+  status: DebtReferenceStatus;
+  label: string;
+  description: string;
+  reviewRequired: true;
+  lineageReferences: string[];
+  destination: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type DebtRestriction = {
+  restrictionId: string;
+  restrictionType: DebtReferenceType | "collections_execution" | "bureau_reporting" | "public_debt_exposure";
+  status: "visible" | "blocked" | "review_required";
+  label: string;
+  description: string;
+  blockedReason: string | null;
+};
+
+export type RentalDebtCanonicalEvent = {
+  eventType: RentalDebtCanonicalEventType;
+  action: string;
+  status: RentalDebtStatus;
+  resourceType: "rental_debt_profile";
+  resourceId: string;
+  summary: string;
+};
+
+export type RentalDebtProfile = {
+  rentalDebtId: string;
+  status: RentalDebtStatus;
+  landlordId: string;
+  tenantId: string;
+  manualReviewRequired: true;
+  collectionsExecutionEnabled: false;
+  bureauReportingEnabled: false;
+  publicDebtExposureEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    partiallyVerifiedReferences: number;
+    blockedReferences: number;
+    unavailableReferences: number;
+    restrictions: number;
+  };
+  paymentDefaultReferences: DebtReference[];
+  delinquencyReferences: DebtReference[];
+  disputeReferences: DebtReference[];
+  consentReferences: DebtReference[];
+  reviewReferences: DebtReference[];
+  evidenceReferences: DebtReference[];
+  auditReferences: DebtReference[];
+  debtRestrictions: DebtRestriction[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: RentalDebtCanonicalEvent[];
+};
+
+export type DeriveRentalDebtProfileInput = {
+  landlordId?: unknown;
+  tenantId?: unknown;
+  generatedAt?: unknown;
+  paymentDefaultRecords?: Array<Record<string, any>> | null;
+  delinquencyRecords?: Array<Record<string, any>> | null;
+  disputeRecords?: Array<Record<string, any>> | null;
+  consentRecords?: Array<Record<string, any>> | null;
+  reviewRecords?: Array<Record<string, any>> | null;
+  evidencePacks?: Array<Record<string, any>> | null;
+  auditEvents?: Array<Record<string, any>> | null;
+};

--- a/rentchain-api/src/routes/__tests__/landlordRentalDebtRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordRentalDebtRoutes.test.ts
@@ -1,0 +1,233 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+
+  function matches(doc: any, filters: Array<{ field: string; op: string; value: any }>) {
+    return filters.every(({ field, op, value }) => {
+      const actual = doc?.data?.[field];
+      if (op === "==") return actual === value;
+      return false;
+    });
+  }
+
+  function makeQuery(name: string, filters: Array<{ field: string; op: string; value: any }> = []) {
+    return {
+      where: (field: string, op: string, value: any) => makeQuery(name, [...filters, { field, op, value }]),
+      get: async () => {
+        const docs = Array.from(ensureCollection(name).values())
+          .filter((doc) => matches(doc, filters))
+          .map((doc) => ({ id: doc.id, exists: true, data: () => doc.data }));
+        return { docs, empty: docs.length === 0, size: docs.length };
+      },
+    };
+  }
+
+  return {
+    resetFakeDb: () => store.clear(),
+    seedDoc: (collection: string, id: string, data: any) => ensureCollection(collection).set(id, { id, data }),
+    fakeDb: {
+      collection: (name: string) => ({
+        where: (field: string, op: string, value: any) => makeQuery(name, [{ field, op, value }]),
+        get: async () => makeQuery(name).get(),
+      }),
+    },
+  };
+});
+
+let mockUser: any;
+
+vi.mock("../../config/firebase", () => ({ db: fakeDb }));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!mockUser) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    req.user = mockUser;
+    return next();
+  },
+}));
+
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: any, res: any, next: any) => {
+    const role = String(req.user?.role || "").trim().toLowerCase();
+    const landlordId = req.user?.landlordId || req.user?.id;
+    if (role !== "landlord" && role !== "admin") return res.status(403).json({ ok: false, error: "Forbidden" });
+    if (!landlordId) return res.status(401).json({ ok: false, error: "Missing landlord context" });
+    req.user.landlordId = landlordId;
+    return next();
+  },
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; user?: Record<string, unknown> | null }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    mockUser = options.user ?? mockUser;
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: mockUser,
+      body: {},
+      query: Object.fromEntries(new URLSearchParams(queryString || "").entries()),
+      params: {},
+      headers: {},
+    };
+    const match = path.match(/^\/rental-debt\/(.+)$/);
+    if (match) req.params = { rentalDebtId: decodeURIComponent(match[1]) };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => (error ? reject(error) : undefined));
+  });
+}
+
+describe("landlordRentalDebtRoutes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    resetFakeDb();
+    mockUser = { id: "landlord-1", landlordId: "landlord-1", role: "landlord" };
+  });
+
+  function seedRentalDebt() {
+    seedDoc("ledgerEvents", "ledger-default-1", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      ledgerEventId: "ledger-default-1",
+      status: "past_due",
+      paymentAccount: "hidden",
+    });
+    seedDoc("rentPayments", "payment-default-1", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      rentPaymentId: "payment-default-1",
+      paymentStatus: "overdue",
+      rawPaymentPayload: "hidden",
+    });
+    seedDoc("delinquencyRecords", "delinquency-1", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      delinquencyId: "delinquency-1",
+      status: "verified",
+      unrestrictedDelinquencyHistory: "hidden",
+    });
+    seedDoc("disputeResolutionReadiness", "dispute-1", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      disputeId: "dispute-1",
+      status: "verified",
+      rawDisputePayload: "hidden",
+    });
+    seedDoc("consents", "consent-1", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      consentId: "consent-1",
+      status: "verified",
+      privateTenantData: "hidden",
+    });
+    seedDoc("operatorReviewSessions", "review-1", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      reviewSessionId: "review-1",
+      status: "completed",
+      privateNote: "hidden",
+    });
+    seedDoc("evidencePacks", "evidence-1", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      evidencePackId: "evidence-1",
+      status: "verified",
+      creditBureauPayload: "hidden",
+    });
+    seedDoc("events", "event-1", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      eventId: "event-1",
+      eventType: "rental_debt_profile_derived",
+      adminOnlyPayload: "hidden",
+    });
+    seedDoc("ledgerEvents", "other-default", {
+      landlordId: "landlord-2",
+      tenantId: "tenant-2",
+      ledgerEventId: "other-default",
+      status: "past_due",
+    });
+  }
+
+  it("returns landlord-scoped rental-debt profiles without sensitive payloads", async () => {
+    seedRentalDebt();
+    const router = (await import("../landlordRentalDebtRoutes")).default;
+
+    const forbidden = await invokeRouter(router, {
+      method: "GET",
+      url: "/rental-debt",
+      user: { id: "tenant-1", role: "tenant" },
+    });
+    expect(forbidden.status).toBe(403);
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/rental-debt?tenantId=tenant-1",
+      user: { id: "landlord-1", landlordId: "landlord-1", role: "landlord" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.profiles).toHaveLength(1);
+    expect(res.body.profiles[0]).toEqual(
+      expect.objectContaining({
+        landlordId: "landlord-1",
+        tenantId: "tenant-1",
+        manualReviewRequired: true,
+        collectionsExecutionEnabled: false,
+        bureauReportingEnabled: false,
+        publicDebtExposureEnabled: false,
+      })
+    );
+    const serialized = JSON.stringify(res.body);
+    expect(serialized).not.toContain("tenant-2");
+    expect(serialized).not.toContain("paymentAccount");
+    expect(serialized).not.toContain("rawPaymentPayload");
+    expect(serialized).not.toContain("unrestrictedDelinquencyHistory");
+    expect(serialized).not.toContain("rawDisputePayload");
+    expect(serialized).not.toContain("privateTenantData");
+    expect(serialized).not.toContain("privateNote");
+    expect(serialized).not.toContain("creditBureauPayload");
+    expect(serialized).not.toContain("adminOnlyPayload");
+  });
+
+  it("returns a single rental-debt profile by id", async () => {
+    seedRentalDebt();
+    const router = (await import("../landlordRentalDebtRoutes")).default;
+    const list = await invokeRouter(router, { method: "GET", url: "/rental-debt?tenantId=tenant-1" });
+    const id = list.body.profiles[0].rentalDebtId;
+
+    const res = await invokeRouter(router, { method: "GET", url: `/rental-debt/${encodeURIComponent(id)}` });
+
+    expect(res.status).toBe(200);
+    expect(res.body.profile.rentalDebtId).toBe(id);
+  });
+
+  it("filters by status", async () => {
+    seedRentalDebt();
+    const router = (await import("../landlordRentalDebtRoutes")).default;
+
+    const filtered = await invokeRouter(router, { method: "GET", url: "/rental-debt?status=blocked" });
+
+    expect(filtered.status).toBe(200);
+    expect(filtered.body.profiles).toEqual([]);
+  });
+});

--- a/rentchain-api/src/routes/landlordRentalDebtRoutes.ts
+++ b/rentchain-api/src/routes/landlordRentalDebtRoutes.ts
@@ -1,0 +1,185 @@
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { requireAuth } from "../middleware/requireAuth";
+import { requireLandlord } from "../middleware/requireLandlord";
+import { deriveRentalDebtProfile } from "../lib/rentalDebt/deriveRentalDebtProfile";
+import type { RentalDebtProfile, RentalDebtStatus } from "../lib/rentalDebt/rentalDebtTypes";
+
+const router = Router();
+const STATUSES = new Set<RentalDebtStatus>(["verified", "partially_verified", "review_required", "blocked", "unknown"]);
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function landlordIdFromReq(req: any) {
+  return asString(req.user?.landlordId || req.user?.id || req.user?.sub, 240);
+}
+
+function sanitizeRecord(record: Record<string, any>) {
+  const safe: Record<string, any> = {};
+  for (const key of [
+    "id",
+    "status",
+    "state",
+    "conclusion",
+    "paymentStatus",
+    "type",
+    "eventType",
+    "domain",
+    "landlordId",
+    "ownerId",
+    "userId",
+    "tenantId",
+    "tenantIds",
+    "primaryTenantId",
+    "applicantTenantId",
+    "identityId",
+    "resourceId",
+    "scopeId",
+    "leaseId",
+    "propertyId",
+    "paymentDefaultId",
+    "delinquencyId",
+    "ledgerEventId",
+    "paymentId",
+    "rentPaymentId",
+    "disputeId",
+    "disputeGovernanceId",
+    "caseId",
+    "consentId",
+    "consentGovernanceId",
+    "identityConsentId",
+    "reviewSessionId",
+    "operatorReviewId",
+    "evidencePackId",
+    "eventId",
+    "createdAt",
+    "updatedAt",
+    "occurredAt",
+    "redacted",
+  ]) {
+    if (record[key] !== undefined) safe[key] = record[key];
+  }
+  return safe;
+}
+
+function belongsToLandlord(record: Record<string, any>, landlordId: string) {
+  return [record.landlordId, record.ownerId, record.userId].map((value) => asString(value, 240)).includes(landlordId);
+}
+
+function tenantIdsFor(record: Record<string, any>) {
+  const tenantIds = Array.isArray(record.tenantIds) ? record.tenantIds.map((item) => asString(item, 240)) : [];
+  return [record.tenantId, record.primaryTenantId, record.applicantTenantId, record.identityId, record.resourceId, record.scopeId]
+    .map((value) => asString(value, 240).replace(/^tenant:/, ""))
+    .concat(tenantIds)
+    .filter(Boolean);
+}
+
+function filterByTenant(records: Record<string, any>[], tenantId: string) {
+  return records.filter((record) => tenantIdsFor(record).includes(tenantId));
+}
+
+function debtLike(record: Record<string, any>) {
+  const fields = [record.status, record.state, record.conclusion, record.paymentStatus, record.type, record.eventType, record.domain]
+    .map((value) => asString(value, 120).toLowerCase())
+    .join(" ");
+  return /\b(default|delinquen|past_due|overdue|arrears|missed|failed|late)\b/.test(fields);
+}
+
+async function loadLandlordCollection(collectionName: string, landlordId: string, limit = 50) {
+  const byId = new Map<string, any>();
+  async function collect(field: "landlordId" | "ownerId" | "userId") {
+    const snap = await db.collection(collectionName).where(field, "==", landlordId).get().catch(() => null);
+    for (const doc of snap?.docs || []) byId.set(doc.id, sanitizeRecord({ id: doc.id, ...((doc.data() as any) || {}) }));
+  }
+  await Promise.all([collect("landlordId"), collect("ownerId"), collect("userId")]);
+  return Array.from(byId.values()).filter((record) => belongsToLandlord(record, landlordId)).slice(0, limit);
+}
+
+function collectTenantIds(records: Record<string, any>[]) {
+  const tenantIds = new Set<string>();
+  for (const record of records) {
+    for (const tenantId of tenantIdsFor(record)) tenantIds.add(tenantId);
+  }
+  return Array.from(tenantIds).sort((a, b) => a.localeCompare(b));
+}
+
+async function buildRentalDebtProfiles(landlordId: string, requestedTenantId?: string): Promise<RentalDebtProfile[]> {
+  const [
+    ledgerEvents,
+    rentPayments,
+    delinquencyRecords,
+    disputeRecords,
+    consentRecords,
+    reviewRecords,
+    evidencePacks,
+    events,
+  ] = await Promise.all([
+    loadLandlordCollection("ledgerEvents", landlordId),
+    loadLandlordCollection("rentPayments", landlordId),
+    Promise.all([
+      loadLandlordCollection("delinquencyRecords", landlordId),
+      loadLandlordCollection("rentalDebtReadiness", landlordId),
+      loadLandlordCollection("rentalDebtProfiles", landlordId),
+    ]).then((groups) => groups.flat()),
+    Promise.all([
+      loadLandlordCollection("disputeResolutionReadiness", landlordId),
+      loadLandlordCollection("disputeGovernance", landlordId),
+    ]).then((groups) => groups.flat()),
+    Promise.all([loadLandlordCollection("consents", landlordId), loadLandlordCollection("consentGovernance", landlordId)]).then((groups) => groups.flat()),
+    loadLandlordCollection("operatorReviewSessions", landlordId),
+    loadLandlordCollection("evidencePacks", landlordId),
+    loadLandlordCollection("events", landlordId),
+  ]);
+
+  const paymentDefaultRecords = [...ledgerEvents, ...rentPayments].filter(debtLike);
+  const debtRecords = [...paymentDefaultRecords, ...delinquencyRecords, ...disputeRecords, ...consentRecords, ...reviewRecords, ...evidencePacks, ...events];
+  const tenantIds = requestedTenantId ? [requestedTenantId] : collectTenantIds(debtRecords);
+
+  return tenantIds.map((tenantId) =>
+    deriveRentalDebtProfile({
+      landlordId,
+      tenantId,
+      paymentDefaultRecords: filterByTenant(paymentDefaultRecords, tenantId),
+      delinquencyRecords: filterByTenant(delinquencyRecords, tenantId),
+      disputeRecords: filterByTenant(disputeRecords, tenantId),
+      consentRecords: filterByTenant(consentRecords, tenantId),
+      reviewRecords: filterByTenant(reviewRecords, tenantId),
+      evidencePacks: filterByTenant(evidencePacks, tenantId),
+      auditEvents: filterByTenant(events, tenantId),
+    })
+  );
+}
+
+router.get("/rental-debt", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = landlordIdFromReq(req);
+    if (!landlordId) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    const tenantId = asString(req.query?.tenantId, 240);
+    const status = asString(req.query?.status, 80) as RentalDebtStatus;
+    let profiles = await buildRentalDebtProfiles(landlordId, tenantId || undefined);
+    if (status && STATUSES.has(status)) profiles = profiles.filter((profile) => profile.status === status);
+    return res.json({ ok: true, profiles });
+  } catch (err: any) {
+    console.error("[landlord-rental-debt] list failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "RENTAL_DEBT_FAILED" });
+  }
+});
+
+router.get("/rental-debt/:rentalDebtId", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = landlordIdFromReq(req);
+    const rentalDebtId = decodeURIComponent(asString(req.params?.rentalDebtId, 500));
+    if (!landlordId || !rentalDebtId) return res.status(400).json({ ok: false, error: "RENTAL_DEBT_ID_REQUIRED" });
+    const profiles = await buildRentalDebtProfiles(landlordId);
+    const profile = profiles.find((item) => item.rentalDebtId === rentalDebtId);
+    if (!profile) return res.status(404).json({ ok: false, error: "RENTAL_DEBT_NOT_FOUND" });
+    return res.json({ ok: true, profile });
+  } catch (err: any) {
+    console.error("[landlord-rental-debt] get failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "RENTAL_DEBT_GET_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -133,6 +133,7 @@ const ReviewTimelinePage = lazy(() => import("./pages/ReviewTimelinePage"));
 const IdentityLayerPage = lazy(() => import("./pages/IdentityLayerPage"));
 const InstitutionalSharingRoomPage = lazy(() => import("./pages/InstitutionalSharingRoomPage"));
 const VerifiedRentalHistoryPage = lazy(() => import("./pages/VerifiedRentalHistoryPage"));
+const RentalDebtPage = lazy(() => import("./pages/RentalDebtPage"));
 const SettlementReadinessPage = lazy(() => import("./pages/SettlementReadinessPage"));
 const RegulatoryProfilePage = lazy(() => import("./pages/RegulatoryProfilePage"));
 const AssetTokenizationReadinessPage = lazy(() => import("./pages/AssetTokenizationReadinessPage"));
@@ -633,6 +634,18 @@ function App() {
               <LandlordNav>
                 <Suspense fallback={null}>
                   <VerifiedRentalHistoryPage />
+                </Suspense>
+              </LandlordNav>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/rental-debt"
+          element={
+            <RequireAuth>
+              <LandlordNav>
+                <Suspense fallback={null}>
+                  <RentalDebtPage />
                 </Suspense>
               </LandlordNav>
             </RequireAuth>

--- a/rentchain-frontend/src/api/rentalDebtApi.ts
+++ b/rentchain-frontend/src/api/rentalDebtApi.ts
@@ -1,0 +1,78 @@
+import { apiFetch } from "./apiFetch";
+
+export type RentalDebtStatus = "verified" | "partially_verified" | "review_required" | "blocked" | "unknown";
+export type DebtReferenceType = "payment_default" | "delinquency" | "dispute" | "consent" | "review" | "evidence" | "audit";
+export type DebtReferenceStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+
+export type DebtReference = {
+  referenceId: string;
+  referenceType: DebtReferenceType;
+  status: DebtReferenceStatus;
+  label: string;
+  description: string;
+  reviewRequired: true;
+  lineageReferences: string[];
+  destination: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type DebtRestriction = {
+  restrictionId: string;
+  restrictionType: DebtReferenceType | "collections_execution" | "bureau_reporting" | "public_debt_exposure";
+  status: "visible" | "blocked" | "review_required";
+  label: string;
+  description: string;
+  blockedReason: string | null;
+};
+
+export type RentalDebtProfile = {
+  rentalDebtId: string;
+  status: RentalDebtStatus;
+  landlordId: string;
+  tenantId: string;
+  manualReviewRequired: true;
+  collectionsExecutionEnabled: false;
+  bureauReportingEnabled: false;
+  publicDebtExposureEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    partiallyVerifiedReferences: number;
+    blockedReferences: number;
+    unavailableReferences: number;
+    restrictions: number;
+  };
+  paymentDefaultReferences: DebtReference[];
+  delinquencyReferences: DebtReference[];
+  disputeReferences: DebtReference[];
+  consentReferences: DebtReference[];
+  reviewReferences: DebtReference[];
+  evidenceReferences: DebtReference[];
+  auditReferences: DebtReference[];
+  debtRestrictions: DebtRestriction[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: Array<{ eventType: string; action: string; status: RentalDebtStatus; resourceId: string; summary: string }>;
+};
+
+export async function fetchRentalDebtProfiles(params?: {
+  tenantId?: string;
+  status?: RentalDebtStatus | "";
+}): Promise<RentalDebtProfile[]> {
+  const search = new URLSearchParams();
+  if (params?.tenantId) search.set("tenantId", params.tenantId);
+  if (params?.status) search.set("status", params.status);
+  const suffix = search.toString() ? `?${search.toString()}` : "";
+  const response = await apiFetch<{ ok: true; profiles: RentalDebtProfile[] }>(`/landlord/rental-debt${suffix}`);
+  return response.profiles;
+}
+
+export async function fetchRentalDebtProfile(rentalDebtId: string): Promise<RentalDebtProfile> {
+  const response = await apiFetch<{ ok: true; profile: RentalDebtProfile }>(
+    `/landlord/rental-debt/${encodeURIComponent(rentalDebtId)}`
+  );
+  return response.profile;
+}

--- a/rentchain-frontend/src/components/debt/RentalDebtPanel.test.tsx
+++ b/rentchain-frontend/src/components/debt/RentalDebtPanel.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import type { RentalDebtProfile } from "@/api/rentalDebtApi";
+import { RentalDebtPanel } from "./RentalDebtPanel";
+
+const profile: RentalDebtProfile = {
+  rentalDebtId: "rental_debt:landlord-1:tenant-1",
+  status: "blocked",
+  landlordId: "landlord-1",
+  tenantId: "tenant-1",
+  manualReviewRequired: true,
+  collectionsExecutionEnabled: false,
+  bureauReportingEnabled: false,
+  publicDebtExposureEnabled: false,
+  generatedAt: "2026-05-07T00:00:00.000Z",
+  summary: {
+    totalReferences: 2,
+    verifiedReferences: 1,
+    partiallyVerifiedReferences: 0,
+    blockedReferences: 1,
+    unavailableReferences: 0,
+    restrictions: 1,
+  },
+  paymentDefaultReferences: [],
+  delinquencyReferences: [],
+  disputeReferences: [
+    {
+      referenceId: "dispute-1",
+      referenceType: "dispute",
+      status: "blocked",
+      label: "Dispute linkage reference",
+      description: "Dispute linkage metadata is available for rental debt accountability review.",
+      reviewRequired: true,
+      lineageReferences: ["dispute-1"],
+      destination: "/review-timeline",
+      redacted: false,
+      redactionReason: null,
+      blockedReason: "Dispute linkage is blocked.",
+    },
+  ],
+  consentReferences: [],
+  reviewReferences: [],
+  evidenceReferences: [],
+  auditReferences: [],
+  debtRestrictions: [
+    {
+      restrictionId: "restriction-1",
+      restrictionType: "dispute",
+      status: "blocked",
+      label: "Dispute linkage reference restriction",
+      description: "Dispute linkage reference is incomplete or blocked for rental debt accountability review.",
+      blockedReason: "Dispute linkage is blocked.",
+    },
+  ],
+  redactions: ["Raw payment account details, private tenant data, unrestricted delinquency histories, and raw screening or credit bureau payloads are excluded."],
+  blockedReasons: ["Dispute linkage is blocked."],
+  canonicalEvents: [],
+};
+
+describe("RentalDebtPanel", () => {
+  it("renders accountability status, restrictions, blocked reasons, and required safety copy", () => {
+    render(
+      <MemoryRouter>
+        <RentalDebtPanel profile={profile} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("View accountability profile")).toBeInTheDocument();
+    expect(screen.getByText("View dispute lineage")).toBeInTheDocument();
+    expect(screen.getByText("View restrictions")).toBeInTheDocument();
+    expect(screen.getAllByText("View blocked reason: Dispute linkage is blocked.").length).toBeGreaterThan(0);
+    expect(screen.getByText("Manual review required")).toBeInTheDocument();
+    expect(screen.getByText(/Rental debt accountability is operationally scoped and review controlled/i)).toBeInTheDocument();
+    expect(screen.getByText(/No collections execution, bureau reporting, or public debt exposure is enabled/i)).toBeInTheDocument();
+    expect(screen.getByText(/Manual review remains required/i)).toBeInTheDocument();
+  });
+
+  it("does not render forbidden debt execution labels", () => {
+    render(
+      <MemoryRouter>
+        <RentalDebtPanel profile={profile} />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText("Send to collections")).not.toBeInTheDocument();
+    expect(screen.queryByText("Report to bureau")).not.toBeInTheDocument();
+    expect(screen.queryByText("Public debt listing")).not.toBeInTheDocument();
+    expect(screen.queryByText("Autonomous enforcement")).not.toBeInTheDocument();
+    expect(screen.queryByText("Auto-report debt")).not.toBeInTheDocument();
+    expect(screen.queryByText("Publish tenant debt")).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/debt/RentalDebtPanel.tsx
+++ b/rentchain-frontend/src/components/debt/RentalDebtPanel.tsx
@@ -1,0 +1,140 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import type { DebtReference, DebtRestriction, RentalDebtProfile } from "@/api/rentalDebtApi";
+import { Card, Section } from "@/components/ui/Ui";
+
+function label(value: string) {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function tone(status: string) {
+  if (status === "blocked") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
+  if (status === "review_required" || status === "partially_verified" || status === "unavailable") {
+    return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
+  }
+  if (status === "verified") return { color: "#166534", background: "#dcfce7", border: "#bbf7d0" };
+  return { color: "#475569", background: "#f8fafc", border: "#e2e8f0" };
+}
+
+function Badge({ children, status }: { children: React.ReactNode; status: string }) {
+  const next = tone(status);
+  return (
+    <span style={{ border: `1px solid ${next.border}`, borderRadius: 999, background: next.background, color: next.color, padding: "3px 9px", fontSize: 12, fontWeight: 900, whiteSpace: "nowrap" }}>
+      {children}
+    </span>
+  );
+}
+
+function ReferenceList({ title, references }: { title: string; references: DebtReference[] }) {
+  return (
+    <Section style={{ display: "grid", gap: 10 }}>
+      <div style={{ fontWeight: 900 }}>{title}</div>
+      {references.length ? (
+        references.slice(0, 12).map((reference) => (
+          <Card key={reference.referenceId} style={{ borderRadius: 8, padding: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+              <div>
+                <strong>{reference.label}</strong>
+                <div style={{ color: "#64748b", fontSize: 13 }}>{label(reference.referenceType)}</div>
+              </div>
+              <Badge status={reference.status}>{label(reference.status)}</Badge>
+            </div>
+            <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>{reference.description}</div>
+            {reference.lineageReferences.length ? <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>Lineage references: {reference.lineageReferences.length}</div> : null}
+            {reference.blockedReason ? <div style={{ color: "#991b1b", fontSize: 13, marginTop: 8 }}>View blocked reason: {reference.blockedReason}</div> : null}
+            {reference.redacted ? <div style={{ color: "#92400e", fontSize: 13, marginTop: 8 }}>{reference.redactionReason || "Redacted rental debt reference"}</div> : null}
+            {reference.destination?.startsWith("/") ? <Link to={reference.destination} style={{ color: "#2563eb", fontWeight: 800, fontSize: 13, marginTop: 8, display: "inline-block" }}>View context</Link> : null}
+          </Card>
+        ))
+      ) : (
+        <Card style={{ color: "#64748b" }}>Context unavailable</Card>
+      )}
+    </Section>
+  );
+}
+
+function RestrictionList({ restrictions }: { restrictions: DebtRestriction[] }) {
+  return (
+    <Section style={{ display: "grid", gap: 10 }}>
+      <div style={{ fontWeight: 900 }}>View restrictions</div>
+      {restrictions.length ? (
+        restrictions.map((restriction) => (
+          <Card key={restriction.restrictionId} style={{ borderRadius: 8, padding: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+              <div>
+                <strong>{restriction.label}</strong>
+                <div style={{ color: "#64748b", fontSize: 13 }}>{label(restriction.restrictionType)}</div>
+              </div>
+              <Badge status={restriction.status}>{label(restriction.status)}</Badge>
+            </div>
+            <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>{restriction.description}</div>
+            {restriction.blockedReason ? <div style={{ color: "#991b1b", fontSize: 13, marginTop: 8 }}>View blocked reason: {restriction.blockedReason}</div> : null}
+          </Card>
+        ))
+      ) : (
+        <Card style={{ color: "#64748b" }}>No rental debt restrictions detected.</Card>
+      )}
+    </Section>
+  );
+}
+
+export function RentalDebtPanel({ profile }: { profile: RentalDebtProfile }) {
+  return (
+    <div style={{ display: "grid", gap: 16 }}>
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+          <div>
+            <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>View accountability profile</div>
+            <h2 style={{ margin: "2px 0 0", fontSize: "1.15rem" }}>Rental debt accountability</h2>
+          </div>
+          <Badge status={profile.status}>{label(profile.status)}</Badge>
+        </div>
+        <div style={{ color: "#475569", lineHeight: 1.55 }}>
+          Rental debt accountability is operationally scoped and review controlled. No collections execution, bureau reporting, or public debt exposure is enabled.
+          Manual review remains required.
+        </div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <Badge status="review_required">Manual review required</Badge>
+          <Badge status={profile.collectionsExecutionEnabled ? "blocked" : "verified"}>Collections execution disabled</Badge>
+          <Badge status={profile.bureauReportingEnabled ? "blocked" : "verified"}>Bureau reporting disabled</Badge>
+          <Badge status={profile.publicDebtExposureEnabled ? "blocked" : "verified"}>Public exposure disabled</Badge>
+        </div>
+      </Section>
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Accountability summary</div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: 10 }}>
+          {[
+            ["References", profile.summary.totalReferences],
+            ["Verified", profile.summary.verifiedReferences],
+            ["Partial", profile.summary.partiallyVerifiedReferences],
+            ["Blocked", profile.summary.blockedReferences],
+            ["Unavailable", profile.summary.unavailableReferences],
+            ["Restrictions", profile.summary.restrictions],
+          ].map(([name, value]) => (
+            <Card key={String(name)} style={{ borderRadius: 8, padding: 12 }}>
+              <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>{name}</div>
+              <strong style={{ color: "#0f172a", fontSize: 22 }}>{String(value)}</strong>
+            </Card>
+          ))}
+        </div>
+      </Section>
+
+      <RestrictionList restrictions={profile.debtRestrictions} />
+      <ReferenceList title="Payment-default lineage" references={profile.paymentDefaultReferences} />
+      <ReferenceList title="Delinquency evidence lineage" references={profile.delinquencyReferences} />
+      <ReferenceList title="View dispute lineage" references={profile.disputeReferences} />
+      <ReferenceList title="Consent governance lineage" references={profile.consentReferences} />
+      <ReferenceList title="View review lineage" references={profile.reviewReferences} />
+      <ReferenceList title="View evidence lineage" references={profile.evidenceReferences} />
+      <ReferenceList title="Audit lineage" references={profile.auditReferences} />
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Redactions</div>
+        {profile.redactions.map((redaction) => (
+          <Card key={redaction} style={{ borderRadius: 8, padding: 12, color: "#475569" }}>{redaction}</Card>
+        ))}
+      </Section>
+    </div>
+  );
+}

--- a/rentchain-frontend/src/pages/RentalDebtPage.test.tsx
+++ b/rentchain-frontend/src/pages/RentalDebtPage.test.tsx
@@ -1,0 +1,99 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import RentalDebtPage from "./RentalDebtPage";
+
+const mockFetchProfiles = vi.fn();
+const mockShowToast = vi.fn();
+
+vi.mock("@/api/rentalDebtApi", () => ({
+  fetchRentalDebtProfiles: (...args: any[]) => mockFetchProfiles(...args),
+}));
+
+vi.mock("@/components/layout/MacShell", () => ({
+  MacShell: ({ children, title }: any) => <main aria-label={title}>{children}</main>,
+}));
+
+vi.mock("@/components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
+const profile = {
+  rentalDebtId: "rental_debt:landlord-1:tenant-1",
+  status: "verified",
+  landlordId: "landlord-1",
+  tenantId: "tenant-1",
+  manualReviewRequired: true,
+  collectionsExecutionEnabled: false,
+  bureauReportingEnabled: false,
+  publicDebtExposureEnabled: false,
+  generatedAt: "2026-05-07T00:00:00.000Z",
+  summary: {
+    totalReferences: 1,
+    verifiedReferences: 1,
+    partiallyVerifiedReferences: 0,
+    blockedReferences: 0,
+    unavailableReferences: 0,
+    restrictions: 0,
+  },
+  paymentDefaultReferences: [],
+  delinquencyReferences: [],
+  disputeReferences: [],
+  consentReferences: [],
+  reviewReferences: [],
+  evidenceReferences: [],
+  auditReferences: [],
+  debtRestrictions: [],
+  redactions: ["Sensitive debt payloads are excluded."],
+  blockedReasons: [],
+  canonicalEvents: [],
+};
+
+describe("RentalDebtPage", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    mockFetchProfiles.mockResolvedValue([profile]);
+  });
+
+  it("loads and renders rental debt accountability with required safety copy", async () => {
+    render(
+      <MemoryRouter>
+        <RentalDebtPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Loading rental debt accountability...")).toBeInTheDocument();
+    expect(await screen.findByText("Accountability summary")).toBeInTheDocument();
+    expect(screen.getAllByText(/Rental debt accountability is operationally scoped and review controlled/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Manual review remains required/i).length).toBeGreaterThan(0);
+    expect(mockFetchProfiles).toHaveBeenCalledWith({ tenantId: undefined, status: "" });
+  });
+
+  it("filters profiles by tenant and status", async () => {
+    render(
+      <MemoryRouter>
+        <RentalDebtPage />
+      </MemoryRouter>
+    );
+
+    fireEvent.change((await screen.findByLabelText("Tenant reference")), { target: { value: "tenant-1" } });
+    fireEvent.change(screen.getByLabelText("Status"), { target: { value: "blocked" } });
+
+    await waitFor(() => {
+      expect(mockFetchProfiles).toHaveBeenLastCalledWith({ tenantId: "tenant-1", status: "blocked" });
+    });
+  });
+
+  it("renders the empty state", async () => {
+    mockFetchProfiles.mockResolvedValue([]);
+
+    render(
+      <MemoryRouter>
+        <RentalDebtPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("No rental debt accountability profiles match these filters.")).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/RentalDebtPage.tsx
+++ b/rentchain-frontend/src/pages/RentalDebtPage.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import { useSearchParams } from "react-router-dom";
+import { fetchRentalDebtProfiles, type RentalDebtProfile, type RentalDebtStatus } from "@/api/rentalDebtApi";
+import { MacShell } from "@/components/layout/MacShell";
+import { RentalDebtPanel } from "@/components/debt/RentalDebtPanel";
+import { Card, Section } from "@/components/ui/Ui";
+import { useToast } from "@/components/ui/ToastProvider";
+
+const statuses: Array<RentalDebtStatus | ""> = ["", "verified", "partially_verified", "review_required", "blocked", "unknown"];
+
+function label(value: string) {
+  return value ? value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase()) : "All";
+}
+
+export default function RentalDebtPage() {
+  const { showToast } = useToast();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [profiles, setProfiles] = React.useState<RentalDebtProfile[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const tenantId = String(searchParams.get("tenantId") || "").trim();
+  const status = String(searchParams.get("status") || "") as RentalDebtStatus | "";
+
+  React.useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const next = await fetchRentalDebtProfiles({ tenantId: tenantId || undefined, status });
+        if (mounted) setProfiles(next);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Failed to load rental debt accountability";
+        if (mounted) {
+          setError(message);
+          showToast({ message: "Failed to load rental debt accountability", description: message, variant: "error" });
+        }
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [tenantId, status, showToast]);
+
+  function updateParams(next: { tenantId?: string; status?: string }) {
+    const params = new URLSearchParams(searchParams);
+    if (next.tenantId !== undefined) {
+      if (next.tenantId.trim()) params.set("tenantId", next.tenantId.trim());
+      else params.delete("tenantId");
+    }
+    if (next.status !== undefined) {
+      if (next.status) params.set("status", next.status);
+      else params.delete("status");
+    }
+    setSearchParams(params);
+  }
+
+  return (
+    <MacShell title="Rental debt accountability" showTopNav={false}>
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "grid", gap: 6 }}>
+            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Rental debt accountability</h1>
+            <div style={{ color: "#475569", maxWidth: 900 }}>
+              Rental debt accountability is operationally scoped and review controlled. No collections execution, bureau reporting, or public debt exposure is enabled.
+              Manual review remains required.
+            </div>
+          </div>
+        </Section>
+
+        <Section style={{ display: "flex", gap: 10, flexWrap: "wrap", alignItems: "end" }}>
+          <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Tenant reference
+            <input
+              value={tenantId}
+              onChange={(event) => updateParams({ tenantId: event.target.value })}
+              placeholder="Optional tenant reference"
+              style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 240 }}
+            />
+          </label>
+          <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Status
+            <select value={status} onChange={(event) => updateParams({ status: event.target.value })} style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 180 }}>
+              {statuses.map((item) => <option key={item || "all"} value={item}>{label(item)}</option>)}
+            </select>
+          </label>
+        </Section>
+
+        {loading ? <Card>Loading rental debt accountability...</Card> : null}
+        {!loading && error ? <Card style={{ color: "#b91c1c" }}>We couldn't load rental debt accountability right now.</Card> : null}
+        {!loading && !error && !profiles.length ? <Card style={{ color: "#64748b" }}>No rental debt accountability profiles match these filters.</Card> : null}
+        {!loading && !error && profiles.length ? (
+          <div style={{ display: "grid", gap: 16 }}>{profiles.map((profile) => <RentalDebtPanel key={profile.rentalDebtId} profile={profile} />)}</div>
+        ) : null}
+      </div>
+    </MacShell>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a deterministic Rental Debt and Accountability read model for payment-default, delinquency, dispute, consent, review, evidence, and audit lineage.
- Adds landlord-scoped read-only endpoints under `/api/landlord/rental-debt`.
- Adds a landlord/governance UI surface at `/rental-debt` with debt restrictions, redactions, and required safety copy.

## Guardrails
- `manualReviewRequired` remains `true`.
- `collectionsExecutionEnabled` remains `false`.
- `bureauReportingEnabled` remains `false`.
- `publicDebtExposureEnabled` remains `false`.
- No collections execution, bureau reporting, autonomous enforcement, public debt exposure, public tenant scoring, or hidden debt scoring path was added.
- Route loading remains landlord-scoped and whitelist-sanitized; raw payment/private tenant/admin-only payloads are excluded.

## Verification
- Backend targeted tests: `9/9` passed.
- Frontend targeted tests: `5/5` passed.
- Backend build: passed.
- Frontend build: passed; existing chunk-size warning remains non-regressive.
- `git diff --check`: passed.
- Dependency/lockfile diff: empty.
- Forbidden debt execution-label scan: clean for prohibited UI labels/buttons.