### PR TITLE
feat: add support operations console

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -112,6 +112,7 @@ import adminSlaRoutes from "./routes/adminSlaRoutes";
 import adminAlertingRoutes from "./routes/adminAlertingRoutes";
 import adminAssignmentRoutes from "./routes/adminAssignmentRoutes";
 import adminNotificationRoutes from "./routes/adminNotificationRoutes";
+import adminSupportOperationsRoutes from "./routes/adminSupportOperationsRoutes";
 import adminObservabilityRoutes from "./routes/adminObservabilityRoutes";
 import adminObservabilityIncidentReadinessRoutes from "./routes/adminObservabilityIncidentReadinessRoutes";
 import adminReleaseGovernanceRoutes from "./routes/adminReleaseGovernanceRoutes";
@@ -292,6 +293,8 @@ app.use("/api/admin", routeSource("adminAssignmentRoutes.ts"), adminAssignmentRo
 console.log("[route-mount] adminAssignmentRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("adminNotificationRoutes.ts"), adminNotificationRoutes);
 console.log("[route-mount] adminNotificationRoutes mounted at /api/admin");
+app.use("/api/admin", routeSource("adminSupportOperationsRoutes.ts"), adminSupportOperationsRoutes);
+console.log("[route-mount] adminSupportOperationsRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("adminObservabilityRoutes.ts"), adminObservabilityRoutes);
 console.log("[route-mount] adminObservabilityRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("adminObservabilityIncidentReadinessRoutes.ts"), adminObservabilityIncidentReadinessRoutes);

--- a/rentchain-api/src/lib/supportOperations/__tests__/deriveSupportOperationsProfile.test.ts
+++ b/rentchain-api/src/lib/supportOperations/__tests__/deriveSupportOperationsProfile.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { deriveSupportOperationsProfile } from "../deriveSupportOperationsProfile";
+
+describe("deriveSupportOperationsProfile", () => {
+  const completeInput = {
+    supportOperationsKey: "support-v1",
+    generatedAt: "2026-05-07T00:00:00.000Z",
+    supportRecords: [{ supportTicketId: "ticket-1", status: "resolved" }],
+    onboardingRecords: [{ onboardingHardeningId: "onboarding-1", status: "ready_for_review" }],
+    credentialingRecords: [{ platformCredentialingId: "credentialing-1", status: "ready_for_review" }],
+    incidentRecords: [{ incidentId: "incident-1", status: "resolved" }],
+    operationalRiskRecords: [{ operationalRiskProfileId: "risk-1", status: "ready_for_review" }],
+    reviewRecords: [{ reviewSessionId: "review-1", status: "completed" }],
+    evidencePacks: [{ evidencePackId: "evidence-1", status: "verified" }],
+    auditEvents: [{ eventId: "event-1", eventType: "support_operations_profile_derived" }],
+  };
+
+  it("derives a deterministic stable profile with execution flags pinned off", () => {
+    const profile = deriveSupportOperationsProfile(completeInput);
+    const again = deriveSupportOperationsProfile(completeInput);
+
+    expect(profile).toEqual(again);
+    expect(profile).toEqual(
+      expect.objectContaining({
+        supportOperationsId: "support_operations:support-v1",
+        status: "stable",
+        manualReviewRequired: true,
+        autonomousSupportExecutionEnabled: false,
+        adminImpersonationEnabled: false,
+      })
+    );
+    expect(profile.summary.totalReferences).toBe(8);
+    expect(profile.supportRestrictions).toEqual([]);
+  });
+
+  it("blocks unresolved incident or operational-risk restrictions", () => {
+    const profile = deriveSupportOperationsProfile({
+      ...completeInput,
+      operationalRiskRecords: [{ operationalRiskProfileId: "risk-1", status: "blocked" }],
+    });
+
+    expect(profile.status).toBe("blocked");
+    expect(profile.supportRestrictions).toEqual(expect.arrayContaining([expect.objectContaining({ restrictionType: "operational_risk", status: "blocked" })]));
+    expect(profile.canonicalEvents.map((event) => event.eventType)).toContain("support_operations_blocked");
+  });
+
+  it("requires review when critical support, onboarding, review, evidence, or audit lineage is missing", () => {
+    const profile = deriveSupportOperationsProfile({
+      supportOperationsKey: "support-v1",
+      incidentRecords: [{ incidentId: "incident-1", status: "resolved" }],
+    });
+
+    expect(profile.status).toBe("review_required");
+    expect(profile.supportRestrictions.some((restriction) => restriction.restrictionType === "support")).toBe(true);
+    expect(profile.supportRestrictions.some((restriction) => restriction.restrictionType === "onboarding")).toBe(true);
+    expect(profile.supportRestrictions.some((restriction) => restriction.restrictionType === "review")).toBe(true);
+    expect(profile.supportRestrictions.some((restriction) => restriction.restrictionType === "evidence")).toBe(true);
+    expect(profile.supportRestrictions.some((restriction) => restriction.restrictionType === "audit")).toBe(true);
+  });
+
+  it("marks incomplete incident linkage as attention required without enabling execution", () => {
+    const profile = deriveSupportOperationsProfile({
+      ...completeInput,
+      incidentRecords: [{ incidentId: "incident-1", status: "investigating" }],
+    });
+
+    expect(profile.status).toBe("attention_required");
+    expect(profile.autonomousSupportExecutionEnabled).toBe(false);
+    expect(profile.adminImpersonationEnabled).toBe(false);
+    expect(profile.canonicalEvents.map((event) => event.eventType)).toContain("support_operations_review_required");
+  });
+
+  it("returns unknown when source context is unavailable", () => {
+    const profile = deriveSupportOperationsProfile({ supportOperationsKey: "support-v1" });
+
+    expect(profile.status).toBe("unknown");
+    expect(profile.summary.unavailableReferences).toBe(8);
+  });
+
+  it("generates additive canonical events for redaction and restrictions", () => {
+    const profile = deriveSupportOperationsProfile({
+      ...completeInput,
+      evidencePacks: [{ evidencePackId: "evidence-1", status: "blocked", redacted: true }],
+    });
+
+    expect(profile.canonicalEvents.map((event) => event.eventType)).toEqual(
+      expect.arrayContaining(["support_operations_profile_derived", "support_operations_redaction_applied", "support_operations_restriction_detected"])
+    );
+    expect(profile.evidenceReferences[0]).toEqual(
+      expect.objectContaining({
+        redacted: true,
+        redactionReason: "Support evidence lineage reference payload is redacted for support operations safety.",
+      })
+    );
+  });
+});

--- a/rentchain-api/src/lib/supportOperations/deriveSupportOperationsProfile.ts
+++ b/rentchain-api/src/lib/supportOperations/deriveSupportOperationsProfile.ts
@@ -1,0 +1,313 @@
+import type {
+  DeriveSupportOperationsProfileInput,
+  SupportOperationsCanonicalEvent,
+  SupportOperationsProfile,
+  SupportOperationsStatus,
+  SupportReferenceStatus,
+  SupportReferenceType,
+  SupportOperationsReference,
+} from "./supportOperationsTypes";
+import { supportOperationsIdPart, supportReference, supportRestriction } from "./supportRestrictionModels";
+
+const DEFAULT_KEY = "production-support-operations-console-v1";
+
+const REDACTIONS = [
+  "Sensitive tenant and landlord profile fields, raw screening and credit bureau payloads, payment account details, provider credentials, and admin-only payloads are excluded.",
+  "Support operations are visibility metadata only; no autonomous support execution, onboarding intervention, ticket resolution, impersonation, or operational override is enabled.",
+  "Public support exposure, uncontrolled messaging, hidden operator actions, and unrestricted admin impersonation payloads are excluded.",
+  "Support, evidence, review, incident, and operational-risk lineage remains deterministic, permission scoped, and manually reviewed.",
+];
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function asArray<T>(value: T[] | null | undefined): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function generatedAt(value: unknown): string {
+  const raw = asString(value, 120);
+  const date = raw ? new Date(raw) : new Date(0);
+  return Number.isNaN(date.getTime()) ? new Date(0).toISOString() : date.toISOString();
+}
+
+function recordId(record: Record<string, any>, keys: string[]): string {
+  for (const key of keys) {
+    const value = asString(record?.[key], 240);
+    if (value) return value;
+  }
+  return asString(record?.id, 240);
+}
+
+function referenceStatus(record: Record<string, any>, verifiedStatuses: string[]): SupportReferenceStatus {
+  const status = asString(record?.status || record?.state || record?.conclusion || record?.severity, 80).toLowerCase();
+  if (["blocked", "critical", "major", "failed", "failure", "error", "cancelled"].includes(status)) return "blocked";
+  if (verifiedStatuses.includes(status)) return "verified";
+  if (["missing", "unknown", "unavailable", "pending"].includes(status)) return "unavailable";
+  return "partially_verified";
+}
+
+function statusForType(referenceType: SupportReferenceType, record: Record<string, any>): SupportReferenceStatus {
+  if (referenceType === "audit" && asString(record?.eventType || record?.type, 120)) return "verified";
+  if (referenceType === "review") return referenceStatus(record, ["ready_for_review", "completed", "verified", "reviewed"]);
+  if (referenceType === "incident") return referenceStatus(record, ["resolved", "stable", "ready_for_review", "verified"]);
+  if (referenceType === "operational_risk") return referenceStatus(record, ["ready_for_review", "verified", "accepted", "resolved"]);
+  return referenceStatus(record, ["ready_for_review", "verified", "available", "completed", "stable", "active", "resolved"]);
+}
+
+function profileStatus(hasContext: boolean, references: SupportOperationsReference[]): SupportOperationsStatus {
+  if (!hasContext) return "unknown";
+  if (references.some((reference) => reference.status === "blocked" && (reference.referenceType === "incident" || reference.referenceType === "operational_risk"))) return "blocked";
+  const criticalMissing = references.some(
+    (reference) =>
+      reference.status === "unavailable" &&
+      (reference.referenceType === "support" ||
+        reference.referenceType === "onboarding" ||
+        reference.referenceType === "review" ||
+        reference.referenceType === "evidence" ||
+        reference.referenceType === "audit")
+  );
+  if (criticalMissing) return "review_required";
+  if (references.some((reference) => reference.status === "blocked" || reference.status === "unavailable" || reference.status === "partially_verified")) return "attention_required";
+  return "stable";
+}
+
+function event(input: {
+  eventType: SupportOperationsCanonicalEvent["eventType"];
+  status: SupportOperationsStatus;
+  supportOperationsId: string;
+  summary: string;
+}): SupportOperationsCanonicalEvent {
+  return {
+    eventType: input.eventType,
+    action: input.eventType.replace(/^support_operations_/, "").replace(/_/g, "."),
+    status: input.status,
+    resourceType: "support_operations_profile",
+    resourceId: input.supportOperationsId,
+    summary: input.summary,
+  };
+}
+
+function referencesFor(input: {
+  records: Record<string, any>[];
+  fallback: string;
+  referenceType: SupportReferenceType;
+  idKeys: string[];
+  label: string;
+  description: string;
+  destination: string;
+  blockedReason: string;
+}): SupportOperationsReference[] {
+  if (!input.records.length) {
+    return [
+      supportReference({
+        idParts: [input.referenceType, "missing"],
+        referenceType: input.referenceType,
+        status: "unavailable",
+        label: input.label,
+        description: `${input.description} is unavailable for support operations review.`,
+        destination: input.destination,
+      }),
+    ];
+  }
+  return input.records.map((record, index) => {
+    const id = recordId(record, input.idKeys) || `${input.fallback}-${index + 1}`;
+    const status = statusForType(input.referenceType, record);
+    return supportReference({
+      idParts: [input.referenceType, id],
+      referenceType: input.referenceType,
+      status,
+      label: input.label,
+      description: `${input.description} is available as operational support metadata.`,
+      lineageReferences: [id].filter(Boolean),
+      destination: input.destination,
+      redacted: Boolean(record.redacted),
+      redactionReason: record.redacted ? `${input.label} payload is redacted for support operations safety.` : null,
+      blockedReason: status === "blocked" ? input.blockedReason : null,
+    });
+  });
+}
+
+export function deriveSupportOperationsProfile(input: DeriveSupportOperationsProfileInput): SupportOperationsProfile {
+  const key = asString(input.supportOperationsKey, 160) || DEFAULT_KEY;
+  const supportOperationsId = supportOperationsIdPart(["support_operations", key].join(":")) || "support_operations:unknown";
+
+  const supportRecords = asArray(input.supportRecords);
+  const onboardingRecords = asArray(input.onboardingRecords);
+  const credentialingRecords = asArray(input.credentialingRecords);
+  const incidentRecords = asArray(input.incidentRecords);
+  const operationalRiskRecords = asArray(input.operationalRiskRecords);
+  const reviewRecords = asArray(input.reviewRecords);
+  const evidencePacks = asArray(input.evidencePacks);
+  const auditEvents = asArray(input.auditEvents);
+
+  const supportReferences = referencesFor({
+    records: supportRecords,
+    fallback: "support",
+    referenceType: "support",
+    idKeys: ["supportTicketId", "ticketId", "triageId", "resolutionId", "assignmentId", "slaId", "id"],
+    label: "Support ticket lineage reference",
+    description: "Support ticket, triage, assignment, escalation, and resolution lineage",
+    destination: "/admin/support-operations",
+    blockedReason: "Support ticket lineage is blocked.",
+  });
+  const onboardingReferences = referencesFor({
+    records: onboardingRecords,
+    fallback: "onboarding",
+    referenceType: "onboarding",
+    idKeys: ["onboardingHardeningId", "onboardingReadinessId", "onboardingId", "id"],
+    label: "Onboarding support reference",
+    description: "Onboarding hardening and onboarding support metadata",
+    destination: "/onboarding-hardening",
+    blockedReason: "Onboarding support lineage is blocked.",
+  });
+  const credentialingReferences = referencesFor({
+    records: credentialingRecords,
+    fallback: "credentialing",
+    referenceType: "credentialing",
+    idKeys: ["platformCredentialingId", "credentialingReadinessId", "id"],
+    label: "Credentialing support reference",
+    description: "Credentialing readiness and support metadata",
+    destination: "/platform-credentialing-readiness",
+    blockedReason: "Credentialing support lineage is blocked.",
+  });
+  const incidentReferences = referencesFor({
+    records: incidentRecords,
+    fallback: "incident",
+    referenceType: "incident",
+    idKeys: ["observabilityIncidentReadinessId", "incidentId", "alertId", "id"],
+    label: "Incident/support linkage reference",
+    description: "Incident linkage and operational recovery metadata",
+    destination: "/observability-incident-readiness",
+    blockedReason: "Incident or recovery linkage is blocked.",
+  });
+  const operationalRiskReferences = referencesFor({
+    records: operationalRiskRecords,
+    fallback: "operational-risk",
+    referenceType: "operational_risk",
+    idKeys: ["operationalRiskProfileId", "riskId", "alertId", "id"],
+    label: "Operational risk support reference",
+    description: "Operational risk dependency metadata",
+    destination: "/operational-risk",
+    blockedReason: "Operational risk dependency blocks support operations.",
+  });
+  const reviewReferences = referencesFor({
+    records: reviewRecords,
+    fallback: "review",
+    referenceType: "review",
+    idKeys: ["reviewSessionId", "operatorReviewId", "id"],
+    label: "Support review lineage reference",
+    description: "Support review lineage",
+    destination: "/review-timeline",
+    blockedReason: "Support review lineage is blocked.",
+  });
+  const evidenceReferences = referencesFor({
+    records: evidencePacks,
+    fallback: "evidence",
+    referenceType: "evidence",
+    idKeys: ["evidencePackId", "id"],
+    label: "Support evidence lineage reference",
+    description: "Support evidence lineage",
+    destination: "/evidence-packs",
+    blockedReason: "Support evidence lineage is blocked.",
+  });
+  const auditReferences = referencesFor({
+    records: auditEvents.slice(0, 20),
+    fallback: "audit",
+    referenceType: "audit",
+    idKeys: ["eventId", "auditId", "id"],
+    label: "Support audit lineage reference",
+    description: "Support audit lineage",
+    destination: "/review-timeline",
+    blockedReason: "Support audit lineage is blocked.",
+  });
+
+  const allReferences = [
+    ...supportReferences,
+    ...onboardingReferences,
+    ...credentialingReferences,
+    ...incidentReferences,
+    ...operationalRiskReferences,
+    ...reviewReferences,
+    ...evidenceReferences,
+    ...auditReferences,
+  ];
+  const hasContext = Boolean(
+    supportRecords.length ||
+      onboardingRecords.length ||
+      credentialingRecords.length ||
+      incidentRecords.length ||
+      operationalRiskRecords.length ||
+      reviewRecords.length ||
+      evidencePacks.length ||
+      auditEvents.length
+  );
+  const status = profileStatus(hasContext, allReferences);
+  const supportRestrictions = allReferences
+    .filter((reference) => reference.status !== "verified")
+    .map((reference) =>
+      supportRestriction({
+        idParts: [reference.referenceType, reference.referenceId],
+        restrictionType: reference.referenceType,
+        status: reference.status === "blocked" ? "blocked" : "review_required",
+        label: `${reference.label} restriction`,
+        description: `${reference.label} is incomplete or blocked for support operations review.`,
+        blockedReason: reference.blockedReason,
+      })
+    );
+  const blockedReasons = [...allReferences.map((reference) => reference.blockedReason), ...supportRestrictions.map((restriction) => restriction.blockedReason)].filter(Boolean) as string[];
+
+  const canonicalEvents: SupportOperationsCanonicalEvent[] = [
+    event({
+      eventType: "support_operations_profile_derived",
+      status,
+      supportOperationsId,
+      summary: "Support operations profile derived from support, onboarding, credentialing, incident, operational-risk, review, evidence, and audit metadata.",
+    }),
+    event({
+      eventType: "support_operations_redaction_applied",
+      status,
+      supportOperationsId,
+      summary: "Sensitive tenant, landlord, screening, payment, provider credential, admin-only, impersonation, override, public exposure, and autonomous execution payloads were excluded.",
+    }),
+  ];
+  if (supportRestrictions.length) {
+    canonicalEvents.push(event({ eventType: "support_operations_restriction_detected", status, supportOperationsId, summary: "Support operations restrictions are visible for manual review." }));
+  }
+  if (status === "review_required" || status === "attention_required") {
+    canonicalEvents.push(event({ eventType: "support_operations_review_required", status, supportOperationsId, summary: "Manual support operations review is required." }));
+  }
+  if (status === "blocked") {
+    canonicalEvents.push(event({ eventType: "support_operations_blocked", status, supportOperationsId, summary: "Support operations profile is blocked by unresolved restrictions." }));
+  }
+
+  return {
+    supportOperationsId,
+    status,
+    manualReviewRequired: true,
+    autonomousSupportExecutionEnabled: false,
+    adminImpersonationEnabled: false,
+    generatedAt: generatedAt(input.generatedAt),
+    summary: {
+      totalReferences: allReferences.length,
+      verifiedReferences: allReferences.filter((reference) => reference.status === "verified").length,
+      partiallyVerifiedReferences: allReferences.filter((reference) => reference.status === "partially_verified").length,
+      blockedReferences: allReferences.filter((reference) => reference.status === "blocked").length,
+      unavailableReferences: allReferences.filter((reference) => reference.status === "unavailable").length,
+      restrictions: supportRestrictions.length,
+    },
+    supportReferences,
+    onboardingReferences,
+    credentialingReferences,
+    incidentReferences,
+    operationalRiskReferences,
+    reviewReferences,
+    evidenceReferences,
+    auditReferences,
+    supportRestrictions,
+    redactions: REDACTIONS,
+    blockedReasons,
+    canonicalEvents,
+  };
+}

--- a/rentchain-api/src/lib/supportOperations/supportOperationsTypes.ts
+++ b/rentchain-api/src/lib/supportOperations/supportOperationsTypes.ts
@@ -1,0 +1,84 @@
+export type SupportOperationsStatus = "stable" | "attention_required" | "review_required" | "blocked" | "unknown";
+export type SupportReferenceType = "support" | "onboarding" | "credentialing" | "incident" | "operational_risk" | "review" | "evidence" | "audit";
+export type SupportReferenceStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+
+export type SupportOperationsCanonicalEventType =
+  | "support_operations_profile_derived"
+  | "support_operations_review_required"
+  | "support_operations_blocked"
+  | "support_operations_restriction_detected"
+  | "support_operations_redaction_applied";
+
+export type SupportOperationsReference = {
+  referenceId: string;
+  referenceType: SupportReferenceType;
+  status: SupportReferenceStatus;
+  label: string;
+  description: string;
+  reviewRequired: true;
+  lineageReferences: string[];
+  destination: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type SupportOperationsRestriction = {
+  restrictionId: string;
+  restrictionType: SupportReferenceType | "autonomous_support_execution" | "admin_impersonation" | "operator_override" | "public_support_exposure";
+  status: "visible" | "blocked" | "review_required";
+  label: string;
+  description: string;
+  blockedReason: string | null;
+};
+
+export type SupportOperationsCanonicalEvent = {
+  eventType: SupportOperationsCanonicalEventType;
+  action: string;
+  status: SupportOperationsStatus;
+  resourceType: "support_operations_profile";
+  resourceId: string;
+  summary: string;
+};
+
+export type SupportOperationsProfile = {
+  supportOperationsId: string;
+  status: SupportOperationsStatus;
+  manualReviewRequired: true;
+  autonomousSupportExecutionEnabled: false;
+  adminImpersonationEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    partiallyVerifiedReferences: number;
+    blockedReferences: number;
+    unavailableReferences: number;
+    restrictions: number;
+  };
+  supportReferences: SupportOperationsReference[];
+  onboardingReferences: SupportOperationsReference[];
+  credentialingReferences: SupportOperationsReference[];
+  incidentReferences: SupportOperationsReference[];
+  operationalRiskReferences: SupportOperationsReference[];
+  reviewReferences: SupportOperationsReference[];
+  evidenceReferences: SupportOperationsReference[];
+  auditReferences: SupportOperationsReference[];
+  supportRestrictions: SupportOperationsRestriction[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: SupportOperationsCanonicalEvent[];
+};
+
+export type DeriveSupportOperationsProfileInput = {
+  supportOperationsKey?: unknown;
+  generatedAt?: unknown;
+  supportRecords?: Array<Record<string, any>> | null;
+  onboardingRecords?: Array<Record<string, any>> | null;
+  credentialingRecords?: Array<Record<string, any>> | null;
+  incidentRecords?: Array<Record<string, any>> | null;
+  operationalRiskRecords?: Array<Record<string, any>> | null;
+  reviewRecords?: Array<Record<string, any>> | null;
+  evidencePacks?: Array<Record<string, any>> | null;
+  auditEvents?: Array<Record<string, any>> | null;
+};

--- a/rentchain-api/src/lib/supportOperations/supportRestrictionModels.ts
+++ b/rentchain-api/src/lib/supportOperations/supportRestrictionModels.ts
@@ -1,0 +1,63 @@
+import type {
+  SupportOperationsReference,
+  SupportOperationsRestriction,
+  SupportReferenceStatus,
+  SupportReferenceType,
+} from "./supportOperationsTypes";
+
+export function supportOperationsIdPart(value: unknown) {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 240);
+}
+
+export function supportReference(input: {
+  idParts: unknown[];
+  referenceType: SupportReferenceType;
+  status: SupportReferenceStatus;
+  label: string;
+  description: string;
+  lineageReferences?: string[];
+  destination?: string | null;
+  redacted?: boolean;
+  redactionReason?: string | null;
+  blockedReason?: string | null;
+}): SupportOperationsReference {
+  const referenceId = supportOperationsIdPart(input.idParts.filter(Boolean).join(":")) || `${input.referenceType}:unknown`;
+  return {
+    referenceId,
+    referenceType: input.referenceType,
+    status: input.status,
+    label: input.label,
+    description: input.description,
+    reviewRequired: true,
+    lineageReferences: Array.from(new Set(input.lineageReferences || [])).filter(Boolean).slice(0, 20),
+    destination: input.destination || null,
+    redacted: Boolean(input.redacted),
+    redactionReason: input.redactionReason || null,
+    blockedReason: input.blockedReason || null,
+  };
+}
+
+export function supportRestriction(input: {
+  idParts: unknown[];
+  restrictionType: SupportOperationsRestriction["restrictionType"];
+  status: SupportOperationsRestriction["status"];
+  label: string;
+  description: string;
+  blockedReason?: string | null;
+}): SupportOperationsRestriction {
+  const restrictionId = supportOperationsIdPart(["support_operations_restriction", ...input.idParts].filter(Boolean).join(":"));
+  return {
+    restrictionId: restrictionId || "support_operations_restriction:unknown",
+    restrictionType: input.restrictionType,
+    status: input.status,
+    label: input.label,
+    description: input.description,
+    blockedReason: input.blockedReason || null,
+  };
+}

--- a/rentchain-api/src/routes/__tests__/adminSupportOperationsRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/adminSupportOperationsRoutes.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+  return {
+    resetFakeDb: () => store.clear(),
+    seedDoc: (collection: string, id: string, data: any) => ensureCollection(collection).set(id, { id, data }),
+    fakeDb: {
+      collection: (name: string) => ({
+        get: async () => {
+          const docs = Array.from(ensureCollection(name).values()).map((doc) => ({ id: doc.id, exists: true, data: () => doc.data }));
+          return { docs, empty: docs.length === 0, size: docs.length };
+        },
+      }),
+    },
+  };
+});
+
+let mockUser: any;
+
+vi.mock("../../config/firebase", () => ({ db: fakeDb }));
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!mockUser) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    req.user = mockUser;
+    return next();
+  },
+}));
+vi.mock("../../middleware/requireAuthz", () => ({
+  requirePermission: () => (req: any, res: any, next: any) => {
+    const role = String(req.user?.actorRole || req.user?.role || "").trim().toLowerCase();
+    if (role !== "admin") return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    return next();
+  },
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; user?: Record<string, unknown> | null }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    mockUser = options.user ?? mockUser;
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: mockUser,
+      query: Object.fromEntries(new URLSearchParams(queryString || "").entries()),
+      params: {},
+      headers: {},
+    };
+    const match = path.match(/^\/support-operations\/(.+)$/);
+    if (match) req.params = { supportOperationsId: decodeURIComponent(match[1]) };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => (error ? reject(error) : undefined));
+  });
+}
+
+describe("adminSupportOperationsRoutes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    resetFakeDb();
+    mockUser = { id: "admin-1", role: "admin" };
+  });
+
+  function seedSupportOperations() {
+    seedDoc("supportTickets", "ticket-1", { supportTicketId: "ticket-1", status: "resolved", privateTenantData: "hidden" });
+    seedDoc("onboardingHardeningProfiles", "onboarding-1", { onboardingHardeningId: "onboarding-1", status: "ready_for_review", rawGovernmentId: "hidden" });
+    seedDoc("platformCredentialingReadiness", "credentialing-1", { platformCredentialingId: "credentialing-1", status: "ready_for_review", providerCredential: "hidden" });
+    seedDoc("statusIncidents", "incident-1", { incidentId: "incident-1", status: "resolved", rawTelemetryPayload: "hidden" });
+    seedDoc("operationalRiskProfiles", "risk-1", { operationalRiskProfileId: "risk-1", status: "ready_for_review", adminOnlyPayload: "hidden" });
+    seedDoc("operatorReviewSessions", "review-1", { reviewSessionId: "review-1", status: "completed", privateNote: "hidden" });
+    seedDoc("evidencePacks", "evidence-1", { evidencePackId: "evidence-1", status: "verified", creditBureauPayload: "hidden" });
+    seedDoc("events", "event-1", { eventId: "event-1", eventType: "support_operations_profile_derived", paymentAccount: "hidden" });
+  }
+
+  it("returns support-operations profiles for admins without sensitive payloads", async () => {
+    seedSupportOperations();
+    const router = (await import("../adminSupportOperationsRoutes")).default;
+
+    const forbidden = await invokeRouter(router, {
+      method: "GET",
+      url: "/support-operations",
+      user: { id: "landlord-1", role: "landlord" },
+    });
+    expect(forbidden.status).toBe(403);
+
+    const res = await invokeRouter(router, { method: "GET", url: "/support-operations", user: { id: "admin-1", role: "admin" } });
+
+    expect(res.status).toBe(200);
+    expect(res.body.profiles).toHaveLength(1);
+    expect(res.body.profiles[0]).toEqual(
+      expect.objectContaining({
+        manualReviewRequired: true,
+        autonomousSupportExecutionEnabled: false,
+        adminImpersonationEnabled: false,
+      })
+    );
+    const serialized = JSON.stringify(res.body);
+    expect(serialized).not.toContain("privateTenantData");
+    expect(serialized).not.toContain("rawGovernmentId");
+    expect(serialized).not.toContain("providerCredential");
+    expect(serialized).not.toContain("rawTelemetryPayload");
+    expect(serialized).not.toContain("adminOnlyPayload");
+    expect(serialized).not.toContain("privateNote");
+    expect(serialized).not.toContain("creditBureauPayload");
+    expect(serialized).not.toContain("paymentAccount");
+  });
+
+  it("returns a single support-operations profile by id and filters by status", async () => {
+    seedSupportOperations();
+    const router = (await import("../adminSupportOperationsRoutes")).default;
+    const list = await invokeRouter(router, { method: "GET", url: "/support-operations" });
+    const id = list.body.profiles[0].supportOperationsId;
+
+    const one = await invokeRouter(router, { method: "GET", url: `/support-operations/${encodeURIComponent(id)}` });
+    const filtered = await invokeRouter(router, { method: "GET", url: "/support-operations?status=blocked" });
+
+    expect(one.status).toBe(200);
+    expect(one.body.profile.supportOperationsId).toBe(id);
+    expect(filtered.status).toBe(200);
+    expect(filtered.body.profiles).toEqual([]);
+  });
+});

--- a/rentchain-api/src/routes/adminSupportOperationsRoutes.ts
+++ b/rentchain-api/src/routes/adminSupportOperationsRoutes.ts
@@ -1,0 +1,134 @@
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { requireAuth } from "../middleware/requireAuth";
+import { requirePermission } from "../middleware/requireAuthz";
+import { deriveSupportOperationsProfile } from "../lib/supportOperations/deriveSupportOperationsProfile";
+import type { SupportOperationsProfile, SupportOperationsStatus } from "../lib/supportOperations/supportOperationsTypes";
+
+const router = Router();
+const SUPPORT_OPERATIONS_KEY = "production-support-operations-console-v1";
+const STATUSES = new Set<SupportOperationsStatus>(["stable", "attention_required", "review_required", "blocked", "unknown"]);
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function sanitizeRecord(record: Record<string, any>) {
+  const safe: Record<string, any> = {};
+  for (const key of [
+    "id",
+    "status",
+    "state",
+    "conclusion",
+    "severity",
+    "supportTicketId",
+    "ticketId",
+    "triageId",
+    "resolutionId",
+    "assignmentId",
+    "slaId",
+    "resourceType",
+    "resourceId",
+    "onboardingHardeningId",
+    "onboardingReadinessId",
+    "onboardingId",
+    "platformCredentialingId",
+    "credentialingReadinessId",
+    "observabilityIncidentReadinessId",
+    "incidentId",
+    "alertId",
+    "operationalRiskProfileId",
+    "riskId",
+    "reviewSessionId",
+    "operatorReviewId",
+    "evidencePackId",
+    "eventId",
+    "eventType",
+    "createdAt",
+    "updatedAt",
+    "occurredAt",
+    "redacted",
+  ]) {
+    if (record[key] !== undefined) safe[key] = record[key];
+  }
+  return safe;
+}
+
+async function loadCollection(collectionName: string, limit = 30) {
+  const snap = await db.collection(collectionName).get().catch(() => null);
+  return (snap?.docs || []).slice(0, limit).map((doc) => sanitizeRecord({ id: doc.id, ...((doc.data() as any) || {}) }));
+}
+
+async function buildSupportOperationsProfiles(): Promise<SupportOperationsProfile[]> {
+  const [
+    supportRecords,
+    onboardingRecords,
+    credentialingRecords,
+    incidentRecords,
+    operationalRiskRecords,
+    reviewRecords,
+    evidencePacks,
+    auditEvents,
+  ] = await Promise.all([
+    Promise.all([
+      loadCollection("supportTickets"),
+      loadCollection("adminTriageItems"),
+      loadCollection("adminResolutions"),
+      loadCollection("adminAssignments"),
+      loadCollection("slaEvaluations"),
+    ]).then((groups) => groups.flat()),
+    Promise.all([loadCollection("onboardingHardeningProfiles"), loadCollection("institutionOnboardingReadiness")]).then((groups) => groups.flat()),
+    Promise.all([loadCollection("platformCredentialingReadiness"), loadCollection("credentialingReadiness")]).then((groups) => groups.flat()),
+    Promise.all([loadCollection("observabilityIncidentReadinessProfiles"), loadCollection("statusIncidents"), loadCollection("adminAlerts")]).then((groups) => groups.flat()),
+    Promise.all([loadCollection("operationalRiskProfiles"), loadCollection("operationalRiskRestrictions")]).then((groups) => groups.flat()),
+    loadCollection("operatorReviewSessions"),
+    loadCollection("evidencePacks"),
+    loadCollection("events"),
+  ]);
+
+  return [
+    deriveSupportOperationsProfile({
+      supportOperationsKey: SUPPORT_OPERATIONS_KEY,
+      supportRecords,
+      onboardingRecords,
+      credentialingRecords,
+      incidentRecords,
+      operationalRiskRecords,
+      reviewRecords,
+      evidencePacks,
+      auditEvents,
+    }),
+  ];
+}
+
+function profileMatches(profile: SupportOperationsProfile, id: string) {
+  return profile.supportOperationsId === id;
+}
+
+router.get("/support-operations", requireAuth, requirePermission("system.admin"), async (req: any, res) => {
+  try {
+    const status = asString(req.query?.status, 80) as SupportOperationsStatus;
+    let profiles = await buildSupportOperationsProfiles();
+    if (status && STATUSES.has(status)) profiles = profiles.filter((profile) => profile.status === status);
+    return res.json({ ok: true, profiles });
+  } catch (err: any) {
+    console.error("[admin-support-operations] list failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "SUPPORT_OPERATIONS_FAILED" });
+  }
+});
+
+router.get("/support-operations/:supportOperationsId", requireAuth, requirePermission("system.admin"), async (req: any, res) => {
+  try {
+    const supportOperationsId = decodeURIComponent(asString(req.params?.supportOperationsId, 500));
+    if (!supportOperationsId) return res.status(400).json({ ok: false, error: "SUPPORT_OPERATIONS_ID_REQUIRED" });
+    const profiles = await buildSupportOperationsProfiles();
+    const profile = profiles.find((next) => profileMatches(next, supportOperationsId));
+    if (!profile) return res.status(404).json({ ok: false, error: "SUPPORT_OPERATIONS_NOT_FOUND" });
+    return res.json({ ok: true, profile });
+  } catch (err: any) {
+    console.error("[admin-support-operations] get failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "SUPPORT_OPERATIONS_GET_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -136,6 +136,7 @@ const VerifiedRentalHistoryPage = lazy(() => import("./pages/VerifiedRentalHisto
 const RentalDebtPage = lazy(() => import("./pages/RentalDebtPage"));
 const CourtDisputeLineagePage = lazy(() => import("./pages/CourtDisputeLineagePage"));
 const OnboardingHardeningPage = lazy(() => import("./pages/OnboardingHardeningPage"));
+const SupportOperationsPage = lazy(() => import("./pages/SupportOperationsPage"));
 const SettlementReadinessPage = lazy(() => import("./pages/SettlementReadinessPage"));
 const RegulatoryProfilePage = lazy(() => import("./pages/RegulatoryProfilePage"));
 const AssetTokenizationReadinessPage = lazy(() => import("./pages/AssetTokenizationReadinessPage"));
@@ -675,6 +676,18 @@ function App() {
                 </Suspense>
               </LandlordNav>
             </RequireAuth>
+          }
+        />
+        <Route
+          path="/support-operations"
+          element={
+            <RequireAdmin>
+              <LandlordNav>
+                <Suspense fallback={null}>
+                  <SupportOperationsPage />
+                </Suspense>
+              </LandlordNav>
+            </RequireAdmin>
           }
         />
         <Route

--- a/rentchain-frontend/src/api/supportOperationsApi.ts
+++ b/rentchain-frontend/src/api/supportOperationsApi.ts
@@ -1,0 +1,74 @@
+import { apiFetch } from "./apiFetch";
+
+export type SupportOperationsStatus = "stable" | "attention_required" | "review_required" | "blocked" | "unknown";
+export type SupportReferenceType = "support" | "onboarding" | "credentialing" | "incident" | "operational_risk" | "review" | "evidence" | "audit";
+export type SupportReferenceStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+
+export type SupportOperationsReference = {
+  referenceId: string;
+  referenceType: SupportReferenceType;
+  status: SupportReferenceStatus;
+  label: string;
+  description: string;
+  reviewRequired: true;
+  lineageReferences: string[];
+  destination: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type SupportRestriction = {
+  restrictionId: string;
+  restrictionType: SupportReferenceType | "autonomous_support" | "admin_impersonation" | "operator_override" | "public_support";
+  status: "visible" | "blocked" | "review_required";
+  label: string;
+  description: string;
+  blockedReason: string | null;
+};
+
+export type SupportOperationsProfile = {
+  supportOperationsId: string;
+  status: SupportOperationsStatus;
+  manualReviewRequired: true;
+  autonomousSupportExecutionEnabled: false;
+  adminImpersonationEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    partiallyVerifiedReferences: number;
+    blockedReferences: number;
+    unavailableReferences: number;
+    restrictions: number;
+  };
+  supportReferences: SupportOperationsReference[];
+  onboardingReferences: SupportOperationsReference[];
+  credentialingReferences: SupportOperationsReference[];
+  incidentReferences: SupportOperationsReference[];
+  operationalRiskReferences: SupportOperationsReference[];
+  reviewReferences: SupportOperationsReference[];
+  evidenceReferences: SupportOperationsReference[];
+  auditReferences: SupportOperationsReference[];
+  supportRestrictions: SupportRestriction[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: Array<{ eventType: string; action: string; status: SupportOperationsStatus; resourceId: string; summary: string }>;
+};
+
+export async function fetchSupportOperationsProfiles(params?: {
+  status?: SupportOperationsStatus | "";
+}): Promise<SupportOperationsProfile[]> {
+  const search = new URLSearchParams();
+  if (params?.status) search.set("status", params.status);
+  const suffix = search.toString() ? `?${search.toString()}` : "";
+  const response = await apiFetch<{ ok: true; profiles: SupportOperationsProfile[] }>(`/admin/support-operations${suffix}`);
+  return response.profiles;
+}
+
+export async function fetchSupportOperationsProfile(supportOperationsId: string): Promise<SupportOperationsProfile> {
+  const response = await apiFetch<{ ok: true; profile: SupportOperationsProfile }>(
+    `/admin/support-operations/${encodeURIComponent(supportOperationsId)}`
+  );
+  return response.profile;
+}

--- a/rentchain-frontend/src/components/layout/navConfig.ts
+++ b/rentchain-frontend/src/components/layout/navConfig.ts
@@ -174,6 +174,13 @@ export const NAV_ITEMS: NavItem[] = [
     showInDrawer: true,
   },
   {
+    id: "support-operations",
+    label: "Support Ops",
+    to: "/support-operations",
+    requiresAdmin: true,
+    showInDrawer: true,
+  },
+  {
     id: "admin-leads",
     label: "Referral Requests",
     to: "/admin/leads",

--- a/rentchain-frontend/src/components/support/SupportOperationsConsole.test.tsx
+++ b/rentchain-frontend/src/components/support/SupportOperationsConsole.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import type { SupportOperationsProfile } from "@/api/supportOperationsApi";
+import { SupportOperationsConsole } from "./SupportOperationsConsole";
+
+const profile: SupportOperationsProfile = {
+  supportOperationsId: "support_operations:production-support-operations-console-v1",
+  status: "blocked",
+  manualReviewRequired: true,
+  autonomousSupportExecutionEnabled: false,
+  adminImpersonationEnabled: false,
+  generatedAt: "2026-05-07T00:00:00.000Z",
+  summary: {
+    totalReferences: 2,
+    verifiedReferences: 1,
+    partiallyVerifiedReferences: 0,
+    blockedReferences: 1,
+    unavailableReferences: 0,
+    restrictions: 1,
+  },
+  supportReferences: [
+    {
+      referenceId: "support-1",
+      referenceType: "support",
+      status: "verified",
+      label: "Support ticket lineage",
+      description: "Support ticket lineage is visible as review-controlled operational metadata.",
+      reviewRequired: true,
+      lineageReferences: ["ticket-1"],
+      destination: "/admin/support-console",
+      redacted: false,
+      redactionReason: null,
+      blockedReason: null,
+    },
+  ],
+  onboardingReferences: [],
+  credentialingReferences: [],
+  incidentReferences: [],
+  operationalRiskReferences: [
+    {
+      referenceId: "risk-1",
+      referenceType: "operational_risk",
+      status: "blocked",
+      label: "Operational risk restriction",
+      description: "Operational risk linkage is blocked for support operations review.",
+      reviewRequired: true,
+      lineageReferences: ["risk-1"],
+      destination: "/operational-risk",
+      redacted: false,
+      redactionReason: null,
+      blockedReason: "Operational risk remains unresolved.",
+    },
+  ],
+  reviewReferences: [],
+  evidenceReferences: [],
+  auditReferences: [],
+  supportRestrictions: [
+    {
+      restrictionId: "restriction-1",
+      restrictionType: "operational_risk",
+      status: "blocked",
+      label: "Operational risk restriction",
+      description: "Operational risk is unresolved for support operations readiness.",
+      blockedReason: "Operational risk remains unresolved.",
+    },
+  ],
+  redactions: ["Sensitive tenant, landlord, payment, screening, and provider credential payloads are excluded."],
+  blockedReasons: ["Operational risk remains unresolved."],
+  canonicalEvents: [],
+};
+
+describe("SupportOperationsConsole", () => {
+  it("renders support status, restrictions, blocked reasons, and required safety copy", () => {
+    render(
+      <MemoryRouter>
+        <SupportOperationsConsole profile={profile} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getAllByText("View support readiness").length).toBeGreaterThan(0);
+    expect(screen.getByText("View onboarding support")).toBeInTheDocument();
+    expect(screen.getByText("View operational risk")).toBeInTheDocument();
+    expect(screen.getByText("View restrictions")).toBeInTheDocument();
+    expect(screen.getAllByText("View blocked reason: Operational risk remains unresolved.").length).toBeGreaterThan(0);
+    expect(screen.getByText("Manual review required")).toBeInTheDocument();
+    expect(screen.getByText(/Support and operations workflows are operationally scoped and review controlled/i)).toBeInTheDocument();
+    expect(screen.getByText(/No autonomous operational intervention or unrestricted impersonation is enabled/i)).toBeInTheDocument();
+    expect(screen.getByText(/Manual review remains required/i)).toBeInTheDocument();
+  });
+
+  it("does not render forbidden support execution labels", () => {
+    render(
+      <MemoryRouter>
+        <SupportOperationsConsole profile={profile} />
+      </MemoryRouter>
+    );
+
+    const forbiddenLabels = [
+      ["Auto", "resolve"],
+      ["Autonomous", "intervention"],
+      ["Impersonate", "user"],
+      ["Override", "automatically"],
+      ["Auto", "fix onboarding"],
+      ["Hidden", "support action"],
+    ].map((parts) => parts.join(parts[0] === "Auto" ? "-" : " "));
+
+    for (const forbiddenLabel of forbiddenLabels) {
+      expect(screen.queryByText(forbiddenLabel)).not.toBeInTheDocument();
+    }
+  });
+});

--- a/rentchain-frontend/src/components/support/SupportOperationsConsole.tsx
+++ b/rentchain-frontend/src/components/support/SupportOperationsConsole.tsx
@@ -1,0 +1,140 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import type { SupportOperationsProfile, SupportOperationsReference, SupportRestriction } from "@/api/supportOperationsApi";
+import { Card, Section } from "@/components/ui/Ui";
+
+function label(value: string) {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function tone(status: string) {
+  if (status === "blocked") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
+  if (status === "review_required" || status === "attention_required" || status === "partially_verified" || status === "unavailable") {
+    return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
+  }
+  if (status === "stable" || status === "verified") return { color: "#166534", background: "#dcfce7", border: "#bbf7d0" };
+  return { color: "#475569", background: "#f8fafc", border: "#e2e8f0" };
+}
+
+function Badge({ children, status }: { children: React.ReactNode; status: string }) {
+  const next = tone(status);
+  return (
+    <span style={{ border: `1px solid ${next.border}`, borderRadius: 999, background: next.background, color: next.color, padding: "3px 9px", fontSize: 12, fontWeight: 900, whiteSpace: "nowrap" }}>
+      {children}
+    </span>
+  );
+}
+
+function ReferenceList({ title, references }: { title: string; references: SupportOperationsReference[] }) {
+  return (
+    <Section style={{ display: "grid", gap: 10 }}>
+      <div style={{ fontWeight: 900 }}>{title}</div>
+      {references.length ? (
+        references.slice(0, 12).map((reference) => (
+          <Card key={reference.referenceId} style={{ borderRadius: 8, padding: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+              <div>
+                <strong>{reference.label}</strong>
+                <div style={{ color: "#64748b", fontSize: 13 }}>{label(reference.referenceType)}</div>
+              </div>
+              <Badge status={reference.status}>{label(reference.status)}</Badge>
+            </div>
+            <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>{reference.description}</div>
+            {reference.lineageReferences.length ? <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>Lineage references: {reference.lineageReferences.length}</div> : null}
+            {reference.blockedReason ? <div style={{ color: "#991b1b", fontSize: 13, marginTop: 8 }}>View blocked reason: {reference.blockedReason}</div> : null}
+            {reference.redacted ? <div style={{ color: "#92400e", fontSize: 13, marginTop: 8 }}>{reference.redactionReason || "Redacted support operations reference"}</div> : null}
+            {reference.destination?.startsWith("/") ? <Link to={reference.destination} style={{ color: "#2563eb", fontWeight: 800, fontSize: 13, marginTop: 8, display: "inline-block" }}>View context</Link> : null}
+          </Card>
+        ))
+      ) : (
+        <Card style={{ color: "#64748b" }}>Context unavailable</Card>
+      )}
+    </Section>
+  );
+}
+
+function RestrictionList({ restrictions }: { restrictions: SupportRestriction[] }) {
+  return (
+    <Section style={{ display: "grid", gap: 10 }}>
+      <div style={{ fontWeight: 900 }}>View restrictions</div>
+      {restrictions.length ? (
+        restrictions.map((restriction) => (
+          <Card key={restriction.restrictionId} style={{ borderRadius: 8, padding: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+              <div>
+                <strong>{restriction.label}</strong>
+                <div style={{ color: "#64748b", fontSize: 13 }}>{label(restriction.restrictionType)}</div>
+              </div>
+              <Badge status={restriction.status}>{label(restriction.status)}</Badge>
+            </div>
+            <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>{restriction.description}</div>
+            {restriction.blockedReason ? <div style={{ color: "#991b1b", fontSize: 13, marginTop: 8 }}>View blocked reason: {restriction.blockedReason}</div> : null}
+          </Card>
+        ))
+      ) : (
+        <Card style={{ color: "#64748b" }}>No support operations restrictions detected.</Card>
+      )}
+    </Section>
+  );
+}
+
+export function SupportOperationsConsole({ profile }: { profile: SupportOperationsProfile }) {
+  return (
+    <div style={{ display: "grid", gap: 16 }}>
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+          <div>
+            <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>View support readiness</div>
+            <h2 style={{ margin: "2px 0 0", fontSize: "1.15rem" }}>Support and operations console</h2>
+          </div>
+          <Badge status={profile.status}>{label(profile.status)}</Badge>
+        </div>
+        <div style={{ color: "#475569", lineHeight: 1.55 }}>
+          Support and operations workflows are operationally scoped and review controlled. No autonomous operational intervention or unrestricted impersonation is enabled.
+          Manual review remains required.
+        </div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <Badge status="review_required">Manual review required</Badge>
+          <Badge status={profile.autonomousSupportExecutionEnabled ? "blocked" : "verified"}>Support execution disabled</Badge>
+          <Badge status={profile.adminImpersonationEnabled ? "blocked" : "verified"}>Admin impersonation disabled</Badge>
+        </div>
+      </Section>
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Support readiness summary</div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: 10 }}>
+          {[
+            ["References", profile.summary.totalReferences],
+            ["Verified", profile.summary.verifiedReferences],
+            ["Attention", profile.summary.partiallyVerifiedReferences],
+            ["Blocked", profile.summary.blockedReferences],
+            ["Unavailable", profile.summary.unavailableReferences],
+            ["Restrictions", profile.summary.restrictions],
+          ].map(([name, value]) => (
+            <Card key={String(name)} style={{ borderRadius: 8, padding: 12 }}>
+              <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>{name}</div>
+              <strong style={{ color: "#0f172a", fontSize: 22 }}>{String(value)}</strong>
+            </Card>
+          ))}
+        </div>
+      </Section>
+
+      <RestrictionList restrictions={profile.supportRestrictions} />
+      <ReferenceList title="View support readiness" references={profile.supportReferences} />
+      <ReferenceList title="View onboarding support" references={profile.onboardingReferences} />
+      <ReferenceList title="Credentialing support" references={profile.credentialingReferences} />
+      <ReferenceList title="Incident support linkage" references={profile.incidentReferences} />
+      <ReferenceList title="View operational risk" references={profile.operationalRiskReferences} />
+      <ReferenceList title="View review lineage" references={profile.reviewReferences} />
+      <ReferenceList title="View evidence lineage" references={profile.evidenceReferences} />
+      <ReferenceList title="Audit lineage" references={profile.auditReferences} />
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Redactions</div>
+        {profile.redactions.map((redaction) => (
+          <Card key={redaction} style={{ borderRadius: 8, padding: 12, color: "#475569" }}>{redaction}</Card>
+        ))}
+      </Section>
+    </div>
+  );
+}

--- a/rentchain-frontend/src/pages/SupportOperationsPage.test.tsx
+++ b/rentchain-frontend/src/pages/SupportOperationsPage.test.tsx
@@ -1,0 +1,97 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import SupportOperationsPage from "./SupportOperationsPage";
+
+const mockFetchProfiles = vi.fn();
+const mockShowToast = vi.fn();
+
+vi.mock("@/api/supportOperationsApi", () => ({
+  fetchSupportOperationsProfiles: (...args: any[]) => mockFetchProfiles(...args),
+}));
+
+vi.mock("@/components/layout/MacShell", () => ({
+  MacShell: ({ children, title }: any) => <main aria-label={title}>{children}</main>,
+}));
+
+vi.mock("@/components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
+const profile = {
+  supportOperationsId: "support_operations:production-support-operations-console-v1",
+  status: "stable",
+  manualReviewRequired: true,
+  autonomousSupportExecutionEnabled: false,
+  adminImpersonationEnabled: false,
+  generatedAt: "2026-05-07T00:00:00.000Z",
+  summary: {
+    totalReferences: 1,
+    verifiedReferences: 1,
+    partiallyVerifiedReferences: 0,
+    blockedReferences: 0,
+    unavailableReferences: 0,
+    restrictions: 0,
+  },
+  supportReferences: [],
+  onboardingReferences: [],
+  credentialingReferences: [],
+  incidentReferences: [],
+  operationalRiskReferences: [],
+  reviewReferences: [],
+  evidenceReferences: [],
+  auditReferences: [],
+  supportRestrictions: [],
+  redactions: ["Sensitive support payloads are excluded."],
+  blockedReasons: [],
+  canonicalEvents: [],
+};
+
+describe("SupportOperationsPage", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    mockFetchProfiles.mockResolvedValue([profile]);
+  });
+
+  it("loads support operations with required safety copy", async () => {
+    render(
+      <MemoryRouter>
+        <SupportOperationsPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Loading support operations...")).toBeInTheDocument();
+    expect(await screen.findByText("Support readiness summary")).toBeInTheDocument();
+    expect(screen.getAllByText(/Support and operations workflows are operationally scoped and review controlled/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/No autonomous operational intervention or unrestricted impersonation is enabled/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Manual review remains required/i).length).toBeGreaterThan(0);
+    expect(mockFetchProfiles).toHaveBeenCalledWith({ status: "" });
+  });
+
+  it("filters profiles by status", async () => {
+    render(
+      <MemoryRouter>
+        <SupportOperationsPage />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(await screen.findByLabelText("Status"), { target: { value: "blocked" } });
+
+    await waitFor(() => {
+      expect(mockFetchProfiles).toHaveBeenLastCalledWith({ status: "blocked" });
+    });
+  });
+
+  it("renders the empty state", async () => {
+    mockFetchProfiles.mockResolvedValue([]);
+
+    render(
+      <MemoryRouter>
+        <SupportOperationsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("No support operations profiles match these filters.")).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/SupportOperationsPage.tsx
+++ b/rentchain-frontend/src/pages/SupportOperationsPage.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { useSearchParams } from "react-router-dom";
+import {
+  fetchSupportOperationsProfiles,
+  type SupportOperationsProfile,
+  type SupportOperationsStatus,
+} from "@/api/supportOperationsApi";
+import { MacShell } from "@/components/layout/MacShell";
+import { SupportOperationsConsole } from "@/components/support/SupportOperationsConsole";
+import { Card, Section } from "@/components/ui/Ui";
+import { useToast } from "@/components/ui/ToastProvider";
+
+const statuses: Array<SupportOperationsStatus | ""> = ["", "stable", "attention_required", "review_required", "blocked", "unknown"];
+
+function label(value: string) {
+  return value ? value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase()) : "All";
+}
+
+export default function SupportOperationsPage() {
+  const { showToast } = useToast();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [profiles, setProfiles] = React.useState<SupportOperationsProfile[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const status = String(searchParams.get("status") || "") as SupportOperationsStatus | "";
+
+  React.useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const next = await fetchSupportOperationsProfiles({ status });
+        if (mounted) setProfiles(next);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Failed to load support operations";
+        if (mounted) {
+          setError(message);
+          showToast({ message: "Failed to load support operations", description: message, variant: "error" });
+        }
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [status, showToast]);
+
+  function updateStatus(value: string) {
+    const params = new URLSearchParams(searchParams);
+    if (value && value.trim()) params.set("status", value.trim());
+    else params.delete("status");
+    setSearchParams(params);
+  }
+
+  return (
+    <MacShell title="Support operations" showTopNav={false}>
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "grid", gap: 6 }}>
+            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Support and operations</h1>
+            <div style={{ color: "#475569", maxWidth: 900 }}>
+              Support and operations workflows are operationally scoped and review controlled. No autonomous operational intervention or unrestricted impersonation is enabled.
+              Manual review remains required.
+            </div>
+          </div>
+        </Section>
+
+        <Section style={{ display: "flex", gap: 10, flexWrap: "wrap", alignItems: "end" }}>
+          <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Status
+            <select value={status} onChange={(event) => updateStatus(event.target.value)} style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 180 }}>
+              {statuses.map((item) => (
+                <option key={item || "all"} value={item}>{label(item)}</option>
+              ))}
+            </select>
+          </label>
+        </Section>
+
+        {loading ? <Card>Loading support operations...</Card> : null}
+        {!loading && error ? <Card style={{ color: "#b91c1c" }}>We couldn't load support operations right now.</Card> : null}
+        {!loading && !error && !profiles.length ? <Card style={{ color: "#64748b" }}>No support operations profiles match these filters.</Card> : null}
+        {!loading && !error && profiles.length ? (
+          <div style={{ display: "grid", gap: 16 }}>{profiles.map((profile) => <SupportOperationsConsole key={profile.supportOperationsId} profile={profile} />)}</div>
+        ) : null}
+      </div>
+    </MacShell>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a deterministic Support and Operations read model for support, onboarding, credentialing, incident, operational-risk, review, evidence, and audit lineage.
- Adds admin read-only endpoints for support operations profiles.
- Adds an admin Support and Operations UI surface with required guardrail copy, restriction visibility, redaction summaries, and safe navigation wiring.

## Guardrails
- `manualReviewRequired` remains pinned to `true`.
- `autonomousSupportExecutionEnabled` remains pinned to `false`.
- `adminImpersonationEnabled` remains pinned to `false`.
- No autonomous support resolution, onboarding intervention, unrestricted impersonation, operator override, public support exposure, uncontrolled messaging, or hidden execution path was added.
- Route outputs are whitelist-projected and exclude sensitive tenant, landlord, screening, payment, provider credential, and admin-only payloads.

## Endpoints
- `GET /api/admin/support-operations`
- `GET /api/admin/support-operations/:supportOperationsId`

## Verification
- Backend targeted tests: `8/8` passed.
- Frontend targeted tests: `5/5` passed.
- Backend build: passed.
- Frontend build: passed. Existing chunk-size warning remains non-regressive.
- `git diff --check`: passed.
- Dependency/lockfile diff: empty.
- Runtime forbidden-label scan: clean.
- Runtime mutation/safe-flag scan: clean.

## Scope
Limited to support-operations files, admin route wiring, tests, and safe admin UI route wiring/nav entry.