### PR TITLE
Institutional identity assurance framework v1

### DIFF
--- a/docs/architecture/institutional-identity-assurance-framework-v1.md
+++ b/docs/architecture/institutional-identity-assurance-framework-v1.md
@@ -1,0 +1,130 @@
+# Institutional Identity Assurance Framework v1
+
+Status: implemented foundation
+Branch: `feat/institutional-identity-assurance-framework-v1`
+Scope: provider-neutral metadata framework, no live provider integration
+
+## Implementation Audit Summary
+
+RentChain already had verified-account foundations through `accountTrust` and operational identity profiles through `identityLayer`. Those systems are useful but intentionally conservative:
+
+- account trust tracks metadata-only verification signals and derives asserted, authenticated, platform-correlated, provider-attested, and institution-reviewed states
+- identity profiles expose permission-scoped operational references, consent lineage, review lineage, redactions, and manual-review requirements
+- tenant portability and institutional identity packages summarize readiness, not provider-grade identity assurance
+- governance helpers classify sensitivity, retention, redaction, and metadata-only telemetry
+- support-console resources expose restricted diagnostics with redacted identifiers
+
+The gap was a missing institutional identity assurance layer that can describe provider-neutral identity attestations without integrating providers or storing raw identity evidence.
+
+## Assurance Model
+
+The framework introduces:
+
+- `IdentityAssuranceSubjectType`
+- `IdentityAssuranceLevel`
+- `IdentityAssuranceStatus`
+- `IdentityAssuranceLifecycleState`
+- `IdentityAssuranceProviderType`
+- `IdentityAssuranceConsentScope`
+- `IdentityAssuranceRetentionClass`
+- `IdentityAssuranceAttestation`
+- `IdentityAssuranceSummary`
+
+The model supports tenants, landlords, applicants, property operators, business entities, organizations, and properties. It is provider-neutral and can represent future attestations from identity providers, business verification providers, property registries, financial identity providers, government digital credential systems, institution reviews, operator reviews, or future providers.
+
+## Privacy and Storage Boundaries
+
+RentChain stores metadata-only assurance state:
+
+- assurance status and level
+- provider category and non-sensitive provider key
+- internal attestation id
+- redacted provider/evidence references for support summaries
+- consent purpose and consent reference metadata
+- retention class
+- completion, expiry, revocation, and reverification timestamps
+- audit event reference
+
+RentChain does not store:
+
+- raw government ID scans
+- passport or driver licence images
+- biometric images, selfie, face maps, or liveness payloads
+- raw provider KYC/KYB/AML payloads
+- SIN/SSN equivalents
+- banking credentials
+- unsupported institution-wide "source of truth" conclusions
+
+Attestations that claim raw sensitive payload storage are ignored by the summary derivation.
+
+## Lifecycle and Events
+
+The framework defines metadata-only event descriptors:
+
+- `identity_assurance_requested`
+- `identity_assurance_started`
+- `identity_assurance_completed`
+- `identity_assurance_failed`
+- `identity_assurance_expired`
+- `identity_assurance_revoked`
+- `identity_assurance_reverification_required`
+
+These are descriptors for future canonical-event alignment. This mission does not add provider callbacks, webhook handling, persistence, external submission, or live provider orchestration.
+
+## Trust-State Alignment
+
+Identity assurance does not replace verified-account foundations.
+
+Completed, active, metadata-only attestations can be converted into conservative account-trust verification signals. The conversion uses internal `identity_assurance:{attestationId}` evidence references rather than raw provider reference ids.
+
+This lets provider-neutral assurance inform `provider_attested` account trust without exposing raw provider identifiers through identity-layer surfaces.
+
+## Support/Admin Visibility
+
+Support-safe summaries expose:
+
+- assurance status
+- assurance level
+- lifecycle state
+- provider category
+- provider key
+- redacted provider reference
+- redacted evidence reference
+- consent purpose
+- retention class
+- completion, expiry, and reverification timestamps
+- review-required flag
+
+Support/admin summaries do not expose raw ID documents, raw provider responses, biometric data, or identity document numbers.
+
+## UI Foundation
+
+The identity layer panel now shows conservative assurance status:
+
+- identity assurance not started
+- pending/requested lifecycle states
+- completed through approved workflow
+- reverification required
+- failed, expired, revoked, or manual-review-required states
+
+The UI avoids unsupported claims such as "KYC approved", "government ID verified", or broad public verified badges.
+
+## Out of Scope Preserved
+
+This framework does not:
+
+- integrate Persona, Trulioo, Verified.Me, Stripe Identity, Equifax, or government credential systems
+- add identity document upload UI
+- store raw identity documents or biometrics
+- implement KYC custody
+- block onboarding
+- expose trust metadata in public share packages
+- widen execution automation
+- add banking, open-banking, insurer, lender, subsidy, blockchain, or tokenization behavior
+
+## Regression Risks
+
+- Future teams may still overread existing tenant-facing `verified` copy unless they use the assurance summary for institutional contexts.
+- Provider integrations will need separate consent, retention, callback, deletion, and support-visibility reviews.
+- Business and property authority assurance are represented as levels but are not implemented as live workflows.
+- Public share packages intentionally do not expose identity assurance metadata in this mission.

--- a/rentchain-api/src/lib/identityAssurance/__tests__/deriveIdentityAssuranceSummary.test.ts
+++ b/rentchain-api/src/lib/identityAssurance/__tests__/deriveIdentityAssuranceSummary.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveIdentityAssuranceSummary,
+  identityAssuranceSignalsFromAttestations,
+  type IdentityAssuranceAttestation,
+} from "../index";
+
+function attestation(overrides: Partial<IdentityAssuranceAttestation> = {}): IdentityAssuranceAttestation {
+  return {
+    attestationId: "attestation-1",
+    subjectType: "tenant",
+    subjectId: "tenant-1",
+    level: "provider_identity_attested",
+    status: "completed",
+    lifecycleState: "completed",
+    providerType: "identity_provider",
+    providerKey: "future_provider",
+    providerReferenceId: "provider-reference-sensitive",
+    evidenceRef: "evidence-reference-sensitive",
+    confidence: "high",
+    consentScope: {
+      consentId: "consent-1",
+      purpose: "identity_assurance",
+      grantedAt: "2026-05-01T00:00:00.000Z",
+      expiresAt: "2026-11-01T00:00:00.000Z",
+      revokedAt: null,
+      institutionRecipientType: "none",
+      attributeScopes: ["identity_status", "assurance_level"],
+    },
+    retentionClass: "provider_reference",
+    issuedAt: "2026-05-01T00:00:00.000Z",
+    completedAt: "2026-05-01T00:10:00.000Z",
+    expiresAt: "2026-11-01T00:00:00.000Z",
+    revokedAt: null,
+    nextReverificationAt: "2026-10-01T00:00:00.000Z",
+    auditEventRef: "event-1",
+    metadataOnly: true,
+    rawSensitivePayloadStored: false,
+    supportVisible: true,
+    publicShareable: false,
+    reviewRequired: false,
+    redacted: false,
+    ...overrides,
+  };
+}
+
+describe("deriveIdentityAssuranceSummary", () => {
+  it("defaults to a non-blocking not-started summary without provider integration", () => {
+    const summary = deriveIdentityAssuranceSummary({
+      subjectType: "tenant",
+      subjectId: "tenant-1",
+      generatedAt: "2026-05-08T00:00:00.000Z",
+    });
+
+    expect(summary.status).toBe("not_started");
+    expect(summary.level).toBe("not_assessed");
+    expect(summary.onboardingBlocking).toBe(false);
+    expect(summary.providerIntegrationEnabled).toBe(false);
+    expect(summary.executionEligible).toBe(false);
+    expect(summary.rawSensitivePayloadStored).toBe(false);
+    expect(summary.supportSummary.rawIdentityDocumentVisible).toBe(false);
+  });
+
+  it("derives completed provider-neutral assurance with redacted support references", () => {
+    const summary = deriveIdentityAssuranceSummary({
+      subjectType: "tenant",
+      subjectId: "tenant-1",
+      attestations: [attestation()],
+      generatedAt: "2026-05-08T00:00:00.000Z",
+    });
+
+    expect(summary.status).toBe("completed");
+    expect(summary.level).toBe("provider_identity_attested");
+    expect(summary.assuranceLabel).toBe("Identity assurance completed through approved workflow");
+    expect(summary.consentAvailable).toBe(true);
+    expect(summary.signalSummary.completedAttestations).toBe(1);
+    expect(summary.supportSummary.attestations[0]).toEqual(
+      expect.objectContaining({
+        providerReferenceRedacted: "***tive",
+        evidenceRefRedacted: "***tive",
+      })
+    );
+    expect(JSON.stringify(summary)).not.toContain("provider-reference-sensitive");
+    expect(JSON.stringify(summary)).not.toContain("evidence-reference-sensitive");
+    expect(summary.canonicalEvents).toEqual(
+      expect.arrayContaining([expect.objectContaining({ eventType: "identity_assurance_completed", metadataOnly: true })])
+    );
+  });
+
+  it("requires reverification without changing onboarding or execution flags", () => {
+    const summary = deriveIdentityAssuranceSummary({
+      subjectType: "applicant",
+      subjectId: "applicant-1",
+      attestations: [attestation({ nextReverificationAt: "2026-05-01T00:00:00.000Z" })],
+      generatedAt: "2026-05-08T00:00:00.000Z",
+    });
+
+    expect(summary.lifecycleState).toBe("reverification_required");
+    expect(summary.reverificationRequired).toBe(true);
+    expect(summary.onboardingBlocking).toBe(false);
+    expect(summary.executionEligible).toBe(false);
+    expect(summary.canonicalEvents).toEqual(
+      expect.arrayContaining([expect.objectContaining({ eventType: "identity_assurance_reverification_required" })])
+    );
+  });
+
+  it("ignores attestations that would imply raw sensitive payload custody", () => {
+    const summary = deriveIdentityAssuranceSummary({
+      attestations: [
+        {
+          ...attestation(),
+          metadataOnly: true,
+          rawSensitivePayloadStored: true as false,
+        },
+      ],
+    });
+
+    expect(summary.status).toBe("not_started");
+    expect(summary.signalSummary.totalAttestations).toBe(0);
+    expect(summary.rawSensitivePayloadStored).toBe(false);
+  });
+
+  it("converts completed attestations into conservative account-trust signals", () => {
+    const signals = identityAssuranceSignalsFromAttestations({
+      attestations: [attestation({ level: "business_attested", subjectType: "business_entity", subjectId: "business-1" })],
+      generatedAt: "2026-05-08T00:00:00.000Z",
+    });
+
+    expect(signals).toEqual([
+      expect.objectContaining({
+        signalType: "business",
+        subjectType: "organization",
+        subjectId: "business-1",
+        status: "verified",
+        source: "future_identity_provider",
+        evidenceType: "provider_reference",
+        rawSensitivePayloadStored: false,
+      }),
+    ]);
+  });
+});

--- a/rentchain-api/src/lib/identityAssurance/deriveIdentityAssuranceSummary.ts
+++ b/rentchain-api/src/lib/identityAssurance/deriveIdentityAssuranceSummary.ts
@@ -1,0 +1,439 @@
+import { redactIdentifier } from "../governance/platformGovernance";
+import { verificationSignal, type AccountTrustSubjectType, type VerificationSignal } from "../accountTrust";
+import type {
+  DeriveIdentityAssuranceSummaryInput,
+  IdentityAssuranceAttestation,
+  IdentityAssuranceEventDescriptor,
+  IdentityAssuranceLevel,
+  IdentityAssuranceLifecycleState,
+  IdentityAssuranceProviderType,
+  IdentityAssuranceStatus,
+  IdentityAssuranceSubjectType,
+  IdentityAssuranceSummary,
+} from "./identityAssuranceTypes";
+
+const SUBJECT_TYPES = new Set<IdentityAssuranceSubjectType>([
+  "tenant",
+  "landlord",
+  "applicant",
+  "property_operator",
+  "business_entity",
+  "organization",
+  "property",
+]);
+
+const LEVEL_RANK: Record<IdentityAssuranceLevel, number> = {
+  not_assessed: 0,
+  account_controlled: 1,
+  platform_correlated: 2,
+  provider_identity_attested: 3,
+  business_attested: 4,
+  property_authority_attested: 5,
+  institution_reviewed: 6,
+};
+
+const REDACTIONS = [
+  "Raw government identity documents are excluded.",
+  "Raw biometric and liveness payloads are excluded.",
+  "Raw provider identity payloads are excluded.",
+  "Identity document numbers and SIN/SSN equivalents are excluded.",
+  "Support summaries expose redacted provider references only.",
+];
+
+function asString(value: unknown, max = 240): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function requestedSubjectType(value: unknown): IdentityAssuranceSubjectType {
+  const raw = asString(value, 80) as IdentityAssuranceSubjectType;
+  return SUBJECT_TYPES.has(raw) ? raw : "tenant";
+}
+
+function safeSubjectId(type: IdentityAssuranceSubjectType, value: unknown) {
+  const raw = asString(value, 400);
+  return raw ? `${type}:${raw.replace(/^[^:]+:/, "")}` : `${type}:unknown`;
+}
+
+function isExpired(attestation: IdentityAssuranceAttestation, generatedAt: string) {
+  if (attestation.status === "expired") return true;
+  if (!attestation.expiresAt) return false;
+  const expiry = Date.parse(attestation.expiresAt);
+  const now = Date.parse(generatedAt);
+  return Number.isFinite(expiry) && Number.isFinite(now) && expiry <= now;
+}
+
+function isReverificationDue(attestation: IdentityAssuranceAttestation, generatedAt: string) {
+  if (!attestation.nextReverificationAt) return false;
+  const next = Date.parse(attestation.nextReverificationAt);
+  const now = Date.parse(generatedAt);
+  return Number.isFinite(next) && Number.isFinite(now) && next <= now;
+}
+
+function isCompletedActive(attestation: IdentityAssuranceAttestation, generatedAt: string) {
+  return (
+    attestation.status === "completed" &&
+    attestation.metadataOnly === true &&
+    attestation.rawSensitivePayloadStored === false &&
+    !attestation.revokedAt &&
+    attestation.lifecycleState !== "revoked" &&
+    !isExpired(attestation, generatedAt)
+  );
+}
+
+function highestLevel(attestations: IdentityAssuranceAttestation[], generatedAt: string): IdentityAssuranceLevel {
+  const active = attestations.filter((attestation) => isCompletedActive(attestation, generatedAt));
+  if (!active.length) return "not_assessed";
+  return active.reduce<IdentityAssuranceLevel>((level, attestation) => {
+    return LEVEL_RANK[attestation.level] > LEVEL_RANK[level] ? attestation.level : level;
+  }, "not_assessed");
+}
+
+function dominantProvider(attestations: IdentityAssuranceAttestation[], generatedAt: string): IdentityAssuranceProviderType {
+  return attestations.find((attestation) => isCompletedActive(attestation, generatedAt))?.providerType || "none";
+}
+
+function deriveStatus(attestations: IdentityAssuranceAttestation[], generatedAt: string): IdentityAssuranceStatus {
+  if (!attestations.length) return "not_started";
+  if (attestations.some((attestation) => attestation.status === "revoked" || attestation.revokedAt)) return "revoked";
+  if (attestations.some((attestation) => isExpired(attestation, generatedAt))) return "expired";
+  if (attestations.some((attestation) => attestation.status === "manual_review_required" || attestation.reviewRequired)) {
+    return "manual_review_required";
+  }
+  if (attestations.some((attestation) => attestation.status === "failed")) return "failed";
+  if (attestations.some((attestation) => isCompletedActive(attestation, generatedAt))) return "completed";
+  if (attestations.some((attestation) => attestation.status === "pending")) return "pending";
+  if (attestations.some((attestation) => attestation.status === "requested")) return "requested";
+  return "not_started";
+}
+
+function deriveLifecycle(
+  status: IdentityAssuranceStatus,
+  attestations: IdentityAssuranceAttestation[],
+  generatedAt: string
+): IdentityAssuranceLifecycleState {
+  if (status === "revoked") return "revoked";
+  if (status === "failed") return "failed";
+  if (status === "manual_review_required") return "manual_review_required";
+  if (status === "completed" && attestations.some((attestation) => isReverificationDue(attestation, generatedAt))) {
+    return "reverification_required";
+  }
+  if (status === "completed") return "completed";
+  if (status === "pending" || status === "requested") return "in_progress";
+  if (attestations.some((attestation) => !attestation.consentScope.consentId)) return "consent_required";
+  return "not_started";
+}
+
+function assuranceCopy(level: IdentityAssuranceLevel, lifecycleState: IdentityAssuranceLifecycleState) {
+  if (lifecycleState === "reverification_required") {
+    return {
+      assuranceLabel: "Reverification required",
+      assuranceDescription:
+        "Identity assurance metadata exists, but the subject needs a fresh provider or review workflow before institutional reliance.",
+    };
+  }
+  if (level === "institution_reviewed") {
+    return {
+      assuranceLabel: "Institution review recorded",
+      assuranceDescription:
+        "A scoped institution or approved operator review is recorded. It remains consent-scoped and does not authorize execution.",
+    };
+  }
+  if (level === "property_authority_attested") {
+    return {
+      assuranceLabel: "Property authority attestation present",
+      assuranceDescription:
+        "Provider-neutral property authority metadata is present. Raw ownership documents and provider payloads are not stored.",
+    };
+  }
+  if (level === "business_attested") {
+    return {
+      assuranceLabel: "Business attestation present",
+      assuranceDescription:
+        "Provider-neutral business assurance metadata is present. This is not a stored KYB payload.",
+    };
+  }
+  if (level === "provider_identity_attested") {
+    return {
+      assuranceLabel: "Identity assurance completed through approved workflow",
+      assuranceDescription:
+        "A provider-neutral identity attestation is present. RentChain stores metadata only, not raw identity documents.",
+    };
+  }
+  if (level === "platform_correlated") {
+    return {
+      assuranceLabel: "Platform-correlated identity signals",
+      assuranceDescription:
+        "RentChain operational records align, but this is not provider-grade identity assurance.",
+    };
+  }
+  if (level === "account_controlled") {
+    return {
+      assuranceLabel: "Account-control assurance only",
+      assuranceDescription:
+        "The subject has account or contact-channel control signals, but institutional identity assurance has not been completed.",
+    };
+  }
+  return {
+    assuranceLabel: "Identity assurance not started",
+    assuranceDescription:
+      "No provider-neutral identity assurance attestation is present. Existing onboarding remains unblocked.",
+  };
+}
+
+function eventDescriptor(params: {
+  eventType: IdentityAssuranceEventDescriptor["eventType"];
+  subjectType: IdentityAssuranceSubjectType;
+  subjectId: string;
+  status: IdentityAssuranceStatus;
+  level: IdentityAssuranceLevel;
+  summary: string;
+}): IdentityAssuranceEventDescriptor {
+  return {
+    eventType: params.eventType,
+    action: params.eventType.replace(/_/g, "."),
+    subjectType: params.subjectType,
+    subjectId: params.subjectId,
+    status: params.status,
+    level: params.level,
+    summary: params.summary,
+    metadataOnly: true,
+  };
+}
+
+function deriveEvents(params: {
+  subjectType: IdentityAssuranceSubjectType;
+  subjectId: string;
+  status: IdentityAssuranceStatus;
+  level: IdentityAssuranceLevel;
+  lifecycleState: IdentityAssuranceLifecycleState;
+  attestations: IdentityAssuranceAttestation[];
+}) {
+  const events: IdentityAssuranceEventDescriptor[] = [];
+  if (params.attestations.some((attestation) => attestation.status === "requested")) {
+    events.push(
+      eventDescriptor({
+        eventType: "identity_assurance_requested",
+        subjectType: params.subjectType,
+        subjectId: params.subjectId,
+        status: params.status,
+        level: params.level,
+        summary: "Identity assurance workflow has been requested.",
+      })
+    );
+  }
+  if (params.attestations.some((attestation) => attestation.status === "pending")) {
+    events.push(
+      eventDescriptor({
+        eventType: "identity_assurance_started",
+        subjectType: params.subjectType,
+        subjectId: params.subjectId,
+        status: params.status,
+        level: params.level,
+        summary: "Identity assurance workflow has started and remains metadata-only.",
+      })
+    );
+  }
+  if (params.status === "completed" || params.lifecycleState === "reverification_required") {
+    events.push(
+      eventDescriptor({
+        eventType: "identity_assurance_completed",
+        subjectType: params.subjectType,
+        subjectId: params.subjectId,
+        status: params.status,
+        level: params.level,
+        summary: "Identity assurance completed through a provider-neutral metadata workflow.",
+      })
+    );
+  }
+  if (params.status === "failed") {
+    events.push(
+      eventDescriptor({
+        eventType: "identity_assurance_failed",
+        subjectType: params.subjectType,
+        subjectId: params.subjectId,
+        status: params.status,
+        level: params.level,
+        summary: "Identity assurance workflow failed and requires review before reliance.",
+      })
+    );
+  }
+  if (params.status === "expired") {
+    events.push(
+      eventDescriptor({
+        eventType: "identity_assurance_expired",
+        subjectType: params.subjectType,
+        subjectId: params.subjectId,
+        status: params.status,
+        level: params.level,
+        summary: "Identity assurance metadata expired.",
+      })
+    );
+  }
+  if (params.status === "revoked") {
+    events.push(
+      eventDescriptor({
+        eventType: "identity_assurance_revoked",
+        subjectType: params.subjectType,
+        subjectId: params.subjectId,
+        status: params.status,
+        level: params.level,
+        summary: "Identity assurance metadata was revoked.",
+      })
+    );
+  }
+  if (params.lifecycleState === "reverification_required") {
+    events.push(
+      eventDescriptor({
+        eventType: "identity_assurance_reverification_required",
+        subjectType: params.subjectType,
+        subjectId: params.subjectId,
+        status: params.status,
+        level: params.level,
+        summary: "Identity assurance reverification is required before institutional reliance.",
+      })
+    );
+  }
+  return events;
+}
+
+function nextReverificationAt(attestations: IdentityAssuranceAttestation[]) {
+  const values = attestations
+    .map((attestation) => attestation.nextReverificationAt)
+    .filter((value): value is string => Boolean(value))
+    .sort();
+  return values[0] || null;
+}
+
+function toSupportAttestation(attestation: IdentityAssuranceAttestation) {
+  return {
+    attestationId: attestation.attestationId,
+    level: attestation.level,
+    status: attestation.status,
+    lifecycleState: attestation.lifecycleState,
+    providerType: attestation.providerType,
+    providerKey: attestation.providerKey,
+    providerReferenceRedacted: redactIdentifier(attestation.providerReferenceId),
+    evidenceRefRedacted: redactIdentifier(attestation.evidenceRef),
+    consentPurpose: attestation.consentScope.purpose,
+    retentionClass: attestation.retentionClass,
+    completedAt: attestation.completedAt,
+    expiresAt: attestation.expiresAt,
+    nextReverificationAt: attestation.nextReverificationAt,
+    reviewRequired: attestation.reviewRequired,
+  };
+}
+
+export function deriveIdentityAssuranceSummary(
+  input: DeriveIdentityAssuranceSummaryInput
+): IdentityAssuranceSummary {
+  const subjectType = requestedSubjectType(input.subjectType);
+  const subjectId = safeSubjectId(subjectType, input.subjectId);
+  const generatedAt = asString(input.generatedAt, 120) || new Date(0).toISOString();
+  const attestations = Array.isArray(input.attestations)
+    ? input.attestations.filter(
+        (attestation) =>
+          attestation.metadataOnly === true &&
+          attestation.rawSensitivePayloadStored === false &&
+          attestation.publicShareable === false
+      )
+    : [];
+  const status = deriveStatus(attestations, generatedAt);
+  const level = highestLevel(attestations, generatedAt);
+  const lifecycleState = deriveLifecycle(status, attestations, generatedAt);
+  const copy = assuranceCopy(level, lifecycleState);
+  const completedAttestations = attestations.filter((attestation) => isCompletedActive(attestation, generatedAt));
+  const reviewReasons = attestations
+    .filter((attestation) => attestation.reviewRequired || attestation.status === "manual_review_required")
+    .map((attestation) => `${attestation.level} requires manual review.`);
+
+  return {
+    subjectType,
+    subjectId,
+    status,
+    level,
+    lifecycleState,
+    assuranceLabel: copy.assuranceLabel,
+    assuranceDescription: copy.assuranceDescription,
+    providerCategory: dominantProvider(attestations, generatedAt),
+    consentRequired: true,
+    consentAvailable: attestations.some((attestation) => Boolean(attestation.consentScope.consentId)),
+    retentionClass: attestations[0]?.retentionClass || "assurance_metadata",
+    metadataOnly: true,
+    rawSensitivePayloadStored: false,
+    providerIntegrationEnabled: false,
+    onboardingBlocking: false,
+    publicShareable: false,
+    executionEligible: false,
+    reverificationRequired: lifecycleState === "reverification_required",
+    nextReverificationAt: nextReverificationAt(attestations),
+    signalSummary: {
+      totalAttestations: attestations.length,
+      completedAttestations: completedAttestations.length,
+      pendingAttestations: attestations.filter((attestation) => attestation.status === "pending" || attestation.status === "requested").length,
+      failedAttestations: attestations.filter((attestation) => attestation.status === "failed").length,
+      expiredAttestations: attestations.filter((attestation) => isExpired(attestation, generatedAt)).length,
+      revokedAttestations: attestations.filter((attestation) => attestation.status === "revoked" || Boolean(attestation.revokedAt)).length,
+      reviewRequiredAttestations: attestations.filter((attestation) => attestation.reviewRequired || attestation.status === "manual_review_required").length,
+    },
+    supportSummary: {
+      visibleToSupport: true,
+      rawProviderPayloadVisible: false,
+      rawIdentityDocumentVisible: false,
+      biometricPayloadVisible: false,
+      identityDocumentNumberVisible: false,
+      attestations: attestations.filter((attestation) => attestation.supportVisible).map(toSupportAttestation),
+    },
+    redactions: REDACTIONS,
+    reviewReasons,
+    canonicalEvents: deriveEvents({
+      subjectType,
+      subjectId,
+      status,
+      level,
+      lifecycleState,
+      attestations,
+    }),
+    generatedAt,
+  };
+}
+
+function accountTrustSubjectType(subjectType: IdentityAssuranceSubjectType): AccountTrustSubjectType {
+  if (subjectType === "property") return "property";
+  if (subjectType === "organization" || subjectType === "business_entity") return "organization";
+  if (subjectType === "property_operator") return "operator";
+  return subjectType;
+}
+
+function signalTypeForLevel(level: IdentityAssuranceLevel): VerificationSignal["signalType"] {
+  if (level === "business_attested") return "business";
+  if (level === "property_authority_attested") return "property";
+  if (level === "institution_reviewed") return "institution";
+  return "identity";
+}
+
+export function identityAssuranceSignalsFromAttestations(params: {
+  attestations?: IdentityAssuranceAttestation[] | null;
+  generatedAt?: unknown;
+}): VerificationSignal[] {
+  const generatedAt = asString(params.generatedAt, 120) || new Date(0).toISOString();
+  return (params.attestations || [])
+    .filter((attestation) => isCompletedActive(attestation, generatedAt))
+    .map((attestation) =>
+      verificationSignal({
+        signalType: signalTypeForLevel(attestation.level),
+        subjectType: accountTrustSubjectType(attestation.subjectType),
+        subjectId: attestation.subjectId.replace(/^[^:]+:/, "") || "unknown",
+        status: "verified",
+        source: attestation.providerType === "institution_review" ? "institution_review" : "future_identity_provider",
+        evidenceType: "provider_reference",
+        confidence: attestation.confidence,
+        providerKey: attestation.providerKey || attestation.providerType,
+        evidenceRef: `identity_assurance:${attestation.attestationId}`,
+        issuedAt: attestation.issuedAt,
+        verifiedAt: attestation.completedAt,
+        expiresAt: attestation.expiresAt,
+        revokedAt: attestation.revokedAt,
+        reviewRequired: attestation.reviewRequired,
+      })
+    );
+}

--- a/rentchain-api/src/lib/identityAssurance/identityAssuranceTypes.ts
+++ b/rentchain-api/src/lib/identityAssurance/identityAssuranceTypes.ts
@@ -1,0 +1,190 @@
+export type IdentityAssuranceSubjectType =
+  | "tenant"
+  | "landlord"
+  | "applicant"
+  | "property_operator"
+  | "business_entity"
+  | "organization"
+  | "property";
+
+export type IdentityAssuranceLevel =
+  | "not_assessed"
+  | "account_controlled"
+  | "platform_correlated"
+  | "provider_identity_attested"
+  | "business_attested"
+  | "property_authority_attested"
+  | "institution_reviewed";
+
+export type IdentityAssuranceStatus =
+  | "not_started"
+  | "requested"
+  | "pending"
+  | "completed"
+  | "failed"
+  | "expired"
+  | "revoked"
+  | "manual_review_required";
+
+export type IdentityAssuranceLifecycleState =
+  | "not_started"
+  | "consent_required"
+  | "ready_to_start"
+  | "in_progress"
+  | "completed"
+  | "reverification_required"
+  | "manual_review_required"
+  | "failed"
+  | "revoked";
+
+export type IdentityAssuranceProviderType =
+  | "none"
+  | "identity_provider"
+  | "business_verification_provider"
+  | "property_registry"
+  | "financial_identity_provider"
+  | "government_digital_credential"
+  | "institution_review"
+  | "operator_review"
+  | "future_provider";
+
+export type IdentityAssuranceConsentPurpose =
+  | "identity_assurance"
+  | "business_assurance"
+  | "property_authority"
+  | "institutional_export"
+  | "support_review"
+  | "future_provider_orchestration";
+
+export type IdentityAssuranceConsentScope = {
+  consentId: string | null;
+  purpose: IdentityAssuranceConsentPurpose;
+  grantedAt: string | null;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  institutionRecipientType: "none" | "landlord" | "insurer" | "lender" | "government" | "auditor" | "future_institution";
+  attributeScopes: string[];
+};
+
+export type IdentityAssuranceRetentionClass =
+  | "assurance_metadata"
+  | "provider_reference"
+  | "support_diagnostics"
+  | "audit_record";
+
+export type IdentityAssuranceAttestation = {
+  attestationId: string;
+  subjectType: IdentityAssuranceSubjectType;
+  subjectId: string;
+  level: IdentityAssuranceLevel;
+  status: IdentityAssuranceStatus;
+  lifecycleState: IdentityAssuranceLifecycleState;
+  providerType: IdentityAssuranceProviderType;
+  providerKey: string | null;
+  providerReferenceId: string | null;
+  evidenceRef: string | null;
+  confidence: "low" | "medium" | "high";
+  consentScope: IdentityAssuranceConsentScope;
+  retentionClass: IdentityAssuranceRetentionClass;
+  issuedAt: string | null;
+  completedAt: string | null;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  nextReverificationAt: string | null;
+  auditEventRef: string | null;
+  metadataOnly: true;
+  rawSensitivePayloadStored: false;
+  supportVisible: boolean;
+  publicShareable: false;
+  reviewRequired: boolean;
+  redacted: boolean;
+};
+
+export type IdentityAssuranceEventType =
+  | "identity_assurance_requested"
+  | "identity_assurance_started"
+  | "identity_assurance_completed"
+  | "identity_assurance_failed"
+  | "identity_assurance_expired"
+  | "identity_assurance_revoked"
+  | "identity_assurance_reverification_required";
+
+export type IdentityAssuranceEventDescriptor = {
+  eventType: IdentityAssuranceEventType;
+  action: string;
+  subjectType: IdentityAssuranceSubjectType;
+  subjectId: string;
+  status: IdentityAssuranceStatus;
+  level: IdentityAssuranceLevel;
+  summary: string;
+  metadataOnly: true;
+};
+
+export type IdentityAssuranceSupportAttestationSummary = {
+  attestationId: string;
+  level: IdentityAssuranceLevel;
+  status: IdentityAssuranceStatus;
+  lifecycleState: IdentityAssuranceLifecycleState;
+  providerType: IdentityAssuranceProviderType;
+  providerKey: string | null;
+  providerReferenceRedacted: string | null;
+  evidenceRefRedacted: string | null;
+  consentPurpose: IdentityAssuranceConsentPurpose;
+  retentionClass: IdentityAssuranceRetentionClass;
+  completedAt: string | null;
+  expiresAt: string | null;
+  nextReverificationAt: string | null;
+  reviewRequired: boolean;
+};
+
+export type IdentityAssuranceSupportSummary = {
+  visibleToSupport: true;
+  rawProviderPayloadVisible: false;
+  rawIdentityDocumentVisible: false;
+  biometricPayloadVisible: false;
+  identityDocumentNumberVisible: false;
+  attestations: IdentityAssuranceSupportAttestationSummary[];
+};
+
+export type IdentityAssuranceSummary = {
+  subjectType: IdentityAssuranceSubjectType;
+  subjectId: string;
+  status: IdentityAssuranceStatus;
+  level: IdentityAssuranceLevel;
+  lifecycleState: IdentityAssuranceLifecycleState;
+  assuranceLabel: string;
+  assuranceDescription: string;
+  providerCategory: IdentityAssuranceProviderType;
+  consentRequired: true;
+  consentAvailable: boolean;
+  retentionClass: IdentityAssuranceRetentionClass;
+  metadataOnly: true;
+  rawSensitivePayloadStored: false;
+  providerIntegrationEnabled: false;
+  onboardingBlocking: false;
+  publicShareable: false;
+  executionEligible: false;
+  reverificationRequired: boolean;
+  nextReverificationAt: string | null;
+  signalSummary: {
+    totalAttestations: number;
+    completedAttestations: number;
+    pendingAttestations: number;
+    failedAttestations: number;
+    expiredAttestations: number;
+    revokedAttestations: number;
+    reviewRequiredAttestations: number;
+  };
+  supportSummary: IdentityAssuranceSupportSummary;
+  redactions: string[];
+  reviewReasons: string[];
+  canonicalEvents: IdentityAssuranceEventDescriptor[];
+  generatedAt: string;
+};
+
+export type DeriveIdentityAssuranceSummaryInput = {
+  subjectType?: unknown;
+  subjectId?: unknown;
+  attestations?: IdentityAssuranceAttestation[] | null;
+  generatedAt?: unknown;
+};

--- a/rentchain-api/src/lib/identityAssurance/index.ts
+++ b/rentchain-api/src/lib/identityAssurance/index.ts
@@ -1,0 +1,2 @@
+export * from "./identityAssuranceTypes";
+export * from "./deriveIdentityAssuranceSummary";

--- a/rentchain-api/src/lib/identityLayer/__tests__/deriveIdentityProfile.test.ts
+++ b/rentchain-api/src/lib/identityLayer/__tests__/deriveIdentityProfile.test.ts
@@ -32,6 +32,14 @@ describe("deriveIdentityProfile", () => {
         executionEligible: false,
       })
     );
+    expect(profile.identityAssurance).toEqual(
+      expect.objectContaining({
+        status: "not_started",
+        level: "not_assessed",
+        rawSensitivePayloadStored: false,
+        onboardingBlocking: false,
+      })
+    );
     expect(profile.consentSummary.consentAvailable).toBe(true);
     expect(profile.reviewReferences).toHaveLength(1);
     expect(profile.canonicalEvents).toEqual(
@@ -112,5 +120,71 @@ describe("deriveIdentityProfile", () => {
     expect(serialized).not.toContain("sensitive-payment-account");
     expect(profile.redactions).toEqual(expect.arrayContaining(["Raw screening and credit bureau payloads are excluded."]));
     expect(profile.trustState.redactions).toEqual(expect.arrayContaining(["Raw government identity documents are excluded."]));
+  });
+
+  it("aligns provider-neutral identity assurance with account trust without exposing raw provider references", () => {
+    const profile = deriveIdentityProfile({
+      identityType: "tenant",
+      identityId: "tenant-assured",
+      generatedAt: "2026-05-08T00:00:00.000Z",
+      tenant: { id: "tenant-assured", createdAt: "2026-05-01T00:00:00.000Z" },
+      consentRecords: [{ id: "consent-assurance", scope: "identity assurance consent" }],
+      identityAssuranceAttestations: [
+        {
+          attestationId: "attestation-1",
+          subjectType: "tenant",
+          subjectId: "tenant-assured",
+          level: "provider_identity_attested",
+          status: "completed",
+          lifecycleState: "completed",
+          providerType: "identity_provider",
+          providerKey: "future_provider",
+          providerReferenceId: "provider-reference-sensitive",
+          evidenceRef: "evidence-reference-sensitive",
+          confidence: "high",
+          consentScope: {
+            consentId: "consent-assurance",
+            purpose: "identity_assurance",
+            grantedAt: "2026-05-01T00:00:00.000Z",
+            expiresAt: "2026-11-01T00:00:00.000Z",
+            revokedAt: null,
+            institutionRecipientType: "none",
+            attributeScopes: ["identity_status", "assurance_level"],
+          },
+          retentionClass: "provider_reference",
+          issuedAt: "2026-05-01T00:00:00.000Z",
+          completedAt: "2026-05-01T00:10:00.000Z",
+          expiresAt: "2026-11-01T00:00:00.000Z",
+          revokedAt: null,
+          nextReverificationAt: "2026-10-01T00:00:00.000Z",
+          auditEventRef: "event-1",
+          metadataOnly: true,
+          rawSensitivePayloadStored: false,
+          supportVisible: true,
+          publicShareable: false,
+          reviewRequired: false,
+          redacted: false,
+        },
+      ],
+    });
+
+    expect(profile.identityAssurance).toEqual(
+      expect.objectContaining({
+        status: "completed",
+        level: "provider_identity_attested",
+        providerIntegrationEnabled: false,
+        onboardingBlocking: false,
+        publicShareable: false,
+      })
+    );
+    expect(profile.trustState.trustLevel).toBe("provider_attested");
+    expect(profile.identityAssurance.supportSummary.attestations[0]).toEqual(
+      expect.objectContaining({
+        providerReferenceRedacted: "***tive",
+        evidenceRefRedacted: "***tive",
+      })
+    );
+    expect(JSON.stringify(profile)).not.toContain("provider-reference-sensitive");
+    expect(JSON.stringify(profile)).not.toContain("evidence-reference-sensitive");
   });
 });

--- a/rentchain-api/src/lib/identityLayer/deriveIdentityProfile.ts
+++ b/rentchain-api/src/lib/identityLayer/deriveIdentityProfile.ts
@@ -7,6 +7,10 @@ import type {
   IdentityLayerType,
 } from "./identityLayerTypes";
 import { deriveAccountTrustState, verificationSignal, type VerificationSignal } from "../accountTrust";
+import {
+  deriveIdentityAssuranceSummary,
+  identityAssuranceSignalsFromAttestations,
+} from "../identityAssurance";
 import { consentReference } from "./identityConsentModels";
 import { identityReference, isVerifiedReference } from "./identityVerificationModels";
 
@@ -372,17 +376,29 @@ export function deriveIdentityProfile(input: DeriveIdentityProfileInput): Identi
   const portabilityStatus = status === "verified" ? "ready" : verifiedReferences > 0 ? "limited" : "not_ready";
   const generatedAt = asString(input.generatedAt, 120) || new Date(0).toISOString();
   const lineageReferences = [...verificationReferences, ...consentReferences, ...reviewReferences, ...eventReferences];
+  const identityAssurance = deriveIdentityAssuranceSummary({
+    subjectType: trustSubjectType(identityType),
+    subjectId: identityId.replace(/^[^:]+:/, "") || "unknown",
+    attestations: input.identityAssuranceAttestations || [],
+    generatedAt,
+  });
   const trustState = deriveAccountTrustState({
     subjectType: trustSubjectType(identityType),
     subjectId: identityId.replace(/^[^:]+:/, "") || "unknown",
     generatedAt,
-    signals: trustSignals({
-      identityType,
-      identityId,
-      sourceRecord,
-      verificationReferences,
-      reviewReferences,
-    }),
+    signals: [
+      ...trustSignals({
+        identityType,
+        identityId,
+        sourceRecord,
+        verificationReferences,
+        reviewReferences,
+      }),
+      ...identityAssuranceSignalsFromAttestations({
+        attestations: input.identityAssuranceAttestations || [],
+        generatedAt,
+      }),
+    ],
   });
 
   const canonicalEvents: IdentityLayerCanonicalEvent[] = [
@@ -466,6 +482,7 @@ export function deriveIdentityProfile(input: DeriveIdentityProfileInput): Identi
       blockedReasons: portabilityStatus === "not_ready" ? ["Identity portability requires verified references."] : [],
     },
     trustState,
+    identityAssurance,
     lineageReferences,
     verificationReferences,
     consentReferences,

--- a/rentchain-api/src/lib/identityLayer/identityLayerTypes.ts
+++ b/rentchain-api/src/lib/identityLayer/identityLayerTypes.ts
@@ -1,3 +1,6 @@
+import type { AccountTrustStateSummary } from "../accountTrust";
+import type { IdentityAssuranceAttestation, IdentityAssuranceSummary } from "../identityAssurance";
+
 export type IdentityLayerType = "tenant" | "property" | "organization" | "operator" | "review_actor";
 
 export type IdentityLayerStatus = "verified" | "partially_verified" | "review_required" | "blocked" | "unknown";
@@ -64,6 +67,7 @@ export type IdentityLayerProfile = {
     blockedReasons: string[];
   };
   trustState: AccountTrustStateSummary;
+  identityAssurance: IdentityAssuranceSummary;
   lineageReferences: IdentityLayerReference[];
   verificationReferences: IdentityLayerReference[];
   consentReferences: IdentityLayerReference[];
@@ -86,5 +90,5 @@ export type DeriveIdentityProfileInput = {
   reviewSessions?: Array<Record<string, unknown>> | null;
   canonicalEvents?: Array<Record<string, unknown>> | null;
   consentRecords?: Array<Record<string, unknown>> | null;
+  identityAssuranceAttestations?: IdentityAssuranceAttestation[] | null;
 };
-import type { AccountTrustStateSummary } from "../accountTrust";

--- a/rentchain-frontend/src/api/identityLayerApi.ts
+++ b/rentchain-frontend/src/api/identityLayerApi.ts
@@ -100,6 +100,114 @@ export type AccountTrustStateSummary = {
   generatedAt: string;
 };
 
+export type IdentityAssuranceLevel =
+  | "not_assessed"
+  | "account_controlled"
+  | "platform_correlated"
+  | "provider_identity_attested"
+  | "business_attested"
+  | "property_authority_attested"
+  | "institution_reviewed";
+
+export type IdentityAssuranceStatus =
+  | "not_started"
+  | "requested"
+  | "pending"
+  | "completed"
+  | "failed"
+  | "expired"
+  | "revoked"
+  | "manual_review_required";
+
+export type IdentityAssuranceLifecycleState =
+  | "not_started"
+  | "consent_required"
+  | "ready_to_start"
+  | "in_progress"
+  | "completed"
+  | "reverification_required"
+  | "manual_review_required"
+  | "failed"
+  | "revoked";
+
+export type IdentityAssuranceProviderType =
+  | "none"
+  | "identity_provider"
+  | "business_verification_provider"
+  | "property_registry"
+  | "financial_identity_provider"
+  | "government_digital_credential"
+  | "institution_review"
+  | "operator_review"
+  | "future_provider";
+
+export type IdentityAssuranceSummary = {
+  subjectType: "tenant" | "landlord" | "applicant" | "property_operator" | "business_entity" | "organization" | "property";
+  subjectId: string;
+  status: IdentityAssuranceStatus;
+  level: IdentityAssuranceLevel;
+  lifecycleState: IdentityAssuranceLifecycleState;
+  assuranceLabel: string;
+  assuranceDescription: string;
+  providerCategory: IdentityAssuranceProviderType;
+  consentRequired: true;
+  consentAvailable: boolean;
+  retentionClass: "assurance_metadata" | "provider_reference" | "support_diagnostics" | "audit_record";
+  metadataOnly: true;
+  rawSensitivePayloadStored: false;
+  providerIntegrationEnabled: false;
+  onboardingBlocking: false;
+  publicShareable: false;
+  executionEligible: false;
+  reverificationRequired: boolean;
+  nextReverificationAt: string | null;
+  signalSummary: {
+    totalAttestations: number;
+    completedAttestations: number;
+    pendingAttestations: number;
+    failedAttestations: number;
+    expiredAttestations: number;
+    revokedAttestations: number;
+    reviewRequiredAttestations: number;
+  };
+  supportSummary: {
+    visibleToSupport: true;
+    rawProviderPayloadVisible: false;
+    rawIdentityDocumentVisible: false;
+    biometricPayloadVisible: false;
+    identityDocumentNumberVisible: false;
+    attestations: Array<{
+      attestationId: string;
+      level: IdentityAssuranceLevel;
+      status: IdentityAssuranceStatus;
+      lifecycleState: IdentityAssuranceLifecycleState;
+      providerType: IdentityAssuranceProviderType;
+      providerKey: string | null;
+      providerReferenceRedacted: string | null;
+      evidenceRefRedacted: string | null;
+      consentPurpose: string;
+      retentionClass: string;
+      completedAt: string | null;
+      expiresAt: string | null;
+      nextReverificationAt: string | null;
+      reviewRequired: boolean;
+    }>;
+  };
+  redactions: string[];
+  reviewReasons: string[];
+  canonicalEvents: Array<{
+    eventType: string;
+    action: string;
+    subjectType: string;
+    subjectId: string;
+    status: IdentityAssuranceStatus;
+    level: IdentityAssuranceLevel;
+    summary: string;
+    metadataOnly: true;
+  }>;
+  generatedAt: string;
+};
+
 export type IdentityLayerProfile = {
   identityId: string;
   identityType: IdentityLayerType;
@@ -126,6 +234,7 @@ export type IdentityLayerProfile = {
     blockedReasons: string[];
   };
   trustState: AccountTrustStateSummary;
+  identityAssurance: IdentityAssuranceSummary;
   lineageReferences: IdentityLayerReference[];
   verificationReferences: IdentityLayerReference[];
   consentReferences: IdentityLayerReference[];

--- a/rentchain-frontend/src/components/identity/IdentityProfilePanel.tsx
+++ b/rentchain-frontend/src/components/identity/IdentityProfilePanel.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import type { IdentityLayerProfile, IdentityLayerReference } from "@/api/identityLayerApi";
+import type { IdentityAssuranceSummary, IdentityLayerProfile, IdentityLayerReference } from "@/api/identityLayerApi";
 import { Card, Section } from "@/components/ui/Ui";
 
 function label(value: string) {
@@ -39,6 +39,56 @@ function Badge({ children, status }: { children: React.ReactNode; status: string
   );
 }
 
+function assuranceSubjectType(profile: IdentityLayerProfile): IdentityAssuranceSummary["subjectType"] {
+  if (profile.trustState.subjectType === "operator") return "property_operator";
+  return profile.trustState.subjectType;
+}
+
+function defaultIdentityAssurance(profile: IdentityLayerProfile): IdentityAssuranceSummary {
+  return {
+    subjectType: assuranceSubjectType(profile),
+    subjectId: profile.trustState.subjectId,
+    status: "not_started",
+    level: "not_assessed",
+    lifecycleState: "not_started",
+    assuranceLabel: "Identity assurance not started",
+    assuranceDescription: "No provider-neutral identity assurance attestation is present. Existing onboarding remains unblocked.",
+    providerCategory: "none",
+    consentRequired: true,
+    consentAvailable: false,
+    retentionClass: "assurance_metadata",
+    metadataOnly: true,
+    rawSensitivePayloadStored: false,
+    providerIntegrationEnabled: false,
+    onboardingBlocking: false,
+    publicShareable: false,
+    executionEligible: false,
+    reverificationRequired: false,
+    nextReverificationAt: null,
+    signalSummary: {
+      totalAttestations: 0,
+      completedAttestations: 0,
+      pendingAttestations: 0,
+      failedAttestations: 0,
+      expiredAttestations: 0,
+      revokedAttestations: 0,
+      reviewRequiredAttestations: 0,
+    },
+    supportSummary: {
+      visibleToSupport: true,
+      rawProviderPayloadVisible: false,
+      rawIdentityDocumentVisible: false,
+      biometricPayloadVisible: false,
+      identityDocumentNumberVisible: false,
+      attestations: [],
+    },
+    redactions: [],
+    reviewReasons: [],
+    canonicalEvents: [],
+    generatedAt: profile.generatedAt,
+  };
+}
+
 function ReferenceList({ title, references }: { title: string; references: IdentityLayerReference[] }) {
   return (
     <Section style={{ display: "grid", gap: 10 }}>
@@ -74,6 +124,8 @@ function ReferenceList({ title, references }: { title: string; references: Ident
 }
 
 export function IdentityProfilePanel({ profile }: { profile: IdentityLayerProfile }) {
+  const identityAssurance = profile.identityAssurance || defaultIdentityAssurance(profile);
+
   return (
     <div style={{ display: "grid", gap: 16 }}>
       <Section style={{ display: "grid", gap: 10 }}>
@@ -146,6 +198,64 @@ export function IdentityProfilePanel({ profile }: { profile: IdentityLayerProfil
           {profile.trustState.missingSignals.length ? (
             <div style={{ color: "#92400e", fontSize: 13, marginTop: 10 }}>
               Missing trust signals: {profile.trustState.missingSignals.map(label).join(", ")}.
+            </div>
+          ) : null}
+        </Card>
+      </Section>
+
+      <Section style={{ display: "grid", gap: 10 }}>
+        <div style={{ fontWeight: 900 }}>Identity assurance</div>
+        <Card style={{ borderRadius: 8, padding: 12 }}>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+            <div>
+              <strong>{identityAssurance.assuranceLabel}</strong>
+              <div style={{ color: "#475569", fontSize: 13, marginTop: 4, lineHeight: 1.5 }}>
+                {identityAssurance.assuranceDescription}
+              </div>
+            </div>
+            <Badge status={identityAssurance.status}>{label(identityAssurance.status)}</Badge>
+          </div>
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginTop: 12 }}>
+            <Badge status={identityAssurance.level}>{label(identityAssurance.level)}</Badge>
+            <Badge status={identityAssurance.providerCategory}>{label(identityAssurance.providerCategory)}</Badge>
+            <Badge status={identityAssurance.consentAvailable ? "available" : "review_required"}>
+              {identityAssurance.consentAvailable ? "Consent recorded" : "Consent required"}
+            </Badge>
+            <Badge status={identityAssurance.rawSensitivePayloadStored ? "blocked" : "available"}>Assurance metadata only</Badge>
+            <Badge status={identityAssurance.onboardingBlocking ? "blocked" : "available"}>Onboarding unblocked</Badge>
+          </div>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(130px, 1fr))", gap: 8, marginTop: 12 }}>
+            {[
+              ["Attestations", identityAssurance.signalSummary.totalAttestations],
+              ["Completed", identityAssurance.signalSummary.completedAttestations],
+              ["Pending", identityAssurance.signalSummary.pendingAttestations],
+              ["Needs review", identityAssurance.signalSummary.reviewRequiredAttestations],
+            ].map(([name, value]) => (
+              <div key={String(name)} style={{ border: "1px solid #e2e8f0", borderRadius: 8, padding: 10 }}>
+                <div style={{ color: "#64748b", fontSize: 12, fontWeight: 800 }}>{name}</div>
+                <strong style={{ color: "#0f172a", fontSize: 18 }}>{String(value)}</strong>
+              </div>
+            ))}
+          </div>
+          {identityAssurance.nextReverificationAt ? (
+            <div style={{ color: "#92400e", fontSize: 13, marginTop: 10 }}>
+              Reverification date: {identityAssurance.nextReverificationAt}
+            </div>
+          ) : null}
+          {identityAssurance.supportSummary.attestations.length ? (
+            <div style={{ display: "grid", gap: 8, marginTop: 12 }}>
+              {identityAssurance.supportSummary.attestations.map((attestation) => (
+                <div key={attestation.attestationId} style={{ border: "1px solid #e2e8f0", borderRadius: 8, padding: 10 }}>
+                  <div style={{ display: "flex", justifyContent: "space-between", gap: 8, flexWrap: "wrap" }}>
+                    <strong>{label(attestation.level)}</strong>
+                    <Badge status={attestation.lifecycleState}>{label(attestation.lifecycleState)}</Badge>
+                  </div>
+                  <div style={{ color: "#64748b", fontSize: 13, marginTop: 6 }}>
+                    Provider: {label(attestation.providerType)}
+                    {attestation.providerReferenceRedacted ? ` · Ref ${attestation.providerReferenceRedacted}` : ""}
+                  </div>
+                </div>
+              ))}
             </div>
           ) : null}
         </Card>

--- a/rentchain-frontend/src/pages/IdentityLayerPage.test.tsx
+++ b/rentchain-frontend/src/pages/IdentityLayerPage.test.tsx
@@ -85,6 +85,48 @@ function profile() {
       canonicalEvents: [],
       generatedAt: "2026-05-06T00:00:00.000Z",
     },
+    identityAssurance: {
+      subjectType: "tenant",
+      subjectId: "tenant:tenant-1",
+      status: "not_started",
+      level: "not_assessed",
+      lifecycleState: "not_started",
+      assuranceLabel: "Identity assurance not started",
+      assuranceDescription: "No provider-neutral identity assurance attestation is present. Existing onboarding remains unblocked.",
+      providerCategory: "none",
+      consentRequired: true,
+      consentAvailable: false,
+      retentionClass: "assurance_metadata",
+      metadataOnly: true,
+      rawSensitivePayloadStored: false,
+      providerIntegrationEnabled: false,
+      onboardingBlocking: false,
+      publicShareable: false,
+      executionEligible: false,
+      reverificationRequired: false,
+      nextReverificationAt: null,
+      signalSummary: {
+        totalAttestations: 0,
+        completedAttestations: 0,
+        pendingAttestations: 0,
+        failedAttestations: 0,
+        expiredAttestations: 0,
+        revokedAttestations: 0,
+        reviewRequiredAttestations: 0,
+      },
+      supportSummary: {
+        visibleToSupport: true,
+        rawProviderPayloadVisible: false,
+        rawIdentityDocumentVisible: false,
+        biometricPayloadVisible: false,
+        identityDocumentNumberVisible: false,
+        attestations: [],
+      },
+      redactions: ["Raw provider identity payloads are excluded."],
+      reviewReasons: [],
+      canonicalEvents: [],
+      generatedAt: "2026-05-06T00:00:00.000Z",
+    },
     lineageReferences: [],
     verificationReferences: [
       {
@@ -129,6 +171,9 @@ describe("IdentityLayerPage", () => {
     expect(screen.getByDisplayValue("tenant-1")).toBeInTheDocument();
     expect(screen.getByText("View verification lineage")).toBeInTheDocument();
     expect(screen.getByText("Account trust state")).toBeInTheDocument();
+    expect(screen.getByText("Identity assurance")).toBeInTheDocument();
+    expect(screen.getByText("Identity assurance not started")).toBeInTheDocument();
+    expect(screen.getByText("Onboarding unblocked")).toBeInTheDocument();
     expect(screen.getByText("Payment account details are excluded.")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /publish identity|share publicly|mint token|export identity publicly|autonomous verification|approve identity automatically/i })).not.toBeInTheDocument();
     expect(apiMocks.fetchIdentityLayerProfile).toHaveBeenCalledWith({ identityType: "tenant", identityId: "tenant-1" });


### PR DESCRIPTION
## Summary
- Adds a provider-neutral institutional identity assurance framework with metadata-only attestation types, lifecycle/status levels, consent scope, retention class, support-safe summaries, and metadata-only event descriptors.
- Conservatively aligns completed active identity assurance attestations with existing account trust signals without exposing raw provider references.
- Adds identity assurance summaries to identity-layer profiles and displays conservative labels in the identity layer UI.
- Documents the framework boundaries in `docs/architecture/institutional-identity-assurance-framework-v1.md`.

## Audit Summary
- Existing `accountTrust` supports trust levels and metadata-only verification signals but not provider-neutral assurance lifecycle objects.
- Existing `identityLayer` profiles are operational/permission-scoped and include trust state, consent lineage, review lineage, and redactions.
- Existing tenant portability/share/export systems summarize readiness and consent controls but do not expose provider-grade identity assurance.
- Governance utilities already enforce metadata-only redaction and retention patterns; this framework reuses those boundaries.

## Scope Guardrails
- No live identity provider integration.
- No raw government ID, biometric, KYC/KYB/AML, screening-provider, or banking payload storage.
- No onboarding blockers.
- No public share-package exposure of assurance metadata.
- No permission, auth, banking, insurer/lender/subsidy, blockchain, or execution automation changes.

## Verification
- Backend targeted: `npm run test:single -- src/lib/identityAssurance/__tests__/deriveIdentityAssuranceSummary.test.ts src/lib/identityLayer/__tests__/deriveIdentityProfile.test.ts src/lib/accountTrust/__tests__/deriveAccountTrustState.test.ts src/lib/governance/__tests__/platformGovernance.test.ts`
- Frontend targeted: `npm run test:single -- src/components/identity/IdentityProfilePanel.test.tsx src/pages/IdentityLayerPage.test.tsx`
- Backend full: `npm run test` (rerun outside sandbox for Supertest listener binding) passed.
- Backend build: `npm run build` passed.
- Frontend full: `npm run test` passed.
- Frontend build: `npm run build` passed.
- `git diff --cached --check` passed.