### PR TITLE
Document accessibility audit and hardening v1

### DIFF
--- a/rentchain-frontend/src/components/applications/PrintApplicationView.tsx
+++ b/rentchain-frontend/src/components/applications/PrintApplicationView.tsx
@@ -61,7 +61,7 @@ export const PrintApplicationView: React.FC<PrintApplicationViewProps> = ({
   const propertyAddress = getPropertyAddress(application);
 
   return (
-    <div className="print-application-view">
+    <article className="print-application-view" aria-label="Application summary print view">
       <style>
         {`
         @media print {
@@ -105,16 +105,18 @@ export const PrintApplicationView: React.FC<PrintApplicationViewProps> = ({
             text-transform: uppercase;
             letter-spacing: 0.06em;
             color: #111;
-            margin-bottom: 4px;
+            margin: 0 0 4px;
           }
           .print-value {
             font-size: 14px;
             color: #000;
             line-height: 1.35;
+            overflow-wrap: anywhere;
           }
           .print-muted {
             color: #111;
             font-size: 12px;
+            overflow-wrap: anywhere;
           }
           .no-print {
             display: none !important;
@@ -126,12 +128,12 @@ export const PrintApplicationView: React.FC<PrintApplicationViewProps> = ({
       `}
       </style>
 
-      <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 12 }}>
+      <header style={{ display: "flex", justifyContent: "space-between", marginBottom: 12 }}>
         <div>
           <div style={{ fontSize: 12, letterSpacing: 0.08, textTransform: "uppercase", marginBottom: 4 }}>
             Application summary
           </div>
-          <div style={{ fontSize: 20, fontWeight: 700 }}>{applicantName}</div>
+          <h1 style={{ margin: 0, fontSize: 20, fontWeight: 700 }}>{applicantName}</h1>
           <div style={{ fontSize: 14, marginTop: 4 }}>
             {application.propertyName}
             {propertyAddress ? ` · ${propertyAddress}` : ""}
@@ -146,18 +148,18 @@ export const PrintApplicationView: React.FC<PrintApplicationViewProps> = ({
           <div>Approved: {formatDate(application.approvedAt, true)}</div>
           <div>Status: {application.status}</div>
         </div>
-      </div>
+      </header>
 
       <div className="print-grid" style={{ marginBottom: 12 }}>
-        <div className="print-card">
-          <div className="print-label">Contact</div>
+        <section className="print-card" aria-labelledby="print-application-contact-heading">
+          <h2 id="print-application-contact-heading" className="print-label">Contact</h2>
           <div className="print-value">{applicantName}</div>
           <div className="print-muted">{commaOrDash(application.email)}</div>
           <div className="print-muted">{commaOrDash(application.phone || application.applicantPhone)}</div>
-        </div>
+        </section>
 
-        <div className="print-card">
-          <div className="print-label">Applicant details</div>
+        <section className="print-card" aria-labelledby="print-application-details-heading">
+          <h2 id="print-application-details-heading" className="print-label">Applicant details</h2>
           <div className="print-value">DOB: {formatDate(application.dateOfBirth)}</div>
           <div className="print-value" style={{ marginTop: 4 }}>
             Recent address: {formatRecentAddress(application)}
@@ -165,11 +167,11 @@ export const PrintApplicationView: React.FC<PrintApplicationViewProps> = ({
           <div className="print-value" style={{ marginTop: 4 }}>
             Monthly income: {formatMoney(application.monthlyIncome)}
           </div>
-        </div>
+        </section>
       </div>
 
-      <div className="print-card" style={{ marginBottom: 12 }}>
-        <div className="print-label">References</div>
+      <section className="print-card" aria-labelledby="print-application-references-heading" style={{ marginBottom: 12 }}>
+        <h2 id="print-application-references-heading" className="print-label">References</h2>
         <div className="print-value">
           Contacted: {application.referencesContacted ? "Yes" : "No"}
           {application.referencesContactedAt
@@ -179,30 +181,30 @@ export const PrintApplicationView: React.FC<PrintApplicationViewProps> = ({
         <div className="print-muted" style={{ marginTop: 4 }}>
           Notes: {application.referencesNotes ? application.referencesNotes : "—"}
         </div>
-      </div>
+      </section>
 
       <div className="print-grid" style={{ marginBottom: 12 }}>
-        <div className="print-card">
-          <div className="print-label">Flags</div>
+        <section className="print-card" aria-labelledby="print-application-flags-heading">
+          <h2 id="print-application-flags-heading" className="print-label">Flags</h2>
           <div className="print-value">
             {application.flags && application.flags.length > 0
               ? application.flags.join(", ")
               : "None recorded"}
           </div>
-        </div>
-        <div className="print-card">
-          <div className="print-label">Notes</div>
+        </section>
+        <section className="print-card" aria-labelledby="print-application-notes-heading">
+          <h2 id="print-application-notes-heading" className="print-label">Notes</h2>
           <div className="print-value">
             {application.notes && application.notes.trim()
               ? application.notes
               : "No notes on file."}
           </div>
-        </div>
+        </section>
       </div>
 
       {application.applicants && application.applicants.length > 0 && (
-        <div className="print-card">
-          <div className="print-label">Applicants</div>
+        <section className="print-card" aria-labelledby="print-application-applicants-heading">
+          <h2 id="print-application-applicants-heading" className="print-label">Applicants</h2>
           {application.applicants.map((appl) => (
             <div key={appl.id} style={{ marginBottom: 8 }}>
               <div className="print-value">
@@ -229,8 +231,8 @@ export const PrintApplicationView: React.FC<PrintApplicationViewProps> = ({
               )}
             </div>
           ))}
-        </div>
+        </section>
       )}
-    </div>
+    </article>
   );
 };

--- a/rentchain-frontend/src/components/billing/SamplePdfModal.test.tsx
+++ b/rentchain-frontend/src/components/billing/SamplePdfModal.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { SamplePdfModal } from "./SamplePdfModal";
 
@@ -40,6 +40,7 @@ describe("SamplePdfModal", () => {
     mockViewport({ width: 1280, coarsePointer: false });
     render(<SamplePdfModal open onClose={vi.fn()} />);
 
+    expect(screen.getByRole("dialog", { name: "Sample screening report" })).toBeInTheDocument();
     expect(await screen.findByTitle("Sample screening report PDF")).toBeInTheDocument();
     expect(screen.queryByText("Open the sample PDF")).not.toBeInTheDocument();
   });
@@ -60,10 +61,34 @@ describe("SamplePdfModal", () => {
       )
     );
     expect(screen.queryByTitle("Sample screening report PDF")).not.toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Open PDF" })).toHaveAttribute(
+    expect(screen.getByRole("link", { name: "Sample screening report PDF: open PDF in a new tab" })).toHaveAttribute(
       "href",
       "/sample/screening_report_sample.pdf?v=1"
     );
-    expect(screen.getByRole("link", { name: "Download PDF" })).toHaveAttribute("download");
+    expect(screen.getByRole("link", { name: "Sample screening report PDF: download PDF" })).toHaveAttribute("download");
+  });
+
+  it("restores focus when the modal closes", () => {
+    mockViewport({ width: 1280, coarsePointer: false });
+    const onClose = vi.fn();
+    const { rerender } = render(
+      <>
+        <button type="button">Open report</button>
+        <SamplePdfModal open={false} onClose={onClose} />
+      </>
+    );
+    const trigger = screen.getByRole("button", { name: "Open report" });
+    trigger.focus();
+    rerender(
+      <>
+        <button type="button">Open report</button>
+        <SamplePdfModal open onClose={onClose} />
+      </>
+    );
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(onClose).toHaveBeenCalled();
+    expect(trigger).toHaveFocus();
   });
 });

--- a/rentchain-frontend/src/components/billing/SamplePdfModal.tsx
+++ b/rentchain-frontend/src/components/billing/SamplePdfModal.tsx
@@ -9,20 +9,28 @@ type Props = {
 
 export function SamplePdfModal({ open, onClose }: Props) {
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+  const titleId = React.useId();
+  const descriptionId = React.useId();
   const [loadError, setLoadError] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
   const pdfUrl = "/sample/screening_report_sample.pdf?v=1";
+
+  const closeModal = React.useCallback(() => {
+    onClose();
+    previouslyFocusedRef.current?.focus();
+  }, [onClose]);
 
   useEffect(() => {
     if (!open) return;
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
-        onClose();
+        closeModal();
       }
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [open, onClose]);
+  }, [closeModal, open]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -45,6 +53,8 @@ export function SamplePdfModal({ open, onClose }: Props) {
 
   useEffect(() => {
     if (!open) return;
+    previouslyFocusedRef.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
     setLoadError(false);
     const node = containerRef.current;
     if (!node) return;
@@ -81,7 +91,7 @@ export function SamplePdfModal({ open, onClose }: Props) {
     <div
       role="presentation"
       onMouseDown={(event) => {
-        if (event.target === event.currentTarget) onClose();
+        if (event.target === event.currentTarget) closeModal();
       }}
       style={{
         position: "fixed",
@@ -98,7 +108,8 @@ export function SamplePdfModal({ open, onClose }: Props) {
         ref={containerRef}
         role="dialog"
         aria-modal="true"
-        aria-label="Sample screening report"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
         style={{
           width: "min(1024px, 95vw)",
           minHeight: isMobile ? "auto" : 520,
@@ -123,10 +134,11 @@ export function SamplePdfModal({ open, onClose }: Props) {
             borderBottom: "1px solid #e2e8f0",
           }}
         >
-          <div style={{ fontWeight: 700 }}>Sample screening report</div>
+          <h2 id={titleId} style={{ margin: 0, fontSize: 16, fontWeight: 700 }}>Sample screening report</h2>
           <div style={{ display: "flex", gap: 8 }}>
             <button
               type="button"
+              aria-label="View sample screening report full page"
               onClick={() => {
                 recordPdfExportEvent("pdf_download_triggered", {
                   exportType: "sample_screening_report",
@@ -154,6 +166,7 @@ export function SamplePdfModal({ open, onClose }: Props) {
               href={pdfUrl}
               target="_blank"
               rel="noreferrer"
+              aria-label="Open sample screening report in a new tab"
               onClick={() =>
                 recordPdfExportEvent("pdf_download_triggered", {
                   exportType: "sample_screening_report",
@@ -175,7 +188,8 @@ export function SamplePdfModal({ open, onClose }: Props) {
             </a>
             <button
               type="button"
-              onClick={onClose}
+              aria-label="Close sample screening report preview"
+              onClick={closeModal}
               style={{
                 border: "1px solid #e2e8f0",
                 background: "#fff",
@@ -189,12 +203,15 @@ export function SamplePdfModal({ open, onClose }: Props) {
             </button>
           </div>
         </div>
+        <div id={descriptionId} style={{ position: "absolute", width: 1, height: 1, overflow: "hidden", clip: "rect(0 0 0 0)" }}>
+          PDF preview controls for the sample screening report.
+        </div>
         <div style={{ flex: 1, position: "relative", background: "#f8fafc", overflow: "visible" }}>
           {loadError ? (
-            <div style={{ padding: 16, fontSize: 14, color: "#b91c1c" }}>
+            <div role="alert" style={{ padding: 16, fontSize: 14, color: "#b91c1c" }}>
               Unable to load the sample report.
               <div style={{ marginTop: 8 }}>
-                <a href={pdfUrl} target="_blank" rel="noreferrer">
+                <a href={pdfUrl} target="_blank" rel="noreferrer" aria-label="Open sample screening report in a new tab">
                   Open in new tab
                 </a>
               </div>

--- a/rentchain-frontend/src/components/documentRendering/PdfPreviewBoundary.test.tsx
+++ b/rentchain-frontend/src/components/documentRendering/PdfPreviewBoundary.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { PdfPreviewBoundary } from "./PdfPreviewBoundary";
+
+const mocks = vi.hoisted(() => ({
+  recordPdfExportEvent: vi.fn(),
+  useMobilePdfPreviewGuard: vi.fn(),
+}));
+
+vi.mock("@/lib/pdfExportObservability", () => ({
+  recordPdfExportEvent: mocks.recordPdfExportEvent,
+}));
+
+vi.mock("@/utils/pdfPreviewGuard", () => ({
+  useMobilePdfPreviewGuard: mocks.useMobilePdfPreviewGuard,
+}));
+
+describe("PdfPreviewBoundary accessibility", () => {
+  it("labels the desktop iframe preview", () => {
+    mocks.useMobilePdfPreviewGuard.mockReturnValue(false);
+
+    render(
+      <PdfPreviewBoundary
+        pdfUrl="/sample.pdf"
+        exportType="sample_screening_report"
+        title="Open the sample PDF"
+        iframeTitle="Sample screening report PDF"
+      />
+    );
+
+    expect(screen.getByTitle("Sample screening report PDF")).toHaveAttribute(
+      "aria-label",
+      "Sample screening report PDF"
+    );
+  });
+
+  it("labels mobile fallback controls with document context", () => {
+    mocks.useMobilePdfPreviewGuard.mockReturnValue(true);
+
+    render(
+      <PdfPreviewBoundary
+        pdfUrl="/sample.pdf"
+        exportType="sample_screening_report"
+        title="Open the sample PDF"
+        iframeTitle="Sample screening report PDF"
+      />
+    );
+
+    expect(screen.getByRole("region", { name: "Open the sample PDF" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Sample screening report PDF: open PDF in a new tab" })).toHaveAttribute(
+      "href",
+      "/sample.pdf"
+    );
+    expect(screen.getByRole("link", { name: "Sample screening report PDF: download PDF" })).toHaveAttribute(
+      "download"
+    );
+  });
+});

--- a/rentchain-frontend/src/components/documentRendering/PdfPreviewBoundary.tsx
+++ b/rentchain-frontend/src/components/documentRendering/PdfPreviewBoundary.tsx
@@ -33,6 +33,9 @@ export function PdfPreviewBoundary({
   onDesktopError,
 }: PdfPreviewBoundaryProps) {
   const useMobileFallback = useMobilePdfPreviewGuard();
+  const fallbackTitleId = React.useId();
+  const fallbackDescriptionId = React.useId();
+  const previewLabel = iframeTitle || title;
 
   React.useEffect(() => {
     if (!active || !useMobileFallback) return;
@@ -46,14 +49,20 @@ export function PdfPreviewBoundary({
 
   if (useMobileFallback) {
     return (
-      <div style={fallbackStyle}>
-        <div style={{ fontWeight: 700 }}>{title}</div>
-        <div style={{ color: "#475569" }}>{fallbackDescription}</div>
+      <div
+        role="region"
+        aria-labelledby={fallbackTitleId}
+        aria-describedby={fallbackDescriptionId}
+        style={fallbackStyle}
+      >
+        <div id={fallbackTitleId} style={{ fontWeight: 700 }}>{title}</div>
+        <div id={fallbackDescriptionId} style={{ color: "#475569" }}>{fallbackDescription}</div>
         <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
           <a
             href={pdfUrl}
             target="_blank"
             rel="noreferrer"
+            aria-label={`${previewLabel}: open PDF in a new tab`}
             onClick={() =>
               recordPdfExportEvent("pdf_download_triggered", {
                 exportType,
@@ -68,6 +77,7 @@ export function PdfPreviewBoundary({
           <a
             href={pdfUrl}
             download
+            aria-label={`${previewLabel}: download PDF`}
             onClick={() =>
               recordPdfExportEvent("pdf_download_triggered", {
                 exportType,
@@ -86,7 +96,8 @@ export function PdfPreviewBoundary({
 
   return (
     <iframe
-      title={iframeTitle || title}
+      title={previewLabel}
+      aria-label={previewLabel}
       src={`${pdfUrl}#view=FitH`}
       className={iframeClassName}
       style={iframeStyle}

--- a/rentchain-frontend/src/components/leases/LeaseDocumentView.tsx
+++ b/rentchain-frontend/src/components/leases/LeaseDocumentView.tsx
@@ -20,10 +20,11 @@ function prettyLeaseStatus(value: string | null | undefined) {
   return normalized.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
-function Section({ title, children }: React.PropsWithChildren<{ title: string }>) {
+function Section({ id, title, children }: React.PropsWithChildren<{ id: string; title: string }>) {
+  const titleId = `${id}-heading`;
   return (
-    <section style={{ display: "grid", gap: 10, paddingTop: 18, borderTop: "1px solid #e2e8f0" }}>
-      <h2 style={{ margin: 0, fontSize: 16, letterSpacing: 0, color: "#0f172a" }}>{title}</h2>
+    <section aria-labelledby={titleId} style={{ display: "grid", gap: 10, paddingTop: 18, borderTop: "1px solid #e2e8f0" }}>
+      <h2 id={titleId} style={{ margin: 0, fontSize: 16, letterSpacing: 0, color: "#0f172a" }}>{title}</h2>
       <div style={{ display: "grid", gap: 8 }}>{children}</div>
     </section>
   );
@@ -32,10 +33,10 @@ function Section({ title, children }: React.PropsWithChildren<{ title: string }>
 function Field({ label, value }: { label: string; value: React.ReactNode }) {
   return (
     <div style={{ display: "grid", gap: 3 }}>
-      <div style={{ fontSize: 12, fontWeight: 700, color: "#64748b", textTransform: "uppercase", letterSpacing: 0 }}>
+      <dt aria-label={label} style={{ fontSize: 12, fontWeight: 700, color: "#64748b", textTransform: "uppercase", letterSpacing: 0 }}>
         {label}
-      </div>
-      <div style={{ color: "#0f172a" }}>{value}</div>
+      </dt>
+      <dd style={{ margin: 0, color: "#0f172a" }}>{value}</dd>
     </div>
   );
 }
@@ -46,10 +47,14 @@ export function LeaseDocumentView({ lease }: { lease: LandlordActiveLease }) {
     date: formatDate,
     status: prettyLeaseStatus,
   });
+  const titleId = React.useId();
+  const descriptionId = React.useId();
 
   return (
     <article
       data-testid="lease-document-view"
+      aria-labelledby={titleId}
+      aria-describedby={descriptionId}
       style={{
         boxSizing: "border-box",
         width: "100%",
@@ -69,20 +74,20 @@ export function LeaseDocumentView({ lease }: { lease: LandlordActiveLease }) {
         <div style={{ fontSize: 12, fontWeight: 800, color: "#64748b", textTransform: "uppercase", letterSpacing: 0 }}>
           {documentDefinition.eyebrow}
         </div>
-        <h1 style={{ margin: 0, fontSize: 26, letterSpacing: 0, color: "#0f172a" }}>{documentDefinition.title}</h1>
-        <div style={{ color: "#475569" }}>
+        <h1 id={titleId} style={{ margin: 0, fontSize: 26, letterSpacing: 0, color: "#0f172a" }}>{documentDefinition.title}</h1>
+        <div id={descriptionId} style={{ color: "#475569" }}>
           {documentDefinition.description}
         </div>
       </header>
 
       {documentDefinition.sections.map((section) => (
-        <Section key={section.id} title={section.title}>
+        <Section key={section.id} id={`lease-section-${section.id}`} title={section.title}>
           {section.fields.length ? (
-            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 14 }}>
+            <dl style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 14, margin: 0 }}>
               {section.fields.map((field) => (
                 <Field key={field.label} label={field.label} value={field.value} />
               ))}
-            </div>
+            </dl>
           ) : null}
           {section.note ? <div style={{ color: "#475569", lineHeight: 1.6 }}>{section.note}</div> : null}
         </Section>

--- a/rentchain-frontend/src/components/leases/LeasePackGeneratorModal.test.tsx
+++ b/rentchain-frontend/src/components/leases/LeasePackGeneratorModal.test.tsx
@@ -1,0 +1,58 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LeasePackGeneratorModal } from "./LeasePackGeneratorModal";
+
+vi.mock("@/api/onboardingApi", () => ({
+  setOnboardingStep: vi.fn(),
+}));
+
+describe("LeasePackGeneratorModal accessibility", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders as a labelled dialog with a labelled property selector", () => {
+    render(
+      <LeasePackGeneratorModal
+        open
+        onClose={vi.fn()}
+        initialPropertyId="property-1"
+        properties={[{ id: "property-1", name: "Coburg Rd", province: "NS" } as any]}
+      />
+    );
+
+    expect(screen.getByRole("dialog", { name: "Generate Lease Pack" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Property")).toHaveValue("property-1");
+    expect(screen.getByRole("link", { name: /Download .* bundle/i })).toHaveAttribute("download");
+  });
+
+  it("closes with Escape and restores focus", () => {
+    const onClose = vi.fn();
+    const { rerender } = render(
+      <>
+        <button type="button">Generate</button>
+        <LeasePackGeneratorModal open={false} onClose={onClose} properties={[]} />
+      </>
+    );
+    const trigger = screen.getByRole("button", { name: "Generate" });
+    trigger.focus();
+
+    rerender(
+      <>
+        <button type="button">Generate</button>
+        <LeasePackGeneratorModal
+          open
+          onClose={onClose}
+          initialPropertyId="property-1"
+          properties={[{ id: "property-1", name: "Coburg Rd", province: "NS" } as any]}
+        />
+      </>
+    );
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(onClose).toHaveBeenCalled();
+    expect(trigger).toHaveFocus();
+  });
+});

--- a/rentchain-frontend/src/components/leases/LeasePackGeneratorModal.tsx
+++ b/rentchain-frontend/src/components/leases/LeasePackGeneratorModal.tsx
@@ -24,6 +24,11 @@ export const LeasePackGeneratorModal: React.FC<Props> = ({
   properties,
   initialPropertyId,
 }) => {
+  const containerRef = React.useRef<HTMLDivElement | null>(null);
+  const previouslyFocusedRef = React.useRef<HTMLElement | null>(null);
+  const titleId = React.useId();
+  const descriptionId = React.useId();
+  const propertySelectId = React.useId();
   const [selectedPropertyId, setSelectedPropertyId] = useState<string>(initialPropertyId || "");
   const [copyMessage, setCopyMessage] = useState<string>("");
 
@@ -35,6 +40,11 @@ export const LeasePackGeneratorModal: React.FC<Props> = ({
   const provinceCode = normalizeProvinceCode(selectedProperty?.province || "UNSET");
   const pack = getLeasePackForProvince(provinceCode);
 
+  const closeModal = React.useCallback(() => {
+    onClose();
+    previouslyFocusedRef.current?.focus();
+  }, [onClose]);
+
   React.useEffect(() => {
     if (!open) return;
     if (initialPropertyId) {
@@ -45,6 +55,28 @@ export const LeasePackGeneratorModal: React.FC<Props> = ({
       setSelectedPropertyId(String(properties[0].id));
     }
   }, [initialPropertyId, open, properties]);
+
+  React.useEffect(() => {
+    if (!open) return;
+    previouslyFocusedRef.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    const node = containerRef.current;
+    const focusable = node?.querySelector<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    focusable?.focus();
+  }, [open]);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        closeModal();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [closeModal, open]);
 
   if (!open) return null;
 
@@ -68,6 +100,27 @@ export const LeasePackGeneratorModal: React.FC<Props> = ({
     }
   };
 
+  const trapFocus = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== "Tab") return;
+    const node = containerRef.current;
+    if (!node) return;
+    const focusable = Array.from(
+      node.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      )
+    ).filter((el) => !el.hasAttribute("disabled"));
+    if (!focusable.length) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
   return (
     <div
       style={{
@@ -82,6 +135,13 @@ export const LeasePackGeneratorModal: React.FC<Props> = ({
       }}
     >
       <div
+        ref={containerRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        tabIndex={-1}
+        onKeyDown={trapFocus}
         style={{
           width: "min(820px, 96vw)",
           maxHeight: "90dvh",
@@ -97,14 +157,15 @@ export const LeasePackGeneratorModal: React.FC<Props> = ({
       >
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: spacing.sm }}>
           <div>
-            <div style={{ fontWeight: 800, fontSize: "1.1rem" }}>Generate Lease Pack</div>
-            <div style={{ color: text.muted, fontSize: "0.92rem", marginTop: 4 }}>
+            <h2 id={titleId} style={{ margin: 0, fontWeight: 800, fontSize: "1.1rem" }}>Generate Lease Pack</h2>
+            <div id={descriptionId} style={{ color: text.muted, fontSize: "0.92rem", marginTop: 4 }}>
               Choose a property to view province pack contents and download documents.
             </div>
           </div>
           <button
             type="button"
-            onClick={onClose}
+            aria-label="Close lease pack generator"
+            onClick={closeModal}
             style={{
               border: `1px solid ${colors.border}`,
               borderRadius: radius.pill,
@@ -118,8 +179,9 @@ export const LeasePackGeneratorModal: React.FC<Props> = ({
         </div>
 
         <div style={{ display: "grid", gap: 8 }}>
-          <label style={{ fontWeight: 700, fontSize: "0.9rem" }}>Property</label>
+          <label htmlFor={propertySelectId} style={{ fontWeight: 700, fontSize: "0.9rem" }}>Property</label>
           <select
+            id={propertySelectId}
             value={selectedPropertyId}
             onChange={(event) => setSelectedPropertyId(event.target.value)}
             style={{
@@ -182,6 +244,7 @@ export const LeasePackGeneratorModal: React.FC<Props> = ({
                 <a
                   href={pack.bundleUrl}
                   download
+                  aria-label={`Download ${pack.title} bundle`}
                   onClick={() => void handleDownload()}
                   style={{
                     borderRadius: radius.pill,
@@ -234,6 +297,7 @@ export const LeasePackGeneratorModal: React.FC<Props> = ({
                       <a
                         href={doc.url}
                         download
+                        aria-label={`Download ${doc.name}`}
                         onClick={() => void handleDownload()}
                         style={{
                           textDecoration: "none",
@@ -278,4 +342,3 @@ export const LeasePackGeneratorModal: React.FC<Props> = ({
     </div>
   );
 };
-

--- a/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.test.tsx
+++ b/rentchain-frontend/src/pages/LandlordLeaseSummaryPage.test.tsx
@@ -78,6 +78,8 @@ describe("LandlordLeaseSummaryPage", () => {
 
     expect(await screen.findByText("Lease summary")).toBeInTheDocument();
     expect(screen.getByTestId("lease-document-view")).toBeInTheDocument();
+    expect(screen.getByRole("article", { name: "Residential Lease Pack" })).toBeInTheDocument();
+    expect(screen.getByRole("term", { name: "Property" })).toBeInTheDocument();
     expect(screen.getByText("Residential Lease Pack")).toBeInTheDocument();
     expect(screen.getByText("Property and Unit")).toBeInTheDocument();
     expect(screen.getByText("Landlord and Tenant")).toBeInTheDocument();

--- a/rentchain-frontend/src/pages/PdfSamplePage.test.tsx
+++ b/rentchain-frontend/src/pages/PdfSamplePage.test.tsx
@@ -45,6 +45,9 @@ describe("PdfSamplePage", () => {
       </MemoryRouter>
     );
 
+    expect(screen.getByRole("heading", { name: "Sample screening report" })).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: "Sample screening report PDF actions" })).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: "Sample screening report PDF preview" })).toBeInTheDocument();
     expect(await screen.findByTitle("Sample screening report")).toBeInTheDocument();
     expect(screen.queryByText("Open the sample PDF")).not.toBeInTheDocument();
   });
@@ -69,10 +72,10 @@ describe("PdfSamplePage", () => {
       )
     );
     expect(screen.queryByTitle("Sample screening report")).not.toBeInTheDocument();
-    expect(screen.getAllByRole("link", { name: "Open PDF" })[0]).toHaveAttribute(
+    expect(screen.getAllByRole("link", { name: "Sample screening report: open PDF in a new tab" })[0]).toHaveAttribute(
       "href",
       "/sample/screening_report_sample.pdf?v=1"
     );
-    expect(screen.getAllByRole("link", { name: "Download PDF" })[0]).toHaveAttribute("download");
+    expect(screen.getAllByRole("link", { name: "Sample screening report: download PDF" })[0]).toHaveAttribute("download");
   });
 });

--- a/rentchain-frontend/src/pages/PdfSamplePage.tsx
+++ b/rentchain-frontend/src/pages/PdfSamplePage.tsx
@@ -9,6 +9,8 @@ const pdfUrl = "/sample/screening_report_sample.pdf?v=1";
 
 const PdfSamplePage: React.FC = () => {
   const navigate = useNavigate();
+  const titleId = React.useId();
+  const previewId = React.useId();
 
   return (
     <div style={{ display: "grid", gap: spacing.md }}>
@@ -22,10 +24,10 @@ const PdfSamplePage: React.FC = () => {
             flexWrap: "wrap",
           }}
         >
-          <div style={{ fontWeight: 700, fontSize: "1.1rem" }}>
+          <h1 id={titleId} style={{ margin: 0, fontWeight: 700, fontSize: "1.1rem" }}>
             Sample screening report
-          </div>
-          <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          </h1>
+          <div role="group" aria-label="Sample screening report PDF actions" style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
             <button
               type="button"
               onClick={() => navigate(-1)}
@@ -44,6 +46,7 @@ const PdfSamplePage: React.FC = () => {
               href={pdfUrl}
               target="_blank"
               rel="noreferrer"
+              aria-label="Open sample screening report in a new tab"
               onClick={() =>
                 recordPdfExportEvent("pdf_download_triggered", {
                   exportType: "sample_screening_report",
@@ -66,6 +69,7 @@ const PdfSamplePage: React.FC = () => {
             <a
               href={pdfUrl}
               download
+              aria-label="Download sample screening report PDF"
               onClick={() =>
                 recordPdfExportEvent("pdf_download_triggered", {
                   exportType: "sample_screening_report",
@@ -88,7 +92,10 @@ const PdfSamplePage: React.FC = () => {
           </div>
         </div>
       </Card>
-      <Card style={{ padding: 0, overflow: "visible" }}>
+      <Card role="region" aria-labelledby={previewId} style={{ padding: 0, overflow: "visible" }}>
+        <div id={previewId} style={{ position: "absolute", width: 1, height: 1, overflow: "hidden", clip: "rect(0 0 0 0)" }}>
+          Sample screening report PDF preview
+        </div>
         <PdfPreviewBoundary
           pdfUrl={pdfUrl}
           exportType="sample_screening_report"

--- a/rentchain-frontend/src/pages/tenant/TenantDocumentsPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantDocumentsPage.tsx
@@ -47,7 +47,7 @@ export const TenantDocumentsPage: React.FC = () => {
           <div style={{ color: "#9ca3af", fontSize: 12, textTransform: "uppercase", letterSpacing: "0.04em" }}>
             Documents & Notices
           </div>
-          <div style={{ fontSize: 20, fontWeight: 700 }}>Issued items</div>
+          <h1 style={{ margin: 0, fontSize: 20, fontWeight: 700 }}>Issued items</h1>
           <div style={{ color: "#9ca3af", fontSize: 13 }}>
             {lease?.propertyName || "Your lease"} · {lease?.unitNumber ? `Unit ${lease.unitNumber}` : "Unit"}
           </div>
@@ -110,6 +110,7 @@ export const TenantDocumentsPage: React.FC = () => {
                         href={d.fileUrl}
                         target="_blank"
                         rel="noopener noreferrer"
+                        aria-label={`View ${d.title || "tenant document"} in a new tab`}
                         style={{ color: "#93c5fd", textDecoration: "underline", fontWeight: 600 }}
                       >
                         View

--- a/rentchain-frontend/src/pages/tenant/TenantNoticeDetailPage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantNoticeDetailPage.tsx
@@ -132,7 +132,7 @@ export default function TenantNoticeDetailPage() {
       <Section style={{ maxWidth: 900, margin: "0 auto" }}>
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: spacing.md }}>
           <div>
-            <div style={{ fontSize: "1.6rem", fontWeight: 800, color: textTokens.primary }}>Notice</div>
+            <h1 style={{ margin: 0, fontSize: "1.6rem", fontWeight: 800, color: textTokens.primary }}>Notice</h1>
             <div style={{ color: textTokens.muted }}>Official communication from your landlord</div>
           </div>
           <a
@@ -186,7 +186,7 @@ export default function TenantNoticeDetailPage() {
           <Card elevated>
             <div style={{ display: "grid", gap: spacing.sm }}>
               <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline" }}>
-                <div style={{ fontSize: "1.3rem", fontWeight: 800, color: textTokens.primary }}>{notice.title}</div>
+                <h2 style={{ margin: 0, fontSize: "1.3rem", fontWeight: 800, color: textTokens.primary }}>{notice.title}</h2>
                 <div style={{ color: textTokens.muted, fontSize: "0.95rem" }}>{formatNoticeType(notice.type)}</div>
               </div>
               <div style={{ color: textTokens.secondary, fontSize: "0.95rem" }}>

--- a/rentchain-frontend/src/styles/printPdfGuardrails.test.ts
+++ b/rentchain-frontend/src/styles/printPdfGuardrails.test.ts
@@ -40,5 +40,8 @@ describe("print PDF guardrails", () => {
     expect(source).not.toMatch(/min-height:\s*100vh/);
     expect(source).toMatch(/overflow:\s*visible/);
     expect(source).toMatch(/transform:\s*none/);
+    expect(source).toMatch(/<article className="print-application-view"/);
+    expect(source).toMatch(/aria-label="Application summary print view"/);
+    expect(source).toMatch(/overflow-wrap:\s*anywhere/);
   });
 });


### PR DESCRIPTION
## Mission
Document Accessibility Audit V1

## Accessibility Audit Summary
- Document accessibility map: audited legal/document paths across lease summary rendering, PDF sample preview/modal, lease pack generation, print-only application output, tenant notice detail, and tenant document download flows.
- Keyboard-navigation findings: PDF sample modal had focus trapping and Escape support but lacked labelled dialog wiring and focus restoration; lease pack generator modal lacked dialog semantics, Escape close, focus restoration, and focus containment.
- Semantic-structure findings: lease document rendering had document-level structure but field/value groups were div-only; print application output was div-only; sample PDF page title and preview region were not exposed as structured headings/regions.
- Print-readability findings: print guardrails were stable, but application print values/notes needed stronger long-text wrapping and section semantics.
- Mobile readability findings: mobile PDF fallback was stable but its fallback region and actions had generic accessible names.
- PDF accessibility gaps: embedded/generated PDFs remain untagged by the current PDF stack; this PR improves surrounding HTML controls and preview semantics without replacing PDF generation.
- Export accessibility risks: repeated actions like Open PDF, Download PDF, Download, and View were ambiguous for assistive technology.
- Regression risks: legal/export visual drift, modal focus behavior, and PDF fallback behavior. Changes are scoped to semantics, labels, focus handling, and wrapping; backend PDFKit/legal generation is untouched.

## Accessibility Architecture Findings
- Shared PDF preview accessibility belongs in `PdfPreviewBoundary` so desktop iframe and mobile fallback behavior stay consistent.
- Document modals need deterministic dialog labelling, Escape behavior, focus restoration, and focus containment without changing export APIs.
- Legal/document field groups should expose definition semantics while preserving existing layout.
- Print-only document views should use article/header/section/heading semantics and long-text wrapping without altering legal copy.

## Files Changed
- `rentchain-frontend/src/components/documentRendering/PdfPreviewBoundary.tsx`
- `rentchain-frontend/src/components/documentRendering/PdfPreviewBoundary.test.tsx`
- `rentchain-frontend/src/components/billing/SamplePdfModal.tsx`
- `rentchain-frontend/src/components/billing/SamplePdfModal.test.tsx`
- `rentchain-frontend/src/pages/PdfSamplePage.tsx`
- `rentchain-frontend/src/pages/PdfSamplePage.test.tsx`
- `rentchain-frontend/src/components/leases/LeaseDocumentView.tsx`
- `rentchain-frontend/src/components/leases/LeasePackGeneratorModal.tsx`
- `rentchain-frontend/src/components/leases/LeasePackGeneratorModal.test.tsx`
- `rentchain-frontend/src/components/applications/PrintApplicationView.tsx`
- `rentchain-frontend/src/pages/tenant/TenantDocumentsPage.tsx`
- `rentchain-frontend/src/pages/tenant/TenantNoticeDetailPage.tsx`
- `rentchain-frontend/src/pages/LandlordLeaseSummaryPage.test.tsx`
- `rentchain-frontend/src/styles/printPdfGuardrails.test.ts`

## Accessibility Hardening Implemented
- Labelled PDF preview iframe and mobile fallback region/actions.
- Added document-context accessible names to PDF open/download actions.
- Added labelled dialog semantics, focus restoration, and alert semantics to the sample PDF modal.
- Added labelled dialog semantics, Escape close, focus restoration, focus containment, labelled property select, and contextual download labels to the lease pack modal.
- Converted lease document fields to semantic definition list terms/definitions.
- Added labelled lease document article/sections.
- Converted print application output to article/header/section/heading structure and added long-text wrapping.
- Added heading/label improvements for tenant document and notice detail surfaces.

## Tests Executed
- `npm run test -- PdfPreviewBoundary SamplePdfModal PdfSamplePage LandlordLeaseSummaryPage LeasePackGeneratorModal printPdfGuardrails` ✅
- `source /Users/rentchain/.nvm/nvm.sh && nvm use 20.20.2 && npm run test` ✅ 256 files / 941 tests
- `source /Users/rentchain/.nvm/nvm.sh && nvm use 20.20.2 && npm run build` ✅
- `git diff --check` ✅

## Manual QA Completed
- Keyboard/focus behavior covered by regression tests for sample PDF modal and lease pack modal.
- Mobile PDF fallback behavior covered by existing and new preview tests.
- Lease summary semantic structure covered by page regression test.
- Print application semantic/readability guardrails covered by static guardrail test.
- Export/download controls reviewed for contextual accessible names.

## Remaining Risks
- Current PDF outputs are not tagged PDFs; this mission intentionally does not replace or refactor the PDF generation stack.
- Broader WCAG certification, advanced screen-reader tuning, and PDF engine-level accessibility remain future work.
- Visual/browser manual QA should still be performed on deployed preview for document rendering appearance before merge.

## Scope Compliance
- Frontend-only.
- No backend PDFKit refactor.
- No export API changes.
- No legal wording changes.
- No visual redesign or document engine rewrite.