### PR TITLE
Recipient Access Audit Dashboard V1

### DIFF
--- a/rentchain-api/src/routes/__tests__/recipientTrustReviewRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/recipientTrustReviewRoutes.test.ts
@@ -208,6 +208,18 @@ describe("recipientTrustReviewRoutes", () => {
     expect(payload).not.toContain("publicAccessEnabled\":true");
     expect(payload).not.toContain("downloadEnabled\":true");
     expect(payload).not.toContain("accessTokenIssued");
+
+    const stored = ensureCollection("tenantInstitutionAccessGrants").get("grant-1");
+    expect(stored.events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          eventType: "recipient_trust_review_opened",
+          metadataOnly: true,
+          status: "available",
+          reason: "review_available",
+        }),
+      ])
+    );
   });
 
   it("blocks revoked, expired, and policy-denied grants", async () => {

--- a/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/tenantPortalRoutes.test.ts
@@ -1529,6 +1529,21 @@ describe("tenantPortalRoutes foundation", () => {
     expect(grant.body?.data?.package?.status).toBe("export_ready");
     expect(grant.body?.data?.recipientAccess?.accessUrl).toBe(null);
     expect(grant.body?.data?.recipientAccess?.accessTokenIssued).toBe(false);
+    expect(grant.body?.data?.auditSummary).toEqual(
+      expect.objectContaining({
+        schemaVersion: "recipient_access_audit.v1",
+        metadataOnly: true,
+        openedReviewCount: 0,
+        blockedReviewCount: 0,
+      })
+    );
+    expect(grant.body?.data?.auditTimeline?.[0]).toEqual(
+      expect.objectContaining({
+        eventType: "tenant_institution_access_granted",
+        reason: "access_granted",
+        metadataOnly: true,
+      })
+    );
     const payload = JSON.stringify(grant.body?.data || {});
     expect(payload).not.toContain("drawnDataUrl");
     expect(payload).not.toContain("documentUrl");
@@ -1537,6 +1552,8 @@ describe("tenantPortalRoutes foundation", () => {
     expect(payload).not.toContain("publicAccessEnabled\":true");
     expect(payload).not.toContain("externalSubmissionEnabled\":true");
     expect(payload).not.toContain("tenant-1");
+    expect(payload).not.toContain("supportMetadataIncluded\":true");
+    expect(payload).not.toContain("rawProviderPayloadIncluded\":true");
     expect(ensureCollection("tenantSharePackages").size).toBe(0);
   });
 

--- a/rentchain-api/src/services/tenantPortal/__tests__/tenantInstitutionAccessService.test.ts
+++ b/rentchain-api/src/services/tenantPortal/__tests__/tenantInstitutionAccessService.test.ts
@@ -188,6 +188,25 @@ describe("tenantInstitutionAccessService", () => {
     const listed = await service.listTenantInstitutionAccessGrants({ tenantId: "tenant-1" });
     expect(listed).toHaveLength(1);
     expect(listed[0].grantId).toBe(grant?.grantId);
+    expect(listed[0].auditSummary).toEqual(
+      expect.objectContaining({
+        schemaVersion: "recipient_access_audit.v1",
+        metadataOnly: true,
+        totalEvents: 1,
+        openedReviewCount: 0,
+        blockedReviewCount: 0,
+      })
+    );
+    expect(listed[0].auditSummary.visibility).toEqual(
+      expect.objectContaining({
+        tenantVisible: true,
+        trustPayloadIncluded: false,
+        supportMetadataIncluded: false,
+        rawProviderPayloadIncluded: false,
+        publicAccessEnabled: false,
+        downloadEnabled: false,
+      })
+    );
 
     const blocked = await service.revokeTenantInstitutionAccessGrant({
       tenantId: "tenant-2",
@@ -246,6 +265,23 @@ describe("tenantInstitutionAccessService", () => {
       })
     );
     expect(review.summary?.includedClaims.length).toBeGreaterThan(0);
+    const listed = await service.listTenantInstitutionAccessGrants({ tenantId: "tenant-1" });
+    expect(listed[0].auditSummary.openedReviewCount).toBe(1);
+    expect(listed[0].auditSummary.blockedReviewCount).toBe(1);
+    expect(listed[0].auditTimeline.map((event) => event.reason)).toEqual(
+      expect.arrayContaining(["review_available", "recipient_email_mismatch", "access_granted"])
+    );
+    expect(listed[0].auditSummary.recipientIdentifier.redactedEmail).toBe("re***@example.com");
+    const auditPayload = JSON.stringify({
+      auditSummary: listed[0].auditSummary,
+      auditTimeline: listed[0].auditTimeline,
+    });
+    expect(auditPayload).not.toContain("tenant-1");
+    expect(auditPayload).not.toContain("policyDecisions");
+    expect(auditPayload).not.toContain("supportMetadataIncluded\":true");
+    expect(auditPayload).not.toContain("rawProviderPayloadIncluded\":true");
+    expect(auditPayload).not.toContain("publicAccessEnabled\":true");
+    expect(auditPayload).not.toContain("downloadEnabled\":true");
     const payload = JSON.stringify(review.summary || {});
     expect(payload).not.toContain("tenant-1");
     expect(payload).not.toContain("policyDecisions");
@@ -310,5 +346,22 @@ describe("tenantInstitutionAccessService", () => {
     });
     expect(blocked.decision.allowed).toBe(false);
     expect(blocked.decision.status).toBe("blocked");
+
+    const grants = await service.listTenantInstitutionAccessGrants({ tenantId: "tenant-1" });
+    const revokedAudit = grants.find((entry) => entry.grantId === revokedGrant?.grantId)?.auditSummary;
+    const expiredAudit = grants.find((entry) => entry.grantId === activeGrant?.grantId)?.auditSummary;
+    const blockedAudit = grants.find((entry) => entry.grantId === blockedGrant?.grantId)?.auditSummary;
+    expect(revokedAudit?.revokedAccessCount).toBeGreaterThan(0);
+    expect(grants.find((entry) => entry.grantId === revokedGrant?.grantId)?.auditTimeline.map((event) => event.reason)).toEqual(
+      expect.arrayContaining(["access_revoked", "grant_revoked"])
+    );
+    expect(expiredAudit?.expiredAccessCount).toBe(1);
+    expect(grants.find((entry) => entry.grantId === activeGrant?.grantId)?.auditTimeline.map((event) => event.reason)).toEqual(
+      expect.arrayContaining(["grant_expired"])
+    );
+    expect(blockedAudit?.blockedReviewCount).toBe(1);
+    expect(grants.find((entry) => entry.grantId === blockedGrant?.grantId)?.auditTimeline.map((event) => event.reason)).toEqual(
+      expect.arrayContaining(["grant_blocked"])
+    );
   });
 });

--- a/rentchain-api/src/services/tenantPortal/tenantInstitutionAccessService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantInstitutionAccessService.ts
@@ -99,29 +99,36 @@ export type TenantInstitutionAccessPreview = {
   disclaimers: string[];
 };
 
-export type TenantInstitutionAccessGrant = TenantInstitutionAccessPreview & {
+export type TenantInstitutionAccessGrantEvent = {
+  eventType:
+    | "tenant_institution_access_granted"
+    | "tenant_institution_access_revoked"
+    | "tenant_institution_access_expired"
+    | "tenant_institution_access_blocked"
+    | "recipient_trust_review_opened"
+    | "recipient_trust_review_blocked"
+    | "recipient_trust_review_expired"
+    | "recipient_trust_review_revoked";
+  occurredAt: string;
+  actorType: "tenant" | "system" | "recipient";
+  metadataOnly: true;
+  outcome?: "granted" | "opened" | "blocked" | "revoked" | "expired";
+  reason?: RecipientTrustReviewAccessDecision["reason"] | "access_granted" | "access_revoked";
+  status?: RecipientTrustReviewStatus | "granted";
+};
+
+type TenantInstitutionAccessStoredGrant = TenantInstitutionAccessPreview & {
   grantId: string;
   lifecycle: "active" | "revoked" | "expired" | "blocked" | "reverification_required";
   createdAt: string;
   updatedAt: string;
-  events: Array<{
-    eventType:
-      | "tenant_institution_access_granted"
-      | "tenant_institution_access_revoked"
-      | "tenant_institution_access_expired"
-      | "tenant_institution_access_blocked"
-      | "recipient_trust_review_opened"
-      | "recipient_trust_review_blocked"
-      | "recipient_trust_review_expired"
-      | "recipient_trust_review_revoked";
-    occurredAt: string;
-    actorType: "tenant" | "system" | "recipient";
-    metadataOnly: true;
-  }>;
+  events: TenantInstitutionAccessGrantEvent[];
+  tenantId: string;
 };
 
-type TenantInstitutionAccessStoredGrant = TenantInstitutionAccessGrant & {
-  tenantId: string;
+export type TenantInstitutionAccessGrant = Omit<TenantInstitutionAccessStoredGrant, "tenantId"> & {
+  auditSummary: TenantInstitutionAccessAuditSummary;
+  auditTimeline: TenantInstitutionAccessAuditEvent[];
 };
 
 export type RecipientTrustReviewStatus =
@@ -202,6 +209,58 @@ export type RecipientTrustReviewResult = {
   summary: RecipientTrustReviewSummary | null;
 };
 
+export type TenantInstitutionAccessAuditOutcome = "granted" | "opened" | "blocked" | "revoked" | "expired";
+
+export type TenantInstitutionAccessAuditEvent = {
+  eventType: TenantInstitutionAccessGrantEvent["eventType"];
+  occurredAt: string;
+  actorType: "tenant" | "system" | "recipient";
+  outcome: TenantInstitutionAccessAuditOutcome;
+  status: RecipientTrustReviewStatus | "granted" | "revoked" | "expired" | "blocked";
+  reason:
+    | RecipientTrustReviewAccessDecision["reason"]
+    | "access_granted"
+    | "access_revoked"
+    | "access_expired"
+    | "access_blocked";
+  metadataOnly: true;
+};
+
+export type TenantInstitutionAccessAuditSummary = {
+  schemaVersion: "recipient_access_audit.v1";
+  metadataOnly: true;
+  totalEvents: number;
+  openedReviewCount: number;
+  blockedReviewCount: number;
+  revokedAccessCount: number;
+  expiredAccessCount: number;
+  lastActivityAt: string | null;
+  lastOpenedAt: string | null;
+  lastBlockedAt: string | null;
+  lastOutcome: TenantInstitutionAccessAuditOutcome | null;
+  lastReason:
+    | RecipientTrustReviewAccessDecision["reason"]
+    | "access_granted"
+    | "access_revoked"
+    | "access_expired"
+    | "access_blocked"
+    | null;
+  recipientIdentifier: {
+    email: string;
+    redactedEmail: string;
+    organizationName: string | null;
+  };
+  visibility: {
+    tenantVisible: true;
+    supportSafe: true;
+    trustPayloadIncluded: false;
+    supportMetadataIncluded: false;
+    rawProviderPayloadIncluded: false;
+    publicAccessEnabled: false;
+    downloadEnabled: false;
+  };
+};
+
 function asString(value: unknown, max = 240): string | null {
   const next = String(value ?? "").trim().slice(0, max);
   return next || null;
@@ -257,6 +316,14 @@ function normalizeRecipient(input: unknown): TenantInstitutionAccessRecipient | 
     organizationName: asString(data?.organizationName, 160),
     authenticationRequirement: "recipient_email_session_required",
   };
+}
+
+function redactEmail(value: string | null | undefined) {
+  const email = normalizeEmail(value);
+  if (!email) return "not available";
+  const [local, domain] = email.split("@");
+  const visible = local.length <= 2 ? local.slice(0, 1) : `${local.slice(0, 2)}***`;
+  return `${visible}@${domain}`;
 }
 
 function grantIdFor(params: {
@@ -402,9 +469,99 @@ function accessPreviewFromTrustPackage(params: {
   };
 }
 
+function outcomeForEventType(eventType: TenantInstitutionAccessAuditEvent["eventType"]): TenantInstitutionAccessAuditOutcome {
+  if (eventType === "tenant_institution_access_granted") return "granted";
+  if (eventType === "tenant_institution_access_revoked" || eventType === "recipient_trust_review_revoked") return "revoked";
+  if (eventType === "tenant_institution_access_expired" || eventType === "recipient_trust_review_expired") return "expired";
+  if (eventType === "recipient_trust_review_opened") return "opened";
+  return "blocked";
+}
+
+function statusForAuditEvent(event: TenantInstitutionAccessStoredGrant["events"][number]): TenantInstitutionAccessAuditEvent["status"] {
+  if (event.status) return event.status as TenantInstitutionAccessAuditEvent["status"];
+  if (event.eventType === "tenant_institution_access_granted") return "granted";
+  if (event.eventType === "tenant_institution_access_revoked" || event.eventType === "recipient_trust_review_revoked") return "revoked";
+  if (event.eventType === "tenant_institution_access_expired" || event.eventType === "recipient_trust_review_expired") return "expired";
+  if (event.eventType === "recipient_trust_review_opened") return "available";
+  return "blocked";
+}
+
+function reasonForAuditEvent(event: TenantInstitutionAccessStoredGrant["events"][number]): TenantInstitutionAccessAuditEvent["reason"] {
+  if (event.reason) return event.reason as TenantInstitutionAccessAuditEvent["reason"];
+  if (event.eventType === "tenant_institution_access_granted") return "access_granted";
+  if (event.eventType === "tenant_institution_access_revoked" || event.eventType === "recipient_trust_review_revoked") {
+    return "access_revoked";
+  }
+  if (event.eventType === "tenant_institution_access_expired" || event.eventType === "recipient_trust_review_expired") {
+    return "access_expired";
+  }
+  if (event.eventType === "recipient_trust_review_opened") return "review_available";
+  return "grant_blocked";
+}
+
+function auditEventFromGrantEvent(event: TenantInstitutionAccessStoredGrant["events"][number]): TenantInstitutionAccessAuditEvent | null {
+  const occurredAt = asString(event?.occurredAt, 80);
+  if (!occurredAt || event?.metadataOnly !== true) return null;
+  const eventType = event.eventType;
+  return {
+    eventType,
+    occurredAt,
+    actorType: event.actorType === "tenant" || event.actorType === "system" ? event.actorType : "recipient",
+    outcome: outcomeForEventType(eventType),
+    status: statusForAuditEvent(event),
+    reason: reasonForAuditEvent(event),
+    metadataOnly: true,
+  };
+}
+
+function buildAccessAudit(record: TenantInstitutionAccessStoredGrant): {
+  auditSummary: TenantInstitutionAccessAuditSummary;
+  auditTimeline: TenantInstitutionAccessAuditEvent[];
+} {
+  const auditTimeline = (Array.isArray(record.events) ? record.events : [])
+    .map(auditEventFromGrantEvent)
+    .filter(Boolean) as TenantInstitutionAccessAuditEvent[];
+  auditTimeline.sort((left, right) => Date.parse(right.occurredAt) - Date.parse(left.occurredAt));
+  const last = auditTimeline[0] || null;
+  const lastOpened = auditTimeline.find((event) => event.outcome === "opened") || null;
+  const lastBlocked = auditTimeline.find((event) => event.outcome === "blocked") || null;
+  return {
+    auditTimeline,
+    auditSummary: {
+      schemaVersion: "recipient_access_audit.v1",
+      metadataOnly: true,
+      totalEvents: auditTimeline.length,
+      openedReviewCount: auditTimeline.filter((event) => event.outcome === "opened").length,
+      blockedReviewCount: auditTimeline.filter((event) => event.outcome === "blocked").length,
+      revokedAccessCount: auditTimeline.filter((event) => event.outcome === "revoked").length,
+      expiredAccessCount: auditTimeline.filter((event) => event.outcome === "expired").length,
+      lastActivityAt: last?.occurredAt || null,
+      lastOpenedAt: lastOpened?.occurredAt || null,
+      lastBlockedAt: lastBlocked?.occurredAt || null,
+      lastOutcome: last?.outcome || null,
+      lastReason: last?.reason || null,
+      recipientIdentifier: {
+        email: record.recipient?.email || "",
+        redactedEmail: redactEmail(record.recipient?.email),
+        organizationName: record.recipient?.organizationName || null,
+      },
+      visibility: {
+        tenantVisible: true,
+        supportSafe: true,
+        trustPayloadIncluded: false,
+        supportMetadataIncluded: false,
+        rawProviderPayloadIncluded: false,
+        publicAccessEnabled: false,
+        downloadEnabled: false,
+      },
+    },
+  };
+}
+
 function publicGrant(record: TenantInstitutionAccessStoredGrant): TenantInstitutionAccessGrant {
   const { tenantId: _tenantId, ...rest } = record;
-  return rest;
+  const { auditSummary, auditTimeline } = buildAccessAudit(record);
+  return { ...rest, auditSummary, auditTimeline };
 }
 
 function asGrant(id: string, data: any): TenantInstitutionAccessStoredGrant {
@@ -532,6 +689,8 @@ async function appendRecipientReviewEvent(params: {
     | "recipient_trust_review_expired"
     | "recipient_trust_review_revoked";
   occurredAt: string;
+  status: RecipientTrustReviewStatus;
+  reason: RecipientTrustReviewAccessDecision["reason"];
 }) {
   const ref = db.collection(COLLECTION).doc(params.grant.grantId);
   const events = [
@@ -541,6 +700,9 @@ async function appendRecipientReviewEvent(params: {
       occurredAt: params.occurredAt,
       actorType: "recipient" as const,
       metadataOnly: true as const,
+      outcome: outcomeForEventType(params.eventType),
+      status: params.status,
+      reason: params.reason,
     },
   ].slice(-50);
   await ref.set({ events, updatedAt: params.occurredAt }, { merge: true });
@@ -561,11 +723,18 @@ export async function getRecipientTrustReview(params: {
   if (!snap.exists) return denyRecipientReview("not_found", "grant_not_found");
 
   const grant = asGrant(grantId, snap.data?.() || {});
+  const reviewedAt = nowIso();
   if (normalizeRecipientEmailForReview(grant.recipient?.email) !== recipientEmail) {
+    await appendRecipientReviewEvent({
+      grant,
+      eventType: "recipient_trust_review_blocked",
+      occurredAt: reviewedAt,
+      status: "recipient_mismatch",
+      reason: "recipient_email_mismatch",
+    });
     return denyRecipientReview("recipient_mismatch", "recipient_email_mismatch");
   }
 
-  const reviewedAt = nowIso();
   const denyWithEvent = async (
     status: RecipientTrustReviewStatus,
     reason: RecipientTrustReviewAccessDecision["reason"],
@@ -574,7 +743,7 @@ export async function getRecipientTrustReview(params: {
       | "recipient_trust_review_expired"
       | "recipient_trust_review_revoked" = "recipient_trust_review_blocked"
   ) => {
-    await appendRecipientReviewEvent({ grant, eventType, occurredAt: reviewedAt });
+    await appendRecipientReviewEvent({ grant, eventType, occurredAt: reviewedAt, status, reason });
     return denyRecipientReview(status, reason);
   };
 
@@ -598,7 +767,13 @@ export async function getRecipientTrustReview(params: {
     return denyWithEvent("policy_denied", "policy_gated_summary_unavailable");
   }
 
-  await appendRecipientReviewEvent({ grant, eventType: "recipient_trust_review_opened", occurredAt: reviewedAt });
+  await appendRecipientReviewEvent({
+    grant,
+    eventType: "recipient_trust_review_opened",
+    occurredAt: reviewedAt,
+    status: "available",
+    reason: "review_available",
+  });
 
   return {
     decision: {
@@ -690,6 +865,9 @@ export async function createTenantInstitutionAccessGrant(params: {
         occurredAt: createdAt,
         actorType: "tenant",
         metadataOnly: true,
+        outcome: "granted",
+        status: "granted",
+        reason: "access_granted",
       },
     ],
   };
@@ -724,6 +902,9 @@ export async function revokeTenantInstitutionAccessGrant(params: { tenantId: str
       occurredAt: updatedAt,
       actorType: "tenant" as const,
       metadataOnly: true as const,
+      outcome: "revoked" as const,
+      status: "revoked" as const,
+      reason: "access_revoked" as const,
     },
   ];
   await ref.set(

--- a/rentchain-frontend/src/api/tenantInstitutionAccess.ts
+++ b/rentchain-frontend/src/api/tenantInstitutionAccess.ts
@@ -106,11 +106,67 @@ export type TenantInstitutionAccessGrant = TenantInstitutionAccessPreview & {
       | "tenant_institution_access_granted"
       | "tenant_institution_access_revoked"
       | "tenant_institution_access_expired"
-      | "tenant_institution_access_blocked";
+      | "tenant_institution_access_blocked"
+      | "recipient_trust_review_opened"
+      | "recipient_trust_review_blocked"
+      | "recipient_trust_review_expired"
+      | "recipient_trust_review_revoked";
     occurredAt: string;
-    actorType: "tenant" | "system";
+    actorType: "tenant" | "system" | "recipient";
     metadataOnly: true;
+    outcome?: "granted" | "opened" | "blocked" | "revoked" | "expired";
+    reason?: string;
+    status?: string;
   }>;
+  auditSummary: TenantInstitutionAccessAuditSummary;
+  auditTimeline: TenantInstitutionAccessAuditEvent[];
+};
+
+export type TenantInstitutionAccessAuditEvent = {
+  eventType:
+    | "tenant_institution_access_granted"
+    | "tenant_institution_access_revoked"
+    | "tenant_institution_access_expired"
+    | "tenant_institution_access_blocked"
+    | "recipient_trust_review_opened"
+    | "recipient_trust_review_blocked"
+    | "recipient_trust_review_expired"
+    | "recipient_trust_review_revoked";
+  occurredAt: string;
+  actorType: "tenant" | "system" | "recipient";
+  outcome: "granted" | "opened" | "blocked" | "revoked" | "expired";
+  status: string;
+  reason: string;
+  metadataOnly: true;
+};
+
+export type TenantInstitutionAccessAuditSummary = {
+  schemaVersion: "recipient_access_audit.v1";
+  metadataOnly: true;
+  totalEvents: number;
+  openedReviewCount: number;
+  blockedReviewCount: number;
+  revokedAccessCount: number;
+  expiredAccessCount: number;
+  lastActivityAt: string | null;
+  lastOpenedAt: string | null;
+  lastBlockedAt: string | null;
+  lastOutcome: "granted" | "opened" | "blocked" | "revoked" | "expired" | null;
+  lastReason: string | null;
+  recipientIdentifier: {
+    email: string;
+    redactedEmail: string;
+    organizationName: string | null;
+  };
+  visibility: {
+    tenantVisible: true;
+    supportSafe: true;
+    trustPayloadIncluded: false;
+    supportMetadataIncluded: false;
+    rawProviderPayloadIncluded: false;
+    publicAccessEnabled: false;
+    downloadEnabled: false;
+  };
 };
 
 export type TenantInstitutionAccessRequest = {

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.test.tsx
@@ -792,6 +792,84 @@ describe("tenant workspace frontend shell", () => {
           occurredAt: "2026-05-09T00:00:00.000Z",
           actorType: "tenant",
           metadataOnly: true,
+          outcome: "granted",
+          status: "granted",
+          reason: "access_granted",
+        },
+        {
+          eventType: "recipient_trust_review_opened",
+          occurredAt: "2026-05-09T01:00:00.000Z",
+          actorType: "recipient",
+          metadataOnly: true,
+          outcome: "opened",
+          status: "available",
+          reason: "review_available",
+        },
+        {
+          eventType: "recipient_trust_review_blocked",
+          occurredAt: "2026-05-09T02:00:00.000Z",
+          actorType: "recipient",
+          metadataOnly: true,
+          outcome: "blocked",
+          status: "recipient_mismatch",
+          reason: "recipient_email_mismatch",
+        },
+      ],
+      auditSummary: {
+        schemaVersion: "recipient_access_audit.v1",
+        metadataOnly: true,
+        totalEvents: 3,
+        openedReviewCount: 1,
+        blockedReviewCount: 1,
+        revokedAccessCount: 0,
+        expiredAccessCount: 0,
+        lastActivityAt: "2026-05-09T02:00:00.000Z",
+        lastOpenedAt: "2026-05-09T01:00:00.000Z",
+        lastBlockedAt: "2026-05-09T02:00:00.000Z",
+        lastOutcome: "blocked",
+        lastReason: "recipient_email_mismatch",
+        recipientIdentifier: {
+          email: "reviewer@example.com",
+          redactedEmail: "re***@example.com",
+          organizationName: "Example Insurance",
+        },
+        visibility: {
+          tenantVisible: true,
+          supportSafe: true,
+          trustPayloadIncluded: false,
+          supportMetadataIncluded: false,
+          rawProviderPayloadIncluded: false,
+          publicAccessEnabled: false,
+          downloadEnabled: false,
+        },
+      },
+      auditTimeline: [
+        {
+          eventType: "recipient_trust_review_blocked",
+          occurredAt: "2026-05-09T02:00:00.000Z",
+          actorType: "recipient",
+          outcome: "blocked",
+          status: "recipient_mismatch",
+          reason: "recipient_email_mismatch",
+          metadataOnly: true,
+        },
+        {
+          eventType: "recipient_trust_review_opened",
+          occurredAt: "2026-05-09T01:00:00.000Z",
+          actorType: "recipient",
+          outcome: "opened",
+          status: "available",
+          reason: "review_available",
+          metadataOnly: true,
+        },
+        {
+          eventType: "tenant_institution_access_granted",
+          occurredAt: "2026-05-09T00:00:00.000Z",
+          actorType: "tenant",
+          outcome: "granted",
+          status: "granted",
+          reason: "access_granted",
+          metadataOnly: true,
         },
       ],
     };
@@ -806,6 +884,13 @@ describe("tenant workspace frontend shell", () => {
         ...institutionAccessGrant.consent,
         granted: false,
         revokedAt: "2026-05-10T00:00:00.000Z",
+      },
+      auditSummary: {
+        ...institutionAccessGrant.auditSummary,
+        revokedAccessCount: 1,
+        lastActivityAt: "2026-05-10T00:00:00.000Z",
+        lastOutcome: "revoked",
+        lastReason: "access_revoked",
       },
     }));
     tenantSharePackagesApi.createTenantSharePackage.mockResolvedValue({
@@ -1512,6 +1597,16 @@ describe("tenant workspace frontend shell", () => {
     });
     expect(await screen.findByText(/Tenant portability metadata available/i)).toBeInTheDocument();
     expect(screen.getAllByText(/Not created/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Access activity/i)).toBeInTheDocument();
+    expect(screen.getByText(/re\*\*\*@example.com/i)).toBeInTheDocument();
+    expect(screen.getByText(/Opened reviews/i)).toBeInTheDocument();
+    expect(screen.getByText(/Blocked attempts/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/recipient email mismatch/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Review opened/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Review blocked/i).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/policyDecisions/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/rawProviderPayload/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/supportMetadataIncluded/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/verified tenant/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/reputation/i)).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /send to institution/i })).not.toBeInTheDocument();

--- a/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
+++ b/rentchain-frontend/src/pages/tenant/TenantWorkspacePage.tsx
@@ -208,6 +208,28 @@ function prettyPolicyReason(value: string) {
   return value.replace(/_/g, " ");
 }
 
+function prettyAccessAuditOutcome(value: string | null | undefined) {
+  switch (value) {
+    case "opened":
+      return "Review opened";
+    case "blocked":
+      return "Review blocked";
+    case "revoked":
+      return "Access revoked";
+    case "expired":
+      return "Access expired";
+    case "granted":
+      return "Access granted";
+    default:
+      return "No activity yet";
+  }
+}
+
+function prettyAccessAuditReason(value: string | null | undefined) {
+  if (!value) return "No recent reason";
+  return prettyPolicyReason(value);
+}
+
 function prettyInstitutionType(
   value: "bank" | "lender" | "insurer" | "regulator" | "internal_review" | null | undefined
 ) {
@@ -1860,6 +1882,55 @@ export default function TenantWorkspacePage() {
                         { label: "Access URL", value: entry.recipientAccess.accessUrl || "Not created" },
                       ]}
                     />
+                    <div style={{ borderTop: "1px solid rgba(15,23,42,0.08)", paddingTop: 8, display: "grid", gap: 8 }}>
+                      <div style={{ fontWeight: 700, color: textTokens.primary }}>Access activity</div>
+                      <TenantKeyValueGrid
+                        rows={[
+                          {
+                            label: "Recipient reference",
+                            value: entry.auditSummary?.recipientIdentifier?.redactedEmail || "Not available",
+                          },
+                          {
+                            label: "Last activity",
+                            value: entry.auditSummary?.lastActivityAt ? formatDate(entry.auditSummary.lastActivityAt) : "No recipient activity yet",
+                          },
+                          {
+                            label: "Last outcome",
+                            value: prettyAccessAuditOutcome(entry.auditSummary?.lastOutcome),
+                          },
+                          {
+                            label: "Last reason",
+                            value: prettyAccessAuditReason(entry.auditSummary?.lastReason),
+                          },
+                          {
+                            label: "Opened reviews",
+                            value: String(entry.auditSummary?.openedReviewCount || 0),
+                          },
+                          {
+                            label: "Blocked attempts",
+                            value: String(entry.auditSummary?.blockedReviewCount || 0),
+                          },
+                          {
+                            label: "Revoked/expired events",
+                            value: String((entry.auditSummary?.revokedAccessCount || 0) + (entry.auditSummary?.expiredAccessCount || 0)),
+                          },
+                        ]}
+                      />
+                      {entry.auditTimeline?.length ? (
+                        <div style={{ display: "grid", gap: 6 }}>
+                          <div style={{ color: textTokens.secondary, fontWeight: 700 }}>Recent access events</div>
+                          {entry.auditTimeline.slice(0, 3).map((event, index) => (
+                            <div key={`${event.eventType}-${event.occurredAt}-${index}`} style={{ color: textTokens.secondary }}>
+                              {prettyAccessAuditOutcome(event.outcome)} - {formatDate(event.occurredAt)} - {prettyAccessAuditReason(event.reason)}
+                            </div>
+                          ))}
+                        </div>
+                      ) : (
+                        <div style={{ color: textTokens.secondary }}>
+                          Recipient review activity will appear here after authenticated review attempts. Trust payloads and support/internal metadata are never shown in this activity summary.
+                        </div>
+                      )}
+                    </div>
                     {entry.lifecycle === "active" ? (
                       <button type="button" onClick={() => void handleRevokeInstitutionAccessGrant(entry.grantId)} disabled={institutionAccessBusy}>
                         Revoke access


### PR DESCRIPTION
## Summary

This PR introduces the first recipient-access audit visibility layer for tenant-mediated institution access.

- Adds safe recipient access audit summaries and timelines derived from existing tenant institution access grant events.
- Records metadata-only recipient review outcomes for opened, blocked, expired, revoked, and recipient mismatch cases.
- Surfaces tenant-owned access activity in the tenant workspace with conservative labels, redacted recipient references, counts, and recent event reasons.
- Preserves existing trust review behavior: no public links, no recipient downloads, no share-package widening, no provider or institution integrations, and no trust payload exposure.

## Audit Summary

The implementation audit found that tenant institution access grants already contained lifecycle events and recipient review routes already appended opened/blocked/revoked/expired events. The main operational gap was visibility: tenants could see grant state but not safe review activity, and wrong-recipient attempts were not represented in the event stream. Support/admin surfaces were intentionally left unchanged for this first additive slice.

Safe fields used here are event type, outcome, status/reason code, actor type, timestamp, metadata-only marker, redacted recipient reference, and lifecycle counts. Unsafe fields remain excluded: trust payloads, export summaries, raw provider payloads, identity/property artifacts, support metadata, public tokens, and confidence internals.

## Validation

- `npm run test` in `rentchain-api` passed: 343 files, 1494 tests. Required elevated local server binding for Supertest in this sandbox.
- `npm run test` in `rentchain-frontend` passed: 257 files, 945 tests.
- Targeted backend tests passed: tenant institution access service, recipient trust review routes, tenant portal routes.
- Targeted frontend tests passed: tenant workspace and recipient trust review page.
- `npm run build` passed in `rentchain-api`.
- `npm run build` passed in `rentchain-frontend`.
- `git diff --check` passed.

## Scope Guardrails

No institution/provider integrations, public trust profiles, recipient downloads, share-package expansion, automated decisions, or trust export semantic changes are introduced.