### PR TITLE
Add legal document composition foundation

### DIFF
--- a/rentchain-api/src/lib/legalDocuments/__tests__/leaseNoticeComposition.test.ts
+++ b/rentchain-api/src/lib/legalDocuments/__tests__/leaseNoticeComposition.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { resolveLeaseNoticeRule } from "../../../config/leaseNoticeRules";
+import { composeLeaseNoticeLegalDocument } from "../leaseNoticeComposition";
+
+describe("leaseNoticeComposition", () => {
+  it("composes province-aware notice metadata without raw document payloads", () => {
+    const rule = resolveLeaseNoticeRule({ province: "NS", leaseType: "fixed_term" });
+    expect(rule).toBeTruthy();
+
+    const documentDefinition = composeLeaseNoticeLegalDocument({
+      leaseId: "lease-1",
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      province: "NS",
+      leaseType: "fixed_term",
+      noticeType: "renewal_offer",
+      rule: rule!,
+      rentChangeMode: "increase",
+      currency: "CAD",
+      currentRent: 1800,
+      proposedRent: 1900,
+      newTermType: "fixed_term",
+      newTermStartDate: "2026-04-01",
+      newTermEndDate: "2027-03-31",
+      responseDeadlineAt: Date.UTC(2026, 2, 1),
+      noticeDueAt: Date.UTC(2026, 0, 1),
+    });
+
+    expect(documentDefinition.metadata).toMatchObject({
+      documentKind: "lease_notice",
+      province: "NS",
+      templateKey: "ns.fixed_term.renewal_offer.v1",
+      version: "ns-v1",
+      sensitivity: "restricted",
+      governance: {
+        sensitivity: "restricted",
+        retentionCategory: "export_metadata",
+        metadataOnly: true,
+      },
+    });
+    expect(documentDefinition.heading).toEqual({
+      title: "Lease notice preview",
+      description: "Proposed rent: 1900 CAD",
+    });
+    expect(documentDefinition.sections.map((section) => section.id)).toEqual([
+      "notice-context",
+      "term-response",
+    ]);
+  });
+});

--- a/rentchain-api/src/lib/legalDocuments/__tests__/scheduleAComposition.test.ts
+++ b/rentchain-api/src/lib/legalDocuments/__tests__/scheduleAComposition.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+  composeScheduleALegalDocument,
+  NS_SCHEDULE_A_TEMPLATE_VERSION,
+} from "../scheduleAComposition";
+
+const draft = {
+  landlordId: "landlord-1",
+  propertyId: "prop-1",
+  unitId: "unit-1",
+  tenantIds: ["tenant-1"],
+  province: "NS",
+  termType: "fixed",
+  startDate: "2026-03-01",
+  endDate: "2027-02-28",
+  baseRentCents: 185000,
+  parkingCents: 10000,
+  dueDay: 1,
+  paymentMethod: "etransfer",
+  nsfFeeCents: 4500,
+  utilitiesIncluded: ["heat", "water"],
+  depositCents: 92500,
+  additionalClauses: "No smoking in common areas.",
+  status: "draft",
+  templateVersion: "ns-schedule-a-v1",
+  createdAt: 1,
+  updatedAt: 1,
+} as const;
+
+describe("scheduleAComposition", () => {
+  it("composes Schedule A sections with province, template, and governance metadata", () => {
+    const documentDefinition = composeScheduleALegalDocument({
+      draftId: "draft-1",
+      draft: draft as any,
+      landlordDisplayName: "Demo Landlord",
+      tenantDisplayNames: ["Tenant One"],
+      propertyAddressLine: "123 Main St, Halifax, NS",
+      unitLabel: "Unit 2A",
+    });
+
+    expect(documentDefinition.metadata).toMatchObject({
+      documentKind: "schedule_a",
+      province: "NS",
+      templateKey: NS_SCHEDULE_A_TEMPLATE_VERSION,
+      version: NS_SCHEDULE_A_TEMPLATE_VERSION,
+      sensitivity: "restricted",
+      governance: {
+        sensitivity: "restricted",
+        retentionCategory: "export_metadata",
+        metadataOnly: true,
+      },
+    });
+    expect(documentDefinition.sections.map((section) => section.id)).toEqual([
+      "lease-summary",
+      "term",
+      "payments",
+      "additional-clauses",
+    ]);
+    expect(documentDefinition.sections[0].fields.map((field) => field.label)).toEqual([
+      "Landlord",
+      "Tenant(s)",
+      "Property",
+      "Unit",
+      "Draft ID",
+    ]);
+    expect(documentDefinition.sections[3].body).toBe("No smoking in common areas.");
+    expect(documentDefinition.footer).toMatch(/supplements Form P/);
+  });
+});

--- a/rentchain-api/src/lib/legalDocuments/leaseNoticeComposition.ts
+++ b/rentchain-api/src/lib/legalDocuments/leaseNoticeComposition.ts
@@ -1,0 +1,88 @@
+import type {
+  LeaseNoticeRule,
+  LeaseNoticeType,
+  LeaseType,
+  RentChangeMode,
+} from "../../config/leaseNoticeRules";
+import { legalExportMetadata, type LegalDocumentDefinition } from "./legalDocumentEngine";
+
+export function composeLeaseNoticeLegalDocument(input: {
+  leaseId: string;
+  landlordId: string;
+  tenantId: string;
+  propertyId: string | null;
+  unitId: string | null;
+  province: string;
+  leaseType: LeaseType;
+  noticeType: LeaseNoticeType;
+  rule: LeaseNoticeRule;
+  rentChangeMode: RentChangeMode;
+  currency: string;
+  currentRent: number | null;
+  proposedRent: number | null;
+  newTermType: LeaseType;
+  newTermStartDate: string;
+  newTermEndDate: string | null;
+  responseDeadlineAt: number;
+  noticeDueAt: number | null;
+}): LegalDocumentDefinition {
+  const body =
+    input.rentChangeMode === "undecided"
+      ? "Rent will be decided later by the landlord."
+      : input.proposedRent != null
+      ? `Proposed rent: ${input.proposedRent} ${input.currency}`
+      : "No rent change provided.";
+
+  return {
+    metadata: legalExportMetadata({
+      documentKind: "lease_notice",
+      title: "Lease notice preview",
+      version: input.rule.ruleVersion,
+      province: input.province,
+      templateKey: input.rule.templateKey,
+      sensitivity: "restricted",
+    }),
+    heading: {
+      title: "Lease notice preview",
+      description: body,
+    },
+    sections: [
+      {
+        id: "notice-context",
+        title: "Notice context",
+        fields: [
+          { key: "leaseId", label: "Lease ID", value: input.leaseId },
+          { key: "noticeType", label: "Notice type", value: input.noticeType },
+          { key: "province", label: "Province", value: input.province },
+          { key: "leaseType", label: "Lease type", value: input.leaseType },
+          { key: "legalTemplateKey", label: "Legal template key", value: input.rule.templateKey },
+          { key: "noticeRuleVersion", label: "Notice rule version", value: input.rule.ruleVersion },
+        ],
+        layout: { avoidBreakInside: true },
+      },
+      {
+        id: "term-response",
+        title: "Term and response",
+        fields: [
+          { key: "rentChangeMode", label: "Rent change mode", value: input.rentChangeMode },
+          {
+            key: "currentRent",
+            label: "Current rent",
+            value: input.currentRent == null ? "Not specified" : String(input.currentRent),
+          },
+          {
+            key: "proposedRent",
+            label: "Proposed rent",
+            value: input.proposedRent == null ? "Not specified" : String(input.proposedRent),
+          },
+          { key: "newTermType", label: "New term type", value: input.newTermType },
+          { key: "newTermStartDate", label: "New term start date", value: input.newTermStartDate },
+          { key: "newTermEndDate", label: "New term end date", value: input.newTermEndDate || "Not specified" },
+          { key: "responseDeadlineAt", label: "Response deadline", value: String(input.responseDeadlineAt) },
+        ],
+        body,
+        layout: { avoidBreakInside: true },
+      },
+    ],
+  };
+}

--- a/rentchain-api/src/lib/legalDocuments/legalDocumentEngine.ts
+++ b/rentchain-api/src/lib/legalDocuments/legalDocumentEngine.ts
@@ -1,0 +1,76 @@
+import {
+  exportGovernanceMetadata,
+  governanceMetadata,
+  type GovernanceMetadata,
+  type GovernanceSensitivity,
+} from "../governance/platformGovernance";
+
+export type LegalDocumentKind = "lease_summary" | "schedule_a" | "lease_notice";
+
+export type LegalDocumentMetadata = {
+  documentKind: LegalDocumentKind;
+  title: string;
+  version: string;
+  province: string | null;
+  templateKey?: string | null;
+  sensitivity: GovernanceSensitivity;
+  governance: GovernanceMetadata;
+};
+
+export type LegalDocumentField = {
+  key: string;
+  label: string;
+  value: string;
+};
+
+export type LegalDocumentSection = {
+  id: string;
+  title: string;
+  fields: LegalDocumentField[];
+  body?: string | null;
+  layout?: {
+    avoidBreakInside?: boolean;
+    signatureSafe?: boolean;
+  };
+};
+
+export type LegalDocumentDefinition = {
+  metadata: LegalDocumentMetadata;
+  heading: {
+    title: string;
+    subtitle?: string | null;
+    description?: string | null;
+  };
+  sections: LegalDocumentSection[];
+  footer?: string | null;
+};
+
+export function legalExportMetadata(params: {
+  documentKind: LegalDocumentKind;
+  title: string;
+  version: string;
+  province?: string | null;
+  templateKey?: string | null;
+  sensitivity?: GovernanceSensitivity;
+}): LegalDocumentMetadata {
+  const exportType = params.documentKind === "lease_notice" ? "lease_summary" : params.documentKind;
+  const defaultGovernance = exportGovernanceMetadata(exportType);
+  const sensitivity = params.sensitivity || defaultGovernance.sensitivity;
+  const governance =
+    sensitivity === defaultGovernance.sensitivity
+      ? defaultGovernance
+      : governanceMetadata({
+          sensitivity,
+          retentionCategory: defaultGovernance.retentionCategory,
+          redactionApplied: defaultGovernance.redactionApplied,
+        });
+  return {
+    documentKind: params.documentKind,
+    title: params.title,
+    version: params.version,
+    province: params.province ? String(params.province).trim().toUpperCase() : null,
+    templateKey: params.templateKey || null,
+    sensitivity,
+    governance,
+  };
+}

--- a/rentchain-api/src/lib/legalDocuments/scheduleAComposition.ts
+++ b/rentchain-api/src/lib/legalDocuments/scheduleAComposition.ts
@@ -1,0 +1,106 @@
+import type { LeaseDraftCore } from "../../services/leaseDraftsService";
+import {
+  legalExportMetadata,
+  type LegalDocumentDefinition,
+  type LegalDocumentField,
+} from "./legalDocumentEngine";
+
+export const NS_SCHEDULE_A_TEMPLATE_VERSION = "ns-schedule-a-v1";
+
+function formatMoney(cents: number | null | undefined): string {
+  const value = Number(cents || 0) / 100;
+  return new Intl.NumberFormat("en-CA", {
+    style: "currency",
+    currency: "CAD",
+    minimumFractionDigits: 2,
+  }).format(value);
+}
+
+function termLabel(termType: LeaseDraftCore["termType"]): string {
+  if (termType === "fixed") return "Fixed term";
+  if (termType === "year-to-year") return "Year-to-year";
+  return "Month-to-month";
+}
+
+function nonEmpty(value: string): string {
+  return value.trim() || "Not specified";
+}
+
+function field(key: string, label: string, value: string | number): LegalDocumentField {
+  return { key, label, value: String(value) };
+}
+
+export function composeScheduleALegalDocument(input: {
+  draftId: string;
+  draft: LeaseDraftCore;
+  landlordDisplayName: string;
+  tenantDisplayNames: string[];
+  propertyAddressLine: string;
+  unitLabel: string;
+}): LegalDocumentDefinition {
+  const { draft } = input;
+  const utilities = draft.utilitiesIncluded.length ? draft.utilitiesIncluded.join(", ") : "None listed";
+  const clauses = draft.additionalClauses?.trim() || "No additional clauses provided.";
+
+  return {
+    metadata: legalExportMetadata({
+      documentKind: "schedule_a",
+      title: "Schedule A addendum",
+      version: NS_SCHEDULE_A_TEMPLATE_VERSION,
+      province: "NS",
+      templateKey: NS_SCHEDULE_A_TEMPLATE_VERSION,
+      sensitivity: "restricted",
+    }),
+    heading: {
+      title: "Schedule A addendum",
+      subtitle: "Province: Nova Scotia (NS)",
+      description: "Reference: Nova Scotia Standard Form of Lease (Form P). Review base lease terms.",
+    },
+    sections: [
+      {
+        id: "lease-summary",
+        title: "Lease Summary",
+        fields: [
+          field("landlord", "Landlord", nonEmpty(input.landlordDisplayName || "Landlord")),
+          field("tenants", "Tenant(s)", nonEmpty(input.tenantDisplayNames.join(", ") || "Tenant")),
+          field("property", "Property", nonEmpty(input.propertyAddressLine || draft.propertyId)),
+          field("unit", "Unit", nonEmpty(input.unitLabel || draft.unitId)),
+          field("draftId", "Draft ID", nonEmpty(input.draftId)),
+        ],
+        layout: { avoidBreakInside: true },
+      },
+      {
+        id: "term",
+        title: "Term",
+        fields: [
+          field("termType", "Term type", termLabel(draft.termType)),
+          field("startDate", "Start date", nonEmpty(draft.startDate)),
+          field("endDate", "End date", nonEmpty(draft.endDate || "")),
+          field("rentDueDay", "Rent due day", draft.dueDay),
+        ],
+        layout: { avoidBreakInside: true },
+      },
+      {
+        id: "payments",
+        title: "Payments",
+        fields: [
+          field("baseRent", "Base rent", formatMoney(draft.baseRentCents)),
+          field("parking", "Parking", formatMoney(draft.parkingCents)),
+          field("deposit", "Deposit", draft.depositCents != null ? formatMoney(draft.depositCents) : "Not specified"),
+          field("nsfFee", "NSF fee", draft.nsfFeeCents != null ? formatMoney(draft.nsfFeeCents) : "Not specified"),
+          field("paymentMethod", "Payment method", nonEmpty(draft.paymentMethod)),
+          field("utilitiesIncluded", "Utilities included", utilities),
+        ],
+        layout: { avoidBreakInside: true },
+      },
+      {
+        id: "additional-clauses",
+        title: "Additional clauses",
+        fields: [],
+        body: clauses,
+        layout: { avoidBreakInside: true },
+      },
+    ],
+    footer: "This Schedule A addendum supplements Form P and does not replace the base lease form.",
+  };
+}

--- a/rentchain-api/src/services/__tests__/leaseDraftsService.legalComposition.test.ts
+++ b/rentchain-api/src/services/__tests__/leaseDraftsService.legalComposition.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { renderNsScheduleAHtml } from "../leaseDraftsService";
+
+describe("leaseDraftsService legal composition rendering", () => {
+  it("renders Schedule A HTML from shared legal composition without losing addendum order", () => {
+    const html = renderNsScheduleAHtml({
+      draftId: "draft-1",
+      draft: {
+        landlordId: "landlord-1",
+        propertyId: "prop-1",
+        unitId: "unit-1",
+        tenantIds: ["tenant-1"],
+        province: "NS",
+        termType: "fixed",
+        startDate: "2026-03-01",
+        endDate: "2027-02-28",
+        baseRentCents: 185000,
+        parkingCents: 10000,
+        dueDay: 1,
+        paymentMethod: "etransfer",
+        nsfFeeCents: 4500,
+        utilitiesIncluded: ["heat", "water"],
+        depositCents: 92500,
+        additionalClauses: "No smoking in common areas.",
+        status: "draft",
+        templateVersion: "ns-schedule-a-v1",
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      landlordDisplayName: "Demo Landlord",
+      tenantDisplayNames: ["Tenant One"],
+      propertyAddressLine: "123 Main St, Halifax, NS",
+      unitLabel: "Unit 2A",
+    });
+
+    expect(html).toContain("Schedule A addendum");
+    expect(html).toContain("Template version: ns-schedule-a-v1");
+    expect(html.indexOf("Lease Summary")).toBeLessThan(html.indexOf("Term"));
+    expect(html.indexOf("Term")).toBeLessThan(html.indexOf("Payments"));
+    expect(html.indexOf("Payments")).toBeLessThan(html.indexOf("Additional clauses"));
+    expect(html).toContain("No smoking in common areas.");
+    expect(html).toContain("This Schedule A addendum supplements Form P");
+  });
+});

--- a/rentchain-api/src/services/__tests__/leaseNoticeWorkflowService.test.ts
+++ b/rentchain-api/src/services/__tests__/leaseNoticeWorkflowService.test.ts
@@ -46,6 +46,7 @@ vi.mock("../../config/firebase", () => ({
 }));
 
 import {
+  buildPreview,
   deriveLandlordVisibleExpiringLeases,
   deriveLeaseNoticeExecutionInputSnapshot,
   normalizeLeaseRecord,
@@ -125,6 +126,43 @@ describe("leaseNoticeWorkflowService renewal operator inputs", () => {
     ).toEqual({
       ok: false,
       error: "PROPOSED_RENT_NOT_ALLOWED_FOR_RENT_CHANGE_MODE",
+    });
+  });
+
+  it("attaches legal document metadata to notice previews", () => {
+    const lease = normalizeLeaseRecord("lease-1", {
+      landlordId: "landlord-1",
+      tenantId: "tenant-1",
+      propertyId: "prop-1",
+      unitId: "unit-1",
+      leaseType: "fixed_term",
+      province: "NS",
+      currentRent: 1650,
+      leaseEndDate: "2026-05-10",
+      status: "active",
+    });
+
+    const previewResult = buildPreview(lease, {
+      rentChangeMode: "increase",
+      proposedRent: 1750,
+      newTermType: "fixed_term",
+      newLeaseStartDate: "2026-05-11",
+      newLeaseEndDate: "2027-05-10",
+      responseDeadlineAt: Date.UTC(2026, 4, 1, 12, 0, 0, 0),
+    });
+
+    expect(previewResult.ok).toBe(true);
+    if (!previewResult.ok) return;
+    expect(previewResult.preview.summary).toEqual({
+      title: "Lease notice preview",
+      body: "Proposed rent: 1750 CAD",
+    });
+    expect(previewResult.preview.legalDocumentMetadata).toMatchObject({
+      documentKind: "lease_notice",
+      province: "NS",
+      templateKey: "ns.fixed_term.renewal_offer.v1",
+      version: "ns-v1",
+      sensitivity: "restricted",
     });
   });
 

--- a/rentchain-api/src/services/leaseDraftsService.ts
+++ b/rentchain-api/src/services/leaseDraftsService.ts
@@ -1,9 +1,13 @@
 import crypto from "crypto";
 import { db } from "../config/firebase";
+import {
+  composeScheduleALegalDocument,
+  NS_SCHEDULE_A_TEMPLATE_VERSION,
+} from "../lib/legalDocuments/scheduleAComposition";
 import { createSignedUrl, putPdfObject } from "../storage/pdfStore";
 import { generateScheduleAPdfBuffer } from "./leasePdf/scheduleAPdf";
 
-export const NS_TEMPLATE_VERSION = "ns-schedule-a-v1";
+export const NS_TEMPLATE_VERSION = NS_SCHEDULE_A_TEMPLATE_VERSION;
 export const NS_PROVINCE = "NS";
 
 export type LeaseDraftStatus = "draft" | "generated" | "activated";
@@ -206,15 +210,6 @@ export function applyPatch(
   };
 }
 
-function formatMoney(cents: number | null | undefined): string {
-  const value = Number(cents || 0) / 100;
-  return new Intl.NumberFormat("en-CA", {
-    style: "currency",
-    currency: "CAD",
-    minimumFractionDigits: 2,
-  }).format(value);
-}
-
 function escapeHtml(input: string): string {
   return input
     .replace(/&/g, "&amp;")
@@ -232,25 +227,30 @@ export function renderNsScheduleAHtml(input: {
   propertyAddressLine: string;
   unitLabel: string;
 }): string {
-  const { draft } = input;
-  const termLabel =
-    draft.termType === "fixed"
-      ? "Fixed term"
-      : draft.termType === "year-to-year"
-      ? "Year-to-year"
-      : "Month-to-month";
-  const utilities = draft.utilitiesIncluded.length
-    ? draft.utilitiesIncluded.map(escapeHtml).join(", ")
-    : "None listed";
-  const clauses = draft.additionalClauses
-    ? escapeHtml(draft.additionalClauses).replace(/\n/g, "<br />")
-    : "No additional clauses provided.";
+  const documentDefinition = composeScheduleALegalDocument(input);
+  const fieldsBySection = new Map(
+    documentDefinition.sections.map((section) => [section.id, section.fields])
+  );
+  const leaseSummaryFields = fieldsBySection.get("lease-summary") || [];
+  const termFields = fieldsBySection.get("term") || [];
+  const paymentFields = fieldsBySection.get("payments") || [];
+  const clauses = escapeHtml(
+    documentDefinition.sections.find((section) => section.id === "additional-clauses")?.body ||
+      "No additional clauses provided."
+  ).replace(/\n/g, "<br />");
+  const renderGridFields = (fields: Array<{ label: string; value: string }>) =>
+    fields
+      .map(
+        (item) =>
+          `<div><div class="key">${escapeHtml(item.label)}</div><div class="value">${escapeHtml(item.value)}</div></div>`
+      )
+      .join("\n        ");
 
   return `<!doctype html>
 <html lang="en-CA">
   <head>
     <meta charset="utf-8" />
-    <title>Schedule A addendum</title>
+    <title>${escapeHtml(documentDefinition.heading.title)}</title>
     <style>
       @page { size: Letter; margin: 0.6in; }
       body { font-family: Arial, sans-serif; color: #111827; font-size: 12px; line-height: 1.45; }
@@ -265,42 +265,30 @@ export function renderNsScheduleAHtml(input: {
     </style>
   </head>
   <body>
-    <h1>Schedule A addendum</h1>
-    <div class="muted">Province: Nova Scotia (NS) • Template version: ${NS_TEMPLATE_VERSION}</div>
-    <div class="muted">Reference: Nova Scotia Standard Form of Lease (Form P). Review base lease terms.</div>
+    <h1>${escapeHtml(documentDefinition.heading.title)}</h1>
+    <div class="muted">${escapeHtml(documentDefinition.heading.subtitle || "Province: Nova Scotia (NS)")} • Template version: ${escapeHtml(documentDefinition.metadata.version)}</div>
+    <div class="muted">${escapeHtml(documentDefinition.heading.description || "")}</div>
     <div class="card">
       <div class="grid">
-        <div><div class="key">Landlord</div><div class="value">${escapeHtml(input.landlordDisplayName || "Landlord")}</div></div>
-        <div><div class="key">Tenant(s)</div><div class="value">${escapeHtml(input.tenantDisplayNames.join(", ") || "Tenant")}</div></div>
-        <div><div class="key">Property</div><div class="value">${escapeHtml(input.propertyAddressLine || input.draft.propertyId)}</div></div>
-        <div><div class="key">Unit</div><div class="value">${escapeHtml(input.unitLabel || input.draft.unitId)}</div></div>
-        <div><div class="key">Draft ID</div><div class="value">${escapeHtml(input.draftId)}</div></div>
+        ${renderGridFields(leaseSummaryFields)}
         <div><div class="key">Generated</div><div class="value">${new Date().toISOString().slice(0, 10)}</div></div>
       </div>
     </div>
 
     <h2>Term</h2>
     <div class="grid">
-      <div><div class="key">Term type</div><div class="value">${escapeHtml(termLabel)}</div></div>
-      <div><div class="key">Start date</div><div class="value">${escapeHtml(draft.startDate)}</div></div>
-      <div><div class="key">End date</div><div class="value">${escapeHtml(draft.endDate || "Not specified")}</div></div>
-      <div><div class="key">Rent due day</div><div class="value">${draft.dueDay}</div></div>
+      ${renderGridFields(termFields)}
     </div>
 
     <h2>Payments</h2>
     <div class="grid">
-      <div><div class="key">Base rent</div><div class="value">${formatMoney(draft.baseRentCents)}</div></div>
-      <div><div class="key">Parking</div><div class="value">${formatMoney(draft.parkingCents)}</div></div>
-      <div><div class="key">Deposit</div><div class="value">${draft.depositCents != null ? formatMoney(draft.depositCents) : "Not specified"}</div></div>
-      <div><div class="key">NSF fee</div><div class="value">${draft.nsfFeeCents != null ? formatMoney(draft.nsfFeeCents) : "Not specified"}</div></div>
-      <div><div class="key">Payment method</div><div class="value">${escapeHtml(draft.paymentMethod)}</div></div>
-      <div><div class="key">Utilities included</div><div class="value">${utilities}</div></div>
+      ${renderGridFields(paymentFields)}
     </div>
 
     <h2>Additional clauses</h2>
     <div class="card">${clauses}</div>
 
-    <p class="footer">This Schedule A addendum supplements Form P and does not replace the base lease form.</p>
+    <p class="footer">${escapeHtml(documentDefinition.footer || "")}</p>
   </body>
 </html>`;
 }

--- a/rentchain-api/src/services/leaseNoticeWorkflowService.ts
+++ b/rentchain-api/src/services/leaseNoticeWorkflowService.ts
@@ -11,6 +11,7 @@ import {
 import { toAutopilotPolicySummary } from "../lib/policy/policyEvaluator";
 import { loadUnitsForProperty, resolveUnitReference } from "./leaseCanonicalizationService";
 import { isTargetedHiddenLeaseId } from "../lib/testDataVisibilityTargets";
+import { composeLeaseNoticeLegalDocument } from "../lib/legalDocuments/leaseNoticeComposition";
 
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -720,6 +721,26 @@ export function buildPreview(lease: LeaseWorkflowLease, input: LeaseNoticePrevie
       : input.rentChangeMode === "undecided"
       ? null
       : proposedRent;
+  const legalDocument = composeLeaseNoticeLegalDocument({
+    leaseId: lease.id,
+    landlordId: lease.landlordId,
+    tenantId: lease.tenantId,
+    propertyId: lease.propertyId,
+    unitId: lease.unitId,
+    province: lease.province,
+    leaseType: lease.leaseType,
+    noticeType,
+    rule,
+    rentChangeMode: input.rentChangeMode,
+    currency: lease.currency,
+    currentRent: lease.currentRent,
+    proposedRent: effectiveProposedRent,
+    newTermType: input.newTermType,
+    newTermStartDate: newLeaseStartDate,
+    newTermEndDate: newLeaseEndDate,
+    responseDeadlineAt,
+    noticeDueAt,
+  });
   const preview = {
     leaseId: lease.id,
     landlordId: lease.landlordId,
@@ -741,14 +762,10 @@ export function buildPreview(lease: LeaseWorkflowLease, input: LeaseNoticePrevie
     responseRequired: true,
     responseDeadlineAt,
     summary: {
-      title: "Lease notice preview",
-      body:
-        input.rentChangeMode === "undecided"
-          ? "Rent will be decided later by the landlord."
-          : effectiveProposedRent != null
-          ? `Proposed rent: ${effectiveProposedRent} ${lease.currency}`
-          : "No rent change provided.",
+      title: legalDocument.heading.title,
+      body: legalDocument.heading.description,
     },
+    legalDocumentMetadata: legalDocument.metadata,
   };
   return { ok: true as const, rule, preview };
 }

--- a/rentchain-api/src/services/leasePdf/scheduleAPdf.ts
+++ b/rentchain-api/src/services/leasePdf/scheduleAPdf.ts
@@ -1,22 +1,6 @@
 import PDFDocument from "pdfkit";
+import { composeScheduleALegalDocument } from "../../lib/legalDocuments/scheduleAComposition";
 import type { LeaseDraftCore } from "../leaseDraftsService";
-
-const NS_TEMPLATE_VERSION = "ns-schedule-a-v1";
-
-function formatMoney(cents: number | null | undefined): string {
-  const value = Number(cents || 0) / 100;
-  return new Intl.NumberFormat("en-CA", {
-    style: "currency",
-    currency: "CAD",
-    minimumFractionDigits: 2,
-  }).format(value);
-}
-
-function termLabel(termType: LeaseDraftCore["termType"]): string {
-  if (termType === "fixed") return "Fixed term";
-  if (termType === "year-to-year") return "Year-to-year";
-  return "Month-to-month";
-}
 
 function nonEmpty(value: string): string {
   return value.trim() || "Not specified";
@@ -30,7 +14,7 @@ export async function generateScheduleAPdfBuffer(input: {
   propertyAddressLine: string;
   unitLabel: string;
 }): Promise<Buffer> {
-  const { draft } = input;
+  const documentDefinition = composeScheduleALegalDocument(input);
   const doc = new PDFDocument({ size: "LETTER", margin: 54 });
   const chunks: Buffer[] = [];
   doc.on("data", (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
@@ -40,42 +24,46 @@ export async function generateScheduleAPdfBuffer(input: {
   doc.moveDown(0.2);
   doc.font("Helvetica").fontSize(10).fillColor("#4b5563");
   doc.text("Nova Scotia Form P addendum");
-  doc.text(`Template version: ${NS_TEMPLATE_VERSION}`);
+  doc.text(`Template version: ${documentDefinition.metadata.version}`);
   doc.moveDown(0.7);
 
-  doc.font("Helvetica-Bold").fontSize(12).fillColor("#111827");
-  doc.text("Lease Summary");
-  doc.moveDown(0.3);
-
-  doc.font("Helvetica").fontSize(10).fillColor("#111827");
-  doc.text(`Landlord: ${nonEmpty(input.landlordDisplayName || "Landlord")}`);
-  doc.text(`Tenant(s): ${nonEmpty(input.tenantDisplayNames.join(", ") || "Tenant")}`);
-  doc.text(`Property: ${nonEmpty(input.propertyAddressLine || draft.propertyId)}`);
-  doc.text(`Unit: ${nonEmpty(input.unitLabel || draft.unitId)}`);
-  doc.text(`Draft ID: ${nonEmpty(input.draftId)}`);
-  doc.moveDown(0.7);
-
-  doc.font("Helvetica-Bold").fontSize(12).fillColor("#111827");
-  doc.text("Term and Payment Details");
-  doc.moveDown(0.3);
-  doc.font("Helvetica").fontSize(10).fillColor("#111827");
-  doc.text(`Term type: ${termLabel(draft.termType)}`);
-  doc.text(`Start date: ${nonEmpty(draft.startDate)}`);
-  doc.text(`End date: ${nonEmpty(draft.endDate || "")}`);
-  doc.text(`Base rent: ${formatMoney(draft.baseRentCents)}`);
-  doc.text(`Parking: ${formatMoney(draft.parkingCents)}`);
-  doc.text(`Rent due day: ${draft.dueDay}`);
-  doc.text(`Payment method: ${nonEmpty(draft.paymentMethod)}`);
-  doc.text(
-    `Deposit: ${draft.depositCents != null ? formatMoney(draft.depositCents) : "Not specified"}`
+  const leaseSummary = documentDefinition.sections.find((section) => section.id === "lease-summary");
+  const term = documentDefinition.sections.find((section) => section.id === "term");
+  const payments = documentDefinition.sections.find((section) => section.id === "payments");
+  const additionalClauses = documentDefinition.sections.find((section) => section.id === "additional-clauses");
+  const fieldByKey = new Map(
+    [...(term?.fields || []), ...(payments?.fields || [])].map((field) => [field.key, field])
   );
-  doc.moveDown(0.7);
+  const termAndPaymentFields = [
+    fieldByKey.get("termType"),
+    fieldByKey.get("startDate"),
+    fieldByKey.get("endDate"),
+    fieldByKey.get("baseRent"),
+    fieldByKey.get("parking"),
+    fieldByKey.get("rentDueDay"),
+    fieldByKey.get("paymentMethod"),
+    fieldByKey.get("deposit"),
+  ].filter(Boolean) as Array<{ label: string; value: string }>;
+
+  const drawFieldSection = (title: string, fields: Array<{ label: string; value: string }>) => {
+    doc.font("Helvetica-Bold").fontSize(12).fillColor("#111827");
+    doc.text(title);
+    doc.moveDown(0.3);
+    doc.font("Helvetica").fontSize(10).fillColor("#111827");
+    fields.forEach((field) => {
+      doc.text(`${field.label}: ${nonEmpty(field.value)}`);
+    });
+    doc.moveDown(0.7);
+  };
+
+  drawFieldSection("Lease Summary", leaseSummary?.fields || []);
+  drawFieldSection("Term and Payment Details", termAndPaymentFields);
 
   doc.font("Helvetica-Bold").fontSize(12).fillColor("#111827");
   doc.text("Additional Clauses");
   doc.moveDown(0.3);
   doc.font("Helvetica").fontSize(10).fillColor("#111827");
-  const clauseText = draft.additionalClauses?.trim() || "No additional clauses provided.";
+  const clauseText = additionalClauses?.body || "No additional clauses provided.";
   doc.text(clauseText, { width: doc.page.width - doc.page.margins.left - doc.page.margins.right });
 
   doc.moveDown(1.2);

--- a/rentchain-frontend/src/components/leases/LeaseDocumentView.tsx
+++ b/rentchain-frontend/src/components/leases/LeaseDocumentView.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import type { LandlordActiveLease } from "@/api/leasesApi";
+import { composeLeaseSummaryLegalDocument } from "@/lib/legalDocumentComposition";
 
 function formatCurrency(value: number | null | undefined) {
   const amount = typeof value === "number" ? value : 0;
@@ -40,6 +41,12 @@ function Field({ label, value }: { label: string; value: React.ReactNode }) {
 }
 
 export function LeaseDocumentView({ lease }: { lease: LandlordActiveLease }) {
+  const documentDefinition = composeLeaseSummaryLegalDocument(lease, {
+    currency: formatCurrency,
+    date: formatDate,
+    status: prettyLeaseStatus,
+  });
+
   return (
     <article
       data-testid="lease-document-view"
@@ -60,75 +67,26 @@ export function LeaseDocumentView({ lease }: { lease: LandlordActiveLease }) {
     >
       <header style={{ display: "grid", gap: 8, textAlign: "center" }}>
         <div style={{ fontSize: 12, fontWeight: 800, color: "#64748b", textTransform: "uppercase", letterSpacing: 0 }}>
-          RentChain lease record
+          {documentDefinition.eyebrow}
         </div>
-        <h1 style={{ margin: 0, fontSize: 26, letterSpacing: 0, color: "#0f172a" }}>Residential Lease Pack</h1>
+        <h1 style={{ margin: 0, fontSize: 26, letterSpacing: 0, color: "#0f172a" }}>{documentDefinition.title}</h1>
         <div style={{ color: "#475569" }}>
-          Document-style summary generated from the current landlord lease record.
+          {documentDefinition.description}
         </div>
       </header>
 
-      <Section title="Property and Unit">
-        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 14 }}>
-          <Field label="Property" value={lease.propertyName || lease.propertyLabel || lease.propertyAddress || "Property"} />
-          <Field label="Unit" value={lease.unitNumber || "—"} />
-          <Field label="Lease reference" value={lease.id} />
-        </div>
-      </Section>
-
-      <Section title="Landlord and Tenant">
-        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 14 }}>
-          <Field label="Tenant" value={lease.tenantName || "Tenant not linked"} />
-          <Field label="Tenant email" value={lease.tenantEmail || "No email on file"} />
-          <Field label="Landlord record" value="Current RentChain landlord account" />
-        </div>
-      </Section>
-
-      <Section title="Lease Term">
-        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 14 }}>
-          <Field label="Start date" value={formatDate(lease.startDate)} />
-          <Field label="End date" value={formatDate(lease.endDate)} />
-          <Field label="Current status" value={prettyLeaseStatus(lease.status)} />
-        </div>
-      </Section>
-
-      <Section title="Rent and Payment Terms">
-        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 14 }}>
-          <Field label="Monthly rent" value={formatCurrency(lease.monthlyRent)} />
-          <Field label="Payment readiness" value={lease.paymentReadiness?.readinessLabel || "Payment readiness unavailable"} />
-          <Field
-            label="Rent collection"
-            value={lease.rentPaymentSummary?.paymentRail.enabled ? "Enabled" : "Not enabled"}
-          />
-        </div>
-        {lease.paymentReadiness?.readinessDescription ? (
-          <div style={{ color: "#475569", lineHeight: 1.5 }}>{lease.paymentReadiness.readinessDescription}</div>
-        ) : null}
-      </Section>
-
-      <Section title="Clauses and Additional Terms">
-        <div style={{ color: "#475569", lineHeight: 1.6 }}>
-          Full legal clauses remain in the attached lease document when one is available. This fallback view summarizes the
-          landlord-visible lease record so the lease is still reviewable when no separate file is attached.
-        </div>
-      </Section>
-
-      {lease.leaseExecution || lease.leaseLifecycleSummary ? (
-        <Section title="Audit and Events">
-          {lease.leaseExecution ? (
-            <div style={{ display: "grid", gap: 4 }}>
-              <strong>{lease.leaseExecution.executionLabel}</strong>
-              <span style={{ color: "#475569" }}>{lease.leaseExecution.executionDescription}</span>
+      {documentDefinition.sections.map((section) => (
+        <Section key={section.id} title={section.title}>
+          {section.fields.length ? (
+            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 14 }}>
+              {section.fields.map((field) => (
+                <Field key={field.label} label={field.label} value={field.value} />
+              ))}
             </div>
           ) : null}
-          {lease.leaseLifecycleSummary ? (
-            <div style={{ display: "grid", gap: 4 }}>
-              <strong>{lease.leaseLifecycleSummary.lifecycleLabel}</strong>
-              <span style={{ color: "#475569" }}>{lease.leaseLifecycleSummary.lifecycleDescription}</span>
-            </div>
-          ) : null}
+          {section.note ? <div style={{ color: "#475569", lineHeight: 1.6 }}>{section.note}</div> : null}
         </Section>
-      ) : null}
+      ))}
     </article>
   );
 }

--- a/rentchain-frontend/src/lib/legalDocumentComposition.test.ts
+++ b/rentchain-frontend/src/lib/legalDocumentComposition.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { composeLeaseSummaryLegalDocument } from "./legalDocumentComposition";
+
+describe("legalDocumentComposition", () => {
+  it("composes lease summary sections in deterministic legal order", () => {
+    const documentDefinition = composeLeaseSummaryLegalDocument(
+      {
+        id: "lease-1",
+        propertyId: "prop-1",
+        propertyName: "Coburg Rd",
+        unitNumber: "3",
+        tenantName: "Tenant One",
+        tenantEmail: "tenant@example.com",
+        monthlyRent: 2100,
+        startDate: "2026-01-01",
+        endDate: "2026-12-31",
+        status: "notice_pending",
+        paymentReadiness: {
+          readinessLabel: "Rent terms ready",
+          readinessDescription: "Payment terms are ready for review.",
+        },
+        rentPaymentSummary: {
+          paymentRail: { enabled: true },
+        },
+        leaseLifecycleSummary: {
+          lifecycleLabel: "Expiring soon",
+          lifecycleDescription: "Notice timing should be reviewed.",
+        },
+      } as any,
+      {
+        currency: (value) => `$${value}`,
+        date: (value) => String(value || "—"),
+        status: (value) => String(value || "Unknown"),
+      }
+    );
+
+    expect(documentDefinition.metadata).toMatchObject({
+      documentType: "lease_summary",
+      version: "lease-summary-v1",
+      sensitivity: "confidential",
+    });
+    expect(documentDefinition.sections.map((section) => section.id)).toEqual([
+      "property-unit",
+      "parties",
+      "term",
+      "rent-payment",
+      "clauses",
+      "audit-events",
+    ]);
+    expect(documentDefinition.sections[4].note).toMatch(/Full legal clauses remain/);
+    expect(documentDefinition.sections[5].note).toContain("Expiring soon: Notice timing should be reviewed.");
+  });
+});

--- a/rentchain-frontend/src/lib/legalDocumentComposition.ts
+++ b/rentchain-frontend/src/lib/legalDocumentComposition.ts
@@ -1,0 +1,140 @@
+import type { LandlordActiveLease } from "@/api/leasesApi";
+
+export type LegalDocumentMetadata = {
+  documentType: string;
+  title: string;
+  version: string;
+  province?: string | null;
+  sensitivity: "public" | "internal" | "confidential" | "restricted";
+};
+
+export type LegalDocumentField = {
+  label: string;
+  value: string;
+};
+
+export type LegalDocumentSection = {
+  id: string;
+  title: string;
+  fields: LegalDocumentField[];
+  note?: string | null;
+  layout?: {
+    avoidBreakInside?: boolean;
+    signatureSafe?: boolean;
+  };
+};
+
+export type LegalDocumentDefinition = {
+  metadata: LegalDocumentMetadata;
+  eyebrow: string;
+  title: string;
+  description: string;
+  sections: LegalDocumentSection[];
+};
+
+export type LeaseSummaryFormatters = {
+  currency(value: number | null | undefined): string;
+  date(value: string | null | undefined): string;
+  status(value: string | null | undefined): string;
+};
+
+const CLAUSES_NOTE =
+  "Full legal clauses remain in the attached lease document when one is available. This fallback view summarizes the landlord-visible lease record so the lease is still reviewable when no separate file is attached.";
+
+function auditEventsNote(lease: LandlordActiveLease): string | null {
+  const notes = [
+    lease.leaseExecution
+      ? `${lease.leaseExecution.executionLabel}: ${lease.leaseExecution.executionDescription}`
+      : "",
+    lease.leaseLifecycleSummary
+      ? `${lease.leaseLifecycleSummary.lifecycleLabel}: ${lease.leaseLifecycleSummary.lifecycleDescription}`
+      : "",
+  ].filter(Boolean);
+  return notes.length ? notes.join(" ") : null;
+}
+
+export function composeLeaseSummaryLegalDocument(
+  lease: LandlordActiveLease,
+  formatters: LeaseSummaryFormatters
+): LegalDocumentDefinition {
+  const sections: LegalDocumentSection[] = [
+    {
+      id: "property-unit",
+      title: "Property and Unit",
+      fields: [
+        { label: "Property", value: lease.propertyName || lease.propertyLabel || lease.propertyAddress || "Property" },
+        { label: "Unit", value: lease.unitNumber || "—" },
+        { label: "Lease reference", value: lease.id },
+      ],
+      layout: { avoidBreakInside: true },
+    },
+    {
+      id: "parties",
+      title: "Landlord and Tenant",
+      fields: [
+        { label: "Tenant", value: lease.tenantName || "Tenant not linked" },
+        { label: "Tenant email", value: lease.tenantEmail || "No email on file" },
+        { label: "Landlord record", value: "Current RentChain landlord account" },
+      ],
+      layout: { avoidBreakInside: true },
+    },
+    {
+      id: "term",
+      title: "Lease Term",
+      fields: [
+        { label: "Start date", value: formatters.date(lease.startDate) },
+        { label: "End date", value: formatters.date(lease.endDate) },
+        { label: "Current status", value: formatters.status(lease.status) },
+      ],
+      layout: { avoidBreakInside: true },
+    },
+    {
+      id: "rent-payment",
+      title: "Rent and Payment Terms",
+      fields: [
+        { label: "Monthly rent", value: formatters.currency(lease.monthlyRent) },
+        {
+          label: "Payment readiness",
+          value: lease.paymentReadiness?.readinessLabel || "Payment readiness unavailable",
+        },
+        {
+          label: "Rent collection",
+          value: lease.rentPaymentSummary?.paymentRail.enabled ? "Enabled" : "Not enabled",
+        },
+      ],
+      note: lease.paymentReadiness?.readinessDescription || null,
+      layout: { avoidBreakInside: true },
+    },
+    {
+      id: "clauses",
+      title: "Clauses and Additional Terms",
+      fields: [],
+      note: CLAUSES_NOTE,
+      layout: { avoidBreakInside: true },
+    },
+  ];
+
+  const auditNote = auditEventsNote(lease);
+  if (auditNote) {
+    sections.push({
+      id: "audit-events",
+      title: "Audit and Events",
+      fields: [],
+      note: auditNote,
+      layout: { avoidBreakInside: true },
+    });
+  }
+
+  return {
+    metadata: {
+      documentType: "lease_summary",
+      title: "Residential Lease Pack",
+      version: "lease-summary-v1",
+      sensitivity: "confidential",
+    },
+    eyebrow: "RentChain lease record",
+    title: "Residential Lease Pack",
+    description: "Document-style summary generated from the current landlord lease record.",
+    sections,
+  };
+}

--- a/rentchain-frontend/src/utils/leaseSummaryPdf.ts
+++ b/rentchain-frontend/src/utils/leaseSummaryPdf.ts
@@ -1,5 +1,6 @@
 import type { LandlordActiveLease } from "@/api/leasesApi";
 import { shouldStartNewPage, triggerDocumentDownload, wrapTextForPdf } from "@/lib/documentRendering";
+import { composeLeaseSummaryLegalDocument } from "@/lib/legalDocumentComposition";
 import { createPdfExportTimer, recordPdfExportEvent } from "@/lib/pdfExportObservability";
 
 function formatCurrency(value: number | null | undefined) {
@@ -29,63 +30,11 @@ function escapePdfText(value: string) {
 }
 
 export function buildLeaseSummaryPdfSource(lease: LandlordActiveLease) {
-  const sections = [
-    {
-      title: "Property and Unit",
-      rows: [
-        ["Property", lease.propertyName || lease.propertyLabel || lease.propertyAddress || "Property"],
-        ["Unit", lease.unitNumber || "—"],
-        ["Lease reference", lease.id],
-      ],
-    },
-    {
-      title: "Landlord and Tenant",
-      rows: [
-        ["Tenant", lease.tenantName || "Tenant not linked"],
-        ["Tenant email", lease.tenantEmail || "No email on file"],
-        ["Landlord record", "Current RentChain landlord account"],
-      ],
-    },
-    {
-      title: "Lease Term",
-      rows: [
-        ["Start date", formatDate(lease.startDate)],
-        ["End date", formatDate(lease.endDate)],
-        ["Current status", prettyLeaseStatus(lease.status)],
-      ],
-    },
-    {
-      title: "Rent and Payment Terms",
-      rows: [
-        ["Monthly rent", formatCurrency(lease.monthlyRent)],
-        ["Payment readiness", lease.paymentReadiness?.readinessLabel || "Payment readiness unavailable"],
-        ["Rent collection", lease.rentPaymentSummary?.paymentRail.enabled ? "Enabled" : "Not enabled"],
-      ],
-      note: lease.paymentReadiness?.readinessDescription || null,
-    },
-    {
-      title: "Clauses and Additional Terms",
-      rows: [],
-      note:
-        "Full legal clauses remain in the attached lease document when one is available. This fallback view summarizes the landlord-visible lease record so the lease is still reviewable when no separate file is attached.",
-    },
-  ];
-  if (lease.leaseExecution || lease.leaseLifecycleSummary) {
-    sections.push({
-      title: "Audit and Events",
-      rows: [],
-      note: [
-        lease.leaseExecution
-          ? `${lease.leaseExecution.executionLabel}: ${lease.leaseExecution.executionDescription}`
-          : "",
-        lease.leaseLifecycleSummary
-          ? `${lease.leaseLifecycleSummary.lifecycleLabel}: ${lease.leaseLifecycleSummary.lifecycleDescription}`
-          : "",
-      ]
-        .filter(Boolean)
-        .join(" "),
-    });
-  }
+  const documentDefinition = composeLeaseSummaryLegalDocument(lease, {
+    currency: formatCurrency,
+    date: formatDate,
+    status: prettyLeaseStatus,
+  });
 
   const page = { width: 612, height: 792 };
   const docX = 54;
@@ -124,24 +73,24 @@ export function buildLeaseSummaryPdfSource(lease: LandlordActiveLease) {
 
   addPage();
   drawPageFrame();
-  textAt("RentChain lease record", 236, y, 10, "F2");
+  textAt(documentDefinition.eyebrow, 236, y, 10, "F2");
   y -= 24;
-  textAt("Residential Lease Pack", 193, y, 20, "F2");
+  textAt(documentDefinition.title, 193, y, 20, "F2");
   y -= 18;
-  textAt("Document-style summary generated from the current landlord lease record.", 128, y, 10);
+  textAt(documentDefinition.description, 128, y, 10);
   y -= 30;
 
-  sections.forEach((section) => {
+  documentDefinition.sections.forEach((section) => {
     ensureSpace(48);
     line(84, y + 14, 528, y + 14);
     textAt(section.title, 84, y, 13, "F2");
     y -= 22;
 
-    section.rows.forEach(([label, value]) => {
+    section.fields.forEach((field) => {
       ensureSpace(34);
       rect(84, y - 8, 444, 24, true);
-      textAt(label.toUpperCase(), 96, y, 8, "F2");
-      textAt(String(value), 252, y, 10);
+      textAt(field.label.toUpperCase(), 96, y, 8, "F2");
+      textAt(field.value, 252, y, 10);
       y -= 28;
     });
 


### PR DESCRIPTION
## Legal-document audit summary
- Document composition map: frontend lease summary composition was duplicated between `LeaseDocumentView` and `leaseSummaryPdf`; backend Schedule A composition was split between HTML and PDFKit renderers; lease notices carried province/rule metadata inline in `leaseNoticeWorkflowService`; province lease packs remain static catalog metadata.
- Legal rendering flow map: lease summary preview/download stays frontend-rendered; Schedule A still uses existing HTML-to-PDF/PDFKit fallback; lease notices still use existing landlord policy and tenant email workflow.
- Province-aware logic map: NS Schedule A and NS notice rules are now represented through legal document metadata; static frontend lease pack catalog remains unchanged.
- Drift risks: duplicated section order, labels, and addendum body handling could diverge between preview/PDF/fallback renderers.
- Governance/privacy concerns: legal document metadata now inherits export governance metadata on backend composition definitions; no raw document payload logging introduced.

## Composition architecture findings
- Added narrow legal composition primitives only: metadata, sections, fields, body/footer, and render-safe layout hints.
- Avoided WYSIWYG/template editing/CMS behavior and avoided replacing PDF/rendering systems.
- Kept adoption to duplicated, high-risk paths: lease summary preview/PDF, Schedule A HTML/PDFKit, and metadata-only lease notice preview composition.

## Files changed
- `rentchain-api/src/lib/legalDocuments/*`
- `rentchain-api/src/services/leaseDraftsService.ts`
- `rentchain-api/src/services/leasePdf/scheduleAPdf.ts`
- `rentchain-api/src/services/leaseNoticeWorkflowService.ts`
- `rentchain-frontend/src/lib/legalDocumentComposition.ts`
- `rentchain-frontend/src/components/leases/LeaseDocumentView.tsx`
- `rentchain-frontend/src/utils/leaseSummaryPdf.ts`
- Focused backend/frontend tests for composition, notice metadata, Schedule A ordering, and lease summary rendering/pagination.

## Composition primitives introduced
- Backend: `LegalDocumentDefinition`, `LegalDocumentSection`, `LegalDocumentField`, `LegalDocumentMetadata`, `legalExportMetadata`.
- Backend document composers: `composeScheduleALegalDocument`, `composeLeaseNoticeLegalDocument`.
- Frontend: lease summary legal document definition and `composeLeaseSummaryLegalDocument`.

## Adoption locations
- Lease summary React preview and frontend PDF builder now consume the same lease summary section definition.
- Schedule A HTML and PDFKit fallback now consume the same Schedule A composition definition while preserving existing renderer paths.
- Lease notice preview now attaches deterministic legal document metadata while preserving existing preview/send APIs.

## Governance/privacy alignment notes
- Backend legal document metadata inherits the existing governance/export metadata layer.
- Schedule A and lease notice definitions are classified as restricted/export metadata.
- No sensitive payload logging or new public access paths were added.

## Verification
- Backend targeted: `npm run test -- legalDocument leaseNoticeWorkflowService leaseDraftsService.legalComposition` passed.
- Backend route target outside sandbox: `npm run test -- legalDocument leaseNoticeWorkflowService leaseDraftsService.legalComposition leaseDraftRoutes` passed.
- Frontend targeted: `npm run test -- legalDocumentComposition LandlordLeaseSummaryPage documentRendering printPdfGuardrails` passed.
- Backend full `npm run test` passed outside sandbox: 334 files, 1,441 tests.
- Frontend full `npm run test` passed: 254 files, 936 tests.
- Backend `npm run build` passed.
- Frontend `npm run build` passed.
- `git diff --check` passed.

## Manual QA notes
- Lease summary preview and save-PDF behavior preserved by existing page tests and PDF source assertions.
- Schedule A generation route tests passed with inline and stored file paths.
- Existing lease notice preview/send workflow tests passed; notice composition metadata is additive.
- No PDF stack replacement, legal formatting redesign, export API change, or frontend visual overhaul.

## Remaining risks
- Signature blocks are modeled as layout-capable metadata but not adopted because current audited paths do not render legal signature blocks.
- Lease ledger PDF remains ledger-specific and was not migrated.
- Future tribunal/package exports still need their own adoption into this composition layer.