### PR TITLE
Add institutional trust export framework

### DIFF
--- a/docs/architecture/institutional-trust-export-framework-v1.md
+++ b/docs/architecture/institutional-trust-export-framework-v1.md
@@ -1,0 +1,158 @@
+# Institutional Trust Export Framework v1
+
+Status: implemented foundation
+Branch: `feat/institutional-trust-export-framework-v1`
+Scope: institution-safe portable trust export composition, no public exposure or institution integration
+
+## Implementation Audit Summary
+
+RentChain already had several export and trust foundations:
+
+- `portableAttestations` defines metadata-only portable trust claims.
+- `attestationPolicyGate` deterministically answers whether a portable attestation is exportable or shareable for a requested audience and purpose.
+- `institutionExports` produces manual-only, read-only institution export previews.
+- `identityAssurance`, `propertyTrust`, and `accountTrust` provide source trust metadata without storing raw identity, property, screening, banking, or provider payloads.
+- support/admin summaries remain separate from portable summaries.
+
+The remaining gap was institution-safe trust export composition: a package-level layer that groups only policy-approved portable attestation summaries into an institution-readable, minimized, auditable export object.
+
+## Export Model
+
+The framework introduces `rentchain-api/src/lib/institutionTrustExports` with:
+
+- `InstitutionalTrustExportPackage`
+- `InstitutionalTrustExportAudience`
+- `InstitutionalTrustExportPurpose`
+- `InstitutionalTrustExportStatus`
+- `InstitutionalTrustExportLifecycle`
+- `InstitutionalTrustExportAuditMetadata`
+- `InstitutionalTrustExportProvenance`
+- `deriveInstitutionalTrustExportPackage`
+- `institutionalTrustExportMappingForPackageType`
+
+Institutional trust export packages are:
+
+- metadata-only
+- consent-scoped
+- policy-gated
+- manual-only
+- non-public
+- external-submission disabled
+- source-provenance aware
+- audit-metadata backed
+
+## Audience And Purpose Model
+
+Supported export audiences include:
+
+- `insurer`
+- `lender`
+- `institutional_landlord`
+- `subsidy_program`
+- `government_review`
+- `tenant_portability`
+- `auditor`
+- `internal_review`
+
+The package layer maps audience and purpose to portable attestation policy contexts. Internal-review contexts are intentionally not treated as portable external exports.
+
+## Policy Gate Integration
+
+Every portable trust summary in an institutional trust export is produced by `buildPolicySafeExportSummary`.
+
+The export package blocks:
+
+- missing or insufficient consent
+- audience mismatch
+- purpose mismatch
+- expired attestations
+- revoked attestations
+- superseded attestations
+- reverification-required attestations
+- internal-only retention
+- unsafe sensitivity
+- unsupported claims
+- raw provider payloads
+- raw evidence
+- support/internal metadata
+- public exposure
+- external submission flags
+- source mismatch
+
+The package carries the underlying policy decisions and machine-readable blocked reasons for auditability.
+
+## Export Minimization
+
+Exports include only `PortableAttestationExportSummary` objects approved by the policy gate.
+
+Exports exclude:
+
+- raw identity documents
+- raw title or registry payloads
+- raw provider payloads
+- support-console notes
+- internal reference ids
+- provider reference ids
+- unpublished governance metadata
+- public profile controls
+- external submission behavior
+- unsupported ownership, creditworthiness, subsidy, identity, or approval conclusions
+
+## Existing Institution Export Alignment
+
+`deriveInstitutionExportPackage` can now attach a `trustExport` and `portable_trust_summary` section only when portable attestations are explicitly supplied by the caller.
+
+Current routes do not load or pass portable attestations. This preserves existing institution export preview behavior and avoids share-package or public exposure changes.
+
+## Auditability
+
+Each institutional trust export package includes:
+
+- export id
+- generated timestamp
+- audience
+- purpose
+- consent-scoped flag
+- policy-gated flag
+- manual-only flag
+- public/external-submission disabled flags
+- portable attestation count
+- exportable attestation count
+- blocked attestation count
+- policy decision count
+
+This is metadata-only auditability. It is not an institution submission record and does not imply external delivery.
+
+## Guardrails Preserved
+
+This framework does not:
+
+- expose trust metadata publicly
+- widen tenant share packages
+- add institution APIs
+- add provider APIs
+- create public trust profiles
+- create reputation scores
+- automate institutional decisions
+- create credit reports
+- add blockchain, tokenization, or verifiable credential behavior
+- submit data to insurers, lenders, subsidy programs, or governments
+
+## Regression Risks
+
+- Future routes must explicitly prove they call this package layer and the attestation policy gate before any external projection.
+- Existing institution export previews are still operational summaries; trust metadata is included only when supplied by a guarded future caller.
+- Institution-specific schemas, packet signing, recipient delivery, consent UX, and revocation notifications remain future work.
+
+## Verification
+
+Tests cover:
+
+- export audience restrictions
+- policy gate enforcement
+- revoked, expired, and reverification-required blocking
+- export minimization and raw/internal metadata exclusion
+- unsupported claim blocking
+- support/internal metadata blocking
+- export audit metadata
+- optional guarded attachment to institution export previews

--- a/docs/architecture/portable-attestation-framework-v1.md
+++ b/docs/architecture/portable-attestation-framework-v1.md
@@ -208,6 +208,7 @@ This framework does not:
 - Institution-specific packet signing, revocation notification, and recipient policy matrices remain future work.
 - Property authority attestations must continue to carry non-ownership disclaimers.
 - The policy gate is currently a pure helper; future route/service adoption must still prove it is called before any external projection.
+- Institution Trust Export Framework v1 adds the first package-level composer for policy-gated portable trust summaries, but routes still must explicitly opt into supplying portable attestations.
 
 ## Verification
 

--- a/rentchain-api/src/lib/institutionExports/__tests__/deriveInstitutionExportPackage.test.ts
+++ b/rentchain-api/src/lib/institutionExports/__tests__/deriveInstitutionExportPackage.test.ts
@@ -1,5 +1,68 @@
 import { describe, expect, it } from "vitest";
 import { deriveInstitutionExportPackage } from "../deriveInstitutionExportPackage";
+import type { PortableAttestation } from "../../portableAttestations/portableAttestationTypes";
+
+function attestation(): PortableAttestation {
+  return {
+    attestationId: "institution-package-attestation-1",
+    attestationType: "property_authority",
+    subjectType: "property",
+    subjectId: "property:prop-1",
+    claimCategory: "property_authority",
+    claimLabel: "Property authority metadata present",
+    claimDescription: "Property authority metadata is present through an approved workflow.",
+    status: "active",
+    lifecycleState: "export_ready",
+    issuerCategory: "property_registry",
+    audience: "lender",
+    consentScope: {
+      consentId: "consent-1",
+      purpose: "lender_review",
+      audience: "lender",
+      grantedAt: "2026-05-01T00:00:00.000Z",
+      expiresAt: "2026-08-01T00:00:00.000Z",
+      revokedAt: null,
+      claimCategories: ["property_authority"],
+      attributeScopes: ["status", "timestamps"],
+    },
+    retentionClass: "portable_metadata",
+    evidenceSummary: {
+      evidenceCategory: "registry_record",
+      sourceSystem: "property_trust",
+      sourceCategory: "provider_neutral_property_trust",
+      sourceVersion: "property_trust.v1",
+      auditEventRef: "event-1",
+      rawEvidenceIncluded: false,
+    },
+    sourceReference: {
+      sourceSystem: "property_trust",
+      sourceId: "property-trust-1",
+      sourceAttestationId: "property-trust-attestation-1",
+      sourceVersion: "property_trust.v1",
+    },
+    confidence: "medium",
+    issuedAt: "2026-05-01T00:00:00.000Z",
+    effectiveAt: "2026-05-01T00:10:00.000Z",
+    expiresAt: "2026-08-01T00:00:00.000Z",
+    revokedAt: null,
+    supersededAt: null,
+    nextReverificationAt: "2026-07-01T00:00:00.000Z",
+    jurisdiction: "CA",
+    redactionProfile: "strict",
+    metadataOnly: true,
+    rawSensitivePayloadStored: false,
+    rawProviderPayloadIncluded: false,
+    supportMetadataIncluded: false,
+    publicAccessEnabled: false,
+    externalSubmissionEnabled: false,
+    unsupportedClaim: false,
+    supportVisible: true,
+    reviewRequired: false,
+    nonAuthorityDisclaimers: ["Property authority metadata is not a legal ownership conclusion."],
+    internalReferenceId: "internal-reference",
+    providerReferenceId: "provider-reference",
+  };
+}
 
 describe("deriveInstitutionExportPackage", () => {
   it("derives a deterministic preview package with manual-only safeguards", () => {
@@ -90,5 +153,40 @@ describe("deriveInstitutionExportPackage", () => {
       ])
     );
     expect(JSON.stringify(pkg.payloadPreview)).not.toMatch(/123-45-6789|creditReport|000123|tenant-1/);
+  });
+
+  it("optionally attaches policy-gated portable trust exports without changing route adoption", () => {
+    const pkg = deriveInstitutionExportPackage({
+      packageType: "lender_due_diligence",
+      landlordId: "landlord-1",
+      generatedAt: "2026-05-05T12:00:00.000Z",
+      properties: [{ id: "prop-1", status: "active", unitsCount: 1 }],
+      portableAttestations: [attestation()],
+    });
+
+    expect(pkg.trustExport).toEqual(
+      expect.objectContaining({
+        audience: "lender",
+        purpose: "lender_review",
+        status: "export_ready",
+        metadataOnly: true,
+        publicAccessEnabled: false,
+        externalSubmissionEnabled: false,
+      })
+    );
+    expect(pkg.sections).toEqual(
+      expect.arrayContaining([expect.objectContaining({ sectionKey: "portable_trust_summary", status: "included", recordsCount: 1 })])
+    );
+    expect(pkg.payloadPreview.portableTrustSummary).toEqual(
+      expect.objectContaining({
+        exportableAttestationCount: 1,
+        policyDecisionCount: 1,
+        metadataOnly: true,
+        publicAccessEnabled: false,
+        externalSubmissionEnabled: false,
+      })
+    );
+    expect(JSON.stringify(pkg.trustExport)).not.toContain("provider-reference");
+    expect(JSON.stringify(pkg.trustExport)).not.toContain("internal-reference");
   });
 });

--- a/rentchain-api/src/lib/institutionExports/deriveInstitutionExportPackage.ts
+++ b/rentchain-api/src/lib/institutionExports/deriveInstitutionExportPackage.ts
@@ -8,6 +8,10 @@ import type {
   InstitutionExportSectionKey,
   InstitutionExportSectionStatus,
 } from "./institutionExportTypes";
+import {
+  deriveInstitutionalTrustExportPackage,
+  institutionalTrustExportMappingForPackageType,
+} from "../institutionTrustExports/deriveInstitutionalTrustExportPackage";
 
 const PACKAGE_AUDIENCE: Record<InstitutionExportPackageType, InstitutionExportAudience> = {
   lender_due_diligence: "lender",
@@ -178,6 +182,7 @@ export function deriveInstitutionExportPackage(input: DeriveInstitutionExportPac
   const maintenanceRequests = arrayOf(input.maintenanceRequests) as Array<Record<string, unknown>>;
   const decisionItems = arrayOf(input.decisionItems) as Array<Record<string, any>>;
   const auditEvents = arrayOf(input.auditEvents);
+  const portableAttestations = Array.isArray(input.portableAttestations) ? input.portableAttestations : null;
 
   const blockedReasons: string[] = [];
   if (!landlordId) blockedReasons.push("Landlord context is required before an institution export preview can be prepared.");
@@ -243,6 +248,27 @@ export function deriveInstitutionExportPackage(input: DeriveInstitutionExportPac
     ),
   ];
 
+  const trustExport = portableAttestations
+    ? deriveInstitutionalTrustExportPackage({
+        exportId: `institutional_trust_export:${packageType}:${landlordId || "missing_landlord"}`,
+        ...institutionalTrustExportMappingForPackageType(packageType),
+        generatedAt,
+        attestations: portableAttestations,
+      })
+    : null;
+
+  if (trustExport) {
+    sections.push(
+      section(
+        "portable_trust_summary",
+        "Portable trust summary",
+        trustExport.status === "export_ready" ? "included" : trustExport.status === "blocked" ? "blocked" : "unavailable",
+        trustExport.exportSummaries.length,
+        trustExport.blockedReasons
+      )
+    );
+  }
+
   return {
     packageId: cleanId(`institution_export:${packageType}:${landlordId || "missing_landlord"}`),
     packageType,
@@ -254,6 +280,7 @@ export function deriveInstitutionExportPackage(input: DeriveInstitutionExportPac
     sections,
     blockedReasons,
     redactions: DEFAULT_REDACTIONS,
+    trustExport,
     payloadPreview: {
       packageType,
       audience,
@@ -285,6 +312,19 @@ export function deriveInstitutionExportPackage(input: DeriveInstitutionExportPac
       auditEventSummary: {
         total: auditEvents.length,
       },
+      portableTrustSummary: trustExport
+        ? {
+            status: trustExport.status,
+            audience: trustExport.audience,
+            purpose: trustExport.purpose,
+            exportableAttestationCount: trustExport.auditMetadata.exportableAttestationCount,
+            blockedAttestationCount: trustExport.auditMetadata.blockedAttestationCount,
+            policyDecisionCount: trustExport.auditMetadata.policyDecisionCount,
+            metadataOnly: true,
+            publicAccessEnabled: false,
+            externalSubmissionEnabled: false,
+          }
+        : null,
     },
   };
 }

--- a/rentchain-api/src/lib/institutionExports/institutionExportTypes.ts
+++ b/rentchain-api/src/lib/institutionExports/institutionExportTypes.ts
@@ -1,3 +1,6 @@
+import type { InstitutionalTrustExportPackage } from "../institutionTrustExports/institutionTrustExportTypes";
+import type { PortableAttestation } from "../portableAttestations/portableAttestationTypes";
+
 export type InstitutionExportPackageType =
   | "lender_due_diligence"
   | "insurance_review"
@@ -18,7 +21,8 @@ export type InstitutionExportSectionKey =
   | "decision_summary"
   | "delinquency_summary"
   | "maintenance_summary"
-  | "audit_event_summary";
+  | "audit_event_summary"
+  | "portable_trust_summary";
 
 export type InstitutionExportSection = {
   sectionKey: InstitutionExportSectionKey;
@@ -45,6 +49,7 @@ export type InstitutionExportPackage = {
   blockedReasons: string[];
   redactions: InstitutionExportRedaction[];
   payloadPreview: Record<string, unknown>;
+  trustExport: InstitutionalTrustExportPackage | null;
 };
 
 export type InstitutionExportPropertyInput = {
@@ -100,4 +105,5 @@ export type DeriveInstitutionExportPackageInput = {
   maintenanceRequests?: InstitutionExportMaintenanceInput[] | null;
   decisionItems?: InstitutionExportDecisionInput[] | null;
   auditEvents?: unknown[] | null;
+  portableAttestations?: PortableAttestation[] | null;
 };

--- a/rentchain-api/src/lib/institutionTrustExports/__tests__/deriveInstitutionalTrustExportPackage.test.ts
+++ b/rentchain-api/src/lib/institutionTrustExports/__tests__/deriveInstitutionalTrustExportPackage.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+import { deriveInstitutionalTrustExportPackage } from "../deriveInstitutionalTrustExportPackage";
+import type { PortableAttestation } from "../../portableAttestations/portableAttestationTypes";
+
+function attestation(overrides: Partial<PortableAttestation> = {}): PortableAttestation {
+  return {
+    attestationId: "trust-export-attestation-1",
+    attestationType: "identity_assurance",
+    subjectType: "tenant",
+    subjectId: "tenant:tenant-1",
+    claimCategory: "identity_assurance",
+    claimLabel: "Identity assurance metadata present",
+    claimDescription: "Identity assurance metadata is present through an approved workflow.",
+    status: "active",
+    lifecycleState: "export_ready",
+    issuerCategory: "identity_provider",
+    audience: "insurer",
+    consentScope: {
+      consentId: "consent-1",
+      purpose: "insurance_review",
+      audience: "insurer",
+      grantedAt: "2026-05-01T00:00:00.000Z",
+      expiresAt: "2026-08-01T00:00:00.000Z",
+      revokedAt: null,
+      claimCategories: ["identity_assurance"],
+      attributeScopes: ["status", "timestamps"],
+    },
+    retentionClass: "portable_metadata",
+    evidenceSummary: {
+      evidenceCategory: "provider_reference",
+      sourceSystem: "identity_assurance",
+      sourceCategory: "provider_neutral_identity_assurance",
+      sourceVersion: "identity_assurance.v1",
+      auditEventRef: "event-1",
+      rawEvidenceIncluded: false,
+    },
+    sourceReference: {
+      sourceSystem: "identity_assurance",
+      sourceId: "identity-source-1",
+      sourceAttestationId: "identity-assurance-1",
+      sourceVersion: "identity_assurance.v1",
+    },
+    confidence: "high",
+    issuedAt: "2026-05-01T00:00:00.000Z",
+    effectiveAt: "2026-05-01T00:10:00.000Z",
+    expiresAt: "2026-08-01T00:00:00.000Z",
+    revokedAt: null,
+    supersededAt: null,
+    nextReverificationAt: "2026-07-01T00:00:00.000Z",
+    jurisdiction: "CA",
+    redactionProfile: "strict",
+    metadataOnly: true,
+    rawSensitivePayloadStored: false,
+    rawProviderPayloadIncluded: false,
+    supportMetadataIncluded: false,
+    publicAccessEnabled: false,
+    externalSubmissionEnabled: false,
+    unsupportedClaim: false,
+    supportVisible: true,
+    reviewRequired: false,
+    nonAuthorityDisclaimers: ["RentChain stores metadata only and is not the identity authority."],
+    internalReferenceId: "internal-reference",
+    providerReferenceId: "provider-reference",
+    ...overrides,
+  };
+}
+
+describe("deriveInstitutionalTrustExportPackage", () => {
+  it("builds a policy-gated insurer export package from consent-scoped portable attestations", () => {
+    const pkg = deriveInstitutionalTrustExportPackage({
+      exportId: "trust-export-1",
+      audience: "insurer",
+      purpose: "insurance_review",
+      generatedAt: "2026-05-08T00:00:00.000Z",
+      attestations: [attestation()],
+    });
+
+    expect(pkg).toEqual(
+      expect.objectContaining({
+        exportId: "trust-export-1",
+        schemaVersion: "institutional_trust_export.v1",
+        audience: "insurer",
+        purpose: "insurance_review",
+        status: "export_ready",
+        lifecycle: "policy_evaluated",
+        metadataOnly: true,
+        consentScoped: true,
+        policyGated: true,
+        manualOnly: true,
+        publicAccessEnabled: false,
+        externalSubmissionEnabled: false,
+      })
+    );
+    expect(pkg.exportSummaries).toHaveLength(1);
+    expect(pkg.policyDecisions[0].reasons).toEqual(["export_allowed"]);
+    expect(pkg.auditMetadata).toEqual(
+      expect.objectContaining({
+        exportableAttestationCount: 1,
+        blockedAttestationCount: 0,
+        policyDecisionCount: 1,
+      })
+    );
+  });
+
+  it("blocks revoked, expired, and reverification-required attestations through the policy gate", () => {
+    const pkg = deriveInstitutionalTrustExportPackage({
+      audience: "insurer",
+      purpose: "insurance_review",
+      generatedAt: "2026-05-08T00:00:00.000Z",
+      attestations: [
+        attestation({ attestationId: "revoked", revokedAt: "2026-05-02T00:00:00.000Z" }),
+        attestation({ attestationId: "expired", expiresAt: "2026-05-01T00:00:00.000Z" }),
+        attestation({ attestationId: "reverify", nextReverificationAt: "2026-05-01T00:00:00.000Z" }),
+      ],
+    });
+
+    expect(pkg.status).toBe("blocked");
+    expect(pkg.exportSummaries).toHaveLength(0);
+    expect(pkg.blockedReasons).toEqual(
+      expect.arrayContaining([
+        "revoked: revoked",
+        "expired: expired",
+        "reverify: reverification_required",
+      ])
+    );
+    expect(pkg.auditMetadata.blockedAttestationCount).toBe(3);
+  });
+
+  it("enforces audience restrictions and excludes raw/internal references from export payloads", () => {
+    const lenderPackage = deriveInstitutionalTrustExportPackage({
+      audience: "lender",
+      purpose: "lender_review",
+      generatedAt: "2026-05-08T00:00:00.000Z",
+      attestations: [attestation()],
+    });
+    const insurerPackage = deriveInstitutionalTrustExportPackage({
+      audience: "insurer",
+      purpose: "insurance_review",
+      generatedAt: "2026-05-08T00:00:00.000Z",
+      attestations: [attestation()],
+    });
+
+    expect(lenderPackage.status).toBe("blocked");
+    expect(lenderPackage.blockedReasons).toEqual(expect.arrayContaining(["trust-export-attestation-1: audience_mismatch"]));
+    expect(JSON.stringify(insurerPackage.exportSummaries)).not.toContain("provider-reference");
+    expect(JSON.stringify(insurerPackage.exportSummaries)).not.toContain("internal-reference");
+    expect(JSON.stringify(insurerPackage.exportSummaries)).not.toContain("identity-source-1");
+  });
+
+  it("blocks internal-review contexts instead of treating them as portable exports", () => {
+    const pkg = deriveInstitutionalTrustExportPackage({
+      audience: "internal_review",
+      purpose: "internal_review",
+      generatedAt: "2026-05-08T00:00:00.000Z",
+      attestations: [attestation()],
+    });
+
+    expect(pkg.status).toBe("blocked");
+    expect(pkg.policyDecisions).toHaveLength(0);
+    expect(pkg.blockedReasons).toContain("Institutional trust export audience and purpose are not portable in this context.");
+  });
+
+  it("blocks raw payload, support metadata, and unsupported claims", () => {
+    const pkg = deriveInstitutionalTrustExportPackage({
+      audience: "insurer",
+      purpose: "insurance_review",
+      generatedAt: "2026-05-08T00:00:00.000Z",
+      attestations: [
+        attestation({ attestationId: "raw", rawProviderPayloadIncluded: true as false }),
+        attestation({ attestationId: "support", supportMetadataIncluded: true as false }),
+        attestation({ attestationId: "unsupported", unsupportedClaim: true as false }),
+      ],
+    });
+
+    expect(pkg.exportSummaries).toHaveLength(0);
+    expect(pkg.blockedReasons).toEqual(
+      expect.arrayContaining([
+        "raw: raw_payload_blocked",
+        "support: support_metadata_blocked",
+        "unsupported: unsupported_claim",
+      ])
+    );
+  });
+});

--- a/rentchain-api/src/lib/institutionTrustExports/deriveInstitutionalTrustExportPackage.ts
+++ b/rentchain-api/src/lib/institutionTrustExports/deriveInstitutionalTrustExportPackage.ts
@@ -1,0 +1,214 @@
+import type { InstitutionExportPackageType } from "../institutionExports/institutionExportTypes";
+import { buildPolicySafeExportSummary } from "../portableAttestations/attestationPolicyGate";
+import type {
+  AttestationPolicyDecision,
+  PortableAttestation,
+} from "../portableAttestations/portableAttestationTypes";
+import type {
+  DeriveInstitutionalTrustExportPackageInput,
+  InstitutionalTrustExportAudience,
+  InstitutionalTrustExportAudienceMapping,
+  InstitutionalTrustExportPackage,
+  InstitutionalTrustExportPurpose,
+  InstitutionalTrustExportRedaction,
+} from "./institutionTrustExportTypes";
+
+const REDACTIONS: InstitutionalTrustExportRedaction[] = [
+  {
+    fieldCategory: "raw_identity_documents",
+    reason: "Raw government ID documents, biometric payloads, and identity-provider payloads are excluded.",
+  },
+  {
+    fieldCategory: "raw_property_or_registry_payloads",
+    reason: "Raw title, registry, business, and property-provider payloads are excluded.",
+  },
+  {
+    fieldCategory: "support_internal_metadata",
+    reason: "Support-console notes, internal references, and unpublished governance metadata are excluded.",
+  },
+  {
+    fieldCategory: "unsupported_claims",
+    reason: "Unsupported verification, ownership, credit, subsidy, and approval claims are blocked.",
+  },
+  {
+    fieldCategory: "public_exposure",
+    reason: "Institutional trust exports are non-public, manual-only, and do not create public trust profiles.",
+  },
+];
+
+const PACKAGE_EXPORT_MAPPING: Record<InstitutionExportPackageType, InstitutionalTrustExportAudienceMapping> = {
+  lender_due_diligence: {
+    audience: "lender",
+    purpose: "lender_review",
+    portableAudience: "lender",
+    portablePurpose: "lender_review",
+  },
+  insurance_review: {
+    audience: "insurer",
+    purpose: "insurance_review",
+    portableAudience: "insurer",
+    portablePurpose: "insurance_review",
+  },
+  government_program_review: {
+    audience: "government_review",
+    purpose: "government_program_review",
+    portableAudience: "government",
+    portablePurpose: "government_program_review",
+  },
+  auditor_review: {
+    audience: "auditor",
+    purpose: "auditor_review",
+    portableAudience: "auditor",
+    portablePurpose: "auditor_review",
+  },
+  internal_admin_review: {
+    audience: "internal_review",
+    purpose: "internal_review",
+    portableAudience: null,
+    portablePurpose: null,
+  },
+};
+
+function asString(value: unknown, max = 240): string {
+  return String(value ?? "").trim().slice(0, max);
+}
+
+function normalizeGeneratedAt(value: unknown): string {
+  const raw = asString(value, 120);
+  const date = raw ? new Date(raw) : new Date();
+  return Number.isNaN(date.getTime()) ? new Date().toISOString() : date.toISOString();
+}
+
+function cleanId(value: unknown): string {
+  return asString(value, 240)
+    .toLowerCase()
+    .replace(/[\/\\#?]+/g, "_")
+    .replace(/[^a-z0-9_.:-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function arrayOf<T>(value: T[] | null | undefined): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function mappingForAudience(
+  audience: InstitutionalTrustExportAudience,
+  purpose: InstitutionalTrustExportPurpose
+): InstitutionalTrustExportAudienceMapping {
+  if (audience === "insurer" && purpose === "insurance_review") {
+    return { audience, purpose, portableAudience: "insurer", portablePurpose: "insurance_review" };
+  }
+  if (audience === "lender" && purpose === "lender_review") {
+    return { audience, purpose, portableAudience: "lender", portablePurpose: "lender_review" };
+  }
+  if (audience === "government_review" && purpose === "government_program_review") {
+    return { audience, purpose, portableAudience: "government", portablePurpose: "government_program_review" };
+  }
+  if (audience === "subsidy_program" && purpose === "government_program_review") {
+    return { audience, purpose, portableAudience: "government", portablePurpose: "government_program_review" };
+  }
+  if (audience === "auditor" && purpose === "auditor_review") {
+    return { audience, purpose, portableAudience: "auditor", portablePurpose: "auditor_review" };
+  }
+  if (audience === "institutional_landlord" && purpose === "institutional_landlord_review") {
+    return { audience, purpose, portableAudience: "institutional_landlord", portablePurpose: "future_institution_review" };
+  }
+  if (audience === "tenant_portability" && purpose === "tenant_controlled_portability") {
+    return { audience, purpose, portableAudience: "tenant", portablePurpose: "tenant_controlled_sharing" };
+  }
+  return { audience, purpose, portableAudience: null, portablePurpose: null };
+}
+
+export function institutionalTrustExportMappingForPackageType(
+  packageType: InstitutionExportPackageType
+): InstitutionalTrustExportAudienceMapping {
+  return PACKAGE_EXPORT_MAPPING[packageType];
+}
+
+function policyReasonLines(decisions: AttestationPolicyDecision[]) {
+  return decisions.flatMap((decision) =>
+    decision.allowed ? [] : decision.reasons.map((reason) => `${decision.attestationId}: ${reason}`)
+  );
+}
+
+export function deriveInstitutionalTrustExportPackage(
+  input: DeriveInstitutionalTrustExportPackageInput
+): InstitutionalTrustExportPackage {
+  const generatedAt = normalizeGeneratedAt(input.generatedAt);
+  const attestations = arrayOf<PortableAttestation>(input.attestations);
+  const mapping = mappingForAudience(input.audience, input.purpose);
+  const exportId = cleanId(input.exportId || `institutional_trust_export:${input.audience}:${input.purpose}`);
+  const policyDecisions: AttestationPolicyDecision[] = [];
+  const exportSummaries: InstitutionalTrustExportPackage["exportSummaries"] = [];
+  const blockedReasons: string[] = [];
+
+  if (!mapping.portableAudience || !mapping.portablePurpose) {
+    blockedReasons.push("Institutional trust export audience and purpose are not portable in this context.");
+  }
+
+  if (!attestations.length) {
+    blockedReasons.push("No portable attestations were provided for institution-safe trust export.");
+  }
+
+  if (mapping.portableAudience && mapping.portablePurpose) {
+    for (const attestation of attestations) {
+      const { decision, exportSummary } = buildPolicySafeExportSummary(attestation, {
+        operation: "export",
+        requestedAudience: mapping.portableAudience,
+        requestedPurpose: mapping.portablePurpose,
+        generatedAt,
+        sensitivity: "confidential",
+        publicRequest: false,
+      });
+      policyDecisions.push(decision);
+      if (exportSummary) exportSummaries.push(exportSummary);
+    }
+  }
+
+  blockedReasons.push(...policyReasonLines(policyDecisions));
+
+  const uniqueBlockedReasons = Array.from(new Set(blockedReasons));
+  const status = exportSummaries.length ? "export_ready" : uniqueBlockedReasons.length ? "blocked" : "unavailable";
+  const lifecycle = status === "export_ready" ? "policy_evaluated" : attestations.length ? "blocked" : "empty";
+
+  return {
+    exportId,
+    schemaVersion: "institutional_trust_export.v1",
+    audience: input.audience,
+    purpose: input.purpose,
+    status,
+    lifecycle,
+    generatedAt,
+    metadataOnly: true,
+    consentScoped: true,
+    policyGated: true,
+    manualOnly: true,
+    publicAccessEnabled: false,
+    externalSubmissionEnabled: false,
+    exportSummaries,
+    policyDecisions,
+    blockedReasons: uniqueBlockedReasons,
+    redactions: REDACTIONS,
+    provenance: {
+      source: "portable_attestations",
+      sourceSchemaVersion: "portable_attestation.v1",
+      sourceCount: attestations.length,
+      policyGate: "attestation_policy_gate.v1",
+    },
+    auditMetadata: {
+      exportId,
+      generatedAt,
+      audience: input.audience,
+      purpose: input.purpose,
+      consentScoped: true,
+      policyGated: true,
+      manualOnly: true,
+      publicAccessEnabled: false,
+      externalSubmissionEnabled: false,
+      portableAttestationCount: attestations.length,
+      exportableAttestationCount: exportSummaries.length,
+      blockedAttestationCount: policyDecisions.filter((decision) => !decision.allowed).length,
+      policyDecisionCount: policyDecisions.length,
+    },
+  };
+}

--- a/rentchain-api/src/lib/institutionTrustExports/index.ts
+++ b/rentchain-api/src/lib/institutionTrustExports/index.ts
@@ -1,0 +1,2 @@
+export * from "./institutionTrustExportTypes";
+export * from "./deriveInstitutionalTrustExportPackage";

--- a/rentchain-api/src/lib/institutionTrustExports/institutionTrustExportTypes.ts
+++ b/rentchain-api/src/lib/institutionTrustExports/institutionTrustExportTypes.ts
@@ -1,0 +1,95 @@
+import type {
+  AttestationPolicyDecision,
+  PortableAttestation,
+  PortableAttestationAudience,
+  PortableAttestationExportSummary,
+  PortableAttestationPurpose,
+} from "../portableAttestations/portableAttestationTypes";
+
+export type InstitutionalTrustExportAudience =
+  | "insurer"
+  | "lender"
+  | "institutional_landlord"
+  | "subsidy_program"
+  | "government_review"
+  | "tenant_portability"
+  | "auditor"
+  | "internal_review";
+
+export type InstitutionalTrustExportPurpose =
+  | "insurance_review"
+  | "lender_review"
+  | "government_program_review"
+  | "institutional_landlord_review"
+  | "tenant_controlled_portability"
+  | "auditor_review"
+  | "internal_review";
+
+export type InstitutionalTrustExportStatus = "export_ready" | "blocked" | "unavailable";
+
+export type InstitutionalTrustExportLifecycle = "policy_evaluated" | "blocked" | "empty";
+
+export type InstitutionalTrustExportRedaction = {
+  fieldCategory: string;
+  reason: string;
+};
+
+export type InstitutionalTrustExportProvenance = {
+  source: "portable_attestations";
+  sourceSchemaVersion: "portable_attestation.v1";
+  sourceCount: number;
+  policyGate: "attestation_policy_gate.v1";
+};
+
+export type InstitutionalTrustExportAuditMetadata = {
+  exportId: string;
+  generatedAt: string;
+  audience: InstitutionalTrustExportAudience;
+  purpose: InstitutionalTrustExportPurpose;
+  consentScoped: true;
+  policyGated: true;
+  manualOnly: true;
+  publicAccessEnabled: false;
+  externalSubmissionEnabled: false;
+  portableAttestationCount: number;
+  exportableAttestationCount: number;
+  blockedAttestationCount: number;
+  policyDecisionCount: number;
+};
+
+export type InstitutionalTrustExportPackage = {
+  exportId: string;
+  schemaVersion: "institutional_trust_export.v1";
+  audience: InstitutionalTrustExportAudience;
+  purpose: InstitutionalTrustExportPurpose;
+  status: InstitutionalTrustExportStatus;
+  lifecycle: InstitutionalTrustExportLifecycle;
+  generatedAt: string;
+  metadataOnly: true;
+  consentScoped: true;
+  policyGated: true;
+  manualOnly: true;
+  publicAccessEnabled: false;
+  externalSubmissionEnabled: false;
+  exportSummaries: PortableAttestationExportSummary[];
+  policyDecisions: AttestationPolicyDecision[];
+  blockedReasons: string[];
+  redactions: InstitutionalTrustExportRedaction[];
+  provenance: InstitutionalTrustExportProvenance;
+  auditMetadata: InstitutionalTrustExportAuditMetadata;
+};
+
+export type InstitutionalTrustExportAudienceMapping = {
+  audience: InstitutionalTrustExportAudience;
+  purpose: InstitutionalTrustExportPurpose;
+  portableAudience: PortableAttestationAudience | null;
+  portablePurpose: PortableAttestationPurpose | null;
+};
+
+export type DeriveInstitutionalTrustExportPackageInput = {
+  exportId?: unknown;
+  audience: InstitutionalTrustExportAudience;
+  purpose: InstitutionalTrustExportPurpose;
+  generatedAt?: unknown;
+  attestations?: PortableAttestation[] | null;
+};


### PR DESCRIPTION
## Summary
- Adds `institutionTrustExports`, a metadata-only institution-safe export composer for portable trust attestations.
- Maps export audiences/purposes to portable attestation policy contexts and gates every exported trust summary through `buildPolicySafeExportSummary`.
- Adds export audit metadata, provenance, minimization redactions, lifecycle/status fields, and blocked policy reasons.
- Optionally attaches a `trustExport` and `portable_trust_summary` section to existing institution export packages only when portable attestations are explicitly provided.

## Implementation Audit Summary
- Existing institution exports were manual-only previews with operational summaries and redactions, but no package-level portable trust export model.
- Portable attestations already had export-safe summaries and a deny-by-default policy gate, but future institution export adoption still needed a controlled package layer.
- Existing routes do not load or pass portable attestations; this PR preserves current route/share-package exposure behavior.

## Guardrails
- No public trust metadata exposure.
- No share-package widening.
- No provider or institution API integration.
- No automated institutional decisions.
- No raw provider, support, internal, identity, title, registry, banking, screening, or governance payload export.

## Tests
- Backend targeted: `npm run test:single -- src/lib/institutionTrustExports/__tests__/deriveInstitutionalTrustExportPackage.test.ts src/lib/institutionExports/__tests__/deriveInstitutionExportPackage.test.ts src/lib/portableAttestations/__tests__/attestationPolicyGate.test.ts src/lib/portableAttestations/__tests__/derivePortableAttestationSummary.test.ts`
- Backend full: `npm run test`
- Backend build: `npm run build`
- Frontend full: `npm run test`
- Frontend build: `npm run build`
- Root: `git diff --check`