### PR TITLE
Add attestation policy gate

### DIFF
--- a/docs/architecture/portable-attestation-framework-v1.md
+++ b/docs/architecture/portable-attestation-framework-v1.md
@@ -66,7 +66,7 @@ Reverification-required summaries may still be projected so recipients can see t
 
 ## Export-Safe Summaries
 
-`derivePortableAttestationSummary` produces export-safe summaries only when all privacy and consent guards pass.
+`derivePortableAttestationSummary` produces export-safe summaries only when all privacy, consent, and policy guards pass. `buildPolicySafeExportSummary` is the reusable gate future adoption points should call before any share package, institution export, insurer workflow, lender workflow, subsidy workflow, or government workflow uses portable attestation metadata.
 
 Export summaries include:
 
@@ -95,6 +95,62 @@ Export summaries do not include:
 - internal governance notes
 - public access controls
 - external submission behavior
+
+## Attestation Policy Gate
+
+Attestation Policy Gate v1 adds deterministic deny-by-default policy evaluation through:
+
+- `AttestationPolicyContext`
+- `AttestationPolicyDecision`
+- `AttestationPolicyReason`
+- `evaluateAttestationPolicy`
+- `assertPortableAttestationShareable`
+- `buildPolicySafeExportSummary`
+
+The gate evaluates the requested operation, audience, purpose, sensitivity context, lifecycle state, consent state, retention class, evidence safety, source alignment, and internal-vs-portable metadata boundaries.
+
+Allowed export or sharing requires:
+
+- active attestation status
+- `export_ready` lifecycle
+- active claim-level consent
+- requested audience matching both the attestation and consent audience
+- requested purpose matching the consent purpose
+- claim category included in consent scope
+- portable retention class
+- non-public context
+- non-internal sensitivity context
+- no raw, provider, evidence, support, public-access, or external-submission payload flags
+- matching evidence and source systems
+
+Blocked decisions include machine-readable reasons such as:
+
+- `consent_missing`
+- `consent_expired`
+- `consent_revoked`
+- `consent_scope_insufficient`
+- `audience_missing`
+- `audience_mismatch`
+- `purpose_missing`
+- `purpose_mismatch`
+- `expired`
+- `revoked`
+- `superseded`
+- `blocked`
+- `reverification_required`
+- `retention_not_portable`
+- `sensitivity_blocked`
+- `unsupported_claim`
+- `raw_payload_blocked`
+- `support_metadata_blocked`
+- `public_exposure_blocked`
+- `external_submission_blocked`
+- `unsafe_evidence_summary`
+- `source_mismatch`
+- `share_allowed`
+- `export_allowed`
+
+`reverification_required` is intentionally blocked by policy even though the underlying framework can represent it. A stale claim may be visible internally for review, but it is not exportable until refreshed.
 
 ## Support/Admin Separation
 
@@ -143,6 +199,7 @@ This framework does not:
 - create reputation scores
 - automate institutional decisions
 - create ownership, identity, creditworthiness, subsidy, or approval conclusions
+- wire portable attestations into tenant share packages or institution exports
 
 ## Regression Risks
 
@@ -150,6 +207,7 @@ This framework does not:
 - Broad "verified" copy in other surfaces can still be overread unless future integrations use the portable schema language.
 - Institution-specific packet signing, revocation notification, and recipient policy matrices remain future work.
 - Property authority attestations must continue to carry non-ownership disclaimers.
+- The policy gate is currently a pure helper; future route/service adoption must still prove it is called before any external projection.
 
 ## Verification
 
@@ -163,3 +221,6 @@ Tests cover:
 - internal/support metadata separation
 - raw source/provider/reference exclusion from export summaries
 - source alignment with identity assurance and property trust foundations
+- deny-by-default policy evaluation
+- consent, audience, purpose, lifecycle, retention, sensitivity, raw payload, support metadata, public exposure, and source-alignment blocking
+- policy-safe export summary generation

--- a/rentchain-api/src/lib/portableAttestations/__tests__/attestationPolicyGate.test.ts
+++ b/rentchain-api/src/lib/portableAttestations/__tests__/attestationPolicyGate.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertPortableAttestationShareable,
+  buildPolicySafeExportSummary,
+  evaluateAttestationPolicy,
+  type PortableAttestation,
+} from "../index";
+
+function attestation(overrides: Partial<PortableAttestation> = {}): PortableAttestation {
+  return {
+    attestationId: "attestation-policy-1",
+    attestationType: "identity_assurance",
+    subjectType: "tenant",
+    subjectId: "tenant:tenant-1",
+    claimCategory: "identity_assurance",
+    claimLabel: "Identity assurance metadata present",
+    claimDescription: "Identity assurance metadata is present through an approved workflow.",
+    status: "active",
+    lifecycleState: "export_ready",
+    issuerCategory: "identity_provider",
+    audience: "insurer",
+    consentScope: {
+      consentId: "consent-1",
+      purpose: "insurance_review",
+      audience: "insurer",
+      grantedAt: "2026-05-01T00:00:00.000Z",
+      expiresAt: "2026-08-01T00:00:00.000Z",
+      revokedAt: null,
+      claimCategories: ["identity_assurance"],
+      attributeScopes: ["status", "timestamps"],
+    },
+    retentionClass: "portable_metadata",
+    evidenceSummary: {
+      evidenceCategory: "provider_reference",
+      sourceSystem: "identity_assurance",
+      sourceCategory: "provider_neutral_identity_assurance",
+      sourceVersion: "identity_assurance.v1",
+      auditEventRef: "event-1",
+      rawEvidenceIncluded: false,
+    },
+    sourceReference: {
+      sourceSystem: "identity_assurance",
+      sourceId: "identity-source-1",
+      sourceAttestationId: "identity-assurance-1",
+      sourceVersion: "identity_assurance.v1",
+    },
+    confidence: "high",
+    issuedAt: "2026-05-01T00:00:00.000Z",
+    effectiveAt: "2026-05-01T00:10:00.000Z",
+    expiresAt: "2026-08-01T00:00:00.000Z",
+    revokedAt: null,
+    supersededAt: null,
+    nextReverificationAt: "2026-07-01T00:00:00.000Z",
+    jurisdiction: "CA",
+    redactionProfile: "strict",
+    metadataOnly: true,
+    rawSensitivePayloadStored: false,
+    rawProviderPayloadIncluded: false,
+    supportMetadataIncluded: false,
+    publicAccessEnabled: false,
+    externalSubmissionEnabled: false,
+    unsupportedClaim: false,
+    supportVisible: true,
+    reviewRequired: false,
+    nonAuthorityDisclaimers: ["RentChain stores metadata only and is not the identity authority."],
+    internalReferenceId: "internal-reference",
+    providerReferenceId: "provider-reference",
+    ...overrides,
+  };
+}
+
+function context(overrides = {}) {
+  return {
+    operation: "export" as const,
+    requestedAudience: "insurer" as const,
+    requestedPurpose: "insurance_review" as const,
+    generatedAt: "2026-05-08T00:00:00.000Z",
+    sensitivity: "confidential" as const,
+    publicRequest: false,
+    ...overrides,
+  };
+}
+
+describe("attestation policy gate", () => {
+  it("allows active consented audience-matched metadata attestations", () => {
+    const decision = evaluateAttestationPolicy(attestation(), context());
+
+    expect(decision.allowed).toBe(true);
+    expect(decision.exportable).toBe(true);
+    expect(decision.reasons).toEqual(["export_allowed"]);
+  });
+
+  it("builds export-safe summaries only when the policy allows export", () => {
+    const result = buildPolicySafeExportSummary(attestation(), context());
+
+    expect(result.decision.exportable).toBe(true);
+    expect(result.exportSummary).toEqual(
+      expect.objectContaining({
+        attestationId: "attestation-policy-1",
+        audience: "insurer",
+        permittedPurpose: "insurance_review",
+        rawProviderPayloadIncluded: false,
+        supportMetadataIncluded: false,
+        publicAccessEnabled: false,
+      })
+    );
+    expect(JSON.stringify(result.exportSummary)).not.toContain("provider-reference");
+    expect(JSON.stringify(result.exportSummary)).not.toContain("internal-reference");
+  });
+
+  it("blocks missing consent with machine-readable reasons", () => {
+    const decision = evaluateAttestationPolicy(
+      attestation({ consentScope: { ...attestation().consentScope, consentId: null, grantedAt: null } }),
+      context()
+    );
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.reasons).toEqual(expect.arrayContaining(["deny_by_default", "consent_missing"]));
+  });
+
+  it("blocks audience and purpose mismatches", () => {
+    const decision = evaluateAttestationPolicy(attestation(), context({ requestedAudience: "lender", requestedPurpose: "lender_review" }));
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.reasons).toEqual(expect.arrayContaining(["audience_mismatch", "purpose_mismatch"]));
+  });
+
+  it("blocks expired, revoked, superseded, and reverification-required attestations", () => {
+    const generatedAt = "2026-05-08T00:00:00.000Z";
+
+    expect(evaluateAttestationPolicy(attestation({ expiresAt: "2026-05-01T00:00:00.000Z" }), context({ generatedAt })).reasons).toContain("expired");
+    expect(evaluateAttestationPolicy(attestation({ revokedAt: "2026-05-01T00:00:00.000Z" }), context({ generatedAt })).reasons).toContain("revoked");
+    expect(evaluateAttestationPolicy(attestation({ supersededAt: "2026-05-01T00:00:00.000Z" }), context({ generatedAt })).reasons).toContain("superseded");
+    expect(evaluateAttestationPolicy(attestation({ nextReverificationAt: "2026-05-01T00:00:00.000Z" }), context({ generatedAt })).reasons).toContain("reverification_required");
+  });
+
+  it("blocks internal-only retention and public exposure contexts", () => {
+    const retentionDecision = evaluateAttestationPolicy(attestation({ retentionClass: "audit_record" }), context());
+    const publicDecision = evaluateAttestationPolicy(attestation(), context({ publicRequest: true }));
+    const sensitivityDecision = evaluateAttestationPolicy(attestation(), context({ sensitivity: "restricted" }));
+    const internalSensitivityDecision = evaluateAttestationPolicy(attestation(), context({ sensitivity: "internal" }));
+
+    expect(retentionDecision.reasons).toContain("retention_not_portable");
+    expect(publicDecision.reasons).toContain("public_exposure_blocked");
+    expect(sensitivityDecision.reasons).toContain("sensitivity_blocked");
+    expect(internalSensitivityDecision.reasons).toContain("sensitivity_blocked");
+  });
+
+  it("blocks raw payloads, support metadata, unsupported claims, and unsafe evidence", () => {
+    expect(evaluateAttestationPolicy(attestation({ rawProviderPayloadIncluded: true as false }), context()).reasons).toContain("raw_payload_blocked");
+    expect(evaluateAttestationPolicy(attestation({ supportMetadataIncluded: true as false }), context()).reasons).toContain("support_metadata_blocked");
+    expect(evaluateAttestationPolicy(attestation({ unsupportedClaim: true as false }), context()).reasons).toContain("unsupported_claim");
+    expect(
+      evaluateAttestationPolicy(
+        attestation({ evidenceSummary: { ...attestation().evidenceSummary, rawEvidenceIncluded: true as false } }),
+        context()
+      ).reasons
+    ).toContain("unsafe_evidence_summary");
+  });
+
+  it("blocks source mismatches between evidence and source references", () => {
+    const decision = evaluateAttestationPolicy(
+      attestation({
+        sourceReference: {
+          ...attestation().sourceReference,
+          sourceSystem: "property_trust",
+        },
+      }),
+      context()
+    );
+
+    expect(decision.reasons).toContain("source_mismatch");
+  });
+
+  it("supports share policy decisions without exposing routes or share packages", () => {
+    const decision = assertPortableAttestationShareable(attestation(), context({ operation: "share" }));
+
+    expect(decision.allowed).toBe(true);
+    expect(decision.shareable).toBe(true);
+    expect(decision.exportable).toBe(false);
+    expect(decision.reasons).toEqual(["share_allowed"]);
+    expect(decision.publicAccessEnabled).toBe(false);
+  });
+});

--- a/rentchain-api/src/lib/portableAttestations/__tests__/derivePortableAttestationSummary.test.ts
+++ b/rentchain-api/src/lib/portableAttestations/__tests__/derivePortableAttestationSummary.test.ts
@@ -68,6 +68,8 @@ describe("derivePortableAttestationSummary", () => {
   it("derives export-safe summaries only from consent-scoped metadata-only attestations", () => {
     const summary = derivePortableAttestationSummary({
       attestations: [attestation()],
+      requestedAudience: "insurer",
+      requestedPurpose: "insurance_review",
       generatedAt: "2026-05-08T00:00:00.000Z",
     });
 
@@ -106,15 +108,21 @@ describe("derivePortableAttestationSummary", () => {
           },
         }),
       ],
+      requestedAudience: "insurer",
+      requestedPurpose: "insurance_review",
       generatedAt: "2026-05-08T00:00:00.000Z",
     });
 
     expect(summary.exportReady).toBe(false);
     expect(summary.exportSummaries).toHaveLength(0);
     expect(summary.supportSummaries[0].status).toBe("pending_consent");
-    expect(summary.blockedReasons).toEqual([
-      "portable-attestation-1: active claim-level consent is required before portability.",
-    ]);
+    expect(summary.policyDecisions[0].reasons).toContain("consent_missing");
+    expect(summary.blockedReasons).toEqual(
+      expect.arrayContaining([
+        "portable-attestation-1: active claim-level consent is required before portability.",
+        "portable-attestation-1: consent_missing",
+      ])
+    );
   });
 
   it("blocks raw payload, public exposure, support metadata, and unsupported claim attempts", () => {
@@ -125,6 +133,8 @@ describe("derivePortableAttestationSummary", () => {
         attestation({ attestationId: "support-attempt", supportMetadataIncluded: true as false }),
         attestation({ attestationId: "unsupported-claim", unsupportedClaim: true as false }),
       ],
+      requestedAudience: "insurer",
+      requestedPurpose: "insurance_review",
       generatedAt: "2026-05-08T00:00:00.000Z",
     });
 
@@ -163,11 +173,16 @@ describe("derivePortableAttestationSummary", () => {
         attestation({ attestationId: "reverify", nextReverificationAt: "2026-05-01T00:00:00.000Z" }),
       ],
       generatedAt: "2026-05-08T00:00:00.000Z",
+      requestedAudience: "insurer",
+      requestedPurpose: "insurance_review",
     });
 
-    expect(summary.exportSummaries).toEqual([
-      expect.objectContaining({ attestationId: "reverify", status: "reverification_required" }),
-    ]);
+    expect(summary.exportSummaries).toHaveLength(0);
+    expect(summary.policyDecisions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ attestationId: "reverify", reasons: expect.arrayContaining(["reverification_required"]) }),
+      ])
+    );
     expect(summary.supportSummaries).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ attestationId: "revoked", lifecycleState: "revoked" }),
@@ -182,6 +197,8 @@ describe("derivePortableAttestationSummary", () => {
   it("keeps support visibility separate and redacted", () => {
     const summary = derivePortableAttestationSummary({
       attestations: [attestation()],
+      requestedAudience: "insurer",
+      requestedPurpose: "insurance_review",
       generatedAt: "2026-05-08T00:00:00.000Z",
     });
 
@@ -231,6 +248,8 @@ describe("derivePortableAttestationSummary", () => {
           nonAuthorityDisclaimers: ["Property authority metadata is not a legal ownership conclusion."],
         }),
       ],
+      requestedAudience: "insurer",
+      requestedPurpose: "insurance_review",
       generatedAt: "2026-05-08T00:00:00.000Z",
     });
 

--- a/rentchain-api/src/lib/portableAttestations/attestationPolicyGate.ts
+++ b/rentchain-api/src/lib/portableAttestations/attestationPolicyGate.ts
@@ -1,0 +1,213 @@
+import type {
+  AttestationPolicyContext,
+  AttestationPolicyDecision,
+  AttestationPolicyReason,
+  PolicySafeExportSummaryResult,
+  PortableAttestation,
+  PortableAttestationExportSummary,
+  PortableAttestationLifecycleState,
+  PortableAttestationPolicySensitivity,
+  PortableAttestationPurpose,
+  PortableAttestationStatus,
+} from "./portableAttestationTypes";
+
+const DEFAULT_ALLOWED_RETENTION = new Set(["portable_metadata", "export_metadata"]);
+
+function asString(value: unknown, max = 240): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function nowIso(value: unknown): string {
+  const raw = asString(value, 80);
+  const parsed = raw ? Date.parse(raw) : NaN;
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : new Date().toISOString();
+}
+
+function timestampAtOrBefore(value: string | null, generatedAt: string) {
+  if (!value) return false;
+  const candidate = Date.parse(value);
+  const now = Date.parse(generatedAt);
+  return Number.isFinite(candidate) && Number.isFinite(now) && candidate <= now;
+}
+
+function lifecycleFromStatus(status: PortableAttestationStatus): PortableAttestationLifecycleState {
+  if (status === "blocked") return "blocked";
+  if (status === "pending_consent") return "consent_required";
+  if (status === "revoked") return "revoked";
+  if (status === "superseded") return "superseded";
+  if (status === "expired") return "expired";
+  if (status === "reverification_required") return "reverification_required";
+  return "export_ready";
+}
+
+function derivedStatus(attestation: PortableAttestation, generatedAt: string): PortableAttestationStatus {
+  if (
+    attestation.metadataOnly !== true ||
+    attestation.rawSensitivePayloadStored !== false ||
+    attestation.rawProviderPayloadIncluded !== false ||
+    attestation.supportMetadataIncluded !== false ||
+    attestation.evidenceSummary.rawEvidenceIncluded !== false ||
+    attestation.publicAccessEnabled !== false ||
+    attestation.externalSubmissionEnabled !== false ||
+    attestation.unsupportedClaim !== false
+  ) {
+    return "blocked";
+  }
+  if (attestation.status === "blocked") return "blocked";
+  if (attestation.revokedAt || attestation.status === "revoked" || attestation.consentScope.revokedAt) return "revoked";
+  if (attestation.status === "superseded" || attestation.supersededAt) return "superseded";
+  if (
+    attestation.status === "expired" ||
+    timestampAtOrBefore(attestation.expiresAt, generatedAt) ||
+    timestampAtOrBefore(attestation.consentScope.expiresAt, generatedAt)
+  ) {
+    return "expired";
+  }
+  if (timestampAtOrBefore(attestation.nextReverificationAt, generatedAt)) return "reverification_required";
+  if (!attestation.consentScope.consentId || !attestation.consentScope.grantedAt) return "pending_consent";
+  return attestation.status;
+}
+
+function isSensitivityAllowed(sensitivity: PortableAttestationPolicySensitivity | null | undefined) {
+  return sensitivity === "confidential" || !sensitivity;
+}
+
+function addReason(reasons: AttestationPolicyReason[], reason: AttestationPolicyReason) {
+  if (!reasons.includes(reason)) reasons.push(reason);
+}
+
+function allowedRetentionClasses(context: AttestationPolicyContext) {
+  return new Set(context.allowedRetentionClasses?.length ? context.allowedRetentionClasses : Array.from(DEFAULT_ALLOWED_RETENTION));
+}
+
+export function evaluateAttestationPolicy(
+  attestation: PortableAttestation,
+  context: AttestationPolicyContext
+): AttestationPolicyDecision {
+  const generatedAt = nowIso(context.generatedAt);
+  const requestedAudience = context.requestedAudience || null;
+  const requestedPurpose = context.requestedPurpose || null;
+  const status = derivedStatus(attestation, generatedAt);
+  const lifecycleState = lifecycleFromStatus(status);
+  const reasons: AttestationPolicyReason[] = ["deny_by_default"];
+
+  if (!requestedAudience) addReason(reasons, "audience_missing");
+  if (requestedAudience && requestedAudience !== attestation.audience) addReason(reasons, "audience_mismatch");
+  if (requestedAudience && requestedAudience !== attestation.consentScope.audience) addReason(reasons, "audience_mismatch");
+
+  if (!requestedPurpose) addReason(reasons, "purpose_missing");
+  if (requestedPurpose && requestedPurpose !== attestation.consentScope.purpose) addReason(reasons, "purpose_mismatch");
+
+  if (!attestation.consentScope.consentId || !attestation.consentScope.grantedAt) addReason(reasons, "consent_missing");
+  if (attestation.consentScope.revokedAt) addReason(reasons, "consent_revoked");
+  if (timestampAtOrBefore(attestation.consentScope.expiresAt, generatedAt)) addReason(reasons, "consent_expired");
+  if (!attestation.consentScope.claimCategories.includes(attestation.claimCategory)) {
+    addReason(reasons, "consent_scope_insufficient");
+  }
+
+  if (status === "expired") addReason(reasons, "expired");
+  if (status === "revoked") addReason(reasons, "revoked");
+  if (status === "superseded") addReason(reasons, "superseded");
+  if (status === "blocked" || lifecycleState === "blocked") addReason(reasons, "blocked");
+  if (status === "reverification_required" || lifecycleState === "reverification_required") {
+    addReason(reasons, "reverification_required");
+  }
+
+  if (!allowedRetentionClasses(context).has(attestation.retentionClass)) addReason(reasons, "retention_not_portable");
+  if (!isSensitivityAllowed(context.sensitivity || "confidential")) addReason(reasons, "sensitivity_blocked");
+
+  if (attestation.unsupportedClaim !== false) addReason(reasons, "unsupported_claim");
+  if (attestation.metadataOnly !== true || attestation.rawSensitivePayloadStored !== false || attestation.rawProviderPayloadIncluded !== false) {
+    addReason(reasons, "raw_payload_blocked");
+  }
+  if (attestation.supportMetadataIncluded !== false) addReason(reasons, "support_metadata_blocked");
+  if (attestation.publicAccessEnabled !== false || context.publicRequest === true) addReason(reasons, "public_exposure_blocked");
+  if (attestation.externalSubmissionEnabled !== false) addReason(reasons, "external_submission_blocked");
+  if (attestation.evidenceSummary.rawEvidenceIncluded !== false) addReason(reasons, "unsafe_evidence_summary");
+  if (attestation.evidenceSummary.sourceSystem !== attestation.sourceReference.sourceSystem) addReason(reasons, "source_mismatch");
+
+  const allowed = reasons.length === 1 && reasons[0] === "deny_by_default" && status === "active" && lifecycleState === "export_ready";
+
+  return {
+    allowed,
+    shareable: allowed && context.operation === "share",
+    exportable: allowed && context.operation === "export",
+    operation: context.operation,
+    attestationId: attestation.attestationId,
+    requestedAudience,
+    requestedPurpose,
+    status,
+    lifecycleState,
+    reasons: allowed ? [context.operation === "share" ? "share_allowed" : "export_allowed"] : reasons,
+    generatedAt,
+    metadataOnly: true,
+    publicAccessEnabled: false,
+    externalSubmissionEnabled: false,
+  };
+}
+
+function toExportSummary(
+  attestation: PortableAttestation,
+  decision: AttestationPolicyDecision,
+  purpose: PortableAttestationPurpose
+): PortableAttestationExportSummary {
+  return {
+    attestationId: attestation.attestationId,
+    schemaVersion: "portable_attestation.v1",
+    attestationType: attestation.attestationType,
+    subjectType: attestation.subjectType,
+    subjectId: attestation.subjectId,
+    claimCategory: attestation.claimCategory,
+    claimLabel: attestation.claimLabel,
+    claimDescription: attestation.claimDescription,
+    status: decision.status,
+    lifecycleState: decision.lifecycleState,
+    issuerCategory: attestation.issuerCategory,
+    audience: attestation.audience,
+    permittedPurpose: purpose,
+    consentReferenceId: attestation.consentScope.consentId as string,
+    consentGrantedAt: attestation.consentScope.grantedAt as string,
+    consentExpiresAt: attestation.consentScope.expiresAt,
+    retentionClass: attestation.retentionClass,
+    evidenceCategory: attestation.evidenceSummary.evidenceCategory,
+    sourceSystem: attestation.evidenceSummary.sourceSystem,
+    sourceCategory: attestation.evidenceSummary.sourceCategory,
+    confidence: attestation.confidence,
+    issuedAt: attestation.issuedAt,
+    effectiveAt: attestation.effectiveAt,
+    expiresAt: attestation.expiresAt,
+    revokedAt: attestation.revokedAt,
+    supersededAt: attestation.supersededAt,
+    nextReverificationAt: attestation.nextReverificationAt,
+    jurisdiction: attestation.jurisdiction,
+    redactionProfile: attestation.redactionProfile,
+    metadataOnly: true,
+    rawEvidenceIncluded: false,
+    rawProviderPayloadIncluded: false,
+    supportMetadataIncluded: false,
+    publicAccessEnabled: false,
+    externalSubmissionEnabled: false,
+    nonAuthorityDisclaimers: attestation.nonAuthorityDisclaimers,
+  };
+}
+
+export function buildPolicySafeExportSummary(
+  attestation: PortableAttestation,
+  context: AttestationPolicyContext
+): PolicySafeExportSummaryResult {
+  const decision = evaluateAttestationPolicy(attestation, { ...context, operation: "export" });
+  return {
+    decision,
+    exportSummary:
+      decision.exportable && context.requestedPurpose
+        ? toExportSummary(attestation, decision, context.requestedPurpose)
+        : null,
+  };
+}
+
+export function assertPortableAttestationShareable(
+  attestation: PortableAttestation,
+  context: AttestationPolicyContext
+): AttestationPolicyDecision {
+  return evaluateAttestationPolicy(attestation, { ...context, operation: "share" });
+}

--- a/rentchain-api/src/lib/portableAttestations/derivePortableAttestationSummary.ts
+++ b/rentchain-api/src/lib/portableAttestations/derivePortableAttestationSummary.ts
@@ -1,8 +1,9 @@
 import { redactIdentifier } from "../governance/platformGovernance";
+import { buildPolicySafeExportSummary } from "./attestationPolicyGate";
 import type {
+  AttestationPolicyDecision,
   DerivePortableAttestationSummaryInput,
   PortableAttestation,
-  PortableAttestationExportSummary,
   PortableAttestationLifecycleState,
   PortableAttestationStatus,
   PortableAttestationSummary,
@@ -86,59 +87,6 @@ function lifecycleFromStatus(status: PortableAttestationStatus): PortableAttesta
   return "export_ready";
 }
 
-function isExportReady(status: PortableAttestationStatus) {
-  return status === "active" || status === "reverification_required";
-}
-
-function toExportSummary(
-  attestation: PortableAttestation,
-  status: PortableAttestationStatus
-): PortableAttestationExportSummary | null {
-  if (!isExportReady(status)) return null;
-  const consentId = attestation.consentScope.consentId;
-  const grantedAt = attestation.consentScope.grantedAt;
-  if (!consentId || !grantedAt) return null;
-
-  return {
-    attestationId: attestation.attestationId,
-    schemaVersion: "portable_attestation.v1",
-    attestationType: attestation.attestationType,
-    subjectType: attestation.subjectType,
-    subjectId: attestation.subjectId,
-    claimCategory: attestation.claimCategory,
-    claimLabel: attestation.claimLabel,
-    claimDescription: attestation.claimDescription,
-    status,
-    lifecycleState: lifecycleFromStatus(status),
-    issuerCategory: attestation.issuerCategory,
-    audience: attestation.audience,
-    permittedPurpose: attestation.consentScope.purpose,
-    consentReferenceId: consentId,
-    consentGrantedAt: grantedAt,
-    consentExpiresAt: attestation.consentScope.expiresAt,
-    retentionClass: attestation.retentionClass,
-    evidenceCategory: attestation.evidenceSummary.evidenceCategory,
-    sourceSystem: attestation.evidenceSummary.sourceSystem,
-    sourceCategory: attestation.evidenceSummary.sourceCategory,
-    confidence: attestation.confidence,
-    issuedAt: attestation.issuedAt,
-    effectiveAt: attestation.effectiveAt,
-    expiresAt: attestation.expiresAt,
-    revokedAt: attestation.revokedAt,
-    supersededAt: attestation.supersededAt,
-    nextReverificationAt: attestation.nextReverificationAt,
-    jurisdiction: attestation.jurisdiction,
-    redactionProfile: attestation.redactionProfile,
-    metadataOnly: true,
-    rawEvidenceIncluded: false,
-    rawProviderPayloadIncluded: false,
-    supportMetadataIncluded: false,
-    publicAccessEnabled: false,
-    externalSubmissionEnabled: false,
-    nonAuthorityDisclaimers: attestation.nonAuthorityDisclaimers,
-  };
-}
-
 function toSupportSummary(
   attestation: PortableAttestation,
   status: PortableAttestationStatus
@@ -180,12 +128,19 @@ function blockedReason(attestation: PortableAttestation, status: PortableAttesta
   return null;
 }
 
+function policyBlockedReasons(decision: AttestationPolicyDecision) {
+  return decision.allowed
+    ? []
+    : decision.reasons.map((reason) => `${decision.attestationId}: ${reason}`);
+}
+
 export function derivePortableAttestationSummary(
   input: DerivePortableAttestationSummaryInput = {}
 ): PortableAttestationSummary {
   const generatedAt = nowIso(input.generatedAt);
   const attestations = Array.isArray(input.attestations) ? input.attestations : [];
-  const exportSummaries: PortableAttestationExportSummary[] = [];
+  const policyDecisions: AttestationPolicyDecision[] = [];
+  const exportSummaries: PortableAttestationSummary["exportSummaries"] = [];
   const supportSummaries: PortableAttestationSupportSummary[] = [];
   const blockedReasons: string[] = [];
 
@@ -194,10 +149,19 @@ export function derivePortableAttestationSummary(
     const reason = blockedReason(attestation, status, generatedAt);
     if (reason) blockedReasons.push(reason);
 
-    const exportSummary = toExportSummary(attestation, status);
+    const { decision, exportSummary } = buildPolicySafeExportSummary(attestation, {
+      operation: "export",
+      requestedAudience: input.requestedAudience || null,
+      requestedPurpose: input.requestedPurpose || null,
+      generatedAt,
+      sensitivity: input.sensitivity || "confidential",
+      publicRequest: input.publicRequest === true,
+    });
+    policyDecisions.push(decision);
+    blockedReasons.push(...policyBlockedReasons(decision));
     if (exportSummary) exportSummaries.push(exportSummary);
 
-    const supportSummary = toSupportSummary(attestation, status);
+    const supportSummary = toSupportSummary(attestation, decision.status);
     if (supportSummary) supportSummaries.push(supportSummary);
   }
 
@@ -210,7 +174,8 @@ export function derivePortableAttestationSummary(
     externalSubmissionEnabled: false,
     metadataOnly: true,
     rawSensitivePayloadStored: false,
-    blockedReasons,
+    blockedReasons: Array.from(new Set(blockedReasons)),
+    policyDecisions,
     exportSummaries,
     supportSummaries,
     redactions: REDACTIONS,

--- a/rentchain-api/src/lib/portableAttestations/index.ts
+++ b/rentchain-api/src/lib/portableAttestations/index.ts
@@ -1,2 +1,3 @@
 export * from "./portableAttestationTypes";
 export * from "./derivePortableAttestationSummary";
+export * from "./attestationPolicyGate";

--- a/rentchain-api/src/lib/portableAttestations/portableAttestationTypes.ts
+++ b/rentchain-api/src/lib/portableAttestations/portableAttestationTypes.ts
@@ -240,6 +240,7 @@ export type PortableAttestationSummary = {
   metadataOnly: true;
   rawSensitivePayloadStored: false;
   blockedReasons: string[];
+  policyDecisions: AttestationPolicyDecision[];
   exportSummaries: PortableAttestationExportSummary[];
   supportSummaries: PortableAttestationSupportSummary[];
   redactions: string[];
@@ -248,4 +249,75 @@ export type PortableAttestationSummary = {
 export type DerivePortableAttestationSummaryInput = {
   attestations?: PortableAttestation[] | null;
   generatedAt?: unknown;
+  requestedAudience?: PortableAttestationAudience | null;
+  requestedPurpose?: PortableAttestationPurpose | null;
+  sensitivity?: PortableAttestationPolicySensitivity | null;
+  publicRequest?: boolean | null;
+};
+
+export type PortableAttestationPolicySensitivity =
+  | "internal"
+  | "confidential"
+  | "restricted"
+  | "public";
+
+export type AttestationPolicyOperation = "share" | "export";
+
+export type AttestationPolicyReason =
+  | "deny_by_default"
+  | "consent_missing"
+  | "consent_expired"
+  | "consent_revoked"
+  | "consent_scope_insufficient"
+  | "audience_missing"
+  | "audience_mismatch"
+  | "purpose_missing"
+  | "purpose_mismatch"
+  | "expired"
+  | "revoked"
+  | "superseded"
+  | "blocked"
+  | "reverification_required"
+  | "retention_not_portable"
+  | "sensitivity_blocked"
+  | "unsupported_claim"
+  | "raw_payload_blocked"
+  | "support_metadata_blocked"
+  | "public_exposure_blocked"
+  | "external_submission_blocked"
+  | "unsafe_evidence_summary"
+  | "source_mismatch"
+  | "share_allowed"
+  | "export_allowed";
+
+export type AttestationPolicyContext = {
+  operation: AttestationPolicyOperation;
+  requestedAudience?: PortableAttestationAudience | null;
+  requestedPurpose?: PortableAttestationPurpose | null;
+  generatedAt?: unknown;
+  sensitivity?: PortableAttestationPolicySensitivity | null;
+  publicRequest?: boolean | null;
+  allowedRetentionClasses?: PortableAttestationRetentionClass[] | null;
+};
+
+export type AttestationPolicyDecision = {
+  allowed: boolean;
+  shareable: boolean;
+  exportable: boolean;
+  operation: AttestationPolicyOperation;
+  attestationId: string;
+  requestedAudience: PortableAttestationAudience | null;
+  requestedPurpose: PortableAttestationPurpose | null;
+  status: PortableAttestationStatus;
+  lifecycleState: PortableAttestationLifecycleState;
+  reasons: AttestationPolicyReason[];
+  generatedAt: string;
+  metadataOnly: true;
+  publicAccessEnabled: false;
+  externalSubmissionEnabled: false;
+};
+
+export type PolicySafeExportSummaryResult = {
+  decision: AttestationPolicyDecision;
+  exportSummary: PortableAttestationExportSummary | null;
 };


### PR DESCRIPTION
## Summary
- Adds a deny-by-default portable attestation policy gate for share/export eligibility.
- Gates export-safe summaries by consent, audience, purpose, lifecycle, expiry/revocation/reverification, retention, sensitivity, source alignment, and raw/internal/support metadata boundaries.
- Adds machine-readable policy reasons and keeps support/admin summaries separate from portable export summaries.
- Documents the policy gate in the portable attestation framework architecture notes.

## Audit Summary
- Current portable attestations already model subject, claim, audience, consent scope, lifecycle timestamps, retention class, evidence summary, and privacy flags.
- Existing export summaries were metadata-only but lacked a reusable policy decision object, requested-audience/requested-purpose context, sensitivity checks, source-alignment blocking, and machine-readable deny reasons.
- Support summaries were already separate and redacted; this PR preserves that separation and blocks support metadata from portable export decisions.

## Guardrails
- No public exposure introduced.
- No share-package widening introduced.
- No provider, institution, blockchain, subsidy, lender, insurer, or export API integration introduced.
- No onboarding behavior changed.

## Tests
- Backend targeted: `npm run test:single -- src/lib/portableAttestations/__tests__/attestationPolicyGate.test.ts src/lib/portableAttestations/__tests__/derivePortableAttestationSummary.test.ts`
- Backend full: `npm run test`
- Backend build: `npm run build`
- Frontend full: `npm run test`
- Frontend build: `npm run build`
- Root: `git diff --check`