### PR TITLE
feat: add court dispute lineage layer

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -138,6 +138,7 @@ import landlordIdentityLayerRoutes from "./routes/landlordIdentityLayerRoutes";
 import landlordSharingRoomRoutes from "./routes/landlordSharingRoomRoutes";
 import landlordRentalHistoryLedgerRoutes from "./routes/landlordRentalHistoryLedgerRoutes";
 import landlordRentalDebtRoutes from "./routes/landlordRentalDebtRoutes";
+import landlordCourtDisputeLineageRoutes from "./routes/landlordCourtDisputeLineageRoutes";
 import landlordSettlementReadinessRoutes from "./routes/landlordSettlementReadinessRoutes";
 import landlordRegulatoryProfileRoutes from "./routes/landlordRegulatoryProfileRoutes";
 import landlordAssetTokenizationReadinessRoutes from "./routes/landlordAssetTokenizationReadinessRoutes";
@@ -343,6 +344,8 @@ app.use("/api/landlord", routeSource("landlordRentalHistoryLedgerRoutes.ts"), la
 console.log("[route-mount] landlordRentalHistoryLedgerRoutes mounted at /api/landlord");
 app.use("/api/landlord", routeSource("landlordRentalDebtRoutes.ts"), landlordRentalDebtRoutes);
 console.log("[route-mount] landlordRentalDebtRoutes mounted at /api/landlord");
+app.use("/api/landlord", routeSource("landlordCourtDisputeLineageRoutes.ts"), landlordCourtDisputeLineageRoutes);
+console.log("[route-mount] landlordCourtDisputeLineageRoutes mounted at /api/landlord");
 app.use("/api/landlord", routeSource("landlordSettlementReadinessRoutes.ts"), landlordSettlementReadinessRoutes);
 console.log("[route-mount] landlordSettlementReadinessRoutes mounted at /api/landlord");
 app.use("/api/landlord", routeSource("landlordRegulatoryProfileRoutes.ts"), landlordRegulatoryProfileRoutes);

--- a/rentchain-api/src/lib/courtDisputeLineage/__tests__/deriveCourtDisputeLineageProfile.test.ts
+++ b/rentchain-api/src/lib/courtDisputeLineage/__tests__/deriveCourtDisputeLineageProfile.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { deriveCourtDisputeLineageProfile } from "../deriveCourtDisputeLineageProfile";
+
+describe("deriveCourtDisputeLineageProfile", () => {
+  const completeInput = {
+    landlordId: "landlord-1",
+    tenantId: "tenant-1",
+    generatedAt: "2026-05-07T00:00:00.000Z",
+    disputeRecords: [{ disputeId: "dispute-1", status: "verified" }],
+    courtRecordReferences: [{ courtRecordId: "court-1", status: "verified" }],
+    filingReadinessReferences: [{ filingReadinessId: "filing-1", status: "verified" }],
+    judgmentOrderReferences: [{ judgmentOrderId: "order-1", status: "verified" }],
+    rentalDebtReferences: [{ rentalDebtId: "debt-1", status: "verified" }],
+    consentRecords: [{ consentId: "consent-1", status: "verified" }],
+    reviewRecords: [{ reviewSessionId: "review-1", status: "completed" }],
+    evidencePacks: [{ evidencePackId: "evidence-1", status: "verified" }],
+    auditEvents: [{ eventId: "event-1", eventType: "court_dispute_lineage_profile_derived" }],
+  };
+
+  it("derives a deterministic verified profile with execution flags pinned off", () => {
+    const profile = deriveCourtDisputeLineageProfile(completeInput);
+    const again = deriveCourtDisputeLineageProfile(completeInput);
+
+    expect(profile).toEqual(again);
+    expect(profile).toEqual(
+      expect.objectContaining({
+        courtDisputeLineageId: "court_dispute_lineage:landlord-1:tenant-1",
+        status: "verified",
+        manualReviewRequired: true,
+        legalFilingExecutionEnabled: false,
+        collectionsExecutionEnabled: false,
+        bureauReportingEnabled: false,
+        publicCourtRecordExposureEnabled: false,
+      })
+    );
+    expect(profile.summary.totalReferences).toBe(9);
+    expect(profile.summary.verifiedReferences).toBe(9);
+    expect(profile.courtDisputeRestrictions).toEqual([]);
+  });
+
+  it("blocks unresolved consent, dispute, or court-record restrictions", () => {
+    const profile = deriveCourtDisputeLineageProfile({
+      ...completeInput,
+      courtRecordReferences: [{ courtRecordId: "court-1", status: "restricted" }],
+    });
+
+    expect(profile.status).toBe("blocked");
+    expect(profile.courtDisputeRestrictions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          restrictionType: "court_record",
+          status: "blocked",
+        }),
+      ])
+    );
+    expect(profile.canonicalEvents.map((event) => event.eventType)).toContain("court_dispute_lineage_blocked");
+  });
+
+  it("requires review when critical dispute, consent, review, evidence, or audit lineage is missing", () => {
+    const profile = deriveCourtDisputeLineageProfile({
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      courtRecordReferences: [{ courtRecordId: "court-1", status: "verified" }],
+    });
+
+    expect(profile.status).toBe("review_required");
+    expect(profile.courtDisputeRestrictions.some((restriction) => restriction.restrictionType === "dispute")).toBe(true);
+    expect(profile.courtDisputeRestrictions.some((restriction) => restriction.restrictionType === "consent")).toBe(true);
+    expect(profile.courtDisputeRestrictions.some((restriction) => restriction.restrictionType === "review")).toBe(true);
+    expect(profile.courtDisputeRestrictions.some((restriction) => restriction.restrictionType === "evidence")).toBe(true);
+    expect(profile.courtDisputeRestrictions.some((restriction) => restriction.restrictionType === "audit")).toBe(true);
+  });
+
+  it("uses partial verification for incomplete operational metadata without enabling execution", () => {
+    const profile = deriveCourtDisputeLineageProfile({
+      ...completeInput,
+      filingReadinessReferences: [{ filingReadinessId: "filing-1", status: "under_review" }],
+    });
+
+    expect(profile.status).toBe("partially_verified");
+    expect(profile.legalFilingExecutionEnabled).toBe(false);
+    expect(profile.collectionsExecutionEnabled).toBe(false);
+    expect(profile.bureauReportingEnabled).toBe(false);
+    expect(profile.publicCourtRecordExposureEnabled).toBe(false);
+    expect(profile.canonicalEvents.map((event) => event.eventType)).toContain("court_dispute_lineage_review_required");
+  });
+
+  it("returns unknown when source context is unavailable", () => {
+    const profile = deriveCourtDisputeLineageProfile({ landlordId: "landlord-1", tenantId: "tenant-1" });
+
+    expect(profile.status).toBe("unknown");
+    expect(profile.summary.unavailableReferences).toBe(9);
+  });
+
+  it("generates additive canonical events for redaction and restrictions", () => {
+    const profile = deriveCourtDisputeLineageProfile({
+      ...completeInput,
+      evidencePacks: [{ evidencePackId: "evidence-1", status: "blocked", redacted: true }],
+    });
+
+    expect(profile.canonicalEvents.map((event) => event.eventType)).toEqual(
+      expect.arrayContaining([
+        "court_dispute_lineage_profile_derived",
+        "court_dispute_lineage_redaction_applied",
+        "court_dispute_lineage_restriction_detected",
+      ])
+    );
+    expect(profile.evidenceReferences[0]).toEqual(
+      expect.objectContaining({
+        redacted: true,
+        redactionReason: "Court/dispute evidence lineage reference payload is redacted for court and dispute lineage safety.",
+      })
+    );
+  });
+});

--- a/rentchain-api/src/lib/courtDisputeLineage/courtDisputeLineageTypes.ts
+++ b/rentchain-api/src/lib/courtDisputeLineage/courtDisputeLineageTypes.ts
@@ -1,0 +1,106 @@
+export type CourtDisputeLineageStatus = "verified" | "partially_verified" | "review_required" | "blocked" | "unknown";
+
+export type CourtDisputeReferenceType =
+  | "dispute"
+  | "court_record"
+  | "filing_readiness"
+  | "judgment_order"
+  | "rental_debt"
+  | "consent"
+  | "review"
+  | "evidence"
+  | "audit";
+export type CourtDisputeReferenceStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+
+export type CourtDisputeCanonicalEventType =
+  | "court_dispute_lineage_profile_derived"
+  | "court_dispute_lineage_review_required"
+  | "court_dispute_lineage_blocked"
+  | "court_dispute_lineage_restriction_detected"
+  | "court_dispute_lineage_redaction_applied";
+
+export type CourtDisputeReference = {
+  referenceId: string;
+  referenceType: CourtDisputeReferenceType;
+  status: CourtDisputeReferenceStatus;
+  label: string;
+  description: string;
+  reviewRequired: true;
+  lineageReferences: string[];
+  destination: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type CourtDisputeRestriction = {
+  restrictionId: string;
+  restrictionType:
+    | CourtDisputeReferenceType
+    | "legal_filing_execution"
+    | "collections_execution"
+    | "bureau_reporting"
+    | "public_court_record_exposure";
+  status: "visible" | "blocked" | "review_required";
+  label: string;
+  description: string;
+  blockedReason: string | null;
+};
+
+export type CourtDisputeCanonicalEvent = {
+  eventType: CourtDisputeCanonicalEventType;
+  action: string;
+  status: CourtDisputeLineageStatus;
+  resourceType: "court_dispute_lineage_profile";
+  resourceId: string;
+  summary: string;
+};
+
+export type CourtDisputeLineageProfile = {
+  courtDisputeLineageId: string;
+  status: CourtDisputeLineageStatus;
+  landlordId: string;
+  tenantId: string;
+  manualReviewRequired: true;
+  legalFilingExecutionEnabled: false;
+  collectionsExecutionEnabled: false;
+  bureauReportingEnabled: false;
+  publicCourtRecordExposureEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    partiallyVerifiedReferences: number;
+    blockedReferences: number;
+    unavailableReferences: number;
+    restrictions: number;
+  };
+  disputeReferences: CourtDisputeReference[];
+  courtRecordReferences: CourtDisputeReference[];
+  filingReadinessReferences: CourtDisputeReference[];
+  judgmentOrderReferences: CourtDisputeReference[];
+  rentalDebtReferences: CourtDisputeReference[];
+  consentReferences: CourtDisputeReference[];
+  reviewReferences: CourtDisputeReference[];
+  evidenceReferences: CourtDisputeReference[];
+  auditReferences: CourtDisputeReference[];
+  courtDisputeRestrictions: CourtDisputeRestriction[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: CourtDisputeCanonicalEvent[];
+};
+
+export type DeriveCourtDisputeLineageProfileInput = {
+  landlordId?: unknown;
+  tenantId?: unknown;
+  generatedAt?: unknown;
+  disputeRecords?: Array<Record<string, any>> | null;
+  courtRecordReferences?: Array<Record<string, any>> | null;
+  filingReadinessReferences?: Array<Record<string, any>> | null;
+  judgmentOrderReferences?: Array<Record<string, any>> | null;
+  rentalDebtReferences?: Array<Record<string, any>> | null;
+  consentRecords?: Array<Record<string, any>> | null;
+  reviewRecords?: Array<Record<string, any>> | null;
+  evidencePacks?: Array<Record<string, any>> | null;
+  auditEvents?: Array<Record<string, any>> | null;
+};

--- a/rentchain-api/src/lib/courtDisputeLineage/courtDisputeRestrictionModels.ts
+++ b/rentchain-api/src/lib/courtDisputeLineage/courtDisputeRestrictionModels.ts
@@ -1,0 +1,63 @@
+import type {
+  CourtDisputeReference,
+  CourtDisputeReferenceStatus,
+  CourtDisputeReferenceType,
+  CourtDisputeRestriction,
+} from "./courtDisputeLineageTypes";
+
+export function courtDisputeIdPart(value: unknown) {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 240);
+}
+
+export function courtDisputeReference(input: {
+  idParts: unknown[];
+  referenceType: CourtDisputeReferenceType;
+  status: CourtDisputeReferenceStatus;
+  label: string;
+  description: string;
+  lineageReferences?: string[];
+  destination?: string | null;
+  redacted?: boolean;
+  redactionReason?: string | null;
+  blockedReason?: string | null;
+}): CourtDisputeReference {
+  const referenceId = courtDisputeIdPart(input.idParts.filter(Boolean).join(":")) || `${input.referenceType}:unknown`;
+  return {
+    referenceId,
+    referenceType: input.referenceType,
+    status: input.status,
+    label: input.label,
+    description: input.description,
+    reviewRequired: true,
+    lineageReferences: Array.from(new Set(input.lineageReferences || [])).filter(Boolean).slice(0, 20),
+    destination: input.destination || null,
+    redacted: Boolean(input.redacted),
+    redactionReason: input.redactionReason || null,
+    blockedReason: input.blockedReason || null,
+  };
+}
+
+export function courtDisputeRestriction(input: {
+  idParts: unknown[];
+  restrictionType: CourtDisputeRestriction["restrictionType"];
+  status: CourtDisputeRestriction["status"];
+  label: string;
+  description: string;
+  blockedReason?: string | null;
+}): CourtDisputeRestriction {
+  const restrictionId = courtDisputeIdPart(["court_dispute_restriction", ...input.idParts].filter(Boolean).join(":"));
+  return {
+    restrictionId: restrictionId || "court_dispute_restriction:unknown",
+    restrictionType: input.restrictionType,
+    status: input.status,
+    label: input.label,
+    description: input.description,
+    blockedReason: input.blockedReason || null,
+  };
+}

--- a/rentchain-api/src/lib/courtDisputeLineage/deriveCourtDisputeLineageProfile.ts
+++ b/rentchain-api/src/lib/courtDisputeLineage/deriveCourtDisputeLineageProfile.ts
@@ -1,0 +1,367 @@
+import type {
+  CourtDisputeCanonicalEvent,
+  CourtDisputeLineageProfile,
+  CourtDisputeLineageStatus,
+  CourtDisputeReference,
+  CourtDisputeReferenceStatus,
+  CourtDisputeReferenceType,
+  DeriveCourtDisputeLineageProfileInput,
+} from "./courtDisputeLineageTypes";
+import {
+  courtDisputeIdPart,
+  courtDisputeReference,
+  courtDisputeRestriction,
+} from "./courtDisputeRestrictionModels";
+
+const REDACTIONS = [
+  "Legal filing workflows, court e-filing payloads, filing forms, filing submission payloads, and legal advice outputs are excluded.",
+  "Raw court documents, raw payment account details, private tenant data, raw screening or credit bureau payloads, and admin-only payloads are excluded.",
+  "Court and dispute lineage is visibility metadata only; no judgment execution, collections execution, bureau reporting, public blacklisting, or autonomous enforcement is enabled.",
+  "Filing-readiness and judgment/order references are operational metadata references only and do not imply legal readiness, legal advice, or legal authority.",
+];
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function asArray<T>(value: T[] | null | undefined): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function generatedAt(value: unknown): string {
+  const raw = asString(value, 120);
+  const date = raw ? new Date(raw) : new Date(0);
+  return Number.isNaN(date.getTime()) ? new Date(0).toISOString() : date.toISOString();
+}
+
+function recordId(record: Record<string, any>, keys: string[]): string {
+  for (const key of keys) {
+    const value = asString(record?.[key], 240);
+    if (value) return value;
+  }
+  return asString(record?.id, 240);
+}
+
+function referenceStatus(record: Record<string, any>, verifiedStatuses: string[]): CourtDisputeReferenceStatus {
+  const status = asString(record?.status || record?.state || record?.conclusion || record?.recordStatus, 80).toLowerCase();
+  if (status === "blocked" || status === "sealed" || status === "restricted" || status === "failure" || status === "failed" || status === "error" || status === "cancelled") {
+    return "blocked";
+  }
+  if (verifiedStatuses.includes(status)) return "verified";
+  if (status === "missing" || status === "unknown" || status === "unavailable" || status === "pending") return "unavailable";
+  return "partially_verified";
+}
+
+function statusForType(referenceType: CourtDisputeReferenceType, record: Record<string, any>): CourtDisputeReferenceStatus {
+  if (referenceType === "review") return referenceStatus(record, ["ready_for_review", "completed", "verified", "reviewed"]);
+  if (referenceType === "audit" && asString(record?.eventType || record?.type, 120)) return "verified";
+  if (referenceType === "rental_debt") return referenceStatus(record, ["verified", "review_required", "partially_verified"]);
+  return referenceStatus(record, ["ready_for_review", "verified", "available", "completed", "stable", "active", "configured"]);
+}
+
+function profileStatus(hasContext: boolean, references: CourtDisputeReference[]): CourtDisputeLineageStatus {
+  if (!hasContext) return "unknown";
+  if (
+    references.some(
+      (reference) =>
+        reference.status === "blocked" &&
+        (reference.referenceType === "consent" || reference.referenceType === "dispute" || reference.referenceType === "court_record")
+    )
+  ) {
+    return "blocked";
+  }
+  const criticalMissing = references.some(
+    (reference) =>
+      reference.status === "unavailable" &&
+      (reference.referenceType === "consent" ||
+        reference.referenceType === "dispute" ||
+        reference.referenceType === "review" ||
+        reference.referenceType === "evidence" ||
+        reference.referenceType === "audit")
+  );
+  if (criticalMissing) return "review_required";
+  if (references.some((reference) => reference.status === "blocked" || reference.status === "unavailable" || reference.status === "partially_verified")) return "partially_verified";
+  return "verified";
+}
+
+function event(input: {
+  eventType: CourtDisputeCanonicalEvent["eventType"];
+  status: CourtDisputeLineageStatus;
+  courtDisputeLineageId: string;
+  summary: string;
+}): CourtDisputeCanonicalEvent {
+  return {
+    eventType: input.eventType,
+    action: input.eventType.replace(/^court_dispute_lineage_/, "").replace(/_/g, "."),
+    status: input.status,
+    resourceType: "court_dispute_lineage_profile",
+    resourceId: input.courtDisputeLineageId,
+    summary: input.summary,
+  };
+}
+
+function referencesFor(input: {
+  records: Record<string, any>[];
+  fallback: string;
+  referenceType: CourtDisputeReferenceType;
+  idKeys: string[];
+  label: string;
+  description: string;
+  destination: string;
+  blockedReason: string;
+}): CourtDisputeReference[] {
+  if (!input.records.length) {
+    return [
+      courtDisputeReference({
+        idParts: [input.referenceType, "missing"],
+        referenceType: input.referenceType,
+        status: "unavailable",
+        label: input.label,
+        description: `${input.description} is unavailable for court and dispute lineage review.`,
+        destination: input.destination,
+      }),
+    ];
+  }
+  return input.records.map((record, index) => {
+    const id = recordId(record, input.idKeys) || `${input.fallback}-${index + 1}`;
+    const status = statusForType(input.referenceType, record);
+    return courtDisputeReference({
+      idParts: [input.referenceType, id],
+      referenceType: input.referenceType,
+      status,
+      label: input.label,
+      description: `${input.description} is available as operational court and dispute lineage metadata.`,
+      lineageReferences: [id].filter(Boolean),
+      destination: input.destination,
+      redacted: Boolean(record.redacted),
+      redactionReason: record.redacted ? `${input.label} payload is redacted for court and dispute lineage safety.` : null,
+      blockedReason: status === "blocked" ? input.blockedReason : null,
+    });
+  });
+}
+
+export function deriveCourtDisputeLineageProfile(input: DeriveCourtDisputeLineageProfileInput): CourtDisputeLineageProfile {
+  const landlordId = asString(input.landlordId, 240) || "unknown";
+  const tenantId = asString(input.tenantId, 240) || "unknown";
+  const courtDisputeLineageId =
+    courtDisputeIdPart(["court_dispute_lineage", landlordId, tenantId].join(":")) || "court_dispute_lineage:unknown";
+
+  const disputeRecords = asArray(input.disputeRecords);
+  const courtRecords = asArray(input.courtRecordReferences);
+  const filingReadinessRecords = asArray(input.filingReadinessReferences);
+  const judgmentOrderRecords = asArray(input.judgmentOrderReferences);
+  const rentalDebtRecords = asArray(input.rentalDebtReferences);
+  const consentRecords = asArray(input.consentRecords);
+  const reviewRecords = asArray(input.reviewRecords);
+  const evidencePacks = asArray(input.evidencePacks);
+  const auditEvents = asArray(input.auditEvents);
+
+  const disputeReferences = referencesFor({
+    records: disputeRecords,
+    fallback: "dispute",
+    referenceType: "dispute",
+    idKeys: ["disputeId", "disputeGovernanceId", "caseId", "id"],
+    label: "Dispute lineage reference",
+    description: "Dispute lineage and dispute-governance metadata",
+    destination: "/review-timeline",
+    blockedReason: "Dispute lineage is blocked.",
+  });
+  const courtRecordReferences = referencesFor({
+    records: courtRecords,
+    fallback: "court-record",
+    referenceType: "court_record",
+    idKeys: ["courtRecordId", "courtReferenceId", "caseId", "id"],
+    label: "Court-record metadata reference",
+    description: "Court-record reference metadata",
+    destination: "/court-dispute-lineage",
+    blockedReason: "Court-record metadata reference is blocked.",
+  });
+  const filingReadinessReferences = referencesFor({
+    records: filingReadinessRecords,
+    fallback: "filing-readiness",
+    referenceType: "filing_readiness",
+    idKeys: ["filingReadinessId", "courtFilingReadinessId", "caseId", "id"],
+    label: "Filing-readiness metadata reference",
+    description: "Read-only filing preparedness metadata",
+    destination: "/court-dispute-lineage",
+    blockedReason: "Filing-readiness metadata reference is blocked.",
+  });
+  const judgmentOrderReferences = referencesFor({
+    records: judgmentOrderRecords,
+    fallback: "judgment-order",
+    referenceType: "judgment_order",
+    idKeys: ["judgmentOrderId", "orderReferenceId", "caseId", "id"],
+    label: "Judgment/order metadata reference",
+    description: "Judgment or order reference metadata",
+    destination: "/court-dispute-lineage",
+    blockedReason: "Judgment/order metadata reference is blocked.",
+  });
+  const rentalDebtReferences = referencesFor({
+    records: rentalDebtRecords,
+    fallback: "rental-debt",
+    referenceType: "rental_debt",
+    idKeys: ["rentalDebtId", "debtReferenceId", "id"],
+    label: "Rental debt accountability reference",
+    description: "Rental debt accountability linkage metadata",
+    destination: "/rental-debt",
+    blockedReason: "Rental debt accountability linkage is blocked.",
+  });
+  const consentReferences = referencesFor({
+    records: consentRecords,
+    fallback: "consent",
+    referenceType: "consent",
+    idKeys: ["consentId", "consentGovernanceId", "identityConsentId", "id"],
+    label: "Consent governance reference",
+    description: "Consent governance and access-control metadata",
+    destination: "/identity-layer",
+    blockedReason: "Consent governance lineage is missing or blocked.",
+  });
+  const reviewReferences = referencesFor({
+    records: reviewRecords,
+    fallback: "review",
+    referenceType: "review",
+    idKeys: ["reviewSessionId", "operatorReviewId", "id"],
+    label: "Court/dispute review lineage reference",
+    description: "Manual court/dispute review lineage metadata",
+    destination: "/review-timeline",
+    blockedReason: "Court/dispute review lineage is blocked.",
+  });
+  const evidenceReferences = referencesFor({
+    records: evidencePacks,
+    fallback: "evidence",
+    referenceType: "evidence",
+    idKeys: ["evidencePackId", "id"],
+    label: "Court/dispute evidence lineage reference",
+    description: "Court/dispute evidence lineage metadata",
+    destination: "/evidence-packs",
+    blockedReason: "Court/dispute evidence lineage is blocked.",
+  });
+  const auditReferences = referencesFor({
+    records: auditEvents.slice(0, 20),
+    fallback: "audit",
+    referenceType: "audit",
+    idKeys: ["eventId", "auditId", "id"],
+    label: "Court/dispute audit lineage reference",
+    description: "Court/dispute audit lineage metadata",
+    destination: "/review-timeline",
+    blockedReason: "Court/dispute audit lineage is blocked.",
+  });
+
+  const allReferences = [
+    ...disputeReferences,
+    ...courtRecordReferences,
+    ...filingReadinessReferences,
+    ...judgmentOrderReferences,
+    ...rentalDebtReferences,
+    ...consentReferences,
+    ...reviewReferences,
+    ...evidenceReferences,
+    ...auditReferences,
+  ];
+  const hasContext = Boolean(
+    disputeRecords.length ||
+      courtRecords.length ||
+      filingReadinessRecords.length ||
+      judgmentOrderRecords.length ||
+      rentalDebtRecords.length ||
+      consentRecords.length ||
+      reviewRecords.length ||
+      evidencePacks.length ||
+      auditEvents.length
+  );
+  const status = profileStatus(hasContext, allReferences);
+  const courtDisputeRestrictions = allReferences
+    .filter((reference) => reference.status !== "verified")
+    .map((reference) =>
+      courtDisputeRestriction({
+        idParts: [reference.referenceType, reference.referenceId],
+        restrictionType: reference.referenceType,
+        status: reference.status === "blocked" ? "blocked" : "review_required",
+        label: `${reference.label} restriction`,
+        description: `${reference.label} is incomplete or blocked for court and dispute lineage review.`,
+        blockedReason: reference.blockedReason,
+      })
+    );
+  const blockedReasons = [...allReferences.map((reference) => reference.blockedReason), ...courtDisputeRestrictions.map((restriction) => restriction.blockedReason)].filter(Boolean) as string[];
+
+  const canonicalEvents: CourtDisputeCanonicalEvent[] = [
+    event({
+      eventType: "court_dispute_lineage_profile_derived",
+      status,
+      courtDisputeLineageId,
+      summary:
+        "Court and dispute lineage profile derived from dispute, court-record, filing-readiness, judgment/order, rental debt, consent, review, evidence, and audit metadata.",
+    }),
+    event({
+      eventType: "court_dispute_lineage_redaction_applied",
+      status,
+      courtDisputeLineageId,
+      summary:
+        "Legal filing, court e-filing, raw court document, legal advice, collections, bureau reporting, public exposure, and sensitive payloads were excluded.",
+    }),
+  ];
+  if (courtDisputeRestrictions.length) {
+    canonicalEvents.push(
+      event({
+        eventType: "court_dispute_lineage_restriction_detected",
+        status,
+        courtDisputeLineageId,
+        summary: "Court and dispute lineage restrictions are visible for manual review.",
+      })
+    );
+  }
+  if (status === "review_required" || status === "partially_verified") {
+    canonicalEvents.push(
+      event({
+        eventType: "court_dispute_lineage_review_required",
+        status,
+        courtDisputeLineageId,
+        summary: "Manual court and dispute lineage review is required.",
+      })
+    );
+  }
+  if (status === "blocked") {
+    canonicalEvents.push(
+      event({
+        eventType: "court_dispute_lineage_blocked",
+        status,
+        courtDisputeLineageId,
+        summary: "Court and dispute lineage profile is blocked by unresolved restrictions.",
+      })
+    );
+  }
+
+  return {
+    courtDisputeLineageId,
+    status,
+    landlordId,
+    tenantId,
+    manualReviewRequired: true,
+    legalFilingExecutionEnabled: false,
+    collectionsExecutionEnabled: false,
+    bureauReportingEnabled: false,
+    publicCourtRecordExposureEnabled: false,
+    generatedAt: generatedAt(input.generatedAt),
+    summary: {
+      totalReferences: allReferences.length,
+      verifiedReferences: allReferences.filter((reference) => reference.status === "verified").length,
+      partiallyVerifiedReferences: allReferences.filter((reference) => reference.status === "partially_verified").length,
+      blockedReferences: allReferences.filter((reference) => reference.status === "blocked").length,
+      unavailableReferences: allReferences.filter((reference) => reference.status === "unavailable").length,
+      restrictions: courtDisputeRestrictions.length,
+    },
+    disputeReferences,
+    courtRecordReferences,
+    filingReadinessReferences,
+    judgmentOrderReferences,
+    rentalDebtReferences,
+    consentReferences,
+    reviewReferences,
+    evidenceReferences,
+    auditReferences,
+    courtDisputeRestrictions,
+    redactions: REDACTIONS,
+    blockedReasons,
+    canonicalEvents,
+  };
+}

--- a/rentchain-api/src/routes/__tests__/landlordCourtDisputeLineageRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordCourtDisputeLineageRoutes.test.ts
@@ -1,0 +1,245 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+
+  function matches(doc: any, filters: Array<{ field: string; op: string; value: any }>) {
+    return filters.every(({ field, op, value }) => {
+      const actual = doc?.data?.[field];
+      if (op === "==") return actual === value;
+      return false;
+    });
+  }
+
+  function makeQuery(name: string, filters: Array<{ field: string; op: string; value: any }> = []) {
+    return {
+      where: (field: string, op: string, value: any) => makeQuery(name, [...filters, { field, op, value }]),
+      get: async () => {
+        const docs = Array.from(ensureCollection(name).values())
+          .filter((doc) => matches(doc, filters))
+          .map((doc) => ({ id: doc.id, exists: true, data: () => doc.data }));
+        return { docs, empty: docs.length === 0, size: docs.length };
+      },
+    };
+  }
+
+  return {
+    resetFakeDb: () => store.clear(),
+    seedDoc: (collection: string, id: string, data: any) => ensureCollection(collection).set(id, { id, data }),
+    fakeDb: {
+      collection: (name: string) => ({
+        where: (field: string, op: string, value: any) => makeQuery(name, [{ field, op, value }]),
+        get: async () => makeQuery(name).get(),
+      }),
+    },
+  };
+});
+
+let mockUser: any;
+
+vi.mock("../../config/firebase", () => ({ db: fakeDb }));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!mockUser) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    req.user = mockUser;
+    return next();
+  },
+}));
+
+vi.mock("../../middleware/requireLandlord", () => ({
+  requireLandlord: (req: any, res: any, next: any) => {
+    const role = String(req.user?.role || "").trim().toLowerCase();
+    const landlordId = req.user?.landlordId || req.user?.id;
+    if (role !== "landlord" && role !== "admin") return res.status(403).json({ ok: false, error: "Forbidden" });
+    if (!landlordId) return res.status(401).json({ ok: false, error: "Missing landlord context" });
+    req.user.landlordId = landlordId;
+    return next();
+  },
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; user?: Record<string, unknown> | null }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    mockUser = options.user ?? mockUser;
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: mockUser,
+      body: {},
+      query: Object.fromEntries(new URLSearchParams(queryString || "").entries()),
+      params: {},
+      headers: {},
+    };
+    const match = path.match(/^\/court-dispute-lineage\/(.+)$/);
+    if (match) req.params = { courtDisputeLineageId: decodeURIComponent(match[1]) };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => (error ? reject(error) : undefined));
+  });
+}
+
+describe("landlordCourtDisputeLineageRoutes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    resetFakeDb();
+    mockUser = { id: "landlord-1", landlordId: "landlord-1", role: "landlord" };
+  });
+
+  function seedCourtDisputeLineage() {
+    seedDoc("disputeResolutionReadiness", "dispute-1", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      disputeId: "dispute-1",
+      status: "verified",
+      rawDisputePayload: "hidden",
+    });
+    seedDoc("courtRecordReferences", "court-1", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      disputeId: "dispute-1",
+      courtRecordId: "court-1",
+      status: "verified",
+      rawCourtDocument: "hidden",
+    });
+    seedDoc("courtFilingReadiness", "filing-1", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      disputeId: "dispute-1",
+      filingReadinessId: "filing-1",
+      status: "verified",
+      filingFormPayload: "hidden",
+    });
+    seedDoc("judgmentOrderReferences", "order-1", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      disputeId: "dispute-1",
+      judgmentOrderId: "order-1",
+      status: "verified",
+      rawJudgmentPayload: "hidden",
+    });
+    seedDoc("rentalDebtProfiles", "debt-1", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      rentalDebtId: "debt-1",
+      status: "verified",
+      rawPaymentPayload: "hidden",
+    });
+    seedDoc("consents", "consent-1", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      consentId: "consent-1",
+      status: "verified",
+      privateTenantData: "hidden",
+    });
+    seedDoc("operatorReviewSessions", "review-1", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      reviewSessionId: "review-1",
+      status: "completed",
+      legalAdviceNote: "hidden",
+    });
+    seedDoc("evidencePacks", "evidence-1", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      evidencePackId: "evidence-1",
+      status: "verified",
+      creditBureauPayload: "hidden",
+    });
+    seedDoc("events", "event-1", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      eventId: "event-1",
+      eventType: "court_dispute_lineage_profile_derived",
+      adminOnlyPayload: "hidden",
+    });
+    seedDoc("courtRecordReferences", "court-other", {
+      landlordId: "landlord-2",
+      tenantId: "tenant-2",
+      courtRecordId: "court-other",
+      status: "verified",
+    });
+  }
+
+  it("returns landlord-scoped court-dispute lineage profiles without sensitive payloads", async () => {
+    seedCourtDisputeLineage();
+    const router = (await import("../landlordCourtDisputeLineageRoutes")).default;
+
+    const forbidden = await invokeRouter(router, {
+      method: "GET",
+      url: "/court-dispute-lineage",
+      user: { id: "tenant-1", role: "tenant" },
+    });
+    expect(forbidden.status).toBe(403);
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/court-dispute-lineage?tenantId=tenant-1&disputeId=dispute-1",
+      user: { id: "landlord-1", landlordId: "landlord-1", role: "landlord" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.profiles).toHaveLength(1);
+    expect(res.body.profiles[0]).toEqual(
+      expect.objectContaining({
+        landlordId: "landlord-1",
+        tenantId: "tenant-1",
+        manualReviewRequired: true,
+        legalFilingExecutionEnabled: false,
+        collectionsExecutionEnabled: false,
+        bureauReportingEnabled: false,
+        publicCourtRecordExposureEnabled: false,
+      })
+    );
+    const serialized = JSON.stringify(res.body);
+    expect(serialized).not.toContain("tenant-2");
+    expect(serialized).not.toContain("rawDisputePayload");
+    expect(serialized).not.toContain("rawCourtDocument");
+    expect(serialized).not.toContain("filingFormPayload");
+    expect(serialized).not.toContain("rawJudgmentPayload");
+    expect(serialized).not.toContain("rawPaymentPayload");
+    expect(serialized).not.toContain("privateTenantData");
+    expect(serialized).not.toContain("legalAdviceNote");
+    expect(serialized).not.toContain("creditBureauPayload");
+    expect(serialized).not.toContain("adminOnlyPayload");
+  });
+
+  it("returns a single court-dispute lineage profile by id", async () => {
+    seedCourtDisputeLineage();
+    const router = (await import("../landlordCourtDisputeLineageRoutes")).default;
+    const list = await invokeRouter(router, { method: "GET", url: "/court-dispute-lineage?tenantId=tenant-1" });
+    const id = list.body.profiles[0].courtDisputeLineageId;
+
+    const res = await invokeRouter(router, { method: "GET", url: `/court-dispute-lineage/${encodeURIComponent(id)}` });
+
+    expect(res.status).toBe(200);
+    expect(res.body.profile.courtDisputeLineageId).toBe(id);
+  });
+
+  it("filters by status", async () => {
+    seedCourtDisputeLineage();
+    const router = (await import("../landlordCourtDisputeLineageRoutes")).default;
+
+    const filtered = await invokeRouter(router, { method: "GET", url: "/court-dispute-lineage?status=blocked" });
+
+    expect(filtered.status).toBe(200);
+    expect(filtered.body.profiles).toEqual([]);
+  });
+});

--- a/rentchain-api/src/routes/landlordCourtDisputeLineageRoutes.ts
+++ b/rentchain-api/src/routes/landlordCourtDisputeLineageRoutes.ts
@@ -1,0 +1,204 @@
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { requireAuth } from "../middleware/requireAuth";
+import { requireLandlord } from "../middleware/requireLandlord";
+import { deriveCourtDisputeLineageProfile } from "../lib/courtDisputeLineage/deriveCourtDisputeLineageProfile";
+import type {
+  CourtDisputeLineageProfile,
+  CourtDisputeLineageStatus,
+} from "../lib/courtDisputeLineage/courtDisputeLineageTypes";
+
+const router = Router();
+const STATUSES = new Set<CourtDisputeLineageStatus>(["verified", "partially_verified", "review_required", "blocked", "unknown"]);
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function landlordIdFromReq(req: any) {
+  return asString(req.user?.landlordId || req.user?.id || req.user?.sub, 240);
+}
+
+function sanitizeRecord(record: Record<string, any>) {
+  const safe: Record<string, any> = {};
+  for (const key of [
+    "id",
+    "status",
+    "state",
+    "conclusion",
+    "recordStatus",
+    "type",
+    "eventType",
+    "domain",
+    "landlordId",
+    "ownerId",
+    "userId",
+    "tenantId",
+    "tenantIds",
+    "primaryTenantId",
+    "applicantTenantId",
+    "identityId",
+    "resourceId",
+    "scopeId",
+    "leaseId",
+    "propertyId",
+    "disputeId",
+    "disputeGovernanceId",
+    "caseId",
+    "courtRecordId",
+    "courtReferenceId",
+    "filingReadinessId",
+    "courtFilingReadinessId",
+    "judgmentOrderId",
+    "orderReferenceId",
+    "rentalDebtId",
+    "debtReferenceId",
+    "consentId",
+    "consentGovernanceId",
+    "identityConsentId",
+    "reviewSessionId",
+    "operatorReviewId",
+    "evidencePackId",
+    "eventId",
+    "createdAt",
+    "updatedAt",
+    "occurredAt",
+    "redacted",
+  ]) {
+    if (record[key] !== undefined) safe[key] = record[key];
+  }
+  return safe;
+}
+
+function belongsToLandlord(record: Record<string, any>, landlordId: string) {
+  return [record.landlordId, record.ownerId, record.userId].map((value) => asString(value, 240)).includes(landlordId);
+}
+
+function tenantIdsFor(record: Record<string, any>) {
+  const tenantIds = Array.isArray(record.tenantIds) ? record.tenantIds.map((item) => asString(item, 240)) : [];
+  return [record.tenantId, record.primaryTenantId, record.applicantTenantId, record.identityId, record.resourceId, record.scopeId]
+    .map((value) => asString(value, 240).replace(/^tenant:/, ""))
+    .concat(tenantIds)
+    .filter(Boolean);
+}
+
+function filterByTenant(records: Record<string, any>[], tenantId: string) {
+  return records.filter((record) => tenantIdsFor(record).includes(tenantId));
+}
+
+function filterByDispute(records: Record<string, any>[], disputeId: string) {
+  return records.filter((record) => [record.disputeId, record.disputeGovernanceId, record.caseId, record.resourceId, record.scopeId, record.id].map((value) => asString(value, 240)).includes(disputeId));
+}
+
+async function loadLandlordCollection(collectionName: string, landlordId: string, limit = 50) {
+  const byId = new Map<string, any>();
+  async function collect(field: "landlordId" | "ownerId" | "userId") {
+    const snap = await db.collection(collectionName).where(field, "==", landlordId).get().catch(() => null);
+    for (const doc of snap?.docs || []) byId.set(doc.id, sanitizeRecord({ id: doc.id, ...((doc.data() as any) || {}) }));
+  }
+  await Promise.all([collect("landlordId"), collect("ownerId"), collect("userId")]);
+  return Array.from(byId.values()).filter((record) => belongsToLandlord(record, landlordId)).slice(0, limit);
+}
+
+function collectTenantIds(records: Record<string, any>[]) {
+  const tenantIds = new Set<string>();
+  for (const record of records) {
+    for (const tenantId of tenantIdsFor(record)) tenantIds.add(tenantId);
+  }
+  return Array.from(tenantIds).sort((a, b) => a.localeCompare(b));
+}
+
+async function buildCourtDisputeLineageProfiles(input: {
+  landlordId: string;
+  tenantId?: string;
+  disputeId?: string;
+}): Promise<CourtDisputeLineageProfile[]> {
+  const [
+    disputeRecords,
+    courtRecordReferences,
+    filingReadinessReferences,
+    judgmentOrderReferences,
+    rentalDebtReferences,
+    consentRecords,
+    reviewRecords,
+    evidencePacks,
+    events,
+  ] = await Promise.all([
+    Promise.all([
+      loadLandlordCollection("disputeResolutionReadiness", input.landlordId),
+      loadLandlordCollection("disputeGovernance", input.landlordId),
+      loadLandlordCollection("courtDisputeLineage", input.landlordId),
+    ]).then((groups) => groups.flat()),
+    loadLandlordCollection("courtRecordReferences", input.landlordId),
+    loadLandlordCollection("courtFilingReadiness", input.landlordId),
+    loadLandlordCollection("judgmentOrderReferences", input.landlordId),
+    loadLandlordCollection("rentalDebtProfiles", input.landlordId),
+    Promise.all([loadLandlordCollection("consents", input.landlordId), loadLandlordCollection("consentGovernance", input.landlordId)]).then((groups) => groups.flat()),
+    loadLandlordCollection("operatorReviewSessions", input.landlordId),
+    loadLandlordCollection("evidencePacks", input.landlordId),
+    loadLandlordCollection("events", input.landlordId),
+  ]);
+
+  const allRecords = [
+    ...disputeRecords,
+    ...courtRecordReferences,
+    ...filingReadinessReferences,
+    ...judgmentOrderReferences,
+    ...rentalDebtReferences,
+    ...consentRecords,
+    ...reviewRecords,
+    ...evidencePacks,
+    ...events,
+  ];
+  const tenantIds = input.tenantId ? [input.tenantId] : collectTenantIds(allRecords);
+
+  return tenantIds.map((tenantId) => {
+    const scopedDisputes = input.disputeId ? filterByDispute(filterByTenant(disputeRecords, tenantId), input.disputeId) : filterByTenant(disputeRecords, tenantId);
+    return deriveCourtDisputeLineageProfile({
+      landlordId: input.landlordId,
+      tenantId,
+      disputeRecords: scopedDisputes,
+      courtRecordReferences: input.disputeId ? filterByDispute(filterByTenant(courtRecordReferences, tenantId), input.disputeId) : filterByTenant(courtRecordReferences, tenantId),
+      filingReadinessReferences: input.disputeId ? filterByDispute(filterByTenant(filingReadinessReferences, tenantId), input.disputeId) : filterByTenant(filingReadinessReferences, tenantId),
+      judgmentOrderReferences: input.disputeId ? filterByDispute(filterByTenant(judgmentOrderReferences, tenantId), input.disputeId) : filterByTenant(judgmentOrderReferences, tenantId),
+      rentalDebtReferences: filterByTenant(rentalDebtReferences, tenantId),
+      consentRecords: filterByTenant(consentRecords, tenantId),
+      reviewRecords: filterByTenant(reviewRecords, tenantId),
+      evidencePacks: filterByTenant(evidencePacks, tenantId),
+      auditEvents: filterByTenant(events, tenantId),
+    });
+  });
+}
+
+router.get("/court-dispute-lineage", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = landlordIdFromReq(req);
+    if (!landlordId) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    const tenantId = asString(req.query?.tenantId, 240);
+    const disputeId = asString(req.query?.disputeId, 240);
+    const status = asString(req.query?.status, 80) as CourtDisputeLineageStatus;
+    let profiles = await buildCourtDisputeLineageProfiles({ landlordId, tenantId: tenantId || undefined, disputeId: disputeId || undefined });
+    if (status && STATUSES.has(status)) profiles = profiles.filter((profile) => profile.status === status);
+    return res.json({ ok: true, profiles });
+  } catch (err: any) {
+    console.error("[landlord-court-dispute-lineage] list failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "COURT_DISPUTE_LINEAGE_FAILED" });
+  }
+});
+
+router.get("/court-dispute-lineage/:courtDisputeLineageId", requireAuth, requireLandlord, async (req: any, res) => {
+  try {
+    const landlordId = landlordIdFromReq(req);
+    const courtDisputeLineageId = decodeURIComponent(asString(req.params?.courtDisputeLineageId, 500));
+    if (!landlordId || !courtDisputeLineageId) return res.status(400).json({ ok: false, error: "COURT_DISPUTE_LINEAGE_ID_REQUIRED" });
+    const profiles = await buildCourtDisputeLineageProfiles({ landlordId });
+    const profile = profiles.find((item) => item.courtDisputeLineageId === courtDisputeLineageId);
+    if (!profile) return res.status(404).json({ ok: false, error: "COURT_DISPUTE_LINEAGE_NOT_FOUND" });
+    return res.json({ ok: true, profile });
+  } catch (err: any) {
+    console.error("[landlord-court-dispute-lineage] get failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "COURT_DISPUTE_LINEAGE_GET_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -134,6 +134,7 @@ const IdentityLayerPage = lazy(() => import("./pages/IdentityLayerPage"));
 const InstitutionalSharingRoomPage = lazy(() => import("./pages/InstitutionalSharingRoomPage"));
 const VerifiedRentalHistoryPage = lazy(() => import("./pages/VerifiedRentalHistoryPage"));
 const RentalDebtPage = lazy(() => import("./pages/RentalDebtPage"));
+const CourtDisputeLineagePage = lazy(() => import("./pages/CourtDisputeLineagePage"));
 const SettlementReadinessPage = lazy(() => import("./pages/SettlementReadinessPage"));
 const RegulatoryProfilePage = lazy(() => import("./pages/RegulatoryProfilePage"));
 const AssetTokenizationReadinessPage = lazy(() => import("./pages/AssetTokenizationReadinessPage"));
@@ -646,6 +647,18 @@ function App() {
               <LandlordNav>
                 <Suspense fallback={null}>
                   <RentalDebtPage />
+                </Suspense>
+              </LandlordNav>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/court-dispute-lineage"
+          element={
+            <RequireAuth>
+              <LandlordNav>
+                <Suspense fallback={null}>
+                  <CourtDisputeLineagePage />
                 </Suspense>
               </LandlordNav>
             </RequireAuth>

--- a/rentchain-frontend/src/api/courtDisputeLineageApi.ts
+++ b/rentchain-frontend/src/api/courtDisputeLineageApi.ts
@@ -1,0 +1,97 @@
+import { apiFetch } from "./apiFetch";
+
+export type CourtDisputeLineageStatus = "verified" | "partially_verified" | "review_required" | "blocked" | "unknown";
+export type CourtDisputeReferenceType =
+  | "dispute"
+  | "court_record"
+  | "filing_readiness"
+  | "judgment_order"
+  | "rental_debt"
+  | "consent"
+  | "review"
+  | "evidence"
+  | "audit";
+export type CourtDisputeReferenceStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+
+export type CourtDisputeReference = {
+  referenceId: string;
+  referenceType: CourtDisputeReferenceType;
+  status: CourtDisputeReferenceStatus;
+  label: string;
+  description: string;
+  reviewRequired: true;
+  lineageReferences: string[];
+  destination: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type CourtDisputeRestriction = {
+  restrictionId: string;
+  restrictionType:
+    | CourtDisputeReferenceType
+    | "legal_filing_execution"
+    | "collections_execution"
+    | "bureau_reporting"
+    | "public_court_record_exposure";
+  status: "visible" | "blocked" | "review_required";
+  label: string;
+  description: string;
+  blockedReason: string | null;
+};
+
+export type CourtDisputeLineageProfile = {
+  courtDisputeLineageId: string;
+  status: CourtDisputeLineageStatus;
+  landlordId: string;
+  tenantId: string;
+  manualReviewRequired: true;
+  legalFilingExecutionEnabled: false;
+  collectionsExecutionEnabled: false;
+  bureauReportingEnabled: false;
+  publicCourtRecordExposureEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    partiallyVerifiedReferences: number;
+    blockedReferences: number;
+    unavailableReferences: number;
+    restrictions: number;
+  };
+  disputeReferences: CourtDisputeReference[];
+  courtRecordReferences: CourtDisputeReference[];
+  filingReadinessReferences: CourtDisputeReference[];
+  judgmentOrderReferences: CourtDisputeReference[];
+  rentalDebtReferences: CourtDisputeReference[];
+  consentReferences: CourtDisputeReference[];
+  reviewReferences: CourtDisputeReference[];
+  evidenceReferences: CourtDisputeReference[];
+  auditReferences: CourtDisputeReference[];
+  courtDisputeRestrictions: CourtDisputeRestriction[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: Array<{ eventType: string; action: string; status: CourtDisputeLineageStatus; resourceId: string; summary: string }>;
+};
+
+export async function fetchCourtDisputeLineageProfiles(params?: {
+  tenantId?: string;
+  disputeId?: string;
+  status?: CourtDisputeLineageStatus | "";
+}): Promise<CourtDisputeLineageProfile[]> {
+  const search = new URLSearchParams();
+  if (params?.tenantId) search.set("tenantId", params.tenantId);
+  if (params?.disputeId) search.set("disputeId", params.disputeId);
+  if (params?.status) search.set("status", params.status);
+  const suffix = search.toString() ? `?${search.toString()}` : "";
+  const response = await apiFetch<{ ok: true; profiles: CourtDisputeLineageProfile[] }>(`/landlord/court-dispute-lineage${suffix}`);
+  return response.profiles;
+}
+
+export async function fetchCourtDisputeLineageProfile(courtDisputeLineageId: string): Promise<CourtDisputeLineageProfile> {
+  const response = await apiFetch<{ ok: true; profile: CourtDisputeLineageProfile }>(
+    `/landlord/court-dispute-lineage/${encodeURIComponent(courtDisputeLineageId)}`
+  );
+  return response.profile;
+}

--- a/rentchain-frontend/src/components/disputes/CourtDisputeLineagePanel.test.tsx
+++ b/rentchain-frontend/src/components/disputes/CourtDisputeLineagePanel.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import type { CourtDisputeLineageProfile } from "@/api/courtDisputeLineageApi";
+import { CourtDisputeLineagePanel } from "./CourtDisputeLineagePanel";
+
+const profile: CourtDisputeLineageProfile = {
+  courtDisputeLineageId: "court_dispute_lineage:landlord-1:tenant-1",
+  status: "blocked",
+  landlordId: "landlord-1",
+  tenantId: "tenant-1",
+  manualReviewRequired: true,
+  legalFilingExecutionEnabled: false,
+  collectionsExecutionEnabled: false,
+  bureauReportingEnabled: false,
+  publicCourtRecordExposureEnabled: false,
+  generatedAt: "2026-05-07T00:00:00.000Z",
+  summary: {
+    totalReferences: 2,
+    verifiedReferences: 1,
+    partiallyVerifiedReferences: 0,
+    blockedReferences: 1,
+    unavailableReferences: 0,
+    restrictions: 1,
+  },
+  disputeReferences: [],
+  courtRecordReferences: [
+    {
+      referenceId: "court-1",
+      referenceType: "court_record",
+      status: "blocked",
+      label: "Court-record metadata reference",
+      description: "Court-record reference metadata is available as operational court and dispute lineage metadata.",
+      reviewRequired: true,
+      lineageReferences: ["court-1"],
+      destination: "/court-dispute-lineage",
+      redacted: false,
+      redactionReason: null,
+      blockedReason: "Court-record metadata reference is blocked.",
+    },
+  ],
+  filingReadinessReferences: [],
+  judgmentOrderReferences: [],
+  rentalDebtReferences: [],
+  consentReferences: [],
+  reviewReferences: [],
+  evidenceReferences: [],
+  auditReferences: [],
+  courtDisputeRestrictions: [
+    {
+      restrictionId: "restriction-1",
+      restrictionType: "court_record",
+      status: "blocked",
+      label: "Court-record metadata reference restriction",
+      description: "Court-record metadata reference is incomplete or blocked for court and dispute lineage review.",
+      blockedReason: "Court-record metadata reference is blocked.",
+    },
+  ],
+  redactions: ["Raw court documents, raw payment account details, private tenant data, raw screening or credit bureau payloads, and admin-only payloads are excluded."],
+  blockedReasons: ["Court-record metadata reference is blocked."],
+  canonicalEvents: [],
+};
+
+describe("CourtDisputeLineagePanel", () => {
+  it("renders court/dispute status, restrictions, blocked reasons, and required safety copy", () => {
+    render(
+      <MemoryRouter>
+        <CourtDisputeLineagePanel profile={profile} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getAllByText("View dispute lineage").length).toBeGreaterThan(0);
+    expect(screen.getByText("View court reference")).toBeInTheDocument();
+    expect(screen.getByText("View restrictions")).toBeInTheDocument();
+    expect(screen.getAllByText("View blocked reason: Court-record metadata reference is blocked.").length).toBeGreaterThan(0);
+    expect(screen.getByText("Manual review required")).toBeInTheDocument();
+    expect(screen.getByText(/Court and dispute lineage is operationally scoped and review controlled/i)).toBeInTheDocument();
+    expect(screen.getByText(/No legal filing, collections execution, bureau reporting, or public court-record exposure is enabled/i)).toBeInTheDocument();
+    expect(screen.getByText(/Manual review remains required/i)).toBeInTheDocument();
+  });
+
+  it("does not render forbidden court/dispute execution labels", () => {
+    render(
+      <MemoryRouter>
+        <CourtDisputeLineagePanel profile={profile} />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText("File with court")).not.toBeInTheDocument();
+    expect(screen.queryByText("Submit legal filing")).not.toBeInTheDocument();
+    expect(screen.queryByText("Send to collections")).not.toBeInTheDocument();
+    expect(screen.queryByText("Report to bureau")).not.toBeInTheDocument();
+    expect(screen.queryByText("Publish court record")).not.toBeInTheDocument();
+    expect(screen.queryByText("Autonomous enforcement")).not.toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/disputes/CourtDisputeLineagePanel.tsx
+++ b/rentchain-frontend/src/components/disputes/CourtDisputeLineagePanel.tsx
@@ -1,0 +1,147 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import type {
+  CourtDisputeLineageProfile,
+  CourtDisputeReference,
+  CourtDisputeRestriction,
+} from "@/api/courtDisputeLineageApi";
+import { Card, Section } from "@/components/ui/Ui";
+
+function label(value: string) {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function tone(status: string) {
+  if (status === "blocked") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
+  if (status === "review_required" || status === "partially_verified" || status === "unavailable") {
+    return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
+  }
+  if (status === "verified") return { color: "#166534", background: "#dcfce7", border: "#bbf7d0" };
+  return { color: "#475569", background: "#f8fafc", border: "#e2e8f0" };
+}
+
+function Badge({ children, status }: { children: React.ReactNode; status: string }) {
+  const next = tone(status);
+  return (
+    <span style={{ border: `1px solid ${next.border}`, borderRadius: 999, background: next.background, color: next.color, padding: "3px 9px", fontSize: 12, fontWeight: 900, whiteSpace: "nowrap" }}>
+      {children}
+    </span>
+  );
+}
+
+function ReferenceList({ title, references }: { title: string; references: CourtDisputeReference[] }) {
+  return (
+    <Section style={{ display: "grid", gap: 10 }}>
+      <div style={{ fontWeight: 900 }}>{title}</div>
+      {references.length ? (
+        references.slice(0, 12).map((reference) => (
+          <Card key={reference.referenceId} style={{ borderRadius: 8, padding: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+              <div>
+                <strong>{reference.label}</strong>
+                <div style={{ color: "#64748b", fontSize: 13 }}>{label(reference.referenceType)}</div>
+              </div>
+              <Badge status={reference.status}>{label(reference.status)}</Badge>
+            </div>
+            <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>{reference.description}</div>
+            {reference.lineageReferences.length ? <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>Lineage references: {reference.lineageReferences.length}</div> : null}
+            {reference.blockedReason ? <div style={{ color: "#991b1b", fontSize: 13, marginTop: 8 }}>View blocked reason: {reference.blockedReason}</div> : null}
+            {reference.redacted ? <div style={{ color: "#92400e", fontSize: 13, marginTop: 8 }}>{reference.redactionReason || "Redacted court/dispute reference"}</div> : null}
+            {reference.destination?.startsWith("/") ? <Link to={reference.destination} style={{ color: "#2563eb", fontWeight: 800, fontSize: 13, marginTop: 8, display: "inline-block" }}>View context</Link> : null}
+          </Card>
+        ))
+      ) : (
+        <Card style={{ color: "#64748b" }}>Context unavailable</Card>
+      )}
+    </Section>
+  );
+}
+
+function RestrictionList({ restrictions }: { restrictions: CourtDisputeRestriction[] }) {
+  return (
+    <Section style={{ display: "grid", gap: 10 }}>
+      <div style={{ fontWeight: 900 }}>View restrictions</div>
+      {restrictions.length ? (
+        restrictions.map((restriction) => (
+          <Card key={restriction.restrictionId} style={{ borderRadius: 8, padding: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+              <div>
+                <strong>{restriction.label}</strong>
+                <div style={{ color: "#64748b", fontSize: 13 }}>{label(restriction.restrictionType)}</div>
+              </div>
+              <Badge status={restriction.status}>{label(restriction.status)}</Badge>
+            </div>
+            <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>{restriction.description}</div>
+            {restriction.blockedReason ? <div style={{ color: "#991b1b", fontSize: 13, marginTop: 8 }}>View blocked reason: {restriction.blockedReason}</div> : null}
+          </Card>
+        ))
+      ) : (
+        <Card style={{ color: "#64748b" }}>No court/dispute restrictions detected.</Card>
+      )}
+    </Section>
+  );
+}
+
+export function CourtDisputeLineagePanel({ profile }: { profile: CourtDisputeLineageProfile }) {
+  return (
+    <div style={{ display: "grid", gap: 16 }}>
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+          <div>
+            <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>View dispute lineage</div>
+            <h2 style={{ margin: "2px 0 0", fontSize: "1.15rem" }}>Court and dispute lineage</h2>
+          </div>
+          <Badge status={profile.status}>{label(profile.status)}</Badge>
+        </div>
+        <div style={{ color: "#475569", lineHeight: 1.55 }}>
+          Court and dispute lineage is operationally scoped and review controlled. No legal filing, collections execution, bureau reporting, or public court-record exposure is enabled.
+          Manual review remains required.
+        </div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <Badge status="review_required">Manual review required</Badge>
+          <Badge status={profile.legalFilingExecutionEnabled ? "blocked" : "verified"}>Legal filing disabled</Badge>
+          <Badge status={profile.collectionsExecutionEnabled ? "blocked" : "verified"}>Collections execution disabled</Badge>
+          <Badge status={profile.bureauReportingEnabled ? "blocked" : "verified"}>Bureau reporting disabled</Badge>
+          <Badge status={profile.publicCourtRecordExposureEnabled ? "blocked" : "verified"}>Public exposure disabled</Badge>
+        </div>
+      </Section>
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Lineage summary</div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: 10 }}>
+          {[
+            ["References", profile.summary.totalReferences],
+            ["Verified", profile.summary.verifiedReferences],
+            ["Partial", profile.summary.partiallyVerifiedReferences],
+            ["Blocked", profile.summary.blockedReferences],
+            ["Unavailable", profile.summary.unavailableReferences],
+            ["Restrictions", profile.summary.restrictions],
+          ].map(([name, value]) => (
+            <Card key={String(name)} style={{ borderRadius: 8, padding: 12 }}>
+              <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>{name}</div>
+              <strong style={{ color: "#0f172a", fontSize: 22 }}>{String(value)}</strong>
+            </Card>
+          ))}
+        </div>
+      </Section>
+
+      <RestrictionList restrictions={profile.courtDisputeRestrictions} />
+      <ReferenceList title="View dispute lineage" references={profile.disputeReferences} />
+      <ReferenceList title="View court reference" references={profile.courtRecordReferences} />
+      <ReferenceList title="Filing preparedness metadata" references={profile.filingReadinessReferences} />
+      <ReferenceList title="Judgment/order metadata" references={profile.judgmentOrderReferences} />
+      <ReferenceList title="Rental debt linkage" references={profile.rentalDebtReferences} />
+      <ReferenceList title="Consent governance lineage" references={profile.consentReferences} />
+      <ReferenceList title="View review lineage" references={profile.reviewReferences} />
+      <ReferenceList title="View evidence lineage" references={profile.evidenceReferences} />
+      <ReferenceList title="Audit lineage" references={profile.auditReferences} />
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Redactions</div>
+        {profile.redactions.map((redaction) => (
+          <Card key={redaction} style={{ borderRadius: 8, padding: 12, color: "#475569" }}>{redaction}</Card>
+        ))}
+      </Section>
+    </div>
+  );
+}

--- a/rentchain-frontend/src/pages/CourtDisputeLineagePage.test.tsx
+++ b/rentchain-frontend/src/pages/CourtDisputeLineagePage.test.tsx
@@ -1,0 +1,103 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import CourtDisputeLineagePage from "./CourtDisputeLineagePage";
+
+const mockFetchProfiles = vi.fn();
+const mockShowToast = vi.fn();
+
+vi.mock("@/api/courtDisputeLineageApi", () => ({
+  fetchCourtDisputeLineageProfiles: (...args: any[]) => mockFetchProfiles(...args),
+}));
+
+vi.mock("@/components/layout/MacShell", () => ({
+  MacShell: ({ children, title }: any) => <main aria-label={title}>{children}</main>,
+}));
+
+vi.mock("@/components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
+const profile = {
+  courtDisputeLineageId: "court_dispute_lineage:landlord-1:tenant-1",
+  status: "verified",
+  landlordId: "landlord-1",
+  tenantId: "tenant-1",
+  manualReviewRequired: true,
+  legalFilingExecutionEnabled: false,
+  collectionsExecutionEnabled: false,
+  bureauReportingEnabled: false,
+  publicCourtRecordExposureEnabled: false,
+  generatedAt: "2026-05-07T00:00:00.000Z",
+  summary: {
+    totalReferences: 1,
+    verifiedReferences: 1,
+    partiallyVerifiedReferences: 0,
+    blockedReferences: 0,
+    unavailableReferences: 0,
+    restrictions: 0,
+  },
+  disputeReferences: [],
+  courtRecordReferences: [],
+  filingReadinessReferences: [],
+  judgmentOrderReferences: [],
+  rentalDebtReferences: [],
+  consentReferences: [],
+  reviewReferences: [],
+  evidenceReferences: [],
+  auditReferences: [],
+  courtDisputeRestrictions: [],
+  redactions: ["Sensitive court and dispute payloads are excluded."],
+  blockedReasons: [],
+  canonicalEvents: [],
+};
+
+describe("CourtDisputeLineagePage", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    mockFetchProfiles.mockResolvedValue([profile]);
+  });
+
+  it("loads and renders court/dispute lineage with required safety copy", async () => {
+    render(
+      <MemoryRouter>
+        <CourtDisputeLineagePage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Loading court and dispute lineage...")).toBeInTheDocument();
+    expect(await screen.findByText("Lineage summary")).toBeInTheDocument();
+    expect(screen.getAllByText(/Court and dispute lineage is operationally scoped and review controlled/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Manual review remains required/i).length).toBeGreaterThan(0);
+    expect(mockFetchProfiles).toHaveBeenCalledWith({ tenantId: undefined, disputeId: undefined, status: "" });
+  });
+
+  it("filters profiles by tenant, dispute, and status", async () => {
+    render(
+      <MemoryRouter>
+        <CourtDisputeLineagePage />
+      </MemoryRouter>
+    );
+
+    fireEvent.change((await screen.findByLabelText("Tenant reference")), { target: { value: "tenant-1" } });
+    fireEvent.change(screen.getByLabelText("Dispute reference"), { target: { value: "dispute-1" } });
+    fireEvent.change(screen.getByLabelText("Status"), { target: { value: "blocked" } });
+
+    await waitFor(() => {
+      expect(mockFetchProfiles).toHaveBeenLastCalledWith({ tenantId: "tenant-1", disputeId: "dispute-1", status: "blocked" });
+    });
+  });
+
+  it("renders the empty state", async () => {
+    mockFetchProfiles.mockResolvedValue([]);
+
+    render(
+      <MemoryRouter>
+        <CourtDisputeLineagePage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("No court and dispute lineage profiles match these filters.")).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/CourtDisputeLineagePage.tsx
+++ b/rentchain-frontend/src/pages/CourtDisputeLineagePage.tsx
@@ -1,0 +1,118 @@
+import React from "react";
+import { useSearchParams } from "react-router-dom";
+import {
+  fetchCourtDisputeLineageProfiles,
+  type CourtDisputeLineageProfile,
+  type CourtDisputeLineageStatus,
+} from "@/api/courtDisputeLineageApi";
+import { MacShell } from "@/components/layout/MacShell";
+import { CourtDisputeLineagePanel } from "@/components/disputes/CourtDisputeLineagePanel";
+import { Card, Section } from "@/components/ui/Ui";
+import { useToast } from "@/components/ui/ToastProvider";
+
+const statuses: Array<CourtDisputeLineageStatus | ""> = ["", "verified", "partially_verified", "review_required", "blocked", "unknown"];
+
+function label(value: string) {
+  return value ? value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase()) : "All";
+}
+
+export default function CourtDisputeLineagePage() {
+  const { showToast } = useToast();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [profiles, setProfiles] = React.useState<CourtDisputeLineageProfile[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const tenantId = String(searchParams.get("tenantId") || "").trim();
+  const disputeId = String(searchParams.get("disputeId") || "").trim();
+  const status = String(searchParams.get("status") || "") as CourtDisputeLineageStatus | "";
+
+  React.useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const next = await fetchCourtDisputeLineageProfiles({ tenantId: tenantId || undefined, disputeId: disputeId || undefined, status });
+        if (mounted) setProfiles(next);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Failed to load court and dispute lineage";
+        if (mounted) {
+          setError(message);
+          showToast({ message: "Failed to load court and dispute lineage", description: message, variant: "error" });
+        }
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [tenantId, disputeId, status, showToast]);
+
+  function updateParams(next: { tenantId?: string; disputeId?: string; status?: string }) {
+    const params = new URLSearchParams(searchParams);
+    if (next.tenantId !== undefined) {
+      if (next.tenantId.trim()) params.set("tenantId", next.tenantId.trim());
+      else params.delete("tenantId");
+    }
+    if (next.disputeId !== undefined) {
+      if (next.disputeId.trim()) params.set("disputeId", next.disputeId.trim());
+      else params.delete("disputeId");
+    }
+    if (next.status !== undefined) {
+      if (next.status) params.set("status", next.status);
+      else params.delete("status");
+    }
+    setSearchParams(params);
+  }
+
+  return (
+    <MacShell title="Court and dispute lineage" showTopNav={false}>
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "grid", gap: 6 }}>
+            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Court and dispute lineage</h1>
+            <div style={{ color: "#475569", maxWidth: 900 }}>
+              Court and dispute lineage is operationally scoped and review controlled. No legal filing, collections execution, bureau reporting, or public court-record exposure is enabled.
+              Manual review remains required.
+            </div>
+          </div>
+        </Section>
+
+        <Section style={{ display: "flex", gap: 10, flexWrap: "wrap", alignItems: "end" }}>
+          <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Tenant reference
+            <input
+              value={tenantId}
+              onChange={(event) => updateParams({ tenantId: event.target.value })}
+              placeholder="Optional tenant reference"
+              style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 220 }}
+            />
+          </label>
+          <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Dispute reference
+            <input
+              value={disputeId}
+              onChange={(event) => updateParams({ disputeId: event.target.value })}
+              placeholder="Optional dispute reference"
+              style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 220 }}
+            />
+          </label>
+          <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Status
+            <select value={status} onChange={(event) => updateParams({ status: event.target.value })} style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 180 }}>
+              {statuses.map((item) => <option key={item || "all"} value={item}>{label(item)}</option>)}
+            </select>
+          </label>
+        </Section>
+
+        {loading ? <Card>Loading court and dispute lineage...</Card> : null}
+        {!loading && error ? <Card style={{ color: "#b91c1c" }}>We couldn't load court and dispute lineage right now.</Card> : null}
+        {!loading && !error && !profiles.length ? <Card style={{ color: "#64748b" }}>No court and dispute lineage profiles match these filters.</Card> : null}
+        {!loading && !error && profiles.length ? (
+          <div style={{ display: "grid", gap: 16 }}>{profiles.map((profile) => <CourtDisputeLineagePanel key={profile.courtDisputeLineageId} profile={profile} />)}</div>
+        ) : null}
+      </div>
+    </MacShell>
+  );
+}


### PR DESCRIPTION
## Summary
- Add a deterministic Court and Dispute Lineage read model for landlord-scoped operational visibility.
- Add read-only landlord endpoints for court/dispute lineage profile derivation.
- Add permissioned frontend visibility for dispute, court-record metadata, filing-readiness metadata, judgment/order metadata, consent, evidence, review, audit, restrictions, and redactions.

## Guardrails
- `manualReviewRequired` remains `true`.
- `legalFilingExecutionEnabled` remains `false`.
- `collectionsExecutionEnabled` remains `false`.
- `bureauReportingEnabled` remains `false`.
- `publicCourtRecordExposureEnabled` remains `false`.
- No legal filing workflow, court e-filing integration, legal advice, collections execution, bureau reporting, public court-record exposure, public blacklisting, autonomous enforcement, AI legal scoring, or hidden execution path is added.
- Filing-readiness and judgment/order references are metadata-only and review controlled.
- Landlord route output uses a whitelist projection and excludes raw court documents, filing forms, legal advice outputs, private tenant data, payment payloads, screening/credit payloads, and admin-only payloads.

## Endpoints
- `GET /api/landlord/court-dispute-lineage`
- `GET /api/landlord/court-dispute-lineage/:courtDisputeLineageId`

## Verification
- Backend targeted tests: passed (`9/9`).
- Frontend targeted tests: passed (`5/5`).
- Backend build: passed.
- Frontend build: passed. Existing chunk-size warning remains non-regressive.
- `git diff --check`: passed.
- Dependency/lockfile diff: empty.
- Forbidden runtime label scan: clean.

## Scope
Limited to court-dispute-lineage backend files, landlord route wiring, frontend API/UI/page wiring, and targeted tests.