### PR TITLE
Add tenant-mediated institution access grants

### DIFF
--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -1470,6 +1470,118 @@ describe("tenantPortalRoutes foundation", () => {
     expect(ensureCollection("tenantSharePackages").size).toBe(0);
   });
 
+  it("creates tenant-mediated institution access grants only after scoped consent", async () => {
+    const router = (await import("../tenantPortalRoutes")).default;
+    const headers = {
+      "x-test-user": JSON.stringify({
+        id: "user-1",
+        email: "tenant@example.com",
+        role: "tenant",
+        tenantId: "tenant-1",
+      }),
+    };
+
+    const missingConsent = await invokeRouter(router, {
+      method: "POST",
+      url: "/institution-access/grants",
+      body: {
+        audience: "insurer",
+        recipient: { email: "reviewer@example.com", organizationName: "Example Insurance" },
+        expiresInDays: 7,
+        consentAccepted: false,
+      },
+      headers,
+    });
+    expect(missingConsent.status).toBe(400);
+    expect(missingConsent.body?.error).toBe("TENANT_INSTITUTION_ACCESS_CONSENT_REQUIRED");
+
+    const preview = await invokeRouter(router, {
+      method: "POST",
+      url: "/institution-access/preview",
+      body: {
+        audience: "insurer",
+        recipient: { email: "reviewer@example.com", organizationName: "Example Insurance" },
+        expiresInDays: 7,
+        consentAccepted: false,
+      },
+      headers,
+    });
+    expect(preview.status).toBe(200);
+    expect(preview.body?.data?.lifecycle).toBe("consent_required");
+    expect(preview.body?.data?.recipientAccess?.enabled).toBe(false);
+    expect(preview.body?.data?.publicAccessEnabled).toBe(false);
+    expect(preview.body?.data?.externalSubmissionEnabled).toBe(false);
+
+    const grant = await invokeRouter(router, {
+      method: "POST",
+      url: "/institution-access/grants",
+      body: {
+        audience: "insurer",
+        recipient: { email: "reviewer@example.com", organizationName: "Example Insurance" },
+        expiresInDays: 7,
+        consentAccepted: true,
+      },
+      headers,
+    });
+    expect(grant.status).toBe(200);
+    expect(grant.body?.data?.lifecycle).toBe("active");
+    expect(grant.body?.data?.consent?.granted).toBe(true);
+    expect(grant.body?.data?.package?.status).toBe("export_ready");
+    expect(grant.body?.data?.recipientAccess?.accessUrl).toBe(null);
+    expect(grant.body?.data?.recipientAccess?.accessTokenIssued).toBe(false);
+    const payload = JSON.stringify(grant.body?.data || {});
+    expect(payload).not.toContain("drawnDataUrl");
+    expect(payload).not.toContain("documentUrl");
+    expect(payload).not.toContain("paymentMethod");
+    expect(payload).not.toContain("supportMetadataIncluded\":true");
+    expect(payload).not.toContain("publicAccessEnabled\":true");
+    expect(payload).not.toContain("externalSubmissionEnabled\":true");
+    expect(payload).not.toContain("tenant-1");
+    expect(ensureCollection("tenantSharePackages").size).toBe(0);
+  });
+
+  it("lists and revokes tenant-mediated institution access grants for the owning tenant", async () => {
+    const router = (await import("../tenantPortalRoutes")).default;
+    const headers = {
+      "x-test-user": JSON.stringify({
+        id: "user-1",
+        email: "tenant@example.com",
+        role: "tenant",
+        tenantId: "tenant-1",
+      }),
+    };
+    const created = await invokeRouter(router, {
+      method: "POST",
+      url: "/institution-access/grants",
+      body: {
+        audience: "lender",
+        recipient: { email: "underwriter@example.com", organizationName: "Example Lender" },
+        expiresInDays: 14,
+        consentAccepted: true,
+      },
+      headers,
+    });
+    const grantId = created.body?.data?.grantId;
+
+    const listed = await invokeRouter(router, {
+      method: "GET",
+      url: "/institution-access/grants",
+      headers,
+    });
+    expect(listed.status).toBe(200);
+    expect(listed.body?.data?.items?.[0]?.grantId).toBe(grantId);
+
+    const revoked = await invokeRouter(router, {
+      method: "POST",
+      url: `/institution-access/grants/${encodeURIComponent(grantId)}/revoke`,
+      headers,
+    });
+    expect(revoked.status).toBe(200);
+    expect(revoked.body?.data?.lifecycle).toBe("revoked");
+    expect(revoked.body?.data?.consent?.granted).toBe(false);
+    expect(revoked.body?.data?.recipientAccess?.enabled).toBe(false);
+  });
+
   it("creates a tenant-owned metadata-only institutional handoff draft safely", async () => {
     const router = (await import("../tenantPortalRoutes")).default;
     const res = await invokeRouter(router, {

--- a/rentchain-api/src/routes/tenantPortalRoutes.ts
+++ b/rentchain-api/src/routes/tenantPortalRoutes.ts
@@ -68,6 +68,12 @@ import {
   previewTenantTrustExport,
   revokeTenantTrustExport,
 } from "../services/tenantPortal/tenantTrustExportService";
+import {
+  createTenantInstitutionAccessGrant,
+  listTenantInstitutionAccessGrants,
+  previewTenantInstitutionAccess,
+  revokeTenantInstitutionAccessGrant,
+} from "../services/tenantPortal/tenantInstitutionAccessService";
 import { recordSystemObservabilityEvent } from "../services/observability/recordSystemObservabilityEvent";
 import { buildLeasePaymentProjection } from "../services/projections/buildLeasePaymentProjection";
 
@@ -3277,6 +3283,133 @@ router.post("/trust-exports/:id/revoke", requireTenantWorkspaceIdentity, async (
       message: err?.message || "failed",
     });
     return res.status(500).json({ ok: false, error: "TENANT_TRUST_EXPORT_REVOKE_FAILED" });
+  }
+});
+
+router.get("/institution-access/grants", requireTenantWorkspaceIdentity, async (req: any, res) => {
+  const context = await resolveWorkspaceContextOrRespond(req, res);
+  if (!context) return;
+
+  const tenantId = String(req.user?.tenantId || context.tenantId || "").trim();
+  if (!tenantId) {
+    return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+  }
+
+  try {
+    const items = await listTenantInstitutionAccessGrants({ tenantId });
+    return res.json({ ok: true, data: { items } });
+  } catch (err: any) {
+    console.error("[tenant/institution-access:list] failed", {
+      tenantId,
+      message: err?.message || "failed",
+    });
+    return res.status(500).json({ ok: false, error: "TENANT_INSTITUTION_ACCESS_LIST_FAILED" });
+  }
+});
+
+router.post("/institution-access/preview", requireTenantWorkspaceIdentity, async (req: any, res) => {
+  const context = await resolveWorkspaceContextOrRespond(req, res);
+  if (!context) return;
+
+  const tenantId = String(req.user?.tenantId || context.tenantId || "").trim();
+  if (!tenantId) {
+    return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+  }
+
+  try {
+    const preview = await previewTenantInstitutionAccess({
+      tenantId,
+      audience: req.body?.audience,
+      purpose: req.body?.purpose,
+      recipient: req.body?.recipient,
+      expiresInDays: req.body?.expiresInDays,
+      consentAccepted: req.body?.consentAccepted === true,
+    });
+    if (!preview) {
+      return res.status(404).json({ ok: false, error: "TENANT_INSTITUTION_ACCESS_UNAVAILABLE" });
+    }
+    return res.json({ ok: true, data: preview });
+  } catch (err: any) {
+    if (err?.message === "tenant_institution_access_recipient_required") {
+      return res.status(400).json({ ok: false, error: "TENANT_INSTITUTION_ACCESS_RECIPIENT_REQUIRED" });
+    }
+    if (err?.message === "tenant_institution_access_expiration_required") {
+      return res.status(400).json({ ok: false, error: "TENANT_INSTITUTION_ACCESS_EXPIRATION_REQUIRED" });
+    }
+    console.error("[tenant/institution-access:preview] failed", {
+      tenantId,
+      message: err?.message || "failed",
+    });
+    return res.status(500).json({ ok: false, error: "TENANT_INSTITUTION_ACCESS_PREVIEW_FAILED" });
+  }
+});
+
+router.post("/institution-access/grants", requireTenantWorkspaceIdentity, async (req: any, res) => {
+  const context = await resolveWorkspaceContextOrRespond(req, res);
+  if (!context) return;
+
+  const tenantId = String(req.user?.tenantId || context.tenantId || "").trim();
+  if (!tenantId) {
+    return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+  }
+
+  try {
+    const grant = await createTenantInstitutionAccessGrant({
+      tenantId,
+      audience: req.body?.audience,
+      purpose: req.body?.purpose,
+      recipient: req.body?.recipient,
+      expiresInDays: req.body?.expiresInDays,
+      consentAccepted: req.body?.consentAccepted === true,
+    });
+    if (!grant) {
+      return res.status(404).json({ ok: false, error: "TENANT_INSTITUTION_ACCESS_UNAVAILABLE" });
+    }
+    return res.json({ ok: true, data: grant });
+  } catch (err: any) {
+    if (err?.message === "tenant_institution_access_consent_required") {
+      return res.status(400).json({ ok: false, error: "TENANT_INSTITUTION_ACCESS_CONSENT_REQUIRED" });
+    }
+    if (err?.message === "tenant_institution_access_recipient_required") {
+      return res.status(400).json({ ok: false, error: "TENANT_INSTITUTION_ACCESS_RECIPIENT_REQUIRED" });
+    }
+    if (err?.message === "tenant_institution_access_expiration_required") {
+      return res.status(400).json({ ok: false, error: "TENANT_INSTITUTION_ACCESS_EXPIRATION_REQUIRED" });
+    }
+    if (err?.message === "tenant_institution_access_policy_blocked") {
+      return res.status(400).json({ ok: false, error: "TENANT_INSTITUTION_ACCESS_POLICY_BLOCKED" });
+    }
+    console.error("[tenant/institution-access:create] failed", {
+      tenantId,
+      message: err?.message || "failed",
+    });
+    return res.status(500).json({ ok: false, error: "TENANT_INSTITUTION_ACCESS_CREATE_FAILED" });
+  }
+});
+
+router.post("/institution-access/grants/:id/revoke", requireTenantWorkspaceIdentity, async (req: any, res) => {
+  const context = await resolveWorkspaceContextOrRespond(req, res);
+  if (!context) return;
+
+  const tenantId = String(req.user?.tenantId || context.tenantId || "").trim();
+  const grantId = String(req.params?.id || "").trim();
+  if (!tenantId || !grantId) {
+    return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+  }
+
+  try {
+    const revoked = await revokeTenantInstitutionAccessGrant({ tenantId, grantId });
+    if (!revoked) {
+      return res.status(404).json({ ok: false, error: "NOT_FOUND" });
+    }
+    return res.json({ ok: true, data: revoked });
+  } catch (err: any) {
+    console.error("[tenant/institution-access:revoke] failed", {
+      tenantId,
+      grantId,
+      message: err?.message || "failed",
+    });
+    return res.status(500).json({ ok: false, error: "TENANT_INSTITUTION_ACCESS_REVOKE_FAILED" });
   }
 });
 

--- a/rentchain-api/src/services/tenantPortal/__tests__/tenantInstitutionAccessService.test.ts
+++ b/rentchain-api/src/services/tenantPortal/__tests__/tenantInstitutionAccessService.test.ts
@@ -1,0 +1,208 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const collections = new Map<string, Map<string, any>>();
+let generatedId = 0;
+
+function ensureCollection(name: string) {
+  if (!collections.has(name)) collections.set(name, new Map());
+  return collections.get(name)!;
+}
+
+const dbMock = {
+  collection: (name: string) => ({
+    async get() {
+      const docs = Array.from(ensureCollection(name).entries()).map(([id, data]) => ({
+        id,
+        data: () => data,
+      }));
+      return { docs, empty: docs.length === 0 };
+    },
+    doc: (id?: string) => {
+      const resolvedId = id || `generated-${++generatedId}`;
+      return {
+        id: resolvedId,
+        async get() {
+          const entry = ensureCollection(name).get(resolvedId);
+          return {
+            id: resolvedId,
+            exists: Boolean(entry),
+            data: () => entry,
+          };
+        },
+        async set(payload: any, options?: { merge?: boolean }) {
+          const current = ensureCollection(name).get(resolvedId) || {};
+          ensureCollection(name).set(resolvedId, options?.merge ? { ...current, ...(payload || {}) } : payload || {});
+        },
+      };
+    },
+    where: (field: string, _op: string, value: any) => ({
+      limit: (_count: number) => ({
+        async get() {
+          const docs = Array.from(ensureCollection(name).entries())
+            .filter(([, data]) => data?.[field] === value)
+            .map(([id, data]) => ({
+              id,
+              data: () => data,
+            }));
+          return { docs, empty: docs.length === 0 };
+        },
+      }),
+    }),
+  }),
+};
+
+const resolveTenancyContext = vi.fn();
+const loadTenantIdentityRecord = vi.fn();
+
+vi.mock("../../../config/firebase", () => ({ db: dbMock }));
+vi.mock("../tenancyContextService", () => ({ resolveTenancyContext }));
+vi.mock("../tenantProfileService", () => ({ loadTenantIdentityRecord }));
+
+describe("tenantInstitutionAccessService", () => {
+  beforeEach(() => {
+    collections.clear();
+    generatedId = 0;
+    vi.clearAllMocks();
+    ensureCollection("tenants").set("tenant-1", {
+      email: "tenant@example.com",
+      leaseId: "lease-1",
+    });
+    ensureCollection("leases").set("lease-1", {
+      status: "active",
+      startDate: "2026-02-01",
+      endDate: "2027-01-31",
+      monthlyRent: 1800,
+      dueDay: 1,
+    });
+    resolveTenancyContext.mockResolvedValue({
+      ok: true,
+      authority: "active_tenant",
+      propertyId: "prop-1",
+      applicationId: "app-1",
+      leaseId: "lease-1",
+      tenantId: "tenant-1",
+      unitId: "unit-1",
+    });
+    loadTenantIdentityRecord.mockResolvedValue({
+      identityStatus: "verified",
+      profile: { completionStatus: "complete" },
+      application: { reusable: true, lastSubmittedAt: "2026-04-20T00:00:00.000Z" },
+      documents: { completionStatus: "complete", missingCategories: [] },
+      screening: { status: "completed", lastCompletedAt: "2026-04-21T00:00:00.000Z" },
+      leases: { activeCount: 1, historicalCount: 1, lastSignedAt: "2026-04-22T00:00:00.000Z" },
+      verification: { level: "strong" },
+      readinessLabel: "Well established",
+      readinessDescription: "Completed verification signals are available.",
+    });
+  });
+
+  it("previews metadata-only institution access and blocks package summaries until consent", async () => {
+    const service = await import("../tenantInstitutionAccessService");
+
+    const preview = await service.previewTenantInstitutionAccess({
+      tenantId: "tenant-1",
+      audience: "insurer",
+      recipient: { email: "Reviewer@Example.com", displayName: "Reviewer", organizationName: "Example Insurance" },
+      expiresInDays: 7,
+      consentAccepted: false,
+    });
+
+    expect(preview?.lifecycle).toBe("consent_required");
+    expect(preview?.recipient.email).toBe("reviewer@example.com");
+    expect(preview?.includedClaims).toEqual([]);
+    expect(preview?.excludedClaims.length).toBeGreaterThan(0);
+    expect(preview?.recipientAccess).toEqual(
+      expect.objectContaining({
+        enabled: false,
+        accessUrl: null,
+        accessTokenIssued: false,
+        recipientAuthenticationRequired: true,
+        downloadEnabled: false,
+      })
+    );
+    const payload = JSON.stringify(preview || {});
+    expect(payload).not.toContain("documentUrl");
+    expect(payload).not.toContain("paymentMethod");
+    expect(payload).not.toContain("supportMetadataIncluded\":true");
+    expect(payload).not.toContain("publicAccessEnabled\":true");
+    expect(payload).not.toContain("externalSubmissionEnabled\":true");
+  });
+
+  it("requires consent, recipient, and expiration before creating an access grant", async () => {
+    const service = await import("../tenantInstitutionAccessService");
+
+    await expect(
+      service.createTenantInstitutionAccessGrant({
+        tenantId: "tenant-1",
+        audience: "insurer",
+        recipient: { email: "reviewer@example.com" },
+        expiresInDays: 7,
+        consentAccepted: false,
+      })
+    ).rejects.toThrow("tenant_institution_access_consent_required");
+
+    await expect(
+      service.createTenantInstitutionAccessGrant({
+        tenantId: "tenant-1",
+        audience: "insurer",
+        expiresInDays: 7,
+        consentAccepted: true,
+      })
+    ).rejects.toThrow("tenant_institution_access_recipient_required");
+
+    await expect(
+      service.createTenantInstitutionAccessGrant({
+        tenantId: "tenant-1",
+        audience: "insurer",
+        recipient: { email: "reviewer@example.com" },
+        consentAccepted: true,
+      })
+    ).rejects.toThrow("tenant_institution_access_expiration_required");
+  });
+
+  it("creates, lists, and revokes tenant-owned access grants without public exposure", async () => {
+    const service = await import("../tenantInstitutionAccessService");
+
+    const grant = await service.createTenantInstitutionAccessGrant({
+      tenantId: "tenant-1",
+      audience: "lender",
+      recipient: { email: "underwriter@example.com", organizationName: "Example Lender" },
+      expiresInDays: 14,
+      consentAccepted: true,
+    });
+
+    expect(grant?.lifecycle).toBe("active");
+    expect(grant?.consent.granted).toBe(true);
+    expect(grant?.package.status).toBe("export_ready");
+    expect(grant?.recipientAccess.enabled).toBe(false);
+    expect(grant?.publicProfileEnabled).toBe(false);
+    expect(grant?.events.map((event) => event.eventType)).toContain("tenant_institution_access_granted");
+    const payload = JSON.stringify(grant || {});
+    expect(payload).not.toContain("tenant-1");
+    expect(payload).not.toContain("publicAccessEnabled\":true");
+    expect(payload).not.toContain("externalSubmissionEnabled\":true");
+    expect(payload).not.toContain("supportMetadataIncluded\":true");
+    expect(ensureCollection("tenantInstitutionAccessGrants").size).toBe(1);
+    expect(Array.from(ensureCollection("tenantInstitutionAccessGrants").values())[0]?.tenantId).toBe("tenant-1");
+
+    const listed = await service.listTenantInstitutionAccessGrants({ tenantId: "tenant-1" });
+    expect(listed).toHaveLength(1);
+    expect(listed[0].grantId).toBe(grant?.grantId);
+
+    const blocked = await service.revokeTenantInstitutionAccessGrant({
+      tenantId: "tenant-2",
+      grantId: grant?.grantId || "",
+    });
+    expect(blocked).toBe(false);
+
+    const revoked = await service.revokeTenantInstitutionAccessGrant({
+      tenantId: "tenant-1",
+      grantId: grant?.grantId || "",
+    });
+    expect(revoked && revoked.lifecycle).toBe("revoked");
+    expect(revoked && revoked.consent.granted).toBe(false);
+    expect(revoked && revoked.recipientAccess.enabled).toBe(false);
+    expect(revoked && revoked.package.exportSummaries.length).toBeGreaterThan(0);
+  });
+});
+

--- a/rentchain-api/src/services/tenantPortal/tenantInstitutionAccessService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantInstitutionAccessService.ts
@@ -1,0 +1,499 @@
+import crypto from "crypto";
+import { db } from "../../config/firebase";
+import type { InstitutionalTrustExportPackage } from "../../lib/institutionTrustExports";
+import type { PortableAttestationClaimCategory } from "../../lib/portableAttestations";
+import {
+  previewTenantTrustExport,
+  type TenantTrustExportAudience,
+  type TenantTrustExportPurpose,
+} from "./tenantTrustExportService";
+
+const COLLECTION = "tenantInstitutionAccessGrants";
+const CONSENT_VERSION = "tenant_institution_access_consent.v1";
+const DEFAULT_EXPIRES_DAYS = 14;
+const MAX_EXPIRES_DAYS = 30;
+
+export type TenantInstitutionAccessAudience = "insurer" | "lender" | "institutional_landlord" | "auditor";
+
+export type TenantInstitutionAccessPurpose =
+  | "insurance_review"
+  | "lender_review"
+  | "institutional_landlord_review"
+  | "auditor_review";
+
+export type TenantInstitutionAccessLifecycle =
+  | "preview"
+  | "active"
+  | "revoked"
+  | "expired"
+  | "blocked"
+  | "consent_required"
+  | "reverification_required";
+
+export type TenantInstitutionAccessRecipient = {
+  email: string;
+  displayName: string | null;
+  organizationName: string | null;
+  authenticationRequirement: "recipient_email_session_required";
+};
+
+export type TenantInstitutionAccessConsentState = {
+  required: true;
+  granted: boolean;
+  consentId: string | null;
+  consentVersion: typeof CONSENT_VERSION;
+  grantedAt: string | null;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  audience: TenantInstitutionAccessAudience;
+  purpose: TenantInstitutionAccessPurpose;
+  recipientEmail: string | null;
+  claimCategories: PortableAttestationClaimCategory[];
+  summary:
+    "Tenant consent is required before RentChain prepares this non-public, metadata-only institution access grant.";
+};
+
+export type TenantInstitutionAccessPreview = {
+  grantId: string | null;
+  schemaVersion: "tenant_institution_access.v1";
+  audience: TenantInstitutionAccessAudience;
+  purpose: TenantInstitutionAccessPurpose;
+  lifecycle: TenantInstitutionAccessLifecycle;
+  recipient: TenantInstitutionAccessRecipient;
+  consent: TenantInstitutionAccessConsentState;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  generatedAt: string;
+  metadataOnly: true;
+  policyGated: true;
+  publicAccessEnabled: false;
+  publicProfileEnabled: false;
+  externalSubmissionEnabled: false;
+  providerIntegrationEnabled: false;
+  automatedDecisioningEnabled: false;
+  recipientAccess: {
+    enabled: false;
+    accessUrl: null;
+    accessTokenIssued: false;
+    recipientAuthenticationRequired: true;
+    sessionBound: true;
+    downloadEnabled: false;
+    summary:
+      "Recipient access is modeled for controlled future review only; no public link or external delivery is created by this grant.";
+  };
+  package: InstitutionalTrustExportPackage;
+  includedClaims: Array<{
+    attestationId: string;
+    claimCategory: PortableAttestationClaimCategory;
+    claimLabel: string;
+    lifecycleState: string;
+    consentExpiresAt: string | null;
+  }>;
+  excludedClaims: Array<{
+    attestationId: string;
+    claimCategory: PortableAttestationClaimCategory;
+    claimLabel: string;
+    reasons: string[];
+  }>;
+  redactions: string[];
+  disclaimers: string[];
+};
+
+export type TenantInstitutionAccessGrant = TenantInstitutionAccessPreview & {
+  grantId: string;
+  lifecycle: "active" | "revoked" | "expired" | "blocked" | "reverification_required";
+  createdAt: string;
+  updatedAt: string;
+  events: Array<{
+    eventType:
+      | "tenant_institution_access_granted"
+      | "tenant_institution_access_revoked"
+      | "tenant_institution_access_expired"
+      | "tenant_institution_access_blocked";
+    occurredAt: string;
+    actorType: "tenant" | "system";
+    metadataOnly: true;
+  }>;
+};
+
+type TenantInstitutionAccessStoredGrant = TenantInstitutionAccessGrant & {
+  tenantId: string;
+};
+
+function asString(value: unknown, max = 240): string | null {
+  const next = String(value ?? "").trim().slice(0, max);
+  return next || null;
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function addDaysIso(start: string, days: number) {
+  return new Date(Date.parse(start) + days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+function clampExpiresInDays(value: unknown) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return null;
+  return Math.min(Math.max(Math.round(numeric), 1), MAX_EXPIRES_DAYS);
+}
+
+function sanitizeAudience(value: unknown): TenantInstitutionAccessAudience {
+  if (value === "lender" || value === "institutional_landlord" || value === "auditor") return value;
+  return "insurer";
+}
+
+function purposeForAudience(audience: TenantInstitutionAccessAudience): TenantInstitutionAccessPurpose {
+  if (audience === "lender") return "lender_review";
+  if (audience === "institutional_landlord") return "institutional_landlord_review";
+  if (audience === "auditor") return "auditor_review";
+  return "insurance_review";
+}
+
+function toTrustExportAudience(audience: TenantInstitutionAccessAudience): TenantTrustExportAudience {
+  return audience;
+}
+
+function toTrustExportPurpose(purpose: TenantInstitutionAccessPurpose): TenantTrustExportPurpose {
+  return purpose;
+}
+
+function normalizeEmail(value: unknown) {
+  const email = asString(value, 320)?.toLowerCase() || null;
+  if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) return null;
+  return email;
+}
+
+function normalizeRecipient(input: unknown): TenantInstitutionAccessRecipient | null {
+  const data = (input || {}) as any;
+  const email = normalizeEmail(data?.email);
+  if (!email) return null;
+  return {
+    email,
+    displayName: asString(data?.displayName, 120),
+    organizationName: asString(data?.organizationName, 160),
+    authenticationRequirement: "recipient_email_session_required",
+  };
+}
+
+function grantIdFor(params: {
+  tenantId: string;
+  audience: TenantInstitutionAccessAudience;
+  purpose: TenantInstitutionAccessPurpose;
+  recipientEmail: string;
+  generatedAt: string;
+}) {
+  const subjectRef = crypto.createHash("sha256").update(params.tenantId).digest("hex").slice(0, 16);
+  const recipientRef = crypto.createHash("sha256").update(params.recipientEmail).digest("hex").slice(0, 12);
+  return [
+    "tenant_institution_access",
+    subjectRef,
+    recipientRef,
+    params.audience,
+    params.purpose,
+    Date.parse(params.generatedAt).toString(36),
+  ]
+    .join(":")
+    .replace(/[^a-zA-Z0-9_.:-]+/g, "_");
+}
+
+function consentIdFor(params: {
+  tenantId: string;
+  grantId: string;
+  audience: TenantInstitutionAccessAudience;
+  purpose: TenantInstitutionAccessPurpose;
+}) {
+  const subjectRef = crypto.createHash("sha256").update(params.tenantId).digest("hex").slice(0, 16);
+  return ["tenant_institution_access_consent", subjectRef, params.grantId, params.audience, params.purpose]
+    .join(":")
+    .replace(/[^a-zA-Z0-9_.:-]+/g, "_");
+}
+
+function lifecycleForPackage(params: {
+  package: InstitutionalTrustExportPackage;
+  consentAccepted: boolean;
+  expiresAt: string | null;
+  revokedAt?: string | null;
+}) {
+  if (params.revokedAt) return "revoked" as const;
+  if (params.expiresAt && Date.parse(params.expiresAt) <= Date.now()) return "expired" as const;
+  if (!params.consentAccepted) return "consent_required" as const;
+  if (params.package.blockedReasons.some((reason) => reason.includes("reverification_required"))) {
+    return "reverification_required" as const;
+  }
+  return params.package.status === "export_ready" ? ("preview" as const) : ("blocked" as const);
+}
+
+function accessPreviewFromTrustPackage(params: {
+  grantId: string | null;
+  tenantId: string;
+  audience: TenantInstitutionAccessAudience;
+  purpose: TenantInstitutionAccessPurpose;
+  recipient: TenantInstitutionAccessRecipient;
+  generatedAt: string;
+  expiresAt: string;
+  consentAccepted: boolean;
+  package: InstitutionalTrustExportPackage;
+  includedClaims: TenantInstitutionAccessPreview["includedClaims"];
+  excludedClaims: TenantInstitutionAccessPreview["excludedClaims"];
+}): TenantInstitutionAccessPreview {
+  const lifecycle = lifecycleForPackage({
+    package: params.package,
+    consentAccepted: params.consentAccepted,
+    expiresAt: params.expiresAt,
+  });
+  const claimCategories = Array.from(
+    new Set([
+      ...params.includedClaims.map((claim) => claim.claimCategory),
+      ...params.excludedClaims.map((claim) => claim.claimCategory),
+    ])
+  );
+  const consentId =
+    params.consentAccepted && params.grantId
+      ? consentIdFor({
+          tenantId: params.tenantId,
+          grantId: params.grantId,
+          audience: params.audience,
+          purpose: params.purpose,
+        })
+      : null;
+
+  return {
+    grantId: params.grantId,
+    schemaVersion: "tenant_institution_access.v1",
+    audience: params.audience,
+    purpose: params.purpose,
+    lifecycle,
+    recipient: params.recipient,
+    consent: {
+      required: true,
+      granted: params.consentAccepted,
+      consentId,
+      consentVersion: CONSENT_VERSION,
+      grantedAt: params.consentAccepted ? params.generatedAt : null,
+      expiresAt: params.expiresAt,
+      revokedAt: null,
+      audience: params.audience,
+      purpose: params.purpose,
+      recipientEmail: params.recipient.email,
+      claimCategories,
+      summary:
+        "Tenant consent is required before RentChain prepares this non-public, metadata-only institution access grant.",
+    },
+    expiresAt: params.expiresAt,
+    revokedAt: null,
+    generatedAt: params.generatedAt,
+    metadataOnly: true,
+    policyGated: true,
+    publicAccessEnabled: false,
+    publicProfileEnabled: false,
+    externalSubmissionEnabled: false,
+    providerIntegrationEnabled: false,
+    automatedDecisioningEnabled: false,
+    recipientAccess: {
+      enabled: false,
+      accessUrl: null,
+      accessTokenIssued: false,
+      recipientAuthenticationRequired: true,
+      sessionBound: true,
+      downloadEnabled: false,
+      summary:
+        "Recipient access is modeled for controlled future review only; no public link or external delivery is created by this grant.",
+    },
+    package: params.package,
+    includedClaims: params.includedClaims,
+    excludedClaims: params.excludedClaims,
+    redactions: [
+      "Raw identity documents are excluded.",
+      "Raw provider payloads are excluded.",
+      "Support/internal metadata is excluded.",
+      "Public trust profiles and public links are not created.",
+      "External institution delivery is disabled.",
+    ],
+    disclaimers: [
+      "This access grant is tenant-mediated and metadata-only.",
+      "Recipient access requires a future authenticated session before any controlled view can be served.",
+      "This grant is not a credit, insurance, subsidy, ownership, or automated eligibility decision.",
+      "Revoked or expired grants must not expose active trust data in RentChain-controlled surfaces.",
+    ],
+  };
+}
+
+function publicGrant(record: TenantInstitutionAccessStoredGrant): TenantInstitutionAccessGrant {
+  const { tenantId: _tenantId, ...rest } = record;
+  return rest;
+}
+
+function asGrant(id: string, data: any): TenantInstitutionAccessStoredGrant {
+  const expiresAt = asString(data?.expiresAt);
+  const lifecycle =
+    data?.lifecycle === "revoked"
+      ? "revoked"
+      : expiresAt && Date.parse(expiresAt) <= Date.now()
+      ? "expired"
+      : data?.lifecycle === "blocked" || data?.package?.status !== "export_ready"
+      ? "blocked"
+      : "active";
+  return {
+    ...(data || {}),
+    grantId: id,
+    lifecycle,
+  } as TenantInstitutionAccessStoredGrant;
+}
+
+export async function previewTenantInstitutionAccess(params: {
+  tenantId: string;
+  audience?: unknown;
+  purpose?: unknown;
+  recipient?: unknown;
+  expiresInDays?: unknown;
+  consentAccepted?: boolean;
+}) {
+  const tenantId = asString(params.tenantId);
+  if (!tenantId) return null;
+  const recipient = normalizeRecipient(params.recipient);
+  if (!recipient) throw new Error("tenant_institution_access_recipient_required");
+  const expiresInDays = clampExpiresInDays(params.expiresInDays);
+  if (!expiresInDays) throw new Error("tenant_institution_access_expiration_required");
+
+  const audience = sanitizeAudience(params.audience);
+  const purpose = purposeForAudience(audience);
+  const generatedAt = nowIso();
+  const expiresAt = addDaysIso(generatedAt, expiresInDays);
+  const grantId = params.consentAccepted
+    ? grantIdFor({ tenantId, audience, purpose, recipientEmail: recipient.email, generatedAt })
+    : null;
+  const trustPreview = await previewTenantTrustExport({
+    tenantId,
+    audience: toTrustExportAudience(audience),
+    purpose: toTrustExportPurpose(purpose),
+    expiresInDays,
+    consentAccepted: params.consentAccepted === true,
+  });
+  if (!trustPreview) return null;
+
+  return accessPreviewFromTrustPackage({
+    grantId,
+    tenantId,
+    audience,
+    purpose,
+    recipient,
+    generatedAt,
+    expiresAt,
+    consentAccepted: params.consentAccepted === true,
+    package: trustPreview.package,
+    includedClaims: trustPreview.includedClaims,
+    excludedClaims: trustPreview.excludedClaims,
+  });
+}
+
+export async function createTenantInstitutionAccessGrant(params: {
+  tenantId: string;
+  audience?: unknown;
+  purpose?: unknown;
+  recipient?: unknown;
+  expiresInDays?: unknown;
+  consentAccepted?: boolean;
+}) {
+  const tenantId = asString(params.tenantId);
+  if (!tenantId) return null;
+  if (params.consentAccepted !== true) throw new Error("tenant_institution_access_consent_required");
+  const preview = await previewTenantInstitutionAccess({ ...params, tenantId, consentAccepted: true });
+  if (!preview) return null;
+  if (preview.lifecycle === "blocked" || preview.lifecycle === "reverification_required" || preview.package.status !== "export_ready") {
+    throw new Error("tenant_institution_access_policy_blocked");
+  }
+  if (!preview.grantId) throw new Error("tenant_institution_access_invalid");
+  const createdAt = preview.generatedAt;
+  const record: TenantInstitutionAccessStoredGrant = {
+    ...preview,
+    grantId: preview.grantId,
+    tenantId,
+    lifecycle: "active",
+    createdAt,
+    updatedAt: createdAt,
+    events: [
+      {
+        eventType: "tenant_institution_access_granted",
+        occurredAt: createdAt,
+        actorType: "tenant",
+        metadataOnly: true,
+      },
+    ],
+  };
+  await db.collection(COLLECTION).doc(record.grantId).set(record);
+  return publicGrant(record);
+}
+
+export async function listTenantInstitutionAccessGrants(params: { tenantId: string }) {
+  const tenantId = asString(params.tenantId);
+  if (!tenantId) return [];
+  const snap = await db.collection(COLLECTION).where("tenantId", "==", tenantId).limit(25).get();
+  return (snap.docs || [])
+    .map((doc: any) => asGrant(String(doc.id || ""), doc.data?.() || {}))
+    .map(publicGrant)
+    .sort((left, right) => Date.parse(right.createdAt || right.generatedAt) - Date.parse(left.createdAt || left.generatedAt));
+}
+
+export async function revokeTenantInstitutionAccessGrant(params: { tenantId: string; grantId: string }) {
+  const tenantId = asString(params.tenantId);
+  const grantId = asString(params.grantId);
+  if (!tenantId || !grantId) return null;
+  const ref = db.collection(COLLECTION).doc(grantId);
+  const snap = await ref.get();
+  if (!snap.exists) return null;
+  const current = asGrant(grantId, snap.data?.() || {});
+  if (current.tenantId !== tenantId) return false;
+  const updatedAt = nowIso();
+  const events = [
+    ...(Array.isArray(current.events) ? current.events : []),
+    {
+      eventType: "tenant_institution_access_revoked" as const,
+      occurredAt: updatedAt,
+      actorType: "tenant" as const,
+      metadataOnly: true as const,
+    },
+  ];
+  await ref.set(
+    {
+      lifecycle: "revoked",
+      revokedAt: updatedAt,
+      updatedAt,
+      events,
+      consent: {
+        ...current.consent,
+        granted: false,
+        revokedAt: updatedAt,
+      },
+      recipientAccess: {
+        ...current.recipientAccess,
+        enabled: false,
+        accessUrl: null,
+        accessTokenIssued: false,
+        downloadEnabled: false,
+      },
+    },
+    { merge: true }
+  );
+  return publicGrant({
+    ...current,
+    lifecycle: "revoked",
+    revokedAt: updatedAt,
+    updatedAt,
+    events,
+    consent: {
+      ...current.consent,
+      granted: false,
+      revokedAt: updatedAt,
+    },
+    recipientAccess: {
+      ...current.recipientAccess,
+      enabled: false,
+      accessUrl: null,
+      accessTokenIssued: false,
+      downloadEnabled: false,
+    },
+  });
+}
+

--- a/rentchain-frontend/src/api/tenantInstitutionAccess.ts
+++ b/rentchain-frontend/src/api/tenantInstitutionAccess.ts
@@ -1,0 +1,169 @@
+import { tenantApiFetch } from "./tenantApiFetch";
+
+export type TenantInstitutionAccessAudience = "insurer" | "lender" | "institutional_landlord" | "auditor";
+
+export type TenantInstitutionAccessPurpose =
+  | "insurance_review"
+  | "lender_review"
+  | "institutional_landlord_review"
+  | "auditor_review";
+
+export type TenantInstitutionAccessLifecycle =
+  | "preview"
+  | "active"
+  | "revoked"
+  | "expired"
+  | "blocked"
+  | "consent_required"
+  | "reverification_required";
+
+export type TenantInstitutionAccessRecipient = {
+  email: string;
+  displayName: string | null;
+  organizationName: string | null;
+  authenticationRequirement: "recipient_email_session_required";
+};
+
+export type TenantInstitutionAccessPreview = {
+  grantId: string | null;
+  schemaVersion: "tenant_institution_access.v1";
+  audience: TenantInstitutionAccessAudience;
+  purpose: TenantInstitutionAccessPurpose;
+  lifecycle: TenantInstitutionAccessLifecycle;
+  recipient: TenantInstitutionAccessRecipient;
+  consent: {
+    required: true;
+    granted: boolean;
+    consentId: string | null;
+    consentVersion: "tenant_institution_access_consent.v1";
+    grantedAt: string | null;
+    expiresAt: string | null;
+    revokedAt: string | null;
+    audience: TenantInstitutionAccessAudience;
+    purpose: TenantInstitutionAccessPurpose;
+    recipientEmail: string | null;
+    claimCategories: string[];
+    summary: string;
+  };
+  expiresAt: string | null;
+  revokedAt: string | null;
+  generatedAt: string;
+  metadataOnly: true;
+  policyGated: true;
+  publicAccessEnabled: false;
+  publicProfileEnabled: false;
+  externalSubmissionEnabled: false;
+  providerIntegrationEnabled: false;
+  automatedDecisioningEnabled: false;
+  recipientAccess: {
+    enabled: false;
+    accessUrl: null;
+    accessTokenIssued: false;
+    recipientAuthenticationRequired: true;
+    sessionBound: true;
+    downloadEnabled: false;
+    summary: string;
+  };
+  package: {
+    status: "export_ready" | "blocked" | "unavailable";
+    blockedReasons: string[];
+    exportSummaries: Array<{
+      attestationId: string;
+      claimCategory: string;
+      claimLabel: string;
+      metadataOnly: true;
+      rawEvidenceIncluded: false;
+      rawProviderPayloadIncluded: false;
+      supportMetadataIncluded: false;
+      publicAccessEnabled: false;
+      externalSubmissionEnabled: false;
+    }>;
+  };
+  includedClaims: Array<{
+    attestationId: string;
+    claimCategory: string;
+    claimLabel: string;
+    lifecycleState: string;
+    consentExpiresAt: string | null;
+  }>;
+  excludedClaims: Array<{
+    attestationId: string;
+    claimCategory: string;
+    claimLabel: string;
+    reasons: string[];
+  }>;
+  redactions: string[];
+  disclaimers: string[];
+};
+
+export type TenantInstitutionAccessGrant = TenantInstitutionAccessPreview & {
+  grantId: string;
+  lifecycle: "active" | "revoked" | "expired" | "blocked" | "reverification_required";
+  createdAt: string;
+  updatedAt: string;
+  events: Array<{
+    eventType:
+      | "tenant_institution_access_granted"
+      | "tenant_institution_access_revoked"
+      | "tenant_institution_access_expired"
+      | "tenant_institution_access_blocked";
+    occurredAt: string;
+    actorType: "tenant" | "system";
+    metadataOnly: true;
+  }>;
+};
+
+export type TenantInstitutionAccessRequest = {
+  audience: TenantInstitutionAccessAudience;
+  purpose?: TenantInstitutionAccessPurpose;
+  recipient: {
+    email: string;
+    displayName?: string;
+    organizationName?: string;
+  };
+  expiresInDays: number;
+  consentAccepted?: boolean;
+};
+
+export async function listTenantInstitutionAccessGrants(): Promise<TenantInstitutionAccessGrant[]> {
+  const res = await tenantApiFetch<{ ok: boolean; data: { items: TenantInstitutionAccessGrant[] } }>(
+    "/tenant/institution-access/grants"
+  );
+  return Array.isArray(res?.data?.items) ? res.data.items : [];
+}
+
+export async function previewTenantInstitutionAccess(
+  request: TenantInstitutionAccessRequest
+): Promise<TenantInstitutionAccessPreview> {
+  const res = await tenantApiFetch<{ ok: boolean; data: TenantInstitutionAccessPreview }>(
+    "/tenant/institution-access/preview",
+    {
+      method: "POST",
+      body: request,
+    }
+  );
+  return res.data;
+}
+
+export async function createTenantInstitutionAccessGrant(
+  request: TenantInstitutionAccessRequest
+): Promise<TenantInstitutionAccessGrant> {
+  const res = await tenantApiFetch<{ ok: boolean; data: TenantInstitutionAccessGrant }>(
+    "/tenant/institution-access/grants",
+    {
+      method: "POST",
+      body: request,
+    }
+  );
+  return res.data;
+}
+
+export async function revokeTenantInstitutionAccessGrant(grantId: string): Promise<TenantInstitutionAccessGrant> {
+  const res = await tenantApiFetch<{ ok: boolean; data: TenantInstitutionAccessGrant }>(
+    `/tenant/institution-access/grants/${encodeURIComponent(grantId)}/revoke`,
+    {
+      method: "POST",
+    }
+  );
+  return res.data;
+}

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -72,6 +72,13 @@ const tenantTrustExportsApi = vi.hoisted(() => ({
   revokeTenantTrustExport: vi.fn(),
 }));
 
+const tenantInstitutionAccessApi = vi.hoisted(() => ({
+  listTenantInstitutionAccessGrants: vi.fn(),
+  previewTenantInstitutionAccess: vi.fn(),
+  createTenantInstitutionAccessGrant: vi.fn(),
+  revokeTenantInstitutionAccessGrant: vi.fn(),
+}));
+
 vi.mock("../../api/tenantPortal", () => tenantPortalApi);
 vi.mock("../../api/tenantApplicationCompletion", () => tenantApplicationCompletionApi);
 vi.mock("../../api/tenantAccess", () => tenantAccessApi);
@@ -88,6 +95,7 @@ vi.mock("../../api/tenantScreeningApi", async () => {
 });
 vi.mock("../../api/tenantSharePackages", () => tenantSharePackagesApi);
 vi.mock("../../api/tenantTrustExports", () => tenantTrustExportsApi);
+vi.mock("../../api/tenantInstitutionAccess", () => tenantInstitutionAccessApi);
 vi.mock("../../api/maintenanceWorkflowApi", async () => {
   const actual = await vi.importActual<any>("../../api/maintenanceWorkflowApi");
   return {
@@ -685,6 +693,120 @@ describe("tenant workspace frontend shell", () => {
       exportId,
       lifecycle: "revoked",
       revokedAt: "2026-05-10T00:00:00.000Z",
+    }));
+    tenantInstitutionAccessApi.listTenantInstitutionAccessGrants.mockResolvedValue([]);
+    const institutionAccessPreview = {
+      grantId: null,
+      schemaVersion: "tenant_institution_access.v1",
+      audience: "insurer",
+      purpose: "insurance_review",
+      lifecycle: "consent_required",
+      recipient: {
+        email: "reviewer@example.com",
+        displayName: null,
+        organizationName: "Example Insurance",
+        authenticationRequirement: "recipient_email_session_required",
+      },
+      consent: {
+        required: true,
+        granted: false,
+        consentId: null,
+        consentVersion: "tenant_institution_access_consent.v1",
+        grantedAt: null,
+        expiresAt: "2026-05-23T00:00:00.000Z",
+        revokedAt: null,
+        audience: "insurer",
+        purpose: "insurance_review",
+        recipientEmail: "reviewer@example.com",
+        claimCategories: ["tenant_portability"],
+        summary:
+          "Tenant consent is required before RentChain prepares this non-public, metadata-only institution access grant.",
+      },
+      expiresAt: "2026-05-23T00:00:00.000Z",
+      revokedAt: null,
+      generatedAt: "2026-05-09T00:00:00.000Z",
+      metadataOnly: true,
+      policyGated: true,
+      publicAccessEnabled: false,
+      publicProfileEnabled: false,
+      externalSubmissionEnabled: false,
+      providerIntegrationEnabled: false,
+      automatedDecisioningEnabled: false,
+      recipientAccess: {
+        enabled: false,
+        accessUrl: null,
+        accessTokenIssued: false,
+        recipientAuthenticationRequired: true,
+        sessionBound: true,
+        downloadEnabled: false,
+        summary:
+          "Recipient access is modeled for controlled future review only; no public link or external delivery is created by this grant.",
+      },
+      package: {
+        status: "blocked",
+        blockedReasons: ["tenant_trust:tenant_portability: consent_missing"],
+        exportSummaries: [],
+      },
+      includedClaims: [],
+      excludedClaims: [
+        {
+          attestationId: "tenant_trust:tenant_portability",
+          claimCategory: "tenant_portability",
+          claimLabel: "tenant portability",
+          reasons: ["consent_missing"],
+        },
+      ],
+      redactions: ["Support/internal metadata is excluded.", "Public trust profiles and public links are not created."],
+      disclaimers: ["This access grant is tenant-mediated and metadata-only."],
+    };
+    const institutionAccessGrant = {
+      ...institutionAccessPreview,
+      grantId: "grant-1",
+      lifecycle: "active",
+      consent: {
+        ...institutionAccessPreview.consent,
+        granted: true,
+        consentId: "consent-1",
+        grantedAt: "2026-05-09T00:00:00.000Z",
+      },
+      package: {
+        status: "export_ready",
+        blockedReasons: [],
+        exportSummaries: [],
+      },
+      includedClaims: [
+        {
+          attestationId: "tenant_trust:tenant_portability",
+          claimCategory: "tenant_portability",
+          claimLabel: "Tenant portability metadata available",
+          lifecycleState: "export_ready",
+          consentExpiresAt: "2026-05-23T00:00:00.000Z",
+        },
+      ],
+      excludedClaims: [],
+      createdAt: "2026-05-09T00:00:00.000Z",
+      updatedAt: "2026-05-09T00:00:00.000Z",
+      events: [
+        {
+          eventType: "tenant_institution_access_granted",
+          occurredAt: "2026-05-09T00:00:00.000Z",
+          actorType: "tenant",
+          metadataOnly: true,
+        },
+      ],
+    };
+    tenantInstitutionAccessApi.previewTenantInstitutionAccess.mockResolvedValue(institutionAccessPreview);
+    tenantInstitutionAccessApi.createTenantInstitutionAccessGrant.mockResolvedValue(institutionAccessGrant);
+    tenantInstitutionAccessApi.revokeTenantInstitutionAccessGrant.mockImplementation(async (grantId: string) => ({
+      ...institutionAccessGrant,
+      grantId,
+      lifecycle: "revoked",
+      revokedAt: "2026-05-10T00:00:00.000Z",
+      consent: {
+        ...institutionAccessGrant.consent,
+        granted: false,
+        revokedAt: "2026-05-10T00:00:00.000Z",
+      },
     }));
     tenantSharePackagesApi.createTenantSharePackage.mockResolvedValue({
       id: "share-1",
@@ -1344,6 +1466,59 @@ describe("tenant workspace frontend shell", () => {
     fireEvent.click(screen.getByRole("button", { name: /Revoke export/i }));
     await waitFor(() => {
       expect(tenantTrustExportsApi.revokeTenantTrustExport).toHaveBeenCalledWith("export-1");
+    });
+  });
+
+  it("requires tenant consent before creating institution access grants", async () => {
+    render(
+      <MemoryRouter>
+        <TenantWorkspacePage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Tenant-mediated institution access/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Create access grant/i })).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText(/Recipient email/i), {
+      target: { value: "reviewer@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText(/Organization/i), {
+      target: { value: "Example Insurance" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Preview access/i }));
+    await waitFor(() => {
+      expect(tenantInstitutionAccessApi.previewTenantInstitutionAccess).toHaveBeenCalledWith(
+        expect.objectContaining({
+          audience: "insurer",
+          recipient: expect.objectContaining({ email: "reviewer@example.com" }),
+          expiresInDays: 14,
+          consentAccepted: false,
+        })
+      );
+    });
+    expect(await screen.findByText(/No claims are accessible until consent and policy checks pass/i)).toBeInTheDocument();
+    expect(screen.getByText(/Public trust profiles and public links are not created/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText(/I consent to preparing metadata-only institution access/i));
+    fireEvent.click(screen.getByRole("button", { name: /Create access grant/i }));
+    await waitFor(() => {
+      expect(tenantInstitutionAccessApi.createTenantInstitutionAccessGrant).toHaveBeenCalledWith(
+        expect.objectContaining({
+          audience: "insurer",
+          consentAccepted: true,
+          recipient: expect.objectContaining({ email: "reviewer@example.com" }),
+        })
+      );
+    });
+    expect(await screen.findByText(/Tenant portability metadata available/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Not created/i).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/verified tenant/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/reputation/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /send to institution/i })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Revoke access/i }));
+    await waitFor(() => {
+      expect(tenantInstitutionAccessApi.revokeTenantInstitutionAccessGrant).toHaveBeenCalledWith("grant-1");
     });
   });
 

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
@@ -37,6 +37,15 @@ import {
   type TenantTrustExportRecord,
 } from "../../api/tenantTrustExports";
 import {
+  createTenantInstitutionAccessGrant,
+  listTenantInstitutionAccessGrants,
+  previewTenantInstitutionAccess,
+  revokeTenantInstitutionAccessGrant,
+  type TenantInstitutionAccessAudience,
+  type TenantInstitutionAccessGrant,
+  type TenantInstitutionAccessPreview,
+} from "../../api/tenantInstitutionAccess";
+import {
   TenantEmptyState,
   TenantErrorState,
   TenantInfoCard,
@@ -171,6 +180,27 @@ function prettyTrustExportLifecycle(value: string | null | undefined) {
     case "preview":
     default:
       return "Preview";
+  }
+}
+
+function institutionAccessPurposeForAudience(audience: TenantInstitutionAccessAudience) {
+  if (audience === "lender") return "lender_review" as const;
+  if (audience === "institutional_landlord") return "institutional_landlord_review" as const;
+  if (audience === "auditor") return "auditor_review" as const;
+  return "insurance_review" as const;
+}
+
+function prettyInstitutionAccessAudience(value: TenantInstitutionAccessAudience | null | undefined) {
+  switch (value) {
+    case "lender":
+      return "Lender review";
+    case "institutional_landlord":
+      return "Institutional landlord review";
+    case "auditor":
+      return "Auditor review";
+    case "insurer":
+    default:
+      return "Insurer review";
   }
 }
 
@@ -327,6 +357,14 @@ export default function TenantWorkspacePage() {
   const [trustExportConsentAccepted, setTrustExportConsentAccepted] = React.useState(false);
   const [trustExportBusy, setTrustExportBusy] = React.useState(false);
   const [trustExportError, setTrustExportError] = React.useState<string | null>(null);
+  const [institutionAccessGrants, setInstitutionAccessGrants] = React.useState<TenantInstitutionAccessGrant[]>([]);
+  const [institutionAccessPreview, setInstitutionAccessPreview] = React.useState<TenantInstitutionAccessPreview | null>(null);
+  const [institutionAccessAudience, setInstitutionAccessAudience] = React.useState<TenantInstitutionAccessAudience>("insurer");
+  const [institutionAccessRecipientEmail, setInstitutionAccessRecipientEmail] = React.useState("");
+  const [institutionAccessOrganization, setInstitutionAccessOrganization] = React.useState("");
+  const [institutionAccessConsentAccepted, setInstitutionAccessConsentAccepted] = React.useState(false);
+  const [institutionAccessBusy, setInstitutionAccessBusy] = React.useState(false);
+  const [institutionAccessError, setInstitutionAccessError] = React.useState<string | null>(null);
   const [freshShareUrl, setFreshShareUrl] = React.useState<string | null>(null);
   const [shareBusy, setShareBusy] = React.useState(false);
   const [shareError, setShareError] = React.useState<string | null>(null);
@@ -363,6 +401,7 @@ export default function TenantWorkspacePage() {
         screeningsResult,
         sharePackagesResult,
         trustExportsResult,
+        institutionAccessGrantsResult,
         handoffDraftsResult,
       ] = await Promise.allSettled([
         getTenantWorkspace(),
@@ -374,6 +413,7 @@ export default function TenantWorkspacePage() {
         listTenantScreenings(),
         listTenantSharePackages(),
         listTenantTrustExports(),
+        listTenantInstitutionAccessGrants(),
         listInstitutionalHandoffDrafts(),
       ]);
 
@@ -394,6 +434,9 @@ export default function TenantWorkspacePage() {
       );
       setSharePackages(sharePackagesResult.status === "fulfilled" ? sharePackagesResult.value : []);
       setTrustExports(trustExportsResult.status === "fulfilled" ? trustExportsResult.value : []);
+      setInstitutionAccessGrants(
+        institutionAccessGrantsResult.status === "fulfilled" ? institutionAccessGrantsResult.value : []
+      );
       setHandoffDrafts(handoffDraftsResult.status === "fulfilled" ? handoffDraftsResult.value : []);
     } catch (err: any) {
       setData(null);
@@ -405,6 +448,7 @@ export default function TenantWorkspacePage() {
       setScreenings([]);
       setSharePackages([]);
       setTrustExports([]);
+      setInstitutionAccessGrants([]);
       setHandoffDrafts([]);
       setError(err?.payload?.error || err?.message || "Unable to load your tenant workspace.");
     } finally {
@@ -606,6 +650,71 @@ export default function TenantWorkspacePage() {
       URL.revokeObjectURL(url);
     } catch {
       setTrustExportError("Trust export JSON download is unavailable in this browser right now.");
+    }
+  }, []);
+
+  const institutionAccessRequest = React.useCallback(
+    (consentAccepted: boolean) => ({
+      audience: institutionAccessAudience,
+      purpose: institutionAccessPurposeForAudience(institutionAccessAudience),
+      recipient: {
+        email: institutionAccessRecipientEmail,
+        organizationName: institutionAccessOrganization,
+      },
+      expiresInDays: 14,
+      consentAccepted,
+    }),
+    [institutionAccessAudience, institutionAccessOrganization, institutionAccessRecipientEmail],
+  );
+
+  const handlePreviewInstitutionAccess = React.useCallback(async () => {
+    try {
+      setInstitutionAccessBusy(true);
+      setInstitutionAccessError(null);
+      const next = await previewTenantInstitutionAccess(institutionAccessRequest(institutionAccessConsentAccepted));
+      setInstitutionAccessPreview(next);
+    } catch (err: any) {
+      setInstitutionAccessError(
+        err?.payload?.error === "TENANT_INSTITUTION_ACCESS_RECIPIENT_REQUIRED"
+          ? "Enter a recipient email before previewing institution access."
+          : err?.payload?.error || err?.message || "Unable to preview institution access right now."
+      );
+    } finally {
+      setInstitutionAccessBusy(false);
+    }
+  }, [institutionAccessConsentAccepted, institutionAccessRequest]);
+
+  const handleCreateInstitutionAccessGrant = React.useCallback(async () => {
+    try {
+      setInstitutionAccessBusy(true);
+      setInstitutionAccessError(null);
+      const created = await createTenantInstitutionAccessGrant(institutionAccessRequest(institutionAccessConsentAccepted));
+      setInstitutionAccessPreview(created);
+      setInstitutionAccessGrants((current) => [created, ...current.filter((entry) => entry.grantId !== created.grantId)]);
+    } catch (err: any) {
+      setInstitutionAccessError(
+        err?.payload?.error === "TENANT_INSTITUTION_ACCESS_CONSENT_REQUIRED"
+          ? "Confirm consent before creating institution access."
+          : err?.payload?.error === "TENANT_INSTITUTION_ACCESS_RECIPIENT_REQUIRED"
+          ? "Enter a recipient email before creating institution access."
+          : err?.payload?.error || err?.message || "Unable to create institution access right now."
+      );
+    } finally {
+      setInstitutionAccessBusy(false);
+    }
+  }, [institutionAccessConsentAccepted, institutionAccessRequest]);
+
+  const handleRevokeInstitutionAccessGrant = React.useCallback(async (grantId: string) => {
+    try {
+      setInstitutionAccessBusy(true);
+      setInstitutionAccessError(null);
+      const revoked = await revokeTenantInstitutionAccessGrant(grantId);
+      setInstitutionAccessGrants((current) => current.map((entry) => (entry.grantId === grantId ? revoked : entry)));
+      setInstitutionAccessPreview((current) => (current?.grantId === grantId ? revoked : current));
+    } catch (err: any) {
+      setInstitutionAccessError(err?.payload?.error || err?.message || "Unable to revoke institution access right now.");
+    } finally {
+      setInstitutionAccessBusy(false);
     }
   }, []);
 
@@ -1601,6 +1710,166 @@ export default function TenantWorkspacePage() {
               ) : (
                 <div style={{ color: textTokens.secondary }}>
                   Prepared trust exports will appear here. They remain tenant-controlled and non-public.
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div
+            style={{
+              border: "1px solid rgba(15,23,42,0.08)",
+              borderRadius: 12,
+              padding: "12px 14px",
+              display: "grid",
+              gap: 10,
+            }}
+          >
+            <div style={{ fontWeight: 700, color: textTokens.primary }}>Tenant-mediated institution access</div>
+            <div style={{ color: textTokens.secondary, lineHeight: 1.6 }}>
+              Prepare a controlled, non-public access grant for a specific recipient. This does not create a public profile, does not send data to an institution, and does not enable automatic decisions.
+            </div>
+
+            <div style={{ display: "grid", gap: 10, gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))" }}>
+              <label style={{ display: "grid", gap: 6 }}>
+                <span style={{ fontWeight: 600, color: textTokens.primary }}>Recipient email</span>
+                <input
+                  value={institutionAccessRecipientEmail}
+                  onChange={(event) => {
+                    setInstitutionAccessRecipientEmail(event.target.value);
+                    setInstitutionAccessPreview(null);
+                  }}
+                  placeholder="reviewer@example.com"
+                />
+              </label>
+              <label style={{ display: "grid", gap: 6 }}>
+                <span style={{ fontWeight: 600, color: textTokens.primary }}>Organization</span>
+                <input
+                  value={institutionAccessOrganization}
+                  onChange={(event) => {
+                    setInstitutionAccessOrganization(event.target.value);
+                    setInstitutionAccessPreview(null);
+                  }}
+                  placeholder="Optional"
+                />
+              </label>
+              <label style={{ display: "grid", gap: 6 }}>
+                <span style={{ fontWeight: 600, color: textTokens.primary }}>Audience</span>
+                <select
+                  value={institutionAccessAudience}
+                  onChange={(event) => {
+                    setInstitutionAccessAudience(event.target.value as TenantInstitutionAccessAudience);
+                    setInstitutionAccessPreview(null);
+                  }}
+                >
+                  <option value="insurer">Insurer review</option>
+                  <option value="lender">Lender review</option>
+                  <option value="institutional_landlord">Institutional landlord review</option>
+                  <option value="auditor">Auditor review</option>
+                </select>
+              </label>
+              <div style={{ color: textTokens.secondary, lineHeight: 1.6 }}>
+                Purpose: {prettyStatus(institutionAccessPurposeForAudience(institutionAccessAudience))}
+                <br />
+                Expires: 14 days after grant
+              </div>
+            </div>
+
+            <label style={{ display: "flex", gap: 10, alignItems: "flex-start", color: textTokens.secondary, lineHeight: 1.5 }}>
+              <input
+                type="checkbox"
+                checked={institutionAccessConsentAccepted}
+                onChange={(event) => {
+                  setInstitutionAccessConsentAccepted(event.target.checked);
+                  setInstitutionAccessPreview(null);
+                }}
+                style={{ marginTop: 4 }}
+              />
+              <span>
+                I consent to preparing metadata-only institution access for {prettyInstitutionAccessAudience(institutionAccessAudience)}. I understand recipient access requires controlled future authentication, no public link is created, and this is not an eligibility or approval decision.
+              </span>
+            </label>
+
+            <div style={{ display: "flex", gap: spacing.sm, flexWrap: "wrap" }}>
+              <button type="button" onClick={() => void handlePreviewInstitutionAccess()} disabled={institutionAccessBusy}>
+                {institutionAccessBusy ? "Checking..." : "Preview access"}
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleCreateInstitutionAccessGrant()}
+                disabled={institutionAccessBusy || !institutionAccessConsentAccepted}
+              >
+                Create access grant
+              </button>
+            </div>
+
+            {institutionAccessError ? <div style={{ color: "#b91c1c" }}>{institutionAccessError}</div> : null}
+
+            {institutionAccessPreview ? (
+              <div style={{ border: "1px solid rgba(15,23,42,0.08)", borderRadius: 12, padding: "12px 14px", display: "grid", gap: 10 }}>
+                <div style={{ display: "flex", justifyContent: "space-between", gap: spacing.sm, flexWrap: "wrap" }}>
+                  <div style={{ fontWeight: 800, color: textTokens.primary }}>Institution access preview</div>
+                  <div style={{ color: textTokens.secondary }}>{prettyTrustExportLifecycle(institutionAccessPreview.lifecycle)}</div>
+                </div>
+                <TenantKeyValueGrid
+                  rows={[
+                    { label: "Recipient", value: institutionAccessPreview.recipient.email },
+                    { label: "Audience", value: prettyInstitutionAccessAudience(institutionAccessPreview.audience) },
+                    { label: "Consent", value: institutionAccessPreview.consent.granted ? "Granted for this access grant" : "Required" },
+                    { label: "Policy status", value: prettyStatus(institutionAccessPreview.package.status) },
+                    { label: "Included claims", value: String(institutionAccessPreview.includedClaims.length) },
+                    { label: "Public access", value: institutionAccessPreview.publicAccessEnabled ? "Enabled" : "Disabled" },
+                    { label: "Recipient URL", value: institutionAccessPreview.recipientAccess.accessUrl || "Not created" },
+                    { label: "Expires", value: formatDate(institutionAccessPreview.expiresAt) },
+                  ]}
+                />
+                <div style={{ display: "grid", gap: 6 }}>
+                  <div style={{ fontWeight: 700, color: textTokens.primary }}>Included metadata</div>
+                  {institutionAccessPreview.includedClaims.length ? (
+                    institutionAccessPreview.includedClaims.map((claim) => (
+                      <div key={claim.attestationId} style={{ color: textTokens.secondary }}>
+                        {claim.claimLabel} - {prettyStatus(claim.claimCategory)}
+                      </div>
+                    ))
+                  ) : (
+                    <div style={{ color: textTokens.secondary }}>No claims are accessible until consent and policy checks pass.</div>
+                  )}
+                </div>
+                <div style={{ display: "grid", gap: 6 }}>
+                  <div style={{ fontWeight: 700, color: textTokens.primary }}>Always excluded</div>
+                  {institutionAccessPreview.redactions.map((item) => (
+                    <div key={item} style={{ color: textTokens.secondary }}>
+                      {item}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+
+            <div style={{ display: "grid", gap: 8 }}>
+              <div style={{ fontWeight: 700, color: textTokens.primary }}>Institution access grants</div>
+              {institutionAccessGrants.length ? (
+                institutionAccessGrants.map((entry) => (
+                  <div key={entry.grantId} style={{ border: "1px solid rgba(15,23,42,0.08)", borderRadius: 12, padding: "12px 14px", display: "grid", gap: 8 }}>
+                    <TenantKeyValueGrid
+                      rows={[
+                        { label: "Recipient", value: entry.recipient.email },
+                        { label: "Audience", value: prettyInstitutionAccessAudience(entry.audience) },
+                        { label: "Status", value: prettyTrustExportLifecycle(entry.lifecycle) },
+                        { label: "Created", value: formatDate(entry.createdAt) },
+                        { label: "Expires", value: formatDate(entry.expiresAt) },
+                        { label: "Access URL", value: entry.recipientAccess.accessUrl || "Not created" },
+                      ]}
+                    />
+                    {entry.lifecycle === "active" ? (
+                      <button type="button" onClick={() => void handleRevokeInstitutionAccessGrant(entry.grantId)} disabled={institutionAccessBusy}>
+                        Revoke access
+                      </button>
+                    ) : null}
+                  </div>
+                ))
+              ) : (
+                <div style={{ color: textTokens.secondary }}>
+                  Institution access grants will appear here. They stay tenant-controlled, time-bound, and non-public.
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Summary

- Adds a tenant-mediated institution access grant service and authenticated tenant routes for preview, create, list, and revoke flows.
- Reuses the existing tenant trust export and institutional trust export policy-gated package derivation so grants remain consent-scoped, audience/purpose-scoped, metadata-only, and time-bound.
- Adds tenant workspace API/UI for controlled grant preview/history/revocation without public links, public profiles, provider integrations, or institution delivery.
- Adds backend service/route tests and frontend workspace tests for consent, expiration, tenant ownership, revocation, policy gating, and metadata minimization.

## Guardrails

- No public recipient route was introduced.
- No share-package behavior was widened.
- No insurer/lender/government/provider integration was added.
- No public profile, reputation score, automated decisioning, blockchain, or verifiable credential behavior was added.
- Raw IDs/documents/provider payloads/support metadata remain excluded from recipient/access summaries.

## Verification

- `source $HOME/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:single -- tenantPortal/__tests__/tenantInstitutionAccessService.test.ts tenantPortal/__tests__/tenantTrustExportService.test.ts` in `rentchain-api`
- `source $HOME/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:single -- routes/__tests__/tenantPortalRoutes.test.ts` in `rentchain-api`
- `source $HOME/.nvm/nvm.sh && nvm use 20.20.2 && npm run test:single -- src/pages/tenant/TenantWorkspacePage.test.tsx` in `rentchain-frontend`
- `source $HOME/.nvm/nvm.sh && nvm use 20.20.2 && npm run build` in `rentchain-api`
- `source $HOME/.nvm/nvm.sh && nvm use 20.20.2 && npm run build` in `rentchain-frontend`
- `source $HOME/.nvm/nvm.sh && nvm use 20.20.2 && npm run test` in `rentchain-api` (rerun with elevated sandbox permissions because the default sandbox blocked supertest local port binding with `listen EPERM`)
- `source $HOME/.nvm/nvm.sh && nvm use 20.20.2 && npm run test` in `rentchain-frontend`
- `git diff --check`