### PR TITLE
feat: add pdf export observability

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -124,6 +124,7 @@ import adminEnterpriseMunicipalReadinessRoutes from "./routes/adminEnterpriseMun
 import adminEcosystemCoordinationRoutes from "./routes/adminEcosystemCoordinationRoutes";
 import adminPlatformCredentialingRoutes from "./routes/adminPlatformCredentialingRoutes";
 import adminConsumerReportingGovernanceRoutes from "./routes/adminConsumerReportingGovernanceRoutes";
+import adminPdfExportObservabilityRoutes from "./routes/adminPdfExportObservabilityRoutes";
 import portfolioScoreRoutes from "./routes/portfolioScoreRoutes";
 import portfolioScoreHistoryRoutes from "./routes/portfolioScoreHistoryRoutes";
 import landlordPortfolioHealthRoutes from "./routes/landlordPortfolioHealthRoutes";
@@ -319,6 +320,8 @@ app.use("/api/admin", routeSource("adminPlatformCredentialingRoutes.ts"), adminP
 console.log("[route-mount] adminPlatformCredentialingRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("adminConsumerReportingGovernanceRoutes.ts"), adminConsumerReportingGovernanceRoutes);
 console.log("[route-mount] adminConsumerReportingGovernanceRoutes mounted at /api/admin");
+app.use("/api/admin", routeSource("adminPdfExportObservabilityRoutes.ts"), adminPdfExportObservabilityRoutes);
+console.log("[route-mount] adminPdfExportObservabilityRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("portfolioScoreRoutes.ts"), portfolioScoreRoutes);
 console.log("[route-mount] portfolioScoreRoutes mounted at /api/admin");
 app.use("/api/admin", routeSource("portfolioScoreHistoryRoutes.ts"), portfolioScoreHistoryRoutes);

--- a/rentchain-api/src/lib/pdfExportObservability/__tests__/derivePdfExportDiagnostics.test.ts
+++ b/rentchain-api/src/lib/pdfExportObservability/__tests__/derivePdfExportDiagnostics.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { derivePdfExportDiagnostics } from "../derivePdfExportDiagnostics";
+
+describe("derivePdfExportDiagnostics", () => {
+  it("derives deterministic PDF export diagnostics without sensitive content", () => {
+    const diagnostics = derivePdfExportDiagnostics([
+      {
+        id: "event-1",
+        eventName: "pdf_export_started",
+        createdAt: Date.parse("2026-05-08T10:00:00.000Z"),
+        eventProps: {
+          exportType: "lease_summary",
+          renderingPath: "frontend_pdf_builder",
+          status: "started",
+        },
+      } as any,
+      {
+        id: "event-2",
+        eventName: "pdf_export_completed",
+        createdAt: Date.parse("2026-05-08T10:00:01.000Z"),
+        eventProps: {
+          exportType: "lease_summary",
+          renderingPath: "frontend_pdf_builder",
+          status: "completed",
+          durationMs: 41,
+          byteSize: 2048,
+          documentText: "must not be projected",
+        },
+      } as any,
+      {
+        id: "event-3",
+        eventName: "pdf_mobile_fallback_used",
+        createdAt: Date.parse("2026-05-08T10:00:02.000Z"),
+        eventProps: {
+          exportType: "sample_screening_report",
+          renderingPath: "mobile_fallback",
+          status: "fallback_used",
+          browserClass: "safari",
+          viewportCategory: "mobile",
+        },
+      } as any,
+      {
+        id: "event-4",
+        eventName: "nudge_opened",
+        createdAt: Date.parse("2026-05-08T10:00:03.000Z"),
+        eventProps: {},
+      } as any,
+    ]);
+
+    expect(diagnostics.manualReviewRequired).toBe(true);
+    expect(diagnostics.telemetryExecutionBlockingEnabled).toBe(false);
+    expect(diagnostics.sensitiveContentLogged).toBe(false);
+    expect(diagnostics.summary).toMatchObject({
+      totalEvents: 3,
+      started: 1,
+      completed: 1,
+      mobileFallbacks: 1,
+      averageDurationMs: 41,
+      totalBytes: 2048,
+    });
+    expect(diagnostics.byExportType).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ exportType: "lease_summary", totalEvents: 2, completed: 1 }),
+        expect.objectContaining({ exportType: "sample_screening_report", mobileFallbacks: 1 }),
+      ])
+    );
+    expect(JSON.stringify(diagnostics)).not.toContain("must not be projected");
+  });
+});

--- a/rentchain-api/src/lib/pdfExportObservability/derivePdfExportDiagnostics.ts
+++ b/rentchain-api/src/lib/pdfExportObservability/derivePdfExportDiagnostics.ts
@@ -1,0 +1,126 @@
+import type { PdfExportDiagnostics, PdfExportTelemetryRecord } from "./pdfExportObservabilityTypes";
+
+function asString(value: unknown, max = 120) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function asNumber(value: unknown) {
+  const next = Number(value);
+  return Number.isFinite(next) ? next : null;
+}
+
+function timestamp(value: unknown) {
+  const next = asNumber(value);
+  return next == null ? 0 : next;
+}
+
+function isoFromMillis(value: unknown) {
+  const millis = timestamp(value);
+  return new Date(millis || 0).toISOString();
+}
+
+function isPdfEvent(record: PdfExportTelemetryRecord) {
+  return asString(record.eventName).startsWith("pdf_");
+}
+
+export function derivePdfExportDiagnostics(records: PdfExportTelemetryRecord[]): PdfExportDiagnostics {
+  const pdfRecords = records.filter(isPdfEvent).sort((a, b) => timestamp(b.createdAt) - timestamp(a.createdAt));
+  const byExportType = new Map<string, { totalEvents: number; completed: number; failed: number; mobileFallbacks: number }>();
+  const byRenderingPath = new Map<string, { totalEvents: number }>();
+  let completed = 0;
+  let failed = 0;
+  let started = 0;
+  let mobileFallbacks = 0;
+  let downloads = 0;
+  let prints = 0;
+  let durationTotal = 0;
+  let durationCount = 0;
+  let totalBytes = 0;
+  let byteCount = 0;
+
+  for (const record of pdfRecords) {
+    const exportType = asString(record.eventProps?.exportType, 120) || "unknown";
+    const renderingPath = asString(record.eventProps?.renderingPath, 120) || "unknown";
+    const exportBucket = byExportType.get(exportType) || {
+      totalEvents: 0,
+      completed: 0,
+      failed: 0,
+      mobileFallbacks: 0,
+    };
+    exportBucket.totalEvents += 1;
+    if (record.eventName === "pdf_export_completed") {
+      completed += 1;
+      exportBucket.completed += 1;
+    }
+    if (record.eventName === "pdf_export_failed") {
+      failed += 1;
+      exportBucket.failed += 1;
+    }
+    if (record.eventName === "pdf_export_started") started += 1;
+    if (record.eventName === "pdf_mobile_fallback_used") {
+      mobileFallbacks += 1;
+      exportBucket.mobileFallbacks += 1;
+    }
+    if (record.eventName === "pdf_download_triggered") downloads += 1;
+    if (record.eventName === "pdf_print_opened") prints += 1;
+    byExportType.set(exportType, exportBucket);
+
+    const pathBucket = byRenderingPath.get(renderingPath) || { totalEvents: 0 };
+    pathBucket.totalEvents += 1;
+    byRenderingPath.set(renderingPath, pathBucket);
+
+    const durationMs = asNumber(record.eventProps?.durationMs);
+    if (durationMs != null && durationMs >= 0) {
+      durationTotal += durationMs;
+      durationCount += 1;
+    }
+    const byteSize = asNumber(record.eventProps?.byteSize);
+    if (byteSize != null && byteSize >= 0) {
+      totalBytes += byteSize;
+      byteCount += 1;
+    }
+  }
+
+  return {
+    diagnosticsId: "pdf_export_observability:latest",
+    generatedAt: new Date().toISOString(),
+    manualReviewRequired: true,
+    telemetryExecutionBlockingEnabled: false,
+    sensitiveContentLogged: false,
+    summary: {
+      totalEvents: pdfRecords.length,
+      started,
+      completed,
+      failed,
+      mobileFallbacks,
+      downloads,
+      prints,
+      averageDurationMs: durationCount ? Math.round(durationTotal / durationCount) : null,
+      totalBytes: byteCount ? totalBytes : null,
+    },
+    byExportType: Array.from(byExportType.entries())
+      .map(([exportType, counts]) => ({ exportType, ...counts }))
+      .sort((a, b) => b.totalEvents - a.totalEvents || a.exportType.localeCompare(b.exportType)),
+    byRenderingPath: Array.from(byRenderingPath.entries())
+      .map(([renderingPath, counts]) => ({ renderingPath, ...counts }))
+      .sort((a, b) => b.totalEvents - a.totalEvents || a.renderingPath.localeCompare(b.renderingPath)),
+    recentEvents: pdfRecords.slice(0, 25).map((record) => ({
+      eventId: record.id,
+      eventName: record.eventName,
+      createdAt: isoFromMillis(record.createdAt),
+      exportType: asString(record.eventProps?.exportType, 120) || null,
+      renderingPath: asString(record.eventProps?.renderingPath, 120) || null,
+      status: asString(record.eventProps?.status, 80) || null,
+      browserClass: asString(record.eventProps?.browserClass, 80) || null,
+      viewportCategory: asString(record.eventProps?.viewportCategory, 80) || null,
+      durationMs: asNumber(record.eventProps?.durationMs),
+      byteSize: asNumber(record.eventProps?.byteSize),
+      errorCode: asString(record.eventProps?.errorCode, 120) || null,
+    })),
+    privacyBoundaries: [
+      "PDF telemetry stores export metadata only.",
+      "Raw PDF contents, screening payloads, document body text, and payment account details are not collected.",
+      "Diagnostics are admin-scoped and non-blocking for export flows.",
+    ],
+  };
+}

--- a/rentchain-api/src/lib/pdfExportObservability/pdfExportObservabilityTypes.ts
+++ b/rentchain-api/src/lib/pdfExportObservability/pdfExportObservabilityTypes.ts
@@ -1,0 +1,94 @@
+export type PdfExportEventName =
+  | "pdf_export_started"
+  | "pdf_export_completed"
+  | "pdf_export_failed"
+  | "pdf_mobile_fallback_used"
+  | "pdf_download_triggered"
+  | "pdf_print_opened";
+
+export type PdfExportType =
+  | "sample_screening_report"
+  | "screening_report"
+  | "application_review_summary"
+  | "tenant_report"
+  | "lease_ledger"
+  | "lease_summary"
+  | "schedule_a"
+  | "transunion_usage"
+  | "print_summary"
+  | "unknown";
+
+export type PdfRenderingPath =
+  | "desktop_iframe"
+  | "mobile_fallback"
+  | "browser_download"
+  | "window_print"
+  | "backend_pdfkit"
+  | "frontend_pdf_builder"
+  | "signed_url"
+  | "unknown";
+
+export type PdfExportTelemetryRecord = {
+  id: string;
+  eventName: PdfExportEventName;
+  createdAt: number;
+  userId?: string | null;
+  landlordId?: string | null;
+  role?: string | null;
+  eventProps: {
+    exportType?: PdfExportType | string | null;
+    renderingPath?: PdfRenderingPath | string | null;
+    status?: string | null;
+    browserClass?: string | null;
+    viewportCategory?: string | null;
+    fallbackMode?: string | null;
+    durationMs?: number | null;
+    byteSize?: number | null;
+    pageCount?: number | null;
+    errorCode?: string | null;
+  };
+};
+
+export type PdfExportDiagnostics = {
+  diagnosticsId: string;
+  generatedAt: string;
+  manualReviewRequired: true;
+  telemetryExecutionBlockingEnabled: false;
+  sensitiveContentLogged: false;
+  summary: {
+    totalEvents: number;
+    started: number;
+    completed: number;
+    failed: number;
+    mobileFallbacks: number;
+    downloads: number;
+    prints: number;
+    averageDurationMs: number | null;
+    totalBytes: number | null;
+  };
+  byExportType: Array<{
+    exportType: string;
+    totalEvents: number;
+    completed: number;
+    failed: number;
+    mobileFallbacks: number;
+  }>;
+  byRenderingPath: Array<{
+    renderingPath: string;
+    totalEvents: number;
+  }>;
+  recentEvents: Array<{
+    eventId: string;
+    eventName: PdfExportEventName;
+    createdAt: string;
+    exportType: string | null;
+    renderingPath: string | null;
+    status: string | null;
+    browserClass: string | null;
+    viewportCategory: string | null;
+    durationMs: number | null;
+    byteSize: number | null;
+    errorCode: string | null;
+  }>;
+  privacyBoundaries: string[];
+};

--- a/rentchain-api/src/lib/pdfExportObservability/recordPdfExportTelemetry.ts
+++ b/rentchain-api/src/lib/pdfExportObservability/recordPdfExportTelemetry.ts
@@ -1,0 +1,62 @@
+import type { PdfExportEventName, PdfExportType, PdfRenderingPath } from "./pdfExportObservabilityTypes";
+
+type RecordPdfExportTelemetryInput = {
+  eventName: PdfExportEventName;
+  req?: any;
+  exportType: PdfExportType;
+  renderingPath: PdfRenderingPath;
+  status?: string | null;
+  durationMs?: number | null;
+  byteSize?: number | null;
+  errorCode?: string | null;
+};
+
+function asString(value: unknown, max = 120) {
+  return String(value || "").trim().slice(0, max);
+}
+
+function asNumber(value: unknown) {
+  const next = Number(value);
+  return Number.isFinite(next) ? next : null;
+}
+
+function browserClass(userAgent: string) {
+  const ua = userAgent.toLowerCase();
+  if (ua.includes("edg/")) return "edge";
+  if (ua.includes("chrome") || ua.includes("crios")) return "chrome";
+  if (ua.includes("firefox") || ua.includes("fxios")) return "firefox";
+  if (ua.includes("safari")) return "safari";
+  return "other";
+}
+
+export async function recordPdfExportTelemetry(input: RecordPdfExportTelemetryInput): Promise<void> {
+  try {
+    const { db } = await import("../../config/firebase");
+    const userId = asString(input.req?.user?.id, 160) || null;
+    const landlordId = asString(input.req?.user?.landlordId || input.req?.user?.id, 160) || null;
+    const role = asString(input.req?.user?.role || input.req?.user?.actorRole, 80) || "unknown";
+    const userAgent = asString(input.req?.headers?.["user-agent"], 400);
+    const durationMs = asNumber(input.durationMs);
+    const byteSize = asNumber(input.byteSize);
+
+    await db.collection("telemetry_events").add({
+      userId,
+      landlordId,
+      role,
+      eventName: input.eventName,
+      eventProps: {
+        exportType: input.exportType,
+        renderingPath: input.renderingPath,
+        status: input.status || null,
+        durationMs: durationMs == null ? null : Math.max(0, Math.round(durationMs)),
+        byteSize: byteSize == null ? null : Math.max(0, Math.round(byteSize)),
+        browserClass: userAgent ? browserClass(userAgent) : "unknown",
+        viewportCategory: "server",
+        errorCode: input.errorCode ? asString(input.errorCode, 120).toLowerCase().replace(/[^a-z0-9_:-]+/g, "_") : null,
+      },
+      createdAt: Date.now(),
+    });
+  } catch (err: any) {
+    console.warn("[pdfExportObservability] telemetry write skipped", err?.message || err);
+  }
+}

--- a/rentchain-api/src/routes/__tests__/adminPdfExportObservabilityRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/adminPdfExportObservabilityRoutes.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { collections, dbMock } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, any>>();
+  function ensureCollection(name: string) {
+    if (!collections.has(name)) collections.set(name, new Map<string, any>());
+    return collections.get(name)!;
+  }
+  return {
+    collections,
+    dbMock: {
+      collection: (name: string) => ({
+        async get() {
+          const docs = Array.from(ensureCollection(name).entries()).map(([id, data]) => ({
+            id,
+            data: () => data,
+          }));
+          return { docs, empty: docs.length === 0, size: docs.length };
+        },
+      }),
+    },
+  };
+});
+
+vi.mock("../../config/firebase", () => ({
+  db: dbMock,
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!req.user) return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+    return next();
+  },
+}));
+
+vi.mock("../../middleware/requireAuthz", () => ({
+  requirePermission: () => (req: any, res: any, next: any) => {
+    if (req.user?.role !== "admin") return res.status(403).json({ ok: false, error: "FORBIDDEN" });
+    return next();
+  },
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; user?: Record<string, unknown> | null }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path: options.url,
+      user: options.user || null,
+      query: {},
+      params: {},
+    };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+function seedTelemetry(id: string, data: any) {
+  if (!collections.has("telemetry_events")) collections.set("telemetry_events", new Map<string, any>());
+  collections.get("telemetry_events")!.set(id, data);
+}
+
+describe("adminPdfExportObservabilityRoutes", () => {
+  beforeEach(() => {
+    collections.clear();
+  });
+
+  it("returns admin-scoped PDF diagnostics with whitelisted metadata", async () => {
+    seedTelemetry("telemetry-1", {
+      eventName: "pdf_export_completed",
+      createdAt: Date.parse("2026-05-08T10:00:00.000Z"),
+      eventProps: {
+        exportType: "screening_report",
+        renderingPath: "backend_pdfkit",
+        status: "completed",
+        byteSize: 4096,
+        tenantName: "Sensitive Tenant",
+      },
+    });
+    seedTelemetry("telemetry-2", {
+      eventName: "nudge_clicked",
+      createdAt: Date.parse("2026-05-08T10:01:00.000Z"),
+      eventProps: {},
+    });
+
+    const router = (await import("../adminPdfExportObservabilityRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/pdf-export-observability",
+      user: { id: "admin-1", role: "admin" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.summary.totalEvents).toBe(1);
+    expect(res.body.summary.completed).toBe(1);
+    expect(res.body.sensitiveContentLogged).toBe(false);
+    expect(JSON.stringify(res.body)).not.toContain("Sensitive Tenant");
+  });
+
+  it("blocks non-admin diagnostics access", async () => {
+    const router = (await import("../adminPdfExportObservabilityRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/pdf-export-observability",
+      user: { id: "landlord-1", role: "landlord" },
+    });
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/rentchain-api/src/routes/__tests__/telemetryRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/telemetryRoutes.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { collections, dbMock } = vi.hoisted(() => {
+  const collections = new Map<string, Map<string, any>>();
+  let autoId = 0;
+  function ensureCollection(name: string) {
+    if (!collections.has(name)) collections.set(name, new Map<string, any>());
+    return collections.get(name)!;
+  }
+  return {
+    collections,
+    dbMock: {
+      collection: (name: string) => ({
+        add: async (payload: any) => {
+          const id = `auto_${++autoId}`;
+          ensureCollection(name).set(id, payload);
+          return { id };
+        },
+      }),
+    },
+  };
+});
+
+vi.mock("../../config/firebase", () => ({
+  db: dbMock,
+}));
+
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    if (!req.user) return res.status(401).json({ ok: false, error: "Unauthorized" });
+    return next();
+  },
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; user?: Record<string, unknown> | null; body?: any }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path: options.url,
+      user: options.user || null,
+      body: options.body || {},
+    };
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, (error: any) => {
+      if (error) reject(error);
+    });
+  });
+}
+
+describe("telemetryRoutes", () => {
+  beforeEach(() => {
+    collections.clear();
+  });
+
+  it("accepts PDF export telemetry and redacts sensitive keys", async () => {
+    const router = (await import("../telemetryRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/telemetry",
+      user: { id: "user-1", role: "landlord", landlordId: "landlord-1" },
+      body: {
+        eventName: "pdf_export_completed",
+        eventProps: {
+          exportType: "lease_summary",
+          renderingPath: "frontend_pdf_builder",
+          durationMs: 22,
+          tenantName: "Private Tenant",
+          documentText: "not a reserved key but should be short metadata only",
+        },
+      },
+    });
+
+    expect(res.status).toBe(200);
+    const stored = Array.from(collections.get("telemetry_events")?.values() || []);
+    expect(stored).toHaveLength(1);
+    expect(stored[0]).toMatchObject({
+      userId: "user-1",
+      landlordId: "landlord-1",
+      role: "landlord",
+      eventName: "pdf_export_completed",
+    });
+    expect(stored[0].eventProps.tenantName).toBeUndefined();
+    expect(stored[0].eventProps.documentText).toBeUndefined();
+  });
+
+  it("continues rejecting unrelated telemetry event families", async () => {
+    const router = (await import("../telemetryRoutes")).default;
+    const res = await invokeRouter(router, {
+      method: "POST",
+      url: "/telemetry",
+      user: { id: "user-1", role: "landlord" },
+      body: { eventName: "tenant_profile_opened", eventProps: {} },
+    });
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/rentchain-api/src/routes/adminPdfExportObservabilityRoutes.ts
+++ b/rentchain-api/src/routes/adminPdfExportObservabilityRoutes.ts
@@ -1,0 +1,38 @@
+import { Router } from "express";
+import { db } from "../config/firebase";
+import { requireAuth } from "../middleware/requireAuth";
+import { requirePermission } from "../middleware/requireAuthz";
+import { derivePdfExportDiagnostics } from "../lib/pdfExportObservability/derivePdfExportDiagnostics";
+import type { PdfExportTelemetryRecord } from "../lib/pdfExportObservability/pdfExportObservabilityTypes";
+
+const router = Router();
+
+function normalizeRecord(doc: any): PdfExportTelemetryRecord | null {
+  const data = doc?.data?.() || {};
+  const eventName = String(data.eventName || "").trim();
+  if (!eventName.startsWith("pdf_")) return null;
+  return {
+    id: String(doc.id || "").trim(),
+    eventName: eventName as PdfExportTelemetryRecord["eventName"],
+    createdAt: Number(data.createdAt || 0),
+    userId: data.userId == null ? null : String(data.userId),
+    landlordId: data.landlordId == null ? null : String(data.landlordId),
+    role: data.role == null ? null : String(data.role),
+    eventProps: data.eventProps && typeof data.eventProps === "object" ? data.eventProps : {},
+  };
+}
+
+router.get("/pdf-export-observability", requireAuth, requirePermission("system.admin"), async (_req: any, res) => {
+  try {
+    const snap = await db.collection("telemetry_events").get();
+    const records = (snap.docs || [])
+      .map(normalizeRecord)
+      .filter(Boolean) as PdfExportTelemetryRecord[];
+    return res.json(derivePdfExportDiagnostics(records));
+  } catch (err: any) {
+    console.error("[adminPdfExportObservabilityRoutes] diagnostics failed", err?.message || err);
+    return res.status(500).json({ ok: false, error: "pdf_export_observability_failed" });
+  }
+});
+
+export default router;

--- a/rentchain-api/src/routes/adminScreeningUsageRoutes.ts
+++ b/rentchain-api/src/routes/adminScreeningUsageRoutes.ts
@@ -3,6 +3,7 @@ import { requireAuth } from "../middleware/requireAuth";
 import { requirePermission } from "../middleware/requireAuthz";
 import { loadTransUnionUsageReport } from "../services/screening/transUnionUsageReportService";
 import { buildTransUnionUsagePdfBuffer } from "../services/screening/transUnionUsageReportPdf";
+import { recordPdfExportTelemetry } from "../lib/pdfExportObservability/recordPdfExportTelemetry";
 const router = Router();
 
 function getReportQuery(req: any) {
@@ -33,6 +34,7 @@ router.get(
   requireAuth,
   requirePermission("system.admin"),
   async (req: any, res) => {
+    const startedAt = Date.now();
     try {
       const report = await loadTransUnionUsageReport(getReportQuery(req));
       const pdfBuffer = await buildTransUnionUsagePdfBuffer(report);
@@ -42,8 +44,26 @@ router.get(
         "Content-Disposition",
         'attachment; filename="rentchain-transunion-usage-summary-v1.pdf"'
       );
+      void recordPdfExportTelemetry({
+        eventName: "pdf_export_completed",
+        req,
+        exportType: "transunion_usage",
+        renderingPath: "backend_pdfkit",
+        status: "completed",
+        durationMs: Date.now() - startedAt,
+        byteSize: pdfBuffer.byteLength,
+      });
       return res.status(200).send(pdfBuffer);
     } catch (err: any) {
+      void recordPdfExportTelemetry({
+        eventName: "pdf_export_failed",
+        req,
+        exportType: "transunion_usage",
+        renderingPath: "backend_pdfkit",
+        status: "failed",
+        durationMs: Date.now() - startedAt,
+        errorCode: err?.message || "transunion_usage_pdf_failed",
+      });
       console.error("[adminScreeningUsageRoutes] transunion usage pdf failed", err?.message || err);
       return res.status(500).json({ ok: false, error: "transunion_usage_pdf_failed" });
     }

--- a/rentchain-api/src/routes/leaseRoutes.ts
+++ b/rentchain-api/src/routes/leaseRoutes.ts
@@ -1,5 +1,6 @@
 import { Router, Request, Response } from "express";
 import PDFDocument from "pdfkit";
+import { recordPdfExportTelemetry } from "../lib/pdfExportObservability/recordPdfExportTelemetry";
 import {
   CreateLeasePayload,
   leaseService,
@@ -2687,6 +2688,7 @@ router.get("/:leaseId/ledger/export.csv", async (req: any, res: Response) => {
 });
 
 router.get("/:leaseId/ledger/export.pdf", async (req: any, res: Response) => {
+  const startedAt = Date.now();
   try {
     const landlordId = req.user?.landlordId || req.user?.id;
     if (!landlordId) return res.status(401).json({ ok: false, error: "Unauthorized" });
@@ -2706,8 +2708,26 @@ router.get("/:leaseId/ledger/export.pdf", async (req: any, res: Response) => {
       "Content-Disposition",
       `attachment; filename=\"lease-ledger-${leaseId}.pdf\"`
     );
+    void recordPdfExportTelemetry({
+      eventName: "pdf_export_completed",
+      req,
+      exportType: "lease_ledger",
+      renderingPath: "backend_pdfkit",
+      status: "completed",
+      durationMs: Date.now() - startedAt,
+      byteSize: pdf.byteLength,
+    });
     return res.status(200).send(pdf);
   } catch (err) {
+    void recordPdfExportTelemetry({
+      eventName: "pdf_export_failed",
+      req,
+      exportType: "lease_ledger",
+      renderingPath: "backend_pdfkit",
+      status: "failed",
+      durationMs: Date.now() - startedAt,
+      errorCode: err instanceof Error ? err.message : "lease_ledger_pdf_failed",
+    });
     console.error("[GET /api/leases/:leaseId/ledger/export.pdf] error", err);
     return res.status(500).json({ ok: false, error: "Failed to export lease ledger PDF" });
   }

--- a/rentchain-api/src/routes/screeningReportHandler.ts
+++ b/rentchain-api/src/routes/screeningReportHandler.ts
@@ -1,7 +1,9 @@
 import { getReportExport, getExportPdfBuffer, validateToken } from "../services/screening/reportExportService";
 import { requireCapability } from "../services/capabilityGuard";
+import { recordPdfExportTelemetry } from "../lib/pdfExportObservability/recordPdfExportTelemetry";
 
 export async function handleScreeningReport(req: any, res: any) {
+  const startedAt = Date.now();
   try {
     const exportId = String(req.query?.exportId || "").trim();
     const token = String(req.query?.token || "").trim();
@@ -56,8 +58,26 @@ export async function handleScreeningReport(req: any, res: any) {
 
     res.setHeader("Content-Type", "application/pdf");
     res.setHeader("Content-Disposition", `attachment; filename=\"screening_${exportId}.pdf\"`);
+    void recordPdfExportTelemetry({
+      eventName: "pdf_export_completed",
+      req,
+      exportType: "screening_report",
+      renderingPath: "backend_pdfkit",
+      status: "completed",
+      durationMs: Date.now() - startedAt,
+      byteSize: pdfBuffer.byteLength,
+    });
     return res.status(200).send(pdfBuffer);
   } catch (err: any) {
+    void recordPdfExportTelemetry({
+      eventName: "pdf_export_failed",
+      req,
+      exportType: "screening_report",
+      renderingPath: "backend_pdfkit",
+      status: "failed",
+      durationMs: Date.now() - startedAt,
+      errorCode: err?.message || "screening_report_failed",
+    });
     console.error("[screening_report] read failed", err?.message || err);
     return res.status(500).json({ ok: false, error: "SCREENING_REPORT_FAILED" });
   }

--- a/rentchain-api/src/routes/telemetryRoutes.ts
+++ b/rentchain-api/src/routes/telemetryRoutes.ts
@@ -4,7 +4,21 @@ import { requireAuth } from "../middleware/requireAuth";
 
 const router = Router();
 
-const REDACT_KEYS = ["email", "phone", "address", "name", "fullName", "tenantEmail", "tenantName"];
+const REDACT_KEYS = [
+  "email",
+  "phone",
+  "address",
+  "name",
+  "fullName",
+  "tenantEmail",
+  "tenantName",
+  "documentText",
+  "documentBody",
+  "pdfContent",
+  "screeningPayload",
+  "paymentAccount",
+];
+const ALLOWED_EVENT_PREFIXES = ["nudge_", "pdf_"];
 
 function sanitizeValue(value: any, depth = 0): any {
   if (depth > 3) return null;
@@ -29,7 +43,7 @@ router.post("/telemetry", requireAuth, async (req: any, res) => {
   if (!userId) return res.status(401).json({ ok: false, error: "Unauthorized" });
 
   const eventName = String(req.body?.eventName || "").trim().toLowerCase();
-  if (!eventName || !eventName.startsWith("nudge_")) {
+  if (!eventName || !ALLOWED_EVENT_PREFIXES.some((prefix) => eventName.startsWith(prefix))) {
     return res.status(400).json({ ok: false, error: "invalid_event_name" });
   }
 

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -139,6 +139,7 @@ const RentalDebtPage = lazy(() => import("./pages/RentalDebtPage"));
 const CourtDisputeLineagePage = lazy(() => import("./pages/CourtDisputeLineagePage"));
 const OnboardingHardeningPage = lazy(() => import("./pages/OnboardingHardeningPage"));
 const SupportOperationsPage = lazy(() => import("./pages/SupportOperationsPage"));
+const PdfExportObservabilityPage = lazy(() => import("./pages/PdfExportObservabilityPage"));
 const SettlementReadinessPage = lazy(() => import("./pages/SettlementReadinessPage"));
 const RegulatoryProfilePage = lazy(() => import("./pages/RegulatoryProfilePage"));
 const AssetTokenizationReadinessPage = lazy(() => import("./pages/AssetTokenizationReadinessPage"));
@@ -1332,6 +1333,14 @@ function App() {
               element={
                 <RequireAdmin>
                   <AdminObservabilityPage />
+                </RequireAdmin>
+              }
+            />
+            <Route
+              path="/admin/pdf-export-observability"
+              element={
+                <RequireAdmin>
+                  <PdfExportObservabilityPage />
                 </RequireAdmin>
               }
             />

--- a/rentchain-frontend/src/api/adminScreeningUsageApi.ts
+++ b/rentchain-frontend/src/api/adminScreeningUsageApi.ts
@@ -3,6 +3,7 @@ import { getAuthToken } from "../lib/authToken";
 import { getFirebaseIdToken } from "../lib/firebaseAuthToken";
 import { apiFetch } from "./apiFetch";
 import { parseContentDispositionFilename } from "./exportDownload";
+import { createPdfExportTimer, errorCodeFromUnknown, recordPdfExportEvent } from "../lib/pdfExportObservability";
 
 export type TransUnionUsageReport = {
   ok: true;
@@ -94,32 +95,56 @@ export async function fetchAdminTransUnionUsage(params?: TransUnionUsageReportPa
 }
 
 export async function downloadAdminTransUnionUsagePdf(params?: TransUnionUsageReportParams) {
+  const timer = createPdfExportTimer();
+  recordPdfExportEvent("pdf_export_started", {
+    exportType: "transunion_usage",
+    renderingPath: "backend_pdfkit",
+    status: "started",
+  });
   const token = getAuthToken() || (await getFirebaseIdToken()) || "";
   const path = `/admin/screening/transunion-usage/pdf${buildTransUnionUsageQuery(params)}`;
-  const response = await fetch(apiUrl(path), {
-    method: "GET",
-    headers: token ? { Authorization: `Bearer ${token}` } : {},
-    credentials: "include",
-  });
+  try {
+    const response = await fetch(apiUrl(path), {
+      method: "GET",
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+      credentials: "include",
+    });
 
-  if (!response.ok) {
-    const text = await response.text().catch(() => "");
-    let message = text || "Failed to export PDF report";
-    try {
-      const json = text ? JSON.parse(text) : null;
-      message = json?.message || json?.error || message;
-    } catch {
-      // Ignore non-JSON error responses.
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      let message = text || "Failed to export PDF report";
+      try {
+        const json = text ? JSON.parse(text) : null;
+        message = json?.message || json?.error || message;
+      } catch {
+        // Ignore non-JSON error responses.
+      }
+      throw new Error(message);
     }
-    throw new Error(message);
-  }
 
-  const blob = await response.blob();
-  return {
-    blob,
-    filename: parseContentDispositionFilename(
-      response.headers.get("Content-Disposition"),
-      "rentchain-transunion-usage-summary-v1.pdf"
-    ),
-  };
+    const blob = await response.blob();
+    recordPdfExportEvent("pdf_export_completed", {
+      exportType: "transunion_usage",
+      renderingPath: "backend_pdfkit",
+      status: "completed",
+      durationMs: timer.durationMs(),
+      byteSize: blob.size,
+    });
+    return {
+      blob,
+      filename: parseContentDispositionFilename(
+        response.headers.get("Content-Disposition"),
+        "rentchain-transunion-usage-summary-v1.pdf"
+      ),
+    };
+  } catch (error) {
+    recordPdfExportEvent("pdf_export_failed", {
+      exportType: "transunion_usage",
+      renderingPath: "backend_pdfkit",
+      status: "failed",
+      durationMs: timer.durationMs(),
+      errorCode: errorCodeFromUnknown(error),
+    });
+    throw error;
+  }
 }

--- a/rentchain-frontend/src/api/exportDownload.test.ts
+++ b/rentchain-frontend/src/api/exportDownload.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   getAuthTokenMock: vi.fn(),
+  logTelemetryEventMock: vi.fn(),
 }));
 
 vi.mock("./config", () => ({
@@ -12,10 +13,15 @@ vi.mock("../lib/authToken", () => ({
   getAuthToken: mocks.getAuthTokenMock,
 }));
 
+vi.mock("./telemetryApi", () => ({
+  logTelemetryEvent: mocks.logTelemetryEventMock,
+}));
+
 describe("exportDownload", () => {
   beforeEach(() => {
     vi.resetModules();
     mocks.getAuthTokenMock.mockReset();
+    mocks.logTelemetryEventMock.mockReset();
     mocks.getAuthTokenMock.mockReturnValue("session-token");
   });
 
@@ -56,5 +62,35 @@ describe("exportDownload", () => {
       credentials: "include",
     });
     expect(result.filename).toBe("rentchain-payments-2026-04-29.csv");
+  });
+
+  it("emits non-blocking PDF export telemetry when observability metadata is provided", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      blob: async () => new Blob(["pdf"], { type: "application/pdf" }),
+      headers: {
+        get: () => 'attachment; filename="lease-ledger.pdf"',
+      },
+    } as any) as any;
+
+    const { downloadAuthenticatedExport } = await import("./exportDownload");
+    await downloadAuthenticatedExport({
+      path: "/leases/lease-1/ledger/export.pdf",
+      fallbackFilename: "lease-ledger.pdf",
+      errorMessage: "Failed to export lease ledger",
+      observability: {
+        exportType: "lease_ledger",
+        renderingPath: "backend_pdfkit",
+      },
+    });
+
+    expect(mocks.logTelemetryEventMock).toHaveBeenCalledWith(
+      "pdf_export_started",
+      expect.objectContaining({ exportType: "lease_ledger", renderingPath: "backend_pdfkit" })
+    );
+    expect(mocks.logTelemetryEventMock).toHaveBeenCalledWith(
+      "pdf_export_completed",
+      expect.objectContaining({ exportType: "lease_ledger", byteSize: 3 })
+    );
   });
 });

--- a/rentchain-frontend/src/api/exportDownload.ts
+++ b/rentchain-frontend/src/api/exportDownload.ts
@@ -1,10 +1,21 @@
 import { apiUrl } from "./config";
 import { getAuthToken } from "../lib/authToken";
+import {
+  createPdfExportTimer,
+  errorCodeFromUnknown,
+  recordPdfExportEvent,
+  type PdfExportType,
+  type PdfRenderingPath,
+} from "../lib/pdfExportObservability";
 
 type DownloadAuthenticatedExportOptions = {
   path: string;
   fallbackFilename: string;
   errorMessage: string;
+  observability?: {
+    exportType: PdfExportType;
+    renderingPath?: PdfRenderingPath;
+  };
 };
 
 export function parseContentDispositionFilename(
@@ -20,28 +31,59 @@ export async function downloadAuthenticatedExport({
   path,
   fallbackFilename,
   errorMessage,
+  observability,
 }: DownloadAuthenticatedExportOptions): Promise<{ blob: Blob; filename: string }> {
-  const token = getAuthToken();
-  const response = await fetch(apiUrl(path), {
-    method: "GET",
-    headers: token ? { Authorization: `Bearer ${token}` } : {},
-    credentials: "include",
-  });
-
-  if (!response.ok) {
-    const text = await response.text().catch(() => "");
-    let message = text || errorMessage;
-    try {
-      const json = text ? JSON.parse(text) : null;
-      message = json?.message || json?.error || message;
-    } catch {
-      // Ignore non-JSON responses and fall back to the provided message.
-    }
-    throw new Error(message);
+  const timer = createPdfExportTimer();
+  if (observability) {
+    recordPdfExportEvent("pdf_export_started", {
+      exportType: observability.exportType,
+      renderingPath: observability.renderingPath || "backend_pdfkit",
+      status: "started",
+    });
   }
+  const token = getAuthToken();
+  try {
+    const response = await fetch(apiUrl(path), {
+      method: "GET",
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+      credentials: "include",
+    });
 
-  const blob = await response.blob();
-  const filename = parseContentDispositionFilename(response.headers.get("Content-Disposition"), fallbackFilename);
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      let message = text || errorMessage;
+      try {
+        const json = text ? JSON.parse(text) : null;
+        message = json?.message || json?.error || message;
+      } catch {
+        // Ignore non-JSON responses and fall back to the provided message.
+      }
+      throw new Error(message);
+    }
 
-  return { blob, filename };
+    const blob = await response.blob();
+    const filename = parseContentDispositionFilename(response.headers.get("Content-Disposition"), fallbackFilename);
+    if (observability) {
+      recordPdfExportEvent("pdf_export_completed", {
+        exportType: observability.exportType,
+        renderingPath: observability.renderingPath || "backend_pdfkit",
+        status: "completed",
+        durationMs: timer.durationMs(),
+        byteSize: blob.size,
+      });
+    }
+
+    return { blob, filename };
+  } catch (error) {
+    if (observability) {
+      recordPdfExportEvent("pdf_export_failed", {
+        exportType: observability.exportType,
+        renderingPath: observability.renderingPath || "backend_pdfkit",
+        status: "failed",
+        durationMs: timer.durationMs(),
+        errorCode: errorCodeFromUnknown(error),
+      });
+    }
+    throw error;
+  }
 }

--- a/rentchain-frontend/src/api/pdfExportObservabilityApi.ts
+++ b/rentchain-frontend/src/api/pdfExportObservabilityApi.ts
@@ -1,0 +1,49 @@
+import { apiFetch } from "./apiFetch";
+
+export type PdfExportDiagnostics = {
+  diagnosticsId: string;
+  generatedAt: string;
+  manualReviewRequired: true;
+  telemetryExecutionBlockingEnabled: false;
+  sensitiveContentLogged: false;
+  summary: {
+    totalEvents: number;
+    started: number;
+    completed: number;
+    failed: number;
+    mobileFallbacks: number;
+    downloads: number;
+    prints: number;
+    averageDurationMs: number | null;
+    totalBytes: number | null;
+  };
+  byExportType: Array<{
+    exportType: string;
+    totalEvents: number;
+    completed: number;
+    failed: number;
+    mobileFallbacks: number;
+  }>;
+  byRenderingPath: Array<{
+    renderingPath: string;
+    totalEvents: number;
+  }>;
+  recentEvents: Array<{
+    eventId: string;
+    eventName: string;
+    createdAt: string;
+    exportType: string | null;
+    renderingPath: string | null;
+    status: string | null;
+    browserClass: string | null;
+    viewportCategory: string | null;
+    durationMs: number | null;
+    byteSize: number | null;
+    errorCode: string | null;
+  }>;
+  privacyBoundaries: string[];
+};
+
+export async function fetchPdfExportDiagnostics(): Promise<PdfExportDiagnostics> {
+  return await apiFetch<PdfExportDiagnostics>("/admin/pdf-export-observability");
+}

--- a/rentchain-frontend/src/api/telemetryApi.ts
+++ b/rentchain-frontend/src/api/telemetryApi.ts
@@ -7,7 +7,7 @@ export async function logTelemetryEvent(
 ): Promise<void> {
   if (!isTelemetryEnabled()) return;
   const normalized = String(eventName || "").trim().toLowerCase();
-  if (!normalized.startsWith("nudge_")) return;
+  if (!normalized.startsWith("nudge_") && !normalized.startsWith("pdf_")) return;
   try {
     await apiFetch("/telemetry", {
       method: "POST",

--- a/rentchain-frontend/src/api/tenantsApi.ts
+++ b/rentchain-frontend/src/api/tenantsApi.ts
@@ -1,5 +1,6 @@
 import { apiJson, getAuthToken, resolveApiUrl } from "@/lib/apiClient";
 import { getFirebaseIdToken } from "@/lib/firebaseAuthToken";
+import { createPdfExportTimer, errorCodeFromUnknown, recordPdfExportEvent } from "@/lib/pdfExportObservability";
 import { apiFetch } from "./http";
 
 type TenantListResponse = TenantApiModel[] | { tenants?: TenantApiModel[] };
@@ -69,6 +70,12 @@ export async function fetchTenants(): Promise<TenantApiModel[]> {
 }
 
 export async function downloadTenantReport(tenantId: string): Promise<{ filename: string; blob: Blob }> {
+  const timer = createPdfExportTimer();
+  recordPdfExportEvent("pdf_export_started", {
+    exportType: "tenant_report",
+    renderingPath: "backend_pdfkit",
+    status: "started",
+  });
   const path = `/tenants/${encodeURIComponent(tenantId)}/report`;
   const url = resolveApiUrl(path);
   const bearerToken = getAuthToken();
@@ -84,37 +91,55 @@ export async function downloadTenantReport(tenantId: string): Promise<{ filename
     headers.set("Authorization", `Bearer ${token}`);
   }
 
-  const response = await fetch(url, {
-    method: "GET",
-    headers,
-    credentials: "include",
-  });
+  try {
+    const response = await fetch(url, {
+      method: "GET",
+      headers,
+      credentials: "include",
+    });
 
-  const contentType = response.headers.get("content-type") || "";
-  if (!response.ok) {
-    const payload: unknown = contentType.includes("application/json")
-      ? await response.json().catch(() => null)
-      : await response.text().catch(() => "");
-    const payloadRecord =
-      payload && typeof payload === "object" ? (payload as Record<string, unknown>) : null;
-    const message =
-      payloadRecord?.message ||
-      payloadRecord?.error ||
-      payloadRecord?.code ||
-      (typeof payload === "string" ? payload : "") ||
-      `Tenant report download failed (${response.status})`;
-    const err: ApiErrorShape = new Error(String(message));
-    err.payload = payload;
-    err.status = response.status;
-    throw err;
+    const contentType = response.headers.get("content-type") || "";
+    if (!response.ok) {
+      const payload: unknown = contentType.includes("application/json")
+        ? await response.json().catch(() => null)
+        : await response.text().catch(() => "");
+      const payloadRecord =
+        payload && typeof payload === "object" ? (payload as Record<string, unknown>) : null;
+      const message =
+        payloadRecord?.message ||
+        payloadRecord?.error ||
+        payloadRecord?.code ||
+        (typeof payload === "string" ? payload : "") ||
+        `Tenant report download failed (${response.status})`;
+      const err: ApiErrorShape = new Error(String(message));
+      err.payload = payload;
+      err.status = response.status;
+      throw err;
+    }
+
+    const blob = await response.blob();
+    const disposition = response.headers.get("content-disposition") || "";
+    const match = disposition.match(/filename="?([^"]+)"?/i);
+    const filename = match?.[1] || `tenant-summary-${tenantId}.pdf`;
+    recordPdfExportEvent("pdf_export_completed", {
+      exportType: "tenant_report",
+      renderingPath: "backend_pdfkit",
+      status: "completed",
+      durationMs: timer.durationMs(),
+      byteSize: blob.size,
+    });
+
+    return { filename, blob };
+  } catch (error) {
+    recordPdfExportEvent("pdf_export_failed", {
+      exportType: "tenant_report",
+      renderingPath: "backend_pdfkit",
+      status: "failed",
+      durationMs: timer.durationMs(),
+      errorCode: errorCodeFromUnknown(error),
+    });
+    throw error;
   }
-
-  const blob = await response.blob();
-  const disposition = response.headers.get("content-disposition") || "";
-  const match = disposition.match(/filename="?([^"]+)"?/i);
-  const filename = match?.[1] || `tenant-summary-${tenantId}.pdf`;
-
-  return { filename, blob };
 }
 
 export async function fetchTenantTenancies(tenantId: string): Promise<TenancyApiModel[]> {

--- a/rentchain-frontend/src/components/billing/SamplePdfModal.test.tsx
+++ b/rentchain-frontend/src/components/billing/SamplePdfModal.test.tsx
@@ -2,6 +2,14 @@ import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { SamplePdfModal } from "./SamplePdfModal";
 
+const telemetryMocks = vi.hoisted(() => ({
+  logTelemetryEvent: vi.fn(),
+}));
+
+vi.mock("../../api/telemetryApi", () => ({
+  logTelemetryEvent: telemetryMocks.logTelemetryEvent,
+}));
+
 function mockViewport(options: { width: number; coarsePointer: boolean }) {
   Object.defineProperty(window, "innerWidth", {
     configurable: true,
@@ -41,6 +49,16 @@ describe("SamplePdfModal", () => {
     render(<SamplePdfModal open onClose={vi.fn()} />);
 
     await waitFor(() => expect(screen.getByText("Open the sample PDF")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(telemetryMocks.logTelemetryEvent).toHaveBeenCalledWith(
+        "pdf_mobile_fallback_used",
+        expect.objectContaining({
+          exportType: "sample_screening_report",
+          renderingPath: "mobile_fallback",
+          fallbackMode: "mobile_open_download",
+        })
+      )
+    );
     expect(screen.queryByTitle("Sample screening report PDF")).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Open PDF" })).toHaveAttribute(
       "href",

--- a/rentchain-frontend/src/components/billing/SamplePdfModal.tsx
+++ b/rentchain-frontend/src/components/billing/SamplePdfModal.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
+import { recordPdfExportEvent } from "../../lib/pdfExportObservability";
 import { useMobilePdfPreviewGuard } from "../../utils/pdfPreviewGuard";
 
 type Props = {
@@ -53,6 +54,16 @@ export function SamplePdfModal({ open, onClose }: Props) {
     );
     focusable?.focus();
   }, [open]);
+
+  useEffect(() => {
+    if (!open || !useMobileFallback) return;
+    recordPdfExportEvent("pdf_mobile_fallback_used", {
+      exportType: "sample_screening_report",
+      renderingPath: "mobile_fallback",
+      status: "fallback_used",
+      fallbackMode: "mobile_open_download",
+    });
+  }, [open, useMobileFallback]);
 
   if (!open) return null;
 
@@ -128,6 +139,11 @@ export function SamplePdfModal({ open, onClose }: Props) {
             <button
               type="button"
               onClick={() => {
+                recordPdfExportEvent("pdf_download_triggered", {
+                  exportType: "sample_screening_report",
+                  renderingPath: "signed_url",
+                  status: "download_triggered",
+                });
                 if (typeof window !== "undefined") {
                   window.location.assign(pdfUrl);
                 }
@@ -149,6 +165,13 @@ export function SamplePdfModal({ open, onClose }: Props) {
               href={pdfUrl}
               target="_blank"
               rel="noreferrer"
+              onClick={() =>
+                recordPdfExportEvent("pdf_download_triggered", {
+                  exportType: "sample_screening_report",
+                  renderingPath: "signed_url",
+                  status: "download_triggered",
+                })
+              }
               style={{
                 fontSize: 13,
                 color: "#0f172a",
@@ -194,10 +217,33 @@ export function SamplePdfModal({ open, onClose }: Props) {
                 Mobile browsers handle PDF files more reliably in the browser viewer or download manager.
               </div>
               <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
-                <a href={pdfUrl} target="_blank" rel="noreferrer">
+                <a
+                  href={pdfUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  onClick={() =>
+                    recordPdfExportEvent("pdf_download_triggered", {
+                      exportType: "sample_screening_report",
+                      renderingPath: "mobile_fallback",
+                      status: "download_triggered",
+                      fallbackMode: "mobile_open_download",
+                    })
+                  }
+                >
                   Open PDF
                 </a>
-                <a href={pdfUrl} download>
+                <a
+                  href={pdfUrl}
+                  download
+                  onClick={() =>
+                    recordPdfExportEvent("pdf_download_triggered", {
+                      exportType: "sample_screening_report",
+                      renderingPath: "mobile_fallback",
+                      status: "download_triggered",
+                      fallbackMode: "mobile_open_download",
+                    })
+                  }
+                >
                   Download PDF
                 </a>
               </div>
@@ -214,7 +260,22 @@ export function SamplePdfModal({ open, onClose }: Props) {
                 border: "none",
                 display: "block",
               }}
-              onError={() => setLoadError(true)}
+              onLoad={() =>
+                recordPdfExportEvent("pdf_export_completed", {
+                  exportType: "sample_screening_report",
+                  renderingPath: "desktop_iframe",
+                  status: "completed",
+                })
+              }
+              onError={() => {
+                setLoadError(true);
+                recordPdfExportEvent("pdf_export_failed", {
+                  exportType: "sample_screening_report",
+                  renderingPath: "desktop_iframe",
+                  status: "failed",
+                  errorCode: "iframe_load_error",
+                });
+              }}
             />
           )}
         </div>

--- a/rentchain-frontend/src/components/layout/navConfig.ts
+++ b/rentchain-frontend/src/components/layout/navConfig.ts
@@ -181,6 +181,13 @@ export const NAV_ITEMS: NavItem[] = [
     showInDrawer: true,
   },
   {
+    id: "pdf-export-observability",
+    label: "PDF Observability",
+    to: "/admin/pdf-export-observability",
+    requiresAdmin: true,
+    showInDrawer: true,
+  },
+  {
     id: "production-integrations",
     label: "Production Integrations",
     to: "/admin/production-integrations",

--- a/rentchain-frontend/src/components/pdfExport/PdfExportObservabilityPanel.test.tsx
+++ b/rentchain-frontend/src/components/pdfExport/PdfExportObservabilityPanel.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { PdfExportObservabilityPanel } from "./PdfExportObservabilityPanel";
+import type { PdfExportDiagnostics } from "@/api/pdfExportObservabilityApi";
+
+const diagnostics: PdfExportDiagnostics = {
+  diagnosticsId: "pdf_export_observability:latest",
+  generatedAt: "2026-05-08T10:00:00.000Z",
+  manualReviewRequired: true,
+  telemetryExecutionBlockingEnabled: false,
+  sensitiveContentLogged: false,
+  summary: {
+    totalEvents: 3,
+    started: 1,
+    completed: 1,
+    failed: 1,
+    mobileFallbacks: 1,
+    downloads: 1,
+    prints: 0,
+    averageDurationMs: 40,
+    totalBytes: 2048,
+  },
+  byExportType: [{ exportType: "lease_summary", totalEvents: 2, completed: 1, failed: 1, mobileFallbacks: 0 }],
+  byRenderingPath: [{ renderingPath: "frontend_pdf_builder", totalEvents: 2 }],
+  recentEvents: [
+    {
+      eventId: "event-1",
+      eventName: "pdf_export_failed",
+      createdAt: "2026-05-08T10:00:00.000Z",
+      exportType: "lease_summary",
+      renderingPath: "frontend_pdf_builder",
+      status: "failed",
+      browserClass: "chrome",
+      viewportCategory: "desktop",
+      durationMs: 40,
+      byteSize: null,
+      errorCode: "render_failed",
+    },
+  ],
+  privacyBoundaries: ["PDF telemetry stores export metadata only."],
+};
+
+describe("PdfExportObservabilityPanel", () => {
+  it("renders diagnostics and privacy boundaries", () => {
+    render(<PdfExportObservabilityPanel diagnostics={diagnostics} />);
+
+    expect(screen.getByText("PDF export observability")).toBeInTheDocument();
+    expect(screen.getByText("Mobile fallbacks")).toBeInTheDocument();
+    expect(screen.getByText(/PDF export telemetry is operational metadata only/i)).toBeInTheDocument();
+    expect(screen.getByText("Lease Summary")).toBeInTheDocument();
+    expect(screen.getByText("render_failed")).toBeInTheDocument();
+    expect(screen.getByText("PDF telemetry stores export metadata only.")).toBeInTheDocument();
+  });
+});

--- a/rentchain-frontend/src/components/pdfExport/PdfExportObservabilityPanel.tsx
+++ b/rentchain-frontend/src/components/pdfExport/PdfExportObservabilityPanel.tsx
@@ -1,0 +1,96 @@
+import type { PdfExportDiagnostics } from "@/api/pdfExportObservabilityApi";
+import { Card } from "@/components/ui/Ui";
+
+function label(value: string | null | undefined) {
+  const raw = String(value || "unknown").trim();
+  return raw.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function Metric({ label: metricLabel, value }: { label: string; value: string | number | null }) {
+  return (
+    <Card style={{ borderRadius: 8, display: "grid", gap: 4 }}>
+      <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>{metricLabel}</div>
+      <div style={{ color: "#0f172a", fontSize: 22, fontWeight: 900 }}>{value ?? "N/A"}</div>
+    </Card>
+  );
+}
+
+export function PdfExportObservabilityPanel({ diagnostics }: { diagnostics: PdfExportDiagnostics }) {
+  return (
+    <div style={{ display: "grid", gap: 16 }}>
+      <Card style={{ borderRadius: 8, display: "grid", gap: 8 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+          <div>
+            <h2 style={{ margin: 0, fontSize: "1.15rem" }}>PDF export observability</h2>
+            <div style={{ color: "#64748b", fontSize: 13 }}>{diagnostics.generatedAt}</div>
+          </div>
+          <div style={{ color: "#334155", fontSize: 13, fontWeight: 800 }}>Manual review required</div>
+        </div>
+        <div style={{ color: "#475569" }}>
+          PDF export telemetry is operational metadata only. It is non-blocking and does not collect document contents,
+          raw screening payloads, or payment account details.
+        </div>
+        <div style={{ color: "#475569", fontSize: 13 }}>
+          Telemetry execution blocking enabled: {diagnostics.telemetryExecutionBlockingEnabled ? "Yes" : "No"}. Sensitive content logged:{" "}
+          {diagnostics.sensitiveContentLogged ? "Yes" : "No"}.
+        </div>
+      </Card>
+
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))", gap: 12 }}>
+        <Metric label="Total events" value={diagnostics.summary.totalEvents} />
+        <Metric label="Completed" value={diagnostics.summary.completed} />
+        <Metric label="Failed" value={diagnostics.summary.failed} />
+        <Metric label="Mobile fallbacks" value={diagnostics.summary.mobileFallbacks} />
+        <Metric label="Downloads" value={diagnostics.summary.downloads} />
+        <Metric label="Prints" value={diagnostics.summary.prints} />
+        <Metric label="Avg duration ms" value={diagnostics.summary.averageDurationMs} />
+        <Metric label="Total bytes" value={diagnostics.summary.totalBytes} />
+      </div>
+
+      <Card style={{ borderRadius: 8, display: "grid", gap: 10 }}>
+        <h3 style={{ margin: 0, fontSize: "1rem" }}>Export types</h3>
+        {diagnostics.byExportType.length ? (
+          diagnostics.byExportType.map((item) => (
+            <div key={item.exportType} style={{ display: "flex", justifyContent: "space-between", gap: 10, borderTop: "1px solid #e2e8f0", paddingTop: 8 }}>
+              <div style={{ fontWeight: 800 }}>{label(item.exportType)}</div>
+              <div style={{ color: "#475569", fontSize: 13 }}>
+                {item.totalEvents} events · {item.completed} completed · {item.failed} failed · {item.mobileFallbacks} fallbacks
+              </div>
+            </div>
+          ))
+        ) : (
+          <div style={{ color: "#64748b" }}>No PDF export telemetry has been recorded yet.</div>
+        )}
+      </Card>
+
+      <Card style={{ borderRadius: 8, display: "grid", gap: 10 }}>
+        <h3 style={{ margin: 0, fontSize: "1rem" }}>Recent diagnostics</h3>
+        {diagnostics.recentEvents.length ? (
+          diagnostics.recentEvents.map((event) => (
+            <div key={event.eventId} style={{ borderTop: "1px solid #e2e8f0", paddingTop: 8, display: "grid", gap: 4 }}>
+              <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+                <strong>{label(event.eventName)}</strong>
+                <span style={{ color: "#64748b", fontSize: 12 }}>{event.createdAt}</span>
+              </div>
+              <div style={{ color: "#475569", fontSize: 13 }}>
+                {label(event.exportType)} · {label(event.renderingPath)} · {label(event.browserClass)} · {label(event.viewportCategory)}
+              </div>
+              {event.errorCode ? <div style={{ color: "#b91c1c", fontSize: 13 }}>{event.errorCode}</div> : null}
+            </div>
+          ))
+        ) : (
+          <div style={{ color: "#64748b" }}>No recent PDF diagnostic events are available.</div>
+        )}
+      </Card>
+
+      <Card style={{ borderRadius: 8, display: "grid", gap: 6 }}>
+        <h3 style={{ margin: 0, fontSize: "1rem" }}>Privacy boundaries</h3>
+        {diagnostics.privacyBoundaries.map((boundary) => (
+          <div key={boundary} style={{ color: "#475569", fontSize: 13 }}>
+            {boundary}
+          </div>
+        ))}
+      </Card>
+    </div>
+  );
+}

--- a/rentchain-frontend/src/components/tenants/LeasePackWizardModal.tsx
+++ b/rentchain-frontend/src/components/tenants/LeasePackWizardModal.tsx
@@ -12,6 +12,7 @@ import {
 import type { Lease } from "@/api/leasesApi";
 import { useToast } from "../ui/ToastProvider";
 import { apiJson } from "@/api/http";
+import { createPdfExportTimer, errorCodeFromUnknown, recordPdfExportEvent } from "@/lib/pdfExportObservability";
 import { normalizeProvinceCode, provinceLabelFromCode, type ProvinceCode } from "@/lib/provinces";
 import { LeaseRiskCard } from "@/components/leases/LeaseRiskCard";
 
@@ -227,6 +228,12 @@ export const LeasePackWizardModal: React.FC<Props> = ({
     }
     setGenerating(true);
     setError("");
+    const timer = createPdfExportTimer();
+    recordPdfExportEvent("pdf_export_started", {
+      exportType: "schedule_a",
+      renderingPath: "backend_pdfkit",
+      status: "started",
+    });
     try {
       let nextDraftId = draftId;
       if (!nextDraftId) {
@@ -243,7 +250,20 @@ export const LeasePackWizardModal: React.FC<Props> = ({
       });
       setSnapshotId(generated.snapshotId);
       setDownloadUrl(generated.scheduleAUrl);
+      recordPdfExportEvent("pdf_export_completed", {
+        exportType: "schedule_a",
+        renderingPath: "backend_pdfkit",
+        status: "completed",
+        durationMs: timer.durationMs(),
+      });
     } catch (err: any) {
+      recordPdfExportEvent("pdf_export_failed", {
+        exportType: "schedule_a",
+        renderingPath: "backend_pdfkit",
+        status: "failed",
+        durationMs: timer.durationMs(),
+        errorCode: errorCodeFromUnknown(err),
+      });
       setError(err?.message || "Failed to generate Schedule A PDF.");
     } finally {
       setGenerating(false);

--- a/rentchain-frontend/src/lib/pdfExportObservability.test.ts
+++ b/rentchain-frontend/src/lib/pdfExportObservability.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const telemetryMocks = vi.hoisted(() => ({
+  logTelemetryEvent: vi.fn(),
+}));
+
+vi.mock("@/api/telemetryApi", () => ({
+  logTelemetryEvent: telemetryMocks.logTelemetryEvent,
+}));
+
+function mockViewport() {
+  Object.defineProperty(window, "innerWidth", { configurable: true, value: 390 });
+  Object.defineProperty(window.navigator, "userAgent", {
+    configurable: true,
+    value: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Version/17.0 Mobile Safari/604.1",
+  });
+  window.matchMedia = vi.fn(() => ({
+    matches: true,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  })) as any;
+}
+
+describe("pdfExportObservability", () => {
+  beforeEach(() => {
+    telemetryMocks.logTelemetryEvent.mockReset();
+    mockViewport();
+  });
+
+  it("emits deterministic metadata without document contents", async () => {
+    const { recordPdfExportEvent } = await import("./pdfExportObservability");
+    recordPdfExportEvent("pdf_export_completed", {
+      exportType: "lease_summary",
+      renderingPath: "frontend_pdf_builder",
+      status: "completed",
+      durationMs: 12.4,
+      byteSize: 99,
+      errorCode: "No raw document text here",
+    });
+
+    expect(telemetryMocks.logTelemetryEvent).toHaveBeenCalledWith(
+      "pdf_export_completed",
+      expect.objectContaining({
+        exportType: "lease_summary",
+        renderingPath: "frontend_pdf_builder",
+        status: "completed",
+        durationMs: 12,
+        byteSize: 99,
+        browserClass: "safari",
+        viewportCategory: "mobile",
+        mobilePreviewUnsafe: true,
+        errorCode: "no_raw_document_text_here",
+      })
+    );
+  });
+});

--- a/rentchain-frontend/src/lib/pdfExportObservability.ts
+++ b/rentchain-frontend/src/lib/pdfExportObservability.ts
@@ -1,0 +1,116 @@
+import { logTelemetryEvent } from "@/api/telemetryApi";
+import { isMobilePdfPreviewUnsafe } from "@/utils/pdfPreviewGuard";
+
+export type PdfExportEventName =
+  | "pdf_export_started"
+  | "pdf_export_completed"
+  | "pdf_export_failed"
+  | "pdf_mobile_fallback_used"
+  | "pdf_download_triggered"
+  | "pdf_print_opened";
+
+export type PdfExportType =
+  | "sample_screening_report"
+  | "screening_report"
+  | "application_review_summary"
+  | "tenant_report"
+  | "lease_ledger"
+  | "lease_summary"
+  | "schedule_a"
+  | "transunion_usage"
+  | "print_summary"
+  | "unknown";
+
+export type PdfRenderingPath =
+  | "desktop_iframe"
+  | "mobile_fallback"
+  | "browser_download"
+  | "window_print"
+  | "backend_pdfkit"
+  | "frontend_pdf_builder"
+  | "signed_url"
+  | "unknown";
+
+export type PdfExportTelemetryProps = {
+  exportType: PdfExportType;
+  renderingPath: PdfRenderingPath;
+  status?: "started" | "completed" | "failed" | "fallback_used" | "download_triggered" | "print_opened";
+  fallbackMode?: "mobile_open_download" | "none";
+  durationMs?: number | null;
+  byteSize?: number | null;
+  pageCount?: number | null;
+  errorCode?: string | null;
+};
+
+function browserClass(userAgent: string) {
+  const ua = userAgent.toLowerCase();
+  if (ua.includes("edg/")) return "edge";
+  if (ua.includes("chrome") || ua.includes("crios")) return "chrome";
+  if (ua.includes("firefox") || ua.includes("fxios")) return "firefox";
+  if (ua.includes("safari")) return "safari";
+  return "other";
+}
+
+function viewportCategory(width: number) {
+  if (width <= 768) return "mobile";
+  if (width <= 1024) return "tablet";
+  return "desktop";
+}
+
+function runtimeContext() {
+  if (typeof window === "undefined") {
+    return {
+      browserClass: "unknown",
+      viewportCategory: "unknown",
+      mobilePreviewUnsafe: false,
+    };
+  }
+  const coarsePointer = window.matchMedia?.("(pointer: coarse)")?.matches ?? false;
+  return {
+    browserClass: browserClass(window.navigator.userAgent || ""),
+    viewportCategory: viewportCategory(window.innerWidth || 0),
+    mobilePreviewUnsafe: isMobilePdfPreviewUnsafe({
+      userAgent: window.navigator.userAgent,
+      width: window.innerWidth,
+      coarsePointer,
+    }),
+  };
+}
+
+function sanitizeErrorCode(value: unknown) {
+  return String(value || "unknown")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_:-]+/g, "_")
+    .slice(0, 120);
+}
+
+export function recordPdfExportEvent(eventName: PdfExportEventName, props: PdfExportTelemetryProps): void {
+  const context = runtimeContext();
+  void logTelemetryEvent(eventName, {
+    exportType: props.exportType,
+    renderingPath: props.renderingPath,
+    status: props.status || null,
+    fallbackMode: props.fallbackMode || null,
+    durationMs: props.durationMs == null ? null : Math.max(0, Math.round(props.durationMs)),
+    byteSize: props.byteSize == null ? null : Math.max(0, Math.round(props.byteSize)),
+    pageCount: props.pageCount == null ? null : Math.max(0, Math.round(props.pageCount)),
+    errorCode: props.errorCode ? sanitizeErrorCode(props.errorCode) : null,
+    ...context,
+  });
+}
+
+export function createPdfExportTimer() {
+  const startedAt = typeof performance !== "undefined" && typeof performance.now === "function" ? performance.now() : Date.now();
+  return {
+    durationMs() {
+      const now = typeof performance !== "undefined" && typeof performance.now === "function" ? performance.now() : Date.now();
+      return Math.max(0, Math.round(now - startedAt));
+    },
+  };
+}
+
+export function errorCodeFromUnknown(error: unknown) {
+  if (error instanceof Error && error.message) return sanitizeErrorCode(error.message);
+  return sanitizeErrorCode(error);
+}

--- a/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
+++ b/rentchain-frontend/src/pages/ApplicationReviewSummaryPage.tsx
@@ -17,6 +17,7 @@ import {
   ReviewSummaryApiError,
 } from "../api/reviewSummaryApi";
 import { useToast } from "../components/ui/ToastProvider";
+import { createPdfExportTimer, errorCodeFromUnknown, recordPdfExportEvent } from "../lib/pdfExportObservability";
 import { buildLandlordIntakeAlignmentView } from "./applicationReviewIntakeAlignment";
 import { buildLandlordReviewGuidance } from "./landlordReviewGuidance";
 import { buildTenantLandlordInteractionLoop } from "./tenantLandlordInteractionLoop";
@@ -381,10 +382,29 @@ function ApplicationReviewSummaryPageBody() {
       });
       return;
     }
+    const timer = createPdfExportTimer();
+    recordPdfExportEvent("pdf_export_started", {
+      exportType: "application_review_summary",
+      renderingPath: "signed_url",
+      status: "started",
+    });
     try {
       const url = await fetchReviewSummaryPdfSignedUrl(id);
+      recordPdfExportEvent("pdf_export_completed", {
+        exportType: "application_review_summary",
+        renderingPath: "signed_url",
+        status: "completed",
+        durationMs: timer.durationMs(),
+      });
       window.open(url, "_blank", "noopener,noreferrer");
     } catch (err: any) {
+      recordPdfExportEvent("pdf_export_failed", {
+        exportType: "application_review_summary",
+        renderingPath: "signed_url",
+        status: "failed",
+        durationMs: timer.durationMs(),
+        errorCode: errorCodeFromUnknown(err),
+      });
       showToast({
         message: "Unable to open PDF",
         description: err?.message || "Failed to load review summary PDF.",

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
@@ -16,6 +16,7 @@ import {
 import { patchDecisionAction } from "@/api/decisionApi";
 import { getAuthToken } from "../lib/authToken";
 import { getFirebaseIdToken } from "../lib/firebaseAuthToken";
+import { createPdfExportTimer, errorCodeFromUnknown, recordPdfExportEvent } from "../lib/pdfExportObservability";
 import {
   archiveLeaseRecord,
   createLeaseNote,
@@ -606,6 +607,15 @@ export default function LeaseLedgerPage() {
   }
 
   async function exportLedger(format: "csv" | "pdf") {
+    const isPdf = format === "pdf";
+    const timer = createPdfExportTimer();
+    if (isPdf) {
+      recordPdfExportEvent("pdf_export_started", {
+        exportType: "lease_ledger",
+        renderingPath: "backend_pdfkit",
+        status: "started",
+      });
+    }
     try {
       const token = (await getFirebaseIdToken()) || getAuthToken();
       const authHeader = token ? { Authorization: `Bearer ${token}` } : {};
@@ -621,6 +631,15 @@ export default function LeaseLedgerPage() {
       });
       if (!res.ok) throw new Error(`Export failed (${res.status})`);
       const blob = await res.blob();
+      if (isPdf) {
+        recordPdfExportEvent("pdf_export_completed", {
+          exportType: "lease_ledger",
+          renderingPath: "backend_pdfkit",
+          status: "completed",
+          durationMs: timer.durationMs(),
+          byteSize: blob.size,
+        });
+      }
       const objectUrl = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = objectUrl;
@@ -630,6 +649,15 @@ export default function LeaseLedgerPage() {
       a.remove();
       URL.revokeObjectURL(objectUrl);
     } catch (err: unknown) {
+      if (isPdf) {
+        recordPdfExportEvent("pdf_export_failed", {
+          exportType: "lease_ledger",
+          renderingPath: "backend_pdfkit",
+          status: "failed",
+          durationMs: timer.durationMs(),
+          errorCode: errorCodeFromUnknown(err),
+        });
+      }
       setError(errorMessage(err, `Failed to export ${format.toUpperCase()}`));
     }
   }

--- a/rentchain-frontend/src/pages/PdfExportObservabilityPage.tsx
+++ b/rentchain-frontend/src/pages/PdfExportObservabilityPage.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { fetchPdfExportDiagnostics, type PdfExportDiagnostics } from "@/api/pdfExportObservabilityApi";
+import { MacShell } from "@/components/layout/MacShell";
+import { PdfExportObservabilityPanel } from "@/components/pdfExport/PdfExportObservabilityPanel";
+import { Card, Section } from "@/components/ui/Ui";
+import { useToast } from "@/components/ui/ToastProvider";
+
+export default function PdfExportObservabilityPage() {
+  const { showToast } = useToast();
+  const [diagnostics, setDiagnostics] = React.useState<PdfExportDiagnostics | null>(null);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const next = await fetchPdfExportDiagnostics();
+        if (mounted) setDiagnostics(next);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Failed to load PDF export observability";
+        if (mounted) {
+          setError(message);
+          showToast({ message: "Failed to load PDF export observability", description: message, variant: "error" });
+        }
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, [showToast]);
+
+  return (
+    <MacShell title="PDF export observability" showTopNav={false}>
+      <div style={{ display: "grid", gap: 16 }}>
+        <Section>
+          <div style={{ display: "grid", gap: 6 }}>
+            <h1 style={{ margin: 0, fontSize: "1.5rem" }}>PDF export observability</h1>
+            <div style={{ color: "#475569", maxWidth: 900 }}>
+              Export diagnostics are operationally scoped and review controlled. Telemetry is additive, non-blocking,
+              and limited to export metadata.
+            </div>
+          </div>
+        </Section>
+        {loading ? <Card>Loading PDF export observability...</Card> : null}
+        {!loading && error ? <Card style={{ color: "#b91c1c" }}>We couldn't load PDF export observability right now.</Card> : null}
+        {!loading && !error && diagnostics ? <PdfExportObservabilityPanel diagnostics={diagnostics} /> : null}
+      </div>
+    </MacShell>
+  );
+}

--- a/rentchain-frontend/src/pages/PdfSamplePage.test.tsx
+++ b/rentchain-frontend/src/pages/PdfSamplePage.test.tsx
@@ -3,6 +3,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import PdfSamplePage from "./PdfSamplePage";
 
+const telemetryMocks = vi.hoisted(() => ({
+  logTelemetryEvent: vi.fn(),
+}));
+
+vi.mock("../api/telemetryApi", () => ({
+  logTelemetryEvent: telemetryMocks.logTelemetryEvent,
+}));
+
 function mockViewport(options: { width: number; coarsePointer: boolean }) {
   Object.defineProperty(window, "innerWidth", {
     configurable: true,
@@ -50,6 +58,16 @@ describe("PdfSamplePage", () => {
     );
 
     await waitFor(() => expect(screen.getByText("Open the sample PDF")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(telemetryMocks.logTelemetryEvent).toHaveBeenCalledWith(
+        "pdf_mobile_fallback_used",
+        expect.objectContaining({
+          exportType: "sample_screening_report",
+          renderingPath: "mobile_fallback",
+          fallbackMode: "mobile_open_download",
+        })
+      )
+    );
     expect(screen.queryByTitle("Sample screening report")).not.toBeInTheDocument();
     expect(screen.getAllByRole("link", { name: "Open PDF" })[0]).toHaveAttribute(
       "href",

--- a/rentchain-frontend/src/pages/PdfSamplePage.tsx
+++ b/rentchain-frontend/src/pages/PdfSamplePage.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
 import { Card } from "../components/ui/Ui";
+import { recordPdfExportEvent } from "../lib/pdfExportObservability";
 import { spacing } from "../styles/tokens";
 import { useMobilePdfPreviewGuard } from "../utils/pdfPreviewGuard";
 
@@ -10,6 +11,16 @@ const PdfSamplePage: React.FC = () => {
   const navigate = useNavigate();
   const [loaded, setLoaded] = React.useState(false);
   const useMobileFallback = useMobilePdfPreviewGuard();
+
+  React.useEffect(() => {
+    if (!useMobileFallback) return;
+    recordPdfExportEvent("pdf_mobile_fallback_used", {
+      exportType: "sample_screening_report",
+      renderingPath: "mobile_fallback",
+      status: "fallback_used",
+      fallbackMode: "mobile_open_download",
+    });
+  }, [useMobileFallback]);
 
   return (
     <div style={{ display: "grid", gap: spacing.md }}>
@@ -45,6 +56,13 @@ const PdfSamplePage: React.FC = () => {
               href={pdfUrl}
               target="_blank"
               rel="noreferrer"
+              onClick={() =>
+                recordPdfExportEvent("pdf_download_triggered", {
+                  exportType: "sample_screening_report",
+                  renderingPath: "signed_url",
+                  status: "download_triggered",
+                })
+              }
               style={{
                 padding: "8px 12px",
                 borderRadius: 10,
@@ -60,6 +78,13 @@ const PdfSamplePage: React.FC = () => {
             <a
               href={pdfUrl}
               download
+              onClick={() =>
+                recordPdfExportEvent("pdf_download_triggered", {
+                  exportType: "sample_screening_report",
+                  renderingPath: "browser_download",
+                  status: "download_triggered",
+                })
+              }
               style={{
                 padding: "8px 12px",
                 borderRadius: 10,
@@ -83,10 +108,35 @@ const PdfSamplePage: React.FC = () => {
               Mobile browsers handle PDF files more reliably in the browser viewer or download manager.
             </div>
             <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-              <a href={pdfUrl} target="_blank" rel="noreferrer" style={{ color: "#0f172a", fontWeight: 700 }}>
+              <a
+                href={pdfUrl}
+                target="_blank"
+                rel="noreferrer"
+                onClick={() =>
+                  recordPdfExportEvent("pdf_download_triggered", {
+                    exportType: "sample_screening_report",
+                    renderingPath: "mobile_fallback",
+                    status: "download_triggered",
+                    fallbackMode: "mobile_open_download",
+                  })
+                }
+                style={{ color: "#0f172a", fontWeight: 700 }}
+              >
                 Open PDF
               </a>
-              <a href={pdfUrl} download style={{ color: "#0f172a", fontWeight: 700 }}>
+              <a
+                href={pdfUrl}
+                download
+                onClick={() =>
+                  recordPdfExportEvent("pdf_download_triggered", {
+                    exportType: "sample_screening_report",
+                    renderingPath: "mobile_fallback",
+                    status: "download_triggered",
+                    fallbackMode: "mobile_open_download",
+                  })
+                }
+                style={{ color: "#0f172a", fontWeight: 700 }}
+              >
                 Download PDF
               </a>
             </div>
@@ -104,7 +154,14 @@ const PdfSamplePage: React.FC = () => {
                 border: "none",
                 display: "block",
               }}
-              onLoad={() => setLoaded(true)}
+              onLoad={() => {
+                setLoaded(true);
+                recordPdfExportEvent("pdf_export_completed", {
+                  exportType: "sample_screening_report",
+                  renderingPath: "desktop_iframe",
+                  status: "completed",
+                });
+              }}
             />
           </>
         )}

--- a/rentchain-frontend/src/pages/screening/ScreeningReportPage.tsx
+++ b/rentchain-frontend/src/pages/screening/ScreeningReportPage.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { Card, Section, Button } from "../../components/ui/Ui";
+import { createPdfExportTimer, errorCodeFromUnknown, recordPdfExportEvent } from "../../lib/pdfExportObservability";
 import { spacing, text, colors, radius } from "../../styles/tokens";
 
 const ScreeningReportPage: React.FC = () => {
@@ -17,6 +18,12 @@ const ScreeningReportPage: React.FC = () => {
     }
     setLoading(true);
     setError(null);
+    const timer = createPdfExportTimer();
+    recordPdfExportEvent("pdf_export_started", {
+      exportType: "screening_report",
+      renderingPath: "backend_pdfkit",
+      status: "started",
+    });
     try {
       const res = await fetch(
         `/api/screening/report?exportId=${encodeURIComponent(exportId)}&token=${encodeURIComponent(token)}`
@@ -30,6 +37,13 @@ const ScreeningReportPage: React.FC = () => {
         throw new Error("This link is invalid or has been revoked.");
       }
       const blob = await res.blob();
+      recordPdfExportEvent("pdf_export_completed", {
+        exportType: "screening_report",
+        renderingPath: "backend_pdfkit",
+        status: "completed",
+        durationMs: timer.durationMs(),
+        byteSize: blob.size,
+      });
       const url = window.URL.createObjectURL(blob);
       const link = document.createElement("a");
       link.href = url;
@@ -39,6 +53,13 @@ const ScreeningReportPage: React.FC = () => {
       link.remove();
       window.URL.revokeObjectURL(url);
     } catch (err: any) {
+      recordPdfExportEvent("pdf_export_failed", {
+        exportType: "screening_report",
+        renderingPath: "backend_pdfkit",
+        status: "failed",
+        durationMs: timer.durationMs(),
+        errorCode: errorCodeFromUnknown(err),
+      });
       setError(err?.message || "Unable to download report.");
     } finally {
       setLoading(false);

--- a/rentchain-frontend/src/utils/leaseSummaryPdf.ts
+++ b/rentchain-frontend/src/utils/leaseSummaryPdf.ts
@@ -1,4 +1,5 @@
 import type { LandlordActiveLease } from "@/api/leasesApi";
+import { createPdfExportTimer, recordPdfExportEvent } from "@/lib/pdfExportObservability";
 
 function formatCurrency(value: number | null | undefined) {
   const amount = typeof value === "number" ? value : 0;
@@ -202,7 +203,20 @@ export function buildLeaseSummaryPdf(lease: LandlordActiveLease) {
 }
 
 export function downloadLeaseSummaryPdf(lease: LandlordActiveLease) {
+  const timer = createPdfExportTimer();
+  recordPdfExportEvent("pdf_export_started", {
+    exportType: "lease_summary",
+    renderingPath: "frontend_pdf_builder",
+    status: "started",
+  });
   const blob = buildLeaseSummaryPdf(lease);
+  recordPdfExportEvent("pdf_export_completed", {
+    exportType: "lease_summary",
+    renderingPath: "frontend_pdf_builder",
+    status: "completed",
+    durationMs: timer.durationMs(),
+    byteSize: blob.size,
+  });
   const url = window.URL.createObjectURL(blob);
   const anchor = document.createElement("a");
   anchor.href = url;

--- a/rentchain-frontend/src/utils/printSummary.ts
+++ b/rentchain-frontend/src/utils/printSummary.ts
@@ -1,3 +1,5 @@
+import { recordPdfExportEvent } from "../lib/pdfExportObservability";
+
 type PrintSummaryMode = "summary" | "lease-renewals" | "application";
 
 const PRINT_SELECTOR_BY_MODE: Record<PrintSummaryMode, string> = {
@@ -47,6 +49,11 @@ export async function printSummaryDocument(mode: PrintSummaryMode = "summary"): 
       });
     });
 
+    recordPdfExportEvent("pdf_print_opened", {
+      exportType: "print_summary",
+      renderingPath: "window_print",
+      status: "print_opened",
+    });
     window.print();
   } finally {
     window.setTimeout(cleanup, 250);


### PR DESCRIPTION
## Summary
- Adds a deterministic PDF export observability model for export lifecycle events, mobile fallback visibility, download/print actions, and backend PDF generation outcomes.
- Adds an admin-only PDF export diagnostics endpoint and UI surface with aggregate export status, failure counts, fallback counts, rendering path summaries, and recent metadata-only events.
- Instruments existing PDF/export flows without changing export URLs, download APIs, PDF formatting, mobile fallback behavior, or backend PDF generation behavior.

## Audit Findings
- Frontend export flows include sample PDF previews, billing sample modal previews, print summary, lease summary generation, application review PDF opening, screening report downloads, admin TransUnion PDF downloads, tenant report downloads, lease ledger PDF exports, and Schedule A generation.
- Backend export flows include screening report PDFs, TransUnion usage PDFs, lease ledger PDFs, and existing Schedule A generation helpers.
- Existing telemetry only accepted nudge events; generic event tracking was intentionally not used for PDF observability because it accepts arbitrary properties and would be a poorer privacy boundary for document export diagnostics.

## Event Model
- `pdf_export_started`
- `pdf_export_completed`
- `pdf_export_failed`
- `pdf_mobile_fallback_used`
- `pdf_download_triggered`
- `pdf_print_opened`

## Privacy Boundaries
- Telemetry records metadata only: export type, rendering path, status, duration, byte size, browser class, viewport category, fallback state, and sanitized error codes.
- No raw PDF contents, document body text, screening payloads, tenant financial contents, payment account details, or provider credentials are logged or displayed.
- Admin diagnostics use whitelist projection and remain behind `system.admin` authorization.

## Validation
- Frontend targeted tests passed: PDF observability helper, export download telemetry, mobile fallback telemetry, billing sample modal telemetry, diagnostics panel rendering.
- Backend targeted tests passed: diagnostics derivation, admin diagnostics route, telemetry route PDF event sanitization, PDF endpoint instrumentation coverage.
- Full frontend test suite passed.
- Full backend test suite passed after rerun outside sandbox for existing Supertest listener restrictions.
- Backend build passed.
- Frontend build passed with the known existing large chunk warning only.
- `git diff --check` passed.
- Dependency and lockfile diff remained empty.