### PR TITLE
feat: add enterprise municipal readiness layer

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -120,6 +120,7 @@ import adminPublicExposureHardeningRoutes from "./routes/adminPublicExposureHard
 import adminCommercialReadinessRoutes from "./routes/adminCommercialReadinessRoutes";
 import adminControlledIntegrationsRoutes from "./routes/adminControlledIntegrationsRoutes";
 import adminProductionIntegrationsRoutes from "./routes/adminProductionIntegrationsRoutes";
+import adminEnterpriseMunicipalReadinessRoutes from "./routes/adminEnterpriseMunicipalReadinessRoutes";
 import adminEcosystemCoordinationRoutes from "./routes/adminEcosystemCoordinationRoutes";
 import adminPlatformCredentialingRoutes from "./routes/adminPlatformCredentialingRoutes";
 import adminConsumerReportingGovernanceRoutes from "./routes/adminConsumerReportingGovernanceRoutes";
@@ -310,6 +311,8 @@ app.use("/api/admin", routeSource("adminControlledIntegrationsRoutes.ts"), admin
 console.log("[route-mount] adminControlledIntegrationsRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("adminProductionIntegrationsRoutes.ts"), adminProductionIntegrationsRoutes);
 console.log("[route-mount] adminProductionIntegrationsRoutes mounted at /api/admin");
+app.use("/api/admin", routeSource("adminEnterpriseMunicipalReadinessRoutes.ts"), adminEnterpriseMunicipalReadinessRoutes);
+console.log("[route-mount] adminEnterpriseMunicipalReadinessRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("adminEcosystemCoordinationRoutes.ts"), adminEcosystemCoordinationRoutes);
 console.log("[route-mount] adminEcosystemCoordinationRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("adminPlatformCredentialingRoutes.ts"), adminPlatformCredentialingRoutes);

--- a/rentchain-api/src/lib/enterpriseMunicipalReadiness/__tests__/deriveEnterpriseMunicipalReadinessProfile.test.ts
+++ b/rentchain-api/src/lib/enterpriseMunicipalReadiness/__tests__/deriveEnterpriseMunicipalReadinessProfile.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { deriveEnterpriseMunicipalReadinessProfile } from "../deriveEnterpriseMunicipalReadinessProfile";
+
+const completeInput = {
+  readinessKey: "enterprise-v1",
+  organizationType: "municipality",
+  generatedAt: "2026-05-07T00:00:00.000Z",
+  institutionalReadiness: [{ onboardingReadinessId: "institution-1", status: "ready_for_review" }],
+  portfolioGovernance: [{ portfolioGovernanceId: "portfolio-1", status: "ready_for_review" }],
+  municipalReadiness: [{ municipalReadinessId: "municipal-1", status: "ready_for_review" }],
+  regulatoryProfiles: [{ regulatoryProfileId: "regulatory-1", status: "ready_for_review" }],
+  operationalRiskProfiles: [{ operationalRiskId: "risk-1", status: "stable" }],
+  operatorReviewSessions: [{ reviewSessionId: "review-1", status: "completed" }],
+  evidencePacks: [{ evidencePackId: "evidence-1", status: "ready_for_review" }],
+  auditEvents: [{ eventId: "event-1", eventType: "enterprise_municipal_readiness_profile_derived" }],
+};
+
+describe("deriveEnterpriseMunicipalReadinessProfile", () => {
+  it("derives deterministic ready-for-review profiles with execution flags pinned off", () => {
+    const profile = deriveEnterpriseMunicipalReadinessProfile(completeInput);
+    const again = deriveEnterpriseMunicipalReadinessProfile(completeInput);
+
+    expect(profile).toEqual(again);
+    expect(profile).toEqual(
+      expect.objectContaining({
+        enterpriseMunicipalReadinessId: "enterprise_municipal_readiness:enterprise-v1:municipality",
+        organizationType: "municipality",
+        status: "ready_for_review",
+        manualApprovalRequired: true,
+        autonomousGovernmentExecutionEnabled: false,
+        autonomousEnterpriseExecutionEnabled: false,
+      })
+    );
+  });
+
+  it("requires review when municipal and evidence lineage are missing", () => {
+    const profile = deriveEnterpriseMunicipalReadinessProfile({
+      ...completeInput,
+      municipalReadiness: [],
+      evidencePacks: [],
+    });
+
+    expect(profile.status).toBe("review_required");
+    expect(profile.enterpriseRestrictions.some((restriction) => restriction.status === "review_required")).toBe(true);
+    expect(profile.canonicalEvents.map((event) => event.eventType)).toContain("enterprise_municipal_review_required");
+  });
+
+  it("blocks unresolved operational-risk restrictions", () => {
+    const profile = deriveEnterpriseMunicipalReadinessProfile({
+      ...completeInput,
+      operationalRiskProfiles: [{ operationalRiskId: "risk-1", status: "blocked" }],
+    });
+
+    expect(profile.status).toBe("blocked");
+    expect(profile.blockedReasons).toContain("Unresolved operational risk blocks enterprise and municipal readiness.");
+    expect(profile.canonicalEvents.map((event) => event.eventType)).toContain("enterprise_municipal_blocked");
+  });
+
+  it("returns unknown without source context", () => {
+    const profile = deriveEnterpriseMunicipalReadinessProfile({ readinessKey: "enterprise-v1", organizationType: "government_program" });
+
+    expect(profile.status).toBe("unknown");
+    expect(profile.manualApprovalRequired).toBe(true);
+    expect(profile.autonomousGovernmentExecutionEnabled).toBe(false);
+    expect(profile.autonomousEnterpriseExecutionEnabled).toBe(false);
+  });
+
+  it("preserves redaction visibility for redacted audit lineage", () => {
+    const profile = deriveEnterpriseMunicipalReadinessProfile({
+      ...completeInput,
+      auditEvents: [{ eventId: "event-1", eventType: "enterprise_municipal_redaction_applied", redacted: true }],
+    });
+
+    expect(profile.auditReferences[0]).toEqual(expect.objectContaining({ redacted: true, status: "partially_verified" }));
+    expect(profile.canonicalEvents.map((event) => event.eventType)).toContain("enterprise_municipal_redaction_applied");
+  });
+});

--- a/rentchain-api/src/lib/enterpriseMunicipalReadiness/deriveEnterpriseMunicipalReadinessProfile.ts
+++ b/rentchain-api/src/lib/enterpriseMunicipalReadiness/deriveEnterpriseMunicipalReadinessProfile.ts
@@ -1,0 +1,337 @@
+import type {
+  DeriveEnterpriseMunicipalReadinessProfileInput,
+  EnterpriseMunicipalCanonicalEvent,
+  EnterpriseMunicipalOrganizationType,
+  EnterpriseMunicipalReadinessProfile,
+  EnterpriseMunicipalReadinessStatus,
+  EnterpriseMunicipalReference,
+  EnterpriseMunicipalReferenceStatus,
+  EnterpriseMunicipalReferenceType,
+} from "./enterpriseMunicipalReadinessTypes";
+import {
+  enterpriseMunicipalIdPart,
+  enterpriseMunicipalReference,
+  enterpriseMunicipalRestriction,
+} from "./enterpriseRestrictionModels";
+
+const DEFAULT_KEY = "institutional-scale-enterprise-municipal-readiness-v1";
+const ORGANIZATION_TYPES = new Set<EnterpriseMunicipalOrganizationType>([
+  "municipality",
+  "affordable_housing_operator",
+  "institutional_landlord",
+  "enterprise_operator",
+  "government_program",
+]);
+
+const REDACTIONS = [
+  "Sensitive tenant, screening, credit bureau, payment, banking, and private document payloads are excluded.",
+  "Government integration payloads, CMHC submission payloads, unrestricted public-sector exports, and municipal system credentials are excluded.",
+  "Enterprise and municipal readiness is visibility metadata only; no autonomous government or enterprise execution is enabled.",
+  "Unrestricted portfolio exposure, hidden institutional orchestration, and admin-only operational payloads are excluded.",
+];
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function asArray<T>(value: T[] | null | undefined): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function generatedAt(value: unknown): string {
+  const raw = asString(value, 120);
+  const date = raw ? new Date(raw) : new Date(0);
+  return Number.isNaN(date.getTime()) ? new Date(0).toISOString() : date.toISOString();
+}
+
+function normalizeOrganizationType(value: unknown): EnterpriseMunicipalOrganizationType {
+  const raw = asString(value, 80) as EnterpriseMunicipalOrganizationType;
+  return ORGANIZATION_TYPES.has(raw) ? raw : "enterprise_operator";
+}
+
+function recordId(record: Record<string, any>, keys: string[]): string {
+  for (const key of keys) {
+    const value = asString(record?.[key], 240);
+    if (value) return value;
+  }
+  return asString(record?.id, 240);
+}
+
+function statusFromRecord(record: Record<string, any>, verifiedStatuses: string[]): EnterpriseMunicipalReferenceStatus {
+  const status = asString(record?.status || record?.state || record?.conclusion || record?.severity, 80).toLowerCase();
+  if (["blocked", "critical", "major", "failed", "failure", "error", "cancelled"].includes(status)) return "blocked";
+  if (verifiedStatuses.includes(status)) return "verified";
+  if (["missing", "unknown", "unavailable", "pending"].includes(status)) return "unavailable";
+  return "partially_verified";
+}
+
+function profileStatus(hasContext: boolean, references: EnterpriseMunicipalReference[]): EnterpriseMunicipalReadinessStatus {
+  if (!hasContext) return "unknown";
+  if (references.some((reference) => reference.status === "blocked" && (reference.referenceType === "operational_risk" || reference.referenceType === "regulatory"))) return "blocked";
+  const criticalMissing = references.some(
+    (reference) =>
+      reference.status === "unavailable" &&
+      (reference.referenceType === "institutional" ||
+        reference.referenceType === "municipal" ||
+        reference.referenceType === "regulatory" ||
+        reference.referenceType === "review" ||
+        reference.referenceType === "evidence")
+  );
+  if (criticalMissing) return "review_required";
+  if (references.some((reference) => reference.status === "blocked" || reference.status === "unavailable" || reference.status === "partially_verified")) return "partially_ready";
+  return "ready_for_review";
+}
+
+function event(input: {
+  eventType: EnterpriseMunicipalCanonicalEvent["eventType"];
+  status: EnterpriseMunicipalReadinessStatus;
+  enterpriseMunicipalReadinessId: string;
+  summary: string;
+}): EnterpriseMunicipalCanonicalEvent {
+  return {
+    eventType: input.eventType,
+    action: input.eventType.replace(/^enterprise_municipal_/, "").replace(/_/g, "."),
+    status: input.status,
+    resourceType: "enterprise_municipal_readiness_profile",
+    resourceId: input.enterpriseMunicipalReadinessId,
+    summary: input.summary,
+  };
+}
+
+function statusForType(referenceType: EnterpriseMunicipalReferenceType, record: Record<string, any>): EnterpriseMunicipalReferenceStatus {
+  if (referenceType === "audit" && asString(record?.eventType || record?.type, 120)) return record.redacted ? "partially_verified" : "verified";
+  if (referenceType === "institutional") return statusFromRecord(record, ["ready_for_review", "verified", "active", "stable"]);
+  if (referenceType === "municipal") return statusFromRecord(record, ["ready_for_review", "verified", "ready", "matched"]);
+  if (referenceType === "portfolio_governance") return statusFromRecord(record, ["ready_for_review", "verified", "healthy", "stable", "available"]);
+  if (referenceType === "regulatory") return statusFromRecord(record, ["ready_for_review", "verified"]);
+  if (referenceType === "operational_risk") return statusFromRecord(record, ["stable", "verified", "accepted", "resolved"]);
+  if (referenceType === "review") return statusFromRecord(record, ["ready_for_review", "completed", "verified", "reviewed"]);
+  return statusFromRecord(record, ["ready_for_review", "verified", "available", "completed", "stable"]);
+}
+
+function referencesFor(input: {
+  records: Record<string, any>[];
+  fallback: string;
+  referenceType: EnterpriseMunicipalReferenceType;
+  idKeys: string[];
+  label: string;
+  description: string;
+  destination: string;
+  blockedReason: string;
+}): EnterpriseMunicipalReference[] {
+  if (!input.records.length) {
+    return [
+      enterpriseMunicipalReference({
+        idParts: [input.referenceType, "missing"],
+        referenceType: input.referenceType,
+        status: "unavailable",
+        label: input.label,
+        description: `${input.description} is unavailable for enterprise and municipal readiness review.`,
+        destination: input.destination,
+      }),
+    ];
+  }
+  return input.records.map((record, index) => {
+    const id = recordId(record, input.idKeys) || `${input.fallback}-${index + 1}`;
+    const status = statusForType(input.referenceType, record);
+    return enterpriseMunicipalReference({
+      idParts: [input.referenceType, id],
+      referenceType: input.referenceType,
+      status,
+      label: input.label,
+      description: `${input.description} is available as institutional readiness metadata.`,
+      lineageReferences: [id].filter(Boolean),
+      destination: input.destination,
+      redacted: Boolean(record.redacted),
+      redactionReason: record.redacted ? `${input.label} payload is redacted for enterprise and municipal readiness safety.` : null,
+      blockedReason: status === "blocked" ? input.blockedReason : null,
+    });
+  });
+}
+
+export function deriveEnterpriseMunicipalReadinessProfile(input: DeriveEnterpriseMunicipalReadinessProfileInput): EnterpriseMunicipalReadinessProfile {
+  const organizationType = normalizeOrganizationType(input.organizationType);
+  const readinessKey = asString(input.readinessKey, 160) || DEFAULT_KEY;
+  const enterpriseMunicipalReadinessId =
+    enterpriseMunicipalIdPart(["enterprise_municipal_readiness", readinessKey, organizationType].join(":")) ||
+    "enterprise_municipal_readiness:unknown";
+
+  const institutionalReadiness = asArray(input.institutionalReadiness);
+  const portfolioGovernance = asArray(input.portfolioGovernance);
+  const municipalReadiness = asArray(input.municipalReadiness);
+  const regulatoryProfiles = asArray(input.regulatoryProfiles);
+  const operationalRiskProfiles = asArray(input.operationalRiskProfiles);
+  const reviews = asArray(input.operatorReviewSessions);
+  const evidencePacks = asArray(input.evidencePacks);
+  const auditEvents = asArray(input.auditEvents);
+
+  const institutionalReferences = referencesFor({
+    records: institutionalReadiness,
+    fallback: "institutional",
+    referenceType: "institutional",
+    idKeys: ["onboardingReadinessId", "institutionOnboardingId", "commercialReadinessId", "platformCredentialingId", "id"],
+    label: "Institutional readiness reference",
+    description: "Enterprise onboarding, credentialing, and institutional governance readiness",
+    destination: "/institution-onboarding-readiness",
+    blockedReason: "Institutional readiness is blocked.",
+  });
+  const portfolioGovernanceReferences = referencesFor({
+    records: portfolioGovernance,
+    fallback: "portfolio-governance",
+    referenceType: "portfolio_governance",
+    idKeys: ["portfolioGovernanceId", "portfolioId", "portfolioScoreId", "id"],
+    label: "Portfolio governance reference",
+    description: "Portfolio governance and operational-scale readiness",
+    destination: "/portfolio-health",
+    blockedReason: "Portfolio governance readiness is blocked.",
+  });
+  const municipalReadinessReferences = referencesFor({
+    records: municipalReadiness,
+    fallback: "municipal",
+    referenceType: "municipal",
+    idKeys: ["municipalReadinessId", "productionIntegrationId", "adapterReadinessId", "registryStatusId", "id"],
+    label: "Municipal readiness reference",
+    description: "Municipal, registry, affordable-housing, and public-sector preparedness",
+    destination: "/admin/production-integrations",
+    blockedReason: "Municipal readiness lineage is blocked.",
+  });
+  const regulatoryReferences = referencesFor({
+    records: regulatoryProfiles,
+    fallback: "regulatory",
+    referenceType: "regulatory",
+    idKeys: ["regulatoryProfileId", "id"],
+    label: "Regulatory readiness reference",
+    description: "Regulatory and governance dependency readiness",
+    destination: "/regulatory-profiles",
+    blockedReason: "Regulatory readiness blocks enterprise and municipal readiness.",
+  });
+  const operationalRiskReferences = referencesFor({
+    records: operationalRiskProfiles,
+    fallback: "operational-risk",
+    referenceType: "operational_risk",
+    idKeys: ["operationalRiskId", "operationalRiskProfileId", "riskId", "id"],
+    label: "Operational risk reference",
+    description: "Operational-risk dependency readiness",
+    destination: "/operational-risk",
+    blockedReason: "Unresolved operational risk blocks enterprise and municipal readiness.",
+  });
+  const reviewReferences = referencesFor({
+    records: reviews,
+    fallback: "review",
+    referenceType: "review",
+    idKeys: ["reviewSessionId", "operatorReviewId", "id"],
+    label: "Institutional review lineage reference",
+    description: "Manual review lineage",
+    destination: "/review-timeline",
+    blockedReason: "Institutional review lineage is blocked.",
+  });
+  const evidenceReferences = referencesFor({
+    records: evidencePacks,
+    fallback: "evidence",
+    referenceType: "evidence",
+    idKeys: ["evidencePackId", "id"],
+    label: "Institutional evidence lineage reference",
+    description: "Evidence lineage",
+    destination: "/evidence-packs",
+    blockedReason: "Institutional evidence lineage is blocked.",
+  });
+  const auditReferences = referencesFor({
+    records: auditEvents.slice(0, 20),
+    fallback: "audit",
+    referenceType: "audit",
+    idKeys: ["eventId", "auditId", "id"],
+    label: "Institutional audit lineage reference",
+    description: "Audit lineage",
+    destination: "/review-timeline",
+    blockedReason: "Institutional audit lineage is blocked.",
+  });
+
+  const allReferences = [
+    ...institutionalReferences,
+    ...portfolioGovernanceReferences,
+    ...municipalReadinessReferences,
+    ...regulatoryReferences,
+    ...operationalRiskReferences,
+    ...reviewReferences,
+    ...evidenceReferences,
+    ...auditReferences,
+  ];
+  const hasContext = Boolean(
+    institutionalReadiness.length ||
+      portfolioGovernance.length ||
+      municipalReadiness.length ||
+      regulatoryProfiles.length ||
+      operationalRiskProfiles.length ||
+      reviews.length ||
+      evidencePacks.length ||
+      auditEvents.length
+  );
+  const status = profileStatus(hasContext, allReferences);
+  const enterpriseRestrictions = allReferences
+    .filter((reference) => reference.status !== "verified")
+    .map((reference) =>
+      enterpriseMunicipalRestriction({
+        idParts: [reference.referenceType, reference.referenceId],
+        restrictionType: reference.referenceType,
+        status: reference.status === "blocked" ? "blocked" : "review_required",
+        label: `${reference.label} restriction`,
+        description: `${reference.label} is incomplete or blocked for enterprise and municipal readiness review.`,
+        blockedReason: reference.blockedReason,
+      })
+    );
+  const blockedReasons = [...allReferences.map((reference) => reference.blockedReason), ...enterpriseRestrictions.map((restriction) => restriction.blockedReason)].filter(Boolean) as string[];
+
+  const canonicalEvents: EnterpriseMunicipalCanonicalEvent[] = [
+    event({
+      eventType: "enterprise_municipal_readiness_profile_derived",
+      status,
+      enterpriseMunicipalReadinessId,
+      summary: "Enterprise municipal readiness profile derived from institutional, municipal, portfolio, regulatory, risk, review, evidence, and audit metadata.",
+    }),
+    event({
+      eventType: "enterprise_municipal_redaction_applied",
+      status,
+      enterpriseMunicipalReadinessId,
+      summary: "Sensitive tenant, screening, payment, banking, public-sector, CMHC submission, portfolio, and admin-only payloads were excluded.",
+    }),
+  ];
+  if (enterpriseRestrictions.length) {
+    canonicalEvents.push(event({ eventType: "enterprise_municipal_restriction_detected", status, enterpriseMunicipalReadinessId, summary: "Enterprise municipal restrictions are visible for manual review." }));
+  }
+  if (status === "review_required" || status === "partially_ready") {
+    canonicalEvents.push(event({ eventType: "enterprise_municipal_review_required", status, enterpriseMunicipalReadinessId, summary: "Manual enterprise municipal review is required." }));
+  }
+  if (status === "blocked") {
+    canonicalEvents.push(event({ eventType: "enterprise_municipal_blocked", status, enterpriseMunicipalReadinessId, summary: "Enterprise municipal readiness is blocked by unresolved restrictions." }));
+  }
+
+  return {
+    enterpriseMunicipalReadinessId,
+    organizationType,
+    status,
+    manualApprovalRequired: true,
+    autonomousGovernmentExecutionEnabled: false,
+    autonomousEnterpriseExecutionEnabled: false,
+    generatedAt: generatedAt(input.generatedAt),
+    summary: {
+      totalReferences: allReferences.length,
+      verifiedReferences: allReferences.filter((reference) => reference.status === "verified").length,
+      partiallyVerifiedReferences: allReferences.filter((reference) => reference.status === "partially_verified").length,
+      blockedReferences: allReferences.filter((reference) => reference.status === "blocked").length,
+      unavailableReferences: allReferences.filter((reference) => reference.status === "unavailable").length,
+      restrictions: enterpriseRestrictions.length,
+    },
+    institutionalReferences,
+    portfolioGovernanceReferences,
+    municipalReadinessReferences,
+    regulatoryReferences,
+    operationalRiskReferences,
+    reviewReferences,
+    evidenceReferences,
+    auditReferences,
+    enterpriseRestrictions,
+    redactions: REDACTIONS,
+    blockedReasons,
+    canonicalEvents,
+  };
+}

--- a/rentchain-api/src/lib/enterpriseMunicipalReadiness/enterpriseMunicipalReadinessTypes.ts
+++ b/rentchain-api/src/lib/enterpriseMunicipalReadiness/enterpriseMunicipalReadinessTypes.ts
@@ -1,0 +1,110 @@
+export type EnterpriseMunicipalOrganizationType =
+  | "municipality"
+  | "affordable_housing_operator"
+  | "institutional_landlord"
+  | "enterprise_operator"
+  | "government_program";
+
+export type EnterpriseMunicipalReadinessStatus = "ready_for_review" | "partially_ready" | "review_required" | "blocked" | "unknown";
+
+export type EnterpriseMunicipalReferenceType =
+  | "institutional"
+  | "municipal"
+  | "portfolio_governance"
+  | "regulatory"
+  | "operational_risk"
+  | "review"
+  | "evidence"
+  | "audit";
+
+export type EnterpriseMunicipalReferenceStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+
+export type EnterpriseMunicipalCanonicalEventType =
+  | "enterprise_municipal_readiness_profile_derived"
+  | "enterprise_municipal_review_required"
+  | "enterprise_municipal_blocked"
+  | "enterprise_municipal_restriction_detected"
+  | "enterprise_municipal_redaction_applied";
+
+export type EnterpriseMunicipalReference = {
+  referenceId: string;
+  referenceType: EnterpriseMunicipalReferenceType;
+  status: EnterpriseMunicipalReferenceStatus;
+  label: string;
+  description: string;
+  reviewRequired: true;
+  lineageReferences: string[];
+  destination: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type EnterpriseMunicipalRestriction = {
+  restrictionId: string;
+  restrictionType:
+    | EnterpriseMunicipalReferenceType
+    | "government_integration"
+    | "cmhc_submission"
+    | "public_sector_export"
+    | "portfolio_exposure"
+    | "enterprise_onboarding_execution"
+    | "institutional_orchestration";
+  status: "visible" | "blocked" | "review_required";
+  label: string;
+  description: string;
+  blockedReason: string | null;
+};
+
+export type EnterpriseMunicipalCanonicalEvent = {
+  eventType: EnterpriseMunicipalCanonicalEventType;
+  action: string;
+  status: EnterpriseMunicipalReadinessStatus;
+  resourceType: "enterprise_municipal_readiness_profile";
+  resourceId: string;
+  summary: string;
+};
+
+export type EnterpriseMunicipalReadinessProfile = {
+  enterpriseMunicipalReadinessId: string;
+  organizationType: EnterpriseMunicipalOrganizationType;
+  status: EnterpriseMunicipalReadinessStatus;
+  manualApprovalRequired: true;
+  autonomousGovernmentExecutionEnabled: false;
+  autonomousEnterpriseExecutionEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    partiallyVerifiedReferences: number;
+    blockedReferences: number;
+    unavailableReferences: number;
+    restrictions: number;
+  };
+  institutionalReferences: EnterpriseMunicipalReference[];
+  portfolioGovernanceReferences: EnterpriseMunicipalReference[];
+  municipalReadinessReferences: EnterpriseMunicipalReference[];
+  regulatoryReferences: EnterpriseMunicipalReference[];
+  operationalRiskReferences: EnterpriseMunicipalReference[];
+  reviewReferences: EnterpriseMunicipalReference[];
+  evidenceReferences: EnterpriseMunicipalReference[];
+  auditReferences: EnterpriseMunicipalReference[];
+  enterpriseRestrictions: EnterpriseMunicipalRestriction[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: EnterpriseMunicipalCanonicalEvent[];
+};
+
+export type DeriveEnterpriseMunicipalReadinessProfileInput = {
+  readinessKey?: unknown;
+  organizationType?: unknown;
+  generatedAt?: unknown;
+  institutionalReadiness?: Array<Record<string, any>> | null;
+  portfolioGovernance?: Array<Record<string, any>> | null;
+  municipalReadiness?: Array<Record<string, any>> | null;
+  regulatoryProfiles?: Array<Record<string, any>> | null;
+  operationalRiskProfiles?: Array<Record<string, any>> | null;
+  operatorReviewSessions?: Array<Record<string, any>> | null;
+  evidencePacks?: Array<Record<string, any>> | null;
+  auditEvents?: Array<Record<string, any>> | null;
+};

--- a/rentchain-api/src/lib/enterpriseMunicipalReadiness/enterpriseRestrictionModels.ts
+++ b/rentchain-api/src/lib/enterpriseMunicipalReadiness/enterpriseRestrictionModels.ts
@@ -1,0 +1,65 @@
+import type {
+  EnterpriseMunicipalReference,
+  EnterpriseMunicipalReferenceStatus,
+  EnterpriseMunicipalReferenceType,
+  EnterpriseMunicipalRestriction,
+} from "./enterpriseMunicipalReadinessTypes";
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+export function enterpriseMunicipalIdPart(value: unknown): string {
+  return asString(value, 500)
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+export function enterpriseMunicipalReference(input: {
+  idParts: unknown[];
+  referenceType: EnterpriseMunicipalReferenceType;
+  status: EnterpriseMunicipalReferenceStatus;
+  label: string;
+  description: string;
+  lineageReferences?: string[];
+  destination?: string | null;
+  redacted?: boolean;
+  redactionReason?: string | null;
+  blockedReason?: string | null;
+}): EnterpriseMunicipalReference {
+  return {
+    referenceId: enterpriseMunicipalIdPart(input.idParts.filter(Boolean).join(":")) || "enterprise_municipal_reference:unknown",
+    referenceType: input.referenceType,
+    status: input.status,
+    label: input.label,
+    description: input.description,
+    reviewRequired: true,
+    lineageReferences: Array.from(new Set(input.lineageReferences || [])).filter(Boolean),
+    destination: input.destination || null,
+    redacted: Boolean(input.redacted),
+    redactionReason: input.redactionReason || null,
+    blockedReason: input.blockedReason || null,
+  };
+}
+
+export function enterpriseMunicipalRestriction(input: {
+  idParts: unknown[];
+  restrictionType: EnterpriseMunicipalRestriction["restrictionType"];
+  status: EnterpriseMunicipalRestriction["status"];
+  label: string;
+  description: string;
+  blockedReason?: string | null;
+}): EnterpriseMunicipalRestriction {
+  return {
+    restrictionId:
+      enterpriseMunicipalIdPart(["enterprise_municipal_restriction", ...input.idParts].filter(Boolean).join(":")) ||
+      "enterprise_municipal_restriction:unknown",
+    restrictionType: input.restrictionType,
+    status: input.status,
+    label: input.label,
+    description: input.description,
+    blockedReason: input.blockedReason || null,
+  };
+}

--- a/rentchain-api/src/routes/__tests__/adminEnterpriseMunicipalReadinessRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/adminEnterpriseMunicipalReadinessRoutes.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fakeDb, resetFakeDb, seedDoc } = vi.hoisted(() => {
+  const store = new Map<string, Map<string, any>>();
+  function ensureCollection(name: string) {
+    if (!store.has(name)) store.set(name, new Map());
+    return store.get(name)!;
+  }
+  return {
+    resetFakeDb: () => store.clear(),
+    seedDoc: (collection: string, id: string, data: any) => ensureCollection(collection).set(id, { id, data }),
+    fakeDb: {
+      collection: (name: string) => ({
+        get: async () => {
+          const docs = Array.from(ensureCollection(name).values()).map((doc) => ({ id: doc.id, exists: true, data: () => doc.data }));
+          return { docs, empty: docs.length === 0, size: docs.length };
+        },
+      }),
+    },
+  };
+});
+
+let mockUser: any;
+
+vi.mock("../../config/firebase", () => ({ db: fakeDb }));
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!mockUser) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    req.user = mockUser;
+    return next();
+  },
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; user?: Record<string, unknown> | null }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const [path, queryString] = options.url.split("?");
+    mockUser = options.user ?? mockUser;
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path,
+      user: mockUser,
+      query: Object.fromEntries(new URLSearchParams(queryString || "").entries()),
+      params: {},
+      headers: {},
+    };
+    const match = path.match(/^\/enterprise-municipal-readiness\/(.+)$/);
+    if (match) req.params = { enterpriseMunicipalReadinessId: decodeURIComponent(match[1]) };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => (error ? reject(error) : undefined));
+  });
+}
+
+describe("adminEnterpriseMunicipalReadinessRoutes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    resetFakeDb();
+    mockUser = { id: "admin-1", role: "admin", permissions: ["system.admin"] };
+  });
+
+  function seedReadinessContext() {
+    seedDoc("institutionOnboardingReadiness", "institution-1", { onboardingReadinessId: "institution-1", institutionType: "municipality", status: "ready_for_review", rawGovernmentId: "hidden" });
+    seedDoc("commercialReadinessProfiles", "commercial-1", { commercialReadinessId: "commercial-1", status: "ready_for_review", adminOnlyPayload: "hidden" });
+    seedDoc("platformCredentialingReadiness", "credentialing-1", { platformCredentialingId: "credentialing-1", status: "ready_for_review", providerCredential: "hidden" });
+    seedDoc("portfolioGovernanceReadiness", "portfolio-1", { portfolioGovernanceId: "portfolio-1", status: "ready_for_review", privateTenantData: "hidden" });
+    seedDoc("productionIntegrationMetadata", "municipal-1", { municipalReadinessId: "municipal-1", organizationType: "municipality", status: "ready_for_review", governmentCredential: "hidden" });
+    seedDoc("interoperabilityAdapterReadiness", "adapter-1", { adapterReadinessId: "adapter-1", adapterType: "registry", status: "ready_for_review", providerToken: "hidden" });
+    seedDoc("regulatoryProfiles", "regulatory-1", { regulatoryProfileId: "regulatory-1", status: "ready_for_review", rawRegistryPayload: "hidden" });
+    seedDoc("operationalRiskProfiles", "risk-1", { operationalRiskId: "risk-1", status: "stable", privateRiskPayload: "hidden" });
+    seedDoc("operatorReviewSessions", "review-1", { reviewSessionId: "review-1", status: "completed", privateNote: "hidden" });
+    seedDoc("evidencePacks", "evidence-1", { evidencePackId: "evidence-1", status: "ready_for_review", creditBureauPayload: "hidden" });
+    seedDoc("events", "event-1", { eventId: "event-1", eventType: "enterprise_municipal_readiness_profile_derived", rawPaymentPayload: "hidden" });
+  }
+
+  it("returns admin-gated profiles without sensitive institutional payloads", async () => {
+    seedReadinessContext();
+    const router = (await import("../adminEnterpriseMunicipalReadinessRoutes")).default;
+
+    const forbidden = await invokeRouter(router, {
+      method: "GET",
+      url: "/enterprise-municipal-readiness",
+      user: { id: "landlord-1", role: "landlord", permissions: [] },
+    });
+    expect(forbidden.status).toBe(403);
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/enterprise-municipal-readiness?organizationType=municipality",
+      user: { id: "admin-1", role: "admin", permissions: ["system.admin"] },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.profiles).toHaveLength(1);
+    expect(res.body.profiles[0]).toEqual(
+      expect.objectContaining({
+        manualApprovalRequired: true,
+        autonomousGovernmentExecutionEnabled: false,
+        autonomousEnterpriseExecutionEnabled: false,
+      })
+    );
+    const payload = JSON.stringify(res.body);
+    expect(payload).not.toContain("rawGovernmentId");
+    expect(payload).not.toContain("adminOnlyPayload");
+    expect(payload).not.toContain("providerCredential");
+    expect(payload).not.toContain("privateTenantData");
+    expect(payload).not.toContain("governmentCredential");
+    expect(payload).not.toContain("providerToken");
+    expect(payload).not.toContain("rawRegistryPayload");
+    expect(payload).not.toContain("creditBureauPayload");
+    expect(payload).not.toContain("rawPaymentPayload");
+  });
+
+  it("returns a single enterprise municipal profile by id and filters by status", async () => {
+    seedReadinessContext();
+    const router = (await import("../adminEnterpriseMunicipalReadinessRoutes")).default;
+    const list = await invokeRouter(router, { method: "GET", url: "/enterprise-municipal-readiness?organizationType=municipality" });
+    const id = list.body.profiles[0].enterpriseMunicipalReadinessId;
+
+    const one = await invokeRouter(router, { method: "GET", url: `/enterprise-municipal-readiness/${encodeURIComponent(id)}` });
+    const filtered = await invokeRouter(router, { method: "GET", url: "/enterprise-municipal-readiness?status=blocked" });
+
+    expect(one.status).toBe(200);
+    expect(one.body.profile.enterpriseMunicipalReadinessId).toBe(id);
+    expect(filtered.status).toBe(200);
+    expect(filtered.body.profiles).toEqual([]);
+  });
+});

--- a/rentchain-api/src/routes/adminEnterpriseMunicipalReadinessRoutes.ts
+++ b/rentchain-api/src/routes/adminEnterpriseMunicipalReadinessRoutes.ts
@@ -1,0 +1,173 @@
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { requireAuth } from "../middleware/requireAuth";
+import { requirePermission } from "../middleware/requireAuthz";
+import { deriveEnterpriseMunicipalReadinessProfile } from "../lib/enterpriseMunicipalReadiness/deriveEnterpriseMunicipalReadinessProfile";
+import type {
+  EnterpriseMunicipalOrganizationType,
+  EnterpriseMunicipalReadinessProfile,
+  EnterpriseMunicipalReadinessStatus,
+} from "../lib/enterpriseMunicipalReadiness/enterpriseMunicipalReadinessTypes";
+
+const router = Router();
+const READINESS_KEY = "institutional-scale-enterprise-municipal-readiness-v1";
+
+const ORGANIZATION_TYPES: EnterpriseMunicipalOrganizationType[] = [
+  "municipality",
+  "affordable_housing_operator",
+  "institutional_landlord",
+  "enterprise_operator",
+  "government_program",
+];
+const STATUSES = new Set<EnterpriseMunicipalReadinessStatus>(["ready_for_review", "partially_ready", "review_required", "blocked", "unknown"]);
+
+function asString(value: unknown, max = 500): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function sanitizeRecord(record: Record<string, any>) {
+  const safe: Record<string, any> = {};
+  for (const key of [
+    "id",
+    "status",
+    "state",
+    "conclusion",
+    "severity",
+    "organizationType",
+    "institutionType",
+    "participantType",
+    "integrationType",
+    "onboardingReadinessId",
+    "institutionOnboardingId",
+    "commercialReadinessId",
+    "platformCredentialingId",
+    "portfolioGovernanceId",
+    "portfolioId",
+    "portfolioScoreId",
+    "municipalReadinessId",
+    "productionIntegrationId",
+    "adapterReadinessId",
+    "registryStatusId",
+    "regulatoryProfileId",
+    "operationalRiskId",
+    "operationalRiskProfileId",
+    "riskId",
+    "reviewSessionId",
+    "operatorReviewId",
+    "evidencePackId",
+    "eventId",
+    "eventType",
+    "resourceType",
+    "resourceId",
+    "createdAt",
+    "updatedAt",
+    "redacted",
+  ]) {
+    if (record[key] !== undefined) safe[key] = record[key];
+  }
+  return safe;
+}
+
+async function loadCollection(collectionName: string, limit = 30) {
+  const snap = await db.collection(collectionName).get().catch(() => null);
+  return (snap?.docs || []).slice(0, limit).map((doc) => sanitizeRecord({ id: doc.id, ...((doc.data() as any) || {}) }));
+}
+
+function organizationTypeFromQuery(value: unknown): EnterpriseMunicipalOrganizationType | "" {
+  const raw = asString(value, 80) as EnterpriseMunicipalOrganizationType;
+  return ORGANIZATION_TYPES.includes(raw) ? raw : "";
+}
+
+function matchesOrganizationType(record: Record<string, any>, organizationType: EnterpriseMunicipalOrganizationType) {
+  const type = asString(record.organizationType || record.institutionType || record.participantType, 80);
+  if (!type) return true;
+  if (organizationType === "municipality") return type === "municipality" || type === "registry";
+  if (organizationType === "institutional_landlord") return type === "institutional_landlord" || type === "enterprise_operator";
+  return type === organizationType;
+}
+
+async function buildEnterpriseMunicipalReadinessProfiles(organizationTypeFilter: EnterpriseMunicipalOrganizationType | ""): Promise<EnterpriseMunicipalReadinessProfile[]> {
+  const [
+    institutionOnboardingReadiness,
+    commercialReadinessProfiles,
+    platformCredentialingReadiness,
+    portfolioGovernance,
+    portfolioScores,
+    productionIntegrations,
+    interoperabilityReadiness,
+    regulatoryProfiles,
+    operationalRiskProfiles,
+    reviews,
+    evidencePacks,
+    auditEvents,
+  ] = await Promise.all([
+    loadCollection("institutionOnboardingReadiness"),
+    loadCollection("commercialReadinessProfiles"),
+    loadCollection("platformCredentialingReadiness"),
+    loadCollection("portfolioGovernanceReadiness"),
+    loadCollection("portfolioScores"),
+    loadCollection("productionIntegrationMetadata"),
+    loadCollection("interoperabilityAdapterReadiness"),
+    loadCollection("regulatoryProfiles"),
+    loadCollection("operationalRiskProfiles"),
+    loadCollection("operatorReviewSessions"),
+    loadCollection("evidencePacks"),
+    loadCollection("events"),
+  ]);
+
+  const types = organizationTypeFilter ? [organizationTypeFilter] : ORGANIZATION_TYPES;
+  return types.map((organizationType) =>
+    deriveEnterpriseMunicipalReadinessProfile({
+      readinessKey: READINESS_KEY,
+      organizationType,
+      institutionalReadiness: [
+        ...institutionOnboardingReadiness.filter((record) => matchesOrganizationType(record, organizationType)),
+        ...commercialReadinessProfiles,
+        ...platformCredentialingReadiness,
+      ],
+      portfolioGovernance: [...portfolioGovernance, ...portfolioScores],
+      municipalReadiness: [
+        ...productionIntegrations.filter((record) => matchesOrganizationType(record, organizationType)),
+        ...interoperabilityReadiness.filter((record) => matchesOrganizationType(record, organizationType)),
+      ],
+      regulatoryProfiles,
+      operationalRiskProfiles,
+      operatorReviewSessions: reviews,
+      evidencePacks,
+      auditEvents,
+    })
+  );
+}
+
+function profileMatches(profile: EnterpriseMunicipalReadinessProfile, id: string) {
+  return profile.enterpriseMunicipalReadinessId === id;
+}
+
+router.get("/enterprise-municipal-readiness", requireAuth, requirePermission("system.admin"), async (req: any, res) => {
+  try {
+    const organizationType = organizationTypeFromQuery(req.query?.organizationType);
+    const status = asString(req.query?.status, 80) as EnterpriseMunicipalReadinessStatus;
+    let profiles = await buildEnterpriseMunicipalReadinessProfiles(organizationType);
+    if (status && STATUSES.has(status)) profiles = profiles.filter((profile) => profile.status === status);
+    return res.json({ ok: true, profiles });
+  } catch (err: any) {
+    console.error("[admin-enterprise-municipal-readiness] list failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "ENTERPRISE_MUNICIPAL_READINESS_FAILED" });
+  }
+});
+
+router.get("/enterprise-municipal-readiness/:enterpriseMunicipalReadinessId", requireAuth, requirePermission("system.admin"), async (req: any, res) => {
+  try {
+    const enterpriseMunicipalReadinessId = decodeURIComponent(asString(req.params?.enterpriseMunicipalReadinessId, 500));
+    if (!enterpriseMunicipalReadinessId) return res.status(400).json({ ok: false, error: "ENTERPRISE_MUNICIPAL_READINESS_ID_REQUIRED" });
+    const profiles = await buildEnterpriseMunicipalReadinessProfiles("");
+    const profile = profiles.find((next) => profileMatches(next, enterpriseMunicipalReadinessId));
+    if (!profile) return res.status(404).json({ ok: false, error: "ENTERPRISE_MUNICIPAL_READINESS_NOT_FOUND" });
+    return res.json({ ok: true, profile });
+  } catch (err: any) {
+    console.error("[admin-enterprise-municipal-readiness] get failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "ENTERPRISE_MUNICIPAL_READINESS_GET_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -117,6 +117,7 @@ const PublicExposureHardeningPage = lazy(() => import("./pages/PublicExposureHar
 const CommercialReadinessPage = lazy(() => import("./pages/CommercialReadinessPage"));
 const ControlledIntegrationsPage = lazy(() => import("./pages/ControlledIntegrationsPage"));
 const ProductionIntegrationsPage = lazy(() => import("./pages/ProductionIntegrationsPage"));
+const EnterpriseMunicipalReadinessPage = lazy(() => import("./pages/EnterpriseMunicipalReadinessPage"));
 const EcosystemCoordinationPage = lazy(() => import("./pages/EcosystemCoordinationPage"));
 const PlatformCredentialingReadinessPage = lazy(() => import("./pages/PlatformCredentialingReadinessPage"));
 const ConsumerReportingGovernancePage = lazy(() => import("./pages/ConsumerReportingGovernancePage"));
@@ -1387,6 +1388,14 @@ function App() {
               element={
                 <RequireAdmin>
                   <ProductionIntegrationsPage />
+                </RequireAdmin>
+              }
+            />
+            <Route
+              path="/admin/enterprise-municipal-readiness"
+              element={
+                <RequireAdmin>
+                  <EnterpriseMunicipalReadinessPage />
                 </RequireAdmin>
               }
             />

--- a/rentchain-frontend/src/api/enterpriseMunicipalReadinessApi.ts
+++ b/rentchain-frontend/src/api/enterpriseMunicipalReadinessApi.ts
@@ -1,0 +1,97 @@
+import { apiFetch } from "./apiFetch";
+
+export type EnterpriseMunicipalOrganizationType =
+  | "municipality"
+  | "affordable_housing_operator"
+  | "institutional_landlord"
+  | "enterprise_operator"
+  | "government_program";
+export type EnterpriseMunicipalReadinessStatus = "ready_for_review" | "partially_ready" | "review_required" | "blocked" | "unknown";
+export type EnterpriseMunicipalReferenceType =
+  | "institutional"
+  | "municipal"
+  | "portfolio_governance"
+  | "regulatory"
+  | "operational_risk"
+  | "review"
+  | "evidence"
+  | "audit";
+export type EnterpriseMunicipalReferenceStatus = "verified" | "partially_verified" | "blocked" | "unavailable";
+
+export type EnterpriseMunicipalReference = {
+  referenceId: string;
+  referenceType: EnterpriseMunicipalReferenceType;
+  status: EnterpriseMunicipalReferenceStatus;
+  label: string;
+  description: string;
+  reviewRequired: true;
+  lineageReferences: string[];
+  destination: string | null;
+  redacted: boolean;
+  redactionReason: string | null;
+  blockedReason: string | null;
+};
+
+export type EnterpriseMunicipalRestriction = {
+  restrictionId: string;
+  restrictionType:
+    | EnterpriseMunicipalReferenceType
+    | "government_execution"
+    | "enterprise_execution"
+    | "cmhc_submission"
+    | "public_sector_export"
+    | "portfolio_exposure";
+  status: "visible" | "blocked" | "review_required";
+  label: string;
+  description: string;
+  blockedReason: string | null;
+};
+
+export type EnterpriseMunicipalReadinessProfile = {
+  enterpriseMunicipalReadinessId: string;
+  organizationType: EnterpriseMunicipalOrganizationType;
+  status: EnterpriseMunicipalReadinessStatus;
+  manualApprovalRequired: true;
+  autonomousGovernmentExecutionEnabled: false;
+  autonomousEnterpriseExecutionEnabled: false;
+  generatedAt: string;
+  summary: {
+    totalReferences: number;
+    verifiedReferences: number;
+    partiallyVerifiedReferences: number;
+    blockedReferences: number;
+    unavailableReferences: number;
+    restrictions: number;
+  };
+  institutionalReferences: EnterpriseMunicipalReference[];
+  portfolioGovernanceReferences: EnterpriseMunicipalReference[];
+  municipalReadinessReferences: EnterpriseMunicipalReference[];
+  regulatoryReferences: EnterpriseMunicipalReference[];
+  operationalRiskReferences: EnterpriseMunicipalReference[];
+  reviewReferences: EnterpriseMunicipalReference[];
+  evidenceReferences: EnterpriseMunicipalReference[];
+  auditReferences: EnterpriseMunicipalReference[];
+  enterpriseRestrictions: EnterpriseMunicipalRestriction[];
+  redactions: string[];
+  blockedReasons: string[];
+  canonicalEvents: Array<{ eventType: string; action: string; status: EnterpriseMunicipalReadinessStatus; resourceId: string; summary: string }>;
+};
+
+export async function fetchEnterpriseMunicipalReadinessProfiles(params?: {
+  organizationType?: EnterpriseMunicipalOrganizationType | "";
+  status?: EnterpriseMunicipalReadinessStatus | "";
+}): Promise<EnterpriseMunicipalReadinessProfile[]> {
+  const search = new URLSearchParams();
+  if (params?.organizationType) search.set("organizationType", params.organizationType);
+  if (params?.status) search.set("status", params.status);
+  const suffix = search.toString() ? `?${search.toString()}` : "";
+  const response = await apiFetch<{ ok: true; profiles: EnterpriseMunicipalReadinessProfile[] }>(`/admin/enterprise-municipal-readiness${suffix}`);
+  return response.profiles;
+}
+
+export async function fetchEnterpriseMunicipalReadinessProfile(enterpriseMunicipalReadinessId: string): Promise<EnterpriseMunicipalReadinessProfile> {
+  const response = await apiFetch<{ ok: true; profile: EnterpriseMunicipalReadinessProfile }>(
+    `/admin/enterprise-municipal-readiness/${encodeURIComponent(enterpriseMunicipalReadinessId)}`
+  );
+  return response.profile;
+}

--- a/rentchain-frontend/src/components/enterprise/EnterpriseMunicipalReadinessPanel.test.tsx
+++ b/rentchain-frontend/src/components/enterprise/EnterpriseMunicipalReadinessPanel.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import type { EnterpriseMunicipalReadinessProfile } from "@/api/enterpriseMunicipalReadinessApi";
+import { EnterpriseMunicipalReadinessPanel } from "./EnterpriseMunicipalReadinessPanel";
+
+const profile: EnterpriseMunicipalReadinessProfile = {
+  enterpriseMunicipalReadinessId: "enterprise_municipal:municipality:municipality",
+  organizationType: "municipality",
+  status: "blocked",
+  manualApprovalRequired: true,
+  autonomousGovernmentExecutionEnabled: false,
+  autonomousEnterpriseExecutionEnabled: false,
+  generatedAt: "2026-05-07T00:00:00.000Z",
+  summary: {
+    totalReferences: 2,
+    verifiedReferences: 1,
+    partiallyVerifiedReferences: 0,
+    blockedReferences: 1,
+    unavailableReferences: 0,
+    restrictions: 1,
+  },
+  institutionalReferences: [
+    {
+      referenceId: "institutional-1",
+      referenceType: "institutional",
+      status: "verified",
+      label: "Institutional onboarding reference",
+      description: "Institutional onboarding readiness is available as review metadata.",
+      reviewRequired: true,
+      lineageReferences: ["institutional-1"],
+      destination: "/institution-onboarding-readiness",
+      redacted: false,
+      redactionReason: null,
+      blockedReason: null,
+    },
+  ],
+  portfolioGovernanceReferences: [],
+  municipalReadinessReferences: [],
+  regulatoryReferences: [],
+  operationalRiskReferences: [],
+  reviewReferences: [],
+  evidenceReferences: [],
+  auditReferences: [],
+  enterpriseRestrictions: [
+    {
+      restrictionId: "restriction-1",
+      restrictionType: "operational_risk",
+      status: "blocked",
+      label: "Operational risk enterprise restriction",
+      description: "Unresolved operational risk blocks enterprise readiness.",
+      blockedReason: "Unresolved operational risk blocks enterprise readiness.",
+    },
+  ],
+  redactions: ["Sensitive tenant, payment, screening, credential, and public-sector execution payloads are excluded."],
+  blockedReasons: ["Unresolved operational risk blocks enterprise readiness."],
+  canonicalEvents: [],
+};
+
+describe("EnterpriseMunicipalReadinessPanel", () => {
+  it("renders readiness status, restrictions, blocked reasons, and required safety copy", () => {
+    render(
+      <MemoryRouter>
+        <EnterpriseMunicipalReadinessPanel profile={profile} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("View readiness")).toBeInTheDocument();
+    expect(screen.getByText("View institutional references")).toBeInTheDocument();
+    expect(screen.getByText("View operational risk")).toBeInTheDocument();
+    expect(screen.getByText("View review lineage")).toBeInTheDocument();
+    expect(screen.getByText("View evidence lineage")).toBeInTheDocument();
+    expect(screen.getByText("View restrictions")).toBeInTheDocument();
+    expect(screen.getByText("View blocked reason: Unresolved operational risk blocks enterprise readiness.")).toBeInTheDocument();
+    expect(screen.getByText("Manual review required")).toBeInTheDocument();
+    expect(screen.getByText(/Enterprise and municipal readiness is operationally scoped and review controlled/i)).toBeInTheDocument();
+    expect(screen.getByText(/No autonomous government or enterprise execution is enabled/i)).toBeInTheDocument();
+    expect(screen.getByText(/Manual review remains required/i)).toBeInTheDocument();
+  });
+
+  it("does not render forbidden enterprise execution labels", () => {
+    render(
+      <MemoryRouter>
+        <EnterpriseMunicipalReadinessPanel profile={profile} />
+      </MemoryRouter>
+    );
+
+    const forbiddenLabels = [
+      ["Submit to", "municipality"],
+      ["Auto", "submit CMHC"],
+      ["Autonomous", "onboarding"],
+      ["Enable government", "execution"],
+      ["Auto", "approve enterprise"],
+      ["Trigger institutional", "rollout"],
+    ].map((parts) => parts.join(parts[0] === "Auto" ? "-" : " "));
+
+    for (const forbiddenLabel of forbiddenLabels) {
+      expect(screen.queryByText(forbiddenLabel)).not.toBeInTheDocument();
+    }
+  });
+});

--- a/rentchain-frontend/src/components/enterprise/EnterpriseMunicipalReadinessPanel.tsx
+++ b/rentchain-frontend/src/components/enterprise/EnterpriseMunicipalReadinessPanel.tsx
@@ -1,0 +1,144 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import type {
+  EnterpriseMunicipalReadinessProfile,
+  EnterpriseMunicipalReference,
+  EnterpriseMunicipalRestriction,
+} from "@/api/enterpriseMunicipalReadinessApi";
+import { Card, Section } from "@/components/ui/Ui";
+
+function label(value: string) {
+  return value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function tone(status: string) {
+  if (status === "blocked") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
+  if (status === "review_required" || status === "partially_ready" || status === "partially_verified" || status === "unavailable" || status === "unknown") {
+    return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
+  }
+  if (status === "ready_for_review" || status === "verified") return { color: "#166534", background: "#dcfce7", border: "#bbf7d0" };
+  return { color: "#475569", background: "#f8fafc", border: "#e2e8f0" };
+}
+
+function Badge({ children, status }: { children: React.ReactNode; status: string }) {
+  const next = tone(status);
+  return (
+    <span style={{ border: `1px solid ${next.border}`, borderRadius: 999, background: next.background, color: next.color, padding: "3px 9px", fontSize: 12, fontWeight: 900, whiteSpace: "nowrap" }}>
+      {children}
+    </span>
+  );
+}
+
+function ReferenceList({ title, references }: { title: string; references: EnterpriseMunicipalReference[] }) {
+  return (
+    <Section style={{ display: "grid", gap: 10 }}>
+      <div style={{ fontWeight: 900 }}>{title}</div>
+      {references.length ? (
+        references.slice(0, 12).map((reference) => (
+          <Card key={reference.referenceId} style={{ borderRadius: 8, padding: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+              <div>
+                <strong>{reference.label}</strong>
+                <div style={{ color: "#64748b", fontSize: 13 }}>{label(reference.referenceType)}</div>
+              </div>
+              <Badge status={reference.status}>{label(reference.status)}</Badge>
+            </div>
+            <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>{reference.description}</div>
+            {reference.lineageReferences.length ? <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>Lineage references: {reference.lineageReferences.length}</div> : null}
+            {reference.blockedReason ? <div style={{ color: "#991b1b", fontSize: 13, marginTop: 8 }}>View blocked reason: {reference.blockedReason}</div> : null}
+            {reference.redacted ? <div style={{ color: "#92400e", fontSize: 13, marginTop: 8 }}>{reference.redactionReason || "Redacted enterprise readiness reference"}</div> : null}
+            {reference.destination?.startsWith("/") ? <Link to={reference.destination} style={{ color: "#2563eb", fontWeight: 800, fontSize: 13, marginTop: 8, display: "inline-block" }}>View context</Link> : null}
+          </Card>
+        ))
+      ) : (
+        <Card style={{ color: "#64748b" }}>Context unavailable</Card>
+      )}
+    </Section>
+  );
+}
+
+function RestrictionList({ restrictions }: { restrictions: EnterpriseMunicipalRestriction[] }) {
+  return (
+    <Section style={{ display: "grid", gap: 10 }}>
+      <div style={{ fontWeight: 900 }}>View restrictions</div>
+      {restrictions.length ? (
+        restrictions.map((restriction) => (
+          <Card key={restriction.restrictionId} style={{ borderRadius: 8, padding: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+              <div>
+                <strong>{restriction.label}</strong>
+                <div style={{ color: "#64748b", fontSize: 13 }}>{label(restriction.restrictionType)}</div>
+              </div>
+              <Badge status={restriction.status}>{label(restriction.status)}</Badge>
+            </div>
+            <div style={{ color: "#475569", fontSize: 13, marginTop: 8 }}>{restriction.description}</div>
+            {restriction.blockedReason ? <div style={{ color: "#991b1b", fontSize: 13, marginTop: 8 }}>View blocked reason: {restriction.blockedReason}</div> : null}
+          </Card>
+        ))
+      ) : (
+        <Card style={{ color: "#64748b" }}>No enterprise readiness restrictions detected.</Card>
+      )}
+    </Section>
+  );
+}
+
+export function EnterpriseMunicipalReadinessPanel({ profile }: { profile: EnterpriseMunicipalReadinessProfile }) {
+  return (
+    <div style={{ display: "grid", gap: 16 }}>
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+          <div>
+            <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>View readiness</div>
+            <h2 style={{ margin: "2px 0 0", fontSize: "1.15rem" }}>{label(profile.organizationType)}</h2>
+          </div>
+          <Badge status={profile.status}>{label(profile.status)}</Badge>
+        </div>
+        <div style={{ color: "#475569", lineHeight: 1.55 }}>
+          Enterprise and municipal readiness is operationally scoped and review controlled. No autonomous government or enterprise execution is enabled.
+          Manual review remains required.
+        </div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <Badge status="review_required">Manual review required</Badge>
+          <Badge status={profile.autonomousGovernmentExecutionEnabled ? "blocked" : "verified"}>Government execution disabled</Badge>
+          <Badge status={profile.autonomousEnterpriseExecutionEnabled ? "blocked" : "verified"}>Enterprise execution disabled</Badge>
+        </div>
+      </Section>
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Enterprise readiness summary</div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: 10 }}>
+          {[
+            ["References", profile.summary.totalReferences],
+            ["Verified", profile.summary.verifiedReferences],
+            ["Partial", profile.summary.partiallyVerifiedReferences],
+            ["Blocked", profile.summary.blockedReferences],
+            ["Unavailable", profile.summary.unavailableReferences],
+            ["Restrictions", profile.summary.restrictions],
+          ].map(([name, value]) => (
+            <Card key={String(name)} style={{ borderRadius: 8, padding: 12 }}>
+              <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>{name}</div>
+              <strong style={{ color: "#0f172a", fontSize: 22 }}>{String(value)}</strong>
+            </Card>
+          ))}
+        </div>
+      </Section>
+
+      <RestrictionList restrictions={profile.enterpriseRestrictions} />
+      <ReferenceList title="View institutional references" references={profile.institutionalReferences} />
+      <ReferenceList title="Portfolio governance" references={profile.portfolioGovernanceReferences} />
+      <ReferenceList title="Municipal readiness" references={profile.municipalReadinessReferences} />
+      <ReferenceList title="Regulatory readiness" references={profile.regulatoryReferences} />
+      <ReferenceList title="View operational risk" references={profile.operationalRiskReferences} />
+      <ReferenceList title="View review lineage" references={profile.reviewReferences} />
+      <ReferenceList title="View evidence lineage" references={profile.evidenceReferences} />
+      <ReferenceList title="Audit references" references={profile.auditReferences} />
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Redactions</div>
+        {profile.redactions.map((redaction) => (
+          <Card key={redaction} style={{ borderRadius: 8, padding: 12, color: "#475569" }}>{redaction}</Card>
+        ))}
+      </Section>
+    </div>
+  );
+}

--- a/rentchain-frontend/src/components/layout/navConfig.ts
+++ b/rentchain-frontend/src/components/layout/navConfig.ts
@@ -188,6 +188,13 @@ export const NAV_ITEMS: NavItem[] = [
     showInDrawer: true,
   },
   {
+    id: "enterprise-municipal-readiness",
+    label: "Enterprise Readiness",
+    to: "/admin/enterprise-municipal-readiness",
+    requiresAdmin: true,
+    showInDrawer: true,
+  },
+  {
     id: "admin-leads",
     label: "Referral Requests",
     to: "/admin/leads",

--- a/rentchain-frontend/src/pages/EnterpriseMunicipalReadinessPage.test.tsx
+++ b/rentchain-frontend/src/pages/EnterpriseMunicipalReadinessPage.test.tsx
@@ -1,0 +1,99 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import EnterpriseMunicipalReadinessPage from "./EnterpriseMunicipalReadinessPage";
+
+const mockFetchProfiles = vi.fn();
+const mockShowToast = vi.fn();
+
+vi.mock("@/api/enterpriseMunicipalReadinessApi", () => ({
+  fetchEnterpriseMunicipalReadinessProfiles: (...args: any[]) => mockFetchProfiles(...args),
+}));
+
+vi.mock("@/components/layout/MacShell", () => ({
+  MacShell: ({ children, title }: any) => <main aria-label={title}>{children}</main>,
+}));
+
+vi.mock("@/components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
+const profile = {
+  enterpriseMunicipalReadinessId: "enterprise_municipal:municipality:municipality",
+  organizationType: "municipality",
+  status: "ready_for_review",
+  manualApprovalRequired: true,
+  autonomousGovernmentExecutionEnabled: false,
+  autonomousEnterpriseExecutionEnabled: false,
+  generatedAt: "2026-05-07T00:00:00.000Z",
+  summary: {
+    totalReferences: 1,
+    verifiedReferences: 1,
+    partiallyVerifiedReferences: 0,
+    blockedReferences: 0,
+    unavailableReferences: 0,
+    restrictions: 0,
+  },
+  institutionalReferences: [],
+  portfolioGovernanceReferences: [],
+  municipalReadinessReferences: [],
+  regulatoryReferences: [],
+  operationalRiskReferences: [],
+  reviewReferences: [],
+  evidenceReferences: [],
+  auditReferences: [],
+  enterpriseRestrictions: [],
+  redactions: ["Sensitive tenant and public-sector execution payloads are excluded."],
+  blockedReasons: [],
+  canonicalEvents: [],
+};
+
+describe("EnterpriseMunicipalReadinessPage", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    mockFetchProfiles.mockResolvedValue([profile]);
+  });
+
+  it("loads enterprise readiness with required safety copy", async () => {
+    render(
+      <MemoryRouter>
+        <EnterpriseMunicipalReadinessPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Loading enterprise readiness...")).toBeInTheDocument();
+    expect(await screen.findByText("Enterprise readiness summary")).toBeInTheDocument();
+    expect(screen.getAllByText(/Enterprise and municipal readiness is operationally scoped and review controlled/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/No autonomous government or enterprise execution is enabled/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Manual review remains required/i).length).toBeGreaterThan(0);
+    expect(mockFetchProfiles).toHaveBeenCalledWith({ organizationType: "", status: "" });
+  });
+
+  it("filters profiles by organization type and status", async () => {
+    render(
+      <MemoryRouter>
+        <EnterpriseMunicipalReadinessPage />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(await screen.findByLabelText("Organization type"), { target: { value: "municipality" } });
+    fireEvent.change(screen.getByLabelText("Status"), { target: { value: "blocked" } });
+
+    await waitFor(() => {
+      expect(mockFetchProfiles).toHaveBeenLastCalledWith({ organizationType: "municipality", status: "blocked" });
+    });
+  });
+
+  it("renders the empty state", async () => {
+    mockFetchProfiles.mockResolvedValue([]);
+
+    render(
+      <MemoryRouter>
+        <EnterpriseMunicipalReadinessPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("No enterprise readiness profiles match these filters.")).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/pages/EnterpriseMunicipalReadinessPage.tsx
+++ b/rentchain-frontend/src/pages/EnterpriseMunicipalReadinessPage.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { useSearchParams } from "react-router-dom";
+import {
+  fetchEnterpriseMunicipalReadinessProfiles,
+  type EnterpriseMunicipalOrganizationType,
+  type EnterpriseMunicipalReadinessProfile,
+  type EnterpriseMunicipalReadinessStatus,
+} from "@/api/enterpriseMunicipalReadinessApi";
+import { EnterpriseMunicipalReadinessPanel } from "@/components/enterprise/EnterpriseMunicipalReadinessPanel";
+import { MacShell } from "@/components/layout/MacShell";
+import { Card, Section } from "@/components/ui/Ui";
+import { useToast } from "@/components/ui/ToastProvider";
+
+const organizationTypes: Array<EnterpriseMunicipalOrganizationType | ""> = ["", "municipality", "affordable_housing_operator", "institutional_landlord", "enterprise_operator", "government_program"];
+const statuses: Array<EnterpriseMunicipalReadinessStatus | ""> = ["", "ready_for_review", "partially_ready", "review_required", "blocked", "unknown"];
+
+function label(value: string) {
+  return value ? value.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase()) : "All";
+}
+
+export default function EnterpriseMunicipalReadinessPage() {
+  const { showToast } = useToast();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [profiles, setProfiles] = React.useState<EnterpriseMunicipalReadinessProfile[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const organizationType = String(searchParams.get("organizationType") || "") as EnterpriseMunicipalOrganizationType | "";
+  const status = String(searchParams.get("status") || "") as EnterpriseMunicipalReadinessStatus | "";
+
+  React.useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const next = await fetchEnterpriseMunicipalReadinessProfiles({ organizationType, status });
+        if (mounted) setProfiles(next);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Failed to load enterprise readiness";
+        if (mounted) {
+          setError(message);
+          showToast({ message: "Failed to load enterprise readiness", description: message, variant: "error" });
+        }
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [organizationType, status, showToast]);
+
+  function updateParam(key: "organizationType" | "status", value: string) {
+    const params = new URLSearchParams(searchParams);
+    if (value && value.trim()) params.set(key, value.trim());
+    else params.delete(key);
+    setSearchParams(params);
+  }
+
+  return (
+    <MacShell title="Enterprise and municipal readiness" showTopNav={false}>
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "grid", gap: 6 }}>
+            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>Enterprise and municipal readiness</h1>
+            <div style={{ color: "#475569", maxWidth: 900 }}>
+              Enterprise and municipal readiness is operationally scoped and review controlled. No autonomous government or enterprise execution is enabled.
+              Manual review remains required.
+            </div>
+          </div>
+        </Section>
+
+        <Section style={{ display: "flex", gap: 10, flexWrap: "wrap", alignItems: "end" }}>
+          <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Organization type
+            <select value={organizationType} onChange={(event) => updateParam("organizationType", event.target.value)} style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 220 }}>
+              {organizationTypes.map((item) => <option key={item || "all"} value={item}>{label(item)}</option>)}
+            </select>
+          </label>
+          <label style={{ display: "grid", gap: 4, color: "#334155", fontSize: 13, fontWeight: 800 }}>
+            Status
+            <select value={status} onChange={(event) => updateParam("status", event.target.value)} style={{ border: "1px solid #cbd5e1", borderRadius: 8, padding: "8px 10px", minWidth: 180 }}>
+              {statuses.map((item) => <option key={item || "all"} value={item}>{label(item)}</option>)}
+            </select>
+          </label>
+        </Section>
+
+        {loading ? <Card>Loading enterprise readiness...</Card> : null}
+        {!loading && error ? <Card style={{ color: "#b91c1c" }}>We couldn't load enterprise readiness right now.</Card> : null}
+        {!loading && !error && !profiles.length ? <Card style={{ color: "#64748b" }}>No enterprise readiness profiles match these filters.</Card> : null}
+        {!loading && !error && profiles.length ? (
+          <div style={{ display: "grid", gap: 16 }}>{profiles.map((profile) => <EnterpriseMunicipalReadinessPanel key={profile.enterpriseMunicipalReadinessId} profile={profile} />)}</div>
+        ) : null}
+      </div>
+    </MacShell>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a deterministic, admin-scoped Enterprise and Municipal Readiness read model.
- Adds read-only admin endpoints for list/detail readiness profiles.
- Adds an admin governance UI surface with required safety copy, restrictions, redactions, and review/evidence lineage visibility.

## Guardrails
- `manualApprovalRequired` remains pinned to `true`.
- `autonomousGovernmentExecutionEnabled` remains pinned to `false`.
- `autonomousEnterpriseExecutionEnabled` remains pinned to `false`.
- No government integration, CMHC submission execution, autonomous enterprise onboarding, public-sector export, portfolio exposure, or hidden execution path was added.
- Route output is whitelist-projected and excludes sensitive tenant/payment/screening/provider credential/admin-only payloads.

## Verification
- Backend targeted tests: `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm test -- --run src/lib/enterpriseMunicipalReadiness/__tests__/deriveEnterpriseMunicipalReadinessProfile.test.ts src/routes/__tests__/adminEnterpriseMunicipalReadinessRoutes.test.ts` passed, 7/7.
- Frontend targeted tests: `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm test -- --run src/components/enterprise/EnterpriseMunicipalReadinessPanel.test.tsx src/pages/EnterpriseMunicipalReadinessPage.test.tsx` passed, 5/5.
- Backend build passed.
- Frontend build passed. Existing large App chunk warning remains non-regressive; new page chunk is small.
- `git diff --check` passed.
- Dependency/lockfile diff remained empty.
- Forbidden enterprise execution label scan passed.
- Runtime mutation/safe-flag scan passed.