### PR TITLE
Verified account foundations v1

### DIFF
--- a/docs/architecture/verified-account-foundations-v1.md
+++ b/docs/architecture/verified-account-foundations-v1.md
@@ -1,0 +1,98 @@
+# Verified Account Foundations v1
+
+Status: implemented foundation
+Branch: `feat/verified-account-foundations-v1`
+Scope: additive trust-state infrastructure, no provider integration, no raw identity custody
+
+## Verification and Trust Audit Summary
+
+RentChain had useful identity and onboarding readiness signals before this mission, but they were fragmented across tenant identity projections, landlord activation, application phone verification, screening status, payment readiness, property registry projections, identity portability, share packages, and identity layer lineage views.
+
+The audit found that existing "verified" language often means an operational reference is available, not that RentChain has provider-grade identity assurance. This is acceptable for current workflow support, but unsafe for future institutional or execution systems unless trust states become explicit and scoped.
+
+## Current Verification Flows
+
+- Landlord onboarding tracks operational activation steps: property, unit, applicant, viewing, screening, and decision readiness.
+- Tenant onboarding derives identity readiness from profile completeness, application reuse, document availability, screening status, and lease evidence.
+- Application phone verification uses OTP metadata on application records.
+- Email verification exists in auth and invite flows, but was not normalized into a reusable account trust projection.
+- Screening completion is a workflow signal, not a government identity assertion.
+- Payment readiness intentionally does not enable processor connection, stored payment methods, money movement, or custody.
+- Property registry projections can support public registry lineage, but do not prove ownership or operator authority.
+
+## Self-Asserted vs Verified Data Map
+
+| Data or signal | Current assurance |
+| --- | --- |
+| Tenant profile fields, application data, income, employment, references | Self-asserted |
+| Uploaded document presence or checklist completion | Self-asserted or platform-observed presence |
+| Landlord-entered property, unit, lease, rent, and tenant details | Self-asserted until corroborated |
+| Application reuse, lease participation, identity timeline, share-package state | Platform-correlated |
+| Phone OTP success | Contact-channel verified |
+| Email verification | Account/contact-channel verified |
+| Screening completion | Workflow/provider-adjacent, not government ID assurance |
+| Public registry projection | Provider/public-source attested for scoped property registry lineage |
+| Business, government identity, ownership/operator authority | Not implemented |
+
+## Trust-State Model
+
+The foundation introduces a conservative trust-state model:
+
+- `asserted`: self-entered or incomplete account context.
+- `authenticated`: verified account access or contact-channel signal.
+- `platform_correlated`: authenticated account plus aligned RentChain operational records.
+- `provider_attested`: scoped provider, registry, or future identity-provider metadata exists.
+- `institution_reviewed`: operator or institution review metadata is present.
+
+V1 deliberately does not introduce execution eligibility. All derived trust states remain manual-review-first and metadata-only.
+
+## Verification Signal Model
+
+Verification signals now carry:
+
+- subject type and subject id
+- signal type
+- lifecycle status
+- source
+- evidence type
+- confidence
+- provider key
+- evidence reference
+- issued, verified, expiry, and revocation timestamps
+- privacy flags proving metadata-only handling
+
+The model is provider-ready for future identity, business, property, screening, payment, insurer, lender, or government attestations without integrating any provider in this mission.
+
+## Governance and Privacy Boundaries
+
+The trust-state foundation preserves these hard boundaries:
+
+- raw government identity documents are excluded
+- raw screening provider payloads are excluded
+- banking and payment account details are excluded
+- biometric payloads are not represented
+- provider integrations are disabled
+- execution eligibility is false
+- external sharing still requires explicit consent
+- manual review remains required
+
+## Adoption
+
+Initial adoption is intentionally narrow:
+
+- Identity layer profiles now include `trustState`.
+- Identity layer trust state is derived from existing metadata-only references.
+- The frontend identity layer shows a conservative account trust state panel.
+
+This avoids changing onboarding flows, export APIs, screening providers, auth core, legal documents, or payment behavior.
+
+## Regression Risks
+
+- Future work could still read old "verified" labels too strongly if it bypasses `trustState`.
+- Provider-grade identity assurance is not implemented yet.
+- Business verification and property ownership/operator authority remain future work.
+- Public share packages should not expose new trust metadata without a separate consent and scope review.
+
+## Recommended Next Path
+
+Future missions should build on this layer with provider-attestation storage and explicit consent scopes before any institutional records or permissioned execution work.

--- a/rentchain-api/src/lib/accountTrust/__tests__/deriveAccountTrustState.test.ts
+++ b/rentchain-api/src/lib/accountTrust/__tests__/deriveAccountTrustState.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import { deriveAccountTrustState } from "../deriveAccountTrustState";
+import { verificationSignal } from "../verificationSignalFactory";
+
+describe("deriveAccountTrustState", () => {
+  it("keeps self-asserted account context at asserted trust without execution eligibility", () => {
+    const state = deriveAccountTrustState({
+      subjectType: "tenant",
+      subjectId: "tenant-1",
+      generatedAt: "2026-05-08T00:00:00.000Z",
+      signals: [
+        verificationSignal({
+          signalType: "identity",
+          subjectType: "tenant",
+          subjectId: "tenant-1",
+          status: "asserted",
+          source: "self_asserted",
+        }),
+      ],
+    });
+
+    expect(state.trustLevel).toBe("asserted");
+    expect(state.manualReviewRequired).toBe(true);
+    expect(state.providerIntegrationEnabled).toBe(false);
+    expect(state.executionEligible).toBe(false);
+    expect(state.rawSensitivePayloadStored).toBe(false);
+    expect(state.signalSummary.assertedSignals).toBe(1);
+    expect(state.missingSignals).toEqual(expect.arrayContaining(["email", "phone", "identity"]));
+  });
+
+  it("derives authenticated trust from email and phone verification metadata", () => {
+    const state = deriveAccountTrustState({
+      subjectType: "applicant",
+      subjectId: "applicant-1",
+      signals: [
+        verificationSignal({
+          signalType: "email",
+          subjectType: "applicant",
+          subjectId: "applicant-1",
+          status: "verified",
+          source: "email_verification",
+          verifiedAt: "2026-05-01T00:00:00.000Z",
+        }),
+        verificationSignal({
+          signalType: "phone",
+          subjectType: "applicant",
+          subjectId: "applicant-1",
+          status: "verified",
+          source: "phone_otp",
+          verifiedAt: "2026-05-01T00:00:00.000Z",
+        }),
+      ],
+    });
+
+    expect(state.trustLevel).toBe("platform_correlated");
+    expect(state.signalSummary.verifiedSignals).toBe(2);
+    expect(state.canonicalEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ eventType: "email_verified" }),
+        expect.objectContaining({ eventType: "phone_verified" }),
+      ])
+    );
+  });
+
+  it("derives platform-correlated trust when authenticated contact aligns with screening", () => {
+    const state = deriveAccountTrustState({
+      subjectType: "tenant",
+      subjectId: "tenant-2",
+      signals: [
+        verificationSignal({
+          signalType: "email",
+          subjectType: "tenant",
+          subjectId: "tenant-2",
+          status: "verified",
+          source: "email_verification",
+        }),
+        verificationSignal({
+          signalType: "screening",
+          subjectType: "tenant",
+          subjectId: "tenant-2",
+          status: "verified",
+          source: "screening_workflow",
+          evidenceType: "screening_order",
+          confidence: "medium",
+          evidenceRef: "screening-1",
+        }),
+      ],
+    });
+
+    expect(state.trustLevel).toBe("platform_correlated");
+    expect(state.signalSummary.verifiedSignals).toBe(2);
+    expect(state.canonicalEvents).toEqual(expect.arrayContaining([expect.objectContaining({ eventType: "screening_verified" })]));
+  });
+
+  it("derives provider-attested trust from registry/provider metadata without raw payload custody", () => {
+    const state = deriveAccountTrustState({
+      subjectType: "property",
+      subjectId: "property-1",
+      signals: [
+        verificationSignal({
+          signalType: "property",
+          subjectType: "property",
+          subjectId: "property-1",
+          status: "verified",
+          source: "public_registry",
+          evidenceType: "registry_record",
+          confidence: "high",
+          providerKey: "public_registry",
+          evidenceRef: "registry-1",
+        }),
+      ],
+    });
+
+    expect(state.trustLevel).toBe("provider_attested");
+    expect(state.signalSummary.providerAttestedSignals).toBe(1);
+    expect(JSON.stringify(state)).not.toContain("passport");
+    expect(state.redactions).toEqual(expect.arrayContaining(["Raw government identity documents are excluded."]));
+  });
+
+  it("records pending identity verification and trust level changes as metadata-only events", () => {
+    const state = deriveAccountTrustState({
+      subjectType: "tenant",
+      subjectId: "tenant-3",
+      previousTrustLevel: "asserted",
+      signals: [
+        verificationSignal({
+          signalType: "email",
+          subjectType: "tenant",
+          subjectId: "tenant-3",
+          status: "verified",
+          source: "email_verification",
+        }),
+        verificationSignal({
+          signalType: "identity",
+          subjectType: "tenant",
+          subjectId: "tenant-3",
+          status: "pending",
+          source: "future_identity_provider",
+          evidenceType: "provider_reference",
+          providerKey: "future_identity_provider",
+          reviewRequired: true,
+        }),
+      ],
+    });
+
+    expect(state.trustLevel).toBe("authenticated");
+    expect(state.signalSummary.pendingSignals).toBe(1);
+    expect(state.signalSummary.reviewRequiredSignals).toBe(1);
+    expect(state.canonicalEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ eventType: "account_verification_started", metadataOnly: true }),
+        expect.objectContaining({ eventType: "identity_verification_requested", metadataOnly: true }),
+        expect.objectContaining({ eventType: "trust_level_changed", metadataOnly: true }),
+      ])
+    );
+  });
+});

--- a/rentchain-api/src/lib/accountTrust/accountTrustTypes.ts
+++ b/rentchain-api/src/lib/accountTrust/accountTrustTypes.ts
@@ -1,0 +1,139 @@
+export type AccountTrustSubjectType =
+  | "tenant"
+  | "landlord"
+  | "applicant"
+  | "operator"
+  | "organization"
+  | "property";
+
+export type AccountTrustLevel =
+  | "asserted"
+  | "authenticated"
+  | "platform_correlated"
+  | "provider_attested"
+  | "institution_reviewed";
+
+export type VerificationSignalType =
+  | "account_access"
+  | "email"
+  | "phone"
+  | "screening"
+  | "payment_method"
+  | "lease_participation"
+  | "identity"
+  | "business"
+  | "property"
+  | "institution";
+
+export type VerificationSignalStatus =
+  | "asserted"
+  | "pending"
+  | "verified"
+  | "failed"
+  | "expired"
+  | "revoked"
+  | "manual_review_required";
+
+export type VerificationSource =
+  | "self_asserted"
+  | "firebase_auth"
+  | "email_verification"
+  | "phone_otp"
+  | "screening_workflow"
+  | "screening_provider"
+  | "payment_provider"
+  | "lease_record"
+  | "public_registry"
+  | "operator_review"
+  | "institution_review"
+  | "future_identity_provider";
+
+export type VerificationEvidenceType =
+  | "metadata_only"
+  | "canonical_event"
+  | "provider_reference"
+  | "screening_order"
+  | "payment_event"
+  | "lease_record"
+  | "registry_record"
+  | "manual_review";
+
+export type VerificationConfidence = "low" | "medium" | "high";
+
+export type VerificationSignal = {
+  signalId: string;
+  signalType: VerificationSignalType;
+  subjectType: AccountTrustSubjectType;
+  subjectId: string;
+  status: VerificationSignalStatus;
+  source: VerificationSource;
+  evidenceType: VerificationEvidenceType;
+  confidence: VerificationConfidence;
+  providerKey: string | null;
+  evidenceRef: string | null;
+  issuedAt: string | null;
+  verifiedAt: string | null;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  metadataOnly: true;
+  rawSensitivePayloadStored: false;
+  redacted: boolean;
+  reviewRequired: boolean;
+};
+
+export type AccountTrustEventType =
+  | "account_trust_state_derived"
+  | "verification_signal_attached"
+  | "account_verification_started"
+  | "identity_verification_requested"
+  | "email_verified"
+  | "phone_verified"
+  | "screening_verified"
+  | "trust_level_changed";
+
+export type AccountTrustEventDescriptor = {
+  eventType: AccountTrustEventType;
+  action: string;
+  subjectType: AccountTrustSubjectType;
+  subjectId: string;
+  trustLevel: AccountTrustLevel;
+  summary: string;
+  metadataOnly: true;
+};
+
+export type AccountTrustStateSummary = {
+  subjectType: AccountTrustSubjectType;
+  subjectId: string;
+  trustLevel: AccountTrustLevel;
+  trustLabel: string;
+  trustDescription: string;
+  manualReviewRequired: true;
+  providerIntegrationEnabled: false;
+  rawSensitivePayloadStored: false;
+  executionEligible: false;
+  externalSharingRequiresConsent: true;
+  signalSummary: {
+    totalSignals: number;
+    assertedSignals: number;
+    pendingSignals: number;
+    verifiedSignals: number;
+    providerAttestedSignals: number;
+    expiredSignals: number;
+    revokedSignals: number;
+    reviewRequiredSignals: number;
+  };
+  activeSignals: VerificationSignal[];
+  missingSignals: VerificationSignalType[];
+  reviewReasons: string[];
+  redactions: string[];
+  canonicalEvents: AccountTrustEventDescriptor[];
+  generatedAt: string;
+};
+
+export type DeriveAccountTrustStateInput = {
+  subjectType?: unknown;
+  subjectId?: unknown;
+  signals?: VerificationSignal[] | null;
+  previousTrustLevel?: AccountTrustLevel | null;
+  generatedAt?: unknown;
+};

--- a/rentchain-api/src/lib/accountTrust/deriveAccountTrustState.ts
+++ b/rentchain-api/src/lib/accountTrust/deriveAccountTrustState.ts
@@ -1,0 +1,303 @@
+import type {
+  AccountTrustEventDescriptor,
+  AccountTrustLevel,
+  AccountTrustStateSummary,
+  AccountTrustSubjectType,
+  DeriveAccountTrustStateInput,
+  VerificationSignal,
+  VerificationSignalType,
+} from "./accountTrustTypes";
+
+const SUBJECT_TYPES = new Set<AccountTrustSubjectType>([
+  "tenant",
+  "landlord",
+  "applicant",
+  "operator",
+  "organization",
+  "property",
+]);
+
+const BASE_MISSING_SIGNALS: VerificationSignalType[] = ["email", "phone", "identity"];
+
+function asString(value: unknown, max = 240): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function requestedSubjectType(value: unknown): AccountTrustSubjectType {
+  const raw = asString(value, 80) as AccountTrustSubjectType;
+  return SUBJECT_TYPES.has(raw) ? raw : "tenant";
+}
+
+function safeSubjectId(type: AccountTrustSubjectType, value: unknown) {
+  const raw = asString(value, 400);
+  return raw ? `${type}:${raw}` : `${type}:unknown`;
+}
+
+function trustCopy(level: AccountTrustLevel): Pick<AccountTrustStateSummary, "trustLabel" | "trustDescription"> {
+  if (level === "institution_reviewed") {
+    return {
+      trustLabel: "Institution review recorded",
+      trustDescription:
+        "The account has institution or operator review metadata, but manual review and scoped consent still remain required.",
+    };
+  }
+  if (level === "provider_attested") {
+    return {
+      trustLabel: "Provider-attested signals present",
+      trustDescription:
+        "At least one scoped provider, registry, or approved workflow signal is present. This is not raw identity custody.",
+    };
+  }
+  if (level === "platform_correlated") {
+    return {
+      trustLabel: "Platform-correlated signals present",
+      trustDescription:
+        "Multiple RentChain operational records align, but they should not be treated as government-grade identity proof.",
+    };
+  }
+  if (level === "authenticated") {
+    return {
+      trustLabel: "Authenticated account signal present",
+      trustDescription:
+        "The account has a verified access or contact signal, but broader institutional verification is still limited.",
+    };
+  }
+  return {
+    trustLabel: "Asserted account context",
+    trustDescription:
+      "The account context is based on asserted or incomplete information and is not institution-ready.",
+  };
+}
+
+function eventDescriptor(params: {
+  eventType: AccountTrustEventDescriptor["eventType"];
+  subjectType: AccountTrustSubjectType;
+  subjectId: string;
+  trustLevel: AccountTrustLevel;
+  summary: string;
+}): AccountTrustEventDescriptor {
+  return {
+    eventType: params.eventType,
+    action: params.eventType.replace(/_/g, "."),
+    subjectType: params.subjectType,
+    subjectId: params.subjectId,
+    trustLevel: params.trustLevel,
+    summary: params.summary,
+    metadataOnly: true,
+  };
+}
+
+function isActiveVerifiedSignal(signal: VerificationSignal) {
+  return (
+    signal.status === "verified" &&
+    signal.metadataOnly === true &&
+    signal.rawSensitivePayloadStored === false &&
+    !signal.redacted &&
+    !signal.revokedAt
+  );
+}
+
+function isAuthenticatedSignal(signal: VerificationSignal) {
+  return (
+    isActiveVerifiedSignal(signal) &&
+    (signal.signalType === "account_access" ||
+      signal.signalType === "email" ||
+      signal.signalType === "phone" ||
+      signal.source === "firebase_auth" ||
+      signal.source === "email_verification" ||
+      signal.source === "phone_otp")
+  );
+}
+
+function isProviderAttestedSignal(signal: VerificationSignal) {
+  if (!isActiveVerifiedSignal(signal)) return false;
+  if (signal.source === "future_identity_provider" || signal.source === "screening_provider") return true;
+  if (signal.source === "public_registry" && signal.evidenceType === "registry_record") return true;
+  if (signal.evidenceType === "provider_reference") return true;
+  return ["identity", "business", "property", "institution"].includes(signal.signalType) && signal.confidence === "high";
+}
+
+function isInstitutionReviewedSignal(signal: VerificationSignal) {
+  return (
+    isActiveVerifiedSignal(signal) &&
+    (signal.signalType === "institution" ||
+      signal.source === "institution_review" ||
+      (signal.source === "operator_review" && signal.evidenceType === "manual_review"))
+  );
+}
+
+function isPlatformCorrelatedSignal(signal: VerificationSignal) {
+  return (
+    isActiveVerifiedSignal(signal) &&
+    ["screening", "lease_participation", "payment_method", "property"].includes(signal.signalType)
+  );
+}
+
+function deriveTrustLevel(signals: VerificationSignal[]): AccountTrustLevel {
+  if (signals.some(isInstitutionReviewedSignal)) return "institution_reviewed";
+  if (signals.some(isProviderAttestedSignal)) return "provider_attested";
+
+  const authenticated = signals.some(isAuthenticatedSignal);
+  const platformSignals = signals.filter(isPlatformCorrelatedSignal);
+  const verifiedTypes = new Set(signals.filter(isActiveVerifiedSignal).map((signal) => signal.signalType));
+
+  if (authenticated && (platformSignals.length > 0 || verifiedTypes.size >= 2)) return "platform_correlated";
+  if (authenticated) return "authenticated";
+  return "asserted";
+}
+
+function deriveMissingSignals(signals: VerificationSignal[]) {
+  const activeTypes = new Set(signals.filter(isActiveVerifiedSignal).map((signal) => signal.signalType));
+  return BASE_MISSING_SIGNALS.filter((signalType) => !activeTypes.has(signalType));
+}
+
+function deriveEvents(params: {
+  subjectType: AccountTrustSubjectType;
+  subjectId: string;
+  trustLevel: AccountTrustLevel;
+  previousTrustLevel: AccountTrustLevel | null;
+  signals: VerificationSignal[];
+}) {
+  const events: AccountTrustEventDescriptor[] = [
+    eventDescriptor({
+      eventType: "account_trust_state_derived",
+      subjectType: params.subjectType,
+      subjectId: params.subjectId,
+      trustLevel: params.trustLevel,
+      summary: "Account trust state derived from metadata-only verification signals.",
+    }),
+  ];
+
+  if (params.signals.length > 0) {
+    events.push(
+      eventDescriptor({
+        eventType: "verification_signal_attached",
+        subjectType: params.subjectType,
+        subjectId: params.subjectId,
+        trustLevel: params.trustLevel,
+        summary: "Verification signal metadata is attached to the trust state.",
+      })
+    );
+  }
+  if (params.signals.some((signal) => signal.status === "pending")) {
+    events.push(
+      eventDescriptor({
+        eventType: "account_verification_started",
+        subjectType: params.subjectType,
+        subjectId: params.subjectId,
+        trustLevel: params.trustLevel,
+        summary: "Account verification workflow has pending metadata.",
+      })
+    );
+  }
+  if (params.signals.some((signal) => signal.signalType === "email" && signal.status === "verified")) {
+    events.push(
+      eventDescriptor({
+        eventType: "email_verified",
+        subjectType: params.subjectType,
+        subjectId: params.subjectId,
+        trustLevel: params.trustLevel,
+        summary: "Email verification signal is present.",
+      })
+    );
+  }
+  if (params.signals.some((signal) => signal.signalType === "phone" && signal.status === "verified")) {
+    events.push(
+      eventDescriptor({
+        eventType: "phone_verified",
+        subjectType: params.subjectType,
+        subjectId: params.subjectId,
+        trustLevel: params.trustLevel,
+        summary: "Phone verification signal is present.",
+      })
+    );
+  }
+  if (params.signals.some((signal) => signal.signalType === "screening" && signal.status === "verified")) {
+    events.push(
+      eventDescriptor({
+        eventType: "screening_verified",
+        subjectType: params.subjectType,
+        subjectId: params.subjectId,
+        trustLevel: params.trustLevel,
+        summary: "Screening workflow completion signal is present.",
+      })
+    );
+  }
+  if (params.signals.some((signal) => signal.signalType === "identity" && signal.status === "pending")) {
+    events.push(
+      eventDescriptor({
+        eventType: "identity_verification_requested",
+        subjectType: params.subjectType,
+        subjectId: params.subjectId,
+        trustLevel: params.trustLevel,
+        summary: "Identity verification has been requested but is not complete.",
+      })
+    );
+  }
+  if (params.previousTrustLevel && params.previousTrustLevel !== params.trustLevel) {
+    events.push(
+      eventDescriptor({
+        eventType: "trust_level_changed",
+        subjectType: params.subjectType,
+        subjectId: params.subjectId,
+        trustLevel: params.trustLevel,
+        summary: "Account trust level changed from the previous derived state.",
+      })
+    );
+  }
+
+  return events;
+}
+
+export function deriveAccountTrustState(input: DeriveAccountTrustStateInput): AccountTrustStateSummary {
+  const subjectType = requestedSubjectType(input.subjectType);
+  const subjectId = safeSubjectId(subjectType, input.subjectId);
+  const signals = Array.isArray(input.signals) ? input.signals : [];
+  const trustLevel = deriveTrustLevel(signals);
+  const copy = trustCopy(trustLevel);
+  const activeSignals = signals.filter(isActiveVerifiedSignal);
+  const reviewReasons = signals
+    .filter((signal) => signal.reviewRequired || signal.status === "manual_review_required")
+    .map((signal) => `${signal.signalType} requires manual review.`);
+  const generatedAt = asString(input.generatedAt, 120) || new Date(0).toISOString();
+
+  return {
+    subjectType,
+    subjectId,
+    trustLevel,
+    trustLabel: copy.trustLabel,
+    trustDescription: copy.trustDescription,
+    manualReviewRequired: true,
+    providerIntegrationEnabled: false,
+    rawSensitivePayloadStored: false,
+    executionEligible: false,
+    externalSharingRequiresConsent: true,
+    signalSummary: {
+      totalSignals: signals.length,
+      assertedSignals: signals.filter((signal) => signal.status === "asserted").length,
+      pendingSignals: signals.filter((signal) => signal.status === "pending").length,
+      verifiedSignals: activeSignals.length,
+      providerAttestedSignals: signals.filter(isProviderAttestedSignal).length,
+      expiredSignals: signals.filter((signal) => signal.status === "expired").length,
+      revokedSignals: signals.filter((signal) => signal.status === "revoked" || Boolean(signal.revokedAt)).length,
+      reviewRequiredSignals: signals.filter((signal) => signal.reviewRequired || signal.status === "manual_review_required").length,
+    },
+    activeSignals,
+    missingSignals: deriveMissingSignals(signals),
+    reviewReasons,
+    redactions: [
+      "Raw government identity documents are excluded.",
+      "Raw screening provider payloads are excluded.",
+      "Banking and payment account details are excluded.",
+      "Trust state stores metadata-only verification signals.",
+    ],
+    canonicalEvents: deriveEvents({
+      subjectType,
+      subjectId,
+      trustLevel,
+      previousTrustLevel: input.previousTrustLevel || null,
+      signals,
+    }),
+    generatedAt,
+  };
+}

--- a/rentchain-api/src/lib/accountTrust/index.ts
+++ b/rentchain-api/src/lib/accountTrust/index.ts
@@ -1,0 +1,3 @@
+export * from "./accountTrustTypes";
+export * from "./deriveAccountTrustState";
+export * from "./verificationSignalFactory";

--- a/rentchain-api/src/lib/accountTrust/verificationSignalFactory.ts
+++ b/rentchain-api/src/lib/accountTrust/verificationSignalFactory.ts
@@ -1,0 +1,59 @@
+import type {
+  AccountTrustSubjectType,
+  VerificationConfidence,
+  VerificationEvidenceType,
+  VerificationSignal,
+  VerificationSignalStatus,
+  VerificationSignalType,
+  VerificationSource,
+} from "./accountTrustTypes";
+
+function asString(value: unknown, max = 240): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+export function verificationSignal(params: {
+  signalType: VerificationSignalType;
+  subjectType: AccountTrustSubjectType;
+  subjectId: unknown;
+  status: VerificationSignalStatus;
+  source: VerificationSource;
+  evidenceType?: VerificationEvidenceType;
+  confidence?: VerificationConfidence;
+  providerKey?: unknown;
+  evidenceRef?: unknown;
+  issuedAt?: unknown;
+  verifiedAt?: unknown;
+  expiresAt?: unknown;
+  revokedAt?: unknown;
+  redacted?: boolean;
+  reviewRequired?: boolean;
+}): VerificationSignal {
+  const subjectId = asString(params.subjectId, 400) || "unknown";
+  const evidenceRef = asString(params.evidenceRef, 400) || null;
+  const signalId = [params.subjectType, subjectId, params.signalType, params.source, evidenceRef || "metadata"]
+    .join(":")
+    .replace(/\s+/g, "_")
+    .toLowerCase();
+
+  return {
+    signalId,
+    signalType: params.signalType,
+    subjectType: params.subjectType,
+    subjectId,
+    status: params.status,
+    source: params.source,
+    evidenceType: params.evidenceType || "metadata_only",
+    confidence: params.confidence || "low",
+    providerKey: asString(params.providerKey, 120) || null,
+    evidenceRef,
+    issuedAt: asString(params.issuedAt, 120) || null,
+    verifiedAt: asString(params.verifiedAt, 120) || null,
+    expiresAt: asString(params.expiresAt, 120) || null,
+    revokedAt: asString(params.revokedAt, 120) || null,
+    metadataOnly: true,
+    rawSensitivePayloadStored: false,
+    redacted: Boolean(params.redacted),
+    reviewRequired: Boolean(params.reviewRequired),
+  };
+}

--- a/rentchain-api/src/lib/identityLayer/__tests__/deriveIdentityProfile.test.ts
+++ b/rentchain-api/src/lib/identityLayer/__tests__/deriveIdentityProfile.test.ts
@@ -24,6 +24,14 @@ describe("deriveIdentityProfile", () => {
       })
     );
     expect(profile.verificationSummary.verifiedReferences).toBeGreaterThan(0);
+    expect(profile.trustState).toEqual(
+      expect.objectContaining({
+        trustLevel: "institution_reviewed",
+        manualReviewRequired: true,
+        rawSensitivePayloadStored: false,
+        executionEligible: false,
+      })
+    );
     expect(profile.consentSummary.consentAvailable).toBe(true);
     expect(profile.reviewReferences).toHaveLength(1);
     expect(profile.canonicalEvents).toEqual(
@@ -43,6 +51,7 @@ describe("deriveIdentityProfile", () => {
     });
 
     expect(profile.status).toBe("partially_verified");
+    expect(profile.trustState.trustLevel).toBe("asserted");
     expect(profile.consentSummary.missingConsentReasons).toContain("Consent lineage reference is missing.");
     expect(profile.portabilitySummary.portabilityStatus).toBe("limited");
   });
@@ -57,6 +66,7 @@ describe("deriveIdentityProfile", () => {
     });
 
     expect(profile.status).toBe("verified");
+    expect(profile.trustState.trustLevel).toBe("provider_attested");
     expect(profile.verificationReferences).toEqual(
       expect.arrayContaining([expect.objectContaining({ label: "Registry verification reference", status: "available" })])
     );
@@ -101,5 +111,6 @@ describe("deriveIdentityProfile", () => {
     expect(serialized).not.toContain("sensitive-credit-payload");
     expect(serialized).not.toContain("sensitive-payment-account");
     expect(profile.redactions).toEqual(expect.arrayContaining(["Raw screening and credit bureau payloads are excluded."]));
+    expect(profile.trustState.redactions).toEqual(expect.arrayContaining(["Raw government identity documents are excluded."]));
   });
 });

--- a/rentchain-api/src/lib/identityLayer/deriveIdentityProfile.ts
+++ b/rentchain-api/src/lib/identityLayer/deriveIdentityProfile.ts
@@ -6,6 +6,7 @@ import type {
   IdentityLayerStatus,
   IdentityLayerType,
 } from "./identityLayerTypes";
+import { deriveAccountTrustState, verificationSignal, type VerificationSignal } from "../accountTrust";
 import { consentReference } from "./identityConsentModels";
 import { identityReference, isVerifiedReference } from "./identityVerificationModels";
 
@@ -69,6 +70,137 @@ function canonicalEvent(params: {
     resourceId: params.resourceId,
     summary: params.summary,
   };
+}
+
+function trustSubjectType(identityType: IdentityLayerType) {
+  if (identityType === "property") return "property" as const;
+  if (identityType === "organization") return "organization" as const;
+  if (identityType === "operator" || identityType === "review_actor") return "operator" as const;
+  return "tenant" as const;
+}
+
+function trustSignals(params: {
+  identityType: IdentityLayerType;
+  identityId: string;
+  sourceRecord: Record<string, unknown> | null | undefined;
+  verificationReferences: IdentityLayerReference[];
+  reviewReferences: IdentityLayerReference[];
+}): VerificationSignal[] {
+  const subjectType = trustSubjectType(params.identityType);
+  const subjectId = params.identityId.replace(/^[^:]+:/, "") || "unknown";
+  const signals: VerificationSignal[] = [];
+  const source = params.sourceRecord || null;
+
+  if (hasValue(source, ["email", "emailVerifiedAt"]) || source?.emailVerified === true) {
+    signals.push(
+      verificationSignal({
+        signalType: "email",
+        subjectType,
+        subjectId,
+        status: source?.emailVerified === true || hasValue(source, ["emailVerifiedAt"]) ? "verified" : "asserted",
+        source: source?.emailVerified === true || hasValue(source, ["emailVerifiedAt"]) ? "email_verification" : "self_asserted",
+        evidenceType: "metadata_only",
+        verifiedAt: source?.emailVerifiedAt,
+      })
+    );
+  }
+  if (hasValue(source, ["phone", "applicantPhone", "phoneVerifiedAt"]) || source?.phoneVerified === true) {
+    signals.push(
+      verificationSignal({
+        signalType: "phone",
+        subjectType,
+        subjectId,
+        status: source?.phoneVerified === true || hasValue(source, ["phoneVerifiedAt"]) ? "verified" : "asserted",
+        source: source?.phoneVerified === true || hasValue(source, ["phoneVerifiedAt"]) ? "phone_otp" : "self_asserted",
+        evidenceType: "metadata_only",
+        verifiedAt: source?.phoneVerifiedAt,
+      })
+    );
+  }
+
+  for (const reference of params.verificationReferences) {
+    if (reference.status !== "available" || reference.redacted) continue;
+    if (reference.referenceType === "screening") {
+      signals.push(
+        verificationSignal({
+          signalType: "screening",
+          subjectType,
+          subjectId,
+          status: "verified",
+          source: "screening_workflow",
+          evidenceType: "screening_order",
+          confidence: "medium",
+          evidenceRef: reference.referenceId,
+          verifiedAt: reference.occurredAt,
+        })
+      );
+    }
+    if (reference.referenceType === "property_registry") {
+      signals.push(
+        verificationSignal({
+          signalType: "property",
+          subjectType,
+          subjectId,
+          status: "verified",
+          source: "public_registry",
+          evidenceType: "registry_record",
+          confidence: "high",
+          providerKey: "public_registry",
+          evidenceRef: reference.referenceId,
+          verifiedAt: reference.occurredAt,
+        })
+      );
+    }
+    if (reference.referenceType === "tenant_profile" || reference.referenceType === "organization") {
+      signals.push(
+        verificationSignal({
+          signalType: "identity",
+          subjectType,
+          subjectId,
+          status: "asserted",
+          source: "self_asserted",
+          evidenceType: "metadata_only",
+          evidenceRef: reference.referenceId,
+          issuedAt: reference.occurredAt,
+        })
+      );
+    }
+  }
+
+  for (const reference of params.reviewReferences) {
+    if (reference.status !== "available" || reference.redacted) continue;
+    signals.push(
+      verificationSignal({
+        signalType: "institution",
+        subjectType,
+        subjectId,
+        status: "verified",
+        source: "operator_review",
+        evidenceType: "manual_review",
+        confidence: "medium",
+        evidenceRef: reference.referenceId,
+        verifiedAt: reference.occurredAt,
+        reviewRequired: true,
+      })
+    );
+  }
+
+  if (hasValue(source, ["identityVerificationId"]) || asString(source?.identityVerificationStatus, 80) === "pending") {
+    signals.push(
+      verificationSignal({
+        signalType: "identity",
+        subjectType,
+        subjectId,
+        status: "pending",
+        source: "future_identity_provider",
+        evidenceType: "metadata_only",
+        confidence: "low",
+        reviewRequired: true,
+      })
+    );
+  }
+
+  return signals;
 }
 
 function tenantReferences(input: DeriveIdentityProfileInput) {
@@ -240,6 +372,18 @@ export function deriveIdentityProfile(input: DeriveIdentityProfileInput): Identi
   const portabilityStatus = status === "verified" ? "ready" : verifiedReferences > 0 ? "limited" : "not_ready";
   const generatedAt = asString(input.generatedAt, 120) || new Date(0).toISOString();
   const lineageReferences = [...verificationReferences, ...consentReferences, ...reviewReferences, ...eventReferences];
+  const trustState = deriveAccountTrustState({
+    subjectType: trustSubjectType(identityType),
+    subjectId: identityId.replace(/^[^:]+:/, "") || "unknown",
+    generatedAt,
+    signals: trustSignals({
+      identityType,
+      identityId,
+      sourceRecord,
+      verificationReferences,
+      reviewReferences,
+    }),
+  });
 
   const canonicalEvents: IdentityLayerCanonicalEvent[] = [
     canonicalEvent({
@@ -321,6 +465,7 @@ export function deriveIdentityProfile(input: DeriveIdentityProfileInput): Identi
       portabilityStatus,
       blockedReasons: portabilityStatus === "not_ready" ? ["Identity portability requires verified references."] : [],
     },
+    trustState,
     lineageReferences,
     verificationReferences,
     consentReferences,

--- a/rentchain-api/src/lib/identityLayer/identityLayerTypes.ts
+++ b/rentchain-api/src/lib/identityLayer/identityLayerTypes.ts
@@ -63,6 +63,7 @@ export type IdentityLayerProfile = {
     portabilityStatus: "ready" | "limited" | "not_ready";
     blockedReasons: string[];
   };
+  trustState: AccountTrustStateSummary;
   lineageReferences: IdentityLayerReference[];
   verificationReferences: IdentityLayerReference[];
   consentReferences: IdentityLayerReference[];
@@ -86,3 +87,4 @@ export type DeriveIdentityProfileInput = {
   canonicalEvents?: Array<Record<string, unknown>> | null;
   consentRecords?: Array<Record<string, unknown>> | null;
 };
+import type { AccountTrustStateSummary } from "../accountTrust";

--- a/rentchain-api/src/routes/__tests__/landlordIdentityLayerRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/landlordIdentityLayerRoutes.test.ts
@@ -154,6 +154,14 @@ describe("landlordIdentityLayerRoutes", () => {
     expect(serialized).not.toContain("sensitive-government-id-value");
     expect(serialized).not.toContain("sensitive-payment-account");
     expect(serialized).not.toContain("tenant-other");
+    expect(res.body.profile.trustState).toEqual(
+      expect.objectContaining({
+        manualReviewRequired: true,
+        rawSensitivePayloadStored: false,
+        providerIntegrationEnabled: false,
+        executionEligible: false,
+      })
+    );
   });
 
   it("returns property identity status with registry lineage", async () => {
@@ -177,6 +185,7 @@ describe("landlordIdentityLayerRoutes", () => {
         tokenizationEnabled: false,
       })
     );
+    expect(res.body.status).not.toHaveProperty("rawSensitivePayloadStored");
   });
 
   it("blocks non-landlord users", async () => {

--- a/rentchain-frontend/src/api/identityLayerApi.ts
+++ b/rentchain-frontend/src/api/identityLayerApi.ts
@@ -23,6 +23,83 @@ export type IdentityLayerReference = {
   blockedReason: string | null;
 };
 
+export type AccountTrustLevel =
+  | "asserted"
+  | "authenticated"
+  | "platform_correlated"
+  | "provider_attested"
+  | "institution_reviewed";
+
+export type VerificationSignalType =
+  | "account_access"
+  | "email"
+  | "phone"
+  | "screening"
+  | "payment_method"
+  | "lease_participation"
+  | "identity"
+  | "business"
+  | "property"
+  | "institution";
+
+export type VerificationSignal = {
+  signalId: string;
+  signalType: VerificationSignalType;
+  subjectType: "tenant" | "landlord" | "applicant" | "operator" | "organization" | "property";
+  subjectId: string;
+  status: "asserted" | "pending" | "verified" | "failed" | "expired" | "revoked" | "manual_review_required";
+  source: string;
+  evidenceType: string;
+  confidence: "low" | "medium" | "high";
+  providerKey: string | null;
+  evidenceRef: string | null;
+  issuedAt: string | null;
+  verifiedAt: string | null;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  metadataOnly: true;
+  rawSensitivePayloadStored: false;
+  redacted: boolean;
+  reviewRequired: boolean;
+};
+
+export type AccountTrustStateSummary = {
+  subjectType: VerificationSignal["subjectType"];
+  subjectId: string;
+  trustLevel: AccountTrustLevel;
+  trustLabel: string;
+  trustDescription: string;
+  manualReviewRequired: true;
+  providerIntegrationEnabled: false;
+  rawSensitivePayloadStored: false;
+  executionEligible: false;
+  externalSharingRequiresConsent: true;
+  signalSummary: {
+    totalSignals: number;
+    assertedSignals: number;
+    pendingSignals: number;
+    verifiedSignals: number;
+    providerAttestedSignals: number;
+    expiredSignals: number;
+    revokedSignals: number;
+    reviewRequiredSignals: number;
+  };
+  activeSignals: VerificationSignal[];
+  missingSignals: VerificationSignalType[];
+  reviewReasons: string[];
+  redactions: string[];
+  canonicalEvents: Array<{
+    eventType: string;
+    action: string;
+    subjectType: VerificationSignal["subjectType"];
+    subjectId: string;
+    trustLevel: AccountTrustLevel;
+    summary: string;
+    metadataOnly: true;
+  }>;
+  generatedAt: string;
+};
+
 export type IdentityLayerProfile = {
   identityId: string;
   identityType: IdentityLayerType;
@@ -48,6 +125,7 @@ export type IdentityLayerProfile = {
     portabilityStatus: "ready" | "limited" | "not_ready";
     blockedReasons: string[];
   };
+  trustState: AccountTrustStateSummary;
   lineageReferences: IdentityLayerReference[];
   verificationReferences: IdentityLayerReference[];
   consentReferences: IdentityLayerReference[];

--- a/rentchain-frontend/src/components/identity/IdentityProfilePanel.test.tsx
+++ b/rentchain-frontend/src/components/identity/IdentityProfilePanel.test.tsx
@@ -31,6 +31,34 @@ function profile(overrides: Partial<IdentityLayerProfile> = {}): IdentityLayerPr
       portabilityStatus: "ready",
       blockedReasons: [],
     },
+    trustState: {
+      subjectType: "tenant",
+      subjectId: "tenant:tenant-1",
+      trustLevel: "platform_correlated",
+      trustLabel: "Platform-correlated signals present",
+      trustDescription: "Multiple RentChain operational records align, but they should not be treated as government-grade identity proof.",
+      manualReviewRequired: true,
+      providerIntegrationEnabled: false,
+      rawSensitivePayloadStored: false,
+      executionEligible: false,
+      externalSharingRequiresConsent: true,
+      signalSummary: {
+        totalSignals: 2,
+        assertedSignals: 0,
+        pendingSignals: 0,
+        verifiedSignals: 2,
+        providerAttestedSignals: 0,
+        expiredSignals: 0,
+        revokedSignals: 0,
+        reviewRequiredSignals: 0,
+      },
+      activeSignals: [],
+      missingSignals: ["identity"],
+      reviewReasons: [],
+      redactions: ["Trust state stores metadata-only verification signals."],
+      canonicalEvents: [],
+      generatedAt: "2026-05-06T00:00:00.000Z",
+    },
     lineageReferences: [],
     verificationReferences: [
       {
@@ -81,6 +109,10 @@ describe("IdentityProfilePanel", () => {
     expect(screen.getByText(/Manual review remains required/i)).toBeInTheDocument();
     expect(screen.getByText(/No public identity sharing or tokenization is enabled/i)).toBeInTheDocument();
     expect(screen.getByText("View verification lineage")).toBeInTheDocument();
+    expect(screen.getByText("Account trust state")).toBeInTheDocument();
+    expect(screen.getByText("Platform-correlated signals present")).toBeInTheDocument();
+    expect(screen.getByText("Execution disabled")).toBeInTheDocument();
+    expect(screen.getByText("Metadata only")).toBeInTheDocument();
     expect(screen.getByText("Tenant profile reference")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "View context" })).toHaveAttribute("href", "/tenants");
     expect(screen.getByText("View consent lineage")).toBeInTheDocument();

--- a/rentchain-frontend/src/components/identity/IdentityProfilePanel.tsx
+++ b/rentchain-frontend/src/components/identity/IdentityProfilePanel.tsx
@@ -10,10 +10,10 @@ function label(value: string) {
 function statusTone(status: string) {
   if (status === "blocked") return { color: "#991b1b", background: "#fee2e2", border: "#fecaca" };
   if (status === "review_required" || status === "missing") return { color: "#92400e", background: "#fef3c7", border: "#fde68a" };
-  if (status === "verified" || status === "available" || status === "ready") {
+  if (status === "verified" || status === "available" || status === "ready" || status === "provider_attested" || status === "institution_reviewed") {
     return { color: "#166534", background: "#dcfce7", border: "#bbf7d0" };
   }
-  if (status === "partially_verified" || status === "limited") {
+  if (status === "partially_verified" || status === "limited" || status === "platform_correlated" || status === "authenticated") {
     return { color: "#9a3412", background: "#ffedd5", border: "#fed7aa" };
   }
   return { color: "#475569", background: "#f8fafc", border: "#e2e8f0" };
@@ -110,6 +110,45 @@ export function IdentityProfilePanel({ profile }: { profile: IdentityLayerProfil
             </Card>
           ))}
         </div>
+      </Section>
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Account trust state</div>
+        <Card style={{ borderRadius: 8, padding: 12 }}>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+            <div>
+              <strong>{profile.trustState.trustLabel}</strong>
+              <div style={{ color: "#475569", fontSize: 13, marginTop: 4, lineHeight: 1.5 }}>
+                {profile.trustState.trustDescription}
+              </div>
+            </div>
+            <Badge status={profile.trustState.trustLevel}>{label(profile.trustState.trustLevel)}</Badge>
+          </div>
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginTop: 12 }}>
+            <Badge status={profile.trustState.manualReviewRequired ? "review_required" : "unknown"}>Manual review required</Badge>
+            <Badge status={profile.trustState.providerIntegrationEnabled ? "available" : "limited"}>Provider integration disabled</Badge>
+            <Badge status={profile.trustState.executionEligible ? "blocked" : "available"}>Execution disabled</Badge>
+            <Badge status={profile.trustState.rawSensitivePayloadStored ? "blocked" : "available"}>Metadata only</Badge>
+          </div>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(130px, 1fr))", gap: 8, marginTop: 12 }}>
+            {[
+              ["Signals", profile.trustState.signalSummary.totalSignals],
+              ["Verified", profile.trustState.signalSummary.verifiedSignals],
+              ["Provider attested", profile.trustState.signalSummary.providerAttestedSignals],
+              ["Needs review", profile.trustState.signalSummary.reviewRequiredSignals],
+            ].map(([name, value]) => (
+              <div key={String(name)} style={{ border: "1px solid #e2e8f0", borderRadius: 8, padding: 10 }}>
+                <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>{name}</div>
+                <strong style={{ color: "#0f172a", fontSize: 18 }}>{String(value)}</strong>
+              </div>
+            ))}
+          </div>
+          {profile.trustState.missingSignals.length ? (
+            <div style={{ color: "#92400e", fontSize: 13, marginTop: 10 }}>
+              Missing trust signals: {profile.trustState.missingSignals.map(label).join(", ")}.
+            </div>
+          ) : null}
+        </Card>
       </Section>
 
       <ReferenceList title="View verification lineage" references={profile.verificationReferences} />

--- a/rentchain-frontend/src/pages/IdentityLayerPage.test.tsx
+++ b/rentchain-frontend/src/pages/IdentityLayerPage.test.tsx
@@ -57,6 +57,34 @@ function profile() {
       portabilityStatus: "limited",
       blockedReasons: [],
     },
+    trustState: {
+      subjectType: "tenant",
+      subjectId: "tenant:tenant-1",
+      trustLevel: "platform_correlated",
+      trustLabel: "Platform-correlated signals present",
+      trustDescription: "Multiple RentChain operational records align, but they should not be treated as government-grade identity proof.",
+      manualReviewRequired: true,
+      providerIntegrationEnabled: false,
+      rawSensitivePayloadStored: false,
+      executionEligible: false,
+      externalSharingRequiresConsent: true,
+      signalSummary: {
+        totalSignals: 2,
+        assertedSignals: 0,
+        pendingSignals: 0,
+        verifiedSignals: 2,
+        providerAttestedSignals: 0,
+        expiredSignals: 0,
+        revokedSignals: 0,
+        reviewRequiredSignals: 0,
+      },
+      activeSignals: [],
+      missingSignals: ["identity"],
+      reviewReasons: [],
+      redactions: ["Trust state stores metadata-only verification signals."],
+      canonicalEvents: [],
+      generatedAt: "2026-05-06T00:00:00.000Z",
+    },
     lineageReferences: [],
     verificationReferences: [
       {
@@ -100,6 +128,7 @@ describe("IdentityLayerPage", () => {
     expect(screen.getByDisplayValue("tenant")).toBeInTheDocument();
     expect(screen.getByDisplayValue("tenant-1")).toBeInTheDocument();
     expect(screen.getByText("View verification lineage")).toBeInTheDocument();
+    expect(screen.getByText("Account trust state")).toBeInTheDocument();
     expect(screen.getByText("Payment account details are excluded.")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /publish identity|share publicly|mint token|export identity publicly|autonomous verification|approve identity automatically/i })).not.toBeInTheDocument();
     expect(apiMocks.fetchIdentityLayerProfile).toHaveBeenCalledWith({ identityType: "tenant", identityId: "tenant-1" });


### PR DESCRIPTION
## Summary

- Added a provider-neutral account trust-state foundation with scoped verification signals, deterministic trust-level derivation, metadata-only event descriptors, and privacy guardrails.
- Adopted the trust-state summary in the existing identity-layer profile read model without changing onboarding, auth, screening providers, exports, legal documents, or payment behavior.
- Added a conservative identity-layer UI panel for account trust state and documented the verification/trust audit findings.

## Scope Guardrails

- No raw government ID storage.
- No KYC custody, biometric payloads, banking/open-banking, blockchain/tokenization, or provider integrations.
- No onboarding blockers or conversion changes.
- No permission architecture rewrite.
- No export API changes.

## Validation

- `rentchain-api`: `npm run test` passed outside sandbox after sandbox port-bind failure (`335` files, `1446` tests).
- `rentchain-frontend`: `npm run test` passed (`256` files, `941` tests).
- Targeted API trust/identity tests passed after final trust mapping adjustment.
- `rentchain-api`: `npm run build` passed.
- `rentchain-frontend`: `npm run build` passed.
- `git diff --check` passed.

## Notes

The first sandboxed full API test run failed with `listen EPERM` from Supertest route tests binding local ephemeral ports. The same full API suite passed when rerun with local port binding allowed.