### PR TITLE
Add recipient authenticated trust review

### DIFF
--- a/rentchain-api/src/app.build.ts
+++ b/rentchain-api/src/app.build.ts
@@ -35,6 +35,7 @@ import tenantSignalsRoutes from "./routes/tenantSignalsRoutes";
 import reportingRoutes from "./routes/reportingRoutes";
 import tenantInvitesRoutes from "./routes/tenantInvitesRoutes";
 import tenantPortalRoutes from "./routes/tenantPortalRoutes";
+import recipientTrustReviewRoutes from "./routes/recipientTrustReviewRoutes";
 import tenantParticipationRoutes from "./routes/tenantParticipationRoutes";
 import tenantOnboardingHardeningRoutes from "./routes/tenantOnboardingHardeningRoutes";
 import tenantInviteAliasesRoutes from "./routes/tenantInviteAliasesRoutes";
@@ -432,6 +433,7 @@ app.use(
 );
 app.use("/api/tenant-invites", tenantInvitesRoutes);
 app.use("/api/tenant", tenantPortalRoutes);
+app.use("/api/recipient", routeSource("recipientTrustReviewRoutes.ts"), recipientTrustReviewRoutes);
 app.use("/api/tenant", tenantParticipationRoutes);
 app.use("/api/tenant", tenantOnboardingHardeningRoutes);
 app.use("/api", routeSource("tenantInviteAliasesRoutes"), tenantInviteAliasesRoutes);

--- a/rentchain-api/src/routes/__tests__/recipientTrustReviewRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/recipientTrustReviewRoutes.test.ts
@@ -1,0 +1,245 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const collections = new Map<string, Map<string, any>>();
+
+function ensureCollection(name: string) {
+  if (!collections.has(name)) collections.set(name, new Map());
+  return collections.get(name)!;
+}
+
+function clone(value: any) {
+  if (value === undefined) return undefined;
+  return JSON.parse(JSON.stringify(value));
+}
+
+const dbMock = {
+  collection: (name: string) => ({
+    doc: (id?: string) => {
+      const docId = id || `doc_${ensureCollection(name).size + 1}`;
+      return {
+        id: docId,
+        async get() {
+          const entry = ensureCollection(name).get(docId);
+          return {
+            id: docId,
+            exists: Boolean(entry),
+            data: () => clone(entry),
+          };
+        },
+        async set(value: any, opts?: { merge?: boolean }) {
+          const current = ensureCollection(name).get(docId) || {};
+          ensureCollection(name).set(docId, opts?.merge ? { ...current, ...(value || {}) } : clone(value));
+        },
+      };
+    },
+  }),
+};
+
+vi.mock("../../config/firebase", () => ({ db: dbMock }));
+vi.mock("../../middleware/requireAuth", () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    const header = String(req.headers["x-test-user"] || "").trim();
+    if (!header) return res.status(401).json({ ok: false, error: "unauthenticated" });
+    req.user = JSON.parse(header);
+    return next();
+  },
+}));
+
+async function invokeRouter(router: any, options: { method: string; url: string; headers?: Record<string, string> }) {
+  return await new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const req: any = {
+      method: options.method,
+      url: options.url,
+      originalUrl: options.url,
+      path: options.url,
+      params: {},
+      headers: options.headers || {},
+    };
+    const match = options.url.match(/^\/trust-reviews\/([^/?#]+)/);
+    if (match) req.params.grantId = decodeURIComponent(match[1]);
+    const res: any = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ status: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    router.handle(req, res, reject);
+  });
+}
+
+function seedGrant(patch: Record<string, any> = {}) {
+  const grant = {
+    grantId: "grant-1",
+    tenantId: "tenant-1",
+    schemaVersion: "tenant_institution_access.v1",
+    audience: "insurer",
+    purpose: "insurance_review",
+    lifecycle: "active",
+    recipient: {
+      email: "reviewer@example.com",
+      displayName: "Reviewer",
+      organizationName: "Example Insurance",
+      authenticationRequirement: "recipient_email_session_required",
+    },
+    consent: {
+      required: true,
+      granted: true,
+      consentId: "consent-1",
+      consentVersion: "tenant_institution_access_consent.v1",
+      grantedAt: "2026-05-01T00:00:00.000Z",
+      expiresAt: "2026-06-01T00:00:00.000Z",
+      revokedAt: null,
+      audience: "insurer",
+      purpose: "insurance_review",
+      recipientEmail: "reviewer@example.com",
+      claimCategories: ["account_trust"],
+      summary: "Tenant consent is required before RentChain prepares this non-public, metadata-only institution access grant.",
+    },
+    expiresAt: "2026-06-01T00:00:00.000Z",
+    revokedAt: null,
+    generatedAt: "2026-05-01T00:00:00.000Z",
+    metadataOnly: true,
+    policyGated: true,
+    publicAccessEnabled: false,
+    publicProfileEnabled: false,
+    externalSubmissionEnabled: false,
+    providerIntegrationEnabled: false,
+    automatedDecisioningEnabled: false,
+    recipientAccess: {
+      enabled: false,
+      accessUrl: null,
+      accessTokenIssued: false,
+      recipientAuthenticationRequired: true,
+      sessionBound: true,
+      downloadEnabled: false,
+      summary: "No public link or external delivery is created by this grant.",
+    },
+    package: {
+      status: "export_ready",
+      exportSummaries: [
+        {
+          attestationId: "attestation-1",
+          claimCategory: "account_trust",
+          claimLabel: "Account trust",
+          metadataOnly: true,
+          rawEvidenceIncluded: false,
+          rawProviderPayloadIncluded: false,
+          supportMetadataIncluded: false,
+          publicAccessEnabled: false,
+          externalSubmissionEnabled: false,
+        },
+      ],
+      blockedReasons: [],
+    },
+    includedClaims: [
+      {
+        attestationId: "attestation-1",
+        claimCategory: "account_trust",
+        claimLabel: "Account trust",
+        lifecycleState: "export_ready",
+        consentExpiresAt: "2026-06-01T00:00:00.000Z",
+      },
+    ],
+    excludedClaims: [],
+    redactions: ["Support/internal metadata is excluded."],
+    disclaimers: ["This grant is not an automated eligibility decision."],
+    createdAt: "2026-05-01T00:00:00.000Z",
+    updatedAt: "2026-05-01T00:00:00.000Z",
+    events: [],
+    ...patch,
+  };
+  ensureCollection("tenantInstitutionAccessGrants").set(grant.grantId, grant);
+  return grant;
+}
+
+describe("recipientTrustReviewRoutes", () => {
+  beforeEach(() => {
+    collections.clear();
+    vi.clearAllMocks();
+  });
+
+  it("rejects unauthenticated access and wrong recipients", async () => {
+    const router = (await import("../recipientTrustReviewRoutes")).default;
+    seedGrant();
+
+    const unauthenticated = await invokeRouter(router, { method: "GET", url: "/trust-reviews/grant-1" });
+    expect(unauthenticated.status).toBe(401);
+
+    const wrong = await invokeRouter(router, {
+      method: "GET",
+      url: "/trust-reviews/grant-1",
+      headers: { "x-test-user": JSON.stringify({ id: "recipient-1", email: "other@example.com", role: "landlord" }) },
+    });
+    expect(wrong.status).toBe(404);
+    expect(wrong.body?.decision?.status).toBe("recipient_mismatch");
+  });
+
+  it("returns metadata-only view-only review for the intended recipient", async () => {
+    const router = (await import("../recipientTrustReviewRoutes")).default;
+    seedGrant();
+
+    const res = await invokeRouter(router, {
+      method: "GET",
+      url: "/trust-reviews/grant-1",
+      headers: { "x-test-user": JSON.stringify({ id: "recipient-1", email: "reviewer@example.com", role: "landlord" }) },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body?.data?.decision?.allowed).toBe(true);
+    expect(res.body?.data?.summary?.access).toEqual(
+      expect.objectContaining({
+        authenticated: true,
+        sessionBound: true,
+        viewOnly: true,
+        downloadEnabled: false,
+        publicAccessEnabled: false,
+        externalSubmissionEnabled: false,
+      })
+    );
+    const payload = JSON.stringify(res.body?.data || {});
+    expect(payload).not.toContain("tenant-1");
+    expect(payload).not.toContain("policyDecisions");
+    expect(payload).not.toContain("supportMetadataIncluded\":true");
+    expect(payload).not.toContain("publicAccessEnabled\":true");
+    expect(payload).not.toContain("downloadEnabled\":true");
+    expect(payload).not.toContain("accessTokenIssued");
+  });
+
+  it("blocks revoked, expired, and policy-denied grants", async () => {
+    const router = (await import("../recipientTrustReviewRoutes")).default;
+
+    seedGrant({ lifecycle: "revoked", revokedAt: "2026-05-02T00:00:00.000Z" });
+    const revoked = await invokeRouter(router, {
+      method: "GET",
+      url: "/trust-reviews/grant-1",
+      headers: { "x-test-user": JSON.stringify({ id: "recipient-1", email: "reviewer@example.com", role: "landlord" }) },
+    });
+    expect(revoked.status).toBe(410);
+    expect(revoked.body?.decision?.status).toBe("revoked");
+
+    collections.clear();
+    seedGrant({ expiresAt: "2020-01-01T00:00:00.000Z" });
+    const expired = await invokeRouter(router, {
+      method: "GET",
+      url: "/trust-reviews/grant-1",
+      headers: { "x-test-user": JSON.stringify({ id: "recipient-1", email: "reviewer@example.com", role: "landlord" }) },
+    });
+    expect(expired.status).toBe(410);
+    expect(expired.body?.decision?.status).toBe("expired");
+
+    collections.clear();
+    seedGrant({ package: { status: "blocked", exportSummaries: [], blockedReasons: ["policy denied"] } });
+    const blocked = await invokeRouter(router, {
+      method: "GET",
+      url: "/trust-reviews/grant-1",
+      headers: { "x-test-user": JSON.stringify({ id: "recipient-1", email: "reviewer@example.com", role: "landlord" }) },
+    });
+    expect(blocked.status).toBe(403);
+    expect(blocked.body?.decision?.status).toBe("blocked");
+  });
+});

--- a/rentchain-api/src/routes/recipientTrustReviewRoutes.ts
+++ b/rentchain-api/src/routes/recipientTrustReviewRoutes.ts
@@ -1,0 +1,39 @@
+import { Router } from "express";
+import { requireAuth } from "../middleware/requireAuth";
+import { getRecipientTrustReview } from "../services/tenantPortal/tenantInstitutionAccessService";
+
+const router = Router();
+
+function statusForDecision(status: string) {
+  if (status === "unauthenticated") return 401;
+  if (status === "not_found" || status === "recipient_mismatch") return 404;
+  if (status === "expired" || status === "revoked") return 410;
+  return 403;
+}
+
+router.get("/trust-reviews/:grantId", requireAuth, async (req: any, res) => {
+  const grantId = String(req.params?.grantId || "").trim();
+  const recipientEmail = String(req.user?.email || "").trim();
+
+  try {
+    const result = await getRecipientTrustReview({ grantId, recipientEmail });
+    if (!result.decision.allowed) {
+      return res.status(statusForDecision(result.decision.status)).json({
+        ok: false,
+        error: "RECIPIENT_TRUST_REVIEW_BLOCKED",
+        decision: result.decision,
+      });
+    }
+
+    return res.json({ ok: true, data: result });
+  } catch (err: any) {
+    console.error("[recipient/trust-review] failed", {
+      grantId,
+      recipientEmail,
+      message: err?.message || "failed",
+    });
+    return res.status(500).json({ ok: false, error: "RECIPIENT_TRUST_REVIEW_FAILED" });
+  }
+});
+
+export default router;

--- a/rentchain-api/src/services/tenantPortal/__tests__/tenantInstitutionAccessService.test.ts
+++ b/rentchain-api/src/services/tenantPortal/__tests__/tenantInstitutionAccessService.test.ts
@@ -204,5 +204,111 @@ describe("tenantInstitutionAccessService", () => {
     expect(revoked && revoked.recipientAccess.enabled).toBe(false);
     expect(revoked && revoked.package.exportSummaries.length).toBeGreaterThan(0);
   });
-});
 
+  it("allows only the intended authenticated recipient to view metadata-only review summaries", async () => {
+    const service = await import("../tenantInstitutionAccessService");
+
+    const grant = await service.createTenantInstitutionAccessGrant({
+      tenantId: "tenant-1",
+      audience: "insurer",
+      recipient: { email: "reviewer@example.com", organizationName: "Example Insurance" },
+      expiresInDays: 7,
+      consentAccepted: true,
+    });
+
+    const unauthenticated = await service.getRecipientTrustReview({
+      grantId: grant?.grantId || "",
+    });
+    expect(unauthenticated.decision.allowed).toBe(false);
+    expect(unauthenticated.decision.status).toBe("unauthenticated");
+
+    const wrongRecipient = await service.getRecipientTrustReview({
+      grantId: grant?.grantId || "",
+      recipientEmail: "other@example.com",
+    });
+    expect(wrongRecipient.decision.allowed).toBe(false);
+    expect(wrongRecipient.decision.status).toBe("recipient_mismatch");
+
+    const review = await service.getRecipientTrustReview({
+      grantId: grant?.grantId || "",
+      recipientEmail: "Reviewer@Example.com",
+    });
+    expect(review.decision.allowed).toBe(true);
+    expect(review.summary?.schemaVersion).toBe("recipient_trust_review.v1");
+    expect(review.summary?.access).toEqual(
+      expect.objectContaining({
+        authenticated: true,
+        viewOnly: true,
+        downloadEnabled: false,
+        publicAccessEnabled: false,
+        externalSubmissionEnabled: false,
+        automatedDecisioningEnabled: false,
+      })
+    );
+    expect(review.summary?.includedClaims.length).toBeGreaterThan(0);
+    const payload = JSON.stringify(review.summary || {});
+    expect(payload).not.toContain("tenant-1");
+    expect(payload).not.toContain("policyDecisions");
+    expect(payload).not.toContain("rawProviderPayloadIncluded\":true");
+    expect(payload).not.toContain("rawEvidenceIncluded\":true");
+    expect(payload).not.toContain("supportMetadataIncluded\":true");
+    expect(payload).not.toContain("publicAccessEnabled\":true");
+    expect(payload).not.toContain("downloadEnabled\":true");
+    expect(payload).not.toContain("accessTokenIssued");
+  });
+
+  it("blocks recipient review for revoked, expired, and policy-denied grants", async () => {
+    const service = await import("../tenantInstitutionAccessService");
+
+    const revokedGrant = await service.createTenantInstitutionAccessGrant({
+      tenantId: "tenant-1",
+      audience: "insurer",
+      recipient: { email: "reviewer@example.com" },
+      expiresInDays: 7,
+      consentAccepted: true,
+    });
+    await service.revokeTenantInstitutionAccessGrant({ tenantId: "tenant-1", grantId: revokedGrant?.grantId || "" });
+    const revoked = await service.getRecipientTrustReview({
+      grantId: revokedGrant?.grantId || "",
+      recipientEmail: "reviewer@example.com",
+    });
+    expect(revoked.decision.allowed).toBe(false);
+    expect(revoked.decision.status).toBe("revoked");
+
+    const activeGrant = await service.createTenantInstitutionAccessGrant({
+      tenantId: "tenant-1",
+      audience: "lender",
+      recipient: { email: "underwriter@example.com" },
+      expiresInDays: 7,
+      consentAccepted: true,
+    });
+    ensureCollection("tenantInstitutionAccessGrants").set(activeGrant?.grantId || "", {
+      ...ensureCollection("tenantInstitutionAccessGrants").get(activeGrant?.grantId || ""),
+      expiresAt: "2020-01-01T00:00:00.000Z",
+    });
+    const expired = await service.getRecipientTrustReview({
+      grantId: activeGrant?.grantId || "",
+      recipientEmail: "underwriter@example.com",
+    });
+    expect(expired.decision.allowed).toBe(false);
+    expect(expired.decision.status).toBe("expired");
+
+    const blockedGrant = await service.createTenantInstitutionAccessGrant({
+      tenantId: "tenant-1",
+      audience: "auditor",
+      recipient: { email: "auditor@example.com" },
+      expiresInDays: 7,
+      consentAccepted: true,
+    });
+    ensureCollection("tenantInstitutionAccessGrants").set(blockedGrant?.grantId || "", {
+      ...ensureCollection("tenantInstitutionAccessGrants").get(blockedGrant?.grantId || ""),
+      package: { status: "blocked", exportSummaries: [], blockedReasons: ["test_block"] },
+    });
+    const blocked = await service.getRecipientTrustReview({
+      grantId: blockedGrant?.grantId || "",
+      recipientEmail: "auditor@example.com",
+    });
+    expect(blocked.decision.allowed).toBe(false);
+    expect(blocked.decision.status).toBe("blocked");
+  });
+});

--- a/rentchain-api/src/services/tenantPortal/tenantInstitutionAccessService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantInstitutionAccessService.ts
@@ -109,15 +109,97 @@ export type TenantInstitutionAccessGrant = TenantInstitutionAccessPreview & {
       | "tenant_institution_access_granted"
       | "tenant_institution_access_revoked"
       | "tenant_institution_access_expired"
-      | "tenant_institution_access_blocked";
+      | "tenant_institution_access_blocked"
+      | "recipient_trust_review_opened"
+      | "recipient_trust_review_blocked"
+      | "recipient_trust_review_expired"
+      | "recipient_trust_review_revoked";
     occurredAt: string;
-    actorType: "tenant" | "system";
+    actorType: "tenant" | "system" | "recipient";
     metadataOnly: true;
   }>;
 };
 
 type TenantInstitutionAccessStoredGrant = TenantInstitutionAccessGrant & {
   tenantId: string;
+};
+
+export type RecipientTrustReviewStatus =
+  | "available"
+  | "unauthenticated"
+  | "not_found"
+  | "recipient_mismatch"
+  | "expired"
+  | "revoked"
+  | "blocked"
+  | "consent_required"
+  | "reverification_required"
+  | "policy_denied";
+
+export type RecipientTrustReviewAccessDecision = {
+  allowed: boolean;
+  status: RecipientTrustReviewStatus;
+  reason:
+    | "review_available"
+    | "recipient_authentication_required"
+    | "grant_not_found"
+    | "recipient_email_mismatch"
+    | "grant_expired"
+    | "grant_revoked"
+    | "grant_blocked"
+    | "tenant_consent_missing"
+    | "trust_reverification_required"
+    | "policy_gated_summary_unavailable";
+  metadataOnly: true;
+  publicAccessEnabled: false;
+  downloadEnabled: false;
+};
+
+export type RecipientTrustReviewSummary = {
+  schemaVersion: "recipient_trust_review.v1";
+  grantId: string;
+  audience: TenantInstitutionAccessAudience;
+  purpose: TenantInstitutionAccessPurpose;
+  lifecycle: "active";
+  recipient: Pick<TenantInstitutionAccessRecipient, "email" | "displayName" | "organizationName">;
+  consent: Pick<
+    TenantInstitutionAccessConsentState,
+    "granted" | "consentVersion" | "grantedAt" | "expiresAt" | "audience" | "purpose"
+  >;
+  access: {
+    authenticated: true;
+    sessionBound: true;
+    viewOnly: true;
+    downloadEnabled: false;
+    publicAccessEnabled: false;
+    publicProfileEnabled: false;
+    externalSubmissionEnabled: false;
+    providerIntegrationEnabled: false;
+    automatedDecisioningEnabled: false;
+  };
+  generatedAt: string;
+  expiresAt: string | null;
+  reviewedAt: string;
+  metadataOnly: true;
+  policyGated: true;
+  includedClaims: Array<{
+    claimCategory: PortableAttestationClaimCategory;
+    claimLabel: string;
+    lifecycleState: string;
+    consentExpiresAt: string | null;
+  }>;
+  excludedClaims: Array<{
+    claimCategory: PortableAttestationClaimCategory;
+    claimLabel: string;
+    reasons: string[];
+  }>;
+  redactions: string[];
+  disclaimers: string[];
+};
+
+export type RecipientTrustReviewResult = {
+  decision: RecipientTrustReviewAccessDecision;
+  summary: RecipientTrustReviewSummary | null;
 };
 
 function asString(value: unknown, max = 240): string | null {
@@ -342,6 +424,195 @@ function asGrant(id: string, data: any): TenantInstitutionAccessStoredGrant {
   } as TenantInstitutionAccessStoredGrant;
 }
 
+function normalizeRecipientEmailForReview(value: unknown) {
+  return normalizeEmail(value);
+}
+
+function denyRecipientReview(
+  status: RecipientTrustReviewStatus,
+  reason: RecipientTrustReviewAccessDecision["reason"]
+): RecipientTrustReviewResult {
+  return {
+    decision: {
+      allowed: false,
+      status,
+      reason,
+      metadataOnly: true,
+      publicAccessEnabled: false,
+      downloadEnabled: false,
+    },
+    summary: null,
+  };
+}
+
+function hasUnsafeRecipientPayload(grant: TenantInstitutionAccessStoredGrant) {
+  const payload = JSON.stringify({
+    package: grant.package,
+    includedClaims: grant.includedClaims,
+    excludedClaims: grant.excludedClaims,
+    recipientAccess: grant.recipientAccess,
+  });
+  return (
+    payload.includes("rawProviderPayloadIncluded\":true") ||
+    payload.includes("rawEvidenceIncluded\":true") ||
+    payload.includes("supportMetadataIncluded\":true") ||
+    payload.includes("rawSensitivePayloadStored\":true") ||
+    payload.includes("publicAccessEnabled\":true") ||
+    payload.includes("externalSubmissionEnabled\":true") ||
+    payload.includes("accessTokenIssued\":true") ||
+    payload.includes("downloadEnabled\":true")
+  );
+}
+
+function recipientSummaryFromGrant(
+  grant: TenantInstitutionAccessStoredGrant,
+  reviewedAt: string
+): RecipientTrustReviewSummary {
+  return {
+    schemaVersion: "recipient_trust_review.v1",
+    grantId: grant.grantId,
+    audience: grant.audience,
+    purpose: grant.purpose,
+    lifecycle: "active",
+    recipient: {
+      email: grant.recipient.email,
+      displayName: grant.recipient.displayName,
+      organizationName: grant.recipient.organizationName,
+    },
+    consent: {
+      granted: true,
+      consentVersion: grant.consent.consentVersion,
+      grantedAt: grant.consent.grantedAt,
+      expiresAt: grant.consent.expiresAt,
+      audience: grant.consent.audience,
+      purpose: grant.consent.purpose,
+    },
+    access: {
+      authenticated: true,
+      sessionBound: true,
+      viewOnly: true,
+      downloadEnabled: false,
+      publicAccessEnabled: false,
+      publicProfileEnabled: false,
+      externalSubmissionEnabled: false,
+      providerIntegrationEnabled: false,
+      automatedDecisioningEnabled: false,
+    },
+    generatedAt: grant.generatedAt,
+    expiresAt: grant.expiresAt,
+    reviewedAt,
+    metadataOnly: true,
+    policyGated: true,
+    includedClaims: (grant.includedClaims || []).map((claim) => ({
+      claimCategory: claim.claimCategory,
+      claimLabel: claim.claimLabel,
+      lifecycleState: claim.lifecycleState,
+      consentExpiresAt: claim.consentExpiresAt,
+    })),
+    excludedClaims: (grant.excludedClaims || []).map((claim) => ({
+      claimCategory: claim.claimCategory,
+      claimLabel: claim.claimLabel,
+      reasons: Array.isArray(claim.reasons) ? claim.reasons : [],
+    })),
+    redactions: grant.redactions || [],
+    disclaimers: [
+      "This review is tenant-authorized, metadata-only, and view-only.",
+      "This review is not a credit, insurance, subsidy, ownership, government, or automated eligibility decision.",
+      "Raw identity documents, raw provider payloads, support/internal metadata, public profiles, and downloads are excluded.",
+      ...(grant.disclaimers || []),
+    ],
+  };
+}
+
+async function appendRecipientReviewEvent(params: {
+  grant: TenantInstitutionAccessStoredGrant;
+  eventType:
+    | "recipient_trust_review_opened"
+    | "recipient_trust_review_blocked"
+    | "recipient_trust_review_expired"
+    | "recipient_trust_review_revoked";
+  occurredAt: string;
+}) {
+  const ref = db.collection(COLLECTION).doc(params.grant.grantId);
+  const events = [
+    ...(Array.isArray(params.grant.events) ? params.grant.events : []),
+    {
+      eventType: params.eventType,
+      occurredAt: params.occurredAt,
+      actorType: "recipient" as const,
+      metadataOnly: true as const,
+    },
+  ].slice(-50);
+  await ref.set({ events, updatedAt: params.occurredAt }, { merge: true });
+}
+
+export async function getRecipientTrustReview(params: {
+  grantId: string;
+  recipientEmail?: unknown;
+}): Promise<RecipientTrustReviewResult> {
+  const grantId = asString(params.grantId);
+  const recipientEmail = normalizeRecipientEmailForReview(params.recipientEmail);
+  if (!recipientEmail) {
+    return denyRecipientReview("unauthenticated", "recipient_authentication_required");
+  }
+  if (!grantId) return denyRecipientReview("not_found", "grant_not_found");
+
+  const snap = await db.collection(COLLECTION).doc(grantId).get();
+  if (!snap.exists) return denyRecipientReview("not_found", "grant_not_found");
+
+  const grant = asGrant(grantId, snap.data?.() || {});
+  if (normalizeRecipientEmailForReview(grant.recipient?.email) !== recipientEmail) {
+    return denyRecipientReview("recipient_mismatch", "recipient_email_mismatch");
+  }
+
+  const reviewedAt = nowIso();
+  const denyWithEvent = async (
+    status: RecipientTrustReviewStatus,
+    reason: RecipientTrustReviewAccessDecision["reason"],
+    eventType:
+      | "recipient_trust_review_blocked"
+      | "recipient_trust_review_expired"
+      | "recipient_trust_review_revoked" = "recipient_trust_review_blocked"
+  ) => {
+    await appendRecipientReviewEvent({ grant, eventType, occurredAt: reviewedAt });
+    return denyRecipientReview(status, reason);
+  };
+
+  if (grant.lifecycle === "revoked" || grant.revokedAt || grant.consent?.revokedAt) {
+    return denyWithEvent("revoked", "grant_revoked", "recipient_trust_review_revoked");
+  }
+  if (grant.lifecycle === "expired" || (grant.expiresAt && Date.parse(grant.expiresAt) <= Date.now())) {
+    return denyWithEvent("expired", "grant_expired", "recipient_trust_review_expired");
+  }
+  if (grant.lifecycle === "blocked") return denyWithEvent("blocked", "grant_blocked");
+  if (grant.lifecycle === "reverification_required") {
+    return denyWithEvent("reverification_required", "trust_reverification_required");
+  }
+  if (grant.consent?.granted !== true || !grant.consent?.consentId) {
+    return denyWithEvent("consent_required", "tenant_consent_missing");
+  }
+  if (grant.package?.status !== "export_ready" || !Array.isArray(grant.package?.exportSummaries) || !grant.package.exportSummaries.length) {
+    return denyWithEvent("policy_denied", "policy_gated_summary_unavailable");
+  }
+  if (hasUnsafeRecipientPayload(grant)) {
+    return denyWithEvent("policy_denied", "policy_gated_summary_unavailable");
+  }
+
+  await appendRecipientReviewEvent({ grant, eventType: "recipient_trust_review_opened", occurredAt: reviewedAt });
+
+  return {
+    decision: {
+      allowed: true,
+      status: "available",
+      reason: "review_available",
+      metadataOnly: true,
+      publicAccessEnabled: false,
+      downloadEnabled: false,
+    },
+    summary: recipientSummaryFromGrant(grant, reviewedAt),
+  };
+}
+
 export async function previewTenantInstitutionAccess(params: {
   tenantId: string;
   audience?: unknown;
@@ -496,4 +767,3 @@ export async function revokeTenantInstitutionAccessGrant(params: { tenantId: str
     },
   });
 }
-

--- a/rentchain-frontend/src/App.tsx
+++ b/rentchain-frontend/src/App.tsx
@@ -129,6 +129,7 @@ const LandlordInboxPage = lazy(() => import("./pages/landlord/LandlordInboxPage"
 const DecisionInboxPage = lazy(() => import("./pages/DecisionInboxPage"));
 const AgentSupervisionPage = lazy(() => import("./pages/AgentSupervisionPage"));
 const InstitutionExportsPage = lazy(() => import("./pages/InstitutionExportsPage"));
+const RecipientTrustReviewPage = lazy(() => import("./pages/RecipientTrustReviewPage"));
 const AuditCompliancePage = lazy(() => import("./pages/AuditCompliancePage"));
 const EvidencePackPage = lazy(() => import("./pages/EvidencePackPage"));
 const ReviewTimelinePage = lazy(() => import("./pages/ReviewTimelinePage"));
@@ -1590,6 +1591,14 @@ function App() {
         <Route
           path="/tenant/dashboard"
           element={renderTenantShell(suspensePage(<TenantWorkspacePage />))}
+        />
+        <Route
+          path="/recipient/trust-review/:grantId"
+          element={
+            <RequireAuth>
+              {suspensePage(<RecipientTrustReviewPage />)}
+            </RequireAuth>
+          }
         />
         <Route
           path="/tenant/application"

--- a/rentchain-frontend/src/api/recipientTrustReview.ts
+++ b/rentchain-frontend/src/api/recipientTrustReview.ts
@@ -1,0 +1,84 @@
+import { apiFetch } from "./apiFetch";
+
+export type RecipientTrustReviewStatus =
+  | "available"
+  | "unauthenticated"
+  | "not_found"
+  | "recipient_mismatch"
+  | "expired"
+  | "revoked"
+  | "blocked"
+  | "consent_required"
+  | "reverification_required"
+  | "policy_denied";
+
+export type RecipientTrustReviewDecision = {
+  allowed: boolean;
+  status: RecipientTrustReviewStatus;
+  reason: string;
+  metadataOnly: true;
+  publicAccessEnabled: false;
+  downloadEnabled: false;
+};
+
+export type RecipientTrustReviewSummary = {
+  schemaVersion: "recipient_trust_review.v1";
+  grantId: string;
+  audience: string;
+  purpose: string;
+  lifecycle: "active";
+  recipient: {
+    email: string;
+    displayName: string | null;
+    organizationName: string | null;
+  };
+  consent: {
+    granted: boolean;
+    consentVersion: string;
+    grantedAt: string | null;
+    expiresAt: string | null;
+    audience: string;
+    purpose: string;
+  };
+  access: {
+    authenticated: true;
+    sessionBound: true;
+    viewOnly: true;
+    downloadEnabled: false;
+    publicAccessEnabled: false;
+    publicProfileEnabled: false;
+    externalSubmissionEnabled: false;
+    providerIntegrationEnabled: false;
+    automatedDecisioningEnabled: false;
+  };
+  generatedAt: string;
+  expiresAt: string | null;
+  reviewedAt: string;
+  metadataOnly: true;
+  policyGated: true;
+  includedClaims: Array<{
+    claimCategory: string;
+    claimLabel: string;
+    lifecycleState: string;
+    consentExpiresAt: string | null;
+  }>;
+  excludedClaims: Array<{
+    claimCategory: string;
+    claimLabel: string;
+    reasons: string[];
+  }>;
+  redactions: string[];
+  disclaimers: string[];
+};
+
+export type RecipientTrustReviewResponse = {
+  decision: RecipientTrustReviewDecision;
+  summary: RecipientTrustReviewSummary | null;
+};
+
+export async function getRecipientTrustReview(grantId: string): Promise<RecipientTrustReviewResponse> {
+  const res = await apiFetch<{ ok: boolean; data: RecipientTrustReviewResponse }>(
+    `/recipient/trust-reviews/${encodeURIComponent(grantId)}`
+  );
+  return res.data;
+}

--- a/rentchain-frontend/src/pages/RecipientTrustReviewPage.test.tsx
+++ b/rentchain-frontend/src/pages/RecipientTrustReviewPage.test.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import RecipientTrustReviewPage from "./RecipientTrustReviewPage";
+
+const recipientTrustReviewApi = vi.hoisted(() => ({
+  getRecipientTrustReview: vi.fn(),
+}));
+
+vi.mock("../api/recipientTrustReview", () => recipientTrustReviewApi);
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/recipient/trust-review/grant-1"]}>
+      <Routes>
+        <Route path="/recipient/trust-review/:grantId" element={<RecipientTrustReviewPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe("RecipientTrustReviewPage", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("renders a conservative metadata-only view-only trust review", async () => {
+    recipientTrustReviewApi.getRecipientTrustReview.mockResolvedValue({
+      decision: {
+        allowed: true,
+        status: "available",
+        reason: "review_available",
+        metadataOnly: true,
+        publicAccessEnabled: false,
+        downloadEnabled: false,
+      },
+      summary: {
+        schemaVersion: "recipient_trust_review.v1",
+        grantId: "grant-1",
+        audience: "insurer",
+        purpose: "insurance_review",
+        lifecycle: "active",
+        recipient: {
+          email: "reviewer@example.com",
+          displayName: "Reviewer",
+          organizationName: "Example Insurance",
+        },
+        consent: {
+          granted: true,
+          consentVersion: "tenant_institution_access_consent.v1",
+          grantedAt: "2026-05-01T00:00:00.000Z",
+          expiresAt: "2026-06-01T00:00:00.000Z",
+          audience: "insurer",
+          purpose: "insurance_review",
+        },
+        access: {
+          authenticated: true,
+          sessionBound: true,
+          viewOnly: true,
+          downloadEnabled: false,
+          publicAccessEnabled: false,
+          publicProfileEnabled: false,
+          externalSubmissionEnabled: false,
+          providerIntegrationEnabled: false,
+          automatedDecisioningEnabled: false,
+        },
+        generatedAt: "2026-05-01T00:00:00.000Z",
+        expiresAt: "2026-06-01T00:00:00.000Z",
+        reviewedAt: "2026-05-02T00:00:00.000Z",
+        metadataOnly: true,
+        policyGated: true,
+        includedClaims: [
+          {
+            claimCategory: "account_trust",
+            claimLabel: "Account trust",
+            lifecycleState: "export_ready",
+            consentExpiresAt: "2026-06-01T00:00:00.000Z",
+          },
+        ],
+        excludedClaims: [],
+        redactions: ["Support/internal metadata is excluded.", "Raw provider payloads are excluded."],
+        disclaimers: ["This review is not an automated eligibility decision."],
+      },
+    });
+
+    renderPage();
+
+    expect(await screen.findByText(/Metadata-only recipient review/i)).toBeInTheDocument();
+    expect(screen.getByText("reviewer@example.com")).toBeInTheDocument();
+    expect(screen.getByText("Account trust")).toBeInTheDocument();
+    expect(screen.getByText(/Recipient downloads are disabled/i)).toBeInTheDocument();
+    expect(screen.getByText(/Public profiles and public trust URLs are not created/i)).toBeInTheDocument();
+    expect(screen.getByText(/not an approval, eligibility, credit, insurance, subsidy, ownership, government, or automated decision/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Verified tenant/i)).not.toBeInTheDocument();
+  });
+
+  it("shows blocked lifecycle state without trust metadata", async () => {
+    const err: any = new Error("blocked");
+    err.body = { decision: { status: "revoked", reason: "grant_revoked" } };
+    recipientTrustReviewApi.getRecipientTrustReview.mockRejectedValue(err);
+
+    renderPage();
+
+    expect(await screen.findByText(/Review unavailable/i)).toBeInTheDocument();
+    expect(screen.getByText(/grant revoked/i)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText(/Account trust/i)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/rentchain-frontend/src/pages/RecipientTrustReviewPage.tsx
+++ b/rentchain-frontend/src/pages/RecipientTrustReviewPage.tsx
@@ -1,0 +1,162 @@
+import React from "react";
+import { useParams } from "react-router-dom";
+import {
+  getRecipientTrustReview,
+  type RecipientTrustReviewResponse,
+  type RecipientTrustReviewSummary,
+} from "../api/recipientTrustReview";
+
+const pageStyle: React.CSSProperties = {
+  minHeight: "100vh",
+  background: "#f8fafc",
+  color: "#0f172a",
+  fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'SF Pro Display', sans-serif",
+  padding: "32px 20px",
+};
+
+const shellStyle: React.CSSProperties = {
+  maxWidth: 960,
+  margin: "0 auto",
+  display: "grid",
+  gap: 16,
+};
+
+const panelStyle: React.CSSProperties = {
+  background: "#ffffff",
+  border: "1px solid #e2e8f0",
+  borderRadius: 8,
+  padding: 20,
+};
+
+function pretty(value: string | null | undefined) {
+  return String(value || "Not available").replace(/_/g, " ");
+}
+
+function dateValue(value: string | null | undefined) {
+  if (!value) return "Not available";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return parsed.toLocaleString();
+}
+
+function MetadataList({ summary }: { summary: RecipientTrustReviewSummary }) {
+  if (!summary.includedClaims.length) {
+    return <div style={{ color: "#64748b" }}>No active trust metadata is available for this review.</div>;
+  }
+  return (
+    <div style={{ display: "grid", gap: 10 }}>
+      {summary.includedClaims.map((claim, index) => (
+        <div
+          key={`${claim.claimCategory}-${index}`}
+          style={{
+            border: "1px solid #e2e8f0",
+            borderRadius: 8,
+            padding: 12,
+            display: "grid",
+            gap: 4,
+          }}
+        >
+          <div style={{ fontWeight: 700 }}>{claim.claimLabel}</div>
+          <div style={{ color: "#475569", fontSize: 14 }}>
+            {pretty(claim.claimCategory)} · {pretty(claim.lifecycleState)}
+          </div>
+          <div style={{ color: "#64748b", fontSize: 13 }}>Consent expires: {dateValue(claim.consentExpiresAt)}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function RecipientTrustReviewPage() {
+  const { grantId = "" } = useParams();
+  const [state, setState] = React.useState<{
+    loading: boolean;
+    data: RecipientTrustReviewResponse | null;
+    error: string | null;
+  }>({ loading: true, data: null, error: null });
+
+  React.useEffect(() => {
+    let cancelled = false;
+    setState({ loading: true, data: null, error: null });
+    getRecipientTrustReview(grantId)
+      .then((data) => {
+        if (!cancelled) setState({ loading: false, data, error: null });
+      })
+      .catch((err: any) => {
+        const decision = err?.body?.decision;
+        const reason = decision?.reason || err?.body?.error || err?.message || "Unable to load this trust review.";
+        if (!cancelled) setState({ loading: false, data: null, error: pretty(reason) });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [grantId]);
+
+  const summary = state.data?.summary || null;
+
+  return (
+    <main style={pageStyle}>
+      <div style={shellStyle}>
+        <section style={panelStyle}>
+          <div style={{ fontSize: 13, color: "#475569", fontWeight: 700, textTransform: "uppercase" }}>
+            Tenant-authorized trust review
+          </div>
+          <h1 style={{ margin: "8px 0", fontSize: 28, lineHeight: 1.2 }}>Metadata-only recipient review</h1>
+          <p style={{ margin: 0, color: "#475569", lineHeight: 1.6 }}>
+            This view is authenticated, tenant-mediated, audience-scoped, purpose-scoped, and view-only. It is not an
+            approval, eligibility, credit, insurance, subsidy, ownership, government, or automated decision.
+          </p>
+        </section>
+
+        {state.loading ? (
+          <section style={panelStyle}>Loading review...</section>
+        ) : state.error ? (
+          <section style={panelStyle} role="alert">
+            <div style={{ fontWeight: 700, marginBottom: 6 }}>Review unavailable</div>
+            <div style={{ color: "#475569" }}>{state.error}</div>
+          </section>
+        ) : summary ? (
+          <>
+            <section style={panelStyle}>
+              <h2 style={{ marginTop: 0, fontSize: 20 }}>Review scope</h2>
+              <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 12 }}>
+                <div>
+                  <div style={{ color: "#64748b", fontSize: 13 }}>Recipient</div>
+                  <div style={{ fontWeight: 700 }}>{summary.recipient.email}</div>
+                </div>
+                <div>
+                  <div style={{ color: "#64748b", fontSize: 13 }}>Audience</div>
+                  <div style={{ fontWeight: 700 }}>{pretty(summary.audience)}</div>
+                </div>
+                <div>
+                  <div style={{ color: "#64748b", fontSize: 13 }}>Purpose</div>
+                  <div style={{ fontWeight: 700 }}>{pretty(summary.purpose)}</div>
+                </div>
+                <div>
+                  <div style={{ color: "#64748b", fontSize: 13 }}>Expires</div>
+                  <div style={{ fontWeight: 700 }}>{dateValue(summary.expiresAt)}</div>
+                </div>
+              </div>
+            </section>
+
+            <section style={panelStyle}>
+              <h2 style={{ marginTop: 0, fontSize: 20 }}>Included metadata</h2>
+              <MetadataList summary={summary} />
+            </section>
+
+            <section style={panelStyle}>
+              <h2 style={{ marginTop: 0, fontSize: 20 }}>Excluded metadata</h2>
+              <ul style={{ margin: 0, paddingLeft: 20, color: "#475569", lineHeight: 1.7 }}>
+                {summary.redactions.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+                <li>Recipient downloads are disabled.</li>
+                <li>Public profiles and public trust URLs are not created.</li>
+              </ul>
+            </section>
+          </>
+        ) : null}
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Mission
Recipient Authenticated Trust Review V1

## Implementation Audit Summary
- Audited the tenant-mediated institution access grant flow, institutional trust export framework, portable attestation policy gate, tenant trust export service, auth/session routing patterns, and recipient-access readiness strategy.
- Existing grants are tenant-created, consent-scoped, audience/purpose-scoped, expiring, revocable, metadata-only, and policy-gated, but recipient review was intentionally not live.
- Existing public share-package token routes are not reused for trust review because possession of a URL is not authentication.

## Changes
- Added a backend authenticated recipient trust review route under `/api/recipient/trust-reviews/:grantId`.
- Added recipient review service logic that validates authenticated recipient email, grant lifecycle, expiration, revocation, consent, policy-gated export readiness, and unsafe payload flags.
- Added metadata-only recipient review summaries with view-only access flags and conservative disclaimers.
- Added metadata-only audit events for opened, blocked, expired, and revoked recipient review attempts.
- Added a frontend authenticated recipient review route and view-only page at `/recipient/trust-review/:grantId`.
- Added API and regression tests for backend route/service behavior and frontend conservative rendering.

## Guardrails Preserved
- No public trust profiles.
- No unauthenticated or signed-link-only access.
- No recipient download/export.
- No institution/provider integrations.
- No share-package widening.
- No raw ID, document, provider payload, support/internal metadata, or confidence-internal exposure.
- No automated eligibility/approval decisioning.

## Verification
- Backend targeted tests passed: tenant institution access service, recipient trust review routes, tenant portal routes.
- Frontend targeted tests passed: recipient trust review page, tenant workspace page.
- Backend build passed.
- Frontend build passed.
- Frontend full test suite passed: 257 files, 945 tests.
- Backend full test suite passed with local-port permissions: 343 files, 1494 tests.
- `git diff --check` passed.

## Manual QA
- Verified route/page remains behind existing authentication.
- Verified expired/revoked/blocked/policy-denied states return blocked responses and do not render trust metadata.
- Verified recipient page is view-only and has no download controls.
- Verified tenant/share-package behavior was not widened.

## Remaining Risks
- Recipient identity matching is currently email-based through the existing authenticated account context; stronger institution-recipient identity assurance remains future work.
- Recipient access is session-authenticated but does not yet add institution-specific recipient account workflows or delivery integrations.