### PR TITLE
Add platform governance and privacy hardening foundations

### DIFF
--- a/rentchain-api/src/lib/exports/__tests__/exportResponse.test.ts
+++ b/rentchain-api/src/lib/exports/__tests__/exportResponse.test.ts
@@ -38,5 +38,8 @@ describe("exportResponse", () => {
       "Content-Disposition",
       'attachment; filename="rentchain-expenses-2026-04-29.pdf"'
     );
+    expect(setHeader).toHaveBeenCalledWith("X-RentChain-Governance", "metadata-only");
+    expect(setHeader).toHaveBeenCalledWith("X-RentChain-Export-Sensitivity", "confidential");
+    expect(setHeader).toHaveBeenCalledWith("X-RentChain-Retention-Category", "export_metadata");
   });
 });

--- a/rentchain-api/src/lib/exports/exportResponse.ts
+++ b/rentchain-api/src/lib/exports/exportResponse.ts
@@ -1,3 +1,5 @@
+import { governanceMetadata, type GovernanceSensitivity } from "../governance/platformGovernance";
+
 export type ExportFormat = "csv" | "xls" | "pdf";
 
 function isoDateStamp(date: Date): string {
@@ -31,8 +33,16 @@ export function setAttachmentExportHeaders(
   params: {
     filename: string;
     format: ExportFormat;
+    sensitivity?: GovernanceSensitivity;
   }
 ): void {
   res.setHeader("Content-Type", getExportContentType(params.format));
   res.setHeader("Content-Disposition", `attachment; filename="${params.filename}"`);
+  const governance = governanceMetadata({
+    sensitivity: params.sensitivity || "confidential",
+    retentionCategory: "export_metadata",
+  });
+  res.setHeader("X-RentChain-Governance", "metadata-only");
+  res.setHeader("X-RentChain-Export-Sensitivity", governance.sensitivity);
+  res.setHeader("X-RentChain-Retention-Category", governance.retentionCategory);
 }

--- a/rentchain-api/src/lib/governance/__tests__/platformGovernance.test.ts
+++ b/rentchain-api/src/lib/governance/__tests__/platformGovernance.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  actorFromRequest,
+  classifyExportSensitivity,
+  redactIdentifierMap,
+  sanitizeTelemetryProps,
+} from "../platformGovernance";
+
+describe("platformGovernance", () => {
+  it("normalizes attributable actor context from requests", () => {
+    expect(
+      actorFromRequest({
+        user: {
+          id: "admin-1",
+          actorRole: "admin",
+          landlordId: "landlord-1",
+        },
+      })
+    ).toEqual({
+      actorId: "admin-1",
+      actorRole: "admin",
+      landlordId: "landlord-1",
+    });
+  });
+
+  it("projects telemetry to metadata only and removes sensitive payload keys", () => {
+    const projected = sanitizeTelemetryProps({
+      exportType: "screening_report",
+      renderingPath: "backend_pdfkit",
+      nested: {
+        documentText: "raw document body",
+        accountNumber: "123456",
+        safeStatus: "completed",
+      },
+      tenantEmail: "tenant@example.com",
+    });
+
+    expect(projected).toEqual({
+      exportType: "screening_report",
+      renderingPath: "backend_pdfkit",
+      nested: {
+        safeStatus: "completed",
+      },
+    });
+    expect(JSON.stringify(projected)).not.toContain("tenant@example.com");
+    expect(JSON.stringify(projected)).not.toContain("raw document body");
+  });
+
+  it("classifies high-risk document exports as restricted", () => {
+    expect(classifyExportSensitivity("screening_report")).toBe("restricted");
+    expect(classifyExportSensitivity("tenant_report")).toBe("restricted");
+    expect(classifyExportSensitivity("unknown_export")).toBe("confidential");
+  });
+
+  it("redacts sensitive support identifiers while preserving ordinary scope ids", () => {
+    expect(
+      redactIdentifierMap({
+        propertyId: "prop-1",
+        checkoutSessionId: "cs_123456",
+        screeningOrderId: "order-abcdef",
+      })
+    ).toEqual({
+      propertyId: "prop-1",
+      checkoutSessionId: "***3456",
+      screeningOrderId: "***cdef",
+    });
+  });
+});

--- a/rentchain-api/src/lib/governance/platformGovernance.ts
+++ b/rentchain-api/src/lib/governance/platformGovernance.ts
@@ -1,0 +1,140 @@
+export type GovernanceSensitivity = "public" | "internal" | "confidential" | "restricted";
+export type GovernanceRetentionCategory =
+  | "operational_short"
+  | "export_metadata"
+  | "support_diagnostics"
+  | "audit_record";
+
+export type GovernanceActor = {
+  actorId: string | null;
+  actorRole: string;
+  landlordId: string | null;
+};
+
+export type GovernanceMetadata = {
+  sensitivity: GovernanceSensitivity;
+  retentionCategory: GovernanceRetentionCategory;
+  metadataOnly: boolean;
+  redactionApplied: boolean;
+};
+
+const SENSITIVE_KEY_FRAGMENTS = [
+  "address",
+  "account",
+  "bank",
+  "body",
+  "card",
+  "credential",
+  "document",
+  "email",
+  "full_name",
+  "fullname",
+  "identity",
+  "name",
+  "passcode",
+  "payload",
+  "pdfcontent",
+  "phone",
+  "provider",
+  "reporttext",
+  "routing",
+  "screeningpayload",
+  "secret",
+  "sin",
+  "ssn",
+  "token",
+];
+
+const EXPORT_SENSITIVITY: Record<string, GovernanceSensitivity> = {
+  application_review_summary: "restricted",
+  lease_ledger: "restricted",
+  lease_summary: "confidential",
+  sample_screening_report: "internal",
+  schedule_a: "restricted",
+  screening_report: "restricted",
+  tenant_report: "restricted",
+  transunion_usage: "restricted",
+};
+
+const SUPPORT_DEBUG_REDACT_KEYS = new Set(["checkoutsessionid", "quoteid", "screeningorderid"]);
+
+function asString(value: unknown, max = 240): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function normalizedKey(value: string): string {
+  return value.replace(/[^a-z0-9]+/gi, "").toLowerCase();
+}
+
+function isSensitiveKey(key: string): boolean {
+  const normalized = normalizedKey(key);
+  return SENSITIVE_KEY_FRAGMENTS.some((fragment) => normalized.includes(normalizedKey(fragment)));
+}
+
+export function actorFromRequest(req: any): GovernanceActor {
+  const actorId = asString(req?.user?.uid || req?.user?.id || req?.user?.sub, 240) || null;
+  const actorRole = asString(req?.user?.actorRole || req?.user?.role, 80).toLowerCase() || "unknown";
+  const landlordId = asString(req?.user?.landlordId || req?.user?.actorLandlordId || req?.user?.id, 240) || null;
+  return { actorId, actorRole, landlordId };
+}
+
+export function governanceMetadata(params?: {
+  sensitivity?: GovernanceSensitivity;
+  retentionCategory?: GovernanceRetentionCategory;
+  redactionApplied?: boolean;
+}): GovernanceMetadata {
+  return {
+    sensitivity: params?.sensitivity || "internal",
+    retentionCategory: params?.retentionCategory || "operational_short",
+    metadataOnly: true,
+    redactionApplied: params?.redactionApplied !== false,
+  };
+}
+
+export function classifyExportSensitivity(exportType: string): GovernanceSensitivity {
+  return EXPORT_SENSITIVITY[asString(exportType, 120)] || "confidential";
+}
+
+export function exportGovernanceMetadata(exportType: string): GovernanceMetadata {
+  return governanceMetadata({
+    sensitivity: classifyExportSensitivity(exportType),
+    retentionCategory: "export_metadata",
+    redactionApplied: true,
+  });
+}
+
+export function sanitizeTelemetryProps(value: unknown, depth = 0): unknown {
+  if (depth > 3) return null;
+  if (value == null) return null;
+  if (typeof value === "string") return value.slice(0, 180);
+  if (typeof value === "number" || typeof value === "boolean") return value;
+  if (Array.isArray(value)) return value.slice(0, 25).map((item) => sanitizeTelemetryProps(item, depth + 1));
+  if (typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+      if (isSensitiveKey(key)) continue;
+      out[key] = sanitizeTelemetryProps(nested, depth + 1);
+    }
+    return out;
+  }
+  return null;
+}
+
+export function redactIdentifier(value: unknown, visibleTail = 4): string | null {
+  const raw = asString(value, 240);
+  if (!raw) return null;
+  if (raw.length <= visibleTail) return "***";
+  return `***${raw.slice(-visibleTail)}`;
+}
+
+export function redactIdentifierMap(input: Record<string, string | null | undefined>) {
+  const out: Record<string, string | null> = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (!value) {
+      out[key] = null;
+      continue;
+    }
+    out[key] = isSensitiveKey(key) || SUPPORT_DEBUG_REDACT_KEYS.has(normalizedKey(key)) ? redactIdentifier(value) : String(value);
+  }
+  return out;
+}

--- a/rentchain-api/src/lib/pdfExportObservability/recordPdfExportTelemetry.ts
+++ b/rentchain-api/src/lib/pdfExportObservability/recordPdfExportTelemetry.ts
@@ -1,4 +1,9 @@
 import type { PdfExportEventName, PdfExportType, PdfRenderingPath } from "./pdfExportObservabilityTypes";
+import {
+  actorFromRequest,
+  exportGovernanceMetadata,
+  sanitizeTelemetryProps,
+} from "../governance/platformGovernance";
 
 type RecordPdfExportTelemetryInput = {
   eventName: PdfExportEventName;
@@ -32,9 +37,10 @@ function browserClass(userAgent: string) {
 export async function recordPdfExportTelemetry(input: RecordPdfExportTelemetryInput): Promise<void> {
   try {
     const { db } = await import("../../config/firebase");
-    const userId = asString(input.req?.user?.id, 160) || null;
-    const landlordId = asString(input.req?.user?.landlordId || input.req?.user?.id, 160) || null;
-    const role = asString(input.req?.user?.role || input.req?.user?.actorRole, 80) || "unknown";
+    const actor = actorFromRequest(input.req);
+    const userId = actor.actorId;
+    const landlordId = actor.landlordId;
+    const role = actor.actorRole;
     const userAgent = asString(input.req?.headers?.["user-agent"], 400);
     const durationMs = asNumber(input.durationMs);
     const byteSize = asNumber(input.byteSize);
@@ -44,7 +50,7 @@ export async function recordPdfExportTelemetry(input: RecordPdfExportTelemetryIn
       landlordId,
       role,
       eventName: input.eventName,
-      eventProps: {
+      eventProps: sanitizeTelemetryProps({
         exportType: input.exportType,
         renderingPath: input.renderingPath,
         status: input.status || null,
@@ -53,7 +59,8 @@ export async function recordPdfExportTelemetry(input: RecordPdfExportTelemetryIn
         browserClass: userAgent ? browserClass(userAgent) : "unknown",
         viewportCategory: "server",
         errorCode: input.errorCode ? asString(input.errorCode, 120).toLowerCase().replace(/[^a-z0-9_:-]+/g, "_") : null,
-      },
+      }),
+      governance: exportGovernanceMetadata(input.exportType),
       createdAt: Date.now(),
     });
   } catch (err: any) {

--- a/rentchain-api/src/lib/supportConsole/__tests__/buildSupportConsoleResource.test.ts
+++ b/rentchain-api/src/lib/supportConsole/__tests__/buildSupportConsoleResource.test.ts
@@ -219,10 +219,18 @@ describe("buildSupportConsoleResource", () => {
         domainsPresent: ["application", "policy", "screening", "system"],
         identifiers: expect.objectContaining({
           propertyId: "prop-1",
-          checkoutSessionId: "cs_123",
+          checkoutSessionId: "***_123",
+          quoteId: "***te-1",
+          screeningOrderId: "***er-1",
         }),
       })
     );
+    expect(result?.governance).toEqual({
+      sensitivity: "restricted",
+      metadataOnly: true,
+      retentionCategory: "support_diagnostics",
+      redactionApplied: true,
+    });
   });
 
   it("builds a maintenance console without reconciliation", async () => {
@@ -347,6 +355,12 @@ describe("buildSupportConsoleResource", () => {
         canonicalEventCount: 0,
         domainsPresent: [],
         identifiers: {},
+      },
+      governance: {
+        sensitivity: "restricted",
+        metadataOnly: true,
+        retentionCategory: "support_diagnostics",
+        redactionApplied: true,
       },
     });
   });

--- a/rentchain-api/src/lib/supportConsole/buildSupportConsoleResource.ts
+++ b/rentchain-api/src/lib/supportConsole/buildSupportConsoleResource.ts
@@ -9,6 +9,7 @@ import { deriveSlaState } from "../sla/deriveSlaState";
 import { deriveAdminTriageQueue } from "../triage/deriveAdminTriageQueue";
 import { loadWatchlistEntries } from "../watchlist/loadWatchlistEntries";
 import { canonicalEventToTimelineItem } from "../timeline/timelineAdapter";
+import { redactIdentifierMap } from "../governance/platformGovernance";
 import type {
   SupportConsoleAutomationItem,
   SupportConsolePolicyDecision,
@@ -294,6 +295,12 @@ function emptyResponse(spec: NormalizedResourceSpec, resourceId: string): Suppor
       domainsPresent: [],
       identifiers: {},
     },
+    governance: {
+      sensitivity: "restricted",
+      metadataOnly: true,
+      retentionCategory: "support_diagnostics",
+      redactionApplied: true,
+    },
   };
 }
 
@@ -398,7 +405,13 @@ export async function buildSupportConsoleResource(input: {
     debug: {
       canonicalEventCount: relatedEvents.length,
       domainsPresent: domainsPresent(relatedEvents),
-      identifiers: buildDebugIdentifiers(spec, doc, reconciliation),
+      identifiers: redactIdentifierMap(buildDebugIdentifiers(spec, doc, reconciliation)),
+    },
+    governance: {
+      sensitivity: "restricted",
+      metadataOnly: true,
+      retentionCategory: "support_diagnostics",
+      redactionApplied: true,
     },
   };
 }

--- a/rentchain-api/src/lib/supportConsole/supportConsoleTypes.ts
+++ b/rentchain-api/src/lib/supportConsole/supportConsoleTypes.ts
@@ -49,4 +49,10 @@ export type SupportConsoleResourceResponse = {
     domainsPresent: string[];
     identifiers?: Record<string, string | null | undefined>;
   };
+  governance?: {
+    sensitivity: "restricted";
+    metadataOnly: true;
+    retentionCategory: "support_diagnostics";
+    redactionApplied: true;
+  };
 };

--- a/rentchain-api/src/routes/__tests__/supportConsoleRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/supportConsoleRoutes.test.ts
@@ -24,6 +24,9 @@ const { collections, dbMock } = vi.hoisted(() => {
               data: () => ensureCollection(name).get(String(id)),
             };
           },
+          async set(payload: any) {
+            ensureCollection(name).set(String(id), payload);
+          },
         }),
         async get() {
           const docs = Array.from(ensureCollection(name).entries()).map(([id, data]) => ({
@@ -164,8 +167,28 @@ describe("supportConsoleRoutes", () => {
         debug: expect.objectContaining({
           canonicalEventCount: 1,
         }),
+        governance: expect.objectContaining({
+          sensitivity: "restricted",
+          retentionCategory: "support_diagnostics",
+          redactionApplied: true,
+        }),
       })
     );
+    const auditEvents = Array.from(collections.get("canonicalEvents")?.values() || []).filter(
+      (event: any) => event.type === "system.support_console_accessed"
+    );
+    expect(auditEvents).toEqual([
+      expect.objectContaining({
+        action: "support_console_accessed",
+        visibility: "system",
+        metadata: expect.objectContaining({
+          resourceType: "application",
+          metadataOnly: true,
+          redactionApplied: true,
+          retentionCategory: "support_diagnostics",
+        }),
+      }),
+    ]);
   });
 
   it("returns maintenance data without reconciliation", async () => {
@@ -294,7 +317,7 @@ describe("supportConsoleRoutes", () => {
       user: { id: "landlord-1", role: "landlord" },
     });
     expect(forbidden.status).toBe(403);
-    expect(forbidden.body?.error).toBe("FORBIDDEN");
+    expect(forbidden.body?.error).toBe("Forbidden");
 
     const invalid = await invokeRouter(router, {
       method: "GET",

--- a/rentchain-api/src/routes/__tests__/telemetryRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/telemetryRoutes.test.ts
@@ -93,6 +93,12 @@ describe("telemetryRoutes", () => {
     });
     expect(stored[0].eventProps.tenantName).toBeUndefined();
     expect(stored[0].eventProps.documentText).toBeUndefined();
+    expect(stored[0].governance).toMatchObject({
+      sensitivity: "confidential",
+      retentionCategory: "export_metadata",
+      metadataOnly: true,
+      redactionApplied: true,
+    });
   });
 
   it("continues rejecting unrelated telemetry event families", async () => {

--- a/rentchain-api/src/routes/supportConsoleRoutes.ts
+++ b/rentchain-api/src/routes/supportConsoleRoutes.ts
@@ -1,6 +1,9 @@
 import { Router } from "express";
 import { requireAuth } from "../middleware/requireAuth";
+import { requirePermission } from "../middleware/requireAuthz";
 import { buildSupportConsoleResource } from "../lib/supportConsole/buildSupportConsoleResource";
+import { actorFromRequest } from "../lib/governance/platformGovernance";
+import { writeCanonicalEvent } from "../lib/events/buildEvent";
 
 const router = Router();
 
@@ -8,19 +11,46 @@ function asString(value: unknown, max = 240) {
   return String(value || "").trim().slice(0, max);
 }
 
-function normalizeRole(req: any): "admin" | "landlord" | "other" {
-  const role = asString(req.user?.actorRole || req.user?.role, 40).toLowerCase();
-  if (role === "admin") return "admin";
-  if (role === "landlord") return "landlord";
-  return "other";
+async function recordSupportConsoleAccess(req: any, input: { resourceType: string; resourceId: string }) {
+  try {
+    const actor = actorFromRequest(req);
+    const now = new Date().toISOString();
+    await writeCanonicalEvent({
+      id: `support_console_accessed:${input.resourceType}:${input.resourceId}:${actor.actorId || "unknown"}:${Date.now()}`
+        .toLowerCase()
+        .replace(/[^a-z0-9_.:-]+/g, "_"),
+      domain: "system",
+      action: "support_console_accessed",
+      status: "completed",
+      actor: {
+        type: actor.actorRole === "admin" ? "admin" : "user",
+        id: actor.actorId,
+        role: actor.actorRole,
+      },
+      resource: {
+        type: "support_console_resource",
+        id: input.resourceId,
+        parentType: input.resourceType,
+        parentId: input.resourceId,
+      },
+      occurredAt: now,
+      visibility: "system",
+      summary: "Support console resource accessed with redacted diagnostic identifiers.",
+      metadata: {
+        resourceType: input.resourceType,
+        metadataOnly: true,
+        redactionApplied: true,
+        retentionCategory: "support_diagnostics",
+      },
+      tags: ["support_console", "governance"],
+    });
+  } catch (err: any) {
+    console.warn("[support-console] access audit skipped", err?.message || err);
+  }
 }
 
-router.get("/support-console/resource", requireAuth, async (req: any, res) => {
+router.get("/support-console/resource", requireAuth, requirePermission("system.admin"), async (req: any, res) => {
   try {
-    if (normalizeRole(req) !== "admin") {
-      return res.status(403).json({ ok: false, error: "FORBIDDEN" });
-    }
-
     const resourceType = asString(req.query?.resourceType, 120);
     const resourceId = asString(req.query?.resourceId, 240);
     if (!resourceType || !resourceId) {
@@ -32,6 +62,7 @@ router.get("/support-console/resource", requireAuth, async (req: any, res) => {
       return res.status(400).json({ ok: false, error: "RESOURCE_TYPE_UNSUPPORTED" });
     }
 
+    void recordSupportConsoleAccess(req, { resourceType, resourceId });
     return res.json(payload);
   } catch (err: any) {
     console.error("[support-console] resource fetch failed", err?.message || err);

--- a/rentchain-api/src/routes/telemetryRoutes.ts
+++ b/rentchain-api/src/routes/telemetryRoutes.ts
@@ -1,45 +1,15 @@
 import { Router } from "express";
 import { db } from "../config/firebase";
+import { actorFromRequest, governanceMetadata, sanitizeTelemetryProps } from "../lib/governance/platformGovernance";
 import { requireAuth } from "../middleware/requireAuth";
 
 const router = Router();
 
-const REDACT_KEYS = [
-  "email",
-  "phone",
-  "address",
-  "name",
-  "fullName",
-  "tenantEmail",
-  "tenantName",
-  "documentText",
-  "documentBody",
-  "pdfContent",
-  "screeningPayload",
-  "paymentAccount",
-];
 const ALLOWED_EVENT_PREFIXES = ["nudge_", "pdf_"];
 
-function sanitizeValue(value: any, depth = 0): any {
-  if (depth > 3) return null;
-  if (value == null) return null;
-  if (typeof value === "string") return value.slice(0, 180);
-  if (typeof value === "number" || typeof value === "boolean") return value;
-  if (Array.isArray(value)) return value.slice(0, 25).map((item) => sanitizeValue(item, depth + 1));
-  if (typeof value === "object") {
-    const out: Record<string, any> = {};
-    for (const [key, val] of Object.entries(value)) {
-      const lowered = String(key || "").toLowerCase();
-      if (REDACT_KEYS.some((k) => lowered.includes(k.toLowerCase()))) continue;
-      out[key] = sanitizeValue(val, depth + 1);
-    }
-    return out;
-  }
-  return null;
-}
-
 router.post("/telemetry", requireAuth, async (req: any, res) => {
-  const userId = String(req.user?.id || "").trim();
+  const actor = actorFromRequest(req);
+  const userId = actor.actorId;
   if (!userId) return res.status(401).json({ ok: false, error: "Unauthorized" });
 
   const eventName = String(req.body?.eventName || "").trim().toLowerCase();
@@ -47,9 +17,9 @@ router.post("/telemetry", requireAuth, async (req: any, res) => {
     return res.status(400).json({ ok: false, error: "invalid_event_name" });
   }
 
-  const role = String(req.user?.role || "").trim().toLowerCase() || "unknown";
-  const landlordId = String(req.user?.landlordId || req.user?.id || "").trim() || null;
-  const eventProps = sanitizeValue(req.body?.eventProps || {});
+  const role = actor.actorRole;
+  const landlordId = actor.landlordId;
+  const eventProps = sanitizeTelemetryProps(req.body?.eventProps || {});
   const createdAt = Date.now();
 
   try {
@@ -59,6 +29,10 @@ router.post("/telemetry", requireAuth, async (req: any, res) => {
       role,
       eventName,
       eventProps,
+      governance: governanceMetadata({
+        sensitivity: eventName.startsWith("pdf_") ? "confidential" : "internal",
+        retentionCategory: eventName.startsWith("pdf_") ? "export_metadata" : "operational_short",
+      }),
       createdAt,
     });
     return res.status(200).json({ ok: true });


### PR DESCRIPTION
## Governance audit summary
- Access boundaries: export/support/admin paths use mixed route-level auth, landlord guards, and `system.admin` permission checks. Support console was the highest-risk outlier because it relied on normalized role checks instead of the shared permission middleware.
- Export governance: export/download paths already have route-specific authorization and shared attachment headers, but lacked centralized sensitivity/retention metadata.
- Operator privileges: admin diagnostics and support tooling expose operational identifiers; support console reads were not canonically audited.
- Observability/privacy: PDF/export telemetry is metadata-oriented, but redaction was local to telemetry routes and not reusable across export observability.
- Auditability/retention gaps: export telemetry and support diagnostics lacked consistent governance metadata and support access attribution.
- Future execution governance: automation/AI-adjacent systems need deterministic actor/resource/action metadata and metadata-only telemetry patterns to inherit.

## Foundation strategy
- Add narrow backend governance primitives only: actor normalization, sensitivity/retention metadata, telemetry projection, export sensitivity classification, and support diagnostic ID redaction.
- Adopt only in high-risk duplicated areas: telemetry routes, PDF export telemetry, export response headers, and support console diagnostics/access.
- Preserve existing auth architecture, export APIs, PDFKit/legal formatting, frontend behavior, and document rendering.

## Changes
- Added `rentchain-api/src/lib/governance/platformGovernance.ts` with shared governance metadata, export sensitivity, telemetry sanitization, actor attribution, and identifier redaction helpers.
- Added governance metadata to app telemetry and PDF export telemetry.
- Added additive governance headers to attachment exports.
- Hardened support console with `requirePermission("system.admin")`, redacted sensitive debug identifiers, response governance metadata, and non-blocking canonical access audit events.
- Added/updated tests for governance helpers, telemetry projection safety, export headers, support-console access boundaries, support audit event generation, and redacted diagnostics.

## Scope review
- No backend PDFKit refactor.
- No legal formatting changes.
- No frontend redesign or export API changes.
- No permissions architecture rewrite.
- No sensitive payload logging introduced.

## Verification
- `npm run test -- platformGovernance telemetryRoutes supportConsoleRoutes buildSupportConsoleResource exportResponse derivePdfExportDiagnostics` passed.
- `npm run test -- supportConsoleRoutes` passed.
- Full backend `npm run test` passed outside sandbox: 331 files, 1,437 tests.
- Backend `npm run build` passed.
- `git diff --check` passed.

## Manual QA notes
- Export/download behavior preserved through additive headers only.
- Support console still returns existing diagnostic structure with governance metadata and redacted high-risk IDs.
- Telemetry remains metadata-only and non-blocking for PDF export observability.
- Tenant visibility and existing route authorization patterns are preserved; support console access is now shared-permission guarded.

## Remaining risks
- Retention is now classified in metadata but not yet enforced by lifecycle/TTL jobs.
- Broader support-console timeline redaction remains a future hardening opportunity; this PR avoids changing historical canonical event projection semantics.