### PR TITLE
fix: harden mobile pdf rendering

### DIFF
--- a/rentchain-frontend/src/components/applications/PrintApplicationView.tsx
+++ b/rentchain-frontend/src/components/applications/PrintApplicationView.tsx
@@ -77,11 +77,15 @@ export const PrintApplicationView: React.FC<PrintApplicationViewProps> = ({
           }
           .print-application-view {
             display: block !important;
-            position: absolute;
-            inset: 0;
+            position: static;
             padding: 32px 36px;
             width: 100%;
-            min-height: 100vh;
+            height: auto;
+            min-height: auto;
+            max-height: none;
+            overflow: visible;
+            transform: none;
+            box-sizing: border-box;
             background: #fff;
             color: #000;
             font-family: "Helvetica Neue", Arial, sans-serif;

--- a/rentchain-frontend/src/components/billing/SamplePdfModal.test.tsx
+++ b/rentchain-frontend/src/components/billing/SamplePdfModal.test.tsx
@@ -1,0 +1,51 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SamplePdfModal } from "./SamplePdfModal";
+
+function mockViewport(options: { width: number; coarsePointer: boolean }) {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    value: options.width,
+  });
+  window.matchMedia = vi.fn((query: string) => {
+    const matches = query.includes("pointer") ? options.coarsePointer : query.includes("max-width") && options.width <= 768;
+    return {
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    } as unknown as MediaQueryList;
+  });
+}
+
+describe("SamplePdfModal", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps the desktop PDF iframe preview", async () => {
+    mockViewport({ width: 1280, coarsePointer: false });
+    render(<SamplePdfModal open onClose={vi.fn()} />);
+
+    expect(await screen.findByTitle("Sample screening report PDF")).toBeInTheDocument();
+    expect(screen.queryByText("Open the sample PDF")).not.toBeInTheDocument();
+  });
+
+  it("does not render a PDF iframe on mobile", async () => {
+    mockViewport({ width: 390, coarsePointer: true });
+    render(<SamplePdfModal open onClose={vi.fn()} />);
+
+    await waitFor(() => expect(screen.getByText("Open the sample PDF")).toBeInTheDocument());
+    expect(screen.queryByTitle("Sample screening report PDF")).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Open PDF" })).toHaveAttribute(
+      "href",
+      "/sample/screening_report_sample.pdf?v=1"
+    );
+    expect(screen.getByRole("link", { name: "Download PDF" })).toHaveAttribute("download");
+  });
+});

--- a/rentchain-frontend/src/components/billing/SamplePdfModal.tsx
+++ b/rentchain-frontend/src/components/billing/SamplePdfModal.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
+import { useMobilePdfPreviewGuard } from "../../utils/pdfPreviewGuard";
 
 type Props = {
   open: boolean;
@@ -9,6 +10,7 @@ export function SamplePdfModal({ open, onClose }: Props) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [loadError, setLoadError] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
+  const useMobileFallback = useMobilePdfPreviewGuard();
   const pdfUrl = "/sample/screening_report_sample.pdf?v=1";
 
   useEffect(() => {
@@ -99,13 +101,14 @@ export function SamplePdfModal({ open, onClose }: Props) {
         aria-label="Sample screening report"
         style={{
           width: "min(1024px, 95vw)",
-          height: isMobile ? "75vh" : "70vh",
+          minHeight: isMobile ? "auto" : 520,
+          maxHeight: isMobile ? "none" : "min(860px, 86dvh)",
           background: "#fff",
           borderRadius: 16,
           boxShadow: "0 30px 80px rgba(2,6,23,0.45)",
           display: "flex",
           flexDirection: "column",
-          overflow: "hidden",
+          overflow: "visible",
         }}
         onMouseDown={(event) => event.stopPropagation()}
         onKeyDown={trapFocus}
@@ -174,13 +177,28 @@ export function SamplePdfModal({ open, onClose }: Props) {
             </button>
           </div>
         </div>
-        <div style={{ flex: 1, position: "relative", background: "#f8fafc" }}>
+        <div style={{ flex: 1, position: "relative", background: "#f8fafc", overflow: "visible" }}>
           {loadError ? (
             <div style={{ padding: 16, fontSize: 14, color: "#b91c1c" }}>
               Unable to load the sample report.
               <div style={{ marginTop: 8 }}>
                 <a href={pdfUrl} target="_blank" rel="noreferrer">
                   Open in new tab
+                </a>
+              </div>
+            </div>
+          ) : useMobileFallback ? (
+            <div style={{ display: "grid", gap: 10, padding: 16, fontSize: 14, color: "#0f172a" }}>
+              <div style={{ fontWeight: 700 }}>Open the sample PDF</div>
+              <div style={{ color: "#475569" }}>
+                Mobile browsers handle PDF files more reliably in the browser viewer or download manager.
+              </div>
+              <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+                <a href={pdfUrl} target="_blank" rel="noreferrer">
+                  Open PDF
+                </a>
+                <a href={pdfUrl} download>
+                  Download PDF
                 </a>
               </div>
             </div>
@@ -191,8 +209,10 @@ export function SamplePdfModal({ open, onClose }: Props) {
               className="w-full h-full rounded-xl"
               style={{
                 width: "100%",
-                height: "100%",
+                minHeight: 520,
+                height: "min(760px, 72dvh)",
                 border: "none",
+                display: "block",
               }}
               onError={() => setLoadError(true)}
             />

--- a/rentchain-frontend/src/index.css
+++ b/rentchain-frontend/src/index.css
@@ -333,6 +333,12 @@ button,
     display: block !important;
     padding: 24px !important;
     background: #fff !important;
+    box-sizing: border-box !important;
+    height: auto !important;
+    min-height: auto !important;
+    max-height: none !important;
+    overflow: visible !important;
+    transform: none !important;
   }
 
   body[data-print-root-active="true"] > [data-print-root="true"],
@@ -357,13 +363,16 @@ button,
   body:not([data-print-root-active="true"]) .print-only-application {
     display: block !important;
     visibility: visible !important;
-    position: absolute !important;
-    left: 0 !important;
-    top: 0 !important;
+    position: static !important;
     width: 100% !important;
     padding: 24px !important;
     background: #fff !important;
     box-sizing: border-box !important;
+    height: auto !important;
+    min-height: auto !important;
+    max-height: none !important;
+    overflow: visible !important;
+    transform: none !important;
   }
 
   body:not([data-print-root-active="true"]) .print-only-summary *,

--- a/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.test.tsx
@@ -131,4 +131,49 @@ describe("LandlordLeaseSummaryPage", () => {
     expect(downloadAnchor?.download).toBe("lease-3.pdf");
     expect(downloadAnchor?.download).not.toMatch(/\.txt$/);
   });
+
+  it("paginates long lease summary content without adding empty trailing pages", () => {
+    const longText = Array.from({ length: 180 }, (_, index) => `deterministic clause ${index + 1}`).join(" ");
+    const pdfText = buildLeaseSummaryPdfSource({
+      id: "lease-long",
+      propertyId: "prop-1",
+      propertyName: "Coburg Rd",
+      unitNumber: "3",
+      monthlyRent: 2100,
+      startDate: "2026-01-01",
+      endDate: "2026-12-31",
+      status: "active",
+      tenantName: "Tony Wenpeng",
+      tenantEmail: "tony@example.com",
+      documentUrl: null,
+      paymentReadiness: {
+        readinessStatus: "ready_to_configure",
+        readinessLabel: "Rent terms ready for future setup",
+        readinessDescription: longText,
+        requiredNextAction: "confirm_payment_setup_later",
+        rentTerms: {
+          rentAmountAvailable: true,
+          dueDateAvailable: true,
+          leaseDatesAvailable: true,
+          tenantLinked: true,
+          leaseExecuted: false,
+        },
+        paymentSetup: {
+          processorConnected: false,
+          moneyMovementEnabled: false,
+          storedPaymentMethod: false,
+        },
+      },
+      leaseExecution: {
+        executionStatus: "ready_for_review",
+        executionLabel: "Execution review",
+        executionDescription: longText,
+      },
+    } as any);
+
+    const pageCount = (pdfText.match(/\/Type \/Page /g) || []).length;
+    expect(pageCount).toBeGreaterThan(1);
+    expect(pdfText).toContain(`/Count ${pageCount}`);
+    expect(pdfText).toContain("deterministic clause 180");
+  });
 });

--- a/rentchain-frontend/src/pages/PdfSamplePage.test.tsx
+++ b/rentchain-frontend/src/pages/PdfSamplePage.test.tsx
@@ -1,0 +1,60 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import PdfSamplePage from "./PdfSamplePage";
+
+function mockViewport(options: { width: number; coarsePointer: boolean }) {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    value: options.width,
+  });
+  window.matchMedia = vi.fn((query: string) => {
+    const matches = query.includes("pointer") ? options.coarsePointer : query.includes("max-width") && options.width <= 768;
+    return {
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    } as unknown as MediaQueryList;
+  });
+}
+
+describe("PdfSamplePage", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders the desktop PDF iframe preview", async () => {
+    mockViewport({ width: 1280, coarsePointer: false });
+    render(
+      <MemoryRouter>
+        <PdfSamplePage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByTitle("Sample screening report")).toBeInTheDocument();
+    expect(screen.queryByText("Open the sample PDF")).not.toBeInTheDocument();
+  });
+
+  it("uses Open and Download actions instead of iframe preview on mobile", async () => {
+    mockViewport({ width: 390, coarsePointer: true });
+    render(
+      <MemoryRouter>
+        <PdfSamplePage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(screen.getByText("Open the sample PDF")).toBeInTheDocument());
+    expect(screen.queryByTitle("Sample screening report")).not.toBeInTheDocument();
+    expect(screen.getAllByRole("link", { name: "Open PDF" })[0]).toHaveAttribute(
+      "href",
+      "/sample/screening_report_sample.pdf?v=1"
+    );
+    expect(screen.getAllByRole("link", { name: "Download PDF" })[0]).toHaveAttribute("download");
+  });
+});

--- a/rentchain-frontend/src/pages/PdfSamplePage.tsx
+++ b/rentchain-frontend/src/pages/PdfSamplePage.tsx
@@ -2,12 +2,14 @@ import React from "react";
 import { useNavigate } from "react-router-dom";
 import { Card } from "../components/ui/Ui";
 import { spacing } from "../styles/tokens";
+import { useMobilePdfPreviewGuard } from "../utils/pdfPreviewGuard";
 
 const pdfUrl = "/sample/screening_report_sample.pdf?v=1";
 
 const PdfSamplePage: React.FC = () => {
   const navigate = useNavigate();
   const [loaded, setLoaded] = React.useState(false);
+  const useMobileFallback = useMobilePdfPreviewGuard();
 
   return (
     <div style={{ display: "grid", gap: spacing.md }}>
@@ -73,20 +75,39 @@ const PdfSamplePage: React.FC = () => {
           </div>
         </div>
       </Card>
-      <Card style={{ padding: 0, overflow: "hidden" }}>
-        {!loaded ? (
-          <div style={{ padding: spacing.md }}>Loading…</div>
-        ) : null}
-        <iframe
-          title="Sample screening report"
-          src={`${pdfUrl}#view=FitH`}
-          style={{
-            width: "100%",
-            height: "90vh",
-            border: "none",
-          }}
-          onLoad={() => setLoaded(true)}
-        />
+      <Card style={{ padding: 0, overflow: "visible" }}>
+        {useMobileFallback ? (
+          <div style={{ display: "grid", gap: spacing.sm, padding: spacing.md }}>
+            <div style={{ fontWeight: 700 }}>Open the sample PDF</div>
+            <div style={{ color: "#475569" }}>
+              Mobile browsers handle PDF files more reliably in the browser viewer or download manager.
+            </div>
+            <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+              <a href={pdfUrl} target="_blank" rel="noreferrer" style={{ color: "#0f172a", fontWeight: 700 }}>
+                Open PDF
+              </a>
+              <a href={pdfUrl} download style={{ color: "#0f172a", fontWeight: 700 }}>
+                Download PDF
+              </a>
+            </div>
+          </div>
+        ) : (
+          <>
+            {!loaded ? <div style={{ padding: spacing.md }}>Loading…</div> : null}
+            <iframe
+              title="Sample screening report"
+              src={`${pdfUrl}#view=FitH`}
+              style={{
+                width: "100%",
+                minHeight: 720,
+                height: "min(900px, 82dvh)",
+                border: "none",
+                display: "block",
+              }}
+              onLoad={() => setLoaded(true)}
+            />
+          </>
+        )}
       </Card>
     </div>
   );

--- a/rentchain-frontend/src/styles/print.css
+++ b/rentchain-frontend/src/styles/print.css
@@ -9,12 +9,16 @@
   }
 
   .rc-print-area {
-    position: absolute;
-    left: 0;
-    top: 0;
+    position: static;
     width: 100%;
     padding: 24px;
     background: white;
+    box-sizing: border-box;
+    height: auto;
+    min-height: auto;
+    max-height: none;
+    overflow: visible;
+    transform: none;
   }
 
   .rc-print-clean {

--- a/rentchain-frontend/src/styles/printPdfGuardrails.test.ts
+++ b/rentchain-frontend/src/styles/printPdfGuardrails.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const srcRoot = resolve(process.cwd(), "src");
+
+describe("print PDF guardrails", () => {
+  it("keeps global print roots free of mobile-dangerous sizing and absolute placement", () => {
+    const indexCss = readFileSync(resolve(srcRoot, "index.css"), "utf8");
+    const printCss = readFileSync(resolve(srcRoot, "styles/print.css"), "utf8");
+
+    expect(indexCss).not.toMatch(/print-only-(summary|lease-renewals|application)[\s\S]*position:\s*absolute/i);
+    expect(indexCss).not.toMatch(/print-only-(summary|lease-renewals|application)[\s\S]*min-height:\s*100vh/i);
+    expect(printCss).not.toMatch(/\.rc-print-area[\s\S]*position:\s*absolute/i);
+    expect(printCss).not.toMatch(/\.rc-print-area[\s\S]*overflow:\s*hidden/i);
+  });
+
+  it("keeps application print view from reserving a viewport-height phantom page", () => {
+    const source = readFileSync(
+      resolve(srcRoot, "components/applications/PrintApplicationView.tsx"),
+      "utf8"
+    );
+
+    expect(source).not.toMatch(/position:\s*absolute/);
+    expect(source).not.toMatch(/inset:\s*0/);
+    expect(source).not.toMatch(/min-height:\s*100vh/);
+    expect(source).toMatch(/overflow:\s*visible/);
+    expect(source).toMatch(/transform:\s*none/);
+  });
+});

--- a/rentchain-frontend/src/utils/leaseSummaryPdf.ts
+++ b/rentchain-frontend/src/utils/leaseSummaryPdf.ts
@@ -85,13 +85,22 @@ export function buildLeaseSummaryPdfSource(lease: LandlordActiveLease) {
     });
   }
 
-  const content: string[] = [];
   const page = { width: 612, height: 792 };
   const docX = 54;
   const docY = 52;
   const docWidth = 504;
   const docHeight = 688;
+  const bottomY = 88;
+  const pageTopY = 704;
+  const pages: string[][] = [];
+  let content: string[] = [];
   let y = 704;
+
+  const addPage = () => {
+    content = [];
+    pages.push(content);
+    y = pageTopY;
+  };
 
   const textAt = (text: string, x: number, baselineY: number, size = 10, font = "F1") => {
     content.push(`BT /${font} ${size} Tf ${x} ${baselineY} Td (${escapePdfText(text)}) Tj ET`);
@@ -102,8 +111,17 @@ export function buildLeaseSummaryPdfSource(lease: LandlordActiveLease) {
   const rect = (x: number, rectY: number, width: number, height: number, fill = false) => {
     content.push(`q ${fill ? "0.97 0.98 0.99 rg" : "0.86 0.89 0.93 RG"} ${x} ${rectY} ${width} ${height} re ${fill ? "f" : "S"} Q`);
   };
+  const drawPageFrame = () => {
+    rect(docX, docY, docWidth, docHeight);
+  };
+  const ensureSpace = (neededHeight: number) => {
+    if (y - neededHeight >= bottomY) return;
+    addPage();
+    drawPageFrame();
+  };
 
-  rect(docX, docY, docWidth, docHeight);
+  addPage();
+  drawPageFrame();
   textAt("RentChain lease record", 236, y, 10, "F2");
   y -= 24;
   textAt("Residential Lease Pack", 193, y, 20, "F2");
@@ -112,11 +130,13 @@ export function buildLeaseSummaryPdfSource(lease: LandlordActiveLease) {
   y -= 30;
 
   sections.forEach((section) => {
+    ensureSpace(48);
     line(84, y + 14, 528, y + 14);
     textAt(section.title, 84, y, 13, "F2");
     y -= 22;
 
     section.rows.forEach(([label, value]) => {
+      ensureSpace(34);
       rect(84, y - 8, 444, 24, true);
       textAt(label.toUpperCase(), 96, y, 8, "F2");
       textAt(String(value), 252, y, 10);
@@ -130,7 +150,7 @@ export function buildLeaseSummaryPdfSource(lease: LandlordActiveLease) {
       words.forEach((word) => {
         const next = current ? `${current} ${word}` : word;
         if (next.length > 86) {
-          wrapped.push(current);
+          if (current) wrapped.push(current);
           current = word;
         } else {
           current = next;
@@ -138,6 +158,7 @@ export function buildLeaseSummaryPdfSource(lease: LandlordActiveLease) {
       });
       if (current) wrapped.push(current);
       wrapped.forEach((wrappedLine) => {
+        ensureSpace(18);
         textAt(wrappedLine, 96, y, 10);
         y -= 14;
       });
@@ -146,15 +167,21 @@ export function buildLeaseSummaryPdfSource(lease: LandlordActiveLease) {
     y -= 10;
   });
 
-  const stream = content.join("\n");
+  const pageObjectIds = pages.map((_, index) => 5 + index * 2);
+  const contentObjectIds = pages.map((_, index) => 6 + index * 2);
   const objects = [
     "1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj\n",
-    "2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj\n",
-    `3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 ${page.width} ${page.height}] /Resources << /Font << /F1 4 0 R /F2 6 0 R >> >> /Contents 5 0 R >> endobj\n`,
-    "4 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj\n",
-    `5 0 obj << /Length ${new TextEncoder().encode(stream).length} >> stream\n${stream}\nendstream endobj\n`,
-    "6 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >> endobj\n",
+    `2 0 obj << /Type /Pages /Kids [${pageObjectIds.map((id) => `${id} 0 R`).join(" ")}] /Count ${pages.length} >> endobj\n`,
+    "3 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj\n",
+    "4 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >> endobj\n",
   ];
+  pages.forEach((pageContent, index) => {
+    const stream = pageContent.join("\n");
+    objects.push(
+      `${pageObjectIds[index]} 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 ${page.width} ${page.height}] /Resources << /Font << /F1 3 0 R /F2 4 0 R >> >> /Contents ${contentObjectIds[index]} 0 R >> endobj\n`,
+      `${contentObjectIds[index]} 0 obj << /Length ${new TextEncoder().encode(stream).length} >> stream\n${stream}\nendstream endobj\n`
+    );
+  });
   let pdf = "%PDF-1.4\n";
   const offsets = [0];
   for (const object of objects) {

--- a/rentchain-frontend/src/utils/pdfPreviewGuard.test.ts
+++ b/rentchain-frontend/src/utils/pdfPreviewGuard.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { isMobilePdfPreviewUnsafe } from "./pdfPreviewGuard";
+
+describe("pdfPreviewGuard", () => {
+  it("blocks embedded PDF previews for mobile user agents", () => {
+    expect(
+      isMobilePdfPreviewUnsafe({
+        userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)",
+        width: 1024,
+        coarsePointer: false,
+      })
+    ).toBe(true);
+  });
+
+  it("blocks embedded PDF previews for narrow coarse-pointer devices", () => {
+    expect(
+      isMobilePdfPreviewUnsafe({
+        userAgent: "Mozilla/5.0",
+        width: 390,
+        coarsePointer: true,
+      })
+    ).toBe(true);
+  });
+
+  it("allows desktop iframe previews", () => {
+    expect(
+      isMobilePdfPreviewUnsafe({
+        userAgent: "Mozilla/5.0",
+        width: 1280,
+        coarsePointer: false,
+      })
+    ).toBe(false);
+  });
+});

--- a/rentchain-frontend/src/utils/pdfPreviewGuard.ts
+++ b/rentchain-frontend/src/utils/pdfPreviewGuard.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react";
+
+export function isMobilePdfPreviewUnsafe(input: {
+  userAgent?: string | null;
+  width?: number | null;
+  coarsePointer?: boolean | null;
+}) {
+  const userAgent = String(input.userAgent || "").toLowerCase();
+  const width = typeof input.width === "number" ? input.width : Number.POSITIVE_INFINITY;
+  const mobileUserAgent = /android|iphone|ipad|ipod|mobile/.test(userAgent);
+  const narrowViewport = width <= 768;
+  return mobileUserAgent || (narrowViewport && input.coarsePointer === true);
+}
+
+export function useMobilePdfPreviewGuard() {
+  const [unsafe, setUnsafe] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return isMobilePdfPreviewUnsafe({
+      userAgent: window.navigator.userAgent,
+      width: window.innerWidth,
+      coarsePointer: window.matchMedia("(pointer: coarse)").matches,
+    });
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const coarsePointerQuery = window.matchMedia("(pointer: coarse)");
+    const narrowQuery = window.matchMedia("(max-width: 768px)");
+    const update = () => {
+      setUnsafe(
+        isMobilePdfPreviewUnsafe({
+          userAgent: window.navigator.userAgent,
+          width: window.innerWidth,
+          coarsePointer: coarsePointerQuery.matches,
+        })
+      );
+    };
+
+    update();
+    const queries = [coarsePointerQuery, narrowQuery];
+    queries.forEach((query) => query.addEventListener?.("change", update));
+    return () => queries.forEach((query) => query.removeEventListener?.("change", update));
+  }, []);
+
+  return unsafe;
+}


### PR DESCRIPTION
## Summary
- add deterministic mobile PDF preview guard and mobile Open/Download fallback for audited embedded PDF previews
- harden desktop PDF iframe sizing with bounded dvh dimensions and non-clipping containers
- repair print roots to avoid absolute positioning, inset roots, 100vh phantom page sizing, clipped overflow, and unsafe transforms
- add deterministic pagination to the hand-built lease summary PDF source

## Root cause
Mobile-only blank pages were traced to embedded PDF iframe previews constrained by vh/overflow containers, and print-only roots using absolute positioning plus viewport-height sizing. Backend PDFKit exports were audited and are not rewritten in this PR.

## Tests
- npm run test:single -- src/utils/pdfPreviewGuard.test.ts src/pages/PdfSamplePage.test.tsx src/components/billing/SamplePdfModal.test.tsx src/styles/printPdfGuardrails.test.ts src/pages/LandlordLeaseSummaryPage.test.tsx
- PATH="/Users/rentchain/.nvm/versions/node/v20.20.2/bin:/Users/rentchain/.codex/tmp/arg0/codex-arg0KnLrp6:/Users/rentchain/.nvm/versions/node/v20.20.2/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Users/rentchain/.vscode/extensions/openai.chatgpt-26.504.30809-darwin-arm64/bin/macos-aarch64" npm run test
- PATH="/Users/rentchain/.nvm/versions/node/v20.20.2/bin:/Users/rentchain/.codex/tmp/arg0/codex-arg0KnLrp6:/Users/rentchain/.nvm/versions/node/v20.20.2/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Users/rentchain/.vscode/extensions/openai.chatgpt-26.504.30809-darwin-arm64/bin/macos-aarch64" npm run build
- git diff --check

## Notes
- Build emits the existing large chunk warning; no new lockfile or dependency changes.
- Physical iPhone Safari and Android Chrome device checks still need human/manual QA before merge.