### PR TITLE
Support-safe institution access diagnostics

### DIFF
--- a/rentchain-api/src/lib/supportConsole/buildSupportConsoleResource.ts
+++ b/rentchain-api/src/lib/supportConsole/buildSupportConsoleResource.ts
@@ -9,19 +9,24 @@ import { deriveSlaState } from "../sla/deriveSlaState";
 import { deriveAdminTriageQueue } from "../triage/deriveAdminTriageQueue";
 import { loadWatchlistEntries } from "../watchlist/loadWatchlistEntries";
 import { canonicalEventToTimelineItem } from "../timeline/timelineAdapter";
-import { redactIdentifierMap } from "../governance/platformGovernance";
+import { redactIdentifier, redactIdentifierMap } from "../governance/platformGovernance";
+import { getSupportInstitutionAccessDiagnostic } from "../../services/tenantPortal/tenantInstitutionAccessService";
 import type {
   SupportConsoleAutomationItem,
   SupportConsolePolicyDecision,
   SupportConsoleResourceResponse,
 } from "./supportConsoleTypes";
 
-type SupportedResourceType = "application" | "maintenance" | "lease";
+type SupportedResourceType = "application" | "maintenance" | "lease" | "institution_access";
 
 type NormalizedResourceSpec = {
   requestedType: SupportedResourceType;
-  canonicalType: "rental_application" | "maintenance_request" | "lease";
-  collectionName: "rentalApplications" | "maintenanceRequests" | "leases";
+  canonicalType:
+    | "rental_application"
+    | "maintenance_request"
+    | "lease"
+    | "tenant_institution_access_grant";
+  collectionName: "rentalApplications" | "maintenanceRequests" | "leases" | "tenantInstitutionAccessGrants";
 };
 
 function asString(value: unknown, max = 240) {
@@ -61,6 +66,17 @@ function normalizeResourceType(value: unknown): NormalizedResourceSpec | null {
       requestedType: "lease",
       canonicalType: "lease",
       collectionName: "leases",
+    };
+  }
+  if (
+    raw === "institution_access" ||
+    raw === "tenant_institution_access" ||
+    raw === "tenant_institution_access_grant"
+  ) {
+    return {
+      requestedType: "institution_access",
+      canonicalType: "tenant_institution_access_grant",
+      collectionName: "tenantInstitutionAccessGrants",
     };
   }
   return null;
@@ -112,9 +128,20 @@ function matchesLeaseResource(resourceId: string, event: CanonicalEventV1) {
   );
 }
 
+function matchesInstitutionAccessResource(resourceId: string, event: CanonicalEventV1) {
+  return (
+    (asString(event.resource?.type, 120) === "tenant_institution_access_grant" &&
+      asString(event.resource?.id, 240) === resourceId) ||
+    asString(event.resource?.parentId, 240) === resourceId ||
+    asString(event.metadata?.grantId, 240) === resourceId ||
+    asString(event.metadata?.resourceId, 240) === resourceId
+  );
+}
+
 function isRelatedResource(spec: NormalizedResourceSpec, resourceId: string, event: CanonicalEventV1) {
   if (spec.requestedType === "application") return matchesApplicationResource(resourceId, event);
   if (spec.requestedType === "maintenance") return matchesMaintenanceResource(resourceId, event);
+  if (spec.requestedType === "institution_access") return matchesInstitutionAccessResource(resourceId, event);
   return matchesLeaseResource(resourceId, event);
 }
 
@@ -125,6 +152,7 @@ function preferredInsightDomain(spec: NormalizedResourceSpec, events: CanonicalE
     return "application";
   }
   if (spec.requestedType === "maintenance") return "maintenance";
+  if (spec.requestedType === "institution_access") return "system";
   return "lease";
 }
 
@@ -226,7 +254,32 @@ function buildLeaseHeader(resourceId: string, lease: any) {
   };
 }
 
+function buildInstitutionAccessHeader(resourceId: string, doc: any, diagnostic: any) {
+  const audience = asOptionalString(diagnostic?.audience || doc?.audience, 80);
+  const purpose = asOptionalString(diagnostic?.purpose || doc?.purpose, 120);
+  const organizationName = asOptionalString(diagnostic?.recipient?.organizationName || doc?.recipient?.organizationName, 160);
+  return {
+    type: "institution_access",
+    id: resourceId,
+    title: organizationName ? `Institution access for ${organizationName}` : `Institution access ${resourceId}`,
+    subtitle: [audience ? `Audience ${audience}` : null, purpose ? `Purpose ${purpose}` : null]
+      .filter(Boolean)
+      .join(" • ") || null,
+    status: asOptionalString(diagnostic?.lifecycle || doc?.lifecycle, 120),
+    parentType: "tenant",
+    parentId: asOptionalString(diagnostic?.tenant?.redactedTenantId, 120),
+  };
+}
+
 function buildDebugIdentifiers(spec: NormalizedResourceSpec, doc: any, reconciliation: any) {
+  if (spec.requestedType === "institution_access") {
+    return {
+      grantReference: redactIdentifier(doc?.grantId),
+      tenantReference: redactIdentifier(doc?.tenantId),
+      recipientEmail: asOptionalString(doc?.recipient?.email, 240),
+    };
+  }
+
   const identifiers: Record<string, string | null | undefined> = {
     landlordId: asOptionalString(doc?.landlordId, 120),
     propertyId: asOptionalString(doc?.propertyId, 120),
@@ -321,6 +374,43 @@ export async function buildSupportConsoleResource(input: {
   const canonicalEvents = await loadCanonicalEvents();
   const relatedEvents = canonicalEvents.filter((event) => isRelatedResource(spec, resourceId, event));
   const sortedEvents = [...relatedEvents].sort(compareEventsDescending);
+
+  if (spec.requestedType === "institution_access") {
+    const diagnostic = await getSupportInstitutionAccessDiagnostic({ grantId: resourceId });
+    return {
+      resource: buildInstitutionAccessHeader(resourceId, doc, diagnostic),
+      timeline: sortedEvents.map(canonicalEventToTimelineItem),
+      insight: diagnostic
+        ? {
+            lifecycle: diagnostic.lifecycle,
+            audience: diagnostic.audience,
+            purpose: diagnostic.purpose,
+            lastOutcome: diagnostic.audit.lastOutcome,
+            lastReason: diagnostic.audit.lastReason,
+          }
+        : null,
+      policyDecisions: [],
+      automation: [],
+      reconciliation: null,
+      sla: null,
+      assignment: null,
+      resolution: null,
+      watch: null,
+      institutionAccessDiagnostic: diagnostic,
+      debug: {
+        canonicalEventCount: relatedEvents.length,
+        domainsPresent: domainsPresent(relatedEvents),
+        identifiers: redactIdentifierMap(buildDebugIdentifiers(spec, doc, null)),
+      },
+      governance: {
+        sensitivity: "restricted",
+        metadataOnly: true,
+        retentionCategory: "support_diagnostics",
+        redactionApplied: true,
+      },
+    };
+  }
+
   const insight = deriveInsightForResource(relatedEvents, {
     resourceType: spec.canonicalType,
     resourceId,

--- a/rentchain-api/src/lib/supportConsole/supportConsoleTypes.ts
+++ b/rentchain-api/src/lib/supportConsole/supportConsoleTypes.ts
@@ -3,6 +3,7 @@ import type { AssignmentRecordV1 } from "../assignment/assignmentTypes";
 import type { ResolutionRecordV1 } from "../resolution/resolutionTypes";
 import type { SlaEvaluationV1 } from "../sla/slaTypes";
 import type { WatchlistEntryV1 } from "../watchlist/watchlistTypes";
+import type { SupportInstitutionAccessDiagnosticSummary } from "../../services/tenantPortal/tenantInstitutionAccessService";
 
 export type SupportConsoleResourceSummary = {
   type: string;
@@ -44,6 +45,7 @@ export type SupportConsoleResourceResponse = {
   assignment?: AssignmentRecordV1 | null;
   resolution?: ResolutionRecordV1 | null;
   watch?: WatchlistEntryV1 | null;
+  institutionAccessDiagnostic?: SupportInstitutionAccessDiagnosticSummary | null;
   debug: {
     canonicalEventCount: number;
     domainsPresent: string[];

--- a/rentchain-api/src/routes/__tests__/supportConsoleRoutes.test.ts
+++ b/rentchain-api/src/routes/__tests__/supportConsoleRoutes.test.ts
@@ -221,6 +221,144 @@ describe("supportConsoleRoutes", () => {
     expect(response.body?.reconciliation).toBeNull();
   });
 
+  it("returns support-safe institution access diagnostics and audits operator access", async () => {
+    seedDoc("tenantInstitutionAccessGrants", "grant-1", {
+      grantId: "grant-1",
+      tenantId: "tenant-1",
+      schemaVersion: "tenant_institution_access.v1",
+      audience: "insurer",
+      purpose: "insurance_review",
+      lifecycle: "active",
+      recipient: {
+        email: "reviewer@example.com",
+        organizationName: "Example Insurance",
+        authenticationRequirement: "recipient_email_session_required",
+      },
+      consent: {
+        required: true,
+        granted: true,
+        consentId: "consent-1",
+        consentVersion: "tenant_institution_access_consent.v1",
+        grantedAt: "2026-05-01T00:00:00.000Z",
+        expiresAt: "2026-06-01T00:00:00.000Z",
+        revokedAt: null,
+        audience: "insurer",
+        purpose: "insurance_review",
+        recipientEmail: "reviewer@example.com",
+        claimCategories: ["account_trust"],
+        summary: "Tenant consent is required before RentChain prepares this non-public, metadata-only institution access grant.",
+      },
+      expiresAt: "2026-06-01T00:00:00.000Z",
+      revokedAt: null,
+      generatedAt: "2026-05-01T00:00:00.000Z",
+      metadataOnly: true,
+      policyGated: true,
+      publicAccessEnabled: false,
+      publicProfileEnabled: false,
+      externalSubmissionEnabled: false,
+      providerIntegrationEnabled: false,
+      automatedDecisioningEnabled: false,
+      recipientAccess: {
+        enabled: false,
+        accessUrl: null,
+        accessTokenIssued: false,
+        recipientAuthenticationRequired: true,
+        sessionBound: true,
+        downloadEnabled: false,
+      },
+      package: {
+        status: "export_ready",
+        exportSummaries: [{ claimCategory: "account_trust", metadataOnly: true }],
+        blockedReasons: [],
+      },
+      includedClaims: [{ claimCategory: "account_trust", claimLabel: "Account trust" }],
+      excludedClaims: [],
+      createdAt: "2026-05-01T00:00:00.000Z",
+      updatedAt: "2026-05-01T00:00:00.000Z",
+      events: [
+        {
+          eventType: "tenant_institution_access_granted",
+          occurredAt: "2026-05-01T00:00:00.000Z",
+          actorType: "tenant",
+          metadataOnly: true,
+          outcome: "granted",
+          status: "granted",
+          reason: "access_granted",
+        },
+        {
+          eventType: "recipient_trust_review_blocked",
+          occurredAt: "2026-05-02T00:00:00.000Z",
+          actorType: "recipient",
+          metadataOnly: true,
+          outcome: "blocked",
+          status: "recipient_mismatch",
+          reason: "recipient_email_mismatch",
+        },
+      ],
+    });
+
+    const router = (await import("../supportConsoleRoutes")).default;
+    const response = await invokeRouter(router, {
+      method: "GET",
+      url: "/support-console/resource?resourceType=institution_access&resourceId=grant-1",
+      user: { id: "admin-1", role: "admin" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body?.resource).toEqual(
+      expect.objectContaining({
+        type: "institution_access",
+        id: "grant-1",
+        status: "active",
+      })
+    );
+    expect(response.body?.institutionAccessDiagnostic).toEqual(
+      expect.objectContaining({
+        schemaVersion: "support_institution_access_diagnostics.v1",
+        recipient: expect.objectContaining({
+          redactedEmail: "re***@example.com",
+        }),
+        audit: expect.objectContaining({
+          totalEvents: 2,
+          blockedReviewCount: 1,
+          reasonCategories: expect.arrayContaining(["access_granted", "recipient_email_mismatch"]),
+        }),
+        payloadSafety: expect.objectContaining({
+          trustPayloadIncluded: false,
+          rawProviderPayloadIncluded: false,
+          supportMetadataIncluded: false,
+        }),
+      })
+    );
+    const payload = JSON.stringify(response.body);
+    expect(payload).not.toContain("tenant-1");
+    expect(payload).not.toContain("reviewer@example.com");
+    expect(payload).not.toContain("includedClaims");
+    expect(payload).not.toContain("exportSummaries");
+
+    const auditEvents = Array.from(collections.get("canonicalEvents")?.values() || []).filter(
+      (event: any) => event.type === "system.institution_access_diagnostics_opened"
+    );
+    expect(auditEvents).toEqual([
+      expect.objectContaining({
+        action: "institution_access_diagnostics_opened",
+        resource: expect.objectContaining({
+          type: "tenant_institution_access_grant",
+          id: "grant-1",
+        }),
+        visibility: "system",
+        metadata: expect.objectContaining({
+          resourceType: "institution_access",
+          metadataOnly: true,
+          redactionApplied: true,
+          trustPayloadIncluded: false,
+          rawProviderPayloadIncluded: false,
+          downloadEnabled: false,
+        }),
+      }),
+    ]);
+  });
+
   it("extracts policy and automation histories", async () => {
     seedDoc("leases", "lease-1", {
       tenantName: "Taylor Tenant",

--- a/rentchain-api/src/routes/supportConsoleRoutes.ts
+++ b/rentchain-api/src/routes/supportConsoleRoutes.ts
@@ -11,16 +11,23 @@ function asString(value: unknown, max = 240) {
   return String(value || "").trim().slice(0, max);
 }
 
+function isInstitutionAccessResourceType(value: unknown) {
+  const raw = asString(value, 120).toLowerCase();
+  return raw === "institution_access" || raw === "tenant_institution_access" || raw === "tenant_institution_access_grant";
+}
+
 async function recordSupportConsoleAccess(req: any, input: { resourceType: string; resourceId: string }) {
   try {
     const actor = actorFromRequest(req);
     const now = new Date().toISOString();
+    const institutionAccess = isInstitutionAccessResourceType(input.resourceType);
+    const action = institutionAccess ? "institution_access_diagnostics_opened" : "support_console_accessed";
     await writeCanonicalEvent({
-      id: `support_console_accessed:${input.resourceType}:${input.resourceId}:${actor.actorId || "unknown"}:${Date.now()}`
+      id: `${action}:${input.resourceType}:${input.resourceId}:${actor.actorId || "unknown"}:${Date.now()}`
         .toLowerCase()
         .replace(/[^a-z0-9_.:-]+/g, "_"),
       domain: "system",
-      action: "support_console_accessed",
+      action,
       status: "completed",
       actor: {
         type: actor.actorRole === "admin" ? "admin" : "user",
@@ -28,21 +35,28 @@ async function recordSupportConsoleAccess(req: any, input: { resourceType: strin
         role: actor.actorRole,
       },
       resource: {
-        type: "support_console_resource",
+        type: institutionAccess ? "tenant_institution_access_grant" : "support_console_resource",
         id: input.resourceId,
         parentType: input.resourceType,
         parentId: input.resourceId,
       },
       occurredAt: now,
       visibility: "system",
-      summary: "Support console resource accessed with redacted diagnostic identifiers.",
+      summary: institutionAccess
+        ? "Institution access diagnostics opened with redacted metadata-only view."
+        : "Support console resource accessed with redacted diagnostic identifiers.",
       metadata: {
         resourceType: input.resourceType,
         metadataOnly: true,
         redactionApplied: true,
         retentionCategory: "support_diagnostics",
+        trustPayloadIncluded: false,
+        rawProviderPayloadIncluded: false,
+        downloadEnabled: false,
       },
-      tags: ["support_console", "governance"],
+      tags: institutionAccess
+        ? ["support_console", "institution_access_diagnostics", "governance"]
+        : ["support_console", "governance"],
     });
   } catch (err: any) {
     console.warn("[support-console] access audit skipped", err?.message || err);

--- a/rentchain-api/src/services/tenantPortal/__tests__/tenantInstitutionAccessService.test.ts
+++ b/rentchain-api/src/services/tenantPortal/__tests__/tenantInstitutionAccessService.test.ts
@@ -364,4 +364,63 @@ describe("tenantInstitutionAccessService", () => {
       expect.arrayContaining(["grant_blocked"])
     );
   });
+
+  it("builds support-safe institution access diagnostics without trust payload exposure", async () => {
+    const service = await import("../tenantInstitutionAccessService");
+
+    const grant = await service.createTenantInstitutionAccessGrant({
+      tenantId: "tenant-1",
+      audience: "insurer",
+      recipient: { email: "reviewer@example.com", organizationName: "Example Insurance" },
+      expiresInDays: 7,
+      consentAccepted: true,
+    });
+
+    await service.getRecipientTrustReview({
+      grantId: grant?.grantId || "",
+      recipientEmail: "other@example.com",
+    });
+    await service.getRecipientTrustReview({
+      grantId: grant?.grantId || "",
+      recipientEmail: "reviewer@example.com",
+    });
+
+    const diagnostic = await service.getSupportInstitutionAccessDiagnostic({ grantId: grant?.grantId || "" });
+    expect(diagnostic).toEqual(
+      expect.objectContaining({
+        schemaVersion: "support_institution_access_diagnostics.v1",
+        lifecycle: "active",
+        audience: "insurer",
+        purpose: "insurance_review",
+        recipient: expect.objectContaining({
+          redactedEmail: "re***@example.com",
+          organizationName: "Example Insurance",
+        }),
+        audit: expect.objectContaining({
+          openedReviewCount: 1,
+          blockedReviewCount: 1,
+          reasonCategories: expect.arrayContaining(["access_granted", "recipient_email_mismatch", "review_available"]),
+        }),
+        payloadSafety: expect.objectContaining({
+          metadataOnly: true,
+          supportSafe: true,
+          trustPayloadIncluded: false,
+          portableAttestationContentsIncluded: false,
+          rawProviderPayloadIncluded: false,
+          rawIdentityPayloadIncluded: false,
+          rawPropertyPayloadIncluded: false,
+          supportMetadataIncluded: false,
+        }),
+      })
+    );
+
+    const payload = JSON.stringify(diagnostic || {});
+    expect(payload).not.toContain("tenant-1");
+    expect(payload).not.toContain("reviewer@example.com");
+    expect(payload).not.toContain("includedClaims");
+    expect(payload).not.toContain("exportSummaries");
+    expect(payload).not.toContain("policyDecisions");
+    expect(payload).not.toContain("supportMetadataIncluded\":true");
+    expect(payload).not.toContain("rawProviderPayloadIncluded\":true");
+  });
 });

--- a/rentchain-api/src/services/tenantPortal/tenantInstitutionAccessService.ts
+++ b/rentchain-api/src/services/tenantPortal/tenantInstitutionAccessService.ts
@@ -2,6 +2,7 @@ import crypto from "crypto";
 import { db } from "../../config/firebase";
 import type { InstitutionalTrustExportPackage } from "../../lib/institutionTrustExports";
 import type { PortableAttestationClaimCategory } from "../../lib/portableAttestations";
+import { redactIdentifier } from "../../lib/governance/platformGovernance";
 import {
   previewTenantTrustExport,
   type TenantTrustExportAudience,
@@ -259,6 +260,83 @@ export type TenantInstitutionAccessAuditSummary = {
     publicAccessEnabled: false;
     downloadEnabled: false;
   };
+};
+
+export type SupportInstitutionAccessDiagnosticEvent = {
+  eventType: TenantInstitutionAccessAuditEvent["eventType"];
+  occurredAt: string;
+  actorType: TenantInstitutionAccessAuditEvent["actorType"];
+  outcome: TenantInstitutionAccessAuditEvent["outcome"];
+  status: TenantInstitutionAccessAuditEvent["status"];
+  reason: TenantInstitutionAccessAuditEvent["reason"];
+  metadataOnly: true;
+  visibility: {
+    supportVisible: true;
+    trustPayloadIncluded: false;
+    rawProviderPayloadIncluded: false;
+    supportMetadataIncluded: false;
+  };
+};
+
+export type SupportInstitutionAccessDiagnosticSummary = {
+  schemaVersion: "support_institution_access_diagnostics.v1";
+  grantId: string;
+  lifecycle: TenantInstitutionAccessLifecycle;
+  audience: TenantInstitutionAccessAudience;
+  purpose: TenantInstitutionAccessPurpose;
+  recipient: {
+    redactedEmail: string;
+    organizationName: string | null;
+    authenticationRequirement: TenantInstitutionAccessRecipient["authenticationRequirement"];
+  };
+  tenant: {
+    redactedTenantId: string | null;
+  };
+  consent: {
+    granted: boolean;
+    consentVersion: typeof CONSENT_VERSION;
+    grantedAt: string | null;
+    expiresAt: string | null;
+    revokedAt: string | null;
+  };
+  access: {
+    recipientAuthenticationRequired: true;
+    sessionBound: true;
+    publicAccessEnabled: false;
+    publicProfileEnabled: false;
+    externalSubmissionEnabled: false;
+    downloadEnabled: false;
+  };
+  package: {
+    status: string;
+    blockedReasonCount: number;
+    exportSummaryCount: number;
+  };
+  audit: {
+    totalEvents: number;
+    openedReviewCount: number;
+    blockedReviewCount: number;
+    revokedAccessCount: number;
+    expiredAccessCount: number;
+    lastActivityAt: string | null;
+    lastOpenedAt: string | null;
+    lastBlockedAt: string | null;
+    lastOutcome: TenantInstitutionAccessAuditSummary["lastOutcome"];
+    lastReason: TenantInstitutionAccessAuditSummary["lastReason"];
+    reasonCategories: string[];
+  };
+  payloadSafety: {
+    metadataOnly: true;
+    supportSafe: true;
+    trustPayloadIncluded: false;
+    portableAttestationContentsIncluded: false;
+    rawProviderPayloadIncluded: false;
+    rawIdentityPayloadIncluded: false;
+    rawPropertyPayloadIncluded: false;
+    supportMetadataIncluded: false;
+    unsafePortablePayloadDetected: boolean;
+  };
+  timeline: SupportInstitutionAccessDiagnosticEvent[];
 };
 
 function asString(value: unknown, max = 240): string | null {
@@ -564,6 +642,81 @@ function publicGrant(record: TenantInstitutionAccessStoredGrant): TenantInstitut
   return { ...rest, auditSummary, auditTimeline };
 }
 
+function supportDiagnosticFromGrant(record: TenantInstitutionAccessStoredGrant): SupportInstitutionAccessDiagnosticSummary {
+  const { auditSummary, auditTimeline } = buildAccessAudit(record);
+  const reasonCategories = Array.from(new Set(auditTimeline.map((event) => event.reason).filter(Boolean))).sort();
+  const timeline = auditTimeline.map((event) => ({
+    ...event,
+    visibility: {
+      supportVisible: true as const,
+      trustPayloadIncluded: false as const,
+      rawProviderPayloadIncluded: false as const,
+      supportMetadataIncluded: false as const,
+    },
+  }));
+
+  return {
+    schemaVersion: "support_institution_access_diagnostics.v1",
+    grantId: record.grantId,
+    lifecycle: record.lifecycle,
+    audience: record.audience,
+    purpose: record.purpose,
+    recipient: {
+      redactedEmail: redactEmail(record.recipient?.email),
+      organizationName: record.recipient?.organizationName || null,
+      authenticationRequirement: "recipient_email_session_required",
+    },
+    tenant: {
+      redactedTenantId: redactIdentifier(record.tenantId),
+    },
+    consent: {
+      granted: record.consent?.granted === true,
+      consentVersion: CONSENT_VERSION,
+      grantedAt: record.consent?.grantedAt || null,
+      expiresAt: record.consent?.expiresAt || null,
+      revokedAt: record.consent?.revokedAt || null,
+    },
+    access: {
+      recipientAuthenticationRequired: true,
+      sessionBound: true,
+      publicAccessEnabled: false,
+      publicProfileEnabled: false,
+      externalSubmissionEnabled: false,
+      downloadEnabled: false,
+    },
+    package: {
+      status: String(record.package?.status || "unknown").slice(0, 120),
+      blockedReasonCount: Array.isArray(record.package?.blockedReasons) ? record.package.blockedReasons.length : 0,
+      exportSummaryCount: Array.isArray(record.package?.exportSummaries) ? record.package.exportSummaries.length : 0,
+    },
+    audit: {
+      totalEvents: auditSummary.totalEvents,
+      openedReviewCount: auditSummary.openedReviewCount,
+      blockedReviewCount: auditSummary.blockedReviewCount,
+      revokedAccessCount: auditSummary.revokedAccessCount,
+      expiredAccessCount: auditSummary.expiredAccessCount,
+      lastActivityAt: auditSummary.lastActivityAt,
+      lastOpenedAt: auditSummary.lastOpenedAt,
+      lastBlockedAt: auditSummary.lastBlockedAt,
+      lastOutcome: auditSummary.lastOutcome,
+      lastReason: auditSummary.lastReason,
+      reasonCategories,
+    },
+    payloadSafety: {
+      metadataOnly: true,
+      supportSafe: true,
+      trustPayloadIncluded: false,
+      portableAttestationContentsIncluded: false,
+      rawProviderPayloadIncluded: false,
+      rawIdentityPayloadIncluded: false,
+      rawPropertyPayloadIncluded: false,
+      supportMetadataIncluded: false,
+      unsafePortablePayloadDetected: hasUnsafeRecipientPayload(record),
+    },
+    timeline,
+  };
+}
+
 function asGrant(id: string, data: any): TenantInstitutionAccessStoredGrant {
   const expiresAt = asString(data?.expiresAt);
   const lifecycle =
@@ -786,6 +939,15 @@ export async function getRecipientTrustReview(params: {
     },
     summary: recipientSummaryFromGrant(grant, reviewedAt),
   };
+}
+
+export async function getSupportInstitutionAccessDiagnostic(params: { grantId: string }) {
+  const grantId = asString(params.grantId);
+  if (!grantId) return null;
+  const snap = await db.collection(COLLECTION).doc(grantId).get();
+  if (!snap.exists) return null;
+  const grant = asGrant(grantId, snap.data?.() || {});
+  return supportDiagnosticFromGrant(grant);
 }
 
 export async function previewTenantInstitutionAccess(params: {

--- a/rentchain-frontend/src/api/supportConsoleApi.ts
+++ b/rentchain-frontend/src/api/supportConsoleApi.ts
@@ -35,6 +35,7 @@ export type SupportConsoleResourceResponse = {
   sla?: SlaEvaluationV1 | null;
   assignment?: AssignmentRecordV1 | null;
   resolution?: ResolutionRecordV1 | null;
+  institutionAccessDiagnostic?: SupportInstitutionAccessDiagnosticSummary | null;
   watch?: {
     version: "v1";
     id: string;
@@ -55,6 +56,75 @@ export type SupportConsoleResourceResponse = {
     domainsPresent: string[];
     identifiers?: Record<string, string | null | undefined>;
   };
+};
+
+export type SupportInstitutionAccessDiagnosticSummary = {
+  schemaVersion: "support_institution_access_diagnostics.v1";
+  grantId: string;
+  lifecycle: string;
+  audience: string;
+  purpose: string;
+  recipient: {
+    redactedEmail: string;
+    organizationName: string | null;
+    authenticationRequirement: string;
+  };
+  tenant: {
+    redactedTenantId: string | null;
+  };
+  consent: {
+    granted: boolean;
+    consentVersion: string;
+    grantedAt: string | null;
+    expiresAt: string | null;
+    revokedAt: string | null;
+  };
+  access: {
+    recipientAuthenticationRequired: true;
+    sessionBound: true;
+    publicAccessEnabled: false;
+    publicProfileEnabled: false;
+    externalSubmissionEnabled: false;
+    downloadEnabled: false;
+  };
+  package: {
+    status: string;
+    blockedReasonCount: number;
+    exportSummaryCount: number;
+  };
+  audit: {
+    totalEvents: number;
+    openedReviewCount: number;
+    blockedReviewCount: number;
+    revokedAccessCount: number;
+    expiredAccessCount: number;
+    lastActivityAt: string | null;
+    lastOpenedAt: string | null;
+    lastBlockedAt: string | null;
+    lastOutcome: string | null;
+    lastReason: string | null;
+    reasonCategories: string[];
+  };
+  payloadSafety: {
+    metadataOnly: true;
+    supportSafe: true;
+    trustPayloadIncluded: false;
+    portableAttestationContentsIncluded: false;
+    rawProviderPayloadIncluded: false;
+    rawIdentityPayloadIncluded: false;
+    rawPropertyPayloadIncluded: false;
+    supportMetadataIncluded: false;
+    unsafePortablePayloadDetected: boolean;
+  };
+  timeline: Array<{
+    eventType: string;
+    occurredAt: string;
+    actorType: string;
+    outcome: string;
+    status: string;
+    reason: string;
+    metadataOnly: true;
+  }>;
 };
 
 export type ResolutionStatus = "open" | "acknowledged" | "in_progress" | "resolved" | "dismissed";

--- a/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.test.tsx
+++ b/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.test.tsx
@@ -240,4 +240,119 @@ describe("SupportDebugConsolePage", () => {
     expect(screen.queryByText(/^Reconciliation$/i)).not.toBeInTheDocument();
     expect(screen.getByText(/No resolution record exists yet for this resource/i)).toBeInTheDocument();
   });
+
+  it("renders support-safe institution access diagnostics without raw trust data", async () => {
+    const { fetchSupportConsoleResource } = await import("../../api/supportConsoleApi");
+    vi.mocked(fetchSupportConsoleResource).mockResolvedValue({
+      resource: {
+        type: "institution_access",
+        id: "grant-1",
+        title: "Institution access for Example Insurance",
+        subtitle: "Audience insurer • Purpose insurance_review",
+        status: "active",
+      },
+      timeline: [],
+      insight: {
+        lifecycle: "active",
+        audience: "insurer",
+        purpose: "insurance_review",
+        lastOutcome: "blocked",
+        lastReason: "recipient_email_mismatch",
+      },
+      policyDecisions: [],
+      automation: [],
+      reconciliation: null,
+      sla: null,
+      assignment: null,
+      resolution: null,
+      institutionAccessDiagnostic: {
+        schemaVersion: "support_institution_access_diagnostics.v1",
+        grantId: "grant-1",
+        lifecycle: "active",
+        audience: "insurer",
+        purpose: "insurance_review",
+        recipient: {
+          redactedEmail: "re***@example.com",
+          organizationName: "Example Insurance",
+          authenticationRequirement: "recipient_email_session_required",
+        },
+        tenant: { redactedTenantId: "***nt-1" },
+        consent: {
+          granted: true,
+          consentVersion: "tenant_institution_access_consent.v1",
+          grantedAt: "2026-05-01T00:00:00.000Z",
+          expiresAt: "2026-06-01T00:00:00.000Z",
+          revokedAt: null,
+        },
+        access: {
+          recipientAuthenticationRequired: true,
+          sessionBound: true,
+          publicAccessEnabled: false,
+          publicProfileEnabled: false,
+          externalSubmissionEnabled: false,
+          downloadEnabled: false,
+        },
+        package: {
+          status: "export_ready",
+          blockedReasonCount: 0,
+          exportSummaryCount: 1,
+        },
+        audit: {
+          totalEvents: 2,
+          openedReviewCount: 1,
+          blockedReviewCount: 1,
+          revokedAccessCount: 0,
+          expiredAccessCount: 0,
+          lastActivityAt: "2026-05-02T00:00:00.000Z",
+          lastOpenedAt: "2026-05-02T00:00:00.000Z",
+          lastBlockedAt: "2026-05-01T00:00:00.000Z",
+          lastOutcome: "opened",
+          lastReason: "review_available",
+          reasonCategories: ["recipient_email_mismatch", "review_available"],
+        },
+        payloadSafety: {
+          metadataOnly: true,
+          supportSafe: true,
+          trustPayloadIncluded: false,
+          portableAttestationContentsIncluded: false,
+          rawProviderPayloadIncluded: false,
+          rawIdentityPayloadIncluded: false,
+          rawPropertyPayloadIncluded: false,
+          supportMetadataIncluded: false,
+          unsafePortablePayloadDetected: false,
+        },
+        timeline: [
+          {
+            eventType: "recipient_trust_review_blocked",
+            occurredAt: "2026-05-01T00:00:00.000Z",
+            actorType: "recipient",
+            outcome: "blocked",
+            status: "recipient_mismatch",
+            reason: "recipient_email_mismatch",
+            metadataOnly: true,
+          },
+        ],
+      },
+      debug: {
+        canonicalEventCount: 0,
+        domainsPresent: [],
+        identifiers: { grantId: "***nt-1" },
+      },
+    } as any);
+
+    renderPage();
+    fireEvent.change(screen.getByLabelText(/Resource type/i), { target: { value: "institution_access" } });
+    fireEvent.change(screen.getByLabelText(/Resource ID/i), { target: { value: "grant-1" } });
+    fireEvent.click(screen.getByRole("button", { name: /Inspect resource/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Institution access diagnostics/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/re\*\*\*@example\.com/i)).toBeInTheDocument();
+    expect(screen.getByText(/recipient_email_mismatch, review_available/i)).toBeInTheDocument();
+    expect(screen.getByText(/Trust payloads, portable attestation contents, provider payloads/i)).toBeInTheDocument();
+    expect(screen.queryByText(/reviewer@example\.com/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/includedClaims/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/exportSummaries/i)).not.toBeInTheDocument();
+  });
 });

--- a/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.tsx
+++ b/rentchain-frontend/src/pages/admin/SupportDebugConsolePage.tsx
@@ -17,6 +17,7 @@ const RESOURCE_OPTIONS = [
   { label: "Application", value: "application" },
   { label: "Maintenance", value: "maintenance" },
   { label: "Lease", value: "lease" },
+  { label: "Institution access", value: "institution_access" },
 ];
 
 function renderKeyValueList(value: Record<string, unknown> | null | undefined) {
@@ -30,6 +31,54 @@ function renderKeyValueList(value: Record<string, unknown> | null | undefined) {
         </div>
       ))}
     </div>
+  );
+}
+
+function renderInstitutionAccessDiagnostics(payload: SupportConsoleResourceResponse) {
+  const diagnostic = payload.institutionAccessDiagnostic;
+  if (!diagnostic) return null;
+  return (
+    <SupportConsoleSection title="Institution access diagnostics">
+      <div style={{ display: "grid", gap: 12 }}>
+        <div style={{ display: "grid", gap: 8, gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))" }}>
+          <div><strong>Lifecycle</strong>: {diagnostic.lifecycle}</div>
+          <div><strong>Audience</strong>: {diagnostic.audience}</div>
+          <div><strong>Purpose</strong>: {diagnostic.purpose}</div>
+          <div><strong>Recipient</strong>: {diagnostic.recipient.redactedEmail}</div>
+          <div><strong>Organization</strong>: {diagnostic.recipient.organizationName || "Not provided"}</div>
+          <div><strong>Consent</strong>: {diagnostic.consent.granted ? "Granted" : "Not granted"}</div>
+          <div><strong>Expires</strong>: {diagnostic.consent.expiresAt || "No expiration available"}</div>
+          <div><strong>Package status</strong>: {diagnostic.package.status}</div>
+        </div>
+        <div style={{ display: "grid", gap: 8, gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))" }}>
+          <div><strong>Opened reviews</strong>: {diagnostic.audit.openedReviewCount}</div>
+          <div><strong>Blocked reviews</strong>: {diagnostic.audit.blockedReviewCount}</div>
+          <div><strong>Revoked events</strong>: {diagnostic.audit.revokedAccessCount}</div>
+          <div><strong>Expired events</strong>: {diagnostic.audit.expiredAccessCount}</div>
+          <div><strong>Last outcome</strong>: {diagnostic.audit.lastOutcome || "None"}</div>
+          <div><strong>Last reason</strong>: {diagnostic.audit.lastReason || "None"}</div>
+        </div>
+        <div>
+          <strong>Reason categories</strong>:{" "}
+          {diagnostic.audit.reasonCategories.length ? diagnostic.audit.reasonCategories.join(", ") : "None"}
+        </div>
+        <div style={{ color: "#475569" }}>
+          Metadata-only diagnostic. Trust payloads, portable attestation contents, provider payloads, raw identity or property data, support metadata, public links, and downloads are excluded.
+        </div>
+        <div style={{ display: "grid", gap: 8 }}>
+          {diagnostic.timeline.length ? (
+            diagnostic.timeline.map((event) => (
+              <div key={`${event.eventType}-${event.occurredAt}-${event.reason}`} style={{ borderTop: "1px solid #e2e8f0", paddingTop: 8 }}>
+                <strong>{event.eventType}</strong> · {event.outcome} · {event.reason}
+                <div style={{ color: "#64748b" }}>{event.occurredAt}</div>
+              </div>
+            ))
+          ) : (
+            <div style={{ color: "#64748b" }}>No institution access events are available.</div>
+          )}
+        </div>
+      </div>
+    </SupportConsoleSection>
   );
 }
 
@@ -140,6 +189,8 @@ export default function SupportDebugConsolePage() {
         {!loading && !error && payload ? (
           <>
             <SupportConsoleHeader resource={payload.resource} />
+
+            {renderInstitutionAccessDiagnostics(payload)}
 
             <SupportConsoleSection title="Derived insight">
               {renderKeyValueList(payload.insight || null)}


### PR DESCRIPTION
## Summary
- Adds a support-safe diagnostic projection for tenant-mediated institution access grants.
- Exposes institution access diagnostics through the existing admin support-console resource flow with metadata-only, redacted lifecycle/audit summaries.
- Adds operator audit events for opening institution access diagnostics.
- Adds admin UI support for operational diagnostics without trust payloads, provider payloads, public exposure, or downloads.

## Guardrails
- No institution/provider integrations added.
- No recipient downloads or share-package widening added.
- No raw trust payloads, portable attestation contents, raw identity/property/provider data, or support/internal payloads exposed.
- Existing tenant/recipient trust review behavior remains unchanged.

## Validation
- `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm run test:single -- src/services/tenantPortal/__tests__/tenantInstitutionAccessService.test.ts` in `rentchain-api`
- `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm run test:single -- src/routes/__tests__/supportConsoleRoutes.test.ts` in `rentchain-api`
- `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm run test:single -- src/routes/__tests__/recipientTrustReviewRoutes.test.ts` in `rentchain-api`
- `npm run test:single -- src/pages/admin/SupportDebugConsolePage.test.tsx` in `rentchain-frontend`
- `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm run test` in `rentchain-api` (rerun with elevated sandbox permissions because Supertest needs local port binding)
- `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm run test` in `rentchain-frontend`
- `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm run build` in `rentchain-api`
- `PATH=/Users/rentchain/.nvm/versions/node/v20.20.2/bin:$PATH npm run build` in `rentchain-frontend`
- `git diff --check`