### PR TITLE
Add tenant-controlled trust export

### DIFF
--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -1331,6 +1331,145 @@ describe("tenantPortalRoutes foundation", () => {
     });
   });
 
+  it("prepares tenant-controlled trust exports only after scoped consent", async () => {
+    const router = (await import("../tenantPortalRoutes")).default;
+    const missingConsent = await invokeRouter(router, {
+      method: "POST",
+      url: "/trust-exports",
+      body: {
+        audience: "tenant_portability",
+        consentAccepted: false,
+      },
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(missingConsent.status).toBe(400);
+    expect(missingConsent.body?.error).toBe("TENANT_TRUST_EXPORT_CONSENT_REQUIRED");
+
+    const preview = await invokeRouter(router, {
+      method: "POST",
+      url: "/trust-exports/preview",
+      body: {
+        audience: "tenant_portability",
+        consentAccepted: false,
+      },
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(preview.status).toBe(200);
+    expect(preview.body?.data?.lifecycle).toBe("consent_required");
+    expect(preview.body?.data?.includedClaims).toEqual([]);
+    expect(preview.body?.data?.publicAccessEnabled).toBe(false);
+    expect(preview.body?.data?.externalSubmissionEnabled).toBe(false);
+
+    const prepared = await invokeRouter(router, {
+      method: "POST",
+      url: "/trust-exports",
+      body: {
+        audience: "tenant_portability",
+        consentAccepted: true,
+      },
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(prepared.status).toBe(200);
+    expect(prepared.body?.data?.lifecycle).toBe("prepared");
+    expect(prepared.body?.data?.consent?.granted).toBe(true);
+    expect(prepared.body?.data?.package?.status).toBe("export_ready");
+    expect(prepared.body?.data?.package?.auditMetadata).toEqual(
+      expect.objectContaining({
+        consentScoped: true,
+        policyGated: true,
+        manualOnly: true,
+        publicAccessEnabled: false,
+        externalSubmissionEnabled: false,
+      })
+    );
+    const payload = JSON.stringify(prepared.body?.data || {});
+    expect(payload).not.toContain("drawnDataUrl");
+    expect(payload).not.toContain("documentUrl");
+    expect(payload).not.toContain("paymentMethod");
+    expect(payload).not.toContain("supportMetadataIncluded\":true");
+    expect(payload).not.toContain("publicAccessEnabled\":true");
+    expect(payload).not.toContain("externalSubmissionEnabled\":true");
+    expect(payload).not.toContain("tenant-1");
+  });
+
+  it("lists and revokes tenant-controlled trust exports without widening public share packages", async () => {
+    const router = (await import("../tenantPortalRoutes")).default;
+    const prepared = await invokeRouter(router, {
+      method: "POST",
+      url: "/trust-exports",
+      body: {
+        audience: "insurer",
+        consentAccepted: true,
+      },
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+    const exportId = prepared.body?.data?.exportId;
+
+    const listed = await invokeRouter(router, {
+      method: "GET",
+      url: "/trust-exports",
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+    expect(listed.status).toBe(200);
+    expect(listed.body?.data?.items?.[0]?.exportId).toBe(exportId);
+
+    const revoked = await invokeRouter(router, {
+      method: "POST",
+      url: `/trust-exports/${encodeURIComponent(exportId)}/revoke`,
+      headers: {
+        "x-test-user": JSON.stringify({
+          id: "user-1",
+          email: "tenant@example.com",
+          role: "tenant",
+          tenantId: "tenant-1",
+        }),
+      },
+    });
+
+    expect(revoked.status).toBe(200);
+    expect(revoked.body?.data?.lifecycle).toBe("revoked");
+    expect(revoked.body?.data?.consent?.granted).toBe(false);
+    expect(ensureCollection("tenantSharePackages").size).toBe(0);
+  });
+
   it("creates a tenant-owned metadata-only institutional handoff draft safely", async () => {
     const router = (await import("../tenantPortalRoutes")).default;
     const res = await invokeRouter(router, {

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -62,6 +62,12 @@ import {
   revokeTenantShareVerificationRequest,
   revokeTenantSharePackage,
 } from "../services/tenantPortal/tenantSharePackageService";
+import {
+  listTenantTrustExports,
+  prepareTenantTrustExport,
+  previewTenantTrustExport,
+  revokeTenantTrustExport,
+} from "../services/tenantPortal/tenantTrustExportService";
 import { recordSystemObservabilityEvent } from "../services/observability/recordSystemObservabilityEvent";
 import { buildLeasePaymentProjection } from "../services/projections/buildLeasePaymentProjection";
 
@@ -3162,6 +3168,116 @@ router.post("/identity/export", requireTenantWorkspaceIdentity, async (req: any,
     ok: true,
     data: institutionalIdentityPackage,
   });
+});
+
+router.get("/trust-exports", requireTenantWorkspaceIdentity, async (req: any, res) => {
+  const context = await resolveWorkspaceContextOrRespond(req, res);
+  if (!context) return;
+
+  const tenantId = String(req.user?.tenantId || context.tenantId || "").trim();
+  if (!tenantId) {
+    return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+  }
+
+  try {
+    const items = await listTenantTrustExports({ tenantId });
+    return res.json({ ok: true, data: { items } });
+  } catch (err: any) {
+    console.error("[tenant/trust-exports:list] failed", {
+      tenantId,
+      message: err?.message || "failed",
+    });
+    return res.status(500).json({ ok: false, error: "TENANT_TRUST_EXPORT_LIST_FAILED" });
+  }
+});
+
+router.post("/trust-exports/preview", requireTenantWorkspaceIdentity, async (req: any, res) => {
+  const context = await resolveWorkspaceContextOrRespond(req, res);
+  if (!context) return;
+
+  const tenantId = String(req.user?.tenantId || context.tenantId || "").trim();
+  if (!tenantId) {
+    return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+  }
+
+  try {
+    const preview = await previewTenantTrustExport({
+      tenantId,
+      audience: req.body?.audience,
+      purpose: req.body?.purpose,
+      expiresInDays: req.body?.expiresInDays,
+      consentAccepted: req.body?.consentAccepted === true,
+    });
+    if (!preview) {
+      return res.status(404).json({ ok: false, error: "TENANT_TRUST_EXPORT_UNAVAILABLE" });
+    }
+    return res.json({ ok: true, data: preview });
+  } catch (err: any) {
+    console.error("[tenant/trust-exports:preview] failed", {
+      tenantId,
+      message: err?.message || "failed",
+    });
+    return res.status(500).json({ ok: false, error: "TENANT_TRUST_EXPORT_PREVIEW_FAILED" });
+  }
+});
+
+router.post("/trust-exports", requireTenantWorkspaceIdentity, async (req: any, res) => {
+  const context = await resolveWorkspaceContextOrRespond(req, res);
+  if (!context) return;
+
+  const tenantId = String(req.user?.tenantId || context.tenantId || "").trim();
+  if (!tenantId) {
+    return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+  }
+
+  try {
+    const prepared = await prepareTenantTrustExport({
+      tenantId,
+      audience: req.body?.audience,
+      purpose: req.body?.purpose,
+      expiresInDays: req.body?.expiresInDays,
+      consentAccepted: req.body?.consentAccepted === true,
+    });
+    if (!prepared) {
+      return res.status(404).json({ ok: false, error: "TENANT_TRUST_EXPORT_UNAVAILABLE" });
+    }
+    return res.json({ ok: true, data: prepared });
+  } catch (err: any) {
+    if (err?.message === "tenant_trust_export_consent_required") {
+      return res.status(400).json({ ok: false, error: "TENANT_TRUST_EXPORT_CONSENT_REQUIRED" });
+    }
+    console.error("[tenant/trust-exports:prepare] failed", {
+      tenantId,
+      message: err?.message || "failed",
+    });
+    return res.status(500).json({ ok: false, error: "TENANT_TRUST_EXPORT_PREPARE_FAILED" });
+  }
+});
+
+router.post("/trust-exports/:id/revoke", requireTenantWorkspaceIdentity, async (req: any, res) => {
+  const context = await resolveWorkspaceContextOrRespond(req, res);
+  if (!context) return;
+
+  const tenantId = String(req.user?.tenantId || context.tenantId || "").trim();
+  const exportId = String(req.params?.id || "").trim();
+  if (!tenantId || !exportId) {
+    return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+  }
+
+  try {
+    const revoked = await revokeTenantTrustExport({ tenantId, exportId });
+    if (!revoked) {
+      return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+    }
+    return res.json({ ok: true, data: revoked });
+  } catch (err: any) {
+    console.error("[tenant/trust-exports:revoke] failed", {
+      tenantId,
+      exportId,
+      message: err?.message || "failed",
+    });
+    return res.status(500).json({ ok: false, error: "TENANT_TRUST_EXPORT_REVOKE_FAILED" });
+  }
 });
 
 router.post("/institutional/handoffs", requireTenantWorkspaceIdentity, async (req: any, res: any) => {

--- a/rentchain-api/src/services/tenantPortal/__tests__/tenantTrustExportService.test.ts
+++ b/rentchain-api/src/services/tenantPortal/__tests__/tenantTrustExportService.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const collections = new Map<string, Map<string, any>>();
+let generatedId = 0;
+
+function ensureCollection(name: string) {
+  if (!collections.has(name)) collections.set(name, new Map());
+  return collections.get(name)!;
+}
+
+const dbMock = {
+  collection: (name: string) => ({
+    async get() {
+      const docs = Array.from(ensureCollection(name).entries()).map(([id, data]) => ({
+        id,
+        data: () => data,
+      }));
+      return { docs, empty: docs.length === 0 };
+    },
+    doc: (id?: string) => {
+      const resolvedId = id || `generated-${++generatedId}`;
+      return {
+        id: resolvedId,
+        async get() {
+          const entry = ensureCollection(name).get(resolvedId);
+          return {
+            id: resolvedId,
+            exists: Boolean(entry),
+            data: () => entry,
+          };
+        },
+        async set(payload: any, options?: { merge?: boolean }) {
+          const current = ensureCollection(name).get(resolvedId) || {};
+          ensureCollection(name).set(resolvedId, options?.merge ? { ...current, ...(payload || {}) } : payload || {});
+        },
+      };
+    },
+    where: (field: string, _op: string, value: any) => ({
+      limit: (_count: number) => ({
+        async get() {
+          const docs = Array.from(ensureCollection(name).entries())
+            .filter(([, data]) => data?.[field] === value)
+            .map(([id, data]) => ({
+              id,
+              data: () => data,
+            }));
+          return { docs, empty: docs.length === 0 };
+        },
+      }),
+    }),
+  }),
+};
+
+const resolveTenancyContext = vi.fn();
+const loadTenantIdentityRecord = vi.fn();
+
+vi.mock("../../../config/firebase", () => ({ db: dbMock }));
+vi.mock("../tenancyContextService", () => ({ resolveTenancyContext }));
+vi.mock("../tenantProfileService", () => ({ loadTenantIdentityRecord }));
+
+describe("tenantTrustExportService", () => {
+  beforeEach(() => {
+    collections.clear();
+    generatedId = 0;
+    vi.clearAllMocks();
+    ensureCollection("tenants").set("tenant-1", {
+      email: "tenant@example.com",
+      leaseId: "lease-1",
+    });
+    ensureCollection("leases").set("lease-1", {
+      status: "active",
+      startDate: "2026-02-01",
+      endDate: "2027-01-31",
+      monthlyRent: 1800,
+      dueDay: 1,
+    });
+    resolveTenancyContext.mockResolvedValue({
+      ok: true,
+      authority: "active_tenant",
+      propertyId: "prop-1",
+      applicationId: "app-1",
+      leaseId: "lease-1",
+      tenantId: "tenant-1",
+      unitId: "unit-1",
+    });
+    loadTenantIdentityRecord.mockResolvedValue({
+      identityStatus: "verified",
+      profile: { completionStatus: "complete" },
+      application: { reusable: true, lastSubmittedAt: "2026-04-20T00:00:00.000Z" },
+      documents: { completionStatus: "complete", missingCategories: [] },
+      screening: { status: "completed", lastCompletedAt: "2026-04-21T00:00:00.000Z" },
+      leases: { activeCount: 1, historicalCount: 1, lastSignedAt: "2026-04-22T00:00:00.000Z" },
+      verification: { level: "strong" },
+      readinessLabel: "Well established",
+      readinessDescription: "Completed verification signals are available.",
+    });
+  });
+
+  it("blocks preview export summaries until explicit tenant consent is present", async () => {
+    const service = await import("../tenantTrustExportService");
+
+    const preview = await service.previewTenantTrustExport({
+      tenantId: "tenant-1",
+      audience: "tenant_portability",
+      consentAccepted: false,
+    });
+
+    expect(preview?.lifecycle).toBe("consent_required");
+    expect(preview?.consent.granted).toBe(false);
+    expect(preview?.includedClaims).toEqual([]);
+    expect(preview?.excludedClaims.length).toBeGreaterThan(0);
+    expect(JSON.stringify(preview)).not.toContain("documentUrl");
+    expect(JSON.stringify(preview)).not.toContain("paymentMethod");
+    expect(preview?.publicAccessEnabled).toBe(false);
+    expect(preview?.externalSubmissionEnabled).toBe(false);
+  });
+
+  it("prepares a consent-scoped metadata-only trust export without public exposure", async () => {
+    const service = await import("../tenantTrustExportService");
+
+    const prepared = await service.prepareTenantTrustExport({
+      tenantId: "tenant-1",
+      audience: "tenant_portability",
+      consentAccepted: true,
+    });
+
+    expect(prepared?.lifecycle).toBe("prepared");
+    expect(prepared?.consent.granted).toBe(true);
+    expect(prepared?.package.status).toBe("export_ready");
+    expect(prepared?.includedClaims.map((claim) => claim.claimCategory)).toEqual(
+      expect.arrayContaining(["identity_assurance", "tenant_portability", "lease_participation", "payment_readiness"])
+    );
+    expect(prepared?.package.auditMetadata).toEqual(
+      expect.objectContaining({
+        consentScoped: true,
+        policyGated: true,
+        manualOnly: true,
+        publicAccessEnabled: false,
+        externalSubmissionEnabled: false,
+      })
+    );
+    const payload = JSON.stringify(prepared || {});
+    expect(payload).not.toContain("rawProviderPayloadIncluded\":true");
+    expect(payload).not.toContain("supportMetadataIncluded\":true");
+    expect(payload).not.toContain("publicAccessEnabled\":true");
+    expect(payload).not.toContain("externalSubmissionEnabled\":true");
+    expect(payload).not.toContain("tenant-1");
+    expect(ensureCollection("tenantTrustExports").size).toBe(1);
+    expect(Array.from(ensureCollection("tenantTrustExports").values())[0]?.tenantId).toBe("tenant-1");
+  });
+
+  it("requires consent before preparation and lets the owning tenant revoke the record", async () => {
+    const service = await import("../tenantTrustExportService");
+
+    await expect(
+      service.prepareTenantTrustExport({
+        tenantId: "tenant-1",
+        audience: "insurer",
+        consentAccepted: false,
+      })
+    ).rejects.toThrow("tenant_trust_export_consent_required");
+
+    const prepared = await service.prepareTenantTrustExport({
+      tenantId: "tenant-1",
+      audience: "insurer",
+      consentAccepted: true,
+    });
+    const blocked = await service.revokeTenantTrustExport({
+      tenantId: "tenant-2",
+      exportId: prepared?.exportId || "",
+    });
+    expect(blocked).toBe(false);
+
+    const revoked = await service.revokeTenantTrustExport({
+      tenantId: "tenant-1",
+      exportId: prepared?.exportId || "",
+    });
+    expect(revoked && revoked.lifecycle).toBe("revoked");
+    expect(revoked && revoked.consent.granted).toBe(false);
+    expect(revoked && revoked.consent.revokedAt).toBeTruthy();
+  });
+});

--- a/rentchain-api/src/services/tenantPortal/tenantTrustExportService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantTrustExportService.ts
@@ -1,0 +1,746 @@
+import crypto from "crypto";
+import { db } from "../../config/firebase";
+import {
+  deriveInstitutionalTrustExportPackage,
+  type InstitutionalTrustExportAudience,
+  type InstitutionalTrustExportPackage,
+  type InstitutionalTrustExportPurpose,
+} from "../../lib/institutionTrustExports";
+import type {
+  PortableAttestation,
+  PortableAttestationAudience,
+  PortableAttestationClaimCategory,
+  PortableAttestationPurpose,
+} from "../../lib/portableAttestations";
+import { deriveTenantCredibilitySignals } from "../tenantCredibility/deriveTenantCredibilitySignals";
+import { deriveIdentityPortability, type PortableIdentity } from "../identityPortability/deriveIdentityPortability";
+import { deriveIdentityTimeline } from "../identityTimeline/deriveIdentityTimeline";
+import { derivePaymentReadiness, type PaymentReadiness } from "../paymentReadiness/derivePaymentReadiness";
+import { resolveTenancyContext } from "./tenancyContextService";
+import {
+  loadTenantIdentityRecord,
+  type TenantIdentityRecord,
+} from "./tenantProfileService";
+
+const COLLECTION = "tenantTrustExports";
+const CONSENT_VERSION = "tenant_trust_export_consent.v1";
+const DEFAULT_EXPIRES_DAYS = 14;
+const MAX_EXPIRES_DAYS = 30;
+
+export type TenantTrustExportAudience =
+  | "tenant_portability"
+  | "insurer"
+  | "lender"
+  | "institutional_landlord"
+  | "auditor";
+
+export type TenantTrustExportPurpose =
+  | "tenant_controlled_portability"
+  | "insurance_review"
+  | "lender_review"
+  | "institutional_landlord_review"
+  | "auditor_review";
+
+export type TenantTrustExportLifecycle =
+  | "preview"
+  | "prepared"
+  | "revoked"
+  | "expired"
+  | "blocked"
+  | "consent_required";
+
+export type TenantTrustExportConsentState = {
+  required: true;
+  granted: boolean;
+  consentId: string | null;
+  consentVersion: typeof CONSENT_VERSION;
+  grantedAt: string | null;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  audience: TenantTrustExportAudience;
+  purpose: TenantTrustExportPurpose;
+  claimCategories: PortableAttestationClaimCategory[];
+  summary:
+    "Tenant consent is required before RentChain prepares this non-public, metadata-only trust export package.";
+};
+
+export type TenantTrustExportPreview = {
+  exportId: string | null;
+  schemaVersion: "tenant_trust_export.v1";
+  audience: TenantTrustExportAudience;
+  purpose: TenantTrustExportPurpose;
+  lifecycle: TenantTrustExportLifecycle;
+  consent: TenantTrustExportConsentState;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  generatedAt: string;
+  metadataOnly: true;
+  publicAccessEnabled: false;
+  externalSubmissionEnabled: false;
+  policyGated: true;
+  package: InstitutionalTrustExportPackage;
+  includedClaims: Array<{
+    attestationId: string;
+    claimCategory: PortableAttestationClaimCategory;
+    claimLabel: string;
+    lifecycleState: string;
+    consentExpiresAt: string | null;
+  }>;
+  excludedClaims: Array<{
+    attestationId: string;
+    claimCategory: PortableAttestationClaimCategory;
+    claimLabel: string;
+    reasons: string[];
+  }>;
+  redactions: string[];
+  disclaimers: string[];
+};
+
+export type TenantTrustExportRecord = TenantTrustExportPreview & {
+  exportId: string;
+  lifecycle: "prepared" | "revoked" | "expired" | "blocked";
+  createdAt: string;
+  updatedAt: string;
+};
+
+type TenantTrustContext = {
+  tenantId: string;
+  identity: TenantIdentityRecord;
+  portableIdentity: PortableIdentity;
+  paymentReadiness: PaymentReadiness | null;
+  leaseSummary: {
+    status: string | null;
+    startDate: string | null;
+    endDate: string | null;
+    monthlyRent: number | null;
+  } | null;
+};
+
+type TenantTrustExportStoredRecord = TenantTrustExportRecord & {
+  tenantId: string;
+};
+
+function asString(value: unknown, max = 240): string | null {
+  const next = String(value ?? "").trim().slice(0, max);
+  return next || null;
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function addDaysIso(start: string, days: number) {
+  return new Date(Date.parse(start) + days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+function clampExpiresInDays(value: unknown) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return DEFAULT_EXPIRES_DAYS;
+  return Math.min(Math.max(Math.round(numeric), 1), MAX_EXPIRES_DAYS);
+}
+
+function sanitizeAudience(value: unknown): TenantTrustExportAudience {
+  return value === "insurer" ||
+    value === "lender" ||
+    value === "institutional_landlord" ||
+    value === "auditor"
+    ? value
+    : "tenant_portability";
+}
+
+function purposeForAudience(audience: TenantTrustExportAudience): TenantTrustExportPurpose {
+  if (audience === "insurer") return "insurance_review";
+  if (audience === "lender") return "lender_review";
+  if (audience === "institutional_landlord") return "institutional_landlord_review";
+  if (audience === "auditor") return "auditor_review";
+  return "tenant_controlled_portability";
+}
+
+function sanitizePurpose(value: unknown, audience: TenantTrustExportAudience): TenantTrustExportPurpose {
+  void value;
+  return purposeForAudience(audience);
+}
+
+function toPortableAudience(audience: TenantTrustExportAudience): PortableAttestationAudience {
+  if (audience === "tenant_portability") return "tenant";
+  return audience;
+}
+
+function toPortablePurpose(purpose: TenantTrustExportPurpose): PortableAttestationPurpose {
+  if (purpose === "tenant_controlled_portability") return "tenant_controlled_sharing";
+  if (purpose === "institutional_landlord_review") return "future_institution_review";
+  return purpose;
+}
+
+function toInstitutionalAudience(audience: TenantTrustExportAudience): InstitutionalTrustExportAudience {
+  return audience;
+}
+
+function toInstitutionalPurpose(purpose: TenantTrustExportPurpose): InstitutionalTrustExportPurpose {
+  return purpose;
+}
+
+function consentIdFor(params: {
+  tenantId: string;
+  audience: TenantTrustExportAudience;
+  purpose: TenantTrustExportPurpose;
+  generatedAt: string;
+}) {
+  const subjectRef = crypto.createHash("sha256").update(params.tenantId).digest("hex").slice(0, 16);
+  return [
+    "tenant_trust_export_consent",
+    subjectRef,
+    params.audience,
+    params.purpose,
+    Date.parse(params.generatedAt).toString(36),
+  ]
+    .join(":")
+    .replace(/[^a-zA-Z0-9_.:-]+/g, "_");
+}
+
+function exportIdFor(params: {
+  tenantId: string;
+  audience: TenantTrustExportAudience;
+  purpose: TenantTrustExportPurpose;
+  generatedAt: string;
+}) {
+  const subjectRef = crypto.createHash("sha256").update(params.tenantId).digest("hex").slice(0, 16);
+  return [
+    "tenant_trust_export",
+    subjectRef,
+    params.audience,
+    params.purpose,
+    Date.parse(params.generatedAt).toString(36),
+  ]
+    .join(":")
+    .replace(/[^a-zA-Z0-9_.:-]+/g, "_");
+}
+
+async function resolveTenantTrustContext(tenantId: string): Promise<TenantTrustContext | null> {
+  const tenantSnap = await db.collection("tenants").doc(tenantId).get().catch(() => null as any);
+  const tenantData = tenantSnap?.exists ? ((tenantSnap.data() as any) || {}) : {};
+  const email = asString(tenantData?.email);
+  const context = await resolveTenancyContext({
+    uid: tenantId,
+    email,
+    tenantId,
+    leaseId: asString(tenantData?.leaseId) || asString(tenantData?.currentLeaseId),
+  });
+  if (!context?.ok) return null;
+
+  const identity = await loadTenantIdentityRecord({
+    context,
+    userId: tenantId,
+    userEmail: email,
+  });
+  if (!identity) return null;
+
+  const leaseSnap = context.leaseId
+    ? await db.collection("leases").doc(String(context.leaseId || "")).get().catch(() => null as any)
+    : null;
+  const lease = leaseSnap?.exists ? ((leaseSnap.data() as any) || {}) : null;
+  const paymentReadiness = lease
+    ? derivePaymentReadiness({
+        leaseId: String(context.leaseId || ""),
+        monthlyRent: lease?.monthlyRent,
+        startDate: lease?.startDate,
+        endDate: lease?.endDate,
+        dueDay: lease?.dueDay,
+        tenantId,
+        propertyId: context.propertyId,
+        unitId: context.unitId,
+        leaseExecution: null,
+      })
+    : null;
+
+  const { landlordSafeSummary } = deriveTenantCredibilitySignals({
+    tenantIdentityRecord: identity,
+    leaseExecution: null,
+  });
+  const identityTimeline = await deriveIdentityTimeline({
+    tenantId,
+    applicationId: context.applicationId,
+    leaseId: context.leaseId,
+  });
+  const { portableIdentity } = deriveIdentityPortability({
+    tenantIdentityRecord: identity,
+    credibilitySummary: landlordSafeSummary,
+    shareAvailability: { sharingEnabled: true },
+    timelineAvailability: {
+      hasIdentityTimeline: Array.isArray(identityTimeline?.events) && identityTimeline.events.length > 0,
+    },
+  });
+
+  return {
+    tenantId,
+    identity,
+    portableIdentity,
+    paymentReadiness,
+    leaseSummary: lease
+      ? {
+          status: asString(lease?.status),
+          startDate: asString(lease?.startDate),
+          endDate: asString(lease?.endDate),
+          monthlyRent: Number.isFinite(Number(lease?.monthlyRent)) ? Number(lease?.monthlyRent) : null,
+        }
+      : null,
+  };
+}
+
+function baseAttestation(params: {
+  attestationId: string;
+  claimCategory: PortableAttestationClaimCategory;
+  claimLabel: string;
+  claimDescription: string;
+  sourceCategory: string;
+  audience: PortableAttestationAudience;
+  purpose: PortableAttestationPurpose;
+  generatedAt: string;
+  consentId: string | null;
+  consentGrantedAt: string | null;
+  consentExpiresAt: string | null;
+  status?: PortableAttestation["status"];
+  lifecycleState?: PortableAttestation["lifecycleState"];
+  confidence?: PortableAttestation["confidence"];
+}): PortableAttestation {
+  return {
+    attestationId: params.attestationId,
+    attestationType: params.claimCategory === "identity_assurance" ? "identity_assurance" : "tenant_portability",
+    subjectType: "tenant",
+    subjectId: "tenant_controlled_subject",
+    claimCategory: params.claimCategory,
+    claimLabel: params.claimLabel,
+    claimDescription: params.claimDescription,
+    status: params.status || "active",
+    lifecycleState: params.lifecycleState || "export_ready",
+    issuerCategory: "rentchain",
+    audience: params.audience,
+    consentScope: {
+      consentId: params.consentId,
+      purpose: params.purpose,
+      audience: params.audience,
+      grantedAt: params.consentGrantedAt,
+      expiresAt: params.consentExpiresAt,
+      revokedAt: null,
+      claimCategories: [params.claimCategory],
+      attributeScopes: ["metadata_summary"],
+    },
+    retentionClass: "portable_metadata",
+    evidenceSummary: {
+      evidenceCategory: "metadata_only",
+      sourceSystem: "tenant_share_package",
+      sourceCategory: params.sourceCategory,
+      sourceVersion: "tenant_trust_export.v1",
+      auditEventRef: null,
+      rawEvidenceIncluded: false,
+    },
+    sourceReference: {
+      sourceSystem: "tenant_share_package",
+      sourceId: "tenant_controlled_trust_export",
+      sourceAttestationId: null,
+      sourceVersion: "tenant_trust_export.v1",
+    },
+    confidence: params.confidence || "medium",
+    issuedAt: params.generatedAt,
+    effectiveAt: params.generatedAt,
+    expiresAt: params.consentExpiresAt,
+    revokedAt: null,
+    supersededAt: null,
+    nextReverificationAt: null,
+    jurisdiction: null,
+    redactionProfile: "strict",
+    metadataOnly: true,
+    rawSensitivePayloadStored: false,
+    rawProviderPayloadIncluded: false,
+    supportMetadataIncluded: false,
+    publicAccessEnabled: false,
+    externalSubmissionEnabled: false,
+    unsupportedClaim: false,
+    supportVisible: true,
+    reviewRequired: true,
+    nonAuthorityDisclaimers: [
+      "This is a tenant-controlled metadata summary, not a public profile or automated approval.",
+      "RentChain is not making a credit, insurance, subsidy, ownership, or identity-authority decision.",
+    ],
+    internalReferenceId: null,
+    providerReferenceId: null,
+  };
+}
+
+function deriveTenantPortableAttestations(params: {
+  context: TenantTrustContext;
+  audience: TenantTrustExportAudience;
+  purpose: TenantTrustExportPurpose;
+  generatedAt: string;
+  consentGranted: boolean;
+  consentExpiresAt: string | null;
+}): PortableAttestation[] {
+  const portableAudience = toPortableAudience(params.audience);
+  const portablePurpose = toPortablePurpose(params.purpose);
+  const consentId = params.consentGranted
+    ? consentIdFor({
+        tenantId: params.context.tenantId,
+        audience: params.audience,
+        purpose: params.purpose,
+        generatedAt: params.generatedAt,
+      })
+    : null;
+  const consentGrantedAt = params.consentGranted ? params.generatedAt : null;
+  const attestations: PortableAttestation[] = [
+    baseAttestation({
+      attestationId: "tenant_trust:identity_assurance",
+      claimCategory: "identity_assurance",
+      claimLabel: "Identity assurance metadata available",
+      claimDescription: `Tenant identity profile status: ${params.context.identity.identityStatus}; verification level: ${params.context.identity.verification.level}.`,
+      sourceCategory: "tenant_identity_record",
+      audience: portableAudience,
+      purpose: portablePurpose,
+      generatedAt: params.generatedAt,
+      consentId,
+      consentGrantedAt,
+      consentExpiresAt: params.consentExpiresAt,
+      confidence: params.context.identity.verification.level === "strong" ? "high" : "medium",
+    }),
+    baseAttestation({
+      attestationId: "tenant_trust:tenant_portability",
+      claimCategory: "tenant_portability",
+      claimLabel: "Tenant portability metadata available",
+      claimDescription: `Portability status: ${params.context.portableIdentity.portabilityStatus}. Reusable across applications: ${
+        params.context.portableIdentity.reusableAcrossApplications ? "yes" : "not yet"
+      }.`,
+      sourceCategory: "tenant_portability_summary",
+      audience: portableAudience,
+      purpose: portablePurpose,
+      generatedAt: params.generatedAt,
+      consentId,
+      consentGrantedAt,
+      consentExpiresAt: params.consentExpiresAt,
+      confidence: params.context.portableIdentity.portabilityStatus === "ready" ? "high" : "medium",
+    }),
+  ];
+
+  if (params.context.leaseSummary) {
+    attestations.push(
+      baseAttestation({
+        attestationId: "tenant_trust:lease_participation",
+        claimCategory: "lease_participation",
+        claimLabel: "Lease participation metadata available",
+        claimDescription: `Tenant lease summary status: ${params.context.leaseSummary.status || "not_available"}.`,
+        sourceCategory: "tenant_lease_summary",
+        audience: portableAudience,
+        purpose: portablePurpose,
+        generatedAt: params.generatedAt,
+        consentId,
+        consentGrantedAt,
+        consentExpiresAt: params.consentExpiresAt,
+      })
+    );
+  }
+
+  if (params.context.paymentReadiness) {
+    attestations.push(
+      baseAttestation({
+        attestationId: "tenant_trust:payment_readiness",
+        claimCategory: "payment_readiness",
+        claimLabel: "Payment readiness metadata available",
+        claimDescription: `Payment readiness status: ${params.context.paymentReadiness.readinessStatus}.`,
+        sourceCategory: "payment_readiness_summary",
+        audience: portableAudience,
+        purpose: portablePurpose,
+        generatedAt: params.generatedAt,
+        consentId,
+        consentGrantedAt,
+        consentExpiresAt: params.consentExpiresAt,
+        confidence: "low",
+      })
+    );
+  }
+
+  return attestations;
+}
+
+function buildConsentState(params: {
+  audience: TenantTrustExportAudience;
+  purpose: TenantTrustExportPurpose;
+  generatedAt: string;
+  expiresAt: string | null;
+  consentGranted: boolean;
+  tenantId: string;
+  claimCategories: PortableAttestationClaimCategory[];
+}): TenantTrustExportConsentState {
+  return {
+    required: true,
+    granted: params.consentGranted,
+    consentId: params.consentGranted
+      ? consentIdFor({
+          tenantId: params.tenantId,
+          audience: params.audience,
+          purpose: params.purpose,
+          generatedAt: params.generatedAt,
+        })
+      : null,
+    consentVersion: CONSENT_VERSION,
+    grantedAt: params.consentGranted ? params.generatedAt : null,
+    expiresAt: params.expiresAt,
+    revokedAt: null,
+    audience: params.audience,
+    purpose: params.purpose,
+    claimCategories: params.claimCategories,
+    summary:
+      "Tenant consent is required before RentChain prepares this non-public, metadata-only trust export package.",
+  };
+}
+
+function tenantPreviewFromPackage(params: {
+  exportId: string | null;
+  tenantId: string;
+  audience: TenantTrustExportAudience;
+  purpose: TenantTrustExportPurpose;
+  generatedAt: string;
+  expiresAt: string | null;
+  consentGranted: boolean;
+  package: InstitutionalTrustExportPackage;
+}): TenantTrustExportPreview {
+  const includedClaims = params.package.exportSummaries.map((summary) => ({
+    attestationId: summary.attestationId,
+    claimCategory: summary.claimCategory,
+    claimLabel: summary.claimLabel,
+    lifecycleState: summary.lifecycleState,
+    consentExpiresAt: summary.consentExpiresAt,
+  }));
+  const summaryIds = new Set(includedClaims.map((claim) => claim.attestationId));
+  const decisionsByAttestation = new Map(
+    params.package.policyDecisions.map((decision) => [decision.attestationId, decision])
+  );
+  const excludedClaims = Array.from(decisionsByAttestation.entries())
+    .filter(([attestationId]) => !summaryIds.has(attestationId))
+    .map(([attestationId, decision]) => ({
+      attestationId,
+      claimCategory: "tenant_portability" as PortableAttestationClaimCategory,
+      claimLabel: attestationId.replace(/^tenant_trust:/, "").replace(/_/g, " "),
+      reasons: decision.reasons,
+    }));
+  const lifecycle: TenantTrustExportLifecycle =
+    params.package.status === "export_ready"
+      ? params.consentGranted
+        ? "preview"
+        : "consent_required"
+      : params.consentGranted
+      ? "blocked"
+      : "consent_required";
+  const claimCategories = Array.from(
+    new Set([
+      ...includedClaims.map((claim) => claim.claimCategory),
+      ...excludedClaims.map((claim) => claim.claimCategory),
+    ])
+  );
+
+  return {
+    exportId: params.exportId,
+    schemaVersion: "tenant_trust_export.v1",
+    audience: params.audience,
+    purpose: params.purpose,
+    lifecycle,
+    consent: buildConsentState({
+      audience: params.audience,
+      purpose: params.purpose,
+      generatedAt: params.generatedAt,
+      expiresAt: params.expiresAt,
+      consentGranted: params.consentGranted,
+      tenantId: params.tenantId,
+      claimCategories,
+    }),
+    expiresAt: params.expiresAt,
+    revokedAt: null,
+    generatedAt: params.generatedAt,
+    metadataOnly: true,
+    publicAccessEnabled: false,
+    externalSubmissionEnabled: false,
+    policyGated: true,
+    package: params.package,
+    includedClaims,
+    excludedClaims,
+    redactions: [
+      "Raw identity documents are excluded.",
+      "Raw provider payloads are excluded.",
+      "Support/internal metadata is excluded.",
+      "Public exposure and external submission are disabled.",
+    ],
+    disclaimers: [
+      "This export is prepared for tenant review and manual use only.",
+      "No institution receives this package automatically.",
+      "Revocation affects RentChain-controlled state and future preparation, not files already downloaded.",
+      "This package is not a credit, insurance, subsidy, ownership, or automated eligibility decision.",
+    ],
+  };
+}
+
+async function buildTenantTrustExportPreview(params: {
+  tenantId: string;
+  audience?: unknown;
+  purpose?: unknown;
+  expiresInDays?: unknown;
+  consentAccepted?: boolean;
+  exportId?: string | null;
+}): Promise<TenantTrustExportPreview | null> {
+  const tenantId = asString(params.tenantId);
+  if (!tenantId) return null;
+  const context = await resolveTenantTrustContext(tenantId);
+  if (!context) return null;
+
+  const audience = sanitizeAudience(params.audience);
+  const purpose = sanitizePurpose(params.purpose, audience);
+  const generatedAt = nowIso();
+  const expiresAt = addDaysIso(generatedAt, clampExpiresInDays(params.expiresInDays));
+  const consentGranted = params.consentAccepted === true;
+  const attestations = deriveTenantPortableAttestations({
+    context,
+    audience,
+    purpose,
+    generatedAt,
+    consentGranted,
+    consentExpiresAt: expiresAt,
+  });
+  const institutionalPackage = deriveInstitutionalTrustExportPackage({
+    exportId:
+      params.exportId ||
+      exportIdFor({
+        tenantId,
+        audience,
+        purpose,
+        generatedAt,
+      }),
+    audience: toInstitutionalAudience(audience),
+    purpose: toInstitutionalPurpose(purpose),
+    generatedAt,
+    attestations,
+  });
+
+  return tenantPreviewFromPackage({
+    exportId: params.exportId || null,
+    tenantId,
+    audience,
+    purpose,
+    generatedAt,
+    expiresAt,
+    consentGranted,
+    package: institutionalPackage,
+  });
+}
+
+function asRecord(id: string, data: any): TenantTrustExportStoredRecord {
+  const expiresAt = asString(data?.expiresAt);
+  const now = Date.now();
+  const lifecycle =
+    data?.lifecycle === "revoked"
+      ? "revoked"
+      : expiresAt && Date.parse(expiresAt) <= now
+      ? "expired"
+      : data?.package?.status === "export_ready"
+      ? "prepared"
+      : "blocked";
+  return {
+    ...(data || {}),
+    exportId: id,
+    lifecycle,
+  } as TenantTrustExportStoredRecord;
+}
+
+function publicRecord(record: TenantTrustExportStoredRecord): TenantTrustExportRecord {
+  const { tenantId: _tenantId, ...rest } = record;
+  return rest;
+}
+
+export async function previewTenantTrustExport(params: {
+  tenantId: string;
+  audience?: unknown;
+  purpose?: unknown;
+  expiresInDays?: unknown;
+  consentAccepted?: boolean;
+}) {
+  return buildTenantTrustExportPreview(params);
+}
+
+export async function prepareTenantTrustExport(params: {
+  tenantId: string;
+  audience?: unknown;
+  purpose?: unknown;
+  expiresInDays?: unknown;
+  consentAccepted?: boolean;
+}) {
+  const tenantId = asString(params.tenantId);
+  if (!tenantId) return null;
+  if (params.consentAccepted !== true) {
+    throw new Error("tenant_trust_export_consent_required");
+  }
+  const audience = sanitizeAudience(params.audience);
+  const purpose = sanitizePurpose(params.purpose, audience);
+  const generatedAt = nowIso();
+  const exportId = exportIdFor({ tenantId, audience, purpose, generatedAt });
+  const preview = await buildTenantTrustExportPreview({
+    tenantId,
+    audience,
+    purpose,
+    expiresInDays: params.expiresInDays,
+    consentAccepted: true,
+    exportId,
+  });
+  if (!preview) return null;
+
+  const record: TenantTrustExportStoredRecord = {
+    ...preview,
+    exportId,
+    tenantId,
+    lifecycle: preview.package.status === "export_ready" ? "prepared" : "blocked",
+    createdAt: generatedAt,
+    updatedAt: generatedAt,
+  };
+  await db.collection(COLLECTION).doc(exportId).set(record);
+  return publicRecord(record);
+}
+
+export async function listTenantTrustExports(params: { tenantId: string }) {
+  const tenantId = asString(params.tenantId);
+  if (!tenantId) return [];
+  const snap = await db.collection(COLLECTION).where("tenantId", "==", tenantId).limit(25).get();
+  return (snap.docs || [])
+    .map((doc: any) => asRecord(String(doc.id || ""), doc.data?.() || {}))
+    .map(publicRecord)
+    .sort((left, right) => Date.parse(right.createdAt || right.generatedAt) - Date.parse(left.createdAt || left.generatedAt));
+}
+
+export async function revokeTenantTrustExport(params: { tenantId: string; exportId: string }) {
+  const tenantId = asString(params.tenantId);
+  const exportId = asString(params.exportId);
+  if (!tenantId || !exportId) return null;
+  const ref = db.collection(COLLECTION).doc(exportId);
+  const snap = await ref.get();
+  if (!snap.exists) return null;
+  const current = asRecord(exportId, snap.data?.() || {});
+  if (current.tenantId !== tenantId) return false;
+  const updatedAt = nowIso();
+  await ref.set(
+    {
+      lifecycle: "revoked",
+      revokedAt: updatedAt,
+      updatedAt,
+      consent: {
+        ...current.consent,
+        granted: false,
+        revokedAt: updatedAt,
+      },
+    },
+    { merge: true }
+  );
+  return publicRecord({
+    ...current,
+    lifecycle: "revoked" as const,
+    revokedAt: updatedAt,
+    updatedAt,
+    consent: {
+      ...current.consent,
+      granted: false,
+      revokedAt: updatedAt,
+    },
+  });
+}

--- a/rentchain-frontend/src/api/tenantTrustExports.ts
+++ b/rentchain-frontend/src/api/tenantTrustExports.ts
@@ -1,0 +1,146 @@
+import { tenantApiFetch } from "./tenantApiFetch";
+
+export type TenantTrustExportAudience =
+  | "tenant_portability"
+  | "insurer"
+  | "lender"
+  | "institutional_landlord"
+  | "auditor";
+
+export type TenantTrustExportPurpose =
+  | "tenant_controlled_portability"
+  | "insurance_review"
+  | "lender_review"
+  | "institutional_landlord_review"
+  | "auditor_review";
+
+export type TenantTrustExportLifecycle =
+  | "preview"
+  | "prepared"
+  | "revoked"
+  | "expired"
+  | "blocked"
+  | "consent_required";
+
+export type TenantTrustExportPreview = {
+  exportId: string | null;
+  schemaVersion: "tenant_trust_export.v1";
+  audience: TenantTrustExportAudience;
+  purpose: TenantTrustExportPurpose;
+  lifecycle: TenantTrustExportLifecycle;
+  consent: {
+    required: true;
+    granted: boolean;
+    consentId: string | null;
+    consentVersion: "tenant_trust_export_consent.v1";
+    grantedAt: string | null;
+    expiresAt: string | null;
+    revokedAt: string | null;
+    audience: TenantTrustExportAudience;
+    purpose: TenantTrustExportPurpose;
+    claimCategories: string[];
+    summary: string;
+  };
+  expiresAt: string | null;
+  revokedAt: string | null;
+  generatedAt: string;
+  metadataOnly: true;
+  publicAccessEnabled: false;
+  externalSubmissionEnabled: false;
+  policyGated: true;
+  package: {
+    exportId: string;
+    status: "export_ready" | "blocked" | "unavailable";
+    lifecycle: "policy_evaluated" | "blocked" | "empty";
+    blockedReasons: string[];
+    exportSummaries: Array<{
+      attestationId: string;
+      claimCategory: string;
+      claimLabel: string;
+      claimDescription: string;
+      consentExpiresAt: string | null;
+      metadataOnly: true;
+      rawEvidenceIncluded: false;
+      rawProviderPayloadIncluded: false;
+      supportMetadataIncluded: false;
+      publicAccessEnabled: false;
+      externalSubmissionEnabled: false;
+      nonAuthorityDisclaimers: string[];
+    }>;
+    auditMetadata: {
+      exportId: string;
+      consentScoped: true;
+      policyGated: true;
+      manualOnly: true;
+      publicAccessEnabled: false;
+      externalSubmissionEnabled: false;
+      portableAttestationCount: number;
+      exportableAttestationCount: number;
+      blockedAttestationCount: number;
+    };
+  };
+  includedClaims: Array<{
+    attestationId: string;
+    claimCategory: string;
+    claimLabel: string;
+    lifecycleState: string;
+    consentExpiresAt: string | null;
+  }>;
+  excludedClaims: Array<{
+    attestationId: string;
+    claimCategory: string;
+    claimLabel: string;
+    reasons: string[];
+  }>;
+  redactions: string[];
+  disclaimers: string[];
+};
+
+export type TenantTrustExportRecord = TenantTrustExportPreview & {
+  exportId: string;
+  lifecycle: "prepared" | "revoked" | "expired" | "blocked";
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type TenantTrustExportRequest = {
+  audience: TenantTrustExportAudience;
+  purpose?: TenantTrustExportPurpose;
+  expiresInDays?: number;
+  consentAccepted?: boolean;
+};
+
+export async function listTenantTrustExports(): Promise<TenantTrustExportRecord[]> {
+  const res = await tenantApiFetch<{ ok: boolean; data: { items: TenantTrustExportRecord[] } }>("/tenant/trust-exports");
+  return Array.isArray(res?.data?.items) ? res.data.items : [];
+}
+
+export async function previewTenantTrustExport(
+  request: TenantTrustExportRequest
+): Promise<TenantTrustExportPreview> {
+  const res = await tenantApiFetch<{ ok: boolean; data: TenantTrustExportPreview }>("/tenant/trust-exports/preview", {
+    method: "POST",
+    body: JSON.stringify(request),
+  });
+  return res.data;
+}
+
+export async function prepareTenantTrustExport(
+  request: TenantTrustExportRequest
+): Promise<TenantTrustExportRecord> {
+  const res = await tenantApiFetch<{ ok: boolean; data: TenantTrustExportRecord }>("/tenant/trust-exports", {
+    method: "POST",
+    body: JSON.stringify(request),
+  });
+  return res.data;
+}
+
+export async function revokeTenantTrustExport(exportId: string): Promise<TenantTrustExportRecord> {
+  const res = await tenantApiFetch<{ ok: boolean; data: TenantTrustExportRecord }>(
+    `/tenant/trust-exports/${encodeURIComponent(exportId)}/revoke`,
+    {
+      method: "POST",
+    }
+  );
+  return res.data;
+}

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -65,6 +65,13 @@ const tenantSharePackagesApi = vi.hoisted(() => ({
   revokeTenantShareVerificationRequest: vi.fn(),
 }));
 
+const tenantTrustExportsApi = vi.hoisted(() => ({
+  listTenantTrustExports: vi.fn(),
+  previewTenantTrustExport: vi.fn(),
+  prepareTenantTrustExport: vi.fn(),
+  revokeTenantTrustExport: vi.fn(),
+}));
+
 vi.mock("../../api/tenantPortal", () => tenantPortalApi);
 vi.mock("../../api/tenantApplicationCompletion", () => tenantApplicationCompletionApi);
 vi.mock("../../api/tenantAccess", () => tenantAccessApi);
@@ -80,6 +87,7 @@ vi.mock("../../api/tenantScreeningApi", async () => {
   };
 });
 vi.mock("../../api/tenantSharePackages", () => tenantSharePackagesApi);
+vi.mock("../../api/tenantTrustExports", () => tenantTrustExportsApi);
 vi.mock("../../api/maintenanceWorkflowApi", async () => {
   const actual = await vi.importActual<any>("../../api/maintenanceWorkflowApi");
   return {
@@ -554,6 +562,130 @@ describe("tenant workspace frontend shell", () => {
       updatedAt: 1710000000000,
     });
     tenantSharePackagesApi.listTenantSharePackages.mockResolvedValue([]);
+    tenantTrustExportsApi.listTenantTrustExports.mockResolvedValue([]);
+    tenantTrustExportsApi.previewTenantTrustExport.mockResolvedValue({
+      exportId: null,
+      schemaVersion: "tenant_trust_export.v1",
+      audience: "tenant_portability",
+      purpose: "tenant_controlled_portability",
+      lifecycle: "consent_required",
+      consent: {
+        required: true,
+        granted: false,
+        consentId: null,
+        consentVersion: "tenant_trust_export_consent.v1",
+        grantedAt: null,
+        expiresAt: "2026-05-23T00:00:00.000Z",
+        revokedAt: null,
+        audience: "tenant_portability",
+        purpose: "tenant_controlled_portability",
+        claimCategories: ["tenant_portability"],
+        summary:
+          "Tenant consent is required before RentChain prepares this non-public, metadata-only trust export package.",
+      },
+      expiresAt: "2026-05-23T00:00:00.000Z",
+      revokedAt: null,
+      generatedAt: "2026-05-09T00:00:00.000Z",
+      metadataOnly: true,
+      publicAccessEnabled: false,
+      externalSubmissionEnabled: false,
+      policyGated: true,
+      package: {
+        exportId: "tenant_trust_export_preview",
+        status: "blocked",
+        lifecycle: "blocked",
+        blockedReasons: ["tenant_trust:tenant_portability: consent_missing"],
+        exportSummaries: [],
+        auditMetadata: {
+          exportId: "tenant_trust_export_preview",
+          consentScoped: true,
+          policyGated: true,
+          manualOnly: true,
+          publicAccessEnabled: false,
+          externalSubmissionEnabled: false,
+          portableAttestationCount: 1,
+          exportableAttestationCount: 0,
+          blockedAttestationCount: 1,
+        },
+      },
+      includedClaims: [],
+      excludedClaims: [
+        {
+          attestationId: "tenant_trust:tenant_portability",
+          claimCategory: "tenant_portability",
+          claimLabel: "tenant portability",
+          reasons: ["consent_missing"],
+        },
+      ],
+      redactions: ["Support/internal metadata is excluded."],
+      disclaimers: ["No institution receives this package automatically."],
+    });
+    tenantTrustExportsApi.prepareTenantTrustExport.mockResolvedValue({
+      exportId: "export-1",
+      schemaVersion: "tenant_trust_export.v1",
+      audience: "tenant_portability",
+      purpose: "tenant_controlled_portability",
+      lifecycle: "prepared",
+      consent: {
+        required: true,
+        granted: true,
+        consentId: "consent-1",
+        consentVersion: "tenant_trust_export_consent.v1",
+        grantedAt: "2026-05-09T00:00:00.000Z",
+        expiresAt: "2026-05-23T00:00:00.000Z",
+        revokedAt: null,
+        audience: "tenant_portability",
+        purpose: "tenant_controlled_portability",
+        claimCategories: ["tenant_portability"],
+        summary:
+          "Tenant consent is required before RentChain prepares this non-public, metadata-only trust export package.",
+      },
+      expiresAt: "2026-05-23T00:00:00.000Z",
+      revokedAt: null,
+      generatedAt: "2026-05-09T00:00:00.000Z",
+      createdAt: "2026-05-09T00:00:00.000Z",
+      updatedAt: "2026-05-09T00:00:00.000Z",
+      metadataOnly: true,
+      publicAccessEnabled: false,
+      externalSubmissionEnabled: false,
+      policyGated: true,
+      package: {
+        exportId: "export-1",
+        status: "export_ready",
+        lifecycle: "policy_evaluated",
+        blockedReasons: [],
+        exportSummaries: [],
+        auditMetadata: {
+          exportId: "export-1",
+          consentScoped: true,
+          policyGated: true,
+          manualOnly: true,
+          publicAccessEnabled: false,
+          externalSubmissionEnabled: false,
+          portableAttestationCount: 1,
+          exportableAttestationCount: 1,
+          blockedAttestationCount: 0,
+        },
+      },
+      includedClaims: [
+        {
+          attestationId: "tenant_trust:tenant_portability",
+          claimCategory: "tenant_portability",
+          claimLabel: "Tenant portability metadata available",
+          lifecycleState: "export_ready",
+          consentExpiresAt: "2026-05-23T00:00:00.000Z",
+        },
+      ],
+      excludedClaims: [],
+      redactions: ["Support/internal metadata is excluded."],
+      disclaimers: ["No institution receives this package automatically."],
+    });
+    tenantTrustExportsApi.revokeTenantTrustExport.mockImplementation(async (exportId: string) => ({
+      ...(await tenantTrustExportsApi.prepareTenantTrustExport()),
+      exportId,
+      lifecycle: "revoked",
+      revokedAt: "2026-05-10T00:00:00.000Z",
+    }));
     tenantSharePackagesApi.createTenantSharePackage.mockResolvedValue({
       id: "share-1",
       createdAt: 1710000000000,
@@ -1169,6 +1301,52 @@ describe("tenant workspace frontend shell", () => {
     expect(global.URL.createObjectURL).toHaveBeenCalledTimes(1);
   });
 
+  it("requires consent before preparing a tenant-controlled trust export", async () => {
+    render(
+      <MemoryRouter>
+        <TenantWorkspacePage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Tenant-controlled trust export/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Prepare export/i })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: /Preview trust export/i }));
+    await waitFor(() => {
+      expect(tenantTrustExportsApi.previewTenantTrustExport).toHaveBeenCalledWith(
+        expect.objectContaining({
+          audience: "tenant_portability",
+          consentAccepted: false,
+        })
+      );
+    });
+    expect(await screen.findByText(/No claims are exportable until consent and policy checks pass/i)).toBeInTheDocument();
+    expect(screen.getByText(/Support\/internal metadata is excluded/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText(/I consent to preparing a metadata-only trust export/i));
+    fireEvent.click(screen.getByRole("button", { name: /Prepare export/i }));
+
+    await waitFor(() => {
+      expect(tenantTrustExportsApi.prepareTenantTrustExport).toHaveBeenCalledWith(
+        expect.objectContaining({
+          audience: "tenant_portability",
+          consentAccepted: true,
+        })
+      );
+    });
+    expect(await screen.findByText(/Tenant portability metadata available/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Public access/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Disabled/i).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/verified tenant/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/reputation/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/send to insurer/i)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Revoke export/i }));
+    await waitFor(() => {
+      expect(tenantTrustExportsApi.revokeTenantTrustExport).toHaveBeenCalledWith("export-1");
+    });
+  });
+
   it("lets tenants prepare and void metadata-only institutional handoff drafts", async () => {
     render(
       <MemoryRouter>
@@ -1177,7 +1355,7 @@ describe("tenant workspace frontend shell", () => {
     );
 
     expect((await screen.findAllByText(/Institutional handoff drafts/i)).length).toBeGreaterThan(0);
-    expect(screen.getByText(/No data is sent automatically/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/No data is sent automatically/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Institution connections are not enabled yet/i)).toBeInTheDocument();
     expect(screen.getByText(/tenant-managed manual-release preparation only/i)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /send/i })).not.toBeInTheDocument();

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
@@ -28,6 +28,15 @@ import {
   type TenantSharePackageLink,
 } from "../../api/tenantSharePackages";
 import {
+  listTenantTrustExports,
+  prepareTenantTrustExport,
+  previewTenantTrustExport,
+  revokeTenantTrustExport,
+  type TenantTrustExportAudience,
+  type TenantTrustExportPreview,
+  type TenantTrustExportRecord,
+} from "../../api/tenantTrustExports";
+import {
   TenantEmptyState,
   TenantErrorState,
   TenantInfoCard,
@@ -121,6 +130,52 @@ function prettyComplianceCheckStatus(value: "pass" | "warning" | "missing" | nul
     default:
       return "Missing";
   }
+}
+
+function trustExportPurposeForAudience(audience: TenantTrustExportAudience) {
+  if (audience === "insurer") return "insurance_review" as const;
+  if (audience === "lender") return "lender_review" as const;
+  if (audience === "institutional_landlord") return "institutional_landlord_review" as const;
+  if (audience === "auditor") return "auditor_review" as const;
+  return "tenant_controlled_portability" as const;
+}
+
+function prettyTrustExportAudience(value: TenantTrustExportAudience | null | undefined) {
+  switch (value) {
+    case "insurer":
+      return "Insurer review";
+    case "lender":
+      return "Lender review";
+    case "institutional_landlord":
+      return "Institutional landlord review";
+    case "auditor":
+      return "Auditor review";
+    case "tenant_portability":
+    default:
+      return "Tenant portability";
+  }
+}
+
+function prettyTrustExportLifecycle(value: string | null | undefined) {
+  switch (value) {
+    case "prepared":
+      return "Prepared";
+    case "revoked":
+      return "Revoked";
+    case "expired":
+      return "Expired";
+    case "blocked":
+      return "Blocked";
+    case "consent_required":
+      return "Consent required";
+    case "preview":
+    default:
+      return "Preview";
+  }
+}
+
+function prettyPolicyReason(value: string) {
+  return value.replace(/_/g, " ");
 }
 
 function prettyInstitutionType(
@@ -266,6 +321,12 @@ export default function TenantWorkspacePage() {
   const [communications, setCommunications] = React.useState<Awaited<ReturnType<typeof getTenantCommunicationsWorkspace>> | null>(null);
   const [screenings, setScreenings] = React.useState<TenantScreeningRequest[]>([]);
   const [sharePackages, setSharePackages] = React.useState<TenantSharePackageLink[]>([]);
+  const [trustExports, setTrustExports] = React.useState<TenantTrustExportRecord[]>([]);
+  const [trustExportPreview, setTrustExportPreview] = React.useState<TenantTrustExportPreview | null>(null);
+  const [trustExportAudience, setTrustExportAudience] = React.useState<TenantTrustExportAudience>("tenant_portability");
+  const [trustExportConsentAccepted, setTrustExportConsentAccepted] = React.useState(false);
+  const [trustExportBusy, setTrustExportBusy] = React.useState(false);
+  const [trustExportError, setTrustExportError] = React.useState<string | null>(null);
   const [freshShareUrl, setFreshShareUrl] = React.useState<string | null>(null);
   const [shareBusy, setShareBusy] = React.useState(false);
   const [shareError, setShareError] = React.useState<string | null>(null);
@@ -301,6 +362,7 @@ export default function TenantWorkspacePage() {
         communicationsResult,
         screeningsResult,
         sharePackagesResult,
+        trustExportsResult,
         handoffDraftsResult,
       ] = await Promise.allSettled([
         getTenantWorkspace(),
@@ -311,6 +373,7 @@ export default function TenantWorkspacePage() {
         getTenantCommunicationsWorkspace(),
         listTenantScreenings(),
         listTenantSharePackages(),
+        listTenantTrustExports(),
         listInstitutionalHandoffDrafts(),
       ]);
 
@@ -330,6 +393,7 @@ export default function TenantWorkspacePage() {
           : [],
       );
       setSharePackages(sharePackagesResult.status === "fulfilled" ? sharePackagesResult.value : []);
+      setTrustExports(trustExportsResult.status === "fulfilled" ? trustExportsResult.value : []);
       setHandoffDrafts(handoffDraftsResult.status === "fulfilled" ? handoffDraftsResult.value : []);
     } catch (err: any) {
       setData(null);
@@ -340,6 +404,7 @@ export default function TenantWorkspacePage() {
       setCommunications(null);
       setScreenings([]);
       setSharePackages([]);
+      setTrustExports([]);
       setHandoffDrafts([]);
       setError(err?.payload?.error || err?.message || "Unable to load your tenant workspace.");
     } finally {
@@ -470,6 +535,79 @@ export default function TenantWorkspacePage() {
       setExportError("JSON download is unavailable in this browser right now.");
     }
   }, [institutionalPackage]);
+
+  const handlePreviewTrustExport = React.useCallback(async () => {
+    try {
+      setTrustExportBusy(true);
+      setTrustExportError(null);
+      const next = await previewTenantTrustExport({
+        audience: trustExportAudience,
+        purpose: trustExportPurposeForAudience(trustExportAudience),
+        expiresInDays: 14,
+        consentAccepted: trustExportConsentAccepted,
+      });
+      setTrustExportPreview(next);
+    } catch (err: any) {
+      setTrustExportError(err?.payload?.error || err?.message || "Unable to preview this trust export right now.");
+    } finally {
+      setTrustExportBusy(false);
+    }
+  }, [trustExportAudience, trustExportConsentAccepted]);
+
+  const handlePrepareTrustExport = React.useCallback(async () => {
+    try {
+      setTrustExportBusy(true);
+      setTrustExportError(null);
+      const prepared = await prepareTenantTrustExport({
+        audience: trustExportAudience,
+        purpose: trustExportPurposeForAudience(trustExportAudience),
+        expiresInDays: 14,
+        consentAccepted: trustExportConsentAccepted,
+      });
+      setTrustExportPreview(prepared);
+      setTrustExports((current) => [prepared, ...current.filter((entry) => entry.exportId !== prepared.exportId)]);
+    } catch (err: any) {
+      setTrustExportError(
+        err?.payload?.error === "TENANT_TRUST_EXPORT_CONSENT_REQUIRED"
+          ? "Confirm consent before preparing a trust export."
+          : err?.payload?.error || err?.message || "Unable to prepare this trust export right now."
+      );
+    } finally {
+      setTrustExportBusy(false);
+    }
+  }, [trustExportAudience, trustExportConsentAccepted]);
+
+  const handleRevokeTrustExport = React.useCallback(async (exportId: string) => {
+    try {
+      setTrustExportBusy(true);
+      setTrustExportError(null);
+      const revoked = await revokeTenantTrustExport(exportId);
+      setTrustExports((current) => current.map((entry) => (entry.exportId === exportId ? revoked : entry)));
+      setTrustExportPreview((current) => (current?.exportId === exportId ? revoked : current));
+    } catch (err: any) {
+      setTrustExportError(err?.payload?.error || err?.message || "Unable to revoke this trust export right now.");
+    } finally {
+      setTrustExportBusy(false);
+    }
+  }, []);
+
+  const handleDownloadTrustExportJson = React.useCallback((record: TenantTrustExportPreview | TenantTrustExportRecord) => {
+    try {
+      const blob = new Blob([JSON.stringify(record, null, 2)], {
+        type: "application/json",
+      });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = "rentchain-tenant-controlled-trust-export.json";
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+    } catch {
+      setTrustExportError("Trust export JSON download is unavailable in this browser right now.");
+    }
+  }, []);
 
   const handleCreateInstitutionalHandoff = React.useCallback(async () => {
     try {
@@ -1306,6 +1444,167 @@ export default function TenantWorkspacePage() {
               ) : null}
             </div>
           ) : null}
+
+          <div
+            style={{
+              border: "1px solid rgba(15,23,42,0.08)",
+              borderRadius: 12,
+              padding: "12px 14px",
+              display: "grid",
+              gap: 10,
+            }}
+          >
+            <div style={{ fontWeight: 700, color: textTokens.primary }}>Tenant-controlled trust export</div>
+            <div style={{ color: textTokens.secondary, lineHeight: 1.6 }}>
+              Prepare a non-public, metadata-only trust export for tenant review. No data is sent automatically, no public profile is created, and support/internal metadata stays excluded.
+            </div>
+
+            <div style={{ display: "grid", gap: 10, gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))" }}>
+              <label style={{ display: "grid", gap: 6 }}>
+                <span style={{ fontWeight: 600, color: textTokens.primary }}>Intended audience</span>
+                <select
+                  value={trustExportAudience}
+                  onChange={(event) => {
+                    setTrustExportAudience(event.target.value as TenantTrustExportAudience);
+                    setTrustExportPreview(null);
+                  }}
+                >
+                  <option value="tenant_portability">Tenant portability</option>
+                  <option value="insurer">Insurer review</option>
+                  <option value="lender">Lender review</option>
+                  <option value="institutional_landlord">Institutional landlord review</option>
+                  <option value="auditor">Auditor review</option>
+                </select>
+              </label>
+              <div style={{ color: textTokens.secondary, lineHeight: 1.6 }}>
+                Purpose: {prettyStatus(trustExportPurposeForAudience(trustExportAudience))}
+                <br />
+                Expires: 14 days after preparation
+              </div>
+            </div>
+
+            <label style={{ display: "flex", gap: 10, alignItems: "flex-start", color: textTokens.secondary, lineHeight: 1.5 }}>
+              <input
+                type="checkbox"
+                checked={trustExportConsentAccepted}
+                onChange={(event) => {
+                  setTrustExportConsentAccepted(event.target.checked);
+                  setTrustExportPreview(null);
+                }}
+                style={{ marginTop: 4 }}
+              />
+              <span>
+                I consent to preparing a metadata-only trust export for {prettyTrustExportAudience(trustExportAudience)}. I understand this does not prove eligibility, does not send data automatically, and revocation cannot recall files already downloaded or shared outside RentChain.
+              </span>
+            </label>
+
+            <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
+              <button type="button" onClick={() => void handlePreviewTrustExport()} disabled={trustExportBusy}>
+                {trustExportBusy ? "Checking..." : "Preview trust export"}
+              </button>
+              <button
+                type="button"
+                onClick={() => void handlePrepareTrustExport()}
+                disabled={trustExportBusy || !trustExportConsentAccepted}
+              >
+                Prepare export
+              </button>
+              {trustExportPreview?.package?.status === "export_ready" ? (
+                <button type="button" onClick={() => handleDownloadTrustExportJson(trustExportPreview)}>
+                  Download preview JSON
+                </button>
+              ) : null}
+            </div>
+
+            {trustExportError ? <div style={{ color: "#b91c1c" }}>{trustExportError}</div> : null}
+
+            {trustExportPreview ? (
+              <div style={{ border: "1px solid rgba(15,23,42,0.08)", borderRadius: 12, padding: "12px 14px", display: "grid", gap: 10 }}>
+                <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.sm, flexWrap: "wrap" }}>
+                  <div style={{ fontWeight: 800, color: textTokens.primary }}>Trust export preview</div>
+                  <div style={{ color: textTokens.secondary }}>{prettyTrustExportLifecycle(trustExportPreview.lifecycle)}</div>
+                </div>
+                <TenantKeyValueGrid
+                  rows={[
+                    { label: "Audience", value: prettyTrustExportAudience(trustExportPreview.audience) },
+                    { label: "Consent", value: trustExportPreview.consent.granted ? "Granted for this package" : "Required" },
+                    { label: "Policy status", value: prettyStatus(trustExportPreview.package.status) },
+                    { label: "Included claims", value: String(trustExportPreview.includedClaims.length) },
+                    { label: "Blocked claims", value: String(trustExportPreview.excludedClaims.length) },
+                    { label: "Public access", value: trustExportPreview.publicAccessEnabled ? "Enabled" : "Disabled" },
+                    { label: "External submission", value: trustExportPreview.externalSubmissionEnabled ? "Enabled" : "Disabled" },
+                    { label: "Expires", value: formatDate(trustExportPreview.expiresAt) },
+                  ]}
+                />
+
+                <div style={{ display: "grid", gap: 6 }}>
+                  <div style={{ fontWeight: 700, color: textTokens.primary }}>Included metadata</div>
+                  {trustExportPreview.includedClaims.length ? (
+                    trustExportPreview.includedClaims.map((claim) => (
+                      <div key={claim.attestationId} style={{ color: textTokens.secondary }}>
+                        {claim.claimLabel} - {prettyStatus(claim.claimCategory)}
+                      </div>
+                    ))
+                  ) : (
+                    <div style={{ color: textTokens.secondary }}>No claims are exportable until consent and policy checks pass.</div>
+                  )}
+                </div>
+
+                {trustExportPreview.excludedClaims.length ? (
+                  <div style={{ display: "grid", gap: 6 }}>
+                    <div style={{ fontWeight: 700, color: textTokens.primary }}>Excluded metadata</div>
+                    {trustExportPreview.excludedClaims.map((claim) => (
+                      <div key={claim.attestationId} style={{ color: textTokens.secondary }}>
+                        {claim.claimLabel}: {claim.reasons.map(prettyPolicyReason).join(", ")}
+                      </div>
+                    ))}
+                  </div>
+                ) : null}
+
+                <div style={{ display: "grid", gap: 6 }}>
+                  <div style={{ fontWeight: 700, color: textTokens.primary }}>Always excluded</div>
+                  {trustExportPreview.redactions.map((item) => (
+                    <div key={item} style={{ color: textTokens.secondary }}>
+                      {item}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+
+            <div style={{ display: "grid", gap: 8 }}>
+              <div style={{ fontWeight: 700, color: textTokens.primary }}>Prepared trust exports</div>
+              {trustExports.length ? (
+                trustExports.map((entry) => (
+                  <div key={entry.exportId} style={{ border: "1px solid rgba(15,23,42,0.08)", borderRadius: 12, padding: "12px 14px", display: "grid", gap: 8 }}>
+                    <TenantKeyValueGrid
+                      rows={[
+                        { label: "Audience", value: prettyTrustExportAudience(entry.audience) },
+                        { label: "Status", value: prettyTrustExportLifecycle(entry.lifecycle) },
+                        { label: "Prepared", value: formatDate(entry.createdAt) },
+                        { label: "Expires", value: formatDate(entry.expiresAt) },
+                        { label: "Claims", value: String(entry.includedClaims.length) },
+                      ]}
+                    />
+                    <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
+                      <button type="button" onClick={() => handleDownloadTrustExportJson(entry)}>
+                        Download JSON
+                      </button>
+                      {entry.lifecycle === "prepared" ? (
+                        <button type="button" onClick={() => void handleRevokeTrustExport(entry.exportId)} disabled={trustExportBusy}>
+                          Revoke export
+                        </button>
+                      ) : null}
+                    </div>
+                  </div>
+                ))
+              ) : (
+                <div style={{ color: textTokens.secondary }}>
+                  Prepared trust exports will appear here. They remain tenant-controlled and non-public.
+                </div>
+              )}
+            </div>
+          </div>
 
           <div
             style={{


### PR DESCRIPTION
## Summary
- Adds a tenant-only trust export preparation service backed by existing portable attestation, policy gate, and institutional trust export foundations.
- Adds tenant-authenticated trust export routes for list, preview, prepare, and revoke without public URLs, institution delivery, provider integrations, or share-package widening.
- Adds a tenant workspace trust export panel with audience selection, explicit consent, policy-gated preview, metadata-only included/excluded summaries, prepared export history, JSON download, and revocation.
- Keeps returned/downloadable trust export packages free of raw tenant ids, raw documents, provider payloads, support metadata, public exposure, and external submission flags.

## Guardrails
- No public trust profile or public export URL.
- No insurer/lender/government/provider API integration.
- No blockchain, verifiable credential, reputation score, or automated decision behavior.
- Existing tenant share packages remain unchanged and are not widened.
- Trust language stays conservative and non-authoritative.

## Verification
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:single -- src/services/tenantPortal/__tests__/tenantTrustExportService.test.ts src/routes/__tests__/tenantPortalRoutes.test.ts` from `rentchain-api`
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build` from `rentchain-api`
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test` from `rentchain-api` outside sandbox after sandbox-local Supertest listener failures
- `npm run test -- src/pages/tenant/TenantWorkspacePage.test.tsx` from `rentchain-frontend`
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run build` from `rentchain-frontend`
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 && npm run test` from `rentchain-frontend`
- `git diff --check`