### PR TITLE
[codex] Add document rendering foundation

### DIFF
--- a/rentchain-frontend/src/components/billing/SamplePdfModal.tsx
+++ b/rentchain-frontend/src/components/billing/SamplePdfModal.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import { recordPdfExportEvent } from "../../lib/pdfExportObservability";
-import { useMobilePdfPreviewGuard } from "../../utils/pdfPreviewGuard";
+import { PdfPreviewBoundary } from "../documentRendering/PdfPreviewBoundary";
 
 type Props = {
   open: boolean;
@@ -11,7 +11,6 @@ export function SamplePdfModal({ open, onClose }: Props) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [loadError, setLoadError] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
-  const useMobileFallback = useMobilePdfPreviewGuard();
   const pdfUrl = "/sample/screening_report_sample.pdf?v=1";
 
   useEffect(() => {
@@ -54,16 +53,6 @@ export function SamplePdfModal({ open, onClose }: Props) {
     );
     focusable?.focus();
   }, [open]);
-
-  useEffect(() => {
-    if (!open || !useMobileFallback) return;
-    recordPdfExportEvent("pdf_mobile_fallback_used", {
-      exportType: "sample_screening_report",
-      renderingPath: "mobile_fallback",
-      status: "fallback_used",
-      fallbackMode: "mobile_open_download",
-    });
-  }, [open, useMobileFallback]);
 
   if (!open) return null;
 
@@ -210,72 +199,23 @@ export function SamplePdfModal({ open, onClose }: Props) {
                 </a>
               </div>
             </div>
-          ) : useMobileFallback ? (
-            <div style={{ display: "grid", gap: 10, padding: 16, fontSize: 14, color: "#0f172a" }}>
-              <div style={{ fontWeight: 700 }}>Open the sample PDF</div>
-              <div style={{ color: "#475569" }}>
-                Mobile browsers handle PDF files more reliably in the browser viewer or download manager.
-              </div>
-              <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
-                <a
-                  href={pdfUrl}
-                  target="_blank"
-                  rel="noreferrer"
-                  onClick={() =>
-                    recordPdfExportEvent("pdf_download_triggered", {
-                      exportType: "sample_screening_report",
-                      renderingPath: "mobile_fallback",
-                      status: "download_triggered",
-                      fallbackMode: "mobile_open_download",
-                    })
-                  }
-                >
-                  Open PDF
-                </a>
-                <a
-                  href={pdfUrl}
-                  download
-                  onClick={() =>
-                    recordPdfExportEvent("pdf_download_triggered", {
-                      exportType: "sample_screening_report",
-                      renderingPath: "mobile_fallback",
-                      status: "download_triggered",
-                      fallbackMode: "mobile_open_download",
-                    })
-                  }
-                >
-                  Download PDF
-                </a>
-              </div>
-            </div>
           ) : (
-            <iframe
-              title="Sample screening report PDF"
-              src={`${pdfUrl}#view=FitH`}
-              className="w-full h-full rounded-xl"
-              style={{
+            <PdfPreviewBoundary
+              pdfUrl={pdfUrl}
+              exportType="sample_screening_report"
+              title="Open the sample PDF"
+              iframeTitle="Sample screening report PDF"
+              iframeClassName="w-full h-full rounded-xl"
+              active={open}
+              fallbackStyle={{ display: "grid", gap: 10, padding: 16, fontSize: 14, color: "#0f172a" }}
+              iframeStyle={{
                 width: "100%",
                 minHeight: 520,
                 height: "min(760px, 72dvh)",
                 border: "none",
                 display: "block",
               }}
-              onLoad={() =>
-                recordPdfExportEvent("pdf_export_completed", {
-                  exportType: "sample_screening_report",
-                  renderingPath: "desktop_iframe",
-                  status: "completed",
-                })
-              }
-              onError={() => {
-                setLoadError(true);
-                recordPdfExportEvent("pdf_export_failed", {
-                  exportType: "sample_screening_report",
-                  renderingPath: "desktop_iframe",
-                  status: "failed",
-                  errorCode: "iframe_load_error",
-                });
-              }}
+              onDesktopError={() => setLoadError(true)}
             />
           )}
         </div>

--- a/rentchain-frontend/src/components/documentRendering/PdfPreviewBoundary.tsx
+++ b/rentchain-frontend/src/components/documentRendering/PdfPreviewBoundary.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+import { recordPdfExportEvent, type PdfExportType } from "@/lib/pdfExportObservability";
+import { useMobilePdfPreviewGuard } from "@/utils/pdfPreviewGuard";
+
+type PdfPreviewBoundaryProps = {
+  pdfUrl: string;
+  exportType: PdfExportType;
+  title: string;
+  iframeTitle?: string;
+  iframeClassName?: string;
+  iframeStyle?: React.CSSProperties;
+  fallbackStyle?: React.CSSProperties;
+  fallbackDescription?: string;
+  active?: boolean;
+  onDesktopLoad?: () => void;
+  onDesktopError?: () => void;
+};
+
+const DEFAULT_FALLBACK_DESCRIPTION =
+  "Mobile browsers handle PDF files more reliably in the browser viewer or download manager.";
+
+export function PdfPreviewBoundary({
+  pdfUrl,
+  exportType,
+  title,
+  iframeTitle,
+  iframeClassName,
+  iframeStyle,
+  fallbackStyle,
+  fallbackDescription = DEFAULT_FALLBACK_DESCRIPTION,
+  active = true,
+  onDesktopLoad,
+  onDesktopError,
+}: PdfPreviewBoundaryProps) {
+  const useMobileFallback = useMobilePdfPreviewGuard();
+
+  React.useEffect(() => {
+    if (!active || !useMobileFallback) return;
+    recordPdfExportEvent("pdf_mobile_fallback_used", {
+      exportType,
+      renderingPath: "mobile_fallback",
+      status: "fallback_used",
+      fallbackMode: "mobile_open_download",
+    });
+  }, [active, exportType, useMobileFallback]);
+
+  if (useMobileFallback) {
+    return (
+      <div style={fallbackStyle}>
+        <div style={{ fontWeight: 700 }}>{title}</div>
+        <div style={{ color: "#475569" }}>{fallbackDescription}</div>
+        <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+          <a
+            href={pdfUrl}
+            target="_blank"
+            rel="noreferrer"
+            onClick={() =>
+              recordPdfExportEvent("pdf_download_triggered", {
+                exportType,
+                renderingPath: "mobile_fallback",
+                status: "download_triggered",
+                fallbackMode: "mobile_open_download",
+              })
+            }
+          >
+            Open PDF
+          </a>
+          <a
+            href={pdfUrl}
+            download
+            onClick={() =>
+              recordPdfExportEvent("pdf_download_triggered", {
+                exportType,
+                renderingPath: "mobile_fallback",
+                status: "download_triggered",
+                fallbackMode: "mobile_open_download",
+              })
+            }
+          >
+            Download PDF
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <iframe
+      title={iframeTitle || title}
+      src={`${pdfUrl}#view=FitH`}
+      className={iframeClassName}
+      style={iframeStyle}
+      onLoad={() => {
+        recordPdfExportEvent("pdf_export_completed", {
+          exportType,
+          renderingPath: "desktop_iframe",
+          status: "completed",
+        });
+        onDesktopLoad?.();
+      }}
+      onError={() => {
+        recordPdfExportEvent("pdf_export_failed", {
+          exportType,
+          renderingPath: "desktop_iframe",
+          status: "failed",
+          errorCode: "iframe_load_error",
+        });
+        onDesktopError?.();
+      }}
+    />
+  );
+}

--- a/rentchain-frontend/src/lib/documentRendering.test.ts
+++ b/rentchain-frontend/src/lib/documentRendering.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createPrintRoot,
+  PRINT_ROOT_ATTRIBUTE,
+  shouldStartNewPage,
+  triggerDocumentDownload,
+  wrapTextForPdf,
+} from "./documentRendering";
+
+describe("documentRendering foundation", () => {
+  it("creates print roots with the shared print-root attribute", () => {
+    const root = createPrintRoot(document);
+
+    expect(root.getAttribute(PRINT_ROOT_ATTRIBUTE)).toBe("true");
+  });
+
+  it("keeps pagination decisions deterministic at the bottom guard", () => {
+    expect(shouldStartNewPage({ cursorY: 120, neededHeight: 30, bottomY: 88 })).toBe(false);
+    expect(shouldStartNewPage({ cursorY: 110, neededHeight: 30, bottomY: 88 })).toBe(true);
+  });
+
+  it("wraps export text without dropping words", () => {
+    expect(wrapTextForPdf("one two three four five", 10)).toEqual(["one two", "three four", "five"]);
+  });
+
+  it("triggers object-url downloads and revokes the object url", () => {
+    const click = vi.fn();
+    const remove = vi.fn();
+    const anchor = {
+      href: "",
+      download: "",
+      click,
+      remove,
+    } as unknown as HTMLAnchorElement;
+    const appendChild = vi.fn();
+    const documentRef = {
+      createElement: vi.fn(() => anchor),
+      body: { appendChild },
+    } as unknown as Document;
+    const urlApi = {
+      createObjectURL: vi.fn(() => "blob:rentchain-document"),
+      revokeObjectURL: vi.fn(),
+    };
+    const blob = new Blob(["pdf"], { type: "application/pdf" });
+
+    triggerDocumentDownload({
+      blob,
+      filename: "lease-summary.pdf",
+      documentRef,
+      urlApi,
+    });
+
+    expect(anchor.href).toBe("blob:rentchain-document");
+    expect(anchor.download).toBe("lease-summary.pdf");
+    expect(appendChild).toHaveBeenCalledWith(anchor);
+    expect(click).toHaveBeenCalled();
+    expect(remove).toHaveBeenCalled();
+    expect(urlApi.revokeObjectURL).toHaveBeenCalledWith("blob:rentchain-document");
+  });
+});

--- a/rentchain-frontend/src/lib/documentRendering.ts
+++ b/rentchain-frontend/src/lib/documentRendering.ts
@@ -1,0 +1,85 @@
+import type { PdfExportType, PdfRenderingPath } from "./pdfExportObservability";
+
+export type PrintSummaryMode = "summary" | "lease-renewals" | "application";
+
+export const PRINT_ROOT_ATTRIBUTE = "data-print-root";
+export const PRINT_ROOT_ACTIVE_ATTRIBUTE = "data-print-root-active";
+export const PRINT_MODE_ATTRIBUTE = "data-print-mode";
+
+export const PRINT_SAFE_CLASS = "rc-print-area";
+export const PRINT_CLEAN_CLASS = "rc-print-clean";
+export const PAGE_BREAK_GUARD_CLASS = "rc-avoid-break";
+
+export const PRINT_SELECTOR_BY_MODE: Record<PrintSummaryMode, string> = {
+  summary: ".print-only-summary",
+  "lease-renewals": ".print-only-lease-renewals",
+  application: ".print-only-application",
+};
+
+export type DocumentDownloadOptions = {
+  blob: Blob;
+  filename: string;
+  documentRef?: Document;
+  urlApi?: Pick<typeof URL, "createObjectURL" | "revokeObjectURL">;
+};
+
+export type PdfPreviewFallbackMetadata = {
+  exportType: PdfExportType;
+  renderingPath: PdfRenderingPath;
+  fallbackMode: "mobile_open_download";
+};
+
+export function createPrintRoot(documentRef: Document = document): HTMLDivElement {
+  const printableRoot = documentRef.createElement("div");
+  printableRoot.setAttribute(PRINT_ROOT_ATTRIBUTE, "true");
+  return printableRoot;
+}
+
+export function nextRenderFrame(windowRef: Window = window): Promise<void> {
+  return new Promise<void>((resolve) => {
+    windowRef.requestAnimationFrame(() => resolve());
+  });
+}
+
+export function shouldStartNewPage(params: {
+  cursorY: number;
+  neededHeight: number;
+  bottomY: number;
+}): boolean {
+  return params.cursorY - params.neededHeight < params.bottomY;
+}
+
+export function wrapTextForPdf(text: string, maxLineLength: number): string[] {
+  const words = String(text || "").split(/\s+/).filter(Boolean);
+  const wrapped: string[] = [];
+  let current = "";
+
+  words.forEach((word) => {
+    const next = current ? `${current} ${word}` : word;
+    if (next.length > maxLineLength) {
+      if (current) wrapped.push(current);
+      current = word;
+    } else {
+      current = next;
+    }
+  });
+
+  if (current) wrapped.push(current);
+  return wrapped;
+}
+
+export function triggerDocumentDownload({
+  blob,
+  filename,
+  documentRef = document,
+  urlApi = URL,
+}: DocumentDownloadOptions): void {
+  const objectUrl = urlApi.createObjectURL(blob);
+  const anchor = documentRef.createElement("a");
+  anchor.href = objectUrl;
+  anchor.download = filename;
+  documentRef.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  urlApi.revokeObjectURL(objectUrl);
+}

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.test.tsx
@@ -56,6 +56,9 @@ describe("LeaseLedgerPage", () => {
     global.fetch = vi.fn(async () => ({
       ok: true,
       blob: async () => new Blob(["%PDF-1.4"], { type: "application/pdf" }),
+      headers: {
+        get: () => null,
+      },
     })) as unknown as typeof fetch;
     mocks.fetchLeaseLedger.mockResolvedValue({
       ok: true,
@@ -644,8 +647,13 @@ describe("LeaseLedgerPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "Export PDF" }));
 
     await waitFor(() => {
-      expect(mocks.leaseLedgerExportUrl).toHaveBeenCalledWith("lease-1", undefined, undefined, "pdf");
-      expect(global.fetch).toHaveBeenCalledWith("https://example.com/export.pdf", expect.any(Object));
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/api/leases/lease-1/ledger/export.pdf"),
+        expect.objectContaining({
+          method: "GET",
+          credentials: "include",
+        })
+      );
       expect(HTMLAnchorElement.prototype.click).toHaveBeenCalledTimes(1);
     });
     expect(createdAnchors[createdAnchors.length - 1]?.download).toBe("lease-ledger-lease-1.pdf");

--- a/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
+++ b/rentchain-frontend/src/pages/LeaseLedgerPage.tsx
@@ -4,7 +4,6 @@ import {
   addLeaseCharge,
   addLeasePayment,
   fetchLeaseLedger,
-  leaseLedgerExportUrl,
   type DelinquencySignalType,
   type LeaseObligationLedgerRow,
   type LeaseObligationLedgerSummary,
@@ -13,10 +12,9 @@ import {
   type LeaseLedgerEntry,
   type PaymentObligationStatus,
 } from "../api/leaseLedgerApi";
+import { downloadAuthenticatedExport } from "../api/exportDownload";
 import { patchDecisionAction } from "@/api/decisionApi";
-import { getAuthToken } from "../lib/authToken";
-import { getFirebaseIdToken } from "../lib/firebaseAuthToken";
-import { createPdfExportTimer, errorCodeFromUnknown, recordPdfExportEvent } from "../lib/pdfExportObservability";
+import { triggerDocumentDownload } from "../lib/documentRendering";
 import {
   archiveLeaseRecord,
   createLeaseNote,
@@ -608,56 +606,25 @@ export default function LeaseLedgerPage() {
 
   async function exportLedger(format: "csv" | "pdf") {
     const isPdf = format === "pdf";
-    const timer = createPdfExportTimer();
-    if (isPdf) {
-      recordPdfExportEvent("pdf_export_started", {
-        exportType: "lease_ledger",
-        renderingPath: "backend_pdfkit",
-        status: "started",
-      });
-    }
     try {
-      const token = (await getFirebaseIdToken()) || getAuthToken();
-      const authHeader = token ? { Authorization: `Bearer ${token}` } : {};
-      const url = leaseLedgerExportUrl(leaseId, from || undefined, to || undefined, format);
-      const res = await fetch(url, {
-        method: "GET",
-        headers: {
-          ...authHeader,
-          "x-api-client": "web",
-          "x-rc-auth": token ? "bearer" : "missing",
-        },
-        credentials: "include",
+      const query = new URLSearchParams();
+      if (from) query.set("from", from);
+      if (to) query.set("to", to);
+      const queryString = query.toString();
+      const path = `/leases/${encodeURIComponent(leaseId)}/ledger/export.${format}${queryString ? `?${queryString}` : ""}`;
+      const { blob, filename } = await downloadAuthenticatedExport({
+        path,
+        fallbackFilename: `lease-ledger-${leaseId}.${format}`,
+        errorMessage: `Failed to export ${format.toUpperCase()}`,
+        observability: isPdf
+          ? {
+              exportType: "lease_ledger",
+              renderingPath: "backend_pdfkit",
+            }
+          : undefined,
       });
-      if (!res.ok) throw new Error(`Export failed (${res.status})`);
-      const blob = await res.blob();
-      if (isPdf) {
-        recordPdfExportEvent("pdf_export_completed", {
-          exportType: "lease_ledger",
-          renderingPath: "backend_pdfkit",
-          status: "completed",
-          durationMs: timer.durationMs(),
-          byteSize: blob.size,
-        });
-      }
-      const objectUrl = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = objectUrl;
-      a.download = `lease-ledger-${leaseId}.${format}`;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      URL.revokeObjectURL(objectUrl);
+      triggerDocumentDownload({ blob, filename, urlApi: URL });
     } catch (err: unknown) {
-      if (isPdf) {
-        recordPdfExportEvent("pdf_export_failed", {
-          exportType: "lease_ledger",
-          renderingPath: "backend_pdfkit",
-          status: "failed",
-          durationMs: timer.durationMs(),
-          errorCode: errorCodeFromUnknown(err),
-        });
-      }
       setError(errorMessage(err, `Failed to export ${format.toUpperCase()}`));
     }
   }

--- a/rentchain-frontend/src/pages/PdfSamplePage.tsx
+++ b/rentchain-frontend/src/pages/PdfSamplePage.tsx
@@ -1,26 +1,14 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
+import { PdfPreviewBoundary } from "../components/documentRendering/PdfPreviewBoundary";
 import { Card } from "../components/ui/Ui";
 import { recordPdfExportEvent } from "../lib/pdfExportObservability";
 import { spacing } from "../styles/tokens";
-import { useMobilePdfPreviewGuard } from "../utils/pdfPreviewGuard";
 
 const pdfUrl = "/sample/screening_report_sample.pdf?v=1";
 
 const PdfSamplePage: React.FC = () => {
   const navigate = useNavigate();
-  const [loaded, setLoaded] = React.useState(false);
-  const useMobileFallback = useMobilePdfPreviewGuard();
-
-  React.useEffect(() => {
-    if (!useMobileFallback) return;
-    recordPdfExportEvent("pdf_mobile_fallback_used", {
-      exportType: "sample_screening_report",
-      renderingPath: "mobile_fallback",
-      status: "fallback_used",
-      fallbackMode: "mobile_open_download",
-    });
-  }, [useMobileFallback]);
 
   return (
     <div style={{ display: "grid", gap: spacing.md }}>
@@ -101,70 +89,20 @@ const PdfSamplePage: React.FC = () => {
         </div>
       </Card>
       <Card style={{ padding: 0, overflow: "visible" }}>
-        {useMobileFallback ? (
-          <div style={{ display: "grid", gap: spacing.sm, padding: spacing.md }}>
-            <div style={{ fontWeight: 700 }}>Open the sample PDF</div>
-            <div style={{ color: "#475569" }}>
-              Mobile browsers handle PDF files more reliably in the browser viewer or download manager.
-            </div>
-            <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-              <a
-                href={pdfUrl}
-                target="_blank"
-                rel="noreferrer"
-                onClick={() =>
-                  recordPdfExportEvent("pdf_download_triggered", {
-                    exportType: "sample_screening_report",
-                    renderingPath: "mobile_fallback",
-                    status: "download_triggered",
-                    fallbackMode: "mobile_open_download",
-                  })
-                }
-                style={{ color: "#0f172a", fontWeight: 700 }}
-              >
-                Open PDF
-              </a>
-              <a
-                href={pdfUrl}
-                download
-                onClick={() =>
-                  recordPdfExportEvent("pdf_download_triggered", {
-                    exportType: "sample_screening_report",
-                    renderingPath: "mobile_fallback",
-                    status: "download_triggered",
-                    fallbackMode: "mobile_open_download",
-                  })
-                }
-                style={{ color: "#0f172a", fontWeight: 700 }}
-              >
-                Download PDF
-              </a>
-            </div>
-          </div>
-        ) : (
-          <>
-            {!loaded ? <div style={{ padding: spacing.md }}>Loading…</div> : null}
-            <iframe
-              title="Sample screening report"
-              src={`${pdfUrl}#view=FitH`}
-              style={{
-                width: "100%",
-                minHeight: 720,
-                height: "min(900px, 82dvh)",
-                border: "none",
-                display: "block",
-              }}
-              onLoad={() => {
-                setLoaded(true);
-                recordPdfExportEvent("pdf_export_completed", {
-                  exportType: "sample_screening_report",
-                  renderingPath: "desktop_iframe",
-                  status: "completed",
-                });
-              }}
-            />
-          </>
-        )}
+        <PdfPreviewBoundary
+          pdfUrl={pdfUrl}
+          exportType="sample_screening_report"
+          title="Open the sample PDF"
+          iframeTitle="Sample screening report"
+          fallbackStyle={{ display: "grid", gap: spacing.sm, padding: spacing.md }}
+          iframeStyle={{
+            width: "100%",
+            minHeight: 720,
+            height: "min(900px, 82dvh)",
+            border: "none",
+            display: "block",
+          }}
+        />
       </Card>
     </div>
   );

--- a/rentchain-frontend/src/styles/printPdfGuardrails.test.ts
+++ b/rentchain-frontend/src/styles/printPdfGuardrails.test.ts
@@ -15,6 +15,20 @@ describe("print PDF guardrails", () => {
     expect(printCss).not.toMatch(/\.rc-print-area[\s\S]*overflow:\s*hidden/i);
   });
 
+  it("routes print helpers through the shared document-rendering foundation", () => {
+    const printSummary = readFileSync(resolve(srcRoot, "utils/printSummary.ts"), "utf8");
+    const leaseSummaryPdf = readFileSync(resolve(srcRoot, "utils/leaseSummaryPdf.ts"), "utf8");
+    const samplePdfModal = readFileSync(resolve(srcRoot, "components/billing/SamplePdfModal.tsx"), "utf8");
+    const samplePdfPage = readFileSync(resolve(srcRoot, "pages/PdfSamplePage.tsx"), "utf8");
+
+    expect(printSummary).toMatch(/createPrintRoot/);
+    expect(printSummary).toMatch(/PRINT_ROOT_ACTIVE_ATTRIBUTE/);
+    expect(leaseSummaryPdf).toMatch(/shouldStartNewPage/);
+    expect(leaseSummaryPdf).toMatch(/wrapTextForPdf/);
+    expect(samplePdfModal).toMatch(/PdfPreviewBoundary/);
+    expect(samplePdfPage).toMatch(/PdfPreviewBoundary/);
+  });
+
   it("keeps application print view from reserving a viewport-height phantom page", () => {
     const source = readFileSync(
       resolve(srcRoot, "components/applications/PrintApplicationView.tsx"),

--- a/rentchain-frontend/src/utils/leaseSummaryPdf.ts
+++ b/rentchain-frontend/src/utils/leaseSummaryPdf.ts
@@ -1,4 +1,5 @@
 import type { LandlordActiveLease } from "@/api/leasesApi";
+import { shouldStartNewPage, triggerDocumentDownload, wrapTextForPdf } from "@/lib/documentRendering";
 import { createPdfExportTimer, recordPdfExportEvent } from "@/lib/pdfExportObservability";
 
 function formatCurrency(value: number | null | undefined) {
@@ -116,7 +117,7 @@ export function buildLeaseSummaryPdfSource(lease: LandlordActiveLease) {
     rect(docX, docY, docWidth, docHeight);
   };
   const ensureSpace = (neededHeight: number) => {
-    if (y - neededHeight >= bottomY) return;
+    if (!shouldStartNewPage({ cursorY: y, neededHeight, bottomY })) return;
     addPage();
     drawPageFrame();
   };
@@ -145,19 +146,7 @@ export function buildLeaseSummaryPdfSource(lease: LandlordActiveLease) {
     });
 
     if (section.note) {
-      const words = String(section.note).split(/\s+/);
-      let current = "";
-      const wrapped: string[] = [];
-      words.forEach((word) => {
-        const next = current ? `${current} ${word}` : word;
-        if (next.length > 86) {
-          if (current) wrapped.push(current);
-          current = word;
-        } else {
-          current = next;
-        }
-      });
-      if (current) wrapped.push(current);
+      const wrapped = wrapTextForPdf(String(section.note), 86);
       wrapped.forEach((wrappedLine) => {
         ensureSpace(18);
         textAt(wrappedLine, 96, y, 10);
@@ -217,12 +206,9 @@ export function downloadLeaseSummaryPdf(lease: LandlordActiveLease) {
     durationMs: timer.durationMs(),
     byteSize: blob.size,
   });
-  const url = window.URL.createObjectURL(blob);
-  const anchor = document.createElement("a");
-  anchor.href = url;
-  anchor.download = `lease-${lease.unitNumber || lease.id}.pdf`;
-  document.body.appendChild(anchor);
-  anchor.click();
-  anchor.remove();
-  window.URL.revokeObjectURL(url);
+  triggerDocumentDownload({
+    blob,
+    filename: `lease-${lease.unitNumber || lease.id}.pdf`,
+    urlApi: window.URL,
+  });
 }

--- a/rentchain-frontend/src/utils/printSummary.ts
+++ b/rentchain-frontend/src/utils/printSummary.ts
@@ -1,24 +1,22 @@
 import { recordPdfExportEvent } from "../lib/pdfExportObservability";
-
-type PrintSummaryMode = "summary" | "lease-renewals" | "application";
-
-const PRINT_SELECTOR_BY_MODE: Record<PrintSummaryMode, string> = {
-  summary: ".print-only-summary",
-  "lease-renewals": ".print-only-lease-renewals",
-  application: ".print-only-application",
-};
+import {
+  createPrintRoot,
+  nextRenderFrame,
+  PRINT_MODE_ATTRIBUTE,
+  PRINT_ROOT_ACTIVE_ATTRIBUTE,
+  PRINT_SELECTOR_BY_MODE,
+  type PrintSummaryMode,
+} from "../lib/documentRendering";
 
 export async function printSummaryDocument(mode: PrintSummaryMode = "summary"): Promise<void> {
   if (typeof window === "undefined" || typeof document === "undefined") return;
 
   const body = document.body;
-  const previousMode = body.getAttribute("data-print-mode");
+  const previousMode = body.getAttribute(PRINT_MODE_ATTRIBUTE);
   const selector = PRINT_SELECTOR_BY_MODE[mode];
   const printableSource = document.querySelector<HTMLElement>(selector);
-  const printableRoot = document.createElement("div");
+  const printableRoot = createPrintRoot(document);
   let cleanedUp = false;
-
-  printableRoot.setAttribute("data-print-root", "true");
 
   if (printableSource) {
     printableRoot.appendChild(printableSource.cloneNode(true));
@@ -29,25 +27,21 @@ export async function printSummaryDocument(mode: PrintSummaryMode = "summary"): 
     cleanedUp = true;
     window.removeEventListener("afterprint", cleanup);
     printableRoot.remove();
-    body.removeAttribute("data-print-root-active");
+    body.removeAttribute(PRINT_ROOT_ACTIVE_ATTRIBUTE);
     if (previousMode) {
-      body.setAttribute("data-print-mode", previousMode);
+      body.setAttribute(PRINT_MODE_ATTRIBUTE, previousMode);
     } else {
-      body.removeAttribute("data-print-mode");
+      body.removeAttribute(PRINT_MODE_ATTRIBUTE);
     }
   };
 
   try {
-    body.setAttribute("data-print-mode", mode);
-    body.setAttribute("data-print-root-active", "true");
+    body.setAttribute(PRINT_MODE_ATTRIBUTE, mode);
+    body.setAttribute(PRINT_ROOT_ACTIVE_ATTRIBUTE, "true");
     body.appendChild(printableRoot);
 
     window.addEventListener("afterprint", cleanup, { once: true });
-    await new Promise<void>((resolve) => {
-      window.requestAnimationFrame(() => {
-        resolve();
-      });
-    });
+    await nextRenderFrame(window);
 
     recordPdfExportEvent("pdf_print_opened", {
       exportType: "print_summary",


### PR DESCRIPTION
## Summary

Adds a narrow frontend document rendering foundation for shared print/PDF/export behavior without redesigning document output or changing backend PDF generation.

## What changed

- Added shared document rendering utilities for print root attributes, print modes, pagination decisions, PDF text wrapping, and object URL downloads.
- Added a reusable `PdfPreviewBoundary` for desktop iframe previews and mobile open/download fallback telemetry.
- Migrated duplicated sample PDF modal/page preview logic to the shared boundary.
- Routed lease summary pagination wrapping and browser download mechanics through the shared utilities.
- Routed lease ledger PDF/CSV downloads through the shared authenticated export/download path.
- Added focused regression tests for rendering primitives, preview fallback adoption, print guardrails, lease summary pagination, and lease ledger export behavior.

## Validation

- `npm run test -- documentRendering printPdfGuardrails SamplePdfModal PdfSamplePage LandlordLeaseSummaryPage exportDownload`
- `npm run test`
- `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm run build`
- `git diff --check`

Note: the default shell Node is v25.8.1, so build required the local Node 20 runtime to satisfy repo preflight.

## Scope notes

Backend PDFKit generators were audited but not refactored in this mission to avoid legal/report formatting drift. This PR keeps backend PDF engines and export APIs intact.