### PR TITLE
Add portable attestation framework foundation

### DIFF
--- a/docs/architecture/portable-attestation-framework-v1.md
+++ b/docs/architecture/portable-attestation-framework-v1.md
@@ -1,0 +1,165 @@
+# Portable Attestation Framework v1
+
+Status: implemented foundation
+Branch: `feat/portable-attestation-framework-v1`
+Scope: provider-neutral metadata framework, no public exposure or institution integration
+
+## Implementation Audit Summary
+
+RentChain already had the core ingredients for portable trust but not a portable attestation contract:
+
+- `accountTrust` derives metadata-only account trust levels from verification signals.
+- `identityAssurance` describes provider-neutral identity/business/property assurance with consent, retention, expiry, revocation, reverification, and support-safe redaction.
+- `propertyTrust` describes business, property, registry-linkage, and operator-authority metadata without ownership conclusions.
+- `identityLayer` aggregates trust, assurance, property trust, consent, redaction, and lineage into internal read models.
+- tenant share packages provide token-gated summary sharing with package expiry/revocation, but not claim-level institutional attestations.
+- institution exports and sharing rooms are preview/review scaffolds with manual-only, non-public behavior.
+- governance utilities already provide metadata-only, retention, sensitivity, telemetry sanitization, and identifier redaction helpers.
+
+The gap was a missing claim-level portable schema that can express what may leave RentChain under explicit consent, recipient purpose, expiration, revocation, and strict minimization.
+
+## Portable Attestation Model
+
+The framework introduces `rentchain-api/src/lib/portableAttestations` with:
+
+- `PortableAttestation`
+- `PortableAttestationType`
+- `PortableAttestationSubjectType`
+- `PortableAttestationClaimCategory`
+- `PortableAttestationStatus`
+- `PortableAttestationLifecycleState`
+- `PortableAttestationConsentScope`
+- `PortableAttestationAudience`
+- `PortableAttestationRetentionClass`
+- `PortableAttestationEvidenceSummary`
+- `PortableAttestationExportSummary`
+- `PortableAttestationSupportSummary`
+
+Portable attestations are provider-neutral and metadata-only. They can reference existing trust sources such as account trust, identity assurance, property trust, legal document metadata, tenant share packages, institution exports, and sharing rooms without replacing those foundations.
+
+## Consent and Audience Scope
+
+Every export-ready portable summary requires:
+
+- claim-level consent id
+- granted timestamp
+- recipient audience
+- permitted purpose
+- claim category allowlist
+- optional consent expiry and revocation timestamps
+
+If consent is missing, expired, revoked, mismatched to the audience, or does not include the claim category, the attestation remains `pending_consent` and no export summary is produced.
+
+## Lifecycle
+
+Lifecycle is first-class:
+
+- active attestations become `export_ready`
+- missing consent becomes `consent_required`
+- expired attestations become `expired`
+- revoked attestations become `revoked`
+- superseded attestations become `superseded`
+- stale attestations become `reverification_required`
+- unsafe payload or unsupported-claim attempts become `blocked`
+
+Reverification-required summaries may still be projected so recipients can see that a previously present claim needs fresh review. Expired, revoked, superseded, blocked, and pending-consent claims are not export-ready.
+
+## Export-Safe Summaries
+
+`derivePortableAttestationSummary` produces export-safe summaries only when all privacy and consent guards pass.
+
+Export summaries include:
+
+- schema version
+- attestation type
+- subject type and scoped subject id
+- claim category, label, and description
+- status and lifecycle
+- issuer category
+- audience and permitted purpose
+- consent reference
+- retention class
+- evidence category and source system
+- timestamps
+- jurisdiction
+- redaction profile
+- non-authority disclaimers
+
+Export summaries do not include:
+
+- raw provider ids
+- raw evidence refs
+- raw provider payloads
+- support-console metadata
+- token hashes
+- internal governance notes
+- public access controls
+- external submission behavior
+
+## Support/Admin Separation
+
+Support summaries are separate from portable summaries. They may show:
+
+- lifecycle state
+- redacted consent/reference/source ids
+- source system
+- retention class
+- expiry, revocation, and reverification timestamps
+
+Support summaries explicitly mark:
+
+- raw provider payloads are not visible
+- raw evidence is not visible
+- support metadata is not portable
+
+This keeps support/admin diagnostics distinct from institution-readable payloads.
+
+## Trust-Source Alignment
+
+Portable attestations reference source systems through `PortableAttestationSourceReference` and `PortableAttestationEvidenceSummary`.
+
+Supported initial source systems:
+
+- `account_trust`
+- `identity_assurance`
+- `property_trust`
+- `legal_document`
+- `tenant_share_package`
+- `institution_export`
+- `sharing_room`
+
+The source reference exists for audit alignment. Raw source identifiers are redacted from support summaries and excluded from export summaries.
+
+## Guardrails Preserved
+
+This framework does not:
+
+- expose attestations publicly
+- widen tenant share packages
+- add public profile pages
+- integrate institution APIs
+- integrate identity, business, registry, insurer, lender, subsidy, or government providers
+- add blockchain, tokenization, or verifiable credential protocols
+- create reputation scores
+- automate institutional decisions
+- create ownership, identity, creditworthiness, subsidy, or approval conclusions
+
+## Regression Risks
+
+- Future adoption could accidentally add portable attestations to existing share payloads without a policy gate.
+- Broad "verified" copy in other surfaces can still be overread unless future integrations use the portable schema language.
+- Institution-specific packet signing, revocation notification, and recipient policy matrices remain future work.
+- Property authority attestations must continue to carry non-ownership disclaimers.
+
+## Verification
+
+Tests cover:
+
+- model validation through typed fixtures
+- consent-scoped export summaries
+- pending consent behavior
+- revocation, expiration, and reverification lifecycle
+- raw payload and unsupported-claim blocking
+- internal/support metadata separation
+- raw source/provider/reference exclusion from export summaries
+- source alignment with identity assurance and property trust foundations

--- a/rentchain-api/src/lib/portableAttestations/__tests__/derivePortableAttestationSummary.test.ts
+++ b/rentchain-api/src/lib/portableAttestations/__tests__/derivePortableAttestationSummary.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it } from "vitest";
+import { derivePortableAttestationSummary, type PortableAttestation } from "../index";
+
+function attestation(overrides: Partial<PortableAttestation> = {}): PortableAttestation {
+  return {
+    attestationId: "portable-attestation-1",
+    attestationType: "identity_assurance",
+    subjectType: "tenant",
+    subjectId: "tenant:tenant-1",
+    claimCategory: "identity_assurance",
+    claimLabel: "Identity assurance metadata present",
+    claimDescription: "Identity assurance metadata is present through an approved workflow.",
+    status: "active",
+    lifecycleState: "export_ready",
+    issuerCategory: "identity_provider",
+    audience: "insurer",
+    consentScope: {
+      consentId: "consent-portable-1",
+      purpose: "insurance_review",
+      audience: "insurer",
+      grantedAt: "2026-05-01T00:00:00.000Z",
+      expiresAt: "2026-08-01T00:00:00.000Z",
+      revokedAt: null,
+      claimCategories: ["identity_assurance"],
+      attributeScopes: ["assurance_level", "status", "timestamps"],
+    },
+    retentionClass: "portable_metadata",
+    evidenceSummary: {
+      evidenceCategory: "provider_reference",
+      sourceSystem: "identity_assurance",
+      sourceCategory: "provider_neutral_identity_assurance",
+      sourceVersion: "identity_assurance.v1",
+      auditEventRef: "audit-event-sensitive",
+      rawEvidenceIncluded: false,
+    },
+    sourceReference: {
+      sourceSystem: "identity_assurance",
+      sourceId: "identity-assurance-source-sensitive",
+      sourceAttestationId: "identity-assurance-1",
+      sourceVersion: "identity_assurance.v1",
+    },
+    confidence: "high",
+    issuedAt: "2026-05-01T00:00:00.000Z",
+    effectiveAt: "2026-05-01T00:10:00.000Z",
+    expiresAt: "2026-08-01T00:00:00.000Z",
+    revokedAt: null,
+    supersededAt: null,
+    nextReverificationAt: "2026-07-01T00:00:00.000Z",
+    jurisdiction: "CA",
+    redactionProfile: "strict",
+    metadataOnly: true,
+    rawSensitivePayloadStored: false,
+    rawProviderPayloadIncluded: false,
+    supportMetadataIncluded: false,
+    publicAccessEnabled: false,
+    externalSubmissionEnabled: false,
+    unsupportedClaim: false,
+    supportVisible: true,
+    reviewRequired: false,
+    nonAuthorityDisclaimers: ["RentChain stores metadata only and is not the identity authority."],
+    internalReferenceId: "internal-reference-sensitive",
+    providerReferenceId: "provider-reference-sensitive",
+    ...overrides,
+  };
+}
+
+describe("derivePortableAttestationSummary", () => {
+  it("derives export-safe summaries only from consent-scoped metadata-only attestations", () => {
+    const summary = derivePortableAttestationSummary({
+      attestations: [attestation()],
+      generatedAt: "2026-05-08T00:00:00.000Z",
+    });
+
+    expect(summary.exportReady).toBe(true);
+    expect(summary.publicAccessEnabled).toBe(false);
+    expect(summary.externalSubmissionEnabled).toBe(false);
+    expect(summary.rawSensitivePayloadStored).toBe(false);
+    expect(summary.exportSummaries).toEqual([
+      expect.objectContaining({
+        schemaVersion: "portable_attestation.v1",
+        status: "active",
+        lifecycleState: "export_ready",
+        audience: "insurer",
+        permittedPurpose: "insurance_review",
+        consentReferenceId: "consent-portable-1",
+        metadataOnly: true,
+        rawEvidenceIncluded: false,
+        rawProviderPayloadIncluded: false,
+        supportMetadataIncluded: false,
+        publicAccessEnabled: false,
+      }),
+    ]);
+    expect(JSON.stringify(summary.exportSummaries)).not.toContain("provider-reference-sensitive");
+    expect(JSON.stringify(summary.exportSummaries)).not.toContain("internal-reference-sensitive");
+    expect(JSON.stringify(summary.exportSummaries)).not.toContain("identity-assurance-source-sensitive");
+  });
+
+  it("requires active claim-level consent before export portability", () => {
+    const summary = derivePortableAttestationSummary({
+      attestations: [
+        attestation({
+          consentScope: {
+            ...attestation().consentScope,
+            consentId: null,
+            grantedAt: null,
+          },
+        }),
+      ],
+      generatedAt: "2026-05-08T00:00:00.000Z",
+    });
+
+    expect(summary.exportReady).toBe(false);
+    expect(summary.exportSummaries).toHaveLength(0);
+    expect(summary.supportSummaries[0].status).toBe("pending_consent");
+    expect(summary.blockedReasons).toEqual([
+      "portable-attestation-1: active claim-level consent is required before portability.",
+    ]);
+  });
+
+  it("blocks raw payload, public exposure, support metadata, and unsupported claim attempts", () => {
+    const summary = derivePortableAttestationSummary({
+      attestations: [
+        attestation({ rawProviderPayloadIncluded: true as false }),
+        attestation({ attestationId: "public-attempt", publicAccessEnabled: true as false }),
+        attestation({ attestationId: "support-attempt", supportMetadataIncluded: true as false }),
+        attestation({ attestationId: "unsupported-claim", unsupportedClaim: true as false }),
+      ],
+      generatedAt: "2026-05-08T00:00:00.000Z",
+    });
+
+    expect(summary.exportReady).toBe(false);
+    expect(summary.exportSummaries).toHaveLength(0);
+    expect(summary.supportSummaries.map((item) => item.status)).toEqual(["blocked", "blocked", "blocked", "blocked"]);
+    expect(summary.blockedReasons).toEqual(
+      expect.arrayContaining([
+        "portable-attestation-1: portable attestation blocked by metadata-only/privacy guardrails.",
+        "public-attempt: portable attestation blocked by metadata-only/privacy guardrails.",
+        "support-attempt: portable attestation blocked by metadata-only/privacy guardrails.",
+        "unsupported-claim: portable attestation blocked by metadata-only/privacy guardrails.",
+      ])
+    );
+  });
+
+  it("derives revocation, expiration, and reverification lifecycle states", () => {
+    const summary = derivePortableAttestationSummary({
+      attestations: [
+        attestation({ attestationId: "revoked", revokedAt: "2026-05-02T00:00:00.000Z" }),
+        attestation({ attestationId: "expired", expiresAt: "2026-05-01T00:00:00.000Z" }),
+        attestation({
+          attestationId: "consent-revoked",
+          consentScope: {
+            ...attestation().consentScope,
+            revokedAt: "2026-05-02T00:00:00.000Z",
+          },
+        }),
+        attestation({
+          attestationId: "consent-expired",
+          consentScope: {
+            ...attestation().consentScope,
+            expiresAt: "2026-05-01T00:00:00.000Z",
+          },
+        }),
+        attestation({ attestationId: "reverify", nextReverificationAt: "2026-05-01T00:00:00.000Z" }),
+      ],
+      generatedAt: "2026-05-08T00:00:00.000Z",
+    });
+
+    expect(summary.exportSummaries).toEqual([
+      expect.objectContaining({ attestationId: "reverify", status: "reverification_required" }),
+    ]);
+    expect(summary.supportSummaries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ attestationId: "revoked", lifecycleState: "revoked" }),
+        expect.objectContaining({ attestationId: "expired", lifecycleState: "expired" }),
+        expect.objectContaining({ attestationId: "consent-revoked", lifecycleState: "revoked" }),
+        expect.objectContaining({ attestationId: "consent-expired", lifecycleState: "expired" }),
+        expect.objectContaining({ attestationId: "reverify", lifecycleState: "reverification_required" }),
+      ])
+    );
+  });
+
+  it("keeps support visibility separate and redacted", () => {
+    const summary = derivePortableAttestationSummary({
+      attestations: [attestation()],
+      generatedAt: "2026-05-08T00:00:00.000Z",
+    });
+
+    expect(summary.supportSummaries[0]).toEqual(
+      expect.objectContaining({
+        consentIdRedacted: "***le-1",
+        internalReferenceRedacted: "***tive",
+        providerReferenceRedacted: "***tive",
+        sourceIdRedacted: "***tive",
+        rawProviderPayloadVisible: false,
+        rawEvidenceVisible: false,
+        supportMetadataPortable: false,
+      })
+    );
+    expect(JSON.stringify(summary.supportSummaries)).not.toContain("provider-reference-sensitive");
+    expect(JSON.stringify(summary.supportSummaries)).not.toContain("identity-assurance-source-sensitive");
+  });
+
+  it("aligns source references without exposing raw source identifiers in portable summaries", () => {
+    const summary = derivePortableAttestationSummary({
+      attestations: [
+        attestation({
+          attestationId: "property-authority",
+          attestationType: "property_authority",
+          subjectType: "property",
+          subjectId: "property:property-1",
+          claimCategory: "property_authority",
+          issuerCategory: "property_registry",
+          consentScope: {
+            ...attestation().consentScope,
+            claimCategories: ["property_authority"],
+          },
+          evidenceSummary: {
+            evidenceCategory: "registry_record",
+            sourceSystem: "property_trust",
+            sourceCategory: "registry_linkage",
+            sourceVersion: "property_trust.v1",
+            auditEventRef: "property-audit-event-sensitive",
+            rawEvidenceIncluded: false,
+          },
+          sourceReference: {
+            sourceSystem: "property_trust",
+            sourceId: "property-trust-source-sensitive",
+            sourceAttestationId: "property-trust-1",
+            sourceVersion: "property_trust.v1",
+          },
+          nonAuthorityDisclaimers: ["Property authority metadata is not a legal ownership conclusion."],
+        }),
+      ],
+      generatedAt: "2026-05-08T00:00:00.000Z",
+    });
+
+    expect(summary.exportSummaries[0]).toEqual(
+      expect.objectContaining({
+        attestationType: "property_authority",
+        sourceSystem: "property_trust",
+        evidenceCategory: "registry_record",
+      })
+    );
+    expect(summary.exportSummaries[0].nonAuthorityDisclaimers).toContain(
+      "Property authority metadata is not a legal ownership conclusion."
+    );
+    expect(JSON.stringify(summary.exportSummaries)).not.toContain("property-trust-source-sensitive");
+  });
+});

--- a/rentchain-api/src/lib/portableAttestations/derivePortableAttestationSummary.ts
+++ b/rentchain-api/src/lib/portableAttestations/derivePortableAttestationSummary.ts
@@ -1,0 +1,218 @@
+import { redactIdentifier } from "../governance/platformGovernance";
+import type {
+  DerivePortableAttestationSummaryInput,
+  PortableAttestation,
+  PortableAttestationExportSummary,
+  PortableAttestationLifecycleState,
+  PortableAttestationStatus,
+  PortableAttestationSummary,
+  PortableAttestationSupportSummary,
+} from "./portableAttestationTypes";
+
+const REDACTIONS = [
+  "Raw identity, screening, payment, title, registry, and provider payloads are excluded.",
+  "Internal governance notes and support-console metadata are excluded.",
+  "Provider and evidence references are not portable by default.",
+  "Portable summaries require claim-level consent and do not create public trust profiles.",
+  "Property authority metadata is not a legal ownership conclusion.",
+];
+
+function asString(value: unknown, max = 240): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function nowIso(value: unknown): string {
+  const raw = asString(value, 80);
+  const parsed = raw ? Date.parse(raw) : NaN;
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : new Date().toISOString();
+}
+
+function timestampAtOrBefore(value: string | null, generatedAt: string) {
+  if (!value) return false;
+  const candidate = Date.parse(value);
+  const now = Date.parse(generatedAt);
+  return Number.isFinite(candidate) && Number.isFinite(now) && candidate <= now;
+}
+
+function hasActiveConsent(attestation: PortableAttestation, generatedAt: string) {
+  const consent = attestation.consentScope;
+  return Boolean(
+    consent.consentId &&
+      consent.grantedAt &&
+      !consent.revokedAt &&
+      !timestampAtOrBefore(consent.expiresAt, generatedAt) &&
+      consent.audience === attestation.audience &&
+      consent.claimCategories.includes(attestation.claimCategory)
+  );
+}
+
+function hasUnsafePayload(attestation: PortableAttestation) {
+  return (
+    attestation.metadataOnly !== true ||
+    attestation.rawSensitivePayloadStored !== false ||
+    attestation.rawProviderPayloadIncluded !== false ||
+    attestation.supportMetadataIncluded !== false ||
+    attestation.evidenceSummary.rawEvidenceIncluded !== false ||
+    attestation.publicAccessEnabled !== false ||
+    attestation.externalSubmissionEnabled !== false ||
+    attestation.unsupportedClaim !== false
+  );
+}
+
+function baseStatus(attestation: PortableAttestation, generatedAt: string): PortableAttestationStatus {
+  if (hasUnsafePayload(attestation)) return "blocked";
+  if (attestation.status === "blocked") return "blocked";
+  if (attestation.revokedAt || attestation.status === "revoked" || attestation.consentScope.revokedAt) return "revoked";
+  if (attestation.status === "superseded" || attestation.supersededAt) return "superseded";
+  if (
+    attestation.status === "expired" ||
+    timestampAtOrBefore(attestation.expiresAt, generatedAt) ||
+    timestampAtOrBefore(attestation.consentScope.expiresAt, generatedAt)
+  ) {
+    return "expired";
+  }
+  if (!hasActiveConsent(attestation, generatedAt)) return "pending_consent";
+  if (timestampAtOrBefore(attestation.nextReverificationAt, generatedAt)) return "reverification_required";
+  return attestation.status === "active" ? "active" : attestation.status;
+}
+
+function lifecycleFromStatus(status: PortableAttestationStatus): PortableAttestationLifecycleState {
+  if (status === "blocked") return "blocked";
+  if (status === "pending_consent") return "consent_required";
+  if (status === "revoked") return "revoked";
+  if (status === "superseded") return "superseded";
+  if (status === "expired") return "expired";
+  if (status === "reverification_required") return "reverification_required";
+  return "export_ready";
+}
+
+function isExportReady(status: PortableAttestationStatus) {
+  return status === "active" || status === "reverification_required";
+}
+
+function toExportSummary(
+  attestation: PortableAttestation,
+  status: PortableAttestationStatus
+): PortableAttestationExportSummary | null {
+  if (!isExportReady(status)) return null;
+  const consentId = attestation.consentScope.consentId;
+  const grantedAt = attestation.consentScope.grantedAt;
+  if (!consentId || !grantedAt) return null;
+
+  return {
+    attestationId: attestation.attestationId,
+    schemaVersion: "portable_attestation.v1",
+    attestationType: attestation.attestationType,
+    subjectType: attestation.subjectType,
+    subjectId: attestation.subjectId,
+    claimCategory: attestation.claimCategory,
+    claimLabel: attestation.claimLabel,
+    claimDescription: attestation.claimDescription,
+    status,
+    lifecycleState: lifecycleFromStatus(status),
+    issuerCategory: attestation.issuerCategory,
+    audience: attestation.audience,
+    permittedPurpose: attestation.consentScope.purpose,
+    consentReferenceId: consentId,
+    consentGrantedAt: grantedAt,
+    consentExpiresAt: attestation.consentScope.expiresAt,
+    retentionClass: attestation.retentionClass,
+    evidenceCategory: attestation.evidenceSummary.evidenceCategory,
+    sourceSystem: attestation.evidenceSummary.sourceSystem,
+    sourceCategory: attestation.evidenceSummary.sourceCategory,
+    confidence: attestation.confidence,
+    issuedAt: attestation.issuedAt,
+    effectiveAt: attestation.effectiveAt,
+    expiresAt: attestation.expiresAt,
+    revokedAt: attestation.revokedAt,
+    supersededAt: attestation.supersededAt,
+    nextReverificationAt: attestation.nextReverificationAt,
+    jurisdiction: attestation.jurisdiction,
+    redactionProfile: attestation.redactionProfile,
+    metadataOnly: true,
+    rawEvidenceIncluded: false,
+    rawProviderPayloadIncluded: false,
+    supportMetadataIncluded: false,
+    publicAccessEnabled: false,
+    externalSubmissionEnabled: false,
+    nonAuthorityDisclaimers: attestation.nonAuthorityDisclaimers,
+  };
+}
+
+function toSupportSummary(
+  attestation: PortableAttestation,
+  status: PortableAttestationStatus
+): PortableAttestationSupportSummary | null {
+  if (!attestation.supportVisible) return null;
+  return {
+    attestationId: attestation.attestationId,
+    attestationType: attestation.attestationType,
+    claimCategory: attestation.claimCategory,
+    status,
+    lifecycleState: lifecycleFromStatus(status),
+    audience: attestation.audience,
+    consentIdRedacted: redactIdentifier(attestation.consentScope.consentId),
+    internalReferenceRedacted: redactIdentifier(attestation.internalReferenceId),
+    providerReferenceRedacted: redactIdentifier(attestation.providerReferenceId),
+    sourceSystem: attestation.sourceReference.sourceSystem,
+    sourceIdRedacted: redactIdentifier(attestation.sourceReference.sourceId),
+    retentionClass: attestation.retentionClass,
+    expiresAt: attestation.expiresAt,
+    revokedAt: attestation.revokedAt,
+    nextReverificationAt: attestation.nextReverificationAt,
+    rawProviderPayloadVisible: false,
+    rawEvidenceVisible: false,
+    supportMetadataPortable: false,
+  };
+}
+
+function blockedReason(attestation: PortableAttestation, status: PortableAttestationStatus, generatedAt: string) {
+  if (hasUnsafePayload(attestation)) {
+    return `${attestation.attestationId}: portable attestation blocked by metadata-only/privacy guardrails.`;
+  }
+  if (!hasActiveConsent(attestation, generatedAt)) {
+    return `${attestation.attestationId}: active claim-level consent is required before portability.`;
+  }
+  if (status === "expired") return `${attestation.attestationId}: attestation is expired.`;
+  if (status === "revoked") return `${attestation.attestationId}: attestation is revoked.`;
+  if (status === "superseded") return `${attestation.attestationId}: attestation is superseded.`;
+  if (status === "blocked") return `${attestation.attestationId}: attestation is blocked.`;
+  return null;
+}
+
+export function derivePortableAttestationSummary(
+  input: DerivePortableAttestationSummaryInput = {}
+): PortableAttestationSummary {
+  const generatedAt = nowIso(input.generatedAt);
+  const attestations = Array.isArray(input.attestations) ? input.attestations : [];
+  const exportSummaries: PortableAttestationExportSummary[] = [];
+  const supportSummaries: PortableAttestationSupportSummary[] = [];
+  const blockedReasons: string[] = [];
+
+  for (const attestation of attestations) {
+    const status = baseStatus(attestation, generatedAt);
+    const reason = blockedReason(attestation, status, generatedAt);
+    if (reason) blockedReasons.push(reason);
+
+    const exportSummary = toExportSummary(attestation, status);
+    if (exportSummary) exportSummaries.push(exportSummary);
+
+    const supportSummary = toSupportSummary(attestation, status);
+    if (supportSummary) supportSummaries.push(supportSummary);
+  }
+
+  return {
+    generatedAt,
+    schemaVersion: "portable_attestation.v1",
+    exportReady: exportSummaries.length > 0,
+    consentRequired: true,
+    publicAccessEnabled: false,
+    externalSubmissionEnabled: false,
+    metadataOnly: true,
+    rawSensitivePayloadStored: false,
+    blockedReasons,
+    exportSummaries,
+    supportSummaries,
+    redactions: REDACTIONS,
+  };
+}

--- a/rentchain-api/src/lib/portableAttestations/index.ts
+++ b/rentchain-api/src/lib/portableAttestations/index.ts
@@ -1,0 +1,2 @@
+export * from "./portableAttestationTypes";
+export * from "./derivePortableAttestationSummary";

--- a/rentchain-api/src/lib/portableAttestations/portableAttestationTypes.ts
+++ b/rentchain-api/src/lib/portableAttestations/portableAttestationTypes.ts
@@ -1,0 +1,251 @@
+export type PortableAttestationType =
+  | "account_trust"
+  | "identity_assurance"
+  | "business_verification"
+  | "property_authority"
+  | "lease_participation"
+  | "legal_document_metadata"
+  | "tenant_portability"
+  | "institution_review";
+
+export type PortableAttestationSubjectType =
+  | "tenant"
+  | "landlord"
+  | "applicant"
+  | "operator"
+  | "organization"
+  | "business_entity"
+  | "property"
+  | "lease"
+  | "legal_document";
+
+export type PortableAttestationClaimCategory =
+  | "account_control"
+  | "identity_assurance"
+  | "business_legitimacy"
+  | "property_registry_linkage"
+  | "property_authority"
+  | "operator_authority"
+  | "lease_participation"
+  | "document_provenance"
+  | "tenant_portability"
+  | "payment_readiness"
+  | "institution_review";
+
+export type PortableAttestationStatus =
+  | "pending_consent"
+  | "active"
+  | "expired"
+  | "revoked"
+  | "superseded"
+  | "reverification_required"
+  | "blocked";
+
+export type PortableAttestationLifecycleState =
+  | "draft"
+  | "consent_required"
+  | "export_ready"
+  | "expired"
+  | "revoked"
+  | "superseded"
+  | "reverification_required"
+  | "blocked";
+
+export type PortableAttestationAudience =
+  | "tenant"
+  | "landlord"
+  | "insurer"
+  | "lender"
+  | "government"
+  | "auditor"
+  | "institutional_landlord"
+  | "compliance_partner"
+  | "future_institution";
+
+export type PortableAttestationPurpose =
+  | "tenant_controlled_sharing"
+  | "landlord_controlled_sharing"
+  | "insurance_review"
+  | "lender_review"
+  | "government_program_review"
+  | "auditor_review"
+  | "compliance_review"
+  | "future_institution_review";
+
+export type PortableAttestationRetentionClass =
+  | "portable_metadata"
+  | "export_metadata"
+  | "audit_record";
+
+export type PortableAttestationIssuerCategory =
+  | "rentchain"
+  | "identity_provider"
+  | "business_verification_provider"
+  | "property_registry"
+  | "institution_review"
+  | "operator_review"
+  | "future_provider";
+
+export type PortableAttestationEvidenceCategory =
+  | "metadata_only"
+  | "provider_reference"
+  | "registry_record"
+  | "trust_signal"
+  | "legal_document_metadata"
+  | "audit_event"
+  | "institution_review";
+
+export type PortableAttestationSourceSystem =
+  | "account_trust"
+  | "identity_assurance"
+  | "property_trust"
+  | "legal_document"
+  | "tenant_share_package"
+  | "institution_export"
+  | "sharing_room";
+
+export type PortableAttestationConsentScope = {
+  consentId: string | null;
+  purpose: PortableAttestationPurpose;
+  audience: PortableAttestationAudience;
+  grantedAt: string | null;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  claimCategories: PortableAttestationClaimCategory[];
+  attributeScopes: string[];
+};
+
+export type PortableAttestationEvidenceSummary = {
+  evidenceCategory: PortableAttestationEvidenceCategory;
+  sourceSystem: PortableAttestationSourceSystem;
+  sourceCategory: string;
+  sourceVersion: string | null;
+  auditEventRef: string | null;
+  rawEvidenceIncluded: false;
+};
+
+export type PortableAttestationSourceReference = {
+  sourceSystem: PortableAttestationSourceSystem;
+  sourceId: string;
+  sourceAttestationId: string | null;
+  sourceVersion: string | null;
+};
+
+export type PortableAttestation = {
+  attestationId: string;
+  attestationType: PortableAttestationType;
+  subjectType: PortableAttestationSubjectType;
+  subjectId: string;
+  claimCategory: PortableAttestationClaimCategory;
+  claimLabel: string;
+  claimDescription: string;
+  status: PortableAttestationStatus;
+  lifecycleState: PortableAttestationLifecycleState;
+  issuerCategory: PortableAttestationIssuerCategory;
+  audience: PortableAttestationAudience;
+  consentScope: PortableAttestationConsentScope;
+  retentionClass: PortableAttestationRetentionClass;
+  evidenceSummary: PortableAttestationEvidenceSummary;
+  sourceReference: PortableAttestationSourceReference;
+  confidence: "none" | "low" | "medium" | "high";
+  issuedAt: string | null;
+  effectiveAt: string | null;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  supersededAt: string | null;
+  nextReverificationAt: string | null;
+  jurisdiction: string | null;
+  redactionProfile: "strict" | "standard";
+  metadataOnly: true;
+  rawSensitivePayloadStored: false;
+  rawProviderPayloadIncluded: false;
+  supportMetadataIncluded: false;
+  publicAccessEnabled: false;
+  externalSubmissionEnabled: false;
+  unsupportedClaim: false;
+  supportVisible: boolean;
+  reviewRequired: boolean;
+  nonAuthorityDisclaimers: string[];
+  internalReferenceId: string | null;
+  providerReferenceId: string | null;
+};
+
+export type PortableAttestationExportSummary = {
+  attestationId: string;
+  schemaVersion: "portable_attestation.v1";
+  attestationType: PortableAttestationType;
+  subjectType: PortableAttestationSubjectType;
+  subjectId: string;
+  claimCategory: PortableAttestationClaimCategory;
+  claimLabel: string;
+  claimDescription: string;
+  status: PortableAttestationStatus;
+  lifecycleState: PortableAttestationLifecycleState;
+  issuerCategory: PortableAttestationIssuerCategory;
+  audience: PortableAttestationAudience;
+  permittedPurpose: PortableAttestationPurpose;
+  consentReferenceId: string;
+  consentGrantedAt: string;
+  consentExpiresAt: string | null;
+  retentionClass: PortableAttestationRetentionClass;
+  evidenceCategory: PortableAttestationEvidenceCategory;
+  sourceSystem: PortableAttestationSourceSystem;
+  sourceCategory: string;
+  confidence: "none" | "low" | "medium" | "high";
+  issuedAt: string | null;
+  effectiveAt: string | null;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  supersededAt: string | null;
+  nextReverificationAt: string | null;
+  jurisdiction: string | null;
+  redactionProfile: "strict" | "standard";
+  metadataOnly: true;
+  rawEvidenceIncluded: false;
+  rawProviderPayloadIncluded: false;
+  supportMetadataIncluded: false;
+  publicAccessEnabled: false;
+  externalSubmissionEnabled: false;
+  nonAuthorityDisclaimers: string[];
+};
+
+export type PortableAttestationSupportSummary = {
+  attestationId: string;
+  attestationType: PortableAttestationType;
+  claimCategory: PortableAttestationClaimCategory;
+  status: PortableAttestationStatus;
+  lifecycleState: PortableAttestationLifecycleState;
+  audience: PortableAttestationAudience;
+  consentIdRedacted: string | null;
+  internalReferenceRedacted: string | null;
+  providerReferenceRedacted: string | null;
+  sourceSystem: PortableAttestationSourceSystem;
+  sourceIdRedacted: string | null;
+  retentionClass: PortableAttestationRetentionClass;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  nextReverificationAt: string | null;
+  rawProviderPayloadVisible: false;
+  rawEvidenceVisible: false;
+  supportMetadataPortable: false;
+};
+
+export type PortableAttestationSummary = {
+  generatedAt: string;
+  schemaVersion: "portable_attestation.v1";
+  exportReady: boolean;
+  consentRequired: true;
+  publicAccessEnabled: false;
+  externalSubmissionEnabled: false;
+  metadataOnly: true;
+  rawSensitivePayloadStored: false;
+  blockedReasons: string[];
+  exportSummaries: PortableAttestationExportSummary[];
+  supportSummaries: PortableAttestationSupportSummary[];
+  redactions: string[];
+};
+
+export type DerivePortableAttestationSummaryInput = {
+  attestations?: PortableAttestation[] | null;
+  generatedAt?: unknown;
+};


### PR DESCRIPTION
## Summary
- Adds a provider-neutral portable attestation framework for consent-scoped, metadata-only trust summaries.
- Introduces consent/audience-scoped attestation primitives, lifecycle handling for pending consent, active, expired, revoked, superseded, reverification-required, and blocked states.
- Adds export-safe and support-safe summary projections that keep raw provider/evidence references, support metadata, public exposure, and unsupported claims out of portable payloads.
- Documents the implementation audit, boundaries, lifecycle, support/admin separation, and remaining risks.

## Scope Guardrails
- No public attestation exposure.
- No tenant share package widening.
- No provider or institution API integration.
- No blockchain, tokenization, verifiable credential protocol, reputation score, or automated institutional decisioning.
- No raw ID/property/provider payload storage.

## Verification
- `cd rentchain-api && source $HOME/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:single -- src/lib/portableAttestations/__tests__/derivePortableAttestationSummary.test.ts src/lib/identityAssurance/__tests__/deriveIdentityAssuranceSummary.test.ts src/lib/propertyTrust/__tests__/derivePropertyTrustSummary.test.ts src/lib/governance/__tests__/platformGovernance.test.ts`
- `cd rentchain-api && source $HOME/.nvm/nvm.sh && nvm use 20.20.2 && npm run build`
- `cd rentchain-api && source $HOME/.nvm/nvm.sh && nvm use 20.20.2 && npm run test` (rerun elevated after sandbox EPERM listener failure; 338 files / 1464 tests passed)
- `cd rentchain-frontend && source $HOME/.nvm/nvm.sh && nvm use 20.20.2 && npm run test`
- `cd rentchain-frontend && source $HOME/.nvm/nvm.sh && nvm use 20.20.2 && npm run build`
- `git diff --check`